### PR TITLE
[release/3.2.2-dev] Created unittest based on the original error in test_fused_moe_router_tensorcore_kernel

### DIFF
--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/fold_one_hot_gather_after_max_with_index.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/fold_one_hot_gather_after_max_with_index.mlir
@@ -1,0 +1,37 @@
+// RUN: triton-opt --triton-to-linalg="named-ops=True" --split-input-file %s | FileCheck %s
+
+module {
+  func.func @fold_one_hot_gather_after_max_with_index(%logits: tensor<2x4xf32>, %indices: tensor<2x4xi32>, %mask: tensor<2x4xi1>) -> tensor<2x1xf32> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<2x4xf32>
+    %masked = arith.select %mask, %logits, %cst : tensor<2x4xi1>, tensor<2x4xf32>
+    %max:2 = "tt.reduce"(%masked, %indices) <{axis = 1 : i32}> ({
+    ^bb0(%in: f32, %in_index: i32, %init: f32, %init_index: i32):
+      %is_greater = arith.cmpf ogt, %in, %init : f32
+      %new_value = arith.select %is_greater, %in, %init : f32
+      %new_index = arith.select %is_greater, %in_index, %init_index : i32
+      tt.reduce.return %new_value, %new_index : f32, i32
+    }) : (tensor<2x4xf32>, tensor<2x4xi32>) -> (tensor<2xf32>, tensor<2xi32>)
+    %expanded_index = tt.expand_dims %max#1 {axis = 1 : i32} : tensor<2xi32> -> tensor<2x1xi32>
+    %broadcasted_index = tt.broadcast %expanded_index : tensor<2x1xi32> -> tensor<2x4xi32>
+    %one_hot = arith.cmpi eq, %broadcasted_index, %indices : tensor<2x4xi32>
+    %one_hot_f32 = arith.uitofp %one_hot : tensor<2x4xi1> to tensor<2x4xf32>
+    %selected = arith.mulf %logits, %one_hot_f32 : tensor<2x4xf32>
+    %sum = "tt.reduce"(%selected) <{axis = 1 : i32}> ({
+    ^bb0(%in: f32, %init: f32):
+      %add = arith.addf %in, %init : f32
+      tt.reduce.return %add : f32
+    }) : (tensor<2x4xf32>) -> tensor<2xf32>
+    %result = tensor.expand_shape %sum [[0, 1]] output_shape [2, 1] : tensor<2xf32> into tensor<2x1xf32>
+    return %result : tensor<2x1xf32>
+  }
+}
+
+// CHECK-LABEL: func.func @fold_one_hot_gather_after_max_with_index
+// CHECK: %[[MAX:.*]]:2 = linalg.reduce
+// CHECK-SAME: reduce_mode = "max_with_index"
+// CHECK-NOT: arith.uitofp
+// CHECK-NOT: arith.mulf
+// CHECK-NOT: arith.cmpi eq
+// CHECK-NOT: linalg.reduce ins(%{{.*}} : tensor<2x4xf32>) outs(%{{.*}} : tensor<2xf32>) dimensions = [1]
+// CHECK: tensor.expand_shape %[[MAX]]#0 {{\[\[}}0, 1{{\]\]}} output_shape [2, 1]
+


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
Unittest created for testing behaviour that added in PR https://github.com/triton-lang/triton-ascend/pull/257.

Added a minimal lit regression test for folding a redundant one-hot value reconstruction after max_with_index.

The tested pattern reconstructs the selected value through:
'cmpi -> uitofp -> mulf -> reduce_sum'
even though max_with_index already produces both the selected value and index. The test verifies that triton-to-linalg removes this redundant reconstruction path and makes the final tensor.expand_shape consume the value result of max_with_index directly.


# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
