### PR TITLE
[release/3.2.2-dev][Autotune] Normalize duplicate reduction axis (backport #146)

### DIFF
--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -599,18 +599,21 @@ class AutoTilingTuner(Autotuner):
         return axis_arg_names
 
     def _promote_axis_arg_name_to_reduction(self, axis):
+        axis = self._get_axis_base_name(axis)
         if not isinstance(axis, str) or not axis:
             return
-        if axis.startswith("r"):
-            return
-        reduction_axis = "r{}".format(axis)
         if self.vector_axes is None:
             self.vector_axes = self._rebuild_vector_axes()
+        reduction_axis = "r{}".format(axis)
         axis_arg_name = self.vector_axes.axis_length_exprs.get(axis, None)
+        if axis_arg_name is None:
+            axis_arg_name = self.vector_axes.axis_length_exprs.get(reduction_axis, None)
+        self.vector_axes.ensure_axis(axis)
         if axis_arg_name is not None:
-            self.vector_axes.ensure_axis(reduction_axis).length_expr = axis_arg_name
-            self.vector_axes.ensure_axis(axis).length_expr = None
-        self.vector_axes.apply_semantic_fields(reduction_axes=[reduction_axis])
+            self.vector_axes.ensure_axis(axis).length_expr = axis_arg_name
+            if reduction_axis in self.vector_axes.axes:
+                self.vector_axes.ensure_axis(reduction_axis).length_expr = None
+        self.vector_axes.apply_semantic_fields(reduction_axes=[axis])
         self.axis_arg_names = self._get_parser_axis_arg_names()
 
     def _init_axis_params(self, key, split_params, tiling_params, low_dim_axes, reduction_axes, hints_axes=None):
@@ -1084,21 +1087,51 @@ class AutoTilingTuner(Autotuner):
                 f"Please ensure that these arguments are passed when calling the function."
             )
 
-    def _normalize_vv_reduction_axes(self, reduction_axes: List[str]) -> List[str]:
+    @staticmethod
+    def _normalize_reduction_axis_name(axis: Optional[str]) -> Optional[str]:
+        if not isinstance(axis, str) or not axis:
+            return None
+        base_axis_names = {
+            name
+            for name in valid_axis_names
+            if isinstance(name, str) and name and not name.startswith("r")
+        }
+        if axis in base_axis_names:
+            return axis
+        candidate = axis
+        while candidate.startswith("r") and len(candidate) > 1:
+            candidate = candidate[1:]
+            if candidate in base_axis_names:
+                return candidate
+        return axis
+
+    def _normalize_reduction_axes(self, reduction_axes: List[str]) -> List[str]:
         normalized = []
         for axis in reduction_axes:
-            if not isinstance(axis, str) or not axis:
-                continue
-            if axis.startswith("r"):
-                normalized.append(axis)
-            else:
-                normalized.append("r{}".format(axis))
+            canonical_axis = self._normalize_reduction_axis_name(axis)
+            if canonical_axis is not None:
+                normalized.append(canonical_axis)
         return normalized
+
+    def _normalize_vv_reduction_axes(self, reduction_axes: List[str]) -> List[str]:
+        return self._normalize_reduction_axes(reduction_axes)
 
     @staticmethod
     def _get_axis_base_name(axis: Optional[str]) -> Optional[str]:
         if not isinstance(axis, str) or not axis:
             return None
+        base_axis_names = {
+            name
+            for name in valid_axis_names
+            if isinstance(name, str) and name and not name.startswith("r")
+        }
+        if axis in base_axis_names:
+            return axis
+        candidate = axis
+        while candidate.startswith("r") and len(candidate) > 1:
+            candidate = candidate[1:]
+            if candidate in base_axis_names:
+                return candidate
         return axis[1:] if axis.startswith("r") else axis
 
     def _apply_vv_axis_semantic_result(self) -> bool:
@@ -1109,21 +1142,24 @@ class AutoTilingTuner(Autotuner):
             return False
 
         applied = False
+        raw_adapter_reduction_axes = list(
+            getattr(self.vv_adapter_result_v2, "reduction_axes", []) or []
+        )
         adapter_reduction_axes = self._normalize_vv_reduction_axes(
-            list(getattr(self.vv_adapter_result_v2, "reduction_axes", []) or [])
+            raw_adapter_reduction_axes
+        )
+        raw_adapter_low_dim_axes = list(
+            getattr(self.vv_adapter_result_v2, "low_dim_axes", []) or []
         )
         if adapter_reduction_axes or self.reduction_axes:
             self.reduction_axes = []
             for reduction_axis in adapter_reduction_axes:
-                base_axis = reduction_axis[1:] if reduction_axis.startswith("r") else reduction_axis
-                if base_axis in self.axis_arg_names and reduction_axis not in self.axis_arg_names:
-                    self._promote_axis_arg_name_to_reduction(base_axis)
+                base_axis = self._get_axis_base_name(reduction_axis)
+                self._promote_axis_arg_name_to_reduction(base_axis)
             self.reduction_axes = list(adapter_reduction_axes)
             applied = True
 
-        adapter_low_dim_axes = list(
-            getattr(self.vv_adapter_result_v2, "low_dim_axes", []) or []
-        )
+        adapter_low_dim_axes = raw_adapter_low_dim_axes
         if adapter_low_dim_axes or self.low_dim_axes:
             self.low_dim_axes = list(adapter_low_dim_axes)
             applied = True
@@ -1366,6 +1402,42 @@ class AutoTilingTuner(Autotuner):
             "reduction_axes": vector_axes.reduction_axes,
             "axis_pid_dims": vector_axes.axis_pid_dims,
             "diagnostics": diagnostics,
+        }
+
+    def _convert_reduction_axes_for_legacy_tile_generator(
+        self,
+        vector_tile_inputs: Dict[str, object],
+    ) -> Dict[str, object]:
+        reduction_base_axes = {
+            self._get_axis_base_name(axis)
+            for axis in list(vector_tile_inputs.get("reduction_axes", []) or [])
+        }
+        reduction_base_axes = {
+            axis for axis in reduction_base_axes
+            if isinstance(axis, str) and axis
+        }
+
+        def legacy_axis_name(axis):
+            base_axis = self._get_axis_base_name(axis)
+            if base_axis in reduction_base_axes:
+                return "r{}".format(base_axis)
+            return axis
+
+        def map_axis_dict(axis_dict):
+            return {
+                legacy_axis_name(axis): value
+                for axis, value in dict(axis_dict or {}).items()
+            }
+
+        return {
+            "axis_sizes": map_axis_dict(vector_tile_inputs.get("axis_sizes", {})),
+            "split_params": map_axis_dict(vector_tile_inputs.get("split_params", {})),
+            "fixed_split_params": map_axis_dict(getattr(self, "fixed_split_params", {})),
+            "tiling_params": map_axis_dict(vector_tile_inputs.get("tiling_params", {})),
+            "low_dim_axes": [
+                legacy_axis_name(axis)
+                for axis in list(vector_tile_inputs.get("low_dim_axes", []) or [])
+            ],
         }
 
     def _apply_fixed_grid_semantics(
@@ -1929,14 +2001,16 @@ class AutoTilingTuner(Autotuner):
         from .tile_generator import KernelMeta, TileGenerator
 
         vector_tile_inputs = self._materialize_vector_tile_inputs(kv_dict, all_args)
-        axis_sizes = vector_tile_inputs["axis_sizes"]
+        legacy_tile_inputs = self._convert_reduction_axes_for_legacy_tile_generator(
+            vector_tile_inputs
+        )
 
         kernel_meta = KernelMeta(
-            axis_sizes,
-            vector_tile_inputs["split_params"],
-            self.fixed_split_params,
-            vector_tile_inputs["tiling_params"],
-            vector_tile_inputs["low_dim_axes"],
+            legacy_tile_inputs["axis_sizes"],
+            legacy_tile_inputs["split_params"],
+            legacy_tile_inputs["fixed_split_params"],
+            legacy_tile_inputs["tiling_params"],
+            legacy_tile_inputs["low_dim_axes"],
             dtype,
             self.persistent_reduction,
             self.dual_reduction,
@@ -2545,11 +2619,13 @@ class AutoTilingTuner(Autotuner):
         Extracts the reduction axis parameters from triton kernel code.
         """
         func_ast = self.fn.parse()
-        parser = ReductionAxesParser(func_ast, self._get_parser_axis_arg_names())
-        reduction_axes = parser.parse()
-        for axis in reduction_axes:
-            self._promote_axis_arg_name_to_reduction(axis)
-        reduction_axes = [f"r{axis}" for axis in reduction_axes]
+        axis_arg_names_before = self._get_parser_axis_arg_names()
+        parser = ReductionAxesParser(func_ast, axis_arg_names_before)
+        raw_reduction_axes = parser.parse()
+        for axis in raw_reduction_axes:
+            base_axis = self._get_axis_base_name(axis)
+            self._promote_axis_arg_name_to_reduction(base_axis)
+        reduction_axes = self._normalize_reduction_axes(raw_reduction_axes)
         self.reduction_axes = list(reduction_axes)
         self._refresh_vector_axes()
 

--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -581,52 +581,9 @@ class AutoTilingTuner(Autotuner):
 
     def _refresh_vector_axes(self) -> None:
         self.vector_axes = self._rebuild_vector_axes()
-        self._sync_reduction_axis_arg_aliases()
         self.axis_arg_names = self._get_parser_axis_arg_names()
 
-    def _sync_reduction_axis_arg_aliases(self) -> None:
-        def resolve_base_axis(axis_name):
-            resolver = getattr(self, "_get_axis_base_name", None)
-            if callable(resolver):
-                return resolver(axis_name)
-            if not isinstance(axis_name, str) or not axis_name:
-                return None
-            candidate = axis_name
-            while candidate.startswith("r") and len(candidate) > 1:
-                candidate = candidate[1:]
-            return candidate
-
-        vector_axes = getattr(self, "vector_axes", None)
-        axis_length_exprs = {}
-        if vector_axes is not None:
-            axis_length_exprs = dict(getattr(vector_axes, "axis_length_exprs", {}) or {})
-
-        synced_aliases = {}
-        for reduction_axis in list(getattr(self, "reduction_axes", []) or []):
-            if not isinstance(reduction_axis, str) or not reduction_axis.startswith("r"):
-                continue
-            base_axis = resolve_base_axis(reduction_axis)
-            if not isinstance(base_axis, str) or not base_axis:
-                continue
-            axis_arg_name = axis_length_exprs.get(base_axis, None)
-            if not self._is_direct_runtime_length_arg_name(axis_arg_name):
-                continue
-            synced_aliases[f"r{base_axis}"] = axis_arg_name
-
-        self.reduction_axis_arg_aliases = synced_aliases
-
     def _get_parser_axis_arg_names(self) -> Dict[str, str]:
-        def resolve_base_axis(axis_name):
-            resolver = getattr(self, "_get_axis_base_name", None)
-            if callable(resolver):
-                return resolver(axis_name)
-            if not isinstance(axis_name, str) or not axis_name:
-                return None
-            candidate = axis_name
-            while candidate.startswith("r") and len(candidate) > 1:
-                candidate = candidate[1:]
-            return candidate
-
         axis_arg_names = {}
         if self.vector_axes is not None:
             axis_arg_names.update(
@@ -637,25 +594,6 @@ class AutoTilingTuner(Autotuner):
                 }
             )
 
-            for reduction_axis in self.vector_axes.reduction_axes:
-                if not isinstance(reduction_axis, str) or not reduction_axis.startswith("r"):
-                    continue
-                base_axis = resolve_base_axis(reduction_axis)
-                if not isinstance(base_axis, str) or not base_axis:
-                    continue
-                base_arg_name = axis_arg_names.get(base_axis, None)
-                if base_arg_name is not None:
-                    axis_arg_names.setdefault(f"r{base_axis}", base_arg_name)
-
-        reduction_axis_arg_aliases = getattr(self, "reduction_axis_arg_aliases", {}) or {}
-        axis_arg_names.update(reduction_axis_arg_aliases)
-        for reduction_axis, arg_name in reduction_axis_arg_aliases.items():
-            if not isinstance(reduction_axis, str) or not reduction_axis.startswith("r"):
-                continue
-            base_axis = reduction_axis[1:]
-            if axis_arg_names.get(base_axis, None) == arg_name:
-                axis_arg_names.pop(base_axis, None)
-
         return axis_arg_names
 
     def _promote_axis_arg_name_to_reduction(self, axis):
@@ -664,19 +602,11 @@ class AutoTilingTuner(Autotuner):
             return
         if self.vector_axes is None:
             self.vector_axes = self._rebuild_vector_axes()
-        reduction_axis = "r{}".format(axis)
         axis_arg_name = self.vector_axes.axis_length_exprs.get(axis, None)
-        if axis_arg_name is None:
-            axis_arg_name = self.vector_axes.axis_length_exprs.get(reduction_axis, None)
         self.vector_axes.ensure_axis(axis)
         if axis_arg_name is not None:
             self.vector_axes.ensure_axis(axis).length_expr = axis_arg_name
-            if reduction_axis in self.vector_axes.axes:
-                self.vector_axes.ensure_axis(reduction_axis).length_expr = None
         self.vector_axes.apply_semantic_fields(reduction_axes=[axis])
-        sync_aliases = getattr(self, "_sync_reduction_axis_arg_aliases", None)
-        if callable(sync_aliases):
-            sync_aliases()
         self.axis_arg_names = self._get_parser_axis_arg_names()
 
     def _init_axis_params(self, key, split_params, tiling_params, low_dim_axes, reduction_axes, hints_axes=None):
@@ -741,8 +671,6 @@ class AutoTilingTuner(Autotuner):
         self.vv_adapter_result_v2 = None
         self.vv_gap_fill_report_v2 = None
         self.vector_axes = self._rebuild_vector_axes()
-        self.reduction_axis_arg_aliases = {}
-        self._sync_reduction_axis_arg_aliases()
         self.axis_arg_names = self._get_parser_axis_arg_names()
 
     def _autoparse_axis_params(self, all_args):
@@ -1153,21 +1081,29 @@ class AutoTilingTuner(Autotuner):
             )
 
     @staticmethod
+    def _require_base_axis_name(axis: Optional[str]) -> Optional[str]:
+        if not isinstance(axis, str) or not axis:
+            return None
+        if axis.startswith("r"):
+            raise ValueError(
+                "r-prefixed axis names are not supported; "
+                f"use the base axis name instead of '{axis}'."
+            )
+        if axis not in valid_axis_names:
+            raise ValueError(f"Unsupported axis name '{axis}'.")
+        return axis
+
+    @staticmethod
     def _normalize_reduction_axis_name(axis: Optional[str]) -> Optional[str]:
         if not isinstance(axis, str) or not axis:
             return None
-        base_axis_names = {
-            name
-            for name in valid_axis_names
-            if isinstance(name, str) and name and not name.startswith("r")
-        }
-        if axis in base_axis_names:
-            return axis
-        candidate = axis
-        while candidate.startswith("r") and len(candidate) > 1:
-            candidate = candidate[1:]
-            if candidate in base_axis_names:
-                return candidate
+        if axis.startswith("r"):
+            raise ValueError(
+                "r-prefixed axis names are not supported; "
+                f"use the base axis name instead of '{axis}'."
+            )
+        if axis not in valid_axis_names:
+            raise ValueError(f"Unsupported axis name '{axis}'.")
         return axis
 
     def _normalize_reduction_axes(self, reduction_axes: List[str]) -> List[str]:
@@ -1185,20 +1121,9 @@ class AutoTilingTuner(Autotuner):
         self,
         axis_mapping: Optional[Dict[str, Any]],
     ) -> Dict[str, Any]:
-        def resolve_base_axis(axis_name):
-            resolver = getattr(self, "_get_axis_base_name", None)
-            if callable(resolver):
-                return resolver(axis_name)
-            if not isinstance(axis_name, str) or not axis_name:
-                return None
-            candidate = axis_name
-            while candidate.startswith("r") and len(candidate) > 1:
-                candidate = candidate[1:]
-            return candidate
-
         normalized = {}
         for axis, value in dict(axis_mapping or {}).items():
-            base_axis = resolve_base_axis(axis)
+            base_axis = self._get_axis_base_name(axis)
             if not isinstance(base_axis, str) or not base_axis:
                 continue
             normalized.setdefault(base_axis, value)
@@ -1208,20 +1133,9 @@ class AutoTilingTuner(Autotuner):
         self,
         axis_names: Optional[List[str]],
     ) -> List[str]:
-        def resolve_base_axis(axis_name):
-            resolver = getattr(self, "_get_axis_base_name", None)
-            if callable(resolver):
-                return resolver(axis_name)
-            if not isinstance(axis_name, str) or not axis_name:
-                return None
-            candidate = axis_name
-            while candidate.startswith("r") and len(candidate) > 1:
-                candidate = candidate[1:]
-            return candidate
-
         normalized = []
         for axis in list(axis_names or []):
-            base_axis = resolve_base_axis(axis)
+            base_axis = self._get_axis_base_name(axis)
             if not isinstance(base_axis, str) or not base_axis:
                 continue
             if base_axis not in normalized:
@@ -1232,19 +1146,14 @@ class AutoTilingTuner(Autotuner):
     def _get_axis_base_name(axis: Optional[str]) -> Optional[str]:
         if not isinstance(axis, str) or not axis:
             return None
-        base_axis_names = {
-            name
-            for name in valid_axis_names
-            if isinstance(name, str) and name and not name.startswith("r")
-        }
-        if axis in base_axis_names:
-            return axis
-        candidate = axis
-        while candidate.startswith("r") and len(candidate) > 1:
-            candidate = candidate[1:]
-            if candidate in base_axis_names:
-                return candidate
-        return axis[1:] if axis.startswith("r") else axis
+        if axis.startswith("r"):
+            raise ValueError(
+                "r-prefixed axis names are not supported; "
+                f"use the base axis name instead of '{axis}'."
+            )
+        if axis not in valid_axis_names:
+            raise ValueError(f"Unsupported axis name '{axis}'.")
+        return axis
 
     def _apply_vv_axis_semantic_result(self) -> bool:
         def resolve_base_axis(axis_name):
@@ -1253,10 +1162,12 @@ class AutoTilingTuner(Autotuner):
                 return resolver(axis_name)
             if not isinstance(axis_name, str) or not axis_name:
                 return None
-            candidate = axis_name
-            while candidate.startswith("r") and len(candidate) > 1:
-                candidate = candidate[1:]
-            return candidate
+            if axis_name.startswith("r"):
+                raise ValueError(
+                    "r-prefixed axis names are not supported; "
+                    f"use the base axis name instead of '{axis_name}'."
+                )
+            return axis_name
 
         def normalize_axis_name_mapping(axis_mapping):
             normalizer = getattr(self, "_normalize_axis_name_mapping", None)
@@ -1480,8 +1391,6 @@ class AutoTilingTuner(Autotuner):
                 getattr(self.vv_adapter_result_v2, "axis_length_exprs", {}) or {}
             )
         axis_expr = axis_length_exprs.get(axis, None)
-        if axis_expr is None and isinstance(axis, str) and axis.startswith("r"):
-            axis_expr = axis_length_exprs.get(axis[1:], None)
         if self._is_direct_runtime_length_arg_name(axis_expr):
             return axis_expr
         parser_axis_arg_names = self._get_parser_axis_arg_names()
@@ -1550,42 +1459,6 @@ class AutoTilingTuner(Autotuner):
             "reduction_axes": vector_axes.reduction_axes,
             "axis_pid_dims": vector_axes.axis_pid_dims,
             "diagnostics": diagnostics,
-        }
-
-    def _convert_reduction_axes_for_legacy_tile_generator(
-        self,
-        vector_tile_inputs: Dict[str, object],
-    ) -> Dict[str, object]:
-        reduction_base_axes = {
-            self._get_axis_base_name(axis)
-            for axis in list(vector_tile_inputs.get("reduction_axes", []) or [])
-        }
-        reduction_base_axes = {
-            axis for axis in reduction_base_axes
-            if isinstance(axis, str) and axis
-        }
-
-        def legacy_axis_name(axis):
-            base_axis = self._get_axis_base_name(axis)
-            if base_axis in reduction_base_axes:
-                return "r{}".format(base_axis)
-            return axis
-
-        def map_axis_dict(axis_dict):
-            return {
-                legacy_axis_name(axis): value
-                for axis, value in dict(axis_dict or {}).items()
-            }
-
-        return {
-            "axis_sizes": map_axis_dict(vector_tile_inputs.get("axis_sizes", {})),
-            "split_params": map_axis_dict(vector_tile_inputs.get("split_params", {})),
-            "fixed_split_params": map_axis_dict(getattr(self, "fixed_split_params", {})),
-            "tiling_params": map_axis_dict(vector_tile_inputs.get("tiling_params", {})),
-            "low_dim_axes": [
-                legacy_axis_name(axis)
-                for axis in list(vector_tile_inputs.get("low_dim_axes", []) or [])
-            ],
         }
 
     def _apply_fixed_grid_semantics(
@@ -1867,19 +1740,14 @@ class AutoTilingTuner(Autotuner):
         if not param_upper:
             return 0
 
-        axis_lower = axis_name.lower()
-        is_reduction_axis = axis_lower.startswith("r")
-        axis_base = axis_lower[1:] if is_reduction_axis else axis_lower
-        if not axis_base:
+        axis_token = axis_name.upper()
+        if not axis_token:
             return 0
 
-        axis_token = ("R" + axis_base.upper()) if is_reduction_axis else axis_base.upper()
         if param_upper.startswith(axis_token):
             return 100
         if "_{}_".format(axis_token) in "_{}_".format(param_upper):
             return 80
-        if is_reduction_axis and axis_token in param_upper:
-            return 60
         return 0
 
     @staticmethod
@@ -1972,12 +1840,10 @@ class AutoTilingTuner(Autotuner):
                     param_name,
                     anchor_map.get(axis, None),
                 )
-                non_reduction_bonus = 1 if not axis.startswith("r") else 0
                 order_score = -axis_order.get(axis, 0)
                 score = (
                     axis_name_score,
                     anchor_score,
-                    non_reduction_bonus,
                     order_score,
                 )
                 if best_score is None or score > best_score:
@@ -2149,16 +2015,14 @@ class AutoTilingTuner(Autotuner):
         from .tile_generator import KernelMeta, TileGenerator
 
         vector_tile_inputs = self._materialize_vector_tile_inputs(kv_dict, all_args)
-        legacy_tile_inputs = self._convert_reduction_axes_for_legacy_tile_generator(
-            vector_tile_inputs
-        )
 
         kernel_meta = KernelMeta(
-            legacy_tile_inputs["axis_sizes"],
-            legacy_tile_inputs["split_params"],
-            legacy_tile_inputs["fixed_split_params"],
-            legacy_tile_inputs["tiling_params"],
-            legacy_tile_inputs["low_dim_axes"],
+            vector_tile_inputs["axis_sizes"],
+            vector_tile_inputs["split_params"],
+            self.fixed_split_params,
+            vector_tile_inputs["tiling_params"],
+            vector_tile_inputs["low_dim_axes"],
+            vector_tile_inputs["reduction_axes"],
             dtype,
             self.persistent_reduction,
             self.dual_reduction,
@@ -2315,20 +2179,10 @@ class AutoTilingTuner(Autotuner):
         if key not in self.cache:
             if self.auto_gen_config:
                 self.cv_parse_result = self._autoparse_axis_params(all_args)
-                reduction_aliases = {
-                    axis for axis, arg_name in self.axis_arg_names.items()
-                    if isinstance(axis, str)
-                    and axis.startswith("r")
-                    and self.axis_arg_names.get(axis[1:], None) == arg_name
-                }
                 _kv_dict = {
                     axis: _args[arg_name]
                     for axis, arg_name in self.axis_arg_names.items()
                     if arg_name in _args
-                    and axis not in {
-                        reduction_axis[1:]
-                        for reduction_axis in reduction_aliases
-                    }
                 }
                 self._gen_tile_configs(_kv_dict, dtype, all_args)
                 self.gen_configs = _expand_configs_with_hints(
@@ -2839,9 +2693,8 @@ class AutoTilingTuner(Autotuner):
     def _get_persistent_reduction_threshold(self, reduction_axis: str) -> int:
         # Keep this heuristic aligned with inductor-style policy:
         # inner reduction axis uses a larger threshold than other axes.
-        # Compare on base axis name so legacy 'r'-prefixed reduction axes and
-        # unprefixed low-dim axes remain consistent during the transition away
-        # from reduction-axis name prefixes.
+        # Reduction axes are stored as base axis names; compare directly with
+        # the low-dim base axis.
         reduction_axis_base = self._get_axis_base_name(reduction_axis)
         low_dim_axis_base = (
             self._get_axis_base_name(self.low_dim_axes[0])

--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -559,9 +559,15 @@ class AutoTilingTuner(Autotuner):
         existing_vector_axes = getattr(self, "vector_axes", None)
         if existing_vector_axes is not None:
             vector_axes.apply_semantic_fields(
-                axis_length_exprs=getattr(existing_vector_axes, "axis_length_exprs", {}),
-                fixed_tiling_exprs=getattr(existing_vector_axes, "fixed_tiling_exprs", {}),
-                axis_dynamic_sources=getattr(existing_vector_axes, "axis_dynamic_sources", {}),
+                axis_length_exprs=self._normalize_axis_name_mapping(
+                    getattr(existing_vector_axes, "axis_length_exprs", {}),
+                ),
+                fixed_tiling_exprs=self._normalize_axis_name_mapping(
+                    getattr(existing_vector_axes, "fixed_tiling_exprs", {}),
+                ),
+                axis_dynamic_sources=self._normalize_axis_name_mapping(
+                    getattr(existing_vector_axes, "axis_dynamic_sources", {}),
+                ),
             )
 
         vector_axes.apply_semantic_fields(
@@ -575,9 +581,52 @@ class AutoTilingTuner(Autotuner):
 
     def _refresh_vector_axes(self) -> None:
         self.vector_axes = self._rebuild_vector_axes()
+        self._sync_reduction_axis_arg_aliases()
         self.axis_arg_names = self._get_parser_axis_arg_names()
 
+    def _sync_reduction_axis_arg_aliases(self) -> None:
+        def resolve_base_axis(axis_name):
+            resolver = getattr(self, "_get_axis_base_name", None)
+            if callable(resolver):
+                return resolver(axis_name)
+            if not isinstance(axis_name, str) or not axis_name:
+                return None
+            candidate = axis_name
+            while candidate.startswith("r") and len(candidate) > 1:
+                candidate = candidate[1:]
+            return candidate
+
+        vector_axes = getattr(self, "vector_axes", None)
+        axis_length_exprs = {}
+        if vector_axes is not None:
+            axis_length_exprs = dict(getattr(vector_axes, "axis_length_exprs", {}) or {})
+
+        synced_aliases = {}
+        for reduction_axis in list(getattr(self, "reduction_axes", []) or []):
+            if not isinstance(reduction_axis, str) or not reduction_axis.startswith("r"):
+                continue
+            base_axis = resolve_base_axis(reduction_axis)
+            if not isinstance(base_axis, str) or not base_axis:
+                continue
+            axis_arg_name = axis_length_exprs.get(base_axis, None)
+            if not self._is_direct_runtime_length_arg_name(axis_arg_name):
+                continue
+            synced_aliases[f"r{base_axis}"] = axis_arg_name
+
+        self.reduction_axis_arg_aliases = synced_aliases
+
     def _get_parser_axis_arg_names(self) -> Dict[str, str]:
+        def resolve_base_axis(axis_name):
+            resolver = getattr(self, "_get_axis_base_name", None)
+            if callable(resolver):
+                return resolver(axis_name)
+            if not isinstance(axis_name, str) or not axis_name:
+                return None
+            candidate = axis_name
+            while candidate.startswith("r") and len(candidate) > 1:
+                candidate = candidate[1:]
+            return candidate
+
         axis_arg_names = {}
         if self.vector_axes is not None:
             axis_arg_names.update(
@@ -591,10 +640,21 @@ class AutoTilingTuner(Autotuner):
             for reduction_axis in self.vector_axes.reduction_axes:
                 if not isinstance(reduction_axis, str) or not reduction_axis.startswith("r"):
                     continue
-                base_axis = reduction_axis[1:]
-                base_arg_name = axis_arg_names.pop(base_axis, None)
+                base_axis = resolve_base_axis(reduction_axis)
+                if not isinstance(base_axis, str) or not base_axis:
+                    continue
+                base_arg_name = axis_arg_names.get(base_axis, None)
                 if base_arg_name is not None:
-                    axis_arg_names.setdefault(reduction_axis, base_arg_name)
+                    axis_arg_names.setdefault(f"r{base_axis}", base_arg_name)
+
+        reduction_axis_arg_aliases = getattr(self, "reduction_axis_arg_aliases", {}) or {}
+        axis_arg_names.update(reduction_axis_arg_aliases)
+        for reduction_axis, arg_name in reduction_axis_arg_aliases.items():
+            if not isinstance(reduction_axis, str) or not reduction_axis.startswith("r"):
+                continue
+            base_axis = reduction_axis[1:]
+            if axis_arg_names.get(base_axis, None) == arg_name:
+                axis_arg_names.pop(base_axis, None)
 
         return axis_arg_names
 
@@ -614,6 +674,9 @@ class AutoTilingTuner(Autotuner):
             if reduction_axis in self.vector_axes.axes:
                 self.vector_axes.ensure_axis(reduction_axis).length_expr = None
         self.vector_axes.apply_semantic_fields(reduction_axes=[axis])
+        sync_aliases = getattr(self, "_sync_reduction_axis_arg_aliases", None)
+        if callable(sync_aliases):
+            sync_aliases()
         self.axis_arg_names = self._get_parser_axis_arg_names()
 
     def _init_axis_params(self, key, split_params, tiling_params, low_dim_axes, reduction_axes, hints_axes=None):
@@ -678,6 +741,8 @@ class AutoTilingTuner(Autotuner):
         self.vv_adapter_result_v2 = None
         self.vv_gap_fill_report_v2 = None
         self.vector_axes = self._rebuild_vector_axes()
+        self.reduction_axis_arg_aliases = {}
+        self._sync_reduction_axis_arg_aliases()
         self.axis_arg_names = self._get_parser_axis_arg_names()
 
     def _autoparse_axis_params(self, all_args):
@@ -1116,6 +1181,53 @@ class AutoTilingTuner(Autotuner):
     def _normalize_vv_reduction_axes(self, reduction_axes: List[str]) -> List[str]:
         return self._normalize_reduction_axes(reduction_axes)
 
+    def _normalize_axis_name_mapping(
+        self,
+        axis_mapping: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        def resolve_base_axis(axis_name):
+            resolver = getattr(self, "_get_axis_base_name", None)
+            if callable(resolver):
+                return resolver(axis_name)
+            if not isinstance(axis_name, str) or not axis_name:
+                return None
+            candidate = axis_name
+            while candidate.startswith("r") and len(candidate) > 1:
+                candidate = candidate[1:]
+            return candidate
+
+        normalized = {}
+        for axis, value in dict(axis_mapping or {}).items():
+            base_axis = resolve_base_axis(axis)
+            if not isinstance(base_axis, str) or not base_axis:
+                continue
+            normalized.setdefault(base_axis, value)
+        return normalized
+
+    def _normalize_axis_name_list(
+        self,
+        axis_names: Optional[List[str]],
+    ) -> List[str]:
+        def resolve_base_axis(axis_name):
+            resolver = getattr(self, "_get_axis_base_name", None)
+            if callable(resolver):
+                return resolver(axis_name)
+            if not isinstance(axis_name, str) or not axis_name:
+                return None
+            candidate = axis_name
+            while candidate.startswith("r") and len(candidate) > 1:
+                candidate = candidate[1:]
+            return candidate
+
+        normalized = []
+        for axis in list(axis_names or []):
+            base_axis = resolve_base_axis(axis)
+            if not isinstance(base_axis, str) or not base_axis:
+                continue
+            if base_axis not in normalized:
+                normalized.append(base_axis)
+        return normalized
+
     @staticmethod
     def _get_axis_base_name(axis: Optional[str]) -> Optional[str]:
         if not isinstance(axis, str) or not axis:
@@ -1135,6 +1247,42 @@ class AutoTilingTuner(Autotuner):
         return axis[1:] if axis.startswith("r") else axis
 
     def _apply_vv_axis_semantic_result(self) -> bool:
+        def resolve_base_axis(axis_name):
+            resolver = getattr(self, "_get_axis_base_name", None)
+            if callable(resolver):
+                return resolver(axis_name)
+            if not isinstance(axis_name, str) or not axis_name:
+                return None
+            candidate = axis_name
+            while candidate.startswith("r") and len(candidate) > 1:
+                candidate = candidate[1:]
+            return candidate
+
+        def normalize_axis_name_mapping(axis_mapping):
+            normalizer = getattr(self, "_normalize_axis_name_mapping", None)
+            if callable(normalizer):
+                return normalizer(axis_mapping)
+            normalized = {}
+            for axis, value in dict(axis_mapping or {}).items():
+                base_axis = resolve_base_axis(axis)
+                if not isinstance(base_axis, str) or not base_axis:
+                    continue
+                normalized.setdefault(base_axis, value)
+            return normalized
+
+        def normalize_axis_name_list(axis_names):
+            normalizer = getattr(self, "_normalize_axis_name_list", None)
+            if callable(normalizer):
+                return normalizer(axis_names)
+            normalized = []
+            for axis in list(axis_names or []):
+                base_axis = resolve_base_axis(axis)
+                if not isinstance(base_axis, str) or not base_axis:
+                    continue
+                if base_axis not in normalized:
+                    normalized.append(base_axis)
+            return normalized
+
         if self.vv_adapter_result_v2 is None:
             return False
         adapter_status = getattr(self.vv_adapter_result_v2, "status", "ok")
@@ -1154,31 +1302,31 @@ class AutoTilingTuner(Autotuner):
         if adapter_reduction_axes or self.reduction_axes:
             self.reduction_axes = []
             for reduction_axis in adapter_reduction_axes:
-                base_axis = self._get_axis_base_name(reduction_axis)
+                base_axis = resolve_base_axis(reduction_axis)
                 self._promote_axis_arg_name_to_reduction(base_axis)
             self.reduction_axes = list(adapter_reduction_axes)
             applied = True
 
-        adapter_low_dim_axes = raw_adapter_low_dim_axes
+        adapter_low_dim_axes = normalize_axis_name_list(raw_adapter_low_dim_axes)
         if adapter_low_dim_axes or self.low_dim_axes:
             self.low_dim_axes = list(adapter_low_dim_axes)
             applied = True
 
-        adapter_split_params = dict(
+        adapter_split_params = normalize_axis_name_mapping(
             getattr(self.vv_adapter_result_v2, "split_params", {}) or {}
         )
         if adapter_split_params or self.split_params:
             self.split_params = dict(adapter_split_params)
             applied = True
 
-        adapter_tiling_params = dict(
+        adapter_tiling_params = normalize_axis_name_mapping(
             getattr(self.vv_adapter_result_v2, "tiling_params", {}) or {}
         )
         if adapter_tiling_params or self.tiling_params:
             self.tiling_params = dict(adapter_tiling_params)
             applied = True
 
-        adapter_axis_pid_dims = dict(
+        adapter_axis_pid_dims = normalize_axis_name_mapping(
             getattr(self.vv_adapter_result_v2, "axis_pid_dims", {}) or {}
         )
         if adapter_axis_pid_dims or self.axis_pid_dims:
@@ -2167,10 +2315,20 @@ class AutoTilingTuner(Autotuner):
         if key not in self.cache:
             if self.auto_gen_config:
                 self.cv_parse_result = self._autoparse_axis_params(all_args)
+                reduction_aliases = {
+                    axis for axis, arg_name in self.axis_arg_names.items()
+                    if isinstance(axis, str)
+                    and axis.startswith("r")
+                    and self.axis_arg_names.get(axis[1:], None) == arg_name
+                }
                 _kv_dict = {
                     axis: _args[arg_name]
                     for axis, arg_name in self.axis_arg_names.items()
                     if arg_name in _args
+                    and axis not in {
+                        reduction_axis[1:]
+                        for reduction_axis in reduction_aliases
+                    }
                 }
                 self._gen_tile_configs(_kv_dict, dtype, all_args)
                 self.gen_configs = _expand_configs_with_hints(
@@ -2604,7 +2762,10 @@ class AutoTilingTuner(Autotuner):
         Extracts the tiling axis parameters from triton kernel code.
         """
         func_ast = self.fn.parse()
-        parser = TilingAxesParser(func_ast, self._get_parser_axis_arg_names(), candidates_params)
+        parser_axis_arg_names = self._normalize_axis_name_mapping(
+            self._get_parser_axis_arg_names()
+        )
+        parser = TilingAxesParser(func_ast, parser_axis_arg_names, candidates_params)
         tiling_axes = parser.parse()
         self.tiling_params = dict(tiling_axes)
         self._refresh_vector_axes()
@@ -2641,7 +2802,10 @@ class AutoTilingTuner(Autotuner):
         Extracts the low dimension axis from triton kernel code.
         """
         func_ast = self.fn.parse()
-        parser = LowDimsAxesParser(func_ast, self._get_parser_axis_arg_names())
+        parser_axis_arg_names = self._normalize_axis_name_mapping(
+            self._get_parser_axis_arg_names()
+        )
+        parser = LowDimsAxesParser(func_ast, parser_axis_arg_names)
         low_dim_axes = parser.parse()
         if len(low_dim_axes) < 1:
             if self.print_autotuning:

--- a/third_party/ascend/backend/runtime/dsl_analysis/vv_param_parser_v2.py
+++ b/third_party/ascend/backend/runtime/dsl_analysis/vv_param_parser_v2.py
@@ -1655,14 +1655,12 @@ def _collect_reduction_axis_indices(func_node: ast.AST, axis_count: int) -> List
     return result
 
 
-def _axis_sort_key(axis_name: str) -> Tuple[int, int, str]:
-    is_reduction = axis_name.startswith("r")
-    base = axis_name[1:] if is_reduction else axis_name
+def _axis_sort_key(axis_name: str) -> Tuple[int, str]:
     try:
-        axis_index = _VALID_AXIS_NAMES.index(base)
+        axis_index = _VALID_AXIS_NAMES.index(axis_name)
     except ValueError:
         axis_index = len(_VALID_AXIS_NAMES)
-    return (axis_index, 1 if is_reduction else 0, axis_name)
+    return (axis_index, axis_name)
 
 
 def _choose_best_site_evidence(

--- a/third_party/ascend/backend/runtime/dsl_analysis/vv_param_parser_v2.py
+++ b/third_party/ascend/backend/runtime/dsl_analysis/vv_param_parser_v2.py
@@ -2050,7 +2050,7 @@ def parse_vv_axis_semantic_v2(
         evidence = evidence_by_index[axis_index]
         base_axis_name = axis_name_by_index[axis_index]
         is_reduction = base_axis_name in reduction_base_axes
-        axis_name = "r{}".format(base_axis_name) if is_reduction else base_axis_name
+        axis_name = base_axis_name
 
         split, split_diag = _select_best_split(evidence.split_candidates)
         tiling, tiling_diag = _select_best_tiling(evidence.tiling_candidates, split.param)

--- a/third_party/ascend/backend/runtime/tile_generator.py
+++ b/third_party/ascend/backend/runtime/tile_generator.py
@@ -35,6 +35,7 @@ from triton.runtime.autotuner import Config
 
 from .utils import (
     get_byte_per_numel,
+    is_valid_axis_name,
     next_power_of_2,
     num_vector_core,
     ub_size_in_kbytes,
@@ -48,17 +49,13 @@ class AxisInfo:
     index: int
     length: int
 
-    prefix: str = ""
     split_name: str = ""
     tiling_name: str = ""
     is_split_axis: bool = False
     is_tunable_split_axis: bool = False
     is_tiling_axis: bool = False
+    is_reduction: bool = False
     fixed_split_size: int = 0
-
-    @property
-    def is_reduction(self):
-        return self.prefix == "r"
 
 
 class KernelMeta:
@@ -69,6 +66,7 @@ class KernelMeta:
         fixed_split_params: Dict[str, int],
         tiling_params: Dict[str, str],
         low_dims: List[str],
+        reduction_axes: List[str],
         dtype: torch.dtype,
         persistent_reduction: bool,
         dual_reduction: bool,
@@ -89,24 +87,24 @@ class KernelMeta:
         :param low_dims: a list of axis name in which the corresponding axis is low dim aixs.
             The axis name must be in key's axis names. Do not add prefix 'r' before the axis name.
         :type low_dims: List[str]
+        :param reduction_axes: a list of base axis names that are reduction axes.
+        :type reduction_axes: List[str]
         :param dual_reduction: performing reduction on more than one axis.
         :param persistent_reduction: there is no splitting in reduction axis.
         """
         self._validate_axis(
-            axis_sizes, split_params, fixed_split_params, tiling_params, low_dims
+            axis_sizes, split_params, fixed_split_params, tiling_params, low_dims, reduction_axes
         )
 
+        reduction_axis_names = set(reduction_axes or [])
         axis_dict = {}
         idx = 0
         for name, length in axis_sizes.items():
-            prefix = ""
-            if name.startswith("r"):
-                prefix = "r"
-
             is_tunable_split_axis = name in split_params
             fixed_split_size = fixed_split_params.get(name, 0)
             is_split_axis = is_tunable_split_axis or fixed_split_size > 0
             is_tiling_axis = name in tiling_params
+            is_reduction = name in reduction_axis_names
             split_name = "" if not is_tunable_split_axis else split_params[name]
             tiling_name = "" if name not in tiling_params else tiling_params[name]
 
@@ -114,12 +112,12 @@ class KernelMeta:
                 name=name,
                 index=idx,
                 length=length,
-                prefix=prefix,
                 split_name=split_name,
                 tiling_name=tiling_name,
                 is_split_axis=is_split_axis,
                 is_tunable_split_axis=is_tunable_split_axis,
                 is_tiling_axis=is_tiling_axis,
+                is_reduction=is_reduction,
                 fixed_split_size=fixed_split_size,
             )
             idx += 1
@@ -145,14 +143,17 @@ class KernelMeta:
         fixed_split_params: Dict[str, int],
         tiling_params: Dict[str, str],
         low_dims: List[str],
+        reduction_axes: List[str],
     ) -> None:
         for axis_name in axis_sizes.keys():
-            if axis_name.startswith("r") and len(axis_name) == 1:
-                raise ValueError("The name of a reduction axis is empty!")
+            if not is_valid_axis_name(axis_name):
+                raise ValueError(
+                    f"Invalid axis name '{axis_name}'. Axis names must be base axes."
+                )
 
         def check_keys(params: List[str], context="parameter"):
             for k in params:
-                if k not in axis_sizes and ("r" + k) not in axis_sizes:
+                if k not in axis_sizes:
                     raise KeyError(
                         f"{context} '{k}' not found in known axes: {axis_sizes.keys()}"
                     )
@@ -161,6 +162,13 @@ class KernelMeta:
         check_keys(fixed_split_params.keys(), "fixed split axis")
         check_keys(tiling_params.keys(), "tiling axis")
         check_keys(low_dims, "low dim axis")
+        for axis_name in list(reduction_axes or []):
+            if isinstance(axis_name, str) and axis_name.startswith("r"):
+                raise ValueError(
+                    f"r-prefixed reduction axis '{axis_name}' is not supported; "
+                    "use the base axis name and pass it through reduction_axes."
+                )
+        check_keys(reduction_axes or [], "reduction axis")
 
 
 @dataclass

--- a/third_party/ascend/backend/runtime/utils.py
+++ b/third_party/ascend/backend/runtime/utils.py
@@ -113,8 +113,6 @@ def get_byte_per_numel(dtype: torch.dtype) -> int:
 
 
 def is_valid_axis_name(name: str) -> bool:
-    if name.startswith("r"):
-        return name[1:] in valid_axis_names
     return name in valid_axis_names
 
 

--- a/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
+++ b/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
@@ -24,7 +24,7 @@ import os
 from collections.abc import Sequence
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import pytest
 import torch
@@ -63,6 +63,7 @@ def _load_autotuner_methods(*method_names):
     extracted_module = ast.Module(body=selected, type_ignores=[])
     ast.fix_missing_locations(extracted_module)
     namespace = {
+        "Any": Any,
         "Dict": Dict,
         "List": List,
         "Optional": Optional,
@@ -95,9 +96,11 @@ def _init_axis_state_for_test(
         "_parse_hints_axes",
         "_get_runtime_arg_names_for_hints_axes",
         "_infer_hints_axes_from_key",
+        "_normalize_axis_name_mapping",
         "_rebuild_vector_axes",
         "_get_parser_axis_arg_names",
         "_is_direct_runtime_length_arg_name",
+        "_sync_reduction_axis_arg_aliases",
         "_init_axis_params",
     )
     tuner = SimpleNamespace()
@@ -117,6 +120,14 @@ def _init_axis_state_for_test(
     rebuild_vector_axes = _normalize_loaded_method(namespace.get("_rebuild_vector_axes"))
     if rebuild_vector_axes is not None:
         tuner._rebuild_vector_axes = rebuild_vector_axes.__get__(tuner, SimpleNamespace)
+    normalize_axis_name_mapping = _normalize_loaded_method(
+        namespace.get("_normalize_axis_name_mapping")
+    )
+    if normalize_axis_name_mapping is not None:
+        tuner._normalize_axis_name_mapping = normalize_axis_name_mapping.__get__(
+            tuner,
+            SimpleNamespace,
+        )
     infer_hints_axes_from_key = _normalize_loaded_method(namespace.get("_infer_hints_axes_from_key"))
     if infer_hints_axes_from_key is not None:
         tuner._infer_hints_axes_from_key = infer_hints_axes_from_key.__get__(tuner, SimpleNamespace)
@@ -128,6 +139,14 @@ def _init_axis_state_for_test(
     )
     if is_direct_runtime_length_arg_name is not None:
         tuner._is_direct_runtime_length_arg_name = is_direct_runtime_length_arg_name
+    sync_reduction_axis_arg_aliases = _normalize_loaded_method(
+        namespace.get("_sync_reduction_axis_arg_aliases")
+    )
+    if sync_reduction_axis_arg_aliases is not None:
+        tuner._sync_reduction_axis_arg_aliases = sync_reduction_axis_arg_aliases.__get__(
+            tuner,
+            SimpleNamespace,
+        )
     tuner.enable_vv_parser_v2 = enable_vv_parser_v2
     tuner.vv_parser_v2_mode = vv_parser_v2_mode
     init_axis_params = _normalize_loaded_method(namespace["_init_axis_params"])
@@ -523,11 +542,13 @@ def test_generate_key_and_configs_uses_axis_arg_names_for_kv_dict():
     namespace = _load_autotuner_methods(
         "_parse_hints_axes",
         "_get_runtime_arg_names_for_hints_axes",
+        "_normalize_axis_name_mapping",
         "_rebuild_vector_axes",
         "_get_axis_base_name",
         "_get_parser_axis_arg_names",
         "_is_direct_runtime_length_arg_name",
         "_promote_axis_arg_name_to_reduction",
+        "_sync_reduction_axis_arg_aliases",
         "_init_axis_params",
         "generate_key_and_configs",
     )
@@ -572,12 +593,18 @@ def test_generate_key_and_configs_uses_axis_arg_names_for_kv_dict():
     tuner._get_axis_base_name = _normalize_loaded_method(
         namespace["_get_axis_base_name"]
     )
+    tuner._normalize_axis_name_mapping = _normalize_loaded_method(
+        namespace["_normalize_axis_name_mapping"]
+    ).__get__(tuner, SimpleNamespace)
     tuner._get_parser_axis_arg_names = _normalize_loaded_method(
         namespace["_get_parser_axis_arg_names"]
     ).__get__(tuner, SimpleNamespace)
     tuner._is_direct_runtime_length_arg_name = _normalize_loaded_method(
         namespace["_is_direct_runtime_length_arg_name"]
     )
+    tuner._sync_reduction_axis_arg_aliases = _normalize_loaded_method(
+        namespace["_sync_reduction_axis_arg_aliases"]
+    ).__get__(tuner, SimpleNamespace)
     tuner._promote_axis_arg_name_to_reduction = _normalize_loaded_method(
         namespace["_promote_axis_arg_name_to_reduction"]
     ).__get__(tuner, SimpleNamespace)
@@ -606,11 +633,13 @@ def test_generate_key_and_configs_preserves_promoted_reduction_axis_identity():
     namespace = _load_autotuner_methods(
         "_parse_hints_axes",
         "_get_runtime_arg_names_for_hints_axes",
+        "_normalize_axis_name_mapping",
         "_rebuild_vector_axes",
         "_get_axis_base_name",
         "_get_parser_axis_arg_names",
         "_is_direct_runtime_length_arg_name",
         "_promote_axis_arg_name_to_reduction",
+        "_sync_reduction_axis_arg_aliases",
         "_init_axis_params",
         "generate_key_and_configs",
     )
@@ -649,12 +678,18 @@ def test_generate_key_and_configs_preserves_promoted_reduction_axis_identity():
     tuner._get_axis_base_name = _normalize_loaded_method(
         namespace["_get_axis_base_name"]
     )
+    tuner._normalize_axis_name_mapping = _normalize_loaded_method(
+        namespace["_normalize_axis_name_mapping"]
+    ).__get__(tuner, SimpleNamespace)
     tuner._get_parser_axis_arg_names = _normalize_loaded_method(
         namespace["_get_parser_axis_arg_names"]
     ).__get__(tuner, SimpleNamespace)
     tuner._is_direct_runtime_length_arg_name = _normalize_loaded_method(
         namespace["_is_direct_runtime_length_arg_name"]
     )
+    tuner._sync_reduction_axis_arg_aliases = _normalize_loaded_method(
+        namespace["_sync_reduction_axis_arg_aliases"]
+    ).__get__(tuner, SimpleNamespace)
     tuner._promote_axis_arg_name_to_reduction = _normalize_loaded_method(
         namespace["_promote_axis_arg_name_to_reduction"]
     ).__get__(tuner, SimpleNamespace)
@@ -678,6 +713,159 @@ def test_generate_key_and_configs_preserves_promoted_reduction_axis_identity():
 
     assert tuner.keys == ["n_elements"]
     assert captured["kv_dict"] == {"x": 23}
+
+
+def test_refresh_vector_axes_clears_stale_reduction_axis_aliases_after_reduction_axes_emptied():
+    namespace = _load_autotuner_methods(
+        "_parse_hints_axes",
+        "_get_runtime_arg_names_for_hints_axes",
+        "_normalize_axis_name_mapping",
+        "_rebuild_vector_axes",
+        "_get_axis_base_name",
+        "_get_parser_axis_arg_names",
+        "_is_direct_runtime_length_arg_name",
+        "_promote_axis_arg_name_to_reduction",
+        "_sync_reduction_axis_arg_aliases",
+        "_refresh_vector_axes",
+        "_init_axis_params",
+        "generate_key_and_configs",
+    )
+    captured = {}
+
+    class FakeArg:
+        dtype = "float16"
+
+    namespace["get_byte_per_numel"] = lambda dtype: 0 if dtype is None else 1
+    namespace["_expand_configs_with_hints"] = lambda fn, configs, config_hints: configs
+
+    tuner = SimpleNamespace(
+        arg_names=["x_ptr", "n_elements"],
+        fn=SimpleNamespace(),
+        _get_constexpr_candidates=lambda: [],
+        cache={},
+        auto_gen_config=True,
+        parser_mode="vector",
+        config_hints={},
+        gen_configs=[],
+        user_configs=[],
+        is_simt_mode=False,
+        user_specified_warps=None,
+        user_specified_multibuffer=None,
+        _autoparse_axis_params=lambda all_args: None,
+        _gen_tile_configs=lambda kv_dict, dtype, all_args: captured.update(kv_dict=dict(kv_dict))
+        or setattr(tuner, "gen_configs", [SimpleNamespace(kwargs={"BLOCK_SIZE": 128})]),
+    )
+    tuner._parse_hints_axes = _normalize_loaded_method(namespace["_parse_hints_axes"]).__get__(tuner, SimpleNamespace)
+    tuner._get_runtime_arg_names_for_hints_axes = _normalize_loaded_method(
+        namespace["_get_runtime_arg_names_for_hints_axes"]
+    ).__get__(tuner, SimpleNamespace)
+    tuner._rebuild_vector_axes = _normalize_loaded_method(
+        namespace["_rebuild_vector_axes"]
+    ).__get__(tuner, SimpleNamespace)
+    tuner._get_axis_base_name = _normalize_loaded_method(
+        namespace["_get_axis_base_name"]
+    )
+    tuner._normalize_axis_name_mapping = _normalize_loaded_method(
+        namespace["_normalize_axis_name_mapping"]
+    ).__get__(tuner, SimpleNamespace)
+    tuner._get_parser_axis_arg_names = _normalize_loaded_method(
+        namespace["_get_parser_axis_arg_names"]
+    ).__get__(tuner, SimpleNamespace)
+    tuner._is_direct_runtime_length_arg_name = _normalize_loaded_method(
+        namespace["_is_direct_runtime_length_arg_name"]
+    )
+    tuner._promote_axis_arg_name_to_reduction = _normalize_loaded_method(
+        namespace["_promote_axis_arg_name_to_reduction"]
+    ).__get__(tuner, SimpleNamespace)
+    tuner._sync_reduction_axis_arg_aliases = _normalize_loaded_method(
+        namespace["_sync_reduction_axis_arg_aliases"]
+    ).__get__(tuner, SimpleNamespace)
+    tuner._refresh_vector_axes = _normalize_loaded_method(
+        namespace["_refresh_vector_axes"]
+    ).__get__(tuner, SimpleNamespace)
+
+    _normalize_loaded_method(namespace["_init_axis_params"])(
+        tuner,
+        ["n_elements"],
+        None,
+        None,
+        None,
+        None,
+        {"x": "n_elements"},
+    )
+
+    tuner.reduction_axis_arg_aliases = {"rx": "n_elements"}
+    tuner.reduction_axes = []
+    tuner._refresh_vector_axes()
+
+    _normalize_loaded_method(namespace["generate_key_and_configs"])(
+        tuner,
+        FakeArg(),
+        29,
+    )
+
+    assert tuner.reduction_axis_arg_aliases == {}
+    assert tuner.axis_arg_names == {"x": "n_elements"}
+    assert captured["kv_dict"] == {"x": 29}
+
+
+def test_legacy_low_dim_and_tiling_parsers_consume_base_axis_names_after_reduction_promotion():
+    namespace = _load_autotuner_methods(
+        "_normalize_axis_name_mapping",
+        "_autoparse_tiling_params",
+        "_autoparse_low_dim_axes",
+    )
+    parser_inputs = {}
+
+    class StubTilingAxesParser:
+        def __init__(self, func_ast, axis_arg_names, candidates_params):
+            parser_inputs["tiling"] = dict(axis_arg_names)
+
+        def parse(self):
+            if "ry" in parser_inputs["tiling"]:
+                return {"x": "X0BLOCK_SUB", "ry": "R1BLOCK_SUB"}
+            return {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"}
+
+    class StubLowDimsAxesParser:
+        def __init__(self, func_ast, axis_arg_names):
+            parser_inputs["low_dim"] = dict(axis_arg_names)
+
+        def parse(self):
+            if "ry" in parser_inputs["low_dim"]:
+                return ["ry"]
+            return ["y"]
+
+    namespace["TilingAxesParser"] = StubTilingAxesParser
+    namespace["LowDimsAxesParser"] = StubLowDimsAxesParser
+
+    refresh_calls = []
+    tuner = SimpleNamespace(
+        fn=SimpleNamespace(parse=lambda: "fake-func-ast"),
+        print_autotuning=False,
+        tiling_params={},
+        low_dim_axes=[],
+        _get_parser_axis_arg_names=lambda: {"x": "x0_numel", "ry": "r1_numel"},
+        _refresh_vector_axes=lambda: refresh_calls.append(True),
+    )
+    tuner._normalize_axis_name_mapping = _normalize_loaded_method(
+        namespace["_normalize_axis_name_mapping"]
+    ).__get__(tuner, SimpleNamespace)
+
+    tiling_params = _normalize_loaded_method(namespace["_autoparse_tiling_params"])(
+        tuner,
+        ["X0BLOCK_SUB", "R1BLOCK_SUB"],
+    )
+    low_dim_axes = _normalize_loaded_method(namespace["_autoparse_low_dim_axes"])(
+        tuner
+    )
+
+    assert parser_inputs["tiling"] == {"x": "x0_numel", "y": "r1_numel"}
+    assert parser_inputs["low_dim"] == {"x": "x0_numel", "y": "r1_numel"}
+    assert tiling_params == {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"}
+    assert tuner.tiling_params == {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"}
+    assert low_dim_axes == ["y"]
+    assert tuner.low_dim_axes == ["y"]
+    assert refresh_calls == [True, True]
 
 
 def test_parse_vv_axis_info_v2_collects_fixed_tiling_expr_for_provided_constexpr():

--- a/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
+++ b/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
@@ -32,10 +32,12 @@ import torch_npu
 import triton
 import triton.backends.ascend.runtime
 import triton.backends.ascend.runtime.autotuner as ascend_autotuner
+from triton.backends.ascend.runtime.tile_generator import KernelMeta
+from triton.backends.ascend.runtime.utils import is_valid_axis_name
 import triton.language as tl
 
 
-VALID_AXIS_NAMES = ["x", "y", "z", "w", "v", "t", "rx", "ry", "rz", "rw", "rv", "rt"]
+VALID_AXIS_NAMES = ["x", "y", "z", "w", "v", "t"]
 AUTOTUNER_PATH = Path(__file__).resolve().parents[2] / "backend" / "runtime" / "autotuner.py"
 VECTOR_AXES_PATH = Path(__file__).resolve().parents[2] / "backend" / "runtime" / "vector_axes.py"
 
@@ -100,7 +102,6 @@ def _init_axis_state_for_test(
         "_rebuild_vector_axes",
         "_get_parser_axis_arg_names",
         "_is_direct_runtime_length_arg_name",
-        "_sync_reduction_axis_arg_aliases",
         "_init_axis_params",
     )
     tuner = SimpleNamespace()
@@ -139,14 +140,6 @@ def _init_axis_state_for_test(
     )
     if is_direct_runtime_length_arg_name is not None:
         tuner._is_direct_runtime_length_arg_name = is_direct_runtime_length_arg_name
-    sync_reduction_axis_arg_aliases = _normalize_loaded_method(
-        namespace.get("_sync_reduction_axis_arg_aliases")
-    )
-    if sync_reduction_axis_arg_aliases is not None:
-        tuner._sync_reduction_axis_arg_aliases = sync_reduction_axis_arg_aliases.__get__(
-            tuner,
-            SimpleNamespace,
-        )
     tuner.enable_vv_parser_v2 = enable_vv_parser_v2
     tuner.vv_parser_v2_mode = vv_parser_v2_mode
     init_axis_params = _normalize_loaded_method(namespace["_init_axis_params"])
@@ -435,9 +428,52 @@ def test_resolve_axis_length_arg_name_uses_base_vv_axis_expr_for_reduction_axis(
         namespace["_get_parser_axis_arg_names"]
     ).__get__(tuner, SimpleNamespace)
 
-    result = _normalize_loaded_method(namespace["_resolve_axis_length_arg_name"])(tuner, "rx")
+    result = _normalize_loaded_method(namespace["_resolve_axis_length_arg_name"])(tuner, "x")
 
     assert result == "n_elements"
+
+
+def test_is_valid_axis_name_rejects_reduction_prefix():
+    assert is_valid_axis_name("x") is True
+    assert is_valid_axis_name("rx") is False
+
+
+def test_kernel_meta_marks_reduction_axes_from_explicit_list():
+    kernel_meta = KernelMeta(
+        axis_sizes={"x": 128, "y": 64},
+        split_params={"x": "XBLOCK"},
+        fixed_split_params={},
+        tiling_params={"y": "YBLOCK_SUB"},
+        low_dims=["y"],
+        reduction_axes=["y"],
+        dtype=torch.float16,
+        persistent_reduction=True,
+        dual_reduction=False,
+        num_buffers=1,
+        is_simt_mode=False,
+    )
+
+    axis_by_name = {axis.name: axis for axis in kernel_meta.axis_info}
+    assert axis_by_name["x"].is_reduction is False
+    assert axis_by_name["y"].is_reduction is True
+    assert [axis.name for axis in kernel_meta.low_dims_axis] == ["y"]
+
+
+def test_kernel_meta_rejects_prefixed_reduction_axes():
+    with pytest.raises(ValueError, match="reduction axis"):
+        KernelMeta(
+            axis_sizes={"x": 128, "y": 64},
+            split_params={"x": "XBLOCK"},
+            fixed_split_params={},
+            tiling_params={"y": "YBLOCK_SUB"},
+            low_dims=["y"],
+            reduction_axes=["ry"],
+            dtype=torch.float16,
+            persistent_reduction=True,
+            dual_reduction=False,
+            num_buffers=1,
+            is_simt_mode=False,
+        )
 
 
 def test_apply_vv_axis_semantic_result_promotes_internal_axis_map_only():
@@ -504,7 +540,7 @@ def test_apply_vv_axis_semantic_result_promotes_internal_axis_map_only():
     assert tuner.reduction_axes == ["x"]
 
 
-def test_promote_reduction_axis_canonicalizes_existing_prefixed_length_expr():
+def test_promote_reduction_axis_rejects_prefixed_axis_name():
     namespace = _load_autotuner_methods(
         "_get_axis_base_name",
         "_get_parser_axis_arg_names",
@@ -512,11 +548,10 @@ def test_promote_reduction_axis_canonicalizes_existing_prefixed_length_expr():
         "_promote_axis_arg_name_to_reduction",
     )
     vector_axes_module = _load_vector_axes_module()
-    vector_axes = vector_axes_module.VectorAxes()
-    vector_axes.apply_semantic_fields(axis_length_exprs={"ry": "r1_numel"})
+    vector_axes = vector_axes_module.VectorAxes.from_hints_axes({"y": "r1_numel"})
     tuner = SimpleNamespace(
         vector_axes=vector_axes,
-        axis_arg_names={"ry": "r1_numel"},
+        axis_arg_names={"y": "r1_numel"},
     )
     tuner._get_axis_base_name = _normalize_loaded_method(
         namespace["_get_axis_base_name"]
@@ -531,11 +566,8 @@ def test_promote_reduction_axis_canonicalizes_existing_prefixed_length_expr():
         namespace["_promote_axis_arg_name_to_reduction"]
     ).__get__(tuner, SimpleNamespace)
 
-    tuner._promote_axis_arg_name_to_reduction("ry")
-
-    assert tuner.vector_axes.axis_length_exprs == {"y": "r1_numel"}
-    assert tuner.vector_axes.reduction_axes == ["y"]
-    assert tuner.axis_arg_names == {"y": "r1_numel"}
+    with pytest.raises(ValueError, match="r-prefixed"):
+        tuner._promote_axis_arg_name_to_reduction("ry")
 
 
 def test_generate_key_and_configs_uses_axis_arg_names_for_kv_dict():
@@ -548,7 +580,6 @@ def test_generate_key_and_configs_uses_axis_arg_names_for_kv_dict():
         "_get_parser_axis_arg_names",
         "_is_direct_runtime_length_arg_name",
         "_promote_axis_arg_name_to_reduction",
-        "_sync_reduction_axis_arg_aliases",
         "_init_axis_params",
         "generate_key_and_configs",
     )
@@ -602,9 +633,6 @@ def test_generate_key_and_configs_uses_axis_arg_names_for_kv_dict():
     tuner._is_direct_runtime_length_arg_name = _normalize_loaded_method(
         namespace["_is_direct_runtime_length_arg_name"]
     )
-    tuner._sync_reduction_axis_arg_aliases = _normalize_loaded_method(
-        namespace["_sync_reduction_axis_arg_aliases"]
-    ).__get__(tuner, SimpleNamespace)
     tuner._promote_axis_arg_name_to_reduction = _normalize_loaded_method(
         namespace["_promote_axis_arg_name_to_reduction"]
     ).__get__(tuner, SimpleNamespace)
@@ -639,7 +667,6 @@ def test_generate_key_and_configs_preserves_promoted_reduction_axis_identity():
         "_get_parser_axis_arg_names",
         "_is_direct_runtime_length_arg_name",
         "_promote_axis_arg_name_to_reduction",
-        "_sync_reduction_axis_arg_aliases",
         "_init_axis_params",
         "generate_key_and_configs",
     )
@@ -687,9 +714,6 @@ def test_generate_key_and_configs_preserves_promoted_reduction_axis_identity():
     tuner._is_direct_runtime_length_arg_name = _normalize_loaded_method(
         namespace["_is_direct_runtime_length_arg_name"]
     )
-    tuner._sync_reduction_axis_arg_aliases = _normalize_loaded_method(
-        namespace["_sync_reduction_axis_arg_aliases"]
-    ).__get__(tuner, SimpleNamespace)
     tuner._promote_axis_arg_name_to_reduction = _normalize_loaded_method(
         namespace["_promote_axis_arg_name_to_reduction"]
     ).__get__(tuner, SimpleNamespace)
@@ -715,7 +739,7 @@ def test_generate_key_and_configs_preserves_promoted_reduction_axis_identity():
     assert captured["kv_dict"] == {"x": 23}
 
 
-def test_refresh_vector_axes_clears_stale_reduction_axis_aliases_after_reduction_axes_emptied():
+def test_refresh_vector_axes_keeps_base_axis_arg_names_without_reduction_aliases():
     namespace = _load_autotuner_methods(
         "_parse_hints_axes",
         "_get_runtime_arg_names_for_hints_axes",
@@ -725,7 +749,6 @@ def test_refresh_vector_axes_clears_stale_reduction_axis_aliases_after_reduction
         "_get_parser_axis_arg_names",
         "_is_direct_runtime_length_arg_name",
         "_promote_axis_arg_name_to_reduction",
-        "_sync_reduction_axis_arg_aliases",
         "_refresh_vector_axes",
         "_init_axis_params",
         "generate_key_and_configs",
@@ -777,9 +800,6 @@ def test_refresh_vector_axes_clears_stale_reduction_axis_aliases_after_reduction
     tuner._promote_axis_arg_name_to_reduction = _normalize_loaded_method(
         namespace["_promote_axis_arg_name_to_reduction"]
     ).__get__(tuner, SimpleNamespace)
-    tuner._sync_reduction_axis_arg_aliases = _normalize_loaded_method(
-        namespace["_sync_reduction_axis_arg_aliases"]
-    ).__get__(tuner, SimpleNamespace)
     tuner._refresh_vector_axes = _normalize_loaded_method(
         namespace["_refresh_vector_axes"]
     ).__get__(tuner, SimpleNamespace)
@@ -794,7 +814,6 @@ def test_refresh_vector_axes_clears_stale_reduction_axis_aliases_after_reduction
         {"x": "n_elements"},
     )
 
-    tuner.reduction_axis_arg_aliases = {"rx": "n_elements"}
     tuner.reduction_axes = []
     tuner._refresh_vector_axes()
 
@@ -804,13 +823,13 @@ def test_refresh_vector_axes_clears_stale_reduction_axis_aliases_after_reduction
         29,
     )
 
-    assert tuner.reduction_axis_arg_aliases == {}
     assert tuner.axis_arg_names == {"x": "n_elements"}
     assert captured["kv_dict"] == {"x": 29}
 
 
-def test_legacy_low_dim_and_tiling_parsers_consume_base_axis_names_after_reduction_promotion():
+def test_legacy_low_dim_and_tiling_parsers_consume_base_axis_names():
     namespace = _load_autotuner_methods(
+        "_get_axis_base_name",
         "_normalize_axis_name_mapping",
         "_autoparse_tiling_params",
         "_autoparse_low_dim_axes",
@@ -822,8 +841,6 @@ def test_legacy_low_dim_and_tiling_parsers_consume_base_axis_names_after_reducti
             parser_inputs["tiling"] = dict(axis_arg_names)
 
         def parse(self):
-            if "ry" in parser_inputs["tiling"]:
-                return {"x": "X0BLOCK_SUB", "ry": "R1BLOCK_SUB"}
             return {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"}
 
     class StubLowDimsAxesParser:
@@ -831,8 +848,6 @@ def test_legacy_low_dim_and_tiling_parsers_consume_base_axis_names_after_reducti
             parser_inputs["low_dim"] = dict(axis_arg_names)
 
         def parse(self):
-            if "ry" in parser_inputs["low_dim"]:
-                return ["ry"]
             return ["y"]
 
     namespace["TilingAxesParser"] = StubTilingAxesParser
@@ -844,8 +859,11 @@ def test_legacy_low_dim_and_tiling_parsers_consume_base_axis_names_after_reducti
         print_autotuning=False,
         tiling_params={},
         low_dim_axes=[],
-        _get_parser_axis_arg_names=lambda: {"x": "x0_numel", "ry": "r1_numel"},
+        _get_parser_axis_arg_names=lambda: {"x": "x0_numel", "y": "r1_numel"},
         _refresh_vector_axes=lambda: refresh_calls.append(True),
+    )
+    tuner._get_axis_base_name = _normalize_loaded_method(
+        namespace["_get_axis_base_name"]
     )
     tuner._normalize_axis_name_mapping = _normalize_loaded_method(
         namespace["_normalize_axis_name_mapping"]
@@ -1606,27 +1624,30 @@ def test_expand_simt_num_warps_configs_default_candidates():
 
 
 @pytest.mark.parametrize(
-    ("raw_axis", "expected"),
+    "axis",
     [
-        ("x", "x"),
-        ("rx", "x"),
-        ("rrx", "x"),
-        ("y", "y"),
-        ("ry", "y"),
-        ("rry", "y"),
-        ("rfoo", "rfoo"),
-        ("rrfoo", "rrfoo"),
+        "x",
+        "y",
+        "z",
     ],
 )
-def test_normalize_reduction_axis_name_canonicalizes_only_known_base_axes(raw_axis, expected):
+def test_normalize_reduction_axis_name_accepts_base_axes_only(axis):
     namespace = _load_autotuner_methods("_normalize_reduction_axis_name")
 
-    result = _normalize_loaded_method(namespace["_normalize_reduction_axis_name"])(raw_axis)
+    result = _normalize_loaded_method(namespace["_normalize_reduction_axis_name"])(axis)
 
-    assert result == expected
+    assert result == axis
 
 
-def test_autoparse_reduction_axes_normalizes_prefixed_parser_output_before_persisting():
+@pytest.mark.parametrize("axis", ["rx", "ry", "rry"])
+def test_normalize_reduction_axis_name_rejects_prefixed_axes(axis):
+    namespace = _load_autotuner_methods("_normalize_reduction_axis_name")
+
+    with pytest.raises(ValueError, match="r-prefixed"):
+        _normalize_loaded_method(namespace["_normalize_reduction_axis_name"])(axis)
+
+
+def test_autoparse_reduction_axes_rejects_prefixed_parser_output():
     namespace = _load_autotuner_methods(
         "_normalize_reduction_axis_name",
         "_normalize_reduction_axes",
@@ -1640,7 +1661,7 @@ def test_autoparse_reduction_axes_normalizes_prefixed_parser_output_before_persi
             self.axis_arg_names = axis_arg_names
 
         def parse(self):
-            return ["rx", "ry"]
+            return ["ry"]
 
     namespace["ReductionAxesParser"] = StubReductionAxesParser
 
@@ -1649,10 +1670,10 @@ def test_autoparse_reduction_axes_normalizes_prefixed_parser_output_before_persi
 
     tuner = SimpleNamespace(
         fn=SimpleNamespace(parse=lambda: "fake-func-ast"),
-        axis_arg_names={"rx": "seq_len", "ry": "dim"},
+        axis_arg_names={"x": "seq_len", "y": "dim"},
         reduction_axes=[],
         print_autotuning=False,
-        _get_parser_axis_arg_names=lambda: {"rx": "seq_len", "ry": "dim"},
+        _get_parser_axis_arg_names=lambda: {"x": "seq_len", "y": "dim"},
         _promote_axis_arg_name_to_reduction=lambda axis: promoted_axes.append(axis),
         _refresh_vector_axes=lambda: refresh_calls.append(True),
     )
@@ -1666,11 +1687,9 @@ def test_autoparse_reduction_axes_normalizes_prefixed_parser_output_before_persi
         namespace["_normalize_reduction_axes"]
     ).__get__(tuner, SimpleNamespace)
 
-    reduction_axes = _normalize_loaded_method(namespace["_autoparse_reduction_axes"])(
-        tuner
-    )
+    with pytest.raises(ValueError, match="r-prefixed"):
+        _normalize_loaded_method(namespace["_autoparse_reduction_axes"])(tuner)
 
-    assert promoted_axes == ["x", "y"]
-    assert reduction_axes == ["x", "y"]
-    assert tuner.reduction_axes == ["x", "y"]
-    assert refresh_calls == [True]
+    assert promoted_axes == []
+    assert tuner.reduction_axes == []
+    assert refresh_calls == []

--- a/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
+++ b/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
@@ -423,7 +423,10 @@ def test_resolve_axis_length_arg_name_uses_base_vv_axis_expr_for_reduction_axis(
 
 def test_apply_vv_axis_semantic_result_promotes_internal_axis_map_only():
     namespace = _load_autotuner_methods(
+        "_normalize_reduction_axis_name",
+        "_normalize_reduction_axes",
         "_normalize_vv_reduction_axes",
+        "_get_axis_base_name",
         "_get_parser_axis_arg_names",
         "_is_direct_runtime_length_arg_name",
         "_promote_axis_arg_name_to_reduction",
@@ -449,9 +452,18 @@ def test_apply_vv_axis_semantic_result_promotes_internal_axis_map_only():
         keys=["n_elements"],
         dual_reduction=False,
     )
+    tuner._normalize_reduction_axis_name = _normalize_loaded_method(
+        namespace["_normalize_reduction_axis_name"]
+    )
+    tuner._normalize_reduction_axes = _normalize_loaded_method(
+        namespace["_normalize_reduction_axes"]
+    ).__get__(tuner, SimpleNamespace)
     tuner._normalize_vv_reduction_axes = _normalize_loaded_method(
         namespace["_normalize_vv_reduction_axes"]
     ).__get__(tuner, SimpleNamespace)
+    tuner._get_axis_base_name = _normalize_loaded_method(
+        namespace["_get_axis_base_name"]
+    )
     tuner._get_parser_axis_arg_names = _normalize_loaded_method(
         namespace["_get_parser_axis_arg_names"]
     ).__get__(tuner, SimpleNamespace)
@@ -469,8 +481,42 @@ def test_apply_vv_axis_semantic_result_promotes_internal_axis_map_only():
 
     assert applied is True
     assert tuner.keys == ["n_elements"]
-    assert tuner.axis_arg_names == {"rx": "n_elements"}
-    assert tuner.reduction_axes == ["rx"]
+    assert tuner.axis_arg_names == {"x": "n_elements"}
+    assert tuner.reduction_axes == ["x"]
+
+
+def test_promote_reduction_axis_canonicalizes_existing_prefixed_length_expr():
+    namespace = _load_autotuner_methods(
+        "_get_axis_base_name",
+        "_get_parser_axis_arg_names",
+        "_is_direct_runtime_length_arg_name",
+        "_promote_axis_arg_name_to_reduction",
+    )
+    vector_axes_module = _load_vector_axes_module()
+    vector_axes = vector_axes_module.VectorAxes()
+    vector_axes.apply_semantic_fields(axis_length_exprs={"ry": "r1_numel"})
+    tuner = SimpleNamespace(
+        vector_axes=vector_axes,
+        axis_arg_names={"ry": "r1_numel"},
+    )
+    tuner._get_axis_base_name = _normalize_loaded_method(
+        namespace["_get_axis_base_name"]
+    )
+    tuner._get_parser_axis_arg_names = _normalize_loaded_method(
+        namespace["_get_parser_axis_arg_names"]
+    ).__get__(tuner, SimpleNamespace)
+    tuner._is_direct_runtime_length_arg_name = _normalize_loaded_method(
+        namespace["_is_direct_runtime_length_arg_name"]
+    )
+    tuner._promote_axis_arg_name_to_reduction = _normalize_loaded_method(
+        namespace["_promote_axis_arg_name_to_reduction"]
+    ).__get__(tuner, SimpleNamespace)
+
+    tuner._promote_axis_arg_name_to_reduction("ry")
+
+    assert tuner.vector_axes.axis_length_exprs == {"y": "r1_numel"}
+    assert tuner.vector_axes.reduction_axes == ["y"]
+    assert tuner.axis_arg_names == {"y": "r1_numel"}
 
 
 def test_generate_key_and_configs_uses_axis_arg_names_for_kv_dict():
@@ -478,6 +524,7 @@ def test_generate_key_and_configs_uses_axis_arg_names_for_kv_dict():
         "_parse_hints_axes",
         "_get_runtime_arg_names_for_hints_axes",
         "_rebuild_vector_axes",
+        "_get_axis_base_name",
         "_get_parser_axis_arg_names",
         "_is_direct_runtime_length_arg_name",
         "_promote_axis_arg_name_to_reduction",
@@ -522,6 +569,9 @@ def test_generate_key_and_configs_uses_axis_arg_names_for_kv_dict():
     tuner._rebuild_vector_axes = _normalize_loaded_method(
         namespace["_rebuild_vector_axes"]
     ).__get__(tuner, SimpleNamespace)
+    tuner._get_axis_base_name = _normalize_loaded_method(
+        namespace["_get_axis_base_name"]
+    )
     tuner._get_parser_axis_arg_names = _normalize_loaded_method(
         namespace["_get_parser_axis_arg_names"]
     ).__get__(tuner, SimpleNamespace)
@@ -557,6 +607,7 @@ def test_generate_key_and_configs_preserves_promoted_reduction_axis_identity():
         "_parse_hints_axes",
         "_get_runtime_arg_names_for_hints_axes",
         "_rebuild_vector_axes",
+        "_get_axis_base_name",
         "_get_parser_axis_arg_names",
         "_is_direct_runtime_length_arg_name",
         "_promote_axis_arg_name_to_reduction",
@@ -595,6 +646,9 @@ def test_generate_key_and_configs_preserves_promoted_reduction_axis_identity():
     tuner._rebuild_vector_axes = _normalize_loaded_method(
         namespace["_rebuild_vector_axes"]
     ).__get__(tuner, SimpleNamespace)
+    tuner._get_axis_base_name = _normalize_loaded_method(
+        namespace["_get_axis_base_name"]
+    )
     tuner._get_parser_axis_arg_names = _normalize_loaded_method(
         namespace["_get_parser_axis_arg_names"]
     ).__get__(tuner, SimpleNamespace)
@@ -623,7 +677,7 @@ def test_generate_key_and_configs_preserves_promoted_reduction_axis_identity():
     )
 
     assert tuner.keys == ["n_elements"]
-    assert captured["kv_dict"] == {"rx": 23}
+    assert captured["kv_dict"] == {"x": 23}
 
 
 def test_parse_vv_axis_info_v2_collects_fixed_tiling_expr_for_provided_constexpr():
@@ -1361,3 +1415,74 @@ def test_expand_simt_num_warps_configs_default_candidates():
 
     assert len(expanded_configs) == 4
     assert [cfg.num_warps for cfg in expanded_configs] == [8, 16, 32, 64]
+
+
+@pytest.mark.parametrize(
+    ("raw_axis", "expected"),
+    [
+        ("x", "x"),
+        ("rx", "x"),
+        ("rrx", "x"),
+        ("y", "y"),
+        ("ry", "y"),
+        ("rry", "y"),
+        ("rfoo", "rfoo"),
+        ("rrfoo", "rrfoo"),
+    ],
+)
+def test_normalize_reduction_axis_name_canonicalizes_only_known_base_axes(raw_axis, expected):
+    namespace = _load_autotuner_methods("_normalize_reduction_axis_name")
+
+    result = _normalize_loaded_method(namespace["_normalize_reduction_axis_name"])(raw_axis)
+
+    assert result == expected
+
+
+def test_autoparse_reduction_axes_normalizes_prefixed_parser_output_before_persisting():
+    namespace = _load_autotuner_methods(
+        "_normalize_reduction_axis_name",
+        "_normalize_reduction_axes",
+        "_get_axis_base_name",
+        "_autoparse_reduction_axes",
+    )
+
+    class StubReductionAxesParser:
+        def __init__(self, func_ast, axis_arg_names):
+            self.func_ast = func_ast
+            self.axis_arg_names = axis_arg_names
+
+        def parse(self):
+            return ["rx", "ry"]
+
+    namespace["ReductionAxesParser"] = StubReductionAxesParser
+
+    promoted_axes = []
+    refresh_calls = []
+
+    tuner = SimpleNamespace(
+        fn=SimpleNamespace(parse=lambda: "fake-func-ast"),
+        axis_arg_names={"rx": "seq_len", "ry": "dim"},
+        reduction_axes=[],
+        print_autotuning=False,
+        _get_parser_axis_arg_names=lambda: {"rx": "seq_len", "ry": "dim"},
+        _promote_axis_arg_name_to_reduction=lambda axis: promoted_axes.append(axis),
+        _refresh_vector_axes=lambda: refresh_calls.append(True),
+    )
+    tuner._get_axis_base_name = _normalize_loaded_method(
+        namespace["_get_axis_base_name"]
+    )
+    tuner._normalize_reduction_axis_name = _normalize_loaded_method(
+        namespace["_normalize_reduction_axis_name"]
+    )
+    tuner._normalize_reduction_axes = _normalize_loaded_method(
+        namespace["_normalize_reduction_axes"]
+    ).__get__(tuner, SimpleNamespace)
+
+    reduction_axes = _normalize_loaded_method(namespace["_autoparse_reduction_axes"])(
+        tuner
+    )
+
+    assert promoted_axes == ["x", "y"]
+    assert reduction_axes == ["x", "y"]
+    assert tuner.reduction_axes == ["x", "y"]
+    assert refresh_calls == [True]

--- a/third_party/ascend/unittest/autotune_ut/test_low_dim_axes_parse.py
+++ b/third_party/ascend/unittest/autotune_ut/test_low_dim_axes_parse.py
@@ -27,9 +27,9 @@ import triton.language as tl
 
 
 def _mock_single_reduction_axis(self):
-    self.vector_axes.ensure_axis("rx").length_expr = "n_elements"
-    self.vector_axes.apply_semantic_fields(reduction_axes=["rx"])
-    return ["rx"]
+    self.vector_axes.ensure_axis("x").length_expr = "n_elements"
+    self.vector_axes.apply_semantic_fields(reduction_axes=["x"])
+    return ["x"]
 
 
 def _mock_apply_vv_with_low_dim_axes(orig_apply, low_dim_axes):
@@ -138,7 +138,7 @@ def test_low_dim_axis_parse_empty_no_persistent_reduction_index_error(mock_autot
         act_res = triton_low_dim_axis_parse_guard_case[(1,)]()
 
     assert act_res["low_dim_axes"] == ["x"]
-    assert act_res["reduction_axes"] == ["rx"]
+    assert act_res["reduction_axes"] == ["x"]
 
 
 def test_persistent_reduction_inner_axis_threshold(mock_autotuner):
@@ -166,7 +166,7 @@ def test_persistent_reduction_inner_axis_threshold(mock_autotuner):
     ), mock.patch.object(
         AutoTilingTuner, "_autoparse_reduction_axes", new=_mock_single_reduction_axis
     ), mock.patch.object(
-        AutoTilingTuner, "_autoparse_low_dim_axes", return_value=["rx"]
+        AutoTilingTuner, "_autoparse_low_dim_axes", return_value=["x"]
     ), mock.patch.object(
         AutoTilingTuner, "_autoparse_split_params", return_value={}
     ), mock.patch.object(

--- a/third_party/ascend/unittest/autotune_ut/test_reduction_axes_parse.py
+++ b/third_party/ascend/unittest/autotune_ut/test_reduction_axes_parse.py
@@ -33,6 +33,16 @@ def assert_outward_semantic_axes_state(act_res, ref_res):
     assert act_res["reduction_axes"] == ref_res["reduction_axes"]
 
 
+def assert_vv_parser_semantic_axes_state(act_res, ref_res):
+    vv_parse_result = act_res["vv_parse_result_v2"]
+    assert vv_parse_result is not None
+    assert vv_parse_result.axis_length_exprs == ref_res["keys"]
+    assert vv_parse_result.split_params == ref_res["split_params"]
+    assert vv_parse_result.tiling_params == ref_res["tiling_params"]
+    assert vv_parse_result.low_dim_axes == ref_res["low_dim_axes"]
+    assert vv_parse_result.reduction_axes == ref_res["reduction_axes"]
+
+
 def test_triton_max_last_dim_case1(mock_autotuner):
     import triton.backends.ascend.runtime
 
@@ -79,6 +89,7 @@ def test_triton_max_last_dim_case1(mock_autotuner):
     act_res = triton_max_last_dim1[grid]()
 
     assert_outward_semantic_axes_state(act_res, ref_res)
+    assert_vv_parser_semantic_axes_state(act_res, ref_res)
     check_axes_parse_res(act_res, ref_res)
 
 
@@ -128,6 +139,7 @@ def test_triton_max_last_dim_case2(mock_autotuner):
     act_res = triton_max_last_dim2[grid]()
 
     assert_outward_semantic_axes_state(act_res, ref_res)
+    assert_vv_parser_semantic_axes_state(act_res, ref_res)
     check_axes_parse_res(act_res, ref_res)
 
 
@@ -177,6 +189,7 @@ def test_triton_max_last_dim_case3(mock_autotuner):
     act_res = triton_max_last_dim3[grid]()
 
     assert_outward_semantic_axes_state(act_res, ref_res)
+    assert_vv_parser_semantic_axes_state(act_res, ref_res)
     check_axes_parse_res(act_res, ref_res)
 
 
@@ -226,4 +239,5 @@ def test_reduction_axes_parse_kernel_type_vector_auto_consistency(mock_autotuner
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_reduction_axes_parse_kernel_type_vector_auto_consistency[grid]()
     assert_outward_semantic_axes_state(act_res, ref_res)
+    assert_vv_parser_semantic_axes_state(act_res, ref_res)
     check_axes_parse_res(act_res, ref_res)

--- a/third_party/ascend/unittest/autotune_ut/test_reduction_axes_parse.py
+++ b/third_party/ascend/unittest/autotune_ut/test_reduction_axes_parse.py
@@ -25,6 +25,14 @@ import triton
 import triton.language as tl
 
 
+def assert_outward_semantic_axes_state(act_res, ref_res):
+    assert act_res["keys"] == ref_res["keys"]
+    assert act_res["split_params"] == ref_res["split_params"]
+    assert act_res["tiling_params"] == ref_res["tiling_params"]
+    assert act_res["low_dim_axes"] == ref_res["low_dim_axes"]
+    assert act_res["reduction_axes"] == ref_res["reduction_axes"]
+
+
 def test_triton_max_last_dim_case1(mock_autotuner):
     import triton.backends.ascend.runtime
 
@@ -70,6 +78,7 @@ def test_triton_max_last_dim_case1(mock_autotuner):
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_max_last_dim1[grid]()
 
+    assert_outward_semantic_axes_state(act_res, ref_res)
     check_axes_parse_res(act_res, ref_res)
 
 
@@ -118,6 +127,7 @@ def test_triton_max_last_dim_case2(mock_autotuner):
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_max_last_dim2[grid]()
 
+    assert_outward_semantic_axes_state(act_res, ref_res)
     check_axes_parse_res(act_res, ref_res)
 
 
@@ -166,6 +176,7 @@ def test_triton_max_last_dim_case3(mock_autotuner):
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_max_last_dim3[grid]()
 
+    assert_outward_semantic_axes_state(act_res, ref_res)
     check_axes_parse_res(act_res, ref_res)
 
 
@@ -214,4 +225,5 @@ def test_reduction_axes_parse_kernel_type_vector_auto_consistency(mock_autotuner
     }
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_reduction_axes_parse_kernel_type_vector_auto_consistency[grid]()
+    assert_outward_semantic_axes_state(act_res, ref_res)
     check_axes_parse_res(act_res, ref_res)

--- a/third_party/ascend/unittest/autotune_ut/test_reduction_axes_parse.py
+++ b/third_party/ascend/unittest/autotune_ut/test_reduction_axes_parse.py
@@ -61,11 +61,11 @@ def test_triton_max_last_dim_case1(mock_autotuner):
             tl.store(out_ptr0 + x0, block_res, x0_mask)
 
     ref_res = {
-        "keys": {"x": "x0_numel", "ry": "r1_numel"},
+        "keys": {"x": "x0_numel", "y": "r1_numel"},
         "split_params": {"x": "X0BLOCK"},
-        "tiling_params": {"x": "X0BLOCK_SUB", "ry": "R1BLOCK_SUB"},
-        "low_dim_axes": ["ry"],
-        "reduction_axes": ["ry"],
+        "tiling_params": {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"},
+        "low_dim_axes": ["y"],
+        "reduction_axes": ["y"],
     }
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_max_last_dim1[grid]()
@@ -109,11 +109,11 @@ def test_triton_max_last_dim_case2(mock_autotuner):
             tl.store(out_ptr0 + x0, block_res, x0_mask)
 
     ref_res = {
-        "keys": {"x": "x0_numel", "ry": "r1_numel"},
+        "keys": {"x": "x0_numel", "y": "r1_numel"},
         "split_params": {"x": "X0BLOCK"},
-        "tiling_params": {"x": "X0BLOCK_SUB", "ry": "R1BLOCK_SUB"},
-        "low_dim_axes": ["ry"],
-        "reduction_axes": ["ry"],
+        "tiling_params": {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"},
+        "low_dim_axes": ["y"],
+        "reduction_axes": ["y"],
     }
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_max_last_dim2[grid]()
@@ -157,11 +157,11 @@ def test_triton_max_last_dim_case3(mock_autotuner):
             tl.store(out_ptr0 + x0, block_res, x0_mask)
 
     ref_res = {
-        "keys": {"x": "x0_numel", "ry": "r1_numel"},
+        "keys": {"x": "x0_numel", "y": "r1_numel"},
         "split_params": {"x": "X0BLOCK"},
-        "tiling_params": {"x": "X0BLOCK_SUB", "ry": "R1BLOCK_SUB"},
-        "low_dim_axes": ["ry"],
-        "reduction_axes": ["ry"],
+        "tiling_params": {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"},
+        "low_dim_axes": ["y"],
+        "reduction_axes": ["y"],
     }
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_max_last_dim3[grid]()
@@ -206,11 +206,11 @@ def test_reduction_axes_parse_kernel_type_vector_auto_consistency(mock_autotuner
             tl.store(out_ptr0 + x0, block_res, x0_mask)
 
     ref_res = {
-        "keys": {"x": "x0_numel", "ry": "r1_numel"},
+        "keys": {"x": "x0_numel", "y": "r1_numel"},
         "split_params": {"x": "X0BLOCK"},
-        "tiling_params": {"x": "X0BLOCK_SUB", "ry": "R1BLOCK_SUB"},
-        "low_dim_axes": ["ry"],
-        "reduction_axes": ["ry"],
+        "tiling_params": {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"},
+        "low_dim_axes": ["y"],
+        "reduction_axes": ["y"],
     }
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_reduction_axes_parse_kernel_type_vector_auto_consistency[grid]()


### PR DESCRIPTION
Backport of #146 onto release/3.2.2-dev.

Original PR: https://github.com/triton-lang/triton-ascend/pull/146

Cherry-picked commits:
- cba43ec6 Fix duplicate reduction axis normalization
- 19793a30 fix(autotune): normalize reduction axis semantics
- da42fc8f fix(autotune): keep reduction axes base-named
