### PR TITLE
fix(ssbuffer): parentOpHasMainLoopAttr only checked direct parent, missing scf.…

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
@@ -80,14 +80,14 @@ static bool forOpHasMainLoopAttr(scf::ForOp forOp)
     return terminator && terminator->hasAttr("ssbuffer.main_loop");
 }
 
-/// Check if a sync op's direct parent has ssbuffer.main_loop attribute
+/// Check if a sync op's ancestor chain contains a scf::ForOp with ssbuffer.main_loop attribute
 static bool parentOpHasMainLoopAttr(Operation *syncOp)
 {
     if (!syncOp) { return false; }
-    Operation *parent = syncOp->getParentOp();
-    if (!parent) { return false; }
-    if (auto forOp = dyn_cast<scf::ForOp>(parent)) {
-        return forOpHasMainLoopAttr(forOp);
+    for (Operation *parent = syncOp->getParentOp(); parent; parent = parent->getParentOp()) {
+        if (auto forOp = dyn_cast<scf::ForOp>(parent)) {
+            return forOpHasMainLoopAttr(forOp);
+        }
     }
     return false;
 }


### PR DESCRIPTION
…if-wrapped sync ops

Problem: crossDeps tags were completely missing when sync ops (sync_block_set/wait) are nested inside scf.if blocks within an scf.for marked with ssbuffer.main_loop. The outer scope pass collected transfer groups but filtered them all out because collectTransferChains couldn't find any transfer ops with main_loop.

Root cause: parentOpHasMainLoopAttr only checked the immediate parent operation. When a sync op was wrapped in scf.if inside scf.for, the direct parent was scf.if, not scf.for, so the main_loop attribute on the enclosing scf.for was invisible.

Fix: walk up the full ancestor chain to find the nearest scf::ForOp with ssbuffer.main_loop attribute, instead of only checking the direct parent.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
