### PR TITLE
feat: add blacklist for AutoBlockify when TRITON_ALL_BLOCKS_PARALLEL=true

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -47,6 +47,8 @@ from triton.backends.ascend.utils import (
     _is_ascend_sanitizer_enabled,
     _is_debug_line_info_disabled,
     _is_auto_map_parallel_blocks_enabled,
+    _get_auto_blockify_blacklist_reasons,
+    _warn_auto_blockify_disabled,
     downgrade_llir,
     force_disable_ffts,
     triton_enable_libdevice_simt,
@@ -127,6 +129,18 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
     # use triton_adapter to lower Triton-MLIR to linalg
     # Get Triton-MLIR as string
     ttir_code = str(mod)
+    auto_map_parallel_blocks_enabled = _is_auto_map_parallel_blocks_enabled()
+    blacklist_reasons = []
+    has_auto_blockify_blacklist_op = metadata.get("has_auto_blockify_blacklist_op")
+    if has_auto_blockify_blacklist_op is None and auto_map_parallel_blocks_enabled:
+        blacklist_reasons = _get_auto_blockify_blacklist_reasons(ttir_code)
+        has_auto_blockify_blacklist_op = bool(blacklist_reasons)
+    elif has_auto_blockify_blacklist_op is None:
+        has_auto_blockify_blacklist_op = False
+    metadata["has_auto_blockify_blacklist_op"] = has_auto_blockify_blacklist_op
+    if has_auto_blockify_blacklist_op and blacklist_reasons:
+        kernel_name = re.search(r"tt\.func\spublic\s+@(\w+)", ttir_code).group(1)
+        _warn_auto_blockify_disabled(kernel_name or "<unknown>", blacklist_reasons)
     with tempfile.TemporaryDirectory() as tmpdir:
         src_path = os.path.join(tmpdir, "kernel.ttir.mlir")
         dst_path = os.path.join(tmpdir, "kernel.ttadapter.mlir")
@@ -143,7 +157,7 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
         auto_blockify_size = metadata["auto_blockify_size"]
         enable_mixed_cv = metadata["enable_mixed_cv"]
         disable_auto_inject_block_sync = metadata["disable_auto_inject_block_sync"]
-        if not _is_auto_map_parallel_blocks_enabled():
+        if has_auto_blockify_blacklist_op or not auto_map_parallel_blocks_enabled:
             auto_blockify_size = 1
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
@@ -311,6 +325,13 @@ def _parse_ttir_metadata(ttir: str, metadata: dict):
     metadata["mix_mode"] = "aiv"
     metadata["kernel_name"] = re.search(KERNEL_NAME_REGEX, ttir).group(1)
     metadata["name"] = metadata["kernel_name"]
+    auto_map_parallel_blocks_enabled = _is_auto_map_parallel_blocks_enabled()
+    has_auto_blockify_blacklist_op = metadata.get("has_auto_blockify_blacklist_op")
+    if has_auto_blockify_blacklist_op is None and auto_map_parallel_blocks_enabled:
+        has_auto_blockify_blacklist_op = bool(_get_auto_blockify_blacklist_reasons(ttir))
+    elif has_auto_blockify_blacklist_op is None:
+        has_auto_blockify_blacklist_op = False
+    metadata["has_auto_blockify_blacklist_op"] = has_auto_blockify_blacklist_op
     # Parse all tensor kinds from arguments
     metadata["tensor_kinds"] = [int(kind) for _, kind in re.findall(TENSOR_KIND_REGEX, ttir)]
     return metadata
@@ -557,7 +578,7 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
                 _compile_option_list += \
                     [f"--link-aicore-bitcode={bitcode}"]
 
-        if _is_auto_map_parallel_blocks_enabled():
+        if _is_auto_map_parallel_blocks_enabled() and not metadata.get("has_auto_blockify_blacklist_op", False):
             _compile_option_list += ["--enable-auto-blockify-loop"]
         npu_compiler_path, env = _get_npucompiler_path()
         if npu_compiler_path.endswith("bishengir-compile"):
@@ -794,7 +815,7 @@ def linalg_to_bin_enable_npu_compile_A2_A3(linalg: str, metadata, opt):
             _compile_option_list += \
                 [f"--disable-size-align-for-cast={disable_size_align_for_cast}"]
 
-        if _is_auto_map_parallel_blocks_enabled():
+        if _is_auto_map_parallel_blocks_enabled() and not metadata.get("has_auto_blockify_blacklist_op", False):
             _compile_option_list += ["--enable-auto-blockify-loop"]
         npu_compiler_path, env = _get_npucompiler_path()
         if npu_compiler_path.endswith("bishengir-compile"):
@@ -931,6 +952,7 @@ class NPUOptions:
     add_auto_scheduling: bool = False
     enable_dynamic_cv_pipeline: bool = False
     hfusion_enable_multiple_consumer_fusion: bool = False
+    has_auto_blockify_blacklist_op: Optional[bool] = None
 
     stream: int = None
     parallel_mode: str = "simd"

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -512,7 +512,14 @@ def generate_npu_wrapper_src(constants, signature, metadata):
         "TRITON_ENABLE_TASKQUEUE", 'true').lower() in ('true', '1')
     enable_grid_warn_print = os.getenv(
         "TRITON_GRID_WARN_PRINT", 'false').lower() in ('true', '1')
-    enable_auto_map_parallel_blocks = _is_auto_map_parallel_blocks_enabled()
+    has_auto_blockify_blacklist_op = getattr(
+      metadata,
+      "has_auto_blockify_blacklist_op",
+      False,
+    )
+    enable_auto_map_parallel_blocks = (
+      _is_auto_map_parallel_blocks_enabled() and not has_auto_blockify_blacklist_op
+    )
     npu_utils = NPUUtils()
     num_physical_blocks = npu_utils.get_aivector_core_num(
     ) if mix_mode == "aiv" else npu_utils.get_aicore_num()

--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -34,6 +34,19 @@ from triton.backends.ascend.backend_register import backend_strategy_registry
 
 import pybind11
 
+AUTO_BLOCKIFY_BLACKLIST_RULES = (
+    (re.compile(r"\btt\.atomic_(?:rmw|cas)\b"), "atomic operations"),
+    (re.compile(r"\btt\.elementwise_inline_asm\b"), "inline elementwise assembly"),
+    (
+        re.compile(r"\btt\.load\b[^\n]*\bisVolatile\s*=\s*true\b"),
+        "loads with volatile",
+    ),
+    (
+        re.compile(r"\btt\.(?:load|store)\b[^\n]*\bcacheModifier\s*="),
+        "loads or stores with cache modifiers",
+    ),
+)
+
 backend_policy = None
 
 
@@ -261,6 +274,21 @@ def _is_debug_line_info_disabled() -> bool:
 
 def _is_auto_map_parallel_blocks_enabled() -> bool:
     return os.getenv("TRITON_ALL_BLOCKS_PARALLEL", "false").lower() in ("true", "1")
+
+
+def _get_auto_blockify_blacklist_reasons(ir_text: str):
+    return [description for pattern, description in AUTO_BLOCKIFY_BLACKLIST_RULES if pattern.search(ir_text)]
+
+
+def _warn_auto_blockify_disabled(kernel_name: str, blacklist_reasons) -> None:
+    if not blacklist_reasons:
+        return
+    reasons = ", ".join(blacklist_reasons)
+    print(
+        f"[WARNING] AutoBlockify disabled for kernel '{kernel_name}'. "
+        f"Unsafe ops: {reasons}. Enabling may cause correctness issues. "
+        "To force enable: set has_auto_blockify_blacklist_op=False."
+    )
 
 
 def _enable_unpublished_feature() -> bool:


### PR DESCRIPTION
## Summary
This PR optimizes the AutoBlockify control logic by setting the global switch `TRITON_ALL_BLOCKS_PARALLEL` to `true` by default (previously `false`) and introducing a **blacklist mechanism to disable AutoBlockify automatically** when unsafe operations are detected, enhancing both safety and default parallel processing capability.

## Key Changes
### 1. Control Parameters & Blacklist Configuration
Simplified AutoBlockify retains three core control parameters, with **a new compile variable(has_auto_blockify_blacklist_op)** added for blacklist management:

| Item                             | Location                         | Default Value  | Function                                                                                                                                                         |
| -------------------------------- | -------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `TRITON_ALL_BLOCKS_PARALLEL`     | Process Environment Variable     | `false` / Unset | Global switch for AutoBlockify parallel processing **(unchanged)**.                                                               |
| `auto_blockify_size`             | Backend Option / Metadata        | `1`            | Expansion factor for the AutoBlockify pass on the TTIR side **(unchanged)**.                                                                                     |
| `has_auto_blockify_blacklist_op` | Backend Option / Kernel Metadata | `None`         | Auto-detected from TTIR only when `TRITON_ALL_BLOCKS_PARALLEL=true` and the value is `None`; user-specified `True/False` takes precedence, written to metadata for compile/runtime consistency. **(New compile variable)** |
#### 1.1 Blacklisted Operation Categories
AutoBlockify will be disabled automatically if any of the following unsafe ops are detected:
1. `tt.atomic_rmw`, `tt.atomic_cas`
2. `tt.elementwise_inline_asm`
3. `tt.load` with `isVolatile = true`
4. `tt.load` / `tt.store` with `cacheModifier = ...`
#### 1.2 Priority Rules for `has_auto_blockify_blacklist_op`
1. User explicit `False`: Skip blacklist processing (overrides auto-detection).
2. User explicit `True`: Enforce blacklist processing.
3. User unspecified (`None`): Auto-detect blacklisted ops from TTIR only when `TRITON_ALL_BLOCKS_PARALLEL=true`.

### 2. Logic Workflow Updates
#### 2.1 Original Logic
The original logic relied solely on `TRITON_ALL_BLOCKS_PARALLEL`(Default: False) to control AutoBlockify, with no blacklist protection. The workflow is as follows:
```mermaid
flowchart TD
    A[Start compiling kernel] --> B{Is TRITON_ALL_BLOCKS_PARALLEL enabled?}
    B -- No --> C[Force auto_blockify_size to 1]
    B -- Yes --> D[Keep metadata.auto_blockify_size]
    C --> E[Do not append --enable-auto-blockify-loop]
    D --> F[Append --enable-auto-blockify-loop]
    E --> G[Generate binary]
    F --> G
    G --> H[Enter runtime launcher]
    H --> I{Is TRITON_ALL_BLOCKS_PARALLEL enabled?}
    I -- No --> J[Do not cap blockNum by physical cores]
    I -- Yes --> K[Cap blockNum by physical cores]
```
#### 2.2 Update Logic
Added conditional blacklist detection and warning mechanism, unified compile/runtime judgment logic while avoiding unnecessary TTIR scans when AutoBlockify is globally disabled. Color coding: Orange = Modified Logic, Blue = Unchanged Original Logic:
```mermaid
flowchart TD
   %% Color legend: Green=New logic, Orange=Modified logic, Blue=Original unchanged logic
  A[Start compiling kernel]:::blue --> B{Is TRITON_ALL_BLOCKS_PARALLEL enabled?}:::orange
  B -- No --> H[Do not append --enable-auto-blockify-loop]:::blue
  B -- Yes --> D[Resolve has_auto_blockify_blacklist_op:<br/>use explicit metadata if provided;<br/>otherwise scan TTIR]:::orange
  D --> E{has_auto_blockify_blacklist_op == True?}:::orange
  E -- Yes --> F[Print WARNING Log AutoBlockify disabled...]:::orange
  E -- No --> I[Keep metadata.auto_blockify_size]:::blue
  F --> H
  I --> J[Append --enable-auto-blockify-loop]:::blue
  H --> K[Generate binary]:::blue
  J --> K
  K --> L[Enter runtime launcher]:::blue
  L --> M{Is TRITON_ALL_BLOCKS_PARALLEL enabled?<br/>AND not has_auto_blockify_blacklist_op?}:::orange
  M -- No --> N[Do not cap blockNum by physical cores]:::blue
  M -- Yes --> O[Cap blockNum by physical cores]:::blue

   %% Color definitions
   classDef green fill:#d4edda,stroke:#28a745,color:#000
   classDef orange fill:#fff3cd,stroke:#fd7e14,color:#000
   classDef blue fill:#e1f5fe,stroke:#17a2b8,color:#000
```
#### 2.3 Logic Comparison

| Comparison Item          | Original Logic                                   | Updated Logic                                                                           |
| ------------------------ | ------------------------------------------------ | --------------------------------------------------------------------------------------- |
| Blacklist Protection     | None                                             | When `TRITON_ALL_BLOCKS_PARALLEL=true`, TTIR blacklist scan adds one extra guard; blacklist hit falls back to the original `false` path |
| Warning                  | None                                             | Prints English warning when auto-detected blacklist triggers AutoBlockify disablement   |
| Compile/Runtime Judgment | Only checks the environment variable             | Checks "environment variable + blacklist `has_auto_blockify_blacklist_op`"              |

### 3. Warning Behavior
When a kernel hits the blacklist (auto-detected and `has_auto_blockify_blacklist_op=True`), the following English warning is printed to inform users of potential safety risks and provide guidance for force-enabling:
```text
[WARNING] AutoBlockify disabled for kernel 'xxxx'. Unsafe ops: loads with volatile, loads or stores with cache modifiers. Enabling may cause correctness issues. To force enable: set has_auto_blockify_blacklist_op=False.
```

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.
- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)