### PR TITLE
feat(mask): solve the tile overlapping issue when grid launch parllel

### DIFF
--- a/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
+++ b/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
@@ -57,6 +57,126 @@ static bool enableSyncBlockLockFlag = true;
 static constexpr const char *routeDiscreteMaskToSimtAttrName =
     "route_discrete_mask_to_simt";
 
+static bool traceUserToTargetOp(Value val) {
+  llvm::SmallVector<Value, 32> worklist;
+  llvm::SmallPtrSet<Value, 32> visited;
+  worklist.push_back(val);
+
+  while (!worklist.empty()) {
+      Value currVal = worklist.pop_back_val();
+      if (!visited.insert(currVal).second)
+          continue;
+
+      for (Operation* user : currVal.getUsers()) {
+          if (auto mulOp = dyn_cast<arith::MulIOp>(user)) {
+              Value lhs = mulOp.getLhs();
+              Value rhs = mulOp.getRhs();
+              Value constVal;
+              if (lhs.getDefiningOp<arith::ConstantOp>()) {
+                  constVal = lhs;
+              } else if (rhs.getDefiningOp<arith::ConstantOp>()) {
+                  constVal = rhs;
+              } else {
+                  continue;
+              }
+
+              auto constDef = constVal.getDefiningOp<arith::ConstantOp>();
+              int64_t blockSize = 0;
+              if (auto intAttr = mlir::dyn_cast<IntegerAttr>(constDef.getValue())) {
+                  blockSize = intAttr.getInt();
+              }
+
+              llvm::SmallVector<Value, 8> searchQueue;
+              llvm::SmallPtrSet<Value, 8> searchVis;
+              for (Value mulRes : mulOp->getResults()) {
+                  searchQueue.push_back(mulRes);
+                  searchVis.insert(mulRes);
+              }
+
+              bool findMatch = false;
+              while (!searchQueue.empty()) {
+                  Value checkVal = searchQueue.pop_back_val();
+                  for (Operation* subUser : checkVal.getUsers()) {
+                    if (auto addOp = dyn_cast<arith::AddIOp>(subUser))
+                    {
+                        Value otherOperand = (addOp.getLhs() == checkVal)
+                            ? addOp.getRhs() : addOp.getLhs();
+                    
+                        Value curSrc = otherOperand;
+                        bool hitRange = false;
+                        int depth = 0;
+                        while (curSrc.getDefiningOp() && depth < 5)
+                        {
+                            Operation* defOp = curSrc.getDefiningOp();
+                            if (auto rangeOp = dyn_cast<triton::MakeRangeOp>(defOp))
+                            {
+                                if (rangeOp.getEnd() == blockSize)
+                                {
+                                    hitRange = true;
+                                    break;
+                                }
+                            }
+
+                            if (isa<arith::ExtSIOp, triton::SplatOp,
+                                    triton::ExpandDimsOp, triton::BroadcastOp>(defOp))
+                            {
+                                curSrc = defOp->getOperand(0);
+                                depth++;
+                                continue;
+                            }
+                            break;
+                        }
+                        if (hitRange)
+                        {
+                            findMatch = true;
+                            break;
+                        }
+                    }
+                      if (isa<arith::ExtSIOp, triton::SplatOp,
+                              triton::ExpandDimsOp, triton::BroadcastOp>(subUser)) {
+                          for (Value subRes : subUser->getResults()) {
+                              if (!searchVis.count(subRes)) {
+                                  searchVis.insert(subRes);
+                                  searchQueue.push_back(subRes);
+                              }
+                          }
+                      }
+                  }
+                  if (findMatch) break;
+              }
+              if (findMatch) {
+                  return true;
+              }
+
+              for (Value mulRes : mulOp->getResults()) {
+                  worklist.push_back(mulRes);
+              }
+          }
+
+          if (isa<arith::ExtSIOp, triton::SplatOp, triton::ExpandDimsOp,
+                  triton::BroadcastOp>(user)) {
+              for (Value res : user->getResults()) {
+                  worklist.push_back(res);
+              }
+          }
+      }
+  }
+  return false;
+}
+
+static bool checkAllProgramIdNonOverlap(ModuleOp module)
+{
+  bool allNonOverlap = true;
+  module.walk([&](triton::GetProgramIdOp pidOp){
+    if(!traceUserToTargetOp(pidOp.getResult()))
+    {
+      allNonOverlap = false;
+    }
+  });
+  return allNonOverlap;
+}
+
+
 LogicalResult isDiscreteMask(Operation *op, Value mask,
                              PatternRewriter &rewriter) {
   if (!mask || op->hasAttr(routeDiscreteMaskToSimtAttrName)) {
@@ -348,7 +468,8 @@ DiscreteMaskAccessConversionPass::DiscreteMaskAccessConversionPass(
 void DiscreteMaskAccessConversionPass::runOnOperation() {
   compileOn91095Flag = this->compileOn91095;
   forceSimtTemplateFlag = this->forceSimtTemplate;
-  enableSyncBlockLockFlag = this->enableSyncBlockLock;
+  bool tileNonOverlap = checkAllProgramIdNonOverlap(getOperation());
+  enableSyncBlockLockFlag = !tileNonOverlap;
   auto moduleOp = getOperation();
 
   RewritePatternSet patterns(&getContext());


### PR DESCRIPTION
Add traceUserToTargetOp  func to trace the use-def chains of tt.get_program_id. It verifies that program id are used in a constant multiplication + addition pattern that matches the range from tt.make_range, ensuring non-overlapping memory access between blocks. 
only the type like this: program_id * BLOCK_SIZE + BLOCK_SIZE can be regarded as tile non-overlap, otherwise, it will be regarded as tile overlap, and set the syncblocklock to be true to run test cases serially in discrete mask template.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
