### PR TITLE
fix(ssbuffer): Fix Vector Block ID Assignment and Core Type for Implicit Transpose Annotations

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -27,6 +27,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 
+#include "bishengir/Dialect/Utils/Util.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -173,8 +174,15 @@ void OpClassifierPass::markCube(Operation *op)
 void OpClassifierPass::matchToTensorPattern(Operation *def)
 {
     auto toTensorOp = dyn_cast<bufferization::ToTensorOp>(def);
+    constexpr llvm::StringLiteral kMayImplicitTransposeWithLastAxis = "MayImplicitTransposeWithLastAxis";
+
     if (!toTensorOp)
         return;
+
+    // special case: implicit transpose
+    if (utils::getAnnotateOpWithAttr(toTensorOp.getResult(), kMayImplicitTransposeWithLastAxis)) {
+        return;
+    }
 
     markCube(toTensorOp);
     cubeSeeds.push_back(toTensorOp);
@@ -476,79 +484,6 @@ int OpClassifierPass::propagateCubeUpstream()
     return 0;
 }
 
-constexpr size_t kMaxAliasCount = 2;
-
-static inline SmallVector<Value, kMaxAliasCount> getAliasingOperands(Operation *op)
-{
-    if (auto viewOp = llvm::dyn_cast<ViewLikeOpInterface>(op)) {
-        return {viewOp.getViewSource()};
-    }
-    if (isa<CastOpInterface, bufferization::ToMemrefOp, bufferization::ToTensorOp, annotation::MarkOp>(op)) {
-        return {op->getOperand(0)};
-    }
-    if (auto selectOp = llvm::dyn_cast<arith::SelectOp>(op)) {
-        return {selectOp.getTrueValue(), selectOp.getFalseValue()};
-    }
-
-    return {};
-}
-
-static bool collectToMemoryAllocation(Operation *op, llvm::SmallPtrSetImpl<Operation *> &out)
-{
-    if (out.contains(op)) {
-        LOG_DEBUG("Short circuited at: " << *op << "\n");
-        return true;
-    }
-
-    if (llvm::isa<memref::AllocOp>(op)) {
-        out.insert(op);
-        LOG_DEBUG("Succeeded at: " << *op << "\n");
-        return true;
-    }
-
-    auto tracedToAlloc = false;
-    auto upstreamAliases = getAliasingOperands(op);
-
-    if (upstreamAliases.empty()) {
-        LOG_DEBUG("Stopped at non-aliasing op: " << *op << "\n");
-    }
-
-    for (Value srcVal : upstreamAliases) {
-        if (auto *op = srcVal.getDefiningOp()) {
-            if (collectToMemoryAllocation(op, out)) {
-                tracedToAlloc = true;
-            }
-        }
-    }
-
-    if (!tracedToAlloc) {
-        LOG_DEBUG("Not marked as VECTOR_ONLY since op does not trace to alloc: " << *op << "\n");
-        return false;
-    }
-
-    out.insert(op);
-    return true;
-}
-
-void OpClassifierPass::markUpstreamsOfImplicitTranspose()
-{
-    static constexpr llvm::StringLiteral kMayImplicitTransposeWithLastAxis = "MayImplicitTransposeWithLastAxis";
-    static constexpr size_t kMaxExpectedAffected = 16;
-
-    auto module = getOperation();
-    llvm::SmallPtrSet<Operation *, kMaxExpectedAffected> affectedOps;
-    module.walk([&](annotation::MarkOp markOp) {
-        if (markOp.isAnnotatedBy(kMayImplicitTransposeWithLastAxis)) {
-            LOG_DEBUG("Tracing Upstream Of " << *markOp << "\n");
-            collectToMemoryAllocation(markOp, affectedOps);
-        }
-    });
-
-    for (auto *op : affectedOps) {
-        opCoreTypes[op] = OP_VECTOR_ONLY;
-    }
-}
-
 // ============================================================================
 // Step 3: Mark remaining operations as VECTOR
 // ============================================================================
@@ -575,9 +510,6 @@ int OpClassifierPass::markRemainingAsVector()
             opCoreTypes[op] = OP_VECTOR_ONLY;
         }
     }
-
-    // Special case: aliases of annotation.mark {MayImplicitTransposeWithLastAxis} to alloc should all be VECTOR_ONLY
-    markUpstreamsOfImplicitTranspose();
 
     return 0;
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp
@@ -25,6 +25,7 @@
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Passes.h"
+#include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "mlir/Analysis/AliasAnalysis.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -33,7 +34,9 @@
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
@@ -273,6 +276,21 @@ static SetVector<Operation *> collectKeepOps(Block *block, SmallVector<Operation
             }
         }
     }
+
+    // special case: annotation.mark always follows the defining op
+    for (auto op : fuseGroup) {
+        auto markOp = llvm::dyn_cast<annotation::MarkOp>(op);
+        if (!markOp) {
+            continue;
+        }
+
+        auto src = markOp.getSrc();
+        auto definingOp = src.getDefiningOp();
+        if (definingOp && keepOps.contains(definingOp)) {
+            keepOps.insert(markOp);
+        }
+    }
+
     return keepOps;
 }
 

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/implicit_transpose_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/implicit_transpose_test.mlir
@@ -1,0 +1,78 @@
+// RUN: triton-opt --plan-compute-block %s | FileCheck %s
+
+module {
+  // Test Case 1 & 2: Implicit Transpose with unlikely condition fill
+  // Verifies that:
+  // 1. %to_tensor, %alloc, and %fill are colored as VECTOR instead of CUBE.
+  // 2. The fill inside the unlikely scf.if is colored as VECTOR.
+  // 3. The annotation.mark has the same block_id as its defining op (to_tensor).
+  func.func @test_implicit_transpose_vector_coloring(%arg0: memref<?xf32>, %arg1: memref<?xf32>, %cond: i1) -> tensor<64x64xf32> {
+    // CHECK-LABEL: func.func @test_implicit_transpose_vector_coloring(
+
+    // CHECK: %[[ALLOC:.+]] = memref.alloc() {ssbuffer.block_id = [[B0:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"}
+    %alloc = memref.alloc() : memref<64x64xf32>
+    %cst = arith.constant 0.000000e+00 : f32
+
+    // CHECK: scf.if
+    // CHECK: linalg.fill {ssbuffer.block_id = {{[0-9]+}} : i32, ssbuffer.core_type = "VECTOR"}
+    scf.if %cond {
+      linalg.fill ins(%cst : f32) outs(%alloc : memref<64x64xf32>)
+    } {hivm.unlikely_condition}
+
+    // CHECK: %[[TENSOR:.+]] = bufferization.to_tensor %[[ALLOC]] restrict writable {ssbuffer.block_id = [[B1:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"}
+    %to_tensor = bufferization.to_tensor %alloc restrict writable : memref<64x64xf32>
+
+    // CHECK: annotation.mark %[[TENSOR]] {MayImplicitTransposeWithLastAxis, ssbuffer.block_id = [[B1]] : i32, ssbuffer.core_type = "VECTOR"}
+    annotation.mark %to_tensor {MayImplicitTransposeWithLastAxis} : tensor<64x64xf32>
+
+    %empty = tensor.empty() : tensor<64x64xf32>
+    %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<64x64xf32>) -> tensor<64x64xf32>
+    %other = tensor.empty() : tensor<64x64xf32>
+
+    %matmul = linalg.matmul ins(%to_tensor, %other : tensor<64x64xf32>, tensor<64x64xf32>) outs(%fill : tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %matmul : tensor<64x64xf32>
+  }
+
+  // Test Case 3: Normal ToTensor without Implicit Transpose
+  // Verifies that a standard matmul-feeding to_tensor without the annotation is still colored as CUBE.
+  func.func @test_normal_to_tensor_cube_coloring(%arg0: memref<?xf32>) -> tensor<64x64xf32> {
+    // CHECK-LABEL: func.func @test_normal_to_tensor_cube_coloring(
+
+    // CHECK: %[[ALLOC_CUBE:.+]] = memref.alloc() {ssbuffer.block_id = [[B2:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"}
+    %alloc = memref.alloc() : memref<64x64xf32>
+
+    // CHECK: %[[TENSOR_CUBE:.+]] = bufferization.to_tensor %[[ALLOC_CUBE]] restrict writable {ssbuffer.block_id = [[B3:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"}
+    %to_tensor = bufferization.to_tensor %alloc restrict writable : memref<64x64xf32>
+
+    %cst = arith.constant 0.000000e+00 : f32
+    %empty = tensor.empty() : tensor<64x64xf32>
+    %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<64x64xf32>) -> tensor<64x64xf32>
+    %other = tensor.empty() : tensor<64x64xf32>
+
+    %matmul = linalg.matmul ins(%to_tensor, %other : tensor<64x64xf32>, tensor<64x64xf32>) outs(%fill : tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %matmul : tensor<64x64xf32>
+  }
+
+  // Test Case 4: Block ID alignment check for annotation.mark
+  // Verifies that annotation.mark always follows its defining operation (%to_tensor)
+  // in terms of block assignment, preventing mismatched block IDs.
+  func.func @test_mark_block_id_alignment(%arg0: memref<?xf32>, %cond: i1) -> tensor<64x64xf32> {
+    // CHECK-LABEL: func.func @test_mark_block_id_alignment(
+
+    %alloc = memref.alloc() : memref<64x64xf32>
+
+    // CHECK: %[[TENSOR_VAL:.+]] = bufferization.to_tensor %{{.+}} restrict writable {ssbuffer.block_id = [[B4:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"}
+    %to_tensor = bufferization.to_tensor %alloc restrict writable : memref<64x64xf32>
+
+    // CHECK: annotation.mark %[[TENSOR_VAL]] {MayImplicitTransposeWithLastAxis, ssbuffer.block_id = [[B4]] : i32, ssbuffer.core_type = "VECTOR"}
+    annotation.mark %to_tensor {MayImplicitTransposeWithLastAxis} : tensor<64x64xf32>
+
+    %cst = arith.constant 0.000000e+00 : f32
+    %empty = tensor.empty() : tensor<64x64xf32>
+    %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<64x64xf32>) -> tensor<64x64xf32>
+    %other = tensor.empty() : tensor<64x64xf32>
+
+    %matmul = linalg.matmul ins(%to_tensor, %other : tensor<64x64xf32>, tensor<64x64xf32>) outs(%fill : tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %matmul : tensor<64x64xf32>
+  }
+}


### PR DESCRIPTION
#### **Description**:
This PR addresses unexpected core-type coloring and block ID splitting issues for operations marked with the `MayImplicitTransposeWithLastAxis` attribute:

* **Vector Core-Type Preservation**:
  * Prevents `bufferization.to_tensor` operations annotated with `MayImplicitTransposeWithLastAxis` from being classified as CUBE seeds. 
  * This adjustment ensures that the annotated `to_tensor`, its corresponding memory allocations (`memref.alloc`), and any associated initializations (e.g., `linalg.fill` inside conditional blocks) maintain the default `VECTOR_ONLY` designation when mapped upstream of a matmul.

* **Block ID Alignment for `annotation.mark`**:
  * Resolves a mismatch where `annotation.mark` and the operation it annotates could be assigned different block IDs due to refinement/eviction logic in vector block planning.
  * Added a handling path in `collectKeepOps` to preserve `annotation.mark` in the exact same `keepOps` group as its defining operation.

* **Tests**:
  * Added regression test cases checking basic behavior, conditional fillings in unlikely branch blocks, block ID consistency, and baseline CUBE classification correctness.