### PR TITLE
[release/3.2.2][Autotune] Recover cv dot rhs tuning param inference

### DIFF
--- a/third_party/ascend/backend/runtime/dsl_analysis/shape_inference.py
+++ b/third_party/ascend/backend/runtime/dsl_analysis/shape_inference.py
@@ -49,6 +49,17 @@ def _is_tl_transpose_call(node: ast.AST) -> bool:
     )
 
 
+def _merge_tensor_name_candidates(*candidates: Optional[str]) -> Optional[str]:
+    names = []
+    for candidate in candidates:
+        if candidate is None or candidate in names:
+            continue
+        names.append(candidate)
+    if len(names) == 1:
+        return names[0]
+    return None
+
+
 def _extract_tensor_name_from_expr(expr: ast.AST) -> Optional[str]:
     if isinstance(expr, ast.Name):
         return expr.id
@@ -75,6 +86,21 @@ def _extract_tensor_name_from_expr(expr: ast.AST) -> Optional[str]:
         if expr.args:
             return _extract_tensor_name_from_expr(expr.args[0])
         return None
+
+    if isinstance(expr, ast.UnaryOp):
+        return _extract_tensor_name_from_expr(expr.operand)
+
+    if isinstance(expr, ast.BinOp):
+        return _merge_tensor_name_candidates(
+            _extract_tensor_name_from_expr(expr.left),
+            _extract_tensor_name_from_expr(expr.right),
+        )
+
+    if isinstance(expr, ast.IfExp):
+        return _merge_tensor_name_candidates(
+            _extract_tensor_name_from_expr(expr.body),
+            _extract_tensor_name_from_expr(expr.orelse),
+        )
 
     if isinstance(expr, ast.Attribute) and isinstance(expr.value, ast.Name):
         return expr.value.id
@@ -140,11 +166,41 @@ class _DotSiteCollector(ast.NodeVisitor):
     def _resolve_tensor_name_and_role(self, expr: ast.AST):
         transposed = _is_tl_transpose_call(expr)
         base_expr = expr.args[0] if transposed and isinstance(expr, ast.Call) and expr.args else expr
-        tensor_name = self._extract_tensor_name(base_expr)
-        role = self.tensor_roles.get(tensor_name, None)
+        tensor_name, role = self._extract_tensor_name_and_role(base_expr)
         if transposed:
             role = self._swap_role(role)
         return tensor_name, role
+
+    def _extract_tensor_name_and_role(self, expr: ast.AST):
+        if isinstance(expr, ast.BinOp):
+            left_name, left_role = self._extract_tensor_name_and_role(expr.left)
+            right_name, right_role = self._extract_tensor_name_and_role(expr.right)
+            if left_role is not None and right_role is None:
+                return left_name, left_role
+            if right_role is not None and left_role is None:
+                return right_name, right_role
+            if left_role is not None and right_role is not None and left_name == right_name:
+                return left_name, left_role
+            return None, None
+
+        if isinstance(expr, ast.UnaryOp):
+            return self._extract_tensor_name_and_role(expr.operand)
+
+        if isinstance(expr, ast.IfExp):
+            body_name, body_role = self._extract_tensor_name_and_role(expr.body)
+            else_name, else_role = self._extract_tensor_name_and_role(expr.orelse)
+            if body_role is not None and else_role is None:
+                return body_name, body_role
+            if else_role is not None and body_role is None:
+                return else_name, else_role
+            if body_role is not None and else_role is not None and body_name == else_name:
+                return body_name, body_role
+            return None, None
+
+        tensor_name = self._extract_tensor_name(expr)
+        if tensor_name is None:
+            return None, None
+        return tensor_name, self.tensor_roles.get(tensor_name, None)
 
     def _extract_tensor_name(self, expr: ast.AST) -> Optional[str]:
         return _extract_tensor_name_from_expr(expr)

--- a/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
+++ b/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
@@ -747,6 +747,92 @@ def test_vector_axes_materialize_axis_sizes_prefers_fixed_tiling_expr_for_non_sp
     assert diagnostics["y"]["resolved_by"] == "fixed_tiling_expr_arg"
 
 
+def test_parse_cv_params_preserves_block_size_n_for_inline_dot_rhs_expression():
+    from triton.backends.ascend.runtime.dsl_analysis.cv_param_parser import (
+        parse_cv_params,
+    )
+
+    func_ast = ast.parse(
+        """
+def matmul_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M,
+    N,
+    K: tl.constexpr,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    phy_grids,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr = 4,
+):
+    offs_am = (0 + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_bn = (0 + tl.arange(0, BLOCK_SIZE_N)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.int32)
+    for i in range(4):
+        for j in range(0, tl.cdiv(K // 4, BLOCK_SIZE_K)):
+            k = i * tl.cdiv(K // 4, BLOCK_SIZE_K) + j
+            a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0)
+            b_uint8 = tl.load(b_ptrs, mask=offs_k[:, None] < K, other=0)
+            mask = 3 << (2 * i)
+            b = (b_uint8 & mask) >> (2 * i)
+            tensor_full = tl.full((1,), 1, dtype=tl.int8)
+            accumulator += tl.dot(a, b.to(tl.int8) - tensor_full, out_dtype=tl.int32)
+"""
+    ).body[0]
+
+    parse_result = parse_cv_params(
+        func_ast,
+        parser_mode="mix",
+        arg_names=[
+            "a_ptr",
+            "b_ptr",
+            "c_ptr",
+            "M",
+            "N",
+            "K",
+            "stride_am",
+            "stride_ak",
+            "stride_bk",
+            "stride_bn",
+            "stride_cm",
+            "stride_cn",
+            "phy_grids",
+        ],
+        provided_args={
+            "M": 2,
+            "N": 3,
+            "K": 128,
+            "stride_am": 128,
+            "stride_ak": 1,
+            "stride_bk": 3,
+            "stride_bn": 1,
+            "stride_cm": 3,
+            "stride_cn": 1,
+            "phy_grids": 1,
+        },
+        explicit_tunable_params=["BLOCK_SIZE_M", "BLOCK_SIZE_N", "BLOCK_SIZE_K"],
+    )
+
+    tunable_names = {item.name for item in parse_result.tunable_params}
+
+    assert "BLOCK_SIZE_M" in tunable_names
+    assert "BLOCK_SIZE_N" in tunable_names
+    assert "BLOCK_SIZE_K" in tunable_names
+    assert parse_result.dot_sites
+    assert parse_result.dot_sites[0].n.tunable_param == "BLOCK_SIZE_N"
+
+
 @triton.autotune(
     configs=[],
     key=["n_elements"],


### PR DESCRIPTION
# `fix: recover cv dot rhs tuning param inference`

## Background

The CV autotune parameter parser relies on dot-site shape inference to recover tunable parameters such as `BLOCK_SIZE_M`, `BLOCK_SIZE_N`, and `BLOCK_SIZE_K`.

For `tl.dot(lhs, rhs)` sites, the parser needs to identify the underlying tensor name and its role on both sides of the dot expression. However, the previous implementation handled only relatively simple RHS expressions. When the RHS tensor was wrapped inside inline arithmetic or conditional expressions, the parser could fail to recover the original tensor role.

As a result, CV kernels using expressions such as:

```python
tl.dot(a, b.to(tl.int8) - tensor_full, out_dtype=tl.int32)
```

could lose the RHS role information, which then caused the `N` dimension tuning parameter inference to break. In practice, this could prevent `BLOCK_SIZE_N` from being preserved in the parsed tunable parameter set.

## Root Cause

The issue came from two related limitations in shape inference:

- Tensor name extraction did not fully support wrapped expressions such as `UnaryOp`, `BinOp`, and `IfExp`.
- Dot-site role resolution did not preserve the tensor role when the RHS expression mixed a real tensor operand with auxiliary scalar or helper expressions.

Because of that, inline RHS expressions could be treated as unresolved, even when the real tensor source was still unambiguous.

## What Changed

This change improves dot-site tensor resolution in `shape_inference.py`:

- Added `_merge_tensor_name_candidates()` to safely merge tensor-name candidates from composite expressions.
- Extended `_extract_tensor_name_from_expr()` to support:
  - `UnaryOp`
  - `BinOp`
  - `IfExp`
- Added `_extract_tensor_name_and_role()` in `_DotSiteCollector` so composite expressions can preserve tensor-role information instead of resolving names only.
- Updated dot-site resolution to select the operand with a valid tensor role when the other side is only an auxiliary expression.
- Kept transpose handling intact by applying role swapping after the base tensor expression is resolved.

With this change, inline RHS expressions such as `b.to(...) - tensor_full` can still resolve back to tensor `b`, allowing the parser to correctly recover the `N`-side tuning parameter.

## Behavior Change

After this fix, CV parameter parsing correctly preserves RHS-derived tuning parameters for inline dot expressions.

For example, in a pattern like:

```python
accumulator += tl.dot(a, b.to(tl.int8) - tensor_full, out_dtype=tl.int32)
```

the parser now continues to infer the RHS `N` dimension and keeps `BLOCK_SIZE_N` in the tunable parameter set.

## Main Files Changed

- `third_party/ascend/backend/runtime/dsl_analysis/shape_inference.py`
- `third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py`