### PR TITLE
[ssbuffer](fix) ignore gpu.barrier & annotation.mark in memdep

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
@@ -84,7 +84,8 @@ private:
                                              DependencyInfo &dep,
                                              size_t depIndex,
                                              llvm::SmallVector<DependencyInfo> memDependencies,
-                                             FlagIdManager &flagManager);
+                                             FlagIdManager &flagManager,
+                                             FlagIdReuseManager &flagIdReuseManager);
 
   std::pair<mlir::Operation *, mlir::Operation *> getBlockStartEnd(int blockId, mlir::ModuleOp module);
   bool isOuterLayerDependency(size_t depIndex,
@@ -147,7 +148,7 @@ private:
     mlir::Operation *consumerEndOp, int flag, mlir::Location loc, int transferIndex, FlagIdReuseManager &flagIdReuseManager,
     mlir::Operation *consumedDataOp = nullptr);
   void insertMemDepSync(mlir::OpBuilder &builder, mlir::Operation *producerOp, mlir::Operation *consumerOp, int flag,
-    mlir::Location loc, bool isCubeToVector);
+    mlir::Location loc, bool isCubeToVector, FlagIdReuseManager &flagIdReuseManager);
   void sortDependencies(llvm::SmallVector<DependencyInfo> &dependencies, mlir::ModuleOp module);
   llvm::SmallVector<mlir::Operation *> insertAnalyzeFlagRelations(mlir::ModuleOp module, FlagIdReuseManager &flagIdReuseManager);
   void remapInterCoreTransferFlagIds(llvm::DenseMap<int, int> &remapResult);

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -24,9 +24,11 @@
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/Common/MemoryEffectsTracker.h"
 
+#include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "mlir/Analysis/AliasAnalysis.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/IR/Builders.h"
@@ -545,6 +547,9 @@ void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info)
         if (op->getNumRegions() > 0) {
             return;
         }
+        if (isa<annotation::MarkOp, gpu::BarrierOp>(op)) {
+            return;
+        }
         auto currBlockIdOpt = CVPipeline::getOpBlockId(op);
         llvm::StringRef currCoreType = getSsbufferCoreType(op);
         if (!currBlockIdOpt || currCoreType.empty()) {
@@ -553,12 +558,18 @@ void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info)
         int currBlockId = static_cast<int>(*currBlockIdOpt);
 
         for (mlir::Operation *predOp : memDepGraph.getExecBefore(op)) {
+            if (isa<annotation::MarkOp, gpu::BarrierOp>(predOp)) {
+                continue;
+            }
             if (predOp->getNumRegions() > 0) {
                 auto realdeps = memDepGraph.getRealDependency(predOp, op);
                 if (realdeps.empty()) {
                     return;
                 }
                 for (mlir::Operation *realPredOp : realdeps) {
+                    if (isa<annotation::MarkOp, gpu::BarrierOp>(realPredOp)) {
+                        continue;
+                    }
                     auto realPredBlockIdOpt = CVPipeline::getOpBlockId(realPredOp);
                     llvm::StringRef realPredCoreType = getSsbufferCoreType(realPredOp);
                     if (!realPredBlockIdOpt || realPredCoreType == currCoreType || realPredCoreType.empty()) {
@@ -573,9 +584,11 @@ void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info)
                     collectMemDepInfo(realPredCoreType, producerBlockId, consumerBlockId, realPredBlockId, currBlockId, memoryDependencies);
 
                     LOG_DEBUG("\n=op with region mem dep analysis= "
+                        << "\nrealpredcoretype" << realPredCoreType
                         << "\nproducer Block: " << realPredBlockId << "\nproducer Op: " << *realPredOp
                         << "\nconsumer Block: " << currBlockId << "\nconsumer Op: " << *op << "\n");
                 }
+                continue;
             }
             auto predBlockIdOpt = CVPipeline::getOpBlockId(predOp);
             llvm::StringRef predCoreType = getSsbufferCoreType(predOp);
@@ -596,6 +609,7 @@ void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info)
             collectMemDepInfo(predCoreType, producerBlockId, consumerBlockId, predBlockId, currBlockId, memoryDependencies);
 
             LOG_DEBUG("\n=mem dep analysis= "
+                << "\npredcoretype" << predCoreType
                 << "\nproducer Block: " << predBlockId << "\nproducer Op: " << *predOp
                 << "\nconsumer Block: " << currBlockId << "\nconsumer Op: " << *op << "\n");
         }

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -896,7 +896,7 @@ void InterCoreTransferAndSyncPass::insertInterCoreSync(
 }
 
 void InterCoreTransferAndSyncPass::insertMemDepSync(OpBuilder &builder, Operation *producerOp, Operation *consumerOp,
-    int flag, Location loc, bool isCubeToVector)
+    int flag, Location loc, bool isCubeToVector, FlagIdReuseManager &flagIdReuseManager)
 {
     LOG_DEBUG("Inserting Memdep sync: " << (isCubeToVector ? "CUBE->VECTOR" : "VECTOR->CUBE") << ", flag = " << flag <<
         "\n");
@@ -930,7 +930,9 @@ void InterCoreTransferAndSyncPass::insertMemDepSync(OpBuilder &builder, Operatio
         StringRef consCoreType = isCubeToVector ? "VECTOR" : "CUBE";
         attachCommonTags(waitOp, static_cast<int>(*consBlockIdOpt), consCoreType);
     }
-
+    attachAnalyzeFlagIdTag(setOp);
+    attachAnalyzeFlagIdTag(waitOp);
+    flagIdReuseManager.insertRelationBetweenSetAndWait(setOp, waitOp);
     LOG_DEBUG("[PIPE_MTE2 setOp]: " << *setOp << "\n");
     LOG_DEBUG("[PIPE_MTE2 waitOp]: " << *waitOp << "\n");
 }
@@ -1105,7 +1107,7 @@ LogicalResult InterCoreTransferAndSyncPass::handleCubeToVector(OpBuilder &builde
 
 // Memory Dependency
 LogicalResult InterCoreTransferAndSyncPass::handleMemoryDependency(OpBuilder &builder, DependencyInfo &dep,
-    size_t depIndex, llvm::SmallVector<DependencyInfo> memDependencies, FlagIdManager &flagManager)
+    size_t depIndex, llvm::SmallVector<DependencyInfo> memDependencies, FlagIdManager &flagManager, FlagIdReuseManager &flagIdReuseManager)
 {
     LOG_DEBUG("Handling memory dependency...\n");
 
@@ -1134,7 +1136,7 @@ LogicalResult InterCoreTransferAndSyncPass::handleMemoryDependency(OpBuilder &bu
     Location loc = prodEnd->getLoc();
 
     // Insert Memdep sync
-    insertMemDepSync(builder, prodEnd, consStart, flagId, loc, isCubeToVector);
+    insertMemDepSync(builder, prodEnd, consStart, flagId, loc, isCubeToVector, flagIdReuseManager);
 
     transferIndex++;
 
@@ -1391,7 +1393,7 @@ LogicalResult InterCoreTransferAndSyncPass::processDependencies(
         LOG_DEBUG("[MEMDEP] value = " << dep.value
                     << " producerBlockId = " << dep.producerBlockId
                     << ", consumerBlockId = " << dep.consumerBlockId << "\n");
-        if (failed(handleMemoryDependency(builder, dep, i, memDependencies, flagManager))) {
+        if (failed(handleMemoryDependency(builder, dep, i, memDependencies, flagManager, flagIdReuseManager))) {
             LOG_DEBUG("[ERROR] Memdep failed! producerBlockId = " << dep.producerBlockId
                     << ", consumerBlockId = " << dep.consumerBlockId << "\n");
         return failure();


### PR DESCRIPTION
# **Main Changes**
BugFix: Ingoring memref dependencies associated with gpu.barrier & annotation.mark in DataDependencyAnalysis Pass, so that no sync_block_set/wait will be added for these op in InterCoreTransferAndSync Pass. 

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
