### PR TITLE
[release/3.2.2][Autotune] 1.Normalize duplicate reduction axis;2.poly norm autotune state fix

### DIFF
--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -559,9 +559,15 @@ class AutoTilingTuner(Autotuner):
         existing_vector_axes = getattr(self, "vector_axes", None)
         if existing_vector_axes is not None:
             vector_axes.apply_semantic_fields(
-                axis_length_exprs=getattr(existing_vector_axes, "axis_length_exprs", {}),
-                fixed_tiling_exprs=getattr(existing_vector_axes, "fixed_tiling_exprs", {}),
-                axis_dynamic_sources=getattr(existing_vector_axes, "axis_dynamic_sources", {}),
+                axis_length_exprs=self._normalize_axis_name_mapping(
+                    getattr(existing_vector_axes, "axis_length_exprs", {}),
+                ),
+                fixed_tiling_exprs=self._normalize_axis_name_mapping(
+                    getattr(existing_vector_axes, "fixed_tiling_exprs", {}),
+                ),
+                axis_dynamic_sources=self._normalize_axis_name_mapping(
+                    getattr(existing_vector_axes, "axis_dynamic_sources", {}),
+                ),
             )
 
         vector_axes.apply_semantic_fields(
@@ -588,29 +594,19 @@ class AutoTilingTuner(Autotuner):
                 }
             )
 
-            for reduction_axis in self.vector_axes.reduction_axes:
-                if not isinstance(reduction_axis, str) or not reduction_axis.startswith("r"):
-                    continue
-                base_axis = reduction_axis[1:]
-                base_arg_name = axis_arg_names.pop(base_axis, None)
-                if base_arg_name is not None:
-                    axis_arg_names.setdefault(reduction_axis, base_arg_name)
-
         return axis_arg_names
 
     def _promote_axis_arg_name_to_reduction(self, axis):
+        axis = self._get_axis_base_name(axis)
         if not isinstance(axis, str) or not axis:
             return
-        if axis.startswith("r"):
-            return
-        reduction_axis = "r{}".format(axis)
         if self.vector_axes is None:
             self.vector_axes = self._rebuild_vector_axes()
         axis_arg_name = self.vector_axes.axis_length_exprs.get(axis, None)
+        self.vector_axes.ensure_axis(axis)
         if axis_arg_name is not None:
-            self.vector_axes.ensure_axis(reduction_axis).length_expr = axis_arg_name
-            self.vector_axes.ensure_axis(axis).length_expr = None
-        self.vector_axes.apply_semantic_fields(reduction_axes=[reduction_axis])
+            self.vector_axes.ensure_axis(axis).length_expr = axis_arg_name
+        self.vector_axes.apply_semantic_fields(reduction_axes=[axis])
         self.axis_arg_names = self._get_parser_axis_arg_names()
 
     def _init_axis_params(self, key, split_params, tiling_params, low_dim_axes, reduction_axes, hints_axes=None):
@@ -1084,24 +1080,120 @@ class AutoTilingTuner(Autotuner):
                 f"Please ensure that these arguments are passed when calling the function."
             )
 
-    def _normalize_vv_reduction_axes(self, reduction_axes: List[str]) -> List[str]:
+    @staticmethod
+    def _require_base_axis_name(axis: Optional[str]) -> Optional[str]:
+        if not isinstance(axis, str) or not axis:
+            return None
+        if axis.startswith("r"):
+            raise ValueError(
+                "r-prefixed axis names are not supported; "
+                f"use the base axis name instead of '{axis}'."
+            )
+        if axis not in valid_axis_names:
+            raise ValueError(f"Unsupported axis name '{axis}'.")
+        return axis
+
+    @staticmethod
+    def _normalize_reduction_axis_name(axis: Optional[str]) -> Optional[str]:
+        if not isinstance(axis, str) or not axis:
+            return None
+        if axis.startswith("r"):
+            raise ValueError(
+                "r-prefixed axis names are not supported; "
+                f"use the base axis name instead of '{axis}'."
+            )
+        if axis not in valid_axis_names:
+            raise ValueError(f"Unsupported axis name '{axis}'.")
+        return axis
+
+    def _normalize_reduction_axes(self, reduction_axes: List[str]) -> List[str]:
         normalized = []
         for axis in reduction_axes:
-            if not isinstance(axis, str) or not axis:
+            canonical_axis = self._normalize_reduction_axis_name(axis)
+            if canonical_axis is not None:
+                normalized.append(canonical_axis)
+        return normalized
+
+    def _normalize_vv_reduction_axes(self, reduction_axes: List[str]) -> List[str]:
+        return self._normalize_reduction_axes(reduction_axes)
+
+    def _normalize_axis_name_mapping(
+        self,
+        axis_mapping: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        normalized = {}
+        for axis, value in dict(axis_mapping or {}).items():
+            base_axis = self._get_axis_base_name(axis)
+            if not isinstance(base_axis, str) or not base_axis:
                 continue
-            if axis.startswith("r"):
-                normalized.append(axis)
-            else:
-                normalized.append("r{}".format(axis))
+            normalized.setdefault(base_axis, value)
+        return normalized
+
+    def _normalize_axis_name_list(
+        self,
+        axis_names: Optional[List[str]],
+    ) -> List[str]:
+        normalized = []
+        for axis in list(axis_names or []):
+            base_axis = self._get_axis_base_name(axis)
+            if not isinstance(base_axis, str) or not base_axis:
+                continue
+            if base_axis not in normalized:
+                normalized.append(base_axis)
         return normalized
 
     @staticmethod
     def _get_axis_base_name(axis: Optional[str]) -> Optional[str]:
         if not isinstance(axis, str) or not axis:
             return None
-        return axis[1:] if axis.startswith("r") else axis
+        if axis.startswith("r"):
+            raise ValueError(
+                "r-prefixed axis names are not supported; "
+                f"use the base axis name instead of '{axis}'."
+            )
+        if axis not in valid_axis_names:
+            raise ValueError(f"Unsupported axis name '{axis}'.")
+        return axis
 
     def _apply_vv_axis_semantic_result(self) -> bool:
+        def resolve_base_axis(axis_name):
+            resolver = getattr(self, "_get_axis_base_name", None)
+            if callable(resolver):
+                return resolver(axis_name)
+            if not isinstance(axis_name, str) or not axis_name:
+                return None
+            if axis_name.startswith("r"):
+                raise ValueError(
+                    "r-prefixed axis names are not supported; "
+                    f"use the base axis name instead of '{axis_name}'."
+                )
+            return axis_name
+
+        def normalize_axis_name_mapping(axis_mapping):
+            normalizer = getattr(self, "_normalize_axis_name_mapping", None)
+            if callable(normalizer):
+                return normalizer(axis_mapping)
+            normalized = {}
+            for axis, value in dict(axis_mapping or {}).items():
+                base_axis = resolve_base_axis(axis)
+                if not isinstance(base_axis, str) or not base_axis:
+                    continue
+                normalized.setdefault(base_axis, value)
+            return normalized
+
+        def normalize_axis_name_list(axis_names):
+            normalizer = getattr(self, "_normalize_axis_name_list", None)
+            if callable(normalizer):
+                return normalizer(axis_names)
+            normalized = []
+            for axis in list(axis_names or []):
+                base_axis = resolve_base_axis(axis)
+                if not isinstance(base_axis, str) or not base_axis:
+                    continue
+                if base_axis not in normalized:
+                    normalized.append(base_axis)
+            return normalized
+
         if self.vv_adapter_result_v2 is None:
             return False
         adapter_status = getattr(self.vv_adapter_result_v2, "status", "ok")
@@ -1109,40 +1201,43 @@ class AutoTilingTuner(Autotuner):
             return False
 
         applied = False
+        raw_adapter_reduction_axes = list(
+            getattr(self.vv_adapter_result_v2, "reduction_axes", []) or []
+        )
         adapter_reduction_axes = self._normalize_vv_reduction_axes(
-            list(getattr(self.vv_adapter_result_v2, "reduction_axes", []) or [])
+            raw_adapter_reduction_axes
+        )
+        raw_adapter_low_dim_axes = list(
+            getattr(self.vv_adapter_result_v2, "low_dim_axes", []) or []
         )
         if adapter_reduction_axes or self.reduction_axes:
             self.reduction_axes = []
             for reduction_axis in adapter_reduction_axes:
-                base_axis = reduction_axis[1:] if reduction_axis.startswith("r") else reduction_axis
-                if base_axis in self.axis_arg_names and reduction_axis not in self.axis_arg_names:
-                    self._promote_axis_arg_name_to_reduction(base_axis)
+                base_axis = resolve_base_axis(reduction_axis)
+                self._promote_axis_arg_name_to_reduction(base_axis)
             self.reduction_axes = list(adapter_reduction_axes)
             applied = True
 
-        adapter_low_dim_axes = list(
-            getattr(self.vv_adapter_result_v2, "low_dim_axes", []) or []
-        )
+        adapter_low_dim_axes = normalize_axis_name_list(raw_adapter_low_dim_axes)
         if adapter_low_dim_axes or self.low_dim_axes:
             self.low_dim_axes = list(adapter_low_dim_axes)
             applied = True
 
-        adapter_split_params = dict(
+        adapter_split_params = normalize_axis_name_mapping(
             getattr(self.vv_adapter_result_v2, "split_params", {}) or {}
         )
         if adapter_split_params or self.split_params:
             self.split_params = dict(adapter_split_params)
             applied = True
 
-        adapter_tiling_params = dict(
+        adapter_tiling_params = normalize_axis_name_mapping(
             getattr(self.vv_adapter_result_v2, "tiling_params", {}) or {}
         )
         if adapter_tiling_params or self.tiling_params:
             self.tiling_params = dict(adapter_tiling_params)
             applied = True
 
-        adapter_axis_pid_dims = dict(
+        adapter_axis_pid_dims = normalize_axis_name_mapping(
             getattr(self.vv_adapter_result_v2, "axis_pid_dims", {}) or {}
         )
         if adapter_axis_pid_dims or self.axis_pid_dims:
@@ -1296,8 +1391,6 @@ class AutoTilingTuner(Autotuner):
                 getattr(self.vv_adapter_result_v2, "axis_length_exprs", {}) or {}
             )
         axis_expr = axis_length_exprs.get(axis, None)
-        if axis_expr is None and isinstance(axis, str) and axis.startswith("r"):
-            axis_expr = axis_length_exprs.get(axis[1:], None)
         if self._is_direct_runtime_length_arg_name(axis_expr):
             return axis_expr
         parser_axis_arg_names = self._get_parser_axis_arg_names()
@@ -1647,19 +1740,14 @@ class AutoTilingTuner(Autotuner):
         if not param_upper:
             return 0
 
-        axis_lower = axis_name.lower()
-        is_reduction_axis = axis_lower.startswith("r")
-        axis_base = axis_lower[1:] if is_reduction_axis else axis_lower
-        if not axis_base:
+        axis_token = axis_name.upper()
+        if not axis_token:
             return 0
 
-        axis_token = ("R" + axis_base.upper()) if is_reduction_axis else axis_base.upper()
         if param_upper.startswith(axis_token):
             return 100
         if "_{}_".format(axis_token) in "_{}_".format(param_upper):
             return 80
-        if is_reduction_axis and axis_token in param_upper:
-            return 60
         return 0
 
     @staticmethod
@@ -1752,12 +1840,10 @@ class AutoTilingTuner(Autotuner):
                     param_name,
                     anchor_map.get(axis, None),
                 )
-                non_reduction_bonus = 1 if not axis.startswith("r") else 0
                 order_score = -axis_order.get(axis, 0)
                 score = (
                     axis_name_score,
                     anchor_score,
-                    non_reduction_bonus,
                     order_score,
                 )
                 if best_score is None or score > best_score:
@@ -1929,14 +2015,14 @@ class AutoTilingTuner(Autotuner):
         from .tile_generator import KernelMeta, TileGenerator
 
         vector_tile_inputs = self._materialize_vector_tile_inputs(kv_dict, all_args)
-        axis_sizes = vector_tile_inputs["axis_sizes"]
 
         kernel_meta = KernelMeta(
-            axis_sizes,
+            vector_tile_inputs["axis_sizes"],
             vector_tile_inputs["split_params"],
             self.fixed_split_params,
             vector_tile_inputs["tiling_params"],
             vector_tile_inputs["low_dim_axes"],
+            vector_tile_inputs["reduction_axes"],
             dtype,
             self.persistent_reduction,
             self.dual_reduction,
@@ -2530,7 +2616,10 @@ class AutoTilingTuner(Autotuner):
         Extracts the tiling axis parameters from triton kernel code.
         """
         func_ast = self.fn.parse()
-        parser = TilingAxesParser(func_ast, self._get_parser_axis_arg_names(), candidates_params)
+        parser_axis_arg_names = self._normalize_axis_name_mapping(
+            self._get_parser_axis_arg_names()
+        )
+        parser = TilingAxesParser(func_ast, parser_axis_arg_names, candidates_params)
         tiling_axes = parser.parse()
         self.tiling_params = dict(tiling_axes)
         self._refresh_vector_axes()
@@ -2545,11 +2634,13 @@ class AutoTilingTuner(Autotuner):
         Extracts the reduction axis parameters from triton kernel code.
         """
         func_ast = self.fn.parse()
-        parser = ReductionAxesParser(func_ast, self._get_parser_axis_arg_names())
-        reduction_axes = parser.parse()
-        for axis in reduction_axes:
-            self._promote_axis_arg_name_to_reduction(axis)
-        reduction_axes = [f"r{axis}" for axis in reduction_axes]
+        axis_arg_names_before = self._get_parser_axis_arg_names()
+        parser = ReductionAxesParser(func_ast, axis_arg_names_before)
+        raw_reduction_axes = parser.parse()
+        for axis in raw_reduction_axes:
+            base_axis = self._get_axis_base_name(axis)
+            self._promote_axis_arg_name_to_reduction(base_axis)
+        reduction_axes = self._normalize_reduction_axes(raw_reduction_axes)
         self.reduction_axes = list(reduction_axes)
         self._refresh_vector_axes()
 
@@ -2565,7 +2656,10 @@ class AutoTilingTuner(Autotuner):
         Extracts the low dimension axis from triton kernel code.
         """
         func_ast = self.fn.parse()
-        parser = LowDimsAxesParser(func_ast, self._get_parser_axis_arg_names())
+        parser_axis_arg_names = self._normalize_axis_name_mapping(
+            self._get_parser_axis_arg_names()
+        )
+        parser = LowDimsAxesParser(func_ast, parser_axis_arg_names)
         low_dim_axes = parser.parse()
         if len(low_dim_axes) < 1:
             if self.print_autotuning:
@@ -2599,9 +2693,8 @@ class AutoTilingTuner(Autotuner):
     def _get_persistent_reduction_threshold(self, reduction_axis: str) -> int:
         # Keep this heuristic aligned with inductor-style policy:
         # inner reduction axis uses a larger threshold than other axes.
-        # Compare on base axis name so legacy 'r'-prefixed reduction axes and
-        # unprefixed low-dim axes remain consistent during the transition away
-        # from reduction-axis name prefixes.
+        # Reduction axes are stored as base axis names; compare directly with
+        # the low-dim base axis.
         reduction_axis_base = self._get_axis_base_name(reduction_axis)
         low_dim_axis_base = (
             self._get_axis_base_name(self.low_dim_axes[0])

--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -583,6 +583,15 @@ class AutoTilingTuner(Autotuner):
         self.vector_axes = self._rebuild_vector_axes()
         self.axis_arg_names = self._get_parser_axis_arg_names()
 
+    def _reset_vector_parse_derived_state(self) -> None:
+        self.fixed_split_params = {}
+        self.fixed_grid_dims = set()
+        self.fixed_grid_dim_values = {}
+        self.split_axis_pid_dims = {}
+        self.axis_pid_dims = {}
+        self.dual_reduction = False
+        self.persistent_reduction = False
+
     def _get_parser_axis_arg_names(self) -> Dict[str, str]:
         axis_arg_names = {}
         if self.vector_axes is not None:
@@ -926,6 +935,7 @@ class AutoTilingTuner(Autotuner):
 
     def _autoparse_axis_params_vector(self, all_args):
         self.vv_gap_fill_report_v2 = None
+        self._reset_vector_parse_derived_state()
         # Normalize vector axis containers for vv-assist flow. In list-key mode
         # these fields are initialized as None, and vv may legitimately fill only
         # split/tiling/low_dim without reduction axes.
@@ -2015,6 +2025,19 @@ class AutoTilingTuner(Autotuner):
         from .tile_generator import KernelMeta, TileGenerator
 
         vector_tile_inputs = self._materialize_vector_tile_inputs(kv_dict, all_args)
+        if self.print_autotuning:
+            print(
+                "Ascend autotuning vector tile inputs: "
+                f"axis_sizes={vector_tile_inputs['axis_sizes']}, "
+                f"split_params={vector_tile_inputs['split_params']}, "
+                f"fixed_split_params={self.fixed_split_params}, "
+                f"tiling_params={vector_tile_inputs['tiling_params']}, "
+                f"low_dim_axes={vector_tile_inputs['low_dim_axes']}, "
+                f"reduction_axes={vector_tile_inputs['reduction_axes']}, "
+                f"persistent_reduction={self.persistent_reduction}, "
+                f"dual_reduction={self.dual_reduction}, "
+                f"num_buffers={self.num_buffers}"
+            )
 
         kernel_meta = KernelMeta(
             vector_tile_inputs["axis_sizes"],

--- a/third_party/ascend/backend/runtime/dsl_analysis/vv_param_parser_v2.py
+++ b/third_party/ascend/backend/runtime/dsl_analysis/vv_param_parser_v2.py
@@ -1655,14 +1655,12 @@ def _collect_reduction_axis_indices(func_node: ast.AST, axis_count: int) -> List
     return result
 
 
-def _axis_sort_key(axis_name: str) -> Tuple[int, int, str]:
-    is_reduction = axis_name.startswith("r")
-    base = axis_name[1:] if is_reduction else axis_name
+def _axis_sort_key(axis_name: str) -> Tuple[int, str]:
     try:
-        axis_index = _VALID_AXIS_NAMES.index(base)
+        axis_index = _VALID_AXIS_NAMES.index(axis_name)
     except ValueError:
         axis_index = len(_VALID_AXIS_NAMES)
-    return (axis_index, 1 if is_reduction else 0, axis_name)
+    return (axis_index, axis_name)
 
 
 def _choose_best_site_evidence(
@@ -2050,7 +2048,7 @@ def parse_vv_axis_semantic_v2(
         evidence = evidence_by_index[axis_index]
         base_axis_name = axis_name_by_index[axis_index]
         is_reduction = base_axis_name in reduction_base_axes
-        axis_name = "r{}".format(base_axis_name) if is_reduction else base_axis_name
+        axis_name = base_axis_name
 
         split, split_diag = _select_best_split(evidence.split_candidates)
         tiling, tiling_diag = _select_best_tiling(evidence.tiling_candidates, split.param)

--- a/third_party/ascend/backend/runtime/tile_generator.py
+++ b/third_party/ascend/backend/runtime/tile_generator.py
@@ -35,6 +35,7 @@ from triton.runtime.autotuner import Config
 
 from .utils import (
     get_byte_per_numel,
+    is_valid_axis_name,
     next_power_of_2,
     num_vector_core,
     ub_size_in_kbytes,
@@ -48,17 +49,13 @@ class AxisInfo:
     index: int
     length: int
 
-    prefix: str = ""
     split_name: str = ""
     tiling_name: str = ""
     is_split_axis: bool = False
     is_tunable_split_axis: bool = False
     is_tiling_axis: bool = False
+    is_reduction: bool = False
     fixed_split_size: int = 0
-
-    @property
-    def is_reduction(self):
-        return self.prefix == "r"
 
 
 class KernelMeta:
@@ -69,6 +66,7 @@ class KernelMeta:
         fixed_split_params: Dict[str, int],
         tiling_params: Dict[str, str],
         low_dims: List[str],
+        reduction_axes: List[str],
         dtype: torch.dtype,
         persistent_reduction: bool,
         dual_reduction: bool,
@@ -89,24 +87,24 @@ class KernelMeta:
         :param low_dims: a list of axis name in which the corresponding axis is low dim aixs.
             The axis name must be in key's axis names. Do not add prefix 'r' before the axis name.
         :type low_dims: List[str]
+        :param reduction_axes: a list of base axis names that are reduction axes.
+        :type reduction_axes: List[str]
         :param dual_reduction: performing reduction on more than one axis.
         :param persistent_reduction: there is no splitting in reduction axis.
         """
         self._validate_axis(
-            axis_sizes, split_params, fixed_split_params, tiling_params, low_dims
+            axis_sizes, split_params, fixed_split_params, tiling_params, low_dims, reduction_axes
         )
 
+        reduction_axis_names = set(reduction_axes or [])
         axis_dict = {}
         idx = 0
         for name, length in axis_sizes.items():
-            prefix = ""
-            if name.startswith("r"):
-                prefix = "r"
-
             is_tunable_split_axis = name in split_params
             fixed_split_size = fixed_split_params.get(name, 0)
             is_split_axis = is_tunable_split_axis or fixed_split_size > 0
             is_tiling_axis = name in tiling_params
+            is_reduction = name in reduction_axis_names
             split_name = "" if not is_tunable_split_axis else split_params[name]
             tiling_name = "" if name not in tiling_params else tiling_params[name]
 
@@ -114,12 +112,12 @@ class KernelMeta:
                 name=name,
                 index=idx,
                 length=length,
-                prefix=prefix,
                 split_name=split_name,
                 tiling_name=tiling_name,
                 is_split_axis=is_split_axis,
                 is_tunable_split_axis=is_tunable_split_axis,
                 is_tiling_axis=is_tiling_axis,
+                is_reduction=is_reduction,
                 fixed_split_size=fixed_split_size,
             )
             idx += 1
@@ -145,14 +143,17 @@ class KernelMeta:
         fixed_split_params: Dict[str, int],
         tiling_params: Dict[str, str],
         low_dims: List[str],
+        reduction_axes: List[str],
     ) -> None:
         for axis_name in axis_sizes.keys():
-            if axis_name.startswith("r") and len(axis_name) == 1:
-                raise ValueError("The name of a reduction axis is empty!")
+            if not is_valid_axis_name(axis_name):
+                raise ValueError(
+                    f"Invalid axis name '{axis_name}'. Axis names must be base axes."
+                )
 
         def check_keys(params: List[str], context="parameter"):
             for k in params:
-                if k not in axis_sizes and ("r" + k) not in axis_sizes:
+                if k not in axis_sizes:
                     raise KeyError(
                         f"{context} '{k}' not found in known axes: {axis_sizes.keys()}"
                     )
@@ -161,6 +162,13 @@ class KernelMeta:
         check_keys(fixed_split_params.keys(), "fixed split axis")
         check_keys(tiling_params.keys(), "tiling axis")
         check_keys(low_dims, "low dim axis")
+        for axis_name in list(reduction_axes or []):
+            if isinstance(axis_name, str) and axis_name.startswith("r"):
+                raise ValueError(
+                    f"r-prefixed reduction axis '{axis_name}' is not supported; "
+                    "use the base axis name and pass it through reduction_axes."
+                )
+        check_keys(reduction_axes or [], "reduction axis")
 
 
 @dataclass

--- a/third_party/ascend/backend/runtime/utils.py
+++ b/third_party/ascend/backend/runtime/utils.py
@@ -113,8 +113,6 @@ def get_byte_per_numel(dtype: torch.dtype) -> int:
 
 
 def is_valid_axis_name(name: str) -> bool:
-    if name.startswith("r"):
-        return name[1:] in valid_axis_names
     return name in valid_axis_names
 
 

--- a/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
+++ b/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
@@ -24,7 +24,7 @@ import os
 from collections.abc import Sequence
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import pytest
 import torch
@@ -32,10 +32,12 @@ import torch_npu
 import triton
 import triton.backends.ascend.runtime
 import triton.backends.ascend.runtime.autotuner as ascend_autotuner
+from triton.backends.ascend.runtime.tile_generator import KernelMeta
+from triton.backends.ascend.runtime.utils import is_valid_axis_name
 import triton.language as tl
 
 
-VALID_AXIS_NAMES = ["x", "y", "z", "w", "v", "t", "rx", "ry", "rz", "rw", "rv", "rt"]
+VALID_AXIS_NAMES = ["x", "y", "z", "w", "v", "t"]
 AUTOTUNER_PATH = Path(__file__).resolve().parents[2] / "backend" / "runtime" / "autotuner.py"
 VECTOR_AXES_PATH = Path(__file__).resolve().parents[2] / "backend" / "runtime" / "vector_axes.py"
 
@@ -63,6 +65,7 @@ def _load_autotuner_methods(*method_names):
     extracted_module = ast.Module(body=selected, type_ignores=[])
     ast.fix_missing_locations(extracted_module)
     namespace = {
+        "Any": Any,
         "Dict": Dict,
         "List": List,
         "Optional": Optional,
@@ -95,6 +98,7 @@ def _init_axis_state_for_test(
         "_parse_hints_axes",
         "_get_runtime_arg_names_for_hints_axes",
         "_infer_hints_axes_from_key",
+        "_normalize_axis_name_mapping",
         "_rebuild_vector_axes",
         "_get_parser_axis_arg_names",
         "_is_direct_runtime_length_arg_name",
@@ -117,6 +121,14 @@ def _init_axis_state_for_test(
     rebuild_vector_axes = _normalize_loaded_method(namespace.get("_rebuild_vector_axes"))
     if rebuild_vector_axes is not None:
         tuner._rebuild_vector_axes = rebuild_vector_axes.__get__(tuner, SimpleNamespace)
+    normalize_axis_name_mapping = _normalize_loaded_method(
+        namespace.get("_normalize_axis_name_mapping")
+    )
+    if normalize_axis_name_mapping is not None:
+        tuner._normalize_axis_name_mapping = normalize_axis_name_mapping.__get__(
+            tuner,
+            SimpleNamespace,
+        )
     infer_hints_axes_from_key = _normalize_loaded_method(namespace.get("_infer_hints_axes_from_key"))
     if infer_hints_axes_from_key is not None:
         tuner._infer_hints_axes_from_key = infer_hints_axes_from_key.__get__(tuner, SimpleNamespace)
@@ -416,14 +428,60 @@ def test_resolve_axis_length_arg_name_uses_base_vv_axis_expr_for_reduction_axis(
         namespace["_get_parser_axis_arg_names"]
     ).__get__(tuner, SimpleNamespace)
 
-    result = _normalize_loaded_method(namespace["_resolve_axis_length_arg_name"])(tuner, "rx")
+    result = _normalize_loaded_method(namespace["_resolve_axis_length_arg_name"])(tuner, "x")
 
     assert result == "n_elements"
 
 
+def test_is_valid_axis_name_rejects_reduction_prefix():
+    assert is_valid_axis_name("x") is True
+    assert is_valid_axis_name("rx") is False
+
+
+def test_kernel_meta_marks_reduction_axes_from_explicit_list():
+    kernel_meta = KernelMeta(
+        axis_sizes={"x": 128, "y": 64},
+        split_params={"x": "XBLOCK"},
+        fixed_split_params={},
+        tiling_params={"y": "YBLOCK_SUB"},
+        low_dims=["y"],
+        reduction_axes=["y"],
+        dtype=torch.float16,
+        persistent_reduction=True,
+        dual_reduction=False,
+        num_buffers=1,
+        is_simt_mode=False,
+    )
+
+    axis_by_name = {axis.name: axis for axis in kernel_meta.axis_info}
+    assert axis_by_name["x"].is_reduction is False
+    assert axis_by_name["y"].is_reduction is True
+    assert [axis.name for axis in kernel_meta.low_dims_axis] == ["y"]
+
+
+def test_kernel_meta_rejects_prefixed_reduction_axes():
+    with pytest.raises(ValueError, match="reduction axis"):
+        KernelMeta(
+            axis_sizes={"x": 128, "y": 64},
+            split_params={"x": "XBLOCK"},
+            fixed_split_params={},
+            tiling_params={"y": "YBLOCK_SUB"},
+            low_dims=["y"],
+            reduction_axes=["ry"],
+            dtype=torch.float16,
+            persistent_reduction=True,
+            dual_reduction=False,
+            num_buffers=1,
+            is_simt_mode=False,
+        )
+
+
 def test_apply_vv_axis_semantic_result_promotes_internal_axis_map_only():
     namespace = _load_autotuner_methods(
+        "_normalize_reduction_axis_name",
+        "_normalize_reduction_axes",
         "_normalize_vv_reduction_axes",
+        "_get_axis_base_name",
         "_get_parser_axis_arg_names",
         "_is_direct_runtime_length_arg_name",
         "_promote_axis_arg_name_to_reduction",
@@ -449,9 +507,18 @@ def test_apply_vv_axis_semantic_result_promotes_internal_axis_map_only():
         keys=["n_elements"],
         dual_reduction=False,
     )
+    tuner._normalize_reduction_axis_name = _normalize_loaded_method(
+        namespace["_normalize_reduction_axis_name"]
+    )
+    tuner._normalize_reduction_axes = _normalize_loaded_method(
+        namespace["_normalize_reduction_axes"]
+    ).__get__(tuner, SimpleNamespace)
     tuner._normalize_vv_reduction_axes = _normalize_loaded_method(
         namespace["_normalize_vv_reduction_axes"]
     ).__get__(tuner, SimpleNamespace)
+    tuner._get_axis_base_name = _normalize_loaded_method(
+        namespace["_get_axis_base_name"]
+    )
     tuner._get_parser_axis_arg_names = _normalize_loaded_method(
         namespace["_get_parser_axis_arg_names"]
     ).__get__(tuner, SimpleNamespace)
@@ -469,15 +536,47 @@ def test_apply_vv_axis_semantic_result_promotes_internal_axis_map_only():
 
     assert applied is True
     assert tuner.keys == ["n_elements"]
-    assert tuner.axis_arg_names == {"rx": "n_elements"}
-    assert tuner.reduction_axes == ["rx"]
+    assert tuner.axis_arg_names == {"x": "n_elements"}
+    assert tuner.reduction_axes == ["x"]
+
+
+def test_promote_reduction_axis_rejects_prefixed_axis_name():
+    namespace = _load_autotuner_methods(
+        "_get_axis_base_name",
+        "_get_parser_axis_arg_names",
+        "_is_direct_runtime_length_arg_name",
+        "_promote_axis_arg_name_to_reduction",
+    )
+    vector_axes_module = _load_vector_axes_module()
+    vector_axes = vector_axes_module.VectorAxes.from_hints_axes({"y": "r1_numel"})
+    tuner = SimpleNamespace(
+        vector_axes=vector_axes,
+        axis_arg_names={"y": "r1_numel"},
+    )
+    tuner._get_axis_base_name = _normalize_loaded_method(
+        namespace["_get_axis_base_name"]
+    )
+    tuner._get_parser_axis_arg_names = _normalize_loaded_method(
+        namespace["_get_parser_axis_arg_names"]
+    ).__get__(tuner, SimpleNamespace)
+    tuner._is_direct_runtime_length_arg_name = _normalize_loaded_method(
+        namespace["_is_direct_runtime_length_arg_name"]
+    )
+    tuner._promote_axis_arg_name_to_reduction = _normalize_loaded_method(
+        namespace["_promote_axis_arg_name_to_reduction"]
+    ).__get__(tuner, SimpleNamespace)
+
+    with pytest.raises(ValueError, match="r-prefixed"):
+        tuner._promote_axis_arg_name_to_reduction("ry")
 
 
 def test_generate_key_and_configs_uses_axis_arg_names_for_kv_dict():
     namespace = _load_autotuner_methods(
         "_parse_hints_axes",
         "_get_runtime_arg_names_for_hints_axes",
+        "_normalize_axis_name_mapping",
         "_rebuild_vector_axes",
+        "_get_axis_base_name",
         "_get_parser_axis_arg_names",
         "_is_direct_runtime_length_arg_name",
         "_promote_axis_arg_name_to_reduction",
@@ -522,6 +621,12 @@ def test_generate_key_and_configs_uses_axis_arg_names_for_kv_dict():
     tuner._rebuild_vector_axes = _normalize_loaded_method(
         namespace["_rebuild_vector_axes"]
     ).__get__(tuner, SimpleNamespace)
+    tuner._get_axis_base_name = _normalize_loaded_method(
+        namespace["_get_axis_base_name"]
+    )
+    tuner._normalize_axis_name_mapping = _normalize_loaded_method(
+        namespace["_normalize_axis_name_mapping"]
+    ).__get__(tuner, SimpleNamespace)
     tuner._get_parser_axis_arg_names = _normalize_loaded_method(
         namespace["_get_parser_axis_arg_names"]
     ).__get__(tuner, SimpleNamespace)
@@ -556,7 +661,9 @@ def test_generate_key_and_configs_preserves_promoted_reduction_axis_identity():
     namespace = _load_autotuner_methods(
         "_parse_hints_axes",
         "_get_runtime_arg_names_for_hints_axes",
+        "_normalize_axis_name_mapping",
         "_rebuild_vector_axes",
+        "_get_axis_base_name",
         "_get_parser_axis_arg_names",
         "_is_direct_runtime_length_arg_name",
         "_promote_axis_arg_name_to_reduction",
@@ -595,6 +702,12 @@ def test_generate_key_and_configs_preserves_promoted_reduction_axis_identity():
     tuner._rebuild_vector_axes = _normalize_loaded_method(
         namespace["_rebuild_vector_axes"]
     ).__get__(tuner, SimpleNamespace)
+    tuner._get_axis_base_name = _normalize_loaded_method(
+        namespace["_get_axis_base_name"]
+    )
+    tuner._normalize_axis_name_mapping = _normalize_loaded_method(
+        namespace["_normalize_axis_name_mapping"]
+    ).__get__(tuner, SimpleNamespace)
     tuner._get_parser_axis_arg_names = _normalize_loaded_method(
         namespace["_get_parser_axis_arg_names"]
     ).__get__(tuner, SimpleNamespace)
@@ -623,7 +736,154 @@ def test_generate_key_and_configs_preserves_promoted_reduction_axis_identity():
     )
 
     assert tuner.keys == ["n_elements"]
-    assert captured["kv_dict"] == {"rx": 23}
+    assert captured["kv_dict"] == {"x": 23}
+
+
+def test_refresh_vector_axes_keeps_base_axis_arg_names_without_reduction_aliases():
+    namespace = _load_autotuner_methods(
+        "_parse_hints_axes",
+        "_get_runtime_arg_names_for_hints_axes",
+        "_normalize_axis_name_mapping",
+        "_rebuild_vector_axes",
+        "_get_axis_base_name",
+        "_get_parser_axis_arg_names",
+        "_is_direct_runtime_length_arg_name",
+        "_promote_axis_arg_name_to_reduction",
+        "_refresh_vector_axes",
+        "_init_axis_params",
+        "generate_key_and_configs",
+    )
+    captured = {}
+
+    class FakeArg:
+        dtype = "float16"
+
+    namespace["get_byte_per_numel"] = lambda dtype: 0 if dtype is None else 1
+    namespace["_expand_configs_with_hints"] = lambda fn, configs, config_hints: configs
+
+    tuner = SimpleNamespace(
+        arg_names=["x_ptr", "n_elements"],
+        fn=SimpleNamespace(),
+        _get_constexpr_candidates=lambda: [],
+        cache={},
+        auto_gen_config=True,
+        parser_mode="vector",
+        config_hints={},
+        gen_configs=[],
+        user_configs=[],
+        is_simt_mode=False,
+        user_specified_warps=None,
+        user_specified_multibuffer=None,
+        _autoparse_axis_params=lambda all_args: None,
+        _gen_tile_configs=lambda kv_dict, dtype, all_args: captured.update(kv_dict=dict(kv_dict))
+        or setattr(tuner, "gen_configs", [SimpleNamespace(kwargs={"BLOCK_SIZE": 128})]),
+    )
+    tuner._parse_hints_axes = _normalize_loaded_method(namespace["_parse_hints_axes"]).__get__(tuner, SimpleNamespace)
+    tuner._get_runtime_arg_names_for_hints_axes = _normalize_loaded_method(
+        namespace["_get_runtime_arg_names_for_hints_axes"]
+    ).__get__(tuner, SimpleNamespace)
+    tuner._rebuild_vector_axes = _normalize_loaded_method(
+        namespace["_rebuild_vector_axes"]
+    ).__get__(tuner, SimpleNamespace)
+    tuner._get_axis_base_name = _normalize_loaded_method(
+        namespace["_get_axis_base_name"]
+    )
+    tuner._normalize_axis_name_mapping = _normalize_loaded_method(
+        namespace["_normalize_axis_name_mapping"]
+    ).__get__(tuner, SimpleNamespace)
+    tuner._get_parser_axis_arg_names = _normalize_loaded_method(
+        namespace["_get_parser_axis_arg_names"]
+    ).__get__(tuner, SimpleNamespace)
+    tuner._is_direct_runtime_length_arg_name = _normalize_loaded_method(
+        namespace["_is_direct_runtime_length_arg_name"]
+    )
+    tuner._promote_axis_arg_name_to_reduction = _normalize_loaded_method(
+        namespace["_promote_axis_arg_name_to_reduction"]
+    ).__get__(tuner, SimpleNamespace)
+    tuner._refresh_vector_axes = _normalize_loaded_method(
+        namespace["_refresh_vector_axes"]
+    ).__get__(tuner, SimpleNamespace)
+
+    _normalize_loaded_method(namespace["_init_axis_params"])(
+        tuner,
+        ["n_elements"],
+        None,
+        None,
+        None,
+        None,
+        {"x": "n_elements"},
+    )
+
+    tuner.reduction_axes = []
+    tuner._refresh_vector_axes()
+
+    _normalize_loaded_method(namespace["generate_key_and_configs"])(
+        tuner,
+        FakeArg(),
+        29,
+    )
+
+    assert tuner.axis_arg_names == {"x": "n_elements"}
+    assert captured["kv_dict"] == {"x": 29}
+
+
+def test_legacy_low_dim_and_tiling_parsers_consume_base_axis_names():
+    namespace = _load_autotuner_methods(
+        "_get_axis_base_name",
+        "_normalize_axis_name_mapping",
+        "_autoparse_tiling_params",
+        "_autoparse_low_dim_axes",
+    )
+    parser_inputs = {}
+
+    class StubTilingAxesParser:
+        def __init__(self, func_ast, axis_arg_names, candidates_params):
+            parser_inputs["tiling"] = dict(axis_arg_names)
+
+        def parse(self):
+            return {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"}
+
+    class StubLowDimsAxesParser:
+        def __init__(self, func_ast, axis_arg_names):
+            parser_inputs["low_dim"] = dict(axis_arg_names)
+
+        def parse(self):
+            return ["y"]
+
+    namespace["TilingAxesParser"] = StubTilingAxesParser
+    namespace["LowDimsAxesParser"] = StubLowDimsAxesParser
+
+    refresh_calls = []
+    tuner = SimpleNamespace(
+        fn=SimpleNamespace(parse=lambda: "fake-func-ast"),
+        print_autotuning=False,
+        tiling_params={},
+        low_dim_axes=[],
+        _get_parser_axis_arg_names=lambda: {"x": "x0_numel", "y": "r1_numel"},
+        _refresh_vector_axes=lambda: refresh_calls.append(True),
+    )
+    tuner._get_axis_base_name = _normalize_loaded_method(
+        namespace["_get_axis_base_name"]
+    )
+    tuner._normalize_axis_name_mapping = _normalize_loaded_method(
+        namespace["_normalize_axis_name_mapping"]
+    ).__get__(tuner, SimpleNamespace)
+
+    tiling_params = _normalize_loaded_method(namespace["_autoparse_tiling_params"])(
+        tuner,
+        ["X0BLOCK_SUB", "R1BLOCK_SUB"],
+    )
+    low_dim_axes = _normalize_loaded_method(namespace["_autoparse_low_dim_axes"])(
+        tuner
+    )
+
+    assert parser_inputs["tiling"] == {"x": "x0_numel", "y": "r1_numel"}
+    assert parser_inputs["low_dim"] == {"x": "x0_numel", "y": "r1_numel"}
+    assert tiling_params == {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"}
+    assert tuner.tiling_params == {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"}
+    assert low_dim_axes == ["y"]
+    assert tuner.low_dim_axes == ["y"]
+    assert refresh_calls == [True, True]
 
 
 def test_parse_vv_axis_info_v2_collects_fixed_tiling_expr_for_provided_constexpr():
@@ -1361,3 +1621,75 @@ def test_expand_simt_num_warps_configs_default_candidates():
 
     assert len(expanded_configs) == 4
     assert [cfg.num_warps for cfg in expanded_configs] == [8, 16, 32, 64]
+
+
+@pytest.mark.parametrize(
+    "axis",
+    [
+        "x",
+        "y",
+        "z",
+    ],
+)
+def test_normalize_reduction_axis_name_accepts_base_axes_only(axis):
+    namespace = _load_autotuner_methods("_normalize_reduction_axis_name")
+
+    result = _normalize_loaded_method(namespace["_normalize_reduction_axis_name"])(axis)
+
+    assert result == axis
+
+
+@pytest.mark.parametrize("axis", ["rx", "ry", "rry"])
+def test_normalize_reduction_axis_name_rejects_prefixed_axes(axis):
+    namespace = _load_autotuner_methods("_normalize_reduction_axis_name")
+
+    with pytest.raises(ValueError, match="r-prefixed"):
+        _normalize_loaded_method(namespace["_normalize_reduction_axis_name"])(axis)
+
+
+def test_autoparse_reduction_axes_rejects_prefixed_parser_output():
+    namespace = _load_autotuner_methods(
+        "_normalize_reduction_axis_name",
+        "_normalize_reduction_axes",
+        "_get_axis_base_name",
+        "_autoparse_reduction_axes",
+    )
+
+    class StubReductionAxesParser:
+        def __init__(self, func_ast, axis_arg_names):
+            self.func_ast = func_ast
+            self.axis_arg_names = axis_arg_names
+
+        def parse(self):
+            return ["ry"]
+
+    namespace["ReductionAxesParser"] = StubReductionAxesParser
+
+    promoted_axes = []
+    refresh_calls = []
+
+    tuner = SimpleNamespace(
+        fn=SimpleNamespace(parse=lambda: "fake-func-ast"),
+        axis_arg_names={"x": "seq_len", "y": "dim"},
+        reduction_axes=[],
+        print_autotuning=False,
+        _get_parser_axis_arg_names=lambda: {"x": "seq_len", "y": "dim"},
+        _promote_axis_arg_name_to_reduction=lambda axis: promoted_axes.append(axis),
+        _refresh_vector_axes=lambda: refresh_calls.append(True),
+    )
+    tuner._get_axis_base_name = _normalize_loaded_method(
+        namespace["_get_axis_base_name"]
+    )
+    tuner._normalize_reduction_axis_name = _normalize_loaded_method(
+        namespace["_normalize_reduction_axis_name"]
+    )
+    tuner._normalize_reduction_axes = _normalize_loaded_method(
+        namespace["_normalize_reduction_axes"]
+    ).__get__(tuner, SimpleNamespace)
+
+    with pytest.raises(ValueError, match="r-prefixed"):
+        _normalize_loaded_method(namespace["_autoparse_reduction_axes"])(tuner)
+
+    assert promoted_axes == []
+    assert tuner.reduction_axes == []
+    assert refresh_calls == []

--- a/third_party/ascend/unittest/autotune_ut/test_common.py
+++ b/third_party/ascend/unittest/autotune_ut/test_common.py
@@ -106,10 +106,20 @@ def check_axes_parse_res(act: dict, ref: dict):
 
     assert set(ref_axis_lengths.values()) == set(act_axis_lengths.values()), \
         f"Semantic dimensions mismatch: ref={set(ref_axis_lengths.values())}, act={set(act_axis_lengths.values())}"
-    
+
+    def resolve_symbol(sym: str, sym_to_sem: dict) -> str:
+        if sym in sym_to_sem:
+            return sym
+        if isinstance(sym, str) and sym.startswith("r") and sym[1:] in sym_to_sem:
+            return sym[1:]
+        raise KeyError(sym)
+
     def normalize_param_dict(param_dict: dict, sym_to_sem: dict) -> dict:
         """Convert {symbol: value} -> {semantic: value}"""
-        return {sym_to_sem[sym]: value for sym, value in param_dict.items()}
+        return {
+            sym_to_sem[resolve_symbol(sym, sym_to_sem)]: value
+            for sym, value in param_dict.items()
+        }
 
     ref_split = normalize_param_dict(ref_state["split_params"], ref_axis_lengths)
     act_split = normalize_param_dict(act_state["split_params"], act_axis_lengths)
@@ -118,14 +128,14 @@ def check_axes_parse_res(act: dict, ref: dict):
     act_tiling = normalize_param_dict(act_state["tiling_params"], act_axis_lengths)
 
     def normalize_axis_list(axis_list: list, sym_to_sem: dict) -> list:
-        return sorted(sym_to_sem[sym] for sym in axis_list)
+        return sorted(sym_to_sem[resolve_symbol(sym, sym_to_sem)] for sym in axis_list)
 
     ref_low = normalize_axis_list(ref_state["low_dim_axes"], ref_axis_lengths)
     act_low = normalize_axis_list(act_state["low_dim_axes"], act_axis_lengths)
 
     ref_red = normalize_axis_list(ref_state["reduction_axes"], ref_axis_lengths)
     act_red = normalize_axis_list(act_state["reduction_axes"], act_axis_lengths)
-    
+
     # Compare normalized structures
     assert ref_split == act_split, f"split_params mismatch: {ref_split} vs {act_split}"
     assert ref_tiling == act_tiling, f"tiling_params mismatch: {ref_tiling} vs {act_tiling}"

--- a/third_party/ascend/unittest/autotune_ut/test_low_dim_axes_parse.py
+++ b/third_party/ascend/unittest/autotune_ut/test_low_dim_axes_parse.py
@@ -27,9 +27,9 @@ import triton.language as tl
 
 
 def _mock_single_reduction_axis(self):
-    self.vector_axes.ensure_axis("rx").length_expr = "n_elements"
-    self.vector_axes.apply_semantic_fields(reduction_axes=["rx"])
-    return ["rx"]
+    self.vector_axes.ensure_axis("x").length_expr = "n_elements"
+    self.vector_axes.apply_semantic_fields(reduction_axes=["x"])
+    return ["x"]
 
 
 def _mock_apply_vv_with_low_dim_axes(orig_apply, low_dim_axes):
@@ -138,7 +138,7 @@ def test_low_dim_axis_parse_empty_no_persistent_reduction_index_error(mock_autot
         act_res = triton_low_dim_axis_parse_guard_case[(1,)]()
 
     assert act_res["low_dim_axes"] == ["x"]
-    assert act_res["reduction_axes"] == ["rx"]
+    assert act_res["reduction_axes"] == ["x"]
 
 
 def test_persistent_reduction_inner_axis_threshold(mock_autotuner):
@@ -166,7 +166,7 @@ def test_persistent_reduction_inner_axis_threshold(mock_autotuner):
     ), mock.patch.object(
         AutoTilingTuner, "_autoparse_reduction_axes", new=_mock_single_reduction_axis
     ), mock.patch.object(
-        AutoTilingTuner, "_autoparse_low_dim_axes", return_value=["rx"]
+        AutoTilingTuner, "_autoparse_low_dim_axes", return_value=["x"]
     ), mock.patch.object(
         AutoTilingTuner, "_autoparse_split_params", return_value={}
     ), mock.patch.object(

--- a/third_party/ascend/unittest/autotune_ut/test_reduction_axes_parse.py
+++ b/third_party/ascend/unittest/autotune_ut/test_reduction_axes_parse.py
@@ -25,6 +25,24 @@ import triton
 import triton.language as tl
 
 
+def assert_outward_semantic_axes_state(act_res, ref_res):
+    assert act_res["keys"] == ref_res["keys"]
+    assert act_res["split_params"] == ref_res["split_params"]
+    assert act_res["tiling_params"] == ref_res["tiling_params"]
+    assert act_res["low_dim_axes"] == ref_res["low_dim_axes"]
+    assert act_res["reduction_axes"] == ref_res["reduction_axes"]
+
+
+def assert_vv_parser_semantic_axes_state(act_res, ref_res):
+    vv_parse_result = act_res["vv_parse_result_v2"]
+    assert vv_parse_result is not None
+    assert vv_parse_result.axis_length_exprs == ref_res["keys"]
+    assert vv_parse_result.split_params == ref_res["split_params"]
+    assert vv_parse_result.tiling_params == ref_res["tiling_params"]
+    assert vv_parse_result.low_dim_axes == ref_res["low_dim_axes"]
+    assert vv_parse_result.reduction_axes == ref_res["reduction_axes"]
+
+
 def test_triton_max_last_dim_case1(mock_autotuner):
     import triton.backends.ascend.runtime
 
@@ -61,15 +79,17 @@ def test_triton_max_last_dim_case1(mock_autotuner):
             tl.store(out_ptr0 + x0, block_res, x0_mask)
 
     ref_res = {
-        "keys": {"x": "x0_numel", "ry": "r1_numel"},
+        "keys": {"x": "x0_numel", "y": "r1_numel"},
         "split_params": {"x": "X0BLOCK"},
-        "tiling_params": {"x": "X0BLOCK_SUB", "ry": "R1BLOCK_SUB"},
-        "low_dim_axes": ["ry"],
-        "reduction_axes": ["ry"],
+        "tiling_params": {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"},
+        "low_dim_axes": ["y"],
+        "reduction_axes": ["y"],
     }
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_max_last_dim1[grid]()
 
+    assert_outward_semantic_axes_state(act_res, ref_res)
+    assert_vv_parser_semantic_axes_state(act_res, ref_res)
     check_axes_parse_res(act_res, ref_res)
 
 
@@ -109,15 +129,17 @@ def test_triton_max_last_dim_case2(mock_autotuner):
             tl.store(out_ptr0 + x0, block_res, x0_mask)
 
     ref_res = {
-        "keys": {"x": "x0_numel", "ry": "r1_numel"},
+        "keys": {"x": "x0_numel", "y": "r1_numel"},
         "split_params": {"x": "X0BLOCK"},
-        "tiling_params": {"x": "X0BLOCK_SUB", "ry": "R1BLOCK_SUB"},
-        "low_dim_axes": ["ry"],
-        "reduction_axes": ["ry"],
+        "tiling_params": {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"},
+        "low_dim_axes": ["y"],
+        "reduction_axes": ["y"],
     }
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_max_last_dim2[grid]()
 
+    assert_outward_semantic_axes_state(act_res, ref_res)
+    assert_vv_parser_semantic_axes_state(act_res, ref_res)
     check_axes_parse_res(act_res, ref_res)
 
 
@@ -157,15 +179,17 @@ def test_triton_max_last_dim_case3(mock_autotuner):
             tl.store(out_ptr0 + x0, block_res, x0_mask)
 
     ref_res = {
-        "keys": {"x": "x0_numel", "ry": "r1_numel"},
+        "keys": {"x": "x0_numel", "y": "r1_numel"},
         "split_params": {"x": "X0BLOCK"},
-        "tiling_params": {"x": "X0BLOCK_SUB", "ry": "R1BLOCK_SUB"},
-        "low_dim_axes": ["ry"],
-        "reduction_axes": ["ry"],
+        "tiling_params": {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"},
+        "low_dim_axes": ["y"],
+        "reduction_axes": ["y"],
     }
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_max_last_dim3[grid]()
 
+    assert_outward_semantic_axes_state(act_res, ref_res)
+    assert_vv_parser_semantic_axes_state(act_res, ref_res)
     check_axes_parse_res(act_res, ref_res)
 
 
@@ -206,12 +230,14 @@ def test_reduction_axes_parse_kernel_type_vector_auto_consistency(mock_autotuner
             tl.store(out_ptr0 + x0, block_res, x0_mask)
 
     ref_res = {
-        "keys": {"x": "x0_numel", "ry": "r1_numel"},
+        "keys": {"x": "x0_numel", "y": "r1_numel"},
         "split_params": {"x": "X0BLOCK"},
-        "tiling_params": {"x": "X0BLOCK_SUB", "ry": "R1BLOCK_SUB"},
-        "low_dim_axes": ["ry"],
-        "reduction_axes": ["ry"],
+        "tiling_params": {"x": "X0BLOCK_SUB", "y": "R1BLOCK_SUB"},
+        "low_dim_axes": ["y"],
+        "reduction_axes": ["y"],
     }
     grid = lambda meta: (meta["X0BLOCK"],)
     act_res = triton_reduction_axes_parse_kernel_type_vector_auto_consistency[grid]()
+    assert_outward_semantic_axes_state(act_res, ref_res)
+    assert_vv_parser_semantic_axes_state(act_res, ref_res)
     check_axes_parse_res(act_res, ref_res)

--- a/third_party/ascend/unittest/autotune_ut/test_vector_parse_state_reset.py
+++ b/third_party/ascend/unittest/autotune_ut/test_vector_parse_state_reset.py
@@ -1,0 +1,109 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import unittest.mock as mock
+
+import triton
+import triton.language as tl
+
+
+def _axis_bases(axes):
+    return [axis[1:] if isinstance(axis, str) and axis.startswith("r") else axis for axis in axes]
+
+
+def _run_autoparse_and_generate(tuner, all_args):
+    tuner.nargs = {}
+    tuner.is_simt_mode = False
+    tuner.user_specified_multibuffer = None
+    tuner.user_specified_num_stages = None
+    tuner.user_specified_warps = None
+    dtype = all_args["x_ptr"].dtype
+    tuner._autoparse_axis_params(all_args)
+    tuner._gen_tile_configs({"x": all_args["n_cols"]}, dtype, all_args)
+    return {
+        "persistent_reduction": tuner.persistent_reduction,
+        "gen_configs": [dict(config.kwargs) for config in tuner.gen_configs],
+        "reduction_axes": list(tuner.reduction_axes or []),
+        "low_dim_axes": list(tuner.low_dim_axes or []),
+        "tiling_params": dict(tuner.tiling_params or {}),
+    }
+
+
+class _FakeTensor:
+    def __init__(self, dtype):
+        self.dtype = dtype
+
+
+def test_vector_parse_state_resets_persistent_reduction_between_shapes():
+    import torch
+    import triton.backends.ascend.runtime
+
+    @triton.autotune(
+        configs=[],
+        key=["n_cols"],
+        hints={"auto_gen_config": True},
+    )
+    @triton.jit
+    def poly_norm_like_kernel(
+        x_ptr,
+        y_ptr,
+        n_cols,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        acc = tl.zeros([], dtype=tl.float32)
+        for start in range(0, n_cols, BLOCK_SIZE):
+            offsets = start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_cols
+            x = tl.load(x_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+            acc += tl.sum(x * x, axis=0)
+        scale = acc / n_cols
+        for start in range(0, n_cols, BLOCK_SIZE):
+            offsets = start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_cols
+            x = tl.load(x_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+            tl.store(y_ptr + offsets, x * scale, mask=mask)
+
+    tuner = poly_norm_like_kernel
+    fake_x = _FakeTensor(torch.bfloat16)
+    fake_y = _FakeTensor(torch.bfloat16)
+
+    with mock.patch(
+        "triton.backends.ascend.runtime.autotuner.get_byte_per_numel",
+        lambda dtype: 2,
+    ):
+        small = _run_autoparse_and_generate(
+            tuner,
+            {"x_ptr": fake_x, "y_ptr": fake_y, "n_cols": 1024},
+        )
+        large = _run_autoparse_and_generate(
+            tuner,
+            {"x_ptr": fake_x, "y_ptr": fake_y, "n_cols": 32768},
+        )
+
+    assert small["persistent_reduction"] is True
+    assert large["tiling_params"] == {"x": "BLOCK_SIZE"}
+    assert large["low_dim_axes"] == ["x"]
+    assert _axis_bases(large["reduction_axes"]) == ["x"]
+    assert large["persistent_reduction"] is False
+    assert large["gen_configs"]
+    assert any(
+        config.get("BLOCK_SIZE", 0) <= 8192
+        for config in large["gen_configs"]
+    )


### PR DESCRIPTION
Backport of #232 and #263 onto `release/3.2.2`.

## Relationship between the two upstream PRs

- #263 was developed on top of #232 on `release/3.2.2-dev`.
- This backport keeps both changes together in the same release branch so the dependency stays intact.

## Commit structure

This branch intentionally contains only 2 business commits:

1. `[release/3.2.2][Autotune] Backport #232 normalize duplicate reduction axis`
2. `[release/3.2.2][Autotune] Backport #263 reset vector parse derived state`

## Supersedes

- Supersedes #146.
- This PR does not modify #146.
- This PR also does not touch #262, which still targets `release/3.2.2-dev`.

## Validation attempted in this environment

Tried to run:

```bash
python -m pytest third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py third_party/ascend/unittest/autotune_ut/test_low_dim_axes_parse.py third_party/ascend/unittest/autotune_ut/test_reduction_axes_parse.py -q
python -m pytest third_party/ascend/unittest/autotune_ut/test_vector_parse_state_reset.py -q
python -m pytest third_party/ascend/unittest/autotune_ut -q
```

In this Codex Windows environment, pytest collection stopped before execution because `triton` and `torch_npu` are unavailable, and local build prerequisites such as `cmake`, `ninja`, and `clang` are also missing.
