### PR TITLE
fix(ssbuffer): fix mistransfer when multi dependent value users in the same block

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -39,6 +39,7 @@ inline constexpr llvm::StringLiteral kVectorFirst = "ssbuffer.vector_first";
 inline constexpr llvm::StringLiteral kAddFromMatmul = "ssbuffer.add_from_matmul";
 inline constexpr llvm::StringLiteral kMainLoop = "ssbuffer.main_loop";
 inline constexpr llvm::StringLiteral kIf = "ssbuffer.if";
+inline constexpr llvm::StringLiteral kIntraBuffer = "ssbuffer.intra_buffer";
 inline constexpr const char *ERRCODE_ATTR = "triton_ascend.dynamic_cv_pipeline.rc";
 static constexpr const int ERRCODE_FAILED = 1;
 static constexpr const int ERRCODE_IGNORED = 2;

--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
@@ -22,6 +22,7 @@
 
 #include "ascend/include/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.h"
 #include "ascend/include/DynamicCVPipeline/Common/BufferCountManager.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 
 #include <climits>
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
@@ -44,6 +45,7 @@ using namespace mlir;
 using namespace hivm;
 using namespace annotation;
 using namespace triton;
+using namespace CVPipeline;
 
 using BufferPair = std::pair<Value, Value>;
 using BufferMap = DenseMap<Value, SmallVector<BufferPair>>;
@@ -51,21 +53,17 @@ using BufferMap = DenseMap<Value, SmallVector<BufferPair>>;
 // Buffer count constants
 constexpr int kBufferCountOne = 1;
 
-// Attribute name constants
-static constexpr const char *kAttrBlockId = "ssbuffer.block_id";
-static constexpr const char *kAttrMainLoop = "ssbuffer.main_loop";
-
 namespace mlir {
 namespace triton {
 
 // Check if forOp has main_loop attribute
 static bool hasMainLoopAttr(scf::ForOp forOp)
 {
-    if (forOp->hasAttr(kAttrMainLoop)) {
+    if (forOp->hasAttr(kMainLoop)) {
         return true;
     }
     if (auto *term = forOp.getBody()->getTerminator())
-        return term->hasAttr(kAttrMainLoop);
+        return term->hasAttr(kMainLoop);
     return false;
 }
 
@@ -106,7 +104,7 @@ struct InnerBlockInfo {
 // Get ssbuffer block_id attribute from op, returns INT_MIN if not found
 static int getSsbufferId(Operation *op)
 {
-    if (auto idAttr = op->getAttrOfType<IntegerAttr>(kAttrBlockId))
+    if (auto idAttr = op->getAttrOfType<IntegerAttr>(kBlockId))
         return idAttr.getInt();
     return INT_MIN;
 }
@@ -131,17 +129,17 @@ static int getForOpPriority(scf::ForOp f)
     constexpr int priorityIterArgs = 3;
 
     // Check if forOp itself has main_loop attribute
-    bool hasMainloop = f->hasAttr(kAttrMainLoop);
+    bool hasMainloop = f->hasAttr(kMainLoop);
     bool bodyHasMainloop = false;
     bool bodyHasBlockId = false;
 
     // Check terminator for main_loop and block_id attributes
     if (auto *term = f.getBody()->getTerminator()) {
-        bodyHasMainloop = term->hasAttr(kAttrMainLoop);
-        bodyHasBlockId = term->getAttrOfType<IntegerAttr>(kAttrBlockId) != nullptr;
+        bodyHasMainloop = term->hasAttr(kMainLoop);
+        bodyHasBlockId = term->getAttrOfType<IntegerAttr>(kBlockId) != nullptr;
     }
 
-    bool opHasBlockId = f->getAttrOfType<IntegerAttr>(kAttrBlockId) != nullptr;
+    bool opHasBlockId = f->getAttrOfType<IntegerAttr>(kBlockId) != nullptr;
     bool hasIterArgs = f.getNumResults() > 0 || !f.getInitArgs().empty();
 
     if (hasMainloop || bodyHasMainloop) {
@@ -203,7 +201,7 @@ static scf::ForOp findNestedMainloopInForOp(scf::ForOp forOp)
         auto nestedFor = dyn_cast<scf::ForOp>(op);
         if (!nestedFor)
             continue;
-        if (nestedFor->hasAttr(kAttrMainLoop))
+        if (nestedFor->hasAttr(kMainLoop))
             return nestedFor;
     }
     return {};
@@ -216,7 +214,7 @@ bool isInsideMainLoopForOp(Operation *op)
         return false;
     }
     if (auto forOp = dyn_cast<scf::ForOp>(parent)) {
-        return forOp->hasAttr(kAttrMainLoop);
+        return forOp->hasAttr(kMainLoop);
     }
     return false;
 }
@@ -226,7 +224,7 @@ bool isInsideMainLoopForOpTraverse(Operation *op)
     Operation *parent = op->getParentOp();
     while (parent) {
         if (auto forOp = dyn_cast<scf::ForOp>(parent)) {
-            if (forOp->hasAttr(kAttrMainLoop)) {
+            if (forOp->hasAttr(kMainLoop)) {
                 return true;
             }
         }
@@ -399,7 +397,7 @@ SmallVector<Value> collectScalarDeps(DenseMap<Value, SmallVector<Value>> &depVal
                 continue;
                 // Check if definingOp's parentOp is a main_loop forOp
                 auto *parentOp = depDefinedOp->getParentOp();
-                if (!parentOp || !parentOp->hasAttr(kAttrMainLoop))
+                if (!parentOp || !parentOp->hasAttr(kMainLoop))
                     continue;
             }
 
@@ -460,7 +458,7 @@ static Value getIterCount(OpBuilder &builder, mlir::scf::ForOp forOp, Location l
             if (newOps)
                 newOps->push_back(iterIdx.getDefiningOp());
             if (blockId >= 0) {
-                iterIdx.getDefiningOp()->setAttr(kAttrBlockId, builder.getI32IntegerAttr(blockId));
+                iterIdx.getDefiningOp()->setAttr(kBlockId, builder.getI32IntegerAttr(blockId));
             }
         }
     } else {
@@ -472,8 +470,8 @@ static Value getIterCount(OpBuilder &builder, mlir::scf::ForOp forOp, Location l
             newOps->push_back(iterIdx.getDefiningOp());
         }
         if (blockId >= 0) {
-            diff.getDefiningOp()->setAttr(kAttrBlockId, builder.getI32IntegerAttr(blockId));
-            iterIdx.getDefiningOp()->setAttr(kAttrBlockId, builder.getI32IntegerAttr(blockId));
+            diff.getDefiningOp()->setAttr(kBlockId, builder.getI32IntegerAttr(blockId));
+            iterIdx.getDefiningOp()->setAttr(kBlockId, builder.getI32IntegerAttr(blockId));
         }
     }
 
@@ -499,7 +497,7 @@ static Value getIterCount(OpBuilder &builder, mlir::scf::ForOp forOp, Location l
     if (newOps)
         newOps->push_back(result.getDefiningOp());
     if (blockId >= 0) {
-        result.getDefiningOp()->setAttr(kAttrBlockId, builder.getI32IntegerAttr(blockId));
+        result.getDefiningOp()->setAttr(kBlockId, builder.getI32IntegerAttr(blockId));
     }
     return result;
 }
@@ -537,8 +535,8 @@ static int buildIfChainTwoBuffers(OpBuilder &builder, Location loc, Value indexV
 
     // Tag counter operations with block_id
     if (blockId >= 0) {
-        zero.getDefiningOp()->setAttr(kAttrBlockId, builder.getI32IntegerAttr(blockId));
-        firstCond.getDefiningOp()->setAttr(kAttrBlockId, builder.getI32IntegerAttr(blockId));
+        zero.getDefiningOp()->setAttr(kBlockId, builder.getI32IntegerAttr(blockId));
+        firstCond.getDefiningOp()->setAttr(kBlockId, builder.getI32IntegerAttr(blockId));
     }
 
     // Then branch: use buffer[0]
@@ -572,8 +570,8 @@ static int buildIfChainMultiBuffers(OpBuilder &builder, Location loc, Value inde
     Value zeroVal = builder.create<mlir::arith::ConstantIntOp>(loc, 0, 32);
     Value firstCond = builder.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::eq, indexVal, zeroVal);
     if (blockId >= 0) {
-        zeroVal.getDefiningOp()->setAttr(kAttrBlockId, builder.getI32IntegerAttr(blockId));
-        firstCond.getDefiningOp()->setAttr(kAttrBlockId, builder.getI32IntegerAttr(blockId));
+        zeroVal.getDefiningOp()->setAttr(kBlockId, builder.getI32IntegerAttr(blockId));
+        firstCond.getDefiningOp()->setAttr(kBlockId, builder.getI32IntegerAttr(blockId));
     }
     newOps.push_back(zeroVal.getDefiningOp());
     newOps.push_back(firstCond.getDefiningOp());
@@ -601,8 +599,8 @@ static int buildIfChainMultiBuffers(OpBuilder &builder, Location loc, Value inde
         Value iVal = builder.create<mlir::arith::ConstantIntOp>(loc, i, 32);
         Value cond = builder.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::eq, indexVal, iVal);
         if (blockId >= 0) {
-            iVal.getDefiningOp()->setAttr(kAttrBlockId, builder.getI32IntegerAttr(blockId));
-            cond.getDefiningOp()->setAttr(kAttrBlockId, builder.getI32IntegerAttr(blockId));
+            iVal.getDefiningOp()->setAttr(kBlockId, builder.getI32IntegerAttr(blockId));
+            cond.getDefiningOp()->setAttr(kBlockId, builder.getI32IntegerAttr(blockId));
         }
         newOps.push_back(iVal.getDefiningOp());
         newOps.push_back(cond.getDefiningOp());
@@ -671,8 +669,8 @@ static Value computeBufferIndex(OpBuilder &builder, mlir::scf::ForOp forOp, Loca
     // Tag counter operations with block_id
     if (blockId >= 0) {
         MLIRContext *ctx = builder.getContext();
-        Nval.getDefiningOp()->setAttr(kAttrBlockId, builder.getI32IntegerAttr(blockId));
-        bufIdx.getDefiningOp()->setAttr(kAttrBlockId, builder.getI32IntegerAttr(blockId));
+        Nval.getDefiningOp()->setAttr(kBlockId, builder.getI32IntegerAttr(blockId));
+        bufIdx.getDefiningOp()->setAttr(kBlockId, builder.getI32IntegerAttr(blockId));
     }
     return bufIdx;
 }
@@ -768,7 +766,7 @@ static void addBlockAttrForOps(SmallVector<Operation *> &newOps, int blockId, Op
 {
     auto attr = builder.getI32IntegerAttr(blockId);
     for (auto *op : newOps)
-        op->setAttr(kAttrBlockId, attr);
+        op->setAttr(kBlockId, attr);
 }
 
 // Add dep_mark attribute to operation
@@ -789,7 +787,7 @@ static void addIntraBufferAttr(SmallVector<Operation *> &ops, OpBuilder &builder
 {
     for (auto *op : ops) {
         if (isa<scf::IfOp>(op) || isa<hivm::CopyOp>(op) || isa<bufferization::ToTensorOp>(op)) {
-            op->setAttr("ssbuffer.intra_buffer", builder.getUnitAttr());
+            op->setAttr(kIntraBuffer, builder.getUnitAttr());
         }
     }
 }
@@ -847,8 +845,8 @@ static Operation *insertBufferSelectionInRegion(OpBuilder &builder, Region &regi
 
     // Tag all operations in newIfOps with block_id
     for (auto *op : newIfOps) {
-        op->setAttr(kAttrBlockId, builder.getI32IntegerAttr(blockId));
-        op->setAttr("ssbuffer.intra_buffer", builder.getUnitAttr());
+        op->setAttr(kBlockId, builder.getI32IntegerAttr(blockId));
+        op->setAttr(kIntraBuffer, builder.getUnitAttr());
     }
 
     // The main scf.if is the first one in outIfOps
@@ -901,10 +899,10 @@ static bool isMultiRegionConsumerFromYield(Operation *depUser, Value depVal)
     return true;  // depVal comes from yield
 }
 
-// Process normal consumer logic (non-scif.if from yield case)
-static int processNormalConsumer(OpBuilder &consumedBuilder, Value depVal, SmallVector<BufferPair> &buffers,
-                                mlir::scf::ForOp mainLoopForOp, Operation *depUser, int userBlockId,
-                                int groupId, OpBuilder &globalBuilder)
+// Process normal consumer for a block: generate one buffer selection and share among all ops in the block
+static int processNormalConsumerBlock(OpBuilder &consumedBuilder, Value depVal, SmallVector<BufferPair> &buffers,
+                                     mlir::scf::ForOp mainLoopForOp, SmallVector<Operation *> &opsInBlock,
+                                     int userBlockId, int groupId, OpBuilder &globalBuilder)
 {
     SmallVector<Operation *> resultIfOps;
     int ret = insertConsumerLogic(consumedBuilder, depVal, buffers, mainLoopForOp, resultIfOps, groupId, userBlockId);
@@ -918,7 +916,7 @@ static int processNormalConsumer(OpBuilder &consumedBuilder, Value depVal, Small
     if (buffers.size() > kBufferCountOne) {
         for (auto *op : resultIfOps) {
             if (isa<scf::IfOp>(op)) {
-                op->setAttr("ssbuffer.intra_buffer", globalBuilder.getUnitAttr());
+                op->setAttr(kIntraBuffer, globalBuilder.getUnitAttr());
             }
         }
     } else {
@@ -928,9 +926,12 @@ static int processNormalConsumer(OpBuilder &consumedBuilder, Value depVal, Small
     Operation *resultIf = resultIfOps.back();
     Value selectedBuffer = resultIf->getResult(0);
 
-    for (OpOperand &use : depUser->getOpOperands()) {
-        if (use.get() == depVal)
-            use.set(selectedBuffer);
+    // Replace operands of all ops in this block
+    for (Operation *opInBlock : opsInBlock) {
+        for (OpOperand &use : opInBlock->getOpOperands()) {
+            if (use.get() == depVal)
+                use.set(selectedBuffer);
+        }
     }
     return 0;
 }
@@ -1003,32 +1004,55 @@ static int processDepVal(Value depVal, mlir::scf::ForOp mainLoopForOp, BufferMap
     if (buffers.size() > kBufferCountOne) {
         for (auto *op : producerNewOps) {
             if (isa<scf::IfOp>(op)) {
-                op->setAttr("ssbuffer.intra_buffer", globalBuilder.getUnitAttr());
+                op->setAttr(kIntraBuffer, globalBuilder.getUnitAttr());
             }
         }
     } else {
         addIntraBufferAttr(producerNewOps, globalBuilder);
     }
 
-    // Process each consumer
+    // Single pass: process both normal ops and multi-region ops
+    // For normal ops: generate one buffer selection per block_id and share among all ops in that block
+    // For multi-region ops: process independently
+    DenseMap<int, SmallVector<Operation *>> opsByBlockId;
+    DenseMap<int, Value> processedBlockSelections;
+
     for (Operation *depUser : depUsers) {
         int userBlockId = getSsbufferId(depUser);
         if (userBlockId < 0 || userBlockId == producerId)
             continue;
 
-        OpBuilder consumedBuilder(mainLoopForOp.getContext());
-        consumedBuilder.setInsertionPoint(depUser);
+        if (isMultiRegionConsumerFromYield(depUser, depVal)) {
+            // Multi-region op: process independently
+            OpBuilder consumedBuilder(mainLoopForOp.getContext());
+            consumedBuilder.setInsertionPoint(depUser);
 
-        if (!isMultiRegionConsumerFromYield(depUser, depVal)) {
-            if (int ret = processNormalConsumer(consumedBuilder, depVal, buffers, mainLoopForOp,
-                                                depUser, userBlockId, groupId, globalBuilder))
+            if (int ret = processMultiRegionAllYields(consumedBuilder, depVal, buffers, mainLoopForOp,
+                                                     depUser, userBlockId, groupId))
                 return ret;
+        } else {
+            // Normal op: collect by block_id for batch processing
+            opsByBlockId[userBlockId].push_back(depUser);
         }
+    }
 
-        if (int ret = processMultiRegionAllYields(consumedBuilder, depVal, buffers, mainLoopForOp,
-                                               depUser, userBlockId, groupId))
+    // For each block_id, generate only one set of buffer selection and share among all ops
+    for (auto &blockPair : opsByBlockId) {
+        int userBlockId = blockPair.first;
+        SmallVector<Operation *> &opsInBlock = blockPair.second;
+        if (opsInBlock.empty())
+            continue;
+
+        // Insert buffer selection at the position of the first op
+        Operation *firstOp = opsInBlock.front();
+        OpBuilder consumedBuilder(mainLoopForOp.getContext());
+        consumedBuilder.setInsertionPoint(firstOp);
+
+        if (int ret = processNormalConsumerBlock(consumedBuilder, depVal, buffers, mainLoopForOp,
+                                               opsInBlock, userBlockId, groupId, globalBuilder))
             return ret;
     }
+
     return 0;
 }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
@@ -42,7 +42,7 @@ static constexpr const char *DEBUG_TYPE = "RemoveAttributes";
 
 // if extra attr is needed, add to ut @
 // third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/test-remove-attrs.mlir
-static constexpr llvm::StringLiteral kAttrsToRemove[] {kBlockId, kCoreType, kTransferId, kMainLoop, kCubeFirst, kVectorFirst, kAddFromMatmul};
+static constexpr llvm::StringLiteral kAttrsToRemove[] {kBlockId, kCoreType, kTransferId, kMainLoop, kCubeFirst, kVectorFirst, kAddFromMatmul, kIntraBuffer};
 
 void RemoveSsbufAttrPass::runOnOperation()
 {

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/Inner-scope.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/Inner-scope.mlir
@@ -705,49 +705,148 @@ func.func @test_t22_tensor_empty_in_nested_if() {
   }
 
 //===--------------------------------------------------------------------===//
-// T23: scf.if with Else Branch Directly Yielding depVal
+// T23: scf.if with Then Branch Using depVal and Else Branch Yielding depVal
 // Test: Real scenario from if_problem.mlir where:
-//       - block_id = 11: linalg.fill produces depVal
+//       - block_id = 11: func.call produces depVal (%154)
 //       - scf.if with block_id = 20 has then/else branches
-//       - then branch has compute using depVal
-//       - else branch directly yields depVal (no compute)
-// Note: This test verifies that basic functionality still works.
-//       The real scenario with func.call producing depVal is tested separately
-//       in if_problem.mlir which is verified manually.
+//       - then branch: compute op uses %154, then yield
+//       - else branch: directly yield %154
+//       - %154 is used by external ops (arith.select in then branch)
+// Note: This test verifies that depVal is properly handled when used in
+//       scf.if then branch compute, and else branch directly yields it.
 //===--------------------------------------------------------------------===//
   // CHECK-LABEL: func.func @test_t23_scf_if_else_branch_yield
   // CHECK-DAG: memref.alloc
   // CHECK-DAG: memref.memory_space_cast {{.*}} {ssbuffer.intraDeps
-  // CHECK-DAG: scf.if {{.*}} -> (tensor<16x32xf16>) {
-  // CHECK-DAG: arith.addf {{.*}} {ssbuffer.block_id = 20 : i32}
-  // CHECK-DAG: scf.yield
-  // CHECK-DAG: } else {
-  // CHECK-DAG: scf.yield {{.*}} : tensor<16x32xf16>
-  // CHECK-DAG: } {ssbuffer.block_id = 20 : i32}
-  // CHECK-DAG: hivm.hir.copy {{.*}} {ssbuffer.block_id = 20 : i32}
+  // CHECK: scf.if {{.*}} -> (tensor<16x32xf16>) {
+  // CHECK: arith.addf {{.*}} {ssbuffer.block_id = 20 : i32}
+  // CHECK: scf.yield
+  // CHECK: } else {
+  // CHECK: scf.yield {{.*}} : tensor<16x32xf16>
+  // CHECK: } {ssbuffer.block_id = 20 : i32}
+  // CHECK: hivm.hir.copy {{.*}} {ssbuffer.block_id = 20 : i32}
 func.func @test_t23_scf_if_else_branch_yield() {
     %c0_i32 = arith.constant 0 : i32
     %c100_i32 = arith.constant 100 : i32
     %c1_i32 = arith.constant 1 : i32
     %cst = arith.constant 1.0 : f32
     %cst_f16 = arith.constant 1.0 : f16
-    %empty = tensor.empty() : tensor<16x32xf16>
+    %empty_16x32 = tensor.empty() : tensor<16x32xf16>
     scope.scope : () -> () {
       // Producer: linalg.fill with block_id = 11
-      %prod = linalg.fill {ssbuffer.block_id = 11 : i32} ins(%cst_f16 : f16) outs(%empty : tensor<16x32xf16>) -> tensor<16x32xf16>
+      %prod = linalg.fill {ssbuffer.block_id = 11 : i32} ins(%cst_f16 : f16) outs(%empty_16x32 : tensor<16x32xf16>) -> tensor<16x32xf16>
       %loop_result = scf.for %i = %c0_i32 to %c100_i32 step %c1_i32 iter_args(%arg = %prod) -> (tensor<16x32xf16>) : i32 {
         %cond = arith.cmpi eq, %i, %c0_i32 : i32
+        %alloc = memref.alloc() {ssbuffer.block_id = 11 : i32} : memref<16x32xf16>
+        %to_tensor = bufferization.to_tensor %alloc restrict writable {ssbuffer.block_id = 11 : i32} : memref<16x32xf16>
         // scf.if with block_id = 20
-        // then branch: compute using %arg (depVal from block_id 11)
-        // else branch: directly yield %arg (depVal from block_id 11)
+        // then branch: compute op uses %to_tensor (depVal from block_id 11), then yield
+        // else branch: directly yield %to_tensor (depVal from block_id 11)
         %if_result = scf.if %cond -> (tensor<16x32xf16>) {
-          %consumed = arith.addf %arg, %arg {ssbuffer.block_id = 20 : i32} : tensor<16x32xf16>
-          scf.yield %consumed : tensor<16x32xf16>
+          %consumed_then = arith.addf %to_tensor, %arg {ssbuffer.block_id = 20 : i32} : tensor<16x32xf16>
+          scf.yield %consumed_then : tensor<16x32xf16>
         } else {
-          scf.yield %arg : tensor<16x32xf16>
+          scf.yield %to_tensor : tensor<16x32xf16>
         } {ssbuffer.block_id = 20 : i32}
         %new_prod = arith.addf %if_result, %if_result {ssbuffer.block_id = 11 : i32} : tensor<16x32xf16>
         scf.yield %new_prod : tensor<16x32xf16>
+      } {ssbuffer.main_loop = 1 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return
+  }
+
+//===--------------------------------------------------------------------===//
+// T24: Same depVal Shared by Multiple Ops in Same block_id
+// Test: When a depVal is used by multiple normal ops in the SAME block_id,
+//       there should be only ONE buffer selection scf.if, shared by all ops.
+//       This tests the fix for duplicate buffer selection generation.
+// Key Check: Only ONE scf.if buffer selection for block_id = 5
+//         : %cons is produced in block_id = 6, used by three ops in block_id = 5
+//         : These three ops should share ONE buffer selection
+//         : The buffer selection result is used by all three ops
+//===--------------------------------------------------------------------===//
+  // CHECK-LABEL: func.func @test_t24_shared_buffer_selection
+  // CHECK-DAG: memref.alloc
+  // CHECK-DAG: memref.memory_space_cast {{.*}} {ssbuffer.intraDeps
+  // Only ONE scf.if buffer selection for block_id = 5 (not two!)
+  // CHECK: scf.if {{.*}} -> (tensor<128xf32>)
+  // CHECK: } {ssbuffer.block_id = 5
+  // CHECK-NOT: scf.if {{.*}} -> (tensor<128xf32>)
+  // CHECK-NOT: } {ssbuffer.block_id = 5
+  // CHECK-DAG: arith.addf %{{.*}}, %{{.*}} {ssbuffer.block_id = 5 : i32}
+  // CHECK-DAG: arith.subf %{{.*}}, %{{.*}} {ssbuffer.block_id = 5 : i32}
+  // CHECK-DAG: arith.mulf %{{.*}}, %{{.*}} {ssbuffer.block_id = 5 : i32}
+  func.func @test_t24_shared_buffer_selection() {
+    %c0_i32 = arith.constant 0 : i32
+    %c100_i32 = arith.constant 100 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %cst = arith.constant 1.0 : f32
+    %empty = tensor.empty() : tensor<128xf32>
+    scope.scope : () -> () {
+      // Producer: block_id = 5
+      %prod = linalg.fill {ssbuffer.block_id = 5 : i32} ins(%cst : f32) outs(%empty : tensor<128xf32>) -> tensor<128xf32>
+      %loop_result = scf.for %i = %c0_i32 to %c100_i32 step %c1_i32 iter_args(%arg = %prod) -> (tensor<128xf32>) : i32 {
+        // %arg is the depVal from previous iteration (block_id = 5)
+        // In block_id = 6, %arg is consumed to produce %cons
+        %cons = arith.addf %arg, %arg {ssbuffer.block_id = 6 : i32} : tensor<128xf32>
+        // In block_id = 5, %cons (the processed depVal) is used by THREE ops
+        // These three ops should share ONE buffer selection
+        %new_prod1 = arith.addf %cons, %cons {ssbuffer.block_id = 5 : i32} : tensor<128xf32>
+        %new_prod2 = arith.subf %cons, %cons {ssbuffer.block_id = 5 : i32} : tensor<128xf32>
+        %new_prod3 = arith.mulf %cons, %cons {ssbuffer.block_id = 5 : i32} : tensor<128xf32>
+        // All three results are yielded out
+        %final = arith.addf %new_prod1, %new_prod2 {ssbuffer.block_id = 5 : i32} : tensor<128xf32>
+        %final2 = arith.addf %final, %new_prod3 {ssbuffer.block_id = 5 : i32} : tensor<128xf32>
+        scf.yield %cons : tensor<128xf32>
+      } {ssbuffer.main_loop = 1 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return
+  }
+
+//===--------------------------------------------------------------------===//
+//===--------------------------------------------------------------------===//
+// T25: Same depVal Used in Two Different block_ids
+// Test: When a depVal is used in TWO DIFFERENT block_ids,
+//       there should be buffer selection scf.if in EACH block_id where it's used.
+//       This tests that cross-block dependency generates buffer selection per block.
+// Key Check: Buffer selection scf.ifs for block_id = 5 and block_id = 7
+//         : %cons is produced in block_id = 6, used in block_id = 5 and block_id = 7
+//         : Each block gets its own buffer selection
+//===--------------------------------------------------------------------===//
+  // CHECK-LABEL: func.func @test_t25_depval_in_two_blocks
+  // CHECK-DAG: memref.alloc
+  // CHECK-DAG: memref.memory_space_cast {{.*}} {ssbuffer.intraDeps
+  // Buffer selection scf.if for block_id=5
+  // CHECK: scf.if {{.*}} -> (tensor<128xf32>)
+  // CHECK: } {ssbuffer.block_id = 5
+  // Buffer selection scf.if for block_id=7
+  // CHECK: scf.if {{.*}} -> (tensor<128xf32>)
+  // CHECK: } {ssbuffer.block_id = 7
+  // Verify the ops using %cons in each block
+  // CHECK-DAG: arith.addf {{.*}} {ssbuffer.block_id = 5 : i32}
+  // CHECK-DAG: arith.subf {{.*}} {ssbuffer.block_id = 7 : i32}
+  func.func @test_t25_depval_in_two_blocks() {
+    %c0_i32 = arith.constant 0 : i32
+    %c100_i32 = arith.constant 100 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %cst = arith.constant 1.0 : f32
+    %empty = tensor.empty() : tensor<128xf32>
+    scope.scope : () -> () {
+      // Producer: block_id = 5
+      %prod = linalg.fill {ssbuffer.block_id = 5 : i32} ins(%cst : f32) outs(%empty : tensor<128xf32>) -> tensor<128xf32>
+      %loop_result = scf.for %i = %c0_i32 to %c100_i32 step %c1_i32 iter_args(%arg = %prod) -> (tensor<128xf32>) : i32 {
+        // %arg is the depVal from previous iteration (block_id = 5)
+        // In block_id = 6, %arg is consumed to produce %cons
+        %cons = arith.addf %arg, %arg {ssbuffer.block_id = 6 : i32} : tensor<128xf32>
+        // In block_id = 5, %cons is used by first op
+        %new_prod1 = arith.addf %cons, %cons {ssbuffer.block_id = 5 : i32} : tensor<128xf32>
+        // In block_id = 7, %cons is used by second op
+        %new_prod2 = arith.subf %cons, %cons {ssbuffer.block_id = 7 : i32} : tensor<128xf32>
+        // Final producer in block_id = 5
+        %final = arith.addf %new_prod1, %new_prod2 {ssbuffer.block_id = 5 : i32} : tensor<128xf32>
+        scf.yield %final : tensor<128xf32>
       } {ssbuffer.main_loop = 1 : i64}
       scope.return
     } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}


### PR DESCRIPTION
This pull request is designed to fix mistransferring when a dependent value is used in multi ops in the same block.
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
