### PR TITLE
feat(autotune): print config timings

### DIFF
--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -2055,6 +2055,28 @@ class AutoTilingTuner(Autotuner):
 
         return valid_configs
 
+    def _print_autotuning_config_timings(self, timings: Dict[Config, object]) -> None:
+        if not self.print_autotuning:
+            return
+
+        def _sort_key(cost):
+            if isinstance(cost, (list, tuple)) and cost:
+                return float(cost[0])
+            return float(cost)
+
+        def _format_cost(cost):
+            if isinstance(cost, (list, tuple)):
+                return "[" + ", ".join(_format_cost(item) for item in cost) + "]"
+            return f"{float(cost):.4f}ms"
+
+        sorted_timings = sorted(timings.items(), key=lambda item: _sort_key(item[1]))
+        total = len(sorted_timings)
+        for index, (config, cost) in enumerate(sorted_timings, start=1):
+            print(
+                "Triton autotuning config timing "
+                f"{index}/{total}: cost={_format_cost(cost)}, config={config};"
+            )
+
     def generate_key_and_configs(self, *args, **kwargs):
         self.nargs = dict(zip(self.arg_names, args))
         self.is_simt_mode = kwargs.get('force_simt_only', False)
@@ -2146,6 +2168,7 @@ class AutoTilingTuner(Autotuner):
                 full_nargs = {**self.nargs, **kwargs, **self.cache[key].all_kwargs()}
                 self.pre_hook(full_nargs, reset_only=True)
                 self.configs_timings = timings
+                self._print_autotuning_config_timings(timings)
                 config = self.cache[key]
             else:
                 config = pruned_configs[0]

--- a/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
+++ b/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
@@ -67,6 +67,7 @@ def _load_autotuner_methods(*method_names):
         "List": List,
         "Optional": Optional,
         "Sequence": Sequence,
+        "Config": triton.Config,
         "valid_axis_names": VALID_AXIS_NAMES,
         "VectorAxes": _load_vector_axes_module().VectorAxes,
     }
@@ -1361,3 +1362,26 @@ def test_expand_simt_num_warps_configs_default_candidates():
 
     assert len(expanded_configs) == 4
     assert [cfg.num_warps for cfg in expanded_configs] == [8, 16, 32, 64]
+
+
+def test_print_autotuning_config_timings_lists_each_config(capsys):
+    method = _normalize_loaded_method(
+        _load_autotuner_methods("_print_autotuning_config_timings")["_print_autotuning_config_timings"]
+    )
+    tuner = SimpleNamespace(print_autotuning=True)
+    timings = {
+        triton.Config({"BLOCK_SIZE": 256}): 0.25,
+        triton.Config({"BLOCK_SIZE": 512}, num_stages=2): [0.125, 0.1, 0.2],
+    }
+
+    method(tuner, timings)
+
+    output = capsys.readouterr().out
+    lines = [line for line in output.splitlines() if "Triton autotuning config timing" in line]
+    assert len(lines) == 2
+    assert "1/2" in lines[0]
+    assert "cost=[0.1250ms, 0.1000ms, 0.2000ms]" in lines[0]
+    assert "BLOCK_SIZE: 512" in lines[0]
+    assert "2/2" in lines[1]
+    assert "cost=0.2500ms" in lines[1]
+    assert "BLOCK_SIZE: 256" in lines[1]


### PR DESCRIPTION
## Summary
- print each autotuning config timing when print_autotuning is enabled
- add a unit test for timing ordering and formatting

## Test Plan
- Not run (per request)
