### PR TITLE
ci: Change the runner to self-hosted

### DIFF
--- a/.github/workflows/Ascend950-pipeline-tests.yml
+++ b/.github/workflows/Ascend950-pipeline-tests.yml
@@ -40,7 +40,9 @@ jobs:
     if: >-
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
+    runs-on: linux-aarch64-cpu-2
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/modelfoundry/actions/actions-runner:latest
     permissions:
       contents: read
       actions: read
@@ -113,7 +115,9 @@ jobs:
          needs.publish.result == 'success' &&
          needs.publish.outputs.pr_num != '')
       )
-    runs-on: ubuntu-latest
+    runs-on: linux-aarch64-cpu-2
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/modelfoundry/actions/actions-runner:latest
     permissions:
       pull-requests: write
       statuses: write

--- a/.github/workflows/runner-preparation.yml
+++ b/.github/workflows/runner-preparation.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: linux-aarch64-cpu-2
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/modelfoundry/actions/actions-runner:latest
     outputs:
       matrix-ASCEND: ${{ steps.set-matrix.outputs.matrix-ASCEND }}
     steps:
@@ -91,6 +93,7 @@ jobs:
       - name: Prepare runner matrix
         id: set-matrix
         if: env.enable_integration == 'true'
+        shell: bash
         run: |
           if [ x"${{ github.repository }}" == x"triton-lang/triton-ascend" ]; then
             echo 'matrix-ASCEND=[{"name":"linux-aarch64-a3-4","runner_type":"linux-aarch64-a3-4","runs_on":["linux-aarch64-a3-4"],"chip_type":"a3"}]' >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
