### PR TITLE
ci: use CANN images in integration tests

### DIFF
--- a/.github/workflows/integration-tests-ascend.yml
+++ b/.github/workflows/integration-tests-ascend.yml
@@ -41,8 +41,8 @@ jobs:
             ~/.triton/llvm
             ~/.triton/json
             ~/.ccache
-          key: ${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python_version }}-triton-${{ hashFiles('cmake/llvm-hash.txt', 'cmake/json-version.txt', 'third_party/ascend/llvm_patch/*.patch') }}
-          restore-keys: ${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python_version }}-triton-
+          key: ${{ runner.os }}-${{ runner.arch }}-cann${{ matrix.cann_version }}-${{ matrix.os }}-${{ matrix.config.chip_type }}-py${{ matrix.python_version }}-triton-${{ hashFiles('cmake/llvm-hash.txt', 'cmake/json-version.txt', 'third_party/ascend/llvm_patch/*.patch') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-cann${{ matrix.cann_version }}-${{ matrix.os }}-${{ matrix.config.chip_type }}-py${{ matrix.python_version }}-triton-
 
       - name: Download and install Bisheng compiler
         shell: bash

--- a/.github/workflows/integration-tests-ascend.yml
+++ b/.github/workflows/integration-tests-ascend.yml
@@ -9,19 +9,21 @@ on:
 
 jobs:
   integration-tests-ascend:
-    name: integration-tests-ascend (${{ matrix.config.name }}, py${{ matrix.python-version }})
+    name: integration-tests-ascend (${{ matrix.config.name }}, py${{ matrix.python_version }})
     runs-on: ${{ matrix.config.runs_on }}
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/triton/triton:A3-8.5.0-latest
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/triton:${{ matrix.cann_version }}-${{ matrix.config.chip_type }}-${{ matrix.os }}-py${{ matrix.python_version }}-latest
     timeout-minutes: 300
     strategy:
       matrix:
         config: ${{ fromJson(inputs.matrix) }}
-        python-version: ['3.10', '3.11']
+        cann_version: ["8.5.0"]
+        os: [ubuntu22.04]
+        python_version: ["3.10", "3.11"]
       fail-fast: false
     env:
       PROTON_SKIP_PC_SAMPLING_TEST: 1
-      PYTHON: "python${{ matrix.python-version }}"
+      PYTHON: "python${{ matrix.python_version }}"
 
     steps:
       - name: Checkout
@@ -39,8 +41,8 @@ jobs:
             ~/.triton/llvm
             ~/.triton/json
             ~/.ccache
-          key: ${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-triton-${{ hashFiles('cmake/llvm-hash.txt', 'cmake/json-version.txt', 'third_party/ascend/llvm_patch/*.patch') }}
-          restore-keys: ${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-triton-
+          key: ${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python_version }}-triton-${{ hashFiles('cmake/llvm-hash.txt', 'cmake/json-version.txt', 'third_party/ascend/llvm_patch/*.patch') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python_version }}-triton-
 
       - name: Download and install Bisheng compiler
         shell: bash

--- a/.github/workflows/runner-preparation.yml
+++ b/.github/workflows/runner-preparation.yml
@@ -93,5 +93,5 @@ jobs:
         if: env.enable_integration == 'true'
         run: |
           if [ x"${{ github.repository }}" == x"triton-lang/triton-ascend" ]; then
-            echo 'matrix-ASCEND=[{"name":"linux-aarch64-a3-4","runner_type":"linux-aarch64-a3-4","runs_on":["linux-aarch64-a3-4"]}]' >> $GITHUB_OUTPUT
+            echo 'matrix-ASCEND=[{"name":"linux-aarch64-a3-4","runner_type":"linux-aarch64-a3-4","runs_on":["linux-aarch64-a3-4"],"chip_type":"a3"}]' >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
Switch integration-tests-ascend to use pre-built CANN images with dynamic tag based on matrix parameters. Move chip_type to runner-preparation config (hardware-bound), and define cann_version/os/python_version as local matrix arrays for easy expansion.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
