### PR TITLE
fix(ssbuffer): simplify and clarify scope-relevant user traversal

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
@@ -150,11 +150,6 @@ static bool matchesScope(Operation *op, StringRef scopeType)
     return getScopeMatchInfo(op, scopeType).matches;
 }
 
-static bool isOpAlive(Operation *op)
-{
-    return op && op->getBlock();
-}
-
 static Value buildNeutralValue(OpBuilder &builder, Value oldOperand, Location loc, StringRef scopeType)
 {
     if (!oldOperand) {
@@ -307,7 +302,7 @@ static bool hasLiveUsers(Operation *op)
 {
     for (Value result : op->getResults()) {
         for (OpOperand &use : result.getUses()) {
-            if (isOpAlive(use.getOwner())) {
+            if (use.getOwner()) {
                 return true;
             }
         }
@@ -374,23 +369,100 @@ static bool canSkipForwardingUse(OpOperand &use, StringRef scopeType)
     return false;
 }
 
-static Operation *findLiveUser(Value value, StringRef scopeType)
+static bool shouldPreserveFromYield(Operation *yieldOwner, unsigned operandIndex, StringRef scopeType)
 {
-    for (OpOperand &use : value.getUses()) {
-        Operation *user = use.getOwner();
-        if (isOpAlive(user) && !canSkipForwardingUse(use, scopeType)) {
-            return user;
-        }
+    bool preserveLoopCarry = needsLoopCarryPreserve(yieldOwner, operandIndex, scopeType);
+    if (!preserveLoopCarry) {
+        return false;
     }
-    return nullptr;
+
+    auto loopOp = dyn_cast<LoopLikeOpInterface>(yieldOwner);
+    if (!loopOp) {
+        return preserveLoopCarry;
+    }
+
+    auto ownerInfo = parseCoreTypeInfo(yieldOwner);
+    if (!ownerInfo) {
+        return preserveLoopCarry;
+    }
+
+    unsigned numResults = yieldOwner->getNumResults();
+    return llvm::any_of(llvm::seq<unsigned>(0, numResults), [&](unsigned resultIndex) {
+        return resultIndex != operandIndex && ownerInfo->getResultType(resultIndex) == scopeType;
+    });
 }
 
-static Operation *findNonTermUser(Value value, StringRef scopeType)
+static Operation *findScopeRelevantUser(Value startValue, StringRef scopeType, bool ignoreTerminators)
 {
-    for (OpOperand &use : value.getUses()) {
-        Operation *user = use.getOwner();
-        if (isOpAlive(user) && !canSkipForwardingUse(use, scopeType) && !user->hasTrait<OpTrait::IsTerminator>()) {
-            return user;
+    SmallVector<Value> worklist {startValue};
+    llvm::SmallPtrSet<void *, kSeenValuesCapacity> seenValues;
+
+    while (!worklist.empty()) {
+        Value value = worklist.pop_back_val();
+        if (!value || !seenValues.insert(value.getAsOpaquePointer()).second) {
+            continue;
+        }
+
+        for (OpOperand &use : value.getUses()) {
+            Operation *user = use.getOwner();
+            if (!user || canSkipForwardingUse(use, scopeType)) {
+                continue;
+            }
+
+            if (hasActiveNestedLoopCarryUse(use, scopeType)) {
+                if (!ignoreTerminators || !user->hasTrait<OpTrait::IsTerminator>()) {
+                    return user;
+                }
+                continue;
+            }
+
+            if (auto conditionOp = dyn_cast<scf::ConditionOp>(user)) {
+                Operation *parentOp = conditionOp.getParentOp();
+                if (parentOp && matchesScope(parentOp, scopeType)) {
+                    if (!ignoreTerminators || !parentOp->hasTrait<OpTrait::IsTerminator>()) {
+                        return parentOp;
+                    }
+                }
+                continue;
+            }
+
+            if (auto yieldOp = dyn_cast<scf::YieldOp>(user)) {
+                Operation *yieldOwner = yieldOp->getParentOp();
+                unsigned operandIndex = use.getOperandNumber();
+
+                if (operandIndex < yieldOwner->getNumResults()) {
+                    if (shouldPreserveFromYield(yieldOwner, operandIndex, scopeType)) {
+                        return yieldOwner;
+                    }
+                    worklist.push_back(yieldOwner->getResult(operandIndex));
+                    continue;
+                }
+
+                if (matchesScope(yieldOwner, scopeType) || isControlFlowOp(yieldOwner)) {
+                    if (!ignoreTerminators || !yieldOwner->hasTrait<OpTrait::IsTerminator>()) {
+                        return yieldOwner;
+                    }
+                }
+                continue;
+            }
+
+            if (matchesScope(user, scopeType)) {
+                if (!ignoreTerminators || !user->hasTrait<OpTrait::IsTerminator>()) {
+                    return user;
+                }
+                continue;
+            }
+
+            if (user->getNumResults() == 0) {
+                if (isControlFlowOp(user) && (!ignoreTerminators || !user->hasTrait<OpTrait::IsTerminator>())) {
+                    return user;
+                }
+                continue;
+            }
+
+            for (Value result : user->getResults()) {
+                worklist.push_back(result);
+            }
         }
     }
     return nullptr;
@@ -477,7 +549,7 @@ static bool slotHasActiveUse(Value startValue, Operation *owner, unsigned slotIn
         }
 
         for (OpOperand &use : value.getUses()) {
-            if (!isOpAlive(use.getOwner())) {
+            if (!use.getOwner()) {
                 continue;
             }
 
@@ -548,7 +620,7 @@ static LogicalResult neutralizeYieldInRegion(Operation *op, const CoreTypeInfo &
 
                 Value oldOperand = yieldOp.getOperand(i);
                 if (i < op->getNumResults()) {
-                    if (Operation *resultUser = findLiveUser(op->getResult(i), scopeType)) {
+                    if (Operation *resultUser = findScopeRelevantUser(op->getResult(i), scopeType, false)) {
                         logDebug("skip neutralizing yield operand #", i, " for scope ", scopeType,
                                  " because parent result #", i, " still has live user '",
                                  resultUser->getName().getStringRef(), "'");
@@ -577,7 +649,7 @@ static LogicalResult neutralizeTerminatorUses(Operation *op, const CoreTypeInfo 
         }
 
         Value result = op->getResult(i);
-        if (Operation *extraUser = findNonTermUser(result, scopeType)) {
+        if (Operation *extraUser = findScopeRelevantUser(result, scopeType, true)) {
             logDebug("skip neutralizing result #", i, " for scope ", scopeType,
                      " because the value still has live user '", extraUser->getName().getStringRef(), "'");
             continue;
@@ -700,7 +772,7 @@ static bool isNormalizedDeadShell(Operation *op, StringRef scopeType)
     }
 
     for (Value result : op->getResults()) {
-        if (findLiveUser(result, scopeType)) {
+        if (findScopeRelevantUser(result, scopeType, false)) {
             return false;
         }
     }
@@ -717,7 +789,7 @@ static LogicalResult executeActions(SmallVector<PendingAction> &actions, StringR
 {
     for (auto it = actions.rbegin(); it != actions.rend(); ++it) {
         Operation *op = it->op;
-        if (!isOpAlive(op)) {
+        if (!op) {
             continue;
         }
 
@@ -741,7 +813,7 @@ static LogicalResult executeActions(SmallVector<PendingAction> &actions, StringR
                         return failure();
                     }
                 }
-                if (isOpAlive(op) && op->getNumRegions() > 0 && isNormalizedDeadShell(op, scopeType)) {
+                if (op && op->getNumRegions() > 0 && isNormalizedDeadShell(op, scopeType)) {
                     if (hasLiveUsers(op)) {
                         logDebug("preserving normalized shell '", op->getName().getStringRef(),
                                  "' in scope ", scopeType,

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/separate_cv_scope_canonicalize_ut.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/separate_cv_scope_canonicalize_ut.mlir
@@ -396,15 +396,84 @@ module {
 
 // -----
 
-// CHECK-LABEL: func.func @memref_slot_neutralize_uses_alloc(
+// CHECK-LABEL: func.func @single_result_for_loop_carry_drops_vector_tail(
+// VECTOR scope: retains full loop logic with two result-bearing if statements
 // CHECK: scope.scope : () -> () {
-// CHECK: scf.if
-// CHECK: memref.store
+// CHECK: %[[FOR_VEC:.*]] = scf.for %{{.*}} = {{.*}} to {{.*}} step {{.*}} iter_args
+// CHECK: %[[IF1_VEC:.*]] = scf.if {{.*}} -> (tensor<4xf32>)
+// CHECK: arith.addf
+// CHECK: scf.yield
+// CHECK: }
+// CHECK: %[[IF2_VEC:.*]] = scf.if {{.*}} -> (tensor<4xf32>)
+// CHECK: arith.addf
+// CHECK: scf.yield
+// CHECK: }
+// CHECK: scf.yield %[[IF2_VEC]]
+// CHECK: }
+// CHECK: %[[EXTRACT:.*]] = tensor.extract %[[FOR_VEC]]
+// CHECK: memref.store %[[EXTRACT]]
 // CHECK: scope.return
 // CHECK: } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CUBE scope: only condition check, yields constant (loop-carry dropped)
 // CHECK: scope.scope : () -> () {
-// CHECK: memref.load
+// CHECK: %[[FOR_CUBE:.*]] = scf.for %{{.*}} = {{.*}} to {{.*}} step {{.*}} iter_args
+// CHECK: scf.if %{{.*}} {
+// CHECK: arith.addf
+// CHECK: tensor.extract
 // CHECK: memref.store
+// CHECK: }
+// CHECK: scf.yield %{{.*}} : tensor<4xf32>
+// CHECK: }
+// CHECK: scope.return
+// CHECK: } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+module {
+  func.func @single_result_for_loop_carry_drops_vector_tail(%lb: i32, %ub: i32, %cond_cube: i1, %cond_vec: i1, %init: tensor<4xf32>, %cube_src: tensor<4xf32>, %vec_src: tensor<4xf32>, %outv: memref<1xf32>, %outc: memref<1xf32>) {
+    %idxv = arith.constant {ssbuffer.core_type = "VECTOR"} 0 : index
+    %idxc = arith.constant {ssbuffer.core_type = "CUBE"} 0 : index
+    %step = arith.constant {ssbuffer.core_type = "VECTOR"} 1 : i32
+    %0 = scf.for %i = %lb to %ub step %step iter_args(%state = %init) -> (tensor<4xf32>) : i32 {
+      %1 = scf.if %cond_cube -> (tensor<4xf32>) {
+        %2 = arith.addf %state, %cube_src {ssbuffer.core_type = "CUBE"} : tensor<4xf32>
+        %3 = tensor.extract %2[%idxc] {ssbuffer.core_type = "CUBE"} : tensor<4xf32>
+        memref.store %3, %outc[%idxc] {ssbuffer.core_type = "CUBE"} : memref<1xf32>
+        scf.yield {ssbuffer.core_type = "VECTOR"} %2 : tensor<4xf32>
+      } else {
+        scf.yield {ssbuffer.core_type = "VECTOR"} %state : tensor<4xf32>
+      } {ssbuffer.core_type = "VECTOR"}
+      %2 = scf.if %cond_vec -> (tensor<4xf32>) {
+        %3 = arith.addf %1, %vec_src {ssbuffer.core_type = "VECTOR"} : tensor<4xf32>
+        scf.yield {ssbuffer.core_type = "VECTOR"} %3 : tensor<4xf32>
+      } else {
+        scf.yield {ssbuffer.core_type = "VECTOR"} %1 : tensor<4xf32>
+      } {ssbuffer.core_type = "VECTOR"}
+      scf.yield {ssbuffer.core_type = "VECTOR"} %2 : tensor<4xf32>
+    } {ssbuffer.core_type = "VECTOR"}
+    %1 = tensor.extract %0[%idxv] {ssbuffer.core_type = "VECTOR"} : tensor<4xf32>
+    memref.store %1, %outv[%idxv] {ssbuffer.core_type = "VECTOR"} : memref<1xf32>
+    func.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @memref_slot_neutralize_uses_alloc(
+// VECTOR scope: retain if-else with arithmetic (addi/subi in branches), then consume result
+// CHECK: scope.scope : () -> () {
+// CHECK: %[[IF_RES:.*]] = scf.if {{.*}} -> (i32)
+// CHECK:   arith.addi
+// CHECK:   scf.yield
+// CHECK: } else
+// CHECK:   arith.subi
+// CHECK:   scf.yield
+// CHECK: }
+// CHECK: %[[FINAL_RES:.*]] = arith.addi %[[IF_RES]], %{{.*}} : i32
+// CHECK: memref.store %[[FINAL_RES]]
+// CHECK: scope.return
+// CHECK: } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CUBE scope: only load and store, no arithmetic
+// CHECK: scope.scope : () -> () {
+// CHECK: %[[LOADED:.*]] = memref.load
+// CHECK: memref.store %[[LOADED]]
 // CHECK: scope.return
 // CHECK: } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
 module {


### PR DESCRIPTION

  - Remove isOpAlive() helper (over-defensive in this pass's context)
  - Replace findLiveUser/findNonTermUser with unified findScopeRelevantUser(value, scopeType, ignoreTerminators)
