### PR TITLE
feat(ssbuffer): add decoupled compute and memory pass

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoadInternal.h
+++ b/third_party/ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoadInternal.h
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ADAPTER_ADD_MULTI_BUFFER_TO_GMLOAD_INTERNAL_H
+#define TRITON_ADAPTER_ADD_MULTI_BUFFER_TO_GMLOAD_INTERNAL_H
+
+#include "ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoadTypes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+using namespace mlir;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+static constexpr const char *DEBUG_TYPE = "add-multi-buffer-to-gm-load";
+#define LOG_DEBUG(...) LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__)
+
+static constexpr llvm::StringLiteral kBufferableMarker("gm_load_bufferable");
+static constexpr llvm::StringLiteral kBlockIdAttr("ssbuffer.block_id");
+static constexpr llvm::StringLiteral kLoadStoreAttr("ssbuffer.load_store");
+static constexpr llvm::StringLiteral kGMLoadMultiBufferStage("gm-load multi-buffer");
+static constexpr unsigned kInitialRefCapacity = 8; // Tuned for typical load chain depth
+static constexpr unsigned kForInductionVarArgIndex = 0;
+static constexpr unsigned kForBodyIterArgOffset = 1;
+// Each load group carries `depth` slot flags plus producer/consumer counters.
+// This count is independent of the configured buffer depth.
+static constexpr int kLoadGroupCounterIterArgCount = 2;
+static constexpr int kLoadGroupProducerCounterOffset = 0;
+static constexpr int kLoadGroupConsumerCounterOffset = 1;
+
+// ============================================================================
+// Data structures (debug/utility only, types are in AddMultiBufferToGMLoadTypes.h)
+// ============================================================================
+
+namespace gmload {
+
+/// Reuses existing arith.constant ops found in the IR rather than creating
+/// duplicates. Pre-populated by scanning a block; get-or-create semantics.
+/// Suitable for untagged constants only (no ssbuffer.block_id attribution).
+struct ConstantCache {
+    llvm::DenseMap<mlir::Attribute, Value> table;
+
+    void scan(Block *block)
+    {
+        for (auto &op : *block)
+            if (auto cst = dyn_cast<arith::ConstantOp>(op))
+                table.try_emplace(cst.getValue(), cst.getResult());
+    }
+
+    Value get(OpBuilder &builder, Location loc, mlir::TypedAttr attr)
+    {
+        auto [cacheIt, inserted] = table.try_emplace(attr, Value {});
+        if (!inserted)
+            return cacheIt->second;
+        cacheIt->second = builder.create<arith::ConstantOp>(loc, attr).getResult();
+        return cacheIt->second;
+    }
+
+    Value getFalse(OpBuilder &builder, Location loc) { return get(builder, loc, builder.getBoolAttr(false)); }
+
+    Value getIndex(OpBuilder &builder, Location loc, int64_t value)
+    {
+        return get(builder, loc, cast<mlir::TypedAttr>(builder.getIndexAttr(value)));
+    }
+};
+
+// ============================================================================
+// Function declarations: Dependency analysis
+// ============================================================================
+
+Operation *getAncestorInBlock(Operation *op, Block *scopeBlock);
+void backwardTrace(Operation *op, Block *scopeBlock, llvm::SetVector<Operation *> &visited,
+                   SmallVectorImpl<Operation *> &worklist);
+void backwardTraceFromWorklist(llvm::SetVector<Operation *> &visited, SmallVectorImpl<Operation *> &worklist,
+                               Block *scopeBlock);
+SmallVector<Operation *> forwardTraceFromAllocs(llvm::SetVector<Operation *> &visited, Block *scopeBlock);
+void captureRegionFreeVars(llvm::SetVector<Operation *> &visited, SmallVectorImpl<Operation *> &worklist,
+                           Block *scopeBlock);
+SmallVector<Operation *> computeLoadChain(Operation *markedOp, Block *scopeBlock);
+memref::AllocOp findBackingAlloc(Operation *markedOp, ArrayRef<Operation *> chain);
+SmallVector<MarkedLoad> collectMarkedOps(ModuleOp module);
+std::optional<int64_t> getConstantTripCount(scf::ForOp forOp);
+void groupByEnclosingForOp(SmallVector<MarkedLoad> &markedOps, SmallVectorImpl<ForBufferCtx> &contexts);
+void collectChainAndMarkedOps(const SmallVector<MarkedLoad> &loads, llvm::DenseSet<Operation *> &allChainOps,
+                              llvm::DenseSet<Operation *> &markedOps);
+bool isResultUsedExternally(Value result, Operation *yieldOp, const llvm::DenseSet<Operation *> &allChainOps,
+                            Block *forBody);
+SmallVector<Value, kInitialRefCapacity> collectOperandsIncludingRegions(Operation *op);
+llvm::DenseSet<Operation *> computeSkipInConsumer(const SmallVector<MarkedLoad> &loads, Block *forBody);
+
+// ============================================================================
+// Function declarations: Loop transformation utilities
+// ============================================================================
+
+bool isLoopInvariant(Value value, scf::ForOp forOp);
+bool getLinearIterArgDelta(Value iterArg, Value yieldVal, scf::ForOp forOp, Value &delta);
+Value castIndexTo(OpBuilder &builder, Location loc, Value value, Type targetType);
+Value castToIndex(OpBuilder &builder, Location loc, Value value);
+void tagWithBlockId(Value value, IntegerAttr blockId);
+void allocateBufferSlots(OpBuilder &builder, Location loc, scf::ForOp forOp, LoadGroup &group);
+ExtendedForInfo buildExtendedFor(OpBuilder &builder, Location loc, scf::ForOp forOp, ArrayRef<LoadGroup> groups,
+                                 ConstantCache &cache);
+bool isDeadIterArg(scf::ForOp forOp, unsigned iterArgIdx);
+FailureOr<scf::ForOp> pruneDeadIterArgs(OpBuilder &builder, scf::ForOp forOp, unsigned candidateCount);
+void eraseDeadBodyOps(Block *body);
+bool isAvailableForClone(Value value, Block *oldBody, const IRMapping &mapping);
+bool areOperandsAvailableForClone(Operation *op, Block *oldBody, const IRMapping &mapping);
+std::optional<int32_t> getBlockId(Operation *op);
+bool sameRunBlockId(const BodyRun &run, std::optional<int32_t> bid);
+SmallVector<BodyRun> collectBodyRuns(Block *body);
+int findRunContainingOp(ArrayRef<BodyRun> runs, Operation *target);
+int findFirstRunWithBlockId(ArrayRef<BodyRun> runs, int32_t blockId);
+void logRepeatedTopLevelBlockRuns(Block *body, llvm::StringRef stage);
+bool isAncestorBlock(Block *ancestor, Block *descendant);
+void deduplicateConstants(ModuleOp module);
+LogicalResult applyMultiBufferToForLoop(ForBufferCtx &context, const llvm::DenseSet<Operation *> &allCtxForOps);
+
+// ============================================================================
+// Function declarations: Consumer/Producer emission
+// ============================================================================
+
+Value emitLoadSlotSelection(OpBuilder &builder, Location loc, const MarkedLoad &load, ArrayRef<Value> slotBufs,
+                            Value target, int depth, IRMapping &mapping, ArrayRef<Value> slotConsts);
+Value emitSlotFlagClear(OpBuilder &builder, Location loc, Value target, Value slotConst, Value flagNext, Value falseVal,
+                        IntegerAttr blockId);
+FailureOr<std::pair<Value, Value>> emitProducerFillForSlot(OpBuilder &builder, Location loc, Block *oldBody,
+                                                           Block *newBody, const LoadGroup &group, int slotIdx,
+                                                           Value flagArg, Value currentProducerCounter,
+                                                           Value tripCount, Value falseVal, Value loopLowerBound,
+                                                           Value loopStep, Value trueFlag, Value indexOne,
+                                                           const SmallVector<Value> &iterArgDeltas,
+                                                           scf::ForOp origForOp);
+LogicalResult emitMultiBufferLoopBody(OpBuilder &builder, Location loc, SmallVectorImpl<LoadGroup> &groups,
+                                      ExtendedForInfo &info, const SmallVector<Value> &groupIndexOneVals,
+                                      const SmallVector<SmallVector<Value>> &allGroupSlotConsts,
+                                      const SmallVector<Value> &allGroupDepthConsts,
+                                      const llvm::DenseSet<Operation *> &allCtxForOps, Value tripCount,
+                                      Value loopLowerBound, Value loopStep, const SmallVector<Value> &groupTrueFlagVals,
+                                      const SmallVector<Value> &iterArgDeltas, scf::ForOp origForOp);
+
+} // namespace gmload
+
+#endif // TRITON_ADAPTER_ADD_MULTI_BUFFER_TO_GMLOAD_INTERNAL_H

--- a/third_party/ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoadPass.h
+++ b/third_party/ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoadPass.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ADAPTER_ADD_MULTI_BUFFER_TO_GMLOAD_PASS_H
+#define TRITON_ADAPTER_ADD_MULTI_BUFFER_TO_GMLOAD_PASS_H
+
+#include "ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoadTypes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/DenseSet.h"
+
+namespace mlir {
+namespace triton {
+
+// Rewrites GM load operations inside scf.for loops into a multi-buffer
+// producer/consumer structure to overlap memory transfers with compute.
+class AddMultiBufferToGMLoadPass : public PassWrapper<AddMultiBufferToGMLoadPass, OperationPass<ModuleOp>> {
+public:
+    MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(AddMultiBufferToGMLoadPass)
+
+    StringRef getArgument() const override { return "gm-load-multi-buffer"; }
+    void runOnOperation() override;
+
+private:
+    // Step 1: Collect marked ops and group by enclosing forOp
+    void collectAndGroupMarkedOps();
+
+    // Step 2: Sort contexts inner-first
+    void sortContextsInnerFirst();
+
+    // Step 3: Transform each for loop with multi-buffer logic
+    LogicalResult applyMultiBufferToGMLoadLoops();
+
+    // Step 4: Cleanup transformed IR
+    void cleanupTransformedIR();
+
+    // Shared state between steps
+    llvm::SmallVector<gmload::MarkedLoad> markedOps_;
+    llvm::SmallVector<gmload::ForBufferCtx, 0> contexts_;
+    llvm::DenseSet<Operation *> allCtxForOps_;
+};
+
+// Create the pass
+std::unique_ptr<OperationPass<ModuleOp>> createAddMultiBufferToGMLoadPass();
+
+} // namespace triton
+} // namespace mlir
+
+#endif // TRITON_ADAPTER_ADD_MULTI_BUFFER_TO_GMLOAD_PASS_H

--- a/third_party/ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoadTypes.h
+++ b/third_party/ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoadTypes.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ADAPTER_ADD_MULTI_BUFFER_TO_GMLOAD_TYPES_H
+#define TRITON_ADAPTER_ADD_MULTI_BUFFER_TO_GMLOAD_TYPES_H
+
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace gmload {
+
+// One marked op and the topo-sorted dependency chain needed to reproduce it.
+struct MarkedLoad {
+    mlir::Operation *markedOp = nullptr;
+    llvm::SmallVector<mlir::Operation *> chain;
+    mlir::memref::AllocOp allocOp;
+};
+
+// Each marked load gets its own independent LoadGroup with its own
+// producer/consumer counter pair.
+struct LoadGroup {
+    llvm::SmallVector<MarkedLoad> loads;
+    int depth = 0;
+    llvm::SmallVector<llvm::SmallVector<mlir::Value>> bufSlots; // bufSlots[slot][load]
+    llvm::SmallVector<mlir::Operation *> mergedChain;
+};
+
+// Transformation context for one scf.for.
+struct ForBufferCtx {
+    mlir::scf::ForOp forOp;
+    llvm::SmallVector<LoadGroup> groups;
+};
+
+// Iter-arg handles for one LoadGroup inside the extended scf.for.
+struct GroupIterArgs {
+    llvm::SmallVector<mlir::Value> flagArgs;
+    mlir::Value prodCounter;
+    mlir::Value consCounter;
+};
+
+// Output of buildExtendedFor: new loop + per-group iter_arg handles.
+struct ExtendedForInfo {
+    mlir::scf::ForOp newForOp;
+    mlir::Block *oldBody = nullptr;
+    mlir::Block *newBody = nullptr;
+    mlir::IRMapping mapping;
+    llvm::SmallVector<GroupIterArgs> groupArgs;
+    mlir::Value falseVal;
+    int numOrig = 0;
+    int depth = 0;
+};
+
+// One consecutive top-level run in an old loop body.
+struct BodyRun {
+    bool hasBlockId = false;
+    int32_t blockId = 0;
+    llvm::SmallVector<mlir::Operation *> ops;
+};
+
+} // namespace gmload
+
+#endif // TRITON_ADAPTER_ADD_MULTI_BUFFER_TO_GMLOAD_TYPES_H

--- a/third_party/ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/AsyncLoadHoistingPass.h
+++ b/third_party/ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/AsyncLoadHoistingPass.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ADAPTER_ASYNC_LOAD_HOISTING_PASS_H
+#define TRITON_ADAPTER_ASYNC_LOAD_HOISTING_PASS_H
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace triton {
+
+class AsyncLoadHoistingPass
+    : public PassWrapper<AsyncLoadHoistingPass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(AsyncLoadHoistingPass)
+
+  AsyncLoadHoistingPass() = default;
+
+  StringRef getArgument() const override { return "async-load-hoisting"; }
+
+  void runOnOperation() override;
+};
+
+std::unique_ptr<OperationPass<ModuleOp>> createAsyncLoadHoistingPass();
+void registerAsyncLoadHoistingPasses();
+
+} // namespace triton
+} // namespace mlir
+
+#endif // TRITON_ADAPTER_ASYNC_LOAD_HOISTING_PASS_H

--- a/third_party/ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/DecoupleComputeAndMemoryPass.h
+++ b/third_party/ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/DecoupleComputeAndMemoryPass.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ADAPTER_DECOUPLE_COMPUTE_AND_MEMORY_PASS_H
+#define TRITON_ADAPTER_DECOUPLE_COMPUTE_AND_MEMORY_PASS_H
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace triton {
+
+/// Sub-pipeline pass that decouples compute and memory operations.
+class DecoupleComputeAndMemoryPass : public PassWrapper<DecoupleComputeAndMemoryPass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(DecoupleComputeAndMemoryPass)
+
+  DecoupleComputeAndMemoryPass() = default;
+
+  void runOnOperation() override;
+};
+
+std::unique_ptr<OperationPass<ModuleOp>> createDecoupleComputeAndMemoryPass();
+
+} // namespace triton
+} // namespace mlir
+
+#endif // TRITON_ADAPTER_DECOUPLE_COMPUTE_AND_MEMORY_PASS_H

--- a/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/DecoupleComputeAndMemoryPass.h"
+#include "mlir/Pass/PassManager.h"
+#include "llvm/Support/Debug.h"
+#include "ascend/include/DynamicCVPipeline/Common/BufferCountManager.h"
+#include "ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoadPass.h"
+#include "ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/AsyncLoadHoistingPass.h"
+
+static constexpr const char *DEBUG_TYPE = "decouple-compute-and-memory";
+#define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << (X) << "\n")
+
+using namespace mlir;
+using namespace triton;
+
+void DecoupleComputeAndMemoryPass::runOnOperation()
+{
+  ModuleOp module = getOperation();
+
+  int depth = BufferCountManager::getInstance().getBufferCountByType(BufferCountManager::DepType::LoadStore);
+
+  if (depth <= 1) {
+    LDBG("Buffer depth <= 1, skip multi-buffer transformation");
+    return;
+  }
+
+  OpPassManager pm(module.getOperationName());
+  LDBG("Enter DecoupleComputeAndMemory pass");
+
+  // Step 1: Hoist memory operations out of compute blocks
+  pm.addPass(createAsyncLoadHoistingPass());
+
+  // Step 2: Apply multi-buffering to memory operations
+  pm.addPass(createAddMultiBufferToGMLoadPass());
+
+  if (failed(runPipeline(pm, module))) {
+    module->emitError() << "[" << DEBUG_TYPE << "] Pass failed!";
+    signalPassFailure();
+  }
+
+  LDBG("Process successfully");
+}
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<OperationPass<ModuleOp>> createDecoupleComputeAndMemoryPass()
+{
+  return std::make_unique<DecoupleComputeAndMemoryPass>();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoad.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoad.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoadInternal.h"
+#include "ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoadPass.h"
+#include "ascend/include/DynamicCVPipeline/Common/BufferCountManager.h"
+
+using namespace mlir;
+using namespace triton;
+using namespace gmload;
+
+// ============================================================================
+// Step functions
+// ============================================================================
+
+void AddMultiBufferToGMLoadPass::collectAndGroupMarkedOps()
+{
+    auto module = getOperation();
+
+    // Scan all IR for marked ops (generic, no loop dependency).
+    markedOps_ = collectMarkedOps(module);
+    if (markedOps_.empty()) {
+        LOG_DEBUG("No marked loads found, nothing to transform\n");
+        return;
+    }
+    LOG_DEBUG("Marked loads collected, start transformation\n");
+
+    // Group by enclosing scf::ForOp.
+    groupByEnclosingForOp(markedOps_, contexts_);
+
+    // Apply depth policy: skip loops whose compile-time trip count is too small
+    // to benefit, then record the slot count on each group.
+    int depth = BufferCountManager::getInstance().getBufferCountByType(BufferCountManager::DepType::LoadStore);
+    llvm::erase_if(contexts_, [depth](const ForBufferCtx &context) {
+        if (auto tripCount = getConstantTripCount(context.forOp))
+            return *tripCount <= depth;
+        return false;
+    });
+    for (auto &context : contexts_)
+        for (auto &group : context.groups)
+            group.depth = depth;
+
+    if (contexts_.empty())
+        LOG_DEBUG("No bufferable loops found\n");
+}
+
+void AddMultiBufferToGMLoadPass::sortContextsInnerFirst()
+{
+    // Sort contexts inner-first so that inner loops are transformed
+    // before the outer loops that contain them.
+    auto getNestingDepth = [](Operation *loopOp) {
+        unsigned nestingDepth = 0;
+        for (Operation *parentOp = loopOp->getParentOp(); parentOp; parentOp = parentOp->getParentOp())
+            ++nestingDepth;
+        return nestingDepth;
+    };
+
+    llvm::sort(contexts_, [&getNestingDepth](const ForBufferCtx &leftContext, const ForBufferCtx &rightContext) {
+        Operation *leftLoopOp = const_cast<scf::ForOp &>(leftContext.forOp).getOperation();
+        Operation *rightLoopOp = const_cast<scf::ForOp &>(rightContext.forOp).getOperation();
+        unsigned leftDepth = getNestingDepth(leftLoopOp);
+        unsigned rightDepth = getNestingDepth(rightLoopOp);
+        if (leftDepth != rightDepth)
+            return leftDepth > rightDepth;
+        if (leftLoopOp->getBlock() == rightLoopOp->getBlock())
+            return leftLoopOp->isBeforeInBlock(rightLoopOp);
+        return false;
+    });
+}
+
+LogicalResult AddMultiBufferToGMLoadPass::applyMultiBufferToGMLoadLoops()
+{
+    for (auto &context : contexts_)
+        allCtxForOps_.insert(context.forOp.getOperation());
+
+    // Process inner loops before outer loops.
+    for (auto &context : contexts_)
+        if (failed(applyMultiBufferToForLoop(context, allCtxForOps_)))
+            return failure();
+
+    return success();
+}
+
+void AddMultiBufferToGMLoadPass::cleanupTransformedIR()
+{
+    auto module = getOperation();
+
+    // Deduplicate untagged constants that inner-loop processing created
+    // before outer-loop processing could provide the dominating equivalents.
+    deduplicateConstants(module);
+
+    // Erase replaced original for ops.
+    llvm::DenseSet<Operation *> nestedForOps;
+    for (auto &context : contexts_) {
+        Operation *parentOp = context.forOp->getParentOp();
+        while (parentOp) {
+            if (allCtxForOps_.contains(parentOp)) {
+                nestedForOps.insert(context.forOp.getOperation());
+                break;
+            }
+            parentOp = parentOp->getParentOp();
+        }
+    }
+
+    for (auto &context : llvm::reverse(contexts_)) {
+        if (nestedForOps.contains(context.forOp.getOperation()))
+            continue;
+        context.forOp.erase();
+    }
+}
+
+// ============================================================================
+// Pass entry point
+// ============================================================================
+
+void AddMultiBufferToGMLoadPass::runOnOperation()
+{
+    auto module = getOperation();
+    LOG_DEBUG("Enter add-multi-buffer-to-gm-load pass\n");
+    LOG_DEBUG("Before add-multi-buffer-to-gm-load:\n" << module << "\n");
+
+    // Step 1: Collect marked ops and group by enclosing forOp
+    markedOps_.clear();
+    contexts_.clear();
+    collectAndGroupMarkedOps();
+    if (contexts_.empty())
+        return;
+
+    // Step 2: Sort contexts inner-first
+    sortContextsInnerFirst();
+
+    // Step 3: Transform each for loop with multi-buffer logic
+    allCtxForOps_.clear();
+    if (failed(applyMultiBufferToGMLoadLoops())) {
+        module.emitError() << "[" << DEBUG_TYPE << "] Step 3 applyMultiBufferToGMLoadLoops failed";
+        signalPassFailure();
+        return;
+    }
+
+    // Step 4: Cleanup transformed IR
+    cleanupTransformedIR();
+
+    LOG_DEBUG("After add-multi-buffer-to-gm-load:\n" << module << "\n");
+    LOG_DEBUG("Process successfully\n");
+}
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<OperationPass<ModuleOp>> createAddMultiBufferToGMLoadPass()
+{
+    return std::make_unique<AddMultiBufferToGMLoadPass>();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/AsyncLoadHoisting.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/AsyncLoadHoisting.cpp
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/AsyncLoadHoistingPass.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Block.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "async-load-hoisting"
+
+using namespace mlir;
+using namespace triton;
+
+
+namespace mlir {
+namespace triton {
+
+// Check if op is a mask processing operation (broadcast, cmpf, select, etc.)
+// Mask values are not directly fed into Cube
+static bool isMaskProcessingOp(Operation* op)
+{
+  return mlir::isa<arith::CmpFOp, arith::SelectOp, arith::MaximumFOp, arith::MinimumFOp>(op);
+}
+
+// Recursively check if all downstream users of op are mask processing operations
+static bool isOnlyUsedByMaskProcessingOpsRecursively(Operation* op, llvm::DenseSet<Operation*>& visited)
+{
+  if (visited.count(op)) {
+    return true; // Already visited
+  }
+  visited.insert(op);
+
+  if (op->getNumResults() == 0) {
+    return false;
+  }
+
+  bool hasAnyUsers = false;
+  for (auto result : op->getResults()) {
+    for (auto* user : result.getUsers()) {
+      hasAnyUsers = true;
+      if (!isMaskProcessingOp(user) && !isOnlyUsedByMaskProcessingOpsRecursively(user, visited)) {
+        return false;
+      }
+    }
+  }
+  if (!hasAnyUsers) {
+    return false;
+  }
+  return true;
+}
+
+// Check if all downstream users of op are mask processing operations
+static bool isOnlyUsedByMaskProcessingOps(Operation* op)
+{
+  llvm::DenseSet<Operation*> visited;
+  return isOnlyUsedByMaskProcessingOpsRecursively(op, visited);
+}
+
+static bool isLoadOp(Operation* op)
+{
+  auto effectInterface = dyn_cast<MemoryEffectOpInterface>(op);
+  if (!effectInterface) {
+    return false;
+  }
+
+  // Skip memref.copy (has exactly 2 operands: src and dst)
+  if (mlir::isa<memref::CopyOp>(op)) {
+    return false;
+  }
+
+  // Skip memref.load with all scalar indices
+  if (mlir::isa<memref::LoadOp>(op)) {
+    bool allScalarIndices = true;
+    for (size_t i = 1; i < op->getNumOperands(); ++i) {
+      auto* defOp = op->getOperand(i).getDefiningOp();
+      if (!defOp || !llvm::isa<arith::ConstantOp>(defOp)) {
+        allScalarIndices = false;
+        break;
+      }
+    }
+    if (allScalarIndices && op->getNumOperands() > 1) {
+      return false;
+    }
+  }
+
+  if (isOnlyUsedByMaskProcessingOps(op)) {
+    return false;
+  }
+
+  return effectInterface.hasEffect<MemoryEffects::Read>();
+}
+
+// Check if a Value's computation chain is linear and predictable.
+// Returns false if the chain contains remsi (modulo), load (indirect addressing),
+// or complex loops.
+static bool isLinearAndPredictable(mlir::Value value, llvm::DenseSet<mlir::Value>& visited)
+{
+  if (value.getDefiningOp<mlir::arith::ConstantOp>()) return true;
+  if (mlir::isa<mlir::BlockArgument>(value)) return true;
+  if (!visited.insert(value).second) return true;
+
+  mlir::Operation* defOp = value.getDefiningOp();
+  if (!defOp) return true;
+
+  // Block nonlinear ops: memref.load (indirect addressing), scf.while/for (complex control flow)
+  if (mlir::isa<mlir::memref::LoadOp, mlir::scf::WhileOp, mlir::scf::ForOp>(defOp)) {
+    return false;
+  }
+
+  // Recursively check operands
+  for (mlir::Value operand : defOp->getOperands()) {
+    mlir::Operation* operandDefOp = operand.getDefiningOp();
+    if (!operandDefOp || operandDefOp->getParentRegion() != defOp->getParentRegion()) {
+      return true; // Cross-region boundary, treat as linear
+    }
+    if (!isLinearAndPredictable(operand, visited)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// Check if all reinterpret_cast offsets in chain are linearly predictable
+static bool filterNonLinearReinterpretCast(const std::vector<mlir::Operation*>& chain)
+{
+  for (mlir::Operation* op : chain) {
+    auto castOp = llvm::dyn_cast<mlir::memref::ReinterpretCastOp>(op);
+    if (!castOp) continue;
+
+    llvm::DenseSet<mlir::Value> visited;
+
+    for (auto offset : castOp.getOffsets()) {
+      if (!isLinearAndPredictable(offset, visited)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+// Get ssbuffer.block_id attribute value, returns -1 if not present
+static int64_t getBlockId(Operation* op)
+{
+  if (auto blockIdAttr = op->getAttrOfType<IntegerAttr>("ssbuffer.block_id")) {
+    return blockIdAttr.getInt();
+  }
+  return -1;
+}
+
+static void collectAddressGenerationOps(Operation* op, int64_t expectedBlockId, llvm::DenseSet<Operation*>& visited, std::vector<Operation*>& chain)
+{
+  for (auto operand : op->getOperands()) {
+    auto* defOp = operand.getDefiningOp();
+
+    if (!defOp || visited.count(defOp) || llvm::isa<arith::ConstantOp>(defOp)) {
+      continue;
+    }
+
+    if (isLoadOp(defOp)) continue;
+
+    if (mlir::isa<MemRefType>(operand.getType())) {
+      for (auto* user : operand.getUsers()) {
+        if (auto copyOp = llvm::dyn_cast<memref::CopyOp>(user);
+            copyOp && copyOp.getTarget() == operand && visited.insert(copyOp).second) {
+          chain.push_back(copyOp);
+          collectAddressGenerationOps(copyOp, expectedBlockId, visited, chain);
+          continue;
+        }
+        if (mlir::isa<memref::SubViewOp>(user) && visited.insert(user).second) {
+          chain.push_back(user);
+          for (auto result : user->getResults()) {
+            for (auto* subviewUser : result.getUsers()) {
+              if (auto copyOp = llvm::dyn_cast<memref::CopyOp>(subviewUser);
+                  visited.insert(copyOp).second) {
+                chain.push_back(copyOp);
+                collectAddressGenerationOps(copyOp, expectedBlockId, visited, chain);
+              }
+            }
+          }
+          collectAddressGenerationOps(user, expectedBlockId, visited, chain);
+        }
+      }
+    }
+
+    visited.insert(defOp);
+    chain.push_back(defOp);
+
+    collectAddressGenerationOps(defOp, expectedBlockId, visited, chain);
+  }
+}
+// Returns full chain and filtered chain (only ops with same block_id)
+static std::pair<std::vector<Operation*>, std::vector<Operation*>> getAddressGenerationChainWithFilter(Operation* loadOp)
+{
+  std::vector<Operation*> chain;
+  chain.push_back(loadOp);
+
+  llvm::DenseSet<Operation*> visitedOp;
+  visitedOp.insert(loadOp);
+
+  int64_t expectedBlockId = getBlockId(loadOp);
+
+  collectAddressGenerationOps(loadOp, expectedBlockId, visitedOp, chain);
+
+  if (chain.size() > 1) {
+    auto* block = loadOp->getBlock();
+    auto sortStartIter = chain.begin() + 1;
+    std::stable_sort(sortStartIter, chain.end(), [block](Operation* a, Operation* b) {
+      for (auto& op : *block) {
+        if (&op == a) return true;
+        if (&op == b) return false;
+      }
+      return false;
+    });
+    auto loadOpIter = chain.begin();
+    std::rotate(loadOpIter, loadOpIter + 1, chain.end());
+  }
+
+  std::vector<Operation*> filteredChain;
+  for (Operation* op : chain) {
+    if (getBlockId(op) == expectedBlockId) {
+      filteredChain.push_back(op);
+    }
+  }
+
+  return {chain, filteredChain};
+}
+
+// Check if chain contains any block argument
+static bool chainContainsBlockArg(Operation* loadOp)
+{
+  auto [fullChain, filteredChain] = getAddressGenerationChainWithFilter(loadOp);
+
+  for (Operation* op : fullChain) {
+    for (auto operand : op->getOperands()) {
+      if (!operand.getDefiningOp()) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+
+// Process all load ops with the same block_id
+static void scanAndHoistBlock(llvm::SmallVector<Operation*> &cache)
+{
+    for (Operation* opPtr : cache) {
+      bool isLoad = isLoadOp(opPtr);
+      bool hasBlockArg = chainContainsBlockArg(opPtr);
+      if (isLoad) {
+        auto [fullChain, filteredChain] = getAddressGenerationChainWithFilter(opPtr);
+        (void)fullChain;
+        bool passNonLinear = filterNonLinearReinterpretCast(filteredChain);
+        if (passNonLinear && hasBlockArg) {
+          opPtr->setAttr("gm_load_bufferable", UnitAttr::get(opPtr->getContext()));
+        }
+      }
+    }
+}
+
+// Traverse all ops in region, grouped by ssbuffer.block_id
+static void asyncLoadHoistingImpl(Region& region)
+{
+  llvm::SmallVector<Operation*> cache;
+
+  for (Block& block : llvm::make_early_inc_range(region)) {
+    for (Operation& op : llvm::make_early_inc_range(block)) {
+      int64_t opBlockId = getBlockId(&op);
+
+      if (op.getNumRegions() > 0) {
+        for (Region& childRegion : op.getRegions()) {
+          if (childRegion.empty()) continue;
+          asyncLoadHoistingImpl(childRegion);
+        }
+        continue;
+      }
+
+      if (cache.empty()) {
+        cache.push_back(&op);
+        continue;
+      }
+
+      int64_t cacheBlockId = getBlockId(cache.front());
+      if (opBlockId == cacheBlockId && opBlockId != -1) {
+        cache.push_back(&op);
+      } else {
+        scanAndHoistBlock(cache);
+        cache.clear();
+        cache.push_back(&op);
+      }
+    }
+  }
+
+  if (!cache.empty()) {
+    scanAndHoistBlock(cache);
+    cache.clear();
+  }
+}
+
+} // namespace triton
+} // namespace mlir
+
+void AsyncLoadHoistingPass::runOnOperation()
+{
+  auto module = getOperation();
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "[async-load-hoisting] Before AsyncLoadHoistingPass:\n" << module << "\n";
+  });
+
+  module->walk([&](func::FuncOp func) {
+    asyncLoadHoistingImpl(func.getBody());
+  });
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "[async-load-hoisting] After AsyncLoadHoistingPass:\n" << module << "\n";
+  });
+}
+
+std::unique_ptr<OperationPass<ModuleOp>> mlir::triton::createAsyncLoadHoistingPass()
+{
+  return std::make_unique<AsyncLoadHoistingPass>();
+}
+
+void mlir::triton::registerAsyncLoadHoistingPasses()
+{
+  registerPass([]() -> std::unique_ptr<mlir::Pass> { return createAsyncLoadHoistingPass(); });
+}

--- a/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/DependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/DependencyAnalysis.cpp
@@ -1,0 +1,387 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoadInternal.h"
+
+namespace gmload {
+
+// ============================================================================
+// Analysis: dependency chain computation
+// ============================================================================
+
+/// Given an op that may be nested inside a region (e.g., inside scf.if),
+/// walk up the parent chain and return the ancestor op that lives directly
+/// in `scopeBlock`. Returns nullptr if no such ancestor exists.
+Operation *getAncestorInBlock(Operation *nestedOp, Block *scopeBlock)
+{
+    while (nestedOp) {
+        if (nestedOp->getBlock() == scopeBlock)
+            return nestedOp;
+        nestedOp = nestedOp->getParentOp();
+    }
+    return nullptr;
+}
+
+/// Add `op` and all its transitive SSA operand-producers within `scopeBlock`
+/// to `visited`. Newly discovered ops are also appended to `worklist`.
+void backwardTrace(Operation *sourceOp, Block *scopeBlock, llvm::SetVector<Operation *> &visited,
+                   SmallVectorImpl<Operation *> &worklist)
+{
+    for (Value operand : sourceOp->getOperands()) {
+        auto *defOp = operand.getDefiningOp();
+        if (!defOp || defOp->getBlock() != scopeBlock)
+            continue;
+        if (visited.insert(defOp))
+            worklist.push_back(defOp);
+    }
+}
+
+/// Process worklist with backward SSA trace until empty.
+/// Used in Phase 1 and Phase 3 of computeLoadChain.
+void backwardTraceFromWorklist(llvm::SetVector<Operation *> &visited, SmallVectorImpl<Operation *> &worklist,
+                               Block *scopeBlock)
+{
+    while (!worklist.empty()) {
+        Operation *currentOp = worklist.pop_back_val();
+        backwardTrace(currentOp, scopeBlock, visited, worklist);
+    }
+}
+
+/// Forward trace from every memref::AllocOp in visited set.
+/// Returns newly discovered ops that use alloc results.
+/// Used in Phase 2 of computeLoadChain.
+SmallVector<Operation *> forwardTraceFromAllocs(llvm::SetVector<Operation *> &visited, Block *scopeBlock)
+{
+    SmallVector<Value> valueWorklist;
+    for (Operation *currentOp : visited) {
+        if (isa<memref::AllocOp>(currentOp)) {
+            for (Value result : currentOp->getResults())
+                valueWorklist.push_back(result);
+        }
+    }
+
+    SmallVector<Operation *> newlyDiscoveredOps;
+    while (!valueWorklist.empty()) {
+        Value currentValue = valueWorklist.pop_back_val();
+        for (Operation *user : currentValue.getUsers()) {
+            Operation *ancestor = getAncestorInBlock(user, scopeBlock);
+            if (!ancestor)
+                continue;
+            if (!visited.insert(ancestor))
+                continue;
+            newlyDiscoveredOps.push_back(ancestor);
+            for (Value result : ancestor->getResults())
+                valueWorklist.push_back(result);
+        }
+    }
+    return newlyDiscoveredOps;
+}
+
+/// Capture free variables used in regions of ops in visited set.
+/// Performs backward trace for each discovered free variable definition.
+/// Used in Phase 4 of computeLoadChain.
+void captureRegionFreeVars(llvm::SetVector<Operation *> &visited, SmallVectorImpl<Operation *> &worklist,
+                           Block *scopeBlock)
+{
+    SmallVector<Operation *> freeVarWorklist;
+    SmallVector<Operation *> initialChain(visited.begin(), visited.end());
+
+    // First pass: collect free variables from all region-containing ops
+    for (Operation *chainOp : initialChain) {
+        if (chainOp->getNumRegions() == 0)
+            continue;
+        chainOp->walk([&](Operation *nested) {
+            if (nested == chainOp)
+                return;
+            for (Value operand : nested->getOperands()) {
+                auto *defOp = operand.getDefiningOp();
+                if (!defOp || defOp->getBlock() != scopeBlock)
+                    continue;
+                if (visited.insert(defOp))
+                    freeVarWorklist.push_back(defOp);
+            }
+        });
+    }
+
+    // Second pass: backward trace and recursively capture nested region free vars
+    worklist.assign(freeVarWorklist.begin(), freeVarWorklist.end());
+    while (!worklist.empty()) {
+        Operation *currentOp = worklist.pop_back_val();
+        backwardTrace(currentOp, scopeBlock, visited, worklist);
+        if (currentOp->getNumRegions() == 0)
+            continue;
+        currentOp->walk([&](Operation *nested) {
+            if (nested == currentOp)
+                return;
+            for (Value operand : nested->getOperands()) {
+                auto *defOp = operand.getDefiningOp();
+                if (!defOp || defOp->getBlock() != scopeBlock)
+                    continue;
+                if (visited.insert(defOp)) {
+                    freeVarWorklist.push_back(defOp);
+                    worklist.push_back(defOp);
+                }
+            }
+        });
+    }
+}
+
+/// Compute the full dependency chain of `markedOp` within `scopeBlock`.
+///   Phase 1  Backward SSA trace from markedOp.
+///   Phase 2  Forward trace from every memref::AllocOp found in Phase 1.
+///   Phase 3  Backward SSA trace from newly discovered ops.
+///   Phase 4  Capture free variables of chain-op regions.
+SmallVector<Operation *> computeLoadChain(Operation *markedOp, Block *scopeBlock)
+{
+    llvm::SetVector<Operation *> visited;
+    SmallVector<Operation *> worklist;
+
+    // Phase 1: backward SSA trace from markedOp
+    visited.insert(markedOp);
+    worklist.push_back(markedOp);
+    backwardTraceFromWorklist(visited, worklist, scopeBlock);
+
+    // Phase 2: forward trace from every memref.alloc in the chain
+    SmallVector<Operation *> newlyDiscoveredOps = forwardTraceFromAllocs(visited, scopeBlock);
+
+    // Phase 3: backward SSA trace from newly discovered ops
+    worklist.assign(newlyDiscoveredOps.begin(), newlyDiscoveredOps.end());
+    backwardTraceFromWorklist(visited, worklist, scopeBlock);
+
+    // Phase 4: capture free variables of chain-op regions
+    captureRegionFreeVars(visited, worklist, scopeBlock);
+
+    // Sort by block position (topological order)
+    SmallVector<Operation *> sorted(visited.begin(), visited.end());
+    llvm::sort(sorted, [](Operation *leftOp, Operation *rightOp) { return leftOp->isBeforeInBlock(rightOp); });
+    return sorted;
+}
+
+/// Find the memref::AllocOp in the chain that backs the marked op.
+memref::AllocOp findBackingAlloc(Operation *markedOp, ArrayRef<Operation *> chain)
+{
+    for (Operation *chainOp : chain) {
+        if (auto alloc = dyn_cast<memref::AllocOp>(chainOp)) {
+            if (markedOp->getNumOperands() > 0 && markedOp->getOperand(0).getDefiningOp() == alloc)
+                return alloc;
+        }
+    }
+    for (Operation *chainOp : chain) {
+        if (auto alloc = dyn_cast<memref::AllocOp>(chainOp))
+            return alloc;
+    }
+    return nullptr;
+}
+
+// ============================================================================
+// Step 1a: Generic marked-op collection (scan all IR)
+// ============================================================================
+
+/// Scan the entire module IR for ops carrying the `kBufferableMarker`
+/// attribute and compute the dependency chain for each.
+SmallVector<MarkedLoad> collectMarkedOps(ModuleOp module)
+{
+    SmallVector<MarkedLoad> results;
+
+    module->walk([&](Operation *op) {
+        if (!op->hasAttr(kBufferableMarker))
+            return;
+        if (op->getNumResults() == 0)
+            return;
+
+        Block *scope = op->getBlock();
+        auto chain = computeLoadChain(op, scope);
+
+        auto alloc = findBackingAlloc(op, chain);
+        if (!alloc)
+            return;
+
+        results.push_back({op, std::move(chain), alloc});
+    });
+
+    return results;
+}
+
+// ============================================================================
+// Step 1b: Group by enclosing loop construct
+// ============================================================================
+
+/// Try to determine the loop trip count at compile time.
+std::optional<int64_t> getConstantTripCount(scf::ForOp forOp)
+{
+    auto lowerBoundConst = forOp.getLowerBound().getDefiningOp<arith::ConstantOp>();
+    auto upperBoundConst = forOp.getUpperBound().getDefiningOp<arith::ConstantOp>();
+    auto stepConst = forOp.getStep().getDefiningOp<arith::ConstantOp>();
+    if (!lowerBoundConst || !upperBoundConst || !stepConst)
+        return std::nullopt;
+
+    auto lowerBoundAttr = dyn_cast<IntegerAttr>(lowerBoundConst.getValue());
+    auto upperBoundAttr = dyn_cast<IntegerAttr>(upperBoundConst.getValue());
+    auto stepAttr = dyn_cast<IntegerAttr>(stepConst.getValue());
+    if (!lowerBoundAttr || !upperBoundAttr || !stepAttr)
+        return std::nullopt;
+
+    int64_t lowerBoundValue = lowerBoundAttr.getInt();
+    int64_t upperBoundValue = upperBoundAttr.getInt();
+    int64_t stepValue = stepAttr.getInt();
+    if (stepValue < 1)
+        return std::nullopt;
+
+    // stepValue >= 1 guaranteed by check above
+    int64_t tripCount = (upperBoundValue - lowerBoundValue + stepValue - 1) / stepValue;
+    return tripCount > 0 ? std::optional<int64_t>(tripCount) : std::nullopt;
+}
+
+/// Group marked loads by their nearest enclosing scf::ForOp.
+/// Each marked load becomes its own independent LoadGroup so that every GM
+/// load has its own producer flags, counters, and slot targets.  Shared
+/// address-computation ops are handled correctly by the consumer skip analysis
+/// without forcing multiple loads into the same multi-buffer state machine.
+void groupByEnclosingForOp(SmallVector<MarkedLoad> &markedOps, SmallVectorImpl<ForBufferCtx> &contexts)
+{
+    // Bucket loads by the nearest enclosing for loop.
+    llvm::DenseMap<Operation *, SmallVector<size_t>> forBuckets;
+    SmallVector<scf::ForOp> forOpsInOrder;
+    for (size_t markedIndex = 0; markedIndex < markedOps.size(); ++markedIndex) {
+        auto forOp = markedOps[markedIndex].markedOp->getParentOfType<scf::ForOp>();
+        if (!forOp)
+            continue;
+        auto [bucketIt, inserted] = forBuckets.try_emplace(forOp.getOperation());
+        if (inserted)
+            forOpsInOrder.push_back(forOp);
+        bucketIt->second.push_back(markedIndex);
+    }
+
+    // Each marked load becomes its own independent LoadGroup.
+    for (auto forOp : forOpsInOrder) {
+        auto &indices = forBuckets[forOp.getOperation()];
+
+        ForBufferCtx context;
+        context.forOp = forOp;
+        for (size_t markedIndex : indices) {
+            LoadGroup group;
+            group.loads.push_back(std::move(markedOps[markedIndex]));
+            if (!group.loads.empty())
+                group.mergedChain = group.loads[0].chain;
+            context.groups.push_back(std::move(group));
+        }
+        contexts.push_back(std::move(context));
+    }
+}
+
+// ============================================================================
+// Consumer skip analysis
+// ============================================================================
+
+/// Collect all chain ops and marked ops from the given loads.
+void collectChainAndMarkedOps(const SmallVector<MarkedLoad> &loads, llvm::DenseSet<Operation *> &allChainOps,
+                              llvm::DenseSet<Operation *> &markedOps)
+{
+    for (const auto &markedLoad : loads) {
+        for (Operation *chainOp : markedLoad.chain)
+            allChainOps.insert(chainOp);
+        markedOps.insert(markedLoad.markedOp);
+    }
+}
+
+/// Check if a result value is used by yield or by non-chain ops in forBody.
+bool isResultUsedExternally(Value result, Operation *yieldOp, const llvm::DenseSet<Operation *> &allChainOps,
+                            Block *forBody)
+{
+    // Check if result is yielded
+    for (Value yieldedValue : yieldOp->getOperands()) {
+        if (yieldedValue == result)
+            return true;
+    }
+    // Check if result is used by non-chain ops
+    for (Operation *user : result.getUsers()) {
+        Operation *ancestor = getAncestorInBlock(user, forBody);
+        if (ancestor && !allChainOps.contains(ancestor))
+            return true;
+    }
+    return false;
+}
+
+/// Collect all operands from an op, including those from nested regions.
+SmallVector<Value, kInitialRefCapacity> collectOperandsIncludingRegions(Operation *op)
+{
+    SmallVector<Value, kInitialRefCapacity> refs;
+    for (Value operand : op->getOperands())
+        refs.push_back(operand);
+    if (op->getNumRegions() > 0) {
+        op->walk([&](Operation *nested) {
+            if (nested == op)
+                return;
+            for (Value operand : nested->getOperands())
+                refs.push_back(operand);
+        });
+    }
+    return refs;
+}
+
+/// Return the set of ops that must be skipped (not cloned) in the consumer
+llvm::DenseSet<Operation *> computeSkipInConsumer(const SmallVector<MarkedLoad> &loads, Block *forBody)
+{
+    llvm::DenseSet<Operation *> allChainOps;
+    llvm::DenseSet<Operation *> markedOps;
+    collectChainAndMarkedOps(loads, allChainOps, markedOps);
+
+    // Phase 1: chain ops whose results are directly used by non-chain ops or
+    // yielded. These must be cloned so non-chain consumers have valid SSA defs.
+    llvm::DenseSet<Operation *> needed;
+    Operation *yieldOp = forBody->getTerminator();
+    for (Operation *chainOp : allChainOps) {
+        if (markedOps.contains(chainOp))
+            continue;
+        bool isNeeded = llvm::any_of(chainOp->getResults(), [&](Value result) {
+            return isResultUsedExternally(result, yieldOp, allChainOps, forBody);
+        });
+        if (isNeeded)
+            needed.insert(chainOp);
+    }
+
+    // Phase 2: backward propagation through operands and region free variables.
+    SmallVector<Operation *> worklist(needed.begin(), needed.end());
+    while (!worklist.empty()) {
+        Operation *currentOp = worklist.pop_back_val();
+        SmallVector<Value, kInitialRefCapacity> operands = collectOperandsIncludingRegions(currentOp);
+        for (Value operand : operands) {
+            auto *defOp = operand.getDefiningOp();
+            if (!defOp || defOp->getBlock() != forBody)
+                continue;
+            if (!allChainOps.contains(defOp) || markedOps.contains(defOp))
+                continue;
+            if (needed.insert(defOp).second)
+                worklist.push_back(defOp);
+        }
+    }
+
+    // Compute skip set as difference: allChainOps - needed
+    llvm::DenseSet<Operation *> skip;
+    for (Operation *chainOp : allChainOps) {
+        if (!needed.contains(chainOp))
+            skip.insert(chainOp);
+    }
+    return skip;
+}
+
+} // namespace gmload

--- a/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/LoopTransform.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/LoopTransform.cpp
@@ -1,0 +1,767 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoadInternal.h"
+
+namespace gmload {
+
+// ============================================================================
+// Dead iter_arg elimination
+// ============================================================================
+
+/// Return true if the iter_arg at `iterArgIdx` in `forOp` is dead
+///   (a) its loop result has no uses outside the loop, AND
+///   (b) its block argument is only used in a chain of side-effect-free ops
+///       whose results ultimately feed only the loop yield.
+bool isDeadIterArg(scf::ForOp forOp, unsigned iterArgIdx)
+{
+    if (!forOp.getResult(iterArgIdx).use_empty()) {
+        return false;
+    }
+
+    Value blockArg = forOp.getBody()->getArgument(iterArgIdx + kForBodyIterArgOffset);
+    Block *forBody = forOp.getBody();
+    Operation *yieldOp = forBody->getTerminator();
+
+    llvm::SmallSetVector<Value, kInitialRefCapacity> frontier;
+    frontier.insert(blockArg);
+
+    while (!frontier.empty()) {
+        Value currentValue = frontier.pop_back_val();
+        for (OpOperand &use : currentValue.getUses()) {
+            Operation *user = use.getOwner();
+            Operation *ancestor = getAncestorInBlock(user, forBody);
+            if (!ancestor) {
+                continue;
+            }
+            if (ancestor == yieldOp) {
+                continue;
+            }
+            if (!mlir::isMemoryEffectFree(ancestor)) {
+                return false;
+            }
+            for (Value result : ancestor->getResults()) {
+                frontier.insert(result);
+            }
+        }
+    }
+    return true;
+}
+
+llvm::DenseSet<unsigned> collectDeadIterArgs(scf::ForOp forOp, unsigned candidateCount)
+{
+    llvm::DenseSet<unsigned> deadSet;
+    for (unsigned iterArgIdx = 0; iterArgIdx < candidateCount; ++iterArgIdx) {
+        if (isDeadIterArg(forOp, iterArgIdx)) {
+            deadSet.insert(iterArgIdx);
+        }
+    }
+    return deadSet;
+}
+
+SmallVector<Value> collectLiveIterArgInits(scf::ForOp forOp, const llvm::DenseSet<unsigned> &deadSet)
+{
+    unsigned numIter = forOp.getNumResults();
+    SmallVector<Value> liveInits;
+    liveInits.reserve(numIter - deadSet.size());
+    for (unsigned iterArgIdx = 0; iterArgIdx < numIter; ++iterArgIdx) {
+        if (!deadSet.contains(iterArgIdx)) {
+            liveInits.push_back(forOp.getInitArgs()[iterArgIdx]);
+        }
+    }
+    return liveInits;
+}
+
+scf::ForOp createForWithLiveIterArgs(OpBuilder &builder, scf::ForOp forOp, ArrayRef<Value> liveInits)
+{
+    builder.setInsertionPoint(forOp);
+    auto newFor = builder.create<scf::ForOp>(forOp.getLoc(), forOp.getLowerBound(), forOp.getUpperBound(),
+                                             forOp.getStep(), liveInits);
+    newFor->setAttrs(forOp->getAttrs());
+    return newFor;
+}
+
+IRMapping buildPrunedIterArgMapping(scf::ForOp oldForOp, scf::ForOp newForOp, const llvm::DenseSet<unsigned> &deadSet)
+{
+    unsigned numIter = oldForOp.getNumResults();
+    Block *oldBody = oldForOp.getBody();
+    Block *newBody = newForOp.getBody();
+
+    IRMapping mapping;
+    mapping.map(oldBody->getArgument(kForInductionVarArgIndex), newForOp.getInductionVar());
+    unsigned liveArgIdx = 0;
+    for (unsigned iterArgIdx = 0; iterArgIdx < numIter; ++iterArgIdx) {
+        Value oldArg = oldBody->getArgument(iterArgIdx + kForBodyIterArgOffset);
+        if (deadSet.contains(iterArgIdx)) {
+            mapping.map(oldArg, oldForOp.getInitArgs()[iterArgIdx]);
+            continue;
+        }
+        mapping.map(oldArg, newBody->getArgument(liveArgIdx++ + kForBodyIterArgOffset));
+    }
+    return mapping;
+}
+
+void clonePrunedForBody(OpBuilder &builder, scf::ForOp oldForOp, scf::ForOp newForOp, IRMapping &mapping)
+{
+    builder.setInsertionPointToStart(newForOp.getBody());
+    for (auto &op : oldForOp.getBody()->without_terminator()) {
+        builder.clone(op, mapping);
+    }
+}
+
+SmallVector<Value> collectLiveYieldOperands(scf::ForOp forOp, const llvm::DenseSet<unsigned> &deadSet,
+                                            IRMapping &mapping)
+{
+    unsigned numIter = forOp.getNumResults();
+    auto oldYield = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+    SmallVector<Value> liveYield;
+    liveYield.reserve(numIter - deadSet.size());
+    for (unsigned iterArgIdx = 0; iterArgIdx < numIter; ++iterArgIdx) {
+        if (!deadSet.contains(iterArgIdx)) {
+            liveYield.push_back(mapping.lookupOrDefault(oldYield.getOperand(iterArgIdx)));
+        }
+    }
+    return liveYield;
+}
+
+void replaceLiveForResults(scf::ForOp oldForOp, scf::ForOp newForOp, const llvm::DenseSet<unsigned> &deadSet)
+{
+    unsigned numIter = oldForOp.getNumResults();
+    unsigned liveArgIdx = 0;
+    for (unsigned iterArgIdx = 0; iterArgIdx < numIter; ++iterArgIdx) {
+        if (!deadSet.contains(iterArgIdx)) {
+            oldForOp.getResult(iterArgIdx).replaceAllUsesWith(newForOp.getResult(liveArgIdx++));
+        }
+    }
+}
+
+/// Rebuild `forOp` dropping all iter_args that satisfy `isDeadIterArg`.
+/// Only the first `candidateCount` iter_args are considered for pruning.
+/// Returns the pruned ForOp, or `forOp` itself when nothing was pruned.
+FailureOr<scf::ForOp> pruneDeadIterArgs(OpBuilder &builder, scf::ForOp forOp, unsigned candidateCount)
+{
+    unsigned numIter = forOp.getNumResults();
+    if (candidateCount > numIter) {
+        forOp.emitError() << "[" << DEBUG_TYPE << "] candidate iter_arg count " << candidateCount
+                          << " exceeds total iter_arg count " << numIter;
+        return failure();
+    }
+
+    llvm::DenseSet<unsigned> deadSet = collectDeadIterArgs(forOp, candidateCount);
+    if (deadSet.empty()) {
+        return forOp;
+    }
+
+    SmallVector<Value> liveInits = collectLiveIterArgInits(forOp, deadSet);
+    scf::ForOp newFor = createForWithLiveIterArgs(builder, forOp, liveInits);
+    IRMapping mapping = buildPrunedIterArgMapping(forOp, newFor, deadSet);
+
+    clonePrunedForBody(builder, forOp, newFor, mapping);
+    SmallVector<Value> liveYield = collectLiveYieldOperands(forOp, deadSet, mapping);
+    builder.create<scf::YieldOp>(forOp.getBody()->getTerminator()->getLoc(), liveYield);
+
+    replaceLiveForResults(forOp, newFor, deadSet);
+    forOp.erase();
+    return newFor;
+}
+
+/// Erase side-effect-free ops in `body` whose results are entirely unused.
+/// Propagates: erasing an op may expose its operand-defining ops as newly dead.
+/// Only considers ops directly in `body` (not nested regions).
+void eraseDeadBodyOps(Block *body)
+{
+    SmallVector<Operation *> worklist;
+    llvm::SmallDenseSet<Operation *, kInitialRefCapacity> queued;
+    auto enqueueIfDead = [&body, &queued, &worklist](Operation *candidateOp) {
+        if (!candidateOp || candidateOp->getBlock() != body || candidateOp == body->getTerminator()) {
+            return;
+        }
+        if (!queued.insert(candidateOp).second) {
+            return;
+        }
+        worklist.push_back(candidateOp);
+    };
+
+    for (auto &op : *body) {
+        if (&op == body->getTerminator()) {
+            continue;
+        }
+        if (mlir::isMemoryEffectFree(&op) &&
+            llvm::all_of(op.getResults(), [](Value result) { return result.use_empty(); })) {
+            enqueueIfDead(&op);
+        }
+    }
+
+    while (!worklist.empty()) {
+        Operation *currentOp = worklist.pop_back_val();
+        queued.erase(currentOp);
+        if (!mlir::isMemoryEffectFree(currentOp)) {
+            continue;
+        }
+        if (!llvm::all_of(currentOp->getResults(), [](Value result) { return result.use_empty(); })) {
+            continue;
+        }
+
+        SmallVector<Operation *, kInitialRefCapacity> operandDefs;
+        for (Value operand : currentOp->getOperands()) {
+            auto *defOp = operand.getDefiningOp();
+            if (defOp && defOp->getBlock() == body) {
+                operandDefs.push_back(defOp);
+            }
+        }
+        currentOp->erase();
+
+        for (Operation *defOp : operandDefs) {
+            if (mlir::isMemoryEffectFree(defOp) &&
+                llvm::all_of(defOp->getResults(), [](Value result) { return result.use_empty(); })) {
+                enqueueIfDead(defOp);
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Producer address projection helpers
+// ============================================================================
+
+/// Return true if `value` is defined outside `forOp` (i.e. loop-invariant).
+bool isLoopInvariant(Value value, scf::ForOp forOp)
+{
+    if (auto blockArg = dyn_cast<BlockArgument>(value)) {
+        return blockArg.getOwner() != forOp.getBody();
+    }
+    Operation *defOp = value.getDefiningOp();
+    Operation *parent = defOp->getParentOp();
+    while (parent) {
+        if (parent == forOp.getOperation()) {
+            return false;
+        }
+        parent = parent->getParentOp();
+    }
+    return true;
+}
+
+/// If the yield value for iter-arg `iterArg` is of the form
+/// arith.addi(iterArg, delta) where `delta` is loop-invariant,
+/// return true and set `delta`.
+bool getLinearIterArgDelta(Value iterArg, Value yieldVal, scf::ForOp forOp, Value &delta)
+{
+    auto addOp = yieldVal.getDefiningOp<arith::AddIOp>();
+    if (!addOp) {
+        return false;
+    }
+    Value candidate;
+    if (addOp.getLhs() == iterArg) {
+        candidate = addOp.getRhs();
+    } else if (addOp.getRhs() == iterArg) {
+        candidate = addOp.getLhs();
+    } else {
+        return false;
+    }
+    if (!isLoopInvariant(candidate, forOp)) {
+        return false;
+    }
+    delta = candidate;
+    return true;
+}
+
+Value castIndexTo(OpBuilder &builder, Location loc, Value value, Type targetType)
+{
+    if (value.getType() == targetType) {
+        return value;
+    }
+    return builder.create<arith::IndexCastOp>(loc, targetType, value);
+}
+
+Value castToIndex(OpBuilder &builder, Location loc, Value value)
+{
+    if (value.getType().isIndex()) {
+        return value;
+    }
+    return builder.create<arith::IndexCastOp>(loc, builder.getIndexType(), value);
+}
+
+// ============================================================================
+// Block-id tagging helper
+// ============================================================================
+
+/// Set kBlockIdAttr on `value`'s defining op if both the op and the attribute exist.
+void tagWithBlockId(Value value, IntegerAttr blockId)
+{
+    if (blockId) {
+        if (auto *defOp = value.getDefiningOp()) {
+            defOp->setAttr(kBlockIdAttr, blockId);
+        }
+    }
+}
+
+// ============================================================================
+// Core transformation helpers
+// ============================================================================
+
+/// Allocate one memref slot per (depth × load) pair before the loop.
+void allocateBufferSlots(OpBuilder &builder, Location loc, scf::ForOp forOp, LoadGroup &group)
+{
+    builder.setInsertionPoint(forOp);
+    int depth = group.depth;
+    int numLoads = static_cast<int>(group.loads.size());
+    group.bufSlots.resize(depth);
+    for (int slotIdx = 0; slotIdx < depth; ++slotIdx) {
+        group.bufSlots[slotIdx].resize(numLoads);
+        for (int loadIdx = 0; loadIdx < numLoads; ++loadIdx) {
+            auto newAlloc = builder.create<memref::AllocOp>(loc, group.loads[loadIdx].allocOp.getType());
+            newAlloc->setAttrs(group.loads[loadIdx].allocOp.getOperation()->getAttrs());
+            group.bufSlots[slotIdx][loadIdx] = newAlloc;
+        }
+    }
+}
+
+/// Build a new scf.for whose iter_args cover all groups:
+///   [original..., (flags_g[depth], prodCounter_g, consCounter_g) for each g].
+/// Returns metadata including per-group iter_arg handles.
+ExtendedForInfo buildExtendedFor(OpBuilder &builder, Location loc, scf::ForOp forOp, ArrayRef<LoadGroup> groups,
+                                 ConstantCache &cache)
+{
+    builder.setInsertionPoint(forOp);
+    int numOrig = static_cast<int>(forOp.getInitArgs().size());
+    int depth = groups.empty() ? 0 : groups[0].depth;
+
+    Value falseVal = cache.getFalse(builder, loc);
+    Value zeroIndex = cache.getIndex(builder, loc, 0);
+
+    SmallVector<Value> inits;
+    inits.reserve(numOrig + static_cast<int>(groups.size()) * (depth + kLoadGroupCounterIterArgCount));
+    for (Value initArg : forOp.getInitArgs()) {
+        inits.push_back(initArg);
+    }
+    for (auto &group : groups) {
+        for (int slotIdx = 0; slotIdx < group.depth; ++slotIdx) {
+            inits.push_back(falseVal);
+        }
+        inits.push_back(zeroIndex); // prodCounter
+        inits.push_back(zeroIndex); // consCounter
+    }
+
+    auto newFor = builder.create<scf::ForOp>(loc, forOp.getLowerBound(), forOp.getUpperBound(), forOp.getStep(), inits);
+    newFor->setAttrs(forOp->getAttrs());
+    Block *oldBody = forOp.getBody();
+    Block *newBody = newFor.getBody();
+
+    IRMapping mapping;
+    mapping.map(oldBody->getArgument(kForInductionVarArgIndex), newBody->getArgument(kForInductionVarArgIndex));
+    for (int initArgIdx = 0; initArgIdx < numOrig; ++initArgIdx) {
+        mapping.map(oldBody->getArgument(initArgIdx + kForBodyIterArgOffset),
+                    newBody->getArgument(initArgIdx + kForBodyIterArgOffset));
+    }
+
+    if (!newBody->empty()) {
+        newBody->getTerminator()->erase();
+    }
+    builder.setInsertionPointToEnd(newBody);
+
+    SmallVector<GroupIterArgs> groupArgs;
+    int argOffset = numOrig;
+    for (auto &group : groups) {
+        GroupIterArgs groupIterArgs;
+        for (int slotIdx = 0; slotIdx < group.depth; ++slotIdx) {
+            groupIterArgs.flagArgs.push_back(newBody->getArgument(kForBodyIterArgOffset + argOffset + slotIdx));
+        }
+        groupIterArgs.prodCounter =
+            newBody->getArgument(kForBodyIterArgOffset + argOffset + group.depth + kLoadGroupProducerCounterOffset);
+        groupIterArgs.consCounter =
+            newBody->getArgument(kForBodyIterArgOffset + argOffset + group.depth + kLoadGroupConsumerCounterOffset);
+        argOffset += group.depth + kLoadGroupCounterIterArgCount;
+        groupArgs.push_back(std::move(groupIterArgs));
+    }
+
+    return {newFor, oldBody, newBody, std::move(mapping), std::move(groupArgs), falseVal, numOrig, depth};
+}
+
+// ============================================================================
+// Clone availability checks
+// ============================================================================
+
+/// Return true if `value` can be used while cloning into the new body with the
+/// current mapping. Values defined outside the old body still dominate; values
+/// defined in the old body must already have been cloned and mapped.
+bool isAvailableForClone(Value value, Block *oldBody, const IRMapping &mapping)
+{
+    if (auto blockArg = dyn_cast<BlockArgument>(value)) {
+        return blockArg.getOwner() != oldBody || static_cast<bool>(mapping.lookupOrNull(value));
+    }
+
+    Operation *defOp = value.getDefiningOp();
+    if (!defOp || defOp->getBlock() != oldBody) {
+        return true;
+    }
+    return static_cast<bool>(mapping.lookupOrNull(value));
+}
+
+/// Check all direct and region-captured operands before cloning an op out of the
+/// old loop body.
+bool areOperandsAvailableForClone(Operation *op, Block *oldBody, const IRMapping &mapping)
+{
+    for (Value operand : collectOperandsIncludingRegions(op)) {
+        if (!isAvailableForClone(operand, oldBody, mapping)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// ============================================================================
+// Body-run utilities
+// ============================================================================
+
+std::optional<int32_t> getBlockId(Operation *op)
+{
+    if (auto bid = op->getAttrOfType<IntegerAttr>(kBlockIdAttr)) {
+        return static_cast<int32_t>(bid.getInt());
+    }
+    return std::nullopt;
+}
+
+bool sameRunBlockId(const BodyRun &run, std::optional<int32_t> bid)
+{
+    if (run.hasBlockId != bid.has_value()) {
+        return false;
+    }
+    return !run.hasBlockId || run.blockId == *bid;
+}
+
+SmallVector<BodyRun> collectBodyRuns(Block *body)
+{
+    SmallVector<BodyRun> runs;
+    for (auto &op : body->without_terminator()) {
+        std::optional<int32_t> bid = getBlockId(&op);
+        if (runs.empty() || !sameRunBlockId(runs.back(), bid)) {
+            BodyRun run;
+            if (bid) {
+                run.hasBlockId = true;
+                run.blockId = *bid;
+            }
+            runs.push_back(std::move(run));
+        }
+        runs.back().ops.push_back(&op);
+    }
+    return runs;
+}
+
+int findRunContainingOp(ArrayRef<BodyRun> runs, Operation *target)
+{
+    for (size_t runIdx = 0; runIdx < runs.size(); ++runIdx) {
+        for (Operation *op : runs[runIdx].ops) {
+            if (op == target) {
+                return static_cast<int>(runIdx);
+            }
+        }
+    }
+    return -1;
+}
+
+int findFirstRunWithBlockId(ArrayRef<BodyRun> runs, int32_t blockId)
+{
+    for (size_t runIdx = 0; runIdx < runs.size(); ++runIdx) {
+        if (runs[runIdx].hasBlockId && runs[runIdx].blockId == blockId) {
+            return static_cast<int>(runIdx);
+        }
+    }
+    return -1;
+}
+
+void logRepeatedTopLevelBlockRuns(Block *body, llvm::StringRef stage)
+{
+    llvm::DenseSet<int32_t> closed;
+    bool hasCurrent = false;
+    int32_t current = 0;
+
+    for (auto &op : body->without_terminator()) {
+        std::optional<int32_t> bid = getBlockId(&op);
+        if (!bid) {
+            if (hasCurrent) {
+                closed.insert(current);
+            }
+            hasCurrent = false;
+            continue;
+        }
+
+        if (hasCurrent && current == *bid) {
+            continue;
+        }
+
+        if (hasCurrent) {
+            closed.insert(current);
+        }
+
+        if (closed.contains(*bid)) {
+            LOG_DEBUG("non-consecutive top-level ssbuffer.block_id run after " << stage << ": block_id=" << *bid
+                                                                               << "\n");
+        }
+        current = *bid;
+        hasCurrent = true;
+    }
+}
+
+// ============================================================================
+// Core transformation
+// ============================================================================
+
+struct LoopInvariantValues {
+    Value lowerBound;
+    Value step;
+    Value tripCount;
+};
+
+struct GroupInvariantValues {
+    SmallVector<Value> trueFlags;
+    SmallVector<Value> indexOnes;
+    SmallVector<SmallVector<Value>> slotConsts;
+    SmallVector<Value> depthConsts;
+};
+
+void allocateBufferSlotsForGroups(OpBuilder &builder, Location loc, scf::ForOp forOp,
+                                  SmallVectorImpl<LoadGroup> &groups)
+{
+    for (auto &group : groups) {
+        allocateBufferSlots(builder, loc, forOp, group);
+    }
+}
+
+LoopInvariantValues emitLoopInvariantValues(OpBuilder &builder, Location loc, scf::ForOp forOp)
+{
+    IntegerAttr forBlockId = forOp->getAttrOfType<IntegerAttr>(kBlockIdAttr);
+    Value lowerBound = forOp.getLowerBound();
+    Value step = forOp.getStep();
+    Value upperBound = forOp.getUpperBound();
+
+    Value lowerBoundIndex = castToIndex(builder, loc, lowerBound);
+    if (lowerBoundIndex != lowerBound) {
+        tagWithBlockId(lowerBoundIndex, forBlockId);
+    }
+    Value stepIndex = castToIndex(builder, loc, step);
+    if (stepIndex != step) {
+        tagWithBlockId(stepIndex, forBlockId);
+    }
+    Value upperBoundIndex = castToIndex(builder, loc, upperBound);
+    if (upperBoundIndex != upperBound) {
+        tagWithBlockId(upperBoundIndex, forBlockId);
+    }
+
+    Value range = builder.create<arith::SubIOp>(loc, upperBoundIndex, lowerBoundIndex);
+    tagWithBlockId(range, forBlockId);
+    Value tripCount = builder.create<arith::CeilDivUIOp>(loc, range, stepIndex);
+    tagWithBlockId(tripCount, forBlockId);
+    return {lowerBound, step, tripCount};
+}
+
+GroupInvariantValues emitGroupInvariantValues(OpBuilder &builder, Location loc, ArrayRef<LoadGroup> groups)
+{
+    int numGroups = static_cast<int>(groups.size());
+    GroupInvariantValues values;
+    values.trueFlags.resize(numGroups);
+    values.indexOnes.resize(numGroups);
+    values.slotConsts.resize(numGroups);
+    values.depthConsts.resize(numGroups);
+
+    for (int groupIdx = 0; groupIdx < numGroups; ++groupIdx) {
+        const auto &group = groups[groupIdx];
+        IntegerAttr blockId =
+            group.loads.empty() ? IntegerAttr {} : group.loads[0].markedOp->getAttrOfType<IntegerAttr>(kBlockIdAttr);
+        int groupDepth = group.depth;
+        values.trueFlags[groupIdx] = builder.create<arith::ConstantOp>(loc, builder.getBoolAttr(true));
+        tagWithBlockId(values.trueFlags[groupIdx], blockId);
+        values.indexOnes[groupIdx] = builder.create<arith::ConstantIndexOp>(loc, 1);
+        tagWithBlockId(values.indexOnes[groupIdx], blockId);
+
+        values.slotConsts[groupIdx].resize(groupDepth);
+        for (int slot = 0; slot < groupDepth; ++slot) {
+            values.slotConsts[groupIdx][slot] = builder.create<arith::ConstantIndexOp>(loc, slot);
+            tagWithBlockId(values.slotConsts[groupIdx][slot], blockId);
+        }
+
+        values.depthConsts[groupIdx] = builder.create<arith::ConstantIndexOp>(loc, groupDepth);
+        tagWithBlockId(values.depthConsts[groupIdx], blockId);
+    }
+
+    return values;
+}
+
+FailureOr<SmallVector<Value>> collectLinearIterArgDeltas(const ExtendedForInfo &info, scf::ForOp forOp)
+{
+    if (info.numOrig < 0) {
+        forOp.emitError() << "[" << DEBUG_TYPE << "] original iter_arg count is negative: " << info.numOrig;
+        return failure();
+    }
+    auto numOrig = static_cast<unsigned>(info.numOrig);
+    if (info.oldBody->getNumArguments() < numOrig + kForBodyIterArgOffset) {
+        forOp.emitError() << "[" << DEBUG_TYPE << "] old loop body has " << info.oldBody->getNumArguments()
+                          << " arguments, expected at least " << (numOrig + kForBodyIterArgOffset);
+        return failure();
+    }
+
+    auto oldYieldOp = cast<scf::YieldOp>(info.oldBody->getTerminator());
+    if (oldYieldOp->getNumOperands() < numOrig) {
+        forOp.emitError() << "[" << DEBUG_TYPE << "] old loop yield has " << oldYieldOp->getNumOperands()
+                          << " operands, expected at least " << numOrig;
+        return failure();
+    }
+
+    SmallVector<Value> iterArgDeltas(info.numOrig, Value {});
+    for (unsigned iterArgIdx = 0; iterArgIdx < numOrig; ++iterArgIdx) {
+        Value delta;
+        if (getLinearIterArgDelta(info.oldBody->getArgument(iterArgIdx + kForBodyIterArgOffset),
+                                  oldYieldOp->getOperand(iterArgIdx), forOp, delta)) {
+            iterArgDeltas[iterArgIdx] = delta;
+        }
+    }
+    return iterArgDeltas;
+}
+
+LogicalResult replaceOriginalForResults(scf::ForOp oldForOp, scf::ForOp newForOp, int numOrig)
+{
+    if (numOrig < 0) {
+        oldForOp.emitError() << "[" << DEBUG_TYPE << "] original result count is negative: " << numOrig;
+        return failure();
+    }
+
+    auto numOrigResults = static_cast<unsigned>(numOrig);
+    if (oldForOp.getNumResults() < numOrigResults || newForOp.getNumResults() < numOrigResults) {
+        oldForOp.emitError() << "[" << DEBUG_TYPE << "] cannot replace " << numOrigResults
+                             << " loop results; old loop has " << oldForOp.getNumResults() << ", new loop has "
+                             << newForOp.getNumResults();
+        return failure();
+    }
+
+    for (unsigned resultIdx = 0; resultIdx < numOrigResults; ++resultIdx) {
+        oldForOp.getResult(resultIdx).replaceAllUsesWith(newForOp.getResult(resultIdx));
+    }
+    return success();
+}
+
+LogicalResult finalizeMultiBufferLoop(OpBuilder &builder, scf::ForOp newForOp, int numOrig)
+{
+    if (numOrig < 0) {
+        newForOp.emitError() << "[" << DEBUG_TYPE << "] original iter_arg count is negative: " << numOrig;
+        return failure();
+    }
+
+    FailureOr<scf::ForOp> finalFor = pruneDeadIterArgs(builder, newForOp, static_cast<unsigned>(numOrig));
+    if (failed(finalFor)) {
+        return failure();
+    }
+
+    eraseDeadBodyOps(finalFor->getBody());
+
+    // Debug-only diagnostic: keep this as a log instead of asserting so the
+    // pass can still dump the transformed IR for investigation.
+    logRepeatedTopLevelBlockRuns(finalFor->getBody(), kGMLoadMultiBufferStage);
+    return success();
+}
+
+/// Apply GM-load multi-buffer rewriting to one scf.for.
+/// allCtxForOps carries the set of all forOps being transformed so that inner
+/// forOps (already handled) are not cloned again into the consumer body.
+LogicalResult applyMultiBufferToForLoop(ForBufferCtx &context, const llvm::DenseSet<Operation *> &allCtxForOps)
+{
+    scf::ForOp forOp = context.forOp;
+    Location loc = forOp.getLoc();
+    OpBuilder builder(forOp);
+
+    allocateBufferSlotsForGroups(builder, loc, forOp, context.groups);
+
+    // Scan parent block once so buildExtendedFor can reuse existing constants.
+    ConstantCache cache;
+    cache.scan(forOp->getBlock());
+
+    builder.setInsertionPoint(forOp);
+    LoopInvariantValues loopValues = emitLoopInvariantValues(builder, loc, forOp);
+    GroupInvariantValues groupValues = emitGroupInvariantValues(builder, loc, context.groups);
+
+    auto info = buildExtendedFor(builder, loc, forOp, context.groups, cache);
+    FailureOr<SmallVector<Value>> iterArgDeltas = collectLinearIterArgDeltas(info, forOp);
+    if (failed(iterArgDeltas)) {
+        return failure();
+    }
+
+    LogicalResult emitBodyStatus = emitMultiBufferLoopBody(
+        builder, loc, context.groups, info, groupValues.indexOnes, groupValues.slotConsts, groupValues.depthConsts,
+        allCtxForOps, loopValues.tripCount, loopValues.lowerBound, loopValues.step, groupValues.trueFlags,
+        *iterArgDeltas, forOp);
+    if (failed(emitBodyStatus)) {
+        return failure();
+    }
+
+    if (failed(replaceOriginalForResults(forOp, info.newForOp, info.numOrig))) {
+        return failure();
+    }
+    if (failed(finalizeMultiBufferLoop(builder, info.newForOp, info.numOrig))) {
+        return failure();
+    }
+    return success();
+}
+
+// ============================================================================
+// Cleanup utilities
+// ============================================================================
+
+bool isAncestorBlock(Block *ancestor, Block *descendant)
+{
+    for (Block *currentBlock = descendant; currentBlock;) {
+        if (currentBlock == ancestor) {
+            return true;
+        }
+        auto *parentOp = currentBlock->getParentOp();
+        if (!parentOp) {
+            break;
+        }
+        currentBlock = parentOp->getBlock();
+    }
+    return false;
+}
+
+void deduplicateConstants(ModuleOp module)
+{
+    llvm::DenseMap<mlir::Attribute, Value> canonical;
+    SmallVector<Operation *> toErase;
+
+    module->walk<mlir::WalkOrder::PreOrder>([&](arith::ConstantOp cst) {
+        if (cst->hasAttr(kBlockIdAttr)) {
+            return mlir::WalkResult::advance();
+        }
+        auto [canonicalIt, inserted] = canonical.try_emplace(cst.getValue(), cst.getResult());
+        if (!inserted && canonicalIt->second != cst.getResult()) {
+            Block *canonBlock = canonicalIt->second.getParentBlock();
+            Block *thisBlock = cst->getBlock();
+            if (canonBlock == thisBlock || isAncestorBlock(canonBlock, thisBlock)) {
+                cst.getResult().replaceAllUsesWith(canonicalIt->second);
+                toErase.push_back(cst);
+            }
+        }
+        return mlir::WalkResult::advance();
+    });
+
+    for (Operation *op : llvm::reverse(toErase)) {
+        op->erase();
+    }
+}
+
+} // namespace gmload

--- a/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/MultiBufferLoopBodyEmission.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/MultiBufferLoopBodyEmission.cpp
@@ -1,0 +1,792 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoadInternal.h"
+
+namespace gmload {
+
+// ============================================================================
+// Producer emission helpers
+// ============================================================================
+
+static bool canSkipBecauseAllResultsMapped(Operation *op, const IRMapping &mapping)
+{
+    if (op->getNumResults() == 0) {
+        return false;
+    }
+    return llvm::all_of(op->getResults(),
+                        [&](Value result) { return static_cast<bool>(mapping.lookupOrNull(result)); });
+}
+
+static LogicalResult materializeProducerOp(OpBuilder &builder, Operation *op, Block *oldBody,
+                                           const llvm::DenseSet<Operation *> &producerSourceOps, IRMapping &mapping,
+                                           llvm::DenseSet<Operation *> &materializedOps,
+                                           llvm::DenseSet<Operation *> &activeOps);
+
+static LogicalResult materializeProducerValue(OpBuilder &builder, Value value, Block *oldBody,
+                                              const llvm::DenseSet<Operation *> &producerSourceOps, IRMapping &mapping,
+                                              llvm::DenseSet<Operation *> &materializedOps,
+                                              llvm::DenseSet<Operation *> &activeOps)
+{
+    if (mapping.lookupOrNull(value)) {
+        return success();
+    }
+
+    if (auto blockArg = dyn_cast<BlockArgument>(value)) {
+        if (blockArg.getOwner() == oldBody) {
+            return failure();
+        }
+        return success();
+    }
+
+    Operation *defOp = value.getDefiningOp();
+    if (!defOp) {
+        return success();
+    }
+
+    if (producerSourceOps.contains(defOp) || defOp->getBlock() == oldBody) {
+        return materializeProducerOp(builder, defOp, oldBody, producerSourceOps, mapping, materializedOps, activeOps);
+    }
+
+    return success();
+}
+
+static LogicalResult materializeProducerOp(OpBuilder &builder, Operation *op, Block *oldBody,
+                                           const llvm::DenseSet<Operation *> &producerSourceOps, IRMapping &mapping,
+                                           llvm::DenseSet<Operation *> &materializedOps,
+                                           llvm::DenseSet<Operation *> &activeOps)
+{
+    if (materializedOps.contains(op) || canSkipBecauseAllResultsMapped(op, mapping)) {
+        return success();
+    }
+
+    if (activeOps.contains(op)) {
+        return failure();
+    }
+
+    if (!producerSourceOps.contains(op) && op->getBlock() == oldBody) {
+        if (!mlir::isMemoryEffectFree(op) || op->getNumRegions() != 0) {
+            return failure();
+        }
+    }
+
+    activeOps.insert(op);
+    for (Value operand : collectOperandsIncludingRegions(op)) {
+        LogicalResult materializeStatus = materializeProducerValue(
+            builder, operand, oldBody, producerSourceOps, mapping, materializedOps, activeOps);
+        if (failed(materializeStatus)) {
+            activeOps.erase(op);
+            return failure();
+        }
+    }
+    activeOps.erase(op);
+
+    builder.clone(*op, mapping);
+    materializedOps.insert(op);
+    return success();
+}
+
+static IntegerAttr getGroupBlockId(const LoadGroup &group)
+{
+    return group.loads.empty() ? IntegerAttr {} : group.loads[0].markedOp->getAttrOfType<IntegerAttr>(kBlockIdAttr);
+}
+
+static Value createProducerFillCondition(OpBuilder &builder, Location loc, Value flagArg, Value currentProducerCounter,
+                                         Value tripCount, Value falseVal, IntegerAttr blockId)
+{
+    Value flagEmpty = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, flagArg, falseVal);
+    tagWithBlockId(flagEmpty, blockId);
+    Value prodLtTripCount =
+        builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ult, currentProducerCounter, tripCount);
+    tagWithBlockId(prodLtTripCount, blockId);
+    Value cond = builder.create<arith::AndIOp>(loc, flagEmpty, prodLtTripCount);
+    tagWithBlockId(cond, blockId);
+    return cond;
+}
+
+static scf::IfOp createProducerFillIf(OpBuilder &builder, Location loc, Value cond, IntegerAttr blockId)
+{
+    auto ifOp = builder.create<scf::IfOp>(loc, TypeRange {builder.getI1Type(), builder.getIndexType()}, cond, true);
+    if (blockId)
+        ifOp->setAttr(kBlockIdAttr, blockId);
+    ifOp->setAttr(kLoadStoreAttr, builder.getUnitAttr());
+    return ifOp;
+}
+
+struct ProducerLoopPosition {
+    Type inductionVarType;
+    Value projectedInductionVar;
+    Value producerCounterInInductionType;
+};
+
+static ProducerLoopPosition mapProducerLoopPosition(OpBuilder &builder, Location loc, Block *oldBody,
+                                                    Value loopLowerBound, Value loopStep, Value currentProducerCounter,
+                                                    IntegerAttr blockId, IRMapping &prodMapping)
+{
+    Value oldInductionVar = oldBody->getArgument(kForInductionVarArgIndex);
+    Type inductionVarType = oldInductionVar.getType();
+
+    Value lowerBound = castIndexTo(builder, loc, loopLowerBound, inductionVarType);
+    if (lowerBound != loopLowerBound)
+        tagWithBlockId(lowerBound, blockId);
+    Value step = castIndexTo(builder, loc, loopStep, inductionVarType);
+    if (step != loopStep)
+        tagWithBlockId(step, blockId);
+    Value producerCounterInInductionType = castIndexTo(builder, loc, currentProducerCounter, inductionVarType);
+    tagWithBlockId(producerCounterInInductionType, blockId);
+    Value inductionOffset = builder.create<arith::MulIOp>(loc, producerCounterInInductionType, step);
+    tagWithBlockId(inductionOffset, blockId);
+    Value projectedInductionVar = builder.create<arith::AddIOp>(loc, lowerBound, inductionOffset);
+    tagWithBlockId(projectedInductionVar, blockId);
+    prodMapping.map(oldInductionVar, projectedInductionVar);
+
+    return {inductionVarType, projectedInductionVar, producerCounterInInductionType};
+}
+
+static LogicalResult validateProducerIterArgInputs(scf::ForOp origForOp, Block *oldBody, Block *newBody,
+                                                   ArrayRef<Value> iterArgDeltas)
+{
+    int numOrig = static_cast<int>(origForOp.getInitArgs().size());
+    if (numOrig < 0) {
+        origForOp.emitError() << "[" << DEBUG_TYPE << "] original iter_arg count is negative: " << numOrig;
+        return failure();
+    }
+
+    auto numOrigArgs = static_cast<unsigned>(numOrig);
+    if (iterArgDeltas.size() < numOrigArgs) {
+        origForOp.emitError() << "[" << DEBUG_TYPE << "] iter_arg delta count " << iterArgDeltas.size()
+                              << " is smaller than original iter_arg count " << numOrigArgs;
+        return failure();
+    }
+    if (oldBody->getNumArguments() < numOrigArgs + kForBodyIterArgOffset ||
+        newBody->getNumArguments() < numOrigArgs + kForBodyIterArgOffset) {
+        origForOp.emitError() << "[" << DEBUG_TYPE << "] loop body argument count is smaller than expected "
+                              << (numOrigArgs + kForBodyIterArgOffset);
+        return failure();
+    }
+    return success();
+}
+
+static LogicalResult mapProducerIterArgs(OpBuilder &builder, Location loc, Block *oldBody, Block *newBody,
+                                         scf::ForOp origForOp, Value loopLowerBound, Value loopStep,
+                                         Value currentProducerCounter, const SmallVector<Value> &iterArgDeltas,
+                                         const ProducerLoopPosition &position, IntegerAttr blockId,
+                                         IRMapping &prodMapping)
+{
+    if (failed(validateProducerIterArgInputs(origForOp, oldBody, newBody, iterArgDeltas))) {
+        return failure();
+    }
+
+    // producerCounterInInductionType is already cast to inductionVarType; cache casts by type to avoid
+    // redundant index_cast ops when multiple iter_args share the same type.
+    llvm::DenseMap<Type, Value> producerCounterByType;
+    producerCounterByType[position.inductionVarType] = position.producerCounterInInductionType;
+
+    int numOrig = static_cast<int>(origForOp.getInitArgs().size());
+    for (int iterArgIdx = 0; iterArgIdx < numOrig; ++iterArgIdx) {
+        Value oldArg = oldBody->getArgument(iterArgIdx + kForBodyIterArgOffset);
+        Value delta = iterArgDeltas[iterArgIdx];
+        if (!delta) {
+            prodMapping.map(oldArg, newBody->getArgument(iterArgIdx + kForBodyIterArgOffset));
+            continue;
+        }
+
+        Type argType = oldArg.getType();
+        Value initArg = origForOp.getInitArgs()[iterArgIdx];
+        // If initArg == lower bound and delta == step this iter_arg tracks the
+        // induction variable exactly; reuse the projected IV.
+        if (initArg == loopLowerBound && delta == loopStep && argType == position.inductionVarType) {
+            prodMapping.map(oldArg, position.projectedInductionVar);
+            continue;
+        }
+
+        auto [counterIt, inserted] = producerCounterByType.try_emplace(argType, Value {});
+        if (inserted) {
+            counterIt->second = castIndexTo(builder, loc, currentProducerCounter, argType);
+            tagWithBlockId(counterIt->second, blockId);
+        }
+        Value argMul = builder.create<arith::MulIOp>(loc, counterIt->second, delta);
+        tagWithBlockId(argMul, blockId);
+        Value argAdd = builder.create<arith::AddIOp>(loc, initArg, argMul);
+        tagWithBlockId(argAdd, blockId);
+        prodMapping.map(oldArg, argAdd);
+    }
+    return success();
+}
+
+static void mapProducerSlotBuffers(const LoadGroup &group, int slotIdx, IRMapping &prodMapping)
+{
+    for (int loadIdx = 0; loadIdx < static_cast<int>(group.loads.size()); ++loadIdx)
+        prodMapping.map(group.loads[loadIdx].allocOp->getResult(0), group.bufSlots[slotIdx][loadIdx]);
+}
+
+static LogicalResult materializeProducerChain(OpBuilder &builder, Block *oldBody, const LoadGroup &group,
+                                              IRMapping &prodMapping)
+{
+    llvm::DenseSet<Operation *> skipSet;
+    for (const MarkedLoad &load : group.loads) {
+        skipSet.insert(load.allocOp);
+        skipSet.insert(load.markedOp);
+    }
+
+    llvm::DenseSet<Operation *> producerSourceOps(group.mergedChain.begin(), group.mergedChain.end());
+    llvm::DenseSet<Operation *> materializedOps;
+    llvm::DenseSet<Operation *> activeOps;
+    for (Operation *op : group.mergedChain) {
+        if (skipSet.contains(op)) {
+            continue;
+        }
+        if (failed(materializeProducerOp(builder, op, oldBody, producerSourceOps, prodMapping, materializedOps,
+                                         activeOps)))
+            return failure();
+    }
+    return success();
+}
+
+static LogicalResult emitProducerFillThenBlock(OpBuilder &builder, Location loc, scf::IfOp ifOp, Block *oldBody,
+                                               Block *newBody, const LoadGroup &group, int slotIdx,
+                                               Value currentProducerCounter, Value loopLowerBound, Value loopStep,
+                                               Value trueFlag, Value indexOne, const SmallVector<Value> &iterArgDeltas,
+                                               scf::ForOp origForOp, IntegerAttr blockId)
+{
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToStart(ifOp.thenBlock());
+
+    IRMapping prodMapping;
+    ProducerLoopPosition position = mapProducerLoopPosition(builder, loc, oldBody, loopLowerBound, loopStep,
+                                                            currentProducerCounter, blockId, prodMapping);
+    LogicalResult mapIterArgStatus = mapProducerIterArgs(
+        builder, loc, oldBody, newBody, origForOp, loopLowerBound, loopStep, currentProducerCounter, iterArgDeltas,
+        position, blockId, prodMapping);
+    if (failed(mapIterArgStatus)) {
+        return failure();
+    }
+    mapProducerSlotBuffers(group, slotIdx, prodMapping);
+    if (failed(materializeProducerChain(builder, oldBody, group, prodMapping))) {
+        return failure();
+    }
+
+    Value prodNext = builder.create<arith::AddIOp>(loc, currentProducerCounter, indexOne);
+    tagWithBlockId(prodNext, blockId);
+    builder.create<scf::YieldOp>(loc, ValueRange {trueFlag, prodNext});
+    return success();
+}
+
+static void emitProducerFillElseBlock(OpBuilder &builder, Location loc, scf::IfOp ifOp, Value flagArg,
+                                      Value currentProducerCounter)
+{
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToStart(ifOp.elseBlock());
+    builder.create<scf::YieldOp>(loc, ValueRange {flagArg, currentProducerCounter});
+}
+
+/// Emit the producer scf.if for one buffer slot.  Returns {flagNext, prodCounterNext}.
+FailureOr<std::pair<Value, Value>> emitProducerFillForSlot(OpBuilder &builder, Location loc, Block *oldBody,
+                                                           Block *newBody, const LoadGroup &group, int slotIdx,
+                                                           Value flagArg, Value currentProducerCounter,
+                                                           Value tripCount, Value falseVal, Value loopLowerBound,
+                                                           Value loopStep, Value trueFlag, Value indexOne,
+                                                           const SmallVector<Value> &iterArgDeltas,
+                                                           scf::ForOp origForOp)
+{
+    IntegerAttr blockId = getGroupBlockId(group);
+    Value cond =
+        createProducerFillCondition(builder, loc, flagArg, currentProducerCounter, tripCount, falseVal, blockId);
+    scf::IfOp ifOp = createProducerFillIf(builder, loc, cond, blockId);
+    LogicalResult thenStatus = emitProducerFillThenBlock(
+        builder, loc, ifOp, oldBody, newBody, group, slotIdx, currentProducerCounter, loopLowerBound, loopStep,
+        trueFlag, indexOne, iterArgDeltas, origForOp, blockId);
+    if (failed(thenStatus)) {
+        return failure();
+    }
+    emitProducerFillElseBlock(builder, loc, ifOp, flagArg, currentProducerCounter);
+
+    return std::make_pair(ifOp.getResult(0), ifOp.getResult(1));
+}
+
+// ============================================================================
+// Consumer emission helpers
+// ============================================================================
+
+/// Emit slot-selection for one load: one ToTensorOp per slot, followed by a
+/// (depth-1)-level comparison/select chain that picks the slot matching
+/// `target`.  Sets mapping[markedOp->result] = selected value.
+Value emitLoadSlotSelection(OpBuilder &builder, Location loc, const MarkedLoad &load, ArrayRef<Value> slotBufs,
+                            Value target, int depth, IRMapping &mapping, ArrayRef<Value> slotConsts)
+{
+    IntegerAttr blockId = load.markedOp->getAttrOfType<IntegerAttr>(kBlockIdAttr);
+    Type tensorTy = load.markedOp->getResult(0).getType();
+
+    SmallVector<Value> slotVals(depth);
+    for (int slotIdx = 0; slotIdx < depth; ++slotIdx) {
+        auto toTensor = builder.create<bufferization::ToTensorOp>(loc, tensorTy, slotBufs[slotIdx], true, true);
+        if (blockId)
+            toTensor->setAttr(kBlockIdAttr, blockId);
+        slotVals[slotIdx] = toTensor;
+    }
+
+    Value result = slotVals[depth - 1];
+    for (int slotIdx = depth - 2; slotIdx >= 0; --slotIdx) {
+        Value eq = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, target, slotConsts[slotIdx]);
+        tagWithBlockId(eq, blockId);
+        result = builder.create<arith::SelectOp>(loc, eq, slotVals[slotIdx], result);
+        tagWithBlockId(result, blockId);
+    }
+
+    mapping.map(load.markedOp->getResult(0), result);
+    return result;
+}
+
+/// Emit the scf.if that clears slot `slotIdx`'s flag when it is the consumed
+/// slot (`target == slotIdx`).  Returns the updated flag value.
+Value emitSlotFlagClear(OpBuilder &builder, Location loc, Value target, Value slotConst, Value flagNext, Value falseVal,
+                        IntegerAttr blockId)
+{
+    Value isConsumed = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, target, slotConst);
+    tagWithBlockId(isConsumed, blockId);
+
+    auto ifClear = builder.create<scf::IfOp>(loc, TypeRange {builder.getI1Type()}, isConsumed, true);
+    if (blockId)
+        ifClear->setAttr(kBlockIdAttr, blockId);
+    ifClear->setAttr(kLoadStoreAttr, builder.getUnitAttr());
+    {
+        OpBuilder::InsertionGuard guard(builder);
+        builder.setInsertionPointToStart(ifClear.thenBlock());
+        builder.create<scf::YieldOp>(loc, ValueRange {falseVal});
+    }
+    {
+        OpBuilder::InsertionGuard guard(builder);
+        builder.setInsertionPointToStart(ifClear.elseBlock());
+        builder.create<scf::YieldOp>(loc, ValueRange {flagNext});
+    }
+    return ifClear.getResult(0);
+}
+
+// ============================================================================
+
+namespace {
+
+struct MultiBufferLoopBodyState {
+    SmallVector<SmallVector<Value>> flagFinals;
+    SmallVector<Value> consCounterNexts;
+    SmallVector<Value> prodCounterFinals;
+    SmallVector<SmallVector<Value>> flagNexts;
+    SmallVector<Value> targets;
+    SmallVector<char> prefixEmitted;
+    SmallVector<char> finalEmitted;
+
+    explicit MultiBufferLoopBodyState(int numGroups)
+        : flagFinals(numGroups), consCounterNexts(numGroups), prodCounterFinals(numGroups), flagNexts(numGroups),
+          targets(numGroups), prefixEmitted(numGroups, 0), finalEmitted(numGroups, 0)
+    {
+    }
+};
+
+static void computeConsumerCloneSets(ArrayRef<LoadGroup> groups, Block *oldBody,
+                                     llvm::DenseSet<Operation *> &allChainOps,
+                                     llvm::DenseSet<Operation *> &retainedChainOpSet)
+{
+    // A retained chain op is a chain op that must still be cloned into the
+    // consumer body because non-chain body code uses it.  Retained ops are
+    // emitted in their original top-level run, not in the load group that
+    // discovered them.
+    for (const LoadGroup &group : groups) {
+        llvm::DenseSet<Operation *> skipSet = computeSkipInConsumer(group.loads, oldBody);
+        for (Operation *op : group.mergedChain) {
+            allChainOps.insert(op);
+            if (!skipSet.contains(op))
+                retainedChainOpSet.insert(op);
+        }
+    }
+}
+
+static bool shouldSkipOldBodyOp(Operation *op, const llvm::DenseSet<Operation *> &allCtxForOps,
+                                const llvm::DenseSet<Operation *> &allChainOps,
+                                const llvm::DenseSet<Operation *> &retainedChainOpSet)
+{
+    if (allCtxForOps.contains(op)) {
+        return true;
+    }
+    return allChainOps.contains(op) && !retainedChainOpSet.contains(op);
+}
+
+struct ProducerFillState {
+    SmallVector<Value> flagNexts;
+    Value producerCounter;
+};
+
+static FailureOr<ProducerFillState> emitProducerFillsForGroup(
+    OpBuilder &builder, Location loc, LoadGroup &group, int groupIdx, ExtendedForInfo &info, Block *oldBody,
+    Value tripCount, Value loopLowerBound, Value loopStep, const SmallVector<Value> &groupTrueFlagVals,
+    const SmallVector<Value> &groupIndexOneVals, const SmallVector<Value> &iterArgDeltas, scf::ForOp origForOp)
+{
+    int groupDepth = group.depth;
+    Value currentProducerCounter = info.groupArgs[groupIdx].prodCounter;
+    SmallVector<Value> flagNexts(groupDepth);
+    for (int slotIdx = 0; slotIdx < groupDepth; ++slotIdx) {
+        FailureOr<std::pair<Value, Value>> producerResult = emitProducerFillForSlot(
+            builder, loc, oldBody, info.newBody, group, slotIdx, info.groupArgs[groupIdx].flagArgs[slotIdx],
+            currentProducerCounter, tripCount, info.falseVal, loopLowerBound, loopStep, groupTrueFlagVals[groupIdx],
+            groupIndexOneVals[groupIdx], iterArgDeltas, origForOp);
+        if (failed(producerResult)) {
+            return failure();
+        }
+
+        auto [flagNext, prodCounterNext] = *producerResult;
+        flagNexts[slotIdx] = flagNext;
+        currentProducerCounter = prodCounterNext;
+    }
+
+    return ProducerFillState {std::move(flagNexts), currentProducerCounter};
+}
+
+static Value emitConsumerSlotTarget(OpBuilder &builder, Location loc, ExtendedForInfo &info, int groupIdx,
+                                    Value groupDepthConst, IntegerAttr blockId)
+{
+    Value target = builder.create<arith::RemUIOp>(loc, info.groupArgs[groupIdx].consCounter, groupDepthConst);
+    tagWithBlockId(target, blockId);
+    return target;
+}
+
+static void emitLoadSlotSelectionsForGroup(OpBuilder &builder, Location loc, LoadGroup &group, int groupIdx,
+                                           int groupDepth, Value target, ExtendedForInfo &info,
+                                           const SmallVector<SmallVector<Value>> &allGroupSlotConsts)
+{
+    for (int loadIdx = 0; loadIdx < static_cast<int>(group.loads.size()); ++loadIdx) {
+        SmallVector<Value> slotBufs(groupDepth);
+        for (int slotIdx = 0; slotIdx < groupDepth; ++slotIdx)
+            slotBufs[slotIdx] = group.bufSlots[slotIdx][loadIdx];
+        emitLoadSlotSelection(builder, loc, group.loads[loadIdx], slotBufs, target, groupDepth, info.mapping,
+                              allGroupSlotConsts[groupIdx]);
+    }
+}
+
+static LogicalResult validateGroupEmissionInputs(ArrayRef<LoadGroup> groups, ExtendedForInfo &info, int groupIdx,
+                                                 ArrayRef<Value> groupTrueFlagVals, ArrayRef<Value> groupIndexOneVals,
+                                                 ArrayRef<Value> allGroupDepthConsts,
+                                                 ArrayRef<SmallVector<Value>> allGroupSlotConsts, scf::ForOp origForOp)
+{
+    if (groupIdx < 0 || static_cast<size_t>(groupIdx) >= groups.size() ||
+        static_cast<size_t>(groupIdx) >= info.groupArgs.size() ||
+        static_cast<size_t>(groupIdx) >= groupTrueFlagVals.size() ||
+        static_cast<size_t>(groupIdx) >= groupIndexOneVals.size() ||
+        static_cast<size_t>(groupIdx) >= allGroupDepthConsts.size() ||
+        static_cast<size_t>(groupIdx) >= allGroupSlotConsts.size()) {
+        origForOp.emitError() << "[" << DEBUG_TYPE << "] load group index " << groupIdx
+                              << " is out of range for multi-buffer emission";
+        return failure();
+    }
+    return success();
+}
+
+static LogicalResult emitProducerAndSelectSlots(
+    OpBuilder &builder, Location loc, SmallVectorImpl<LoadGroup> &groups, int groupIdx, ExtendedForInfo &info,
+    Block *oldBody, Value tripCount, Value loopLowerBound, Value loopStep,
+    const SmallVector<Value> &groupTrueFlagVals, const SmallVector<Value> &groupIndexOneVals,
+    const SmallVector<Value> &iterArgDeltas, scf::ForOp origForOp, const SmallVector<Value> &allGroupDepthConsts,
+    const SmallVector<SmallVector<Value>> &allGroupSlotConsts, MultiBufferLoopBodyState &state)
+{
+    LogicalResult validateStatus = validateGroupEmissionInputs(
+        groups, info, groupIdx, groupTrueFlagVals, groupIndexOneVals, allGroupDepthConsts, allGroupSlotConsts,
+        origForOp);
+    if (failed(validateStatus)) {
+        return failure();
+    }
+    if (static_cast<size_t>(groupIdx) >= state.prefixEmitted.size()) {
+        origForOp.emitError() << "[" << DEBUG_TYPE << "] load group index " << groupIdx
+                              << " exceeds multi-buffer state size " << state.prefixEmitted.size();
+        return failure();
+    }
+    if (state.prefixEmitted[groupIdx]) {
+        return success();
+    }
+
+    LoadGroup &group = groups[groupIdx];
+    int groupDepth = group.depth;
+    IntegerAttr blockId = getGroupBlockId(group);
+
+    FailureOr<ProducerFillState> fillState =
+        emitProducerFillsForGroup(builder, loc, group, groupIdx, info, oldBody, tripCount, loopLowerBound, loopStep,
+                                  groupTrueFlagVals, groupIndexOneVals, iterArgDeltas, origForOp);
+    if (failed(fillState)) {
+        return failure();
+    }
+
+    state.flagNexts[groupIdx] = std::move(fillState->flagNexts);
+    state.prodCounterFinals[groupIdx] = fillState->producerCounter;
+    Value target = emitConsumerSlotTarget(builder, loc, info, groupIdx, allGroupDepthConsts[groupIdx], blockId);
+    state.targets[groupIdx] = target;
+    emitLoadSlotSelectionsForGroup(builder, loc, group, groupIdx, groupDepth, target, info, allGroupSlotConsts);
+
+    state.prefixEmitted[groupIdx] = 1;
+    return success();
+}
+
+static LogicalResult emitConsumerReleaseForGroup(OpBuilder &builder, Location loc, SmallVectorImpl<LoadGroup> &groups,
+                                                 int groupIdx, ExtendedForInfo &info,
+                                                 const SmallVector<Value> &groupIndexOneVals,
+                                                 const SmallVector<SmallVector<Value>> &allGroupSlotConsts,
+                                                 MultiBufferLoopBodyState &state)
+{
+    if (state.finalEmitted[groupIdx]) {
+        return success();
+    }
+
+    LoadGroup &group = groups[groupIdx];
+    int groupDepth = group.depth;
+    IntegerAttr blockId = getGroupBlockId(group);
+
+    state.flagFinals[groupIdx].resize(groupDepth);
+    for (int slotIdx = 0; slotIdx < groupDepth; ++slotIdx) {
+        state.flagFinals[groupIdx][slotIdx] =
+            emitSlotFlagClear(builder, loc, state.targets[groupIdx], allGroupSlotConsts[groupIdx][slotIdx],
+                              state.flagNexts[groupIdx][slotIdx], info.falseVal, blockId);
+    }
+
+    state.consCounterNexts[groupIdx] =
+        builder.create<arith::AddIOp>(loc, info.groupArgs[groupIdx].consCounter, groupIndexOneVals[groupIdx]);
+    tagWithBlockId(state.consCounterNexts[groupIdx], blockId);
+    state.finalEmitted[groupIdx] = 1;
+    return success();
+}
+
+static LogicalResult emitConsumerReleaseAfterPrefix(
+    OpBuilder &builder, Location loc, SmallVectorImpl<LoadGroup> &groups, int groupIdx, ExtendedForInfo &info,
+    Block *oldBody, Value tripCount, Value loopLowerBound, Value loopStep, const SmallVector<Value> &groupTrueFlagVals,
+    const SmallVector<Value> &groupIndexOneVals, const SmallVector<Value> &iterArgDeltas, scf::ForOp origForOp,
+    const SmallVector<Value> &allGroupDepthConsts, const SmallVector<SmallVector<Value>> &allGroupSlotConsts,
+    MultiBufferLoopBodyState &state)
+{
+    if (!state.prefixEmitted[groupIdx]) {
+        LogicalResult producerStatus = emitProducerAndSelectSlots(
+            builder, loc, groups, groupIdx, info, oldBody, tripCount, loopLowerBound, loopStep, groupTrueFlagVals,
+            groupIndexOneVals, iterArgDeltas, origForOp, allGroupDepthConsts, allGroupSlotConsts, state);
+        if (failed(producerStatus)) {
+            return failure();
+        }
+    }
+
+    return emitConsumerReleaseForGroup(builder, loc, groups, groupIdx, info, groupIndexOneVals, allGroupSlotConsts,
+                                       state);
+}
+
+static LogicalResult collectGroupsByOwnerOp(ArrayRef<LoadGroup> groups, Block *oldBody,
+                                            llvm::DenseMap<Operation *, SmallVector<int>> &groupsByOwnerOp)
+{
+    for (int groupIdx = 0; groupIdx < static_cast<int>(groups.size()); ++groupIdx) {
+        if (groups[groupIdx].loads.empty()) {
+            continue;
+        }
+
+        Operation *owner = getAncestorInBlock(groups[groupIdx].loads[0].markedOp, oldBody);
+        if (!owner) {
+            return failure();
+        }
+        groupsByOwnerOp[owner].push_back(groupIdx);
+    }
+    return success();
+}
+
+static LogicalResult emitProducerHooksForOwnerGroups(
+    OpBuilder &builder, Location loc, ArrayRef<int> ownerGroups, SmallVectorImpl<LoadGroup> &groups,
+    ExtendedForInfo &info, Block *oldBody, Value tripCount, Value loopLowerBound, Value loopStep,
+    const SmallVector<Value> &groupTrueFlagVals, const SmallVector<Value> &groupIndexOneVals,
+    const SmallVector<Value> &iterArgDeltas, scf::ForOp origForOp, const SmallVector<Value> &allGroupDepthConsts,
+    const SmallVector<SmallVector<Value>> &allGroupSlotConsts, MultiBufferLoopBodyState &state)
+{
+    for (int groupIdx : ownerGroups) {
+        LogicalResult producerStatus = emitProducerAndSelectSlots(
+            builder, loc, groups, groupIdx, info, oldBody, tripCount, loopLowerBound, loopStep, groupTrueFlagVals,
+            groupIndexOneVals, iterArgDeltas, origForOp, allGroupDepthConsts, allGroupSlotConsts, state);
+        if (failed(producerStatus)) {
+            return failure();
+        }
+    }
+    return success();
+}
+
+static LogicalResult emitConsumerReleaseHooksForOwnerGroups(
+    OpBuilder &builder, Location loc, ArrayRef<int> ownerGroups, SmallVectorImpl<LoadGroup> &groups,
+    ExtendedForInfo &info, Block *oldBody, Value tripCount, Value loopLowerBound, Value loopStep,
+    const SmallVector<Value> &groupTrueFlagVals, const SmallVector<Value> &groupIndexOneVals,
+    const SmallVector<Value> &iterArgDeltas, scf::ForOp origForOp, const SmallVector<Value> &allGroupDepthConsts,
+    const SmallVector<SmallVector<Value>> &allGroupSlotConsts, MultiBufferLoopBodyState &state)
+{
+    for (int groupIdx : ownerGroups) {
+        LogicalResult releaseStatus = emitConsumerReleaseAfterPrefix(
+            builder, loc, groups, groupIdx, info, oldBody, tripCount, loopLowerBound, loopStep, groupTrueFlagVals,
+            groupIndexOneVals, iterArgDeltas, origForOp, allGroupDepthConsts, allGroupSlotConsts, state);
+        if (failed(releaseStatus)) {
+            return failure();
+        }
+    }
+    return success();
+}
+
+static LogicalResult cloneOldBodyOpIfNeeded(OpBuilder &builder, Operation *op, Block *oldBody, IRMapping &mapping,
+                                            const llvm::DenseSet<Operation *> &allCtxForOps,
+                                            const llvm::DenseSet<Operation *> &allChainOps,
+                                            const llvm::DenseSet<Operation *> &retainedChainOpSet)
+{
+    if (shouldSkipOldBodyOp(op, allCtxForOps, allChainOps, retainedChainOpSet)) {
+        return success();
+    }
+    if (!areOperandsAvailableForClone(op, oldBody, mapping)) {
+        return failure();
+    }
+    builder.clone(*op, mapping);
+    return success();
+}
+
+static LogicalResult emitOldBodyWithMultiBufferHooks(
+    OpBuilder &builder, Location loc, SmallVectorImpl<LoadGroup> &groups, ExtendedForInfo &info,
+    const llvm::DenseMap<Operation *, SmallVector<int>> &groupsByOwnerOp,
+    const llvm::DenseSet<Operation *> &allCtxForOps, const llvm::DenseSet<Operation *> &allChainOps,
+    const llvm::DenseSet<Operation *> &retainedChainOpSet, Value tripCount, Value loopLowerBound, Value loopStep,
+    const SmallVector<Value> &groupTrueFlagVals, const SmallVector<Value> &groupIndexOneVals,
+    const SmallVector<Value> &iterArgDeltas, scf::ForOp origForOp, const SmallVector<Value> &allGroupDepthConsts,
+    const SmallVector<SmallVector<Value>> &allGroupSlotConsts, MultiBufferLoopBodyState &state)
+{
+    Block *oldBody = info.oldBody;
+    for (auto &op : oldBody->without_terminator()) {
+        auto ownerIt = groupsByOwnerOp.find(&op);
+        if (ownerIt != groupsByOwnerOp.end()) {
+            LogicalResult producerHookStatus = emitProducerHooksForOwnerGroups(
+                builder, loc, ownerIt->second, groups, info, oldBody, tripCount, loopLowerBound, loopStep,
+                groupTrueFlagVals, groupIndexOneVals, iterArgDeltas, origForOp, allGroupDepthConsts,
+                allGroupSlotConsts, state);
+            if (failed(producerHookStatus)) {
+                return failure();
+            }
+        }
+
+        LogicalResult cloneStatus =
+            cloneOldBodyOpIfNeeded(builder, &op, oldBody, info.mapping, allCtxForOps, allChainOps, retainedChainOpSet);
+        if (failed(cloneStatus)) {
+            return failure();
+        }
+
+        if (ownerIt != groupsByOwnerOp.end()) {
+            LogicalResult releaseHookStatus = emitConsumerReleaseHooksForOwnerGroups(
+                builder, loc, ownerIt->second, groups, info, oldBody, tripCount, loopLowerBound, loopStep,
+                groupTrueFlagVals, groupIndexOneVals, iterArgDeltas, origForOp, allGroupDepthConsts,
+                allGroupSlotConsts, state);
+            if (failed(releaseHookStatus)) {
+                return failure();
+            }
+        }
+    }
+    return success();
+}
+
+static LogicalResult emitUnownedGroupsAtBodyEnd(
+    OpBuilder &builder, Location loc, SmallVectorImpl<LoadGroup> &groups, ExtendedForInfo &info, Block *oldBody,
+    Value tripCount, Value loopLowerBound, Value loopStep, const SmallVector<Value> &groupTrueFlagVals,
+    const SmallVector<Value> &groupIndexOneVals, const SmallVector<Value> &iterArgDeltas, scf::ForOp origForOp,
+    const SmallVector<Value> &allGroupDepthConsts, const SmallVector<SmallVector<Value>> &allGroupSlotConsts,
+    MultiBufferLoopBodyState &state)
+{
+    for (int groupIdx = 0; groupIdx < static_cast<int>(groups.size()); ++groupIdx) {
+        if (state.prefixEmitted[groupIdx]) {
+            continue;
+        }
+
+        LogicalResult producerStatus = emitProducerAndSelectSlots(
+            builder, loc, groups, groupIdx, info, oldBody, tripCount, loopLowerBound, loopStep, groupTrueFlagVals,
+            groupIndexOneVals, iterArgDeltas, origForOp, allGroupDepthConsts, allGroupSlotConsts, state);
+        if (failed(producerStatus)) {
+            return failure();
+        }
+        LogicalResult releaseStatus = emitConsumerReleaseAfterPrefix(
+            builder, loc, groups, groupIdx, info, oldBody, tripCount, loopLowerBound, loopStep, groupTrueFlagVals,
+            groupIndexOneVals, iterArgDeltas, origForOp, allGroupDepthConsts, allGroupSlotConsts, state);
+        if (failed(releaseStatus)) {
+            return failure();
+        }
+    }
+    return success();
+}
+
+static void emitCombinedYield(OpBuilder &builder, Location loc, ArrayRef<LoadGroup> groups, ExtendedForInfo &info,
+                              const MultiBufferLoopBodyState &state)
+{
+    auto oldYield = cast<scf::YieldOp>(info.oldBody->getTerminator());
+    SmallVector<Value> yieldVals;
+    yieldVals.reserve(info.numOrig + static_cast<int>(groups.size()) * (info.depth + kLoadGroupCounterIterArgCount));
+    for (Value yieldedValue : oldYield.getOperands()) {
+        yieldVals.push_back(info.mapping.lookupOrDefault(yieldedValue));
+    }
+    for (int groupIdx = 0; groupIdx < static_cast<int>(groups.size()); ++groupIdx) {
+        for (int slotIdx = 0; slotIdx < groups[groupIdx].depth; ++slotIdx) {
+            yieldVals.push_back(state.flagFinals[groupIdx][slotIdx]);
+        }
+        yieldVals.push_back(state.prodCounterFinals[groupIdx]);
+        yieldVals.push_back(state.consCounterNexts[groupIdx]);
+    }
+    builder.create<scf::YieldOp>(loc, yieldVals);
+}
+
+} // namespace
+
+/// Emit the full loop body with producer prefetch, consumer slot selection,
+/// cloned compute, slot release, and a combined scf.yield.
+LogicalResult emitMultiBufferLoopBody(OpBuilder &builder, Location loc, SmallVectorImpl<LoadGroup> &groups,
+                                      ExtendedForInfo &info, const SmallVector<Value> &groupIndexOneVals,
+                                      const SmallVector<SmallVector<Value>> &allGroupSlotConsts,
+                                      const SmallVector<Value> &allGroupDepthConsts,
+                                      const llvm::DenseSet<Operation *> &allCtxForOps, Value tripCount,
+                                      Value loopLowerBound, Value loopStep, const SmallVector<Value> &groupTrueFlagVals,
+                                      const SmallVector<Value> &iterArgDeltas, scf::ForOp origForOp)
+{
+    int numGroups = static_cast<int>(groups.size());
+    Block *oldBody = info.oldBody;
+
+    llvm::DenseSet<Operation *> allChainOps;
+    llvm::DenseSet<Operation *> retainedChainOpSet;
+    computeConsumerCloneSets(groups, oldBody, allChainOps, retainedChainOpSet);
+
+    MultiBufferLoopBodyState state(numGroups);
+    llvm::DenseMap<Operation *, SmallVector<int>> groupsByOwnerOp;
+    if (failed(collectGroupsByOwnerOp(groups, oldBody, groupsByOwnerOp))) {
+        return failure();
+    }
+
+    LogicalResult bodyStatus = emitOldBodyWithMultiBufferHooks(
+        builder, loc, groups, info, groupsByOwnerOp, allCtxForOps, allChainOps, retainedChainOpSet, tripCount,
+        loopLowerBound, loopStep, groupTrueFlagVals, groupIndexOneVals, iterArgDeltas, origForOp,
+        allGroupDepthConsts, allGroupSlotConsts, state);
+    if (failed(bodyStatus)) {
+        return failure();
+    }
+
+    LogicalResult unownedStatus = emitUnownedGroupsAtBodyEnd(
+        builder, loc, groups, info, oldBody, tripCount, loopLowerBound, loopStep, groupTrueFlagVals, groupIndexOneVals,
+        iterArgDeltas, origForOp, allGroupDepthConsts, allGroupSlotConsts, state);
+    if (failed(unownedStatus)) {
+        return failure();
+    }
+
+    emitCombinedYield(builder, loc, groups, info, state);
+    return success();
+}
+
+} // namespace gmload

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/DecoupleComputeAndMemory/test_decouple_compute_and_memory_basic_transform.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/DecoupleComputeAndMemory/test_decouple_compute_and_memory_basic_transform.mlir
@@ -1,0 +1,201 @@
+// RUN: triton-opt --gm-load-multi-buffer %s | FileCheck %s
+
+// ============================================================================
+// TC-B01: Basic double buffer (depth=2) transformation
+// Verifies a single Q load with gm_load_bufferable is correctly rewritten
+// into a 2-slot double-buffer structure with Producer/Consumer split.
+// ============================================================================
+
+// CHECK-LABEL: func.func @tc_b01_double_buffer_basic
+func.func @tc_b01_double_buffer_basic(
+  %arg0: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %arg1: tensor<128x128xf32>
+) -> tensor<128x128xf32> {
+  %c28_i32 = arith.constant 28 : i32
+  %c65536_i32 = arith.constant 65536 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c128 = arith.constant 128 : index
+
+  // Two buffer slots allocated before loop
+  // CHECK: %[[Q_SLOT0:.*]] = memref.alloc() : memref<128x128xf16>
+  // CHECK: %[[Q_SLOT1:.*]] = memref.alloc() : memref<128x128xf16>
+
+  // Trip count computed via ceildivui
+  // CHECK: arith.ceildivui
+
+  // scf.for gets 4 extra iter_args: 2 flags + prod_counter + cons_counter
+  // CHECK: scf.for {{.+}} iter_args({{.+}}) -> (tensor<128x128xf32>, i1, i1, index, index)
+
+  // Producer fills slots via memref.copy
+  // CHECK: memref.copy {{.*}}, %[[Q_SLOT0]]
+  // CHECK: memref.copy {{.*}}, %[[Q_SLOT1]]
+
+  // Consumer uses remui + select for FIFO slot selection
+  // CHECK: arith.remui {{.*}}, %c2
+  // CHECK: bufferization.to_tensor %[[Q_SLOT0]]
+  // CHECK: bufferization.to_tensor %[[Q_SLOT1]]
+  // CHECK: arith.select
+
+  // Consumer body uses selected tensor for matmul
+  // CHECK: linalg.matmul
+
+  %result = scf.for %arg16 = %c0_i32 to %c65536_i32 step %c28_i32
+    iter_args(%acc = %arg1) -> tensor<128x128xf32> : i32 {
+    %iv_idx = arith.index_cast %arg16 : i32 to index
+    %row_off = arith.muli %iv_idx, %c128 : index
+    %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+    %q_alloc = memref.alloc () : memref<128x128xf16>
+    memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
+    scf.yield %qk : tensor<128x128xf32>
+  }
+  return %result : tensor<128x128xf32>
+}
+
+// ============================================================================
+// TC-B02: No gm_load_bufferable marker -> Pass-through
+// Verifies that without the gm_load_bufferable attribute, the pass does
+// not transform the IR at all.
+// ============================================================================
+
+// CHECK-LABEL: func.func @tc_b02_no_marker_pass_through
+func.func @tc_b02_no_marker_pass_through(
+  %arg0: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}
+) {
+  %c28_i32 = arith.constant 28 : i32
+  %c65536_i32 = arith.constant 65536 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c128 = arith.constant 128 : index
+
+  // No transformation without marker
+  // CHECK-NOT: arith.ceildivui
+  // CHECK-NOT: arith.remui
+  // CHECK-NOT: arith.select
+  // CHECK: scf.for {{.*}} : i32 {
+  // CHECK: memref.copy
+
+  scf.for %arg16 = %c0_i32 to %c65536_i32 step %c28_i32 : i32 {
+    %iv_idx = arith.index_cast %arg16 : i32 to index
+    %row_off = arith.muli %iv_idx, %c128 : index
+    %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+    %q_alloc = memref.alloc () : memref<128x128xf16>
+    memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable : memref<128x128xf16> to tensor<128x128xf16>
+  }
+  return
+}
+
+// ============================================================================
+// TC-B03: Trip count <= depth -> skip transformation
+// When the loop trip count (compile-time known) is <= buffer depth (2),
+// the pass should skip transformation since there is no pipeline benefit.
+// ============================================================================
+
+// CHECK-LABEL: func.func @tc_b03_trip_count_too_small
+func.func @tc_b03_trip_count_too_small(
+  %arg0: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}
+) {
+  %c0 = arith.constant 0 : index
+  %c2 = arith.constant 2 : index
+  %c1 = arith.constant 1 : index
+  %c128 = arith.constant 128 : index
+
+  // Trip count = ceildiv(2 - 0, 1) = 2 = depth -> skip
+  // CHECK-NOT: arith.ceildivui
+  // CHECK-NOT: arith.remui
+  // CHECK: scf.for %{{.*}} = %c0 to %c2 step %c1
+  // CHECK: memref.copy
+
+  scf.for %iv = %c0 to %c2 step %c1 : index {
+    %row_off = arith.muli %iv, %c128 : index
+    %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+    %q_alloc = memref.alloc () : memref<128x128xf16>
+    memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+  }
+  return
+}
+
+// ============================================================================
+// TC-B03b: Trip count = depth + 1 -> should transform (minimal valid TC)
+// Verifies that when trip count is just above depth, transformation happens.
+// ============================================================================
+
+// CHECK-LABEL: func.func @tc_b03b_trip_count_minimal_valid
+func.func @tc_b03b_trip_count_minimal_valid(
+  %arg0: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}
+) {
+  %c0 = arith.constant 0 : index
+  %c3 = arith.constant 3 : index
+  %c1 = arith.constant 1 : index
+  %c128 = arith.constant 128 : index
+
+  // Trip count = 3 > depth(2) -> should transform
+  // CHECK: arith.ceildivui
+  // CHECK: arith.remui {{.*}}, %c2
+
+  scf.for %iv = %c0 to %c3 step %c1 : index {
+    %row_off = arith.muli %iv, %c128 : index
+    %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+    %q_alloc = memref.alloc () : memref<128x128xf16>
+    memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+  }
+  return
+}
+
+// ============================================================================
+// TC-B13: No backing alloc in chain -> pass should skip
+// When the gm_load_bufferable to_tensor has no associated memref.alloc
+// in its dependency chain, the pass cannot create buffer slots and must skip.
+// ============================================================================
+
+// CHECK-LABEL: func.func @tc_b13_no_backing_alloc_skip
+func.func @tc_b13_no_backing_alloc_skip(
+  %arg0: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}
+) {
+  %c28_i32 = arith.constant 28 : i32
+  %c65536_i32 = arith.constant 65536 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c128 = arith.constant 128 : index
+
+  // No memref.alloc in chain -> pass skips this load
+  // CHECK-NOT: arith.ceildivui
+  // CHECK-NOT: arith.remui
+  // CHECK: scf.for {{.*}} : i32 {
+  // CHECK: bufferization.to_tensor {{.*}} {gm_load_bufferable}
+
+  scf.for %arg16 = %c0_i32 to %c65536_i32 step %c28_i32 : i32 {
+    %iv_idx = arith.index_cast %arg16 : i32 to index
+    %row_off = arith.muli %iv_idx, %c128 : index
+    // No alloc - direct reinterpret_cast used as to_tensor source
+    %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+    %q_tensor = bufferization.to_tensor %q_src_rc restrict writable {gm_load_bufferable} : memref<128x128xf16, strided<[128, 1], offset: ?>> to tensor<128x128xf16>
+  }
+  return
+}
+
+// ============================================================================
+// TC-B15: No marked loads at all -> entire pass is a no-op
+// Verifies the pass handles an empty scf.for with no gm_load_bufferable ops.
+// ============================================================================
+
+// CHECK-LABEL: func.func @tc_b15_no_marked_loads_noop
+func.func @tc_b15_no_marked_loads_noop() {
+  %c0 = arith.constant 0 : index
+  %c10 = arith.constant 10 : index
+  %c1 = arith.constant 1 : index
+
+  // CHECK-NOT: arith.ceildivui
+  // CHECK-NOT: arith.remui
+  // CHECK: scf.for
+
+  scf.for %iv = %c0 to %c10 step %c1 : index {
+    %val = arith.addi %iv, %c1 : index
+  }
+  return
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/DecoupleComputeAndMemory/test_decouple_compute_and_memory_complex_scenarios.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/DecoupleComputeAndMemory/test_decouple_compute_and_memory_complex_scenarios.mlir
@@ -1,0 +1,315 @@
+// RUN: triton-opt --gm-load-multi-buffer %s | FileCheck %s
+
+// ============================================================================
+// TC-B10: Multiple loads in same loop - each gets independent state
+// When multiple loads have gm_load_bufferable in the same scf.for,
+// each load group gets its own buffer slots, flags, and counters.
+// ============================================================================
+
+// CHECK-LABEL: func.func @tc_b10_multiple_loads_same_loop
+func.func @tc_b10_multiple_loads_same_loop(
+  %arg0: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %arg1: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %arg2: tensor<128x128xf32>
+) -> tensor<128x128xf32> {
+  %c28_i32 = arith.constant 28 : i32
+  %c65536_i32 = arith.constant 65536 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c128 = arith.constant 128 : index
+
+  // Each load gets 2 slots = 4 allocs total before the loop
+  // CHECK: memref.alloc() : memref<128x128xf16>
+  // CHECK: memref.alloc() : memref<128x128xf16>
+  // CHECK: memref.alloc() : memref<128x128xf16>
+  // CHECK: memref.alloc() : memref<128x128xf16>
+
+  // Each load gets independent control: 2*(2 flags + prod + cons) = 8 control iter_args
+  // CHECK: scf.for {{.+}} iter_args({{.+}}) -> (tensor<128x128xf32>, i1, i1, index, index, i1, i1, index, index)
+
+  // Two separate select chains (one per load group)
+  // CHECK: arith.select
+  // CHECK: arith.select
+  // CHECK: linalg.matmul
+
+  %result = scf.for %arg16 = %c0_i32 to %c65536_i32 step %c28_i32
+    iter_args(%acc = %arg2) -> tensor<128x128xf32> : i32 {
+    %iv_idx = arith.index_cast %arg16 : i32 to index
+    %row_off = arith.muli %iv_idx, %c128 : index
+
+    %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+    %q_alloc = memref.alloc () : memref<128x128xf16>
+    memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+
+    %k_src_rc = memref.reinterpret_cast %arg1 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+    %k_alloc = memref.alloc () : memref<128x128xf16>
+    memref.copy %k_src_rc, %k_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+    %k_tensor = bufferization.to_tensor %k_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+
+    %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %k_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
+    scf.yield %qk : tensor<128x128xf32>
+  }
+  return %result : tensor<128x128xf32>
+}
+
+// ============================================================================
+// TC-B11: Nested loops - inner loop transformed first
+// When only the inner loop has a marked load, buffer slots are allocated
+// inside the outer loop body (before the inner loop).
+// ============================================================================
+
+// CHECK-LABEL: func.func @tc_b11_nested_loops_inner_first
+func.func @tc_b11_nested_loops_inner_first(
+  %arg0: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %arg1: tensor<128x128xf32>
+) -> tensor<128x128xf32> {
+  %c28_i32 = arith.constant 28 : i32
+  %c1024_i32 = arith.constant 1024 : i32
+  %c8192_i32 = arith.constant 8192 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c128 = arith.constant 128 : index
+
+  // Outer loop (no marked load in outer body)
+  // CHECK: scf.for {{.*}} : i32 {
+
+  // Inner loop has marked load - buffer slots allocated inside outer body
+  // CHECK: memref.alloc() : memref<128x128xf16>
+  // CHECK: memref.alloc() : memref<128x128xf16>
+  // CHECK: scf.for {{.+}} iter_args({{.+}}) -> (tensor<128x128xf32>, i1, i1, index, index)
+
+  %outer_result = scf.for %outer_iv = %c0_i32 to %c1024_i32 step %c28_i32
+    iter_args(%outer_acc = %arg1) -> tensor<128x128xf32> : i32 {
+
+    %inner_result = scf.for %inner_iv = %c0_i32 to %c8192_i32 step %c128_i32
+      iter_args(%inner_acc = %outer_acc) -> tensor<128x128xf32> : i32 {
+      %iv_idx = arith.index_cast %inner_iv : i32 to index
+      %row_off = arith.muli %iv_idx, %c128 : index
+      %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+      %q_alloc = memref.alloc () : memref<128x128xf16>
+      memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+      %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+      %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%inner_acc : tensor<128x128xf32>) -> tensor<128x128xf32>
+      scf.yield %qk : tensor<128x128xf32>
+    }
+    scf.yield %inner_result : tensor<128x128xf32>
+  }
+  return %outer_result : tensor<128x128xf32>
+}
+
+// ============================================================================
+// TC-B12: Linear iter_arg delta projection
+// When the loop has an iter_arg that follows a linear delta pattern
+// (iter_arg_yield = addi(iter_arg, loop_invariant)), the pass should
+// recognize it and correctly project the address calculation.
+// ============================================================================
+
+// CHECK-LABEL: func.func @tc_b12_linear_iter_arg_delta
+func.func @tc_b12_linear_iter_arg_delta(
+  %arg0: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %offset_init: i32,
+  %arg1: tensor<128x128xf32>
+) -> tensor<128x128xf32> {
+  %c28_i32 = arith.constant 28 : i32
+  %c65536_i32 = arith.constant 65536 : i32
+  %c128 = arith.constant 128 : index
+  %c128_i32 = arith.constant 128 : i32
+
+  // iter_arg with linear delta gets multi-buffer + projected delta
+  // CHECK: scf.for {{.+}} iter_args({{.+}}) -> (i32, i1, i1, index, index)
+
+  %result = scf.for %iv = %offset_init to %c65536_i32 step %c28_i32
+    iter_args(%offset = %offset_init) -> i32 : i32 {
+    %offset_idx = arith.index_cast %offset : i32 to index
+    %row_off = arith.muli %offset_idx, %c128 : index
+    %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+    %q_alloc = memref.alloc () : memref<128x128xf16>
+    memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %acc_dummy = tensor.empty() : tensor<128x128xf32>
+    %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc_dummy : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+    // Linear delta: offset_new = offset + 128
+    %offset_new = arith.addi %offset, %c128_i32 : i32
+    scf.yield %offset_new : i32
+  }
+
+  // Use the result to prevent dead code elimination
+  %final_idx = arith.index_cast %result : i32 to index
+  %final_row = arith.muli %final_idx, %c128 : index
+  %final_view = memref.reinterpret_cast %arg0 to offset: [%final_row], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+  %final_alloc = memref.alloc() : memref<128x128xf16>
+  memref.copy %final_view, %final_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+  %final_tensor = bufferization.to_tensor %final_alloc restrict writable : memref<128x128xf16> to tensor<128x128xf16>
+  %ext = arith.extf %final_tensor : tensor<128x128xf16> to tensor<128x128xf32>
+  %sum = arith.addf %ext, %arg1 : tensor<128x128xf32>
+  return %sum : tensor<128x128xf32>
+}
+
+// ============================================================================
+// TC-B18: Multiple marked loads + original iter_args combined
+// Combines TC-B06 and TC-B10: multiple marked loads in a loop that already
+// has original iter_args. Verifies iter_args layout:
+// [orig_args...] + [control_group_1...] + [control_group_2...]
+// ============================================================================
+
+// CHECK-LABEL: func.func @tc_b18_multi_load_with_orig_iter_args
+func.func @tc_b18_multi_load_with_orig_iter_args(
+  %arg0: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %arg1: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %acc_init: tensor<128x128xf32>,
+  %lse_init: tensor<128xf32>
+) -> (tensor<128x128xf32>, tensor<128xf32>) {
+  %c28_i32 = arith.constant 28 : i32
+  %c65536_i32 = arith.constant 65536 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c128 = arith.constant 128 : index
+
+  // 4 allocs total: 2 slots per load group
+  // CHECK: memref.alloc() : memref<128x128xf16>
+  // CHECK: memref.alloc() : memref<128x128xf16>
+  // CHECK: memref.alloc() : memref<128x128xf16>
+  // CHECK: memref.alloc() : memref<128x128xf16>
+
+  // iter_args: 2 orig + 4*2 control = 10 total
+  // CHECK: scf.for {{.+}} iter_args({{.+}}) -> (tensor<128x128xf32>, tensor<128xf32>, i1, i1, index, index, i1, i1, index, index)
+
+  %result:2 = scf.for %arg16 = %c0_i32 to %c65536_i32 step %c28_i32
+    iter_args(%acc = %acc_init, %lse = %lse_init)
+    -> (tensor<128x128xf32>, tensor<128xf32>) : i32 {
+    %iv_idx = arith.index_cast %arg16 : i32 to index
+    %row_off = arith.muli %iv_idx, %c128 : index
+
+    %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+    %q_alloc = memref.alloc () : memref<128x128xf16>
+    memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+
+    %k_src_rc = memref.reinterpret_cast %arg1 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+    %k_alloc = memref.alloc () : memref<128x128xf16>
+    memref.copy %k_src_rc, %k_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+    %k_tensor = bufferization.to_tensor %k_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+
+    %acc_new = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %k_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
+    scf.yield %acc_new, %lse : tensor<128x128xf32>, tensor<128xf32>
+  }
+  return %result#0, %result#1 : tensor<128x128xf32>, tensor<128xf32>
+}
+
+// ============================================================================
+// TC-B19: Different data types (bf16)
+// Verifies the pass handles bf16 tensors correctly, not just f16.
+// ============================================================================
+
+// CHECK-LABEL: func.func @tc_b19_bf16_data_type
+func.func @tc_b19_bf16_data_type(
+  %arg0: memref<?xbf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %arg1: tensor<128x128xf32>
+) -> tensor<128x128xf32> {
+  %c28_i32 = arith.constant 28 : i32
+  %c65536_i32 = arith.constant 65536 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c128 = arith.constant 128 : index
+
+  // bf16 buffer slots
+  // CHECK: %[[S0:.*]] = memref.alloc() : memref<128x128xbf16>
+  // CHECK: %[[S1:.*]] = memref.alloc() : memref<128x128xbf16>
+  // CHECK: arith.remui {{.*}}, %c2
+
+  %result = scf.for %arg16 = %c0_i32 to %c65536_i32 step %c28_i32
+    iter_args(%acc = %arg1) -> tensor<128x128xf32> : i32 {
+    %iv_idx = arith.index_cast %arg16 : i32 to index
+    %row_off = arith.muli %iv_idx, %c128 : index
+    %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xbf16> to memref<128x128xbf16, strided<[128, 1], offset: ?>>
+    %q_alloc = memref.alloc () : memref<128x128xbf16>
+    memref.copy %q_src_rc, %q_alloc : memref<128x128xbf16, strided<[128, 1], offset: ?>> to memref<128x128xbf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xbf16> to tensor<128x128xbf16>
+    %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
+    scf.yield %qk : tensor<128x128xf32>
+  }
+  return %result : tensor<128x128xf32>
+}
+
+// ============================================================================
+// TC-B20: Nested loops with marked load in outer loop only
+// When only the outer loop has a marked load (and the inner loop has none),
+// the outer loop gets transformed while the inner loop stays unchanged.
+// ============================================================================
+
+// CHECK-LABEL: func.func @tc_b20_outer_loop_marked_only
+func.func @tc_b20_outer_loop_marked_only(
+  %arg0: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %arg1: tensor<128x128xf32>
+) -> tensor<128x128xf32> {
+  %c28_i32 = arith.constant 28 : i32
+  %c1024_i32 = arith.constant 1024 : i32
+  %c4_i32 = arith.constant 4 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c128 = arith.constant 128 : index
+
+  // Outer loop has marked load -> gets buffer slots before outer loop
+  // CHECK: %[[S0:.*]] = memref.alloc() : memref<128x128xf16>
+  // CHECK: %[[S1:.*]] = memref.alloc() : memref<128x128xf16>
+  // CHECK: scf.for {{.+}} iter_args({{.+}}) -> (tensor<128x128xf32>, i1, i1, index, index)
+
+  // Inner loop has no marked load -> stays as-is
+  // CHECK: scf.for {{.*}} : i32 {
+
+  %outer_result = scf.for %outer_iv = %c0_i32 to %c1024_i32 step %c28_i32
+    iter_args(%outer_acc = %arg1) -> tensor<128x128xf32> : i32 {
+    %iv_idx = arith.index_cast %outer_iv : i32 to index
+    %row_off = arith.muli %iv_idx, %c128 : index
+    %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+    %q_alloc = memref.alloc () : memref<128x128xf16>
+    memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%outer_acc : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+    // Inner loop with no marked load
+    %inner_result = scf.for %inner_iv = %c0_i32 to %c4_i32 step %c1_i32
+      iter_args(%inner_acc = %qk) -> tensor<128x128xf32> : i32 {
+      %add = arith.addf %inner_acc, %inner_acc : tensor<128x128xf32>
+      scf.yield %add : tensor<128x128xf32>
+    }
+    scf.yield %inner_result : tensor<128x128xf32>
+  }
+  return %outer_result : tensor<128x128xf32>
+}
+
+// ============================================================================
+// TC-B21: Index-typed IV (not i32)
+// Verifies the pass handles scf.for with index-typed induction variable
+// correctly, where the address calculation chain uses index arithmetic.
+// ============================================================================
+
+// CHECK-LABEL: func.func @tc_b21_index_iv_type
+func.func @tc_b21_index_iv_type(
+  %arg0: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %arg1: tensor<128x128xf32>
+) -> tensor<128x128xf32> {
+  %c0 = arith.constant 0 : index
+  %c2344 = arith.constant 2344 : index
+  %c28 = arith.constant 28 : index
+  %c128 = arith.constant 128 : index
+
+  // Index-typed IV: address chain uses index arithmetic directly
+  // CHECK: %[[S0:.*]] = memref.alloc() : memref<128x128xf16>
+  // CHECK: %[[S1:.*]] = memref.alloc() : memref<128x128xf16>
+  // CHECK: arith.remui {{.*}}, %c2
+
+  %result = scf.for %iv = %c0 to %c2344 step %c28
+    iter_args(%acc = %arg1) -> tensor<128x128xf32> : index {
+    %row_off = arith.muli %iv, %c128 : index
+    %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+    %q_alloc = memref.alloc () : memref<128x128xf16>
+    memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
+    scf.yield %qk : tensor<128x128xf32>
+  }
+  return %result : tensor<128x128xf32>
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/DecoupleComputeAndMemory/test_decouple_compute_and_memory_gm_load_multi_buffer_block_id.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/DecoupleComputeAndMemory/test_decouple_compute_and_memory_gm_load_multi_buffer_block_id.mlir
@@ -1,0 +1,901 @@
+// RUN: triton-opt --gm-load-multi-buffer %s | FileCheck %s
+
+// ============================================================================
+// Test Group B1: DTS1 VECTOR - two independent marked loads with shared address
+//
+// Based on dts1_result_v1_multibuffer_ir_issues.zh.md:
+// - Problem 1: Two marked loads must each have independent multi-buffer
+//   state (buffer slots, flags, counters, slot selection).
+// - Problem 3: Top-level block_id runs must be consecutive.
+//   Old pass produced 7 -> 8 -> 7 -> 8 -> 9; fix must produce 7 -> 8 -> 9.
+//
+// Key pattern: block 7 has remaining body ops (%24=muli, %25=index_cast)
+// used by block 9 store address (%46=muli %25). These must NOT be placed
+// between two block 8 runs.
+// ============================================================================
+
+// CHECK-LABEL: func.func @_attn_bwd
+func.func @_attn_bwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg3: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg4: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg5: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg6: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 2 : i32}, %arg7: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg8: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg9: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg10: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg11: f32, %arg12: i32, %arg13: i32, %arg14: i32, %arg15: i32, %arg16: i32, %arg17: i32) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+  %cst = arith.constant {ssbuffer.block_id = 7 : i32} dense<[4, 4, 16, 16]> : tensor<4xi64>
+  %cst_0 = arith.constant {ssbuffer.block_id = 7 : i32} dense<[64, 4, 16]> : tensor<3xi64>
+  %c64_i32 = arith.constant {MixUse, ssbuffer.block_id = 12 : i32} 64 : i32
+  %c8388608_i32 = arith.constant {MixUse, ssbuffer.block_id = 12 : i32} 8388608 : i32
+  %c1048576_i32 = arith.constant {MixUse, ssbuffer.block_id = 12 : i32} 1048576 : i32
+  %c8_i32 = arith.constant {MixUse, ssbuffer.block_id = 12 : i32} 8 : i32
+  %c8192_i32 = arith.constant {ssbuffer.block_id = 12 : i32} 8192 : i32
+  %c128_i32 = arith.constant {MixUse, ssbuffer.block_id = 12 : i32} 128 : i32
+  %c131072_i32 = arith.constant {Undefined, ssbuffer.block_id = 12 : i32} 131072 : i32
+  %c28_i32 = arith.constant {Undefined, ssbuffer.block_id = 12 : i32} 28 : i32
+  %c0_i32 = arith.constant {Undefined, ssbuffer.block_id = 12 : i32} 0 : i32
+  %c1_i32 = arith.constant {Undefined, ssbuffer.block_id = 12 : i32} 1 : i32
+  %cst_1 = arith.constant {ssbuffer.block_id = 12 : i32} 0.000000e+00 : f32
+  %c128 = arith.constant {ssbuffer.block_id = 12 : i32} 128 : index
+
+  // R1: Each load gets 2 independent buffer slots (4 total)
+  // CHECK: memref.alloc() {ssbuffer.block_id = 7 : i32} : memref<64xf32>
+  // CHECK: memref.alloc() {ssbuffer.block_id = 7 : i32} : memref<64xf32>
+  // CHECK: memref.alloc() {ssbuffer.block_id = 8 : i32} : memref<64xf32>
+  // CHECK: memref.alloc() {ssbuffer.block_id = 8 : i32} : memref<64xf32>
+
+  // R1: 2 original iter_args + 8 control (4 per load) = 10 total
+  // CHECK: scf.for {{.*}} iter_args({{.*}}) -> (tensor<64x128xf32>, tensor<64x128xf32>, i1, i1, index, index, i1, i1, index, index)
+
+  scope.scope : () -> () {
+    %0 = tensor.empty() {ssbuffer.block_id = 12 : i32} : tensor<64x128xf32>
+    %1 = linalg.fill {ssbuffer.block_id = 12 : i32} ins(%cst_1 : f32) outs(%0 : tensor<64x128xf32>) -> tensor<64x128xf32>
+    %2 = tensor.empty() {ssbuffer.block_id = 12 : i32} : tensor<64x64xf32>
+    %3 = linalg.fill {ssbuffer.block_id = 12 : i32} ins(%cst_1 : f32) outs(%2 : tensor<64x64xf32>) -> tensor<64x64xf32>
+    %4 = linalg.fill {ssbuffer.block_id = 12 : i32} ins(%arg11 : f32) outs(%2 : tensor<64x64xf32>) -> tensor<64x64xf32>
+    scf.for %arg18 = %arg15 to %c131072_i32 step %c28_i32  : i32 {
+      %5 = arith.divsi %arg18, %c128_i32 {MixUse, ssbuffer.block_id = 10 : i32} : i32
+      %6 = arith.muli %5, %c8192_i32 {ssbuffer.block_id = 10 : i32} : i32
+      %7 = arith.remsi %5, %c8_i32 {MixUse, ssbuffer.block_id = 10 : i32} : i32
+      %8 = arith.muli %7, %c1048576_i32 {MixUse, ssbuffer.block_id = 10 : i32} : i32
+      %9 = arith.divsi %5, %c8_i32 {MixUse, ssbuffer.block_id = 10 : i32} : i32
+      %10 = arith.muli %9, %c8388608_i32 {MixUse, ssbuffer.block_id = 10 : i32} : i32
+      %11 = arith.addi %8, %10 {MixUse, ssbuffer.block_id = 10 : i32} : i32
+      %12 = arith.index_cast %11 {ssbuffer.block_id = 10 : i32} : i32 to index
+      %13 = arith.index_cast %6 {ssbuffer.block_id = 10 : i32} : i32 to index
+      %alloc = memref.alloc() {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x4x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x4x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_2 = memref.alloc() {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 1 : i32} : memref<4x4x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_2 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 1 : i32} : memref<4x4x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_3 = memref.alloc() {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 2 : i32} : memref<4x4x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_3 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 2 : i32} : memref<4x4x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_4 = memref.alloc() {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 3 : i32} : memref<64x64xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_4 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<3>, ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 3 : i32} : memref<64x64xf32, #hivm.address_space<ub>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 4
+      %alloc_5 = memref.alloc() {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 4 : i32} : memref<64x64xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_5 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<4>, ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 4 : i32} : memref<64x64xf32, #hivm.address_space<ub>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 4 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 5
+      %alloc_6 = memref.alloc() {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 5 : i32} : memref<64x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_6 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<5>, ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 5 : i32} : memref<64x128xf32, #hivm.address_space<ub>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 5 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 6
+      %alloc_7 = memref.alloc() {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 6 : i32} : memref<64x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_7 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<6>, ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 6 : i32} : memref<64x128xf32, #hivm.address_space<ub>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 6 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 7
+      %alloc_8 = memref.alloc() {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 7 : i32} : memref<64x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_8 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<7>, ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 7 : i32} : memref<64x128xf32, #hivm.address_space<ub>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 7 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 8
+
+      // ── Inner loop (main_loop) ────────────────────────────────────────
+
+      // R2: Block 7 remaining ops (%24=muli %arg19, %25=index_cast %24)
+      // must stay in block 7 run, BEFORE block 8 starts.
+      // This produces: 7 -> 8 -> 9 (not 7 -> 8 -> 7 -> 8 -> 9).
+
+      // Block 7: first producer slot
+      // CHECK: scf.if {{.*}} -> (i1, index) {
+      // CHECK: memref.copy {{.*}} {ssbuffer.block_id = 7
+      // CHECK: } {ssbuffer.block_id = 7 : i32, ssbuffer.load_store}
+
+      // Block 7: second producer slot (uses first slot's updated index)
+      // CHECK: scf.if {{.*}} -> (i1, index) {
+      // CHECK: memref.copy {{.*}} {ssbuffer.block_id = 7
+      // CHECK: } {ssbuffer.block_id = 7 : i32, ssbuffer.load_store}
+
+      // Block 7: consumer select
+      // CHECK: arith.remui {{.*}} {ssbuffer.block_id = 7
+      // CHECK: bufferization.to_tensor {{.*}} {ssbuffer.block_id = 7
+      // CHECK: bufferization.to_tensor {{.*}} {ssbuffer.block_id = 7
+      // CHECK: arith.select {{.*}} {ssbuffer.block_id = 7
+
+      // Block 7: flag clear (now before compute)
+      // CHECK: scf.if {{.*}} -> (i1) {
+      // CHECK: } {ssbuffer.block_id = 7 : i32, ssbuffer.load_store}
+      // CHECK: scf.if {{.*}} -> (i1) {
+      // CHECK: } {ssbuffer.block_id = 7 : i32, ssbuffer.load_store}
+
+      // Block 7: compute using selected tensor
+      // CHECK: arith.mulf {{.*ssbuffer.block_id = 7}}
+      // CHECK: linalg.broadcast ins({{.*}} : tensor<64xf32>) {{.*}} {ssbuffer.block_id = 7
+      // CHECK: math.exp {{.*}} ssbuffer.block_id = 7
+
+      // Block 7: sync + copy to cbuf
+      // CHECK: hivm.hir.sync_block_wait {{.*ssbuffer.block_id = 7}}
+      // CHECK: hivm.hir.copy {{.*ssbuffer.block_id = 7}}
+      // CHECK: hivm.hir.sync_block_set {{.*ssbuffer.block_id = 7}}
+
+      // Block 8: first producer slot (independent from block 7)
+      // CHECK: scf.if {{.*}} -> (i1, index) {
+      // CHECK: memref.copy {{.*}} {ssbuffer.block_id = 8
+      // CHECK: } {ssbuffer.block_id = 8 : i32, ssbuffer.load_store}
+
+      // Block 8: second producer slot
+      // CHECK: scf.if {{.*}} -> (i1, index) {
+      // CHECK: memref.copy {{.*}} {ssbuffer.block_id = 8
+      // CHECK: } {ssbuffer.block_id = 8 : i32, ssbuffer.load_store}
+
+      // Block 8: consumer select (independent from block 7)
+      // CHECK: arith.remui {{.*}} {ssbuffer.block_id = 8
+      // CHECK: bufferization.to_tensor {{.*}} {ssbuffer.block_id = 8
+      // CHECK: bufferization.to_tensor {{.*}} {ssbuffer.block_id = 8
+      // CHECK: arith.select {{.*}} {ssbuffer.block_id = 8
+
+      // Block 8: flag clear (now before compute)
+      // CHECK: scf.if {{.*}} -> (i1) {
+      // CHECK: } {ssbuffer.block_id = 8 : i32, ssbuffer.load_store}
+      // CHECK: scf.if {{.*}} -> (i1) {
+      // CHECK: } {ssbuffer.block_id = 8 : i32, ssbuffer.load_store}
+
+      // Block 8: compute using selected tensor
+      // CHECK: arith.extf {{.*ssbuffer.block_id = 8}}
+      // CHECK: arith.mulf {{.*ssbuffer.block_id = 8}}
+
+      // Block 8: sync + copy to cbuf
+      // CHECK: hivm.hir.sync_block_wait {{.*ssbuffer.block_id = 8}}
+      // CHECK: hivm.hir.copy {{.*ssbuffer.block_id = 8}}
+      // CHECK: hivm.hir.sync_block_set {{.*ssbuffer.block_id = 8}}
+
+      // Block 9: tail (uses %25 from block 7 for store address)
+      // CHECK: hivm.hir.sync_block_wait {{.*ssbuffer.block_id = 9}}
+      // CHECK: arith.muli {{.*ssbuffer.block_id = 9}}
+      // CHECK: arith.addi {{.*ssbuffer.block_id = 9}}
+      // CHECK: hivm.hir.store {{.*ssbuffer.block_id = 9}}
+      // CHECK: hivm.hir.sync_block_set {{.*ssbuffer.block_id = 9}}
+
+      // scf.yield with 10 values
+      // CHECK: scf.yield {{.*}} : tensor<64x128xf32>, tensor<64x128xf32>, i1, i1, index, index, i1, i1, index, index
+
+      %14:2 = scf.for %arg19 = %c0_i32 to %c128_i32 step %c1_i32 iter_args(%arg20 = %1, %arg21 = %1) -> (tensor<64x128xf32>, tensor<64x128xf32>)  : i32 {
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 4
+        %memspacecast = memref.memory_space_cast %alloc_4 {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 3 : i32} : memref<64x64xf32, #hivm.address_space<ub>> to memref<64x64xf32>
+        %23 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 3 : i32} : memref<64x64xf32> to tensor<64x64xf32>
+        %24 = arith.muli %arg19, %c64_i32 {MixUse, ssbuffer.block_id = 7 : i32} : i32
+        %25 = arith.index_cast %24 {ssbuffer.block_id = 7 : i32} : i32 to index
+        %26 = arith.addi %13, %25 {ssbuffer.block_id = 7 : i32} : index
+        %reinterpret_cast_10 = memref.reinterpret_cast %arg9 to offset: [%26], sizes: [64], strides: [1] {ssbuffer.block_id = 7 : i32} : memref<?xf32> to memref<64xf32, strided<[1], offset: ?>>
+        %alloc_11 = memref.alloc() {ssbuffer.block_id = 7 : i32} : memref<64xf32>
+        memref.copy %reinterpret_cast_10, %alloc_11 {ssbuffer.block_id = 7 : i32} : memref<64xf32, strided<[1], offset: ?>> to memref<64xf32>
+        %27 = bufferization.to_tensor %alloc_11 restrict writable {gm_load_bufferable, ssbuffer.block_id = 7 : i32} : memref<64xf32> to tensor<64xf32>
+        %28 = arith.addf %23, %3 {ssbuffer.block_id = 7 : i32} : tensor<64x64xf32>
+        %29 = arith.mulf %28, %4 {DataUse, ssbuffer.block_id = 7 : i32} : tensor<64x64xf32>
+        %broadcasted = linalg.broadcast ins(%27 : tensor<64xf32>) outs(%2 : tensor<64x64xf32>) dimensions = [1]  {ssbuffer.block_id = 7 : i32}
+        %30 = arith.subf %29, %broadcasted {DataUse, ssbuffer.block_id = 7 : i32} : tensor<64x64xf32>
+        %31 = math.exp %30 {DataUse, ssbuffer.block_id = 7 : i32} : tensor<64x64xf32>
+        %32 = arith.truncf %31 {DataUse, ssbuffer.block_id = 7 : i32} : tensor<64x64xf32> to tensor<64x64xf16>
+        %reshape = tensor.reshape %32(%cst_0) {ssbuffer.block_id = 7 : i32} : (tensor<64x64xf16>, tensor<3xi64>) -> tensor<64x4x16xf16>
+        %33 = tensor.empty() {ssbuffer.block_id = 7 : i32} : tensor<4x64x16xf16>
+        %transposed = linalg.transpose ins(%reshape : tensor<64x4x16xf16>) outs(%33 : tensor<4x64x16xf16>) permutation = [1, 0, 2]  {ssbuffer.block_id = 7 : i32}
+        %reshape_12 = tensor.reshape %transposed(%cst) {ssbuffer.block_id = 7 : i32} : (tensor<4x64x16xf16>, tensor<4xi64>) -> tensor<4x4x16x16xf16>
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+        hivm.hir.copy ins(%reshape_12 : tensor<4x4x16x16xf16>) outs(%alloc_2 : memref<4x4x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 1 : i32}
+        hivm.hir.sync_block_set {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+        hivm.hir.sync_block_set {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 4
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 8 : i32, ssbuffer.transfer_id = 4 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 5
+        %memspacecast_13 = memref.memory_space_cast %alloc_5 {ssbuffer.block_id = 8 : i32, ssbuffer.transfer_id = 4 : i32} : memref<64x64xf32, #hivm.address_space<ub>> to memref<64x64xf32>
+        %34 = bufferization.to_tensor %memspacecast_13 restrict writable {ssbuffer.block_id = 8 : i32, ssbuffer.transfer_id = 4 : i32} : memref<64x64xf32> to tensor<64x64xf32>
+        %reinterpret_cast_14 = memref.reinterpret_cast %arg10 to offset: [%26], sizes: [64], strides: [1] {ssbuffer.block_id = 8 : i32} : memref<?xf32> to memref<64xf32, strided<[1], offset: ?>>
+        %alloc_15 = memref.alloc() {ssbuffer.block_id = 8 : i32} : memref<64xf32>
+        memref.copy %reinterpret_cast_14, %alloc_15 {ssbuffer.block_id = 8 : i32} : memref<64xf32, strided<[1], offset: ?>> to memref<64xf32>
+        %35 = bufferization.to_tensor %alloc_15 restrict writable {gm_load_bufferable, ssbuffer.block_id = 8 : i32} : memref<64xf32> to tensor<64xf32>
+        %36 = arith.addf %34, %3 {ssbuffer.block_id = 8 : i32} : tensor<64x64xf32>
+        %broadcasted_16 = linalg.broadcast ins(%35 : tensor<64xf32>) outs(%2 : tensor<64x64xf32>) dimensions = [1]  {ssbuffer.block_id = 8 : i32}
+        %37 = arith.subf %36, %broadcasted_16 {DataUse, ssbuffer.block_id = 8 : i32} : tensor<64x64xf32>
+        %38 = arith.extf %32 {DataUse, ssbuffer.block_id = 8 : i32} : tensor<64x64xf16> to tensor<64x64xf32>
+        %39 = arith.mulf %38, %37 {DataUse, ssbuffer.block_id = 8 : i32} : tensor<64x64xf32>
+        %40 = arith.mulf %39, %4 {DataUse, ssbuffer.block_id = 8 : i32} : tensor<64x64xf32>
+        %41 = arith.truncf %40 {DataUse, ssbuffer.block_id = 8 : i32} : tensor<64x64xf32> to tensor<64x64xf16>
+        %reshape_17 = tensor.reshape %41(%cst_0) {ssbuffer.block_id = 8 : i32} : (tensor<64x64xf16>, tensor<3xi64>) -> tensor<64x4x16xf16>
+        %42 = tensor.empty() {ssbuffer.block_id = 8 : i32} : tensor<4x64x16xf16>
+        %transposed_18 = linalg.transpose ins(%reshape_17 : tensor<64x4x16xf16>) outs(%42 : tensor<4x64x16xf16>) permutation = [1, 0, 2]  {ssbuffer.block_id = 8 : i32}
+        %reshape_19 = tensor.reshape %transposed_18(%cst) {ssbuffer.block_id = 8 : i32} : (tensor<4x64x16xf16>, tensor<4xi64>) -> tensor<4x4x16x16xf16>
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 8 : i32, ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+        hivm.hir.copy ins(%reshape_19 : tensor<4x4x16x16xf16>) outs(%alloc : memref<4x4x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 8 : i32, ssbuffer.transfer_id = 0 : i32}
+        hivm.hir.sync_block_set {ssbuffer.block_id = 8 : i32, ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 8 : i32, ssbuffer.transfer_id = 2 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 3
+        hivm.hir.copy ins(%reshape_19 : tensor<4x4x16x16xf16>) outs(%alloc_3 : memref<4x4x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 8 : i32, ssbuffer.transfer_id = 2 : i32}
+        hivm.hir.sync_block_set {ssbuffer.block_id = 8 : i32, ssbuffer.transfer_id = 2 : i32}[<VECTOR>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 3
+        hivm.hir.sync_block_set {ssbuffer.block_id = 8 : i32, ssbuffer.transfer_id = 4 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 5
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 7 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 8
+        %memspacecast_20 = memref.memory_space_cast %alloc_8 {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 7 : i32} : memref<64x128xf32, #hivm.address_space<ub>> to memref<64x128xf32>
+        %43 = bufferization.to_tensor %memspacecast_20 restrict writable {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 7 : i32} : memref<64x128xf32> to tensor<64x128xf32>
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 6 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 7
+        %memspacecast_21 = memref.memory_space_cast %alloc_7 {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 6 : i32} : memref<64x128xf32, #hivm.address_space<ub>> to memref<64x128xf32>
+        %44 = bufferization.to_tensor %memspacecast_21 restrict writable {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 6 : i32} : memref<64x128xf32> to tensor<64x128xf32>
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 5 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 6
+        %memspacecast_22 = memref.memory_space_cast %alloc_6 {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 5 : i32} : memref<64x128xf32, #hivm.address_space<ub>> to memref<64x128xf32>
+        %45 = bufferization.to_tensor %memspacecast_22 restrict writable {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 5 : i32} : memref<64x128xf32> to tensor<64x128xf32>
+        %46 = arith.muli %25, %c128 {ssbuffer.block_id = 9 : i32} : index
+        %47 = arith.addi %12, %46 {ssbuffer.block_id = 9 : i32} : index
+        %48 = arith.addf %44, %arg21 {ssbuffer.block_id = 9 : i32} : tensor<64x128xf32>
+        %49 = arith.addf %43, %arg20 {ssbuffer.block_id = 9 : i32} : tensor<64x128xf32>
+        %50 = arith.addf %45, %1 {ssbuffer.block_id = 9 : i32} : tensor<64x128xf32>
+        %reinterpret_cast_23 = memref.reinterpret_cast %arg6 to offset: [%47], sizes: [64, 128], strides: [128, 1] {ssbuffer.block_id = 9 : i32} : memref<?xf16> to memref<64x128xf16, strided<[128, 1], offset: ?>>
+        %51 = arith.truncf %50 {DataUse, ssbuffer.block_id = 9 : i32} : tensor<64x128xf32> to tensor<64x128xf16>
+        hivm.hir.store ins(%51 : tensor<64x128xf16>) outs(%reinterpret_cast_23 : memref<64x128xf16, strided<[128, 1], offset: ?>>) {ssbuffer.block_id = 9 : i32} atomic = <add>
+        hivm.hir.sync_block_set {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 5 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 6
+        hivm.hir.sync_block_set {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 6 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 7
+        hivm.hir.sync_block_set {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 7 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 8
+        scf.yield %49, %48 : tensor<64x128xf32>, tensor<64x128xf32>
+      } {DataUse, ssbuffer.block_id = 13 : i32, ssbuffer.main_loop = 0 : i32}
+      hivm.hir.sync_block_wait {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 2 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 3
+      hivm.hir.sync_block_wait {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+      hivm.hir.sync_block_wait {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+      %15 = arith.muli %5, %c128_i32 {ssbuffer.block_id = 11 : i32} : i32
+      %16 = arith.subi %arg18, %15 {ssbuffer.block_id = 11 : i32} : i32
+      %17 = arith.muli %16, %c64_i32 {ssbuffer.block_id = 11 : i32} : i32
+      %18 = arith.index_cast %17 {ssbuffer.block_id = 11 : i32} : i32 to index
+      %19 = arith.muli %18, %c128 {ssbuffer.block_id = 11 : i32} : index
+      %20 = arith.addi %12, %19 {ssbuffer.block_id = 11 : i32} : index
+      %reinterpret_cast = memref.reinterpret_cast %arg7 to offset: [%20], sizes: [64, 128], strides: [128, 1] {ssbuffer.block_id = 11 : i32} : memref<?xf16> to memref<64x128xf16, strided<[128, 1], offset: ?>>
+      %21 = arith.truncf %14#0 {DataUse, ssbuffer.block_id = 11 : i32} : tensor<64x128xf32> to tensor<64x128xf16>
+      bufferization.materialize_in_destination %21 in writable %reinterpret_cast {ssbuffer.block_id = 11 : i32} : (tensor<64x128xf16>, memref<64x128xf16, strided<[128, 1], offset: ?>>) -> ()
+      %reinterpret_cast_9 = memref.reinterpret_cast %arg8 to offset: [%20], sizes: [64, 128], strides: [128, 1] {ssbuffer.block_id = 11 : i32} : memref<?xf16> to memref<64x128xf16, strided<[128, 1], offset: ?>>
+      %22 = arith.truncf %14#1 {DataUse, ssbuffer.block_id = 11 : i32} : tensor<64x128xf32> to tensor<64x128xf16>
+      bufferization.materialize_in_destination %22 in writable %reinterpret_cast_9 {ssbuffer.block_id = 11 : i32} : (tensor<64x128xf16>, memref<64x128xf16, strided<[128, 1], offset: ?>>) -> ()
+    } {Undefined, ssbuffer.block_id = 14 : i32}
+    scope.return
+  } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+  return
+}
+
+// ============================================================================
+// Test Group B2: Complex multi-buffer - two gm_load_bufferable with inner
+// alloc + fill + copy pattern, block_id propagation through blocks 12/13/14
+//
+// Two marked loads share the same loop but use different buffer types:
+// - Load 1: memref<64x32xbf16> (alloc inside loop, fill + copy then read)
+// - Load 2: memref<64xf32> (alloc inside loop, fill + copy then read)
+//
+// Each gets 2 buffer slots (double buffer), 4 control iter_args each.
+// ============================================================================
+
+// CHECK-LABEL: func.func @_attn_bwd_complex
+func.func @_attn_bwd_complex(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xbf16>, %arg3: memref<?xbf16>, %arg4: memref<?xbf16>, %arg5: memref<?xbf16>, %arg6: memref<?xf32>, %arg7: memref<?xbf16>, %arg8: memref<?xf32>, %arg9: i32, %arg10: i32, %arg11: i32, %arg12: i32, %arg13: i32, %arg14: i32) {
+  %cst = arith.constant dense<[2, 4, 16, 16]> : tensor<4xi64>
+  %cst_0 = arith.constant dense<[64, 2, 16]> : tensor<3xi64>
+  %cst_1 = arith.constant 0.000000e+00 : f32
+  %cst_2 = arith.constant 0.000000e+00 : bf16
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c32_i32 = arith.constant 32 : i32
+  %c63_i32 = arith.constant 63 : i32
+  %c64_i32 = arith.constant 64 : i32
+  %c128_i64 = arith.constant 128 : i64
+  %c16384_i64 = arith.constant 16384 : i64
+  %c16384_i32 = arith.constant 16384 : i32
+  %c524288_i64 = arith.constant 524288 : i64
+  %c0 = arith.constant 0 : index
+  %c64 = arith.constant 64 : index
+  %c32 = arith.constant 32 : index
+  %c128 = arith.constant 128 : index
+  %c8192 = arith.constant 8192 : index
+  %c4096 = arith.constant 4096 : index
+
+  // R1: Each load gets 2 buffer slots (4 total: 2 bf16 + 2 f32)
+  // CHECK: memref.alloc() {ssbuffer.block_id = 12 : i32} : memref<64x32xbf16>
+  // CHECK: memref.alloc() {ssbuffer.block_id = 12 : i32} : memref<64x32xbf16>
+  // CHECK: memref.alloc() {ssbuffer.block_id = 12 : i32} : memref<64xf32>
+  // CHECK: memref.alloc() {ssbuffer.block_id = 12 : i32} : memref<64xf32>
+
+  // R1: 2 original iter_args + 8 control (4 per load) = 10 total
+  // CHECK: scf.for {{.*}} iter_args({{.*}}) -> (tensor<64x32xf32>, tensor<64x32xf32>, i1, i1, index, index, i1, i1, index, index)
+
+  scope.scope : () -> () {
+      %0 = tensor.empty() {ssbuffer.block_id = 15 : i32} : tensor<64x32xf32>
+      %1 = linalg.fill {ssbuffer.block_id = 15 : i32} ins(%cst_1 : f32) outs(%0 : tensor<64x32xf32>) -> tensor<64x32xf32>
+      %2 = tensor.empty() {ssbuffer.block_id = 15 : i32} : tensor<64xf32>
+      %3 = linalg.fill {ssbuffer.block_id = 15 : i32} ins(%cst_1 : f32) outs(%2 : tensor<64xf32>) -> tensor<64xf32>
+      %4 = arith.divsi %arg14, %c32_i32 {ssbuffer.block_id = 15 : i32} : i32
+      %5 = arith.remsi %arg14, %c32_i32 {ssbuffer.block_id = 15 : i32} : i32
+      %6 = arith.muli %4, %arg9 {ssbuffer.block_id = 15 : i32} : i32
+      %7 = arith.addi %arg9, %c63_i32 {ssbuffer.block_id = 15 : i32} : i32
+      %8 = arith.divsi %7, %c64_i32 {ssbuffer.block_id = 15 : i32} : i32
+      %9 = arith.muli %4, %8 {ssbuffer.block_id = 15 : i32} : i32
+      %10 = arith.muli %9, %c32_i32 {ssbuffer.block_id = 15 : i32} : i32
+      %11 = arith.addi %10, %5 {ssbuffer.block_id = 15 : i32} : i32
+      %12 = arith.extsi %11 {ssbuffer.block_id = 15 : i32} : i32 to i64
+      %13 = arith.muli %12, %c16384_i64 {ssbuffer.block_id = 15 : i32} : i64
+      %14 = arith.muli %6, %c32_i32 {ssbuffer.block_id = 15 : i32} : i32
+      %15 = arith.addi %14, %5 {ssbuffer.block_id = 15 : i32} : i32
+      %16 = arith.extsi %15 {ssbuffer.block_id = 15 : i32} : i32 to i64
+      %17 = arith.muli %16, %c128_i64 {ssbuffer.block_id = 15 : i32} : i64
+      %18 = arith.index_cast %17 {ssbuffer.block_id = 15 : i32} : i64 to index
+      %19 = arith.muli %arg13, %c32_i32 {ssbuffer.block_id = 15 : i32} : i32
+      %20 = arith.index_cast %15 {ssbuffer.block_id = 15 : i32} : i32 to index
+      %alloc = memref.alloc() {ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 0 : i32} : memref<2x4x16x16xbf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 0 : i32} : memref<2x4x16x16xbf16, #hivm.address_space<cbuf>>
+      %alloc_3 = memref.alloc() {ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 1 : i32} : memref<2x4x16x16xbf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_3 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 1 : i32} : memref<2x4x16x16xbf16, #hivm.address_space<cbuf>>
+      %alloc_4 = memref.alloc() {ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 2 : i32} : memref<2x4x16x16xbf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_4 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 2 : i32} : memref<2x4x16x16xbf16, #hivm.address_space<cbuf>>
+      %alloc_5 = memref.alloc() {ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 3 : i32} : memref<2x4x16x16xbf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_5 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<3>, ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 3 : i32} : memref<2x4x16x16xbf16, #hivm.address_space<cbuf>>
+      %alloc_6 = memref.alloc() {ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 4 : i32} : memref<64x32xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_6 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<4>, ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 4 : i32} : memref<64x32xf32, #hivm.address_space<ub>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 4 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 5
+      %alloc_7 = memref.alloc() {ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 5 : i32} : memref<64x32xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_7 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<5>, ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 5 : i32} : memref<64x32xf32, #hivm.address_space<ub>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 5 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 6
+      %alloc_8 = memref.alloc() {ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 6 : i32} : memref<64x32xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_8 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<6>, ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 6 : i32} : memref<64x32xf32, #hivm.address_space<ub>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 6 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 7
+      %alloc_9 = memref.alloc() {ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 7 : i32} : memref<64x32xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_9 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<7>, ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 7 : i32} : memref<64x32xf32, #hivm.address_space<ub>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 7 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 8
+      %21:2 = scf.for %arg16 = %c0_i32 to %8 step %c1_i32 iter_args(%arg17 = %1, %arg18 = %1) -> (tensor<64x32xf32>, tensor<64x32xf32>)  : i32 {
+        %57 = arith.extsi %arg16 {ssbuffer.block_id = 12 : i32} : i32 to i64
+        %58 = arith.muli %57, %c524288_i64 {ssbuffer.block_id = 12 : i32} : i64
+        %59 = arith.addi %13, %58 {ssbuffer.block_id = 12 : i32} : i64
+        %60 = arith.index_cast %59 {ssbuffer.block_id = 12 : i32} : i64 to index
+        %61 = arith.maxsi %19, %c0_i32 {ssbuffer.block_id = 12 : i32} : i32
+        %62 = arith.index_cast %61 {ssbuffer.block_id = 12 : i32} : i32 to index
+        %63 = arith.addi %60, %62 {ssbuffer.block_id = 12 : i32} : index
+        %reinterpret_cast_13 = memref.reinterpret_cast %arg7 to offset: [%63], sizes: [64, 32], strides: [128, 1] {ssbuffer.block_id = 12 : i32} : memref<?xbf16> to memref<64x32xbf16, strided<[128, 1], offset: ?>>
+        %64 = arith.truncf %arg17 {DataUse, ssbuffer.block_id = 12 : i32} : tensor<64x32xf32> to tensor<64x32xbf16>
+        %reshape = tensor.reshape %64(%cst_0) {ssbuffer.block_id = 12 : i32} : (tensor<64x32xbf16>, tensor<3xi64>) -> tensor<64x2x16xbf16>
+        %65 = tensor.empty() {ssbuffer.block_id = 12 : i32} : tensor<2x64x16xbf16>
+        %transposed = linalg.transpose ins(%reshape : tensor<64x2x16xbf16>) outs(%65 : tensor<2x64x16xbf16>) permutation = [1, 0, 2]  {ssbuffer.block_id = 12 : i32}
+        %reshape_14 = tensor.reshape %transposed(%cst) {ssbuffer.block_id = 12 : i32} : (tensor<2x64x16xbf16>, tensor<4xi64>) -> tensor<2x4x16x16xbf16>
+        %66 = arith.divsi %62, %c128 {ssbuffer.block_id = 12 : i32} : index
+        %67 = arith.subi %c128, %66 {ssbuffer.block_id = 12 : i32} : index
+        %68 = arith.maxsi %67, %c0 {ssbuffer.block_id = 12 : i32} : index
+        %69 = arith.minsi %68, %c64 {ssbuffer.block_id = 12 : i32} : index
+        %70 = arith.remsi %62, %c128 {ssbuffer.block_id = 12 : i32} : index
+        %71 = arith.subi %c128, %70 {ssbuffer.block_id = 12 : i32} : index
+        %72 = arith.maxsi %71, %c0 {ssbuffer.block_id = 12 : i32} : index
+        %73 = arith.minsi %72, %c32 {ssbuffer.block_id = 12 : i32} : index
+        %74 = arith.minsi %69, %c0 {ssbuffer.block_id = 12 : i32} : index
+        %75 = arith.subi %69, %74 {ssbuffer.block_id = 12 : i32} : index
+        %76 = arith.subi %c0_i32, %19 {ssbuffer.block_id = 12 : i32} : i32
+        %77 = arith.maxsi %76, %c0_i32 {ssbuffer.block_id = 12 : i32} : i32
+        %78 = arith.index_cast %77 {ssbuffer.block_id = 12 : i32} : i32 to index
+        %79 = arith.minsi %78, %73 {ssbuffer.block_id = 12 : i32} : index
+        %80 = arith.subi %73, %79 {ssbuffer.block_id = 12 : i32} : index
+        %extracted_slice_15 = tensor.extract_slice %64[%74, %79] [%75, %80] [1, 1] {ssbuffer.block_id = 12 : i32} : tensor<64x32xbf16> to tensor<?x?xbf16>
+        %subview_16 = memref.subview %reinterpret_cast_13[0, 0] [%75, %80] [1, 1] {ssbuffer.block_id = 12 : i32} : memref<64x32xbf16, strided<[128, 1], offset: ?>> to memref<?x?xbf16, strided<[128, 1], offset: ?>>
+        bufferization.materialize_in_destination %extracted_slice_15 in writable %subview_16 {ssbuffer.block_id = 12 : i32} : (tensor<?x?xbf16>, memref<?x?xbf16, strided<[128, 1], offset: ?>>) -> ()
+        %81 = arith.addi %60, %c8192 {ssbuffer.block_id = 12 : i32} : index
+        %82 = arith.addi %81, %62 {ssbuffer.block_id = 12 : i32} : index
+        %reinterpret_cast_17 = memref.reinterpret_cast %arg7 to offset: [%82], sizes: [64, 32], strides: [128, 1] {ssbuffer.block_id = 12 : i32} : memref<?xbf16> to memref<64x32xbf16, strided<[128, 1], offset: ?>>
+        %83 = arith.truncf %arg18 {DataUse, ssbuffer.block_id = 12 : i32} : tensor<64x32xf32> to tensor<64x32xbf16>
+        %reshape_18 = tensor.reshape %83(%cst_0) {ssbuffer.block_id = 12 : i32} : (tensor<64x32xbf16>, tensor<3xi64>) -> tensor<64x2x16xbf16>
+        %84 = tensor.empty() {ssbuffer.block_id = 12 : i32} : tensor<2x64x16xbf16>
+        %transposed_19 = linalg.transpose ins(%reshape_18 : tensor<64x2x16xbf16>) outs(%84 : tensor<2x64x16xbf16>) permutation = [1, 0, 2]  {ssbuffer.block_id = 12 : i32}
+        %reshape_20 = tensor.reshape %transposed_19(%cst) {ssbuffer.block_id = 12 : i32} : (tensor<2x64x16xbf16>, tensor<4xi64>) -> tensor<2x4x16x16xbf16>
+        %85 = arith.subi %82, %60 {ssbuffer.block_id = 12 : i32} : index
+        %86 = arith.divsi %85, %c128 {ssbuffer.block_id = 12 : i32} : index
+        %87 = arith.subi %c128, %86 {ssbuffer.block_id = 12 : i32} : index
+        %88 = arith.maxsi %87, %c0 {ssbuffer.block_id = 12 : i32} : index
+        %89 = arith.minsi %88, %c64 {ssbuffer.block_id = 12 : i32} : index
+        %90 = arith.remsi %85, %c128 {ssbuffer.block_id = 12 : i32} : index
+        %91 = arith.subi %c128, %90 {ssbuffer.block_id = 12 : i32} : index
+        %92 = arith.maxsi %91, %c0 {ssbuffer.block_id = 12 : i32} : index
+        %93 = arith.minsi %92, %c32 {ssbuffer.block_id = 12 : i32} : index
+        %94 = arith.minsi %89, %c0 {ssbuffer.block_id = 12 : i32} : index
+        %95 = arith.subi %89, %94 {ssbuffer.block_id = 12 : i32} : index
+        %96 = arith.minsi %78, %93 {ssbuffer.block_id = 12 : i32} : index
+        %97 = arith.subi %93, %96 {ssbuffer.block_id = 12 : i32} : index
+        %extracted_slice_21 = tensor.extract_slice %83[%94, %96] [%95, %97] [1, 1] {ssbuffer.block_id = 12 : i32} : tensor<64x32xbf16> to tensor<?x?xbf16>
+        %subview_22 = memref.subview %reinterpret_cast_17[0, 0] [%95, %97] [1, 1] {ssbuffer.block_id = 12 : i32} : memref<64x32xbf16, strided<[128, 1], offset: ?>> to memref<?x?xbf16, strided<[128, 1], offset: ?>>
+        bufferization.materialize_in_destination %extracted_slice_21 in writable %subview_22 {ssbuffer.block_id = 12 : i32} : (tensor<?x?xbf16>, memref<?x?xbf16, strided<[128, 1], offset: ?>>) -> ()
+        %98 = arith.muli %arg16, %c64_i32 {MixUse, ssbuffer.block_id = 12 : i32} : i32
+        %99 = arith.maxsi %98, %c0_i32 {ssbuffer.block_id = 12 : i32} : i32
+        %100 = arith.index_cast %99 {ssbuffer.block_id = 12 : i32} : i32 to index
+        %101 = arith.muli %100, %c4096 {ssbuffer.block_id = 12 : i32} : index
+        %102 = arith.addi %101, %18 {ssbuffer.block_id = 12 : i32} : index
+        %103 = arith.index_cast %arg9 {ssbuffer.block_id = 12 : i32} : i32 to index
+        %104 = arith.subi %c0_i32, %98 {ssbuffer.block_id = 12 : i32} : i32
+        %105 = arith.maxsi %104, %c0_i32 {ssbuffer.block_id = 12 : i32} : i32
+        %106 = arith.index_cast %105 {ssbuffer.block_id = 12 : i32} : i32 to index
+        %107 = arith.addi %102, %62 {ssbuffer.block_id = 12 : i32} : index
+        %alloc_23 = memref.alloc() {ssbuffer.block_id = 12 : i32} : memref<64x32xbf16>
+        %108 = arith.subi %107, %18 {ssbuffer.block_id = 12 : i32} : index
+        %109 = arith.divsi %108, %c4096 {ssbuffer.block_id = 12 : i32} : index
+        %110 = arith.subi %103, %109 {ssbuffer.block_id = 12 : i32} : index
+        %111 = arith.maxsi %110, %c0 {ssbuffer.block_id = 12 : i32} : index
+        %112 = arith.minsi %111, %c64 {ssbuffer.block_id = 12 : i32} : index
+        %113 = arith.remsi %108, %c4096 {ssbuffer.block_id = 12 : i32} : index
+        %114 = arith.subi %c128, %113 {ssbuffer.block_id = 12 : i32} : index
+        %115 = arith.maxsi %114, %c0 {ssbuffer.block_id = 12 : i32} : index
+        %116 = arith.minsi %115, %c32 {ssbuffer.block_id = 12 : i32} : index
+        %117 = arith.minsi %106, %112 {ssbuffer.block_id = 12 : i32} : index
+        %118 = arith.subi %112, %117 {ssbuffer.block_id = 12 : i32} : index
+        %119 = arith.minsi %78, %116 {ssbuffer.block_id = 12 : i32} : index
+        %120 = arith.subi %116, %119 {ssbuffer.block_id = 12 : i32} : index
+        %121 = arith.cmpi slt, %118, %c64 {ssbuffer.block_id = 12 : i32} : index
+        %122 = arith.cmpi slt, %120, %c32 {ssbuffer.block_id = 12 : i32} : index
+        %123 = arith.ori %121, %122 {ssbuffer.block_id = 12 : i32} : i1
+        %124 = arith.muli %100, %c32 {ssbuffer.block_id = 12 : i32} : index
+        %alloc_24 = memref.alloc() {ssbuffer.block_id = 12 : i32} : memref<64xf32>
+        %125 = arith.divsi %124, %c32 {ssbuffer.block_id = 12 : i32} : index
+        %126 = arith.subi %103, %125 {ssbuffer.block_id = 12 : i32} : index
+        %127 = arith.maxsi %126, %c0 {ssbuffer.block_id = 12 : i32} : index
+        %128 = arith.minsi %127, %c64 {ssbuffer.block_id = 12 : i32} : index
+        %129 = arith.minsi %106, %128 {ssbuffer.block_id = 12 : i32} : index
+        %130 = arith.subi %128, %129 {ssbuffer.block_id = 12 : i32} : index
+        %131 = arith.cmpi slt, %130, %c64 {ssbuffer.block_id = 12 : i32} : index
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 12 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+        hivm.hir.copy ins(%reshape_14 : tensor<2x4x16x16xbf16>) outs(%alloc_3 : memref<2x4x16x16xbf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 12 : i32, ssbuffer.transfer_id = 1 : i32}
+        hivm.hir.sync_block_set {ssbuffer.block_id = 12 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 12 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 4
+        hivm.hir.copy ins(%reshape_20 : tensor<2x4x16x16xbf16>) outs(%alloc_5 : memref<2x4x16x16xbf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 12 : i32, ssbuffer.transfer_id = 3 : i32}
+        hivm.hir.sync_block_set {ssbuffer.block_id = 12 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 4
+        scf.if %131 {
+          linalg.fill {ssbuffer.block_id = 11 : i32} ins(%cst_1 : f32) outs(%alloc_24 : memref<64xf32>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 19 : i32}
+        scf.if %123 {
+          linalg.fill {ssbuffer.block_id = 10 : i32} ins(%cst_2 : bf16) outs(%alloc_23 : memref<64x32xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 20 : i32}
+
+        // ── Producer: Load 1 (bf16) ──────────────────────────────────
+        // R2: First producer slot for bf16 load
+        // CHECK: scf.if {{.*}} -> (i1, index) {
+        // CHECK: memref.copy {{.*}} {ssbuffer.block_id = 13
+        // CHECK: } {ssbuffer.block_id = 13 : i32, ssbuffer.load_store}
+
+        // R2: Second producer slot for bf16 load
+        // CHECK: scf.if {{.*}} -> (i1, index) {
+        // CHECK: memref.copy {{.*}} {ssbuffer.block_id = 13
+        // CHECK: } {ssbuffer.block_id = 13 : i32, ssbuffer.load_store}
+
+        // R2: Load 1 consumer select (bf16)
+        // CHECK: arith.remui {{.*}} {ssbuffer.block_id = 13
+        // CHECK: bufferization.to_tensor {{.*}} {ssbuffer.block_id = 13
+        // CHECK: bufferization.to_tensor {{.*}} {ssbuffer.block_id = 13
+        // CHECK: arith.select {{.*}} {ssbuffer.block_id = 13
+
+        // R2: Load 1 flag clear (now before compute)
+        // CHECK: scf.if {{.*}} -> (i1) {
+        // CHECK: } {ssbuffer.block_id = 13 : i32, ssbuffer.load_store}
+        // CHECK: scf.if {{.*}} -> (i1) {
+        // CHECK: } {ssbuffer.block_id = 13 : i32, ssbuffer.load_store}
+
+        // ── Producer: Load 2 (f32) ───────────────────────────────────
+        // R3: First producer slot for f32 load
+        // CHECK: scf.if {{.*}} -> (i1, index) {
+        // CHECK: memref.copy {{.*}} {ssbuffer.block_id = 13
+        // CHECK: } {ssbuffer.block_id = 13 : i32, ssbuffer.load_store}
+
+        // R3: Second producer slot for f32 load
+        // CHECK: scf.if {{.*}} -> (i1, index) {
+        // CHECK: memref.copy {{.*}} {ssbuffer.block_id = 13
+        // CHECK: } {ssbuffer.block_id = 13 : i32, ssbuffer.load_store}
+
+        // R3: Load 2 consumer select (f32)
+        // CHECK: arith.remui {{.*}} {ssbuffer.block_id = 13
+        // CHECK: bufferization.to_tensor {{.*}} {ssbuffer.block_id = 13
+        // CHECK: bufferization.to_tensor {{.*}} {ssbuffer.block_id = 13
+        // CHECK: arith.select {{.*}} {ssbuffer.block_id = 13
+
+        // R3: Load 2 flag clear (now before compute)
+        // CHECK: scf.if {{.*}} -> (i1) {
+        // CHECK: } {ssbuffer.block_id = 13 : i32, ssbuffer.load_store}
+        // CHECK: scf.if {{.*}} -> (i1) {
+        // CHECK: } {ssbuffer.block_id = 13 : i32, ssbuffer.load_store}
+
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 7 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 8
+        %memspacecast = memref.memory_space_cast %alloc_9 {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 7 : i32} : memref<64x32xf32, #hivm.address_space<ub>> to memref<64x32xf32>
+        %132 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 7 : i32} : memref<64x32xf32> to tensor<64x32xf32>
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 5 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 6
+        %memspacecast_25 = memref.memory_space_cast %alloc_7 {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 5 : i32} : memref<64x32xf32, #hivm.address_space<ub>> to memref<64x32xf32>
+        %133 = bufferization.to_tensor %memspacecast_25 restrict writable {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 5 : i32} : memref<64x32xf32> to tensor<64x32xf32>
+        %134 = arith.addf %133, %1 {ssbuffer.block_id = 13 : i32} : tensor<64x32xf32>
+        %135 = arith.addf %132, %134 {ssbuffer.block_id = 13 : i32} : tensor<64x32xf32>
+        %reinterpret_cast_26 = memref.reinterpret_cast %arg3 to offset: [%107], sizes: [64, 32], strides: [4096, 1] {ssbuffer.block_id = 13 : i32} : memref<?xbf16> to memref<64x32xbf16, strided<[4096, 1], offset: ?>>
+        %subview_27 = memref.subview %reinterpret_cast_26[0, 0] [%118, %120] [1, 1] {ssbuffer.block_id = 13 : i32} : memref<64x32xbf16, strided<[4096, 1], offset: ?>> to memref<?x?xbf16, strided<[4096, 1], offset: ?>>
+        %subview_28 = memref.subview %alloc_23[%117, %119] [%118, %120] [1, 1] {ssbuffer.block_id = 13 : i32} : memref<64x32xbf16> to memref<?x?xbf16, strided<[32, 1], offset: ?>>
+        memref.copy %subview_27, %subview_28 {ssbuffer.block_id = 13 : i32} : memref<?x?xbf16, strided<[4096, 1], offset: ?>> to memref<?x?xbf16, strided<[32, 1], offset: ?>>
+        %136 = bufferization.to_tensor %alloc_23 restrict writable {gm_load_bufferable, ssbuffer.block_id = 13 : i32} : memref<64x32xbf16> to tensor<64x32xbf16>
+        %137 = arith.extf %136 {DataUse, ssbuffer.block_id = 13 : i32} : tensor<64x32xbf16> to tensor<64x32xf32>
+        %138 = arith.subf %137, %135 {DataUse, ssbuffer.block_id = 13 : i32} : tensor<64x32xf32>
+        %reinterpret_cast_29 = memref.reinterpret_cast %arg5 to offset: [%107], sizes: [64, 32], strides: [4096, 1] {ssbuffer.block_id = 13 : i32} : memref<?xbf16> to memref<64x32xbf16, strided<[4096, 1], offset: ?>>
+        %139 = arith.truncf %138 {DataUse, ssbuffer.block_id = 13 : i32} : tensor<64x32xf32> to tensor<64x32xbf16>
+        %extracted_slice_30 = tensor.extract_slice %139[%117, %119] [%118, %120] [1, 1] {ssbuffer.block_id = 13 : i32} : tensor<64x32xbf16> to tensor<?x?xbf16>
+        %subview_31 = memref.subview %reinterpret_cast_29[0, 0] [%118, %120] [1, 1] {ssbuffer.block_id = 13 : i32} : memref<64x32xbf16, strided<[4096, 1], offset: ?>> to memref<?x?xbf16, strided<[4096, 1], offset: ?>>
+        bufferization.materialize_in_destination %extracted_slice_30 in writable %subview_31 {ssbuffer.block_id = 13 : i32} : (tensor<?x?xbf16>, memref<?x?xbf16, strided<[4096, 1], offset: ?>>) -> ()
+        %140 = arith.addi %arg16, %c1_i32 {ssbuffer.block_id = 13 : i32} : i32
+        %141 = arith.muli %140, %c64_i32 {ssbuffer.block_id = 13 : i32} : i32
+        %142 = arith.minsi %141, %arg9 {ssbuffer.block_id = 13 : i32} : i32
+        %143 = arith.subi %142, %c1_i32 {ssbuffer.block_id = 13 : i32} : i32
+        %144 = arith.muli %143, %c32_i32 {ssbuffer.block_id = 13 : i32} : i32
+        %145 = arith.addi %14, %144 {ssbuffer.block_id = 13 : i32} : i32
+        %146 = arith.addi %145, %5 {ssbuffer.block_id = 13 : i32} : i32
+        %147 = arith.index_cast %146 {ssbuffer.block_id = 13 : i32} : i32 to index
+        %reinterpret_cast_32 = memref.reinterpret_cast %arg6 to offset: [%147], sizes: [1], strides: [1] {ssbuffer.block_id = 13 : i32} : memref<?xf32> to memref<1xf32, strided<[1], offset: ?>>
+        %148 = memref.load %reinterpret_cast_32[%c0] {ssbuffer.block_id = 13 : i32} : memref<1xf32, strided<[1], offset: ?>>
+        %149 = arith.addi %124, %20 {ssbuffer.block_id = 13 : i32} : index
+        %reinterpret_cast_33 = memref.reinterpret_cast %arg6 to offset: [%149], sizes: [64], strides: [32] {ssbuffer.block_id = 13 : i32} : memref<?xf32> to memref<64xf32, strided<[32], offset: ?>>
+        %subview_34 = memref.subview %reinterpret_cast_33[0] [%130] [1] {ssbuffer.block_id = 13 : i32} : memref<64xf32, strided<[32], offset: ?>> to memref<?xf32, strided<[32], offset: ?>>
+        %subview_35 = memref.subview %alloc_24[%129] [%130] [1] {ssbuffer.block_id = 13 : i32} : memref<64xf32> to memref<?xf32, strided<[1], offset: ?>>
+        memref.copy %subview_34, %subview_35 {ssbuffer.block_id = 13 : i32} : memref<?xf32, strided<[32], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+        %150 = bufferization.to_tensor %alloc_24 restrict writable {gm_load_bufferable, ssbuffer.block_id = 13 : i32} : memref<64xf32> to tensor<64xf32>
+        %151 = linalg.fill {ssbuffer.block_id = 13 : i32} ins(%148 : f32) outs(%2 : tensor<64xf32>) -> tensor<64xf32>
+        %152 = arith.subf %151, %150 {DataUse, ssbuffer.block_id = 13 : i32} : tensor<64xf32>
+        %153 = math.exp2 %152 {DataUse, ssbuffer.block_id = 13 : i32} : tensor<64xf32>
+        %154 = arith.index_cast %98 {DataUse, ssbuffer.block_id = 13 : i32} : i32 to index
+        %155 = arith.addi %154, %c64 {DataUse, ssbuffer.block_id = 13 : i32} : index
+        %156 = arith.index_cast %arg9 {DataUse, ssbuffer.block_id = 13 : i32} : i32 to index
+        %157 = arith.maxsi %154, %156 {DataUse, ssbuffer.block_id = 13 : i32} : index
+        %158 = arith.minsi %155, %157 {DataUse, ssbuffer.block_id = 13 : i32} : index
+        %159 = arith.subi %158, %154 {DataUse, ssbuffer.block_id = 13 : i32} : index
+        %extracted_slice_36 = tensor.extract_slice %153[0] [%159] [1] {DataUse, ssbuffer.block_id = 13 : i32} : tensor<64xf32> to tensor<?xf32>
+        %inserted_slice = tensor.insert_slice %extracted_slice_36 into %3[0] [%159] [1] {DataUse, ssbuffer.block_id = 13 : i32} : tensor<?xf32> into tensor<64xf32>
+        %broadcasted = linalg.broadcast ins(%inserted_slice : tensor<64xf32>) outs(%0 : tensor<64x32xf32>) dimensions = [1]  {ssbuffer.block_id = 13 : i32}
+        %160 = arith.mulf %138, %broadcasted {DataUse, ssbuffer.block_id = 13 : i32} : tensor<64x32xf32>
+        %161 = arith.truncf %160 {DataUse, ssbuffer.block_id = 13 : i32} : tensor<64x32xf32> to tensor<64x32xbf16>
+        %reshape_37 = tensor.reshape %161(%cst_0) {ssbuffer.block_id = 13 : i32} : (tensor<64x32xbf16>, tensor<3xi64>) -> tensor<64x2x16xbf16>
+        %162 = tensor.empty() {ssbuffer.block_id = 13 : i32} : tensor<2x64x16xbf16>
+        %transposed_38 = linalg.transpose ins(%reshape_37 : tensor<64x2x16xbf16>) outs(%162 : tensor<2x64x16xbf16>) permutation = [1, 0, 2]  {ssbuffer.block_id = 13 : i32}
+        %reshape_39 = tensor.reshape %transposed_38(%cst) {ssbuffer.block_id = 13 : i32} : (tensor<2x64x16xbf16>, tensor<4xi64>) -> tensor<2x4x16x16xbf16>
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+        hivm.hir.copy ins(%reshape_39 : tensor<2x4x16x16xbf16>) outs(%alloc : memref<2x4x16x16xbf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 0 : i32}
+        hivm.hir.sync_block_set {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 2 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 3
+        hivm.hir.copy ins(%reshape_39 : tensor<2x4x16x16xbf16>) outs(%alloc_4 : memref<2x4x16x16xbf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 2 : i32}
+        hivm.hir.sync_block_set {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 2 : i32}[<VECTOR>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 3
+        hivm.hir.sync_block_set {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 5 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 6
+        hivm.hir.sync_block_set {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 7 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 8
+
+        // R6: Block 14 compute
+        // CHECK: hivm.hir.sync_block_wait {{.*ssbuffer.block_id = 14}}
+        // CHECK: arith.mulf {{.*ssbuffer.block_id = 14}}
+        // CHECK: arith.addf {{.*ssbuffer.block_id = 14}}
+
+        // R7: scf.yield with 10 values
+        // CHECK: scf.yield {{.*}} : tensor<64x32xf32>, tensor<64x32xf32>, i1, i1, index, index, i1, i1, index, index
+
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 6 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 7
+        %memspacecast_40 = memref.memory_space_cast %alloc_8 {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 6 : i32} : memref<64x32xf32, #hivm.address_space<ub>> to memref<64x32xf32>
+        %163 = bufferization.to_tensor %memspacecast_40 restrict writable {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 6 : i32} : memref<64x32xf32> to tensor<64x32xf32>
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 4 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 5
+        %memspacecast_41 = memref.memory_space_cast %alloc_6 {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 4 : i32} : memref<64x32xf32, #hivm.address_space<ub>> to memref<64x32xf32>
+        %164 = bufferization.to_tensor %memspacecast_41 restrict writable {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 4 : i32} : memref<64x32xf32> to tensor<64x32xf32>
+        %165 = tensor.empty() {ssbuffer.block_id = 14 : i32} : tensor<1xf32>
+        %inserted = tensor.insert %148 into %165[%c0] {ssbuffer.block_id = 14 : i32} : tensor<1xf32>
+        %166 = math.exp2 %inserted {DataUse, ssbuffer.block_id = 14 : i32} : tensor<1xf32>
+        %extracted = tensor.extract %166[%c0] {DataUse, ssbuffer.block_id = 14 : i32} : tensor<1xf32>
+        %167 = linalg.fill {ssbuffer.block_id = 14 : i32} ins(%extracted : f32) outs(%0 : tensor<64x32xf32>) -> tensor<64x32xf32>
+        %168 = arith.mulf %arg17, %167 {DataUse, ssbuffer.block_id = 14 : i32} : tensor<64x32xf32>
+        %169 = arith.mulf %arg18, %167 {DataUse, ssbuffer.block_id = 14 : i32} : tensor<64x32xf32>
+        %170 = arith.addf %163, %168 {ssbuffer.block_id = 14 : i32} : tensor<64x32xf32>
+        %171 = arith.addf %164, %169 {ssbuffer.block_id = 14 : i32} : tensor<64x32xf32>
+        hivm.hir.sync_block_set {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 4 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 5
+        hivm.hir.sync_block_set {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 6 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 7
+        scf.yield %170, %171 : tensor<64x32xf32>, tensor<64x32xf32>
+      } {DataUse, ssbuffer.block_id = 23 : i32, ssbuffer.main_loop = 0 : i32}
+      hivm.hir.sync_block_wait {ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 4
+      hivm.hir.sync_block_wait {ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 2 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 3
+      hivm.hir.sync_block_wait {ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+      hivm.hir.sync_block_wait {ssbuffer.block_id = 23 : i32, ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+      %22 = arith.muli %arg14, %c16384_i32 {ssbuffer.block_id = 16 : i32} : i32
+      %23 = arith.index_cast %22 {ssbuffer.block_id = 16 : i32} : i32 to index
+      %24 = arith.maxsi %19, %c0_i32 {ssbuffer.block_id = 16 : i32} : i32
+      %25 = arith.index_cast %24 {ssbuffer.block_id = 16 : i32} : i32 to index
+      %26 = arith.addi %23, %25 {ssbuffer.block_id = 16 : i32} : index
+      %reinterpret_cast = memref.reinterpret_cast %arg8 to offset: [%26], sizes: [64, 32], strides: [128, 1] {ssbuffer.block_id = 16 : i32} : memref<?xf32> to memref<64x32xf32, strided<[128, 1], offset: ?>>
+      %27 = arith.divsi %25, %c128 {ssbuffer.block_id = 16 : i32} : index
+      %28 = arith.subi %c128, %27 {ssbuffer.block_id = 16 : i32} : index
+      %29 = arith.maxsi %28, %c0 {ssbuffer.block_id = 16 : i32} : index
+      %30 = arith.minsi %29, %c64 {ssbuffer.block_id = 16 : i32} : index
+      %31 = arith.remsi %25, %c128 {ssbuffer.block_id = 16 : i32} : index
+      %32 = arith.subi %c128, %31 {ssbuffer.block_id = 16 : i32} : index
+      %33 = arith.maxsi %32, %c0 {ssbuffer.block_id = 16 : i32} : index
+      %34 = arith.minsi %33, %c32 {ssbuffer.block_id = 16 : i32} : index
+      %35 = arith.minsi %30, %c0 {ssbuffer.block_id = 16 : i32} : index
+      %36 = arith.subi %30, %35 {ssbuffer.block_id = 16 : i32} : index
+      %37 = arith.subi %c0_i32, %19 {ssbuffer.block_id = 16 : i32} : i32
+      %38 = arith.maxsi %37, %c0_i32 {ssbuffer.block_id = 16 : i32} : i32
+      %39 = arith.index_cast %38 {ssbuffer.block_id = 16 : i32} : i32 to index
+      %40 = arith.minsi %39, %34 {ssbuffer.block_id = 16 : i32} : index
+      %41 = arith.subi %34, %40 {ssbuffer.block_id = 16 : i32} : index
+      %extracted_slice = tensor.extract_slice %21#0[%35, %40] [%36, %41] [1, 1] {ssbuffer.block_id = 16 : i32} : tensor<64x32xf32> to tensor<?x?xf32>
+      %subview = memref.subview %reinterpret_cast[0, 0] [%36, %41] [1, 1] {ssbuffer.block_id = 16 : i32} : memref<64x32xf32, strided<[128, 1], offset: ?>> to memref<?x?xf32, strided<[128, 1], offset: ?>>
+      bufferization.materialize_in_destination %extracted_slice in writable %subview {ssbuffer.block_id = 16 : i32} : (tensor<?x?xf32>, memref<?x?xf32, strided<[128, 1], offset: ?>>) -> ()
+      %42 = arith.addi %23, %c8192 {ssbuffer.block_id = 16 : i32} : index
+      %43 = arith.addi %42, %25 {ssbuffer.block_id = 16 : i32} : index
+      %reinterpret_cast_10 = memref.reinterpret_cast %arg8 to offset: [%43], sizes: [64, 32], strides: [128, 1] {ssbuffer.block_id = 16 : i32} : memref<?xf32> to memref<64x32xf32, strided<[128, 1], offset: ?>>
+      %44 = arith.subi %43, %23 {ssbuffer.block_id = 16 : i32} : index
+      %45 = arith.divsi %44, %c128 {ssbuffer.block_id = 16 : i32} : index
+      %46 = arith.subi %c128, %45 {ssbuffer.block_id = 16 : i32} : index
+      %47 = arith.maxsi %46, %c0 {ssbuffer.block_id = 16 : i32} : index
+      %48 = arith.minsi %47, %c64 {ssbuffer.block_id = 16 : i32} : index
+      %49 = arith.remsi %44, %c128 {ssbuffer.block_id = 16 : i32} : index
+      %50 = arith.subi %c128, %49 {ssbuffer.block_id = 16 : i32} : index
+      %51 = arith.maxsi %50, %c0 {ssbuffer.block_id = 16 : i32} : index
+      %52 = arith.minsi %51, %c32 {ssbuffer.block_id = 16 : i32} : index
+      %53 = arith.minsi %48, %c0 {ssbuffer.block_id = 16 : i32} : index
+      %54 = arith.subi %48, %53 {ssbuffer.block_id = 16 : i32} : index
+      %55 = arith.minsi %39, %52 {ssbuffer.block_id = 16 : i32} : index
+      %56 = arith.subi %52, %55 {ssbuffer.block_id = 16 : i32} : index
+      %extracted_slice_11 = tensor.extract_slice %21#1[%53, %55] [%54, %56] [1, 1] {ssbuffer.block_id = 16 : i32} : tensor<64x32xf32> to tensor<?x?xf32>
+      %subview_12 = memref.subview %reinterpret_cast_10[0, 0] [%54, %56] [1, 1] {ssbuffer.block_id = 16 : i32} : memref<64x32xf32, strided<[128, 1], offset: ?>> to memref<?x?xf32, strided<[128, 1], offset: ?>>
+      bufferization.materialize_in_destination %extracted_slice_11 in writable %subview_12 {ssbuffer.block_id = 16 : i32} : (tensor<?x?xf32>, memref<?x?xf32, strided<[128, 1], offset: ?>>) -> ()
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+  return
+}
+
+// ============================================================================
+// Test Group B3: attn_fwd - mixed VECTOR + CUBE scopes, 3 gm_load_bufferable
+//
+// Scope 1 (VECTOR): No gm_load_bufferable - should remain unchanged.
+// Scope 2 (CUBE): 3 marked loads across outer+inner loops:
+//   - Load A (outer loop, block_id=2): memref<128x128xf16> → double-buffered
+//   - Load B (inner loop, block_id=0): memref<128x128xf16> → double-buffered
+//   - Load C (inner loop, block_id=1): memref<128x128xf16> → double-buffered
+//
+// Outer loop gets 4 control iter_args (for Load A).
+// Inner loop gets 8 control iter_args (4 for Load B + 4 for Load C).
+// ============================================================================
+
+// CHECK-LABEL: func.func @_attn_fwd
+func.func @_attn_fwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg3: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg4: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg5: memref<?xf32> {tt.divisibility = 16 : i32}, %arg6: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg7: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg8: memref<?xi32> {tt.divisibility = 16 : i32}, %arg9: i32, %arg10: i32, %arg11: i32, %arg12: i32, %arg13: i32, %arg14: i32, %arg15: i32) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %cst = arith.constant {ssbuffer.block_id = 5 : i32} dense<[8, 8, 16, 16]> : tensor<4xi64>
+    %cst_0 = arith.constant {ssbuffer.block_id = 5 : i32} dense<[128, 8, 16]> : tensor<3xi64>
+    %cst_1 = arith.constant {ssbuffer.block_id = 10 : i32} 0.000000e+00 : f32
+    %c28_i32 = arith.constant {ssbuffer.block_id = 10 : i32} 28 : i32
+    %c65536_i32 = arith.constant {ssbuffer.block_id = 10 : i32} 65536 : i32
+    %c8192_i32 = arith.constant {ssbuffer.block_id = 10 : i32} 8192 : i32
+    %c128_i32 = arith.constant {ssbuffer.block_id = 10 : i32} 128 : i32
+    %c1048576_i64 = arith.constant {ssbuffer.block_id = 10 : i32} 1048576 : i64
+    %c8388608_i64 = arith.constant {ssbuffer.block_id = 10 : i32} 8388608 : i64
+    %c8_i32 = arith.constant {ssbuffer.block_id = 10 : i32} 8 : i32
+    %c64_i32 = arith.constant {ssbuffer.block_id = 10 : i32} 64 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 10 : i32} 0 : i32
+    %cst_2 = arith.constant {ssbuffer.block_id = 10 : i32} 5.000000e-01 : f32
+    %cst_3 = arith.constant {ssbuffer.block_id = 10 : i32} 0xFF800000 : f32
+    %cst_4 = arith.constant {ssbuffer.block_id = 10 : i32} 1.000000e+00 : f32
+    %c128 = arith.constant {ssbuffer.block_id = 10 : i32} 128 : index
+
+    // ── Scope 1 (VECTOR): no gm_load_bufferable → unchanged ─────────
+
+    scope.scope : () -> () {
+      %0 = tensor.empty() {ssbuffer.block_id = 10 : i32} : tensor<128x128xf32>
+      %1 = linalg.fill {ssbuffer.block_id = 10 : i32} ins(%cst_1 : f32) outs(%0 : tensor<128x128xf32>) -> tensor<128x128xf32>
+      %2 = linalg.fill {ssbuffer.block_id = 10 : i32} ins(%cst_2 : f32) outs(%0 : tensor<128x128xf32>) -> tensor<128x128xf32>
+      %3 = tensor.empty() {ssbuffer.block_id = 10 : i32} : tensor<128xf32>
+      %4 = linalg.fill {ssbuffer.block_id = 10 : i32} ins(%cst_3 : f32) outs(%3 : tensor<128xf32>) -> tensor<128xf32>
+      %5 = linalg.fill {ssbuffer.block_id = 10 : i32} ins(%cst_4 : f32) outs(%3 : tensor<128xf32>) -> tensor<128xf32>
+      scf.for %arg16 = %arg13 to %c65536_i32 step %c28_i32  : i32 {
+        %alloc = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+        annotation.mark %alloc {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+        %alloc_5 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+        annotation.mark %alloc_5 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+        hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 2
+        %alloc_6 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+        annotation.mark %alloc_6 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+        hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 3
+        %6:5 = scf.for %arg17 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg18 = %1, %arg19 = %5, %arg20 = %4, %arg21 = %c0_i32, %arg22 = %c0_i32) -> (tensor<128x128xf32>, tensor<128xf32>, tensor<128xf32>, i32, i32)  : i32 {
+          hivm.hir.sync_block_wait {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 2
+          %memspacecast = memref.memory_space_cast %alloc_5 {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>> to memref<128x128xf32>
+          %30 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32> to tensor<128x128xf32>
+          %31 = arith.mulf %30, %2 {ssbuffer.block_id = 5 : i32} : tensor<128x128xf32>
+          %reduced = linalg.reduce ins(%31 : tensor<128x128xf32>) outs(%4 : tensor<128xf32>) dimensions = [1]  {ssbuffer.block_id = 5 : i32}
+            (%in: f32, %init: f32) {
+              %47 = arith.maximumf %in, %init : f32
+              linalg.yield %47 : f32
+            }
+          %32 = arith.maximumf %arg20, %reduced {ssbuffer.block_id = 5 : i32} : tensor<128xf32>
+          %broadcasted_8 = linalg.broadcast ins(%32 : tensor<128xf32>) outs(%0 : tensor<128x128xf32>) dimensions = [1]  {ssbuffer.block_id = 5 : i32}
+          %33 = arith.subf %31, %broadcasted_8 {ssbuffer.block_id = 5 : i32} : tensor<128x128xf32>
+          %34 = math.exp %33 {ssbuffer.block_id = 5 : i32} : tensor<128x128xf32>
+          %35 = arith.truncf %34 {ssbuffer.block_id = 5 : i32} : tensor<128x128xf32> to tensor<128x128xf16>
+          %reshape = tensor.reshape %35(%cst_0) {ssbuffer.block_id = 5 : i32} : (tensor<128x128xf16>, tensor<3xi64>) -> tensor<128x8x16xf16>
+          annotation.mark %reshape {ssbuffer.block_id = 5 : i32, tiling_dim_mapping = {"1" = 1 : index}} : tensor<128x8x16xf16>
+          %36 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<8x128x16xf16>
+          %transposed = linalg.transpose ins(%reshape : tensor<128x8x16xf16>) outs(%36 : tensor<8x128x16xf16>) permutation = [1, 0, 2]  {ssbuffer.block_id = 5 : i32}
+          %reshape_9 = tensor.reshape %transposed(%cst) {ssbuffer.block_id = 5 : i32} : (tensor<8x128x16xf16>, tensor<4xi64>) -> tensor<8x8x16x16xf16>
+          annotation.mark %reshape_9 {ssbuffer.block_id = 5 : i32, tiling_dim_mapping = {"1" = 1 : index}} : tensor<8x8x16x16xf16>
+          hivm.hir.sync_block_wait {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+          hivm.hir.copy ins(%reshape_9 : tensor<8x8x16x16xf16>) outs(%alloc : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 0 : i32}
+          hivm.hir.sync_block_set {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
+          hivm.hir.sync_block_set {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 2
+          hivm.hir.sync_block_wait {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 2 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 3
+          %memspacecast_10 = memref.memory_space_cast %alloc_6 {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32, #hivm.address_space<ub>> to memref<128x128xf32>
+          %37 = bufferization.to_tensor %memspacecast_10 restrict writable {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32> to tensor<128x128xf32>
+          %38 = linalg.fill {ssbuffer.block_id = 7 : i32} ins(%cst_1 : f32) outs(%3 : tensor<128xf32>) -> tensor<128xf32>
+          %reduced_11 = linalg.reduce ins(%34 : tensor<128x128xf32>) outs(%38 : tensor<128xf32>) dimensions = [1]  {ssbuffer.block_id = 7 : i32}
+            (%in: f32, %init: f32) {
+              %47 = arith.addf %in, %init : f32
+              linalg.yield %47 : f32
+            }
+          %39 = arith.subf %arg20, %32 {ssbuffer.block_id = 7 : i32} : tensor<128xf32>
+          %40 = math.exp %39 {ssbuffer.block_id = 7 : i32} : tensor<128xf32>
+          %41 = arith.mulf %arg19, %40 {ssbuffer.block_id = 7 : i32} : tensor<128xf32>
+          %42 = arith.addf %41, %reduced_11 {ssbuffer.block_id = 7 : i32} : tensor<128xf32>
+          %broadcasted_12 = linalg.broadcast ins(%40 : tensor<128xf32>) outs(%0 : tensor<128x128xf32>) dimensions = [1]  {ssbuffer.block_id = 7 : i32}
+          %43 = arith.mulf %arg18, %broadcasted_12 {ssbuffer.block_id = 7 : i32} : tensor<128x128xf32>
+          %44 = arith.addf %37, %43 {ssbuffer.block_id = 7 : i32} : tensor<128x128xf32>
+          %45 = arith.addi %arg21, %c128_i32 {ssbuffer.block_id = 7 : i32} : i32
+          %46 = arith.addi %arg22, %c128_i32 {ssbuffer.block_id = 7 : i32} : i32
+          hivm.hir.sync_block_set {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 2 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 3
+          scf.yield %44, %42, %32, %45, %46 : tensor<128x128xf32>, tensor<128xf32>, tensor<128xf32>, i32, i32
+        } {ssbuffer.block_id = 11 : i32, ssbuffer.main_loop = 0 : i32}
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 9 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_S>] flag = 4
+        %7 = arith.divsi %arg16, %c64_i32 {ssbuffer.block_id = 9 : i32} : i32
+        %8 = arith.remsi %arg16, %c64_i32 {ssbuffer.block_id = 9 : i32} : i32
+        %9 = arith.divsi %7, %c8_i32 {ssbuffer.block_id = 9 : i32} : i32
+        %10 = arith.remsi %7, %c8_i32 {ssbuffer.block_id = 9 : i32} : i32
+        %11 = arith.extsi %9 {ssbuffer.block_id = 9 : i32} : i32 to i64
+        %12 = arith.muli %11, %c8388608_i64 {ssbuffer.block_id = 9 : i32} : i64
+        %13 = arith.extsi %10 {ssbuffer.block_id = 9 : i32} : i32 to i64
+        %14 = arith.muli %13, %c1048576_i64 {ssbuffer.block_id = 9 : i32} : i64
+        %15 = arith.addi %12, %14 {ssbuffer.block_id = 9 : i32} : i64
+        %16 = arith.index_cast %15 {ssbuffer.block_id = 9 : i32} : i64 to index
+        %17 = arith.muli %8, %c128_i32 {ssbuffer.block_id = 9 : i32} : i32
+        %18 = arith.maxsi %17, %c0_i32 {ssbuffer.block_id = 9 : i32} : i32
+        %19 = arith.index_cast %18 {ssbuffer.block_id = 9 : i32} : i32 to index
+        %20 = arith.muli %19, %c128 {ssbuffer.block_id = 9 : i32} : index
+        %21 = arith.addi %20, %16 {ssbuffer.block_id = 9 : i32} : index
+        %reinterpret_cast = memref.reinterpret_cast %arg7 to offset: [%21], sizes: [128, 128], strides: [128, 1] {ssbuffer.block_id = 9 : i32} : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+        %22 = math.log %6#1 {ssbuffer.block_id = 9 : i32} : tensor<128xf32>
+        %23 = arith.addf %6#2, %22 {ssbuffer.block_id = 9 : i32} : tensor<128xf32>
+        %broadcasted = linalg.broadcast ins(%6#1 : tensor<128xf32>) outs(%0 : tensor<128x128xf32>) dimensions = [1]  {ssbuffer.block_id = 9 : i32}
+        %24 = arith.divf %6#0, %broadcasted {ssbuffer.block_id = 9 : i32} : tensor<128x128xf32>
+        %25 = arith.muli %7, %c8192_i32 {ssbuffer.block_id = 9 : i32} : i32
+        %26 = arith.index_cast %25 {ssbuffer.block_id = 9 : i32} : i32 to index
+        %27 = arith.index_cast %17 {ssbuffer.block_id = 9 : i32} : i32 to index
+        %28 = arith.addi %26, %27 {ssbuffer.block_id = 9 : i32} : index
+        %reinterpret_cast_7 = memref.reinterpret_cast %arg6 to offset: [%28], sizes: [128], strides: [1] {ssbuffer.block_id = 9 : i32} : memref<?xf32> to memref<128xf32, strided<[1], offset: ?>>
+        bufferization.materialize_in_destination %23 in writable %reinterpret_cast_7 {ssbuffer.block_id = 9 : i32} : (tensor<128xf32>, memref<128xf32, strided<[1], offset: ?>>) -> ()
+        %29 = arith.truncf %24 {ssbuffer.block_id = 9 : i32} : tensor<128x128xf32> to tensor<128x128xf16>
+        bufferization.materialize_in_destination %29 in writable %reinterpret_cast {ssbuffer.block_id = 9 : i32} : (tensor<128x128xf16>, memref<128x128xf16, strided<[128, 1], offset: ?>>) -> ()
+      } {ssbuffer.block_id = 12 : i32}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+
+    // ── Scope 2 (CUBE): 3 gm_load_bufferable → multi-buffered ───────
+    // R1: Load A (outer loop, block_id=2) gets 2 buffer slots
+    // CHECK: memref.alloc() {ssbuffer.block_id = 2 : i32} : memref<128x128xf16>
+    // CHECK: memref.alloc() {ssbuffer.block_id = 2 : i32} : memref<128x128xf16>
+
+    // R1: Outer loop gets 4 control iter_args (for Load A)
+    // CHECK: scf.for {{.*}} iter_args({{.*}}) -> (i1, i1, index, index)
+
+    // R2: Load A producer + consumer
+    // CHECK: scf.if {{.*}} -> (i1, index) {
+    // CHECK: memref.copy {{.*}} {ssbuffer.block_id = 2
+    // CHECK: } {ssbuffer.block_id = 2 : i32, ssbuffer.load_store}
+    // CHECK: scf.if {{.*}} -> (i1, index) {
+    // CHECK: memref.copy {{.*}} {ssbuffer.block_id = 2
+    // CHECK: } {ssbuffer.block_id = 2 : i32, ssbuffer.load_store}
+
+    // R2: Load A consumer select
+    // CHECK: arith.remui {{.*}} {ssbuffer.block_id = 2
+    // CHECK: bufferization.to_tensor {{.*}} {ssbuffer.block_id = 2
+    // CHECK: bufferization.to_tensor {{.*}} {ssbuffer.block_id = 2
+    // CHECK: arith.select {{.*}} {ssbuffer.block_id = 2
+
+    // R2: Load A flag clear
+    // CHECK: scf.if {{.*}} -> (i1) {
+    // CHECK: } {ssbuffer.block_id = 2 : i32, ssbuffer.load_store}
+    // CHECK: scf.if {{.*}} -> (i1) {
+    // CHECK: } {ssbuffer.block_id = 2 : i32, ssbuffer.load_store}
+
+    // R3: Loads B & C (inner loop, block_id=0 and block_id=1) each get 2 slots
+    // CHECK: memref.alloc() {ssbuffer.block_id = 0 : i32} : memref<128x128xf16>
+    // CHECK: memref.alloc() {ssbuffer.block_id = 0 : i32} : memref<128x128xf16>
+    // CHECK: memref.alloc() {ssbuffer.block_id = 1 : i32} : memref<128x128xf16>
+    // CHECK: memref.alloc() {ssbuffer.block_id = 1 : i32} : memref<128x128xf16>
+
+    // R3: Inner loop gets 8 control iter_args (4 for Load B + 4 for Load C)
+    // CHECK: scf.for {{.*}} iter_args({{.*}}) -> (i1, i1, index, index, i1, i1, index, index)
+
+    // R4: Load B (block_id=0) producer + consumer
+    // CHECK: scf.if {{.*}} -> (i1, index) {
+    // CHECK: memref.copy {{.*}} {ssbuffer.block_id = 0
+    // CHECK: } {ssbuffer.block_id = 0 : i32, ssbuffer.load_store}
+    // CHECK: arith.remui {{.*}} {ssbuffer.block_id = 0
+    // CHECK: bufferization.to_tensor {{.*}} {ssbuffer.block_id = 0
+    // CHECK: bufferization.to_tensor {{.*}} {ssbuffer.block_id = 0
+    // CHECK: arith.select {{.*}} {ssbuffer.block_id = 0
+
+    // R5: Load C (block_id=1) producer + consumer
+    // CHECK: scf.if {{.*}} -> (i1, index) {
+    // CHECK: memref.copy {{.*}} {ssbuffer.block_id = 1
+    // CHECK: } {ssbuffer.block_id = 1 : i32, ssbuffer.load_store}
+    // CHECK: arith.remui {{.*}} {ssbuffer.block_id = 1
+    // CHECK: bufferization.to_tensor {{.*}} {ssbuffer.block_id = 1
+    // CHECK: bufferization.to_tensor {{.*}} {ssbuffer.block_id = 1
+    // CHECK: arith.select {{.*}} {ssbuffer.block_id = 1
+
+    // R6: Inner loop yield with 8 values
+    // CHECK: scf.yield {{.*}} : i1, i1, index, index, i1, i1, index, index
+
+    // R7: Outer loop yield with 4 values
+    // CHECK: scf.yield {{.*}} : i1, i1, index, index
+
+    scope.scope : () -> () {
+      %0 = tensor.empty() {ssbuffer.block_id = 3 : i32} : tensor<128x128xf32>
+      %1 = linalg.fill {ssbuffer.block_id = 3 : i32} ins(%cst_1 : f32) outs(%0 : tensor<128x128xf32>) -> tensor<128x128xf32>
+      scf.for %arg16 = %arg13 to %c65536_i32 step %c28_i32  : i32 {
+        %2 = arith.divsi %arg16, %c64_i32 {ssbuffer.block_id = 2 : i32} : i32
+        %3 = arith.remsi %arg16, %c64_i32 {ssbuffer.block_id = 2 : i32} : i32
+        %4 = arith.divsi %2, %c8_i32 {ssbuffer.block_id = 2 : i32} : i32
+        %5 = arith.remsi %2, %c8_i32 {ssbuffer.block_id = 2 : i32} : i32
+        %6 = arith.muli %5, %arg9 {ssbuffer.block_id = 2 : i32} : i32
+        %7 = arith.divsi %6, %c8_i32 {ssbuffer.block_id = 2 : i32} : i32
+        %8 = arith.extsi %4 {ssbuffer.block_id = 2 : i32} : i32 to i64
+        %9 = arith.muli %8, %c8388608_i64 {ssbuffer.block_id = 2 : i32} : i64
+        %10 = arith.extsi %5 {ssbuffer.block_id = 2 : i32} : i32 to i64
+        %11 = arith.muli %10, %c1048576_i64 {ssbuffer.block_id = 2 : i32} : i64
+        %12 = arith.addi %9, %11 {ssbuffer.block_id = 2 : i32} : i64
+        %13 = arith.extsi %7 {ssbuffer.block_id = 2 : i32} : i32 to i64
+        %14 = arith.muli %13, %c1048576_i64 {ssbuffer.block_id = 2 : i32} : i64
+        %15 = arith.addi %9, %14 {ssbuffer.block_id = 2 : i32} : i64
+        %16 = arith.index_cast %12 {ssbuffer.block_id = 2 : i32} : i64 to index
+        %17 = arith.muli %3, %c128_i32 {ssbuffer.block_id = 2 : i32} : i32
+        %18 = arith.maxsi %17, %c0_i32 {ssbuffer.block_id = 2 : i32} : i32
+        %19 = arith.index_cast %18 {ssbuffer.block_id = 2 : i32} : i32 to index
+        %20 = arith.muli %19, %c128 {ssbuffer.block_id = 2 : i32} : index
+        %21 = arith.addi %20, %16 {ssbuffer.block_id = 2 : i32} : index
+        %reinterpret_cast = memref.reinterpret_cast %arg2 to offset: [%21], sizes: [128, 128], strides: [128, 1] {ssbuffer.block_id = 2 : i32} : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+        %22 = arith.index_cast %15 {ssbuffer.block_id = 2 : i32} : i64 to index
+        %alloc = memref.alloc() {ssbuffer.block_id = 2 : i32} : memref<128x128xf16>
+        memref.copy %reinterpret_cast, %alloc {ssbuffer.block_id = 2 : i32} : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+        %23 = bufferization.to_tensor %alloc restrict writable {gm_load_bufferable, ssbuffer.block_id = 2 : i32} : memref<128x128xf16> to tensor<128x128xf16>
+        %alloc_5 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+        annotation.mark %alloc_5 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+        hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+        %alloc_6 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+        annotation.mark %alloc_6 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+        %alloc_7 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+        annotation.mark %alloc_7 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+        %24:2 = scf.for %arg17 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg18 = %c0_i32, %arg19 = %c0_i32) -> (i32, i32)  : i32 {
+          %25 = arith.index_cast %arg18 {ssbuffer.block_id = 0 : i32} : i32 to index
+          %26 = arith.muli %25, %c128 {ssbuffer.block_id = 0 : i32} : index
+          %27 = arith.addi %26, %22 {ssbuffer.block_id = 0 : i32} : index
+          %reinterpret_cast_8 = memref.reinterpret_cast %arg3 to offset: [%27], sizes: [128, 128], strides: [128, 1] {ssbuffer.block_id = 0 : i32} : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+          %alloc_9 = memref.alloc() {ssbuffer.block_id = 0 : i32} : memref<128x128xf16>
+          memref.copy %reinterpret_cast_8, %alloc_9 {ssbuffer.block_id = 0 : i32} : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+          %28 = bufferization.to_tensor %alloc_9 restrict writable {gm_load_bufferable, ssbuffer.block_id = 0 : i32} : memref<128x128xf16> to tensor<128x128xf16>
+          %29 = tensor.empty() {ssbuffer.block_id = 0 : i32} : tensor<128x128xf16>
+          %transposed = linalg.transpose ins(%28 : tensor<128x128xf16>) outs(%29 : tensor<128x128xf16>) permutation = [1, 0]  {ssbuffer.block_id = 0 : i32}
+          %30 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 0 : i32} ins(%23, %transposed : tensor<128x128xf16>, tensor<128x128xf16>) outs(%1 : tensor<128x128xf32>) -> tensor<128x128xf32>
+          hivm.hir.sync_block_wait {ssbuffer.block_id = 0 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_V>, <PIPE_FIX>] flag = 2
+          hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 0 : i32, ssbuffer.transfer_id = 1 : i32} ins(%30 : tensor<128x128xf32>) outs(%alloc_6 : memref<128x128xf32, #hivm.address_space<ub>>)
+          hivm.hir.sync_block_set {ssbuffer.block_id = 0 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_FIX>, <PIPE_V>] flag = 2
+          hivm.hir.sync_block_wait {ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
+          %31 = hivm.hir.convert_layout %alloc_5 output_shape [128, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 0 : i32} : (memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) -> memref<128x128xf16, #hivm.address_space<cbuf>>
+          %memspacecast = memref.memory_space_cast %31 {ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 0 : i32} : memref<128x128xf16, #hivm.address_space<cbuf>> to memref<128x128xf16>
+          %32 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 0 : i32} : memref<128x128xf16> to tensor<128x128xf16>
+          %33 = arith.index_cast %arg19 {ssbuffer.block_id = 1 : i32} : i32 to index
+          %34 = arith.muli %33, %c128 {ssbuffer.block_id = 1 : i32} : index
+          %35 = arith.addi %34, %22 {ssbuffer.block_id = 1 : i32} : index
+          %reinterpret_cast_10 = memref.reinterpret_cast %arg4 to offset: [%35], sizes: [128, 128], strides: [128, 1] {ssbuffer.block_id = 1 : i32} : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+          %alloc_11 = memref.alloc() {ssbuffer.block_id = 1 : i32} : memref<128x128xf16>
+          memref.copy %reinterpret_cast_10, %alloc_11 {ssbuffer.block_id = 1 : i32} : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+          %36 = bufferization.to_tensor %alloc_11 restrict writable {gm_load_bufferable, ssbuffer.block_id = 1 : i32} : memref<128x128xf16> to tensor<128x128xf16>
+          %37 = tensor.empty() {ssbuffer.block_id = 1 : i32} : tensor<128x128xf32>
+          %38 = linalg.fill {ssbuffer.block_id = 1 : i32} ins(%cst_1 : f32) outs(%37 : tensor<128x128xf32>) -> tensor<128x128xf32>
+          %39 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 1 : i32} ins(%32, %36 : tensor<128x128xf16>, tensor<128x128xf16>) outs(%38 : tensor<128x128xf32>) -> tensor<128x128xf32>
+          hivm.hir.sync_block_set {ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+          hivm.hir.sync_block_wait {ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 2 : i32}[<CUBE>, <PIPE_V>, <PIPE_FIX>] flag = 3
+          hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 2 : i32} ins(%39 : tensor<128x128xf32>) outs(%alloc_7 : memref<128x128xf32, #hivm.address_space<ub>>)
+          hivm.hir.sync_block_set {ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 2 : i32}[<CUBE>, <PIPE_FIX>, <PIPE_V>] flag = 3
+          %40 = arith.addi %arg18, %c128_i32 {ssbuffer.block_id = 7 : i32} : i32
+          %41 = arith.addi %arg19, %c128_i32 {ssbuffer.block_id = 7 : i32} : i32
+          scf.yield %40, %41 : i32, i32
+        } {ssbuffer.block_id = 11 : i32, ssbuffer.main_loop = 0 : i32}
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32}[<CUBE>, <PIPE_V>, <PIPE_FIX>] flag = 3
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_V>, <PIPE_FIX>] flag = 2
+        hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32}[<CUBE>, <PIPE_FIX>, <PIPE_S>] flag = 4
+      } {ssbuffer.block_id = 12 : i32}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+    return
+  }
+

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/DecoupleComputeAndMemory/test_decouple_compute_and_memory_producer_consumer.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/DecoupleComputeAndMemory/test_decouple_compute_and_memory_producer_consumer.mlir
@@ -1,0 +1,238 @@
+// RUN: triton-opt --gm-load-multi-buffer %s | FileCheck %s
+
+// ============================================================================
+// TC-B04: Producer IV projection correctness
+// Verifies that the Producer uses projected IV (lb + prod_counter * step)
+// instead of the current loop IV to compute prefetch addresses.
+// ============================================================================
+
+// CHECK-LABEL: func.func @tc_b04_iv_projection
+func.func @tc_b04_iv_projection(
+  %arg0: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %arg1: tensor<128x128xf32>
+) -> tensor<128x128xf32> {
+  %c28_i32 = arith.constant 28 : i32
+  %c65536_i32 = arith.constant 65536 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c128 = arith.constant 128 : index
+
+  // Producer computes virtual IV: lb_i32 + prod_counter_i32 * step_i32
+  // CHECK: scf.if {{.*}} -> (i1, index) {
+  // CHECK: arith.index_cast {{.*}} : index to i32
+  // CHECK: arith.muli {{.*}}, %c28_i32 : i32
+  // CHECK: arith.addi %c0_i32, {{.*}} : i32
+  // CHECK: arith.index_cast {{.*}} : i32 to index
+  // CHECK: memref.copy
+
+  %result = scf.for %arg16 = %c0_i32 to %c65536_i32 step %c28_i32
+    iter_args(%acc = %arg1) -> tensor<128x128xf32> : i32 {
+    %iv_idx = arith.index_cast %arg16 : i32 to index
+    %row_off = arith.muli %iv_idx, %c128 : index
+    %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+    %q_alloc = memref.alloc () : memref<128x128xf16>
+    memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
+    scf.yield %qk : tensor<128x128xf32>
+  }
+  return %result : tensor<128x128xf32>
+}
+
+// ============================================================================
+// TC-B04b: IV projection with runtime lower bound
+// Verifies Producer IV projection when the loop lower bound is a runtime
+// value (e.g., %offset_init), not a compile-time constant.
+// ============================================================================
+
+// CHECK-LABEL: func.func @tc_b04b_iv_projection_runtime_lb
+func.func @tc_b04b_iv_projection_runtime_lb(
+  %arg0: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %offset_init: i32,
+  %arg1: tensor<128x128xf32>
+) -> tensor<128x128xf32> {
+  %c28_i32 = arith.constant 28 : i32
+  %c65536_i32 = arith.constant 65536 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c128 = arith.constant 128 : index
+
+  // Producer should use %offset_init as lb for projection
+  // CHECK: scf.if {{.*}} -> (i1, index) {
+  // CHECK: arith.index_cast {{.*}} : index to i32
+  // CHECK: arith.muli {{.*}}, %c28_i32 : i32
+  // CHECK: arith.addi {{.*}}, {{.*}} : i32
+  // CHECK: memref.copy
+
+  %result = scf.for %arg16 = %offset_init to %c65536_i32 step %c28_i32
+    iter_args(%acc = %arg1) -> tensor<128x128xf32> : i32 {
+    %iv_idx = arith.index_cast %arg16 : i32 to index
+    %row_off = arith.muli %iv_idx, %c128 : index
+    %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+    %q_alloc = memref.alloc () : memref<128x128xf16>
+    memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
+    scf.yield %qk : tensor<128x128xf32>
+  }
+  return %result : tensor<128x128xf32>
+}
+
+// ============================================================================
+// TC-B06: Preserve original iter_args and extend with control args
+// When the scf.for already has original iter_args (e.g., acc, lse), the
+// 4 control iter_args (2 flags + prod + cons) are appended at the end.
+// ============================================================================
+
+// CHECK-LABEL: func.func @tc_b06_preserve_original_iter_args
+func.func @tc_b06_preserve_original_iter_args(
+  %arg0: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %acc_init: tensor<128x128xf32>,
+  %lse_init: tensor<128xf32>
+) -> (tensor<128x128xf32>, tensor<128xf32>) {
+  %c28_i32 = arith.constant 28 : i32
+  %c65536_i32 = arith.constant 65536 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c128 = arith.constant 128 : index
+
+  // Original 2 iter_args preserved, 4 control args appended = 6 total
+  // CHECK: scf.for {{.+}} iter_args({{.+}}) -> (tensor<128x128xf32>, tensor<128xf32>, i1, i1, index, index)
+
+  %result:2 = scf.for %arg16 = %c0_i32 to %c65536_i32 step %c28_i32
+    iter_args(%acc = %acc_init, %lse = %lse_init)
+    -> (tensor<128x128xf32>, tensor<128xf32>) : i32 {
+    %iv_idx = arith.index_cast %arg16 : i32 to index
+    %row_off = arith.muli %iv_idx, %c128 : index
+    %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+    %q_alloc = memref.alloc () : memref<128x128xf16>
+    memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %acc_new = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
+    scf.yield %acc_new, %lse : tensor<128x128xf32>, tensor<128xf32>
+  }
+  return %result#0, %result#1 : tensor<128x128xf32>, tensor<128xf32>
+}
+
+// ============================================================================
+// TC-B07: Dead DMA elimination
+// Q load is marked (gm_load_bufferable) and gets multi-buffered.
+// K load is unmarked and remains as normal alloc+copy in the consumer body.
+// The Q load's memref.copy should be eliminated from the consumer body.
+// ============================================================================
+
+// CHECK-LABEL: func.func @tc_b07_dead_dma_elimination
+func.func @tc_b07_dead_dma_elimination(
+  %arg0: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %arg1: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %arg2: tensor<128x128xf32>
+) -> tensor<128x128xf32> {
+  %c28_i32 = arith.constant 28 : i32
+  %c65536_i32 = arith.constant 65536 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c128 = arith.constant 128 : index
+
+  // Q gets 2 buffer slots; K stays as normal alloc+copy in consumer
+  // CHECK: %[[Q_SLOT0:.*]] = memref.alloc() : memref<128x128xf16>
+  // CHECK: %[[Q_SLOT1:.*]] = memref.alloc() : memref<128x128xf16>
+
+  // Consumer: Q selected via arith.select, then K loaded normally, then matmul
+  // CHECK: arith.select
+  // CHECK: memref.alloc() : memref<128x128xf16>
+  // CHECK: memref.copy
+  // CHECK: linalg.matmul
+
+  %result = scf.for %arg16 = %c0_i32 to %c65536_i32 step %c28_i32
+    iter_args(%acc = %arg2) -> tensor<128x128xf32> : i32 {
+    %iv_idx = arith.index_cast %arg16 : i32 to index
+    %row_off = arith.muli %iv_idx, %c128 : index
+
+    %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+    %q_alloc = memref.alloc () : memref<128x128xf16>
+    memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+
+    %k_src_rc = memref.reinterpret_cast %arg1 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+    %k_alloc = memref.alloc () : memref<128x128xf16>
+    memref.copy %k_src_rc, %k_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+    %k_tensor = bufferization.to_tensor %k_alloc restrict writable : memref<128x128xf16> to tensor<128x128xf16>
+
+    %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %k_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
+    scf.yield %qk : tensor<128x128xf32>
+  }
+  return %result : tensor<128x128xf32>
+}
+
+// ============================================================================
+// TC-B16: Producer flag state machine initialization
+// Verifies that flag iter_args are initialized to false and counter
+// iter_args are initialized to 0 (c0 index).
+// ============================================================================
+
+// CHECK-LABEL: func.func @tc_b16_flag_counter_init
+func.func @tc_b16_flag_counter_init(
+  %arg0: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %arg1: tensor<128x128xf32>
+) -> tensor<128x128xf32> {
+  %c28_i32 = arith.constant 28 : i32
+  %c65536_i32 = arith.constant 65536 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c128 = arith.constant 128 : index
+  %false = arith.constant false
+  %c0 = arith.constant 0 : index
+
+  // Flags init to %false, counters init to %c0
+  // CHECK: %false = arith.constant false
+  // CHECK: %[[C0:.*]] = arith.constant 0 : index
+  // CHECK: scf.for {{.*}} iter_args({{.*}} = %false, {{.*}} = %false, {{.*}} = %[[C0]], {{.*}} = %[[C0]])
+
+  %result = scf.for %arg16 = %c0_i32 to %c65536_i32 step %c28_i32
+    iter_args(%acc = %arg1) -> tensor<128x128xf32> : i32 {
+    %iv_idx = arith.index_cast %arg16 : i32 to index
+    %row_off = arith.muli %iv_idx, %c128 : index
+    %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+    %q_alloc = memref.alloc () : memref<128x128xf16>
+    memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
+    scf.yield %qk : tensor<128x128xf32>
+  }
+  return %result : tensor<128x128xf32>
+}
+
+// ============================================================================
+// TC-B17: Producer condition check structure
+// Verifies the Producer's scf.if condition: flag_empty AND has_more_trips.
+// ============================================================================
+
+// CHECK-LABEL: func.func @tc_b17_producer_condition_structure
+func.func @tc_b17_producer_condition_structure(
+  %arg0: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %arg1: tensor<128x128xf32>
+) -> tensor<128x128xf32> {
+  %c28_i32 = arith.constant 28 : i32
+  %c65536_i32 = arith.constant 65536 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c128 = arith.constant 128 : index
+
+  // Producer checks: flag == false (empty) AND prod_counter < trip_count
+  // CHECK: arith.cmpi eq, {{.*}}, %false
+  // CHECK: arith.cmpi ult, {{.*}}, {{.*}}
+  // CHECK: arith.andi
+
+  %result = scf.for %arg16 = %c0_i32 to %c65536_i32 step %c28_i32
+    iter_args(%acc = %arg1) -> tensor<128x128xf32> : i32 {
+    %iv_idx = arith.index_cast %arg16 : i32 to index
+    %row_off = arith.muli %iv_idx, %c128 : index
+    %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+    %q_alloc = memref.alloc () : memref<128x128xf16>
+    memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
+    scf.yield %qk : tensor<128x128xf32>
+  }
+  return %result : tensor<128x128xf32>
+}


### PR DESCRIPTION
# Description
新增DecoupleComputeAndMemory Passs实现 ，CV场景下，该 pass 旨在对GM load 操作应用 multi-buffering 变换，以提升内存访问效率，实现如下计算访存分离的效果：
```
时刻:      |───── 迭代0 ─────|───── 迭代1 ─────|───── 迭代2 ─────|───── 迭代3 ─────|

Producer:   填slot0[IV0]       填slot0[IV2]                             ...
            填slot1[IV1]                          填slot1[IV3]

Consumer:   读slot0[IV0]       读slot1[IV1]       读slot0[IV2]          ...


```



- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
