### PR TITLE
fix(ssbuffer): annotation.mark should remain ordered within its corre…

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/Common/MemoryEffectsTracker.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/MemoryEffectsTracker.cpp
@@ -213,6 +213,11 @@ SmallVector<MemoryEffects::EffectInstance> MemoryDependenceGraph::collectOuterEf
 {
     unknown = false;
 
+    if (auto markOp = dyn_cast<annotation::MarkOp>(op)) {
+        MemoryEffects::EffectInstance scopedWrite(MemoryEffects::Write::get());
+        return {remapEffectValue(scopedWrite, markOp.getSrc())};
+    }
+
     std::optional<SmallVector<MemoryEffects::EffectInstance>> raw = getEffectsRecursively(op);
     if (!raw) {
         unknown = true;

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_annotation_mark_memory_effects.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_annotation_mark_memory_effects.mlir
@@ -1,0 +1,32 @@
+// RUN: triton-opt --debug-only=memory-effects-tracker --plan-compute-block %s 2>&1 | FileCheck %s
+
+module {
+  // CHECK-LABEL: func.func @annotation_mark_memref_is_not_memory_barrier
+  // CHECK: %{{.*}} = memref.load
+  // CHECK: %[[ALLOC:[A-Za-z0-9_]+]] = memref.alloc()
+  // CHECK: Analyzing op annotation.mark %[[ALLOC]] {MayImplicitTransposeWithLastAxis}
+  // CHECK-NEXT: [memory-effects-tracker] Defs:
+  // CHECK-NEXT: [memory-effects-tracker] Preds:
+  // CHECK-NEXT: [memory-effects-tracker] linalg.fill {{.*}} outs(%[[ALLOC]]
+  // CHECK-NEXT: [memory-effects-tracker] Analyzing op %{{.*}} = bufferization.to_tensor %[[ALLOC]]
+  // CHECK-NEXT: [memory-effects-tracker] Defs:
+  // CHECK-NEXT: [memory-effects-tracker] linalg.fill {{.*}} outs(%[[ALLOC]]
+  // CHECK-NEXT: [memory-effects-tracker] Preds:
+  // CHECK-NEXT: [memory-effects-tracker] annotation.mark %[[ALLOC]] {MayImplicitTransposeWithLastAxis}
+  func.func @annotation_mark_memref_is_not_memory_barrier(
+    %arg0: memref<4xf32>,
+    %rhs: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    %c0 = arith.constant 0 : index
+    %zero = arith.constant 0.0 : f32
+    %unused = memref.load %arg0[%c0] : memref<4xf32>
+    %alloc = memref.alloc() : memref<4x4xf32>
+    linalg.fill ins(%zero : f32) outs(%alloc : memref<4x4xf32>)
+    annotation.mark %alloc {MayImplicitTransposeWithLastAxis} : memref<4x4xf32>
+    %lhs = bufferization.to_tensor %alloc restrict writable : memref<4x4xf32>
+    %out = tensor.empty() : tensor<4x4xf32>
+    %init = linalg.fill ins(%zero : f32) outs(%out : tensor<4x4xf32>) -> tensor<4x4xf32>
+    %mm = linalg.matmul ins(%lhs, %rhs : tensor<4x4xf32>, tensor<4x4xf32>)
+      outs(%init : tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %mm : tensor<4x4xf32>
+  }
+}


### PR DESCRIPTION
…sponding memory.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

Fix MemoryEffectsTracker handling for annotation.mark.

`annotation.mark` declares an unscoped MemWrite, which made the tracker treat it as a full memory barrier and produced unrelated execBefore predecessors. This change scopes the write effect to the marked value, preserving ordering for later users of that value while avoiding spurious dependencies.

Added a DynamicCVPipeline regression test covering MayImplicitTransposeWithLastAxis marks and verifying that only relevant memory dependencies are tracked.