### PR TITLE
[ssbuffer](fix) ancestor walk for checking forOp ssbuffer.main_loop

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
@@ -83,16 +83,39 @@ static bool forOpHasMainLoopAttr(scf::ForOp forOp)
     return terminator && terminator->hasAttr("ssbuffer.main_loop");
 }
 
-/// Check if a sync op's direct parent has ssbuffer.main_loop attribute
+/// Check if a sync op's ancestor chain contains a scf::ForOp with ssbuffer.main_loop attribute
 static bool parentOpHasMainLoopAttr(Operation *syncOp)
 {
     if (!syncOp) { return false; }
-    Operation *parent = syncOp->getParentOp();
-    if (!parent) { return false; }
-    if (auto forOp = dyn_cast<scf::ForOp>(parent)) {
-        return forOpHasMainLoopAttr(forOp);
+    for (Operation *parent = syncOp->getParentOp(); parent; parent = parent->getParentOp()) {
+        if (auto forOp = dyn_cast<scf::ForOp>(parent)) {
+            return forOpHasMainLoopAttr(forOp);
+        }
     }
     return false;
+}
+
+/// Walk up the ancestor chain to find the nearest enclosing scf::ForOp
+static scf::ForOp findEnclosingForOp(Operation *op)
+{
+    for (Operation *parent = op->getParentOp(); parent; parent = parent->getParentOp()) {
+        if (auto forOp = dyn_cast<scf::ForOp>(parent)) {
+            return forOp;
+        }
+    }
+    return nullptr;
+}
+
+/// Walk up to find the first ancestor op that lives directly in the forOp body,
+/// to get a safe insertion point for condition computation.
+static Operation *findAnchorInForBody(Operation *op, scf::ForOp forOp)
+{
+    for (Operation *parent = op->getParentOp(); parent && parent != forOp.getOperation();
+         parent = parent->getParentOp()) {
+        if (parent->getParentOp() == forOp.getOperation())
+            return parent;
+    }
+    return op; // fallback: op itself is directly in forOp body
 }
 
 // --- Operation search helpers ---
@@ -857,15 +880,17 @@ static int addPollingControlFlow(DenseMap<int, TransferGroupInfo> &groups)
     for (auto &p : groups) {
         TransferGroupInfo &g = p.second;
 
-        // Get sender's scf.for
-        Operation *senderWaitParent = g.senderChain.waitOp->getParentOp();
-        scf::ForOp senderForOp = cast<scf::ForOp>(senderWaitParent);
+        // Get sender's enclosing scf.for (walk up past scf.if wrappers)
+        scf::ForOp senderForOp = findEnclosingForOp(g.senderChain.waitOp);
+        if (!senderForOp) { return -1; }
 
         int senderBid = getBlockId(g.senderChain.waitOp);
         int senderTid = getTransferId(g.senderChain.waitOp);
 
-        // Insert polling condition at sender waitOp's position
-        OpBuilder senderCondBuilderForInsert(senderForOp.getBody(), Block::iterator(g.senderChain.waitOp));
+        // Insert polling condition before the anchor op in forOp body
+        // (walk up past scf.if wrappers to find direct child of forOp body)
+        Operation *senderAnchor = findAnchorInForBody(g.senderChain.waitOp, senderForOp);
+        OpBuilder senderCondBuilderForInsert(senderForOp.getBody(), Block::iterator(senderAnchor));
         Value senderCond = createPollingCondition(senderForOp, senderCondBuilderForInsert, senderBid, senderTid);
         OpBuilder senderBuilder(senderForOp.getBody()->getTerminator());
 
@@ -878,21 +903,21 @@ static int addPollingControlFlow(DenseMap<int, TransferGroupInfo> &groups)
 
         // Process receiver chain (may use different scf.for) (isProducer=false)
         if (g.receiverChain.waitOp) {
-            Operation *receiverWaitParent = g.receiverChain.waitOp->getParentOp();
+            scf::ForOp receiverForOp = findEnclosingForOp(g.receiverChain.waitOp);
 
-            if (receiverWaitParent == senderWaitParent) {
+            if (receiverForOp == senderForOp) {
                 // Use the same cond
                 if (processTransferChain(g.receiverChain, senderCond,
                                          g.receiverInputBuffer, g.receiverOutputBuffer,
                                          g.outputFlag, false, senderBuilder) != 0) {
                     return -1;
                 }
-            } else {
+            } else if (receiverForOp) {
                 // Receiver uses a different scf.for, create new cond
-                scf::ForOp receiverForOp = cast<scf::ForOp>(receiverWaitParent);
                 int receiverBid = getBlockId(g.receiverChain.waitOp);
                 int receiverTid = getTransferId(g.receiverChain.waitOp);
-                OpBuilder receiverCondBuilderForInsert(receiverForOp.getBody(), Block::iterator(g.receiverChain.waitOp));
+                Operation *receiverAnchor = findAnchorInForBody(g.receiverChain.waitOp, receiverForOp);
+                OpBuilder receiverCondBuilderForInsert(receiverForOp.getBody(), Block::iterator(receiverAnchor));
                 Value receiverCond = createPollingCondition(receiverForOp, receiverCondBuilderForInsert, receiverBid, receiverTid);
                 OpBuilder receiverBuilder(receiverForOp.getBody()->getTerminator());
                 if (processTransferChain(g.receiverChain, receiverCond,


### PR DESCRIPTION
…ow for scf.if-wrapped ops

Commit 103fa734 fixed parentOpHasMainLoopAttr to walk the ancestor chain when checking for ssbuffer.main_loop, but addPollingControlFlow still used cast<scf::ForOp>(getParentOp()) which crashes when wait ops are nested inside scf.if blocks within scf.for. Also the OpBuilder insertion point used the nested waitOp's iterator directly, causing cross-block iterator violation.

Fixes:
- parentOpHasMainLoopAttr: walk ancestor chain (from 103fa734)
- findEnclosingForOp: new helper to find enclosing scf::ForOp
- findAnchorInForBody: new helper for safe insertion point in forOp body
- addPollingControlFlow: use findEnclosingForOp + findAnchorInForBody

Verified with interCoreBufNum=2: all 3 steps complete successfully.

Co-Authored-By: DeLong code

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
