### PR TITLE
[fix](TritonOpConverter):fix device_print precision for reduce/matmul…

### DIFF
--- a/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
@@ -603,6 +603,35 @@ private:
   static constexpr llvm::StringRef prefixAttrName = "prefix";
   static constexpr llvm::StringRef hexAttrName = "hex";
 
+  bool isPromotedFromReduceOrMatmul(mlir::Value v) const {
+    mlir::Operation *defOp = v.getDefiningOp();
+    if (!defOp) return false;
+    return mlir::isa<mlir::linalg::ReduceOp,
+                     mlir::linalg::MatmulOp,
+                     mlir::linalg::BatchMatmulOp,
+                     mlir::triton::ReduceOp,
+                     mlir::triton::DotOp>(defOp);
+  }
+
+  mlir::arith::TruncFOp findDownstreamTruncF(mlir::Value v,
+                                             mlir::Block *blk) const {
+    auto srcTy = mlir::dyn_cast<mlir::RankedTensorType>(v.getType());
+    if (!srcTy) return nullptr;
+    unsigned srcW = srcTy.getElementType().getIntOrFloatBitWidth();
+
+    for (mlir::Operation *user : v.getUsers()) {
+      auto truncOp = mlir::dyn_cast<mlir::arith::TruncFOp>(user);
+      if (!truncOp) continue;
+      if (truncOp->getBlock() != blk) continue;
+      auto dstTy = mlir::dyn_cast<mlir::RankedTensorType>(
+          truncOp.getResult().getType());
+      if (!dstTy) continue;
+      if (dstTy.getElementType().getIntOrFloatBitWidth() >= srcW) continue;
+      return truncOp;
+    }
+    return nullptr;
+  }
+
 public:
   LogicalResult
   matchAndRewrite(triton::PrintOp op, OpAdaptor adaptor,

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -1906,11 +1906,26 @@ LogicalResult TritonPreciseSqrtConverter::matchAndRewrite(
 LogicalResult DevicePrintConverter::matchAndRewrite(
     triton::PrintOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
+  //fix: hoist downstream sub-f32 truncf above the print
+  SmallVector<Value> fixedArgs(op.getArgs().begin(), op.getArgs().end());
+  Operation *insertAfter = nullptr;
+  for (auto &arg : fixedArgs) {
+    if (!this->isPromotedFromReduceOrMatmul(arg)) continue;
+    auto truncOp = this->findDownstreamTruncF(arg, op->getBlock());
+    if (!truncOp) continue;
+    arg = truncOp.getResult();
+    if (!truncOp->isBeforeInBlock(op)) {
+      if (!insertAfter || insertAfter->isBeforeInBlock(truncOp)) {
+        insertAfter = truncOp;
+      }
+    }
+  }
+
   auto moduleOp = op->getParentOfType<ModuleOp>();
   rewriter.setInsertionPoint(moduleOp.getBody(),
                              std::prev(moduleOp.getBody()->end()));
   SmallVector<Type, 4> inputTypes;
-  for (auto arg : op.getArgs()) {
+  for (auto arg : fixedArgs) {
     inputTypes.push_back(arg.getType());
   }
   auto libFnType = rewriter.getFunctionType(inputTypes, {});
@@ -1928,12 +1943,16 @@ LogicalResult DevicePrintConverter::matchAndRewrite(
   auto hexAttr = op.getHexAttr();
   funcOp->setAttr(hexAttrName, hexAttr);
 
-  rewriter.setInsertionPoint(op);
-  rewriter.create<func::CallOp>(op.getLoc(), funcOp, op.getArgs());
+  if (insertAfter) {
+    rewriter.setInsertionPointAfter(insertAfter);
+  } else {
+    rewriter.setInsertionPoint(op);
+  }
+  rewriter.create<func::CallOp>(op.getLoc(), funcOp, fixedArgs);
 
   rewriter.eraseOp(op);
   return success();
-}
+} 
 
 LogicalResult DeviceAssertConverter::matchAndRewrite(
     triton::AssertOp op, OpAdaptor adaptor,

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_device_print_precision.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_device_print_precision.mlir
@@ -1,0 +1,46 @@
+// RUN: triton-opt --pass-pipeline="builtin.module(auto-blockify{auto-blockify-size=1},triton-to-structured{enable-mask-fallback-conversion=false optimize-dynamic-offset=false},discrete-mask-access-conversion{compile-on-910-95=false force-simt-template=true},triton-to-annotation,triton-to-unstructure{compile-on-910-95=false force-simt-template=true},triton-to-hivm,triton-to-hfusion,triton-to-llvm,bubble-up-operation,triton-to-structured{enable-mask-fallback-conversion=false optimize-dynamic-offset=false},triton-to-linalg{compile-on-910-95=false enable-nd2nz-on-vector=false enable-select-analysis=true global-kernel=false named-ops=true})" --split-input-file %s | FileCheck %s
+
+
+module attributes {hacc.target = #hacc.target<"Ascend910_9382">} {
+  tt.func public @kernel_max_2d_precision_fix(
+      %arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<32> : tensor<16x1xi32>
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %2 = tt.expand_dims %0 {axis = 1 : i32} : tensor<16xi32> -> tensor<16x1xi32>
+    %3 = arith.muli %2, %cst : tensor<16x1xi32>
+    %4 = tt.expand_dims %1 {axis = 0 : i32} : tensor<32xi32> -> tensor<1x32xi32>
+    %5 = tt.broadcast %3 : tensor<16x1xi32> -> tensor<16x32xi32>
+    %6 = tt.broadcast %4 : tensor<1x32xi32> -> tensor<16x32xi32>
+    %7 = arith.addi %5, %6 : tensor<16x32xi32>
+    %8 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<16x32x!tt.ptr<f16>>
+    %9 = tt.addptr %8, %7 : tensor<16x32x!tt.ptr<f16>>, tensor<16x32xi32>
+    %10 = tt.load %9 : tensor<16x32x!tt.ptr<f16>>
+    tt.print " x: " {hex = false, isSigned = array<i32: 0>} : %10 : tensor<16x32xf16>
+    %11 = arith.extf %10 : tensor<16x32xf16> to tensor<16x32xf32>
+    %12 = "tt.reduce"(%11) <{axis = 1 : i32}> ({
+    ^bb0(%arg2: f32, %arg3: f32):
+      %16 = arith.maxnumf %arg2, %arg3 : f32
+      tt.reduce.return %16 : f32
+    }) : (tensor<16x32xf32>) -> tensor<16xf32>
+    tt.print " ret: " {hex = false, isSigned = array<i32: 0>} : %12 : tensor<16xf32>
+    %13 = tt.splat %arg1 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+    %14 = tt.addptr %13, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+    %15 = arith.truncf %12 : tensor<16xf32> to tensor<16xf16>
+    tt.store %14, %15 : tensor<16x!tt.ptr<f16>>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: func.func private @triton_print_0(tensor<16x32xf16>)
+// CHECK-LABEL: func.func private @triton_print_1(tensor<16xf16>)
+
+// CHECK:         %[[EXT:.+]] = arith.extf {{.+}} : tensor<16x32xf16> to tensor<16x32xf32>
+// CHECK:         %[[FILL:.+]] = linalg.fill {{.+}} -> tensor<16xf32>
+// CHECK:         %[[REDUCED:.+]] = linalg.reduce ins(%[[EXT]] : tensor<16x32xf32>) outs(%[[FILL]] : tensor<16xf32>) dimensions = [1]
+// CHECK:           arith.maxnumf
+// CHECK:           linalg.yield
+// CHECK:         %[[TRUNC:.+]] = arith.truncf %[[REDUCED]] : tensor<16xf32> to tensor<16xf16>
+// CHECK:         call @triton_print_1(%[[TRUNC]]) : (tensor<16xf16>) -> ()
+// CHECK:         bufferization.materialize_in_destination %[[TRUNC]]


### PR DESCRIPTION
当 kernel 输入是 f16 或 bf16,经过 `tl.reduce` / `tl.max` 或 `tl.dot` 等操作后,中间过程会被自动提升到 f32。如果之后调用 `tl.device_print` 打印结果,输出值的精度变成 f32

典型场景:

### Reduce 场景

```python
x = tl.load(in_ptr0 + idx)
ret = tl.max(x, -1)
tl.device_print("ret", ret)
tl.store(out_ptr0 + odx, ret)
```
对应 IR(简化):

```mlir
%1 = arith.extf %0 : tensor<...xf16> to tensor<...xf32>
%reduced = linalg.reduce ins(%1 ...) ... -> tensor<...xf32>
call @triton_print_1(%reduced) : (tensor<...xf32>) -> ()
%4 = arith.truncf %reduced : tensor<...xf32> to tensor<...xf16>
materialize_in_destination %4 ...
```
这样的情况，既不符合用户预期，也影响了npuir的VF融合过程，故优化之

修复后的 IR:

```mlir
%1 = arith.extf %0 : tensor<...xf16> to tensor<...xf32>
call @triton_print_0(%0) : (tensor<...xf16>) -> ()
%reduced = linalg.reduce ins(%1 ...) ...
%4 = arith.truncf %reduced : tensor<...xf32> to tensor<...xf16>
call @triton_print_1(%4) : (tensor<...xf16>) -> ()
materialize_in_destination %4 in writable %reinterpret_cast_0
```