### PR TITLE
[API](fix) Align tensor sanitize_overflow default setting

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -880,27 +880,27 @@ class tensor(base_value):
 
     @builtin
     def __add__(self, other, _semantic=None):
-        return add(self, other, sanitize_overflow=False, _semantic=_semantic)
+        return add(self, other, sanitize_overflow=True, _semantic=_semantic)
 
     @builtin
     def __radd__(self, other, _semantic=None):
-        return add(other, self, sanitize_overflow=False, _semantic=_semantic)
+        return add(other, self, sanitize_overflow=True, _semantic=_semantic)
 
     @builtin
     def __sub__(self, other, _semantic=None):
-        return sub(self, other, sanitize_overflow=False, _semantic=_semantic)
+        return sub(self, other, sanitize_overflow=True, _semantic=_semantic)
 
     @builtin
     def __rsub__(self, other, _semantic=None):
-        return sub(other, self, sanitize_overflow=False, _semantic=_semantic)
+        return sub(other, self, sanitize_overflow=True, _semantic=_semantic)
 
     @builtin
     def __mul__(self, other, _semantic=None):
-        return mul(self, other, sanitize_overflow=False, _semantic=_semantic)
+        return mul(self, other, sanitize_overflow=True, _semantic=_semantic)
 
     @builtin
     def __rmul__(self, other, _semantic=None):
-        return mul(other, self, sanitize_overflow=False, _semantic=_semantic)
+        return mul(other, self, sanitize_overflow=True, _semantic=_semantic)
 
     @builtin
     def __truediv__(self, other, _semantic=None):

--- a/third_party/ascend/unittest/pytest_ut/test_alloc.py
+++ b/third_party/ascend/unittest/pytest_ut/test_alloc.py
@@ -40,6 +40,7 @@ class Options:
     cluster_dims = (1, 1, 1)
     enable_fp_fusion = True
     debug = False
+    sanitize_overflow = True
 
 
 def compile_kernel(kernel, signature, constants):

--- a/third_party/ascend/unittest/pytest_ut/test_arch.py
+++ b/third_party/ascend/unittest/pytest_ut/test_arch.py
@@ -40,6 +40,7 @@ class Options:
     enable_fp_fusion = True
     debug = False
     arch = "Ascend950"
+    sanitize_overflow = True
 
 
 def compile_kernel(kernel, signature, constants):

--- a/third_party/ascend/unittest/pytest_ut/test_ascend_barrier.py
+++ b/third_party/ascend/unittest/pytest_ut/test_ascend_barrier.py
@@ -20,6 +20,7 @@ class Options:
     cluster_dims = (1, 1, 1)
     enable_fp_fusion = True
     debug = False
+    sanitize_overflow = True
 
 
 def compile_kernel(kernel, signature, constants):

--- a/third_party/ascend/unittest/pytest_ut/test_bind_buffer.py
+++ b/third_party/ascend/unittest/pytest_ut/test_bind_buffer.py
@@ -40,6 +40,7 @@ class Options:
     cluster_dims = (1, 1, 1)
     enable_fp_fusion = True
     debug = False
+    sanitize_overflow = True
 
 
 def compile_kernel(kernel, signature, constants):

--- a/third_party/ascend/unittest/pytest_ut/test_copy.py
+++ b/third_party/ascend/unittest/pytest_ut/test_copy.py
@@ -40,6 +40,7 @@ class Options:
     enable_fp_fusion = True
     debug = False
     arch = "Ascend910_95"
+    sanitize_overflow = True
 
 
 def compile_kernel(kernel, signature, constants):

--- a/third_party/ascend/unittest/pytest_ut/test_fixpipe.py
+++ b/third_party/ascend/unittest/pytest_ut/test_fixpipe.py
@@ -40,6 +40,7 @@ class Options:
     enable_fp_fusion = True
     debug = False
     arch = "Ascend910_95"
+    sanitize_overflow = True
 
 
 def compile_kernel(kernel, signature, constants):

--- a/third_party/ascend/unittest/pytest_ut/test_fixpipe_tensor_dst.py
+++ b/third_party/ascend/unittest/pytest_ut/test_fixpipe_tensor_dst.py
@@ -41,6 +41,7 @@ class Options:
     enable_fp_fusion = True
     debug = False
     arch = "Ascend910_95"
+    sanitize_overflow = True
 
 
 def compile_kernel(kernel, signature, constants):

--- a/third_party/ascend/unittest/pytest_ut/test_multibuffer.py
+++ b/third_party/ascend/unittest/pytest_ut/test_multibuffer.py
@@ -40,6 +40,7 @@ class Options:
     cluster_dims = (1, 1, 1)
     enable_fp_fusion = True
     debug = False
+    sanitize_overflow = True
 
 
 def compile_kernel(kernel, signature, constants):

--- a/third_party/ascend/unittest/pytest_ut/test_scope.py
+++ b/third_party/ascend/unittest/pytest_ut/test_scope.py
@@ -20,6 +20,7 @@ class Options:
     cluster_dims = (1, 1, 1)
     enable_fp_fusion = True
     debug = False
+    sanitize_overflow = True
 
 
 def compile_kernel(kernel, signature, constants):

--- a/third_party/ascend/unittest/pytest_ut/test_scope_buffer.py
+++ b/third_party/ascend/unittest/pytest_ut/test_scope_buffer.py
@@ -35,6 +35,7 @@ class Options:
     cluster_dims = (1, 1, 1)
     enable_fp_fusion = True
     debug = False
+    sanitize_overflow = True
 
 
 def compile_kernel(kernel, signature, constants):

--- a/third_party/ascend/unittest/pytest_ut/test_subview.py
+++ b/third_party/ascend/unittest/pytest_ut/test_subview.py
@@ -40,6 +40,7 @@ class Options:
     cluster_dims = (1, 1, 1)
     enable_fp_fusion = True
     debug = False
+    sanitize_overflow = True
 
 
 def compile_kernel(kernel, signature, constants):

--- a/third_party/ascend/unittest/pytest_ut/test_sync_block_all.py
+++ b/third_party/ascend/unittest/pytest_ut/test_sync_block_all.py
@@ -20,6 +20,7 @@ class Options:
     cluster_dims = (1, 1, 1)
     enable_fp_fusion = True
     debug = False
+    sanitize_overflow = True
 
 
 def compile_kernel(kernel, signature, constants):

--- a/third_party/ascend/unittest/pytest_ut/test_to_tensor.py
+++ b/third_party/ascend/unittest/pytest_ut/test_to_tensor.py
@@ -39,6 +39,7 @@ class Options:
     cluster_dims = (1, 1, 1)
     enable_fp_fusion = True
     debug = False
+    sanitize_overflow = True
 
 
 def compile_kernel(kernel, signature, constants):


### PR DESCRIPTION
## Summary
This PR changes the default value of `sanitize_overflow` from `False` to `True` in tensor magic methods (`__add__`, `__radd__`, `__sub__`, `__rsub__`, `__mul__`, `__rmul__`) to match upstream.

Before this change, tensor arithmetic operators forwarded to the free functions with `sanitize_overflow=False`:

```python
@builtin
def __add__(self, other, _semantic=None):
    return add(self, other, sanitize_overflow=False, _semantic=_semantic)
```

This PR aligns with upstream by passing `sanitize_overflow=True`:

```python
@builtin
def __add__(self, other, _semantic=None):
    return add(self, other, sanitize_overflow=True, _semantic=_semantic)
```

## Why this change is safe

Setting `sanitize_overflow=True` in the tensor operators has **no functional impact** on Ascend, for two independent reasons:

### 1. `device_assert` is gated by `TRITON_DEBUG`

The `sanitize_overflow` mechanism works by inserting `tl.device_assert()` calls to catch integer overflow at runtime. The `device_assert` implementation in `semantic.py` has a debug guard:

```python
def device_assert(self, cond, msg, mask):
    if not self.builder.options.debug:   # requires TRITON_DEBUG=1
        return
    ...
    self.builder.create_assert(cond.handle, msg)
```

In production (where `TRITON_DEBUG` is not set), `device_assert` returns immediately without generating any IR assert instructions. Therefore `sanitize_overflow=True` produces exactly the same compiled kernel as `sanitize_overflow=False` under normal usage.

### 2. Ascend backend explicitly filters overflow-detection asserts

Even when `TRITON_DEBUG=1` is set and assert IR is generated, the Ascend backend's `DeviceAssertConverter` in `triton-to-linalg` explicitly removes them:

```cpp
// TritonToLinalg/TritonOpConverter.cpp
auto msgAttr = op.getMessageAttr();
// Filter out automatically inserted assert ops
if (auto strAttr = mlir::dyn_cast<mlir::StringAttr>(msgAttr)) {
    llvm::StringRef msg = strAttr.getValue();
    if (msg.contains("overflow detected for operation")) {
      rewriter.eraseOp(op);   // silently removed
      return success();
    }
}
```

This filter only matches the `"overflow detected for operation"` message produced by `binary_op_sanitize_overflow_impl`. **User-written `tl.device_assert()` calls are not affected** — they pass through the converter normally.

### Summary of the two-layer protection

| Scenario | `sanitize_overflow=True` effect |
|----------|-------------------------------|
| `TRITON_DEBUG` unset (production) | `device_assert` returns early → no IR generated |
| `TRITON_DEBUG=1` (debug) | Assert IR generated, then **erased by Ascend backend** |

In both cases, the final compiled kernel is identical to what `sanitize_overflow=False` would produce.

### 3. Fix local `Options` class missing `sanitize_overflow` in test cases

As a side effect of enabling `sanitize_overflow=True`, the `binary_op_sanitize_overflow_impl` now accesses `self.builder.options.sanitize_overflow` during integer arithmetic.  Such as, `test_arch.py` file defined its own minimal `Options` class for bypassing the full compile pipeline, but omitted the `sanitize_overflow` attribute:

```python
class Options:
    num_warps = 4
    num_stages = 3
    ...
    # sanitize_overflow was missing
```

This caused `AttributeError: 'Options' object has no attribute 'sanitize_overflow'` when the test used integer operations (e.g. `offs_a * M` with int32). This PR adds `sanitize_overflow = True` to the test's `Options` class also.

## User Impact
No user-visible change is expected.

The practical benefit of this change is purely maintainability:

1. The file is aligned with upstream, reducing diff noise during future syncs.
2. If a future upstream change modifies how `sanitize_overflow` is handled, the Ascend fork will pick it up without conflict.
3. The code no longer carries an unnecessary local divergence whose original rationale is undocumented.

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
	[rules](https://cbea.ms/git-commit/#why-not-how).
- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
	- [x] This PR does not need a test because the change has no functional impact on Ascend (see "Why this change is safe" above).
	- [ ] I have added tests.
		- `/python/test` for end-to-end tests
- Select one of the following.
	- [x] I have not added any `lit` tests.
	- [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
		including the "tests should be minimal" section. (Usually running Python code
		and using the instructions it generates is not minimal.)
