### PR TITLE
[ssbuffer](fix) Check sync direction when reuse the flagIds, only the…

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/FlagIdReuse.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/FlagIdReuse.h
@@ -49,6 +49,9 @@ private:
     bool hasPath(llvm::SmallSet<Operation *, CVPipeline::INIT_SIZE> &visited, Operation *from, Operation *to);
     void preworkForAnalyze(const llvm::SmallVector<Operation *> &syncOps);
 
+    enum class SyncDir { VectorToCube, CubeToVector };
+    SyncDir getFlagDirection(int flagId);
+
     // Lifecycle boundary of a flag group: earliest set (acquire) / latest wait (release).
     Operation *getEarliestSet(int flagId);
     Operation *getLatestWait(int flagId);

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
@@ -65,7 +65,6 @@ static constexpr llvm::StringLiteral interceptrFunc[] {
   "parallel_based_bwd_kernel",
   "chunk_generalized_iplr_delta_rule_fwd_kernel_h",
   "chunk_dplr_fwd_kernel_h",
-  "prepare_wy_repr_bwd_kernel",
 };
 
 static LogicalResult verifyFuncNames(ModuleOp module)

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/FlagIdReuse.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/FlagIdReuse.cpp
@@ -143,11 +143,39 @@ bool FlagIdReuseManager::flagReleasedBefore(int before, int after)
     return opPrecedes(release, acquire);
 }
 
+// A transfer's data-movement direction, read off its sync pipes. Cube->Vector
+// transfers (fixpipe) ride the FIX/V pipes; Vector->Cube transfers (copy) ride
+// the MTE*/M pipes. The two never share a pipe, so a single pipe decides.
+FlagIdReuseManager::SyncDir FlagIdReuseManager::getFlagDirection(int flagId)
+{
+    for (auto *op : flagIdToOps[flagId]) {
+        PipeAttr srcPipe, dstPipe;
+        if (auto setOp = llvm::dyn_cast<SyncBlockSetOp>(op)) {
+            srcPipe = setOp.getTpipeAttr();
+            dstPipe = setOp.getPipeAttr();
+        } else if (auto waitOp = llvm::dyn_cast<SyncBlockWaitOp>(op)) {
+            srcPipe = waitOp.getTpipeAttr();
+            dstPipe = waitOp.getPipeAttr();
+        }
+        for (PipeAttr pipe : {srcPipe, dstPipe}) {
+            if (pipe && (pipe.getPipe() == hivm::PIPE::PIPE_FIX || pipe.getPipe() == hivm::PIPE::PIPE_V)) {
+                return SyncDir::CubeToVector;
+            }
+        }
+    }
+    return SyncDir::VectorToCube;
+}
+
 // Conservative: two flags interfere unless one is provably released before the
 // other is acquired. Any uncertainty falls back to "interfere" (no reuse), so a
 // reused id is never shared by two concurrently-live transfers.
 bool FlagIdReuseManager::flagsInterfere(int lhs, int rhs)
 {
+    // Opposite-direction transfers (Vector->Cube vs Cube->Vector) execute
+    // concurrently on the two cores, so their flag lifetimes always overlap
+    if (getFlagDirection(lhs) != getFlagDirection(rhs)) {
+        return true;
+    }
     return !flagReleasedBefore(lhs, rhs) && !flagReleasedBefore(rhs, lhs);
 }
 

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/flag_reuse_cross_direction.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/flag_reuse_cross_direction.mlir
@@ -1,0 +1,63 @@
+// RUN: triton-opt --add-block-id-for-control-ops --data-dependency-analysis --inter-core-transfer-and-sync --mark-main-loop %s | FileCheck %s --implicit-check-not="flag = -1" --implicit-check-not="flag = 15" --implicit-check-not="<PIPE_FIX>, <PIPE_V>] flag = 2" --implicit-check-not="<PIPE_MTE3>, <PIPE_MTE1>] flag = 1"
+
+// Regression for the cross-direction flag-id reuse bug. A Vector->Cube copy
+// (set[VECTOR, MTE3, MTE1]) used to be merged onto the same flag as an adjacent
+// Cube->Vector fixpipe wait (wait[VECTOR, FIX, V]), e.g. in the wild:
+//
+//     hivm.hir.sync_block_set [<VECTOR>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
+//     hivm.hir.sync_block_wait[<VECTOR>, <PIPE_FIX>,  <PIPE_V>]    flag = 1   <- WRONG
+//
+// The two directions run concurrently on the two cores, so a shared counting
+// flag lets the wait steal the set's signal. They must never share a flag id.
+// Here a long Vector->Cube->Vector matmul chain needs more than MAX_FLAG_ID
+// flags, forcing reuse; the result must partition strictly by direction.
+
+module {
+  func.func @flag_reuse_cross_direction() {
+    %cst = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 0.000000e+00 : f32
+    %e0 = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+    %v0 = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : f32) outs(%e0 : tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    // round 1: V->C (matmul consumes %v0), then C->V (exp consumes %m1)
+    %ef1 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %m1 = linalg.matmul {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%v0, %v0 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%ef1 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %v1 = math.exp %m1 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+
+    %ef2 = tensor.empty() {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %m2 = linalg.matmul {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE"} ins(%v1, %v1 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%ef2 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %v2 = math.exp %m2 {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+
+    %ef3 = tensor.empty() {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %m3 = linalg.matmul {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} ins(%v2, %v2 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%ef3 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %v3 = math.exp %m3 {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+
+    %ef4 = tensor.empty() {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %m4 = linalg.matmul {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} ins(%v3, %v3 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%ef4 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %v4 = math.exp %m4 {ssbuffer.block_id = 9 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+
+    %ef5 = tensor.empty() {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %m5 = linalg.matmul {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"} ins(%v4, %v4 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%ef5 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %v5 = math.exp %m5 {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+
+    %ef6 = tensor.empty() {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %m6 = linalg.matmul {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "CUBE"} ins(%v5, %v5 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%ef6 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %v6 = math.exp %m6 {ssbuffer.block_id = 13 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+
+    %ef7 = tensor.empty() {ssbuffer.block_id = 14 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %m7 = linalg.matmul {ssbuffer.block_id = 14 : i32, ssbuffer.core_type = "CUBE"} ins(%v6, %v6 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%ef7 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %v7 = math.exp %m7 {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+
+    %ef8 = tensor.empty() {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %m8 = linalg.matmul {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"} ins(%v7, %v7 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%ef8 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %v8 = math.exp %m8 {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @flag_reuse_cross_direction
+// Vector->Cube (MTE3/MTE1) copies all reuse one flag; Cube->Vector (FIX/V)
+// fixpipes all reuse another; the two never collide.
+// CHECK: <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+// CHECK: <PIPE_FIX>, <PIPE_V>] flag = 1
+// CHECK: return

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/flag_reuse_over_limit.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/flag_reuse_over_limit.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt --add-block-id-for-control-ops --data-dependency-analysis --inter-core-transfer-and-sync --mark-main-loop %s | FileCheck %s --implicit-check-not="flag = -1" --implicit-check-not="flag = 15"
+// RUN: triton-opt --add-block-id-for-control-ops --data-dependency-analysis --inter-core-transfer-and-sync --mark-main-loop %s | FileCheck %s --implicit-check-not="flag = -1" --implicit-check-not="flag = 15" --implicit-check-not="<PIPE_FIX>, <PIPE_V>] flag = 2" --implicit-check-not="<PIPE_MTE3>, <PIPE_MTE1>] flag = 1"
 
 module {
   func.func @flag_reuse_over_limit() {
@@ -34,7 +34,15 @@ module {
   }
 }
 
+// This is an alternating Cube->Vector / Vector->Cube chain that needs more than
+// MAX_FLAG_ID flags before reuse. Opposite-direction transfers run concurrently
+// on the two cores (a shared counting-flag would let one core's wait steal the
+// other's set), so they must never share a flag id. Same-direction transfers,
+// serialized by their pipe's FIFO, all collapse onto one flag. The result is a
+// strict partition by direction: every Cube->Vector (FIX/V) sync uses one flag
+// and every Vector->Cube (MTE3/MTE1) sync uses a different one (enforced by the
+// implicit-check-not directives in the RUN line).
 // CHECK-LABEL: func.func @flag_reuse_over_limit
-// CHECK: {{flag = }}[[REUSED_FLAG:[0-9]+]]{{$}}
-// CHECK-COUNT-29: {{flag = }}[[REUSED_FLAG]]{{$}}
+// CHECK: <PIPE_FIX>, <PIPE_V>] flag = 1
+// CHECK: <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
 // CHECK: return


### PR DESCRIPTION
… same directions are accepted

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

The bug in the flagID reuse module is fixed. In the previous version, the sequence of operations in the same block is determined based on the program sequence. However, the operations are later split by core, which causes the actual sequence to be inconsistent with the original program sequence. 

In this version, the program sequence is split by pipe, ensuring that the actual sequence is consistent with the split program sequence.