### PR TITLE
[ci](test) verify upstream restricted files label

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 default_stages: [pre-commit, pre-push, manual]
+# Upstream restricted-files labeler verification.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0


### PR DESCRIPTION
## Purpose
Verify that the upstream `pull_request_target` labeler applies `restricted-files` when a PR changes a file outside the allowlist.

## Expected result
The PR should automatically receive the `restricted-files` label because it changes `.pre-commit-config.yaml`.
