### PR TITLE
feat: Analysis adapt for custom op

### DIFF
--- a/third_party/ascend/include/TritonToLinalg/BlockPtrAnalysis.h
+++ b/third_party/ascend/include/TritonToLinalg/BlockPtrAnalysis.h
@@ -22,11 +22,11 @@
 
 #ifndef TRITON_ANALYSIS_BLOCKPTRANALYSIS_H
 #define TRITON_ANALYSIS_BLOCKPTRANALYSIS_H
-
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/Dialect/Linalg/IR/Linalg.h"
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -262,6 +262,9 @@ public:
                         ConversionPatternRewriter &rewriter,
                         const llvm::SmallDenseMap<Value, BlockData> &known);
 
+  static void parseCustomOp(hivm::CustomOp op, BlockData &data, const Location &loc, ConversionPatternRewriter &rewriter,
+                          const llvm::SmallDenseMap<Value, BlockData> &known, unsigned resultIdx);
+
   static void rewriteAddPtr(triton::AddPtrOp op,
                             triton::AddPtrOp::Adaptor &adaptor,
                             ConversionPatternRewriter &rewriter,
@@ -275,6 +278,8 @@ public:
   static void rewriteAdvanceOp(triton::AdvanceOp op,
                                ConversionPatternRewriter &rewriter,
                                llvm::SmallDenseMap<Value, BlockData> &known);
+
+  static void rewriteCustomOp(hivm::CustomOp op, hivm::CustomOp::Adaptor &adaptor, ConversionPatternRewriter &rewriter);
 
   template <typename T>
   static std::enable_if_t<std::is_same_v<T, scf::YieldOp> ||

--- a/third_party/ascend/include/TritonToUnstructure/OffsetAnalysis.h
+++ b/third_party/ascend/include/TritonToUnstructure/OffsetAnalysis.h
@@ -22,13 +22,14 @@
 
 #ifndef TRITON_ANALYSIS_OFFSETANALYSIS_H
 #define TRITON_ANALYSIS_OFFSETANALYSIS_H
-
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Value.h"
+#include "mlir/Transforms/DialectConversion.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
@@ -267,6 +268,9 @@ void parseInsert(tensor::InsertOp op, const Location &loc,
 void parseIntToPtr(triton::IntToPtrOp op, const Location &loc,
                    RewriterBase &rewriter,
                    llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+
+void parseCustomOp(hivm::CustomOp op, const Location &loc, RewriterBase &rewriter,
+                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap, unsigned resultIdx);
 } // namespace triton
 
 } // namespace mlir

--- a/third_party/ascend/include/Utils/Utils.h
+++ b/third_party/ascend/include/Utils/Utils.h
@@ -30,6 +30,7 @@
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -37,6 +38,7 @@
 
 #include <functional>
 #include <optional>
+#include <string>
 
 namespace mlir {
 
@@ -45,6 +47,8 @@ namespace ConverterUtils {
 const std::string GeneratedByMakeTensorPtrTAG = "GeneratedByMakeTensorPtr";
 const std::string discreteMaskAttrName = "DiscreteMask";
 const std::string discreteAttrName = "DiscreteMemAccess";
+const std::string continuousAttrName = "ContinuousMemAccess";
+const std::string customSrcPtrIndexAttrName = "SrcPtrIndex";
 
 bool isaPermutedMemRefType(MemRefType);
 
@@ -256,6 +260,10 @@ Value convertToIndexIfNeeded(Value intValue, const Location &loc, OpBuilder &b);
 RankedTensorType getExtractSlicedType(ArrayRef<OpFoldResult> shape,
                                       const llvm::SmallBitVector &droppedDims,
                                       Type elemType);
+
+bool checkStructureAnnotated(Operation* op, RewriterBase& rewriter);
+
+bool isDistributedTypeCustomOp(Operation* op);
 } // namespace mlir
 
 #endif // TRITONNPU_UTILS_UTILS_H

--- a/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
@@ -27,9 +27,9 @@
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
 
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
@@ -41,7 +41,10 @@
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OperationSupport.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/ValueRange.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "triton/Dialect/Triton/IR/Types.h"
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/SmallVectorExtras.h"
@@ -421,11 +424,12 @@ void BlockDataParser::parse(
         parseTensorPtr(advanceOp, data, loc, rewriter, known);
       } else if (auto intToPtrOp = dyn_cast<triton::IntToPtrOp>(op)) {
         data.setSource(remappedPtr);
+      } else if (isDistributedTypeCustomOp(op)) {
+        data.setSource(remappedPtr);
       } else {
         LLVM_DEBUG({ llvm::dbgs() << operand << "\n"; });
-        llvm_unreachable(
-            "Unexpected operand defining operation, a scalar "
-            "pointer can only be produced by AddPtrOp or direct block ptr");
+        llvm_unreachable("Unexpected operand defining operation, a scalar "
+                         "pointer can only be produced by AddPtrOp or direct block ptr or hivm CustomOp");
       }
     } else {
       data.setSource(remappedPtr);
@@ -482,12 +486,18 @@ void BlockDataParser::parse(
     parseFill(fillOp, data, loc, rewriter, known);
   } else if (auto selectOp = operand.getDefiningOp<arith::SelectOp>()){
     parseSelect(selectOp, data, loc, rewriter, known);
+  } else if (isDistributedTypeCustomOp(operand.getDefiningOp())) {
+    auto customOp = operand.getDefiningOp<hivm::CustomOp>();
+    auto opResult = dyn_cast<OpResult>(operand);
+    assert(opResult && "Expected operand to be an OpResult");
+    unsigned resultIdx = opResult.getResultNumber();
+    parseCustomOp(customOp, data, loc, rewriter, known, resultIdx);
   } else if (auto genericOp = operand.getDefiningOp<linalg::GenericOp>()) {
     if (genericOp->hasAttr("tt.from_make_range")) {
-      parseLinalgGenericFromMakeRange(genericOp, data, loc, rewriter, known);
+        parseLinalgGenericFromMakeRange(genericOp, data, loc, rewriter, known);
     } else {
-      operand.dump();
-      llvm_unreachable("encountered AddPtrOp produced by unsupported operation");
+        operand.dump();
+        llvm_unreachable("encountered AddPtrOp produced by unsupported operation");
     }
   } else if (auto atomicRMWOp = operand.getDefiningOp<triton::AtomicRMWOp>()) {
     parseAtomicRmw(atomicRMWOp, data, loc, rewriter, known);
@@ -1002,6 +1012,18 @@ void parseIndirectLoad(OpTy op, BlockData &data, const Location &loc,
   data.setSource(opRes);
 }
 
+void BlockDataParser::parseCustomOp(hivm::CustomOp op, BlockData &data, const Location &loc,
+                                  ConversionPatternRewriter &rewriter,
+                                  const llvm::SmallDenseMap<Value, BlockData> &known, unsigned resultIdx)
+{
+  auto srcValArrayAttr = op->getAttrOfType<DenseI32ArrayAttr>(ConverterUtils::customSrcPtrIndexAttrName);
+  assert(srcValArrayAttr && "structure hivm.custom op should present src tensor<tt.ptr>");
+  auto srcValArray = srcValArrayAttr.asArrayRef();
+  assert(srcValArray[resultIdx] != -1 && "tensor<tt.ptr> result should map to src tensor<tt.ptr>");
+  parse(op->getOperand(srcValArray[resultIdx]), data, loc, rewriter, known);
+  data.setSource(rewriter.getRemappedValue(op->getResult(resultIdx)));
+}
+
 void BlockDataParser::parseFill(linalg::FillOp op, BlockData &data,
                                 const Location &loc,
                                 ConversionPatternRewriter &rewriter,
@@ -1225,6 +1247,52 @@ OpFoldResult accumulatePotentialOffsetOnBase(
   }
 
   return offset;
+}
+
+void BlockDataParser::rewriteCustomOp(hivm::CustomOp op, hivm::CustomOp::Adaptor &adaptor,
+                                      ConversionPatternRewriter &rewriter)
+{
+  if (isDistributedTypeCustomOp(op)){
+    auto ip = rewriter.saveInsertionPoint();
+    rewriter.setInsertionPoint(op);
+    auto loc = op.getLoc();
+    llvm::SmallVector<Value> newOutputs;
+    for (auto out : op.getOutputs()) {
+        auto tensorTy = llvm::cast<RankedTensorType>(out.getType());
+        if(llvm::isa<triton::PointerType>(tensorTy.getElementType())){
+          // simd library shouldn't output tensor<tt.ptr>
+          // after rewrite, delete the tensor<tt.ptr> output value
+          continue;
+        }
+        newOutputs.emplace_back(rewriter.getRemappedValue(out));
+    }
+    llvm::SmallVector<Type> resultTypes;
+    for (auto ty : op->getResultTypes()) {
+        if (auto ptrTy = llvm::dyn_cast<triton::PointerType>(ty)) {
+            resultTypes.emplace_back(MemRefType::get({ShapedType::kDynamic}, ptrTy.getPointeeType()));
+            continue;
+        }
+        if (auto tensorTy = llvm::dyn_cast<RankedTensorType>(ty)) {
+            if (auto ptrTy = llvm::dyn_cast<triton::PointerType>(tensorTy.getElementType())) {
+                resultTypes.emplace_back(MemRefType::get(tensorTy.getShape(), ptrTy.getPointeeType()));
+                continue;
+            }
+        }
+        resultTypes.emplace_back(ty);
+    }
+    auto newCustomOp = rewriter.create<hivm::CustomOp>(loc, resultTypes, op.getName(), adaptor.getInputs(), newOutputs,
+                                                       adaptor.getTempBuffers());
+    auto operandSegmentSizesAttr = newCustomOp->getAttr("operandSegmentSizes");
+    newCustomOp->setAttrs(op->getAttrs());
+    newCustomOp->setAttr("operandSegmentSizes", operandSegmentSizesAttr);
+    rewriter.replaceOp(op, newCustomOp.getResults());
+    rewriter.restoreInsertionPoint(ip);
+  } else {
+    auto res_types = adaptor.getOutputs().getTypes();
+    auto new_op = rewriter.create<hivm::CustomOp>(
+      op->getLoc(), res_types, adaptor.getOperands(), op->getAttrs());
+    rewriter.replaceOp(op, new_op);
+  }
 }
 
 // Design for load/store boundary_check.
@@ -2124,7 +2192,11 @@ void BlockDataParser::rewriteLoopOp(
   // in the loop body, so we can take advantage of the states we built up
   for (auto *region : newOp.getLoopRegions()) {
     for (auto &bodyOp : region->getOps()) {
-      if (auto addptrOp = dyn_cast<triton::AddPtrOp>(bodyOp)) {
+      if (isDistributedTypeCustomOp(&bodyOp)) {
+        auto customOp = dyn_cast<hivm::CustomOp>(bodyOp);
+        auto adaptor = hivm::CustomOp::Adaptor(customOp);
+        rewriteCustomOp(customOp, adaptor, rewriter);
+      } else if (auto addptrOp = dyn_cast<triton::AddPtrOp>(bodyOp)) {
         // FIXME: Constructed adaptor here does not hold the transformed op info.
         auto adaptor = triton::AddPtrOp::Adaptor(addptrOp);
         rewriteAddPtr(addptrOp, adaptor, rewriter, known);

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "ascend/include/TritonToLinalg/TritonToLinalgPass.h"
+#include "TritonToLinalg/BlockPtrAnalysis.h"
 #include "ascend/include/TritonToLinalg/ArgMinMaxConverter.h"
 #include "ascend/include/TritonToLinalg/FunctionConverter.h"
 #include "ascend/include/TritonToLinalg/LoadStoreConverter.h"
@@ -37,12 +38,14 @@
 #include "ascend/include/Utils/InterleaveOptimization.h"
 #include "ascend/include/Utils/Utils.h"
 
+#include "bishengir/Dialect/HFusion/IR/HFusion.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "bishengir/Dialect/HFusion/IR/HFusion.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/IR/TypeRange.h"
+#include "mlir/IR/Types.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #include "triton/Dialect/Triton/IR/Dialect.h"
@@ -98,10 +101,7 @@ public:
   matchAndRewrite(hivm::CustomOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override
   {
-    auto res_types = adaptor.getOutputs().getTypes();
-    auto new_op = rewriter.create<hivm::CustomOp>(
-      op->getLoc(), res_types, adaptor.getOperands(), op->getAttrs());
-    rewriter.replaceOp(op, new_op);
+    BlockDataParser::rewriteCustomOp(op, adaptor, rewriter);
     return success();
   }
 };

--- a/third_party/ascend/lib/TritonToLinalg/UseAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/UseAnalysis.cpp
@@ -554,6 +554,12 @@ LogicalResult triton::runUseAnalysis(triton::FuncOp &funcOp) {
       op->removeAttr("MetaUse");
     }
   });
+  // hivm.custom present library call, shouldn't be metause
+  funcOp.walk([&](hivm::CustomOp op) {
+    if (isMetaUse(op)) {
+      op->removeAttr("MetaUse");
+    }
+  });
   LLVM_DEBUG({
     os << "[UseAnalysis] After post-process, funcOp is " << *funcOp << "\n";
   });

--- a/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
@@ -23,8 +23,12 @@
 #include "TritonToUnstructure/OffsetAnalysis.h"
 #include "Utils/Utils.h"
 
+#include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "triton/Dialect/Triton/IR/Types.h"
 
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "triton-offset-analysis"
@@ -239,6 +243,12 @@ void parse(Value operand, const Location &loc, RewriterBase &rewriter,
         parseExtractSlice(extractSliceOp, loc, rewriter, offsetMap);
       } else if (auto insertSliceOp = dyn_cast<tensor::InsertSliceOp>(defOp)) {
         parseInsertSlice(insertSliceOp, loc, rewriter, offsetMap);
+      } else if (isDistributedTypeCustomOp(defOp)) {
+        auto customOp = dyn_cast<hivm::CustomOp>(defOp);
+        auto opResult = dyn_cast<OpResult>(operand);
+        assert(opResult && "Expected operand to be an OpResult");
+        unsigned resultIdx = opResult.getResultNumber();
+        parseCustomOp(customOp, loc, rewriter, offsetMap, resultIdx);
       }
     }
   } else if (auto blockArgument = dyn_cast<BlockArgument>(operand)) {
@@ -1141,6 +1151,41 @@ void parseIntToPtr(triton::IntToPtrOp op, const Location &loc,
   auto dst = op.getResult();
   offsetMap[dst] = PtrOffsetInfo(dst);
   offsetMap[dst].setScalarLike(true);
+}
+
+void parseCustomOp(hivm::CustomOp op, const Location &loc, RewriterBase &rewriter,
+                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap, unsigned int resultIdx)
+{
+    for (auto operand : op.getInputs()) {
+        parse(operand, op->getLoc(), rewriter, offsetMap);
+    }
+    auto dst = op->getResult(resultIdx);
+    offsetMap[dst] = PtrOffsetInfo();
+    auto tensorType = dyn_cast<RankedTensorType>(dst.getType());
+    if (!tensorType) {
+        if (isa<triton::PointerType>(dst.getType())) {
+            offsetMap[dst].setPtr(dst);
+            offsetMap[dst].setZeroOffset();
+        } else if (isa<IntegerType>(dst.getType())) {
+            offsetMap[dst].setOffset(dst);
+        } else {
+            emitError(loc) << "Unsupported return type for hivm.custom: " << dst.getType();
+        }
+        return;
+    }
+    if(llvm::isa<triton::PointerType>(tensorType.getElementType())){
+      if (checkStructureAnnotated(op, rewriter)) {
+        auto srcValArrayAttr = op->getAttrOfType<DenseI32ArrayAttr>(ConverterUtils::customSrcPtrIndexAttrName);
+        assert(srcValArrayAttr && "structure hivm.custom op should present src tensor<tt.ptr>");
+        auto srcValArray = srcValArrayAttr.asArrayRef();
+        assert(srcValArray[resultIdx] != -1 && "tensor<tt.ptr> result should map to src tensor<tt.ptr>");
+        auto srcOffsetInfo = offsetMap[op->getOperand(srcValArray[resultIdx])];
+        offsetMap[dst] = srcOffsetInfo;
+        return;
+      }
+      emitError(loc) << "Unsupported return unstructure RankedTensor of tt.ptr for hivm.custom: " << dst;
+    }
+    offsetMap[dst].setUnstructured(tensorType.getRank());
 }
 
 } // namespace triton

--- a/third_party/ascend/lib/Utils/Utils.cpp
+++ b/third_party/ascend/lib/Utils/Utils.cpp
@@ -22,6 +22,8 @@
 
 #include "ascend/include/Utils/Utils.h"
 
+#include "bishengir/Dialect/Annotation/IR/Annotation.h"
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -34,6 +36,7 @@
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Transforms/DialectConversion.h"
 
@@ -1306,5 +1309,21 @@ RankedTensorType getExtractSlicedType(ArrayRef<OpFoldResult> shape,
     }
   }
   return RankedTensorType::get(targetShape, elemType);
+}
+
+bool checkStructureAnnotated(Operation* op, RewriterBase& rewriter) {
+  return llvm::any_of(op->getUsers(), [&rewriter](Operation *user) {
+    auto annotationOp = dyn_cast<annotation::MarkOp>(user);
+    if (annotationOp && annotationOp->hasAttr(ConverterUtils::continuousAttrName)) {
+      rewriter.eraseOp(annotationOp);
+      return true;
+    }
+    return false;
+  });
+}
+
+bool isDistributedTypeCustomOp(Operation* op){
+  return op->hasAttr("hivm.is_distributed") &&
+         llvm::isa<hivm::CustomOp>(op);
 }
 } // namespace mlir

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/custom_op_ptr.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/custom_op_ptr.mlir
@@ -1,0 +1,84 @@
+// RUN: triton-opt --triton-to-linalg --split-input-file %s | FileCheck %s
+
+// Test hivm.hir.custom with distributed type producing tensor<tt.ptr> results
+// The custom op result type is converted to memref, and load uses the remapped result
+// CHECK-LABEL: func.func @test_custom_op_ptr_output
+// CHECK: hivm.hir.custom
+// CHECK-SAME: hivm.is_distributed
+// CHECK: memref
+
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @test_custom_op_ptr_output(%src_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %dst_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<0.000000e+00> : tensor<8xf32>
+    %empty = tensor.empty() : tensor<8x!tt.ptr<f32>>
+    %c8_i32 = arith.constant 8 : i32
+    %pid = tt.get_program_id x : i32
+    %offs = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+    %base = arith.muli %pid, %c8_i32 : i32
+    %base_splat = tt.splat %base : i32 -> tensor<8xi32>
+    %offs_full = arith.addi %offs, %base_splat : tensor<8xi32>
+
+    // Create input tensor<tt.ptr>
+    %src_ptrs = tt.splat %src_ptr : !tt.ptr<f32> -> tensor<8x!tt.ptr<f32>>
+    %src_addptr = tt.addptr %src_ptrs, %offs_full : tensor<8x!tt.ptr<f32>>, tensor<8xi32>
+
+    // hivm.hir.custom with distributed type producing tensor<tt.ptr> output
+    // The SrcPtrIndex maps result to input operand 0 for structured analysis
+    %custom_result = hivm.hir.custom
+        {hivm.is_distributed, hivm.pipe = #hivm.pipe<PIPE_V>, hivm.tcore_type = #hivm.tcore_type<VECTOR>, symbol = "test_ptr_op_impl", SrcPtrIndex = array<i32: 0>}
+        "test_ptr_op"
+        ins(%src_addptr : tensor<8x!tt.ptr<f32>>)
+        outs(%empty : tensor<8x!tt.ptr<f32>>) -> tensor<8x!tt.ptr<f32>>
+
+    // Load from custom result pointer - uses remapped value after conversion
+    %data = tt.load %custom_result : tensor<8x!tt.ptr<f32>>
+
+    // Store result
+    %dst_ptrs = tt.splat %dst_ptr : !tt.ptr<f32> -> tensor<8x!tt.ptr<f32>>
+    %dst_addptr = tt.addptr %dst_ptrs, %offs_full : tensor<8x!tt.ptr<f32>>, tensor<8xi32>
+    tt.store %dst_addptr, %data : tensor<8x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// -----
+
+// Test hivm.hir.custom with distributed type producing tt.ptr results
+// The custom op result type is converted to memref, and load uses the remapped result
+// CHECK-LABEL: func.func @test_custom_op_ptr_output
+// CHECK: hivm.hir.custom
+// CHECK-SAME: hivm.is_distributed
+// CHECK: memref
+
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @test_custom_op_ptr_output(%src_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %dst_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<0.000000e+00> : tensor<8xf32>
+    %c8_i32 = arith.constant 8 : i32
+    %pid = tt.get_program_id x : i32
+    %offs = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+    %base = arith.muli %pid, %c8_i32 : i32
+    %base_splat = tt.splat %base : i32 -> tensor<8xi32>
+    %offs_full = arith.addi %offs, %base_splat : tensor<8xi32>
+
+    // Create input tensor<tt.ptr>
+    %src_ptrs = tt.splat %src_ptr : !tt.ptr<f32> -> tensor<8x!tt.ptr<f32>>
+    %src_addptr = tt.addptr %src_ptrs, %offs_full : tensor<8x!tt.ptr<f32>>, tensor<8xi32>
+
+    // hivm.hir.custom with distributed type producing tensor<tt.ptr> output
+    // The SrcPtrIndex maps result to input operand 0 for structured analysis
+    %custom_result = hivm.hir.custom
+        {hivm.is_distributed, hivm.pipe = #hivm.pipe<PIPE_V>, hivm.tcore_type = #hivm.tcore_type<VECTOR>, symbol = "test_ptr_op_impl"}
+        "test_ptr_op"
+        ins(%src_ptr : !tt.ptr<f32>) -> !tt.ptr<f32>
+    %custom_splat = tt.splat %custom_result : !tt.ptr<f32> -> tensor<8x!tt.ptr<f32>>
+    %src_addptr1 = tt.addptr %custom_splat, %offs_full : tensor<8x!tt.ptr<f32>>, tensor<8xi32>
+    // Load from custom result pointer - uses remapped value after conversion
+    %data = tt.load %src_addptr1 : tensor<8x!tt.ptr<f32>>
+
+    // Store result
+    %dst_ptrs = tt.splat %dst_ptr : !tt.ptr<f32> -> tensor<8x!tt.ptr<f32>>
+    %dst_addptr = tt.addptr %dst_ptrs, %offs_full : tensor<8x!tt.ptr<f32>>, tensor<8xi32>
+    tt.store %dst_addptr, %data : tensor<8x!tt.ptr<f32>>
+    tt.return
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/custom_op_offset.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/custom_op_offset.mlir
@@ -1,0 +1,28 @@
+// RUN: triton-opt %s --triton-to-unstructure | FileCheck %s
+
+// Test hivm.hir.custom with distributed type and ContinuousMemAccess annotation
+// The annotation is processed by checkStructureAnnotated and erased during analysis
+// CHECK-LABEL: tt.func @test_custom_op_offset
+// CHECK: hivm.hir.custom
+// CHECK-SAME: hivm.is_distributed
+// CHECK-NOT: annotation.mark
+
+tt.func @test_custom_op_offset(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>) -> tensor<8xf32> {
+    %0 = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+    %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<8x!tt.ptr<f32>>
+    %2 = tt.addptr %1, %0 : tensor<8x!tt.ptr<f32>>, tensor<8xi32>
+    %empty = tensor.empty() : tensor<8x!tt.ptr<f32>>
+
+    // hivm.hir.custom with distributed type producing tensor<tt.ptr> output
+    %3 = hivm.hir.custom
+        {hivm.is_distributed, hivm.pipe = #hivm.pipe<PIPE_V>, hivm.tcore_type = #hivm.tcore_type<VECTOR>, symbol = "test_offset_op_impl", SrcPtrIndex = array<i32: 0>}
+        "test_offset_op"
+        ins(%2 : tensor<8x!tt.ptr<f32>>)
+        outs(%empty : tensor<8x!tt.ptr<f32>>) -> tensor<8x!tt.ptr<f32>>
+
+    // Mark as continuous mem access - this annotation is processed and erased during analysis
+    annotation.mark %3 {ContinuousMemAccess} : tensor<8x!tt.ptr<f32>>
+
+    %4 = tt.load %3 : tensor<8x!tt.ptr<f32>>
+    tt.return %4 : tensor<8xf32>
+}


### PR DESCRIPTION
Consider cases as below:
1. this custom op will return tensor<!tt.ptr> value, it will enter in OffsetAnalysis
```
%a_ptrs_83 = hivm.hir.custom {SrcPtrIndex = array<i32: 0>, hivm.is_distributed, hivm.pipe = #hivm.pipe<PIPE_S>, hivm.tcore_type = #hivm.tcore_type<CUBE_AND_VECTOR>, hivm.vf_mode = #hivm.vf_mode<SIMD>, no_side_effect, symbol = "aclshmem_consume_token_half_ptr_2d"} "dist.aclshmem_consume_token_half_ptr_2d" ins(%a_ptrs_76, %token_34 : tensor<128x32x!tt.ptr<f16>>, i32) outs(%a_ptrs_82 : tensor<128x32x!tt.ptr<f16>>) -> tensor<128x32x!tt.ptr<f16>>
```
2. this custom op will return !tt.ptr value, if it is used by tt.load, it will enter in BlockPtrAnalysis
```
%remote_mem_ptr = hivm.hir.custom {hivm.is_distributed, hivm.pipe = #hivm.pipe<PIPE_S>, hivm.tcore_type = #hivm.tcore_type<CUBE_AND_VECTOR>, hivm.vf_mode = #hivm.vf_mode<SIMD>, no_side_effect, symbol = "aclshmem_ptr_int64"} "dist.aclshmem_ptr_int64" ins(%remote_ptr, %target_rank : !tt.ptr<i64>, i32) -> !tt.ptr<i64>
```
so in this PR, we add hivm custom op adaption for BlockPtrAnalysis and OffsetAnalysis
fixes https://github.com/triton-lang/triton-ascend/issues/418

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
