### PR TITLE
[BugFix] Fix precision error of MM test cases

### DIFF
--- a/third_party/ascend/tutorials/03-matrix-multiplication.py
+++ b/third_party/ascend/tutorials/03-matrix-multiplication.py
@@ -130,7 +130,7 @@ def matmul_kernel(
     # # Write back the block of the output matrix C with masks.
     # Comment out the following lines to enable split the workload to two vector cores
     SUB_BLK_M: tl.constexpr = BLOCK_SIZE_M // 2
-    for s in extension.parallel(0, 2, bind_sub_block=True):
+    for s in range(0, 2):
         vec_sub_blk = extension.extract_slice(
             accumulator, (s * SUB_BLK_M, 0), (SUB_BLK_M, BLOCK_SIZE_N), (1, 1)
         )
@@ -214,5 +214,4 @@ def test():
 
 
 if __name__ == "__main__":
-    print("skip on this case")
-    # test()
+    test()

--- a/third_party/ascend/unittest/pytest_ut/test_03_matrix_multiplication.py
+++ b/third_party/ascend/unittest/pytest_ut/test_03_matrix_multiplication.py
@@ -131,7 +131,7 @@ def matmul_kernel(
     # # Write back the block of the output matrix C with masks.
     # Comment out the following lines to enable split the workload to two vector cores
     SUB_BLK_M: tl.constexpr = BLOCK_SIZE_M // 2
-    for s in extension.parallel(0, 2, bind_sub_block=True):
+    for s in range(0, 2):
         vec_sub_blk = extension.extract_slice(
             accumulator, (s * SUB_BLK_M, 0), (SUB_BLK_M, BLOCK_SIZE_N), (1, 1)
         )
@@ -201,7 +201,6 @@ def matmul(a, b, activation=""):
 # ---------
 #
 # We can test our custom matrix multiplication operation against a native torch implementation.
-@pytest.mark.skip(reason="skip on this case")
 @pytest.mark.parametrize(
     "shape",
     [


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
Fix the precision error in test_03_matrix_multiplication.py caused by upgrading to the new version of npu-ir in the gating check.
# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
