### PR TITLE
[Autotune] poly norm autotune state fix release 3.2.2 dev

### DIFF
--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -577,6 +577,15 @@ class AutoTilingTuner(Autotuner):
         self.vector_axes = self._rebuild_vector_axes()
         self.axis_arg_names = self._get_parser_axis_arg_names()
 
+    def _reset_vector_parse_derived_state(self) -> None:
+        self.fixed_split_params = {}
+        self.fixed_grid_dims = set()
+        self.fixed_grid_dim_values = {}
+        self.split_axis_pid_dims = {}
+        self.axis_pid_dims = {}
+        self.dual_reduction = False
+        self.persistent_reduction = False
+
     def _get_parser_axis_arg_names(self) -> Dict[str, str]:
         axis_arg_names = {}
         if self.vector_axes is not None:
@@ -930,6 +939,7 @@ class AutoTilingTuner(Autotuner):
 
     def _autoparse_axis_params_vector(self, all_args):
         self.vv_gap_fill_report_v2 = None
+        self._reset_vector_parse_derived_state()
         # Normalize vector axis containers for vv-assist flow. In list-key mode
         # these fields are initialized as None, and vv may legitimately fill only
         # split/tiling/low_dim without reduction axes.
@@ -1929,20 +1939,45 @@ class AutoTilingTuner(Autotuner):
         from .tile_generator import KernelMeta, TileGenerator
 
         vector_tile_inputs = self._materialize_vector_tile_inputs(kv_dict, all_args)
+        if self.print_autotuning:
+            print(
+                "Ascend autotuning vector tile inputs: "
+                f"axis_sizes={vector_tile_inputs['axis_sizes']}, "
+                f"split_params={vector_tile_inputs['split_params']}, "
+                f"fixed_split_params={self.fixed_split_params}, "
+                f"tiling_params={vector_tile_inputs['tiling_params']}, "
+                f"low_dim_axes={vector_tile_inputs['low_dim_axes']}, "
+                f"reduction_axes={vector_tile_inputs['reduction_axes']}, "
+                f"persistent_reduction={self.persistent_reduction}, "
+                f"dual_reduction={self.dual_reduction}, "
+                f"num_buffers={self.num_buffers}"
+            )
         axis_sizes = vector_tile_inputs["axis_sizes"]
-
-        kernel_meta = KernelMeta(
+        kernel_meta_args = [
             axis_sizes,
             vector_tile_inputs["split_params"],
             self.fixed_split_params,
             vector_tile_inputs["tiling_params"],
             vector_tile_inputs["low_dim_axes"],
-            dtype,
-            self.persistent_reduction,
-            self.dual_reduction,
-            self.num_buffers,
-            self.is_simt_mode,
+        ]
+        kernel_meta_signature = inspect.signature(KernelMeta.__init__)
+        if "reduction_axes" in kernel_meta_signature.parameters:
+            kernel_meta_args.append(
+                [
+                    self._get_axis_base_name(axis)
+                    for axis in vector_tile_inputs["reduction_axes"]
+                ]
+            )
+        kernel_meta_args.extend(
+            [
+                dtype,
+                self.persistent_reduction,
+                self.dual_reduction,
+                self.num_buffers,
+                self.is_simt_mode,
+            ]
         )
+        kernel_meta = KernelMeta(*kernel_meta_args)
         tile_gen = TileGenerator(kernel_meta=kernel_meta)
         tile_gen.descend_split_tiling()
 

--- a/third_party/ascend/unittest/autotune_ut/test_common.py
+++ b/third_party/ascend/unittest/autotune_ut/test_common.py
@@ -106,10 +106,20 @@ def check_axes_parse_res(act: dict, ref: dict):
 
     assert set(ref_axis_lengths.values()) == set(act_axis_lengths.values()), \
         f"Semantic dimensions mismatch: ref={set(ref_axis_lengths.values())}, act={set(act_axis_lengths.values())}"
-    
+
+    def resolve_symbol(sym: str, sym_to_sem: dict) -> str:
+        if sym in sym_to_sem:
+            return sym
+        if isinstance(sym, str) and sym.startswith("r") and sym[1:] in sym_to_sem:
+            return sym[1:]
+        raise KeyError(sym)
+
     def normalize_param_dict(param_dict: dict, sym_to_sem: dict) -> dict:
         """Convert {symbol: value} -> {semantic: value}"""
-        return {sym_to_sem[sym]: value for sym, value in param_dict.items()}
+        return {
+            sym_to_sem[resolve_symbol(sym, sym_to_sem)]: value
+            for sym, value in param_dict.items()
+        }
 
     ref_split = normalize_param_dict(ref_state["split_params"], ref_axis_lengths)
     act_split = normalize_param_dict(act_state["split_params"], act_axis_lengths)
@@ -118,14 +128,14 @@ def check_axes_parse_res(act: dict, ref: dict):
     act_tiling = normalize_param_dict(act_state["tiling_params"], act_axis_lengths)
 
     def normalize_axis_list(axis_list: list, sym_to_sem: dict) -> list:
-        return sorted(sym_to_sem[sym] for sym in axis_list)
+        return sorted(sym_to_sem[resolve_symbol(sym, sym_to_sem)] for sym in axis_list)
 
     ref_low = normalize_axis_list(ref_state["low_dim_axes"], ref_axis_lengths)
     act_low = normalize_axis_list(act_state["low_dim_axes"], act_axis_lengths)
 
     ref_red = normalize_axis_list(ref_state["reduction_axes"], ref_axis_lengths)
     act_red = normalize_axis_list(act_state["reduction_axes"], act_axis_lengths)
-    
+
     # Compare normalized structures
     assert ref_split == act_split, f"split_params mismatch: {ref_split} vs {act_split}"
     assert ref_tiling == act_tiling, f"tiling_params mismatch: {ref_tiling} vs {act_tiling}"

--- a/third_party/ascend/unittest/autotune_ut/test_vector_parse_state_reset.py
+++ b/third_party/ascend/unittest/autotune_ut/test_vector_parse_state_reset.py
@@ -1,0 +1,109 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import unittest.mock as mock
+
+import triton
+import triton.language as tl
+
+
+def _axis_bases(axes):
+    return [axis[1:] if isinstance(axis, str) and axis.startswith("r") else axis for axis in axes]
+
+
+def _run_autoparse_and_generate(tuner, all_args):
+    tuner.nargs = {}
+    tuner.is_simt_mode = False
+    tuner.user_specified_multibuffer = None
+    tuner.user_specified_num_stages = None
+    tuner.user_specified_warps = None
+    dtype = all_args["x_ptr"].dtype
+    tuner._autoparse_axis_params(all_args)
+    tuner._gen_tile_configs({"x": all_args["n_cols"]}, dtype, all_args)
+    return {
+        "persistent_reduction": tuner.persistent_reduction,
+        "gen_configs": [dict(config.kwargs) for config in tuner.gen_configs],
+        "reduction_axes": list(tuner.reduction_axes or []),
+        "low_dim_axes": list(tuner.low_dim_axes or []),
+        "tiling_params": dict(tuner.tiling_params or {}),
+    }
+
+
+class _FakeTensor:
+    def __init__(self, dtype):
+        self.dtype = dtype
+
+
+def test_vector_parse_state_resets_persistent_reduction_between_shapes():
+    import torch
+    import triton.backends.ascend.runtime
+
+    @triton.autotune(
+        configs=[],
+        key=["n_cols"],
+        hints={"auto_gen_config": True},
+    )
+    @triton.jit
+    def poly_norm_like_kernel(
+        x_ptr,
+        y_ptr,
+        n_cols,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        acc = tl.zeros([], dtype=tl.float32)
+        for start in range(0, n_cols, BLOCK_SIZE):
+            offsets = start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_cols
+            x = tl.load(x_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+            acc += tl.sum(x * x, axis=0)
+        scale = acc / n_cols
+        for start in range(0, n_cols, BLOCK_SIZE):
+            offsets = start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_cols
+            x = tl.load(x_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+            tl.store(y_ptr + offsets, x * scale, mask=mask)
+
+    tuner = poly_norm_like_kernel
+    fake_x = _FakeTensor(torch.bfloat16)
+    fake_y = _FakeTensor(torch.bfloat16)
+
+    with mock.patch(
+        "triton.backends.ascend.runtime.autotuner.get_byte_per_numel",
+        lambda dtype: 2,
+    ):
+        small = _run_autoparse_and_generate(
+            tuner,
+            {"x_ptr": fake_x, "y_ptr": fake_y, "n_cols": 1024},
+        )
+        large = _run_autoparse_and_generate(
+            tuner,
+            {"x_ptr": fake_x, "y_ptr": fake_y, "n_cols": 32768},
+        )
+
+    assert small["persistent_reduction"] is True
+    assert large["tiling_params"] == {"x": "BLOCK_SIZE"}
+    assert large["low_dim_axes"] == ["x"]
+    assert _axis_bases(large["reduction_axes"]) == ["x"]
+    assert large["persistent_reduction"] is False
+    assert large["gen_configs"]
+    assert any(
+        config.get("BLOCK_SIZE", 0) <= 8192
+        for config in large["gen_configs"]
+    )


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)


# Fix vector parse derived-state leakage across shapes in poly_norm autotuner

## Background

In the Ascend autotune auto-generation path for `poly_norm`, some large-shape cases produced:

- `Expanded to 0 SIMD configs`
- `Generated configs number: 0`

This is not fixed by changing LigerKernel seed configs or enlarging the autotune key. The real issue is that `AutoTilingTuner` reuses vector parse derived state across different shapes within the same tuner instance, so a small-shape `persistent_reduction=True` leaks into later large-shape runs.

## Root Cause

In the `poly_norm` scenario:

- small `n_cols` can set `persistent_reduction` to `True`
- the same autotuner instance is then reused for larger `n_cols`
- the derived parser state is not reset before the next vector parse
- tile generation sees the wrong persistent-reduction semantics and may prune all candidates

This leads to empty generated configs for large shapes.

## Changes

### 1. Reset vector-parse derived state per run

Add `_reset_vector_parse_derived_state()` in `AutoTilingTuner` and call it at the beginning of each `_autoparse_axis_params_vector()` run.

The reset covers only derived state:

- `fixed_split_params`
- `fixed_grid_dims`
- `fixed_grid_dim_values`
- `split_axis_pid_dims`
- `axis_pid_dims`
- `dual_reduction`
- `persistent_reduction`

This ensures parser-derived state is recomputed from the current shape instead of leaking from a previous one.

### 2. Add vector tile input diagnostics

Add debug printing in `_gen_tile_configs()` for the vector tile-generator inputs:

- `axis_sizes`
- `split_params`
- `fixed_split_params`
- `tiling_params`
- `low_dim_axes`
- `reduction_axes`
- `persistent_reduction`
- `dual_reduction`
- `num_buffers`

This makes future autotune candidate-generation issues much easier to diagnose.

### 3. Add regression coverage

Add `test_vector_parse_state_reset.py` to cover the same autotuner instance processing a small shape followed by a large shape.

The test verifies:

- `persistent_reduction` is `True` for the small shape
- it is recomputed to `False` for the large shape
- the large shape produces non-empty generated configs

### 4. Normalize equivalent reduction-axis naming in test comparison

Update the shared autotune test comparison helper to treat equivalent symbolic axis names such as `x` and `rx` as the same semantic axis, avoiding false regression failures caused only by naming representation.

## Validation

### Unit Tests

Executed:

```bash
python -m pytest third_party/ascend/unittest/autotune_ut/test_vector_parse_state_reset.py -q
python -m pytest third_party/ascend/unittest/autotune_ut -q
```

Results:

- `test_vector_parse_state_reset.py`: `1 passed`
- `autotune_ut`: `68 passed, 3 skipped`




# 修复 poly_norm autotuner 中 vector parse 派生状态跨 shape 污染问题

## 背景

`poly_norm` 在 Ascend autotune 自动生成阶段，部分大 shape 场景会出现：

- `Expanded to 0 SIMD configs`
- `Generated configs number: 0`

该问题不是通过修改 LigerKernel seed config 或扩大 autotune key 规避的，而是 `AutoTilingTuner` 在同一实例连续处理不同 shape 时，vector parse 的派生状态没有在每轮解析前重置，导致小 shape 计算出的 `persistent_reduction=True` 污染后续大 shape。

## 根因

在 `poly_norm` 场景下：

- 小 `n_cols` 会将 `persistent_reduction` 置为 `True`
- 同一个 autotuner 实例后续继续处理大 `n_cols` 时，这个派生状态未被清理
- tile generator 因错误的 persistent reduction 语义裁掉候选，最终出现 `0 config`

## 修复内容

### 1. 重置 vector parse 派生状态

在 `AutoTilingTuner` 中新增 `_reset_vector_parse_derived_state()`，并在每轮 `_autoparse_axis_params_vector()` 开头调用，重置以下派生状态：

- `fixed_split_params`
- `fixed_grid_dims`
- `fixed_grid_dim_values`
- `split_axis_pid_dims`
- `axis_pid_dims`
- `dual_reduction`
- `persistent_reduction`

这样可以保证每个 shape 的 parser 派生状态都基于当前输入重新计算。

### 2. 增强 vector tile inputs 诊断

在 `_gen_tile_configs()` 中打印 vector tile generator 的关键输入，便于定位后续类似问题，包括：

- `axis_sizes`
- `split_params`
- `fixed_split_params`
- `tiling_params`
- `low_dim_axes`
- `reduction_axes`
- `persistent_reduction`
- `dual_reduction`
- `num_buffers`

### 3. 新增回归测试

新增 `test_vector_parse_state_reset.py`，覆盖同一 autotuner 实例先处理小 `n_cols`、再处理大 `n_cols` 的场景，验证：

- 小 shape 下 `persistent_reduction` 为 `True`
- 大 shape 下会重新计算并回到 `False`
- 大 shape 能生成非空 autotune configs

### 4. 兼容现有 reduction 轴命名差异

在 autotune 单测公共比较逻辑中，兼容 `x` / `rx` 这类语义等价的轴名，避免因命名形式差异导致 parser 回归误报。

## 验证结果

### 单测

执行：

```bash
python -m pytest third_party/ascend/unittest/autotune_ut/test_vector_parse_state_reset.py -q
python -m pytest third_party/ascend/unittest/autotune_ut -q
```

结果：

- `test_vector_parse_state_reset.py`: `1 passed`
- `autotune_ut`: `68 passed, 3 skipped`

