### PR TITLE
[ssbuffer](fix) Resolve cycle detection failure for nested sub-region operations in PlanCubeBlock

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
@@ -163,8 +163,9 @@ bool DependencyCycleDetector::detectCycle()
     llvm::DenseSet<Operation *> externalUsers;
     for (auto *op : group) {
         forEachUser(op, memGraph, [&](Operation *user) {
-            if (!group.contains(user)) {
-                externalUsers.insert(user);
+            auto *userInBlock = getAncestorInBlock(user, block);
+            if (userInBlock && !group.contains(userInBlock)) {
+                externalUsers.insert(userInBlock);
             }
         });
     }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_plan_cube_block_cycle.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_plan_cube_block_cycle.mlir
@@ -1,0 +1,38 @@
+// RUN: triton-opt --plan-cube-block %s | FileCheck %s
+
+module {
+
+  // S208. Test cycle detection across sub-regions (e.g., scf.if).
+  // The memory dependence graph (memGraph) only tracks memory dependencies within the same block/region.
+  // Thus, directly tracing from an operation inside scf.if (linalg.fill) cannot reach its main-block consumer (linalg.matmul).
+  //
+  // By resolving the inner-region operation to its main-block ancestor (scf.if), the cycle detector
+  // correctly identifies the cyclic dependency: group (%alloc) -> scf.if (external) -> group (%result).
+  // This prevents invalid grouping that would otherwise cause a topological scheduling deadlock.
+
+  // CHECK-LABEL: func.func @test_subregion_dependency_cycle(
+  // CHECK:       [[ALLOC:%[A-Za-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = [[TC_CUBE0:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"}
+  // CHECK:       scf.if %{{.*}} {
+  // CHECK:         linalg.fill {{.*}} {ssbuffer.block_id = [[TC_CUBE1:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"}
+  // CHECK:       }
+  // CHECK:       memref.copy {{.*}} {ssbuffer.block_id = [[TC_CUBE2:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"}
+  // CHECK:       linalg.matmul {input_precision = "ieee", ssbuffer.block_id = [[TC_CUBE3:[0-9]+]] : i32, ssbuffer.core_type = "CUBE"}
+  func.func @test_subregion_dependency_cycle(%arg0: memref<32x32xf32>, %arg1: memref<32x32xf32>, %arg2: tensor<32x32xf32>, %cond: i1) -> tensor<32x32xf32> {
+    %alloc = memref.alloc() {ssbuffer.core_type = "CUBE"} : memref<32x32xf32>
+
+    scf.if %cond {
+      %cst = arith.constant 0.0 : f32
+      linalg.fill {ssbuffer.core_type = "CUBE"} ins(%cst : f32) outs(%alloc : memref<32x32xf32>)
+    }
+
+    memref.copy %arg0, %alloc {ssbuffer.core_type = "CUBE"} : memref<32x32xf32> to memref<32x32xf32>
+    %tensor = bufferization.to_tensor %alloc restrict writable {ssbuffer.core_type = "CUBE"} : memref<32x32xf32>
+    %out = tensor.empty() {ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %result = linalg.matmul {input_precision = "ieee", ssbuffer.core_type = "CUBE"}
+      ins(%tensor, %arg2 : tensor<32x32xf32>, tensor<32x32xf32>)
+      outs(%out : tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    return %result : tensor<32x32xf32>
+  }
+}
+


### PR DESCRIPTION
## PR Title / PR 标题
`fix(ssbuffer): resolve cycle detection failure for nested sub-region operations in PlanCubeBlock | 修复 PlanCubeBlock 中嵌套子区域操作的循环依赖检测失效问题`

---

## 1. Overview / 概述

### English
This PR addresses an issue in the `PlanCubeBlockPass` cycle detection mechanism (`DependencyCycleDetector`) where dependency cycles involving operations nested within sub-regions (such as `scf.if` or `scf.for`) were not correctly identified. By resolving nested user operations to their respective block-level ancestor operations before checking for external group users, the pass correctly identifies cyclic dependencies that span across control-flow regions, preventing scheduling deadlocks during topological partitioning.

### 中文
本 PR 解决了 `PlanCubeBlockPass` 循环依赖检测机制（`DependencyCycleDetector`）中的一个问题，即包含嵌套在子区域（例如 `scf.if` 或 `scf.for`）中的操作的依赖环路无法被正确识别。通过在检查外部组用户之前，将嵌套的用户操作解析为其对应的块级祖先操作，该 Pass 能够正确识别跨越控制流区域的循环依赖关系，从而防止拓扑分区过程中的调度死锁。

---

## 2. Key Changes / 关键变更

### English
- **`PlanCubeBlock.cpp`**:
  - Modified `DependencyCycleDetector::detectCycle()` to map each nested user operation (`user`) to its top-level block ancestor (`userInBlock`) using `getAncestorInBlock(user, block)` before checking membership in the candidate `group`.
  - Only insert the resolved `userInBlock` into the `externalUsers` set if it is valid and not already a member of the current grouping.
- **`test_plan_cube_block_cycle.mlir`**:
  - Added a new MLIR unit test `test_subregion_dependency_cycle` to verify that a cycle involving an `scf.if` block containing a `linalg.fill` that writes to a shared `%alloc` is correctly identified and separated into distinct Cube blocks, preventing invalid fusion.

### 中文
- **`PlanCubeBlock.cpp`**:
  - 修改了 `DependencyCycleDetector::detectCycle()`，在检查候选组（`group`）的成员资格之前，使用 `getAncestorInBlock(user, block)` 将每个嵌套的用户操作（`user`）映射到其顶层的块级祖先操作（`userInBlock`）。
  - 仅当解析后的 `userInBlock` 有效且不属于当前分组时，才将其插入到 `externalUsers`（外部用户）集合中。
- **`test_plan_cube_block_cycle.mlir`**:
  - 新增了一个 MLIR 单元测试 `test_subregion_dependency_cycle`，以验证当 `scf.if` 块中包含对共享 `%alloc` 进行写入的 `linalg.fill` 操作时，其循环依赖关系能被正确识别，并被划分到不同的 Cube 块中，从而避免了非法的算子融合。

---

## 3. Technical Deep-Dive / 技术细节剖析

### English
In MLIR, operations can be nested within regions of container operations (such as `scf.if` or `scf.for`). When the `PlanCubeBlockPass` analyzes a `Block`, it schedules operations and groups them at that specific block level. 

During cycle detection in `DependencyCycleDetector::detectCycle()`, we iterate over the users of a candidate group to identify "external users" that might transition back into the group (creating a cycle). 
1. **The Bug**: Previously, the cycle detector checked direct users. If a user was nested inside a sub-region (e.g., a `linalg.fill` inside `scf.if`), the detector would register `linalg.fill` as the external user. However, `MemoryDependenceGraph` (`memGraph`) maps memory dependencies at the block level. When querying `memGraph.getExecAfter(linalg.fill)`, the graph yields no block-level downstream dependencies because `linalg.fill` resides in a nested block. Consequently, the cycle detector concluded that no path existed from this external user back to the group, failing to detect the cycle.
2. **The Fix**: By invoking `getAncestorInBlock(user, block)`, the nested operation (e.g., `linalg.fill`) is resolved to its ancestor in the current block (e.g., `scf.if`). Since `scf.if` represents the collective memory effects of its nested region, `memGraph` correctly tracks block-level memory dependencies for `scf.if`. Querying `memGraph.getExecAfter(scf.if)` successfully yields the main-block operations executing after it, enabling the DFS traversal to trace back to the group and flag the cycle.

### 中文
在 MLIR 中，操作可以嵌套在容器操作（例如 `scf.if` 或 `scf.for`）的区域（Regions）中。当 `PlanCubeBlockPass` 分析一个 `Block` 时，它会在该特定块级别对操作进行调度和分组。

在 `DependencyCycleDetector::detectCycle()` 的环路检测过程中，我们会迭代候选组的外部用户，以识别可能重新指向该组的路径（从而形成环路）：
1. **缺陷原因**：此前，环路检测器直接检查直接用户。如果某个用户嵌套在子区域内（例如 `scf.if` 内部的 `linalg.fill`），检测器会直接将 `linalg.fill` 记为外部用户。然而，内存依赖图（`memGraph`）是在块级（Block-level）映射内存依赖关系的。当查询 `memGraph.getExecAfter(linalg.fill)` 时，由于 `linalg.fill` 处于嵌套块中，该图不会返回块级的下游依赖关系。因此，检测器会误判为“不存在从该外部用户返回该组的路径”，从而漏检环路。
2. **修复方案**：通过调用 `getAncestorInBlock(user, block)`，嵌套的操作（例如 `linalg.fill`）将被解析为它在当前块中的祖先操作（例如 `scf.if`）。由于 `scf.if` 封装了其嵌套区域的集体内存效应，`memGraph` 能够正确跟踪 `scf.if` 在块级的内存依赖关系。此时查询 `memGraph.getExecAfter(scf.if)` 可以成功获取在其后执行的主块操作，从而使 DFS 遍历能够追踪回该组，并正确标记环路。

---

## 4. Impact & Risk Assessment / 影响与风险评估

### English
- **Breaking Changes**: No. This change is entirely internal to the compilation pipeline's analysis phase and does not alter any public APIs or IR definitions.
- **Performance Impact**: Negligible. Resolving ancestors via parent-pointer traversal is extremely lightweight (typically 1–3 levels of region traversal). Correct cycle detection prevents topological scheduling deadlocks, improving pipeline robustness.
- **Backward Compatibility**: Fully backward compatible.

### 中文
- **破坏性变更**: 否。此更改完全属于编译流水线分析阶段的内部逻辑，未修改任何公共 API 或 IR 定义。
- **性能影响**: 微乎其微。通过父指针遍历解析祖先操作是非常轻量级的操作（通常仅需遍历 1~3 层区域）。正确的环路检测可以避免拓扑调度死锁，从而提升流水线的鲁棒性。
- **向后兼容性**: 完全向后兼容。

---

## 5. Verification & Testing / 测试与验证方法

### English
- **Automated Unit Tests**:
  - Run the newly added MLIR test file:
    ```bash
    triton-opt --plan-cube-block third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_plan_cube_block_cycle.mlir
    ```
  - The test verifies that a dependency cycle passing through an `scf.if` container is identified, forcing `%alloc`, `linalg.fill` (inside `scf.if`), and `linalg.matmul` to be assigned to different `ssbuffer.block_id` values instead of being incorrectly fused.

### 中文
- **自动单元测试**:
  - 运行新添加的 MLIR 测试文件：
    ```bash
    triton-opt --plan-cube-block third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_plan_cube_block_cycle.mlir
    ```
  - 该测试验证了跨越 `scf.if` 容器的依赖环路能被正确识别，从而强制将 `%alloc`、`linalg.fill`（位于 `scf.if` 内部）和 `linalg.matmul` 分配到不同的 `ssbuffer.block_id` 中，避免了错误的算子融合。