### PR TITLE
[driver](fix) Fix get_active_torch_device NameError in Ascend driver

### DIFF
--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -182,7 +182,7 @@ class NPUDriver(DriverBase):
         return get_backend_func("get_current_device")
 
     def get_active_torch_device(self):
-        import torch_npu
+        import torch
         return torch.device("npu", self.get_current_device())
 
     def set_current_device(self, device):

--- a/third_party/ascend/unittest/pytest_ut/test_get_active_torch_device.py
+++ b/third_party/ascend/unittest/pytest_ut/test_get_active_torch_device.py
@@ -1,0 +1,32 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import pytest
+import torch
+import triton
+
+
+@pytest.mark.backend("torch_npu")
+def test_get_active_torch_device_returns_npu_device():
+    device = triton.runtime.driver.active.get_active_torch_device()
+
+    assert isinstance(device, torch.device)
+    assert device.type == "npu"
+    assert device.index == torch.npu.current_device()


### PR DESCRIPTION
## Summary
This PR fixes a NameError in the Ascend backend implementation of get_active_torch_device and adds a minimal regression test to cover the failure mode.

Running Triton tutorials such as `python/tutorials/06-fused-attention.py` currently fails at startup with:

```text
NameError: name 'torch' is not defined
```

The failure is caused by `triton.backends.ascend.driver.NPUDriver.get_active_torch_device` importing torch_npu but then calling `torch.device(...)`. The function uses the torch symbol directly, so importing torch_npu alone is insufficient.

## Key Changes
### 1. Fix get_active_torch_device import
Updated `get_active_torch_device` in `third_party/ascend/backend/driver.py` to import torch instead of torch_npu.

Before:

```python
def get_active_torch_device(self):
    import torch_npu
    return torch.device("npu", self.get_current_device())
```

After:

```python
def get_active_torch_device(self):
    import torch
    return torch.device("npu", self.get_current_device())
```

### 2. Add a minimal regression test
Added a minimal pytest case under third_party/ascend/unittest/pytest_ut to validate that:

1. get_active_torch_device can be called successfully.
2. The returned object is a torch.device.
3. The returned device type is npu.
4. The returned device index matches torch.npu.current_device().

## Why importing torch is sufficient
The Ascend torch runtime is integrated through the PyTorch-side NPU extension. In normal torch_npu environments, importing torch is enough to construct and use torch.device("npu", ...).

This function only needs the torch symbol because it returns a torch.device object. It does not directly use any torch_npu symbol in the function body.

Therefore:

1. Importing torch is required.
2. Importing torch_npu is not required in this function.
3. Importing torch_npu alone does not define the torch symbol, so it cannot satisfy torch.device(...).

## User Impact
This fix restores the expected behavior for tutorial and runtime code paths that call:

```python
triton.runtime.driver.active.get_active_torch_device()
```

Without this fix, users hit an immediate runtime exception before kernel compilation or execution starts.

## Validation
The bug is reproducible with a minimal call to get_active_torch_device and is covered by the new pytest regression case.

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
  - [x] I have added tests.
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.
- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)