### PR TITLE
feat: Enhance offset analysis and change the tensor of the all-one type in the select op to continuous memory access

### DIFF
--- a/third_party/ascend/include/TritonToLinalg/MaskAnalysis.h
+++ b/third_party/ascend/include/TritonToLinalg/MaskAnalysis.h
@@ -197,6 +197,10 @@ private:
   // Operand is the result of expand_dims
   LogicalResult parseExpandDims(triton::ExpandDimsOp expandDimsOp,
                                 const Location &loc, OpBuilder &builder);
+
+  // Operand is the result of insert
+  LogicalResult parseInsert(tensor::InsertOp insertOp, const Location &loc,
+                            OpBuilder &builder);
 };
 
 std::optional<MaskState> runMaskAnalysis(Operation *op, OpBuilder &builder);

--- a/third_party/ascend/isin_by_search_kernel.mlir
+++ b/third_party/ascend/isin_by_search_kernel.mlir
@@ -1,0 +1,62 @@
+// RUN: triton-opt --discrete-mask-access-conversion --triton-to-unstructure --triton-to-linalg --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: func.func @isin_by_search_kernel
+// CHECK: %[[FOR_VAR:.*]]:6 = scf.for
+// CHECK-SAME: iter_args({{.*}}) -> (tensor<1xi1>, tensor<1xi1>, index, index, index, index) : i32
+module {
+  tt.func public @isin_by_search_kernel(
+    %arg0: !tt.ptr<i64> {tt.divisibility = 16 : i32}, 
+    %arg1: !tt.ptr<i16> {tt.divisibility = 16 : i32}, 
+    %arg2: !tt.ptr<i1> {tt.divisibility = 16 : i32}, 
+    %arg3: i32 {tt.divisibility = 16 : i32}
+  ) attributes {noinline = false} {
+    %c1_i64 = arith.constant 1 : i64
+    %cst = arith.constant dense<0> : tensor<1xi32>
+    %cst_0 = arith.constant dense<2> : tensor<1xi32>
+    %cst_1 = arith.constant dense<1> : tensor<1xi32>
+    %cst_2 = arith.constant dense<0> : tensor<1xi64>
+    %c0_i32 = arith.constant 0 : i32
+    %c20_i32 = arith.constant 20 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %cst_3 = arith.constant dense<0> : tensor<1xi16>
+    %cst_4 = arith.constant dense<false> : tensor<1xi1>
+    %0 = tt.get_program_id x : i32
+    %1 = arith.extsi %0 : i32 to i64
+    %2 = arith.cmpi slt, %1, %c1_i64 : i64
+    %3 = tt.splat %2 : i1 -> tensor<1xi1>
+    %4 = tt.addptr %arg0, %1 : !tt.ptr<i64>, i64
+    %5 = tt.splat %4 : !tt.ptr<i64> -> tensor<1x!tt.ptr<i64>>
+    %6 = tt.load %5, %3, %cst_2 : tensor<1x!tt.ptr<i64>>
+    %7 = tt.splat %arg3 : i32 -> tensor<1xi32>
+    %8 = arith.cmpi sgt, %arg3, %c0_i32 : i32
+    %9 = tt.splat %8 : i1 -> tensor<1xi1>
+    %10 = tt.splat %arg1 : !tt.ptr<i16> -> tensor<1x!tt.ptr<i16>>
+    %11:4 = scf.for %arg4 = %c0_i32 to %c20_i32 step %c1_i32 iter_args(%arg5 = %cst_4, %arg6 = %cst, %arg7 = %7, %arg8 = %9) -> (tensor<1xi1>, tensor<1xi32>, tensor<1xi32>, tensor<1xi1>)  : i32 {
+      %16 = arith.subi %arg7, %arg6 : tensor<1xi32>
+      %17 = arith.divsi %16, %cst_0 : tensor<1xi32>
+      %18 = arith.addi %arg6, %17 : tensor<1xi32>
+      %19 = arith.select %arg8, %18, %cst : tensor<1xi1>, tensor<1xi32>
+      %20 = tt.addptr %10, %19 : tensor<1x!tt.ptr<i16>>, tensor<1xi32>
+      %21 = tt.load %20, %arg8, %cst_3 : tensor<1x!tt.ptr<i16>>
+      %22 = arith.extsi %21 : tensor<1xi16> to tensor<1xi64>
+      %23 = arith.cmpi eq, %22, %6 : tensor<1xi64>
+      %24 = arith.ori %cst_4, %23 : tensor<1xi1>
+      %25 = arith.select %arg8, %24, %arg5 : tensor<1xi1>, tensor<1xi1>
+      %26 = arith.cmpi slt, %22, %6 : tensor<1xi64>
+      %27 = arith.andi %arg8, %26 : tensor<1xi1>
+      %28 = arith.addi %19, %cst_1 : tensor<1xi32>
+      %29 = arith.select %27, %28, %arg6 : tensor<1xi1>, tensor<1xi32>
+      %30 = arith.cmpi sgt, %22, %6 : tensor<1xi64>
+      %31 = arith.andi %arg8, %30 : tensor<1xi1>
+      %32 = arith.select %31, %19, %arg7 : tensor<1xi1>, tensor<1xi32>
+      %33 = arith.cmpi slt, %29, %32 : tensor<1xi32>
+      scf.yield %25, %29, %32, %33 : tensor<1xi1>, tensor<1xi32>, tensor<1xi32>, tensor<1xi1>
+    }
+    %12 = tt.addptr %arg2, %1 : !tt.ptr<i1>, i64
+    %13 = tt.bitcast %12 : !tt.ptr<i1> -> !tt.ptr<i8>
+    %14 = tt.splat %13 : !tt.ptr<i8> -> tensor<1x!tt.ptr<i8>>
+    %15 = arith.extui %11#0 : tensor<1xi1> to tensor<1xi8>
+    tt.store %14, %15, %3 : tensor<1x!tt.ptr<i8>>
+    tt.return
+  }
+}

--- a/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
@@ -1608,11 +1608,18 @@ BlockDataParser::rewriteTerminator(
       }
     }
 
+    auto sizesRef = state.getSizesRef();
+    size_t dimIdx = 0;
     for (OpFoldResult stride : state.getStridesRef()) {
       if (isa<Attribute>(stride)) {
-        auto constStride = stride.get<Attribute>();
-        assert(isa<IntegerAttr>(constStride) &&
-               dyn_cast<IntegerAttr>(constStride).getInt() == 1 &&
+        auto constStride = cast<Attribute>(stride);
+        assert(isa<IntegerAttr>(constStride) && "attribute strides should be IntegerAttr");
+
+        auto strideVal = dyn_cast<IntegerAttr>(constStride).getInt();
+        bool isSizeOne = (dimIdx < sizesRef.size() &&
+                          isa<Attribute>(sizesRef[dimIdx]) &&
+                          cast<IntegerAttr>(cast<Attribute>(sizesRef[dimIdx])).getInt() == 1);
+        assert((strideVal == 1 || (strideVal == 0 && isSizeOne)) &&
                "attribute strides should be ones");
         auto constOp = rewriter.create<arith::ConstantOp>(
             op.getLoc(), rewriter.getIndexAttr(1));
@@ -1620,6 +1627,7 @@ BlockDataParser::rewriteTerminator(
       } else {
         operands.push_back(stride.get<Value>());
       }
+      dimIdx++;
     }
   }
 

--- a/third_party/ascend/lib/TritonToLinalg/MaskAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/MaskAnalysis.cpp
@@ -126,6 +126,8 @@ LogicalResult MaskState::parse(Value operand, const Location &loc,
           [&](auto op) { return this->parseDiv(op, loc, builder); })
       .Case<arith::SelectOp>(
           [&](auto op) { return this->parseSel(op, loc, builder); })
+      .Case<tensor::InsertOp>(
+          [&](auto op) { return this->parseInsert(op, loc, builder); })
       .Default([&](Operation *op) { return failure(); });
 }
 
@@ -678,6 +680,23 @@ LogicalResult MaskState::parseExpandDims(triton::ExpandDimsOp expandDimsOp,
   this->offsets.insert(this->offsets.begin() + axis, builder.getIndexAttr(0));
 
   return success();
+}
+
+LogicalResult MaskState::parseInsert(tensor::InsertOp insertOp,
+                                     const Location &loc,
+                                     OpBuilder &builder)
+{
+  if (auto tensorType = dyn_cast<RankedTensorType>(insertOp.getType())) {
+    if (llvm::all_of(tensorType.getShape(), [](int64_t dim) { return dim == 1; })) {
+      SmallVector<Value> indices(tensorType.getRank(), builder.create<arith::ConstantIndexOp>(loc, 0));
+      auto scalarlizeTensor = builder.create<tensor::ExtractOp>(loc, insertOp, indices).getResult();
+      this->offsets = SmallVector<OpFoldResult>(tensorType.getRank(), builder.getIndexAttr(0));
+      this->dims = SmallVector<OpFoldResult>(tensorType.getRank(), builder.getIndexAttr(1));
+      this->scalar = getOpFoldResultOfLayoutInfo(scalarlizeTensor, builder);
+      return success();
+    }
+  }
+  return failure();
 }
 
 void MaskState::eraseInsertedOps(Operation *rawOp, PatternRewriter &rewriter) {

--- a/third_party/ascend/lib/TritonToLinalg/UseAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/UseAnalysis.cpp
@@ -361,7 +361,7 @@ LogicalResult triton::runUseAnalysis(triton::FuncOp &funcOp) {
     bool shapedResult = true;
     for (auto result : op->getResults())
       shapedResult &= isa<ShapedType>(result.getType());
-    if (!shapedResult || isa<LoopLikeOpInterface, scf::IfOp>(op)) {
+    if (!shapedResult || isa<LoopLikeOpInterface, scf::IfOp, arith::SelectOp>(op)) {
       LLVM_DEBUG({ op->setAttr("MixUse", UnitAttr::get(context)); });
       return;
     }

--- a/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
@@ -802,19 +802,6 @@ void parseSelect(arith::SelectOp op, const Location &loc,
   if (!dstType)
     return;
 
-  // recognize "all dims size == 1", which cannot be handled in linalg pass's rewrite loop right now
-  // fix rewrite loop in linalg pass and remove this special handling
-  bool dstAllDimsAreOne = false;
-  if (auto rankedDstType = dyn_cast<RankedTensorType>(dstType)) {
-    dstAllDimsAreOne = llvm::all_of(
-        rankedDstType.getShape(), [](int64_t dim) { return dim == 1; });
-  }
-
-  if (dstAllDimsAreOne) {
-    offsetMap[dst].setUnstructured(dstType.getRank());
-    return;
-  }
-
   auto dstIsScalar = trueValueScalarLike && falseValueScalarLike && conditionScalarLike;
   offsetMap[dst].setScalarLike(dstIsScalar);
 


### PR DESCRIPTION
**bugfix1:** The restriction that forcibly treats tensor types with all 1（<1x1x1x...>） in the select op during pointer analysis as non-contiguous has been removed.
Because under the original restriction, it would lead to a situation where, when processing tensor<1x> types, they would be expanded into discrete memory access.However, when the MLIR's built-in forloop optimization（SimplifyTrivialLoops） recognizing that the loop count is 1, it would fall back. Yet, it did not remove the discrete memory access label applied to the load op during the discrete memory access optimization（{DiscreteMemAccess}）.
When the linalg pass later attempts to transform the load, if it detects that the load has a discrete memory access label, it will read the init args of the outer forloop of the load. Where the discrete memory access forloop has already been fall back by SimplifyTrivialLoops , this can lead to a series of errors (for example, if the discrete memory access forloop has been erased but the kernel itself still contains a forloop, reading the init args as empty can cause a core dump).

**bugfix2:** When recognize a indextensor in forloop init args in the rewriteforloop, it will be convert to offset + stride，but in some scene, for example，the args is recognize as indextensor, then in blockptranalysis, it will be analysised as scalar, and in rewriteTerminator it need the stride must equal one, so an assert error occurs.

**bugfix3:** When the mask is composed of splats, it is identified as a continuous mask in the discrete mask analysis pass. However, when it enters the Triton to Linalg pass, if all dimensions are 1, the splat op is converted into an insert op. In this case, the mask analysis cannot identify the insert op, and the mask is analyzed as discontinuous. As a result, the problem occurs.

**bugfix4:** In the use analysis, when there is indirect memory access, the 1st load op is initially marked as a meta use. In the Post-process, this situation is handled by identifying and marking the instruction chain related to indirect memory access, and then re-marking it as mixuse to ensure it is not eliminated in subsequent conversion stages.
If an op appears in a computation chain involving a set of indirect memory accesses, such as load(1st) -> computeOp -> load(2nd), and this op has been used through assert or print, it will be marked as Mixuse. In this case, the op will be clone into a mixuse op and a metause op before the Post-process phase.
The mixuse op is used for assert, and the metause op is used for 2nd loads. However, since the op was initially marked as Mixuse, the 1st load op is also marked as Mixuse, thus skipping the post-process. Since the split metause op is used for 2nd loads, its elimination can cause a series of issues. Currently, a temporary modified for this situation is to disable cloning of select ops.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
