### PR TITLE
ci: optimize llvm-build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,27 @@ name: Integration Tests
 on:
   workflow_dispatch:
   pull_request:
-    branches-ignore: ['llvm-**']
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
+      - 'MANIFEST.in'
+      - '.gitignore'
+      - '.github/CODEOWNERS'
+      - '.github/dependabot.yml'
+      - 'cmake/llvm-hash.txt'
+      - 'third_party/ascend/llvm_patch/**'
+      - 'docker/**'
+      - 'requirements.txt'
+      - 'requirements_dev.txt'
+      - '.github/workflows/build-docker-image.yml'
+      - '.github/workflows/create_release.yml'
+      - '.github/workflows/documentation.yml'
+      - '.github/workflows/llvm-build.yml'
+      - '.github/workflows/llvm-build/**'
+      - '.github/workflows/pre-commit.yml'
+      - '.github/workflows/runner-preparation.yml'
+      - '.github/workflows/wheels.yml'
   merge_group:
     branches: [main, 'dev-**']
     types: [checks_requested]

--- a/.github/workflows/integration-tests-ascend.yml
+++ b/.github/workflows/integration-tests-ascend.yml
@@ -45,7 +45,8 @@ jobs:
             ca-certificates ninja-build libzstd-dev \
             git zlib1g-dev \
             clang clang-15 lld-15 ccache
-          ${PYTHON} -m pip install cmake ninja
+          ${PYTHON} -m pip install cmake ninja \
+            -i https://repo.huaweicloud.com/repository/pypi/simple/
 
       - name: Compute cache keys
         id: cache-key
@@ -193,7 +194,8 @@ jobs:
           IS_MANYLINUX="${IS_MANYLINUX:-False}" \
           TRITON_WHEEL_VERSION_SUFFIX="${TRITON_WHEEL_VERSION_SUFFIX:-rc3}" \
           ${PYTHON} setup.py bdist_wheel
-          ${PYTHON} -m pip install dist/*.whl
+          ${PYTHON} -m pip install dist/*.whl \
+            -i https://repo.huaweicloud.com/repository/pypi/simple/
 
       - name: CCache stats
         run: ccache --print-stats

--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - cmake/llvm-hash.txt
       - third_party/ascend/llvm_patch/**
+      - .github/workflows/llvm-build.yml
   pull_request:
     paths:
       - cmake/llvm-hash.txt
@@ -58,8 +59,15 @@ jobs:
       shell: bash
       run: |
         PATCH_DIR="llvm-build/third_party/ascend/llvm_patch"
-        if [ -d "${PATCH_DIR}" ] && [ "$(ls -A ${PATCH_DIR}/*.patch 2>/dev/null)" ]; then
-          PATCH_HASH=$(cat ${PATCH_DIR}/*.patch | sha256sum | cut -d' ' -f1 | cut -c1-8)
+        if [ -d "${PATCH_DIR}" ] && find "${PATCH_DIR}" -maxdepth 1 -type f -name '*.patch' -print -quit | grep -q .; then
+          PATCH_HASH=$(
+            LC_ALL=C find "${PATCH_DIR}" -maxdepth 1 -type f -name '*.patch' -print0 \
+              | sort -z \
+              | xargs -0 cat \
+              | sha256sum \
+              | cut -d' ' -f1 \
+              | cut -c1-8
+          )
         else
           PATCH_HASH="00000000"
         fi
@@ -137,37 +145,6 @@ jobs:
         ninja -C llvm-project/build install
 
         tar czf "${{ env.llvm_install_dir }}.tar.gz" "${{ env.llvm_install_dir }}"
-
-    
-    - name: Configure, Build, and Install LLVM (macOS arm64)
-      if: matrix.config.arch == 'arm64' && matrix.config.target-os == 'macos'
-      run: >
-        python3 -m pip install -r llvm-project/mlir/python/requirements.txt
-
-        cmake -GNinja -Bllvm-project/build
-        -DCMAKE_BUILD_TYPE=Release
-        -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
-        -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-        -DCMAKE_INSTALL_PREFIX="${{ env.llvm_install_dir }}"
-        -DCMAKE_LINKER=lld
-        -DCMAKE_OSX_ARCHITECTURES=arm64
-        -DLLVM_BUILD_UTILS=ON
-        -DLLVM_BUILD_TOOLS=ON
-        -DLLVM_ENABLE_ASSERTIONS=ON
-        -DMLIR_ENABLE_BINDINGS_PYTHON=ON
-        -DLLVM_ENABLE_PROJECTS="mlir;lld"
-        -DLLVM_ENABLE_ZSTD=OFF
-        -DLLVM_INSTALL_UTILS=ON
-        -DLLVM_TARGETS_TO_BUILD="AArch64;NVPTX;AMDGPU"
-        -DLLVM_USE_HOST_TOOLS=ON
-        -DLLVM_ENABLE_TERMINFO=OFF
-        -DLLVM_ABI_BREAKING_CHECKS=FORCE_OFF
-        llvm-project/llvm
-
-        ninja -C llvm-project/build install
-
-        tar czf "${{ env.llvm_install_dir }}.tar.gz" "${{ env.llvm_install_dir }}"
-
 
     - name: Configure, Build, Test, and Install LLVM (CentOS)
       if: matrix.config.target-os == 'centos'

--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -2,12 +2,13 @@ name: LLVM Build
 
 on:
   push:
-    branches:
-      - llvm-head
     paths:
       - cmake/llvm-hash.txt
+      - third_party/ascend/llvm_patch/**
   pull_request:
     paths:
+      - cmake/llvm-hash.txt
+      - third_party/ascend/llvm_patch/**
       - .github/workflows/llvm-build.yml
   workflow_dispatch:
 
@@ -23,7 +24,7 @@ jobs:
   build:
     name: Build on ${{ matrix.config.runner }}
     runs-on: ${{ matrix.config.runs_on }}
-    timeout-minutes: 240  # 4 hours
+    timeout-minutes: 240
 
     strategy:
       fail-fast: true
@@ -31,6 +32,9 @@ jobs:
         config:
         - {runner: 'Ubuntu 22.04', runs_on: 'ubuntu-22.04', target-os: 'ubuntu', arch: 'x64'}
         - {runner: 'Ubuntu 22.04 ARM64', runs_on: 'ubuntu-22.04-arm', target-os: 'ubuntu', arch: 'arm64'}
+        - {runner: 'CentOS 7', runs_on: 'ubuntu-22.04', target-os: 'centos', arch: 'x64'}
+        - {runner: 'AlmaLinux 8', runs_on: 'ubuntu-22.04', target-os: 'almalinux', arch: 'x64'}
+        - {runner: 'AlmaLinux 8 ARM64', runs_on: 'ubuntu-22.04-arm', target-os: 'almalinux', arch: 'arm64'}
 
     steps:
 
@@ -38,11 +42,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: llvm-build
-
-    - name: Install ccache
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y ccache
 
     - name: Fetch LLVM Commit Hash
       shell: bash
@@ -55,7 +54,19 @@ jobs:
         echo "Short LLVM commit hash: ${SHORT_LLVM_COMMIT_HASH}"
         echo "short_llvm_commit_hash=${SHORT_LLVM_COMMIT_HASH}" >> ${GITHUB_ENV}
 
-        INSTALL_DIR="llvm-${SHORT_LLVM_COMMIT_HASH}-${{ matrix.config.target-os }}-${{ matrix.config.arch }}"
+    - name: Compute Patch Hash
+      shell: bash
+      run: |
+        PATCH_DIR="llvm-build/third_party/ascend/llvm_patch"
+        if [ -d "${PATCH_DIR}" ] && [ "$(ls -A ${PATCH_DIR}/*.patch 2>/dev/null)" ]; then
+          PATCH_HASH=$(cat ${PATCH_DIR}/*.patch | sha256sum | cut -d' ' -f1 | cut -c1-8)
+        else
+          PATCH_HASH="00000000"
+        fi
+        echo "Patch hash: ${PATCH_HASH}"
+        echo "patch_hash=${PATCH_HASH}" >> ${GITHUB_ENV}
+
+        INSTALL_DIR="llvm-${{ env.short_llvm_commit_hash }}-${PATCH_HASH}-${{ matrix.config.target-os }}-${{ matrix.config.arch }}"
         echo "LLVM installation directory name: ${INSTALL_DIR}"
         echo "llvm_install_dir=${INSTALL_DIR}" >> ${GITHUB_ENV}
 
@@ -98,51 +109,113 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{ env.SCCACHE_DIR }}
-        key: ${{ matrix.config.target-os }}-${{ matrix.config.arch }}-${{ env.short_llvm_commit_hash }}
+        key: ${{ matrix.config.target-os }}-${{ matrix.config.arch }}-${{ env.short_llvm_commit_hash }}-${{ env.patch_hash }}
         restore-keys: ${{ matrix.config.target-os }}-${{ matrix.config.arch }}-
 
-    - name: Free disk space
-      uses: jlumbroso/free-disk-space@v1.3.1
-      with:
-        tool-cache: false
-        android: true
-        dotnet: true
-        haskell: true
-        large-packages: false
-        swap-storage: true
-
-    # NOTE: check-mlir is temporarily disabled because the LLVM patches in
-    # third_party/ascend/llvm_patch/ modify bytecode encoding for several ops
-    # (FuncOp, CondBranchOp, MatmulOp, etc.), causing MLIR bytecode roundtrip
-    # tests to fail. The patches are needed for triton-ascend functionality.
-    # TODO: Fix the patch's readProperties/writeProperties implementations to
-    # ensure bytecode compatibility, then re-enable check-mlir.
-    - name: Configure, Build, and Install LLVM
-      run: |
+    - name: Configure, Build, and Install LLVM (Ubuntu)
+      if: matrix.config.target-os == 'ubuntu'
+      run: >
         python3 -m pip install -r llvm-project/mlir/python/requirements.txt
 
-        cmake -GNinja -Bllvm-project/build \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_C_COMPILER=clang \
-          -DCMAKE_CXX_COMPILER=clang++ \
-          -DCMAKE_C_COMPILER_LAUNCHER=sccache \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
-          -DCMAKE_INSTALL_PREFIX="${{ env.llvm_install_dir }}" \
-          -DCMAKE_LINKER=lld \
-          -DLLVM_BUILD_UTILS=ON \
-          -DLLVM_BUILD_TOOLS=ON \
-          -DLLVM_ENABLE_ASSERTIONS=ON \
-          -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
-          -DLLVM_ENABLE_PROJECTS="mlir;lld" \
-          -DLLVM_INSTALL_UTILS=ON \
-          -DLLVM_TARGETS_TO_BUILD="host;NVPTX;AMDGPU" \
-          -DLLVM_ENABLE_TERMINFO=OFF \
-          -DLLVM_ENABLE_ZSTD=OFF \
-          llvm-project/llvm
+        cmake -GNinja -Bllvm-project/build
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+        -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+        -DCMAKE_INSTALL_PREFIX="${{ env.llvm_install_dir }}"
+        -DCMAKE_LINKER=lld
+        -DLLVM_BUILD_UTILS=ON
+        -DLLVM_BUILD_TOOLS=ON
+        -DLLVM_ENABLE_ASSERTIONS=ON
+        -DMLIR_ENABLE_BINDINGS_PYTHON=ON
+        -DLLVM_ENABLE_PROJECTS="mlir;lld"
+        -DLLVM_INSTALL_UTILS=ON
+        -DLLVM_TARGETS_TO_BUILD="host;NVPTX;AMDGPU"
+        -DLLVM_ENABLE_TERMINFO=OFF
+        -DLLVM_ENABLE_ZSTD=OFF
+        llvm-project/llvm
 
         ninja -C llvm-project/build install
 
         tar czf "${{ env.llvm_install_dir }}.tar.gz" "${{ env.llvm_install_dir }}"
+
+    
+    - name: Configure, Build, and Install LLVM (macOS arm64)
+      if: matrix.config.arch == 'arm64' && matrix.config.target-os == 'macos'
+      run: >
+        python3 -m pip install -r llvm-project/mlir/python/requirements.txt
+
+        cmake -GNinja -Bllvm-project/build
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+        -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+        -DCMAKE_INSTALL_PREFIX="${{ env.llvm_install_dir }}"
+        -DCMAKE_LINKER=lld
+        -DCMAKE_OSX_ARCHITECTURES=arm64
+        -DLLVM_BUILD_UTILS=ON
+        -DLLVM_BUILD_TOOLS=ON
+        -DLLVM_ENABLE_ASSERTIONS=ON
+        -DMLIR_ENABLE_BINDINGS_PYTHON=ON
+        -DLLVM_ENABLE_PROJECTS="mlir;lld"
+        -DLLVM_ENABLE_ZSTD=OFF
+        -DLLVM_INSTALL_UTILS=ON
+        -DLLVM_TARGETS_TO_BUILD="AArch64;NVPTX;AMDGPU"
+        -DLLVM_USE_HOST_TOOLS=ON
+        -DLLVM_ENABLE_TERMINFO=OFF
+        -DLLVM_ABI_BREAKING_CHECKS=FORCE_OFF
+        llvm-project/llvm
+
+        ninja -C llvm-project/build install
+
+        tar czf "${{ env.llvm_install_dir }}.tar.gz" "${{ env.llvm_install_dir }}"
+
+
+    - name: Configure, Build, Test, and Install LLVM (CentOS)
+      if: matrix.config.target-os == 'centos'
+      run: |
+        # if this step crashes, it can leave behind a stale docker container
+        docker container prune -f
+        docker rmi -f $(docker images -q) 2>/dev/null || true
+
+        docker build --tag llvm-build --build-arg llvm_dir=llvm-project \
+          -f llvm-build/.github/workflows/llvm-build/centos.Dockerfile .
+
+        # Create temporary container to copy cache and installed artifacts.
+        CONTAINER_ID=$(docker create llvm-build)
+        docker cp "${CONTAINER_ID}:/install" "${{ env.llvm_install_dir }}"
+        tar czf "${{ env.llvm_install_dir }}.tar.gz" "${{ env.llvm_install_dir }}"
+
+        # We remove the existing directory, otherwise docker will
+        # create a subdirectory inside the existing directory.
+        rm -rf "${{ env.SCCACHE_DIR }}"
+        docker cp "${CONTAINER_ID}:/sccache" "${{ env.SCCACHE_DIR }}"
+        sudo chown -R "$(id -u -n):$(id -g -n)" "${{ env.SCCACHE_DIR }}"
+
+        docker rm "${CONTAINER_ID}"
+
+    - name: Configure, Build, Test, and Install LLVM (AlmaLinux)
+      if: matrix.config.target-os == 'almalinux'
+      run: |
+        # if this step crashes, it can leave behind a stale docker container
+        docker container prune -f
+        docker rmi -f $(docker images -q) 2>/dev/null || true
+
+        docker build --tag llvm-build --build-arg llvm_dir=llvm-project \
+          -f llvm-build/.github/workflows/llvm-build/almalinux.Dockerfile .
+
+        # Create temporary container to copy cache and installed artifacts.
+        CONTAINER_ID=$(docker create llvm-build)
+
+        # We remove the existing directories, otherwise docker cp will
+        # create a subdirectory inside the existing directory.
+        rm -rf "${{ env.SCCACHE_DIR }}" "${{ env.llvm_install_dir }}"
+
+        docker cp "${CONTAINER_ID}:/install" "${{ env.llvm_install_dir }}"
+        tar czf "${{ env.llvm_install_dir }}.tar.gz" "${{ env.llvm_install_dir }}"
+
+        docker cp "${CONTAINER_ID}:/sccache" "${{ env.SCCACHE_DIR }}"
+        sudo chown -R "$(id -u -n):$(id -g -n)" "${{ env.SCCACHE_DIR }}"
+
+        docker rm "${CONTAINER_ID}"
 
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v4
@@ -152,13 +225,14 @@ jobs:
           ${{ github.workspace }}/llvm-*-${{ matrix.config.target-os }}-${{ matrix.config.arch }}.tar.gz
 
     - name: Upload LLVM Artifacts to OBS
+      if: github.event_name == 'push' && github.repository == 'triton-lang/triton-ascend'
       env:
         AK: ${{ secrets.OBS_AK }}
         SK: ${{ secrets.OBS_SK }}
       run: |
         if [ -z "${AK}" ] || [ -z "${SK}" ]; then
-          echo "Please set AK and SK secrets before uploading."
-          exit 1
+          echo "OBS credentials not available, skipping upload."
+          exit 0
         fi
 
         OBSUTIL_URL="https://obs-community.obs.cn-north-1.myhuaweicloud.com/obsutil/current/obsutil_linux_${{ matrix.config.arch == 'x64' && 'amd64' || 'arm64' }}.tar.gz"

--- a/.github/workflows/llvm-build/almalinux.Dockerfile
+++ b/.github/workflows/llvm-build/almalinux.Dockerfile
@@ -1,8 +1,8 @@
 FROM almalinux:8
 ARG llvm_dir=llvm-project
 # Add the cache artifacts and the LLVM source tree to the container
-ADD sccache /sccache
-ADD "${llvm_dir}" /source/llvm-project
+COPY sccache /sccache
+COPY "${llvm_dir}" /source/llvm-project
 ENV SCCACHE_DIR="/sccache"
 ENV SCCACHE_CACHE_SIZE="2G"
 
@@ -27,7 +27,7 @@ RUN cmake -GNinja -Bbuild \
   -DCMAKE_CXX_FLAGS="-Wno-everything" \
   -DCMAKE_LINKER=lld \
   -DCMAKE_INSTALL_PREFIX="/install" \
-  -DCMAKE_PREFIX_PATH="/usr/local/lib/python3.9/site-packages/nanobind" \
+  -Dnanobind_DIR="/usr/local/lib/python3.9/site-packages/nanobind/cmake" \
   -DPython3_EXECUTABLE=/usr/bin/python3.9 \
   -DPython_EXECUTABLE=/usr/bin/python3.9 \
   -DLLVM_BUILD_UTILS=ON \

--- a/.github/workflows/llvm-build/almalinux.Dockerfile
+++ b/.github/workflows/llvm-build/almalinux.Dockerfile
@@ -7,10 +7,11 @@ ENV SCCACHE_DIR="/sccache"
 ENV SCCACHE_CACHE_SIZE="2G"
 
 RUN dnf install --assumeyes llvm-toolset
-RUN dnf install --assumeyes python38-pip python38-devel git
+RUN dnf install --assumeyes python39-pip python39-devel git
+RUN alternatives --set python3 /usr/bin/python3.9
 
 RUN python3 -m pip install --upgrade pip
-RUN python3 -m pip install --upgrade cmake ninja sccache lit
+RUN python3 -m pip install --upgrade cmake ninja sccache lit nanobind
 
 # Install MLIR's Python Dependencies
 RUN python3 -m pip install -r /source/llvm-project/mlir/python/requirements.txt
@@ -26,6 +27,9 @@ RUN cmake -GNinja -Bbuild \
   -DCMAKE_CXX_FLAGS="-Wno-everything" \
   -DCMAKE_LINKER=lld \
   -DCMAKE_INSTALL_PREFIX="/install" \
+  -DCMAKE_PREFIX_PATH="/usr/local/lib/python3.9/site-packages/nanobind" \
+  -DPython3_EXECUTABLE=/usr/bin/python3.9 \
+  -DPython_EXECUTABLE=/usr/bin/python3.9 \
   -DLLVM_BUILD_UTILS=ON \
   -DLLVM_BUILD_TOOLS=ON \
   -DLLVM_ENABLE_ASSERTIONS=ON \

--- a/.github/workflows/llvm-build/centos.Dockerfile
+++ b/.github/workflows/llvm-build/centos.Dockerfile
@@ -1,0 +1,56 @@
+FROM centos:7
+ARG llvm_dir=llvm-project
+# Add the cache artifacts and the LLVM source tree to the container
+ADD sccache /sccache
+ADD "${llvm_dir}" /source/llvm-project
+ENV SCCACHE_DIR="/sccache"
+ENV SCCACHE_CACHE_SIZE="2G"
+
+RUN echo -e "[llvmtoolset-build]\nname=LLVM Toolset 13.0 - Build\nbaseurl=https://buildlogs.centos.org/c7-llvm-toolset-13.0.x86_64/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/llvmtoolset-build.repo
+
+# Note: This is required patch since CentOS have reached EOL
+# otherwise any yum install setp will fail
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
+# Install build dependencies
+RUN yum install --assumeyes centos-release-scl
+
+# The definition of insanity is doing the same thing and expecting a different result
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
+RUN yum install --assumeyes --nogpgcheck llvm-toolset-13.0
+RUN yum install --assumeyes rh-python38-python-devel rh-python38-python-pip
+SHELL [ "/usr/bin/scl", "enable", "llvm-toolset-13.0", "rh-python38" ]
+
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install --upgrade cmake ninja sccache
+
+# Install MLIR's Python Dependencies
+RUN python3 -m pip install -r /source/llvm-project/mlir/python/requirements.txt
+
+# Configure, Build, Test, and Install LLVM
+RUN cmake -GNinja -Bbuild \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_CXX_COMPILER=clang++ \
+  -DCMAKE_ASM_COMPILER=clang \
+  -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+  -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
+  -DCMAKE_CXX_FLAGS="-Wno-everything" \
+  -DCMAKE_LINKER=lld \
+  -DCMAKE_INSTALL_PREFIX="/install" \
+  -DLLVM_BUILD_UTILS=ON \
+  -DLLVM_BUILD_TOOLS=ON \
+  -DLLVM_ENABLE_ASSERTIONS=ON \
+  -DMLIR_ENABLE_BINDINGS_PYTHON=OFF \
+  -DLLVM_ENABLE_PROJECTS="mlir;lld" \
+  -DLLVM_ENABLE_TERMINFO=OFF \
+  -DLLVM_INSTALL_UTILS=ON \
+  -DLLVM_TARGETS_TO_BUILD="host;NVPTX;AMDGPU" \
+  /source/llvm-project/llvm
+
+RUN ninja -C build install

--- a/.github/workflows/llvm-build/centos.Dockerfile
+++ b/.github/workflows/llvm-build/centos.Dockerfile
@@ -1,15 +1,15 @@
 FROM centos:7
 ARG llvm_dir=llvm-project
 # Add the cache artifacts and the LLVM source tree to the container
-ADD sccache /sccache
-ADD "${llvm_dir}" /source/llvm-project
+COPY sccache /sccache
+COPY "${llvm_dir}" /source/llvm-project
 ENV SCCACHE_DIR="/sccache"
 ENV SCCACHE_CACHE_SIZE="2G"
 
 RUN echo -e "[llvmtoolset-build]\nname=LLVM Toolset 13.0 - Build\nbaseurl=https://buildlogs.centos.org/c7-llvm-toolset-13.0.x86_64/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/llvmtoolset-build.repo
 
 # Note: This is required patch since CentOS have reached EOL
-# otherwise any yum install setp will fail
+# otherwise any yum install step will fail
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo


### PR DESCRIPTION
- Add patch hash to version naming for unique build identification
- Add CentOS 7 and AlmaLinux 8 (x64/arm64) build targets using Docker
- Trigger build only when llvm-hash or patches change
- Upload to OBS only on push events (skip for PRs)
- Update cache key to include patch hash

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
