### PR TITLE
[tritonparse](feat)  Optimize NPUOptions fields.

### DIFF
--- a/third_party/ascend/backend/__init__.py
+++ b/third_party/ascend/backend/__init__.py
@@ -50,5 +50,28 @@ def _apply_ascend_patch():
         CodeGenerator.__init__ = _patched_cg_init
         CodeGenerator._ascend_patch_applied = True
 
+    # Patch compiler.parse to support Ascend-specific IR extensions
+    # for ir_override and TRITON_KERNEL_OVERRIDE features.
+    from triton.compiler import compiler as _compiler_module
+
+    if not getattr(_compiler_module, "_ascend_parse_patch_applied", False):
+        from pathlib import Path as _Path
+        from triton._C.libtriton import ir as _ir
+
+        # Keep the original community logic intact, adding Ascend extensions
+        # to the existing text/binary branches.
+        def _patched_parse(full_name, ext, context):
+            if ext == "ttir" or ext == "ttgir":
+                module = _ir.parse_mlir_module(full_name, context)
+                module.context = context
+                return module
+            if ext in ("llir", "ptx", "amdgcn", "ttadapter", "bcmlir"):
+                return _Path(full_name).read_text()
+            if ext in ("cubin", "hsaco", "mlirbc", "npubin"):
+                return _Path(full_name).read_bytes()
+
+        _compiler_module.parse = _patched_parse
+        _compiler_module._ascend_parse_patch_applied = True
+
 
 __all__ = ["do_bench_npu"]

--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -785,10 +785,7 @@ class NPUOptions:
     num_ctas: int = 1
     num_stages: int = 1 if is_compile_on_910_95 else 2
     warp_size: int = 32
-    num_buffers_warp_spec: int = 0
-    num_consumer_groups: int = 0
-    reg_dec_producer: int = 0
-    reg_inc_consumer: int = 0
+    ir_override: Optional[str] = None  # filename of a user-defined IR (*.{ttir|ttadapter|mlirbc|bcmlir|npubin})
 
     auto_blockify_size: int = 1
     enable_auto_blockify: bool = None

--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -350,18 +350,12 @@ class AutoTilingTuner(Autotuner):
                 _kv_dict = {k: _args[v] for k, v in self.keys.items() if v in _args}
                 self._gen_tile_configs(_kv_dict, dtype)
             if len(self.gen_configs) == 0 and len(self.user_configs) == 0:
-                self.configs = [
-                    Config(
-                        {},
-                        num_warps=4,
-                        num_stages=2,
-                        num_ctas=1,
-                        num_buffers_warp_spec=0,
-                        num_consumer_groups=0,
-                        reg_dec_producer=0,
-                        reg_inc_consumer=0,
-                    )
-                ]
+                self.configs = [Config(
+                    {},
+                    num_warps=4,
+                    num_stages=2,
+                    num_ctas=1,
+                )]
             else:
                 self.configs = self.gen_configs + self.user_configs
         return key
@@ -1080,9 +1074,7 @@ def get_max_configs(config, kernel_type="mix", **kwargs):
 
         new_config = Config(kwargs=new_kwargs, num_warps=config.num_warps,
                             num_stages=num_stages_val if num_stages_val is not None else config.num_stages,
-                            num_ctas=config.num_ctas, num_buffers_warp_spec=config.num_buffers_warp_spec,
-                            num_consumer_groups=config.num_consumer_groups, reg_dec_producer=config.reg_dec_producer,
-                            reg_inc_consumer=config.reg_inc_consumer, maxnreg=config.maxnreg, pre_hook=config.pre_hook)
+                            num_ctas=config.num_ctas, maxnreg=config.maxnreg, pre_hook=config.pre_hook)
         new_configs.append(new_config)
 
     return new_configs

--- a/third_party/ascend/unittest/autotune_ut/test_ir_override.py
+++ b/third_party/ascend/unittest/autotune_ut/test_ir_override.py
@@ -1,0 +1,193 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+Test `ir_override` for Ascend NPU compilation stages.
+
+Strategy (inspired by upstream test_autotuner.py):
+  1. Compile a "donor" kernel (does ``×10``) with ``TRITON_KERNEL_DUMP=1``
+     to obtain dumped IR files (``.ttir`` / ``.ttadapter`` / ``.bcmlir``).
+  2. Replace the donor function name with the target function name in each
+     dumped file and save them as override inputs.
+  3. Run a "target" kernel (identity: load → store) with ``ir_override``
+     pointing to the renamed IR files.
+  4. Verify the target output equals ``input × 10`` — proving that the
+     override actually replaced the compilation stage.
+"""
+
+import os
+import pathlib
+
+import pytest
+import torch
+import torch_npu
+
+import triton
+import triton.backends.ascend.runtime  # noqa: F401 – patches triton.autotune
+import triton.language as tl
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+
+def _find_dumped_files(dump_root: str):
+    """Walk *dump_root* and return ``{ext: filepath}`` for Ascend IR stages."""
+    extensions = ("ttir", "ttadapter", "bcmlir")
+    found = {}
+    for dirpath, _, filenames in os.walk(dump_root):
+        for fn in filenames:
+            for ext in extensions:
+                if fn.endswith(f".{ext}"):
+                    found[ext] = os.path.join(dirpath, fn)
+    return found
+
+
+# ── test class ─────────────────────────────────────────────────────────
+
+
+class TestIrOverride:
+    """
+    End-to-end tests for ``ir_override`` at three Ascend compilation stages:
+    ``.ttir``, ``.ttadapter``, and ``.bcmlir``.
+    """
+
+    N = 1024
+    DONOR_NAME = "_donor_mul10"
+    TARGET_NAME = "_target_identity"
+
+    @pytest.fixture(scope="class")
+    def donor_ir(self, tmp_path_factory):
+        """Compile donor kernel once, dump its IR (shared across all tests)."""
+        tmp_path = tmp_path_factory.mktemp("ir_override")
+        dump_dir = tmp_path / "dump"
+        dump_dir.mkdir()
+
+        # Route dumped IR into a known, isolated directory.
+        # TRITON_ALWAYS_COMPILE forces recompilation so the stage loop
+        # runs and dumps every IR stage even when a cached compiled
+        # kernel already exists.
+        _old_dump = os.environ.get("TRITON_KERNEL_DUMP")
+        _old_dump_dir = os.environ.get("TRITON_DUMP_DIR")
+        _old_always = os.environ.get("TRITON_ALWAYS_COMPILE")
+        os.environ["TRITON_KERNEL_DUMP"] = "1"
+        os.environ["TRITON_DUMP_DIR"] = str(dump_dir)
+        os.environ["TRITON_ALWAYS_COMPILE"] = "1"
+        try:
+            # ── donor kernel: ×10 ──
+            @triton.autotune(
+                configs=[triton.Config({"BLOCK_SIZE": 32}, num_warps=4, num_stages=2, num_ctas=1)],
+                key=["N"],
+                do_bench=False,
+                hints={"auto_gen_config": False},
+            )
+            @triton.jit
+            def _donor_mul10(x_ptr, output_ptr, N, BLOCK_SIZE: tl.constexpr):
+                offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+                mask = offsets < N
+                x = tl.load(x_ptr + offsets, mask=mask)
+                output = x * 10.0
+                tl.store(output_ptr + offsets, output, mask=mask)
+
+            x = torch.randn(self.N, device="npu")
+            out = torch.empty_like(x)
+            grid = lambda meta: (triton.cdiv(self.N, meta["BLOCK_SIZE"]), )
+            _donor_mul10[grid](x, out, self.N)
+            torch.testing.assert_close(out, x * 10.0)
+        finally:
+            if _old_dump is not None:
+                os.environ["TRITON_KERNEL_DUMP"] = _old_dump
+            else:
+                os.environ.pop("TRITON_KERNEL_DUMP", None)
+            if _old_dump_dir is not None:
+                os.environ["TRITON_DUMP_DIR"] = _old_dump_dir
+            else:
+                os.environ.pop("TRITON_DUMP_DIR", None)
+            if _old_always is not None:
+                os.environ["TRITON_ALWAYS_COMPILE"] = _old_always
+            else:
+                os.environ.pop("TRITON_ALWAYS_COMPILE", None)
+
+        # Return (dumped_files, tmp_path) for test methods.
+        return {
+            "dumped": _find_dumped_files(str(dump_dir)),
+            "tmp_path": tmp_path,
+        }
+
+    # ── per-stage test runner ──────────────────────────────────────────
+
+    def _run_override_test(self, donor_ir, ext: str):
+        """Run target kernel (identity) with ``ir_override`` from donor IR."""
+        dumped = donor_ir["dumped"]
+        tmp_path = donor_ir["tmp_path"]
+
+        src_path = dumped.get(ext)
+        if src_path is None:
+            pytest.skip(f"No dumped .{ext} file found "
+                        f"(bytecode mode may be disabled or stage not reached)")
+
+        # Copy donor IR and rename the function symbol inside.
+        content = pathlib.Path(src_path).read_text()
+        content = content.replace(self.DONOR_NAME, self.TARGET_NAME)
+        override_path = tmp_path / f"override.{ext}"
+        override_path.write_text(content)
+
+        # ── target kernel: identity ──
+        @triton.autotune(
+            configs=[
+                triton.Config(
+                    {"BLOCK_SIZE": 32, "ir_override": str(override_path)},
+                    num_warps=4,
+                    num_stages=2,
+                    num_ctas=1,
+                )
+            ],
+            key=["N"],
+            do_bench=False,
+            hints={"auto_gen_config": False},
+        )
+        @triton.jit
+        def _target_identity(x_ptr, output_ptr, N, BLOCK_SIZE: tl.constexpr):
+            offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < N
+            x = tl.load(x_ptr + offsets, mask=mask)
+            tl.store(output_ptr + offsets, x, mask=mask)
+
+        x = torch.randn(self.N, device="npu")
+        out = torch.empty_like(x)
+        grid = lambda meta: (triton.cdiv(self.N, meta["BLOCK_SIZE"]), )
+        _target_identity[grid](x, out, self.N)
+
+        # If override works → ×10.  If silently ignored → identity.
+        torch.testing.assert_close(out, x * 10.0, msg=f"ir_override with .{ext} did not take effect")
+
+    # ── test cases ─────────────────────────────────────────────────────
+
+    @pytest.mark.autotune
+    def test_override_ttir(self, donor_ir):
+        """Override the ``.ttir`` compilation stage."""
+        self._run_override_test(donor_ir, "ttir")
+
+    @pytest.mark.autotune
+    def test_override_ttadapter(self, donor_ir):
+        """Override the ``.ttadapter`` compilation stage."""
+        self._run_override_test(donor_ir, "ttadapter")
+
+    @pytest.mark.autotune
+    def test_override_bcmlir(self, donor_ir):
+        """Override the ``.bcmlir`` compilation stage (bytecode → MLIR text)."""
+        self._run_override_test(donor_ir, "bcmlir")


### PR DESCRIPTION
# Optimize NPUOptions: remove dead warp-spec fields and support `ir_override` feature

## 1. Remove 4 warp specialization fields

### Affected fields

| Field | Type | Removed default | Purpose |
|------|------|-------------|------|
| `num_buffers_warp_spec` | `int` | `0` | Number of async buffers between producer and consumer |
| `num_consumer_groups` | `int` | `0` | Number of consumer warp groups |
| `reg_dec_producer` | `int` | `0` | Producer warp register reduction |
| `reg_inc_consumer` | `int` | `0` | Consumer warp register increment |

### Background

These fields are **warp specialization** compilation parameters for NVIDIA SM90+ (Hopper) GPUs. They rely on the `setmaxnreg` instruction and async warp scheduling, which are Hopper-specific features. They were added to `triton.Config.__init__` and `CUDAOptions` in upstream Triton v3.2.0, but were **removed from `triton.Config.__init__` starting in v3.4.0** (warp specialization is now handled internally via TTIR encoding).

triton-ascend is a fork based on upstream v3.5.0, where `triton.Config.__init__` no longer accepts these parameters. However, `NPUOptions` still carries these fields with a constant default of `0`. Ascend NPU hardware has no warp specialization support — these fields are **dead code**.

### Problem

Although these fields serve no purpose on Ascend, they are serialized into `compilation_metadata` and written to NDJSON logs. When tritonparse generates a reproducer script using `--kernel-import override-ttir`, these field values (always `0`) are written into the generated `triton.Config(...)` call:

```python
# Generated reproducer script (broken)
triton.Config(
    kwargs={"BLOCK_SIZE_M": 16, ...},
    num_warps=32,
    num_stages=2,
    num_ctas=1,
    num_buffers_warp_spec=0,   # ← Config.__init__ does not accept this
    num_consumer_groups=0,      # ← Config.__init__ does not accept this
    reg_dec_producer=0,         # ← Config.__init__ does not accept this
    reg_inc_consumer=0,         # ← Config.__init__ does not accept this
    ir_override=_IR_OVERRIDE_FILE,
)
```

Since these parameters are not in `Config.__init__`'s signature in Triton 3.5.0, Python raises `TypeError` at import time, making the reproducer script unusable:

```
TypeError: Config.__init__() got an unexpected keyword argument 'num_buffers_warp_spec'
```

### Change

Remove the four field definitions from `NPUOptions`:

```diff
  cluster_dims: tuple = (1, 1, 1)
  num_warps: int = 32
  num_ctas: int = 1
  num_stages: int = 1 if is_compile_on_910_95 else 2
  warp_size: int = 32
- num_buffers_warp_spec: int = 0
- num_consumer_groups: int = 0
- reg_dec_producer: int = 0
- reg_inc_consumer: int = 0
```

Also clean up two `triton.Config(...)` call sites in `third_party/ascend/backend/runtime/autotuner.py` that pass these four parameters (these calls would also crash with the same `TypeError` if executed).

---

## 2. Support `ir_override` feature

`ir_override` is a standard feature in upstream Triton (already supported by the NVIDIA backend). It allows users to supply a pre-compiled intermediate IR file, and the compilation pipeline skips the corresponding stage, using the provided IR in its place.

**How it works:** The compilation pipeline processes a kernel through multiple stages in sequence — `ttir` → `ttadapter` → `mlirbc` → `bcmlir` → `npubin`. At each stage, the compiler checks whether `ir_override` is set and its file extension matches the current stage（via `ir_override.endswith(f".{ext}")`）. If it matches, the normal compilation result is discarded and the file content is used instead.

```mermaid
flowchart TD
    S["module = Source.make_ir()"] --> LOOP["for ext, compile_ir in stages:"]

    LOOP --> STAGE["next_module = compile_ir(module)<br/>// normal compilation for this stage"]
    STAGE --> CHECK{"ir_override.endswith('.' + ext) ?<br/>// e.g. '/path/to/kernel.ttadapter' matches ext='ttadapter'"}

    CHECK -->|"No（or ir_override=None）"| KEEP["keep normal compilation result"]
    CHECK -->|"Yes"| PARSE["next_module = parse(file, ext)<br/>// read user IR file, replace result"]

    PARSE --> KEEP
    KEEP --> NEXT["module = next_module<br/>// pass to next stage as input"]
    NEXT --> LOOP
```

When `ir_override` is `None`, the check always fails — every stage keeps its normal compilation result, equivalent to the standard pipeline. When set, only the stage whose extension matches is overridden; all other stages proceed normally.

This is a prerequisite for **tritonparse's reproducer feature** (`--kernel-import override-ttir`), which generates scripts that re-execute kernels by injecting dumped IR files.

To enable this feature on Ascend, two gaps need to be addressed:

1. **`NPUOptions` must accept the `ir_override` kwarg.** The shared `_pack_args` validation logic rejects any keyword not present in `NPUOptions.__dataclass_fields__`. Without this field, passing `ir_override` raises `KeyError`.

2. **The shared `compiler.py:parse()` function must handle Ascend-specific IR extensions.** The community `parse` only recognizes NVIDIA and AMD extensions (`.ttir`, `.ttgir`, `.llir`, `.ptx`, `.cubin`, `.hsaco`, etc.). Ascend's compilation pipeline uses four additional extensions — `.ttadapter`, `.bcmlir`, `.mlirbc`, and `.npubin` — which `parse` does not know how to read.

### Change

Add `ir_override` to `NPUOptions`:

```diff
  cluster_dims: tuple = (1, 1, 1)
  num_warps: int = 32
  num_ctas: int = 1
  num_stages: int = 1 if is_compile_on_910_95 else 2
  warp_size: int = 32
+ ir_override: Optional[str] = None  # filename of a user-defined IR (*.{ttir|ttadapter|mlirbc|bcmlir|npubin})
```

### Adapt `compiler.parse` via monkey-patch

The community `parse` function maps IR extensions to read operations — MLIR module parsing for `.ttir`/`.ttgir`, text reads for `.llir`/`.ptx`/`.amdgcn`, and binary reads for `.cubin`/`.hsaco`. Ascend's additional extensions need the same treatment:

| Extension | Read method | Rationale |
|-----------|-------------|-----------|
| `.ttadapter` | `read_text()` | Returns a string (linalg MLIR text), same as the original `ttir_to_linalg` stage |
| `.bcmlir` | `read_text()` | Returns a string (MLIR text from bytecode), same as the original `bc_to_linalg_by_bishengir_opt` stage |
| `.mlirbc` | `read_bytes()` | Returns bytes (MLIR bytecode) |
| `.npubin` | `read_bytes()` | Returns bytes (NPU binary) |

`.ttir` is already handled by the community `parse` (MLIR module parsing).

Rather than modifying the shared `compiler.py`, we extend the existing `_apply_ascend_patch()` mechanism in `third_party/ascend/backend/__init__.py`. The patched `parse` preserves the community logic verbatim and adds Ascend extensions to the existing branches:

```python
def _patched_parse(full_name, ext, context):
    if ext == "ttir" or ext == "ttgir":                           # community unchanged
        module = ir.parse_mlir_module(full_name, context)
        module.context = context
        return module
    if ext in ("llir", "ptx", "amdgcn", "ttadapter", "bcmlir"):  # Ascend text extensions appended
        return Path(full_name).read_text()
    if ext in ("cubin", "hsaco", "mlirbc", "npubin"):            # Ascend binary extensions appended
        return Path(full_name).read_bytes()
```

---

## Files changed

| File | Change |
|------|--------|
| `third_party/ascend/backend/compiler.py` | `NPUOptions`: remove 4 warp spec fields, add `ir_override` |
| `third_party/ascend/backend/__init__.py` | `_apply_ascend_patch()`: append `compiler.parse` monkey-patch for Ascend IR extensions |
| `third_party/ascend/backend/runtime/autotuner.py` | Remove 4 warp spec params from default Config construction |
| `third_party/ascend/backend/runtime/autotuner.py` | Remove 4 warp spec params from Config clone |
| `third_party/ascend/unittest/autotune_ut/test_ir_override.py` | New: 3 end-to-end override tests (`.ttir`, `.ttadapter`, `.bcmlir`) |

---

## Test strategy

Three end-to-end tests (`test_override_ttir`, `test_override_ttadapter`, `test_override_bcmlir`) validate the `ir_override` pipeline:

1. Compile a "donor" kernel (`×10` operation) with IR dumping enabled to obtain compiled IR files.
2. For each test, copy the donor's dumped IR for the target stage, rename the kernel function, and pass it as `ir_override` to a "target" kernel (identity operation).
3. Verify the target produces `×10` output — confirming the overridden IR replaced the original compilation stage.

The IR is dumped at test time rather than hardcoded, ensuring compatibility across different Ascend hardware generations.

---

## Summary

- **Remove `num_buffers_warp_spec` and related fields**: NVIDIA Hopper-specific parameters with no purpose on Ascend NPU. Kept as dead code they break tritonparse reproducer scripts.
- **Support `ir_override` feature**: Enable tritonparse's `--kernel-import override-ttir` reproducer mode on Ascend. Involves adding the field to `NPUOptions` (keyword validation) and extending `compiler.parse` to handle Ascend IR extensions (`.ttadapter`, `.bcmlir`, `.mlirbc`, `.npubin`) via monkey-patch.
- **Add override tests**: Three end-to-end tests validate `ir_override` at the `.ttir`, `.ttadapter`, and `.bcmlir` compilation stages.
