### PR TITLE
[ssbuffer](fix) process yield op in scf.if

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/Utils.h
@@ -54,7 +54,7 @@ LogicalResult topologicalSort(SmallVector<Operation *> &ops);
 SmallVector<int> getBlockIdsInOrder(scf::ForOp forOp);
 
 // Get the block_id of the immediate child of scf.for that contains op
-std::optional<int64_t> getForDirectChildBlockId(Operation *op);
+std::optional<int> getForDirectChildBlockId(Operation *op);
 
 // Find the tcb group id that contains value v
 int findTcbGroupId(Value v, llvm::DenseMap<int, SmallVector<Value>> &tightlyCoupledBufferGroups);

--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -74,7 +74,7 @@ inline constexpr CoreType fromStrCoreType(std::string_view s)
 
 // Functions for managing core types
 CoreType getOpCoreType(Operation *op);
-std::optional<int64_t> getOpBlockId(Operation *op);
+std::optional<int> getOpBlockId(Operation *op);
 llvm::LogicalResult verifyOpBlockId(Operation *op);
 int getAvailableBlockId(ModuleOp module);
 void setFallbackAttr(ModuleOp module);

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/Utils.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ADAPTER_SPLIT_DATAFLOW_UTILS_H
+#define TRITON_ADAPTER_SPLIT_DATAFLOW_UTILS_H
+
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace mlir {
+namespace triton {
+
+void setOpBlockId(mlir::Operation *op, int blockId);
+void setOpCoreType(mlir::Operation *op, llvm::StringRef coreType);
+
+}
+}
+
+#endif // TRITON_ADAPTER_SPLIT_DATAFLOW_UTILS_H

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/Utils.cpp
@@ -166,7 +166,7 @@ SmallVector<int> triton::getBlockIdsInOrder(scf::ForOp forOp)
 // Get the block_id of the immediate child of scf.for that contains op
 // For nested ops inside scf.if/scf.for, returns the block_id of the immediate child of scf.for
 // Only considers scf.for ops that have ssbuffer.main_loop attribute
-std::optional<int64_t> triton::getForDirectChildBlockId(Operation *op) {
+std::optional<int> triton::getForDirectChildBlockId(Operation *op) {
   if (!op) {
     return std::nullopt;
   }

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -55,7 +55,7 @@ llvm::LogicalResult verifyOpBlockId(Operation *op)
     return llvm::success();
 }
 
-std::optional<int64_t> getOpBlockId(Operation *op)
+std::optional<int> getOpBlockId(Operation *op)
 {
     auto blockIdAttr = op->getAttrOfType<IntegerAttr>(kBlockId);
     if (!blockIdAttr) {
@@ -71,7 +71,7 @@ int getAvailableBlockId(ModuleOp module)
     module.walk([&](Operation *op) {
         auto blockIdOpt = getOpBlockId(op);
         if (blockIdOpt) {
-            int currentId = static_cast<int>(*blockIdOpt);
+            int currentId = *blockIdOpt;
             if (currentId > maxBlockId) {
                 maxBlockId = currentId;
             }

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
@@ -124,7 +124,7 @@ bool willCreateCycle(llvm::ArrayRef<Operation *> opsToUnify, const MemoryDepende
     DenseMap<Operation *, int> origBlockIdMap;
     for (auto *op : opsToUnify) {
         auto optBlockId = getOpBlockId(op);
-        origBlockIdMap[op] = optBlockId ? static_cast<int>(*optBlockId) : -1;
+        origBlockIdMap[op] = optBlockId ? *optBlockId : -1;
         bm.updateBlockId(op, targetBlockId);
     }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
@@ -103,7 +103,7 @@ static LogicalResult getCommonBlockId(ArrayRef<Operation *> ops, int &blockId) {
       for (auto *user : op->getUsers()) {
         if (auto copyOp = dyn_cast<memref::CopyOp>(user)) {
           if (auto blockId = CVPipeline::getOpBlockId(copyOp)) {
-            copyBlockIds.insert(static_cast<int>(*blockId));
+            copyBlockIds.insert(*blockId);
           }
         }
       }

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/AddBlockIdForControlOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/AddBlockIdForControlOps.cpp
@@ -35,6 +35,7 @@ using namespace mlir::triton;
 // Pass Entry Point
 void AddBlockIdForControlOpsPass::runOnOperation()
 {
+  static constexpr int kIntegerBitWidth = 32;
   LOG_DEBUG("\n--- enter AddBlockIdForControlOpsPass --->\n");
   ModuleOp module = getOperation();
 
@@ -45,17 +46,35 @@ void AddBlockIdForControlOpsPass::runOnOperation()
 
   // Step 2: add block_id for control flow ops
   module.walk([&](Operation *op) {
+    
     // skip op with block_id
     if (op->getAttrOfType<IntegerAttr>("ssbuffer.block_id")) {
       return;
     }
 
     if (isa<scf::ForOp, scf::IfOp, scf::WhileOp>(op)) {
+      
       maxBlockId++;
-      static constexpr int kIntegerBitWidth = 32;
       op->setAttr("ssbuffer.block_id",
                   IntegerAttr::get(IntegerType::get(module.getContext(), kIntegerBitWidth), maxBlockId));
       LOG_DEBUG("Added block_id " << maxBlockId << " to " << *op << "\n");
+    }
+
+    // coretype of scf.yield may not be the same with defining op
+    if (isa<scf::YieldOp>(op) && isa<scf::IfOp>(op->getParentOp())) {
+      Operation *parentOp = op->getParentOp();
+      auto ifBlockIdOpt = CVPipeline::getOpBlockId(parentOp);
+
+      int yieldBlockId;
+      if (ifBlockIdOpt) {
+        yieldBlockId = static_cast<int>(*ifBlockIdOpt);
+      } else {
+        maxBlockId++;
+        yieldBlockId = maxBlockId;
+      }
+      op->setAttr("ssbuffer.block_id",
+                  IntegerAttr::get(IntegerType::get(module.getContext(), kIntegerBitWidth), yieldBlockId));
+      LOG_DEBUG("Added block_id " << yieldBlockId << " to " << *op << "\n");
     }
   });
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/AddBlockIdForControlOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/AddBlockIdForControlOps.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/AddBlockIdForControlOps.h"
+#include "ascend/include/DynamicCVPipeline/SplitDataflow/Utils.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "llvm/Support/Debug.h"
 
@@ -35,7 +36,6 @@ using namespace mlir::triton;
 // Pass Entry Point
 void AddBlockIdForControlOpsPass::runOnOperation()
 {
-  static constexpr int kIntegerBitWidth = 32;
   LOG_DEBUG("\n--- enter AddBlockIdForControlOpsPass --->\n");
   ModuleOp module = getOperation();
 
@@ -46,17 +46,14 @@ void AddBlockIdForControlOpsPass::runOnOperation()
 
   // Step 2: add block_id for control flow ops
   module.walk([&](Operation *op) {
-    
     // skip op with block_id
-    if (op->getAttrOfType<IntegerAttr>("ssbuffer.block_id")) {
+    if (op->getAttrOfType<IntegerAttr>(CVPipeline::kBlockId)) {
       return;
     }
 
-    if (isa<scf::ForOp, scf::IfOp, scf::WhileOp>(op)) {
-      
+    if (isa<scf::ForOp, scf::IfOp>(op)) {
       maxBlockId++;
-      op->setAttr("ssbuffer.block_id",
-                  IntegerAttr::get(IntegerType::get(module.getContext(), kIntegerBitWidth), maxBlockId));
+      setOpBlockId(op, maxBlockId);
       LOG_DEBUG("Added block_id " << maxBlockId << " to " << *op << "\n");
     }
 
@@ -67,13 +64,12 @@ void AddBlockIdForControlOpsPass::runOnOperation()
 
       int yieldBlockId;
       if (ifBlockIdOpt) {
-        yieldBlockId = static_cast<int>(*ifBlockIdOpt);
+        yieldBlockId = *ifBlockIdOpt;
       } else {
         maxBlockId++;
         yieldBlockId = maxBlockId;
       }
-      op->setAttr("ssbuffer.block_id",
-                  IntegerAttr::get(IntegerType::get(module.getContext(), kIntegerBitWidth), yieldBlockId));
+      setOpBlockId(op, yieldBlockId);
       LOG_DEBUG("Added block_id " << yieldBlockId << " to " << *op << "\n");
     }
   });

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h"
+#include "ascend/include/DynamicCVPipeline/SplitDataflow/Utils.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/Common/MemoryEffectsTracker.h"
 
@@ -52,9 +53,6 @@ using namespace mlir::triton;
 using namespace mlir::CVPipeline;
 
 // Attribute name constants
-static constexpr const char *kBlockIdAttr = "ssbuffer.block_id";
-static constexpr const char *kCoreTypeAttr = "ssbuffer.core_type";
-static constexpr const char *kTransferIdAttr = "ssbuffer.transfer_id";
 static constexpr const char *ssbufferCoreTypeCubeAttr = "CUBE";
 static constexpr const char *ssbufferCoreTypeVectorAttr = "VECTOR";
 static constexpr int ND_SHAPE_LENGTH = 2;
@@ -62,7 +60,7 @@ static constexpr int ND_SHAPE_LENGTH = 2;
 // Helper: ssbuffer.core_type
 llvm::StringRef getSsbufferCoreType(Operation *op)
 {
-    if (auto attr = op->getAttrOfType<mlir::StringAttr>(kCoreTypeAttr)) {
+    if (auto attr = op->getAttrOfType<mlir::StringAttr>(CVPipeline::kCoreType)) {
         return attr.getValue();
     }
     return "";
@@ -90,7 +88,7 @@ bool DataDependencyAnalysisPass::isControlFlowOp(mlir::Operation *op)
 {
     if (!op)
         return false;
-    return isa<scf::ForOp>(op) || isa<scf::IfOp>(op) || isa<scf::WhileOp>(op) || isa<scf::YieldOp>(op);
+    return isa<scf::ForOp>(op) || isa<scf::IfOp>(op) || isa<scf::YieldOp>(op);
 }
 
 bool DataDependencyAnalysisPass::isCubeOrVectorOp(mlir::Operation *op)
@@ -222,7 +220,7 @@ void DataDependencyAnalysisPass::createBlockInfoMap(DataDependencyInfo &info)
     module.walk([&](mlir::Operation *op) {
         auto opBlockIdOpt = CVPipeline::getOpBlockId(op);
         if (opBlockIdOpt) {
-            int opBlockId = static_cast<int>(*opBlockIdOpt);
+            int opBlockId = *opBlockIdOpt;
             // When the id changes, the block ends && Exclude the initial state
             if (opBlockId != currentId && currentId != startCurrId) {
                 collectBlockInfo(info, currentId, currentOps);
@@ -302,8 +300,8 @@ void DataDependencyAnalysisPass::insertProducerAndRecordDeps(scf::ForOp forOp,
     builder.setInsertionPointToStart(&bodyBlock);
     Location loc = forOp.getLoc();
     auto constOp = builder.create<arith::ConstantIntOp>(loc, 0, 32);
-    constOp->setAttr(kBlockIdAttr, IntegerAttr::get(IntegerType::get(builder.getContext(), 32), newId));
-    constOp->setAttr(kCoreTypeAttr, StringAttr::get(builder.getContext(), initCoreType));
+    setOpBlockId(constOp, newId);
+    setOpCoreType(constOp, initCoreType);
 
     BlockInfo blockInfo;
     blockInfo.blockId = newId;
@@ -318,7 +316,7 @@ void DataDependencyAnalysisPass::insertProducerAndRecordDeps(scf::ForOp forOp,
             LOG_DEBUG("Warning: User block ID not found for iterArg user.\n");
             continue;
         }
-        int userBlockId = static_cast<int>(*userBlockIdOpt);
+        int userBlockId = *userBlockIdOpt;
 
         // Determine dependency type based on initCoreType
         DependencyType depType;
@@ -464,7 +462,7 @@ void DataDependencyAnalysisPass::analyzeExternalInputs(DataDependencyInfo &info)
                     LOG_DEBUG("Warning: [v->c] Producer block ID not found for input value.\n");
                     continue;
                 }
-                int producerId = static_cast<int>(*producerIdOpt);
+                int producerId = *producerIdOpt;
                 collectDepInfo(input, DependencyType::VectorToCube, v2cDependencies, producerId, blockInfo.blockId,
                     info);
             }
@@ -526,7 +524,7 @@ void DataDependencyAnalysisPass::analyzeExternalOutputs(DataDependencyInfo &info
                         LOG_DEBUG("Warning: [c->v] Consumer block ID not found for user operation.\n");
                         continue;
                     }
-                    int consumerId = static_cast<int>(*consumerIdOpt);
+                    int consumerId = *consumerIdOpt;
                     auto inserted = handledBlockIds.insert(consumerId).second;
                     if (inserted) {
                       collectDepInfo(output, DependencyType::CubeToVector, c2vDependencies, blockInfo.blockId, consumerId,
@@ -581,7 +579,7 @@ void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info)
         if (!currBlockIdOpt || currCoreType.empty()) {
             return;
         }
-        int currBlockId = static_cast<int>(*currBlockIdOpt);
+        int currBlockId = *currBlockIdOpt;
 
         for (mlir::Operation *predOp : memDepGraph.getExecBefore(op)) {
             if (isa<annotation::MarkOp, gpu::BarrierOp>(predOp)) {
@@ -621,7 +619,7 @@ void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info)
             if (!predBlockIdOpt || predCoreType == currCoreType || predCoreType.empty()) {
                 continue;
             }
-            int predBlockId = static_cast<int>(*predBlockIdOpt);
+            int predBlockId = *predBlockIdOpt;
 
             auto [producerBlockId, consumerBlockId] = findCommonLevelBlockIds(info, predBlockId, currBlockId);
             if (producerBlockId == -1 || consumerBlockId == -1) {
@@ -752,8 +750,8 @@ std::pair<int, int> DataDependencyAnalysisPass::findCommonLevelBlockIds(DataDepe
             mlir::Operation *pPrevOp = pAncestors[pIndex - 1];
             auto pPrevIdOpt = CVPipeline::getOpBlockId(pPrevOp);
             auto cPrevIdOpt = CVPipeline::getOpBlockId(before);
-            int pPrevId = pPrevIdOpt ? static_cast<int>(*pPrevIdOpt) : -1;
-            int cPrevId = cPrevIdOpt ? static_cast<int>(*cPrevIdOpt) : -1;
+            int pPrevId = pPrevIdOpt ? *pPrevIdOpt : -1;
+            int cPrevId = cPrevIdOpt ? *cPrevIdOpt : -1;
             if (!pPrevIdOpt) {
                 LOG_DEBUG("Warning: Producer ancestor operation has no block ID attribute.\n");
             }

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h"
+#include "ascend/include/DynamicCVPipeline/SplitDataflow/Utils.h"
 
 #include <memory>
 #include <optional>
@@ -60,11 +61,6 @@ static constexpr const char *DEBUG_TYPE = "inter-core-transfer-and-sync";
 using namespace mlir::triton;
 using namespace hivm;
 
-// Attribute name constants
-static constexpr const char *kBlockIdAttr = "ssbuffer.block_id";
-static constexpr const char *kCoreTypeAttr = "ssbuffer.core_type";
-static constexpr const char *kTransferIdAttr = "ssbuffer.transfer_id";
-
 static constexpr int kIntegerBitWidth = 32;
 static constexpr int NzDimWidth = 16;
 
@@ -91,10 +87,10 @@ static uint64_t getBlockElemsFor32BAlign(Type elemType)
     constexpr uint64_t kAlignBytes = 32;
     uint64_t elemBytes = getElemBytesForAlign(elemType);
     if (elemBytes == 0) {
-        return -1;
+        return 0;
     }
     if (elemBytes < 0 || kAlignBytes % elemBytes != 0) {
-        return -1;
+        return 0;
     }
     if (elemBytes >= kAlignBytes) {
         return 1;
@@ -105,16 +101,16 @@ static uint64_t getBlockElemsFor32BAlign(Type elemType)
 static void attachCommonTags(Operation *op, int blockId, StringRef coreType)
 {
     MLIRContext *ctx = op->getContext();
-    op->setAttr(kBlockIdAttr, IntegerAttr::get(IntegerType::get(ctx, kIntegerBitWidth), blockId));
-    op->setAttr(kCoreTypeAttr, StringAttr::get(ctx, coreType));
+    setOpBlockId(op, blockId);
+    setOpCoreType(op, coreType);
 }
 
 static void attachTransferTags(Operation *op, int blockId, StringRef coreType, int transferId)
 {
     MLIRContext *ctx = op->getContext();
-    op->setAttr(kBlockIdAttr, IntegerAttr::get(IntegerType::get(ctx, kIntegerBitWidth), blockId));
-    op->setAttr(kCoreTypeAttr, StringAttr::get(ctx, coreType));
-    op->setAttr(kTransferIdAttr, IntegerAttr::get(IntegerType::get(ctx, kIntegerBitWidth), transferId));
+    setOpBlockId(op, blockId);
+    setOpCoreType(op, coreType);
+    op->setAttr(CVPipeline::kTransferId, IntegerAttr::get(IntegerType::get(ctx, kIntegerBitWidth), transferId));
 }
 
 static void attachAnalyzeFlagIdTag(Operation *op)
@@ -128,7 +124,7 @@ std::pair<mlir::Operation *, mlir::Operation *> InterCoreTransferAndSyncPass::ge
     mlir::ModuleOp module)
 {
     mlir::Operation *knownOpInBlock = nullptr;
-    module.walk([&](mlir::Operation *op) {
+    module.walk<WalkOrder::PreOrder>([&](mlir::Operation *op) {
         if (knownOpInBlock) {
             return;
         }
@@ -154,7 +150,7 @@ std::pair<mlir::Operation *, mlir::Operation *> InterCoreTransferAndSyncPass::ge
         if (!blockIdOpt) {
             continue;
         }
-        int blockId = static_cast<int>(*blockIdOpt);
+        int blockId = *blockIdOpt;
         if (!start) {
             if (targetId == blockId) {
                 start = &op;
@@ -269,6 +265,9 @@ std::pair<bool, bool> InterCoreTransferAndSyncPass::isExpectedShape(Value value,
     SmallVector<int64_t> &expectedShape, bool isMatmulA, bool isMatmulB, bool isOnlyDepInMatmul)
 {
     auto tensorTy = dyn_cast<TensorType>(value.getType());
+    if (!tensorTy) {
+        return { true, false };
+    }
     ArrayRef<int64_t> currShape = tensorTy.getShape();
     bool isEqualedShape = currShape.equals(expectedShape);
     bool matmulPadding = false;
@@ -348,10 +347,10 @@ void InterCoreTransferAndSyncPass::extractMatmulResult(
     Value rhs = matmulOp->getOperands()[1];
     Value acc = matmulOp->getOperands()[2];
     Value originalResult = matmulOp->getResult(0);
-    auto lhsType = dyn_cast<RankedTensorType>(lhs.getType());
-    auto rhsType = dyn_cast<RankedTensorType>(rhs.getType());
-    auto accType = dyn_cast<RankedTensorType>(acc.getType());
-    auto resType = dyn_cast<RankedTensorType>(originalResult.getType());
+    auto lhsType = cast<RankedTensorType>(lhs.getType());
+    auto rhsType = cast<RankedTensorType>(rhs.getType());
+    auto accType = cast<RankedTensorType>(acc.getType());
+    auto resType = cast<RankedTensorType>(originalResult.getType());
     if (lhsType.getShape()[0] == accType.getShape()[0]
         && rhsType.getShape()[1] == accType.getShape()[1]) {
         return;
@@ -377,6 +376,7 @@ void InterCoreTransferAndSyncPass::extractMatmulResult(
     mlir::Operation *paddingAccOp = linalgFillOp;
     if (!matmulCIsEmpty(acc)) {
         LOG_DEBUG("nd2nz shape is unaligned and matmul C is not empty");
+        CVPipeline::setFallbackAttr(module);
         signalPassFailure();
     }
 
@@ -418,7 +418,7 @@ void InterCoreTransferAndSyncPass::extractMatmulResult(
 
 void InterCoreTransferAndSyncPass::rewriteMatmulWithNewShape(OpBuilder &builder, Operation *matmulOp, Location loc, bool isMatmulA, bool isMatmulB, bool matmulPadding, bool isOnlyDepInMatmul)
 {
-    int matmulOpBlockId = static_cast<int>(CVPipeline::getOpBlockId(matmulOp).value_or(-1));
+    int matmulOpBlockId = CVPipeline::getOpBlockId(matmulOp).value_or(-1);
 
     if (matmulPadding) {
         int matmulIndex = isMatmulA ? 1 : 0;
@@ -440,7 +440,7 @@ void InterCoreTransferAndSyncPass::rewriteTransposeWithNewShape(OpBuilder &build
     auto expectedType = RankedTensorType::get(newOutputShape, elemType);
     // Create new empty tensor with new shape
     auto tensorEmptyOp = builder.create<tensor::EmptyOp>(loc, newOutputShape, elemType);
-    attachCommonTags(tensorEmptyOp, static_cast<int>(CVPipeline::getOpBlockId(transposeOp).value_or(-1)), "CUBE");
+    attachCommonTags(tensorEmptyOp, CVPipeline::getOpBlockId(transposeOp).value_or(-1), "CUBE");
     Value transposeOpResult = transposeOp->getResult(0);
     transposeOp->setOperand(1, tensorEmptyOp.getResult());
     transposeOp->getResult(0).setType(expectedType);
@@ -451,6 +451,9 @@ mlir::Value InterCoreTransferAndSyncPass::normalizeIfNeeded(OpBuilder &builder, 
     mlir::Value origValue, SmallVector<int64_t> expectedShape, int originBlockId, bool matmulPadding, bool isOnlyDepInMatmul)
 {
     auto origTensorType = dyn_cast<RankedTensorType>(origValue.getType());
+    if (!origTensorType) {
+        return origValue;
+    }
 
     int64_t iniM = origTensorType.getDimSize(0);
     int64_t iniN = origTensorType.getDimSize(1);
@@ -484,7 +487,7 @@ mlir::Value InterCoreTransferAndSyncPass::normalizeIfNeeded(OpBuilder &builder, 
         LOG_DEBUG(*user << "\n");
         auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
         LOG_DEBUG("int userBlockId = getOpBlockId(user);" << (userBlockIdOpt ? *userBlockIdOpt : -1) << "\n");
-        if (!userBlockIdOpt || static_cast<int>(*userBlockIdOpt) != cId) {
+        if (!userBlockIdOpt || *userBlockIdOpt != cId) {
             continue;
         }
         user->replaceUsesOfWith(origValue, tensorInsertSliceOp.getResult());
@@ -636,7 +639,7 @@ std::pair<Operation *, Operation *> InterCoreTransferAndSyncPass::createTransfer
         consAllocOp = builder.create<memref::AllocOp>(loc, allocType);
         auto markConsOp = annotateTightlyCoupledBuffer(builder, consAllocOp, loc);
 
-        int loopBlockId = static_cast<int>(CVPipeline::getOpBlockId(mainLoopOp).value_or(-1));
+        int loopBlockId = CVPipeline::getOpBlockId(mainLoopOp).value_or(-1);
         attachTransferTags(prodAllocOp, loopBlockId, prodTag, transferIndex);
         attachTransferTags(consAllocOp, loopBlockId, consTag, transferIndex);
         attachTransferTags(markProdOp, loopBlockId, prodTag, transferIndex);
@@ -668,14 +671,14 @@ mlir::Operation *InterCoreTransferAndSyncPass::analyzeConsumerReadInsertPoint(
     llvm::DenseSet<mlir::Operation *> consumerOps;
     for (Operation *user : srcValue.getUsers()) {
         auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
-        if (userBlockIdOpt && static_cast<int>(*userBlockIdOpt) == iniConsumerId) {
+        if (userBlockIdOpt && *userBlockIdOpt == iniConsumerId) {
             consumerOps.insert(user);
         }
     }
 
     mlir::Operation* firstFoundOp = nullptr;
 
-    module->walk([&](mlir::Operation* op) {
+    module->walk<WalkOrder::PreOrder>([&](mlir::Operation* op) {
         if (consumerOps.contains(op)) {
             firstFoundOp = op;
             return mlir::WalkResult::interrupt(); 
@@ -689,7 +692,7 @@ mlir::Operation *InterCoreTransferAndSyncPass::analyzeConsumerReadInsertPoint(
 mlir::Operation *InterCoreTransferAndSyncPass::getConsumerWaitPoint(int transferIndex)
 {
     mlir::Operation *consumerWaitPoint = nullptr;
-    module.walk([&](mlir::Operation *op) {
+    module.walk<WalkOrder::PreOrder>([&](mlir::Operation *op) {
         if (consumerWaitPoint) {
             return;
         }
@@ -697,7 +700,7 @@ mlir::Operation *InterCoreTransferAndSyncPass::getConsumerWaitPoint(int transfer
             && !isa<LLVM::LoadOp>(op)) {
             return;
         }
-        auto transferIdAttr = op->getAttrOfType<IntegerAttr>(kTransferIdAttr);
+        auto transferIdAttr = op->getAttrOfType<IntegerAttr>(CVPipeline::kTransferId);
         if (transferIdAttr && transferIdAttr.getInt() == transferIndex) {
             consumerWaitPoint = op;
         }
@@ -713,9 +716,8 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(OpBuilder &b
     mlir::Operation *receiveOp = nullptr;
     Value receiveValue;
 
-    int vecBlockId = static_cast<int>(CVPipeline::getOpBlockId(vectorEndOp).value_or(-1));
-    int cubeBlockId = static_cast<int>(CVPipeline::getOpBlockId(cubeStartOp).value_or(-1));
-    LOG_DEBUG("Inserting [Vector->Cube] transfer for value: " << srcValue << "\n");
+    int vecBlockId = CVPipeline::getOpBlockId(vectorEndOp).value_or(-1);
+    int cubeBlockId = CVPipeline::getOpBlockId(cubeStartOp).value_or(-1);
 
     if (isScaler) {
         builder.setInsertionPointAfter(vectorEndOp);
@@ -798,7 +800,7 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(OpBuilder &b
     for (Operation *user : users) {
         LOG_DEBUG("[v->c user]" << *user << "\n");
         auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
-        if (userBlockIdOpt && static_cast<int>(*userBlockIdOpt) == iniConsumerId) {
+        if (userBlockIdOpt && *userBlockIdOpt == iniConsumerId) {
             user->replaceUsesOfWith(srcValue, receiveValue);
         }
     }
@@ -818,8 +820,8 @@ Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(OpBuilder &b
     int64_t N = srcTensorType.getDimSize(1);
     Type elemType = srcTensorType.getElementType();
 
-    int cubeBlockId = static_cast<int>(CVPipeline::getOpBlockId(srcValue.getDefiningOp()).value_or(-1));
-    int vecBlockId = static_cast<int>(CVPipeline::getOpBlockId(vectorStartOp).value_or(-1));
+    int cubeBlockId = CVPipeline::getOpBlockId(srcValue.getDefiningOp()).value_or(-1);
+    int vecBlockId = CVPipeline::getOpBlockId(vectorStartOp).value_or(-1);
 
     auto [cubeAllocOp, vecAllocOp] = createTransferAllocs(builder, loc, { M, N }, elemType, hivm::AddressSpace::UB,
         cubeEndOp, vectorStartOp, cubeBlockId, vecBlockId, "CUBE", "VECTOR", transferIndex);
@@ -850,7 +852,7 @@ Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(OpBuilder &b
     for (Operation *user : users) {
         LOG_DEBUG("[c->v user]" << *user << "\n");
         auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
-        if (userBlockIdOpt && static_cast<int>(*userBlockIdOpt) == iniConsumerId) {
+        if (userBlockIdOpt && *userBlockIdOpt == iniConsumerId) {
             user->replaceUsesOfWith(srcValue, toTensorOp.getResult());
         }
     }
@@ -914,8 +916,8 @@ void InterCoreTransferAndSyncPass::insertInterCoreSync(
 
     auto flagId = builder.getIntegerAttr(builder.getI64Type(), flag);
 
-    int producerBlockId = static_cast<int>(CVPipeline::getOpBlockId(transferOp).value_or(-1));
-    int consumerBlockId = static_cast<int>(CVPipeline::getOpBlockId(consumerStartOp).value_or(-1));
+    int producerBlockId = CVPipeline::getOpBlockId(transferOp).value_or(-1);
+    int consumerBlockId = CVPipeline::getOpBlockId(consumerStartOp).value_or(-1);
 
     Operation *mainLoopOp = findMainLoopforTransfer(transferOp, consumerStartOp);
 
@@ -1000,11 +1002,11 @@ void InterCoreTransferAndSyncPass::insertMemDepSync(OpBuilder &builder, Operatio
     auto consBlockIdOpt = CVPipeline::getOpBlockId(consumerOp);
     if (prodBlockIdOpt) {
         StringRef prodCoreType = isCubeToVector ? "CUBE" : "VECTOR";
-        attachCommonTags(setOp, static_cast<int>(*prodBlockIdOpt), prodCoreType);
+        attachCommonTags(setOp, *prodBlockIdOpt, prodCoreType);
     }
     if (consBlockIdOpt) {
         StringRef consCoreType = isCubeToVector ? "VECTOR" : "CUBE";
-        attachCommonTags(waitOp, static_cast<int>(*consBlockIdOpt), consCoreType);
+        attachCommonTags(waitOp, *consBlockIdOpt, consCoreType);
     }
     attachAnalyzeFlagIdTag(setOp);
     attachAnalyzeFlagIdTag(waitOp);
@@ -1028,7 +1030,7 @@ static std::optional<hivm::TCoreType> getAnalyzeCoreType(Operation *op)
         }
     }
 
-    auto coreStringAttr = op->getAttrOfType<StringAttr>(kCoreTypeAttr);
+    auto coreStringAttr = op->getAttrOfType<StringAttr>(CVPipeline::kCoreType);
     if (!coreStringAttr) {
         return std::nullopt;
     }
@@ -1301,7 +1303,7 @@ llvm::SmallVector<mlir::Operation *> InterCoreTransferAndSyncPass::insertAnalyze
                     definingOp = blockArgument.getOwner()->getParentOp();
                 }
             }
-            if (relationOpSet.contains(definingOp)) {
+            if (definingOp && relationOpSet.contains(definingOp)) {
                 insertRelation(definingOp, op);
             }
         }
@@ -1355,7 +1357,7 @@ void InterCoreTransferAndSyncPass::sortDependencies(llvm::SmallVector<Dependency
     //         to each operation, representing its position in the IR.
     llvm::DenseMap<mlir::Operation *, unsigned> opOrder;
     unsigned order = 0;
-    module.walk([&](mlir::Operation *op) {
+    module.walk<WalkOrder::PreOrder>([&](mlir::Operation *op) {
         opOrder[op] = order++;
     });
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/MarkMainLoop.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/MarkMainLoop.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/MarkMainLoop.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "mlir/IR/Operation.h"
 #include "llvm/Support/Debug.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
@@ -51,9 +52,9 @@ void MarkMainLoopPass::runOnOperation()
     });
 
     for (scf::ForOp forOp : mainLoops) {
-        if (!forOp->hasAttr("ssbuffer.main_loop")) {
+        if (!forOp->hasAttr(CVPipeline::kMainLoop)) {
             // Add attribute with integer value (current counter ID)
-            forOp->setAttr("ssbuffer.main_loop", Builder(module.getContext()).getI32IntegerAttr(mainLoopIdCounter));
+            forOp->setAttr(CVPipeline::kMainLoop, Builder(module.getContext()).getI32IntegerAttr(mainLoopIdCounter));
             mainLoopIdCounter++;
         }
     }
@@ -62,7 +63,7 @@ void MarkMainLoopPass::runOnOperation()
     // Keep only the innermost main_loop
     SmallVector<scf::ForOp> allMainLoops;
     module.walk([&](scf::ForOp forOp) {
-        if (forOp->hasAttr("ssbuffer.main_loop")) {
+        if (forOp->hasAttr(CVPipeline::kMainLoop)) {
             allMainLoops.push_back(forOp);
         }
     });
@@ -71,13 +72,13 @@ void MarkMainLoopPass::runOnOperation()
         // Check if there's any nested for loop with main_loop attribute
         bool hasNestedMainLoop = false;
         forOp.walk([&](scf::ForOp nestedForOp) {
-            if (nestedForOp != forOp && nestedForOp->hasAttr("ssbuffer.main_loop")) {
+            if (nestedForOp != forOp && nestedForOp->hasAttr(CVPipeline::kMainLoop)) {
                 hasNestedMainLoop = true;
             }
         });
         // Remove attribute from outer loop if inner loop also has it
         if (hasNestedMainLoop) {
-            forOp->removeAttr("ssbuffer.main_loop");
+            forOp->removeAttr(CVPipeline::kMainLoop);
         }
     }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/Utils.cpp
@@ -1,0 +1,43 @@
+
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/DynamicCVPipeline/SplitDataflow/Utils.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/StringRef.h"
+
+using namespace mlir;
+using namespace llvm;
+
+void triton::setOpBlockId(mlir::Operation *op, int blockId)
+{
+    static constexpr int kIntegerBitWidth = 32;
+    op->setAttr(CVPipeline::kBlockId,
+                IntegerAttr::get(IntegerType::get(op->getContext(), kIntegerBitWidth), blockId));
+}
+
+void triton::setOpCoreType(mlir::Operation *op, llvm::StringRef coreType)
+{
+    op->setAttr(CVPipeline::kCoreType, StringAttr::get(op->getContext(), coreType));
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_yield_if_dependencies.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_yield_if_dependencies.mlir
@@ -1,0 +1,54 @@
+// RUN: triton-opt --add-block-id-for-control-ops --data-dependency-analysis --inter-core-transfer-and-sync --mark-main-loop %s | FileCheck %s
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_yield_if_dependencies(%arg0: i32) {
+    %cst = arith.constant {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
+    %c128_i32 = arith.constant {MixUse, ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} 128 : i32
+    %c64_i32 = arith.constant {Undefined, ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} 64 : i32
+    %0 = arith.muli %arg0, %c128_i32 {MixUse, ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : i32
+    %1 = arith.addi %arg0, %c64_i32 {Undefined, ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : i32
+    %2 = arith.cmpi sge, %1, %0 {Undefined, ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : i32
+    %3 = tensor.empty() {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
+    %4 = linalg.fill {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : f32) outs(%3 : tensor<128x128xf32>) -> tensor<128x128xf32>
+    %5 = math.exp2 %4 {DataUse, ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
+
+    %6 = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+    %7 = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : f32) outs(%3 : tensor<128x128xf32>) -> tensor<128x128xf32>
+    %alloc = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf32>
+    %8 = bufferization.to_tensor %alloc {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf32>
+    %9 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%8, %8 : tensor<128x128xf32>, tensor<128x128xf32>) outs(%7 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+    %10:2 = scf.if %2 -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+      %12 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
+      scf.yield {Undefined, ssbuffer.core_type = "VECTOR, VECTOR"} %12, %12 : tensor<128x128xf32>, tensor<128x128xf32>
+    } else {
+      scf.yield {Undefined, ssbuffer.core_type = "VECTOR, VECTOR"} %5, %9 : tensor<128x128xf32>, tensor<128x128xf32>
+    } {DataUse, ssbuffer.core_type = "VECTOR, VECTOR"}
+    %11 = arith.mulf %10#0, %10#1 {DataUse, ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
+    return
+  }
+}
+
+// CHECK-LABEL: @test_yield_if_dependencies
+
+// CHECK: %[[EXP_5:[a-z0-9_]+]] = math.exp2
+// CHECK: %[[MATMUL_9:[a-z0-9_]+]] = linalg.matmul
+// CHECK: %[[ALLOC_0:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+// CHECK: annotation.mark %[[ALLOC_0]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+// CHECK: hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} ins(%[[MATMUL_9]] : tensor<128x128xf32>) outs(%[[ALLOC_0]] : memref<128x128xf32, #hivm.address_space<ub>>)
+// CHECK: hivm.hir.sync_block_set {{.*}} flag = 1
+// CHECK: hivm.hir.sync_block_wait {{.*}} flag = 1
+// CHECK: %[[ALLOC_1:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+// CHECK: annotation.mark %[[ALLOC_1]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+// CHECK: %[[MEMSPACECAST:[a-z0-9_]+]] = memref.memory_space_cast %[[ALLOC_1]] {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32, #hivm.address_space<ub>> to memref<128x128xf32>
+// CHECK: %[[TENSOR_10:[a-z0-9_]+]] = bufferization.to_tensor %[[MEMSPACECAST]] restrict writable {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32>
+// CHECK: %[[IF_11:[a-z0-9_]+]]:2 = scf.if
+// CHECK: %[[EMPTY_13:[a-z0-9_]+]] = tensor.empty()
+// CHECK: scf.yield {Undefined, ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR, VECTOR"} %[[EMPTY_13]], %[[EMPTY_13]] : tensor<128x128xf32>, tensor<128x128xf32>
+// CHECK: } else {
+// CHECK: scf.yield {Undefined, ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR, VECTOR"} %[[EXP_5]], %[[TENSOR_10]] : tensor<128x128xf32>, tensor<128x128xf32>
+// CHECK: } {DataUse, ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR, VECTOR"}
+// CHECK: arith.mulf %[[IF_11]]#0, %[[IF_11]]#1 
+// CHECK: return
+
+


### PR DESCRIPTION
# Main Changes
**bugfix:**
1. add ssbuffer.block_id to scf.yield which is in scf.if op to analyze related datadependencies
2. fix warning vulnerabilities and standardize code
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
