### PR TITLE
fix(cdiv): wrap result in constexpr for Number inputs

### DIFF
--- a/python/triton/language/math.py
+++ b/python/triton/language/math.py
@@ -280,9 +280,9 @@ def cdiv(x, div, _builder=None):
         elif isinstance(x, int) and isinstance(div, int):
             res = x // div
             rem = x % div
-            return res + (1 if rem != 0 else 0)
+            return core.constexpr(res + (1 if rem != 0 else 0))
         else:
-            return py_ceil(x / div)
+            return core.constexpr(py_ceil(x / div))
 
     x = semantic.to_tensor(x, _builder)
     div = semantic.to_tensor(div, _builder)


### PR DESCRIPTION
Prevent type errors in cases like `range(tl.cdiv(X, Y) + 1, ...`