### PR TITLE
[WIP][SIMT] Enable auto-blockify loop for SIMT-only compile

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -1047,6 +1047,10 @@ def ttir_to_npubin(mod, metadata, opt):
                     _compile_option_list += [
                         f"--append-bisheng-options={bisheng_options}"
                     ]
+            if _is_auto_map_parallel_blocks_enabled() and not metadata.get(
+                "has_auto_blockify_blacklist_op", False
+            ):
+                _compile_option_list += ["--enable-auto-blockify-loop"]
 
         npu_compiler_path, env = _get_npucompiler_path()
         cmd_list = (


### PR DESCRIPTION
SIMT-only compilation bypasses the linalg-to-npubin path where TRITON_ALL_BLOCKS_PARALLEL adds --enable-auto-blockify-loop. 
Add the same env and blacklist-gated flag in ttir_to_npubin so compile-time blockify matches runtime block capping.