### PR TITLE
[ssbuffer](fix) fix cases where alloc is initialized in RegionBranchOp

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -74,9 +74,16 @@ int getAvailableBlockId(ModuleOp module);
 void setFallbackAttr(ModuleOp module);
 bool isScfOp(Operation *op);
 
-inline bool isCubeOp(Operation *op)
+CoreType getCoreTypeOfSimpleOpOrCf(Operation *op);
+
+inline bool isCubeSimpleOpOrCf(Operation *op)
 {
-    return !isScfOp(op) && CVPipeline::getOpCoreType(op) == CoreType::CUBE_ONLY;
+    return getCoreTypeOfSimpleOpOrCf(op) == CoreType::CUBE_ONLY;
+}
+
+inline bool isVectorSimpleOpOrCf(Operation *op)
+{
+    return getCoreTypeOfSimpleOpOrCf(op) == CoreType::VECTOR_ONLY;
 }
 
 bool isVectorOnlyOp(Operation *op);

--- a/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h
+++ b/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h
@@ -23,20 +23,56 @@
 #ifndef TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_PLAN_COMPUTE_BLOCK_COMMON_H
 #define TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_PLAN_COMPUTE_BLOCK_COMMON_H
 
-#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
-#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
-#include "DynamicCVPipeline/Common/Utils.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
+
 #include "mlir/IR/Block.h"
 #include "mlir/IR/Operation.h"
-#include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/SmallVector.h"
+
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
 
 namespace mlir {
 namespace CVPipeline {
 
+class DependencyHelper {
+    using PredFn = llvm::function_ref<void(Operation *)>;
+
+    template <typename Fn> static auto mapToAncestorInBlock(Block *block, Fn &&pred)
+    {
+        return [block, pred = std::forward<Fn>(pred)](Operation *op) {
+            if (auto *ancestor = block->findAncestorOpInBlock(*op)) {
+                return pred(ancestor);
+            }
+        };
+    }
+
+  public:
+    const MemoryDependenceGraph &memGraph;
+
+    explicit DependencyHelper(const MemoryDependenceGraph &memGraph) : memGraph(memGraph) {}
+
+    void forEachUser(Operation *op, PredFn pred) const;
+
+    template <bool AcrossIterArg> void forEachSource(Operation *op, PredFn pred) const;
+
+    void forEachUserInSameBlock(Operation *op, PredFn pred) const
+    {
+        forEachUser(op, mapToAncestorInBlock(op->getBlock(), pred));
+    }
+
+    template <bool AcrossIterArg> void forEachSourceInSameBlock(Operation *op, PredFn pred) const
+    {
+        forEachSource<AcrossIterArg>(op, mapToAncestorInBlock(op->getBlock(), pred));
+    }
+};
+
 Operation *getAncestorInBlock(Operation *inner, Block *block);
-void initializeIndegreeForBlock(Block *block, llvm::DenseMap<Operation *, int> &indegree,
-                                const MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm);
+void initializeIndegreeForBlock(Block *block,
+                                llvm::DenseMap<Operation *, int> &indegree,
+                                const DependencyHelper &depHelper,
+                                ComputeBlockIdManager &bm);
 
 } // namespace CVPipeline
 } // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -1,6 +1,8 @@
 #include <optional>
 
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/Debug.h"
 #include "llvm/Support/LogicalResult.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -10,8 +12,16 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/Visitors.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+
+static constexpr const char *DEBUG_TYPE = "DynamicCVPipeline/Utils";
+#define DBGS(...) LLVM_DEBUG(llvm::dbgs() << __VA_ARGS__)
+#define LOG_DEBUG(...) DBGS("\n[" << DEBUG_TYPE << "] " << __VA_ARGS__)
+
 namespace mlir {
 namespace CVPipeline {
 
@@ -102,6 +112,54 @@ bool isVectorOnlyOp(Operation *op)
 bool isScfOp(Operation *op)
 {
   return llvm::isa<scf::SCFDialect>(op->getDialect());
+}
+
+CoreType getCoreTypeOfSimpleOpOrCf(Operation *op)
+{
+    if (op == nullptr) {
+        return CoreType::UNDETERMINED;
+    }
+    if (!llvm::isa<RegionBranchOpInterface>(op)) {
+        return getOpCoreType(op);
+    }
+
+    CoreType coreType = CoreType::UNDETERMINED;
+    Operation *failingOp = nullptr;
+
+    // we need to skip sub-op of non-cf ops with regions, hence preorder here
+    op->walk<WalkOrder::PreOrder>([&](Operation *subOp) -> WalkResult {
+        if (llvm::isa<RegionBranchOpInterface>(subOp) || subOp->hasTrait<OpTrait::IsTerminator>()) {
+            return WalkResult::advance();
+        }
+
+        CoreType curr = getOpCoreType(subOp);
+        // we have met a simple op without core type
+        if (curr == CoreType::UNDETERMINED) {
+            coreType = CoreType::UNDETERMINED;
+            failingOp = subOp;
+            return WalkResult::interrupt();
+        }
+
+        if (coreType == CoreType::UNDETERMINED) {
+            coreType = curr;
+        } else if (curr != coreType) {
+            // some ops have different core type
+            coreType = CoreType::UNDETERMINED;
+            failingOp = subOp;
+            return WalkResult::interrupt();
+        }
+
+        // skip sub-op
+        return WalkResult::skip();
+    });
+
+    LOG_DEBUG("CoreType of RegionBranchOp is " << coreType << ": " << *op);
+    LLVM_DEBUG({
+        if (coreType == CoreType::UNDETERMINED && failingOp != nullptr) {
+            llvm::dbgs() << "\nCoreType is UNDETERMINED due to " << *failingOp;
+        }
+    });
+    return coreType;
 }
 
 } // namespace CVPipeline

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/Common.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/Common.cpp
@@ -19,37 +19,82 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
- 
+
+#include "llvm/ADT/iterator.h"
+#include "llvm/Support/Casting.h"
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Value.h"
+
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
+
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
 #include "DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
 
 namespace mlir {
 namespace CVPipeline {
 
-void initializeIndegreeForBlock(Block *block, llvm::DenseMap<Operation *, int> &indegree,
-                                const MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
+void DependencyHelper::forEachUser(Operation *op, DependencyHelper::PredFn pred) const
 {
+    for (auto *user : op->getUsers()) {
+        pred(user);
+    }
+    for (auto *user : memGraph.getExecAfter(op)) {
+        pred(user);
+    }
+}
 
-    block->walk([&](Operation *op) {
-        if (op->getBlock() != block) { return; }
-        indegree[op] = 0;
-        // We need to consider op itself && op's region-contained ops.
-        op->walk([&](Operation *nestedOp) {
-            for (auto inValue : nestedOp->getOperands()) {
-                if (auto defOp = inValue.getDefiningOp()) {
-                    if (defOp->getBlock() == block && !bm.isSameBlock(defOp, op)) {
-                        indegree[op]++;
-                    }
-                }
+template <bool AcrossIterArg> void DependencyHelper::forEachSource(Operation *op, DependencyHelper::PredFn pred) const
+{
+    auto forOp = llvm::dyn_cast_if_present<scf::ForOp>(op->getBlock()->getParentOp());
+    op->walk([&, this](Operation *subOp) {
+        for (auto operand : subOp->getOperands()) {
+            if (auto *defOp = operand.getDefiningOp()) {
+                pred(defOp);
+                continue;
             }
 
-            for (auto memDepUser : memGraph.getExecBefore(nestedOp)) {
-                if (memDepUser->getBlock() == block && !bm.isSameBlock(memDepUser, op)) {
-                    indegree[op]++;
+            if constexpr (AcrossIterArg) {
+                if (!forOp) {
+                    continue;
                 }
+                auto blockArg = llvm::dyn_cast<BlockArgument>(operand);
+                auto *yieldedVal = forOp.getTiedLoopYieldedValue(blockArg);
+                // this also ensures blockArg.getOwner() == op->getBlock()
+                if (!yieldedVal) {
+                    continue;
+                }
+                if (auto *defOp = yieldedVal->get().getDefiningOp()) {
+                    pred(defOp);
+                }
+            }
+        }
+        for (auto *source : memGraph.getExecBefore(subOp)) {
+            pred(source);
+        }
+    });
+}
+
+// Instantiate concrete functions for linking
+template void mlir::CVPipeline::DependencyHelper::forEachSource<true>(
+    mlir::Operation *op, llvm::function_ref<void(mlir::Operation *)> callback) const;
+
+template void mlir::CVPipeline::DependencyHelper::forEachSource<false>(
+    mlir::Operation *op, llvm::function_ref<void(mlir::Operation *)> callback) const;
+
+void initializeIndegreeForBlock(Block *block,
+                                llvm::DenseMap<Operation *, int> &indegree,
+                                const DependencyHelper &depHelper,
+                                ComputeBlockIdManager &bm)
+{
+    for (auto *op : llvm::make_pointer_range(block->getOperations())) {
+        indegree[op] = 0;
+        depHelper.forEachSource<false>(op, [&](Operation *source) {
+            if (source->getBlock() == block && !bm.isSameBlock(source, op)) {
+                indegree[op]++;
             }
         });
-    });
+    }
 }
 
 Operation *getAncestorInBlock(Operation *inner, Block *block)

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
@@ -163,8 +163,9 @@ bool DependencyCycleDetector::detectCycle()
     llvm::DenseSet<Operation *> externalUsers;
     for (auto *op : group) {
         forEachUser(op, memGraph, [&](Operation *user) {
-            if (!group.contains(user)) {
-                externalUsers.insert(user);
+            auto *userInBlock = getAncestorInBlock(user, block);
+            if (userInBlock && !group.contains(userInBlock)) {
+                externalUsers.insert(userInBlock);
             }
         });
     }

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
@@ -68,7 +68,7 @@ namespace {
 class SeedRegionPlanner {
     Operation *seed;
     Block *block;
-    const MemoryDependenceGraph &memGraph;
+    const DependencyHelper &depHelper;
     ComputeBlockIdManager &bm;
     llvm::DenseSet<Operation *> &assigned;
     llvm::SmallVectorImpl<Operation *> &group;
@@ -79,16 +79,16 @@ class SeedRegionPlanner {
     void addUsersToGroup();
 
 public:
-    SeedRegionPlanner(Operation *seed,
-                      Block *block,
-                      const MemoryDependenceGraph &memGraph,
-                      llvm::DenseSet<Operation *> &assigned,
-                      llvm::SmallVectorImpl<Operation *> &group,
-                      ComputeBlockIdManager &bm)
-        : seed(seed), block(block), memGraph(memGraph), assigned(assigned), group(group), bm(bm)
-    {
-        group.push_back(seed);
-    }
+  SeedRegionPlanner(Operation *seed,
+                    Block *block,
+                    const DependencyHelper &depHelper,
+                    llvm::DenseSet<Operation *> &assigned,
+                    llvm::SmallVectorImpl<Operation *> &group,
+                    ComputeBlockIdManager &bm)
+      : seed(seed), block(block), depHelper(depHelper), assigned(assigned), group(group), bm(bm)
+  {
+      group.push_back(seed);
+  }
 
     void run();
 };
@@ -101,7 +101,7 @@ namespace {
 class DependencyCycleDetector {
     const llvm::DenseSet<mlir::Operation *> &group;
     llvm::DenseSet<mlir::Operation *> visited;
-    const MemoryDependenceGraph &memGraph;
+    const DependencyHelper &depHelper;
     ComputeBlockIdManager &bm;
     Block *const block;
 
@@ -109,10 +109,10 @@ class DependencyCycleDetector {
 
   public:
     DependencyCycleDetector(Block *block,
-                            const MemoryDependenceGraph &memGraph,
+                            const DependencyHelper &depHelper,
                             llvm::DenseSet<mlir::Operation *> &group,
                             ComputeBlockIdManager &bm)
-        : block(block), memGraph(memGraph), group(group), bm(bm)
+        : block(block), depHelper(depHelper), group(group), bm(bm)
     {}
 
     bool detectCycle();
@@ -129,43 +129,30 @@ bool DependencyCycleDetector::detectCycleFrom(Operation *cur)
         return false;
     }
 
-    auto userCreatesCycle = [this, cur](Operation *user) {
-        auto *userInBlock = getAncestorInBlock(user, block);
-        if (!userInBlock) {
-            return false;
-        }
-        auto userBlockId = bm.getBlockIdByOp(userInBlock);
+    bool createsCycle = false;
+
+    depHelper.forEachUserInSameBlock(cur, [&](Operation *user) {
+        auto userBlockId = bm.getBlockIdByOp(user);
         if (userBlockId == -1) {
-            return detectCycleFrom(userInBlock);
+            createsCycle = createsCycle || detectCycleFrom(user);
+            return;
         }
 
-        return llvm::any_of(bm.getOpsByBlockId(userBlockId), [this](Operation *user) { return detectCycleFrom(user); });
-    };
+        createsCycle = createsCycle || llvm::any_of(bm.getOpsByBlockId(userBlockId),
+                                                    [this](Operation *user) { return detectCycleFrom(user); });
+        return;
+    });
 
-    return llvm::any_of(cur->getUsers(), userCreatesCycle) ||
-           llvm::any_of(memGraph.getExecAfter(cur), userCreatesCycle);
-}
-
-static void forEachUser(Operation *op,
-                        const MemoryDependenceGraph &memGraph,
-                        const std::function<void(Operation *op)> &pred)
-{
-    for (auto *user : op->getUsers()) {
-        pred(user);
-    }
-    for (auto *user : memGraph.getExecAfter(op)) {
-        pred(user);
-    }
+    return createsCycle;
 }
 
 bool DependencyCycleDetector::detectCycle()
 {
     llvm::DenseSet<Operation *> externalUsers;
     for (auto *op : group) {
-        forEachUser(op, memGraph, [&](Operation *user) {
-            auto *userInBlock = getAncestorInBlock(user, block);
-            if (userInBlock && !group.contains(userInBlock)) {
-                externalUsers.insert(userInBlock);
+        depHelper.forEachUserInSameBlock(op, [&](Operation *user) {
+            if (!group.contains(user)) {
+                externalUsers.insert(user);
             }
         });
     }
@@ -178,7 +165,7 @@ bool SeedRegionPlanner::willCreateCycle(Operation *op)
     llvm::DenseSet<mlir::Operation *> okSet(group.begin(), group.end());
     okSet.insert(op);
 
-    DependencyCycleDetector dfs = {block, memGraph, okSet, bm};
+    DependencyCycleDetector dfs = {block, depHelper, okSet, bm};
     return dfs.detectCycle();
 }
 
@@ -189,7 +176,7 @@ bool SeedRegionPlanner::willCreateCycle(Operation *op)
  */
 bool SeedRegionPlanner::isEligible(Operation *op)
 {
-    if (!isCubeOp(op) || assigned.contains(op) || isMatmulOp(op)) {
+    if (!isCubeSimpleOpOrCf(op) || assigned.contains(op) || isMatmulOp(op)) {
         return false;
     }
     return !willCreateCycle(op);
@@ -209,54 +196,23 @@ void SeedRegionPlanner::addSourcesToGroup()
     size_t head = 0;
     while (head < group.size()) {
         Operation *currOp = group[head++];
-
-        // Check data operands
-        for (Value iop : currOp->getOperands()) {
-            if (auto *def = iop.getDefiningOp()) {
-                tryAddToGroup(def);
-            }
-            // Check loop-carried dependencies (SCF ForOp iter_args)
-            if (auto barg = dyn_cast<BlockArgument>(iop)) {
-                if (barg.getOwner() == block && isa<scf::ForOp>(block->getParentOp()) && barg.getArgNumber() > 0) {
-                    auto *yieldOp = barg.getOwner()->getTerminator();
-                    if (auto *yieldedValDef = yieldOp->getOperand(barg.getArgNumber() - 1).getDefiningOp()) {
-                        tryAddToGroup(yieldedValDef);
-                    }
-                }
-            }
-        }
-
-        // Check memory dependencies (RAW/WAW/WAR)
-        for (auto *def : memGraph.getMemDefs(currOp)) {
-            tryAddToGroup(def);
-        }
+        depHelper.forEachSource<false>(currOp, [this](Operation *source) { tryAddToGroup(source); });
     }
 }
 
 void SeedRegionPlanner::addUsersToGroup()
 {
-    llvm::SmallVector<Operation *> queue {seed};
+    llvm::SmallVector<Operation *> stack {seed};
     llvm::DenseSet<Operation *> forwardVisited;
     forwardVisited.insert(seed);
 
-    unsigned qIdx = 0;
-    while (qIdx < queue.size()) {
-        Operation *currOp = queue[qIdx++];
-        SmallVector<Operation *> allUsers;
-        for (auto *u : currOp->getUsers()) {
-            allUsers.push_back(u);
-        }
-
-        for (auto *u : memGraph.getMemUsers(currOp)) {
-            allUsers.push_back(u);
-        }
-
-        for (auto *userOp : allUsers) {
-            auto *userInBlock = getAncestorInBlock(userOp, block);
-            if (tryAddToGroup(userInBlock)) {
-                queue.push_back(userInBlock);
+    while (!stack.empty()) {
+        Operation *currOp = stack.pop_back_val();
+        depHelper.forEachUserInSameBlock(currOp, [&](Operation *user) {
+            if (tryAddToGroup(user)) {
+                stack.push_back(user);
             }
-        }
+        });
     }
 }
 
@@ -280,7 +236,7 @@ class TopologicalPartitionPlanner {
     unsigned nonAssignedCubeCnt = 0;
     llvm::DenseMap<Operation *, int> indegree;
     llvm::DenseSet<Operation *> &assigned;
-    const MemoryDependenceGraph &memGraph;
+    const DependencyHelper &depHelper;
     ComputeBlockIdManager &bm;
     llvm::DenseSet<Operation *> newassigned;
     llvm::DenseSet<Operation *> bypassVisited;
@@ -288,27 +244,28 @@ class TopologicalPartitionPlanner {
 
     void removeNonCubeOpsRecursively(Operation *op);
     llvm::LogicalResult removeReadyNonCubeOps();
-    bool shouldSkip(Operation *op) { return !isCubeOp(op) || assigned.contains(op); };
+
+    bool shouldSkip(Operation *op) { return !isCubeSimpleOpOrCf(op) || assigned.contains(op); };
     bool canExpandTo(Operation *op);
     void dumpQueueAndIndegreeInfo();
     llvm::LogicalResult populateQueueWithReadyOps();
     llvm::SmallVector<Operation *> createNewGroupFromQueue();
 
-public:
+  public:
     TopologicalPartitionPlanner(Block *block,
                                 llvm::DenseSet<Operation *> &assigned,
-                                const MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
-        : block(block), assigned(assigned), memGraph(memGraph), bm(bm)
+                                const DependencyHelper &depHelper,
+                                ComputeBlockIdManager &bm)
+        : block(block), assigned(assigned), depHelper(depHelper), bm(bm)
     {
-        initializeIndegreeForBlock(block, indegree, memGraph, bm);
+        initializeIndegreeForBlock(block, indegree, depHelper, bm);
 
         block->walk([&](Operation *op) {
-            if (op->getBlock() == block && isCubeOp(op) && !assigned.contains(op)) {
+            if (op->getBlock() == block && isCubeSimpleOpOrCf(op) && !assigned.contains(op)) {
                 nonAssignedCubeCnt++;
             }
         });
     }
-
     llvm::LogicalResult run();
 };
 
@@ -319,46 +276,25 @@ void TopologicalPartitionPlanner::removeNonCubeOpsRecursively(Operation *op)
 {
     LOG_DEBUG("\tRemoved non-cube:" << *op << "\n");
     bypassVisited.insert(op);
-    auto *block = op->getBlock();
-    SmallVector<Operation *> allusers;
-    allusers.append(op->getUsers().begin(), op->getUsers().end());
-    for (auto *memUser : memGraph.getExecAfter(op)) {
-        allusers.push_back(memUser);
-    }
-    for (auto *user : allusers) {
-        auto *userInBlock = getAncestorInBlock(user, block);
-        if (!userInBlock || !indegree.contains(userInBlock) ||
-            bm.isSameBlock(userInBlock, op)) {
-            continue;
+    depHelper.forEachUserInSameBlock(op, [&](Operation *user) {
+        if (!indegree.contains(user) || bm.isSameBlock(user, op)) {
+            return;
         }
-        LOG_DEBUG("Sub indegree to " << *userInBlock << " from " << *op << "new degree =  " << indegree[userInBlock] - 1
-                                     << "\n");
-        indegree[userInBlock]--;
-        if (!bm.isWholeCubeReady(userInBlock, indegree) || bypassVisited.contains(userInBlock) ||
-            !shouldSkip(userInBlock)) {
-            continue;
+        LOG_DEBUG("Sub indegree to " << *user << " from " << *op << "new degree =  " << indegree[user] - 1 << "\n");
+        indegree[user]--;
+        if (!bm.isWholeCubeReady(user, indegree) || bypassVisited.contains(user) || !shouldSkip(user)) {
+            return;
         }
-        auto blockId = bm.getBlockIdByOp(userInBlock);
+        auto blockId = bm.getBlockIdByOp(user);
         if (blockId == -1) {
-            removeNonCubeOpsRecursively(userInBlock);
-            continue;
+            removeNonCubeOpsRecursively(user);
+            return;
         }
         for (auto *passop : bm.getOpsByBlockId(blockId)) {
             if (!bypassVisited.contains(passop)) {
                 removeNonCubeOpsRecursively(passop);
             }
         }
-    }
-}
-
-static bool mapsAreDiff(const llvm::DenseMap<Operation *, int> &a, const llvm::DenseMap<Operation *, int> &b)
-{
-    if (a.size() != b.size()) {
-        return true;
-    }
-    return llvm::any_of(a, [&b](std::pair<Operation *, int> aIter) {
-        auto bIter = b.find(aIter.first);
-        return bIter == b.end() || bIter->second != aIter.second;
     });
 }
 
@@ -385,7 +321,7 @@ llvm::LogicalResult TopologicalPartitionPlanner::removeReadyNonCubeOps()
             }
         }
     }
-    if (!mapsAreDiff(indegreeBefore, indegree) && beforeVisitedSize == bypassVisited.size()) {
+    if (indegreeBefore == indegree && beforeVisitedSize == bypassVisited.size()) {
         if (Operation *parentOp = block->getParentOp()) {
             parentOp->emitError("PlanCubeBlock cannot make progress while scheduling cube operations");
         }
@@ -398,7 +334,7 @@ llvm::LogicalResult TopologicalPartitionPlanner::removeReadyNonCubeOps()
 // Expansion condition: op must be CUBE_ONLY, indegree == 0 and all its dependency ops are CUBE_ONLY
 bool TopologicalPartitionPlanner::canExpandTo(Operation *op)
 {
-    if (!isCubeOp(op) || assigned.contains(op)) {
+    if (!isCubeSimpleOpOrCf(op) || assigned.contains(op)) {
         return false;
     }
     auto it = indegree.find(op);
@@ -432,7 +368,7 @@ void TopologicalPartitionPlanner::dumpQueueAndIndegreeInfo()
     bool foundRemainingCube = false;
     for (auto &p : indegree) {
         Operation *op = p.first;
-        if (!op || op->getBlock() != block || !CVPipeline::isCubeOp(op) || assigned.contains(op) ||
+        if (!op || op->getBlock() != block || !isCubeSimpleOpOrCf(op) || assigned.contains(op) ||
             newassigned.contains(op)) {
             continue;
         }
@@ -451,7 +387,7 @@ llvm::LogicalResult TopologicalPartitionPlanner::populateQueueWithReadyOps()
             op->emitError("Indegree cannot be negative");
             return llvm::failure();
         }
-        if (indegree == 0 && !newassigned.contains(op) && isCubeOp(op) && !assigned.contains(op)) {
+        if (indegree == 0 && !newassigned.contains(op) && isCubeSimpleOpOrCf(op) && !assigned.contains(op)) {
             queue.push(op);
         }
     }
@@ -469,23 +405,17 @@ llvm::SmallVector<Operation *> TopologicalPartitionPlanner::createNewGroupFromQu
         group.push_back(currOp);
         nonAssignedCubeCnt--;
 
-        llvm::SmallVector<Operation *> allUsers;
-        for (auto *user : currOp->getUsers())
-          allUsers.push_back(user);
-        for (auto *user : memGraph.getExecAfter(currOp))
-          allUsers.push_back(user);
-        for (auto *user : allUsers) {
-            auto *userInBlock = getAncestorInBlock(user, block);
-            if (userInBlock && !newassigned.contains(userInBlock)) {
-                auto &userInDegree = indegree[userInBlock];
+        depHelper.forEachUserInSameBlock(currOp, [&](Operation *user) {
+            if (!newassigned.contains(user)) {
+                auto &userInDegree = indegree[user];
                 userInDegree--;
-                LOG_DEBUG("Sub indegree to " << *userInBlock << " from " << *currOp << "new degree = " << userInDegree
+                LOG_DEBUG("Sub indegree to " << *user << " from " << *currOp << "new degree = " << userInDegree
                                              << "\n");
-                if (canExpandTo(userInBlock)) {
-                    queue.push(userInBlock);
+                if (canExpandTo(user)) {
+                    queue.push(user);
                 }
             }
-        }
+        });
     }
     return group;
 }
@@ -524,7 +454,7 @@ static SmallVector<Operation *> collectMatmulOps(Block *block)
     return computeOps;
 }
 
-static void fuseMarkOpToDef(Block *block, ComputeBlockIdManager &bm, const MemoryDependenceGraph &memGraph)
+static void fuseMarkOpToDef(Block *block, ComputeBlockIdManager &bm, const DependencyHelper &depHelper)
 {
     for (auto *op : llvm::make_pointer_range(block->getOperations())) {
         if (getOpCoreType(op) != CUBE_ONLY) {
@@ -552,7 +482,7 @@ static void fuseMarkOpToDef(Block *block, ComputeBlockIdManager &bm, const Memor
         }
         newGroup.insert(markOp);
 
-        DependencyCycleDetector dfs {block, memGraph, newGroup, bm};
+        DependencyCycleDetector dfs {block, depHelper, newGroup, bm};
         if (!dfs.detectCycle()) {
             bm.updateBlockId(markOp, defBlockId);
         }
@@ -563,7 +493,9 @@ static void fuseMarkOpToDef(Block *block, ComputeBlockIdManager &bm, const Memor
  * Main entry point: Process a single block by grouping operations into
  * execution blocks using BFS and topological traversal.
  */
-static llvm::LogicalResult processBlockWithCubeBFS(Block *block, const MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
+static llvm::LogicalResult processBlockWithCubeBFS(Block *block,
+                                                   const DependencyHelper &depHelper,
+                                                   ComputeBlockIdManager &bm)
 {
     llvm::DenseSet<Operation *> assigned;
     auto allDots = collectMatmulOps(block);
@@ -575,7 +507,7 @@ static llvm::LogicalResult processBlockWithCubeBFS(Block *block, const MemoryDep
         }
 
         llvm::SmallVector<Operation *> newGroup;
-        SeedRegionPlanner regionPlanner {dot, block, memGraph, assigned, newGroup, bm};
+        SeedRegionPlanner regionPlanner {dot, block, depHelper, assigned, newGroup, bm};
         regionPlanner.run();
 
         for (auto *op : newGroup) {
@@ -587,11 +519,11 @@ static llvm::LogicalResult processBlockWithCubeBFS(Block *block, const MemoryDep
     }
 
     // Phase 2: Handle remaining Cube Ops following Topo order
-    TopologicalPartitionPlanner topoPlanner {block, assigned, memGraph, bm};
+    TopologicalPartitionPlanner topoPlanner {block, assigned, depHelper, bm};
     if (failed(topoPlanner.run())) {
         return failure();
     }
-    fuseMarkOpToDef(block, bm, memGraph);
+    fuseMarkOpToDef(block, bm, depHelper);
     return llvm::success();
 }
 
@@ -600,15 +532,16 @@ void mlir::triton::PlanCubeBlockPass::runOnOperation()
     LOG_DEBUG("\n--- Step 2: Partitioning compute blocks for cube operations --->\n");
     auto moduleOp = getOperation();
     auto &aa = getAnalysis<AliasAnalysis>();
-    auto memGraph = MemoryDependenceGraph(moduleOp, aa);
+    MemoryDependenceGraph memGraph {moduleOp, aa};
+    DependencyHelper depHelper {memGraph};
     auto bm = ComputeBlockIdManager(moduleOp);
 
     // We do not need to skip linalg blocks since they do not have core types and do not contain matmul
     auto result = moduleOp.walk([&](Block *block) {
-      if (llvm::failed(processBlockWithCubeBFS(block, memGraph, bm))) {
-        return WalkResult::interrupt();
-      }
-      return WalkResult::advance();
+        if (llvm::failed(processBlockWithCubeBFS(block, depHelper, bm))) {
+            return WalkResult::interrupt();
+        }
+        return WalkResult::advance();
     });
     if (result.wasInterrupted()) {
       signalPassFailure();

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <algorithm>
 #include <memory>
 #include "DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
@@ -28,14 +27,12 @@
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Passes.h"
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "mlir/Analysis/AliasAnalysis.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Block.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SetVector.h"
-#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
@@ -49,28 +46,10 @@ using namespace mlir;
 using namespace triton;
 using namespace CVPipeline;
 
-namespace mlir {
-namespace triton {
-class PlanVectorBlockPass : public PassWrapper<PlanVectorBlockPass, OperationPass<ModuleOp>> {
-public:
-    MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PlanVectorBlockPass)
-
-    PlanVectorBlockPass() = default;
-    void runOnOperation() override;
-
-    llvm::StringRef getArgument() const final
-    {
-      return "plan-vector-block";
-    }
-};
-
-bool isFusableOp(Operation *op)
+static bool isFusableOp(Operation *op)
 {
-    if (CVPipeline::getOpCoreType(op) == CVPipeline::CoreType::VECTOR_ONLY) {
-        if (isa<RegionBranchOpInterface>(op)) {
-            // pass control ops like scf::ForOp/scf::IfOp/scf::WhileOp
-            return false;
-        }
+    if (isVectorSimpleOpOrCf(op)) {
+        // skip terminators
         if (op->getBlock()->mightHaveTerminator() && op == op->getBlock()->getTerminator()) {
             return false;
         }
@@ -79,51 +58,49 @@ bool isFusableOp(Operation *op)
     return false;
 }
 
-void passAndCollectCandidates(Operation *nowOp, DenseMap<Operation *, int> &indegree,
-                              SmallVector<Operation *> &candidates, DenseMap<Operation *, bool> &visited,
-                              const CVPipeline::MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
+static void passAndCollectCandidates(Operation *nowOp,
+                                     DenseMap<Operation *, int> &indegree,
+                                     SmallVector<Operation *> &candidates,
+                                     DenseMap<Operation *, bool> &visited,
+                                     const CVPipeline::MemoryDependenceGraph &memGraph,
+                                     ComputeBlockIdManager &bm)
 {
     LOG_DEBUG("Bypassing non-fusable op " << *nowOp << "\nnow candidates size: " << candidates.size() << "\n");
-    auto block = nowOp->getBlock();
-    SmallVector<Operation *> allusers;
-    allusers.append(nowOp->getUsers().begin(), nowOp->getUsers().end());
-    for (auto memUser : memGraph.getExecAfter(nowOp)) {
-        allusers.push_back(memUser);
-    }
-    for (auto user : allusers) {
-        auto userInBlock = CVPipeline::getAncestorInBlock(user, block);
-        if (!userInBlock) {
-            continue;
-        }
-        if (!bm.isSameBlock(userInBlock, nowOp)) {
-            indegree[userInBlock]--;
+    DependencyHelper depHelper {memGraph};
+    depHelper.forEachUserInSameBlock(nowOp, [&](Operation *user) {
+        if (!bm.isSameBlock(user, nowOp)) {
+            indegree[user]--;
         }
 
-        if (bm.isWholeCubeReady(userInBlock, indegree)) {
-            if (!isFusableOp(userInBlock) && !visited[userInBlock]) {
-                if (bm.getBlockIdByOp(userInBlock) == -1) {
-                    visited[userInBlock] = true; // mark as fused to avoid duplicate bypass
-                    passAndCollectCandidates(userInBlock, indegree, candidates, visited, memGraph, bm);
-                } else {
-                    for (auto cubeop : bm.getOpsByBlockId(bm.getBlockIdByOp(userInBlock))) {
-                        if (!visited[cubeop]) {
-                            visited[cubeop] = true;
-                            passAndCollectCandidates(cubeop, indegree, candidates, visited, memGraph, bm);
-                        }
+        if (!bm.isWholeCubeReady(user, indegree)) {
+            return;
+        }
+        if (!isFusableOp(user) && !visited[user]) {
+            if (bm.getBlockIdByOp(user) == -1) {
+                visited[user] = true; // mark as fused to avoid duplicate bypass
+                passAndCollectCandidates(user, indegree, candidates, visited, memGraph, bm);
+            } else {
+                for (auto cubeop : bm.getOpsByBlockId(bm.getBlockIdByOp(user))) {
+                    if (!visited[cubeop]) {
+                        visited[cubeop] = true;
+                        passAndCollectCandidates(cubeop, indegree, candidates, visited, memGraph, bm);
                     }
                 }
-            } else if (isFusableOp(userInBlock) && !visited[userInBlock]) {
-                visited[userInBlock] = true;
-                candidates.push_back(userInBlock);
             }
+        } else if (isFusableOp(user) && !visited[user]) {
+            visited[user] = true;
+            candidates.push_back(user);
         }
-    }
+    });
 
     LOG_DEBUG("After bypassing, candidates size: " << candidates.size() << "\n");
 }
 
-void byPassNonFusable(DenseMap<Operation *, int> &indegree, SmallVector<Operation *> &candidates,
-                      DenseMap<Operation *, bool> &visited, const CVPipeline::MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
+static void byPassNonFusable(DenseMap<Operation *, int> &indegree,
+                             SmallVector<Operation *> &candidates,
+                             DenseMap<Operation *, bool> &visited,
+                             const CVPipeline::MemoryDependenceGraph &memGraph,
+                             ComputeBlockIdManager &bm)
 {
     // for every non-fusable candidates, bypass it.
     for (auto &[op, degree] : indegree) {
@@ -143,8 +120,11 @@ void byPassNonFusable(DenseMap<Operation *, int> &indegree, SmallVector<Operatio
     }
 }
 
-void updateCandidates(Operation *nextFused, SmallVector<Operation *> &candidates, DenseMap<Operation *, int> &indegree,
-                      DenseMap<Operation *, bool> &visited, const CVPipeline::MemoryDependenceGraph &memGraph)
+static void updateCandidates(Operation *nextFused,
+                             SmallVector<Operation *> &candidates,
+                             DenseMap<Operation *, int> &indegree,
+                             DenseMap<Operation *, bool> &visited,
+                             const CVPipeline::MemoryDependenceGraph &memGraph)
 {
     // 1. Already fuse with nextFused, so remove it from candidates
     for (auto it = candidates.begin(); it != candidates.end(); it++) {
@@ -155,29 +135,23 @@ void updateCandidates(Operation *nextFused, SmallVector<Operation *> &candidates
     }
 
     // 2. Add new candidates whose indegree becomes 0 after fusing nextFused.
-    auto block = nextFused->getBlock();
-    SmallVector<Operation *> allusers;
-    allusers.append(nextFused->getUsers().begin(), nextFused->getUsers().end());
-    for (auto memUser : memGraph.getExecAfter(nextFused)) {
-        allusers.push_back(memUser);
-    }
-    for (auto user : allusers) {
-        auto userInBlock = CVPipeline::getAncestorInBlock(user, block);
-        if (!userInBlock) {
-            continue;
-        }
-        if (!visited[userInBlock]) {
-            indegree[userInBlock]--;
-            if (indegree[userInBlock] == 0 && isFusableOp(userInBlock)) {
-                visited[userInBlock] = true;
-                candidates.push_back(userInBlock);
+    DependencyHelper depHelper {memGraph};
+    depHelper.forEachUserInSameBlock(nextFused, [&](Operation *user) {
+        if (!visited[user]) {
+            indegree[user]--;
+            if (indegree[user] == 0 && isFusableOp(user)) {
+                visited[user] = true;
+                candidates.push_back(user);
             }
         }
-    }
+    });
 }
 
-void findCandidates(DenseMap<Operation *, int> &indegree, SmallVector<Operation *> &candidates,
-                    DenseMap<Operation *, bool> &visited, const CVPipeline::MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
+static void findCandidates(DenseMap<Operation *, int> &indegree,
+                           SmallVector<Operation *> &candidates,
+                           DenseMap<Operation *, bool> &visited,
+                           const CVPipeline::MemoryDependenceGraph &memGraph,
+                           ComputeBlockIdManager &bm)
 {
     // 1. if no candidate, try to bypass non-fusable
     LOG_DEBUG("Finding source ops............\n");
@@ -200,22 +174,16 @@ static SmallVector<Operation *> findOpsAdjacentToCube(Block *block, const SmallV
                                                       const CVPipeline::MemoryDependenceGraph &memGraph)
 {
     SmallVector<Operation *> toProcess;
+    DependencyHelper depHelper {memGraph};
     for (Operation *op : fuseGroup) {
-        SmallVector<Operation *> allUsers;
-        allUsers.append(op->getUsers().begin(), op->getUsers().end());
-        for (auto memUser : memGraph.getExecAfter(op)) {
-            allUsers.push_back(memUser);
-        }
-
-        for (auto user : allUsers) {
-            auto userInBlock = CVPipeline::getAncestorInBlock(user, block);
-            if (!userInBlock || (block->mightHaveTerminator() && userInBlock == block->getTerminator())) {
-                continue;
+        depHelper.forEachUserInSameBlock(op, [&](Operation *user) {
+            if (block->mightHaveTerminator() && user == block->getTerminator()) {
+                return;
             }
-            if (!isFusableOp(userInBlock) && !visited[userInBlock]) {
+            if (!isFusableOp(user) && !visited[user]) {
                 toProcess.push_back(op);
             }
-        }
+        });
     }
     return toProcess;
 }
@@ -238,6 +206,7 @@ static SetVector<Operation *> collectKeepOps(Block *block, SmallVector<Operation
                                              const CVPipeline::MemoryDependenceGraph &memGraph)
 {
     SetVector<Operation *> keepOps;
+    DependencyHelper depHelper {memGraph};
     while (!toProcess.empty()) {
         Operation *op = toProcess.front();
         toProcess.erase(toProcess.begin());
@@ -246,45 +215,22 @@ static SetVector<Operation *> collectKeepOps(Block *block, SmallVector<Operation
         }
         keepOps.insert(op);
 
-        // Add all operands to process
-        for (auto operand : op->getOperands()) {
-            if (auto defOp = operand.getDefiningOp()) {
-                if (!keepOps.contains(defOp) && llvm::is_contained(fuseGroup, defOp)) {
-                    toProcess.push_back(defOp);
-                }
-                continue;
+        depHelper.forEachSource<true>(op, [&](Operation *source) {
+            if (!keepOps.contains(source) && llvm::is_contained(fuseGroup, source)) {
+                toProcess.push_back(source);
             }
-
-            // Loop-carried dependency: block argument -> yielded value
-            int argIdx = getLoopCarriedArgIndex(operand, block);
-            if (argIdx == -1) {
-                continue;
-            }
-            auto barg = cast<BlockArgument>(operand);
-            auto *yieldOp = barg.getOwner()->getTerminator();
-            auto *yieldedDef = yieldOp->getOperand(argIdx - 1).getDefiningOp();
-            if (!keepOps.contains(yieldedDef) && llvm::is_contained(fuseGroup, yieldedDef)) {
-                toProcess.push_back(yieldedDef);
-            }
-        }
-
-        // Memory dependency
-        for (auto memDef : memGraph.getExecBefore(op)) {
-            if (!keepOps.contains(memDef) && llvm::is_contained(fuseGroup, memDef)) {
-                toProcess.push_back(memDef);
-            }
-        }
+        });
     }
 
     // special case: annotation.mark always follows the defining op
-    for (auto op : fuseGroup) {
+    for (auto *op : fuseGroup) {
         auto markOp = llvm::dyn_cast<annotation::MarkOp>(op);
         if (!markOp) {
             continue;
         }
 
         auto src = markOp.getSrc();
-        auto definingOp = src.getDefiningOp();
+        auto *definingOp = src.getDefiningOp();
         if (definingOp && keepOps.contains(definingOp)) {
             keepOps.insert(markOp);
         }
@@ -307,19 +253,10 @@ static void evictAndRestoreState(Block *block, const SetVector<Operation *> &kee
     }
     fuseGroup.assign(keepOps.begin(), keepOps.end());
 
+    DependencyHelper depHelper {memGraph};
     // 2. Restore indegree for successors and reset visited for removed ops
     for (Operation *op : toRemove) {
-        SmallVector<Operation *> allUsers;
-        allUsers.append(op->getUsers().begin(), op->getUsers().end());
-        for (auto memUser : memGraph.getExecAfter(op)) {
-            allUsers.push_back(memUser);
-        }
-
-        for (auto user : allUsers) {
-            if (auto userInBlock = CVPipeline::getAncestorInBlock(user, block)) {
-                indegree[userInBlock]++;
-            }
-        }
+        depHelper.forEachUserInSameBlock(op, [&](Operation *user) { indegree[user]++; });
         visited[op] = false;
     }
 
@@ -341,9 +278,13 @@ static void evictAndRestoreState(Block *block, const SetVector<Operation *> &kee
     }
 }
 
-void refineFuseGroup(Block *block, SmallVector<Operation *> &nowFuseGroup, DenseMap<Operation *, bool> &visited,
-                     SmallVector<Operation *> &candidates, DenseMap<Operation *, int> &indegree,
-                     const CVPipeline::MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
+static void refineFuseGroup(Block *block,
+                            SmallVector<Operation *> &nowFuseGroup,
+                            DenseMap<Operation *, bool> &visited,
+                            SmallVector<Operation *> &candidates,
+                            DenseMap<Operation *, int> &indegree,
+                            const CVPipeline::MemoryDependenceGraph &memGraph,
+                            ComputeBlockIdManager &bm)
 {
     // 1.Find ops in fuse group whose next node is a non-fusable (CUBE-only) op
     auto toProcess = findOpsAdjacentToCube(block, nowFuseGroup, visited, memGraph);
@@ -364,13 +305,15 @@ void refineFuseGroup(Block *block, SmallVector<Operation *> &nowFuseGroup, Dense
 }
 
 // Main function to plan vector block id for one block
-llvm::LogicalResult planVectorBlockId(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
+static llvm::LogicalResult planVectorBlockId(Block *block,
+                                             const CVPipeline::MemoryDependenceGraph &memGraph,
+                                             ComputeBlockIdManager &bm)
 {
     // 1. topo initialize
     llvm::DenseMap<Operation *, int> indegree;
     llvm::SmallVector<Operation *> queue;
     llvm::DenseMap<Operation *, bool> visited; // has been visited in search
-    initializeIndegreeForBlock(block, indegree, memGraph, bm);
+    initializeIndegreeForBlock(block, indegree, DependencyHelper {memGraph}, bm);
 
     // 2. initialize visited and find initial candidates
     block->walk([&](Operation *op) {
@@ -409,6 +352,18 @@ llvm::LogicalResult planVectorBlockId(Block *block, const CVPipeline::MemoryDepe
     return llvm::success();
 }
 
+namespace {
+
+class PlanVectorBlockPass : public PassWrapper<PlanVectorBlockPass, OperationPass<ModuleOp>> {
+  public:
+    MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PlanVectorBlockPass)
+
+    PlanVectorBlockPass() = default;
+    void runOnOperation() override;
+
+    llvm::StringRef getArgument() const final { return "plan-vector-block"; }
+};
+
 void PlanVectorBlockPass::runOnOperation()
 {
     // 1. Build memory dependence graph
@@ -416,7 +371,6 @@ void PlanVectorBlockPass::runOnOperation()
     auto &aa = getAnalysis<AliasAnalysis>();
     auto memDepGraph = MemoryDependenceGraph(moduleOp, aa);
     auto bm = ComputeBlockIdManager(moduleOp);
-
 
     // 2. search blocks in topo order and assign block id for each block
     llvm::SmallVector<Block *> blocks;
@@ -428,6 +382,11 @@ void PlanVectorBlockPass::runOnOperation()
         }
     });
 }
+
+} // namespace
+
+namespace mlir {
+namespace triton {
 
 std::unique_ptr<OperationPass<ModuleOp>> createPlanVectorBlockPass()
 {

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
@@ -50,7 +50,9 @@
 
 using namespace mlir;
 static constexpr const char *DEBUG_TYPE = "ReorderOpsByBlockIdPass";
-#define LOG_DEBUG(...) LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__)
+
+#define DBGS(...) LLVM_DEBUG(llvm::dbgs() << __VA_ARGS__)
+#define LOG_DEBUG(...) DBGS("\n[" << DEBUG_TYPE << "] " << __VA_ARGS__)
 
 using namespace triton;
 using namespace CVPipeline;
@@ -110,7 +112,7 @@ template <bool IsMemory> void EdgeHelper::addEdge(Operation *pred, Operation *su
         return;
     }
     if (seen.insert({pred, succ}).second) {
-        LOG_DEBUG("Adding " << (IsMemory ? "memory " : "") << "edge from " << *pred << " to " << *succ << "\n");
+        LOG_DEBUG("Adding " << (IsMemory ? "memory " : "") << "edge from " << *pred << " to " << *succ);
         graph.succs[pred].push_back(succ);
         graph.preds[succ].push_back(pred);
     }
@@ -128,7 +130,7 @@ BlockOpGraph::BlockOpGraph(ArrayRef<Operation *> allOps, Block *block, const Mem
     EdgeHelper edges(*this, block);
 
     for (Operation *op : allOps) {
-        LOG_DEBUG("Processing op: " << *op << "\n");
+        LOG_DEBUG("Processing op: " << *op);
         // Edges from operand defs (including defs nested inside other ops).
         for (Value const operand : op->getOperands()) {
             Operation *defOp = operand.getDefiningOp();
@@ -231,11 +233,11 @@ GroupAdjacencyGraph::GroupAdjacencyGraph(const BlockOpGraph &g, const DenseMap<O
     // Logging the constructed group graph.
     LOG_DEBUG("Group-level edges:\n");
     for (unsigned i = 0; i < n; ++i) {
-        LOG_DEBUG("  Group " << groupIds[i] << " -> ");
+        DBGS("  Group " << groupIds[i] << " -> ");
         for (unsigned succIdx : succs[i]) {
-            LOG_DEBUG(groupIds[succIdx] << " ");
+            DBGS(groupIds[succIdx] << " ");
         }
-        LOG_DEBUG("\n");
+        DBGS("\n");
     }
 }
 
@@ -269,9 +271,8 @@ llvm::FailureOr<SmallVector<int>> GroupAdjacencyGraph::computeTopologicalOrder()
 
     LOG_DEBUG("Group order: ");
     for (int id : result) {
-        LOG_DEBUG(id << " ");
+        DBGS(id << " ");
     }
-    LOG_DEBUG("\n");
 
     if (result.size() == n) {
         return result;
@@ -357,10 +358,11 @@ static llvm::LogicalResult reorderOpsInBlock(Block &block, const MemoryDependenc
 
 void ReorderOpsByBlockIdPass::runOnOperation()
 {
-    LOG_DEBUG("\n=== Pass: TuningOpSeq ===\n");
     OpBuilder const builder(&getContext());
 
     auto moduleOp = getOperation();
+    LOG_DEBUG("Input mlir: \n" << moduleOp << "\n==========\n");
+
     auto &aa = getAnalysis<AliasAnalysis>();
     auto memGraph = MemoryDependenceGraph(moduleOp, aa);
     auto bm = ComputeBlockIdManager(moduleOp);
@@ -377,7 +379,7 @@ void ReorderOpsByBlockIdPass::runOnOperation()
         return WalkResult::advance();
     });
 
-    LOG_DEBUG("=== Pass TuningOpSeq complete ===\n");
+    LOG_DEBUG("Output mlir: \n" << moduleOp << "\n==========\n");
 }
 
 std::unique_ptr<OperationPass<ModuleOp>> mlir::triton::createReorderOpsByBlockIdPass()

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_plan_blockid_alloc_for_use.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_plan_blockid_alloc_for_use.mlir
@@ -1,0 +1,117 @@
+// RUN: triton-opt --plan-cube-block --plan-vector-block %s | FileCheck %s
+
+// S208. Pure vector scf.if: the entire if operation should be identified as a single VECTOR op.
+// The inputs and outputs outside the loop/if should be planned under consistent vector block IDs.
+// CHECK-LABEL: func.func @test_pure_vector_if_op(
+// CHECK: [[CST:%[a-zA-Z0-9_]+]] = arith.constant {ssbuffer.block_id = [[TC_VEC0:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"}
+// CHECK: [[IF_RES:%[0-9]+]] = scf.if %arg2 -> (tensor<64x64xf32>) {
+// CHECK: arith.addf {{.*}} {ssbuffer.block_id = [[TC_VEC_IN:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"}
+// CHECK: } else {
+// CHECK: arith.mulf {{.*}} {ssbuffer.block_id = [[TC_VEC_IN2:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"}
+// CHECK: } {ssbuffer.block_id = [[TC_VEC0]] : i32}
+// CHECK: [[OUT:%[0-9]+]] = arith.subf [[IF_RES]], %arg0 {ssbuffer.block_id = [[TC_VEC0]] : i32, ssbuffer.core_type = "VECTOR"}
+// CHECK: return [[OUT]]
+func.func @test_pure_vector_if_op(%arg0: tensor<64x64xf32>, %arg1: tensor<64x64xf32>, %arg2: i1) -> tensor<64x64xf32> {
+    %cst = arith.constant {ssbuffer.core_type = "VECTOR"} 1.000000e+00 : f32
+    %0 = scf.if %arg2 -> (tensor<64x64xf32>) {
+        %1 = arith.addf %arg0, %arg1 {ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+        scf.yield %1 : tensor<64x64xf32>
+    } else {
+        %2 = arith.mulf %arg0, %arg1 {ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+        scf.yield %2 : tensor<64x64xf32>
+    }
+    %3 = arith.subf %0, %arg0 {ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+    return %3 : tensor<64x64xf32>
+}
+
+// S209. Pure cube scf.for: the entire loop operation is identified as CUBE_ONLY.
+// CHECK-LABEL: func.func @test_pure_cube_for_op(
+// CHECK: [[C0:%.+]] = arith.constant {ssbuffer.block_id = [[TC_CUBE_OUT:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"} 0 : index
+// CHECK: [[FOR_RES:%[0-9]+]] = scf.for {{.*}} step {{.*}} iter_args({{.*}}) -> (tensor<64x64xf32>) {
+// CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = [[TC_CUBE_IN:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"}
+// CHECK: } {ssbuffer.block_id = [[TC_CUBE_OUT]] : i32}
+func.func @test_pure_cube_for_op(%arg0: tensor<64x64xf16>, %arg1: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %c0 = arith.constant {ssbuffer.core_type = "CUBE"} 0 : index
+    %c1 = arith.constant {ssbuffer.core_type = "CUBE"} 1 : index
+    %c4 = arith.constant {ssbuffer.core_type = "CUBE"} 4 : index
+    %res = scf.for %iv = %c0 to %c4 step %c1 iter_args(%arg2 = %arg1) -> (tensor<64x64xf32>) {
+        %trunc = arith.truncf %arg2 {ssbuffer.core_type = "CUBE"} : tensor<64x64xf32> to tensor<64x64xf16>
+        %out = tensor.empty() {ssbuffer.core_type = "CUBE"} : tensor<64x64xf32>
+        %mm = linalg.matmul {input_precision = "ieee", ssbuffer.core_type = "CUBE"} ins(%trunc, %arg0 : tensor<64x64xf16>, tensor<64x64xf16>) outs(%out : tensor<64x64xf32>) -> tensor<64x64xf32>
+        scf.yield %mm : tensor<64x64xf32>
+    }
+    return %res : tensor<64x64xf32>
+}
+
+
+// S210. SCF loop with nested non-CF region ops (e.g., linalg.generic).
+// The preorder walk should skip the nested blocks of non-RegionBranchOp operations,
+// thereby correctly identifying the loop as pure VECTOR despite containing scalar region ops.
+// CHECK-LABEL: func.func @test_scf_with_nested_non_cf_regions(
+// CHECK: [[C0:%.+]] = arith.constant {ssbuffer.block_id = [[TC_VEC_OUT:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+// CHECK: [[FOR_RES:%[0-9]+]] = scf.for {{.*}} step {{.*}} iter_args({{.*}}) -> (tensor<256xi32>) {
+// CHECK: linalg.generic {indexing_maps = {{.*}}, iterator_types = ["parallel"]} {{.*}}ssbuffer.block_id = [[TC_VEC_IN:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"
+// CHECK: } {ssbuffer.block_id = [[TC_VEC_OUT]] : i32}
+#map_ut = affine_map<(d0) -> (d0)>
+func.func @test_scf_with_nested_non_cf_regions(%arg0: tensor<256xi32>) -> tensor<256xi32> {
+    %c0 = arith.constant {ssbuffer.core_type = "VECTOR"} 0 : index
+    %c1 = arith.constant {ssbuffer.core_type = "VECTOR"} 1 : index
+    %c4 = arith.constant {ssbuffer.core_type = "VECTOR"} 4 : index
+    %res = scf.for %iv = %c0 to %c4 step %c1 iter_args(%arg1 = %arg0) -> (tensor<256xi32>) {
+        %out = tensor.empty() {ssbuffer.core_type = "VECTOR"} : tensor<256xi32>
+        %generic = linalg.generic {indexing_maps = [#map_ut], iterator_types = ["parallel"]} outs(%out : tensor<256xi32>) attrs = {ssbuffer.core_type = "VECTOR"} {
+        ^bb0(%val: i32):
+            %idx = linalg.index 0 : index
+            %cast = arith.index_cast %idx : index to i32
+            linalg.yield %cast : i32
+        } -> tensor<256xi32>
+        scf.yield %generic : tensor<256xi32>
+    }
+    return %res : tensor<256xi32>
+}
+
+// S211. Mixed scf.if containing both CUBE and VECTOR ops.
+// The control-flow op should be identified as UNDETERMINED, preventing it from being treated
+// as a single CUBE or VECTOR block (the scf.if should not obtain any ssbuffer.block_id attribute).
+// CHECK-LABEL: func.func @test_mixed_cf_op_undetermined(
+// CHECK-NOT: scf.if {{.*}} ssbuffer.block_id
+// CHECK: scf.if %arg2 -> (tensor<64x64xf32>) {
+// CHECK: arith.addf {{.*}} {ssbuffer.block_id = [[TC_VEC_IN:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"}
+// CHECK: } else {
+// CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = [[TC_CUBE_IN:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"}
+// CHECK: }
+func.func @test_mixed_cf_op_undetermined(%arg0: tensor<64x64xf32>, %arg1: tensor<64x64xf16>, %arg2: i1) -> tensor<64x64xf32> {
+    %0 = scf.if %arg2 -> (tensor<64x64xf32>) {
+        %1 = arith.addf %arg0, %arg0 {ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+        scf.yield %1 : tensor<64x64xf32>
+    } else {
+        %out = tensor.empty() {ssbuffer.core_type = "CUBE"} : tensor<64x64xf32>
+        %2 = linalg.matmul {input_precision = "ieee", ssbuffer.core_type = "CUBE"} ins(%arg1, %arg1 : tensor<64x64xf16>, tensor<64x64xf16>) outs(%out : tensor<64x64xf32>) -> tensor<64x64xf32>
+        scf.yield %2 : tensor<64x64xf32>
+    }
+    return %0 : tensor<64x64xf32>
+}
+
+
+// S212. Alloc and its use spanning across a vector scf.for loop.
+// The scf.for loop is identified as a pure VECTOR op and is fused with the alloc
+// and its use, ensuring they all share the same block ID outside the loop.
+// CHECK-LABEL: func.func @test_alloc_and_use_around_for_loop(
+// CHECK: [[ALLOC:%[A-Za-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = [[TC_VEC_OUT:[0-9]+]] : i32, ssbuffer.core_type = "VECTOR"}
+// CHECK: scf.for
+// CHECK: } {ssbuffer.block_id = [[TC_VEC_OUT]] : i32}
+// CHECK: [[TENSOR:%[0-9]+]] = bufferization.to_tensor [[ALLOC]] restrict writable {ssbuffer.block_id = [[TC_VEC_OUT]] : i32, ssbuffer.core_type = "VECTOR"}
+func.func @test_alloc_and_use_around_for_loop(%arg0: memref<?xf16>, %arg1: i32) -> tensor<128x64xf16> {
+    %c0 = arith.constant {ssbuffer.core_type = "VECTOR"} 0 : index
+    %c1 = arith.constant {ssbuffer.core_type = "VECTOR"} 1 : index
+    %c128 = arith.constant {ssbuffer.core_type = "VECTOR"} 128 : index
+    %alloc = memref.alloc() {ssbuffer.core_type = "VECTOR"} : memref<128x64xf16>
+    scf.for %arg23 = %c0 to %c128 step %c1 {
+        %subview = memref.subview %alloc[%arg23, 0] [1, 64] [1, 1] {ssbuffer.core_type = "VECTOR"} : memref<128x64xf16> to memref<1x64xf16, strided<[64, 1], offset: ?>>
+        %reinterpret = memref.reinterpret_cast %arg0 to offset: [%arg23], sizes: [1, 64], strides: [64, 1] {ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<1x64xf16, strided<[64, 1], offset: ?>>
+        memref.copy %reinterpret, %subview {ssbuffer.core_type = "VECTOR"} : memref<1x64xf16, strided<[64, 1], offset: ?>> to memref<1x64xf16, strided<[64, 1], offset: ?>>
+    }
+    %res = bufferization.to_tensor %alloc restrict writable {ssbuffer.core_type = "VECTOR"} : memref<128x64xf16>
+    return %res : tensor<128x64xf16>
+}
+

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_plan_cube_block_cycle.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_plan_cube_block_cycle.mlir
@@ -1,0 +1,38 @@
+// RUN: triton-opt --plan-cube-block %s | FileCheck %s
+
+module {
+
+  // S208. Test cycle detection across sub-regions (e.g., scf.if).
+  // The memory dependence graph (memGraph) only tracks memory dependencies within the same block/region.
+  // Thus, directly tracing from an operation inside scf.if (linalg.fill) cannot reach its main-block consumer (linalg.matmul).
+  //
+  // By resolving the inner-region operation to its main-block ancestor (scf.if), the cycle detector
+  // correctly identifies the cyclic dependency: group (%alloc) -> scf.if (external) -> group (%result).
+  // This prevents invalid grouping that would otherwise cause a topological scheduling deadlock.
+
+  // CHECK-LABEL: func.func @test_subregion_dependency_cycle(
+  // CHECK:       [[ALLOC:%[A-Za-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = [[TC_CUBE0:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"}
+  // CHECK:       scf.if %{{.*}} {
+  // CHECK:         linalg.fill {{.*}} {ssbuffer.block_id = [[TC_CUBE1:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"}
+  // CHECK:       }
+  // CHECK:       memref.copy {{.*}} {ssbuffer.block_id = [[TC_CUBE2:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"}
+  // CHECK:       linalg.matmul {input_precision = "ieee", ssbuffer.block_id = [[TC_CUBE3:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"}
+  func.func @test_subregion_dependency_cycle(%arg0: memref<32x32xf32>, %arg1: memref<32x32xf32>, %arg2: tensor<32x32xf32>, %cond: i1) -> tensor<32x32xf32> {
+    %alloc = memref.alloc() {ssbuffer.core_type = "CUBE"} : memref<32x32xf32>
+
+    scf.if %cond {
+      %cst = arith.constant 0.0 : f32
+      linalg.fill {ssbuffer.core_type = "CUBE"} ins(%cst : f32) outs(%alloc : memref<32x32xf32>)
+    }
+
+    memref.copy %arg0, %alloc {ssbuffer.core_type = "CUBE"} : memref<32x32xf32> to memref<32x32xf32>
+    %tensor = bufferization.to_tensor %alloc restrict writable {ssbuffer.core_type = "CUBE"} : memref<32x32xf32>
+    %out = tensor.empty() {ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %result = linalg.matmul {input_precision = "ieee", ssbuffer.core_type = "CUBE"}
+      ins(%tensor, %arg2 : tensor<32x32xf32>, tensor<32x32xf32>)
+      outs(%out : tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    return %result : tensor<32x32xf32>
+  }
+}
+


### PR DESCRIPTION
## PR Title / PR 标题
`fix(ssbuffer): fix cases where alloc is initialized in RegionBranchOp | 修复在 RegionBranchOp 中初始化 alloc 导致 block id 不一致的问题`

---

## 1. Overview / 概述
### English
This pull request addresses an issue in the block ID planning passes where memory allocations and their subsequent uses across control-flow structures (such as `scf.for` or `scf.if` loops) were assigned different block IDs. This mismatch occurred because control-flow operations containing nested regions were not evaluated as unified core-specific (Vector-only or Cube-only) blocks. This PR resolves the issue by identifying entire control-flow operations that consist strictly of a single core type as a single logical operation during scheduling and planning.

### 中文
此 Pull Request 解决了在块 ID 规划（block ID planning）通道中，跨控制流结构（例如 `scf.for` 或 `scf.if` 循环）的内存分配（alloc）与其后续使用被分配了不同 block ID 的问题。该不一致问题是因为包含嵌套区域的控制流算子未被作为一个统一的、特定于核心（仅 Vector 或仅 Cube）的块来进行评估。本 PR 通过在调度和规划过程中，将仅包含单一核心类型算子的控制流算子整体识别为单个逻辑算子，从而解决了此问题。

---

## 2. Key Changes / 关键变更

### English
- **`third_party/ascend/include/DynamicCVPipeline/Common/Utils.h`**:
  - Declared `getCoreTypeOfSimpleOpOrCf` to determine the unified core type of simple operations and control-flow operations.
  - Replaced `isCubeOp` with `isCubeSimpleOpOrCf` and added `isVectorSimpleOpOrCf`.
- **`third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp`**:
  - Implemented `getCoreTypeOfSimpleOpOrCf` utilizing a pre-order walk over `RegionBranchOpInterface` nested regions.
  - Handled skipping of nested sub-operations inside non-control-flow region operations (e.g., `linalg.generic`) to ensure correct classification of outer loops.
- **`third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp`**:
  - Updated planning eligibility checks and topological sorting methods to utilize `isCubeSimpleOpOrCf` instead of `isCubeOp`.
- **`third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp`**:
  - Replaced manual control-flow check in `isFusableOp` with `isVectorSimpleOpOrCf`, enabling the fusion of entire vector-only control-flow constructs.
  - Refactored several helper functions to be static and encapsulated internal structures.
- **`third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp`**:
  - Cleaned up debug logging macros and formatters to support structured diagnostic output.
- **`third_party/ascend/unittest/.../test_plan_blockid_alloc_for_use.mlir`**:
  - Added new test cases verifying behavior across pure vector `scf.if`, pure cube `scf.for`, loops with nested non-CF regions (`linalg.generic`), mixed core control flows, and allocations spanning loop boundaries.

### 中文
- **`third_party/ascend/include/DynamicCVPipeline/Common/Utils.h`**:
  - 声明了 `getCoreTypeOfSimpleOpOrCf`，用以确定简单算子和控制流算子的统一核心类型。
  - 用 `isCubeSimpleOpOrCf` 代替了 `isCubeOp`，并新增了 `isVectorSimpleOpOrCf`。
- **`third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp`**:
  - 实现了 `getCoreTypeOfSimpleOpOrCf`，利用前序遍历（pre-order walk）对 `RegionBranchOpInterface` 的嵌套区域进行分析。
  - 处理了跳过非控制流区域算子（例如 `linalg.generic`）内部嵌套子算子的逻辑，确保外层循环分类的准确性。
- **`third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp`**:
  - 更新了块规划适用性检查和拓扑排序方法，采用 `isCubeSimpleOpOrCf` 代替原有的 `isCubeOp`。
- **`third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp`**:
  - 将 `isFusableOp` 中手动的控制流判断逻辑替换为 `isVectorSimpleOpOrCf`，从而允许将整个仅含 Vector 算子的控制流结构作为一个整体进行融合。
  - 重构了若干辅助函数，将其设为静态函数并对内部结构进行了封装。
- **`third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp`**:
  - 清理并重构了调试日志宏和格式化器，以提供结构化的诊断输出。
- **`third_party/ascend/unittest/.../test_plan_blockid_alloc_for_use.mlir`**:
  - 添加了全新的测试用例，覆盖了纯 Vector 的 `scf.if`、纯 Cube 的 `scf.for`、带有嵌套非 CF 区域（如 `linalg.generic`）的循环、混合核心的控制流以及跨越循环边界的内存分配（alloc）。

---

## 3. Technical Deep-Dive / 技术细节剖析

### English
The block ID planning algorithm maps sequential operations into scheduled blocks characterized by a execution target (Cube or Vector). Previously, control-flow instructions implementing `RegionBranchOpInterface` (such as `scf.for` or `scf.if`) were either skipped or evaluated fragmentarily. When an allocation (`memref.alloc`) occurred outside an `scf.for` but its uses were within or after it, the boundary of the loop interrupted the dependency chain, splitting them into different block IDs.

To solve this, this PR models a control flow operation as a single unified operation if all operations within its regions belong to the same core type:
1. **Hierarchical Traversal**: The utility `getCoreTypeOfSimpleOpOrCf` recursively walks the nested blocks using a pre-order traversal.
2. **Region Isolation**:
   - Nested `RegionBranchOpInterface` constructs are recursively evaluated.
   - For non-control-flow operations that possess regions (such as `linalg.generic`), their child operations are bypassed via `WalkResult::skip()`. This is because their inner blocks represent element-wise computation threads rather than independent scheduled steps.
3. **Inconsistency Fallback**: If a control-flow operation contains mismatched core types (e.g., both Vector and Cube operations) or undetermined operations, the wrapper operation's core type falls back to `CoreType::UNDETERMINED`. This ensures that mixed loops are handled conservative and safely, without being scheduled under a single block ID.

### 中文
块 ID 规划算法将顺序操作映射到由执行目标（Cube 或 Vector）表征的调度块中。在此之前，实现 `RegionBranchOpInterface` 的控制流指令（如 `scf.for` 或 `scf.if`）要么被跳过，要么被割裂地评估。当分配操作（`memref.alloc`）发生在 `scf.for` 外部，但其使用发生在循环内部或循环之后时，循环边界会打断依赖关系链，导致它们被分配到不同的 block ID。

为了解决这个问题，本 PR 将控制流算子建模为一个统一的单一算子（若其区域内的所有算子都属于相同的核心类型）：
1. **层级遍历**：`getCoreTypeOfSimpleOpOrCf` 工具函数使用前序遍历递归地遍历嵌套块。
2. **区域隔离**：
   - 嵌套的 `RegionBranchOpInterface` 结构会被递归评估。
   - 对于带有 region 的非控制流算子（例如 `linalg.generic`），其子操作会通过 `WalkResult::skip()` 被跳过。这是因为这些内部块代表的是元素级计算线程，而不是独立的调度步骤。
3. **不一致性回退**：如果控制流算子中包含不匹配的核心类型（例如，同时包含 Vector 和 Cube 算子）或未确定的算子，则包装算子的核心类型将回退为 `CoreType::UNDETERMINED`。这确保了对混合循环的处理是保守且安全的，而不会被强行合并到单个 block ID 中。

---

## 4. Impact & Risk Assessment / 影响与风险评估

### English
- **Breaking Changes**: No breaking changes. Existing APIs and dialect definitions remain unmodified.
- **Performance Impact**: Minimal compile-time overhead added due to recursive walk on control-flow blocks during block ID planning passes. Runtime performance of the generated code may improve due to better fusion and aligned block assignments.
- **Backward Compatibility**: Fully backward compatible.

### 中文
- **破坏性变更**: 否。现有 API 和 dialect 定义保持不变。
- **性能影响**: 极小。仅在 block ID 规划通道中由于对控制流块进行递归遍历而增加了微乎其微的编译时开销。生成的代码运行性能可能会由于更好的融合以及对齐的块分配而有所提升。
- **向后兼容性**: 完全向后兼容。

---

## 5. Verification & Testing / 测试与验证方法

### English
A new suite of MLIR integration tests has been added in `test_plan_blockid_alloc_for_use.mlir` to verify correctness:
- **`test_pure_vector_if_op`**: Verifies that a pure vector `scf.if` gets treated as a single unified `VECTOR` block, aligning block IDs across uses.
- **`test_pure_cube_for_op`**: Confirms a pure cube loop resolves to a single unified `CUBE` block.
- **`test_scf_with_nested_non_cf_regions`**: Verifies that `linalg.generic` nested within an `scf.for` loop does not interrupt the traversal, allowing the entire loop to be correctly marked as `VECTOR`.
- **`test_mixed_cf_op_undetermined`**: Assures that a control-flow operation containing mixed Vector and Cube operations resolves to `UNDETERMINED` and is not assigned any unified block ID.
- **`test_alloc_and_use_around_for_loop`**: Validates that an allocation outside a loop and its subsequent use inside/after are successfully assigned matching block IDs.

### 中文
在 `test_plan_blockid_alloc_for_use.mlir` 中添加了一套全新的 MLIR 集成测试以验证正确性：
- **`test_pure_vector_if_op`**：验证纯 Vector 的 `scf.if` 是否被作为单个统一的 `VECTOR` 块处理，从而对齐不同使用处的 block ID。
- **`test_pure_cube_for_op`**：确认纯 Cube 循环正确解析为单个统一的 `CUBE` 块。
- **`test_scf_with_nested_non_cf_regions`**：验证嵌套在 `scf.for` 循环内的 `linalg.generic` 不会打断遍历，使得整个循环仍能被正确标记为 `VECTOR`。
- **`test_mixed_cf_op_undetermined`**：确保包含混合 Vector 和 Cube 算子的控制流算子解析为 `UNDETERMINED` 并且不被分配任何统一的 block ID。
- **`test_alloc_and_use_around_for_loop`**：验证在循环外部分配的内存及其在循环内外的后续使用是否能够成功分配到匹配的 block ID。