### PR TITLE
fix(ssbuffer): remove single instance.

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h
+++ b/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h
@@ -36,7 +36,7 @@ namespace CVPipeline {
 
 Operation *getAncestorInBlock(Operation *inner, Block *block);
 void initializeIndegreeForBlock(Block *block, llvm::DenseMap<Operation *, int> &indegree,
-                                const MemoryDependenceGraph &memGraph);
+                                const MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm);
 
 } // namespace CVPipeline
 } // namespace mlir

--- a/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h
+++ b/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h
@@ -38,34 +38,28 @@ namespace CVPipeline {
  */
 class ComputeBlockIdManager {
 public:
-    static ComputeBlockIdManager &getInstance()
-    {
-        static ComputeBlockIdManager instance;
-        return instance;
-    }
 
-    unsigned int getNextId();
-
+    ComputeBlockIdManager(Operation *root);
     bool isSameBlock(Operation *a, Operation *b);
     bool isWholeCubeReady(Operation *seedOp, llvm::DenseMap<Operation *, int> &indegree);
-
-    llvm::LogicalResult markOpBlockId(Operation *op, int blockId);
+    
+    llvm::LogicalResult markOpBlockId(Operation *op);
+    llvm::LogicalResult markOpsWithNewId(llvm::SmallVectorImpl<Operation *> &ops);
     void updateBlockId(Operation *op, int blockId);
-
+    
     llvm::SmallVector<Operation *> getOpsByBlockId(int blockId);
     int getBlockIdByOp(Operation *op);
-    llvm::LogicalResult markOpsWithNewId(llvm::SmallVectorImpl<Operation *> &ops);
     void reset();
-
-private:
-    ComputeBlockIdManager() : cntComputeBlockId(0) {}
-    llvm::LogicalResult record(Operation *op, int blockId);
-
-    unsigned int cntComputeBlockId;
+    int getNextId();
+    
+    private:
+    
+    int cntComputeBlockId;
     llvm::DenseMap<int, llvm::SmallVector<Operation *>> blockIdToOps;
     llvm::DenseMap<Operation *, int> opToBlockId;
     mutable std::mutex managerMutex;
     const int blockIdWidth = 32;
+    llvm::LogicalResult markAndRecord(Operation *op, int blockId);
 };
 
 } // namespace CVPipeline

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UBUsageOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UBUsageOptPass.cpp
@@ -27,13 +27,16 @@
 #include "mlir/Analysis/AliasAnalysis.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Block.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <cstdint>
+#include <optional>
 #include <queue>
 
 #define DEBUG_TYPE "ub-usage-opt"
@@ -60,8 +63,8 @@ class UBUsageOptPass : public PassWrapper<UBUsageOptPass, OperationPass<ModuleOp
                            SmallVector<SmallVector<int>> &linkOut, SmallVector<SmallVector<int>> &linkIn,
                            SmallVector<int> &linkSize, SmallVector<int> &linkStart, SmallVector<int> &linkEnd,
                            SmallVector<int> &nodeBlockId, SmallVector<int> &nodeCoreType, SmallVector<int> &nodeArgs,
-                           const CVPipeline::MemoryDependenceGraph &memGraph);
-    llvm::LogicalResult UBUsageOptimization(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph);
+                           const CVPipeline::MemoryDependenceGraph &memGraph, CVPipeline::ComputeBlockIdManager &bm);
+    llvm::LogicalResult UBUsageOptimization(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph, CVPipeline::ComputeBlockIdManager &bm);
 };
 } // namespace triton
 } // namespace mlir
@@ -123,7 +126,7 @@ void UBUsageOptPass::buildUBUsageGraph(Block *block, DenseMap<Operation *, int> 
                                        SmallVector<SmallVector<int>> &linkIn, SmallVector<int> &linkSize,
                                        SmallVector<int> &linkStart, SmallVector<int> &linkEnd,
                                        SmallVector<int> &nodeBlockId, SmallVector<int> &nodeCoreType,
-                                       SmallVector<int> &nodeArgs, const CVPipeline::MemoryDependenceGraph &memGraph)
+                                       SmallVector<int> &nodeArgs, const CVPipeline::MemoryDependenceGraph &memGraph, CVPipeline::ComputeBlockIdManager &bm)
 {
     DenseMap<int, int> cubeBlockId2nodeId;
     const int cubeCoreType = static_cast<int>(CVPipeline::CoreType::CUBE_ONLY);
@@ -132,7 +135,6 @@ void UBUsageOptPass::buildUBUsageGraph(Block *block, DenseMap<Operation *, int> 
         if (op2nodeId.find(op) != op2nodeId.end()) {
             return op2nodeId.at(op);
         }
-        auto &bm = CVPipeline::ComputeBlockIdManager::getInstance();
         int coreType = static_cast<int>(CVPipeline::getOpCoreType(op));
         int blockId = bm.getBlockIdByOp(op);
         bool canShrink = (coreType == cubeCoreType && blockId != -1);
@@ -232,7 +234,6 @@ void UBUsageOptPass::buildUBUsageGraph(Block *block, DenseMap<Operation *, int> 
                 }
                 // To avoid unnesessary self-cycle.
                 // Two ops in the same cube block lead to self-cycle, so continue it.
-                auto &bm = CVPipeline::ComputeBlockIdManager::getInstance();
                 int coreType = static_cast<int>(CVPipeline::getOpCoreType(op));
                 int srcBlockId = bm.getBlockIdByOp(srcInBlock);
                 int dstBlockId = bm.getBlockIdByOp(&blockOp);
@@ -261,7 +262,6 @@ void UBUsageOptPass::buildUBUsageGraph(Block *block, DenseMap<Operation *, int> 
                 }
                 // To avoid unnesessary self-cycle.
                 // Two ops in the same cube block lead to self-cycle, so continue it.
-                auto &bm = CVPipeline::ComputeBlockIdManager::getInstance();
                 int coreType = static_cast<int>(CVPipeline::getOpCoreType(op));
                 int srcBlockId = bm.getBlockIdByOp(srcInBlock);
                 int dstBlockId = bm.getBlockIdByOp(&blockOp);
@@ -486,14 +486,15 @@ struct DependencyCycleDetector {
     llvm::DenseSet<mlir::Operation *> &okSet; // node in okSet will become one compute block;
     llvm::DenseSet<mlir::Operation *> visited;
     const CVPipeline::MemoryDependenceGraph &memGraph;
+    CVPipeline::ComputeBlockIdManager &bm;
     Block *block;
     void clear() { visited.clear(); }
     bool operator()(Operation *cur);
     bool dfs(Operation *cur) { return (*this)(cur); };
 
     DependencyCycleDetector(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph,
-                            llvm::DenseSet<mlir::Operation *> &okSet)
-        : block(block), memGraph(memGraph), okSet(okSet)
+                            llvm::DenseSet<mlir::Operation *> &okSet, CVPipeline::ComputeBlockIdManager &bm)
+        : block(block), memGraph(memGraph), okSet(okSet), bm(bm)
     {
     }
 };
@@ -516,7 +517,6 @@ bool DependencyCycleDetector::operator()(Operation *cur)
     }
     for (auto *user : allusers) {
         auto *userInBlock = CVPipeline::getAncestorInBlock(user, block);
-        auto &bm = CVPipeline::ComputeBlockIdManager::getInstance();
         if (bm.getBlockIdByOp(userInBlock) == -1) {
             if (dfs(userInBlock)) {
                 return true;
@@ -537,13 +537,12 @@ bool DependencyCycleDetector::operator()(Operation *cur)
     * Walk from every op in targetBlockId and willaddOps.
     * if reach other blockid ops and dfs find any targetBlockId op, then there is cycle.
 */
-static bool willCreateCycle(llvm::SmallVectorImpl<Operation *> &willaddOps, Block *block,
-                            const CVPipeline::MemoryDependenceGraph &memGraph, int targetBlockId)
+std::optional<bool> willCreateCycle(llvm::SmallVectorImpl<Operation *> &willaddOps, Block *block,
+                            const CVPipeline::MemoryDependenceGraph &memGraph, int targetBlockId, CVPipeline::ComputeBlockIdManager &bm)
 {
     // Step1: Init, Add willaddOps to targetBlockId.
     // OkSet is new block, includes two part: 1. original ops in targetBlockId. 2. willaddOps.
     llvm::DenseSet<mlir::Operation *> okSet;  
-    auto &bm = CVPipeline::ComputeBlockIdManager::getInstance();
     for (auto op : bm.getOpsByBlockId(targetBlockId)) {
         okSet.insert(op);
     }
@@ -554,7 +553,7 @@ static bool willCreateCycle(llvm::SmallVectorImpl<Operation *> &willaddOps, Bloc
         originBlockId[op] = bm.getBlockIdByOp(op);
         bm.updateBlockId(op, targetBlockId);
     }
-    DependencyCycleDetector dfs = {block, memGraph, okSet};
+    DependencyCycleDetector dfs = {block, memGraph, okSet, bm};
 
     // Step2: Walk from every op in okSet
     auto ret = false;
@@ -600,10 +599,8 @@ static bool willCreateCycle(llvm::SmallVectorImpl<Operation *> &willaddOps, Bloc
 }
 
 bool applyRecordChange(DenseMap<int, int> &recordChange, DenseMap<int, Operation *> &nodeId2op,
-                       const CVPipeline::MemoryDependenceGraph &memGraph)
+                       const CVPipeline::MemoryDependenceGraph &memGraph, CVPipeline::ComputeBlockIdManager &bm)
 {
-    auto &bm = CVPipeline::ComputeBlockIdManager::getInstance();
-
     // Get ever blockid should be add which nodeId in recordChange.
     DenseMap<int, SmallVector<int>> blockWilladd;
     for (const auto &it : recordChange) {
@@ -619,7 +616,7 @@ bool applyRecordChange(DenseMap<int, int> &recordChange, DenseMap<int, Operation
         for (int nodeId : willaddNodes) {
             willaddOps.push_back(nodeId2op[nodeId]);
         }
-        if (willCreateCycle(willaddOps, willaddOps[0]->getBlock(), memGraph, targetBlockId)) {
+        if (willCreateCycle(willaddOps, willaddOps[0]->getBlock(), memGraph, targetBlockId, bm).value_or(true)) {
             LOG_DEBUG("Find cycle when apply change for blockId: " << targetBlockId << "\n");
             for (auto nodeId : willaddNodes) {
                 LOG_DEBUG("  - " << *nodeId2op[nodeId]<<"\n");
@@ -636,7 +633,7 @@ bool applyRecordChange(DenseMap<int, int> &recordChange, DenseMap<int, Operation
     return hasError;
 }
 
-llvm::LogicalResult UBUsageOptPass::UBUsageOptimization(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph)
+llvm::LogicalResult UBUsageOptPass::UBUsageOptimization(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph, CVPipeline::ComputeBlockIdManager &bm)
 {
     if (!isa<scf::ForOp>(block->getParentOp())) {
         return llvm::success();
@@ -652,7 +649,7 @@ llvm::LogicalResult UBUsageOptPass::UBUsageOptimization(Block *block, const CVPi
     SmallVector<int> nodeCoreType;
     SmallVector<int> nodeArgs;
     buildUBUsageGraph(block, op2nodeId, nodeId2op, linkOut, linkIn, linkSize, linkStart, linkEnd, nodeBlockId,
-                      nodeCoreType, nodeArgs, memGraph);
+                      nodeCoreType, nodeArgs, memGraph, bm);
     SmallVector<SmallVector<int>> needUbOpts =
         collectNeedUbOpts(linkOut, linkIn, linkStart, linkEnd, nodeBlockId, nodeCoreType, nodeId2op);
     int candidateCnt = 0;
@@ -667,7 +664,7 @@ llvm::LogicalResult UBUsageOptPass::UBUsageOptimization(Block *block, const CVPi
                                                                 linkEnd, nodeBlockId, nodeCoreType, nodeId2op);
     LOG_DEBUG("Need change blockId for " << recordChange.size() << " nodes\n");
 
-    if (applyRecordChange(recordChange, nodeId2op, memGraph)) {
+    if (applyRecordChange(recordChange, nodeId2op, memGraph, bm)) {
         // FIXME: it shouldn't happen....
         llvm::errs() << "Some skiped when apply UB usage optimization changes.\n";
     }
@@ -681,12 +678,13 @@ void mlir::triton::UBUsageOptPass::runOnOperation()
     ModuleOp module = getOperation();
     auto &aliasAnalysis = getAnalysis<AliasAnalysis>();
     CVPipeline::MemoryDependenceGraph memDepGraph(module, aliasAnalysis);
+    auto bm = CVPipeline::ComputeBlockIdManager(module);
 
     llvm::SmallVector<Block *> blocks;
     module.walk([&](Block *block) { blocks.push_back(block); });
 
     for (Block *block : blocks) {
-        if (UBUsageOptimization(block, memDepGraph).failed()) {
+        if (UBUsageOptimization(block, memDepGraph, bm).failed()) {
             llvm::errs() << "UB usage optimization failed in block:\n";
         }
     }

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
@@ -29,6 +29,7 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/CastInterfaces.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -54,13 +55,14 @@ struct CycleDfs {
   llvm::DenseSet<mlir::Operation *> &okSet;
   llvm::DenseSet<mlir::Operation *> visited;
   const CVPipeline::MemoryDependenceGraph &memGraph;
+  CVPipeline::ComputeBlockIdManager &bm;
   Block *block;
   void clear() { visited.clear(); }
   bool operator()(Operation *cur);
   bool dfs(Operation *cur) { return (*this)(cur); };
   CycleDfs(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph,
-           llvm::DenseSet<mlir::Operation *> &okSet)
-      : block(block), memGraph(memGraph), okSet(okSet) {}
+           llvm::DenseSet<mlir::Operation *> &okSet, CVPipeline::ComputeBlockIdManager &bm)
+      : block(block), memGraph(memGraph), okSet(okSet), bm(bm) {}
 };
 
 bool CycleDfs::operator()(Operation *cur) {
@@ -83,7 +85,6 @@ bool CycleDfs::operator()(Operation *cur) {
       LOG_DEBUG("[CycleDfs] Cycle found, userInBlock in okSet: " << userInBlock->getName());
       return true;
     }
-    auto &bm = CVPipeline::ComputeBlockIdManager::getInstance();
     int userBlockId = bm.getBlockIdByOp(userInBlock);
     if (userBlockId == -1) {
       if (dfs(userInBlock)) {
@@ -115,7 +116,7 @@ bool CycleDfs::operator()(Operation *cur) {
  */
 static bool willCreateCycle(memref::AllocOp allocOp, FillInfo &fillInfo,
                             const CVPipeline::MemoryDependenceGraph &memGraph,
-                            int targetBlockId) {
+                            int targetBlockId, CVPipeline::ComputeBlockIdManager &bm) {
   auto *block = allocOp->getBlock();
 
   // Build "safe set": contains all ops corresponding to targetBlockId
@@ -123,7 +124,6 @@ static bool willCreateCycle(memref::AllocOp allocOp, FillInfo &fillInfo,
   // it means unification would create a cycle
   llvm::DenseSet<Operation *> okSet;
 
-  auto &bm = CVPipeline::ComputeBlockIdManager::getInstance();
 
   // Add all ops corresponding to targetBlockId to okSet
   for (auto *op : bm.getOpsByBlockId(targetBlockId)) {
@@ -136,7 +136,7 @@ static bool willCreateCycle(memref::AllocOp allocOp, FillInfo &fillInfo,
   okSet.insert(fillInfo.parentIf.getOperation());
 
   // Initialize DFS detector
-  CycleDfs dfs(block, memGraph, okSet);
+  CycleDfs dfs(block, memGraph, okSet, bm);
   bool hasCycle = false;
 
   // Traverse each operation in the safe set as starting point,
@@ -153,7 +153,6 @@ static bool willCreateCycle(memref::AllocOp allocOp, FillInfo &fillInfo,
       if (okSet.contains(userInBlock)) {
         continue;
       }
-      auto &bm = CVPipeline::ComputeBlockIdManager::getInstance();
       int userBlockId = bm.getBlockIdByOp(userInBlock);
       if (userBlockId == -1) {
         dfs.clear();
@@ -183,11 +182,6 @@ static std::optional<int> lookupOpBlockId(Operation *op) {
     if (auto attr = op->getAttrOfType<IntegerAttr>("ssbuffer.block_id"))
         return attr.getInt();
     return -1;
-}
-
-static void markOpBlockId(Operation *op, int blockId) {
-    auto &bm = CVPipeline::ComputeBlockIdManager::getInstance();
-    bm.updateBlockId(op, blockId);
 }
 
 /**
@@ -389,7 +383,7 @@ static FillInfo splitSCFIfIfNeeded(FillInfo &info) {
  * @param memGraph Memory dependence graph for cycle detection
  * @return bool Returns true if unification was performed, false otherwise
  */
-static bool tryUnifyForAlloc(memref::AllocOp allocOp, const CVPipeline::MemoryDependenceGraph &memGraph) {
+static bool tryUnifyForAlloc(memref::AllocOp allocOp, const CVPipeline::MemoryDependenceGraph &memGraph, CVPipeline::ComputeBlockIdManager &bm) {
   // Step1: Collect direct users (excluding linalg.fill)
   Value allocResult = allocOp.getResult();
   LOG_DEBUG("[tryUnifyForAlloc] start from allocOp: " << *allocOp);
@@ -419,7 +413,7 @@ static bool tryUnifyForAlloc(memref::AllocOp allocOp, const CVPipeline::MemoryDe
   }
 
   // Step5: Cycle detection - check if unification would create cycle
-  if (willCreateCycle(allocOp, fillInfo, memGraph, *targetBlockId)) {
+  if (willCreateCycle(allocOp, fillInfo, memGraph, *targetBlockId, bm)) {
     LOG_DEBUG("[Cycle detection] Find cycle! Did not change block_id: "<< targetBlockId);
     return false;
   }
@@ -428,15 +422,17 @@ static bool tryUnifyForAlloc(memref::AllocOp allocOp, const CVPipeline::MemoryDe
   LOG_DEBUG("[tryUnifyForAlloc] Unifying block_id to " << *targetBlockId << " for:");
   LOG_DEBUG("  - alloc: " << *allocOp.getOperation());
   LOG_DEBUG("  - fillOp: " << *fillInfo.fillOp.getOperation());
-  markOpBlockId(allocOp, *targetBlockId);
-  markOpBlockId(fillInfo.fillOp, *targetBlockId);
-  markOpBlockId(fillInfo.parentIf, *targetBlockId);
+  
+  bm.updateBlockId(allocOp, *targetBlockId);
+  bm.updateBlockId(fillInfo.fillOp, *targetBlockId);
+  bm.updateBlockId(fillInfo.parentIf, *targetBlockId);
+
   return true;
 }
 
 } // anonymous namespace
 
-void forgeFilledAllocInIf(linalg::FillOp fillOp)
+void forgeFilledAllocInIf(linalg::FillOp fillOp, CVPipeline::ComputeBlockIdManager &bm)
 {
     Value out = *fillOp.getOutputs().begin();
     memref::AllocOp allocOp = llvm::dyn_cast_if_present<memref::AllocOp>(out.getDefiningOp());
@@ -445,34 +441,34 @@ void forgeFilledAllocInIf(linalg::FillOp fillOp)
         return;
     }
     auto blockId = CVPipeline::getOpBlockId(allocOp).value();
-    markOpBlockId(ifOp, blockId);
-    markOpBlockId(fillOp, blockId);
+    bm.updateBlockId(ifOp, blockId);
+    bm.updateBlockId(fillOp, blockId);
 }
 
-void dfsMarkAsBlockId(Operation *op, unsigned blockId)
+void dfsMarkAsBlockId(Operation *op, unsigned blockId, CVPipeline::ComputeBlockIdManager &bm)
 {
     if (!op) {
         return;
     }
-    markOpBlockId(op, blockId);
+    bm.updateBlockId(op, blockId);
     llvm::TypeSwitch<Operation *>(op)
       .Case([&](ViewLikeOpInterface viewOp) {
-          dfsMarkAsBlockId(viewOp.getViewSource().getDefiningOp(), blockId);
+          dfsMarkAsBlockId(viewOp.getViewSource().getDefiningOp(), blockId, bm);
       })
       .Case([&](CastOpInterface castOp) {
-          dfsMarkAsBlockId(castOp->getOperand(0).getDefiningOp(), blockId);
+          dfsMarkAsBlockId(castOp->getOperand(0).getDefiningOp(), blockId, bm);
       })
     ;
 }
 
-void forgeCopyOp(memref::CopyOp copyOp, CVPipeline::MemoryDependenceGraph &memGraph)
+void forgeCopyOp(memref::CopyOp copyOp, CVPipeline::MemoryDependenceGraph &memGraph, CVPipeline::ComputeBlockIdManager &bm)
 {
     Value src = copyOp.getSource();
     Value dst = copyOp.getTarget();
     auto blockId = CVPipeline::getOpBlockId(copyOp).value();
 
-    dfsMarkAsBlockId(src.getDefiningOp(), blockId);
-    dfsMarkAsBlockId(dst.getDefiningOp(), blockId);
+    dfsMarkAsBlockId(src.getDefiningOp(), blockId, bm);
+    dfsMarkAsBlockId(dst.getDefiningOp(), blockId, bm);
 }
 
 class UnifyAllocBlockPass
@@ -494,8 +490,9 @@ public:
     LOG_DEBUG("Before: " << *module << "\n");
     auto &aa = getAnalysis<AliasAnalysis>();
     CVPipeline::MemoryDependenceGraph memGraph(module, aa);
+    auto bm = CVPipeline::ComputeBlockIdManager(module);
 
-    module.walk([&](memref::CopyOp copyOp){forgeCopyOp(copyOp, memGraph);});
+    module.walk([&](memref::CopyOp copyOp){forgeCopyOp(copyOp, memGraph, bm);});
 
     module.walk([&](linalg::FillOp fillOp) {
         auto *parentOp = fillOp->getParentOp();
@@ -508,7 +505,7 @@ public:
             return;
         }
         LOG_DEBUG("Processing: " << ifOp << "\n");
-        forgeFilledAllocInIf(fillOp);
+        forgeFilledAllocInIf(fillOp, bm);
     });
 
     int processedCount = 0;
@@ -516,7 +513,7 @@ public:
 
     module.walk([&](memref::AllocOp allocOp) {
       processedCount++;
-      if (tryUnifyForAlloc(allocOp, memGraph)) {
+      if (tryUnifyForAlloc(allocOp, memGraph, bm)) {
         successCount++;
       }
     });

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock.cpp
@@ -44,7 +44,6 @@ void PlanComputeBlockPass::runOnOperation()
 {
     ModuleOp module = getOperation();
     OpPassManager pm(module.getOperationName());
-    CVPipeline::ComputeBlockIdManager::getInstance().reset();
     LOG_DEBUG("Enter pass.\n");
 
     // Step 1: Run OpClassifierPass to classify operations

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/Common.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/Common.cpp
@@ -21,14 +21,14 @@
  */
  
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
+#include "DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
 
 namespace mlir {
 namespace CVPipeline {
 
 void initializeIndegreeForBlock(Block *block, llvm::DenseMap<Operation *, int> &indegree,
-                                const MemoryDependenceGraph &memGraph)
+                                const MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
 {
-    auto &bm = ComputeBlockIdManager::getInstance();
 
     block->walk([&](Operation *op) {
         if (op->getBlock() != block) { return; }

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.cpp
@@ -21,16 +21,32 @@
  */
 
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/Debug.h"
-#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "llvm/Support/LogicalResult.h"
 
 namespace mlir {
 namespace CVPipeline {
+
+ComputeBlockIdManager::ComputeBlockIdManager(Operation *root)
+{
+    cntComputeBlockId = 0;
+    blockIdToOps.clear();
+    opToBlockId.clear();
+    root->walk([&](Operation *op) {
+        if (auto blockIdAttr = op->getAttrOfType<IntegerAttr>(kBlockId)) {
+            if (auto blockId = blockIdAttr.getInt()) {
+                opToBlockId[op] = blockId;
+                blockIdToOps[blockId].push_back(op);
+                cntComputeBlockId = std::max(cntComputeBlockId, static_cast<int>(blockId));
+            }
+        }
+    });
+    cntComputeBlockId++; // ensure new id is unique
+}
 
 bool ComputeBlockIdManager::isWholeCubeReady(Operation *seedOp, llvm::DenseMap<Operation *, int> &indegree)
 {
@@ -58,41 +74,25 @@ bool ComputeBlockIdManager::isSameBlock(Operation *a, Operation *b)
     return false;
 }
 
-unsigned int ComputeBlockIdManager::getNextId()
+int ComputeBlockIdManager::getNextId()
 {
-    std::lock_guard<std::mutex> lock(managerMutex);
     return cntComputeBlockId++;
-}
-
-llvm::LogicalResult ComputeBlockIdManager::markOpBlockId(Operation *op, int blockId)
-{
-    if (blockId < 0) {
-        op->emitError("marking block id as negative");
-        return llvm::failure();
-    }
-    if (!op) {
-        return llvm::success();
-    }
-    MLIRContext *ctx = op->getContext();
-    op->setAttr(kBlockId, IntegerAttr::get(IntegerType::get(ctx, blockIdWidth), blockId));
-    return record(op, blockId);
 }
 
 void ComputeBlockIdManager::updateBlockId(Operation *op, int blockId)
 {
-
+    // Force Update.
     MLIRContext *ctx = op->getContext();
     op->setAttr(kBlockId, IntegerAttr::get(IntegerType::get(ctx, blockIdWidth), blockId));
-    std::lock_guard<std::mutex> lock(managerMutex);
     auto it = opToBlockId.find(op);
     if (it != opToBlockId.end()) {
         int preBlockId = it->second;
         auto &vec = blockIdToOps[preBlockId];
-        auto vecIt = llvm::find(vec, op);  
+        auto vecIt = llvm::find(vec, op);
         if (vecIt != vec.end()) {
             vec.erase(vecIt);
         }
-    } 
+    }
     opToBlockId[op] = blockId;
     blockIdToOps[blockId].push_back(op);
 }
@@ -102,7 +102,7 @@ llvm::SmallVector<Operation *> ComputeBlockIdManager::getOpsByBlockId(int blockI
     if (blockId == -1) {
         return {};
     }
-    std::lock_guard<std::mutex> lock(managerMutex);
+
     auto it = blockIdToOps.find(blockId);
     if (it == blockIdToOps.end()) {
         return {};
@@ -112,7 +112,6 @@ llvm::SmallVector<Operation *> ComputeBlockIdManager::getOpsByBlockId(int blockI
 
 int ComputeBlockIdManager::getBlockIdByOp(Operation *op)
 {
-    std::lock_guard<std::mutex> lock(managerMutex);
     auto it = opToBlockId.find(op);
     if (it != opToBlockId.end()) {
         return it->second;
@@ -120,34 +119,11 @@ int ComputeBlockIdManager::getBlockIdByOp(Operation *op)
     return -1;
 }
 
-llvm::LogicalResult ComputeBlockIdManager::markOpsWithNewId(llvm::SmallVectorImpl<Operation *> &ops)
+llvm::LogicalResult ComputeBlockIdManager::markAndRecord(Operation *op, int blockId)
 {
-    if (ops.empty()) {
-        return llvm::success();
-    }
-    int id = static_cast<int>(getNextId());
-    for (Operation *op : ops) {
-        if (llvm::failed(markOpBlockId(op, id))) {
-            return llvm::failure();
-        }
-    }
-    return llvm::success();
-}
-
-void ComputeBlockIdManager::reset()
-{
-    std::lock_guard<std::mutex> lock(managerMutex);
-    cntComputeBlockId = 0;
-    blockIdToOps.clear();
-    opToBlockId.clear();
-}
-
-llvm::LogicalResult ComputeBlockIdManager::record(Operation *op, int blockId)
-{
-    if (!op || blockId < 0) {
-        return llvm::success();
-    }
-    std::lock_guard<std::mutex> lock(managerMutex);
+    // When we call mark, we assume the op have no record in manager.
+    MLIRContext *ctx = op->getContext();
+    op->setAttr(kBlockId, IntegerAttr::get(IntegerType::get(ctx, blockIdWidth), blockId));
     auto itOld = opToBlockId.find(op);
     if (itOld != opToBlockId.end()) {
         llvm::errs() << "Error: Operation already has a block id. Op: " << *op << ", old block id: " << itOld->second
@@ -156,14 +132,36 @@ llvm::LogicalResult ComputeBlockIdManager::record(Operation *op, int blockId)
     }
 
     opToBlockId[op] = blockId;
-    auto &vec = blockIdToOps[blockId];
-    for (Operation *existing : vec) {
-        if (existing == op) {
-            return llvm::success();
+    blockIdToOps[blockId].push_back(op);
+    return llvm::success();
+}
+
+llvm::LogicalResult ComputeBlockIdManager::markOpBlockId(Operation *op)
+{
+    int blockId = getNextId();
+    return markAndRecord(op, blockId);
+}
+
+llvm::LogicalResult ComputeBlockIdManager::markOpsWithNewId(llvm::SmallVectorImpl<Operation *> &ops)
+{
+    if (ops.empty()) {
+        return llvm::success();
+    }
+    int id = getNextId();
+    for (Operation *op : ops) {
+
+        if (llvm::failed(markAndRecord(op, id))) {
+            return llvm::failure();
         }
     }
-    vec.push_back(op);
     return llvm::success();
+}
+
+void ComputeBlockIdManager::reset()
+{
+    cntComputeBlockId = 0;
+    blockIdToOps.clear();
+    opToBlockId.clear();
 }
 
 } // namespace CVPipeline

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
@@ -64,6 +64,7 @@ class SeedRegionPlanner {
     Operation *seed;
     Block *block;
     const MemoryDependenceGraph &memGraph;
+    ComputeBlockIdManager &bm;
     llvm::DenseSet<Operation *> &assigned;
     llvm::SmallVectorImpl<Operation *> &group;
     bool willCreateCycle(Operation *op);
@@ -77,8 +78,9 @@ public:
                       Block *block,
                       const MemoryDependenceGraph &memGraph,
                       llvm::DenseSet<Operation *> &assigned,
-                      llvm::SmallVectorImpl<Operation *> &group)
-        : seed(seed), block(block), memGraph(memGraph), assigned(assigned), group(group)
+                      llvm::SmallVectorImpl<Operation *> &group,
+                      ComputeBlockIdManager &bm)
+        : seed(seed), block(block), memGraph(memGraph), assigned(assigned), group(group), bm(bm)
     {
         group.push_back(seed);
     }
@@ -95,6 +97,7 @@ struct DependencyCycleDetector {
     llvm::DenseSet<mlir::Operation *> &okSet;
     llvm::DenseSet<mlir::Operation *> visited;
     const MemoryDependenceGraph &memGraph;
+    ComputeBlockIdManager &bm;
     Block *block;
     void clear() { visited.clear(); }
     bool operator()(Operation *cur);
@@ -102,8 +105,9 @@ struct DependencyCycleDetector {
 
     DependencyCycleDetector(Block *block,
                             const MemoryDependenceGraph &memGraph,
-                            llvm::DenseSet<mlir::Operation *> &okSet)
-        : block(block), memGraph(memGraph), okSet(okSet)
+                            llvm::DenseSet<mlir::Operation *> &okSet,
+                            ComputeBlockIdManager &bm)
+        : block(block), memGraph(memGraph), okSet(okSet), bm(bm)
     {}
 };
 
@@ -125,7 +129,6 @@ bool DependencyCycleDetector::operator()(Operation *cur)
     }
     for (auto *user : allusers) {
         auto *userInBlock = getAncestorInBlock(user, block);
-        auto &bm = ComputeBlockIdManager::getInstance();
         if (bm.getBlockIdByOp(userInBlock) == -1) {
             if (dfs(userInBlock)) {
                 return true;
@@ -147,7 +150,7 @@ bool SeedRegionPlanner::willCreateCycle(Operation *op)
     llvm::DenseSet<mlir::Operation *> okSet(group.begin(), group.end());
     okSet.insert(op);
 
-    DependencyCycleDetector dfs = {block, memGraph, okSet};
+    DependencyCycleDetector dfs = {block, memGraph, okSet, bm};
 
     // DFS from every result in okSet
     for (mlir::Operation *okOp : okSet) {
@@ -161,7 +164,6 @@ bool SeedRegionPlanner::willCreateCycle(Operation *op)
             if (okSet.contains(userInBlock)) {
                 continue;
             }
-            auto &bm = ComputeBlockIdManager::getInstance();
             if (bm.getBlockIdByOp(userInBlock) == -1) {
                 dfs.clear();
                 if (dfs(userInBlock)) {
@@ -280,6 +282,7 @@ class TopologicalPartitionPlanner {
     llvm::DenseMap<Operation *, int> indegree;
     llvm::DenseSet<Operation *> &assigned;
     const MemoryDependenceGraph &memGraph;
+    ComputeBlockIdManager &bm;
     llvm::DenseSet<Operation *> newassigned;
     llvm::DenseSet<Operation *> bypassVisited;
     std::queue<Operation *> queue;
@@ -295,10 +298,10 @@ class TopologicalPartitionPlanner {
 public:
     TopologicalPartitionPlanner(Block *block,
                                 llvm::DenseSet<Operation *> &assigned,
-                                const MemoryDependenceGraph &memGraph)
-        : block(block), assigned(assigned), memGraph(memGraph)
+                                const MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
+        : block(block), assigned(assigned), memGraph(memGraph), bm(bm)
     {
-        initializeIndegreeForBlock(block, indegree, memGraph);
+        initializeIndegreeForBlock(block, indegree, memGraph, bm);
 
         block->walk([&](Operation *op) {
             if (op->getBlock() == block && isCubeOp(op) && !assigned.contains(op)) {
@@ -320,14 +323,13 @@ void TopologicalPartitionPlanner::removeNonCubeOpsRecursively(Operation *op)
     auto *block = op->getBlock();
     SmallVector<Operation *> allusers;
     allusers.append(op->getUsers().begin(), op->getUsers().end());
-    auto &bm = ComputeBlockIdManager::getInstance();
     for (auto *memUser : memGraph.getExecAfter(op)) {
         allusers.push_back(memUser);
     }
     for (auto *user : allusers) {
         auto *userInBlock = getAncestorInBlock(user, block);
         if (!userInBlock || !indegree.contains(userInBlock) ||
-            ComputeBlockIdManager::getInstance().isSameBlock(userInBlock, op)) {
+            bm.isSameBlock(userInBlock, op)) {
             continue;
         }
         LOG_DEBUG("Sub indegree to " << *userInBlock << " from " << *op << "new degree =  " << indegree[userInBlock] - 1
@@ -337,7 +339,6 @@ void TopologicalPartitionPlanner::removeNonCubeOpsRecursively(Operation *op)
             !shouldSkip(userInBlock)) {
             continue;
         }
-        auto &bm = ComputeBlockIdManager::getInstance();
         auto blockId = bm.getBlockIdByOp(userInBlock);
         if (blockId == -1) {
             removeNonCubeOpsRecursively(userInBlock);
@@ -368,7 +369,6 @@ static bool mapsAreDiff(const llvm::DenseMap<Operation *, int> &a, const llvm::D
  */
 llvm::LogicalResult TopologicalPartitionPlanner::removeReadyNonCubeOps()
 {
-    auto &bm = ComputeBlockIdManager::getInstance();
     auto indegreeBefore = indegree;
     size_t beforeVisitedSize = bypassVisited.size();
     for (auto &p : indegree) {
@@ -493,7 +493,6 @@ llvm::SmallVector<Operation *> TopologicalPartitionPlanner::createNewGroupFromQu
 
 llvm::LogicalResult TopologicalPartitionPlanner::run()
 {
-    auto &bm = ComputeBlockIdManager::getInstance();
     while (nonAssignedCubeCnt > 0) {
         if (failed(populateQueueWithReadyOps())) {
             return llvm::failure();
@@ -530,7 +529,7 @@ static SmallVector<Operation *> collectMatmulOps(Block *block)
  * Main entry point: Process a single block by grouping operations into
  * execution blocks using BFS and topological traversal.
  */
-static llvm::LogicalResult processBlockWithCubeBFS(Block *block, const MemoryDependenceGraph &memGraph)
+static llvm::LogicalResult processBlockWithCubeBFS(Block *block, const MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
 {
     llvm::DenseSet<Operation *> assigned;
     auto allDots = collectMatmulOps(block);
@@ -542,19 +541,19 @@ static llvm::LogicalResult processBlockWithCubeBFS(Block *block, const MemoryDep
         }
 
         llvm::SmallVector<Operation *> newGroup;
-        SeedRegionPlanner regionPlanner {dot, block, memGraph, assigned, newGroup};
+        SeedRegionPlanner regionPlanner {dot, block, memGraph, assigned, newGroup, bm};
         regionPlanner.run();
 
         for (auto *op : newGroup) {
             assigned.insert(op);
         }
-        if (llvm::failed(ComputeBlockIdManager::getInstance().markOpsWithNewId(newGroup))) {
+        if (llvm::failed(bm.markOpsWithNewId(newGroup))) {
           return llvm::failure();
         }
     }
 
     // Phase 2: Handle remaining Cube Ops following Topo order
-    TopologicalPartitionPlanner topoPlanner {block, assigned, memGraph};
+    TopologicalPartitionPlanner topoPlanner {block, assigned, memGraph, bm};
     return topoPlanner.run();
 }
 
@@ -564,10 +563,11 @@ void mlir::triton::PlanCubeBlockPass::runOnOperation()
     auto moduleOp = getOperation();
     auto &aa = getAnalysis<AliasAnalysis>();
     auto memGraph = MemoryDependenceGraph(moduleOp, aa);
+    auto bm = ComputeBlockIdManager(moduleOp);
 
     // We do not need to skip linalg blocks since they do not have core types and do not contain matmul
     auto result = moduleOp.walk([&](Block *block) {
-      if (llvm::failed(processBlockWithCubeBFS(block, memGraph))) {
+      if (llvm::failed(processBlockWithCubeBFS(block, memGraph, bm))) {
         return WalkResult::interrupt();
       }
       return WalkResult::advance();

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <memory>
+#include "DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Passes.h"
@@ -43,6 +44,7 @@ static constexpr const char *DEBUG_TYPE = "plan-vector-block";
 
 using namespace mlir;
 using namespace triton;
+using namespace CVPipeline;
 
 namespace mlir {
 namespace triton {
@@ -76,9 +78,8 @@ bool isFusableOp(Operation *op)
 
 void passAndCollectCandidates(Operation *nowOp, DenseMap<Operation *, int> &indegree,
                               SmallVector<Operation *> &candidates, DenseMap<Operation *, bool> &visited,
-                              const CVPipeline::MemoryDependenceGraph &memGraph)
+                              const CVPipeline::MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
 {
-    auto &bm = CVPipeline::ComputeBlockIdManager::getInstance();
     LOG_DEBUG("Bypassing non-fusable op " << *nowOp << "\nnow candidates size: " << candidates.size() << "\n");
     auto block = nowOp->getBlock();
     SmallVector<Operation *> allusers;
@@ -99,12 +100,12 @@ void passAndCollectCandidates(Operation *nowOp, DenseMap<Operation *, int> &inde
             if (!isFusableOp(userInBlock) && !visited[userInBlock]) {
                 if (bm.getBlockIdByOp(userInBlock) == -1) {
                     visited[userInBlock] = true; // mark as fused to avoid duplicate bypass
-                    passAndCollectCandidates(userInBlock, indegree, candidates, visited, memGraph);
+                    passAndCollectCandidates(userInBlock, indegree, candidates, visited, memGraph, bm);
                 } else {
                     for (auto cubeop : bm.getOpsByBlockId(bm.getBlockIdByOp(userInBlock))) {
                         if (!visited[cubeop]) {
                             visited[cubeop] = true;
-                            passAndCollectCandidates(cubeop, indegree, candidates, visited, memGraph);
+                            passAndCollectCandidates(cubeop, indegree, candidates, visited, memGraph, bm);
                         }
                     }
                 }
@@ -119,20 +120,19 @@ void passAndCollectCandidates(Operation *nowOp, DenseMap<Operation *, int> &inde
 }
 
 void byPassNonFusable(DenseMap<Operation *, int> &indegree, SmallVector<Operation *> &candidates,
-                      DenseMap<Operation *, bool> &visited, const CVPipeline::MemoryDependenceGraph &memGraph)
+                      DenseMap<Operation *, bool> &visited, const CVPipeline::MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
 {
     // for every non-fusable candidates, bypass it.
     for (auto &[op, degree] : indegree) {
-        auto &bm = CVPipeline::ComputeBlockIdManager::getInstance();
         if (bm.isWholeCubeReady(op, indegree) && !isFusableOp(op) && !visited[op]) {
             if (bm.getBlockIdByOp(op) == -1) {
                 visited[op] = true; // mark as fused to avoid duplicate bypass
-                passAndCollectCandidates(op, indegree, candidates, visited, memGraph);
+                passAndCollectCandidates(op, indegree, candidates, visited, memGraph, bm);
             } else {
                 for (auto cubeop : bm.getOpsByBlockId(bm.getBlockIdByOp(op))) {
                     if (!visited[cubeop]) {
                         visited[cubeop] = true;
-                        passAndCollectCandidates(cubeop, indegree, candidates, visited, memGraph);
+                        passAndCollectCandidates(cubeop, indegree, candidates, visited, memGraph, bm);
                     }
                 }
             }
@@ -144,7 +144,6 @@ void updateCandidates(Operation *nextFused, SmallVector<Operation *> &candidates
                       DenseMap<Operation *, bool> &visited, const CVPipeline::MemoryDependenceGraph &memGraph)
 {
     // 1. Already fuse with nextFused, so remove it from candidates
-    auto &bm = CVPipeline::ComputeBlockIdManager::getInstance();
     for (auto it = candidates.begin(); it != candidates.end(); it++) {
         if (*it == nextFused) {
             it = candidates.erase(it);
@@ -175,13 +174,13 @@ void updateCandidates(Operation *nextFused, SmallVector<Operation *> &candidates
 }
 
 void findCandidates(DenseMap<Operation *, int> &indegree, SmallVector<Operation *> &candidates,
-                    DenseMap<Operation *, bool> &visited, const CVPipeline::MemoryDependenceGraph &memGraph)
+                    DenseMap<Operation *, bool> &visited, const CVPipeline::MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
 {
     // 1. if no candidate, try to bypass non-fusable
     LOG_DEBUG("Finding source ops............\n");
     if (candidates.empty()) {
         LOG_DEBUG("No candidates available, try bypass\n");
-        byPassNonFusable(indegree, candidates, visited, memGraph);
+        byPassNonFusable(indegree, candidates, visited, memGraph, bm);
     }
     // 2. find candidates whose indegree is 0 and not visited, add them to candidates and mark visited
     for (auto &[op, degree] : indegree) {
@@ -326,13 +325,13 @@ static void evictAndRestoreState(Block *block, const SetVector<Operation *> &kee
 
 void refineFuseGroup(Block *block, SmallVector<Operation *> &nowFuseGroup, DenseMap<Operation *, bool> &visited,
                      SmallVector<Operation *> &candidates, DenseMap<Operation *, int> &indegree,
-                     const CVPipeline::MemoryDependenceGraph &memGraph)
+                     const CVPipeline::MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
 {
     // 1.Find ops in fuse group whose next node is a non-fusable (CUBE-only) op
     auto toProcess = findOpsAdjacentToCube(block, nowFuseGroup, visited, memGraph);
     // 2. early return: if cannot find one node which next node is CUBE, need to check if return or not;
     if (toProcess.empty()) {
-        findCandidates(indegree, candidates, visited, memGraph);
+        findCandidates(indegree, candidates, visited, memGraph, bm);
         if (candidates.empty()) {
             return;
         }
@@ -347,13 +346,13 @@ void refineFuseGroup(Block *block, SmallVector<Operation *> &nowFuseGroup, Dense
 }
 
 // Main function to plan vector block id for one block
-llvm::LogicalResult planVectorBlockId(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph)
+llvm::LogicalResult planVectorBlockId(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
 {
     // 1. topo initialize
     llvm::DenseMap<Operation *, int> indegree;
     llvm::SmallVector<Operation *> queue;
     llvm::DenseMap<Operation *, bool> visited; // has been visited in search
-    CVPipeline::initializeIndegreeForBlock(block, indegree, memGraph);
+    initializeIndegreeForBlock(block, indegree, memGraph, bm);
 
     // 2. initialize visited and find initial candidates
     block->walk([&](Operation *op) {
@@ -365,7 +364,7 @@ llvm::LogicalResult planVectorBlockId(Block *block, const CVPipeline::MemoryDepe
             }
         }
     });
-    findCandidates(indegree, queue, visited, memGraph);
+    findCandidates(indegree, queue, visited, memGraph, bm);
 
     // 3. find fuse group follow topo order
     llvm::SmallVector<Operation *> nowFuseGroup;
@@ -379,15 +378,14 @@ llvm::LogicalResult planVectorBlockId(Block *block, const CVPipeline::MemoryDepe
         if (queue.empty() || nextFused == nullptr) {
             // finish one group, assign block id and start next iteration
             // Cut error operations before assigning block id
-            refineFuseGroup(block, nowFuseGroup, visited, queue, indegree, memGraph);
+            refineFuseGroup(block, nowFuseGroup, visited, queue, indegree, memGraph, bm);
 
-            auto &bm = CVPipeline::ComputeBlockIdManager::getInstance();
             if (llvm::failed(bm.markOpsWithNewId(nowFuseGroup))) {
                 return llvm::failure();
             }
             nowFuseGroup.clear();
             // reset queue
-            findCandidates(indegree, queue, visited, memGraph);
+            findCandidates(indegree, queue, visited, memGraph, bm);
         }
     }
     return llvm::success();
@@ -395,16 +393,18 @@ llvm::LogicalResult planVectorBlockId(Block *block, const CVPipeline::MemoryDepe
 
 void PlanVectorBlockPass::runOnOperation()
 {
-    ModuleOp module = getOperation();
     // 1. Build memory dependence graph
-    auto &aliasAnalysis = getAnalysis<mlir::AliasAnalysis>();
-    CVPipeline::MemoryDependenceGraph memDepGraph(module, aliasAnalysis);
+    auto moduleOp = getOperation();
+    auto &aa = getAnalysis<AliasAnalysis>();
+    auto memDepGraph = MemoryDependenceGraph(moduleOp, aa);
+    auto bm = ComputeBlockIdManager(moduleOp);
+
 
     // 2. search blocks in topo order and assign block id for each block
     llvm::SmallVector<Block *> blocks;
-    module.walk([&](Block *block) {
-        if (llvm::failed(planVectorBlockId(block, memDepGraph))) {
-            module.emitError() << "[" << DEBUG_TYPE << "] Failed to plan vector block id for block";
+    moduleOp.walk([&](Block *block) {
+        if (llvm::failed(planVectorBlockId(block, memDepGraph, bm))) {
+            moduleOp.emitError() << "[" << DEBUG_TYPE << "] Failed to plan vector block id for block";
             signalPassFailure();
             return;
         }

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
@@ -28,7 +28,6 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/Support/Debug.h"
-#include "llvm/Support/Error.h"
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -158,7 +157,7 @@ BlockOpGraph::BlockOpGraph(ArrayRef<Operation *> allOps, Block *block, const Mem
     }
 }
 
-static llvm::FailureOr<DenseMap<Operation *, int>> collectBlockIds(ArrayRef<Operation *> allOps)
+static llvm::FailureOr<DenseMap<Operation *, int>> collectBlockIds(ArrayRef<Operation *> allOps, ComputeBlockIdManager &bm)
 {
     DenseMap<Operation *, int> opBlockId;
     for (Operation *op : allOps) {
@@ -167,7 +166,7 @@ static llvm::FailureOr<DenseMap<Operation *, int>> collectBlockIds(ArrayRef<Oper
         }
         auto blockIdAttrRes = getOpBlockId(op);
         int64_t blockId =
-            blockIdAttrRes.has_value() ? blockIdAttrRes.value() : ComputeBlockIdManager::getInstance().getNextId();
+            blockIdAttrRes.has_value() ? blockIdAttrRes.value() : bm.getNextId();
         opBlockId[op] = blockId;
     }
     return opBlockId;
@@ -330,12 +329,12 @@ static void applyReorder(Block &block, ArrayRef<Operation *> reordered)
     }
 }
 
-static llvm::LogicalResult reorderOpsInBlock(Block &block, const MemoryDependenceGraph &memGraph)
+static llvm::LogicalResult reorderOpsInBlock(Block &block, const MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
 {
     const auto allOps = llvm::to_vector(llvm::make_pointer_range(block.without_terminator()));
 
     const BlockOpGraph graph {allOps, &block, memGraph};
-    llvm::FailureOr<DenseMap<Operation *, int>> opBlockIdOpt = collectBlockIds(allOps);
+    llvm::FailureOr<DenseMap<Operation *, int>> opBlockIdOpt = collectBlockIds(allOps, bm);
     if (failed(opBlockIdOpt)) {
         return failure();
     }
@@ -364,6 +363,7 @@ void ReorderOpsByBlockIdPass::runOnOperation()
     auto moduleOp = getOperation();
     auto &aa = getAnalysis<AliasAnalysis>();
     auto memGraph = MemoryDependenceGraph(moduleOp, aa);
+    auto bm = ComputeBlockIdManager(moduleOp);
     moduleOp.walk([&](Block *block) {
         auto *parentOp = block->getParentOp();
         if (!parentOp ||
@@ -371,7 +371,7 @@ void ReorderOpsByBlockIdPass::runOnOperation()
             !(isa<func::FuncOp>(parentOp) || isa<scf::SCFDialect>(parentOp->getDialect()))) {
             return WalkResult::skip();
         }
-        if (llvm::failed(reorderOpsInBlock(*block, memGraph))) {
+        if (llvm::failed(reorderOpsInBlock(*block, memGraph, bm))) {
             signalPassFailure();
         }
         return WalkResult::advance();

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/ub_usage_opt.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/ub_usage_opt.mlir
@@ -1,0 +1,67 @@
+// RUN: triton-opt --ub-usage-opt %s | FileCheck %s
+
+// Test UB usage optimization: dividing of V1 and V2 should change to one small ub dependency.
+// math.exp<64x64> -> || ->linalg.fill<64> -> linalg.reduce<64> -> arith.subf<64> -> xxx 
+// math.exp<64x64> -> linalg.fill<64> -> linalg.reduce<64> -> arith.subf<64> -> || -> xxx
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  // CHECK-LABEL: func.func @_attn_fwd
+  func.func @_attn_fwd(%arg7: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %out_offset_i64: i64) attributes {global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %c0_i32 = arith.constant {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} 0 : i32
+    %c64 = arith.constant {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} 64 : index
+    %cst = arith.constant {ssbuffer.block_id = 13 : i32, ssbuffer.core_type = "VECTOR"} 1.000000e+00 : f32
+    %cst_f16 = arith.constant {ssbuffer.block_id = 13 : i32, ssbuffer.core_type = "VECTOR"} 1.000000e+00 : f16
+    %c0_i32_4 = arith.constant {ssbuffer.block_id = 13 : i32, ssbuffer.core_type = "VECTOR"} 0 : i32
+    %0 = tensor.empty() {ssbuffer.block_id = 13 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+    %1 = linalg.fill {ssbuffer.block_id = 13 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : f32) outs(%0 : tensor<64x64xf32>) -> tensor<64x64xf32>
+    %f16_tensor_empty = tensor.empty() {ssbuffer.block_id = 13 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16>
+    %f16_tensor = linalg.fill {ssbuffer.block_id = 13 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_f16 : f16) outs(%f16_tensor_empty : tensor<64x64xf16>) -> tensor<64x64xf16>
+    %4 = tensor.empty() {ssbuffer.block_id = 13 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64xf32>
+    %5 = linalg.fill {ssbuffer.block_id = 13 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : f32) outs(%4 : tensor<64xf32>) -> tensor<64xf32>
+    
+    %40:3 = scf.for %arg17 = %c0_i32_4 to %c0_i32_4 step %c0_i32_4 iter_args(%arg18 = %5, %arg19 = %1, %arg20 = %5) -> (tensor<64xf32>, tensor<64x64xf32>, tensor<64xf32>) : i32 {
+      %69 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%f16_tensor, %f16_tensor : tensor<64x64xf16>, tensor<64x64xf16>) outs(%1 : tensor<64x64xf32>) -> tensor<64x64xf32>
+      
+      %71 = arith.mulf %69, %1 {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+      %reduced = linalg.reduce ins(%71 : tensor<64x64xf32>) outs(%5 : tensor<64xf32>) dimensions = [1] {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "VECTOR"}
+        (%in: f32, %init: f32) {
+          %93 = arith.maximumf %in, %init : f32
+          linalg.yield %93 : f32
+        }
+      %72 = arith.maximumf %arg20, %reduced {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64xf32>
+      %broadcasted_18 = linalg.broadcast ins(%72 : tensor<64xf32>) outs(%0 : tensor<64x64xf32>) dimensions = [1] {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "VECTOR"}
+      %73 = arith.subf %71, %broadcasted_18 {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+      %74 = math.exp %73 {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+      %75 = arith.truncf %74 {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+      %83 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%75, %f16_tensor : tensor<64x64xf16>, tensor<64x64xf16>) outs(%1 : tensor<64x64xf32>) -> tensor<64x64xf32>
+      
+      // CHECK: %{{.*}} = linalg.fill {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "VECTOR"} ins(%{{.*}} : f32) outs(%{{.*}} : tensor<64xf32>) -> tensor<64xf32>
+      %84 = linalg.fill {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : f32) outs(%4 : tensor<64xf32>) -> tensor<64xf32>
+      // CHECK: %{{.*}} = linalg.reduce ins(%{{.*}} : tensor<64x64xf32>) outs(%{{.*}} : tensor<64xf32>) dimensions = [1]  {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "VECTOR"}
+      %reduced_22 = linalg.reduce ins(%74 : tensor<64x64xf32>) outs(%84 : tensor<64xf32>) dimensions = [1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"}
+        (%in: f32, %init: f32) {
+          %93 = arith.addf %in, %init : f32
+          linalg.yield %93 : f32
+        }
+      // CHECK: %{{.*}} = arith.subf %{{.*}}, %{{.*}} {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64xf32>
+      %85 = arith.subf %arg20, %72 {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64xf32>
+      %86 = math.exp %85 {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64xf32>
+      %87 = arith.mulf %arg18, %86 {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64xf32>
+      %88 = arith.addf %87, %reduced_22 {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64xf32>
+      %broadcasted_23 = linalg.broadcast ins(%86 : tensor<64xf32>) outs(%0 : tensor<64x64xf32>) dimensions = [1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"}
+      %89 = arith.mulf %arg19, %broadcasted_23 {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+      %90 = arith.addf %83, %89 {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+      
+      scf.yield {ssbuffer.core_type = "VECTOR, VECTOR, VECTOR"} %88, %90, %72 : tensor<64xf32>, tensor<64x64xf32>, tensor<64xf32>
+    } {ssbuffer.core_type = "VECTOR, VECTOR, VECTOR, VECTOR, VECTOR", tt.divisibility_arg1 = dense<64> : tensor<1xi32>}
+        
+    %out_offset = arith.index_cast %out_offset_i64 {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"} : i64 to index
+    %reinterpret_cast_13 = memref.reinterpret_cast %arg7 to offset: [%out_offset], sizes: [64, 64], strides: [64, 1] {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    %broadcasted = linalg.broadcast ins(%40#0 : tensor<64xf32>) outs(%0 : tensor<64x64xf32>) dimensions = [1] {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"}
+    %55 = arith.divf %40#1, %broadcasted {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+    %60 = arith.truncf %55 {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    bufferization.materialize_in_destination %60 in writable %reinterpret_cast_13 {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+    
+    return
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/plan_compute_block_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/plan_compute_block_test.mlir
@@ -22,14 +22,14 @@
 // CHECK: [[CYCLE_A:%[0-9]+]] = arith.truncf %arg3 {ssbuffer.block_id = [[TC01_VEC]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32> to tensor<4x4xf16>
 // CHECK: [[CYCLE_C:%[0-9]+]] = linalg.matmul {ssbuffer.block_id = [[TC01_CYCLE:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} ins({{.*}}, [[CYCLE_A]] : tensor<4x4xf16>, tensor<4x4xf16>)
 // CHECK: [[DEP_ALLOC0:%[A-Za-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = [[TC01_DEP_LOAD0:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf16>
-// CHECK-NEXT: [[DEP_T0:%[0-9]+]] = bufferization.to_tensor [[DEP_ALLOC0]] restrict writable {ssbuffer.block_id = [[TC01_DEP_LOAD0]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf16> to tensor<4x4xf16>
+// CHECK-NEXT: [[DEP_T0:%[0-9]+]] = bufferization.to_tensor [[DEP_ALLOC0]] restrict writable {ssbuffer.block_id = [[TC01_DEP_LOAD0]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf16>
 // CHECK: [[DEP_FILL0:%[0-9]+]] = linalg.fill {ssbuffer.block_id = [[TC01_DEP0:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} ins({{.*}} : f32) outs({{.*}} : tensor<4x4xf32>) -> tensor<4x4xf32>
 // CHECK-NEXT: [[DEP_MM0:%[0-9]+]] = linalg.matmul {ssbuffer.block_id = [[TC01_DEP0]] : i32, ssbuffer.core_type = "CUBE"} ins({{.*}}, [[DEP_T0]] : tensor<4x4xf16>, tensor<4x4xf16>) outs([[DEP_FILL0]] : tensor<4x4xf32>)
 // CHECK: linalg.matmul {ssbuffer.block_id = [[TC01_VF0:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} ins({{.*}}, %arg5 : tensor<4x4xf16>, tensor<4x4xf16>) outs({{.*}} : tensor<4x4xf32>)
 // CHECK: arith.addf {{.*}}, %arg7 {ssbuffer.block_id = [[TC01_VF_VEC:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"}
 // CHECK: [[DEP_ADD1:%[0-9]+]] = arith.addf [[DEP_MM0]], {{.*}} {ssbuffer.block_id = [[TC01_VF_VEC]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32>
 // CHECK-NEXT: [[DEP_CAST1:%[0-9]+]] = arith.truncf [[DEP_ADD1]] {ssbuffer.block_id = [[TC01_VF_VEC]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32> to tensor<4x4xf16>
-// CHECK: [[DEP_T1:%[0-9]+]] = bufferization.to_tensor {{.*}} {ssbuffer.block_id = [[TC01_DEP1:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf16> to tensor<4x4xf16>
+// CHECK: [[DEP_T1:%[0-9]+]] = bufferization.to_tensor {{.*}} {ssbuffer.block_id = [[TC01_DEP1:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf16>
 // CHECK: [[DEP_FILL1:%[0-9]+]] = linalg.fill {ssbuffer.block_id = [[TC01_DEP1]] : i32, ssbuffer.core_type = "CUBE"} ins({{.*}} : f32) outs({{.*}} : tensor<4x4xf32>) -> tensor<4x4xf32>
 // CHECK-NEXT: [[DEP_MM1_CUBE:%[0-9]+]] = linalg.matmul {ssbuffer.block_id = [[TC01_DEP1]] : i32, ssbuffer.core_type = "CUBE"} ins([[DEP_CAST1]], [[DEP_T1]] : tensor<4x4xf16>, tensor<4x4xf16>) outs([[DEP_FILL1]] : tensor<4x4xf32>)
 // CHECK-NEXT: [[DEP_MM1:%[0-9]+]] = arith.addf [[DEP_MM1_CUBE]], {{.*}} {ssbuffer.block_id = [[TC01_DEP_VEC:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"}
@@ -41,7 +41,7 @@
 // CHECK-NEXT: [[TR_MM:%[0-9]+]] = linalg.matmul {ssbuffer.block_id = [[TC01_TR]] : i32, ssbuffer.core_type = "CUBE"} ins({{.*}}, [[TR]] : tensor<4x4xf16>, tensor<4x4xf16>) outs([[TR_FILL]] : tensor<4x4xf32>)
 // CHECK: [[MEM_ALLOC:%[A-Za-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = [[TC01_MEM:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf32>
 // CHECK-NEXT: linalg.fill {ssbuffer.block_id = [[TC01_MEM]] : i32, ssbuffer.core_type = "CUBE"} ins({{.*}} : f32) outs([[MEM_ALLOC]] : memref<4x4xf32>)
-// CHECK-NEXT: [[MEM_T:%[0-9]+]] = bufferization.to_tensor [[MEM_ALLOC]] restrict writable {ssbuffer.block_id = [[TC01_MEM]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf32> to tensor<4x4xf32>
+// CHECK-NEXT: [[MEM_T:%[0-9]+]] = bufferization.to_tensor [[MEM_ALLOC]] restrict writable {ssbuffer.block_id = [[TC01_MEM]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf32>
 // CHECK: [[MEM_FILL:%[0-9]+]] = linalg.fill {ssbuffer.block_id = [[TC01_MEM]] : i32, ssbuffer.core_type = "CUBE"} ins({{.*}} : f32) outs({{.*}} : tensor<4x4xf32>) -> tensor<4x4xf32>
 // CHECK-NEXT: [[MEM_MM:%[0-9]+]] = linalg.matmul {ssbuffer.block_id = [[TC01_MEM]] : i32, ssbuffer.core_type = "CUBE"} ins([[MEM_T]], {{.*}} : tensor<4x4xf32>, tensor<4x4xf32>) outs([[MEM_FILL]] : tensor<4x4xf32>)
 // CHECK: return {{.*}}
@@ -65,8 +65,8 @@ func.func @tc01_single_block_comprehensive(
   %alloc_b = memref.alloc() : memref<4x4xf16>
   memref.copy %ma, %alloc_a : memref<4x4xf16> to memref<4x4xf16>
   memref.copy %mb, %alloc_b : memref<4x4xf16> to memref<4x4xf16>
-  %load_a = bufferization.to_tensor %alloc_a restrict writable : memref<4x4xf16> to tensor<4x4xf16>
-  %load_b = bufferization.to_tensor %alloc_b restrict writable : memref<4x4xf16> to tensor<4x4xf16>
+  %load_a = bufferization.to_tensor %alloc_a restrict writable : memref<4x4xf16>
+  %load_b = bufferization.to_tensor %alloc_b restrict writable : memref<4x4xf16>
   %tr_init = tensor.empty() : tensor<4x4xf16>
   %load_bt = linalg.transpose ins(%load_b : tensor<4x4xf16>) outs(%tr_init : tensor<4x4xf16>) permutation = [1, 0]
   %mm0_empty = tensor.empty() : tensor<4x4xf32>
@@ -84,7 +84,7 @@ func.func @tc01_single_block_comprehensive(
   %vec_from_cube2 = arith.addf %vec_from_cube1, %store1 : tensor<4x4xf32>
 
   // Same producer has both CUBE and VECTOR consumers.
-  %shared_tensor = bufferization.to_tensor %shared_src restrict writable : memref<4x4xf32> to tensor<4x4xf32>
+  %shared_tensor = bufferization.to_tensor %shared_src restrict writable : memref<4x4xf32>
   %shared_fill = linalg.fill ins(%two : f32) outs(%dst1 : tensor<4x4xf32>) -> tensor<4x4xf32>
   %shared_mm = linalg.matmul ins(%shared_tensor, %fb : tensor<4x4xf32>, tensor<4x4xf32>) outs(%shared_fill : tensor<4x4xf32>) -> tensor<4x4xf32>
   %shared_vec = arith.addf %shared_tensor, %fa : tensor<4x4xf32>
@@ -103,7 +103,7 @@ func.func @tc01_single_block_comprehensive(
   // No-result fill with memref outs must be classified with the downstream CUBE use.
   %scratch = memref.alloc() : memref<4x4xf32>
   linalg.fill ins(%zero : f32) outs(%scratch : memref<4x4xf32>)
-  %scratch_tensor = bufferization.to_tensor %scratch restrict writable : memref<4x4xf32> to tensor<4x4xf32>
+  %scratch_tensor = bufferization.to_tensor %scratch restrict writable : memref<4x4xf32>
   %scratch_mm = linalg.matmul ins(%scratch_tensor, %fa : tensor<4x4xf32>, tensor<4x4xf32>) outs(%dst1 : tensor<4x4xf32>) -> tensor<4x4xf32>
 
   // VF findCandidates/updateCandidates: VECTOR chains are blocked by
@@ -132,8 +132,8 @@ func.func @tc01_single_block_comprehensive(
   // anchors, a cube result feeding another cube dot, and vector side users.
   %dep_alloc0 = memref.alloc() : memref<4x4xf16>
   %dep_alloc1 = memref.alloc() : memref<4x4xf16>
-  %dep_t0 = bufferization.to_tensor %dep_alloc0 restrict writable : memref<4x4xf16> to tensor<4x4xf16>
-  %dep_t1 = bufferization.to_tensor %dep_alloc1 restrict writable : memref<4x4xf16> to tensor<4x4xf16>
+  %dep_t0 = bufferization.to_tensor %dep_alloc0 restrict writable : memref<4x4xf16>
+  %dep_t1 = bufferization.to_tensor %dep_alloc1 restrict writable : memref<4x4xf16>
   %dep_pre0 = arith.subf %fa, %fb : tensor<4x4xf32>
   %dep_pre1 = arith.mulf %dep_pre0, %fa : tensor<4x4xf32>
   %dep_cast0 = arith.truncf %dep_pre1 : tensor<4x4xf32> to tensor<4x4xf16>
@@ -175,8 +175,8 @@ func.func @tc01_single_block_comprehensive(
 // CHECK-NEXT: [[ALLOC_B:%[A-Za-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = [[TC02_OUTER]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf16>
 // CHECK-NEXT: memref.copy %arg0, [[ALLOC_A]] {ssbuffer.block_id = [[TC02_OUTER]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf16> to memref<4x4xf16>
 // CHECK-NEXT: memref.copy %arg1, [[ALLOC_B]] {ssbuffer.block_id = [[TC02_OUTER]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf16> to memref<4x4xf16>
-// CHECK-NEXT: [[LOAD_A:%[0-9]+]] = bufferization.to_tensor [[ALLOC_A]] restrict writable {ssbuffer.block_id = [[TC02_OUTER]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf16> to tensor<4x4xf16>
-// CHECK-NEXT: [[LOAD_B:%[0-9]+]] = bufferization.to_tensor [[ALLOC_B]] restrict writable {ssbuffer.block_id = [[TC02_OUTER]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf16> to tensor<4x4xf16>
+// CHECK-NEXT: [[LOAD_A:%[0-9]+]] = bufferization.to_tensor [[ALLOC_A]] restrict writable {ssbuffer.block_id = [[TC02_OUTER]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf16>
+// CHECK-NEXT: [[LOAD_B:%[0-9]+]] = bufferization.to_tensor [[ALLOC_B]] restrict writable {ssbuffer.block_id = [[TC02_OUTER]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf16>
 // CHECK-NEXT: [[OUTER_EMPTY:%[0-9]+]] = tensor.empty() {ssbuffer.block_id = [[TC02_OUTER]] : i32, ssbuffer.core_type = "CUBE"} : tensor<4x4xf32>
 // CHECK-NEXT: [[ZERO:%[A-Za-z0-9_]+]] = arith.constant {ssbuffer.block_id = [[TC02_OUTER]] : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
 // CHECK-NEXT: [[OUTER_FILL:%[0-9]+]] = linalg.fill {ssbuffer.block_id = [[TC02_OUTER]] : i32, ssbuffer.core_type = "CUBE"} ins([[ZERO]] : f32) outs([[OUTER_EMPTY]] : tensor<4x4xf32>) -> tensor<4x4xf32>
@@ -235,8 +235,8 @@ func.func @tc02_nested_control_flow(
   %alloc_b = memref.alloc() : memref<4x4xf16>
   memref.copy %ma, %alloc_a : memref<4x4xf16> to memref<4x4xf16>
   memref.copy %mb, %alloc_b : memref<4x4xf16> to memref<4x4xf16>
-  %load_a = bufferization.to_tensor %alloc_a restrict writable : memref<4x4xf16> to tensor<4x4xf16>
-  %load_b = bufferization.to_tensor %alloc_b restrict writable : memref<4x4xf16> to tensor<4x4xf16>
+  %load_a = bufferization.to_tensor %alloc_a restrict writable : memref<4x4xf16>
+  %load_b = bufferization.to_tensor %alloc_b restrict writable : memref<4x4xf16>
   %empty = tensor.empty() : tensor<4x4xf32>
   %fill = linalg.fill ins(%zero : f32) outs(%empty : tensor<4x4xf32>) -> tensor<4x4xf32>
   %outer_mm = linalg.matmul ins(%load_a, %load_b : tensor<4x4xf16>, tensor<4x4xf16>) outs(%fill : tensor<4x4xf32>) -> tensor<4x4xf32>
@@ -340,7 +340,7 @@ func.func @tc03d_all_cube_matmul_only(
 // CHECK-NEXT: [[ZERO:%[A-Za-z0-9_]+]] = arith.constant {ssbuffer.block_id = [[TC03E_VEC:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} 0.000000e+00 : f32
 // CHECK-NEXT: [[ALLOC:%[A-Za-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = [[TC03E_CUBE:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf32>
 // CHECK-NEXT: linalg.fill {ssbuffer.block_id = [[TC03E_CUBE]] : i32, ssbuffer.core_type = "CUBE"} ins([[ZERO]] : f32) outs([[ALLOC]] : memref<4x4xf32>)
-// CHECK-NEXT: [[T:%[0-9]+]] = bufferization.to_tensor [[ALLOC]] restrict writable {ssbuffer.block_id = [[TC03E_CUBE]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf32> to tensor<4x4xf32>
+// CHECK-NEXT: [[T:%[0-9]+]] = bufferization.to_tensor [[ALLOC]] restrict writable {ssbuffer.block_id = [[TC03E_CUBE]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf32>
 // CHECK-NEXT: [[EMPTY:%[0-9]+]] = tensor.empty() {ssbuffer.block_id = [[TC03E_CUBE]] : i32, ssbuffer.core_type = "CUBE"} : tensor<4x4xf32>
 // CHECK-NEXT: [[ACC_ZERO:%[A-Za-z0-9_]+]] = arith.constant {ssbuffer.block_id = [[TC03E_CUBE]] : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
 // CHECK-NEXT: [[FILL:%[0-9]+]] = linalg.fill {ssbuffer.block_id = [[TC03E_CUBE]] : i32, ssbuffer.core_type = "CUBE"} ins([[ACC_ZERO]] : f32) outs([[EMPTY]] : tensor<4x4xf32>) -> tensor<4x4xf32>
@@ -353,7 +353,7 @@ func.func @tc03e_memref_fill_no_result(
   %zero = arith.constant 0.0 : f32
   %scratch = memref.alloc() : memref<4x4xf32>
   linalg.fill ins(%zero : f32) outs(%scratch : memref<4x4xf32>)
-  %t = bufferization.to_tensor %scratch restrict writable : memref<4x4xf32> to tensor<4x4xf32>
+  %t = bufferization.to_tensor %scratch restrict writable : memref<4x4xf32>
   %r = linalg.matmul ins(%t, %a : tensor<4x4xf32>, tensor<4x4xf32>) outs(%dst : tensor<4x4xf32>) -> tensor<4x4xf32>
   return %r : tensor<4x4xf32>
 }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_op_classifier.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_op_classifier.mlir
@@ -1,424 +1,379 @@
-// RUN: triton-opt --op-classifier %s | FileCheck %s
+// RUN: triton-opt --plan-compute-block %s | FileCheck %s
 
-module {
-  // CHECK: func.func @test_matmul_to_tensor
-  // Test: bufferization.to_tensor upstream pattern -> CUBE
-  // CHECK-DAG: memref.alloc{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: bufferization.to_tensor{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: linalg.matmul{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: linalg.fill{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: bufferization.materialize_in_destination{{.*}}{ssbuffer.core_type = "VECTOR"}
-  func.func @test_matmul_to_tensor(%arg0: memref<1024x1024xf32>, %arg1: memref<1024x1024xf32>) {
-    %memref = memref.alloc() : memref<1024x1024xf32>
-    %tensor = bufferization.to_tensor %memref : memref<1024x1024xf32> to tensor<1024x1024xf32>
-    %init = tensor.empty() : tensor<1024x1024xf32>
-    %zero = arith.constant 0.0 : f32
-    %filled = linalg.fill ins(%zero : f32) outs(%init : tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
-    %result = linalg.matmul ins(%tensor, %tensor : tensor<1024x1024xf32>, tensor<1024x1024xf32>) outs(%filled : tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
-    bufferization.materialize_in_destination %result in writable %memref : (tensor<1024x1024xf32>, memref<1024x1024xf32>) -> ()
-    return
-  }
+// ============================================================================
+// TC-01: Single Block Comprehensive
+// ============================================================================
+// A single function/block covers the general non-control-flow behavior:
+// - matmul classification as CUBE and independent cube group partitioning.
+// - upstream CUBE propagation through fill, tensor.empty, transpose, to_tensor,
+//   memref.alloc/copy, and no-result memref linalg.fill.
+// - downstream CUBE propagation through extract_slice, materialize_in_destination,
+//   direct hivm.hir.store, and extract_slice -> hivm.hir.store.
+// - VECTOR partitioning after the current PlanVectorBlock pass.
+// - one producer used by both CUBE and VECTOR consumers.
+// - CUBE -> VECTOR transfer with multiple consumers and reorder-sensitive users.
+// - vector accumulator legalization for matmul outs.
+//   vector->cube, multi-dot partitioning, willCreateCycle, and reorder cases.
 
-  // CHECK: func.func @test_matmul_to_tensor
-  // Test: bufferization.to_tensor upstream pattern -> CUBE
-  // CHECK-DAG: memref.alloc{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: bufferization.to_tensor{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: linalg.matmul{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: linalg.fill{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: bufferization.materialize_in_destination{{.*}}{ssbuffer.core_type = "VECTOR"}
-  func.func @test_matmul_to_tensor1(%arg0: memref<1024x1024xf32>, %arg1: memref<1024x1024xf32>) {
-    %memref = memref.alloc() : memref<1024x1024xf32>
-    %tensor = bufferization.to_tensor %memref : memref<1024x1024xf32> to tensor<1024x1024xf32>
-    %init = tensor.empty() : tensor<1024x1024xf32>
-    %zero = arith.constant 0.0 : f32
-    %filled = linalg.fill ins(%zero : f32) outs(%init : tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
-    %init1 = tensor.empty() : tensor<1024x1024xf32>
-    %1 = arith.constant 0.0 : f32
-    %filled1 = linalg.fill ins(%1 : f32) outs(%init1 : tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
-    %add = arith.addf %filled, %filled1 : tensor<1024x1024xf32>
-    %result = linalg.matmul ins(%tensor, %tensor : tensor<1024x1024xf32>, tensor<1024x1024xf32>) outs(%add : tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
-    bufferization.materialize_in_destination %result in writable %memref : (tensor<1024x1024xf32>, memref<1024x1024xf32>) -> ()
-    return
-  }
+// CHECK-LABEL: func.func @tc01_single_block_comprehensive(
+// CHECK: [[WIDE:%[0-9]+]] = arith.extf {{.*}} {ssbuffer.block_id = [[TC01_VEC:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf16> to tensor<4x4xf32>
+// CHECK-NEXT: [[NARROW:%[0-9]+]] = arith.truncf [[WIDE]] {ssbuffer.block_id = [[TC01_VEC]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32> to tensor<4x4xf16>
+// CHECK: [[DEP_PRE0:%[0-9]+]] = arith.subf {{.*}} {ssbuffer.block_id = [[TC01_VEC]] : i32, ssbuffer.core_type = "VECTOR"}
+// CHECK: [[CYCLE_A:%[0-9]+]] = arith.truncf %arg3 {ssbuffer.block_id = [[TC01_VEC]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32> to tensor<4x4xf16>
+// CHECK: [[CYCLE_C:%[0-9]+]] = linalg.matmul {ssbuffer.block_id = [[TC01_CYCLE:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} ins({{.*}}, [[CYCLE_A]] : tensor<4x4xf16>, tensor<4x4xf16>)
+// CHECK: [[DEP_ALLOC0:%[A-Za-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = [[TC01_DEP_LOAD0:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf16>
+// CHECK-NEXT: [[DEP_T0:%[0-9]+]] = bufferization.to_tensor [[DEP_ALLOC0]] restrict writable {ssbuffer.block_id = [[TC01_DEP_LOAD0]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf16>
+// CHECK: [[DEP_FILL0:%[0-9]+]] = linalg.fill {ssbuffer.block_id = [[TC01_DEP0:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} ins({{.*}} : f32) outs({{.*}} : tensor<4x4xf32>) -> tensor<4x4xf32>
+// CHECK-NEXT: [[DEP_MM0:%[0-9]+]] = linalg.matmul {ssbuffer.block_id = [[TC01_DEP0]] : i32, ssbuffer.core_type = "CUBE"} ins({{.*}}, [[DEP_T0]] : tensor<4x4xf16>, tensor<4x4xf16>) outs([[DEP_FILL0]] : tensor<4x4xf32>)
+// CHECK: linalg.matmul {ssbuffer.block_id = [[TC01_VF0:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} ins({{.*}}, %arg5 : tensor<4x4xf16>, tensor<4x4xf16>) outs({{.*}} : tensor<4x4xf32>)
+// CHECK: arith.addf {{.*}}, %arg7 {ssbuffer.block_id = [[TC01_VF_VEC:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"}
+// CHECK: [[DEP_ADD1:%[0-9]+]] = arith.addf [[DEP_MM0]], {{.*}} {ssbuffer.block_id = [[TC01_VF_VEC]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32>
+// CHECK-NEXT: [[DEP_CAST1:%[0-9]+]] = arith.truncf [[DEP_ADD1]] {ssbuffer.block_id = [[TC01_VF_VEC]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32> to tensor<4x4xf16>
+// CHECK: [[DEP_T1:%[0-9]+]] = bufferization.to_tensor {{.*}} {ssbuffer.block_id = [[TC01_DEP1:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf16>
+// CHECK: [[DEP_FILL1:%[0-9]+]] = linalg.fill {ssbuffer.block_id = [[TC01_DEP1]] : i32, ssbuffer.core_type = "CUBE"} ins({{.*}} : f32) outs({{.*}} : tensor<4x4xf32>) -> tensor<4x4xf32>
+// CHECK-NEXT: [[DEP_MM1_CUBE:%[0-9]+]] = linalg.matmul {ssbuffer.block_id = [[TC01_DEP1]] : i32, ssbuffer.core_type = "CUBE"} ins([[DEP_CAST1]], [[DEP_T1]] : tensor<4x4xf16>, tensor<4x4xf16>) outs([[DEP_FILL1]] : tensor<4x4xf32>)
+// CHECK-NEXT: [[DEP_MM1:%[0-9]+]] = arith.addf [[DEP_MM1_CUBE]], {{.*}} {ssbuffer.block_id = [[TC01_DEP_VEC:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"}
+// CHECK: [[DEP_SIDE:%[0-9]+]] = arith.addf {{.*}}, [[DEP_MM1]] {ssbuffer.block_id = [[TC01_DEP_VEC]] : i32, ssbuffer.core_type = "VECTOR"}
+// CHECK: [[DEP_MM2:%[0-9]+]] = linalg.matmul {ssbuffer.block_id = [[TC01_DEP2:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} ins({{.*}}) outs({{.*}} : tensor<4x4xf32>)
+// CHECK: [[TR_EMPTY:%[0-9]+]] = tensor.empty() {ssbuffer.block_id = [[TC01_TR:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} : tensor<4x4xf16>
+// CHECK-NEXT: [[TR:%[A-Za-z0-9_]+]] = linalg.transpose ins([[NARROW]] : tensor<4x4xf16>) outs([[TR_EMPTY]] : tensor<4x4xf16>) permutation = [1, 0]  {ssbuffer.block_id = [[TC01_TR]] : i32, ssbuffer.core_type = "CUBE"}
+// CHECK: [[TR_FILL:%[0-9]+]] = linalg.fill {ssbuffer.block_id = [[TC01_TR]] : i32, ssbuffer.core_type = "CUBE"} ins({{.*}} : f32) outs({{.*}} : tensor<4x4xf32>) -> tensor<4x4xf32>
+// CHECK-NEXT: [[TR_MM:%[0-9]+]] = linalg.matmul {ssbuffer.block_id = [[TC01_TR]] : i32, ssbuffer.core_type = "CUBE"} ins({{.*}}, [[TR]] : tensor<4x4xf16>, tensor<4x4xf16>) outs([[TR_FILL]] : tensor<4x4xf32>)
+// CHECK: [[MEM_ALLOC:%[A-Za-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = [[TC01_MEM:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf32>
+// CHECK-NEXT: linalg.fill {ssbuffer.block_id = [[TC01_MEM]] : i32, ssbuffer.core_type = "CUBE"} ins({{.*}} : f32) outs([[MEM_ALLOC]] : memref<4x4xf32>)
+// CHECK-NEXT: [[MEM_T:%[0-9]+]] = bufferization.to_tensor [[MEM_ALLOC]] restrict writable {ssbuffer.block_id = [[TC01_MEM]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf32>
+// CHECK: [[MEM_FILL:%[0-9]+]] = linalg.fill {ssbuffer.block_id = [[TC01_MEM]] : i32, ssbuffer.core_type = "CUBE"} ins({{.*}} : f32) outs({{.*}} : tensor<4x4xf32>) -> tensor<4x4xf32>
+// CHECK-NEXT: [[MEM_MM:%[0-9]+]] = linalg.matmul {ssbuffer.block_id = [[TC01_MEM]] : i32, ssbuffer.core_type = "CUBE"} ins([[MEM_T]], {{.*}} : tensor<4x4xf32>, tensor<4x4xf32>) outs([[MEM_FILL]] : tensor<4x4xf32>)
+// CHECK: return {{.*}}
+func.func @tc01_single_block_comprehensive(
+    %ma: memref<4x4xf16>,
+    %mb: memref<4x4xf16>,
+    %shared_src: memref<4x4xf32>,
+    %fa: tensor<4x4xf32>,
+    %fb: tensor<4x4xf32>,
+    %ta: tensor<4x4xf16>,
+    %tb: tensor<4x4xf16>,
+    %dst0: tensor<4x4xf32>,
+    %dst1: tensor<4x4xf32>,
+    %memdst: memref<4x4xf32>) -> (tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf16>) {
+  %zero = arith.constant 0.0 : f32
+  %one = arith.constant 1.0 : f32
+  %two = arith.constant 2.0 : f32
 
-  // CHECK: func.func @test_transpose_only
-  // Test: linalg.transpose -> linalg.matmul (transpose feeds matmul) -> transpose is CUBE
-  // Also tests: memref.alloc -> memref.copy -> bufferization.to_tensor -> linalg.transpose -> linalg.matmul
-  // CHECK-DAG: memref.alloc{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: memref.copy{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: bufferization.to_tensor{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: linalg.transpose{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: linalg.matmul{{.*}}{ssbuffer.core_type = "CUBE"}
-  func.func @test_transpose_only(%arg0: memref<64x64xf32>, %arg1: memref<64x64xf32>) {
-    // Allocate temp buffer for copy
-    %temp = memref.alloc() : memref<64x64xf32>
-    // Copy data from input to temp buffer
-    memref.copy %arg0, %temp : memref<64x64xf32> to memref<64x64xf32>
-    // Convert to tensor
-    %tensor = bufferization.to_tensor %temp : memref<64x64xf32> to tensor<64x64xf32>
-    // Transpose: 64x64 -> 64x64 (permutation [1,0])
-    %trans_out = tensor.empty() : tensor<64x64xf32>
-    %transposed = linalg.transpose ins(%tensor : tensor<64x64xf32>) outs(%trans_out : tensor<64x64xf32>) permutation = [1, 0]
-    // Fill output for matmul
-    %fill_out = tensor.empty() : tensor<64x64xf32>
-    %zero = arith.constant 0.0 : f32
-    %filled = linalg.fill ins(%zero : f32) outs(%fill_out : tensor<64x64xf32>) -> tensor<64x64xf32>
-    // Matmul using transposed input -> transpose should be CUBE
-    %result = linalg.matmul ins(%transposed, %tensor : tensor<64x64xf32>, tensor<64x64xf32>) outs(%filled : tensor<64x64xf32>) -> tensor<64x64xf32>
-    return
-  }
+  // Load path: memref copy -> to_tensor -> transpose -> matmul.
+  %alloc_a = memref.alloc() : memref<4x4xf16>
+  %alloc_b = memref.alloc() : memref<4x4xf16>
+  memref.copy %ma, %alloc_a : memref<4x4xf16> to memref<4x4xf16>
+  memref.copy %mb, %alloc_b : memref<4x4xf16> to memref<4x4xf16>
+  %load_a = bufferization.to_tensor %alloc_a restrict writable : memref<4x4xf16>
+  %load_b = bufferization.to_tensor %alloc_b restrict writable : memref<4x4xf16>
+  %tr_init = tensor.empty() : tensor<4x4xf16>
+  %load_bt = linalg.transpose ins(%load_b : tensor<4x4xf16>) outs(%tr_init : tensor<4x4xf16>) permutation = [1, 0]
+  %mm0_empty = tensor.empty() : tensor<4x4xf32>
+  %mm0_fill = linalg.fill ins(%zero : f32) outs(%mm0_empty : tensor<4x4xf32>) -> tensor<4x4xf32>
+  %mm0 = linalg.matmul ins(%load_a, %load_bt : tensor<4x4xf16>, tensor<4x4xf16>) outs(%mm0_fill : tensor<4x4xf32>) -> tensor<4x4xf32>
 
-  // CHECK: func.func @test_transpose_only_add
-  // Test: linalg.transpose -> linalg.matmul (transpose feeds matmul) -> transpose is CUBE
-  // Also tests: memref.alloc -> memref.copy -> bufferization.to_tensor -> linalg.transpose -> linalg.matmul
-  // CHECK-DAG: memref.alloc{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-NOT: memref.alloc
-  // CHECK-DAG: memref.copy{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-DAG: bufferization.to_tensor{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-DAG: linalg.transpose{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-DAG: arith.addf{{.*}}{ssbuffer.core_type = "VECTOR"}
-  func.func @test_transpose_only_add(%arg0: memref<64x64xf32>, %arg1: memref<64x64xf32>) {
-    // Allocate temp buffer for copy
-    %temp = memref.alloc() : memref<64x64xf32>
-    // Copy data from input to temp buffer
-    memref.copy %arg0, %temp : memref<64x64xf32> to memref<64x64xf32>
-    // Convert to tensor
-    %tensor = bufferization.to_tensor %temp : memref<64x64xf32> to tensor<64x64xf32>
-    // Transpose: 64x64 -> 64x64 (permutation [1,0])
-    %trans_out = tensor.empty() : tensor<64x64xf32>
-    %transposed = linalg.transpose ins(%tensor : tensor<64x64xf32>) outs(%trans_out : tensor<64x64xf32>) permutation = [1, 0]
-    %result = arith.addf %transposed, %tensor : tensor<64x64xf32>
-    return
-  }
+  // Downstream CUBE users and CUBE -> VECTOR transfer.
+  %slice0 = tensor.extract_slice %mm0[0, 0] [4, 4] [1, 1] : tensor<4x4xf32> to tensor<4x4xf32>
+  bufferization.materialize_in_destination %mm0 in writable %memdst : (tensor<4x4xf32>, memref<4x4xf32>) -> ()
+  %store0 = hivm.hir.store ins(%mm0 : tensor<4x4xf32>) outs(%dst0 : tensor<4x4xf32>) -> tensor<4x4xf32>
+  %store1 = hivm.hir.store ins(%slice0 : tensor<4x4xf32>) outs(%dst1 : tensor<4x4xf32>) -> tensor<4x4xf32>
+  %vec_fill = linalg.fill ins(%one : f32) outs(%dst0 : tensor<4x4xf32>) -> tensor<4x4xf32>
+  %vec_from_cube0 = arith.addf %mm0, %vec_fill : tensor<4x4xf32>
+  %vec_from_cube1 = arith.mulf %vec_from_cube0, %store0 : tensor<4x4xf32>
+  %vec_from_cube2 = arith.addf %vec_from_cube1, %store1 : tensor<4x4xf32>
 
-  // CHECK: func.func @test_alloc_is_cube_and_vector
-  // Test: linalg.transpose -> linalg.matmul (transpose feeds matmul) -> transpose is CUBE
-  // Also tests: memref.alloc -> memref.copy -> bufferization.to_tensor -> linalg.transpose -> linalg.matmul
-  // CHECK-DAG: memref.alloc{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: memref.copy{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: bufferization.to_tensor{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: bufferization.to_tensor{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-DAG: linalg.transpose{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: linalg.transpose{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-DAG: linalg.matmul{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: arith.addf{{.*}}{ssbuffer.core_type = "VECTOR"}
-  func.func @test_alloc_is_cube_and_vector(%arg0: memref<64x64xf32>, %arg1: memref<64x64xf32>) {
-    // Allocate temp buffer for copy
-    %temp = memref.alloc() : memref<64x64xf32>
-    // Copy data from input to temp buffer
-    memref.copy %arg0, %temp : memref<64x64xf32> to memref<64x64xf32>
-    // Convert to tensor
-    %tensor = bufferization.to_tensor %temp : memref<64x64xf32> to tensor<64x64xf32>
-    // Transpose: 64x64 -> 64x64 (permutation [1,0])
-    %trans_out = tensor.empty() : tensor<64x64xf32>
-    %transposed = linalg.transpose ins(%tensor : tensor<64x64xf32>) outs(%trans_out : tensor<64x64xf32>) permutation = [1, 0]
-    // Fill output for matmul
-    %fill_out = tensor.empty() : tensor<64x64xf32>
-    %zero = arith.constant 0.0 : f32
-    %filled = linalg.fill ins(%zero : f32) outs(%fill_out : tensor<64x64xf32>) -> tensor<64x64xf32>
-    // Matmul using transposed input -> transpose should be CUBE
-    %result = linalg.matmul ins(%transposed, %tensor : tensor<64x64xf32>, tensor<64x64xf32>) outs(%filled : tensor<64x64xf32>) -> tensor<64x64xf32>
-    %result2 = arith.addf %transposed, %tensor : tensor<64x64xf32>
-    return
-  }
+  // Same producer has both CUBE and VECTOR consumers.
+  %shared_tensor = bufferization.to_tensor %shared_src restrict writable : memref<4x4xf32>
+  %shared_fill = linalg.fill ins(%two : f32) outs(%dst1 : tensor<4x4xf32>) -> tensor<4x4xf32>
+  %shared_mm = linalg.matmul ins(%shared_tensor, %fb : tensor<4x4xf32>, tensor<4x4xf32>) outs(%shared_fill : tensor<4x4xf32>) -> tensor<4x4xf32>
+  %shared_vec = arith.addf %shared_tensor, %fa : tensor<4x4xf32>
 
-  // CHECK: func.func @test_matmul_store
-  // Test: tensor.extract_slice and hivm.hir.store downstream patterns -> CUBE
-  // CHECK-DAG: bufferization.to_tensor{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: linalg.matmul{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: linalg.fill{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: tensor.extract_slice{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-DAG: hivm.hir.store{{.*}}{ssbuffer.core_type = "VECTOR"}
-  func.func @test_matmul_store(%arg0: memref<256x256xf32>, %arg1: memref<256x256xf32>, %arg2: memref<256x256xf32>) {
-    %memref_a = bufferization.to_tensor %arg0 : memref<256x256xf32> to tensor<256x256xf32>
-    %memref_b = bufferization.to_tensor %arg1 : memref<256x256xf32> to tensor<256x256xf32>
-    %init = tensor.empty() : tensor<256x256xf32>
-    %zero = arith.constant 0.0 : f32
-    %filled = linalg.fill ins(%zero : f32) outs(%init : tensor<256x256xf32>) -> tensor<256x256xf32>
-    %result = linalg.matmul ins(%memref_a, %memref_b : tensor<256x256xf32>, tensor<256x256xf32>) outs(%filled : tensor<256x256xf32>) -> tensor<256x256xf32>
-    %slice = tensor.extract_slice %result[0, 0] [128, 128] [1, 1] : tensor<256x256xf32> to tensor<128x128xf32>
-    %c0 = arith.constant 0 : index
-    %subview = memref.subview %arg2[%c0, %c0] [128, 128] [1, 1] : memref<256x256xf32> to memref<128x128xf32, strided<[256, 1], offset: ?>>
-    hivm.hir.store ins(%slice : tensor<128x128xf32>) outs(%subview : memref<128x128xf32, strided<[256, 1], offset: ?>>)
-    return
-  }
+  // Vector accumulator legalization: matmul outs is VECTOR, pass should split it.
+  %vec_acc = arith.addf %fa, %fb : tensor<4x4xf32>
+  %legalized_mm = linalg.matmul ins(%ta, %tb : tensor<4x4xf16>, tensor<4x4xf16>) outs(%vec_acc : tensor<4x4xf32>) -> tensor<4x4xf32>
 
-  // CHECK: func.func @test_vector_ops
-  // Test: element-wise operations -> VECTOR
-  // CHECK-DAG: arith.addf{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-DAG: arith.mulf{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-DAG: arith.subf{{.*}}{ssbuffer.core_type = "VECTOR"}
-  func.func @test_vector_ops(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>) {
-    %a = arith.addf %arg0, %arg1 : tensor<1024xf32>
-    %b = arith.mulf %a, %arg0 : tensor<1024xf32>
-    %c = arith.subf %b, %arg1 : tensor<1024xf32>
-    return
-  }
+  // Transpose compute-input boundary: extf/truncf stay VECTOR, transpose is CUBE.
+  %wide = arith.extf %tb : tensor<4x4xf16> to tensor<4x4xf32>
+  %narrow = arith.truncf %wide : tensor<4x4xf32> to tensor<4x4xf16>
+  %tr2_init = tensor.empty() : tensor<4x4xf16>
+  %computed_t = linalg.transpose ins(%narrow : tensor<4x4xf16>) outs(%tr2_init : tensor<4x4xf16>) permutation = [1, 0]
+  %tr_mm = linalg.matmul ins(%ta, %computed_t : tensor<4x4xf16>, tensor<4x4xf16>) outs(%dst0 : tensor<4x4xf32>) -> tensor<4x4xf32>
 
-  // CHECK: func.func @test_scf_if
-  // Test: scf.if with matmul inside -> matmul is CUBE
-  // CHECK-DAG: linalg.matmul{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: scf.yield{{.*}}{ssbuffer.core_type = "VECTOR"}
-  func.func @test_scf_if(%arg0: i1, %arg1: tensor<512x512xf32>, %arg2: tensor<512x512xf32>) {
-    %init = tensor.empty() : tensor<512x512xf32>
-    %zero = arith.constant 0.0 : f32
-    %filled = linalg.fill ins(%zero : f32) outs(%init : tensor<512x512xf32>) -> tensor<512x512xf32>
-    %result = scf.if %arg0 -> (tensor<512x512xf32>) {
-      %matmul_result = linalg.matmul ins(%arg1, %arg1 : tensor<512x512xf32>, tensor<512x512xf32>) outs(%filled : tensor<512x512xf32>) -> tensor<512x512xf32>
-      scf.yield %matmul_result : tensor<512x512xf32>
+  // No-result fill with memref outs must be classified with the downstream CUBE use.
+  %scratch = memref.alloc() : memref<4x4xf32>
+  linalg.fill ins(%zero : f32) outs(%scratch : memref<4x4xf32>)
+  %scratch_tensor = bufferization.to_tensor %scratch restrict writable : memref<4x4xf32>
+  %scratch_mm = linalg.matmul ins(%scratch_tensor, %fa : tensor<4x4xf32>, tensor<4x4xf32>) outs(%dst1 : tensor<4x4xf32>) -> tensor<4x4xf32>
+
+  // VF findCandidates/updateCandidates: VECTOR chains are blocked by
+  // CUBE matmul barriers, then new VECTOR candidates appear downstream.
+  %vf0 = arith.addf %fa, %fb : tensor<4x4xf32>
+  %vf1 = arith.mulf %vf0, %fa : tensor<4x4xf32>
+  %vf2 = arith.truncf %vf1 : tensor<4x4xf32> to tensor<4x4xf16>
+  %vf_mm0 = linalg.matmul ins(%vf2, %ta : tensor<4x4xf16>, tensor<4x4xf16>) outs(%dst0 : tensor<4x4xf32>) -> tensor<4x4xf32>
+  %vf3 = arith.addf %vf_mm0, %fb : tensor<4x4xf32>
+  %vf4 = arith.mulf %vf3, %fa : tensor<4x4xf32>
+  %vf5 = arith.truncf %vf4 : tensor<4x4xf32> to tensor<4x4xf16>
+  %vf_mm1 = linalg.matmul ins(%vf5, %tb : tensor<4x4xf16>, tensor<4x4xf16>) outs(%vf_mm0 : tensor<4x4xf32>) -> tensor<4x4xf32>
+  %vf6 = arith.addf %vf_mm1, %vf3 : tensor<4x4xf32>
+
+  // cutError variants: one VECTOR prefix is kept because it feeds a CUBE
+  // barrier, while an independent VECTOR suffix must be cut and scheduled later.
+  %cut_a = arith.addf %fa, %fb : tensor<4x4xf32>
+  %cut_b = arith.mulf %cut_a, %fa : tensor<4x4xf32>
+  %cut_c = arith.addf %cut_b, %cut_b : tensor<4x4xf32>
+  %cut_cast = arith.truncf %cut_c : tensor<4x4xf32> to tensor<4x4xf16>
+  %cut_mm = linalg.matmul ins(%cut_cast, %ta : tensor<4x4xf16>, tensor<4x4xf16>) outs(%dst1 : tensor<4x4xf32>) -> tensor<4x4xf32>
+  %cut_e = arith.addf %fa, %fa : tensor<4x4xf32>
+  %cut_f = arith.addf %cut_mm, %cut_e : tensor<4x4xf32>
+
+  // multiple dot
+  // anchors, a cube result feeding another cube dot, and vector side users.
+  %dep_alloc0 = memref.alloc() : memref<4x4xf16>
+  %dep_alloc1 = memref.alloc() : memref<4x4xf16>
+  %dep_t0 = bufferization.to_tensor %dep_alloc0 restrict writable : memref<4x4xf16>
+  %dep_t1 = bufferization.to_tensor %dep_alloc1 restrict writable : memref<4x4xf16>
+  %dep_pre0 = arith.subf %fa, %fb : tensor<4x4xf32>
+  %dep_pre1 = arith.mulf %dep_pre0, %fa : tensor<4x4xf32>
+  %dep_cast0 = arith.truncf %dep_pre1 : tensor<4x4xf32> to tensor<4x4xf16>
+  %dep_mm0 = linalg.matmul ins(%dep_cast0, %dep_t0 : tensor<4x4xf16>, tensor<4x4xf16>) outs(%dst0 : tensor<4x4xf32>) -> tensor<4x4xf32>
+  %dep_cast1 = arith.truncf %dep_mm0 : tensor<4x4xf32> to tensor<4x4xf16>
+  %dep_mm1 = linalg.matmul ins(%dep_cast1, %dep_t1 : tensor<4x4xf16>, tensor<4x4xf16>) outs(%dst1 : tensor<4x4xf32>) -> tensor<4x4xf32>
+  %dep_side0 = arith.extf %dep_cast0 : tensor<4x4xf16> to tensor<4x4xf32>
+  %dep_side1 = arith.addf %dep_side0, %dep_mm1 : tensor<4x4xf32>
+  %dep_cast2 = arith.truncf %dep_side1 : tensor<4x4xf32> to tensor<4x4xf16>
+  %dep_mm2 = linalg.matmul ins(%dep_cast2, %dep_cast1 : tensor<4x4xf16>, tensor<4x4xf16>) outs(%dep_mm1 : tensor<4x4xf32>) -> tensor<4x4xf32>
+
+  // willCreateCycle for dot fusion: A feeds both a VECTOR path to C and
+  // C directly, so A and C cannot be merged if it would create a cycle.
+  %cycle_a = arith.truncf %fa : tensor<4x4xf32> to tensor<4x4xf16>
+  %cycle_b0 = arith.extf %cycle_a : tensor<4x4xf16> to tensor<4x4xf32>
+  %cycle_b1 = arith.addf %cycle_b0, %fb : tensor<4x4xf32>
+  %cycle_b2 = arith.truncf %cycle_b1 : tensor<4x4xf32> to tensor<4x4xf16>
+  %cycle_c = linalg.matmul ins(%cycle_b2, %cycle_a : tensor<4x4xf16>, tensor<4x4xf16>) outs(%dst0 : tensor<4x4xf32>) -> tensor<4x4xf32>
+  %cycle_d = arith.addf %cycle_c, %fa : tensor<4x4xf32>
+
+  return %vec_from_cube2, %shared_mm, %shared_vec, %legalized_mm, %tr_mm, %scratch_mm, %vf6, %cut_f, %dep_mm2, %cycle_b2 : tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf16>
+}
+
+// -----
+
+// ============================================================================
+// TC-02: Nested Blocks / Control Flow
+// ============================================================================
+// Based on the TC-01 patterns but adds scf.for, scf.if, nested blocks, and
+// multi-result yields. Checks focus on propagation through region boundaries.
+
+// CHECK-LABEL: func.func @tc02_nested_control_flow(
+// CHECK-NOT: call
+// CHECK: [[C0:%c[0-9]+]] = arith.constant {ssbuffer.block_id = [[TC02_TOP_VEC:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+// CHECK-NEXT: [[C1:%c[0-9]+]] = arith.constant {ssbuffer.block_id = [[TC02_TOP_VEC]] : i32, ssbuffer.core_type = "VECTOR"} 1 : index
+// CHECK-NEXT: [[IF_PRE0:%[0-9]+]] = arith.addf %arg6, %arg7 {ssbuffer.block_id = [[TC02_TOP_VEC]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32>
+// CHECK-NEXT: [[DENSE:%[A-Za-z0-9_]+]] = arith.constant {ssbuffer.block_id = [[TC02_TOP_VEC]] : i32, ssbuffer.core_type = "VECTOR"} dense<1.000000e+00> : tensor<4x4xf32>
+// CHECK-NEXT: [[ALLOC_A:%[A-Za-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = [[TC02_OUTER:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf16>
+// CHECK-NEXT: [[ALLOC_B:%[A-Za-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = [[TC02_OUTER]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf16>
+// CHECK-NEXT: memref.copy %arg0, [[ALLOC_A]] {ssbuffer.block_id = [[TC02_OUTER]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf16> to memref<4x4xf16>
+// CHECK-NEXT: memref.copy %arg1, [[ALLOC_B]] {ssbuffer.block_id = [[TC02_OUTER]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf16> to memref<4x4xf16>
+// CHECK-NEXT: [[LOAD_A:%[0-9]+]] = bufferization.to_tensor [[ALLOC_A]] restrict writable {ssbuffer.block_id = [[TC02_OUTER]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf16>
+// CHECK-NEXT: [[LOAD_B:%[0-9]+]] = bufferization.to_tensor [[ALLOC_B]] restrict writable {ssbuffer.block_id = [[TC02_OUTER]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf16>
+// CHECK-NEXT: [[OUTER_EMPTY:%[0-9]+]] = tensor.empty() {ssbuffer.block_id = [[TC02_OUTER]] : i32, ssbuffer.core_type = "CUBE"} : tensor<4x4xf32>
+// CHECK-NEXT: [[ZERO:%[A-Za-z0-9_]+]] = arith.constant {ssbuffer.block_id = [[TC02_OUTER]] : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
+// CHECK-NEXT: [[OUTER_FILL:%[0-9]+]] = linalg.fill {ssbuffer.block_id = [[TC02_OUTER]] : i32, ssbuffer.core_type = "CUBE"} ins([[ZERO]] : f32) outs([[OUTER_EMPTY]] : tensor<4x4xf32>) -> tensor<4x4xf32>
+// CHECK-NEXT: [[OUTER_MM:%[0-9]+]] = linalg.matmul {ssbuffer.block_id = [[TC02_OUTER]] : i32, ssbuffer.core_type = "CUBE"} ins([[LOAD_A]], [[LOAD_B]] : tensor<4x4xf16>, tensor<4x4xf16>) outs([[OUTER_FILL]] : tensor<4x4xf32>) -> tensor<4x4xf32>
+// CHECK: [[OUTER_ACC:%[0-9]+]] = arith.addf [[OUTER_MM]], {{.*}} {ssbuffer.block_id = [[TC02_AFTER_OUTER:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32>
+// CHECK-NEXT: [[OUTER_VEC:%[0-9]+]] = arith.addf [[OUTER_ACC]], %arg6 {ssbuffer.block_id = [[TC02_AFTER_OUTER]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32>
+// CHECK-NEXT: [[IF_PRE1:%[0-9]+]] = arith.mulf %arg7, [[OUTER_VEC]] {ssbuffer.block_id = [[TC02_AFTER_OUTER]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32>
+// CHECK-NEXT: [[REGION:%[0-9]+]] = scf.if %arg5 -> (tensor<4x4xf32>) {
+// CHECK-NEXT: [[INSIDE:%[0-9]+]] = arith.addf [[IF_PRE0]], %arg7 {ssbuffer.block_id = [[TC02_REGION_VEC:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32>
+// CHECK-NEXT: scf.yield {ssbuffer.core_type = "VECTOR"} [[INSIDE]] : tensor<4x4xf32>
+// CHECK: } else {
+// CHECK-NEXT: scf.yield {ssbuffer.core_type = "VECTOR"} [[IF_PRE1]] : tensor<4x4xf32>
+// CHECK-NEXT: } {ssbuffer.core_type = "VECTOR"}
+// CHECK-NEXT: [[REGION_AFTER:%[0-9]+]] = arith.addf [[IF_PRE1]], [[REGION]] {ssbuffer.block_id = [[TC02_AFTER_VEC:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32>
+// CHECK-NEXT: [[LOOP:%[0-9]+]]:2 = scf.for {{.*}} = [[C0]] to %arg4 step [[C1]] iter_args({{.*}} = [[OUTER_ACC]], {{.*}} = [[OUTER_VEC]]) -> (tensor<4x4xf32>, tensor<4x4xf32>) {
+// CHECK-NEXT: [[IF2:%[0-9]+]]:2 = scf.if %arg5 -> (tensor<4x4xf32>, tensor<4x4xf32>) {
+// CHECK: [[INNER_MM:%[0-9]+]] = linalg.matmul {ssbuffer.block_id = [[TC02_INNER_CUBE:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} ins(%arg2, %arg3 : tensor<4x4xf16>, tensor<4x4xf16>) outs({{.*}} : tensor<4x4xf32>) -> tensor<4x4xf32>
+// CHECK-NEXT: [[INNER_ACC:%[0-9]+]] = arith.addf [[INNER_MM]], {{.*}} {ssbuffer.block_id = [[TC02_THEN_VEC:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32>
+// CHECK-NEXT: [[THEN_VEC:%[0-9]+]] = arith.addf {{.*}}, %arg7 {ssbuffer.block_id = [[TC02_THEN_VEC]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32>
+// CHECK-NEXT: scf.yield {ssbuffer.core_type = "VECTOR, VECTOR"} [[INNER_ACC]], [[THEN_VEC]] : tensor<4x4xf32>, tensor<4x4xf32>
+// CHECK: } else {
+// CHECK-NEXT: [[ELSE_VEC:%[0-9]+]] = arith.mulf {{.*}}, %arg7 {ssbuffer.block_id = [[TC02_ELSE_VEC:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32>
+// CHECK-NEXT: scf.yield {ssbuffer.core_type = "VECTOR,{{ *}}VECTOR"} {{.*}}, [[ELSE_VEC]] : tensor<4x4xf32>, tensor<4x4xf32>
+// CHECK-NEXT: } {ssbuffer.core_type = "VECTOR,{{ *}}VECTOR"}
+// CHECK-NEXT: scf.yield {ssbuffer.core_type = "VECTOR, VECTOR"} [[IF2]]#0, [[IF2]]#1 : tensor<4x4xf32>, tensor<4x4xf32>
+// CHECK-NEXT: } {ssbuffer.core_type = "VECTOR, VECTOR"}
+// CHECK-NEXT: [[LOOP2:%[0-9]+]]:2 = scf.for {{.*}} = [[C0]] to %arg4 step [[C1]] iter_args({{.*}} = [[LOOP]]#0, {{.*}} = [[OUTER_ACC]]) -> (tensor<4x4xf32>, tensor<4x4xf32>) {
+// CHECK-NEXT: [[A_CAST:%[0-9]+]] = arith.truncf {{.*}} {ssbuffer.block_id = [[TC02_LOOP_VEC:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32> to tensor<4x4xf16>
+// CHECK-NEXT: [[D_CAST:%[0-9]+]] = arith.truncf {{.*}} {ssbuffer.block_id = [[TC02_LOOP_VEC]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32> to tensor<4x4xf16>
+// CHECK-NEXT: [[E_EMPTY:%[0-9]+]] = tensor.empty() {ssbuffer.block_id = [[TC02_LOOP_CUBE0:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} : tensor<4x4xf32>
+// CHECK-NEXT: [[E_ZERO:%[A-Za-z0-9_]+]] = arith.constant {ssbuffer.block_id = [[TC02_LOOP_CUBE0]] : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
+// CHECK-NEXT: [[E_FILL:%[0-9]+]] = linalg.fill {ssbuffer.block_id = [[TC02_LOOP_CUBE0]] : i32, ssbuffer.core_type = "CUBE"} ins([[E_ZERO]] : f32) outs([[E_EMPTY]] : tensor<4x4xf32>) -> tensor<4x4xf32>
+// CHECK-NEXT: [[E_MM:%[0-9]+]] = linalg.matmul {ssbuffer.block_id = [[TC02_LOOP_CUBE0]] : i32, ssbuffer.core_type = "CUBE"} ins([[D_CAST]], %arg3 : tensor<4x4xf16>, tensor<4x4xf16>) outs([[E_FILL]] : tensor<4x4xf32>) -> tensor<4x4xf32>
+// CHECK-NEXT: [[B_EMPTY:%[0-9]+]] = tensor.empty() {ssbuffer.block_id = [[TC02_LOOP_CUBE1:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} : tensor<4x4xf32>
+// CHECK-NEXT: [[B_ZERO:%[A-Za-z0-9_]+]] = arith.constant {ssbuffer.block_id = [[TC02_LOOP_CUBE1]] : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
+// CHECK-NEXT: [[B_FILL:%[0-9]+]] = linalg.fill {ssbuffer.block_id = [[TC02_LOOP_CUBE1]] : i32, ssbuffer.core_type = "CUBE"} ins([[B_ZERO]] : f32) outs([[B_EMPTY]] : tensor<4x4xf32>) -> tensor<4x4xf32>
+// CHECK-NEXT: [[B_MM:%[0-9]+]] = linalg.matmul {ssbuffer.block_id = [[TC02_LOOP_CUBE1]] : i32, ssbuffer.core_type = "CUBE"} ins([[A_CAST]], %arg2 : tensor<4x4xf16>, tensor<4x4xf16>) outs([[B_FILL]] : tensor<4x4xf32>) -> tensor<4x4xf32>
+// CHECK-NEXT: [[B_TMP:%[0-9]+]] = tensor.empty() {ssbuffer.block_id = [[TC02_LOOP_VEC2:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32>
+// CHECK-NEXT: [[B_ADD0:%[0-9]+]] = arith.addf [[B_MM]], [[B_TMP]] {ssbuffer.block_id = [[TC02_LOOP_VEC2]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32>
+// CHECK-NEXT: [[B_NEXT:%[0-9]+]] = arith.addf [[B_ADD0]], [[DENSE]] {ssbuffer.block_id = [[TC02_LOOP_VEC2]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32>
+// CHECK: [[E_NEXT:%[0-9]+]] = arith.addf {{.*}}, [[DENSE]] {ssbuffer.block_id = [[TC02_LOOP_VEC2]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32>
+// CHECK-NEXT: scf.yield {ssbuffer.core_type = "VECTOR, VECTOR"} [[B_NEXT]], [[E_NEXT]] : tensor<4x4xf32>, tensor<4x4xf32>
+// CHECK-NEXT: } {ssbuffer.core_type = "VECTOR, VECTOR"}
+// CHECK-NEXT: return [[LOOP]]#0, [[LOOP]]#1, [[REGION_AFTER]], [[LOOP2]]#0, [[LOOP2]]#1 : tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>
+func.func @tc02_nested_control_flow(
+    %ma: memref<4x4xf16>,
+    %mb: memref<4x4xf16>,
+    %ta: tensor<4x4xf16>,
+    %tb: tensor<4x4xf16>,
+    %n: index,
+    %cond: i1,
+    %v0: tensor<4x4xf32>,
+    %v1: tensor<4x4xf32>) -> (tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>) {
+  %zero = arith.constant 0.0 : f32
+  %alloc_a = memref.alloc() : memref<4x4xf16>
+  %alloc_b = memref.alloc() : memref<4x4xf16>
+  memref.copy %ma, %alloc_a : memref<4x4xf16> to memref<4x4xf16>
+  memref.copy %mb, %alloc_b : memref<4x4xf16> to memref<4x4xf16>
+  %load_a = bufferization.to_tensor %alloc_a restrict writable : memref<4x4xf16>
+  %load_b = bufferization.to_tensor %alloc_b restrict writable : memref<4x4xf16>
+  %empty = tensor.empty() : tensor<4x4xf32>
+  %fill = linalg.fill ins(%zero : f32) outs(%empty : tensor<4x4xf32>) -> tensor<4x4xf32>
+  %outer_mm = linalg.matmul ins(%load_a, %load_b : tensor<4x4xf16>, tensor<4x4xf16>) outs(%fill : tensor<4x4xf32>) -> tensor<4x4xf32>
+  %outer_vec = arith.addf %outer_mm, %v0 : tensor<4x4xf32>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %loop:2 = scf.for %i = %c0 to %n step %c1 iter_args(%cube_acc = %outer_mm, %vec_acc = %outer_vec) -> (tensor<4x4xf32>, tensor<4x4xf32>) {
+    %if:2 = scf.if %cond -> (tensor<4x4xf32>, tensor<4x4xf32>) {
+      %inner_mm = linalg.matmul ins(%ta, %tb : tensor<4x4xf16>, tensor<4x4xf16>) outs(%cube_acc : tensor<4x4xf32>) -> tensor<4x4xf32>
+      %inner_vec = arith.addf %vec_acc, %v1 : tensor<4x4xf32>
+      scf.yield %inner_mm, %inner_vec : tensor<4x4xf32>, tensor<4x4xf32>
     } else {
-      scf.yield %filled : tensor<512x512xf32>
+      %else_vec = arith.mulf %vec_acc, %v1 : tensor<4x4xf32>
+      scf.yield %cube_acc, %else_vec : tensor<4x4xf32>, tensor<4x4xf32>
     }
-    return
+    scf.yield %if#0, %if#1 : tensor<4x4xf32>, tensor<4x4xf32>
   }
 
-  // CHECK: func.func @test_scf_for_loop
-  // Test: scf.for loop with operations inside -> operations are VECTOR
-  // CHECK-DAG: linalg.fill{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-DAG: arith.addf{{.*}}{ssbuffer.core_type = "VECTOR"}
-  func.func @test_scf_for_loop(%arg0: tensor<512x512xf32>) {
-    %lb = arith.constant 0 : index
-    %ub = arith.constant 10 : index
-    %step = arith.constant 1 : index
-    %init = tensor.empty() : tensor<512x512xf32>
-    %zero = arith.constant 0.0 : f32
-    scf.for %i = %lb to %ub step %step {
-      %filled = linalg.fill ins(%zero : f32) outs(%init : tensor<512x512xf32>) -> tensor<512x512xf32>
-      %add = arith.addf %filled, %arg0 : tensor<512x512xf32>
-    }
-    return
+  // an if region has VECTOR values produced before the
+  // region, used inside the region, and merged back after the region.
+  %if_pre0 = arith.addf %v0, %v1 : tensor<4x4xf32>
+  %if_pre1 = arith.mulf %v1, %outer_vec : tensor<4x4xf32>
+  %region_v = scf.if %cond -> (tensor<4x4xf32>) {
+    %inside_v = arith.addf %if_pre0, %v1 : tensor<4x4xf32>
+    scf.yield %inside_v : tensor<4x4xf32>
+  } else {
+    scf.yield %if_pre1 : tensor<4x4xf32>
   }
+  %region_after = arith.addf %if_pre1, %region_v : tensor<4x4xf32>
 
-  // CHECK: func.func @test_memref_matmul_and_vector
-  // Test: memref input with alloc/copy/fill, matmul and element-wise both use the same tensor
-  // Note: bufferization.to_tensor bridges memref<->tensor, gets CUBE for matmul, VECTOR for add
-  // CHECK-DAG: memref.alloc{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: memref.copy{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: bufferization.to_tensor %{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: bufferization.to_tensor %{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-DAG: tensor.empty{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: arith.constant{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: linalg.fill{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: linalg.matmul{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: arith.addf{{.*}}{ssbuffer.core_type = "VECTOR"}
-  func.func @test_memref_matmul_and_vector(%arg0: memref<64x64xf32>, %arg1: memref<64x64xf32>, %arg2: memref<64x64xf32>) {
-    %temp = memref.alloc() : memref<64x64xf32>
-    memref.copy %arg0, %temp : memref<64x64xf32> to memref<64x64xf32>
-    %tensor = bufferization.to_tensor %temp : memref<64x64xf32> to tensor<64x64xf32>
-    %init = tensor.empty() : tensor<64x64xf32>
-    %zero = arith.constant 0.0 : f32
-    %filled = linalg.fill ins(%zero : f32) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
-    %result = linalg.matmul ins(%filled, %tensor : tensor<64x64xf32>, tensor<64x64xf32>) outs(%filled : tensor<64x64xf32>) -> tensor<64x64xf32>
-    %add = arith.addf %result, %tensor : tensor<64x64xf32>
-    return
+  // two loop-carried values each feed a separate dot and are
+  // yielded independently, covering inter-iteration dependencies.
+  %cst_tensor = arith.constant dense<1.0> : tensor<4x4xf32>
+  %loop2:2 = scf.for %j = %c0 to %n step %c1 iter_args(%arg_a = %loop#0, %arg_b = %outer_mm) -> (tensor<4x4xf32>, tensor<4x4xf32>) {
+    %a_cast = arith.truncf %arg_a : tensor<4x4xf32> to tensor<4x4xf16>
+    %out_b = tensor.empty() : tensor<4x4xf32>
+    %b_mm = linalg.matmul ins(%a_cast, %ta : tensor<4x4xf16>, tensor<4x4xf16>) outs(%out_b : tensor<4x4xf32>) -> tensor<4x4xf32>
+    %c_next = arith.addf %b_mm, %cst_tensor : tensor<4x4xf32>
+    %d_cast = arith.truncf %arg_b : tensor<4x4xf32> to tensor<4x4xf16>
+    %out_e = tensor.empty() : tensor<4x4xf32>
+    %e_mm = linalg.matmul ins(%d_cast, %tb : tensor<4x4xf16>, tensor<4x4xf16>) outs(%out_e : tensor<4x4xf32>) -> tensor<4x4xf32>
+    %f_next = arith.addf %e_mm, %cst_tensor : tensor<4x4xf32>
+    scf.yield %c_next, %f_next : tensor<4x4xf32>, tensor<4x4xf32>
   }
+  return %loop#0, %loop#1, %region_after, %loop2#0, %loop2#1 : tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>
+}
 
-  // CHECK: func.func @test_scf_if_result_mixed_cube_vector_users
-  // Test: scf.if result used by both CUBE (matmul) and VECTOR (arith.addf) operations.
-  // This triggers hasMixedUsers=true -> CUBE_AND_VECTOR conflict handling.
-  // The scf.yield and scf.if should be annotated with the mixed core_type.
-  // CHECK-DAG: linalg.fill{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: linalg.matmul{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: arith.addf{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-DAG: scf.yield{{.*}}{ssbuffer.core_type = "VECTOR"}
-  func.func @test_scf_if_result_mixed_cube_vector_users(%arg0: i1, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32>) {
-    %init = tensor.empty() : tensor<128x128xf32>
-    %zero = arith.constant 0.0 : f32
-    %filled = linalg.fill ins(%zero : f32) outs(%init : tensor<128x128xf32>) -> tensor<128x128xf32>
-    %cond_result = scf.if %arg0 -> (tensor<128x128xf32>) {
-      // then branch: matmul (CUBE) - matmul feeds into both matmul and add outside
-      %matmul_result = linalg.matmul ins(%arg1, %arg1 : tensor<128x128xf32>, tensor<128x128xf32>) outs(%filled : tensor<128x128xf32>) -> tensor<128x128xf32>
-      scf.yield %matmul_result : tensor<128x128xf32>
-    } else {
-      // else branch: fill (CUBE)
-      scf.yield %filled : tensor<128x128xf32>
-    }
-    // cond_result is used by both matmul (CUBE) and add (VECTOR) -> mixed users
-    %matmul2_result = linalg.matmul ins(%cond_result, %arg1 : tensor<128x128xf32>, tensor<128x128xf32>) outs(%filled : tensor<128x128xf32>) -> tensor<128x128xf32>
-    %add_result = arith.addf %cond_result, %arg2 : tensor<128x128xf32>
-    return
-  }
+// -----
 
-  // CHECK: func.func @test_scf_for_iter_arg_mixed_users
-  // Test: scf.for iter_arg is used directly by both matmul (CUBE) inside loop and
-  // arith.addf (VECTOR) outside loop -> triggers hasMixedUsers on iter_arg.
-  // handleSCFYieldAndIterArgConflicts collects dependency chain, marks shared ops
-  // as CUBE_AND_VECTOR, propagates core types.
-  // CHECK-DAG: linalg.fill{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: linalg.matmul{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: arith.addf{{.*}}{ssbuffer.core_type = "VECTOR"}
-  func.func @test_scf_for_iter_arg_mixed_users(%arg0: tensor<64x64xf32>) {
-    %lb = arith.constant 0 : index
-    %ub = arith.constant 3 : index
-    %step = arith.constant 1 : index
-    %init = tensor.empty() : tensor<64x64xf32>
-    %zero = arith.constant 0.0 : f32
-    %initial = linalg.fill ins(%zero : f32) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
-    // iter_arg carries %initial; inside loop, matmul uses the iter_arg (CUBE).
-    // outside loop, arith.addf uses the loop result which depends on iter_arg (VECTOR).
-    %loop_result = scf.for %i = %lb to %ub step %step iter_args(%initial_iter = %initial) -> tensor<64x64xf32> {
-      %filled = linalg.fill ins(%zero : f32) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
-      %matmul_result = linalg.matmul ins(%initial_iter, %initial_iter : tensor<64x64xf32>, tensor<64x64xf32>) outs(%filled : tensor<64x64xf32>) -> tensor<64x64xf32>
-      scf.yield %matmul_result : tensor<64x64xf32>
-    }
-    %add_result = arith.addf %loop_result, %initial : tensor<64x64xf32>
-    return
-  }
+// ============================================================================
+// TC-03: Edge Cases
+// ============================================================================
 
-  // CHECK: func.func @test_cube_and_vector_split_simple
-  // Test: A single shared operation (linalg.fill) is used by both matmul (CUBE)
-  // and arith.addf (VECTOR). After classification, fill should be CUBE_AND_VECTOR,
-  // triggering handleCubeAndVector to split it into CUBE_ONLY (for matmul) and
-  // VECTOR_ONLY (for add) versions.
-  // Both original and cloned operations should pass CHECK-DAG.
-  // CHECK-DAG: tensor.empty{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: tensor.empty{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-DAG: arith.constant{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: arith.constant{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-DAG: linalg.fill{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: linalg.fill{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-DAG: linalg.matmul{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: arith.addf{{.*}}{ssbuffer.core_type = "VECTOR"}
-  func.func @test_cube_and_vector_split_simple(%arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>) {
-    %init = tensor.empty() : tensor<128x128xf32>
-    %zero = arith.constant 0.0 : f32
-    %filled = linalg.fill ins(%zero : f32) outs(%init : tensor<128x128xf32>) -> tensor<128x128xf32>
-    // %filled feeds matmul (CUBE) and is also used by add (VECTOR)
-    %matmul_result = linalg.matmul ins(%arg0, %arg1 : tensor<128x128xf32>, tensor<128x128xf32>) outs(%filled : tensor<128x128xf32>) -> tensor<128x128xf32>
-    %add_result = arith.addf %filled, %matmul_result : tensor<128x128xf32>
-    return
-  }
+// CHECK-LABEL: func.func @tc03a_empty_func(
+// CHECK-NEXT: return
+// CHECK-NEXT: }
+func.func @tc03a_empty_func() {
+  return
+}
 
-  // CHECK: func.func @test_cube_and_vector_split_chain
-  // Test: A chain of operations where the middle op is shared between CUBE and VECTOR.
-  //   fill → matmul (CUBE)     fill → add (VECTOR)
-  // After split, the fill that feeds matmul is CUBE_ONLY, and a cloned fill for add is VECTOR_ONLY.
-  // CHECK-DAG: linalg.fill{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: linalg.fill{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-DAG: linalg.matmul{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: arith.addf{{.*}}{ssbuffer.core_type = "VECTOR"}
-  func.func @test_cube_and_vector_split_chain(%arg0: tensor<64x64xf32>, %arg1: tensor<64x64xf32>) {
-    %init = tensor.empty() : tensor<64x64xf32>
-    %zero = arith.constant 0.0 : f32
-    %filled = linalg.fill ins(%zero : f32) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
-    %matmul_result = linalg.matmul ins(%arg0, %arg1 : tensor<64x64xf32>, tensor<64x64xf32>) outs(%filled : tensor<64x64xf32>) -> tensor<64x64xf32>
-    %add_result = arith.addf %filled, %arg0 : tensor<64x64xf32>
-    %mul_result = arith.mulf %add_result, %matmul_result : tensor<64x64xf32>
-    return
-  }
+// CHECK-LABEL: func.func @tc03b_all_vector_no_matmul(
+// CHECK-NEXT: [[R:%[0-9]+]] = arith.addf %arg0, %arg1 {ssbuffer.block_id = [[TC03B_VEC:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} : f32
+// CHECK-NEXT: return [[R]] : f32
+func.func @tc03b_all_vector_no_matmul(%a: f32, %b: f32) -> f32 {
+  %r = arith.addf %a, %b : f32
+  return %r : f32
+}
 
-  // CHECK: func.func @test_cube_and_vector_split_multiple_users
-  // Test: Multiple matmul (CUBE) and multiple arith (VECTOR) users share the same fill.
-  // handleCubeAndVector should split the shared fill into one CUBE version and one VECTOR
-  // version, with both matmul ops using the CUBE version and all arith ops using the VECTOR clone.
-  // CHECK-DAG: linalg.fill{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: linalg.fill{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-DAG: linalg.matmul{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: linalg.matmul{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: arith.addf{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-DAG: arith.mulf{{.*}}{ssbuffer.core_type = "VECTOR"}
-  func.func @test_cube_and_vector_split_multiple_users(%arg0: tensor<64x64xf32>) {
-    %init = tensor.empty() : tensor<64x64xf32>
-    %zero = arith.constant 0.0 : f32
-    %filled = linalg.fill ins(%zero : f32) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
-    %mat0 = linalg.matmul ins(%arg0, %arg0 : tensor<64x64xf32>, tensor<64x64xf32>) outs(%filled : tensor<64x64xf32>) -> tensor<64x64xf32>
-    %mat1 = linalg.matmul ins(%mat0, %arg0 : tensor<64x64xf32>, tensor<64x64xf32>) outs(%filled : tensor<64x64xf32>) -> tensor<64x64xf32>
-    %add = arith.addf %filled, %arg0 : tensor<64x64xf32>
-    %mul = arith.mulf %add, %mat1 : tensor<64x64xf32>
-    return
+// CHECK-LABEL: func.func @tc03c_empty_loop(
+// CHECK-NEXT: [[C0:%c[0-9]+]] = arith.constant {ssbuffer.block_id = [[TC03C_VEC:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+// CHECK-NEXT: [[C1:%c[0-9]+]] = arith.constant {ssbuffer.block_id = [[TC03C_VEC]] : i32, ssbuffer.core_type = "VECTOR"} 1 : index
+// CHECK-NEXT: [[LOOP:%[0-9]+]] = scf.for {{.*}} = [[C0]] to %arg0 step [[C1]] iter_args({{.*}} = %arg1) -> (tensor<4x4xf32>) {
+// CHECK-NEXT: scf.yield {ssbuffer.core_type = "VECTOR"} {{.*}} : tensor<4x4xf32>
+// CHECK-NEXT: } {ssbuffer.core_type = "VECTOR"}
+// CHECK-NEXT: return [[LOOP]] : tensor<4x4xf32>
+func.func @tc03c_empty_loop(%n: index, %init: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %r = scf.for %i = %c0 to %n step %c1 iter_args(%v = %init) -> (tensor<4x4xf32>) {
+    scf.yield %v : tensor<4x4xf32>
   }
+  return %r : tensor<4x4xf32>
+}
 
-  // CHECK: func.func @test_cube_and_vector_split_with_alloc
-  // Test: memref.alloc -> to_tensor -> fill -> {matmul(CUBE), add(VECTOR)}.
-  // The fill is shared between CUBE and VECTOR paths and will be split.
-  // CHECK-DAG: memref.alloc{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: bufferization.to_tensor{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: linalg.fill{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: linalg.fill{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-DAG: linalg.matmul{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: arith.addf{{.*}}{ssbuffer.core_type = "VECTOR"}
-  func.func @test_cube_and_vector_split_with_alloc(%arg0: memref<64x64xf32>, %arg1: memref<64x64xf32>) {
-    %alloc = memref.alloc() : memref<64x64xf32>
-    %tensor = bufferization.to_tensor %alloc : memref<64x64xf32> to tensor<64x64xf32>
-    %init = tensor.empty() : tensor<64x64xf32>
-    %zero = arith.constant 0.0 : f32
-    %filled = linalg.fill ins(%zero : f32) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
-    %matmul_result = linalg.matmul ins(%tensor, %tensor : tensor<64x64xf32>, tensor<64x64xf32>) outs(%filled : tensor<64x64xf32>) -> tensor<64x64xf32>
-    %add_result = arith.addf %filled, %tensor : tensor<64x64xf32>
-    return
-  }
+// CHECK-LABEL: func.func @tc03d_all_cube_matmul_only(
+// CHECK-NEXT: [[EMPTY:%[0-9]+]] = tensor.empty() {ssbuffer.block_id = [[TC03D_CUBE:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} : tensor<4x4xf32>
+// CHECK-NEXT: [[ZERO:%[A-Za-z0-9_]+]] = arith.constant {ssbuffer.block_id = [[TC03D_CUBE]] : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
+// CHECK-NEXT: [[FILL:%[0-9]+]] = linalg.fill {ssbuffer.block_id = [[TC03D_CUBE]] : i32, ssbuffer.core_type = "CUBE"} ins([[ZERO]] : f32) outs([[EMPTY]] : tensor<4x4xf32>) -> tensor<4x4xf32>
+// CHECK-NEXT: [[MM:%[0-9]+]] = linalg.matmul {ssbuffer.block_id = [[TC03D_CUBE]] : i32, ssbuffer.core_type = "CUBE"} ins(%arg0, %arg1 : tensor<4x4xf16>, tensor<4x4xf16>) outs([[FILL]] : tensor<4x4xf32>) -> tensor<4x4xf32>
+// CHECK-NEXT: [[ADD:%[0-9]+]] = arith.addf [[MM]], %arg2 {ssbuffer.block_id = [[TC03D_VEC:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32>
+// CHECK-NEXT: return [[ADD]] : tensor<4x4xf32>
+func.func @tc03d_all_cube_matmul_only(
+    %a: tensor<4x4xf16>,
+    %b: tensor<4x4xf16>,
+    %acc: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  %r = linalg.matmul ins(%a, %b : tensor<4x4xf16>, tensor<4x4xf16>) outs(%acc : tensor<4x4xf32>) -> tensor<4x4xf32>
+  return %r : tensor<4x4xf32>
+}
 
-  // CHECK: func.func @test_scf_scalar_with_cube_and_vector_users
-  // Test: scf.for carrying a tensor through iterations with only scalar arithmetic
-  // inside. The tensor iter_arg is used by both matmul (CUBE) and addf (VECTOR)
-  // inside the loop. Since there's no matmul seed inside the loop, the scalar
-  // body (arith.addi/muli) propagates VECTOR classification from downstream.
-  // The fill outside the loop feeds the VECTOR path only (through iter_arg) and
-  // is classified VECTOR. The matmul and add inside the loop are correctly CUBE
-  // and VECTOR respectively.
-  // CHECK-DAG: arith.addi{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-DAG: arith.muli{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-DAG: linalg.fill{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK-DAG: linalg.matmul{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK-DAG: arith.addf{{.*}}{ssbuffer.core_type = "VECTOR"}
-  func.func @test_scf_scalar_with_cube_and_vector_users(%arg0: i32, %arg1: i32) {
-    %lb = arith.constant 0 : index
-    %ub = arith.constant 10 : index
-    %step = arith.constant 1 : index
-    %c0 = arith.constant 0.0 : f32
-    %init = tensor.empty() : tensor<32x32xf32>
-    %filled = linalg.fill ins(%c0 : f32) outs(%init : tensor<32x32xf32>) -> tensor<32x32xf32>
-    // Loop carries %filled tensor through iterations with scalar ops alongside.
-    // Inside the loop, %filled is used by both matmul (CUBE) and addf (VECTOR).
-    // Since no matmul seed is inside the loop, scalar body propagates VECTOR.
-    %loop_result:2 = scf.for %i = %lb to %ub step %step iter_args(%iter = %arg0, %fill_iter = %filled) -> (i32, tensor<32x32xf32>) {
-      %sum = arith.addi %iter, %arg1 : i32
-      %prod = arith.muli %sum, %arg1 : i32
-      %mat1 = linalg.matmul ins(%fill_iter, %fill_iter : tensor<32x32xf32>, tensor<32x32xf32>) outs(%fill_iter : tensor<32x32xf32>) -> tensor<32x32xf32>
-      scf.yield %prod, %mat1 : i32, tensor<32x32xf32>
-    }
-    %mat = linalg.matmul ins(%loop_result#1, %loop_result#1 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%loop_result#1 : tensor<32x32xf32>) -> tensor<32x32xf32>
-    %add = arith.addf %loop_result#1, %loop_result#1 : tensor<32x32xf32>
-    return
-  }
+// CHECK-LABEL: func.func @tc03e_memref_fill_no_result(
+// CHECK-NEXT: [[ZERO:%[A-Za-z0-9_]+]] = arith.constant {ssbuffer.block_id = [[TC03E_VEC:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} 0.000000e+00 : f32
+// CHECK-NEXT: [[ALLOC:%[A-Za-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = [[TC03E_CUBE:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf32>
+// CHECK-NEXT: linalg.fill {ssbuffer.block_id = [[TC03E_CUBE]] : i32, ssbuffer.core_type = "CUBE"} ins([[ZERO]] : f32) outs([[ALLOC]] : memref<4x4xf32>)
+// CHECK-NEXT: [[T:%[0-9]+]] = bufferization.to_tensor [[ALLOC]] restrict writable {ssbuffer.block_id = [[TC03E_CUBE]] : i32, ssbuffer.core_type = "CUBE"} : memref<4x4xf32>
+// CHECK-NEXT: [[EMPTY:%[0-9]+]] = tensor.empty() {ssbuffer.block_id = [[TC03E_CUBE]] : i32, ssbuffer.core_type = "CUBE"} : tensor<4x4xf32>
+// CHECK-NEXT: [[ACC_ZERO:%[A-Za-z0-9_]+]] = arith.constant {ssbuffer.block_id = [[TC03E_CUBE]] : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
+// CHECK-NEXT: [[FILL:%[0-9]+]] = linalg.fill {ssbuffer.block_id = [[TC03E_CUBE]] : i32, ssbuffer.core_type = "CUBE"} ins([[ACC_ZERO]] : f32) outs([[EMPTY]] : tensor<4x4xf32>) -> tensor<4x4xf32>
+// CHECK-NEXT: [[MM:%[0-9]+]] = linalg.matmul {ssbuffer.block_id = [[TC03E_CUBE]] : i32, ssbuffer.core_type = "CUBE"} ins([[T]], %arg0 : tensor<4x4xf32>, tensor<4x4xf32>) outs([[FILL]] : tensor<4x4xf32>) -> tensor<4x4xf32>
+// CHECK-NEXT: [[ADD:%[0-9]+]] = arith.addf [[MM]], %arg1 {ssbuffer.block_id = [[TC03E_ADD:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32>
+// CHECK-NEXT: return [[ADD]] : tensor<4x4xf32>
+func.func @tc03e_memref_fill_no_result(
+    %a: tensor<4x4xf32>,
+    %dst: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  %zero = arith.constant 0.0 : f32
+  %scratch = memref.alloc() : memref<4x4xf32>
+  linalg.fill ins(%zero : f32) outs(%scratch : memref<4x4xf32>)
+  %t = bufferization.to_tensor %scratch restrict writable : memref<4x4xf32>
+  %r = linalg.matmul ins(%t, %a : tensor<4x4xf32>, tensor<4x4xf32>) outs(%dst : tensor<4x4xf32>) -> tensor<4x4xf32>
+  return %r : tensor<4x4xf32>
+}
 
-  // CHECK: func.func @test_linalg_generic_with_block
-  // Test: linalg.generic with an explicit block body. The generic has a block
-  // containing arith.mulf and arith.addf. These inner ops should NOT receive
-  // ssbuffer.core_type attributes (they inherit from the parent generic only).
-  // The generic's output uses the VECTOR version of the split fill, so generic
-  // is classified VECTOR. Its result feeds both matmul (CUBE) and addf (VECTOR).
-  //
-  // The linalg.generic block body is verified with CHECK/CHECK-NOT (sequential).
-  // Since CHECK-NOT for inner ops consumes the stream past linalg.yield, outer
-  // ops that appear earlier (linalg.fill) are verified with CHECK-DAG before
-  // the linalg.generic check.
-  // CHECK: linalg.fill{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK: linalg.generic{{.*}}{ssbuffer.core_type = "VECTOR"}
-  // CHECK: ^bb0
-  // CHECK: arith.mulf
-  // CHECK-NOT: ssbuffer.core_type
-  // CHECK: arith.addf
-  // CHECK-NOT: ssbuffer.core_type
-  // CHECK: linalg.yield
-  // CHECK: linalg.fill{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK: linalg.matmul{{.*}}{ssbuffer.core_type = "CUBE"}
-  // CHECK: arith.addf{{.*}}{ssbuffer.core_type = "VECTOR"}
-  func.func @test_linalg_generic_with_block(%arg0: tensor<64x64xf32>, %arg1: tensor<64x64xf32>) {
-    %zero = arith.constant 0.0 : f32
-    %init = tensor.empty() : tensor<64x64xf32>
-    %filled = linalg.fill ins(%zero : f32) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
-    // linalg.generic with explicit block: computes element-wise mul + add
-    %generic_result = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]}
-      ins(%arg0, %arg1 : tensor<64x64xf32>, tensor<64x64xf32>)
-      outs(%filled : tensor<64x64xf32>) {
-    ^bb(%a: f32, %b: f32, %c: f32):
-      %mul = arith.mulf %a, %b : f32
-      %add = arith.addf %mul, %c : f32
-      linalg.yield %add : f32
-    } -> tensor<64x64xf32>
-    %mat = linalg.matmul ins(%generic_result, %arg0 : tensor<64x64xf32>, tensor<64x64xf32>) outs(%filled : tensor<64x64xf32>) -> tensor<64x64xf32>
-    %add = arith.addf %generic_result, %mat : tensor<64x64xf32>
-    return
+// CHECK-LABEL: func.func @tc03f_if_all_vector(
+// CHECK-NEXT: [[IF:%[0-9]+]] = scf.if %arg0 -> (tensor<4x4xf32>) {
+// CHECK-NEXT: [[THEN:%[0-9]+]] = arith.addf %arg1, %arg2 {ssbuffer.block_id = [[TC03F_THEN:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32>
+// CHECK-NEXT: scf.yield {ssbuffer.core_type = "VECTOR"} [[THEN]] : tensor<4x4xf32>
+// CHECK: } else {
+// CHECK-NEXT: [[ELSE:%[0-9]+]] = arith.mulf %arg1, %arg2 {ssbuffer.block_id = [[TC03F_ELSE:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x4xf32>
+// CHECK-NEXT: scf.yield {ssbuffer.core_type = "VECTOR"} [[ELSE]] : tensor<4x4xf32>
+// CHECK-NEXT: } {ssbuffer.core_type = "VECTOR"}
+// CHECK-NEXT: return [[IF]] : tensor<4x4xf32>
+func.func @tc03f_if_all_vector(%cond: i1, %x: tensor<4x4xf32>, %y: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  %r = scf.if %cond -> (tensor<4x4xf32>) {
+    %a = arith.addf %x, %y : tensor<4x4xf32>
+    scf.yield %a : tensor<4x4xf32>
+  } else {
+    %b = arith.mulf %x, %y : tensor<4x4xf32>
+    scf.yield %b : tensor<4x4xf32>
   }
+  return %r : tensor<4x4xf32>
 }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_plan_blockid.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_plan_blockid.mlir
@@ -6,8 +6,8 @@ module{
 // CHECK-LABEL: func.func @test_core_type_deps(
 // CHECK: [[ALLOC_VEC:%[A-Za-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = [[TC_VEC3:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} : memref<64x64xf16>
 // CHECK-NEXT: [[ALLOC_0_VEC:%[A-Za-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = [[TC_VEC3]] : i32, ssbuffer.core_type = "VECTOR"} : memref<64x64xf16>
-// CHECK-NEXT: [[TO_TENSOR0:%[0-9]+]] = bufferization.to_tensor [[ALLOC_VEC]] restrict writable {ssbuffer.block_id = [[TC_VEC3]] : i32, ssbuffer.core_type = "VECTOR"} : memref<64x64xf16> to tensor<64x64xf16>
-// CHECK-NEXT: [[TO_TENSOR1:%[0-9]+]] = bufferization.to_tensor [[ALLOC_0_VEC]] restrict writable {ssbuffer.block_id = [[TC_VEC3]] : i32, ssbuffer.core_type = "VECTOR"} : memref<64x64xf16> to tensor<64x64xf16>
+// CHECK-NEXT: [[TO_TENSOR0:%[0-9]+]] = bufferization.to_tensor [[ALLOC_VEC]] restrict writable {ssbuffer.block_id = [[TC_VEC3]] : i32, ssbuffer.core_type = "VECTOR"} : memref<64x64xf16>
+// CHECK-NEXT: [[TO_TENSOR1:%[0-9]+]] = bufferization.to_tensor [[ALLOC_0_VEC]] restrict writable {ssbuffer.block_id = [[TC_VEC3]] : i32, ssbuffer.core_type = "VECTOR"} : memref<64x64xf16>
 // CHECK-NEXT: [[SUBF_VEC:%[0-9]+]] = arith.subf %arg0, %arg1 {ssbuffer.block_id = [[TC_VEC3]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
 // CHECK-NEXT: [[EXP_VEC:%[0-9]+]] = math.exp [[SUBF_VEC]] {ssbuffer.block_id = [[TC_VEC3]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
 // CHECK-NEXT: [[TRUNC_CUBE0:%[0-9]+]] = arith.truncf [[EXP_VEC]] {ssbuffer.block_id = [[TC_CUBE0:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} : tensor<64x64xf32> to tensor<64x64xf16>
@@ -31,8 +31,8 @@ module{
     func.func @test_core_type_deps(%arg0: tensor<64x64xf32>, %arg1: tensor<64x64xf32>, %arg2: tensor<64xf32>, %arg3: tensor<64xf32>) -> tensor<64x64xf16> {
         %alloc_0 = memref.alloc() {ssbuffer.core_type = "VECTOR"} : memref<64x64xf16>
         %alloc_1 = memref.alloc() {ssbuffer.core_type = "VECTOR"} : memref<64x64xf16>
-        %0 = bufferization.to_tensor %alloc_0 restrict writable {ssbuffer.core_type = "VECTOR"} : memref<64x64xf16> to tensor<64x64xf16>
-        %1 = bufferization.to_tensor %alloc_1 restrict writable {ssbuffer.core_type = "VECTOR"} : memref<64x64xf16> to tensor<64x64xf16>
+        %0 = bufferization.to_tensor %alloc_0 restrict writable {ssbuffer.core_type = "VECTOR"} : memref<64x64xf16>
+        %1 = bufferization.to_tensor %alloc_1 restrict writable {ssbuffer.core_type = "VECTOR"} : memref<64x64xf16>
         %2 = arith.subf %arg0, %arg1 {ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
         %3 = math.exp %2 {ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
         %4 = arith.truncf %3 {ssbuffer.core_type = "CUBE"} : tensor<64x64xf32> to tensor<64x64xf16>   
@@ -58,7 +58,7 @@ module{
 
 // CHECK-LABEL: func.func @test_shrink_cube_block(
 // CHECK-NEXT: [[ALLOC_VEC:%[A-Za-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = [[TC_VEC4:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} : memref<64x128xf16>
-// CHECK-NEXT: [[TO_TENSOR_VEC4:%[0-9]+]] = bufferization.to_tensor [[ALLOC_VEC]] restrict writable {ssbuffer.block_id = [[TC_VEC4]] : i32, ssbuffer.core_type = "VECTOR"} : memref<64x128xf16> to tensor<64x128xf16>
+// CHECK-NEXT: [[TO_TENSOR_VEC4:%[0-9]+]] = bufferization.to_tensor [[ALLOC_VEC]] restrict writable {ssbuffer.block_id = [[TC_VEC4]] : i32, ssbuffer.core_type = "VECTOR"} : memref<64x128xf16>
 // CHECK-NEXT: [[SUBF_CUBE2:%[0-9]+]] = arith.subf %arg0, %arg5 {ssbuffer.block_id = [[TC_CUBE2:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} : tensor<64x64xf32>
 // CHECK-NEXT: [[EXP_VEC6:%[0-9]+]] = math.exp [[SUBF_CUBE2]] {ssbuffer.block_id = [[TC_VEC6:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
 // CHECK-NEXT: [[TRUNC_CUBE3:%[0-9]+]] = arith.truncf [[EXP_VEC6]] {ssbuffer.block_id = [[TC_CUBE3:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} : tensor<64x64xf32> to tensor<64x64xf16>
@@ -77,16 +77,16 @@ module{
 
     func.func @test_shrink_cube_block(%arg0: tensor<64x64xf32>, %arg1: tensor<64xf32>, %arg2: tensor<64x128xf32>, %arg3: tensor<128x64xf16>, %arg4: tensor<128x64xf16>, %arg5: tensor<64x64xf32>, %arg6: tensor<64xf32>) -> tensor<64x64xf16> {
         %alloc_8 = memref.alloc() {ssbuffer.core_type = "VECTOR"} : memref<64x128xf16>
-        %32 = bufferization.to_tensor %alloc_8 restrict writable {ssbuffer.core_type = "VECTOR"} : memref<64x128xf16> to tensor<64x128xf16>
-        %37 = arith.subf %arg0, %arg5 {ssbuffer.core_type = "CUBE", ssbuffer.block_id = 0} : tensor<64x64xf32>
+        %32 = bufferization.to_tensor %alloc_8 restrict writable {ssbuffer.core_type = "VECTOR"} : memref<64x128xf16>
+        %37 = arith.subf %arg0, %arg5 {ssbuffer.core_type = "CUBE"} : tensor<64x64xf32>
         %38 = math.exp %37 {ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
-        %39 = arith.truncf %38 {ssbuffer.core_type = "CUBE", ssbuffer.block_id = 1} : tensor<64x64xf32> to tensor<64x64xf16>
+        %39 = arith.truncf %38 {ssbuffer.core_type = "CUBE"} : tensor<64x64xf32> to tensor<64x64xf16>
         %40 = tensor.empty() {ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16>
         %transposed_13 = linalg.transpose ins(%39 : tensor<64x64xf16>) outs(%40 : tensor<64x64xf16>) permutation = [1, 0] {ssbuffer.core_type = "VECTOR"}
-        %41 = linalg.matmul {input_precision = "ieee", ssbuffer.core_type = "CUBE", ssbuffer.block_id = 1} ins(%transposed_13, %32 : tensor<64x64xf16>, tensor<64x128xf16>) outs(%arg2 : tensor<64x128xf32>) -> tensor<64x128xf32>
+        %41 = linalg.matmul {input_precision = "ieee", ssbuffer.core_type = "CUBE"} ins(%transposed_13, %32 : tensor<64x64xf16>, tensor<64x128xf16>) outs(%arg2 : tensor<64x128xf32>) -> tensor<64x128xf32>
         %2 = tensor.empty() {ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
         %3 = tensor.empty() {ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
-        %42 = linalg.matmul {input_precision = "ieee", ssbuffer.core_type = "CUBE", ssbuffer.block_id = 3} ins(%32, %arg4 : tensor<64x128xf16>, tensor<128x64xf16>) outs(%3 : tensor<64x64xf32>) -> tensor<64x64xf32>
+        %42 = linalg.matmul {input_precision = "ieee", ssbuffer.core_type = "CUBE"} ins(%32, %arg4 : tensor<64x128xf16>, tensor<128x64xf16>) outs(%3 : tensor<64x64xf32>) -> tensor<64x64xf32>
         %broadcasted_14 = linalg.broadcast ins(%arg6 : tensor<64xf32>) outs(%2 : tensor<64x64xf32>) dimensions = [1] {ssbuffer.core_type = "VECTOR"}
         %43 = arith.subf %42, %broadcasted_14 {ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
         %44 = arith.extf %39 {ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf32>
@@ -99,7 +99,7 @@ module{
 
 // CHECK-LABEL: func.func @test_fusion_cycle_dot(
 // CHECK: [[ALLOC_VEC:%[A-Za-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = [[TC_VEC4:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} : memref<64x64xf16>
-// CHECK-NEXT: [[TO_TENSOR_VEC:%[0-9]+]] = bufferization.to_tensor [[ALLOC_VEC]] restrict writable {ssbuffer.block_id = [[TC_VEC4]] : i32, ssbuffer.core_type = "VECTOR"} : memref<64x64xf16> to tensor<64x64xf16>
+// CHECK-NEXT: [[TO_TENSOR_VEC:%[0-9]+]] = bufferization.to_tensor [[ALLOC_VEC]] restrict writable {ssbuffer.block_id = [[TC_VEC4]] : i32, ssbuffer.core_type = "VECTOR"} : memref<64x64xf16>
 // CHECK-NEXT: [[TRUNC_CUBE1:%[0-9]+]] = arith.truncf %arg0 {ssbuffer.block_id = [[TC_CUBE1:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} : tensor<64x64xf32> to tensor<64x64xf16>
 // CHECK-NEXT: [[EXTF_VEC3:%[0-9]+]] = arith.extf [[TRUNC_CUBE1]] {ssbuffer.block_id = [[TC_VEC3:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf32>
 // CHECK-NEXT: [[ADDF_VEC3:%[0-9]+]] = arith.addf [[EXTF_VEC3]], %arg1 {ssbuffer.block_id = [[TC_VEC3]] : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
@@ -111,7 +111,7 @@ module{
 
     func.func @test_fusion_cycle_dot(%arg0: tensor<64x64xf32>, %arg1: tensor<64x64xf32>) -> tensor<64x64xf32> {
         %alloc_0 = memref.alloc() {ssbuffer.core_type = "VECTOR"} : memref<64x64xf16>
-        %0 = bufferization.to_tensor %alloc_0 restrict writable {ssbuffer.core_type = "VECTOR"} : memref<64x64xf16> to tensor<64x64xf16>
+        %0 = bufferization.to_tensor %alloc_0 restrict writable {ssbuffer.core_type = "VECTOR"} : memref<64x64xf16>
         %a = arith.truncf %arg0 {ssbuffer.core_type = "CUBE"} : tensor<64x64xf32> to tensor<64x64xf16>
         %b0 = arith.extf %a {ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf32>
         %b1 = arith.addf %b0, %arg1 {ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_plan_compute_block_subview_memory_deps.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_plan_compute_block_subview_memory_deps.mlir
@@ -15,36 +15,8 @@ module {
       : memref<64x64xf16> to memref<?x?xf16, strided<[64, 1], offset: ?>>
     memref.copy %src_view, %dst_view {ssbuffer.core_type = "VECTOR"}
       : memref<?x?xf16, strided<[64, 1], offset: ?>> to memref<?x?xf16, strided<[64, 1], offset: ?>>
-    %lhs = bufferization.to_tensor %alloc restrict writable {ssbuffer.core_type = "VECTOR"} : memref<64x64xf16>
-    %out = tensor.empty() {ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
-    %mm = linalg.matmul {input_precision = "ieee", ssbuffer.core_type = "CUBE"}
-      ins(%lhs, %rhs : tensor<64x64xf16>, tensor<64x64xf16>)
-      outs(%out : tensor<64x64xf32>) -> tensor<64x64xf32>
-    return %mm : tensor<64x64xf32>
-  }
-
-  // CHECK-LABEL: func.func @for_subview_copy_feeds_outer_to_tensor(
-  // CHECK: [[ALLOC:%[A-Za-z0-9_]+]] = memref.alloc() {{.*}}ssbuffer.core_type = "CUBE"
-  // CHECK: scf.for
-  // CHECK: memref.copy {{.*}}ssbuffer.core_type = "CUBE"
-  // CHECK: } {{.*}}ssbuffer.core_type = "CUBE"
-  // CHECK: [[LHS:%[0-9]+]] = bufferization.to_tensor [[ALLOC]] restrict writable {{.*}}ssbuffer.core_type = "CUBE"
-  // CHECK: linalg.matmul {{.*}}ssbuffer.core_type = "CUBE"
-  func.func @for_subview_copy_feeds_outer_to_tensor(%src: memref<64x64xf16>, %rhs: tensor<64x64xf16>) -> tensor<64x64xf32> {
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %c4 = arith.constant 4 : index
-    %c64 = arith.constant 64 : index
-    %alloc = memref.alloc() {ssbuffer.core_type = "VECTOR"} : memref<64x64xf16>
-    scf.for %i = %c0 to %c4 step %c1 {
-      %src_view = memref.subview %src[%c0, %c0] [%c64, %c64] [1, 1]
-        : memref<64x64xf16> to memref<?x?xf16, strided<[64, 1], offset: ?>>
-      %dst_view = memref.subview %alloc[%c0, %c0] [%c64, %c64] [1, 1]
-        : memref<64x64xf16> to memref<?x?xf16, strided<[64, 1], offset: ?>>
-      memref.copy %src_view, %dst_view {ssbuffer.core_type = "VECTOR"}
-        : memref<?x?xf16, strided<[64, 1], offset: ?>> to memref<?x?xf16, strided<[64, 1], offset: ?>>
-    }
-    %lhs = bufferization.to_tensor %alloc restrict writable {ssbuffer.core_type = "VECTOR"} : memref<64x64xf16>
+    %lhs = bufferization.to_tensor %alloc restrict writable {ssbuffer.core_type = "VECTOR"}
+      : memref<64x64xf16>
     %out = tensor.empty() {ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
     %mm = linalg.matmul {input_precision = "ieee", ssbuffer.core_type = "CUBE"}
       ins(%lhs, %rhs : tensor<64x64xf16>, tensor<64x64xf16>)
@@ -72,7 +44,8 @@ module {
 
     %lhs_view = memref.subview %lhs_gm[%c0, %c0] [64, 64] [1, 1]
       : memref<64x64xf16> to memref<64x64xf16, strided<[64, 1], offset: ?>>
-    %lhs = bufferization.to_tensor %lhs_view restrict writable : memref<64x64xf16, strided<[64, 1], offset: ?>>
+    %lhs = bufferization.to_tensor %lhs_view restrict writable
+      : memref<64x64xf16, strided<[64, 1], offset: ?>>
     %out = tensor.empty() : tensor<64x64xf32>
     %init = linalg.fill ins(%zero_f32 : f32) outs(%out : tensor<64x64xf32>) -> tensor<64x64xf32>
     %mm = linalg.matmul {input_precision = "ieee"}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_plan_cube_block_subview_memory_deps_hang.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_plan_cube_block_subview_memory_deps_hang.mlir
@@ -82,7 +82,7 @@ module {
           : memref<?x?xbf16, strided<[?, ?], offset: ?>> to memref<?x?xbf16, strided<[256, 1]>>
       annotation.mark %lhs_cube {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : memref<128x256xbf16>
       %lhs = bufferization.to_tensor %lhs_cube restrict writable {ssbuffer.core_type = "CUBE"}
-          : memref<128x256xbf16> to tensor<128x256xbf16>
+          : memref<128x256xbf16>
       annotation.mark %lhs {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : tensor<128x256xbf16>
 
       %rhs_vec = memref.alloc() {ssbuffer.core_type = "VECTOR"} : memref<64x256xbf16>
@@ -105,7 +105,7 @@ module {
           : memref<?x?xbf16, strided<[?, ?], offset: ?>> to memref<?x?xbf16, strided<[256, 1]>>
       annotation.mark %rhs_cube {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : memref<64x256xbf16>
       %rhs = bufferization.to_tensor %rhs_cube restrict writable {ssbuffer.core_type = "CUBE"}
-          : memref<64x256xbf16> to tensor<64x256xbf16>
+          : memref<64x256xbf16>
       annotation.mark %rhs {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : tensor<64x256xbf16>
 
       %rhs_t_empty = tensor.empty() {ssbuffer.core_type = "CUBE"} : tensor<256x64xbf16>
@@ -187,7 +187,7 @@ module {
           : memref<?x?xbf16, strided<[?, ?], offset: ?>> to memref<?x?xbf16, strided<[256, 1]>>
       annotation.mark %lhs_cube {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : memref<128x256xbf16>
       %lhs = bufferization.to_tensor %lhs_cube restrict writable {ssbuffer.core_type = "CUBE"}
-          : memref<128x256xbf16> to tensor<128x256xbf16>
+          : memref<128x256xbf16>
       annotation.mark %lhs {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : tensor<128x256xbf16>
 
       %rhs_vec = memref.alloc() {ssbuffer.core_type = "VECTOR"} : memref<64x256xbf16>
@@ -210,7 +210,7 @@ module {
           : memref<?x?xbf16, strided<[?, ?], offset: ?>> to memref<?x?xbf16, strided<[256, 1]>>
       annotation.mark %rhs_cube {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : memref<64x256xbf16>
       %rhs = bufferization.to_tensor %rhs_cube restrict writable {ssbuffer.core_type = "CUBE"}
-          : memref<64x256xbf16> to tensor<64x256xbf16>
+          : memref<64x256xbf16>
       annotation.mark %rhs {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : tensor<64x256xbf16>
 
       %rhs_t_empty = tensor.empty() {ssbuffer.core_type = "CUBE"} : tensor<256x64xbf16>
@@ -292,7 +292,7 @@ module {
           : memref<?x?xbf16, strided<[?, ?], offset: ?>> to memref<?x?xbf16, strided<[256, 1]>>
       annotation.mark %lhs_cube {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : memref<128x256xbf16>
       %lhs = bufferization.to_tensor %lhs_cube restrict writable {ssbuffer.core_type = "CUBE"}
-          : memref<128x256xbf16> to tensor<128x256xbf16>
+          : memref<128x256xbf16>
       annotation.mark %lhs {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : tensor<128x256xbf16>
 
       %rhs_vec = memref.alloc() {ssbuffer.core_type = "VECTOR"} : memref<64x256xbf16>
@@ -315,7 +315,7 @@ module {
           : memref<?x?xbf16, strided<[?, ?], offset: ?>> to memref<?x?xbf16, strided<[256, 1]>>
       annotation.mark %rhs_cube {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : memref<64x256xbf16>
       %rhs = bufferization.to_tensor %rhs_cube restrict writable {ssbuffer.core_type = "CUBE"}
-          : memref<64x256xbf16> to tensor<64x256xbf16>
+          : memref<64x256xbf16>
       annotation.mark %rhs {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : tensor<64x256xbf16>
 
       %rhs_t_empty = tensor.empty() {ssbuffer.core_type = "CUBE"} : tensor<256x64xbf16>
@@ -397,7 +397,7 @@ module {
           : memref<?x?xbf16, strided<[?, ?], offset: ?>> to memref<?x?xbf16, strided<[256, 1]>>
       annotation.mark %lhs_cube {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : memref<128x256xbf16>
       %lhs = bufferization.to_tensor %lhs_cube restrict writable {ssbuffer.core_type = "CUBE"}
-          : memref<128x256xbf16> to tensor<128x256xbf16>
+          : memref<128x256xbf16>
       annotation.mark %lhs {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : tensor<128x256xbf16>
 
       %rhs_vec = memref.alloc() {ssbuffer.core_type = "VECTOR"} : memref<64x256xbf16>
@@ -420,7 +420,7 @@ module {
           : memref<?x?xbf16, strided<[?, ?], offset: ?>> to memref<?x?xbf16, strided<[256, 1]>>
       annotation.mark %rhs_cube {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : memref<64x256xbf16>
       %rhs = bufferization.to_tensor %rhs_cube restrict writable {ssbuffer.core_type = "CUBE"}
-          : memref<64x256xbf16> to tensor<64x256xbf16>
+          : memref<64x256xbf16>
       annotation.mark %rhs {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : tensor<64x256xbf16>
 
       %rhs_t_empty = tensor.empty() {ssbuffer.core_type = "CUBE"} : tensor<256x64xbf16>
@@ -502,7 +502,7 @@ module {
           : memref<?x?xbf16, strided<[?, ?], offset: ?>> to memref<?x?xbf16, strided<[256, 1]>>
       annotation.mark %lhs_cube {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : memref<128x256xbf16>
       %lhs = bufferization.to_tensor %lhs_cube restrict writable {ssbuffer.core_type = "CUBE"}
-          : memref<128x256xbf16> to tensor<128x256xbf16>
+          : memref<128x256xbf16>
       annotation.mark %lhs {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : tensor<128x256xbf16>
 
       %rhs_vec = memref.alloc() {ssbuffer.core_type = "VECTOR"} : memref<64x256xbf16>
@@ -525,7 +525,7 @@ module {
           : memref<?x?xbf16, strided<[?, ?], offset: ?>> to memref<?x?xbf16, strided<[256, 1]>>
       annotation.mark %rhs_cube {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : memref<64x256xbf16>
       %rhs = bufferization.to_tensor %rhs_cube restrict writable {ssbuffer.core_type = "CUBE"}
-          : memref<64x256xbf16> to tensor<64x256xbf16>
+          : memref<64x256xbf16>
       annotation.mark %rhs {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : tensor<64x256xbf16>
 
       %rhs_t_empty = tensor.empty() {ssbuffer.core_type = "CUBE"} : tensor<256x64xbf16>
@@ -607,7 +607,7 @@ module {
           : memref<?x?xbf16, strided<[?, ?], offset: ?>> to memref<?x?xbf16, strided<[256, 1]>>
       annotation.mark %lhs_cube {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : memref<128x256xbf16>
       %lhs = bufferization.to_tensor %lhs_cube restrict writable {ssbuffer.core_type = "CUBE"}
-          : memref<128x256xbf16> to tensor<128x256xbf16>
+          : memref<128x256xbf16>
       annotation.mark %lhs {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : tensor<128x256xbf16>
 
       %rhs_vec = memref.alloc() {ssbuffer.core_type = "VECTOR"} : memref<64x256xbf16>
@@ -630,7 +630,7 @@ module {
           : memref<?x?xbf16, strided<[?, ?], offset: ?>> to memref<?x?xbf16, strided<[256, 1]>>
       annotation.mark %rhs_cube {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : memref<64x256xbf16>
       %rhs = bufferization.to_tensor %rhs_cube restrict writable {ssbuffer.core_type = "CUBE"}
-          : memref<64x256xbf16> to tensor<64x256xbf16>
+          : memref<64x256xbf16>
       annotation.mark %rhs {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : tensor<64x256xbf16>
 
       %rhs_t_empty = tensor.empty() {ssbuffer.core_type = "CUBE"} : tensor<256x64xbf16>
@@ -712,7 +712,7 @@ module {
           : memref<?x?xbf16, strided<[?, ?], offset: ?>> to memref<?x?xbf16, strided<[256, 1]>>
       annotation.mark %lhs_cube {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : memref<128x256xbf16>
       %lhs = bufferization.to_tensor %lhs_cube restrict writable {ssbuffer.core_type = "CUBE"}
-          : memref<128x256xbf16> to tensor<128x256xbf16>
+          : memref<128x256xbf16>
       annotation.mark %lhs {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : tensor<128x256xbf16>
 
       %rhs_vec = memref.alloc() {ssbuffer.core_type = "VECTOR"} : memref<64x256xbf16>
@@ -735,7 +735,7 @@ module {
           : memref<?x?xbf16, strided<[?, ?], offset: ?>> to memref<?x?xbf16, strided<[256, 1]>>
       annotation.mark %rhs_cube {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : memref<64x256xbf16>
       %rhs = bufferization.to_tensor %rhs_cube restrict writable {ssbuffer.core_type = "CUBE"}
-          : memref<64x256xbf16> to tensor<64x256xbf16>
+          : memref<64x256xbf16>
       annotation.mark %rhs {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : tensor<64x256xbf16>
 
       %rhs_t_empty = tensor.empty() {ssbuffer.core_type = "CUBE"} : tensor<256x64xbf16>
@@ -817,7 +817,7 @@ module {
           : memref<?x?xbf16, strided<[?, ?], offset: ?>> to memref<?x?xbf16, strided<[256, 1]>>
       annotation.mark %lhs_cube {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : memref<128x256xbf16>
       %lhs = bufferization.to_tensor %lhs_cube restrict writable {ssbuffer.core_type = "CUBE"}
-          : memref<128x256xbf16> to tensor<128x256xbf16>
+          : memref<128x256xbf16>
       annotation.mark %lhs {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : tensor<128x256xbf16>
 
       %rhs_vec = memref.alloc() {ssbuffer.core_type = "VECTOR"} : memref<64x256xbf16>
@@ -840,7 +840,7 @@ module {
           : memref<?x?xbf16, strided<[?, ?], offset: ?>> to memref<?x?xbf16, strided<[256, 1]>>
       annotation.mark %rhs_cube {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : memref<64x256xbf16>
       %rhs = bufferization.to_tensor %rhs_cube restrict writable {ssbuffer.core_type = "CUBE"}
-          : memref<64x256xbf16> to tensor<64x256xbf16>
+          : memref<64x256xbf16>
       annotation.mark %rhs {MayImplicitTransposeWithLastAxis, ssbuffer.core_type = "CUBE"} : tensor<64x256xbf16>
 
       %rhs_t_empty = tensor.empty() {ssbuffer.core_type = "CUBE"} : tensor<256x64xbf16>


### PR DESCRIPTION
Now ComputeBlockIdManager is a global instance, which limited autotune. This PR change refector these code.
 ### Main Change
1. Refactor. Didn't bring any new features.
2. Improve unit testing

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
