### PR TITLE
[WIP] test_fused_moe_router_tensorcore_kernel passed

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -1048,6 +1048,12 @@ def ttir_to_npubin(mod, metadata, opt):
                         f"--append-bisheng-options={bisheng_options}"
                     ]
 
+            # Enable SIMT auto-blockify when TRITON_ALL_BLOCKS_PARALLEL is set,
+            # mirroring the SIMD compile paths. driver.py's runtime block-count
+            # cap keys off the same env switch, so the two stay in sync.
+            if _is_auto_map_parallel_blocks_enabled():
+                _compile_option_list += ["--enable-auto-blockify-loop"]
+
         npu_compiler_path, env = _get_npucompiler_path()
         cmd_list = (
             [npu_compiler_path, src_path]

--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -951,7 +951,7 @@ class NPUOptions:
     enable_vf_fusion: bool = None
     # todo: this code will be removed in version 530.
     add_auto_scheduling: bool = False
-    enable_dynamic_cv_pipeline: bool = False
+    enable_dynamic_cv_pipeline: bool = True if is_compile_on_910_95 else False
     hfusion_enable_multiple_consumer_fusion: bool = False
     has_auto_blockify_blacklist_op: Optional[bool] = None
     intra_cache_num: int = None

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
@@ -1291,7 +1291,10 @@ void UpdateConditionInfoPass::runOnOperation()
   // Step2:Update the conditions of ifOp based on the intraCoreDependentMap and crossCoreDependentMap
   int updateResult = updateIfConds(module, ssbufferPtrs);
     
-  assert(updateResult == UPDATE_CONDITION_INFO_SUCCESS && "updateIfConds failed!");
+  if (updateResult != UPDATE_CONDITION_INFO_SUCCESS) {
+    LDBG("updateIfConds failed!");
+    signalPassFailure();
+  }
 
   LDBG("Exit UpdateConditionInfo pass." << "\n");
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.cpp
@@ -1044,23 +1044,38 @@ void UpdateLoopIterTimesPass::runOnOperation()
   DenseMap<int, SmallVector<Operation *>> cmap;
   DenseMap<int, SmallVector<Operation *>> vmap;
   ret = GetMainLoopIdToLoopOpMap(module, cmap, vmap);
-  assert(ret == 0 && "GetMainLoopIdToLoopOpMap Failed!");
+  if (ret != 0) {
+    LDBG("GetMainLoopIdToLoopOpMap Failed!");
+    signalPassFailure();
+  }
 
   // step2: Calculate info for each loop operation, store into the same iterationTimesinfoMap
   DenseMap<Operation *, IterationTimesInfo> infoMap;
   ret = ComputeMainLoopTimes(cmap, infoMap);
-  assert(ret == 0 && "ComputeMainLoopTimes from cube Failed!");
+  if (ret != 0) {
+    LDBG("ComputeMainLoopTimes from cube Failed!");
+    signalPassFailure();
+  }
   ret = ComputeMainLoopTimes(vmap, infoMap);
-  assert(ret == 0 && "ComputeMainLoopTimes from vector Failed!");
+  if (ret != 0) {
+    LDBG("ComputeMainLoopTimes from vector Failed!");
+    signalPassFailure();
+  }
 
   // step3: Update loop iteration count (process loop operations with same id from both cmap and vmap)
   ret = UpdateForLoopIteration(cmap, vmap, infoMap);
-  assert(ret == 0 && "Update ForLoop Iteration Failed!");
+  if (ret != 0) {
+    LDBG("Update ForLoop Iteration Failed!");
+    signalPassFailure();
+  }
   LDBG("after UpdateForLoopIteration:\n" << module);
 
   // step4: Replace loop counter by if blocks' counter
   ret = replaceForOpCounterInIfOps();
-  assert(ret == 0 && "replaceForOpCounterInIfOps Failed!");
+  if (ret != 0) {
+    LDBG("replaceForOpCounterInIfOps Failed!");
+    signalPassFailure();
+  }
 
   LDBG("after updateloopitertimes:\n" << module);
   LDBG("\nExit UpdateLoopIterTimes pass.");

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
@@ -41,9 +41,15 @@ using namespace triton;
 namespace {
 
 static constexpr llvm::StringLiteral interceptrFunc[] {
+  "_attn_fwd",
   "_attn_bwd",
   "_kernel_matmul_fp8_row_non_persistent",
   "bmm_kernel",
+  "lightning_indexer_grad_kernel",
+  "backward_dkdv",
+  "backward_dq",
+  "backward_sum_o_do",
+  "forward_kernel",
 };
 
 static LogicalResult verifyFuncNames(ModuleOp module)

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
@@ -32,6 +32,7 @@
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/CastInterfaces.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
@@ -481,7 +482,7 @@ static FillInfo splitSCFIfIfNeeded(FillInfo &info) {
  * @return LogicalResult Returns success if unification was performed, failure otherwise
  */
 static LogicalResult tryUnifyForAlloc(memref::AllocOp allocOp, 
-                                      const CVPipeline::MemoryDependenceGraph &memGraph, 
+                                      const CVPipeline::MemoryDependenceGraph &memGraph,
                                       CVPipeline::ComputeBlockIdManager &bm) {
   // Step1: Collect direct users (excluding linalg.fill)
   Value allocResult = allocOp.getResult();
@@ -568,11 +569,17 @@ public:
     CVPipeline::MemoryDependenceGraph memGraph(module, aa);
     auto bm = CVPipeline::ComputeBlockIdManager(module);
 
+    llvm::SmallVector<memref::AllocOp> allocOps;
+
     module.walk([&](memref::AllocOp allocOp) {
+      allocOps.push_back(allocOp);
+    });
+    
+    for (memref::AllocOp allocOp: allocOps) {
       if (failed(tryUnifyForAlloc(allocOp, memGraph, bm))) {
         signalPassFailure();
       }
-    });
+    }
 
     LOG_DEBUG("After: " << *module << "\n");
   }

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -213,8 +213,11 @@ void DataDependencyAnalysisPass::collectDepInfo(mlir::Value depvalue, Dependency
     depInfo.iniProducerBlockId = iniProdId;
     depInfo.iniConsumerBlockId = iniConsId;
     std::pair<int, int> commonLevelIds = findCommonLevelBlockIds(info, iniProdId, iniConsId);
-    assert(commonLevelIds.first != -1 && commonLevelIds.second != -1 &&
-        "Could not find common level block IDs for producer and consumer blocks");
+    if (commonLevelIds.first == -1 || commonLevelIds.second == -1) {
+        LOG_DEBUG("Could not find common level block IDs for producer and consumer blocks");
+        signalPassFailure();
+    }
+
     depInfo.producerBlockId = commonLevelIds.first;
     depInfo.consumerBlockId = commonLevelIds.second;
 
@@ -232,7 +235,10 @@ llvm::SmallVector<mlir::Operation *> DataDependencyAnalysisPass::collectDiffCore
         if (isa<scf::YieldOp>(user)) {
             continue;
         }
-        assert(!isControlFlowOp(user) && "warning: cannot process nested iterarg!");
+        if (isControlFlowOp(user)) {
+            LOG_DEBUG("cannot process nested iterarg!");
+            signalPassFailure();
+        }
 
         auto userCoreType = getCoreTypeWithIndex(user, 0);
         if (userCoreType != initCoreType && !userCoreType.empty()) {
@@ -342,7 +348,10 @@ void DataDependencyAnalysisPass::processIterArgDependencies()
             
             // Only process if init and yield have matching core types
             // Mismatch indicates a more complex dependency pattern that requires special handling
-            assert(initCoreType == yieldCoreType && "iterarg init core_type conflicts with yield");
+            if (initCoreType != yieldCoreType) {
+                LOG_DEBUG("iterarg init core_type conflicts with yield");
+                signalPassFailure();
+            }
 
             auto diffUsers = collectDiffCoreTypeUsers(iterArg, initCoreType);
             if (!diffUsers.empty()) {
@@ -488,8 +497,10 @@ void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info)
             int predBlockId = static_cast<int>(*predBlockIdOpt);
 
             auto [producerBlockId, consumerBlockId] = findCommonLevelBlockIds(info, predBlockId, currBlockId);
-            assert(producerBlockId != -1 && consumerBlockId != -1 &&
-                "Could not find common level block IDs for producer and consumer blocks");
+            if (producerBlockId == -1 || consumerBlockId == -1) {
+                LOG_DEBUG("Could not find common level block IDs for producer and consumer blocks");
+                signalPassFailure();
+            }
             if (producerBlockId == consumerBlockId) {
                 continue;
             }

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -211,7 +211,10 @@ SmallVector<int64_t> InterCoreTransferAndSyncPass::computeExpectedShape(Value va
 {
     auto tensorTy = dyn_cast<TensorType>(value.getType());
     static constexpr int NdShapeLength = 2;
-    assert(tensorTy && tensorTy.getRank() == NdShapeLength && "source shape is not 2-dim!");
+    if (!tensorTy || tensorTy.getRank() != NdShapeLength) {
+        LOG_DEBUG("source shape is not 2-dim!");
+        signalPassFailure();
+    }
 
     int64_t M = tensorTy.getDimSize(0);
     int64_t N = tensorTy.getDimSize(1);
@@ -454,7 +457,10 @@ mlir::Operation *InterCoreTransferAndSyncPass::annotateTightlyCoupledBuffer(OpBu
 Operation *InterCoreTransferAndSyncPass::findMainLoopforTransfer(Operation *endOp, Operation *startOp)
 {
     Operation *lca = endOp->getParentOp();
-    assert(lca == startOp->getParentOp() && "startOp and endOp are not in the same parent block, which is unexpected.");
+    if (lca != startOp->getParentOp()) {
+        LOG_DEBUG("startOp and endOp are not in the same parent block, which is unexpected.");
+        signalPassFailure();
+    }
     Operation *current = lca;
     while (current) {
         if (isa<scf::ForOp>(current)) {

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -766,6 +766,140 @@ LogicalResult TritonToLinalgPass::processLegalStrideOperations(ModuleOp moduleOp
   return success();
 }
 
+struct FoldOneHotGatherAfterReduceWithIndex
+    : public OpRewritePattern<linalg::ReduceOp> {
+  using OpRewritePattern<linalg::ReduceOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::ReduceOp op,
+                                PatternRewriter &rewriter) const final {
+    // Match only ordinary reduce-sum, not max_with_index itself.
+    if (op->getAttrOfType<StringAttr>("reduce_mode"))
+      return failure();
+
+    if (op.getNumResults() != 1 || op.getInputs().size() != 1)
+      return failure();
+
+    if (!isAddFReduction(op))
+      return failure();
+
+    auto mulOp = op.getInputs()[0].getDefiningOp<arith::MulFOp>();
+    if (!mulOp)
+      return failure();
+
+    Value logits;
+    Value maskAsFloat;
+
+    if (mulOp.getRhs().getDefiningOp<arith::UIToFPOp>()) {
+      logits = mulOp.getLhs();
+      maskAsFloat = mulOp.getRhs();
+    } else if (mulOp.getLhs().getDefiningOp<arith::UIToFPOp>()) {
+      logits = mulOp.getRhs();
+      maskAsFloat = mulOp.getLhs();
+    } else {
+      return failure();
+    }
+
+    auto castOp = maskAsFloat.getDefiningOp<arith::UIToFPOp>();
+    if (!castOp)
+      return failure();
+
+    auto cmpOp = castOp.getIn().getDefiningOp<arith::CmpIOp>();
+    if (!cmpOp || cmpOp.getPredicate() != arith::CmpIPredicate::eq)
+      return failure();
+
+    Value lhsBase = stripShapeAndBroadcast(cmpOp.getLhs());
+    Value rhsBase = stripShapeAndBroadcast(cmpOp.getRhs());
+
+    linalg::ReduceOp reduceWithIndex = getMaxWithIndexFromIndexValue(lhsBase);
+    Value arangeBase = rhsBase;
+
+    if (!reduceWithIndex) {
+      reduceWithIndex = getMaxWithIndexFromIndexValue(rhsBase);
+      arangeBase = lhsBase;
+    }
+
+    if (!reduceWithIndex)
+      return failure();
+
+    if (reduceWithIndex.getNumResults() != 2 ||
+        reduceWithIndex.getInputs().size() < 2)
+      return failure();
+
+    // Check that the other side of arange == idx is the same arange
+    // used as the index input of max_with_index.
+    Value reduceIndexBase =
+        stripShapeAndBroadcast(reduceWithIndex.getInputs()[1]);
+
+    if (arangeBase != reduceIndexBase)
+      return failure();
+
+    if (op.getDimensionsAttr() != reduceWithIndex.getDimensionsAttr())
+      return failure();
+
+    // In our case:
+    //   masked = select(cond, logits, -inf)
+    //   max_with_index(masked, arange)
+    Value maxInput = reduceWithIndex.getInputs()[0];
+    auto selectOp = maxInput.getDefiningOp<arith::SelectOp>();
+    if (!selectOp)
+      return failure();
+
+    if (selectOp.getTrueValue() != logits &&
+        selectOp.getFalseValue() != logits)
+      return failure();
+
+    if (op.getResult(0).getType() != reduceWithIndex.getResult(0).getType())
+      return failure();
+
+    rewriter.replaceOp(op, reduceWithIndex.getResult(0));
+    return success();
+  }
+
+private:
+  static bool isAddFReduction(linalg::ReduceOp op) {
+    Region &region = op.getRegion();
+    if (!region.hasOneBlock())
+      return false;
+
+    Block &block = region.front();
+    auto yieldOp = dyn_cast<linalg::YieldOp>(block.getTerminator());
+    if (!yieldOp || yieldOp.getNumOperands() != 1)
+      return false;
+
+    return yieldOp.getOperand(0).getDefiningOp<arith::AddFOp>() != nullptr;
+  }
+
+  static Value stripShapeAndBroadcast(Value value) {
+    while (Operation *def = value.getDefiningOp()) {
+      if (isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp>(def) ||
+          def->getName().getStringRef() == "linalg.broadcast") {
+        if (def->getNumOperands() == 0)
+          break;
+        value = def->getOperand(0);
+        continue;
+      }
+      break;
+    }
+    return value;
+  }
+
+  static linalg::ReduceOp getMaxWithIndexFromIndexValue(Value value) {
+    auto result = dyn_cast<OpResult>(value);
+    if (!result || result.getResultNumber() != 1)
+      return nullptr;
+
+    auto reduceOp = dyn_cast<linalg::ReduceOp>(result.getOwner());
+    if (!reduceOp)
+      return nullptr;
+
+    auto reduceMode = reduceOp->getAttrOfType<StringAttr>("reduce_mode");
+    if (!reduceMode || reduceMode != "max_with_index")
+      return nullptr;
+
+    return reduceOp;
+  }
+};
+
 void TritonToLinalgPass::runOnOperation() {
   compileOn91095Flag = this->compileOn91095;
 
@@ -903,6 +1037,20 @@ void TritonToLinalgPass::runOnOperation() {
     moduleOp->emitError("failed to apply Conversion Patterns");
     signalPassFailure();
   }
+
+// 7.1 Fold redundant one-hot gather after max_with_index.
+// This must run after Triton ops are converted to linalg.reduce.
+{
+  RewritePatternSet foldPatterns(&getContext());
+  foldPatterns.add<FoldOneHotGatherAfterReduceWithIndex>(&getContext());
+
+  if (failed(applyPatternsAndFoldGreedily(moduleOp,
+                                          std::move(foldPatterns)))) {
+    moduleOp->emitError("failed to fold one-hot gather after max_with_index");
+    signalPassFailure();
+    return;
+  }
+}
 
   // Execute legal stride operations conversion
   if (failed(processLegalStrideOperations(moduleOp))) {


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
This change works around the accuracy issue in fused_moe_router_tensorcore_kernel by folding a redundant one-hot value selection in TTAdapter IR.

The generated IR reconstructed the selected top2 value through:

cmpi -> uitofp -> mulf -> reduce_sum

although max_with_index had already produced both the selected value and index. On Ascend this path can produce an incorrect top2 value, leading to a wrong top2 weight.

The workaround reuses the value result of max_with_index directly instead of recomputing it through the one-hot mask. This fixes the failing test, but does not fully address the underlying lower-level issue in the mask/cast/multiply/reduce path.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
