### PR TITLE
feat(ssbuffer): fix iterarg dependencies in DataDependenciesAnalysis & add SplitDataflow to triton-opt

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -2,6 +2,12 @@
 #include "ascend/include/TritonToLinalg/Passes.h"
 #include "ascend/include/TritonControlFlowOpt/Passes.h"
 #include "ascend/include/DiscreteMaskAccessConversion/Passes.h"
+#include "ascend/include/DynamicCVPipeline/SplitDataflow/AddBlockIdForControlOps.h"
+#include "ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h"
+#include "ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h"
+#include "ascend/include/DynamicCVPipeline/SplitDataflow/MarkMainLoop.h"
+#include "ascend/include/DynamicCVPipeline/SplitDataflow/PreserveControlAttrsCanonicalize.h"
+#include "ascend/include/DynamicCVPipeline/SplitDataflow/SeparateCVScope.h"
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition.h"
 #include "ascend/include/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.h"
 #include "ascend/include/DynamicCVPipeline/RemoveAttributes.h"
@@ -96,6 +102,12 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   // mlir::registerTritonAMDGPUConvertToBufferOps();
 
   // DynamicCVPipeline passes
+  mlir::triton::registerAddBlockIdForControlOpsPasses();
+  mlir::triton::registerDataDependencyAnalysisPasses();
+  mlir::triton::registerInterCoreTransferAndSyncPasses();
+  mlir::triton::registerMarkMainLoopPasses();
+  mlir::triton::registerSeparateCVScopePasses();
+  mlir::triton::registerPreserveControlAttrsCanonicalizePasses();
   mlir::triton::registerAddControlFlowConditionPasses();
   mlir::triton::registerAddMultiBufferOuterScopePasses();
   mlir::triton::registerRemoveSsbufAttrPasses();

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
@@ -132,7 +132,13 @@ private:
                                                 int producerBlockId,
                                                 int consumerBlockId);
 
-  bool isControlFlowOp(mlir::Operation *op);
+    bool isControlFlowOp(mlir::Operation *op);
+    bool isValidTensorForDependency(mlir::Value value);
+    bool isFuncOpArg(mlir::Value value);
+    std::pair<scf::ForOp, int> isScfForOpIterArg(mlir::Value value);
+    int getAvaliableBlockId();
+    void processIterArgInputDependencies(scf::ForOp forOp, mlir::Value value, int iterArgIndex, 
+    llvm::SmallVector<DependencyInfo> &dependencies, int processingBlockId, DataDependencyInfo &info);
 
   mlir::ModuleOp module;
 };

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/AddBlockIdForControlOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/AddBlockIdForControlOps.cpp
@@ -78,5 +78,10 @@ std::unique_ptr<OperationPass<ModuleOp>> createAddBlockIdForControlOpsPass()
     return std::make_unique<AddBlockIdForControlOpsPass>();
 }
 
+void registerAddBlockIdForControlOpsPasses()
+{
+  registerPass([]() -> std::unique_ptr<mlir::Pass> { return createAddBlockIdForControlOpsPass(); });
+}
+
 } // namespace triton
 } // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -560,6 +560,11 @@ std::unique_ptr<OperationPass<ModuleOp>> createDataDependencyAnalysisPass()
     return std::make_unique<DataDependencyAnalysisPass>();
 }
 
+void registerDataDependencyAnalysisPasses()
+{
+  registerPass([]() -> std::unique_ptr<mlir::Pass> { return createDataDependencyAnalysisPass(); });
+}
+
 // Helper: Get BlockId
 int getSsbufferBlockId(Operation *op)
 {

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -24,6 +24,7 @@
 #include "ascend/include/DynamicCVPipeline/Common/MemoryEffectsTracker.h"
 
 #include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -83,6 +84,56 @@ bool DataDependencyAnalysisPass::isControlFlowOp(mlir::Operation *op)
     if (!op)
         return false;
     return isa<scf::ForOp>(op) || isa<scf::IfOp>(op) || isa<scf::WhileOp>(op) || isa<scf::YieldOp>(op);
+}
+
+// Helper: Check if value is a valid tensor for dependency analysis
+// Returns true if value is TensorType and not defined by EmptyOp/FillOp
+bool DataDependencyAnalysisPass::isValidTensorForDependency(mlir::Value value)
+{
+    if (!dyn_cast<mlir::TensorType>(value.getType())) {
+        return false;
+    }
+    Operation *defOp = value.getDefiningOp();
+    if (defOp && isa<tensor::EmptyOp, linalg::FillOp>(defOp)) {
+        return false;
+    }
+    return true;
+}
+
+// Helper: Check if value is a arg in func which is from gm
+bool DataDependencyAnalysisPass::isFuncOpArg(mlir::Value value)
+{
+    if (auto blockArg = mlir::dyn_cast<mlir::BlockArgument>(value)) {
+        mlir::Block *ownerBlock = blockArg.getOwner();
+
+        if (auto funcOp = dyn_cast<mlir::func::FuncOp>(ownerBlock->getParentOp())) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Helper: Check if value is a iterarg in scf.for
+std::pair<scf::ForOp, int> DataDependencyAnalysisPass::isScfForOpIterArg(mlir::Value value)
+{
+    auto blockArg = dyn_cast<mlir::BlockArgument>(value);
+    if (!blockArg) {
+        return {nullptr, -1};
+    }
+    Block *block = blockArg.getOwner();
+    if (!block || !block->getParent()) {
+        return {nullptr, -1};
+    }
+    auto forOp = dyn_cast<scf::ForOp>(block->getParentOp());
+    if (!forOp) {
+        return {nullptr, -1};
+    }
+    unsigned argIndex = blockArg.getArgNumber();
+    if (argIndex > 0) {
+        return {forOp, argIndex - 1};
+    }
+
+    return {nullptr, -1};
 }
 
 // Helper: Build and record BlockInfo
@@ -184,6 +235,58 @@ void DataDependencyAnalysisPass::collectDepInfo(mlir::Value depvalue, Dependency
     dependencies.push_back(depInfo);
 }
 
+int DataDependencyAnalysisPass::getAvaliableBlockId()
+{
+    int maxBlockId = -1;
+    module.walk([&](Operation *op) {
+        int currentId = getSsbufferBlockId(op);
+        if (currentId > maxBlockId) {
+            maxBlockId = currentId;
+        }
+    });
+    return maxBlockId + 1;
+}
+
+void DataDependencyAnalysisPass::processIterArgInputDependencies(scf::ForOp forOp, 
+    mlir::Value value, int iterArgIndex, llvm::SmallVector<DependencyInfo> &dependencies, 
+    int processingBlockId, DataDependencyInfo &info)
+{
+    mlir::Value initValue = forOp.getInits()[iterArgIndex];
+    Operation *initDefOp = initValue.getDefiningOp();
+    if (!initDefOp) {
+        return;
+    }
+    auto initDefReuslt = dyn_cast<mlir::OpResult>(initValue);
+    auto initCoreType = getCoreTypeWithIndex(initDefOp, initDefReuslt ? initDefReuslt.getResultNumber() : 0);
+    auto yieldCoreType = getCoreTypeWithIndex(forOp, iterArgIndex);
+    if (initCoreType == "VECTOR" && yieldCoreType == "VECTOR") {
+        int newId = getAvaliableBlockId();
+        // Insert arith::ConstantOp at the beginning of forOp's body
+        OpBuilder builder(forOp);
+        Block &bodyBlock = forOp.getRegion().front();
+        builder.setInsertionPointToStart(&bodyBlock);
+        Location loc = forOp.getLoc();
+        auto constOp = builder.create<arith::ConstantIntOp>(loc, 0, 32);
+
+        // Set block_id and core_type attributes
+        constOp->setAttr(kBlockIdAttr, IntegerAttr::get(IntegerType::get(builder.getContext(), 32), newId));
+        constOp->setAttr(kCoreTypeAttr, StringAttr::get(builder.getContext(), "VECTOR"));
+
+        DependencyInfo depInfo;
+        depInfo.type = DependencyType::VectorToCube;
+        depInfo.value = value;
+        depInfo.iniProducerBlockId = newId;
+        depInfo.iniConsumerBlockId = processingBlockId;
+        depInfo.producerBlockId = newId;
+        depInfo.consumerBlockId = processingBlockId;
+        dependencies.push_back(depInfo);
+    } else if (initCoreType == "VECTOR" && yieldCoreType == "CUBE") {
+        LOG_DEBUG("[warning] iterarg init core_type conflict with yield!!!!!!\n");
+    } else if (initCoreType == "CUBE" && yieldCoreType == "VECTOR") {
+        LOG_DEBUG("[warning] iterarg init core_type conflict with yield!!!!!!\n");
+    }
+}
+
 // Analyze V->C
 void DataDependencyAnalysisPass::analyzeExternalInputs(DataDependencyInfo &info)
 {
@@ -196,18 +299,19 @@ void DataDependencyAnalysisPass::analyzeExternalInputs(DataDependencyInfo &info)
             continue;
         LOG_DEBUG("Analyzing external inputs for Cube Block ID: " << id << "\n");
         for (mlir::Value input : blockInfo.inputs) {
+            // Check if input is a value which can be produced by CUBE
+            if (!isValidTensorForDependency(input)) {
+                LOG_DEBUG("Warning: [v->c] Input value is not a valid tensor for dependency analysis.\n");
+                continue;
+            }
             // Check if input is a func.func blockarg.
-            if (auto arg = mlir::dyn_cast<mlir::BlockArgument>(input)) {
+            if (isFuncOpArg(input)) {
                 LOG_DEBUG("Warning: [v->c] Input value is a function parameter.\n");
                 continue;
             }
-            // Check if input is a value which can be produced by CUBE
-            if (!dyn_cast<mlir::TensorType>(input.getType())) {
-                LOG_DEBUG("Warning: [v->c] Input value is not TensorType\n");
-                continue;
-            }
-            if (isa<tensor::EmptyOp, linalg::FillOp>(input.getDefiningOp())) {
-                LOG_DEBUG("Warning: [v->c] Input value is defined by tensor::EmptyOp/linalg::FillOp.\n");
+            auto [iterArgForOp, iterArgIndex] = isScfForOpIterArg(input);
+            if (iterArgIndex != -1) {
+                processIterArgInputDependencies(iterArgForOp, input, iterArgIndex, v2cDependencies, blockInfo.blockId, info);
                 continue;
             }
 
@@ -251,13 +355,9 @@ void DataDependencyAnalysisPass::analyzeExternalOutputs(DataDependencyInfo &info
             continue;
 
         for (mlir::Value output : blockInfo.outputs) {
-            // Check if input is a value which can be produced by VECTOR
-            if (!dyn_cast<mlir::TensorType>(output.getType())) {
-                LOG_DEBUG("Warning: ExternalOutput is not TensorType\n");
-                continue;
-            }
-            if (isa<tensor::EmptyOp, linalg::FillOp>(output.getDefiningOp())) {
-                LOG_DEBUG("Warning: [c->v] output value is defined by tensor::EmptyOp/linalg::FillOp.\n");
+            // Check if output is a value which can be produced by CUBE
+            if (!isValidTensorForDependency(output)) {
+                LOG_DEBUG("Warning: [c->v] Output value is not a valid tensor for dependency analysis.\n");
                 continue;
             }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -317,9 +317,13 @@ mlir::Value InterCoreTransferAndSyncPass::normalizeIfNeeded(OpBuilder &builder, 
     int64_t iniM = origTensorType.getDimSize(0);
     int64_t iniN = origTensorType.getDimSize(1);
     Type elemType = origTensorType.getElementType();
-
-    builder.setInsertionPointAfter(origValue.getDefiningOp());
-
+    if (isa<mlir::BlockArgument>(origValue)) {
+        auto [originProdStart, originProdEnd] = getBlockStartEnd(originBlockId, module);
+        builder.setInsertionPointAfter(originProdEnd);
+    } else {
+        builder.setInsertionPointAfter(origValue.getDefiningOp());
+    }
+    
     auto floatElemTy = cast<FloatType>(elemType);
     auto zeroConstOp = builder.create<arith::ConstantFloatOp>(
         loc, APFloat::getZero(floatElemTy.getFloatSemantics()), floatElemTy);
@@ -376,7 +380,8 @@ void InterCoreTransferAndSyncPass::Nd2NzNormalize(OpBuilder &builder, Dependency
     }
     // Step 1: Compute expected shape
     SmallVector<int64_t> expectedShape = computeExpectedShape(origValue);
-    int originBlockId = getSsbufferBlockId(origValue.getDefiningOp());
+    
+    int originBlockId = dep.iniProducerBlockId;
     // Step 2: If shapes match, return original value
     if (!isShapeExpected(origValue, expectedShape)) {
         newValue = normalizeIfNeeded(builder, dep, loc, origValue, expectedShape, originBlockId);
@@ -400,7 +405,13 @@ void InterCoreTransferAndSyncPass::Nd2NzNormalize(OpBuilder &builder, Dependency
     auto type3D = RankedTensorType::get(shape3D, elemType);
     auto typeTrans = RankedTensorType::get(shapeTrans, elemType);
     auto typeFinal = RankedTensorType::get(shapeFinal, elemType);
-    builder.setInsertionPointAfter(newValue.getDefiningOp());
+    if (newValue.getDefiningOp()) {
+        builder.setInsertionPointAfter(newValue.getDefiningOp());
+    } else {
+        auto [newProdStart, newProdEnd] = getBlockStartEnd(originBlockId, module);
+        builder.setInsertionPointAfter(newProdEnd);
+    }
+    
     auto reshape3Dcst = builder.create<arith::ConstantOp>(loc, builder.getI64TensorAttr(shape3D));
     auto reshape3DOp = builder.create<tensor::ReshapeOp>(loc, type3D, newValue, reshape3Dcst);
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/MarkMainLoop.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/MarkMainLoop.cpp
@@ -87,9 +87,16 @@ void MarkMainLoopPass::runOnOperation()
 // Create the pass
 namespace mlir {
 namespace triton {
+
 std::unique_ptr<OperationPass<ModuleOp>> createMarkMainLoopPass()
 {
     return std::make_unique<MarkMainLoopPass>();
 }
+
+void registerMarkMainLoopPasses()
+{
+  registerPass([]() -> std::unique_ptr<mlir::Pass> { return createMarkMainLoopPass(); });
+}
+
 } // namespace triton
 } // namespace mlir

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/03.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/03.mlir
@@ -3,7 +3,7 @@
 module {
   func.func @tc03_bidirectional_transfer(%arg0: memref<256x256xf16>) {
     %alloc = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<256x256xf16>
-    %t0 = bufferization.to_tensor %alloc {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<256x256xf16> to tensor<256x256xf16>
+    %t0 = bufferization.to_tensor %alloc {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<256x256xf16>
     %cst = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} 0.0 : f16
     %empty = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : tensor<256x256xf32>
     %init = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : f16) outs(%empty : tensor<256x256xf32>) -> tensor<256x256xf32>
@@ -12,7 +12,7 @@ module {
     %t2 = tensor.empty() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : tensor<256x256xf32>
     %transposed = linalg.transpose ins(%exp : tensor<256x256xf32>) outs(%t2 : tensor<256x256xf32>) permutation = [1, 0]  {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"}
     %alloc2 = memref.alloc() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<256x256xf32>
-    %t3 = bufferization.to_tensor %alloc2 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<256x256xf32> to tensor<256x256xf32>
+    %t3 = bufferization.to_tensor %alloc2 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<256x256xf32>
     %mat2 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} ins(%t3, %transposed : tensor<256x256xf32>, tensor<256x256xf32>) outs(%empty : tensor<256x256xf32>) -> tensor<256x256xf32>
     return
   }
@@ -28,7 +28,7 @@ module {
 // CHECK: %[[ALLOC_1:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<256x256xf32, #hivm.address_space<ub>>
 // CHECK: annotation.mark %[[ALLOC_1]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<256x256xf32, #hivm.address_space<ub>>
 // CHECK: %[[MEMSPACECAST:[a-z0-9_]+]] = memref.memory_space_cast %[[ALLOC_1]] {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<256x256xf32, #hivm.address_space<ub>> to memref<256x256xf32>
-// CHECK: %[[TENSOR_4:[a-z0-9_]+]] = bufferization.to_tensor %[[MEMSPACECAST]] restrict writable {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<256x256xf32> to tensor<256x256xf32>
+// CHECK: %[[TENSOR_4:[a-z0-9_]+]] = bufferization.to_tensor %[[MEMSPACECAST]] restrict writable {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<256x256xf32>
 // CHECK: %[[EXP_5:[a-z0-9_]+]] = math.exp %[[TENSOR_4]] {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : tensor<256x256xf32>
 // CHECK: %[[cst_2:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} dense<[256, 32, 8]> : tensor<3xi64>
 // CHECK: %[[RESHAPE:[a-z0-9_]+]] = tensor.reshape %[[EXP_5]](%[[cst_2]]) {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<256x256xf32>, tensor<3xi64>) -> tensor<256x32x8xf32>
@@ -45,7 +45,7 @@ module {
 // CHECK: annotation.mark %[[ALLOC_6]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<32x16x16x8xf32, #hivm.address_space<cbuf>>
 // CHECK: %[[MEM_7:[a-z0-9_]+]] = hivm.hir.convert_layout %[[ALLOC_6]] output_shape [256, 256] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : (memref<32x16x16x8xf32, #hivm.address_space<cbuf>>) -> memref<256x256xf32, #hivm.address_space<cbuf>>
 // CHECK: %[[MEMSPACECAST_7:[a-z0-9_]+]] = memref.memory_space_cast %[[MEM_7]] {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<256x256xf32, #hivm.address_space<cbuf>> to memref<256x256xf32>
-// CHECK: %[[TENSOR_8:[a-z0-9_]+]] = bufferization.to_tensor %[[MEMSPACECAST_7]] restrict writable {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<256x256xf32> to tensor<256x256xf32>
+// CHECK: %[[TENSOR_8:[a-z0-9_]+]] = bufferization.to_tensor %[[MEMSPACECAST_7]] restrict writable {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<256x256xf32>
 // CHECK: %[[EMPTY_9:[a-z0-9_]+]] = tensor.empty()
 // CHECK: linalg.transpose ins(%[[TENSOR_8]] : tensor<256x256xf32>) outs(%[[EMPTY_9]] : tensor<256x256xf32>) permutation = [1, 0]  {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"}
 // CHECK: memref.alloc()

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/04.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/04.mlir
@@ -1,0 +1,72 @@
+// RUN: triton-opt --add-block-id-for-control-ops --data-dependency-analysis --inter-core-transfer-and-sync --mark-main-loop %s | FileCheck %s
+
+module {
+  func.func @tc04_single_v_multi_c(%arg0: memref<128x128xf16>) {
+    %c0 = arith.constant {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    %c128 = arith.constant {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} 128 : index
+    %cst = arith.constant {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} 1.0 : f16
+    scf.for %i = %c0 to %c128 step %c128 {
+      %t0 = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf16>
+      %fill = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : f16) outs(%t0 : tensor<128x128xf16>) -> tensor<128x128xf16>
+      %exp = math.exp %fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf16>
+      %alloc1 = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16>
+      %t1 = bufferization.to_tensor %alloc1 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16>
+      %empty1 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf16>
+      %mat1 = linalg.matmul {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%exp, %t1 : tensor<128x128xf16>, tensor<128x128xf16>) outs(%empty1 : tensor<128x128xf16>) -> tensor<128x128xf16>
+      %alloc2 = memref.alloc() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16>
+      %t2 = bufferization.to_tensor %alloc2 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16>
+      %empty2 = tensor.empty() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf16>
+      %mat2 = linalg.matmul {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} ins(%exp, %t2 : tensor<128x128xf16>, tensor<128x128xf16>) outs(%empty2 : tensor<128x128xf16>) -> tensor<128x128xf16>
+    }
+
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @tc04_single_v_multi_c
+// CHECK: %[[ALLOC:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+// CHECK: annotation.mark %[[ALLOC]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+// CHECK: %[[ALLOC_0:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+// CHECK: annotation.mark %[[ALLOC_0]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+// CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+// CHECK: %[[ALLOC_1:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+// CHECK: annotation.mark %[[ALLOC_1]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+// CHECK: %[[ALLOC_2:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+// CHECK: annotation.mark %[[ALLOC_2]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+// CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+// CHECK: scf.for
+// CHECK: %[[EXP_2:[a-z0-9_]+]] = math.exp
+// CHECK: %[[CST_3:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} dense<[128, 8, 16]> : tensor<3xi64>
+// CHECK: %[[RESHAPE:[a-z0-9_]+]] = tensor.reshape %[[EXP_2]](%[[CST_3]]) {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<128x128xf16>, tensor<3xi64>) -> tensor<128x8x16xf16>
+// CHECK: %[[EMPTY_3:[a-z0-9_]+]] = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8x128x16xf16>
+// CHECK: %[[TRANSPOSED:[a-z0-9_]+]] = linalg.transpose ins(%[[RESHAPE]] : tensor<128x8x16xf16>) outs(%[[EMPTY_3]] : tensor<8x128x16xf16>) permutation = [1, 0, 2]  {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"}
+// CHECK: %[[CST_4:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} dense<[8, 8, 16, 16]> : tensor<4xi64>
+// CHECK: %[[RESHAPE_5:[a-z0-9_]+]] = tensor.reshape %[[TRANSPOSED]](%[[CST_4]]) {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<8x128x16xf16>, tensor<4xi64>) -> tensor<8x8x16x16xf16>
+// CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+// CHECK: hivm.hir.copy ins(%[[RESHAPE_5]] : tensor<8x8x16x16xf16>) outs(%[[ALLOC]] : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32}
+// CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
+// CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+// CHECK: hivm.hir.copy ins(%[[RESHAPE_5]] : tensor<8x8x16x16xf16>) outs(%[[ALLOC_1]] : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32}
+// CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+// CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
+// CHECK: %[[MEM_4:[a-z0-9_]+]] = hivm.hir.convert_layout %[[ALLOC_0]] output_shape [128, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : (memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) -> memref<128x128xf16, #hivm.address_space<cbuf>>
+// CHECK: %[[MEMSPACECAST:[a-z0-9_]+]] = memref.memory_space_cast %[[MEM_4]] {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf16, #hivm.address_space<cbuf>> to memref<128x128xf16>
+// CHECK: %[[TENSOR_5:[a-z0-9_]+]] = bufferization.to_tensor %[[MEMSPACECAST]] restrict writable {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf16>
+// CHECK: memref.alloc()
+// CHECK: %[[TENSOR_6:[a-z0-9_]+]] = bufferization.to_tensor
+// CHECK: %[[TENSOR_7:[a-z0-9_]+]] = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf16>
+// CHECK: linalg.matmul {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%[[TENSOR_5]], %[[TENSOR_6]] : tensor<128x128xf16>, tensor<128x128xf16>) outs(%[[TENSOR_7]] : tensor<128x128xf16>) -> tensor<128x128xf16>
+// CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+// CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+// CHECK: %[[MEM_9:[a-z0-9_]+]] = hivm.hir.convert_layout %[[ALLOC_2]] output_shape [128, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32} : (memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) -> memref<128x128xf16, #hivm.address_space<cbuf>>
+// CHECK: %[[MEMSPACECAST_7:[a-z0-9_]+]] = memref.memory_space_cast %[[MEM_9]] {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32} : memref<128x128xf16, #hivm.address_space<cbuf>> to memref<128x128xf16>
+// CHECK: %[[TENSOR_10:[a-z0-9_]+]] = bufferization.to_tensor %[[MEMSPACECAST_7]] restrict writable {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32} : memref<128x128xf16>
+// CHECK: memref.alloc()
+// CHECK: %[[TENSOR_11:[a-z0-9_]+]] = bufferization.to_tensor
+// CHECK: %[[EMPTY_12:[a-z0-9_]+]] = tensor.empty()
+// CHECK: linalg.matmul {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} ins(%[[TENSOR_10]], %[[TENSOR_11]] : tensor<128x128xf16>, tensor<128x128xf16>) outs(%[[EMPTY_12]] : tensor<128x128xf16>) -> tensor<128x128xf16>
+// CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+// CHECK: } {ssbuffer.block_id = 4 : i32, ssbuffer.main_loop = 0 : i32, ssbuffer.vector_first}
+// CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+// CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+// CHECK: return

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/06.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/06.mlir
@@ -10,7 +10,7 @@ module {
     %exp = math.exp %fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf16>
     %result = scf.for %i = %c0 to %n step %c1 iter_args(%acc = %init) -> (tensor<128x128xf32>) {
       %alloc = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16>
-      %t1 = bufferization.to_tensor %alloc {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16> to tensor<128x128xf16>
+      %t1 = bufferization.to_tensor %alloc {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16>
       %empty = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
       %mm = linalg.matmul {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%exp, %t1 : tensor<128x128xf16>, tensor<128x128xf16>) outs(%empty : tensor<128x128xf32>) -> tensor<128x128xf32>
       scf.yield {ssbuffer.core_type = "CUBE"} %mm : tensor<128x128xf32>
@@ -37,7 +37,7 @@ module {
 // CHECK: annotation.mark %[[ALLOC_3]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
 // CHECK: %[[MEM_4:[a-z0-9_]+]] = hivm.hir.convert_layout %[[ALLOC_3]] output_shape [128, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : (memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) -> memref<128x128xf16, #hivm.address_space<cbuf>>
 // CHECK: %[[MEMSPACECAST:[a-z0-9_]+]] = memref.memory_space_cast %[[MEM_4]] {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf16, #hivm.address_space<cbuf>> to memref<128x128xf16>
-// CHECK: %[[TENSOR_5:[a-z0-9_]+]] = bufferization.to_tensor %[[MEMSPACECAST]] restrict writable {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf16> to tensor<128x128xf16>
+// CHECK: %[[TENSOR_5:[a-z0-9_]+]] = bufferization.to_tensor %[[MEMSPACECAST]] restrict writable {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf16>
 // CHECK: scf.for
 // CHECK: memref.alloc()
 // CHECK: %[[TENSOR_7:[a-z0-9_]+]] = bufferization.to_tensor

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/07.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/07.mlir
@@ -1,0 +1,76 @@
+// RUN: triton-opt --add-block-id-for-control-ops --data-dependency-analysis --inter-core-transfer-and-sync --mark-main-loop %s | FileCheck %s
+
+module {
+  func.func @tc07_nested_forop(%arg0: memref<128x128xf16>, %m: index, %n: index, %init: tensor<128x128xf32>) {
+    %c0 = arith.constant {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    %c1 = arith.constant {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} 1 : index
+    %cst = arith.constant {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} 0.0 : f16
+    %result = scf.for %i = %c0 to %m step %c1 iter_args(%acc1 = %init) -> (tensor<128x128xf32>) {
+      %inner = scf.for %j = %c0 to %n step %c1 iter_args(%acc2 = %acc1) -> (tensor<128x128xf32>) {
+        %alloc = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf16>
+        %t0 = bufferization.to_tensor %alloc {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf16>
+        %fill = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : f16) outs(%t0 : tensor<128x128xf16>) -> tensor<128x128xf16>
+        %exp = math.exp %fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf16>
+        %alloc2 = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16>
+        %t1 = bufferization.to_tensor %alloc2 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16>
+        %empty = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+        %mm = linalg.matmul {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%exp, %t1 : tensor<128x128xf16>, tensor<128x128xf16>) outs(%empty : tensor<128x128xf32>) -> tensor<128x128xf32>
+        scf.yield {ssbuffer.core_type = "CUBE"} %mm : tensor<128x128xf32>
+      } {ssbuffer.core_type = "CUBE"}
+      %exp2 = math.exp %inner {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
+      scf.yield {ssbuffer.core_type = "VECTOR"} %exp2 : tensor<128x128xf32>
+    } {ssbuffer.core_type = "VECTOR"}
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @tc07_nested_forop
+// CHECK: %[[ALLOC:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+// CHECK: annotation.mark %[[ALLOC]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+// CHECK: %[[ALLOC_0:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+// CHECK: annotation.mark %[[ALLOC_0]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+// CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 2
+// CHECK: scf.for
+// CHECK: %[[ALLOC_1:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+// CHECK: annotation.mark %[[ALLOC_1]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+// CHECK: %[[ALLOC_2:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+// CHECK: annotation.mark %[[ALLOC_2]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+// CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+// CHECK: %[[FOR_1:[a-z0-9_]+]] = scf.for
+// CHECK: memref.alloc()
+// CHECK: bufferization.to_tensor
+// CHECK: %[[FILL_5:[a-z0-9_]+]] = linalg.fill
+// CHECK: %[[EXP_6:[a-z0-9_]+]] = math.exp %[[FILL_5]] {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf16>
+// CHECK: %[[CST_4:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} dense<[128, 8, 16]> : tensor<3xi64>
+// CHECK: %[[RESHAPE:[a-z0-9_]+]] = tensor.reshape %[[EXP_6]](%[[CST_4]]) {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<128x128xf16>, tensor<3xi64>) -> tensor<128x8x16xf16>
+// CHECK: %[[EMPTY_7:[a-z0-9_]+]] = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8x128x16xf16>
+// CHECK: %[[TRANSPOSED:[a-z0-9_]+]] = linalg.transpose ins(%[[RESHAPE]] : tensor<128x8x16xf16>) outs(%[[EMPTY_7]] : tensor<8x128x16xf16>) permutation = [1, 0, 2]  {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"}
+// CHECK: %[[CST_5:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} dense<[8, 8, 16, 16]> : tensor<4xi64>
+// CHECK: %[[RESHAPE_6:[a-z0-9_]+]] = tensor.reshape %[[TRANSPOSED]](%[[CST_5]]) {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<8x128x16xf16>, tensor<4xi64>) -> tensor<8x8x16x16xf16>
+// CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+// CHECK: hivm.hir.copy ins(%[[RESHAPE_6]] : tensor<8x8x16x16xf16>) outs(%[[ALLOC_1]] : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32}
+// CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
+// CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
+// CHECK: %[[MEM_8:[a-z0-9_]+]] = hivm.hir.convert_layout %[[ALLOC_2]] output_shape [128, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : (memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) -> memref<128x128xf16, #hivm.address_space<cbuf>>
+// CHECK: %[[MEMSPACECAST_7:[a-z0-9_]+]] = memref.memory_space_cast %[[MEM_8]] {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf16, #hivm.address_space<cbuf>> to memref<128x128xf16>
+// CHECK: %[[TENSOR_9:[a-z0-9_]+]] = bufferization.to_tensor %[[MEMSPACECAST_7]] restrict writable {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf16>
+// CHECK: memref.alloc()
+// CHECK: %[[TENSOR_10:[a-z0-9_]+]] = bufferization.to_tensor
+// CHECK: %[[EMPTY_11:[a-z0-9_]+]] = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+// CHECK: linalg.matmul {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%[[TENSOR_9]], %[[TENSOR_10]] : tensor<128x128xf16>, tensor<128x128xf16>) outs(%[[EMPTY_11]] : tensor<128x128xf32>) -> tensor<128x128xf32>
+// CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+// CHECK: scf.yield
+// CHECK: } {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE", ssbuffer.main_loop = 0 : i32, ssbuffer.vector_first}
+// CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+// CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_V>, <PIPE_FIX>] flag = 2
+// CHECK: hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32} ins(%[[FOR_1]] : tensor<128x128xf32>) outs(%[[ALLOC]] : memref<128x128xf32, #hivm.address_space<ub>>)
+// CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_FIX>, <PIPE_V>] flag = 2
+// CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 2
+// CHECK: %[[MEMSPACECAST:[a-z0-9_]+]] = memref.memory_space_cast %[[ALLOC_0]] {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>> to memref<128x128xf32>
+// CHECK: %[[TENSOR_13:[a-z0-9_]+]] = bufferization.to_tensor %[[MEMSPACECAST]] restrict writable {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32>
+// CHECK: math.exp %[[TENSOR_13]] {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
+// CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 2
+// CHECK: scf.yield
+// CHECK: } {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"}
+// CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_V>, <PIPE_FIX>] flag = 2
+// CHECK: return

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/08.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/08.mlir
@@ -5,11 +5,11 @@ module {
     %cst = arith.constant {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "CUBE"} 0.0 : f16
     %result = scf.if %cond -> (tensor<128x128xf32>) {
       %alloc = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf16>
-      %t0 = bufferization.to_tensor %alloc {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf16> to tensor<128x128xf16>
+      %t0 = bufferization.to_tensor %alloc {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf16>
       %fill = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : f16) outs(%t0 : tensor<128x128xf16>) -> tensor<128x128xf16>
       %exp = math.exp %fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf16>
       %alloc2 = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16>
-      %t1 = bufferization.to_tensor %alloc2 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16> to tensor<128x128xf16>
+      %t1 = bufferization.to_tensor %alloc2 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16>
       %empty = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
       %mm = linalg.matmul {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%exp, %t1 : tensor<128x128xf16>, tensor<128x128xf16>) outs(%empty : tensor<128x128xf32>) -> tensor<128x128xf32>
       scf.yield {ssbuffer.core_type = "CUBE"} %mm : tensor<128x128xf32>
@@ -25,7 +25,7 @@ module {
 // CHECK: %cst = arith.constant {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f16
 // CHECK: %0 = scf.if %arg0 -> (tensor<128x128xf32>) {
 // CHECK: %alloc = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf16>
-// CHECK: %1 = bufferization.to_tensor %alloc {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf16> to tensor<128x128xf16>
+// CHECK: %1 = bufferization.to_tensor %alloc {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf16>
 // CHECK: %2 = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : f16) outs(%1 : tensor<128x128xf16>) -> tensor<128x128xf16>
 // CHECK: %3 = math.exp %2 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf16>
 // CHECK: %cst_0 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} dense<[128, 8, 16]> : tensor<3xi64>
@@ -43,9 +43,9 @@ module {
 // CHECK: annotation.mark %alloc_4 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
 // CHECK: %5 = hivm.hir.convert_layout %alloc_4 output_shape [128, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : (memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) -> memref<128x128xf16, #hivm.address_space<cbuf>>
 // CHECK: %memspacecast = memref.memory_space_cast %5 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf16, #hivm.address_space<cbuf>> to memref<128x128xf16>
-// CHECK: %6 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf16> to tensor<128x128xf16>
+// CHECK: %6 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf16>
 // CHECK: %alloc_5 = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16>
-// CHECK: %7 = bufferization.to_tensor %alloc_5 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16> to tensor<128x128xf16>
+// CHECK: %7 = bufferization.to_tensor %alloc_5 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16>
 // CHECK: %8 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
 // CHECK: %9 = linalg.matmul {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%6, %7 : tensor<128x128xf16>, tensor<128x128xf16>) outs(%8 : tensor<128x128xf32>) -> tensor<128x128xf32>
 // CHECK: scf.yield {ssbuffer.core_type = "CUBE"} %9 : tensor<128x128xf32>

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/09.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/09.mlir
@@ -8,7 +8,7 @@ module {
 
     %result:2 = scf.for %i = %c0 to %n step %c1 iter_args(%acc1 = %init1, %acc2 = %init2) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
       %alloc = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16>
-      %t0 = bufferization.to_tensor %alloc {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16> to tensor<128x128xf16>
+      %t0 = bufferization.to_tensor %alloc {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16>
       %mm1 = linalg.matmul {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%t0, %t0 : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc1 : tensor<128x128xf32>) -> tensor<128x128xf32>
       %mm2 = linalg.matmul {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%t0, %t0 : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc2 : tensor<128x128xf32>) -> tensor<128x128xf32>
       scf.yield {ssbuffer.core_type = "CUBE, CUBE"} %mm1, %mm2 : tensor<128x128xf32>, tensor<128x128xf32>
@@ -25,7 +25,7 @@ module {
 // CHECK: %cst = arith.constant {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f16
 // CHECK: %0:2 = scf.for %arg4 = %c0 to %arg1 step %c1 iter_args(%arg5 = %arg2, %arg6 = %arg3) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
 // CHECK: %alloc_4 = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16>
-// CHECK: %4 = bufferization.to_tensor %alloc_4 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16> to tensor<128x128xf16>
+// CHECK: %4 = bufferization.to_tensor %alloc_4 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16>
 // CHECK: %5 = linalg.matmul {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%4, %4 : tensor<128x128xf16>, tensor<128x128xf16>) outs(%arg5 : tensor<128x128xf32>) -> tensor<128x128xf32>
 // CHECK: %6 = linalg.matmul {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%4, %4 : tensor<128x128xf16>, tensor<128x128xf16>) outs(%arg6 : tensor<128x128xf32>) -> tensor<128x128xf32>
 // CHECK: scf.yield {ssbuffer.core_type = "CUBE, CUBE"} %5, %6 : tensor<128x128xf32>, tensor<128x128xf32>
@@ -42,11 +42,11 @@ module {
 // CHECK: %alloc_1 = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
 // CHECK: annotation.mark %alloc_1 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
 // CHECK: %memspacecast = memref.memory_space_cast %alloc_1 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>> to memref<128x128xf32>
-// CHECK: %1 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32> to tensor<128x128xf32>
+// CHECK: %1 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32>
 // CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 1
 // CHECK: %alloc_2 = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
 // CHECK: annotation.mark %alloc_2 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
 // CHECK: %memspacecast_3 = memref.memory_space_cast %alloc_2 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32, #hivm.address_space<ub>> to memref<128x128xf32>
-// CHECK: %2 = bufferization.to_tensor %memspacecast_3 restrict writable {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32> to tensor<128x128xf32>
+// CHECK: %2 = bufferization.to_tensor %memspacecast_3 restrict writable {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32>
 // CHECK: %3 = arith.addf %2, %1 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
 // CHECK: return

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/11.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/11.mlir
@@ -9,8 +9,7 @@ module {
     %cst = arith.constant {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} 1.0 : f32
 
     %alloc = memref.alloc() {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32>
-    %t0 = bufferization.to_tensor %alloc {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32> to tensor<128x128xf32>
-
+    %t0 = bufferization.to_tensor %alloc {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32>
     %fill = linalg.fill {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : f32) outs(%t0 : tensor<128x128xf32>) -> tensor<128x128xf32>
 
     %add = arith.addf %fill, %fill {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/12.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/12.mlir
@@ -9,7 +9,7 @@ module {
     %cst = arith.constant {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "CUBE"} 0.0 : f16
 
     %alloc = memref.alloc() {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16>
-    %t0 = bufferization.to_tensor %alloc {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16> to tensor<128x128xf16>
+    %t0 = bufferization.to_tensor %alloc {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf16>
 
     %empty = tensor.empty() {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf16>
     %fill = linalg.fill {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : f16) outs(%empty : tensor<128x128xf16>) -> tensor<128x128xf16>

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/16.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/16.mlir
@@ -4,16 +4,16 @@ module {
   func.func @tc16_chained_matmul(%arg0: memref<128x64xf16>, %arg1: memref<64x128xf16>, %arg2: memref<128x64xf16>, %arg3: memref<64x128xf16>) {
     %cst = arith.constant {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "CUBE"} 0.0 : f16
     %alloc_a = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<128x64xf16>
-    %t_a = bufferization.to_tensor %alloc_a {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<128x64xf16> to tensor<128x64xf16>
+    %t_a = bufferization.to_tensor %alloc_a {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<128x64xf16>
     %alloc_b = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<64x128xf16>
-    %t_b = bufferization.to_tensor %alloc_b {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<64x128xf16> to tensor<64x128xf16>
+    %t_b = bufferization.to_tensor %alloc_b {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<64x128xf16>
     %empty = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
     %fill = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : f16) outs(%empty : tensor<128x128xf32>) -> tensor<128x128xf32>
     %mm1 = linalg.matmul {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%t_a, %t_b : tensor<128x64xf16>, tensor<64x128xf16>) outs(%fill : tensor<128x128xf32>) -> tensor<128x128xf32>
     %alloc_c = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x64xf16>
-    %t_c = bufferization.to_tensor %alloc_c {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x64xf16> to tensor<128x64xf16>
+    %t_c = bufferization.to_tensor %alloc_c {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x64xf16>
     %alloc_d = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<64x128xf16>
-    %t_d = bufferization.to_tensor %alloc_d {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<64x128xf16> to tensor<64x128xf16>
+    %t_d = bufferization.to_tensor %alloc_d {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<64x128xf16>
     %mm2 = linalg.matmul {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%t_c, %t_d : tensor<128x64xf16>, tensor<64x128xf16>) outs(%mm1 : tensor<128x128xf32>) -> tensor<128x128xf32>
     %add = arith.addf %mm1, %mm2 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
     return
@@ -23,9 +23,9 @@ module {
 // CHECK-LABEL: func.func @tc16_chained_matmul
 // CHECK: %cst = arith.constant {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f16
 // CHECK: %alloc = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<128x64xf16>
-// CHECK: %0 = bufferization.to_tensor %alloc {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<128x64xf16> to tensor<128x64xf16>
+// CHECK: %0 = bufferization.to_tensor %alloc {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<128x64xf16>
 // CHECK: %alloc_0 = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<64x128xf16>
-// CHECK: %1 = bufferization.to_tensor %alloc_0 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<64x128xf16> to tensor<64x128xf16>
+// CHECK: %1 = bufferization.to_tensor %alloc_0 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<64x128xf16>
 // CHECK: %2 = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
 // CHECK: %3 = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : f16) outs(%2 : tensor<128x128xf32>) -> tensor<128x128xf32>
 // CHECK: %4 = linalg.matmul {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%0, %1 : tensor<128x64xf16>, tensor<64x128xf16>) outs(%3 : tensor<128x128xf32>) -> tensor<128x128xf32>
@@ -34,9 +34,9 @@ module {
 // CHECK: hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32} ins(%4 : tensor<128x128xf32>) outs(%alloc_1 : memref<128x128xf32, #hivm.address_space<ub>>)
 // CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_FIX>, <PIPE_V>] flag = 2
 // CHECK: %alloc_2 = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x64xf16>
-// CHECK: %5 = bufferization.to_tensor %alloc_2 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x64xf16> to tensor<128x64xf16>
+// CHECK: %5 = bufferization.to_tensor %alloc_2 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x64xf16>
 // CHECK: %alloc_3 = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<64x128xf16>
-// CHECK: %6 = bufferization.to_tensor %alloc_3 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<64x128xf16> to tensor<64x128xf16>
+// CHECK: %6 = bufferization.to_tensor %alloc_3 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<64x128xf16>
 // CHECK: %7 = linalg.matmul {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%5, %6 : tensor<128x64xf16>, tensor<64x128xf16>) outs(%4 : tensor<128x128xf32>) -> tensor<128x128xf32>
 // CHECK: %alloc_4 = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
 // CHECK: annotation.mark %alloc_4 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
@@ -46,11 +46,11 @@ module {
 // CHECK: %alloc_5 = memref.alloc() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
 // CHECK: annotation.mark %alloc_5 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
 // CHECK: %memspacecast = memref.memory_space_cast %alloc_5 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>> to memref<128x128xf32>
-// CHECK: %8 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32> to tensor<128x128xf32>
+// CHECK: %8 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32>
 // CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 1
 // CHECK: %alloc_6 = memref.alloc() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
 // CHECK: annotation.mark %alloc_6 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
 // CHECK: %memspacecast_7 = memref.memory_space_cast %alloc_6 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32, #hivm.address_space<ub>> to memref<128x128xf32>
-// CHECK: %9 = bufferization.to_tensor %memspacecast_7 restrict writable {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32> to tensor<128x128xf32>
+// CHECK: %9 = bufferization.to_tensor %memspacecast_7 restrict writable {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32>
 // CHECK: %10 = arith.addf %8, %9 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
 // CHECK: return

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/17.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/17.mlir
@@ -8,7 +8,7 @@ module {
     %fill = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : f16) outs(%t0 : tensor<100x64xf16>) -> tensor<100x64xf16>
     %exp = math.exp %fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<100x64xf16>
     %alloc = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xf16>
-    %t1 = bufferization.to_tensor %alloc {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xf16> to tensor<64x64xf16>
+    %t1 = bufferization.to_tensor %alloc {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xf16>
     %empty = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<100x64xf32>
     %cst_cube = arith.constant {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} 0.0 : f16
     %init = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_cube : f16) outs(%empty : tensor<100x64xf32>) -> tensor<100x64xf32>
@@ -42,9 +42,9 @@ module {
     // CHECK: annotation.mark %alloc_5 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<4x7x16x16xf16, #hivm.address_space<cbuf>>
     // CHECK: %6 = hivm.hir.convert_layout %alloc_5 output_shape [112, 64] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : (memref<4x7x16x16xf16, #hivm.address_space<cbuf>>) -> memref<112x64xf16, #hivm.address_space<cbuf>>
     // CHECK: %memspacecast = memref.memory_space_cast %6 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<112x64xf16, #hivm.address_space<cbuf>> to memref<112x64xf16>
-    // CHECK: %7 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<112x64xf16> to tensor<112x64xf16>
+    // CHECK: %7 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<112x64xf16>
     // CHECK: %alloc_6 = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xf16>
-    // CHECK: %8 = bufferization.to_tensor %alloc_6 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xf16> to tensor<64x64xf16>
+    // CHECK: %8 = bufferization.to_tensor %alloc_6 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xf16>
     // CHECK: %9 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<100x64xf32>
     // CHECK: %cst_7 = arith.constant {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f16
     // CHECK: %10 = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_7 : f16) outs(%9 : tensor<100x64xf32>) -> tensor<100x64xf32>


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
