### PR TITLE
fix(ssbuffer): fix op's block_id check in Utils

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -38,6 +38,7 @@ inline constexpr llvm::StringLiteral kCubeFirst = "ssbuffer.cube_first";
 inline constexpr llvm::StringLiteral kVectorFirst = "ssbuffer.vector_first";
 inline constexpr llvm::StringLiteral kAddFromMatmul = "ssbuffer.add_from_matmul";
 inline constexpr llvm::StringLiteral kMainLoop = "ssbuffer.main_loop";
+inline constexpr llvm::StringLiteral kTcoreType = "hivm.tcore_type";
 inline constexpr llvm::StringLiteral kIf = "ssbuffer.if";
 inline constexpr llvm::StringLiteral kIntraBuffer = "ssbuffer.intra_buffer";
 inline constexpr const char *ERRCODE_ATTR = "triton_ascend.dynamic_cv_pipeline.rc";

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/Utils.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/Utils.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
 #include <optional>
 
@@ -57,7 +58,7 @@ LogicalResult triton::collectOpsByBlockId(scf::ForOp forOp,
                                           llvm::DenseMap<int, SmallVector<Operation *>> &blockOps)
 {
   for (Operation &op : forOp.getBody()->without_terminator()) {
-    if (auto attr = op.getAttrOfType<IntegerAttr>("ssbuffer.block_id")) {
+    if (auto attr = op.getAttrOfType<IntegerAttr>(CVPipeline::kBlockId)) {
       blockOps[attr.getInt()].push_back(&op);
     } else {
       return failure();
@@ -152,7 +153,7 @@ SmallVector<int> triton::getBlockIdsInOrder(scf::ForOp forOp)
   llvm::DenseSet<int> seenIds;
 
   for (Operation &op : forOp.getBody()->without_terminator()) {
-    if (auto blockIdAttr = op.getAttrOfType<IntegerAttr>("ssbuffer.block_id")) {
+    if (auto blockIdAttr = op.getAttrOfType<IntegerAttr>(CVPipeline::kBlockId)) {
       int id = blockIdAttr.getInt();
       if (seenIds.insert(id).second) {
         idsInOrder.push_back(id);
@@ -164,7 +165,7 @@ SmallVector<int> triton::getBlockIdsInOrder(scf::ForOp forOp)
 
 // Helper to get block_id attribute from op
 std::optional<int64_t> triton::getOpBlockId(Operation *op) {
-  auto blockIdAttr = op->getAttrOfType<IntegerAttr>("ssbuffer.block_id");
+  auto blockIdAttr = op->getAttrOfType<IntegerAttr>(CVPipeline::kBlockId);
   if (!blockIdAttr) {
     return std::nullopt;
   }
@@ -173,20 +174,23 @@ std::optional<int64_t> triton::getOpBlockId(Operation *op) {
 
 // Get the block_id of the immediate child of scf.for that contains op
 // For nested ops inside scf.if/scf.for, returns the block_id of the immediate child of scf.for
+// Only considers scf.for ops that have ssbuffer.main_loop attribute
 std::optional<int64_t> triton::getForDirectChildBlockId(Operation *op) {
-  scf::ForOp forOp = op->getParentOfType<scf::ForOp>();
-  if (!forOp) {
+  if (!op) {
     return std::nullopt;
   }
-
-  // Walk up from op until we reach a direct child of forOp
-  while (op->getParentOp() != forOp.getOperation()) {
-    op = op->getParentOp();
-    if (!op) {
-      return std::nullopt;
+  Operation *parent = op->getParentOp();
+  while (parent) {
+    // Found the main_loop forOp, op is its direct child
+    if (auto forOp = dyn_cast<scf::ForOp>(parent)) {
+      if (forOp->hasAttr(CVPipeline::kMainLoop)) {
+        return getOpBlockId(op);
+      }
     }
+    op = parent;
+    parent = parent->getParentOp();
   }
-  return getOpBlockId(op);
+  return std::nullopt;
 }
 
 // Find the tcb group id that contains value v
@@ -207,11 +211,11 @@ LogicalResult triton::getScopeType(Operation *scopeOp, bool &isCube, bool &isVec
   isCube = false;
   isVector = false;
 
-  if (!scopeOp->hasAttr("hivm.tcore_type")) {
+  if (!scopeOp->hasAttr(CVPipeline::kTcoreType)) {
     return failure();
   }
 
-  auto attr = scopeOp->getAttr("hivm.tcore_type");
+  auto attr = scopeOp->getAttr(CVPipeline::kTcoreType);
   auto aiCAttr = hivm::TCoreTypeAttr::get(scopeOp->getContext(), hivm::TCoreType::CUBE);
   auto aiVAttr = hivm::TCoreTypeAttr::get(scopeOp->getContext(), hivm::TCoreType::VECTOR);
   if (attr == aiCAttr) {


### PR DESCRIPTION
DynamicCVPipeline: fix op's block_id check in Utils

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
