### PR TITLE
[Gluon](fix) Restore gluon cdiv to upstream standard

### DIFF
--- a/python/triton/experimental/gluon/language/_standard.py
+++ b/python/triton/experimental/gluon/language/_standard.py
@@ -4,7 +4,6 @@ import triton.language.standard as tl_standard
 from .._runtime import GluonJITFunction, jit
 from triton import knobs
 from . import _core as ttgl
-from triton.language.standard import cdiv as tl_cdiv
 
 T = TypeVar("T")
 
@@ -17,8 +16,7 @@ def _import_from_triton(fn: JITFunction[T]) -> GluonJITFunction[T]:
     return gluon_fn
 
 
-#cdiv = _import_from_triton(tl_standard.cdiv)
-cdiv = _import_from_triton(tl_cdiv)
+cdiv = _import_from_triton(tl_standard.cdiv)
 sum = _import_from_triton(tl_standard.sum)
 max = _import_from_triton(tl_standard.max)
 min = _import_from_triton(tl_standard.min)


### PR DESCRIPTION
## Summary
This PR reverts a local intrusive change in Gluon standard library wiring and restores the upstream for `cdiv`.

Before this change, Gluon imported `cdiv` through an extra local alias:

```python
from triton.language.standard import cdiv as tl_cdiv
cdiv = _import_from_triton(tl_cdiv)
```

This PR removes that local fork and switches back to the upstream form:

```python
import triton.language.standard as tl_standard
cdiv = _import_from_triton(tl_standard.cdiv)
```

## Why this rollback is safe
This rollback is expected to have no functional impact.

The reason is straightforward:

1. There is only one canonical `cdiv` definition in `python/triton/language/standard.py`.
2. The previous implementation imported that same object into a temporary alias named `tl_cdiv`.
3. The reverted implementation references the same function through the module attribute `tl_standard.cdiv`.
4. In both cases, Gluon still wraps the same Triton JIT function through `_import_from_triton`.

As a result, this change does not alter `cdiv` semantics, code generation behavior, or the public Gluon API. It only removes an unnecessary local divergence from upstream.

## User Impact
No user-visible behavior change is expected.

Users will continue to call Gluon `cdiv` through the same API surface. The practical effect of this PR is improved maintainability:

1. The file is aligned again with upstream style.
2. Future upstream syncs become simpler.
3. The code no longer carries an unnecessary local special case.

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
	[rules](https://cbea.ms/git-commit/#why-not-how).
- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
	- [x] This PR does not need a test because it restores the upstream import path without changing cdiv implementation or behavior.
	- [ ] I have added tests.
		- `/python/test` for end-to-end tests
- Select one of the following.
	- [x] I have not added any `lit` tests.
	- [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
		including the "tests should be minimal" section. (Usually running Python code
		and using the instructions it generates is not minimal.)
