### PR TITLE
[ssbuffer](fix) a*b+c add matmul connect scenario

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -47,6 +47,7 @@ inline constexpr llvm::StringLiteral kIntraBuffer = "ssbuffer.intra_buffer";
 inline constexpr llvm::StringLiteral kAnalyzeFlagId = "ssbuffer.analyze_flag_id";
 inline constexpr llvm::StringLiteral kLoopCarriedL0C = "ssbuffer.loop_carried_l0c";
 inline constexpr llvm::StringLiteral kCrossDeps = "ssbuffer.crossDeps";
+inline constexpr llvm::StringLiteral kMayNotExec = "ssbuffer.may_not_exec";
 inline constexpr const char *ERRCODE_ATTR = "triton_ascend.dynamic_cv_pipeline.rc";
 static constexpr const int ERRCODE_FAILED = 1;
 static constexpr const int ERRCODE_IGNORED = 2;

--- a/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h
+++ b/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h
@@ -46,7 +46,7 @@ enum OpCoreType { OP_UNDETERMINED = 0, OP_CUBE_ONLY = 1, OP_VECTOR_ONLY = 2, OP_
 
 // OpClassifierPass for categorizing operations as CUBE or VECTOR
 class OpClassifierPass : public PassWrapper<OpClassifierPass, OperationPass<ModuleOp>> {
-public:
+  public:
     MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(OpClassifierPass)
 
     // Constructor
@@ -64,7 +64,9 @@ public:
     }
     ::llvm::StringRef getName() const override { return "OpClassifierPass"; }
 
-private:
+  private:
+    llvm::DenseMap<Operation *, Operation *> CloneOpMap;
+
     // Map from operation to its core type
     llvm::DenseMap<Operation *, OpCoreType> opCoreTypes;
 
@@ -87,6 +89,7 @@ private:
     void matchToTensorPattern(Operation *def);
     void matchTransposePattern(Operation *def);
     void matchFillPattern(Operation *def);
+    void matchEmptyPattern(Operation *def);
 
     // Downstream pattern matching helpers
     void matchStorePattern(Operation *user);
@@ -134,7 +137,7 @@ private:
 
     // Step 5: Handle else region yield of scf.if by extracting core_type from then region yield
     bool handleYieldFromElseRegion(std::vector<OpCoreType> &coreTypes, unsigned operandIndex,
-                                   Operation *thenYieldForElse, Value &operand);
+                                   Operation *thenYieldForElse, Value &operand, Operation *elseYieldOp);
 
     // Step 6: Handle CUBE_AND_VECTOR operations
     int handleCubeAndVector();

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -32,6 +32,7 @@
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Interfaces/CastInterfaces.h"
@@ -39,8 +40,8 @@
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Support/LLVM.h"
 
-#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h"
 
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
 
@@ -287,6 +288,30 @@ void OpClassifierPass::matchFillPattern(Operation *def)
 }
 
 // ============================================================================
+// Pattern: tensor.empty → matmul (Upstream)
+// ============================================================================
+// Matches cases where matmul's output initial value comes from tensor.empty.
+// empty initializes the output matrix (typically to 0).
+// IR Example
+//   %value = arith.constant 0.0 : f32
+//   %out = tensor.empty() : tensor<1024x1024xf32>
+//   %result = linalg.matmul ins(%a, %b) outs(%out)
+// Matching Logic
+//   1. Check if matmul's operand defining op is tensor.empty
+//   2. If matched, mark empty as CUBE and add to cubeSeeds
+// Purpose: empty operation initializes matmul's output buffer;
+// ============================================================================
+void OpClassifierPass::matchEmptyPattern(Operation *def)
+{
+    auto emptyOp = dyn_cast<tensor::EmptyOp>(def);
+    if (!emptyOp)
+        return;
+
+    markCube(emptyOp);
+    cubeSeeds.push_back(emptyOp);
+}
+
+// ============================================================================
 // Pattern: matmul → hivm.hir.store (Downstream)
 // ============================================================================
 // Matches cases where matmul's output is directly stored to memory.
@@ -404,6 +429,7 @@ int OpClassifierPass::patternMatchCUBE()
             matchToTensorPattern(def);
             matchTransposePattern(def);
             matchFillPattern(def);
+            matchEmptyPattern(def);
         }
 
         // ---- Downstream pattern matching ----
@@ -982,7 +1008,7 @@ void OpClassifierPass::propagateCoreTypeUpwardForYield(Operation *startOp, OpCor
 //   - operand: The current operand value from the else region's yield
 // Returns: true if core_type was successfully extracted and propagated, false otherwise.
 bool OpClassifierPass::handleYieldFromElseRegion(std::vector<OpCoreType> &coreTypes, unsigned operandIndex,
-                                                 Operation *thenYieldForElse, Value &operand)
+                                                 Operation *thenYieldForElse, Value &operand, Operation *elseYieldOp)
 {
     // Only handle if thenYieldForElse is provided and is a scf.yield
     if (!thenYieldForElse || !isa<scf::YieldOp>(thenYieldForElse)) {
@@ -1007,6 +1033,17 @@ bool OpClassifierPass::handleYieldFromElseRegion(std::vector<OpCoreType> &coreTy
 
     // Propagate the determined core_type upstream to the defining operation
     if (Operation *defOp = operand.getDefiningOp()) {
+        if (CloneOpMap.count(defOp) && opCoreTypes.count(defOp) && opCoreTypes[defOp] != coreTypeToUse) {
+            Operation *cloneOp = CloneOpMap[defOp];
+            // Replace the operand in else yield with the cloneOp's result
+            for (unsigned i = 0; i < defOp->getNumResults(); ++i) {
+                if (defOp->getResult(i) == operand) {
+                    elseYieldOp->setOperand(operandIndex, cloneOp->getResult(i));
+                    defOp = cloneOp;
+                    break;
+                }
+            }
+        }
         propagateCoreTypeUpwardForYield(defOp, coreTypeToUse);
     }
 
@@ -1043,8 +1080,23 @@ void OpClassifierPass::processYieldOperation(Operation *op, Operation *thenYield
             // Use then region yield's core_type attribute to determine type.
             // If then yield has a comma-separated multi-value type string (e.g.
             // "CUBE,VECTOR"), extract the i-th component for this operand.
-            if (handleYieldFromElseRegion(coreTypes, i, thenYieldForElse, operand)) {
+            if (handleYieldFromElseRegion(coreTypes, i, thenYieldForElse, operand, op)) {
                 continue;
+            }
+
+            if (Operation *defOp = operand.getDefiningOp()) {
+                if (CloneOpMap.count(defOp) && opCoreTypes.count(defOp) && opCoreTypes[defOp] == OP_CUBE_ONLY) {
+                    Operation *cloneOp = CloneOpMap[defOp];
+                    // Replace the operand in else yield with the cloneOp's result
+                    for (unsigned j = 0; j < defOp->getNumResults(); ++j) {
+                        if (defOp->getResult(j) == operand && j < cloneOp->getNumResults()) {
+                            op->setOperand(i, cloneOp->getResult(j));
+                            defOp = cloneOp;
+                            operand = op->getOperand(i);
+                            break;
+                        }
+                    }
+                }
             }
 
             // ---------------------------------------------------------------
@@ -1246,6 +1298,8 @@ void OpClassifierPass::splitOperationForCubeAndVector(Operation *op, llvm::Dense
     opCoreTypes[vectorOp] = OP_VECTOR_ONLY;
     opToVectorClone[op] = vectorOp; // record for callers' operand mapping
     allOps.push_back(vectorOp);     // track new op so it gets core_type stamped
+    CloneOpMap[op] = vectorOp;      // record for laterClone map
+    CloneOpMap[vectorOp] = op;      // record for laterClone map
 
     // ------------------------------------------------------------------
     // Phase 4: Redirect VECTOR-only users to the cloned result

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp.cpp
@@ -29,6 +29,8 @@
 
 #include "ascend/include/DynamicCVPipeline/StandardizeOp.h"
 #include "ascend/include/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.h"
+#include "ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 
 using namespace mlir;
 using namespace triton;
@@ -48,6 +50,19 @@ void StandardizeOpPass::runOnOperation()
 
     if (llvm::failed(runPipeline(pm, op))) {
         LOG_DEBUG("Pipeline Failed!");
+        signalPassFailure();
+    }
+
+    bool findMayNotExec = false;
+    op->walk([&](linalg::MatmulOp matmulOp) {
+        if (matmulOp->hasAttr(CVPipeline::kMayNotExec)) {
+            findMayNotExec = true;
+        }
+    });
+
+    if (findMayNotExec) {
+        LOG_DEBUG("Matmul may not execute!");
+        CVPipeline::setFallbackAttr(op);
         signalPassFailure();
     }
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
@@ -20,15 +20,15 @@
  * THE SOFTWARE.
  */
 
-#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/ADT/iterator.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/LogicalResult.h"
+#include <cstddef>
+#include <optional>
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -41,8 +41,10 @@
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Value.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Support/LLVM.h"
+#include "llvm/ADT/SmallVector.h"
 
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.h"
@@ -66,6 +68,13 @@ struct MatmulInputs {
     Value bias;
 };
 
+struct SplitInfo {
+    bool mayNotExec;
+    Value outerInValue;
+    Value outerOutValue;
+    bool shouldSplit;
+};
+
 } // namespace
 
 static inline MatmulInputs parseMatmulInputs(linalg::MatmulOp matmulOp)
@@ -76,9 +85,12 @@ static inline MatmulInputs parseMatmulInputs(linalg::MatmulOp matmulOp)
     return {inputs[0], inputs[1], inits[0]};
 }
 
-// the user is responsible for checking biasDefOp is not null
+// The user is responsible for checking biasDefOp is not null.
 static bool operationIsFillZero(Operation *op)
 {
+    if (!op) {
+        return false;
+    }
     auto fillOp = dyn_cast<linalg::FillOp>(op);
     if (!fillOp) {
         return false;
@@ -87,48 +99,32 @@ static bool operationIsFillZero(Operation *op)
     return matchPattern(filledVal, m_Zero()) || matchPattern(filledVal, m_AnyZeroFloat());
 }
 
-// this generally should always be true, but just for safety...
+// This generally should always be true, but just for safety...
 static bool isFloatOrInt(RankedTensorType tensorType)
 {
     auto elmType = tensorType.getElementType();
     return isa<FloatType, IntegerType>(elmType);
 }
 
-// Search outward from args to obtain the following information:
-// 1. Whether args is only used and updated by matmul: bool argsLimitedInMatmul
-// 2. Whether matmul is guaranteed to execute: bool mayNotExec
-// 3. Outermost initial value: Value outerInVal
-// 4. Outermost for or if, i.e., where to insert if/else.
-static Value searchInArgsChain(Value nextValueOfC, bool &argsLimitedInMatmul, bool &mayNotExec, Value &outerInVal)
+/**
+ * Search outward from args to obtain the following information:
+ * 1. Whether args is only used and updated by matmul: bool argsLimitedInMatmul
+ * 2. Whether matmul is guaranteed to execute: bool mayNotExec
+ * 3. Outermost initial value: Value outerInValue
+ * 4. Outermost for or if, i.e., where to insert if/else.
+ */
+static Value searchInArgsChain(Value nextValueOfC, bool &argsLimitedInMatmul, bool &mayNotExec, Value &outerInValue)
 {
-    if (outerInVal.getDefiningOp()) {
-        return nextValueOfC;
-    }
     auto op = nextValueOfC.getDefiningOp();
     auto parentOp = op->getParentOp();
-    Value nextSearchValue = nextValueOfC;
-
-    // update mayNotExec
-    if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
-        IntegerAttr ubAttr, lbAttr;
-        if (matchPattern(forOp.getUpperBound(), m_Constant(&ubAttr)) &&
-            matchPattern(forOp.getLowerBound(), m_Constant(&lbAttr)))
-        {
-            if (ubAttr.getValue().sle(lbAttr.getValue())) {
-                mayNotExec = true;
-            }
-        } else {
-            mayNotExec = true;
-        }
-    } else if (auto ifOp = dyn_cast<scf::IfOp>(parentOp)) {
-        if (!matchPattern(ifOp.getCondition(), m_One())) {
-            mayNotExec = true;
-        }
+    if (outerInValue.getDefiningOp()) {
+        return nextValueOfC;
     }
 
     // update argsLimitedInMatmul
+    Value nextSearchValue = nextValueOfC;
     if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
-        auto blockArg = dyn_cast_if_present<BlockArgument>(outerInVal);
+        auto blockArg = dyn_cast_if_present<BlockArgument>(outerInValue);
         if (!blockArg || blockArg.getOwner() != forOp.getBody()) {
             argsLimitedInMatmul = false;
             return nextValueOfC;
@@ -148,19 +144,38 @@ static Value searchInArgsChain(Value nextValueOfC, bool &argsLimitedInMatmul, bo
                 break;
             }
         }
-        outerInVal = forOp.getInitArgs()[argIdx];
-        nextSearchValue = forOp->getResult(argIdx);
+        // check res is only used by yield
+        for (auto &use : nextValueOfC.getUses()) {
+            auto user = use.getOwner();
+            auto userInBlock = CVPipeline::getAncestorInBlock(user, op->getBlock());
+            auto yieldOp = dyn_cast<scf::YieldOp>(userInBlock);
+            if (!yieldOp) {
+                argsLimitedInMatmul = false;
+                break;
+            } else if (yieldOp->getBlock() != forOp.getBody()) {
+                argsLimitedInMatmul = false;
+                break;
+            } else if (use.getOperandNumber() != argIdx) {
+                argsLimitedInMatmul = false;
+                break;
+            }
+        }
+
+        if (argsLimitedInMatmul) {
+            outerInValue = forOp.getInitArgs()[argIdx];
+            nextSearchValue = forOp->getResult(argIdx);
+        }
     } else if (auto ifOp = dyn_cast<scf::IfOp>(parentOp)) {
         if (!ifOp.elseBlock()) {
             argsLimitedInMatmul = false;
         }
-        auto otherYieldOp = op->getBlock() == ifOp->getBlock() ? cast<scf::YieldOp>(ifOp.elseBlock()->getTerminator())
+        auto otherYieldOp = op->getBlock() == ifOp.thenBlock() ? cast<scf::YieldOp>(ifOp.elseBlock()->getTerminator())
                                                                : cast<scf::YieldOp>(ifOp.thenBlock()->getTerminator());
-        auto opYieldOp = op->getBlock() == ifOp->getBlock() ? cast<scf::YieldOp>(ifOp.thenBlock()->getTerminator())
+        auto opYieldOp = op->getBlock() == ifOp.thenBlock() ? cast<scf::YieldOp>(ifOp.thenBlock()->getTerminator())
                                                             : cast<scf::YieldOp>(ifOp.elseBlock()->getTerminator());
         int resultIdx = -1;
         for (unsigned i = 0; i < otherYieldOp->getNumOperands(); ++i) {
-            if (otherYieldOp->getOperand(i) == outerInVal && opYieldOp->getOperand(i) == nextSearchValue) {
+            if (otherYieldOp->getOperand(i) == outerInValue && opYieldOp->getOperand(i) == nextSearchValue) {
                 resultIdx = i;
                 break;
             }
@@ -176,318 +191,289 @@ static Value searchInArgsChain(Value nextValueOfC, bool &argsLimitedInMatmul, bo
     }
 
     if (!argsLimitedInMatmul) {
-        return nextValueOfC; // early return
+        return nextValueOfC;
     }
-    return searchInArgsChain(nextSearchValue, argsLimitedInMatmul, mayNotExec, outerInVal);
-}
-
-template <typename Container> static Container filterNonIgnoredOps(const Container &container)
-{
-    auto filteredRange = llvm::make_filter_range(container, [](Operation *op) { return !isa<tensor::DimOp>(op); });
-    return Container(filteredRange.begin(), filteredRange.end());
-}
-
-static OpOperand *getOnlyUse(Operation *op, Value value)
-{
-    auto uses =
-        make_pointer_range(make_filter_range(op->getOpOperands(), [=](OpOperand &use) { return use.get() == value; }));
-    llvm::SmallVector<OpOperand *> usesVec(uses.begin(), uses.end());
-    if (usesVec.size() != 1) {
-        return nullptr;
+    // update mayNotExec
+    if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
+        IntegerAttr ubAttr, lbAttr;
+        if (matchPattern(forOp.getUpperBound(), m_Constant(&ubAttr)) &&
+            matchPattern(forOp.getLowerBound(), m_Constant(&lbAttr)))
+        {
+            if (ubAttr.getValue().sle(lbAttr.getValue())) {
+                mayNotExec = true;
+            }
+        } else {
+            mayNotExec = true;
+        }
+    } else if (auto ifOp = dyn_cast<scf::IfOp>(parentOp)) {
+        if (!matchPattern(ifOp.getCondition(), m_One())) {
+            mayNotExec = true;
+        }
     }
-
-    return usesVec[0];
+    return searchInArgsChain(nextSearchValue, argsLimitedInMatmul, mayNotExec, outerInValue);
 }
 
 /**
- * @brief Traces a chain of single-user operations starting from the given value.
- * Returns true if an operation matching the predicate is found in the chain.
+ * Traces the chain of users of a given value to find a matching operation.
+ * This function recursively follows the use-def chain through various operation types
+ * (ViewLikeOpInterface, scf::ForOp, scf::YieldOp) to locate an operation that matches
+ * the specified criteria.
  *
- * This function follows the def-use chain through operations that have exactly
- * one user. It traverses through:
- * - View-like operations (follows their single result)
- * - For loops (tracks init args to iteration arguments, then continues from yield to result)
- * - Yield operations within for/if (maps yield operands to parent operation results)
- * - Skip-able operations specified by isSkipOp callback
+ * Parameters:
+ *   value        - The starting value whose users are to be traced.
+ *   needSingle   - If true, requires that the value has exactly one user in its parent block.
+ *                  If multiple users exist, returns std::nullopt.
+ *   isMatchedOp  - A predicate function that determines if an operation is the target match.
+ *                  Returns true if the operation matches the desired criteria.
+ *   isSkipOp     - A predicate function that determines if an operation should be skipped.
+ *                  If true and the operation has a single result, continues tracing through
+ *                  that result.
  *
- * @param value The starting value to trace from
- * @param isMatchedOp Callback to check if an operation matches the criteria
- * @param isSkipOp Callback to check if an operation should be skipped (continue tracing its result)
- * @return True if a matching operation is found, false otherwise
+ * Returns:
+ *   The matched operation if found, or std::nullopt if no match is found or if
+ *   the single-user requirement is violated.
  */
-static bool traceSingleChainUser(Value value, const std::function<bool(Operation *, Value v)> &isMatchedOp,
-                                 const std::function<bool(Operation *, Value v)> &isSkipOp)
+std::optional<Operation *> traceChainUser(Value value, bool needSingle,
+                                          const std::function<bool(Operation *, Value v)> &isMatchedOp,
+                                          const std::function<bool(Operation *, Value v)> &isSkipOp)
 {
-    if (!value) {
+    Operation *nextUser = nullptr;
+    for (auto &use : value.getUses()) {
+        Operation *user = use.getOwner();
+        auto userInblock = CVPipeline::getAncestorInBlock(user, value.getParentBlock());
+        if (nextUser && userInblock != nextUser && needSingle) {
+            return std::nullopt; // not single user
+        } else if (!nextUser && userInblock) {
+            nextUser = userInblock;
+        }
+    }
+
+    for (auto &use : value.getUses()) {
+        Operation *user = use.getOwner();
+        if (llvm::isa<ViewLikeOpInterface, tensor::ExtractSliceOp>(user)) {
+            return traceChainUser(user->getResult(0), needSingle, isMatchedOp, isSkipOp);
+        }
+
+        if (auto forOp = dyn_cast<scf::ForOp>(user)) {
+            auto initArgs = forOp.getInitArgs();
+            int initIndx = -1;
+            int useCnt = 0;
+            for (auto [i, arg] : llvm::enumerate(initArgs)) {
+                if (arg == value) {
+                    initIndx = i;
+                    useCnt++;
+                }
+            }
+            if (useCnt == 1) {
+                return traceChainUser(forOp.getRegionIterArgs()[initIndx], needSingle, isMatchedOp, isSkipOp);
+            }
+            return std::nullopt;
+        }
+
+        if (auto yieldOp = dyn_cast<scf::YieldOp>(user)) {
+            auto operands = yieldOp.getOperands();
+            auto it = llvm::find(operands, value);
+            if (it == operands.end()) {
+                return std::nullopt;
+            }
+            auto index = std::distance(operands.begin(), it);
+
+            Operation *parentOp = yieldOp->getParentOp();
+            if (!parentOp || static_cast<size_t>(index) >= parentOp->getNumResults()) {
+                return std::nullopt;
+            }
+
+            return traceChainUser(parentOp->getResult(index), needSingle, isMatchedOp, isSkipOp);
+        }
+
+        if (isMatchedOp(user, value)) {
+            return user;
+        }
+        if (isSkipOp(user, value)) {
+            if (user->getNumResults() == 1) {
+                return traceChainUser(user->getResult(0), needSingle, isMatchedOp, isSkipOp);
+            }
+            return std::nullopt;
+        }
+    }
+    return std::nullopt;
+}
+
+static bool isSubviewFromGlobalMemory(ViewLikeOpInterface viewOp)
+{
+    // Subview ops may be nested many layers deep through reinterpretation or other subviews.
+    // like, subview (subview (reinterpret_cast (subview (reinterpret_cast (arg0)))))
+    // so we need Search and only keep same block view-like op.
+    if (!viewOp) {
         return false;
     }
-
-    auto users = filterNonIgnoredOps(llvm::DenseSet<Operation *>(value.user_begin(), value.user_end()));
-    if (users.size() != 1) {
-        return false;
-    }
-
-    auto *user = *users.begin();
-    if (llvm::isa<ViewLikeOpInterface>(user)) {
-        return traceSingleChainUser(user->getResult(0), isMatchedOp, isSkipOp);
-    }
-
-    if (auto forOp = dyn_cast<scf::ForOp>(user)) {
-        auto initArgs = forOp.getInitArgs();
-        int initIndx = -1;
-        int useCnt = 0;
-        for (auto [i, arg] : llvm::enumerate(initArgs)) {
-            if (arg == value) {
-                initIndx = i;
-                useCnt++;
+    Value source = viewOp.getViewSource();
+    while (true) {
+        LOG_DEBUG("Check view source: " << source << "\n");
+        if (auto blockArg = dyn_cast<BlockArgument>(source)) {
+            Operation *parentOp = blockArg.getOwner()->getParentOp();
+            if (isa<func::FuncOp>(parentOp)) {
+                return true;
+            } else if (isa<LoopLikeOpInterface>(parentOp)) {
+                auto argIndex = blockArg.getArgNumber();
+                if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
+                    if (argIndex > 0) {
+                        source = forOp.getInitArgs()[argIndex - 1];
+                    }
+                } else if (auto whileOp = dyn_cast<scf::WhileOp>(parentOp)) {
+                    source = whileOp.getInits()[argIndex];
+                } else {
+                    LOG_DEBUG("Subview source block argument is from unknow block.");
+                    return false;
+                }
             }
         }
-        if (useCnt == 1) {
-            return traceSingleChainUser(forOp.getRegionIterArgs()[initIndx], isMatchedOp, isSkipOp);
+        // From other view-like op
+        if (auto viewLike = dyn_cast<ViewLikeOpInterface>(source.getDefiningOp())) {
+            source = viewLike.getViewSource();
+            continue;
         }
-        return false;
-    }
-
-    // used in yield, we need find the for/if result;
-    auto parentOp = user->getParentOp();
-    if (parentOp && isa<scf::YieldOp>(user) && llvm::isa_and_present<scf::ForOp, scf::IfOp>(parentOp)) {
-        auto use = getOnlyUse(user, value);
-        if (!use) {
-            return false;
-        }
-        return traceSingleChainUser(parentOp->getResult(use->getOperandNumber()), isMatchedOp, isSkipOp);
-    }
-
-    if (isMatchedOp(user, value)) {
-        return true;
-    }
-
-    if (isSkipOp(user, value)) {
-        if (user && user->getNumResults() == 1) {
-            return traceSingleChainUser(user->getResult(0), isMatchedOp, isSkipOp);
-        }
+        LOG_DEBUG("Subview source defining op is not ViewLikeOpInterface: " << source);
         return false;
     }
     return false;
 }
 
-static bool verifyAndHandleLoopCarriedL0C(linalg::MatmulOp matmulOp, PatternRewriter &rewriter, Value bias)
+/**
+ * Determines whether a matmul operation should be split based on its output usage.
+ * A split is needed when the matmul output is used in ways that would cause hardware issues:
+ * 1. (Specific scenarios Filter) Output is used by a nested matmul (L0C -> L0C) which causes NPUIR fixpipe errors.
+ * 2. Output is used as input A or B of another matmul (L0C -> L1), which requires
+ *    materialization to global memory.
+ *
+ * Parameters:
+ *   matmulOp     - The matmul operation to check.
+ *   outerOutValue   - The outermost result value in the use-def chain.
+ *   outerInValue - The outermost initial value (bias) in the use-def chain.
+ *
+ * Returns:
+ *   true if the matmul should be split due to output usage, false otherwise.
+ */
+static bool isOutputFilter(linalg::MatmulOp matmulOp, Value &outerOutValue, Value &outerInValue)
 {
-    if (matmulOp->hasAttr(CVPipeline::kLoopCarriedL0C)) {
-        return false;
-    }
-
-    bool argsLimitedInMatmul = true;
-    bool mayNotExec = false;
-    Value outerInVal = bias;
-    auto outerValue = searchInArgsChain(matmulOp.getResult(0), argsLimitedInMatmul, mayNotExec, outerInVal);
-    auto *outerDefOp = outerValue.getDefiningOp();
-    if (!argsLimitedInMatmul) {
-        LOG_DEBUG("Split because bias is not limited in args" << matmulOp);
-        return true;
-    }
-
-    if (!operationIsFillZero(outerInVal.getDefiningOp())) {
-        // From one matmul
-        auto defMatmul =
-            dyn_cast_if_present<linalg::MatmulOp>(hivm::traceDefOp<linalg::MatmulOp>(bias).value_or(nullptr));
-        if (!defMatmul) {
-            LOG_DEBUG("Split because bias may not be zero, and the init value is not from matmul: " << matmulOp);
-            return true;
+    // Specific scenario: used by store and nextUser is nested
+    auto matchStoreGm = [](Operation *op, Value value) {
+        if (auto nextStoreGM = dyn_cast<bufferization::MaterializeInDestinationOp>(op)) {
+            Value dest = nextStoreGM.getDest();
+            auto viewOp = dest.getDefiningOp<ViewLikeOpInterface>();
+            return isSubviewFromGlobalMemory(viewOp);
+        } else if (auto hivmStore = dyn_cast<hivm::StoreOp>(op)) {
+            auto dest = hivmStore.getDst();
+            auto viewOp = dest.getDefiningOp<ViewLikeOpInterface>();
+            return isSubviewFromGlobalMemory(viewOp);
         }
-        LOG_DEBUG("Split because avoiding NPUIR insert fixpipe errors" << matmulOp);
+        return false;
+    };
+    auto storeToGM =
+        traceChainUser(outerOutValue, false, matchStoreGm, [](Operation *op, Value value) { return false; });
+    if (storeToGM.has_value() && storeToGM.value()->getBlock() != outerOutValue.getParentBlock()) {
+        LOG_DEBUG("(store) Split because avoiding NPUIR insert fixpipe errors. " << matmulOp);
         return true;
     }
-    auto matchFunc = [=](Operation *op, Value value) {
+
+    // Specific scenario: used by single L0C and nextUser is nested
+    auto matchMatmulC = [](Operation *op, Value value) {
         if (auto nextMatmulOp = dyn_cast<linalg::MatmulOp>(op)) {
             auto inputs = parseMatmulInputs(nextMatmulOp);
             return inputs.a != value && inputs.b != value && inputs.bias == value;
         }
         return false;
     };
-
-    if (traceSingleChainUser(outerValue, matchFunc, [](Operation *op, Value value) { return false; })) {
-        // To one matmul
-        LOG_DEBUG("Split because avoiding NPUIR insert fixpipe errors" << matmulOp);
+    auto usedByL0C =
+        traceChainUser(outerOutValue, true, matchMatmulC, [](Operation *op, Value value) { return false; });
+    if (usedByL0C.has_value() && usedByL0C.value()->getBlock() != outerOutValue.getParentBlock()) {
+        LOG_DEBUG("(first) Split because avoiding NPUIR insert fixpipe errors. " << matmulOp);
+        return true;
+    }
+    return false;
+}
+static bool shouldSplitByOutput(linalg::MatmulOp matmulOp, Value &outerOutValue, Value &outerInValue)
+{
+    if (isOutputFilter(matmulOp, outerOutValue, outerInValue)) {
+        return true;
+    }
+    // used by any L1
+    auto matchMatmulAB = [](Operation *op, Value value) {
+        if (auto nextMatmulOp = dyn_cast<linalg::MatmulOp>(op)) {
+            auto inputs = parseMatmulInputs(nextMatmulOp);
+            return inputs.a == value || inputs.b == value;
+        }
+        return false;
+    };
+    auto skipCubeop = [=](Operation *op, Value value) { return isa<linalg::TransposeOp>(op); };
+    auto usedByL1 = traceChainUser(outerOutValue, false, matchMatmulAB, skipCubeop);
+    if (usedByL1.has_value()) {
+        LOG_DEBUG("Split avoid L0C -> L1. " << matmulOp); // S01-S08
         return true;
     }
 
-    matmulOp->setAttr(CVPipeline::kLoopCarriedL0C, rewriter.getUnitAttr());
-
-    if (mayNotExec) {
-        LOG_DEBUG("Split because the for loop may not execute" << matmulOp);
-        return true;
-    }
-    LOG_DEBUG("Not Split because bias can remain in L0C" << matmulOp);
     return false;
 }
 
 /**
- * @brief Evaluates whether a Matmul operation is a candidate for splitting.
+ * Determines whether a matmul operation should be split based on its input (bias) source.
+ * The split is avoided when:
+ * 1. The bias is filled with zeros (no need to split).
+ * 2. The bias comes from another matmul output (L0C remaining in the chain).
  *
- * This pattern identifies tensor-based matmul operations where the accumulator (bias) is
- * non-zero or dynamic. Splitting isolates the pure GEMM computation (ideal for CUBE hardware)
- * from the accumulator addition (ideal for VECTOR hardware), preventing hardware execution stalls.
+ * Parameters:
+ *   matmulOp     - The matmul operation to check.
+ *   outerOutValue   - The outermost result value in the use-def chain.
+ *   outerInValue - The outermost initial value (bias) in the use-def chain.
  *
- * Matching Logic and Rules:
- *
- * 1. Validation Checks:
- *    - The matmul must operate on tensors (tensor mode).
- *    - The element type of the output must be an integer or a float type.
- *
- * 2. Rule 1: Dynamic / Block Argument Accumulator
- *    - If the bias tensor is a block argument (i.e., it has no defining operation in the
- *      current block), its compile-time value is unknown. We conservatively assume it is
- *      non-zero and trigger a split.
- *
- * 3. Rule 2: Zero-Accumulator Bypass (Do Not Split)
- *    - If the bias tensor is statically known to be a constant zero (e.g., initialized via
- *      linalg.fill with 0), the split is bypassed. Standard lowerings already optimize
- *      this cleanly without introducing a redundant vector addition.
- *
- * 4. Default Split:
- *    - If the bias is defined, non-zero, and does not fall under Rule 3, split the operation.
+ * Returns:
+ *   true if the matmul should be split due to input source, false otherwise.
  */
-static bool shouldSplit(linalg::MatmulOp matmulOp, PatternRewriter &rewriter)
+static bool isInputFilter(linalg::MatmulOp matmulOp, Value &outerOutValue, Value &outerInValue)
 {
-    auto matmulResult = matmulOp->getResult(0);
-    for (auto res : matmulResult.getUsers()) {
-        if (auto nextMatmul = dyn_cast<linalg::MatmulOp>(res)) {
-            auto inputs = parseMatmulInputs(nextMatmul);
-            if (inputs.a == matmulResult || inputs.b == matmulResult) {
-                LOG_DEBUG("Split because the user is matmul's A or B." << matmulOp);
-                return true;
-            }
+    // Specific scenario: outerInValue from L0C and nextUser is nested
+    auto defMatmul =
+        dyn_cast_if_present<linalg::MatmulOp>(hivm::traceDefOp<linalg::MatmulOp>(outerInValue).value_or(nullptr));
+    if (defMatmul) {
+        auto defInMatmulBlock = CVPipeline::getAncestorInBlock(defMatmul, matmulOp->getBlock());
+        if (!defInMatmulBlock) {
+            LOG_DEBUG("(Second) Split because avoiding NPUIR insert fixpipe errors. " << matmulOp);
+            return true;
         }
     }
-
-    auto bias = parseMatmulInputs(matmulOp).bias;
-    auto *biasDefOp = bias.getDefiningOp();
-    // Rule 1: bias is block arg -> split if result cannot remain in l0c
-    if (!biasDefOp) {
-        return verifyAndHandleLoopCarriedL0C(matmulOp, rewriter, bias);
+    return false;
+}
+static bool shouldSplitByInput(linalg::MatmulOp matmulOp, Value &outerOutValue, Value &outerInValue)
+{
+    if (isInputFilter(matmulOp, outerOutValue, outerInValue)) {
+        return true;
     }
-
-    // Rule 2: matmul a b 0 -> do not split
-    if (operationIsFillZero(biasDefOp)) {
-        LOG_DEBUG("Not split because bias is zero: " << matmulOp);
+    if (operationIsFillZero(outerInValue.getDefiningOp())) {
+        LOG_DEBUG("Not split because bias is zero. " << matmulOp);
         return false;
     }
-
-    // Otherwise split:
-    LOG_DEBUG("Should split: " << matmulOp);
-
+    auto defMatmul =
+        dyn_cast_if_present<linalg::MatmulOp>(hivm::traceDefOp<linalg::MatmulOp>(outerInValue).value_or(nullptr));
+    if (defMatmul) {
+        LOG_DEBUG("Not split because L0C remain. " << matmulOp);
+        return false;
+    }
+    // from broadcast [N]->[M, N] // S11 S12 S19 S20
     return true;
 }
 
 /**
- * @brief Transforms a matmul with a non-zero accumulator into a zero-initialized matmul
- * followed by an elementwise addition.
- *
- * This transformation breaks the combined GEMM-and-accumulation execution down to isolate
- * the high-throughput matrix multiply from vector-based bias additions.
- *
- * =========================================================================================
- * --- [BEFORE] ---
- * %bias = ... : tensor<MxNxf32>
- * %result = linalg.matmul ins(%a, %b : tensor<MxKxf32>, tensor<KxNxf32>)
- *                       outs(%bias : tensor<MxNxf32>) -> tensor<MxNxf32>
- *
- * =========================================================================================
- * --- [AFTER] ---
- * // Step 1: Create a placeholder empty tensor matching the output shape
- * %empty = tensor.empty() : tensor<MxNxf32>
- *
- * // Step 2: Initialize constant zero corresponding to the element type
- * %cst_0 = arith.constant 0.000000e+00 : f32
- *
- * // Step 3: Fill the empty tensor to establish a zero-accumulator
- * %zero_acc = linalg.fill ins(%cst_0 : f32) outs(%empty : tensor<MxNxf32>) -> tensor<MxNxf32>
- *
- * // Step 4: Perform the pure GEMM operation on the zero-accumulator
- * %matmul_res = linalg.matmul ins(%a, %b : tensor<MxKxf32>, tensor<KxNxf32>)
- *                           outs(%zero_acc : tensor<MxNxf32>) -> tensor<MxNxf32>
- *
- * // Step 5: Complete the operation by adding the original bias using an elementwise add
- * %result = arith.addf %matmul_res, %bias : tensor<MxNxf32>
- * =========================================================================================
- *
- * Assumptions:
- * 1. The operation is tensor-based (not buffer-based).
- * 2. The accumulator (bias) is not statically known to be zero.
- * 3. The element type is a primitive float or integer type.
+ * Verifies whether a matmul operation is valid for split transformation.
+ * Returns false if the matmul should be skipped due to:
+ * 1. Already processed matmul (has kLoopCarriedL0C attribute)
+ * 2. Illegal matmul (missing inits or inputs)
+ * 3. Memref-type matmul (not tensor mode)
  */
-static void splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rewriter)
-{
-    auto inputs = matmulOp.getDpsInputs();
-    auto a = inputs[0];
-    auto b = inputs[1];
-
-    // this is the accumulator/out operand, not result in tensor mode
-    auto bias = matmulOp.getDpsInits()[0];
-
-    auto outputType = dyn_cast<RankedTensorType>(bias.getType());
-    if (!outputType) {
-        LOG_DEBUG("Not tensor mode: " << matmulOp
-                                      << "; the caller does not ensure the assumption. Cowardly doing nothing");
-        return;
-    }
-    auto elmType = outputType.getElementType();
-
-    Location loc = matmulOp.getLoc();
-
-    // [Step 1] Create tensor.empty for the new accumulator tensor
-    // Same shape and type as original matmul output
-    SmallVector<Value> dynamicSizes;
-    for (int64_t i = 0; i < outputType.getRank(); ++i) {
-        if (outputType.isDynamicDim(i)) {
-            dynamicSizes.push_back(rewriter.create<tensor::DimOp>(loc, bias, i));
-        }
-    }
-    auto emptyOp = rewriter.create<tensor::EmptyOp>(loc, outputType, dynamicSizes);
-
-    // [Step 2] Create zero constant based on element type
-    // Supports both floating-point (arith.constant float) and integer types
-    Value zeroValue;
-    if (auto floatType = dyn_cast<FloatType>(elmType)) {
-        APFloat zeroAPFloat = APFloat::getZero(floatType.getFloatSemantics());
-        zeroValue = rewriter.create<arith::ConstantFloatOp>(loc, zeroAPFloat, floatType).getResult();
-    } else if (auto intType = dyn_cast<IntegerType>(elmType)) {
-        zeroValue = rewriter.create<arith::ConstantIntOp>(loc, 0, intType).getResult();
-    } else {
-        // User does not ensure assumption 3.
-        return;
-    }
-
-    // [Step 3] Use linalg.fill to populate empty tensor with zero -> zero accumulator
-    auto fillOp = rewriter.create<linalg::FillOp>(loc, ValueRange {zeroValue}, ValueRange {emptyOp.getResult()});
-
-    // [Step 5] Create new matmul using zero-filled tensor as accumulator
-    // New matmul runs entirely on CUBE with no VECTOR dependency
-    auto newMatmul = rewriter.create<linalg::MatmulOp>(loc, ValueRange {a, b}, ValueRange {fillOp.getResult(0)});
-    NamedAttrList attrs(matmulOp->getAttrDictionary());
-    constexpr StringLiteral kShouldRemoveAttrs[] = {"operandSegmentSizes", "res_attrs", "arg_attrs"};
-    for (auto attr : kShouldRemoveAttrs) {
-        attrs.erase(attr);
-    }
-    newMatmul->setAttrs(attrs);
-    auto newMatmulRes = newMatmul.getResult(0);
-
-    // [Step 6] Create add: add(new_matmul_result, outs_value)
-    // This is the "c" in a*b+c, added after the matmul result
-    Operation *addOp;
-    if (isa<FloatType>(elmType)) {
-        addOp = rewriter.create<arith::AddFOp>(loc, newMatmulRes, bias).getOperation();
-    } else {
-        addOp = rewriter.create<arith::AddIOp>(loc, newMatmulRes, bias).getOperation();
-    }
-
-    addOp->setAttr(CVPipeline::kAddFromMatmul, rewriter.getUnitAttr());
-    rewriter.replaceOp(matmulOp, addOp);
-}
-
 static bool verifyMatmul(linalg::MatmulOp matmulOp)
 {
+    if (matmulOp->hasAttr(CVPipeline::kLoopCarriedL0C)) {
+        return false;
+    }
     auto inits = matmulOp.getDpsInits();
     auto inputs = matmulOp.getDpsInputs();
     if (inits.empty() || inputs.size() < 2) {
@@ -505,20 +491,132 @@ static bool verifyMatmul(linalg::MatmulOp matmulOp)
         LOG_DEBUG("Not split because not integer or float: " << matmulOp);
         return false;
     }
-
     return true;
+}
+
+/**
+ * Determines whether a matmul operation should be split based on comprehensive analysis.
+ * This function performs a complete analysis of the matmul operation's context, including:
+ * 1. Tracing the use-def chain of the output to find the outermost scope.
+ * 2. Evaluating input-based split criteria via shouldSplitByInput() and shouldSplitByOutput().
+ *
+ * Parameters:
+ *   matmulOp - The matmul operation to analyze.
+ *
+ * Returns:
+ *   An optional SplitInfo structure containing:
+ *   - mayNotExec: Whether the matmul might not execute (e.g., in a conditional or empty loop).
+ *   - outerInValue: The outermost initial value (original bias) in the chain.
+ *   - outerOutValue: The outermost result value in the chain.
+ *   - shouldSplit: Boolean indicating whether the split transformation should be applied.
+ *   Returns std::nullopt if analysis cannot be performed.
+ */
+static std::optional<SplitInfo> shouldSplit(linalg::MatmulOp matmulOp)
+{
+
+    if (!verifyMatmul(matmulOp)) {
+        return std::nullopt;
+    }
+
+    auto matmulInput = parseMatmulInputs(matmulOp);
+    bool argsLimitedInMatmul = true;
+    bool mayNotExec = false;
+    Value outerInValue = matmulInput.bias;
+    auto outerOutValue = searchInArgsChain(matmulOp.getResult(0), argsLimitedInMatmul, mayNotExec, outerInValue);
+    if (!argsLimitedInMatmul) {
+        LOG_DEBUG("Split because bias is not limited in args" << matmulOp); // S25
+        return SplitInfo {mayNotExec, outerInValue, outerOutValue, true};
+    }
+
+    if (!shouldSplitByInput(matmulOp, outerOutValue, outerInValue) &&
+        !shouldSplitByOutput(matmulOp, outerOutValue, outerInValue))
+    {
+        return SplitInfo {mayNotExec, outerInValue, outerOutValue, false};
+    }
+
+    return SplitInfo {mayNotExec, outerInValue, outerOutValue, true};
+}
+
+static void splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rewriter, SplitInfo splitInfo)
+{
+    auto outputType = dyn_cast<RankedTensorType>(parseMatmulInputs(matmulOp).bias.getType());
+    if (!outputType) {
+        LOG_DEBUG("Not tensor mode: " << matmulOp
+                                      << "; the caller does not ensure the assumption. Cowardly doing nothing");
+        return;
+    }
+    auto elmType = outputType.getElementType();
+
+    Location loc = matmulOp.getLoc();
+
+    // [Step 1] Create tensor.empty for the new accumulator tensor
+    // Same shape and type as original matmul output
+    auto outerDefOp = splitInfo.outerOutValue.getDefiningOp();
+    rewriter.setInsertionPoint(outerDefOp);
+    SmallVector<Value> dynamicSizes;
+    for (int64_t i = 0; i < outputType.getRank(); ++i) {
+        if (outputType.isDynamicDim(i)) {
+            dynamicSizes.push_back(rewriter.create<tensor::DimOp>(loc, parseMatmulInputs(matmulOp).bias, i));
+        }
+    }
+    auto emptyOp = rewriter.create<tensor::EmptyOp>(loc, outputType, dynamicSizes);
+    splitInfo.outerInValue.replaceUsesWithIf(emptyOp->getResult(0),
+                                             [&](OpOperand &opop) { return opop.getOwner() == outerDefOp; });
+
+    // [Step 2] Create new matmul using zero-filled tensor as accumulator
+    // New matmul runs entirely on CUBE with no VECTOR dependency
+    auto inputs = parseMatmulInputs(matmulOp);
+    auto a = inputs.a;
+    auto b = inputs.b;
+    auto bias = inputs.bias;
+    rewriter.setInsertionPoint(matmulOp);
+    auto newMatmul = rewriter.create<linalg::MatmulOp>(loc, ValueRange {a, b}, ValueRange {bias});
+    NamedAttrList attrs(matmulOp->getAttrDictionary());
+    constexpr StringLiteral kShouldRemoveAttrs[] = {"operandSegmentSizes", "res_attrs", "arg_attrs"};
+    for (auto attr : kShouldRemoveAttrs) {
+        attrs.erase(attr);
+    }
+    newMatmul->setAttrs(attrs);
+
+    // [Step 3] Create add: add(new_matmul_result, outs_value)
+    // This is the "c" in a*b+c, added after the matmul result
+    rewriter.setInsertionPointAfterValue(splitInfo.outerOutValue);
+    Operation *addOp;
+    if (isa<FloatType>(elmType)) {
+        addOp = rewriter.create<arith::AddFOp>(loc, splitInfo.outerOutValue, splitInfo.outerInValue).getOperation();
+    } else {
+        addOp = rewriter.create<arith::AddIOp>(loc, splitInfo.outerOutValue, splitInfo.outerInValue).getOperation();
+    }
+    addOp->setAttr(CVPipeline::kAddFromMatmul, rewriter.getUnitAttr());
+    splitInfo.outerOutValue.replaceUsesWithIf(addOp->getResult(0),
+                                              [&](OpOperand &opop) { return opop.getOwner() != addOp; });
+
+    rewriter.replaceOp(matmulOp, newMatmul);
 }
 
 LogicalResult SplitMatmulPattern::matchAndRewrite(linalg::MatmulOp matmulOp, PatternRewriter &rewriter) const
 {
-    if (!verifyMatmul(matmulOp)) {
+    LOG_DEBUG("check matmulOp = " << matmulOp);
+    auto splitInfoOpt = shouldSplit(matmulOp);
+    if (!splitInfoOpt.has_value()) {
         return failure();
     }
+    auto splitInfo = splitInfoOpt.value();
+    LOG_DEBUG("-------------------");
+    LOG_DEBUG("matmulOp = " << matmulOp);
+    LOG_DEBUG("outerOutValue = " << splitInfo.outerOutValue);
+    LOG_DEBUG("outerInValue = " << splitInfo.outerInValue);
+    LOG_DEBUG("mayNotExec = " << splitInfo.mayNotExec);
+    LOG_DEBUG("shouldSplit = " << splitInfo.shouldSplit);
+    LOG_DEBUG("-------------------");
+    matmulOp->setAttr(CVPipeline::kLoopCarriedL0C, rewriter.getUnitAttr());
 
-    if (!shouldSplit(matmulOp, rewriter)) {
-        return failure();
+    if (splitInfo.shouldSplit) {
+        splitMatmul(matmulOp, rewriter, splitInfo);
     }
 
-    splitMatmul(matmulOp, rewriter);
+    if (splitInfo.mayNotExec) {
+        matmulOp->setAttr(CVPipeline::kMayNotExec, rewriter.getUnitAttr());
+    }
     return success();
 }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_match_empty_pattern.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_match_empty_pattern.mlir
@@ -1,0 +1,20 @@
+// RUN: triton-opt --op-classifier %s | FileCheck %s
+
+// Test tensor.empty pattern matching: empty outside loop, used as iter_arg, matmul uses iter_arg as output
+
+module {
+  // CHECK-LABEL: func.func @test_empty_loop_iter_arg
+  // CHECK: tensor.empty() {ssbuffer.core_type = "CUBE"}
+  // CHECK: scf.for
+  // CHECK: linalg.matmul {ssbuffer.core_type = "CUBE"}
+  func.func @test_empty_loop_iter_arg(%a: tensor<64x64xf16>, %b: tensor<64x64xf16>, %n: index) -> tensor<64x64xf32> {
+    %empty = tensor.empty() : tensor<64x64xf32>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %result = scf.for %i = %c0 to %n step %c1 iter_args(%acc = %empty) -> (tensor<64x64xf32>) {
+      %mm = linalg.matmul ins(%a, %b : tensor<64x64xf16>, tensor<64x64xf16>) outs(%acc : tensor<64x64xf32>) -> tensor<64x64xf32>
+      scf.yield %mm : tensor<64x64xf32>
+    }
+    return %result : tensor<64x64xf32>
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/StandardizeOp/split_matmul.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/StandardizeOp/split_matmul.mlir
@@ -5,10 +5,8 @@ module {
   // According to Rule 2, its value is unknown, so we split it.
   // CHECK-LABEL: func.func @case1_block_arg_bias
   // CHECK-SAME: (%[[A:.*]]: tensor<32x64xf32>, %[[B:.*]]: tensor<64x32xf32>, %[[BIAS:.*]]: tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK-DAG: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK-DAG: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
-  // CHECK: %[[ZERO:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK: %[[MM:.*]] = linalg.matmul ins(%[[A]], %[[B]] : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%[[A]], %[[B]] : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD:.*]] = arith.addf %[[MM]], %[[BIAS]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // CHECK: return %[[ADD]] : tensor<32x32xf32>
   func.func @case1_block_arg_bias(%A: tensor<32x64xf32>, %B: tensor<64x32xf32>, %bias: tensor<32x32xf32>) -> tensor<32x32xf32> {
@@ -22,7 +20,7 @@ module {
   // CHECK: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
   // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xf32>
   // CHECK: %[[ZERO:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK: %[[MM:.*]] = linalg.matmul ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK-NOT: arith.addf
   // CHECK: return %[[MM]]
   func.func @case2_zero_bias(%A: tensor<32x64xf32>, %B: tensor<64x32xf32>) -> tensor<32x32xf32> {
@@ -37,14 +35,15 @@ module {
   // According to Rule 1, %mm1 must be split even though its bias is constant zero.
   // %mm2's bias is zero and its result is not used by any other matmul, so %mm2 is not split.
   // CHECK-LABEL: func.func @case3_result_used_by_matmul
-  // CHECK-DAG: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
-  // CHECK: %[[EMPTY32:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[ZERO32:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY32]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK: %[[MM1:.*]] = linalg.matmul ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO32]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK-NOT: arith.addf
-  // CHECK: %[[EMPTY16:.*]] = tensor.empty() : tensor<32x16xf32>
-  // CHECK: %[[ZERO16:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY16]] : tensor<32x16xf32>) -> tensor<32x16xf32>
-  // CHECK: %[[MM2:.*]] = linalg.matmul ins(%[[MM1]], %{{.*}} : tensor<32x32xf32>, tensor<32x16xf32>) outs(%[[ZERO16]] : tensor<32x16xf32>) -> tensor<32x16xf32>
+  // CHECK: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
+  // CHECK: %[[EMPTY1:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[ZERO1:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[EMPTY2:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[MM1:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ADD:.*]] = arith.addf %[[MM1]], %[[ZERO1]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
+  // CHECK: %[[EMPTY3:.*]] = tensor.empty() : tensor<32x16xf32>
+  // CHECK: %[[ZERO2:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY3]] : tensor<32x16xf32>) -> tensor<32x16xf32>
+  // CHECK: %[[MM2:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%[[ADD]], %{{.*}} : tensor<32x32xf32>, tensor<32x16xf32>) outs(%[[ZERO2]] : tensor<32x16xf32>) -> tensor<32x16xf32>
   // CHECK-NOT: arith.addf
   // CHECK: return %[[MM2]]
   func.func @case3_result_used_by_matmul(%A: tensor<32x64xf32>, %B: tensor<64x32xf32>, %B2: tensor<32x16xf32>) -> tensor<32x16xf32> {
@@ -62,13 +61,11 @@ module {
   // Case 4: Bias is non-zero (filled with a non-zero constant 1.0).
   // It should be split into a zero-initialized matmul followed by an arith.addf.
   // CHECK-LABEL: func.func @case4_nonzero_bias
-  // CHECK-DAG: %[[C1:.*]] = arith.constant 1.000000e+00 : f32
-  // CHECK-DAG: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
-  // CHECK: %[[BIAS_EMPTY:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[BIAS:.*]] = linalg.fill ins(%[[C1]] : f32) outs(%[[BIAS_EMPTY]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[ZERO:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK: %[[MM:.*]] = linalg.matmul ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[C1:.*]] = arith.constant 1.000000e+00 : f32
+  // CHECK: %[[EMPTY1:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[BIAS:.*]] = linalg.fill ins(%[[C1]] : f32) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[EMPTY2:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD:.*]] = arith.addf %[[MM]], %[[BIAS]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // CHECK: return %[[ADD]]
   func.func @case4_nonzero_bias(%A: tensor<32x64xf32>, %B: tensor<64x32xf32>) -> tensor<32x32xf32> {
@@ -79,120 +76,49 @@ module {
     return %mm : tensor<32x32xf32>
   }
 
-  // Case 5: Bias is a 1D-to-2D broadcasted tensor.
-  // This non-zero bias definition should be split.
-  // CHECK-LABEL: func.func @case5_broadcast_bias
-  // CHECK-DAG: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
-  // CHECK: %[[BIAS_EMPTY:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[BIAS:.*]] = linalg.broadcast ins(%{{.*}} : tensor<32xf32>) outs(%[[BIAS_EMPTY]] : tensor<32x32xf32>) dimensions = [0]
-  // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[ZERO:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK: %[[MM:.*]] = linalg.matmul ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK: %[[ADD:.*]] = arith.addf %[[MM]], %[[BIAS]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
-  func.func @case5_broadcast_bias(%A: tensor<32x64xf32>, %B: tensor<64x32xf32>, %bias_1d: tensor<32xf32>) -> tensor<32x32xf32> {
-    %empty_bias = tensor.empty() : tensor<32x32xf32>
-    %bias = linalg.broadcast ins(%bias_1d : tensor<32xf32>) outs(%empty_bias : tensor<32x32xf32>) dimensions = [0]
-    %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias : tensor<32x32xf32>) -> tensor<32x32xf32>
-    return %mm : tensor<32x32xf32>
-  }
-
-  // Case 6: Integer matmul.
+  // Case 5: Integer matmul.
   // Splitting should generate integer zero constant and use arith.addi for accumulation.
-  // CHECK-LABEL: func.func @case6_integer_bias
+  // CHECK-LABEL: func.func @case5_integer_bias
   // CHECK-SAME: (%[[A:.*]]: tensor<32x64xi32>, %[[B:.*]]: tensor<64x32xi32>, %[[BIAS:.*]]: tensor<32x32xi32>) -> tensor<32x32xi32>
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
   // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xi32>
-  // CHECK: %[[ZERO:.*]] = linalg.fill ins(%[[C0]] : i32) outs(%[[EMPTY]] : tensor<32x32xi32>) -> tensor<32x32xi32>
-  // CHECK: %[[MM:.*]] = linalg.matmul ins(%[[A]], %[[B]] : tensor<32x64xi32>, tensor<64x32xi32>) outs(%[[ZERO]] : tensor<32x32xi32>) -> tensor<32x32xi32>
+  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%[[A]], %[[B]] : tensor<32x64xi32>, tensor<64x32xi32>) outs(%[[EMPTY]] : tensor<32x32xi32>) -> tensor<32x32xi32>
   // CHECK: %[[ADD:.*]] = arith.addi %[[MM]], %[[BIAS]] {ssbuffer.add_from_matmul} : tensor<32x32xi32>
-  func.func @case6_integer_bias(%A: tensor<32x64xi32>, %B: tensor<64x32xi32>, %bias: tensor<32x32xi32>) -> tensor<32x32xi32> {
+  func.func @case5_integer_bias(%A: tensor<32x64xi32>, %B: tensor<64x32xi32>, %bias: tensor<32x32xi32>) -> tensor<32x32xi32> {
     %mm = linalg.matmul ins(%A, %B : tensor<32x64xi32>, tensor<64x32xi32>) outs(%bias : tensor<32x32xi32>) -> tensor<32x32xi32>
     return %mm : tensor<32x32xi32>
   }
 
-  // Case 7: Dynamic shape dimensions.
+  // Case 6: Dynamic shape dimensions.
   // The split logic should fetch dynamic dimension sizes using tensor.dim.
-  // CHECK-LABEL: func.func @case7_dynamic_shape
+  // CHECK-LABEL: func.func @case6_dynamic_shape
   // CHECK-SAME: (%[[A:.*]]: tensor<?x?xf32>, %[[B:.*]]: tensor<?x?xf32>, %[[BIAS:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32>
-  // CHECK-DAG: %[[C0_IDX:.*]] = arith.constant 0 : index
-  // CHECK-DAG: %[[DIM0:.*]] = tensor.dim %[[BIAS]], %[[C0_IDX]] : tensor<?x?xf32>
-  // CHECK-DAG: %[[C1_IDX:.*]] = arith.constant 1 : index
-  // CHECK-DAG: %[[DIM1:.*]] = tensor.dim %[[BIAS]], %[[C1_IDX]] : tensor<?x?xf32>
-  // CHECK-DAG: %[[C0_FLT:.*]] = arith.constant 0.000000e+00 : f32
+  // CHECK: %[[C1_IDX:.*]] = arith.constant 1 : index
+  // CHECK: %[[C0_IDX:.*]] = arith.constant 0 : index
+  // CHECK: %[[DIM0:.*]] = tensor.dim %[[BIAS]], %[[C0_IDX]] : tensor<?x?xf32>
+  // CHECK: %[[DIM1:.*]] = tensor.dim %[[BIAS]], %[[C1_IDX]] : tensor<?x?xf32>
   // CHECK: %[[EMPTY:.*]] = tensor.empty(%[[DIM0]], %[[DIM1]]) : tensor<?x?xf32>
-  // CHECK: %[[ZERO:.*]] = linalg.fill ins(%[[C0_FLT]] : f32) outs(%[[EMPTY]] : tensor<?x?xf32>) -> tensor<?x?xf32>
-  // CHECK: %[[MM:.*]] = linalg.matmul ins(%[[A]], %[[B]] : tensor<?x?xf32>, tensor<?x?xf32>) outs(%[[ZERO]] : tensor<?x?xf32>) -> tensor<?x?xf32>
+  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%[[A]], %[[B]] : tensor<?x?xf32>, tensor<?x?xf32>) outs(%[[EMPTY]] : tensor<?x?xf32>) -> tensor<?x?xf32>
   // CHECK: %[[ADD:.*]] = arith.addf %[[MM]], %[[BIAS]] {ssbuffer.add_from_matmul} : tensor<?x?xf32>
-  func.func @case7_dynamic_shape(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>, %bias: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  func.func @case6_dynamic_shape(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>, %bias: tensor<?x?xf32>) -> tensor<?x?xf32> {
     %mm = linalg.matmul ins(%A, %B : tensor<?x?xf32>, tensor<?x?xf32>) outs(%bias : tensor<?x?xf32>) -> tensor<?x?xf32>
     return %mm : tensor<?x?xf32>
   }
-
-  // Case 8: Matmul inside scf.for with loop-carried bias.
-  // The bias is a loop-carried variable with zero initial value.
-  // The matmul is marked as loop_carried_l0c and not split (no addf).
-  // CHECK-LABEL: func.func @case8_for_loop_carried_bias
-  // CHECK: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
-  // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[ZERO_INIT:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK: %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[BIAS:.*]] = %[[ZERO_INIT]]) -> (tensor<32x32xf32>)
-  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[BIAS]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK-NOT: arith.addf
-  // CHECK: scf.yield %[[MM]] : tensor<32x32xf32>
-  func.func @case8_for_loop_carried_bias(%A: tensor<32x64xf32>, %B: tensor<64x32xf32>) -> tensor<32x32xf32> {
-    %c0 = arith.constant 0 : index
-    %c10 = arith.constant 10 : index
-    %c1 = arith.constant 1 : index
-    %cst = arith.constant 0.0 : f32
-    %empty = tensor.empty() : tensor<32x32xf32>
-    %zero_init = linalg.fill ins(%cst : f32) outs(%empty : tensor<32x32xf32>) -> tensor<32x32xf32>
-    %result = scf.for %iv = %c0 to %c10 step %c1 iter_args(%bias = %zero_init) -> (tensor<32x32xf32>) {
-      %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias : tensor<32x32xf32>) -> tensor<32x32xf32>
-      scf.yield %mm : tensor<32x32xf32>
-    }
-    return %result : tensor<32x32xf32>
-  }
-
-  // Case 9: Matmul inside scf.if without else branch.
-  // The if statement result is not used, so the entire if block is removed.
-  // Only the zero initialization remains.
-  // CHECK-LABEL: func.func @case9_if_no_else
-  // CHECK: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
-  // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[ZERO:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK-NOT: scf.if
-  // CHECK-NOT: linalg.matmul
-  // CHECK-NOT: arith.addf
-  // CHECK: return %[[ZERO]] : tensor<32x32xf32>
-  func.func @case9_if_no_else(%cond: i1, %A: tensor<32x64xf32>, %B: tensor<64x32xf32>, %bias: tensor<32x32xf32>) -> tensor<32x32xf32> {
-    %cst = arith.constant 0.0 : f32
-    %empty = tensor.empty() : tensor<32x32xf32>
-    %zero = linalg.fill ins(%cst : f32) outs(%empty : tensor<32x32xf32>) -> tensor<32x32xf32>
-    scf.if %cond {
-      %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias : tensor<32x32xf32>) -> tensor<32x32xf32>
-      scf.yield
-    }
-    return %zero : tensor<32x32xf32>
-  }
-
-  // Case 10: Matmul inside scf.if with both then and else branches.
+  
+  // Case 7: Matmul inside scf.if with both then and else branches.
   // Both branches have matmul with bias from function argument, so both are split.
-  // CHECK-LABEL: func.func @case10_if_else
-  // CHECK-DAG: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
+  // CHECK-LABEL: func.func @case7_if_else
   // CHECK: scf.if %{{.*}} -> (tensor<32x32xf32>) {
   // CHECK: %[[EMPTY1:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[ZERO1:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK: %[[MM1:.*]] = linalg.matmul ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM1:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD1:.*]] = arith.addf %[[MM1]], %{{.*}} {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // CHECK: scf.yield %[[ADD1]] : tensor<32x32xf32>
   // CHECK: } else {
   // CHECK: %[[EMPTY2:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[ZERO2:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK: %[[MM2:.*]] = linalg.matmul ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM2:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD2:.*]] = arith.addf %[[MM2]], %{{.*}} {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // CHECK: scf.yield %[[ADD2]] : tensor<32x32xf32>
   // CHECK: }
-  func.func @case10_if_else(%cond: i1, %A: tensor<32x64xf32>, %B: tensor<64x32xf32>, %bias: tensor<32x32xf32>) -> tensor<32x32xf32> {
+  func.func @case7_if_else(%cond: i1, %A: tensor<32x64xf32>, %B: tensor<64x32xf32>, %bias: tensor<32x32xf32>) -> tensor<32x32xf32> {
     %result = scf.if %cond -> (tensor<32x32xf32>) {
       %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias : tensor<32x32xf32>) -> tensor<32x32xf32>
       scf.yield %mm : tensor<32x32xf32>
@@ -203,18 +129,18 @@ module {
     return %result : tensor<32x32xf32>
   }
 
-  // Case 11: Nested scf.for loops with matmul.
+// Case 8: Nested scf.for loops with matmul.
   // The matmul is in an inner loop with bias as a loop-carried variable with zero initial value.
   // The inner matmul is marked as loop_carried_l0c and not split (no addf).
-  // CHECK-LABEL: func.func @case11_nested_for
+  // CHECK-LABEL: func.func @case8_nested_for
   // CHECK: scf.for {{.*}} {
-  // CHECK: %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[BIAS:.*]] = %{{.*}}) -> (tensor<32x32xf32>)
+  // CHECK: %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[BIAS:.*]] = %{{.*}}) -> (tensor<32x32xf32>) {
   // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[BIAS]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK-NOT: arith.addf
   // CHECK: scf.yield %[[MM]] : tensor<32x32xf32>
   // CHECK: }
   // CHECK: }
-  func.func @case11_nested_for(%A: tensor<32x64xf32>, %B: tensor<64x32xf32>) -> tensor<32x32xf32> {
+  func.func @case8_nested_for(%A: tensor<32x64xf32>, %B: tensor<64x32xf32>) -> tensor<32x32xf32> {
     %c0 = arith.constant 0 : index
     %c10 = arith.constant 10 : index
     %c1 = arith.constant 1 : index
@@ -230,6 +156,232 @@ module {
       scf.yield %inner_result : tensor<32x32xf32>
     }
     return %outer_result : tensor<32x32xf32>
+  }
+
+  // Case 9: Nested scf.for loops with non-zero initial value.
+  // The initial bias is filled with 1.0 (non-zero), so the behavior differs from case8.
+  // An empty tensor is created and used as iter_args, and an arith.addf is added after the loop.
+  // CHECK-LABEL: func.func @case9_nested_for_nonzero_init
+  // CHECK: %[[CST:.*]] = arith.constant 1.000000e+00 : f32
+  // CHECK: %[[EMPTY1:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[NONZERO_INIT:.*]] = linalg.fill ins(%[[CST]] : f32) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[EMPTY2:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[FOR_RESULT:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[EMPTY2]]) -> (tensor<32x32xf32>) {
+  // CHECK: %[[INNER_RESULT:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %{{.*}}) -> (tensor<32x32xf32>) {
+  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK-NOT: arith.addf
+  // CHECK: scf.yield %[[MM]] : tensor<32x32xf32>
+  // CHECK: }
+  // CHECK: scf.yield %[[INNER_RESULT]] : tensor<32x32xf32>
+  // CHECK: }
+  // CHECK: %[[ADD:.*]] = arith.addf %[[FOR_RESULT]], %[[NONZERO_INIT]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
+  // CHECK: return %[[ADD]] : tensor<32x32xf32>
+  func.func @case9_nested_for_nonzero_init(%A: tensor<32x64xf32>, %B: tensor<64x32xf32>) -> tensor<32x32xf32> {
+    %c0 = arith.constant 0 : index
+    %c10 = arith.constant 10 : index
+    %c1 = arith.constant 1 : index
+    %cst = arith.constant 1.0 : f32
+    %empty = tensor.empty() : tensor<32x32xf32>
+    %nonzero_init = linalg.fill ins(%cst : f32) outs(%empty : tensor<32x32xf32>) -> tensor<32x32xf32>
+    
+    %outer_result = scf.for %outer_iv = %c0 to %c10 step %c1 iter_args(%outer_acc = %nonzero_init) -> (tensor<32x32xf32>) {
+      %inner_result = scf.for %inner_iv = %c0 to %c10 step %c1 iter_args(%bias = %outer_acc) -> (tensor<32x32xf32>) {
+        %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias : tensor<32x32xf32>) -> tensor<32x32xf32>
+        scf.yield %mm : tensor<32x32xf32>
+      }
+      scf.yield %inner_result : tensor<32x32xf32>
+    }
+    return %outer_result : tensor<32x32xf32>
+  }
+
+  // Case 10: Cascaded matmul chains with zero and non-zero initialization.
+  // Chain 1 (zero init): c -> %1 -> %2 -> %3
+  // Chain 2 (non-zero init): d -> %4 -> %5 -> %6
+  // Zero-init chain: matmul ops use previous output directly (L0C chain, no split).
+  // Non-zero chain: each matmul is split into empty + matmul + addf pattern.
+  // CHECK-LABEL: func.func @case10_cascaded_matmul_chains
+  // CHECK: %[[CST_ZERO:.*]] = arith.constant 0.000000e+00 : f32
+  // CHECK: %[[CST_NONZERO:.*]] = arith.constant 1.000000e+00 : f32
+  // CHECK: %[[EMPTY0:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[C:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY0]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // Chain 1: zero init - L0C chain, no split
+  // CHECK: %[[MM1:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[C]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM2:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[MM1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM3:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[MM2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK-NOT: arith.addf {{.*}} %[[MM3]]
+  // Chain 2: non-zero init - each matmul is split
+  // CHECK: %[[EMPTY_D:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[D:.*]] = linalg.fill ins(%[[CST_NONZERO]] : f32) outs(%[[EMPTY_D]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[EMPTY4:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[MM4:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY4]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ADD4:.*]] = arith.addf %[[MM4]], %[[D]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
+  // CHECK: %[[EMPTY5:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[MM5:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY5]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ADD5:.*]] = arith.addf %[[MM5]], %[[ADD4]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
+  // CHECK: %[[EMPTY6:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[MM6:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY6]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ADD6:.*]] = arith.addf %[[MM6]], %[[ADD5]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
+  // Final combination
+  // CHECK: %[[RESULT:.*]] = arith.addf %[[MM3]], %[[ADD6]] : tensor<32x32xf32>
+  // CHECK: return %[[RESULT]] : tensor<32x32xf32>
+  func.func @case10_cascaded_matmul_chains(%A: tensor<32x64xf32>, %B: tensor<64x32xf32>) -> tensor<32x32xf32> {
+    %cst_zero = arith.constant 0.0 : f32
+    %cst_nonzero = arith.constant 1.0 : f32
+    %empty = tensor.empty() : tensor<32x32xf32>
+    
+    // Chain 1: zero initialization
+    %c = linalg.fill ins(%cst_zero : f32) outs(%empty : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %1 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%c : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %2 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%1 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %3 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%2 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    
+    // Chain 2: non-zero initialization  
+    %empty2 = tensor.empty() : tensor<32x32xf32>
+    %d = linalg.fill ins(%cst_nonzero : f32) outs(%empty2 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %4 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%d : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %5 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%4 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %6 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%5 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    
+    // Combine the two chains
+    %result = arith.addf %3, %6 : tensor<32x32xf32>
+    return %result : tensor<32x32xf32>
+  }
+
+  // Case 11: Cascaded matmul chains wrapped in separate scf.for loops.
+  // Each matmul is in a separate for loop, with bias as iter_args.
+  // Chain 1 (zero init): c -> for1(%mm1) -> for2(%mm2) -> for3(%mm3)
+  // Chain 2 (non-zero init): d -> for4(%mm4) -> for5(%mm5) -> for6(%mm6)
+  // Unlike case8 (nested for loops), separate for loops cause each matmul to be split.
+  // Each for loop: empty tensor -> for(matmul) -> addf(previous_result)
+  // CHECK-LABEL: func.func @case11_cascaded_for_loops
+  // CHECK: %[[CST_ZERO:.*]] = arith.constant 0.000000e+00 : f32
+  // CHECK: %[[CST_NONZERO:.*]] = arith.constant 1.000000e+00 : f32
+  // CHECK: %[[EMPTY1:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[C:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // Chain 1: for loop 1
+  // CHECK: %[[EMPTY_FOR1:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[FOR1:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[EMPTY_FOR1]]) -> (tensor<32x32xf32>) {
+  // CHECK: %[[MM1:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: scf.yield %[[MM1]] : tensor<32x32xf32>
+  // CHECK: }
+  // CHECK: %[[ADD1:.*]] = arith.addf %[[FOR1]], %[[C]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
+  // Chain 1: for loop 2
+  // CHECK: %[[EMPTY_FOR2:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[FOR2:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[EMPTY_FOR2]]) -> (tensor<32x32xf32>) {
+  // CHECK: %[[MM2:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: scf.yield %[[MM2]] : tensor<32x32xf32>
+  // CHECK: }
+  // CHECK: %[[ADD2:.*]] = arith.addf %[[FOR2]], %[[ADD1]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
+  // Chain 1: for loop 3
+  // CHECK: %[[EMPTY_FOR3:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[FOR3:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[EMPTY_FOR3]]) -> (tensor<32x32xf32>) {
+  // CHECK: %[[MM3:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: scf.yield %[[MM3]] : tensor<32x32xf32>
+  // CHECK: }
+  // CHECK: %[[ADD3:.*]] = arith.addf %[[FOR3]], %[[ADD2]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
+  // Chain 2: for loop 4 (non-zero init)
+  // CHECK: %[[EMPTY_D:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[D:.*]] = linalg.fill ins(%[[CST_NONZERO]] : f32) outs(%[[EMPTY_D]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[EMPTY_FOR4:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[FOR4:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[EMPTY_FOR4]]) -> (tensor<32x32xf32>) {
+  // CHECK: %[[MM4:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: scf.yield %[[MM4]] : tensor<32x32xf32>
+  // CHECK: }
+  // CHECK: %[[ADD4:.*]] = arith.addf %[[FOR4]], %[[D]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
+  // Chain 2: for loop 5
+  // CHECK: %[[EMPTY_FOR5:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[FOR5:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[EMPTY_FOR5]]) -> (tensor<32x32xf32>) {
+  // CHECK: %[[MM5:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: scf.yield %[[MM5]] : tensor<32x32xf32>
+  // CHECK: }
+  // CHECK: %[[ADD5:.*]] = arith.addf %[[FOR5]], %[[ADD4]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
+  // Chain 2: for loop 6
+  // CHECK: %[[EMPTY_FOR6:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[FOR6:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[EMPTY_FOR6]]) -> (tensor<32x32xf32>) {
+  // CHECK: %[[MM6:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: scf.yield %[[MM6]] : tensor<32x32xf32>
+  // CHECK: }
+  // CHECK: %[[ADD6:.*]] = arith.addf %[[FOR6]], %[[ADD5]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
+  // Final combination
+  // CHECK: %[[RESULT:.*]] = arith.addf %[[ADD3]], %[[ADD6]] : tensor<32x32xf32>
+  // CHECK: return %[[RESULT]] : tensor<32x32xf32>
+  func.func @case11_cascaded_for_loops(%A: tensor<32x64xf32>, %B: tensor<64x32xf32>) -> tensor<32x32xf32> {
+    %c0_idx = arith.constant 0 : index
+    %c10_idx = arith.constant 10 : index
+    %c1_idx = arith.constant 1 : index
+    
+    %cst_zero = arith.constant 0.0 : f32
+    %cst_nonzero = arith.constant 1.0 : f32
+    %empty1 = tensor.empty() : tensor<32x32xf32>
+    
+    // Chain 1: zero initialization, each matmul in a for loop
+    %c = linalg.fill ins(%cst_zero : f32) outs(%empty1 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %for1_result = scf.for %i1 = %c0_idx to %c10_idx step %c1_idx iter_args(%bias1 = %c) -> (tensor<32x32xf32>) {
+      %mm1 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias1 : tensor<32x32xf32>) -> tensor<32x32xf32>
+      scf.yield %mm1 : tensor<32x32xf32>
+    }
+    %for2_result = scf.for %i2 = %c0_idx to %c10_idx step %c1_idx iter_args(%bias2 = %for1_result) -> (tensor<32x32xf32>) {
+      %mm2 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias2 : tensor<32x32xf32>) -> tensor<32x32xf32>
+      scf.yield %mm2 : tensor<32x32xf32>
+    }
+    %for3_result = scf.for %i3 = %c0_idx to %c10_idx step %c1_idx iter_args(%bias3 = %for2_result) -> (tensor<32x32xf32>) {
+      %mm3 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias3 : tensor<32x32xf32>) -> tensor<32x32xf32>
+      scf.yield %mm3 : tensor<32x32xf32>
+    }
+    
+    // Chain 2: non-zero initialization, each matmul in a for loop
+    %empty2 = tensor.empty() : tensor<32x32xf32>
+    %d = linalg.fill ins(%cst_nonzero : f32) outs(%empty2 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %for4_result = scf.for %i4 = %c0_idx to %c10_idx step %c1_idx iter_args(%bias4 = %d) -> (tensor<32x32xf32>) {
+      %mm4 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias4 : tensor<32x32xf32>) -> tensor<32x32xf32>
+      scf.yield %mm4 : tensor<32x32xf32>
+    }
+    %for5_result = scf.for %i5 = %c0_idx to %c10_idx step %c1_idx iter_args(%bias5 = %for4_result) -> (tensor<32x32xf32>) {
+      %mm5 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias5 : tensor<32x32xf32>) -> tensor<32x32xf32>
+      scf.yield %mm5 : tensor<32x32xf32>
+    }
+    %for6_result = scf.for %i6 = %c0_idx to %c10_idx step %c1_idx iter_args(%bias6 = %for5_result) -> (tensor<32x32xf32>) {
+      %mm6 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias6 : tensor<32x32xf32>) -> tensor<32x32xf32>
+      scf.yield %mm6 : tensor<32x32xf32>
+    }
+    
+    // Combine the two chains
+    %result = arith.addf %for3_result, %for6_result : tensor<32x32xf32>
+    return %result : tensor<32x32xf32>
+  }
+
+  // Case 12: scf.if containing scf.for with matmul.
+  // The then branch has a for loop with matmul, the else branch yields zero initial value directly.
+  // Matmul in the for loop is marked as loop_carried_l0c and not split, maintaining the L0C chain.
+  // CHECK-LABEL: func.func @case12_if_for
+  // CHECK: scf.if %{{.*}} -> (tensor<32x32xf32>) {
+  // CHECK: %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[BIAS:.*]] = %{{.*}}) -> (tensor<32x32xf32>) {
+  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[BIAS]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK-NOT: arith.addf
+  // CHECK: scf.yield %[[MM]] : tensor<32x32xf32>
+  // CHECK: }
+  // CHECK: scf.yield %[[FOR]] : tensor<32x32xf32>
+  // CHECK: } else {
+  // CHECK: scf.yield %{{.*}} : tensor<32x32xf32>
+  // CHECK: }
+  func.func @case12_if_for(%cond: i1, %A: tensor<32x64xf32>, %B: tensor<64x32xf32>) -> tensor<32x32xf32> {
+    %c0 = arith.constant 0 : index
+    %c10 = arith.constant 10 : index
+    %c1 = arith.constant 1 : index
+    %cst = arith.constant 0.0 : f32
+    %empty = tensor.empty() : tensor<32x32xf32>
+    %zero_init = linalg.fill ins(%cst : f32) outs(%empty : tensor<32x32xf32>) -> tensor<32x32xf32>
+    
+    %result = scf.if %cond -> (tensor<32x32xf32>) {
+      %for_result = scf.for %iv = %c0 to %c10 step %c1 iter_args(%acc = %zero_init) -> (tensor<32x32xf32>) {
+        %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%acc : tensor<32x32xf32>) -> tensor<32x32xf32>
+        scf.yield %mm : tensor<32x32xf32>
+      }
+      scf.yield %for_result : tensor<32x32xf32>
+    } else {
+      scf.yield %zero_init : tensor<32x32xf32>
+    }
+    return %result : tensor<32x32xf32>
   }
 }
 


### PR DESCRIPTION
# Key Changes 
This PR introduces two core improvements to SplitMatmulPattern for the a*b+c (matmul with bias) compute pattern:
1. Hoist the add operation out of the loop to reduce CUBE-Vector interactions
In the previous implementation, linalg.add (bias add) was placed inside the for-loop body immediately after linalg.matmul, causing a CUBE-to-Vector handoff on every loop iteration. This PR hoists the add out of the loop so that all matmul iterations complete first, followed by a single add, substantially reducing the number of CUBE-Vector (CV) interactions:
```
// Before
for() {
    matmul
    add
}

// After
for() {
    matmul
}
add
```


2. Detect cascaded bias scenarios and skip splitting when unsupported
A new detection pass identifies cascaded bias patterns (e.g. multi-level bias additions). When the resulting compute graph falls into a form not supported by NPUIR, the pattern intentionally skips the split and preserves the original IR, preventing the generation of illegal or inefficient instruction sequences. All other valid scenarios continue to be split and optimized as before. Cascaded bias scenarios like:

```
%1 = matmul(a, b, %init)
%2 = matmul(a, b, %1)
```
However, the following is not supported(Next matmul is nested)
```
%res = for(%args = %init){
    %1 = matmul(a, b, %args )
     yield %1
}
for/if{
    %1 = matmul(a, b, %res)
     ...
}

```


# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
