### PR TITLE
[CI](feat) Add docs preview status workflow

### DIFF
--- a/.github/workflows/docs-preview-status.yml
+++ b/.github/workflows/docs-preview-status.yml
@@ -1,0 +1,136 @@
+name: Docs preview status
+
+# Mirrors the RTD PR build state onto a GitHub commit status, so contributors
+# see the docs preview link in the PR checks list without needing the RTD
+# GitHub App installed.
+#
+# Optional repo secret: RTD_TOKEN (RTD account -> API tokens). Only needed for
+# a private RTD project or a higher API rate limit; a public project's builds
+# API is read anonymously.
+#
+# Runs via pull_request_target so the built-in GITHUB_TOKEN can write commit
+# statuses (a fork's pull_request token is read-only). We never check out PR
+# code — only read PR metadata and query the RTD API — so this is safe for
+# fork PRs.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  statuses: write
+  pull-requests: read
+
+concurrency:
+  group: docs-preview-status-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  poll:
+    runs-on: ubuntu-latest
+    env:
+      RTD_PROJECT: triton-ascend
+      MAX_WAIT_MIN: '20'
+      # Gentle polling: a public RTD project's builds API is read without auth,
+      # so a low cadence keeps us well under anonymous rate limits (~40 requests
+      # over the full 20 min window).
+      POLL_INTERVAL_SEC: '30'
+    steps:
+      - uses: actions/github-script@v7
+        env:
+          RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
+        with:
+          script: |
+            const project    = process.env.RTD_PROJECT;
+            const token      = process.env.RTD_TOKEN;
+            const maxWaitMin = parseInt(process.env.MAX_WAIT_MIN, 10);
+            const pollSec    = parseInt(process.env.POLL_INTERVAL_SEC, 10);
+
+            const pr  = context.payload.pull_request.number;
+            const sha = context.payload.pull_request.head.sha;
+            const ctx = 'docs/readthedocs';
+            // External (PR) preview domain for community RTD. The bare root
+            // 302-redirects to the project's default language/version path
+            // (e.g. /zh-cn/<pr>/). RTD does NOT expose external versions at the
+            // /versions/<pr>/ detail route, so we construct this rather than
+            // reading urls.documentation from the API.
+            const previewUrl = `https://${project}--${pr}.org.readthedocs.build/`;
+
+            async function setStatus(state, description) {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                sha,
+                state,
+                target_url: previewUrl,
+                description: description.slice(0, 140),
+                context: ctx,
+              });
+            }
+
+            // Initial pending state so the check shows up immediately.
+            await setStatus('pending', 'Waiting for Read the Docs build...');
+
+            // RTD_TOKEN is optional: a public project's builds API is readable
+            // anonymously. The token is only needed for private projects (or
+            // for a higher rate limit), so send it only when configured.
+            const authHeaders = token ? { headers: { Authorization: `Token ${token}` } } : {};
+            // Documented project builds list, filtered to this PR's head commit.
+            // RTD builds the external (PR) version from the head SHA, so ?commit=
+            // pins the status to the exact commit under test rather than a
+            // superseded build. Results are newest-first; [0] is the latest
+            // attempt for this commit. (?version= is ignored by the API, and the
+            // /versions/<pr>/ detail route 404s for external versions.)
+            const buildsUrl  = `https://app.readthedocs.org/api/v3/projects/${project}/builds/?commit=${sha}`;
+            const deadline = Date.now() + maxWaitMin * 60 * 1000;
+            const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+            let lastReportedState = 'pending';
+
+            while (Date.now() < deadline) {
+              // Authoritative build state for this PR. The build state is a
+              // nested object: {"code": "finished", "name": "Finished"}.
+              let build = null;
+              try {
+                const bResp = await fetch(buildsUrl, authHeaders);
+                if (bResp.ok) {
+                  const bData = await bResp.json();
+                  build = (bData.results || [])[0] || null;
+                } else {
+                  core.warning(`RTD builds API ${bResp.status}: ${await bResp.text()}`);
+                }
+              } catch (e) {
+                core.info(`Builds fetch failed: ${e.message}; retrying.`);
+              }
+
+              if (!build) {
+                // RTD hasn't registered a build for this PR yet — keep waiting.
+                await sleep(pollSec * 1000);
+                continue;
+              }
+
+              const state = (build.state && build.state.code) || 'unknown';
+
+              // Terminal states: finished (success flag decides) and cancelled.
+              // Stop polling on either, otherwise we hang until the deadline.
+              if (state === 'finished') {
+                if (build.success) {
+                  await setStatus('success', 'Preview built successfully');
+                } else {
+                  await setStatus('failure', 'Read the Docs build failed');
+                }
+                return;
+              }
+              if (state === 'cancelled') {
+                await setStatus('failure', 'Read the Docs build was cancelled');
+                return;
+              }
+
+              if (state !== lastReportedState) {
+                await setStatus('pending', `RTD build: ${state}`);
+                lastReportedState = state;
+              }
+              await sleep(pollSec * 1000);
+            }
+
+            await setStatus('failure', `Build did not finish in ${maxWaitMin} min`);


### PR DESCRIPTION
### Summary

Mirrors the Read the Docs PR build state onto a GitHub commit status so contributors see the docs preview link in the PR checks list without the RTD GitHub App installed.

- Reads build state from the documented project builds list filtered by the PR head commit (GET /builds/?commit=<sha>), which pins the status to the exact commit under test. 
- Treats both "finished" (success flag decides) and "cancelled" as terminal states so a cancelled build is reported instead of polling to the timeout.
- RTD_TOKEN is optional: a public project's builds API is read anonymously; the token is only sent when configured (private project or higher rate limit).
- Polls every 30s for up to 20 min (~40 requests/run), well under anonymous rate limits.

Runs via pull_request_target so the built-in GITHUB_TOKEN can write commit statuses; no PR code is checked out.
