### PR TITLE
fix(device_print):fix the core dump when device print value is none

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/UseAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/UseAnalysis.cpp
@@ -84,8 +84,10 @@ void triton::UseAnalysis::visitOperation(Operation *op,
           propagateUse(operands[2], UseType::MetaUse);
         }
       })
-      .Case<triton::PrintOp>(
-          [&](auto print) { propagateUse(operands[0], UseType::DataUse); })
+      .Case<triton::PrintOp>([&](auto print){
+        for (auto operand : operands)
+          propagateUse(operand, UseType::DataUse);
+      })
       .Case<triton::AssertOp>(
           [&](auto assert) { propagateUse(operands[0], UseType::DataUse); })
       .Case<triton::StoreOp>([&](auto store) {

--- a/third_party/ascend/unittest/pytest_ut/test_device_print_comprehensive.py
+++ b/third_party/ascend/unittest/pytest_ut/test_device_print_comprehensive.py
@@ -54,6 +54,7 @@ def comprehensive_print_kernel(
     n_elements,
     BLOCK_SIZE: tl.constexpr,
 ):
+    tl.device_print("=====debug=====")
     pid = tl.program_id(0)
     block_start = pid * BLOCK_SIZE
 
@@ -102,7 +103,7 @@ def test_comprehensive_print():
     expected = x * 2.0 + 1.0
     torch.testing.assert_close(y, expected, rtol=1e-5, atol=1e-5)
 
-    for i in range(11):
+    for i in range(12):
         opStr = "call @triton_print_" + str(i)
         assert opStr in h.asm["ttadapter"]
 


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
