### PR TITLE
[CI] Rename the display of the Ascend950 Pipeline Tests

### DIFF
--- a/.github/workflows/Ascend950-pipeline-tests.yml
+++ b/.github/workflows/Ascend950-pipeline-tests.yml
@@ -1,4 +1,11 @@
 name: Ascend950 Pipeline Tests
+run-name: >-
+  ${{
+    (github.event_name == 'workflow_run' && github.event.workflow_run.display_title)
+    || (github.event_name == 'pull_request_target' && format('cleanup · {0}', github.event.pull_request.title))
+    || (github.event_name == 'workflow_dispatch' && format('manual re-trigger · PR #{0}', inputs.pr_id))
+    || format('run {0}', github.run_id)
+  }}
 # Combined orchestration after Wheels finishes (or on PR close):
 #   publish: download wheel artifact → upload to obs://.../triton-ascend/<N>/
 #   trigger: needs publish; calls blue-yellow /start and polls /query


### PR DESCRIPTION
Summary
------------
Since the `Ascend pipeline tests` task is triggered by `workflow_run`, it does not automatically obtain the pr name. Here, the run-name method is used to synchronize the task names in the action list to the pr names. At the same time, identifiers have been added to the task names related to `workflow_dispatch` tasks and `cleanup` tasks