### PR TITLE
feat: update autoblockify blacklist for multiple return statements

### DIFF
--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -45,6 +45,10 @@ AUTO_BLOCKIFY_BLACKLIST_RULES = (
         re.compile(r"\btt\.(?:load|store)\b[^\n]*\bcacheModifier\s*="),
         "loads or stores with cache modifiers",
     ),
+    (
+        re.compile(r"^\s*tt\.return\b.*?^\s*tt\.return\b", re.MULTILINE | re.DOTALL),
+        "multiple tt.return operations",
+    ),
 )
 
 backend_policy = None


### PR DESCRIPTION
## Summary
Update autoblockify blacklist for multiple `tt.return` statements

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
