### PR TITLE
[docs](NFC) mirror enable_auto_blockify env var note to zh

### DIFF
--- a/docs/zh/environment_variable_and_compiler_options_reference.md
+++ b/docs/zh/environment_variable_and_compiler_options_reference.md
@@ -44,7 +44,7 @@ python run_kernel.py
 | **编译控制** | TRITON_COMPILE_ONLY | 0 或未设置 | remote_launch时使用，只编译不运行。 | 0：不启用<br>1：启用 | |
 | **编译控制** | TRITON_DISABLE_FFTS | 0 或未设置 | 是否禁用FFTS。 | 0：启用<br>1：禁用 | |
 | **编译控制** | TRITON_DISABLE_PRECOMPILE | 0 或未设置 | 是否禁用预编译。                                                                                                                                                                                                                                                                                  | 0：启用预编译<br>1：禁用预编译                                                                               | |
-| **运行与调度** | TRITON_ALL_BLOCKS_PARALLEL | 0 或未设置 | 启用或禁用自动根据物理核数优化逻辑核数，仅当逻辑核间可并行时方可启动。当逻辑核数大于物理核数时，启动该优化，则编译器自动调整逻辑核数量为物理核数，减少调度开销；启用后允许grid>65535。限制：triton kernel的逻辑必须对执行顺序不敏感才能开启该选项，否则可能会导致死锁。 | 0：不启用<br>1：启用 | |
+| **运行与调度** | TRITON_ALL_BLOCKS_PARALLEL | 0 或未设置 | 启用或禁用自动根据物理核数优化逻辑核数，仅当逻辑核间可并行时方可启动。当逻辑核数大于物理核数时，启动该优化，则编译器自动调整逻辑核数量为物理核数，减少调度开销；启用后允许grid>65535。限制：triton kernel的逻辑必须对执行顺序不敏感才能开启该选项，否则可能会导致死锁。per-kernel 选项 `enable_auto_blockify`（详见 `architecture_difference.md`）在显式设置时优先于该环境变量；环境变量仅对未设置 `enable_auto_blockify` 的 kernel 起默认值作用。 | 0：不启用<br>1：启用 | |
 | **运行与调度** | TRITON_ENABLE_TASKQUEUE | 0 或未设置 | 是否开启task_queue。 | 0：不启用<br>1：启用 | |
 | **运行与调度** | TRITON_ENABLE_SANITIZER | 0 或未设置 | 是否启用 SANITIZER。 | 0：不启用<br>1：启用 | |
 | **运行与调度** | ENABLE_PRINT_UB_BITS | 0 或未设置 | 打开后可以获取当前UB占用量，给inductor使用。 | 0：不启用<br>1：启用 | |


### PR DESCRIPTION
## Summary

TA MR !1805 (commit `7616dbe3f`) added a clause to the **en** `TRITON_ALL_BLOCKS_PARALLEL` row of `environment_variable_and_compiler_options_reference.md` explaining that the per-kernel `enable_auto_blockify` option (documented in `architecture_difference.md`) takes precedence over the env var. The **zh** equivalent was never updated, so zh readers got the env-var-only view without the resolution-order context.

This PR mirrors the en clause into the zh row, in 中文.

## What changed

- `docs/zh/environment_variable_and_compiler_options_reference.md` — append one sentence to the existing `TRITON_ALL_BLOCKS_PARALLEL` row's description cell (1 line, +1/-1).

## Test plan

- [ ] Render the zh page and visually verify the appended sentence parses cleanly in the table cell
- [ ] Confirm doc-tools / linkcheck passes