### PR TITLE
docs(api): tl.load / tl.store — cache_modifier + volatile on A5 SIMT-only

### DIFF
--- a/docs/zh/triton_api/Memory_Pointer_Ops/tl.load.md
+++ b/docs/zh/triton_api/Memory_Pointer_Ops/tl.load.md
@@ -31,12 +31,12 @@ triton.language.load(
 | `other`     | `tensor` 或`scalar`   | 可选参数，当且仅当`mask!=None`时可传入<br> 若`mask[i]==False` ，将返回值的第`i`个位置设置为`other[i]`或`other`（若`other`是`scalar`类型）, 需要支持tensor，因为tritonGPU社区上是tensor和scalar都支持的，other[]] = mask[i]|
 | `boundary_check` | `tuple(int)` | 可选参数，当且仅当`pointer`来源于`tl.make_block_ptr`时可传入<br>整数元组，指示需要做边界检查的维度                                         |
 | `padding_option`   | `""`或`"zero"`或`"nan"`               | 可选参数，当且仅当`boundary_check`不为空时可传入<br>表示访问越界时填充的值 |
-| `cache_modifier`   | `""` 或 `"ca"`或`"cg"`                | 可选参数，控制NVIDIA PTX上的cache选项，对Ascend硬件无效                                                |
+| `cache_modifier`   | `""` 或 `"ca"`或`"cg"`或`"cv"`        | 可选参数，控制cache 行为。Ascend A5 SIMT-only 模式下支持：`""`/`"ca"` → 走 cache（CA），`"cg"`/`"cv"` → 绕过 cache（NCA）。**硬件粒度仅 cache / uncache 两级**，不实现 Triton 上游全部细分（.ca/.cg/.cv）。全局内存生效；共享内存忽略（硬件不支持）。A2/A3 / 非 SIMT-only 模式对硬件无效。 |
 | `eviction_policy`   | `str`                | 控制NVIDIA PTX的eviction策略， 对Ascend硬件无效                                                |
-| `volatile`   | `str`                 | 控制NVIDIA PTX的volatile选项， 对Ascend硬件无效                                        |
+| `volatile`   | `bool`                | 控制 volatile 内存语义，保证内存序、禁止编译器/硬件优化掉 load。Ascend A5 SIMT-only 模式下支持（全局内存与共享内存均生效）；A2/A3 / 非 SIMT-only 模式对硬件无效。 |
 | `_semantic`   | -                 | 保留参数，暂不支持外部调用                                                |
 
-当前910代际均还不支持cache_modifier，eviction_policy， volatile等参数
+**Ascend A5 / SIMT-only 路径已支持 `cache_modifier` 与 `volatile`**（详见参数表）；A2/A3 上 cache_modifier / eviction_policy / volatile 暂不支持。`eviction_policy` 整体对 Ascend 硬件无效。
 
 ### 2.2 支持规格
 

--- a/docs/zh/triton_api/Memory_Pointer_Ops/tl.store.md
+++ b/docs/zh/triton_api/Memory_Pointer_Ops/tl.store.md
@@ -28,7 +28,7 @@ triton.language.store(
 | `value`       | `tensor` 或 `scalar`  | 要存储的值，支持隐式广播和隐式类型转换  |
 | `mask`       | `int1`或`tensor<int1>`    | 可选参数，当且仅当`pointer` 不来源于`tl.make_block_ptr`时可传入<br>若`mask[i]==False` ，则不会将`value[i]`存储到`pointer[i]`指向的地址,是`True`则正常存储 <br>若`pointer`来源于`tl.make_block_ptr`，则`mask`必须是`None`                                        |
 | `boundary_check` | `tuple(int)` | 可选参数，当且仅当`pointer`来源于`tl.make_block_ptr`时可传入<br>整数元组，指示需要做边界检查的维度                                         |
-| `cache_modifier`   | `""` 或 `"ca"`或`"cg"`                | 可选参数，控制NVIDIA PTX上的cache选项，对Ascend硬件无效                                                |
+| `cache_modifier`   | `""` 或 `"cg"`或`"wb"`或`"cs"`或`"wt"` | 可选参数，控制cache 行为。Ascend A5 SIMT-only 模式下支持：`""`/`"wb"` → 走 cache（CA），`"cg"`/`"cs"`/`"wt"` → 绕过 cache（NCA）。**硬件粒度仅 cache / uncache 两级**，不实现 Triton 上游全部细分（.wb/.cg/.cs/.wt）。全局内存生效；共享内存忽略（硬件不支持）。A2/A3 / 非 SIMT-only 模式对硬件无效。 |
 | `eviction_policy`   | `str`                | 控制NVIDIA PTX的eviction策略， 对Ascend硬件无效                                                |
 | `_semantic`   | -                 | 保留参数，暂不支持外部调用                                                |
 
@@ -44,7 +44,7 @@ triton.language.store(
 | Ascend A2/A3 | √    | √     | √     | ×     | ×      | ×      | ×      | √     | √    | √    | ×    | √    |  √    |
 
 结论：Ascend 对比 GPU 缺失uint8、uint16、uint32、uint64、fp64的支持能力（硬件限制）。
-专家意见：eviction_policy和cache_modifier参见load
+专家意见：eviction_policy 与 cache_modifier 详见 `tl.load.md`；Ascend A5 SIMT-only 模式下 `cache_modifier` 已支持（cache / uncache 两级），`eviction_policy` 整体不支持。
 
 #### 2.2.2 Shape 支持
 
@@ -72,7 +72,7 @@ triton.language.store(
 
 > 相对社区能力缺失且无法实现
 
-Ascend 对比 GPU 缺失uint8、uint16、uint32、uint64、fp64的支持能力（硬件限制）, eviction_policy和cache_modifier在NPU上功能还不完善。
+Ascend 对比 GPU 缺失uint8、uint16、uint32、uint64、fp64的支持能力（硬件限制）。`cache_modifier` 在 A5 SIMT-only 模式下已支持 cache / uncache 两级映射；`eviction_policy` 整体不支持。
 
 | 差异点                                 | 描述                                                         | 解决途径                       |
 | -------------------------------------- | ------------------------------------------------------------ | ------------------------------ |


### PR DESCRIPTION
## Summary
Port of [#124](https://github.com/triton-lang/triton-ascend/pull/124) to `release/3.2.2`.

The Ascend A5 SIMT-only path lowers Triton's `cache_modifier` and `volatile` modifiers to the downstream DPX `cacheModifier` + `volatileOption` attributes carried by `ascend_dpx.{load,store}`. The docs previously said both modifiers were *对 Ascend 硬件无效* / *still unsupported on 910*; this PR refreshes both pages to reflect the new support contract.

## Changes
- **`docs/zh/triton_api/Memory_Pointer_Ops/tl.load.md`** — `cache_modifier` enumerates `""`/`"ca"`/`"cg"`/`"cv"` with the cache↔CA, uncache↔NCA two-level mapping (global memory effective, shared memory ignored). `volatile` retyped `str` → `bool` and marked supported on A5 SIMT-only. Summary line refreshed.
- **`docs/zh/triton_api/Memory_Pointer_Ops/tl.store.md`** — same treatment, with the store-side modifiers `""`/`"wb"`/`"cg"`/`"cs"`/`"wt"`. 专家意见 + 特殊限制 sections updated.

## Notes
- **No code changes; docs only.** Diff matches PR #124 byte-for-byte (verified).
- **EN counterparts do not exist** — `docs/en/triton_api/Memory_Pointer_Ops/` is absent on both `main` and `release/3.2.2`; the API reference tree is ZH-only, so nothing to mirror on the EN side.
- Compiler-side support lands in NPUIR via the SR281 lit tests at `Ascend/AscendNPU-IR-Dev#1056` (cache-option-cg-volatile.mlir, cache-option-cv.mlir, shared_mem_modifiers.mlir).