### PR TITLE
Ci/introduce uv to accelerate pip install for ascend machine

### DIFF
--- a/.github/workflows/integration-tests-ascend.yml
+++ b/.github/workflows/integration-tests-ascend.yml
@@ -24,6 +24,13 @@ jobs:
     env:
       PROTON_SKIP_PC_SAMPLING_TEST: 1
       PYTHON: "python${{ matrix.python_version }}"
+      UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      UV_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi"
+      UV_INDEX_STRATEGY: "unsafe-best-match"
+      UV_INSECURE_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
+      UV_HTTP_TIMEOUT: 120
+      UV_NO_CACHE: 1
+      UV_SYSTEM_PYTHON: 1
 
     steps:
       - name: Checkout
@@ -101,8 +108,8 @@ jobs:
           if [ "$NUM_PROCS" -lt 1 ]; then NUM_PROCS=1; fi
           MAX_JOBS="$NUM_PROCS" \
           ${PYTHON} setup.py bdist_wheel
-          ${PYTHON} -m pip install dist/*.whl \
-            -i https://repo.huaweicloud.com/repository/pypi/simple/
+          ${PYTHON} -m pip install uv
+          uv pip install dist/*.whl --no-deps
 
       - name: CCache stats
         run: ccache --print-stats

--- a/.github/workflows/integration-tests-ascend.yml
+++ b/.github/workflows/integration-tests-ascend.yml
@@ -26,7 +26,6 @@ jobs:
       PYTHON: "python${{ matrix.python_version }}"
       UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
       UV_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi"
-      UV_INDEX_STRATEGY: "unsafe-best-match"
       UV_INSECURE_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
       UV_HTTP_TIMEOUT: 120
       UV_NO_CACHE: 1
@@ -109,7 +108,7 @@ jobs:
           MAX_JOBS="$NUM_PROCS" \
           ${PYTHON} setup.py bdist_wheel
           ${PYTHON} -m pip install uv
-          uv pip install dist/*.whl --no-deps
+          uv pip install --python "${PYTHON}" dist/*.whl --no-deps
 
       - name: CCache stats
         run: ccache --print-stats


### PR DESCRIPTION
Replace pip install with uv pip install in CI workflows to speed up dependency resolution.

## Changes


- `integration-tests-ascend.yml` — pip install dist/*.whl → uv pip install


## Improve effect
from 7-9 minutes to 1m30s about 530%

<img width="598" height="64" alt="image" src="https://github.com/user-attachments/assets/ae1b4b89-1703-4d8a-b343-620d52f4c659" />
 and 
<img width="2042" height="78" alt="image" src="https://github.com/user-attachments/assets/916de981-46ab-4313-a878-524e3ffc3690" />

 to 

<img width="2042" height="89" alt="image" src="https://github.com/user-attachments/assets/1fb63720-3fce-4f1f-bb77-55c5ea7f7f53" />
and 

<img width="2033" height="84" alt="image" src="https://github.com/user-attachments/assets/eb27d107-8528-4a5e-b045-91d839a3dc78" />
