### PR TITLE
fix(ssbuffer): fix buffer transfer in else region

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
@@ -259,14 +259,14 @@ static int groupOpsBySsbufferId(SmallVector<Operation *> &allOps,
 
 // Returns 0=success (including normal skip when blocks empty), -1=invalid negative block ID
 static int collectInnerBlockInfo(scf::ForOp forOp, DenseMap<Value, InnerBlockInfo> &blocks,
-                                 DenseMap<Value, SmallVector<Value>> &depValueMap)
+                                 DenseMap<Value, SmallVector<Value>> &depValueMap,
+                                 SmallVector<Operation *> &allOps)
 {
     depValueMap.clear();
     Block *body = forOp.getBody();
     if (!body)
         return 0;
 
-    SmallVector<Operation *> allOps;
     collectNestedOps(body, allOps);
 
     llvm::MapVector<int, SmallVector<Operation *>> opsById;
@@ -298,13 +298,57 @@ static int collectInnerBlockInfo(scf::ForOp forOp, DenseMap<Value, InnerBlockInf
     return 0;
 }
 
-DenseMap<Value, SmallVector<Operation *>> buildDepUserMap(DenseMap<Value, InnerBlockInfo> &blocks)
+// Check if a yieldOp is already processed in blocks
+static bool isYieldAlreadyProcessed(scf::YieldOp yieldOp, DenseMap<Value, InnerBlockInfo> &blocks)
+{
+    for (auto &p : blocks) {
+        if (llvm::is_contained(p.second.ops, yieldOp.getOperation())) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Process yield op that is not in blocks: add parent multi-region op as consumer
+// Generic version: supports any op with >= 2 regions (scf.if, scf.while, etc.)
+static void processYieldNotInBlocks(scf::YieldOp yieldOp, DenseMap<Value, InnerBlockInfo> &blocks,
+                                    DenseMap<Value, SmallVector<Operation *>> &depUserMap)
+{
+    if (isYieldAlreadyProcessed(yieldOp, blocks))
+        return;
+
+    Operation *parentOp = yieldOp->getParentOp();
+    // Generic: check if parent op has >= 2 regions
+    if (!parentOp || parentOp->getNumRegions() < 2)
+        return;
+
+    for (Value operand : yieldOp->getOperands()) {
+        // Add parent multi-region op as consumer for yield operands
+        // This handles cases where depVal is only used in yield (not as direct operand)
+        depUserMap[operand].push_back(parentOp);
+    }
+}
+
+DenseMap<Value, SmallVector<Operation *>> buildDepUserMap(DenseMap<Value, InnerBlockInfo> &blocks,
+                                                          SmallVector<Operation *> &allOps,
+                                                          DenseMap<Value, SmallVector<Value>> &depValueMap)
 {
     DenseMap<Value, SmallVector<Operation *>> depUserMap;
+
+    // First pass: process operations in blocks
     for (auto &p : blocks)
         for (Operation *op : p.second.ops)
             for (Value operand : op->getOperands())
                 depUserMap[operand].push_back(op);
+
+    // Second pass: process yield operations that are not in blocks (e.g., INT_MIN block_id)
+    // Generic version: supports any multi-region op's yield
+    for (Operation *op : allOps) {
+        if (auto yieldOp = dyn_cast<scf::YieldOp>(op)) {
+            processYieldNotInBlocks(yieldOp, blocks, depUserMap);
+        }
+    }
+
     return depUserMap;
 }
 
@@ -768,6 +812,49 @@ static SmallVector<Operation *> collectCrossBlockUsers(Value depVal, int produce
     return crossBlockUsers;
 }
 
+// Insert buffer selection logic (scf.if + to_tensor) at the start of the given region.
+// Returns the scf::IfOp that performs the buffer selection, or nullptr on failure.
+static Operation *insertBufferSelectionInRegion(OpBuilder &builder, Region &region, Location loc,
+                                              Value depVal, SmallVector<BufferPair> &buffers,
+                                              mlir::scf::ForOp forOp, int blockId)
+{
+    auto memrefType = mlir::cast<mlir::MemRefType>(buffers[0].second.getType());
+    auto tensorType = mlir::RankedTensorType::get(memrefType.getShape(), memrefType.getElementType());
+
+    // Insert at the start of the region
+    builder.setInsertionPointToStart(&region.front());
+
+    // Compute buffer index
+    Value readIdx = computeBufferIndex(builder, forOp, loc, buffers.size(), nullptr, blockId);
+
+    // Build buffer selection if-else chain
+    SmallVector<Operation *> newIfOps;
+    SmallVector<Operation *> outIfOps;
+    int ret = buildIfChain(
+        builder, loc, readIdx, buffers, newIfOps, outIfOps,
+        [&](OpBuilder &b, Location l, Value buffer) -> Operation* {
+            return createToTensorOp(b, l, tensorType, buffer);
+        },
+        [&](OpBuilder &b, Location l, Operation *op) -> Value {
+            return cast<mlir::bufferization::ToTensorOp>(op).getResult();
+        },
+        tensorType, blockId);
+    if (ret != 0)
+        return nullptr;
+
+    if (newIfOps.empty())
+        return nullptr;
+
+    // Tag all operations in newIfOps with block_id
+    for (auto *op : newIfOps) {
+        op->setAttr(kAttrBlockId, builder.getI32IntegerAttr(blockId));
+        op->setAttr("ssbuffer.intra_buffer", builder.getUnitAttr());
+    }
+
+    // The main scf.if is the first one in outIfOps
+    return outIfOps.front();
+}
+
 static void markScalarDeps(SmallVector<Value> &scalarValueList, DenseMap<Value, SmallVector<Operation *>> &depUserMap,
                            OpBuilder &builder, int startDepMark)
 {
@@ -798,6 +885,100 @@ static void markScalarDeps(SmallVector<Value> &scalarValueList, DenseMap<Value, 
     }
 }
 
+// Check if depUser is a multi-region op and depVal is not a direct operand
+// Returns true when op was added as consumer due to yield using depVal
+// Generic version: supports any op with >= 2 regions (scf.if, scf.while, etc.)
+static bool isMultiRegionConsumerFromYield(Operation *depUser, Value depVal)
+{
+    // Check if op has >= 2 regions (generic for any multi-region op)
+    if (depUser->getNumRegions() < 2)
+        return false;
+
+    for (OpOperand &operand : depUser->getOpOperands()) {
+        if (operand.get() == depVal)
+            return false;  // depVal is a direct operand
+    }
+    return true;  // depVal comes from yield
+}
+
+// Process normal consumer logic (non-scif.if from yield case)
+static int processNormalConsumer(OpBuilder &consumedBuilder, Value depVal, SmallVector<BufferPair> &buffers,
+                                mlir::scf::ForOp mainLoopForOp, Operation *depUser, int userBlockId,
+                                int groupId, OpBuilder &globalBuilder)
+{
+    SmallVector<Operation *> resultIfOps;
+    int ret = insertConsumerLogic(consumedBuilder, depVal, buffers, mainLoopForOp, resultIfOps, groupId, userBlockId);
+    if (ret != 0)
+        return -1;
+
+    if (resultIfOps.empty())
+        return 0;
+
+    addBlockAttrForOps(resultIfOps, userBlockId, globalBuilder);
+    if (buffers.size() > kBufferCountOne) {
+        for (auto *op : resultIfOps) {
+            if (isa<scf::IfOp>(op)) {
+                op->setAttr("ssbuffer.intra_buffer", globalBuilder.getUnitAttr());
+            }
+        }
+    } else {
+        addIntraBufferAttr(resultIfOps, globalBuilder);
+    }
+
+    Operation *resultIf = resultIfOps.back();
+    Value selectedBuffer = resultIf->getResult(0);
+
+    for (OpOperand &use : depUser->getOpOperands()) {
+        if (use.get() == depVal)
+            use.set(selectedBuffer);
+    }
+    return 0;
+}
+
+// Handle all regions (except region 0) when depVal is used in that region's yield
+// Generic version: supports any op with >= 2 regions (scf.if, scf.while, etc.)
+// For scf.if: handles else region (region index 1)
+// For scf.while: handles after region (region index 1)
+// For any op with 3+ regions: handles all regions from index 1 onwards
+static int processMultiRegionAllYields(OpBuilder &consumedBuilder, Value depVal, SmallVector<BufferPair> &buffers,
+                                       mlir::scf::ForOp mainLoopForOp, Operation *depUser, int userBlockId,
+                                       int groupId)
+{
+    // Generic: check if op has >= 2 regions
+    if (depUser->getNumRegions() < 2)
+        return 0;
+
+    // Iterate through all regions (from region 1 onwards, excluding region 0)
+    for (size_t i = 1; i < depUser->getNumRegions(); ++i) {
+        Region &region = depUser->getRegion(i);
+        if (region.empty())
+            continue;
+
+        auto yieldOp = dyn_cast<scf::YieldOp>(region.back().getTerminator());
+        if (!yieldOp)
+            continue;
+
+        for (OpOperand &operand : yieldOp->getOpOperands()) {
+            if (operand.get() != depVal)
+                continue;
+
+            Operation *selectIf = insertBufferSelectionInRegion(
+                consumedBuilder, region, yieldOp.getLoc(),
+                depVal, buffers, mainLoopForOp, userBlockId);
+            if (!selectIf)
+                return -1;
+
+            if (groupId >= 0) {
+                selectIf->setAttr("ssbuffer.intraDeps", consumedBuilder.getI32ArrayAttr({groupId, 0}));
+            }
+
+            operand.set(selectIf->getResult(0));
+            return 0;  // Only handle one
+        }
+    }
+    return 0;
+}
+
 // Process producer and consumer for a single dependency value
 static int processDepVal(Value depVal, mlir::scf::ForOp mainLoopForOp, BufferMap &bufferMap,
                          DenseMap<Value, SmallVector<Operation *>> &depUserMap, OpBuilder &globalBuilder,
@@ -819,7 +1000,6 @@ static int processDepVal(Value depVal, mlir::scf::ForOp mainLoopForOp, BufferMap
     producedBuffers.setInsertionPointAfter(depDefinedOp);
     SmallVector<Operation *> producerNewOps = insertProducerLogic(producedBuffers, depVal, buffers, mainLoopForOp);
     addBlockAttrForOps(producerNewOps, producerId, globalBuilder);
-    // Tag producer: N > 1 only tag scf.if, N == 1 tag materialize_in_destination
     if (buffers.size() > kBufferCountOne) {
         for (auto *op : producerNewOps) {
             if (isa<scf::IfOp>(op)) {
@@ -838,34 +1018,16 @@ static int processDepVal(Value depVal, mlir::scf::ForOp mainLoopForOp, BufferMap
 
         OpBuilder consumedBuilder(mainLoopForOp.getContext());
         consumedBuilder.setInsertionPoint(depUser);
-        SmallVector<Operation *> resultIfOps;
-        int ret =
-            insertConsumerLogic(consumedBuilder, depVal, buffers, mainLoopForOp, resultIfOps, groupId, userBlockId);
-        if (ret != 0)
-            return -1;
 
-        if (resultIfOps.empty())
-            continue;
-        // Tag consumer with block_id
-        addBlockAttrForOps(resultIfOps, userBlockId, globalBuilder);
-        // Tag consumer: N > 1 only tag scf.if, N == 1 tag to_tensor
-        if (buffers.size() > kBufferCountOne) {
-            for (auto *op : resultIfOps) {
-                if (isa<scf::IfOp>(op)) {
-                    op->setAttr("ssbuffer.intra_buffer", globalBuilder.getUnitAttr());
-                }
-            }
-        } else {
-            addIntraBufferAttr(resultIfOps, globalBuilder);
+        if (!isMultiRegionConsumerFromYield(depUser, depVal)) {
+            if (int ret = processNormalConsumer(consumedBuilder, depVal, buffers, mainLoopForOp,
+                                                depUser, userBlockId, groupId, globalBuilder))
+                return ret;
         }
 
-        Operation *resultIf = resultIfOps.back();
-        Value selectedBuffer = resultIf->getResult(0);
-
-        for (OpOperand &use : depUser->getOpOperands()) {
-            if (use.get() == depVal)
-                use.set(selectedBuffer);
-        }
+        if (int ret = processMultiRegionAllYields(consumedBuilder, depVal, buffers, mainLoopForOp,
+                                               depUser, userBlockId, groupId))
+            return ret;
     }
     return 0;
 }
@@ -991,7 +1153,8 @@ static int addInnerMultiBuffer(mlir::scf::ForOp mainLoopForOp, OpBuilder &builde
 {
     DenseMap<Value, InnerBlockInfo> blocks;
     DenseMap<Value, SmallVector<Value>> depValueMap;
-    if (collectInnerBlockInfo(mainLoopForOp, blocks, depValueMap) != 0)
+    SmallVector<Operation *> allOps;
+    if (collectInnerBlockInfo(mainLoopForOp, blocks, depValueMap, allOps) != 0)
         return -1;
 
     if (blocks.empty())
@@ -1003,7 +1166,7 @@ static int addInnerMultiBuffer(mlir::scf::ForOp mainLoopForOp, OpBuilder &builde
         return 0;
     }
 
-    auto depUserMap = buildDepUserMap(blocks);
+    auto depUserMap = buildDepUserMap(blocks, allOps, depValueMap);
 
     auto valueList = collectBufferValues(depValueMap);
     auto bufferMap = insertBuffersBeforeFor(mainLoopForOp, valueList, builder, groupId);

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/Inner-scope.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/Inner-scope.mlir
@@ -704,4 +704,54 @@ func.func @test_t22_tensor_empty_in_nested_if() {
     return
   }
 
+//===--------------------------------------------------------------------===//
+// T23: scf.if with Else Branch Directly Yielding depVal
+// Test: Real scenario from if_problem.mlir where:
+//       - block_id = 11: linalg.fill produces depVal
+//       - scf.if with block_id = 20 has then/else branches
+//       - then branch has compute using depVal
+//       - else branch directly yields depVal (no compute)
+// Note: This test verifies that basic functionality still works.
+//       The real scenario with func.call producing depVal is tested separately
+//       in if_problem.mlir which is verified manually.
+//===--------------------------------------------------------------------===//
+  // CHECK-LABEL: func.func @test_t23_scf_if_else_branch_yield
+  // CHECK-DAG: memref.alloc
+  // CHECK-DAG: memref.memory_space_cast {{.*}} {ssbuffer.intraDeps
+  // CHECK-DAG: scf.if {{.*}} -> (tensor<16x32xf16>) {
+  // CHECK-DAG: arith.addf {{.*}} {ssbuffer.block_id = 20 : i32}
+  // CHECK-DAG: scf.yield
+  // CHECK-DAG: } else {
+  // CHECK-DAG: scf.yield {{.*}} : tensor<16x32xf16>
+  // CHECK-DAG: } {ssbuffer.block_id = 20 : i32}
+  // CHECK-DAG: hivm.hir.copy {{.*}} {ssbuffer.block_id = 20 : i32}
+func.func @test_t23_scf_if_else_branch_yield() {
+    %c0_i32 = arith.constant 0 : i32
+    %c100_i32 = arith.constant 100 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %cst = arith.constant 1.0 : f32
+    %cst_f16 = arith.constant 1.0 : f16
+    %empty = tensor.empty() : tensor<16x32xf16>
+    scope.scope : () -> () {
+      // Producer: linalg.fill with block_id = 11
+      %prod = linalg.fill {ssbuffer.block_id = 11 : i32} ins(%cst_f16 : f16) outs(%empty : tensor<16x32xf16>) -> tensor<16x32xf16>
+      %loop_result = scf.for %i = %c0_i32 to %c100_i32 step %c1_i32 iter_args(%arg = %prod) -> (tensor<16x32xf16>) : i32 {
+        %cond = arith.cmpi eq, %i, %c0_i32 : i32
+        // scf.if with block_id = 20
+        // then branch: compute using %arg (depVal from block_id 11)
+        // else branch: directly yield %arg (depVal from block_id 11)
+        %if_result = scf.if %cond -> (tensor<16x32xf16>) {
+          %consumed = arith.addf %arg, %arg {ssbuffer.block_id = 20 : i32} : tensor<16x32xf16>
+          scf.yield %consumed : tensor<16x32xf16>
+        } else {
+          scf.yield %arg : tensor<16x32xf16>
+        } {ssbuffer.block_id = 20 : i32}
+        %new_prod = arith.addf %if_result, %if_result {ssbuffer.block_id = 11 : i32} : tensor<16x32xf16>
+        scf.yield %new_prod : tensor<16x32xf16>
+      } {ssbuffer.main_loop = 1 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return
+  }
+
 }


### PR DESCRIPTION
This pull request is designed to fix buffer transfer in else region when there're dependent values.
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
