### PR TITLE
fix: extractOp is added to be marked as Datause in UseAnalysis

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/UseAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/UseAnalysis.cpp
@@ -153,6 +153,11 @@ void triton::UseAnalysis::visitOperation(Operation *op,
           propagateUse(operand, UseType::DataUse);
         }
       })
+      .Case<tensor::ExtractOp>([&](auto extractOp) {
+        for (auto operand : operands) {
+          propagateUse(operand, UseType::DataUse);
+        }
+      })
       .Case<hivm::FixpipeOp>([&](auto fixpipeOp) {
         propagateUse(operands[0], UseType::DataUse);
       })


### PR DESCRIPTION
The use analysis lacks an explicit marking for extractOp, which may lead to the erroneous marking of extractOp as MetaUse. Since the result of extractOp is a scalar, pointer analysis will stop when it identifies a scalar. Therefore, if extractOp is involved in pointer calculations, it must be explicitly marked as DataUse. If this is not done, it may be incorrectly deleted by MetaUseEraser, introducing a series of issues related to unrealized_conversion_cast.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
