### PR TITLE
ci: Add the MLIR test and remove the timeout period

### DIFF
--- a/.github/workflows/Ascend950-pipeline-tests.yml
+++ b/.github/workflows/Ascend950-pipeline-tests.yml
@@ -176,7 +176,7 @@ jobs:
         run: |
           gh api -X POST "repos/${{ github.repository }}/statuses/${SHA}" \
             -f state=pending \
-            -f context='A5 Pipeline Tests' \
+            -f context='Ascend950 Pipeline Tests' \
             -f description='Pipeline running' \
             -f target_url="$TARGET"
 
@@ -322,7 +322,7 @@ jobs:
           done
 
           if [ "$DONE" != "true" ]; then
-            write_status "TIMEOUT" "polling exceeded 240 attempts without a terminal status"
+            write_status "TIMEOUT" "polling exceeded 720 attempts without a terminal status"
             exit 1
           fi
           echo "terminal status: ${ST} - ${MSG}"
@@ -355,7 +355,7 @@ jobs:
         run: |
           gh api -X POST "repos/${{ github.repository }}/statuses/${SHA}" \
             -f state="$STATE" \
-            -f context='A5 Pipeline Tests' \
+            -f context='Ascend950 Pipeline Tests' \
             -f description="${DESC:-UNKNOWN}" \
             -f target_url="$TARGET"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ on:
     branches: [main, 'dev-**']
     types: [checks_requested]
   push:
-    branches: [main]
+    branches: [main, 'release/**']
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/integration-tests-ascend.yml
+++ b/.github/workflows/integration-tests-ascend.yml
@@ -87,7 +87,6 @@ jobs:
           TRITON_BUILD_WITH_O1: true
           TRITON_BUILD_PROTON: OFF
           TRITON_WHEEL_NAME: "triton-ascend"
-          TRITON_APPEND_CMAKE_ARGS: "-DTRITON_BUILD_UT=OFF"
         run: |
           nproc
           source /usr/local/Ascend/cann/set_env.sh
@@ -120,3 +119,30 @@ jobs:
           # NOTE: kernel tests are temporarily disabled due to intermittent failures
           # that cause CI instability. TODO: Fix flaky kernel tests and re-enable.
           # ${PYTHON} -m pytest -s -v -n "$NUM_PROCS" --dist=loadfile third_party/ascend/unittest/kernels/test_triton_kernel.py
+
+      # NOTE: Conversion is not fully merged yet; failures must not block CI.
+      # Remove `continue-on-error` once the module lands.
+      - name: Run MLIR FileCheck tests (non-blocking)
+        if: always()
+        continue-on-error: true
+        working-directory: python
+        shell: bash
+        run: |
+          source /usr/local/Ascend/cann/set_env.sh
+          export PATH="/usr/local/bisheng/tools/bishengir/bin:$PATH"
+          TEST_MLIR_DIR=$(ls -d build/cmake.*/third_party/ascend/unittest 2>/dev/null | head -1 || true)
+          echo "TEST_MLIR_DIR=${TEST_MLIR_DIR:-<not found>}"
+          if [ -n "${TEST_MLIR_DIR}" ] && [ -d "${TEST_MLIR_DIR}" ]; then
+            lit -v "${TEST_MLIR_DIR}"
+          else
+            echo "MLIR test directory not found."
+            echo "Expected to match: build/cmake.*/third_party/ascend/unittest"
+            echo "Working directory: $(pwd)"
+            if [ -d build ]; then
+              echo "Contents of build directory:"
+              find build -maxdepth 4 -print
+            else
+              echo "build directory does not exist"
+            fi
+            exit 1
+          fi

--- a/.github/workflows/integration-tests-ascend.yml
+++ b/.github/workflows/integration-tests-ascend.yml
@@ -87,6 +87,9 @@ jobs:
           TRITON_BUILD_WITH_O1: true
           TRITON_BUILD_PROTON: OFF
           TRITON_WHEEL_NAME: "triton-ascend"
+          # Enable C++/MLIR unit tests so CMake generates third_party/ascend/unittest/lit.site.cfg.py
+          # in the build dir (required by the MLIR FileCheck step below).
+          TRITON_APPEND_CMAKE_ARGS: "-DTRITON_BUILD_UT=ON"
         run: |
           nproc
           source /usr/local/Ascend/cann/set_env.sh
@@ -130,19 +133,11 @@ jobs:
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           export PATH="/usr/local/bisheng/tools/bishengir/bin:$PATH"
-          TEST_MLIR_DIR=$(ls -d build/cmake.*/third_party/ascend/unittest 2>/dev/null | head -1 || true)
+          TEST_MLIR_DIR=$(ls -d build/cmake.*/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline 2>/dev/null | head -1 || true)
           echo "TEST_MLIR_DIR=${TEST_MLIR_DIR:-<not found>}"
-          if [ -n "${TEST_MLIR_DIR}" ] && [ -d "${TEST_MLIR_DIR}" ]; then
-            lit -v "${TEST_MLIR_DIR}"
-          else
+          if [ -z "${TEST_MLIR_DIR}" ] || [ ! -d "${TEST_MLIR_DIR}" ]; then
             echo "MLIR test directory not found."
-            echo "Expected to match: build/cmake.*/third_party/ascend/unittest"
-            echo "Working directory: $(pwd)"
-            if [ -d build ]; then
-              echo "Contents of build directory:"
-              find build -maxdepth 4 -print
-            else
-              echo "build directory does not exist"
-            fi
+            echo "Expected to match: build/cmake.*/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline"
             exit 1
           fi
+          lit -v "${TEST_MLIR_DIR}"

--- a/.github/workflows/integration-tests-ascend.yml
+++ b/.github/workflows/integration-tests-ascend.yml
@@ -133,11 +133,15 @@ jobs:
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           export PATH="/usr/local/bisheng/tools/bishengir/bin:$PATH"
-          TEST_MLIR_DIR=$(ls -d build/cmake.*/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline 2>/dev/null | head -1 || true)
-          echo "TEST_MLIR_DIR=${TEST_MLIR_DIR:-<not found>}"
-          if [ -z "${TEST_MLIR_DIR}" ] || [ ! -d "${TEST_MLIR_DIR}" ]; then
-            echo "MLIR test directory not found."
-            echo "Expected to match: build/cmake.*/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline"
+          # CMake only drops lit.site.cfg.py into the build dir; the .mlir test files
+          # themselves stay in the source tree (lit.cfg.py points test_source_root back
+          # at <source>/third_party/ascend/unittest). So we must aim lit at the build-dir
+          # site cfg to get substitutions, then filter down to the DynamicCVPipeline suite.
+          BUILD_UT_DIR=$(ls -d build/cmake.*/third_party/ascend/unittest 2>/dev/null | head -1 || true)
+          echo "BUILD_UT_DIR=${BUILD_UT_DIR:-<not found>}"
+          if [ -z "${BUILD_UT_DIR}" ] || [ ! -f "${BUILD_UT_DIR}/lit.site.cfg.py" ]; then
+            echo "lit.site.cfg.py not found — TRITON_BUILD_UT may not have taken effect."
+            echo "Expected: build/cmake.*/third_party/ascend/unittest/lit.site.cfg.py"
             exit 1
           fi
-          lit -v "${TEST_MLIR_DIR}"
+          lit -v "${BUILD_UT_DIR}" --filter 'Conversion/General/DynamicCVPipeline'


### PR DESCRIPTION
Summary
-------------

- Add the MLIR test for Conversion
- Remove -DTRITON_BUILD_UT=OFF, and it defaults to ON
- Remove the timeout period of the Ascend950 test and the name display during the test was modified

