### PR TITLE
[Feature]: Support descriptor scatter op

### DIFF
--- a/third_party/ascend/include/TritonToLinalg/DescriptorConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/DescriptorConverter.h
@@ -70,6 +70,16 @@ public:
                   ConversionPatternRewriter &rewriter) const override;
 };
 
+class DescriptorScatterConverter
+    : public OpConversionPattern<triton::DescriptorScatterOp> {
+public:
+  using OpConversionPattern<triton::DescriptorScatterOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::DescriptorScatterOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override;
+};
+
 } // end of namespace DescriptorConverter
 
 #endif // TRITON_ADAPTER_DESCRIPTORCONVERTER_H

--- a/third_party/ascend/lib/TritonToLinalg/DescriptorConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/DescriptorConverter.cpp
@@ -197,4 +197,68 @@ LogicalResult DescriptorStoreConverter::matchAndRewrite(
   return success();
 }
 
+LogicalResult DescriptorScatterConverter::matchAndRewrite(
+    triton::DescriptorScatterOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+  auto loc = op.getLoc();
+  auto descTy = op.getDesc().getType();
+  auto srcType = cast<RankedTensorType>(op.getSrc().getType());
+  const auto rowBlockShape = descTy.getSignlessBlockType().getShape();
+
+  auto desc = unpackDescriptor(descTy, adaptor.getDesc(), rewriter);
+  SmallVector<int32_t> tensorShapeValues;
+  tensorShapeValues.reserve(rowBlockShape.size());
+  for (auto dim : rowBlockShape) {
+    tensorShapeValues.push_back(static_cast<int32_t>(dim));
+  }
+
+  auto zeroIndex = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  auto oneIndex = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+  Value rowUpperBound;
+  if (srcType.isDynamicDim(0)) {
+    rowUpperBound = rewriter.create<tensor::DimOp>(loc, adaptor.getSrc(), 0);
+  } else {
+    rowUpperBound =
+        rewriter.create<arith::ConstantIndexOp>(loc, srcType.getShape()[0]);
+  }
+  auto rowBoundaryCheck = getFullBoundaryCheckAttr(rewriter, rowBlockShape);
+  auto cacheModifier = triton::CacheModifierAttr::get(
+      rewriter.getContext(), triton::CacheModifier::NONE);
+  auto evictionPolicy = triton::EvictionPolicyAttr::get(
+      rewriter.getContext(), triton::EvictionPolicy::NORMAL);
+
+  auto loop = rewriter.create<scf::ForOp>(
+      loc, zeroIndex, rowUpperBound, oneIndex, ValueRange{},
+      [&](OpBuilder &nestedBuilder, Location nestedLoc, Value rowIv,
+          ValueRange) {
+        Value xOffset = nestedBuilder.create<tensor::ExtractOp>(
+            nestedLoc, adaptor.getXOffsets(), ValueRange{rowIv});
+        Value tensorPtr = nestedBuilder.create<triton::MakeTensorPtrOp>(
+            nestedLoc, desc.base, desc.shape, desc.strides,
+            ValueRange{xOffset, adaptor.getYOffset()}, tensorShapeValues,
+            computeOrder(rowBlockShape));
+        SmallVector<OpFoldResult> extractOffsets{rowIv,
+                                                 nestedBuilder.getIndexAttr(0)};
+        SmallVector<OpFoldResult> extractSizes{
+            nestedBuilder.getIndexAttr(rowBlockShape[0]),
+            nestedBuilder.getIndexAttr(rowBlockShape[1])};
+        SmallVector<OpFoldResult> extractStrides{nestedBuilder.getIndexAttr(1),
+                                                 nestedBuilder.getIndexAttr(1)};
+        auto rowValue = nestedBuilder.create<tensor::ExtractSliceOp>(
+            nestedLoc, adaptor.getSrc(), extractOffsets, extractSizes,
+            extractStrides);
+        auto rowStore = nestedBuilder.create<triton::StoreOp>(
+            nestedLoc, tensorPtr, rowValue.getResult(), Value(),
+            rowBoundaryCheck, cacheModifier, evictionPolicy);
+        rowStore->setAttr(ConverterUtils::discreteAttrName,
+                          nestedBuilder.getUnitAttr());
+        nestedBuilder.create<scf::YieldOp>(nestedLoc);
+      });
+  loop->setAttr("ExtractedLoadOrStore", rewriter.getUnitAttr());
+  loop->setAttr("hivm.parallel_loop", rewriter.getUnitAttr());
+
+  rewriter.eraseOp(op);
+  return success();
+}
+
 } // namespace DescriptorConverter

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -681,6 +681,7 @@ LogicalResult
 TritonToLinalgPass::processDescriptorOperations(ModuleOp moduleOp) {
   // --- ConversionTarget: dynamic legality checks ---
   mlir::ConversionTarget target(getContext());
+  target.addLegalDialect<mlir::tensor::TensorDialect>();
 
   // Dialect-level dynamic legality: ops are legal if none of their
   // operands/results use TensorDescType.
@@ -701,13 +702,16 @@ TritonToLinalgPass::processDescriptorOperations(ModuleOp moduleOp) {
                funcOp.getFunctionType().getResults());
   });
   target.addLegalOp<triton::MakeTensorDescOp>();
-  target.addIllegalOp<triton::DescriptorLoadOp, triton::DescriptorStoreOp>();
+  target.addIllegalOp<triton::DescriptorLoadOp, triton::DescriptorStoreOp,
+                      triton::DescriptorScatterOp>();
 
   // --- Patterns ---
   mlir::RewritePatternSet patterns(&getContext());
   patterns.add<DescriptorConverter::DescriptorLoadConverter>(
       patterns.getContext());
   patterns.add<DescriptorConverter::DescriptorStoreConverter>(
+      patterns.getContext());
+  patterns.add<DescriptorConverter::DescriptorScatterConverter>(
       patterns.getContext());
 
   mlir::ConversionConfig config;

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_parse_descriptor_scatter.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_parse_descriptor_scatter.mlir
@@ -1,0 +1,37 @@
+// RUN: triton-opt --triton-to-linalg --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: func.func @tensor_descriptor_scatter_rows_kernel
+// CHECK-NOT: tt.descriptor_scatter
+// CHECK: %[[C128:.*]] = arith.constant 128 : index
+// CHECK: scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}}
+// CHECK: %[[XOFFSET:.*]] = tensor.extract %{{.*}}[%{{.*}}] : tensor<32xi32>
+// CHECK: %[[BASE:.*]] = arith.muli %{{.*}}, %[[C128]] : index
+// CHECK: %[[VIEW:.*]] = memref.reinterpret_cast %{{.*}} to offset: [%{{.*}}], sizes: [1, 32], strides: [128, 1]
+// CHECK: %[[ROW:.*]] = tensor.extract_slice %{{.*}}[%{{.*}}, 0] [1, 32] [1, 1] : tensor<32x32xf32> to tensor<1x32xf32>
+// CHECK: %[[SUBVIEW:.*]] = memref.subview %[[VIEW]]
+// CHECK: bufferization.materialize_in_destination %{{.*}} in writable %[[SUBVIEW]]
+
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @tensor_descriptor_scatter_rows_kernel(%out_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %in_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %idx_ptr: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %y: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %desc = arith.constant 1 : i64
+    %desc_0 = arith.constant 128 : i64
+    %c128_i32 = arith.constant 128 : i32
+    %data = arith.constant dense<32> : tensor<32x1xi32>
+    %idx = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %idx_1 = tt.splat %idx_ptr : !tt.ptr<i32> -> tensor<32x!tt.ptr<i32>>
+    %idx_2 = tt.addptr %idx_1, %idx : tensor<32x!tt.ptr<i32>>, tensor<32xi32>
+    %idx_3 = tt.load %idx_2 : tensor<32x!tt.ptr<i32>>
+    %data_4 = tt.expand_dims %idx {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+    %data_5 = arith.muli %data_4, %data : tensor<32x1xi32>
+    %data_6 = tt.splat %in_ptr : !tt.ptr<f32> -> tensor<32x1x!tt.ptr<f32>>
+    %data_7 = tt.addptr %data_6, %data_5 : tensor<32x1x!tt.ptr<f32>>, tensor<32x1xi32>
+    %data_8 = tt.expand_dims %idx {axis = 0 : i32} : tensor<32xi32> -> tensor<1x32xi32>
+    %data_9 = tt.broadcast %data_7 : tensor<32x1x!tt.ptr<f32>> -> tensor<32x32x!tt.ptr<f32>>
+    %data_10 = tt.broadcast %data_8 : tensor<1x32xi32> -> tensor<32x32xi32>
+    %data_11 = tt.addptr %data_9, %data_10 : tensor<32x32x!tt.ptr<f32>>, tensor<32x32xi32>
+    %data_12 = tt.load %data_11 : tensor<32x32x!tt.ptr<f32>>
+    %desc_13 = tt.make_tensor_descriptor %out_ptr, [%c128_i32, %c128_i32], [%desc_0, %desc] : <f32>, <tensor<1x32xf32>>
+    tt.descriptor_scatter %desc_13[%idx_3, %y], %data_12 : !tt.tensordesc<tensor<1x32xf32>>, tensor<32xi32>, i32, tensor<32x32xf32>
+    tt.return
+  }
+}

--- a/third_party/ascend/unittest/pytest_ut/test_tensor_descriptor.py
+++ b/third_party/ascend/unittest/pytest_ut/test_tensor_descriptor.py
@@ -223,3 +223,45 @@ def test_tensor_descriptor_padding(dtype, padding):
         expected[IM:OM, :] = float('nan')
 
     torch.testing.assert_close(expected, out_device_tma, equal_nan=True)
+
+
+@pytest.mark.parametrize("X, Y", [(128, 128), (64, 256)])
+@pytest.mark.parametrize("BLOCK_X, BLOCK_Y", [(32, 32), (64, 128), (16, 128), (512, 16)])
+@pytest.mark.parametrize("dtype", ['float32', 'float16', 'bfloat16', 'int32'])
+@pytest.mark.parametrize("y", [0, 32, 48])
+def test_tensor_descriptor_scatter(X, Y, BLOCK_X, BLOCK_Y, dtype, y):
+
+    def torch_scatter_rows(input, idx, y, block_y, X, Y):
+        out = torch.zeros((X, Y), dtype=input.dtype, device=input.device)
+        for i, j in enumerate(idx):
+            out[j][y:y + block_y] = input[i]
+        return out
+
+    @triton.jit
+    def tensor_descriptor_scatter_rows_kernel(out_ptr, in_ptr, idx_ptr, y, X: tl.constexpr, Y: tl.constexpr,
+                                              BLOCK_X: tl.constexpr, BLOCK_Y: tl.constexpr):
+        idx = tl.load(idx_ptr + tl.arange(0, BLOCK_X))
+        data = tl.load(in_ptr + tl.arange(0, BLOCK_X)[:, None] * BLOCK_Y + tl.arange(0, BLOCK_Y)[None, :])
+        desc = tl.make_tensor_descriptor(out_ptr, [X, Y], [Y, 1], [1, BLOCK_Y])
+        desc.scatter(data, idx, y)
+
+    device = 'npu'
+    if BLOCK_X > X or y + BLOCK_Y > Y:
+        pytest.skip()
+
+    torch.manual_seed(42)
+    torch_dtype = getattr(torch, dtype)
+    input_tensor = torch.arange(BLOCK_X * BLOCK_Y, dtype=torch_dtype, device=device).reshape(BLOCK_X, BLOCK_Y)
+    output = torch.zeros((X, Y), dtype=torch_dtype, device=device)
+
+    idx = torch.randperm(BLOCK_X, dtype=torch.int32, device=device)
+
+    def alloc_fn(size: int, align: int, stream):
+        return torch.empty(size, dtype=torch.int8, device=device)
+
+    triton.set_allocator(alloc_fn)
+
+    tensor_descriptor_scatter_rows_kernel[(1, )](output, input_tensor, idx, y, X, Y, BLOCK_X, BLOCK_Y)
+
+    ref = torch_scatter_rows(input_tensor, idx, y, BLOCK_Y, X, Y)
+    torch.testing.assert_close(ref, output, atol=0, rtol=0)


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
## Related Issue
https://github.com/triton-lang/triton-ascend/issues/71
## Background

After the upstream upgrade, the community introduced a new `descriptor_scatter` op. The current Ascend backend does not yet support lowering for `descriptor_scatter`, so this change adds backend support for the new tensor descriptor scatter functionality.

## Feature Overview

`descriptor scatter` is used to write a 2D input block back to selected rows of a target tensor based on a 2D tensor descriptor, using a given set of row indices and a shared column offset. Each write updates one contiguous 1D block in the column dimension.

## Interface

| Parameter   | Type                         | Required | Description                                                  |
| ----------- | ---------------------------- | -------- | ------------------------------------------------------------ |
| src         | 2D tensor                    | Yes      | Source data block to be written back, where each row corresponds to one scatter source row |
| `x_offsets` | 1D tensor / row index vector | Yes      | Target row indices for scatter. The i-th row of src is written to the [x_offsets[j\]]-th row of the destination tensor |
| `y_offset`  | scalar integer               | Yes      | Shared starting offset in the column dimension. All scattered rows start writing from this column position |

## Changes

1. Add DescriptorScatterConverter to provide a dedicated lowering path for `tt.descriptor_scatter`.
2. Implement scatter lowering using a row-wise `tensor.extract_slice + MakeTensorPtrOp + triton::StoreOp` scheme.

## Constraints

1. This only applies to 2D tensor descriptor.
2. The basic scatter unit is one contiguous row block.
3. Each value in `x_offsets` must fall within the valid row range of the destination tensor.
4. `y_offset` and the corresponding column block write range must satisfy column boundary constraints.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
