### PR TITLE
feat(ssbuffer): add fallback for ssbuffer

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -4,6 +4,7 @@
 #include "ascend/include/DiscreteMaskAccessConversion/Passes.h"
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition.h"
 #include "ascend/include/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.h"
+#include "ascend/include/DynamicCVPipeline/Passes.h"
 #include "ascend/include/DynamicCVPipeline/RemoveAttributes.h"
 #include "ascend/include/TritonToStructured/Passes.h"
 #include "ascend/include/TritonToAnnotation/Passes.h"
@@ -96,6 +97,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   // mlir::registerTritonAMDGPUConvertToBufferOps();
 
   // DynamicCVPipeline passes
+  mlir::triton::registerAddDynamicCVPipelinePasses();
   mlir::triton::registerAddControlFlowConditionPasses();
   mlir::triton::registerAddMultiBufferOuterScopePasses();
   mlir::triton::registerRemoveSsbufAttrPasses();

--- a/third_party/ascend/ascend_ir.cc
+++ b/third_party/ascend/ascend_ir.cc
@@ -497,6 +497,18 @@ void init_ascend_ir(py::module &&m) {
     context.appendDialectRegistry(registry);
     context.loadAllAvailableDialects();
   });
+  m.def("get_int_attr",
+        [](OpState &op, std::string &name) -> py::object {
+          auto ret = op->getAttrOfType<IntegerAttr>(name);
+          if (!ret) {
+            return py::none();
+          }
+          return py::cast(ret.getInt());
+        });
+  m.def("remove_attr",
+        [](OpState &op, std::string &name) -> void {
+          op->removeAttr(name);
+        });
 
   py::class_<AscendNPUIROpBuilder, TritonOpBuilder>(
       m, "ascendnpu_ir_builder", py::module_local(), py::dynamic_attr())

--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -70,6 +70,35 @@ from triton.tools.get_ascend_devices import is_compile_on_910_95
 def min_dot_size(target: GPUTarget):
     return lambda lhsType, rhsType: (1, 1, 1)
 
+# Get result code saved in module {attr_name = rc}
+def _get_then_remove_rc(mod, attr_name: str) -> int:
+    get_int_attr = getattr(ascend.ir, "get_int_attr", None)
+    remove_attr = getattr(ascend.ir, "remove_attr", None)
+
+    if get_int_attr is None:
+        return -1
+    attr_value = get_int_attr(mod, attr_name)
+
+    if remove_attr:
+        remove_attr(mod, attr_name)
+    
+    if not isinstance(attr_value, int):
+        return -1
+
+    return attr_value
+
+
+def _adjust_metadata_by_module_result(mod, metadata, opt, **kwargs):
+    rc = _get_then_remove_rc(mod, "triton_ascend.dynamic_cv_pipeline.rc")
+    if rc != -1 and rc > 0:
+        # When the option dynamic_cv_pipeline is set to False,
+        # these options should also reverted.
+        metadata["enable_dynamic_cv_pipeline"] = False
+        metadata["enable_mixed_cv"] = kwargs["enable_mixed_cv"]
+        metadata["disable_auto_inject_block_sync"] = kwargs["disable_auto_inject_block_sync"]
+        if opt.debug:
+            print(f"SSBUFFER return code={rc}, will fallback to enable_dynamic_cv_pipeline=False")
+
 
 def make_ttir(mod, metadata, opt):
     if "hash" not in metadata:
@@ -112,6 +141,8 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
         enable_mask_fallback_conversion = metadata["enable_mask_fallback_conversion"]
         optimize_dynamic_offset = metadata["optimize_dynamic_offset"]
         auto_blockify_size = metadata["auto_blockify_size"]
+        enable_mixed_cv = metadata["enable_mixed_cv"]
+        disable_auto_inject_block_sync = metadata["disable_auto_inject_block_sync"]
         if not _is_auto_map_parallel_blocks_enabled():
             auto_blockify_size = 1
         pm = ir.pass_manager(mod.context)
@@ -165,6 +196,12 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
             compile_on_910_95
         )
         if metadata["enable_dynamic_cv_pipeline"]:
+            if metadata["set_workspace_multibuffer"] != None:
+                raise ValueError(
+                    "\"enable_dynamic_cv_pipeline\" cannot be used with \"set_workspace_multibuffer\"."
+                )
+            metadata["enable_mixed_cv"] = True
+            metadata["disable_auto_inject_block_sync"] = True
             ascend.passes.ttir.add_dynamic_cv_pipeline(pm, compile_on_910_95)
 
         _val = metadata.get("intra_cache_num")
@@ -180,6 +217,9 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
             ascend.passes.ttir.set_buffer_count(2, _val)
 
         pm.run(mod)
+        _adjust_metadata_by_module_result(mod, metadata, opt,
+                                          enable_mixed_cv=enable_mixed_cv,
+                                          disable_auto_inject_block_sync=disable_auto_inject_block_sync)
 
         if opt.debug:
             dump_manager = get_dump_manager(metadata["hash"])

--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -23,6 +23,7 @@
 #ifndef ADD_AUTO_SCHEDULING_COMMON_UTILS_H
 #define ADD_AUTO_SCHEDULING_COMMON_UTILS_H
 #include <string_view>
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Value.h"
 #include "llvm/ADT/StringRef.h"
@@ -35,6 +36,9 @@ inline constexpr llvm::StringLiteral kBlockId = "ssbuffer.block_id";
 inline constexpr llvm::StringLiteral kTransferId = "ssbuffer.transfer_id";
 inline constexpr llvm::StringLiteral kCubeFirst = "ssbuffer.cube_first";
 inline constexpr llvm::StringLiteral kVectorFirst = "ssbuffer.vector_first";
+inline constexpr const char *ERRCODE_ATTR = "triton_ascend.dynamic_cv_pipeline.rc";
+static constexpr const int ERRCODE_FAILED = 1;
+static constexpr const int ERRCODE_IGNORED = 2;
 
 enum CoreType {
     UNDETERMINED = 0,
@@ -59,6 +63,7 @@ inline constexpr CoreType fromStrCoreType(std::string_view s)
 CoreType getOpCoreType(Operation *op);
 std::optional<int64_t> getOpBlockId(Operation *op);
 llvm::LogicalResult verifyOpBlockId(Operation *op);
+void setFallbackAttr(ModuleOp module);
 
 inline bool isCubeOp(Operation *op)
 {

--- a/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h
+++ b/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h
@@ -110,6 +110,8 @@ private:
     // Step 4: Propagate VECTOR core type upstream
     int propagateVectorUpstream();
 
+    bool checkPureCubeOrVector();
+
     // Initialize the pass
     void initializePass(ModuleOp module);
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
@@ -22,8 +22,10 @@
 
 #include "llvm/Support/Debug.h"
 
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/PassManager.h"
 
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition.h"
 #include "ascend/include/DynamicCVPipeline/RemoveAttributes.h"
 #include "ascend/include/DynamicCVPipeline/AllocMultiCache.h"
@@ -52,15 +54,18 @@ AddDynamicCVPipelinePass::AddDynamicCVPipelinePass(
 void AddDynamicCVPipelinePass::runOnOperation()
 {
     auto moduleOp = getOperation();
+    OpBuilder builder(moduleOp.getContext());
     compileOn91095Flag = this->compileOn91095;
 
     LDBG("Enter pass");
+    moduleOp->removeAttr(CVPipeline::ERRCODE_ATTR);
 
     if (!compileOn91095Flag) {
         llvm::errs() << "Add-dynamic-cv-pipeline is only supported on 91095 now.\n";
         return;
     }
 
+    ModuleOp moduleBackup(moduleOp->clone());
     PassManager pm(&getContext(), moduleOp.getOperationName());
 
     pm.addPass(createPlanComputeBlockPass());
@@ -71,11 +76,22 @@ void AddDynamicCVPipelinePass::runOnOperation()
     pm.addPass(createAddControlFlowConditionPass());
     pm.addPass(createRemoveSsbufAttrPass());
 
-    if (failed(runPipeline(pm, getOperation()))) {
-        moduleOp->emitError() << "[" << DEBUG_TYPE << "] Pass failed!";
-        signalPassFailure();
+    if (failed(runPipeline(pm, moduleOp))) {
+        auto errCodeAttr = moduleOp->getAttrOfType<IntegerAttr>(CVPipeline::ERRCODE_ATTR);
+        if (!errCodeAttr) {
+            moduleOp->emitWarning() << "[" << DEBUG_TYPE << "] "
+                << "Pass failed; fallback to compilation without dynamic CV pipeline.";
+        }
+        
+        int errCode = errCodeAttr ? static_cast<int>(errCodeAttr.getInt()) : CVPipeline::ERRCODE_FAILED;
+        moduleOp->setAttrs(moduleBackup.getOperation()->getAttrs());
+        moduleOp.getBodyRegion().takeBody(moduleBackup.getBodyRegion());
+        moduleBackup->destroy();
+        moduleOp->setAttr(CVPipeline::ERRCODE_ATTR, builder.getI32IntegerAttr(errCode));
+        return;
     }
 
+    moduleBackup->destroy();
     LDBG("Process successfully");
 }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -3,6 +3,7 @@
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Builders.h"
 namespace mlir {
 namespace CVPipeline {
 
@@ -54,6 +55,12 @@ std::optional<int64_t> getOpBlockId(Operation *op)
     }
 
     return blockIdAttr.getInt();
+}
+
+void setFallbackAttr(ModuleOp module)
+{
+    OpBuilder builder(module.getContext());
+    module->setAttr(CVPipeline::ERRCODE_ATTR, builder.getI32IntegerAttr(CVPipeline::ERRCODE_IGNORED));
 }
 
 } // namespace CVPipeline

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock.cpp
@@ -60,8 +60,13 @@ void PlanComputeBlockPass::runOnOperation()
     pm.addPass(createReorderOpsByBlockIdPass());
 
     if (failed(runPipeline(pm, module))) {
-        module->emitError() << "[" << DEBUG_TYPE << "] Pass failed!";
+        auto errCodeAttr = module->getAttrOfType<IntegerAttr>(CVPipeline::ERRCODE_ATTR);
+        int errCode = errCodeAttr ? static_cast<int>(errCodeAttr.getInt()) : CVPipeline::ERRCODE_FAILED;
+        if (errCode != CVPipeline::ERRCODE_IGNORED) {
+            module->emitError() << "[" << DEBUG_TYPE << "] Pass failed!";
+        }
         signalPassFailure();
+        return;
     }
 
     LOG_DEBUG("Process successfully\n");

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -37,6 +37,7 @@
 #include "mlir/Support/LLVM.h"
 
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
 
@@ -694,6 +695,24 @@ int OpClassifierPass::propagateVectorUpstream()
     }
 
     return 0;
+}
+
+bool OpClassifierPass::checkPureCubeOrVector()
+{
+    bool hasCube = false;
+    bool hasVector = false;
+    for (auto &[op, type] : opCoreTypes) {
+        if (isInsideNestedLinalgRegion(op)) {
+            continue;
+        }
+        if (type & OP_CUBE_ONLY) {
+            hasCube = true;
+        }
+        if (type & OP_VECTOR_ONLY) {
+            hasVector = true;
+        }
+    }
+    return !hasCube || !hasVector;
 }
 
 // ============================================================================
@@ -1398,6 +1417,15 @@ void OpClassifierPass::runOnOperation()
 
     // Step 4: VECTOR upstream BFS
     if (propagateVectorUpstream() != 0) {
+        signalPassFailure();
+        return;
+    }
+
+    // Intermedia Check: pure cube or pure vector leads to skipping.
+    if (checkPureCubeOrVector()) {
+        LOG_DEBUG("Non-CV scenarios. "
+                  "The DynamicCVPipeline pass will be interrupted, and resumed to the original workflow.");
+        CVPipeline::setFallbackAttr(module);
         signalPassFailure();
         return;
     }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddDynamicCVPipeline/fallback_pure_cc_vv.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddDynamicCVPipeline/fallback_pure_cc_vv.mlir
@@ -1,0 +1,37 @@
+// RUN: triton-opt '--add_dynamic_cv_pipeline=compile-on-910-95=True' --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: module attributes {triton_ascend.dynamic_cv_pipeline.rc = 2 : i32}
+module {
+  // CHECK-LABEL: func.func @fallback_pure_vv(
+  // CHECK-NOT: ssbuffer.
+  // CHECK: arith.addf %arg0, %arg1 : tensor<16xf32>
+  // CHECK-NOT: ssbuffer.
+  // CHECK: arith.mulf {{%.*}}, %arg0 : tensor<16xf32>
+  // CHECK-NOT: ssbuffer.
+  // CHECK: return {{%.*}} : tensor<16xf32>
+  func.func @fallback_pure_vv(%arg0: tensor<16xf32>, %arg1: tensor<16xf32>) -> tensor<16xf32> {
+    %add = arith.addf %arg0, %arg1 : tensor<16xf32>
+    %mul = arith.mulf %add, %arg0 : tensor<16xf32>
+    return %mul : tensor<16xf32>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: module attributes {triton_ascend.dynamic_cv_pipeline.rc = 2 : i32}
+module {
+  // CHECK-LABEL: func.func @fallback_pure_cc(
+  // CHECK-NOT: ssbuffer.
+  // CHECK: linalg.matmul ins(%arg0, %arg1 : memref<16x16xf16>, memref<16x16xf16>) outs(%arg2 : memref<16x16xf32>)
+  // CHECK-NOT: ssbuffer.
+  // CHECK: return
+  func.func @fallback_pure_cc(
+      %arg0: memref<16x16xf16>,
+      %arg1: memref<16x16xf16>,
+      %arg2: memref<16x16xf32>) {
+    linalg.matmul
+      ins(%arg0, %arg1 : memref<16x16xf16>, memref<16x16xf16>)
+      outs(%arg2 : memref<16x16xf32>)
+    return
+  }
+}


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

A fallback mechanism has been added. Currently, the ssbuffer feature is automatically disabled—triggering a fallback—in the following scenarios:
1. Pure V-class operators
2. Pure C-class operators
3. Scenarios involving exceptions