### PR TITLE
[atomic_cas](fix) roll back the modification of atomic_cas

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1382,18 +1382,8 @@ class TritonSemantic(Generic[TensorTy]):
         sem = self._str_to_sem(sem)
         scope = self._str_to_scope(scope)
         element_ty = ptr.type.scalar.element_ty
-        if not is_compile_on_910_95:
-            supported_types = [tl.int8, tl.uint8, tl.int16, tl.int32, tl.int64, tl.float16, tl.bfloat16, tl.float32]
-            if element_ty not in supported_types:
-                raise ValueError(f"atomic_cas does not support {str(element_ty)}. "
-                                 "All support dtypes are int8, uint8, int16, int32, int64, float16, bfloat16, float32.")
-        else:
-            unsupported_types = [tl.int1]
-            if element_ty in unsupported_types:
-                raise ValueError(
-                    f"atomic_cas does not support {str(element_ty)}. "
-                    "All support dtypes are int8, uint8, int16, uint16, int32, uint32, int64, uint64, fp8e4m3, fp8e5m2, float16, bfloat16, float32."
-                )
+        if element_ty.primitive_bitwidth not in [16, 32, 64]:
+            raise ValueError("atomic_cas only supports elements with width {16, 32, 64}")
         return self.tensor(self.builder.create_atomic_cas(ptr.handle, cmp.handle, val.handle, sem, scope), val.type)
 
     def atom_red_typechecking_impl(self, ptr: TensorTy, val: TensorTy, mask: TensorTy,


### PR DESCRIPTION
triton上游代码侵入式修改回退

相关侵入式修改 https://gitcode.com/Ascend/triton-ascend/pull/1166
<img width="1097" height="40" alt="image" src="https://github.com/user-attachments/assets/77f6e7d0-5914-4bec-9b0e-6be0e9debc89" />

涉及文件：
.\python\triton\language\semantic.py

该修改涉及atomic_cas的dtype检查，可以直接回退，回退后与社区限制一致，支持位宽为16、32、64位的数据类型

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
