### PR TITLE
feat: add enable_auto_blockify metadata to control if a kernel use auto blockify

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -1,4 +1,4 @@
-﻿# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -54,9 +54,7 @@ from triton.backends.ascend.utils import (
     triton_enable_libdevice_simt,
     get_cann_version_file_hash,
 )
-from triton.backends.ascend.driver import (
-    NPUUtils
-)
+from triton.backends.ascend.driver import (NPUUtils)
 from triton.backends.compiler import (
     AttrsDescriptor,
     BaseBackend,
@@ -72,6 +70,7 @@ from triton.tools.get_ascend_devices import is_compile_on_910_95
 def min_dot_size(target: GPUTarget):
     return lambda lhsType, rhsType: (1, 1, 1)
 
+
 # Get result code saved in module {attr_name = rc}
 def _get_then_remove_rc(mod, attr_name: str) -> int:
     get_int_attr = getattr(ascend.ir, "get_int_attr", None)
@@ -83,7 +82,7 @@ def _get_then_remove_rc(mod, attr_name: str) -> int:
 
     if remove_attr:
         remove_attr(mod, attr_name)
-    
+
     if not isinstance(attr_value, int):
         return -1
 
@@ -130,7 +129,7 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
     # use triton_adapter to lower Triton-MLIR to linalg
     # Get Triton-MLIR as string
     ttir_code = str(mod)
-    auto_map_parallel_blocks_enabled = _is_auto_map_parallel_blocks_enabled()
+    auto_map_parallel_blocks_enabled = _is_auto_map_parallel_blocks_enabled(metadata)
     blacklist_reasons = []
     has_auto_blockify_blacklist_op = metadata.get("has_auto_blockify_blacklist_op")
     if has_auto_blockify_blacklist_op is None and auto_map_parallel_blocks_enabled:
@@ -163,10 +162,7 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
             auto_blockify_size = 1
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
-        ascend.passes.ttir.add_auto_blockify(
-            pm,
-            auto_blockify_size
-        )
+        ascend.passes.ttir.add_auto_blockify(pm, auto_blockify_size)
         if (metadata["add_auto_scheduling"]):
             ascend.passes.ttir.add_dag_sync(pm)
             ascend.passes.ttir.add_dag_scope(pm)
@@ -177,40 +173,18 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
             passes.common.add_canonicalizer(pm)
 
         ascend.passes.ttir.add_triton_control_flow_opt(pm)
-        ascend.passes.ttir.add_triton_to_structure(
-            pm,
-            enable_mask_fallback_conversion,
-            optimize_dynamic_offset
-        )
-        ascend.passes.ttir.add_discrete_mask_access_conversion(
-            pm,
-            compile_on_910_95,
-            force_simt_template,
-            enable_sync_block_lock
-        )
+        ascend.passes.ttir.add_triton_to_structure(pm, enable_mask_fallback_conversion, optimize_dynamic_offset)
+        ascend.passes.ttir.add_discrete_mask_access_conversion(pm, compile_on_910_95, force_simt_template,
+                                                               enable_sync_block_lock)
         ascend.passes.ttir.add_triton_to_annotation(pm)
-        ascend.passes.ttir.add_triton_to_unstructure(
-            pm,
-            compile_on_910_95,
-            force_simt_template
-        )
+        ascend.passes.ttir.add_triton_to_unstructure(pm, compile_on_910_95, force_simt_template)
         ascend.passes.ttir.add_triton_to_hivm(pm)
         ascend.passes.ttir.add_triton_to_hfusion(pm)
         ascend.passes.ttir.add_triton_to_llvm(pm)
         ascend.passes.ttir.add_bubble_up_operation(pm)
-        ascend.passes.ttir.add_triton_to_structure(
-            pm,
-            enable_mask_fallback_conversion,
-            optimize_dynamic_offset
-        )
-        ascend.passes.ttir.add_triton_to_linalg(
-            pm,
-            False,
-            named_ops,
-            enable_nd2nz_on_vector,
-            enable_select_analysis,
-            compile_on_910_95
-        )
+        ascend.passes.ttir.add_triton_to_structure(pm, enable_mask_fallback_conversion, optimize_dynamic_offset)
+        ascend.passes.ttir.add_triton_to_linalg(pm, False, named_ops, enable_nd2nz_on_vector, enable_select_analysis,
+                                                compile_on_910_95)
         if metadata["enable_dynamic_cv_pipeline"]:
             metadata["set_workspace_multibuffer"] = 0
             metadata["enable_mixed_cv"] = True
@@ -230,8 +204,7 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
             ascend.passes.ttir.set_buffer_count("LOAD", _load_val)
 
         pm.run(mod)
-        _adjust_metadata_by_module_result(mod, metadata, opt,
-                                          enable_mixed_cv=enable_mixed_cv,
+        _adjust_metadata_by_module_result(mod, metadata, opt, enable_mixed_cv=enable_mixed_cv,
                                           disable_auto_inject_block_sync=disable_auto_inject_block_sync,
                                           set_workspace_multibuffer=set_workspace_multibuffer)
 
@@ -325,7 +298,7 @@ def _parse_ttir_metadata(ttir: str, metadata: dict):
     metadata["mix_mode"] = "aiv"
     metadata["kernel_name"] = re.search(KERNEL_NAME_REGEX, ttir).group(1)
     metadata["name"] = metadata["kernel_name"]
-    auto_map_parallel_blocks_enabled = _is_auto_map_parallel_blocks_enabled()
+    auto_map_parallel_blocks_enabled = _is_auto_map_parallel_blocks_enabled(metadata)
     has_auto_blockify_blacklist_op = metadata.get("has_auto_blockify_blacklist_op")
     if has_auto_blockify_blacklist_op is None and auto_map_parallel_blocks_enabled:
         has_auto_blockify_blacklist_op = bool(_get_auto_blockify_blacklist_reasons(ttir))
@@ -347,11 +320,8 @@ def get_auto_bind_sub_block_option(metadata):
     # auto_tile_and_bind_subblock is read from the module.
     # enable_auto_bind_sub_block is set by the user and has a higher priority.
     enable_auto_bind_sub_block = metadata["enable_auto_bind_sub_block"]
-    return (
-        metadata["auto_tile_and_bind_subblock"]
-        if enable_auto_bind_sub_block is None
-        else enable_auto_bind_sub_block
-    )
+    return (metadata["auto_tile_and_bind_subblock"]
+            if enable_auto_bind_sub_block is None else enable_auto_bind_sub_block)
 
 
 def _save_npuir_debug_output(stdout_bytes: bytes, stderr_bytes: bytes, tmpdir: str, metadata_hash: str):
@@ -365,11 +335,7 @@ def _save_npuir_debug_output(stdout_bytes: bytes, stderr_bytes: bytes, tmpdir: s
         f.write(combined)
 
     dump_manager = get_dump_manager(metadata_hash)
-    dump_manager.put(
-        Path(output_path).read_text(encoding='utf-8'),
-        "kernel.npuir.mlir",
-        binary=False
-    )
+    dump_manager.put(Path(output_path).read_text(encoding='utf-8'), "kernel.npuir.mlir", binary=False)
 
 
 def try_compile_with_config(linalg: str, ub_config: Dict[str, Any], metadata: dict, opt) -> Tuple[bool, str]:
@@ -579,8 +545,9 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
                 _compile_option_list += \
                     [f"--link-aicore-bitcode={bitcode}"]
 
-        if _is_auto_map_parallel_blocks_enabled() and not metadata.get("has_auto_blockify_blacklist_op", False):
+        if _is_auto_map_parallel_blocks_enabled(metadata) and not metadata.get("has_auto_blockify_blacklist_op", False):
             _compile_option_list += ["--enable-auto-blockify-loop"]
+
         npu_compiler_path, env = _get_npucompiler_path()
         if npu_compiler_path.endswith("bishengir-compile"):
             _compile_option_list += [
@@ -589,9 +556,7 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
             ]
         bisheng_options = metadata["bisheng_options"]
         if bisheng_options is not None:
-            _compile_option_list += [
-                f"--append-bisheng-options={bisheng_options}"
-            ]
+            _compile_option_list += [f"--append-bisheng-options={bisheng_options}"]
         mix_mode = opt.mix_mode
         if mix_mode in ["aic"]:
             _compile_option_list += ["--disable-hfusion-vectorize=true"]
@@ -599,11 +564,7 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
         if opt.debug:
             _compile_option_list += ["--bishengir-print-ir-after=hivm-graph-sync-solver"]
 
-        cmd_list = (
-            [npu_compiler_path, ttadapter_path]
-            + _compile_option_list
-            + ["-o", bin_file]
-        )
+        cmd_list = ([npu_compiler_path, ttadapter_path] + _compile_option_list + ["-o", bin_file])
         vf_merge_level = metadata["vf_merge_level"]
         if vf_merge_level is not None:
             cmd_list += [f"--enable-vf-merge-level={vf_merge_level}"]
@@ -616,13 +577,7 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
             print(f"[DEBUG] cmd_list: {' '.join(cmd_list)}")
 
         try:
-            ret = subprocess.run(
-                cmd_list,
-                env=env,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                check=True
-            )
+            ret = subprocess.run(cmd_list, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
         except subprocess.CalledProcessError as e:
             if opt.debug:
                 _save_npuir_debug_output(e.stdout, e.stderr, tmpdir, metadata["hash"])
@@ -816,7 +771,7 @@ def linalg_to_bin_enable_npu_compile_A2_A3(linalg: str, metadata, opt):
             _compile_option_list += \
                 [f"--disable-size-align-for-cast={disable_size_align_for_cast}"]
 
-        if _is_auto_map_parallel_blocks_enabled() and not metadata.get("has_auto_blockify_blacklist_op", False):
+        if _is_auto_map_parallel_blocks_enabled(metadata) and not metadata.get("has_auto_blockify_blacklist_op", False):
             _compile_option_list += ["--enable-auto-blockify-loop"]
         npu_compiler_path, env = _get_npucompiler_path()
         if npu_compiler_path.endswith("bishengir-compile"):
@@ -829,22 +784,12 @@ def linalg_to_bin_enable_npu_compile_A2_A3(linalg: str, metadata, opt):
         if opt.debug:
             _compile_option_list += ["--mlir-print-ir-after-failure"]
             _compile_option_list += ["--bishengir-print-ir-after=hivm-graph-sync-solver"]
-        cmd_list = (
-            [npu_compiler_path, ttadapter_path]
-            + _compile_option_list
-            + ["-o", bin_file]
-        )
+        cmd_list = ([npu_compiler_path, ttadapter_path] + _compile_option_list + ["-o", bin_file])
         if opt.debug or os.getenv("TRITON_PRINT_UBTUNING", None) == "1":
             print(f"[DEBUG] cmd_list: {' '.join(cmd_list)}")
 
         try:
-            ret = subprocess.run(
-                cmd_list,
-                env=env,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                check=True
-            )
+            ret = subprocess.run(cmd_list, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
         except subprocess.CalledProcessError as e:
             if opt.debug:
                 _save_npuir_debug_output(e.stdout, e.stderr, tmpdir, metadata["hash"])
@@ -898,6 +843,7 @@ class NPUOptions:
     reg_inc_consumer: int = 0
 
     auto_blockify_size: int = 1
+    enable_auto_blockify: bool = None
     compile_on_910_95: bool = is_compile_on_910_95
     optimize_dynamic_offset: bool = False
     enable_mask_fallback_conversion: bool = False
@@ -908,7 +854,6 @@ class NPUOptions:
     enable_fp_fusion: bool = True
     allow_fp8e4nv: bool = False
     auto_tile_and_bind_subblock: bool = True
-    vf_merge_level: int = 0
     supported_fp8_dtypes: Tuple[str] = ("fp8e5", "fp8e4b15", "fp8e4nv", "fp8e4b8", "fp8e5b16")
     deprecated_fp8_dtypes: Tuple[str] = ()
     vf_merge_level: int = 1
@@ -1032,7 +977,9 @@ def ttir_to_npubin(mod, metadata, opt):
             _compile_option_list += [f"--num-warps={opt.num_warps}"]
             _compile_option_list += [f"--threads-per-warp={opt.warp_size}"]
             if opt.enable_bishengir_simt_optimization != 000:
-                _compile_option_list += [f"--enable-bishengir-simt-optimization={opt.enable_bishengir_simt_optimization}"]
+                _compile_option_list += [
+                    f"--enable-bishengir-simt-optimization={opt.enable_bishengir_simt_optimization}"
+                ]
             if opt.simt_stack_limit:
                 _compile_option_list += [f"--simt-stack-limit={opt.simt_stack_limit}"]
             if opt.shared_mem_dynamic_size is not None:
@@ -1046,23 +993,17 @@ def ttir_to_npubin(mod, metadata, opt):
             if (enable_libdevice_simt):
                 bisheng_options = metadata["bisheng_options"]
                 if bisheng_options is not None:
-                    _compile_option_list += [
-                        f"--append-bisheng-options={bisheng_options}"
-                    ]
+                    _compile_option_list += [f"--append-bisheng-options={bisheng_options}"]
 
             # Enable SIMT auto-blockify when TRITON_ALL_BLOCKS_PARALLEL is set,
             # mirroring the SIMD compile paths. driver.py's runtime block-count
             # cap keys off the same env switch, so the two stay in sync.
-            if _is_auto_map_parallel_blocks_enabled():
+            if _is_auto_map_parallel_blocks_enabled(metadata):
                 _compile_option_list += ["--enable-auto-blockify-loop"]
 
         npu_compiler_path, env = _get_npucompiler_path()
-        cmd_list = (
-            [npu_compiler_path, src_path]
-            + _compile_option_list
-            + ["-o", bin_file]
-        )
-        ret = subprocess.run(cmd_list, env = env, capture_output = True, check = True)
+        cmd_list = ([npu_compiler_path, src_path] + _compile_option_list + ["-o", bin_file])
+        ret = subprocess.run(cmd_list, env=env, capture_output=True, check=True)
         if not Path(bin_path).exists():
             error_msg = ret.stderr.decode('utf-8')
             print(f"[DEBUG] {bin_path} is not found")
@@ -1085,11 +1026,7 @@ class AscendBackend(BaseBackend):
     def parse_options(self, opts) -> Any:
         # TODO: get available targets when building options?
         if self.target.backend == "npu":
-            args = {
-                k: opts[k]
-                for k in NPUOptions.__dataclass_fields__.keys()
-                if k in opts
-            }
+            args = {k: opts[k] for k in NPUOptions.__dataclass_fields__.keys() if k in opts}
             args.setdefault("arch", self.target.arch)
             options = NPUOptions(**args)
             # Costmodel path should avoid extra BC<->MLIR conversion stages
@@ -1097,10 +1034,8 @@ class AscendBackend(BaseBackend):
             if getattr(options, "enable_costmodel_backend", False):
                 object.__setattr__(options, "use_bytecode", False)
         else:
-            raise NotImplementedError(
-                f"Backend '{self.target.backend}' is not supported. "
-                "Please ensure the target backend is set to 'npu'."
-            )
+            raise NotImplementedError(f"Backend '{self.target.backend}' is not supported. "
+                                      "Please ensure the target backend is set to 'npu'.")
         return options
 
     def pack_metadata(self, metadata):
@@ -1141,32 +1076,18 @@ class AscendBackend(BaseBackend):
         if self.target.backend == "npu":
             stages["ttir"] = lambda src, metadata: make_ttir(src, metadata, options)
             if options.force_simt_only:
-                stages["npubin"] = (
-                    lambda src, metadata: ttir_to_npubin(
-                        src, metadata, options
-                    )
-                )
+                stages["npubin"] = (lambda src, metadata: ttir_to_npubin(src, metadata, options))
                 return
-            stages["ttadapter"] = lambda src, metadata: ttir_to_linalg(
-                src, metadata, options, named_ops=True
-            )
+            stages["ttadapter"] = lambda src, metadata: ttir_to_linalg(src, metadata, options, named_ops=True)
             if options.compile_on_910_95:
                 stages["npubin"] = (
-                    lambda src, metadata: linalg_to_bin_enable_npu_compile_910_95(
-                        src, metadata, options
-                    )
-                )
+                    lambda src, metadata: linalg_to_bin_enable_npu_compile_910_95(src, metadata, options))
             else:
                 stages["npubin"] = (
-                    lambda src, metadata: linalg_to_bin_enable_npu_compile_A2_A3(
-                        src, metadata, options
-                    )
-                )
+                    lambda src, metadata: linalg_to_bin_enable_npu_compile_A2_A3(src, metadata, options))
         else:
-            raise NotImplementedError(
-                f"Backend '{self.target.backend}' is not supported. "
-                "Please ensure the target backend is set to 'npu'."
-            )
+            raise NotImplementedError(f"Backend '{self.target.backend}' is not supported. "
+                                      "Please ensure the target backend is set to 'npu'.")
 
     @functools.lru_cache()
     def hash(self):

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -48,6 +48,7 @@ from triton.backends.ascend.utils import (
 import triton.backends.ascend.utils as _ascend_utils
 
 class NPUUtils(object):
+
     def __new__(cls):
         if not hasattr(cls, 'instance'):
             cls.instance = super(NPUUtils, cls).__new__(cls)
@@ -105,6 +106,7 @@ class NPUUtils(object):
 
 
 class NPULauncher(object):
+
     def __init__(self, src, metadata):
         self.compile_only = os.getenv("TRITON_COMPILE_ONLY", 'false').lower() in ('true', '1')
         self.enable_msprof_register_tensor = os.getenv("TRITON_REGISTER_TENSOR_MSPROF", 'false').lower() in ('true', '1')
@@ -146,11 +148,13 @@ class NPULauncher(object):
         else:
             if self.compile_only:
                 return
-  
+
             profiler_registered = self.launch(*args, **kwargs)
             _ascend_utils.TRITON_PROFILER_REGISTERED = (profiler_registered == 1)
 
+
 class NPUDriver(DriverBase):
+
     def __init__(self):
         self.utils = NPUUtils()
         self.launcher_cls = NPULauncher
@@ -158,11 +162,13 @@ class NPUDriver(DriverBase):
 
     @classmethod
     def is_active(cls):
+
         def test_npucompiler():
             from triton.backends.ascend.utils import _get_bisheng_path
             npucompiler = _get_bisheng_path()
             targets = subprocess.check_output([npucompiler, "-print-targets"]).decode().strip().split()
             return "hiipu64" in targets
+
         try:
             return test_npucompiler()
         except Exception as e_npucompiler:
@@ -220,7 +226,7 @@ def _precompile_npu_ext_with_lock(header_src, enable_precompile):
     cache = get_cache_manager(precompile_hash)
     gch_path = cache.get_file("precompiled.h.gch")
     header_path = cache.get_file("precompiled.h")
-    if enable_precompile: 
+    if enable_precompile:
         if header_path is not None and gch_path is not None:
             return header_path
     else:
@@ -248,7 +254,7 @@ def _precompile_npu_ext_with_lock(header_src, enable_precompile):
             return header_path
         finally:
             fcntl.flock(f, fcntl.LOCK_UN)
-    
+
 
 def make_npu_launcher_stub(header_src, wrapper_src, debug=False):
     """
@@ -258,7 +264,7 @@ def make_npu_launcher_stub(header_src, wrapper_src, debug=False):
     # if precompile header file and its gch file not exist, do precompile
     header_path = _precompile_npu_ext_with_lock(header_src, enable_precompile)
     assert header_path is not None, "the precompiled.h path is empty."
-    
+
     # try to get cached file
     so_cache_key = hashlib.sha256(wrapper_src.encode("utf-8")).hexdigest()
     so_cache_manager = get_cache_manager(so_cache_key)
@@ -275,7 +281,7 @@ def make_npu_launcher_stub(header_src, wrapper_src, debug=False):
             print(f"Dumping precompiled.h to {dump_manager.cache_dir}")
             dump_manager.put(header_src, "precompiled.h", binary=False)
         print(f"Dumping {name}.cxx to {dump_manager.cache_dir}")
-        dump_manager.put(wrapper_src, f"{name}.cxx", binary = False)
+        dump_manager.put(wrapper_src, f"{name}.cxx", binary=False)
 
     cache_path = so_cache_manager.get_file(so_name)
     if cache_path is not None:
@@ -283,12 +289,12 @@ def make_npu_launcher_stub(header_src, wrapper_src, debug=False):
 
     kernel_launcher_type = "torch"
 
-
     with tempfile.TemporaryDirectory() as tmpdir:
         src_path = os.path.join(tmpdir, f"{name}.cxx")
         with open(src_path, "w") as f:
             f.write(wrapper_src)
-        so_path = _build_npu_ext(name, header_path, src_path, kernel_launcher=kernel_launcher_type, precompile=enable_precompile)
+        so_path = _build_npu_ext(name, header_path, src_path, kernel_launcher=kernel_launcher_type,
+                                 precompile=enable_precompile)
         if debug:
             with open(so_path, "rb") as f:
                 dump_manager.put(f.read(), so_name, binary=True)
@@ -366,8 +372,7 @@ def extract_device_print_code_from_cann():
 
 
 def generate_npu_header_src():
-    enable_taskqueue = os.getenv(
-        "TRITON_ENABLE_TASKQUEUE", 'true').lower() in ('true', '1')
+    enable_taskqueue = os.getenv("TRITON_ENABLE_TASKQUEUE", 'true').lower() in ('true', '1')
     return f"""
 /*
  * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
@@ -407,6 +412,7 @@ def generate_npu_header_src():
 
 #endif
 """
+
 
 # the template is from triton-adapter HEAD. Wrapping the generated kernel binary into a python module
 def generate_npu_wrapper_src(constants, signature, metadata):
@@ -505,7 +511,7 @@ def generate_npu_wrapper_src(constants, signature, metadata):
         int gridX, gridY, gridZ;
         rtStream_t stream;
         const void *functon;
-        PyObject* packed_metadata,       
+        PyObject* packed_metadata,
         *args_expand
     """
 
@@ -515,23 +521,18 @@ def generate_npu_wrapper_src(constants, signature, metadata):
 
     arch = get_ascend_arch_from_env()
     target_support_ffts = is_ffts_supported(arch) and (not force_disable_ffts())
-    enable_device_print = os.getenv(
-        "TRITON_DEVICE_PRINT", 'false').lower() in ('true', '1')
-    enable_taskqueue = os.getenv(
-        "TRITON_ENABLE_TASKQUEUE", 'true').lower() in ('true', '1')
-    enable_grid_warn_print = os.getenv(
-        "TRITON_GRID_WARN_PRINT", 'false').lower() in ('true', '1')
+    enable_device_print = os.getenv("TRITON_DEVICE_PRINT", 'false').lower() in ('true', '1')
+    enable_taskqueue = os.getenv("TRITON_ENABLE_TASKQUEUE", 'true').lower() in ('true', '1')
+    enable_grid_warn_print = os.getenv("TRITON_GRID_WARN_PRINT", 'false').lower() in ('true', '1')
     has_auto_blockify_blacklist_op = getattr(
-      metadata,
-      "has_auto_blockify_blacklist_op",
-      False,
+        metadata,
+        "has_auto_blockify_blacklist_op",
+        False,
     )
-    enable_auto_map_parallel_blocks = (
-      _is_auto_map_parallel_blocks_enabled() and not has_auto_blockify_blacklist_op
-    )
+    enable_auto_map_parallel_blocks = (_is_auto_map_parallel_blocks_enabled(metadata)
+                                       and not has_auto_blockify_blacklist_op)
     npu_utils = NPUUtils()
-    num_physical_blocks = npu_utils.get_aivector_core_num(
-    ) if mix_mode == "aiv" else npu_utils.get_aicore_num()
+    num_physical_blocks = npu_utils.get_aivector_core_num() if mix_mode == "aiv" else npu_utils.get_aicore_num()
     task_type, mix_block_dim_ratio = _format_of_msprof_task_type_ratio(bs_task_type, mix_mode)
     is_mix_task_type = "true" if ("MIX" in task_type) else "false"
     LINE_CHANGE_CHAR = chr(10)  # it is \n

--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -18,7 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-
 import functools
 import hashlib
 import os
@@ -176,9 +175,7 @@ def _get_npucompiler_path() -> str:
         if npu_compiler_path is None:
             npu_compiler_root = os.getenv("TRITON_NPU_COMPILER_PATH", None)
             if npu_compiler_root is None:
-                raise EnvironmentError(
-                    "Couldn't find executable bishengir-compile or TRITON_NPU_COMPILER_PATH."
-                )
+                raise EnvironmentError("Couldn't find executable bishengir-compile or TRITON_NPU_COMPILER_PATH.")
             npu_compiler_path = os.path.join(npu_compiler_root, "npuc")
     return npu_compiler_path, env
 
@@ -188,9 +185,7 @@ def _get_bisheng_path() -> str:
     if bisheng_path is None:
         npu_compiler_root = os.getenv("TRITON_NPU_COMPILER_PATH", None)
         if npu_compiler_root is None:
-            raise EnvironmentError(
-                "Couldn't find executable bisheng or TRITON_NPU_COMPILER_PATH"
-            )
+            raise EnvironmentError("Couldn't find executable bisheng or TRITON_NPU_COMPILER_PATH")
         bisheng_path = os.path.join(npu_compiler_root, "ccec")
     return bisheng_path
 
@@ -258,9 +253,7 @@ def _check_bishengir_is_regbased() -> bool:
 def _get_ascend_path() -> Path:
     path = os.getenv("ASCEND_HOME_PATH", "")
     if path == "":
-        raise EnvironmentError(
-            "ASCEND_HOME_PATH is not set, source <ascend-toolkit>/set_env.sh first"
-        )
+        raise EnvironmentError("ASCEND_HOME_PATH is not set, source <ascend-toolkit>/set_env.sh first")
     return Path(path)
 
 
@@ -272,9 +265,25 @@ def _is_debug_line_info_disabled() -> bool:
     return os.getenv("TRITON_DISABLE_LINE_INFO", "true").lower() in ("true", "1")
 
 
-def _is_auto_map_parallel_blocks_enabled() -> bool:
+def _is_auto_map_parallel_blocks_enabled(metadata) -> bool:
+
+    def metadata_get(metadata, key, default=None):
+        try:
+            return metadata.get(key, default)
+        except AttributeError:
+            return getattr(metadata, key, default)
+
     default_parallel = "true" if is_compile_on_910_95 else "false"
-    return os.getenv("TRITON_ALL_BLOCKS_PARALLEL", default_parallel).lower() in ("true", "1")
+    is_env_set = os.getenv("TRITON_ALL_BLOCKS_PARALLEL", default_parallel).lower() in ("true", "1")
+    is_opt_set = metadata_get(metadata, "enable_auto_blockify", False)
+    flag = False
+    if is_env_set:
+        if (is_opt_set is None or is_opt_set):
+            flag = True
+    else:
+        if is_opt_set:
+            flag = True
+    return flag
 
 
 def _get_auto_blockify_blacklist_reasons(ir_text: str):
@@ -285,11 +294,9 @@ def _warn_auto_blockify_disabled(kernel_name: str, blacklist_reasons) -> None:
     if not blacklist_reasons:
         return
     reasons = ", ".join(blacklist_reasons)
-    print(
-        f"[WARNING] AutoBlockify disabled for kernel '{kernel_name}'. "
-        f"Unsafe ops: {reasons}. Enabling may cause correctness issues. "
-        "To force enable: set has_auto_blockify_blacklist_op=False."
-    )
+    print(f"[WARNING] AutoBlockify disabled for kernel '{kernel_name}'. "
+          f"Unsafe ops: {reasons}. Enabling may cause correctness issues. "
+          "To force enable: set has_auto_blockify_blacklist_op=False.")
 
 
 def _enable_unpublished_feature() -> bool:
@@ -528,6 +535,7 @@ def _check_bishengir_able_save_ir() -> bool:
     except Exception as e:
         print(f"ERROR: {e}")
         return False
+
 
 def get_ascend_arch_from_env():
     arch = os.getenv("TRITON_ASCEND_ARCH", "")


### PR DESCRIPTION
之前启用bishengir-compile的enable-auto-blockify-loop选项只有环境变量控制，现在增加metadata选项enable_auto_blockify在算子调用时控制。
逻辑是metadata.get("has_auto_blockify_blacklist_op", False)不是False的时候

- 环境变量TRITON_ALL_BLOCKS_PARALLEL=1，算子调用时enable_auto_blockify未指定（默认值None），bishengir-compile启用--enable-auto-blockify-loop
- 环境变量TRITON_ALL_BLOCKS_PARALLEL=1，算子调用时enable_auto_blockify=True，bishengir-compile启用--enable-auto-blockify-loop
- 环境变量TRITON_ALL_BLOCKS_PARALLEL=1，算子调用时enable_auto_blockify=False，bishengir-compile不会启用--enable-auto-blockify-loop
- 环境变量TRITON_ALL_BLOCKS_PARALLEL=0，算子调用时enable_auto_blockify未指定（默认值None），bishengir-compile不会启用--enable-auto-blockify-loop
- 环境变量TRITON_ALL_BLOCKS_PARALLEL=0，算子调用时enable_auto_blockify=True，bishengir-compile启用--enable-auto-blockify-loop
- 环境变量TRITON_ALL_BLOCKS_PARALLEL=0，算子调用时enable_auto_blockify=False，bishengir-compile不会启用--enable-auto-blockify-loop