### PR TITLE
feat(autoblockify): enable auto-blockify on the SIMT path (env-gated)

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -1048,6 +1048,12 @@ def ttir_to_npubin(mod, metadata, opt):
                         f"--append-bisheng-options={bisheng_options}"
                     ]
 
+            # Enable SIMT auto-blockify when TRITON_ALL_BLOCKS_PARALLEL is set,
+            # mirroring the SIMD compile paths. driver.py's runtime block-count
+            # cap keys off the same env switch, so the two stay in sync.
+            if _is_auto_map_parallel_blocks_enabled():
+                _compile_option_list += ["--enable-auto-blockify-loop"]
+
         npu_compiler_path, env = _get_npucompiler_path()
         cmd_list = (
             [npu_compiler_path, src_path]


### PR DESCRIPTION
## Summary
Enables SIMT auto-blockify on `release/3.2.2`. `ttir_to_npubin` now forwards `--enable-auto-blockify-loop` to `bishengir-compile` when `TRITON_ALL_BLOCKS_PARALLEL` is set, mirroring the existing SIMD compile paths (`linalg_to_bin_enable_npu_compile_*`).

## Scope
Intentionally **env-var only** — no per-kernel `NPUOption.enable_auto_blockify` on this branch, no `driver.py` change, no interaction with the existing auto-blockify blacklist (`has_auto_blockify_blacklist_op`). Diff is a single 6-line addition to `compiler.py`.

## Why this works without driver.py changes
`release/3.2.2`'s `driver.py` already keys `enable_auto_map_parallel_blocks` off `_is_auto_map_parallel_blocks_enabled()` (with the existing `and not has_auto_blockify_blacklist_op` gate). The compile-time flag now keys off the same env switch, so SIMT compile-time and SIMT runtime cap stay in sync end-to-end via `TRITON_ALL_BLOCKS_PARALLEL` alone. SIMD behavior is byte-for-byte unchanged.

## Relation to upstream gitcode !1805
`!1805` (the auto-blockify-v2 work) on `main` introduced a per-kernel `NPUOptions.enable_auto_blockify` tri-state and a layered `driver.py` cap. `release/3.2.2` does not use that tri-state model — it uses the env switch + the blacklist. So the SIMT enablement on this branch is the env-var equivalent, not a verbatim cherry-pick.

## Reviewer note — intentional asymmetry
SIMT auto-blockify on this branch has **no op blacklist** (consistent with !1805 / main): a kernel with non-commutative atomics is blockified on the SIMT path even though the SIMD path's blacklist would skip it. This matches the existing design; a SIMT-side blacklist is tracked separately.