### PR TITLE
ci: Fix the issue of failure in obtaining the PR number

### DIFF
--- a/.github/workflows/A5-pipeline-tests.yml
+++ b/.github/workflows/A5-pipeline-tests.yml
@@ -117,6 +117,7 @@ jobs:
     timeout-minutes: 90
     permissions:
       pull-requests: write
+      statuses: write
     steps:
       # Default checkout pulls the base repo at the workflow's ref (safe).
       # Do not pass ref: head_sha — that would execute fork code.
@@ -134,14 +135,16 @@ jobs:
           # Title/body are mutable by the PR author at any time — same race
           # the original artifact collector had.
           P=$(gh pr view "$PR_ID" --repo "${{ github.repository }}" \
-                --json title,body,baseRefName)
+                --json title,body,baseRefName,headRefOid)
           PR_TITLE=$(echo "$P" | jq -r .title)
           PR_DESC=$(echo  "$P" | jq -r '.body // ""')
           BRANCH_B=$(echo "$P" | jq -r .baseRefName)
+          HEAD_SHA=$(echo "$P" | jq -r .headRefOid)
 
           {
             echo "pr_id=$PR_ID"
             echo "branch_b=$BRANCH_B"
+            echo "head_sha=$HEAD_SHA"
           } >> "$GITHUB_OUTPUT"
 
           # PR_TITLE / PR_DESC may contain newlines; pass via env file as multi-line values.
@@ -153,6 +156,19 @@ jobs:
             printf '%s\n' "$PR_DESC"
             echo "__EOF__"
           } >> "$GITHUB_ENV"
+
+      - name: Set commit status (pending)
+        if: steps.ctx.outputs.head_sha != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA:      ${{ steps.ctx.outputs.head_sha }}
+          TARGET:   ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh api -X POST "repos/${{ github.repository }}/statuses/${SHA}" \
+            -f state=pending \
+            -f context='A5 Pipeline Tests' \
+            -f description='Pipeline running' \
+            -f target_url="$TARGET"
 
       - name: Trigger pipeline
         id: run
@@ -290,19 +306,20 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Upsert sticky comment (final)
-        if: always() && steps.ctx.outputs.pr_id != ''
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          number: ${{ steps.ctx.outputs.pr_id }}
-          header: blue-yellow
-          message: |
-            ${{ steps.run.outcome == 'success' && '✅' || '❌' }} **Blue-Yellow pipeline: ${{ steps.final.outputs.status }}**
-
-            - msg: `${{ steps.final.outputs.msg }}`
-            - blueRecordId: `${{ steps.final.outputs.blueRecordId }}`
-            ${{ steps.final.outputs.yellowPipelineUrl != '' && format('- [yellow pipeline]({0})', steps.final.outputs.yellowPipelineUrl) || '' }}
-            - [run logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+      - name: Set commit status (final)
+        if: always() && steps.ctx.outputs.head_sha != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA:      ${{ steps.ctx.outputs.head_sha }}
+          STATE:    ${{ steps.run.outcome == 'success' && 'success' || 'failure' }}
+          DESC:     ${{ steps.final.outputs.status }}
+          TARGET:   ${{ steps.final.outputs.yellowPipelineUrl != '' && steps.final.outputs.yellowPipelineUrl || format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
+        run: |
+          gh api -X POST "repos/${{ github.repository }}/statuses/${SHA}" \
+            -f state="$STATE" \
+            -f context='A5 Pipeline Tests' \
+            -f description="${DESC:-UNKNOWN}" \
+            -f target_url="$TARGET"
 
   cleanup:
     if: github.event_name == 'pull_request_target'

--- a/.github/workflows/A5-pipeline-tests.yml
+++ b/.github/workflows/A5-pipeline-tests.yml
@@ -313,7 +313,7 @@ jobs:
           SHA:      ${{ steps.ctx.outputs.head_sha }}
           STATE:    ${{ steps.run.outcome == 'success' && 'success' || 'failure' }}
           DESC:     ${{ steps.final.outputs.status }}
-          TARGET:   ${{ steps.final.outputs.yellowPipelineUrl != '' && steps.final.outputs.yellowPipelineUrl || format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
+          TARGET:   ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           gh api -X POST "repos/${{ github.repository }}/statuses/${SHA}" \
             -f state="$STATE" \

--- a/.github/workflows/A5-pipeline-tests.yml
+++ b/.github/workflows/A5-pipeline-tests.yml
@@ -58,14 +58,13 @@ jobs:
         id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          # workflow_run.pull_requests is empty for fork PRs, so look up by
-          # head SHA via the API instead.
-          NUM=$(gh api "/repos/${{ github.repository }}/commits/${SHA}/pulls" \
+          NUM=$(gh api "/repos/${{ github.repository }}/pulls?state=open&head=${HEAD_OWNER}:${HEAD_BRANCH}" \
                   --jq 'if length > 0 then .[0].number else empty end')
           if [ -z "${NUM}" ]; then
-            echo "No PR found for SHA ${SHA}; nothing to publish."
+            echo "No open PR found for ${HEAD_OWNER}:${HEAD_BRANCH}; nothing to publish."
             exit 0
           fi
           echo "num=${NUM}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
Fix PR-number resolution in the A5 Pipeline Tests / publish job so it works for fork PRs.

## Problem
The previous lookup queried `/repos/<base>/commits/<sha>/pulls` using `workflow_run.head_sha`. For PRs from a fork to the base repo, the head commit lives in the fork — the base repo's commit DB only references it via `refs/pull/N/head`, which the `/commits/<sha>/pulls` endpoint doesn't traverse. Result: NUM was empty and the publish job exited without uploading the wheel.

This was masked during same-fork testing (where head commits are in the queried repo's commit DB) and only surfaced once the PR was opened against upstream.

## Fix
Look up the PR by head owner + branch instead of by commit SHA:

GET `/repos/<base>/pulls?state=open&head=<head_owner>:<head_branch>`
This works for both same-repo and cross-fork PRs because the head= filter is the canonical GitHub-supported way to identify a PR's source.

## Files changed
`.github/workflows/A5-pipeline-tests.yml `— replace SHA-based lookup with `head_repository.owner.login + head_branch` query in the Resolve PR number step.