### PR TITLE
fix: Use SIMD instead of SIMT for continuous low-dimension offset load/store when total size >= 64

### DIFF
--- a/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
@@ -495,8 +495,9 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
   }
 
   // Force scalarize if memory is not aligned
-  if (sizeInByte % 32 != 0)
+  if (sizeInByte % 32 != 0) {
     ptrOffsetInfo.setUnstructured(ptrOffsetInfo.getRank());
+  }
 
   LLVM_DEBUG({
     auto &os = llvm::dbgs();
@@ -509,7 +510,7 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
   // SIMT Indirect Fast-Path Lowering in 950 seiries
   bool indirectFastPathEnabled =
       compileOn91095Flag && forceSimtTemplateFlag &&
-      (ptrOffsetInfo.isUnstructuredOrScalarlike() || routeDiscreteMaskToSimt);
+      ((!ptrOffsetInfo.isStructured() && sizeInByte < 64) || routeDiscreteMaskToSimt);
   bool rankWithinIndirectLoadStoreFastPathLimit = resultShape.size() <= 5;
   if (indirectFastPathEnabled &&
       succeeded(tryRewriteIndirectFastPath(op, loc, srcPtr, ptrOffset,
@@ -518,6 +519,11 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
   }
 
   LLVM_DEBUG({
+    if (sizeInByte >= 64) {
+      auto &os = llvm::dbgs();
+      os << "Skip SIMT indirect fast path because continuous shape product is "
+        << sizeInByte << " (>=64)\n";
+    }
     if constexpr (std::is_same_v<MemAccOpTy, triton::LoadOp> ||
                   std::is_same_v<MemAccOpTy, triton::StoreOp>) {
       if (indirectFastPathEnabled &&


### PR DESCRIPTION
Use SIMD instead of SIMT for continuous low-dimension offset load/store when total size >= 64

### Function Test
TestCase：test/ligerkernel_operator_cases/Liger_Ascend/test/transformers/test_embedding.py

Version：
pip show triton-ascend
Name: triton-ascend
Version: 3.2.2+git12646684
Summary: A language and compiler for custom Deep Learning operations
Home-page: https://gitcode.com/Ascend/triton-ascend/
Author: Philippe Tillet
Author-email: phil@openai.com
License: 
Location: /usr/local/python3.11.0/lib/python3.11/site-packages
Requires: attrs, decorator, numpy, pandas, psutil, pybind11, pytest, pytest-xdist, pyyaml, scipy, triton

Test Result：
<img width="1084" height="144" alt="image" src="https://github.com/user-attachments/assets/8170ba75-737c-4878-a84d-c5497eb6bc24" />


### Performance Test
TestCase：gitcode.com/TritonAscendTest/mojo_opset.git tests/specific_shape_perf_acc/test_store_lowrank.py::test_store_lowrank

mixed means 'shape size < 64 use SIMT, shape size >= 64 use SIMD'

序号 | 数据类型 | key_lr shape | label_cache shape | Token 数 | SIMD 性能 (μs) | SIMT 性能 (μs) | SIMT/SIMD 加速比 | mixed 性能 (μs) | mixed/SIMD 加速比
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | fp16 | (24, 1, 128) | (256, 1, 512, 128) | 24 | 2.5174 | 2.541 | 1.009374752 | 2.2672 | 0.900611742
2 | fp16 | (2048, 1, 128) | (256, 1, 512, 128) | 2048 | 5.2528 | 5.3242 | 1.013592751 | 5.5402 | 1.054713677
3 | fp16 | (13312, 1, 128) | (256, 1, 512, 128) | 13312 | 23.28 | 24.202 | 1.039604811 | 23.0740 | 0.991151203
4 | fp16 | (24, 8, 128) | (256, 8, 512, 128) | 24 | 2.6116 | 18.684 | 7.154234952 | 2.4940 | 0.954970133
5 | fp16 | (2048, 8, 128) | (256, 8, 512, 128) | 2048 | 7.2088 | 54.5208 | 7.563089557 | 7.5686 | 1.049911220
6 | fp16 | (13312, 8, 128) | (256, 8, 512, 128) | 13312 | 30.8784 | 269.5633 | 8.7298338 | 31.1862 | 1.010000518
7 | bf16 | (24, 1, 128) | (256, 1, 512, 128) | 24 | 2.4494 | 2.4576 | 1.003347759 | 2.1464 | 0.876296154
8 | bf16 | (2048, 1, 128) | (256, 1, 512, 128) | 2048 | 5.2238 | 5.3314 | 1.020598032 | 5.5036 | 1.053562541
9 | bf16 | (13312, 1, 128) | (256, 1, 512, 128) | 13312 | 23.183 | 23.82 | 1.027477031 | 23.2176 | 1.001492473
10 | bf16 | (24, 8, 128) | (256, 8, 512, 128) | 24 | 2.6356 | 18.73 | 7.106541205 | 2.7350 | 1.037714372
11 | bf16 | (2048, 8, 128) | (256, 8, 512, 128) | 2048 | 7.1354 | 54.6182 | 7.654539339 | 7.5562 | 1.058973568
12 | bf16 | (13312, 8, 128) | (256, 8, 512, 128) | 13312 | 30.9816 | 281.4824 | 9.085470085 | 30.9782 | 0.999896713
13 | fp32 | (24, 1, 128) | (256, 1, 512, 128) | 24 | 2.484 | 2.505 | 1.008454106 | 2.3400 | 0.942029002
14 | fp32 | (2048, 1, 128) | (256, 1, 512, 128) | 2048 | 5.3468 | 5.0976 | 0.953392683 | 5.6734 | 1.061083264
15 | fp32 | (13312, 1, 128) | (256, 1, 512, 128) | 13312 | 23.6544 | 23.3538 | 0.987292005 | 23.4534 | 0.991494174
16 | fp32 | (24, 8, 128) | (256, 8, 512, 128) | 24 | 2.9006 | 20.087 | 6.925118941 | 2.9014 | 1.000275805
17 | fp32 | (2048, 8, 128) | (256, 8, 512, 128) | 2048 | 8.4614 | 55.6688 | 6.579147659 | 8.8644 | 1.047628052
18 | fp32 | (13312, 8, 128) | (256, 8, 512, 128) | 13312 | 45.763 | 275.5764 | 6.021816752 | 48.4964 | 1.059729476


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
