### PR TITLE
[release/3.2.2-dev] test_fused_moe_router_tensorcore_kernel passed

### DIFF
--- a/third_party/ascend/include/TritonToLinalg/ArgMinMaxConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/ArgMinMaxConverter.h
@@ -356,6 +356,8 @@ public:
   ArgMaxConverter(MLIRContext *context) : ArgMinMaxBaseConverter(context) {}
 };
 
+void populatePostConversionCanonicalizationPatterns(RewritePatternSet &patterns);
+
 } // namespace TTOpConverters
 
 #endif

--- a/third_party/ascend/lib/TritonToLinalg/ArgMinMaxConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/ArgMinMaxConverter.cpp
@@ -103,3 +103,124 @@ int8_t ArgMaxConverter::getBaseReductionIntValue() { return std::numeric_limits<
 uint8_t ArgMaxConverter::getBaseReductionUIntValue() { return std::numeric_limits<uint8_t>::min(); }
 
 } // namespace TTOpConverters
+
+
+namespace {
+struct FoldOneHotGatherAfterReduceWithIndex
+    : public OpRewritePattern<linalg::ReduceOp> {
+  using OpRewritePattern<linalg::ReduceOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::ReduceOp op,
+                                PatternRewriter &rewriter) const final {
+    if (op->getAttrOfType<StringAttr>("reduce_mode"))
+      return failure();
+    if (op.getNumResults() != 1 || op.getInputs().size() != 1)
+      return failure();
+    if (!isAddFReduction(op))
+      return failure();
+
+    auto mulOp = op.getInputs()[0].getDefiningOp<arith::MulFOp>();
+    if (!mulOp)
+      return failure();
+
+    Value logits;
+    Value maskAsFloat;
+    if (mulOp.getRhs().getDefiningOp<arith::UIToFPOp>()) {
+      logits = mulOp.getLhs();
+      maskAsFloat = mulOp.getRhs();
+    } else if (mulOp.getLhs().getDefiningOp<arith::UIToFPOp>()) {
+      logits = mulOp.getRhs();
+      maskAsFloat = mulOp.getLhs();
+    } else {
+      return failure();
+    }
+
+    auto castOp = maskAsFloat.getDefiningOp<arith::UIToFPOp>();
+    if (!castOp)
+      return failure();
+
+    auto cmpOp = castOp.getIn().getDefiningOp<arith::CmpIOp>();
+    if (!cmpOp || cmpOp.getPredicate() != arith::CmpIPredicate::eq)
+      return failure();
+
+    Value lhsBase = stripShapeAndBroadcast(cmpOp.getLhs());
+    Value rhsBase = stripShapeAndBroadcast(cmpOp.getRhs());
+
+    linalg::ReduceOp reduceWithIndex = getMaxWithIndexFromIndexValue(lhsBase);
+    Value arangeBase = rhsBase;
+    if (!reduceWithIndex) {
+      reduceWithIndex = getMaxWithIndexFromIndexValue(rhsBase);
+      arangeBase = lhsBase;
+    }
+    if (!reduceWithIndex)
+      return failure();
+
+    if (reduceWithIndex.getNumResults() != 2 || reduceWithIndex.getInputs().size() < 2)
+      return failure();
+
+    Value reduceIndexBase = stripShapeAndBroadcast(reduceWithIndex.getInputs()[1]);
+    if (arangeBase != reduceIndexBase)
+      return failure();
+    if (op.getDimensionsAttr() != reduceWithIndex.getDimensionsAttr())
+      return failure();
+
+    Value maxInput = reduceWithIndex.getInputs()[0];
+    auto selectOp = maxInput.getDefiningOp<arith::SelectOp>();
+    if (selectOp && selectOp.getTrueValue() != logits && selectOp.getFalseValue() != logits)
+      return failure();
+    if (!selectOp && maxInput != logits)
+      return failure();
+
+    if (op.getResult(0).getType() != reduceWithIndex.getResult(0).getType())
+      return failure();
+
+    rewriter.replaceOp(op, reduceWithIndex.getResult(0));
+    return success();
+  }
+
+private:
+  static bool isAddFReduction(linalg::ReduceOp op) {
+    Region &region = op.getRegion();
+    if (!region.hasOneBlock())
+      return false;
+    Block &block = region.front();
+    auto yieldOp = dyn_cast<linalg::YieldOp>(block.getTerminator());
+    if (!yieldOp || yieldOp.getNumOperands() != 1)
+      return false;
+    return yieldOp.getOperand(0).getDefiningOp<arith::AddFOp>() != nullptr;
+  }
+
+  static Value stripShapeAndBroadcast(Value value) {
+    while (Operation *def = value.getDefiningOp()) {
+      if (isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp>(def) ||
+          def->getName().getStringRef() == "linalg.broadcast") {
+        if (def->getNumOperands() == 0)
+          break;
+        value = def->getOperand(0);
+        continue;
+      }
+      break;
+    }
+    return value;
+  }
+
+  static linalg::ReduceOp getMaxWithIndexFromIndexValue(Value value) {
+    auto result = dyn_cast<OpResult>(value);
+    if (!result || result.getResultNumber() != 1)
+      return nullptr;
+
+    auto reduceOp = dyn_cast<linalg::ReduceOp>(result.getOwner());
+    if (!reduceOp)
+      return nullptr;
+
+    auto reduceMode = reduceOp->getAttrOfType<StringAttr>("reduce_mode");
+    if (!reduceMode || reduceMode != "max_with_index")
+      return nullptr;
+    return reduceOp;
+  }
+};
+} // namespace
+
+void TTOpConverters::populatePostConversionCanonicalizationPatterns(RewritePatternSet &patterns) {
+  patterns.add<FoldOneHotGatherAfterReduceWithIndex>(patterns.getContext());
+}

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -766,6 +766,140 @@ LogicalResult TritonToLinalgPass::processLegalStrideOperations(ModuleOp moduleOp
   return success();
 }
 
+struct FoldOneHotGatherAfterReduceWithIndex
+    : public OpRewritePattern<linalg::ReduceOp> {
+  using OpRewritePattern<linalg::ReduceOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::ReduceOp op,
+                                PatternRewriter &rewriter) const final {
+    // Match only ordinary reduce-sum, not max_with_index itself.
+    if (op->getAttrOfType<StringAttr>("reduce_mode"))
+      return failure();
+
+    if (op.getNumResults() != 1 || op.getInputs().size() != 1)
+      return failure();
+
+    if (!isAddFReduction(op))
+      return failure();
+
+    auto mulOp = op.getInputs()[0].getDefiningOp<arith::MulFOp>();
+    if (!mulOp)
+      return failure();
+
+    Value logits;
+    Value maskAsFloat;
+
+    if (mulOp.getRhs().getDefiningOp<arith::UIToFPOp>()) {
+      logits = mulOp.getLhs();
+      maskAsFloat = mulOp.getRhs();
+    } else if (mulOp.getLhs().getDefiningOp<arith::UIToFPOp>()) {
+      logits = mulOp.getRhs();
+      maskAsFloat = mulOp.getLhs();
+    } else {
+      return failure();
+    }
+
+    auto castOp = maskAsFloat.getDefiningOp<arith::UIToFPOp>();
+    if (!castOp)
+      return failure();
+
+    auto cmpOp = castOp.getIn().getDefiningOp<arith::CmpIOp>();
+    if (!cmpOp || cmpOp.getPredicate() != arith::CmpIPredicate::eq)
+      return failure();
+
+    Value lhsBase = stripShapeAndBroadcast(cmpOp.getLhs());
+    Value rhsBase = stripShapeAndBroadcast(cmpOp.getRhs());
+
+    linalg::ReduceOp reduceWithIndex = getMaxWithIndexFromIndexValue(lhsBase);
+    Value arangeBase = rhsBase;
+
+    if (!reduceWithIndex) {
+      reduceWithIndex = getMaxWithIndexFromIndexValue(rhsBase);
+      arangeBase = lhsBase;
+    }
+
+    if (!reduceWithIndex)
+      return failure();
+
+    if (reduceWithIndex.getNumResults() != 2 ||
+        reduceWithIndex.getInputs().size() < 2)
+      return failure();
+
+    // Check that the other side of arange == idx is the same arange
+    // used as the index input of max_with_index.
+    Value reduceIndexBase =
+        stripShapeAndBroadcast(reduceWithIndex.getInputs()[1]);
+
+    if (arangeBase != reduceIndexBase)
+      return failure();
+
+    if (op.getDimensionsAttr() != reduceWithIndex.getDimensionsAttr())
+      return failure();
+
+    // In our case:
+    //   masked = select(cond, logits, -inf)
+    //   max_with_index(masked, arange)
+    Value maxInput = reduceWithIndex.getInputs()[0];
+    auto selectOp = maxInput.getDefiningOp<arith::SelectOp>();
+    if (!selectOp)
+      return failure();
+
+    if (selectOp.getTrueValue() != logits &&
+        selectOp.getFalseValue() != logits)
+      return failure();
+
+    if (op.getResult(0).getType() != reduceWithIndex.getResult(0).getType())
+      return failure();
+
+    rewriter.replaceOp(op, reduceWithIndex.getResult(0));
+    return success();
+  }
+
+private:
+  static bool isAddFReduction(linalg::ReduceOp op) {
+    Region &region = op.getRegion();
+    if (!region.hasOneBlock())
+      return false;
+
+    Block &block = region.front();
+    auto yieldOp = dyn_cast<linalg::YieldOp>(block.getTerminator());
+    if (!yieldOp || yieldOp.getNumOperands() != 1)
+      return false;
+
+    return yieldOp.getOperand(0).getDefiningOp<arith::AddFOp>() != nullptr;
+  }
+
+  static Value stripShapeAndBroadcast(Value value) {
+    while (Operation *def = value.getDefiningOp()) {
+      if (isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp>(def) ||
+          def->getName().getStringRef() == "linalg.broadcast") {
+        if (def->getNumOperands() == 0)
+          break;
+        value = def->getOperand(0);
+        continue;
+      }
+      break;
+    }
+    return value;
+  }
+
+  static linalg::ReduceOp getMaxWithIndexFromIndexValue(Value value) {
+    auto result = dyn_cast<OpResult>(value);
+    if (!result || result.getResultNumber() != 1)
+      return nullptr;
+
+    auto reduceOp = dyn_cast<linalg::ReduceOp>(result.getOwner());
+    if (!reduceOp)
+      return nullptr;
+
+    auto reduceMode = reduceOp->getAttrOfType<StringAttr>("reduce_mode");
+    if (!reduceMode || reduceMode != "max_with_index")
+      return nullptr;
+
+    return reduceOp;
+  }
+};
+
 void TritonToLinalgPass::runOnOperation() {
   compileOn91095Flag = this->compileOn91095;
 
@@ -903,6 +1037,20 @@ void TritonToLinalgPass::runOnOperation() {
     moduleOp->emitError("failed to apply Conversion Patterns");
     signalPassFailure();
   }
+
+// 7.1 Fold redundant one-hot gather after max_with_index.
+// This must run after Triton ops are converted to linalg.reduce.
+{
+  RewritePatternSet foldPatterns(&getContext());
+  foldPatterns.add<FoldOneHotGatherAfterReduceWithIndex>(&getContext());
+
+  if (failed(applyPatternsAndFoldGreedily(moduleOp,
+                                          std::move(foldPatterns)))) {
+    moduleOp->emitError("failed to fold one-hot gather after max_with_index");
+    signalPassFailure();
+    return;
+  }
+}
 
   // Execute legal stride operations conversion
   if (failed(processLegalStrideOperations(moduleOp))) {

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -766,140 +766,6 @@ LogicalResult TritonToLinalgPass::processLegalStrideOperations(ModuleOp moduleOp
   return success();
 }
 
-struct FoldOneHotGatherAfterReduceWithIndex
-    : public OpRewritePattern<linalg::ReduceOp> {
-  using OpRewritePattern<linalg::ReduceOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(linalg::ReduceOp op,
-                                PatternRewriter &rewriter) const final {
-    // Match only ordinary reduce-sum, not max_with_index itself.
-    if (op->getAttrOfType<StringAttr>("reduce_mode"))
-      return failure();
-
-    if (op.getNumResults() != 1 || op.getInputs().size() != 1)
-      return failure();
-
-    if (!isAddFReduction(op))
-      return failure();
-
-    auto mulOp = op.getInputs()[0].getDefiningOp<arith::MulFOp>();
-    if (!mulOp)
-      return failure();
-
-    Value logits;
-    Value maskAsFloat;
-
-    if (mulOp.getRhs().getDefiningOp<arith::UIToFPOp>()) {
-      logits = mulOp.getLhs();
-      maskAsFloat = mulOp.getRhs();
-    } else if (mulOp.getLhs().getDefiningOp<arith::UIToFPOp>()) {
-      logits = mulOp.getRhs();
-      maskAsFloat = mulOp.getLhs();
-    } else {
-      return failure();
-    }
-
-    auto castOp = maskAsFloat.getDefiningOp<arith::UIToFPOp>();
-    if (!castOp)
-      return failure();
-
-    auto cmpOp = castOp.getIn().getDefiningOp<arith::CmpIOp>();
-    if (!cmpOp || cmpOp.getPredicate() != arith::CmpIPredicate::eq)
-      return failure();
-
-    Value lhsBase = stripShapeAndBroadcast(cmpOp.getLhs());
-    Value rhsBase = stripShapeAndBroadcast(cmpOp.getRhs());
-
-    linalg::ReduceOp reduceWithIndex = getMaxWithIndexFromIndexValue(lhsBase);
-    Value arangeBase = rhsBase;
-
-    if (!reduceWithIndex) {
-      reduceWithIndex = getMaxWithIndexFromIndexValue(rhsBase);
-      arangeBase = lhsBase;
-    }
-
-    if (!reduceWithIndex)
-      return failure();
-
-    if (reduceWithIndex.getNumResults() != 2 ||
-        reduceWithIndex.getInputs().size() < 2)
-      return failure();
-
-    // Check that the other side of arange == idx is the same arange
-    // used as the index input of max_with_index.
-    Value reduceIndexBase =
-        stripShapeAndBroadcast(reduceWithIndex.getInputs()[1]);
-
-    if (arangeBase != reduceIndexBase)
-      return failure();
-
-    if (op.getDimensionsAttr() != reduceWithIndex.getDimensionsAttr())
-      return failure();
-
-    // In our case:
-    //   masked = select(cond, logits, -inf)
-    //   max_with_index(masked, arange)
-    Value maxInput = reduceWithIndex.getInputs()[0];
-    auto selectOp = maxInput.getDefiningOp<arith::SelectOp>();
-    if (!selectOp)
-      return failure();
-
-    if (selectOp.getTrueValue() != logits &&
-        selectOp.getFalseValue() != logits)
-      return failure();
-
-    if (op.getResult(0).getType() != reduceWithIndex.getResult(0).getType())
-      return failure();
-
-    rewriter.replaceOp(op, reduceWithIndex.getResult(0));
-    return success();
-  }
-
-private:
-  static bool isAddFReduction(linalg::ReduceOp op) {
-    Region &region = op.getRegion();
-    if (!region.hasOneBlock())
-      return false;
-
-    Block &block = region.front();
-    auto yieldOp = dyn_cast<linalg::YieldOp>(block.getTerminator());
-    if (!yieldOp || yieldOp.getNumOperands() != 1)
-      return false;
-
-    return yieldOp.getOperand(0).getDefiningOp<arith::AddFOp>() != nullptr;
-  }
-
-  static Value stripShapeAndBroadcast(Value value) {
-    while (Operation *def = value.getDefiningOp()) {
-      if (isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp>(def) ||
-          def->getName().getStringRef() == "linalg.broadcast") {
-        if (def->getNumOperands() == 0)
-          break;
-        value = def->getOperand(0);
-        continue;
-      }
-      break;
-    }
-    return value;
-  }
-
-  static linalg::ReduceOp getMaxWithIndexFromIndexValue(Value value) {
-    auto result = dyn_cast<OpResult>(value);
-    if (!result || result.getResultNumber() != 1)
-      return nullptr;
-
-    auto reduceOp = dyn_cast<linalg::ReduceOp>(result.getOwner());
-    if (!reduceOp)
-      return nullptr;
-
-    auto reduceMode = reduceOp->getAttrOfType<StringAttr>("reduce_mode");
-    if (!reduceMode || reduceMode != "max_with_index")
-      return nullptr;
-
-    return reduceOp;
-  }
-};
-
 void TritonToLinalgPass::runOnOperation() {
   compileOn91095Flag = this->compileOn91095;
 
@@ -1038,11 +904,13 @@ void TritonToLinalgPass::runOnOperation() {
     signalPassFailure();
   }
 
-// 7.1 Fold redundant one-hot gather after max_with_index.
-// This must run after Triton ops are converted to linalg.reduce.
+// 7.1 Workaround: fold duplicated one-hot reconstruction emitted after
+// ArgMax lowering. The issue is not in triton::ReduceOp semantics themselves;
+// redundant value reconstruction is materialized later and can lower to
+// incorrect code on Ascend, so this is fixed post-conversion on linalg::ReduceOp.
 {
   RewritePatternSet foldPatterns(&getContext());
-  foldPatterns.add<FoldOneHotGatherAfterReduceWithIndex>(&getContext());
+  TTOpConverters::populatePostConversionCanonicalizationPatterns(foldPatterns);
 
   if (failed(applyPatternsAndFoldGreedily(moduleOp,
                                           std::move(foldPatterns)))) {


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
This change works around the accuracy issue in fused_moe_router_tensorcore_kernel by folding a redundant one-hot value selection in TTAdapter IR.

The generated IR reconstructed the selected top2 value through:

cmpi -> uitofp -> mulf -> reduce_sum

although max_with_index had already produced both the selected value and index. On Ascend this path can produce an incorrect top2 value, leading to a wrong top2 weight.

The workaround reuses the value result of max_with_index directly instead of recomputing it through the one-hot mask. This fixes the failing test, but does not fully address the underlying lower-level issue in the mask/cast/multiply/reduce path.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
