### PR TITLE
fix: keep scalar ceil meta computations scalar

### DIFF
--- a/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
@@ -31,11 +31,13 @@
 
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Transforms/DialectConversion.h"
 
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
@@ -107,6 +109,98 @@ public:
 
 template <typename MathOp>
 class ScalarMathCanonicalizer : public OpRewritePattern<MathOp> {
+  // Keep scalar math scalar when it feeds pointer metadata or control flow.
+  static bool isMetaOrControlOperand(Value value, OpOperand &use) {
+    Operation *user = use.getOwner();
+    if (isa<triton::LoadOp>(user)) {
+      return true;
+    }
+    if (auto store = dyn_cast<triton::StoreOp>(user)) {
+      return value == store.getPtr() || value == store.getMask();
+    }
+    if (auto indirectStore =
+            dyn_cast<triton::ascend::IndirectStoreOp>(user)) {
+      return value == indirectStore.getSrc() ||
+             value == indirectStore.getOffsets() ||
+             value == indirectStore.getMask();
+    }
+    if (auto atomic = dyn_cast<triton::AtomicRMWOp>(user)) {
+      return value == atomic.getPtr() || value == atomic.getMask();
+    }
+    if (auto atomic = dyn_cast<triton::AtomicCASOp>(user)) {
+      return value == atomic.getPtr();
+    }
+    if (auto addPtr = dyn_cast<triton::AddPtrOp>(user)) {
+      return value == addPtr.getOffset();
+    }
+    if (isa<triton::MakeTensorPtrOp>(user)) {
+      return use.getOperandNumber() != 0;
+    }
+    if (auto forOp = dyn_cast<scf::ForOp>(user)) {
+      return value == forOp.getLowerBound() ||
+             value == forOp.getUpperBound() || value == forOp.getStep();
+    }
+    if (auto ifOp = dyn_cast<scf::IfOp>(user)) {
+      return value == ifOp.getCondition();
+    }
+    if (auto conditionOp = dyn_cast<scf::ConditionOp>(user)) {
+      return value == conditionOp.getCondition();
+    }
+    if (auto selectOp = dyn_cast<arith::SelectOp>(user)) {
+      return value == selectOp.getCondition();
+    }
+    return false;
+  }
+
+  static bool isKnownDataOperand(Value value, OpOperand &use) {
+    Operation *user = use.getOwner();
+    if (auto store = dyn_cast<triton::StoreOp>(user)) {
+      return value == store.getValue();
+    }
+    if (auto indirectStore =
+            dyn_cast<triton::ascend::IndirectStoreOp>(user)) {
+      return value == indirectStore.getValue();
+    }
+    if (auto atomic = dyn_cast<triton::AtomicRMWOp>(user)) {
+      return value == atomic.getVal();
+    }
+    if (auto atomic = dyn_cast<triton::AtomicCASOp>(user)) {
+      return value == atomic.getCmp() || value == atomic.getVal();
+    }
+    return false;
+  }
+
+  static bool
+  hasMetaOrControlUse(Value value,
+                      llvm::SmallPtrSetImpl<Operation *> &visitedOps,
+                      unsigned depth = 0) {
+    if (depth > 64) {
+      return true;
+    }
+    for (OpOperand &use : value.getUses()) {
+      if (isMetaOrControlOperand(value, use)) {
+        return true;
+      }
+      if (isKnownDataOperand(value, use)) {
+        continue;
+      }
+
+      Operation *user = use.getOwner();
+      if (!visitedOps.insert(user).second) {
+        continue;
+      }
+      if (user->getNumResults() == 0) {
+        return true;
+      }
+      for (Value result : user->getResults()) {
+        if (hasMetaOrControlUse(result, visitedOps, depth + 1)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
 public:
   using OpRewritePattern<MathOp>::OpRewritePattern;
 
@@ -127,6 +221,11 @@ public:
     if (auto linalgOp = op->template getParentOfType<triton::ScanOp>()) {
       return rewriter.notifyMatchFailure(
           op, "ScalarMathCanonicalizer handles op not within tt.scan.");
+    }
+    llvm::SmallPtrSet<Operation *, 16> visitedOps;
+    if (hasMetaOrControlUse(op->getResult(0), visitedOps)) {
+      return rewriter.notifyMatchFailure(
+          op, "ScalarMathCanonicalizer skips meta or control uses.");
     }
     auto loc = op.getLoc();
     llvm::SmallVector<Value> inputs;

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/scalar_ceil_meta_use.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/scalar_ceil_meta_use.mlir
@@ -1,0 +1,39 @@
+// RUN: triton-opt --triton-to-linalg --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: func.func @scalar_ceil_meta_use
+// CHECK-NOT: tensor<1xf32>
+// CHECK: math.ceil %{{.*}} : f32
+// CHECK-NOT: tensor<1xf32>
+// CHECK: arith.fptosi %{{.*}} : f32 to i32
+// CHECK-NOT: unrealized_conversion_cast
+// CHECK-NOT: tensor<1xf32>
+
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @scalar_ceil_meta_use(%x: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %out: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %T: i32) attributes {noinline = false} {
+    %cst = arith.constant 3.200000e+01 : f32
+    %zero = arith.constant 0.000000e+00 : f32
+    %c0 = arith.constant 0 : index
+    %c0_i32 = arith.constant 0 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %T_i64 = arith.extsi %T : i32 to i64
+    %T_f32 = arith.sitofp %T : i32 to f32
+    %div = arith.divf %T_f32, %cst : f32
+    %ceil = math.ceil %div : f32
+    %ceil_i32 = arith.fptosi %ceil : f32 to i32
+    %next = arith.muli %ceil_i32, %c32_i32 : i32
+    %last = arith.subi %next, %c32_i32 : i32
+    %ptr = tt.make_tensor_ptr %x, [%T_i64], [%c1_i64], [%last] {order = array<i32: 0>} : <tensor<32xf32>>
+    %loaded = tt.load %ptr {boundaryCheck = array<i32: 0>, padding = 1 : i32} : !tt.ptr<tensor<32xf32>>
+    scf.for %iv = %c0_i32 to %last step %c32_i32 : i32 {
+      %out_ptr = tt.addptr %out, %iv : !tt.ptr<f32>, i32
+      tt.store %out_ptr, %zero : !tt.ptr<f32>
+    }
+    %mask = arith.cmpi slt, %last, %T : i32
+    %out_ptr = tt.addptr %out, %last : !tt.ptr<f32>, i32
+    %val = tensor.extract %loaded[%c0] : tensor<32xf32>
+    tt.store %out_ptr, %val, %mask : !tt.ptr<f32>
+    tt.return
+  }
+}

--- a/third_party/ascend/unittest/pytest_ut/test_scalar_calc.py
+++ b/third_party/ascend/unittest/pytest_ut/test_scalar_calc.py
@@ -243,6 +243,24 @@ def test_scalar_ceil_calc(param_list):
     triton_kernel[1, 1, 1](y_cal, x0, N=N)
     test_common.validate_cmp(dtype, y_cal[0], y_ref)
 
+### ceil meta use
+def test_scalar_ceil_meta_use():
+
+    @triton.jit(do_not_specialize=["T"])
+    def triton_kernel(in_ptr0, out_ptr0, T, BS: tl.constexpr):
+        last = tl.ceil(T / BS).to(tl.int32) * BS - BS
+        tmp0 = tl.load(in_ptr0 + last, mask=last < T, other=0.0)
+        tl.store(out_ptr0, tmp0)
+
+    T = 2000
+    BS = 32
+    N = triton.cdiv(T, BS) * BS
+    x0 = torch.arange(N, dtype=torch.float32).npu()
+    y_ref = x0[triton.cdiv(T, BS) * BS - BS]
+    y_cal = torch.empty((1,), dtype=torch.float32).npu()
+    triton_kernel[1, 1, 1](x0, y_cal, T, BS=BS)
+    test_common.validate_cmp("float32", y_cal[0], y_ref)
+
 ### floor
 @pytest.mark.parametrize('param_list',
                          [


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
