### PR TITLE
[TritonToLinalg](fix) guard tile chunk coalescing for dynamic boundaries

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/StridedLoadStoreRewrite.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/StridedLoadStoreRewrite.cpp
@@ -187,15 +187,23 @@ static bool offsetMayContainStrideGtOne(Value offset, int depthBudget = 16) {
     return false;
 }
 
-// Walk through tt.splat to find the underlying scalar !tt.ptr<T>.
-// Returns null if the base is not a simple splat of a scalar pointer.
-static Value getScalarBasePtr(Value tensorPtr) {
+// Walk through shape-only wrappers to find the underlying scalar !tt.ptr<T>.
+// TileChunkCoalescing lifts invariant pointer tensors as
+// broadcast(expand_dims(splat(ptr))), which is still a scalar base pointer for
+// indirect access construction.
+static Value getScalarBasePtr(Value tensorPtr, int depthBudget = 8) {
+    if (depthBudget <= 0)
+        return Value();
     if (auto splatOp = tensorPtr.getDefiningOp<triton::SplatOp>()) {
         Value src = splatOp.getSrc();
         if (isa<triton::PointerType>(src.getType())) {
             return src;
         }
     }
+    if (auto broadcastOp = tensorPtr.getDefiningOp<triton::BroadcastOp>())
+        return getScalarBasePtr(broadcastOp.getSrc(), depthBudget - 1);
+    if (auto expandDimsOp = tensorPtr.getDefiningOp<triton::ExpandDimsOp>())
+        return getScalarBasePtr(expandDimsOp.getSrc(), depthBudget - 1);
     return Value();
 }
 
@@ -371,7 +379,7 @@ static LogicalResult tryRewriteAddPtrLoad(triton::LoadOp op,
                                           PatternRewriter &rewriter) {
     auto loc = op.getLoc();
 
-    // The base must be a simple tt.splat of a scalar pointer.
+    // The base must resolve to a scalar pointer through shape-only wrappers.
     Value scalarBase = getScalarBasePtr(addPtrOp.getPtr());
     if (!scalarBase) return failure();
 

--- a/third_party/ascend/lib/TritonToLinalg/TileChunkCoalescing.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TileChunkCoalescing.cpp
@@ -146,6 +146,18 @@ static std::optional<TileSeed> findSeed(ModuleOp moduleOp) {
     maxAxis = std::max<int32_t>(maxAxis, pid.getAxisAsInt());
   });
 
+  // Only one program-id op may read the coalesced axis: we replace the seed
+  // pid by the per-lane tile vector, but a second (non-CSE'd) pid of the same
+  // axis would keep returning the now-divided block id -> its tile indices
+  // would silently address the wrong tiles. Bail unless unique.
+  int32_t maxAxisPids = 0;
+  moduleOp.walk([&](triton::GetProgramIdOp pid) {
+    if (pid.getAxisAsInt() == maxAxis)
+      ++maxAxisPids;
+  });
+  if (maxAxisPids != 1)
+    return std::nullopt;
+
   // Full TA path: the launcher divides grid[maxAxis] by H, so the kernel-visible
   // num_programs(maxAxis) becomes grid/H instead of grid. If the kernel reads it
   // (e.g. for its own bound arithmetic) coalescing would silently change that
@@ -188,28 +200,68 @@ static std::optional<TileSeed> findSeed(ModuleOp moduleOp) {
           if (!range || range.getStart() != 0 || range.getEnd() != T)
             continue;
 
-          // Optional boundary mask: addi -> cmpi slt(offs, BOUND).
+          // Boundary-safety scan: taint everything pid-derived (through
+          // elementwise arith and shape ops) and require that NO tainted value
+          // feeds boundary handling, except the one canonical all-true tile
+          // mask `cmpi slt(offs, BOUND)` directly on offs with constant
+          // BOUND >= T and BOUND % T == 0 (provably all-true, droppable).
+          //
+          // Everything else is real boundary logic on the chunk axis and must
+          // block coalescing:
+          //   * cmpi with a runtime BOUND (kernel arg): a partial last tile may
+          //     exist; the lifted mask `(pid*H+h)*T + t < BOUND` is
+          //     non-separable (MaskAnalysis bails, load stays unconverted) and
+          //     the launcher's grid/H drops remainder tiles -> wrong results.
+          //   * cmpi reached through expand_dims/broadcast/addi/... or with
+          //     other predicates/operand order: same non-separability.
+          //   * min/max clamps and div/rem wraparound on pid-derived offsets:
+          //     the lifted addressing is non-affine across tiles (PtrAnalysis
+          //     bails).
           int64_t bound = 0;
           Value mask;
-          for (Operation *au : add.getResult().getUsers()) {
-            auto cmp = dyn_cast<arith::CmpIOp>(au);
-            if (!cmp || cmp.getPredicate() != arith::CmpIPredicate::slt ||
-                cmp.getLhs() != add.getResult())
-              continue;
-            int64_t b = 0;
-            if (!getConstInt(cmp.getRhs(), b) || b <= 0)
-              return;  // unsafe dynamic/empty mask; abandon this pid entirely
-            // A partial-tile mask (problem axis not a multiple of T) means the
-            // last tile is only partly valid: dropping it would read/write OOB,
-            // and a lifted 2D mask like `(pid*H+h)*T + t < BOUND` is
-            // non-separable (MaskAnalysis bails, load stays unconverted). So we
-            // refuse to coalesce this kernel.
-            if (b % T != 0)
-              return;  // unsafe; abandon this pid entirely
-            bound = b;
-            mask = cmp.getResult();
-            break;
+          bool unsafe = false;
+          DenseSet<Value> taint;
+          SmallVector<Value> twl;
+          taint.insert(pid.getResult());
+          twl.push_back(pid.getResult());
+          while (!twl.empty() && !unsafe) {
+            Value cur = twl.pop_back_val();
+            for (Operation *tu : cur.getUsers()) {
+              if (auto cmp = dyn_cast<arith::CmpIOp>(tu)) {
+                if (mask && cmp.getResult() == mask)
+                  continue;
+                int64_t b = 0;
+                if (!mask && cur == add.getResult() && cmp.getLhs() == cur &&
+                    cmp.getPredicate() == arith::CmpIPredicate::slt &&
+                    getConstInt(cmp.getRhs(), b) && b >= T && b % T == 0) {
+                  bound = b;
+                  mask = cmp.getResult();
+                  continue;
+                }
+                unsafe = true;
+                break;
+              }
+              if (isa<arith::MinSIOp, arith::MaxSIOp, arith::MinUIOp,
+                      arith::MaxUIOp, arith::RemSIOp, arith::RemUIOp,
+                      arith::DivSIOp, arith::DivUIOp, arith::CeilDivSIOp,
+                      arith::FloorDivSIOp>(tu)) {
+                unsafe = true;
+                break;
+              }
+              bool propagates = isa<triton::SplatOp, triton::ExpandDimsOp,
+                                    triton::BroadcastOp, triton::AddPtrOp>(tu);
+              if (auto *d = tu->getDialect())
+                propagates |= d->getNamespace() ==
+                              arith::ArithDialect::getDialectNamespace();
+              if (!propagates)
+                continue;  // load/store/scan/... results carry data, not offsets
+              for (Value r : tu->getResults())
+                if (taint.insert(r).second)
+                  twl.push_back(r);
+            }
           }
+          if (unsafe)
+            return;  // real boundary handling on the chunk axis; abandon pid
           // Match with or without a mask. Unmasked kernels (bound == 0) have no
           // static tile count; chooseH falls back to a power-of-two factor.
           result = TileSeed{pid, maxAxis, T, bound, mask};
@@ -410,6 +462,41 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
       if (!okAsLoadMask && !okAsStoreMask)
         return;
     }
+  }
+
+  // Preflight: from here on we create ops; every op of the region must be
+  // provably rebuildable in lifted form, otherwise the new op would fail the
+  // verifier AFTER the IR is already mutated -- a hard compile error instead
+  // of a silent fallback. Anything we cannot prove safe bails here, while the
+  // IR is still untouched.
+  Block *pidBlock = seed->pid->getBlock();
+  for (Operation *op : ordered) {
+    // Straight-line code only: a region op nested in scf.for/scf.if has
+    // loop-carried/branch semantics the elementwise lift does not model.
+    if (op->getBlock() != pidBlock)
+      return;
+    // Zero-operand ops (constants, make_range) reach the generic rebuild with
+    // a lifted result type but unchanged attributes (e.g. a DenseElementsAttr
+    // of the OLD shape) -> verifier failure.
+    if (!isa<triton::LoadOp, triton::StoreOp>(op) && op->getNumOperands() == 0)
+      return;
+    // arith.select: the lift turns a scalar condition into tensor<Hxi1>, which
+    // no longer matches the lifted tensor operands -> invalid op.
+    if (auto sel = dyn_cast<arith::SelectOp>(op)) {
+      bool condTensor = isa<RankedTensorType>(sel.getCondition().getType());
+      bool valTensor = isa<RankedTensorType>(sel.getTrueValue().getType());
+      if (condTensor != valTensor)
+        return;
+    }
+    // Lifting bumps the boundary-check axes; only block-pointer accesses carry
+    // them and those never reach here, so any non-empty set means an IR shape
+    // we did not anticipate.
+    if (auto ld = dyn_cast<triton::LoadOp>(op))
+      if (!ld.getBoundaryCheck().empty())
+        return;
+    if (auto st = dyn_cast<triton::StoreOp>(op))
+      if (!st.getBoundaryCheck().empty())
+        return;
   }
 
   auto liftTy = [&](Type t) -> RankedTensorType {

--- a/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/tile_chunk_coalescing.mlir
+++ b/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/tile_chunk_coalescing.mlir
@@ -122,3 +122,58 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
     tt.return
   }
 }
+
+// -----
+// A 2-D masked block may contain the tile-index signature on the outer grid
+// axis, but a dynamic boundary mask on that axis means grid/H is not provably
+// exact and the lifted mask is not a single structured slice. Keep the original
+// program shape instead.
+// CHECK-LABEL: module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+// CHECK-NOT: hacc.coalesce_factor
+// CHECK-LABEL: func.func @tile_chunk_skip_2d_dynamic_boundary
+// CHECK-NOT: tensor<2x256x256
+// CHECK: memref.copy
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @tile_chunk_skip_2d_dynamic_boundary(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                                      %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                                      %m: i32, %n: i32) {
+    %pid_m = tt.get_program_id x : i32
+    %pid_n = tt.get_program_id y : i32
+    %c256 = arith.constant 256 : i32
+    %zero = arith.constant dense<0.000000e+00> : tensor<256x256xf32>
+
+    %row_blk = arith.muli %pid_m, %c256 : i32
+    %row_range = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %row_splat = tt.splat %row_blk : i32 -> tensor<256xi32>
+    %row = arith.addi %row_splat, %row_range : tensor<256xi32>
+    %row_2d = tt.expand_dims %row {axis = 1 : i32} : tensor<256xi32> -> tensor<256x1xi32>
+
+    %col_blk = arith.muli %pid_n, %c256 : i32
+    %col_range = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %col_splat = tt.splat %col_blk : i32 -> tensor<256xi32>
+    %col = arith.addi %col_splat, %col_range : tensor<256xi32>
+    %col_2d = tt.expand_dims %col {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
+
+    %n_row = tt.splat %n : i32 -> tensor<256x1xi32>
+    %row_offset = arith.muli %row_2d, %n_row : tensor<256x1xi32>
+    %row_offset_bc = tt.broadcast %row_offset : tensor<256x1xi32> -> tensor<256x256xi32>
+    %col_bc = tt.broadcast %col_2d : tensor<1x256xi32> -> tensor<256x256xi32>
+    %offsets = arith.addi %row_offset_bc, %col_bc : tensor<256x256xi32>
+
+    %m_bound = tt.splat %m : i32 -> tensor<256x1xi32>
+    %row_mask = arith.cmpi slt, %row_2d, %m_bound : tensor<256x1xi32>
+    %row_mask_bc = tt.broadcast %row_mask : tensor<256x1xi1> -> tensor<256x256xi1>
+    %n_bound = tt.splat %n : i32 -> tensor<1x256xi32>
+    %col_mask = arith.cmpi slt, %col_2d, %n_bound : tensor<1x256xi32>
+    %col_mask_bc = tt.broadcast %col_mask : tensor<1x256xi1> -> tensor<256x256xi1>
+    %mask = arith.andi %row_mask_bc, %col_mask_bc : tensor<256x256xi1>
+
+    %src_base = tt.splat %arg0 : !tt.ptr<f32> -> tensor<256x256x!tt.ptr<f32>>
+    %src_ptr = tt.addptr %src_base, %offsets : tensor<256x256x!tt.ptr<f32>>, tensor<256x256xi32>
+    %val = tt.load %src_ptr, %mask, %zero : tensor<256x256x!tt.ptr<f32>>
+    %dst_base = tt.splat %arg1 : !tt.ptr<f32> -> tensor<256x256x!tt.ptr<f32>>
+    %dst_ptr = tt.addptr %dst_base, %offsets : tensor<256x256x!tt.ptr<f32>>, tensor<256x256xi32>
+    tt.store %dst_ptr, %val, %mask : tensor<256x256x!tt.ptr<f32>>
+    tt.return
+  }
+}


### PR DESCRIPTION
### Summary

This PR tightens `TileChunkCoalescing` safety checks for cases where the coalesced grid axis also participates in dynamic boundary handling.

Tile chunk coalescing prepends an `H` lane and the launcher shrinks the corresponding grid dimension by `H`. If a dynamic boundary mask depends on that same program id, the pass cannot prove that `grid / H` is exact, and the lifted mask may no longer be representable as a structured rectangular slice. In those cases, the pass now keeps the original uncoalesced program shape.

### Changes

- Require a unique `get_program_id` use on the coalesced axis before rewriting.
- Add a boundary-safety scan for pid-derived values:
  - allow only canonical static all-true tile masks,
  - reject dynamic boundary masks and non-affine boundary logic on the chunk axis.
- Add a preflight check before mutating IR so unsupported lifted ops bail out cleanly.
- Teach strided load/store rewrite to see through shape-only pointer wrappers such as broadcast(expand_dims(splat(ptr)))`.
- Add a MLIR regression test for 2D dynamic-boundary tile chunk cases.

### Verification

- Ran `tile_chunk_coalescing.mlir` through `triton-opt | FileCheck`.
