### PR TITLE
feat(ssbuffer): add fallback logic for multi buffer while having memref type dependent values

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h
@@ -90,7 +90,23 @@ public:
   }
 };
 
+// Pass for analyzing MemRef-type dependencies in main_loop
+class AnalyzeDepsPass : public PassWrapper<AnalyzeDepsPass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(AnalyzeDepsPass)
+
+  AnalyzeDepsPass() = default;
+
+  void runOnOperation() override;
+
+  llvm::StringRef getArgument() const override { return "analyze-deps"; }
+  llvm::StringRef getDescription() const override {
+    return "Analyze dependencies and detect MemRefType usage in main_loop";
+  }
+};
+
 std::unique_ptr<OperationPass<ModuleOp>> createAnalyzeArgsPass();
+std::unique_ptr<OperationPass<ModuleOp>> createAnalyzeDepsPass();
 std::unique_ptr<OperationPass<ModuleOp>> createAnalyzeFlagPass();
 std::unique_ptr<OperationPass<ModuleOp>> createAnalyzeDataFlowPass();
 std::unique_ptr<OperationPass<ModuleOp>> createAnalyzeScopePass();

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow.cpp
@@ -45,6 +45,8 @@ void AnalyzeDataFlowPass::runOnOperation()
 
   pm.addPass(createAnalyzeFlagPass());
 
+  pm.addPass(createAnalyzeDepsPass());
+
   if (failed(runPipeline(pm, module))) {
     signalPassFailure();
   }
@@ -65,6 +67,7 @@ void registerAnalyzeDataFlowPasses()
     registerPass(createAnalyzeArgsPass);
     registerPass(createAnalyzeFlagPass);
     registerPass(createAnalyzeScopePass);
+    registerPass(createAnalyzeDepsPass);
     registerPass(createAnalyzeDataFlowPass);
 }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeDeps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeDeps.cpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "bishengir/Dialect/Scope/IR/Scope.h"
+
+static constexpr const char *DEBUG_TYPE = "analyze-deps";
+#define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
+#define LDBG(...) \
+LLVM_DEBUG({ \
+  DBGS(); \
+  llvm::dbgs() << __VA_ARGS__; \
+  llvm::dbgs() << "\n"; \
+})
+
+using namespace llvm;
+using namespace mlir;
+using namespace triton;
+using namespace scope;
+using namespace hivm;
+
+namespace {
+
+void collectNestedOps(Block *block, SmallVector<Operation *> &ops)
+{
+    for (auto &op : *block) {
+        ops.push_back(&op);
+        for (auto &region : op.getRegions())
+            for (auto &innerBlock : region)
+                collectNestedOps(&innerBlock, ops);
+    }
+}
+
+// Collect operations with ssbuffer.main_loop attribute recursively in a region
+static void collectMainLoopOpsRecursively(Region &region, SmallVector<Operation *> &mainLoopOps)
+{
+    for (Block &block : region) {
+        for (Operation &op : block) {
+            if (op.hasAttr("ssbuffer.main_loop")) {
+                mainLoopOps.push_back(&op);
+            }
+            for (auto &nestedRegion : op.getRegions())
+                collectMainLoopOpsRecursively(nestedRegion, mainLoopOps);
+        }
+    }
+}
+
+// Check if mainLoopOp's region contains MemRefType dependency values
+// whose definingOp's parent is within mainLoopOp's region
+static bool hasMemRefDepsInRegion(Operation *mainLoopOp)
+{
+    for (Region &region : mainLoopOp->getRegions()) {
+        for (Block &block : region) {
+            SmallVector<Operation *> allOps;
+            collectNestedOps(&block, allOps);
+
+            for (Operation *op : allOps) {
+                for (Value operand : op->getOperands()) {
+                    Operation *defOp = operand.getDefiningOp();
+                    if (!defOp)
+                        continue;
+                    // Check if definingOp is within mainLoopOp's region
+                    if (!region.isAncestor(defOp->getParentRegion()))
+                        continue;
+                    if (isa<MemRefType>(operand.getType())) {
+                        LDBG("[ERROR]: Found MemRefType dependency in main_loop!\n");
+                        return true;
+                    }
+                }
+                for (Value result : op->getResults()) {
+                    Operation *defOp = result.getDefiningOp();
+                    if (!defOp)
+                        continue;
+                    if (!region.isAncestor(defOp->getParentRegion()))
+                        continue;
+                    if (isa<MemRefType>(result.getType())) {
+                        LDBG("[ERROR]: Found MemRefType result in main_loop!\n");
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+bool checkMemRefDepsInMainLoop(ModuleOp module)
+{
+    bool hasMemRef = false;
+
+    module.walk([&](ScopeOp scope) -> WalkResult {
+        // Check if scope has VECTOR core type
+        auto coreTypeAttr = scope->getAttrOfType<TCoreTypeAttr>(TCoreTypeAttr::name);
+        if (!coreTypeAttr)
+            return WalkResult::advance();
+
+        if (coreTypeAttr.getTcoretype() != TCoreType::VECTOR) {
+            return WalkResult::advance();
+        }
+
+        // Within VECTOR scope, find all ops with ssbuffer.main_loop attribute
+        SmallVector<Operation *> mainLoopOps;
+        collectMainLoopOpsRecursively(scope.getBodyRegion(), mainLoopOps);
+
+        for (auto *mainLoopOp : mainLoopOps) {
+            if (hasMemRefDepsInRegion(mainLoopOp)) {
+                hasMemRef = true;
+                return WalkResult::interrupt();
+            }
+        }
+
+        return WalkResult::advance();
+    });
+
+    return hasMemRef;
+}
+
+void AnalyzeDepsPass::runOnOperation()
+{
+    ModuleOp module = getOperation();
+
+    LDBG("Enter AnalyzeDeps pass");
+
+    if (checkMemRefDepsInMainLoop(module)) {
+        LDBG("AnalyzeDeps found MemRefType deps, signalFailure");
+        signalPassFailure();
+        return;
+    }
+
+    LDBG("AnalyzeDeps pass completed successfully");
+}
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<OperationPass<ModuleOp>> createAnalyzeDepsPass()
+{
+    return std::make_unique<AnalyzeDepsPass>();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-memref-deps-fail.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-memref-deps-fail.mlir
@@ -1,0 +1,20 @@
+// RUN: not triton-opt --analyze-deps %s --mlir-print-ir-after-all 2>&1 | FileCheck %s
+
+// Test: MemRefType result (memref.alloc) in main_loop should trigger signalFailure
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_memref_deps_fail() attributes {global_kernel = "local"} {
+    %c0_i32 = arith.constant {ssbuffer.block_id = 15 : i32} 0 : i32
+    %c1_i32 = arith.constant {ssbuffer.block_id = 15 : i32} 1 : i32
+    %c10_i32 = arith.constant {ssbuffer.block_id = 15 : i32} 10 : i32
+    scope.scope : () -> () {
+      %0 = scf.for %i = %c0_i32 to %c10_i32 step %c1_i32 iter_args(%arg0 = %c0_i32) -> (i32) : i32 {
+        %alloc = memref.alloc() {ssbuffer.block_id = 15 : i32} : memref<64xf32>
+        scf.yield %c0_i32 : i32
+      } {ssbuffer.main_loop = 0 : i32}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return
+  }
+}
+
+// CHECK: IR Dump After mlir::triton::AnalyzeDepsPass Failed

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-memref-deps-outside-mainloop-pass.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-memref-deps-outside-mainloop-pass.mlir
@@ -1,0 +1,26 @@
+// RUN: triton-opt --analyze-deps %s | FileCheck %s
+
+// Test: MemRefType outside main_loop should pass
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_memref_outside_mainloop_pass(%arg0: memref<?xi8>, %arg1: memref<?xi8>) attributes {global_kernel = "local"} {
+    %c0_i32 = arith.constant {ssbuffer.block_id = 15 : i32} 0 : i32
+    %c1_i32 = arith.constant {ssbuffer.block_id = 15 : i32} 1 : i32
+    %c10_i32 = arith.constant {ssbuffer.block_id = 15 : i32} 10 : i32
+    %alloc = memref.alloc() {ssbuffer.block_id = 16 : i32} : memref<64xf32>
+    scope.scope : () -> () {
+      %0 = tensor.empty() {ssbuffer.block_id = 15 : i32} : tensor<64xf32>
+      %1 = linalg.fill {ssbuffer.block_id = 15 : i32} ins(%c0_i32 : i32) outs(%0 : tensor<64xf32>) -> tensor<64xf32>
+      %2 = scf.for %i = %c0_i32 to %c10_i32 step %c1_i32 iter_args(%arg2 = %1) -> (tensor<64xf32>) : i32 {
+        %3 = arith.constant {ssbuffer.block_id = 15 : i32} 1.0 : f32
+        %4 = tensor.empty() {ssbuffer.block_id = 15 : i32} : tensor<64xf32>
+        %5 = linalg.fill {ssbuffer.block_id = 15 : i32} ins(%3 : f32) outs(%4 : tensor<64xf32>) -> tensor<64xf32>
+        scf.yield %5 : tensor<64xf32>
+      } {ssbuffer.main_loop = 0 : i32}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return
+  }
+}
+
+// CHECK: module attributes
+// CHECK: func.func @test_memref_outside_mainloop_pass

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-memref-deps-pass.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-memref-deps-pass.mlir
@@ -1,0 +1,25 @@
+// RUN: triton-opt --analyze-deps %s | FileCheck %s
+
+// Test: No MemRefType operand in main_loop should pass
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_memref_deps_pass(%arg0: memref<?xi8>, %arg1: memref<?xi8>) attributes {global_kernel = "local"} {
+    %c0_i32 = arith.constant {ssbuffer.block_id = 15 : i32} 0 : i32
+    %c1_i32 = arith.constant {ssbuffer.block_id = 15 : i32} 1 : i32
+    %c10_i32 = arith.constant {ssbuffer.block_id = 15 : i32} 10 : i32
+    scope.scope : () -> () {
+      %0 = tensor.empty() {ssbuffer.block_id = 15 : i32} : tensor<64xf32>
+      %1 = linalg.fill {ssbuffer.block_id = 15 : i32} ins(%c0_i32 : i32) outs(%0 : tensor<64xf32>) -> tensor<64xf32>
+      %2 = scf.for %i = %c0_i32 to %c10_i32 step %c1_i32 iter_args(%arg2 = %1) -> (tensor<64xf32>) : i32 {
+        %3 = arith.constant {ssbuffer.block_id = 15 : i32} 1.0 : f32
+        %4 = tensor.empty() {ssbuffer.block_id = 15 : i32} : tensor<64xf32>
+        %5 = linalg.fill {ssbuffer.block_id = 15 : i32} ins(%3 : f32) outs(%4 : tensor<64xf32>) -> tensor<64xf32>
+        scf.yield %5 : tensor<64xf32>
+      } {ssbuffer.main_loop = 0 : i32}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return
+  }
+}
+
+// CHECK: module attributes
+// CHECK: func.func @test_memref_deps_pass

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-memref-deps-result-fail.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-memref-deps-result-fail.mlir
@@ -1,0 +1,22 @@
+// RUN: not triton-opt --analyze-deps %s --mlir-print-ir-after-all 2>&1 | FileCheck %s
+
+// Test: MemRefType result (memref.alloc) in main_loop should trigger signalFailure
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_memref_result_deps_fail(%arg0: memref<?xi8>, %arg1: memref<?xi8>) attributes {global_kernel = "local"} {
+    %c0_i32 = arith.constant {ssbuffer.block_id = 15 : i32} 0 : i32
+    %c1_i32 = arith.constant {ssbuffer.block_id = 15 : i32} 1 : i32
+    %c10_i32 = arith.constant {ssbuffer.block_id = 15 : i32} 10 : i32
+    scope.scope : () -> () {
+      %0 = tensor.empty() {ssbuffer.block_id = 15 : i32} : tensor<64xf32>
+      %1 = linalg.fill {ssbuffer.block_id = 15 : i32} ins(%c0_i32 : i32) outs(%0 : tensor<64xf32>) -> tensor<64xf32>
+      %2 = scf.for %i = %c0_i32 to %c10_i32 step %c1_i32 iter_args(%arg2 = %1) -> (tensor<64xf32>) : i32 {
+        %alloc = memref.alloc() {ssbuffer.block_id = 15 : i32} : memref<64xf32>
+        scf.yield %1 : tensor<64xf32>
+      } {ssbuffer.main_loop = 0 : i32}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return
+  }
+}
+
+// CHECK: IR Dump After mlir::triton::AnalyzeDepsPass Failed


### PR DESCRIPTION
Add skip logic for multi buffer while having memref type dependent values
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
