### PR TITLE
[ssbuffer](fix) UBUsageOpt should update op in if.

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UBUsageOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UBUsageOptPass.cpp
@@ -603,6 +603,30 @@ std::optional<bool> willCreateCycle(llvm::SmallVectorImpl<Operation *> &willaddO
     return ret;
 }
 
+static void processOpsInblock(Operation *parentOp, int targetId, CVPipeline::ComputeBlockIdManager &bm)
+{
+    // If the parentOp's blockId is the same as every op's id in each of its blocks,
+    // we need to change the ops inside its blocks to targetId as well.
+    int parentBlockId = bm.getBlockIdByOp(parentOp);
+    if (parentBlockId == -1) {
+        return;
+    }
+
+    bool allSame = true;
+    parentOp->walk([&](Operation *op) {
+        auto innerBlockId = bm.getBlockIdByOp(op);
+        if (innerBlockId != -1 && innerBlockId != parentBlockId) {
+            allSame = false;
+            return WalkResult::interrupt();
+        }
+        return WalkResult::advance();
+    });
+
+    if (allSame) {
+        parentOp->walk([&](Operation *op) { bm.updateBlockId(op, targetId); });
+    }
+}
+
 bool applyRecordChange(DenseMap<int, int> &recordChange, DenseMap<int, Operation *> &nodeId2op,
                        const CVPipeline::MemoryDependenceGraph &memGraph, CVPipeline::ComputeBlockIdManager &bm)
 {
@@ -631,6 +655,7 @@ bool applyRecordChange(DenseMap<int, int> &recordChange, DenseMap<int, Operation
         }
 
         for (auto op : willaddOps) {
+            processOpsInblock(op, targetBlockId, bm);
             bm.updateBlockId(op, targetBlockId);
         }
     }


### PR DESCRIPTION
# Main Changes
BugFix: when op in the block is all same block_id, we should update them when update if's block_id.

bug:
```
    scf.if %50 {
      linalg.fill {ssbuffer.block_id = 88 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_1 : bf16) outs(%alloc_6 : memref<16x16xbf16>)
    } {hivm.unlikely_condition, ssbuffer.block_id = 89 : i32}
```
after fix:
```
    scf.if %50 {
      linalg.fill {ssbuffer.block_id = 89 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_1 : bf16) outs(%alloc_6 : memref<16x16xbf16>)
    } {hivm.unlikely_condition, ssbuffer.block_id = 89 : i32}
```

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
