### PR TITLE
feat(autotune): make compile_mode a tunable parameter

### DIFF
--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -111,10 +111,11 @@ class AutoTilingTuner(Autotuner):
             self.user_configs = []
         else:
             self.user_configs = configs
-        self.is_simt_mode = False
         self.simt_stack_limit = 8192
         self.user_specified_warps = None
         self.user_specified_multibuffer = None
+        self.user_specified_compile_mode = None
+        self.user_specified_simt_stack_limit = None
         self.default_multibuffer = not is_compile_on_910_95
         self.print_autotuning = os.getenv("TRITON_PRINT_AUTOTUNING", None) == "1"
         # Compile kernels in parallel by default for triton.runtime.JITFunction,
@@ -277,7 +278,8 @@ class AutoTilingTuner(Autotuner):
                              f"These arguments must be explicitly provided and cannot be automatically tuned. "
                              f"Please ensure that these arguments are passed when calling the function.")
 
-    def _gen_tile_configs(self, kv_dict: Dict[str, int], dtype: torch.dtype) -> List[Config]:
+    def _gen_tile_configs(self, kv_dict: Dict[str, int], dtype: torch.dtype,
+                          candidate_modes: List[str]) -> List[Config]:
         from .tile_generator import KernelMeta, TileGenerator
 
         axis_sizes = {}
@@ -288,38 +290,57 @@ class AutoTilingTuner(Autotuner):
                 raise ValueError(f"Not supported dim type: {type(v)}, `int` is the only supported type")
             axis_sizes[k] = v
 
-        kernel_meta = KernelMeta(
-            axis_sizes,
-            self.split_params,
-            self.fixed_split_params,
-            self.tiling_params,
-            self.low_dim_axes,
-            dtype,
-            self.persistent_reduction,
-            self.dual_reduction,
-            self.num_buffers,
-            self.is_simt_mode,
-        )
-        tile_gen = TileGenerator(kernel_meta=kernel_meta)
-        tile_gen.descend_split_tiling()
-
         self.gen_configs.clear()
-        self.gen_configs = tile_gen.configs
+        all_configs = []
+        for mode in candidate_modes:
+            is_simt_mode = (mode == 'simt_only')
+            kernel_meta = KernelMeta(
+                axis_sizes,
+                self.split_params,
+                self.fixed_split_params,
+                self.tiling_params,
+                self.low_dim_axes,
+                dtype,
+                self.persistent_reduction,
+                self.dual_reduction,
+                self.num_buffers,
+                is_simt_mode,
+            )
+            tile_gen = TileGenerator(kernel_meta=kernel_meta)
+            tile_gen.descend_split_tiling()
+            mode_configs = tile_gen.configs
 
-        if self.is_simt_mode:
-            self.gen_configs = self._expand_simt_num_warps_configs(self.gen_configs)
-        else:
-            self.gen_configs = self._expand_simd_multibuffer_configs(self.gen_configs)
+            if is_simt_mode:
+                mode_configs = self._expand_simt_num_warps_configs(mode_configs)
+            else:
+                mode_configs = self._expand_simd_multibuffer_configs(mode_configs)
+
+            # Tag each config with compile_mode so it flows to NPUOptions via
+            # JITFunction.run kwargs. SIMT configs also carry simt_stack_limit:
+            # the user's call-site value if supplied, else the default. It is
+            # marked autotune-managed in _make_kernel_call so a call-site value
+            # does not collide with the per-config tag.
+            simt_stack_limit = (self.user_specified_simt_stack_limit
+                                if self.user_specified_simt_stack_limit is not None else self.simt_stack_limit)
+            for cfg in mode_configs:
+                cfg.kwargs['compile_mode'] = mode
+                if is_simt_mode and 'simt_stack_limit' not in cfg.kwargs:
+                    cfg.kwargs['simt_stack_limit'] = simt_stack_limit
+
+            all_configs.extend(mode_configs)
+
+        self.gen_configs = all_configs
 
         if len(self.gen_configs) == 0:
             print("[WARNING] The generated candidate tiling configs are empty based on provided parameters!")
 
         if self.print_autotuning:
-            print("Generated configs number: {}".format(len(self.gen_configs)))
+            print(f"Generated configs number: {len(self.gen_configs)} "
+                  f"(across modes: {candidate_modes})")
 
     def generate_key_and_configs(self, *args, **kwargs):
         self.nargs = dict(zip(self.arg_names, args))
-        self.is_simt_mode = kwargs.get('force_simt_only', False)
+
         if 'num_warps' in kwargs and kwargs['num_warps'] is not None:
             self.user_specified_warps = kwargs['num_warps']
         else:
@@ -328,6 +349,25 @@ class AutoTilingTuner(Autotuner):
             self.user_specified_multibuffer = kwargs['multibuffer']
         else:
             self.user_specified_multibuffer = None
+        if 'simt_stack_limit' in kwargs and kwargs['simt_stack_limit'] is not None:
+            self.user_specified_simt_stack_limit = kwargs['simt_stack_limit']
+        else:
+            self.user_specified_simt_stack_limit = None
+
+        # Determine the candidate set of compile_mode values to autotune over.
+        # `force_simt_only=True` is treated as an alias for `compile_mode='simt_only'`
+        # for backward compatibility.
+        user_compile_mode = kwargs.get('compile_mode')
+        if user_compile_mode is None and kwargs.get('force_simt_only', False):
+            user_compile_mode = 'simt_only'
+        self.user_specified_compile_mode = user_compile_mode
+
+        if user_compile_mode is not None:
+            candidate_modes = [user_compile_mode]
+        elif is_compile_on_910_95:
+            candidate_modes = ['simd', 'simt_only']
+        else:
+            candidate_modes = ['simd']
 
         # generate key
         all_args = {**self.nargs, **kwargs}
@@ -343,33 +383,24 @@ class AutoTilingTuner(Autotuner):
         if dtype is None:
             raise NotImplementedError("Not support for non-Tensor inputs")
 
+        # The cache key encodes the search-space scope: "auto" means autotune
+        # explored both modes, while a specific mode means the user pinned it.
+        # This prevents cross-contamination between user-pinned and full-search runs.
+        key.append(("compile_mode_constraint", user_compile_mode or "auto"))
         key = tuple(key)
         if key not in self.cache:
             if self.auto_gen_config:
                 self._autoparse_axis_params(all_args)
                 _kv_dict = {k: _args[v] for k, v in self.keys.items() if v in _args}
-                self._gen_tile_configs(_kv_dict, dtype)
+                self._gen_tile_configs(_kv_dict, dtype, candidate_modes)
             if len(self.gen_configs) == 0 and len(self.user_configs) == 0:
-                self.configs = [
-                    Config(
-                        {},
-                        num_warps=4,
-                        num_stages=2,
-                        num_ctas=1,
-                        num_buffers_warp_spec=0,
-                        num_consumer_groups=0,
-                        reg_dec_producer=0,
-                        reg_inc_consumer=0,
-                    )
-                ]
+                self.configs = [Config({}, num_warps=4, num_stages=2, num_ctas=1)]
             else:
                 self.configs = self.gen_configs + self.user_configs
         return key
 
     def run(self, *args, **kwargs):
         key = self.generate_key_and_configs(*args, **kwargs)
-        if self.is_simt_mode and kwargs.get('simt_stack_limit', None) is None:
-            kwargs['simt_stack_limit'] = self.simt_stack_limit
         used_cached_result = True
         if key not in self.cache:
             # prune configs
@@ -400,7 +431,10 @@ class AutoTilingTuner(Autotuner):
         if config.pre_hook is not None:
             full_nargs = {**self.nargs, **kwargs, **config.all_kwargs()}
             config.pre_hook(full_nargs)
-        final_kwargs = dict(config.all_kwargs(), **kwargs)
+        # config wins on overlapping keys (mirrors _make_kernel_call's precedence):
+        # an explicit compile_mode in a user_config beats a call-site pin, and a
+        # per-config tag from _gen_tile_configs flows through unchanged.
+        final_kwargs = dict(kwargs, **config.all_kwargs())
         ret = self.fn.run(
             *args,
             **final_kwargs,
@@ -473,12 +507,17 @@ class AutoTilingTuner(Autotuner):
 
     def _make_kernel_call(self, *args, config, **meta):
         # check for conflicts, i.e. meta-parameters both provided
-        # as kwargs and by the autotuner
-        conflicts = meta.keys() & config.kwargs.keys()
+        # as kwargs and by the autotuner. compile_mode, force_simt_only and
+        # simt_stack_limit are deliberately co-managed by the autotuner (it
+        # tags each Config with these for multi-mode tuning), so collisions
+        # on those keys are expected and resolved by Config.kwargs winning.
+        autotune_managed = {'compile_mode', 'force_simt_only', 'simt_stack_limit'}
+        conflicts = (meta.keys() & config.kwargs.keys()) - autotune_managed
         if conflicts:
             raise ValueError(f"Conflicting meta-parameters: {', '.join(conflicts)}."
                              " Make sure that you don't re-define auto-tuned symbols.")
-        # augment meta-parameters with tunable ones
+        # augment meta-parameters with tunable ones (config.kwargs wins on
+        # autotune_managed keys via the second-position in dict()).
         current = dict(meta, **config.all_kwargs())
         full_nargs = {**self.nargs, **current}
 
@@ -518,10 +557,15 @@ class AutoTilingTuner(Autotuner):
                     triton.AsyncCompileMode(executor),
             ):
                 for config in pruned_configs:
-                    ret.append(self.fn.warmup(*args, **kwargs, **config.all_kwargs()))
+                    # Pre-merge so config wins on overlapping keys (e.g.
+                    # compile_mode); a direct **kwargs/**config.all_kwargs()
+                    # double-unpack would raise on duplicate keys.
+                    merged = dict(kwargs, **config.all_kwargs())
+                    ret.append(self.fn.warmup(*args, **merged))
         else:
             for config in pruned_configs:
-                ret.append(self.fn.warmup(*args, **kwargs, **config.all_kwargs()))
+                merged = dict(kwargs, **config.all_kwargs())
+                ret.append(self.fn.warmup(*args, **merged))
         self.nargs = None
         return ret
 
@@ -1080,9 +1124,7 @@ def get_max_configs(config, kernel_type="mixcv", **kwargs):
 
         new_config = Config(kwargs=new_kwargs, num_warps=config.num_warps,
                             num_stages=num_stages_val if num_stages_val is not None else config.num_stages,
-                            num_ctas=config.num_ctas, num_buffers_warp_spec=config.num_buffers_warp_spec,
-                            num_consumer_groups=config.num_consumer_groups, reg_dec_producer=config.reg_dec_producer,
-                            reg_inc_consumer=config.reg_inc_consumer, maxnreg=config.maxnreg, pre_hook=config.pre_hook)
+                            num_ctas=config.num_ctas, maxnreg=config.maxnreg, pre_hook=config.pre_hook)
         new_configs.append(new_config)
 
     return new_configs

--- a/third_party/ascend/unittest/autotune_ut/test_compile_mode_tunable.py
+++ b/third_party/ascend/unittest/autotune_ut/test_compile_mode_tunable.py
@@ -1,0 +1,352 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+Tests for compile_mode as a tunable autotune parameter.
+
+Three scenarios for how the user supplies compile_mode:
+  1. Not specified anywhere -> autotune explores both 'simd' and 'simt_only'
+     candidate modes (on 910_95 hardware), each tagged on the generated configs.
+  2. Specified in @triton.autotune Config kwargs -> the user-supplied configs
+     come through with their declared compile_mode; the autotuner also adds
+     auto-generated configs spanning both modes (since the call site has no
+     compile_mode).
+  3. Specified at the kernel call site (kernel[grid](x, compile_mode=...))
+     -> autotune restricts the candidate set to that single mode.
+"""
+
+import os
+import contextlib
+from unittest import mock
+import sys
+
+import pytest
+import torch
+import triton
+import triton.backends.ascend.runtime  # trigger _patch_autotune
+from triton.runtime.jit import JITFunction
+from triton.tools.get_ascend_devices import is_compile_on_910_95
+
+os.environ["TRITON_PRINT_AUTOTUNING"] = "1"
+
+# Skip the whole file on non-SIMT-capable hardware. The autotuner only emits
+# 'simt_only' candidate configs on 910_95-class devices; on A3 (e.g. 910B)
+# bishengir-compile lacks the SIMT flags (--enable-triton-ir-compile,
+# --pure-simt, --num-warps, --threads-per-warp, --shared-mem-dynamic-size)
+# and rejects them at compile time. The whole compile_mode-tunable contract
+# is moot on non-SIMT hardware, so skip.
+if not is_compile_on_910_95:
+    pytest.skip(
+        "compile_mode tunable feature requires 910_95-class hardware "
+        "(SIMT-capable bishengir-compile); skipping on this runner.",
+        allow_module_level=True,
+    )
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def spy_run_kwarg(name):
+    """Capture the value of kwarg `name` seen by JITFunction.run on every
+    invocation. Any value passed via either call-site kwargs or
+    config.all_kwargs() is recorded; absence is recorded as None.
+    """
+    seen = []
+    real_run = JITFunction.run
+
+    def spying_run(self, *args, grid, warmup, **kwargs):
+        seen.append(kwargs.get(name))
+        return real_run(self, *args, grid=grid, warmup=warmup, **kwargs)
+
+    with mock.patch.object(JITFunction, 'run', spying_run):
+        yield seen
+
+
+def spy_compile_modes():
+    """Capture the compile_mode kwarg value seen by JITFunction.run."""
+    return spy_run_kwarg('compile_mode')
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: no compile_mode specified anywhere
+# ---------------------------------------------------------------------------
+
+
+def test_no_compile_mode_explores_both_modes():
+    """When no compile_mode is supplied, autotune generates configs in both
+    'simd' and 'simt_only' on SIMT-capable hardware and benchmarks them
+    together.
+    """
+
+    @triton.autotune(configs=[], key=[])
+    @triton.jit
+    def kernel(X):
+        pass
+
+    x = torch.randn(1, device="npu")
+    with spy_compile_modes() as seen:
+        kernel[(1, )](x)
+
+    modes = {m for m in seen if m is not None}
+    assert 'simd' in modes, f"Expected 'simd' in benchmarked modes, got: {modes}"
+    assert 'simt_only' in modes, f"Expected 'simt_only' in benchmarked modes, got: {modes}"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2: compile_mode declared in @triton.autotune Config kwargs
+# ---------------------------------------------------------------------------
+
+
+def test_compile_mode_in_autotune_configs():
+    """User-supplied configs in @triton.autotune carry their own compile_mode.
+    They flow through unchanged. The autotuner does not strip or override
+    them.
+    """
+
+    @triton.autotune(configs=[
+        triton.Config({'compile_mode': 'simd'}),
+        triton.Config({'compile_mode': 'simt_only'}),
+    ], key=[])
+    @triton.jit
+    def kernel(X):
+        pass
+
+    x = torch.randn(1, device="npu")
+    with spy_compile_modes() as seen:
+        kernel[(1, )](x)
+
+    modes = {m for m in seen if m is not None}
+    # Both modes from user_configs should appear in the benchmarked set.
+    assert 'simd' in modes, f"User-supplied SIMD config should run with 'simd', got: {modes}"
+    assert 'simt_only' in modes, f"User-supplied SIMT config should run with 'simt_only', got: {modes}"
+
+
+def test_no_pin_modeless_user_config_defaults_to_simd():
+    """When the user supplies a mix of explicit-mode and no-mode configs in
+    @triton.autotune AND does not pin compile_mode at the call site, the
+    no-mode config falls through to NPUOptions' default ('simd'), while
+    explicit-mode configs run in their declared mode.
+    """
+
+    @triton.autotune(
+        configs=[
+            triton.Config({'compile_mode': 'simt_only'}),
+            triton.Config({}),  # no compile_mode -> NPUOptions default = simd
+        ], key=[])
+    @triton.jit
+    def kernel(X):
+        pass
+
+    x = torch.randn(1, device="npu")
+    with spy_compile_modes() as seen:
+        kernel[(1, )](x)
+
+    # Explicit SIMT config runs as SIMT.
+    assert 'simt_only' in seen, f"Explicit SIMT config should run as SIMT, got: {seen}"
+    # No-mode config arrives at JIT.run with no compile_mode kwarg
+    # (NPUOptions then applies its default of 'simd').
+    assert None in seen, (f"No-mode user_config should arrive without compile_mode in kwargs, "
+                          f"got: {seen}")
+
+
+def test_user_pin_propagates_to_modeless_user_configs():
+    """When the user pins compile_mode at the call site, that pin propagates
+    to user_configs that do not declare their own compile_mode. User_configs
+    that DO declare a compile_mode keep their declared value (config wins).
+    Verifies that the call-sit pin honours user intent across all configs.
+    """
+
+    @triton.autotune(
+        configs=[
+            triton.Config({'compile_mode': 'simd'}),  # explicit, should stay SIMD
+            triton.Config({}),  # no mode, should inherit pin
+        ], key=[])
+    @triton.jit
+    def kernel(X):
+        pass
+
+    x = torch.randn(1, device="npu")
+    with spy_compile_modes() as seen:
+        kernel[(1, )](x, compile_mode='simt_only')
+
+    modes = {m for m in seen if m is not None}
+    # Explicit SIMD config wins over the call-site pin (config.kwargs takes
+    # precedence on autotune-managed keys).
+    assert 'simd' in modes, (f"Explicit-mode config should keep its declared compile_mode, got: {modes}")
+    # No-mode config inherits the call-site pin.
+    assert 'simt_only' in modes, (f"No-mode user_config should inherit the call-site pin 'simt_only', "
+                                  f"got: {modes}")
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3: compile_mode passed at the kernel call site
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("pinned_mode", ["simd", "simt_only"])
+def test_compile_mode_at_call_site_restricts_to_pinned(pinned_mode):
+    """When the user pins compile_mode at the kernel call site, autotune
+    restricts the candidate set to that single mode. No configs in any
+    other mode are benchmarked.
+    """
+
+    @triton.autotune(configs=[], key=[])
+    @triton.jit
+    def kernel(X):
+        pass
+
+    x = torch.randn(1, device="npu")
+    with spy_compile_modes() as seen:
+        kernel[(1, )](x, compile_mode=pinned_mode)
+
+    modes = {m for m in seen if m is not None}
+    assert modes == {pinned_mode}, (f"Pinning compile_mode='{pinned_mode}' should restrict the candidate "
+                                    f"set to that mode only, got: {modes}")
+
+
+def test_force_simt_only_kwarg_is_alias_for_simt_pinned():
+    """The legacy force_simt_only=True kwarg is treated as an alias for
+    compile_mode='simt_only': the candidate set shrinks to SIMT only.
+    """
+
+    @triton.autotune(configs=[], key=[])
+    @triton.jit
+    def kernel(X):
+        pass
+
+    x = torch.randn(1, device="npu")
+    with spy_compile_modes() as seen:
+        kernel[(1, )](x, force_simt_only=True)
+
+    modes = {m for m in seen if m is not None}
+    assert modes == {'simt_only'}, (f"force_simt_only=True should pin to SIMT, got: {modes}")
+
+
+# ---------------------------------------------------------------------------
+# Cache scoping: pinned and auto runs do not share entries
+# ---------------------------------------------------------------------------
+
+
+def test_auto_and_pinned_runs_have_separate_cache_entries():
+    """An auto-search run and a user-pinned run on the same args produce
+    distinct cache entries: the cache key encodes the user constraint.
+    """
+
+    @triton.autotune(configs=[], key=[])
+    @triton.jit
+    def kernel(X):
+        pass
+
+    x = torch.randn(1, device="npu")
+
+    kernel[(1, )](x)
+    after_auto = len(kernel.cache)
+
+    kernel[(1, )](x, compile_mode='simd')
+    after_simd = len(kernel.cache)
+
+    kernel[(1, )](x, compile_mode='simt_only')
+    after_simt = len(kernel.cache)
+
+    assert after_auto >= 1, "Auto run should populate the cache"
+    assert after_simd > after_auto, (f"Pinning compile_mode='simd' should add a separate cache entry "
+                                     f"(auto={after_auto}, after_simd={after_simd})")
+    assert after_simt > after_simd, (f"Pinning compile_mode='simt_only' should add another separate entry "
+                                     f"(after_simd={after_simd}, after_simt={after_simt})")
+
+
+# ---------------------------------------------------------------------------
+# Pinned runs are repeatable: a second pinned call hits cache
+# ---------------------------------------------------------------------------
+
+
+def test_pinned_run_repeats_hit_cache():
+    """A second call with the same pinned compile_mode hits the cache and
+    does not produce a new entry.
+    """
+
+    @triton.autotune(configs=[], key=[])
+    @triton.jit
+    def kernel(X):
+        pass
+
+    x = torch.randn(1, device="npu")
+
+    kernel[(1, )](x, compile_mode='simt_only')
+    after_first = len(kernel.cache)
+
+    kernel[(1, )](x, compile_mode='simt_only')
+    after_second = len(kernel.cache)
+
+    assert after_first == after_second, (f"Repeated pinned call should reuse the cached entry "
+                                         f"(after_first={after_first}, after_second={after_second})")
+
+
+# ---------------------------------------------------------------------------
+# simt_stack_limit: per-config tag must not collide with a call-site override
+# ---------------------------------------------------------------------------
+
+
+def test_simt_stack_limit_override_at_call_site():
+    """A call-site simt_stack_limit is honored on SIMT configs and does not
+    collide with the per-config tag the autotuner attaches.
+
+    Regression: _gen_tile_configs tags every SIMT config with simt_stack_limit
+    in its kwargs. simt_stack_limit must therefore be autotune-managed in
+    _make_kernel_call — otherwise a call-site value lands in both meta and
+    config.kwargs and the conflict check raises
+    ValueError("Conflicting meta-parameters: simt_stack_limit").
+    """
+
+    @triton.autotune(configs=[], key=[])
+    @triton.jit
+    def kernel(X):
+        pass
+
+    x = torch.randn(1, device="npu")
+    with spy_run_kwarg('simt_stack_limit') as seen:
+        # Before the fix this raised inside _make_kernel_call before any run.
+        kernel[(1, )](x, compile_mode='simt_only', simt_stack_limit=16384)
+
+    assert 16384 in seen, (f"Call-site simt_stack_limit=16384 should reach the kernel on the "
+                           f"SIMT path, got: {seen}")
+
+
+def test_simt_stack_limit_defaults_when_unset():
+    """When the user does not pass simt_stack_limit, SIMT configs still carry
+    the autotuner's default so it reaches the compiler deterministically."""
+
+    @triton.autotune(configs=[], key=[])
+    @triton.jit
+    def kernel(X):
+        pass
+
+    x = torch.randn(1, device="npu")
+    with spy_run_kwarg('simt_stack_limit') as seen:
+        kernel[(1, )](x, compile_mode='simt_only')
+
+    # 8192 is AutoTilingTuner.simt_stack_limit, tagged on every SIMT config.
+    assert 8192 in seen, (f"SIMT configs should carry the default simt_stack_limit=8192 "
+                          f"when the user does not override it, got: {seen}")
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"] + sys.argv[1:]))


### PR DESCRIPTION
Add compile_mode (simd / simt_only) to the autotuner's candidate search space. When the user does not specify compile_mode at the kernel call site, autotune generates configs in both SIMD and SIMT modes (on SIMT-capable hardware) and benchmarks them together, picking the fastest. When the user specifies compile_mode, the search space is restricted to that single mode — matching the existing pattern for num_warps and multibuffer.

Implementation:
- Replace per-call self.is_simt_mode flag with per-config tagging: each generated Config carries compile_mode in its kwargs dict, so the value flows through JITFunction.run -> NPUOptions transparently.
- _gen_tile_configs now loops over candidate_modes, calling TileGenerator with the appropriate is_simt_mode per mode and applying mode-specific expansion (warps for SIMT, multibuffer for SIMD). Configs are concatenated into a unified candidate pool.
- Add user_specified_compile_mode tracking in generate_key_and_configs with force_simt_only=True kept as a back-compat alias.
- Cache key gains a "compile_mode_constraint" component so that user-pinned and full-search results do not collide.
- simt_stack_limit injection moves from per-call to per-config (set on each SIMT config at expansion time).
- Mark compile_mode and force_simt_only as autotune-managed in _make_kernel_call: they're allowed to appear in both call-site kwargs and Config.kwargs, with Config.kwargs winning. This is what lets user call-site pins propagate to user_configs that lack their own mode, while auto-tagged gen_configs keep their per-mode tags.

Bundled fix: drop the four stale
num_buffers_warp_spec / num_consumer_groups / reg_dec_producer / reg_inc_consumer kwargs from the empty-configs fallback Config(...) in generate_key_and_configs and from the Config rebuild in get_max_configs. They were briefly added to upstream Triton's Config by ebffad5a5 (PR #5622, warp-spec) and removed by 6312144c0; the Ascend autotuner still passed them, raising TypeError on any caller that hit either path. No behavior change — NPUOptions defaults those four fields to 0 anyway, and nothing else in the repo reads them. The fix incidentally lets test_compile_mode_tunable.py use the natural @triton.autotune(configs=[], key=[]) pattern without a workaround kernel.

Tests: third_party/ascend/unittest/autotune_ut/test_compile_mode_tunable.py covers the three input scenarios (no pin, pin in @autotune Config, pin at call site), the force_simt_only alias, cache scoping, and mixed-mode user_configs.
