### PR TITLE
[ssbuffer](fix) intercept cloning tensor/memref ops in CloneOps

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/CloneOps.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/CloneOps.h
@@ -39,6 +39,7 @@ public:
   LogicalResult validateBlockIdsConsecutive(ModuleOp module);
   LogicalResult cloneOpsInMainLoop(scf::ForOp forOp);
   LogicalResult cleanupClonedOpsInMainLoop(scf::ForOp forOp);
+  LogicalResult validateClonedOpsInVector(ModuleOp module);
 
   llvm::StringRef getArgument() const override
   {

--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -48,6 +48,7 @@ inline constexpr llvm::StringLiteral kAnalyzeFlagId = "ssbuffer.analyze_flag_id"
 inline constexpr llvm::StringLiteral kLoopCarriedL0C = "ssbuffer.loop_carried_l0c";
 inline constexpr llvm::StringLiteral kCrossDeps = "ssbuffer.crossDeps";
 inline constexpr llvm::StringLiteral kMayNotExec = "ssbuffer.may_not_exec";
+inline constexpr llvm::StringLiteral kClone = "ssbuffer.clone";
 inline constexpr const char *ERRCODE_ATTR = "triton_ascend.dynamic_cv_pipeline.rc";
 
 static constexpr const int ERRCODE_FAILED = 1;

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CloneOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CloneOps.cpp
@@ -29,6 +29,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/IRMapping.h"
 
 static constexpr const char *DEBUG_TYPE = "CloneOps";
@@ -132,9 +133,9 @@ static LogicalResult cloneOpsForBlock(int curId, SmallVector<Operation *> &curOp
 
   for (Operation *op : toClone) {
     Operation *cloned = cloneOpWithMapping(op, builder, valueMap);
-    cloned->setAttr("ssbuffer.block_id", builder.getI32IntegerAttr(curId));
-    if (auto origBlockIdAttr = op->getAttrOfType<IntegerAttr>("ssbuffer.block_id")) {
-      cloned->setAttr("ssbuffer.clone", origBlockIdAttr);
+    cloned->setAttr(CVPipeline::kBlockId, builder.getI32IntegerAttr(curId));
+    if (auto origBlockIdOpt = CVPipeline::getOpBlockId(op)) {
+      cloned->setAttr(CVPipeline::kClone, builder.getI32IntegerAttr(static_cast<int32_t>(*origBlockIdOpt)));
     }
     clonedOps.push_back(cloned);
   }
@@ -266,7 +267,7 @@ static LogicalResult cleanupClonedOps(scf::ForOp forOp,
     // Find last index of cloned ops
     int startIdx = -1;
     for (int j = curOps.size() - 1; j >= 0; --j) {
-      if (curOps[j]->hasAttr("ssbuffer.clone")) {
+      if (curOps[j]->hasAttr(CVPipeline::kClone)) {
         startIdx = j;
         break;
       }
@@ -280,7 +281,7 @@ static LogicalResult cleanupClonedOps(scf::ForOp forOp,
     // have already been processed (and erased if applicable)
     for (int j = startIdx; j >= 0; --j) {
       Operation *op = curOps[j];
-      if (!op->hasAttr("ssbuffer.clone")) {
+      if (!op->hasAttr(CVPipeline::kClone)) {
         break;
       }
       // Rebuild memGraph after each erasure to reflect current IR state
@@ -294,7 +295,7 @@ static LogicalResult cleanupClonedOps(scf::ForOp forOp,
 
   // Check whether new forOp is valid after cleanup
   for (Operation &op : forOp.getBody()->without_terminator()) {
-    if (op.hasAttr("ssbuffer.clone")) {
+    if (op.hasAttr(CVPipeline::kClone)) {
       if (isa<SyncBlockWaitOp>(op) || isa<SyncBlockSetOp>(op) ||
           isa<hivm::FixpipeOp>(op)) {
         LDBG("[ERROR]: Cloned sync/fixpipe op should have been erased: " << op.getName() << "\n");
@@ -315,7 +316,7 @@ LogicalResult CloneOpsPass::cleanupClonedOpsInMainLoop(scf::ForOp forOp)
     return success();
   }
 
-  auto attr = scopeOp->getAttrOfType<hivm::TCoreTypeAttr>("hivm.tcore_type");
+  auto attr = scopeOp->getAttrOfType<hivm::TCoreTypeAttr>(CVPipeline::kTcoreType);
   if (!attr) {
     return success();
   }
@@ -347,13 +348,13 @@ static bool areBlockIdsConsecutive(scf::ForOp forOp)
 {
   SmallVector<int> idsInOrder;
   for (Operation &op : forOp.getBody()->without_terminator()) {
-    auto blockIdAttr = op.getAttrOfType<IntegerAttr>("ssbuffer.block_id");
-    if (!blockIdAttr) {
+    auto blockIdOpt = CVPipeline::getOpBlockId(&op);
+    if (!blockIdOpt) {
       LDBG("[ERROR]: Op missing ssbuffer.block_id: " << op.getName() << "\n");
       return false;
     }
 
-    idsInOrder.push_back(blockIdAttr.getInt());
+    idsInOrder.push_back(static_cast<int>(*blockIdOpt));
   }
 
   // Check that each block_id forms a contiguous range
@@ -381,7 +382,7 @@ static bool areBlockIdsConsecutive(scf::ForOp forOp)
 LogicalResult CloneOpsPass::validateBlockIdsConsecutive(ModuleOp module)
 {
   WalkResult result = module.walk([&](Operation *op) -> WalkResult {
-    if (!op->hasAttr("ssbuffer.main_loop")) {
+    if (!op->hasAttr(CVPipeline::kMainLoop)) {
       return WalkResult::advance();
     }
     auto forOp = dyn_cast<scf::ForOp>(op);
@@ -394,6 +395,57 @@ LogicalResult CloneOpsPass::validateBlockIdsConsecutive(ModuleOp module)
     }
     return WalkResult::advance();
   });
+  if (result.wasInterrupted())
+    return failure();
+
+  return success();
+}
+
+// Check that no op in a VECTOR scope's main_loop forOp has a tensor or
+// memref result carrying the ssbuffer.clone attribute.
+LogicalResult CloneOpsPass::validateClonedOpsInVector(ModuleOp module)
+{
+  WalkResult result = module.walk([&](Operation *op) -> WalkResult {
+    if (!op->hasAttr(CVPipeline::kMainLoop)) {
+      return WalkResult::advance();
+    }
+    auto forOp = dyn_cast<scf::ForOp>(op);
+    if (!forOp) {
+      LDBG("[Error]: op with ssbuffer.main_loop is not a scf::ForOp\n");
+      return WalkResult::interrupt();
+    }
+
+    scope::ScopeOp scopeOp = forOp->getParentOfType<scope::ScopeOp>();
+    if (!scopeOp) {
+      return WalkResult::advance();
+    }
+
+    auto attr = scopeOp->getAttrOfType<hivm::TCoreTypeAttr>(CVPipeline::kTcoreType);
+    if (!attr) {
+      return WalkResult::advance();
+    }
+
+    if (attr != hivm::TCoreTypeAttr::get(module.getContext(), hivm::TCoreType::VECTOR)) {
+      return WalkResult::advance();
+    }
+
+    for (Operation &bodyOp : forOp.getBody()->without_terminator()) {
+      if (!bodyOp.hasAttr(CVPipeline::kClone)) {
+        continue;
+      }
+      bool hasTensorOrMemref = llvm::any_of(bodyOp.getResults(), [](Value result) {
+        return isa<RankedTensorType, MemRefType>(result.getType());
+      });
+      if (hasTensorOrMemref) {
+        LDBG("[Error]: VECTOR main_loop contains cloned op with tensor/memref type: "
+             << bodyOp.getName() << "\n");
+        return WalkResult::interrupt();
+      }
+    }
+
+    return WalkResult::advance();
+  });
+
   if (result.wasInterrupted())
     return failure();
 
@@ -415,7 +467,7 @@ void CloneOpsPass::runOnOperation()
   // Clone ops in vector/cube to ensure that each block_id has its own
   // ops without sharing
   module.walk([&](Operation *op) -> WalkResult {
-    if (!op->hasAttr("ssbuffer.main_loop")) {
+    if (!op->hasAttr(CVPipeline::kMainLoop)) {
       return WalkResult::advance();
     }
     auto forOp = dyn_cast<scf::ForOp>(op);
@@ -436,8 +488,15 @@ void CloneOpsPass::runOnOperation()
     }
     return WalkResult::advance();
   });
-
+  
   LDBG("after cloneOps:\n" << module << "\n");
+
+  // Validate no cloned tensor/memref ops remaining in VECTOR main_loop forOp
+  if (failed(validateClonedOpsInVector(module))) {
+    signalPassFailure();
+    return;
+  }
+
 }
 
 namespace mlir {

--- a/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
@@ -42,7 +42,7 @@ static constexpr const char *DEBUG_TYPE = "RemoveAttributes";
 
 // if extra attr is needed, add to ut @
 // third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/test-remove-attrs.mlir
-static constexpr llvm::StringLiteral kAttrsToRemove[] {kBlockId, kCoreType, kTransferId, kMainLoop, kCubeFirst, kVectorFirst, kAddFromMatmul, kIntraBuffer, kAnalyzeFlagId, kLoopCarriedL0C, kMatmulADep, kMatmulBDep, kMatmulExtract, kCrossDeps};
+static constexpr llvm::StringLiteral kAttrsToRemove[] {kBlockId, kCoreType, kTransferId, kMainLoop, kCubeFirst, kVectorFirst, kAddFromMatmul, kIntraBuffer, kAnalyzeFlagId, kLoopCarriedL0C, kMatmulADep, kMatmulBDep, kMatmulExtract, kCrossDeps, kClone};
 
 void RemoveSsbufAttrPass::runOnOperation()
 {

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/check-clone-tensor-memref-ops.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/check-clone-tensor-memref-ops.mlir
@@ -1,0 +1,21 @@
+// RUN: triton-opt --clone-ops --verify-diagnostics %s --allow-unregistered-dialect
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_vector_clone_tensor_op(%arg0: memref<?xi8>, %arg1: memref<?xi8>) attributes {global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c10_i64 = arith.constant 10 : i64
+    %c1_f32 = arith.constant 1.000000e+00 : f32
+    %t1 = tensor.empty() : tensor<256x64xf32>
+    scope.scope : () -> () {
+      %0 = tensor.empty() : tensor<256x64xf32>
+      scf.for %arg2 = %c0_i64 to %c10_i64 step %c1_i64  : i64 {
+        %1 = linalg.fill {ssbuffer.block_id = 11 : i32} ins(%c1_f32 : f32) outs(%0 : tensor<256x64xf32>) -> tensor<256x64xf32>
+        %2 = arith.addf %1, %t1 {ssbuffer.block_id = 12 : i32} : tensor<256x64xf32>
+        %3 = linalg.fill {ssbuffer.block_id = 12 : i32} ins(%c1_f32 : f32) outs(%2 : tensor<256x64xf32>) -> tensor<256x64xf32>
+      } {ssbuffer.block_id = 10 : i32, ssbuffer.main_loop = 0 : i32}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return {ssbuffer.core_type = "VECTOR"}
+  }
+}


### PR DESCRIPTION
**DynamicCVPipeline：Intercept scenarios where upstream PASS fails to handle tensor/memref type op dependencies, and signal a PASS failure for error reporting**
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
