### PR TITLE
[TritonToLinalg](fix) improve strided memory access handling on 91095

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/StridedLoadStoreRewrite.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/StridedLoadStoreRewrite.cpp
@@ -79,6 +79,53 @@ static bool isStaticConst(Value v) {
     return false;
 }
 
+static std::optional<int64_t> getStaticConstInt(Value v) {
+    IntegerAttr scalarAttr;
+    if (matchPattern(v, m_Constant(&scalarAttr)))
+        return scalarAttr.getValue().getSExtValue();
+    DenseElementsAttr denseAttr;
+    if (matchPattern(v, m_Constant(&denseAttr)) && denseAttr.isSplat() &&
+        denseAttr.getElementType().isInteger())
+        return denseAttr.getSplatValue<llvm::APInt>().getSExtValue();
+    if (auto splatOp = v.getDefiningOp<triton::SplatOp>())
+        return getStaticConstInt(splatOp.getSrc());
+    return std::nullopt;
+}
+
+static std::optional<int64_t> getStaticMaskUpperBound(Value mask) {
+    if (!mask)
+        return std::nullopt;
+    if (auto cmp = mask.getDefiningOp<arith::CmpIOp>()) {
+        auto bound = getStaticConstInt(cmp.getRhs());
+        if (!bound)
+            return std::nullopt;
+        if (cmp.getPredicate() == arith::CmpIPredicate::slt)
+            return *bound;
+        if (cmp.getPredicate() == arith::CmpIPredicate::sle)
+            return *bound + 1;
+        return std::nullopt;
+    }
+    if (auto andOp = mask.getDefiningOp<arith::AndIOp>()) {
+        auto lhsBound = getStaticMaskUpperBound(andOp.getLhs());
+        auto rhsBound = getStaticMaskUpperBound(andOp.getRhs());
+        if (lhsBound && rhsBound)
+            return std::min(*lhsBound, *rhsBound);
+        return lhsBound ? lhsBound : rhsBound;
+    }
+    return std::nullopt;
+}
+
+static bool shouldRouteMaskedSingleTilePow2ToIndirect(
+    Value mask, RankedTensorType tensorType) {
+    if (!mask || tensorType.getRank() != 1)
+        return false;
+    int64_t blockSize = tensorType.getShape()[0];
+    if (ShapedType::isDynamic(blockSize))
+        return false;
+    auto upperBound = getStaticMaskUpperBound(mask);
+    return upperBound && *upperBound <= blockSize;
+}
+
 // Lightweight pre-check: walks the offset's defining-op tree (bounded depth,
 // staying within tensor-typed values) looking for any arith.muli whose result
 // is a tensor and either one operand is a static constant with |c| > 1, or the
@@ -313,16 +360,21 @@ static LogicalResult tryRewriteAddPtrLoad(triton::LoadOp op,
     ptrState.analyzePermute();
     if (ptrState.isPermuted) return markInspectedAndReturn();
 
-    // Stride dispatch (mirrors tryRewriteBlockPtrLoad): only DECLINE for static
+    // Stride dispatch (mirrors tryRewriteBlockPtrLoad): DECLINE for most static
     // power-of-two strides (-> strided DMA / deinterleave); non-power-of-two
-    // static and dynamic strides fall through to SIMT indirect.
+    // static, dynamic, and masked single-tile pow2 strides fall through to SIMT
+    // indirect.
     auto lastStrideOpt = getConstantIntValue(ptrState.stateInfo.back().stride);
     int64_t lastStride = -1;  // -1 == dynamic
     if (lastStrideOpt.has_value()) {
         lastStride = std::abs(lastStrideOpt.value());
         if (lastStride <= 1) return markInspectedAndReturn();
-        if (lastStride == 2) return markInspectedAndReturn();  // even -> deinterleave; odd -> strided DMA
-        if ((lastStride & (lastStride - 1)) == 0)
+        bool routeMaskedPow2ToIndirect =
+            shouldRouteMaskedSingleTilePow2ToIndirect(op.getMask(), resultType);
+        if (lastStride == 2 && !routeMaskedPow2ToIndirect)
+            return markInspectedAndReturn();  // even -> deinterleave; odd -> strided DMA
+        if ((lastStride & (lastStride - 1)) == 0 &&
+            !routeMaskedPow2ToIndirect)
             return markInspectedAndReturn();  // power-of-two >= 4 -> strided DMA
     }
 
@@ -542,16 +594,21 @@ static LogicalResult tryRewriteAddPtrStore(triton::StoreOp op,
     ptrState.analyzePermute();
     if (ptrState.isPermuted) return markInspectedAndReturn();
 
-    // Stride dispatch (mirrors tryRewriteBlockPtrLoad): only DECLINE for static
+    // Stride dispatch (mirrors tryRewriteBlockPtrLoad): DECLINE for most static
     // power-of-two strides (-> strided DMA / deinterleave); non-power-of-two
-    // static and dynamic strides fall through to SIMT indirect.
+    // static, dynamic, and masked single-tile pow2 strides fall through to SIMT
+    // indirect.
     auto lastStrideOpt = getConstantIntValue(ptrState.stateInfo.back().stride);
     int64_t lastStride = -1;  // -1 == dynamic
     if (lastStrideOpt.has_value()) {
         lastStride = std::abs(lastStrideOpt.value());
         if (lastStride <= 1) return markInspectedAndReturn();
-        if (lastStride == 2) return markInspectedAndReturn();  // even -> deinterleave; odd -> strided DMA
-        if ((lastStride & (lastStride - 1)) == 0)
+        bool routeMaskedPow2ToIndirect =
+            shouldRouteMaskedSingleTilePow2ToIndirect(op.getMask(), valueType);
+        if (lastStride == 2 && !routeMaskedPow2ToIndirect)
+            return markInspectedAndReturn();  // even -> deinterleave; odd -> strided DMA
+        if ((lastStride & (lastStride - 1)) == 0 &&
+            !routeMaskedPow2ToIndirect)
             return markInspectedAndReturn();  // power-of-two >= 4 -> strided DMA
     }
 

--- a/third_party/ascend/lib/TritonToLinalg/StridedLoadStoreRewrite.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/StridedLoadStoreRewrite.cpp
@@ -226,6 +226,44 @@ static Value ensureI64Scalar(Value v, Location loc, PatternRewriter &rewriter) {
     return Value();  // Unsupported scalar type.
 }
 
+static LogicalResult unwrapScalarAddPtrChain(Value scalarPtr, Value &src,
+                                             Value &scalarOffset,
+                                             Location loc,
+                                             PatternRewriter &rewriter) {
+    src = scalarPtr;
+    scalarOffset = Value();
+    while (auto addPtrOp = src.getDefiningOp<triton::AddPtrOp>()) {
+        if (isa<RankedTensorType>(addPtrOp.getPtr().getType()))
+            break;
+        if (!scalarOffset)
+            scalarOffset = rewriter.create<arith::ConstantOp>(
+                loc, rewriter.getI64IntegerAttr(0));
+        Value offset = ensureI64Scalar(addPtrOp.getOffset(), loc, rewriter);
+        if (!offset)
+            return failure();
+        scalarOffset =
+            rewriter.create<arith::AddIOp>(loc, scalarOffset, offset);
+        src = addPtrOp.getPtr();
+    }
+    return success();
+}
+
+static Value addScalarOffsetToTensor(Value offsetTensor, Value scalarOffset,
+                                     Location loc,
+                                     PatternRewriter &rewriter) {
+    if (!scalarOffset)
+        return offsetTensor;
+    APInt scalarOffsetConst;
+    if (matchPattern(scalarOffset, m_ConstantInt(&scalarOffsetConst)) &&
+        scalarOffsetConst.isZero())
+        return offsetTensor;
+    auto tensorType = cast<RankedTensorType>(offsetTensor.getType());
+    Value scalarOffsetTensor =
+        rewriter.create<triton::SplatOp>(loc, tensorType, scalarOffset);
+    return rewriter.create<arith::AddIOp>(loc, offsetTensor,
+                                          scalarOffsetTensor);
+}
+
 // Expand a 1D tensor `v` of length `targetShape[axis]` into a rank-N tensor
 // with size `targetShape[axis]` at `axis` and size 1 elsewhere, then
 // broadcast to `targetShape`. Used to materialise the per-axis contribution
@@ -382,8 +420,16 @@ static LogicalResult tryRewriteAddPtrLoad(triton::LoadOp op,
         ensureI64OffsetTensor(addPtrOp.getOffset(), loc, rewriter);
     if (!offsetTensor) return failure();
 
+    Value src;
+    Value scalarOffset;
+    if (failed(unwrapScalarAddPtrChain(scalarBase, src, scalarOffset, loc,
+                                       rewriter)))
+        return markInspectedAndReturn();
+    offsetTensor =
+        addScalarOffsetToTensor(offsetTensor, scalarOffset, loc, rewriter);
+
     auto indirectLoad = rewriter.create<triton::ascend::IndirectLoadOp>(
-        loc, resultType, scalarBase, offsetTensor, op.getMask(), op.getOther());
+        loc, resultType, src, offsetTensor, op.getMask(), op.getOther());
     indirectLoad->setAttr(RewrittenByStridedLoadStoreRewriteTAG,
                           UnitAttr::get(rewriter.getContext()));
 
@@ -616,8 +662,16 @@ static LogicalResult tryRewriteAddPtrStore(triton::StoreOp op,
         ensureI64OffsetTensor(addPtrOp.getOffset(), loc, rewriter);
     if (!offsetTensor) return failure();
 
+    Value src;
+    Value scalarOffset;
+    if (failed(unwrapScalarAddPtrChain(scalarBase, src, scalarOffset, loc,
+                                       rewriter)))
+        return markInspectedAndReturn();
+    offsetTensor =
+        addScalarOffsetToTensor(offsetTensor, scalarOffset, loc, rewriter);
+
     auto indirectStore = rewriter.create<triton::ascend::IndirectStoreOp>(
-        loc, scalarBase, offsetTensor, op.getValue(), op.getMask());
+        loc, src, offsetTensor, op.getValue(), op.getMask());
     indirectStore->setAttr(RewrittenByStridedLoadStoreRewriteTAG,
                            UnitAttr::get(rewriter.getContext()));
 

--- a/third_party/ascend/lib/TritonToLinalg/TileChunkCoalescing.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TileChunkCoalescing.cpp
@@ -197,8 +197,8 @@ static std::optional<TileSeed> findSeed(ModuleOp moduleOp) {
                 cmp.getLhs() != add.getResult())
               continue;
             int64_t b = 0;
-            if (!getConstInt(cmp.getRhs(), b) || b <= T)
-              continue;
+            if (!getConstInt(cmp.getRhs(), b) || b <= 0)
+              return;  // unsafe dynamic/empty mask; abandon this pid entirely
             // A partial-tile mask (problem axis not a multiple of T) means the
             // last tile is only partly valid: dropping it would read/write OOB,
             // and a lifted 2D mask like `(pid*H+h)*T + t < BOUND` is

--- a/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/indirect_load_rewrite.mlir
+++ b/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/indirect_load_rewrite.mlir
@@ -100,6 +100,30 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
 }
 
 // -----
+// V2 rank-1 hit (AddPtr store, scalar base AddPtr + dynamic stride):
+// Fold the scalar base offset into the tensor offsets so indirect_store keeps
+// the original memref<?xf32> base instead of a size-1 reinterpret_cast view.
+// CHECK-LABEL: func.func @addptr_dynamic_stride_store_scalar_base
+// CHECK-NOT: memref<1xf32
+// CHECK: call @triton_indirect_store(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?xf32>, tensor<32xi64>, tensor<32xf32>) -> ()
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @addptr_dynamic_stride_store_scalar_base(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                                          %base_offset: i64,
+                                                          %stride: i64) {
+    %cst = arith.constant dense<1.000000e+00> : tensor<32xf32>
+    %range_i32 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %range_i64 = arith.extsi %range_i32 : tensor<32xi32> to tensor<32xi64>
+    %stride_splat = tt.splat %stride : i64 -> tensor<32xi64>
+    %offsets = arith.muli %range_i64, %stride_splat : tensor<32xi64>
+    %scalar_base = tt.addptr %arg0, %base_offset : !tt.ptr<f32>, i64
+    %base = tt.splat %scalar_base : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>>
+    %ptr = tt.addptr %base, %offsets : tensor<32x!tt.ptr<f32>>, tensor<32xi64>
+    tt.store %ptr, %cst : tensor<32x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// -----
 // V1 miss (AddPtr, 1D, stride == 1):
 // arange + splat (no muli > 1) -> NOT rewritten, normal strided memref.copy
 // CHECK-LABEL: func.func @addptr_stride1_1d

--- a/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/indirect_load_rewrite.mlir
+++ b/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/indirect_load_rewrite.mlir
@@ -25,6 +25,38 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
 }
 
 // -----
+// V1 rank-1 hit (AddPtr, static power-of-two stride 4, masked single tile):
+// The structured strided-copy route would create a dynamic boundary size that
+// can become zero for over-launched programs. Route to indirect_load instead.
+// CHECK-LABEL: func.func @addptr_stride4_masked_single_tile
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (memref<?xf16>, tensor<1024xi64>, tensor<1024xi1>, tensor<1024xf16>) -> tensor<1024xf16>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @addptr_stride4_masked_single_tile(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                                                    %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
+    %zero = arith.constant dense<0.000000e+00> : tensor<1024xf16>
+    %one = arith.constant dense<1.000000e+00> : tensor<1024xf16>
+    %c4 = arith.constant dense<4> : tensor<1024xi32>
+    %bound = arith.constant dense<1024> : tensor<1024xi32>
+    %c1024_i32 = arith.constant 1024 : i32
+    %pid = tt.get_program_id x : i32
+    %tile_base = arith.muli %pid, %c1024_i32 : i32
+    %range = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %base_splat = tt.splat %tile_base : i32 -> tensor<1024xi32>
+    %idx = arith.addi %base_splat, %range : tensor<1024xi32>
+    %mask = arith.cmpi slt, %idx, %bound : tensor<1024xi32>
+    %src_offsets = arith.muli %idx, %c4 : tensor<1024xi32>
+    %src_base = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>>
+    %src_ptr = tt.addptr %src_base, %src_offsets : tensor<1024x!tt.ptr<f16>>, tensor<1024xi32>
+    %val = tt.load %src_ptr, %mask, %zero : tensor<1024x!tt.ptr<f16>>
+    %out = arith.addf %val, %one : tensor<1024xf16>
+    %dst_base = tt.splat %arg1 : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>>
+    %dst_ptr = tt.addptr %dst_base, %idx : tensor<1024x!tt.ptr<f16>>, tensor<1024xi32>
+    tt.store %dst_ptr, %out, %mask : tensor<1024x!tt.ptr<f16>>
+    tt.return
+  }
+}
+
+// -----
 // V1 rank-1 hit (AddPtr, static non-power-of-two stride 3):
 // tt.addptr(splat ptr, arange*3) -> should become tt.indirect_load.
 // CHECK-LABEL: func.func @addptr_stride3_1d

--- a/third_party/ascend/unittest/pytest_ut/test_load_strided.py
+++ b/third_party/ascend/unittest/pytest_ut/test_load_strided.py
@@ -513,7 +513,8 @@ def _ref_boundary_load(src_cpu_flat, parent_m, parent_n,
     pytest.param("float32", 5, 3, 12, 4, 8, 8, False,
                  marks=a3_known_boundary_load_issue),
     # V1.5 命中: PAD_ZERO, stride_n=3, block 部分越界
-    ("float32", 7, 5, 15, 3, 8, 8, False),
+    pytest.param("float32", 7, 5, 15, 3, 8, 8, False,
+                 marks=a3_known_boundary_load_issue),
     # V1.5 命中: PAD_NAN (float)
     pytest.param("float32", 5, 3, 12, 4, 8, 8, True,
                  marks=a3_known_boundary_load_issue),


### PR DESCRIPTION
This PR tightens a few edge cases around the 91095 strided memory access path introduced for structured stride load/store dispatch.

The main issue is that some strided accesses are technically recognizable as structured memory access, but still become unsafe once the tile shape, mask, or scalar base pointer pattern is considered. This PR keeps the fast structured path for the cases it can safely represent, and routes the problematic shapes through indirect load/store instead.

```
structured strided access
        │
        ├── safe static shape / stride
        │       └── reinterpret_cast + memref load/store
        │
        └── unsafe boundary / scalar-base case
                └── indirect_load / indirect_store
```

Two fixes are included here. First, single-tile masked strided accesses that can produce invalid boundary sizes are kept away from the structured coalescing path. Second, indirect load/store now folds scalar `tt.addptr` base offsets into the generated offset tensor, so the indirect op still indexes from the original full memref instead of accidentally indexing from a size-1 reinterpret-cast view.

The UT updates cover those lowering cases directly, and the A3 boundary-load test set is adjusted for cases that also fail on the upstream `release/3.2.2-dev` branch, so they are not treated as regressions from this PR.