### PR TITLE
[ssbuffer](fix) plan cube add seed first without judge cycles

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlockPass.h
+++ b/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlockPass.h
@@ -26,21 +26,28 @@
 #include <memory>
 
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Operation.h"
 #include "mlir/Pass/Pass.h"
+
+#include "DynamicCVPipeline/PlanComputeBlock/Common.h"
+#include "DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
 
 namespace mlir {
 namespace triton {
 
 class PlanCubeBlockPass : public PassWrapper<PlanCubeBlockPass, OperationPass<ModuleOp>> {
-public:
+  public:
     MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PlanCubeBlockPass);
 
     PlanCubeBlockPass() = default;
     void runOnOperation() override;
 
-    llvm::StringRef getArgument() const final {
-      return "plan-cube-block";
-    }
+    llvm::StringRef getArgument() const final { return "plan-cube-block"; }
+
+  private:
+    SmallVector<Operation *> matchSeed(Operation *dotOp, CVPipeline::ComputeBlockIdManager &bm);
+    llvm::LogicalResult processBlockWithCubeBFS(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph,
+                                                CVPipeline::ComputeBlockIdManager &bm);
 };
 
 std::unique_ptr<OperationPass<ModuleOp>> createPlanCubeBlockPass();

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
@@ -178,11 +178,7 @@ bool willCreateCycle(llvm::ArrayRef<Operation *> opsToUnify, const MemoryDepende
     }
 
     for (auto &[op, origBlockId] : origBlockIdMap) {
-        if (origBlockId == -1) {
-            op->removeAttr(kBlockId);
-        } else {
-            bm.updateBlockId(op, origBlockId);
-        }
+        bm.updateBlockId(op, origBlockId);
     }
 
     return hasCycle;

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.cpp
@@ -83,7 +83,11 @@ void ComputeBlockIdManager::updateBlockId(Operation *op, int blockId)
 {
     // Force Update.
     MLIRContext *ctx = op->getContext();
-    op->setAttr(kBlockId, IntegerAttr::get(IntegerType::get(ctx, blockIdWidth), blockId));
+    if (blockId == -1) {
+        op->removeAttr(kBlockId);
+    } else {
+        op->setAttr(kBlockId, IntegerAttr::get(IntegerType::get(ctx, blockIdWidth), blockId));
+    }
     auto it = opToBlockId.find(op);
     if (it != opToBlockId.end()) {
         int preBlockId = it->second;
@@ -127,7 +131,7 @@ llvm::LogicalResult ComputeBlockIdManager::markAndRecord(Operation *op, int bloc
     MLIRContext *ctx = op->getContext();
     op->setAttr(kBlockId, IntegerAttr::get(IntegerType::get(ctx, blockIdWidth), blockId));
     auto itOld = opToBlockId.find(op);
-    if (itOld != opToBlockId.end()) {
+    if (itOld != opToBlockId.end() && itOld->second != -1) {
         llvm::errs() << "Error: Operation already has a block id. Op: " << *op << ", old block id: " << itOld->second
                      << ", new block id: " << blockId << "\n";
         return llvm::failure();

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
@@ -34,8 +34,12 @@
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include "DynamicCVPipeline/ComputeBlockOpt/Common.h"
 #include "mlir/Analysis/AliasAnalysis.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Block.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -47,9 +51,8 @@
 
 #include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
 #include "DynamicCVPipeline/Common/Utils.h"
-#include "DynamicCVPipeline/PlanComputeBlock/Common.h"
-#include "DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
+#include "bishengir/Dialect/HIVM/IR/HIVMImpl.h"
 
 using namespace mlir;
 using namespace triton;
@@ -66,7 +69,7 @@ static bool isMatmulOp(Operation *op)
 namespace {
 
 class SeedRegionPlanner {
-    Operation *seed;
+    SmallVector<Operation*> seeds;
     Block *block;
     const MemoryDependenceGraph &memGraph;
     ComputeBlockIdManager &bm;
@@ -75,19 +78,19 @@ class SeedRegionPlanner {
     bool willCreateCycle(Operation *op);
     bool isEligible(Operation *op);
     bool tryAddToGroup(Operation *op);
-    void addSourcesToGroup();
-    void addUsersToGroup();
 
 public:
-    SeedRegionPlanner(Operation *seed,
+    SeedRegionPlanner(SmallVector<Operation*> seeds,
                       Block *block,
                       const MemoryDependenceGraph &memGraph,
                       llvm::DenseSet<Operation *> &assigned,
                       llvm::SmallVectorImpl<Operation *> &group,
                       ComputeBlockIdManager &bm)
-        : seed(seed), block(block), memGraph(memGraph), assigned(assigned), group(group), bm(bm)
+        : seeds(seeds), block(block), memGraph(memGraph), assigned(assigned), group(group), bm(bm)
     {
-        group.push_back(seed);
+        for(auto sd: seeds) {
+            group.push_back(sd);
+        }
     }
 
     void run();
@@ -204,7 +207,7 @@ bool SeedRegionPlanner::tryAddToGroup(Operation *op)
     return true;
 }
 
-void SeedRegionPlanner::addSourcesToGroup()
+void SeedRegionPlanner::run()
 {
     size_t head = 0;
     while (head < group.size()) {
@@ -233,42 +236,6 @@ void SeedRegionPlanner::addSourcesToGroup()
     }
 }
 
-void SeedRegionPlanner::addUsersToGroup()
-{
-    llvm::SmallVector<Operation *> queue {seed};
-    llvm::DenseSet<Operation *> forwardVisited;
-    forwardVisited.insert(seed);
-
-    unsigned qIdx = 0;
-    while (qIdx < queue.size()) {
-        Operation *currOp = queue[qIdx++];
-        SmallVector<Operation *> allUsers;
-        for (auto *u : currOp->getUsers()) {
-            allUsers.push_back(u);
-        }
-
-        for (auto *u : memGraph.getMemUsers(currOp)) {
-            allUsers.push_back(u);
-        }
-
-        for (auto *userOp : allUsers) {
-            auto *userInBlock = getAncestorInBlock(userOp, block);
-            if (tryAddToGroup(userInBlock)) {
-                queue.push_back(userInBlock);
-            }
-        }
-    }
-}
-
-/**
- * Performs a BFS to expand a group from a seed operation (usually a Dot/Compute op).
- * It explores both operands (backward) and users (forward).
- */
-void SeedRegionPlanner::run()
-{
-    addSourcesToGroup();
-    addUsersToGroup();
-}
 
 namespace {
 
@@ -559,11 +526,50 @@ static void fuseMarkOpToDef(Block *block, ComputeBlockIdManager &bm, const Memor
     }
 }
 
+
+static bool checkValidInputSeed(Operation* op) {
+    // keep unify to OpClassifer
+    return isa<linalg::TransposeOp, bufferization::ToTensorOp, linalg::FillOp, tensor::EmptyOp>(op);
+}
+static bool checkValidUserSeed(Operation* op) {
+    // keep unify to OpClassifer
+    return isa<hivm::StoreOp, bufferization::MaterializeInDestinationOp, ViewLikeOpInterface, tensor::ExtractSliceOp>(op);
+}
+SmallVector<Operation*> PlanCubeBlockPass::matchSeed(Operation* dotOp, ComputeBlockIdManager &bm)
+{
+    // match inputs
+    SmallVector<Operation*> ret;
+    ret.push_back(dotOp);
+    for (Value operand : dotOp->getOperands()) {
+        Operation *def = operand.getDefiningOp();
+        if (!def)
+            continue;
+        if (checkValidInputSeed(def) && isCubeOp(def) && dotOp->getBlock() == def->getBlock() && bm.getBlockIdByOp(def) == -1) {
+            ret.push_back(def);
+        }
+    }
+    // match outputs
+    Operation* nowOp = dotOp;
+    while (nowOp->hasOneUse()) {
+        auto user = *nowOp->getUsers().begin();
+        if(user->getBlock() != dotOp->getBlock() || !isCubeOp(user) || bm.getBlockIdByOp(user) != -1){
+            break;
+        }
+        if (checkValidUserSeed(user)) {
+            nowOp = user;
+            ret.push_back(user);
+        } else {
+            break;
+        }
+    }
+    return ret;
+}
+
 /**
  * Main entry point: Process a single block by grouping operations into
  * execution blocks using BFS and topological traversal.
  */
-static llvm::LogicalResult processBlockWithCubeBFS(Block *block, const MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
+llvm::LogicalResult PlanCubeBlockPass::processBlockWithCubeBFS(Block *block, const MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
 {
     llvm::DenseSet<Operation *> assigned;
     auto allDots = collectMatmulOps(block);
@@ -573,9 +579,14 @@ static llvm::LogicalResult processBlockWithCubeBFS(Block *block, const MemoryDep
         if (assigned.contains(dot)) {
             continue;
         }
-
+        auto temBlockId = bm.getNextId();
+        llvm::SmallVector<Operation*> dotSeeds = matchSeed(dot, bm);
+        if (willCreateCycle(dotSeeds, memGraph, temBlockId, bm)) {
+            LOG_DEBUG("Cube Seed already have a cycle!!");
+            return llvm::failure();
+        }
         llvm::SmallVector<Operation *> newGroup;
-        SeedRegionPlanner regionPlanner {dot, block, memGraph, assigned, newGroup, bm};
+        SeedRegionPlanner regionPlanner {dotSeeds, block, memGraph, assigned, newGroup, bm};
         regionPlanner.run();
 
         for (auto *op : newGroup) {

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp
@@ -427,6 +427,7 @@ llvm::LogicalResult planVectorBlockId(Block *block, const CVPipeline::MemoryDepe
 
 void PlanVectorBlockPass::runOnOperation()
 {
+    LOG_DEBUG("\n---PlanVectorBlockPass start---\n");
     // 1. Build memory dependence graph
     auto moduleOp = getOperation();
     auto &aa = getAnalysis<AliasAnalysis>();


### PR DESCRIPTION
# Fix cube block planning to check cycles before seed assignment
## Summary
This PR fixes an issue in cube block planning where seed operations were assigned block IDs before checking for potential cycles in the memory dependence graph.

## Changes
- Improve cycle detection: Now checks for cycles before assigning block IDs to seed operations
- Enhance ComputeBlockIdManager: Added proper handling of -1 block ID to support removal/reset of block attributes
- SeedRegionPlanner: Extracts related seed operations (both input and output dependencies) from a dot operation before grouping. Removed addUsersToGroup logic and refactored to support multiple seeds instead of single seed
- Refactor block ID management: Consolidated block ID update logic to handle -1 cases properly

## Key Modifications
1. PlanCubeBlock.cpp: Main logic changes for seed matching and cycle checking
2. ComputeBlockIdManager.cpp: Fixed updateBlockId to properly handle -1 case
3. Common.cpp: Simplified rollback logic in cycle detection
4. PlanCubeBlockPass.h: Added private helper methods
5. PlanVectorBlockPass.cpp: Added debug logging


# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
