### PR TITLE
feat(triton): support descriptor atomic op(descriptor_reduce)

### DIFF
--- a/docker/3.2.1-910b-debian12-py3.11/Dockerfile
+++ b/docker/3.2.1-910b-debian12-py3.11/Dockerfile
@@ -144,7 +144,7 @@ RUN pip3 install --no-cache-dir \
     wheel \
     pybind11 \
     --index-url ${PIP_SOURCE}
- 
+
 RUN \
     git config --global http.postBuffer 524288000 && \
     git config --global http.lowSpeedLimit 0 && \
@@ -167,7 +167,7 @@ RUN \
       -DLLVM_ENABLE_LLD=ON \
       -DCMAKE_INSTALL_PREFIX=${LLVM_INSTALL_PREFIX} && \
     ninja install
-    
+
 # Stage 5: Copy results from previous stages
 FROM library/debian:12 AS official-debian
 

--- a/docker/3.2.1-910b-openeuler24.03-py3.11/Dockerfile
+++ b/docker/3.2.1-910b-openeuler24.03-py3.11/Dockerfile
@@ -139,7 +139,7 @@ RUN pip3 install --no-cache-dir \
     wheel \
     pybind11 \
     --index-url ${PIP_SOURCE}
- 
+
 RUN \
     git config --global http.postBuffer 524288000 && \
     git config --global http.lowSpeedLimit 0 && \
@@ -161,7 +161,7 @@ RUN \
       -DLLVM_TARGETS_TO_BUILD="host;NVPTX;AMDGPU" \
       -DLLVM_ENABLE_LLD=ON \
       -DCMAKE_INSTALL_PREFIX=${LLVM_INSTALL_PREFIX} && \
-    ninja install 
+    ninja install
 
 # Stage 5: Copy results from previous stages
 FROM openeuler/openeuler:24.03 AS official-openeuler

--- a/docker/3.2.1-910b-ubuntu22.04-py3.11/Dockerfile
+++ b/docker/3.2.1-910b-ubuntu22.04-py3.11/Dockerfile
@@ -145,7 +145,7 @@ RUN pip3 install --no-cache-dir \
     wheel \
     pybind11 \
     --index-url ${PIP_SOURCE}
- 
+
 RUN \
     git config --global http.postBuffer 524288000 && \
     git config --global http.lowSpeedLimit 0 && \

--- a/docker/3.2.1-950-debian12-py3.11/Dockerfile
+++ b/docker/3.2.1-950-debian12-py3.11/Dockerfile
@@ -145,7 +145,7 @@ RUN pip3 install --no-cache-dir \
     wheel \
     pybind11 \
     --index-url ${PIP_SOURCE}
- 
+
 RUN \
     git config --global http.postBuffer 524288000 && \
     git config --global http.lowSpeedLimit 0 && \

--- a/docker/3.2.1-950-openeuler24.03-py3.11/Dockerfile
+++ b/docker/3.2.1-950-openeuler24.03-py3.11/Dockerfile
@@ -139,7 +139,7 @@ RUN pip3 install --no-cache-dir \
     wheel \
     pybind11 \
     --index-url ${PIP_SOURCE}
- 
+
 RUN \
     git config --global http.postBuffer 524288000 && \
     git config --global http.lowSpeedLimit 0 && \
@@ -161,7 +161,7 @@ RUN \
       -DLLVM_TARGETS_TO_BUILD="host;NVPTX;AMDGPU" \
       -DLLVM_ENABLE_LLD=ON \
       -DCMAKE_INSTALL_PREFIX=${LLVM_INSTALL_PREFIX} && \
-    ninja install 
+    ninja install
 
 # Stage 5: Copy results from previous stages
 FROM openeuler/openeuler:24.03 AS official-openeuler

--- a/docker/3.2.1-950-ubuntu22.04-py3.11/Dockerfile
+++ b/docker/3.2.1-950-ubuntu22.04-py3.11/Dockerfile
@@ -145,7 +145,7 @@ RUN pip3 install --no-cache-dir \
     wheel \
     pybind11 \
     --index-url ${PIP_SOURCE}
- 
+
 RUN \
     git config --global http.postBuffer 524288000 && \
     git config --global http.lowSpeedLimit 0 && \

--- a/docker/3.2.1-a3-debian12-py3.11/Dockerfile
+++ b/docker/3.2.1-a3-debian12-py3.11/Dockerfile
@@ -145,7 +145,7 @@ RUN pip3 install --no-cache-dir \
     wheel \
     pybind11 \
     --index-url ${PIP_SOURCE}
- 
+
 RUN \
     git config --global http.postBuffer 524288000 && \
     git config --global http.lowSpeedLimit 0 && \

--- a/docker/3.2.1-a3-openeuler24.03-py3.11/Dockerfile
+++ b/docker/3.2.1-a3-openeuler24.03-py3.11/Dockerfile
@@ -139,7 +139,7 @@ RUN pip3 install --no-cache-dir \
     wheel \
     pybind11 \
     --index-url ${PIP_SOURCE}
- 
+
 RUN \
     git config --global http.postBuffer 524288000 && \
     git config --global http.lowSpeedLimit 0 && \
@@ -161,7 +161,7 @@ RUN \
       -DLLVM_TARGETS_TO_BUILD="host;NVPTX;AMDGPU" \
       -DLLVM_ENABLE_LLD=ON \
       -DCMAKE_INSTALL_PREFIX=${LLVM_INSTALL_PREFIX} && \
-    ninja install 
+    ninja install
 
 # Stage 5: Copy results from previous stages
 FROM openeuler/openeuler:24.03 AS official-openeuler

--- a/docker/3.2.1-a3-ubuntu22.04-py3.11/Dockerfile
+++ b/docker/3.2.1-a3-ubuntu22.04-py3.11/Dockerfile
@@ -144,7 +144,7 @@ RUN pip3 install --no-cache-dir \
     wheel \
     pybind11 \
     --index-url ${PIP_SOURCE}
- 
+
 RUN \
     git config --global http.postBuffer 524288000 && \
     git config --global http.lowSpeedLimit 0 && \

--- a/third_party/ascend/include/TritonToLinalg/DescriptorConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/DescriptorConverter.h
@@ -90,6 +90,16 @@ public:
                   ConversionPatternRewriter &rewriter) const override;
 };
 
+class DescriptorReduceConverter
+    : public OpConversionPattern<triton::DescriptorReduceOp> {
+public:
+  using OpConversionPattern<triton::DescriptorReduceOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::DescriptorReduceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override;
+};
+
 } // end of namespace DescriptorConverter
 
 #endif // TRITON_ADAPTER_DESCRIPTORCONVERTER_H

--- a/third_party/ascend/lib/TritonToLinalg/DescriptorConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/DescriptorConverter.cpp
@@ -153,7 +153,8 @@ Value generatePtrFromOffsetRanges(OpBuilder &builder, Location loc,
         loc, indexTensorType, offsetWithStride);
 
     // Add to the pointer
-    ptr = builder.create<triton::AddPtrOp>(loc, ptrTensorType, ptr, broadcasted);
+    ptr =
+        builder.create<triton::AddPtrOp>(loc, ptrTensorType, ptr, broadcasted);
   }
 
   return ptr;
@@ -537,29 +538,29 @@ std::optional<RMWOp> translateReduceKind(DescriptorReduceKind kind,
 }
 
 LogicalResult DescriptorReduceConverter::matchAndRewrite(
-  triton::DescriptorReduceOp op, OpAdaptor adaptor,
-  ConversionPatternRewriter &rewriter) const {
-    auto loc = op.getLoc();
-    auto descTy = op.getDesc().getType();
-    const auto blockShape = descTy.getBlockType().getShape();
-    auto desc = unpackDescriptor(descTy, adaptor.getDesc(), rewriter);
-    auto offsets = castToI64(rewriter, op.getIndices());
-    auto rmwOp = translateReduceKind(op.getKind(), descTy);
-    if (!rmwOp) {
-      std::string msgstring;
-      llvm::raw_string_ostream msg(msgstring);
-      msg << "Cannot fallback on descriptor atomic op, unsupported for type "
-          << descTy.getBlockType().getElementType();
-      return op->emitError(msgstring);
-    }
+    triton::DescriptorReduceOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+  auto loc = op.getLoc();
+  auto descTy = op.getDesc().getType();
+  const auto blockShape = descTy.getBlockType().getShape();
+  auto desc = unpackDescriptor(descTy, adaptor.getDesc(), rewriter);
+  auto offsets = castToI64(rewriter, op.getIndices());
+  auto rmwOp = translateReduceKind(op.getKind(), descTy);
+  if (!rmwOp) {
+    std::string msgstring;
+    llvm::raw_string_ostream msg(msgstring);
+    msg << "Cannot fallback on descriptor atomic op, unsupported for type "
+        << descTy.getBlockType().getElementType();
+    return op->emitError(msgstring);
+  }
 
-    rewriter.create<triton::AtomicRMWOp>(
-        loc, descTy.getSignlessBlockType(), *rmwOp,
-        generatePtr(rewriter, loc, blockShape, desc, offsets), op.getSrc(),
-        generateMask(rewriter, loc, blockShape, desc, offsets),
-        MemSemantic::ACQUIRE_RELEASE, MemSyncScope::GPU);
-    op.erase();
-    return success();
+  rewriter.create<triton::AtomicRMWOp>(
+      loc, descTy.getSignlessBlockType(), *rmwOp,
+      generatePtr(rewriter, loc, blockShape, desc, offsets), op.getSrc(),
+      generateMask(rewriter, loc, blockShape, desc, offsets),
+      MemSemantic::ACQUIRE_RELEASE, MemSyncScope::GPU);
+  op.erase();
+  return success();
 }
 
 } // namespace DescriptorConverter

--- a/third_party/ascend/lib/TritonToLinalg/DescriptorConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/DescriptorConverter.cpp
@@ -98,6 +98,149 @@ DenseI32ArrayAttr getFullBoundaryCheckAttr(ConversionPatternRewriter &rewriter,
   return rewriter.getDenseI32ArrayAttr(boundaryCheck);
 }
 
+Value expandOffsets(OpBuilder &builder, Location loc,
+                    ArrayRef<int64_t> blockShape, Value offsets, unsigned dim) {
+  Value expandedResult = offsets;
+  for (size_t j = 0; j < blockShape.size(); ++j) {
+    if (j == dim) {
+      continue;
+    }
+    expandedResult =
+        builder.create<triton::ExpandDimsOp>(loc, expandedResult, j);
+  }
+
+  return expandedResult;
+}
+
+Value getExpandedOffsetWithRange(OpBuilder &builder, const Location &loc,
+                                 ArrayRef<std::int64_t> blockShape,
+                                 Value offset, unsigned dim) {
+  // Add range
+  auto indexI32RowType =
+      RankedTensorType::get({blockShape[dim]}, builder.getI32Type());
+  auto indexRowType =
+      RankedTensorType::get({blockShape[dim]}, builder.getI64Type());
+  Value splatOffset =
+      builder.create<triton::SplatOp>(loc, indexRowType, offset);
+  Value range = builder.create<triton::MakeRangeOp>(loc, indexI32RowType, 0,
+                                                    blockShape[dim]);
+  Value i64Range = builder.create<arith::ExtSIOp>(loc, indexRowType, range);
+
+  Value offsets = builder.create<arith::AddIOp>(loc, splatOffset, i64Range);
+  return expandOffsets(builder, loc, blockShape, offsets, dim);
+}
+
+Value generatePtrFromOffsetRanges(OpBuilder &builder, Location loc,
+                                  ArrayRef<int64_t> blockShape,
+                                  Descriptor &desc, ValueRange offsets) {
+  assert(blockShape.size() == desc.shape.size());
+  assert(blockShape.size() == offsets.size());
+  auto indexTensorType =
+      RankedTensorType::get(blockShape, builder.getI64Type());
+  auto ptrType = cast<triton::PointerType>(desc.base.getType());
+  auto ptrTensorType = RankedTensorType::get(blockShape, ptrType);
+
+  // Generate offsets per dimension
+  Value ptr = builder.create<triton::SplatOp>(loc, ptrTensorType, desc.base);
+  for (unsigned i = 0; i < blockShape.size(); ++i) {
+    // We must splat strides into the expanded shape not a row for retaining
+    // the divisibility information given by strides
+    Value splatStride = builder.create<triton::SplatOp>(
+        loc, offsets[i].getType(), desc.strides[i]);
+    Value offsetWithStride =
+        builder.create<arith::MulIOp>(loc, offsets[i], splatStride);
+    Value broadcasted = builder.create<triton::BroadcastOp>(
+        loc, indexTensorType, offsetWithStride);
+
+    // Add to the pointer
+    ptr = builder.create<triton::AddPtrOp>(loc, ptrTensorType, ptr, broadcasted);
+  }
+
+  return ptr;
+}
+
+Value generatePtr(OpBuilder &builder, const Location &loc,
+                  ArrayRef<std::int64_t> blockShape, Descriptor &desc,
+                  ValueRange offsets) {
+  assert(blockShape.size() == desc.shape.size());
+  assert(blockShape.size() == offsets.size());
+  SmallVector<Value> offsetRanges;
+  for (unsigned i = 0; i < blockShape.size(); ++i) {
+    auto offsetWithRange =
+        getExpandedOffsetWithRange(builder, loc, blockShape, offsets[i], i);
+    offsetRanges.push_back(offsetWithRange);
+  }
+
+  return generatePtrFromOffsetRanges(builder, loc, blockShape, desc,
+                                     offsetRanges);
+}
+
+Value generateMaskFromOffsetRanges(OpBuilder &builder, const Location &loc,
+                                   ArrayRef<std::int64_t> blockShape,
+                                   Descriptor &desc, ValueRange offsetRanges) {
+  assert(blockShape.size() == desc.shape.size());
+  assert(blockShape.size() == offsetRanges.size());
+
+  // Generate mask per dimension
+  auto maskTensorType = RankedTensorType::get(blockShape, builder.getI1Type());
+  Value mask;
+  for (std::size_t i = 0; i < blockShape.size(); ++i) {
+    auto offsetWithRange = offsetRanges[i];
+
+    // Compare with lower bound
+    Value lowerBound = builder.create<mlir::arith::ConstantIntOp>(
+        loc, builder.getI64Type(), 0);
+    Value splatLowerBound = builder.create<triton::SplatOp>(
+        loc, offsetWithRange.getType(), lowerBound);
+    Value cmpLower = builder.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::sge, offsetWithRange, splatLowerBound);
+
+    // Compare with upper bound
+    Value splatUpperBound = builder.create<triton::SplatOp>(
+        loc, offsetWithRange.getType(), desc.shape[i]);
+    Value cmpUpper = builder.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::slt, offsetWithRange, splatUpperBound);
+
+    // And and broadcast
+    Value andResult = builder.create<arith::AndIOp>(loc, cmpLower, cmpUpper);
+    Value broadcasted =
+        builder.create<triton::BroadcastOp>(loc, maskTensorType, andResult);
+
+    // And up all results
+    if (!mask) {
+      mask = broadcasted;
+    } else {
+      mask = builder.create<arith::AndIOp>(loc, mask, broadcasted);
+    }
+  }
+
+  return mask;
+}
+
+Value generateMask(OpBuilder &builder, const Location &loc,
+                   ArrayRef<std::int64_t> blockShape, Descriptor &desc,
+                   ValueRange offsets) {
+  assert(blockShape.size() == desc.shape.size());
+  assert(blockShape.size() == offsets.size());
+  SmallVector<Value> offsetRanges;
+  for (unsigned i = 0; i < blockShape.size(); ++i) {
+    auto offsetWithRange =
+        getExpandedOffsetWithRange(builder, loc, blockShape, offsets[i], i);
+    offsetRanges.push_back(offsetWithRange);
+  }
+
+  return generateMaskFromOffsetRanges(builder, loc, blockShape, desc,
+                                      offsetRanges);
+}
+
+SmallVector<mlir::Value> castToI64(OpBuilder &builder,
+                                   mlir::ValueRange values) {
+  auto i64Type = builder.getI64Type();
+  return llvm::map_to_vector(values, [&](mlir::Value v) {
+    return builder.createOrFold<arith::ExtSIOp>(v.getLoc(), i64Type, v);
+  });
+}
+
 LogicalResult DescriptorLoadConverter::matchAndRewrite(
     triton::DescriptorLoadOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
@@ -359,6 +502,64 @@ LogicalResult DescriptorGatherConverter::matchAndRewrite(
 
   rewriter.replaceOp(op, loop.getResult(0));
   return success();
+}
+
+std::optional<RMWOp> translateReduceKind(DescriptorReduceKind kind,
+                                         TensorDescType ty) {
+  auto scalarTy = ty.getBlockType().getElementType();
+  switch (kind) {
+  case DescriptorReduceKind::ADD:
+    return scalarTy.isInteger() ? RMWOp::ADD : RMWOp::FADD;
+  case DescriptorReduceKind::MIN:
+    if (scalarTy.isUnsignedInteger()) {
+      return RMWOp::UMIN;
+    } else if (scalarTy.isSignedInteger()) {
+      return RMWOp::MIN;
+    }
+    return {};
+  case DescriptorReduceKind::MAX:
+    if (scalarTy.isUnsignedInteger()) {
+      return RMWOp::UMAX;
+    } else if (scalarTy.isSignedInteger()) {
+      return RMWOp::MAX;
+    }
+    return {};
+  case DescriptorReduceKind::AND:
+    return RMWOp::AND;
+  case DescriptorReduceKind::OR:
+    return RMWOp::OR;
+  case DescriptorReduceKind::XOR:
+    return RMWOp::XOR;
+  default:
+    break;
+  }
+  return {};
+}
+
+LogicalResult DescriptorReduceConverter::matchAndRewrite(
+  triton::DescriptorReduceOp op, OpAdaptor adaptor,
+  ConversionPatternRewriter &rewriter) const {
+    auto loc = op.getLoc();
+    auto descTy = op.getDesc().getType();
+    const auto blockShape = descTy.getBlockType().getShape();
+    auto desc = unpackDescriptor(descTy, adaptor.getDesc(), rewriter);
+    auto offsets = castToI64(rewriter, op.getIndices());
+    auto rmwOp = translateReduceKind(op.getKind(), descTy);
+    if (!rmwOp) {
+      std::string msgstring;
+      llvm::raw_string_ostream msg(msgstring);
+      msg << "Cannot fallback on descriptor atomic op, unsupported for type "
+          << descTy.getBlockType().getElementType();
+      return op->emitError(msgstring);
+    }
+
+    rewriter.create<triton::AtomicRMWOp>(
+        loc, descTy.getSignlessBlockType(), *rmwOp,
+        generatePtr(rewriter, loc, blockShape, desc, offsets), op.getSrc(),
+        generateMask(rewriter, loc, blockShape, desc, offsets),
+        MemSemantic::ACQUIRE_RELEASE, MemSyncScope::GPU);
+    op.erase();
+    return success();
 }
 
 } // namespace DescriptorConverter

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -703,8 +703,8 @@ TritonToLinalgPass::processDescriptorOperations(ModuleOp moduleOp) {
   });
   target.addLegalOp<triton::MakeTensorDescOp>();
   target.addIllegalOp<triton::DescriptorLoadOp, triton::DescriptorStoreOp,
-                    triton::DescriptorScatterOp, triton::DescriptorGatherOp,
-                    triton::DescriptorReduceOp>();
+                      triton::DescriptorScatterOp, triton::DescriptorGatherOp,
+                      triton::DescriptorReduceOp>();
 
   // --- Patterns ---
   mlir::RewritePatternSet patterns(&getContext());

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -702,9 +702,9 @@ TritonToLinalgPass::processDescriptorOperations(ModuleOp moduleOp) {
                funcOp.getFunctionType().getResults());
   });
   target.addLegalOp<triton::MakeTensorDescOp>();
-  target
-      .addIllegalOp<triton::DescriptorLoadOp, triton::DescriptorStoreOp,
-                    triton::DescriptorScatterOp, triton::DescriptorGatherOp>();
+  target.addIllegalOp<triton::DescriptorLoadOp, triton::DescriptorStoreOp,
+                    triton::DescriptorScatterOp, triton::DescriptorGatherOp,
+                    triton::DescriptorReduceOp>();
 
   // --- Patterns ---
   mlir::RewritePatternSet patterns(&getContext());
@@ -715,6 +715,8 @@ TritonToLinalgPass::processDescriptorOperations(ModuleOp moduleOp) {
   patterns.add<DescriptorConverter::DescriptorScatterConverter>(
       patterns.getContext());
   patterns.add<DescriptorConverter::DescriptorGatherConverter>(
+      patterns.getContext());
+  patterns.add<DescriptorConverter::DescriptorReduceConverter>(
       patterns.getContext());
 
   mlir::ConversionConfig config;

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_parse_descriptor_reduce.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_parse_descriptor_reduce.mlir
@@ -1,0 +1,38 @@
+// RUN: triton-opt --triton-to-linalg --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: func.func @kernel
+// CHECK: %[[SUBVIEW:.*]] = memref.subview %[[RC:.*]][%[[VAL_36:.*]], %[[VAL_39:.*]]] [%[[VAL_38:.*]], %[[VAL_41:.*]]] [1, 1] : memref<2x16xi32, strided<[?, 1], offset: ?>> to memref<?x?xi32, strided<[?, 1], offset: ?>> 
+// CHECK: %[[EXTRACT:.*]] = tensor.extract_slice %[[VAL_7:.*]][%[[VAL_36]], %[[VAL_39]]] [%[[VAL_38]], %[[VAL_41]]] [1, 1] : tensor<2x16xi32> to tensor<?x?xi32>
+// CHECK: hivm.hir.store ins(%[[EXTRACT]] : tensor<?x?xi32>) outs(%[[SUBVIEW]] : memref<?x?xi32, strided<[?, 1], offset: ?>>) atomic = <add>
+
+module {
+  tt.func public @kernel(%a_ptr: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %out_ptr: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %M: i32 , %N: i32 {tt.divisibility = 16 : i32} ) attributes {noinline = false} {
+    %desc = arith.constant 1 : i64 
+    %c16_i32 = arith.constant 16 : i32 
+    %c2_i32 = arith.constant 2 : i32 
+    %moffset = tt.get_program_id x : i32 
+    %moffset_0 = arith.muli %moffset, %c2_i32 : i32 
+    %noffset = tt.get_program_id y : i32 
+    %noffset_1 = arith.muli %noffset, %c16_i32 : i32 
+    %midx = tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32> 
+    %midx_2 = tt.expand_dims %midx {axis = 1 : i32} : tensor<2xi32> -> tensor<2x1xi32> 
+    %midx_3 = tt.splat %moffset_0 : i32 -> tensor<2x1xi32> 
+    %midx_4 = arith.addi %midx_3, %midx_2 : tensor<2x1xi32> 
+    %nidx = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32> 
+    %nidx_5 = tt.expand_dims %nidx {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32> 
+    %nidx_6 = tt.splat %noffset_1 : i32 -> tensor<1x16xi32> 
+    %nidx_7 = arith.addi %nidx_6, %nidx_5 : tensor<1x16xi32> 
+    %idx = tt.splat %N : i32 -> tensor<2x1xi32> 
+    %idx_8 = arith.muli %midx_4, %idx : tensor<2x1xi32> 
+    %idx_9 = tt.broadcast %idx_8 : tensor<2x1xi32> -> tensor<2x16xi32> 
+    %idx_10 = tt.broadcast %nidx_7 : tensor<1x16xi32> -> tensor<2x16xi32> 
+    %idx_11 = arith.addi %idx_9, %idx_10 : tensor<2x16xi32> 
+    %val = tt.splat %a_ptr : !tt.ptr<i32> -> tensor<2x16x!tt.ptr<i32>> 
+    %val_12 = tt.addptr %val, %idx_11 : tensor<2x16x!tt.ptr<i32>>, tensor<2x16xi32> 
+    %val_13 = tt.load %val_12 : tensor<2x16x!tt.ptr<i32>> 
+    %desc_14 = arith.extsi %N : i32 to i64 
+    %desc_15 = tt.make_tensor_descriptor %out_ptr, [%M, %N], [%desc_14, %desc] : <i32>, <tensor<2x16xsi32>> 
+    tt.descriptor_reduce add, %desc_15[%moffset_0, %noffset_1], %val_13 : !tt.tensordesc<tensor<2x16xsi32>>, tensor<2x16xi32> 
+    tt.return 
+  } 
+} 

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_parse_descriptor_reduce.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_parse_descriptor_reduce.mlir
@@ -1,38 +1,38 @@
 // RUN: triton-opt --triton-to-linalg --split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: func.func @kernel
-// CHECK: %[[SUBVIEW:.*]] = memref.subview %[[RC:.*]][%[[VAL_36:.*]], %[[VAL_39:.*]]] [%[[VAL_38:.*]], %[[VAL_41:.*]]] [1, 1] : memref<2x16xi32, strided<[?, 1], offset: ?>> to memref<?x?xi32, strided<[?, 1], offset: ?>> 
+// CHECK: %[[SUBVIEW:.*]] = memref.subview %[[RC:.*]][%[[VAL_36:.*]], %[[VAL_39:.*]]] [%[[VAL_38:.*]], %[[VAL_41:.*]]] [1, 1] : memref<2x16xi32, strided<[?, 1], offset: ?>> to memref<?x?xi32, strided<[?, 1], offset: ?>>
 // CHECK: %[[EXTRACT:.*]] = tensor.extract_slice %[[VAL_7:.*]][%[[VAL_36]], %[[VAL_39]]] [%[[VAL_38]], %[[VAL_41]]] [1, 1] : tensor<2x16xi32> to tensor<?x?xi32>
 // CHECK: hivm.hir.store ins(%[[EXTRACT]] : tensor<?x?xi32>) outs(%[[SUBVIEW]] : memref<?x?xi32, strided<[?, 1], offset: ?>>) atomic = <add>
 
 module {
   tt.func public @kernel(%a_ptr: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %out_ptr: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %M: i32 , %N: i32 {tt.divisibility = 16 : i32} ) attributes {noinline = false} {
-    %desc = arith.constant 1 : i64 
-    %c16_i32 = arith.constant 16 : i32 
-    %c2_i32 = arith.constant 2 : i32 
-    %moffset = tt.get_program_id x : i32 
-    %moffset_0 = arith.muli %moffset, %c2_i32 : i32 
-    %noffset = tt.get_program_id y : i32 
-    %noffset_1 = arith.muli %noffset, %c16_i32 : i32 
-    %midx = tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32> 
-    %midx_2 = tt.expand_dims %midx {axis = 1 : i32} : tensor<2xi32> -> tensor<2x1xi32> 
-    %midx_3 = tt.splat %moffset_0 : i32 -> tensor<2x1xi32> 
-    %midx_4 = arith.addi %midx_3, %midx_2 : tensor<2x1xi32> 
-    %nidx = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32> 
-    %nidx_5 = tt.expand_dims %nidx {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32> 
-    %nidx_6 = tt.splat %noffset_1 : i32 -> tensor<1x16xi32> 
-    %nidx_7 = arith.addi %nidx_6, %nidx_5 : tensor<1x16xi32> 
-    %idx = tt.splat %N : i32 -> tensor<2x1xi32> 
-    %idx_8 = arith.muli %midx_4, %idx : tensor<2x1xi32> 
-    %idx_9 = tt.broadcast %idx_8 : tensor<2x1xi32> -> tensor<2x16xi32> 
-    %idx_10 = tt.broadcast %nidx_7 : tensor<1x16xi32> -> tensor<2x16xi32> 
-    %idx_11 = arith.addi %idx_9, %idx_10 : tensor<2x16xi32> 
-    %val = tt.splat %a_ptr : !tt.ptr<i32> -> tensor<2x16x!tt.ptr<i32>> 
-    %val_12 = tt.addptr %val, %idx_11 : tensor<2x16x!tt.ptr<i32>>, tensor<2x16xi32> 
-    %val_13 = tt.load %val_12 : tensor<2x16x!tt.ptr<i32>> 
-    %desc_14 = arith.extsi %N : i32 to i64 
-    %desc_15 = tt.make_tensor_descriptor %out_ptr, [%M, %N], [%desc_14, %desc] : <i32>, <tensor<2x16xsi32>> 
-    tt.descriptor_reduce add, %desc_15[%moffset_0, %noffset_1], %val_13 : !tt.tensordesc<tensor<2x16xsi32>>, tensor<2x16xi32> 
-    tt.return 
-  } 
-} 
+    %desc = arith.constant 1 : i64
+    %c16_i32 = arith.constant 16 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %moffset = tt.get_program_id x : i32
+    %moffset_0 = arith.muli %moffset, %c2_i32 : i32
+    %noffset = tt.get_program_id y : i32
+    %noffset_1 = arith.muli %noffset, %c16_i32 : i32
+    %midx = tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32>
+    %midx_2 = tt.expand_dims %midx {axis = 1 : i32} : tensor<2xi32> -> tensor<2x1xi32>
+    %midx_3 = tt.splat %moffset_0 : i32 -> tensor<2x1xi32>
+    %midx_4 = arith.addi %midx_3, %midx_2 : tensor<2x1xi32>
+    %nidx = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %nidx_5 = tt.expand_dims %nidx {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+    %nidx_6 = tt.splat %noffset_1 : i32 -> tensor<1x16xi32>
+    %nidx_7 = arith.addi %nidx_6, %nidx_5 : tensor<1x16xi32>
+    %idx = tt.splat %N : i32 -> tensor<2x1xi32>
+    %idx_8 = arith.muli %midx_4, %idx : tensor<2x1xi32>
+    %idx_9 = tt.broadcast %idx_8 : tensor<2x1xi32> -> tensor<2x16xi32>
+    %idx_10 = tt.broadcast %nidx_7 : tensor<1x16xi32> -> tensor<2x16xi32>
+    %idx_11 = arith.addi %idx_9, %idx_10 : tensor<2x16xi32>
+    %val = tt.splat %a_ptr : !tt.ptr<i32> -> tensor<2x16x!tt.ptr<i32>>
+    %val_12 = tt.addptr %val, %idx_11 : tensor<2x16x!tt.ptr<i32>>, tensor<2x16xi32>
+    %val_13 = tt.load %val_12 : tensor<2x16x!tt.ptr<i32>>
+    %desc_14 = arith.extsi %N : i32 to i64
+    %desc_15 = tt.make_tensor_descriptor %out_ptr, [%M, %N], [%desc_14, %desc] : <i32>, <tensor<2x16xsi32>>
+    tt.descriptor_reduce add, %desc_15[%moffset_0, %noffset_1], %val_13 : !tt.tensordesc<tensor<2x16xsi32>>, tensor<2x16xi32>
+    tt.return
+  }
+}

--- a/third_party/ascend/unittest/pytest_ut/test_tensor_descriptor.py
+++ b/third_party/ascend/unittest/pytest_ut/test_tensor_descriptor.py
@@ -304,3 +304,66 @@ def test_tensor_descriptor_gather(X, Y, BLOCK_X, BLOCK_Y, dtype, y):
 
     ref = torch_gather_rows(input_tensor, idx, y, BLOCK_Y)
     torch.testing.assert_close(ref, output, atol=0, rtol=0)
+
+REDUCE_OP = {
+    "add": lambda a, b: a + b,
+    "min": lambda a, b: torch.minimum(a, b),
+    "max": lambda a, b: torch.maximum(a, b),
+    "and": lambda a, b: torch.bitwise_and(a, b),
+    "or": lambda a, b: torch.bitwise_or(a, b),
+    "xor": lambda a, b: torch.bitwise_xor(a, b),
+}
+
+SKIP_KINDS = {"and", "or", "xor"}
+all_kinds = ["add", "min", "max", "and", "or", "xor"]
+kind_parms = [
+    pytest.param(k, marks=pytest.mask.skip(reason=f"skip for bishengir compile failed on a2")) if k in SKIP_KINDS else k
+    for k in all_kinds
+    ]
+
+@pytest.mark.parametrize("kind", kind_parms)
+@pytest.mark.parametrize("dtype", ['int32'])
+@pytest.mark.parametrize("M_BLOCK,N_BLOCK", [(2, 16)])
+def test_tensor_descriptor_reduce(kind, dtype, M_BLOCK, N_BLOCK): 
+
+    @triton.jit(debug=True)
+    def kernel(a_ptr,out_ptr, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr, kind: tl.constexpr):
+        moffset = tl.program_id(0) * M_BLOCK
+        noffset = tl.program_id(1) * N_BLOCK
+
+        midx = moffset + tl.arange(0, M_BLOCK)[:, None]
+        nidx = noffset + tl.arange(0, N_BLOCK)[None, :]
+        idx = midx * N + nidx
+        val = tl.load(a_ptr + idx)
+       
+        desc = tl.make_tensor_descriptor(
+            out_ptr,
+            shape=[M, N],
+            strides=[N, 1],
+            block_shape=[M_BLOCK, N_BLOCK],
+        )
+   
+        if kind == "add":
+            desc.atomic_add([moffset, noffset], val)
+        elif kind == "min":
+            desc.atomic_min([moffset, noffset], val)
+        elif kind == "max":
+            desc.atomic_max([moffset, noffset], val)
+        elif kind == "and":
+            desc.atomic_and([moffset, noffset], val)
+        elif kind == "or":
+            desc.atomic_or([moffset, noffset], val)
+        else:
+            tl.static_assert(kind == "xor")
+            desc.atomic_xor([moffset, noffset], val)
+
+    M, N = M_BLOCK * 2, N_BLOCK * 2  
+    inp = test_common.generate_tensor((M, N), dtype).npu()
+    out = test_common.generate_tensor((M, N), dtype).npu()
+
+    grid_m = M // M_BLOCK
+    grid_n = N // N_BLOCK
+
+    expect = REDUCE_OP[kind](inp, out)
+    kernel[(grid_m, grid_n)](inp, out, M, N, M_BLOCK, N_BLOCK, kind)
+    torch.testing.assert_close(expect, out)

--- a/third_party/ascend/unittest/pytest_ut/test_tensor_descriptor.py
+++ b/third_party/ascend/unittest/pytest_ut/test_tensor_descriptor.py
@@ -305,6 +305,7 @@ def test_tensor_descriptor_gather(X, Y, BLOCK_X, BLOCK_Y, dtype, y):
     ref = torch_gather_rows(input_tensor, idx, y, BLOCK_Y)
     torch.testing.assert_close(ref, output, atol=0, rtol=0)
 
+
 REDUCE_OP = {
     "add": lambda a, b: a + b,
     "min": lambda a, b: torch.minimum(a, b),
@@ -317,17 +318,18 @@ REDUCE_OP = {
 SKIP_KINDS = {"and", "or", "xor"}
 all_kinds = ["add", "min", "max", "and", "or", "xor"]
 kind_parms = [
-    pytest.param(k, marks=pytest.mask.skip(reason=f"skip for bishengir compile failed on a2")) if k in SKIP_KINDS else k
-    for k in all_kinds
-    ]
+    pytest.param(k, marks=pytest.mark.skip(
+        reason=f"skip for bishengir compile failed on a2,succeed on a5")) if k in SKIP_KINDS else k for k in all_kinds
+]
+
 
 @pytest.mark.parametrize("kind", kind_parms)
 @pytest.mark.parametrize("dtype", ['int32'])
 @pytest.mark.parametrize("M_BLOCK,N_BLOCK", [(2, 16)])
-def test_tensor_descriptor_reduce(kind, dtype, M_BLOCK, N_BLOCK): 
+def test_tensor_descriptor_reduce(kind, dtype, M_BLOCK, N_BLOCK):
 
     @triton.jit(debug=True)
-    def kernel(a_ptr,out_ptr, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr, kind: tl.constexpr):
+    def kernel(a_ptr, out_ptr, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr, kind: tl.constexpr):
         moffset = tl.program_id(0) * M_BLOCK
         noffset = tl.program_id(1) * N_BLOCK
 
@@ -335,14 +337,14 @@ def test_tensor_descriptor_reduce(kind, dtype, M_BLOCK, N_BLOCK):
         nidx = noffset + tl.arange(0, N_BLOCK)[None, :]
         idx = midx * N + nidx
         val = tl.load(a_ptr + idx)
-       
+
         desc = tl.make_tensor_descriptor(
             out_ptr,
             shape=[M, N],
             strides=[N, 1],
             block_shape=[M_BLOCK, N_BLOCK],
         )
-   
+
         if kind == "add":
             desc.atomic_add([moffset, noffset], val)
         elif kind == "min":
@@ -357,7 +359,7 @@ def test_tensor_descriptor_reduce(kind, dtype, M_BLOCK, N_BLOCK):
             tl.static_assert(kind == "xor")
             desc.atomic_xor([moffset, noffset], val)
 
-    M, N = M_BLOCK * 2, N_BLOCK * 2  
+    M, N = M_BLOCK * 2, N_BLOCK * 2
     inp = test_common.generate_tensor((M, N), dtype).npu()
     out = test_common.generate_tensor((M, N), dtype).npu()
 


### PR DESCRIPTION
### Background
triton convert desc.atomic_add(desc is block tensor defined by tl.make_tensor_descriptor ) to descriptor_reduce add
such as case: 
desc = tl.make_tensor_descriptor(
            out_ptr,
            shape=[M, N],
            strides=[N, 1],
            block_shape=[M_BLOCK, N_BLOCK],
        )
desc.atomic_add([moffset, noffset], val)
will be converted to
%desc_15 = tt.make_tensor_descriptor %out_ptr, [%M, %N], [%desc_14, %desc] : <i32>, <tensor<2x16xsi32>> 
  tt.descriptor_reduce add, %desc_15[%moffset_0, %noffset_1], %val_13 : !tt.tensordesc<tensor<2x16xsi32>>, tensor<2x16xi32>
### Feature Overview
Increase implementation of  tt.descriptor_reduce, convert tt.descriptor_reduce to tt.atomic_rmw 
### Note
  bishengir compile failed on a2,succeed on a5 for desc.atomic_and, desc.atomic_or ,  desc.atomic_xor op, temporarily skip





