### PR TITLE
[ssbuffer](fix) nd2nz matmul C padding

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
@@ -112,6 +112,7 @@ private:
                                         bool isMatmulA,
                                         bool isMatmulB,
                                         bool isOnlyDepInMatmul);
+  bool matmulCIsEmpty(mlir::Value acc);
   void padMatmulInnerDim(OpBuilder &builder, Operation *matmulOp, Location loc, int matmulIndex, int matmulOpBlockId);
   void extractMatmulResult(OpBuilder &builder, Operation *matmulOp, Location loc, int matmulOpBlockId, llvm::DenseMap<mlir::Value, mlir::Value> &cubeValueMapping, bool isOnlyDepInMatmul);
   mlir::Value normalizeIfNeeded(mlir::OpBuilder &builder,

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -318,6 +318,28 @@ void InterCoreTransferAndSyncPass::padMatmulInnerDim(OpBuilder &builder, Operati
     attachCommonTags(tensorInsertSliceOp, matmulOpBlockId, "CUBE");
 }
 
+bool InterCoreTransferAndSyncPass::matmulCIsEmpty(mlir::Value acc)
+{
+    auto accDefOp = acc.getDefiningOp();
+    if (accDefOp) {
+        if (isa<tensor::EmptyOp>(accDefOp)) {
+            return true;
+        }
+        if (auto fillOp = dyn_cast<linalg::FillOp>(accDefOp)) {
+            Value fillVal = fillOp.getOperand(0); 
+            if (auto constOp = fillVal.getDefiningOp<arith::ConstantOp>()) {
+                Attribute attr = constOp.getValue();
+
+                if ((isa<FloatAttr>(attr) && cast<FloatAttr>(attr).getValue().isZero()) ||
+                    (isa<IntegerAttr>(attr) && cast<IntegerAttr>(attr).getValue().isZero())) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
 void InterCoreTransferAndSyncPass::extractMatmulResult(
     OpBuilder &builder, Operation *matmulOp, Location loc,
     int matmulOpBlockId, llvm::DenseMap<mlir::Value, mlir::Value> &cubeValueMapping, bool isOnlyDepInMatmul)
@@ -330,6 +352,11 @@ void InterCoreTransferAndSyncPass::extractMatmulResult(
     auto rhsType = dyn_cast<RankedTensorType>(rhs.getType());
     auto accType = dyn_cast<RankedTensorType>(acc.getType());
     auto resType = dyn_cast<RankedTensorType>(originalResult.getType());
+    if (lhsType.getShape()[0] == accType.getShape()[0]
+        && rhsType.getShape()[1] == accType.getShape()[1]) {
+        return;
+    }
+
     ArrayRef<int64_t> accshape = accType.getShape();
     ArrayRef<int64_t> resshape = resType.getShape();
     SmallVector<int64_t> expectedShape = { lhsType.getShape()[0], rhsType.getShape()[1] };
@@ -347,7 +374,13 @@ void InterCoreTransferAndSyncPass::extractMatmulResult(
     attachCommonTags(tensorEmptyOp, matmulOpBlockId, "CUBE");
     attachCommonTags(linalgFillOp, matmulOpBlockId, "CUBE");
 
-    Value newAccResult = linalgFillOp->getResult(0);
+    mlir::Operation *paddingAccOp = linalgFillOp;
+    if (!matmulCIsEmpty(acc)) {
+        LOG_DEBUG("nd2nz shape is unaligned and matmul C is not empty");
+        signalPassFailure();
+    }
+
+    Value newAccResult = paddingAccOp->getResult(0);
 
     static constexpr int accIndex = 2;
     matmulOp->setOperand(accIndex, newAccResult);


### PR DESCRIPTION
#Main Changes
bugfix: Skip ND2NZ MatmulC for non-zero matrices requiring padding
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
