### PR TITLE
feat(ssbuffer): fix iterarg dependencies in SplitDataflow

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -63,6 +63,7 @@ inline constexpr CoreType fromStrCoreType(std::string_view s)
 CoreType getOpCoreType(Operation *op);
 std::optional<int64_t> getOpBlockId(Operation *op);
 llvm::LogicalResult verifyOpBlockId(Operation *op);
+int getAvailableBlockId(ModuleOp module);
 void setFallbackAttr(ModuleOp module);
 
 inline bool isCubeOp(Operation *op)

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
@@ -132,7 +132,16 @@ private:
                                                 int producerBlockId,
                                                 int consumerBlockId);
 
-  bool isControlFlowOp(mlir::Operation *op);
+    bool isControlFlowOp(mlir::Operation *op);
+    bool isValidTensorForDependency(mlir::Value value);
+    bool isOuterOpArg(mlir::Value value);
+    void processIterArgDependencies();
+    llvm::SmallVector<mlir::Operation *> collectDiffCoreTypeUsers(
+        mlir::BlockArgument iterArg, llvm::StringRef initCoreType);
+    void insertProducerAndRecordDeps(scf::ForOp forOp, mlir::BlockArgument iterArg,
+                                     llvm::StringRef initCoreType,
+                                     llvm::SmallVector<mlir::Operation *> &diffUsers,
+                                     DataDependencyInfo &info);
 
   mlir::ModuleOp module;
 };
@@ -140,9 +149,6 @@ private:
 std::unique_ptr<OperationPass<ModuleOp>> createDataDependencyAnalysisPass();
 
 void registerDataDependencyAnalysisPasses();
-
-// Helper: Get BlockId
-int getSsbufferBlockId(Operation* op);
 
 } // namespace triton
 } // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -57,6 +57,21 @@ std::optional<int64_t> getOpBlockId(Operation *op)
     return blockIdAttr.getInt();
 }
 
+int getAvailableBlockId(ModuleOp module)
+{
+    int maxBlockId = -1;
+    module.walk([&](Operation *op) {
+        auto blockIdOpt = getOpBlockId(op);
+        if (blockIdOpt) {
+            int currentId = static_cast<int>(*blockIdOpt);
+            if (currentId > maxBlockId) {
+                maxBlockId = currentId;
+            }
+        }
+    });
+    return maxBlockId + 1;
+}
+
 void setFallbackAttr(ModuleOp module)
 {
     OpBuilder builder(module.getContext());

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/AddBlockIdForControlOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/AddBlockIdForControlOps.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/AddBlockIdForControlOps.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "llvm/Support/Debug.h"
 
 using namespace mlir;
@@ -38,15 +39,7 @@ void AddBlockIdForControlOpsPass::runOnOperation()
   ModuleOp module = getOperation();
 
   // Step 1: find the max block_id
-  int maxBlockId = -1;
-  module.walk([&](Operation *op) {
-    if (auto attr = op->getAttrOfType<IntegerAttr>("ssbuffer.block_id")) {
-      int currentId = attr.getInt();
-      if (currentId > maxBlockId) {
-        maxBlockId = currentId;
-      }
-    }
-  });
+  int maxBlockId = CVPipeline::getAvailableBlockId(module) - 1;
 
   LOG_DEBUG("maxBlockId: " << maxBlockId << "\n");
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -21,9 +21,11 @@
  */
 
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/Common/MemoryEffectsTracker.h"
 
 #include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -50,6 +52,8 @@ using namespace mlir::CVPipeline;
 static constexpr const char *kBlockIdAttr = "ssbuffer.block_id";
 static constexpr const char *kCoreTypeAttr = "ssbuffer.core_type";
 static constexpr const char *kTransferIdAttr = "ssbuffer.transfer_id";
+static constexpr const char *ssbufferCoreTypeCubeAttr = "CUBE";
+static constexpr const char *ssbufferCoreTypeVectorAttr = "VECTOR";
 
 // Helper: ssbuffer.core_type
 llvm::StringRef getSsbufferCoreType(Operation *op)
@@ -85,6 +89,33 @@ bool DataDependencyAnalysisPass::isControlFlowOp(mlir::Operation *op)
     return isa<scf::ForOp>(op) || isa<scf::IfOp>(op) || isa<scf::WhileOp>(op) || isa<scf::YieldOp>(op);
 }
 
+// Helper: Check if value is a valid tensor for dependency analysis
+// Returns true if value is TensorType and not defined by EmptyOp/FillOp
+bool DataDependencyAnalysisPass::isValidTensorForDependency(mlir::Value value)
+{
+    if (!dyn_cast<mlir::TensorType>(value.getType())) {
+        return false;
+    }
+    Operation *defOp = value.getDefiningOp();
+
+    // EmptyOp/FillOp can be processed both by CUBE and VECTOR
+    // so they should not be data dependency
+    if (defOp && isa<tensor::EmptyOp, linalg::FillOp>(defOp)) {
+        return false;
+    }
+    return true;
+}
+
+// Helper: Check if value is a BlockArgument
+bool DataDependencyAnalysisPass::isOuterOpArg(mlir::Value value)
+{
+    if (auto blockArg = mlir::dyn_cast<mlir::BlockArgument>(value)) {
+        mlir::Block *ownerBlock = blockArg.getOwner();
+        return true;
+    }
+    return false;
+}
+
 // Helper: Build and record BlockInfo
 void DataDependencyAnalysisPass::collectBlockInfo(DataDependencyInfo &info, int blockId,
     llvm::SmallVector<mlir::Operation *> &ops)
@@ -101,7 +132,7 @@ void DataDependencyAnalysisPass::collectBlockInfo(DataDependencyInfo &info, int 
     // In cases with one or more core_types
     // as long as there is a cube, it is necessary to check the dataflow.
     StringRef coreType = getSsbufferCoreType(ops[0]);
-    if (coreType.contains("CUBE")) {
+    if (coreType.contains(ssbufferCoreTypeCubeAttr)) {
         blockInfo.isCube = true;
     }
 
@@ -149,8 +180,9 @@ void DataDependencyAnalysisPass::createBlockInfoMap(DataDependencyInfo &info)
     llvm::SmallVector<mlir::Operation *> currentOps;
 
     module.walk([&](mlir::Operation *op) {
-        int opBlockId = getSsbufferBlockId(op);
-        if (opBlockId != -1) {
+        auto opBlockIdOpt = CVPipeline::getOpBlockId(op);
+        if (opBlockIdOpt) {
+            int opBlockId = static_cast<int>(*opBlockIdOpt);
             // When the id changes, the block ends && Exclude the initial state
             if (opBlockId != currentId && currentId != startCurrId) {
                 collectBlockInfo(info, currentId, currentOps);
@@ -184,6 +216,137 @@ void DataDependencyAnalysisPass::collectDepInfo(mlir::Value depvalue, Dependency
     dependencies.push_back(depInfo);
 }
 
+
+// Collects users of iterArg that have a different core type than initCoreType.
+llvm::SmallVector<mlir::Operation *> DataDependencyAnalysisPass::collectDiffCoreTypeUsers(
+    mlir::BlockArgument iterArg, llvm::StringRef initCoreType)
+{
+    llvm::SmallVector<mlir::Operation *> diffUsers;
+
+    for (mlir::Operation *user : iterArg.getUsers()) {
+        if (isa<scf::YieldOp>(user)) {
+            continue;
+        }
+        assert(!isControlFlowOp(user) && "warning: cannot process nested iterarg!");
+
+        auto userCoreType = getCoreTypeWithIndex(user, 0);
+        if (userCoreType != initCoreType && !userCoreType.empty()) {
+            diffUsers.push_back(user);
+        }
+    }
+
+    return diffUsers;
+}
+
+// Inserts a producer block at the beginning of the for loop body and records
+// cross-core-type dependencies for each user in diffUsers.
+void DataDependencyAnalysisPass::insertProducerAndRecordDeps(scf::ForOp forOp,
+    mlir::BlockArgument iterArg, llvm::StringRef initCoreType,
+    llvm::SmallVector<mlir::Operation *> &diffUsers, DataDependencyInfo &info)
+{
+    auto &v2cDependencies = info.getV2CDependencies();
+    auto &c2vDependencies = info.getC2VDependencies();
+
+    int newId = CVPipeline::getAvailableBlockId(module);
+    OpBuilder builder(forOp);
+    Block &bodyBlock = forOp.getRegion().front();
+    builder.setInsertionPointToStart(&bodyBlock);
+    Location loc = forOp.getLoc();
+    auto constOp = builder.create<arith::ConstantIntOp>(loc, 0, 32);
+    constOp->setAttr(kBlockIdAttr, IntegerAttr::get(IntegerType::get(builder.getContext(), 32), newId));
+    constOp->setAttr(kCoreTypeAttr, StringAttr::get(builder.getContext(), initCoreType));
+
+    for (auto &user : diffUsers) {
+        auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
+        if (!userBlockIdOpt) {
+            LOG_DEBUG("Warning: User block ID not found for iterArg user.\n");
+            continue;
+        }
+        int userBlockId = static_cast<int>(*userBlockIdOpt);
+
+        // Determine dependency type based on initCoreType
+        DependencyType depType;
+        if (initCoreType == ssbufferCoreTypeVectorAttr) {
+            depType = DependencyType::VectorToCube;
+        } else if (initCoreType == ssbufferCoreTypeCubeAttr) {
+            depType = DependencyType::CubeToVector;
+        } else {
+            LOG_DEBUG("Warning: Unknown initCoreType: " << initCoreType << "\n");
+            continue;
+        }
+
+        // Record dependency
+        DependencyInfo depInfo;
+        depInfo.type = depType;
+        depInfo.value = iterArg;
+        depInfo.iniProducerBlockId = newId;
+        depInfo.iniConsumerBlockId = userBlockId;
+        depInfo.producerBlockId = newId;
+        depInfo.consumerBlockId = userBlockId;
+
+        if (depType == DependencyType::VectorToCube) {
+            v2cDependencies.push_back(depInfo);
+        } else {
+            c2vDependencies.push_back(depInfo);
+        }
+
+        LOG_DEBUG("Recorded iterArg dependency: " << initCoreType << " -> "
+            << (depType == DependencyType::VectorToCube ? ssbufferCoreTypeCubeAttr : ssbufferCoreTypeVectorAttr)
+            << ", producerBlockId=" << newId << ", consumerBlockId=" << userBlockId << "\n");
+    }
+}
+
+// Process iterArg dependencies for all scf.for operations in the module.
+// This function iterates through all for loops and checks each iterArg to determine
+// if there are cross-core-type data dependencies.
+void DataDependencyAnalysisPass::processIterArgDependencies()
+{
+    auto &info = getAnalysis<DataDependencyInfo>();
+
+    // Step1: Collect all scf.for operations in the module
+    llvm::SmallVector<scf::ForOp> forOps;
+    module.walk([&](scf::ForOp forOp) {
+        forOps.push_back(forOp);
+    });
+    LOG_DEBUG("Processing iterArg dependencies, found " << forOps.size() << " scf.for ops\n");
+
+    // Step2: Process each iterArg of each scf.for operation
+    for (scf::ForOp forOp : forOps) {
+        size_t numIterArgs = forOp.getInitArgs().size();
+
+        for (int iterArgIndex = 0; iterArgIndex < numIterArgs; ++iterArgIndex) {
+            mlir::Value initValue = forOp.getInits()[iterArgIndex];
+            // Skip non-tensor values as they don't require inter-core synchronization
+            if (!isValidTensorForDependency(initValue)) {
+                LOG_DEBUG("iterarg: "<< initValue <<"is not valid tensor for dependency!");
+                continue;
+            }
+
+            mlir::BlockArgument iterArg = forOp.getRegionIterArg(iterArgIndex);
+            mlir::Value yieldedValue = forOp.getYieldedValues()[iterArgIndex];
+
+            Operation *initDefOp = initValue.getDefiningOp();
+            if (!initDefOp) {
+                LOG_DEBUG("warning: nested iterarg!");
+                continue;
+            }
+
+            auto initDefResult = dyn_cast<mlir::OpResult>(initValue);
+            auto initCoreType = getCoreTypeWithIndex(initDefOp, initDefResult ? initDefResult.getResultNumber() : 0);
+            auto yieldCoreType = getCoreTypeWithIndex(forOp, iterArgIndex);
+            
+            // Only process if init and yield have matching core types
+            // Mismatch indicates a more complex dependency pattern that requires special handling
+            assert(initCoreType == yieldCoreType && "iterarg init core_type conflicts with yield");
+
+            auto diffUsers = collectDiffCoreTypeUsers(iterArg, initCoreType);
+            if (!diffUsers.empty()) {
+                insertProducerAndRecordDeps(forOp, iterArg, initCoreType, diffUsers, info);
+            }
+        }
+    }
+}
+
 // Analyze V->C
 void DataDependencyAnalysisPass::analyzeExternalInputs(DataDependencyInfo &info)
 {
@@ -196,18 +359,14 @@ void DataDependencyAnalysisPass::analyzeExternalInputs(DataDependencyInfo &info)
             continue;
         LOG_DEBUG("Analyzing external inputs for Cube Block ID: " << id << "\n");
         for (mlir::Value input : blockInfo.inputs) {
-            // Check if input is a func.func blockarg.
-            if (auto arg = mlir::dyn_cast<mlir::BlockArgument>(input)) {
-                LOG_DEBUG("Warning: [v->c] Input value is a function parameter.\n");
-                continue;
-            }
             // Check if input is a value which can be produced by CUBE
-            if (!dyn_cast<mlir::TensorType>(input.getType())) {
-                LOG_DEBUG("Warning: [v->c] Input value is not TensorType\n");
+            if (!isValidTensorForDependency(input)) {
+                LOG_DEBUG("Warning: [v->c] Input value is not a valid tensor for dependency analysis.\n");
                 continue;
             }
-            if (isa<tensor::EmptyOp, linalg::FillOp>(input.getDefiningOp())) {
-                LOG_DEBUG("Warning: [v->c] Input value is defined by tensor::EmptyOp/linalg::FillOp.\n");
+            // Check if input is a blockarg.
+            if (isOuterOpArg(input)) {
+                LOG_DEBUG("Warning: [v->c] Input value is a function/scf parameter.\n");
                 continue;
             }
 
@@ -220,17 +379,18 @@ void DataDependencyAnalysisPass::analyzeExternalInputs(DataDependencyInfo &info)
             }
 
             // Case 1: Cube -> C->C special case
-            if (coreType == "CUBE") {
+            if (coreType == ssbufferCoreTypeCubeAttr) {
                 continue;
             }
             // Case 2: Vector -> V->C dependency
-            if (coreType == "VECTOR") {
+            if (coreType == ssbufferCoreTypeVectorAttr) {
                 LOG_DEBUG("Found external input with VECTOR core type: " << input << "\n");
-                auto producerId = getSsbufferBlockId(input.getDefiningOp());
-                if (producerId == -1) {
+                auto producerIdOpt = CVPipeline::getOpBlockId(input.getDefiningOp());
+                if (!producerIdOpt) {
                     LOG_DEBUG("Warning: [v->c] Producer block ID not found for input value.\n");
                     continue;
                 }
+                int producerId = static_cast<int>(*producerIdOpt);
                 collectDepInfo(input, DependencyType::VectorToCube, v2cDependencies, producerId, blockInfo.blockId,
                     info);
             }
@@ -251,20 +411,16 @@ void DataDependencyAnalysisPass::analyzeExternalOutputs(DataDependencyInfo &info
             continue;
 
         for (mlir::Value output : blockInfo.outputs) {
-            // Check if input is a value which can be produced by VECTOR
-            if (!dyn_cast<mlir::TensorType>(output.getType())) {
-                LOG_DEBUG("Warning: ExternalOutput is not TensorType\n");
-                continue;
-            }
-            if (isa<tensor::EmptyOp, linalg::FillOp>(output.getDefiningOp())) {
-                LOG_DEBUG("Warning: [c->v] output value is defined by tensor::EmptyOp/linalg::FillOp.\n");
+            // Check if output is a value which can be produced by CUBE
+            if (!isValidTensorForDependency(output)) {
+                LOG_DEBUG("Warning: [c->v] Output value is not a valid tensor for dependency analysis.\n");
                 continue;
             }
 
             auto opResult = dyn_cast<OpResult>(output);
             unsigned resultIndex = opResult.getResultNumber();
             StringRef resultCoreType = getCoreTypeWithIndex(output.getDefiningOp(), resultIndex);
-            if (resultCoreType != "CUBE") {
+            if (resultCoreType != ssbufferCoreTypeCubeAttr) {
                 continue;
             }
             // Check who is using this output
@@ -283,13 +439,14 @@ void DataDependencyAnalysisPass::analyzeExternalOutputs(DataDependencyInfo &info
                     LOG_DEBUG("Warning: [c->v] Input value has no core type attribute.\n");
                     continue;
                 }
-                if (userCoreType == "VECTOR") {
+                if (userCoreType == ssbufferCoreTypeVectorAttr) {
                     LOG_DEBUG("Found external output used by VECTOR core type: " << output << "\n");
-                    auto consumerId = getSsbufferBlockId(user);
-                    if (consumerId == -1) {
+                    auto consumerIdOpt = CVPipeline::getOpBlockId(user);
+                    if (!consumerIdOpt) {
                         LOG_DEBUG("Warning: [c->v] Consumer block ID not found for user operation.\n");
                         continue;
                     }
+                    int consumerId = static_cast<int>(*consumerIdOpt);
                     collectDepInfo(output, DependencyType::CubeToVector, c2vDependencies, blockInfo.blockId, consumerId,
                         info);
                 }
@@ -310,18 +467,20 @@ void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info)
     MemoryDependenceGraph memDepGraph(module, aliasAnalysis);
 
     module.walk([&](mlir::Operation *op) {
-        int currBlockId = getSsbufferBlockId(op);
+        auto currBlockIdOpt = CVPipeline::getOpBlockId(op);
         llvm::StringRef currCoreType = getSsbufferCoreType(op);
-        if (currBlockId == -1 || currCoreType.empty()) {
+        if (!currBlockIdOpt || currCoreType.empty()) {
             return;
         }
+        int currBlockId = static_cast<int>(*currBlockIdOpt);
 
         for (mlir::Operation *predOp : memDepGraph.getExecBefore(op)) {
-            int predBlockId = getSsbufferBlockId(predOp);
+            auto predBlockIdOpt = CVPipeline::getOpBlockId(predOp);
             llvm::StringRef predCoreType = getSsbufferCoreType(predOp);
-            if (predBlockId == -1 || predCoreType == currCoreType || predCoreType.empty()) {
+            if (!predBlockIdOpt || predCoreType == currCoreType || predCoreType.empty()) {
                 continue;
             }
+            int predBlockId = static_cast<int>(*predBlockIdOpt);
 
             auto [producerBlockId, consumerBlockId] = findCommonLevelBlockIds(info, predBlockId, currBlockId);
             assert(producerBlockId != -1 && consumerBlockId != -1 &&
@@ -332,9 +491,9 @@ void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info)
 
             DependencyInfo depInfo;
 
-            if (predCoreType == "CUBE") {
+            if (predCoreType == ssbufferCoreTypeCubeAttr) {
                 depInfo.type = DependencyType::CubeToVector;
-            } else if (predCoreType == "VECTOR") {
+            } else if (predCoreType == ssbufferCoreTypeVectorAttr) {
                 depInfo.type = DependencyType::VectorToCube;
             }
             depInfo.producerBlockId = producerBlockId;
@@ -405,12 +564,14 @@ std::pair<int, int> DataDependencyAnalysisPass::findCommonLevelBlockIds(DataDepe
                 break;
             }
             mlir::Operation *pPrevOp = pAncestors[pIndex - 1];
-            int pPrevId = getSsbufferBlockId(pPrevOp);
-            int cPrevId = getSsbufferBlockId(before);
-            if (pPrevId == -1) {
+            auto pPrevIdOpt = CVPipeline::getOpBlockId(pPrevOp);
+            auto cPrevIdOpt = CVPipeline::getOpBlockId(before);
+            int pPrevId = pPrevIdOpt ? static_cast<int>(*pPrevIdOpt) : -1;
+            int cPrevId = cPrevIdOpt ? static_cast<int>(*cPrevIdOpt) : -1;
+            if (!pPrevIdOpt) {
                 LOG_DEBUG("Warning: Producer ancestor operation has no block ID attribute.\n");
             }
-            if (cPrevId == -1) {
+            if (!cPrevIdOpt) {
                 LOG_DEBUG("Warning: Consumer ancestor operation has no block ID attribute.\n");
             }
             return { pPrevId, cPrevId };
@@ -435,11 +596,14 @@ void DataDependencyAnalysisPass::runOnOperation()
     // Step 1: Collect block information (populate blockInfoMap)
     createBlockInfoMap(info);
 
-    // Step 2: Analyze dependencies (populate v2c, c2v lists)
+    // Step 2: Analyze iter_args dependencies
+    processIterArgDependencies();
+
+    // Step 3: Analyze dependencies (populate v2c, c2v lists)
     analyzeExternalInputs(info);
     analyzeExternalOutputs(info);
 
-    // Step 3: Analyze memory dependencies (PIPE_S sync)
+    // Step 4: Analyze memory dependencies (PIPE_S sync)
     analyzeMemoryEffect(info);
 
     info.setValid(true);
@@ -460,13 +624,5 @@ std::unique_ptr<OperationPass<ModuleOp>> createDataDependencyAnalysisPass()
     return std::make_unique<DataDependencyAnalysisPass>();
 }
 
-// Helper: Get BlockId
-int getSsbufferBlockId(Operation *op)
-{
-    if (auto attr = op->getAttrOfType<IntegerAttr>(kBlockIdAttr)) {
-        return attr.getInt();
-    }
-    return -1;
-}
 } // namespace triton
 } // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -26,6 +26,7 @@
 #include <optional>
 
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/Common/FlagIdManager.h"
 
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
@@ -121,7 +122,7 @@ std::pair<mlir::Operation *, mlir::Operation *> InterCoreTransferAndSyncPass::ge
         if (knownOpInBlock) {
             return;
         }
-        if (getSsbufferBlockId(op) == targetId) {
+        if (CVPipeline::getOpBlockId(op).value_or(-1) == targetId) {
             knownOpInBlock = op;
         }
     });
@@ -139,11 +140,11 @@ std::pair<mlir::Operation *, mlir::Operation *> InterCoreTransferAndSyncPass::ge
 
     // Iterate through all operations in the current block
     for (Operation &op : *block) {
-        int blockId = getSsbufferBlockId(&op);
-        if (blockId == -1) {
+        auto blockIdOpt = CVPipeline::getOpBlockId(&op);
+        if (!blockIdOpt) {
             continue;
         }
-
+        int blockId = static_cast<int>(*blockIdOpt);
         if (!start) {
             if (targetId == blockId) {
                 start = &op;
@@ -240,7 +241,7 @@ bool InterCoreTransferAndSyncPass::isShapeExpected(Value value, SmallVector<int6
 
 void InterCoreTransferAndSyncPass::rewriteMatmulWithNewShape(OpBuilder &builder, Operation *matmulOp, Location loc)
 {
-    int matmulOpBlockId = getSsbufferBlockId(matmulOp);
+    int matmulOpBlockId = static_cast<int>(CVPipeline::getOpBlockId(matmulOp).value_or(-1));
 
     Value lhs = matmulOp->getOperands()[0];
     Value rhs = matmulOp->getOperands()[1];
@@ -302,7 +303,7 @@ void InterCoreTransferAndSyncPass::rewriteTransposeWithNewShape(OpBuilder &build
     auto expectedType = RankedTensorType::get(newOutputShape, elemType);
     // Create new empty tensor with new shape
     auto tensorEmptyOp = builder.create<tensor::EmptyOp>(loc, newOutputShape, elemType);
-    attachCommonTags(tensorEmptyOp, getSsbufferBlockId(transposeOp), "CUBE");
+    attachCommonTags(tensorEmptyOp, static_cast<int>(CVPipeline::getOpBlockId(transposeOp).value_or(-1)), "CUBE");
     Value transposeOpResult = transposeOp->getResult(0);
     transposeOp->setOperand(1, tensorEmptyOp.getResult());
     transposeOp->getResult(0).setType(expectedType);
@@ -317,9 +318,13 @@ mlir::Value InterCoreTransferAndSyncPass::normalizeIfNeeded(OpBuilder &builder, 
     int64_t iniM = origTensorType.getDimSize(0);
     int64_t iniN = origTensorType.getDimSize(1);
     Type elemType = origTensorType.getElementType();
-
-    builder.setInsertionPointAfter(origValue.getDefiningOp());
-
+    if (isa<mlir::BlockArgument>(origValue)) {
+        auto [originProdStart, originProdEnd] = getBlockStartEnd(originBlockId, module);
+        builder.setInsertionPointAfter(originProdEnd);
+    } else {
+        builder.setInsertionPointAfter(origValue.getDefiningOp());
+    }
+    
     auto floatElemTy = cast<FloatType>(elemType);
     auto zeroConstOp = builder.create<arith::ConstantFloatOp>(
         loc, APFloat::getZero(floatElemTy.getFloatSemantics()), floatElemTy);
@@ -339,9 +344,9 @@ mlir::Value InterCoreTransferAndSyncPass::normalizeIfNeeded(OpBuilder &builder, 
     LOG_DEBUG("int cId = dep.iniConsumerBlockId;" << cId << "\n");
     for (Operation *user : origValue.getUsers()) {
         LOG_DEBUG(*user << "\n");
-        int userBlockId = getSsbufferBlockId(user);
-        LOG_DEBUG("int userBlockId = getSsbufferBlockId(user);" << userBlockId << "\n");
-        if (userBlockId == -1 || userBlockId != cId) {
+        auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
+        LOG_DEBUG("int userBlockId = getOpBlockId(user);" << (userBlockIdOpt ? *userBlockIdOpt : -1) << "\n");
+        if (!userBlockIdOpt || static_cast<int>(*userBlockIdOpt) != cId) {
             continue;
         }
         user->replaceUsesOfWith(origValue, tensorInsertSliceOp.getResult());
@@ -355,7 +360,7 @@ mlir::Value InterCoreTransferAndSyncPass::normalizeIfNeeded(OpBuilder &builder, 
             LOG_DEBUG("after rewriteTransposeWithNewShape\n");
             for (Operation *transposeuser : transposeOp->getUsers()) {
                 auto matmulOp = dyn_cast<linalg::MatmulOp>(transposeuser);
-                if (matmulOp && getSsbufferBlockId(matmulOp) == cId) {
+                if (matmulOp && CVPipeline::getOpBlockId(matmulOp).value_or(-1) == cId) {
                     rewriteMatmulWithNewShape(builder, matmulOp, loc);
                 }
             }
@@ -376,7 +381,8 @@ void InterCoreTransferAndSyncPass::Nd2NzNormalize(OpBuilder &builder, Dependency
     }
     // Step 1: Compute expected shape
     SmallVector<int64_t> expectedShape = computeExpectedShape(origValue);
-    int originBlockId = getSsbufferBlockId(origValue.getDefiningOp());
+    
+    int originBlockId = dep.iniProducerBlockId;
     // Step 2: If shapes match, return original value
     if (!isShapeExpected(origValue, expectedShape)) {
         newValue = normalizeIfNeeded(builder, dep, loc, origValue, expectedShape, originBlockId);
@@ -400,7 +406,13 @@ void InterCoreTransferAndSyncPass::Nd2NzNormalize(OpBuilder &builder, Dependency
     auto type3D = RankedTensorType::get(shape3D, elemType);
     auto typeTrans = RankedTensorType::get(shapeTrans, elemType);
     auto typeFinal = RankedTensorType::get(shapeFinal, elemType);
-    builder.setInsertionPointAfter(newValue.getDefiningOp());
+    if (newValue.getDefiningOp()) {
+        builder.setInsertionPointAfter(newValue.getDefiningOp());
+    } else {
+        auto [newProdStart, newProdEnd] = getBlockStartEnd(originBlockId, module);
+        builder.setInsertionPointAfter(newProdEnd);
+    }
+    
     auto reshape3Dcst = builder.create<arith::ConstantOp>(loc, builder.getI64TensorAttr(shape3D));
     auto reshape3DOp = builder.create<tensor::ReshapeOp>(loc, type3D, newValue, reshape3Dcst);
 
@@ -472,7 +484,7 @@ std::pair<Operation *, Operation *> InterCoreTransferAndSyncPass::createTransfer
         consAllocOp = builder.create<memref::AllocOp>(loc, allocType);
         auto markConsOp = annotateTightlyCoupledBuffer(builder, consAllocOp, loc);
 
-        int loopBlockId = getSsbufferBlockId(mainLoopOp);
+        int loopBlockId = static_cast<int>(CVPipeline::getOpBlockId(mainLoopOp).value_or(-1));
         attachTransferTags(prodAllocOp, loopBlockId, prodTag, transferIndex);
         attachTransferTags(consAllocOp, loopBlockId, consTag, transferIndex);
         attachTransferTags(markProdOp, loopBlockId, prodTag, transferIndex);
@@ -508,8 +520,8 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(OpBuilder &b
     auto normalizedTensorType = cast<RankedTensorType>(normalizedValue.getType());
     Type elemType = srcTensorType.getElementType();
 
-    int vecBlockId = getSsbufferBlockId(vectorEndOp);
-    int cubeBlockId = getSsbufferBlockId(cubeStartOp);
+    int vecBlockId = static_cast<int>(CVPipeline::getOpBlockId(vectorEndOp).value_or(-1));
+    int cubeBlockId = static_cast<int>(CVPipeline::getOpBlockId(cubeStartOp).value_or(-1));
 
     auto [vecAllocOp, cubeAllocOp] = createTransferAllocs(builder, loc, normalizedTensorType.getShape(), elemType,
         hivm::AddressSpace::L1, vectorEndOp, cubeStartOp, vecBlockId, cubeBlockId, "VECTOR", "CUBE", transferIndex);
@@ -541,8 +553,8 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(OpBuilder &b
     LOG_DEBUG("[toTensorOp]: " << *toTensorOp << "\n");
 
     for (Operation *user : srcValue.getUsers()) {
-        int userBlockId = getSsbufferBlockId(user);
-        if (userBlockId == iniConsumerId) {
+        auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
+        if (userBlockIdOpt && static_cast<int>(*userBlockIdOpt) == iniConsumerId) {
             user->replaceUsesOfWith(srcValue, toTensorOp.getResult());
         }
     }
@@ -558,8 +570,8 @@ Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(OpBuilder &b
     int64_t N = srcTensorType.getDimSize(1);
     Type elemType = srcTensorType.getElementType();
 
-    int cubeBlockId = getSsbufferBlockId(srcValue.getDefiningOp());
-    int vecBlockId = getSsbufferBlockId(vectorStartOp);
+    int cubeBlockId = static_cast<int>(CVPipeline::getOpBlockId(srcValue.getDefiningOp()).value_or(-1));
+    int vecBlockId = static_cast<int>(CVPipeline::getOpBlockId(vectorStartOp).value_or(-1));
 
     auto [cubeAllocOp, vecAllocOp] = createTransferAllocs(builder, loc, { M, N }, elemType, hivm::AddressSpace::UB,
         cubeEndOp, vectorStartOp, cubeBlockId, vecBlockId, "CUBE", "VECTOR", transferIndex);
@@ -586,8 +598,8 @@ Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(OpBuilder &b
     LOG_DEBUG("[toTensorOp]: " << *toTensorOp << "\n");
 
     for (Operation *user : srcValue.getUsers()) {
-        int userBlockId = getSsbufferBlockId(user);
-        if (userBlockId == iniConsumerId) {
+        auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
+        if (userBlockIdOpt && static_cast<int>(*userBlockIdOpt) == iniConsumerId) {
             user->replaceUsesOfWith(srcValue, toTensorOp.getResult());
         }
     }
@@ -609,8 +621,8 @@ void InterCoreTransferAndSyncPass::insertInterCoreSync(
     auto pipeMAttr = PipeAttr::get(builder.getContext(), hivm::PIPE::PIPE_M);
     auto flagId = builder.getIntegerAttr(builder.getI64Type(), flag);
 
-    int producerBlockId = getSsbufferBlockId(transferOp);
-    int consumerBlockId = getSsbufferBlockId(consumerStartOp);
+    int producerBlockId = static_cast<int>(CVPipeline::getOpBlockId(transferOp).value_or(-1));
+    int consumerBlockId = static_cast<int>(CVPipeline::getOpBlockId(consumerStartOp).value_or(-1));
 
     Operation *mainLoopOp = findMainLoopforTransfer(transferOp, consumerStartOp);
 
@@ -635,7 +647,7 @@ void InterCoreTransferAndSyncPass::insertInterCoreSync(
             builder.setInsertionPointAfter(mainLoopOp);
             auto waitOpForEnd = builder.create<SyncBlockWaitOp>(loc, cubeCoreAttr, pipeVAttr, pipeFixAttr, flagId);
 
-            int startEndBlockId = getSsbufferBlockId(mainLoopOp);
+            int startEndBlockId = static_cast<int>(CVPipeline::getOpBlockId(mainLoopOp).value_or(-1));
             attachTransferTags(setOpForStart, startEndBlockId, "VECTOR", transferIndex);
             attachTransferTags(waitOpForEnd, startEndBlockId, "CUBE", transferIndex);
         }
@@ -662,7 +674,7 @@ void InterCoreTransferAndSyncPass::insertInterCoreSync(
             builder.setInsertionPointAfter(mainLoopOp);
             auto waitOpForEnd = builder.create<SyncBlockWaitOp>(loc, vecCoreAttr, pipeMAttr, pipeMte3Attr, flagId);
 
-            int startEndBlockId = getSsbufferBlockId(mainLoopOp);
+            int startEndBlockId = static_cast<int>(CVPipeline::getOpBlockId(mainLoopOp).value_or(-1));
             attachTransferTags(setOpForStart, startEndBlockId, "CUBE", transferIndex);
             attachTransferTags(waitOpForEnd, startEndBlockId, "VECTOR", transferIndex);
         }
@@ -695,15 +707,15 @@ void InterCoreTransferAndSyncPass::insertPipeSSync(OpBuilder &builder, Operation
     builder.setInsertionPoint(consumerOp);
     auto waitOp = builder.create<SyncBlockWaitOp>(loc, dstCoreAttr, srcPipeAttr, dstPipeAttr, flagId);
 
-    int prodBlockId = getSsbufferBlockId(producerOp);
-    int consBlockId = getSsbufferBlockId(consumerOp);
-    if (prodBlockId != -1) {
+    auto prodBlockIdOpt = CVPipeline::getOpBlockId(producerOp);
+    auto consBlockIdOpt = CVPipeline::getOpBlockId(consumerOp);
+    if (prodBlockIdOpt) {
         StringRef prodCoreType = isCubeToVector ? "CUBE" : "VECTOR";
-        attachCommonTags(setOp, prodBlockId, prodCoreType);
+        attachCommonTags(setOp, static_cast<int>(*prodBlockIdOpt), prodCoreType);
     }
-    if (consBlockId != -1) {
+    if (consBlockIdOpt) {
         StringRef consCoreType = isCubeToVector ? "VECTOR" : "CUBE";
-        attachCommonTags(waitOp, consBlockId, consCoreType);
+        attachCommonTags(waitOp, static_cast<int>(*consBlockIdOpt), consCoreType);
     }
 
     LOG_DEBUG("[PIPE_S setOp]: " << *setOp << "\n");

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_iterarg_dependencies.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_iterarg_dependencies.mlir
@@ -1,0 +1,79 @@
+// RUN: triton-opt --add-block-id-for-control-ops --data-dependency-analysis --inter-core-transfer-and-sync --mark-main-loop %s | FileCheck %s
+
+module {
+    func.func @iterarg_dependencies(%arg4: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}){
+    %c1_i32 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 1 : i32
+    %c128_i32 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 128 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 0 : i32
+    %cst_0 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 0.000000e+00 : f32
+    %2 = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x32xf32>
+    %3 = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_0 : f32) outs(%2 : tensor<64x32xf32>) -> tensor<64x32xf32>
+    %4 = math.exp %3 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x32xf32>
+    %0 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %1 = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_0 : f32) outs(%0 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %91 = scf.for %arg20 = %c0_i32 to %c128_i32 step %c1_i32 iter_args(%arg21 = %4) -> (tensor<64x32xf32>)  : i32 {
+        %alloc_23 = memref.alloc() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<32x64xf32>
+        %179 = bufferization.to_tensor %alloc_23 restrict writable {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<32x64xf32>
+        %182 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} ins(%179, %arg21 : tensor<32x64xf32>, tensor<64x32xf32>) outs(%1 : tensor<32x32xf32>) -> tensor<32x32xf32>
+
+        %201 = math.exp %182 {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+        %cst_100 = arith.constant {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} 0.000000e+00 : f16
+        %300 = tensor.empty() {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x32xf32>
+        %400 = linalg.fill {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_100 : f16) outs(%300 : tensor<64x32xf32>) -> tensor<64x32xf32>
+        %inserted_slice = tensor.insert_slice %201 into %400[0, 0] [32, 32] [1, 1] {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32> into tensor<64x32xf32>
+
+        scf.yield {ssbuffer.core_type = "VECTOR"} %inserted_slice : tensor<64x32xf32>
+    } {ssbuffer.core_type = "VECTOR"}
+    return
+}}
+
+
+// CHECK-LABEL: func.func @iterarg_dependencies
+
+// CHECK: %[[EXP_2:[a-z0-9_]+]] = math.exp
+// CHECK: %[[FILL_4:[a-z0-9_]+]] = linalg.fill
+// CHECK: %[[ALLOC:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<4x4x16x8xf32, #hivm.address_space<cbuf>>
+// CHECK: annotation.mark %[[ALLOC]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<4x4x16x8xf32, #hivm.address_space<cbuf>>
+// CHECK: %[[ALLOC_0:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<4x4x16x8xf32, #hivm.address_space<cbuf>>
+// CHECK: annotation.mark %[[ALLOC_0]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<4x4x16x8xf32, #hivm.address_space<cbuf>>
+// CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+// CHECK: %[[ALLOC_1:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32} : memref<32x32xf32, #hivm.address_space<ub>>
+// CHECK: annotation.mark %[[ALLOC_1]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32} : memref<32x32xf32, #hivm.address_space<ub>>
+// CHECK: %[[ALLOC_2:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<32x32xf32, #hivm.address_space<ub>>
+// CHECK: annotation.mark %[[ALLOC_2]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<32x32xf32, #hivm.address_space<ub>>
+// CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 2
+
+// CHECK: scf.for {{.*}} iter_args(%[[ARG_2:[a-z0-9_]+]] = %[[EXP_2]])
+// CHECK: arith.constant {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR"} 0 : i32
+// CHECK: %[[CST_4:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR"} dense<[64, 4, 8]> : tensor<3xi64>
+// CHECK: %[[RESHAPE:[a-z0-9_]+]] = tensor.reshape %[[ARG_2]](%[[CST_4]]) {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x32xf32>, tensor<3xi64>) -> tensor<64x4x8xf32>
+// CHECK: %[[EMPTY_6:[a-z0-9_]+]] = tensor.empty() {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x64x8xf32>
+// CHECK: %[[TRANSPOSED:[a-z0-9_]+]] = linalg.transpose ins(%[[RESHAPE]] : tensor<64x4x8xf32>) outs(%[[EMPTY_6]] : tensor<4x64x8xf32>) permutation = [1, 0, 2]  {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR"}
+// CHECK: %[[CST_5:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR"} dense<[4, 4, 16, 8]> : tensor<4xi64>
+// CHECK: %[[RESHAPE_6:[a-z0-9_]+]] = tensor.reshape %[[TRANSPOSED]](%[[CST_5]]) {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<4x64x8xf32>, tensor<4xi64>) -> tensor<4x4x16x8xf32>
+// CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+// CHECK: hivm.hir.copy ins(%[[RESHAPE_6]] : tensor<4x4x16x8xf32>) outs(%[[ALLOC]] : memref<4x4x16x8xf32, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32}
+// CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
+// CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
+// CHECK: %[[MEM_7:[a-z0-9_]+]] = hivm.hir.convert_layout %[[ALLOC_0]] output_shape [64, 32] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : (memref<4x4x16x8xf32, #hivm.address_space<cbuf>>) -> memref<64x32xf32, #hivm.address_space<cbuf>>
+// CHECK: %[[MEMSPACECAST:[a-z0-9_]+]] = memref.memory_space_cast %[[MEM_7]] {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<64x32xf32, #hivm.address_space<cbuf>> to memref<64x32xf32>
+// CHECK: %[[TENSOR_8:[a-z0-9_]+]] = bufferization.to_tensor %[[MEMSPACECAST]] restrict writable {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<64x32xf32>
+// CHECK: memref.alloc()
+// CHECK: %[[TENSOR_9:[a-z0-9_]+]] = bufferization.to_tensor
+// CHECK: %[[MATMUL_10:[a-z0-9_]+]] = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} ins(%[[TENSOR_9]], %[[TENSOR_8]] : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[FILL_4]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+// CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+// CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_V>, <PIPE_FIX>] flag = 2
+// CHECK: hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32} ins(%[[MATMUL_10]] : tensor<32x32xf32>) outs(%[[ALLOC_1]] : memref<32x32xf32, #hivm.address_space<ub>>)
+// CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_FIX>, <PIPE_V>] flag = 2
+// CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 2
+// CHECK: %[[MEMSPACECAST_8:[a-z0-9_]+]] = memref.memory_space_cast %[[ALLOC_2]] {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<32x32xf32, #hivm.address_space<ub>> to memref<32x32xf32>
+// CHECK: %[[TENSOR_11:[a-z0-9_]+]] = bufferization.to_tensor %[[MEMSPACECAST_8]] restrict writable {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<32x32xf32>
+// CHECK: %[[EXP_12:[a-z0-9_]+]] = math.exp %[[TENSOR_11]]
+// CHECK: %[[INSERTED_SLICE:[a-z0-9_]+]] = tensor.insert_slice %[[EXP_12]]
+// CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 2
+// CHECK: scf.yield {ssbuffer.core_type = "VECTOR"} %[[INSERTED_SLICE]] : tensor<64x32xf32>
+// CHECK: } {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.main_loop = 0 : i32}
+
+// CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_V>, <PIPE_FIX>] flag = 2
+// CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+// CHECK: return


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
