### PR TITLE
fix(ssbuffer):Fallback when memref type dependent values are found in addmulti-cache pass.

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
@@ -1186,8 +1186,8 @@ static int addInnerMultiBuffer(mlir::scf::ForOp mainLoopForOp, OpBuilder &builde
 
     // If memref-type dependency values exist, skip double buffer processing
     if (hasMemrefDepValue(depValueMap)) {
-        vectorScope->setAttr("ssbuffer.skip", builder.getUnitAttr());
-        return 0;
+        LDBG("ERROR: Memref type dependent values found!");
+        return -1;
     }
 
     auto depUserMap = buildDepUserMap(blocks, allOps, depValueMap);

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/Inner-scope-memref-dep.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/Inner-scope-memref-dep.mlir
@@ -1,0 +1,38 @@
+// RUN: (triton-opt --add_multi_buffer_inner_scope %s 2>&1 || echo "PASS") | FileCheck %s
+// CHECK: PASS
+
+// T26: Memref Type Dependency Triggers Fallback
+// Test: When memref.alloc with block_id=X produces a memref, and later
+//       bufferization.to_tensor with block_id=Y uses that memref (X != Y),
+//       the memref is a cross-block dependency and hasMemrefDepValue returns
+//       true, causing pass failure.
+// Key Check: Pass should fail (exit code != 0)
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_t26_memref_dep_fallback() {
+    %c0_i32 = arith.constant 0 : i32
+    %c100_i32 = arith.constant 100 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %cst = arith.constant 1.0 : f32
+    %empty = tensor.empty() : tensor<128xf32>
+    scope.scope : () -> () {
+      // Producer in block_id = 5
+      %prod = linalg.fill {ssbuffer.block_id = 5 : i32} ins(%cst : f32) outs(%empty : tensor<128xf32>) -> tensor<128xf32>
+      // Main loop - all operations inside must have proper ssbuffer.block_id
+      %loop_result = scf.for %i = %c0_i32 to %c100_i32 step %c1_i32 iter_args(%arg = %prod) -> (tensor<128xf32>) : i32 {
+        // memref.alloc in block_id = 9 (producer block)
+        %alloc = memref.alloc() {ssbuffer.block_id = 9 : i32} : memref<128xf32>
+        // bufferization.to_tensor in block_id = 10 (consumer block, different from 9)
+        // This uses %alloc directly, creating a cross-block memref dependency
+        %tensor_from_alloc = bufferization.to_tensor %alloc restrict writable {ssbuffer.block_id = 10 : i32} : memref<128xf32>
+        // Use the tensor in block_id = 10
+        %consumed = arith.addf %tensor_from_alloc, %tensor_from_alloc {ssbuffer.block_id = 10 : i32} : tensor<128xf32>
+        // Producer continuation in block_id = 5
+        %new_prod = arith.addf %consumed, %arg {ssbuffer.block_id = 5 : i32} : tensor<128xf32>
+        scf.yield %new_prod : tensor<128xf32>
+      } {ssbuffer.main_loop = 1 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return
+  }
+}


### PR DESCRIPTION
This pull request is designed to fallback when memref type dependent values are found in addmulti-cache pass.
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
