### PR TITLE
fix(ssbuffer): set set_workspace_multibuffer to false when ssbuffer enable

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -98,6 +98,7 @@ def _adjust_metadata_by_module_result(mod, metadata, opt, **kwargs):
         metadata["enable_dynamic_cv_pipeline"] = False
         metadata["enable_mixed_cv"] = kwargs["enable_mixed_cv"]
         metadata["disable_auto_inject_block_sync"] = kwargs["disable_auto_inject_block_sync"]
+        metadata["set_workspace_multibuffer"] = kwargs["set_workspace_multibuffer"]
         if opt.debug:
             print(f"SSBUFFER return code={rc}, will fallback to enable_dynamic_cv_pipeline=False")
 
@@ -157,6 +158,7 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
         auto_blockify_size = metadata["auto_blockify_size"]
         enable_mixed_cv = metadata["enable_mixed_cv"]
         disable_auto_inject_block_sync = metadata["disable_auto_inject_block_sync"]
+        set_workspace_multibuffer = metadata["set_workspace_multibuffer"]
         if has_auto_blockify_blacklist_op or not auto_map_parallel_blocks_enabled:
             auto_blockify_size = 1
         pm = ir.pass_manager(mod.context)
@@ -210,10 +212,7 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
             compile_on_910_95
         )
         if metadata["enable_dynamic_cv_pipeline"]:
-            if metadata["set_workspace_multibuffer"] != None:
-                raise ValueError(
-                    "\"enable_dynamic_cv_pipeline\" cannot be used with \"set_workspace_multibuffer\"."
-                )
+            metadata["set_workspace_multibuffer"] = None
             metadata["enable_mixed_cv"] = True
             metadata["disable_auto_inject_block_sync"] = True
             ascend.passes.ttir.add_dynamic_cv_pipeline(pm, compile_on_910_95)
@@ -233,7 +232,8 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
         pm.run(mod)
         _adjust_metadata_by_module_result(mod, metadata, opt,
                                           enable_mixed_cv=enable_mixed_cv,
-                                          disable_auto_inject_block_sync=disable_auto_inject_block_sync)
+                                          disable_auto_inject_block_sync=disable_auto_inject_block_sync,
+                                          set_workspace_multibuffer=set_workspace_multibuffer)
 
         if opt.debug:
             dump_manager = get_dump_manager(metadata["hash"])

--- a/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
@@ -47,6 +47,22 @@ namespace triton {
 } // namespace triton
 } // namespace mlir
 
+namespace {
+
+void restoreModuleFromBackup(ModuleOp moduleOp, ModuleOp moduleBackup)
+{
+    Operation *moduleOperation = moduleOp.getOperation();
+    Operation *backupOperation = moduleBackup.getOperation();
+
+    moduleOperation->setLoc(backupOperation->getLoc());
+    moduleOperation->setAttrs(backupOperation->getAttrs());
+    if (moduleOperation->getPropertiesStorageSize() != 0) {
+        moduleOperation->copyProperties(backupOperation->getPropertiesStorage());
+    }
+    moduleOp.getBodyRegion().takeBody(moduleBackup.getBodyRegion());
+}
+
+} // namespace
 
 AddDynamicCVPipelinePass::AddDynamicCVPipelinePass(
     const AddDynamicCVPipelineOptions &options)
@@ -86,8 +102,7 @@ void AddDynamicCVPipelinePass::runOnOperation()
         }
         
         int errCode = errCodeAttr ? static_cast<int>(errCodeAttr.getInt()) : CVPipeline::ERRCODE_FAILED;
-        moduleOp->setAttrs(moduleBackup.getOperation()->getAttrs());
-        moduleOp.getBodyRegion().takeBody(moduleBackup.getBodyRegion());
+        restoreModuleFromBackup(moduleOp, moduleBackup);
         moduleBackup->destroy();
         moduleOp->setAttr(CVPipeline::ERRCODE_ATTR, builder.getI32IntegerAttr(errCode));
         return;


### PR DESCRIPTION
set set_workspace_multibuffer to false when ssbuffer enable

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

Fixed an issue with the rollback mechanism options, added a compatibility mechanism for the `set_workspace` option.