### PR TITLE
Merge/ecouple launcher aten 2 release 3.2.2

### DIFF
--- a/docs/zh/environment_variable_reference.md
+++ b/docs/zh/environment_variable_reference.md
@@ -28,7 +28,6 @@
 | **编译控制** | TRITON_ASCEND_COMPILE_SPEED_OPT | 0 或未设置 | 控制JIT编译器在发现内核编译失败后是否跳过后续编译阶段。设为`1`跳过（默认`0`继续尝试）。 | 0：继续尝试<br>1：跳过 | |
 | **编译控制** | TRITON_COMPILE_ONLY | 0 或未设置 | remote_launch时使用，只编译不运行。 | 0：不启用<br>1：启用 | |
 | **编译控制** | TRITON_DISABLE_FFTS | 0 或未设置 | 是否禁用FFTS。 | 0：启用<br>1：禁用 | |
-| **编译控制** | TRITON_DISABLE_PRECOMPILE | 0 或未设置 | 是否禁用预编译。                                                                                                                                                                                                                                                                                  | 0：使能预编译<br>1：禁用预编译                                                                               | |
 | **运行与调度** | TRITON_ALL_BLOCKS_PARALLEL | 0 或未设置 | 启用或禁用自动根据物理核数优化逻辑核数，仅当逻辑核间可并行时方可启动。当逻辑核数大于物理核数时，启动该优化，则编译器自动调整逻辑核数量为物理核数，减少调度开销；使能后允许grid>65535。限制：triton kernel的逻辑必须对执行顺序不敏感才能开启该选项，否则可能会导致死锁。 | 0：不启用<br>1：启用 | |
 | **运行与调度** | TRITON_ENABLE_TASKQUEUE | 0 或未设置 | 是否开启task_queue。 | 0：不启用<br>1：启用 | |
 | **运行与调度** | TRITON_ENABLE_SANITIZER | 0 或未设置 | 是否使能SANITIZER。 | 0：不启用<br>1：启用 | |

--- a/third_party/ascend/backend/backend_register.py
+++ b/third_party/ascend/backend/backend_register.py
@@ -179,7 +179,7 @@ def get_tensor_params_shape(*args):
 
 
 @backend_strategy_registry.register("mindspore", "get_cc_cmd")
-def get_cc_cmd(build_pch):
+def get_cc_cmd():
     import mindspore
     mindspore_path = os.path.dirname(os.path.realpath(mindspore.__file__))
     cc_cmd = [
@@ -196,17 +196,14 @@ def get_cc_cmd(build_pch):
         f"-I{os.path.join(mindspore_path, 'include/mindspore/ops/include')}",
         f"-D_GLIBCXX_USE_CXX11_ABI={get_mindspore_cxx_abi()}",
         "-DENABLE_FAST_HASH_TABLE=1",
+        f"-L{os.path.join(mindspore_path, 'lib')}",
+        f"-lmindspore_pynative_utils",
     ]
-    if not build_pch:
-        cc_cmd += [
-                f"-L{os.path.join(mindspore_path, 'lib')}",
-                f"-lmindspore_pynative_utils",
-            ]
     return cc_cmd
 
 
 @backend_strategy_registry.register("torch_npu", "get_cc_cmd")
-def get_cc_cmd(build_pch):
+def get_cc_cmd():
     import torch
     import torch_npu
     torch_path = os.path.dirname(os.path.realpath(torch.__file__))
@@ -215,12 +212,9 @@ def get_cc_cmd(build_pch):
         f"-I{os.path.join(torch_path, 'include')}",
         f"-I{os.path.join(torch_npu_path, 'include')}",
         f"-D_GLIBCXX_USE_CXX11_ABI={get_torch_cxx_abi()}",
+        f"-L{os.path.join(torch_npu_path, 'lib')}",
+        f"-ltorch_npu",
     ]
-    if not build_pch:
-        cc_cmd += [
-            f"-L{os.path.join(torch_npu_path, 'lib')}",
-            f"-ltorch_npu",
-        ]
     return cc_cmd
 
 

--- a/third_party/ascend/backend/backend_register.py
+++ b/third_party/ascend/backend/backend_register.py
@@ -304,7 +304,7 @@ def allocate_memory(size, stream):
 @backend_strategy_registry.register("mindspore", "allocate_sync_block_lock")
 def allocate_sync_block_lock(size, stream):
     return f'''auto sync_ptr = std::make_shared<mindspore::kernel::pyboost::MemBlock>(device_context, {size}, reinterpret_cast<uint64_t>({stream}));
-    syncBlockLock_ptr = work_ptr->ptr_;'''
+    syncBlockLock_ptr = sync_ptr->ptr_;'''
 
 
 @backend_strategy_registry.register("torch_npu", "allocate_sync_block_lock")

--- a/third_party/ascend/backend/backend_register.py
+++ b/third_party/ascend/backend/backend_register.py
@@ -204,6 +204,14 @@ def get_cc_cmd():
 
 @backend_strategy_registry.register("torch_npu", "get_cc_cmd")
 def get_cc_cmd():
+    return [
+        f"-D_GLIBCXX_USE_CXX11_ABI={get_torch_cxx_abi()}",
+        "-ldl",
+    ]
+
+
+@backend_strategy_registry.register("torch_npu", "get_cc_cmd_npu_utils")
+def get_cc_cmd_npu_utils():
     import torch
     import torch_npu
     torch_path = os.path.dirname(os.path.realpath(torch.__file__))
@@ -214,6 +222,7 @@ def get_cc_cmd():
         f"-D_GLIBCXX_USE_CXX11_ABI={get_torch_cxx_abi()}",
         f"-L{os.path.join(torch_npu_path, 'lib')}",
         f"-ltorch_npu",
+        "-DUSE_TORCH_NPU",
     ]
     return cc_cmd
 

--- a/third_party/ascend/backend/backend_register.py
+++ b/third_party/ascend/backend/backend_register.py
@@ -298,7 +298,7 @@ def allocate_memory(size, stream):
 
 @backend_strategy_registry.register("torch_npu", "allocate_memory")
 def allocate_memory(size, stream):
-    return f"init_npu_utils(); workspace_addr_ptr = g_allocate_workspace({size});"
+    return f"init_npu_utils(); workspace_addr_ptr = g_allocate_workspace({size}, &workspace_handle);"
 
 
 @backend_strategy_registry.register("mindspore", "allocate_sync_block_lock")
@@ -309,7 +309,7 @@ def allocate_sync_block_lock(size, stream):
 
 @backend_strategy_registry.register("torch_npu", "allocate_sync_block_lock")
 def allocate_sync_block_lock(size, stream):
-    return f"init_npu_utils(); syncBlockLock_ptr = g_allocate_sync_block_lock({size}, {stream});"
+    return f"init_npu_utils(); syncBlockLock_ptr = g_allocate_sync_block_lock({size}, {stream}, &syncBlockLock_handle);"
 
 
 @backend_strategy_registry.register("mindspore", "pre_launch")

--- a/third_party/ascend/backend/backend_register.py
+++ b/third_party/ascend/backend/backend_register.py
@@ -284,9 +284,7 @@ def header_file(enable_taskqueue):
 
 @backend_strategy_registry.register("torch_npu", "header_file")
 def header_file(enable_taskqueue):
-    return f'''#include <ATen/ATen.h>
-#include <torch_npu/csrc/core/npu/NPUWorkspaceAllocator.h>
-{'#include <torch_npu/csrc/framework/OpCommand.h>' if {enable_taskqueue} else ''}'''
+    return '#include <dlfcn.h>\n#include <functional>'
 
 
 @backend_strategy_registry.register("mindspore", "allocate_memory")
@@ -297,7 +295,7 @@ def allocate_memory(size, stream):
 
 @backend_strategy_registry.register("torch_npu", "allocate_memory")
 def allocate_memory(size, stream):
-    return f"workspace_addr_ptr = const_cast<void *>(at::empty({size}, at::TensorOptions().device(at::kPrivateUse1).dtype(at::kByte)).storage().data());"
+    return f"init_npu_utils(); workspace_addr_ptr = g_allocate_workspace({size});"
 
 
 @backend_strategy_registry.register("mindspore", "allocate_sync_block_lock")
@@ -308,7 +306,7 @@ def allocate_sync_block_lock(size, stream):
 
 @backend_strategy_registry.register("torch_npu", "allocate_sync_block_lock")
 def allocate_sync_block_lock(size, stream):
-    return f"syncBlockLock_ptr = const_cast<void *>(at_npu::native::allocate_workspace({size}, {stream}).storage().data());"
+    return f"init_npu_utils(); syncBlockLock_ptr = g_allocate_sync_block_lock({size}, {stream});"
 
 
 @backend_strategy_registry.register("mindspore", "pre_launch")
@@ -332,5 +330,4 @@ def async_launch(func):
 
 @backend_strategy_registry.register("torch_npu", "async_launch")
 def async_launch(func):
-    return f'''at_npu::native::OpCommand cmd;
-    cmd.Name(name.c_str()).SetCustomHandler({func}).Run();'''
+    return f"init_npu_utils(); g_async_launch(static_cast<void*>(&{func}), name.c_str());"

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -310,8 +310,11 @@ def generate_npu_wrapper_src(constants, signature, metadata):
     import os
     workspace_size = int(metadata.workspace_size) \
                           if hasattr(metadata, 'workspace_size') else -1
-    lock_init_value = int(metadata.lock_init_value) \
-                          if hasattr(metadata, 'lock_init_value') else 0
+    lock_init_value = int(
+        metadata.lock_init_value if hasattr(metadata, 'lock_init_value')
+        else metadata.lock_init_val if hasattr(metadata, 'lock_init_val')
+        else 0
+    )
     lock_num = int(metadata.lock_num) \
                           if hasattr(metadata, 'lock_num') else -1
     bs_task_type = metadata.bs_task_type if hasattr(metadata, 'bs_task_type') else 0

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -59,7 +59,7 @@ class NPUUtils(object):
         cache = get_cache_manager(key)
         fname = "npu_utils.so"
         cache_path = cache.get_file(fname)
-        if cache_path is None:
+        if cache_path is None or not os.path.exists(cache_path):
             with tempfile.TemporaryDirectory() as tmpdir:
                 tmp_src_path = os.path.join(tmpdir, "npu_utils.cpp")
                 with open(tmp_src_path, "w") as f:
@@ -113,8 +113,6 @@ class NPULauncher(object):
         signature = {cst_key(key): value for key, value in src.signature.items()}
         wrapper_src = generate_npu_wrapper_src(constants, signature, metadata)
         so_launcher_path = make_npu_launcher_stub(header_src, wrapper_src, metadata.debug)
-        npu_utils_inst = NPUUtils()
-        os.environ["TRITON_NPU_UTILS_SO_PATH"] = npu_utils_inst.npu_utils_mod.__file__
         # setup for remote run
         # TODO: use a var to pack all vars required to run on a remote machine
         self.mix_mode = metadata.mix_mode
@@ -533,7 +531,9 @@ def generate_npu_wrapper_src(constants, signature, metadata):
     sync_lock_fail_code = 'fprintf(stderr, "Error: syncBlockLock allocation failed\\n"); return;'
     workspace_fail_code = 'fprintf(stderr, "Error: workspace allocation failed\\n"); return;'
 
-    cpp_npu_utils_dlopen = """
+    npu_utils_inst = NPUUtils()
+    npu_utils_so_path = npu_utils_inst.npu_utils_mod.__file__
+    cpp_npu_utils_dlopen = f"""
 typedef void* (*triton_allocate_workspace_t)(uint64_t);
 typedef void* (*triton_allocate_sync_block_lock_t)(uint64_t, void*);
 typedef void  (*triton_async_launch_t)(void*, const char*);
@@ -542,22 +542,18 @@ static triton_allocate_workspace_t g_allocate_workspace = nullptr;
 static triton_allocate_sync_block_lock_t g_allocate_sync_block_lock = nullptr;
 static triton_async_launch_t g_async_launch = nullptr;
 
-static void init_npu_utils() {
+static void init_npu_utils() {{
     if (g_allocate_workspace) return;
-    const char* so_path = getenv("TRITON_NPU_UTILS_SO_PATH");
-    if (!so_path) {
-        fprintf(stderr, "Error: TRITON_NPU_UTILS_SO_PATH not set\\n");
-        return;
-    }
+    const char* so_path = "{npu_utils_so_path}";
     void* handle = dlopen(so_path, RTLD_LAZY);
-    if (!handle) {
+    if (!handle) {{
         fprintf(stderr, "Error: dlopen %s failed: %s\\n", so_path, dlerror());
         return;
-    }
+    }}
     g_allocate_workspace = (triton_allocate_workspace_t)dlsym(handle, "triton_allocate_workspace");
     g_allocate_sync_block_lock = (triton_allocate_sync_block_lock_t)dlsym(handle, "triton_allocate_sync_block_lock");
     g_async_launch = (triton_async_launch_t)dlsym(handle, "triton_async_launch");
-}
+}}
 """
 
     cpp_device_pointer = """

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -73,7 +73,9 @@ class NPUUtils(object):
         # setup for remote run
         env_arch = get_ascend_arch_from_env()
 
-    def load_binary(self, name, kernel, shared, device, mix_mode):
+    def load_binary(self, name, kernel, shared, device, mix_mode=None):
+        if mix_mode is None:
+            name, mix_mode = name.rsplit("_", 1)
         return self.npu_utils_mod.load_kernel_binary(name, kernel, shared, device, mix_mode)
 
     @functools.lru_cache()
@@ -443,13 +445,15 @@ def generate_npu_wrapper_src(constants, signature, metadata):
     npu_utils_inst = NPUUtils()
     npu_utils_so_path = npu_utils_inst.npu_utils_mod.__file__
     cpp_npu_utils_dlopen = f"""
-typedef void* (*triton_allocate_workspace_t)(uint64_t);
-typedef void* (*triton_allocate_sync_block_lock_t)(uint64_t, void*);
+typedef void* (*triton_allocate_workspace_t)(uint64_t, void**);
+typedef void* (*triton_allocate_sync_block_lock_t)(uint64_t, void*, void**);
 typedef void  (*triton_async_launch_t)(void*, const char*);
+typedef void  (*triton_release_retained_tensor_t)(void*);
 
 static triton_allocate_workspace_t g_allocate_workspace = nullptr;
 static triton_allocate_sync_block_lock_t g_allocate_sync_block_lock = nullptr;
 static triton_async_launch_t g_async_launch = nullptr;
+static triton_release_retained_tensor_t g_release_retained_tensor = nullptr;
 
 static void init_npu_utils() {{
     if (g_allocate_workspace) return;
@@ -462,6 +466,16 @@ static void init_npu_utils() {{
     g_allocate_workspace = (triton_allocate_workspace_t)dlsym(handle, "triton_allocate_workspace");
     g_allocate_sync_block_lock = (triton_allocate_sync_block_lock_t)dlsym(handle, "triton_allocate_sync_block_lock");
     g_async_launch = (triton_async_launch_t)dlsym(handle, "triton_async_launch");
+    g_release_retained_tensor = (triton_release_retained_tensor_t)dlsym(handle, "triton_release_retained_tensor");
+}}
+
+static void release_npu_tensor_handle(void* handle) {{
+    if (!handle) return;
+    if (!g_release_retained_tensor) {{
+        fprintf(stderr, "Error: triton_release_retained_tensor is unavailable\\n");
+        return;
+    }}
+    g_release_retained_tensor(handle);
 }}
 """
 
@@ -690,6 +704,7 @@ extern "C" {
 #include <assert.h>
 #include <stdbool.h>
 #include <string>
+#include <memory>
 #include <sys/syscall.h>
 #include <vector>
 #include <Python.h>
@@ -722,13 +737,19 @@ static void _launch(const char* kernelName, const void* func, rtStream_t stream,
   std::string name = "";
   name.append(kernelName);
   void *workspace_addr_ptr = NULL;
+  void *workspace_handle = NULL;
   uint32_t blockNum4Workspace = gridX * gridY * gridZ;
   {get_backend_func("pre_launch", True)}
   {f'''
   uint64_t totalWorkSpaceSize = {workspace_size} * blockNum4Workspace;
   {get_backend_func("allocate_memory", "totalWorkSpaceSize", "stream")}
+  std::shared_ptr<void> workspace_handle_guard(workspace_handle, release_npu_tensor_handle);
+  if (!workspace_addr_ptr) {{
+    {workspace_fail_code}
+  }}
   ''' if workspace_size > 0 else ''}
   {'std::function<rtError_t()> launch_call = [=]() -> rtError_t' if enable_taskqueue else ''} {{
+    {f'(void)workspace_handle_guard;' if workspace_size > 0 else ''}
     {get_backend_func("pre_launch", False)}
     uint32_t blockNum = gridX * gridY * gridZ;
 
@@ -750,10 +771,12 @@ static void _launch(const char* kernelName, const void* func, rtStream_t stream,
     {'if (ret != RT_ERROR_NONE) return ret;' if (target_support_ffts and enable_taskqueue) else 'if (ret != RT_ERROR_NONE) return;' if (target_support_ffts and (not enable_taskqueue)) else ''}
     // stub argument for workspace
     void *syncBlockLock_ptr = NULL;
+    void *syncBlockLock_handle = NULL;
     uint16_t ModuleId = 0;
     {f'''
     uint64_t syncBlockLockSize = {lock_num} * sizeof(int64_t);
     {get_backend_func("allocate_sync_block_lock", "syncBlockLockSize", "stream")}
+    std::shared_ptr<void> syncBlockLock_handle_guard(syncBlockLock_handle, release_npu_tensor_handle);
     if (!syncBlockLock_ptr) {{
       {alloc_success_code if enable_taskqueue else sync_lock_fail_code}
     }}

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -54,7 +54,8 @@ class NPUUtils(object):
         dirname = os.path.dirname(os.path.realpath(__file__))
         src_path = os.path.join(dirname, "npu_utils.cpp")
         src = Path(src_path).read_text()
-        key = hashlib.md5(src.encode("utf-8")).hexdigest()
+        version_info = get_backend_func("version_hash")
+        key = hashlib.md5((src + "_".join(version_info)).encode("utf-8")).hexdigest()
         cache = get_cache_manager(key)
         fname = "npu_utils.so"
         cache_path = cache.get_file(fname)
@@ -112,6 +113,8 @@ class NPULauncher(object):
         signature = {cst_key(key): value for key, value in src.signature.items()}
         wrapper_src = generate_npu_wrapper_src(constants, signature, metadata)
         so_launcher_path = make_npu_launcher_stub(header_src, wrapper_src, metadata.debug)
+        npu_utils_inst = NPUUtils()
+        os.environ["TRITON_NPU_UTILS_SO_PATH"] = npu_utils_inst.npu_utils_mod.__file__
         # setup for remote run
         # TODO: use a var to pack all vars required to run on a remote machine
         self.mix_mode = metadata.mix_mode
@@ -530,6 +533,33 @@ def generate_npu_wrapper_src(constants, signature, metadata):
     sync_lock_fail_code = 'fprintf(stderr, "Error: syncBlockLock allocation failed\\n"); return;'
     workspace_fail_code = 'fprintf(stderr, "Error: workspace allocation failed\\n"); return;'
 
+    cpp_npu_utils_dlopen = """
+typedef void* (*triton_allocate_workspace_t)(uint64_t);
+typedef void* (*triton_allocate_sync_block_lock_t)(uint64_t, void*);
+typedef void  (*triton_async_launch_t)(void*, const char*);
+
+static triton_allocate_workspace_t g_allocate_workspace = nullptr;
+static triton_allocate_sync_block_lock_t g_allocate_sync_block_lock = nullptr;
+static triton_async_launch_t g_async_launch = nullptr;
+
+static void init_npu_utils() {
+    if (g_allocate_workspace) return;
+    const char* so_path = getenv("TRITON_NPU_UTILS_SO_PATH");
+    if (!so_path) {
+        fprintf(stderr, "Error: TRITON_NPU_UTILS_SO_PATH not set\\n");
+        return;
+    }
+    void* handle = dlopen(so_path, RTLD_LAZY);
+    if (!handle) {
+        fprintf(stderr, "Error: dlopen %s failed: %s\\n", so_path, dlerror());
+        return;
+    }
+    g_allocate_workspace = (triton_allocate_workspace_t)dlsym(handle, "triton_allocate_workspace");
+    g_allocate_sync_block_lock = (triton_allocate_sync_block_lock_t)dlsym(handle, "triton_allocate_sync_block_lock");
+    g_async_launch = (triton_async_launch_t)dlsym(handle, "triton_async_launch");
+}
+"""
+
     cpp_device_pointer = """
 typedef struct _DevicePtrInfo {
   void *dev_ptr;
@@ -765,6 +795,8 @@ extern "C" {
 
 {cpp_msprof_extern}
 
+{cpp_npu_utils_dlopen}
+
 {cpp_device_pointer}
 
 static void _launch(const char* kernelName, const void* func, rtStream_t stream, int gridX, int gridY, int gridZ, std::vector<std::vector<int64_t>> &tensorShapes, std::vector<int> &tensorKinds{', ' + arg_decls if len(signature) > 0 else ''}) {{
@@ -780,7 +812,7 @@ static void _launch(const char* kernelName, const void* func, rtStream_t stream,
   uint64_t totalWorkSpaceSize = {workspace_size} * blockNum4Workspace;
   {get_backend_func("allocate_memory", "totalWorkSpaceSize", "stream")}
   ''' if workspace_size > 0 else ''}
-  {'auto launch_call = [=]() -> rtError_t' if enable_taskqueue else ''} {{
+  {'std::function<rtError_t()> launch_call = [=]() -> rtError_t' if enable_taskqueue else ''} {{
     {get_backend_func("pre_launch", False)}
     uint32_t blockNum = gridX * gridY * gridZ;
 

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -32,8 +32,6 @@ from triton.runtime.cache import get_cache_manager, get_dump_manager, default_ca
 from triton.backends.driver import DriverBase
 from triton.backends.compiler import GPUTarget
 from triton.backends.ascend.utils import (
-    _precompile_npu_hash,
-    _precompile_npu_ext,
     _build_npu_ext,
     _check_cxx11_abi,
     convert_sigtype_to_int,
@@ -64,7 +62,7 @@ class NPUUtils(object):
                 tmp_src_path = os.path.join(tmpdir, "npu_utils.cpp")
                 with open(tmp_src_path, "w") as f:
                     f.write(src)
-                so = _build_npu_ext("npu_utils", None, tmp_src_path)
+                so = _build_npu_ext("npu_utils", tmp_src_path)
                 with open(so, "rb") as f:
                     cache_path = cache.put(f.read(), fname, binary=True)
         import importlib.util
@@ -106,13 +104,12 @@ class NPULauncher(object):
         self.compile_only = os.getenv("TRITON_COMPILE_ONLY", 'false').lower() in ('true', '1')
         self.enable_msprof_register_tensor = os.getenv("TRITON_REGISTER_TENSOR_MSPROF", 'false').lower() in ('true', '1')
         debug_mode = metadata.debug
-        header_src = generate_npu_header_src()
         constants = src.constants if hasattr(src, "constants") else dict()
         cst_key = lambda i: src.fn.arg_names.index(i) if isinstance(i, str) else i
         constants = {cst_key(key): value for key, value in constants.items()}
         signature = {cst_key(key): value for key, value in src.signature.items()}
         wrapper_src = generate_npu_wrapper_src(constants, signature, metadata)
-        so_launcher_path = make_npu_launcher_stub(header_src, wrapper_src, metadata.debug)
+        so_launcher_path = make_npu_launcher_stub(wrapper_src, metadata.debug)
         # setup for remote run
         # TODO: use a var to pack all vars required to run on a remote machine
         self.mix_mode = metadata.mix_mode
@@ -205,56 +202,12 @@ class NPUDriver(DriverBase):
         return get_backend_func("get_empty_tensor", cache_size // 4)
 
 
-def _precompile_npu_ext_with_lock(header_src, enable_precompile):
-    import fcntl
-    precompile_hash = _precompile_npu_hash(header_src)
-    cache = get_cache_manager(precompile_hash)
-    gch_path = cache.get_file("precompiled.h.gch")
-    header_path = cache.get_file("precompiled.h")
-    if enable_precompile: 
-        if header_path is not None and gch_path is not None:
-            return header_path
-    else:
-        if header_path is not None:
-            return header_path
-    cache_dir = os.getenv("TRITON_CACHE_DIR", "").strip() or default_cache_dir()
-    lock_path = os.path.join(cache_dir, f"{precompile_hash}.lock")
-    with open(lock_path, "a+") as f:
-        try:
-            fcntl.flock(f, fcntl.LOCK_EX)
-            header_path = cache.get_file("precompiled.h")
-            if enable_precompile:
-                gch_path = cache.get_file("precompiled.h.gch")
-                if header_path is not None and gch_path is not None:
-                    return header_path
-            else:
-                if header_path is not None:
-                    return header_path
-            header_path = cache.put(header_src, "precompiled.h", binary=False)
-            if not enable_precompile:
-                return header_path
-            src_dir = os.path.dirname(header_path)
-            gch_path = os.path.join(src_dir, "precompiled.h.gch")
-            _precompile_npu_ext(header_path, gch_path)
-            return header_path
-        finally:
-            fcntl.flock(f, fcntl.LOCK_UN)
-    
-
-def make_npu_launcher_stub(header_src, wrapper_src, debug=False):
+def make_npu_launcher_stub(wrapper_src, debug=False):
     """
     Generate the launcher stub to launch the kernel
     """
-    enable_precompile = not os.getenv("TRITON_DISABLE_PRECOMPILE", 'false').lower() in ('true', '1')
-    # if precompile header file and its gch file not exist, do precompile
-    header_path = _precompile_npu_ext_with_lock(header_src, enable_precompile)
-    assert header_path is not None, "the precompiled.h path is empty."
-    
-    # try to get cached file
     so_cache_key = hashlib.sha256(wrapper_src.encode("utf-8")).hexdigest()
     so_cache_manager = get_cache_manager(so_cache_key)
-    # append the cxx11_abi value to the launcher name to avoid
-    # linking to a launcher with wrong cxx11_abi.
     use_cxx11_abi = _check_cxx11_abi()
     name = f"launcher_cxx11abi{use_cxx11_abi}"
     suffix = sysconfig.get_config_var('EXT_SUFFIX')
@@ -262,9 +215,6 @@ def make_npu_launcher_stub(header_src, wrapper_src, debug=False):
 
     if debug:
         dump_manager = get_dump_manager(so_cache_key)
-        if header_path is not None:
-            print(f"Dumping precompiled.h to {dump_manager.cache_dir}")
-            dump_manager.put(header_src, "precompiled.h", binary=False)
         print(f"Dumping {name}.cxx to {dump_manager.cache_dir}")
         dump_manager.put(wrapper_src, f"{name}.cxx", binary = False)
 
@@ -274,12 +224,11 @@ def make_npu_launcher_stub(header_src, wrapper_src, debug=False):
 
     kernel_launcher_type = "torch"
 
-
     with tempfile.TemporaryDirectory() as tmpdir:
         src_path = os.path.join(tmpdir, f"{name}.cxx")
         with open(src_path, "w") as f:
             f.write(wrapper_src)
-        so_path = _build_npu_ext(name, header_path, src_path, kernel_launcher=kernel_launcher_type, precompile=enable_precompile)
+        so_path = _build_npu_ext(name, src_path, kernel_launcher=kernel_launcher_type)
         if debug:
             with open(so_path, "rb") as f:
                 dump_manager.put(f.read(), so_name, binary=True)
@@ -355,49 +304,6 @@ def extract_device_print_code_from_cann():
         read_header('internal/debug_tunnel/tunnel_impl.h')
     ])
 
-
-def generate_npu_header_src():
-    enable_taskqueue = os.getenv(
-        "TRITON_ENABLE_TASKQUEUE", 'true').lower() in ('true', '1')
-    return f"""
-/*
- * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
- * Copyright 2018-2020 Philippe Tillet
- * Copyright 2020-2022 OpenAI
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
-#ifndef TRITON_NPU_HEADERS
-#define TRITON_NPU_HEADERS
-
-#include <assert.h>
-#include <stdbool.h>
-#include <string>
-#include <sys/syscall.h>
-#include <vector>
-#include <Python.h>
-#include "runtime/runtime/rt.h"
-#include <acl/acl.h>
-{get_backend_func("header_file", enable_taskqueue)}
-
-#endif
-"""
 
 # the template is from triton-adapter HEAD. Wrapping the generated kernel binary into a python module
 def generate_npu_wrapper_src(constants, signature, metadata):
@@ -775,12 +681,23 @@ extern "C" {
     ret = rtKernelLaunchWithFlagV2(func, blockNum, &argsInfo, NULL, stream, 0, &cfgInfo);
 """
 
-    precompile_headers = f"""
-#include "precompiled.h"
+    npu_headers = f"""
+#ifndef TRITON_NPU_HEADERS
+#define TRITON_NPU_HEADERS
+#include <assert.h>
+#include <stdbool.h>
+#include <string>
+#include <sys/syscall.h>
+#include <vector>
+#include <Python.h>
+#include "runtime/runtime/rt.h"
+#include <acl/acl.h>
+{get_backend_func("header_file", enable_taskqueue)}
+#endif
 """
 
     return f"""
-{precompile_headers}
+{npu_headers}
 {'#define __CCE_ENABLE_PRINT__' if enable_device_print else ''}
 {extract_device_print_code_from_cann() if enable_device_print else ''}
 #define PY_SSIZE_T_CLEAN

--- a/third_party/ascend/backend/npu_utils.cpp
+++ b/third_party/ascend/backend/npu_utils.cpp
@@ -329,18 +329,34 @@ static PyObject* copyMemory(PyObject* self, PyObject* args) {
 
 #ifdef USE_TORCH_NPU
 struct RetainedTensorHandle {
-  explicit RetainedTensorHandle(at::Tensor tensor) : tensor(std::move(tensor)) {}
+  RetainedTensorHandle(at::Tensor tensor, const char *kind, uint64_t size)
+      : tensor(std::move(tensor)), kind(kind), size(size),
+        data(const_cast<void*>(this->tensor.storage().data())) {}
 
   at::Tensor tensor;
+  const char *kind;
+  uint64_t size;
+  void *data;
 };
 
-static void *retainTensor(at::Tensor tensor, void **handle) {
+static void logRetainedTensor(const char *action, const RetainedTensorHandle *handle) {
+  fprintf(stderr,
+          "[TRITON_NPU_TENSOR_LIFETIME] action=%s kind=%s size=%llu handle=%p data=%p\n",
+          action,
+          handle->kind,
+          static_cast<unsigned long long>(handle->size),
+          static_cast<const void*>(handle),
+          handle->data);
+}
+
+static void *retainTensor(at::Tensor tensor, void **handle, const char *kind, uint64_t size) {
   if (handle == nullptr) {
     return nullptr;
   }
-  auto *retained = new RetainedTensorHandle(std::move(tensor));
+  auto *retained = new RetainedTensorHandle(std::move(tensor), kind, size);
+  logRetainedTensor("create", retained);
   *handle = retained;
-  return const_cast<void*>(retained->tensor.storage().data());
+  return retained->data;
 }
 
 extern "C" void* triton_allocate_workspace(uint64_t size, void **handle)
@@ -350,7 +366,7 @@ extern "C" void* triton_allocate_workspace(uint64_t size, void **handle)
   }
   *handle = nullptr;
   auto tensor = at::empty(size, at::TensorOptions().device(at::kPrivateUse1).dtype(at::kByte));
-  return retainTensor(std::move(tensor), handle);
+  return retainTensor(std::move(tensor), handle, "workspace", size);
 }
 
 extern "C" void* triton_allocate_sync_block_lock(uint64_t size, void* stream, void **handle)
@@ -360,12 +376,14 @@ extern "C" void* triton_allocate_sync_block_lock(uint64_t size, void* stream, vo
   }
   *handle = nullptr;
   auto tensor = at_npu::native::allocate_workspace(size, reinterpret_cast<rtStream_t>(stream));
-  return retainTensor(std::move(tensor), handle);
+  return retainTensor(std::move(tensor), handle, "sync_block_lock", size);
 }
 
 extern "C" void triton_release_retained_tensor(void *handle)
 {
-  delete static_cast<RetainedTensorHandle*>(handle);
+  auto *retained = static_cast<RetainedTensorHandle*>(handle);
+  logRetainedTensor("release", retained);
+  delete retained;
 }
 
 extern "C" void triton_async_launch(void* func_obj, const char* name)

--- a/third_party/ascend/backend/npu_utils.cpp
+++ b/third_party/ascend/backend/npu_utils.cpp
@@ -33,6 +33,13 @@
 
 #include "runtime/runtime/rt.h"
 
+#ifdef USE_TORCH_NPU
+#include <ATen/ATen.h>
+#include <torch_npu/csrc/core/npu/NPUWorkspaceAllocator.h>
+#include <torch_npu/csrc/framework/OpCommand.h>
+#include <functional>
+#endif
+
 // Use map to differentiate same name functions from different binary
 static std::unordered_map<std::string, size_t> registered_names;
 static std::unordered_map<std::string, std::unique_ptr<size_t>> func_stubs;
@@ -318,6 +325,24 @@ static PyObject* copyMemory(PyObject* self, PyObject* args) {
 	Py_INCREF(Py_None);
 	return Py_None;
 }
+
+#ifdef USE_TORCH_NPU
+extern "C" void* triton_allocate_workspace(uint64_t size) {
+  auto tensor = at::empty(size, at::TensorOptions().device(at::kPrivateUse1).dtype(at::kByte));
+  return const_cast<void*>(tensor.storage().data());
+}
+
+extern "C" void* triton_allocate_sync_block_lock(uint64_t size, void* stream) {
+  auto tensor = at_npu::native::allocate_workspace(size, reinterpret_cast<rtStream_t>(stream));
+  return const_cast<void*>(tensor.storage().data());
+}
+
+extern "C" void triton_async_launch(void* func_obj, const char* name) {
+  auto& func = *static_cast<std::function<rtError_t()>*>(func_obj);
+  at_npu::native::OpCommand cmd;
+  cmd.Name(name).SetCustomHandler(func).Run();
+}
+#endif
 
 static PyMethodDef NpuUtilsMethods[] = {
     {"load_kernel_binary", loadKernelBinary, METH_VARARGS,

--- a/third_party/ascend/backend/npu_utils.cpp
+++ b/third_party/ascend/backend/npu_utils.cpp
@@ -327,17 +327,20 @@ static PyObject* copyMemory(PyObject* self, PyObject* args) {
 }
 
 #ifdef USE_TORCH_NPU
-extern "C" void* triton_allocate_workspace(uint64_t size) {
+extern "C" void* triton_allocate_workspace(uint64_t size)
+{
   auto tensor = at::empty(size, at::TensorOptions().device(at::kPrivateUse1).dtype(at::kByte));
   return const_cast<void*>(tensor.storage().data());
 }
 
-extern "C" void* triton_allocate_sync_block_lock(uint64_t size, void* stream) {
+extern "C" void* triton_allocate_sync_block_lock(uint64_t size, void* stream)
+{
   auto tensor = at_npu::native::allocate_workspace(size, reinterpret_cast<rtStream_t>(stream));
   return const_cast<void*>(tensor.storage().data());
 }
 
-extern "C" void triton_async_launch(void* func_obj, const char* name) {
+extern "C" void triton_async_launch(void* func_obj, const char* name)
+{
   auto& func = *static_cast<std::function<rtError_t()>*>(func_obj);
   at_npu::native::OpCommand cmd;
   cmd.Name(name).SetCustomHandler(func).Run();

--- a/third_party/ascend/backend/npu_utils.cpp
+++ b/third_party/ascend/backend/npu_utils.cpp
@@ -38,6 +38,7 @@
 #include <torch_npu/csrc/core/npu/NPUWorkspaceAllocator.h>
 #include <torch_npu/csrc/framework/OpCommand.h>
 #include <functional>
+#include <mutex>
 #endif
 
 // Use map to differentiate same name functions from different binary
@@ -327,15 +328,25 @@ static PyObject* copyMemory(PyObject* self, PyObject* args) {
 }
 
 #ifdef USE_TORCH_NPU
+static std::mutex retained_tensor_mutex;
+static std::vector<at::Tensor> retained_tensors;
+
+static void retainTensor(const at::Tensor &tensor) {
+  std::lock_guard<std::mutex> guard(retained_tensor_mutex);
+  retained_tensors.push_back(tensor);
+}
+
 extern "C" void* triton_allocate_workspace(uint64_t size)
 {
   auto tensor = at::empty(size, at::TensorOptions().device(at::kPrivateUse1).dtype(at::kByte));
+  retainTensor(tensor);
   return const_cast<void*>(tensor.storage().data());
 }
 
 extern "C" void* triton_allocate_sync_block_lock(uint64_t size, void* stream)
 {
   auto tensor = at_npu::native::allocate_workspace(size, reinterpret_cast<rtStream_t>(stream));
+  retainTensor(tensor);
   return const_cast<void*>(tensor.storage().data());
 }
 

--- a/third_party/ascend/backend/npu_utils.cpp
+++ b/third_party/ascend/backend/npu_utils.cpp
@@ -30,6 +30,7 @@
 #include <unordered_map>
 #include <fstream>
 #include <algorithm>
+#include <utility>
 
 #include "runtime/runtime/rt.h"
 
@@ -38,7 +39,6 @@
 #include <torch_npu/csrc/core/npu/NPUWorkspaceAllocator.h>
 #include <torch_npu/csrc/framework/OpCommand.h>
 #include <functional>
-#include <mutex>
 #endif
 
 // Use map to differentiate same name functions from different binary
@@ -328,26 +328,44 @@ static PyObject* copyMemory(PyObject* self, PyObject* args) {
 }
 
 #ifdef USE_TORCH_NPU
-static std::mutex retained_tensor_mutex;
-static std::vector<at::Tensor> retained_tensors;
+struct RetainedTensorHandle {
+  explicit RetainedTensorHandle(at::Tensor tensor) : tensor(std::move(tensor)) {}
 
-static void retainTensor(const at::Tensor &tensor) {
-  std::lock_guard<std::mutex> guard(retained_tensor_mutex);
-  retained_tensors.push_back(tensor);
+  at::Tensor tensor;
+};
+
+static void *retainTensor(at::Tensor tensor, void **handle) {
+  if (handle == nullptr) {
+    return nullptr;
+  }
+  auto *retained = new RetainedTensorHandle(std::move(tensor));
+  *handle = retained;
+  return const_cast<void*>(retained->tensor.storage().data());
 }
 
-extern "C" void* triton_allocate_workspace(uint64_t size)
+extern "C" void* triton_allocate_workspace(uint64_t size, void **handle)
 {
+  if (handle == nullptr) {
+    return nullptr;
+  }
+  *handle = nullptr;
   auto tensor = at::empty(size, at::TensorOptions().device(at::kPrivateUse1).dtype(at::kByte));
-  retainTensor(tensor);
-  return const_cast<void*>(tensor.storage().data());
+  return retainTensor(std::move(tensor), handle);
 }
 
-extern "C" void* triton_allocate_sync_block_lock(uint64_t size, void* stream)
+extern "C" void* triton_allocate_sync_block_lock(uint64_t size, void* stream, void **handle)
 {
+  if (handle == nullptr) {
+    return nullptr;
+  }
+  *handle = nullptr;
   auto tensor = at_npu::native::allocate_workspace(size, reinterpret_cast<rtStream_t>(stream));
-  retainTensor(tensor);
-  return const_cast<void*>(tensor.storage().data());
+  return retainTensor(std::move(tensor), handle);
+}
+
+extern "C" void triton_release_retained_tensor(void *handle)
+{
+  delete static_cast<RetainedTensorHandle*>(handle);
 }
 
 extern "C" void triton_async_launch(void* func_obj, const char* name)

--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -350,9 +350,10 @@ def _build_npu_ext(obj_name: str, src_path, *, kernel_launcher="torch") -> str:
         "-lascendcl",
     ]
     if kernel_launcher == "torch":
-        cc_cmd += get_backend_func("get_cc_cmd")
         if obj_name == "npu_utils":
-            cc_cmd += ["-DUSE_TORCH_NPU"]
+            cc_cmd += get_backend_func("get_cc_cmd_npu_utils")
+        else:
+            cc_cmd += get_backend_func("get_cc_cmd")
 
     cc_cmd += ["-std=c++17", "-shared", "-fPIC", "-o", so_path]
 

--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -439,6 +439,8 @@ def _build_npu_ext(obj_name: str, header_path, src_path, *, kernel_launcher="tor
     # FIXME: check why this condition works wrong in parall scene
     if kernel_launcher == "torch":
         cc_cmd += get_backend_func("get_cc_cmd", build_pch=False)
+        if obj_name == "npu_utils":
+            cc_cmd += ["-DUSE_TORCH_NPU"]
 
     cc_cmd += ["-std=c++17", "-shared", "-fPIC", "-Winvalid-pch", "-o", so_path]
 

--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -315,110 +315,23 @@ def _get_cxx():
     return cxx
 
 
-def _get_cxx_precompiled(header_path):
-    cc_cmd = []
-    cxx = os.environ.get("CC")
-    if cxx is None:
-        clangxx = shutil.which("clang++")
-        gxx = shutil.which("g++")
-        if clangxx is not None:
-            cc_cmd += [clangxx, "-include", header_path]
-        elif gxx is not None:
-            cc_cmd += [gxx]
-        else:
-            raise RuntimeError("Failed to find C++ compiler")
-    else:
-        cc_cmd += [cxx]
-    return cc_cmd
-
-
-def _precompile_npu_hash(header_src):
-    import sys
-    cxx = _get_cxx()
-    py_version = sys.version
-    asc_path = _get_ascend_path().name
-    version_txt = [header_src, cxx, py_version, asc_path]
-    version_txt += get_backend_func("version_hash")
-    hash_txt = hashlib.sha256("_".join(version_txt).encode("utf-8")).hexdigest()
-    return hash_txt
-
-
-def _precompile_npu_ext(header_path, gch_path):
-    cxx = _get_cxx()
-    cc_cmd = [cxx, "-x", "c++-header", header_path]
-    # disable all warnings
-    cc_cmd += [f"-w"]
-    # find the python library
-    if hasattr(sysconfig, "get_default_scheme"):
-        scheme = sysconfig.get_default_scheme()
-    else:
-        scheme = sysconfig._get_default_scheme()
-    # 'posix_local' is a custom scheme on Debian. However, starting Python 3.10, the default install
-    # path changes to include 'local'. This change is required to use triton with system-wide python.
-    if scheme == "posix_local":
-        scheme = "posix_prefix"
-    py_include_dir = sysconfig.get_paths(scheme=scheme)["include"]
-    cc_cmd += [f"-I{py_include_dir}"]
-    # device_print.h
-    cc_cmd += [f"-I{os.path.dirname(os.path.realpath(__file__))}"]
-    # find the ascend library
-    asc_path = _get_ascend_path()
-
-    rt_path = os.path.join(asc_path, "include/experiment/runtime/runtime/rt.h")
-    if not os.path.exists(rt_path):
-        cc_cmd += [
-            f"-I{os.path.join(asc_path, 'pkg_inc')}",
-            f"-I{os.path.join(asc_path, 'pkg_inc/profiling')}",
-        ]
-
-    cc_cmd += [
-        f"-I{os.path.join(asc_path, 'include')}",
-        f"-I{os.path.join(asc_path, 'include/experiment')}",
-        f"-I{os.path.join(asc_path, 'include/experiment/msprof')}",
-        f"-I{pybind11.get_include()}",
-    ]
-
-    cc_cmd += get_backend_func("get_cc_cmd", build_pch=True)
-
-    cc_cmd += ["-std=c++17", "-shared", "-fPIC", "-o", gch_path]
-
-    result = subprocess.run(cc_cmd, capture_output=True, text=True)
-
-    if result.returncode == 0:
-        return header_path
-    else:
-        raise RuntimeError(f"Failed to compile {gch_path}, error: {result.stderr},cmd={cc_cmd}")
-
-
-def _build_npu_ext(obj_name: str, header_path, src_path, *, kernel_launcher="torch", precompile=False) -> str:
+def _build_npu_ext(obj_name: str, src_path, *, kernel_launcher="torch") -> str:
     suffix = sysconfig.get_config_var("EXT_SUFFIX")
     src_dir = os.path.dirname(src_path)
     so_path = os.path.join(src_dir, f"{obj_name}{suffix}")
-    if precompile:
-        cc_cmd = _get_cxx_precompiled(header_path)
-        cc_cmd += [src_path]
-    else:
-        cxx = _get_cxx()
-        cc_cmd = [cxx, src_path]
-    # disable all warnings
+    cxx = _get_cxx()
+    cc_cmd = [cxx, src_path]
     cc_cmd += [f"-w"]
-    # find the python library
     if hasattr(sysconfig, "get_default_scheme"):
         scheme = sysconfig.get_default_scheme()
     else:
         scheme = sysconfig._get_default_scheme()
-    # 'posix_local' is a custom scheme on Debian. However, starting Python 3.10, the default install
-    # path changes to include 'local'. This change is required to use triton with system-wide python.
     if scheme == "posix_local":
         scheme = "posix_prefix"
     py_include_dir = sysconfig.get_paths(scheme=scheme)["include"]
     cc_cmd += [f"-I{py_include_dir}"]
-    # device_print.h
     cc_cmd += [f"-I{os.path.dirname(os.path.realpath(__file__))}"]
-    # find the ascend library
     asc_path = _get_ascend_path()
-    if header_path is not None:
-        cc_cmd += [f"-I{os.path.dirname(header_path)}"]
 
     rt_path = os.path.join(asc_path, "include/experiment/runtime/runtime/rt.h")
     if not os.path.exists(rt_path):
@@ -436,24 +349,19 @@ def _build_npu_ext(obj_name: str, header_path, src_path, *, kernel_launcher="tor
         "-lruntime",
         "-lascendcl",
     ]
-    # FIXME: check why this condition works wrong in parall scene
     if kernel_launcher == "torch":
-        cc_cmd += get_backend_func("get_cc_cmd", build_pch=False)
+        cc_cmd += get_backend_func("get_cc_cmd")
         if obj_name == "npu_utils":
             cc_cmd += ["-DUSE_TORCH_NPU"]
 
-    cc_cmd += ["-std=c++17", "-shared", "-fPIC", "-Winvalid-pch", "-o", so_path]
+    cc_cmd += ["-std=c++17", "-shared", "-fPIC", "-o", so_path]
 
     result = subprocess.run(cc_cmd, capture_output=True, text=True)
 
     if result.returncode == 0:
         return so_path
     else:
-        if "precompiled.h.gch" in result.stderr:
-            # only for clang++, when precompile invalid, fallback to normal compile
-            return _build_npu_ext(obj_name, header_path, src_path, precompile=False)
-        else:
-            raise RuntimeError(f"Failed to compile {src_path}, error: {result.stderr},cmd={cc_cmd}")
+        raise RuntimeError(f"Failed to compile {src_path}, error: {result.stderr},cmd={cc_cmd}")
 
 
 def _get_kernel_target(metadata: dict):

--- a/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
+++ b/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
@@ -1,0 +1,68 @@
+import importlib.util
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+
+DEFAULT_UTILS_PATH = (
+    Path(__file__).resolve().parents[2] / "backend" / "utils.py"
+)
+
+
+def _get_utils_path():
+    override = os.environ.get("TRITON_ASCEND_UTILS_UNDER_TEST")
+    if override:
+        return Path(override)
+    return DEFAULT_UTILS_PATH
+
+
+def _load_utils_module():
+    utils_path = _get_utils_path()
+    spec = importlib.util.spec_from_file_location("repo_backend_utils", utils_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _assert_npu_utils_uses_special_flags(utils, monkeypatch, tmp_path):
+    monkeypatch.setattr(utils, "_get_cxx", lambda: "c++")
+    monkeypatch.setattr(utils, "_get_ascend_path", lambda: str(tmp_path / "ascend"))
+    monkeypatch.setattr(utils.pybind11, "get_include", lambda: "/pybind11")
+    monkeypatch.setattr(utils.sysconfig, "get_config_var", lambda name: ".so")
+    monkeypatch.setattr(
+        utils.sysconfig, "get_default_scheme", lambda: "posix_prefix", raising=False
+    )
+    monkeypatch.setattr(
+        utils.sysconfig, "get_paths", lambda scheme=None: {"include": "/pyinclude"}
+    )
+
+    calls = []
+
+    def fake_get_backend_func(name, *args, **kwargs):
+        calls.append((name, args, kwargs))
+        if name == "get_cc_cmd_npu_utils":
+            return ["-DUSE_TORCH_NPU"]
+        if name == "get_cc_cmd":
+            return ["-ldl"]
+        return []
+
+    monkeypatch.setattr(utils, "get_backend_func", fake_get_backend_func)
+    monkeypatch.setattr(
+        utils.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stderr=""),
+    )
+
+    src_path = tmp_path / "npu_utils.cpp"
+    src_path.write_text("int main() { return 0; }\n")
+
+    so_path = utils._build_npu_ext("npu_utils", str(src_path), kernel_launcher="torch")
+
+    assert so_path.endswith(".so")
+    assert any(name == "get_cc_cmd_npu_utils" for name, _, _ in calls)
+    assert not any(name == "get_cc_cmd" for name, _, _ in calls)
+
+
+def test_npu_utils_build_uses_special_flags(monkeypatch, tmp_path):
+    utils = _load_utils_module()
+    _assert_npu_utils_uses_special_flags(utils, monkeypatch, tmp_path)

--- a/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_lifetime.py
+++ b/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_lifetime.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 
 BACKEND_DIR = Path(__file__).resolve().parents[2] / "backend"
+PYTEST_DIR = Path(__file__).resolve().parent
 
 
 def test_npu_utils_uses_releaseable_tensor_handles():
@@ -23,6 +24,20 @@ def test_npu_utils_logs_tensor_handle_lifecycle():
     assert 'logRetainedTensor("release", retained);' in src
     assert 'retainTensor(std::move(tensor), handle, "workspace", size)' in src
     assert 'retainTensor(std::move(tensor), handle, "sync_block_lock", size)' in src
+
+
+def test_runtime_lifecycle_case_explicitly_prints_release():
+    runtime_case = PYTEST_DIR / "test_backend_npu_utils_runtime_lifetime.py"
+
+    assert runtime_case.exists()
+    src = runtime_case.read_text()
+
+    assert 'print("[TEST] release workspace tensor handle", flush=True)' in src
+    assert 'print("[TEST] release sync_block_lock tensor handle", flush=True)' in src
+    assert "triton_release_retained_tensor(workspace_handle)" in src
+    assert "triton_release_retained_tensor(sync_handle)" in src
+    assert "[TRITON_NPU_TENSOR_LIFETIME] action=release kind=workspace" in src
+    assert "[TRITON_NPU_TENSOR_LIFETIME] action=release kind=sync_block_lock" in src
 
 
 def test_launcher_keeps_tensor_handles_until_launch_finishes():

--- a/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_lifetime.py
+++ b/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_lifetime.py
@@ -12,7 +12,17 @@ def test_npu_utils_uses_releaseable_tensor_handles():
     assert "struct RetainedTensorHandle" in src
     assert "triton_release_retained_tensor" in src
     assert "new RetainedTensorHandle" in src
-    assert "delete static_cast<RetainedTensorHandle*>" in src
+    assert "delete retained;" in src
+
+
+def test_npu_utils_logs_tensor_handle_lifecycle():
+    src = (BACKEND_DIR / "npu_utils.cpp").read_text()
+
+    assert "[TRITON_NPU_TENSOR_LIFETIME]" in src
+    assert 'logRetainedTensor("create", retained);' in src
+    assert 'logRetainedTensor("release", retained);' in src
+    assert 'retainTensor(std::move(tensor), handle, "workspace", size)' in src
+    assert 'retainTensor(std::move(tensor), handle, "sync_block_lock", size)' in src
 
 
 def test_launcher_keeps_tensor_handles_until_launch_finishes():

--- a/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_lifetime.py
+++ b/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_lifetime.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+
+BACKEND_DIR = Path(__file__).resolve().parents[2] / "backend"
+
+
+def test_npu_utils_uses_releaseable_tensor_handles():
+    src = (BACKEND_DIR / "npu_utils.cpp").read_text()
+
+    assert "retained_tensors" not in src
+    assert "retained_tensor_mutex" not in src
+    assert "struct RetainedTensorHandle" in src
+    assert "triton_release_retained_tensor" in src
+    assert "new RetainedTensorHandle" in src
+    assert "delete static_cast<RetainedTensorHandle*>" in src
+
+
+def test_launcher_keeps_tensor_handles_until_launch_finishes():
+    driver_src = (BACKEND_DIR / "driver.py").read_text()
+    register_src = (BACKEND_DIR / "backend_register.py").read_text()
+
+    assert "triton_release_retained_tensor_t" in driver_src
+    assert 'dlsym(handle, "triton_release_retained_tensor")' in driver_src
+    assert "std::shared_ptr<void>" in driver_src
+    assert "release_npu_tensor_handle" in driver_src
+    assert "workspace_handle" in driver_src
+    assert "syncBlockLock_handle" in driver_src
+
+    assert "g_allocate_workspace({size}, &workspace_handle)" in register_src
+    assert "g_allocate_sync_block_lock({size}, {stream}, &syncBlockLock_handle)" in register_src
+
+
+def test_npu_utils_load_binary_accepts_legacy_combined_kernel_name():
+    driver_src = (BACKEND_DIR / "driver.py").read_text()
+
+    assert "def load_binary(self, name, kernel, shared, device, mix_mode=None):" in driver_src
+    assert 'name, mix_mode = name.rsplit("_", 1)' in driver_src

--- a/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_runtime_lifetime.py
+++ b/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_runtime_lifetime.py
@@ -1,0 +1,68 @@
+import ctypes
+
+import pytest
+
+
+def _load_retained_tensor_api():
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("torch_npu")
+    from torch_npu._C import _npu_getCurrentRawStream as get_raw_stream
+    from triton.backends.ascend.driver import NPUUtils
+
+    try:
+        torch.npu.set_device(0)
+        torch.empty((1,), device="npu")
+    except Exception as exc:
+        pytest.skip(f"NPU runtime is unavailable: {exc}")
+
+    lib = ctypes.CDLL(NPUUtils().npu_utils_mod.__file__)
+    lib.triton_allocate_workspace.argtypes = [
+        ctypes.c_uint64,
+        ctypes.POINTER(ctypes.c_void_p),
+    ]
+    lib.triton_allocate_workspace.restype = ctypes.c_void_p
+    lib.triton_allocate_sync_block_lock.argtypes = [
+        ctypes.c_uint64,
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_void_p),
+    ]
+    lib.triton_allocate_sync_block_lock.restype = ctypes.c_void_p
+    lib.triton_release_retained_tensor.argtypes = [ctypes.c_void_p]
+    lib.triton_release_retained_tensor.restype = None
+    return torch, get_raw_stream, lib
+
+
+def test_npu_utils_prints_retained_tensor_release_lifecycle(capfd):
+    torch, get_raw_stream, lib = _load_retained_tensor_api()
+
+    workspace_handle = ctypes.c_void_p()
+    print("[TEST] create workspace tensor space", flush=True)
+    workspace_ptr = lib.triton_allocate_workspace(4096, ctypes.byref(workspace_handle))
+    assert workspace_ptr
+    assert workspace_handle.value
+
+    print("[TEST] release workspace tensor handle", flush=True)
+    lib.triton_release_retained_tensor(workspace_handle)
+
+    sync_handle = ctypes.c_void_p()
+    print("[TEST] create sync_block_lock tensor space", flush=True)
+    sync_ptr = lib.triton_allocate_sync_block_lock(
+        64,
+        ctypes.c_void_p(get_raw_stream(0)),
+        ctypes.byref(sync_handle),
+    )
+    assert sync_ptr
+    assert sync_handle.value
+
+    print("[TEST] release sync_block_lock tensor handle", flush=True)
+    lib.triton_release_retained_tensor(sync_handle)
+    torch.npu.synchronize()
+
+    captured = capfd.readouterr()
+    text = captured.out + captured.err
+    assert "[TEST] release workspace tensor handle" in text
+    assert "[TEST] release sync_block_lock tensor handle" in text
+    assert "[TRITON_NPU_TENSOR_LIFETIME] action=create kind=workspace" in text
+    assert "[TRITON_NPU_TENSOR_LIFETIME] action=release kind=workspace" in text
+    assert "[TRITON_NPU_TENSOR_LIFETIME] action=create kind=sync_block_lock" in text
+    assert "[TRITON_NPU_TENSOR_LIFETIME] action=release kind=sync_block_lock" in text


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)


# compilation pipeline optimization.

- **Compilation Pipeline Optimization**: Extracted `torch_npu`-related workspace/sync lock/async launch capabilities from the launcher into a standalone `npu_utils.so`, transforming the launcher into a lightweight bridge layer that reduces compile-time heavy dependencies.

## Performance Gains

### Overview

| Scenario         | Metric                                                 | Old Architecture | New Architecture | Absolute Change | Relative Change |
| ---------------- | ------------------------------------------------------ | ---------------- | ---------------- | --------------- | --------------- |
| First Compile    | `total_compile + npu_utils_build_so + launcher_build`  | 16.266s          | 9.121s           | -7.145s         | -43.93%         |
| Second Compile   | `total_compile + launcher_build`                       | 3.503s           | 2.621s           | -0.882s         | -25.19%         |

### First Compile `softmax` Phase Breakdown

| Phase                      | Old Arch(s) | New Arch(s) | Change(s)  | Notes                                        |
| -------------------------- | ----------: | ----------: | ---------: | -------------------------------------------- |
| `total_compile`            |       2.415 |       2.406 |     -0.009 | Triton kernel core compilation nearly unchanged  |
| `npu_utils_build_so`       |       0.809 |       6.168 |     +5.359 | `torch_npu` dependency cost centralized in `npu_utils.so` build |
| `launcher_build`           |      13.042 |       0.548 |    -12.495 | Launcher build cost reduced significantly    |

Launcher detail:

| Sub-phase                    | Old Arch(s) | New Arch(s) | Change(s)   |
| ---------------------------- | ----------: | ----------: | ---------: |
| `launcher_precompile_header` |      11.615 |       0.000 |    -11.615 |
| `launcher_build_stub`        |      13.040 |       0.546 |    -12.494 |
| `launcher_load_module`       |       0.002 |       0.001 |     -0.001 |

### Second Compile `test_sum` Phase Breakdown

| Phase             | Old Arch(s) | New Arch(s) | Change(s) | Notes                                |
| ----------------- | ----------: | ----------: | --------: | ------------------------------------ |
| `total_compile`   |       2.048 |       2.072 |    +0.024 | Triton kernel core compilation nearly unchanged   |
| `launcher_build`  |       1.456 |       0.549 |    -0.907 | Launcher build continues to benefit  |

Launcher detail:

| Sub-phase                    | Old Arch(s) | New Arch(s) | Change(s) |
| ---------------------------- | ----------: | ----------: | --------: |
| `launcher_precompile_header` |       0.000 |       0.000 |     0.000 |
| `launcher_build_stub`        |       1.453 |       0.548 |    -0.905 |
| `launcher_load_module`       |       0.002 |       0.001 |    -0.001 |

On second compile, `npu_utils.so` has already been cached, so there is no additional `npu_utils_build_so` overhead.

### Performance Analysis

- First compile gain driver: removed `launcher_precompile_header` (11.615s → 0s), launcher build dropped from 13.04s to 0.55s
- Second compile gain driver: launcher build consistently shortened to ~0.55s (1.453s → 0.548s)
- Cost: `npu_utils_build_so` first build increased from 0.809s to 6.168s, but the launcher-side gain is larger, resulting in significant overall compile time improvement
- `Kernel compile` core (`stage_npubin`) is essentially unchanged, confirming the optimization did not impact the core compilation flow

## Core Changes

### npu\_utils.so Extraction

Centralized `torch_npu`-related capabilities into `npu_utils.cpp`:

1. **Added `USE_TORCH_NPU` conditional compilation block**: centralized management of `ATen/ATen.h`, `torch_npu/csrc/core/npu/NPUWorkspaceAllocator.h`, `torch_npu/csrc/framework/OpCommand.h`, and other dependencies
2. **Added three `extern "C"` exported interfaces**:
   - `triton_allocate_workspace`: workspace allocation
   - `triton_allocate_sync_block_lock`: sync block lock allocation
   - `triton_async_launch`: taskqueue async launch
3. **Added tensor lifetime retention mechanism (opaque handle + RAII guard)**: prevents raw pointers returned from being invalidated during launch, while also solving the ever-growing global `retained_tensors` vector memory leak risk

### Launcher Lightweighting

The launcher no longer directly depends on `torch_npu`, instead loading `npu_utils.so` at runtime via `dlopen/dlsym`:

- No longer includes `precompiled.h`, replaced with a lightweight header
- No longer directly constructs `at_npu::native::OpCommand`, instead forwards through `npu_utils.so`
- No longer carries `torch_npu` heavy dependencies at compile time

### retained_tensors Memory Leak Fix (Opaque Handle + RAII Guard)

#### Background

After decoupling the launcher, the underlying `at::Tensor` objects for workspace and sync block lock changed from temporary launcher-side objects to internally allocated objects within `npu_utils.so`. The previous implementation used a global `retained_tensors` vector inside `npu_utils.cpp` to hold all allocated tensors. While this approach avoided dangling pointers, the vector only grew without shrinking, causing continuous accumulation of unused workspace/sync lock tensors during long training runs or frequent compilation.

#### Solution

Replace the process-level global `retained_tensors` container with per-allocation releasable opaque handles, with the launcher side using `std::shared_ptr` custom deleters to achieve RAII automatic release. RAII (Resource Acquisition Is Initialization) binds resource lifetime to object lifetime: `shared_ptr` holds the handle upon construction (resource acquisition), and when leaving scope, it automatically destructs and invokes the deleter to release the underlying tensor, guaranteeing no resource leaks regardless of normal return or exception exit.

**New struct in `npu_utils.cpp`:**

```cpp
struct RetainedTensorHandle {
  explicit RetainedTensorHandle(at::Tensor tensor) : tensor(std::move(tensor)) {}
  at::Tensor tensor;
};
```

**Allocation interfaces changed from returning only a device pointer to also returning a handle:**

```cpp
extern "C" void* triton_allocate_workspace(uint64_t size, void **handle);
extern "C" void* triton_allocate_sync_block_lock(uint64_t size, void* stream, void **handle);
extern "C" void triton_release_retained_tensor(void *handle);
```

The `handle` points to a `RetainedTensorHandle`, which holds the actual `at::Tensor`. The launcher still passes the returned `void*` device pointer to runtime args, but also saves the handle.

**New release function pointer in launcher generated code:**

```cpp
typedef void (*triton_release_retained_tensor_t)(void*);
static triton_release_retained_tensor_t g_release_retained_tensor = nullptr;
```

**RAII guard constructed immediately after workspace allocation:**

```cpp
void *workspace_handle = NULL;
workspace_addr_ptr = g_allocate_workspace(totalWorkSpaceSize, &workspace_handle);
std::shared_ptr<void> workspace_handle_guard(workspace_handle, release_npu_tensor_handle);
```

**Sync block lock allocated inside `launch_call`, using the same guard pattern:**

```cpp
void *syncBlockLock_handle = NULL;
syncBlockLock_ptr = g_allocate_sync_block_lock(syncBlockLockSize, stream, &syncBlockLock_handle);
std::shared_ptr<void> syncBlockLock_handle_guard(syncBlockLock_handle, release_npu_tensor_handle);
```

When `TRITON_ENABLE_TASKQUEUE=true`, the `launch_call` lambda captures by `[=]`, so `workspace_handle_guard` stays alive along with the asynchronously submitted callable; in the non-taskqueue path, `_launch` synchronously waits for `rtStreamSynchronize(stream)` before returning, after which the guard destructs and releases the handle.

#### Lifecycle

**workspace:**
1. Launcher calls `g_allocate_workspace(size, &workspace_handle)`
2. `npu_utils.so` creates a `RetainedTensorHandle`, placing the tensor inside
3. Launcher obtains the device pointer `workspace_addr_ptr` and creates `workspace_handle_guard`
4. Kernel launch uses `workspace_addr_ptr`
5. After launch completes, guard destructs, calling `triton_release_retained_tensor(handle)`
6. Handle is deleted, `at::Tensor` destructs, releasing underlying device memory

**sync block lock:**
1. Launcher calls `g_allocate_sync_block_lock(size, stream, &syncBlockLock_handle)` inside the launch callable
2. `npu_utils.so` creates a handle and returns the device pointer
3. Launcher initializes lock data using `rtMemcpy`
4. Kernel launch uses `syncBlockLock_ptr`
5. After callable completes, guard destructs and releases the handle

#### Error Handling

- Allocation interfaces return `nullptr` when receiving a null handle pointer
- `*handle` is set to `nullptr` before allocation to prevent callers from erroneously freeing an uninitialized value
- On workspace allocation failure, prints `Error: workspace allocation failed` and returns
- On sync block lock allocation failure, follows the existing taskqueue/non-taskqueue return strategy
- `release_npu_tensor_handle` prints an error and returns when the release function pointer does not exist, preventing null function pointer invocation

#### Files Involved

- `third_party/ascend/backend/npu_utils.cpp` — removed global `retained_tensors` and mutex, added `RetainedTensorHandle`, allocation interfaces return both device pointer and opaque handle, added `triton_release_retained_tensor`
- `third_party/ascend/backend/driver.py` — launcher generated code gains release function pointer and `release_npu_tensor_handle`, workspace/sync block lock uses `std::shared_ptr<void>` guard to manage handles, `NPUUtils.load_binary` compatible with both old and new call signatures
- `third_party/ascend/backend/backend_register.py` — torch_npu backend workspace/sync block lock allocation template passes handle address
- `third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_lifetime.py` — covers global vector removal, release interface existence, launcher guard generation, and `load_binary` compatibility
