### PR TITLE
docs: clarify that multibuffer is enabled by default

### DIFF
--- a/docs/en/architecture_design_and_core_features.md
+++ b/docs/en/architecture_design_and_core_features.md
@@ -77,7 +77,7 @@ This project extends the support for Huawei Ascend NPU (using the CANN software 
 
 |No.| NPU Option                                   | Hardware Platform    | Description|
 | --- | --------------------------------------------- | ---------- | ----- |
-| 1   | multibuffer                                   | NPU        | Autotune option. It enables or disables the ping-pong pipeline.|
+| 1   | multibuffer                                   | NPU        | Autotune option. It enables or disables the ping-pong pipeline. Enabled by default.|
 | 2   | enable_auto_bind_sub_block                    | NPU        | Autotune option (CV-fused kernels only). It enables or disables auto-binding of sub-blocks.|
 | 3   | enable_hivm_auto_cv_balance                   | NPU        | Autotune option (CV-fused kernels only). It enables or disables automatic CV balancing.|
 | 4   | sync_solver                                   | NPU        | Autotune option (CV-fused kernels only). It enables or disables the synchronization solver. |

--- a/docs/en/environment_variable_and_compiler_options_reference.md
+++ b/docs/en/environment_variable_and_compiler_options_reference.md
@@ -75,7 +75,7 @@ The following table describes the options.
 
 | Category | Compiler Option | Default/Values | Function Description | Setting Description |
 |----------|-----------------|----------------|----------------------|--------------------|
-| **General pipeline** | `multibuffer` | `True`, `False`; disabled by default in 910_95 compilation scenarios | Enables or disables ping-pong/double-buffer pipelines. | `triton.Config` or launch meta-parameter |
+| **General pipeline** | `multibuffer` | `True` (default), `False` | Enables or disables ping-pong/double-buffer pipelines. Enabled by default. | `triton.Config` or launch meta-parameter |
 | **CV fusion** | `enable_auto_bind_sub_block` | `None`, `True`, `False` | Enables or disables automatic sub-block binding. | `triton.Config` or launch meta-parameter |
 | **CV fusion** | `enable_hivm_auto_cv_balance` | `None`, `True`, `False` | Enables or disables automatic CV balance. | `triton.Config` or autotune parameter |
 | **CV fusion/sync** | `sync_solver` | `None`, `True`, `False` | Enables or disables the HIVM synchronization solver. | `triton.Config` or launch meta-parameter |

--- a/docs/zh/architecture_design_and_core_features.md
+++ b/docs/zh/architecture_design_and_core_features.md
@@ -77,7 +77,7 @@
 
 |序号| NPUOptions                                    | 硬件平台     | 用途 |
 | --- | --------------------------------------------- | ---------- | ----- |
-| 1   | multibuffer                                   | NPU        | Autotune Option: Enable or disable ping-pong pipeline. |
+| 1   | multibuffer                                   | NPU        | Autotune Option: Enable or disable ping-pong pipeline. Enabled by default. |
 | 2   | enable_auto_bind_sub_block                    | NPU        | Autotune option (CV-fused kernels only): Enable or disable auto-binding of sub-blocks. |
 | 3   | enable_hivm_auto_cv_balance                   | NPU        | Autotune option (CV-fused kernels only): Enable or disable automatic CV balancing. |
 | 4   | sync_solver                                   | NPU        | Autotune option (CV-fused kernels only): Enable or disable the synchronization solver. |

--- a/docs/zh/environment_variable_and_compiler_options_reference.md
+++ b/docs/zh/environment_variable_and_compiler_options_reference.md
@@ -77,7 +77,7 @@ kernel[grid](..., BLOCK_SIZE=1024, multibuffer=True)
 
 | 类别 | 编译选项 | 默认值/可选值 | 功能说明 | 配置说明 |
 |------|----------|----------------|----------|----------|
-| **通用流水** | `multibuffer` | `True`、`False`；910_95 编译场景默认关闭 | 启用或禁用 ping-pong/double buffer 流水。 | `triton.Config` 或 launch meta-parameter |
+| **通用流水** | `multibuffer` | `True`（默认）、`False` | 启用或禁用 ping-pong/double buffer 流水。默认开启。 | `triton.Config` 或 launch meta-parameter |
 | **CV 融合** | `enable_auto_bind_sub_block` | `None`、`True`、`False` | 启用或禁用自动绑定 sub-block。 | `triton.Config` 或 launch meta-parameter |
 | **CV 融合** | `enable_hivm_auto_cv_balance` | `None`、`True`、`False` | 启用或禁用自动 CV balance。 | `triton.Config` 或 Autotune 参数 |
 | **CV 融合/同步** | `sync_solver` | `None`、`True`、`False` | 启用或禁用 HIVM 同步求解器。 | `triton.Config` 或 launch meta-parameter |


### PR DESCRIPTION
## Summary

Update the EN and ZH compiler options reference tables (`environment_variable_and_compiler_options_reference.md`) and the architecture / feature overview tables (`architecture_design_and_core_features.md`) to explicitly state that `multibuffer` is enabled by default.

The previous wording either left the default implicit or only mentioned a 910_95 caveat, which could confuse users about the actual default value of this option.

This is a docs-only change.

## Test plan

- [ ] Verify docs render correctly in the documentation site.
- [ ] Confirm no functional code changes (docs-only PR).