### PR TITLE
[release/3.2.2][Autotune] Support unsigned dtype byte sizes

### DIFF
--- a/third_party/ascend/backend/runtime/utils.py
+++ b/third_party/ascend/backend/runtime/utils.py
@@ -78,6 +78,9 @@ byte_per_numel = {
     torch.int16: 2,  # torch.int16 or torch.short
     torch.int8: 1,  # torch.int8
     torch.uint8: 1,  # torch.uint8
+    torch.uint16: 2,  # torch.uint16
+    torch.uint32: 4,  # torch.uint32
+    torch.uint64: 8,  # torch.uint64
     torch.bool: 1,  # torch.bool
     torch.complex32: 4,  # torch.complex32 (not yet available in PyTorch as of the latest stable release)
     torch.complex64: 8,  # torch.complex64

--- a/third_party/ascend/unittest/pytest_ut/test_runtime_utils.py
+++ b/third_party/ascend/unittest/pytest_ut/test_runtime_utils.py
@@ -20,6 +20,8 @@
 import logging
 import os
 from triton.backends.ascend import utils
+from triton.backends.ascend.runtime import utils as runtime_utils
+import torch
 
 
 def test_get_logger():
@@ -31,3 +33,9 @@ def test_get_ascend_arch_from_env():
     os.environ["TRITON_ASCEND_ARCH"] = "Ascend910_9599"
     result = utils.get_ascend_arch_from_env()
     assert result == "Ascend910_9599"
+
+
+def test_get_byte_per_numel_supports_unsigned_integer_dtypes():
+    assert runtime_utils.get_byte_per_numel(torch.uint16) == 2
+    assert runtime_utils.get_byte_per_numel(torch.uint32) == 4
+    assert runtime_utils.get_byte_per_numel(torch.uint64) == 8


### PR DESCRIPTION
Supersedes #79 because the branch was recreated as a clean single-commit reroll.

Backport of GitCode MR !1869 from Ascend/triton-ascend to elease/3.2.2.

Source: https://gitcode.com/Ascend/triton-ascend/pull/1869

This PR backports the unsigned dtype byte-size runtime fix only. The source MR is stacked on top of the duplicate reduction-axis fix from !1866, which is proposed separately here to keep the backports reviewable and independent.