### PR TITLE
feat(ssbuffer): add a*b+c when c is limited in args

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/Utils.h
@@ -32,6 +32,10 @@
 namespace mlir {
 namespace triton {
 
+// Attribute names for DynamicCV pipeline
+inline constexpr llvm::StringLiteral kSSBufferIfAttr = "ssbuffer.if";
+inline constexpr llvm::StringLiteral kHIVMMatmulLimitedInCubeAttr = "hivm.matmul_limited_in_cube";
+
 // Collect all nested ops within an operation's regions
 LogicalResult collectAllNestedOps(Operation *op, llvm::DenseSet<Operation *> &regionOps);
 

--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -42,6 +42,7 @@ inline constexpr llvm::StringLiteral kTcoreType = "hivm.tcore_type";
 inline constexpr llvm::StringLiteral kIf = "ssbuffer.if";
 inline constexpr llvm::StringLiteral kIntraBuffer = "ssbuffer.intra_buffer";
 inline constexpr llvm::StringLiteral kAnalyzeFlagId = "ssbuffer.analyze_flag_id";
+inline constexpr llvm::StringLiteral kLoopCarriedL0C = "ssbuffer.loop_carried_l0c";
 inline constexpr const char *ERRCODE_ATTR = "triton_ascend.dynamic_cv_pipeline.rc";
 static constexpr const int ERRCODE_FAILED = 1;
 static constexpr const int ERRCODE_IGNORED = 2;
@@ -71,10 +72,11 @@ std::optional<int64_t> getOpBlockId(Operation *op);
 llvm::LogicalResult verifyOpBlockId(Operation *op);
 int getAvailableBlockId(ModuleOp module);
 void setFallbackAttr(ModuleOp module);
+bool isScfOp(Operation *op);
 
 inline bool isCubeOp(Operation *op)
 {
-    return CVPipeline::getOpCoreType(op) == CoreType::CUBE_ONLY;
+    return !isScfOp(op) && CVPipeline::getOpCoreType(op) == CoreType::CUBE_ONLY;
 }
 
 bool isVectorOnlyOp(Operation *op);

--- a/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h
+++ b/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h
@@ -27,16 +27,13 @@
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
 #include "mlir/Analysis/AliasAnalysis.h"
-#include "bishengir/Dialect/Annotation/IR/Annotation.h"
-#include "bishengir/Dialect/HIVM/IR/HIVM.h"
-#include "mlir/Analysis/AliasAnalysis.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Value.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
@@ -121,6 +118,7 @@ private:
 
     // Get the core type of an operation
     OpCoreType getCoreType(Operation *op) const;
+    OpCoreType getForInitCoreType(OpOperand *operand) const;
 
     // Set the core type of an operation
     void setCoreType(Operation *op, OpCoreType coreType);

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CreateIfOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CreateIfOps.cpp
@@ -224,7 +224,10 @@ static scf::IfOp createIfOpForBlock(OpBuilder &builder, Location loc, int blockI
     ifOp = builder.create<scf::IfOp>(loc, TypeRange{}, trueVal, false);
   }
 
-  ifOp->setAttr("ssbuffer.if", builder.getI32IntegerAttr(blockId));
+  ifOp->setAttr(kSSBufferIfAttr, builder.getI32IntegerAttr(blockId));
+
+  // notify npuir that of the scenario
+  ifOp->setAttr(kHIVMMatmulLimitedInCubeAttr, builder.getUnitAttr());
 
   return ifOp;
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -6,6 +6,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -96,6 +97,11 @@ bool isVectorOnlyOp(Operation *op)
         .Case<arith::SelectOp, math::FloorOp>(
             [](Operation *op) { return isa<RankedTensorType>(op->getResult(0).getType()); })
         .Default([](auto) { return false; });
+}
+
+bool isScfOp(Operation *op)
+{
+  return llvm::isa<scf::SCFDialect>(op->getDialect());
 }
 
 } // namespace CVPipeline

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -31,9 +31,11 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Interfaces/CastInterfaces.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Support/LLVM.h"
 
@@ -383,6 +385,19 @@ int OpClassifierPass::patternMatchCUBE()
         // ---- Upstream pattern matching ----
         for (Value operand : op->getOperands()) {
             Operation *def = operand.getDefiningOp();
+            // A null defining op means `operand` is a loop iter_arg block argument.
+            // Walk back to its init operand (repeating to also cross nested loops).
+            for (Value cur = operand; !def;) {
+                auto blockArg = dyn_cast<BlockArgument>(cur);
+                auto loopLike =
+                    blockArg ? dyn_cast_or_null<LoopLikeOpInterface>(blockArg.getOwner()->getParentOp()) : nullptr;
+                OpOperand *init = loopLike ? loopLike.getTiedLoopInit(blockArg) : nullptr;
+                if (!init) {
+                    break;
+                }
+                cur = init->get();
+                def = cur.getDefiningOp();
+            }
             if (!def)
                 continue;
 
@@ -394,9 +409,51 @@ int OpClassifierPass::patternMatchCUBE()
         // ---- Downstream pattern matching ----
         for (Value result : op->getResults()) {
             for (Operation *user : result.getUsers()) {
-                matchStorePattern(user);
-                matchExtractSlicePattern(user);
-                matchMaterializePattern(user);
+                // If user is scf.yield, follow the chain to find real users
+                Operation *curUser = user;
+                while (curUser) {
+                    if (auto yieldOp = dyn_cast<scf::YieldOp>(curUser)) {
+                        if (Operation *scfOp = yieldOp->getParentOp()) {
+                            // Find which operand index the previous result corresponds to in the yield
+                            unsigned yieldOperandIdx = 0;
+                            Value prevResult = result;
+                            for (unsigned i = 0; i < yieldOp->getNumOperands(); ++i) {
+                                if (yieldOp->getOperand(i) == prevResult) {
+                                    yieldOperandIdx = i;
+                                    break;
+                                }
+                            }
+                            // Get the corresponding scf result
+                            if (yieldOperandIdx < scfOp->getNumResults()) {
+                                Value scfResult = scfOp->getResult(yieldOperandIdx);
+                                prevResult = scfResult;
+                                // Find the next user (skipping yield)
+                                curUser = nullptr;
+                                for (Operation *nextUser : scfResult.getUsers()) {
+                                    if (!isa<scf::YieldOp>(nextUser)) {
+                                        curUser = nextUser;
+                                        break;
+                                    }
+                                }
+                                // If no non-yield user found, continue searching from yield
+                                if (!curUser) {
+                                    for (Operation *nextUser : scfResult.getUsers()) {
+                                        if (isa<scf::YieldOp>(nextUser)) {
+                                            curUser = nextUser;
+                                            break;
+                                        }
+                                    }
+                                }
+                                continue;
+                            }
+                        }
+                        break;
+                    }
+                    matchStorePattern(curUser);
+                    matchExtractSlicePattern(curUser);
+                    matchMaterializePattern(curUser);
+                    break;
+                }
             }
         }
     }
@@ -1084,6 +1141,29 @@ int OpClassifierPass::handleSCFYield()
     return 0;
 }
 
+OpCoreType OpClassifierPass::getForInitCoreType(OpOperand *operand) const
+{
+    auto forOp = llvm::dyn_cast<scf::ForOp>(operand->getOwner());
+    if (!forOp) {
+        return OP_UNDETERMINED;
+    }
+    auto iterArg = forOp.getTiedLoopRegionIterArg(operand);
+    if (!iterArg) {
+        // the result is used as lower/upper bound or step
+        return OP_UNDETERMINED;
+    }
+    auto sourceOperand = forOp.getTiedLoopYieldedValue(iterArg);
+    if (!sourceOperand) {
+        return OP_UNDETERMINED;
+    }
+    auto defOp = sourceOperand->get().getDefiningOp();
+    if (!defOp) {
+        // might be a blockarg, not necessary for our use-case
+        return OP_UNDETERMINED;
+    }
+    return getCoreType(defOp);
+}
+
 // ============================================================================
 // Step 6: CUBE_AND_VECTOR Operation Handling
 // ============================================================================
@@ -1180,7 +1260,14 @@ void OpClassifierPass::splitOperationForCubeAndVector(Operation *op, llvm::Dense
         llvm::SmallVector<OpOperand *> usesToUpdate;
         for (OpOperand &use : originalResult.getUses()) {
             Operation *user = use.getOwner();
-            if (user && user != vectorOp && getCoreType(user) == OP_VECTOR_ONLY) {
+            if (!user || user == vectorOp) {
+                continue;
+            }
+            OpCoreType coreType = getCoreType(user);
+            if (llvm::isa<scf::ForOp>(user)) {
+                coreType = getForInitCoreType(&use);
+            }
+            if (coreType == OP_VECTOR_ONLY) {
                 usesToUpdate.push_back(&use);
             }
         }

--- a/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
@@ -42,7 +42,7 @@ static constexpr const char *DEBUG_TYPE = "RemoveAttributes";
 
 // if extra attr is needed, add to ut @
 // third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/test-remove-attrs.mlir
-static constexpr llvm::StringLiteral kAttrsToRemove[] {kBlockId, kCoreType, kTransferId, kMainLoop, kCubeFirst, kVectorFirst, kAddFromMatmul, kIntraBuffer, kAnalyzeFlagId};
+static constexpr llvm::StringLiteral kAttrsToRemove[] {kBlockId, kCoreType, kTransferId, kMainLoop, kCubeFirst, kVectorFirst, kAddFromMatmul, kIntraBuffer, kAnalyzeFlagId, kLoopCarriedL0C};
 
 void RemoveSsbufAttrPass::runOnOperation()
 {

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/PreserveControlAttrsCanonicalize.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/PreserveControlAttrsCanonicalize.cpp
@@ -86,6 +86,7 @@ private:
         if (!isTrackedControlFlowOp(oldOp))
             return nullptr;
 
+        // Prefer direct replacement from definingOps
         for (Value value : replacements) {
             if (!value)
                 continue;
@@ -94,9 +95,17 @@ private:
                 return defOp;
         }
 
+        // Fallback: search recentInserts in reverse, skip nested candidates
         for (Operation *candidate : llvm::reverse(recentInserts.getArrayRef())) {
-            if (canTransferAttrs(oldOp, candidate))
-                return candidate;
+            if (!canTransferAttrs(oldOp, candidate))
+                continue;
+
+            // Skip candidates nested inside another new control flow op
+            Operation *parent = candidate->getParentOp();
+            if (parent && recentInserts.contains(parent) && isTrackedControlFlowOp(parent))
+                continue;
+
+            return candidate;
         }
         return nullptr;
     }

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
@@ -820,6 +820,10 @@ void mlir::triton::SeparateCVScopePass::runOnOperation()
         }
     }
 
+    module.walk([](scope::ScopeOp scopeOp) {
+        scopeOp->setAttr("hivm.matmul_limited_in_cube", UnitAttr::get(scopeOp->getContext()));
+    });
+
     debugDumpOperation("after SeparateCVScopePass", module.getOperation());
 }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp.cpp
@@ -42,6 +42,7 @@ namespace mlir::triton {
 void StandardizeOpPass::runOnOperation()
 {
     auto op = getOperation();
+    LOG_DEBUG("Input mlir:\n" << op);
     OpPassManager pm(op.getOperationName());
     pm.addPass(createPatternMatchRewritePass());
 

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.cpp
@@ -44,7 +44,11 @@ void PatternMatchRewritePass::runOnOperation()
     RewritePatternSet patterns(ctx);
     patterns.add<SplitMatmulPattern>(ctx);
 
-    if (llvm::failed(applyPatternsAndFoldGreedily(moduleOp, std::move(patterns)))) {
+    // the way we handle matmul dependencies across for blocks
+    // requres the patternmatching to go top-down
+    GreedyRewriteConfig config = GreedyRewriteConfig();
+    config.useTopDownTraversal = true;
+    if (llvm::failed(applyPatternsAndFoldGreedily(moduleOp, std::move(patterns), config))) {
         LOG_DEBUG("matchAndRewrite does not converge!");
         signalPassFailure();
         return;

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
@@ -20,23 +20,35 @@
  * THE SOFTWARE.
  */
 
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/ADT/iterator.h"
+#include "llvm/IR/Verifier.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/LogicalResult.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "mlir/IR/BuiltinAttributeInterfaces.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/IR/OperationSupport.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Support/LLVM.h"
 
-#include "ascend/include/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.h"
+
+#include "DynamicCVPipeline/PlanComputeBlock/Common.h"
+#include "bishengir/Dialect/HIVM/IR/HIVMImpl.h"
 
 using namespace llvm;
 using namespace mlir;
@@ -46,26 +58,33 @@ using namespace CVSplit;
 static constexpr const char *DEBUG_TYPE = "SplitMatmul";
 #define LOG_DEBUG(...) LLVM_DEBUG(llvm::dbgs() << "\n[" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
 
-// the user is responsible for checking biasDefOp is not null
-static bool biasIsZero(Operation *biasDefOp)
+namespace {
+
+struct MatmulInputs {
+    Value a;
+    Value b;
+    Value bias;
+};
+
+} // namespace
+
+static inline MatmulInputs parseMatmulInputs(linalg::MatmulOp matmulOp)
 {
-    auto fillOp = dyn_cast<linalg::FillOp>(biasDefOp);
+    auto inits = matmulOp.getDpsInits();
+    auto inputs = matmulOp.getDpsInputs();
+
+    return {inputs[0], inputs[1], inits[0]};
+}
+
+// the user is responsible for checking biasDefOp is not null
+static bool operationIsFillZero(Operation *op)
+{
+    auto fillOp = dyn_cast<linalg::FillOp>(op);
     if (!fillOp) {
         return false;
     }
     auto filledVal = fillOp.getInputs()[0];
-    auto constOp = filledVal.getDefiningOp<arith::ConstantOp>();
-    if (!constOp) {
-        return false;
-    }
-    return mlir::TypeSwitch<TypedAttr, bool>(constOp.getValueAttr())
-        .Case<FloatAttr, IntegerAttr>([](auto intOrFloatAttr) { return intOrFloatAttr.getValue().isZero(); })
-        .Default([](auto) { return false; });
-}
-
-static bool resultIsUsedByMatmul(Value res)
-{
-    return llvm::any_of(res.getUsers(), [](Operation *op) { return isa<linalg::MatmulOp>(op); });
+    return matchPattern(filledVal, m_Zero()) || matchPattern(filledVal, m_AnyZeroFloat());
 }
 
 // this generally should always be true, but just for safety...
@@ -73,6 +92,205 @@ static bool isFloatOrInt(RankedTensorType tensorType)
 {
     auto elmType = tensorType.getElementType();
     return isa<FloatType, IntegerType>(elmType);
+}
+
+// Search outward from args to obtain the following information:
+// 1. Whether args is only used and updated by matmul: bool argsLimitedInMatmul
+// 2. Whether matmul is guaranteed to execute: bool mayNotExec
+// 3. Outermost initial value: Value outerInVal
+// 4. Outermost for or if, i.e., where to insert if/else.
+static Value searchInArgsChain(Value nextValueOfC, bool &argsLimitedInMatmul, bool &mayNotExec, Value &outerInVal)
+{
+    if (outerInVal.getDefiningOp()) {
+        return nextValueOfC;
+    }
+    auto op = nextValueOfC.getDefiningOp();
+    auto parentOp = op->getParentOp();
+    Value nextSearchValue = nextValueOfC;
+
+    // update mayNotExec
+    if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
+        IntegerAttr ubAttr, lbAttr;
+        if (matchPattern(forOp.getUpperBound(), m_Constant(&ubAttr)) &&
+            matchPattern(forOp.getLowerBound(), m_Constant(&lbAttr)))
+        {
+            if (ubAttr.getValue().sle(lbAttr.getValue())) {
+                mayNotExec = true;
+            }
+        } else {
+            mayNotExec = true;
+        }
+    } else if (auto ifOp = dyn_cast<scf::IfOp>(parentOp)) {
+        if (!matchPattern(ifOp.getCondition(), m_One())) {
+            mayNotExec = true;
+        }
+    }
+
+    // update argsLimitedInMatmul
+    if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
+        auto blockArg = dyn_cast_if_present<BlockArgument>(outerInVal);
+        if (!blockArg || blockArg.getOwner() != forOp.getBody()) {
+            argsLimitedInMatmul = false;
+            return nextValueOfC;
+        }
+        int argIdx = blockArg.getArgNumber() - 1;
+        for (auto &use : blockArg.getUses()) {
+            auto user = use.getOwner();
+            // Allowed: the op itself (mmad or inner for/if that chains to mmad).
+            auto userInBlock = CVPipeline::getAncestorInBlock(user, op->getBlock());
+            if (userInBlock == op) {
+                continue;
+            }
+            if (auto yieldOp = dyn_cast<scf::YieldOp>(userInBlock)) {
+                argsLimitedInMatmul = (use.getOperandNumber() == argIdx);
+            } else {
+                argsLimitedInMatmul = false;
+                break;
+            }
+        }
+        outerInVal = forOp.getInitArgs()[argIdx];
+        nextSearchValue = forOp->getResult(argIdx);
+    } else if (auto ifOp = dyn_cast<scf::IfOp>(parentOp)) {
+        if (!ifOp.elseBlock()) {
+            argsLimitedInMatmul = false;
+        }
+        auto otherYieldOp = op->getBlock() == ifOp->getBlock() ? cast<scf::YieldOp>(ifOp.elseBlock()->getTerminator())
+                                                               : cast<scf::YieldOp>(ifOp.thenBlock()->getTerminator());
+        auto opYieldOp = op->getBlock() == ifOp->getBlock() ? cast<scf::YieldOp>(ifOp.thenBlock()->getTerminator())
+                                                            : cast<scf::YieldOp>(ifOp.elseBlock()->getTerminator());
+        int resultIdx = -1;
+        for (unsigned i = 0; i < otherYieldOp->getNumOperands(); ++i) {
+            if (otherYieldOp->getOperand(i) == outerInVal && opYieldOp->getOperand(i) == nextSearchValue) {
+                resultIdx = i;
+                break;
+            }
+        }
+        if (resultIdx == -1) {
+            argsLimitedInMatmul = false;
+        } else {
+            nextSearchValue = ifOp.getResult(resultIdx);
+        }
+    } else {
+        argsLimitedInMatmul = false;
+        LOG_DEBUG("WARN: no for/if out to matmul.");
+    }
+
+    if (!argsLimitedInMatmul) {
+        return nextValueOfC; // early return
+    }
+    return searchInArgsChain(nextSearchValue, argsLimitedInMatmul, mayNotExec, outerInVal);
+}
+
+template <typename Container> static Container filterNonIgnoredOps(const Container &container)
+{
+    auto filteredRange = llvm::make_filter_range(container, [](Operation *op) { return !isa<tensor::DimOp>(op); });
+    return Container(filteredRange.begin(), filteredRange.end());
+}
+
+static OpOperand *getOnlyUse(Operation *op, Value value)
+{
+    auto uses =
+        make_pointer_range(make_filter_range(op->getOpOperands(), [=](OpOperand &use) { return use.get() == value; }));
+    llvm::SmallVector<OpOperand *> usesVec(uses.begin(), uses.end());
+    if (usesVec.size() != 1) {
+        return nullptr;
+    }
+
+    return usesVec[0];
+}
+
+/**
+ * @brief Traces a chain of single-user operations starting from the given value.
+ * Returns true if an operation matching the predicate is found in the chain.
+ *
+ * This function follows the def-use chain through operations that have exactly
+ * one user. It traverses through view-like operations and for loops by
+ * tracking init args to their corresponding iteration arguments.
+ *
+ * @param value The starting value to trace from
+ * @param isMatchedOp Callback to check if an operation matches the criteria
+ * @return True if a matching operation is found, false otherwise
+ */
+static bool traceSingleChainUser(Value value, const std::function<bool(Operation *, Value v)> &isMatchedOp)
+{
+    if (!value) {
+        return false;
+    }
+
+    auto users = filterNonIgnoredOps(llvm::DenseSet<Operation *>(value.user_begin(), value.user_end()));
+    if (users.size() != 1) {
+        return false;
+    }
+
+    auto *user = *users.begin();
+    if (isMatchedOp(user, value)) {
+        return true;
+    }
+
+    if (llvm::isa<ViewLikeOpInterface>(user)) {
+        return traceSingleChainUser(user->getResult(0), isMatchedOp);
+    }
+    
+    if (auto forOp = dyn_cast<scf::ForOp>(user)) {
+        auto initArgs = forOp.getInitArgs();
+        int initIndx = -1;
+        int useCnt = 0;
+        for (auto [i, arg] : llvm::enumerate(initArgs)) {
+            if (arg == value) {
+                initIndx = i;
+                useCnt++;
+            }
+        }
+        if (useCnt == 1) {
+            return traceSingleChainUser(
+                forOp.getRegionIterArgs()[initIndx], isMatchedOp);
+        }
+    }
+    return false;
+}
+
+static bool verifyAndHandleLoopCarriedL0C(linalg::MatmulOp matmulOp, PatternRewriter &rewriter, Value bias)
+{
+    if (matmulOp->hasAttr(CVPipeline::kLoopCarriedL0C)) {
+        return false;
+    }
+
+    bool argsLimitedInMatmul = true;
+    bool mayNotExec = false;
+    Value outerInVal = bias;
+    auto outerValue = searchInArgsChain(matmulOp.getResult(0), argsLimitedInMatmul, mayNotExec, outerInVal);
+    auto *outerDefOp = outerValue.getDefiningOp();
+    if (!argsLimitedInMatmul) {
+        LOG_DEBUG("Split because bias is not limited in args" << matmulOp);
+        return true;
+    }
+
+    if (!operationIsFillZero(outerInVal.getDefiningOp())) {
+        // From one matmul
+        auto defMatmul =
+            dyn_cast_if_present<linalg::MatmulOp>(hivm::traceDefOp<linalg::MatmulOp>(bias).value_or(nullptr));
+        if (!defMatmul) {
+            LOG_DEBUG("Split because bias may not be zero, and the init value is not from matmul: " << matmulOp);
+            return true;
+        }
+        LOG_DEBUG("Split because avoiding NPUIR insert fixpipe errors" << matmulOp);
+        return true;
+    }
+
+    if(traceSingleChainUser(outerValue,[=](Operation *op, Value value) { return isa<linalg::MatmulOp>(op); })) {
+        // To one matmul
+        LOG_DEBUG("Split because avoiding NPUIR insert fixpipe errors" << matmulOp);
+        return true;
+    }
+
+    matmulOp->setAttr(CVPipeline::kLoopCarriedL0C, rewriter.getUnitAttr());
+
+    if (mayNotExec) {
+        LOG_DEBUG("Split because the for loop may not execute" << matmulOp);
+        return true;
+    }
+    LOG_DEBUG("Not Split because bias can remain in L0C" << matmulOp);
+    return false;
 }
 
 /**
@@ -88,65 +306,38 @@ static bool isFloatOrInt(RankedTensorType tensorType)
  *    - The matmul must operate on tensors (tensor mode).
  *    - The element type of the output must be an integer or a float type.
  *
- * 2. Rule 1: Downstream Consumption
- *    - If the matmul output is directly consumed by another matmul, split the operation
- *      to optimize pipeline scheduling and dependencies across sequential GEMM layers.
- *
- * 3. Rule 2: Dynamic / Block Argument Accumulator
+ * 2. Rule 1: Dynamic / Block Argument Accumulator
  *    - If the bias tensor is a block argument (i.e., it has no defining operation in the
  *      current block), its compile-time value is unknown. We conservatively assume it is
  *      non-zero and trigger a split.
  *
- * 4. Rule 3: Zero-Accumulator Bypass (Do Not Split)
+ * 3. Rule 2: Zero-Accumulator Bypass (Do Not Split)
  *    - If the bias tensor is statically known to be a constant zero (e.g., initialized via
  *      linalg.fill with 0), the split is bypassed. Standard lowerings already optimize
  *      this cleanly without introducing a redundant vector addition.
  *
- * 5. Default Split:
+ * 4. Default Split:
  *    - If the bias is defined, non-zero, and does not fall under Rule 3, split the operation.
  */
-static bool shouldSplit(linalg::MatmulOp matmulOp)
+static bool shouldSplit(linalg::MatmulOp matmulOp, PatternRewriter &rewriter)
 {
-    auto inits = matmulOp.getDpsInits();
-    auto inputs = matmulOp.getDpsInputs();
-    if (inits.empty() || inputs.size() < 2) {
-        LOG_DEBUG("Not split because op is illegal: " << matmulOp);
-        return false;
-    }
-
-    auto bias = matmulOp.getDpsInits()[0];
-    auto outputType = dyn_cast<RankedTensorType>(bias.getType());
-    if (!outputType) {
-        LOG_DEBUG("Not split because not tensor mode matmul: " << matmulOp);
-        return false;
-    }
-    if (!isFloatOrInt(outputType)) {
-        LOG_DEBUG("Not split because not integer or float: " << matmulOp);
-        return false;
-    }
-
-    // Rule 1: result is used by another matmul -> split
-    if (resultIsUsedByMatmul(matmulOp.getResult(0))) {
-        LOG_DEBUG("Split because result is used by another matmul: " << matmulOp);
-        return true;
-    }
-
-    // Rule 2: bias is block arg -> split
+    auto bias = parseMatmulInputs(matmulOp).bias;
     auto *biasDefOp = bias.getDefiningOp();
+
+    // Rule 1: bias is block arg -> split if result cannot remain in l0c
     if (!biasDefOp) {
-        LOG_DEBUG("Split because bias is block arg: " << matmulOp);
-        // no defining op, split
-        return true;
+        return verifyAndHandleLoopCarriedL0C(matmulOp, rewriter, bias);
     }
 
-    // Rule 3: matmul a b 0 -> do not split
-    if (biasIsZero(biasDefOp)) {
+    // Rule 2: matmul a b 0 -> do not split
+    if (operationIsFillZero(biasDefOp)) {
         LOG_DEBUG("Not split because bias is zero: " << matmulOp);
         return false;
     }
 
     // Otherwise split:
     LOG_DEBUG("Should split: " << matmulOp);
+
     return true;
 }
 
@@ -192,6 +383,7 @@ static void splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rewriter)
     auto inputs = matmulOp.getDpsInputs();
     auto a = inputs[0];
     auto b = inputs[1];
+
     // this is the accumulator/out operand, not result in tensor mode
     auto bias = matmulOp.getDpsInits()[0];
 
@@ -255,9 +447,36 @@ static void splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rewriter)
     rewriter.replaceOp(matmulOp, addOp);
 }
 
+static bool verifyMatmul(linalg::MatmulOp matmulOp)
+{
+    auto inits = matmulOp.getDpsInits();
+    auto inputs = matmulOp.getDpsInputs();
+    if (inits.empty() || inputs.size() < 2) {
+        LOG_DEBUG("Not split because op is illegal: " << matmulOp);
+        return false;
+    }
+
+    auto bias = matmulOp.getDpsInits()[0];
+    auto outputType = dyn_cast<RankedTensorType>(bias.getType());
+    if (!outputType) {
+        LOG_DEBUG("Not split because not tensor mode matmul: " << matmulOp);
+        return false;
+    }
+    if (!isFloatOrInt(outputType)) {
+        LOG_DEBUG("Not split because not integer or float: " << matmulOp);
+        return false;
+    }
+
+    return true;
+}
+
 LogicalResult SplitMatmulPattern::matchAndRewrite(linalg::MatmulOp matmulOp, PatternRewriter &rewriter) const
 {
-    if (!shouldSplit(matmulOp)) {
+    if (!verifyMatmul(matmulOp)) {
+        return failure();
+    }
+
+    if (!shouldSplit(matmulOp, rewriter)) {
         return failure();
     }
 

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/StandardizeOp/split_matmul.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/StandardizeOp/split_matmul.mlir
@@ -5,8 +5,8 @@ module {
   // According to Rule 2, its value is unknown, so we split it.
   // CHECK-LABEL: func.func @case1_block_arg_bias
   // CHECK-SAME: (%[[A:.*]]: tensor<32x64xf32>, %[[B:.*]]: tensor<64x32xf32>, %[[BIAS:.*]]: tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
+  // CHECK-DAG: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK-DAG: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
   // CHECK: %[[ZERO:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[MM:.*]] = linalg.matmul ins(%[[A]], %[[B]] : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD:.*]] = arith.addf %[[MM]], %[[BIAS]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
@@ -37,16 +37,14 @@ module {
   // According to Rule 1, %mm1 must be split even though its bias is constant zero.
   // %mm2's bias is zero and its result is not used by any other matmul, so %mm2 is not split.
   // CHECK-LABEL: func.func @case3_result_used_by_matmul
-  // CHECK: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
+  // CHECK-DAG: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
   // CHECK: %[[EMPTY32:.*]] = tensor.empty() : tensor<32x32xf32>
   // CHECK: %[[ZERO32:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY32]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK: %[[MM1_ACC:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[MM1_ZERO:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[MM1_ACC]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK: %[[MM1:.*]] = linalg.matmul ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[MM1_ZERO]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK: %[[ADD:.*]] = arith.addf %[[MM1]], %[[ZERO32]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
+  // CHECK: %[[MM1:.*]] = linalg.matmul ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO32]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK-NOT: arith.addf
   // CHECK: %[[EMPTY16:.*]] = tensor.empty() : tensor<32x16xf32>
   // CHECK: %[[ZERO16:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY16]] : tensor<32x16xf32>) -> tensor<32x16xf32>
-  // CHECK: %[[MM2:.*]] = linalg.matmul ins(%[[ADD]], %{{.*}} : tensor<32x32xf32>, tensor<32x16xf32>) outs(%[[ZERO16]] : tensor<32x16xf32>) -> tensor<32x16xf32>
+  // CHECK: %[[MM2:.*]] = linalg.matmul ins(%[[MM1]], %{{.*}} : tensor<32x32xf32>, tensor<32x16xf32>) outs(%[[ZERO16]] : tensor<32x16xf32>) -> tensor<32x16xf32>
   // CHECK-NOT: arith.addf
   // CHECK: return %[[MM2]]
   func.func @case3_result_used_by_matmul(%A: tensor<32x64xf32>, %B: tensor<64x32xf32>, %B2: tensor<32x16xf32>) -> tensor<32x16xf32> {
@@ -64,10 +62,11 @@ module {
   // Case 4: Bias is non-zero (filled with a non-zero constant 1.0).
   // It should be split into a zero-initialized matmul followed by an arith.addf.
   // CHECK-LABEL: func.func @case4_nonzero_bias
-  // CHECK: %[[C1:.*]] = arith.constant 1.000000e+00 : f32
-  // CHECK: %[[BIAS:.*]] = linalg.fill ins(%[[C1]] : f32) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK-DAG: %[[C1:.*]] = arith.constant 1.000000e+00 : f32
+  // CHECK-DAG: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
+  // CHECK: %[[BIAS_EMPTY:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[BIAS:.*]] = linalg.fill ins(%[[C1]] : f32) outs(%[[BIAS_EMPTY]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
   // CHECK: %[[ZERO:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[MM:.*]] = linalg.matmul ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD:.*]] = arith.addf %[[MM]], %[[BIAS]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
@@ -83,9 +82,10 @@ module {
   // Case 5: Bias is a 1D-to-2D broadcasted tensor.
   // This non-zero bias definition should be split.
   // CHECK-LABEL: func.func @case5_broadcast_bias
-  // CHECK: %[[BIAS:.*]] = linalg.broadcast ins(%{{.*}} : tensor<32xf32>) outs(%{{.*}} : tensor<32x32xf32>) dimensions = [0]
+  // CHECK-DAG: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
+  // CHECK: %[[BIAS_EMPTY:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[BIAS:.*]] = linalg.broadcast ins(%{{.*}} : tensor<32xf32>) outs(%[[BIAS_EMPTY]] : tensor<32x32xf32>) dimensions = [0]
   // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
   // CHECK: %[[ZERO:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[MM:.*]] = linalg.matmul ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD:.*]] = arith.addf %[[MM]], %[[BIAS]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
@@ -100,8 +100,8 @@ module {
   // Splitting should generate integer zero constant and use arith.addi for accumulation.
   // CHECK-LABEL: func.func @case6_integer_bias
   // CHECK-SAME: (%[[A:.*]]: tensor<32x64xi32>, %[[B:.*]]: tensor<64x32xi32>, %[[BIAS:.*]]: tensor<32x32xi32>) -> tensor<32x32xi32>
-  // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xi32>
   // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+  // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xi32>
   // CHECK: %[[ZERO:.*]] = linalg.fill ins(%[[C0]] : i32) outs(%[[EMPTY]] : tensor<32x32xi32>) -> tensor<32x32xi32>
   // CHECK: %[[MM:.*]] = linalg.matmul ins(%[[A]], %[[B]] : tensor<32x64xi32>, tensor<64x32xi32>) outs(%[[ZERO]] : tensor<32x32xi32>) -> tensor<32x32xi32>
   // CHECK: %[[ADD:.*]] = arith.addi %[[MM]], %[[BIAS]] {ssbuffer.add_from_matmul} : tensor<32x32xi32>
@@ -118,14 +118,118 @@ module {
   // CHECK-DAG: %[[DIM0:.*]] = tensor.dim %[[BIAS]], %[[C0_IDX]] : tensor<?x?xf32>
   // CHECK-DAG: %[[C1_IDX:.*]] = arith.constant 1 : index
   // CHECK-DAG: %[[DIM1:.*]] = tensor.dim %[[BIAS]], %[[C1_IDX]] : tensor<?x?xf32>
+  // CHECK-DAG: %[[C0_FLT:.*]] = arith.constant 0.000000e+00 : f32
   // CHECK: %[[EMPTY:.*]] = tensor.empty(%[[DIM0]], %[[DIM1]]) : tensor<?x?xf32>
-  // CHECK: %[[C0_FLT:.*]] = arith.constant 0.000000e+00 : f32
   // CHECK: %[[ZERO:.*]] = linalg.fill ins(%[[C0_FLT]] : f32) outs(%[[EMPTY]] : tensor<?x?xf32>) -> tensor<?x?xf32>
   // CHECK: %[[MM:.*]] = linalg.matmul ins(%[[A]], %[[B]] : tensor<?x?xf32>, tensor<?x?xf32>) outs(%[[ZERO]] : tensor<?x?xf32>) -> tensor<?x?xf32>
   // CHECK: %[[ADD:.*]] = arith.addf %[[MM]], %[[BIAS]] {ssbuffer.add_from_matmul} : tensor<?x?xf32>
   func.func @case7_dynamic_shape(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>, %bias: tensor<?x?xf32>) -> tensor<?x?xf32> {
     %mm = linalg.matmul ins(%A, %B : tensor<?x?xf32>, tensor<?x?xf32>) outs(%bias : tensor<?x?xf32>) -> tensor<?x?xf32>
     return %mm : tensor<?x?xf32>
+  }
+
+  // Case 8: Matmul inside scf.for with loop-carried bias.
+  // The bias is a loop-carried variable with zero initial value.
+  // The matmul is marked as loop_carried_l0c and not split (no addf).
+  // CHECK-LABEL: func.func @case8_for_loop_carried_bias
+  // CHECK: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
+  // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[ZERO_INIT:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[BIAS:.*]] = %[[ZERO_INIT]]) -> (tensor<32x32xf32>)
+  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[BIAS]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK-NOT: arith.addf
+  // CHECK: scf.yield %[[MM]] : tensor<32x32xf32>
+  func.func @case8_for_loop_carried_bias(%A: tensor<32x64xf32>, %B: tensor<64x32xf32>) -> tensor<32x32xf32> {
+    %c0 = arith.constant 0 : index
+    %c10 = arith.constant 10 : index
+    %c1 = arith.constant 1 : index
+    %cst = arith.constant 0.0 : f32
+    %empty = tensor.empty() : tensor<32x32xf32>
+    %zero_init = linalg.fill ins(%cst : f32) outs(%empty : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %result = scf.for %iv = %c0 to %c10 step %c1 iter_args(%bias = %zero_init) -> (tensor<32x32xf32>) {
+      %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias : tensor<32x32xf32>) -> tensor<32x32xf32>
+      scf.yield %mm : tensor<32x32xf32>
+    }
+    return %result : tensor<32x32xf32>
+  }
+
+  // Case 9: Matmul inside scf.if without else branch.
+  // The if statement result is not used, so the entire if block is removed.
+  // Only the zero initialization remains.
+  // CHECK-LABEL: func.func @case9_if_no_else
+  // CHECK: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
+  // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[ZERO:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK-NOT: scf.if
+  // CHECK-NOT: linalg.matmul
+  // CHECK-NOT: arith.addf
+  // CHECK: return %[[ZERO]] : tensor<32x32xf32>
+  func.func @case9_if_no_else(%cond: i1, %A: tensor<32x64xf32>, %B: tensor<64x32xf32>, %bias: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %cst = arith.constant 0.0 : f32
+    %empty = tensor.empty() : tensor<32x32xf32>
+    %zero = linalg.fill ins(%cst : f32) outs(%empty : tensor<32x32xf32>) -> tensor<32x32xf32>
+    scf.if %cond {
+      %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias : tensor<32x32xf32>) -> tensor<32x32xf32>
+      scf.yield
+    }
+    return %zero : tensor<32x32xf32>
+  }
+
+  // Case 10: Matmul inside scf.if with both then and else branches.
+  // Both branches have matmul with bias from function argument, so both are split.
+  // CHECK-LABEL: func.func @case10_if_else
+  // CHECK-DAG: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
+  // CHECK: scf.if %{{.*}} -> (tensor<32x32xf32>) {
+  // CHECK: %[[EMPTY1:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[ZERO1:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM1:.*]] = linalg.matmul ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ADD1:.*]] = arith.addf %[[MM1]], %{{.*}} {ssbuffer.add_from_matmul} : tensor<32x32xf32>
+  // CHECK: scf.yield %[[ADD1]] : tensor<32x32xf32>
+  // CHECK: } else {
+  // CHECK: %[[EMPTY2:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[ZERO2:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM2:.*]] = linalg.matmul ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ADD2:.*]] = arith.addf %[[MM2]], %{{.*}} {ssbuffer.add_from_matmul} : tensor<32x32xf32>
+  // CHECK: scf.yield %[[ADD2]] : tensor<32x32xf32>
+  // CHECK: }
+  func.func @case10_if_else(%cond: i1, %A: tensor<32x64xf32>, %B: tensor<64x32xf32>, %bias: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %result = scf.if %cond -> (tensor<32x32xf32>) {
+      %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias : tensor<32x32xf32>) -> tensor<32x32xf32>
+      scf.yield %mm : tensor<32x32xf32>
+    } else {
+      %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias : tensor<32x32xf32>) -> tensor<32x32xf32>
+      scf.yield %mm : tensor<32x32xf32>
+    }
+    return %result : tensor<32x32xf32>
+  }
+
+  // Case 11: Nested scf.for loops with matmul.
+  // The matmul is in an inner loop with bias as a loop-carried variable with zero initial value.
+  // The inner matmul is marked as loop_carried_l0c and not split (no addf).
+  // CHECK-LABEL: func.func @case11_nested_for
+  // CHECK: scf.for {{.*}} {
+  // CHECK: %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[BIAS:.*]] = %{{.*}}) -> (tensor<32x32xf32>)
+  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[BIAS]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK-NOT: arith.addf
+  // CHECK: scf.yield %[[MM]] : tensor<32x32xf32>
+  // CHECK: }
+  // CHECK: }
+  func.func @case11_nested_for(%A: tensor<32x64xf32>, %B: tensor<64x32xf32>) -> tensor<32x32xf32> {
+    %c0 = arith.constant 0 : index
+    %c10 = arith.constant 10 : index
+    %c1 = arith.constant 1 : index
+    %cst = arith.constant 0.0 : f32
+    %empty = tensor.empty() : tensor<32x32xf32>
+    %zero_init = linalg.fill ins(%cst : f32) outs(%empty : tensor<32x32xf32>) -> tensor<32x32xf32>
+    
+    %outer_result = scf.for %outer_iv = %c0 to %c10 step %c1 iter_args(%outer_acc = %zero_init) -> (tensor<32x32xf32>) {
+      %inner_result = scf.for %inner_iv = %c0 to %c10 step %c1 iter_args(%bias = %outer_acc) -> (tensor<32x32xf32>) {
+        %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias : tensor<32x32xf32>) -> tensor<32x32xf32>
+        scf.yield %mm : tensor<32x32xf32>
+      }
+      scf.yield %inner_result : tensor<32x32xf32>
+    }
+    return %outer_result : tensor<32x32xf32>
   }
 }
 


### PR DESCRIPTION
# Problem
When splitting `matmul(A, B, C)`, the compiler may incorrectly split the C tensor even when its values are loop-carried variables meant to stay resident in L0C. This causes unnecessary eviction and reload of C between iterations, adding avoidable memory traffic.

# Changes

1. Identify C-resident loop variables: Added analysis to detect C values in `matmul(A, B, C)` split contexts that are loop-carried and eligible for L0C residency throughout the entire reduction loop.
3. Guard against spurious splits: When such values are identified, the splitting pass is suppressed for those tensors, ensuring they remain resident in L0C across iterations without unnecessary eviction or re-load.
4. No functional change for non-resident C values: The optimization is applied conservatively — only to values confirmed to reside in L0C; other cases follow the existing splitting path unchanged.



# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
