### PR TITLE
[setup](fix) Remove triton pin from install_requires to prevent libtriton clobbering

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -845,34 +845,8 @@ def get_package_name():
     return os.environ.get("TRITON_WHEEL_NAME", "triton_ascend")
 
 
-ARCHITECTURE_ALIASES = {
-    "x86_64": "x86_64",
-    "amd64": "x86_64",
-    "i386": "x86_64",
-    "i686": "x86_64",
-    "arm64": "arm",
-    "aarch64": "arm",
-    "armv7l": "arm",
-    "armv8l": "arm",
-    "arm": "arm",
-}
-
-ARCHITECTURE_DEPENDENCIES = {
-    "x86_64": ["triton==3.2.0"],
-    "arm": ["triton==3.5.0"],
-}
-
-
-def get_architecture():
-    arch = platform.machine().lower()
-    try:
-        return ARCHITECTURE_ALIASES[arch]
-    except KeyError as exc:
-        raise RuntimeError(f"Unsupported CPU architecture: {arch}") from exc
-
-
 def get_install_requirements():
-    install_requires = [
+    return [
         "attrs==24.2.0",
         "numpy==1.26.4",
         "scipy==1.13.1;python_version<'3.13'",
@@ -885,8 +859,6 @@ def get_install_requirements():
         "pybind11",
         "pandas",
     ]
-    arch = get_architecture()
-    return [*install_requires, *ARCHITECTURE_DEPENDENCIES[arch]]
 
 
 is_manylinux = check_env_flag("IS_MANYLINUX", "FALSE")


### PR DESCRIPTION
### Summary

The triton-ascend wheel ships the full `triton/` namespace and produces `triton/_C/libtriton/` (a package directory) with the ascend backend compiled in. Declaring `triton==X.Y.Z` in install_requires causes pip to also pull the upstream `triton` distribution, whose `triton/_C/libtriton.cpython-*.so` (a single extension file) overwrites our package directory.

After that, `from triton._C.libtriton.ascend import ir` at backend import time fails with:

    ModuleNotFoundError: No module named 'triton._C.libtriton.ascend';
    'triton._C.libtriton' is not a package

Remove the architecture-keyed triton dependency machinery and keep get_install_requirements as the runtime-only dependency list.
