### PR TITLE
fix(ssbuffer): Generalize vector-only op detection and fallback mechanism for CUBE control flow

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -75,6 +75,9 @@ inline bool isCubeOp(Operation *op)
 {
     return CVPipeline::getOpCoreType(op) == CoreType::CUBE_ONLY;
 }
+
+bool isVectorOnlyOp(Operation *op);
+
 } // namespace CVPipeline
 } // namespace mlir
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeCubeContolFLowInputChain.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeCubeContolFLowInputChain.cpp
@@ -20,16 +20,24 @@
  * THE SOFTWARE.
  */
 
-#include "ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h"
-#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
-#include "bishengir/Dialect/HIVM/IR/HIVM.h"
-#include "bishengir/Dialect/Scope/IR/Scope.h"
+
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/ValueRange.h"
+#include "mlir/Support/LLVM.h"
+
+#include "ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "bishengir/Dialect/Scope/IR/Scope.h"
 
 static constexpr const char *DEBUG_TYPE = "analyze-cube-control-flow-input-chain";
 #define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
@@ -58,11 +66,17 @@ static bool isCubeScope(scope::ScopeOp scopeOp)
 
 static bool isControlFlowOp(Operation *op)
 {
-    return isa<scf::IfOp>(op) || isa<scf::ForOp>(op) || isa<scf::WhileOp>(op);
+    return llvm::isa<scf::SCFDialect>(op->getDialect());
 }
 
-static bool hasDefiningChainWithReduceOrTensorSelect(Value val,
-                                                     llvm::DenseSet<Value> &visited)
+static bool hasIncompatibleOpForCondition(Value val, llvm::DenseSet<Value> &visited);
+
+static inline bool hasIncompatibleUpstream(ValueRange operands, llvm::DenseSet<Value> &visited)
+{
+    return llvm::any_of(operands, [&](Value operand) { return hasIncompatibleOpForCondition(operand, visited); });
+}
+
+static bool hasIncompatibleOpForCondition(Value val, llvm::DenseSet<Value> &visited)
 {
     if (visited.contains(val)) {
         return false;
@@ -70,54 +84,38 @@ static bool hasDefiningChainWithReduceOrTensorSelect(Value val,
     visited.insert(val);
 
     Operation *defOp = val.getDefiningOp();
-    while (defOp) {
-
-        if (isa<linalg::ReduceOp>(defOp)) {
-            LDBG("Found linalg.reduce in defining chain");
-            return true;
-        }
-
-        if (auto selectOp = dyn_cast<arith::SelectOp>(defOp)) {
-            if (isa<RankedTensorType>(selectOp.getType())) {
-                LDBG("Found arith.select with tensor result in defining chain");
-                return true;
-            }
-        }
-
-        if (defOp->getNumOperands() == 0) {
-            break;
-        }
-
-        for (Value operand : defOp->getOperands()) {
-            if (hasDefiningChainWithReduceOrTensorSelect(operand, visited)) {
-                return true;
-            }
-        }
-        
-        break;
+    if (!defOp) {
+        return false;
     }
-
-    return false;
+    if (isVectorOnlyOp(defOp)) {
+        LDBG("Fallback reason: incompatible upstream op for control flow: " << *defOp);
+        return true;
+    }
+    return hasIncompatibleUpstream(defOp->getOperands(), visited);
 }
 
 static bool checkControlFlowOpInputs(Operation *cfOp)
 {
+    llvm::SmallVector<Value> scalarOperands;
+    llvm::TypeSwitch<Operation *>(cfOp)
+        .Case([&](scf::IfOp ifOp) { scalarOperands.push_back(ifOp.getCondition()); })
+        .Case([&](scf::ForOp forOp) {
+            scalarOperands.append({forOp.getLowerBound(), forOp.getUpperBound(), forOp.getStep()});
+        })
+        .Case([&](scf::WhileOp whileOp) {
+            // while op is very complicated, all loop-carried vars may influence conditions, conservatively take all
+            // args
+            auto operands = whileOp->getOperands();
+            scalarOperands.append(operands.begin(), operands.end());
+        })
+        .Default([&](Operation *op) {
+            // user passed in unknown op, conservatively take all operands
+            auto operands = op->getOperands();
+            scalarOperands.append(operands.begin(), operands.end());
+        });
+
     llvm::DenseSet<Value> visited;
-
-    auto checkOperands = [&](ValueRange operands) {
-        for (Value operand : operands) {
-            if (hasDefiningChainWithReduceOrTensorSelect(operand, visited)) {
-                return true;
-            }
-        }
-        return false;
-    };
-
-    if (checkOperands(cfOp->getOperands())) {
-        return true;
-    }
-
-    return false;
+    return hasIncompatibleUpstream(scalarOperands, visited);
 }
 
 bool checkCubeControlFlowInputChain(ModuleOp module)

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -1,9 +1,16 @@
 #include <optional>
+
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/LogicalResult.h"
-#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/Builders.h"
+
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 namespace mlir {
 namespace CVPipeline {
 
@@ -76,6 +83,19 @@ void setFallbackAttr(ModuleOp module)
 {
     OpBuilder builder(module.getContext());
     module->setAttr(CVPipeline::ERRCODE_ATTR, builder.getI32IntegerAttr(CVPipeline::ERRCODE_IGNORED));
+}
+
+bool isVectorOnlyOp(Operation *op)
+{
+    if (!op) {
+        return false;
+    }
+
+    return llvm::TypeSwitch<Operation *, bool>(op)
+        .Case([](linalg::ReduceOp) { return true; })
+        .Case<arith::SelectOp, math::FloorOp>(
+            [](Operation *op) { return isa<RankedTensorType>(op->getResult(0).getType()); })
+        .Default([](auto) { return false; });
 }
 
 } // namespace CVPipeline

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_skip_cases.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_skip_cases.mlir
@@ -1,0 +1,140 @@
+// RUN: triton-opt -split-input-file --analyze-cube-control-flow-input-chain -verify-diagnostics -debug %s 2>&1 | FileCheck %s
+
+// ============================================================================
+// Scenario 1: Fallback case for linalg.reduce (Vector Only Op)
+// linalg.reduce is unconditionally considered vector-only and triggers fallback.
+// ============================================================================
+
+func.func @test_scf_if_with_linalg_reduce(%input : tensor<16x16xf32>, %init : tensor<16xf32>, %c0 : index, %zero : f32) {
+  scope.scope : () -> () {
+    %reduced = linalg.reduce ins(%input : tensor<16x16xf32>) outs(%init : tensor<16xf32>) dimensions = [0]
+      (%in: f32, %out: f32) {
+        %sum = arith.addf %in, %out : f32
+        linalg.yield %sum : f32
+      }
+    %val = tensor.extract %reduced[%c0] : tensor<16xf32>
+    %cond = arith.cmpf ogt, %val, %zero : f32
+
+    // CHECK: [analyze-cube-control-flow-input-chain] Fallback reason: incompatible upstream op for control flow: {{.*}} = linalg.reduce
+    scf.if %cond {
+      // some body
+    }
+    scope.return
+  } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+  return
+}
+
+// -----
+
+// ============================================================================
+// Scenario 2: Fallback case for arith.select with RankedTensorType result
+// arith.select returning a RankedTensorType is considered vector-only.
+// ============================================================================
+
+func.func @test_scf_for_with_tensor_select(%cond : i1, %t1 : tensor<16xindex>, %t2 : tensor<16xindex>, %c0 : index, %step : index) {
+  scope.scope : () -> () {
+    %select_tensor = arith.select %cond, %t1, %t2 : i1, tensor<16xindex>
+    %ub = tensor.extract %select_tensor[%c0] : tensor<16xindex>
+    %lb = arith.constant 0 : index
+
+    // CHECK: [analyze-cube-control-flow-input-chain] Fallback reason: incompatible upstream op for control flow: {{.*}} = arith.select
+    scf.for %i = %lb to %ub step %step {
+      // some body
+    }
+    scope.return
+  } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+  return
+}
+
+// -----
+
+// ============================================================================
+// Scenario 3: Fallback case for math.floor with RankedTensorType result
+// math.floor returning a RankedTensorType is considered vector-only.
+// ============================================================================
+
+func.func @test_scf_while_with_tensor_floor(%input : tensor<16xf32>, %c0 : index) {
+  scope.scope : () -> () {
+    %floor_tensor = math.floor %input : tensor<16xf32>
+    %init_val = tensor.extract %floor_tensor[%c0] : tensor<16xf32>
+
+    // CHECK: [analyze-cube-control-flow-input-chain] Fallback reason: incompatible upstream op for control flow: {{.*}} = math.floor
+    %result = scf.while (%arg = %init_val) : (f32) -> f32 {
+      %cond = arith.constant true
+      scf.condition(%cond) %arg : f32
+    } do {
+    ^bb0(%arg2: f32):
+      scf.yield %arg2 : f32
+    }
+    scope.return
+  } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+  return
+}
+
+// -----
+
+// ============================================================================
+// Scenario 4: Successful case with scalar select (No Fallback)
+// arith.select returning a scalar is compatible and should NOT trigger fallback.
+// ============================================================================
+
+// CHECK-LABEL: func.func @test_scf_if_with_scalar_select
+func.func @test_scf_if_with_scalar_select(%cond : i1, %val_a : f32, %val_b : f32) {
+  scope.scope : () -> () {
+    // This select returns a scalar (f32), which is NOT a RankedTensorType.
+    %selected = arith.select %cond, %val_a, %val_b : f32
+    %zero = arith.constant 0.0 : f32
+    %if_cond = arith.cmpf ogt, %selected, %zero : f32
+
+    // CHECK-NOT: Fallback reason:
+    scf.if %if_cond {
+      // some body
+    }
+    scope.return
+  } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+  return
+}
+
+// -----
+
+// ============================================================================
+// Scenario 5: Successful case with scalar floor (No Fallback)
+// math.floor returning a scalar is compatible and should NOT trigger fallback.
+// ============================================================================
+
+// CHECK-LABEL: func.func @test_scf_if_with_scalar_floor
+func.func @test_scf_if_with_scalar_floor(%val : f32) {
+  scope.scope : () -> () {
+    // This math.floor returns a scalar (f32), which is NOT a RankedTensorType.
+    %floored = math.floor %val : f32
+    %zero = arith.constant 0.0 : f32
+    %if_cond = arith.cmpf ogt, %floored, %zero : f32
+
+    // CHECK-NOT: Fallback reason:
+    scf.if %if_cond {
+      // some body
+    }
+    scope.return
+  } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+  return
+}
+
+// -----
+
+// ============================================================================
+// Scenario 6: Normal control flow without any vector-only ops (No Fallback)
+// ============================================================================
+
+// CHECK-LABEL: func.func @test_scf_if_fully_compatible
+func.func @test_scf_if_fully_compatible(%val_a : f32, %val_b : f32) {
+  scope.scope : () -> () {
+    %cond = arith.cmpf ogt, %val_a, %val_b : f32
+
+    // CHECK-NOT: Fallback reason:
+    scf.if %cond {
+      // some body
+    }
+    scope.return
+  } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+  return
+}


### PR DESCRIPTION
# 重构 CUBE 控制流输入链分析并通用化向量算子检测与回退机制

## 1. Overview / 概述
### English
This PR refactors the control flow dependency analysis within CUBE scopes to identify incompatible vector-only operations feeding into loop or conditional boundaries. It introduces a unified classification utility, `isVectorOnlyOp`, which consolidates checks for operations like `linalg.reduce`, tensor-typed `arith.select`, and now tensor-typed `math.floor`. When such vector operations are detected in the upstream dependency chain of a control-flow condition, the pass marks the module with a fallback attribute and triggers a controlled pass failure, allowing the upper-level compilation pipeline to gracefully fallback to native compilation.

### 中文
本 PR 重构了 CUBE 作用域内控制流依赖链的分析，旨在识别输入到循环或条件分支边界的不兼容向量特有（vector-only）算子。引入了统一的分类工具函数 `isVectorOnlyOp`，合并了对 `linalg.reduce`、张量类型 `arith.select` 以及新增的张量类型 `math.floor` 的检查。当在控制流条件的上游依赖链中检测到这些向量操作时，该 Pass 将为模块设置回退属性并触发受控的 Pass 失败，促使上层编译框架安全、优雅地回退（fallback）至 native 编译模式。

---

## 2. Key Changes / 关键变更

### English
- **`Common/Utils.h` & `Common/Utils.cpp`**:
  - Declared and implemented `isVectorOnlyOp` utilizing `llvm::TypeSwitch` to centralize the classification of vector-only operations.
  - Added support for identifying `math.floor` operating on `RankedTensorType` as a vector-only op, alongside existing `linalg.reduce` and tensor-typed `arith.select`.
- **`AnalyzeCubeContolFLowInputChain.cpp`**:
  - Replaced the hardcoded, nested `while` loop logic in `hasDefiningChainWithReduceOrTensorSelect` with a recursive helper `hasIncompatibleOpForCondition` tracking visited values with a `DenseSet`.
  - Generalized control-flow input scanning via `checkControlFlowOpInputs` to correctly isolate critical scalar operands across `scf.IfOp` (condition), `scf.ForOp` (bounds and step), and `scf.WhileOp` (all loop-carried operands).
- **`test_skip_cases.mlir`**:
  - Added comprehensive unit tests covering 6 distinct test scenarios to verify successful parsing cases (no fallback) and incompatible cases (triggering fallback).

### 中文
- **`Common/Utils.h` 与 `Common/Utils.cpp`**:
  - 声明并实现了 `isVectorOnlyOp`，利用 `llvm::TypeSwitch` 集中管理向量特有（vector-only）算子的归类判定。
  - 新增对返回 `RankedTensorType` 的 `math.floor` 算子的识别，使其与现有的 `linalg.reduce` 和张量类型 `arith.select` 一同被归类为不兼容的向量特有算子。
- **`AnalyzeCubeContolFLowInputChain.cpp`**:
  - 用递归辅助函数 `hasIncompatibleOpForCondition` 替代了原先 `hasDefiningChainWithReduceOrTensorSelect` 中硬编码的嵌套 `while` 循环逻辑，并使用 `DenseSet` 规避重复遍历。
  - 扩展了 `checkControlFlowOpInputs` 函数，使其能针对不同的控制流算子精准提取关键标量操作数，包括 `scf.IfOp`（条件）、`scf.ForOp`（上下界和步长）以及 `scf.WhileOp`（循环传递的全部操作数）。
- **`test_skip_cases.mlir`**:
  - 添加了包含 6 种场景的单元测试文件，用于验证正常解析（不回退）与检测到不兼容算子（触发回退）两种执行路径。

---

## 3. Technical Deep-Dive / 技术细节剖析
### English
The previous implementation of the input dependency chain validation was prone to missing non-scalar operations of new types and relied on a brittle manual traversal scheme. 

This PR addresses this with two major improvements:
1. **Extensible Classification**: Through `isVectorOnlyOp`, checking for any newly introduced vector-only instruction is simplified. For instance, any `math.floor` operation yielding a `RankedTensorType` is correctly isolated as a vector-only op, while its scalar equivalent remains acceptable.
2. **Robust Dependency Traversal**: The implementation now performs a depth-first traversal of the operands using a `DenseSet<Value>` to avoid infinite loops on cyclic dataflows (though rare in SSA form, it represents a safer pattern).
3. **Graceful Fallback Mechanism**: If an incompatible dependency is encountered, `setFallbackAttr(module)` marks the module with `ERRCODE_IGNORED`, and `signalPassFailure()` is invoked. Although this halts the specialized optimization pipeline and reports an expected pass failure, upper-level drivers interpret this error as a trigger to fall back to native execution without disrupting the compilation flow.

### 中文
原有的输入依赖链验证实现难以扩展到新的非标量算子类型，且依赖于脆弱的手动遍历机制。

本 PR 通过两项重大改进解决了这些问题：
1. **可扩展的分类机制**：通过统一的 `isVectorOnlyOp` 辅助函数，使得引入和检查新的向量特有操作变得更加简单。例如，作用于 `RankedTensorType` 的 `math.floor` 会被准确识别并归类为向量特有算子，而标量形式的 `math.floor` 仍被视为兼容算子。
2. **健壮的依赖遍历**：新实现使用 `DenseSet<Value>` 对操作数进行深度优先遍历，防止在复杂数据流中产生循环访问，从而规避了潜在的遍历死循环。
3. **优雅的回退（Fallback）机制**：当分析检测到不兼容的操作数时，`setFallbackAttr(module)` 会向模块写入 `ERRCODE_IGNORED` 属性，并调用 `signalPassFailure()` 中断当前 Pass。虽然此行为会导致专有优化 Pass 失败报错，但该错误是预期内的，上层调度逻辑捕获后将自动触发回退至 native 编译流程，从而保障了编译器的整体健壮性。

---

## 4. Impact & Risk Assessment / 影响与风险评估
### English
- **Breaking Changes**: No. Behavior remains fully backward compatible.
- **Performance Impact**: Minor compilation-time overhead due to the recursive depth-first search of operands. This is bounded by the complexity of the SSA sub-graph and optimized by utilizing the `visited` set to prevent duplicate lookups.
- **Backward Compatibility**: Fully compatible. The deliberate pass failure is a controlled behavior designed to trigger native fallback logic in the outer compilation framework.

### 中文
- **破坏性变更**: 否。系统行为完全向后兼容。
- **性能影响**: 由于对操作数进行了递归深度优先搜索，会带来极微小的编译耗时开销。该开销受 SSA 子图复杂度限制，且已通过 `visited` 集合避免重复查找进行了优化。
- **向后兼容性**: 完全兼容。本 Pass 主动触发的失败是受控且符合预期的行为，用以指示外部编译框架安全地回退到 native 流水线。

---

## 5. Verification & Testing / 测试与验证方法
### English
- **Unit Tests**: Added `test_skip_cases.mlir` which includes automated assertions (`FileCheck`) to verify:
  - Detection of `linalg.reduce` triggering a fallback warning.
  - Detection of tensor-typed `arith.select` triggering a fallback warning.
  - Detection of tensor-typed `math.floor` triggering a fallback warning.
  - Validation that scalar-typed `arith.select`, scalar `math.floor`, and fully compatible control flows are correctly accepted without triggering fallback logic.

### 中文
- **单元测试**：新增了 `test_skip_cases.mlir` 测试文件，使用 `FileCheck` 自动化验证以下场景：
  - 验证检测到 `linalg.reduce` 时触发回退警告。
  - 验证检测到张量类型 `arith.select` 时触发回退警告。
  - 验证检测到张量类型 `math.floor` 时触发回退警告。
  - 验证标量类型 `arith.select`、标量类型 `math.floor` 以及完全兼容的控制流不会触发回退逻辑，可顺利通过分析。