### PR TITLE
Supports dynamic step sizes for ParamSpace

### DIFF
--- a/third_party/ascend/backend/runtime/cv_autotune/generators/cv_tile_generator.py
+++ b/third_party/ascend/backend/runtime/cv_autotune/generators/cv_tile_generator.py
@@ -100,6 +100,10 @@ class CVTileGenerator:
     _K_DEFAULT_MAX = 128
     _K_STRIDE = 16
 
+    _STEP_SMALL = 16
+    _STEP_LARGE = 32
+    _STEP_THRESHOLD = 64
+
     def __init__(self,
                 cv_parse_result: CvParseResult,
                 hardware_constraints: Optional[HardwareConstraints] = None,
@@ -176,34 +180,34 @@ class CVTileGenerator:
 
     def _make_param(self, name: str, max_val: int, min_val: int, stride: int) -> ParamSpace:
         """
-        Build a parameter search space and handle non-uniform max values.
+        Build a parameter search space with segmented strides.
 
-        Two irregular cases are supported:
-        1. ``max < stride``: use ``max`` as the only value (ENUM type).
-        2. ``max >= stride`` but ``max % stride != 0``: use the aligned stride
-           sequence and append ``max`` as the tail value.
+        Supports dynamic step sizes:
+        - Step = 16 when current value < 64.
+        - Step = 32 when current value > 64.
+        Always includes `min_val` and `max_val`. Returns an ENUM ParamSpace.
 
         Args:
             name: Parameter name.
-            max_val: Axis length upper bound.
-            min_val: Minimum tile value.
-            stride: Step size.
+            max_val: Upper bound.
+            min_val: Lower bound.
+            stride: (Ignored, kept for API compatibility.)
 
         Returns:
-            ParamSpace: Search-space definition.
+            ParamSpace: ENUM type containing the generated tile sizes.
         """
         # Case 1: max < stride, so max itself is the only legal value.
-        if max_val < stride:
-            return ParamSpace(name=name, type="ENUM", values=[max_val])
-
-        # Regular case: max is aligned to stride.
-        if max_val % stride == 0:
-            return ParamSpace(name=name, type="NUM", min=min_val, max=max_val, stride=stride)
-
-        # Case 2: max is not stride-aligned, append it after the aligned range.
-        aligned_max = (max_val // stride) * stride
-        base_values = list(range(min_val, aligned_max + 1, stride))
-        values = base_values + [max_val]
+        values = []
+        current = min_val
+        while current <= max_val:
+            values.append(current)
+            if current < self._STEP_THRESHOLD:
+                current += self._STEP_SMALL
+            else:
+                current += self._STEP_LARGE
+        if values[-1] != max_val:
+            values.append(max_val)
+        values = sorted(set(values))
         return ParamSpace(name=name, type="ENUM", values=values)
 
     @staticmethod


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
