### PR TITLE
[docs](feat) document cache_modifier + volatile on tl.load/store

### DIFF
--- a/docs/zh/python-api/_ascend_constraints.py
+++ b/docs/zh/python-api/_ascend_constraints.py
@@ -570,9 +570,9 @@ CONSTRAINTS = {
         "constraints": [
             "DataType: Ascend A2/A3 does not support uint16/uint32/uint64/fp64, \
                 Ascend 950 does not support fp64 (hardware limitation).",
-            "``cache_modifier``: has no effect on Ascend.",
+            "``cache_modifier``: Ascend A5 SIMT-only accepts the Triton upstream strings (``''``, ``'.ca'``, ``'.cg'``, ``'.cv'``); the backend folds them to a two-level cache / uncache mapping (``'.ca'`` -> cache, ``'.cg'`` / ``'.cv'`` -> uncache). Effective on global memory; ignored on shared memory. A2/A3 and non-SIMT-only paths ignore the modifier.",
             "``eviction_policy``: has no effect on Ascend.",
-            "``volatile``: has no effect on Ascend.",
+            "``volatile``: ``bool``; on Ascend A5 SIMT-only, guarantees memory ordering and prevents the compiler/hardware from hoisting or eliding the load. Effective on both global and shared memory. A2/A3 and non-SIMT-only paths ignore the modifier.",
             "Compatibility issues with branch and loop statements: \
                 Complex pointer and mask calculations involving branches or loops may cause compilation failures.",
         ],
@@ -836,6 +836,9 @@ CONSTRAINTS = {
         "constraints": [
             "DataType: Ascend A2/A3 does not support uint16/uint32/uint64/fp64, \
                 Ascend 950 does not support fp64 (hardware limitation).",
+            "``cache_modifier``: Ascend A5 SIMT-only accepts the Triton upstream strings (``''``, ``'.wb'``, ``'.cg'``, ``'.cs'``, ``'.wt'``); the backend folds them to a two-level cache / uncache mapping (``'.wb'`` -> cache, ``'.cg'`` / ``'.cs'`` / ``'.wt'`` -> uncache). Effective on global memory; ignored on shared memory. A2/A3 and non-SIMT-only paths ignore the modifier.",
+            "``eviction_policy``: has no effect on Ascend.",
+            "``volatile``: not accepted (the Triton upstream ``tl.store`` signature does not expose a ``volatile=`` keyword).",
             "Compatibility issues with branch and loop statements: \
                 Complex pointer and mask calculations involving branches or loops may cause compilation failures.",
         ],


### PR DESCRIPTION
…only

The Ascend A5 SIMT-only path now lowers Triton's `cache_modifier` and `volatile` modifiers to the downstream DPX cacheModifier + volatileOption attributes carried by `ascend_dpx.{load,store}`. The doc previously said both modifiers were "对Ascend硬件无效" / "still unsupported on 910"; this commit refreshes both pages to reflect the new support contract.

tl.load.md:
- `cache_modifier`: enumerate `""`/`"ca"`/`"cg"`/`"cv"`; describe the cache↔CA, uncache↔NCA two-level hardware mapping (global memory effective, shared memory ignored).
- `volatile`: type bool (was incorrectly listed as str); supported on A5 SIMT-only for both global and shared memory.
- Summary line under the param table refreshed: A5 SIMT-only supports cache_modifier + volatile; eviction_policy remains globally unsupported.

tl.store.md:
- `cache_modifier`: enumerate `""`/`"wb"`/`"cg"`/`"cs"`/`"wt"`; same two-level mapping; same global-effective / shared-ignored caveat.
- 专家意见 + 特殊限制 sections updated to match.

Compiler-side support lands in NPUIR via the SR281 lit tests at Ascend/AscendNPU-IR-Dev#1056 (cache-option-cg-volatile.mlir, cache-option-cv.mlir, shared_mem_modifiers.mlir).

No code changes; docs only.
