### PR TITLE
[ssbuffer](fix): restore control-attr transfer and split split matmul pattern adjustments

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/PreserveControlAttrsCanonicalize.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/PreserveControlAttrsCanonicalize.cpp
@@ -95,16 +95,17 @@ private:
                 return defOp;
         }
 
-        // Fallback: search recentInserts in reverse, skip nested candidates
+        Block *oldBlock = oldOp->getBlock();
+        if (!oldBlock)
+            return nullptr;
+
+        // Fallback: search recentInserts in reverse, but only accept same-block candidates.
         for (Operation *candidate : llvm::reverse(recentInserts.getArrayRef())) {
             if (!canTransferAttrs(oldOp, candidate))
                 continue;
 
-            // Skip candidates nested inside another new control flow op
-            Operation *parent = candidate->getParentOp();
-            if (parent && recentInserts.contains(parent) && isTrackedControlFlowOp(parent))
+            if (candidate->getBlock() != oldBlock)
                 continue;
-
             return candidate;
         }
         return nullptr;

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/preserve_control_attrs_canonicalize_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/preserve_control_attrs_canonicalize_test.mlir
@@ -88,3 +88,72 @@ module {
     return
   }
 }
+
+
+// -----
+
+// CHECK-LABEL: "func.func"() <{{.*}}sym_name = "nested_for_replacement_keeps_outer_main_loop"
+// CHECK: %{{.*}} = "scf.for"(
+// CHECK: }) {ssbuffer.block_id = 16 : i32} : (index, index, index, i32) -> i32
+// CHECK-NOT: ssbuffer.main_loop
+// CHECK-NOT: ssbuffer.core_type
+// CHECK-NEXT: "scf.yield"
+// CHECK-NEXT: }) {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.main_loop = 0 : i32} : (index, index, index, i32) -> i32
+
+module {
+  func.func @nested_for_replacement_keeps_outer_main_loop(%seed: i32) -> i32 {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0 = arith.constant 0 : index
+    %c2 = arith.constant 2 : index
+    %c1 = arith.constant 1 : index
+    %0:2 = scf.for %iv = %c0 to %c2 step %c1 iter_args(%acc = %seed, %dead = %c0_i32) -> (i32, i32) {
+      %1 = scf.for %j = %c0 to %c2 step %c1 iter_args(%sum = %acc) -> (i32) {
+        %2 = arith.addi %sum, %c1_i32 : i32
+        scf.yield %2 : i32
+      } {ssbuffer.block_id = 16 : i32}
+      scf.yield %1, %dead : i32, i32
+    } {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.main_loop = 0 : i32}
+    return %0#0 : i32
+  }
+}
+
+// -----
+
+
+// CHECK-LABEL: "func.func"() <{{.*}}sym_name = "nested_multi_for_main_loop_not_inner"
+// CHECK: %{{.*}}:2 = "scf.for"(
+// CHECK: }) {ssbuffer.block_id = 16 : i32} : (index, index, index, i32) -> i32
+// CHECK-NOT: ssbuffer.main_loop
+// CHECK-NOT: ssbuffer.pipe_stage
+// CHECK-NEXT: %{{.*}} = "scf.for"(
+// CHECK-NEXT: ^bb0
+// CHECK: }) {ssbuffer.pipe_stage = 3 : i32} : (index, index, index, i32) -> i32
+// CHECK-NOT: ssbuffer.main_loop
+// CHECK-NOT: ssbuffer.block_id
+// CHECK-NEXT: "scf.yield"
+// CHECK-NEXT: }) {ssbuffer.main_loop = 0 : i32} : (index, index, index, i32, i32) -> (i32, i32)
+// CHECK-NOT: ssbuffer.block_id
+// CHECK-NOT: ssbuffer.pipe_stage
+
+module {
+  func.func @nested_multi_for_main_loop_not_inner(%seed: i32) -> (i32, i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0 = arith.constant 0 : index
+    %c2 = arith.constant 2 : index
+    %c1 = arith.constant 1 : index
+    %0:2 = scf.for %iv = %c0 to %c2 step %c1 iter_args(%acc = %seed, %dead = %c0_i32) -> (i32, i32) {
+      %1 = scf.for %j = %c0 to %c2 step %c1 iter_args(%sum = %acc) -> (i32) {
+        %2 = arith.addi %sum, %c1_i32 : i32
+        scf.yield %2 : i32
+      } {ssbuffer.block_id = 16 : i32}
+      %3 = scf.for %k = %c0 to %c2 step %c1 iter_args(%sum2 = %acc) -> (i32) {
+        %4 = arith.addi %sum2, %c1_i32 : i32
+        scf.yield %4 : i32
+      } {ssbuffer.pipe_stage = 3 : i32}
+      scf.yield %1, %3 : i32, i32
+    } {ssbuffer.main_loop = 0 : i32}
+    return %0#0, %0#1 : i32, i32
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/separate_cv_scope_canonicalize_ut.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/separate_cv_scope_canonicalize_ut.mlir
@@ -14,12 +14,12 @@
 // CHECK: arith.addi
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<VECTOR>}
 // CHECK: scope.scope : () -> () {
 // CHECK: arith.muli
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<CUBE>}
 module {
   func.func @basic_scope_split_and_cleanup(%vec_in: i32, %cube_in: i32, %outv: memref<1xi32>, %outc: memref<1xi32>) {
     %idxv = arith.constant {ssbuffer.core_type = "VECTOR"} 0 : index
@@ -43,12 +43,12 @@ module {
 // CHECK: scf.if
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<VECTOR>}
 // CHECK: scope.scope : () -> () {
 // CHECK: scf.if
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<CUBE>}
 module {
   func.func @container_if_without_core_type(%cond: i1, %vec_in: i32, %cube_in: i32, %outv: memref<1xi32>, %outc: memref<1xi32>) {
     %idxv = arith.constant {ssbuffer.core_type = "VECTOR"} 0 : index
@@ -78,13 +78,13 @@ module {
 // CHECK: scf.yield
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<VECTOR>}
 // CHECK: scope.scope : () -> () {
 // CHECK: scf.if
 // CHECK: scf.yield
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<CUBE>}
 module {
   func.func @mixed_if_yield_neutralize_scalar(%cond: i1, %vec_in: i32, %cube_in: i32, %outv: memref<1xi32>, %outc: memref<1xi32>) {
     %idxv = arith.constant {ssbuffer.core_type = "VECTOR"} 0 : index
@@ -115,12 +115,12 @@ module {
 // CHECK: scf.for
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<VECTOR>}
 // CHECK: scope.scope : () -> () {
 // CHECK: scf.for
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<CUBE>}
 module {
   func.func @mixed_for_iter_args_index_neutralize(%lb: i32, %ub: i32, %vec_init: i32, %cube_init: index, %outv: memref<1xi32>, %outc: memref<1xindex>) {
     %idxv = arith.constant {ssbuffer.core_type = "VECTOR"} 0 : index
@@ -147,12 +147,12 @@ module {
 // CHECK: scf.for
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<VECTOR>}
 // CHECK: scope.scope : () -> () {
 // CHECK: scf.for
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<CUBE>}
 module {
   func.func @for_forwarding_use_can_be_ignored(%lb: i32, %ub: i32, %vec_init: i32, %cube_init: i32, %outv: memref<1xi32>, %outc: memref<1xi32>) {
     %idxv = arith.constant {ssbuffer.core_type = "VECTOR"} 0 : index
@@ -184,13 +184,13 @@ module {
 // CHECK: arith.addf
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<VECTOR>}
 // CHECK: scope.scope : () -> () {
 // CHECK: scf.for
 // CHECK-NOT: arith.addf
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<CUBE>}
 module {
   func.func @for_cross_slot_yield_use_does_not_preserve_source(%lb: i32, %ub: i32, %vec_src: f32, %vec_dst: f32, %cube_init: i32, %outv: memref<1xf32>, %outc: memref<1xi32>) {
     %idxv = arith.constant {ssbuffer.core_type = "VECTOR"} 0 : index
@@ -219,13 +219,13 @@ module {
 // CHECK: scf.if
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<VECTOR>}
 // CHECK: scope.scope : () -> () {
 // CHECK: scf.if
 // CHECK: scf.while
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<CUBE>}
 module {
   func.func @while_dependency_preserved_for_cube(%cond: i1, %vec_init: i64, %cube_init: i64, %limit: i64, %outv: memref<1xi64>, %outc: memref<1xi64>) {
     %idxv = arith.constant {ssbuffer.core_type = "VECTOR"} 0 : index
@@ -264,13 +264,13 @@ module {
 // CHECK: scf.if
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<VECTOR>}
 // CHECK: scope.scope : () -> () {
 // CHECK: scf.while
 // CHECK: scf.if
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<CUBE>}
 module {
   func.func @while_inner_if_terminator_use_blocks_dead_shell_erase(%if_cond: i1, %vec_init: i32, %cube_init: i32, %limit: i32, %outv: memref<1xi32>, %outc: memref<1xi32>) {
     %idxv = arith.constant {ssbuffer.core_type = "VECTOR"} 0 : index
@@ -306,12 +306,12 @@ module {
 // CHECK: scf.while
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<VECTOR>}
 // CHECK: scope.scope : () -> () {
 // CHECK: scf.while
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<CUBE>}
 module {
   func.func @while_forwarding_use_can_be_ignored(%vec_init: i64, %cube_init: i64, %limit: i64, %outv: memref<1xi64>, %outc: memref<1xi64>) {
     %idxv = arith.constant {ssbuffer.core_type = "VECTOR"} 0 : index
@@ -351,7 +351,7 @@ module {
 // CHECK: scf.while
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<VECTOR>}
 // CHECK: scope.scope : () -> () {
 // CHECK: %[[FOR:.*]]:2 = scf.for
 // CHECK: %[[IF:.*]]:2 = scf.if
@@ -361,7 +361,7 @@ module {
 // CHECK: scf.yield %[[IF]]#0, %[[IF]]#1 : i32, i64
 // CHECK: memref.store %[[FOR]]#1
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<CUBE>}
 module {
   func.func @for_same_slot_loop_carry_preserved(%lb: i32, %ub: i32, %cond: i1, %vec_init: i32, %cube_init: i64, %outv: memref<1xi32>, %outc: memref<1xi64>) {
     %idxv = arith.constant {ssbuffer.core_type = "VECTOR"} 0 : index
@@ -401,12 +401,12 @@ module {
 // CHECK: scf.if
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<VECTOR>}
 // CHECK: scope.scope : () -> () {
 // CHECK: memref.load
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<CUBE>}
 module {
   func.func @memref_slot_neutralize_uses_alloc(%cond: i1, %src: memref<4xi32>, %vec_seed: i32, %outv: memref<1xi32>, %outc: memref<1xi32>) {
     %idxv = arith.constant {ssbuffer.core_type = "VECTOR"} 0 : index
@@ -435,12 +435,12 @@ module {
 // CHECK: arith.addf
 // CHECK: bufferization.materialize_in_destination
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<VECTOR>}
 // CHECK: scope.scope : () -> () {
 // CHECK: scf.if
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<CUBE>}
 module {
   func.func @static_tensor_slot_neutralize_uses_dense_zero(%cond: i1, %src: tensor<4xf32>, %cube_seed: i32, %outv: memref<4xf32>, %outc: memref<1xi32>) {
     %idxc = arith.constant {ssbuffer.core_type = "CUBE"} 0 : index
@@ -469,13 +469,13 @@ module {
 // CHECK: arith.addi
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<VECTOR>}
 // CHECK: scope.scope : () -> () {
 // CHECK: arith.muli
 // CHECK-NOT: arith.addi
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<CUBE>}
 module {
   func.func @cross_scope_live_user_keeps_producer(%cube_seed: i32, %vec_seed: i32, %outv: memref<1xi32>, %outc: memref<1xi32>) {
     %idxv = arith.constant {ssbuffer.core_type = "VECTOR"} 0 : index
@@ -496,14 +496,14 @@ module {
 // CHECK-NOT: scf.if
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<VECTOR>}
 // CHECK: scope.scope : () -> () {
 // CHECK: scf.if
 // CHECK: scf.yield
 // CHECK: memref.store
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<CUBE>}
 module {
   func.func @short_core_type_list_falls_back_to_first(%cond: i1, %vec_seed: i32, %cube_seed0: i32, %cube_seed1: i32, %outv: memref<1xi32>, %outc0: memref<1xi32>, %outc1: memref<1xi32>) {
     %idxv = arith.constant {ssbuffer.core_type = "VECTOR"} 0 : index
@@ -549,7 +549,7 @@ module {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   memref.store %[[RES_V]]
 // CHECK-NEXT:   scope.return
-// CHECK-NEXT: } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CHECK-NEXT: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<VECTOR>}
 // CUBE scope: scf.if also folds to arith.select (preserved, NOT neutralized
 // to 0); for loop runs the correct number of times with CUBE memref.store
 // CHECK-NEXT: scope.scope : () -> () {
@@ -558,7 +558,7 @@ module {
 // CHECK-NEXT:     memref.store
 // CHECK-NEXT:   }
 // CHECK-NEXT:   scope.return
-// CHECK-NEXT: } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+// CHECK-NEXT: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<CUBE>}
 module {
   func.func @vector_if_bound_with_cube_loop_side_effect(
       %cond: i1, %ub_a: i32, %ub_b: i32, %vinit: i32, %cube_val: i32,
@@ -597,7 +597,7 @@ module {
 // CHECK:      scope.scope : () -> () {
 // CHECK-NEXT:   memref.store
 // CHECK-NEXT:   scope.return
-// CHECK-NEXT: } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CHECK-NEXT: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<VECTOR>}
 // CUBE scope: the inner if folds to arith.select (no side effects in its
 // branches) and feeds the condition of the preserved outer scf.if guarding
 // the CUBE store; the condition is NOT neutralized to a constant.
@@ -607,7 +607,7 @@ module {
 // CHECK-NEXT:     memref.store
 // CHECK-NEXT:   }
 // CHECK-NEXT:   scope.return
-// CHECK-NEXT: } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+// CHECK-NEXT: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<CUBE>}
 module {
   func.func @vector_if_condition_gates_cube_if_branch(
       %cond: i1, %va: i1, %vb: i1, %cube_val: i32,
@@ -652,7 +652,7 @@ module {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   memref.store
 // CHECK-NEXT:   scope.return
-// CHECK-NEXT: } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CHECK-NEXT: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<VECTOR>}
 // CUBE scope: the inner if folds to arith.select feeding scf.condition; the
 // while loop and its CUBE store body are preserved (condition not constant).
 // CHECK-NEXT: scope.scope : () -> () {
@@ -665,7 +665,7 @@ module {
 // CHECK-NEXT:     scf.yield
 // CHECK-NEXT:   }
 // CHECK-NEXT:   scope.return
-// CHECK-NEXT: } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+// CHECK-NEXT: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<CUBE>}
 module {
   func.func @vector_if_condition_gates_cube_while_body(
       %va: i1, %vb: i1, %vec_init: i32, %cube_val: i32,

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/separate_cv_scope_ut.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/separate_cv_scope_ut.mlir
@@ -13,12 +13,12 @@
 // CHECK: tensor.extract
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<VECTOR>}
 // CHECK: scope.scope : () -> () {
 // CHECK: scf.for
 // CHECK: memref.store
 // CHECK: scope.return
-// CHECK: } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+// CHECK: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<CUBE>}
 module {
   func.func @if_results_feed_followup_loop_structural_user_repro(
       %lb: i32,


### PR DESCRIPTION
Replace nested-op exclusion with same-block check for fallback attribute transfer candidates, and add null guard for oldOp block.