### PR TITLE
[ssbuffer](fix) Resolve iter_arg deadlock and compilation problems

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition.h
@@ -36,10 +36,10 @@
 namespace mlir {
 namespace triton {
 
-// Indicates the relationship between a tensor iter_args and ssbuffer.if in the main_loop
+// Indicates the relationship between a tensor iter_arg and ssbuffer.if in the main_loop
 struct TensorIterArgIfOpRelation {
   Value iterArg;
-  llvm::SmallVector<scf::IfOp> producers;
+  scf::IfOp producer;
   llvm::SmallVector<scf::IfOp> consumers;
 };
 
@@ -63,9 +63,6 @@ struct ControlFlowConditionInfo {
   llvm::DenseMap<scf::ForOp, llvm::SmallVector<TensorIterArgIfOpRelation>> tensorIterArgDepsMap;
   // Used to record the index of the control condition variable for the newly created iter_args for tensor iter_args
   llvm::DenseMap<scf::ForOp, llvm::DenseMap<Value, SmallVector<int>>> tensorIterArgIndicesMap;
-  
-  // Record each ifOp as the variables that need to be controlled when it acts as a consumer or a producer
-  llvm::DenseMap<scf::IfOp, TensorIterArgIfOpVars> tensorIterArgIfOpVars;
   
   // unique counter value for each ifblock
   llvm::DenseMap<scf::IfOp, Value> cntArgs;

--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.h
@@ -176,6 +176,8 @@ private:
     DenseMap<Value, Value> controlVarToLatestValue;
     SmallVector<Value> currentUsedVars;
     ControlFlowConditionInfo *info = nullptr;
+    // Record each ifOp as the variables that need to be controlled when it acts as a consumer or a producer
+    llvm::DenseMap<scf::IfOp, TensorIterArgIfOpVars> tensorIterArgIfOpVars;
 };
 
 std::unique_ptr<OperationPass<ModuleOp> > createUpdateConditionInfoPass();

--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.h
@@ -101,6 +101,17 @@ private:
       DenseMap<Operation *, int> &ifOpIndex,
       DenseMap<Value, SmallVector<Value>> &crossDeps);
 
+  // Calculate factor based on iteration dependencies (tensor iter_args dependencies)
+  // For iter deps: consumer and producer are IfOps within the same forOp
+  // Returns {maxRequiredBuffers, maxX} where:
+  //   - maxRequiredBuffers: maximum (m - n + 1) across all dependencies
+  //   - maxX: the x value corresponding to maxRequiredBuffers
+  //   - returns {-1, -1} on error
+  std::pair<int, int> calculateIterDepsFactor(
+      scf::ForOp forOp,
+      SmallVector<scf::IfOp> &ifOps,
+      DenseMap<Operation *, int> &ifOpIndex);
+
   // Extend for loop iteration count
   scf::ForOp extendForOpIterationCount(scf::ForOp oldForOp, int ifCount,
                                        int requiredBuffers, int x,

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
@@ -805,6 +805,9 @@ int UpdateConditionInfoPass::collectIntraCoreOutputConditions(
 // Build the ifOp variable mapping for the tensor iter_args
 int UpdateConditionInfoPass::buildTensorIterArgIfOpVarMap(scf::ForOp forOp)
 {
+  // Clear any previous data
+  tensorIterArgIfOpVars.clear();
+  
   if (!info->tensorIterArgDepsMap.count(forOp) || !info->tensorIterArgIndicesMap.count(forOp)) {
     LDBG("Skip buildTensorIterArgIfOpVarMap: no tensor iter_args info for this forOp\n");
     return UPDATE_CONDITION_INFO_SUCCESS;
@@ -839,10 +842,10 @@ int UpdateConditionInfoPass::buildTensorIterArgIfOpVarMap(scf::ForOp forOp)
       consumerToVar[consumer] = var;
     }
     
-    // Add all the variables of the consumers that depend on each producer
-    for (scf::IfOp producer : relation.producers) {
+    // Add all the variables of the consumers that depend on the producer
+    if (relation.producer) {
       for (auto &[consumer, var] : consumerToVar) {
-        producerVars[producer].insert(var);
+        producerVars[relation.producer].insert(var);
       }
     }
     
@@ -854,14 +857,14 @@ int UpdateConditionInfoPass::buildTensorIterArgIfOpVarMap(scf::ForOp forOp)
   
   // Convert the temporary data structure to tensorIfOpVarMap
   for (auto &[producer, vars] : producerVars) {
-    auto &ifOpVars = info->tensorIterArgIfOpVars[producer];
+    auto &ifOpVars = tensorIterArgIfOpVars[producer];
     for (Value var : vars) {
       ifOpVars.producerVars.push_back(var);
     }
   }
   
   for (auto &[consumer, vars] : consumerVars) {
-    auto &ifOpVars = info->tensorIterArgIfOpVars[consumer];
+    auto &ifOpVars = tensorIterArgIfOpVars[consumer];
     for (Value var : vars) {
       ifOpVars.consumerVars.push_back(var);
     }
@@ -875,11 +878,11 @@ void UpdateConditionInfoPass::collectTensorIterArgInputConditions(
     SmallVector<Value> &conditions, DenseSet<Value> &usedVarsSet,
     DenseMap<Value, VarUpdateType> &varUpdateTypes)
 {
-  if (!info->tensorIterArgIfOpVars.count(ifOp)) {
+  if (!tensorIterArgIfOpVars.count(ifOp)) {
     return;
   }
 
-  auto &ifOpVars = info->tensorIterArgIfOpVars[ifOp];
+  auto &ifOpVars = tensorIterArgIfOpVars[ifOp];
   for (Value var : ifOpVars.consumerVars) {
     Value varToUse = var;
     auto latestIt = controlVarToLatestValue.find(var);
@@ -902,11 +905,11 @@ void UpdateConditionInfoPass::collectTensorIterArgOutputConditions(
     SmallVector<Value> &conditions, DenseSet<Value> &usedVarsSet,
     DenseMap<Value, VarUpdateType> &varUpdateTypes)
 {
-  if (!info->tensorIterArgIfOpVars.count(ifOp)) {
+  if (!tensorIterArgIfOpVars.count(ifOp)) {
     return;
   }
 
-  auto &ifOpVars = info->tensorIterArgIfOpVars[ifOp];
+  auto &ifOpVars = tensorIterArgIfOpVars[ifOp];
   for (Value var : ifOpVars.producerVars) {
     Value varToUse = var;
     auto latestIt = controlVarToLatestValue.find(var);
@@ -1308,11 +1311,29 @@ int UpdateConditionInfoPass::combineConditions(ModuleOp module, Value crossCoreC
     info->cntArgs[newIfOp] = counter;
   }
 
+  // Update mappings that refer to the old ifOp BEFORE erasing it
   // Update the tensorIterArgIfOpVars mapping
-  if (info->tensorIterArgIfOpVars.count(ifOp)) {
-    auto ifOpVars = info->tensorIterArgIfOpVars[ifOp];
-    info->tensorIterArgIfOpVars.erase(ifOp);
-    info->tensorIterArgIfOpVars[newIfOp] = ifOpVars;
+  if (tensorIterArgIfOpVars.count(ifOp)) {
+    auto ifOpVars = tensorIterArgIfOpVars[ifOp];
+    tensorIterArgIfOpVars.erase(ifOp);
+    tensorIterArgIfOpVars[newIfOp] = ifOpVars;
+  }
+  
+  // Update tensorIterArgDepsMap with new ifOp
+  if (info->tensorIterArgDepsMap.count(forOp)) {
+    auto &depsVec = info->tensorIterArgDepsMap[forOp];
+    for (auto &relation : depsVec) {
+      // Update producer ifOp - use pointer comparison
+      if (relation.producer.getOperation() == ifOp.getOperation()) {
+        relation.producer = newIfOp;
+      }
+      // Update consumer ifOps
+      for (auto &consumerIfOp : relation.consumers) {
+        if (consumerIfOp.getOperation() == ifOp.getOperation()) {
+          consumerIfOp = newIfOp;
+        }
+      }
+    }
   }
 
   updateControlVarToLatestValue(newIfOp, ifOp, hasCounter, counter);

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateForOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateForOps.cpp
@@ -448,6 +448,7 @@ LogicalResult UpdateForOpsPass::insertInterCorePipeS(ModuleOp module)
 // Analyze the producer/consumer relationship between the tensor type iter_args in the main_loop and ssbuffer.if
 LogicalResult UpdateForOpsPass::analyzeTensorIterArgDependencies(ModuleOp module, ControlFlowConditionInfo *info)
 {
+  bool failed = false;
   module.walk([&](Operation *op) -> WalkResult {
     if (!op->hasAttr(kSsbufferMainLoop)) {
       return WalkResult::advance();
@@ -455,6 +456,7 @@ LogicalResult UpdateForOpsPass::analyzeTensorIterArgDependencies(ModuleOp module
     auto forOp = dyn_cast<scf::ForOp>(op);
     if (!forOp) {
       LDBG("[Error]: op with ssbuffer.main_loop is not a scf::ForOp\n");
+      failed = true;
       return WalkResult::interrupt();
     }
 
@@ -466,7 +468,7 @@ LogicalResult UpdateForOpsPass::analyzeTensorIterArgDependencies(ModuleOp module
       }
 
       LDBG("Found tensor type iter_arg: " << iterArg << "\n");
-      llvm::SmallVector<scf::IfOp> producerIfOps;
+      scf::IfOp producerIfOp = nullptr;
       llvm::SmallVector<scf::IfOp> consumerIfOps;
 
       for (auto &use : iterArg.getUses()) {
@@ -500,47 +502,61 @@ LogicalResult UpdateForOpsPass::analyzeTensorIterArgDependencies(ModuleOp module
           }
         }
 
-        // Check current status of ifOp
-        bool inProducer = llvm::is_contained(producerIfOps, ifOp);
-        bool inConsumer = llvm::is_contained(consumerIfOps, ifOp);
-
-        if (!inProducer && !inConsumer) {
-          // First time seeing this ifOp
-          if (isProducer) {
-            producerIfOps.push_back(ifOp);
-            LDBG("  Found producer ifOp (first time): " << ifOp << "\n");
-          } else {
-            consumerIfOps.push_back(ifOp);
-            LDBG("  Found consumer ifOp (first time): " << ifOp << "\n");
+        // Check and update status of ifOp
+        if (isProducer) {
+          if (producerIfOp && producerIfOp != ifOp) {
+            // Found a different producer ifOp! This is an error.
+            LDBG("[Error]: tensor iter_arg " << iterArg << " has multiple different producers!\n");
+            LDBG("Existing producer: " << producerIfOp << "\n");
+            LDBG("New producer: " << ifOp << "\n");
+            failed = true;
+            return WalkResult::interrupt();
           }
-        } else if (inConsumer && isProducer) {
-          // Was consumer, now need to upgrade to producer (this is the only update case)
-          consumerIfOps.erase(llvm::find(consumerIfOps, ifOp));
-          producerIfOps.push_back(ifOp);
-          LDBG("  ifOp was consumer, now updated to producer: " << ifOp << "\n");
+          if (!producerIfOp) {
+            // First producer, or upgrade from consumer
+            auto it = llvm::find(consumerIfOps, ifOp);
+            if (it != consumerIfOps.end()) {
+              consumerIfOps.erase(it);
+              LDBG("This ifOp was consumer, now updated to producer: " << ifOp << "\n");
+            } else {
+              LDBG("Found producer ifOp (first time): " << ifOp << "\n");
+            }
+            producerIfOp = ifOp;
+          }
+          // Else: already is this producer, do nothing
+        } else {
+          // isConsumer
+          if (producerIfOp == ifOp) {
+            // Already a producer, even if current use is consumer, do nothing
+            continue;
+          }
+          if (!llvm::is_contained(consumerIfOps, ifOp)) {
+            consumerIfOps.push_back(ifOp);
+            LDBG("Found consumer ifOp (first time): " << ifOp << "\n");
+          }
+          // Else: already a consumer, do nothing
         }
-        // Note: if already in producer, do nothing even if current use is consumer
       }
       // Check: must have both producers AND consumers
-      if (producerIfOps.empty() || consumerIfOps.empty()) {
-        LDBG("[Warning]: tensor iter_arg " << iterArg << " has only "
-                                           << (producerIfOps.empty() ? "consumers" : "producers") << ", skipped\n");
+      if (!producerIfOp || consumerIfOps.empty()) {
+        LDBG("tensor iter_arg " << iterArg << " has only "
+                                           << (!producerIfOp ? "consumers" : "producers") << ", skipped\n");
         continue;
       }
       TensorIterArgIfOpRelation relation;
       relation.iterArg = iterArg;
-      relation.producers = producerIfOps;
+      relation.producer = producerIfOp;
       relation.consumers = consumerIfOps;
 
       info->tensorIterArgDepsMap[forOp].push_back(relation);
-      LDBG("Recorded tensor iter_arg dependency: " << iterArg << " has " << relation.producers.size() << " producers, "
+      LDBG("Recorded tensor iter_arg dependency: " << iterArg << " has 1 producer, "
                                                    << relation.consumers.size() << " consumers\n");
     }
 
     return WalkResult::advance();
   });
 
-  return success();
+  return failed ? failure() : success();
 }
 
 void UpdateForOpsPass::runOnOperation() {

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.cpp
@@ -422,6 +422,25 @@ std::pair<int, int> UpdateLoopIterTimesPass::calculateFactor(scf::ForOp forOp)
     }
   }
 
+  // Step3: Calculate factor based on iteration dependencies (tensor iter_args dependencies)
+  bool hasIterDeps = info->tensorIterArgDepsMap.count(forOp) &&
+                     !info->tensorIterArgDepsMap[forOp].empty();
+
+  if (hasIterDeps) {
+    LDBG("find cross-iteration dependency, size: " << info->tensorIterArgDepsMap[forOp].size());
+    auto [iterRequiredBuffers, iterX] = calculateIterDepsFactor(forOp, ifOps, ifOpIndex);
+    if (iterRequiredBuffers == -1 || iterX == -1) {
+      LDBG("calculateIterDepsFactor failed!");
+      return {-1, -1};
+    }
+    // Compare iterRequiredBuffers/iterX vs maxRequiredBuffers/maxX
+    // Take the larger fraction
+    if (iterRequiredBuffers * maxX > maxRequiredBuffers * iterX) {
+      maxRequiredBuffers = iterRequiredBuffers;
+      maxX = iterX;
+    }
+  }
+
   return {maxRequiredBuffers, maxX};
 }
 
@@ -651,6 +670,79 @@ std::pair<int, int> UpdateLoopIterTimesPass::calculateCrossDepsFactor(
     if (requiredBuffers * maxX > maxRequiredBuffers * x) {
       maxRequiredBuffers = requiredBuffers;
       maxX = x;
+    }
+  }
+
+  return {maxRequiredBuffers, maxX};
+}
+
+// calculateIterDepsFactor computes the buffer factor based on iteration dependencies
+// For iter deps: consumer and producer are IfOps within the same forOp
+// Core idea: iteration dependencies are special - consume first, then produce
+// So if consumer ifOp (m) and producer ifOp (n) have dependency,
+// we need (n - m) buffers to support the loop extension
+// This function iterates all dependencies from tensorIterArgDepsMap and finds the maximum required buffer count
+std::pair<int, int> UpdateLoopIterTimesPass::calculateIterDepsFactor(
+    scf::ForOp forOp,
+    SmallVector<scf::IfOp> &ifOps,
+    DenseMap<Operation *, int> &ifOpIndex)
+{
+  int maxRequiredBuffers = 1;
+  int maxX = 1;
+
+  // Check if this forOp has iteration dependencies
+  if (!info->tensorIterArgDepsMap.count(forOp)) {
+    return {maxRequiredBuffers, maxX};
+  }
+
+  auto &iterArgDepsVec = info->tensorIterArgDepsMap[forOp];
+
+  // Iterate all tensor iter_args dependencies in this forOp
+  // tensorIterArgDepsMap now stores a SmallVector of TensorIterArgIfOpRelation
+  for (TensorIterArgIfOpRelation &relation : iterArgDepsVec) {
+    scf::IfOp producerIfOp = relation.producer;
+    llvm::SmallVector<scf::IfOp> &consumerIfOps = relation.consumers;
+
+    // Skip if no producer or consumers
+    if (!producerIfOp || consumerIfOps.empty()) {
+      continue;
+    }
+
+    // x is the number of producer buffers (1 for iteration dependencies)
+    int x = 1;
+
+    // Get producer IfOp index (n)
+    auto producerIt = ifOpIndex.find(producerIfOp.getOperation());
+    if (producerIt == ifOpIndex.end()) {
+      LDBG("Producer IfOp not found in ifOps list!");
+      return {-1, -1};
+    }
+    int n = producerIt->second;
+
+    // For each consumer IfOp, find its index (m)
+    // Calculate requiredBuffers = n - m (consume first, then produce)
+    for (scf::IfOp consumerIfOp : consumerIfOps) {
+      // Find consumer IfOp index in ifOps list
+      auto consumerIt = ifOpIndex.find(consumerIfOp.getOperation());
+      if (consumerIt == ifOpIndex.end()) {
+        LDBG("Consumer IfOp not found in ifOps list!");
+        return {-1, -1};
+      }
+      int m = consumerIt->second;
+
+      if (n <= m) {
+        LDBG("Producer IfOp index (n) is not greater than consumer IfOp index (m)!");
+        return {-1, -1};
+      }
+      int requiredBuffers = n - m;
+      LDBG("consumerIfOp : " << consumerIfOp);
+      LDBG("consumer m: " << m << ", n: " << n);
+      LDBG("requiredBuffers: " << requiredBuffers);
+
+      if (requiredBuffers * maxX > maxRequiredBuffers * x) {
+        maxRequiredBuffers = requiredBuffers;
+        maxX = x;
+      }
     }
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
@@ -46,6 +46,7 @@ static constexpr llvm::StringLiteral interceptrFunc[] {
     "bwd_qkv_kernel",
     "parallel_nsa_compression_fwd_kernel",
     "parallel_nsa_compression_bwd_kernel_dq",
+    "chunkwise_fwd_kernel",
     "chunk_dplr_fwd_kernel_h",
 };
 

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/iter_args_has_multi_producer.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/iter_args_has_multi_producer.mlir
@@ -1,0 +1,48 @@
+// RUN: triton-opt --update-for-ops --debug %s 2>&1 | FileCheck %s
+
+// Test for tensor iter_arg with two if producers - should fail with error
+// CHECK: [Error]: tensor iter_arg <block argument> of type 'tensor<64x64xf32>' at index: 1 has multiple different producers!
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_iter_args_multi_producer(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %cst = arith.constant {ssbuffer.block_id = 1} 0.0 : f32
+    %c0 = arith.constant {ssbuffer.block_id = 1} 0 : i32
+    %c1 = arith.constant {ssbuffer.block_id = 1} 1 : i32
+    %c5 = arith.constant {ssbuffer.block_id = 1} 5 : i32
+    %true = arith.constant true
+    %false = arith.constant false
+    
+    scope.scope : () -> () {
+      // Create initial tensor
+      %tensor_init = tensor.empty() {ssbuffer.block_id = 1} : tensor<64x64xf32>
+      %filled_tensor = linalg.fill {ssbuffer.block_id = 1} ins(%cst : f32) outs(%tensor_init : tensor<64x64xf32>) -> tensor<64x64xf32>
+      
+      // Loop with tensor iter_arg
+      %result = scf.for %i = %c0 to %c5 step %c1 iter_args(%iter_arg = %filled_tensor) -> (tensor<64x64xf32>) : i32 {
+        // First if that yields the tensor
+        %val1 = scf.if %true -> (tensor<64x64xf32>) {
+          %new_tensor1 = tensor.empty() {ssbuffer.block_id = 2} : tensor<64x64xf32>
+          %filled1 = linalg.fill {ssbuffer.block_id = 2} ins(%cst : f32) outs(%new_tensor1 : tensor<64x64xf32>) -> tensor<64x64xf32>
+          scf.yield %filled1 : tensor<64x64xf32>
+        } else {
+          scf.yield %iter_arg : tensor<64x64xf32>
+        } {ssbuffer.if = 2 : i32}
+        
+        // Second if that also yields the tensor
+        %val2 = scf.if %false -> (tensor<64x64xf32>) {
+          %new_tensor2 = tensor.empty() {ssbuffer.block_id = 3} : tensor<64x64xf32>
+          %filled2 = linalg.fill {ssbuffer.block_id = 3} ins(%cst : f32) outs(%new_tensor2 : tensor<64x64xf32>) -> tensor<64x64xf32>
+          scf.yield %filled2 : tensor<64x64xf32>
+        } else {
+          scf.yield %iter_arg : tensor<64x64xf32>
+        } {ssbuffer.if = 3 : i32}
+        
+        // Yield from loop
+        scf.yield %val2 : tensor<64x64xf32>
+      } {ssbuffer.block_id = 10, ssbuffer.main_loop = 0 : i32}
+      
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    
+    return {ssbuffer.core_type = "VECTOR"}
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/iter_args_only_consumer.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/iter_args_only_consumer.mlir
@@ -1,0 +1,47 @@
+// RUN: triton-opt --update-for-ops --debug %s 2>&1 | FileCheck %s
+
+// Test for tensor iter_arg with only consumer if ops
+// CHECK: tensor iter_arg <block argument> of type 'tensor<64x64xf32>' at index: 1 has only consumers, skipped
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_iter_args_only_consumer(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %cst = arith.constant {ssbuffer.block_id = 1} 0.0 : f32
+    %c0 = arith.constant {ssbuffer.block_id = 1} 0 : i32
+    %c1 = arith.constant {ssbuffer.block_id = 1} 1 : i32
+    %c5 = arith.constant {ssbuffer.block_id = 1} 5 : i32
+    %true = arith.constant true
+    %false = arith.constant false
+    %empty_tensor = tensor.empty() : tensor<64x64xf32>
+
+    scope.scope : () -> () {
+      // Create initial tensor
+      %tensor_init = tensor.empty() {ssbuffer.block_id = 1} : tensor<64x64xf32>
+      %filled_tensor = linalg.fill {ssbuffer.block_id = 1} ins(%cst : f32) outs(%tensor_init : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+      // Loop with tensor iter_arg
+      %result = scf.for %i = %c0 to %c5 step %c1 iter_args(%iter_arg = %filled_tensor) -> (tensor<64x64xf32>) : i32 {
+        // Create a separate tensor for yield
+        %yield_tensor = tensor.empty() {ssbuffer.block_id = 2} : tensor<64x64xf32>
+        %filled_yield = linalg.fill {ssbuffer.block_id = 2} ins(%cst : f32) outs(%yield_tensor : tensor<64x64xf32>) -> tensor<64x64xf32>
+        
+        // Only consumer if op 1 - uses iter_arg but yields other value
+        %val1 = scf.if %true -> (tensor<64x64xf32>) {
+          // Use iter_arg in some operation (consumer) - use broadcast with empty dimensions
+          %broadcasted = linalg.broadcast {ssbuffer.block_id = 2 : i32} ins(%iter_arg : tensor<64x64xf32>) outs(%yield_tensor : tensor<64x64xf32>) dimensions = []
+          // Yield a different value
+          scf.yield %filled_yield : tensor<64x64xf32>
+        } else {
+          // Also use iter_arg in another way
+          %broadcasted2 = linalg.broadcast {ssbuffer.block_id = 2 : i32} ins(%iter_arg : tensor<64x64xf32>) outs(%yield_tensor : tensor<64x64xf32>) dimensions = []
+          scf.yield %filled_yield : tensor<64x64xf32>
+        } {ssbuffer.if = 2 : i32}
+
+        // Yield from loop - yield the same value that came from if
+        scf.yield %val1 : tensor<64x64xf32>
+      } {ssbuffer.block_id = 10, ssbuffer.main_loop = 0 : i32}
+
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+
+    return {ssbuffer.core_type = "VECTOR"}
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/iter_args_only_producer.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/iter_args_only_producer.mlir
@@ -1,0 +1,41 @@
+// RUN: triton-opt --update-for-ops %s --debug %s 2>&1 | FileCheck %s
+
+// Test for tensor iter_arg with only producer if ops
+// CHECK: scf.for {{.*}} iter_args({{.*}}, {{.*}}) ->
+// CHECK: tensor iter_arg <block argument> of type 'tensor<64x64xf32>' at index: 1 has only producers, skipped
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_iter_args_only_producer(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %cst = arith.constant {ssbuffer.block_id = 1} 0.0 : f32
+    %c0 = arith.constant {ssbuffer.block_id = 1} 0 : i32
+    %c1 = arith.constant {ssbuffer.block_id = 1} 1 : i32
+    %c5 = arith.constant {ssbuffer.block_id = 1} 5 : i32
+    %true = arith.constant true
+
+    scope.scope : () -> () {
+      // Create initial tensor
+      %tensor_init = tensor.empty() {ssbuffer.block_id = 1} : tensor<64x64xf32>
+      %filled_tensor = linalg.fill {ssbuffer.block_id = 1} ins(%cst : f32) outs(%tensor_init : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+      // Loop with tensor iter_arg
+      %result = scf.for %i = %c0 to %c5 step %c1 iter_args(%iter_arg = %filled_tensor) -> (tensor<64x64xf32>) : i32 {
+        // Only producer if op - yields new tensor value
+        %val1 = scf.if %true -> (tensor<64x64xf32>) {
+          %new_tensor1 = tensor.empty() {ssbuffer.block_id = 2} : tensor<64x64xf32>
+          %filled1 = linalg.fill {ssbuffer.block_id = 2} ins(%cst : f32) outs(%new_tensor1 : tensor<64x64xf32>) -> tensor<64x64xf32>
+          scf.yield %filled1 : tensor<64x64xf32>
+        } else {
+          %new_tensor2 = tensor.empty() {ssbuffer.block_id = 2} : tensor<64x64xf32>
+          %filled2 = linalg.fill {ssbuffer.block_id = 2} ins(%cst : f32) outs(%new_tensor2 : tensor<64x64xf32>) -> tensor<64x64xf32>
+          scf.yield %iter_arg : tensor<64x64xf32>
+        } {ssbuffer.if = 2 : i32}
+
+        // Yield from loop
+        scf.yield %val1 : tensor<64x64xf32>
+      } {ssbuffer.block_id = 10, ssbuffer.main_loop = 0 : i32}
+
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+
+    return {ssbuffer.core_type = "VECTOR"}
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/multi_deps_add_condition_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/multi_deps_add_condition_test.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">}
 // CHECK-LABEL: func.func @_attn_fwd(
-// CHECK-DAG: [[C3:%[^ ]+]] = arith.constant 3 : i32
+// CHECK-DAG: [[C3:%[^ ]+]] = arith.constant 2 : i32
 
 // CHECK-DAG: arith.cmpi slt
 // CHECK-DAG: arith.cmpi slt
@@ -133,7 +133,7 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
           %c0_i32_18 = arith.constant {ssbuffer.block_id = 6 : i32} 0 : i32
           %51 = arith.cmpi eq, %50, %c0_i32_18 {ssbuffer.block_id = 6 : i32} : i32
           %producer_buf = memref.alloc() {ssbuffer.block_id = 6 : i32} : memref<128xf32, #hivm.address_space<ub>>
-          %producer_cast = memref.memory_space_cast %producer_buf {ssbuffer.block_id = 6 : i32, ssbuffer.intraDeps = [0 : i32, 1 : i32]} : memref<128xf32, #hivm.address_space<ub>> to memref<128xf32>
+          %producer_cast = memref.memory_space_cast %producer_buf {ssbuffer.block_id = 6 : i32} : memref<128xf32, #hivm.address_space<ub>> to memref<128xf32>
           %producer_tensor = bufferization.to_tensor %producer_cast writable {ssbuffer.block_id = 6 : i32} : memref<128xf32>
 
           %c1_buf = memref.alloc() {ssbuffer.block_id = 6 : i32} : memref<128xf32, #hivm.address_space<ub>>


### PR DESCRIPTION
1. 分scope合理，因uboverflow，“chunkwise_fwd_kernel”加白名单回退
2.迭代依赖的生产者应该只有一个，更换vector数据类型为scf if类型，并判断生产者是否只有一个。更新map信息，便于更新迭代次数的pass使用。
3.适配迭代依赖的条件，增加for的迭代次数
1.Scope division is reasonable; due to overflow, "chunkwise_fwd_kernel" has been whitelisted and rolled back.
2.The producer of the iteration dependency should be unique; change the vector data type to scf if type and verify that there is only one producer. Update the map information to facilitate the pass for updating iteration counts.
3. Adjust the conditions for iterative dependencies and increase the number of iterations of the for loop


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
