### PR TITLE
[API](fix) Remove auto-zero-padding in _load_block_pointer

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1070,10 +1070,7 @@ class TritonSemantic(Generic[TensorTy]):
         # Check `boundary_check` argument
         boundary_check = self._canonicalize_boundary_check(boundary_check, dst_ty.get_block_shapes())
 
-        if boundary_check and padding is None:
-            padding = ir.PADDING_OPTION.PAD_ZERO
-
-    # Build IR
+        # Build IR
         return self.tensor(
             self.builder.create_tensor_pointer_load(ptr.handle, boundary_check, padding, cache, eviction, is_volatile),
             dst_ty)

--- a/third_party/ascend/unittest/pytest_ut/test_boundary_check.py
+++ b/third_party/ascend/unittest/pytest_ut/test_boundary_check.py
@@ -263,6 +263,103 @@ def test_complex_base():
     assert torch.allclose(out_tensor.cpu(), torch.tensor(expected, device='cpu'), atol=1e-4)
 
 
+# ========== Test 8: padding_option="" (no padding, in-bounds) + boundary_check ==========
+@triton.jit
+def no_padding_in_bounds_kernel(
+    out_ptr,
+    in_ptr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    ptr = tl.make_block_ptr(base=in_ptr, shape=(BLOCK_SIZE * 2, ), strides=(1, ), offsets=(0, ),
+                            block_shape=(BLOCK_SIZE, ), order=(0, ))
+    data = tl.load(ptr, boundary_check=(0, ), padding_option="")
+    result = tl.sum(data)
+    tl.store(out_ptr, result)
+
+
+def test_no_padding_in_bounds():
+    """
+    boundary_check enabled but all accesses are in-bounds (BLOCK_SIZE out of BLOCK_SIZE*2).
+    With padding_option="", the result should still be correct since no out-of-bounds access occurs.
+    """
+    BLOCK_SIZE = 64
+    in_tensor = torch.randn(BLOCK_SIZE * 2, dtype=torch.float32).npu()
+    out_tensor = torch.zeros(1, dtype=torch.float32).npu()
+    no_padding_in_bounds_kernel[(1, )](
+        out_ptr=out_tensor,
+        in_ptr=in_tensor,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+    expected = in_tensor.cpu()[:BLOCK_SIZE].sum().item()
+    assert torch.allclose(out_tensor.cpu(), torch.tensor(expected, device='cpu'), atol=1e-4)
+
+
+# ========== Test 9: padding_option="" (no padding, out-of-bounds) + boundary_check ==========
+@triton.jit
+def no_padding_out_of_bounds_kernel(
+    out_ptr,
+    in_ptr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    ptr = tl.make_block_ptr(base=in_ptr, shape=(BLOCK_SIZE, ), strides=(1, ), offsets=(0, ),
+                            block_shape=(BLOCK_SIZE * 2, ), order=(0, ))
+    data = tl.load(ptr, boundary_check=(0, ), padding_option="")
+    result = tl.sum(data)
+    tl.store(out_ptr, result)
+
+
+def test_no_padding_out_of_bounds():
+    """
+    boundary_check enabled with actual out-of-bounds access (BLOCK_SIZE*2 load from BLOCK_SIZE data).
+    With padding_option="", out-of-bounds values are undefined — the kernel should still compile and
+    not crash.
+    """
+    BLOCK_SIZE = 64
+    in_tensor = torch.randn(BLOCK_SIZE, dtype=torch.float32).npu()
+    out_tensor = torch.zeros(1, dtype=torch.float32).npu()
+    # Should compile and run without error
+    no_padding_out_of_bounds_kernel[(1, )](
+        out_ptr=out_tensor,
+        in_ptr=in_tensor,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+
+# ========== Test 10: padding_option="" with dynamic base + boundary_check ==========
+@triton.jit
+def no_padding_dynamic_base_kernel(
+    out_ptr,
+    in_ptr,
+    offset: tl.int32,
+    BLOCK_SIZE: tl.constexpr,
+):
+    base = in_ptr + offset
+    ptr = tl.make_block_ptr(base=base, shape=(BLOCK_SIZE * 2, ), strides=(1, ), offsets=(0, ),
+                            block_shape=(BLOCK_SIZE, ), order=(0, ))
+    data = tl.load(ptr, boundary_check=(0, ), padding_option="")
+    result = tl.sum(data)
+    tl.store(out_ptr, result)
+
+
+def test_no_padding_dynamic_base():
+    """
+    Same as test_no_padding_in_bounds but with a dynamic base address (offset).
+    All accesses are in-bounds, so results should match the reference.
+    """
+    BLOCK_SIZE = 64
+    offset = 32
+    in_tensor = torch.randn(BLOCK_SIZE * 4, dtype=torch.float32).npu()
+    out_tensor = torch.zeros(1, dtype=torch.float32).npu()
+    no_padding_dynamic_base_kernel[(1, )](
+        out_ptr=out_tensor,
+        in_ptr=in_tensor,
+        offset=offset,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+    expected = in_tensor.cpu()[offset:offset + BLOCK_SIZE].sum().item()
+    assert torch.allclose(out_tensor.cpu(), torch.tensor(expected, device='cpu'), atol=1e-4)
+
+
 if __name__ == "__main__":
     print("Running all boundary_check tests...")
     test_static_base()
@@ -272,4 +369,7 @@ if __name__ == "__main__":
     test_nan_padding()
     test_multi_advance()
     test_complex_base()
+    test_no_padding_in_bounds()
+    test_no_padding_out_of_bounds()
+    test_no_padding_dynamic_base()
     print("All tests completed successfully!")


### PR DESCRIPTION
## Summary
This PR removes an Ascend-local change in `_load_block_pointer` that automatically defaulted `padding` to `PAD_ZERO` when `boundary_check` was set. Upstream does not have this default; users control padding explicitly via `tl.load`'s `padding_option` parameter.

Before this change, the Ascend backend silently applied zero-padding when `boundary_check` was specified without an explicit `padding_option`:

```python
# semantic.py _load_block_pointer (before)
if boundary_check and padding is None:
    padding = ir.PADDING_OPTION.PAD_ZERO
```

After this PR, the behavior matches upstream — `padding` stays `None` unless the user explicitly sets `padding_option`:

```python
# semantic.py _load_block_pointer (after)
# (the if-block above is removed; padding flows through unchanged)
```

## Why this rollback is safe

### The auto-default was redundant

The `tl.load` API already provides `padding_option` for users to control padding behavior:

```python
# Before: boundary_check without padding_option implicitly used zero-padding
x = tl.load(block_ptr, boundary_check=(0,), padding_option="")

# After: boundary_check without padding_option passes padding=None
# To get the same behavior, explicitly specify zero:
x = tl.load(block_ptr, boundary_check=(0,), padding_option="zero")
```

### No behavioral change for most usage patterns

| Call pattern | Before (Ascend) | After (aligned) |
|---|---|---|
| `tl.load(block_ptr)` | no padding | no padding (unchanged) |
| `tl.load(block_ptr, boundary_check=(0,), padding_option="zero")` | zero-padding | zero-padding (unchanged) |
| `tl.load(block_ptr, boundary_check=(0,), padding_option="nan")` | nan-padding | nan-padding (unchanged) |
| `tl.load(block_ptr, boundary_check=(0,), padding_option="")` | **silently zero-padded** | passes `padding=None` |

The only affected case is the last row — `boundary_check` with empty `padding_option`. Upstream treats this as "user did not request any padding", while the Ascend fork silently overrode it to zero. Users who relied on this implicit behavior should add `padding_option="zero"` explicitly.

### Aligned with upstream semantics

Upstream's `_load_block_pointer` has never contained this auto-default logic. Removing it eliminates an unnecessary divergence and makes the load behavior predictable across backends.

## User Impact

Minimal impact expected. If any existing kernel relies on the implicit zero-padding when using `boundary_check` with an empty `padding_option`:

```python
# If your kernel does this:
x = tl.load(block_ptr, boundary_check=(0, 1,))

# And relies on out-of-bounds elements being zero, update to:
x = tl.load(block_ptr, boundary_check=(0, 1), padding_option="zero")
```

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
	[rules](https://cbea.ms/git-commit/#why-not-how).
- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
	- [x] This PR does not need a test because it removes a local extension and aligns with upstream; existing tests cover the block pointer load path.
	- [ ] I have added tests.
		- `/python/test` for end-to-end tests
- Select one of the following.
	- [x] I have not added any `lit` tests.
	- [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
		including the "tests should be minimal" section. (Usually running Python code
		and using the instructions it generates is not minimal.)
