### PR TITLE
fix(ssbuffer): fix bugs some ifblocks not include while caculating intra factor

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.cpp
@@ -208,41 +208,64 @@ static bool isRunFirst(SmallVector<scf::IfOp> &ifOps, llvm::DenseMap<Value, Smal
   return true;
 }
 
-// Collect ifOps from forOp that contain sync_block_wait or sync_block_set op
+// Type definition for IfOp filter function
+// Returns true if the IfOp should be collected, false otherwise
+using IfOpFilter = std::function<bool(scf::IfOp)>;
+
+// Default filter that accepts all IfOps
+static bool defaultIfOpFilter(scf::IfOp ifOp) {
+  return true;
+}
+
+// Filter that checks if IfOp contains sync_block_wait or sync_block_set op
+static bool syncBlockFilter(scf::IfOp ifOp) {
+  bool containsSyncBlock = false;
+  ifOp.walk([&](Operation *innerOp) {
+    if (isa<hivm::SyncBlockWaitOp>(innerOp) || isa<hivm::SyncBlockSetOp>(innerOp)) {
+      containsSyncBlock = true;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return containsSyncBlock;
+}
+
+// Collect ifOps from forOp based on the provided filter
 // Fills ifOps and ifOpIndexMap with the collected ifOps
-// Returns the number of ifOps collected
-static int collectIfOps(
+// Returns the number of ifOps collected on success, or -1 on error
+int collectIfOps(
     scf::ForOp forOp,
     SmallVector<scf::IfOp> &ifOps,
-    llvm::DenseMap<Operation *, int> &ifOpIndexMap)
+    llvm::DenseMap<Operation *, int> &ifOpIndexMap,
+    IfOpFilter filter = defaultIfOpFilter)
 {
   ifOps.clear();
   ifOpIndexMap.clear();
   int index = 1;
+  int ret = 0;
 
   forOp.walk([&](Operation* op) {
     if (op->hasAttr(CVPipeline::kIf)) {
       auto ifOp = dyn_cast<scf::IfOp>(op);
-      if (ifOp) {
-        // Check if this ifOp contains sync_block_wait op
-        bool isVaildBlock = false;
-        ifOp.walk([&](Operation *innerOp) {
-          if (isa<hivm::SyncBlockWaitOp>(innerOp) || isa<hivm::SyncBlockSetOp>(innerOp)) {
-            isVaildBlock = true;
-            return WalkResult::interrupt();
-          }
-          return WalkResult::advance();
-        });
-        if (isVaildBlock) {
-          ifOps.push_back(ifOp);
-          ifOpIndexMap[ifOp.getOperation()] = index++;
-        }
+      if (!ifOp) {
+        ret = -1;
+        LDBG("ssbuffer.if attribute is not allocated on ifOp!");
+        return WalkResult::interrupt();
+      }
+      // Apply the filter to determine if this IfOp should be collected
+      if (filter(ifOp)) {
+        ifOps.push_back(ifOp);
+        ifOpIndexMap[ifOp.getOperation()] = index++;
       }
     }
     return WalkResult::advance();
   });
 
-  return ifOps.size();
+  if (ret == -1) {
+    return -1;
+  } else {
+    return ifOps.size();
+  }
 }
 
 // Helper function to find the other side's mainloop and collect its ifOps
@@ -292,11 +315,16 @@ static scf::ForOp findOtherSideMainloopAndIfOps(
 
   // Collect ifOps from the other side's mainloop
   // Only collect ifOps that contain hivm.hir.sync_block_wait op
-  int ifOpsCount = collectIfOps(otherSideForOp, otherSideIfOps, otherSideIfOpIndexMap);
-
-  if (ifOpsCount == 0) {
-    LDBG("Other side mainloop does not contain any ifblocks!");
-    return nullptr;
+  int ifOpsCount = collectIfOps(otherSideForOp, otherSideIfOps, otherSideIfOpIndexMap, syncBlockFilter);
+  switch (ifOpsCount) {
+    case -1:
+      LDBG("Failed to collect ifOps from other side mainloop!");
+      return nullptr;
+    case 0:
+      LDBG("Other side mainloop does not contain any ifblocks!");
+      return nullptr;
+    default:
+      break;
   }
 
   return otherSideForOp;
@@ -317,10 +345,15 @@ std::pair<int, int> UpdateLoopIterTimesPass::calculateFactor(scf::ForOp forOp)
   SmallVector<scf::IfOp> ifOps;
   DenseMap<Operation *, int> ifOpIndex;
   int ifOpsCount = collectIfOps(forOp, ifOps, ifOpIndex);
-
-  if (ifOpsCount == 0) {
-    LDBG("mainloop do not contains ifblocks!");
-    return {-1, -1};
+  switch (ifOpsCount) {
+    case -1:
+      LDBG("Failed to collect ifOps!");
+      return {-1, -1};
+    case 0:
+      LDBG("mainloop do not contains ifblocks!");
+      return {-1, -1};
+    default:
+      break;
   }
 
   // Step2: Calculate factor based on intra-core dependencies
@@ -356,7 +389,22 @@ std::pair<int, int> UpdateLoopIterTimesPass::calculateFactor(scf::ForOp forOp)
     llvm::DenseMap<Value, SmallVector<Value>> filteredCrossCoreMap =
         filterCrossCoreMapByForOp(forOp, extendedCrossCoreMap);
 
-    auto [crossRequiredBuffers, crossX] = calculateCrossDepsFactor(forOp, ifOps, ifOpIndex, filteredCrossCoreMap);
+    // for caculating the crossdeps, need to filter ifblocks without sync_wait/sync_set op
+    SmallVector<scf::IfOp> filterIfOps;
+    DenseMap<Operation *, int> filterIfOpIndex;
+    int filterIfOpsCount = collectIfOps(forOp, filterIfOps, filterIfOpIndex, syncBlockFilter);
+    switch (filterIfOpsCount) {
+      case -1:
+        LDBG("Failed to collect filtered ifOps!");
+        return {-1, -1};
+      case 0:
+        LDBG("mainloop do not contains filtered ifblocks!");
+        return {-1, -1};
+      default:
+        break;
+    }
+
+    auto [crossRequiredBuffers, crossX] = calculateCrossDepsFactor(forOp, filterIfOps, filterIfOpIndex, filteredCrossCoreMap);
     if (crossRequiredBuffers == -1 || crossX == -1) {
       LDBG("calculateCrossDepsFactor failed!");
       return {-1, -1};
@@ -406,6 +454,10 @@ static int getProducerIfOpIndex(SmallVector<Value> &producerBuffers,
       if (isa<hivm::FixpipeOp>(user) || isa<hivm::CopyOp>(user)) {
         producerIfOpIndex = findIfOpIndexInList(user, otherSideIfOps, otherSideIfOpIndexMap);
         if (producerIfOpIndex == -1) {
+          LDBG("user : " << *user);
+          for (auto ifop : otherSideIfOps){
+            LDBG("other side ifop: " << ifop);
+          }
           LDBG("Can not find the producerBuffers in any ifOps of other side mainloop!");
           return -1;
         }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/add_controlflow_condition_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/add_controlflow_condition_test.mlir
@@ -92,9 +92,9 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
           %44 = arith.remsi %43, %c2_i32 {ssbuffer.block_id = 5 : i32} : i32
           %45 = arith.cmpi eq, %44, %c0_i32_15 {ssbuffer.block_id = 5 : i32} : i32
           scf.if %45 {
-            bufferization.materialize_in_destination %42 in restrict writable %memspacecast {ssbuffer.block_id = 5 : i32} : (tensor<128xf32>, memref<128xf32>) -> ()
+            hivm.hir.copy ins(%42 : tensor<128xf32>) outs(%memspacecast : memref<128xf32>) {ssbuffer.block_id = 5 : i32}
           } else {
-            bufferization.materialize_in_destination %42 in restrict writable %memspacecast_9 {ssbuffer.block_id = 5 : i32} : (tensor<128xf32>, memref<128xf32>) -> ()
+            hivm.hir.copy ins(%42 : tensor<128xf32>) outs(%memspacecast_9 : memref<128xf32>) {ssbuffer.block_id = 5 : i32}
           } {ssbuffer.block_id = 5 : i32}
           %46 = arith.mulf %arg18, %42 {ssbuffer.block_id = 5 : i32} : tensor<128xf32>
           %47 = arith.addf %46, %reduced_14 {ssbuffer.block_id = 5 : i32} : tensor<128xf32>
@@ -156,15 +156,21 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
       scope.return
     } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
     scope.scope : () -> () {
-        %alloc = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+        %alloc = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 0 : i32, ssbuffer.crossDeps = [2 : i32, 1 : i32]} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
         annotation.mark %alloc {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
         %alloc_5 = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
         annotation.mark %alloc_5 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
         %alloc_6 = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
         annotation.mark %alloc_6 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
-        %30:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
-          hivm.hir.sync_block_wait {ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
-          %48 = hivm.hir.convert_layout %alloc_5 output_shape [64, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 2 : i32, ssbuffer.crossDeps = [1 : i32, 0 : i32], ssbuffer.transfer_id = 1 : i32} : (memref<128x128xf32, #hivm.address_space<ub>>) -> memref<64x128xf32, #hivm.address_space<ub>>
+        %20:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
+          hivm.hir.sync_block_wait {ssbuffer.block_id = 0 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+          %30 = tensor.empty() {ssbuffer.block_id = 0 : i32} : tensor<128x128xf32>
+          hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 0 : i32, ssbuffer.transfer_id = 1 : i32} ins(%30 : tensor<128x128xf32>) outs(%alloc_5 : memref<128x128xf32, #hivm.address_space<ub>>)
+
+          hivm.hir.sync_block_wait {ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+          %32 = hivm.hir.convert_layout %alloc output_shape [128, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 0 : i32, ssbuffer.crossDeps = [2 : i32, 0 : i32]} : (memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) -> memref<128x128xf16, #hivm.address_space<cbuf>>
+          %40 = tensor.empty() {ssbuffer.block_id = 1 : i32} : tensor<128x128xf32>
+          hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 2 : i32} ins(%40 : tensor<128x128xf32>) outs(%alloc_6 : memref<128x128xf32, #hivm.address_space<ub>>)
           scf.yield %arg17, %arg18 : i32, i32
         } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
       scope.return

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/crossCoreDeps_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/crossCoreDeps_test.mlir
@@ -18,20 +18,20 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
     // CHECK:       %[[ADDR1:.*]] = llvm.mlir.constant(1024 : i64) : i64
     // CHECK:       %[[PTR0:.*]] = llvm.inttoptr %[[ADDR0]] : i64 to !llvm.ptr<11>
     // CHECK:       %[[PTR1:.*]] = llvm.inttoptr %[[ADDR1]] : i64 to !llvm.ptr<11>
-    // CHECK:       llvm.store %[[ZERO]], %[[PTR0]] : i32, !llvm.ptr<11>
-    // CHECK:       llvm.store %[[ZERO]], %[[PTR1]] : i32, !llvm.ptr<11>
+    // CHECK:       llvm.store volatile %[[ZERO]], %[[PTR0]] : i32, !llvm.ptr<11>
+    // CHECK:       llvm.store volatile %[[ZERO]], %[[PTR1]] : i32, !llvm.ptr<11>
     // CHECK:       %[[ADDR2:.*]] = llvm.mlir.constant(4 : i64) : i64
     // CHECK:       %[[ADDR3:.*]] = llvm.mlir.constant(1028 : i64) : i64
     // CHECK:       %[[PTR2:.*]] = llvm.inttoptr %[[ADDR2]] : i64 to !llvm.ptr<11>
     // CHECK:       %[[PTR3:.*]] = llvm.inttoptr %[[ADDR3]] : i64 to !llvm.ptr<11>
-    // CHECK:       llvm.store %[[ZERO]], %[[PTR2]] : i32, !llvm.ptr<11>
-    // CHECK:       llvm.store %[[ZERO]], %[[PTR3]] : i32, !llvm.ptr<11>
+    // CHECK:       llvm.store volatile %[[ZERO]], %[[PTR2]] : i32, !llvm.ptr<11>
+    // CHECK:       llvm.store volatile %[[ZERO]], %[[PTR3]] : i32, !llvm.ptr<11>
     // CHECK:       %[[ADDR4:.*]] = llvm.mlir.constant(8 : i64) : i64
     // CHECK:       %[[ADDR5:.*]] = llvm.mlir.constant(1032 : i64) : i64
     // CHECK:       %[[PTR4:.*]] = llvm.inttoptr %[[ADDR4]] : i64 to !llvm.ptr<11>
     // CHECK:       %[[PTR5:.*]] = llvm.inttoptr %[[ADDR5]] : i64 to !llvm.ptr<11>
-    // CHECK:       llvm.store %[[ZERO]], %[[PTR4]] : i32, !llvm.ptr<11>
-    // CHECK:       llvm.store %[[ZERO]], %[[PTR5]] : i32, !llvm.ptr<11>
+    // CHECK:       llvm.store volatile %[[ZERO]], %[[PTR4]] : i32, !llvm.ptr<11>
+    // CHECK:       llvm.store volatile %[[ZERO]], %[[PTR5]] : i32, !llvm.ptr<11>
     scope.scope : () -> () {
       // Vector scope only process each vector core's ssbuffer ptr
       // CHECK:       arith.constant 1024
@@ -52,6 +52,7 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
         // CHECK:       llvm.load
         // CHECK:       arith.cmpi slt
         // CHECK:       scf.if
+        hivm.hir.sync_block_set {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 4
         %memspacecast_11 = memref.memory_space_cast %alloc_5 {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32, ssbuffer.crossDeps = [0 : i32, 0 : i32]} : memref<128x128xf32, #hivm.address_space<ub>> to memref<128x128xf32>
         %reshape_13 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<8x8x16x16xf16>
         hivm.hir.copy ins(%reshape_13 : tensor<8x8x16x16xf16>) outs(%alloc : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 0 : i32}
@@ -67,8 +68,8 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
         // CHECK:       llvm.load
         // CHECK:       arith.cmpi sgt
         // CHECK:       scf.if
+        hivm.hir.sync_block_set {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 4
         %memspacecast_16 = memref.memory_space_cast %alloc_6 {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 2 : i32, ssbuffer.crossDeps = [1, 0]} : memref<128x128xf32, #hivm.address_space<ub>> to memref<128x128xf32>
-        %48 = bufferization.to_tensor %memspacecast_16 restrict writable {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32> to tensor<128x128xf32>
         // CHECK:       llvm.load
         // CHECK:       arith.subi
         // CHECK:       llvm.store
@@ -92,6 +93,7 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
         // CHECK:       arith.cmpi slt
         // CHECK:       arith.cmpi slt
         // CHECK:       scf.if
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 0 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
         %30 = tensor.empty() {ssbuffer.block_id = 0 : i32} : tensor<128x128xf32>
         hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 0 : i32, ssbuffer.transfer_id = 1 : i32} ins(%30 : tensor<128x128xf32>) outs(%alloc_6 : memref<128x128xf32, #hivm.address_space<ub>>)
         // CHECK:       llvm.load
@@ -112,6 +114,7 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
         // CHECK:       arith.cmpi slt
         // CHECK:       arith.cmpi slt
         // CHECK:       scf.if
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
         %32 = hivm.hir.convert_layout %alloc_5 output_shape [128, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 0 : i32, ssbuffer.crossDeps = [2 : i32, 0 : i32]} : (memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) -> memref<128x128xf16, #hivm.address_space<cbuf>>
         %40 = tensor.empty() {ssbuffer.block_id = 1 : i32} : tensor<128x128xf32>
         hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 2 : i32} ins(%40 : tensor<128x128xf32>) outs(%alloc_7 : memref<128x128xf32, #hivm.address_space<ub>>)
@@ -130,9 +133,6 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
         // CHECK:       } {ssbuffer.if = 1 : i32}
         scf.yield %arg17, %arg18 : i32, i32
       } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
-      scope.return
-    } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
-    scope.scope : () -> () {
       scope.return
     } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
     return {ssbuffer.core_type = "VECTOR"}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/lack_mainloop_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/lack_mainloop_test.mlir
@@ -1,15 +1,9 @@
-// RUN: triton-opt --add-control-flow-condition %s | FileCheck %s
+// RUN: ! triton-opt -add-control-flow-condition %s 2>&1 | FileCheck %s
 
-
-// ============================================================================
-// TC-01: sufficient multicache
-// ============================================================================
-// This test verifies:
-// 1. New loop upper bound calculation (arith.subi, arith.ceildivui, arith.muli, arith.addi)
-// 2. iter_args expanded
-// 3. MainLoop counter will be replaced by each counter of ifblocks
-// If Vm has intra-core dependency on Vn (m>n), to achieve optimal pipeline, at most m-n+1 data flows need to exist simultaneously, which is requireNum
-// If multicache count is sufficient (bufferNum >= requireNum), only need to increase iteration times with number of ifblock
+// Can not find the other side's mainloop with id
+// CHECK: Assertion
+// CHECK: PLEASE submit a bug report
+// CHECK: Stack dump:
 
 module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
   func.func @_attn_fwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg3: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg4: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg5: memref<?xf32> {tt.divisibility = 16 : i32}, %arg6: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg7: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg8: memref<?xi32> {tt.divisibility = 16 : i32}, %arg9: i32, %arg10: i32, %arg11: i32, %arg12: i32, %arg13: i32, %arg14: i32, %arg15: i32) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
@@ -24,21 +18,8 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
       %alloc_11 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
       annotation.mark %alloc_11 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
 
-      // CHECK:       %[[IFCOUNT:.*]] = arith.constant 2
-      // CHECK:       %[[REQUIRENUM:.*]] = arith.constant 1
-      // CHECK:       %[[BUFFERNUM:.*]] = arith.constant 1
-      // CHECK:       arith.subi
-      // CHECK:       arith.ceildivui
-      // CHECK:       arith.muli %{{.*}}, %[[REQUIRENUM]]
-      // CHECK:       arith.ceildivui %{{.*}}, %[[BUFFERNUM]]
-      // CHECK:       arith.addi %{{.*}}, %[[IFCOUNT]]
-      // CHECK:       arith.muli
-      // CHECK:       arith.addi
-      // CHECK:       scf.for
-      // CHECK:       iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32, %[[CNT0:.*]] = %{{.+}}, %[[CNT1:.*]] = %{{.+}}, %arg21 = %{{.+}})
       %30:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
         %42 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<128xf32>
-        // CHECK:       arith.divui %[[CNT0]], %c128_i32 {ssbuffer.block_id = 5 : i32} : i32
         %43 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 5 : i32} : i32
         %c0_i32_15 = arith.constant {ssbuffer.block_id = 5 : i32} 0 : i32
         %c2_i32 = arith.constant {ssbuffer.block_id = 5 : i32} 2 : i32
@@ -53,7 +34,11 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
         %reshape_40 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<8x4x16x16xf16>
         hivm.hir.copy ins(%reshape_40 : tensor<8x4x16x16xf16>) outs(%alloc_11 : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}
 
-        // CHECK:       arith.divui %[[CNT1]], %c128_i32 {ssbuffer.block_id = 7 : i32} : i32
+        %46 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 6 : i32} : i32
+        %c0_i32_16 = arith.constant {ssbuffer.block_id = 6 : i32} 0 : i32
+        %c2_i32_6 = arith.constant {ssbuffer.block_id = 6 : i32} 2 : i32
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+
         %49 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 7 : i32} : i32
         %c2_i32_17 = arith.constant {ssbuffer.block_id = 7 : i32} 2 : i32
         %50 = arith.remsi %49, %c2_i32_17 {ssbuffer.block_id = 7 : i32} : i32
@@ -70,7 +55,8 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
         scf.yield %arg17, %arg18 : i32, i32
       } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
       scope.return
-    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    }{hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+
     scope.scope : () -> () {
       %alloc_11 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [1 : i32, 1 : i32], ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
       annotation.mark %alloc_11 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
@@ -78,7 +64,7 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
         hivm.hir.sync_block_wait {ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
         %48 = hivm.hir.convert_layout %alloc_11 output_shape [64, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 2 : i32, ssbuffer.crossDeps = [1 : i32, 0 : i32], ssbuffer.transfer_id = 1 : i32} : (memref<8x4x16x16xf16, #hivm.address_space<cbuf>>) -> memref<64x128xf16, #hivm.address_space<cbuf>>
         scf.yield %arg17, %arg18 : i32, i32
-      } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
+      } {ssbuffer.block_id = 9 : i32}
       scope.return
     } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
     return {ssbuffer.core_type = "VECTOR"}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/multi_deps_add_condition_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/multi_deps_add_condition_test.mlir
@@ -197,19 +197,25 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
       scope.return
     } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
     scope.scope : () -> () {
-        %alloc = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+        %alloc = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 0 : i32, ssbuffer.crossDeps = [2 : i32, 1 : i32]} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
         annotation.mark %alloc {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
         %alloc_5 = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
         annotation.mark %alloc_5 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
         %alloc_6 = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
         annotation.mark %alloc_6 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
-        %30:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
-          hivm.hir.sync_block_wait {ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
-          %48 = hivm.hir.convert_layout %alloc_5 output_shape [64, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 2 : i32, ssbuffer.crossDeps = [1 : i32, 0 : i32], ssbuffer.transfer_id = 1 : i32} : (memref<128x128xf32, #hivm.address_space<ub>>) -> memref<64x128xf32, #hivm.address_space<ub>>
+        %20:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
+          hivm.hir.sync_block_wait {ssbuffer.block_id = 0 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+          %30 = tensor.empty() {ssbuffer.block_id = 0 : i32} : tensor<128x128xf32>
+          hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 0 : i32, ssbuffer.transfer_id = 1 : i32} ins(%30 : tensor<128x128xf32>) outs(%alloc_5 : memref<128x128xf32, #hivm.address_space<ub>>)
+
+          hivm.hir.sync_block_wait {ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+          %32 = hivm.hir.convert_layout %alloc output_shape [128, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 0 : i32, ssbuffer.crossDeps = [2 : i32, 0 : i32]} : (memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) -> memref<128x128xf16, #hivm.address_space<cbuf>>
+          %40 = tensor.empty() {ssbuffer.block_id = 1 : i32} : tensor<128x128xf32>
+          hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 2 : i32} ins(%40 : tensor<128x128xf32>) outs(%alloc_6 : memref<128x128xf32, #hivm.address_space<ub>>)
           scf.yield %arg17, %arg18 : i32, i32
         } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
       scope.return
-   }{hivm.tcore_type = #hivm.tcore_type<CUBE>}
+    }{hivm.tcore_type = #hivm.tcore_type<CUBE>}
     return {ssbuffer.core_type = "VECTOR"}
   }
 }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/no_deps_add_condition_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/no_deps_add_condition_test.mlir
@@ -1,6 +1,4 @@
-// RUN: triton-opt -add-control-flow-condition %s 2>&1| FileCheck %s
-
-// RUN: not triton-opt -add-control-flow-condition %s 2>&1 | FileCheck %s
+// RUN: ! triton-opt -add-control-flow-condition %s 2>&1 | FileCheck %s
 
 // CHECK: Assertion
 // CHECK: updateIfConds failed

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/single_deps_add_condition_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/single_deps_add_condition_test.mlir
@@ -125,15 +125,21 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
       scope.return
     } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
     scope.scope : () -> () {
-        %alloc = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+        %alloc = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 0 : i32, ssbuffer.crossDeps = [2 : i32, 1 : i32]} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
         annotation.mark %alloc {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
         %alloc_5 = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
         annotation.mark %alloc_5 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
         %alloc_6 = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
         annotation.mark %alloc_6 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
-        %30:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
-          hivm.hir.sync_block_wait {ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
-          %48 = hivm.hir.convert_layout %alloc_5 output_shape [64, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 2 : i32, ssbuffer.crossDeps = [1 : i32, 0 : i32], ssbuffer.transfer_id = 1 : i32} : (memref<128x128xf32, #hivm.address_space<ub>>) -> memref<64x128xf32, #hivm.address_space<ub>>
+        %20:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
+          hivm.hir.sync_block_wait {ssbuffer.block_id = 0 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+          %30 = tensor.empty() {ssbuffer.block_id = 0 : i32} : tensor<128x128xf32>
+          hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 0 : i32, ssbuffer.transfer_id = 1 : i32} ins(%30 : tensor<128x128xf32>) outs(%alloc_5 : memref<128x128xf32, #hivm.address_space<ub>>)
+
+          hivm.hir.sync_block_wait {ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+          %32 = hivm.hir.convert_layout %alloc output_shape [128, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 0 : i32, ssbuffer.crossDeps = [2 : i32, 0 : i32]} : (memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) -> memref<128x128xf16, #hivm.address_space<cbuf>>
+          %40 = tensor.empty() {ssbuffer.block_id = 1 : i32} : tensor<128x128xf32>
+          hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 2 : i32} ins(%40 : tensor<128x128xf32>) outs(%alloc_6 : memref<128x128xf32, #hivm.address_space<ub>>)
           scf.yield %arg17, %arg18 : i32, i32
         } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
       scope.return

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/updateLoopIterTimes_insufficient_cross_intra_deps_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/updateLoopIterTimes_insufficient_cross_intra_deps_test.mlir
@@ -1,0 +1,124 @@
+// RUN: triton-opt --add-control-flow-condition %s | FileCheck %s
+
+// ============================================================================
+// TC-05: insufficient crossdependent and intradependent multicache
+// ============================================================================
+// CrossCore Data Dependency:
+// V1 -> C1 C2
+// C1 -> V2
+// V2 -> C2
+// C2 -> V3
+// intraCore Data Dependency:
+// V1 -> V3
+
+// intraCore Dependency need 3 cache, but only allocate one; intraFactor = 3
+// crossCore Dependency need 2 cache, but only allocate one; crossFactor = 2
+// max factor = 3
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @_attn_fwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg3: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg4: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg5: memref<?xf32> {tt.divisibility = 16 : i32}, %arg6: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg7: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg8: memref<?xi32> {tt.divisibility = 16 : i32}, %arg9: i32, %arg10: i32, %arg11: i32, %arg12: i32, %arg13: i32, %arg14: i32, %arg15: i32) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %c8192_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 8192 : i32
+    %c128_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 128 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 0 : i32
+    scope.scope : () -> () {
+      %alloc_7 = memref.alloc() : memref<128xf32, #hivm.address_space<ub>>
+      %memspacecast = memref.memory_space_cast %alloc_7 {ssbuffer.intraDeps = [0 : i32, 1 : i32]} : memref<128xf32, #hivm.address_space<ub>> to memref<128xf32>
+      %alloc = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_11 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_11 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_12 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_12 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_13 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [3 : i32, 1 : i32], ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_13 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<3>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 4
+      %alloc_14 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [4 : i32, 1 : i32], ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_14 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<4>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+
+      // CHECK:       %[[IFCOUNT:.*]] = arith.constant 3
+      // CHECK:       %[[REQUIRENUM:.*]] = arith.constant 3
+      // CHECK:       %[[BUFFERNUM:.*]] = arith.constant 1
+      // CHECK:       arith.subi
+      // CHECK:       arith.ceildivui
+      // CHECK:       arith.muli %{{.*}}, %[[REQUIRENUM]]
+      // CHECK:       arith.ceildivui %{{.*}}, %[[BUFFERNUM]]
+      // CHECK:       arith.addi %{{.*}}, %[[IFCOUNT]]
+      // CHECK:       arith.muli
+      // CHECK:       arith.addi
+      // CHECK:       scf.for
+      %30:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
+        %42 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<128xf32>
+        hivm.hir.copy ins(%42 : tensor<128xf32>) outs(%memspacecast : memref<128xf32>) {ssbuffer.block_id = 5 : i32}
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+        %reshape_40 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<4x1x16x16xf16>
+        hivm.hir.copy ins(%reshape_40 : tensor<4x1x16x16xf16>) outs(%alloc : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}
+        %reshape_41 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<8x4x16x16xf16>
+        hivm.hir.copy ins(%reshape_41 : tensor<8x4x16x16xf16>) outs(%alloc_11 : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}
+
+
+        %46 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 6 : i32} : i32
+        %c0_i32_16 = arith.constant {ssbuffer.block_id = 6 : i32} 0 : i32
+        %c2_i32_6 = arith.constant {ssbuffer.block_id = 6 : i32} 2 : i32
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+        %memspacecast_11 = memref.memory_space_cast %alloc_13 {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 1 : i32, ssbuffer.crossDeps = [3 : i32, 0 : i32]} : memref<16x128xf32, #hivm.address_space<ub>> to memref<16x128xf32>
+        %reshape_42 = tensor.empty() {ssbuffer.block_id = 6 : i32} : tensor<4x8x16x16xf16>
+        hivm.hir.copy ins(%reshape_42 : tensor<4x8x16x16xf16>) outs(%alloc_12 : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 1 : i32}
+
+
+        %55 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 7 : i32, ssbuffer.intraDeps = [0 : i32, 0 : i32]} : memref<128xf32>
+        %49 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 7 : i32} : i32
+        %c2_i32_17 = arith.constant {ssbuffer.block_id = 7 : i32} 2 : i32
+        %50 = arith.remsi %49, %c2_i32_17 {ssbuffer.block_id = 7 : i32} : i32
+        %c0_i32_18 = arith.constant {ssbuffer.block_id = 7 : i32} 0 : i32
+        %51 = arith.cmpi eq, %50, %c0_i32_18 {ssbuffer.block_id = 7 : i32} : i32
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+        %memspacecast_12 = memref.memory_space_cast %alloc_14 {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 1 : i32, ssbuffer.crossDeps = [4 : i32, 0 : i32]} : memref<16x64xf32, #hivm.address_space<ub>> to memref<16x64xf32>
+        scf.yield %arg17, %arg18 : i32, i32
+      } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+
+    scope.scope : () -> () {
+      %alloc_10 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [0 : i32, 1 : i32], ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_10 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+      %alloc_11 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [1 : i32, 1 : i32], ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_11 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+      %alloc_12 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [2 : i32, 1 : i32], ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_12 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 3
+      %alloc_13 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_13 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<3>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      %alloc_14 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_14 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<4>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+      // CHECK:       %[[IFCOUNT:.*]] = arith.constant 3
+      // CHECK:       %[[REQUIRENUM:.*]] = arith.constant 3
+      // CHECK:       %[[BUFFERNUM:.*]] = arith.constant 1
+      // CHECK:       arith.subi
+      // CHECK:       arith.ceildivui
+      // CHECK:       arith.muli %{{.*}}, %[[REQUIRENUM]]
+      // CHECK:       arith.ceildivui %{{.*}}, %[[BUFFERNUM]]
+      // CHECK:       arith.addi %{{.*}}, %[[IFCOUNT]]
+      // CHECK:       arith.muli
+      // CHECK:       arith.addi
+      // CHECK:       scf.for
+      %30:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+        %50 = hivm.hir.convert_layout %alloc_10 output_shape [16, 64] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 2 : i32, ssbuffer.crossDeps = [0 : i32, 0 : i32], ssbuffer.transfer_id = 0 : i32} : (memref<4x1x16x16xf16, #hivm.address_space<cbuf>>) -> memref<16x64xf16, #hivm.address_space<cbuf>>
+        %54 = tensor.empty() {ssbuffer.block_id = 2 : i32} : tensor<16x128xf32>
+        hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 3 : i32} ins(%54 : tensor<16x128xf32>) outs(%alloc_13 : memref<16x128xf32, #hivm.address_space<ub>>)
+
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 3 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+        %48 = hivm.hir.convert_layout %alloc_11 output_shape [64, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 3 : i32, ssbuffer.crossDeps = [1 : i32, 0 : i32], ssbuffer.transfer_id = 1 : i32} : (memref<8x4x16x16xf16, #hivm.address_space<cbuf>>) -> memref<64x128xf16, #hivm.address_space<cbuf>>
+        %45 = hivm.hir.convert_layout %alloc_12 output_shape [128, 64] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 3 : i32, ssbuffer.crossDeps = [2 : i32, 0 : i32], ssbuffer.transfer_id = 2 : i32} : (memref<4x8x16x16xf16, #hivm.address_space<cbuf>>) -> memref<128x64xf16, #hivm.address_space<cbuf>>
+        %47 = tensor.empty() {ssbuffer.block_id = 3 : i32} : tensor<16x64xf32>
+        hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 3 : i32, ssbuffer.transfer_id = 4 : i32} ins(%47 : tensor<16x64xf32>) outs(%alloc_14 : memref<16x64xf32, #hivm.address_space<ub>>)
+
+        scf.yield %arg17, %arg18 : i32, i32
+      } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+    return {ssbuffer.core_type = "VECTOR"}
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/updateLoopIterTimes_insufficient_crossdeps_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/updateLoopIterTimes_insufficient_crossdeps_test.mlir
@@ -1,0 +1,113 @@
+// RUN: triton-opt --add-control-flow-condition %s | FileCheck %s
+
+// ============================================================================
+// TC-04: insufficient crossdependent multicache
+// ============================================================================
+// CrossCore Data Dependency:
+// V1 -> C1 C2
+// C1 -> V2
+// V2 -> C2
+// C2 -> V3
+// if only allocate one buffer for V1 -> C2 dependency, need to double the loop iteration times
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @_attn_fwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg3: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg4: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg5: memref<?xf32> {tt.divisibility = 16 : i32}, %arg6: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg7: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg8: memref<?xi32> {tt.divisibility = 16 : i32}, %arg9: i32, %arg10: i32, %arg11: i32, %arg12: i32, %arg13: i32, %arg14: i32, %arg15: i32) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %c8192_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 8192 : i32
+    %c128_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 128 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 0 : i32
+    scope.scope : () -> () {
+      %alloc = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_11 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_11 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_12 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_12 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_13 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [3 : i32, 1 : i32], ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_13 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<3>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 4
+      %alloc_14 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [4 : i32, 1 : i32], ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_14 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<4>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+
+      // CHECK:       %[[IFCOUNT:.*]] = arith.constant 3
+      // CHECK:       %[[REQUIRENUM:.*]] = arith.constant 2
+      // CHECK:       %[[BUFFERNUM:.*]] = arith.constant 1
+      // CHECK:       arith.subi
+      // CHECK:       arith.ceildivui
+      // CHECK:       arith.muli %{{.*}}, %[[REQUIRENUM]]
+      // CHECK:       arith.ceildivui %{{.*}}, %[[BUFFERNUM]]
+      // CHECK:       arith.addi %{{.*}}, %[[IFCOUNT]]
+      // CHECK:       arith.muli
+      // CHECK:       arith.addi
+      // CHECK:       scf.for
+      // CHECK:       iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32, %[[CNT0:.*]] = %{{.+}}, %[[CNT1:.*]] = %{{.+}}, %[[CNT2:.*]] = %{{.+}})
+      %30:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
+        %42 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<128xf32>
+        // CHECK:       arith.divui %[[CNT0]], %c128_i32 {ssbuffer.block_id = 5 : i32} : i32
+        %43 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 5 : i32} : i32
+        %c0_i32_15 = arith.constant {ssbuffer.block_id = 5 : i32} 0 : i32
+        %c2_i32 = arith.constant {ssbuffer.block_id = 5 : i32} 2 : i32
+        %44 = arith.remsi %43, %c2_i32 {ssbuffer.block_id = 5 : i32} : i32
+        %45 = arith.cmpi eq, %44, %c0_i32_15 {ssbuffer.block_id = 5 : i32} : i32
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+        %reshape_40 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<4x1x16x16xf16>
+        hivm.hir.copy ins(%reshape_40 : tensor<4x1x16x16xf16>) outs(%alloc : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}
+        %reshape_41 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<8x4x16x16xf16>
+        hivm.hir.copy ins(%reshape_41 : tensor<8x4x16x16xf16>) outs(%alloc_11 : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}
+
+        // CHECK:       arith.divui %[[CNT1]], %c128_i32 {ssbuffer.block_id = 6 : i32} : i32
+        %46 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 6 : i32} : i32
+        %c0_i32_16 = arith.constant {ssbuffer.block_id = 6 : i32} 0 : i32
+        %c2_i32_6 = arith.constant {ssbuffer.block_id = 6 : i32} 2 : i32
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+        %memspacecast_11 = memref.memory_space_cast %alloc_13 {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 1 : i32, ssbuffer.crossDeps = [3 : i32, 0 : i32]} : memref<16x128xf32, #hivm.address_space<ub>> to memref<16x128xf32>
+        %reshape_42 = tensor.empty() {ssbuffer.block_id = 6 : i32} : tensor<4x8x16x16xf16>
+        hivm.hir.copy ins(%reshape_42 : tensor<4x8x16x16xf16>) outs(%alloc_12 : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 1 : i32}
+
+
+        // CHECK:       arith.divui %[[CNT2]], %c128_i32 {ssbuffer.block_id = 7 : i32} : i32
+        %49 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 7 : i32} : i32
+        %c2_i32_17 = arith.constant {ssbuffer.block_id = 7 : i32} 2 : i32
+        %50 = arith.remsi %49, %c2_i32_17 {ssbuffer.block_id = 7 : i32} : i32
+        %c0_i32_18 = arith.constant {ssbuffer.block_id = 7 : i32} 0 : i32
+        %51 = arith.cmpi eq, %50, %c0_i32_18 {ssbuffer.block_id = 7 : i32} : i32
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+        %memspacecast_12 = memref.memory_space_cast %alloc_14 {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 1 : i32, ssbuffer.crossDeps = [4 : i32, 0 : i32]} : memref<16x64xf32, #hivm.address_space<ub>> to memref<16x64xf32>
+        scf.yield %arg17, %arg18 : i32, i32
+      } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+
+    scope.scope : () -> () {
+      %alloc_10 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [0 : i32, 1 : i32], ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_10 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+      %alloc_11 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [1 : i32, 1 : i32], ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_11 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+      %alloc_12 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [2 : i32, 1 : i32], ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_12 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 3
+      %alloc_13 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_13 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<3>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      %alloc_14 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_14 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<4>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+      %30:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
+
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+        %50 = hivm.hir.convert_layout %alloc_10 output_shape [16, 64] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 2 : i32, ssbuffer.crossDeps = [0 : i32, 0 : i32], ssbuffer.transfer_id = 0 : i32} : (memref<4x1x16x16xf16, #hivm.address_space<cbuf>>) -> memref<16x64xf16, #hivm.address_space<cbuf>>
+        %54 = tensor.empty() {ssbuffer.block_id = 2 : i32} : tensor<16x128xf32>
+        hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 3 : i32} ins(%54 : tensor<16x128xf32>) outs(%alloc_13 : memref<16x128xf32, #hivm.address_space<ub>>)
+
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 3 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+        %48 = hivm.hir.convert_layout %alloc_11 output_shape [64, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 3 : i32, ssbuffer.crossDeps = [1 : i32, 0 : i32], ssbuffer.transfer_id = 1 : i32} : (memref<8x4x16x16xf16, #hivm.address_space<cbuf>>) -> memref<64x128xf16, #hivm.address_space<cbuf>>
+        %45 = hivm.hir.convert_layout %alloc_12 output_shape [128, 64] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 3 : i32, ssbuffer.crossDeps = [2 : i32, 0 : i32], ssbuffer.transfer_id = 2 : i32} : (memref<4x8x16x16xf16, #hivm.address_space<cbuf>>) -> memref<128x64xf16, #hivm.address_space<cbuf>>
+        %47 = tensor.empty() {ssbuffer.block_id = 3 : i32} : tensor<16x64xf32>
+        hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 3 : i32, ssbuffer.transfer_id = 4 : i32} ins(%47 : tensor<16x64xf32>) outs(%alloc_14 : memref<16x64xf32, #hivm.address_space<ub>>)
+
+        scf.yield %arg17, %arg18 : i32, i32
+      } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+    return {ssbuffer.core_type = "VECTOR"}
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/updateLoopIterTimes_intradeps_in_nosyncif_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/updateLoopIterTimes_intradeps_in_nosyncif_test.mlir
@@ -1,15 +1,10 @@
 // RUN: triton-opt --add-control-flow-condition %s | FileCheck %s
 
-
 // ============================================================================
-// TC-01: sufficient multicache
+// TC-06: insufficient intra multicache and intra dependency in no-cv-sync ifblocks
 // ============================================================================
-// This test verifies:
-// 1. New loop upper bound calculation (arith.subi, arith.ceildivui, arith.muli, arith.addi)
-// 2. iter_args expanded
-// 3. MainLoop counter will be replaced by each counter of ifblocks
 // If Vm has intra-core dependency on Vn (m>n), to achieve optimal pipeline, at most m-n+1 data flows need to exist simultaneously, which is requireNum
-// If multicache count is sufficient (bufferNum >= requireNum), only need to increase iteration times with number of ifblock
+// If multicache count is insufficient (bufferNum < requireNum), iteration count needs to be multiplied by requireNum / bufferNum
 
 module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
   func.func @_attn_fwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg3: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg4: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg5: memref<?xf32> {tt.divisibility = 16 : i32}, %arg6: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg7: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg8: memref<?xi32> {tt.divisibility = 16 : i32}, %arg9: i32, %arg10: i32, %arg11: i32, %arg12: i32, %arg13: i32, %arg14: i32, %arg15: i32) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
@@ -23,10 +18,14 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
       %memspacecast_9 = memref.memory_space_cast %alloc_8 {ssbuffer.intraDeps = [0 : i32, 1 : i32]} : memref<128xf32, #hivm.address_space<ub>> to memref<128xf32>
       %alloc_11 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
       annotation.mark %alloc_11 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_1 = memref.alloc() : memref<128xf32, #hivm.address_space<ub>>
+      %memspacecast_1 = memref.memory_space_cast %alloc_1 {ssbuffer.intraDeps = [1 : i32, 1 : i32]} : memref<128xf32, #hivm.address_space<ub>> to memref<128xf32>
+      %alloc_2 = memref.alloc() : memref<128xf32, #hivm.address_space<ub>>
+      %memspacecast_2 = memref.memory_space_cast %alloc_2 {ssbuffer.intraDeps = [1 : i32, 1 : i32]} : memref<128xf32, #hivm.address_space<ub>> to memref<128xf32>
 
-      // CHECK:       %[[IFCOUNT:.*]] = arith.constant 2
-      // CHECK:       %[[REQUIRENUM:.*]] = arith.constant 1
-      // CHECK:       %[[BUFFERNUM:.*]] = arith.constant 1
+      // CHECK:       %[[IFCOUNT:.*]] = arith.constant 4
+      // CHECK:       %[[REQUIRENUM:.*]] = arith.constant 3
+      // CHECK:       %[[BUFFERNUM:.*]] = arith.constant 2
       // CHECK:       arith.subi
       // CHECK:       arith.ceildivui
       // CHECK:       arith.muli %{{.*}}, %[[REQUIRENUM]]
@@ -35,10 +34,19 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
       // CHECK:       arith.muli
       // CHECK:       arith.addi
       // CHECK:       scf.for
-      // CHECK:       iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32, %[[CNT0:.*]] = %{{.+}}, %[[CNT1:.*]] = %{{.+}}, %arg21 = %{{.+}})
+      // CHECK:       iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32, %[[CNT0:.*]] = %{{.+}}, %[[CNT1:.*]] = %{{.+}}, %[[CNT2:.*]] = %{{.+}}, %[[CNT3:.*]] = %{{.+}}, %{{.+}} = %{{.+}}, %{{.+}} = %{{.+}})
       %30:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
+        %tensor = tensor.empty() {ssbuffer.block_id = 1 : i32} : tensor<128xf32>
+        %c0_i32_55 = arith.constant {ssbuffer.block_id = 1 : i32} 0 : i32
+        %cond = arith.cmpi eq, %arg16, %c0_i32_55 {ssbuffer.block_id = 1 : i32} : i32
+        scf.if %cond {
+          hivm.hir.copy ins(%tensor : tensor<128xf32>) outs(%memspacecast_1 : memref<128xf32>) {ssbuffer.block_id = 5 : i32}
+        } else {
+          hivm.hir.copy ins(%tensor : tensor<128xf32>) outs(%memspacecast_2 : memref<128xf32>) {ssbuffer.block_id = 5 : i32}
+        } {ssbuffer.block_id = 1 : i32}
+
         %42 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<128xf32>
-        // CHECK:       arith.divui %[[CNT0]], %c128_i32 {ssbuffer.block_id = 5 : i32} : i32
+        // CHECK:       arith.divui %[[CNT1]], %c128_i32 {ssbuffer.block_id = 5 : i32} : i32
         %43 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 5 : i32} : i32
         %c0_i32_15 = arith.constant {ssbuffer.block_id = 5 : i32} 0 : i32
         %c2_i32 = arith.constant {ssbuffer.block_id = 5 : i32} 2 : i32
@@ -49,11 +57,24 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
         } else {
           hivm.hir.copy ins(%42 : tensor<128xf32>) outs(%memspacecast_9 : memref<128xf32>) {ssbuffer.block_id = 5 : i32}
         } {ssbuffer.block_id = 5 : i32}
+        %comsumer = scf.if %45 -> (tensor<128xf32>) {
+          %55 = bufferization.to_tensor %memspacecast_1 restrict writable : memref<128xf32>
+          scf.yield %55 : tensor<128xf32>
+        } else {
+          %55 = bufferization.to_tensor %memspacecast_2 restrict writable : memref<128xf32>
+          scf.yield %55 : tensor<128xf32>
+        } {ssbuffer.block_id = 5 : i32, ssbuffer.intraDeps = [1 : i32, 0 : i32]}
         hivm.hir.sync_block_wait {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
         %reshape_40 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<8x4x16x16xf16>
         hivm.hir.copy ins(%reshape_40 : tensor<8x4x16x16xf16>) outs(%alloc_11 : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}
 
-        // CHECK:       arith.divui %[[CNT1]], %c128_i32 {ssbuffer.block_id = 7 : i32} : i32
+        // CHECK:       arith.divui %[[CNT2]], %c128_i32 {ssbuffer.block_id = 6 : i32} : i32
+        %46 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 6 : i32} : i32
+        %c0_i32_16 = arith.constant {ssbuffer.block_id = 6 : i32} 0 : i32
+        %c2_i32_6 = arith.constant {ssbuffer.block_id = 6 : i32} 2 : i32
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+
+        // CHECK:       arith.divui %[[CNT3]], %c128_i32 {ssbuffer.block_id = 7 : i32} : i32
         %49 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 7 : i32} : i32
         %c2_i32_17 = arith.constant {ssbuffer.block_id = 7 : i32} 2 : i32
         %50 = arith.remsi %49, %c2_i32_17 {ssbuffer.block_id = 7 : i32} : i32
@@ -71,6 +92,7 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
       } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
       scope.return
     } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+
     scope.scope : () -> () {
       %alloc_11 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [1 : i32, 1 : i32], ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
       annotation.mark %alloc_11 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/updateLoopIterTimes_redundentIf_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/updateLoopIterTimes_redundentIf_test.mlir
@@ -1,0 +1,133 @@
+// RUN: triton-opt --add-control-flow-condition %s | FileCheck %s
+
+// ============================================================================
+// TC-03: insufficient crossdependent multicache and contains redundent ifblocks
+// ============================================================================
+// CrossCore Data Dependency:
+// V1 -> C1 C2
+// C1 -> V2
+// V2 -> C2
+// C2 -> V3
+// if only allocate one buffer for V1 -> C2 dependency, need to double the loop iteration times
+// there are some useless ifblocks inserted in CV blocks
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @_attn_fwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg3: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg4: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg5: memref<?xf32> {tt.divisibility = 16 : i32}, %arg6: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg7: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg8: memref<?xi32> {tt.divisibility = 16 : i32}, %arg9: i32, %arg10: i32, %arg11: i32, %arg12: i32, %arg13: i32, %arg14: i32, %arg15: i32) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %c8192_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 8192 : i32
+    %c128_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 128 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 0 : i32
+    scope.scope : () -> () {
+      %alloc = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_11 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_11 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_12 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_12 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_13 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [3 : i32, 1 : i32], ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_13 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<3>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 4
+      %alloc_14 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [4 : i32, 1 : i32], ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_14 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<4>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+
+      // CHECK:       %[[IFCOUNT:.*]] = arith.constant 6
+      // CHECK:       %[[REQUIRENUM:.*]] = arith.constant 2
+      // CHECK:       %[[BUFFERNUM:.*]] = arith.constant 1
+      // CHECK:       arith.subi
+      // CHECK:       arith.ceildivui
+      // CHECK:       arith.muli %{{.*}}, %[[REQUIRENUM]]
+      // CHECK:       arith.ceildivui %{{.*}}, %[[BUFFERNUM]]
+      // CHECK:       arith.addi %{{.*}}, %[[IFCOUNT]]
+      // CHECK:       arith.muli
+      // CHECK:       arith.addi
+      // CHECK:       scf.for
+       // CHECK:       iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32, %[[CNT0:.*]] = %{{.+}}, %[[CNT1:.*]] = %{{.+}}, %[[CNT2:.*]] = %{{.+}}, %[[CNT3:.*]] = %{{.+}}, %[[CNT4:.*]] = %{{.+}}, %[[CNT5:.*]] = %{{.+}})
+      %30:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
+        // CHECK:       scf.if
+        %a1 = arith.constant {ssbuffer.block_id = 1 : i32} 2 : i32
+        %b1 = arith.constant {ssbuffer.block_id = 1 : i32} 2 : i32
+        %c1 = arith.constant {ssbuffer.block_id = 1 : i32} 2 : i32
+
+        %42 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<128xf32>
+        // CHECK:       arith.divui %[[CNT1]], %c128_i32 {ssbuffer.block_id = 5 : i32} : i32
+        %43 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 5 : i32} : i32
+        %c0_i32_15 = arith.constant {ssbuffer.block_id = 5 : i32} 0 : i32
+        %c2_i32 = arith.constant {ssbuffer.block_id = 5 : i32} 2 : i32
+        %44 = arith.remsi %43, %c2_i32 {ssbuffer.block_id = 5 : i32} : i32
+        %45 = arith.cmpi eq, %44, %c0_i32_15 {ssbuffer.block_id = 5 : i32} : i32
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+        %reshape_40 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<4x1x16x16xf16>
+        hivm.hir.copy ins(%reshape_40 : tensor<4x1x16x16xf16>) outs(%alloc : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}
+        %reshape_41 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<8x4x16x16xf16>
+        hivm.hir.copy ins(%reshape_41 : tensor<8x4x16x16xf16>) outs(%alloc_11 : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}
+
+        // CHECK:       scf.if
+        %a2 = arith.constant {ssbuffer.block_id = 2 : i32} 2 : i32
+        %b2 = arith.constant {ssbuffer.block_id = 2 : i32} 2 : i32
+        %c2 = arith.constant {ssbuffer.block_id = 2 : i32} 2 : i32
+
+        // CHECK:       arith.divui %[[CNT3]], %c128_i32 {ssbuffer.block_id = 6 : i32} : i32
+        %46 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 6 : i32} : i32
+        %c0_i32_16 = arith.constant {ssbuffer.block_id = 6 : i32} 0 : i32
+        %c2_i32_6 = arith.constant {ssbuffer.block_id = 6 : i32} 2 : i32
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+        %memspacecast_11 = memref.memory_space_cast %alloc_13 {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 1 : i32, ssbuffer.crossDeps = [3 : i32, 0 : i32]} : memref<16x128xf32, #hivm.address_space<ub>> to memref<16x128xf32>
+        %reshape_42 = tensor.empty() {ssbuffer.block_id = 6 : i32} : tensor<4x8x16x16xf16>
+        hivm.hir.copy ins(%reshape_42 : tensor<4x8x16x16xf16>) outs(%alloc_12 : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 1 : i32}
+
+        // CHECK:       scf.if
+        %a3 = arith.constant {ssbuffer.block_id = 3 : i32} 2 : i32
+        %b3 = arith.constant {ssbuffer.block_id = 3 : i32} 2 : i32
+        %c3 = arith.constant {ssbuffer.block_id = 3 : i32} 2 : i32
+
+        // CHECK:       arith.divui %[[CNT5]], %c128_i32 {ssbuffer.block_id = 7 : i32} : i32
+        %49 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 7 : i32} : i32
+        %c2_i32_17 = arith.constant {ssbuffer.block_id = 7 : i32} 2 : i32
+        %50 = arith.remsi %49, %c2_i32_17 {ssbuffer.block_id = 7 : i32} : i32
+        %c0_i32_18 = arith.constant {ssbuffer.block_id = 7 : i32} 0 : i32
+        %51 = arith.cmpi eq, %50, %c0_i32_18 {ssbuffer.block_id = 7 : i32} : i32
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+        %memspacecast_12 = memref.memory_space_cast %alloc_14 {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 1 : i32, ssbuffer.crossDeps = [4 : i32, 0 : i32]} : memref<16x64xf32, #hivm.address_space<ub>> to memref<16x64xf32>
+        scf.yield %arg17, %arg18 : i32, i32
+      } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+
+    scope.scope : () -> () {
+      %alloc_10 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [0 : i32, 1 : i32], ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_10 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+      %alloc_11 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [1 : i32, 1 : i32], ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_11 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+      %alloc_12 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [2 : i32, 1 : i32], ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_12 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 3
+      %alloc_13 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_13 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<3>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      %alloc_14 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_14 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<4>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+      %30:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
+
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+        %50 = hivm.hir.convert_layout %alloc_10 output_shape [16, 64] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 2 : i32, ssbuffer.crossDeps = [0 : i32, 0 : i32], ssbuffer.transfer_id = 0 : i32} : (memref<4x1x16x16xf16, #hivm.address_space<cbuf>>) -> memref<16x64xf16, #hivm.address_space<cbuf>>
+        %54 = tensor.empty() {ssbuffer.block_id = 2 : i32} : tensor<16x128xf32>
+        hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 3 : i32} ins(%54 : tensor<16x128xf32>) outs(%alloc_13 : memref<16x128xf32, #hivm.address_space<ub>>)
+
+        // CHECK:       scf.if
+        %a1 = arith.constant {ssbuffer.block_id = 1 : i32} 2 : i32
+        %b1 = arith.constant {ssbuffer.block_id = 1 : i32} 2 : i32
+        %c1 = arith.constant {ssbuffer.block_id = 1 : i32} 2 : i32
+
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 3 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+        %48 = hivm.hir.convert_layout %alloc_11 output_shape [64, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 3 : i32, ssbuffer.crossDeps = [1 : i32, 0 : i32], ssbuffer.transfer_id = 1 : i32} : (memref<8x4x16x16xf16, #hivm.address_space<cbuf>>) -> memref<64x128xf16, #hivm.address_space<cbuf>>
+        %45 = hivm.hir.convert_layout %alloc_12 output_shape [128, 64] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 3 : i32, ssbuffer.crossDeps = [2 : i32, 0 : i32], ssbuffer.transfer_id = 2 : i32} : (memref<4x8x16x16xf16, #hivm.address_space<cbuf>>) -> memref<128x64xf16, #hivm.address_space<cbuf>>
+        %47 = tensor.empty() {ssbuffer.block_id = 3 : i32} : tensor<16x64xf32>
+        hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 3 : i32, ssbuffer.transfer_id = 4 : i32} ins(%47 : tensor<16x64xf32>) outs(%alloc_14 : memref<16x64xf32, #hivm.address_space<ub>>)
+
+        scf.yield %arg17, %arg18 : i32, i32
+      } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+    return {ssbuffer.core_type = "VECTOR"}
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/updateLoopIterTimes_sufficient_crossdeps_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/updateLoopIterTimes_sufficient_crossdeps_test.mlir
@@ -1,0 +1,134 @@
+// RUN: triton-opt --add-control-flow-condition %s | FileCheck %s
+
+// ============================================================================
+// TC-04: insufficient crossdependent multicache
+// ============================================================================
+// CrossCore Data Dependency:
+// V1 -> C1 C2
+// C1 -> V2
+// V2 -> C2
+// C2 -> V3
+// if only allocate two buffer for V1 -> C2 dependency, no need to double the loop iteration times
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @_attn_fwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg3: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg4: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg5: memref<?xf32> {tt.divisibility = 16 : i32}, %arg6: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg7: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg8: memref<?xi32> {tt.divisibility = 16 : i32}, %arg9: i32, %arg10: i32, %arg11: i32, %arg12: i32, %arg13: i32, %arg14: i32, %arg15: i32) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %c8192_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 8192 : i32
+    %c128_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 128 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 0 : i32
+    scope.scope : () -> () {
+      %alloc = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_11 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_11 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_12 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_12 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_13 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [3 : i32, 1 : i32], ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_13 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<3>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 4
+      %alloc_14 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [4 : i32, 1 : i32], ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_14 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<4>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+      %alloc_15 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_15 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<5>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+
+      // CHECK:       %[[IFCOUNT:.*]] = arith.constant 3
+      // CHECK:       %[[REQUIRENUM:.*]] = arith.constant 1
+      // CHECK:       %[[BUFFERNUM:.*]] = arith.constant 1
+      // CHECK:       arith.subi
+      // CHECK:       arith.ceildivui
+      // CHECK:       arith.muli %{{.*}}, %[[REQUIRENUM]]
+      // CHECK:       arith.ceildivui %{{.*}}, %[[BUFFERNUM]]
+      // CHECK:       arith.addi %{{.*}}, %[[IFCOUNT]]
+      // CHECK:       arith.muli
+      // CHECK:       arith.addi
+      // CHECK:       scf.for
+      // CHECK:       iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32, %[[CNT0:.*]] = %{{.+}}, %[[CNT1:.*]] = %{{.+}}, %[[CNT2:.*]] = %{{.+}})
+      %30:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
+        %42 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<128xf32>
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+        %reshape_40 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<4x1x16x16xf16>
+        hivm.hir.copy ins(%reshape_40 : tensor<4x1x16x16xf16>) outs(%alloc : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}
+        // CHECK:       arith.divui %[[CNT0]], %c128_i32 {ssbuffer.block_id = 5 : i32} : i32
+        %43 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 5 : i32} : i32
+        %c0_i32_15 = arith.constant {ssbuffer.block_id = 5 : i32} 0 : i32
+        %c2_i32 = arith.constant {ssbuffer.block_id = 5 : i32} 2 : i32
+        %44 = arith.remsi %43, %c2_i32 {ssbuffer.block_id = 5 : i32} : i32
+        %45 = arith.cmpi eq, %44, %c0_i32_15 {ssbuffer.block_id = 5 : i32} : i32
+        %reshape_41 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<8x4x16x16xf16>
+        scf.if %45 {
+          hivm.hir.copy ins(%reshape_41 : tensor<8x4x16x16xf16>) outs(%alloc_11 : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}
+        } else {
+          hivm.hir.copy ins(%reshape_41 : tensor<8x4x16x16xf16>) outs(%alloc_15 : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}
+        } {ssbuffer.block_id = 5 : i32}
+
+        // CHECK:       arith.divui %[[CNT1]], %c128_i32 {ssbuffer.block_id = 6 : i32} : i32
+        %46 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 6 : i32} : i32
+        %c0_i32_16 = arith.constant {ssbuffer.block_id = 6 : i32} 0 : i32
+        %c2_i32_6 = arith.constant {ssbuffer.block_id = 6 : i32} 2 : i32
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+        %memspacecast_11 = memref.memory_space_cast %alloc_13 {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 1 : i32, ssbuffer.crossDeps = [3 : i32, 0 : i32]} : memref<16x128xf32, #hivm.address_space<ub>> to memref<16x128xf32>
+        %reshape_42 = tensor.empty() {ssbuffer.block_id = 6 : i32} : tensor<4x8x16x16xf16>
+        hivm.hir.copy ins(%reshape_42 : tensor<4x8x16x16xf16>) outs(%alloc_12 : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 1 : i32}
+
+
+        // CHECK:       arith.divui %[[CNT2]], %c128_i32 {ssbuffer.block_id = 7 : i32} : i32
+        %49 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 7 : i32} : i32
+        %c2_i32_17 = arith.constant {ssbuffer.block_id = 7 : i32} 2 : i32
+        %50 = arith.remsi %49, %c2_i32_17 {ssbuffer.block_id = 7 : i32} : i32
+        %c0_i32_18 = arith.constant {ssbuffer.block_id = 7 : i32} 0 : i32
+        %51 = arith.cmpi eq, %50, %c0_i32_18 {ssbuffer.block_id = 7 : i32} : i32
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+        %memspacecast_12 = memref.memory_space_cast %alloc_14 {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 1 : i32, ssbuffer.crossDeps = [4 : i32, 0 : i32]} : memref<16x64xf32, #hivm.address_space<ub>> to memref<16x64xf32>
+        scf.yield %arg17, %arg18 : i32, i32
+      } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+
+    scope.scope : () -> () {
+      %alloc_10 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [0 : i32, 1 : i32], ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_10 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+      %alloc_11 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [1 : i32, 1 : i32], ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_11 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+      %alloc_12 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [2 : i32, 1 : i32], ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_12 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 3
+      %alloc_13 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_13 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<3>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      %alloc_14 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_14 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<4>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+      %alloc_15 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [1 : i32, 1 : i32], ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_15 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<5>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      %30:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
+
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+        %50 = hivm.hir.convert_layout %alloc_10 output_shape [16, 64] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 2 : i32, ssbuffer.crossDeps = [0 : i32, 0 : i32], ssbuffer.transfer_id = 0 : i32} : (memref<4x1x16x16xf16, #hivm.address_space<cbuf>>) -> memref<16x64xf16, #hivm.address_space<cbuf>>
+        %54 = tensor.empty() {ssbuffer.block_id = 2 : i32} : tensor<16x128xf32>
+        hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 3 : i32} ins(%54 : tensor<16x128xf32>) outs(%alloc_13 : memref<16x128xf32, #hivm.address_space<ub>>)
+
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 3 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+        %43 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 3 : i32} : i32
+        %c0_i32_15 = arith.constant {ssbuffer.block_id = 3 : i32} 0 : i32
+        %45 = arith.cmpi eq, %43, %c0_i32_15 {ssbuffer.block_id = 3 : i32} : i32
+        %comsumer = scf.if %45 -> (tensor<64x128xf16>) {
+          %48 = hivm.hir.convert_layout %alloc_11 output_shape [64, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.transfer_id = 1 : i32} : (memref<8x4x16x16xf16, #hivm.address_space<cbuf>>) -> memref<64x128xf16, #hivm.address_space<cbuf>>
+          %memspacecast1 = memref.memory_space_cast %48 : memref<64x128xf16, #hivm.address_space<cbuf>> to memref<64x128xf16>
+          %46 = bufferization.to_tensor %memspacecast1 restrict writable  : memref<64x128xf16>
+          scf.yield %46 : tensor<64x128xf16>
+        } else {
+          %48 = hivm.hir.convert_layout %alloc_15 output_shape [64, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.transfer_id = 1 : i32} : (memref<8x4x16x16xf16, #hivm.address_space<cbuf>>) -> memref<64x128xf16, #hivm.address_space<cbuf>>
+          %memspacecast1 = memref.memory_space_cast %48 : memref<64x128xf16, #hivm.address_space<cbuf>> to memref<64x128xf16>
+          %46 = bufferization.to_tensor %memspacecast1 restrict writable  : memref<64x128xf16>
+          scf.yield %46 : tensor<64x128xf16>
+        } {ssbuffer.block_id = 3 : i32, ssbuffer.crossDeps = [1 : i32, 0 : i32]}
+        %55 = hivm.hir.convert_layout %alloc_12 output_shape [128, 64] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 3 : i32, ssbuffer.crossDeps = [2 : i32, 0 : i32], ssbuffer.transfer_id = 2 : i32} : (memref<4x8x16x16xf16, #hivm.address_space<cbuf>>) -> memref<128x64xf16, #hivm.address_space<cbuf>>
+        %47 = tensor.empty() {ssbuffer.block_id = 3 : i32} : tensor<16x64xf32>
+        hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 3 : i32, ssbuffer.transfer_id = 4 : i32} ins(%47 : tensor<16x64xf32>) outs(%alloc_14 : memref<16x64xf32, #hivm.address_space<ub>>)
+
+        scf.yield %arg17, %arg18 : i32, i32
+      } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+    return {ssbuffer.core_type = "VECTOR"}
+  }
+}


### PR DESCRIPTION
fix(ssbuffer): fix bugs some ifblocks not include while caculating intra factor

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
