### PR TITLE
fix(ssbufer): Preserve control-flow attributes during canonicalization

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/PreserveControlAttrsCanonicalize.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/PreserveControlAttrsCanonicalize.cpp
@@ -139,7 +139,9 @@ void mlir::triton::PreserveControlAttrsCanonicalizePass::runOnOperation()
     RewritePatternSet patterns(&getContext());
     populateCanonicalizationPatterns(&getContext(), patterns);
 
+    PreserveControlAttrsListener listener;
     GreedyRewriteConfig config;
+    config.listener = &listener;
 
     if (failed(applyPatternsAndFoldGreedily(getOperation(),
                                             FrozenRewritePatternSet(std::move(patterns)),

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/preserve_control_attrs_canonicalize_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/preserve_control_attrs_canonicalize_test.mlir
@@ -41,3 +41,50 @@ module {
     return %0#0 : i32
   }
 }
+
+// -----
+
+// CHECK-LABEL: "func.func"() <{{.*}}sym_name = "if_attr_survives_unused_result_canonicalize"
+// CHECK-DAG: "arith.select"
+// CHECK-DAG: "scf.if"
+// CHECK: }) {hivm.unlikely_condition, ssbuffer.block_id = 11 : i32} : (i1) -> ()
+
+module {
+  func.func @if_attr_survives_unused_result_canonicalize(%cond: i1, %arg0: i32, %buf: memref<1xi32>) -> i32 {
+    %c0 = arith.constant 0 : index
+    %c0_i32 = arith.constant 0 : i32
+    %0:2 = "scf.if"(%cond) ({
+      memref.store %arg0, %buf[%c0] : memref<1xi32>
+      "scf.yield"(%arg0, %c0_i32) : (i32, i32) -> ()
+    }, {
+      memref.store %c0_i32, %buf[%c0] : memref<1xi32>
+      "scf.yield"(%c0_i32, %arg0) : (i32, i32) -> ()
+    }) {hivm.unlikely_condition, ssbuffer.block_id = 11 : i32} : (i1) -> (i32, i32)
+    return %0#0 : i32
+  }
+}
+
+// -----
+
+// CHECK-LABEL: "func.func"() <{{.*}}sym_name = "merged_zero_result_if_preserves_attrs"
+// CHECK: "scf.if"
+// CHECK: "memref.store"
+// CHECK: "memref.store"
+// CHECK: }) {hivm.unlikely_condition, ssbuffer.block_id = 7 : i32} : (i1) -> ()
+// CHECK-NOT: "scf.if"
+// CHECK: "func.return"
+
+module {
+  func.func @merged_zero_result_if_preserves_attrs(%cond: i1, %lhs: memref<1xi32>, %rhs: memref<1xi32>) {
+    %c0 = arith.constant 0 : index
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    scf.if %cond {
+      memref.store %c1_i32, %lhs[%c0] : memref<1xi32>
+    } {hivm.unlikely_condition, ssbuffer.block_id = 7 : i32}
+    scf.if %cond {
+      memref.store %c2_i32, %rhs[%c0] : memref<1xi32>
+    } {hivm.unlikely_condition, ssbuffer.block_id = 7 : i32}
+    return
+  }
+}


### PR DESCRIPTION
Attach a GreedyRewriteConfig listener to transfer control-flow attributes (e.g. hivm.unlikely_condition, ssbuffer.block_id) from original SCF ops to their canonicalized replacements; add a regression test verifying attribute preservation when adjacent zero-result scf.if ops are merged.
