### PR TITLE
feat(TritonToLinalg): add device print offset rewrite

### DIFF
--- a/third_party/ascend/include/TritonToLinalg/DevicePrintOffsetRewrite.h
+++ b/third_party/ascend/include/TritonToLinalg/DevicePrintOffsetRewrite.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ASCEND_TRITONTOLINALG_DEVICEPRINTOFFSETREWRITE_H
+#define TRITON_ASCEND_TRITONTOLINALG_DEVICEPRINTOFFSETREWRITE_H
+
+#include "mlir/IR/BuiltinOps.h"
+
+namespace mlir {
+namespace triton {
+
+void rewriteDevicePrintOffsets(ModuleOp moduleOp);
+
+}  // namespace triton
+}  // namespace mlir
+
+#endif  // TRITON_ASCEND_TRITONTOLINALG_DEVICEPRINTOFFSETREWRITE_H

--- a/third_party/ascend/lib/TritonToLinalg/CMakeLists.txt
+++ b/third_party/ascend/lib/TritonToLinalg/CMakeLists.txt
@@ -11,6 +11,7 @@ add_triton_library(TritonToLinalg
         ImplicitPermute.cpp
         DescriptorConverter
         MarkTensorKindPass.cpp
+        DevicePrintOffsetRewrite.cpp
 
   DEPENDS
   TritonToLinalgConversionPassIncGen

--- a/third_party/ascend/lib/TritonToLinalg/DevicePrintOffsetRewrite.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/DevicePrintOffsetRewrite.cpp
@@ -1,0 +1,529 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/TritonToLinalg/DevicePrintOffsetRewrite.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/OpDefinition.h"
+
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <functional>
+
+namespace mlir {
+namespace triton {
+namespace {
+
+static bool hasOnlyPrintUsers(Value v) {
+  if (v.use_empty()) return false;
+  for (Operation *u : v.getUsers()) {
+    auto callOp = dyn_cast<func::CallOp>(u);
+    if (!callOp) return false;
+    if (!callOp.getCallee().starts_with("triton_print")) return false;
+  }
+  return true;
+}
+
+static Value materializeIndex(OpBuilder &bd, Location loc, OpFoldResult ofr) {
+  if (auto attr = ofr.dyn_cast<Attribute>()) {
+    int64_t v = cast<IntegerAttr>(attr).getInt();
+    return bd.create<arith::ConstantIndexOp>(loc, v);
+  }
+  auto val = ofr.get<Value>();
+  Type ty = val.getType();
+  if (ty.isIndex()) return val;
+  if (isa<IntegerType>(ty))
+    return bd.create<arith::IndexCastOp>(loc, bd.getIndexType(), val);
+  return nullptr;
+}
+
+static bool isStaticEqual(OpFoldResult ofr, int64_t target) {
+  if (auto attr = ofr.dyn_cast<Attribute>())
+    return cast<IntegerAttr>(attr).getInt() == target;
+  return false;
+}
+
+class ScalarChainWalker {
+public:
+  ScalarChainWalker(OpBuilder &bd, Location loc) : bd(bd), loc(loc) {}
+
+  Value emit(Value v, ArrayRef<Value> indices) {
+    Operation *def = v.getDefiningOp();
+    if (!def) return nullptr;
+
+    if (auto cstOp = dyn_cast<arith::ConstantOp>(def))
+      return scalarFromConstant(cstOp);
+    if (auto fillOp = dyn_cast<linalg::FillOp>(def))
+      return scalarFromFill(fillOp);
+    if (auto generic = dyn_cast<linalg::GenericOp>(def))
+      return scalarFromMakeRange(generic, indices);
+
+    if (auto bc = dyn_cast<linalg::BroadcastOp>(def))
+      return emitBroadcast(bc, indices);
+    if (auto exp = dyn_cast<tensor::ExpandShapeOp>(def))
+      return emitExpandShape(exp, indices);
+    if (auto col = dyn_cast<tensor::CollapseShapeOp>(def))
+      return emitCollapseShape(col, indices);
+
+    if (def->getNumOperands() != 2) return nullptr;
+    Value lhs = emit(def->getOperand(0), indices);
+    Value rhs = emit(def->getOperand(1), indices);
+    if (!lhs || !rhs) return nullptr;
+    return emitBinaryArith(def, lhs, rhs);
+  }
+
+private:
+  Value scalarFromConstant(arith::ConstantOp op) {
+    auto i32Ty = bd.getI32Type();
+    if (auto dense = dyn_cast<DenseIntElementsAttr>(op.getValue()))
+      if (dense.isSplat())
+        return bd.create<arith::ConstantIntOp>(
+            loc, dense.getSplatValue<APInt>().getSExtValue(), i32Ty);
+    if (auto intAttr = dyn_cast<IntegerAttr>(op.getValue()))
+      return bd.create<arith::ConstantIntOp>(loc, intAttr.getInt(), i32Ty);
+    return nullptr;
+  }
+
+  Value scalarFromFill(linalg::FillOp op) {
+    if (op.getInputs().empty()) return nullptr;
+    Value sc = op.getInputs()[0];
+    auto i32Ty = bd.getI32Type();
+    auto scTy = sc.getType();
+
+    if (auto cstOp = sc.getDefiningOp<arith::ConstantOp>()) {
+      if (auto intAttr = dyn_cast<IntegerAttr>(cstOp.getValue()))
+        return bd.create<arith::ConstantIntOp>(loc, intAttr.getInt(), i32Ty);
+      return nullptr;
+    }
+    if (scTy.isInteger(32)) return sc;
+    if (scTy.isIndex())
+      return bd.create<arith::IndexCastOp>(loc, i32Ty, sc);
+    if (auto intTy = dyn_cast<IntegerType>(scTy)) {
+      if (intTy.getWidth() < 32)
+        return bd.create<arith::ExtSIOp>(loc, i32Ty, sc);
+      if (intTy.getWidth() > 32)
+        return bd.create<arith::TruncIOp>(loc, i32Ty, sc);
+    }
+    return nullptr;
+  }
+
+  Value scalarFromMakeRange(linalg::GenericOp op, ArrayRef<Value> indices) {
+    auto i32Ty = bd.getI32Type();
+    if (!op->hasAttr("tt.from_make_range")) return nullptr;
+    if (indices.size() != 1) return nullptr;
+    int64_t off = 0;
+    if (auto a = op->getAttrOfType<IntegerAttr>("tt.make_range_offset"))
+      off = a.getInt();
+    Value v32 = bd.create<arith::IndexCastOp>(loc, i32Ty, indices[0]);
+    if (off != 0) {
+      Value oc = bd.create<arith::ConstantIntOp>(loc, off, i32Ty);
+      v32 = bd.create<arith::AddIOp>(loc, v32, oc);
+    }
+    return v32;
+  }
+
+  Value emitBroadcast(linalg::BroadcastOp op, ArrayRef<Value> indices) {
+    auto bcDims = op.getDimensions();
+    llvm::DenseSet<int64_t> dropSet(bcDims.begin(), bcDims.end());
+    SmallVector<Value> inputIdx;
+    for (size_t k = 0; k < indices.size(); ++k)
+      if (!dropSet.count(k)) inputIdx.push_back(indices[k]);
+    return emit(op.getInput(), inputIdx);
+  }
+
+  Value emitExpandShape(tensor::ExpandShapeOp op, ArrayRef<Value> indices) {
+    auto resTy = cast<RankedTensorType>(op.getResult().getType());
+    SmallVector<Value> inputIdx;
+    for (auto group : op.getReassociationIndices()) {
+      Value combined;
+      for (size_t i = 0; i < group.size(); ++i) {
+        int64_t d = group[i];
+        int64_t weight = 1;
+        for (size_t j = i + 1; j < group.size(); ++j)
+          weight *= resTy.getDimSize(group[j]);
+        Value term = indices[d];
+        if (weight != 1) {
+          Value w = bd.create<arith::ConstantIndexOp>(loc, weight);
+          term = bd.create<arith::MulIOp>(loc, term, w);
+        }
+        combined = !combined ? term
+                             : bd.create<arith::AddIOp>(loc, combined, term);
+      }
+      if (!combined) combined = bd.create<arith::ConstantIndexOp>(loc, 0);
+      inputIdx.push_back(combined);
+    }
+    return emit(op.getSrc(), inputIdx);
+  }
+
+  Value emitCollapseShape(tensor::CollapseShapeOp op, ArrayRef<Value> indices) {
+    auto inTy = cast<RankedTensorType>(op.getSrc().getType());
+    SmallVector<Value> inputIdx(inTy.getRank());
+    Value c0 = bd.create<arith::ConstantIndexOp>(loc, 0);
+
+    auto reassoc = op.getReassociationIndices();
+    for (size_t outDim = 0; outDim < indices.size(); ++outDim) {
+      auto &group = reassoc[outDim];
+      Value out = indices[outDim];
+
+      int64_t leftmostNonOne = -1;
+      for (size_t i = 0; i < group.size(); ++i)
+        if (inTy.getDimSize(group[i]) != 1) { leftmostNonOne = (int64_t)i; break; }
+
+      for (size_t i = 0; i < group.size(); ++i) {
+        int64_t d = group[i];
+        int64_t size = inTy.getDimSize(d);
+        if (size == 1) { inputIdx[d] = c0; continue; }
+        int64_t weight = 1;
+        for (size_t j = i + 1; j < group.size(); ++j)
+          weight *= inTy.getDimSize(group[j]);
+        Value v = out;
+        if (weight != 1) {
+          Value w = bd.create<arith::ConstantIndexOp>(loc, weight);
+          v = bd.create<arith::DivUIOp>(loc, v, w);
+        }
+        if ((int64_t)i != leftmostNonOne) {
+          Value s = bd.create<arith::ConstantIndexOp>(loc, size);
+          v = bd.create<arith::RemUIOp>(loc, v, s);
+        }
+        inputIdx[d] = v;
+      }
+    }
+    return emit(op.getSrc(), inputIdx);
+  }
+
+  Value emitBinaryArith(Operation *def, Value lhs, Value rhs) {
+    if (isa<arith::MulIOp>(def))  return bd.create<arith::MulIOp>(loc, lhs, rhs);
+    if (isa<arith::AddIOp>(def))  return bd.create<arith::AddIOp>(loc, lhs, rhs);
+    if (isa<arith::SubIOp>(def))  return bd.create<arith::SubIOp>(loc, lhs, rhs);
+    if (isa<arith::RemSIOp>(def)) return bd.create<arith::RemSIOp>(loc, lhs, rhs);
+    if (isa<arith::DivSIOp>(def)) return bd.create<arith::DivSIOp>(loc, lhs, rhs);
+    if (isa<arith::RemUIOp>(def)) return bd.create<arith::RemUIOp>(loc, lhs, rhs);
+    if (isa<arith::DivUIOp>(def)) return bd.create<arith::DivUIOp>(loc, lhs, rhs);
+    return nullptr;
+  }
+
+  OpBuilder &bd;
+  Location loc;
+};
+
+static void emitLoopsAndPrint(
+    OpBuilder &builder, Location loc,
+    func::FuncOp scalarPrintFn,
+    ArrayRef<int64_t> shape,
+    llvm::function_ref<Value(OpBuilder &, Location, ArrayRef<Value>)> scalarGen) {
+  auto i32Ty = builder.getI32Type();
+  Value c0 = builder.create<arith::ConstantIndexOp>(loc, 0);
+  Value c1 = builder.create<arith::ConstantIndexOp>(loc, 1);
+
+  SmallVector<Value> ivs(shape.size(), c0);
+  OpBuilder bd = builder;
+  for (size_t k = 0; k < shape.size(); ++k) {
+    if (shape[k] <= 1) continue;
+    Value upper = bd.create<arith::ConstantIndexOp>(loc, shape[k]);
+    auto forOp = bd.create<scf::ForOp>(loc, c0, upper, c1);
+    ivs[k] = forOp.getInductionVar();
+    bd.setInsertionPoint(forOp.getBody()->getTerminator());
+  }
+
+  Value scalar = scalarGen(bd, loc, ivs);
+  if (!scalar) return;
+  if (scalar.getType().isIndex())
+    scalar = bd.create<arith::IndexCastOp>(loc, i32Ty, scalar);
+  else if (!scalar.getType().isInteger(32))
+    return;
+  bd.create<func::CallOp>(loc, scalarPrintFn, ValueRange{scalar});
+}
+
+enum class ChainKind {
+  Unsupported,
+  Linear,
+  Linearized,
+};
+
+struct OffsetChainInfo {
+  ChainKind kind = ChainKind::Unsupported;
+  StringRef rejectReason;
+  SmallVector<int64_t> shape;
+  Value chainRoot;
+  SmallVector<OpFoldResult> strides;
+  OpFoldResult baseOffset;
+};
+
+static void classifyChain(Value root, bool &canWalk, bool &hasDivMod) {
+  canWalk = true;
+  hasDivMod = false;
+
+  llvm::DenseSet<Operation *> visited;
+  std::function<void(Value)> walk = [&](Value v) {
+    if (!canWalk) return;
+    auto ty = dyn_cast<RankedTensorType>(v.getType());
+    if (!ty) return;
+    if (!ty.hasStaticShape()) { canWalk = false; return; }
+
+    Operation *def = v.getDefiningOp();
+    if (!def) { canWalk = false; return; }
+    if (!visited.insert(def).second) return;
+
+    if (auto fillOp = dyn_cast<linalg::FillOp>(def)) {
+      if (fillOp.getInputs().empty() ||
+          !fillOp.getInputs()[0].getType().isIntOrIndex())
+        canWalk = false;
+      return;
+    }
+    if (isa<arith::ConstantOp, tensor::EmptyOp>(def)) return;
+    if (auto g = dyn_cast<linalg::GenericOp>(def)) {
+      if (!g->hasAttr("tt.from_make_range")) canWalk = false;
+      return;
+    }
+    if (auto bc = dyn_cast<linalg::BroadcastOp>(def)) {
+      walk(bc.getInput());
+      return;
+    }
+    if (auto exp = dyn_cast<tensor::ExpandShapeOp>(def)) {
+      auto resTy = cast<RankedTensorType>(exp.getResult().getType());
+      for (auto group : exp.getReassociationIndices())
+        for (int64_t d : group)
+          if (ShapedType::isDynamic(resTy.getDimSize(d))) {
+            canWalk = false; return;
+          }
+      walk(exp.getSrc());
+      return;
+    }
+    if (auto col = dyn_cast<tensor::CollapseShapeOp>(def)) {
+      auto inTy = cast<RankedTensorType>(col.getSrc().getType());
+      for (auto group : col.getReassociationIndices())
+        for (int64_t d : group)
+          if (ShapedType::isDynamic(inTy.getDimSize(d))) {
+            canWalk = false; return;
+          }
+      walk(col.getSrc());
+      return;
+    }
+    if (isa<arith::RemSIOp, arith::DivSIOp,
+            arith::RemUIOp, arith::DivUIOp>(def)) {
+      hasDivMod = true;
+      for (Value operand : def->getOperands()) walk(operand);
+      return;
+    }
+    if (isa<arith::MulIOp, arith::AddIOp, arith::SubIOp>(def)) {
+      for (Value operand : def->getOperands()) walk(operand);
+      return;
+    }
+    canWalk = false;
+  };
+
+  walk(root);
+}
+
+static memref::ReinterpretCastOp findMatchingCast(
+    func::FuncOp funcOp, ArrayRef<int64_t> targetShape) {
+  memref::ReinterpretCastOp best;
+  unsigned bestScore = 0;
+  funcOp.walk([&](memref::ReinterpretCastOp c) {
+    auto resTy = dyn_cast<MemRefType>(c.getResult().getType());
+    if (!resTy) return;
+    if (resTy.getShape() != targetShape) return;
+    unsigned score = 0;
+    if (auto blockArg = dyn_cast<BlockArgument>(c.getSource())) {
+      unsigned idx = blockArg.getArgNumber();
+      if (auto argDict = funcOp.getArgAttrDict(idx))
+        if (argDict.contains("tt.tensor_kind")) score = 1;
+    }
+    if (score >= bestScore) {
+      bestScore = score;
+      best = c;
+    }
+  });
+  return best;
+}
+
+static OffsetChainInfo analyzeChain(Value arg,
+                                     func::FuncOp funcOp,
+                                     Operation *anchorOp,
+                                     DominanceInfo &domInfo) {
+  OffsetChainInfo info;
+
+  auto argTy = dyn_cast<RankedTensorType>(arg.getType());
+  if (!argTy) {
+    info.rejectReason = "arg not RankedTensorType";
+    return info;
+  }
+  if (!argTy.hasStaticShape()) {
+    info.rejectReason = "arg has dynamic shape";
+    return info;
+  }
+  if (!hasOnlyPrintUsers(arg)) {
+    info.rejectReason = "arg has non-print users";
+    return info;
+  }
+
+  info.shape.assign(argTy.getShape().begin(), argTy.getShape().end());
+  info.chainRoot = arg;
+
+  bool canWalk = false;
+  bool hasDivMod = false;
+  classifyChain(arg, canWalk, hasDivMod);
+  if (!canWalk) {
+    info.rejectReason = "chain contains unsupported op";
+    return info;
+  }
+
+  if (argTy.getRank() > 1 && !hasDivMod) {
+    auto castOp = findMatchingCast(funcOp, argTy.getShape());
+    if (castOp) {
+      SmallVector<OpFoldResult> mixedStrides = castOp.getMixedStrides();
+      SmallVector<OpFoldResult> mixedOffsets = castOp.getMixedOffsets();
+      if (mixedOffsets.size() == 1 &&
+          (int64_t)mixedStrides.size() == argTy.getRank()) {
+        auto domOk = [&](OpFoldResult ofr) -> bool {
+          if (auto val = ofr.dyn_cast<Value>())
+            return domInfo.dominates(val, anchorOp);
+          return true;
+        };
+        bool domAllOk = domOk(mixedOffsets[0]);
+        if (domAllOk)
+          for (auto s : mixedStrides)
+            if (!domOk(s)) { domAllOk = false; break; }
+        if (domAllOk) {
+          info.kind = ChainKind::Linear;
+          info.strides = std::move(mixedStrides);
+          info.baseOffset = mixedOffsets[0];
+          return info;
+        }
+      }
+    }
+  }
+
+  info.kind = ChainKind::Linearized;
+  return info;
+}
+
+struct RewriteCandidate {
+  func::CallOp callOp;
+  OffsetChainInfo info;
+};
+
+static void rewriteCandidate(RewriteCandidate &cand, ModuleOp moduleOp) {
+  auto i32Ty = IntegerType::get(moduleOp.getContext(), 32);
+  auto oldFn = dyn_cast_or_null<func::FuncOp>(
+      SymbolTable::lookupSymbolIn(moduleOp, cand.callOp.getCalleeAttr()));
+  if (!oldFn) return;
+
+  auto newFnTy = FunctionType::get(moduleOp.getContext(), {i32Ty}, {});
+  oldFn.setFunctionType(newFnTy);
+
+  OpBuilder b(cand.callOp);
+  Location loc = cand.callOp.getLoc();
+  OffsetChainInfo &info = cand.info;
+
+  switch (info.kind) {
+    case ChainKind::Linear: {
+      auto gen = [&info](OpBuilder &bd, Location loc,
+                          ArrayRef<Value> ivs) -> Value {
+        Value acc;
+        if (!isStaticEqual(info.baseOffset, 0)) {
+          acc = materializeIndex(bd, loc, info.baseOffset);
+          if (!acc) return nullptr;
+        }
+        for (size_t k = 0; k < info.shape.size(); ++k) {
+          if (info.shape[k] <= 1) continue;
+          Value idx = ivs[k];
+          if (!isStaticEqual(info.strides[k], 1)) {
+            Value s = materializeIndex(bd, loc, info.strides[k]);
+            if (!s) return nullptr;
+            idx = bd.create<arith::MulIOp>(loc, idx, s);
+          }
+          if (!acc) acc = idx;
+          else      acc = bd.create<arith::AddIOp>(loc, acc, idx);
+        }
+        if (!acc) acc = bd.create<arith::ConstantIndexOp>(loc, 0);
+        return acc;
+      };
+      emitLoopsAndPrint(b, loc, oldFn, info.shape, gen);
+      break;
+    }
+
+    case ChainKind::Linearized: {
+      Value root = info.chainRoot;
+      auto gen = [root](OpBuilder &bd, Location loc,
+                         ArrayRef<Value> ivs) -> Value {
+        ScalarChainWalker walker(bd, loc);
+        return walker.emit(root, ivs);
+      };
+      emitLoopsAndPrint(b, loc, oldFn, info.shape, gen);
+      break;
+    }
+
+    case ChainKind::Unsupported:
+      return;
+  }
+
+  cand.callOp.erase();
+}
+
+static void rewriteOneFunc(func::FuncOp funcOp) {
+  auto moduleOp = funcOp->getParentOfType<ModuleOp>();
+  if (!moduleOp) return;
+
+  DominanceInfo domInfo(funcOp);
+  SmallVector<RewriteCandidate> candidates;
+
+  funcOp.walk([&](func::CallOp callOp) {
+    if (!callOp.getCallee().starts_with("triton_print")) return;
+    if (callOp.getNumOperands() != 1) return;
+
+    OffsetChainInfo info = analyzeChain(
+        callOp.getOperand(0), funcOp, callOp.getOperation(), domInfo);
+    if (info.kind == ChainKind::Unsupported) return;
+
+    candidates.push_back({callOp, std::move(info)});
+  });
+
+  for (auto &cand : candidates)
+    rewriteCandidate(cand, moduleOp);
+}
+
+}  // namespace
+
+void rewriteDevicePrintOffsets(ModuleOp moduleOp) {
+  moduleOp.walk([&](func::FuncOp funcOp) {
+    if (funcOp.isPrivate()) return;
+    rewriteOneFunc(funcOp);
+  });
+}
+
+}  // namespace triton
+}  // namespace mlir

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -26,6 +26,7 @@
 #include "ascend/include/TritonToLinalg/FunctionConverter.h"
 #include "ascend/include/TritonToLinalg/LoadStoreConverter.h"
 #include "ascend/include/TritonToLinalg/TritonOpConverter.h"
+#include "ascend/include/TritonToLinalg/DevicePrintOffsetRewrite.h"
 #include "ascend/include/Dialect/TritonAscend/IR/TritonAscendDialect.h"
 #include "ascend/include/TritonToLinalg/DescriptorConverter.h"
 #include "ascend/include/TritonToLinalg/HoistBroadcast.h"
@@ -911,6 +912,8 @@ void TritonToLinalgPass::runOnOperation() {
   // 8. Convert function prologue/epilogue.
   moduleOp.walk(
       [&](triton::FuncOp func) { this->convertTTFunc(func, existDot, existSIMTOp); });
+
+  rewriteDevicePrintOffsets(moduleOp);
 
   // 9. Clean up dead code and simplify IR.
   PassManager pm(&getContext(), moduleOp.getOperationName());

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_device_print_offset_rewrite.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_device_print_offset_rewrite.mlir
@@ -1,0 +1,459 @@
+// RUN: triton-opt --pass-pipeline="builtin.module(auto-blockify{auto-blockify-size=1},triton-to-structured{enable-mask-fallback-conversion=false optimize-dynamic-offset=false},discrete-mask-access-conversion{compile-on-910-95=false force-simt-template=true},triton-to-annotation,triton-to-unstructure{compile-on-910-95=false force-simt-template=true},triton-to-hivm,triton-to-hfusion,triton-to-llvm,bubble-up-operation,triton-to-structured{enable-mask-fallback-conversion=false optimize-dynamic-offset=false},triton-to-linalg{compile-on-910-95=false enable-nd2nz-on-vector=false enable-select-analysis=true global-kernel=false named-ops=true})" --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: func.func @kernel_B8_dynamic_offset
+// CHECK: %[[PIDOFF:.*]] = arith.muli
+// CHECK: scf.for %[[IV:.*]] = {{.*}} to {{.*}} step {{.*}} {
+// CHECK:   %[[IV32:.*]] = arith.index_cast %[[IV]] : index to i32
+// CHECK:   arith.addi %[[PIDOFF]], %[[IV32]] : i32
+// CHECK:   func.call @triton_print_{{[0-9]+}}({{.*}}) : (i32) -> ()
+// CHECK: }
+
+module attributes {hacc.target = #hacc.target<"Ascend910_9382">} {
+  tt.func public @kernel_B8_dynamic_offset(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c8_i32 = arith.constant 8 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c8_i32 : i32
+    %2 = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+    %3 = tt.splat %1 : i32 -> tensor<8xi32>
+    %4 = arith.addi %3, %2 : tensor<8xi32>
+    %5 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<8x!tt.ptr<i32>>
+    %6 = tt.addptr %5, %4 : tensor<8x!tt.ptr<i32>>, tensor<8xi32>
+    %7 = tt.load %6 : tensor<8x!tt.ptr<i32>>
+    tt.print " idx_B8: " {hex = false, isSigned = array<i32: 1>} : %4 : tensor<8xi32>
+    %8 = tt.splat %arg1 : !tt.ptr<i32> -> tensor<8x!tt.ptr<i32>>
+    %9 = tt.addptr %8, %4 : tensor<8x!tt.ptr<i32>>, tensor<8xi32>
+    tt.store %9, %7 : tensor<8x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL:  func.func private @triton_print_0(i32)
+// CHECK-LABEL:  func.func @triton_max_6d_dimm1
+// CHECK-DAG:    %[[C31744:.*]] = arith.constant 31744 : index
+// CHECK-DAG:    %[[C1024:.*]] = arith.constant 1024 : index
+// CHECK-DAG:    %[[C256:.*]] = arith.constant 256 : index
+// CHECK:        scf.for %[[IV0:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK:          scf.for %[[IV1:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK:            scf.for %[[IV2:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK:              scf.for %[[IV3:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK:                %{{.*}} = arith.muli %[[IV0]], %[[C31744]] : index
+// CHECK:                %{{.*}} = arith.muli %[[IV1]], %[[C1024]] : index
+// CHECK:                %{{.*}} = arith.addi
+// CHECK:                %{{.*}} = arith.muli %[[IV2]], %[[C256]] : index
+// CHECK:                %{{.*}} = arith.addi
+// CHECK:                %{{.*}} = arith.addi %{{.*}}, %[[IV3]] : index
+// CHECK:                %{{.*}} = arith.index_cast %{{.*}} : index to i32
+// CHECK:                func.call @triton_print_{{[0-9]+}}(%{{.*}}) : (i32) -> ()
+// CHECK:              }
+// CHECK:            }
+// CHECK:          }
+// CHECK:        }
+
+module attributes {hacc.target = #hacc.target<"Ascend910_9382">} {
+  tt.func public @triton_max_6d_dimm1(%arg0: !tt.ptr<i8> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i8> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %true = arith.constant true
+    %cst = arith.constant dense<256> : tensor<1x1x4x1x1xi32>
+    %cst_0 = arith.constant dense<256> : tensor<1x31x1x1x1xi32>
+    %cst_1 = arith.constant dense<4> : tensor<1x31x1x1x1xi32>
+    %cst_2 = arith.constant dense<256> : tensor<4x1x1x1x1xi32>
+    %cst_3 = arith.constant dense<4> : tensor<4x1x1x1x1xi32>
+    %cst_4 = arith.constant dense<31> : tensor<4x1x1x1x1xi32>
+    %cst_5 = arith.constant dense<256> : tensor<1x1x4x1x1x1xi32>
+    %cst_6 = arith.constant dense<256> : tensor<1x31x1x1x1x1xi32>
+    %cst_7 = arith.constant dense<4> : tensor<1x31x1x1x1x1xi32>
+    %cst_8 = arith.constant dense<256> : tensor<4x1x1x1x1x1xi32>
+    %cst_9 = arith.constant dense<4> : tensor<4x1x1x1x1x1xi32>
+    %cst_10 = arith.constant dense<31> : tensor<4x1x1x1x1x1xi32>
+    %0 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %1 = tt.make_range {end = 31 : i32, start = 0 : i32} : tensor<31xi32>
+    %2 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %3 = tt.expand_dims %0 {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
+    %4 = tt.expand_dims %3 {axis = 2 : i32} : tensor<4x1xi32> -> tensor<4x1x1xi32>
+    %5 = tt.expand_dims %4 {axis = 3 : i32} : tensor<4x1x1xi32> -> tensor<4x1x1x1xi32>
+    %6 = tt.expand_dims %5 {axis = 4 : i32} : tensor<4x1x1x1xi32> -> tensor<4x1x1x1x1xi32>
+    %7 = tt.expand_dims %6 {axis = 5 : i32} : tensor<4x1x1x1x1xi32> -> tensor<4x1x1x1x1x1xi32>
+    %8 = arith.muli %7, %cst_10 : tensor<4x1x1x1x1x1xi32>
+    %9 = arith.muli %8, %cst_9 : tensor<4x1x1x1x1x1xi32>
+    %10 = arith.muli %9, %cst_8 : tensor<4x1x1x1x1x1xi32>
+    %11 = tt.expand_dims %1 {axis = 0 : i32} : tensor<31xi32> -> tensor<1x31xi32>
+    %12 = tt.expand_dims %11 {axis = 2 : i32} : tensor<1x31xi32> -> tensor<1x31x1xi32>
+    %13 = tt.expand_dims %12 {axis = 3 : i32} : tensor<1x31x1xi32> -> tensor<1x31x1x1xi32>
+    %14 = tt.expand_dims %13 {axis = 4 : i32} : tensor<1x31x1x1xi32> -> tensor<1x31x1x1x1xi32>
+    %15 = tt.expand_dims %14 {axis = 5 : i32} : tensor<1x31x1x1x1xi32> -> tensor<1x31x1x1x1x1xi32>
+    %16 = arith.muli %15, %cst_7 : tensor<1x31x1x1x1x1xi32>
+    %17 = arith.muli %16, %cst_6 : tensor<1x31x1x1x1x1xi32>
+    %18 = tt.broadcast %10 : tensor<4x1x1x1x1x1xi32> -> tensor<4x31x1x1x1x1xi32>
+    %19 = tt.broadcast %17 : tensor<1x31x1x1x1x1xi32> -> tensor<4x31x1x1x1x1xi32>
+    %20 = arith.addi %18, %19 : tensor<4x31x1x1x1x1xi32>
+    %21 = tt.expand_dims %0 {axis = 0 : i32} : tensor<4xi32> -> tensor<1x4xi32>
+    %22 = tt.expand_dims %21 {axis = 1 : i32} : tensor<1x4xi32> -> tensor<1x1x4xi32>
+    %23 = tt.expand_dims %22 {axis = 3 : i32} : tensor<1x1x4xi32> -> tensor<1x1x4x1xi32>
+    %24 = tt.expand_dims %23 {axis = 4 : i32} : tensor<1x1x4x1xi32> -> tensor<1x1x4x1x1xi32>
+    %25 = tt.expand_dims %24 {axis = 5 : i32} : tensor<1x1x4x1x1xi32> -> tensor<1x1x4x1x1x1xi32>
+    %26 = arith.muli %25, %cst_5 : tensor<1x1x4x1x1x1xi32>
+    %27 = tt.broadcast %20 : tensor<4x31x1x1x1x1xi32> -> tensor<4x31x4x1x1x1xi32>
+    %28 = tt.broadcast %26 : tensor<1x1x4x1x1x1xi32> -> tensor<4x31x4x1x1x1xi32>
+    %29 = arith.addi %27, %28 : tensor<4x31x4x1x1x1xi32>
+    %30 = tt.expand_dims %2 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
+    %31 = tt.expand_dims %30 {axis = 1 : i32} : tensor<1x256xi32> -> tensor<1x1x256xi32>
+    %32 = tt.expand_dims %31 {axis = 2 : i32} : tensor<1x1x256xi32> -> tensor<1x1x1x256xi32>
+    %33 = tt.expand_dims %32 {axis = 4 : i32} : tensor<1x1x1x256xi32> -> tensor<1x1x1x256x1xi32>
+    %34 = tt.expand_dims %33 {axis = 5 : i32} : tensor<1x1x1x256x1xi32> -> tensor<1x1x1x256x1x1xi32>
+    %35 = tt.broadcast %29 : tensor<4x31x4x1x1x1xi32> -> tensor<4x31x4x256x1x1xi32>
+    %36 = tt.broadcast %34 : tensor<1x1x1x256x1x1xi32> -> tensor<4x31x4x256x1x1xi32>
+    %37 = arith.addi %35, %36 : tensor<4x31x4x256x1x1xi32>
+    tt.print ": " {hex = false, isSigned = array<i32: 1>} : %37 : tensor<4x31x4x256x1x1xi32>
+    %38 = tt.splat %arg0 : !tt.ptr<i8> -> tensor<4x31x4x256x1x1x!tt.ptr<i8>>
+    %39 = tt.addptr %38, %37 : tensor<4x31x4x256x1x1x!tt.ptr<i8>>, tensor<4x31x4x256x1x1xi32>
+    %40 = tt.load %39 : tensor<4x31x4x256x1x1x!tt.ptr<i8>>
+    tt.assert %true, "Expecting input to be integer type" : i1
+    %41 = "tt.reduce"(%40) <{axis = 5 : i32}> ({
+    ^bb0(%arg2: i8, %arg3: i8):
+      %59 = arith.maxsi %arg2, %arg3 : i8
+      tt.reduce.return %59 : i8
+    }) : (tensor<4x31x4x256x1x1xi8>) -> tensor<4x31x4x256x1xi8>
+    %42 = arith.muli %6, %cst_4 : tensor<4x1x1x1x1xi32>
+    %43 = arith.muli %42, %cst_3 : tensor<4x1x1x1x1xi32>
+    %44 = arith.muli %43, %cst_2 : tensor<4x1x1x1x1xi32>
+    %45 = arith.muli %14, %cst_1 : tensor<1x31x1x1x1xi32>
+    %46 = arith.muli %45, %cst_0 : tensor<1x31x1x1x1xi32>
+    %47 = tt.broadcast %44 : tensor<4x1x1x1x1xi32> -> tensor<4x31x1x1x1xi32>
+    %48 = tt.broadcast %46 : tensor<1x31x1x1x1xi32> -> tensor<4x31x1x1x1xi32>
+    %49 = arith.addi %47, %48 : tensor<4x31x1x1x1xi32>
+    %50 = arith.muli %24, %cst : tensor<1x1x4x1x1xi32>
+    %51 = tt.broadcast %49 : tensor<4x31x1x1x1xi32> -> tensor<4x31x4x1x1xi32>
+    %52 = tt.broadcast %50 : tensor<1x1x4x1x1xi32> -> tensor<4x31x4x1x1xi32>
+    %53 = arith.addi %51, %52 : tensor<4x31x4x1x1xi32>
+    %54 = tt.broadcast %53 : tensor<4x31x4x1x1xi32> -> tensor<4x31x4x256x1xi32>
+    %55 = tt.broadcast %33 : tensor<1x1x1x256x1xi32> -> tensor<4x31x4x256x1xi32>
+    %56 = arith.addi %54, %55 : tensor<4x31x4x256x1xi32>
+    %57 = tt.splat %arg1 : !tt.ptr<i8> -> tensor<4x31x4x256x1x!tt.ptr<i8>>
+    %58 = tt.addptr %57, %56 : tensor<4x31x4x256x1x!tt.ptr<i8>>, tensor<4x31x4x256x1xi32>
+    tt.store %58, %41 : tensor<4x31x4x256x1x!tt.ptr<i8>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @triton_max_6d_dimm1
+// CHECK-DAG:   %[[C95232:.*]] = arith.constant 95232 : index
+// CHECK-DAG:   %[[C3072:.*]] = arith.constant 3072 : index
+// CHECK-DAG:   %[[C768:.*]] = arith.constant 768 : index
+// CHECK-DAG:   %[[C3:.*]] = arith.constant 3 : index
+// CHECK:       scf.for %[[IV0:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK:         scf.for %[[IV1:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK:           scf.for %[[IV2:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK:             scf.for %[[IV3:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK:               %{{.*}} = arith.muli %[[IV0]], %[[C95232]] : index
+// CHECK:               %{{.*}} = arith.muli %[[IV1]], %[[C3072]] : index
+// CHECK:               %{{.*}} = arith.addi
+// CHECK:               %{{.*}} = arith.muli %[[IV2]], %[[C768]] : index
+// CHECK:               %{{.*}} = arith.addi
+// CHECK:               %{{.*}} = arith.muli %[[IV3]], %[[C3]] : index
+// CHECK:               %{{.*}} = arith.addi
+// CHECK:               %{{.*}} = arith.index_cast {{.*}} : index to i32
+// CHECK:               func.call @triton_print_{{[0-9]+}}({{.*}}) : (i32) -> ()
+// CHECK:             }
+// CHECK:           }
+// CHECK:         }
+// CHECK:       }
+
+module attributes {hacc.target = #hacc.target<"Ascend910_9382">} {
+  tt.func public @triton_max_6d_dimm1(%arg0: !tt.ptr<i8> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i8> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %true = arith.constant true
+    %cst = arith.constant dense<256> : tensor<1x1x4x1x1xi32>
+    %cst_0 = arith.constant dense<256> : tensor<1x31x1x1x1xi32>
+    %cst_1 = arith.constant dense<4> : tensor<1x31x1x1x1xi32>
+    %cst_2 = arith.constant dense<256> : tensor<4x1x1x1x1xi32>
+    %cst_3 = arith.constant dense<4> : tensor<4x1x1x1x1xi32>
+    %cst_4 = arith.constant dense<31> : tensor<4x1x1x1x1xi32>
+    %cst_5 = arith.constant dense<3> : tensor<4x31x4x256x1x1xi32>
+    %cst_6 = arith.constant dense<256> : tensor<1x1x4x1x1x1xi32>
+    %cst_7 = arith.constant dense<256> : tensor<1x31x1x1x1x1xi32>
+    %cst_8 = arith.constant dense<4> : tensor<1x31x1x1x1x1xi32>
+    %cst_9 = arith.constant dense<256> : tensor<4x1x1x1x1x1xi32>
+    %cst_10 = arith.constant dense<4> : tensor<4x1x1x1x1x1xi32>
+    %cst_11 = arith.constant dense<31> : tensor<4x1x1x1x1x1xi32>
+    %0 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %1 = tt.make_range {end = 31 : i32, start = 0 : i32} : tensor<31xi32>
+    %2 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %3 = tt.expand_dims %0 {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
+    %4 = tt.expand_dims %3 {axis = 2 : i32} : tensor<4x1xi32> -> tensor<4x1x1xi32>
+    %5 = tt.expand_dims %4 {axis = 3 : i32} : tensor<4x1x1xi32> -> tensor<4x1x1x1xi32>
+    %6 = tt.expand_dims %5 {axis = 4 : i32} : tensor<4x1x1x1xi32> -> tensor<4x1x1x1x1xi32>
+    %7 = tt.expand_dims %6 {axis = 5 : i32} : tensor<4x1x1x1x1xi32> -> tensor<4x1x1x1x1x1xi32>
+    %8 = arith.muli %7, %cst_11 : tensor<4x1x1x1x1x1xi32>
+    %9 = arith.muli %8, %cst_10 : tensor<4x1x1x1x1x1xi32>
+    %10 = arith.muli %9, %cst_9 : tensor<4x1x1x1x1x1xi32>
+    %11 = tt.expand_dims %1 {axis = 0 : i32} : tensor<31xi32> -> tensor<1x31xi32>
+    %12 = tt.expand_dims %11 {axis = 2 : i32} : tensor<1x31xi32> -> tensor<1x31x1xi32>
+    %13 = tt.expand_dims %12 {axis = 3 : i32} : tensor<1x31x1xi32> -> tensor<1x31x1x1xi32>
+    %14 = tt.expand_dims %13 {axis = 4 : i32} : tensor<1x31x1x1xi32> -> tensor<1x31x1x1x1xi32>
+    %15 = tt.expand_dims %14 {axis = 5 : i32} : tensor<1x31x1x1x1xi32> -> tensor<1x31x1x1x1x1xi32>
+    %16 = arith.muli %15, %cst_8 : tensor<1x31x1x1x1x1xi32>
+    %17 = arith.muli %16, %cst_7 : tensor<1x31x1x1x1x1xi32>
+    %18 = tt.broadcast %10 : tensor<4x1x1x1x1x1xi32> -> tensor<4x31x1x1x1x1xi32>
+    %19 = tt.broadcast %17 : tensor<1x31x1x1x1x1xi32> -> tensor<4x31x1x1x1x1xi32>
+    %20 = arith.addi %18, %19 : tensor<4x31x1x1x1x1xi32>
+    %21 = tt.expand_dims %0 {axis = 0 : i32} : tensor<4xi32> -> tensor<1x4xi32>
+    %22 = tt.expand_dims %21 {axis = 1 : i32} : tensor<1x4xi32> -> tensor<1x1x4xi32>
+    %23 = tt.expand_dims %22 {axis = 3 : i32} : tensor<1x1x4xi32> -> tensor<1x1x4x1xi32>
+    %24 = tt.expand_dims %23 {axis = 4 : i32} : tensor<1x1x4x1xi32> -> tensor<1x1x4x1x1xi32>
+    %25 = tt.expand_dims %24 {axis = 5 : i32} : tensor<1x1x4x1x1xi32> -> tensor<1x1x4x1x1x1xi32>
+    %26 = arith.muli %25, %cst_6 : tensor<1x1x4x1x1x1xi32>
+    %27 = tt.broadcast %20 : tensor<4x31x1x1x1x1xi32> -> tensor<4x31x4x1x1x1xi32>
+    %28 = tt.broadcast %26 : tensor<1x1x4x1x1x1xi32> -> tensor<4x31x4x1x1x1xi32>
+    %29 = arith.addi %27, %28 : tensor<4x31x4x1x1x1xi32>
+    %30 = tt.expand_dims %2 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
+    %31 = tt.expand_dims %30 {axis = 1 : i32} : tensor<1x256xi32> -> tensor<1x1x256xi32>
+    %32 = tt.expand_dims %31 {axis = 2 : i32} : tensor<1x1x256xi32> -> tensor<1x1x1x256xi32>
+    %33 = tt.expand_dims %32 {axis = 4 : i32} : tensor<1x1x1x256xi32> -> tensor<1x1x1x256x1xi32>
+    %34 = tt.expand_dims %33 {axis = 5 : i32} : tensor<1x1x1x256x1xi32> -> tensor<1x1x1x256x1x1xi32>
+    %35 = tt.broadcast %29 : tensor<4x31x4x1x1x1xi32> -> tensor<4x31x4x256x1x1xi32>
+    %36 = tt.broadcast %34 : tensor<1x1x1x256x1x1xi32> -> tensor<4x31x4x256x1x1xi32>
+    %37 = arith.addi %35, %36 : tensor<4x31x4x256x1x1xi32>
+    %38 = arith.muli %37, %cst_5 : tensor<4x31x4x256x1x1xi32>
+    tt.print ": " {hex = false, isSigned = array<i32: 1>} : %38 : tensor<4x31x4x256x1x1xi32>
+    %39 = tt.splat %arg0 : !tt.ptr<i8> -> tensor<4x31x4x256x1x1x!tt.ptr<i8>>
+    %40 = tt.addptr %39, %38 : tensor<4x31x4x256x1x1x!tt.ptr<i8>>, tensor<4x31x4x256x1x1xi32>
+    %41 = tt.load %40 : tensor<4x31x4x256x1x1x!tt.ptr<i8>>
+    tt.assert %true, "Expecting input to be integer type" : i1
+    %42 = "tt.reduce"(%41) <{axis = 5 : i32}> ({
+    ^bb0(%arg2: i8, %arg3: i8):
+      %60 = arith.maxsi %arg2, %arg3 : i8
+      tt.reduce.return %60 : i8
+    }) : (tensor<4x31x4x256x1x1xi8>) -> tensor<4x31x4x256x1xi8>
+    %43 = arith.muli %6, %cst_4 : tensor<4x1x1x1x1xi32>
+    %44 = arith.muli %43, %cst_3 : tensor<4x1x1x1x1xi32>
+    %45 = arith.muli %44, %cst_2 : tensor<4x1x1x1x1xi32>
+    %46 = arith.muli %14, %cst_1 : tensor<1x31x1x1x1xi32>
+    %47 = arith.muli %46, %cst_0 : tensor<1x31x1x1x1xi32>
+    %48 = tt.broadcast %45 : tensor<4x1x1x1x1xi32> -> tensor<4x31x1x1x1xi32>
+    %49 = tt.broadcast %47 : tensor<1x31x1x1x1xi32> -> tensor<4x31x1x1x1xi32>
+    %50 = arith.addi %48, %49 : tensor<4x31x1x1x1xi32>
+    %51 = arith.muli %24, %cst : tensor<1x1x4x1x1xi32>
+    %52 = tt.broadcast %50 : tensor<4x31x1x1x1xi32> -> tensor<4x31x4x1x1xi32>
+    %53 = tt.broadcast %51 : tensor<1x1x4x1x1xi32> -> tensor<4x31x4x1x1xi32>
+    %54 = arith.addi %52, %53 : tensor<4x31x4x1x1xi32>
+    %55 = tt.broadcast %54 : tensor<4x31x4x1x1xi32> -> tensor<4x31x4x256x1xi32>
+    %56 = tt.broadcast %33 : tensor<1x1x1x256x1xi32> -> tensor<4x31x4x256x1xi32>
+    %57 = arith.addi %55, %56 : tensor<4x31x4x256x1xi32>
+    %58 = tt.splat %arg1 : !tt.ptr<i8> -> tensor<4x31x4x256x1x!tt.ptr<i8>>
+    %59 = tt.addptr %58, %57 : tensor<4x31x4x256x1x!tt.ptr<i8>>, tensor<4x31x4x256x1xi32>
+    tt.store %59, %42 : tensor<4x31x4x256x1x!tt.ptr<i8>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @kernel_B1_modulo_offset
+// CHECK:         %[[C2:.*]] = arith.constant 2 : i32
+// CHECK:         %[[C4:.*]] = arith.constant 4 : i32
+// CHECK:       scf.for %[[IV:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK:         %[[IV32:.*]] = arith.index_cast %[[IV]] : index to i32
+// CHECK:         %[[DIV:.*]] = arith.divsi %[[IV32]], %[[C4]] : i32
+// CHECK:         %[[MUL:.*]] = arith.muli %[[DIV]], %[[C2]] : i32
+// CHECK:         %[[REM:.*]] = arith.remsi %[[IV32]], %{{.*}} : i32
+// CHECK:         %{{.*}} = arith.addi %[[MUL]], %[[REM]] : i32
+// CHECK:         func.call @triton_print_{{[0-9]+}}({{.*}}) : (i32) -> ()
+// CHECK:       }
+// CHECK-NOT:   arith.remsi {{.*}} : tensor<16xi32>
+// CHECK-NOT:   arith.divsi {{.*}} : tensor<16xi32>
+
+module attributes {hacc.target = #hacc.target<"Ascend910_9382">} {
+  tt.func public @kernel_B1_modulo_offset(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<2> : tensor<16xi32>
+    %cst_0 = arith.constant dense<4> : tensor<16xi32>
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = arith.remsi %0, %cst_0 : tensor<16xi32>
+    %2 = arith.divsi %0, %cst_0 : tensor<16xi32>
+    %3 = arith.muli %2, %cst : tensor<16xi32>
+    %4 = arith.addi %3, %1 : tensor<16xi32>
+    tt.print " idx_B1: " {hex = false, isSigned = array<i32: 1>} : %4 : tensor<16xi32>
+    %5 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %6 = tt.addptr %5, %4 : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %7 = tt.load %6 : tensor<16x!tt.ptr<i32>>
+    %8 = tt.splat %arg1 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %9 = tt.addptr %8, %0 : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    tt.store %9, %7 : tensor<16x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @kernel_B9_neg_stride
+// CHECK:         %[[C15:.*]] = arith.constant 15 : i32
+// CHECK:       scf.for %[[IV:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK:         %[[IV32:.*]] = arith.index_cast %[[IV]] : index to i32
+// CHECK:         %{{.*}} = arith.subi %[[C15]], %[[IV32]] : i32
+// CHECK:         func.call @triton_print_{{[0-9]+}}({{.*}}) : (i32) -> ()
+// CHECK:       }
+// CHECK-NOT:   arith.subi {{.*}} : tensor<16xi32>
+
+module attributes {hacc.target = #hacc.target<"Ascend910_9382">} {
+  tt.func public @kernel_B9_neg_stride(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<15> : tensor<16xi32>
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = arith.subi %cst, %0 : tensor<16xi32>
+    %2 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %3 = tt.addptr %2, %1 : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %4 = tt.load %3 : tensor<16x!tt.ptr<i32>>
+    tt.print " idx_B9: " {hex = false, isSigned = array<i32: 1>} : %1 : tensor<16xi32>
+    %5 = tt.splat %arg1 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %6 = tt.addptr %5, %0 : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    tt.store %6, %4 : tensor<16x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @kernel_B1_modulo_offset
+// CHECK:         %[[C4:.*]] = arith.constant 4 : i32
+// CHECK:       scf.for %[[IV:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK:         %[[IV32:.*]] = arith.index_cast %[[IV]] : index to i32
+// CHECK:         %{{.*}} = arith.remsi %[[IV32]], %[[C4]] : i32
+// CHECK:         func.call @triton_print_{{[0-9]+}}({{.*}}) : (i32) -> ()
+// CHECK:       }
+// CHECK-NOT:   arith.remsi {{.*}} : tensor<16xi32>
+
+module attributes {hacc.target = #hacc.target<"Ascend910_9382">} {
+  tt.func public @kernel_B1_modulo_offset(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<4> : tensor<16xi32>
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = arith.remsi %0, %cst : tensor<16xi32>
+    tt.print " idx_B1: " {hex = false, isSigned = array<i32: 1>} : %1 : tensor<16xi32>
+    %2 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %3 = tt.addptr %2, %1 : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %4 = tt.load %3 : tensor<16x!tt.ptr<i32>>
+    %5 = tt.splat %arg1 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %6 = tt.addptr %5, %0 : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    tt.store %6, %4 : tensor<16x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @triton_max_1d_dimm1
+// CHECK:       scf.for %[[IV:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK:         %[[IV32:.*]] = arith.index_cast %[[IV]] : index to i32
+// CHECK:         func.call @triton_print_{{[0-9]+}}(%[[IV32]]) : (i32) -> ()
+// CHECK:       }
+// CHECK-NOT:   linalg.generic {{.*}} attrs {{.*}} tt.from_make_range {{.*}} tensor<2xi32>
+
+module attributes {hacc.target = #hacc.target<"Ascend910_9382">} {
+  tt.func public @triton_max_1d_dimm1(%arg0: !tt.ptr<i8> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i8> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %true = arith.constant true
+    %0 = tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32>
+    tt.print " idx: " {hex = false, isSigned = array<i32: 1>} : %0 : tensor<2xi32>
+    %1 = tt.splat %arg0 : !tt.ptr<i8> -> tensor<2x!tt.ptr<i8>>
+    %2 = tt.addptr %1, %0 : tensor<2x!tt.ptr<i8>>, tensor<2xi32>
+    %3 = tt.load %2 : tensor<2x!tt.ptr<i8>>
+    tt.print " x: " {hex = false, isSigned = array<i32: 0>} : %3 : tensor<2xi8>
+    tt.assert %true, "Expecting input to be integer type" : i1
+    %4 = "tt.reduce"(%3) <{axis = 0 : i32}> ({
+    ^bb0(%arg2: i8, %arg3: i8):
+      %8 = arith.maxui %arg2, %arg3 : i8
+      tt.reduce.return %8 : i8
+    }) : (tensor<2xi8>) -> i8
+    tt.print " ret: " {hex = false, isSigned = array<i32: 0>} : %4 : i8
+    // Wrap scalar store in tensor form so PtrAnalysis can lower it.
+    %5 = tt.splat %arg1 : !tt.ptr<i8> -> tensor<1x!tt.ptr<i8>>
+    %6 = tt.splat %4 : i8 -> tensor<1xi8>
+    %7 = tt.make_range {end = 1 : i32, start = 0 : i32} : tensor<1xi32>
+    %8 = tt.addptr %5, %7 : tensor<1x!tt.ptr<i8>>, tensor<1xi32>
+    tt.store %8, %6 : tensor<1x!tt.ptr<i8>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK:       func.func private @triton_print_{{[0-9]+}}(i32){{.*}}prefix = " idx_B10: "
+// CHECK-LABEL: func.func @kernel_B10_2d_dynamic_offset
+// CHECK:       scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK:         scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK:           func.call @triton_print_{{[0-9]+}}(%{{.*}}) : (i32) -> ()
+// CHECK:         }
+// CHECK:       }
+
+module attributes {hacc.target = #hacc.target<"Ascend910_9382">} {
+  tt.func public @kernel_B10_2d_dynamic_offset(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32},%arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<16> : tensor<4x1xi32>
+    %c8_i32 = arith.constant 8 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = tt.get_program_id y : i32
+    %2 = arith.muli %0, %c4_i32 : i32
+    %3 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %4 = tt.splat %2 : i32 -> tensor<4xi32>
+    %5 = arith.addi %4, %3 : tensor<4xi32>
+    %6 = arith.muli %1, %c8_i32 : i32
+    %7 = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+    %8 = tt.splat %6 : i32 -> tensor<8xi32>
+    %9 = arith.addi %8, %7 : tensor<8xi32>
+    %10 = tt.expand_dims %5 {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
+    %11 = arith.muli %10, %cst : tensor<4x1xi32>
+    %12 = tt.expand_dims %9 {axis = 0 : i32} : tensor<8xi32> -> tensor<1x8xi32>
+    %13 = tt.broadcast %11 : tensor<4x1xi32> -> tensor<4x8xi32>
+    %14 = tt.broadcast %12 : tensor<1x8xi32> -> tensor<4x8xi32>
+    %15 = arith.addi %13, %14 : tensor<4x8xi32>
+    %16 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<4x8x!tt.ptr<i32>>
+    %17 = tt.addptr %16, %15 : tensor<4x8x!tt.ptr<i32>>, tensor<4x8xi32>
+    %18 = tt.load %17 : tensor<4x8x!tt.ptr<i32>>
+    tt.print " idx_B10: " {hex = false, isSigned = array<i32: 1>} : %15 : tensor<4x8xi32>
+    %19 = tt.splat %arg1 : !tt.ptr<i32> -> tensor<4x8x!tt.ptr<i32>>
+    %20 = tt.addptr %19, %15 : tensor<4x8x!tt.ptr<i32>>, tensor<4x8xi32>
+    tt.store %20, %18 : tensor<4x8x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+
+
+// CHECK-LABEL: func.func @kernel_B11_2d_divmod_linearization
+// CHECK-NOT:   func.call @triton_print_{{[0-9]+}}({{.*}}) : (tensor<{{.*}}xi32>)
+// CHECK:       scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK:         scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK-DAG:       arith.divsi
+// CHECK-DAG:       arith.remsi
+// CHECK:           func.call @triton_print_{{[0-9]+}}(%{{.*}}) : (i32) -> ()
+// CHECK:         }
+// CHECK:       }
+
+module attributes {hacc.target = #hacc.target<"Ascend910_9382">} {
+  tt.func public @kernel_B11_2d_divmod_linearization(
+      %arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+      %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst   = arith.constant dense<4> : tensor<4x8xi32>
+    %cst_0 = arith.constant dense<8> : tensor<4x8xi32>
+    %cst_1 = arith.constant dense<8> : tensor<4x1xi32>
+    %0 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
+    %2 = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+    %3 = tt.expand_dims %2 {axis = 0 : i32} : tensor<8xi32> -> tensor<1x8xi32>
+    %4 = arith.muli %1, %cst_1 : tensor<4x1xi32>
+    %5 = tt.broadcast %4 : tensor<4x1xi32> -> tensor<4x8xi32>
+    %6 = tt.broadcast %3 : tensor<1x8xi32> -> tensor<4x8xi32>
+    %7 = arith.addi %5, %6 : tensor<4x8xi32>
+    %8 = arith.divsi %7, %cst_0 : tensor<4x8xi32>
+    %9 = arith.remsi %7, %cst_0 : tensor<4x8xi32>
+    %10 = arith.muli %8, %cst : tensor<4x8xi32>
+    %11 = arith.addi %10, %9 : tensor<4x8xi32>
+    %12 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<4x8x!tt.ptr<i32>>
+    %13 = tt.addptr %12, %11 : tensor<4x8x!tt.ptr<i32>>, tensor<4x8xi32>
+    %14 = tt.load %13 : tensor<4x8x!tt.ptr<i32>>
+    tt.print " addr_B11: " {hex = false, isSigned = array<i32: 1>} : %11 : tensor<4x8xi32>
+    %15 = tt.splat %arg1 : !tt.ptr<i32> -> tensor<4x8x!tt.ptr<i32>>
+    %16 = tt.addptr %15, %11 : tensor<4x8x!tt.ptr<i32>>, tensor<4x8xi32>
+    tt.store %16, %14 : tensor<4x8x!tt.ptr<i32>>
+    tt.return
+  }
+}


### PR DESCRIPTION
## 背景

`tl.device_print` 是 Triton kernel 在 Ascend NPU 上调试的关键工具。但当用户打印
结构化的 offset tensor(例如 `tt.make_range` + `arith.muli` + `tt.broadcast`
组成的多维索引链),offset 物化会显著占用 UB。

例如打印 6D shape `4×31×4×256×1×1` 的 i32 offset tensor,光这一次 print 就要在
UB 上物化 508 KB,导致UB 溢出 → kernel crash

## 解决方案

新增一个后处理 helper(`rewriteDevicePrintOffsets`),在 `TritonToLinalgPass` 里 `applyPartialConversion` 之后调用一次。对每个 `func.call @triton_print_*`:

1. 遍历 `print arg` 的 `def chain`,识别这个 offset 的"形态类型"
2. 根据形态选择对应的 `emit` 策略
3. 把 `triton_print_*` 的函数签名从 `(tensor<...>)` 改成 `(i32)`,emit 嵌套 `scf.for` + 每次内层迭代一次标量 print

整个 offset tensor 不再物化,UB 占用从几百 KB 到**约等于 0**(只剩寄存器级算术)。

## 识别与改写的整体流程

整个 helper 的代码组织成三层职责清晰的模块:

```
rewriteDevicePrintOffsets(moduleOp)                       ← 公开入口
    │
    └─ rewriteOneFunc(funcOp)                              ← 单 func 编排
          │
          ├─ DominanceInfo 建一次
          │
          ├─ walk: 每个 triton_print 调用
          │     └─ analyzeChain(arg, funcOp, callOp, domInfo)    [识别层]
          │           ├─ 基本前置检查
          │           ├─ classifyChain  ← 唯一一次链遍历
          │           ├─ 优先尝试 Linear:findMatchingCast + dominance 验证
          │           └─ 退回 Linearized
          │
          └─ rewriteCandidate                              [改写层]
                ├─ 改 fn signature 成 (i32) -> ()
                ├─ switch ChainKind:
                │     ├─ Linear      → gen 用 strides + baseOffset(脱链)
                │     └─ Linearized  → gen 用 ScalarChainWalker(回链)
                ├─ emitLoopsAndPrint                       [Emit 层]
                └─ erase 原 callOp
```

### IR 改写效果

改写前(6D 4×31×4×256×1×1 offset print,~508 KB UB):

```
%0 = tensor.empty() : tensor<4xi32>
%1 = linalg.generic{tt.from_make_range} ... -> tensor<4xi32>
...(大量 expand_shape / muli / broadcast / addi tensor 操作)...
%32 = arith.addi %... %... : tensor<4x31x4x256x1x1xi32>
call @triton_print_2(%32) : (tensor<4x31x4x256x1x1xi32>) -> ()
```

改写后:

```
scf.for %iv0 = %c0 to %c4 step %c1 {
  scf.for %iv1 = %c0 to %c31 step %c1 {
    scf.for %iv2 = %c0 to %c4 step %c1 {
      scf.for %iv3 = %c0 to %c256 step %c1 {
        %a = arith.muli %iv0, %c31744 : index
        %b = arith.muli %iv1, %c1024 : index
        %ab = arith.addi %a, %b : index
        %c = arith.muli %iv2, %c256 : index
        %abc = arith.addi %ab, %c : index
        %abcd = arith.addi %abc, %iv3 : index
        %v = arith.index_cast %abcd : index to i32
        func.call @triton_print_2(%v) : (i32) -> ()
      }
    }
  }
}
```

idx print 的 UB 占用:**约等于 0**(只剩寄存器级算术)。

## 支持的 pattern

| Pattern | 状态 |
|---|---|
| 1D `arange`  | ✓ |
| 1D `arange * k`(stride 放大)| ✓ |
| 1D `arange + base`(静态 base offset)  | ✓ |
| 1D `(N-1) - arange`(反向索引)  | ✓ |
| 1D `arange % P` / `arange // P` | ✓ |
| 1D `(i // P) * S + (i % P)`(1D 线性化) | ✓ |
| 1D `pid * BLOCK + arange`(动态 offset)  | ✓ |
| 多维结构化 offset(连续) | ✓ |
| 多维结构化 offset(stride 放大)  | ✓ |
| 多维 + 动态 base offset(GEMM / attention)| ✓ |
| 多维 + div/mod 线性化(高维线性化) | ✓ |

对于跳过的 pattern,helper 不做任何改写,原 IR 完整保留,print 输出依然正确
(UB 占用与改写前相同)。

## 安全保证

helper 改写的前提是所有以下条件**同时**成立:

| 条件 | 检查点 |
|---|---|
| print arg 的 shape 完全静态 | `analyzeChain` 入口 |
| print arg 只被 `triton_print_*` 调用消费 | `hasOnlyPrintUsers` |
| 整条 def 链都是白名单内的 op | `classifyChain` |
| Linear 路径:cast 的 mixed strides / offset 里所有动态 SSA 值都 dominate print 调用点 | `analyzeChain` 里 `domInfo.dominates` 验证 |

任一条件不满足,`analyzeChain` 返回 `ChainKind::Unsupported`,helper 对该候选 return,原 IR 不动。

## 测试

- FileCheck 单元测试:
  `third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_device_print_offset_rewrite.mlir`
  覆盖所有代表性 pattern
