### PR TITLE
[ssbuffer](fix) Split a*b+c when may not execute (Temp for wzw)

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -47,7 +47,6 @@ inline constexpr llvm::StringLiteral kIntraBuffer = "ssbuffer.intra_buffer";
 inline constexpr llvm::StringLiteral kAnalyzeFlagId = "ssbuffer.analyze_flag_id";
 inline constexpr llvm::StringLiteral kLoopCarriedL0C = "ssbuffer.loop_carried_l0c";
 inline constexpr llvm::StringLiteral kCrossDeps = "ssbuffer.crossDeps";
-inline constexpr llvm::StringLiteral kMayNotExec = "ssbuffer.may_not_exec";
 inline constexpr const char *ERRCODE_ATTR = "triton_ascend.dynamic_cv_pipeline.rc";
 
 static constexpr const int ERRCODE_FAILED = 1;

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp.cpp
@@ -52,19 +52,6 @@ void StandardizeOpPass::runOnOperation()
         LOG_DEBUG("Pipeline Failed!");
         signalPassFailure();
     }
-
-    bool findMayNotExec = false;
-    op->walk([&](linalg::MatmulOp matmulOp) {
-        if (matmulOp->hasAttr(CVPipeline::kMayNotExec)) {
-            findMayNotExec = true;
-        }
-    });
-
-    if (findMayNotExec) {
-        LOG_DEBUG("Matmul may not execute!");
-        CVPipeline::setFallbackAttr(op);
-        signalPassFailure();
-    }
 }
 
 std::unique_ptr<OperationPass<ModuleOp>> createStandardizeOpPass()

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
@@ -537,8 +537,9 @@ static std::optional<SplitInfo> shouldSplit(linalg::MatmulOp matmulOp)
     return SplitInfo {mayNotExec, outerInValue, outerOutValue, true};
 }
 
-static void splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rewriter, SplitInfo splitInfo)
+static void splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rewriter, SplitInfo splitInfo, Operation *addPoint)
 {
+
     auto outputType = dyn_cast<RankedTensorType>(parseMatmulInputs(matmulOp).bias.getType());
     if (!outputType) {
         LOG_DEBUG("Not tensor mode: " << matmulOp
@@ -561,7 +562,7 @@ static void splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rewriter, Sp
     }
     auto emptyOp = rewriter.create<tensor::EmptyOp>(loc, outputType, dynamicSizes);
     splitInfo.outerInValue.replaceUsesWithIf(emptyOp->getResult(0),
-                                             [&](OpOperand &opop) { return opop.getOwner() == outerDefOp; });
+                                           [&](OpOperand &opop) { return opop.getOwner() == outerDefOp; });
 
     // [Step 2] Create new matmul using zero-filled tensor as accumulator
     // New matmul runs entirely on CUBE with no VECTOR dependency
@@ -580,7 +581,11 @@ static void splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rewriter, Sp
 
     // [Step 3] Create add: add(new_matmul_result, outs_value)
     // This is the "c" in a*b+c, added after the matmul result
-    rewriter.setInsertionPointAfterValue(splitInfo.outerOutValue);
+    if (addPoint) {
+        rewriter.setInsertionPoint(addPoint);
+    } else {
+        rewriter.setInsertionPointAfterValue(splitInfo.outerOutValue);
+    }
     Operation *addOp;
     if (isa<FloatType>(elmType)) {
         addOp = rewriter.create<arith::AddFOp>(loc, splitInfo.outerOutValue, splitInfo.outerInValue).getOperation();
@@ -589,8 +594,7 @@ static void splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rewriter, Sp
     }
     addOp->setAttr(CVPipeline::kAddFromMatmul, rewriter.getUnitAttr());
     splitInfo.outerOutValue.replaceUsesWithIf(addOp->getResult(0),
-                                              [&](OpOperand &opop) { return opop.getOwner() != addOp; });
-
+                                           [&](OpOperand &opop) { return opop.getOwner() != addOp; });
     rewriter.replaceOp(matmulOp, newMatmul);
 }
 
@@ -611,12 +615,8 @@ LogicalResult SplitMatmulPattern::matchAndRewrite(linalg::MatmulOp matmulOp, Pat
     LOG_DEBUG("-------------------");
     matmulOp->setAttr(CVPipeline::kLoopCarriedL0C, rewriter.getUnitAttr());
 
-    if (splitInfo.shouldSplit) {
-        splitMatmul(matmulOp, rewriter, splitInfo);
-    }
-
-    if (splitInfo.mayNotExec) {
-        matmulOp->setAttr(CVPipeline::kMayNotExec, rewriter.getUnitAttr());
+    if (splitInfo.shouldSplit ) {
+        splitMatmul(matmulOp, rewriter, splitInfo, nullptr);
     }
     return success();
 }


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
