### PR TITLE
[device_print](fix) fix the core dump when device print value is none

### DIFF
--- a/docs/zh/triton_api/Debug_Ops/device_print.md
+++ b/docs/zh/triton_api/Debug_Ops/device_print.md
@@ -41,38 +41,9 @@ A3：
 
 Ascend 对比 GPU 缺失uint8、uint16、uint32、uint64、fp64的支持能力（硬件限制）。
 
-**DevicePrint 功能限制**
-
-**现象描述：**
-device_print 只能打印参与运算的结果值，无法打印纯粹用于访存的 offset 变量。
-
-**根本原因：**
-在访存分析优化阶段，编译器会将仅用于地址计算的 offset 优化掉，这些中间变量不会保留到最终的执行代码中。
-
-**示例场景：**
-
-```python
-@triton.jit
-def add_kernel(x_ptr,  # *Pointer* to first input vector.
-               y_ptr,  # *Pointer* to second input vector.
-               output_ptr,  # *Pointer* to output vector.
-               of_ptr,
-               n_elements,  # Size of the vector.
-               BLOCK_SIZE: tl.constexpr,  # Number of elements each program should process.
-               # NOTE: `constexpr` so it can be used as a shape value.
-               ):
-
-    pid = tl.program_id(axis=0)  # We use a 1D launch grid so axis is 0.
-    block_start = pid * BLOCK_SIZE
-    offsets = block_start + tl.arange(0, BLOCK_SIZE)
-    tl.device_print("offsets:", offsets)// ❌ 无法打印，已被优化
-```
-
-另外在特定情况下，`device_print`会展开一些辅助dma代码，导致底层报错，相关功能还在优化中
-
 ### 2.4 使用方法
 
-**注意**：`prefix`字符串前缀在使用`device_print`时是必须加上的，否则会导致编译错误。目前不支持单独打印`prefix`字符串。
+**注意**：`prefix`字符串前缀在使用`device_print`时是必须加上的，否则会导致编译错误。
 
 ```python
 import triton

--- a/third_party/ascend/lib/TritonToLinalg/UseAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/UseAnalysis.cpp
@@ -84,8 +84,10 @@ void triton::UseAnalysis::visitOperation(Operation *op,
           propagateUse(operands[2], UseType::MetaUse);
         }
       })
-      .Case<triton::PrintOp>(
-          [&](auto print) { propagateUse(operands[0], UseType::DataUse); })
+      .Case<triton::PrintOp>([&](auto print) {
+        for (auto operand : operands)
+          propagateUse(operand, UseType::DataUse);
+      })
       .Case<triton::AssertOp>(
           [&](auto assert) { propagateUse(operands[0], UseType::DataUse); })
       .Case<triton::StoreOp>([&](auto store) {

--- a/third_party/ascend/unittest/pytest_ut/test_device_print_comprehensive.py
+++ b/third_party/ascend/unittest/pytest_ut/test_device_print_comprehensive.py
@@ -54,6 +54,7 @@ def comprehensive_print_kernel(
     n_elements,
     BLOCK_SIZE: tl.constexpr,
 ):
+    tl.device_print("=====debug=====")
     pid = tl.program_id(0)
     block_start = pid * BLOCK_SIZE
 
@@ -102,7 +103,7 @@ def test_comprehensive_print():
     expected = x * 2.0 + 1.0
     torch.testing.assert_close(y, expected, rtol=1e-5, atol=1e-5)
 
-    for i in range(11):
+    for i in range(12):
         opStr = "call @triton_print_" + str(i)
         assert opStr in h.asm["ttadapter"]
 


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
