### PR TITLE
[Docs](fix) Update extra memory ops documentation 

### DIFF
--- a/docs/zh/python-api/_ascend_constraints.py
+++ b/docs/zh/python-api/_ascend_constraints.py
@@ -839,4 +839,44 @@ CONSTRAINTS = {
         ],
         "example": "triton.language.zeros_like",
     },
+    "triton.language.extra.cann.extension.index_put": {
+        "constraints": [
+            "Only supported on Ascend 950.",
+            "``ptr.dtype``: only supports float16, bfloat16, float32.",
+            "``ptr`` and ``value`` must have the same rank.",
+            "``index``: must be an integer tensor. If ``index.rank`` != 1, it will be reshaped to 1D.",
+            "``index.numel``: must equal ``value.shape[dim]``.",
+            "``value``: supports 2~5D tensors.",
+            "``dim``: must satisfy 0 <= dim < rank(value) - 1.",
+        ],
+        "example":
+        "triton.language.extra.cann.extension.index_put",
+    },
+    "triton.language.extra.cann.extension.gather_out_to_ub": {
+        "constraints": [
+            "Only supported on Ascend 950.",
+            "``src.dtype``: only supports float16, bfloat16, float32.",
+            "``src`` and ``index`` must have the same rank.",
+            "``index``: must be an integer tensor, with rank in [1, 5].",
+            "``dim``: must satisfy 0 <= dim < rank(index).",
+            "``other``: must be a scalar value.",
+            "For every dimension ``i`` not equal to ``dim``, ``index.size[i]`` <= ``src.size[i]``.",
+            "The output shape is the same as ``index.shape``.",
+        ],
+        "example":
+        "triton.language.extra.cann.extension.gather_out_to_ub",
+    },
+    "triton.language.extra.cann.extension.scatter_ub_to_out": {
+        "constraints": [
+            "Only supported on Ascend 950.",
+            "``ptr.dtype``: only supports float16, bfloat16, float32.",
+            "``ptr``, ``index`` and ``value`` must have the same rank.",
+            "``index``: must be an integer tensor, with rank in [1, 5].",
+            "``dim``: must satisfy 0 <= dim < rank(index).",
+            "For every dimension ``i`` not equal to ``dim``, ``index.size[i]`` <= ``ptr.size[i]``.",
+            "The output shape is the same as ``index.shape``.",
+        ],
+        "example":
+        "triton.language.extra.cann.extension.scatter_ub_to_out",
+    },
 }

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.extension.gather_out_to_ub.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.extension.gather_out_to_ub.py
@@ -1,0 +1,55 @@
+import torch
+import triton
+import triton.language as tl
+from triton.language.extra.cann.extension import gather_out_to_ub
+from triton.tools.get_ascend_devices import is_compile_on_910_95
+
+
+@triton.jit
+def kernel(src_ptr, index_ptr, out_ptr):
+    """
+    Test gather_out_to_ub with a 2D index tile:
+    1. Load a [2,2] index tile from GM into UB
+    2. Gather values from src (in GM) along dim=0 using the index tile
+    3. Store the gathered result (in UB) to output
+    """
+    # index tile shape: [2,2]
+    y0_local = tl.arange(0, 2)[:, None]  # [0,1] rows
+    x1_local = tl.arange(0, 2)[None, :]  # [0,1] cols
+    mask = (y0_local < 2) & (x1_local < 2)
+
+    # Load index tile to UB
+    index = tl.load(index_ptr + y0_local * 2 + x1_local, mask)
+
+    # Call gather_out_to_ub: gather values from src along dim=0
+    gathered = gather_out_to_ub(src=src_ptr, index=index, index_boundary=4, dim=0, src_stride=(2, 1), end_offset=(2, 2),
+                                start_offset=(0, 0))
+
+    tl.store(out_ptr + y0_local * 2 + x1_local, gathered, mask)
+
+
+def test_gather_out_to_ub():
+    # src(4,2) = [[1.,2.],[3.,4.],[5.,6.],[7.,8.]]
+    src = torch.tensor([[1., 2.], [3., 4.], [5., 6.], [7., 8.]], device='npu')
+    # index(2,2) = [[0,1],[2,3]]
+    index = torch.tensor([[0, 1], [2, 3]], device='npu')
+    out = torch.empty((2, 2), device='npu', dtype=torch.float32)
+
+    kernel[(1, )](src, index, out)
+
+    # Reference: gather along dim=0 with src(4,2) and index(2,2)
+    # out[i,j] = src[index[i,j], j]
+    # out[0,0] = src[index[0,0]=0, 0] = 1.0
+    # out[0,1] = src[index[0,1]=1, 1] = 4.0
+    # out[1,0] = src[index[1,0]=2, 0] = 5.0
+    # out[1,1] = src[index[1,1]=3, 1] = 8.0
+    expected = torch.tensor([[1., 4.], [5., 8.]], device='cpu')
+    assert torch.allclose(out.cpu(), expected), \
+        f"Mismatch: expected {expected}, got {out.cpu()}"
+
+
+if __name__ == "__main__":
+    if not is_compile_on_910_95:
+        print("gather_out_to_ub is only supported on Ascend 950, skipping test.")
+    else:
+        test_gather_out_to_ub()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.extension.index_put.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.extension.index_put.py
@@ -1,0 +1,55 @@
+import torch
+import triton
+import triton.language as tl
+from triton.language.extra.cann.extension import index_put
+from triton.tools.get_ascend_devices import is_compile_on_910_95
+
+
+@triton.jit
+def kernel(value_ptr, index_ptr, dst_ptr):
+    """
+    Test index_put with a 2D value and 1D index:
+    1. Load index tensor from GM (shape [2])
+    2. Load value tensor from GM (shape [2, 2])
+    3. Scatter value rows into dst at positions given by index along dim=0
+    4. The operation: dst[index[i], :] = value[i, :]
+    """
+    # index tile shape: [2]
+    index_local = tl.arange(0, 2)
+    x1_local = tl.arange(0, 2)[None, :]  # shape=(1,2)
+
+    index_tile = tl.load(index_ptr + index_local)
+    value_tile = tl.load(value_ptr + index_local[:, None] * 2 + x1_local)
+
+    index_put(ptr=dst_ptr, index=index_tile, value=value_tile, dim=0, index_boundary=4, end_offset=(2, 2),
+              start_offset=(0, 0), dst_stride=(2, 1))
+
+
+def test_index_put():
+    # dst: (4,2) of zeros
+    dst = torch.zeros((4, 2), device='npu', dtype=torch.float32)
+    # value = [[1., 2.],
+    #          [3., 4.]]
+    value = torch.tensor([[1., 2.], [3., 4.]], device='npu')
+    # index = [2, 0]
+    index = torch.tensor([2, 0], device='npu')
+
+    kernel[(1, )](value, index, dst)
+
+    # Reference: dst[index[i], :] = value[i, :]
+    # dst[2, :] = value[0, :] = [1., 2.]
+    # dst[0, :] = value[1, :] = [3., 4.]
+    # expected = [[3., 4.],
+    #             [0., 0.],
+    #             [1., 2.],
+    #             [0., 0.]]
+    expected = torch.tensor([[3., 4.], [0., 0.], [1., 2.], [0., 0.]], device='cpu')
+    assert torch.allclose(dst.cpu(), expected), \
+        f"Mismatch: expected {expected}, got {dst.cpu()}"
+
+
+if __name__ == "__main__":
+    if not is_compile_on_910_95:
+        print("index_put is only supported on Ascend 950, skipping test.")
+    else:
+        test_index_put()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.extension.scatter_ub_to_out.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.extension.scatter_ub_to_out.py
@@ -1,0 +1,58 @@
+import torch
+import triton
+import triton.language as tl
+from triton.language.extra.cann.extension import scatter_ub_to_out
+from triton.tools.get_ascend_devices import is_compile_on_910_95
+
+
+@triton.jit
+def kernel(value_ptr, index_ptr, dst_ptr):
+    """
+    Test scatter_ub_to_out with a 2D value tile:
+    1. Load a [2,2] value tile from GM into UB
+    2. Load a [2,2] index tile from GM into UB
+    3. Scatter value elements from UB into dst (in GM) at positions given by index along dim=0
+    4. The operation: dst[index[i,j], j] = value[i,j]
+    """
+    # index tile shape: [2,2]
+    y0_local = tl.arange(0, 2)[:, None]  # [0,1] rows
+    x1_local = tl.arange(0, 2)[None, :]  # [0,1] cols
+    mask = (y0_local < 2) & (x1_local < 2)
+
+    value = tl.load(value_ptr + y0_local * 2 + x1_local, mask)
+    index = tl.load(index_ptr + y0_local * 2 + x1_local, mask)
+
+    scatter_ub_to_out(ptr=dst_ptr, value=value, index=index, index_boundary=4, dim=0, dst_stride=(2, 1),
+                      end_offset=(2, 2), start_offset=(0, 0))
+
+
+def test_scatter_ub_to_out():
+    # dst: (4,2) of zeros
+    dst = torch.zeros((4, 2), device='npu', dtype=torch.float32)
+    # value(2,2) = [[1.,2.],[3.,4.]]
+    value = torch.tensor([[1., 2.], [3., 4.]], device='npu')
+    # index(2,2) = [[1,2],[3,0]]
+    index = torch.tensor([[1, 2], [3, 0]], device='npu')
+
+    kernel[(1, )](value, index, dst)
+
+    # Reference: scatter along dim=0 with dst(4,2) and value/index(2,2)
+    # dst[index[i,j], j] = value[i,j]
+    # dst[index[0,0]=1, 0] = value[0,0] = 1.0
+    # dst[index[0,1]=2, 1] = value[0,1] = 2.0
+    # dst[index[1,0]=3, 0] = value[1,0] = 3.0
+    # dst[index[1,1]=0, 1] = value[1,1] = 4.0
+    # expected = [[0., 4.],
+    #             [1., 0.],
+    #             [0., 2.],
+    #             [3., 0.]]
+    expected = torch.tensor([[0., 4.], [1., 0.], [0., 2.], [3., 0.]], device='cpu')
+    assert torch.allclose(dst.cpu(), expected), \
+        f"Mismatch: expected {expected}, got {dst.cpu()}"
+
+
+if __name__ == "__main__":
+    if not is_compile_on_910_95:
+        print("scatter_ub_to_out is only supported on Ascend 950, skipping test.")
+    else:
+        test_scatter_ub_to_out()

--- a/docs/zh/python-api/_examples/triton.language.gather.py
+++ b/docs/zh/python-api/_examples/triton.language.gather.py
@@ -1,8 +1,20 @@
+import torch
+import triton
+import triton.language as tl
+
+
 @triton.jit
-def gather_kernel(src_ptr, idx_ptr, out_ptr, axis: tl.constexpr, src_dim0: tl.constexpr, src_dim1: tl.constexpr,
-                  src_stride0: tl.constexpr, src_stride1: tl.constexpr, idx_dim0: tl.constexpr, idx_dim1: tl.constexpr,
-                  idx_stride0: tl.constexpr, idx_stride1: tl.constexpr, out_dim0: tl.constexpr, out_dim1: tl.constexpr,
-                  out_stride0: tl.constexpr, out_stride1: tl.constexpr):
+def kernel(src_ptr, idx_ptr, out_ptr, axis: tl.constexpr, src_dim0: tl.constexpr, src_dim1: tl.constexpr,
+           src_stride0: tl.constexpr, src_stride1: tl.constexpr, idx_dim0: tl.constexpr, idx_dim1: tl.constexpr,
+           idx_stride0: tl.constexpr, idx_stride1: tl.constexpr, out_dim0: tl.constexpr, out_dim1: tl.constexpr,
+           out_stride0: tl.constexpr, out_stride1: tl.constexpr):
+    """
+    Test tl.gather with a 2D tensor:
+    1. Load src tensor from GM
+    2. Load index tensor from GM
+    3. Gather elements from src along the given axis using the index
+    4. Store the gathered result to output
+    """
     src_offs = (tl.arange(0, src_dim0)[:, None] * src_stride0 + tl.arange(0, src_dim1)[None, :] * src_stride1)
     src = tl.load(src_ptr + src_offs)
 
@@ -13,3 +25,27 @@ def gather_kernel(src_ptr, idx_ptr, out_ptr, axis: tl.constexpr, src_dim0: tl.co
 
     out_offs = (tl.arange(0, out_dim0)[:, None] * out_stride0 + tl.arange(0, out_dim1)[None, :] * out_stride1)
     tl.store(out_ptr + out_offs, out)
+
+
+def test_gather():
+    # src(4,2) = [[1.,2.],[3.,4.],[5.,6.],[7.,8.]]
+    src = torch.tensor([[1., 2.], [3., 4.], [5., 6.], [7., 8.]], device='npu')
+    # idx(2,2) = [[0,1],[2,0]]
+    idx = torch.tensor([[0, 1], [2, 0]], device='npu', dtype=torch.int32)
+    out = torch.empty((2, 2), device='npu', dtype=torch.float32)
+
+    kernel[(1, )](src, idx, out, axis=0, src_dim0=4, src_dim1=2, src_stride0=2, src_stride1=1, idx_dim0=2, idx_dim1=2,
+                  idx_stride0=2, idx_stride1=1, out_dim0=2, out_dim1=2, out_stride0=2, out_stride1=1)
+    # Reference: gather along axis=0 with src(4,2) and idx(2,2)
+    # out[i,j] = src[idx[i,j], j]
+    # out[0,0] = src[idx[0,0]=0, 0] = 1.0
+    # out[0,1] = src[idx[0,1]=1, 1] = 4.0
+    # out[1,0] = src[idx[1,0]=2, 0] = 5.0
+    # out[1,1] = src[idx[1,1]=0, 1] = 2.0
+    expected = torch.tensor([[1., 4.], [5., 2.]], device='cpu')
+    assert torch.allclose(out.cpu(), expected), \
+        f"Mismatch: expected {expected}, got {out.cpu()}"
+
+
+if __name__ == "__main__":
+    test_gather()

--- a/third_party/ascend/language/cann/extension/mem_ops.py
+++ b/third_party/ascend/language/cann/extension/mem_ops.py
@@ -26,6 +26,7 @@ def index_put(ptr: tensor, index: tensor, value: tensor, dim: int, index_boundar
     Index put values from a tensor into a destination tensor.
 
     Index put operation for different tensor ranks:
+
     1. 2D index scatter (0 <= dim < 1):
         1.1 dim = 0
         out[index[i]][start_offset[1]:end_offset[1]] = value[i][0:end_offset[1]-start_offset[1]]
@@ -37,60 +38,22 @@ def index_put(ptr: tensor, index: tensor, value: tensor, dim: int, index_boundar
             out[start_offset[0]:end_offset[0]][index[j]][start_offset[2]:end_offset[2]]
                 = value[0:end_offset[0]-start_offset[0]][j][0:end_offset[2]-start_offset[2]]
 
-
-    :param ptr: pointer type, the destination tensor pointer (in GM)
-    :param index: tensor, a index to scatter (in UB)
-    :param value: tensor, a value to store (in UB)
-    :param dim: int32, the dimension to scatter along
-    :param index_boundary: int64, the upper boundary for index values
-    :param end_offset: tuple of int, the offsets of each dimension for the end of the scatter region
-    :param start_offset: tuple of int, the offsets of each dimension for the start of the scatter region
-    :param dst_stride: tuple of int, the stride of each dimension of destination tensor
-
-    Constraints
-    ***********
-    - `ptr` and `value` must have the same rank.
-    - `ptr.dtype` only supports `float16`, `bfloat16`, `float32` currently.
-    - `index` must be an integer tensor. If `index.rank` != 1, it will be reshaped to 1D.
-    - `index.numel` must equal `value.shape[dim]`.
-    - `value` support 2~5D tensors.
-    - `dim` must be valid (0 <= dim < rank(value) - 1).
-
-    Example
-    *******
-    .. code-block:: python
-
-        import torch
-        import triton
-        import triton.language as tl
-        from triton.language.extra.cann.extension import index_put
-
-        @triton.jit
-        def simple_index_put_kernel(value_ptr, index_ptr, dst_ptr):
-            # index tile shape: [2]
-            index_local = tl.arange(0, 2)
-            x1_local = tl.arange(0, 2)[None, :]  # shape=(1,2)
-
-            index_tile = tl.load(index_ptr + index_local)
-            value_tile = tl.load(value_ptr + index_local[:, None]*2 + x1_local)
-
-            index_put(
-                ptr=dst_ptr,
-                index=index_tile,
-                value=value_tile,
-                dim=0,
-                index_boundary=4,
-                end_offset=(2, 2),
-                start_offset=(0, 0),
-                dst_stride=(2, 1)
-            )
-
-        dst = torch.zeros((4,2), device='npu', dtype=torch.float32)
-        value = torch.tensor([[1.,2.], [3.,4.]], device='npu')
-        index = torch.tensor([2, 0], device='npu')
-
-        simple_index_put_kernel[(1,)](value, index, dst)
-        print("IndexPut result:", dst) # ref:[[3.,4.], [0.,0.], [1.,2.], [0.,0.]]
+    :param ptr: The destination tensor pointer (in GM).
+    :type ptr: pointer type
+    :param index: An index to scatter (in UB).
+    :type index: tensor
+    :param value: A value to store (in UB).
+    :type value: tensor
+    :param dim: The dimension to scatter along.
+    :type dim: int
+    :param index_boundary: The upper boundary for index values (must be a compile-time constant).
+    :type index_boundary: int
+    :param end_offset: The offsets of each dimension for the end of the scatter region.
+    :type end_offset: tuple of int
+    :param start_offset: The offsets of each dimension for the start of the scatter region.
+    :type start_offset: tuple of int
+    :param dst_stride: The stride of each dimension of destination tensor.
+    :type dst_stride: tuple of int
     """
 
     import warnings
@@ -155,6 +118,7 @@ def gather_out_to_ub(src: tensor, index: tensor, index_boundary: int, dim: int, 
     along a specified dimension with out-of-bound handling.
 
     Gather operation for different tensor ranks:
+
     1. 1D index gather:
         out[i] = src[start_offset[0] + index[i]]
     2. 2D index gather (0 <= dim < 2):
@@ -170,65 +134,25 @@ def gather_out_to_ub(src: tensor, index: tensor, index_boundary: int, dim: int, 
         3.3 dim = 2
             out[i][j][k] = src[start_offset[0] + i][start_offset[1] + j][start_offset[2] + index[i][j][k]]
 
-    :param src: pointer type, the source tensor pointer (in GM)
-    :param index: tensor, a tensor to gather (in UB)
-    :param index_boundary: int64, the upper boundary for index values
-    :param dim: int32, the dimension to gather along
-    :param src_stride: tuple of int64, the stride of each dimension of src tensor
-    :param end_offset: tuple of int32, the end offsets of each dimension for index tensor
-    :param start_offset: tuple of int32, the start offsets of each dimension for index tensor
-    :param other(Optional): scalar value, the default value when index is out of boundary (in UB)
-    :return: tensor, with the same shape as `index.shape` (in UB)
+    :param src: The source tensor pointer (in GM).
+    :type src: pointer type
+    :param index: A tensor to gather (in UB).
+    :type index: tensor
+    :param index_boundary: The upper boundary for index values.
+    :type index_boundary: int
+    :param dim: The dimension to gather along.
+    :type dim: int
+    :param src_stride: The stride of each dimension of src tensor.
+    :type src_stride: tuple of int
+    :param end_offset: The end offsets of each dimension for index tensor.
+    :type end_offset: tuple of int
+    :param start_offset: The start offsets of each dimension for index tensor.
+    :type start_offset: tuple of int
+    :param other: The default value when index is out of boundary (in UB).
+    :type other: scalar, optional
 
-    Constraints
-    ***********
-    - `src` and `index` must have the same rank.
-    - `src.dtype` only supports `float16`, `bfloat16`, `float32` currently.
-    - `index` must be an integer tensor, with rank between 1 and 5.
-    - `dim` must be valid (0 <= dim < rank(index)).
-    - `other` must be a scalar value.
-    - For every dimension `i` not equal to `dim`, `index.size[i]` <= `src.size[i]`.
-    - The output shape is the same as `index.shape`. If `index` is None, \
-        the output tensor will be an empty tensor with the same shape as `index`.
-
-    Example
-    *******
-    .. code-block:: python
-
-        import torch
-        import triton
-        import triton.language as tl
-        from triton.language.extra.cann.extension import gather_out_to_ub
-
-        @triton.jit
-        def simple_gather_kernel(src_ptr, index_ptr, out_ptr):
-            # index tile shape: [2,2]
-            y0_local = tl.arange(0, 2)[:, None]  # [0,1] rows
-            x1_local = tl.arange(0, 2)[None, :]  # [0,1] cols
-            mask = (y0_local < 2) & (x1_local < 2)
-
-            # Load index tile to UB
-            index = tl.load(index_ptr + y0_local*2 + x1_local, mask)
-
-            # Call gather_out_to_ub: gather values from src along dim=0
-            gathered = gather_out_to_ub(
-                src=src_ptr,
-                index=index,
-                index_boundary=4,
-                dim=0,
-                src_stride=(2, 1),
-                end_offset=(2, 2),
-                start_offset=(0, 0)
-            )
-
-            tl.store(out_ptr + y0_local*2 + x1_local, gathered, mask)
-
-        src = torch.tensor([[1.,2.], [3.,4.], [5.,6.], [7.,8.]], device='npu')
-        index = torch.tensor([[0,1], [2,3]], device='npu')
-        out = torch.empty((2,2), device='npu', dtype=torch.float32)
-
-        simple_gather_kernel[(1,)](src, index, out)
-        print("Gather result:", out)  # ref: [[1.,4.], [5.,8.]]
+    :return: Tensor with the same shape as ``index.shape`` (in UB).
+    :rtype: tensor
     """
 
     def gather_out_to_ub_impl(src: tl.tensor, index: tl.tensor, index_boundary: int, dim: int, src_stride: Tuple,
@@ -282,6 +206,7 @@ def scatter_ub_to_out(ptr: tensor, value: tensor, index: tensor, index_boundary:
     along a specified dimension, with index-boundary checking.
 
     Scatter operation for different tensor ranks:
+
     1. 1D index scatter:
         out[start_offset[0] + index[i]] = value[i]
     2. 2D index scatter (0 <= dim < 2):
@@ -297,61 +222,22 @@ def scatter_ub_to_out(ptr: tensor, value: tensor, index: tensor, index_boundary:
         3.3 dim = 2
             out[start_offset[0] + i][start_offset[1] + j][start_offset[2] + index[i][j][k]] = value[i][j][k]
 
-    :param ptr: pointer type, the destination tensor pointer (in GM)
-    :param value: tensor, a tile value to store (in UB)
-    :param index: tensor, a index to scatter (in UB)
-    :param index_boundary: int64, the upper boundary for index values
-    :param dim: int32, the dimension to scatter along
-    :param dst_stride: tuple of int64, the stride of each dimension of destination tensor
-    :param end_offset: tuple of int32, the end offsets of each dimension for index tensor
-    :param start_offset: tuple of int32, the start offsets of each dimension for index tensor
-
-    Constraints
-    ***********
-    - `ptr`, `index` and `value` must have the same rank.
-    - `ptr.dtype` only supports `float16`, `bfloat16`, `float32` currently.
-    - `index` must be an integer tensor, with rank between 1 and 5.
-    - `dim` must be valid (0 <= dim < rank(index)).
-    - For every dimension `i` not equal to `dim`, `index.size[i]` <= `ptr.size[i]`.
-    - The output shape is the same as `index.shape`. If `index` is None, \
-        the output tensor will be an empty tensor with the same shape as `index`.
-
-    Example
-    *******
-    .. code-block:: python
-
-        import torch
-        import triton
-        import triton.language as tl
-        from triton.language.extra.cann.extension import scatter_ub_to_out
-
-        @triton.jit
-        def simple_scatter_kernel(value_ptr, index_ptr, dst_ptr):
-            # index tile shape: [2,2]
-            y0_local = tl.arange(0, 2)[:, None]  # [0,1] rows
-            x1_local = tl.arange(0, 2)[None, :]  # [0,1] cols
-            mask = (y0_local < 2) & (x1_local < 2)
-
-            value = tl.load(value_ptr + y0_local*2 + x1_local, mask)
-            index = tl.load(index_ptr + y0_local*2 + x1_local, mask)
-
-            scatter_ub_to_out(
-                ptr=dst_ptr,
-                value=value,
-                index=index,
-                index_boundary=4,
-                dim=0,
-                dst_stride=(2, 1),
-                end_offset=(2, 2),
-                start_offset=(0, 0)
-            )
-
-        dst = torch.zeros((4,2), device='npu', dtype=torch.float32)
-        value = torch.tensor([[1.,2.], [3.,4.]], device='npu')
-        index = torch.tensor([[1,2], [3,0]], device='npu')
-
-        simple_scatter_kernel[(1,)](value, index, dst)
-        print("Scatter result:", dst)  # ref:[[0.,4.], [1.,0.], [0.,2.], [3.,0.]]
+    :param ptr: The destination tensor pointer (in GM).
+    :type ptr: pointer type
+    :param value: A tile value to store (in UB).
+    :type value: tensor
+    :param index: An index to scatter (in UB).
+    :type index: tensor
+    :param index_boundary: The upper boundary for index values.
+    :type index_boundary: int
+    :param dim: The dimension to scatter along.
+    :type dim: int
+    :param dst_stride: The stride of each dimension of destination tensor.
+    :type dst_stride: tuple of int
+    :param end_offset: The end offsets of each dimension for index tensor.
+    :type end_offset: tuple of int
+    :param start_offset: The start offsets of each dimension for index tensor.
+    :type start_offset: tuple of int
     """
 
     def scatter_ub_to_out_impl(ptr: tl.tensor, value: tl.tensor, index: tl.tensor, index_boundary: int, dim: int,


### PR DESCRIPTION
## Summary
Refine documentation examples and platform constraints for Triton memory operations.
This change covers four extra memory APIs (`triton.language.gather`, `triton.language.extra.cann.extension.index_put`,
`triton.language.extra.cann.extension.gather_out_to_ub`, `triton.language.extra.cann.extension.scatter_ub_to_out`).
﻿
All example scripts are standardized with the following improvements:
- Rewrite and simplify test logic to eliminate redundant calculation
- Uniform kernel docstring style with clear step-by-step workflow
- Provide self-contained, fully runnable test entries
﻿
Meanwhile, Ascend-specific constraint descriptions are unified and polished to consistent technical English, accurately recording hardware limitations and usage specifications of memory access APIs.

## User Impact
No code behavior change. This PR only updates documentation examples and
constraint metadata.

## Document Render Preview
Example: triton.language.extra.cann.extension.index_put
<img width="950" height="930" alt="image" src="https://github.com/user-attachments/assets/f30edf82-fcd1-4f32-b8c1-3e206162fc4d" />

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
	[rules](https://cbea.ms/git-commit/#why-not-how).
- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
	- [x] This PR does not need a test because it only updates documentation examples and constraint metadata.
	- [ ] I have added tests.
		- `/python/test` for end-to-end tests
- Select one of the following.
	- [x] I have not added any `lit` tests.
	- [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
		including the "tests should be minimal" section. (Usually running Python code
		and using the instructions it generates is not minimal.)
