### PR TITLE
[ssbuffer](fix) a*b+c split in special scenes

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.h
+++ b/third_party/ascend/include/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.h
@@ -32,10 +32,13 @@
 namespace mlir::triton::CVSplit {
 
 class SplitMatmulPattern : public mlir::OpRewritePattern<linalg::MatmulOp> {
-    using OpRewritePattern<linalg::MatmulOp>::OpRewritePattern;
-
   public:
+    explicit SplitMatmulPattern(mlir::MLIRContext *context, bool needSplitAll)
+        : OpRewritePattern<linalg::MatmulOp>(context), needSplitAll(needSplitAll) {}
     llvm::LogicalResult matchAndRewrite(linalg::MatmulOp matmulOp, PatternRewriter &rewriter) const override;
+
+  private:
+    bool needSplitAll;
 };
 
 class PatternMatchRewritePass : public PassWrapper<PatternMatchRewritePass, OperationPass<ModuleOp>> {

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.cpp
@@ -25,6 +25,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 
 #include "ascend/include/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.h"
 
@@ -35,14 +36,30 @@ using namespace CVSplit;
 static constexpr const char *DEBUG_TYPE = "PatternMatchRewrites";
 #define LOG_DEBUG(...) LLVM_DEBUG(llvm::dbgs() << "\n[" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
 
+static constexpr llvm::StringLiteral needSplitAllFuncNme[] {
+  "_swa_bwd_dq_kernel",
+  "_swa_bwd_dkdv_kernel"
+};
+
 void PatternMatchRewritePass::runOnOperation()
 {
     auto moduleOp = getOperation();
     LOG_DEBUG("Input mlir:\n" << moduleOp);
 
+    
+    bool needSplitAll = false;
+    moduleOp.walk([&](func::FuncOp funcOp) -> WalkResult {
+        if (!llvm::is_contained(needSplitAllFuncNme, funcOp.getSymName())) {
+        return WalkResult::advance();
+        }
+        LOG_DEBUG("[INFO] Matmul should split anyway: " << funcOp.getSymName());
+        needSplitAll = true;
+        return WalkResult::interrupt();
+    });
+
     auto *ctx = &getContext();
     RewritePatternSet patterns(ctx);
-    patterns.add<SplitMatmulPattern>(ctx);
+    patterns.add<SplitMatmulPattern>(ctx, needSplitAll);
 
     // the way we handle matmul dependencies across for blocks
     // requres the patternmatching to go top-down

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
@@ -43,6 +43,7 @@
 #include "mlir/IR/Value.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/SmallVector.h"
 
@@ -511,7 +512,7 @@ static bool verifyMatmul(linalg::MatmulOp matmulOp)
  *   - shouldSplit: Boolean indicating whether the split transformation should be applied.
  *   Returns std::nullopt if analysis cannot be performed.
  */
-static std::optional<SplitInfo> shouldSplit(linalg::MatmulOp matmulOp)
+static std::optional<SplitInfo> shouldSplit(linalg::MatmulOp matmulOp, bool needSplitAll)
 {
 
     if (!verifyMatmul(matmulOp)) {
@@ -519,6 +520,11 @@ static std::optional<SplitInfo> shouldSplit(linalg::MatmulOp matmulOp)
     }
 
     auto matmulInput = parseMatmulInputs(matmulOp);
+    if (needSplitAll) {
+        LOG_DEBUG("Split because needSplitAll is true. " << matmulOp);
+        return SplitInfo {false, matmulInput.bias, matmulOp.getResult(0), true};
+    }
+
     bool argsLimitedInMatmul = true;
     bool mayNotExec = false;
     Value outerInValue = matmulInput.bias;
@@ -597,7 +603,7 @@ static void splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rewriter, Sp
 LogicalResult SplitMatmulPattern::matchAndRewrite(linalg::MatmulOp matmulOp, PatternRewriter &rewriter) const
 {
     LOG_DEBUG("check matmulOp = " << matmulOp);
-    auto splitInfoOpt = shouldSplit(matmulOp);
+    auto splitInfoOpt = shouldSplit(matmulOp, needSplitAll);
     if (!splitInfoOpt.has_value()) {
         return failure();
     }


### PR DESCRIPTION

Apply a TA-side handling for the native precision errors in the Mojo SWA operator introduced by PR #580.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
