### PR TITLE
feat(autoblockify): enable TRITON_ALL_BLOCKS_PARALLEL by default on 950 series

### DIFF
--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -273,7 +273,8 @@ def _is_debug_line_info_disabled() -> bool:
 
 
 def _is_auto_map_parallel_blocks_enabled() -> bool:
-    return os.getenv("TRITON_ALL_BLOCKS_PARALLEL", "false").lower() in ("true", "1")
+    default_parallel = "true" if is_compile_on_910_95 else "false"
+    return os.getenv("TRITON_ALL_BLOCKS_PARALLEL", default_parallel).lower() in ("true", "1")
 
 
 def _get_auto_blockify_blacklist_reasons(ir_text: str):


### PR DESCRIPTION
## Summary
Enable TRITON_ALL_BLOCKS_PARALLEL to enable AutoBlockify by default on 950 series.

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
