### PR TITLE
fix(ssbuffer):fix mistransfer between different levels

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
@@ -105,6 +105,33 @@ struct InnerBlockInfo {
     SmallVector<Operation *> ops;
 };
 
+// Effective block_id for cross-block dep judgment: prefer the enclosing
+// multi-region op's block_id (inner ops are attributed to the op itself,
+// not their own innermost id), else the innermost recorded block_id walking
+// up to the main_loop boundary.
+static std::optional<int64_t> getOutermostSsbufferId(Operation *op)
+{
+    std::optional<int64_t> result;
+    for (Operation *current = op; current; current = current->getParentOp()) {
+        // Any multi-region op (scf.if, scf.while, ...) acts as a logical
+        // block boundary: its block_id overrides anything inside it.
+        if (current->getNumRegions() >= 2)
+            return getOpBlockId(current);
+
+        // main_loop is an attribute, not exclusive to forOp. Take the
+        // boundary's id only if nothing was recorded on the way up.
+        if (current->hasAttr(kMainLoop))
+            return result.has_value() ? result : -1;
+
+        // Otherwise remember the deepest id seen; the parent walk will
+        // overwrite it if a closer-to-boundary op carries one.
+        if (auto curId = getOpBlockId(current); curId.has_value())
+            result = curId;
+    }
+    return result;
+}
+
+
 void collectNestedOps(Block *block, SmallVector<Operation *> &ops)
 {
     for (auto &op : *block) {
@@ -174,8 +201,12 @@ scf::ForOp findMainloopInScope(scope::ScopeOp scope)
     return mainLoopForOp;
 }
 
-// Collect a single dependency value to depValueMap
-static void collectDepValue(Value operand, Block *body, int currentBlockId, DenseMap<Value, int> &outputToBlockId,
+// Collect a single dependency value to depValueMap. Same-block check uses
+// outermost id so inner ops of a multi-region op (e.g. subview at block 3
+// inside ifOp at block 4) are not treated as cross-block consumers of a
+// same-block producer.
+static void collectDepValue(Value operand, Block *body, Operation *currentOp,
+                            DenseMap<Value, int> &outputToBlockId,
                             DenseMap<Value, SmallVector<Value>> &depValueMap, Value groupKey)
 {
     if (auto barg = dyn_cast<BlockArgument>(operand)) {
@@ -184,8 +215,13 @@ static void collectDepValue(Value operand, Block *body, int currentBlockId, Dens
         return;
     }
 
-    if (outputToBlockId.count(operand) && outputToBlockId[operand] != currentBlockId &&
-        !llvm::is_contained(depValueMap[groupKey], operand))
+    if (!outputToBlockId.count(operand))
+        return;
+    auto currentOutermost = getOutermostSsbufferId(currentOp);
+    auto operandOutermost = getOutermostSsbufferId(operand.getDefiningOp());
+    if (currentOutermost.has_value() && currentOutermost == operandOutermost)
+        return;
+    if (!llvm::is_contained(depValueMap[groupKey], operand))
         depValueMap[groupKey].push_back(operand);
 }
 
@@ -246,14 +282,55 @@ static int groupOpsBySsbufferId(SmallVector<Operation *> &allOps,
             opsByValue[res] = op;
         }
     }
+    // Deduplicate: a multi-result op (e.g. scf.if) is inserted N times in
+    // opsByValue and would produce duplicated dep_marks like [1, 1] otherwise.
+    DenseSet<Operation *> seen;
     for (auto &p : opsByValue) {
-        auto id = getOpBlockId(p.second);
+        Operation *op = p.second;
+        if (!seen.insert(op).second)
+            continue;
+        auto id = getOpBlockId(op);
         if (!id.has_value()) {
             continue;
         }
-        opsById[*id].push_back(p.second);
+        opsById[*id].push_back(op);
     }
     return 0;
+}
+
+// True when operand is produced by an op with a block_id and lives in a
+// different logical block from the consumer (mirrors the same-block check
+// in collectDepValue).
+static bool isCrossBlockDepOperand(Operation *consumerOp, Value operand,
+                                   const DenseMap<Value, int> &outputToBlockId)
+{
+    if (!outputToBlockId.count(operand))
+        return false;
+    auto consumerOutermost = getOutermostSsbufferId(consumerOp);
+    auto operandOutermost = getOutermostSsbufferId(operand.getDefiningOp());
+    return !(consumerOutermost.has_value() && consumerOutermost == operandOutermost);
+}
+
+// Invoke callback for each cross-block dep operand yielded by a multi-region
+// op (e.g. scf.if, scf.while). Skips ops with fewer than 2 regions, empty
+// regions, and regions whose terminator is not scf.yield.
+static void forEachYieldedCrossBlockDep(Operation *op,
+                                        const DenseMap<Value, int> &outputToBlockId,
+                                        llvm::function_ref<void(Value)> callback)
+{
+    if (op->getNumRegions() < 2)
+        return;
+    for (Region &region : op->getRegions()) {
+        if (region.empty())
+            continue;
+        auto yieldOp = dyn_cast<scf::YieldOp>(region.back().getTerminator());
+        if (!yieldOp)
+            continue;
+        for (Value operand : yieldOp->getOperands()) {
+            if (isCrossBlockDepOperand(op, operand, outputToBlockId))
+                callback(operand);
+        }
+    }
 }
 
 // Returns 0=success (including normal skip when blocks empty), -1=invalid negative block ID
@@ -281,7 +358,9 @@ static int collectInnerBlockInfo(scf::ForOp forOp, DenseMap<Value, InnerBlockInf
             for (auto res : op->getResults())
                 outputToBlockId[res] = p.first;
 
-    // Collect dependency values for each block
+    // Collect dependency values for each block. Inner ops of multi-region ops
+    // (e.g. scf.if) are included so their scalar deps get tracked; cross-block
+    // judgment still attributes them to the ifOp via getOutermostSsbufferId.
     for (auto &p : opsById) {
         Value groupKey = p.second.front()->getResult(0);
         InnerBlockInfo bi;
@@ -291,7 +370,19 @@ static int collectInnerBlockInfo(scf::ForOp forOp, DenseMap<Value, InnerBlockInf
 
         for (Operation *op : bi.ops)
             for (Value operand : op->getOperands())
-                collectDepValue(operand, body, p.first, outputToBlockId, depValueMap, groupKey);
+                collectDepValue(operand, body, op, outputToBlockId, depValueMap, groupKey);
+    }
+
+    // Additional pass: collect deps from yield ops of multi-region consumers
+    // (e.g. scf.if), treating the multi-region op as the dep consumer.
+    for (auto &blockPair : blocks) {
+        Value blockKey = blockPair.first;
+        for (Operation *op : blockPair.second.ops) {
+            forEachYieldedCrossBlockDep(op, outputToBlockId, [&](Value operand) {
+                if (!llvm::is_contained(depValueMap[blockKey], operand))
+                    depValueMap[blockKey].push_back(operand);
+            });
+        }
     }
 
     return 0;
@@ -414,8 +505,8 @@ SmallVector<Value> collectScalarDeps(DenseMap<Value, SmallVector<Value>> &depVal
             SmallVector<Operation *> depUsers = userIt->second;
             bool hasCrossBlockUser = false;
             for (Operation *depUser : depUsers) {
-                auto userId = getOpBlockId(depUser);
-                if (userId.value_or(-1) != *producerId) {
+                auto userId = getOutermostSsbufferId(depUser);
+                if (!userId.has_value() || *userId != *producerId) {
                     hasCrossBlockUser = true;
                     break;
                 }
@@ -985,10 +1076,9 @@ static SmallVector<Operation *> collectCrossBlockUsers(Value depVal, int produce
         return crossBlockUsers;
 
     for (Operation *depUser : userIt->second) {
-        auto userId = getOpBlockId(depUser);
-        if ((userId.value_or(-1) != producerId) && isInsideMainLoopForOpTraverse(depUser)) {
+        auto userId = getOutermostSsbufferId(depUser);
+        if ((!userId.has_value() || *userId != producerId) && isInsideMainLoopForOpTraverse(depUser))
             crossBlockUsers.push_back(depUser);
-        }
     }
     return crossBlockUsers;
 }
@@ -1201,7 +1291,7 @@ static int processDepVal(Value depVal, mlir::scf::ForOp mainLoopForOp, BufferMap
     DenseMap<int, Value> processedBlockSelections;
 
     for (Operation *depUser : depUsers) {
-        auto userBlockId = getOpBlockId(depUser);
+        auto userBlockId = getOutermostSsbufferId(depUser);
         if (!userBlockId.has_value() || *userBlockId == producerId)
             continue;
 
@@ -1219,21 +1309,37 @@ static int processDepVal(Value depVal, mlir::scf::ForOp mainLoopForOp, BufferMap
         }
     }
 
-    // For each block_id, generate only one set of buffer selection and share among all ops
+    // Re-group by Block* before processing: getOutermostSsbufferId may merge
+    // ops from different Regions (e.g. then/else of an scf.if) into the same
+    // block_id, but a single buffer selection's result is only visible in its
+    // own Region, so sharing across Regions would break SSA dominance.
     for (auto &blockPair : opsByBlockId) {
         int userBlockId = blockPair.first;
         SmallVector<Operation *> &opsInBlock = blockPair.second;
         if (opsInBlock.empty())
             continue;
 
-        // Insert buffer selection at the position of the first op
-        Operation *firstOp = opsInBlock.front();
-        OpBuilder consumedBuilder(mainLoopForOp.getContext());
-        consumedBuilder.setInsertionPoint(firstOp);
+        DenseMap<Block *, SmallVector<Operation *>> opsByBlock;
+        for (Operation *op : opsInBlock) {
+            Block *blk = op->getBlock();
+            if (!blk)
+                continue;
+            opsByBlock[blk].push_back(op);
+        }
 
-        if (int ret = processNormalConsumerBlock(consumedBuilder, depVal, buffers, mainLoopForOp,
-                                               opsInBlock, userBlockId, groupId, globalBuilder))
-            return ret;
+        for (auto &regionPair : opsByBlock) {
+            SmallVector<Operation *> &opsInRegion = regionPair.second;
+            if (opsInRegion.empty())
+                continue;
+
+            Operation *firstOp = opsInRegion.front();
+            OpBuilder consumedBuilder(mainLoopForOp.getContext());
+            consumedBuilder.setInsertionPoint(firstOp);
+
+            if (int ret = processNormalConsumerBlock(consumedBuilder, depVal, buffers, mainLoopForOp,
+                                                   opsInRegion, userBlockId, groupId, globalBuilder))
+                return ret;
+        }
     }
 
     return 0;
@@ -1287,8 +1393,8 @@ static int processTensorDependencies(mlir::scf::ForOp mainLoopForOp, DenseMap<Va
             // Check if all users are in the same block
             bool allUsersSameBlock = true;
             for (Operation *depUser : depUsers) {
-                auto userId = getOpBlockId(depUser);
-                if (userId.value_or(-1) != *producerId) {
+                auto userId = getOutermostSsbufferId(depUser);
+                if (!userId.has_value() || *userId != *producerId) {
                     allUsersSameBlock = false;
                     break;
                 }
@@ -1371,7 +1477,8 @@ static int addInnerMultiBuffer(mlir::scf::ForOp mainLoopForOp, OpBuilder &builde
     if (blocks.empty())
         return -1;
 
-    // If memref-type dependency values exist, skip double buffer processing
+    // Memref-type dep values are not supported here; fail loudly so downstream
+    // passes don't see an unmarked-but-skipped scope.
     if (hasMemrefDepValue(depValueMap)) {
         LDBG("ERROR: Memref type dependent values found!");
         return -1;

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/Inner-scope.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/Inner-scope.mlir
@@ -205,7 +205,7 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
         } else {
           %r2 = arith.divsi %compute, %c1_i64 {ssbuffer.block_id = 9 : i32} : i64
           scf.yield %r2 : i64
-        }
+        }{ssbuffer.block_id = 12 : i32}
         memref.store %compute, %cast_alloc[%c0] {ssbuffer.block_id = 12 : i32} : memref<1xi64, strided<[1], offset: ?>>
       } {ssbuffer.block_id = 26 : i32, ssbuffer.main_loop = 1 : i64}
       scope.return
@@ -847,6 +847,357 @@ func.func @test_t23_scf_if_else_branch_yield() {
         // Final producer in block_id = 5
         %final = arith.addf %new_prod1, %new_prod2 {ssbuffer.block_id = 5 : i32} : tensor<128xf32>
         scf.yield %final : tensor<128xf32>
+      } {ssbuffer.main_loop = 1 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return
+  }
+
+//===--------------------------------------------------------------------===//
+// T26: ifOp inner ops - dep_mark applied with cross-block producer (baseline)
+// Test: An ifOp at block 12 with inner ops at blocks 8 and 9 uses a scalar
+//       producer at block 11. This is a baseline test that verifies dep_mark
+//       is added when producer and ifOp are in different blocks.
+// NOTE: This test passes with BOTH getSsbufferId AND getOutermostSsbufferId
+//       because all blocks (8, 9, 12) are cross-block from producer (11).
+//       See T27 for the test that ACTUALLY distinguishes the fix.
+// Key Check: dep_mark is added to producer and inner ops
+//===--------------------------------------------------------------------===//
+// CHECK-LABEL: func.func @test_t26_ifop_inner_dep_mark
+// CHECK: arith.addi {{.*}} {ssbuffer.block_id = 11 : i32, ssbuffer.dep_mark
+// CHECK: scf.if
+// CHECK: arith.muli {{.*}} {ssbuffer.block_id = 8 : i32, ssbuffer.dep_mark
+// CHECK: arith.divsi {{.*}} {ssbuffer.block_id = 9 : i32, ssbuffer.dep_mark
+  func.func @test_t26_ifop_inner_dep_mark() {
+    %true = arith.constant true
+    %c0_i64 = arith.constant 0 : i64
+    %c100_i64 = arith.constant 100 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c0 = arith.constant 0 : index
+    scope.scope : () -> () {
+      %alloc = memref.alloc() : memref<1xi64>
+      %cast_alloc = memref.cast %alloc : memref<1xi64> to memref<1xi64, strided<[1], offset: ?>>
+      scf.for %i = %c0_i64 to %c100_i64 step %c1_i64 : i64 {
+        %load = memref.load %cast_alloc[%c0] {ssbuffer.block_id = 11 : i32} : memref<1xi64, strided<[1], offset: ?>>
+        %compute = arith.addi %load, %c1_i64 {ssbuffer.block_id = 11 : i32} : i64
+        %result = scf.if %true -> (i64) {
+          %r1 = arith.muli %compute, %c1_i64 {ssbuffer.block_id = 8 : i32} : i64
+          scf.yield %r1 : i64
+        } else {
+          %r2 = arith.divsi %compute, %c1_i64 {ssbuffer.block_id = 9 : i32} : i64
+          scf.yield %r2 : i64
+        } {ssbuffer.block_id = 12 : i32}
+        memref.store %compute, %cast_alloc[%c0] {ssbuffer.block_id = 12 : i32} : memref<1xi64, strided<[1], offset: ?>>
+      } {ssbuffer.block_id = 26 : i32, ssbuffer.main_loop = 1 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return
+  }
+
+//===--------------------------------------------------------------------===//
+// T27: ifOp inner ops - same-block producer, no dep_mark
+// Test: When the ifOp is at the SAME block as the producer (both block 11),
+//       the cross-block dep judgment should treat them as same-block
+//       (11 vs 11), so NO dep_mark should be added.
+//       This is the inverse case of T26.
+// Key Check: NO dep_mark on producer or inner ops
+//===--------------------------------------------------------------------===//
+// CHECK-LABEL: func.func @test_t27_ifop_same_block_no_dep_mark
+// CHECK-NOT: arith.addi {{.*}} ssbuffer.dep_mark
+// CHECK-NOT: arith.muli {{.*}} ssbuffer.dep_mark
+// CHECK-NOT: arith.divsi {{.*}} ssbuffer.dep_mark
+  func.func @test_t27_ifop_same_block_no_dep_mark() {
+    %true = arith.constant true
+    %c0_i64 = arith.constant 0 : i64
+    %c100_i64 = arith.constant 100 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c0 = arith.constant 0 : index
+    scope.scope : () -> () {
+      %alloc = memref.alloc() : memref<1xi64>
+      %cast_alloc = memref.cast %alloc : memref<1xi64> to memref<1xi64, strided<[1], offset: ?>>
+      scf.for %i = %c0_i64 to %c100_i64 step %c1_i64 : i64 {
+        %load = memref.load %cast_alloc[%c0] {ssbuffer.block_id = 11 : i32} : memref<1xi64, strided<[1], offset: ?>>
+        %compute = arith.addi %load, %c1_i64 {ssbuffer.block_id = 11 : i32} : i64
+        // ifOp at block 11 - SAME block as producer
+        %result = scf.if %true -> (i64) {
+          %r1 = arith.muli %compute, %c1_i64 {ssbuffer.block_id = 8 : i32} : i64
+          scf.yield %r1 : i64
+        } else {
+          %r2 = arith.divsi %compute, %c1_i64 {ssbuffer.block_id = 9 : i32} : i64
+          scf.yield %r2 : i64
+        } {ssbuffer.block_id = 11 : i32}
+        memref.store %compute, %cast_alloc[%c0] {ssbuffer.block_id = 12 : i32} : memref<1xi64, strided<[1], offset: ?>>
+      } {ssbuffer.block_id = 26 : i32, ssbuffer.main_loop = 1 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return
+  }
+
+//===--------------------------------------------------------------------===//
+// T28: ifOp with 2 results - producer-side buffer selection not duplicated
+// Test: An ifOp with 2 results (multi-result). The dedup fix in
+//       groupOpsBySsbufferId ensures the ifOp is added to opsById[18] only
+//       ONCE (not twice, once per result). Without the fix, processDepVal
+//       would iterate the ifOp twice and generate a duplicate producer-side
+//       scf.if buffer selection (with intra_buffer attribute).
+// Key Check: Only ONE scf.if with intra_buffer at block_id = 18
+//         : Pattern is checked structurally, not by specific intraDeps value
+//===--------------------------------------------------------------------===//
+// CHECK-LABEL: func.func @test_t28_multi_result_ifop_no_dup_intraDeps
+// The ifOp's producer-side buffer selection scf.if (with intra_buffer at block 18)
+// should appear exactly once. It contains hivm.hir.copy for the ifOp's result.
+// CHECK: scf.if
+// CHECK: hivm.hir.copy {{.*}} outs({{.*}}) {ssbuffer.block_id = 18 : i32}
+// CHECK: } {ssbuffer.block_id = 18 : i32, ssbuffer.intra_buffer}
+// No duplicate producer-side scf.if would produce another intra_buffer at block 18
+// CHECK-NOT: } {ssbuffer.block_id = 18 : i32, ssbuffer.intra_buffer}
+  func.func @test_t28_multi_result_ifop_no_dup_intraDeps() {
+    %c0_i32 = arith.constant 0 : i32
+    %c100_i32 = arith.constant 100 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %cst = arith.constant 1.0 : f32
+    %empty = tensor.empty() : tensor<128xf32>
+    %alloc = memref.alloc() : memref<128xf32, #hivm.address_space<ub>>
+    scope.scope : () -> () {
+      // Transfer producer at block 11
+      %memspacecast = memref.memory_space_cast %alloc {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128xf32, #hivm.address_space<ub>> to memref<128xf32>
+      %depval = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128xf32>
+      %loop_result = scf.for %i = %c0_i32 to %c100_i32 step %c1_i32 iter_args(%arg = %depval) -> (tensor<128xf32>) : i32 {
+        %cond = arith.cmpi eq, %i, %c0_i32 : i32
+        // ifOp with 2 results - the duplication bug would manifest here
+        %if_result:2 = scf.if %cond -> (tensor<128xf32>, tensor<128xf32>) {
+          %consumed = arith.addf %arg, %arg {ssbuffer.block_id = 11 : i32} : tensor<128xf32>
+          scf.yield %consumed, %consumed : tensor<128xf32>, tensor<128xf32>
+        } else {
+          %other = arith.mulf %arg, %arg {ssbuffer.block_id = 11 : i32} : tensor<128xf32>
+          scf.yield %other, %other : tensor<128xf32>, tensor<128xf32>
+        } {ssbuffer.block_id = 18 : i32}
+        %next = arith.addf %if_result#0, %if_result#0 {ssbuffer.block_id = 11 : i32} : tensor<128xf32>
+        scf.yield %next : tensor<128xf32>
+      } {ssbuffer.main_loop = 1 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return
+  }
+
+//===--------------------------------------------------------------------===//
+// T29: ifOp inner ops - producer-side buffer uses ifOp's block_id (baseline)
+// Test: An ifOp at block 18 yields a result that is used outside (block 11).
+//       The producer-side hivm.hir.copy for the ifOp's result must use the
+//       ifOp's block_id (18).
+// NOTE: This test passes with BOTH getSsbufferId AND getOutermostSsbufferId
+//       because for the ifOp itself, both return 18 (ifOp's own block_id).
+//       The fix only changes behavior for INNER ops of the ifOp (see T27).
+// Key Check: hivm.hir.copy (producer side) is at block_id = 18 (ifOp's)
+//===--------------------------------------------------------------------===//
+// CHECK-LABEL: func.func @test_t29_ifop_buffer_uses_ifop_block_id
+// CHECK: scf.if
+// CHECK: hivm.hir.copy {{.*}} outs({{.*}}) {ssbuffer.block_id = 18 : i32}
+// CHECK: } {ssbuffer.block_id = 18 : i32, ssbuffer.intra_buffer}
+  func.func @test_t29_ifop_buffer_uses_ifop_block_id() {
+    %c0_i32 = arith.constant 0 : i32
+    %c100_i32 = arith.constant 100 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %cst = arith.constant 1.0 : f32
+    %empty = tensor.empty() : tensor<128xf32>
+    %alloc = memref.alloc() : memref<128xf32, #hivm.address_space<ub>>
+    scope.scope : () -> () {
+      // Transfer producer at block 11
+      %memspacecast = memref.memory_space_cast %alloc {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128xf32, #hivm.address_space<ub>> to memref<128xf32>
+      %depval = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128xf32>
+      %loop_result = scf.for %i = %c0_i32 to %c100_i32 step %c1_i32 iter_args(%arg = %depval) -> (tensor<128xf32>) : i32 {
+        %cond = arith.cmpi eq, %i, %c0_i32 : i32
+        // ifOp at block 18 with 2 results, inner ops at block 11
+        %if_result:2 = scf.if %cond -> (tensor<128xf32>, tensor<128xf32>) {
+          %consumed = arith.addf %arg, %arg {ssbuffer.block_id = 11 : i32} : tensor<128xf32>
+          scf.yield %consumed, %consumed : tensor<128xf32>, tensor<128xf32>
+        } else {
+          %other = arith.mulf %arg, %arg {ssbuffer.block_id = 11 : i32} : tensor<128xf32>
+          scf.yield %other, %other : tensor<128xf32>, tensor<128xf32>
+        } {ssbuffer.block_id = 18 : i32}
+        %next = arith.addf %if_result#0, %if_result#0 {ssbuffer.block_id = 11 : i32} : tensor<128xf32>
+        scf.yield %next : tensor<128xf32>
+      } {ssbuffer.main_loop = 1 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return
+  }
+
+//===--------------------------------------------------------------------===//
+// T30: memref.alloc in outer forOp, subview in nested forOp
+// Mirrors the wy_input.mlir structure:
+//   - outer forOp (block 8, main_loop = 0): wraps everything
+//   - inside: %alloc_8 at block 4, then inner forOp at block 4
+//   - inside inner forOp: %subview_17 at block 3 uses %alloc_8
+// getOutermostSsbufferId should treat subview_17's logical block as 4
+// (the inner forOp's block), so alloc_8 (block 4) -> subview_17 is same-block
+// and no dep_mark / no ssbuffer.skip should be emitted.
+//===--------------------------------------------------------------------===//
+// CHECK-LABEL: func.func @test_t30_forop_memref_alloc_nested
+// CHECK-NOT: ssbuffer.skip
+// CHECK-NOT: memref.alloc.*ssbuffer\.dep_mark
+// CHECK-NOT: memref.subview.*ssbuffer\.dep_mark
+  func.func @test_t30_forop_memref_alloc_nested() {
+    %c0_i32 = arith.constant 0 : i32
+    %c100_i32 = arith.constant 100 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c128 = arith.constant 128 : index
+    %c64 = arith.constant 64 : index
+    %c64_i32 = arith.constant 64 : i32
+    scope.scope : () -> () {
+      %36:3 = scf.for %arg19 = %c0_i32 to %c100_i32 step %c1_i32 iter_args(%arg20 = %c0_i32, %arg21 = %c0_i32, %arg22 = %c0_i32) -> (i32, i32, i32) : i32 {
+        // %alloc_8 at block 4 — outside inner forOp
+        %alloc_8 = memref.alloc() {ssbuffer.block_id = 4 : i32} : memref<128x64xf16>
+        // Inner forOp at block 4, no main_loop attribute
+        scf.for %arg23 = %c0 to %c128 step %c1 {
+          // %subview_17 at block 3 — uses %alloc_8
+          %subview_17 = memref.subview %alloc_8[%arg23, 0] [1, 64] [1, 1] {ssbuffer.block_id = 3 : i32} : memref<128x64xf16> to memref<1x64xf16, strided<[64, 1], offset: ?>>
+        } {ssbuffer.block_id = 4 : i32}
+        // %to_tensor at block 4 — also uses %alloc_8, same-block
+        %to_tensor = bufferization.to_tensor %alloc_8 restrict writable {ssbuffer.block_id = 4 : i32} : memref<128x64xf16>
+        scf.yield %arg20, %arg21, %arg22 : i32, i32, i32
+      } {ssbuffer.block_id = 8 : i32, ssbuffer.main_loop = 0 : i32}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return
+  }
+
+//===--------------------------------------------------------------------===//
+// T31: memref.alloc outside ifOp, subview inside ifOp
+// Same logical structure as T30 but with an ifOp in place of the inner forOp:
+//   - outer forOp (block 8, main_loop = 0): wraps everything
+//   - inside: %alloc_8 at block 4, then ifOp at block 4
+//   - inside ifOp: %subview_17 at block 3 uses %alloc_8
+// getOutermostSsbufferId should treat subview_17's logical block as 4
+// (the ifOp's block), so alloc_8 (block 4) -> subview_17 is same-block
+// and no dep_mark / no ssbuffer.skip should be emitted.
+//===--------------------------------------------------------------------===//
+// CHECK-LABEL: func.func @test_t31_ifop_memref_alloc_nested
+// CHECK-NOT: ssbuffer.skip
+// CHECK-NOT: memref.alloc.*ssbuffer\.dep_mark
+// CHECK-NOT: memref.subview.*ssbuffer\.dep_mark
+  func.func @test_t31_ifop_memref_alloc_nested() {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %c100_i32 = arith.constant 100 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c128 = arith.constant 128 : index
+    scope.scope : () -> () {
+      %36:3 = scf.for %arg19 = %c0_i32 to %c100_i32 step %c1_i32 iter_args(%arg20 = %c0_i32, %arg21 = %c0_i32, %arg22 = %c0_i32) -> (i32, i32, i32) : i32 {
+        // %alloc_8 at block 4 — outside the ifOp
+        %alloc_8 = memref.alloc() {ssbuffer.block_id = 4 : i32} : memref<128x64xf16>
+        // ifOp at block 4, condition is %true (always taken)
+        %if_result:2 = scf.if %true -> (memref<128x64xf16>, i32) {
+          // %subview_17 at block 3 — uses %alloc_8, inside ifOp
+          %subview_17 = memref.subview %alloc_8[%c0, 0] [1, 64] [1, 1] {ssbuffer.block_id = 3 : i32} : memref<128x64xf16> to memref<1x64xf16, strided<[64, 1], offset: ?>>
+          scf.yield %alloc_8, %arg22 : memref<128x64xf16>, i32
+        } else {
+          scf.yield %alloc_8, %arg22 : memref<128x64xf16>, i32
+        } {ssbuffer.block_id = 4 : i32}
+        // %to_tensor at block 4 — uses %alloc_8, same-block
+        %to_tensor = bufferization.to_tensor %alloc_8 restrict writable {ssbuffer.block_id = 4 : i32} : memref<128x64xf16>
+        scf.yield %arg20, %arg21, %arg22 : i32, i32, i32
+      } {ssbuffer.block_id = 8 : i32, ssbuffer.main_loop = 0 : i32}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return
+  }
+
+//===--------------------------------------------------------------------===//
+// T32: forOp with same block as producer - NO dep_mark
+// Same scenario as T27 but uses scf.for instead of scf.if.
+//   - producer addi at block 11, produces %compute
+//   - forOp at block 11 (SAME block as producer), inner muli at block 8
+//   - inner muli uses %compute
+// getOutermostSsbufferId walks up the parent chain and records each
+// non-main_loop forOp's block_id, so the inner muli's outermost id is
+// the enclosing forOp's block_id (11), matching the producer (11).
+// The cross-block dep judgment should treat them as same-block (11 vs 11),
+// so NO dep_mark should be added.
+// Key Check: NO dep_mark on producer or inner ops
+//===--------------------------------------------------------------------===//
+// CHECK-LABEL: func.func @test_t32_forop_same_block_no_dep_mark
+// CHECK-NOT: arith.addi {{.*}} ssbuffer.dep_mark
+// CHECK-NOT: arith.muli {{.*}} ssbuffer.dep_mark
+  func.func @test_t32_forop_same_block_no_dep_mark() {
+    %c0_i64 = arith.constant 0 : i64
+    %c100_i64 = arith.constant 100 : i64
+    %c10_i64 = arith.constant 10 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c0 = arith.constant 0 : index
+    scope.scope : () -> () {
+      %alloc = memref.alloc() : memref<1xi64>
+      %cast_alloc = memref.cast %alloc : memref<1xi64> to memref<1xi64, strided<[1], offset: ?>>
+      scf.for %i = %c0_i64 to %c100_i64 step %c1_i64 : i64 {
+        %load = memref.load %cast_alloc[%c0] {ssbuffer.block_id = 11 : i32} : memref<1xi64, strided<[1], offset: ?>>
+        %compute = arith.addi %load, %c1_i64 {ssbuffer.block_id = 11 : i32} : i64
+        // forOp at block 11 - SAME block as producer
+        %result = scf.for %j = %c0_i64 to %c10_i64 step %c1_i64 iter_args(%a = %c0_i64) -> (i64) : i64 {
+          %r1 = arith.muli %compute, %c1_i64 {ssbuffer.block_id = 8 : i32} : i64
+          scf.yield %r1 : i64
+        } {ssbuffer.block_id = 11 : i32}
+        memref.store %compute, %cast_alloc[%c0] {ssbuffer.block_id = 12 : i32} : memref<1xi64, strided<[1], offset: ?>>
+      } {ssbuffer.block_id = 26 : i32, ssbuffer.main_loop = 1 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return
+  }
+
+//===--------------------------------------------------------------------===//
+// T33: depVal used in BOTH then/else branches of scf.if - dominance fix
+// Test: A cross-block depVal inside the main_loop forOp (linalg.fill result,
+//       block 13) is consumed in BOTH the then and else branches of an
+//       scf.if (block 21). Both branches have ops with block_id 11 (then)
+//       and block_id 12 (else). getOutermostSsbufferId maps both to
+//       userBlockId=21 (the scf.if's own block_id).
+//       Without the per-region grouping fix, the pass inserts ONE buffer
+//       selection scf.if at the first op's position (e.g. then branch) and
+//       uses its result in BOTH branches, which breaks SSA dominance
+//       (else branch references a value defined in then branch).
+//       Fix: group opsInBlock by their containing Block; insert a separate
+//       buffer selection per region.
+// Key Check: TWO scf.if with intra_buffer (one in then, one in else)
+//         : each branch's use of the depVal is replaced with its own result
+//         : NO dominance verification error
+//===--------------------------------------------------------------------===//
+  // CHECK-LABEL: func.func @test_t33_ifop_both_branches_depval
+  // linalg.fill (depVal) at block 13 inside main_loop forOp
+  // CHECK: linalg.fill {ssbuffer.block_id = 13 : i32}
+  // The scf.if at block 21 (the user of the depVal)
+  // CHECK: scf.if
+  // BOTH branches must have a buffer selection scf.if (intra_buffer at block 21)
+  // CHECK-DAG: } {ssbuffer.block_id = 21 : i32, ssbuffer.intraDeps = [0 : i32, 0 : i32], ssbuffer.intra_buffer}
+  // CHECK-DAG: } {ssbuffer.block_id = 21 : i32, ssbuffer.intraDeps = [0 : i32, 0 : i32], ssbuffer.intra_buffer}
+  // CHECK-DAG: bufferization.to_tensor
+  // CHECK-DAG: bufferization.to_tensor
+  // Both consumer ops still present
+  // CHECK-DAG: arith.addf {{.*}} {ssbuffer.block_id = 11 : i32}
+  // CHECK-DAG: arith.addf {{.*}} {ssbuffer.block_id = 12 : i32}
+  func.func @test_t33_ifop_both_branches_depval() {
+    %c0_i32 = arith.constant 0 : i32
+    %c100_i32 = arith.constant 100 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %cst = arith.constant 1.0 : f32
+    %true = arith.constant true
+    %empty = tensor.empty() : tensor<32xf32>
+    scope.scope : () -> () {
+      scf.for %i = %c0_i32 to %c100_i32 step %c1_i32 : i32 {
+        // depVal: linalg.fill at block 13 - direct child of main_loop forOp
+        %filled = linalg.fill {ssbuffer.block_id = 13 : i32} ins(%cst : f32) outs(%empty : tensor<32xf32>) -> tensor<32xf32>
+        // scf.if at block 21 - uses %filled in BOTH then and else branches
+        %result = scf.if %true -> (tensor<32xf32>) {
+          // then branch - block 11
+          %r1 = arith.addf %filled, %filled {ssbuffer.block_id = 11 : i32} : tensor<32xf32>
+          scf.yield %r1 : tensor<32xf32>
+        } else {
+          // else branch - block 12
+          %r2 = arith.addf %filled, %filled {ssbuffer.block_id = 12 : i32} : tensor<32xf32>
+          scf.yield %r2 : tensor<32xf32>
+        } {ssbuffer.block_id = 21 : i32}
       } {ssbuffer.main_loop = 1 : i64}
       scope.return
     } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}


### PR DESCRIPTION
**Background:**
The pass originally used an operation's own `block_id` to determine cross-block dependencies. This caused incorrect behavior for multi-region operations such as `scf.if`: operations inside different regions could be mistakenly treated as belonging to the same block as their producers. As a result, tensors were allocated to the wrong memory level, leading to UB overflows and data corruption.

**Solution:**

**Core Fix**

* Introduced `getOutermostSsbufferId()` to compute an operation's **logical block_id**.
* Updated all cross-block dependency checks to use this logical block identifier instead of the operation's local `block_id`.

**Related Fixes**

* Added a secondary partitioning step based on `Block*` to preserve SSA correctness, since the outermost-block approach can group operations from different `then`/`else` regions under the same logical ID.
* Extended the yield-collection pass to capture dependencies inside `scf.if` regions.
* Added `DenseSet`-based deduplication to prevent duplicate `dep_mark` generation for multi-result operations.



<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
