### PR TITLE
fix(ssbuffer): blockid of markop in cube should follow its defining op

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.cpp
@@ -87,10 +87,12 @@ void ComputeBlockIdManager::updateBlockId(Operation *op, int blockId)
     auto it = opToBlockId.find(op);
     if (it != opToBlockId.end()) {
         int preBlockId = it->second;
-        auto &vec = blockIdToOps[preBlockId];
-        auto vecIt = llvm::find(vec, op);
-        if (vecIt != vec.end()) {
-            vec.erase(vecIt);
+        if (preBlockId != -1) {
+            auto &vec = blockIdToOps[preBlockId];
+            auto vecIt = llvm::find(vec, op);
+            if (vecIt != vec.end()) {
+                vec.erase(vecIt);
+            }
         }
     }
     opToBlockId[op] = blockId;

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
@@ -27,10 +27,14 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/iterator.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include "DynamicCVPipeline/Common/Utils.h"
+#include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "mlir/Analysis/AliasAnalysis.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -525,6 +529,28 @@ static SmallVector<Operation *> collectMatmulOps(Block *block)
     return computeOps;
 }
 
+static void fuseMarkOpToDef(Block *block, ComputeBlockIdManager &bm)
+{
+    for (auto op : llvm::make_pointer_range(block->getOperations())) {
+        if (getOpCoreType(op) != CUBE_ONLY) {
+            continue;
+        }
+        auto markOp = llvm::dyn_cast<annotation::MarkOp>(op);
+        if (!markOp) {
+            continue;
+        }
+        auto defOp = markOp.getSrc().getDefiningOp();
+        if (!defOp) {
+            continue;
+        }
+
+        auto defBlockId = bm.getBlockIdByOp(defOp);
+        if (defBlockId != -1) {
+            bm.updateBlockId(markOp, defBlockId);
+        }
+    }
+}
+
 /**
  * Main entry point: Process a single block by grouping operations into
  * execution blocks using BFS and topological traversal.
@@ -554,7 +580,11 @@ static llvm::LogicalResult processBlockWithCubeBFS(Block *block, const MemoryDep
 
     // Phase 2: Handle remaining Cube Ops following Topo order
     TopologicalPartitionPlanner topoPlanner {block, assigned, memGraph, bm};
-    return topoPlanner.run();
+    if (failed(topoPlanner.run())) {
+        return failure();
+    }
+    fuseMarkOpToDef(block, bm);
+    return llvm::success();
 }
 
 void mlir::triton::PlanCubeBlockPass::runOnOperation()

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_plan_cube_block_markop.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_plan_cube_block_markop.mlir
@@ -1,0 +1,88 @@
+// RUN: triton-opt --plan-cube-block %s | FileCheck %s
+
+module {
+  // ============================================================================
+  // 1. fuse_mark_with_alloc
+  // ============================================================================
+  // CHECK-LABEL: func.func @fuse_mark_with_alloc
+  // CHECK: %[[ALLOC:.*]] = memref.alloc() {ssbuffer.block_id = [[ID_ALLOC:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"}
+  // CHECK-NEXT: annotation.mark %[[ALLOC]] {ssbuffer.block_id = [[ID_ALLOC]] : i32, ssbuffer.core_type = "CUBE"}
+  // CHECK-NEXT: %[[T0:.*]] = bufferization.to_tensor %[[ALLOC]] restrict writable {ssbuffer.block_id = [[ID_MAT:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"}
+  // CHECK-NEXT: %[[MM:.*]] = linalg.matmul {ssbuffer.block_id = [[ID_MAT]] : i32, ssbuffer.core_type = "CUBE"}
+  func.func @fuse_mark_with_alloc(%arg0: tensor<4x4xf16>, %arg1: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    %alloc = memref.alloc() {ssbuffer.core_type = "CUBE"} : memref<4x4xf16>
+    annotation.mark %alloc {ssbuffer.core_type = "CUBE"} : memref<4x4xf16>
+    %0 = bufferization.to_tensor %alloc restrict writable {ssbuffer.core_type = "CUBE"} : memref<4x4xf16>
+    %1 = linalg.matmul {ssbuffer.core_type = "CUBE"} ins(%0, %arg0 : tensor<4x4xf16>, tensor<4x4xf16>) outs(%arg1 : tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %1 : tensor<4x4xf32>
+  }
+
+  // -----
+
+  // ============================================================================
+  // 2. fuse_mark_with_empty
+  // ============================================================================
+  // CHECK-LABEL: func.func @fuse_mark_with_empty
+  // CHECK: %[[EMPTY:.*]] = tensor.empty() {ssbuffer.block_id = [[ID:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"}
+  // CHECK-NEXT: annotation.mark %[[EMPTY]] {ssbuffer.block_id = [[ID]] : i32, ssbuffer.core_type = "CUBE"}
+  // CHECK-NEXT: %[[MM:.*]] = linalg.matmul {ssbuffer.block_id = [[ID]] : i32, ssbuffer.core_type = "CUBE"}
+  func.func @fuse_mark_with_empty(%arg0: tensor<4x4xf16>, %arg1: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    %0 = tensor.empty() {ssbuffer.core_type = "CUBE"} : tensor<4x4xf16>
+    annotation.mark %0 {ssbuffer.core_type = "CUBE"} : tensor<4x4xf16>
+    %1 = linalg.matmul {ssbuffer.core_type = "CUBE"} ins(%0, %arg0 : tensor<4x4xf16>, tensor<4x4xf16>) outs(%arg1 : tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %1 : tensor<4x4xf32>
+  }
+
+  // -----
+
+  // ============================================================================
+  // 3. mark_on_block_arg
+  // ============================================================================
+  // CHECK-LABEL: func.func @mark_on_block_arg
+  // CHECK: annotation.mark %arg0 {ssbuffer.block_id = [[ID_MARK:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"}
+  // CHECK-NEXT: %[[MM:.*]] = linalg.matmul {ssbuffer.block_id = [[ID_MAT:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"}
+  func.func @mark_on_block_arg(%arg0: tensor<4x4xf16>, %arg1: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    annotation.mark %arg0 {ssbuffer.core_type = "CUBE"} : tensor<4x4xf16>
+    %0 = linalg.matmul {ssbuffer.core_type = "CUBE"} ins(%arg0, %arg0 : tensor<4x4xf16>, tensor<4x4xf16>) outs(%arg1 : tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+
+  // -----
+
+  // ============================================================================
+  // 4. multiple_marks_chain
+  // ============================================================================
+  // CHECK-LABEL: func.func @multiple_marks_chain
+  // CHECK: %[[ALLOC:.*]] = memref.alloc() {ssbuffer.block_id = [[ID_ALLOC:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"}
+  // CHECK-NEXT: annotation.mark %[[ALLOC]] {ssbuffer.block_id = [[ID_ALLOC]] : i32, ssbuffer.core_type = "CUBE"}
+  // CHECK-NEXT: annotation.mark %[[ALLOC]] {ssbuffer.block_id = [[ID_ALLOC]] : i32, ssbuffer.core_type = "CUBE"}
+  // CHECK-NEXT: %[[T0:.*]] = bufferization.to_tensor %[[ALLOC]] restrict writable {ssbuffer.block_id = [[ID_MAT:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"}
+  // CHECK-NEXT: %[[MM:.*]] = linalg.matmul {ssbuffer.block_id = [[ID_MAT]] : i32, ssbuffer.core_type = "CUBE"}
+  func.func @multiple_marks_chain(%arg0: tensor<4x4xf16>, %arg1: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    %alloc = memref.alloc() {ssbuffer.core_type = "CUBE"} : memref<4x4xf16>
+    annotation.mark %alloc {ssbuffer.core_type = "CUBE"} : memref<4x4xf16>
+    annotation.mark %alloc {ssbuffer.core_type = "CUBE"} : memref<4x4xf16>
+    %0 = bufferization.to_tensor %alloc restrict writable {ssbuffer.core_type = "CUBE"} : memref<4x4xf16>
+    %1 = linalg.matmul {ssbuffer.core_type = "CUBE"} ins(%0, %arg0 : tensor<4x4xf16>, tensor<4x4xf16>) outs(%arg1 : tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %1 : tensor<4x4xf32>
+  }
+
+  // -----
+
+  // ============================================================================
+  // 5. non_cube_mark_skipped
+  // ============================================================================
+  // CHECK-LABEL: func.func @non_cube_mark_skipped
+  // CHECK: %[[ALLOC:.*]] = memref.alloc() {ssbuffer.core_type = "VECTOR"}
+  // CHECK-NEXT: annotation.mark %[[ALLOC]] {ssbuffer.core_type = "VECTOR"} : memref<4x4xf16>
+  // CHECK-NOT: ssbuffer.block_id
+  // CHECK: %[[T0:.*]] = bufferization.to_tensor %[[ALLOC]] restrict writable {ssbuffer.core_type = "VECTOR"}
+  // CHECK-NEXT: %[[MM:.*]] = linalg.matmul {ssbuffer.block_id = [[ID_MAT:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"}
+  func.func @non_cube_mark_skipped(%arg0: tensor<4x4xf16>, %arg1: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    %alloc = memref.alloc() {ssbuffer.core_type = "VECTOR"} : memref<4x4xf16>
+    annotation.mark %alloc {ssbuffer.core_type = "VECTOR"} : memref<4x4xf16>
+    %0 = bufferization.to_tensor %alloc restrict writable {ssbuffer.core_type = "VECTOR"} : memref<4x4xf16>
+    %1 = linalg.matmul {ssbuffer.core_type = "CUBE"} ins(%0, %arg0 : tensor<4x4xf16>, tensor<4x4xf16>) outs(%arg1 : tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %1 : tensor<4x4xf32>
+  }
+}


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
