### PR TITLE
bugfix: Add missing `backend_name` and `launch_cooperative_grid` fields to NPUOptions

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -871,6 +871,8 @@ class NPUOptions:
     enable_persistent: bool = False
     optimize_epilogue: bool = False
     enable_fp_fusion: bool = True
+    launch_cooperative_grid: bool = False
+    backend_name: str = 'cann'
     allow_fp8e4nv: bool = False
     auto_tile_and_bind_subblock: bool = True
     supported_fp8_dtypes: Tuple[str] = ("fp8e5", "fp8e4b15", "fp8e4nv", "fp8e4b8", "fp8e5b16")


### PR DESCRIPTION
## Summary

`NPUOptions` in triton-ascend is missing two standard fields that exist in Triton upstream `CompileOptions`. They address two separate issues:

1. **`backend_name`** — missing backend identifier, causing tools like tritonparse to fail detecting the Ascend backend.
2. **`launch_cooperative_grid`** — missing attribute, causing `AttributeError` crash when any tool registers Triton hooks on the Ascend backend.

## Change 1: `backend_name: str = "cann"` — Backend Identification

`backend_name` is a long-standing standard field in Triton upstream `CompileOptions`. All official backends define it:

| Backend | Value | Location |
|---------|-------|----------|
| NVIDIA | `"cuda"` | `backends/nvidia/compiler.py` |
| AMD | `"hip"` | `backends/amd/compiler.py` |
| Ascend | **missing** | — |

This field is not triton-ascend-specific — it has been part of the upstream interface for a long time. Tools like tritonparse rely on it to identify which backend a kernel was compiled for. Without it, the Ascend backend cannot be correctly identified.

## Change 2: `launch_cooperative_grid: bool = False` — Fix Hook Crash

### The Problem

<img width="1373" height="454" alt="image" src="https://github.com/user-attachments/assets/f9f235b1-a5ac-4111-af4f-24ffa055e893" />

Triton upstream (since v3.4) provides a hook mechanism (`jit_cache_hook`, `jit_pre_compile_hook`, `jit_post_compile_hook`) that allows external tools to inject callbacks into the JIT compilation pipeline. The hook entry point `_call_hook` in `triton/runtime/jit.py:629-635` unconditionally accesses `options.launch_cooperative_grid` to construct a kernel repr string:

```python
def _call_hook(self, hook, key, signature, device, constants, options, configs, is_warmup):
    if not hook:
        return None  # Safe exit when no hook is registered

    # This line is reached when ANY hook is registered
    repr = f"... launch_cooperative_grid={options.launch_cooperative_grid}]({arg_reprs})"
    ...
```

Since `NPUOptions` does not define `launch_cooperative_grid`, any tool that registers a Triton hook on the Ascend backend will crash:

```
AttributeError: 'NPUOptions' object has no attribute 'launch_cooperative_grid'
```

This affects **any** tool using Triton's hook mechanism on Ascend, not just tritonparse.

### The Fix

Add `launch_cooperative_grid: bool = False` to `NPUOptions`, matching the upstream default.

This field controls whether a kernel is launched in **Cooperative Grid** mode (cross-block synchronization). On NVIDIA it maps to `CU_LAUNCH_ATTRIBUTE_COOPERATIVE`, on AMD it maps to HIP cooperative group launch. On Ascend, this field has no actual functionality — Ascend uses `enable_sync_block_lock` for cross-block coordination. The value is purely for upstream interface compatibility.

| Backend | Value | Actual Functionality |
|---------|-------|---------------------|
| NVIDIA | `False` | Maps to `CU_LAUNCH_ATTRIBUTE_COOPERATIVE` |
| AMD | `False` | Maps to HIP cooperative group launch |
| Ascend | **missing** → `False` | N/A (uses `enable_sync_block_lock` instead) |

### Flow Diagram

```mermaid
flowchart TD
    A["JIT compilation triggered (_do_compile)"] --> B["Call _call_hook(hook, ...)"]
    B --> C{"Is hook registered?"}
    C -- "No (None)" --> D["Return immediately, no issue ✅"]
    C -- "Yes" --> E["Build kernel repr string<br/>(accesses options.launch_cooperative_grid)"]
    E --> F{"Is launch_cooperative_grid<br/>defined in NPUOptions?"}
    F -- "Yes" --> G["Normal execution ✅"]
    F -- "No" --> H["AttributeError crash ❌"]

    style D fill:#4a4,stroke:#282,color:#fff
    style G fill:#4a4,stroke:#282,color:#fff
    style H fill:#a44,stroke:#822,color:#fff
```

## Impact

- No functional impact on existing workloads. 
- `launch_cooperative_grid` has no actual functionality on Ascend — it is purely for interface compatibility.
- `backend_name` is a read-only identifier that does not affect compilation or execution behavior.

## Testing

Verified with tritonparse hook registration on Ascend NPU — backend is correctly identified and no `AttributeError` after adding both fields.
<img width="1341" height="597" alt="image" src="https://github.com/user-attachments/assets/7df9018c-da27-45c6-a154-522329e7179f" />

