### PR TITLE
[Doc](fix) update code owners in third_party/ascend

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,7 +47,7 @@ lib/Dialect/TritonGPU/Transforms/TritonGPUConversion.cpp @TecJesh
 # -----------
 third_party/amd/ @TecJesh
 third_party/proton/ @TecJesh
-third_party/ascend/ @HEX1A0A
+third_party/ascend/ @KanuaK @WuTYSFG @hongziqi
 
 # -----------
 # gluon


### PR DESCRIPTION
## Summary
This PR updates the `.github/CODEOWNERS` entry for `third_party/ascend/`, replacing the inactive owner `@HEX1A0A` with three active core developers: `@KanuaK`, `@WuTYSFG`, and `@hongziqi`.

Before:

```gitignore
third_party/ascend/  @HEX1A0A
```

After:

```gitignore
third_party/ascend/  @KanuaK @WuTYSFG @hongziqi
```

## Why this change is needed

1. **`@HEX1A0A` is no longer active on triton-ascend.** Leaving them as the sole CODEOWNER causes PRs affecting `third_party/ascend/` to stall waiting for review from someone who is not available day-to-day.

2. **Single point of failure.** One person covering ~30 subdirectories spanning C++ MLIR passes, Python backend, language frontend, and tests creates a review bottleneck and a bus-factor risk.

3. **Aligns with the community pattern.** Upstream already uses multiple co-owners for backend directories (e.g., `third_party/amd/` and `third_party/proton/` are assigned to domain experts). This PR brings `third_party/ascend/` in line with that practice.

## Decision rationale

The change was discussed at the [2026-06-18 Triton-Ascend BiWeekly Meeting](https://github.com/triton-lang/triton-ascend/blob/main/docs/zh/community/community_technical_meeting.md) and the team voted on three options:

| Option | Decision |
|---|---|
| Keep a single owner | ❌ Still a bottleneck |
| Granular owners per subdirectory (MLIR vs. Backend vs. Language…) | ❌ Over-engineers the review assignment for the current team size |
| **Multiple co-owners for the full directory** | ✅ **Adopted** — lightweight, provides redundancy, any one of the three can review |

Attendees who reached consensus: Hong Ziqi, Zhu Guanda, Zhou Yihan, Cheng Maofan, Wu Tianyao, Zhou Hao, Hu Qiao.

## User Impact

No code change. This is a repository governance update only. PRs touching `third_party/ascend/` will now request review from three active maintainers instead of one inactive maintainer.

## Related ISSUE
https://github.com/triton-lang/triton-ascend/issues/667

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it only updates the CODEOWNERS governance file; no code or build behavior is affected.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
