### PR TITLE
[Docs](fix) Optimize APIs constraints & examples for Creation/Scan Ops

### DIFF
--- a/docs/zh/python-api/_ascend_constraints.py
+++ b/docs/zh/python-api/_ascend_constraints.py
@@ -80,12 +80,10 @@ CONSTRAINTS = {
     },
     "triton.language.arange": {
         "constraints": [
-            "DataType: Ascend does not support int32 (hardware limitation).",
-            "start和end必须大于等于0",
-            "end - start < 1048576 (TRITON_MAX_TENSOR_NUMEL)",
-            "start和end必须是编译时常量（tl.constexpr）",
-            "``output_type`` (Ascend extension): Ascend输出类型为uint16，GPU输出类型为int32",
-            "``relaxed_requirement`` (Ascend extension): CUDA要求range=(end-start)必须为2的幂次方，Ascend无此要求",
+            "Arguments must be tl.constexpr of uint or int type (int64 not supported).",
+            "start and end must be greater than or equal to 0.",
+            "end - start < 1048576 (TRITON_MAX_TENSOR_NUMEL), applicable to both NV and Ascend.",
+            "``relaxed_requirement`` (Ascend extension): CUDA requires range=(end-start) to be a power of 2, Ascend has no such requirement.",
         ],
         "example":
         "triton.language.arange",
@@ -108,8 +106,8 @@ CONSTRAINTS = {
     },
     "triton.language.associative_scan": {
         "constraints": [
-            "DataType: Ascend does not support uint16, uint32, uint64 (hardware limitation).",
-            "reverse=True要求tl.load加载数据时对齐，不能使用mask过滤多余数据索引",
+            "DataType: Ascend A2/A3 does not support uint16, uint32, uint64 (hardware limitation).",
+            "reverse=True requires alignment when loading data with tl.load, and mask cannot be used to filter redundant data indices",
         ],
         "example":
         "triton.language.associative_scan",
@@ -208,8 +206,8 @@ CONSTRAINTS = {
     },
     "triton.language.cat": {
         "constraints": [
-            "DataType: Ascend does not support uint16, uint32, uint64 (hardware limitation).",
-            "``can_reorder``: Ascend和GPU都只支持can_reorder=True",
+            "DataType: Ascend A2/A3 does not support uint16, uint32, uint64 (hardware limitation).",
+            "``can_reorder``: Both Ascend and GPU only support can_reorder=True",
         ],
         "example":
         "triton.language.cat",
@@ -257,15 +255,19 @@ CONSTRAINTS = {
     },
     "triton.language.cumprod": {
         "constraints": [
-            "DataType: Ascend does not support uint16, uint32, uint64 (hardware limitation).",
+            "DataType: Ascend A2/A3 does not support uint16, uint32, uint64 (hardware limitation).",
+            "reverse=True requires alignment when loading data with tl.load, and mask cannot be used to filter redundant data indices",
         ],
-        "example": "triton.language.cumprod",
+        "example":
+        "triton.language.cumprod",
     },
     "triton.language.cumsum": {
         "constraints": [
-            "DataType: Ascend does not support uint16, uint32, uint64 (hardware limitation).",
+            "DataType: Ascend A2/A3 does not support uint16, uint32, uint64 (hardware limitation).",
+            "reverse=True requires alignment when loading data with tl.load, and mask cannot be used to filter redundant data indices",
         ],
-        "example": "triton.language.cumsum",
+        "example":
+        "triton.language.cumsum",
     },
     "triton.language.debug_barrier": {
         "example": "triton.language.debug_barrier",
@@ -463,7 +465,7 @@ CONSTRAINTS = {
     },
     "triton.language.full": {
         "constraints": [
-            "DataType: Ascend does not support uint16, uint32, uint64 (hardware limitation).",
+            "DataType: Ascend A2/A3 does not support uint16, uint32, uint64 (hardware limitation).",
         ],
         "example": "triton.language.full",
     },
@@ -907,13 +909,13 @@ CONSTRAINTS = {
     },
     "triton.language.zeros": {
         "constraints": [
-            "DataType: Ascend does not support uint16, uint32, uint64 (hardware limitation).",
+            "DataType: Ascend A2/A3 does not support uint16, uint32, uint64 (hardware limitation).",
         ],
         "example": "triton.language.zeros",
     },
     "triton.language.zeros_like": {
         "constraints": [
-            "DataType: Ascend does not support uint16, uint32, uint64 (hardware limitation).",
+            "DataType: Ascend A2/A3 does not support uint16, uint32, uint64 (hardware limitation).",
         ],
         "example": "triton.language.zeros_like",
     },

--- a/docs/zh/python-api/_examples/triton.language.arange.py
+++ b/docs/zh/python-api/_examples/triton.language.arange.py
@@ -1,5 +1,24 @@
+import torch
+import triton
+import triton.language as tl
+
+
 @triton.jit
-def triton_arange(z, BLOCK: tl.constexpr, START: tl.constexpr, END: tl.constexpr):
+def arange_kernel(output_ptr, BLOCK: tl.constexpr, START: tl.constexpr, END: tl.constexpr):
     off = tl.arange(0, BLOCK)
     val = tl.arange(START, END)
-    tl.store(z + off, val)
+    tl.store(output_ptr + off, val)
+
+
+def test_arange():
+    start = 0
+    end = 128
+    BLOCK = end - start
+    output = torch.zeros(BLOCK, dtype=torch.int32).npu()
+    arange_kernel[(1, )](output, BLOCK=BLOCK, START=start, END=end)
+    expected = torch.arange(start, end, dtype=torch.int32)
+    assert torch.allclose(output.cpu(), expected.cpu())
+
+
+if __name__ == "__main__":
+    test_arange()

--- a/docs/zh/python-api/_examples/triton.language.associative_scan.py
+++ b/docs/zh/python-api/_examples/triton.language.associative_scan.py
@@ -1,30 +1,14 @@
-@triton.jit
-def bitwise_and_fn(a, b):
-    return a & b
+import torch
+import triton
+import triton.language as tl
+
+
+def combine_fn_test(a, b):
+    return a + b
 
 
 @triton.jit
-def bitwise_or_fn(a, b):
-    return a | b
-
-
-@triton.jit
-def bitwise_xor_fn(a, b):
-    return a ^ b
-
-
-@triton.jit
-def minimum_fn(a, b):
-    return tl.minimum(a, b)
-
-
-@triton.jit
-def maximum_fn(a, b):
-    return tl.maximum(a, b)
-
-
-@triton.jit
-def triton_kernel_2d_scan(
+def associative_scan_2d_kernel(
     out_ptr0,
     in_ptr0,
     dim: tl.constexpr,
@@ -33,7 +17,6 @@ def triton_kernel_2d_scan(
     numel_r: tl.constexpr,
     XBLOCK: tl.constexpr,
     RBLOCK: tl.constexpr,
-    combine_fn_name: tl.constexpr,
 ):
     tl.static_assert(numel_x == XBLOCK, "numel_x must be equal to XBLOCK in this kernel")
     tl.static_assert(numel_r == RBLOCK, "numel_r must be equal to RBLOCK in this kernel")
@@ -41,15 +24,25 @@ def triton_kernel_2d_scan(
     idx_r = tl.arange(0, RBLOCK)
     idx = idx_x[:, None] * numel_r + idx_r[None, :]
     x = tl.load(in_ptr0 + idx)
-
-    if combine_fn_name == "maximum_fn":
-        ret = tl.associative_scan(x, axis=dim, reverse=reverse, combine_fn=maximum_fn)
-    elif combine_fn_name == "minimum_fn":
-        ret = tl.associative_scan(x, axis=dim, reverse=reverse, combine_fn=minimum_fn)
-    elif combine_fn_name == "bitwise_or_fn":
-        ret = tl.associative_scan(x, axis=dim, reverse=reverse, combine_fn=bitwise_or_fn)
-    elif combine_fn_name == "bitwise_xor_fn":
-        ret = tl.associative_scan(x, axis=dim, reverse=reverse, combine_fn=bitwise_xor_fn)
-    elif combine_fn_name == "bitwise_and_fn":
-        ret = tl.associative_scan(x, axis=dim, reverse=reverse, combine_fn=bitwise_and_fn)
+    ret = tl.associative_scan(x, axis=dim, reverse=reverse, combine_fn=combine_fn_test)
     tl.store(out_ptr0 + idx, ret)
+
+
+def test_associative_scan_2d():
+    X = 4
+    R = 8
+    dim = 0
+    reverse = False
+
+    x = torch.randn((X, R), dtype=torch.float32).npu()
+    output = torch.zeros_like(x)
+
+    associative_scan_2d_kernel[(1, )](output, x, dim=dim, reverse=reverse, numel_x=X, numel_r=R, XBLOCK=X, RBLOCK=R)
+
+    expected = torch.cumsum(x.cpu(), dim=dim)
+
+    assert torch.allclose(output.cpu(), expected.cpu())
+
+
+if __name__ == "__main__":
+    test_associative_scan_2d()

--- a/docs/zh/python-api/_examples/triton.language.cat.py
+++ b/docs/zh/python-api/_examples/triton.language.cat.py
@@ -1,8 +1,36 @@
+import torch
+import triton
+import triton.language as tl
+
+
 @triton.jit
-def fn_npu_(output_ptr, x_ptr, y_ptr, XB: tl.constexpr):
+def cat_1d_kernel(output_ptr, x_ptr, y_ptr, XB: tl.constexpr):
+    """
+    Concatenate two 1D tensors x and y of length XB into a continuous tensor of length XB*2.
+    """
     idx = tl.arange(0, XB)
     X = tl.load(x_ptr + idx)
     Y = tl.load(y_ptr + idx)
+
     ret = tl.cat(X, Y, can_reorder=True)
+
     oidx = tl.arange(0, XB * 2)
     tl.store(output_ptr + oidx, ret)
+
+
+def test_cat_1d():
+    XB = 8
+
+    x = torch.randn(XB, dtype=torch.float32).npu()
+    y = torch.randn(XB, dtype=torch.float32).npu()
+    output = torch.zeros(XB * 2, dtype=torch.float32).npu()
+
+    cat_1d_kernel[(1, )](output, x, y, XB=XB)
+
+    expected = torch.cat([x.cpu(), y.cpu()], dim=0)
+
+    assert torch.allclose(output.cpu(), expected.cpu())
+
+
+if __name__ == "__main__":
+    test_cat_1d()

--- a/docs/zh/python-api/_examples/triton.language.cumprod.py
+++ b/docs/zh/python-api/_examples/triton.language.cumprod.py
@@ -1,5 +1,10 @@
+import torch
+import triton
+import triton.language as tl
+
+
 @triton.jit
-def triton_kernel_2d(
+def cumprod_2d_kernel(
     out_ptr0,
     in_ptr0,
     dim: tl.constexpr,
@@ -9,6 +14,10 @@ def triton_kernel_2d(
     XBLOCK: tl.constexpr,
     RBLOCK: tl.constexpr,
 ):
+    """
+    Cumulatively product the input tensor (shape numel_x × numel_r) along the specified dimension,
+    writing the result to out_ptr0.
+    """
     tl.static_assert(numel_x == XBLOCK, "numel_x must be equal to XBLOCK in this kernel")
     tl.static_assert(numel_r == RBLOCK, "numel_r must be equal to RBLOCK in this kernel")
     idx_x = tl.arange(0, XBLOCK)
@@ -17,3 +26,26 @@ def triton_kernel_2d(
     x = tl.load(in_ptr0 + idx)
     ret = tl.cumprod(x, axis=dim, reverse=reverse)
     tl.store(out_ptr0 + idx, ret)
+
+
+def test_cumprod_2d():
+    X = 4
+    R = 8
+    dim = 0
+    reverse = False
+
+    x = torch.randn((X, R), dtype=torch.float32).npu()
+    output = torch.zeros_like(x)
+
+    cumprod_2d_kernel[(1, )](output, x, dim=dim, reverse=reverse, numel_x=X, numel_r=R, XBLOCK=X, RBLOCK=R)
+
+    if reverse:
+        expected = torch.flip(torch.cumprod(torch.flip(x.cpu(), [dim]), dim=dim), [dim])
+    else:
+        expected = torch.cumprod(x.cpu(), dim=dim)
+
+    assert torch.allclose(output.cpu(), expected.cpu())
+
+
+if __name__ == "__main__":
+    test_cumprod_2d()

--- a/docs/zh/python-api/_examples/triton.language.cumsum.py
+++ b/docs/zh/python-api/_examples/triton.language.cumsum.py
@@ -1,5 +1,10 @@
+import torch
+import triton
+import triton.language as tl
+
+
 @triton.jit
-def triton_kernel_2d(
+def cumsum_2d_kernel(
     out_ptr0,
     in_ptr0,
     dim: tl.constexpr,
@@ -9,6 +14,10 @@ def triton_kernel_2d(
     XBLOCK: tl.constexpr,
     RBLOCK: tl.constexpr,
 ):
+    """
+    Cumulatively sum the input tensor (shape numel_x × numel_r) along the specified dimension,
+    writing the result to out_ptr0.
+    """
     tl.static_assert(numel_x == XBLOCK, "numel_x must be equal to XBLOCK in this kernel")
     tl.static_assert(numel_r == RBLOCK, "numel_r must be equal to RBLOCK in this kernel")
     idx_x = tl.arange(0, XBLOCK)
@@ -17,3 +26,26 @@ def triton_kernel_2d(
     x = tl.load(in_ptr0 + idx)
     ret = tl.cumsum(x, axis=dim, reverse=reverse)
     tl.store(out_ptr0 + idx, ret)
+
+
+def test_cumsum_2d():
+    X = 4
+    R = 8
+    dim = 0
+    reverse = False
+
+    x = torch.randn((X, R), dtype=torch.float32).npu()
+    output = torch.zeros_like(x)
+
+    cumsum_2d_kernel[(1, )](output, x, dim=dim, reverse=reverse, numel_x=X, numel_r=R, XBLOCK=X, RBLOCK=R)
+
+    if reverse:
+        expected = torch.flip(torch.cumsum(torch.flip(x.cpu(), [dim]), dim=dim), [dim])
+    else:
+        expected = torch.cumsum(x.cpu(), dim=dim)
+
+    assert torch.allclose(output.cpu(), expected.cpu())
+
+
+if __name__ == "__main__":
+    test_cumsum_2d()

--- a/docs/zh/python-api/_examples/triton.language.full.py
+++ b/docs/zh/python-api/_examples/triton.language.full.py
@@ -1,8 +1,37 @@
+import torch
+import triton
+import triton.language as tl
+
+
 @triton.jit
-def fn_f32(output_ptr, XB: tl.constexpr, YB: tl.constexpr, ZB: tl.constexpr):
+def full_2d_kernel(output_ptr, XB: tl.constexpr, YB: tl.constexpr, VALUE: tl.constexpr):
+    """
+    Generate a 2D tensor of shape (XB, YB) with all elements set to VALUE,
+    and store it in row-major order at output_ptr.
+    """
     xidx = tl.arange(0, XB)
     yidx = tl.arange(0, YB)
-    zidx = tl.arange(0, ZB)
-    ret = tl.full((XB, YB, ZB), value=100, dtype=tl.float32)
-    oidx = xidx[:, None, None] * YB * ZB + yidx[None, :, None] * ZB + zidx[None, None, :]
+
+    ret = tl.full((XB, YB), value=VALUE, dtype=tl.float32)
+
+    oidx = xidx[:, None] * YB + yidx[None, :]
+
     tl.store(output_ptr + oidx, ret)
+
+
+def test_full_2d():
+    XB = 4
+    YB = 8
+    VALUE = 100.0
+
+    output = torch.zeros((XB, YB), dtype=torch.float32).npu()
+
+    full_2d_kernel[(1, )](output, XB=XB, YB=YB, VALUE=VALUE)
+
+    expected = torch.full((XB, YB), VALUE, dtype=torch.float32)
+
+    assert torch.allclose(output.cpu(), expected.cpu())
+
+
+if __name__ == "__main__":
+    test_full_2d()

--- a/docs/zh/python-api/_examples/triton.language.zeros.py
+++ b/docs/zh/python-api/_examples/triton.language.zeros.py
@@ -1,10 +1,35 @@
+import torch
+import triton
+import triton.language as tl
+
+
 @triton.jit
-def fn_f32(output_ptr, x_ptr, XB: tl.constexpr, YB: tl.constexpr, ZB: tl.constexpr):
+def zeros_2d_kernel(output_ptr, XB: tl.constexpr, YB: tl.constexpr):
+    """
+    Generate a 2D zero tensor with shape (XB, YB) and store it to output_ptr in row-major order.
+    """
     xidx = tl.arange(0, XB)
     yidx = tl.arange(0, YB)
-    zidx = tl.arange(0, ZB)
-    idx = xidx[:, None, None] * YB * ZB + yidx[None, :, None] * ZB + zidx[None, None, :]
-    X = tl.load(x_ptr + idx)
-    ret = tl.zeros((XB, YB, ZB), dtype=tl.float32)
-    oidx = xidx[:, None, None] * YB * ZB + yidx[None, :, None] * ZB + zidx[None, None, :]
+
+    ret = tl.zeros((XB, YB), dtype=tl.float32)
+
+    oidx = xidx[:, None] * YB + yidx[None, :]
+
     tl.store(output_ptr + oidx, ret)
+
+
+def test_zeros_2d():
+    XB = 4
+    YB = 8
+
+    output = torch.zeros((XB, YB), dtype=torch.float32).npu()
+
+    zeros_2d_kernel[(1, )](output, XB=XB, YB=YB)
+
+    expected = torch.zeros((XB, YB), dtype=torch.float32)
+
+    assert torch.allclose(output.cpu(), expected.cpu())
+
+
+if __name__ == "__main__":
+    test_zeros_2d()

--- a/docs/zh/python-api/_examples/triton.language.zeros_like.py
+++ b/docs/zh/python-api/_examples/triton.language.zeros_like.py
@@ -1,10 +1,38 @@
+import torch
+import triton
+import triton.language as tl
+
+
 @triton.jit
-def fn_npu_(output_ptr, x_ptr, XB: tl.constexpr, YB: tl.constexpr, ZB: tl.constexpr):
+def zeros_like_2d_kernel(output_ptr, x_ptr, XB: tl.constexpr, YB: tl.constexpr):
+    """
+    Load the input tensor X, generate a zero tensor with the same shape, and store it to output_ptr.
+    """
     xidx = tl.arange(0, XB)
     yidx = tl.arange(0, YB)
-    zidx = tl.arange(0, ZB)
-    idx = xidx[:, None, None] * YB * ZB + yidx[None, :, None] * ZB + zidx[None, None, :]
+
+    idx = xidx[:, None] * YB + yidx[None, :]
+
     X = tl.load(x_ptr + idx)
+
     ret = tl.zeros_like(X)
-    oidx = xidx[:, None, None] * YB * ZB + yidx[None, :, None] * ZB + zidx[None, None, :]
-    tl.store(output_ptr + oidx, ret)
+
+    tl.store(output_ptr + idx, ret)
+
+
+def test_zeros_like_2d():
+    XB = 4
+    YB = 8
+
+    x = torch.randn((XB, YB), dtype=torch.float32).npu()
+    output = torch.zeros_like(x)
+
+    zeros_like_2d_kernel[(1, )](output, x, XB=XB, YB=YB)
+
+    expected = torch.zeros_like(x.cpu())
+
+    assert torch.allclose(output.cpu(), expected.cpu())
+
+
+if __name__ == "__main__":
+    test_zeros_like_2d()


### PR DESCRIPTION
## Summary
Refine documentation examples and platform constraints for Triton creation operations and scan operatitons.
This change covers seven core APIs (`arange/full/zeros/zeros_like/associative_scan/cumsum/cumprod/cat`).
﻿
All example scripts are standardized with the following improvements:
- Rewrite and simplify test logic to eliminate redundant calculation
- Uniform kernel docstring style with clear step-by-step workflow
- Provide self-contained, fully runnable test entries
﻿
Meanwhile, Ascend-specific constraint descriptions are unified and polished to consistent technical English, accurately recording hardware limitations and usage specifications of those APIs.

## User Impact
No code behavior change. This PR only updates documentation examples and
constraint metadata.

## Document Render Preview
Example: triton.language.zeros

