### PR TITLE
[docs](NFC) add enable_auto_blockify row to zh compilation table

### DIFF
--- a/docs/zh/migration_guide/architecture_difference.md
+++ b/docs/zh/migration_guide/architecture_difference.md
@@ -173,6 +173,7 @@ tl.load() 和 tl.store()
 | tile_mix_vector_loop                          | CV算子的一个优化项，当前vector可以切几份                        | 默认None；如 [2,4,8]，autotune中可配置                       |
 | tile_mix_cube_loop                            | CV算子一个优化项，当前cube可以切几份      | 默认None；如 [2,4,8]，autotune中可配置                      |
 | auto_blockify_size                            | TRITON_ALL_BLOCKS_PARALLEL优化项，用于指定扩展的左起第一个维度的大小。 | 默认1；如 [2,4,8]，autotune中可配置                       |
+| enable_auto_blockify                          | per-kernel 级别覆盖 `TRITON_ALL_BLOCKS_PARALLEL` 环境变量。显式设为 **true** 或 **false** 时，kernel 按该值生效（忽略环境变量）；未设置（None）时由环境变量决定。优先级：该选项 > 环境变量 > 关。编译期 blockify pass 与运行期 block-count cap 都按此解析后的值生效，二者永远一致。 | 默认 None；可取值 **true** / **false** / None。 |
 
 - 注：优化编译选项在ascend/backend/compiler.py代码中。
 - 注：CV算子表示该算子运算过程中既使用了AI Core又使用了Vector Core。


### PR DESCRIPTION
## Summary

TA MR !1805 (commit `7616dbe3f`) added an `enable_auto_blockify` row to the **en** Compilation Optimization table in `docs/en/migration_guide/architecture_difference.md` (current line 157); the **zh** version of that table never received the corresponding row, so the zh `architecture_difference.md` only documents the older `auto_blockify_size` tunable.

This PR mirrors the en row into zh, in 中文.

## What changed

- `docs/zh/migration_guide/architecture_difference.md` — append one row to the Compilation Optimization table, right after `auto_blockify_size` (+1 line).

## Test plan

- [ ] Render the zh page and visually verify the new row sits naturally in the table
- [ ] Confirm doc-tools / linkcheck passes