### PR TITLE
fix(TritonToLinalg): empty-input unrealized_conversion_cast on multi-reduce kernels

### DIFF
--- a/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
@@ -157,11 +157,11 @@ public:
                                 PatternRewriter &rewriter) const override;
 };
 
-class ReduceSingleCanonicalizer : public OpRewritePattern<triton::ReduceOp> {
+class ReduceSingleCanonicalizer : public OpConversionPattern<triton::ReduceOp> {
 public:
-  using OpRewritePattern<triton::ReduceOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(triton::ReduceOp reduceOp,
-                                PatternRewriter &rewriter) const override;
+  using OpConversionPattern<triton::ReduceOp>::OpConversionPattern;
+  LogicalResult matchAndRewrite(triton::ReduceOp reduceOp, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override;
 };
 
 class DenseConstantConverter : public OpConversionPattern<arith::ConstantOp> {

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -680,48 +680,62 @@ MakeTensorPtrCanonicalizer::matchAndRewrite(triton::MakeTensorPtrOp op,
   return success();
 }
 
-LogicalResult ReduceSingleCanonicalizer::matchAndRewrite(triton::ReduceOp reduceOp, PatternRewriter &rewriter) const
+LogicalResult ReduceSingleCanonicalizer::matchAndRewrite(
+    triton::ReduceOp reduceOp, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const
 {
     assert(reduceOp.getSrcs().size() <=2 && "Only reduce or reduce with index are supported");
-    auto src = reduceOp.getSrcs()[0];
-    auto srcType = cast<RankedTensorType>(src.getType());
+    auto src = adaptor.getOperands()[0];
+    Value tensorSrc = src;
+    RankedTensorType srcType;
+    if (auto memrefType = dyn_cast<MemRefType>(src.getType())) {
+      tensorSrc = rewriter.create<bufferization::ToTensorOp>(
+          reduceOp.getLoc(), src, /*restrict=*/true)
+          .getResult();
+      srcType = RankedTensorType::get(memrefType.getShape(),
+                                      memrefType.getElementType());
+    } else {
+      srcType = cast<RankedTensorType>(src.getType());
+    }
     auto srcShape = srcType.getShape();
     if (llvm::any_of(srcShape, [](auto s) { return s != 1; }))
       return rewriter.notifyMatchFailure(reduceOp, "reduce's srcs are not all with single element");
     auto loc = reduceOp->getLoc();
 
     // Handle Reduce Value
-    auto res = reduceOp.getResult()[0];
     Value extracted;
     if (srcType.getRank() == 1) {
         auto zero = rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
-        extracted = rewriter.create<tensor::ExtractOp>(loc, src, zero.getResult()).getResult();
+        extracted = rewriter.create<tensor::ExtractOp>(loc, tensorSrc, zero.getResult()).getResult();
     } else {
-        auto resShape = cast<RankedTensorType>(res.getType()).getShape();
-        auto collapseReassociationIndicesOptional = getReassociationIndicesForCollapse(srcShape, resShape);
+        auto resType = cast<RankedTensorType>(reduceOp.getResult()[0].getType());
+        auto collapseReassociationIndicesOptional = getReassociationIndicesForCollapse(srcShape, resType.getShape());
         if (!collapseReassociationIndicesOptional.has_value()) {
             return rewriter.notifyMatchFailure(reduceOp, "Failure with getReassociationIndicesForCollapse call");
         }
         auto collapseReassociationIndices = collapseReassociationIndicesOptional.value();
-        extracted = rewriter.create<tensor::CollapseShapeOp>(loc, src, collapseReassociationIndices).getResult();
+        extracted = rewriter.create<tensor::CollapseShapeOp>(loc, tensorSrc, collapseReassociationIndices).getResult();
     }
-    res.replaceAllUsesWith(extracted);
 
     // Handle Reduce Index
-    if(reduceOp.getSrcs().size() == 1)
+    if(reduceOp.getSrcs().size() == 1) {
+      rewriter.replaceOp(reduceOp, extracted);
       return success();
+    }
 
     auto resIdx = reduceOp.getResult()[1];
     auto zeroI32 = rewriter.create<arith::ConstantOp>(loc, rewriter.getI32IntegerAttr(0));
+    Value indexReplacement;
     if (srcType.getRank() == 1) {
-        resIdx.replaceAllUsesWith(zeroI32);
+        indexReplacement = zeroI32;
     } else {
       auto resIdxShape = cast<RankedTensorType>(resIdx.getType()).getShape();
       auto initTensor = rewriter.create<tensor::EmptyOp>(loc, resIdxShape, rewriter.getI32Type());
       auto fillOp = rewriter.create<linalg::FillOp>(loc, ValueRange{zeroI32}, ValueRange{initTensor});
-      resIdx.replaceAllUsesWith(fillOp.getResult(0));
+      indexReplacement = fillOp.getResult(0);
     }
 
+    rewriter.replaceOp(reduceOp, {extracted, indexReplacement});
     return success();
 }
 

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -153,6 +153,26 @@ TritonTypeConverter::TritonTypeConverter() {
     }
     return MemRefType::get(tensorType.getShape(), elemType);
   });
+
+  addSourceMaterialization(
+      [](OpBuilder &builder, Type resultType, ValueRange inputs,
+         Location loc) -> std::optional<Value> {
+        if (inputs.empty())
+          return std::nullopt;
+        return builder
+            .create<UnrealizedConversionCastOp>(loc, resultType, inputs)
+            .getResult(0);
+      });
+
+  addTargetMaterialization(
+      [](OpBuilder &builder, Type resultType, ValueRange inputs,
+         Location loc) -> std::optional<Value> {
+        if (inputs.empty())
+          return std::nullopt;
+        return builder
+            .create<UnrealizedConversionCastOp>(loc, resultType, inputs)
+            .getResult(0);
+      });
 }
 
 void TritonToLinalgPass::addProgramInfo(triton::FuncOp func,
@@ -577,7 +597,6 @@ void TritonToLinalgPass::populateTritonToLinalgCanonicalizationPatterns(RewriteP
         // TTOpConverters::ScalarMathCanonicalizer<arith::ExtFOp>
         // TTOpConverters::ScalarMathCanonicalizer<arith::TruncFOp>
         >(patterns.getContext());
-    patterns.add<TTOpConverters::ReduceSingleCanonicalizer>(patterns.getContext());
     if (this->enableSelectAnalysis) {
       patterns.add<TTOpConverters::SelectCanonicalizer>(patterns.getContext());
     }
@@ -606,6 +625,7 @@ void TritonToLinalgPass::populateTritonToLinalgConversionPatterns(
   // reduce converters
   patterns.add<TTOpConverters::ArgMinConverter>(patterns.getContext());
   patterns.add<TTOpConverters::ArgMaxConverter>(patterns.getContext());
+  patterns.add<TTOpConverters::ReduceSingleCanonicalizer>(patterns.getContext());
   patterns.add<TTOpConverters::ReduceConverter>(patterns.getContext());
   patterns.add<TTOpConverters::ScanConverter>(patterns.getContext());
   patterns.add<TTOpConverters::ReshapeConverter>(patterns.getContext());
@@ -898,7 +918,10 @@ void TritonToLinalgPass::runOnOperation() {
   });
 
   // 7. Convert ops.
-  if (failed(applyPartialConversion(moduleOp, target, std::move(patterns)))) {
+  mlir::ConversionConfig config;
+  config.buildMaterializations = true;
+  if (failed(applyPartialConversion(moduleOp, target, std::move(patterns),
+                                    config))) {
     moduleOp->emitError("failed to apply Conversion Patterns");
     signalPassFailure();
   }

--- a/third_party/ascend/unittest/pytest_ut/test_two_reduce_offsets.py
+++ b/third_party/ascend/unittest/pytest_ut/test_two_reduce_offsets.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def two_reduce_kernel(a_ptr, b_ptr, out_ptr):
+    """Two tl.sum reductions produce scalar offsets used for pointer arithmetic.
+    Regression test: the second reduce path must not crash with an
+    unrealized_conversion_cast from empty inputs.
+    """
+    offs = tl.arange(0, 1)
+    a = tl.load(a_ptr + offs)
+    b = tl.load(b_ptr + offs)
+
+    off1 = tl.sum(a - b // 2)
+    tmp = tl.load(b_ptr + off1.to(tl.int64))
+
+    off2 = tl.sum(a - b)
+    tl.store(out_ptr + off2.to(tl.int64), tmp)
+
+
+def test_two_reduce_scalar_offsets():
+    d = "npu"
+    t = torch.int64
+
+    # a[0] = 5, b[0] = 2
+    #   r1 = 5 - 2//2 = 4  ->  tmp = b[4] = 40
+    #   r2 = 5 - 2   = 3  ->  out[3] = 40
+    a = torch.tensor([5], dtype=t, device=d)
+    b = torch.tensor([2, 10, 20, 30, 40], dtype=t, device=d)
+    out = torch.zeros(10, dtype=t, device=d)
+
+    two_reduce_kernel[(1,)](a, b, out)
+
+    expected = torch.zeros(10, dtype=t, device=d)
+    expected[3] = 40
+
+    torch.testing.assert_close(out, expected)


### PR DESCRIPTION
This pr fixes scalar `tt.reduce` lowering by moving `ReduceSingleCanonicalizer` from canonicalization to conversion

Problematic IR pattern:
```
%a = tt.load %ptr ... : tensor<1x...>
%r = tt.reduce %a ... : tensor<1x...> -> tensor<...>
```

Before, the reduce could be canonicalized too early into something like:
```
%a = tt.load %ptr ... : tensor<1x...>
%r = tensor.extract %a[...] : tensor<1x...>
```

Then use analysis no longer saw the original `tt.load -> tt.reduce` relation and could treat required load-related ops as unused, causing them to be erased

Keeping this rewrite in conversion preserves `tt.reduce` for analysis. Since it is now a conversion pattern, it uses adaptor operands, which may already be remapped to memref if the producer load was converted first