### PR TITLE
[WIP]feat: add sub pass registrations and NPUOptions fields for buffer count management

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -233,6 +233,17 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
             metadata["disable_auto_inject_block_sync"] = True
             ascend.passes.ttir.add_dynamic_cv_pipeline(pm, compile_on_910_95)
 
+        # ascend.passes.ttir.pre_check_available(pm)
+        # ascend.passes.ttir.standardize_op(pm)
+        # ascend.passes.ttir.plan_compute_block(pm)
+        # ascend.passes.ttir.compute_block_opt(pm)
+        # ascend.passes.ttir.split_dataflow(pm)
+        # ascend.passes.ttir.analyze_data_flow(pm)
+        # ascend.passes.ttir.separate_memory_from_compute(pm)
+        # ascend.passes.ttir.alloc_multi_cache(pm)
+        # ascend.passes.ttir.add_control_flow_condition(pm)
+        # ascend.passes.ttir.remove_ssbuf_attr(pm)
+
         _intra_val = metadata.get("intra_cache_num")
         if _intra_val is not None:
             ascend.passes.ttir.set_buffer_count("INTRA", _intra_val)

--- a/third_party/ascend/triton_ascend.cc
+++ b/third_party/ascend/triton_ascend.cc
@@ -23,6 +23,11 @@
 
 #include "ascend/include/DynamicCVPipeline/Passes.h"
 #include "ascend/include/DynamicCVPipeline/Common/BufferCountManager.h"
+#include "ascend/include/DynamicCVPipeline/AllocMultiCache.h"
+#include "ascend/include/DynamicCVPipeline/AddControlFlowCondition.h"
+#include "ascend/include/DynamicCVPipeline/SplitDataflowPass.h"
+#include "ascend/include/DynamicCVPipeline/SeparateMemoryFromComputePass.h"
+#include "ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h"
 // todo: this code will be removed in version 530.
 #include "ascend/include/TritonAffinityOpt/Passes.h"
 
@@ -400,6 +405,27 @@ void init_triton_ascend_passes_ttir(py::module &&m) {
           mlir::triton::BufferCountManager::DepType::LoadStore, count);
     }
   });
+
+  m.def("pre_check_available", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::createPreCheckAvailablePass());});
+  m.def("standardize_op", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::createStandardizeOpPass());});
+  m.def("plan_compute_block", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::createPlanComputeBlockPass());});
+  m.def("compute_block_opt", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::createComputeBlockOptPass());});
+  m.def("split_dataflow", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::createSplitDataflowPass());});
+  m.def("analyze_data_flow", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::createAnalyzeDataFlowPass());});
+  m.def("separate_memory_from_compute", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::createSeparateMemoryFromComputePass());});
+  m.def("alloc_multi_cache", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::createAllocMultiCachePass());});
+  m.def("add_control_flow_condition", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::createAddControlFlowConditionPass());});
+  m.def("remove_ssbuf_attr", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::createRemoveSsbufAttrPass());});
 }
 
 #if TRITON_ASCEND_HAS_INPROC_COSTMODEL


### PR DESCRIPTION
cherry-pick this PR to add sub-pass registrations to your code

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
