### PR TITLE
(fix) Export CANN vector ops from triton.language

### DIFF
--- a/python/triton/language/__init__.py
+++ b/python/triton/language/__init__.py
@@ -131,6 +131,11 @@ from .random import (
     randn4x,
     uint_to_uniform_float,
 )
+from .extra.cann.extension import (
+    extract_slice,
+    get_element,
+    insert_slice,
+)
 from . import target_info
 
 __all__ = [
@@ -183,6 +188,7 @@ __all__ = [
     "erf",
     "exp",
     "exp2",
+    "extract_slice",
     "expand_dims",
     "extra",
     "fdiv",
@@ -199,10 +205,12 @@ __all__ = [
     "fma",
     "full",
     "gather",
+    "get_element",
     "histogram",
     "inline_asm_elementwise",
     "interleave",
     "int1",
+    "insert_slice",
     "int16",
     "int32",
     "int64",

--- a/third_party/ascend/unittest/pytest_ut/test_language_exports.py
+++ b/third_party/ascend/unittest/pytest_ut/test_language_exports.py
@@ -1,0 +1,8 @@
+import triton.language as tl
+import triton.language.extra.cann.extension as al
+
+
+def test_cann_vec_ops_exported_from_triton_language():
+    for name in ("extract_slice", "get_element", "insert_slice"):
+        assert getattr(tl, name) is getattr(al, name)
+        assert name in tl.__all__


### PR DESCRIPTION
## Summary
- Export CANN vector ops `extract_slice`, `get_element`, and `insert_slice` from `triton.language`.
- Add a focused import-level regression test that keeps the `tl.*` aliases aligned with `triton.language.extra.cann.extension`.

## Motivation
Some compatibility code and kernels reference CANN vector ops through the common `triton.language as tl` namespace. The CANN extension already exports these ops, but `triton.language` does not expose them, which makes the `tl.*` path fail.

Evidence from the reported environment:
```text
triton file: /opt/mamba/envs/ascend-infer/lib/python3.13/site-packages/triton/__init__.py
tl file: /opt/mamba/envs/ascend-infer/lib/python3.13/site-packages/triton/language/__init__.py
has tl.extract_slice: False
has al.extract_slice: True
al file: /opt/mamba/envs/ascend-infer/lib/python3.13/site-packages/triton/language/extra/cann/extension/__init__.py
```

The missing `tl.extract_slice` also appears in runtime failure traces when JIT visits an attribute access:
```text
File "/opt/mamba/envs/ascend-infer/lib/python3.13/site-packages/triton/runtime/jit.py", line 144, in visit_Attribute
AttributeError: module 'triton.language' has no attribute 'extract_slice'
Error 模型 Qwen/Qwen3-30B-A3B 验证失败
```

Exporting these existing CANN extension functions from `triton.language` restores the expected `tl.extract_slice` compatibility path without changing the underlying implementation.

## Validation
- `python3 -m py_compile python/triton/language/__init__.py third_party/ascend/unittest/pytest_ut/test_language_exports.py`
- `git diff --check upstream/main...fix/export-cann-vec-ops-github`

## Note
- `PYTHONPATH="$PWD/python:$PWD/third_party/ascend" /opt/mamba/envs/ascend-infer/bin/python -m pytest -q third_party/ascend/unittest/pytest_ut/test_language_exports.py` is blocked in this local checkout because the source tree has not built `triton._C`; CI/build environments with the extension available should run the added test normally.