### PR TITLE
feat(ssbuffer): add Quantization Pattern to fixpipe opt

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
@@ -24,6 +24,7 @@
 #include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -32,9 +33,14 @@
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Block.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
+#include "mlir/Support/LLVM.h"
+#include "triton/Analysis/Utility.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
@@ -56,6 +62,7 @@ class FixpipeOptPass : public PassWrapper<FixpipeOptPass, OperationPass<ModuleOp
     void runOnOperation() override;
 
     llvm::StringRef getArgument() const final { return "fixpipe-opt"; }
+    void getDependentDialects(DialectRegistry &registry) const override;
 
     llvm::StringRef getDescription() const final
     {
@@ -63,11 +70,15 @@ class FixpipeOptPass : public PassWrapper<FixpipeOptPass, OperationPass<ModuleOp
     }
 
   private:
-    bool matchFixpipePattern(linalg::MatmulOp matmulOp, SmallVector<Operation *> &matchedOps);
-    bool applyFixpipeOpt(SmallVector<Operation *> &matchedOps, const CVPipeline::MemoryDependenceGraph &memGraph,
+    bool matchFixpipePattern(linalg::MatmulOp matmulOp, SetVector<Operation *> &matchedOps);
+    bool isFixpipeCastPattern(Operation *truncOp, SetVector<Operation *> &matchedOps);
+    bool isFixpipeMulPattern(Operation *mulOp, SetVector<Operation *> &matchedOps);
+    bool isStoreToGM(Operation *materializeOp, SetVector<Operation *> &matchedOps);
+    bool applyFixpipeOpt(SetVector<Operation *> &matchedOps, const CVPipeline::MemoryDependenceGraph &memGraph,
                          CVPipeline::ComputeBlockIdManager &bm);
-    bool isSubviewFromGlobalMemory(memref::SubViewOp subviewOp, SmallVector<Operation *> &matchedOps);
+    bool isSubviewFromGlobalMemory(ViewLikeOpInterface viewOp, SetVector<Operation *> &matchedOps);
     bool isValidTrunc(Operation *op);
+    bool isValidMul(Operation *op, Value matmulValues, SetVector<Operation *> &matchedOps);
 };
 
 namespace {
@@ -122,7 +133,7 @@ bool DependencyCycleDetector::dfs(Operation *cur)
  * Walk from every op in targetBlockId and willaddOps.
  * if reach other blockid ops and dfs find any targetBlockId op, then there is cycle.
  */
-static std::optional<bool> willCreateCycle(llvm::SmallVectorImpl<Operation *> &willaddOps, Block *block,
+static std::optional<bool> willCreateCycle(SetVector<Operation *> &willaddOps, Block *block,
                                            const CVPipeline::MemoryDependenceGraph &memGraph, int targetBlockId,
                                            CVPipeline::ComputeBlockIdManager &bm)
 {
@@ -208,15 +219,109 @@ bool FixpipeOptPass::isValidTrunc(Operation *op)
     return false;
 }
 
-bool FixpipeOptPass::isSubviewFromGlobalMemory(memref::SubViewOp subviewOp, SmallVector<Operation *> &matchedOps)
+/** Determines if a value is "scalar-like" based on the following criteria:
+ 1. True scalar types (integer, index, or float)
+ 2. Tensor types with empty shape (e.g., tensor<f32>)
+ 3. Constant tensors where all elements have the same value (splat constants)
+ 4. Tensors with shape where all dimensions equal 1 (single-element tensors)
+ */
+static bool isScalarLike(Value value)
+{
+    Type type = value.getType();
+    auto shapedType = dyn_cast<ShapedType>(type);
+
+    // 1. scalar
+    if (!shapedType) {
+        return type.isIntOrIndexOrFloat();
+    }
+
+    // 2. tensor<f32> with empty shape is also considered scalar-like
+    ArrayRef<int64_t> shape = shapedType.getShape();
+    if (shape.empty()) {
+        return true;
+    }
+
+    // 3. tensor with constant value
+    Attribute attr;
+    if (matchPattern(value, m_Constant(&attr))) {
+        auto denseAttr = dyn_cast<DenseIntOrFPElementsAttr>(attr);
+        return denseAttr && denseAttr.isSplat() && denseAttr.getElementType().isIntOrIndexOrFloat();
+    }
+
+    // 4. tensor with one element
+    return llvm::all_of(shape, [](int64_t dim) { return dim == 1; });
+}
+
+void transSource(Value value, SetVector<Operation *> &matchedOps, Block *block)
+{
+    if (!isScalarLike(value)) {
+        return;
+    }
+
+    if (auto defOp = value.getDefiningOp()) {
+        // We need to find one point, value changes from tensor to scalar.
+        // So use specific op condition to stop searching.
+        if (isa<tensor::ExtractOp>(defOp)) {
+            return;
+        }
+        if (llvm::find(matchedOps, defOp) != matchedOps.end()) {
+            return;
+        }
+        if (defOp->getBlock() != block) {
+            return;
+        }
+        matchedOps.insert(defOp);
+        defOp->walk([&](Operation *nestedOp) {
+            for (Value operand : nestedOp->getOperands()) {
+                transSource(operand, matchedOps, block);
+            }
+        });
+    }
+}
+
+bool FixpipeOptPass::isValidMul(Operation *op, Value matmulValue, SetVector<Operation *> &matchedOps)
+{
+    // Just filter: arith.mulf/muli(scalar)
+    if (!isa<arith::MulFOp>(op) && !isa<arith::MulIOp>(op)) {
+        return false;
+    }
+    auto quantScalarValue = op->getOperand(0) == matmulValue ? op->getOperand(1) : op->getOperand(0);
+    if (isScalarLike(quantScalarValue)) {
+        transSource(quantScalarValue, matchedOps, op->getBlock());
+        return true;
+    }
+
+    // From one fill op with constant value or args....
+    if (auto defOp = quantScalarValue.getDefiningOp()) {
+        if (auto fillOp = dyn_cast<linalg::FillOp>(defOp)) {
+            auto operands = fillOp->getOperands();
+            if (!operands.empty()) {
+                Value fillValue = operands[0];
+                if (isScalarLike(fillValue)) {
+                    if (llvm::find(matchedOps, fillOp) == matchedOps.end() && fillOp.getBlock() == op->getBlock()) {
+                        matchedOps.insert(fillOp);
+                    }
+                    transSource(fillValue, matchedOps, op->getBlock());
+                    return true;
+                } else {
+                    LOG_DEBUG("Fill operand is not scalar-like, NOT match. fill=" << *fillOp);
+                    return false;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+bool FixpipeOptPass::isSubviewFromGlobalMemory(ViewLikeOpInterface viewOp, SetVector<Operation *> &matchedOps)
 {
     // Subview ops may be nested many layers deep through reinterpretation or other subviews.
     // like, subview (subview (reinterpret_cast (subview (reinterpret_cast (arg0)))))
     // so we need Search and only keep same block view-like op.
-    Value source = subviewOp.getSource();
-    auto block = subviewOp->getBlock();
+    Value source = viewOp.getViewSource();
+    auto block = viewOp->getBlock();
     while (true) {
-        LOG_DEBUG("Check subview source: " << source << "\n");
+        LOG_DEBUG("Check view source: " << source << "\n");
         if (auto blockArg = dyn_cast<BlockArgument>(source)) {
             Operation *parentOp = blockArg.getOwner()->getParentOp();
             if (isa<func::FuncOp>(parentOp)) {
@@ -229,7 +334,7 @@ bool FixpipeOptPass::isSubviewFromGlobalMemory(memref::SubViewOp subviewOp, Smal
         // From other view-like op
         if (auto viewLike = dyn_cast<ViewLikeOpInterface>(source.getDefiningOp())) {
             if (viewLike->getBlock() == block) {
-                matchedOps.push_back(viewLike.getOperation());
+                matchedOps.insert(viewLike.getOperation());
             }
             source = viewLike.getViewSource();
             continue;
@@ -240,7 +345,34 @@ bool FixpipeOptPass::isSubviewFromGlobalMemory(memref::SubViewOp subviewOp, Smal
     return false;
 }
 
-/** To use fixpipe optimization, the pattern should be like below:
+bool FixpipeOptPass::isStoreToGM(Operation *storeOp, SetVector<Operation *> &matchedOps)
+{
+    ViewLikeOpInterface viewOp = nullptr;
+    if (auto materializeOp = dyn_cast<bufferization::MaterializeInDestinationOp>(storeOp)) {
+        Value destMemref = materializeOp.getDest();
+        viewOp = destMemref.getDefiningOp<ViewLikeOpInterface>();
+    } else if (auto hivmStore = dyn_cast<hivm::StoreOp>(storeOp)) {
+        auto dest = hivmStore.getDst();
+        viewOp = dest.getDefiningOp<ViewLikeOpInterface>();
+    } else {
+        LOG_DEBUG("Cannot find store op, NOT match");
+        return false;
+    }
+
+    if (!viewOp) {
+        LOG_DEBUG("store destination is not from ViewLikeOpInterface, NOT match");
+        return false;
+    }
+    matchedOps.insert(storeOp);
+    matchedOps.insert(viewOp);
+    if (!isSubviewFromGlobalMemory(viewOp, matchedOps)) {
+        LOG_DEBUG("Subview is not from global memory (GM), NOT match.");
+        return false;
+    }
+    return true;
+}
+
+/** Fixpipe supports cast, the pattern should be like below:
     linalg.matmul
         ↓
     arith.truncf(f32->bf16, f32->f16, i32->i8)
@@ -250,22 +382,8 @@ bool FixpipeOptPass::isSubviewFromGlobalMemory(memref::SubViewOp subviewOp, Smal
     bufferization.materialize_in_destination memref.subview(gm)
     After optimization, all these ops will be in same block with matmul and set core_type to CUBE.
  */
-bool FixpipeOptPass::matchFixpipePattern(linalg::MatmulOp matmulOp, SmallVector<Operation *> &matchedOps)
+bool FixpipeOptPass::isFixpipeCastPattern(Operation *truncOp, SetVector<Operation *> &matchedOps)
 {
-    Value matmulResult = matmulOp.getResult(0);
-    if (!matmulResult.hasOneUse()) {
-        LOG_DEBUG("Matmul not only one user, NOT match.");
-        return false;
-    }
-    auto maybeTrunc = *matmulResult.getUsers().begin();
-    Operation *truncOp = nullptr;
-    if (isValidTrunc(maybeTrunc)) {
-        truncOp = maybeTrunc;
-    } else {
-        LOG_DEBUG("Cannot find valid trunc op (f32->bf16/f16 or i32->i8), NOT match.");
-        return false;
-    }
-
     Value truncResult = truncOp->getResult(0);
     if (!truncResult.hasOneUse()) {
         LOG_DEBUG("Trunc not only one user, NOT match.");
@@ -295,27 +413,92 @@ bool FixpipeOptPass::matchFixpipePattern(linalg::MatmulOp matmulOp, SmallVector<
         return false;
     }
 
-    Value destMemref = materializeOp.getDest();
-    auto subviewOp = destMemref.getDefiningOp<memref::SubViewOp>();
-    if (!subviewOp) {
-        LOG_DEBUG("Materialize destination is not from memref.subview, NOT match");
-        return false;
-    }
-
-    matchedOps.push_back(matmulOp);
-    matchedOps.push_back(truncOp);
-    matchedOps.push_back(extractSliceOp);
-    matchedOps.push_back(materializeOp);
-    matchedOps.push_back(subviewOp);
-
-    if (!isSubviewFromGlobalMemory(subviewOp, matchedOps)) {
-        LOG_DEBUG("Subview is not from global memory (GM), NOT match.");
+    matchedOps.insert(truncOp);
+    matchedOps.insert(extractSliceOp);
+    if (!isStoreToGM(materializeOp, matchedOps)) {
+        LOG_DEBUG("Not store to GM pattern, NOT match.");
         return false;
     }
     return true;
 }
 
-bool FixpipeOptPass::applyFixpipeOpt(SmallVector<Operation *> &matchedOps,
+/** Fixpipe supports scaling, the pattern should be like below:
+    linalg.matmul
+        ↓
+    arith.mulf/muli (mul one scalar-like value for quantization)
+        ↓
+    tensor.extract_slice (optional)
+        ↓
+    bufferization.materialize_in_destination memref.subview(gm)
+    After optimization, all these ops will be in same block with matmul and set core_type to CUBE.
+ */
+bool FixpipeOptPass::isFixpipeMulPattern(Operation *mulOp, SetVector<Operation *> &matchedOps)
+{
+    Value mulResult = mulOp->getResult(0);
+    if (!mulResult.hasOneUse()) {
+        LOG_DEBUG("Mul not only one user, NOT match.");
+        return false;
+    }
+    auto maybeExtract = *mulResult.getUsers().begin();
+    tensor::ExtractSliceOp extractSliceOp = nullptr;
+    Value extractResult = mulResult;
+    if (auto extract = dyn_cast<tensor::ExtractSliceOp>(maybeExtract)) {
+        extractSliceOp = extract;
+        extractResult = extractSliceOp.getResult();
+        matchedOps.insert(extractSliceOp);
+    }
+
+    if (!extractResult.hasOneUse()) {
+        LOG_DEBUG("Extract Slice not only one user, NOT match.");
+        return false;
+    }
+
+    matchedOps.insert(mulOp);
+    if (!isStoreToGM(*extractResult.getUsers().begin(), matchedOps)) {
+        LOG_DEBUG("Not store to GM pattern, NOT match.");
+        return false;
+    }
+    return true;
+}
+
+/** Match fixpipe optimization patterns starting from a matmul operation.
+ Pattern 1 (Cast Pattern):
+   linalg.matmul -> arith.truncf/i -> tensor.extract_slice ->
+   bufferization.materialize_in_destination(memref.subview(gm))
+
+ Pattern 2 (Quantization Pattern):
+   linalg.matmul -> arith.mulf -> tensor.extract_slice ->
+   bufferization.materialize_in_destination(memref.subview(gm))
+ */
+bool FixpipeOptPass::matchFixpipePattern(linalg::MatmulOp matmulOp, SetVector<Operation *> &matchedOps)
+{
+    LOG_DEBUG("Check matmul op: " << *matmulOp);
+    Value matmulResult = matmulOp.getResult(0);
+    if (!matmulResult.hasOneUse()) {
+        LOG_DEBUG("Matmul not only one user, NOT match.");
+        return false;
+    }
+    matchedOps.insert(matmulOp);
+
+    auto matmulUser = *matmulResult.getUsers().begin();
+
+    if (isValidTrunc(matmulUser)) {
+        if (isFixpipeCastPattern(matmulUser, matchedOps)) {
+            return true;
+        }
+    } else if (isValidMul(matmulUser, matmulResult, matchedOps)) {
+        if (isFixpipeMulPattern(matmulUser, matchedOps)) {
+            return true;
+        }
+    } else {
+        LOG_DEBUG("Cannot find valid consumer op (trunc or mulf), NOT match.");
+        return false;
+    }
+
+    return false;
+}
+
+bool FixpipeOptPass::applyFixpipeOpt(SetVector<Operation *> &matchedOps,
                                      const CVPipeline::MemoryDependenceGraph &memGraph,
                                      CVPipeline::ComputeBlockIdManager &bm)
 {
@@ -323,6 +506,12 @@ bool FixpipeOptPass::applyFixpipeOpt(SmallVector<Operation *> &matchedOps,
     // 1. Change block_id to the matmul's block id
     // 2. Change core_type to CUBE.
     Operation *matmulOp = matchedOps[0];
+    for (auto op : matchedOps) {
+        if (isa<linalg::MatmulOp>(op)) {
+            matmulOp = op;
+            break;
+        }
+    }
     int targetBlockId = bm.getBlockIdByOp(matmulOp);
     auto block = matmulOp->getBlock();
 
@@ -330,12 +519,22 @@ bool FixpipeOptPass::applyFixpipeOpt(SmallVector<Operation *> &matchedOps,
         return false;
     }
     for (Operation *op : matchedOps) {
-        bm.updateBlockId(op, targetBlockId);
-    }
-    for (Operation *op : matchedOps) {
-        op->setAttr(CVPipeline::kCoreType, StringAttr::get(op->getContext(), "CUBE"));
+        if (isa<scf::SCFDialect>(op->getDialect())) {
+            op->walk([&](Operation *nestedOp) {
+                bm.updateBlockId(nestedOp, targetBlockId);
+                nestedOp->setAttr(CVPipeline::kCoreType, StringAttr::get(op->getContext(), "CUBE"));
+            });
+        } else {
+            bm.updateBlockId(op, targetBlockId);
+            op->setAttr(CVPipeline::kCoreType, StringAttr::get(op->getContext(), "CUBE"));
+        }
     }
     return true;
+}
+
+void FixpipeOptPass::getDependentDialects(DialectRegistry &registry) const
+{
+    registry.insert<hivm::HIVMDialect>();
 }
 
 void FixpipeOptPass::runOnOperation()
@@ -346,15 +545,49 @@ void FixpipeOptPass::runOnOperation()
     LOG_DEBUG("== FixpipeOpt Pass Start ==\n");
     LOG_DEBUG(module);
 
-    SmallVector<SmallVector<Operation *>> allMatchedPatterns;
+    SmallVector<SetVector<Operation *>> allMatchedPatterns;
 
     module.walk([&](linalg::MatmulOp matmulOp) {
-        SmallVector<Operation *> matchedOps;
+        SetVector<Operation *> matchedOps;
         if (matchFixpipePattern(matmulOp, matchedOps)) {
             allMatchedPatterns.push_back(matchedOps);
         }
     });
     LOG_DEBUG("== Found " << allMatchedPatterns.size() << " fixpipe patterns ==\n");
+
+    /** Inorder to avoid cycle, clone scalar-like ops.
+        A-> B -> C
+        ↘      ↗
+            D
+        Now we want to fuse A/B/C, so clone A' for D to avoid cycle.
+    */
+    auto bmOriginal = CVPipeline::ComputeBlockIdManager(module);
+    for (auto &matchedOps : allMatchedPatterns) {
+        auto sorted = mlir::multiRootTopologicalSort(matchedOps);
+        for (Operation *op : llvm::reverse(sorted)) {
+            if (op->getNumResults() == 1 && isScalarLike(op->getResult(0))) {
+                // replace op not in matchedOps with cloned op, and keep original op for other pattern.
+                SmallVector<OpOperand *> otherUses;
+                for (auto &use : op->getResult(0).getUses()) {
+                    Operation *userOp = use.getOwner();
+                    auto userInBlock = CVPipeline::getAncestorInBlock(userOp, op->getBlock());
+                    if (llvm::find(matchedOps, userInBlock) == matchedOps.end() &&
+                        bmOriginal.getBlockIdByOp(userInBlock) != bmOriginal.getBlockIdByOp(matchedOps[0]))
+                    {
+                        otherUses.push_back(&use);
+                    }
+                }
+                if (otherUses.size() > 0) {
+                    LOG_DEBUG("now cloned: " << *op << "\n");
+                    OpBuilder builder(op);
+                    auto clonedOp = builder.clone(*op);
+                    for (auto use : otherUses) {
+                        (*use).set(clonedOp->getResult(0));
+                    }
+                }
+            }
+        }
+    }
 
     auto bm = CVPipeline::ComputeBlockIdManager(module);
     for (auto &matchedOps : allMatchedPatterns) {

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/fixpipe_opt.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/fixpipe_opt.mlir
@@ -201,4 +201,105 @@ module {
     bufferization.materialize_in_destination %extract2 in writable %subview2 {ssbuffer.block_id = 104 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
     return
   }
+
+  // Test 12: mulf with splat constant tensor - should match (scalar-like via constant splat)
+  // CHECK-LABEL: func @test_mulf_with_scalar_constant
+  func.func @test_mulf_with_scalar_constant(%arg0: memref<128x64xf32> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>) {
+    %c0 = arith.constant 0 : index
+    // CHECK: linalg.matmul {ssbuffer.block_id = 111 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 111 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 111 : i32, ssbuffer.core_type = "CUBE"}
+    %scale_tensor = arith.constant dense<0.003921568627> : tensor<64x64xf32>
+    %mulf = arith.mulf %matmul, %scale_tensor {ssbuffer.block_id = 112 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 111 : i32, ssbuffer.core_type = "CUBE"}
+    %extract = tensor.extract_slice %mulf[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 113 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf32>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 111 : i32, ssbuffer.core_type = "CUBE"}
+    %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 114 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf32> to memref<64x64xf32, strided<[64, 1]>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 111 : i32, ssbuffer.core_type = "CUBE"}
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 115 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf32>, memref<64x64xf32, strided<[64, 1]>>) -> ()
+    return
+  }
+
+  // Test 13: mulf with splat constant tensor (reversed order) - should match
+  // CHECK-LABEL: func @test_mulf_with_scalar_constant_reversed
+  func.func @test_mulf_with_scalar_constant_reversed(%arg0: memref<128x64xf32> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>) {
+    // CHECK: linalg.matmul {ssbuffer.block_id = 121 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 121 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 121 : i32, ssbuffer.core_type = "CUBE"}
+    %scale_tensor = arith.constant dense<0.003921568627> : tensor<64x64xf32>
+    %mulf = arith.mulf %scale_tensor, %matmul {ssbuffer.block_id = 122 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>  // scale first, matmul second
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 121 : i32, ssbuffer.core_type = "CUBE"}
+    %extract = tensor.extract_slice %mulf[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 123 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf32>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 121 : i32, ssbuffer.core_type = "CUBE"}
+    %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 124 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf32> to memref<64x64xf32, strided<[64, 1]>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 121 : i32, ssbuffer.core_type = "CUBE"}
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 125 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf32>, memref<64x64xf32, strided<[64, 1]>>) -> ()
+    return
+  }
+
+  // Test 14: mulf with tensor (NOT scalar) - should NOT match (false positive protection)
+  // CHECK-LABEL: func @test_mulf_with_tensor_not_scalar
+  func.func @test_mulf_with_tensor_not_scalar(%arg0: memref<128x64xf32> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>, %other_tensor: tensor<64x64xf32>) {
+    // CHECK: linalg.matmul {ssbuffer.block_id = 141 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 141 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 142 : i32, ssbuffer.core_type = "VECTOR"}
+    %mulf = arith.mulf %matmul, %other_tensor {ssbuffer.block_id = 142 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>  // NOT scalar
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 143 : i32, ssbuffer.core_type = "VECTOR"}
+    %extract = tensor.extract_slice %mulf[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 143 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf32>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 144 : i32, ssbuffer.core_type = "VECTOR"}
+    %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 144 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf32> to memref<64x64xf32, strided<[64, 1]>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 145 : i32, ssbuffer.core_type = "VECTOR"}
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 145 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf32>, memref<64x64xf32, strided<[64, 1]>>) -> ()
+    return
+  }
+
+
+  // Test 15: mulf result with multiple users - should NOT match
+  // CHECK-LABEL: func @test_mulf_multiple_users
+  func.func @test_mulf_multiple_users(%arg0: memref<128x64xf32> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>) {
+    // CHECK: linalg.matmul {ssbuffer.block_id = 171 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 171 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 172 : i32, ssbuffer.core_type = "VECTOR"}
+    %scale_tensor = arith.constant dense<0.003921568627> : tensor<64x64xf32>
+    %mulf = arith.mulf %matmul, %scale_tensor {ssbuffer.block_id = 172 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+    // mulf has multiple users
+    %extract1 = tensor.extract_slice %mulf[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 173 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf32>
+    %extract2 = tensor.extract_slice %mulf[0, 0] [32, 32] [1, 1] {ssbuffer.block_id = 174 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<32x32xf32>
+    return
+  }
+
+  // Test 16: muli with integer dense constant tensor - should match
+  // CHECK-LABEL: func @test_mulf_with_int_scalar
+  func.func @test_mulf_with_int_scalar(%arg0: memref<128x64xi32> {tt.divisibility = 16 : i32}, %A: tensor<64x64xi16>, %B: tensor<64x64xi16>, %init: tensor<64x64xi32>) {
+    // CHECK: linalg.matmul {ssbuffer.block_id = 181 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 181 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xi16>, tensor<64x64xi16>) outs(%init : tensor<64x64xi32>) -> tensor<64x64xi32>
+    // CHECK: arith.muli %{{.*}} {ssbuffer.block_id = 181 : i32, ssbuffer.core_type = "CUBE"}
+    %scale_tensor = arith.constant dense<255> : tensor<64x64xi32>
+    %mulf = arith.muli %matmul, %scale_tensor {ssbuffer.block_id = 182 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xi32>
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 181 : i32, ssbuffer.core_type = "CUBE"}
+    %extract = tensor.extract_slice %mulf[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 183 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xi32> to tensor<64x64xi32>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 181 : i32, ssbuffer.core_type = "CUBE"}
+    %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 184 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xi32> to memref<64x64xi32, strided<[64, 1]>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 181 : i32, ssbuffer.core_type = "CUBE"}
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 185 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xi32>, memref<64x64xi32, strided<[64, 1]>>) -> ()
+    return
+  }
+
+  // Test 17: mulf with scale from linalg.fill with scalar arg - should match
+  // CHECK-LABEL: func @test_mulf_with_fill_scalar_arg
+  func.func @test_mulf_with_fill_scalar_arg(%arg0: memref<128x64xf32> {tt.divisibility = 16 : i32}, %scale: f32, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>, %fill_init: tensor<64x64xf32>) {
+    // CHECK: linalg.fill {ssbuffer.block_id = 190 : i32, ssbuffer.core_type = "VECTOR"} ins(%{{.*}} : f32) outs(%{{.*}} : tensor<64x64xf32>) {{.*}}
+    %fill = linalg.fill {ssbuffer.block_id = 190 : i32, ssbuffer.core_type = "VECTOR"} ins(%scale : f32) outs(%fill_init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK: linalg.matmul {ssbuffer.block_id = 191 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 191 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 191 : i32, ssbuffer.core_type = "CUBE"}
+    %mulf = arith.mulf %matmul, %fill {ssbuffer.block_id = 192 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 191 : i32, ssbuffer.core_type = "CUBE"}
+    %extract = tensor.extract_slice %mulf[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 193 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf32>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 191 : i32, ssbuffer.core_type = "CUBE"}
+    %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 194 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf32> to memref<64x64xf32, strided<[64, 1]>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 191 : i32, ssbuffer.core_type = "CUBE"}
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 195 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf32>, memref<64x64xf32, strided<[64, 1]>>) -> ()
+    return
+  }
 }


### PR DESCRIPTION

Extends the FixpipeOptPass to recognize a second fixpipe-eligible pattern — the Quantization Pattern — in addition to the existing Cast Pattern.

Support for:
```
linalg.matmul → arith.mulf (scalar-like scaling factor) → tensor.extract_slice (optional) → materialize_in_destination(subview(gm))
```

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
