### PR TITLE
fix(ssbuffer): fix forOp iter_args clone issue in ProcessArgs

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/ProcessArgs.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/ProcessArgs.h
@@ -1,51 +1,64 @@
- /*
- 	  * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
- 	  *
- 	  * Permission is hereby granted, free of charge, to any person obtaining a copy
- 	  * of this software and associated documentation files (the "Software"), to deal
- 	  * in the Software without restriction, including without limitation the rights
- 	  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- 	  * copies of the Software, and to permit persons to whom the Software is
- 	  * furnished to do so, subject to the following conditions:
- 	  *
- 	  * The above copyright notice and this permission notice shall be included in
- 	  * all copies or substantial portions of the Software.
- 	  *
- 	  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- 	  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- 	  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- 	  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- 	  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- 	  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- 	  * THE SOFTWARE.
- 	  */
- 	 
- 	 #ifndef TRITON_ASCEND_SSBUF_PROCESS_ARGS_FOR_CONTROL_FLOW_H
- 	 #define TRITON_ASCEND_SSBUF_PROCESS_ARGS_FOR_CONTROL_FLOW_H
- 	 #include "mlir/Dialect/SCF/IR/SCF.h"
- 	 #include "mlir/IR/BuiltinOps.h"
- 	 #include "mlir/IR/DialectRegistry.h"
- 	 #include "mlir/Pass/Pass.h"
- 	 
- 	 namespace mlir {
- 	 namespace triton {
- 	 
- 	 class ProcessArgsPass : public PassWrapper<ProcessArgsPass, OperationPass<ModuleOp>> {
- 	 public:
- 	   ProcessArgsPass() = default;
- 	 
- 	   void runOnOperation() override;
- 	 
- 	   LogicalResult processSharedIterArgs(ModuleOp module);
- 	 
- 	   llvm::StringRef getArgument() const override
- 	   {
- 	     return "process-args";
- 	   }
- 	 };
- 	 
- 	 std::unique_ptr<OperationPass<ModuleOp>> createProcessArgsPass();
- 	 
- 	 } // namespace triton
- 	 } // namespace mlir
- 	 #endif // TRITON_ASCEND_SSBUF_PROCESS_ARGS_FOR_CONTROL_FLOW_H
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ASCEND_SSBUF_PROCESS_ARGS_FOR_CONTROL_FLOW_H
+#define TRITON_ASCEND_SSBUF_PROCESS_ARGS_FOR_CONTROL_FLOW_H
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/DialectRegistry.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace triton {
+
+// For each shared iter_arg, we need to track:
+// - Which block_ids use it
+// - Who is the owner (first block_id in order)
+// - For each non-owner block, what new iter_arg index to use
+struct SharedArgInfo {
+  int argIndex;
+  Value iterArg;
+  int ownerBlockId;
+  int newArgIndex;
+  int nonOwnerBlockId;
+
+  SharedArgInfo(int arg, int owner, int newIdx, int nonOwner)
+      : argIndex(arg), iterArg(Value()), ownerBlockId(owner),
+        newArgIndex(newIdx), nonOwnerBlockId(nonOwner) {}
+};
+
+class ProcessArgsPass : public PassWrapper<ProcessArgsPass, OperationPass<ModuleOp>> {
+ public:
+  ProcessArgsPass() = default;
+
+  void runOnOperation() override;
+
+  LogicalResult processSharedIterArgs(ModuleOp module);
+
+  llvm::StringRef getArgument() const override { return "process-args"; }
+};
+
+std::unique_ptr<OperationPass<ModuleOp>> createProcessArgsPass();
+
+} // namespace triton
+} // namespace mlir
+#endif // TRITON_ASCEND_SSBUF_PROCESS_ARGS_FOR_CONTROL_FLOW_H

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/ProcessArgs.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/ProcessArgs.cpp
@@ -42,19 +42,11 @@ using namespace llvm;
 using namespace mlir;
 using namespace triton;
 
-// For each shared iter_arg, we need to track:
-// - Which block_ids use it
-// - Who is the owner (first block_id in order)
-// - For each non-owner block, what new iter_arg index to use
-struct SharedArgInfo {
-  int argIndex;           // original iter_arg index (0, 1, 2...)
-  Value iterArg;          // the original iter_arg value
-  int ownerBlockId;       // block_id that "owns" this arg (first in order)
-  int newArgIndex;        // new iter_arg index in the new for op (for this specific block)
-  int nonOwnerBlockId;    // the non-owner block that needs a clone
-};
-
-static LogicalResult processSharedIterArgsInForOp(scf::ForOp forOp)
+// Collects mapping from iter_arg index to block_ids that use it.
+// For each iter_arg, tracks which block_ids reference it in their operations.
+static LogicalResult collectArgIndexToBlockIds(
+    scf::ForOp forOp,
+    llvm::DenseMap<int, llvm::DenseSet<int>> &argIndexToBlockIds)
 {
   Block *body = forOp.getBody();
   if (!body || !body->mightHaveTerminator()) {
@@ -62,8 +54,6 @@ static LogicalResult processSharedIterArgsInForOp(scf::ForOp forOp)
     return failure();
   }
 
-  // Step 1: Find which block_ids use which iter_args
-  llvm::DenseMap<int, llvm::DenseSet<int>> argIndexToBlockIds;  // argIndex -> set of blockIds
   for (Operation &op : body->without_terminator()) {
     auto blockIdAttr = op.getAttrOfType<IntegerAttr>("ssbuffer.block_id");
     if (!blockIdAttr) continue;
@@ -78,183 +68,256 @@ static LogicalResult processSharedIterArgsInForOp(scf::ForOp forOp)
       }
     }
   }
+  return success();
+}
 
-  // Step 2: Find iter_args used by multiple block_ids (shared args)
-  // Get block_ids in order
-  SmallVector<int> idsInOrder = getBlockIdsInOrder(forOp);
-
-  // For each shared arg, create a SharedArgInfo for each non-owner block
-  SmallVector<SharedArgInfo> sharedArgsInfo;
-  llvm::DenseMap<int, int> oldArgIndexToNewArgIndexBase;  // first new arg index per shared arg
-
+// Finds iter_args used by multiple block_ids (shared args).
+// Determines owner block (first in order) and creates SharedArgInfo for each non-owner.
+// Each non-owner block gets its own extra iter_arg.
+static LogicalResult findSharedArgs(
+    const llvm::DenseMap<int, llvm::DenseSet<int>> &argIndexToBlockIds,
+    const SmallVector<int> &idsInOrder,
+    SmallVector<SharedArgInfo> &sharedArgsInfo)
+{
   int extraArgCount = 0;
   for (auto &p : argIndexToBlockIds) {
     int argIndex = p.first;
     const llvm::DenseSet<int> &blockIds = p.second;
 
-    if (blockIds.size() > 1) {
-      // Find owner block (first in order)
-      int ownerBlockId = -1;
-      for (int id : idsInOrder) {
-        if (blockIds.contains(id)) {
-          ownerBlockId = id;
-          break;
-        }
+    if (blockIds.size() <= 1) continue;
+
+    int ownerBlockId = -1;
+    for (int id : idsInOrder) {
+      if (blockIds.contains(id)) {
+        ownerBlockId = id;
+        break;
       }
-      if (ownerBlockId == -1) continue;
+    }
+    if (ownerBlockId == -1) continue;
 
-      // Record the base new arg index for this shared arg
-      oldArgIndexToNewArgIndexBase[argIndex] = forOp.getNumRegionIterArgs() + extraArgCount;
-      extraArgCount++;
+    // Each non-owner block for this argIndex gets its own extra iter_arg
+    for (int bid : blockIds) {
+      if (bid != ownerBlockId) {
+        sharedArgsInfo.push_back(
+            SharedArgInfo(argIndex, ownerBlockId, extraArgCount, bid));
+        extraArgCount++;
+      }
+    }
+  }
+  return success();
+}
 
-      // For each non-owner block, create a SharedArgInfo
-      for (int bid : blockIds) {
-        if (bid != ownerBlockId) {
-          SharedArgInfo info;
-          info.argIndex = argIndex;
-          info.iterArg = forOp.getRegionIterArgs()[argIndex];
-          info.ownerBlockId = ownerBlockId;
-          info.newArgIndex = oldArgIndexToNewArgIndexBase[argIndex];
-          info.nonOwnerBlockId = bid;
-          sharedArgsInfo.push_back(info);
+// Finds the computation operation in owner block that produces the iter_arg value.
+// compOp is the defining op of the iter_arg in the scf.yield operand list.
+static LogicalResult findCompOpInOwnerBlock(
+    scf::ForOp forOp,
+    Block *body,
+    const SharedArgInfo &info,
+    Operation *&compOp)
+{
+  auto yieldOp = cast<scf::YieldOp>(body->getTerminator());
+  Value yieldArg = yieldOp.getOperand(info.argIndex);
+
+  if (auto *defOp = yieldArg.getDefiningOp()) {
+    compOp = defOp;
+    return success();
+  }
+
+  return failure();
+}
+
+// Collects all operations in the computation chain by backward traversal from compOp.
+// Builds the dependency graph needed to clone the computation for non-owner blocks.
+static void collectChainOps(
+    scf::ForOp forOp,
+    Operation *compOp,
+    llvm::DenseSet<Operation*> &chainOps)
+{
+  SmallVector<Operation*> worklist;
+  worklist.push_back(compOp);
+
+  while (!worklist.empty()) {
+    Operation *op = worklist.pop_back_val();
+    if (chainOps.contains(op)) continue;
+    chainOps.insert(op);
+
+    for (Value operand : op->getOperands()) {
+      if (auto *defOp = operand.getDefiningOp()) {
+        if (defOp->getParentOp() == forOp && !chainOps.contains(defOp)) {
+          worklist.push_back(defOp);
         }
       }
     }
   }
+}
 
-  if (sharedArgsInfo.empty()) {
-    return success();
-  }
-
-  LDBG("Found " << sharedArgsInfo.size() << " shared iter_args to process\n");
-
-  // Step 3: Find the computation chain for each shared arg
-  // The chain starts from the owner block's operation that produces the yield input
-  llvm::DenseMap<int, Operation*> sharedArgToCompOp;  // argIndex -> comp op
-  llvm::DenseMap<int, llvm::DenseSet<Operation*>> sharedArgToChainOps;  // argIndex -> chain ops
-
+// Builds computation info (compOp and chainOps) for each shared arg.
+static LogicalResult buildCompInfoForSharedArgs(
+    scf::ForOp forOp,
+    Block *body,
+    SmallVector<SharedArgInfo> &sharedArgsInfo,
+    llvm::DenseMap<int, Operation*> &sharedArgToCompOp,
+    llvm::DenseMap<int, llvm::DenseSet<Operation*>> &sharedArgToChainOps)
+{
   for (auto &info : sharedArgsInfo) {
     int argIndex = info.argIndex;
     if (sharedArgToCompOp.contains(argIndex)) continue;
 
-    Value iterArg = forOp.getRegionIterArgs()[argIndex];
-
-    // Find the operation in owner block that uses iterArg and whose result goes to yield
     Operation *compOp = nullptr;
-    for (Operation &op : body->without_terminator()) {
-      auto blockIdAttr = op.getAttrOfType<IntegerAttr>("ssbuffer.block_id");
-      if (!blockIdAttr || blockIdAttr.getInt() != info.ownerBlockId) continue;
-
-      // Check if op uses iterArg
-      bool usesIterArg = false;
-      for (Value operand : op.getOperands()) {
-        if (operand == iterArg) {
-          usesIterArg = true;
-          break;
-        }
-      }
-      if (!usesIterArg) continue;
-
-      // Check if result is used by yield
-      for (Value result : op.getResults()) {
-        for (OpOperand &use : result.getUses()) {
-          if (isa<scf::YieldOp>(use.getOwner())) {
-            compOp = &op;
-            break;
-          }
-        }
-        if (compOp) break;
-      }
-      if (compOp) break;
-    }
-
-    if (!compOp) {
-      LDBG("Could not find comp op for arg index " << argIndex);
+    if (failed(findCompOpInOwnerBlock(forOp, body, info, compOp))) {
       continue;
     }
 
     sharedArgToCompOp[argIndex] = compOp;
 
-    // Collect the computation chain (backward traversal)
     llvm::DenseSet<Operation*> chainOps;
-    SmallVector<Operation*> worklist;
-    worklist.push_back(compOp);
-
-    while (!worklist.empty()) {
-      Operation *op = worklist.pop_back_val();
-      if (chainOps.contains(op)) continue;
-      chainOps.insert(op);
-
-      for (Value operand : op->getOperands()) {
-        if (auto *defOp = operand.getDefiningOp()) {
-          if (defOp->getParentOp() == forOp && !chainOps.contains(defOp)) {
-            worklist.push_back(defOp);
-          }
-        }
-      }
-    }
-
+    collectChainOps(forOp, compOp, chainOps);
     sharedArgToChainOps[argIndex] = chainOps;
   }
+  return success();
+}
 
-  // Step 4: Create new for op with extra iter_args
+// Creates a new scf.for op with extra iter_args for shared arguments.
+// Copies attributes from the original for op.
+// Each SharedArgInfo entry (non-owner block) gets its own extra iter_arg.
+static scf::ForOp createNewForOp(
+    scf::ForOp forOp,
+    const SmallVector<SharedArgInfo> &sharedArgsInfo)
+{
   OpBuilder builder(forOp);
   SmallVector<Value> newInitArgs(forOp.getInitArgs().begin(), forOp.getInitArgs().end());
 
-  // Add new init args (one per shared arg)
-  for (auto &p : oldArgIndexToNewArgIndexBase) {
-    int oldArgIndex = p.first;
-    newInitArgs.push_back(forOp.getInitArgs()[oldArgIndex]);
+  // Each non-owner block gets its own extra iter_arg
+  for (auto &info : sharedArgsInfo) {
+    newInitArgs.push_back(forOp.getInitArgs()[info.argIndex]);
   }
 
   scf::ForOp newForOp = builder.create<scf::ForOp>(
       forOp.getLoc(), forOp.getLowerBound(), forOp.getUpperBound(),
       forOp.getStep(), newInitArgs);
 
-  // Copy attributes
   for (auto &attr : forOp->getAttrs()) {
     newForOp->setAttr(attr.getName(), attr.getValue());
   }
+  return newForOp;
+}
 
-  // Step 5: Migrate body - redirect old block args to new block args, move ops
-  Block *oldBlock = forOp.getBody();
-  Block *newBlock = newForOp.getBody();
-
-  // Save old block arguments BEFORE replaceAllUsesWith
-  // Note: oldBlock has (1 induction var + N iter_args) arguments
-  // newBlock has (1 induction var + N + M iter_args) arguments where M = num shared args
-  SmallVector<Value> oldBlockArgs;
-  for (unsigned i = 0; i < oldBlock->getNumArguments(); ++i) {
-    oldBlockArgs.push_back(oldBlock->getArgument(i));
-  }
-
-  // Map from iter_arg index to block arg index (offset by 1 for induction var)
-  auto getOldBlockArgIdx = [&](int iterArgIdx) { return iterArgIdx + 1; };
-  auto getNewBlockArgIdx = [&](int iterArgIdx) { return iterArgIdx + 1; };
-
-  // Redirect block arguments
+// Migrates operations from old block to new block.
+// Redirects block arguments to new block arguments and moves all ops.
+static void migrateBody(Block *oldBlock, Block *newBlock)
+{
   for (unsigned i = 0; i < oldBlock->getNumArguments(); ++i) {
     oldBlock->getArgument(i).replaceAllUsesWith(newBlock->getArgument(i));
   }
 
-  // Move all operations
   for (Operation &op : llvm::make_early_inc_range(oldBlock->without_terminator())) {
     op.moveBefore(newBlock, newBlock->end());
   }
+}
 
-  // Step 6: For each shared arg info, clone the chain into the non-owner block
-  // and replace uses of the old iter_arg with the new one
-  SmallVector<Value> clonedResults;  // one per SharedArgInfo, in order
+// Clones the computation chain for a non-owner block.
+// Topologically sorts the chain and clones each op with remapped operands.
+// argRemapping: maps migrated iter_arg Value -> new extra iter_arg Value.
+// resultMapper: maps original op results -> cloned op results.
+// clonedArgIdx: unique index for this non-owner block's clone (used as ssbuffer.arg).
+static LogicalResult cloneChainForBlock(
+    SharedArgInfo &info,
+    Operation *compOp,
+    const llvm::DenseSet<Operation*> &chainOps,
+    Block *newBlock,
+    IRMapping &argRemapping,
+    OpBuilder &cloneBuilder,
+    IRMapping &resultMapper,
+    int clonedArgIdx)
+{
+  if (!compOp || chainOps.empty()) {
+    return failure();
+  }
 
+  SmallVector<Operation *> sortedChain(chainOps.begin(), chainOps.end());
+  if (failed(topologicalSort(sortedChain))) {
+    return failure();
+  }
+
+  for (Operation *op : sortedChain) {
+    IRMapping opMapper;
+    for (OpOperand &operand : op->getOpOperands()) {
+      Value oldVal = operand.get();
+      Value newVal = oldVal;
+      if (argRemapping.contains(oldVal)) {
+        newVal = argRemapping.lookup(oldVal);
+      } else if (resultMapper.contains(oldVal)) {
+        // Operand is a result from earlier in the owner chain, use cloned result
+        newVal = resultMapper.lookup(oldVal);
+      }
+      opMapper.map(oldVal, newVal);
+    }
+
+    if (resultMapper.contains(op->getResult(0))) continue;
+
+    Operation *cloned = cloneBuilder.clone(*op, opMapper);
+    cloned->setAttr("ssbuffer.block_id", cloneBuilder.getI32IntegerAttr(info.nonOwnerBlockId));
+    cloned->setAttr("ssbuffer.arg", cloneBuilder.getI32IntegerAttr(info.argIndex));
+
+    resultMapper.map(op->getResult(0), cloned->getResult(0));
+    cloneBuilder.setInsertionPointAfter(cloned);
+  }
+  return success();
+}
+
+// Replaces iter_arg uses in non-owner block with the cloned iter_arg.
+// argRemapping maps migrated iter_arg Value -> new extra iter_arg Value.
+static LogicalResult replaceIterArgsInBlock(
+    SharedArgInfo &info,
+    Block *newBlock,
+    IRMapping &argRemapping,
+    OpBuilder &cloneBuilder)
+{
+  for (Operation &op : newBlock->without_terminator()) {
+    auto blockIdAttr = op.getAttrOfType<IntegerAttr>("ssbuffer.block_id");
+    if (!blockIdAttr || blockIdAttr.getInt() != info.nonOwnerBlockId) continue;
+
+    for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+      Value operand = op.getOperand(i);
+      if (argRemapping.contains(operand)) {
+        Value newVal = argRemapping.lookup(operand);
+        op.setOperand(i, newVal);
+        op.setAttr("ssbuffer.arg", cloneBuilder.getI32IntegerAttr(info.argIndex));
+      }
+    }
+  }
+  return success();
+}
+
+// Processes each shared arg: finds insertion point, clones chain, replaces iter_args.
+// Collects cloned results for building new yield operands.
+static LogicalResult processSharedArgsIteration(
+    scf::ForOp forOp,
+    Block *newBlock,
+    SmallVector<SharedArgInfo> &sharedArgsInfo,
+    const llvm::DenseMap<int, Operation*> &sharedArgToCompOp,
+    const llvm::DenseMap<int, llvm::DenseSet<Operation*>> &sharedArgToChainOps,
+    const SmallVector<Value> &oldBlockArgs,
+    SmallVector<Value> &clonedResults)
+{
+  unsigned numOriginalIterArgs = forOp.getNumRegionIterArgs();
+  unsigned extraIterArgsBase = 1 + numOriginalIterArgs; // block arg index where extra iter_args start
+
+  int clonedArgIdx = clonedResults.size();
   for (auto &info : sharedArgsInfo) {
     int argIndex = info.argIndex;
-    Operation *compOp = sharedArgToCompOp[argIndex];
-    if (!compOp) continue;
+    info.iterArg = forOp.getRegionIterArgs()[argIndex];
 
-    llvm::DenseSet<Operation*> &chainOps = sharedArgToChainOps[argIndex];
-    if (chainOps.empty()) continue;
+    // The migrated iter_arg (original iter_arg moved to new block)
+    Value migratedIterArg = newBlock->getArgument(argIndex + 1);
+    // The new extra iter_arg added for this shared arg
+    unsigned newExtraBlockArgIdx = extraIterArgsBase + info.newArgIndex;
+    Value newExtraIterArg = newBlock->getArgument(newExtraBlockArgIdx);
 
-    // Find the last op in the non-owner block
+    // Build argRemapping: migratedIterArg -> newExtraIterArg
+    IRMapping argRemapping;
+    argRemapping.map(migratedIterArg, newExtraIterArg);
+
     Operation *lastOpInBlock = nullptr;
     for (Operation &op : newBlock->without_terminator()) {
       auto blockIdAttr = op.getAttrOfType<IntegerAttr>("ssbuffer.block_id");
@@ -263,76 +326,77 @@ static LogicalResult processSharedIterArgsInForOp(scf::ForOp forOp)
       }
     }
 
-    // Create mapper: new iter_arg (at argIndex) -> cloned iter_arg (at newArgIndex)
-    // After replaceAllUsesWith, operations use newBlock->getArgument(argIndex+1)
-    // We need to map this to the clone at newArgIndex+1
-    IRMapping argMapper;
-    Value oldBlockArg = oldBlockArgs[getOldBlockArgIdx(info.argIndex)];  // Save for Step 7 replacement
-    Value newBlockArg = newBlock->getArgument(getNewBlockArgIdx(info.newArgIndex));  // Clone
-    // Map the NEW block arg (which is what operations use after replaceAllUsesWith) to the clone
-    argMapper.map(newBlock->getArgument(getNewBlockArgIdx(info.argIndex)), newBlockArg);
-
-    // Topological sort the chain
-    SmallVector<Operation *> sortedChain(chainOps.begin(), chainOps.end());
-    if (failed(topologicalSort(sortedChain))) continue;
-
-    // Clone the chain after lastOpInBlock
     OpBuilder cloneBuilder(newBlock, newBlock->end());
     if (lastOpInBlock) {
       cloneBuilder.setInsertionPointAfter(lastOpInBlock);
     }
 
     IRMapping resultMapper;
-    for (Operation *op : sortedChain) {
-      IRMapping opMapper;
-      // Map operands
-      for (OpOperand &operand : op->getOpOperands()) {
-        Value oldVal = operand.get();
-        Value newVal = oldVal;
-        if (argMapper.contains(oldVal)) {
-          newVal = argMapper.lookup(oldVal);
-        }
-        opMapper.map(oldVal, newVal);
-      }
-
-      // Skip if already cloned (shouldn't happen with topological sort)
-      if (resultMapper.contains(op->getResult(0))) continue;
-
-      // Clone the op
-      Operation *cloned = cloneBuilder.clone(*op, opMapper);
-      cloned->setAttr("ssbuffer.block_id", cloneBuilder.getI32IntegerAttr(info.nonOwnerBlockId));
-      cloned->setAttr("ssbuffer.arg", cloneBuilder.getI32IntegerAttr(info.argIndex));
-
-      resultMapper.map(op->getResult(0), cloned->getResult(0));
-      cloneBuilder.setInsertionPointAfter(cloned);
+    if (failed(cloneChainForBlock(info, sharedArgToCompOp.lookup(argIndex),
+                                  sharedArgToChainOps.lookup(argIndex),
+                                  newBlock, argRemapping,
+                                  cloneBuilder, resultMapper, clonedArgIdx))) {
+      continue;
     }
 
-    // Record the cloned result
-    Value clonedResult = resultMapper.lookup(compOp->getResult(0));
+    if (failed(replaceIterArgsInBlock(info, newBlock, argRemapping, cloneBuilder))) {
+      continue;
+    }
+
+    Value clonedResult = resultMapper.lookup(
+        sharedArgToCompOp.lookup(argIndex)->getResult(0));
     clonedResults.push_back(clonedResult);
+    clonedArgIdx++;
+  }
+  return success();
+}
 
-    // Step 7: In the non-owner block, replace the iter_arg with the cloned iter_arg
-    // After replaceAllUsesWith, operands already use newBlock->getArgument(argIndex+1)
-    // We need to replace them with newBlock->getArgument(newArgIndex+1) which is the clone
-    Value originalArg = newBlock->getArgument(getNewBlockArgIdx(info.argIndex));
-    for (Operation &op : newBlock->without_terminator()) {
-      auto blockIdAttr = op.getAttrOfType<IntegerAttr>("ssbuffer.block_id");
-      if (!blockIdAttr || blockIdAttr.getInt() != info.nonOwnerBlockId) continue;
-
-      // Check each operand of this op - replace if it matches original arg
-      for (unsigned i = 0; i < op.getNumOperands(); ++i) {
-        Value operandVal = op.getOperand(i);
-        if (operandVal == originalArg) {
-          op.setOperand(i, newBlockArg);
-          op.setAttr("ssbuffer.arg", cloneBuilder.getI32IntegerAttr(info.argIndex));
-        }
-      }
-    }
+// Prepares all shared args data: collects arg->blockId mapping, finds shared args,
+// and builds computation info for each shared arg.
+static LogicalResult prepareSharedArgsData(
+    scf::ForOp forOp,
+    SmallVector<SharedArgInfo> &sharedArgsInfo,
+    llvm::DenseMap<int, Operation*> &sharedArgToCompOp,
+    llvm::DenseMap<int, llvm::DenseSet<Operation*>> &sharedArgToChainOps)
+{
+  Block *body = forOp.getBody();
+  if (!body || !body->mightHaveTerminator()) {
+    LDBG("[Error]: forOp body is invalid or has no terminator\n");
+    return failure();
   }
 
-  // Step 8: Build yield with original operands + cloned results
+  llvm::DenseMap<int, llvm::DenseSet<int>> argIndexToBlockIds;
+  if (failed(collectArgIndexToBlockIds(forOp, argIndexToBlockIds))) {
+    return failure();
+  }
+
+  SmallVector<int> idsInOrder = getBlockIdsInOrder(forOp);
+  if (failed(findSharedArgs(argIndexToBlockIds, idsInOrder, sharedArgsInfo))) {
+    return failure();
+  }
+
+  if (sharedArgsInfo.empty()) {
+    return success();
+  }
+
+  LDBG("[INFO]: Found " << sharedArgsInfo.size() << " shared iter_args to process\n");
+
+  if (failed(buildCompInfoForSharedArgs(forOp, body, sharedArgsInfo,
+                                        sharedArgToCompOp, sharedArgToChainOps))) {
+    return failure();
+  }
+
+  return success();
+}
+
+// Builds new yield op with original operands plus cloned results.
+static LogicalResult buildNewYieldOp(
+    Block *oldBlock, Block *newBlock, scf::ForOp newForOp,
+    const SmallVector<Value> &clonedResults)
+{
   auto oldYield = cast<scf::YieldOp>(oldBlock->getTerminator());
   SmallVector<Value> yieldOperands;
+
   for (unsigned i = 0; i < oldYield.getNumOperands(); ++i) {
     yieldOperands.push_back(oldYield.getOperand(i));
   }
@@ -340,23 +404,70 @@ static LogicalResult processSharedIterArgsInForOp(scf::ForOp forOp)
     yieldOperands.push_back(result);
   }
 
-  builder.setInsertionPointToEnd(newBlock);
+  OpBuilder builder = OpBuilder::atBlockEnd(newBlock);
   builder.create<scf::YieldOp>(newForOp.getLoc(), yieldOperands);
   oldYield.erase();
+  return success();
+}
 
-  // Step 9: Replace uses and erase old for op
-  if (forOp.getNumResults() > 0) {
+// Replaces all uses of old for op with new for op results and erases old for op.
+static LogicalResult replaceForOpAndErase(scf::ForOp oldForOp, scf::ForOp newForOp)
+{
+  if (oldForOp.getNumResults() > 0) {
     SmallVector<Value> newResults;
-    for (unsigned i = 0; i < forOp.getNumResults(); ++i) {
+    for (unsigned i = 0; i < oldForOp.getNumResults(); ++i) {
       newResults.push_back(newForOp.getResult(i));
     }
-    forOp.replaceAllUsesWith(newResults);
+    oldForOp.replaceAllUsesWith(newResults);
   }
-  forOp.erase();
+  oldForOp.erase();
+  return success();
+}
+
+// Main entry point for processing shared iter_args in a single for op.
+// Orchestrates data preparation, new for op creation, body migration, and cloning.
+static LogicalResult processSharedIterArgsInForOp(scf::ForOp forOp)
+{
+  SmallVector<SharedArgInfo> sharedArgsInfo;
+  llvm::DenseMap<int, Operation*> sharedArgToCompOp;
+  llvm::DenseMap<int, llvm::DenseSet<Operation*>> sharedArgToChainOps;
+
+  if (failed(prepareSharedArgsData(forOp, sharedArgsInfo,
+                                   sharedArgToCompOp, sharedArgToChainOps))) {
+    return failure();
+  }
+
+  scf::ForOp newForOp = createNewForOp(forOp, sharedArgsInfo);
+  Block *oldBlock = forOp.getBody();
+  Block *newBlock = newForOp.getBody();
+
+  SmallVector<Value> oldBlockArgs;
+  for (unsigned i = 0; i < oldBlock->getNumArguments(); ++i) {
+    oldBlockArgs.push_back(oldBlock->getArgument(i));
+  }
+
+  migrateBody(oldBlock, newBlock);
+
+  SmallVector<Value> clonedResults;
+  if (failed(processSharedArgsIteration(forOp, newBlock, sharedArgsInfo,
+                                       sharedArgToCompOp, sharedArgToChainOps,
+                                       oldBlockArgs, clonedResults))) {
+    return failure();
+  }
+
+  if (failed(buildNewYieldOp(oldBlock, newBlock, newForOp, clonedResults))) {
+    return failure();
+  }
+
+  if (failed(replaceForOpAndErase(forOp, newForOp))) {
+    return failure();
+  }
 
   return success();
 }
 
+// Walks module to find for ops with ssbuffer.main_loop attribute.
+// Processes each main loop to handle shared iter_args.
 LogicalResult ProcessArgsPass::processSharedIterArgs(ModuleOp module)
 {
   WalkResult result = module.walk([&](Operation *op) -> WalkResult {

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/test-iter-args-update.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/test-iter-args-update.mlir
@@ -1,0 +1,85 @@
+// RUN: triton-opt --process-args %s --allow-unregistered-dialect | FileCheck %s
+
+// Test that ProcessArgs correctly handles shared iter_args by cloning computation
+// chains and updating operands to new values.
+
+// CHECK: func.func @test_iter_args_update
+module attributes {hacc.target = #hacc.target<"Ascend910_9589">} {
+  func.func @test_iter_args_update(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg3: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg4: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg5: memref<?xf32> {tt.divisibility = 16 : i32}, %arg6: memref<?xi32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg7: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg8: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg9: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg10: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg11: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg12: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg13: i32 {tt.divisibility = 16 : i32}, %arg14: i32 {tt.divisibility = 16 : i32}, %arg15: i32 {tt.divisibility = 16 : i32}, %arg16: i32 {tt.divisibility = 16 : i32}, %arg17: i32 {tt.divisibility = 16 : i32}, %arg18: i32 {tt.divisibility = 16 : i32}, %arg19: i32 {tt.divisibility = 16 : i32}, %arg20: i32 {tt.divisibility = 16 : i32}, %arg21: i32, %arg22: i32, %arg23: i32 {tt.divisibility = 16 : i32}, %arg24: i32 {tt.divisibility = 16 : i32}, %arg25: i32 {tt.divisibility = 16 : i32}, %arg26: i32 {tt.divisibility = 16 : i32}, %arg27: i32 {tt.divisibility = 16 : i32}, %arg28: i32 {tt.divisibility = 16 : i32}, %arg29: i32 {tt.divisibility = 16 : i32}, %arg30: i32 {tt.divisibility = 16 : i32}, %arg31: i32, %arg32: i32, %arg33: i32, %arg34: i32, %arg35: i32, %arg36: i32) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %cst_1 = arith.constant {ssbuffer.block_id = 34 : i32} 0.000000e+00 : f32
+    %c32_i32 = arith.constant {MixUse, ssbuffer.block_id = 34 : i32} 32 : i32
+    %c0_i32 = arith.constant {MixUse, ssbuffer.block_id = 34 : i32} 0 : i32
+    %c128_i32 = arith.constant {MixUse, ssbuffer.block_id = 34 : i32} 128 : i32
+    %c8_i32 = arith.constant {ssbuffer.block_id = 34 : i32} 8 : i32
+    %c32 = arith.constant {DataUse, ssbuffer.block_id = 34 : i32} 32 : index
+    %c0 = arith.constant {ssbuffer.block_id = 34 : i32} 0 : index
+    %c1 = arith.constant {ssbuffer.block_id = 34 : i32} 1 : index
+    %0 = tensor.empty() {ssbuffer.block_id = 19 : i32} : tensor<32x32xf32>
+    %1 = arith.divsi %arg35, %c8_i32 {ssbuffer.block_id = 19 : i32} : i32
+    %2 = arith.remsi %arg35, %c8_i32 {ssbuffer.block_id = 19 : i32} : i32
+    %3 = arith.index_cast %1 {ssbuffer.block_id = 19 : i32} : i32 to index
+    %4 = arith.muli %2, %arg14 {ssbuffer.block_id = 17 : i32} : i32
+    %5 = arith.index_cast %4 {ssbuffer.block_id = 17 : i32} : i32 to index
+    %6 = arith.index_cast %arg16 {ssbuffer.block_id = 17 : i32} : i32 to index
+    %7 = arith.muli %5, %6 {ssbuffer.block_id = 17 : i32} : index
+    %8 = arith.muli %arg14, %c32_i32 {ssbuffer.block_id = 17 : i32} : i32
+    %9 = arith.muli %arg30, %c32_i32 {ssbuffer.block_id = 17 : i32} : i32
+    %10 = arith.index_cast %arg14 {ssbuffer.block_id = 17 : i32} : i32 to index
+    %11 = arith.index_cast %arg30 {ssbuffer.block_id = 17 : i32} : i32 to index
+    %12 = arith.index_cast %8 {ssbuffer.block_id = 17 : i32} : i32 to index
+    %13 = arith.index_cast %9 {ssbuffer.block_id = 17 : i32} : i32 to index
+    %14 = arith.minsi %8, %c128_i32 {ssbuffer.block_id = 17 : i32} : i32
+    %15 = tensor.empty() {ssbuffer.block_id = 34 : i32} : tensor<32x32xf32>
+    %16 = linalg.fill {ssbuffer.block_id = 34 : i32} ins(%cst_1 : f32) outs(%15 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %alloc = memref.alloc() {ssbuffer.block_id = 18 : i32} : memref<32x32xf32>
+    %17:2 = scf.for %arg37 = %c0_i32 to %14 step %c32_i32 iter_args(%arg38 = %c0, %arg39 = %c0) -> (index, index)  : i32 {
+      %18 = arith.index_cast %arg37 {ssbuffer.block_id = 4 : i32} : i32 to index
+      %19 = arith.addi %18, %c32 {ssbuffer.block_id = 4 : i32} : index
+      %20 = arith.maxsi %18, %12 {ssbuffer.block_id = 4 : i32} : index
+      %21 = arith.minsi %19, %20 {ssbuffer.block_id = 4 : i32} : index
+      %22 = arith.subi %21, %18 {ssbuffer.block_id = 4 : i32} : index
+      %23 = arith.minsi %22, %c32 {ssbuffer.block_id = 4 : i32} : index
+      %24 = arith.cmpi slt, %23, %c32 {ssbuffer.block_id = 4 : i32} : index
+      %alloc_1 = memref.alloc() {ssbuffer.block_id = 4 : i32} : memref<32x32xf32>
+      scf.if %24 {
+        linalg.fill {ssbuffer.block_id = 4 : i32} ins(%cst_1 : f32) outs(%alloc_1 : memref<32x32xf32>)
+      } {hivm.unlikely_condition, ssbuffer.block_id = 4 : i32}
+      %25 = arith.addi %3, %arg38 {ssbuffer.block_id = 4 : i32} : index
+      %26 = bufferization.to_tensor %alloc_1 restrict writable {ssbuffer.block_id = 4 : i32} : memref<32x32xf32>
+      %27 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 4 : i32} ins(%26, %15 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%16 : tensor<32x32xf32>) -> tensor<32x32xf32>
+      %28 = arith.index_cast %8 {ssbuffer.block_id = 4 : i32} : i32 to index
+      %29 = arith.addi %arg38, %28 {ssbuffer.block_id = 4 : i32} : index
+      hivm.hir.sync_block_wait {ssbuffer.block_id = 4 : i32, ssbuffer.transfer_id = 5 : i32}[<CUBE>, <PIPE_V>, <PIPE_FIX>] flag = 6
+      hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 4 : i32, ssbuffer.transfer_id = 5 : i32} ins(%27 : tensor<32x32xf32>) outs(%alloc : memref<32x32xf32>)
+      hivm.hir.sync_block_set {ssbuffer.block_id = 4 : i32, ssbuffer.transfer_id = 5 : i32}[<CUBE>, <PIPE_FIX>, <PIPE_V>] flag = 6
+      %30 = arith.index_cast %arg37 {ssbuffer.block_id = 5 : i32, ssbuffer.clone = 4 : i32} : i32 to index
+      %31 = arith.addi %30, %c32 {ssbuffer.block_id = 5 : i32, ssbuffer.clone = 4 : i32} : index
+      %32 = arith.maxsi %30, %12 {ssbuffer.block_id = 5 : i32, ssbuffer.clone = 4 : i32} : index
+      %33 = arith.minsi %31, %32 {ssbuffer.block_id = 5 : i32, ssbuffer.clone = 4 : i32} : index
+      %34 = arith.subi %33, %30 {ssbuffer.block_id = 5 : i32, ssbuffer.clone = 4 : i32} : index
+      %35 = arith.minsi %34, %c32 {ssbuffer.block_id = 5 : i32, ssbuffer.clone = 4 : i32} : index
+      %36 = arith.cmpi slt, %35, %c32 {ssbuffer.block_id = 5 : i32, ssbuffer.clone = 4 : i32} : index
+      %alloc_2 = memref.alloc() {ssbuffer.block_id = 5 : i32} : memref<32x32xf32>
+      scf.if %36 {
+        linalg.fill {ssbuffer.block_id = 5 : i32} ins(%cst_1 : f32) outs(%alloc_2 : memref<32x32xf32>)
+      } {hivm.unlikely_condition, ssbuffer.block_id = 5 : i32}
+      %37 = arith.addi %7, %arg39 {ssbuffer.block_id = 5 : i32} : index
+      %transposed_2 = linalg.transpose ins(%15 : tensor<32x32xf32>) outs(%0 : tensor<32x32xf32>) permutation = [1, 0]  {ssbuffer.block_id = 5 : i32}
+      %38 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<32x32xf32>
+      %39 = linalg.fill {ssbuffer.block_id = 5 : i32} ins(%cst_1 : f32) outs(%38 : tensor<32x32xf32>) -> tensor<32x32xf32>
+      %40 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 5 : i32} ins(%transposed_2, %15 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%39 : tensor<32x32xf32>) -> tensor<32x32xf32>
+      %41 = arith.index_cast %9 {ssbuffer.block_id = 5 : i32} : i32 to index
+      %42 = arith.addi %arg39, %41 {ssbuffer.block_id = 5 : i32} : index
+      %43 = arith.addi %3, %arg38 {ssbuffer.block_id = 10 : i32} : index
+      %44 = arith.addi %7, %arg39 {ssbuffer.block_id = 11 : i32} : index
+      // CHECK: %[[RES0:.*]] = arith.addi %3, %arg40 {ssbuffer.arg = 0 : i32, ssbuffer.block_id = 10 : i32} : index
+      // CHECK: %[[RES1:.*]] = arith.index_cast %8 {ssbuffer.arg = 0 : i32, ssbuffer.block_id = 10 : i32} : i32 to index
+      // CHECK: %[[RES2:.*]] = arith.addi %arg40, %[[RES1]] {ssbuffer.arg = 0 : i32, ssbuffer.block_id = 10 : i32} : index
+      // CHECK: %[[RES3:.*]] = arith.addi %7, %arg41 {ssbuffer.arg = 1 : i32, ssbuffer.block_id = 11 : i32} : index
+      // CHECK: %[[RES4:.*]] = arith.index_cast %9 {ssbuffer.arg = 1 : i32, ssbuffer.block_id = 11 : i32} : i32 to index
+      // CHECK: %[[RES5:.*]] = arith.addi %arg41, %[[RES4]] {ssbuffer.arg = 1 : i32, ssbuffer.block_id = 11 : i32} : index
+      scf.yield %29, %42 : index, index
+    } {DataUse, ssbuffer.block_id = 36 : i32, ssbuffer.main_loop = 0 : i32}
+    return
+  }
+}


### PR DESCRIPTION
**DynamicCVPpipeline: fix forOp iter_args clone issue in ProcessArgs**

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
