### PR TITLE
[ssbuffer](feat) add scaler transfer through ssbuffer in SplitDataflow

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/SSBufferManager.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/SSBufferManager.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_COMMON_SSBUFFER_MANAGER_H
+#define TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_COMMON_SSBUFFER_MANAGER_H
+
+#include <optional>
+#include "llvm/ADT/DenseMap.h"
+#include "mlir/IR/Value.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/Builders.h"
+
+namespace mlir {
+namespace triton {
+
+// SSBuffer Manager for managing SSBuffer address allocation and type tracking
+// Purpose: Globally manage SSBuffer addresses across the entire pass pipeline
+// This class maintains a single mapping table: Value -> address (int64_t)
+// Type information is retrieved from the Value itself
+class SSBufferManager {
+public:
+  // SSBuffer address space and constants
+  static constexpr int SSBUF_ADDR_SPACE = 11;
+  static constexpr int ADDR_INT_TYPE = 64;
+  static constexpr int SSBUF_BASE_ADDR = 2048;      // Base address for SSBuffer
+  static constexpr int SSBUF_ADDR_OFFSET = 8;       // Address offset for each allocation
+  static constexpr int SSBUF_ADDR_MAX = 6072;       // Maximum allowed address
+
+  // Constructor
+  SSBufferManager() = default;
+
+  std::optional<int64_t> allocateAddr(Value value);
+
+  std::optional<std::pair<Value, Type>> findValueByAddr(int64_t addr);
+
+  std::optional<int64_t> writeToSSBuffer(Value value, OpBuilder &builder,
+                                         SmallVectorImpl<Operation *> &createdOps);
+
+  std::optional<Value> readFromSSBuffer(int64_t addr, OpBuilder &builder,
+                                        SmallVectorImpl<Operation *> &createdOps);
+
+  // Get the number of allocated addresses
+  size_t getAllocatedCount() const { return valueToAddrMap.size(); }
+
+  // Clear all mappings (for testing or reset)
+  void clear() { 
+    valueToAddrMap.clear();
+    addrToValueMap.clear();
+  }
+
+private:
+  static bool isScalarType(Type type);
+
+  // Forward mapping: Value -> address (int64_t)
+  // Used for address allocation and reuse
+  llvm::DenseMap<Value, int64_t> valueToAddrMap;
+  
+  // Reverse mapping: address (int64_t) -> Value
+  // Used for fast lookup when reading from SSBuffer
+  // This avoids O(n) traversal in findValueByAddr
+  llvm::DenseMap<int64_t, Value> addrToValueMap;
+};
+
+} // namespace triton
+} // namespace mlir
+
+#endif // TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_COMMON_SSBUFFER_MANAGER_H

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
@@ -51,7 +51,7 @@ struct BlockInfo {
 struct DependencyInfo {
   DependencyType type;
   mlir::Value value;
-
+  bool isScaler = false;
   int producerBlockId;
   int consumerBlockId;
   int iniProducerBlockId;
@@ -146,6 +146,7 @@ private:
     bool isCubeOrVectorOp(mlir::Operation *op);
     bool isValidShapeForDependency(mlir::Value value);
     bool isValidValueForDependency(mlir::Value value);
+    bool isValidScalarDependency(mlir::Value value);
     bool isOuterOpArg(mlir::Value value);
     void processIterArgDependencies();
     void analyzeV2CMatmulABType(DataDependencyInfo &info);

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
@@ -26,6 +26,7 @@
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h"
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/FlagIdReuse.h"
 #include "ascend/include/DynamicCVPipeline/Common/FlagIdManager.h"
+#include "ascend/include/DynamicCVPipeline/Common/SSBufferManager.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -38,6 +39,17 @@
 
 namespace mlir {
 namespace triton {
+
+struct TransferPipeConfig {
+    hivm::PipeAttr forReadTPipe;
+    hivm::PipeAttr forReadPipe;
+    hivm::PipeAttr forWriteTPipe;
+    hivm::PipeAttr forWritePipe;
+    hivm::TCoreTypeAttr srcCoreAttr;
+    hivm::TCoreTypeAttr dstCoreAttr;
+    llvm::StringRef srcCoreType;
+    llvm::StringRef dstCoreType;
+};
 
 // Define pass
 class InterCoreTransferAndSyncPass : public PassWrapper<InterCoreTransferAndSyncPass, OperationPass<ModuleOp>> {
@@ -67,6 +79,7 @@ private:
 
   llvm::DenseMap<mlir::Value, mlir::Value> vecValueMapping;
   llvm::DenseMap<mlir::Value, mlir::Value> cubeValueMapping;
+  SSBufferManager ssbufferManager;
 
   mlir::LogicalResult processDependencies(FlagIdManager &flagManager, FlagIdReuseManager &flagIdReuseManager);
   mlir::LogicalResult handleVectorToCube(mlir::OpBuilder &builder,
@@ -140,10 +153,11 @@ private:
   mlir::Operation *getConsumerWaitPoint(int transferIndex);
   mlir::Operation *insertVectorToCubeTransfer(mlir::OpBuilder &builder, mlir::Value srcValue,
     mlir::Value normalizedValue, mlir::Operation *vectorEndOp, mlir::Operation *cubeStartOp, mlir::Location loc,
-    int transferIndex, int iniConsumerId, mlir::Operation **consumedDataOp = nullptr);
+    int transferIndex, int iniConsumerId, bool isScaler, mlir::Operation **consumedDataOp = nullptr);
   mlir::Operation *insertCubeToVectorTransfer(mlir::OpBuilder &builder, mlir::Value srcValue,
     mlir::Operation *cubeEndOp, mlir::Operation *vectorStartOp, mlir::Location loc, int transferIndex,
     int iniConsumerId, mlir::Operation **consumedDataOp = nullptr);
+  TransferPipeConfig getTransferPipeConfig(Operation *transferOp);
   void insertInterCoreSync(mlir::OpBuilder &builder, mlir::Operation *transferOp, mlir::Operation *consumerStartOp,
     mlir::Operation *consumerEndOp, int flag, mlir::Location loc, int transferIndex, FlagIdReuseManager &flagIdReuseManager,
     mlir::Operation *consumedDataOp = nullptr);

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CloneOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CloneOps.cpp
@@ -401,8 +401,8 @@ LogicalResult CloneOpsPass::validateBlockIdsConsecutive(ModuleOp module)
   return success();
 }
 
-// Check that no op in a VECTOR scope's main_loop forOp has a tensor or
-// memref result carrying the ssbuffer.clone attribute.
+// Check that no op in a VECTOR scope's main_loop forOp has a tensor result \
+// carrying the ssbuffer.clone attribute.
 LogicalResult CloneOpsPass::validateClonedOpsInVector(ModuleOp module)
 {
   WalkResult result = module.walk([&](Operation *op) -> WalkResult {
@@ -433,11 +433,11 @@ LogicalResult CloneOpsPass::validateClonedOpsInVector(ModuleOp module)
       if (!bodyOp.hasAttr(CVPipeline::kClone)) {
         continue;
       }
-      bool hasTensorOrMemref = llvm::any_of(bodyOp.getResults(), [](Value result) {
-        return isa<RankedTensorType, MemRefType>(result.getType());
+      bool hasTensorDep = llvm::any_of(bodyOp.getResults(), [](Value result) {
+        return isa<RankedTensorType>(result.getType());
       });
-      if (hasTensorOrMemref) {
-        LDBG("[Error]: VECTOR main_loop contains cloned op with tensor/memref type: "
+      if (hasTensorDep) {
+        LDBG("[Error]: VECTOR main_loop contains cloned op with tensor type: "
              << bodyOp.getName() << "\n");
         return WalkResult::interrupt();
       }
@@ -491,7 +491,7 @@ void CloneOpsPass::runOnOperation()
   
   LDBG("after cloneOps:\n" << module << "\n");
 
-  // Validate no cloned tensor/memref ops remaining in VECTOR main_loop forOp
+  // Validate no cloned tensor ops remaining in VECTOR main_loop forOp
   if (failed(validateClonedOpsInVector(module))) {
     signalPassFailure();
     return;

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/SSBufferManager.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/SSBufferManager.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/DynamicCVPipeline/Common/SSBufferManager.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+
+using namespace mlir;
+using namespace triton;
+
+// Helper function to check if a type is a scalar type
+// Scalar types include: IntegerType (i1, i8, i16, i32, i64, etc.)
+// and FloatType (f16, f32, f64, bf16, f8, etc.)
+bool SSBufferManager::isScalarType(Type type)
+{
+  // Check if it's a scalar type
+  if (isa<IntegerType>(type)) {
+    return true;
+  } else if (isa<FloatType>(type)) {
+    return true;
+  } else {
+    // Not a scalar type
+    return false;
+  }
+}
+
+// Allocate SSBuffer address for a value
+std::optional<int64_t> SSBufferManager::allocateAddr(Value value)
+{
+  // Check if the value's type is a scalar type
+  Type valueType = value.getType();
+  if (!isScalarType(valueType)) {
+    // Not a scalar type, return error
+    return std::nullopt;
+  }
+
+  // Check if this value already has an allocated SSBuffer address
+  auto it = valueToAddrMap.find(value);
+  if (it != valueToAddrMap.end()) {
+    // Reuse the existing SSBuffer address
+    return it->second;
+  }
+
+  // Allocate a new SSBuffer address based on current map size
+  // Address = base_addr + map_size * offset
+  int64_t addrValue = SSBUF_BASE_ADDR + valueToAddrMap.size() * SSBUF_ADDR_OFFSET;
+
+  // Check if address exceeds maximum limit
+  if (addrValue > SSBUF_ADDR_MAX) {
+    // Address out of range, return error
+    return std::nullopt;
+  }
+
+  valueToAddrMap[value] = addrValue;
+  addrToValueMap[addrValue] = value;
+  return addrValue;
+}
+
+// Find the Value and its type for a given address
+std::optional<std::pair<Value, Type>> SSBufferManager::findValueByAddr(int64_t addr)
+{
+  // Use reverse mapping table for fast lookup
+  auto it = addrToValueMap.find(addr);
+  if (it == addrToValueMap.end()) {
+    // Address not found in mapping table
+    return std::nullopt;
+  }
+
+  // Found the address in the reverse mapping table
+  Value foundValue = it->second;
+  Type dataType = foundValue.getType();
+  return std::make_pair(foundValue, dataType);
+}
+
+// Write a value to SSBuffer and return the SSBuffer address (int64_t)
+std::optional<int64_t> SSBufferManager::writeToSSBuffer(Value value, OpBuilder &builder,
+                                                        SmallVectorImpl<Operation *> &createdOps)
+{
+  // Allocate or get existing SSBuffer address
+  auto addrResult = allocateAddr(value);
+  if (!addrResult) {
+    // Address allocation failed (either not scalar type or out of range)
+    return std::nullopt;
+  }
+
+  int64_t addrValue = addrResult.value();
+  Location loc = builder.getUnknownLoc();
+  auto i64Type = builder.getIntegerType(ADDR_INT_TYPE);
+  auto ptrType = LLVM::LLVMPointerType::get(builder.getContext(), SSBUF_ADDR_SPACE);
+
+  // Create address constant
+  auto addrAttr = builder.getIntegerAttr(i64Type, addrValue);
+  auto addrConst = builder.create<LLVM::ConstantOp>(loc, i64Type, addrAttr);
+  createdOps.push_back(addrConst);  // Record the created operation
+
+  // Convert integer address to pointer
+  auto ptr = builder.create<LLVM::IntToPtrOp>(loc, ptrType, addrConst.getResult());
+  createdOps.push_back(ptr);  // Record the created operation
+
+  // Store the value to SSBuffer
+  auto storeOp = builder.create<LLVM::StoreOp>(loc, value, ptr.getResult(), 0, /*volatile=*/true);
+  createdOps.push_back(storeOp);  // Record the created operation
+
+  // Return the address value (int64_t), not the pointer
+  return addrValue;
+}
+
+// Read a value from SSBuffer based on the given address (int64_t)
+std::optional<Value> SSBufferManager::readFromSSBuffer(int64_t addr, OpBuilder &builder,
+                                                        SmallVectorImpl<Operation *> &createdOps)
+{
+  // Find the Value and its type for the given address
+  auto findResult = findValueByAddr(addr);
+  if (!findResult) {
+    // Address not found in manager, return error
+    return std::nullopt;
+  }
+
+  Value foundValue = findResult.value().first;
+  Type dataType = findResult.value().second;
+
+  Location loc = builder.getUnknownLoc();
+  auto i64Type = builder.getIntegerType(ADDR_INT_TYPE);
+  auto ptrType = LLVM::LLVMPointerType::get(builder.getContext(), SSBUF_ADDR_SPACE);
+
+  // Create address constant
+  auto addrAttr = builder.getIntegerAttr(i64Type, addr);
+  auto addrConst = builder.create<LLVM::ConstantOp>(loc, i64Type, addrAttr);
+  createdOps.push_back(addrConst);  // Record the created operation
+
+  // Convert integer address to pointer
+  auto ptr = builder.create<LLVM::IntToPtrOp>(loc, ptrType, addrConst.getResult());
+  createdOps.push_back(ptr);  // Record the created operation
+
+  // Load the value from SSBuffer address with the retrieved data type
+  auto loadOp = builder.create<LLVM::LoadOp>(
+      loc, dataType, ptr.getResult(), 0, /*volatile=*/true);
+  createdOps.push_back(loadOp);  // Record the created operation
+
+  return loadOp.getResult();
+}

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -114,10 +114,25 @@ bool DataDependencyAnalysisPass::isValidShapeForDependency(mlir::Value value)
     return true;
 }
 
+bool DataDependencyAnalysisPass::isValidScalarDependency(mlir::Value value)
+{
+    if (isa<mlir::IntegerType, mlir::FloatType>(value.getType())) {
+        auto defOp = value.getDefiningOp();
+        if (defOp && isa<tensor::ExtractOp>(defOp)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 // Helper: Check if value is a valid tensor for dependency analysis
 // Returns true if value is TensorType and not defined by EmptyOp/FillOp
 bool DataDependencyAnalysisPass::isValidValueForDependency(mlir::Value value)
 {
+    if (isValidScalarDependency(value)) {
+        return true;
+    }
+
     if (!isValidShapeForDependency(value)) {
         return false;
     }
@@ -240,7 +255,9 @@ void DataDependencyAnalysisPass::collectDepInfo(mlir::Value depvalue, Dependency
 
     depInfo.producerBlockId = commonLevelIds.first;
     depInfo.consumerBlockId = commonLevelIds.second;
-
+    if (isValidScalarDependency(depvalue)) {
+        depInfo.isScaler = true;
+    }
     dependencies.push_back(depInfo);
 }
 
@@ -387,6 +404,11 @@ void DataDependencyAnalysisPass::processIterArgDependencies()
             // Only process if init and yield have matching core types
             // Mismatch indicates a more complex dependency pattern that requires special handling
             if (initCoreType != yieldCoreType) {
+                if (!isValidValueForDependency(initValue)) {
+                    if (collectDiffCoreTypeUsers(iterArg, yieldCoreType).empty()) {
+                        continue;
+                    }
+                }
                 LOG_DEBUG("iterarg init core_type conflicts with yield");
                 signalPassFailure();
             }
@@ -466,6 +488,10 @@ void DataDependencyAnalysisPass::analyzeExternalOutputs(DataDependencyInfo &info
             // Check if output is a value which can be produced by CUBE
             if (!isValidValueForDependency(output)) {
                 LOG_DEBUG("Warning: [c->v] Output value is not a valid tensor for dependency analysis.\n");
+                continue;
+            }
+            if (isa<mlir::IntegerType, mlir::FloatType>(output.getType())) {
+                LOG_DEBUG("Warning: [c->v] Output value is a scalar, not a valid tensor for dependency analysis.\n");
                 continue;
             }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -40,6 +40,7 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Block.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Dominance.h"
@@ -631,22 +632,25 @@ std::pair<Operation *, Operation *> InterCoreTransferAndSyncPass::createTransfer
 mlir::Operation *InterCoreTransferAndSyncPass::analyzeConsumerReadInsertPoint(
     Value srcValue, int iniConsumerId)
 {
-    llvm::SmallVector<mlir::Operation *> consumerOps;
+    llvm::DenseSet<mlir::Operation *> consumerOps;
     for (Operation *user : srcValue.getUsers()) {
         auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
         if (userBlockIdOpt && static_cast<int>(*userBlockIdOpt) == iniConsumerId) {
-            consumerOps.push_back(user);
+            consumerOps.insert(user);
         }
     }
-    auto firstConsumerOp = std::min_element(
-        consumerOps.begin(), 
-        consumerOps.end(), 
-        [](mlir::Operation* a, mlir::Operation* b) {
-            return a->isBeforeInBlock(b);
+
+    mlir::Operation* firstFoundOp = nullptr;
+
+    module->walk([&](mlir::Operation* op) {
+        if (consumerOps.contains(op)) {
+            firstFoundOp = op;
+            return mlir::WalkResult::interrupt(); 
         }
-    );
-    
-    return firstConsumerOp != consumerOps.end() ? *firstConsumerOp : nullptr;
+        return mlir::WalkResult::advance();
+    });
+
+    return firstFoundOp;
 }
 
 mlir::Operation *InterCoreTransferAndSyncPass::getConsumerWaitPoint(int transferIndex)
@@ -656,7 +660,8 @@ mlir::Operation *InterCoreTransferAndSyncPass::getConsumerWaitPoint(int transfer
         if (consumerWaitPoint) {
             return;
         }
-        if (!isa<hivm::ConvertLayoutOp>(op) && !isa<memref::MemorySpaceCastOp>(op)) {
+        if (!isa<hivm::ConvertLayoutOp>(op) && !isa<memref::MemorySpaceCastOp>(op)
+            && !isa<LLVM::LoadOp>(op)) {
             return;
         }
         auto transferIdAttr = op->getAttrOfType<IntegerAttr>(kTransferIdAttr);
@@ -669,58 +674,105 @@ mlir::Operation *InterCoreTransferAndSyncPass::getConsumerWaitPoint(int transfer
 
 Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(OpBuilder &builder, Value srcValue,
     Value normalizedValue, Operation *vectorEndOp, Operation *cubeStartOp, Location loc, int transferIndex,
-    int iniConsumerId, Operation **consumedDataOp)
+    int iniConsumerId, bool isScaler, Operation **consumedDataOp)
 {
-    LOG_DEBUG("Inserting [Vector->Cube] transfer for value: " << srcValue << "\n");
-    // Step 1: Get input information (2D tensor: MxN)
-    auto srcTensorType = cast<RankedTensorType>(srcValue.getType());
-    auto normalizedTensorType = cast<RankedTensorType>(normalizedValue.getType());
-    Type elemType = srcTensorType.getElementType();
+    mlir::Operation *sendOp = nullptr;
+    mlir::Operation *receiveOp = nullptr;
+    Value receiveValue;
 
     int vecBlockId = static_cast<int>(CVPipeline::getOpBlockId(vectorEndOp).value_or(-1));
     int cubeBlockId = static_cast<int>(CVPipeline::getOpBlockId(cubeStartOp).value_or(-1));
+    LOG_DEBUG("Inserting [Vector->Cube] transfer for value: " << srcValue << "\n");
 
-    auto [vecAllocOp, cubeAllocOp] = createTransferAllocs(builder, loc, normalizedTensorType.getShape(), elemType,
-        hivm::AddressSpace::L1, vectorEndOp, cubeStartOp, vecBlockId, cubeBlockId, "VECTOR", "CUBE", transferIndex);
+    if (isScaler) {
+        builder.setInsertionPointAfter(vectorEndOp);
+        SmallVector<Operation *> writeOps;
+        LOG_DEBUG("before writeToSSBuffer\n");
+        auto addrOpt = ssbufferManager.writeToSSBuffer(srcValue, builder, writeOps);
+        if (!addrOpt) {
+            LOG_DEBUG("[v->c] Failed to write scalar value to SSBuffer\n");
+            return nullptr;
+        }
+        int64_t addr = *addrOpt;
+        LOG_DEBUG("after writeToSSBuffer\n");
+        Operation *storeOp = nullptr;
+        for (Operation *op : writeOps) {
+            attachTransferTags(op, vecBlockId, "VECTOR", transferIndex);
+            if (isa<LLVM::StoreOp>(op)) {
+                storeOp = op;
+            }
+        }
+        sendOp = storeOp;
+        LOG_DEBUG("before readFromSSBuffer\n");
+        builder.setInsertionPoint(cubeStartOp);
+        SmallVector<Operation *> readOps;
+        auto loadedValueOpt = ssbufferManager.readFromSSBuffer(addr, builder, readOps);
+        if (!loadedValueOpt) {
+            LOG_DEBUG("[v->c] Failed to read scalar value from SSBuffer\n");
+            return nullptr;
+        }
+        receiveValue = *loadedValueOpt;
+        LOG_DEBUG("after readFromSSBuffer\n");
+        Operation *loadOp = nullptr;
+        for (Operation *op : readOps) {
+            attachTransferTags(op, cubeBlockId, "CUBE", transferIndex);
+            if (isa<LLVM::LoadOp>(op)) {
+                loadOp = op;
+            }
+        }
+        receiveOp = loadOp;
 
-    auto copyOp = builder.create<hivm::CopyOp>(loc, mlir::TypeRange{}, normalizedValue, vecAllocOp->getResult(0));
+    } else {
+        // Step 1: Get input information (2D tensor: MxN)
+        auto srcTensorType = cast<RankedTensorType>(srcValue.getType());
+        auto normalizedTensorType = cast<RankedTensorType>(normalizedValue.getType());
+        Type elemType = srcTensorType.getElementType();
 
-    attachTransferTags(copyOp, vecBlockId, "VECTOR", transferIndex);
+        auto [vecAllocOp, cubeAllocOp] = createTransferAllocs(builder, loc, normalizedTensorType.getShape(), elemType,
+            hivm::AddressSpace::L1, vectorEndOp, cubeStartOp, vecBlockId, cubeBlockId, "VECTOR", "CUBE", transferIndex);
 
-    LOG_DEBUG("[copyOp]: " << *copyOp << "\n");
+        auto copyOp = builder.create<hivm::CopyOp>(loc, mlir::TypeRange{}, normalizedValue, vecAllocOp->getResult(0));
 
-    builder.setInsertionPoint(cubeStartOp);
+        attachTransferTags(copyOp, vecBlockId, "VECTOR", transferIndex);
 
-    auto nzLayout = hivm::DataLayoutAttr::get(builder.getContext(), hivm::DataLayout::nZ);
-    auto ndLayout = hivm::DataLayoutAttr::get(builder.getContext(), hivm::DataLayout::ND);
-    auto cbufaddressSpaceAttr = builder.getAttr<hivm::AddressSpaceAttr>(hivm::AddressSpace::L1);
-    auto newAllocType = MemRefType::get(srcTensorType.getShape(), elemType, nullptr, cbufaddressSpaceAttr);
-    auto convertLayoutOp = builder.create<hivm::ConvertLayoutOp>(loc, newAllocType, cubeAllocOp->getResult(0),
-        nzLayout, // srcLayout
-        ndLayout  // dstLayout
-    );
-    auto plainMemrefType = MemRefType::get(srcTensorType.getShape(), elemType);
-    auto memspaceCastOp = builder.create<memref::MemorySpaceCastOp>(loc, plainMemrefType, convertLayoutOp.getResult());
-    auto toTensorOp =
-        builder.create<bufferization::ToTensorOp>(loc, srcTensorType, memspaceCastOp.getResult(), true, true);
+        LOG_DEBUG("[copyOp]: " << *copyOp << "\n");
 
-    attachTransferTags(convertLayoutOp, cubeBlockId, "CUBE", transferIndex);
-    attachTransferTags(memspaceCastOp, cubeBlockId, "CUBE", transferIndex);
-    attachTransferTags(toTensorOp, cubeBlockId, "CUBE", transferIndex);
-    LOG_DEBUG("[toTensorOp]: " << *toTensorOp << "\n");
+        builder.setInsertionPoint(cubeStartOp);
+
+        auto nzLayout = hivm::DataLayoutAttr::get(builder.getContext(), hivm::DataLayout::nZ);
+        auto ndLayout = hivm::DataLayoutAttr::get(builder.getContext(), hivm::DataLayout::ND);
+        auto cbufaddressSpaceAttr = builder.getAttr<hivm::AddressSpaceAttr>(hivm::AddressSpace::L1);
+        auto newAllocType = MemRefType::get(srcTensorType.getShape(), elemType, nullptr, cbufaddressSpaceAttr);
+        auto convertLayoutOp = builder.create<hivm::ConvertLayoutOp>(loc, newAllocType, cubeAllocOp->getResult(0),
+            nzLayout, // srcLayout
+            ndLayout  // dstLayout
+        );
+        auto plainMemrefType = MemRefType::get(srcTensorType.getShape(), elemType);
+        auto memspaceCastOp = builder.create<memref::MemorySpaceCastOp>(loc, plainMemrefType, convertLayoutOp.getResult());
+        auto toTensorOp =
+            builder.create<bufferization::ToTensorOp>(loc, srcTensorType, memspaceCastOp.getResult(), true, true);
+
+        attachTransferTags(convertLayoutOp, cubeBlockId, "CUBE", transferIndex);
+        attachTransferTags(memspaceCastOp, cubeBlockId, "CUBE", transferIndex);
+        attachTransferTags(toTensorOp, cubeBlockId, "CUBE", transferIndex);
+        LOG_DEBUG("[toTensorOp]: " << *toTensorOp << "\n");
+        sendOp = copyOp;
+        receiveOp = toTensorOp;
+        receiveValue = toTensorOp.getResult();
+    }
 
     llvm::SmallVector<Operation *> users(srcValue.getUsers().begin(), srcValue.getUsers().end());
     for (Operation *user : users) {
         LOG_DEBUG("[v->c user]" << *user << "\n");
         auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
         if (userBlockIdOpt && static_cast<int>(*userBlockIdOpt) == iniConsumerId) {
-            user->replaceUsesOfWith(srcValue, toTensorOp.getResult());
+            user->replaceUsesOfWith(srcValue, receiveValue);
         }
     }
     if (consumedDataOp) {
-        *consumedDataOp = toTensorOp;
+        *consumedDataOp = receiveOp;
     }
-    return copyOp;
+    return sendOp;
 }
 
 Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(OpBuilder &builder, Value srcValue,
@@ -775,6 +827,49 @@ Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(OpBuilder &b
     return fixpipeOp;
 }
 
+TransferPipeConfig InterCoreTransferAndSyncPass::getTransferPipeConfig(Operation *transferOp)
+{
+    auto cubeCoreAttr = hivm::TCoreTypeAttr::get(module.getContext(), hivm::TCoreType::CUBE);
+    auto vecCoreAttr = hivm::TCoreTypeAttr::get(module.getContext(), hivm::TCoreType::VECTOR);
+    auto pipeFixAttr = PipeAttr::get(module.getContext(), hivm::PIPE::PIPE_FIX);
+    auto pipeVAttr = PipeAttr::get(module.getContext(), hivm::PIPE::PIPE_V);
+    auto pipeMte3Attr = PipeAttr::get(module.getContext(), hivm::PIPE::PIPE_MTE3);
+    auto pipeMte1Attr = PipeAttr::get(module.getContext(), hivm::PIPE::PIPE_MTE1);
+    auto pipeMAttr = PipeAttr::get(module.getContext(), hivm::PIPE::PIPE_M);
+    auto pipeSAttr = PipeAttr::get(module.getContext(), hivm::PIPE::PIPE_S);
+    TransferPipeConfig config;
+    if (isa<hivm::FixpipeOp>(transferOp)) {
+        config.forReadTPipe = pipeFixAttr;
+        config.forReadPipe = pipeVAttr;
+        config.forWriteTPipe = pipeVAttr;
+        config.forWritePipe = pipeFixAttr;
+        config.srcCoreAttr = cubeCoreAttr;
+        config.dstCoreAttr = vecCoreAttr;
+        config.srcCoreType = "CUBE";
+        config.dstCoreType = "VECTOR";
+    } else if (isa<hivm::CopyOp>(transferOp)) {
+        config.forReadTPipe = pipeMte3Attr;
+        config.forReadPipe = pipeMte1Attr;
+        config.forWriteTPipe = pipeMAttr;
+        config.forWritePipe = pipeMte3Attr;
+        config.srcCoreAttr = vecCoreAttr;
+        config.dstCoreAttr = cubeCoreAttr;
+        config.srcCoreType = "VECTOR";
+        config.dstCoreType = "CUBE";
+    } else if (isa<LLVM::StoreOp>(transferOp)) {
+        config.forReadTPipe = pipeVAttr;
+        config.forReadPipe = pipeFixAttr;
+        config.forWriteTPipe = pipeFixAttr;
+        config.forWritePipe = pipeVAttr;
+        config.srcCoreAttr = vecCoreAttr;
+        config.dstCoreAttr = cubeCoreAttr;
+        config.srcCoreType = "VECTOR";
+        config.dstCoreType = "CUBE";
+    }
+    return config;
+}
+
+
 void InterCoreTransferAndSyncPass::insertInterCoreSync(
     OpBuilder &builder, Operation *transferOp,
     Operation *consumerStartOp, Operation *consumerEndOp,
@@ -783,13 +878,7 @@ void InterCoreTransferAndSyncPass::insertInterCoreSync(
     Operation *consumedDataOp)
 {
     LOG_DEBUG("Inserting inter-core synchronization for transferOp: " << *transferOp << "\n");
-    auto cubeCoreAttr = hivm::TCoreTypeAttr::get(builder.getContext(), hivm::TCoreType::CUBE);
-    auto vecCoreAttr = hivm::TCoreTypeAttr::get(builder.getContext(), hivm::TCoreType::VECTOR);
-    auto pipeFixAttr = PipeAttr::get(builder.getContext(), hivm::PIPE::PIPE_FIX);
-    auto pipeVAttr = PipeAttr::get(builder.getContext(), hivm::PIPE::PIPE_V);
-    auto pipeMte3Attr = PipeAttr::get(builder.getContext(), hivm::PIPE::PIPE_MTE3);
-    auto pipeMte1Attr = PipeAttr::get(builder.getContext(), hivm::PIPE::PIPE_MTE1);
-    auto pipeMAttr = PipeAttr::get(builder.getContext(), hivm::PIPE::PIPE_M);
+
     auto flagId = builder.getIntegerAttr(builder.getI64Type(), flag);
 
     int producerBlockId = static_cast<int>(CVPipeline::getOpBlockId(transferOp).value_or(-1));
@@ -797,102 +886,56 @@ void InterCoreTransferAndSyncPass::insertInterCoreSync(
 
     Operation *mainLoopOp = findMainLoopforTransfer(transferOp, consumerStartOp);
 
-    if (dyn_cast<hivm::FixpipeOp>(transferOp)) {
-        builder.setInsertionPointAfter(transferOp);
-        auto setOpForRead = builder.create<SyncBlockSetOp>(loc, cubeCoreAttr, pipeFixAttr, pipeVAttr, flagId);
-        attachTransferTags(setOpForRead, producerBlockId, "CUBE", transferIndex);
-        builder.setInsertionPoint(consumerStartOp);
-        auto waitOpForRead = builder.create<SyncBlockWaitOp>(loc, vecCoreAttr, pipeFixAttr, pipeVAttr, flagId);
-        attachTransferTags(waitOpForRead, consumerBlockId, "VECTOR", transferIndex);
+    auto config = getTransferPipeConfig(transferOp);
 
-        if (mainLoopOp) {
-            builder.setInsertionPoint(transferOp);
-            auto waitOpForWrite = builder.create<SyncBlockWaitOp>(loc, cubeCoreAttr, pipeVAttr, pipeFixAttr, flagId);
-            attachTransferTags(waitOpForWrite, producerBlockId, "CUBE", transferIndex);
-            builder.setInsertionPointAfter(consumerEndOp);
-            auto setOpForWrite = builder.create<SyncBlockSetOp>(loc, vecCoreAttr, pipeVAttr, pipeFixAttr, flagId);
-            attachTransferTags(setOpForWrite, consumerBlockId, "VECTOR", transferIndex);
+    builder.setInsertionPointAfter(transferOp);
+    auto setOpForRead = builder.create<SyncBlockSetOp>(loc, config.srcCoreAttr, config.forReadTPipe, config.forReadPipe, flagId);
+    attachTransferTags(setOpForRead, producerBlockId, config.srcCoreType, transferIndex);
+    builder.setInsertionPoint(consumerStartOp);
+    auto waitOpForRead = builder.create<SyncBlockWaitOp>(loc, config.dstCoreAttr, config.forReadTPipe, config.forReadPipe, flagId);
+    attachTransferTags(waitOpForRead, consumerBlockId, config.dstCoreType, transferIndex);
 
-            builder.setInsertionPoint(mainLoopOp);
-            auto setOpForStart = builder.create<SyncBlockSetOp>(loc, vecCoreAttr, pipeVAttr, pipeFixAttr, flagId);
-            builder.setInsertionPointAfter(mainLoopOp);
-            auto waitOpForEnd = builder.create<SyncBlockWaitOp>(loc, cubeCoreAttr, pipeVAttr, pipeFixAttr, flagId);
+    if (mainLoopOp) {
+        builder.setInsertionPoint(transferOp);
+        auto waitOpForWrite = builder.create<SyncBlockWaitOp>(loc, config.srcCoreAttr, config.forWriteTPipe, config.forWritePipe, flagId);
+        attachTransferTags(waitOpForWrite, producerBlockId, config.srcCoreType, transferIndex);
 
-            int startEndBlockId = static_cast<int>(CVPipeline::getOpBlockId(mainLoopOp).value_or(-1));
-            attachTransferTags(setOpForStart, startEndBlockId, "VECTOR", transferIndex);
-            attachTransferTags(waitOpForEnd, startEndBlockId, "CUBE", transferIndex);
+        builder.setInsertionPointAfter(consumerEndOp);
+        auto setOpForWrite = builder.create<SyncBlockSetOp>(loc, config.dstCoreAttr, config.forWriteTPipe, config.forWritePipe, flagId);
+        attachTransferTags(setOpForWrite, consumerBlockId, config.dstCoreType, transferIndex);
 
-            attachAnalyzeFlagIdTag(setOpForRead);
-            attachAnalyzeFlagIdTag(waitOpForRead);
-            attachAnalyzeFlagIdTag(waitOpForWrite);
-            attachAnalyzeFlagIdTag(setOpForWrite);
-            attachAnalyzeFlagIdTag(setOpForStart);
-            attachAnalyzeFlagIdTag(waitOpForEnd);
-            // E2: register every set->wait pair of this transfer, not just the
-            // loop start/end pair. Each pair is the only proof of cross-core
-            // ordering for the sync ops it connects.
-            flagIdReuseManager.insertRelationBetweenSetAndWait(setOpForRead, waitOpForRead);
-            flagIdReuseManager.insertRelationBetweenSetAndWait(setOpForWrite, waitOpForWrite);
-            flagIdReuseManager.insertRelationBetweenSetAndWait(setOpForStart, waitOpForEnd);
-            // E4: link the read-wait to the consumed data it guards so the sync
-            // op is threaded into the downstream dataflow graph.
-            flagIdReuseManager.insertRelationBetweenSetAndWait(waitOpForRead, consumedDataOp);
-            return;
-        }
+        builder.setInsertionPoint(mainLoopOp);
+        auto setOpForStart = builder.create<SyncBlockSetOp>(loc, config.dstCoreAttr, config.forWriteTPipe, config.forWritePipe, flagId);
+        builder.setInsertionPointAfter(mainLoopOp);
+        auto waitOpForEnd = builder.create<SyncBlockWaitOp>(loc, config.srcCoreAttr, config.forWriteTPipe, config.forWritePipe, flagId);
+
+        int startEndBlockId = static_cast<int>(CVPipeline::getOpBlockId(mainLoopOp).value_or(-1));
+        attachTransferTags(setOpForStart, startEndBlockId, config.dstCoreType, transferIndex);
+        attachTransferTags(waitOpForEnd, startEndBlockId, config.srcCoreType, transferIndex);
+
         attachAnalyzeFlagIdTag(setOpForRead);
         attachAnalyzeFlagIdTag(waitOpForRead);
+        attachAnalyzeFlagIdTag(waitOpForWrite);
+        attachAnalyzeFlagIdTag(setOpForWrite);
+        attachAnalyzeFlagIdTag(setOpForStart);
+        attachAnalyzeFlagIdTag(waitOpForEnd);
+        // E2: register every set->wait pair of this transfer, not just the
+        // loop start/end pair. Each pair is the only proof of cross-core
+        // ordering for the sync ops it connects.
         flagIdReuseManager.insertRelationBetweenSetAndWait(setOpForRead, waitOpForRead);
-        flagIdReuseManager.insertRelationBetweenSetAndWait(waitOpForRead, consumedDataOp);
-        return;
-    } else if (dyn_cast<hivm::CopyOp>(transferOp)) {
-        builder.setInsertionPointAfter(transferOp);
-        auto setOpForRead = builder.create<SyncBlockSetOp>(loc, vecCoreAttr, pipeMte3Attr, pipeMte1Attr, flagId);
-        attachTransferTags(setOpForRead, producerBlockId, "VECTOR", transferIndex);
-        builder.setInsertionPoint(consumerStartOp);
-        auto waitOpForRead = builder.create<SyncBlockWaitOp>(loc, cubeCoreAttr, pipeMte3Attr, pipeMte1Attr, flagId);
-        attachTransferTags(waitOpForRead, consumerBlockId, "CUBE", transferIndex);
-
-        if (mainLoopOp) {
-            builder.setInsertionPoint(transferOp);
-            auto waitOpForWrite = builder.create<SyncBlockWaitOp>(loc, vecCoreAttr, pipeMAttr, pipeMte3Attr, flagId);
-            attachTransferTags(waitOpForWrite, producerBlockId, "VECTOR", transferIndex);
-
-            builder.setInsertionPointAfter(consumerEndOp);
-            auto setOpForWrite = builder.create<SyncBlockSetOp>(loc, cubeCoreAttr, pipeMAttr, pipeMte3Attr, flagId);
-            attachTransferTags(setOpForWrite, consumerBlockId, "CUBE", transferIndex);
-
-            builder.setInsertionPoint(mainLoopOp);
-            auto setOpForStart = builder.create<SyncBlockSetOp>(loc, cubeCoreAttr, pipeMAttr, pipeMte3Attr, flagId);
-            builder.setInsertionPointAfter(mainLoopOp);
-            auto waitOpForEnd = builder.create<SyncBlockWaitOp>(loc, vecCoreAttr, pipeMAttr, pipeMte3Attr, flagId);
-
-            int startEndBlockId = static_cast<int>(CVPipeline::getOpBlockId(mainLoopOp).value_or(-1));
-            attachTransferTags(setOpForStart, startEndBlockId, "CUBE", transferIndex);
-            attachTransferTags(waitOpForEnd, startEndBlockId, "VECTOR", transferIndex);
-
-            attachAnalyzeFlagIdTag(setOpForRead);
-            attachAnalyzeFlagIdTag(waitOpForRead);
-            attachAnalyzeFlagIdTag(waitOpForWrite);
-            attachAnalyzeFlagIdTag(setOpForWrite);
-            attachAnalyzeFlagIdTag(setOpForStart);
-            attachAnalyzeFlagIdTag(waitOpForEnd);
-            // E2: register every set->wait pair of this transfer, not just the
-            // loop start/end pair. Each pair is the only proof of cross-core
-            // ordering for the sync ops it connects.
-            flagIdReuseManager.insertRelationBetweenSetAndWait(setOpForRead, waitOpForRead);
-            flagIdReuseManager.insertRelationBetweenSetAndWait(setOpForWrite, waitOpForWrite);
-            flagIdReuseManager.insertRelationBetweenSetAndWait(setOpForStart, waitOpForEnd);
-            // E4: link the read-wait to the consumed data it guards so the sync
-            // op is threaded into the downstream dataflow graph.
-            flagIdReuseManager.insertRelationBetweenSetAndWait(waitOpForRead, consumedDataOp);
-            return;
-        }
-        attachAnalyzeFlagIdTag(setOpForRead);
-        attachAnalyzeFlagIdTag(waitOpForRead);
-        flagIdReuseManager.insertRelationBetweenSetAndWait(setOpForRead, waitOpForRead);
+        flagIdReuseManager.insertRelationBetweenSetAndWait(setOpForWrite, waitOpForWrite);
+        flagIdReuseManager.insertRelationBetweenSetAndWait(setOpForStart, waitOpForEnd);
+        // E4: link the read-wait to the consumed data it guards so the sync
+        // op is threaded into the downstream dataflow graph.
         flagIdReuseManager.insertRelationBetweenSetAndWait(waitOpForRead, consumedDataOp);
         return;
     }
+    attachAnalyzeFlagIdTag(setOpForRead);
+    attachAnalyzeFlagIdTag(waitOpForRead);
+    flagIdReuseManager.insertRelationBetweenSetAndWait(setOpForRead, waitOpForRead);
+    flagIdReuseManager.insertRelationBetweenSetAndWait(waitOpForRead, consumedDataOp);
+    return;
+    
 }
 
 void InterCoreTransferAndSyncPass::insertMemDepSync(OpBuilder &builder, Operation *producerOp, Operation *consumerOp,
@@ -1033,13 +1076,13 @@ LogicalResult InterCoreTransferAndSyncPass::handleVectorToCube(OpBuilder &builde
     auto [consStart, consEnd] = getBlockStartEnd(dep.consumerBlockId, module);
 
     Operation *consumedDataOp = nullptr;
-  
     if (dep.consumerBlockId == dep.iniConsumerBlockId) {
         auto consumerPoint = analyzeConsumerReadInsertPoint(srcValue, dep.iniConsumerBlockId);
         consStart = consumerPoint;
     }
+    LOG_DEBUG("after analyzeConsumerReadInsertPoint\n");
     Operation *transferOp = insertVectorToCubeTransfer(builder, srcValue, normalizedVal, prodEnd, consStart, loc,
-        transferIndex, dep.iniConsumerBlockId, &consumedDataOp);
+        transferIndex, dep.iniConsumerBlockId, dep.isScaler, &consumedDataOp);
 
     int flagId = flagManager.acquireId(prodStart);
     auto [newProdStart, newProdEnd] = getBlockStartEnd(dep.producerBlockId, module);
@@ -1342,8 +1385,10 @@ LogicalResult InterCoreTransferAndSyncPass::processDependencies(
     LOG_DEBUG("Step 1: Handle V->C dependencies\n");
     // Step 1: Handle V->C dependencies
     for (auto &dep : V2CDependencies) {
-        Location loc = dep.value.getLoc();
-        Nd2NzNormalize(builder, dep, loc);
+        if (!dep.isScaler) {
+            Location loc = dep.value.getLoc();
+            Nd2NzNormalize(builder, dep, loc);
+        }
     }
     llvm::DenseMap<mlir::Value, mlir::Value> vecvalueMapping = getVecValueMapping();
     llvm::DenseMap<mlir::Value, mlir::Value> cubevalueMapping = getCubeValueMapping();
@@ -1407,7 +1452,7 @@ void InterCoreTransferAndSyncPass::getDependentDialects(DialectRegistry &registr
 {
     registry
         .insert<func::FuncDialect, arith::ArithDialect, linalg::LinalgDialect, scf::SCFDialect, tensor::TensorDialect,
-        bufferization::BufferizationDialect, memref::MemRefDialect, hivm::HIVMDialect, annotation::AnnotationDialect>();
+        bufferization::BufferizationDialect, memref::MemRefDialect, hivm::HIVMDialect, LLVM::LLVMDialect, annotation::AnnotationDialect>();
 }
 
 // Pass Entry Point


### PR DESCRIPTION
# Main Changes
New feature: Pass scalar needed to store cube result directly to GM from the Vector core to the Cube core.
input:
```
%extracted = tensor.extract %reduced[] {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "VECTOR"} : tensor<f32>
%65 = arith.cmpf ogt, %extracted, %cst_5 {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE"} : f32
```
output:
```
%extracted = tensor.extract %reduced[] {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "VECTOR"} : tensor<f32>
%60 = llvm.inttoptr %0 {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : i64 to !llvm.ptr<11>
llvm.store volatile %extracted, %60 {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : f32, !llvm.ptr<11>
hivm.hir.sync_block_set {ssbuffer.analyze_flag_id, ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 2
%63 = llvm.inttoptr %0 {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32} : i64 to !llvm.ptr<11>
hivm.hir.sync_block_wait {ssbuffer.analyze_flag_id, ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_V>, <PIPE_FIX>] flag = 2
%64 = llvm.load volatile %63 {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32} : !llvm.ptr<11> -> f32
%65 = arith.cmpf ogt, %64, %cst_5 {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE"} : f32
```

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
