### PR TITLE
[Docs](fix) Update memory ops documentation examples and constraints

### DIFF
--- a/docs/zh/python-api/_ascend_constraints.py
+++ b/docs/zh/python-api/_ascend_constraints.py
@@ -71,12 +71,11 @@ CONSTRAINTS = {
     },
     "triton.language.advance": {
         "constraints": [
-            "DataType: Ascend does not support fp64, uint16, uint32, uint64, uint8 (hardware limitation).",
-            "仅允许通过调整order参数的顺序来表达转置语义，不能通过调整stride参数的顺序实现转置语义",
-            "与较复杂的循环和分支语句搭配使用可能出现编译问题",
+            "DataType: Ascend A2/A3 does not support uint16/uint32/uint64/fp64, \
+                Ascend 950 does not support fp64 (hardware limitation).",
+            "Compilation issues may arise when used with complex loops and branch statements."
         ],
-        "example":
-        "triton.language.advance",
+        "example": "triton.language.advance",
     },
     "triton.language.arange": {
         "constraints": [
@@ -501,24 +500,25 @@ CONSTRAINTS = {
     },
     "triton.language.load": {
         "constraints": [
-            "DataType: Ascend does not support fp64, uint16, uint32, uint64, uint8 (hardware limitation).",
+            "DataType: Ascend A2/A3 does not support uint16/uint32/uint64/fp64, \
+                Ascend 950 does not support fp64 (hardware limitation).",
             "``cache_modifier``: has no effect on Ascend.",
             "``eviction_policy``: has no effect on Ascend.",
             "``volatile``: has no effect on Ascend.",
-            "``padding_option``: is not supported on Ascend.",
-            "与分支、循环语句搭配使用时的泛化性问题，pointer和mask的计算过程涉及较复杂的循环和分支语句可能出现编译问题",
+            "Compatibility issues with branch and loop statements: \
+                Complex pointer and mask calculations involving branches or loops may cause compilation failures.",
         ],
-        "example":
-        "triton.language.load",
+        "example": "triton.language.load",
     },
     "triton.language.load_tensor_descriptor": {
         "constraints": [
-            "DataType: Ascend does not support uint16, uint32, uint64 (hardware limitation).",
-            "make_tensor_descriptor / load_tensor_descriptor / store_tensor_descriptor 需配套使用，不能与 tl.load() / tl.store() 混用",
-            "Triton 3.2.0 存在部分函数（如cast）的兼容性问题，建议升级至 3.4.0",
+            "DataType: Ascend A2/A3 does not support uint16/uint32/uint64/fp64, \
+                Ascend 950 does not support fp64 (hardware limitation).",
+            "`make_tensor_descriptor`, `load_tensor_descriptor` and `store_tensor_descriptor` \
+                must be used as a suite in Triton 3.2.x. Do not mix them with `tl.load()` or `tl.store()`.",
+            "Compatibility issues exist for certain functions (e.g. cast) in Triton 3.2.x."
         ],
-        "example":
-        "triton.language.load_tensor_descriptor",
+        "example": "triton.language.load_tensor_descriptor",
     },
     "triton.language.log": {
         "constraints": [
@@ -534,23 +534,23 @@ CONSTRAINTS = {
     },
     "triton.language.make_block_ptr": {
         "constraints": [
-            "DataType: Ascend does not support fp64, uint16, uint32, uint64, uint8 (hardware limitation).",
-            "仅允许通过调整order参数的顺序来表达转置语义，不能通过调整stride参数的顺序实现转置语义",
-            "与分支、循环语句搭配使用时的泛化性问题",
+            "DataType: Ascend A2/A3 does not support uint16/uint32/uint64/fp64, \
+                Ascend 950 does not support fp64 (hardware limitation).",
+            "Transpose logic can only be implemented by adjusting the `order` parameter. \
+                Do not reorder strides to achieve transpose.",
+            "Compatibility issues may occur when used together with branch and loop statements."
         ],
-        "example":
-        "triton.language.make_block_ptr",
+        "example": "triton.language.make_block_ptr",
     },
     "triton.language.make_tensor_descriptor": {
         "constraints": [
-            "DataType: Ascend does not support uint16, uint32, uint64 (hardware limitation).",
-            "``strides``: 前面的维度必须是16字节的整数倍，最后一维必须是连续存储的",
-            "make_tensor_descriptor / load_tensor_descriptor / store_tensor_descriptor 需配套使用，不能与 tl.load() / tl.store() 混用",
-            "不支持padding_option入参",
-            "Triton 3.2.0 存在部分函数（如cast）的兼容性问题，建议升级至 3.4.0",
+            "DataType: Ascend A2/A3 does not support uint16/uint32/uint64/fp64, \
+                Ascend 950 does not support fp64 (hardware limitation).",
+            "`make_tensor_descriptor`, `load_tensor_descriptor` and `store_tensor_descriptor` \
+                must be used as a suite in Triton 3.2.x. Do not mix them with `tl.load()` or `tl.store()`.",
+            "Compatibility issues exist for certain functions (e.g. cast) in Triton 3.2.x."
         ],
-        "example":
-        "triton.language.make_tensor_descriptor",
+        "example": "triton.language.make_tensor_descriptor",
     },
     "triton.language.max": {
         "constraints": [
@@ -733,10 +733,22 @@ CONSTRAINTS = {
         ],
         "example": "triton.language.static_range",
     },
-    "triton.language.store": {},
+    "triton.language.store": {
+        "constraints": [
+            "DataType: Ascend A2/A3 does not support uint16/uint32/uint64/fp64, \
+                Ascend 950 does not support fp64 (hardware limitation).",
+            "Compatibility issues with branch and loop statements: \
+                Complex pointer and mask calculations involving branches or loops may cause compilation failures.",
+        ],
+        "example": "triton.language.store",
+    },
     "triton.language.store_tensor_descriptor": {
         "constraints": [
-            "DataType: Ascend does not support uint16, uint32, uint64 (hardware limitation).",
+            "DataType: Ascend A2/A3 does not support uint16/uint32/uint64/fp64, \
+                Ascend 950 does not support fp64 (hardware limitation).",
+            "`make_tensor_descriptor`, `load_tensor_descriptor` and `store_tensor_descriptor` \
+                must be used as a suite in Triton 3.2.x. Do not mix them with `tl.load()` or `tl.store()`.",
+            "Compatibility issues exist for certain functions (e.g. cast) in Triton 3.2.x."
         ],
         "example": "triton.language.store_tensor_descriptor",
     },

--- a/docs/zh/python-api/_examples/triton.language.advance.py
+++ b/docs/zh/python-api/_examples/triton.language.advance.py
@@ -1,5 +1,17 @@
+import torch
+import triton
+import triton.language as tl
+
+
 @triton.jit
-def kernel(output_ptr, x_ptr, y_ptr, z_ptr, output_ptr1, XB: tl.constexpr, YB: tl.constexpr, ZB: tl.constexpr):
+def kernel(output_ptr, x_ptr, XB: tl.constexpr, YB: tl.constexpr, ZB: tl.constexpr):
+    """
+    Test tl.advance for 3D block_ptr:
+    1. Create block_ptr with initial offset (3, 1, 2)
+    2. Use tl.advance to roll back offset to (0, 0, 0)
+    3. Load full tensor and store to output
+    """
+    # Create 3D block pointer with initial offset (3, 1, 2)
     block_ptr_in = tl.make_block_ptr(
         base=x_ptr,
         shape=(XB, YB, ZB),
@@ -8,9 +20,11 @@ def kernel(output_ptr, x_ptr, y_ptr, z_ptr, output_ptr1, XB: tl.constexpr, YB: t
         block_shape=(XB, YB, ZB),
         order=(2, 1, 0),
     )
-    bbptr = tl.advance(block_ptr_in, (-3, -1, -2))
-    X = tl.load(bbptr)
+    # Roll back offset to origin (0, 0, 0) via tl.advance
+    reset_ptr = tl.advance(block_ptr_in, (-3, -1, -2))
+    data = tl.load(reset_ptr)
 
+    # Output block pointer
     block_ptr_out = tl.make_block_ptr(
         base=output_ptr,
         shape=(XB, YB, ZB),
@@ -19,4 +33,19 @@ def kernel(output_ptr, x_ptr, y_ptr, z_ptr, output_ptr1, XB: tl.constexpr, YB: t
         block_shape=(XB, YB, ZB),
         order=(2, 1, 0),
     )
-    tl.store(block_ptr_out, X)
+    tl.store(block_ptr_out, data)
+
+
+def test_advance():
+    XB, YB, ZB = 4, 4, 4
+    x = torch.arange(XB * YB * ZB).reshape(XB, YB, ZB).npu()
+    output = torch.zeros_like(x)
+
+    # Run Triton kernel
+    kernel[(1,)](output, x, XB, YB, ZB)
+
+    assert torch.all(output.cpu() == x.cpu())
+
+
+if __name__ == "__main__":
+    test_advance()

--- a/docs/zh/python-api/_examples/triton.language.load.py
+++ b/docs/zh/python-api/_examples/triton.language.load.py
@@ -1,11 +1,32 @@
+import torch
+import triton
+import triton.language as tl
+
+
 @triton.jit
-def kernel(out_ptr0, in_ptr0, in_ptr1, in_ptr2, stride_in_r, XS: tl.constexpr, RS: tl.constexpr):
+def kernel(output_ptr, x_ptr, N: tl.constexpr):
+    """
+    Test tl.load/tl.store with a 1D tensor pointer:
+    1. Load data via pointer + offset
+    2. Store loaded data to output
+    """
     pid = tl.program_id(0)
-    in_idx0 = pid * XS + tl.arange(0, XS)
-    in_idx1 = tl.arange(0, RS)
-    tmp0 = tl.load(in_ptr0 + in_idx0)
-    tmp1 = tl.load(in_ptr1 + in_idx1)
-    in_idx2 = tmp0[:, None] * stride_in_r + tmp1[None, :]
-    tmp2 = tl.load(in_ptr2 + in_idx2)
-    out0_idx = in_idx0[:, None] * RS + in_idx1[None, :]
-    tl.store(out_ptr0 + out0_idx, tmp2)
+    offset = pid * N + tl.arange(0, N)[:]
+    data = tl.load(x_ptr + offset)
+    tl.store(output_ptr + offset, data)
+
+
+def test_load_store():
+    N = 128
+    total = 4 * N
+    x = torch.arange(total, dtype=torch.float32).npu()
+    output = torch.zeros_like(x)
+
+    # Run Triton kernel
+    kernel[(4,)](output, x, N)
+
+    assert torch.allclose(output.cpu(), x.cpu())
+
+
+if __name__ == "__main__":
+    test_load_store()

--- a/docs/zh/python-api/_examples/triton.language.load_tensor_descriptor.py
+++ b/docs/zh/python-api/_examples/triton.language.load_tensor_descriptor.py
@@ -1,12 +1,43 @@
+import torch
+import triton
+import triton.language as tl
+
+
 @triton.jit
 def inplace_abs(in_out_ptr, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+    """
+    Load a block of data from a tensor descriptor and store the element-wise
+    absolute value back in place.
+    """
     desc = tl.make_tensor_descriptor(
         in_out_ptr,
         shape=[M, N],
         strides=[N, 1],
         block_shape=[M_BLOCK, N_BLOCK],
     )
+
     moffset = tl.program_id(0) * M_BLOCK
     noffset = tl.program_id(1) * N_BLOCK
+
+    # 1.use tl.load_tensor_descriptor/tl.store_tensor_descriptor
+    # value = tl.load_tensor_descriptor(desc, [moffset, noffset])
+    # tl.store_tensor_descriptor(desc, [moffset, noffset], tl.abs(value))
+    # 2.use desc.load/desc.store indirectly (suggested)
     value = desc.load([moffset, noffset])
     desc.store([moffset, noffset], tl.abs(value))
+
+
+def test_tensor_descriptor():
+    M, N = 256, 256
+    M_BLOCK, N_BLOCK = 32, 32
+    x = torch.randn(M, N, dtype=torch.float32).npu()
+    x_ref = x.abs()
+
+    grid = (M // M_BLOCK, N // N_BLOCK)
+    inplace_abs[grid](x, M, N, M_BLOCK, N_BLOCK)
+
+    assert torch.allclose(x.cpu(), x_ref.cpu())
+
+
+if __name__ == "__main__":
+    test_tensor_descriptor()

--- a/docs/zh/python-api/_examples/triton.language.make_block_ptr.py
+++ b/docs/zh/python-api/_examples/triton.language.make_block_ptr.py
@@ -1,25 +1,51 @@
+import torch
+import triton
+import triton.language as tl
+
+
 @triton.jit
-def kernel(in0_ptr: tl.tensor, out0_ptr: tl.tensor, in0_stride0: int, in0_stride1: int, in0_stride2: int,
-           in0_stride_order0: tl.constexpr, in0_stride_order1: tl.constexpr, in0_stride_order2: tl.constexpr,
-           out0_stride0: int, out0_stride1: int, out0_stride2: int, out0_stride_order0: tl.constexpr,
-           out0_stride_order1: tl.constexpr, out0_stride_order2: tl.constexpr, s0: int, s1: int, s2: int,
-           tile_size0: tl.constexpr, tile_size1: tl.constexpr, tile_size2: tl.constexpr):
-    tile_id0 = tl.program_id(axis=0)
-    tile_id1 = tl.program_id(axis=1)
-    tile_id2 = tl.program_id(axis=2)
-    offset0 = (tile_id0 * tile_size0).to(tl.int32)
-    offset1 = (tile_id1 * tile_size1).to(tl.int32)
-    offset2 = (tile_id2 * tile_size2).to(tl.int32)
-    in0_bptr = tl.make_block_ptr(in0_ptr, (s0, s1, s2), (in0_stride0, in0_stride1, in0_stride2),
-                                 (offset0, offset1, offset2), (tile_size0, tile_size1, tile_size2),
-                                 order=(in0_stride_order0, in0_stride_order1, in0_stride_order2))
-    in0 = tl.load(in0_bptr,
-                  boundary_check=(in0_stride_order0, in0_stride_order1, in0_stride_order2)).to(in0_ptr.type.element_ty)
+def kernel(output_ptr, x_ptr, XB: tl.constexpr, YB: tl.constexpr, ZB: tl.constexpr):
+    """
+    Test tl.make_block_ptr for 3D tensor:
+    1. Create 3D block pointer with initial offset (1, 2, 3)
+    2. Load data with boundary check and zero padding
+    3. Store the loaded block to output tensor
+    """
+    # Create block pointer starting at offset (1, 2, 3)
+    block_ptr_in = tl.make_block_ptr(
+        base=x_ptr,
+        shape=(XB, YB, ZB),
+        strides=(YB * ZB, ZB, 1),
+        offsets=(1, 2, 3),
+        block_shape=(2, 2, 2),
+        order=(2, 1, 0),
+    )
+    # Load with boundary check and out-of-bounds zero padding
+    data = tl.load(block_ptr_in, boundary_check=(0, 1, 2), padding_option="zero")
 
-    out0 = in0
+    # Create block pointer for output at origin (0, 0, 0)
+    block_ptr_out = tl.make_block_ptr(
+        base=output_ptr,
+        shape=(XB, YB, ZB),
+        strides=(YB * ZB, ZB, 1),
+        offsets=(0, 0, 0),
+        block_shape=(2, 2, 2),
+        order=(2, 1, 0),
+    )
+    tl.store(block_ptr_out, data)
 
-    out0_bptr = tl.make_block_ptr(out0_ptr, (s0, s1, s2), (out0_stride0, out0_stride1, out0_stride2),
-                                  (offset0, offset1, offset2), (tile_size0, tile_size1, tile_size2),
-                                  order=(out0_stride_order0, out0_stride_order1, out0_stride_order2))
-    tl.store(out0_bptr, out0.to(out0_bptr.type.element_ty),
-             boundary_check=(out0_stride_order0, out0_stride_order1, out0_stride_order2))
+
+def test_make_block_ptr():
+    XB, YB, ZB = 4, 4, 4
+    x = torch.arange(XB * YB * ZB, dtype=torch.float32).reshape(XB, YB, ZB).npu()
+    output = torch.zeros_like(x)
+
+    kernel[(1,)](output, x, XB, YB, ZB)
+
+    ref = torch.zeros((2, 2, 2), dtype=torch.float32).npu()
+    ref[:, :, :1] = x[1:3, 2:4, 3:4]
+    assert torch.allclose(output[:2, :2, :2].cpu(), ref.cpu())
+
+
+if __name__ == "__main__":
+    test_make_block_ptr()

--- a/docs/zh/python-api/_examples/triton.language.make_tensor_descriptor.py
+++ b/docs/zh/python-api/_examples/triton.language.make_tensor_descriptor.py
@@ -1,12 +1,43 @@
+import torch
+import triton
+import triton.language as tl
+
+
 @triton.jit
 def inplace_abs(in_out_ptr, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+    """
+    Load a block of data from a tensor descriptor and store the element-wise
+    absolute value back in place.
+    """
     desc = tl.make_tensor_descriptor(
         in_out_ptr,
         shape=[M, N],
         strides=[N, 1],
         block_shape=[M_BLOCK, N_BLOCK],
     )
+
     moffset = tl.program_id(0) * M_BLOCK
     noffset = tl.program_id(1) * N_BLOCK
+
+    # 1.use tl.load_tensor_descriptor/tl.store_tensor_descriptor
+    # value = tl.load_tensor_descriptor(desc, [moffset, noffset])
+    # tl.store_tensor_descriptor(desc, [moffset, noffset], tl.abs(value))
+    # 2.use desc.load/desc.store indirectly (suggested)
     value = desc.load([moffset, noffset])
     desc.store([moffset, noffset], tl.abs(value))
+
+
+def test_tensor_descriptor():
+    M, N = 256, 256
+    M_BLOCK, N_BLOCK = 32, 32
+    x = torch.randn(M, N, dtype=torch.float32).npu()
+    x_ref = x.abs()
+
+    grid = (M // M_BLOCK, N // N_BLOCK)
+    inplace_abs[grid](x, M, N, M_BLOCK, N_BLOCK)
+
+    assert torch.allclose(x.cpu(), x_ref.cpu())
+
+
+if __name__ == "__main__":
+    test_tensor_descriptor()

--- a/docs/zh/python-api/_examples/triton.language.store.py
+++ b/docs/zh/python-api/_examples/triton.language.store.py
@@ -1,14 +1,32 @@
+import torch
+import triton
+import triton.language as tl
+
+
 @triton.jit
-def kernel(out_ptr0, in_ptr1, in_ptr2, in_ptr3, stride_in_r, XS: tl.constexpr, RS: tl.constexpr):
+def kernel(output_ptr, x_ptr, N: tl.constexpr):
+    """
+    Test tl.load/tl.store with a 1D tensor pointer:
+    1. Load data via pointer + offset
+    2. Store loaded data to output
+    """
     pid = tl.program_id(0)
-    in_idx0 = pid * XS + tl.arange(0, XS)
-    in_idx1 = tl.arange(0, RS)
-    tmp0 = tl.arange(0, XS)
-    tmp1 = tl.load(in_ptr1 + in_idx1)
-    in_idx2 = tmp0[:, None] * stride_in_r + tmp1[None, :]
-    tmp2 = tl.load(in_ptr2 + in_idx2)
-    tmp2 = tl.math.exp(tmp2)
-    tmp3 = tl.load(in_ptr3 + in_idx1)
-    tmp3 = tmp3 + 1 - 8
-    out0_idx = in_idx0[:, None] * RS + tmp3[None, :]
-    tl.store(out_ptr0 + out0_idx, tmp2)
+    offset = pid * N + tl.arange(0, N)[:]
+    data = tl.load(x_ptr + offset)
+    tl.store(output_ptr + offset, data)
+
+
+def test_load_store():
+    N = 128
+    total = 4 * N
+    x = torch.arange(total, dtype=torch.float32).npu()
+    output = torch.zeros_like(x)
+
+    # Run Triton kernel
+    kernel[(4,)](output, x, N)
+
+    assert torch.allclose(output.cpu(), x.cpu())
+
+
+if __name__ == "__main__":
+    test_load_store()

--- a/docs/zh/python-api/_examples/triton.language.store_tensor_descriptor.py
+++ b/docs/zh/python-api/_examples/triton.language.store_tensor_descriptor.py
@@ -1,12 +1,43 @@
+import torch
+import triton
+import triton.language as tl
+
+
 @triton.jit
 def inplace_abs(in_out_ptr, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+    """
+    Load a block of data from a tensor descriptor and store the element-wise
+    absolute value back in place.
+    """
     desc = tl.make_tensor_descriptor(
         in_out_ptr,
         shape=[M, N],
         strides=[N, 1],
         block_shape=[M_BLOCK, N_BLOCK],
     )
+
     moffset = tl.program_id(0) * M_BLOCK
     noffset = tl.program_id(1) * N_BLOCK
+
+    # 1.use tl.load_tensor_descriptor/tl.store_tensor_descriptor
+    # value = tl.load_tensor_descriptor(desc, [moffset, noffset])
+    # tl.store_tensor_descriptor(desc, [moffset, noffset], tl.abs(value))
+    # 2.use desc.load/desc.store indirectly (suggested)
     value = desc.load([moffset, noffset])
     desc.store([moffset, noffset], tl.abs(value))
+
+
+def test_tensor_descriptor():
+    M, N = 256, 256
+    M_BLOCK, N_BLOCK = 32, 32
+    x = torch.randn(M, N, dtype=torch.float32).npu()
+    x_ref = x.abs()
+
+    grid = (M // M_BLOCK, N // N_BLOCK)
+    inplace_abs[grid](x, M, N, M_BLOCK, N_BLOCK)
+
+    assert torch.allclose(x.cpu(), x_ref.cpu())
+
+
+if __name__ == "__main__":
+    test_tensor_descriptor()

--- a/docs/zh/python-api/triton.language.rst
+++ b/docs/zh/python-api/triton.language.rst
@@ -69,11 +69,11 @@ Memory/Pointer Ops
 
     load
     store
-    make_block_ptr
-    advance
     make_tensor_descriptor
     load_tensor_descriptor
     store_tensor_descriptor
+    make_block_ptr
+    advance
 
 Indexing Ops
 ------------


### PR DESCRIPTION
## Summary
Refine documentation examples and platform constraints for Triton memory operations.
This change covers seven core memory APIs (`tl.load`, `tl.store`,
`tl.make_block_ptr`, `tl.advance`, `tl.make_tensor_descriptor`,
`tl.load_tensor_descriptor`, `tl.store_tensor_descriptor`).
﻿
All example scripts are standardized with the following improvements:
- Rewrite and simplify test logic to eliminate redundant calculation
- Uniform kernel docstring style with clear step-by-step workflow
- Provide self-contained, fully runnable test entries
﻿
Meanwhile, Ascend-specific constraint descriptions are unified and polished to consistent technical English, accurately recording hardware limitations and usage specifications of memory access APIs.

## User Impact
No code behavior change. This PR only updates documentation examples and
constraint metadata.

## Document Render Preview
Example: triton.language.load
<img width="1177" height="751" alt="image" src="https://github.com/user-attachments/assets/ced90c9d-5a98-48e1-b1ad-29a1bb30a130" />

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
	[rules](https://cbea.ms/git-commit/#why-not-how).
- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
	- [x] This PR does not need a test because it only updates documentation examples and constraint metadata.
	- [ ] I have added tests.
		- `/python/test` for end-to-end tests
- Select one of the following.
	- [x] I have not added any `lit` tests.
	- [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
		including the "tests should be minimal" section. (Usually running Python code
		and using the instructions it generates is not minimal.)
