### PR TITLE
[release/3.2.2][Autotune] Normalize duplicate reduction axis

### DIFF
--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -599,18 +599,21 @@ class AutoTilingTuner(Autotuner):
         return axis_arg_names
 
     def _promote_axis_arg_name_to_reduction(self, axis):
+        axis = self._get_axis_base_name(axis)
         if not isinstance(axis, str) or not axis:
             return
-        if axis.startswith("r"):
-            return
-        reduction_axis = "r{}".format(axis)
         if self.vector_axes is None:
             self.vector_axes = self._rebuild_vector_axes()
+        reduction_axis = "r{}".format(axis)
         axis_arg_name = self.vector_axes.axis_length_exprs.get(axis, None)
+        if axis_arg_name is None:
+            axis_arg_name = self.vector_axes.axis_length_exprs.get(reduction_axis, None)
+        self.vector_axes.ensure_axis(axis)
         if axis_arg_name is not None:
-            self.vector_axes.ensure_axis(reduction_axis).length_expr = axis_arg_name
-            self.vector_axes.ensure_axis(axis).length_expr = None
-        self.vector_axes.apply_semantic_fields(reduction_axes=[reduction_axis])
+            self.vector_axes.ensure_axis(axis).length_expr = axis_arg_name
+            if reduction_axis in self.vector_axes.axes:
+                self.vector_axes.ensure_axis(reduction_axis).length_expr = None
+        self.vector_axes.apply_semantic_fields(reduction_axes=[axis])
         self.axis_arg_names = self._get_parser_axis_arg_names()
 
     def _init_axis_params(self, key, split_params, tiling_params, low_dim_axes, reduction_axes, hints_axes=None):
@@ -1084,21 +1087,51 @@ class AutoTilingTuner(Autotuner):
                 f"Please ensure that these arguments are passed when calling the function."
             )
 
-    def _normalize_vv_reduction_axes(self, reduction_axes: List[str]) -> List[str]:
+    @staticmethod
+    def _normalize_reduction_axis_name(axis: Optional[str]) -> Optional[str]:
+        if not isinstance(axis, str) or not axis:
+            return None
+        base_axis_names = {
+            name
+            for name in valid_axis_names
+            if isinstance(name, str) and name and not name.startswith("r")
+        }
+        if axis in base_axis_names:
+            return axis
+        candidate = axis
+        while candidate.startswith("r") and len(candidate) > 1:
+            candidate = candidate[1:]
+            if candidate in base_axis_names:
+                return candidate
+        return axis
+
+    def _normalize_reduction_axes(self, reduction_axes: List[str]) -> List[str]:
         normalized = []
         for axis in reduction_axes:
-            if not isinstance(axis, str) or not axis:
-                continue
-            if axis.startswith("r"):
-                normalized.append(axis)
-            else:
-                normalized.append("r{}".format(axis))
+            canonical_axis = self._normalize_reduction_axis_name(axis)
+            if canonical_axis is not None:
+                normalized.append(canonical_axis)
         return normalized
+
+    def _normalize_vv_reduction_axes(self, reduction_axes: List[str]) -> List[str]:
+        return self._normalize_reduction_axes(reduction_axes)
 
     @staticmethod
     def _get_axis_base_name(axis: Optional[str]) -> Optional[str]:
         if not isinstance(axis, str) or not axis:
             return None
+        base_axis_names = {
+            name
+            for name in valid_axis_names
+            if isinstance(name, str) and name and not name.startswith("r")
+        }
+        if axis in base_axis_names:
+            return axis
+        candidate = axis
+        while candidate.startswith("r") and len(candidate) > 1:
+            candidate = candidate[1:]
+            if candidate in base_axis_names:
+                return candidate
         return axis[1:] if axis.startswith("r") else axis
 
     def _apply_vv_axis_semantic_result(self) -> bool:
@@ -1109,21 +1142,24 @@ class AutoTilingTuner(Autotuner):
             return False
 
         applied = False
+        raw_adapter_reduction_axes = list(
+            getattr(self.vv_adapter_result_v2, "reduction_axes", []) or []
+        )
         adapter_reduction_axes = self._normalize_vv_reduction_axes(
-            list(getattr(self.vv_adapter_result_v2, "reduction_axes", []) or [])
+            raw_adapter_reduction_axes
+        )
+        raw_adapter_low_dim_axes = list(
+            getattr(self.vv_adapter_result_v2, "low_dim_axes", []) or []
         )
         if adapter_reduction_axes or self.reduction_axes:
             self.reduction_axes = []
             for reduction_axis in adapter_reduction_axes:
-                base_axis = reduction_axis[1:] if reduction_axis.startswith("r") else reduction_axis
-                if base_axis in self.axis_arg_names and reduction_axis not in self.axis_arg_names:
-                    self._promote_axis_arg_name_to_reduction(base_axis)
+                base_axis = self._get_axis_base_name(reduction_axis)
+                self._promote_axis_arg_name_to_reduction(base_axis)
             self.reduction_axes = list(adapter_reduction_axes)
             applied = True
 
-        adapter_low_dim_axes = list(
-            getattr(self.vv_adapter_result_v2, "low_dim_axes", []) or []
-        )
+        adapter_low_dim_axes = raw_adapter_low_dim_axes
         if adapter_low_dim_axes or self.low_dim_axes:
             self.low_dim_axes = list(adapter_low_dim_axes)
             applied = True
@@ -1366,6 +1402,42 @@ class AutoTilingTuner(Autotuner):
             "reduction_axes": vector_axes.reduction_axes,
             "axis_pid_dims": vector_axes.axis_pid_dims,
             "diagnostics": diagnostics,
+        }
+
+    def _convert_reduction_axes_for_legacy_tile_generator(
+        self,
+        vector_tile_inputs: Dict[str, object],
+    ) -> Dict[str, object]:
+        reduction_base_axes = {
+            self._get_axis_base_name(axis)
+            for axis in list(vector_tile_inputs.get("reduction_axes", []) or [])
+        }
+        reduction_base_axes = {
+            axis for axis in reduction_base_axes
+            if isinstance(axis, str) and axis
+        }
+
+        def legacy_axis_name(axis):
+            base_axis = self._get_axis_base_name(axis)
+            if base_axis in reduction_base_axes:
+                return "r{}".format(base_axis)
+            return axis
+
+        def map_axis_dict(axis_dict):
+            return {
+                legacy_axis_name(axis): value
+                for axis, value in dict(axis_dict or {}).items()
+            }
+
+        return {
+            "axis_sizes": map_axis_dict(vector_tile_inputs.get("axis_sizes", {})),
+            "split_params": map_axis_dict(vector_tile_inputs.get("split_params", {})),
+            "fixed_split_params": map_axis_dict(getattr(self, "fixed_split_params", {})),
+            "tiling_params": map_axis_dict(vector_tile_inputs.get("tiling_params", {})),
+            "low_dim_axes": [
+                legacy_axis_name(axis)
+                for axis in list(vector_tile_inputs.get("low_dim_axes", []) or [])
+            ],
         }
 
     def _apply_fixed_grid_semantics(
@@ -1929,14 +2001,16 @@ class AutoTilingTuner(Autotuner):
         from .tile_generator import KernelMeta, TileGenerator
 
         vector_tile_inputs = self._materialize_vector_tile_inputs(kv_dict, all_args)
-        axis_sizes = vector_tile_inputs["axis_sizes"]
+        legacy_tile_inputs = self._convert_reduction_axes_for_legacy_tile_generator(
+            vector_tile_inputs
+        )
 
         kernel_meta = KernelMeta(
-            axis_sizes,
-            vector_tile_inputs["split_params"],
-            self.fixed_split_params,
-            vector_tile_inputs["tiling_params"],
-            vector_tile_inputs["low_dim_axes"],
+            legacy_tile_inputs["axis_sizes"],
+            legacy_tile_inputs["split_params"],
+            legacy_tile_inputs["fixed_split_params"],
+            legacy_tile_inputs["tiling_params"],
+            legacy_tile_inputs["low_dim_axes"],
             dtype,
             self.persistent_reduction,
             self.dual_reduction,
@@ -2545,11 +2619,13 @@ class AutoTilingTuner(Autotuner):
         Extracts the reduction axis parameters from triton kernel code.
         """
         func_ast = self.fn.parse()
-        parser = ReductionAxesParser(func_ast, self._get_parser_axis_arg_names())
-        reduction_axes = parser.parse()
-        for axis in reduction_axes:
-            self._promote_axis_arg_name_to_reduction(axis)
-        reduction_axes = [f"r{axis}" for axis in reduction_axes]
+        axis_arg_names_before = self._get_parser_axis_arg_names()
+        parser = ReductionAxesParser(func_ast, axis_arg_names_before)
+        raw_reduction_axes = parser.parse()
+        for axis in raw_reduction_axes:
+            base_axis = self._get_axis_base_name(axis)
+            self._promote_axis_arg_name_to_reduction(base_axis)
+        reduction_axes = self._normalize_reduction_axes(raw_reduction_axes)
         self.reduction_axes = list(reduction_axes)
         self._refresh_vector_axes()
 

--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -559,9 +559,15 @@ class AutoTilingTuner(Autotuner):
         existing_vector_axes = getattr(self, "vector_axes", None)
         if existing_vector_axes is not None:
             vector_axes.apply_semantic_fields(
-                axis_length_exprs=getattr(existing_vector_axes, "axis_length_exprs", {}),
-                fixed_tiling_exprs=getattr(existing_vector_axes, "fixed_tiling_exprs", {}),
-                axis_dynamic_sources=getattr(existing_vector_axes, "axis_dynamic_sources", {}),
+                axis_length_exprs=self._normalize_axis_name_mapping(
+                    getattr(existing_vector_axes, "axis_length_exprs", {}),
+                ),
+                fixed_tiling_exprs=self._normalize_axis_name_mapping(
+                    getattr(existing_vector_axes, "fixed_tiling_exprs", {}),
+                ),
+                axis_dynamic_sources=self._normalize_axis_name_mapping(
+                    getattr(existing_vector_axes, "axis_dynamic_sources", {}),
+                ),
             )
 
         vector_axes.apply_semantic_fields(
@@ -575,9 +581,52 @@ class AutoTilingTuner(Autotuner):
 
     def _refresh_vector_axes(self) -> None:
         self.vector_axes = self._rebuild_vector_axes()
+        self._sync_reduction_axis_arg_aliases()
         self.axis_arg_names = self._get_parser_axis_arg_names()
 
+    def _sync_reduction_axis_arg_aliases(self) -> None:
+        def resolve_base_axis(axis_name):
+            resolver = getattr(self, "_get_axis_base_name", None)
+            if callable(resolver):
+                return resolver(axis_name)
+            if not isinstance(axis_name, str) or not axis_name:
+                return None
+            candidate = axis_name
+            while candidate.startswith("r") and len(candidate) > 1:
+                candidate = candidate[1:]
+            return candidate
+
+        vector_axes = getattr(self, "vector_axes", None)
+        axis_length_exprs = {}
+        if vector_axes is not None:
+            axis_length_exprs = dict(getattr(vector_axes, "axis_length_exprs", {}) or {})
+
+        synced_aliases = {}
+        for reduction_axis in list(getattr(self, "reduction_axes", []) or []):
+            if not isinstance(reduction_axis, str) or not reduction_axis.startswith("r"):
+                continue
+            base_axis = resolve_base_axis(reduction_axis)
+            if not isinstance(base_axis, str) or not base_axis:
+                continue
+            axis_arg_name = axis_length_exprs.get(base_axis, None)
+            if not self._is_direct_runtime_length_arg_name(axis_arg_name):
+                continue
+            synced_aliases[f"r{base_axis}"] = axis_arg_name
+
+        self.reduction_axis_arg_aliases = synced_aliases
+
     def _get_parser_axis_arg_names(self) -> Dict[str, str]:
+        def resolve_base_axis(axis_name):
+            resolver = getattr(self, "_get_axis_base_name", None)
+            if callable(resolver):
+                return resolver(axis_name)
+            if not isinstance(axis_name, str) or not axis_name:
+                return None
+            candidate = axis_name
+            while candidate.startswith("r") and len(candidate) > 1:
+                candidate = candidate[1:]
+            return candidate
+
         axis_arg_names = {}
         if self.vector_axes is not None:
             axis_arg_names.update(
@@ -591,10 +640,21 @@ class AutoTilingTuner(Autotuner):
             for reduction_axis in self.vector_axes.reduction_axes:
                 if not isinstance(reduction_axis, str) or not reduction_axis.startswith("r"):
                     continue
-                base_axis = reduction_axis[1:]
-                base_arg_name = axis_arg_names.pop(base_axis, None)
+                base_axis = resolve_base_axis(reduction_axis)
+                if not isinstance(base_axis, str) or not base_axis:
+                    continue
+                base_arg_name = axis_arg_names.get(base_axis, None)
                 if base_arg_name is not None:
-                    axis_arg_names.setdefault(reduction_axis, base_arg_name)
+                    axis_arg_names.setdefault(f"r{base_axis}", base_arg_name)
+
+        reduction_axis_arg_aliases = getattr(self, "reduction_axis_arg_aliases", {}) or {}
+        axis_arg_names.update(reduction_axis_arg_aliases)
+        for reduction_axis, arg_name in reduction_axis_arg_aliases.items():
+            if not isinstance(reduction_axis, str) or not reduction_axis.startswith("r"):
+                continue
+            base_axis = reduction_axis[1:]
+            if axis_arg_names.get(base_axis, None) == arg_name:
+                axis_arg_names.pop(base_axis, None)
 
         return axis_arg_names
 
@@ -614,6 +674,9 @@ class AutoTilingTuner(Autotuner):
             if reduction_axis in self.vector_axes.axes:
                 self.vector_axes.ensure_axis(reduction_axis).length_expr = None
         self.vector_axes.apply_semantic_fields(reduction_axes=[axis])
+        sync_aliases = getattr(self, "_sync_reduction_axis_arg_aliases", None)
+        if callable(sync_aliases):
+            sync_aliases()
         self.axis_arg_names = self._get_parser_axis_arg_names()
 
     def _init_axis_params(self, key, split_params, tiling_params, low_dim_axes, reduction_axes, hints_axes=None):
@@ -678,6 +741,8 @@ class AutoTilingTuner(Autotuner):
         self.vv_adapter_result_v2 = None
         self.vv_gap_fill_report_v2 = None
         self.vector_axes = self._rebuild_vector_axes()
+        self.reduction_axis_arg_aliases = {}
+        self._sync_reduction_axis_arg_aliases()
         self.axis_arg_names = self._get_parser_axis_arg_names()
 
     def _autoparse_axis_params(self, all_args):
@@ -1116,6 +1181,53 @@ class AutoTilingTuner(Autotuner):
     def _normalize_vv_reduction_axes(self, reduction_axes: List[str]) -> List[str]:
         return self._normalize_reduction_axes(reduction_axes)
 
+    def _normalize_axis_name_mapping(
+        self,
+        axis_mapping: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        def resolve_base_axis(axis_name):
+            resolver = getattr(self, "_get_axis_base_name", None)
+            if callable(resolver):
+                return resolver(axis_name)
+            if not isinstance(axis_name, str) or not axis_name:
+                return None
+            candidate = axis_name
+            while candidate.startswith("r") and len(candidate) > 1:
+                candidate = candidate[1:]
+            return candidate
+
+        normalized = {}
+        for axis, value in dict(axis_mapping or {}).items():
+            base_axis = resolve_base_axis(axis)
+            if not isinstance(base_axis, str) or not base_axis:
+                continue
+            normalized.setdefault(base_axis, value)
+        return normalized
+
+    def _normalize_axis_name_list(
+        self,
+        axis_names: Optional[List[str]],
+    ) -> List[str]:
+        def resolve_base_axis(axis_name):
+            resolver = getattr(self, "_get_axis_base_name", None)
+            if callable(resolver):
+                return resolver(axis_name)
+            if not isinstance(axis_name, str) or not axis_name:
+                return None
+            candidate = axis_name
+            while candidate.startswith("r") and len(candidate) > 1:
+                candidate = candidate[1:]
+            return candidate
+
+        normalized = []
+        for axis in list(axis_names or []):
+            base_axis = resolve_base_axis(axis)
+            if not isinstance(base_axis, str) or not base_axis:
+                continue
+            if base_axis not in normalized:
+                normalized.append(base_axis)
+        return normalized
+
     @staticmethod
     def _get_axis_base_name(axis: Optional[str]) -> Optional[str]:
         if not isinstance(axis, str) or not axis:
@@ -1135,6 +1247,42 @@ class AutoTilingTuner(Autotuner):
         return axis[1:] if axis.startswith("r") else axis
 
     def _apply_vv_axis_semantic_result(self) -> bool:
+        def resolve_base_axis(axis_name):
+            resolver = getattr(self, "_get_axis_base_name", None)
+            if callable(resolver):
+                return resolver(axis_name)
+            if not isinstance(axis_name, str) or not axis_name:
+                return None
+            candidate = axis_name
+            while candidate.startswith("r") and len(candidate) > 1:
+                candidate = candidate[1:]
+            return candidate
+
+        def normalize_axis_name_mapping(axis_mapping):
+            normalizer = getattr(self, "_normalize_axis_name_mapping", None)
+            if callable(normalizer):
+                return normalizer(axis_mapping)
+            normalized = {}
+            for axis, value in dict(axis_mapping or {}).items():
+                base_axis = resolve_base_axis(axis)
+                if not isinstance(base_axis, str) or not base_axis:
+                    continue
+                normalized.setdefault(base_axis, value)
+            return normalized
+
+        def normalize_axis_name_list(axis_names):
+            normalizer = getattr(self, "_normalize_axis_name_list", None)
+            if callable(normalizer):
+                return normalizer(axis_names)
+            normalized = []
+            for axis in list(axis_names or []):
+                base_axis = resolve_base_axis(axis)
+                if not isinstance(base_axis, str) or not base_axis:
+                    continue
+                if base_axis not in normalized:
+                    normalized.append(base_axis)
+            return normalized
+
         if self.vv_adapter_result_v2 is None:
             return False
         adapter_status = getattr(self.vv_adapter_result_v2, "status", "ok")
@@ -1154,31 +1302,31 @@ class AutoTilingTuner(Autotuner):
         if adapter_reduction_axes or self.reduction_axes:
             self.reduction_axes = []
             for reduction_axis in adapter_reduction_axes:
-                base_axis = self._get_axis_base_name(reduction_axis)
+                base_axis = resolve_base_axis(reduction_axis)
                 self._promote_axis_arg_name_to_reduction(base_axis)
             self.reduction_axes = list(adapter_reduction_axes)
             applied = True
 
-        adapter_low_dim_axes = raw_adapter_low_dim_axes
+        adapter_low_dim_axes = normalize_axis_name_list(raw_adapter_low_dim_axes)
         if adapter_low_dim_axes or self.low_dim_axes:
             self.low_dim_axes = list(adapter_low_dim_axes)
             applied = True
 
-        adapter_split_params = dict(
+        adapter_split_params = normalize_axis_name_mapping(
             getattr(self.vv_adapter_result_v2, "split_params", {}) or {}
         )
         if adapter_split_params or self.split_params:
             self.split_params = dict(adapter_split_params)
             applied = True
 
-        adapter_tiling_params = dict(
+        adapter_tiling_params = normalize_axis_name_mapping(
             getattr(self.vv_adapter_result_v2, "tiling_params", {}) or {}
         )
         if adapter_tiling_params or self.tiling_params:
             self.tiling_params = dict(adapter_tiling_params)
             applied = True
 
-        adapter_axis_pid_dims = dict(
+        adapter_axis_pid_dims = normalize_axis_name_mapping(
             getattr(self.vv_adapter_result_v2, "axis_pid_dims", {}) or {}
         )
         if adapter_axis_pid_dims or self.axis_pid_dims:
@@ -2167,10 +2315,20 @@ class AutoTilingTuner(Autotuner):
         if key not in self.cache:
             if self.auto_gen_config:
                 self.cv_parse_result = self._autoparse_axis_params(all_args)
+                reduction_aliases = {
+                    axis for axis, arg_name in self.axis_arg_names.items()
+                    if isinstance(axis, str)
+                    and axis.startswith("r")
+                    and self.axis_arg_names.get(axis[1:], None) == arg_name
+                }
                 _kv_dict = {
                     axis: _args[arg_name]
                     for axis, arg_name in self.axis_arg_names.items()
                     if arg_name in _args
+                    and axis not in {
+                        reduction_axis[1:]
+                        for reduction_axis in reduction_aliases
+                    }
                 }
                 self._gen_tile_configs(_kv_dict, dtype, all_args)
                 self.gen_configs = _expand_configs_with_hints(
@@ -2604,7 +2762,10 @@ class AutoTilingTuner(Autotuner):
         Extracts the tiling axis parameters from triton kernel code.
         """
         func_ast = self.fn.parse()
-        parser = TilingAxesParser(func_ast, self._get_parser_axis_arg_names(), candidates_params)
+        parser_axis_arg_names = self._normalize_axis_name_mapping(
+            self._get_parser_axis_arg_names()
+        )
+        parser = TilingAxesParser(func_ast, parser_axis_arg_names, candidates_params)
         tiling_axes = parser.parse()
         self.tiling_params = dict(tiling_axes)
         self._refresh_vector_axes()
@@ -2641,7 +2802,10 @@ class AutoTilingTuner(Autotuner):
         Extracts the low dimension axis from triton kernel code.
         """
         func_ast = self.fn.parse()
-        parser = LowDimsAxesParser(func_ast, self._get_parser_axis_arg_names())
+        parser_axis_arg_names = self._normalize_axis_name_mapping(
+            self._get_parser_axis_arg_names()
+        )
+        parser = LowDimsAxesParser(func_ast, parser_axis_arg_names)
         low_dim_axes = parser.parse()
         if len(low_dim_axes) < 1:
             if self.print_autotuning:

--- a/third_party/ascend/backend/runtime/dsl_analysis/vv_param_parser_v2.py
+++ b/third_party/ascend/backend/runtime/dsl_analysis/vv_param_parser_v2.py
@@ -2050,7 +2050,7 @@ def parse_vv_axis_semantic_v2(
         evidence = evidence_by_index[axis_index]
         base_axis_name = axis_name_by_index[axis_index]
         is_reduction = base_axis_name in reduction_base_axes
-        axis_name = "r{}".format(base_axis_name) if is_reduction else base_axis_name
+        axis_name = base_axis_name
 
         split, split_diag = _select_best_split(evidence.split_candidates)
         tiling, tiling_diag = _select_best_tiling(evidence.tiling_candidates, split.param)

--- a/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
+++ b/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
@@ -24,7 +24,7 @@ import os
 from collections.abc import Sequence
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import pytest
 import torch
@@ -63,6 +63,7 @@ def _load_autotuner_methods(*method_names):
     extracted_module = ast.Module(body=selected, type_ignores=[])
     ast.fix_missing_locations(extracted_module)
     namespace = {
+        "Any": Any,
         "Dict": Dict,
         "List": List,
         "Optional": Optional,
@@ -95,9 +96,11 @@ def _init_axis_state_for_test(
         "_parse_hints_axes",
         "_get_runtime_arg_names_for_hints_axes",
         "_infer_hints_axes_from_key",
+        "_normalize_axis_name_mapping",
         "_rebuild_vector_axes",
         "_get_parser_axis_arg_names",
         "_is_direct_runtime_length_arg_name",
+        "_sync_reduction_axis_arg_aliases",
         "_init_axis_params",
     )
     tuner = SimpleNamespace()
@@ -117,6 +120,14 @@ def _init_axis_state_for_test(
     rebuild_vector_axes = _normalize_loaded_method(namespace.get("_rebuild_vector_axes"))
     if rebuild_vector_axes is not None:
         tuner._rebuild_vector_axes = rebuild_vector_axes.__get__(tuner, SimpleNamespace)
+    normalize_axis_name_mapping = _normalize_loaded_method(
+        namespace.get("_normalize_axis_name_mapping")
+    )
+    if normalize_axis_name_mapping is not None:
+        tuner._normalize_axis_name_mapping = normalize_axis_name_mapping.__get__(
+            tuner,
+            SimpleNamespace,
+        )
     infer_hints_axes_from_key = _normalize_loaded_method(namespace.get("_infer_hints_axes_from_key"))
     if infer_hints_axes_from_key is not None:
         tuner._infer_hints_axes_from_key = infer_hints_axes_from_key.__get__(tuner, SimpleNamespace)
@@ -128,6 +139,14 @@ def _init_axis_state_for_test(
     )
     if is_direct_runtime_length_arg_name is not None:
         tuner._is_direct_runtime_length_arg_name = is_direct_runtime_length_arg_name
+    sync_reduction_axis_arg_aliases = _normalize_loaded_method(
+        namespace.get("_sync_reduction_axis_arg_aliases")
+    )
+    if sync_reduction_axis_arg_aliases is not None:
+        tuner._sync_reduction_axis_arg_aliases = sync_reduction_axis_arg_aliases.__get__(
+            tuner,
+            SimpleNamespace,
+        )
     tuner.enable_vv_parser_v2 = enable_vv_parser_v2
     tuner.vv_parser_v2_mode = vv_parser_v2_mode
     init_axis_params = _normalize_loaded_method(namespace["_init_axis_params"])
@@ -523,11 +542,13 @@ def test_generate_key_and_configs_uses_axis_arg_names_for_kv_dict():
     namespace = _load_autotuner_methods(
         "_parse_hints_axes",
         "_get_runtime_arg_names_for_hints_axes",
+        "_normalize_axis_name_mapping",
         "_rebuild_vector_axes",
         "_get_axis_base_name",
         "_get_parser_axis_arg_names",
         "_is_direct_runtime_length_arg_name",
         "_promote_axis_arg_name_to_reduction",
+        "_sync_reduction_axis_arg_aliases",
         "_init_axis_params",
         "generate_key_and_configs",
     )
@@ -572,12 +593,18 @@ def test_generate_key_and_configs_uses_axis_arg_names_for_kv_dict():
     tuner._get_axis_base_name = _normalize_loaded_method(
         namespace["_get_axis_base_name"]
     )
+    tuner._normalize_axis_name_mapping = _normalize_loaded_method(
+        namespace["_normalize_axis_name_mapping"]
+    ).__get__(tuner, SimpleNamespace)
     tuner._get_parser_axis_arg_names = _normalize_loaded_method(
         namespace["_get_parser_axis_arg_names"]
     ).__get__(tuner, SimpleNamespace)
     tuner._is_direct_runtime_length_arg_name = _normalize_loaded_method(
         namespace["_is_direct_runtime_length_arg_name"]
     )
+    tuner._sync_reduction_axis_arg_aliases = _normalize_loaded_method(
+        namespace["_sync_reduction_axis_arg_aliases"]
+    ).__get__(tuner, SimpleNamespace)
     tuner._promote_axis_arg_name_to_reduction = _normalize_loaded_method(
         namespace["_promote_axis_arg_name_to_reduction"]
     ).__get__(tuner, SimpleNamespace)
@@ -606,11 +633,13 @@ def test_generate_key_and_configs_preserves_promoted_reduction_axis_identity():
     namespace = _load_autotuner_methods(
         "_parse_hints_axes",
         "_get_runtime_arg_names_for_hints_axes",
+        "_normalize_axis_name_mapping",
         "_rebuild_vector_axes",
         "_get_axis_base_name",
         "_get_parser_axis_arg_names",
         "_is_direct_runtime_length_arg_name",
         "_promote_axis_arg_name_to_reduction",
+        "_sync_reduction_axis_arg_aliases",
         "_init_axis_params",
         "generate_key_and_configs",
     )
@@ -649,12 +678,18 @@ def test_generate_key_and_configs_preserves_promoted_reduction_axis_identity():
     tuner._get_axis_base_name = _normalize_loaded_method(
         namespace["_get_axis_base_name"]
     )
+    tuner._normalize_axis_name_mapping = _normalize_loaded_method(
+        namespace["_normalize_axis_name_mapping"]
+    ).__get__(tuner, SimpleNamespace)
     tuner._get_parser_axis_arg_names = _normalize_loaded_method(
         namespace["_get_parser_axis_arg_names"]
     ).__get__(tuner, SimpleNamespace)
     tuner._is_direct_runtime_length_arg_name = _normalize_loaded_method(
         namespace["_is_direct_runtime_length_arg_name"]
     )
+    tuner._sync_reduction_axis_arg_aliases = _normalize_loaded_method(
+        namespace["_sync_reduction_axis_arg_aliases"]
+    ).__get__(tuner, SimpleNamespace)
     tuner._promote_axis_arg_name_to_reduction = _normalize_loaded_method(
         namespace["_promote_axis_arg_name_to_reduction"]
     ).__get__(tuner, SimpleNamespace)
@@ -678,6 +713,159 @@ def test_generate_key_and_configs_preserves_promoted_reduction_axis_identity():
 
     assert tuner.keys == ["n_elements"]
     assert captured["kv_dict"] == {"x": 23}
+
+
+def test_refresh_vector_axes_clears_stale_reduction_axis_aliases_after_reduction_axes_emptied():
+    namespace = _load_autotuner_methods(
+        "_parse_hints_axes",
+        "_get_runtime_arg_names_for_hints_axes",
+        "_normalize_axis_name_mapping",
+        "_rebuild_vector_axes",
+        "_get_axis_base_name",
+        "_get_parser_axis_arg_names",
+        "_is_direct_runtime_length_arg_name",
+        "_promote_axis_arg_name_to_reduction",
+        "_sync_reduction_axis_arg_aliases",
+        "_refresh_vector_axes",
+        "_init_axis_params",
+        "generate_key_and_configs",
+    )
+    captured = {}
+
+    class FakeArg:
+        dtype = "float16"
+
+    namespace["get_byte_per_numel"] = lambda dtype: 0 if dtype is None else 1
+    namespace["_expand_configs_with_hints"] = lambda fn, configs, config_hints: configs
+
+    tuner = SimpleNamespace(
+        arg_names=["x_ptr", "n_elements"],
+        fn=SimpleNamespace(),
+        _get_constexpr_candidates=lambda: [],
+        cache={},
+        auto_gen_config=True,
+        parser_mode="vector",
+        config_hints={},
+        gen_configs=[],
+        user_configs=[],
+        is_simt_mode=False,
+        user_specified_warps=None,
+        user_specified_multibuffer=None,
+        _autoparse_axis_params=lambda all_args: None,
+        _gen_tile_configs=lambda kv_dict, dtype, all_args: captured.update(kv_dict=dict(kv_dict))
+        or setattr(tuner, "gen_configs", [SimpleNamespace(kwargs={"BLOCK_SIZE": 128})]),
+    )
+    tuner._parse_hints_axes = _normalize_loaded_method(namespace["_parse_hints_axes"]).__get__(tuner, SimpleNamespace)
+    tuner._get_runtime_arg_names_for_hints_axes = _normalize_loaded_method(
+        namespace["_get_runtime_arg_names_for_hints_axes"]
+    ).__get__(tuner, SimpleNamespace)
+    tuner._rebuild_vector_axes = _normalize_loaded_method(
+        namespace["_rebuild_vector_axes"]
+    ).__get__(tuner, SimpleNamespace)
+    tuner._get_axis_base_name = _normalize_loaded_method(
+        namespace["_get_axis_base_name"]
+    )
+    tuner._normalize_axis_name_mapping = _normalize_loaded_method(
+        namespace["_normalize_axis_name_mapping"]
+    ).__get__(tuner, SimpleNamespace)
+    tuner._get_parser_axis_arg_names = _normalize_loaded_method(
+        namespace["_get_parser_axis_arg_names"]
+    ).__get__(tuner, SimpleNamespace)
+    tuner._is_direct_runtime_length_arg_name = _normalize_loaded_method(
+        namespace["_is_direct_runtime_length_arg_name"]
+    )
+    tuner._promote_axis_arg_name_to_reduction = _normalize_loaded_method(
+        namespace["_promote_axis_arg_name_to_reduction"]
+    ).__get__(tuner, SimpleNamespace)
+    tuner._sync_reduction_axis_arg_aliases = _normalize_loaded_method(
+        namespace["_sync_reduction_axis_arg_aliases"]
+    ).__get__(tuner, SimpleNamespace)
+    tuner._refresh_vector_axes = _normalize_loaded_method(
+        namespace["_refresh_vector_axes"]
+    ).__get__(tuner, SimpleNamespace)
+
+    _normalize_loaded_method(namespace["_init_axis_params"])(
+        tuner,
+        ["n_elements"],
+        None,
+        None,
+        None,
+        None,
+        {"x": "n_elements"},
+    )
+
+    tuner.reduction_axis_arg_aliases = {"rx": "n_elements"}
+    tuner.reduction_axes = []
+    tuner._refresh_vector_axes()
+
+    _normalize_loaded_method(namespace["generate_key_and_configs"])(
+        tuner,
+        FakeArg(),
+        29,
+    )
+
+    assert tuner.reduction_axis_arg_aliases == {}
+    assert tuner.axis_arg_names == {"x": "n_elements"}
+    assert captured["kv_dict"] == {"x": 29}
+
+
+def test_legacy_low_dim_and_tiling_parsers_consume_base_axis_names_after_reduction_promotion():
+    namespace = _load_autotuner_methods(
+        "_normalize_axis_name_mapping",
+        "_autoparse_tiling_params",
+        "_autoparse_low_dim_axes",
+    )
+    parser_inputs = {}
+
+    class StubTilingAxesParser:
+        def __init__(self, func_ast, axis_arg_names, candidates_params):
+            parser_inputs["tiling"] = dict(axis_arg_names)
+
+        def parse(self):
+            if "ry" in parser_inputs["tiling"]:
+                return {"x": "X0BLOCK_SUB", "ry": "R1BLOCK_SUB"}
+            return {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"}
+
+    class StubLowDimsAxesParser:
+        def __init__(self, func_ast, axis_arg_names):
+            parser_inputs["low_dim"] = dict(axis_arg_names)
+
+        def parse(self):
+            if "ry" in parser_inputs["low_dim"]:
+                return ["ry"]
+            return ["y"]
+
+    namespace["TilingAxesParser"] = StubTilingAxesParser
+    namespace["LowDimsAxesParser"] = StubLowDimsAxesParser
+
+    refresh_calls = []
+    tuner = SimpleNamespace(
+        fn=SimpleNamespace(parse=lambda: "fake-func-ast"),
+        print_autotuning=False,
+        tiling_params={},
+        low_dim_axes=[],
+        _get_parser_axis_arg_names=lambda: {"x": "x0_numel", "ry": "r1_numel"},
+        _refresh_vector_axes=lambda: refresh_calls.append(True),
+    )
+    tuner._normalize_axis_name_mapping = _normalize_loaded_method(
+        namespace["_normalize_axis_name_mapping"]
+    ).__get__(tuner, SimpleNamespace)
+
+    tiling_params = _normalize_loaded_method(namespace["_autoparse_tiling_params"])(
+        tuner,
+        ["X0BLOCK_SUB", "R1BLOCK_SUB"],
+    )
+    low_dim_axes = _normalize_loaded_method(namespace["_autoparse_low_dim_axes"])(
+        tuner
+    )
+
+    assert parser_inputs["tiling"] == {"x": "x0_numel", "y": "r1_numel"}
+    assert parser_inputs["low_dim"] == {"x": "x0_numel", "y": "r1_numel"}
+    assert tiling_params == {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"}
+    assert tuner.tiling_params == {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"}
+    assert low_dim_axes == ["y"]
+    assert tuner.low_dim_axes == ["y"]
+    assert refresh_calls == [True, True]
 
 
 def test_parse_vv_axis_info_v2_collects_fixed_tiling_expr_for_provided_constexpr():

--- a/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
+++ b/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
@@ -423,7 +423,10 @@ def test_resolve_axis_length_arg_name_uses_base_vv_axis_expr_for_reduction_axis(
 
 def test_apply_vv_axis_semantic_result_promotes_internal_axis_map_only():
     namespace = _load_autotuner_methods(
+        "_normalize_reduction_axis_name",
+        "_normalize_reduction_axes",
         "_normalize_vv_reduction_axes",
+        "_get_axis_base_name",
         "_get_parser_axis_arg_names",
         "_is_direct_runtime_length_arg_name",
         "_promote_axis_arg_name_to_reduction",
@@ -449,9 +452,18 @@ def test_apply_vv_axis_semantic_result_promotes_internal_axis_map_only():
         keys=["n_elements"],
         dual_reduction=False,
     )
+    tuner._normalize_reduction_axis_name = _normalize_loaded_method(
+        namespace["_normalize_reduction_axis_name"]
+    )
+    tuner._normalize_reduction_axes = _normalize_loaded_method(
+        namespace["_normalize_reduction_axes"]
+    ).__get__(tuner, SimpleNamespace)
     tuner._normalize_vv_reduction_axes = _normalize_loaded_method(
         namespace["_normalize_vv_reduction_axes"]
     ).__get__(tuner, SimpleNamespace)
+    tuner._get_axis_base_name = _normalize_loaded_method(
+        namespace["_get_axis_base_name"]
+    )
     tuner._get_parser_axis_arg_names = _normalize_loaded_method(
         namespace["_get_parser_axis_arg_names"]
     ).__get__(tuner, SimpleNamespace)
@@ -469,8 +481,42 @@ def test_apply_vv_axis_semantic_result_promotes_internal_axis_map_only():
 
     assert applied is True
     assert tuner.keys == ["n_elements"]
-    assert tuner.axis_arg_names == {"rx": "n_elements"}
-    assert tuner.reduction_axes == ["rx"]
+    assert tuner.axis_arg_names == {"x": "n_elements"}
+    assert tuner.reduction_axes == ["x"]
+
+
+def test_promote_reduction_axis_canonicalizes_existing_prefixed_length_expr():
+    namespace = _load_autotuner_methods(
+        "_get_axis_base_name",
+        "_get_parser_axis_arg_names",
+        "_is_direct_runtime_length_arg_name",
+        "_promote_axis_arg_name_to_reduction",
+    )
+    vector_axes_module = _load_vector_axes_module()
+    vector_axes = vector_axes_module.VectorAxes()
+    vector_axes.apply_semantic_fields(axis_length_exprs={"ry": "r1_numel"})
+    tuner = SimpleNamespace(
+        vector_axes=vector_axes,
+        axis_arg_names={"ry": "r1_numel"},
+    )
+    tuner._get_axis_base_name = _normalize_loaded_method(
+        namespace["_get_axis_base_name"]
+    )
+    tuner._get_parser_axis_arg_names = _normalize_loaded_method(
+        namespace["_get_parser_axis_arg_names"]
+    ).__get__(tuner, SimpleNamespace)
+    tuner._is_direct_runtime_length_arg_name = _normalize_loaded_method(
+        namespace["_is_direct_runtime_length_arg_name"]
+    )
+    tuner._promote_axis_arg_name_to_reduction = _normalize_loaded_method(
+        namespace["_promote_axis_arg_name_to_reduction"]
+    ).__get__(tuner, SimpleNamespace)
+
+    tuner._promote_axis_arg_name_to_reduction("ry")
+
+    assert tuner.vector_axes.axis_length_exprs == {"y": "r1_numel"}
+    assert tuner.vector_axes.reduction_axes == ["y"]
+    assert tuner.axis_arg_names == {"y": "r1_numel"}
 
 
 def test_generate_key_and_configs_uses_axis_arg_names_for_kv_dict():
@@ -478,6 +524,7 @@ def test_generate_key_and_configs_uses_axis_arg_names_for_kv_dict():
         "_parse_hints_axes",
         "_get_runtime_arg_names_for_hints_axes",
         "_rebuild_vector_axes",
+        "_get_axis_base_name",
         "_get_parser_axis_arg_names",
         "_is_direct_runtime_length_arg_name",
         "_promote_axis_arg_name_to_reduction",
@@ -522,6 +569,9 @@ def test_generate_key_and_configs_uses_axis_arg_names_for_kv_dict():
     tuner._rebuild_vector_axes = _normalize_loaded_method(
         namespace["_rebuild_vector_axes"]
     ).__get__(tuner, SimpleNamespace)
+    tuner._get_axis_base_name = _normalize_loaded_method(
+        namespace["_get_axis_base_name"]
+    )
     tuner._get_parser_axis_arg_names = _normalize_loaded_method(
         namespace["_get_parser_axis_arg_names"]
     ).__get__(tuner, SimpleNamespace)
@@ -557,6 +607,7 @@ def test_generate_key_and_configs_preserves_promoted_reduction_axis_identity():
         "_parse_hints_axes",
         "_get_runtime_arg_names_for_hints_axes",
         "_rebuild_vector_axes",
+        "_get_axis_base_name",
         "_get_parser_axis_arg_names",
         "_is_direct_runtime_length_arg_name",
         "_promote_axis_arg_name_to_reduction",
@@ -595,6 +646,9 @@ def test_generate_key_and_configs_preserves_promoted_reduction_axis_identity():
     tuner._rebuild_vector_axes = _normalize_loaded_method(
         namespace["_rebuild_vector_axes"]
     ).__get__(tuner, SimpleNamespace)
+    tuner._get_axis_base_name = _normalize_loaded_method(
+        namespace["_get_axis_base_name"]
+    )
     tuner._get_parser_axis_arg_names = _normalize_loaded_method(
         namespace["_get_parser_axis_arg_names"]
     ).__get__(tuner, SimpleNamespace)
@@ -623,7 +677,7 @@ def test_generate_key_and_configs_preserves_promoted_reduction_axis_identity():
     )
 
     assert tuner.keys == ["n_elements"]
-    assert captured["kv_dict"] == {"rx": 23}
+    assert captured["kv_dict"] == {"x": 23}
 
 
 def test_parse_vv_axis_info_v2_collects_fixed_tiling_expr_for_provided_constexpr():
@@ -1361,3 +1415,74 @@ def test_expand_simt_num_warps_configs_default_candidates():
 
     assert len(expanded_configs) == 4
     assert [cfg.num_warps for cfg in expanded_configs] == [8, 16, 32, 64]
+
+
+@pytest.mark.parametrize(
+    ("raw_axis", "expected"),
+    [
+        ("x", "x"),
+        ("rx", "x"),
+        ("rrx", "x"),
+        ("y", "y"),
+        ("ry", "y"),
+        ("rry", "y"),
+        ("rfoo", "rfoo"),
+        ("rrfoo", "rrfoo"),
+    ],
+)
+def test_normalize_reduction_axis_name_canonicalizes_only_known_base_axes(raw_axis, expected):
+    namespace = _load_autotuner_methods("_normalize_reduction_axis_name")
+
+    result = _normalize_loaded_method(namespace["_normalize_reduction_axis_name"])(raw_axis)
+
+    assert result == expected
+
+
+def test_autoparse_reduction_axes_normalizes_prefixed_parser_output_before_persisting():
+    namespace = _load_autotuner_methods(
+        "_normalize_reduction_axis_name",
+        "_normalize_reduction_axes",
+        "_get_axis_base_name",
+        "_autoparse_reduction_axes",
+    )
+
+    class StubReductionAxesParser:
+        def __init__(self, func_ast, axis_arg_names):
+            self.func_ast = func_ast
+            self.axis_arg_names = axis_arg_names
+
+        def parse(self):
+            return ["rx", "ry"]
+
+    namespace["ReductionAxesParser"] = StubReductionAxesParser
+
+    promoted_axes = []
+    refresh_calls = []
+
+    tuner = SimpleNamespace(
+        fn=SimpleNamespace(parse=lambda: "fake-func-ast"),
+        axis_arg_names={"rx": "seq_len", "ry": "dim"},
+        reduction_axes=[],
+        print_autotuning=False,
+        _get_parser_axis_arg_names=lambda: {"rx": "seq_len", "ry": "dim"},
+        _promote_axis_arg_name_to_reduction=lambda axis: promoted_axes.append(axis),
+        _refresh_vector_axes=lambda: refresh_calls.append(True),
+    )
+    tuner._get_axis_base_name = _normalize_loaded_method(
+        namespace["_get_axis_base_name"]
+    )
+    tuner._normalize_reduction_axis_name = _normalize_loaded_method(
+        namespace["_normalize_reduction_axis_name"]
+    )
+    tuner._normalize_reduction_axes = _normalize_loaded_method(
+        namespace["_normalize_reduction_axes"]
+    ).__get__(tuner, SimpleNamespace)
+
+    reduction_axes = _normalize_loaded_method(namespace["_autoparse_reduction_axes"])(
+        tuner
+    )
+
+    assert promoted_axes == ["x", "y"]
+    assert reduction_axes == ["x", "y"]
+    assert tuner.reduction_axes == ["x", "y"]
+    assert refresh_calls == [True]

--- a/third_party/ascend/unittest/autotune_ut/test_reduction_axes_parse.py
+++ b/third_party/ascend/unittest/autotune_ut/test_reduction_axes_parse.py
@@ -33,6 +33,16 @@ def assert_outward_semantic_axes_state(act_res, ref_res):
     assert act_res["reduction_axes"] == ref_res["reduction_axes"]
 
 
+def assert_vv_parser_semantic_axes_state(act_res, ref_res):
+    vv_parse_result = act_res["vv_parse_result_v2"]
+    assert vv_parse_result is not None
+    assert vv_parse_result.axis_length_exprs == ref_res["keys"]
+    assert vv_parse_result.split_params == ref_res["split_params"]
+    assert vv_parse_result.tiling_params == ref_res["tiling_params"]
+    assert vv_parse_result.low_dim_axes == ref_res["low_dim_axes"]
+    assert vv_parse_result.reduction_axes == ref_res["reduction_axes"]
+
+
 def test_triton_max_last_dim_case1(mock_autotuner):
     import triton.backends.ascend.runtime
 
@@ -79,6 +89,7 @@ def test_triton_max_last_dim_case1(mock_autotuner):
     act_res = triton_max_last_dim1[grid]()
 
     assert_outward_semantic_axes_state(act_res, ref_res)
+    assert_vv_parser_semantic_axes_state(act_res, ref_res)
     check_axes_parse_res(act_res, ref_res)
 
 
@@ -128,6 +139,7 @@ def test_triton_max_last_dim_case2(mock_autotuner):
     act_res = triton_max_last_dim2[grid]()
 
     assert_outward_semantic_axes_state(act_res, ref_res)
+    assert_vv_parser_semantic_axes_state(act_res, ref_res)
     check_axes_parse_res(act_res, ref_res)
 
 
@@ -177,6 +189,7 @@ def test_triton_max_last_dim_case3(mock_autotuner):
     act_res = triton_max_last_dim3[grid]()
 
     assert_outward_semantic_axes_state(act_res, ref_res)
+    assert_vv_parser_semantic_axes_state(act_res, ref_res)
     check_axes_parse_res(act_res, ref_res)
 
 
@@ -226,4 +239,5 @@ def test_reduction_axes_parse_kernel_type_vector_auto_consistency(mock_autotuner
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_reduction_axes_parse_kernel_type_vector_auto_consistency[grid]()
     assert_outward_semantic_axes_state(act_res, ref_res)
+    assert_vv_parser_semantic_axes_state(act_res, ref_res)
     check_axes_parse_res(act_res, ref_res)

--- a/third_party/ascend/unittest/autotune_ut/test_reduction_axes_parse.py
+++ b/third_party/ascend/unittest/autotune_ut/test_reduction_axes_parse.py
@@ -25,6 +25,14 @@ import triton
 import triton.language as tl
 
 
+def assert_outward_semantic_axes_state(act_res, ref_res):
+    assert act_res["keys"] == ref_res["keys"]
+    assert act_res["split_params"] == ref_res["split_params"]
+    assert act_res["tiling_params"] == ref_res["tiling_params"]
+    assert act_res["low_dim_axes"] == ref_res["low_dim_axes"]
+    assert act_res["reduction_axes"] == ref_res["reduction_axes"]
+
+
 def test_triton_max_last_dim_case1(mock_autotuner):
     import triton.backends.ascend.runtime
 
@@ -70,6 +78,7 @@ def test_triton_max_last_dim_case1(mock_autotuner):
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_max_last_dim1[grid]()
 
+    assert_outward_semantic_axes_state(act_res, ref_res)
     check_axes_parse_res(act_res, ref_res)
 
 
@@ -118,6 +127,7 @@ def test_triton_max_last_dim_case2(mock_autotuner):
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_max_last_dim2[grid]()
 
+    assert_outward_semantic_axes_state(act_res, ref_res)
     check_axes_parse_res(act_res, ref_res)
 
 
@@ -166,6 +176,7 @@ def test_triton_max_last_dim_case3(mock_autotuner):
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_max_last_dim3[grid]()
 
+    assert_outward_semantic_axes_state(act_res, ref_res)
     check_axes_parse_res(act_res, ref_res)
 
 
@@ -214,4 +225,5 @@ def test_reduction_axes_parse_kernel_type_vector_auto_consistency(mock_autotuner
     }
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_reduction_axes_parse_kernel_type_vector_auto_consistency[grid]()
+    assert_outward_semantic_axes_state(act_res, ref_res)
     check_axes_parse_res(act_res, ref_res)

--- a/third_party/ascend/unittest/autotune_ut/test_reduction_axes_parse.py
+++ b/third_party/ascend/unittest/autotune_ut/test_reduction_axes_parse.py
@@ -61,11 +61,11 @@ def test_triton_max_last_dim_case1(mock_autotuner):
             tl.store(out_ptr0 + x0, block_res, x0_mask)
 
     ref_res = {
-        "keys": {"x": "x0_numel", "ry": "r1_numel"},
+        "keys": {"x": "x0_numel", "y": "r1_numel"},
         "split_params": {"x": "X0BLOCK"},
-        "tiling_params": {"x": "X0BLOCK_SUB", "ry": "R1BLOCK_SUB"},
-        "low_dim_axes": ["ry"],
-        "reduction_axes": ["ry"],
+        "tiling_params": {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"},
+        "low_dim_axes": ["y"],
+        "reduction_axes": ["y"],
     }
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_max_last_dim1[grid]()
@@ -109,11 +109,11 @@ def test_triton_max_last_dim_case2(mock_autotuner):
             tl.store(out_ptr0 + x0, block_res, x0_mask)
 
     ref_res = {
-        "keys": {"x": "x0_numel", "ry": "r1_numel"},
+        "keys": {"x": "x0_numel", "y": "r1_numel"},
         "split_params": {"x": "X0BLOCK"},
-        "tiling_params": {"x": "X0BLOCK_SUB", "ry": "R1BLOCK_SUB"},
-        "low_dim_axes": ["ry"],
-        "reduction_axes": ["ry"],
+        "tiling_params": {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"},
+        "low_dim_axes": ["y"],
+        "reduction_axes": ["y"],
     }
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_max_last_dim2[grid]()
@@ -157,11 +157,11 @@ def test_triton_max_last_dim_case3(mock_autotuner):
             tl.store(out_ptr0 + x0, block_res, x0_mask)
 
     ref_res = {
-        "keys": {"x": "x0_numel", "ry": "r1_numel"},
+        "keys": {"x": "x0_numel", "y": "r1_numel"},
         "split_params": {"x": "X0BLOCK"},
-        "tiling_params": {"x": "X0BLOCK_SUB", "ry": "R1BLOCK_SUB"},
-        "low_dim_axes": ["ry"],
-        "reduction_axes": ["ry"],
+        "tiling_params": {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"},
+        "low_dim_axes": ["y"],
+        "reduction_axes": ["y"],
     }
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_max_last_dim3[grid]()
@@ -206,11 +206,11 @@ def test_reduction_axes_parse_kernel_type_vector_auto_consistency(mock_autotuner
             tl.store(out_ptr0 + x0, block_res, x0_mask)
 
     ref_res = {
-        "keys": {"x": "x0_numel", "ry": "r1_numel"},
+        "keys": {"x": "x0_numel", "y": "r1_numel"},
         "split_params": {"x": "X0BLOCK"},
-        "tiling_params": {"x": "X0BLOCK_SUB", "ry": "R1BLOCK_SUB"},
-        "low_dim_axes": ["ry"],
-        "reduction_axes": ["ry"],
+        "tiling_params": {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"},
+        "low_dim_axes": ["y"],
+        "reduction_axes": ["y"],
     }
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_reduction_axes_parse_kernel_type_vector_auto_consistency[grid]()


### PR DESCRIPTION
Supersedes #78 because the branch was recreated as a clean single-commit reroll.

# Fix low-dim parsing failure caused by duplicated reduction-axis prefixes in the Ascend autotuner

## Background

`Q2TritonKernel/tests/mamba/test_angle_dt_kernel.py` failed during the Ascend autotune flow for `angle_dt_bwd_kernel[grid](...)` with the following error:

```text
KeyError: "low dim axis 'rry' not found in known axes: dict_keys(['rx', 'ry'])"
```

The failure happened during autotune axis parsing and tiling-config generation for the backward kernel, rather than during numerical computation.

## Root Cause

The co-debug logs and a local backward-only reproduction showed that the issue came from inconsistent reduction-axis normalization in `autotuner.py`:

- `_get_parser_axis_arg_names()` can already produce reduction-axis names with an `r` prefix, such as `rx` and `ry`
- `_autoparse_reduction_axes()` still unconditionally applies `f"r{axis}"` to the parser output
- As a result, reduction axes that already have the prefix are prefixed again, producing `rrx` / `rry`
- `_autoparse_low_dim_axes()` then continues parsing on the polluted key space, which further pollutes low-dim axes into values such as `rry`
- Finally, `KernelMeta._validate_axis()` receives `low_dim_axes=['rry']` while the known axes are only `rx` / `ry`, which triggers the exception

`tile_generator.py` is not the source of the bug. It only correctly rejects the invalid input propagated from upstream.

## Solution

This fix adopts a unified reduction-axis canonicalization helper in `autotuner.py` and consolidates the reduction-axis naming rules there:

- Add a shared helper to canonicalize reduction-axis names
- Canonicalize only when the name can be reduced to a valid base axis `x/y/z/w/v/t`, instead of using a broad `lstrip("r")`
- Use the following canonicalization rules consistently:
  - `x -> rx`
  - `rx -> rx`
  - `rrx -> rx`
  - `y -> ry`
  - `ry -> ry`
  - `rry -> ry`
- Reuse the same canonicalization logic in both the `vv` path and the legacy parser path

At the same time, `_autoparse_reduction_axes()` is reordered to:

1. Iterate over the raw parser output
2. Extract the base axis
3. Call `_promote_axis_arg_name_to_reduction()` first to complete state migration
4. Generate canonical reduction axes through the shared helper
5. Write the canonical result back to `self.reduction_axes`

This avoids the problem where normalizing first and promoting later could skip state migration for `axis_arg_names` / `vector_axes`.

## Why Not Change `tile_generator.py`

This fix does not add compatibility for `rrx` / `rry` in `tile_generator.py` for the following reasons:

- The downstream exception is a correct safeguard against invalid input
- The real bug is upstream in `autotuner`, where the invalid values are generated
- Relaxing validation downstream would hide the underlying reduction-axis / low-dim naming pollution issue

Therefore, this fix stops the invalid input from being generated in `autotuner.py`, without expanding the scope into a parser protocol redesign or adding fallback behavior in `tile_generator.py`.

## Main Changes

- `third_party/ascend/backend/runtime/autotuner.py`
  - Add a reduction-axis canonicalization helper
  - Reuse the shared helper in the `vv` path
  - Update `_autoparse_reduction_axes()` to promote first and normalize second
- `third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py`
  - Add minimal coverage for reduction-axis canonicalization
  - Cover the case where parser output already includes the `r` prefix and must not produce `rrx` / `rry`