### PR TITLE
fix(ssbuffer): Deduplicate inputs and C2V dependencies in DataDependencyAnalysis

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
@@ -31,6 +31,7 @@
 #include "mlir/Pass/Pass.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 
@@ -42,7 +43,7 @@ struct BlockInfo {
   int blockId;
   bool isCube;
   bool isControl;
-  llvm::SmallVector<mlir::Value> inputs;
+  llvm::SetVector<mlir::Value> inputs;
   llvm::SmallVector<mlir::Value> outputs;
   llvm::SmallVector<mlir::Operation*> Operations;
 };
@@ -67,7 +68,7 @@ public:
     }
 
   // for MLIR Analysis framework
-  bool isInvalidated(const mlir::AnalysisManager::PreservedAnalyses &pa) 
+  bool isInvalidated(const mlir::AnalysisManager::PreservedAnalyses &pa)
   {
     return false;
   }

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -37,6 +37,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/Value.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/ADT/SmallVector.h"
 
@@ -154,7 +155,7 @@ void DataDependencyAnalysisPass::collectBlockInfo(DataDependencyInfo &info, int 
             mlir::Operation *defOp = operand.getDefiningOp();
             // If defOp is not null and defOp is not in current ops set, it's an external input
             if (!defOp || opSet.find(defOp) == opSet.end()) {
-                blockInfo.inputs.push_back(operand);
+                blockInfo.inputs.insert(operand);
             }
         }
         for (auto result : op->getResults()) {
@@ -345,7 +346,7 @@ void DataDependencyAnalysisPass::processIterArgDependencies()
             auto initDefResult = dyn_cast<mlir::OpResult>(initValue);
             auto initCoreType = getCoreTypeWithIndex(initDefOp, initDefResult ? initDefResult.getResultNumber() : 0);
             auto yieldCoreType = getCoreTypeWithIndex(forOp, iterArgIndex);
-            
+
             // Only process if init and yield have matching core types
             // Mismatch indicates a more complex dependency pattern that requires special handling
             if (initCoreType != yieldCoreType) {
@@ -437,7 +438,9 @@ void DataDependencyAnalysisPass::analyzeExternalOutputs(DataDependencyInfo &info
             if (resultCoreType != ssbufferCoreTypeCubeAttr) {
                 continue;
             }
+
             // Check who is using this output
+            llvm::DenseSet<int> handledBlockIds;
             for (mlir::Operation *user : output.getUsers()) {
                 int outputIndex = 0;
                 if (isControlFlowOp(user)) {
@@ -461,8 +464,11 @@ void DataDependencyAnalysisPass::analyzeExternalOutputs(DataDependencyInfo &info
                         continue;
                     }
                     int consumerId = static_cast<int>(*consumerIdOpt);
-                    collectDepInfo(output, DependencyType::CubeToVector, c2vDependencies, blockInfo.blockId, consumerId,
-                        info);
+                    auto inserted = handledBlockIds.insert(consumerId).second;
+                    if (inserted) {
+                      collectDepInfo(output, DependencyType::CubeToVector, c2vDependencies, blockInfo.blockId, consumerId,
+                          info);
+                    }
                 }
                 // If user belongs to Cube block, this C->C dependency was handled
                 // in the Input analysis phase, so here we only handle C->V.

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -566,7 +566,9 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(OpBuilder &b
     attachTransferTags(toTensorOp, cubeBlockId, "CUBE", transferIndex);
     LOG_DEBUG("[toTensorOp]: " << *toTensorOp << "\n");
 
-    for (Operation *user : srcValue.getUsers()) {
+    llvm::SmallVector<Operation *> users(srcValue.getUsers().begin(), srcValue.getUsers().end());
+    for (Operation *user : users) {
+        LOG_DEBUG("[v->c user]" << *user << "\n");
         auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
         if (userBlockIdOpt && static_cast<int>(*userBlockIdOpt) == iniConsumerId) {
             user->replaceUsesOfWith(srcValue, toTensorOp.getResult());
@@ -616,7 +618,9 @@ Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(OpBuilder &b
     attachTransferTags(toTensorOp, vecBlockId, "VECTOR", transferIndex);
     LOG_DEBUG("[toTensorOp]: " << *toTensorOp << "\n");
 
-    for (Operation *user : srcValue.getUsers()) {
+    llvm::SmallVector<Operation *> users(srcValue.getUsers().begin(), srcValue.getUsers().end());
+    for (Operation *user : users) {
+        LOG_DEBUG("[c->v user]" << *user << "\n");
         auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
         if (userBlockIdOpt && static_cast<int>(*userBlockIdOpt) == iniConsumerId) {
             user->replaceUsesOfWith(srcValue, toTensorOp.getResult());

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/dep-dedup.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/dep-dedup.mlir
@@ -1,0 +1,50 @@
+// RUN: triton-opt --add-block-id-for-control-ops --data-dependency-analysis --inter-core-transfer-and-sync --mark-main-loop %s | FileCheck %s
+
+module {
+  // Test 1: C->V Deduplication (Multiple Vector ops in Block 2 using the same Cube output from Block 1)
+  // CHECK-LABEL: func.func @test_c2v_dedup
+  func.func @test_c2v_dedup(%arg0: memref<256x256xf16>) {
+    %alloc = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<256x256xf16>
+    %t0 = bufferization.to_tensor %alloc {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<256x256xf16>
+    %cst = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} 0.0 : f16
+    %empty = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : tensor<256x256xf32>
+    %init = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : f16) outs(%empty : tensor<256x256xf32>) -> tensor<256x256xf32>
+
+    // Block 1 (CUBE) produces %mat1
+    %mat1 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%t0, %t0 : tensor<256x256xf16>, tensor<256x256xf16>) outs(%init : tensor<256x256xf32>) -> tensor<256x256xf32>
+
+    // Block 2 (VECTOR) uses %mat1 twice
+    %exp1 = math.exp %mat1 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : tensor<256x256xf32>
+    %exp2 = math.absf %mat1 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : tensor<256x256xf32>
+    return
+  }
+  // CHECK: %[[MATMUL:[a-z0-9_]+]] = linalg.matmul
+  // CHECK: %[[ALLOC_C2V:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32}
+  // CHECK: hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32} ins(%[[MATMUL]] : tensor<256x256xf32>) outs(%[[ALLOC_C2V]] : memref<256x256xf32, #hivm.address_space<ub>>)
+  // CHECK: hivm.hir.sync_block_set {ssbuffer.analyze_flag_id, ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_FIX>, <PIPE_V>] flag = 2
+  // CHECK: hivm.hir.sync_block_wait {ssbuffer.analyze_flag_id, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 2
+  // CHECK-NOT: hivm.hir.fixpipe
+  // CHECK-NOT: hivm.hir.sync_block_set
+  // CHECK-NOT: hivm.hir.sync_block_wait
+
+  // Test 2: V->C Deduplication (Multiple Cube ops in Block 2 using the same Vector output from Block 1)
+  // CHECK-LABEL: func.func @test_v2c_dedup
+  func.func @test_v2c_dedup(%arg0: tensor<256x256xf32>) {
+    // Block 1 (VECTOR) produces %exp
+    %exp = math.exp %arg0 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : tensor<256x256xf32>
+
+    // Block 2 (CUBE) uses %exp twice
+    %t2 = tensor.empty() {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE"} : tensor<256x256xf32>
+    %transposed1 = linalg.transpose ins(%exp : tensor<256x256xf32>) outs(%t2 : tensor<256x256xf32>) permutation = [1, 0]  {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE"}
+    %transposed2 = linalg.transpose ins(%exp : tensor<256x256xf32>) outs(%t2 : tensor<256x256xf32>) permutation = [1, 0]  {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE"}
+    return
+  }
+  // CHECK: %[[EXP:[a-z0-9_]+]] = math.exp
+  // CHECK: %[[ALLOC_V2C:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32}
+  // CHECK: hivm.hir.copy ins({{.*}} : tensor<32x16x16x8xf32>) outs(%[[ALLOC_V2C]] : memref<32x16x16x8xf32, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32}
+  // CHECK: hivm.hir.sync_block_set {ssbuffer.analyze_flag_id, ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
+  // CHECK: hivm.hir.sync_block_wait {ssbuffer.analyze_flag_id, ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
+  // CHECK-NOT: hivm.hir.copy
+  // CHECK-NOT: hivm.hir.sync_block_set
+  // CHECK-NOT: hivm.hir.sync_block_wait
+}


### PR DESCRIPTION
## Description / 概述

### English
This PR addresses some redundant data issues in the data dependency analysis within the `DynamicCVPipeline`. Specifically, it introduces deduplication for block inputs and Cube-to-Vector (C2V) dependencies to improve the accuracy of the analysis representation.

### 中文
此 PR 旨在处理 `DynamicCVPipeline` 数据依赖分析中产生的部分冗余数据。具体而言，它对 Block 的输入以及 Cube-to-Vector (C2V) 依赖关系进行了去重，以提升依赖分析表示的准确性。

---

## Key Changes / 主要修改

### English
1. **Deduplicate Block Inputs**:
   - Changed the type of `blockInfo.inputs` from `llvm::SmallVector<mlir::Value>` to `llvm::DenseSet<mlir::Value>`.
   - This ensures that if multiple operations within the same block reference the same external `mlir::Value`, it is only recorded as a single input in `blockInfo.inputs`.

2. **Deduplicate Cube-to-Vector (C2V) Dependencies**:
   - Introduced a `llvm::DenseSet<int> handledBlockIds` during the user-traversal phase for C2V dependencies.
   - This ensures that a dependency between the current block and a consumer block is recorded at most once, even if multiple operations inside the consumer block use the same output.

3. **Code Cleanup**:
   - Removed minor trailing whitespaces and adjusted end-of-file formatting.

### 中文
1. **对 Block 输入去重**：
   - 将 `blockInfo.inputs` 的类型从 `llvm::SmallVector<mlir::Value>` 变更为 `llvm::DenseSet<mlir::Value>`。
   - 从而避免了当同一个 Block 内有多个操作引用同一个外部 `mlir::Value` 时，该值被多次重复加入输入列表的问题。

2. **对 Cube-to-Vector (C2V) 依赖关系去重**：
   - 在遍历用户以建立 C2V 依赖的阶段，引入了 `llvm::DenseSet<int> handledBlockIds`。
   - 这可以确保即使消费者 Block 内有多个操作同时使用了该输出，当前 Block 与该消费者 Block 之间的依赖关系也只会被记录一次。

3. **代码清理**：
   - 清理了部分行尾空格，并对文件末尾的换行进行了规范化处理。