### PR TITLE
[Inline](fix) Allow TritonAscend dialect to be inlined

### DIFF
--- a/third_party/ascend/include/Dialect/TritonAscend/IR/TritonAscendDialect.h
+++ b/third_party/ascend/include/Dialect/TritonAscend/IR/TritonAscendDialect.h
@@ -27,9 +27,15 @@
 #define GET_OP_CLASSES
 #include "ascend/include/Dialect/TritonAscend/IR/TritonAscendOps.h.inc"
 
+#include "mlir/Transforms/InliningUtils.h"
+
 namespace mlir::triton::ascend {
 
-
+struct TritonAscendInlinerInterface : public mlir::DialectInlinerInterface {
+    using mlir::DialectInlinerInterface::DialectInlinerInterface;
+    // All operations within the TritonAscend dialect (eg: ascend.sort, ascend.flip) can be inlined.
+    bool isLegalToInline(mlir::Operation *, mlir::Region *, bool, mlir::IRMapping &) const final { return true; }
+};
 
 } // namespace mlir::triton::ascend
 

--- a/third_party/ascend/lib/Dialect/TritonAscend/IR/TritonAscendDialect.cpp
+++ b/third_party/ascend/lib/Dialect/TritonAscend/IR/TritonAscendDialect.cpp
@@ -25,15 +25,17 @@
 using namespace mlir;
 using namespace mlir::triton::ascend;
 
-void TritonAscendDialect::initialize() {
-  addOperations<
+void TritonAscendDialect::initialize()
+{
+    addOperations<
 #define GET_OP_LIST
 #include "ascend/include/Dialect/TritonAscend/IR/TritonAscendOps.cpp.inc"
-      >();
-  addAttributes<
+        >();
+    addAttributes<
 #define GET_ATTRDEF_LIST
 #include "ascend/include/Dialect/TritonAscend/IR/TritonAscendOpsAttrDefs.cpp.inc"
-      >();
+        >();
+    addInterfaces<TritonAscendInlinerInterface>();
 }
 
 #include "ascend/include/Dialect/TritonAscend/IR/TritonAscendDialect.cpp.inc"

--- a/third_party/ascend/unittest/pytest_ut/test_call_sort.py
+++ b/third_party/ascend/unittest/pytest_ut/test_call_sort.py
@@ -1,0 +1,30 @@
+import triton
+import pytest
+import torch
+import triton.language as tl
+import triton.language.extra.cann.extension as extension
+
+
+@triton.jit
+def sort_kernel_1d(X, Z, M: tl.constexpr, descending: tl.constexpr):
+    off = tl.arange(0, M)
+    x = tl.load(X + off)
+    x = extension.sort(x, descending=descending, dim=0)
+    tl.store(Z + off, x)
+
+
+@triton.jit
+def sort_call_kernel(X, Z, M: tl.constexpr, descending: tl.constexpr):
+    sort_kernel_1d(X, Z, M, descending)
+
+
+def test_sort_call():
+    shape = (8, )
+    descending = True
+    x = torch.randn(size=shape, dtype=torch.float32).npu()
+    triton_res = torch.empty_like(x)
+    M = x.shape[0]
+    sort_call_kernel[(1, )](x, triton_res, M, descending)
+
+    torch_res = torch.sort(x, descending=descending)[0]
+    assert (torch_res == triton_res).all(), (torch_res, triton_res)


### PR DESCRIPTION
1 、对于extension.sort/flip op转换成ttir时会生成ascend.sort/flip ，然而TritonAscendDialect 没有注册 DialectInlinerInterface ，导致 MLIR 标准 Inliner pass 拒绝内联任何包含 ascend.* 操作的函数。而TA代码中又没有tt.call的解析，故extension.sort/flip嵌套调用会失败
2、在代码中增加对TritonAscendDialect 内联的合法性方法注册，使ascend.* 操作的方言可以被内联，从而修复报错