### PR TITLE
fix(ssbuffer): Stop operator classifier propagation in arithmetic operations.

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -454,6 +454,21 @@ int OpClassifierPass::propagateCubeUpstream()
             if (!def || cubeVisited.count(def) || isa<linalg::MatmulOp>(def))
                 continue;
 
+            // Skip arith dialect ops with tensor results (they should be VECTOR, not CUBE)
+            if (isa<arith::ArithDialect>(def->getDialect())) {
+                bool hasTensorResult = false;
+                for (Value result : def->getResults()) {
+                    if (isa<RankedTensorType>(result.getType())) {
+                        hasTensorResult = true;
+                        break;
+                    }
+                }
+                if (hasTensorResult) {
+                    LLVM_DEBUG(DBGS() << "skip " << def->getName().getStringRef() << ": arith tensor op\n");
+                    continue;
+                }
+            }
+
             // Skip operations inside linalg block (internal values)
             // But don't skip the linalg op itself
             if (isInsideNestedLinalgRegion(def)) {
@@ -665,7 +680,8 @@ int OpClassifierPass::propagateVectorUpstream()
         vecQueue.pop();
         // Skip builtin.module, func.func, and func.return operations
         if (isa<ModuleOp, func::FuncOp, func::ReturnOp>(cur) ||
-            (isa<memref::CopyOp, memref::AllocaOp>(cur) && opCoreTypes[cur] == OP_CUBE_ONLY)) {
+            (isa<memref::CopyOp, memref::AllocaOp>(cur) && opCoreTypes[cur] == OP_CUBE_ONLY))
+        {
             continue;
         }
         LLVM_DEBUG(DBGS() << "vec-def: " << *cur << "\n");


### PR DESCRIPTION
This PR ensures that the operator classifier stops propagating when encountering arithmetic operations, preventing incorrect classification states from bleeding into downstream operations.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
