### PR TITLE
[ssbuffer](fix) fix bug in MemoryEffectsTracker on recursive unknown op

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/MemoryEffectsTracker.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/MemoryEffectsTracker.h
@@ -58,6 +58,7 @@ private:
 
     struct Snapshot {
         SmallVector<MemSlot> states;
+        Operation *lastBarrier = nullptr;
     };
 
     void analyzeOp(Operation *op);
@@ -95,6 +96,11 @@ private:
 
     SmallVector<std::unique_ptr<MemSlot>> slots;
     DenseMap<Value, MemSlot *> valueToSlot;
+
+    // Most recent unknown (barrier) op in program order within the current
+    // scope. A newly allocated buffer is ordered after it so that allocations
+    // do not move across an unknown op (see collectPreds / applyEffects).
+    Operation *lastBarrier = nullptr;
 };
 
 } // namespace CVPipeline

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/MemoryEffectsTracker.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/MemoryEffectsTracker.cpp
@@ -299,7 +299,22 @@ SmallVector<MemoryEffects::EffectInstance> MemoryDependenceGraph::collectOuterEf
 
     std::optional<SmallVector<MemoryEffects::EffectInstance>> raw;
     if (recursive) {
-        raw = getEffectsRecursively(op);
+        SmallVector<Operation *> leafOps;
+        collectLeafOps(op, leafOps);
+        raw.emplace();
+        for (Operation *leaf : leafOps) {
+            bool leafUnknown = false;
+            SmallVector<MemoryEffects::EffectInstance> leafEffects =
+                collectOuterEffects(leaf, leafUnknown, /*recursive=*/false);
+            if (leafUnknown) {
+                if (leaf != op) {
+                    LOG_DEBUG("Op " << *op << " is unknown due to nested op " << *leaf << "\n");
+                }
+                unknown = true;
+                return {};
+            }
+            raw->append(leafEffects.begin(), leafEffects.end());
+        }
     } else if (auto effectInterface = dyn_cast<MemoryEffectOpInterface>(op)) {
         raw.emplace();
         effectInterface.getEffects(*raw);

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/MemoryEffectsTracker.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/MemoryEffectsTracker.cpp
@@ -134,6 +134,7 @@ MemoryDependenceGraph::MemoryDependenceGraph(Operation *root, AliasAnalysis &aa)
     analyzeOp(root);
     slots.clear();
     valueToSlot.clear();
+    lastBarrier = nullptr;
 }
 
 ArrayRef<Operation *> MemoryDependenceGraph::getMemDefs(Operation *op) const
@@ -185,6 +186,7 @@ SmallVector<Operation *> MemoryDependenceGraph::getRealDependency(Operation *fro
     // Create slots for frontOps, using existing effects logic to process
     slots.clear();
     valueToSlot.clear();
+    lastBarrier = nullptr;
     llvm::SmallSetVector<Operation *, INIT_SIZE> dependencyOps;
     for (Operation *leafOp : leafOps) {
         auto effects = collectOuterEffects(leafOp, unknown, false);
@@ -265,6 +267,7 @@ void MemoryDependenceGraph::analyzeRegionsOf(Operation *op)
         if (isolated) {
             slots.clear();
             valueToSlot.clear();
+            lastBarrier = nullptr;
         }
 
         for (Block &block : region) {
@@ -460,6 +463,10 @@ void MemoryDependenceGraph::collectPreds(ArrayRef<MemoryEffects::EffectInstance>
             for (MemSlot *s : resolveAliasSlots(v, cache)) {
                 addFromSlot(s, true);
             }
+        } else if (isa<MemoryEffects::Allocate>(e.getEffect())) {
+            if (lastBarrier) {
+                preds.insert(lastBarrier);
+            }
         }
     }
 
@@ -475,6 +482,7 @@ void MemoryDependenceGraph::applyEffects(Operation *op, ArrayRef<MemoryEffects::
             slot->lastWriter = op;
             slot->pendingReads.clear();
         }
+        lastBarrier = op;
         return;
     }
 
@@ -546,6 +554,7 @@ void MemoryDependenceGraph::applyEffects(Operation *op, ArrayRef<MemoryEffects::
 MemoryDependenceGraph::Snapshot MemoryDependenceGraph::takeSnapshot() const
 {
     Snapshot snap;
+    snap.lastBarrier = lastBarrier;
     snap.states.reserve(slots.size());
     for (const auto &slot : slots) {
         snap.states.push_back(*slot);
@@ -555,6 +564,7 @@ MemoryDependenceGraph::Snapshot MemoryDependenceGraph::takeSnapshot() const
 
 void MemoryDependenceGraph::restoreSnapshot(Snapshot &&snap)
 {
+    lastBarrier = snap.lastBarrier;
     slots.clear();
     valueToSlot.clear();
     slots.reserve(snap.states.size());

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_alloc_ordered_after_barrier.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_alloc_ordered_after_barrier.mlir
@@ -1,0 +1,39 @@
+// RUN: triton-opt --debug-only=memory-effects-tracker --plan-compute-block %s 2>&1 | FileCheck %s
+
+// An unknown op (here gpu.barrier, which exposes no memory-effect interface)
+// acts as a full memory barrier. A buffer allocated after such an op must not
+// move across it, so the barrier must show up in the allocation's Preds.
+
+module {
+  // Case 1: barrier and allocation live in the same block. The ordering edge is
+  // barrier -> alloc.
+  // CHECK-LABEL: func.func @alloc_after_barrier_same_block
+  // CHECK:      Analyzing op {{.*}} = memref.alloc()
+  // CHECK-NEXT: [memory-effects-tracker] Defs:
+  // CHECK-NEXT: [memory-effects-tracker] Preds:
+  // CHECK-NEXT: [memory-effects-tracker] gpu.barrier
+  func.func @alloc_after_barrier_same_block(%arg0: memref<4xf32>) {
+    %c0 = arith.constant 0 : index
+    %v = memref.load %arg0[%c0] : memref<4xf32>
+    gpu.barrier
+    %alloc = memref.alloc() : memref<4x4xf32>
+    return
+  }
+
+  // Case 2: the barrier is nested inside scf.if. The ordering edge must NOT
+  // cross the block boundary: it is emitted from the parent-block ancestor
+  // (scf.if, which is itself unknown because it contains the barrier), and NOT
+  // from the gpu.barrier inside the nested region.
+  // CHECK-LABEL: func.func @alloc_after_nested_barrier
+  // CHECK:      Analyzing op {{.*}} = memref.alloc()
+  // CHECK-NEXT: [memory-effects-tracker] Defs:
+  // CHECK-NEXT: [memory-effects-tracker] Preds:
+  // CHECK-NEXT: [memory-effects-tracker] scf.if
+  func.func @alloc_after_nested_barrier(%cond: i1) {
+    scf.if %cond {
+      gpu.barrier
+    }
+    %alloc = memref.alloc() : memref<4x4xf32>
+    return
+  }
+}


### PR DESCRIPTION

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

Fixed issues related to memory dependency identification:
1. Failure to associate `alloc` operations with memory barriers.
2. Failure to apply known-operation filtering when processing a parent operation containing nested `unknown` operations.
