### PR TITLE
fix(ssbuffer): Prevent coloring of SCF dialect in operator classifier

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -681,7 +681,7 @@ int OpClassifierPass::propagateVectorUpstream()
 
             // Skip operations that should not be marked VECTOR:
             // - matmul: never mark matmul as vector (CUBE-only operation)
-            if (isa<linalg::MatmulOp>(def)) {
+            if (isa<linalg::MatmulOp>(def) || isa<scf::SCFDialect>(def->getDialect())) {
                 LLVM_DEBUG(DBGS() << "skip " << def->getName().getStringRef() << ": should not be marked VECTOR\n");
                 continue;
             }


### PR DESCRIPTION
This PR fixes an issue where the operator classifier was incorrectly applying color/tags to the scf (Structured Control Flow) dialect. The classification logic has been updated to bypass scf operations, ensuring they remain uncolored as intended.
for example:
    %0 = arith.add
    %1 = scf.if %0 (cube)
affter ssbuffer op classifier:
    %0 = arith.add (vector)
    %1 = scf.if %0 (cube)

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
