### PR TITLE
fix(smit): atomic operations using SIMD for better performance

### DIFF
--- a/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
+++ b/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
@@ -295,12 +295,6 @@ struct DiscreteMaskAtomicConversion : OpRewritePattern<mlir::triton::AtomicRMWOp
     if (failed(isDiscreteMask(op, mask, rewriter)))
       return failure();
 
-    if (compileOn91095Flag && forceSimtTemplateFlag &&
-        IndirectAtomicUtils::canUseIndirectAtomicFastPath(op)) {
-      op->setAttr(routeDiscreteMaskToSimtAttrName, rewriter.getUnitAttr());
-      return failure();
-    }
-
     const std::map<RMWOp, TypelessValue> initMap = {
         {RMWOp::FADD, TypelessValue::Zero},
         {RMWOp::ADD, TypelessValue::Zero},


### PR DESCRIPTION
### Performance Test

算子名称 | Input Shapes[0] | Input Data Types[0] | SIMD 耗时 (us) | SIMT 耗时 (us) | ROLLBACK 耗时 (us)
-- | -- | -- | -- | -- | --
struct_ptr_disc_mask_atomic_add_3d | 16,16,16 | INT32 | 3.309 | 81.163 | 4.102
struct_ptr_disc_mask_atomic_max_3d | 16,16,16 | INT32 | 3.406 | 84.499 | 3.607
struct_ptr_disc_mask_atomic_min_3d | 16,16,16 | INT32 | 3.443 | 79.454 | 3.506
struct_ptr_disc_mask_atomic_and_3d | 16,16,16 | INT32 | 4.114 | 96.141 | 4.029
struct_ptr_disc_mask_atomic_or_3d | 16,16,16 | INT32 | 3.790 | 95.451 | 3.894
struct_ptr_disc_mask_atomic_xor_3d | 16,16,16 | INT32 | 3.697 | 96.191 | 4.292
struct_ptr_disc_mask_atomic_add_3d | 16,16,16 | FLOAT | 3.366 | 93.772 | 3.852
struct_ptr_disc_mask_atomic_max_3d | 16,16,16 | FLOAT | 3.509 | 95.249 | 3.569
struct_ptr_disc_mask_atomic_min_3d | 16,16,16 | FLOAT | 3.372 | 92.389 | 3.867

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
