### PR TITLE
fix(ssbuffer): The `triton_indirect_load` function is specially identified as an op with no memory side effects.

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/Common/MemoryEffectsTracker.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/MemoryEffectsTracker.cpp
@@ -35,6 +35,7 @@
 // all prior writers/readers and become the sole writer for every slot.
 
 #include "ascend/include/DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Block.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpDefinition.h"
@@ -90,6 +91,12 @@ MemoryEffects::EffectInstance remapEffectValue(const MemoryEffects::EffectInstan
 
     return MemoryEffects::EffectInstance(effect.getEffect(), cast<BlockArgument>(value), effect.getParameters(),
                                          effect.getStage(), effect.getEffectOnFullRegion(), effect.getResource());
+}
+
+bool isKnownNoMemoryEffectCall(Operation *op)
+{
+    auto callOp = dyn_cast<func::CallOp>(op);
+    return callOp && callOp.getCallee().starts_with("triton_indirect_load");
 }
 
 } // namespace
@@ -215,7 +222,9 @@ SmallVector<MemoryEffects::EffectInstance> MemoryDependenceGraph::collectOuterEf
 
     std::optional<SmallVector<MemoryEffects::EffectInstance>> raw = getEffectsRecursively(op);
     if (!raw) {
-        unknown = true;
+        if (!isKnownNoMemoryEffectCall(op)) {
+            unknown = true;
+        }
         return {};
     }
 

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_triton_indirect_load_call_memory_effects.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_triton_indirect_load_call_memory_effects.mlir
@@ -1,0 +1,33 @@
+// RUN: triton-opt --debug-only=memory-effects-tracker --plan-compute-block %s 2>&1 | FileCheck %s
+
+module {
+  func.func private @triton_indirect_load_0(%arg0: memref<4x4xf32>) -> tensor<4x4xf32>
+
+  // CHECK-LABEL: func.func @triton_indirect_load_call_is_not_memory_barrier
+  // CHECK: %[[ALLOC:[A-Za-z0-9_]+]] = memref.alloc()
+  // CHECK: linalg.fill {{.*}} outs(%[[ALLOC]]
+  // CHECK: Analyzing op %{{.*}} = func.call @triton_indirect_load_0(%[[ALLOC]])
+  // CHECK-NEXT: [memory-effects-tracker] Defs:
+  // CHECK-NEXT: [memory-effects-tracker] Preds:
+  // CHECK-NEXT: [memory-effects-tracker] Analyzing op %{{.*}} = bufferization.to_tensor %[[ALLOC]]
+  // CHECK-NEXT: [memory-effects-tracker] Defs:
+  // CHECK-NEXT: [memory-effects-tracker] linalg.fill {{.*}} outs(%[[ALLOC]]
+  // CHECK-NEXT: [memory-effects-tracker] Preds:
+  // CHECK-NEXT: [memory-effects-tracker] linalg.fill {{.*}} outs(%[[ALLOC]]
+  func.func @triton_indirect_load_call_is_not_memory_barrier(
+    %arg0: memref<4xf32>,
+    %rhs: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    %c0 = arith.constant 0 : index
+    %zero = arith.constant 0.0 : f32
+    %unused = memref.load %arg0[%c0] : memref<4xf32>
+    %alloc = memref.alloc() : memref<4x4xf32>
+    linalg.fill ins(%zero : f32) outs(%alloc : memref<4x4xf32>)
+    %ignored = func.call @triton_indirect_load_0(%alloc) : (memref<4x4xf32>) -> tensor<4x4xf32>
+    %lhs = bufferization.to_tensor %alloc restrict writable : memref<4x4xf32>
+    %out = tensor.empty() : tensor<4x4xf32>
+    %init = linalg.fill ins(%zero : f32) outs(%out : tensor<4x4xf32>) -> tensor<4x4xf32>
+    %mm = linalg.matmul ins(%lhs, %rhs : tensor<4x4xf32>, tensor<4x4xf32>)
+      outs(%init : tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %mm : tensor<4x4xf32>
+  }
+}


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

Add a memEffect patch for known function call. Do not set `unknown=true` for `triton_indirect_load`