### PR TITLE
[SSBuffer](fix) Disable SplitIfByBlockId pass in pipeline

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
@@ -94,7 +94,6 @@ void AddDynamicCVPipelinePass::runOnOperation()
     pm.addPass(createComputeBlockOptPass());
     pm.addPass(createSplitDataflowPass());
     pm.addPass(createAnalyzeDataFlowPass());
-    pm.addPass(createSplitIfByBlockIdPass());
     pm.addPass(createSeparateMemoryFromComputePass());
     pm.addPass(createAllocMultiCachePass());
     pm.addPass(createAddControlFlowConditionPass());


### PR DESCRIPTION
730: Enable splitif, disabled for now.