### PR TITLE
fix(ssbuffer): bugfix Subview results should leads to source.

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/Common/MemoryEffectsTracker.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/MemoryEffectsTracker.cpp
@@ -73,6 +73,25 @@ bool isDefinedInside(Value v, Operation *op)
     return op->isProperAncestor(defOp);
 }
 
+Value getViewSource(Value val)
+{
+    while (auto viewLike = val.getDefiningOp<ViewLikeOpInterface>()) {
+        val = viewLike.getViewSource();
+    }
+    return val;
+}
+
+MemoryEffects::EffectInstance remapEffectValue(const MemoryEffects::EffectInstance &effect, Value value)
+{
+    if (auto result = dyn_cast<OpResult>(value)) {
+        return MemoryEffects::EffectInstance(effect.getEffect(), result, effect.getParameters(), effect.getStage(),
+                                             effect.getEffectOnFullRegion(), effect.getResource());
+    }
+
+    return MemoryEffects::EffectInstance(effect.getEffect(), cast<BlockArgument>(value), effect.getParameters(),
+                                         effect.getStage(), effect.getEffectOnFullRegion(), effect.getResource());
+}
+
 } // namespace
 
 MemoryDependenceGraph::MemoryDependenceGraph(Operation *root, AliasAnalysis &aa) : root(root), aa(aa)
@@ -202,11 +221,18 @@ SmallVector<MemoryEffects::EffectInstance> MemoryDependenceGraph::collectOuterEf
 
     SmallVector<MemoryEffects::EffectInstance> filtered;
     filtered.reserve(raw->size());
-    for (auto &e : *raw) {
-        if (isDefinedInside(e.getValue(), op)) {
+    for (const auto &e : *raw) {
+        Value value = e.getValue();
+        if (!value) {
+            filtered.push_back(e);
             continue;
         }
-        filtered.push_back(e);
+
+        Value source = getViewSource(value);
+        if (isDefinedInside(source, op)) {
+            continue;
+        }
+        filtered.push_back(source == value ? e : remapEffectValue(e, source));
     }
     return filtered;
 }
@@ -217,13 +243,7 @@ AliasResult MemoryDependenceGraph::queryAlias(Value lhs, Value rhs)
         auto arg = llvm::dyn_cast<BlockArgument>(val);
         return arg && arg.getOwner()->isEntryBlock();
     };
-    auto getSource = [] (Value val) -> Value {
-        while (auto viewLike = val.getDefiningOp<ViewLikeOpInterface>()) {
-            val = viewLike.getViewSource();
-        }
-        return val;
-    };
-    if (isFuncEntryArg(getSource(lhs)) && isFuncEntryArg(getSource(rhs))) {
+    if (isFuncEntryArg(getViewSource(lhs)) && isFuncEntryArg(getViewSource(rhs))) {
         return lhs == rhs ? AliasResult::MustAlias : AliasResult::NoAlias;
     }
     return aa.alias(lhs, rhs);

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_plan_compute_block_subview_memory_deps.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_plan_compute_block_subview_memory_deps.mlir
@@ -15,8 +15,36 @@ module {
       : memref<64x64xf16> to memref<?x?xf16, strided<[64, 1], offset: ?>>
     memref.copy %src_view, %dst_view {ssbuffer.core_type = "VECTOR"}
       : memref<?x?xf16, strided<[64, 1], offset: ?>> to memref<?x?xf16, strided<[64, 1], offset: ?>>
-    %lhs = bufferization.to_tensor %alloc restrict writable {ssbuffer.core_type = "VECTOR"}
-      : memref<64x64xf16> to tensor<64x64xf16>
+    %lhs = bufferization.to_tensor %alloc restrict writable {ssbuffer.core_type = "VECTOR"} : memref<64x64xf16>
+    %out = tensor.empty() {ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+    %mm = linalg.matmul {input_precision = "ieee", ssbuffer.core_type = "CUBE"}
+      ins(%lhs, %rhs : tensor<64x64xf16>, tensor<64x64xf16>)
+      outs(%out : tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %mm : tensor<64x64xf32>
+  }
+
+  // CHECK-LABEL: func.func @for_subview_copy_feeds_outer_to_tensor(
+  // CHECK: [[ALLOC:%[A-Za-z0-9_]+]] = memref.alloc() {{.*}}ssbuffer.core_type = "CUBE"
+  // CHECK: scf.for
+  // CHECK: memref.copy {{.*}}ssbuffer.core_type = "CUBE"
+  // CHECK: } {{.*}}ssbuffer.core_type = "CUBE"
+  // CHECK: [[LHS:%[0-9]+]] = bufferization.to_tensor [[ALLOC]] restrict writable {{.*}}ssbuffer.core_type = "CUBE"
+  // CHECK: linalg.matmul {{.*}}ssbuffer.core_type = "CUBE"
+  func.func @for_subview_copy_feeds_outer_to_tensor(%src: memref<64x64xf16>, %rhs: tensor<64x64xf16>) -> tensor<64x64xf32> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %c64 = arith.constant 64 : index
+    %alloc = memref.alloc() {ssbuffer.core_type = "VECTOR"} : memref<64x64xf16>
+    scf.for %i = %c0 to %c4 step %c1 {
+      %src_view = memref.subview %src[%c0, %c0] [%c64, %c64] [1, 1]
+        : memref<64x64xf16> to memref<?x?xf16, strided<[64, 1], offset: ?>>
+      %dst_view = memref.subview %alloc[%c0, %c0] [%c64, %c64] [1, 1]
+        : memref<64x64xf16> to memref<?x?xf16, strided<[64, 1], offset: ?>>
+      memref.copy %src_view, %dst_view {ssbuffer.core_type = "VECTOR"}
+        : memref<?x?xf16, strided<[64, 1], offset: ?>> to memref<?x?xf16, strided<[64, 1], offset: ?>>
+    }
+    %lhs = bufferization.to_tensor %alloc restrict writable {ssbuffer.core_type = "VECTOR"} : memref<64x64xf16>
     %out = tensor.empty() {ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
     %mm = linalg.matmul {input_precision = "ieee", ssbuffer.core_type = "CUBE"}
       ins(%lhs, %rhs : tensor<64x64xf16>, tensor<64x64xf16>)
@@ -44,8 +72,7 @@ module {
 
     %lhs_view = memref.subview %lhs_gm[%c0, %c0] [64, 64] [1, 1]
       : memref<64x64xf16> to memref<64x64xf16, strided<[64, 1], offset: ?>>
-    %lhs = bufferization.to_tensor %lhs_view restrict writable
-      : memref<64x64xf16, strided<[64, 1], offset: ?>> to tensor<64x64xf16>
+    %lhs = bufferization.to_tensor %lhs_view restrict writable : memref<64x64xf16, strided<[64, 1], offset: ?>>
     %out = tensor.empty() : tensor<64x64xf32>
     %init = linalg.fill ins(%zero_f32 : f32) outs(%out : tensor<64x64xf32>) -> tensor<64x64xf32>
     %mm = linalg.matmul {input_precision = "ieee"}


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

This PR resolves the following issue: 
When a compute block creates a subview of a memref internally and subsequently manipulates the memory through that subview, the system incorrectly interprets this as an internal memory operation, causing the memory modifications to be lost during external processing.
