### PR TITLE
[Frontend](fix) Revert fp8 datatype support for tl.full

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -932,16 +932,6 @@ void init_triton_ir(py::module &&m) {
              return self.create<arith::ConstantOp>(
                  self.getBuilder().getF64FloatAttr(v));
            })
-      .def("get_fp8e4nv",
-           [](TritonOpBuilder &self, double v) -> Value {
-             return self.create<arith::ConstantOp>(FloatAttr::get(
-                 Float8E4M3FNType::get((self.getBuilder().getContext())), v));
-           })
-      .def("get_fp8e5",
-           [](TritonOpBuilder &self, double v) -> Value {
-             return self.create<arith::ConstantOp>(FloatAttr::get(
-                 Float8E5M2Type::get(self.getBuilder().getContext()), v));
-           })
       .def("get_null_value",
            [](TritonOpBuilder &self, Type type) -> Value {
              if (auto floatTy = dyn_cast<FloatType>(type))


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
### Related Issue
#645 
### Summary

Remove the `get_fp8e4nv` and `get_fp8e5` intrusive modifications from `ir.cc` that enabled fp8 constant value creation.

### Why

These two functions were originally introduced as an intrusive change to support fp8 data types in `tl.full`,
However, the `full` op spec does not support fp8, remove it.

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
