### PR TITLE
[autotune](fix) fixing the conflict when multibuffer is passed in

### DIFF
--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -410,9 +410,6 @@ class AutoTilingTuner(Autotuner):
         ):
             normalized_configs = []
             for base_cfg in base_configs:
-                if self.user_specified_multibuffer is not None:
-                    base_cfg.kwargs["multibuffer"] = self.user_specified_multibuffer
-
                 if self.user_specified_num_stages is not None:
                     base_cfg.num_stages = self.user_specified_num_stages
                     # Keep compiler-visible multibuffer consistent when only num_stages is specified.


### PR DESCRIPTION
当前存在bug：传入multibuffer时报错
<img width="984" height="180" alt="image" src="https://github.com/user-attachments/assets/b58b1c26-8c57-49bb-977f-7aa8af7f2bd2" />

报错原因：传入的编译选项和autotune生成的config都有multibuffer，产生冲突
修改：在传入编译选项中存在multibuffer时，autotune的config不再生成multibuffer
测试：
<img width="1690" height="83" alt="image" src="https://github.com/user-attachments/assets/30d03c5b-5218-4a80-9f9f-8e9593eb80ed" />
修改后不再输出multibuffer
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
