### PR TITLE
[PtrAnalysis](fix) Fix the negative index calculate for reinterpret_cast

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
@@ -1208,10 +1208,8 @@ void BlockDataParser::rewriteAddPtr(
                        << constVal.value() << " at dim " << i << "\n";
         });
 
-        Value zero = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
         Value negOffsetVal = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), constVal.value());
-        Value newOffset = rewriter.create<arith::SubIOp>(op.getLoc(), zero, negOffsetVal);
-        offsets[i] = newOffset;
+        offsets[i] = negOffsetVal;
       }
     }
   }

--- a/third_party/ascend/unittest/pytest_ut/test_neg_index.py
+++ b/third_party/ascend/unittest/pytest_ut/test_neg_index.py
@@ -1,0 +1,54 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+
+import pytest
+import triton
+import triton.language as tl
+import time
+import torch
+import torch_npu
+import test_common
+
+
+@triton.jit
+def triton_neg_index_load_kernel(in_ptr, out_ptr, BLOCK_SIZE: tl.constexpr, NEG_INDEX: tl.constexpr):
+    offset = tl.arange(0, BLOCK_SIZE)
+    mask = offset >= NEG_INDEX
+    tmp = tl.load(in_ptr + ((-NEG_INDEX) + offset), mask, other=0.0)
+    tl.store(out_ptr + offset, tmp)
+
+
+def triton_neg_index_load(in_tensor, index):
+    out_tensor = torch.zeros(in_tensor.shape, device=in_tensor.device, dtype=in_tensor.dtype)
+    triton_neg_index_load_kernel[(1,)](in_tensor, out_tensor, in_tensor.numel(), index)
+    return out_tensor
+
+
+def torch_neg_index_load(in_tensor, index):
+    out = torch.zeros(in_tensor.shape, device=in_tensor.device, dtype=in_tensor.dtype)
+    out[index:] = in_tensor[:index]
+    return out
+
+
+def test_neg_index_load():
+    input_data = torch.arange(12, device="npu", dtype=torch.float32)
+    triton_out = triton_neg_index_load(input_data, 6)
+    torch_out = torch_neg_index_load(input_data, 6)


### PR DESCRIPTION
## Summary

This PR fixes **incorrect negative-offset lowering** for block pointer paths in `BlockPtrAnalysis::rewriteAddPtr`. The previous code wrapped the already-negative constant with `0 - negOffsetVal`, which flipped the sign and
produced a wrong positive offset. The fix preserves the negative sign and generates the offset more directly.


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
