### PR TITLE
[CI](chore) Separate pre-commit check into its own workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,6 @@ jobs:
   runner-preparation:
     uses: ./.github/workflows/runner-preparation.yml
 
-  pre-commit:
-    uses: ./.github/workflows/pre-commit.yml
-
   integration-tests-ascend:
     needs: runner-preparation
     if: needs.runner-preparation.outputs.matrix-ASCEND != ''

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,7 +1,19 @@
 name: Pre-Commit Check
 
 on:
-  workflow_call:
+  workflow_dispatch:
+  pull_request:
+  merge_group:
+    branches: [main, 'dev-**']
+    types: [checks_requested]
+  push:
+    branches: [main, 'release/**']
+
+concurrency:
+  group: pre-commit-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions: read-all
 
 jobs:
   pre-commit:


### PR DESCRIPTION
### Summary

Make pre-commit a standalone workflow

Previously `pre-commit` ran as a job inside `ci.yml`, so it inherited that `workflow's paths-ignore filters (docs, *.md, etc.)`. As a result, formatting checks were skipped on PRs that only touched ignored paths — even though pre-commit runs against --all-files and should always apply.

This PR splits `pre-commit` out into its own workflow with its own `pull_request` trigger (no path filters), so it runs on every PR regardless of which files changed, and removes the job from `ci.yml`.