### PR TITLE
feat(ssbuffer): fixpipe opt

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
@@ -33,6 +33,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createUBUsageOptPass();
 std::unique_ptr<OperationPass<ModuleOp>> createUnifyAllocBlockPass();
 void registerUnifyAllocBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createFuseAdotBaddCPass();
+std::unique_ptr<OperationPass<ModuleOp>> createFixpipeOptPass();
 
 } // namespace triton
 } // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
@@ -1,0 +1,378 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Block.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "fixpipe-opt"
+#define LOG_DEBUG(msg) LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << msg << "\n")
+
+using namespace mlir;
+using namespace triton;
+
+namespace mlir {
+namespace triton {
+
+class FixpipeOptPass : public PassWrapper<FixpipeOptPass, OperationPass<ModuleOp>> {
+  public:
+    MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(FixpipeOptPass)
+
+    FixpipeOptPass() = default;
+    void runOnOperation() override;
+
+    llvm::StringRef getArgument() const final { return "fixpipe-opt"; }
+
+    llvm::StringRef getDescription() const final
+    {
+        return "Optimize matmul-cast-store pattern for fixpipe by setting core_type to CUBE";
+    }
+
+  private:
+    bool matchFixpipePattern(linalg::MatmulOp matmulOp, SmallVector<Operation *> &matchedOps);
+    bool applyFixpipeOpt(SmallVector<Operation *> &matchedOps, const CVPipeline::MemoryDependenceGraph &memGraph,
+                         CVPipeline::ComputeBlockIdManager &bm);
+    bool isSubviewFromGlobalMemory(memref::SubViewOp subviewOp, SmallVector<Operation *> &matchedOps);
+    bool isValidTrunc(Operation *op);
+};
+
+namespace {
+struct DependencyCycleDetector {
+    llvm::DenseSet<mlir::Operation *> &opsInNewBlock;
+    llvm::DenseSet<mlir::Operation *> visited;
+    const CVPipeline::MemoryDependenceGraph &memGraph;
+    CVPipeline::ComputeBlockIdManager &bm;
+    Block *block;
+    void clear() { visited.clear(); }
+    bool dfs(Operation *cur);
+    DependencyCycleDetector(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph,
+                            llvm::DenseSet<mlir::Operation *> &opsInNewBlock, CVPipeline::ComputeBlockIdManager &bm)
+        : block(block), memGraph(memGraph), opsInNewBlock(opsInNewBlock), bm(bm)
+    {
+    }
+};
+
+} // namespace
+
+bool DependencyCycleDetector::dfs(Operation *cur)
+{
+    if (opsInNewBlock.contains(cur)) {
+        return true;
+    }
+    if (!visited.insert(cur).second) {
+        return false;
+    }
+
+    SmallVector<Operation *> allusers;
+    allusers.append(cur->getUsers().begin(), cur->getUsers().end());
+    allusers.append(memGraph.getExecAfter(cur).begin(), memGraph.getExecAfter(cur).end());
+    for (auto *user : allusers) {
+        auto *userInBlock = CVPipeline::getAncestorInBlock(user, block);
+        if (bm.getBlockIdByOp(userInBlock) == -1) {
+            if (dfs(userInBlock)) {
+                return true;
+            }
+        } else {
+            for (auto *nx : bm.getOpsByBlockId(bm.getBlockIdByOp(userInBlock))) {
+                if (dfs(nx)) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+/**
+ * Check if adding willaddOps to targetBlockId will create cycle.
+ * Walk from every op in targetBlockId and willaddOps.
+ * if reach other blockid ops and dfs find any targetBlockId op, then there is cycle.
+ */
+static std::optional<bool> willCreateCycle(llvm::SmallVectorImpl<Operation *> &willaddOps, Block *block,
+                                           const CVPipeline::MemoryDependenceGraph &memGraph, int targetBlockId,
+                                           CVPipeline::ComputeBlockIdManager &bm)
+{
+    // Step1: Init, Add willaddOps to targetBlockId.
+    // opsInNewBlock is new block, includes two part: 1. original ops in targetBlockId. 2. willaddOps.
+    llvm::DenseSet<mlir::Operation *> opsInNewBlock;
+    for (auto op : bm.getOpsByBlockId(targetBlockId)) {
+        opsInNewBlock.insert(op);
+    }
+    llvm::DenseMap<mlir::Operation *, int> originBlockId;
+    for (auto op : willaddOps) {
+        opsInNewBlock.insert(op);
+        // For backtracing
+        originBlockId[op] = bm.getBlockIdByOp(op);
+        bm.updateBlockId(op, targetBlockId);
+    }
+    DependencyCycleDetector detector = {block, memGraph, opsInNewBlock, bm};
+
+    // Step2: Walk from every op in opsInNewBlock
+    auto ret = false;
+    for (mlir::Operation *testOp : opsInNewBlock) {
+        SmallVector<Operation *> allusers;
+        allusers.append(testOp->getUsers().begin(), testOp->getUsers().end());
+        allusers.append(memGraph.getExecAfter(testOp).begin(), memGraph.getExecAfter(testOp).end());
+        for (auto *user : allusers) {
+            auto *userInBlock = CVPipeline::getAncestorInBlock(user, block);
+            if (opsInNewBlock.contains(userInBlock)) {
+                continue;
+            }
+            if (bm.getBlockIdByOp(userInBlock) == -1) {
+                detector.clear();
+                if (detector.dfs(userInBlock)) {
+                    ret = true;
+                    break;
+                }
+                continue;
+            }
+            auto opsUsedBlockId = bm.getOpsByBlockId(bm.getBlockIdByOp(userInBlock));
+            for (auto *userOp : opsUsedBlockId) {
+                detector.clear();
+                if (detector.dfs(userOp)) {
+                    ret = true;
+                    break;
+                }
+            }
+        }
+        if (ret) {
+            // early stop if find cycle.
+            break;
+        }
+    }
+
+    // Step3: Backtrace blockId change.
+    for (auto op : willaddOps) {
+        bm.updateBlockId(op, originBlockId[op]);
+    }
+    return ret;
+}
+
+bool FixpipeOptPass::isValidTrunc(Operation *op)
+{
+    // Just filter: arith.truncf(f32->bf16, f32->f16, i32->i8)
+    if (auto truncFOp = dyn_cast<arith::TruncFOp>(op)) {
+        Type inType = truncFOp.getIn().getType();
+        Type outType = truncFOp.getResult().getType();
+        if (auto shapedType = dyn_cast<ShapedType>(inType))
+            inType = shapedType.getElementType();
+        if (auto shapedType = dyn_cast<ShapedType>(outType))
+            outType = shapedType.getElementType();
+
+        return isa<Float32Type>(inType) && (isa<BFloat16Type>(outType) || isa<Float16Type>(outType));
+    }
+    if (auto truncIOp = dyn_cast<arith::TruncIOp>(op)) {
+        Type inType = truncIOp.getIn().getType();
+        Type outType = truncIOp.getResult().getType();
+        if (auto shapedType = dyn_cast<ShapedType>(inType))
+            inType = shapedType.getElementType();
+        if (auto shapedType = dyn_cast<ShapedType>(outType))
+            outType = shapedType.getElementType();
+
+        return inType.isInteger(32) && outType.isInteger(8);
+    }
+    return false;
+}
+
+bool FixpipeOptPass::isSubviewFromGlobalMemory(memref::SubViewOp subviewOp, SmallVector<Operation *> &matchedOps)
+{
+    // Subview ops may be nested many layers deep through reinterpretation or other subviews.
+    // like, subview (subview (reinterpret_cast (subview (reinterpret_cast (arg0)))))
+    // so we need Search and only keep same block view-like op.
+    Value source = subviewOp.getSource();
+    auto block = subviewOp->getBlock();
+    while (true) {
+        LOG_DEBUG("Check subview source: " << source << "\n");
+        if (auto blockArg = dyn_cast<BlockArgument>(source)) {
+            Operation *parentOp = blockArg.getOwner()->getParentOp();
+            if (isa<func::FuncOp>(parentOp)) {
+                return true;
+            } else {
+                LOG_DEBUG("Subview source block argument is not from func entry block.");
+                return false;
+            }
+        }
+        // From other view-like op
+        if (auto viewLike = dyn_cast<ViewLikeOpInterface>(source.getDefiningOp())) {
+            if (viewLike->getBlock() == block) {
+                matchedOps.push_back(viewLike.getOperation());
+            }
+            source = viewLike.getViewSource();
+            continue;
+        }
+        LOG_DEBUG("Subview source defining op is not ViewLikeOpInterface: " << source);
+        return false;
+    }
+    return false;
+}
+
+/** To use fixpipe optimization, the pattern should be like below:
+    linalg.matmul
+        ↓
+    arith.truncf(f32->bf16, f32->f16, i32->i8)
+        ↓
+    tensor.extract_slice
+        ↓
+    bufferization.materialize_in_destination memref.subview(gm)
+    After optimization, all these ops will be in same block with matmul and set core_type to CUBE.
+ */
+bool FixpipeOptPass::matchFixpipePattern(linalg::MatmulOp matmulOp, SmallVector<Operation *> &matchedOps)
+{
+    Value matmulResult = matmulOp.getResult(0);
+    if (!matmulResult.hasOneUse()) {
+        LOG_DEBUG("Matmul not only one user, NOT match.");
+        return false;
+    }
+    auto maybeTrunc = *matmulResult.getUsers().begin();
+    Operation *truncOp = nullptr;
+    if (isValidTrunc(maybeTrunc)) {
+        truncOp = maybeTrunc;
+    } else {
+        LOG_DEBUG("Cannot find valid trunc op (f32->bf16/f16 or i32->i8), NOT match.");
+        return false;
+    }
+
+    Value truncResult = truncOp->getResult(0);
+    if (!truncResult.hasOneUse()) {
+        LOG_DEBUG("Trunc not only one user, NOT match.");
+        return false;
+    }
+    auto maybeExtract = *truncResult.getUsers().begin();
+    tensor::ExtractSliceOp extractSliceOp = nullptr;
+    if (auto extract = dyn_cast<tensor::ExtractSliceOp>(maybeExtract)) {
+        extractSliceOp = extract;
+    } else {
+        LOG_DEBUG("Cannot find extract slice op, NOT match");
+        return false;
+    }
+
+    Value extractResult = extractSliceOp.getResult();
+    if (!extractResult.hasOneUse()) {
+        LOG_DEBUG("Extract Slice not only one user, NOT match.");
+        return false;
+    }
+    auto maybeMaterialize = *extractResult.getUsers().begin();
+    bufferization::MaterializeInDestinationOp materializeOp = nullptr;
+
+    if (auto materialize = dyn_cast<bufferization::MaterializeInDestinationOp>(maybeMaterialize)) {
+        materializeOp = materialize;
+    } else {
+        LOG_DEBUG("Cannot find materialize op, NOT match");
+        return false;
+    }
+
+    Value destMemref = materializeOp.getDest();
+    auto subviewOp = destMemref.getDefiningOp<memref::SubViewOp>();
+    if (!subviewOp) {
+        LOG_DEBUG("Materialize destination is not from memref.subview, NOT match");
+        return false;
+    }
+
+    matchedOps.push_back(matmulOp);
+    matchedOps.push_back(truncOp);
+    matchedOps.push_back(extractSliceOp);
+    matchedOps.push_back(materializeOp);
+    matchedOps.push_back(subviewOp);
+
+    if (!isSubviewFromGlobalMemory(subviewOp, matchedOps)) {
+        LOG_DEBUG("Subview is not from global memory (GM), NOT match.");
+        return false;
+    }
+    return true;
+}
+
+bool FixpipeOptPass::applyFixpipeOpt(SmallVector<Operation *> &matchedOps,
+                                     const CVPipeline::MemoryDependenceGraph &memGraph,
+                                     CVPipeline::ComputeBlockIdManager &bm)
+{
+    // If there are no cycle in Compute Block level, we apply:
+    // 1. Change block_id to the matmul's block id
+    // 2. Change core_type to CUBE.
+    Operation *matmulOp = matchedOps[0];
+    int targetBlockId = bm.getBlockIdByOp(matmulOp);
+    auto block = matmulOp->getBlock();
+
+    if (willCreateCycle(matchedOps, block, memGraph, targetBlockId, bm).value_or(true)) {
+        return false;
+    }
+    for (Operation *op : matchedOps) {
+        bm.updateBlockId(op, targetBlockId);
+    }
+    for (Operation *op : matchedOps) {
+        op->setAttr(CVPipeline::kCoreType, StringAttr::get(op->getContext(), "CUBE"));
+    }
+    return true;
+}
+
+void FixpipeOptPass::runOnOperation()
+{
+    ModuleOp module = getOperation();
+    auto &aliasAnalysis = getAnalysis<AliasAnalysis>();
+    CVPipeline::MemoryDependenceGraph memDepGraph(module, aliasAnalysis);
+    LOG_DEBUG("== FixpipeOpt Pass Start ==\n");
+    LOG_DEBUG(module);
+
+    SmallVector<SmallVector<Operation *>> allMatchedPatterns;
+
+    module.walk([&](linalg::MatmulOp matmulOp) {
+        SmallVector<Operation *> matchedOps;
+        if (matchFixpipePattern(matmulOp, matchedOps)) {
+            allMatchedPatterns.push_back(matchedOps);
+        }
+    });
+    LOG_DEBUG("== Found " << allMatchedPatterns.size() << " fixpipe patterns ==\n");
+
+    auto bm = CVPipeline::ComputeBlockIdManager(module);
+    for (auto &matchedOps : allMatchedPatterns) {
+        if (!applyFixpipeOpt(matchedOps, memDepGraph, bm)) {
+            for (Operation *op : matchedOps) {
+                LOG_DEBUG("Cannot set block id for op: " << *op);
+            }
+            LOG_DEBUG("Cannot set one Block Id, may be because cycle");
+        }
+    }
+
+    LOG_DEBUG("== FixpipeOpt Pass Complete ==\n");
+}
+
+std::unique_ptr<OperationPass<ModuleOp>> createFixpipeOptPass()
+{
+    return std::make_unique<FixpipeOptPass>();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
@@ -47,8 +47,11 @@ void ComputeBlockOptPass::runOnOperation()
 
     pm.addPass(createUBUsageOptPass());
     pm.addPass(createReorderOpsByBlockIdPass());
-
+    
     pm.addPass(createFuseAdotBaddCPass());
+    
+    pm.addPass(createFixpipeOptPass());
+    pm.addPass(createReorderOpsByBlockIdPass());
 
     if (failed(runPipeline(pm, module))) {
         signalPassFailure();
@@ -70,6 +73,7 @@ void registerComputeBlockOptPasses()
     registerPass(createUBUsageOptPass);
     registerPass(createFuseAdotBaddCPass);
     registerPass(createUnifyAllocBlockPass);
+    registerPass(createFixpipeOptPass);
 }
 
 } // namespace triton

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/fixpipe_opt.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/fixpipe_opt.mlir
@@ -1,0 +1,204 @@
+// RUN: triton-opt --fixpipe-opt %s | FileCheck %s
+
+module {
+  // Test 1: Basic fixpipe pattern - should match and set core_type to CUBE
+  // CHECK-LABEL: func @test_basic_fixpipe_pattern
+  func.func @test_basic_fixpipe_pattern(%arg0: memref<128x64xf16> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>) {
+    // CHECK: linalg.matmul {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK: arith.truncf %{{.*}} {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"}
+    %trunc = arith.truncf %matmul {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"}
+    %extract = tensor.extract_slice %trunc[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"}
+    %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16> to memref<64x64xf16, strided<[64, 1]>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"}
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1]>>) -> ()
+    return
+  }
+
+  // Test 2: Nested subview chain from global memory - should match
+  // CHECK-LABEL: func @test_nested_subview_from_global
+  func.func @test_nested_subview_from_global(%arg0: memref<256x64xf16> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>) {
+    // CHECK: linalg.matmul {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK: arith.truncf %{{.*}} {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"}
+    %trunc = arith.truncf %matmul {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"}
+    %extract = tensor.extract_slice %trunc[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 13 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"}
+    %subview1 = memref.subview %arg0[0, 0] [128, 64] [1, 1] {ssbuffer.block_id = 14 : i32, ssbuffer.core_type = "VECTOR"} : memref<256x64xf16> to memref<128x64xf16, strided<[64, 1]>>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"}
+    %subview2 = memref.subview %subview1[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1]>> to memref<64x64xf16, strided<[64, 1]>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"}
+    bufferization.materialize_in_destination %extract in writable %subview2 {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1]>>) -> ()
+    return
+  }
+
+  // Test 3: Reinterpret_cast chain from global memory - should match
+  // CHECK-LABEL: func @test_reinterpret_cast_from_global
+  func.func @test_reinterpret_cast_from_global(%arg0: memref<?xf16> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>) {
+    %c0 = arith.constant 0 : index
+    // CHECK: linalg.matmul {ssbuffer.block_id = 21 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 21 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK: arith.truncf %{{.*}} {ssbuffer.block_id = 21 : i32, ssbuffer.core_type = "CUBE"}
+    %trunc = arith.truncf %matmul {ssbuffer.block_id = 22 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 21 : i32, ssbuffer.core_type = "CUBE"}
+    %extract = tensor.extract_slice %trunc[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 23 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    // CHECK: memref.reinterpret_cast %{{.*}} {ssbuffer.block_id = 21 : i32, ssbuffer.core_type = "CUBE"}
+    %reinterpret = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [128, 64], strides: [64, 1] {ssbuffer.block_id = 24 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 21 : i32, ssbuffer.core_type = "CUBE"}
+    %subview = memref.subview %reinterpret[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 25 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 21 : i32, ssbuffer.core_type = "CUBE"}
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 25 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+    return
+  }
+
+  // Test 4: Subview from scf.for iter arg (global memory) - should match
+  // CHECK-LABEL: func @test_subview_from_for_iter_arg
+  func.func @test_subview_from_for_iter_arg(%arg0: memref<128x64xf16> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c10 = arith.constant 10 : index
+    
+    %result = scf.for %iv = %c0 to %c10 step %c1 iter_args(%memref = %arg0) -> (memref<128x64xf16>) {
+      // CHECK: linalg.matmul {ssbuffer.block_id = 31 : i32, ssbuffer.core_type = "CUBE"}
+      %matmul = linalg.matmul {ssbuffer.block_id = 31 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
+      // CHECK: arith.truncf %{{.*}} {ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"}
+      %trunc = arith.truncf %matmul {ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+      // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 33 : i32, ssbuffer.core_type = "VECTOR"}
+      %extract = tensor.extract_slice %trunc[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 33 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+      // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 34 : i32, ssbuffer.core_type = "VECTOR"}
+      %subview = memref.subview %memref[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 34 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16> to memref<64x64xf16, strided<[64, 1]>>
+      // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 35 : i32, ssbuffer.core_type = "VECTOR"}
+      bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 35 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1]>>) -> ()
+      
+      scf.yield %memref : memref<128x64xf16>
+    }
+    
+    return
+  }
+
+  // Test 5: No truncf op - should NOT match
+  // CHECK-LABEL: func @test_no_truncf
+  func.func @test_no_truncf(%arg0: memref<128x64xf16> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf16>) {
+    // CHECK: linalg.matmul {ssbuffer.block_id = 41 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 41 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf16>) -> tensor<64x64xf16>
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 43 : i32, ssbuffer.core_type = "VECTOR"}
+    %extract = tensor.extract_slice %matmul[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 43 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 44 : i32, ssbuffer.core_type = "VECTOR"}
+    %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 44 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16> to memref<64x64xf16, strided<[64, 1]>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 45 : i32, ssbuffer.core_type = "VECTOR"}
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 45 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1]>>) -> ()
+    return
+  }
+
+  // Test 6: Subview from alloc (not global memory) - should NOT match
+  // CHECK-LABEL: func @test_subview_from_alloc
+  func.func @test_subview_from_alloc(%A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>) {
+    // CHECK: linalg.matmul {ssbuffer.block_id = 51 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 51 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK: arith.truncf %{{.*}} {ssbuffer.block_id = 52 : i32, ssbuffer.core_type = "VECTOR"}
+    %trunc = arith.truncf %matmul {ssbuffer.block_id = 52 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 53 : i32, ssbuffer.core_type = "VECTOR"}
+    %extract = tensor.extract_slice %trunc[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 53 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    // CHECK: memref.alloc() {ssbuffer.block_id = 54 : i32, ssbuffer.core_type = "VECTOR"}
+    %alloc = memref.alloc() {ssbuffer.block_id = 54 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 55 : i32, ssbuffer.core_type = "VECTOR"}
+    %subview = memref.subview %alloc[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 55 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16> to memref<64x64xf16, strided<[64, 1]>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 55 : i32, ssbuffer.core_type = "VECTOR"}
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 55 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1]>>) -> ()
+    return
+  }
+
+  // Test 7: No extract_slice op - should NOT match
+  // CHECK-LABEL: func @test_no_extract_slice
+  func.func @test_no_extract_slice(%arg0: memref<128x64xf16> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>) {
+    // CHECK: linalg.matmul {ssbuffer.block_id = 61 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 61 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK: arith.truncf %{{.*}} {ssbuffer.block_id = 62 : i32, ssbuffer.core_type = "VECTOR"}
+    %trunc = arith.truncf %matmul {ssbuffer.block_id = 62 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 64 : i32, ssbuffer.core_type = "VECTOR"}
+    %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 64 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16> to memref<64x64xf16, strided<[64, 1]>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 65 : i32, ssbuffer.core_type = "VECTOR"}
+    bufferization.materialize_in_destination %trunc in writable %subview {ssbuffer.block_id = 65 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1]>>) -> ()
+    return
+  }
+
+  // Test 8: No materialize_in_destination op - should NOT match
+  // CHECK-LABEL: func @test_no_materialize
+  func.func @test_no_materialize(%arg0: memref<128x64xf16> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>) {
+    // CHECK: linalg.matmul {ssbuffer.block_id = 71 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 71 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK: arith.truncf %{{.*}} {ssbuffer.block_id = 72 : i32, ssbuffer.core_type = "VECTOR"}
+    %trunc = arith.truncf %matmul {ssbuffer.block_id = 72 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 73 : i32, ssbuffer.core_type = "VECTOR"}
+    %extract = tensor.extract_slice %trunc[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 73 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    return
+  }
+
+  // Test 9: Destination is function argument (not from subview) - should NOT match
+  // CHECK-LABEL: func @test_dest_not_subview
+  func.func @test_dest_not_subview(%A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>, %dest: memref<64x64xf16, strided<[64, 1]>>) {
+    // CHECK: linalg.matmul {ssbuffer.block_id = 81 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 81 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK: arith.truncf %{{.*}} {ssbuffer.block_id = 82 : i32, ssbuffer.core_type = "CUBE"}
+    %trunc = arith.truncf %matmul {ssbuffer.block_id = 82 : i32, ssbuffer.core_type = "CUBE"} : tensor<64x64xf32> to tensor<64x64xf16>
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 83 : i32, ssbuffer.core_type = "VECTOR"}
+    %extract = tensor.extract_slice %trunc[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 83 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 85 : i32}
+    bufferization.materialize_in_destination %extract in writable %dest {ssbuffer.block_id = 85 : i32} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1]>>) -> ()
+    return
+  }
+
+  // Test 10: Not linalg.matmul (using arithmetic ops) - should NOT match
+  // CHECK-LABEL: func @test_not_matmul
+  func.func @test_not_matmul(%arg0: memref<128x64xf16> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>) {
+    // CHECK: arith.extf %{{.*}} {ssbuffer.block_id = 91 : i32, ssbuffer.core_type = "VECTOR"}
+    %extA = arith.extf %A {ssbuffer.block_id = 91 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf32>
+    // CHECK: arith.extf %{{.*}} {ssbuffer.block_id = 91 : i32, ssbuffer.core_type = "VECTOR"}
+    %extB = arith.extf %B {ssbuffer.block_id = 91 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf32>
+    // CHECK: arith.addf %{{.*}} {ssbuffer.block_id = 91 : i32, ssbuffer.core_type = "VECTOR"}
+    %add = arith.addf %extA, %extB {ssbuffer.block_id = 91 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+    // CHECK: arith.truncf %{{.*}} {ssbuffer.block_id = 91 : i32, ssbuffer.core_type = "VECTOR"}
+    %trunc = arith.truncf %add {ssbuffer.block_id = 91 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 95 : i32, ssbuffer.core_type = "CUBE"}
+    %extract = tensor.extract_slice %trunc[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 95 : i32, ssbuffer.core_type = "CUBE"} : tensor<64x64xf16> to tensor<64x64xf16>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 96 : i32, ssbuffer.core_type = "CUBE"}
+    %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 96 : i32, ssbuffer.core_type = "CUBE"} : memref<128x64xf16> to memref<64x64xf16, strided<[64, 1]>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 97 : i32}
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 97 : i32} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1]>>) -> ()
+    return
+  }
+
+  // Test 11: Cyclic fixpipe chains - should NOT merge due to cycle
+  // CHECK-LABEL: func @test_cyclic_fixpipe
+  func.func @test_cyclic_fixpipe(%arg0: memref<128x64xf16> {tt.divisibility = 16 : i32}, %arg1: memref<?xf16> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>, %init2: tensor<64x64xf32>) {
+    %c0 = arith.constant 0 : index
+    // CHECK: linalg.matmul {ssbuffer.block_id = 100 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 100 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK: arith.addf %{{.*}} {ssbuffer.block_id = 101 : i32, ssbuffer.core_type = "VECTOR"}
+    %extA = arith.extf %A {ssbuffer.block_id = 101 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf32>
+    %extB = arith.extf %B {ssbuffer.block_id = 101 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf32>
+    %add = arith.addf %extA, %extB {ssbuffer.block_id = 101 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+    // CHECK: memref.reinterpret_cast %{{.*}} {ssbuffer.block_id = 101 : i32, ssbuffer.core_type = "VECTOR"}
+    %reinterpret = memref.reinterpret_cast %arg1 to offset: [%c0], sizes: [128, 64], strides: [64, 1] {ssbuffer.block_id = 101 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 101 : i32, ssbuffer.core_type = "VECTOR"}
+    %subview1 = memref.subview %reinterpret[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 101 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    // CHECK: arith.truncf %{{.*}} {ssbuffer.block_id = 101 : i32, ssbuffer.core_type = "VECTOR"}
+    %trunc1 = arith.truncf %add {ssbuffer.block_id = 101 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 102 : i32, ssbuffer.core_type = "VECTOR"}
+    %extract1 = tensor.extract_slice %trunc1[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 102 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 102 : i32, ssbuffer.core_type = "VECTOR"}
+    bufferization.materialize_in_destination %extract1 in writable %subview1 {ssbuffer.block_id = 102 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+    // CHECK: arith.truncf %{{.*}} {ssbuffer.block_id = 103 : i32, ssbuffer.core_type = "VECTOR"}
+    %trunc2 = arith.truncf %matmul {ssbuffer.block_id = 103 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 104 : i32, ssbuffer.core_type = "VECTOR"}
+    %extract2 = tensor.extract_slice %trunc2[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 104 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 103 : i32, ssbuffer.core_type = "VECTOR"}
+    %subview2 = memref.subview %reinterpret[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 103 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 104 : i32, ssbuffer.core_type = "VECTOR"}
+    bufferization.materialize_in_destination %extract2 in writable %subview2 {ssbuffer.block_id = 104 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+    return
+  }
+}


### PR DESCRIPTION
This PR introduces a new optimization pass (FixpipeOptPass) in the DynamicCVPipeline that optimizes the fixpipe pattern for Ascend hardware. The pass identifies a specific operation chain: 
```
linalg.matmul 
↓
arith.truncf
↓
tensor.extract_slice 
↓
bufferization.materialize_in_destination memref.subview(gm)
```
When matched, the pass sets the ssbuffer.core_type attribute to "CUBE" for all operations in the pattern and merges them into the same compute block. 
The implementation includes cycle detection to prevent dependency violations when consolidating operations. 


# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
