### PR TITLE
[ci] Speed up CI dependency installation by Increase caching usage for `pip`

### DIFF
--- a/.github/workflows/integration-tests-ascend.yml
+++ b/.github/workflows/integration-tests-ascend.yml
@@ -24,6 +24,12 @@ jobs:
     env:
       PROTON_SKIP_PC_SAMPLING_TEST: 1
       PYTHON: "python${{ matrix.python_version }}"
+      UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      UV_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi"
+      UV_INSECURE_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
+      UV_HTTP_TIMEOUT: 120
+      UV_NO_CACHE: 1
+      UV_SYSTEM_PYTHON: 1
 
     steps:
       - name: Checkout
@@ -102,8 +108,8 @@ jobs:
           NUM_PROCS=$(( $(nproc) / 3 ))
           if [ "$NUM_PROCS" -lt 1 ]; then NUM_PROCS=1; fi
           MAX_JOBS="$NUM_PROCS" ${PYTHON} setup.py bdist_wheel
-          ${PYTHON} -m pip install dist/*.whl \
-            -i https://repo.huaweicloud.com/repository/pypi/simple/ --force-reinstall
+          ${PYTHON} -m pip install uv
+          uv pip install --python "${PYTHON}" dist/*.whl
 
       - name: CCache stats
         run: ccache --print-stats

--- a/.github/workflows/integration-tests-ascend.yml
+++ b/.github/workflows/integration-tests-ascend.yml
@@ -26,6 +26,7 @@ jobs:
       PYTHON: "python${{ matrix.python_version }}"
       PIP_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
       PIP_TRUSTED_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
+      PIP_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi"
 
     steps:
       - name: Checkout
@@ -100,11 +101,12 @@ jobs:
           fi
 
           ${PYTHON} -m pip uninstall triton-ascend triton -y || true
+          ${PYTHON} -m pip install -v dist/*.whl --force-reinstall
           ccache --zero-stats
           NUM_PROCS=$(( $(nproc) / 3 ))
           if [ "$NUM_PROCS" -lt 1 ]; then NUM_PROCS=1; fi
           MAX_JOBS="$NUM_PROCS" ${PYTHON} setup.py bdist_wheel
-          ${PYTHON} -m pip install dist/*.whl --force-reinstall
+
 
       - name: CCache stats
         run: ccache --print-stats

--- a/.github/workflows/integration-tests-ascend.yml
+++ b/.github/workflows/integration-tests-ascend.yml
@@ -30,6 +30,8 @@ jobs:
       UV_HTTP_TIMEOUT: 120
       UV_NO_CACHE: 1
       UV_SYSTEM_PYTHON: 1
+      PIP_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_TRUSTED_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
 
     steps:
       - name: Checkout
@@ -104,12 +106,11 @@ jobs:
           fi
 
           ${PYTHON} -m pip uninstall triton-ascend triton -y || true
-          ${PYTHON} -m pip install uv
           ccache --zero-stats
           NUM_PROCS=$(( $(nproc) / 3 ))
           if [ "$NUM_PROCS" -lt 1 ]; then NUM_PROCS=1; fi
           MAX_JOBS="$NUM_PROCS" ${PYTHON} setup.py bdist_wheel
-          uv pip install --python "${PYTHON}" --no-deps dist/*.whl
+          ${PYTHON} -m pip install dist/*.whl --force-reinstall
 
       - name: CCache stats
         run: ccache --print-stats

--- a/.github/workflows/integration-tests-ascend.yml
+++ b/.github/workflows/integration-tests-ascend.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: "true"
+          fetch-depth: 1
 
       - name: Add git safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -101,11 +102,11 @@ jobs:
           fi
 
           ${PYTHON} -m pip uninstall triton-ascend triton -y || true
-          ${PYTHON} -m pip install -v dist/*.whl --force-reinstall
           ccache --zero-stats
           NUM_PROCS=$(( $(nproc) / 3 ))
           if [ "$NUM_PROCS" -lt 1 ]; then NUM_PROCS=1; fi
           MAX_JOBS="$NUM_PROCS" ${PYTHON} setup.py bdist_wheel
+          ${PYTHON} -m pip install -v dist/*.whl --force-reinstall
 
 
       - name: CCache stats

--- a/.github/workflows/integration-tests-ascend.yml
+++ b/.github/workflows/integration-tests-ascend.yml
@@ -104,12 +104,12 @@ jobs:
           fi
 
           ${PYTHON} -m pip uninstall triton-ascend triton -y || true
+          ${PYTHON} -m pip install uv
           ccache --zero-stats
           NUM_PROCS=$(( $(nproc) / 3 ))
           if [ "$NUM_PROCS" -lt 1 ]; then NUM_PROCS=1; fi
           MAX_JOBS="$NUM_PROCS" ${PYTHON} setup.py bdist_wheel
-          ${PYTHON} -m pip install uv
-          uv pip install --python "${PYTHON}" dist/*.whl
+          uv pip install --python "${PYTHON}" --no-deps dist/*.whl
 
       - name: CCache stats
         run: ccache --print-stats

--- a/.github/workflows/integration-tests-ascend.yml
+++ b/.github/workflows/integration-tests-ascend.yml
@@ -24,12 +24,6 @@ jobs:
     env:
       PROTON_SKIP_PC_SAMPLING_TEST: 1
       PYTHON: "python${{ matrix.python_version }}"
-      UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
-      UV_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi"
-      UV_INSECURE_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
-      UV_HTTP_TIMEOUT: 120
-      UV_NO_CACHE: 1
-      UV_SYSTEM_PYTHON: 1
       PIP_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
       PIP_TRUSTED_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
 


### PR DESCRIPTION
## Description

Speed up CI dependency installation by Increase caching usage for `pip`. Change  from https://repo.huaweicloud.com/repository/pypi/simple/ to http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple

### Changes

add  PIP_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
      PIP_TRUSTED_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
      PIP_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi"