### PR TITLE
feat(op): support descriptor gather op

### DIFF
--- a/third_party/ascend/include/TritonToLinalg/DescriptorConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/DescriptorConverter.h
@@ -66,6 +66,14 @@ public:
                                   ConversionPatternRewriter &rewriter) const override;
 };
 
+class DescriptorGatherConverter : public OpConversionPattern<triton::DescriptorGatherOp> {
+public:
+    using OpConversionPattern<triton::DescriptorGatherOp>::OpConversionPattern;
+
+    LogicalResult matchAndRewrite(triton::DescriptorGatherOp op, OpAdaptor adaptor,
+                                  ConversionPatternRewriter &rewriter) const override;
+};
+
 } // end of namespace DescriptorConverter
 
 #endif // TRITON_ADAPTER_DESCRIPTORCONVERTER_H

--- a/third_party/ascend/lib/TritonToLinalg/DescriptorConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/DescriptorConverter.cpp
@@ -197,4 +197,82 @@ LogicalResult DescriptorStoreConverter::matchAndRewrite(triton::DescriptorStoreO
     return success();
 }
 
+SmallVector<NamedAttribute> filterSegmentSizes(ArrayRef<NamedAttribute> attrs)
+{
+    SmallVector<NamedAttribute> filteredAttrs;
+    llvm::copy_if(attrs, std::back_inserter(filteredAttrs), [](const NamedAttribute &attr) {
+        return attr.getName().getValue() != "operandSegmentSizes";
+    });
+    return filteredAttrs;
+}
+
+LogicalResult DescriptorGatherConverter::matchAndRewrite(triton::DescriptorGatherOp op, OpAdaptor adaptor,
+                                                         ConversionPatternRewriter &rewriter) const
+{
+    auto loc = op.getLoc();
+    auto descTy = op.getDesc().getType();
+    auto resultType = cast<RankedTensorType>(op.getResult().getType());
+    const auto blockShape = resultType.getShape();
+    const auto rowBlockShape = descTy.getSignlessBlockType().getShape();
+
+    auto desc = unpackDescriptor(descTy, adaptor.getDesc(), rewriter);
+    SmallVector<int32_t> tensorShapeValues;
+    tensorShapeValues.reserve(rowBlockShape.size());
+    for (auto dim : rowBlockShape) {
+        tensorShapeValues.push_back(static_cast<int32_t>(dim));
+    }
+
+    auto zeroIndex = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    auto oneIndex = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    auto rowUpperBound = rewriter.create<arith::ConstantIndexOp>(loc, blockShape[0]);
+    auto rowBoundaryCheck = getFullBoundaryCheckAttr(rewriter, rowBlockShape);
+    auto cache = triton::CacheModifierAttr::get(rewriter.getContext(), triton::CacheModifier::NONE);
+    auto evict = triton::EvictionPolicyAttr::get(rewriter.getContext(), triton::EvictionPolicy::NORMAL);
+    auto isVolatile = rewriter.getBoolAttr(false);
+
+    if (auto attr = op->getAttrOfType<triton::CacheModifierAttr>("cache")) cache = attr;
+    if (auto attr = op->getAttrOfType<triton::EvictionPolicyAttr>("evict")) evict = attr;
+    if (auto attr = op->getAttrOfType<BoolAttr>("isVolatile")) isVolatile = attr;
+
+    Value initTensor = rewriter.create<tensor::EmptyOp>(loc, blockShape, resultType.getElementType());
+    auto loop = rewriter.create<scf::ForOp>(
+        loc, zeroIndex, rowUpperBound, oneIndex, ValueRange{initTensor},
+        [&](OpBuilder &nestedBuilder, Location nestedLoc, Value rowIv, ValueRange iterArgs) {
+            Value xOffset = nestedBuilder.create<tensor::ExtractOp>(nestedLoc, adaptor.getXOffsets(), ValueRange{rowIv});
+            Value tensorPtr = nestedBuilder.create<triton::MakeTensorPtrOp>(nestedLoc,
+                                                                            desc.base,
+                                                                            desc.shape,
+                                                                            desc.strides,
+                                                                            ValueRange{xOffset, adaptor.getYOffset()},
+                                                                            tensorShapeValues,
+                                                                            computeOrder(rowBlockShape));
+            auto rowLoad = nestedBuilder.create<triton::LoadOp>(nestedLoc,
+                                                                descTy.getSignlessBlockType(),
+                                                                tensorPtr,
+                                                                Value(),
+                                                                Value(),
+                                                                rowBoundaryCheck,
+                                                                desc.padding,
+                                                                cache,
+                                                                evict,
+                                                                isVolatile);
+            rowLoad->setAttrs(filterSegmentSizes(op->getAttrs()));
+            SmallVector<OpFoldResult> insertOffsets{rowIv, nestedBuilder.getIndexAttr(0)};
+            SmallVector<OpFoldResult> insertSizes{nestedBuilder.getIndexAttr(rowBlockShape[0]),
+                                                  nestedBuilder.getIndexAttr(rowBlockShape[1])};
+            SmallVector<OpFoldResult> insertStrides{nestedBuilder.getIndexAttr(1),
+                                                    nestedBuilder.getIndexAttr(1)};
+            Value updatedTensor = nestedBuilder.create<tensor::InsertSliceOp>(nestedLoc,
+                                                                              rowLoad.getResult(),
+                                                                              iterArgs[0],
+                                                                              insertOffsets,
+                                                                              insertSizes,
+                                                                              insertStrides);
+            nestedBuilder.create<scf::YieldOp>(nestedLoc, updatedTensor);
+        });
+
+    rewriter.replaceOp(op, loop.getResults());
+    return success();
+}
+
 } // namespace DescriptorConverter

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -664,6 +664,7 @@ LogicalResult TritonToLinalgPass::processDescriptorOperations(ModuleOp moduleOp)
 {
     // --- ConversionTarget: dynamic legality checks ---
     mlir::ConversionTarget target(getContext());
+    target.addLegalDialect<mlir::tensor::TensorDialect>();
 
     // Dialect-level dynamic legality: ops are legal if none of their operands/results use TensorDescType.
     target.addDynamicallyLegalDialect<mlir::arith::ArithDialect, mlir::scf::SCFDialect, triton::TritonDialect>(
@@ -677,12 +678,13 @@ LogicalResult TritonToLinalgPass::processDescriptorOperations(ModuleOp moduleOp)
                !DescriptorConverter::hasATensorDescriptorType(funcOp.getFunctionType().getResults());
     });
     target.addLegalOp<triton::MakeTensorDescOp>();
-    target.addIllegalOp<triton::DescriptorLoadOp, triton::DescriptorStoreOp>();
+    target.addIllegalOp<triton::DescriptorLoadOp, triton::DescriptorStoreOp, triton::DescriptorGatherOp>();
 
     // --- Patterns ---
     mlir::RewritePatternSet patterns(&getContext());
     patterns.add<DescriptorConverter::DescriptorLoadConverter>(patterns.getContext());
     patterns.add<DescriptorConverter::DescriptorStoreConverter>(patterns.getContext());
+    patterns.add<DescriptorConverter::DescriptorGatherConverter>(patterns.getContext());
 
     mlir::ConversionConfig config;
     config.buildMaterializations = true;

--- a/third_party/ascend/unittest/pytest_ut/test_tensor_descriptor.py
+++ b/third_party/ascend/unittest/pytest_ut/test_tensor_descriptor.py
@@ -224,3 +224,46 @@ def test_tensor_descriptor_padding(dtype, padding):
         expected[IM:OM, :] = float('nan')
 
     torch.testing.assert_close(expected, out_device_tma, equal_nan=True)
+
+
+@pytest.mark.parametrize("X, Y", [(128, 128), (64, 256)])
+@pytest.mark.parametrize("BLOCK_X, BLOCK_Y", [(32, 32), (64, 128), (16, 128), (512, 16)])
+@pytest.mark.parametrize("dtype", ['float32', 'float16', 'bfloat16', 'int32', 'int16'])
+@pytest.mark.parametrize("y", [0, 32, 48])
+def test_tensor_descriptor_gather(X, Y, BLOCK_X, BLOCK_Y, dtype, y):
+    
+    @triton.jit
+    def tensor_descriptor_gather_rows_kernel(out_ptr, in_ptr, idx_ptr, y, X: tl.constexpr, Y: tl.constexpr, BLOCK_X: tl.constexpr,
+                            BLOCK_Y: tl.constexpr):
+        idx = tl.load(idx_ptr + tl.arange(0, BLOCK_X))
+        desc = tl.make_tensor_descriptor(in_ptr, [X, Y], [Y, 1], [1, BLOCK_Y])
+        out = desc.gather(idx, y)
+        tl.store(out_ptr + tl.arange(0, BLOCK_X)[:, None] * BLOCK_Y + tl.arange(0, BLOCK_Y)[None, :], out)
+
+    def torch_gather_rows(input, idx, y, block_y):
+        out = torch.empty(0, device=input.device, dtype=input.dtype)
+        for i in idx:
+            x = input[i][y:y + block_y]
+            out = torch.cat((out, x.reshape(1, x.shape[0])), dim=0)
+        return out
+    
+    device = 'npu'
+    if BLOCK_X > X or y + BLOCK_Y > Y:
+        pytest.skip()
+
+    torch.manual_seed(42)
+    torch_dtype = getattr(torch, dtype)
+    input_tensor = test_common.generate_tensor((X, Y), dtype).npu()
+    output = torch.empty((BLOCK_X, BLOCK_Y), dtype=torch_dtype, device=device)
+
+    idx = torch.randint(BLOCK_X, (BLOCK_X, ), dtype=torch.int32, device=device)
+
+    def alloc_fn(size: int, align: int, steam):
+        return torch.empty(size, dtype=torch.int8, device=device)
+
+    triton.set_allocator(alloc_fn)
+
+    tensor_descriptor_gather_rows_kernel[(1, )](output, input_tensor, idx, y, X, Y, BLOCK_X, BLOCK_Y)
+
+    ref = torch_gather_rows(input_tensor, idx, y, BLOCK_Y)
+    torch.testing.assert_close(ref, output, atol=0, rtol=0)


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
## Related Issue
#69 

## Background

After the upstream upgrade, the community introduced a new `descriptor_gather` op. The current Ascend backend does not yet support lowering for `descriptor_gather`, so this change adds backend support for the new gather op.

## Feature Overview

`descriptor gather` is used to gather multiple rows from an input tensor based on a 2D tensor descriptor and a given set of row indices, while reading a contiguous block starting from a shared column offset.

## Interface

| Parameter   | Type                         | Required | Description                                                  |
| ----------- | ---------------------------- | -------- | ------------------------------------------------------------ |
| `x_offsets` | 1D tensor / row index vector | Yes      | The set of row indices to gather. The i-th row of the output corresponds to the [x_offsets[i\]]-th row of the input. |
| `y_offset`  | scalar integer               | Yes      | The unified starting offset in the column dimension. All gathered rows start reading from this column position. |

## Return Value

Returns a 2D tensor with shape: [len(x_offsets), desc.block_shape[1]]

Where:

- The first dimension is the number of gathered rows, which is the length of `x_offsets`
- The second dimension is the block size read in the column dimension for each row, which is [desc.block_shape[1\]]

The element type of the returned tensor is the same as the underlying element type described by desc.

## Changes

1. Add DescriptorGatherConverter to provide specific lowering for `tt.descriptor_gather`.
2. Implement gather lowering using a row-wise `descriptor load + tensor.insert_slice` scheme to assemble the result tensor.
3. Explicitly mark the tensor dialect as legal in the descriptor conversion target, so that tensor ops introduced during gather lowering, such as tensor.empty, tensor.extract, and tensor.insert_slice, can be handled correctly.

## Constraints

1. This only applies to 2D tensor descriptor.
2. The current semantics require the descriptor row block size to be `1`.
3. Each index in `x_offsets` must fall within the valid row range of the input tensor.
4. `y_offset` and the corresponding column block access range must satisfy column boundary constraints.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
