### PR TITLE
fix(ssbuffer): add volatile attr for load/store ssbufferspace

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
@@ -83,8 +83,8 @@ SmallVector<SmallVector<Value>> UpdateConditionInfoPass::allocSSBuffer(ModuleOp 
         auto ptr0 = builder.create<mlir::LLVM::IntToPtrOp>(scopeOp->getLoc(), ptrType, addr0Const.getResult());
         auto ptr1 = builder.create<mlir::LLVM::IntToPtrOp>(scopeOp->getLoc(), ptrType, addr1Const.getResult());
 
-        builder.create<LLVM::StoreOp>(scopeOp->getLoc(), zeroConst, ptr0);
-        builder.create<LLVM::StoreOp>(scopeOp->getLoc(), zeroConst, ptr1);
+        builder.create<LLVM::StoreOp>(scopeOp->getLoc(), zeroConst, ptr0, 0, /*volatile=*/true);
+        builder.create<LLVM::StoreOp>(scopeOp->getLoc(), zeroConst, ptr1, 0, /*volatile=*/true);
 
         ssbufferVec0Ptrs.push_back(ptr0.getResult());
         ssbufferVec1Ptrs.push_back(ptr1.getResult());
@@ -544,15 +544,15 @@ Value UpdateConditionInfoPass::addCrossCoreConditions(
     Value cond = nullptr;
     if (isAIC) {
       Value vec0Value = builder.create<LLVM::LoadOp>(loc, builder.getI32Type(),
-          getSSBufferPtr(isAIC, inputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs));
+          getSSBufferPtr(isAIC, inputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs), 0, /*volatile=*/true);
       Value vec1Value = builder.create<LLVM::LoadOp>(loc, builder.getI32Type(),
-          getSSBufferPtr(isAIC, inputGroupIdx, 1, VectorSSBufferPtrs, ssbufferPtrs));
+          getSSBufferPtr(isAIC, inputGroupIdx, 1, VectorSSBufferPtrs, ssbufferPtrs), 0, /*volatile=*/true);
       Value vec0Cond = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sgt, vec0Value, zeroConst);
       Value vec1Cond = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sgt, vec1Value, zeroConst);
       cond = builder.create<arith::AndIOp>(loc, vec0Cond, vec1Cond);
     } else {
       Value value = builder.create<LLVM::LoadOp>(loc, builder.getI32Type(),
-          getSSBufferPtr(isAIC, inputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs));
+          getSSBufferPtr(isAIC, inputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs), 0, /*volatile=*/true);
       cond = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sgt, value, zeroConst);
     }
     combineCondition(cond);
@@ -567,15 +567,15 @@ Value UpdateConditionInfoPass::addCrossCoreConditions(
     Value cond = nullptr;
     if (isAIC) {
       Value vec0Value = builder.create<LLVM::LoadOp>(loc, builder.getI32Type(),
-          getSSBufferPtr(isAIC, outputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs));
+          getSSBufferPtr(isAIC, outputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs), 0, /*volatile=*/true);
       Value vec1Value = builder.create<LLVM::LoadOp>(loc, builder.getI32Type(),
-          getSSBufferPtr(isAIC, outputGroupIdx, 1, VectorSSBufferPtrs, ssbufferPtrs));
+          getSSBufferPtr(isAIC, outputGroupIdx, 1, VectorSSBufferPtrs, ssbufferPtrs), 0, /*volatile=*/true);
       Value vec0Cond = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt, vec0Value, bufferNum);
       Value vec1Cond = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt, vec1Value, bufferNum);
       cond = builder.create<arith::AndIOp>(loc, vec0Cond, vec1Cond);
     } else {
       Value value = builder.create<LLVM::LoadOp>(loc, builder.getI32Type(),
-          getSSBufferPtr(isAIC, outputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs));
+          getSSBufferPtr(isAIC, outputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs), 0, /*volatile=*/true);
       cond = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt, value, bufferNum);
     }
     combineCondition(cond);
@@ -600,42 +600,42 @@ void UpdateConditionInfoPass::updateCrossCoreControlVars(
   for (int inputGroupIdx : crossCoreInputValues) {
     if (isAIC) {
       Value vec0Value = builder.create<LLVM::LoadOp>(loc, builder.getI32Type(),
-          getSSBufferPtr(isAIC, inputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs));
+          getSSBufferPtr(isAIC, inputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs), 0, /*volatile=*/true);
       Value vec1Value = builder.create<LLVM::LoadOp>(loc, builder.getI32Type(),
-          getSSBufferPtr(isAIC, inputGroupIdx, 1, VectorSSBufferPtrs, ssbufferPtrs));
+          getSSBufferPtr(isAIC, inputGroupIdx, 1, VectorSSBufferPtrs, ssbufferPtrs), 0, /*volatile=*/true);
       Value vec0NewValue = builder.create<arith::SubIOp>(loc, vec0Value, oneConst);
       Value vec1NewValue = builder.create<arith::SubIOp>(loc, vec1Value, oneConst);
       builder.create<LLVM::StoreOp>(loc, vec0NewValue,
-          getSSBufferPtr(isAIC, inputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs));
+          getSSBufferPtr(isAIC, inputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs), 0, /*volatile=*/true);
       builder.create<LLVM::StoreOp>(loc, vec1NewValue,
-          getSSBufferPtr(isAIC, inputGroupIdx, 1, VectorSSBufferPtrs, ssbufferPtrs));
+          getSSBufferPtr(isAIC, inputGroupIdx, 1, VectorSSBufferPtrs, ssbufferPtrs), 0, /*volatile=*/true);
     } else {
       Value value = builder.create<LLVM::LoadOp>(loc, builder.getI32Type(),
-          getSSBufferPtr(isAIC, inputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs));
+          getSSBufferPtr(isAIC, inputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs), 0, /*volatile=*/true);
       Value newValue = builder.create<arith::SubIOp>(loc, value, oneConst);
       builder.create<LLVM::StoreOp>(loc, newValue,
-          getSSBufferPtr(isAIC, inputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs));
+          getSSBufferPtr(isAIC, inputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs), 0, /*volatile=*/true);
     }
   }
 
   for (int outputGroupIdx : crossCoreOutputValues) {
     if (isAIC) {
       Value vec0Value = builder.create<LLVM::LoadOp>(loc, builder.getI32Type(),
-          getSSBufferPtr(isAIC, outputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs));
+          getSSBufferPtr(isAIC, outputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs), 0, /*volatile=*/true);
       Value vec1Value = builder.create<LLVM::LoadOp>(loc, builder.getI32Type(),
-          getSSBufferPtr(isAIC, outputGroupIdx, 1, VectorSSBufferPtrs, ssbufferPtrs));
+          getSSBufferPtr(isAIC, outputGroupIdx, 1, VectorSSBufferPtrs, ssbufferPtrs), 0, /*volatile=*/true);
       Value vec0NewValue = builder.create<arith::AddIOp>(loc, vec0Value, oneConst);
       Value vec1NewValue = builder.create<arith::AddIOp>(loc, vec1Value, oneConst);
       builder.create<LLVM::StoreOp>(loc, vec0NewValue,
-          getSSBufferPtr(isAIC, outputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs));
+          getSSBufferPtr(isAIC, outputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs), 0, /*volatile=*/true);
       builder.create<LLVM::StoreOp>(loc, vec1NewValue,
-          getSSBufferPtr(isAIC, outputGroupIdx, 1, VectorSSBufferPtrs, ssbufferPtrs));
+          getSSBufferPtr(isAIC, outputGroupIdx, 1, VectorSSBufferPtrs, ssbufferPtrs), 0, /*volatile=*/true);
     } else {
       Value value = builder.create<LLVM::LoadOp>(loc, builder.getI32Type(),
-          getSSBufferPtr(isAIC, outputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs));
+          getSSBufferPtr(isAIC, outputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs), 0, /*volatile=*/true);
       Value newValue = builder.create<arith::AddIOp>(loc, value, oneConst);
       builder.create<LLVM::StoreOp>(loc, newValue,
-          getSSBufferPtr(isAIC, outputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs));
+          getSSBufferPtr(isAIC, outputGroupIdx, 0, VectorSSBufferPtrs, ssbufferPtrs), 0, /*volatile=*/true);
     }
   }
 }


### PR DESCRIPTION
fix(ssbuffer): add volatile attr for load/store ssbufferspace

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
