### PR TITLE
ci: add PR auto-labeler and release-branch push trigger

### DIFF
--- a/.github/actions/labeler.yml
+++ b/.github/actions/labeler.yml
@@ -1,0 +1,36 @@
+build:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'CMakeLists.txt'
+          - 'cmake/**'
+          - 'Makefile'
+          - 'setup.py'
+          - 'pyproject.toml'
+          - 'MANIFEST.in'
+          - 'safe_compile.cmake'
+
+CICD:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/workflows/**'
+          - '.github/actions/**'
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'requirements*.txt'
+          - '.github/dependabot.yml'
+
+document:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.md'
+          - 'docs/**'
+
+release:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'RELEASE.md'
+          - 'version.txt'
+  - head-branch: ['^release/']
+  - base-branch: ['^release/']

--- a/.github/workflows/Ascend950-pipeline-tests.yml
+++ b/.github/workflows/Ascend950-pipeline-tests.yml
@@ -114,7 +114,6 @@ jobs:
          needs.publish.outputs.pr_num != '')
       )
     runs-on: ubuntu-latest
-    timeout-minutes: 90
     permissions:
       pull-requests: write
       statuses: write
@@ -162,7 +161,7 @@ jobs:
         run: |
           gh api -X POST "repos/${{ github.repository }}/statuses/${SHA}" \
             -f state=pending \
-            -f context='A5 Pipeline Tests' \
+            -f context='Ascend950 Pipeline Tests' \
             -f description='Pipeline running' \
             -f target_url="$TARGET"
 
@@ -310,7 +309,7 @@ jobs:
           done
 
           if [ "$DONE" != "true" ]; then
-            write_status "TIMEOUT" "polling exceeded 240 attempts without a terminal status"
+            write_status "TIMEOUT" "polling exceeded 720 attempts without a terminal status"
             exit 1
           fi
           echo "terminal status: ${ST} - ${MSG}"
@@ -343,7 +342,7 @@ jobs:
         run: |
           gh api -X POST "repos/${{ github.repository }}/statuses/${SHA}" \
             -f state="$STATE" \
-            -f context='A5 Pipeline Tests' \
+            -f context='Ascend950 Pipeline Tests' \
             -f description="${DESC:-UNKNOWN}" \
             -f target_url="$TARGET"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ on:
     branches: [main, 'dev-**']
     types: [checks_requested]
   push:
-    branches: [main]
+    branches: [main, 'release/**']
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/actions/labeler.yml
+          sync-labels: true

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -73,6 +73,12 @@ jobs:
           # at /project/.triton-cache and /project/.ccache inside the container.
           mkdir -p .triton-cache .ccache
 
+          # Wheel version: <base>rc3+devYYYYMMDD. Compute the build date once on
+          # the host (UTC) so all matrix cells agree even if they straddle
+          # midnight. IS_MANYLINUX=TRUE suppresses the +git<hash> append in
+          # setup.py's get_version() since +dev<date> is our local segment.
+          BUILD_DATE=$(date -u +%Y%m%d)
+
           # required to build Python 3.14 with cibuildwheel 2.23.3
           # todo: Need to update system Python to 3.11 and update cibuildwheel to latest
 
@@ -81,7 +87,8 @@ jobs:
             TRITON_BUILD_PROTON=OFF \
             TRITON_WHEEL_NAME=triton-ascend \
             TRITON_APPEND_CMAKE_ARGS='-DTRITON_BUILD_UT=OFF' \
-            TRITON_WHEEL_VERSION_SUFFIX=${TRITON_WHEEL_VERSION_SUFFIX:-rc3} \
+            TRITON_WHEEL_VERSION_SUFFIX=${TRITON_WHEEL_VERSION_SUFFIX:-rc3}+dev${BUILD_DATE} \
+            IS_MANYLINUX=TRUE \
             TRITON_HOME=/project/.triton-cache \
             TRITON_BUILD_WITH_CCACHE=true \
             CCACHE_DIR=/project/.ccache \
@@ -117,4 +124,4 @@ jobs:
       - name: Upload wheels to OBS
         if: github.event_name != 'pull_request'
         shell: bash
-        run: obsutil/obsutil cp -u wheelhouse/*.whl "obs://triton-ascend-artifacts/triton-ascend/"
+        run: obsutil/obsutil cp -u wheelhouse/*.whl "obs://ascend-artifcat-packages/pypi/packages/ascend/repos/pypi/triton-ascend/nightly/"


### PR DESCRIPTION
Summary
-------------

- Add auto-labeler workflow and label rules for PRs
- Wire release-branch push trigger into ci.yml
- Remove the timeout period from the Ascend950 pipeline test
- Modify the name of the wheels package and the obs address