### PR TITLE
[fix](ssbuffer): support discrete load store (unit attribute "ExtractedLoadOrStore" on forOp)

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -47,8 +47,22 @@ inline constexpr llvm::StringLiteral kIntraBuffer = "ssbuffer.intra_buffer";
 inline constexpr llvm::StringLiteral kAnalyzeFlagId = "ssbuffer.analyze_flag_id";
 inline constexpr llvm::StringLiteral kLoopCarriedL0C = "ssbuffer.loop_carried_l0c";
 inline constexpr const char *ERRCODE_ATTR = "triton_ascend.dynamic_cv_pipeline.rc";
+
 static constexpr const int ERRCODE_FAILED = 1;
 static constexpr const int ERRCODE_IGNORED = 2;
+constexpr size_t kExpectedMaxMemEffects = 2;
+
+class MoveOnly {
+  protected:
+    MoveOnly() = default;
+    ~MoveOnly() = default;
+
+    MoveOnly(const MoveOnly &) = delete;
+    MoveOnly &operator=(const MoveOnly &) = delete;
+
+    MoveOnly(MoveOnly &&) = default;
+    MoveOnly &operator=(MoveOnly &&) = default;
+};
 
 enum CoreType {
     UNDETERMINED = 0,
@@ -83,6 +97,33 @@ inline bool isCubeOp(Operation *op)
 }
 
 bool isVectorOnlyOp(Operation *op);
+
+// ============================================================================
+// Function Name: mlir::CVPipeline::getAliasSource
+// ============================================================================
+/**
+ * @brief Resolves the immediate source of a value by tracing through alias-introducing operations.
+ *
+ * **Purpose**:
+ * To identify underlying memory buffers or tensors by stripping away view-like transformations,
+ * type casts, and bufferization casts (e.g., to_memref, to_tensor).
+ *
+ * **Inputs & Assumptions**:
+ * - `value` (mlir::Value): The value to analyze.
+ * - Assumptions: If the defining operation implements CastOpInterface, it is assumed to be a
+ *   single-operand cast; otherwise, it is treated as an unknown cast.
+ *
+ * **Outputs & Guarantees**:
+ * - Returns the direct source `mlir::Value` of the alias.
+ * - Returns `nullptr` if the input value is null, has no defining operation, or is defined
+ *   by an operation that does not introduce a recognizable alias.
+ * - Guarantees that only one level of the alias chain is resolved per call.
+ *
+ * **Safety Boundaries & Constraints**:
+ * - Safe against null inputs.
+ * - Returns `nullptr` for multi-operand casts to prevent incorrect tracing assumptions.
+ */
+Value getAliasSource(Value value);
 
 } // namespace CVPipeline
 } // namespace mlir

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h
@@ -23,10 +23,13 @@
 #ifndef TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_COMPUTE_BLOCK_OPT_COMMON_H
 #define TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_COMPUTE_BLOCK_OPT_COMMON_H
 
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/LogicalResult.h"
+
+#include "mlir/IR/Operation.h"
+
 #include "ascend/include/DynamicCVPipeline/Common/MemoryEffectsTracker.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
-#include "mlir/IR/Operation.h"
-#include "llvm/ADT/ArrayRef.h"
 
 namespace mlir {
 namespace CVPipeline {
@@ -52,6 +55,53 @@ namespace CVPipeline {
 bool willCreateCycle(llvm::ArrayRef<Operation *> opsToUnify,
                      const MemoryDependenceGraph &memGraph, int targetBlockId,
                      ComputeBlockIdManager &bm);
+
+/**
+ * @brief Collect predecessor operations in a block for the given values
+ *
+ * This function traces back through SSA dependencies to find all operations
+ * that affect the given startValue within a specific block.
+ *
+ * Special handling for scf.for loop-carried dependencies:
+ * When an operand is a BlockArgument from scf.for iter_arg, we also trace
+ * through the yieldOp to find the operation that provides the yielded value.
+ * This ensures we capture operations that update loop-carried variables
+ * (e.g., %79 that updates %arg19).
+ *
+ * @param startValue The value to trace back from
+ * @param block The block to search within
+ * @return SmallVector<Operation*> List of predecessor operations
+ */
+SmallVector<Operation *> collectBlockPredecessors(ValueRange startValues, Block *block);
+
+// ============================================================================
+// Function Name: mlir::CVPipeline::tryUpdate
+// ============================================================================
+/**
+ * @brief Safely updates the block ID for a collection of operations after cycle verification.
+ *
+ * **Purpose**:
+ * To assign a new scheduling block ID to a set of operations, ensuring that the assignment
+ * does not introduce any invalid cyclical dependencies in the block-level execution graph.
+ *
+ * **Inputs & Assumptions**:
+ * - `ops` (llvm::ArrayRef<Operation *>): The operations to be updated.
+ * - `memGraph` (const MemoryDependenceGraph &): The memory dependence graph for safety verification.
+ * - `targetBlockId` (int64_t): The destination block ID.
+ * - `bm` (ComputeBlockIdManager &): The block ID manager handling the state updates.
+ *
+ * **Outputs & Guarantees**:
+ * - Returns `llvm::success()` if the updates were verified as cycle-free and successfully applied.
+ * - Returns `llvm::failure()` if the update would introduce a cycle.
+ * - Guarantees transactional behavior: if validation fails, the system state remains unmodified.
+ *
+ * **Safety Boundaries & Constraints**:
+ * - Relies on `willCreateCycle` to perform speculative validation and roll back changes on failure.
+ */
+llvm::LogicalResult tryUpdate(llvm::ArrayRef<Operation *> ops,
+                              const MemoryDependenceGraph &memGraph,
+                              int64_t targetBlockId,
+                              ComputeBlockIdManager &bm);
 
 } // namespace CVPipeline
 } // namespace mlir

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
@@ -23,6 +23,8 @@
 #ifndef TRITON_ADAPTER_BLOCK_ID_OPT_PASSES_H
 #define TRITON_ADAPTER_BLOCK_ID_OPT_PASSES_H
 
+#include <memory>
+
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 
@@ -35,6 +37,9 @@ void registerUnifyAllocBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createMergeVectorIfBlockPass();
 void registerMergeVectorIfBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createFixpipeOptPass();
+
+std::unique_ptr<OperationPass<ModuleOp>> createDiscreteLoadStorePass();
+void registerDiscreteLoadStorePass();
 
 } // namespace triton
 } // namespace mlir

--- a/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h
+++ b/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h
@@ -23,12 +23,14 @@
 #ifndef TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_PLAN_COMPUTE_BLOCK_COMPUTE_BLOCK_ID_MANAGER_H
 #define TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_PLAN_COMPUTE_BLOCK_COMPUTE_BLOCK_ID_MANAGER_H
 
-#include <mutex>
-#include "mlir/IR/Operation.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/LogicalResult.h"
+
+#include "mlir/IR/Operation.h"
+
+#include "DynamicCVPipeline/Common/Utils.h"
 
 namespace mlir {
 namespace CVPipeline {
@@ -36,28 +38,24 @@ namespace CVPipeline {
 /**
     * the class is to promise CUBEID and VECTORID are unified.
  */
-class ComputeBlockIdManager {
-public:
-
+class ComputeBlockIdManager : MoveOnly {
+  public:
     ComputeBlockIdManager(Operation *root);
     bool isSameBlock(Operation *a, Operation *b);
     bool isWholeCubeReady(Operation *seedOp, llvm::DenseMap<Operation *, int> &indegree);
-    
+
     llvm::LogicalResult markOpBlockId(Operation *op);
     llvm::LogicalResult markOpsWithNewId(llvm::SmallVectorImpl<Operation *> &ops);
     void updateBlockId(Operation *op, int blockId);
-    
+
     llvm::SmallVector<Operation *> getOpsByBlockId(int blockId);
     int getBlockIdByOp(Operation *op);
-    void reset();
     int getNextId();
-    
+
     private:
-    
     int cntComputeBlockId;
     llvm::DenseMap<int, llvm::SmallVector<Operation *>> blockIdToOps;
     llvm::DenseMap<Operation *, int> opToBlockId;
-    mutable std::mutex managerMutex;
     const int blockIdWidth = 32;
     llvm::LogicalResult markAndRecord(Operation *op, int blockId);
 };

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -4,12 +4,15 @@
 #include "llvm/Support/LogicalResult.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Interfaces/CastInterfaces.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 namespace mlir {
@@ -102,6 +105,30 @@ bool isVectorOnlyOp(Operation *op)
 bool isScfOp(Operation *op)
 {
   return llvm::isa<scf::SCFDialect>(op->getDialect());
+}
+
+Value getAliasSource(Value value)
+{
+    if (!value) {
+        return nullptr;
+    }
+    auto *defOp = value.getDefiningOp();
+    if (!defOp) {
+        return nullptr;
+    }
+    return llvm::TypeSwitch<Operation *, Value>(defOp)
+        .Case<ViewLikeOpInterface>([](ViewLikeOpInterface viewOp) { return viewOp.getViewSource(); })
+        .Case<CastOpInterface>([](CastOpInterface castOp) -> Value {
+            if (castOp->getOperands().size() == 1) {
+                return castOp->getOperand(0);
+            }
+
+            // Unknown cast op, cowardly avoiding incorrecly finding source
+            return nullptr;
+        })
+        .Case<bufferization::ToMemrefOp>([](bufferization::ToMemrefOp toMemrefOp) { return toMemrefOp.getTensor(); })
+        .Case<bufferization::ToTensorOp>([](bufferization::ToTensorOp toTensorOp) { return toTensorOp.getMemref(); })
+        .Default([](auto) { return nullptr; });
 }
 
 } // namespace CVPipeline

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
@@ -20,14 +20,22 @@
  * THE SOFTWARE.
  */
 
-#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
-#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
-#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
-#include "mlir/IR/Operation.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/LogicalResult.h"
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Operation.h"
+
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
+
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
 
 static constexpr const char *DEBUG_TYPE = "compute-block-opt-common";
 #define LOG_DEBUG(...) LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
@@ -179,6 +187,70 @@ bool willCreateCycle(llvm::ArrayRef<Operation *> opsToUnify, const MemoryDepende
     }
 
     return hasCycle;
+}
+
+SmallVector<Operation *> collectBlockPredecessors(ValueRange startValues, Block *block)
+{
+    SmallVector<Operation *> result;
+    SmallVector<Operation *> toProcess;
+
+    auto addToProcess = [&](Operation *op) {
+        if (auto *ancestorInBlock = CVPipeline::getAncestorInBlock(op, block)) {
+            if (!llvm::is_contained(result, ancestorInBlock)) {
+                toProcess.push_back(ancestorInBlock);
+            }
+        }
+    };
+
+    for (auto startValue : startValues) {
+        if (auto *condDefOp = startValue.getDefiningOp()) {
+            addToProcess(condDefOp);
+        }
+    }
+
+    while (!toProcess.empty()) {
+        auto *op = toProcess.pop_back_val();
+        if (llvm::is_contained(result, op)) {
+            continue;
+        }
+        result.push_back(op);
+
+        for (auto operand : op->getOperands()) {
+            if (auto *defOp = operand.getDefiningOp()) {
+                // SSA operand: trace to its defining operation
+                addToProcess(defOp);
+            } else if (auto blockArg = dyn_cast<BlockArgument>(operand)) {
+                // Block argument: check if it's from scf.for iter_arg
+                Operation *parentOp = blockArg.getOwner()->getParentOp();
+                if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
+                    auto *tiedOperand = forOp.getTiedLoopYieldedValue(blockArg);
+                    if (!tiedOperand || !tiedOperand->get()) {
+                        continue;
+                    }
+                    auto *defOp = tiedOperand->get().getDefiningOp();
+                    if (defOp) {
+                        addToProcess(defOp);
+                    }
+                }
+            }
+        }
+    }
+    return result;
+}
+
+llvm::LogicalResult tryUpdate(llvm::ArrayRef<Operation *> ops,
+                              const MemoryDependenceGraph &memGraph,
+                              int64_t targetBlockId,
+                              ComputeBlockIdManager &bm)
+{
+    if (CVPipeline::willCreateCycle(ops, memGraph, targetBlockId, bm)) {
+        return llvm::failure();
+    }
+
+    for (auto *op : ops) {
+        bm.updateBlockId(op, targetBlockId);
+    }
+    return llvm::success();
 }
 
 } // namespace CVPipeline

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/DiscreteLoadStore.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/DiscreteLoadStore.cpp
@@ -1,0 +1,430 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <optional>
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/LogicalResult.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Value.h"
+#include "mlir/IR/Visitors.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassRegistry.h"
+
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "DynamicCVPipeline/Common/Utils.h"
+#include "DynamicCVPipeline/ComputeBlockOpt/Common.h"
+#include "DynamicCVPipeline/ComputeBlockOpt/Passes.h"
+#include "DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "bishengir/Dialect/HIVM/IR/HIVMImpl.h"
+
+static constexpr const char *DEBUG_TYPE = "DiscreteLoadStore";
+#define DBGS(...) LLVM_DEBUG(llvm::dbgs() << __VA_ARGS__)
+#define LOG_DEBUG(...) DBGS("\n[" << DEBUG_TYPE << "] " << __VA_ARGS__)
+
+using namespace mlir;
+using namespace CVPipeline;
+
+// ============================================================================
+// Function Name: traceToDefVal
+// ============================================================================
+/**
+ * @brief Iteratively traces an aliased value back to its original definition.
+ *
+ * **Purpose**:
+ * To locate the ultimate root definition of a value by continuously unwrapping alias-introducing operations.
+ *
+ * **Inputs & Assumptions**:
+ * - `value` (mlir::Value): The starting value.
+ * - Assumptions: The SSA graph is acyclic, ensuring the trace loop will always terminate.
+ *
+ * **Outputs & Guarantees**:
+ * - Returns the root `mlir::Value` that is not defined by any recognizable alias-introducing operation.
+ * - Guarantees the returned value is non-null if the input is non-null.
+ *
+ * **Safety Boundaries & Constraints**:
+ * - Gracefully returns the last resolved value if a step in the chain results in a null value or has no defining op.
+ */
+static Value traceToDefVal(Value value)
+{
+    while (auto source = getAliasSource(value)) {
+        value = source;
+    }
+
+    return value;
+}
+
+// ============================================================================
+// Function Name: isGMArg
+// ============================================================================
+/**
+ * @brief Checks if a value is an argument to the entry block of a function (representing Global Memory).
+ *
+ * **Purpose**:
+ * To distinguish global inputs/outputs (GM arguments) from intermediate buffers allocated locally.
+ *
+ * **Inputs & Assumptions**:
+ * - `value` (mlir::Value): The value to check.
+ *
+ * **Outputs & Guarantees**:
+ * - Returns `true` if the value is a block argument belonging to the entry block of a `func::FuncOp`.
+ * - Returns `false` otherwise.
+ *
+ * **Safety Boundaries & Constraints**:
+ * - Safe against values that are not block arguments, or block arguments residing in nested region blocks.
+ */
+static bool isGMArg(Value value)
+{
+    auto blockArg = llvm::dyn_cast_if_present<BlockArgument>(value);
+    if (!blockArg) {
+        return false;
+    }
+    auto *ownerBlock = blockArg.getOwner();
+    auto funcOp = llvm::dyn_cast_or_null<func::FuncOp>(ownerBlock->getParentOp());
+    return funcOp && &funcOp.getFunctionBody().front() == ownerBlock;
+}
+
+namespace {
+
+enum class MemEffectType { LOAD, STORE };
+
+struct AnalysisResult {
+    MemEffectType type;
+    Operation *localOp;
+};
+}
+
+static llvm::StringLiteral literalEffectType(std::optional<MemEffectType> effectType)
+{
+    if (effectType == MemEffectType::LOAD) {
+        return "LOAD";
+    }
+    if (effectType == MemEffectType::STORE) {
+        return "STORE";
+    }
+
+    return "NULL";
+}
+
+// ============================================================================
+// Function Name: analyseMemOp
+// ============================================================================
+/**
+ * @brief Analyzes a memory-effect-bearing operation to classify it as a discrete load or store.
+ *
+ * **Purpose**:
+ * To identify if an operation acts as a transfer bridge between Global Memory (GM) and local buffers.
+ *
+ * **Inputs & Assumptions**:
+ * - `memOp` (MemoryEffectOpInterface): The memory operation to analyze.
+ *
+ * **Outputs & Guarantees**:
+ * - Returns a populated `std::optional<AnalysisResult>` containing the transfer direction (LOAD/STORE)
+ *   and the local buffer defining operation if a consistent GM-to-local (or local-to-GM) pattern is found.
+ * - Returns `std::nullopt` if the memory effects are inconsistent, null, or do not represent a discrete transfer.
+ *
+ * **Safety Boundaries & Constraints**:
+ * - Restricts memory effect collections using a local buffer of size `kExpectedMaxMemEffects`.
+ * - Ignores memory effects that do not have a concrete target value.
+ */
+static std::optional<AnalysisResult> analyseMemOp(MemoryEffectOpInterface memOp)
+{
+    LOG_DEBUG("Analysing: " << *memOp.getOperation() << "\n");
+    Operation *localOp = nullptr;
+    std::optional<MemEffectType> localType;
+    std::optional<MemEffectType> gmType;
+
+    llvm::SmallVector<MemoryEffects::EffectInstance, kExpectedMaxMemEffects> memEffects;
+    memOp.getEffects(memEffects);
+    for (auto effectInstance : memEffects) {
+        auto target = effectInstance.getValue();
+        if (!target) {
+            continue;
+        }
+
+        auto defVal = traceToDefVal(target);
+        LOG_DEBUG("\n====== target ======\n" << target << "\n====== defVal ======\n" << defVal << "\n");
+        if (isGMArg(defVal)) {
+            if (gmType.has_value()) {
+                continue;
+            }
+            if (isa<MemoryEffects::Write>(effectInstance.getEffect())) {
+                gmType = MemEffectType::STORE;
+            } else if (isa<MemoryEffects::Read>(effectInstance.getEffect())) {
+                gmType = MemEffectType::LOAD;
+            }
+            continue;
+        }
+
+        // source is some local operation
+        if (localType.has_value()) {
+            continue;
+        }
+        auto *defOp = defVal.getDefiningOp();
+        if (!defOp) {
+            continue;
+        }
+        localOp = defOp;
+        if (isa<MemoryEffects::Write>(effectInstance.getEffect())) {
+            localType = MemEffectType::LOAD;
+        } else if (isa<MemoryEffects::Read>(effectInstance.getEffect())) {
+            localType = MemEffectType::STORE;
+        }
+    }
+
+    LOG_DEBUG("GM Type: " << literalEffectType(gmType) << "; LocalType: " << literalEffectType(localType) << "\n");
+    if (!(gmType.has_value() && localType.has_value() && gmType == localType && localOp != nullptr)) {
+        return std::nullopt;
+    }
+
+    return AnalysisResult {localType.value(), localOp};
+}
+
+static llvm::FailureOr<AnalysisResult> analyseExtractedLoadStore(scf::ForOp forOp)
+{
+    if (!forOp->hasAttr(hivm::ExtractLoadStoreAttr)) {
+        return llvm::failure();
+    }
+    std::optional<AnalysisResult> resultOpt;
+    auto walkResult = forOp->walk([&](MemoryEffectOpInterface memOp) {
+        auto currResult = analyseMemOp(memOp);
+        if (!currResult.has_value()) {
+            return WalkResult::advance();
+        }
+        if (resultOpt.has_value()) {
+            return WalkResult::interrupt();
+        }
+        resultOpt = currResult;
+        return WalkResult::advance();
+    });
+    if (walkResult.wasInterrupted() || !resultOpt.has_value()) {
+        LOG_DEBUG("expected exactly one single mem op from/to gm in " << forOp << "\n");
+        return llvm::failure();
+    }
+
+    return resultOpt.value();
+}
+
+// ============================================================================
+// Function Name: getCommonBlockId
+// ============================================================================
+/**
+ * @brief Checks if a list of operations all share the exact same block ID.
+ *
+ * **Purpose**:
+ * To determine if a set of operations is already clustered together into the same scheduling group.
+ *
+ * **Inputs & Assumptions**:
+ * - `ops` (llvm::ArrayRef<Operation *>): The operations to examine.
+ *
+ * **Outputs & Guarantees**:
+ * - Returns `std::optional<int64_t>` containing the block ID if all operations share the same ID.
+ * - Returns `std::nullopt` if there is a block ID mismatch, or if any operation lacks an assigned block ID.
+ *
+ * **Safety Boundaries & Constraints**:
+ * - Safe to execute with empty lists.
+ */
+static std::optional<int64_t> getCommonBlockId(llvm::ArrayRef<Operation *> ops)
+{
+    std::optional<int64_t> blockIdOpt;
+    for (auto *op : ops) {
+        auto currBlockId = getOpBlockId(op);
+        if (!blockIdOpt.has_value()) {
+            blockIdOpt = currBlockId;
+        }
+        if (currBlockId.has_value() && currBlockId != blockIdOpt) {
+            return std::nullopt;
+        }
+    }
+    return blockIdOpt;
+}
+
+// ============================================================================
+// Function Name: applyFixes
+// ============================================================================
+/**
+ * @brief Coordinates block ID updates for discrete load/store loops and their dependencies.
+ *
+ * **Purpose**:
+ * To unify the block IDs of the loop structure, its local buffer, and optionally its upstream
+ * condition-calculating operations to match the block ID of the external users.
+ *
+ * **Inputs & Assumptions**:
+ * - `forOp` (scf::ForOp): The loop operation executing the load/store.
+ * - `analysis` (AnalysisResult): Structural analysis of the memory transfer.
+ * - `memGraph` (const MemoryDependenceGraph &): The memory dependence graph for safety analysis.
+ * - `bm` (ComputeBlockIdManager &): The block ID manager.
+ *
+ * **Outputs & Guarantees**:
+ * - Returns `llvm::success()` if block IDs were successfully unified (either with or without upstreams).
+ * - Returns `llvm::failure()` if no target block ID could be determined.
+ *
+ * **Safety Boundaries & Constraints**:
+ * - Attempts a progressive update: first tries to update loop operations together with upstream condition
+ *   predecessors; if that fails due to cycles, falls back to updating only the core loop operations.
+ */
+static llvm::LogicalResult applyFixes(scf::ForOp forOp,
+                                      AnalysisResult analysis,
+                                      const MemoryDependenceGraph &memGraph,
+                                      ComputeBlockIdManager &bm)
+{
+    auto *localOp = analysis.localOp;
+
+    // store / no users - follow defOp
+    auto targetBlockId = getOpBlockId(localOp);
+
+    // load - follow users
+    if (analysis.type == MemEffectType::LOAD) {
+        auto users = llvm::to_vector(
+            llvm::make_filter_range(localOp->getUsers(), [&](Operation *user) { return !forOp->isAncestor(user); }));
+        if (!users.empty()) {
+            targetBlockId = getCommonBlockId(users);
+            if (!targetBlockId.has_value()) {
+                LOG_DEBUG("Users do not share the same block id: " << *localOp << "\n");
+                return llvm::failure();
+            }
+        }
+    }
+
+    if (!targetBlockId.has_value()) {
+        LOG_DEBUG("No users and alloc does not have block id: " << *localOp << "\n");
+        return llvm::failure();
+    }
+
+    llvm::SmallVector<Operation *> coreOps {localOp};
+    forOp->walk([&](Operation *op) { coreOps.push_back(op); });
+
+    SmallVector<Operation *> extendedOps = CVPipeline::collectBlockPredecessors(
+        {forOp.getLowerBound(), forOp.getUpperBound(), forOp.getStep()}, forOp->getBlock());
+    extendedOps.append(coreOps);
+
+    if (llvm::succeeded(tryUpdate(extendedOps, memGraph, targetBlockId.value(), bm))) {
+        LOG_DEBUG("Successfully applied fixes to users and for upstreams: " << *localOp << "\n");
+        return llvm::success();
+    }
+
+    if (llvm::succeeded(tryUpdate(coreOps, memGraph, targetBlockId.value(), bm))) {
+        LOG_DEBUG("Successfully applied fixes to users: " << *localOp << "\n");
+        return llvm::success();
+    }
+
+    LOG_DEBUG("Failed to apply fixes to required ops: " << *localOp << "\n");
+
+    // Similar to unify alloc block pass, we do not signal pass failure in this case
+    return llvm::success();
+}
+
+namespace {
+
+// ============================================================================
+// Class: DiscreteLoadStore
+// ============================================================================
+/**
+ * @class DiscreteLoadStore
+ * @brief Optimization pass targeting discrete memory transfer loops.
+ *
+ * **Purpose**:
+ * Analyzes `scf.for` loops marked for load/store extraction and unifies their block IDs with
+ * local buffers and external users to prevent execution bottlenecks.
+ *
+ * **Inputs & Assumptions**:
+ * - Operates on a `ModuleOp` containing operations from the SCF, MemRef, and Func dialects.
+ * - Assumes the existence of `AliasAnalysis` to build accurate memory dependency graphs.
+ *
+ * **Outputs & Guarantees**:
+ * - Guarantees that scheduling block IDs are updated in place for valid discrete transfer loops.
+ * - Guarantees that the resulting block-level graph is cycle-free, preserving correctness.
+ *
+ * **Safety Boundaries & Constraints**:
+ * - If analysis fails, reports a pass failure and emits compiler errors on the offending loop operation.
+ */
+class DiscreteLoadStore : public PassWrapper<DiscreteLoadStore, OperationPass<ModuleOp>> {
+  public:
+    MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(DiscreteLoadStore)
+    DiscreteLoadStore() = default;
+
+    StringRef getArgument() const override { return "discrete-load-store"; }
+
+    void runOnOperation() override
+    {
+        ModuleOp moduleOp = getOperation();
+        LOG_DEBUG("Before: " << moduleOp << "\n");
+        auto &aa = getAnalysis<AliasAnalysis>();
+        MemoryDependenceGraph memGraph(moduleOp, aa);
+        auto bm = ComputeBlockIdManager(moduleOp);
+
+        auto result = moduleOp->walk([&](scf::ForOp forOp) {
+            if (!forOp->hasAttr(hivm::ExtractLoadStoreAttr)) {
+                return WalkResult::advance();
+            }
+
+            auto analysisResult = analyseExtractedLoadStore(forOp);
+            if (llvm::failed(analysisResult)) {
+                forOp.emitError() << "\n[" << DEBUG_TYPE << "] Analysis failed";
+                return WalkResult::interrupt();
+            }
+
+            if (llvm::failed(applyFixes(forOp, analysisResult.value(), memGraph, bm))) {
+                forOp.emitError() << "\n[" << DEBUG_TYPE << "] Block Id fixes failed (unrecoverable)";
+                return WalkResult::interrupt();
+            }
+
+            return WalkResult::advance();
+        });
+
+        if (result.wasInterrupted()) {
+            signalPassFailure();
+            return;
+        }
+
+        LOG_DEBUG("After: " << moduleOp << "\n");
+    }
+};
+
+} // namespace
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<OperationPass<ModuleOp>> createDiscreteLoadStorePass()
+{
+    return std::make_unique<DiscreteLoadStore>();
+}
+
+void registerDiscreteLoadStorePass()
+{
+    registerPass(createDiscreteLoadStorePass);
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
@@ -131,74 +131,6 @@ static LogicalResult getCommonBlockId(ArrayRef<Operation *> ops, int &blockId) {
 }
 
 /**
- * @brief Collect predecessor operations in a block for a given value
- *
- * This function traces back through SSA dependencies to find all operations
- * that affect the given startValue within a specific block.
- *
- * Special handling for scf.for loop-carried dependencies:
- * When an operand is a BlockArgument from scf.for iter_arg, we also trace
- * through the yieldOp to find the operation that provides the yielded value.
- * This ensures we capture operations that update loop-carried variables
- * (e.g., %79 that updates %arg19).
- *
- * @param startValue The value to trace back from
- * @param block The block to search within
- * @return SmallVector<Operation*> List of predecessor operations
- */
-static SmallVector<Operation *> collectBlockPredecessors(Value startValue, Block *block) {
-  SmallVector<Operation *> result;
-  SmallVector<Operation *> toProcess;
-
-  auto addToProcess = [&](Operation *op) {
-    if (auto *ancestorInBlock = CVPipeline::getAncestorInBlock(op, block)) {
-      if (!llvm::is_contained(result, ancestorInBlock)) {
-        toProcess.push_back(ancestorInBlock);
-      }
-    }
-  };
-
-  if (auto *condDefOp = startValue.getDefiningOp()) {
-    addToProcess(condDefOp);
-  }
-
-  while (!toProcess.empty()) {
-    auto *op = toProcess.pop_back_val();
-    if (llvm::is_contained(result, op)) {
-      continue;
-    }
-    result.push_back(op);
-
-    for (auto operand : op->getOperands()) {
-      if (auto *defOp = operand.getDefiningOp()) {
-        // SSA operand: trace to its defining operation
-        addToProcess(defOp);
-      } else if (auto blockArg = dyn_cast<BlockArgument>(operand)) {
-        // Block argument: check if it's from scf.for iter_arg
-        Operation *parentOp = blockArg.getOwner()->getParentOp();
-        if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
-          unsigned argIdx = blockArg.getArgNumber();
-          // argIdx == 0 is the loop variable, not iter_arg; skip invalid indices
-          if (argIdx == 0 || argIdx > forOp.getInitArgs().size()) {
-            continue;
-          }
-          Operation *yieldOp = forOp.getBody()->getTerminator();
-          if (!isa<scf::YieldOp>(yieldOp) || argIdx > yieldOp->getNumOperands()) {
-            continue;
-          }
-          // Get the value yielded for this iter_arg and trace its defining op
-          Value yieldedValue = yieldOp->getOperand(argIdx - 1);
-          if (auto *yieldedDef = yieldedValue.getDefiningOp()) {
-            addToProcess(yieldedDef);
-          }
-        }
-      }
-    }
-  }
-  return result;
-}
-
-/**
  * @brief Find linalg.fill operation that uses alloc as outs inside scf.if
  *
  * This function searches for linalg.fill operations that satisfy:
@@ -340,7 +272,7 @@ static FillInfo splitSCFIfIfNeeded(FillInfo &info) {
  * @param memGraph Memory dependence graph for cycle detection
  * @return LogicalResult Returns success if unification was performed, failure otherwise
  */
-static LogicalResult tryUnifyForAlloc(memref::AllocOp allocOp, 
+static LogicalResult tryUnifyForAlloc(memref::AllocOp allocOp,
                                       const CVPipeline::MemoryDependenceGraph &memGraph,
                                       CVPipeline::ComputeBlockIdManager &bm) {
   // Step1: Collect direct users (excluding linalg.fill)
@@ -374,7 +306,7 @@ static LogicalResult tryUnifyForAlloc(memref::AllocOp allocOp,
 
   // Step5: Collect predecessor_ops for scf.if condition
   SmallVector<Operation *> conditionOps =
-      collectBlockPredecessors(fillInfo.parentIf.getCondition(), fillInfo.parentIf->getBlock());
+      CVPipeline::collectBlockPredecessors(fillInfo.parentIf.getCondition(), fillInfo.parentIf->getBlock());
 
   // Step6: Cycle detection and block_id assignment with fallback
   SmallVector<Operation *> coreOps = {
@@ -433,7 +365,7 @@ public:
     module.walk([&](memref::AllocOp allocOp) {
       allocOps.push_back(allocOp);
     });
-    
+
     for (memref::AllocOp allocOp: allocOps) {
       if (failed(tryUnifyForAlloc(allocOp, memGraph, bm))) {
         signalPassFailure();

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
@@ -20,14 +20,16 @@
  * THE SOFTWARE.
  */
 
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Pass/PassRegistry.h"
+
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/ComputeBlockOptPass.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlockPass.h"
+
 #include "DynamicCVPipeline/ComputeBlockOpt/Passes.h"
 #include "DynamicCVPipeline/PlanComputeBlock/Passes.h"
 #include "DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.h"
-#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
-#include "ascend/include/DynamicCVPipeline/PlanComputeBlockPass.h"
-
-#include "mlir/Pass/PassManager.h"
 
 using namespace mlir;
 using namespace triton;
@@ -43,6 +45,9 @@ void ComputeBlockOptPass::runOnOperation()
         Then, use UBUsageOpt to find the smallest UB dependency location and divide the computation blocks.
      */
     pm.addPass(createUnifyAllocBlockPass());
+    pm.addPass(createReorderOpsByBlockIdPass());
+
+    pm.addPass(createDiscreteLoadStorePass());
     pm.addPass(createReorderOpsByBlockIdPass());
 
     pm.addPass(createMergeVectorIfBlockPass());
@@ -75,6 +80,7 @@ void registerComputeBlockOptPasses()
     registerPass(createUnifyAllocBlockPass);
     registerPass(createMergeVectorIfBlockPass);
     registerPass(createFixpipeOptPass);
+    registerDiscreteLoadStorePass();
 }
 
 } // namespace triton

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.cpp
@@ -159,12 +159,5 @@ llvm::LogicalResult ComputeBlockIdManager::markOpsWithNewId(llvm::SmallVectorImp
     return llvm::success();
 }
 
-void ComputeBlockIdManager::reset()
-{
-    cntComputeBlockId = 0;
-    blockIdToOps.clear();
-    opToBlockId.clear();
-}
-
 } // namespace CVPipeline
 } // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -27,7 +27,6 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 
-#include "bishengir/Dialect/Utils/Util.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -39,10 +38,12 @@
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Support/LLVM.h"
 
-#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h"
 
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
+#include "bishengir/Dialect/HIVM/IR/HIVMImpl.h"
+#include "bishengir/Dialect/Utils/Util.h"
 
 using namespace mlir;
 static constexpr const char *DEBUG_TYPE = "op-classifier";
@@ -657,6 +658,10 @@ int OpClassifierPass::markRemainingAsVector()
 
         if (opCoreTypes[op] == OP_UNDETERMINED && !isa<scf::YieldOp>(op)) {
             opCoreTypes[op] = OP_VECTOR_ONLY;
+        }
+
+        if (isa<scf::ForOp>(op) && op->hasAttr(hivm::ExtractLoadStoreAttr)) {
+            op->walk([this](Operation *nestedOp) { opCoreTypes[nestedOp] = OP_VECTOR_ONLY; });
         }
     }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
@@ -157,6 +157,28 @@ BlockOpGraph::BlockOpGraph(ArrayRef<Operation *> allOps, Block *block, const Mem
     }
 }
 
+// ============================================================================
+// Method: collectBlockIds
+// ============================================================================
+/**
+ * @brief Collects block IDs across operations, traversing nested operations when necessary.
+ *
+ * **Purpose**:
+ * Resolves or assigns unique block IDs for a list of operations, ensuring that sub-operations
+ * within nested regions are accounted for when checking scheduling groups.
+ *
+ * **Inputs & Assumptions**:
+ * - `allOps` (ArrayRef<Operation *>): List of outer operations.
+ * - `bm` (ComputeBlockIdManager &): The block ID manager.
+ *
+ * **Outputs & Guarantees**:
+ * - Returns a `DenseMap<Operation *, int>` associating each operation with its block ID.
+ * - Returns `llvm::failure()` if validation of any operation block ID fails.
+ *
+ * **Safety Boundaries & Constraints**:
+ * - If an operation does not have a block ID assigned directly, performs a recursive walk on its
+ *   nested regions to find a unified block ID. If nested block IDs conflict, assigns a new unique ID.
+ */
 static llvm::FailureOr<DenseMap<Operation *, int>> collectBlockIds(ArrayRef<Operation *> allOps, ComputeBlockIdManager &bm)
 {
     DenseMap<Operation *, int> opBlockId;
@@ -164,10 +186,28 @@ static llvm::FailureOr<DenseMap<Operation *, int>> collectBlockIds(ArrayRef<Oper
         if (llvm::failed(verifyOpBlockId(op))) {
             return llvm::failure();
         }
-        auto blockIdAttrRes = getOpBlockId(op);
-        int64_t blockId =
-            blockIdAttrRes.has_value() ? blockIdAttrRes.value() : bm.getNextId();
-        opBlockId[op] = blockId;
+        auto blockIdOpt = getOpBlockId(op);
+        if (blockIdOpt.has_value()) {
+            opBlockId[op] = blockIdOpt.value();
+            continue;
+        }
+
+        auto result = op->walk([&](Operation *nestedOp) {
+            auto currBlockIdOpt = getOpBlockId(nestedOp);
+            if (!blockIdOpt.has_value()) {
+                blockIdOpt = getOpBlockId(nestedOp);
+            }
+            if (currBlockIdOpt.has_value() && currBlockIdOpt != blockIdOpt) {
+                return WalkResult::interrupt();
+            }
+            return WalkResult::advance();
+        });
+        if (result.wasInterrupted() || !blockIdOpt.has_value()) {
+            blockIdOpt = bm.getNextId();
+        } else {
+            bm.updateBlockId(op, blockIdOpt.value());
+        }
+        opBlockId[op] = blockIdOpt.value();
     }
     return opBlockId;
 }
@@ -357,14 +397,15 @@ static llvm::LogicalResult reorderOpsInBlock(Block &block, const MemoryDependenc
 
 void ReorderOpsByBlockIdPass::runOnOperation()
 {
-    LOG_DEBUG("\n=== Pass: TuningOpSeq ===\n");
-    OpBuilder const builder(&getContext());
-
     auto moduleOp = getOperation();
+    LOG_DEBUG("Input mlir:\n" << moduleOp << "\n");
+    llvm::dbgs().flush();
+
+    OpBuilder const builder(&getContext());
     auto &aa = getAnalysis<AliasAnalysis>();
     auto memGraph = MemoryDependenceGraph(moduleOp, aa);
     auto bm = ComputeBlockIdManager(moduleOp);
-    moduleOp.walk([&](Block *block) {
+    auto result = moduleOp.walk([&](Block *block) {
         auto *parentOp = block->getParentOp();
         if (!parentOp ||
             // whitelist ops to reorder
@@ -372,12 +413,16 @@ void ReorderOpsByBlockIdPass::runOnOperation()
             return WalkResult::skip();
         }
         if (llvm::failed(reorderOpsInBlock(*block, memGraph, bm))) {
-            signalPassFailure();
+            return WalkResult::interrupt();
         }
         return WalkResult::advance();
     });
 
-    LOG_DEBUG("=== Pass TuningOpSeq complete ===\n");
+    if (result.wasInterrupted()) {
+        signalPassFailure();
+        return;
+    }
+    LOG_DEBUG("Output mlir:\n" << moduleOp << "\n");
 }
 
 std::unique_ptr<OperationPass<ModuleOp>> mlir::triton::createReorderOpsByBlockIdPass()

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/discrete_load_store.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/discrete_load_store.mlir
@@ -1,0 +1,68 @@
+// RUN: triton-opt --discrete-load-store %s | FileCheck %s
+
+// ============================================================================
+// Test Case: @test_discrete_load
+// ============================================================================
+// This test verifies that for a discrete LOAD (GM -> local buffer), the block IDs
+// of the local allocation, the scf.for loop (with ExtractedLoadOrStore attribute),
+// and the operations inside the loop are unified to the block ID of the local
+// buffer's external users.
+//
+// - Initial state:
+//   - %alloc has block_id = 4
+//   - scf.for loop and its internal ops have block_id = 3
+//   - bufferization.to_tensor (external user of %alloc) has block_id = 5
+// - Expected unified block_id: 5
+// ============================================================================
+// CHECK-LABEL: func.func @test_discrete_load
+func.func @test_discrete_load(%arg0: memref<?xf16>, %lb: index, %ub: index, %step: index) {
+  // CHECK: [[ALLOC:%.*]] = memref.alloc() {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"}
+  %alloc = memref.alloc() {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x32xf16>
+
+  // CHECK: scf.for [[LOOP_IV:%.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
+  // CHECK:   %{{.*}} = memref.reinterpret_cast %{{.*}} to offset: [0], sizes: [1, 32], strides: [32, 1] {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"}
+  // CHECK:   %{{.*}} = memref.subview [[ALLOC]][[[LOOP_IV]], 0] [1, 32] [1, 1] {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"}
+  // CHECK:   memref.copy %{{.*}}, %{{.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"}
+  // CHECK: } {ExtractedLoadOrStore, ssbuffer.block_id = 5 : i32}
+  scf.for %arg1 = %lb to %ub step %step {
+    %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [0], sizes: [1, 32], strides: [32, 1] {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<1x32xf16, strided<[32, 1], offset: ?>>
+    %subview = memref.subview %alloc[%arg1, 0] [1, 32] [1, 1] {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x32xf16> to memref<1x32xf16, strided<[32, 1], offset: ?>>
+    memref.copy %reinterpret_cast, %subview {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : memref<1x32xf16, strided<[32, 1], offset: ?>> to memref<1x32xf16, strided<[32, 1], offset: ?>>
+  } {ExtractedLoadOrStore, ssbuffer.block_id = 3 : i32}
+
+  // CHECK: %{{.*}} = bufferization.to_tensor [[ALLOC]] restrict writable {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"}
+  %to_tensor = bufferization.to_tensor %alloc restrict writable {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x32xf16>
+  return
+}
+
+// ============================================================================
+// Test Case: @test_discrete_store
+// ============================================================================
+// This test verifies that for a discrete STORE (local buffer -> GM), the block IDs
+// of the scf.for loop (with ExtractedLoadOrStore attribute) and the operations
+// inside the loop are unified to the block ID of the local buffer (%alloc) itself.
+//
+// - Initial state:
+//   - %alloc has block_id = 2
+//   - scf.for loop and its internal ops have block_id = 3
+// - Expected unified block_id: 2
+// ============================================================================
+// CHECK-LABEL: func.func @test_discrete_store
+func.func @test_discrete_store(%arg0: memref<?xf16>, %lb: index, %ub: index, %step: index) {
+  // CHECK: [[ALLOC:%.*]] = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"}
+  %alloc = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x32xf16>
+
+  // CHECK: scf.for [[LOOP_IV:%.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
+  // CHECK:   %{{.*}} = memref.reinterpret_cast %{{.*}} to offset: [0], sizes: [1, 32], strides: [32, 1] {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"}
+  // CHECK:   %{{.*}} = memref.subview [[ALLOC]][[[LOOP_IV]], 0] [1, 32] [1, 1] {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"}
+  // CHECK:   memref.copy %{{.*}}, %{{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"}
+  // CHECK: } {ExtractedLoadOrStore, ssbuffer.block_id = 2 : i32}
+  scf.for %arg1 = %lb to %ub step %step {
+    %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [0], sizes: [1, 32], strides: [32, 1] {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<1x32xf16, strided<[32, 1], offset: ?>>
+    %subview = memref.subview %alloc[%arg1, 0] [1, 32] [1, 1] {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x32xf16> to memref<1x32xf16, strided<[32, 1], offset: ?>>
+    memref.copy %subview, %reinterpret_cast {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : memref<1x32xf16, strided<[32, 1], offset: ?>> to memref<1x32xf16, strided<[32, 1], offset: ?>>
+  } {ExtractedLoadOrStore, ssbuffer.block_id = 3 : i32}
+
+  return
+}
+


### PR DESCRIPTION
## PR Title / PR 标题
`[fix](ssbuffer): support discrete load store (unit attribute "ExtractedLoadOrStore" on forOp) | [修复][ssbuffer] 支持离散加载与存储（处理 forOp 上的 "ExtractedLoadOrStore" 属性）`

## 1. Overview / 概述
### English
This PR introduces the `DiscreteLoadStore` optimization pass inside the Ascend Triton Dynamic CV Pipeline framework. This pass targets discrete load/store loops annotated with the `hivm::ExtractLoadStoreAttr` (`ExtractedLoadOrStore` unit attribute) and unifies their computational block IDs (`ssbuffer.block_id`) with the corresponding local buffer allocation or external users. This ensures memory loading/storing operations and their loop structures are tightly grouped and scheduled within correct, non-cyclic computation blocks.

### 中文
本 PR 在昇腾 Triton 动态 CV 流水线（Dynamic CV Pipeline）优化框架中引入了 `DiscreteLoadStore` 优化通道。该通道主要针对带有 `hivm::ExtractLoadStoreAttr`（即 `ExtractedLoadOrStore` 属性）的离散加载/存储（Load/Store）循环，将其计算块 ID（`ssbuffer.block_id`）与相对应的本地缓存（Local Buffer）分配操作或外部使用者相统一。这保证了内存加载/存储操作及其循环结构能够在正确且无环的计算块内进行组合和调度。

## 2. Key Changes / 关键变更
### English
- **New Optimization Pass**:
  - Implemented `DiscreteLoadStorePass` in `DiscreteLoadStore.cpp` to analyze, categorize (LOAD vs. STORE), and unify block IDs for annotated loops and their upstream/downstream operations.
- **Refactoring of Helper Functions**:
  - Moved `collectBlockPredecessors` from `UnifyAllocBlockPass.cpp` to `ComputeBlockOpt/Common.cpp` as a shared utility and generalized it to accept a `ValueRange` to trace multiple inputs (such as loop bounds and step) simultaneously.
  - Implemented `tryUpdate` in `Common.cpp` to attempt block ID updates and automatically roll back if cycle detection fails.
  - Added `getAliasSource` in `Utils.cpp` to trace through views (`ViewLikeOpInterface`), casts (`CastOpInterface`), and bufferization conversions (`ToMemrefOp` / `ToTensorOp`) to locate original buffer definitions.
- **Op Classifier Enhancement**:
  - Updated `OpClassifier.cpp` to recursively mark all nested operations inside an `scf.for` loop annotated with `ExtractLoadStoreAttr` as `OP_VECTOR_ONLY`.
- **Block Reordering Support**:
  - Refactored `collectBlockIds` in `ReorderOpsByBlockId.cpp` to allow operations without a block ID to inherit a common block ID from their nested child operations if a unique block ID exists.
- **ComputeBlockIdManager Cleanups**:
  - Made `ComputeBlockIdManager` inherit from `MoveOnly` to prevent copy overhead, removed redundant thread-safety locks (`std::mutex`), and removed the unused `reset()` method.
- **Pipeline Integration**:
  - Added `DiscreteLoadStorePass` into the main `ComputeBlockOptPass` pipeline sequence.
- **Unit Testing**:
  - Added unit test cases in `discrete_load_store.mlir` to verify the block ID unification logic for both LOAD and STORE patterns.

### 中文
- **新增优化 Pass**:
  - 在 `DiscreteLoadStore.cpp` 中实现 `DiscreteLoadStorePass`，用于分析、分类（LOAD 或 STORE）并统一被标记循环及其上游/下游操作的计算块 ID（block_id）。
- **辅助函数重构**:
  - 将 `UnifyAllocBlockPass.cpp` 中的 `collectBlockPredecessors` 移至 `ComputeBlockOpt/Common.cpp` 作为公共函数，并泛化为支持 `ValueRange`，以便能够同时追踪多个输入（例如：循环上下界及步长）。
  - 在 `Common.cpp` 中实现 `tryUpdate`，在尝试更新 block_id 的同时检测成环风险，并在失败时自动回滚。
  - 在 `Utils.cpp` 中新增 `getAliasSource`，支持递归追踪 View、Cast 以及 Bufferization 转换（如 `ToMemrefOp`、`ToTensorOp`）的原始 Buffer 定义。
- **算子分类器（Op Classifier）增强**:
  - 更新 `OpClassifier.cpp`，支持将带有 `ExtractLoadStoreAttr` 属性的 `scf.for` 循环内部所有嵌套算子递归标记为 `OP_VECTOR_ONLY`（仅向量执行）。
- **计算块重排序逻辑完善**:
  - 在 `ReorderOpsByBlockId.cpp` 的 `collectBlockIds` 中，允许没有 block_id 的操作在存在唯一 block_id 时，递归地从其嵌套子操作中继承相同的 block_id。
- **ComputeBlockIdManager 清理**:
  - 使 `ComputeBlockIdManager` 继承自 `MoveOnly` 以避免拷贝开销，移除了冗余的 `std::mutex` 线程锁，并删除了未使用的 `reset()` 方法。
- **流水线集成**:
  - 在主通道 `ComputeBlockOptPass` 的流水线串联中引入并注册了 `DiscreteLoadStorePass`。
- **单元测试**:
  - 在 `discrete_load_store.mlir` 中新增单元测试，验证了离散 LOAD 和 STORE 模式下 Block ID 统一合并的正确性。

## 3. Technical Deep-Dive / 技术细节剖析
### English
The `DiscreteLoadStore` pass automates the scheduling alignment of discrete global memory (GM) transfers.
- **Analysis Stage**:
  The pass queries the memory effects of operations inside an annotated `scf.for` loop via `MemoryEffectOpInterface`. By traversing to alias sources (`traceToDefVal` utilizing `getAliasSource`), it checks whether one memory target resides in the Function Arguments representing Global Memory (`isGMArg`). Depending on whether the transaction writes to or reads from GM, it classifies the scenario as `STORE` or `LOAD`.
- **Block ID Alignment Strategy**:
  - **LOAD**: If it is a LOAD (GM $\rightarrow$ Local), the loop fetches data that downstream operations will consume. The pass aligns the block ID of the loop, its nested ops, and the allocation to the **common block ID of the local buffer's external users**. This clusters the LOAD action directly with the computation block that consumes the tensor.
  - **STORE**: If it is a STORE (Local $\rightarrow$ GM), the loop is writing local results back to GM. The pass aligns the block ID of the loop, its nested ops, and upstreams to the **block ID of the local buffer allocation itself**.
- **Upstream Operation Inclusion & Cycle Recovery**:
  To ensure the loop doesn't get isolated or scheduled before its dependencies are ready, loop-control upstreams (lower/upper bound, step calculations) are gathered using `collectBlockPredecessors`. The block ID updates are validated by `willCreateCycle` within the dependency graph (`MemoryDependenceGraph`). If updating the full set (`extendedOps`) causes a cyclic dependency, the pass falls back to updating only the core set (`coreOps` - the allocation and loop operations).

### 中文
`DiscreteLoadStore` 通道实现了离散全局内存（GM）搬移调度对齐的自动化。
- **分析阶段**:
  该 Pass 通过 `MemoryEffectOpInterface` 遍历被标记的 `scf.for` 循环内部操作。利用 `traceToDefVal`（结合 `getAliasSource`）递归查询别名源，确认是否有其中一个内存目标位于表示全局内存（GM）的函数参数中（`isGMArg`）。根据具体是对 GM 进行写操作还是读操作，将场景分类为 `STORE`（存储）或 `LOAD`（加载）。
- **Block ID 对齐策略**:
  - **LOAD（加载）**: 如果是 LOAD（GM $\rightarrow$ Local），说明循环在加载下游算子所需的数据。该 Pass 会将该循环、其内部操作以及 Alloc 内存分配的 block_id 统一对齐到**该 Local Buffer 外部使用者的公共 block_id**。这样能确保 LOAD 操作与消费该 Tensor 的计算块紧密聚集在一起。
  - **STORE（存储）**: 如果是 STORE（Local $\rightarrow$ GM），说明循环在写回计算结果。该 Pass 会将循环、其内部操作以及上游操作的 block_id 统一对齐到**该 Local Buffer 分配本身的 block_id**。
- **上游操作追踪与成环恢复机制**:
  为防止循环在依赖未就绪时被提前或推迟调度，Pass 利用 `collectBlockPredecessors` 收集控制该循环的控制上游（如 LowerBound/UpperBound/Step 相关的计算操作）。接着，通过内存依赖图（`MemoryDependenceGraph`）的 `willCreateCycle` 函数验证 block_id 的更新。若更新完整集合（`extendedOps`）会导致依赖成环，Pass 将回退至仅更新核心集合（`coreOps` - 仅包含分配操作和循环操作本身）。

## 4. Impact & Risk Assessment / 影响与风险评估
### English
- **Breaking Changes**: No. This is a compiler optimization pass and does not change the user-facing API or standard IR definitions.
- **Performance Impact**: Positive. By unifying discrete Load/Store block IDs, operations can be grouped and scheduled much more effectively within the Dynamic CV Pipeline, improving memory locality and pipelining capability.
- **Backward Compatibility**: Fully compatible with existing passes in the Ascend compilation chain.

### 中文
- **破坏性变更**: 否。这属于编译器内部优化通道，不改变面向用户的 API 或标准 IR 定义。
- **性能影响**: 积极。通过统一离散加载/存储的 block_id，可以使相关操作在动态 CV 流水线中进行更高效的合并和重排调度，从而提高数据局部性并增强流水线并行能力。
- **向后兼容性**: 与昇腾编译链中的现有 Pass 完全向后兼容。

## 5. Verification & Testing / 测试与验证方法
### English
- **Unit Test Case**:
  Added `discrete_load_store.mlir` which includes:
  - `@test_discrete_load`: Verifies unified block ID propagation from external users back to the `scf.for` and local allocation for LOAD loops.
  - `@test_discrete_store`: Verifies block ID propagation from the local allocation forward to the `scf.for` and internal operations for STORE loops.
- **Execution**:
  Verified via LLVM's FileCheck with:
  ```bash
  triton-opt --discrete-load-store third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/discrete_load_store.mlir
  ```

### 中文
- **单元测试用例**:
  新增 `discrete_load_store.mlir` 测试，包括：
  - `@test_discrete_load`: 验证对于 LOAD 循环，block_id 能够成功从外部使用者向前传播至 `scf.for` 及本地分配。
  - `@test_discrete_store`: 验证对于 STORE 循环，block_id 能够成功从本地分配向后传播至 `scf.for` 及其内部嵌套操作。
- **执行方式**:
  通过 LLVM FileCheck 工具进行验证：
  ```bash
  triton-opt --discrete-load-store third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/discrete_load_store.mlir
  ```