### PR TITLE
[ssbuffer](fix) set fallback when existing tensor iter_args dependency and execution is parallel

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h
@@ -23,9 +23,13 @@
 #ifndef TRITON_ASCEND_ANALYZE_DATAFLOW_H
 #define TRITON_ASCEND_ANALYZE_DATAFLOW_H
 
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Pass/Pass.h"
+
+#include <string>
 
 namespace mlir {
 namespace triton {

--- a/third_party/ascend/include/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeArgs.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeArgs.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ASCEND_ANALYZE_ARGS_H
+#define TRITON_ASCEND_ANALYZE_ARGS_H
+
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+
+#include <string>
+
+namespace mlir {
+namespace triton {
+
+// Data structures shared across the AnalyzeArgs pass. They describe the
+// per-block and per-main_loop state collected during the dataflow graph
+// analysis. Kept in the header so other tools / TUs can consume them
+// without re-declaring the same shape.
+
+// Adjacency-list node describing one compute block that participates in
+// inter-core (VECTOR<->CUBE) data transfer within a main_loop forOp.
+struct BlockNodeInfo {
+  int mainloopId = 0;
+  std::string belongingScope;
+  int blockId = 0;
+  llvm::SmallVector<BlockNodeInfo *, 4> outNodes;
+};
+
+// Data collected for each tensor iter_arg: the first block_id that uses it.
+// (We rely on checkTensorArgsUseAfterUpdate to guarantee every subsequent use
+// happens before the iter_arg is updated, so the "first use" block_id is the
+// only piece of block_id context we need.)
+struct TensorArgBlockInfo {
+  int firstBlockId = -1;
+};
+
+// Per-main_loop collected state. One entry per forOp marked with
+// `ssbuffer.main_loop`, carrying the block nodes of that main_loop and
+// enough context (the forOp itself + scope) to do further cross-scope
+// linking later.
+struct MainLoopData {
+  scf::ForOp forOp;
+  std::string scope;
+  int mainloopId = 0;
+  llvm::SmallVector<BlockNodeInfo, 8> blockNodes;
+};
+
+// The "boundary" nodes of one scope in the dataflow graph:
+//   - inDegreeZero:  entry-point nodes (no other same-scope node can reach
+//                    them via the dataflow graph)
+//   - outDegreeZero: exit-point nodes (they cannot reach any other
+//                    same-scope node)
+// Used for both VECTOR and CUBE sides.
+struct DegreeInfo {
+  llvm::SmallVector<BlockNodeInfo *, 4> inDegreeZero;
+  llvm::SmallVector<BlockNodeInfo *, 4> outDegreeZero;
+};
+
+// Per-block tensor iter_arg usage inside one main_loop:
+//   updated: indices of tensor iter_args whose new value is produced by
+//            this block (its op's result is yielded by the forOp)
+//   used:    indices of tensor iter_args that this block consumes as
+//            operands on the next iteration
+struct BlockIterArgUsage {
+  llvm::DenseSet<unsigned> updated;
+  llvm::DenseSet<unsigned> used;
+};
+
+} // namespace triton
+} // namespace mlir
+
+#endif // TRITON_ASCEND_ANALYZE_ARGS_H

--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -22,10 +22,15 @@
 
 #ifndef ADD_AUTO_SCHEDULING_COMMON_UTILS_H
 #define ADD_AUTO_SCHEDULING_COMMON_UTILS_H
+#include <functional>
 #include <string_view>
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Value.h"
+#include "mlir/IR/Visitors.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace mlir {
@@ -42,6 +47,7 @@ inline constexpr llvm::StringLiteral kVectorFirst = "ssbuffer.vector_first";
 inline constexpr llvm::StringLiteral kAddFromMatmul = "ssbuffer.add_from_matmul";
 inline constexpr llvm::StringLiteral kMainLoop = "ssbuffer.main_loop";
 inline constexpr llvm::StringLiteral kTcoreType = "hivm.tcore_type";
+inline constexpr llvm::StringLiteral kTightlyCoupledBuffer = "hivm.tightly_coupled_buffer";
 inline constexpr llvm::StringLiteral kIf = "ssbuffer.if";
 inline constexpr llvm::StringLiteral kIntraBuffer = "ssbuffer.intra_buffer";
 inline constexpr llvm::StringLiteral kAnalyzeFlagId = "ssbuffer.analyze_flag_id";
@@ -92,6 +98,35 @@ llvm::LogicalResult verifyOpBlockId(Operation *op);
 int getAvailableBlockId(ModuleOp module);
 void setFallbackAttr(ModuleOp module);
 bool isScfOp(Operation *op);
+
+// Walk up the parent chain from `op` to find the enclosing scope.scope op
+// and return its core type as a string ("VECTOR" / "CUBE"). Returns
+// "UNKNOWN" if no scope.scope with a tcore_type attribute is found.
+std::string getEnclosingScope(Operation *op);
+
+// Returns the iter_arg index of `v` in `forOp` if `v` is one of forOp's
+// region iter_args AND its type is a ranked tensor; otherwise returns -1.
+// Used to detect tensor-typed loop-carried values.
+int getTensorIterArgIndex(Value v, scf::ForOp forOp);
+
+// Resolve a Value to its underlying memref.alloc. When traceCasts is true,
+// walk through memref.memory_space_cast / bufferization.to_tensor /
+// bufferization.to_memref (used on the VECTOR side, which consumes a
+// CUBE-produced buffer through such casts). Bounded to a small depth to
+// guard against pathological cases.
+memref::AllocOp findAlloc(Value v, bool traceCasts);
+
+// Walk every scf::ForOp in `module` marked with `ssbuffer.main_loop` and
+// invoke `callback(forOp, mainloopId)` for each. The callback returns a
+// WalkResult so it can short-circuit the walk when desired.
+//
+// The typed-walk callback (`scf::ForOp` parameter) already filters to forOps,
+// so callers don't need to dyn_cast. The `hasAttr` + `getAttrOfType` checks
+// are pulled into the helper so every site that needs the
+// "main_loop forOp + mainloopId" pair uses the same filter.
+void walkMainLoopForOps(
+    ModuleOp module,
+    const std::function<WalkResult(scf::ForOp forOp, int mainloopId)> &callback);
 
 inline bool isCubeOp(Operation *op)
 {

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeArgs.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeArgs.cpp
@@ -21,13 +21,21 @@
  */
 
 #include "ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h"
+#include "ascend/include/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeArgs.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "bishengir/Dialect/Scope/IR/Scope.h"
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "bishengir/Dialect/Annotation/IR/Annotation.h"
 
 static constexpr const char *DEBUG_TYPE = "analyze-args-in-forOps";
 #define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
@@ -67,24 +75,9 @@ static LogicalResult isInterceptedModule(ModuleOp module)
   return failure();
 }
 
-// Check if a value is a tensor-type iter_arg and return its index, -1 otherwise.
-static int getTensorIterArgIndex(Value v, scf::ForOp forOp)
-{
-  for (unsigned i = 0; i < forOp.getNumRegionIterArgs(); ++i) {
-    if (v == forOp.getRegionIterArgs()[i]) {
-      if (isa<RankedTensorType>(forOp.getRegionIterArgs()[i].getType())) {
-        return i;
-      }
-    }
-  }
-  return -1;
-}
-
-// Data collected for each tensor iter_arg: first block_id that uses it, and set of all block_ids
-struct TensorArgBlockInfo {
-  int firstBlockId = -1;
-  llvm::DenseSet<int> blockIds;
-};
+// Pulled in here as a local alias for concise call sites within this file.
+using CVPipeline::getOpBlockId;
+using CVPipeline::getTensorIterArgIndex;
 
 // Collect block info for all tensor-type iter_args in the forOp body
 static llvm::DenseMap<unsigned, TensorArgBlockInfo>
@@ -98,17 +91,16 @@ collectTensorArgBlockInfo(scf::ForOp forOp)
   }
 
   for (Operation &op : body->without_terminator()) {
-    auto blockIdAttr = op.getAttrOfType<IntegerAttr>("ssbuffer.block_id");
-    if (!blockIdAttr) {
+    auto blockIdOpt = CVPipeline::getOpBlockId(&op);
+    if (!blockIdOpt) {
       continue;
     }
-    int blockId = blockIdAttr.getInt();
+    int blockId = static_cast<int>(*blockIdOpt);
 
     for (OpOperand &operand : op.getOpOperands()) {
-      int argIdx = getTensorIterArgIndex(operand.get(), forOp);
+      int argIdx = CVPipeline::getTensorIterArgIndex(operand.get(), forOp);
       if (argIdx >= 0) {
         auto &info = result[argIdx];
-        info.blockIds.insert(blockId);
         if (info.firstBlockId < 0) {
           info.firstBlockId = blockId;
         }
@@ -119,21 +111,12 @@ collectTensorArgBlockInfo(scf::ForOp forOp)
   return result;
 }
 
-// Check if any tensor-type iter_arg appears in different block_ids.
-static bool checkMultiBlockUse(const llvm::DenseMap<unsigned, TensorArgBlockInfo> &argBlockInfo)
-{
-  for (auto &p : argBlockInfo) {
-    if (p.second.blockIds.size() > 1) {
-      LDBG("[INFO]: Found tensor iter_arg using in multi block_ids!\n");
-      return true;
-    }
-  }
-  return false;
-}
-
-// Check if the first block_id differs from the block_id of yield's defining op.
-static bool checkUseUpdateMismatch(scf::ForOp forOp,
-                                   const llvm::DenseMap<unsigned, TensorArgBlockInfo> &argBlockInfo)
+// Check if the first use block_id differs from the block_id of yield's defining op.
+// Because checkTensorArgsUseAfterUpdate guarantees that every use of a tensor
+// iter_arg happens before its update, a "different block_id" between use and
+// update is the only remaining signal that matters.
+static LogicalResult checkUseUpdateMismatch(scf::ForOp forOp,
+                                            const llvm::DenseMap<unsigned, TensorArgBlockInfo> &argBlockInfo)
 {
   Block *body = forOp.getBody();
   auto yieldOp = cast<scf::YieldOp>(body->getTerminator());
@@ -153,50 +136,771 @@ static bool checkUseUpdateMismatch(scf::ForOp forOp,
       continue;
     }
 
-    auto defBlockIdAttr = defOp->getAttrOfType<IntegerAttr>("ssbuffer.block_id");
-    if (!defBlockIdAttr) {
+    auto defBlockIdOpt = CVPipeline::getOpBlockId(defOp);
+    if (!defBlockIdOpt) {
       continue;
     }
 
-    if (it->second.firstBlockId != defBlockIdAttr.getInt()) {
-      LDBG("[INFO]: Found tensor iter_arg using and updating in different block_ids!\n");
+    if (it->second.firstBlockId != *defBlockIdOpt) {
+      LDBG("[INFO]: Found tensor iter_arg using and updating in different block_ids!");
+      return failure();
+    }
+  }
+  return success();
+}
+
+// Main check function: a tensor iter_arg whose first use block_id differs from
+// the block_id of its update op makes the main_loop non-serial.
+static LogicalResult hasTensorArgInDifferentBlockIds(scf::ForOp forOp)
+{
+  auto argBlockInfo = collectTensorArgBlockInfo(forOp);
+  if (failed(checkUseUpdateMismatch(forOp, argBlockInfo))) {
+    return failure();
+  }
+  return success();
+}
+
+// For a single main_loop forOp, find every block_id (within the forOp body)
+// that contains a hivm.hir.sync_block_wait op -- these are the blocks that
+// actually receive cross-core data and are the "real" block nodes for the
+// VECTOR/CUBE dataflow graph.
+static void collectBlockNodesInMainLoop(scf::ForOp forOp, int mainloopId,
+                                        const std::string &belongingScope,
+                                        llvm::SmallVectorImpl<BlockNodeInfo> &blockNodes)
+{
+  // Each block_id should only contribute one node per (mainloopId, scope).
+  llvm::DenseSet<int> seenBlockIds;
+  forOp.walk([&](hivm::SyncBlockWaitOp syncWaitOp) {
+    auto blockIdOpt = getOpBlockId(syncWaitOp);
+    if (!blockIdOpt) {
+      return;
+    }
+    int blockId = static_cast<int>(*blockIdOpt);
+    if (seenBlockIds.contains(blockId)) {
+      return;
+    }
+    seenBlockIds.insert(blockId);
+
+    BlockNodeInfo node;
+    node.mainloopId = mainloopId;
+    node.belongingScope = belongingScope;
+    node.blockId = blockId;
+    blockNodes.push_back(std::move(node));
+  });
+}
+
+// Build the VECTOR/CUBE dataflow graph for every main_loop forOp in the
+// module. Each main_loop's block nodes are stored in its MainLoopData.
+//
+// A block is treated as a "real" block node only when it contains a
+// hivm.hir.sync_block_wait op (i.e. it is on the receiving side of an
+// inter-core data transfer). Blocks that do not participate in cross-core
+// communication are intentionally excluded.
+static void buildDataFlowGraph(ModuleOp module,
+                               llvm::SmallVectorImpl<MainLoopData> &mainLoops)
+{
+  CVPipeline::walkMainLoopForOps(module, [&](scf::ForOp forOp, int mainloopId) -> WalkResult {
+    MainLoopData data;
+    data.forOp = forOp;
+    data.mainloopId = mainloopId;
+    data.scope = CVPipeline::getEnclosingScope(forOp);
+
+    collectBlockNodesInMainLoop(forOp, data.mainloopId, data.scope,
+                                data.blockNodes);
+
+    LDBG("[INFO]: main_loop id=" << data.mainloopId << ", scope=" << data.scope
+                                 << ", node count=" << data.blockNodes.size()
+                                );
+    mainLoops.push_back(std::move(data));
+    return WalkResult::advance();
+  });
+}
+
+// Walk every annotation.mark op in the module and build a map
+// `markedValue -> hivm.tightly_coupled_buffer id`. The id is the
+// cross-scope equivalence key: same id on the VECTOR side and on the CUBE
+// side means the two memref.alloc values refer to the same physical buffer.
+static void buildMarkValueToTcbIdMap(ModuleOp module,
+                                     llvm::DenseMap<Value, int> &valueToTcbId)
+{
+  module.walk([&](annotation::MarkOp markOp) {
+    auto tcbAttr =
+        markOp->getAttrOfType<hivm::HIVMTightlyCoupledBufferAttr>(
+            CVPipeline::kTightlyCoupledBuffer);
+    if (!tcbAttr) {
+      return;
+    }
+    auto id = tcbAttr.getId();
+    if (!id) {
+      return;
+    }
+    valueToTcbId[markOp.getOperand(0)] = id.value();
+  });
+}
+
+// Build a blockId -> BlockNodeInfo* lookup table for the given block nodes.
+// Used to resolve a walked op's `ssbuffer.block_id` back to its node in
+// O(1) inside the per-op callback.
+static llvm::DenseMap<int, BlockNodeInfo *>
+buildBlockIdToNodeMap(llvm::SmallVectorImpl<BlockNodeInfo> &blockNodes)
+{
+  llvm::DenseMap<int, BlockNodeInfo *> blockIdToNode;
+  for (BlockNodeInfo &node : blockNodes) {
+    blockIdToNode[node.blockId] = &node;
+  }
+  return blockIdToNode;
+}
+
+// Append targetNode to srcNode->outNodes, deduping. A block may emit
+// multiple copies / fixpipes to the same peer node, so a single dedup
+// pass avoids duplicate edges in the adjacency list.
+static void addUniqueOutNode(BlockNodeInfo *srcNode, BlockNodeInfo *targetNode)
+{
+  if (!llvm::is_contained(srcNode->outNodes, targetNode)) {
+    srcNode->outNodes.push_back(targetNode);
+  }
+}
+
+// Build tcb_id -> BlockNode* reverse map for a forOp's block nodes by
+// walking every op, finding the underlying memref.alloc for each operand,
+// and resolving its tcb_id. Used in both directions:
+//   - CUBE side: alloc is consumed directly (traceCasts=false)
+//   - VECTOR side: alloc is consumed through casts (traceCasts=true)
+static void buildTcbConsumerMap(
+    scf::ForOp forOp,
+    llvm::SmallVectorImpl<BlockNodeInfo> &blockNodes,
+    const llvm::DenseMap<Value, int> &valueToTcbId,
+    bool traceCasts,
+    llvm::DenseMap<int, BlockNodeInfo *> &tcbToNode)
+{
+  auto blockIdToNode = buildBlockIdToNodeMap(blockNodes);
+
+  forOp.walk([&](Operation *op) {
+    auto blockIdOpt = getOpBlockId(op);
+    if (!blockIdOpt) {
+      return;
+    }
+    auto nodeIt = blockIdToNode.find(static_cast<int>(*blockIdOpt));
+    if (nodeIt == blockIdToNode.end()) {
+      return;
+    }
+    BlockNodeInfo *node = nodeIt->second;
+
+    for (Value operand : op->getOperands()) {
+      memref::AllocOp allocOp = CVPipeline::findAlloc(operand, traceCasts);
+      if (!allocOp) {
+        continue;
+      }
+      auto tcbIt = valueToTcbId.find(allocOp.getResult());
+      if (tcbIt != valueToTcbId.end()) {
+        tcbToNode[tcbIt->second] = node;
+      }
+    }
+  });
+}
+
+// Populate outNodes on the src side by walking a specific inter-core
+// transfer op type and matching its dst's tcb_id against tcbToTargetNode.
+//   - VECTOR -> CUBE:    OpType = hivm::CopyOp,    tcbToTargetNode = tcbToCubeNode
+//   - CUBE   -> VECTOR:  OpType = hivm::FixpipeOp, tcbToTargetNode = tcbToVectorNode
+template <typename OpType>
+static void populateOutNodesViaTransferOp(
+    scf::ForOp forOp,
+    llvm::SmallVectorImpl<BlockNodeInfo> &srcBlockNodes,
+    const llvm::DenseMap<Value, int> &valueToTcbId,
+    const llvm::DenseMap<int, BlockNodeInfo *> &tcbToTargetNode)
+{
+  auto blockIdToNode = buildBlockIdToNodeMap(srcBlockNodes);
+
+  forOp.walk([&](OpType op) {
+    auto blockIdOpt = getOpBlockId(op);
+    if (!blockIdOpt) {
+      return;
+    }
+    auto nodeIt = blockIdToNode.find(static_cast<int>(*blockIdOpt));
+    if (nodeIt == blockIdToNode.end()) {
+      return;
+    }
+    BlockNodeInfo *srcNode = nodeIt->second;
+
+    Value dst = op.getDst();
+    auto tcbIt = valueToTcbId.find(dst);
+    if (tcbIt == valueToTcbId.end()) {
+      return;
+    }
+
+    auto targetIt = tcbToTargetNode.find(tcbIt->second);
+    if (targetIt == tcbToTargetNode.end()) {
+      return;
+    }
+    addUniqueOutNode(srcNode, targetIt->second);
+  });
+}
+
+// Forward DFS: can `start` reach any other-scope node in `scopeSet` by
+// walking the dataflow outNodes (which may pass through nodes of other
+// scopes)? A node whose outNodes all terminate inside other-scope land
+// returns false -- it is an outDegreeZero candidate.
+static bool canReachOtherScopeNode(
+    BlockNodeInfo *start,
+    const llvm::DenseSet<BlockNodeInfo *> &scopeSet)
+{
+  llvm::DenseSet<BlockNodeInfo *> visited;
+  llvm::SmallVector<BlockNodeInfo *, 16> stack;
+  stack.push_back(start);
+  visited.insert(start);
+  while (!stack.empty()) {
+    BlockNodeInfo *cur = stack.pop_back_val();
+    for (BlockNodeInfo *next : cur->outNodes) {
+      if (!visited.insert(next).second) {
+        continue;
+      }
+      if (scopeSet.contains(next)) {
+        return true;
+      }
+      stack.push_back(next);
+    }
+  }
+  return false;
+}
+
+// Backward DFS: can any other-scope node in `scopeSet` reach `start` by
+// walking the reverse dataflow (which may pass through nodes of other
+// scopes)? A node whose inNodes all originate inside other-scope land
+// returns false -- it is an inDegreeZero candidate.
+static bool isReachableFromOtherScopeNode(
+    BlockNodeInfo *start,
+    const llvm::DenseSet<BlockNodeInfo *> &scopeSet,
+    const llvm::DenseMap<BlockNodeInfo *,
+                         llvm::SmallVector<BlockNodeInfo *, 4>> &reverseGraph)
+{
+  llvm::DenseSet<BlockNodeInfo *> visited;
+  llvm::SmallVector<BlockNodeInfo *, 16> stack;
+  stack.push_back(start);
+  visited.insert(start);
+  while (!stack.empty()) {
+    BlockNodeInfo *cur = stack.pop_back_val();
+    auto revIt = reverseGraph.find(cur);
+    if (revIt == reverseGraph.end()) {
+      continue;
+    }
+    for (BlockNodeInfo *prev : revIt->second) {
+      if (!visited.insert(prev).second) {
+        continue;
+      }
+      if (scopeSet.contains(prev)) {
+        return true;
+      }
+      stack.push_back(prev);
+    }
+  }
+  return false;
+}
+
+// For every main_loop's block nodes whose scope matches `scope`, find the
+// "boundary" nodes in the scope-induced reachability:
+//   - inDegreeZero:  no other same-scope node can reach this one
+//   - outDegreeZero: this node cannot reach any other same-scope node
+//
+// Reachability is computed on the full dataflow graph, so a chain like
+// <scope> -> <other scope> -> <scope> still counts as same-scope
+// reachability. A node with all in-edges from other-scope nodes whose own
+// in-chains never reach this scope is treated as if it has no in-edges;
+// the symmetric rule applies to outDegreeZero.
+static DegreeInfo findDegreeZeroNodesInScope(
+    llvm::ArrayRef<MainLoopData> mainLoops,
+    llvm::StringRef scope)
+{
+  DegreeInfo result;
+
+  // Collect all same-scope nodes across mainloops.
+  llvm::SmallVector<BlockNodeInfo *, 8> scopeNodes;
+  llvm::DenseSet<BlockNodeInfo *> scopeSet;
+  for (const MainLoopData &data : mainLoops) {
+    if (data.scope != scope) {
+      continue;
+    }
+    for (const BlockNodeInfo &node : data.blockNodes) {
+      BlockNodeInfo *p = const_cast<BlockNodeInfo *>(&node);
+      scopeNodes.push_back(p);
+      scopeSet.insert(p);
+    }
+  }
+
+  if (scopeNodes.empty()) {
+    return result;
+  }
+
+  // Build reverse edges (target -> list of sources) once for the backward DFS.
+  llvm::DenseMap<BlockNodeInfo *, llvm::SmallVector<BlockNodeInfo *, 4>>
+      reverseGraph;
+  for (const MainLoopData &data : mainLoops) {
+    for (const BlockNodeInfo &node : data.blockNodes) {
+      for (BlockNodeInfo *out : node.outNodes) {
+        reverseGraph[out].push_back(const_cast<BlockNodeInfo *>(&node));
+      }
+    }
+  }
+
+  for (BlockNodeInfo *node : scopeNodes) {
+    if (!canReachOtherScopeNode(node, scopeSet)) {
+      result.outDegreeZero.push_back(node);
+    }
+    if (!isReachableFromOtherScopeNode(node, scopeSet, reverseGraph)) {
+      result.inDegreeZero.push_back(node);
+    }
+  }
+
+  return result;
+}
+
+// Log a DegreeInfo result in the standard "[INFO]: <scope> <dir>-degree-0"
+// format. Used by analyzeMainLoopDataflow to print both VECTOR and CUBE
+// results in a consistent way.
+static void logDegreeInfo(llvm::StringRef scope, const DegreeInfo &info)
+{
+  LDBG("[INFO]: " << scope << " in-degree-0 (entry) nodes: "
+                  << info.inDegreeZero.size());
+  for (BlockNodeInfo *n : info.inDegreeZero) {
+    LDBG("  mainloopId=" << n->mainloopId
+                         << ", blockId=" << n->blockId);
+  }
+  LDBG("[INFO]: " << scope << " out-degree-0 (exit) nodes: "
+                  << info.outDegreeZero.size());
+  for (BlockNodeInfo *n : info.outDegreeZero) {
+    LDBG("  mainloopId=" << n->mainloopId
+                         << ", blockId=" << n->blockId);
+  }
+}
+
+// Walk the forOp body once and build a block_id -> iter_arg usage map.
+// An op without a `ssbuffer.block_id` attribute is skipped (it is either
+// outside the ssbuffer block system or a non-block op).
+static llvm::DenseMap<int, BlockIterArgUsage>
+collectBlockIterArgUsage(scf::ForOp forOp)
+{
+  llvm::DenseMap<int, BlockIterArgUsage> result;
+  if (!forOp) {
+    return result;
+  }
+  Block *body = forOp.getBody();
+  if (!body) {
+    return result;
+  }
+  auto yieldOp = cast<scf::YieldOp>(body->getTerminator());
+
+  for (Operation &op : body->without_terminator()) {
+    auto blockIdOpt = getOpBlockId(&op);
+    if (!blockIdOpt) {
+      continue;
+    }
+    int blockId = static_cast<int>(*blockIdOpt);
+    BlockIterArgUsage &usage = result[blockId];
+
+    // Which iter_args does this op consume?
+    for (OpOperand &operand : op.getOpOperands()) {
+      int argIdx = getTensorIterArgIndex(operand.get(), forOp);
+      if (argIdx >= 0) {
+        usage.used.insert(argIdx);
+      }
+    }
+
+    // Which iter_args does this op produce a new value for (yielded)?
+    // yieldOp's i-th operand is the new value for the i-th iter_arg.
+    for (OpResult opResult : op.getOpResults()) {
+      for (OpOperand &yieldOperand : yieldOp->getOpOperands()) {
+        if (yieldOperand.get() == opResult) {
+          unsigned argIdx = yieldOperand.getOperandNumber();
+          if (isa<RankedTensorType>(
+                  forOp.getRegionIterArgs()[argIdx].getType())) {
+            usage.updated.insert(argIdx);
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+// Returns true if `outNode` updates a tensor iter_arg that `inNode` uses.
+// This is the "edge" in the bipartite fully-connected check: an out
+// produces a new value for the iter_arg (yielded), and an in consumes
+// the iter_arg on the next iteration. Both sides must touch the same
+// iter_arg index for the edge to exist.
+static bool hasUpdateUseConnection(
+    BlockNodeInfo *outNode, BlockNodeInfo *inNode,
+    const llvm::DenseMap<int, BlockIterArgUsage> &usageMap)
+{
+  auto outIt = usageMap.find(outNode->blockId);
+  auto inIt = usageMap.find(inNode->blockId);
+  if (outIt == usageMap.end() || inIt == usageMap.end()) {
+    return false;
+  }
+  for (unsigned argIdx : outIt->second.updated) {
+    if (inIt->second.used.contains(argIdx)) {
       return true;
     }
   }
   return false;
 }
 
-// Main check function that combines both conditions
-static bool hasTensorArgInDifferentBlockIds(scf::ForOp forOp)
+// Partition degree-zero nodes by mainloopId so the per-mainloop check
+// in isScopeSerialExecution can look them up in O(1).
+static void partitionDegreeZeroByMainloop(
+    const DegreeInfo &degreeInfo,
+    llvm::DenseMap<int, llvm::SmallVector<BlockNodeInfo *, 4>> &inByMainloop,
+    llvm::DenseMap<int, llvm::SmallVector<BlockNodeInfo *, 4>> &outByMainloop)
 {
-  auto argBlockInfo = collectTensorArgBlockInfo(forOp);
-  return checkMultiBlockUse(argBlockInfo) ||
-         checkUseUpdateMismatch(forOp, argBlockInfo);
+  for (BlockNodeInfo *n : degreeInfo.inDegreeZero) {
+    inByMainloop[n->mainloopId].push_back(n);
+  }
+  for (BlockNodeInfo *n : degreeInfo.outDegreeZero) {
+    outByMainloop[n->mainloopId].push_back(n);
+  }
+}
+
+// Per-mainloop fully-connected check. Returns true when every
+// (out, in) pair is connected by an iter_arg-update edge, or when one
+// side is empty (trivially serial).
+static bool checkMainloopFullyConnected(
+    llvm::StringRef scope, int mid,
+    llvm::ArrayRef<BlockNodeInfo *> inZero,
+    llvm::ArrayRef<BlockNodeInfo *> outZero,
+    scf::ForOp forOp)
+{
+  if (inZero.empty() || outZero.empty()) {
+    LDBG("[INFO]: " << scope << " mainloopId="
+                    << mid << ": inDegZero=" << inZero.size()
+                    << ", outDegZero=" << outZero.size()
+                    << " -> trivially serial (one side empty)");
+    return true;
+  }
+
+  auto usageMap = collectBlockIterArgUsage(forOp);
+
+  for (BlockNodeInfo *outNode : outZero) {
+    for (BlockNodeInfo *inNode : inZero) {
+      // Self-edge (outNode == inNode) is trivially present: the same
+      // block is both the entry and exit of the dataflow subgraph, so
+      // the data flows through itself. No cross-block iter_arg check
+      // is needed -- the strict hasUpdateUseConnection check below is
+      // only meaningful for genuine cross-block (out != in) edges.
+      if (outNode == inNode) {
+        continue;
+      }
+      if (!hasUpdateUseConnection(outNode, inNode, usageMap)) {
+        LDBG("[WARN]: " << scope << " mainloopId="
+                        << mid << ": no iter_arg edge from outDegZero blockId="
+                        << outNode->blockId << " to inDegZero blockId="
+                        << inNode->blockId);
+        LDBG("[INFO]: " << scope << " mainloopId="
+                        << mid << ": NOT fully connected -> NOT serial");
+        return false;
+      }
+    }
+  }
+
+  LDBG("[INFO]: " << scope << " mainloopId="
+                  << mid << ": fully connected -> serial");
+  return true;
+}
+
+// Returns true if the mainloop identified by `mainloopId` is serial:
+// both its VECTOR and CUBE main_loops are fully connected through
+// their iter_arg-update edges. A mainloopId without a matching VECTOR
+// or CUBE forOp is treated as trivially serial on the missing side.
+static bool isMainloopSerial(
+    int mainloopId, llvm::ArrayRef<MainLoopData> mainLoops,
+    const llvm::DenseMap<int, llvm::SmallVector<BlockNodeInfo *, 4>>
+        &vectorInByMainloop,
+    const llvm::DenseMap<int, llvm::SmallVector<BlockNodeInfo *, 4>>
+        &vectorOutByMainloop,
+    const llvm::DenseMap<int, llvm::SmallVector<BlockNodeInfo *, 4>>
+        &cubeInByMainloop,
+    const llvm::DenseMap<int, llvm::SmallVector<BlockNodeInfo *, 4>>
+        &cubeOutByMainloop)
+{
+  const MainLoopData *vectorData = nullptr;
+  const MainLoopData *cubeData = nullptr;
+  for (const MainLoopData &data : mainLoops) {
+    if (data.mainloopId != mainloopId) {
+      continue;
+    }
+    if (data.scope == "VECTOR") {
+      vectorData = &data;
+    } else if (data.scope == "CUBE") {
+      cubeData = &data;
+    }
+  }
+
+  auto lookupZero = [](
+      const llvm::DenseMap<int, llvm::SmallVector<BlockNodeInfo *, 4>>
+          &byMainloop,
+      int mid) {
+    auto it = byMainloop.find(mid);
+    if (it == byMainloop.end()) {
+      return llvm::ArrayRef<BlockNodeInfo *>{};
+    }
+    return llvm::ArrayRef<BlockNodeInfo *>(it->second);
+  };
+
+  bool vectorSerial = true;
+  if (vectorData) {
+    llvm::ArrayRef<BlockNodeInfo *> inZero = lookupZero(vectorInByMainloop, mainloopId);
+    llvm::ArrayRef<BlockNodeInfo *> outZero = lookupZero(vectorOutByMainloop, mainloopId);
+    vectorSerial = checkMainloopFullyConnected(
+        "VECTOR", mainloopId, inZero, outZero, vectorData->forOp);
+  }
+
+  bool cubeSerial = true;
+  if (cubeData) {
+    llvm::ArrayRef<BlockNodeInfo *> inZero = lookupZero(cubeInByMainloop, mainloopId);
+    llvm::ArrayRef<BlockNodeInfo *> outZero = lookupZero(cubeOutByMainloop, mainloopId);
+    cubeSerial = checkMainloopFullyConnected(
+        "CUBE", mainloopId, inZero, outZero, cubeData->forOp);
+  }
+
+  return vectorSerial && cubeSerial;
+}
+
+// Build the dataflow graph (per-mainloop block nodes) and 
+// the module-wide tcb_id lookup. The graph is just adjacency info
+// without inter-core edges.
+static void collectDataflowGraph(
+    ModuleOp module,
+    llvm::SmallVectorImpl<MainLoopData> &mainLoops,
+    llvm::DenseMap<Value, int> &valueToTcbId)
+{
+  buildDataFlowGraph(module, mainLoops);
+  buildMarkValueToTcbIdMap(module, valueToTcbId);
+}
+
+// Link a single (VECTOR, CUBE) mainloop pair's out-edges in both
+// directions: VECTOR -> CUBE (via CopyOp) and CUBE -> VECTOR (via FixpipeOp).
+static void linkOneMainloopPair(
+    MainLoopData *vectorData, MainLoopData *cubeData,
+    const llvm::DenseMap<Value, int> &valueToTcbId)
+{
+  // tcb_id -> CUBE BlockNode* (which CUBE block consumes each buffer).
+  // CUBE consumes its alloc directly (no cast tracing).
+  llvm::DenseMap<int, BlockNodeInfo *> tcbToCubeNode;
+  buildTcbConsumerMap(cubeData->forOp, cubeData->blockNodes,
+                      valueToTcbId, /*traceCasts=*/false, tcbToCubeNode);
+
+  // tcb_id -> VECTOR BlockNode* (which VECTOR block consumes each buffer).
+  // VECTOR reads the CUBE-produced alloc through memref/tensor casts.
+  llvm::DenseMap<int, BlockNodeInfo *> tcbToVectorNode;
+  buildTcbConsumerMap(vectorData->forOp, vectorData->blockNodes,
+                      valueToTcbId, /*traceCasts=*/true, tcbToVectorNode);
+
+  populateOutNodesViaTransferOp<hivm::CopyOp>(
+      vectorData->forOp, vectorData->blockNodes, valueToTcbId, tcbToCubeNode);
+  populateOutNodesViaTransferOp<hivm::FixpipeOp>(
+      cubeData->forOp, cubeData->blockNodes, valueToTcbId, tcbToVectorNode);
+}
+
+// Pair each VECTOR mainloop with its matching CUBE mainloop
+// by mainloopId, then populate the out-edges of both sides.
+static void linkDataflowEdges(
+    llvm::SmallVectorImpl<MainLoopData> &mainLoops,
+    const llvm::DenseMap<Value, int> &valueToTcbId)
+{
+  // Group MainLoopData by mainloopId, separated by scope. VECTOR and CUBE
+  // main_loops with the same mainloopId are a matched pair.
+  llvm::DenseMap<int, MainLoopData *> vectorLoopById;
+  llvm::DenseMap<int, MainLoopData *> cubeLoopById;
+  for (MainLoopData &data : mainLoops) {
+    if (data.scope == "VECTOR") {
+      vectorLoopById[data.mainloopId] = &data;
+    } else if (data.scope == "CUBE") {
+      cubeLoopById[data.mainloopId] = &data;
+    }
+  }
+
+  for (auto &entry : vectorLoopById) {
+    int mainloopId = entry.first;
+    MainLoopData *vectorData = entry.second;
+    auto cubeIt = cubeLoopById.find(mainloopId);
+    if (cubeIt == cubeLoopById.end()) {
+      LDBG("[WARN]: No matching CUBE main_loop for mainloopId="
+           << mainloopId << "; skipping out-edge population.");
+      continue;
+    }
+    linkOneMainloopPair(vectorData, cubeIt->second, valueToTcbId);
+  }
+}
+
+// Debug print of the full dataflow graph (one log line per node + per
+// outgoing edge).
+static void printDataflowGraph(llvm::ArrayRef<MainLoopData> mainLoops)
+{
+  size_t total = 0;
+  for (const MainLoopData &data : mainLoops) {
+    total += data.blockNodes.size();
+  }
+  LDBG("[INFO]: Collected " << total
+                            << " block nodes with inter-core data transfer");
+  for (const MainLoopData &data : mainLoops) {
+    for (const BlockNodeInfo &node : data.blockNodes) {
+      LDBG("  mainloopId=" << node.mainloopId
+                           << ", scope=" << node.belongingScope
+                           << ", blockId=" << node.blockId
+                           << ", outNodes.size=" << node.outNodes.size());
+      for (BlockNodeInfo *out : node.outNodes) {
+        LDBG("    -> (mainloopId=" << out->mainloopId
+                                   << ", scope=" << out->belongingScope
+                                   << ", blockId=" << out->blockId << ")");
+      }
+    }
+  }
+}
+
+// Compute in-degree-0 / out-degree-0 nodes for VECTOR and CUBE.
+// A node is inDegreeZero when no other same-scope node can reach it
+// (possibly through nodes of the other scope); symmetric for outDegreeZero.
+// These are the entry/exit points of the scope-induced dataflow chain.
+static void findScopeBoundaries(
+    llvm::ArrayRef<MainLoopData> mainLoops,
+    DegreeInfo &vectorDegree, DegreeInfo &cubeDegree)
+{
+  vectorDegree = findDegreeZeroNodesInScope(mainLoops, "VECTOR");
+  cubeDegree = findDegreeZeroNodesInScope(mainLoops, "CUBE");
+  logDegreeInfo("VECTOR", vectorDegree);
+  logDegreeInfo("CUBE", cubeDegree);
+}
+
+// Serial-execution check. A mainloop is "serial" when, for
+// both its VECTOR and CUBE forOps, every out-degree-0 node updates a
+// tensor iter_arg that every in-degree-0 node uses (bipartite fully
+// connected under the iter_arg-update edge). The overall result is the
+// AND across every mainloopId: the CV pipeline is only considered
+// unnecessary (i.e. we fall back) when ALL main_loop forOps are
+// serial. A single non-serial mainloopId keeps the CV pipeline active.
+static bool checkSerialExecution(
+    llvm::ArrayRef<MainLoopData> mainLoops,
+    const DegreeInfo &vectorDegree, const DegreeInfo &cubeDegree)
+{
+  // Per-scope, per-mainloopId degree-zero maps.
+  llvm::DenseMap<int, llvm::SmallVector<BlockNodeInfo *, 4>> vectorInByMainloop;
+  llvm::DenseMap<int, llvm::SmallVector<BlockNodeInfo *, 4>> vectorOutByMainloop;
+  llvm::DenseMap<int, llvm::SmallVector<BlockNodeInfo *, 4>> cubeInByMainloop;
+  llvm::DenseMap<int, llvm::SmallVector<BlockNodeInfo *, 4>> cubeOutByMainloop;
+  partitionDegreeZeroByMainloop(vectorDegree, vectorInByMainloop,
+                                vectorOutByMainloop);
+  partitionDegreeZeroByMainloop(cubeDegree, cubeInByMainloop, cubeOutByMainloop);
+
+  // All unique mainloopIds across both scopes.
+  llvm::DenseSet<int> allMainloopIds;
+  for (const MainLoopData &data : mainLoops) {
+    allMainloopIds.insert(data.mainloopId);
+  }
+
+  bool allSerial = true;
+  for (int mid : allMainloopIds) {
+    bool isSerial = isMainloopSerial(mid, mainLoops, vectorInByMainloop,
+                                     vectorOutByMainloop, cubeInByMainloop,
+                                     cubeOutByMainloop);
+    LDBG("[INFO]: mainloopId=" << mid << " serial: "
+                               << (isSerial ? "YES" : "NO"));
+    if (!isSerial) {
+      allSerial = false;
+    }
+  }
+
+  LDBG("[INFO]: All main_loops serial: " << (allSerial ? "YES" : "NO"));
+  
+  if(allSerial) {
+    LDBG("[INFO]: All executions in mainloop are serial!");
+  }
+
+  return allSerial;
+}
+
+static bool checkMainLoopDataflow(ModuleOp module)
+{
+  llvm::SmallVector<MainLoopData, 4> mainLoops;
+  llvm::DenseMap<Value, int> valueToTcbId;
+  collectDataflowGraph(module, mainLoops, valueToTcbId);
+
+  linkDataflowEdges(mainLoops, valueToTcbId);
+  printDataflowGraph(mainLoops);
+
+  DegreeInfo vectorDegree;
+  DegreeInfo cubeDegree;
+  findScopeBoundaries(mainLoops, vectorDegree, cubeDegree);
+
+  return checkSerialExecution(mainLoops, vectorDegree, cubeDegree);
 }
 
 } // namespace
 
+// Check "use-after-update" patterns on tensor iter_args in main_loop forOp.
+bool checkTensorArgsUseAfterUpdate(ModuleOp module)
+{
+  bool hasViolation = false;
+  CVPipeline::walkMainLoopForOps(module, [&](scf::ForOp forOp, int /*mainloopId*/) -> WalkResult {
+    Block *body = forOp.getBody();
+    if (!body) {
+      return WalkResult::advance();
+    }
+    auto yieldOp = cast<scf::YieldOp>(body->getTerminator());
+
+    for (unsigned i = 0; i < forOp.getNumRegionIterArgs(); ++i) {
+      if (!isa<RankedTensorType>(forOp.getRegionIterArgs()[i].getType())) {
+        continue;
+      }
+      Operation *defOp = yieldOp.getOperand(i).getDefiningOp();
+      if (!defOp) {
+        continue;
+      }
+      Value iterArg = forOp.getRegionIterArgs()[i];
+
+      for (Operation *user : iterArg.getUsers()) {
+        if (user == yieldOp) {
+          continue;
+        }
+        // The user may live in a nested region inside the forOp body
+        // (e.g. inside an scf.if). Walk up to the top-level op in
+        // the body so we can compare program order with defOp.
+        Operation *topLevelUser = user;
+        while (topLevelUser && topLevelUser->getParentOp() != forOp) {
+          topLevelUser = topLevelUser->getParentOp();
+        }
+        if (!topLevelUser || topLevelUser->getBlock() != body) {
+          continue;
+        }
+        if (!defOp->isBeforeInBlock(topLevelUser)) {
+          continue;
+        }
+        LDBG("[ERROR]: Exists tensor iter_args use after update!");
+        hasViolation = true;
+      }
+    }
+    return WalkResult::advance();
+  });
+  return hasViolation;
+}
+
 bool checkTensorArgsInMainLoop(ModuleOp module)
 {
   bool shouldReturn = false;
+  bool isExistIterArgs = false;
 
-  module.walk([&](Operation *op) -> WalkResult {
-    if (!op->hasAttr("ssbuffer.main_loop")) {
-      return WalkResult::advance();
-    }
-
-    auto forOp = dyn_cast<scf::ForOp>(op);
-    if (!forOp) {
-      return WalkResult::advance();
-    }
-
-    if (hasTensorArgInDifferentBlockIds(forOp)) {
-      shouldReturn = true;
+  CVPipeline::walkMainLoopForOps(module, [&](scf::ForOp forOp, int /*mainloopId*/) -> WalkResult {
+    if (failed(hasTensorArgInDifferentBlockIds(forOp))) {
+      isExistIterArgs = true;
       return WalkResult::interrupt();
     }
 
     return WalkResult::advance();
   });
+
+  if (isExistIterArgs) {
+    // Returns true when the dataflow is serial on both VECTOR/CUBE side
+    shouldReturn = checkMainLoopDataflow(module);
+  }
 
   return shouldReturn;
 }
@@ -207,7 +911,12 @@ void AnalyzeArgsPass::runOnOperation()
 
   LDBG("Before AnalyzeArgs:\n" << module << "\n");
 
-  if (failed(isInterceptedModule(module))) {
+  // if (failed(isInterceptedModule(module))) {
+  //   return;
+  // }
+  
+  if(checkTensorArgsUseAfterUpdate(module)) {
+    signalPassFailure();
     return;
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -16,6 +16,9 @@
 #include "mlir/Interfaces/CastInterfaces.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
 
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "bishengir/Dialect/Scope/IR/Scope.h"
+
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 namespace mlir {
 namespace CVPipeline {
@@ -135,6 +138,76 @@ Value getAliasSource(Value value)
         .Case<memref::TransposeOp>([](memref::TransposeOp transOp) { return transOp.getIn(); })
         .Case<tensor::ExtractSliceOp>([](tensor::ExtractSliceOp extOp) { return extOp.getSource(); })
         .Default([](auto) { return nullptr; });
+}
+
+std::string getEnclosingScope(Operation *op)
+{
+  Operation *cur = op;
+  while ((cur = cur->getParentOp())) {
+    if (auto scopeOp = dyn_cast<scope::ScopeOp>(cur)) {
+      auto coreTypeAttr = scopeOp->getAttrOfType<hivm::TCoreTypeAttr>(
+          hivm::TCoreTypeAttr::name);
+      if (!coreTypeAttr) {
+        return "UNKNOWN";
+      }
+      return coreTypeAttr.getTcoretype() == hivm::TCoreType::VECTOR
+                 ? "VECTOR"
+                 : "CUBE";
+    }
+  }
+  return "UNKNOWN";
+}
+
+int getTensorIterArgIndex(Value v, scf::ForOp forOp)
+{
+  for (unsigned i = 0; i < forOp.getNumRegionIterArgs(); ++i) {
+    if (v == forOp.getRegionIterArgs()[i]) {
+      if (isa<RankedTensorType>(forOp.getRegionIterArgs()[i].getType())) {
+        return i;
+      }
+    }
+  }
+  return -1;
+}
+
+memref::AllocOp findAlloc(Value v, bool traceCasts)
+{
+  if (!traceCasts) {
+    return v.getDefiningOp<memref::AllocOp>();
+  }
+  Operation *defOp = v.getDefiningOp();
+  for (int i = 0; i < 16 && defOp; ++i) {
+    if (auto allocOp = dyn_cast<memref::AllocOp>(defOp)) {
+      return allocOp;
+    }
+    if (isa<memref::MemorySpaceCastOp, bufferization::ToTensorOp,
+            bufferization::ToMemrefOp>(defOp)) {
+      if (defOp->getNumOperands() == 0) {
+        return nullptr;
+      }
+      defOp = defOp->getOperand(0).getDefiningOp();
+      continue;
+    }
+    return nullptr;
+  }
+  return nullptr;
+}
+
+void walkMainLoopForOps(
+    ModuleOp module,
+    const std::function<WalkResult(scf::ForOp forOp, int mainloopId)> &callback)
+{
+  module.walk([&](scf::ForOp forOp) -> WalkResult {
+    if (!forOp->hasAttr(CVPipeline::kMainLoop)) {
+      return WalkResult::advance();
+    }
+    auto mainloopIdAttr =
+        forOp->getAttrOfType<IntegerAttr>(CVPipeline::kMainLoop);
+    if (!mainloopIdAttr) {
+      return WalkResult::advance();
+    }
+    return callback(forOp, mainloopIdAttr.getInt());
+  });
 }
 
 } // namespace CVPipeline

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-tensor-args-use-after-update.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-tensor-args-use-after-update.mlir
@@ -1,0 +1,246 @@
+// RUN: triton-opt --analyze-data-flow --verify-diagnostics %s
+
+// CHECK-LABEL: func.func @test_tensor_args_use_after_update
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_tensor_args_use_after_update(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xbf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg3: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg4: memref<?xbf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg5: memref<?xbf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg6: f32, %arg7: i32, %arg8: i32, %arg9: i32, %arg10: i32, %arg11: i32, %arg12: i32, %arg13: i32) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %cst = arith.constant {ssbuffer.block_id = 11 : i32} 0x7F800000 : f32
+    %c1_i32 = arith.constant {ssbuffer.block_id = 11 : i32} 1 : i32
+    %cst_0 = arith.constant {ssbuffer.block_id = 11 : i32} 0.000000e+00 : f32
+    %c-1_i32 = arith.constant {Undefined, ssbuffer.block_id = 11 : i32} -1 : i32
+    %c7_i32 = arith.constant {Undefined, ssbuffer.block_id = 11 : i32} 7 : i32
+    %cst_1 = arith.constant {ssbuffer.block_id = 11 : i32} 0.000000e+00 : bf16
+    %c64_i32 = arith.constant {ssbuffer.block_id = 12 : i32} 64 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 12 : i32} 0 : i32
+    %c16384_i32 = arith.constant {ssbuffer.block_id = 12 : i32} 16384 : i32
+    %c2048_i32 = arith.constant {ssbuffer.block_id = 12 : i32} 2048 : i32
+    %c64 = arith.constant {ssbuffer.block_id = 12 : i32} 64 : index
+    %c0 = arith.constant {ssbuffer.block_id = 12 : i32} 0 : index
+    %c32_i32 = arith.constant {ssbuffer.block_id = 13 : i32} 32 : i32
+    %c6_i32 = arith.constant {ssbuffer.block_id = 13 : i32} 6 : i32
+    %c32 = arith.constant {ssbuffer.block_id = 13 : i32} 32 : index
+    %cst_2 = arith.constant {ssbuffer.block_id = 9 : i32} dense<[4, 2, 16, 16]> : tensor<4xi64>
+    %cst_3 = arith.constant {ssbuffer.block_id = 9 : i32} dense<[32, 4, 16]> : tensor<3xi64>
+    scope.scope : () -> () {
+      %0 = tensor.empty() {ssbuffer.block_id = 11 : i32} : tensor<32xf32>
+      %1 = linalg.fill {ssbuffer.block_id = 11 : i32} ins(%cst : f32) outs(%0 : tensor<32xf32>) -> tensor<32xf32>
+      %2 = tensor.empty() {ssbuffer.block_id = 11 : i32} : tensor<32x64xf32>
+      %3 = linalg.fill {ssbuffer.block_id = 11 : i32} ins(%cst_0 : f32) outs(%2 : tensor<32x64xf32>) -> tensor<32x64xf32>
+      %4 = arith.muli %arg12, %c64_i32 {ssbuffer.block_id = 12 : i32} : i32
+      %5 = arith.muli %arg13, %c16384_i32 {ssbuffer.block_id = 12 : i32} : i32
+      %6 = arith.muli %arg11, %c32_i32 {ssbuffer.block_id = 13 : i32} : i32
+      %7 = arith.muli %arg7, %c32_i32 {ssbuffer.block_id = 13 : i32} : i32
+      %8 = arith.muli %arg13, %arg7 {ssbuffer.block_id = 14 : i32} : i32
+      %9 = arith.muli %8, %c32_i32 {ssbuffer.block_id = 14 : i32} : i32
+      %10 = arith.index_cast %9 {ssbuffer.block_id = 14 : i32} : i32 to index
+      %11 = linalg.fill {ssbuffer.block_id = 14 : i32} ins(%arg6 : f32) outs(%2 : tensor<32x64xf32>) -> tensor<32x64xf32>
+      %alloc = memref.alloc() {ssbuffer.block_id = 15 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x2x16x16xbf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 15 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x2x16x16xbf16, #hivm.address_space<cbuf>>
+      %alloc_4 = memref.alloc() {ssbuffer.block_id = 15 : i32, ssbuffer.transfer_id = 1 : i32} : memref<32x64xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_4 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 15 : i32, ssbuffer.transfer_id = 1 : i32} : memref<32x64xf32, #hivm.address_space<ub>>
+      hivm.hir.sync_block_set {ssbuffer.analyze_flag_id, ssbuffer.block_id = 15 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 2
+      %12:2 = scf.for %arg14 = %c-1_i32 to %c7_i32 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %3) -> (tensor<32xf32>, tensor<32x64xf32>)  : i32 {
+        %13 = arith.subi %c6_i32, %arg14 {ssbuffer.block_id = 8 : i32} : i32
+        %14 = arith.muli %13, %c64_i32 {ssbuffer.block_id = 8 : i32} : i32
+        %15 = arith.subi %14, %c1_i32 {ssbuffer.block_id = 8 : i32} : i32
+        %16 = arith.maxsi %15, %c0_i32 {ssbuffer.block_id = 8 : i32} : i32
+        %17 = arith.index_cast %6 {ssbuffer.block_id = 8 : i32} : i32 to index
+        %18 = arith.maxsi %17, %c0 {ssbuffer.block_id = 8 : i32} : index
+        %19 = arith.subi %c32, %18 {ssbuffer.block_id = 8 : i32} : index
+        %20 = arith.maxsi %19, %c0 {ssbuffer.block_id = 8 : i32} : index
+        %21 = arith.minsi %20, %c32 {ssbuffer.block_id = 8 : i32} : index
+        %22 = arith.index_cast %arg7 {ssbuffer.block_id = 8 : i32} : i32 to index
+        %23 = arith.index_cast %14 {ssbuffer.block_id = 8 : i32} : i32 to index
+        %24 = arith.maxsi %23, %c0 {ssbuffer.block_id = 8 : i32} : index
+        %25 = arith.subi %22, %24 {ssbuffer.block_id = 8 : i32} : index
+        %26 = arith.maxsi %25, %c0 {ssbuffer.block_id = 8 : i32} : index
+        %27 = arith.minsi %26, %c64 {ssbuffer.block_id = 8 : i32} : index
+        %28 = arith.subi %c0_i32, %14 {ssbuffer.block_id = 8 : i32} : i32
+        %29 = arith.maxsi %28, %c0_i32 {ssbuffer.block_id = 8 : i32} : i32
+        %30 = arith.index_cast %29 {ssbuffer.block_id = 8 : i32} : i32 to index
+        %31 = arith.minsi %30, %27 {ssbuffer.block_id = 8 : i32} : index
+        %32 = arith.subi %27, %31 {ssbuffer.block_id = 8 : i32} : index
+        %33 = arith.subi %c0_i32, %6 {ssbuffer.block_id = 8 : i32} : i32
+        %34 = arith.maxsi %33, %c0_i32 {ssbuffer.block_id = 8 : i32} : i32
+        %35 = arith.index_cast %34 {ssbuffer.block_id = 8 : i32} : i32 to index
+        %36 = arith.minsi %35, %21 {ssbuffer.block_id = 8 : i32} : index
+        %37 = arith.subi %21, %36 {ssbuffer.block_id = 8 : i32} : index
+        %38 = arith.cmpi slt, %32, %c64 {ssbuffer.block_id = 8 : i32} : index
+        %39 = arith.cmpi slt, %37, %c32 {ssbuffer.block_id = 8 : i32} : index
+        %40 = arith.ori %38, %39 {ssbuffer.block_id = 8 : i32} : i1
+        %41 = arith.muli %16, %c32_i32 {ssbuffer.block_id = 8 : i32} : i32
+        %42 = arith.addi %41, %6 {ssbuffer.block_id = 8 : i32} : i32
+        %43 = arith.index_cast %7 {ssbuffer.block_id = 8 : i32} : i32 to index
+        %44 = arith.index_cast %42 {ssbuffer.block_id = 8 : i32} : i32 to index
+        %45 = arith.maxsi %44, %c0 {ssbuffer.block_id = 8 : i32} : index
+        %46 = arith.subi %43, %45 {ssbuffer.block_id = 8 : i32} : index
+        %47 = arith.maxsi %46, %c0 {ssbuffer.block_id = 8 : i32} : index
+        %48 = arith.minsi %47, %c32 {ssbuffer.block_id = 8 : i32} : index
+        %49 = arith.subi %c0_i32, %42 {ssbuffer.block_id = 8 : i32} : i32
+        %50 = arith.maxsi %49, %c0_i32 {ssbuffer.block_id = 8 : i32} : i32
+        %51 = arith.index_cast %50 {ssbuffer.block_id = 8 : i32} : i32 to index
+        %52 = arith.minsi %51, %48 {ssbuffer.block_id = 8 : i32} : index
+        %53 = arith.subi %48, %52 {ssbuffer.block_id = 8 : i32} : index
+        %54 = arith.cmpi slt, %53, %c32 {ssbuffer.block_id = 8 : i32} : index
+        %alloc_5 = memref.alloc() {ssbuffer.block_id = 9 : i32} : memref<64x32xbf16>
+        %alloc_6 = memref.alloc() {ssbuffer.block_id = 9 : i32} : memref<32xf32>
+        %alloc_7 = memref.alloc() {ssbuffer.block_id = 9 : i32} : memref<64x32xf32>
+        scf.if %54 {
+          linalg.fill {ssbuffer.block_id = 9 : i32} ins(%cst_0 : f32) outs(%alloc_6 : memref<32xf32>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 9 : i32}
+        scf.if %40 {
+          linalg.fill {ssbuffer.block_id = 9 : i32} ins(%cst_0 : f32) outs(%alloc_7 : memref<64x32xf32>)
+          linalg.fill {ssbuffer.block_id = 9 : i32} ins(%cst_1 : bf16) outs(%alloc_5 : memref<64x32xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 9 : i32}
+        %55 = arith.maxsi %14, %c0_i32 {ssbuffer.block_id = 9 : i32} : i32
+        %56 = arith.index_cast %55 {ssbuffer.block_id = 9 : i32} : i32 to index
+        %57 = arith.maxsi %6, %c0_i32 {ssbuffer.block_id = 9 : i32} : i32
+        %58 = arith.index_cast %57 {ssbuffer.block_id = 9 : i32} : i32 to index
+        %59 = arith.muli %56, %c32 {ssbuffer.block_id = 9 : i32} : index
+        %60 = arith.addi %59, %10 {ssbuffer.block_id = 9 : i32} : index
+        %61 = arith.addi %60, %58 {ssbuffer.block_id = 9 : i32} : index
+        %reinterpret_cast = memref.reinterpret_cast %arg2 to offset: [%61], sizes: [64, 32], strides: [32, 1] {ssbuffer.block_id = 9 : i32} : memref<?xbf16> to memref<64x32xbf16, strided<[32, 1], offset: ?>>
+        %subview = memref.subview %reinterpret_cast[0, 0] [%32, %37] [1, 1] {ssbuffer.block_id = 9 : i32} : memref<64x32xbf16, strided<[32, 1], offset: ?>> to memref<?x?xbf16, strided<[32, 1], offset: ?>>
+        %subview_8 = memref.subview %alloc_5[%31, %36] [%32, %37] [1, 1] {ssbuffer.block_id = 9 : i32} : memref<64x32xbf16> to memref<?x?xbf16, strided<[32, 1], offset: ?>>
+        memref.copy %subview, %subview_8 {ssbuffer.block_id = 9 : i32} : memref<?x?xbf16, strided<[32, 1], offset: ?>> to memref<?x?xbf16, strided<[32, 1], offset: ?>>
+        %62 = bufferization.to_tensor %alloc_5 restrict writable {ssbuffer.block_id = 9 : i32} : memref<64x32xbf16>
+        %63 = tensor.empty() {ssbuffer.block_id = 9 : i32} : tensor<32x64xbf16>
+        %transposed = linalg.transpose ins(%62 : tensor<64x32xbf16>) outs(%63 : tensor<32x64xbf16>) permutation = [1, 0]  {ssbuffer.block_id = 9 : i32}
+        %64 = arith.extf %transposed {DataUse, ssbuffer.block_id = 9 : i32} : tensor<32x64xbf16> to tensor<32x64xf32>
+        %65 = arith.mulf %64, %11 {DataUse, ssbuffer.block_id = 9 : i32} : tensor<32x64xf32>
+        %66 = arith.truncf %65 {DataUse, ssbuffer.block_id = 9 : i32} : tensor<32x64xf32> to tensor<32x64xbf16>
+        %67 = arith.maxsi %42, %c0_i32 {ssbuffer.block_id = 9 : i32} : i32
+        %68 = arith.index_cast %67 {ssbuffer.block_id = 9 : i32} : i32 to index
+        %69 = arith.addi %68, %10 {ssbuffer.block_id = 9 : i32} : index
+        %reinterpret_cast_9 = memref.reinterpret_cast %arg3 to offset: [%69], sizes: [32], strides: [1] {ssbuffer.block_id = 9 : i32} : memref<?xf32> to memref<32xf32, strided<[1], offset: ?>>
+        %subview_10 = memref.subview %reinterpret_cast_9[0] [%53] [1] {ssbuffer.block_id = 9 : i32} : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+        %subview_11 = memref.subview %alloc_6[%52] [%53] [1] {ssbuffer.block_id = 9 : i32} : memref<32xf32> to memref<?xf32, strided<[1], offset: ?>>
+        memref.copy %subview_10, %subview_11 {ssbuffer.block_id = 9 : i32} : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+        %70 = bufferization.to_tensor %alloc_6 restrict writable {ssbuffer.block_id = 9 : i32} : memref<32xf32>
+        %reinterpret_cast_12 = memref.reinterpret_cast %arg3 to offset: [%61], sizes: [64, 32], strides: [32, 1] {ssbuffer.block_id = 9 : i32} : memref<?xf32> to memref<64x32xf32, strided<[32, 1], offset: ?>>
+        %subview_13 = memref.subview %reinterpret_cast_12[0, 0] [%32, %37] [1, 1] {ssbuffer.block_id = 9 : i32} : memref<64x32xf32, strided<[32, 1], offset: ?>> to memref<?x?xf32, strided<[32, 1], offset: ?>>
+        %subview_14 = memref.subview %alloc_7[%31, %36] [%32, %37] [1, 1] {ssbuffer.block_id = 9 : i32} : memref<64x32xf32> to memref<?x?xf32, strided<[32, 1], offset: ?>>
+        memref.copy %subview_13, %subview_14 {ssbuffer.block_id = 9 : i32} : memref<?x?xf32, strided<[32, 1], offset: ?>> to memref<?x?xf32, strided<[32, 1], offset: ?>>
+        %71 = bufferization.to_tensor %alloc_7 restrict writable {ssbuffer.block_id = 9 : i32} : memref<64x32xf32>
+        %transposed_15 = linalg.transpose ins(%71 : tensor<64x32xf32>) outs(%2 : tensor<32x64xf32>) permutation = [1, 0]  {ssbuffer.block_id = 9 : i32}
+        %broadcasted = linalg.broadcast ins(%70 : tensor<32xf32>) outs(%2 : tensor<32x64xf32>) dimensions = [1]  {ssbuffer.block_id = 9 : i32}
+        %72 = arith.subf %broadcasted, %transposed_15 {DataUse, ssbuffer.block_id = 9 : i32} : tensor<32x64xf32>
+        %73 = math.exp %72 {DataUse, ssbuffer.block_id = 9 : i32} : tensor<32x64xf32>
+        %74 = arith.extf %66 {DataUse, ssbuffer.block_id = 9 : i32} : tensor<32x64xbf16> to tensor<32x64xf32>
+        %75 = arith.mulf %74, %73 {DataUse, ssbuffer.block_id = 9 : i32} : tensor<32x64xf32>
+        %76 = arith.truncf %75 {DataUse, ssbuffer.block_id = 9 : i32} : tensor<32x64xf32> to tensor<32x64xbf16>
+        %reshape = tensor.reshape %76(%cst_3) {ssbuffer.block_id = 9 : i32} : (tensor<32x64xbf16>, tensor<3xi64>) -> tensor<32x4x16xbf16>
+        %77 = tensor.empty() {ssbuffer.block_id = 9 : i32} : tensor<4x32x16xbf16>
+        %transposed_16 = linalg.transpose ins(%reshape : tensor<32x4x16xbf16>) outs(%77 : tensor<4x32x16xbf16>) permutation = [1, 0, 2]  {ssbuffer.block_id = 9 : i32}
+        %reshape_17 = tensor.reshape %transposed_16(%cst_2) {ssbuffer.block_id = 9 : i32} : (tensor<4x32x16xbf16>, tensor<4xi64>) -> tensor<4x2x16x16xbf16>
+        hivm.hir.sync_block_wait {ssbuffer.analyze_flag_id, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+        hivm.hir.copy ins(%reshape_17 : tensor<4x2x16x16xbf16>) outs(%alloc : memref<4x2x16x16xbf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 0 : i32}
+        hivm.hir.sync_block_set {ssbuffer.analyze_flag_id, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
+        hivm.hir.sync_block_wait {ssbuffer.analyze_flag_id, ssbuffer.block_id = 10 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 2
+        %memspacecast = memref.memory_space_cast %alloc_4 {ssbuffer.block_id = 10 : i32, ssbuffer.transfer_id = 1 : i32} : memref<32x64xf32, #hivm.address_space<ub>> to memref<32x64xf32>
+        %78 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 10 : i32, ssbuffer.transfer_id = 1 : i32} : memref<32x64xf32>
+        %79 = arith.maxsi %4, %c0_i32 {ssbuffer.block_id = 10 : i32} : i32
+        %80 = arith.index_cast %79 {ssbuffer.block_id = 10 : i32} : i32 to index
+        %81 = arith.muli %13, %c2048_i32 {ssbuffer.block_id = 10 : i32} : i32
+        %82 = arith.index_cast %5 {ssbuffer.block_id = 10 : i32} : i32 to index
+        %83 = arith.index_cast %81 {ssbuffer.block_id = 10 : i32} : i32 to index
+        %84 = arith.addi %82, %83 {ssbuffer.block_id = 10 : i32} : index
+        %85 = arith.muli %58, %c64 {ssbuffer.block_id = 10 : i32} : index
+        %86 = arith.addi %85, %84 {ssbuffer.block_id = 10 : i32} : index
+        %87 = arith.addi %86, %80 {ssbuffer.block_id = 10 : i32} : index
+        %reinterpret_cast_18 = memref.reinterpret_cast %arg5 to offset: [%87], sizes: [32, 64], strides: [64, 1] {ssbuffer.block_id = 10 : i32} : memref<?xbf16> to memref<32x64xbf16, strided<[64, 1], offset: ?>>
+        %88 = arith.index_cast %4 {ssbuffer.block_id = 10 : i32} : i32 to index
+        %89 = arith.maxsi %88, %c0 {ssbuffer.block_id = 10 : i32} : index
+        %90 = arith.subi %c64, %89 {ssbuffer.block_id = 10 : i32} : index
+        %91 = arith.maxsi %90, %c0 {ssbuffer.block_id = 10 : i32} : index
+        %92 = arith.minsi %91, %c64 {ssbuffer.block_id = 10 : i32} : index
+        %93 = arith.subi %c0_i32, %4 {ssbuffer.block_id = 10 : i32} : i32
+        %94 = arith.maxsi %93, %c0_i32 {ssbuffer.block_id = 10 : i32} : i32
+        %95 = arith.index_cast %94 {ssbuffer.block_id = 10 : i32} : i32 to index
+        %96 = arith.minsi %95, %92 {ssbuffer.block_id = 10 : i32} : index
+        %97 = arith.subi %92, %96 {ssbuffer.block_id = 10 : i32} : index
+        %98 = arith.truncf %arg16 {DataUse, ssbuffer.block_id = 10 : i32} : tensor<32x64xf32> to tensor<32x64xbf16>
+        %extracted_slice = tensor.extract_slice %98[%36, %96] [%37, %97] [1, 1] {ssbuffer.block_id = 10 : i32} : tensor<32x64xbf16> to tensor<?x?xbf16>
+        %subview_19 = memref.subview %reinterpret_cast_18[0, 0] [%37, %97] [1, 1] {ssbuffer.block_id = 10 : i32} : memref<32x64xbf16, strided<[64, 1], offset: ?>> to memref<?x?xbf16, strided<[64, 1], offset: ?>>
+        bufferization.materialize_in_destination %extracted_slice in writable %subview_19 {ssbuffer.block_id = 10 : i32} : (tensor<?x?xbf16>, memref<?x?xbf16, strided<[64, 1], offset: ?>>) -> ()
+        %99 = arith.subf %70, %arg15 {DataUse, ssbuffer.block_id = 10 : i32} : tensor<32xf32>
+        %100 = math.exp %99 {DataUse, ssbuffer.block_id = 10 : i32} : tensor<32xf32>
+        %broadcasted_20 = linalg.broadcast ins(%100 : tensor<32xf32>) outs(%2 : tensor<32x64xf32>) dimensions = [1]  {ssbuffer.block_id = 10 : i32}
+        %101 = arith.mulf %arg16, %broadcasted_20 {DataUse, ssbuffer.block_id = 10 : i32} : tensor<32x64xf32>
+        %102 = arith.addf %78, %101 {ssbuffer.add_from_matmul, ssbuffer.block_id = 10 : i32} : tensor<32x64xf32>
+        hivm.hir.sync_block_set {ssbuffer.analyze_flag_id, ssbuffer.block_id = 10 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 2
+        scf.yield %70, %102 : tensor<32xf32>, tensor<32x64xf32>
+      } {Undefined, ssbuffer.block_id = 15 : i32, ssbuffer.main_loop = 0 : i32}
+      hivm.hir.sync_block_wait {ssbuffer.analyze_flag_id, ssbuffer.block_id = 15 : i32, ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+      scope.return
+    } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    scope.scope : () -> () {
+      %0 = arith.muli %arg13, %arg7 {ssbuffer.block_id = 4 : i32} : i32
+      %1 = arith.muli %0, %c64_i32 {ssbuffer.block_id = 4 : i32} : i32
+      %2 = arith.index_cast %1 {ssbuffer.block_id = 4 : i32} : i32 to index
+      %3 = arith.muli %arg12, %c64_i32 {ssbuffer.block_id = 4 : i32} : i32
+      %alloc = memref.alloc() {ssbuffer.block_id = 15 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x2x16x16xbf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 15 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x2x16x16xbf16, #hivm.address_space<cbuf>>
+      hivm.hir.sync_block_set {ssbuffer.analyze_flag_id, ssbuffer.block_id = 15 : i32, ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+      %alloc_4 = memref.alloc() {ssbuffer.block_id = 15 : i32, ssbuffer.transfer_id = 1 : i32} : memref<32x64xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_4 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 15 : i32, ssbuffer.transfer_id = 1 : i32} : memref<32x64xf32, #hivm.address_space<ub>>
+      scf.for %arg14 = %c-1_i32 to %c7_i32 step %c1_i32  : i32 {
+        %4 = arith.subi %c6_i32, %arg14 {ssbuffer.block_id = 2 : i32} : i32
+        %5 = arith.muli %4, %c64_i32 {ssbuffer.block_id = 2 : i32} : i32
+        %6 = arith.index_cast %arg7 {ssbuffer.block_id = 2 : i32} : i32 to index
+        %7 = arith.index_cast %5 {ssbuffer.block_id = 2 : i32} : i32 to index
+        %8 = arith.maxsi %7, %c0 {ssbuffer.block_id = 2 : i32} : index
+        %9 = arith.subi %6, %8 {ssbuffer.block_id = 2 : i32} : index
+        %10 = arith.maxsi %9, %c0 {ssbuffer.block_id = 2 : i32} : index
+        %11 = arith.minsi %10, %c64 {ssbuffer.block_id = 2 : i32} : index
+        %12 = arith.subi %c0_i32, %5 {ssbuffer.block_id = 2 : i32} : i32
+        %13 = arith.maxsi %12, %c0_i32 {ssbuffer.block_id = 2 : i32} : i32
+        %14 = arith.index_cast %13 {ssbuffer.block_id = 2 : i32} : i32 to index
+        %15 = arith.minsi %14, %11 {ssbuffer.block_id = 2 : i32} : index
+        %16 = arith.subi %11, %15 {ssbuffer.block_id = 2 : i32} : index
+        %17 = arith.cmpi slt, %16, %c64 {ssbuffer.block_id = 2 : i32} : index
+        %alloc_5 = memref.alloc() {ssbuffer.block_id = 2 : i32} : memref<64x64xbf16>
+        %18 = arith.index_cast %3 {ssbuffer.block_id = 2 : i32} : i32 to index
+        %19 = arith.maxsi %18, %c0 {ssbuffer.block_id = 2 : i32} : index
+        %20 = arith.subi %c64, %19 {ssbuffer.block_id = 2 : i32} : index
+        %21 = arith.maxsi %20, %c0 {ssbuffer.block_id = 2 : i32} : index
+        %22 = arith.minsi %21, %c64 {ssbuffer.block_id = 2 : i32} : index
+        %23 = arith.subi %c0_i32, %3 {ssbuffer.block_id = 2 : i32} : i32
+        %24 = arith.maxsi %23, %c0_i32 {ssbuffer.block_id = 2 : i32} : i32
+        %25 = arith.index_cast %24 {ssbuffer.block_id = 2 : i32} : i32 to index
+        %26 = arith.minsi %25, %22 {ssbuffer.block_id = 2 : i32} : index
+        %27 = arith.subi %22, %26 {ssbuffer.block_id = 2 : i32} : index
+        %28 = arith.cmpi slt, %27, %c64 {ssbuffer.block_id = 2 : i32} : index
+        %29 = arith.ori %17, %28 {ssbuffer.block_id = 2 : i32} : i1
+        scf.if %29 {
+          linalg.fill {ssbuffer.block_id = 2 : i32} ins(%cst_1 : bf16) outs(%alloc_5 : memref<64x64xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 2 : i32}
+        %30 = arith.maxsi %5, %c0_i32 {ssbuffer.block_id = 2 : i32} : i32
+        %31 = arith.index_cast %30 {ssbuffer.block_id = 2 : i32} : i32 to index
+        %32 = arith.maxsi %3, %c0_i32 {ssbuffer.block_id = 2 : i32} : i32
+        %33 = arith.index_cast %32 {ssbuffer.block_id = 2 : i32} : i32 to index
+        %34 = arith.muli %31, %c64 {ssbuffer.block_id = 2 : i32} : index
+        %35 = arith.addi %34, %2 {ssbuffer.block_id = 2 : i32} : index
+        %36 = arith.addi %35, %33 {ssbuffer.block_id = 2 : i32} : index
+        %reinterpret_cast = memref.reinterpret_cast %arg4 to offset: [%36], sizes: [64, 64], strides: [64, 1] {ssbuffer.block_id = 2 : i32} : memref<?xbf16> to memref<64x64xbf16, strided<[64, 1], offset: ?>>
+        %subview = memref.subview %reinterpret_cast[0, 0] [%16, %27] [1, 1] {ssbuffer.block_id = 2 : i32} : memref<64x64xbf16, strided<[64, 1], offset: ?>> to memref<?x?xbf16, strided<[64, 1], offset: ?>>
+        %subview_6 = memref.subview %alloc_5[%15, %26] [%16, %27] [1, 1] {ssbuffer.block_id = 2 : i32} : memref<64x64xbf16> to memref<?x?xbf16, strided<[64, 1], offset: ?>>
+        memref.copy %subview, %subview_6 {ssbuffer.block_id = 2 : i32} : memref<?x?xbf16, strided<[64, 1], offset: ?>> to memref<?x?xbf16, strided<[64, 1], offset: ?>>
+        %37 = bufferization.to_tensor %alloc_5 restrict writable {ssbuffer.block_id = 2 : i32} : memref<64x64xbf16>
+        %38 = tensor.empty() {ssbuffer.block_id = 2 : i32} : tensor<32x64xf32>
+        %39 = linalg.fill {ssbuffer.block_id = 2 : i32} ins(%cst_0 : f32) outs(%38 : tensor<32x64xf32>) -> tensor<32x64xf32>
+        hivm.hir.sync_block_wait {ssbuffer.analyze_flag_id, ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
+        %40 = hivm.hir.convert_layout %alloc output_shape [32, 64] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 0 : i32} : (memref<4x2x16x16xbf16, #hivm.address_space<cbuf>>) -> memref<32x64xbf16, #hivm.address_space<cbuf>>
+        %memspacecast = memref.memory_space_cast %40 {ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 0 : i32} : memref<32x64xbf16, #hivm.address_space<cbuf>> to memref<32x64xbf16>
+        %41 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 0 : i32} : memref<32x64xbf16>
+        %42 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 2 : i32} ins(%41, %37 : tensor<32x64xbf16>, tensor<64x64xbf16>) outs(%39 : tensor<32x64xf32>) -> tensor<32x64xf32>
+        hivm.hir.sync_block_set {ssbuffer.analyze_flag_id, ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+        hivm.hir.sync_block_wait {ssbuffer.analyze_flag_id, ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_V>, <PIPE_FIX>] flag = 2
+        hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 1 : i32} ins(%42 : tensor<32x64xf32>) outs(%alloc_4 : memref<32x64xf32, #hivm.address_space<ub>>)
+        hivm.hir.sync_block_set {ssbuffer.analyze_flag_id, ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_FIX>, <PIPE_V>] flag = 2
+      } {Undefined, ssbuffer.block_id = 15 : i32, ssbuffer.main_loop = 0 : i32}
+      hivm.hir.sync_block_wait {ssbuffer.analyze_flag_id, ssbuffer.block_id = 15 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_V>, <PIPE_FIX>] flag = 2
+      scope.return
+    } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<CUBE>}
+    return
+  }
+}


### PR DESCRIPTION
[ssbuffer](fix) set fallback when existing tensor iter_args dependency and execution is parallel

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
