### PR TITLE
[release/3.2.2-dev][ControlFlowOpt] Add impl of PtrAnalysis and lit tests

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -1048,6 +1048,12 @@ def ttir_to_npubin(mod, metadata, opt):
                         f"--append-bisheng-options={bisheng_options}"
                     ]
 
+            # Enable SIMT auto-blockify when TRITON_ALL_BLOCKS_PARALLEL is set,
+            # mirroring the SIMD compile paths. driver.py's runtime block-count
+            # cap keys off the same env switch, so the two stay in sync.
+            if _is_auto_map_parallel_blocks_enabled():
+                _compile_option_list += ["--enable-auto-blockify-loop"]
+
         npu_compiler_path, env = _get_npucompiler_path()
         cmd_list = (
             [npu_compiler_path, src_path]

--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -951,7 +951,7 @@ class NPUOptions:
     enable_vf_fusion: bool = None
     # todo: this code will be removed in version 530.
     add_auto_scheduling: bool = False
-    enable_dynamic_cv_pipeline: bool = False
+    enable_dynamic_cv_pipeline: bool = True if is_compile_on_910_95 else False
     hfusion_enable_multiple_consumer_fusion: bool = False
     has_auto_blockify_blacklist_op: Optional[bool] = None
     intra_cache_num: int = None

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
@@ -1291,7 +1291,10 @@ void UpdateConditionInfoPass::runOnOperation()
   // Step2:Update the conditions of ifOp based on the intraCoreDependentMap and crossCoreDependentMap
   int updateResult = updateIfConds(module, ssbufferPtrs);
     
-  assert(updateResult == UPDATE_CONDITION_INFO_SUCCESS && "updateIfConds failed!");
+  if (updateResult != UPDATE_CONDITION_INFO_SUCCESS) {
+    LDBG("updateIfConds failed!");
+    signalPassFailure();
+  }
 
   LDBG("Exit UpdateConditionInfo pass." << "\n");
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.cpp
@@ -1044,23 +1044,38 @@ void UpdateLoopIterTimesPass::runOnOperation()
   DenseMap<int, SmallVector<Operation *>> cmap;
   DenseMap<int, SmallVector<Operation *>> vmap;
   ret = GetMainLoopIdToLoopOpMap(module, cmap, vmap);
-  assert(ret == 0 && "GetMainLoopIdToLoopOpMap Failed!");
+  if (ret != 0) {
+    LDBG("GetMainLoopIdToLoopOpMap Failed!");
+    signalPassFailure();
+  }
 
   // step2: Calculate info for each loop operation, store into the same iterationTimesinfoMap
   DenseMap<Operation *, IterationTimesInfo> infoMap;
   ret = ComputeMainLoopTimes(cmap, infoMap);
-  assert(ret == 0 && "ComputeMainLoopTimes from cube Failed!");
+  if (ret != 0) {
+    LDBG("ComputeMainLoopTimes from cube Failed!");
+    signalPassFailure();
+  }
   ret = ComputeMainLoopTimes(vmap, infoMap);
-  assert(ret == 0 && "ComputeMainLoopTimes from vector Failed!");
+  if (ret != 0) {
+    LDBG("ComputeMainLoopTimes from vector Failed!");
+    signalPassFailure();
+  }
 
   // step3: Update loop iteration count (process loop operations with same id from both cmap and vmap)
   ret = UpdateForLoopIteration(cmap, vmap, infoMap);
-  assert(ret == 0 && "Update ForLoop Iteration Failed!");
+  if (ret != 0) {
+    LDBG("Update ForLoop Iteration Failed!");
+    signalPassFailure();
+  }
   LDBG("after UpdateForLoopIteration:\n" << module);
 
   // step4: Replace loop counter by if blocks' counter
   ret = replaceForOpCounterInIfOps();
-  assert(ret == 0 && "replaceForOpCounterInIfOps Failed!");
+  if (ret != 0) {
+    LDBG("replaceForOpCounterInIfOps Failed!");
+    signalPassFailure();
+  }
 
   LDBG("after updateloopitertimes:\n" << module);
   LDBG("\nExit UpdateLoopIterTimes pass.");

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
@@ -41,9 +41,15 @@ using namespace triton;
 namespace {
 
 static constexpr llvm::StringLiteral interceptrFunc[] {
+  "_attn_fwd",
   "_attn_bwd",
   "_kernel_matmul_fp8_row_non_persistent",
   "bmm_kernel",
+  "lightning_indexer_grad_kernel",
+  "backward_dkdv",
+  "backward_dq",
+  "backward_sum_o_do",
+  "forward_kernel",
 };
 
 static LogicalResult verifyFuncNames(ModuleOp module)

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
@@ -32,6 +32,7 @@
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/CastInterfaces.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
@@ -481,7 +482,7 @@ static FillInfo splitSCFIfIfNeeded(FillInfo &info) {
  * @return LogicalResult Returns success if unification was performed, failure otherwise
  */
 static LogicalResult tryUnifyForAlloc(memref::AllocOp allocOp, 
-                                      const CVPipeline::MemoryDependenceGraph &memGraph, 
+                                      const CVPipeline::MemoryDependenceGraph &memGraph,
                                       CVPipeline::ComputeBlockIdManager &bm) {
   // Step1: Collect direct users (excluding linalg.fill)
   Value allocResult = allocOp.getResult();
@@ -568,11 +569,17 @@ public:
     CVPipeline::MemoryDependenceGraph memGraph(module, aa);
     auto bm = CVPipeline::ComputeBlockIdManager(module);
 
+    llvm::SmallVector<memref::AllocOp> allocOps;
+
     module.walk([&](memref::AllocOp allocOp) {
+      allocOps.push_back(allocOp);
+    });
+    
+    for (memref::AllocOp allocOp: allocOps) {
       if (failed(tryUnifyForAlloc(allocOp, memGraph, bm))) {
         signalPassFailure();
       }
-    });
+    }
 
     LOG_DEBUG("After: " << *module << "\n");
   }

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -213,8 +213,11 @@ void DataDependencyAnalysisPass::collectDepInfo(mlir::Value depvalue, Dependency
     depInfo.iniProducerBlockId = iniProdId;
     depInfo.iniConsumerBlockId = iniConsId;
     std::pair<int, int> commonLevelIds = findCommonLevelBlockIds(info, iniProdId, iniConsId);
-    assert(commonLevelIds.first != -1 && commonLevelIds.second != -1 &&
-        "Could not find common level block IDs for producer and consumer blocks");
+    if (commonLevelIds.first == -1 || commonLevelIds.second == -1) {
+        LOG_DEBUG("Could not find common level block IDs for producer and consumer blocks");
+        signalPassFailure();
+    }
+
     depInfo.producerBlockId = commonLevelIds.first;
     depInfo.consumerBlockId = commonLevelIds.second;
 
@@ -232,7 +235,10 @@ llvm::SmallVector<mlir::Operation *> DataDependencyAnalysisPass::collectDiffCore
         if (isa<scf::YieldOp>(user)) {
             continue;
         }
-        assert(!isControlFlowOp(user) && "warning: cannot process nested iterarg!");
+        if (isControlFlowOp(user)) {
+            LOG_DEBUG("cannot process nested iterarg!");
+            signalPassFailure();
+        }
 
         auto userCoreType = getCoreTypeWithIndex(user, 0);
         if (userCoreType != initCoreType && !userCoreType.empty()) {
@@ -342,7 +348,10 @@ void DataDependencyAnalysisPass::processIterArgDependencies()
             
             // Only process if init and yield have matching core types
             // Mismatch indicates a more complex dependency pattern that requires special handling
-            assert(initCoreType == yieldCoreType && "iterarg init core_type conflicts with yield");
+            if (initCoreType != yieldCoreType) {
+                LOG_DEBUG("iterarg init core_type conflicts with yield");
+                signalPassFailure();
+            }
 
             auto diffUsers = collectDiffCoreTypeUsers(iterArg, initCoreType);
             if (!diffUsers.empty()) {
@@ -488,8 +497,10 @@ void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info)
             int predBlockId = static_cast<int>(*predBlockIdOpt);
 
             auto [producerBlockId, consumerBlockId] = findCommonLevelBlockIds(info, predBlockId, currBlockId);
-            assert(producerBlockId != -1 && consumerBlockId != -1 &&
-                "Could not find common level block IDs for producer and consumer blocks");
+            if (producerBlockId == -1 || consumerBlockId == -1) {
+                LOG_DEBUG("Could not find common level block IDs for producer and consumer blocks");
+                signalPassFailure();
+            }
             if (producerBlockId == consumerBlockId) {
                 continue;
             }

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -211,7 +211,10 @@ SmallVector<int64_t> InterCoreTransferAndSyncPass::computeExpectedShape(Value va
 {
     auto tensorTy = dyn_cast<TensorType>(value.getType());
     static constexpr int NdShapeLength = 2;
-    assert(tensorTy && tensorTy.getRank() == NdShapeLength && "source shape is not 2-dim!");
+    if (!tensorTy || tensorTy.getRank() != NdShapeLength) {
+        LOG_DEBUG("source shape is not 2-dim!");
+        signalPassFailure();
+    }
 
     int64_t M = tensorTy.getDimSize(0);
     int64_t N = tensorTy.getDimSize(1);
@@ -454,7 +457,10 @@ mlir::Operation *InterCoreTransferAndSyncPass::annotateTightlyCoupledBuffer(OpBu
 Operation *InterCoreTransferAndSyncPass::findMainLoopforTransfer(Operation *endOp, Operation *startOp)
 {
     Operation *lca = endOp->getParentOp();
-    assert(lca == startOp->getParentOp() && "startOp and endOp are not in the same parent block, which is unexpected.");
+    if (lca != startOp->getParentOp()) {
+        LOG_DEBUG("startOp and endOp are not in the same parent block, which is unexpected.");
+        signalPassFailure();
+    }
     Operation *current = lca;
     while (current) {
         if (isa<scf::ForOp>(current)) {

--- a/third_party/ascend/lib/TritonControlFlowOpt/TritonControlFlowOptPass.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/TritonControlFlowOptPass.cpp
@@ -800,14 +800,14 @@ static LogicalResult structureFunctionBody(Operation *funcOp, Region &body) {
 
 enum class PtrKind { Tensor, Block };
 
-struct TensorPtrParts {
+struct TensorPtrInfo {
   Type resultType;
   Value base;
   Value offset;
   bool scalarBase = false;
 };
 
-struct BlockPtrParts {
+struct BlockPtrInfo {
   Type resultType;
   Value base;
   SmallVector<Value> shape;
@@ -816,25 +816,22 @@ struct BlockPtrParts {
   DenseI32ArrayAttr order;
 };
 
-struct PtrParts {
+struct CFPtrInfo {
   PtrKind kind;
-  TensorPtrParts tensor;
-  BlockPtrParts block;
+  TensorPtrInfo tensor;
+  BlockPtrInfo block;
 };
 
-struct ForPointerInfo {
-  unsigned oldIndex = 0;
-  PtrParts initParts;
-  SmallVector<Value> deltaValues;
-  SmallVector<unsigned> newIndices;
+struct RewriteEnv {
+  IRMapping valueMapping;
+  DenseMap<Value, CFPtrInfo> pointerComponents;
 };
 
-struct WhilePointerInfo {
+struct LoopPointerInfo {
   unsigned oldIndex = 0;
-  PtrParts initParts;
-  SmallVector<Value> conditionDeltaValues;
-  SmallVector<Value> yieldDeltaValues;
+  CFPtrInfo initInfo;
   SmallVector<unsigned> newIndices;
+  SmallVector<Value> ivDeltas;
 };
 
 enum class IfComponentKind {
@@ -852,8 +849,8 @@ struct IfComponent {
 
 struct IfPointerInfo {
   unsigned oldIndex = 0;
-  PtrParts thenParts;
-  PtrParts elseParts;
+  CFPtrInfo thenInfo;
+  CFPtrInfo elseInfo;
   SmallVector<IfComponent> components;
 };
 
@@ -869,12 +866,6 @@ static bool isBlockPointerType(Type type) {
 
 static bool isControlFlowPointerType(Type type) {
   return isTensorPointerType(type) || isBlockPointerType(type);
-}
-
-static unsigned getBlockPointerRank(Type type) {
-  auto ptrType = cast<triton::PointerType>(type);
-  auto tensorType = cast<RankedTensorType>(ptrType.getPointeeType());
-  return tensorType.getRank();
 }
 
 static Value createZeroLike(OpBuilder &builder, Location loc, Type type) {
@@ -942,6 +933,44 @@ static Value castIntegerLike(OpBuilder &builder, Location loc, Value value,
   return builder.create<arith::TruncIOp>(loc, targetType, value);
 }
 
+static FailureOr<Type> getWiderIntegerLikeType(Type lhs, Type rhs) {
+  if (lhs == rhs)
+    return lhs;
+
+  if (lhs.isIndex() && rhs.isIndex())
+    return lhs;
+  if (lhs.isIndex() && isa<IntegerType>(rhs))
+    return lhs;
+  if (isa<IntegerType>(lhs) && rhs.isIndex())
+    return rhs;
+
+  auto lhsInt = dyn_cast<IntegerType>(lhs);
+  auto rhsInt = dyn_cast<IntegerType>(rhs);
+  if (lhsInt && rhsInt)
+    return lhsInt.getWidth() >= rhsInt.getWidth() ? lhs : rhs;
+
+  auto lhsTensor = dyn_cast<RankedTensorType>(lhs);
+  auto rhsTensor = dyn_cast<RankedTensorType>(rhs);
+  if (!lhsTensor || !rhsTensor ||
+      lhsTensor.getShape() != rhsTensor.getShape())
+    return failure();
+
+  Type lhsElement = lhsTensor.getElementType();
+  Type rhsElement = rhsTensor.getElementType();
+  if (lhsElement == rhsElement)
+    return lhs;
+  if (lhsElement.isIndex() && isa<IntegerType>(rhsElement))
+    return lhs;
+  if (isa<IntegerType>(lhsElement) && rhsElement.isIndex())
+    return rhs;
+
+  auto lhsElementInt = dyn_cast<IntegerType>(lhsElement);
+  auto rhsElementInt = dyn_cast<IntegerType>(rhsElement);
+  if (!lhsElementInt || !rhsElementInt)
+    return failure();
+  return lhsElementInt.getWidth() >= rhsElementInt.getWidth() ? lhs : rhs;
+}
+
 static Value createAdd(OpBuilder &builder, Location loc, Value lhs,
                        Value rhs) {
   if (!lhs || !rhs)
@@ -954,37 +983,76 @@ static Value createAdd(OpBuilder &builder, Location loc, Value lhs,
   return builder.create<arith::AddIOp>(loc, lhs, rhs);
 }
 
-static FailureOr<TensorPtrParts>
-analyzeTensorPtr(Value value, OpBuilder &builder, Location loc) {
+static Value createAddWithWiderType(OpBuilder &builder, Location loc, Value lhs,
+                                    Value rhs) {
+  if (!lhs || !rhs)
+    return nullptr;
+
+  FailureOr<Type> targetType =
+      getWiderIntegerLikeType(lhs.getType(), rhs.getType());
+  if (failed(targetType))
+    return nullptr;
+
+  lhs = castIntegerLike(builder, loc, lhs, *targetType);
+  rhs = castIntegerLike(builder, loc, rhs, *targetType);
+  if (!lhs || !rhs)
+    return nullptr;
+  return builder.create<arith::AddIOp>(loc, lhs, rhs);
+}
+
+static Value createMul(OpBuilder &builder, Location loc, Value lhs,
+                       Value rhs) {
+  if (!lhs || !rhs)
+    return nullptr;
+  if (lhs.getType() != rhs.getType()) {
+    rhs = castIntegerLike(builder, loc, rhs, lhs.getType());
+    if (!rhs)
+      return nullptr;
+  }
+  return builder.create<arith::MulIOp>(loc, lhs, rhs);
+}
+
+static Value remapValue(Value value, const RewriteEnv &env) {
+  if (Value mapped = env.valueMapping.lookupOrNull(value))
+    return mapped;
+  return value;
+}
+
+static FailureOr<CFPtrInfo> analyzePtr(Value value, const RewriteEnv &env,
+                                       OpBuilder &builder, Location loc);
+
+static FailureOr<TensorPtrInfo>
+analyzeTensorPtr(Value value, const RewriteEnv &env, OpBuilder &builder,
+                 Location loc) {
+  if (auto it = env.pointerComponents.find(value);
+      it != env.pointerComponents.end() && it->second.kind == PtrKind::Tensor)
+    return it->second.tensor;
+
+  value = remapValue(value, env);
+
   if (auto addPtrOp = value.getDefiningOp<triton::AddPtrOp>()) {
-    FailureOr<TensorPtrParts> baseParts =
-        analyzeTensorPtr(addPtrOp.getPtr(), builder, loc);
-    if (failed(baseParts))
+    FailureOr<CFPtrInfo> baseInfo =
+        analyzePtr(addPtrOp.getPtr(), env, builder, loc);
+    if (failed(baseInfo) || (*baseInfo).kind != PtrKind::Tensor)
       return failure();
 
+    TensorPtrInfo tensor = (*baseInfo).tensor;
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPoint(addPtrOp);
     Value offset = addPtrOp.getOffset();
-    if ((*baseParts).offset.getType() != offset.getType()) {
-      (*baseParts).offset =
-          castIntegerLike(builder, addPtrOp.getLoc(), (*baseParts).offset,
-                          offset.getType());
-      if (!(*baseParts).offset)
-        return failure();
-    }
-    Value newOffset =
-        createAdd(builder, addPtrOp.getLoc(), (*baseParts).offset, offset);
+    Value newOffset = createAddWithWiderType(builder, addPtrOp.getLoc(),
+                                             tensor.offset, offset);
     if (!newOffset)
       return failure();
-    (*baseParts).offset = newOffset;
-    (*baseParts).resultType = value.getType();
-    return *baseParts;
+    tensor.offset = newOffset;
+    tensor.resultType = value.getType();
+    return tensor;
   }
 
   if (auto splatOp = value.getDefiningOp<triton::SplatOp>()) {
     if (!isa<triton::PointerType>(splatOp.getSrc().getType()))
       return failure();
-    TensorPtrParts parts;
+    TensorPtrInfo parts;
     parts.resultType = value.getType();
     parts.base = splatOp.getSrc();
     parts.scalarBase = true;
@@ -999,7 +1067,7 @@ analyzeTensorPtr(Value value, OpBuilder &builder, Location loc) {
   if (!isTensorPointerType(value.getType()))
     return failure();
 
-  TensorPtrParts parts;
+  TensorPtrInfo parts;
   parts.resultType = value.getType();
   parts.base = value;
   parts.scalarBase = false;
@@ -1014,10 +1082,17 @@ analyzeTensorPtr(Value value, OpBuilder &builder, Location loc) {
   return parts;
 }
 
-static FailureOr<BlockPtrParts>
-analyzeBlockPtr(Value value, OpBuilder &builder, Location loc) {
+static FailureOr<BlockPtrInfo>
+analyzeBlockPtr(Value value, const RewriteEnv &env, OpBuilder &builder,
+                Location loc) {
+  if (auto it = env.pointerComponents.find(value);
+      it != env.pointerComponents.end() && it->second.kind == PtrKind::Block)
+    return it->second.block;
+
+  value = remapValue(value, env);
+
   if (auto makePtrOp = value.getDefiningOp<triton::MakeTensorPtrOp>()) {
-    BlockPtrParts parts;
+    BlockPtrInfo parts;
     parts.resultType = value.getType();
     parts.base = makePtrOp.getBase();
     parts.shape.assign(makePtrOp.getShape().begin(), makePtrOp.getShape().end());
@@ -1030,55 +1105,61 @@ analyzeBlockPtr(Value value, OpBuilder &builder, Location loc) {
   }
 
   if (auto advanceOp = value.getDefiningOp<triton::AdvanceOp>()) {
-    FailureOr<BlockPtrParts> baseParts =
-        analyzeBlockPtr(advanceOp.getPtr(), builder, loc);
-    if (failed(baseParts))
+    FailureOr<CFPtrInfo> baseInfo =
+        analyzePtr(advanceOp.getPtr(), env, builder, loc);
+    if (failed(baseInfo) || (*baseInfo).kind != PtrKind::Block)
       return failure();
-    if ((*baseParts).offsets.size() != advanceOp.getOffsets().size())
+    BlockPtrInfo block = (*baseInfo).block;
+    if (block.offsets.size() != advanceOp.getOffsets().size())
       return failure();
 
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPoint(advanceOp);
     for (auto [idx, delta] : llvm::enumerate(advanceOp.getOffsets())) {
       Value newOffset =
-          createAdd(builder, advanceOp.getLoc(), (*baseParts).offsets[idx],
-                    delta);
+          createAdd(builder, advanceOp.getLoc(), block.offsets[idx], delta);
       if (!newOffset)
         return failure();
-      (*baseParts).offsets[idx] = newOffset;
+      block.offsets[idx] = newOffset;
     }
-    (*baseParts).resultType = value.getType();
-    return *baseParts;
+    block.resultType = value.getType();
+    return block;
   }
 
   return failure();
 }
 
-static FailureOr<PtrParts> analyzePtr(Value value, OpBuilder &builder,
-                                      Location loc) {
+static FailureOr<CFPtrInfo> analyzePtr(Value value, const RewriteEnv &env,
+                                       OpBuilder &builder, Location loc) {
+  if (auto it = env.pointerComponents.find(value);
+      it != env.pointerComponents.end())
+    return it->second;
+
+  value = remapValue(value, env);
+
   if (isBlockPointerType(value.getType())) {
-    FailureOr<BlockPtrParts> block = analyzeBlockPtr(value, builder, loc);
+    FailureOr<BlockPtrInfo> block = analyzeBlockPtr(value, env, builder, loc);
     if (failed(block))
       return failure();
-    PtrParts parts{PtrKind::Block};
-    parts.block = *block;
-    return parts;
+    CFPtrInfo info{PtrKind::Block};
+    info.block = *block;
+    return info;
   }
 
   if (isTensorPointerType(value.getType())) {
-    FailureOr<TensorPtrParts> tensor = analyzeTensorPtr(value, builder, loc);
+    FailureOr<TensorPtrInfo> tensor = analyzeTensorPtr(value, env, builder, loc);
     if (failed(tensor))
       return failure();
-    PtrParts parts{PtrKind::Tensor};
-    parts.tensor = *tensor;
-    return parts;
+    CFPtrInfo info{PtrKind::Tensor};
+    info.tensor = *tensor;
+    return info;
   }
 
   return failure();
 }
 
 static Value rebuildTensorPtr(OpBuilder &builder, Location loc,
-                              const TensorPtrParts &parts, Value base,
+                              const TensorPtrInfo &parts, Value base,
                               Value offset) {
   Value ptrBase = base;
   if (parts.scalarBase && isTensorPointerType(parts.resultType))
@@ -1088,7 +1169,7 @@ static Value rebuildTensorPtr(OpBuilder &builder, Location loc,
 }
 
 static Value rebuildBlockPtr(OpBuilder &builder, Location loc,
-                             const BlockPtrParts &parts, Value base,
+                             const BlockPtrInfo &parts, Value base,
                              ArrayRef<Value> shape, ArrayRef<Value> strides,
                              ArrayRef<Value> offsets) {
   return builder.create<triton::MakeTensorPtrOp>(
@@ -1096,39 +1177,188 @@ static Value rebuildBlockPtr(OpBuilder &builder, Location loc,
       ValueRange(offsets), parts.order);
 }
 
-static Value rebuildPtr(OpBuilder &builder, Location loc, const PtrParts &parts,
-                        ArrayRef<Value> values) {
-  if (parts.kind == PtrKind::Tensor) {
-    if (values.size() == 1)
-      return rebuildTensorPtr(builder, loc, parts.tensor, parts.tensor.base,
-                              values[0]);
-    if (values.size() == 2)
-      return rebuildTensorPtr(builder, loc, parts.tensor, values[0], values[1]);
-    return nullptr;
+static Value rebuildPtr(OpBuilder &builder, Location loc,
+                        const CFPtrInfo &info) {
+  if (info.kind == PtrKind::Tensor)
+    return rebuildTensorPtr(builder, loc, info.tensor, info.tensor.base,
+                            info.tensor.offset);
+  return rebuildBlockPtr(builder, loc, info.block, info.block.base,
+                         info.block.shape, info.block.strides,
+                         info.block.offsets);
+}
+
+static void recordPointer(Value oldPtr, const CFPtrInfo &info, Value rebuiltPtr,
+                          RewriteEnv &env) {
+  env.pointerComponents[oldPtr] = info;
+  env.valueMapping.map(oldPtr, rebuiltPtr);
+}
+
+static SmallVector<Value> getLoopComponentValues(const CFPtrInfo &info) {
+  if (info.kind == PtrKind::Tensor)
+    return {info.tensor.offset};
+  return info.block.offsets;
+}
+
+static SmallVector<Type> getLoopComponentTypes(const CFPtrInfo &info) {
+  SmallVector<Type> types;
+  for (Value value : getLoopComponentValues(info))
+    types.push_back(value.getType());
+  return types;
+}
+
+static CFPtrInfo withLoopComponentValues(CFPtrInfo info,
+                                         ArrayRef<Value> values) {
+  if (info.kind == PtrKind::Tensor) {
+    if (values.size() != 1)
+      return info;
+    info.tensor.offset = values[0];
+    return info;
   }
 
-  unsigned rank = parts.block.offsets.size();
-  if (values.size() == rank)
-    return rebuildBlockPtr(builder, loc, parts.block, parts.block.base,
-                           parts.block.shape, parts.block.strides, values);
+  if (values.size() == info.block.offsets.size())
+    info.block.offsets.assign(values.begin(), values.end());
+  return info;
+}
 
+static bool areLoopCompatible(const CFPtrInfo &initInfo,
+                              const CFPtrInfo &nextInfo) {
+  if (initInfo.kind != nextInfo.kind)
+    return false;
+  if (initInfo.kind == PtrKind::Tensor)
+    return initInfo.tensor.resultType == nextInfo.tensor.resultType &&
+           initInfo.tensor.base == nextInfo.tensor.base &&
+           initInfo.tensor.scalarBase == nextInfo.tensor.scalarBase &&
+           haveSameTypes(getLoopComponentValues(initInfo),
+                         getLoopComponentValues(nextInfo));
+
+  return initInfo.block.resultType == nextInfo.block.resultType &&
+         initInfo.block.base == nextInfo.block.base &&
+         initInfo.block.order == nextInfo.block.order &&
+         initInfo.block.shape == nextInfo.block.shape &&
+         initInfo.block.strides == nextInfo.block.strides &&
+         initInfo.block.offsets.size() == nextInfo.block.offsets.size() &&
+         haveSameTypes(getLoopComponentValues(initInfo),
+                       getLoopComponentValues(nextInfo));
+}
+
+static bool isScalarIntegerLike(Type type) {
+  return type.isIndex() || isa<IntegerType>(type);
+}
+
+static bool isConstantIndex(Value value, int64_t expected) {
+  auto constOp = value.getDefiningOp<arith::ConstantIndexOp>();
+  return constOp && constOp.value() == expected;
+}
+
+static bool isRangeFromZeroByOne(scf::ForOp forOp) {
+  return isConstantIndex(forOp.getLowerBound(), 0) &&
+         isConstantIndex(forOp.getStep(), 1);
+}
+
+static bool isDefinedOutside(Operation *scope, Value value) {
+  if (Operation *defOp = value.getDefiningOp())
+    return !scope->isAncestor(defOp);
+
+  auto blockArg = dyn_cast<BlockArgument>(value);
+  if (!blockArg)
+    return false;
+
+  Operation *ownerOp = blockArg.getOwner()->getParentOp();
+  return ownerOp != scope && (!ownerOp || !scope->isAncestor(ownerOp));
+}
+
+static FailureOr<SmallVector<Value>>
+matchSimpleForIvDeltas(scf::ForOp forOp, const LoopPointerInfo &info,
+                       Value yieldOperand) {
+  if (!isRangeFromZeroByOne(forOp) || info.initInfo.kind != PtrKind::Block)
+    return failure();
+
+  auto advanceOp = yieldOperand.getDefiningOp<triton::AdvanceOp>();
+  if (!advanceOp ||
+      advanceOp.getPtr() != forOp.getRegionIterArgs()[info.oldIndex])
+    return failure();
+
+  if (advanceOp.getOffsets().size() != info.initInfo.block.offsets.size())
+    return failure();
+
+  SmallVector<Value> deltas;
+  for (auto [initOffset, delta] :
+       llvm::zip(info.initInfo.block.offsets, advanceOp.getOffsets())) {
+    if (!isScalarIntegerLike(initOffset.getType()) ||
+        !isScalarIntegerLike(delta.getType()) ||
+        !isDefinedOutside(forOp, delta))
+      return failure();
+    deltas.push_back(delta);
+  }
+  return deltas;
+}
+
+static FailureOr<CFPtrInfo>
+withForIvClosedFormComponents(const LoopPointerInfo &info, Value iv,
+                              OpBuilder &builder, Location loc,
+                              const RewriteEnv &env) {
+  if (info.ivDeltas.empty())
+    return failure();
+
+  SmallVector<Value> initComponents = getLoopComponentValues(info.initInfo);
+  if (initComponents.size() != info.ivDeltas.size())
+    return failure();
+
+  SmallVector<Value> components;
+  components.reserve(initComponents.size());
+  for (auto [initComponent, delta] :
+       llvm::zip(initComponents, info.ivDeltas)) {
+    Type componentType = initComponent.getType();
+    if (!isScalarIntegerLike(componentType))
+      return failure();
+
+    Value typedIv = castIntegerLike(builder, loc, iv, componentType);
+    Value typedDelta =
+        castIntegerLike(builder, loc, remapValue(delta, env), componentType);
+    if (!typedIv || !typedDelta)
+      return failure();
+
+    Value scaledDelta = createMul(builder, loc, typedIv, typedDelta);
+    Value component = createAdd(builder, loc, initComponent, scaledDelta);
+    if (!scaledDelta || !component)
+      return failure();
+    components.push_back(component);
+  }
+
+  return withLoopComponentValues(info.initInfo, components);
+}
+
+static LoopPointerInfo *findLoopInfo(SmallVectorImpl<LoopPointerInfo> &infos,
+                                     unsigned oldIndex) {
+  for (LoopPointerInfo &info : infos) {
+    if (info.oldIndex == oldIndex)
+      return &info;
+  }
+  return nullptr;
+}
+
+static const LoopPointerInfo *findLoopInfo(ArrayRef<LoopPointerInfo> infos,
+                                           unsigned oldIndex) {
+  for (const LoopPointerInfo &info : infos) {
+    if (info.oldIndex == oldIndex)
+      return &info;
+  }
   return nullptr;
 }
 
 static SmallVector<Value>
-collectForRebuildValues(const ForPointerInfo &info, scf::ForOp forOp,
-                        bool useResults) {
+collectForComponents(const LoopPointerInfo &info, scf::ForOp forOp,
+                     bool useResults) {
   SmallVector<Value> values;
-  for (unsigned newIndex : info.newIndices) {
+  for (unsigned newIndex : info.newIndices)
     values.push_back(useResults ? forOp.getResult(newIndex)
                                 : forOp.getRegionIterArgs()[newIndex]);
-  }
   return values;
 }
 
 static SmallVector<Value>
-collectWhileRebuildValues(const WhilePointerInfo &info, scf::WhileOp whileOp,
-                          bool useResults, bool useAfterArgs) {
+collectWhileComponents(const LoopPointerInfo &info, scf::WhileOp whileOp,
+                       bool useResults, bool useAfterArgs) {
   SmallVector<Value> values;
   for (unsigned newIndex : info.newIndices) {
     if (useResults)
@@ -1141,120 +1371,55 @@ collectWhileRebuildValues(const WhilePointerInfo &info, scf::WhileOp whileOp,
   return values;
 }
 
-static FailureOr<SmallVector<Value>>
-getBlockPtrDelta(Value value, Value iterArg, OpBuilder &builder, Location loc) {
-  unsigned rank = getBlockPointerRank(iterArg.getType());
-  if (value == iterArg) {
-    SmallVector<Value> zeros;
-    zeros.reserve(rank);
-    for (unsigned i = 0; i < rank; ++i)
-      zeros.push_back(createZeroLike(builder, loc, builder.getI32Type()));
-    return zeros;
-  }
+static LogicalResult rewriteControlFlowOp(Operation *op, OpBuilder &builder,
+                                          RewriteEnv &env);
 
-  auto advanceOp = value.getDefiningOp<triton::AdvanceOp>();
-  if (!advanceOp || advanceOp.getOffsets().size() != rank)
-    return failure();
-
-  FailureOr<SmallVector<Value>> baseDelta =
-      getBlockPtrDelta(advanceOp.getPtr(), iterArg, builder, loc);
-  if (failed(baseDelta))
-    return failure();
+static LogicalResult materializePointerResult(Operation &bodyOp,
+                                              Operation *clonedOp,
+                                              OpBuilder &builder,
+                                              RewriteEnv &env) {
+  if (!isa<triton::AddPtrOp, triton::AdvanceOp>(bodyOp))
+    return success();
 
   OpBuilder::InsertionGuard guard(builder);
-  builder.setInsertionPoint(advanceOp);
-  for (auto [idx, step] : llvm::enumerate(advanceOp.getOffsets())) {
-    Value newDelta =
-        createAdd(builder, advanceOp.getLoc(), (*baseDelta)[idx], step);
-    if (!newDelta)
+  builder.setInsertionPointAfter(clonedOp);
+
+  for (auto [oldResult, clonedResult] :
+       llvm::zip(bodyOp.getResults(), clonedOp->getResults())) {
+    if (!isControlFlowPointerType(oldResult.getType()))
+      continue;
+
+    FailureOr<CFPtrInfo> info =
+        analyzePtr(clonedResult, env, builder, oldResult.getLoc());
+    if (failed(info))
+      continue;
+
+    Value rebuilt = rebuildPtr(builder, oldResult.getLoc(), *info);
+    if (!rebuilt)
       return failure();
-    (*baseDelta)[idx] = newDelta;
+    recordPointer(oldResult, *info, rebuilt, env);
   }
-  return *baseDelta;
+
+  return success();
 }
 
-static FailureOr<SmallVector<Value>>
-getTensorPtrDelta(Value value, Value iterArg, OpBuilder &builder,
-                  Location loc) {
-  if (value == iterArg) {
-    Value zero = createZeroOffset(builder, loc, iterArg.getType());
-    if (!zero)
-      return failure();
-    return SmallVector<Value>{zero};
-  }
-
-  auto addPtrOp = value.getDefiningOp<triton::AddPtrOp>();
-  if (!addPtrOp)
-    return failure();
-
-  FailureOr<SmallVector<Value>> baseDelta =
-      getTensorPtrDelta(addPtrOp.getPtr(), iterArg, builder, loc);
-  if (failed(baseDelta) || baseDelta->size() != 1)
-    return failure();
-
-  OpBuilder::InsertionGuard guard(builder);
-  builder.setInsertionPoint(addPtrOp);
-  Value delta = (*baseDelta)[0];
-  Value step = addPtrOp.getOffset();
-  if (delta.getType() != step.getType()) {
-    delta = castIntegerLike(builder, addPtrOp.getLoc(), delta, step.getType());
-    if (!delta)
+static LogicalResult rewriteBodyOps(Block *oldBlock, OpBuilder &builder,
+                                    RewriteEnv &env) {
+  for (Operation &bodyOp : oldBlock->without_terminator()) {
+    if (isa<scf::ForOp, scf::WhileOp, scf::IfOp>(bodyOp) &&
+        succeeded(rewriteControlFlowOp(&bodyOp, builder, env)))
+      continue;
+    Operation *clonedOp = builder.clone(bodyOp, env.valueMapping);
+    if (failed(materializePointerResult(bodyOp, clonedOp, builder, env)))
       return failure();
   }
-  Value newDelta = createAdd(builder, addPtrOp.getLoc(), delta, step);
-  if (!newDelta)
-    return failure();
-  return SmallVector<Value>{newDelta};
+  return success();
 }
 
-static FailureOr<SmallVector<Value>>
-getPointerDelta(Value value, Value iterArg, OpBuilder &builder, Location loc) {
-  if (isBlockPointerType(iterArg.getType()))
-    return getBlockPtrDelta(value, iterArg, builder, loc);
-  if (isTensorPointerType(iterArg.getType()))
-    return getTensorPtrDelta(value, iterArg, builder, loc);
-  return failure();
-}
-
-static ForPointerInfo *findForInfo(SmallVectorImpl<ForPointerInfo> &infos,
-                                   unsigned oldIndex) {
-  for (ForPointerInfo &info : infos) {
-    if (info.oldIndex == oldIndex)
-      return &info;
-  }
-  return nullptr;
-}
-
-static const ForPointerInfo *
-findForInfo(ArrayRef<ForPointerInfo> infos, unsigned oldIndex) {
-  for (const ForPointerInfo &info : infos) {
-    if (info.oldIndex == oldIndex)
-      return &info;
-  }
-  return nullptr;
-}
-
-static WhilePointerInfo *
-findWhileInfo(SmallVectorImpl<WhilePointerInfo> &infos, unsigned oldIndex) {
-  for (WhilePointerInfo &info : infos) {
-    if (info.oldIndex == oldIndex)
-      return &info;
-  }
-  return nullptr;
-}
-
-static const WhilePointerInfo *
-findWhileInfo(ArrayRef<WhilePointerInfo> infos, unsigned oldIndex) {
-  for (const WhilePointerInfo &info : infos) {
-    if (info.oldIndex == oldIndex)
-      return &info;
-  }
-  return nullptr;
-}
-
-static LogicalResult tryDecoupleFor(scf::ForOp forOp, IRRewriter &rewriter) {
+static LogicalResult rewriteForOp(scf::ForOp forOp, OpBuilder &builder,
+                                  RewriteEnv &env) {
   auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
-  SmallVector<ForPointerInfo, 4> pointerInfos;
+  SmallVector<LoopPointerInfo, 4> pointerInfos;
 
   OpBuilder analysisBuilder(forOp.getContext());
   analysisBuilder.setInsertionPoint(forOp);
@@ -1262,114 +1427,131 @@ static LogicalResult tryDecoupleFor(scf::ForOp forOp, IRRewriter &rewriter) {
   for (auto [idx, iterArg] : llvm::enumerate(forOp.getRegionIterArgs())) {
     if (!isControlFlowPointerType(iterArg.getType()))
       continue;
-    if (idx >= yieldOp.getNumOperands())
+    if (idx >= forOp.getInitArgs().size() || idx >= yieldOp.getNumOperands())
       return failure();
 
-    FailureOr<PtrParts> initParts =
-        analyzePtr(forOp.getInitArgs()[idx], analysisBuilder, forOp.getLoc());
-    if (failed(initParts))
+    FailureOr<CFPtrInfo> initInfo =
+        analyzePtr(forOp.getInitArgs()[idx], env, analysisBuilder,
+                   forOp.getLoc());
+    if (failed(initInfo))
       continue;
-
-    FailureOr<SmallVector<Value>> delta = getPointerDelta(
-        yieldOp.getOperand(idx), iterArg, analysisBuilder, yieldOp.getLoc());
-    if (failed(delta))
-      continue;
-
     pointerInfos.push_back(
-        ForPointerInfo{static_cast<unsigned>(idx), *initParts, *delta, {}});
+        LoopPointerInfo{static_cast<unsigned>(idx), *initInfo, {}});
   }
 
   if (pointerInfos.empty())
     return failure();
 
+  for (LoopPointerInfo &info : pointerInfos) {
+    FailureOr<SmallVector<Value>> deltas =
+        matchSimpleForIvDeltas(forOp, info,
+                               yieldOp.getOperand(info.oldIndex));
+    if (succeeded(deltas))
+      info.ivDeltas = *deltas;
+  }
+
   SmallVector<Value> newInitArgs;
   SmallVector<unsigned> oldToNewStart(forOp.getInitArgs().size(), 0);
   for (auto [idx, initArg] : llvm::enumerate(forOp.getInitArgs())) {
     oldToNewStart[idx] = newInitArgs.size();
-    if (ForPointerInfo *info = findForInfo(pointerInfos, idx)) {
-      if (info->initParts.kind == PtrKind::Tensor) {
+    if (LoopPointerInfo *info = findLoopInfo(pointerInfos, idx)) {
+      for (Value component : getLoopComponentValues(info->initInfo)) {
         info->newIndices.push_back(newInitArgs.size());
-        newInitArgs.push_back(info->initParts.tensor.offset);
-      } else {
-        for (Value offset : info->initParts.block.offsets) {
-          info->newIndices.push_back(newInitArgs.size());
-          newInitArgs.push_back(offset);
-        }
+        newInitArgs.push_back(component);
       }
       continue;
     }
-    newInitArgs.push_back(initArg);
+    newInitArgs.push_back(remapValue(initArg, env));
   }
 
-  rewriter.setInsertionPoint(forOp);
-  auto newForOp = rewriter.create<scf::ForOp>(
-      forOp.getLoc(), forOp.getLowerBound(), forOp.getUpperBound(),
-      forOp.getStep(), newInitArgs,
-      [&](OpBuilder &builder, Location loc, Value iv, ValueRange args) {
-        IRMapping mapping;
-        mapping.map(forOp.getInductionVar(), iv);
+  bool bodyOk = true;
+  auto newForOp = builder.create<scf::ForOp>(
+      forOp.getLoc(), remapValue(forOp.getLowerBound(), env),
+      remapValue(forOp.getUpperBound(), env), remapValue(forOp.getStep(), env),
+      newInitArgs,
+      [&](OpBuilder &bodyBuilder, Location loc, Value iv, ValueRange args) {
+        RewriteEnv bodyEnv = env;
+        bodyEnv.valueMapping.map(forOp.getInductionVar(), iv);
 
         for (auto [idx, oldArg] : llvm::enumerate(forOp.getRegionIterArgs())) {
-          if (const ForPointerInfo *info = findForInfo(pointerInfos, idx)) {
-            SmallVector<Value> rebuildValues;
+          if (const LoopPointerInfo *info = findLoopInfo(pointerInfos, idx)) {
+            SmallVector<Value> values;
             for (unsigned newIndex : info->newIndices)
-              rebuildValues.push_back(args[newIndex]);
-            Value rebuilt = rebuildPtr(builder, loc, info->initParts,
-                                       rebuildValues);
-            mapping.map(oldArg, rebuilt);
+              values.push_back(args[newIndex]);
+            CFPtrInfo argInfo = withLoopComponentValues(info->initInfo, values);
+            FailureOr<CFPtrInfo> closedFormInfo =
+                withForIvClosedFormComponents(*info, iv, bodyBuilder, loc,
+                                              bodyEnv);
+            if (succeeded(closedFormInfo))
+              argInfo = *closedFormInfo;
+            Value rebuilt = rebuildPtr(bodyBuilder, loc, argInfo);
+            if (!rebuilt) {
+              bodyOk = false;
+              continue;
+            }
+            recordPointer(oldArg, argInfo, rebuilt, bodyEnv);
             continue;
           }
-          mapping.map(oldArg, args[oldToNewStart[idx]]);
+          bodyEnv.valueMapping.map(oldArg, args[oldToNewStart[idx]]);
         }
 
-        for (Operation &bodyOp : forOp.getBody()->without_terminator())
-          builder.clone(bodyOp, mapping);
+        if (failed(rewriteBodyOps(forOp.getBody(), bodyBuilder, bodyEnv)))
+          bodyOk = false;
 
         SmallVector<Value> newYieldOperands;
         for (auto [idx, oldOperand] : llvm::enumerate(yieldOp.getOperands())) {
-          if (const ForPointerInfo *info = findForInfo(pointerInfos, idx)) {
-            for (auto [componentIdx, delta] :
-                 llvm::enumerate(info->deltaValues)) {
-              Value current = args[info->newIndices[componentIdx]];
-              Value mappedDelta = mapping.lookupOrDefault(delta);
-              newYieldOperands.push_back(
-                  createAdd(builder, yieldOp.getLoc(), current, mappedDelta));
+          if (const LoopPointerInfo *info = findLoopInfo(pointerInfos, idx)) {
+            FailureOr<CFPtrInfo> nextInfo =
+                analyzePtr(oldOperand, bodyEnv, bodyBuilder,
+                           yieldOp.getLoc());
+            if (failed(nextInfo) ||
+                !areLoopCompatible(info->initInfo, *nextInfo)) {
+              bodyOk = false;
+              for (unsigned newIndex : info->newIndices)
+                newYieldOperands.push_back(args[newIndex]);
+              continue;
             }
+            for (Value component : getLoopComponentValues(*nextInfo))
+              newYieldOperands.push_back(component);
             continue;
           }
-          newYieldOperands.push_back(mapping.lookupOrDefault(oldOperand));
+          newYieldOperands.push_back(remapValue(oldOperand, bodyEnv));
         }
 
-        builder.create<scf::YieldOp>(yieldOp.getLoc(), newYieldOperands);
+        bodyBuilder.create<scf::YieldOp>(yieldOp.getLoc(), newYieldOperands);
       });
   newForOp->setAttrs(forOp->getAttrs());
 
-  rewriter.setInsertionPointAfter(newForOp);
-  SmallVector<Value> replacements;
-  for (auto [idx, oldResult] : llvm::enumerate(forOp.getResults())) {
-    if (const ForPointerInfo *info = findForInfo(pointerInfos, idx)) {
-      SmallVector<Value> rebuildValues =
-          collectForRebuildValues(*info, newForOp, /*useResults=*/true);
-      replacements.push_back(
-          rebuildPtr(rewriter, oldResult.getLoc(), info->initParts,
-                     rebuildValues));
-      continue;
-    }
-    replacements.push_back(newForOp.getResult(oldToNewStart[idx]));
+  if (!bodyOk) {
+    newForOp.erase();
+    return failure();
   }
 
-  if (llvm::any_of(replacements, [](Value value) { return !value; }))
-    return failure();
+  builder.setInsertionPointAfter(newForOp);
+  for (auto [idx, oldResult] : llvm::enumerate(forOp.getResults())) {
+    if (const LoopPointerInfo *info = findLoopInfo(pointerInfos, idx)) {
+      CFPtrInfo resultInfo = withLoopComponentValues(
+          info->initInfo,
+          collectForComponents(*info, newForOp, /*useResults=*/true));
+      Value rebuilt = rebuildPtr(builder, oldResult.getLoc(), resultInfo);
+      if (!rebuilt) {
+        newForOp.erase();
+        return failure();
+      }
+      recordPointer(oldResult, resultInfo, rebuilt, env);
+      continue;
+    }
+    env.valueMapping.map(oldResult, newForOp.getResult(oldToNewStart[idx]));
+  }
 
-  rewriter.replaceOp(forOp, replacements);
   return success();
 }
 
-static LogicalResult tryDecoupleWhile(scf::WhileOp whileOp,
-                                      IRRewriter &rewriter) {
+static LogicalResult rewriteWhileOp(scf::WhileOp whileOp, OpBuilder &builder,
+                                    RewriteEnv &env) {
   scf::ConditionOp conditionOp = whileOp.getConditionOp();
   scf::YieldOp yieldOp = whileOp.getYieldOp();
-  SmallVector<WhilePointerInfo, 4> pointerInfos;
+  SmallVector<LoopPointerInfo, 4> pointerInfos;
 
   OpBuilder analysisBuilder(whileOp.getContext());
   analysisBuilder.setInsertionPoint(whileOp);
@@ -1377,31 +1559,17 @@ static LogicalResult tryDecoupleWhile(scf::WhileOp whileOp,
   for (auto [idx, beforeArg] : llvm::enumerate(whileOp.getBeforeArguments())) {
     if (!isControlFlowPointerType(beforeArg.getType()))
       continue;
-    if (idx >= conditionOp.getArgs().size() || idx >= yieldOp.getNumOperands() ||
-        idx >= whileOp.getInits().size())
+    if (idx >= whileOp.getInits().size() || idx >= conditionOp.getArgs().size()
+        || idx >= yieldOp.getNumOperands())
       return failure();
 
-    FailureOr<PtrParts> initParts =
-        analyzePtr(whileOp.getInits()[idx], analysisBuilder, whileOp.getLoc());
-    if (failed(initParts))
+    FailureOr<CFPtrInfo> initInfo =
+        analyzePtr(whileOp.getInits()[idx], env, analysisBuilder,
+                   whileOp.getLoc());
+    if (failed(initInfo))
       continue;
-
-    FailureOr<SmallVector<Value>> conditionDelta =
-        getPointerDelta(conditionOp.getArgs()[idx], beforeArg, analysisBuilder,
-                        conditionOp.getLoc());
-    if (failed(conditionDelta))
-      continue;
-
-    Value afterArg = whileOp.getAfterArguments()[idx];
-    FailureOr<SmallVector<Value>> yieldDelta =
-        getPointerDelta(yieldOp.getOperand(idx), afterArg, analysisBuilder,
-                        yieldOp.getLoc());
-    if (failed(yieldDelta))
-      continue;
-
-    pointerInfos.push_back(WhilePointerInfo{static_cast<unsigned>(idx),
-                                            *initParts, *conditionDelta,
-                                            *yieldDelta, {}});
+    pointerInfos.push_back(
+        LoopPointerInfo{static_cast<unsigned>(idx), *initInfo, {}});
   }
 
   if (pointerInfos.empty())
@@ -1412,127 +1580,146 @@ static LogicalResult tryDecoupleWhile(scf::WhileOp whileOp,
   SmallVector<unsigned> oldToNewStart(whileOp.getInits().size(), 0);
   for (auto [idx, initArg] : llvm::enumerate(whileOp.getInits())) {
     oldToNewStart[idx] = newInits.size();
-    if (WhilePointerInfo *info = findWhileInfo(pointerInfos, idx)) {
-      if (info->initParts.kind == PtrKind::Tensor) {
+    if (LoopPointerInfo *info = findLoopInfo(pointerInfos, idx)) {
+      for (Value component : getLoopComponentValues(info->initInfo)) {
         info->newIndices.push_back(newInits.size());
-        newInits.push_back(info->initParts.tensor.offset);
-        newResultTypes.push_back(info->initParts.tensor.offset.getType());
-      } else {
-        for (Value offset : info->initParts.block.offsets) {
-          info->newIndices.push_back(newInits.size());
-          newInits.push_back(offset);
-          newResultTypes.push_back(offset.getType());
-        }
+        newInits.push_back(component);
+        newResultTypes.push_back(component.getType());
       }
       continue;
     }
-    newInits.push_back(initArg);
+    newInits.push_back(remapValue(initArg, env));
     newResultTypes.push_back(whileOp.getResult(idx).getType());
   }
 
-  rewriter.setInsertionPoint(whileOp);
-  auto newWhileOp = rewriter.create<scf::WhileOp>(
+  bool bodyOk = true;
+  auto newWhileOp = builder.create<scf::WhileOp>(
       whileOp.getLoc(), newResultTypes, newInits,
-      [&](OpBuilder &builder, Location loc, ValueRange args) {
-        IRMapping mapping;
+      [&](OpBuilder &bodyBuilder, Location loc, ValueRange args) {
+        RewriteEnv beforeEnv = env;
         for (auto [idx, oldArg] :
              llvm::enumerate(whileOp.getBeforeArguments())) {
-          if (const WhilePointerInfo *info = findWhileInfo(pointerInfos, idx)) {
-            SmallVector<Value> rebuildValues;
+          if (const LoopPointerInfo *info = findLoopInfo(pointerInfos, idx)) {
+            SmallVector<Value> values;
             for (unsigned newIndex : info->newIndices)
-              rebuildValues.push_back(args[newIndex]);
-            Value rebuilt = rebuildPtr(builder, loc, info->initParts,
-                                       rebuildValues);
-            mapping.map(oldArg, rebuilt);
+              values.push_back(args[newIndex]);
+            CFPtrInfo argInfo = withLoopComponentValues(info->initInfo, values);
+            Value rebuilt = rebuildPtr(bodyBuilder, loc, argInfo);
+            if (!rebuilt) {
+              bodyOk = false;
+              continue;
+            }
+            recordPointer(oldArg, argInfo, rebuilt, beforeEnv);
             continue;
           }
-          mapping.map(oldArg, args[oldToNewStart[idx]]);
+          beforeEnv.valueMapping.map(oldArg, args[oldToNewStart[idx]]);
         }
 
-        for (Operation &bodyOp : whileOp.getBeforeBody()->without_terminator())
-          builder.clone(bodyOp, mapping);
+        if (failed(rewriteBodyOps(whileOp.getBeforeBody(), bodyBuilder,
+                                  beforeEnv)))
+          bodyOk = false;
 
         SmallVector<Value> newConditionArgs;
         for (auto [idx, oldArg] : llvm::enumerate(conditionOp.getArgs())) {
-          if (const WhilePointerInfo *info = findWhileInfo(pointerInfos, idx)) {
-            for (auto [componentIdx, delta] :
-                 llvm::enumerate(info->conditionDeltaValues)) {
-              Value current = args[info->newIndices[componentIdx]];
-              Value mappedDelta = mapping.lookupOrDefault(delta);
-              newConditionArgs.push_back(createAdd(
-                  builder, conditionOp.getLoc(), current, mappedDelta));
+          if (const LoopPointerInfo *info = findLoopInfo(pointerInfos, idx)) {
+            FailureOr<CFPtrInfo> conditionInfo =
+                analyzePtr(oldArg, beforeEnv, bodyBuilder,
+                           conditionOp.getLoc());
+            if (failed(conditionInfo) ||
+                !areLoopCompatible(info->initInfo, *conditionInfo)) {
+              bodyOk = false;
+              for (unsigned newIndex : info->newIndices)
+                newConditionArgs.push_back(args[newIndex]);
+              continue;
             }
+            for (Value component : getLoopComponentValues(*conditionInfo))
+              newConditionArgs.push_back(component);
             continue;
           }
-          newConditionArgs.push_back(mapping.lookupOrDefault(oldArg));
+          newConditionArgs.push_back(remapValue(oldArg, beforeEnv));
         }
 
-        builder.create<scf::ConditionOp>(
+        bodyBuilder.create<scf::ConditionOp>(
             conditionOp.getLoc(),
-            mapping.lookupOrDefault(conditionOp.getCondition()),
+            remapValue(conditionOp.getCondition(), beforeEnv),
             newConditionArgs);
       },
-      [&](OpBuilder &builder, Location loc, ValueRange args) {
-        IRMapping mapping;
+      [&](OpBuilder &bodyBuilder, Location loc, ValueRange args) {
+        RewriteEnv afterEnv = env;
         for (auto [idx, oldArg] : llvm::enumerate(whileOp.getAfterArguments())) {
-          if (const WhilePointerInfo *info = findWhileInfo(pointerInfos, idx)) {
-            SmallVector<Value> rebuildValues;
+          if (const LoopPointerInfo *info = findLoopInfo(pointerInfos, idx)) {
+            SmallVector<Value> values;
             for (unsigned newIndex : info->newIndices)
-              rebuildValues.push_back(args[newIndex]);
-            Value rebuilt = rebuildPtr(builder, loc, info->initParts,
-                                       rebuildValues);
-            mapping.map(oldArg, rebuilt);
+              values.push_back(args[newIndex]);
+            CFPtrInfo argInfo = withLoopComponentValues(info->initInfo, values);
+            Value rebuilt = rebuildPtr(bodyBuilder, loc, argInfo);
+            if (!rebuilt) {
+              bodyOk = false;
+              continue;
+            }
+            recordPointer(oldArg, argInfo, rebuilt, afterEnv);
             continue;
           }
-          mapping.map(oldArg, args[oldToNewStart[idx]]);
+          afterEnv.valueMapping.map(oldArg, args[oldToNewStart[idx]]);
         }
 
-        for (Operation &bodyOp : whileOp.getAfterBody()->without_terminator())
-          builder.clone(bodyOp, mapping);
+        if (failed(rewriteBodyOps(whileOp.getAfterBody(), bodyBuilder,
+                                  afterEnv)))
+          bodyOk = false;
 
         SmallVector<Value> newYieldOperands;
         for (auto [idx, oldOperand] : llvm::enumerate(yieldOp.getOperands())) {
-          if (const WhilePointerInfo *info = findWhileInfo(pointerInfos, idx)) {
-            for (auto [componentIdx, delta] :
-                 llvm::enumerate(info->yieldDeltaValues)) {
-              Value current = args[info->newIndices[componentIdx]];
-              Value mappedDelta = mapping.lookupOrDefault(delta);
-              newYieldOperands.push_back(
-                  createAdd(builder, yieldOp.getLoc(), current, mappedDelta));
+          if (const LoopPointerInfo *info = findLoopInfo(pointerInfos, idx)) {
+            FailureOr<CFPtrInfo> nextInfo =
+                analyzePtr(oldOperand, afterEnv, bodyBuilder,
+                           yieldOp.getLoc());
+            if (failed(nextInfo) ||
+                !areLoopCompatible(info->initInfo, *nextInfo)) {
+              bodyOk = false;
+              for (unsigned newIndex : info->newIndices)
+                newYieldOperands.push_back(args[newIndex]);
+              continue;
             }
+            for (Value component : getLoopComponentValues(*nextInfo))
+              newYieldOperands.push_back(component);
             continue;
           }
-          newYieldOperands.push_back(mapping.lookupOrDefault(oldOperand));
+          newYieldOperands.push_back(remapValue(oldOperand, afterEnv));
         }
 
-        builder.create<scf::YieldOp>(yieldOp.getLoc(), newYieldOperands);
+        bodyBuilder.create<scf::YieldOp>(yieldOp.getLoc(), newYieldOperands);
       });
   newWhileOp->setAttrs(whileOp->getAttrs());
 
-  rewriter.setInsertionPointAfter(newWhileOp);
-  SmallVector<Value> replacements;
-  for (auto [idx, oldResult] : llvm::enumerate(whileOp.getResults())) {
-    if (const WhilePointerInfo *info = findWhileInfo(pointerInfos, idx)) {
-      SmallVector<Value> rebuildValues = collectWhileRebuildValues(
-          *info, newWhileOp, /*useResults=*/true, /*useAfterArgs=*/false);
-      replacements.push_back(
-          rebuildPtr(rewriter, oldResult.getLoc(), info->initParts,
-                     rebuildValues));
-      continue;
-    }
-    replacements.push_back(newWhileOp.getResult(oldToNewStart[idx]));
+  if (!bodyOk) {
+    newWhileOp.erase();
+    return failure();
   }
 
-  if (llvm::any_of(replacements, [](Value value) { return !value; }))
-    return failure();
+  builder.setInsertionPointAfter(newWhileOp);
+  for (auto [idx, oldResult] : llvm::enumerate(whileOp.getResults())) {
+    if (const LoopPointerInfo *info = findLoopInfo(pointerInfos, idx)) {
+      CFPtrInfo resultInfo = withLoopComponentValues(
+          info->initInfo,
+          collectWhileComponents(*info, newWhileOp, /*useResults=*/true,
+                                 /*useAfterArgs=*/false));
+      Value rebuilt = rebuildPtr(builder, oldResult.getLoc(), resultInfo);
+      if (!rebuilt) {
+        newWhileOp.erase();
+        return failure();
+      }
+      recordPointer(oldResult, resultInfo, rebuilt, env);
+      continue;
+    }
+    env.valueMapping.map(oldResult, newWhileOp.getResult(oldToNewStart[idx]));
+  }
 
-  rewriter.replaceOp(whileOp, replacements);
   return success();
 }
 
 static LogicalResult
-addIfTensorComponents(const TensorPtrParts &thenParts,
-                      const TensorPtrParts &elseParts,
+addIfTensorComponents(const TensorPtrInfo &thenParts,
+                      const TensorPtrInfo &elseParts,
                       SmallVectorImpl<IfComponent> &components) {
   if (thenParts.base != elseParts.base)
     return failure();
@@ -1544,8 +1731,8 @@ addIfTensorComponents(const TensorPtrParts &thenParts,
 }
 
 static LogicalResult
-addIfBlockComponents(const BlockPtrParts &thenParts,
-                     const BlockPtrParts &elseParts,
+addIfBlockComponents(const BlockPtrInfo &thenParts,
+                     const BlockPtrInfo &elseParts,
                      SmallVectorImpl<IfComponent> &components) {
   if (thenParts.resultType != elseParts.resultType ||
       thenParts.order != elseParts.order ||
@@ -1597,41 +1784,82 @@ addIfBlockComponents(const BlockPtrParts &thenParts,
   return success();
 }
 
-static Value getThenComponentValue(const IfPointerInfo &info,
-                                   const IfComponent &component) {
-  if (info.thenParts.kind == PtrKind::Tensor) {
-    if (component.kind == IfComponentKind::TensorOffset)
-      return info.thenParts.tensor.offset;
-    return nullptr;
+static FailureOr<CFPtrInfo>
+analyzePtrForIfPlanning(Value value, const RewriteEnv &env,
+                        OpBuilder &builder, Location loc);
+
+static FailureOr<CFPtrInfo>
+analyzeNestedIfResultForPlanning(scf::IfOp ifOp, unsigned resultIndex,
+                                 const RewriteEnv &env, OpBuilder &builder,
+                                 Location loc) {
+  if (!ifOp.elseBlock() || resultIndex >= ifOp.getNumResults())
+    return failure();
+
+  scf::YieldOp thenYield = ifOp.thenYield();
+  scf::YieldOp elseYield = ifOp.elseYield();
+  if (resultIndex >= thenYield.getNumOperands() ||
+      resultIndex >= elseYield.getNumOperands())
+    return failure();
+
+  FailureOr<CFPtrInfo> thenInfo = analyzePtrForIfPlanning(
+      thenYield.getOperand(resultIndex), env, builder, loc);
+  FailureOr<CFPtrInfo> elseInfo = analyzePtrForIfPlanning(
+      elseYield.getOperand(resultIndex), env, builder, loc);
+  if (failed(thenInfo) || failed(elseInfo) ||
+      thenInfo->kind != elseInfo->kind)
+    return failure();
+
+  SmallVector<IfComponent> components;
+  if (thenInfo->kind == PtrKind::Tensor) {
+    if (thenInfo->tensor.resultType != elseInfo->tensor.resultType ||
+        thenInfo->tensor.scalarBase != elseInfo->tensor.scalarBase)
+      return failure();
+    if (failed(addIfTensorComponents(thenInfo->tensor, elseInfo->tensor,
+                                     components)))
+      return failure();
+  } else if (failed(addIfBlockComponents(thenInfo->block, elseInfo->block,
+                                         components))) {
+    return failure();
   }
 
-  switch (component.kind) {
-  case IfComponentKind::BlockShape:
-    return info.thenParts.block.shape[component.dim];
-  case IfComponentKind::BlockStride:
-    return info.thenParts.block.strides[component.dim];
-  case IfComponentKind::BlockOffset:
-    return info.thenParts.block.offsets[component.dim];
-  default:
-    return nullptr;
-  }
+  return *thenInfo;
 }
 
-static Value getElseComponentValue(const IfPointerInfo &info,
-                                   const IfComponent &component) {
-  if (info.elseParts.kind == PtrKind::Tensor) {
+static FailureOr<CFPtrInfo>
+analyzePtrForIfPlanning(Value value, const RewriteEnv &env,
+                        OpBuilder &builder, Location loc) {
+  if (auto it = env.pointerComponents.find(value);
+      it != env.pointerComponents.end())
+    return it->second;
+
+  Value mapped = remapValue(value, env);
+  if (auto result = dyn_cast<OpResult>(mapped)) {
+    if (auto nestedIf = dyn_cast<scf::IfOp>(result.getOwner())) {
+      FailureOr<CFPtrInfo> nestedInfo = analyzeNestedIfResultForPlanning(
+          nestedIf, result.getResultNumber(), env, builder, loc);
+      if (succeeded(nestedInfo))
+        return nestedInfo;
+    }
+  }
+
+  return analyzePtr(value, env, builder, loc);
+}
+
+static Value getComponentValue(const CFPtrInfo &info,
+                               const IfComponent &component) {
+  if (info.kind == PtrKind::Tensor) {
     if (component.kind == IfComponentKind::TensorOffset)
-      return info.elseParts.tensor.offset;
+      return info.tensor.offset;
     return nullptr;
   }
 
   switch (component.kind) {
   case IfComponentKind::BlockShape:
-    return info.elseParts.block.shape[component.dim];
+    return info.block.shape[component.dim];
   case IfComponentKind::BlockStride:
-    return info.elseParts.block.strides[component.dim];
+    return info.block.strides[component.dim];
   case IfComponentKind::BlockOffset:
-    return info.elseParts.block.offsets[component.dim];
+    return info.block.offsets[component.dim];
   default:
     return nullptr;
   }
@@ -1646,46 +1874,45 @@ findIfInfo(ArrayRef<IfPointerInfo> infos, unsigned oldIndex) {
   return nullptr;
 }
 
-static Value rebuildIfPointer(OpBuilder &builder, Location loc,
-                              const IfPointerInfo &info,
-                              ArrayRef<Value> componentValues) {
+static FailureOr<CFPtrInfo>
+makeIfResultInfo(const IfPointerInfo &info, ArrayRef<Value> componentValues) {
   unsigned componentIndex = 0;
-  if (info.thenParts.kind == PtrKind::Tensor) {
-    Value base = info.thenParts.tensor.base;
-    Value offset = nullptr;
+  CFPtrInfo resultInfo = info.thenInfo;
+  if (info.thenInfo.kind == PtrKind::Tensor) {
     for (const IfComponent &component : info.components) {
       Value value = componentValues[componentIndex++];
-      if (component.kind == IfComponentKind::TensorOffset)
-        offset = value;
+      switch (component.kind) {
+      case IfComponentKind::TensorOffset:
+        resultInfo.tensor.offset = value;
+        break;
+      default:
+        return failure();
+      }
     }
-    return rebuildTensorPtr(builder, loc, info.thenParts.tensor, base, offset);
+    return resultInfo;
   }
 
-  Value base = info.thenParts.block.base;
-  SmallVector<Value> shape = info.thenParts.block.shape;
-  SmallVector<Value> strides = info.thenParts.block.strides;
-  SmallVector<Value> offsets = info.thenParts.block.offsets;
   for (const IfComponent &component : info.components) {
     Value value = componentValues[componentIndex++];
     switch (component.kind) {
     case IfComponentKind::BlockShape:
-      shape[component.dim] = value;
+      resultInfo.block.shape[component.dim] = value;
       break;
     case IfComponentKind::BlockStride:
-      strides[component.dim] = value;
+      resultInfo.block.strides[component.dim] = value;
       break;
     case IfComponentKind::BlockOffset:
-      offsets[component.dim] = value;
+      resultInfo.block.offsets[component.dim] = value;
       break;
     default:
-      return nullptr;
+      return failure();
     }
   }
-  return rebuildBlockPtr(builder, loc, info.thenParts.block, base, shape,
-                         strides, offsets);
+  return resultInfo;
 }
 
-static LogicalResult tryDecoupleIf(scf::IfOp ifOp, IRRewriter &rewriter) {
+static LogicalResult rewriteIfOp(scf::IfOp ifOp, OpBuilder &builder,
+                                 RewriteEnv &env) {
   if (!ifOp.elseBlock() || ifOp->getNumResults() == 0)
     return failure();
 
@@ -1699,30 +1926,32 @@ static LogicalResult tryDecoupleIf(scf::IfOp ifOp, IRRewriter &rewriter) {
   for (auto [idx, result] : llvm::enumerate(ifOp.getResults())) {
     if (!isControlFlowPointerType(result.getType()))
       continue;
+    if (thenYield.getOperand(idx) == elseYield.getOperand(idx))
+      continue;
 
-    FailureOr<PtrParts> thenParts = analyzePtr(
-        thenYield.getOperand(idx), analysisBuilder, thenYield.getLoc());
-    FailureOr<PtrParts> elseParts = analyzePtr(
-        elseYield.getOperand(idx), analysisBuilder, elseYield.getLoc());
-    if (failed(thenParts) || failed(elseParts) ||
-        (*thenParts).kind != (*elseParts).kind)
+    FailureOr<CFPtrInfo> thenInfo = analyzePtrForIfPlanning(
+        thenYield.getOperand(idx), env, analysisBuilder, thenYield.getLoc());
+    FailureOr<CFPtrInfo> elseInfo = analyzePtrForIfPlanning(
+        elseYield.getOperand(idx), env, analysisBuilder, elseYield.getLoc());
+    if (failed(thenInfo) || failed(elseInfo) ||
+        (*thenInfo).kind != (*elseInfo).kind)
       continue;
 
     IfPointerInfo info;
     info.oldIndex = idx;
-    info.thenParts = *thenParts;
-    info.elseParts = *elseParts;
-    if (info.thenParts.kind == PtrKind::Tensor) {
-      if (info.thenParts.tensor.resultType != info.elseParts.tensor.resultType ||
-          info.thenParts.tensor.scalarBase != info.elseParts.tensor.scalarBase)
+    info.thenInfo = *thenInfo;
+    info.elseInfo = *elseInfo;
+    if (info.thenInfo.kind == PtrKind::Tensor) {
+      if (info.thenInfo.tensor.resultType != info.elseInfo.tensor.resultType ||
+          info.thenInfo.tensor.scalarBase != info.elseInfo.tensor.scalarBase)
         continue;
-      if (failed(addIfTensorComponents(info.thenParts.tensor,
-                                       info.elseParts.tensor,
+      if (failed(addIfTensorComponents(info.thenInfo.tensor,
+                                       info.elseInfo.tensor,
                                        info.components)))
         continue;
     } else {
-      if (failed(addIfBlockComponents(info.thenParts.block,
-                                      info.elseParts.block, info.components)))
+      if (failed(addIfBlockComponents(info.thenInfo.block,
+                                      info.elseInfo.block, info.components)))
         continue;
     }
     pointerInfos.push_back(info);
@@ -1741,74 +1970,129 @@ static LogicalResult tryDecoupleIf(scf::IfOp ifOp, IRRewriter &rewriter) {
     newResultTypes.push_back(result.getType());
   }
 
-  auto buildBranch = [&](OpBuilder &builder, Location loc, bool isThen) {
-    IRMapping mapping;
+  bool bodyOk = true;
+  auto buildBranch = [&](OpBuilder &branchBuilder, Location loc,
+                         bool isThen) -> LogicalResult {
+    RewriteEnv branchEnv = env;
     Block *oldBlock = isThen ? ifOp.thenBlock() : ifOp.elseBlock();
     scf::YieldOp oldYield = isThen ? thenYield : elseYield;
-    for (Operation &bodyOp : oldBlock->without_terminator())
-      builder.clone(bodyOp, mapping);
+    if (failed(rewriteBodyOps(oldBlock, branchBuilder, branchEnv)))
+      return failure();
 
     SmallVector<Value> newYieldOperands;
     for (auto [idx, oldOperand] : llvm::enumerate(oldYield.getOperands())) {
       if (const IfPointerInfo *info = findIfInfo(pointerInfos, idx)) {
+        FailureOr<CFPtrInfo> branchInfo =
+            analyzePtr(oldOperand, branchEnv, branchBuilder,
+                       oldYield.getLoc());
+        if (failed(branchInfo) || branchInfo->kind != info->thenInfo.kind)
+          return failure();
         for (const IfComponent &component : info->components) {
-          Value value = isThen ? getThenComponentValue(*info, component)
-                               : getElseComponentValue(*info, component);
-          newYieldOperands.push_back(mapping.lookupOrDefault(value));
+          Value value = getComponentValue(*branchInfo, component);
+          if (!value || value.getType() != component.type)
+            return failure();
+          newYieldOperands.push_back(value);
         }
         continue;
       }
-      newYieldOperands.push_back(mapping.lookupOrDefault(oldOperand));
+      newYieldOperands.push_back(remapValue(oldOperand, branchEnv));
     }
-    builder.create<scf::YieldOp>(oldYield.getLoc(), newYieldOperands);
+    branchBuilder.create<scf::YieldOp>(oldYield.getLoc(), newYieldOperands);
+    return success();
   };
 
-  rewriter.setInsertionPoint(ifOp);
-  auto newIfOp = rewriter.create<scf::IfOp>(
-      ifOp.getLoc(), newResultTypes, ifOp.getCondition(), true);
+  auto newIfOp = builder.create<scf::IfOp>(
+      ifOp.getLoc(), newResultTypes, remapValue(ifOp.getCondition(), env),
+      true);
   newIfOp->setAttrs(ifOp->getAttrs());
 
   {
-    OpBuilder::InsertionGuard guard(rewriter);
+    OpBuilder::InsertionGuard guard(builder);
     if (newResultTypes.empty()) {
       newIfOp.thenBlock()->getTerminator()->erase();
-      rewriter.setInsertionPointToEnd(newIfOp.thenBlock());
+      builder.setInsertionPointToEnd(newIfOp.thenBlock());
     } else {
-      rewriter.setInsertionPointToStart(newIfOp.thenBlock());
+      builder.setInsertionPointToStart(newIfOp.thenBlock());
     }
-    buildBranch(rewriter, ifOp.getLoc(), /*isThen=*/true);
+    if (failed(buildBranch(builder, ifOp.getLoc(), /*isThen=*/true)))
+      bodyOk = false;
   }
   {
-    OpBuilder::InsertionGuard guard(rewriter);
+    OpBuilder::InsertionGuard guard(builder);
     if (newResultTypes.empty()) {
       newIfOp.elseBlock()->getTerminator()->erase();
-      rewriter.setInsertionPointToEnd(newIfOp.elseBlock());
+      builder.setInsertionPointToEnd(newIfOp.elseBlock());
     } else {
-      rewriter.setInsertionPointToStart(newIfOp.elseBlock());
+      builder.setInsertionPointToStart(newIfOp.elseBlock());
     }
-    buildBranch(rewriter, ifOp.getLoc(), /*isThen=*/false);
+    if (failed(buildBranch(builder, ifOp.getLoc(), /*isThen=*/false)))
+      bodyOk = false;
   }
 
-  rewriter.setInsertionPointAfter(newIfOp);
-  SmallVector<Value> replacements;
+  if (!bodyOk) {
+    newIfOp.erase();
+    return failure();
+  }
+
+  builder.setInsertionPointAfter(newIfOp);
   unsigned newResultIndex = 0;
   for (auto [idx, oldResult] : llvm::enumerate(ifOp.getResults())) {
     if (const IfPointerInfo *info = findIfInfo(pointerInfos, idx)) {
       SmallVector<Value> componentValues;
       for (unsigned i = 0; i < info->components.size(); ++i)
         componentValues.push_back(newIfOp.getResult(newResultIndex++));
-      replacements.push_back(
-          rebuildIfPointer(rewriter, oldResult.getLoc(), *info,
-                           componentValues));
+      FailureOr<CFPtrInfo> resultInfo =
+          makeIfResultInfo(*info, componentValues);
+      if (failed(resultInfo)) {
+        newIfOp.erase();
+        return failure();
+      }
+      Value rebuilt = rebuildPtr(builder, oldResult.getLoc(), *resultInfo);
+      if (!rebuilt) {
+        newIfOp.erase();
+        return failure();
+      }
+      recordPointer(oldResult, *resultInfo, rebuilt, env);
       continue;
     }
-    replacements.push_back(newIfOp.getResult(newResultIndex++));
+    env.valueMapping.map(oldResult, newIfOp.getResult(newResultIndex++));
   }
 
-  if (llvm::any_of(replacements, [](Value value) { return !value; }))
+  return success();
+}
+
+static LogicalResult rewriteControlFlowOp(Operation *op, OpBuilder &builder,
+                                          RewriteEnv &env) {
+  if (auto forOp = dyn_cast<scf::ForOp>(op))
+    return rewriteForOp(forOp, builder, env);
+  if (auto whileOp = dyn_cast<scf::WhileOp>(op))
+    return rewriteWhileOp(whileOp, builder, env);
+  if (auto ifOp = dyn_cast<scf::IfOp>(op))
+    return rewriteIfOp(ifOp, builder, env);
+  return failure();
+}
+
+static SmallVector<Value> collectReplacements(Operation *op,
+                                              const RewriteEnv &env) {
+  SmallVector<Value> replacements;
+  replacements.reserve(op->getNumResults());
+  for (Value result : op->getResults())
+    replacements.push_back(remapValue(result, env));
+  return replacements;
+}
+
+static LogicalResult tryDecoupleControlFlowOp(Operation *op,
+                                              IRRewriter &rewriter) {
+  RewriteEnv env;
+  rewriter.setInsertionPoint(op);
+  if (failed(rewriteControlFlowOp(op, rewriter, env)))
     return failure();
 
-  rewriter.replaceOp(ifOp, replacements);
+  SmallVector<Value> replacements = collectReplacements(op, env);
+  if (replacements.size() != op->getNumResults() ||
+      llvm::any_of(replacements, [](Value value) { return !value; }))
+    return failure();
+  rewriter.replaceOp(op, replacements);
   return success();
 }
 
@@ -1868,15 +2152,7 @@ void TritonControlFlowOptPass::runOnOperation() {
     if (op->getParentOp() == nullptr)
       continue;
 
-    LogicalResult result = failure();
-    if (auto forOp = dyn_cast<scf::ForOp>(op))
-      result = tryDecoupleFor(forOp, rewriter);
-    else if (auto whileOp = dyn_cast<scf::WhileOp>(op))
-      result = tryDecoupleWhile(whileOp, rewriter);
-    else if (auto ifOp = dyn_cast<scf::IfOp>(op))
-      result = tryDecoupleIf(ifOp, rewriter);
-
-    (void)result;
+    (void)tryDecoupleControlFlowOp(op, rewriter);
   }
 
   if (failed(verify(moduleOp)))

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/cf_terminal_return.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/cf_terminal_return.mlir
@@ -1,0 +1,134 @@
+// RUN: triton-opt --triton-control-flow-opt --split-input-file %s | FileCheck %s --implicit-check-not="cf.cond_br" --implicit-check-not="cf.br"
+
+module {
+  tt.func public @terminal_return_void(%cond: i1) {
+    cf.cond_br %cond, ^bb1, ^bb2
+  ^bb1:
+    tt.return
+  ^bb2:
+    cf.br ^bb3
+  ^bb3:
+    tt.return
+  }
+}
+
+// CHECK-LABEL: tt.func public @terminal_return_void
+// CHECK:       scf.if %{{.*}} {
+// CHECK:       } else {
+// CHECK:       }
+// CHECK:       tt.return
+
+// -----
+
+module {
+  tt.func public @terminal_return_value(%cond: i1, %lhs: i32, %rhs: i32) -> i32 {
+    cf.cond_br %cond, ^bb1, ^bb2
+  ^bb1:
+    %then = arith.addi %lhs, %rhs : i32
+    tt.return %then : i32
+  ^bb2:
+    %else = arith.subi %lhs, %rhs : i32
+    tt.return %else : i32
+  }
+}
+
+// CHECK-LABEL: tt.func public @terminal_return_value
+// CHECK:       %[[IF:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:         arith.addi
+// CHECK:         scf.yield %{{.*}} : i32
+// CHECK:       } else {
+// CHECK:         arith.subi
+// CHECK:         scf.yield %{{.*}} : i32
+// CHECK:       }
+// CHECK:       tt.return %[[IF]] : i32
+
+// -----
+
+module {
+  tt.func public @terminal_return_nested(%outer: i1, %inner: i1, %x: i32, %y: i32, %z: i32) -> i32 {
+    cf.cond_br %outer, ^bb1, ^bb2
+  ^bb1:
+    %then = arith.addi %x, %y : i32
+    tt.return %then : i32
+  ^bb2:
+    cf.cond_br %inner, ^bb3, ^bb4
+  ^bb3:
+    %inner_then = arith.addi %x, %z : i32
+    tt.return %inner_then : i32
+  ^bb4:
+    %inner_else = arith.subi %x, %z : i32
+    tt.return %inner_else : i32
+  }
+}
+
+// CHECK-LABEL: tt.func public @terminal_return_nested
+// CHECK:       %[[OUTER:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:         arith.addi
+// CHECK:         scf.yield %{{.*}} : i32
+// CHECK:       } else {
+// CHECK:         %[[INNER:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:           arith.addi
+// CHECK:           scf.yield %{{.*}} : i32
+// CHECK:         } else {
+// CHECK:           arith.subi
+// CHECK:           scf.yield %{{.*}} : i32
+// CHECK:         }
+// CHECK:         scf.yield %[[INNER]] : i32
+// CHECK:       }
+// CHECK:       tt.return %[[OUTER]] : i32
+
+// -----
+
+module {
+  tt.func public @terminal_return_branch_args(%cond: i1, %lhs: i32, %rhs: i32, %bias: i32) -> i32 {
+    cf.cond_br %cond, ^bb1(%lhs : i32), ^bb2(%rhs : i32)
+  ^bb1(%v1: i32):
+    %then = arith.addi %v1, %bias : i32
+    tt.return %then : i32
+  ^bb2(%v2: i32):
+    %else = arith.subi %v2, %bias : i32
+    tt.return %else : i32
+  }
+}
+
+// CHECK-LABEL: tt.func public @terminal_return_branch_args
+// CHECK:       %[[IF:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:         arith.addi
+// CHECK:         scf.yield %{{.*}} : i32
+// CHECK:       } else {
+// CHECK:         arith.subi
+// CHECK:         scf.yield %{{.*}} : i32
+// CHECK:       }
+// CHECK:       tt.return %[[IF]] : i32
+
+// -----
+
+module {
+  tt.func public @terminal_return_nested_with_join(%outer: i1, %inner: i1, %x: i32, %y: i32, %z: i32) -> i32 {
+    cf.cond_br %outer, ^bb1(%x : i32), ^bb_join(%y : i32)
+  ^bb1(%v: i32):
+    cf.cond_br %inner, ^bb_ret, ^bb_join(%v : i32)
+  ^bb_ret:
+    %early = arith.addi %x, %z : i32
+    tt.return %early : i32
+  ^bb_join(%j: i32):
+    %cont = arith.subi %j, %z : i32
+    tt.return %cont : i32
+  }
+}
+
+// CHECK-LABEL: tt.func public @terminal_return_nested_with_join
+// CHECK:       %[[OUTER:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:         %[[INNER:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:           arith.addi
+// CHECK:           scf.yield %{{.*}} : i32
+// CHECK:         } else {
+// CHECK:           arith.subi
+// CHECK:           scf.yield %{{.*}} : i32
+// CHECK:         }
+// CHECK:         scf.yield %[[INNER]] : i32
+// CHECK:       } else {
+// CHECK:         arith.subi
+// CHECK:         scf.yield %{{.*}} : i32
+// CHECK:       }
+// CHECK:       tt.return %[[OUTER]] : i32

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/cf_to_scf_empty_result_if.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/cf_to_scf_empty_result_if.mlir
@@ -1,0 +1,20 @@
+// RUN: triton-opt --triton-control-flow-opt --split-input-file %s | FileCheck %s --implicit-check-not="cf.cond_br" --implicit-check-not="cf.br"
+
+module {
+  tt.func public @cf_to_scf_empty_result_if(%cond: i1, %lhs: i32, %rhs: i32) -> i32 {
+    %c0_i32 = arith.constant 0 : i32
+    cf.cond_br %cond, ^bb_return, ^bb_compute
+  ^bb_return:
+    tt.return %c0_i32 : i32
+  ^bb_compute:
+    %unused = arith.addi %lhs, %rhs : i32
+    cf.br ^bb_return
+  }
+}
+
+// CHECK-LABEL: tt.func public @cf_to_scf_empty_result_if
+// CHECK:       scf.if %{{.*}} {
+// CHECK:       } else {
+// CHECK:         arith.addi
+// CHECK:       }
+// CHECK:       tt.return

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/cf_to_scf_result_types.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/cf_to_scf_result_types.mlir
@@ -1,0 +1,25 @@
+// RUN: triton-opt --triton-control-flow-opt --split-input-file %s | FileCheck %s --implicit-check-not="cf.cond_br" --implicit-check-not="cf.br"
+
+module {
+  tt.func public @cf_to_scf_result_types(%cond: i1, %lhs: i32, %rhs: i32) -> i32 {
+    cf.cond_br %cond, ^bb1, ^bb2
+  ^bb1:
+    %then = arith.addi %lhs, %rhs : i32
+    cf.br ^bb3(%then : i32)
+  ^bb2:
+    %else = arith.subi %lhs, %rhs : i32
+    cf.br ^bb3(%else : i32)
+  ^bb3(%result: i32):
+    tt.return %result : i32
+  }
+}
+
+// CHECK-LABEL: tt.func public @cf_to_scf_result_types
+// CHECK:       %[[IF:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:         arith.addi
+// CHECK:         scf.yield %{{.*}} : i32
+// CHECK:       } else {
+// CHECK:         arith.subi
+// CHECK:         scf.yield %{{.*}} : i32
+// CHECK:       }
+// CHECK:       tt.return %[[IF]] : i32

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/nested_cf_to_scf.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/nested_cf_to_scf.mlir
@@ -1,0 +1,40 @@
+// RUN: triton-opt --triton-control-flow-opt --split-input-file %s | FileCheck %s --implicit-check-not="cf.cond_br" --implicit-check-not="cf.br"
+
+module {
+  tt.func public @nested_cf_to_scf(%outer: i1, %inner: i1, %x: i32, %y: i32, %z: i32) -> i32 {
+    cf.cond_br %outer, ^bb1, ^bb2
+  ^bb1:
+    cf.cond_br %inner, ^bb3, ^bb4
+  ^bb2:
+    %outer_else = arith.subi %y, %z : i32
+    cf.br ^bb6(%outer_else : i32)
+  ^bb3:
+    %inner_then = arith.addi %x, %z : i32
+    cf.br ^bb5(%inner_then : i32)
+  ^bb4:
+    %inner_else = arith.subi %x, %z : i32
+    cf.br ^bb5(%inner_else : i32)
+  ^bb5(%inner_result: i32):
+    %then_result = arith.addi %inner_result, %y : i32
+    cf.br ^bb6(%then_result : i32)
+  ^bb6(%result: i32):
+    tt.return %result : i32
+  }
+}
+
+// CHECK-LABEL: tt.func public @nested_cf_to_scf
+// CHECK:       %[[OUTER_IF:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:         %[[INNER_IF:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:           arith.addi
+// CHECK:           scf.yield %{{.*}} : i32
+// CHECK:         } else {
+// CHECK:           arith.subi
+// CHECK:           scf.yield %{{.*}} : i32
+// CHECK:         }
+// CHECK:         arith.addi %[[INNER_IF]]
+// CHECK:         scf.yield %{{.*}} : i32
+// CHECK:       } else {
+// CHECK:         arith.subi
+// CHECK:         scf.yield %{{.*}} : i32
+// CHECK:       }
+// CHECK:       tt.return %[[OUTER_IF]] : i32

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scf_pointer_decouple.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scf_pointer_decouple.mlir
@@ -1,0 +1,693 @@
+// RUN: triton-opt --triton-control-flow-opt --split-input-file %s | FileCheck %s
+
+module {
+  tt.func public @for_block_ptr_dynamic_step(%base: !tt.ptr<f16>, %ub: index) -> !tt.ptr<tensor<32xf16>> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %ptr0 = tt.make_tensor_ptr %base, [%c32_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<32xf16>>
+    %final = scf.for %iv = %c0 to %ub step %c1 iter_args(%ptr = %ptr0) -> (!tt.ptr<tensor<32xf16>>) {
+      %iv_i32 = arith.index_cast %iv : index to i32
+      %next = tt.advance %ptr, [%iv_i32] : !tt.ptr<tensor<32xf16>>
+      scf.yield %next : !tt.ptr<tensor<32xf16>>
+    }
+    tt.return %final : !tt.ptr<tensor<32xf16>>
+  }
+}
+
+// CHECK-LABEL: tt.func public @for_block_ptr_dynamic_step
+// CHECK:       %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[OFF:.*]] = %{{.*}}) -> (i32) {
+// CHECK-NOT:     arith.muli
+// CHECK:         tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[OFF]]] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:         %[[NEXT:.*]] = arith.addi %[[OFF]], %{{.*}} : i32
+// CHECK:         scf.yield %[[NEXT]] : i32
+// CHECK:       }
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[FOR]]] {order = array<i32: 0>} : <tensor<32xf16>>
+
+// -----
+
+module {
+  tt.func public @for_block_ptr_invariant_step_closed_form(%base: !tt.ptr<f16>, %ub: index, %stride: i32) -> tensor<32xf16> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %empty_i32 = tt.splat %c0_i32 : i32 -> tensor<32xi32>
+    %empty_f16 = arith.sitofp %empty_i32 : tensor<32xi32> to tensor<32xf16>
+    %ptr0 = tt.make_tensor_ptr %base, [%c32_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<32xf16>>
+    %res:2 = scf.for %iv = %c0 to %ub step %c1 iter_args(%ptr = %ptr0, %acc = %empty_f16) -> (!tt.ptr<tensor<32xf16>>, tensor<32xf16>) {
+      %next = tt.advance %ptr, [%stride] : !tt.ptr<tensor<32xf16>>
+      %loaded = tt.load %next : !tt.ptr<tensor<32xf16>>
+      scf.yield %next, %loaded : !tt.ptr<tensor<32xf16>>, tensor<32xf16>
+    }
+    tt.return %res#1 : tensor<32xf16>
+  }
+}
+
+// CHECK-LABEL: tt.func public @for_block_ptr_invariant_step_closed_form
+// CHECK:       %[[FOR:[^:]+]]:2 = scf.for %[[IV:[^ ]+]] =
+// CHECK-SAME:  {{.*}} iter_args(%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) -> (i32, tensor<32xf16>) {
+// CHECK:         %[[IV_I32:.*]] = arith.index_cast %[[IV]] : index to i32
+// CHECK:         %[[SCALED:.*]] = arith.muli %[[IV_I32]], %{{.*}} : i32
+// CHECK:         %[[CURRENT:.*]] = arith.addi %{{.*}}, %[[SCALED]] : i32
+// CHECK:         %[[NEXT:.*]] = arith.addi %[[CURRENT]], %{{.*}} : i32
+// CHECK:         %[[LOAD_PTR:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[NEXT]]] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:         %[[LOADED:.*]] = tt.load %[[LOAD_PTR]] : !tt.ptr<tensor<32xf16>>
+// CHECK:         scf.yield %[[NEXT]], %[[LOADED]] : i32, tensor<32xf16>
+// CHECK:       }
+// CHECK:       tt.return %[[FOR]]#1 : tensor<32xf16>
+
+// -----
+
+module {
+  tt.func public @while_block_ptr_basic(%base: !tt.ptr<f16>, %n: i32) -> !tt.ptr<tensor<32xf16>> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %ptr0 = tt.make_tensor_ptr %base, [%c32_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<32xf16>>
+    %res:2 = scf.while (%i = %c0_i32, %ptr = %ptr0) : (i32, !tt.ptr<tensor<32xf16>>) -> (i32, !tt.ptr<tensor<32xf16>>) {
+      %cond = arith.cmpi slt, %i, %n : i32
+      scf.condition(%cond) %i, %ptr : i32, !tt.ptr<tensor<32xf16>>
+    } do {
+    ^bb0(%i_a: i32, %ptr_a: !tt.ptr<tensor<32xf16>>):
+      %next_i = arith.addi %i_a, %c1_i32 : i32
+      %next_ptr = tt.advance %ptr_a, [%c1_i32] : !tt.ptr<tensor<32xf16>>
+      scf.yield %next_i, %next_ptr : i32, !tt.ptr<tensor<32xf16>>
+    }
+    tt.return %res#1 : !tt.ptr<tensor<32xf16>>
+  }
+}
+
+// CHECK-LABEL: tt.func public @while_block_ptr_basic
+// CHECK:       %[[WHILE:.*]]:2 = scf.while (%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) : (i32, i32) -> (i32, i32) {
+// CHECK:       scf.condition(%{{.*}}) %{{.*}}, %{{.*}} : i32, i32
+// CHECK:       } do {
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%{{.*}}] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:       scf.yield %{{.*}}, %{{.*}} : i32, i32
+// CHECK:       }
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[WHILE]]#1] {order = array<i32: 0>} : <tensor<32xf16>>
+
+// -----
+
+module {
+  tt.func public @if_block_ptr_same_base_offsets(%base: !tt.ptr<f16>, %cond: i1) -> !tt.ptr<tensor<32xf16>> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %ptr0 = tt.make_tensor_ptr %base, [%c32_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<32xf16>>
+    %selected = scf.if %cond -> (!tt.ptr<tensor<32xf16>>) {
+      %then_ptr = tt.advance %ptr0, [%c1_i32] : !tt.ptr<tensor<32xf16>>
+      scf.yield %then_ptr : !tt.ptr<tensor<32xf16>>
+    } else {
+      %else_ptr = tt.advance %ptr0, [%c2_i32] : !tt.ptr<tensor<32xf16>>
+      scf.yield %else_ptr : !tt.ptr<tensor<32xf16>>
+    }
+    tt.return %selected : !tt.ptr<tensor<32xf16>>
+  }
+}
+
+// CHECK-LABEL: tt.func public @if_block_ptr_same_base_offsets
+// CHECK:       %[[OFF:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:         scf.yield %{{.*}} : i32
+// CHECK:       } else {
+// CHECK:         scf.yield %{{.*}} : i32
+// CHECK:       }
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[OFF]]] {order = array<i32: 0>} : <tensor<32xf16>>
+
+// -----
+
+module {
+  tt.func public @if_tensor_ptr_same_base_offsets(%base: !tt.ptr<f32>, %cond: i1) -> tensor<4x!tt.ptr<f32>> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %off1 = tt.splat %c1_i32 : i32 -> tensor<4xi32>
+    %off2 = tt.splat %c2_i32 : i32 -> tensor<4xi32>
+    %splat = tt.splat %base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %selected = scf.if %cond -> (tensor<4x!tt.ptr<f32>>) {
+      %then_ptr = tt.addptr %splat, %off1 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scf.yield %then_ptr : tensor<4x!tt.ptr<f32>>
+    } else {
+      %else_ptr = tt.addptr %splat, %off2 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scf.yield %else_ptr : tensor<4x!tt.ptr<f32>>
+    }
+    tt.return %selected : tensor<4x!tt.ptr<f32>>
+  }
+}
+
+// CHECK-LABEL: tt.func public @if_tensor_ptr_same_base_offsets
+// CHECK:       %[[OFF:.*]] = scf.if %{{.*}} -> (tensor<4xi32>) {
+// CHECK:         scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:       } else {
+// CHECK:         scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:       }
+// CHECK:       tt.splat %{{.*}} : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+// CHECK:       tt.addptr %{{.*}}, %[[OFF]] : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+
+// -----
+
+module {
+  tt.func public @while_block_ptr_large_step(%base: !tt.ptr<f16>, %n: i32) -> !tt.ptr<tensor<32xf16>> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c37_i32 = arith.constant 37 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %ptr0 = tt.make_tensor_ptr %base, [%c128_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<32xf16>>
+    %res:2 = scf.while (%i = %c0_i32, %ptr = %ptr0) : (i32, !tt.ptr<tensor<32xf16>>) -> (i32, !tt.ptr<tensor<32xf16>>) {
+      %cond = arith.cmpi slt, %i, %n : i32
+      scf.condition(%cond) %i, %ptr : i32, !tt.ptr<tensor<32xf16>>
+    } do {
+    ^bb0(%i_a: i32, %ptr_a: !tt.ptr<tensor<32xf16>>):
+      %next_i = arith.addi %i_a, %c1_i32 : i32
+      %next_ptr = tt.advance %ptr_a, [%c37_i32] : !tt.ptr<tensor<32xf16>>
+      scf.yield %next_i, %next_ptr : i32, !tt.ptr<tensor<32xf16>>
+    }
+    tt.return %res#1 : !tt.ptr<tensor<32xf16>>
+  }
+}
+
+// CHECK-LABEL: tt.func public @while_block_ptr_large_step
+// CHECK-DAG:   %[[C37:.*]] = arith.constant 37 : i32
+// CHECK:       } do {
+// CHECK:         %[[NEXT_OFF:.*]] = arith.addi %{{.*}}, %[[C37]] : i32
+// CHECK:         scf.yield %{{.*}}, %[[NEXT_OFF]] : i32, i32
+
+// -----
+
+module {
+  tt.func public @while_tensor_ptr_addptr_step(%base: !tt.ptr<f32>, %n: i32) -> tensor<4x!tt.ptr<f32>> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %splat = tt.splat %base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %res:2 = scf.while (%i = %c0_i32, %ptr = %splat) : (i32, tensor<4x!tt.ptr<f32>>) -> (i32, tensor<4x!tt.ptr<f32>>) {
+      %cond = arith.cmpi slt, %i, %n : i32
+      scf.condition(%cond) %i, %ptr : i32, tensor<4x!tt.ptr<f32>>
+    } do {
+    ^bb0(%i_a: i32, %ptr_a: tensor<4x!tt.ptr<f32>>):
+      %next_i = arith.addi %i_a, %c1_i32 : i32
+      %step = tt.splat %c4_i32 : i32 -> tensor<4xi32>
+      %next_ptr = tt.addptr %ptr_a, %step : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scf.yield %next_i, %next_ptr : i32, tensor<4x!tt.ptr<f32>>
+    }
+    tt.return %res#1 : tensor<4x!tt.ptr<f32>>
+  }
+}
+
+// CHECK-LABEL: tt.func public @while_tensor_ptr_addptr_step
+// CHECK:       scf.while
+// CHECK-SAME:  tensor<4xi32>
+// CHECK:       } do {
+// CHECK:         %[[STEP:.*]] = tt.splat %{{.*}} : i32 -> tensor<4xi32>
+// CHECK:         %[[NEXT_OFF:.*]] = arith.addi %{{.*}}, %[[STEP]] : tensor<4xi32>
+// CHECK:         scf.yield %{{.*}}, %[[NEXT_OFF]] : i32, tensor<4xi32>
+
+// -----
+
+module {
+  tt.func public @for_tensor_ptr_preserves_wide_loop_offset(%base: !tt.ptr<f32>, %ub: index) -> tensor<4x!tt.ptr<f32>> {
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i64 = arith.constant 8 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %wide_offset = tt.splat %c8_i64 : i64 -> tensor<4xi64>
+    %narrow_step = tt.splat %c1_i32 : i32 -> tensor<4xi32>
+    %splat = tt.splat %base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %ptr0 = tt.addptr %splat, %wide_offset : tensor<4x!tt.ptr<f32>>, tensor<4xi64>
+    %final = scf.for %iv = %c0 to %ub step %c1 iter_args(%ptr = %ptr0) -> (tensor<4x!tt.ptr<f32>>) {
+      %next = tt.addptr %ptr, %narrow_step : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scf.yield %next : tensor<4x!tt.ptr<f32>>
+    }
+    tt.return %final : tensor<4x!tt.ptr<f32>>
+  }
+}
+
+// CHECK-LABEL: tt.func public @for_tensor_ptr_preserves_wide_loop_offset
+// CHECK:       %[[STEP32:.*]] = tt.splat %{{.*}} : i32 -> tensor<4xi32>
+// CHECK:       %[[FOR:.*]] = scf.for
+// CHECK-SAME:  -> (tensor<4xi64>) {
+// CHECK:         %[[STEP64:.*]] = arith.extsi %[[STEP32]] : tensor<4xi32> to tensor<4xi64>
+// CHECK:         %[[NEXT:.*]] = arith.addi %{{.*}}, %[[STEP64]] : tensor<4xi64>
+// CHECK:         scf.yield %[[NEXT]] : tensor<4xi64>
+// CHECK:       }
+// CHECK:       tt.addptr %{{.*}}, %[[FOR]] : tensor<4x!tt.ptr<f32>>, tensor<4xi64>
+
+// -----
+
+module {
+  tt.func public @for_if_block_ptr_same_base_post_advance(%base: !tt.ptr<f16>, %cond: i1) -> !tt.ptr<tensor<32xf16>> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c3_i32 = arith.constant 3 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    %ptr0 = tt.make_tensor_ptr %base, [%c32_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<32xf16>>
+    %final = scf.for %iv = %c0 to %c4 step %c1 iter_args(%ptr = %ptr0) -> (!tt.ptr<tensor<32xf16>>) {
+      %selected = scf.if %cond -> (!tt.ptr<tensor<32xf16>>) {
+        %then_ptr = tt.advance %ptr, [%c1_i32] : !tt.ptr<tensor<32xf16>>
+        scf.yield %then_ptr : !tt.ptr<tensor<32xf16>>
+      } else {
+        %else_ptr = tt.advance %ptr, [%c3_i32] : !tt.ptr<tensor<32xf16>>
+        scf.yield %else_ptr : !tt.ptr<tensor<32xf16>>
+      }
+      %next = tt.advance %selected, [%c2_i32] : !tt.ptr<tensor<32xf16>>
+      scf.yield %next : !tt.ptr<tensor<32xf16>>
+    }
+    tt.return %final : !tt.ptr<tensor<32xf16>>
+  }
+}
+
+// CHECK-LABEL: tt.func public @for_if_block_ptr_same_base_post_advance
+// CHECK:       %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[OFF:.*]] = %{{.*}}) -> (i32) {
+// CHECK:         %[[SELECTED:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:           arith.addi %[[OFF]], %{{.*}} : i32
+// CHECK:           scf.yield %{{.*}} : i32
+// CHECK:         } else {
+// CHECK:           arith.addi %[[OFF]], %{{.*}} : i32
+// CHECK:           scf.yield %{{.*}} : i32
+// CHECK:         }
+// CHECK:         %[[NEXT:.*]] = arith.addi %[[SELECTED]], %{{.*}} : i32
+// CHECK:         scf.yield %[[NEXT]] : i32
+// CHECK:       }
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[FOR]]] {order = array<i32: 0>} : <tensor<32xf16>>
+
+// -----
+
+module {
+  tt.func public @while_if_block_ptr_same_base_post_advance(%base: !tt.ptr<f16>, %n: i32) -> !tt.ptr<tensor<32xf16>> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c3_i32 = arith.constant 3 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %ptr0 = tt.make_tensor_ptr %base, [%c32_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<32xf16>>
+    %res:2 = scf.while (%i = %c0_i32, %ptr = %ptr0) : (i32, !tt.ptr<tensor<32xf16>>) -> (i32, !tt.ptr<tensor<32xf16>>) {
+      %cond = arith.cmpi slt, %i, %n : i32
+      scf.condition(%cond) %i, %ptr : i32, !tt.ptr<tensor<32xf16>>
+    } do {
+    ^bb0(%i_a: i32, %ptr_a: !tt.ptr<tensor<32xf16>>):
+      %is_one = arith.cmpi eq, %i_a, %c1_i32 : i32
+      %selected = scf.if %is_one -> (!tt.ptr<tensor<32xf16>>) {
+        %then_ptr = tt.advance %ptr_a, [%c3_i32] : !tt.ptr<tensor<32xf16>>
+        scf.yield %then_ptr : !tt.ptr<tensor<32xf16>>
+      } else {
+        %else_ptr = tt.advance %ptr_a, [%c1_i32] : !tt.ptr<tensor<32xf16>>
+        scf.yield %else_ptr : !tt.ptr<tensor<32xf16>>
+      }
+      %next_ptr = tt.advance %selected, [%c2_i32] : !tt.ptr<tensor<32xf16>>
+      %next_i = arith.addi %i_a, %c1_i32 : i32
+      scf.yield %next_i, %next_ptr : i32, !tt.ptr<tensor<32xf16>>
+    }
+    tt.return %res#1 : !tt.ptr<tensor<32xf16>>
+  }
+}
+
+// CHECK-LABEL: tt.func public @while_if_block_ptr_same_base_post_advance
+// CHECK:       %[[WHILE:.*]]:2 = scf.while
+// CHECK-SAME:  (i32, i32) -> (i32, i32)
+// CHECK:       } do {
+// CHECK:         %[[SELECTED:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:           scf.yield %{{.*}} : i32
+// CHECK:         } else {
+// CHECK:           scf.yield %{{.*}} : i32
+// CHECK:         }
+// CHECK:         %[[NEXT:.*]] = arith.addi %[[SELECTED]], %{{.*}} : i32
+// CHECK:         scf.yield %{{.*}}, %[[NEXT]] : i32, i32
+// CHECK:       }
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[WHILE]]#1] {order = array<i32: 0>} : <tensor<32xf16>>
+
+// -----
+
+module {
+  tt.func public @for_if_tensor_ptr_same_base_post_addptr(%base: !tt.ptr<f32>, %cond: i1) -> tensor<4x!tt.ptr<f32>> {
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c3_i32 = arith.constant 3 : i32
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    %off1 = tt.splat %c1_i32 : i32 -> tensor<4xi32>
+    %off2 = tt.splat %c2_i32 : i32 -> tensor<4xi32>
+    %off3 = tt.splat %c3_i32 : i32 -> tensor<4xi32>
+    %splat = tt.splat %base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %final = scf.for %iv = %c0 to %c4 step %c1 iter_args(%ptr = %splat) -> (tensor<4x!tt.ptr<f32>>) {
+      %selected = scf.if %cond -> (tensor<4x!tt.ptr<f32>>) {
+        %then_ptr = tt.addptr %ptr, %off1 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+        scf.yield %then_ptr : tensor<4x!tt.ptr<f32>>
+      } else {
+        %else_ptr = tt.addptr %ptr, %off3 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+        scf.yield %else_ptr : tensor<4x!tt.ptr<f32>>
+      }
+      %next = tt.addptr %selected, %off2 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scf.yield %next : tensor<4x!tt.ptr<f32>>
+    }
+    tt.return %final : tensor<4x!tt.ptr<f32>>
+  }
+}
+
+// CHECK-LABEL: tt.func public @for_if_tensor_ptr_same_base_post_addptr
+// CHECK-DAG:   %[[C2:.*]] = arith.constant 2 : i32
+// CHECK-DAG:   %[[POST_STEP:.*]] = tt.splat %[[C2]] : i32 -> tensor<4xi32>
+// CHECK:       %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[OFF:.*]] = %{{.*}}) -> (tensor<4xi32>) {
+// CHECK:         %[[CARRIED:.*]] = arith.addi %{{.*}}, %[[OFF]] : tensor<4xi32>
+// CHECK:         %[[SELECTED:.*]] = scf.if %{{.*}} -> (tensor<4xi32>) {
+// CHECK:           arith.addi %{{.*}}, %{{.*}} : tensor<4xi32>
+// CHECK:           scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:         } else {
+// CHECK:           arith.addi %{{.*}}, %{{.*}} : tensor<4xi32>
+// CHECK:           scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:         }
+// CHECK:         %[[MERGED:.*]] = arith.addi %[[CARRIED]], %[[SELECTED]] : tensor<4xi32>
+// CHECK:         %[[NEXT:.*]] = arith.addi %{{.*}}, %[[POST_STEP]] : tensor<4xi32>
+// CHECK:         scf.yield %[[NEXT]] : tensor<4xi32>
+// CHECK:       }
+// CHECK:       tt.addptr %{{.*}}, %[[FOR]] : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+
+// -----
+
+module {
+  tt.func public @if_tensor_ptr_diff_base_not_decoupled(%base0: !tt.ptr<f32>, %base1: !tt.ptr<f32>, %cond: i1) -> tensor<4x!tt.ptr<f32>> {
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %off1 = tt.splat %c1_i32 : i32 -> tensor<4xi32>
+    %off2 = tt.splat %c2_i32 : i32 -> tensor<4xi32>
+    %splat0 = tt.splat %base0 : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %splat1 = tt.splat %base1 : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %selected = scf.if %cond -> (tensor<4x!tt.ptr<f32>>) {
+      %then_ptr = tt.addptr %splat0, %off1 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scf.yield %then_ptr : tensor<4x!tt.ptr<f32>>
+    } else {
+      %else_ptr = tt.addptr %splat1, %off2 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scf.yield %else_ptr : tensor<4x!tt.ptr<f32>>
+    }
+    tt.return %selected : tensor<4x!tt.ptr<f32>>
+  }
+}
+
+// CHECK-LABEL: tt.func public @if_tensor_ptr_diff_base_not_decoupled
+// CHECK:       scf.if %{{.*}} -> (tensor<4x!tt.ptr<f32>>) {
+// CHECK:         tt.addptr
+// CHECK:       } else {
+// CHECK:         tt.addptr
+// CHECK:       }
+
+// -----
+
+module {
+  tt.func public @for_if_block_ptr_load_after_post_advance(%base: !tt.ptr<f16>, %cond: i1) -> tensor<32xf16> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c3_i32 = arith.constant 3 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    %empty = tt.splat %c0_i32 : i32 -> tensor<32xi32>
+    %empty_f16 = arith.sitofp %empty : tensor<32xi32> to tensor<32xf16>
+    %ptr0 = tt.make_tensor_ptr %base, [%c32_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<32xf16>>
+    %res:2 = scf.for %iv = %c0 to %c4 step %c1 iter_args(%ptr = %ptr0, %acc = %empty_f16) -> (!tt.ptr<tensor<32xf16>>, tensor<32xf16>) {
+      %selected = scf.if %cond -> (!tt.ptr<tensor<32xf16>>) {
+        %then_ptr = tt.advance %ptr, [%c1_i32] : !tt.ptr<tensor<32xf16>>
+        scf.yield %then_ptr : !tt.ptr<tensor<32xf16>>
+      } else {
+        %else_ptr = tt.advance %ptr, [%c3_i32] : !tt.ptr<tensor<32xf16>>
+        scf.yield %else_ptr : !tt.ptr<tensor<32xf16>>
+      }
+      %next = tt.advance %selected, [%c2_i32] : !tt.ptr<tensor<32xf16>>
+      %loaded = tt.load %next : !tt.ptr<tensor<32xf16>>
+      scf.yield %next, %loaded : !tt.ptr<tensor<32xf16>>, tensor<32xf16>
+    }
+    tt.return %res#1 : tensor<32xf16>
+  }
+}
+
+// CHECK-LABEL: tt.func public @for_if_block_ptr_load_after_post_advance
+// CHECK:       %[[FOR:.*]]:2 = scf.for {{.*}} iter_args(%[[OFF:.*]] = %{{.*}}, %{{.*}} = %{{.*}}) -> (i32, tensor<32xf16>) {
+// CHECK:         %[[SELECTED:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:           arith.addi %[[OFF]], %{{.*}} : i32
+// CHECK:           scf.yield %{{.*}} : i32
+// CHECK:         } else {
+// CHECK:           arith.addi %[[OFF]], %{{.*}} : i32
+// CHECK:           scf.yield %{{.*}} : i32
+// CHECK:         }
+// CHECK:         %[[NEXT:.*]] = arith.addi %[[SELECTED]], %{{.*}} : i32
+// CHECK:         %[[LOAD_PTR:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[NEXT]]] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:         %[[LOADED:.*]] = tt.load %[[LOAD_PTR]] : !tt.ptr<tensor<32xf16>>
+// CHECK:         scf.yield %[[NEXT]], %[[LOADED]] : i32, tensor<32xf16>
+// CHECK:       }
+// CHECK:       tt.return %[[FOR]]#1 : tensor<32xf16>
+
+// -----
+
+module {
+  tt.func public @for_nested_if_block_ptr_load_after_post_advance(%base: !tt.ptr<f32>, %cond0: i1, %cond1: i1) -> tensor<16xf32> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c3_i32 = arith.constant 3 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    %empty_i32 = tt.splat %c0_i32 : i32 -> tensor<16xi32>
+    %empty_f32 = arith.sitofp %empty_i32 : tensor<16xi32> to tensor<16xf32>
+    %ptr0 = tt.make_tensor_ptr %base, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf32>>
+    %res:2 = scf.for %iv = %c0 to %c4 step %c1 iter_args(%ptr = %ptr0, %acc = %empty_f32) -> (!tt.ptr<tensor<16xf32>>, tensor<16xf32>) {
+      %selected = scf.if %cond0 -> (!tt.ptr<tensor<16xf32>>) {
+        %a = tt.advance %ptr, [%c1_i32] : !tt.ptr<tensor<16xf32>>
+        %inner = scf.if %cond1 -> (!tt.ptr<tensor<16xf32>>) {
+          %b = tt.advance %a, [%c2_i32] : !tt.ptr<tensor<16xf32>>
+          scf.yield %b : !tt.ptr<tensor<16xf32>>
+        } else {
+          %b = tt.advance %a, [%c4_i32] : !tt.ptr<tensor<16xf32>>
+          scf.yield %b : !tt.ptr<tensor<16xf32>>
+        }
+        scf.yield %inner : !tt.ptr<tensor<16xf32>>
+      } else {
+        %a = tt.advance %ptr, [%c3_i32] : !tt.ptr<tensor<16xf32>>
+        %inner = scf.if %cond1 -> (!tt.ptr<tensor<16xf32>>) {
+          %b = tt.advance %a, [%c1_i32] : !tt.ptr<tensor<16xf32>>
+          scf.yield %b : !tt.ptr<tensor<16xf32>>
+        } else {
+          %b = tt.advance %a, [%c2_i32] : !tt.ptr<tensor<16xf32>>
+          scf.yield %b : !tt.ptr<tensor<16xf32>>
+        }
+        scf.yield %inner : !tt.ptr<tensor<16xf32>>
+      }
+      %next = tt.advance %selected, [%c1_i32] : !tt.ptr<tensor<16xf32>>
+      %loaded = tt.load %next : !tt.ptr<tensor<16xf32>>
+      scf.yield %next, %loaded : !tt.ptr<tensor<16xf32>>, tensor<16xf32>
+    }
+    tt.return %res#1 : tensor<16xf32>
+  }
+}
+
+// CHECK-LABEL: tt.func public @for_nested_if_block_ptr_load_after_post_advance
+// CHECK:       %[[FOR:.*]]:2 = scf.for {{.*}} iter_args(%[[OFF:.*]] = %{{.*}}, %{{.*}} = %{{.*}}) -> (i32, tensor<16xf32>) {
+// CHECK:         %[[SELECTED:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:           %[[THEN_INNER:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:             scf.yield %{{.*}} : i32
+// CHECK:           } else {
+// CHECK:             scf.yield %{{.*}} : i32
+// CHECK:           }
+// CHECK:           scf.yield %[[THEN_INNER]] : i32
+// CHECK:         } else {
+// CHECK:           %[[ELSE_INNER:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:             scf.yield %{{.*}} : i32
+// CHECK:           } else {
+// CHECK:             scf.yield %{{.*}} : i32
+// CHECK:           }
+// CHECK:           scf.yield %[[ELSE_INNER]] : i32
+// CHECK:         }
+// CHECK:         %[[NEXT:.*]] = arith.addi %[[SELECTED]], %{{.*}} : i32
+// CHECK:         %[[LOAD_PTR:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[NEXT]]] {order = array<i32: 0>} : <tensor<16xf32>>
+// CHECK:         %[[LOADED:.*]] = tt.load %[[LOAD_PTR]] : !tt.ptr<tensor<16xf32>>
+// CHECK:         scf.yield %[[NEXT]], %[[LOADED]] : i32, tensor<16xf32>
+// CHECK:       }
+// CHECK:       tt.return %[[FOR]]#1 : tensor<16xf32>
+
+// -----
+
+module {
+  tt.func public @for_nested_if_tensor_ptr_load_after_post_addptr(%base: !tt.ptr<f32>, %cond0: i1, %cond1: i1) -> tensor<4xf32> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c3_i32 = arith.constant 3 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    %off1 = tt.splat %c1_i32 : i32 -> tensor<4xi32>
+    %off2 = tt.splat %c2_i32 : i32 -> tensor<4xi32>
+    %off3 = tt.splat %c3_i32 : i32 -> tensor<4xi32>
+    %off4 = tt.splat %c4_i32 : i32 -> tensor<4xi32>
+    %empty_i32 = tt.splat %c0_i32 : i32 -> tensor<4xi32>
+    %empty_f32 = arith.sitofp %empty_i32 : tensor<4xi32> to tensor<4xf32>
+    %ptr0 = tt.splat %base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %res:2 = scf.for %iv = %c0 to %c4 step %c1 iter_args(%ptr = %ptr0, %acc = %empty_f32) -> (tensor<4x!tt.ptr<f32>>, tensor<4xf32>) {
+      %selected = scf.if %cond0 -> (tensor<4x!tt.ptr<f32>>) {
+        %a = tt.addptr %ptr, %off1 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+        %inner = scf.if %cond1 -> (tensor<4x!tt.ptr<f32>>) {
+          %b = tt.addptr %a, %off2 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+          scf.yield %b : tensor<4x!tt.ptr<f32>>
+        } else {
+          %b = tt.addptr %a, %off4 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+          scf.yield %b : tensor<4x!tt.ptr<f32>>
+        }
+        scf.yield %inner : tensor<4x!tt.ptr<f32>>
+      } else {
+        %a = tt.addptr %ptr, %off3 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+        %inner = scf.if %cond1 -> (tensor<4x!tt.ptr<f32>>) {
+          %b = tt.addptr %a, %off1 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+          scf.yield %b : tensor<4x!tt.ptr<f32>>
+        } else {
+          %b = tt.addptr %a, %off2 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+          scf.yield %b : tensor<4x!tt.ptr<f32>>
+        }
+        scf.yield %inner : tensor<4x!tt.ptr<f32>>
+      }
+      %next = tt.addptr %selected, %off1 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      %loaded = tt.load %next : tensor<4x!tt.ptr<f32>>
+      scf.yield %next, %loaded : tensor<4x!tt.ptr<f32>>, tensor<4xf32>
+    }
+    tt.return %res#1 : tensor<4xf32>
+  }
+}
+
+// CHECK-LABEL: tt.func public @for_nested_if_tensor_ptr_load_after_post_addptr
+// CHECK:       %[[FOR:.*]]:2 = scf.for
+// CHECK-SAME:  tensor<4xi32>
+// CHECK:         %[[SELECTED:.*]] = scf.if %{{.*}} -> (tensor<4xi32>) {
+// CHECK:           %[[THEN_INNER:.*]] = scf.if %{{.*}} -> (tensor<4xi32>) {
+// CHECK:             scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:           } else {
+// CHECK:             scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:           }
+// CHECK:           arith.addi %{{.*}}, %[[THEN_INNER]] : tensor<4xi32>
+// CHECK:           scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:         } else {
+// CHECK:           %[[ELSE_INNER:.*]] = scf.if %{{.*}} -> (tensor<4xi32>) {
+// CHECK:             scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:           } else {
+// CHECK:             scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:           }
+// CHECK:           arith.addi %{{.*}}, %[[ELSE_INNER]] : tensor<4xi32>
+// CHECK:           scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:         }
+// CHECK:         arith.addi %{{.*}}, %{{.*}} : tensor<4xi32>
+// CHECK:         tt.addptr %{{.*}}, %{{.*}} : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+// CHECK:         %[[LOADED:.*]] = tt.load %{{.*}} : tensor<4x!tt.ptr<f32>>
+// CHECK:         scf.yield %{{.*}}, %[[LOADED]] : tensor<4xi32>, tensor<4xf32>
+// CHECK:       }
+// CHECK:       tt.return %[[FOR]]#1 : tensor<4xf32>
+
+// -----
+
+module {
+  tt.func public @if_block_ptr_same_base_dynamic_shape(%base: !tt.ptr<f32>, %cond: i1, %shape0: i64, %shape1: i64) -> !tt.ptr<tensor<16xf32>> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %selected = scf.if %cond -> (!tt.ptr<tensor<16xf32>>) {
+      %then_ptr = tt.make_tensor_ptr %base, [%shape0], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf32>>
+      scf.yield %then_ptr : !tt.ptr<tensor<16xf32>>
+    } else {
+      %else_ptr = tt.make_tensor_ptr %base, [%shape1], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf32>>
+      scf.yield %else_ptr : !tt.ptr<tensor<16xf32>>
+    }
+    tt.return %selected : !tt.ptr<tensor<16xf32>>
+  }
+}
+
+// CHECK-LABEL: tt.func public @if_block_ptr_same_base_dynamic_shape
+// CHECK:       %[[SHAPE:.*]] = scf.if %{{.*}} -> (i64) {
+// CHECK:         scf.yield %{{.*}} : i64
+// CHECK:       } else {
+// CHECK:         scf.yield %{{.*}} : i64
+// CHECK:       }
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%[[SHAPE]]], [%{{.*}}], [%{{.*}}] {order = array<i32: 0>} : <tensor<16xf32>>
+
+// -----
+
+module {
+  tt.func public @if_block_ptr_diff_base_not_decoupled(%base0: !tt.ptr<f32>, %base1: !tt.ptr<f32>, %cond: i1) -> !tt.ptr<tensor<16xf32>> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %ptr0 = tt.make_tensor_ptr %base0, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf32>>
+    %ptr1 = tt.make_tensor_ptr %base1, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf32>>
+    %selected = scf.if %cond -> (!tt.ptr<tensor<16xf32>>) {
+      %then_ptr = tt.advance %ptr0, [%c1_i32] : !tt.ptr<tensor<16xf32>>
+      scf.yield %then_ptr : !tt.ptr<tensor<16xf32>>
+    } else {
+      %else_ptr = tt.advance %ptr1, [%c2_i32] : !tt.ptr<tensor<16xf32>>
+      scf.yield %else_ptr : !tt.ptr<tensor<16xf32>>
+    }
+    tt.return %selected : !tt.ptr<tensor<16xf32>>
+  }
+}
+
+// CHECK-LABEL: tt.func public @if_block_ptr_diff_base_not_decoupled
+// CHECK:       scf.if %{{.*}} -> (!tt.ptr<tensor<16xf32>>) {
+// CHECK:         tt.advance
+// CHECK:       } else {
+// CHECK:         tt.advance
+// CHECK:       }
+
+// -----
+
+module {
+  tt.func public @if_same_nested_result_not_decoupled(%base: !tt.ptr<f32>, %cond0: i1, %cond1: i1) -> !tt.ptr<tensor<16xf32>> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %ptr = tt.make_tensor_ptr %base, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf32>>
+    %inner = scf.if %cond0 -> (!tt.ptr<tensor<16xf32>>) {
+      %then_ptr = tt.advance %ptr, [%c1_i32] : !tt.ptr<tensor<16xf32>>
+      scf.yield %then_ptr : !tt.ptr<tensor<16xf32>>
+    } else {
+      %else_ptr = tt.advance %ptr, [%c2_i32] : !tt.ptr<tensor<16xf32>>
+      scf.yield %else_ptr : !tt.ptr<tensor<16xf32>>
+    }
+    %outer = scf.if %cond1 -> (!tt.ptr<tensor<16xf32>>) {
+      scf.yield %inner : !tt.ptr<tensor<16xf32>>
+    } else {
+      scf.yield %inner : !tt.ptr<tensor<16xf32>>
+    }
+    tt.return %outer : !tt.ptr<tensor<16xf32>>
+  }
+}
+
+// CHECK-LABEL: tt.func public @if_same_nested_result_not_decoupled
+// CHECK:       %[[INNER_OFF:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:         scf.yield %{{.*}} : i32
+// CHECK:       } else {
+// CHECK:         scf.yield %{{.*}} : i32
+// CHECK:       }
+// CHECK:       %[[INNER_PTR:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[INNER_OFF]]] {order = array<i32: 0>} : <tensor<16xf32>>
+// CHECK:       %[[OUTER:.*]] = scf.if %{{.*}} -> (!tt.ptr<tensor<16xf32>>) {
+// CHECK:         scf.yield %[[INNER_PTR]] : !tt.ptr<tensor<16xf32>>
+// CHECK:       } else {
+// CHECK:         scf.yield %[[INNER_PTR]] : !tt.ptr<tensor<16xf32>>
+// CHECK:       }
+// CHECK:       tt.return %[[OUTER]] : !tt.ptr<tensor<16xf32>>

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scf_scalar_pointer_boundary.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scf_scalar_pointer_boundary.mlir
@@ -1,0 +1,21 @@
+// RUN: triton-opt --triton-control-flow-opt --split-input-file %s | FileCheck %s
+
+module {
+  tt.func public @scalar_pointer_scf_iter_arg_not_decoupled(%base: !tt.ptr<f32>) -> !tt.ptr<f32> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    %result = scf.for %iv = %c0 to %c4 step %c1 iter_args(%ptr = %base) -> (!tt.ptr<f32>) {
+      %next = tt.addptr %ptr, %c1_i32 : !tt.ptr<f32>, i32
+      scf.yield %next : !tt.ptr<f32>
+    }
+    tt.return %result : !tt.ptr<f32>
+  }
+}
+
+// CHECK-LABEL: tt.func public @scalar_pointer_scf_iter_arg_not_decoupled
+// CHECK:       scf.for {{.*}} iter_args(%{{.*}} = %{{.*}}) -> (!tt.ptr<f32>)
+// CHECK:       tt.addptr
+// CHECK:       tt.return %{{.*}} : !tt.ptr<f32>

--- a/third_party/ascend/unittest/pytest_ut/test_control_flow.py
+++ b/third_party/ascend/unittest/pytest_ut/test_control_flow.py
@@ -439,6 +439,213 @@ def test_control_flow_stress_while_if_else_block_ptr_advance():
 
 
 @triton.jit
+def _for_if_else_block_ptr_load_after_post_advance_kernel(
+    in_ptr,
+    out_ptr,
+    flag,
+    n_elements,
+    block: tl.constexpr,
+    n_loops: tl.constexpr,
+):
+    bp = tl.make_block_ptr(
+        base=in_ptr,
+        shape=(n_elements,),
+        strides=(1,),
+        offsets=(0,),
+        block_shape=(block,),
+        order=(0,),
+    )
+    acc = tl.zeros([block], tl.float32)
+    for _ in range(0, n_loops):
+        if flag != 0:
+            bp = tl.advance(bp, (1,))
+        else:
+            bp = tl.advance(bp, (3,))
+        bp = tl.advance(bp, (2,))
+        acc += tl.load(bp)
+    tl.store(out_ptr + tl.arange(0, block), acc)
+
+
+def test_control_flow_stress_for_if_else_block_ptr_load_after_post_advance():
+    block, n_loops = 16, 4
+    n_elements = block + n_loops * 5
+    x = torch.randn((n_elements,), dtype=torch.float32, device="npu")
+
+    for flag in [1, 0]:
+        out = torch.empty((block,), dtype=torch.float32, device="npu")
+        _for_if_else_block_ptr_load_after_post_advance_kernel[(1,)](
+            x, out, flag, n_elements, block, n_loops
+        )
+
+        pos = 0
+        expected = torch.zeros((block,), dtype=torch.float32, device="npu")
+        for _ in range(n_loops):
+            pos += 1 if flag != 0 else 3
+            pos += 2
+            expected += x[pos:pos + block]
+        _assert_close(out, expected)
+
+
+@triton.jit
+def _for_if_else_tensor_ptr_load_after_post_addptr_kernel(
+    in_ptr,
+    out_ptr,
+    flag,
+    block: tl.constexpr,
+    n_loops: tl.constexpr,
+):
+    offs = tl.arange(0, block)
+    step_then = tl.zeros([block], tl.int32) + 1
+    step_else = tl.zeros([block], tl.int32) + 3
+    step_after = tl.zeros([block], tl.int32) + 2
+    ptrs = in_ptr + offs
+    acc = tl.zeros([block], tl.float32)
+    for _ in range(0, n_loops):
+        if flag != 0:
+            ptrs = ptrs + step_then
+        else:
+            ptrs = ptrs + step_else
+        ptrs = ptrs + step_after
+        acc += tl.load(ptrs)
+    tl.store(out_ptr + offs, acc)
+
+
+def test_control_flow_stress_for_if_else_tensor_ptr_load_after_post_addptr():
+    block, n_loops = 16, 4
+    n_elements = block + n_loops * 5
+    x = torch.randn((n_elements,), dtype=torch.float32, device="npu")
+
+    for flag in [1, 0]:
+        out = torch.empty((block,), dtype=torch.float32, device="npu")
+        _for_if_else_tensor_ptr_load_after_post_addptr_kernel[(1,)](
+            x, out, flag, block, n_loops
+        )
+
+        pos = 0
+        expected = torch.zeros((block,), dtype=torch.float32, device="npu")
+        for _ in range(n_loops):
+            pos += 1 if flag != 0 else 3
+            pos += 2
+            expected += x[pos:pos + block]
+        _assert_close(out, expected)
+
+
+@triton.jit
+def _for_nested_if_block_ptr_load_after_repeated_advance_kernel(
+    in_ptr,
+    out_ptr,
+    flag0,
+    flag1,
+    n_elements,
+    block: tl.constexpr,
+    n_loops: tl.constexpr,
+):
+    bp = tl.make_block_ptr(
+        base=in_ptr,
+        shape=(n_elements,),
+        strides=(1,),
+        offsets=(0,),
+        block_shape=(block,),
+        order=(0,),
+    )
+    acc = tl.zeros([block], tl.float32)
+    for _ in range(0, n_loops):
+        if flag0 != 0:
+            bp = tl.advance(bp, (1,))
+            if flag1 != 0:
+                bp = tl.advance(bp, (2,))
+            else:
+                bp = tl.advance(bp, (4,))
+        else:
+            bp = tl.advance(bp, (3,))
+            if flag1 != 0:
+                bp = tl.advance(bp, (1,))
+            else:
+                bp = tl.advance(bp, (2,))
+        bp = tl.advance(bp, (1,))
+        acc += tl.load(bp)
+    tl.store(out_ptr + tl.arange(0, block), acc)
+
+
+def test_control_flow_stress_for_nested_if_block_ptr_load_after_repeated_advance():
+    block, n_loops = 16, 4
+    n_elements = block + n_loops * 6
+    x = torch.randn((n_elements,), dtype=torch.float32, device="npu")
+
+    for flag0, flag1 in [(1, 1), (1, 0), (0, 1), (0, 0)]:
+        out = torch.empty((block,), dtype=torch.float32, device="npu")
+        _for_nested_if_block_ptr_load_after_repeated_advance_kernel[(1,)](
+            x, out, flag0, flag1, n_elements, block, n_loops
+        )
+
+        pos = 0
+        expected = torch.zeros((block,), dtype=torch.float32, device="npu")
+        for _ in range(n_loops):
+            if flag0 != 0:
+                pos += 1
+                pos += 2 if flag1 != 0 else 4
+            else:
+                pos += 3
+                pos += 1 if flag1 != 0 else 2
+            pos += 1
+            expected += x[pos:pos + block]
+        _assert_close(out, expected)
+
+
+@triton.jit
+def _for_while_if_block_ptr_load_after_nested_advance_kernel(
+    in_ptr,
+    out_ptr,
+    flag,
+    n_elements,
+    inner_iters,
+    block: tl.constexpr,
+    outer_loops: tl.constexpr,
+):
+    bp = tl.make_block_ptr(
+        base=in_ptr,
+        shape=(n_elements,),
+        strides=(1,),
+        offsets=(0,),
+        block_shape=(block,),
+        order=(0,),
+    )
+    acc = tl.zeros([block], tl.float32)
+    for _ in range(0, outer_loops):
+        j = 0
+        while j < inner_iters:
+            if flag != 0:
+                bp = tl.advance(bp, (1,))
+            else:
+                bp = tl.advance(bp, (2,))
+            j = j + 1
+        bp = tl.advance(bp, (3,))
+        acc += tl.load(bp)
+    tl.store(out_ptr + tl.arange(0, block), acc)
+
+
+def test_control_flow_stress_for_while_if_block_ptr_load_after_nested_advance():
+    block, outer_loops, inner_iters = 16, 3, 2
+    n_elements = block + outer_loops * (inner_iters * 2 + 3)
+    x = torch.randn((n_elements,), dtype=torch.float32, device="npu")
+
+    for flag in [1, 0]:
+        out = torch.empty((block,), dtype=torch.float32, device="npu")
+        _for_while_if_block_ptr_load_after_nested_advance_kernel[(1,)](
+            x, out, flag, n_elements, inner_iters, block, outer_loops
+        )
+
+        pos = 0
+        expected = torch.zeros((block,), dtype=torch.float32, device="npu")
+        for _ in range(outer_loops):
+            for _ in range(inner_iters):
+                pos += 1 if flag != 0 else 2
+            pos += 3
+            expected += x[pos:pos + block]
+        _assert_close(out, expected)
+
+
+@triton.jit
 def _for_2d_multi_advance_kernel(
     in_ptr,
     out_ptr,
@@ -568,3 +775,62 @@ def test_control_flow_while_tensor_ptr_dynamic_step():
         pos += step
         expected += x[pos:pos + block]
     _assert_close(out, expected)
+
+
+@triton.jit
+def _for_nested_if_tensor_ptr_load_after_repeated_addptr_kernel(
+    in_ptr,
+    out_ptr,
+    flag0,
+    flag1,
+    block: tl.constexpr,
+    n_loops: tl.constexpr,
+):
+    offs = tl.arange(0, block)
+    step1 = tl.zeros([block], tl.int32) + 1
+    step2 = tl.zeros([block], tl.int32) + 2
+    step3 = tl.zeros([block], tl.int32) + 3
+    step4 = tl.zeros([block], tl.int32) + 4
+    ptrs = in_ptr + offs
+    acc = tl.zeros([block], tl.float32)
+    for _ in range(0, n_loops):
+        if flag0 != 0:
+            ptrs = ptrs + step1
+            if flag1 != 0:
+                ptrs = ptrs + step2
+            else:
+                ptrs = ptrs + step4
+        else:
+            ptrs = ptrs + step3
+            if flag1 != 0:
+                ptrs = ptrs + step1
+            else:
+                ptrs = ptrs + step2
+        ptrs = ptrs + step1
+        acc += tl.load(ptrs)
+    tl.store(out_ptr + offs, acc)
+
+
+def test_control_flow_stress_for_nested_if_tensor_ptr_load_after_repeated_addptr():
+    block, n_loops = 16, 4
+    n_elements = block + n_loops * 6
+    x = torch.randn((n_elements,), dtype=torch.float32, device="npu")
+
+    for flag0, flag1 in [(1, 1), (1, 0), (0, 1), (0, 0)]:
+        out = torch.empty((block,), dtype=torch.float32, device="npu")
+        _for_nested_if_tensor_ptr_load_after_repeated_addptr_kernel[(1,)](
+            x, out, flag0, flag1, block, n_loops
+        )
+
+        pos = 0
+        expected = torch.zeros((block,), dtype=torch.float32, device="npu")
+        for _ in range(n_loops):
+            if flag0 != 0:
+                pos += 1
+                pos += 2 if flag1 != 0 else 4
+            else:
+                pos += 3
+                pos += 1 if flag1 != 0 else 2
+            pos += 1
+            expected += x[pos:pos + block]
+        _assert_close(out, expected)


### PR DESCRIPTION
## Summary

The initial `TritonControlFlowOpt` pass added in #66 can recognize basic pointer evolution across control flow, but nested control flow and loop-carried pointer updates still need a richer model. In particular, a pointer may be selected by an `if`, advanced again after the branch, carried through a loop backedge, and then used by `tl.load` / `tl.store`.

For example:

```python
for _ in range(n):
    if cond:
        ptr = tl.advance(ptr, [a])
    else:
        ptr = tl.advance(ptr, [b])

    ptr = tl.advance(ptr, [c])
    value = tl.load(ptr)
```

The useful fact is that both branches still refer to the same pointer base while only selected components (usually offsets) differ. This PR refactors the pass around an explicit rewrite environment and pointer-info model so `scf.if`, `scf.for`, and `scf.while` can carry analyzable pointer components instead of opaque pointer SSA values.

Related to #148.

## Changes

- Refactors `TritonControlFlowOptPass` around `RewriteEnv` and unified `CFPtrInfo` tracking for tensor and block pointers.
- Rewrites supported `scf.for`, `scf.while`, and `scf.if` bodies recursively, preserving pointer facts across nested control flow.
- Extends `scf.if` planning so nested pointer results can be analyzed through branch yields before rebuilding the pointer in the parent scope.
- Carries block pointer shape, stride, and offset components through branch results when they differ between compatible same-base pointers.
- Adds a limited closed-form rewrite for simple invariant-step block pointer advances in `scf.for`, so loads inside the loop can use the current iteration offset directly.
- Keeps scalar pointer boundaries conservative: unsupported scalar pointer loop-carried values are not decoupled.
- Extends CFG-to-SCF lit coverage for result types, empty-result branches, nested CFGs, and terminal-return patterns.
- Adds a guard for same-SSA pointer yields in `scf.if` planning so no unnecessary zero-component pointer rewrite is attempted.
- Makes unexpected `IfComponentKind` handling fail explicitly instead of silently ignoring an unsupported component.

## Impact

- Enables the Ascend backend to compile and lower more Triton kernels with nested pointer updates across `if` / `for` / `while` control flow.
- Improves correctness for cases where a pointer is updated inside a branch and then advanced or loaded after the branch merge.
- Adds MLIR-level regression coverage for the pass itself, making future changes easier to review without relying only on end-to-end NPU tests.
- Does not change Triton frontend syntax or user-facing APIs.
- Keeps the rewrite bounded: incompatible pointer bases, unsupported pointer forms, and unsupported control-flow shapes are left unchanged or rejected instead of being rewritten with incomplete pointer facts.

## Tests

Adds MLIR/FileCheck coverage under `TritonControlFlowOpt` for:

- CFG-to-SCF conversion with result types, empty-result branches, nested CFGs, and terminal returns;
- scalar pointer boundary behavior;
- `scf.for`, `scf.while`, and `scf.if` pointer decomposition;
- nested `scf.if` pointer planning;
- same-base and different-base pointer cases;
- block pointer dynamic shape components;
- invariant-step closed-form rebuild and dynamic-step negative coverage;
- same-SSA pointer yields that should not be decoupled.

Adds end-to-end control-flow kernels covering:

- block pointer `tl.advance` through `for` / `while` / `if`;
- tensor pointer `tl.addptr` through `if`, `while`, and nested `if`;
- post-branch pointer updates followed by load;
- nested `if` and nested `for` / `while` pointer updates;
- 2D block pointer multi-dimensional advances;
- dynamic-step and no-factual-IV while cases.

Validation:

- `for test in third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/*.mlir; do triton-opt --triton-control-flow-opt --split-input-file "$test" | FileCheck "$test"; done`
- `pytest third_party/ascend/unittest/pytest_ut/test_control_flow.py -n 16`
