### PR TITLE
[ci] switch to uv with huawei mirror

### DIFF
--- a/.github/workflows/integration-tests-ascend.yml
+++ b/.github/workflows/integration-tests-ascend.yml
@@ -24,6 +24,12 @@ jobs:
     env:
       PROTON_SKIP_PC_SAMPLING_TEST: 1
       PYTHON: "python${{ matrix.python_version }}"
+      UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      UV_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi"
+      UV_INDEX_STRATEGY: unsafe-best-match
+      UV_INSECURE_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
+      UV_HTTP_TIMEOUT: 120
+      UV_NO_CACHE: 1
       UV_SYSTEM_PYTHON: 1
 
     steps:
@@ -106,7 +112,7 @@ jobs:
           NUM_PROCS=$(( $(nproc) / 3 ))
           if [ "$NUM_PROCS" -lt 1 ]; then NUM_PROCS=1; fi
           MAX_JOBS="$NUM_PROCS" ${PYTHON} setup.py bdist_wheel
-          uv pip install --python "${PYTHON}" -i https://repo.huaweicloud.com/repository/pypi/simple/ dist/*.whl
+          uv pip install --python "${PYTHON}" dist/*.whl
 
       - name: CCache stats
         run: ccache --print-stats

--- a/.github/workflows/integration-tests-ascend.yml
+++ b/.github/workflows/integration-tests-ascend.yml
@@ -24,6 +24,7 @@ jobs:
     env:
       PROTON_SKIP_PC_SAMPLING_TEST: 1
       PYTHON: "python${{ matrix.python_version }}"
+      UV_SYSTEM_PYTHON: 1
 
     steps:
       - name: Checkout
@@ -100,12 +101,12 @@ jobs:
           fi
 
           ${PYTHON} -m pip uninstall triton-ascend triton -y || true
+          ${PYTHON} -m pip install uv
           ccache --zero-stats
           NUM_PROCS=$(( $(nproc) / 3 ))
           if [ "$NUM_PROCS" -lt 1 ]; then NUM_PROCS=1; fi
           MAX_JOBS="$NUM_PROCS" ${PYTHON} setup.py bdist_wheel
-          ${PYTHON} -m pip install dist/*.whl \
-            -i https://repo.huaweicloud.com/repository/pypi/simple/ --force-reinstall
+          uv pip install --python "${PYTHON}" -i https://repo.huaweicloud.com/repository/pypi/simple/ dist/*.whl
 
       - name: CCache stats
         run: ccache --print-stats


### PR DESCRIPTION
Replace pip install with uv pip install for wheel installation.

## Changes
- `pip install` → `uv pip install` with huawei mirror as index
- Based on release/3.2.2-dev

## Note
uv doesn't support `--force-reinstall`. Since the old triton is already uninstalled via `pip uninstall` before the wheel is installed, there's nothing to force over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)