### PR TITLE
fix: add mlir scope symbols to keep consitent with upstream

### DIFF
--- a/python/src/ir.h
+++ b/python/src/ir.h
@@ -16,34 +16,34 @@ using namespace triton;
 class TritonOpBuilder {
 public:
   TritonOpBuilder(mlir::MLIRContext *context, const std::string &compile_mode = "simd") {
-    builder = std::make_unique<OpBuilder>(context);
-    lastLoc = std::make_unique<Location>(builder->getUnknownLoc());
+    builder = std::make_unique<mlir::OpBuilder>(context);
+    lastLoc = std::make_unique<mlir::Location>(builder->getUnknownLoc());
     this->compile_mode = compile_mode;
   }
 
-  OpBuilder &getBuilder() { return *builder; }
+  mlir::OpBuilder &getBuilder() { return *builder; }
   mlir::MLIRContext *getContext() { return builder->getContext(); }
 
   bool isLineInfoEnabled() { return lineInfoEnabled; }
 
   bool isSimtMode() const { return compile_mode == "simt"; }
 
-  void setLastLoc(Location loc) {
+  void setLastLoc(mlir::Location loc) {
     if (lineInfoEnabled)
-      lastLoc = std::make_unique<Location>(loc);
+      lastLoc = std::make_unique<mlir::Location>(loc);
   }
 
   void setLastLoc(const std::string &fileName, int line, int column) {
     auto context = builder->getContext();
-    setLastLoc(FileLineColLoc::get(context, fileName, line, column));
+    setLastLoc(mlir::FileLineColLoc::get(context, fileName, line, column));
   }
 
-  Location getLastLoc() {
+  mlir::Location getLastLoc() {
     assert(lastLoc);
     return *lastLoc;
   }
 
-  void setInsertionPointToStart(Block &block) {
+  void setInsertionPointToStart(mlir::Block &block) {
     if (!block.empty())
       setLastLoc(block.begin()->getLoc());
     else
@@ -51,7 +51,7 @@ public:
     builder->setInsertionPointToStart(&block);
   }
 
-  void setInsertionPointToEnd(Block &block) {
+  void setInsertionPointToEnd(mlir::Block &block) {
     if (!block.empty())
       setLastLoc(block.back().getLoc());
     else
@@ -59,12 +59,12 @@ public:
     builder->setInsertionPointToEnd(&block);
   }
 
-  void setInsertionPointAfter(Operation &op) {
+  void setInsertionPointAfter(mlir::Operation &op) {
     setLastLoc(op.getLoc());
     builder->setInsertionPointAfter(&op);
   }
 
-  void restoreInsertionPoint(OpBuilder::InsertPoint pt) {
+  void restoreInsertionPoint(mlir::OpBuilder::InsertPoint pt) {
     if (pt.isSet() && pt.getPoint() != pt.getBlock()->end())
       setLastLoc(pt.getPoint()->getLoc());
     else
@@ -79,7 +79,8 @@ public:
 
   // Overload to create or fold a single result operation.
   template <typename OpTy, typename... Args>
-  std::enable_if_t<OpTy::template hasTrait<OpTrait::OneResult>(), Value>
+  std::enable_if_t<OpTy::template hasTrait<mlir::OpTrait::OneResult>(),
+                   mlir::Value>
   createOrFold(Args &&...args) {
     auto loc = getLastLoc();
     return builder->createOrFold<OpTy>(loc, std::forward<Args>(args)...);
@@ -87,16 +88,17 @@ public:
 
   // Overload to create or fold a zero result operation.
   template <typename OpTy, typename... Args>
-  std::enable_if_t<OpTy::template hasTrait<OpTrait::ZeroResults>(), OpTy>
+  std::enable_if_t<OpTy::template hasTrait<mlir::OpTrait::ZeroResults>(), OpTy>
   createOrFold(Args &&...args) {
     auto loc = getLastLoc();
     return builder->createOrFold<OpTy>(loc, std::forward<Args>(args)...);
   }
 
 private:
-  std::unique_ptr<OpBuilder> builder;
-  std::unique_ptr<Location> lastLoc;
-  bool lineInfoEnabled = !triton::tools::getBoolEnv("TRITON_DISABLE_LINE_INFO");
+  std::unique_ptr<mlir::OpBuilder> builder;
+  std::unique_ptr<mlir::Location> lastLoc;
+  bool lineInfoEnabled =
+      !mlir::triton::tools::getBoolEnv("TRITON_DISABLE_LINE_INFO");
   std::string compile_mode;
 };
 


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
