### PR TITLE
[SIMT Template](feat) Support StrideLoad/Store ops

### DIFF
--- a/third_party/ascend/include/Dialect/TritonAscend/IR/TritonAscendOps.td
+++ b/third_party/ascend/include/Dialect/TritonAscend/IR/TritonAscendOps.td
@@ -343,6 +343,75 @@ def IndirectLoadOp : TT_Ascend_Op<"indirect_load", [
   ];
 }
 
+//
+// Built-in: StrideLoad Op
+//
+def StrideLoadOp : TT_Ascend_Op<"stride_load", [
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+  SameVariadicOperandSize
+]> {
+  let summary = "Built-in: strided load from global memory";
+
+  let description = [{
+    Built-in operation emitted by the compiler for SIMT stride-load templates.
+    It loads a tensor from a scalar source pointer with one i32/i64 linear
+    base offset, per-dimension physical strides and valid element counts.
+    Out-of-bound elements are filled with the scalar `other` value.
+  }];
+
+  let arguments = (
+    ins TT_Ptr:$src,
+        AnyTypeOf<[I32, I64]>:$offset,
+        AnyType:$other,
+        Variadic<AnyTypeOf<[I32, I64]>>:$stride,
+        Variadic<AnyTypeOf<[I32, I64]>>:$numel
+  );
+
+  let results = (outs TT_Tensor:$result);
+
+  let assemblyFormat = [{
+    $src `:` type($src) `,`
+    $offset `:` type($offset) `,`
+    $other `:` type($other) `,`
+    `[` $stride `:` type($stride) `]` `,`
+    `[` $numel `:` type($numel) `]`
+    attr-dict `->` type($result)
+  }];
+}
+
+//
+// Built-in: StrideStore Op
+//
+def StrideStoreOp : TT_Ascend_Op<"stride_store", [
+  MemoryEffects<[MemWrite<GlobalMemory>]>,
+  SameVariadicOperandSize
+]> {
+  let summary = "Built-in: strided store to global memory";
+
+  let description = [{
+    Built-in operation emitted by the compiler for SIMT stride-store templates.
+    It stores a tensor to a scalar destination pointer with one i32/i64 linear
+    base offset, per-dimension physical strides and valid element counts.
+  }];
+
+  let arguments = (
+    ins TT_Ptr:$dst,
+        TT_Type:$src,
+        AnyTypeOf<[I32, I64]>:$offset,
+        Variadic<AnyTypeOf<[I32, I64]>>:$stride,
+        Variadic<AnyTypeOf<[I32, I64]>>:$numel
+  );
+
+  let assemblyFormat = [{
+    $dst `:` type($dst) `,`
+    $src `:` type($src) `,`
+    $offset `:` type($offset) `,`
+    `[` $stride `:` type($stride) `]` `,`
+    `[` $numel `:` type($numel) `]`
+    attr-dict
+  }];
+}
+
 
 //
 // Built-in: IndirectStore Op

--- a/third_party/ascend/include/TritonToLinalg/StridedLoadStoreRewrite.h
+++ b/third_party/ascend/include/TritonToLinalg/StridedLoadStoreRewrite.h
@@ -31,8 +31,8 @@ namespace StridedLoadStoreRewrite {
 using namespace mlir;
 using namespace triton;
 
-// Tag stamped on tt.indirect_load ops that this sub-step emits so the pattern
-// driver does not re-enter on its own output.
+// Tag stamped on ttasc ops that this sub-step emits so the pattern driver does
+// not re-enter on its own output.
 inline constexpr const char *RewrittenByStridedLoadStoreRewriteTAG =
     "RewrittenByStridedLoadStoreRewrite";
 
@@ -44,8 +44,8 @@ inline constexpr const char *RewrittenByStridedLoadStoreRewriteTAG =
 inline constexpr const char *InspectedByStridedLoadStoreRewriteTAG =
     "InspectedByStridedLoadStoreRewrite";
 
-// V1 SIMT IndirectLoad fast-path rewrite:
-//   Convert tt.load to tt.indirect_load when the load's effective per-axis
+// V1 SIMT StrideLoad fast-path rewrite:
+//   Convert tt.load to tt.stride_load when the load's effective per-axis
 //   strides have a statically-known last-axis stride > 1 with a non-permuted
 //   layout (i.e. ImplicitPermute would not / did not touch it, and it isn't
 //   the stride==2 even-size case handled by DeinterleaveStatusOptimization).
@@ -63,7 +63,7 @@ public:
                                   PatternRewriter &rewriter) const override;
 };
 
-// V2: mirror of LoadConverter for tt.store -> tt.indirect_store. Same trigger
+// V2: mirror of LoadConverter for tt.store -> tt.stride_store. Same trigger
 // condition (non-permuted + static last-axis stride > 1, non-deinterleave),
 // same source-op restrictions (AddPtr / make_tensor_ptr / one-level advance),
 // same MLIR-pattern-contract handling via the Inspected/Rewritten tags.

--- a/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
@@ -689,6 +689,30 @@ private:
   static constexpr llvm::StringRef funcNameBase = "triton_indirect_load";
 };
 
+class StrideLoadConverter
+    : public OpConversionPattern<triton::ascend::StrideLoadOp> {
+public:
+  using OpConversionPattern<triton::ascend::StrideLoadOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(triton::ascend::StrideLoadOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override;
+
+private:
+  static constexpr llvm::StringRef funcNameBase = "triton_stride_load";
+};
+
+class StrideStoreConverter
+    : public OpConversionPattern<triton::ascend::StrideStoreOp> {
+public:
+  using OpConversionPattern<triton::ascend::StrideStoreOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(triton::ascend::StrideStoreOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override;
+
+private:
+  static constexpr llvm::StringRef funcNameBase = "triton_stride_store";
+};
+
 class IndirectStoreConverter : public OpConversionPattern<triton::ascend::IndirectStoreOp> {
 public:
   using OpConversionPattern<triton::ascend::IndirectStoreOp>::OpConversionPattern;

--- a/third_party/ascend/lib/Dialect/TritonAscend/IR/TritonAscendOps.cpp
+++ b/third_party/ascend/lib/Dialect/TritonAscend/IR/TritonAscendOps.cpp
@@ -34,6 +34,13 @@ void IndirectLoadOp::getEffects(
                        triton::GlobalMemory::get());
 }
 
+void StrideLoadOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Read::get(), &getSrcMutable(),
+                       triton::GlobalMemory::get());
+}
+
 //-- IndexSelectSimdOp --
 LogicalResult IndexSelectSimdOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> location, ValueRange operands,

--- a/third_party/ascend/lib/TritonToLinalg/CMakeLists.txt
+++ b/third_party/ascend/lib/TritonToLinalg/CMakeLists.txt
@@ -28,6 +28,7 @@ add_triton_library(TritonToLinalg
   MLIRTensorDialect
   MLIRTransforms
   MLIRSupport
+  BiShengIRHIVMDialect
   TritonIR
   TritonTransforms
   TritonAnalysis

--- a/third_party/ascend/lib/TritonToLinalg/MarkTensorKindPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/MarkTensorKindPass.cpp
@@ -47,6 +47,10 @@ template <typename T, typename = void> struct has_getSrc : std::false_type {};
 template <typename T>
 struct has_getSrc<T, std::void_t<decltype(std::declval<T>().getSrc())>> : std::true_type {};
 
+template <typename T, typename = void> struct has_getDst : std::false_type {};
+template <typename T>
+struct has_getDst<T, std::void_t<decltype(std::declval<T>().getDst())>> : std::true_type {};
+
 template <typename T, typename = void> struct has_getBase : std::false_type {};
 template <typename T>
 struct has_getBase<T, std::void_t<decltype(std::declval<T>().getBase())>> : std::true_type {};
@@ -56,6 +60,8 @@ static Value extractPointer(OpTy op)
 {
   if constexpr (has_getPtr<OpTy>::value)
     return op.getPtr();
+  else if constexpr (has_getDst<OpTy>::value)
+    return op.getDst();
   else if constexpr (has_getSrc<OpTy>::value)
     return op.getSrc();
   else if constexpr (has_getBase<OpTy>::value)
@@ -134,7 +140,8 @@ void MarkTensorKindPass::runOnOperation() {
       MarkTensorKindPattern<TensorKind::INPUT, triton::LoadOp>,
       MarkTensorKindPattern<TensorKind::INPUT, triton::ascend::IndexSelectSimdOp>,
       MarkTensorKindPattern<TensorKind::INPUT, triton::ascend::GatherOutToUbOp>,
-      MarkTensorKindPattern<TensorKind::INPUT, triton::ascend::IndirectLoadOp>
+      MarkTensorKindPattern<TensorKind::INPUT, triton::ascend::IndirectLoadOp>,
+      MarkTensorKindPattern<TensorKind::INPUT, triton::ascend::StrideLoadOp>
   >(&getContext());
 
   // OUTPUT tensors
@@ -142,6 +149,7 @@ void MarkTensorKindPass::runOnOperation() {
       MarkTensorKindPattern<TensorKind::OUTPUT, triton::StoreOp>,
       MarkTensorKindPattern<TensorKind::OUTPUT, triton::ascend::IndexPutOp>,
       MarkTensorKindPattern<TensorKind::OUTPUT, triton::ascend::ScatterUbToOutOp>,
+      MarkTensorKindPattern<TensorKind::OUTPUT, triton::ascend::StrideStoreOp>,
       MarkTensorKindPattern<TensorKind::OUTPUT, triton::ascend::IndirectStoreOp>
   >(&getContext());
 

--- a/third_party/ascend/lib/TritonToLinalg/StridedLoadStoreRewrite.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/StridedLoadStoreRewrite.cpp
@@ -22,6 +22,7 @@
 
 #include "TritonToLinalg/StridedLoadStoreRewrite.h"
 #include "TritonToLinalg/ImplicitPermute.h"
+#include "TritonToLinalg/MaskAnalysis.h"
 #include "TritonToStructured/PtrAnalysis.h"
 #include "Utils/Utils.h"
 
@@ -245,6 +246,307 @@ static Value addScalarOffsetToTensor(Value offsetTensor, Value scalarOffset,
                                           scalarOffsetTensor);
 }
 
+static Value getStrideLoadOtherScalar(triton::LoadOp op,
+                                      RankedTensorType resultType,
+                                      PatternRewriter &rewriter) {
+    auto loc = op.getLoc();
+    Type elementType = resultType.getElementType();
+    if (Value other = op.getOther()) {
+        if (auto splatOp = other.getDefiningOp<triton::SplatOp>())
+            return splatOp.getSrc();
+
+        DenseElementsAttr denseAttr;
+        if (matchPattern(other, m_Constant(&denseAttr)) && denseAttr.isSplat()) {
+            if (auto floatType = dyn_cast<FloatType>(elementType)) {
+                return rewriter.create<arith::ConstantOp>(
+                    loc, rewriter.getFloatAttr(
+                             elementType,
+                             denseAttr.getSplatValue<APFloat>()));
+            }
+            if (isa<IntegerType>(elementType)) {
+                return rewriter.create<arith::ConstantOp>(
+                    loc, rewriter.getIntegerAttr(
+                             elementType,
+                             denseAttr.getSplatValue<APInt>()));
+            }
+        }
+        return Value();
+    }
+
+    if (op.getPadding().has_value() &&
+        op.getPadding().value() == triton::PaddingOption::PAD_NAN) {
+        auto floatTy = dyn_cast<FloatType>(elementType);
+        if (!floatTy) return Value();
+        return rewriter.create<arith::ConstantOp>(
+            loc, rewriter.getFloatAttr(
+                     elementType,
+                     APFloat::getNaN(floatTy.getFloatSemantics())));
+    }
+    return rewriter.create<arith::ConstantOp>(loc,
+                                              rewriter.getZeroAttr(elementType));
+}
+
+static Value createStrideLoadOp(Location loc, RankedTensorType resultType,
+                                Value src, Value offset, Value other,
+                                ArrayRef<Value> strides,
+                                ArrayRef<Value> numels,
+                                PatternRewriter &rewriter) {
+    int64_t rank = resultType.getRank();
+    if (static_cast<int64_t>(strides.size()) != rank ||
+        static_cast<int64_t>(numels.size()) != rank) {
+        return Value();
+    }
+
+    Type indexType = rewriter.getI32Type();
+    auto chooseIndexType = [&](Value value) -> bool {
+        Type type = value.getType();
+        if (isa<IndexType>(type) || type.isInteger(64)) {
+            indexType = rewriter.getI64Type();
+            return true;
+        }
+        return type.isInteger(32);
+    };
+    auto castToIndexType = [&](Value value) -> Value {
+        Type type = value.getType();
+        if (type == indexType) return value;
+        if (isa<IndexType>(type))
+            return rewriter.create<arith::IndexCastOp>(loc, indexType, value);
+        if (type.isInteger(32) && indexType.isInteger(64))
+            return rewriter.create<arith::ExtSIOp>(loc, indexType, value);
+        return Value();
+    };
+    auto chooseAll = [&](ArrayRef<Value> values) -> bool {
+        for (Value value : values) {
+            if (!chooseIndexType(value)) return false;
+        }
+        return true;
+    };
+
+    if (!chooseIndexType(offset) || !chooseAll(strides) ||
+        !chooseAll(numels))
+        return Value();
+    offset = castToIndexType(offset);
+    if (!offset) return Value();
+    SmallVector<Value> castStrides;
+    SmallVector<Value> castNumels;
+    castStrides.reserve(rank);
+    castNumels.reserve(rank);
+    for (Value stride : strides) {
+        stride = castToIndexType(stride);
+        if (!stride) return Value();
+        castStrides.push_back(stride);
+    }
+    for (Value numel : numels) {
+        numel = castToIndexType(numel);
+        if (!numel) return Value();
+        castNumels.push_back(numel);
+    }
+
+    auto strideLoad = rewriter.create<triton::ascend::StrideLoadOp>(
+        loc, resultType, src, offset, other, castStrides, castNumels);
+    strideLoad->setAttr(RewrittenByStridedLoadStoreRewriteTAG,
+                        UnitAttr::get(rewriter.getContext()));
+    return strideLoad->getResult(0);
+}
+
+static Operation *createStrideStoreOp(Location loc, RankedTensorType valueType,
+                                      Value dst, Value src, Value offset,
+                                      ArrayRef<Value> strides,
+                                      ArrayRef<Value> numels,
+                                      PatternRewriter &rewriter) {
+    int64_t rank = valueType.getRank();
+    if (static_cast<int64_t>(strides.size()) != rank ||
+        static_cast<int64_t>(numels.size()) != rank) {
+        return nullptr;
+    }
+
+    Type indexType = rewriter.getI32Type();
+    auto chooseIndexType = [&](Value value) -> bool {
+        Type type = value.getType();
+        if (isa<IndexType>(type) || type.isInteger(64)) {
+            indexType = rewriter.getI64Type();
+            return true;
+        }
+        return type.isInteger(32);
+    };
+    auto castToIndexType = [&](Value value) -> Value {
+        Type type = value.getType();
+        if (type == indexType) return value;
+        if (isa<IndexType>(type))
+            return rewriter.create<arith::IndexCastOp>(loc, indexType, value);
+        if (type.isInteger(32) && indexType.isInteger(64))
+            return rewriter.create<arith::ExtSIOp>(loc, indexType, value);
+        return Value();
+    };
+    auto chooseAll = [&](ArrayRef<Value> values) -> bool {
+        for (Value value : values) {
+            if (!chooseIndexType(value)) return false;
+        }
+        return true;
+    };
+
+    if (!chooseIndexType(offset) || !chooseAll(strides) ||
+        !chooseAll(numels))
+        return nullptr;
+    offset = castToIndexType(offset);
+    if (!offset) return nullptr;
+    SmallVector<Value> castStrides;
+    SmallVector<Value> castNumels;
+    castStrides.reserve(rank);
+    castNumels.reserve(rank);
+    for (Value stride : strides) {
+        stride = castToIndexType(stride);
+        if (!stride) return nullptr;
+        castStrides.push_back(stride);
+    }
+    for (Value numel : numels) {
+        numel = castToIndexType(numel);
+        if (!numel) return nullptr;
+        castNumels.push_back(numel);
+    }
+
+    auto strideStore = rewriter.create<triton::ascend::StrideStoreOp>(
+        loc, dst, src, offset, castStrides, castNumels);
+    strideStore->setAttr(RewrittenByStridedLoadStoreRewriteTAG,
+                         UnitAttr::get(rewriter.getContext()));
+    return strideStore.getOperation();
+}
+
+static Value materializeI64(OpFoldResult ofr, Location loc,
+                            PatternRewriter &rewriter) {
+    if (auto attr = ofr.dyn_cast<Attribute>()) {
+        int64_t value = cast<IntegerAttr>(attr).getInt();
+        return rewriter.create<arith::ConstantOp>(
+            loc, rewriter.getI64IntegerAttr(value));
+    }
+    return ensureI64Scalar(ofr.get<Value>(), loc, rewriter);
+}
+
+static Value clampI64(Value value, Value lower, Value upper, Location loc,
+                      PatternRewriter &rewriter) {
+    value = rewriter.create<arith::MaxSIOp>(loc, value, lower);
+    return rewriter.create<arith::MinSIOp>(loc, value, upper);
+}
+
+static Value getPrefixMaskNumel(Operation *op, Value mask,
+                                RankedTensorType resultType,
+                                PatternRewriter &rewriter) {
+    if (!mask) {
+        return rewriter.create<arith::ConstantOp>(
+            op->getLoc(),
+            rewriter.getI64IntegerAttr(resultType.getShape().front()));
+    }
+
+    auto maskState = triton::runMaskAnalysis(op, rewriter);
+    if (!maskState || maskState->getRank() != 1) return Value();
+
+    auto offset = getConstantIntValue(maskState->offsets.front());
+    if (!offset.has_value() || offset.value() != 0) return Value();
+
+    auto loc = op->getLoc();
+    Value zero = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getI64IntegerAttr(0));
+    Value block = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getI64IntegerAttr(resultType.getShape().front()));
+    Value numel = materializeI64(maskState->dims.front(), loc, rewriter);
+    if (!numel) return Value();
+    return clampI64(numel, zero, block, loc, rewriter);
+}
+
+static FailureOr<SmallVector<Value>> getAddPtrStrideNumels(
+    Operation *op, Value mask, RankedTensorType resultType,
+    PatternRewriter &rewriter) {
+    auto loc = op->getLoc();
+    int64_t rank = resultType.getRank();
+    ArrayRef<int64_t> shape = resultType.getShape();
+
+    if (!mask) {
+        SmallVector<Value> numels;
+        for (int64_t d = 0; d < rank; ++d)
+            numels.push_back(rewriter.create<arith::ConstantOp>(
+                loc, rewriter.getI64IntegerAttr(shape[d])));
+        return numels;
+    }
+
+    if (rank == 1) {
+        Value numel = getPrefixMaskNumel(op, mask, resultType, rewriter);
+        if (!numel) return failure();
+        return SmallVector<Value>{numel};
+    }
+
+    auto maskState = triton::runMaskAnalysis(op, rewriter);
+    if (!maskState || maskState->getRank() != rank) return failure();
+
+    for (int64_t d = 0; d < rank; ++d) {
+        auto offsetVal = getConstantIntValue(maskState->offsets[d]);
+        if (!offsetVal.has_value() || offsetVal.value() != 0)
+            return failure();
+    }
+
+    Value zero = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getI64IntegerAttr(0));
+    SmallVector<Value> numels;
+    numels.reserve(rank);
+    for (int64_t d = 0; d < rank; ++d) {
+        Value block = rewriter.create<arith::ConstantOp>(
+            loc, rewriter.getI64IntegerAttr(shape[d]));
+        Value numel = materializeI64(maskState->dims[d], loc, rewriter);
+        if (!numel) return failure();
+        numel = clampI64(numel, zero, block, loc, rewriter);
+        numels.push_back(numel);
+    }
+    return numels;
+}
+
+static FailureOr<SmallVector<Value>> getBlockPtrStrideNumels(
+    Operation *op, Value mask, ArrayRef<int32_t> boundaryCheck,
+    triton::MakeTensorPtrOp mtpt,
+    RankedTensorType resultType, ArrayRef<Value> logicalOffsets,
+    PatternRewriter &rewriter) {
+    auto loc = op->getLoc();
+    Value zero = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getI64IntegerAttr(0));
+    ArrayRef<int64_t> shape = resultType.getShape();
+    int64_t rank = resultType.getRank();
+    SmallVector<Value> numels;
+    numels.reserve(rank);
+
+    if (mask && rank != 1) return failure();
+    Value prefixMaskNumel;
+    if (mask) {
+        prefixMaskNumel = getPrefixMaskNumel(op, mask, resultType, rewriter);
+        if (!prefixMaskNumel) return failure();
+    }
+
+    for (int64_t d = 0; d < rank; ++d) {
+        Value block = rewriter.create<arith::ConstantOp>(
+            loc, rewriter.getI64IntegerAttr(shape[d]));
+        Value numel = (d == 0 && prefixMaskNumel) ? prefixMaskNumel : block;
+
+        bool hasBoundaryCheck = false;
+        for (int32_t axis : boundaryCheck) {
+            if (axis == static_cast<int32_t>(d)) {
+                hasBoundaryCheck = true;
+                break;
+            }
+        }
+        if (hasBoundaryCheck) {
+            Value parentSize = ensureI64Scalar(mtpt.getShape()[d], loc,
+                                               rewriter);
+            if (!parentSize) return failure();
+            Value remaining =
+                rewriter.create<arith::SubIOp>(loc, parentSize,
+                                               logicalOffsets[d]);
+            Value boundaryNumel =
+                clampI64(remaining, zero, block, loc, rewriter);
+            numel = rewriter.create<arith::MinSIOp>(loc, numel, boundaryNumel);
+        }
+        numels.push_back(numel);
+    }
+
+    return numels;
+}
+
 // Expand a 1D tensor `v` of length `targetShape[axis]` into a rank-N tensor
 // with size `targetShape[axis]` at `axis` and size 1 elsewhere, then
 // broadcast to `targetShape`. Used to materialise the per-axis contribution
@@ -393,6 +695,68 @@ static LogicalResult tryRewriteAddPtrLoad(triton::LoadOp op,
         !routeMaskedPow2ToIndirect)
         return markInspectedAndReturn();  // power-of-two >= 4 -> strided DMA
 
+    bool useStrideLoad = !routeMaskedPow2ToIndirect;
+    if (useStrideLoad && resultType.getRank() >= 1 &&
+        resultType.getRank() <= 3 &&
+        resultType.hasStaticShape() &&
+        static_cast<int64_t>(ptrState.stateInfo.size()) ==
+            resultType.getRank()) {
+        Value src = ptrState.source;
+        SmallVector<Value> strides;
+        SmallVector<Value> numels;
+        strides.reserve(resultType.getRank());
+
+        Value baseOffset = materializeI64(ptrState.offset, loc, rewriter);
+        bool operandsReady = src && baseOffset;
+        for (int64_t d = 0; operandsReady && d < resultType.getRank(); ++d) {
+            Value stride =
+                materializeI64(ptrState.stateInfo[d].stride, loc, rewriter);
+            if (!stride) {
+                operandsReady = false;
+                break;
+            }
+            strides.push_back(stride);
+        }
+
+        if (operandsReady) {
+            auto numelsResult =
+                getAddPtrStrideNumels(op.getOperation(), op.getMask(),
+                                      resultType, rewriter);
+            if (succeeded(numelsResult)) {
+                numels = *numelsResult;
+            } else {
+                operandsReady = false;
+            }
+        }
+        Value other = operandsReady
+                          ? getStrideLoadOtherScalar(op, resultType, rewriter)
+                          : Value();
+        operandsReady = operandsReady && other;
+
+        if (operandsReady) {
+            Value strideLoadResult = createStrideLoadOp(
+                loc, resultType, src, baseOffset, other, strides, numels,
+                rewriter);
+            if (!strideLoadResult) return markInspectedAndReturn();
+
+            LLVM_DEBUG({
+                llvm::dbgs()
+                    << "----------------------------------------------\n";
+                llvm::dbgs() << "StridedLoadStoreRewrite [AddPtr]: tt.load -> "
+                                "ttasc.stride_load\n";
+                llvm::dbgs() << "  last_stride = " << lastStride << "\n";
+                llvm::dbgs() << strideLoadResult.getDefiningOp() << "\n";
+                llvm::dbgs()
+                    << "----------------------------------------------\n";
+            });
+            rewriter.replaceOp(op, strideLoadResult);
+            return success();
+        }
+    }
+
+    if (useStrideLoad && resultType.getRank() <= 3)
+        return markInspectedAndReturn();
+
     Value offsetTensor =
         ensureI64OffsetTensor(addPtrOp.getOffset(), loc, rewriter);
     if (!offsetTensor) return failure();
@@ -412,7 +776,8 @@ static LogicalResult tryRewriteAddPtrLoad(triton::LoadOp op,
 
     LLVM_DEBUG({
         llvm::dbgs() << "----------------------------------------------\n";
-        llvm::dbgs() << "StridedLoadStoreRewrite [AddPtr]: tt.load -> tt.indirect_load\n";
+        llvm::dbgs() << "StridedLoadStoreRewrite [AddPtr]: tt.load -> "
+                        "tt.indirect_load\n";
         llvm::dbgs() << "  last_stride = " << lastStride << "\n";
         llvm::dbgs() << indirectLoad << "\n";
         llvm::dbgs() << "----------------------------------------------\n";
@@ -455,8 +820,8 @@ static LogicalResult tryRewriteBlockPtrLoad(triton::LoadOp op,
     // Stride dispatch: strided DMA on the MTE engine only supports power-of-two
     // strides; a non-power-of-two stride would degrade to a slow scalar access.
     // Dynamic strides stay on the structured SIMD path because they may be
-    // runtime stride 1 or power-of-two, where SIMT indirect is slower. So we
-    // only rewrite to SIMT indirect for *static non-power-of-two* strides:
+    // runtime stride 1 or power-of-two, where SIMT stride is slower. So we
+    // only rewrite to SIMT stride for *static non-power-of-two* strides:
     //   stride 1 -> contiguous; stride 2 (even dim) -> deinterleave;
     //   stride >= 4 (power of two) -> (compact) strided DMA.
     APInt lastStrideC;
@@ -479,11 +844,10 @@ static LogicalResult tryRewriteBlockPtrLoad(triton::LoadOp op,
     // Unwrap any `tt.addptr` chain on the SCALAR base ptr (e.g. when the
     // kernel writes `tl.make_block_ptr(s + bos*H + i_h, ...)`). If we left
     // those scalar AddPtrs in place, the AddPtrConverter would lower each
-    // into a `memref.reinterpret_cast ... sizes: [1]` single-element view,
-    // and our tt.indirect_load would receive a size-1 src that the per-axis
-    // offset tensor indexes way out of bounds. By walking the scalar AddPtr
-    // chain here we (a) fold its scalar offsets into `scalarBaseAdj` and
-    // (b) recover the original underlying `!tt.ptr<T>` to use as our src.
+    // into a `memref.reinterpret_cast ... sizes: [1]` single-element view. By
+    // walking the scalar AddPtr chain here we (a) fold its scalar offsets into
+    // `scalarBaseAdj` and (b) recover the original underlying `!tt.ptr<T>` to
+    // use as our src.
     Value src = mtpt.getBase();
     Value scalarBaseAdj = rewriter.create<arith::ConstantOp>(
         loc, rewriter.getI64IntegerAttr(0));
@@ -499,8 +863,16 @@ static LogicalResult tryRewriteBlockPtrLoad(triton::LoadOp op,
         src = addptr.getPtr();
     }
 
-    // Build the scalar base offset: scalarBaseAdj + sum_d (mtpt.offsets[d] + adv.offsets[d]) * strides[d].
+    // Build the scalar base offset:
+    //   scalarBaseAdj + sum_d (mtpt.offsets[d] + adv.offsets[d]) * strides[d].
+    // Boundary checks are expressed in logical make_tensor_ptr coordinates, so
+    // numels must use the unstrided per-axis offsets rather than this physical
+    // GM offset.
     Value scalarBase = scalarBaseAdj;
+    SmallVector<Value> logicalOffsets;
+    SmallVector<Value> strideOperands;
+    logicalOffsets.reserve(rank);
+    strideOperands.reserve(rank);
     for (int64_t d = 0; d < rank; ++d) {
         Value baseOff = ensureI64Scalar(mtptOffsets[d], loc, rewriter);
         if (!baseOff) return failure();
@@ -509,13 +881,45 @@ static LogicalResult tryRewriteBlockPtrLoad(triton::LoadOp op,
             if (!advStep) return failure();
             baseOff = rewriter.create<arith::AddIOp>(loc, baseOff, advStep);
         }
+        logicalOffsets.push_back(baseOff);
         Value strI64 = ensureI64Scalar(strides[d], loc, rewriter);
         if (!strI64) return failure();
+        strideOperands.push_back(strI64);
         Value prod = rewriter.create<arith::MulIOp>(loc, baseOff, strI64);
         scalarBase = rewriter.create<arith::AddIOp>(loc, scalarBase, prod);
     }
 
-    // offset_tensor = splat(scalarBase) + sum_d broadcast(arange(0,B_d) * strides[d])
+    if (resultType.getRank() >= 1 &&
+        resultType.getRank() <= 3 && resultType.hasStaticShape()) {
+        FailureOr<SmallVector<Value>> numels = getBlockPtrStrideNumels(
+            op.getOperation(), op.getMask(), op.getBoundaryCheck(), mtpt,
+            resultType, logicalOffsets, rewriter);
+        if (succeeded(numels)) {
+            Value other = getStrideLoadOtherScalar(op, resultType, rewriter);
+            if (!other) return failure();
+            Value strideLoadResult = createStrideLoadOp(
+                loc, resultType, src, scalarBase, other, strideOperands, *numels,
+                rewriter);
+            if (!strideLoadResult) return failure();
+
+            LLVM_DEBUG({
+                llvm::dbgs()
+                    << "----------------------------------------------\n";
+                llvm::dbgs() << "StridedLoadStoreRewrite [BlockPtr"
+                             << (advance ? "+Advance" : "")
+                             << "]: tt.load -> ttasc.stride_load\n";
+                llvm::dbgs() << "  last_stride = " << lastStride << "\n";
+                llvm::dbgs() << strideLoadResult.getDefiningOp() << "\n";
+                llvm::dbgs()
+                    << "----------------------------------------------\n";
+            });
+            rewriter.replaceOp(op, strideLoadResult);
+            return success();
+        }
+    }
+
+    if (rank <= 3) return failure();
+
     auto i64TensorTy = RankedTensorType::get(shape, i64Ty);
     Value offsetTensor =
         rewriter.create<triton::SplatOp>(loc, i64TensorTy, scalarBase);
@@ -588,7 +992,8 @@ static LogicalResult tryRewriteBlockPtrLoad(triton::LoadOp op,
 // V2 (Store) helpers ----------------------------------------------------------
 
 // AddPtr path for tt.store. Mirrors tryRewriteAddPtrLoad but emits
-// triton::ascend::IndirectStoreOp and eraseOp's the original tt.store.
+// triton::ascend::StrideStoreOp when the mask can be represented by per-axis
+// numel bounds.
 static LogicalResult tryRewriteAddPtrStore(triton::StoreOp op,
                                             triton::AddPtrOp addPtrOp,
                                             RankedTensorType valueType,
@@ -626,6 +1031,63 @@ static LogicalResult tryRewriteAddPtrStore(triton::StoreOp op,
     if ((lastStride & (lastStride - 1)) == 0 &&
         !routeMaskedPow2ToIndirect)
         return markInspectedAndReturn();  // power-of-two >= 4 -> strided DMA
+
+    bool useStrideStore = !routeMaskedPow2ToIndirect;
+    if (useStrideStore && valueType.getRank() >= 1 &&
+        valueType.getRank() <= 3 &&
+        valueType.hasStaticShape() &&
+        static_cast<int64_t>(ptrState.stateInfo.size()) ==
+            valueType.getRank()) {
+        Value dst = ptrState.source;
+        SmallVector<Value> strides;
+        SmallVector<Value> numels;
+        strides.reserve(valueType.getRank());
+
+        Value baseOffset = materializeI64(ptrState.offset, loc, rewriter);
+        bool operandsReady = dst && baseOffset;
+        for (int64_t d = 0; operandsReady && d < valueType.getRank(); ++d) {
+            Value stride =
+                materializeI64(ptrState.stateInfo[d].stride, loc, rewriter);
+            if (!stride) {
+                operandsReady = false;
+                break;
+            }
+            strides.push_back(stride);
+        }
+
+        if (operandsReady) {
+            auto numelsResult = getAddPtrStrideNumels(
+                op.getOperation(), op.getMask(), valueType, rewriter);
+            if (succeeded(numelsResult)) {
+                numels = *numelsResult;
+            } else {
+                operandsReady = false;
+            }
+        }
+
+        if (operandsReady) {
+            Operation *strideStore = createStrideStoreOp(
+                loc, valueType, dst, op.getValue(), baseOffset, strides, numels,
+                rewriter);
+            if (!strideStore) return markInspectedAndReturn();
+
+            LLVM_DEBUG({
+                llvm::dbgs()
+                    << "----------------------------------------------\n";
+                llvm::dbgs() << "StridedLoadStoreRewrite [AddPtr/Store]: "
+                                "tt.store -> ttasc.stride_store\n";
+                llvm::dbgs() << "  last_stride = " << lastStride << "\n";
+                llvm::dbgs() << *strideStore << "\n";
+                llvm::dbgs()
+                    << "----------------------------------------------\n";
+            });
+            rewriter.eraseOp(op);
+            return success();
+        }
+    }
+
+    if (useStrideStore && valueType.getRank() <= 3)
+        return markInspectedAndReturn();
 
     Value offsetTensor =
         ensureI64OffsetTensor(addPtrOp.getOffset(), loc, rewriter);
@@ -678,7 +1140,7 @@ static LogicalResult tryRewriteBlockPtrStore(triton::StoreOp op,
         return failure();
     // Stride dispatch (mirrors tryRewriteBlockPtrLoad): dynamic strides stay on
     // the structured SIMD path; only static non-power-of-two strides fall
-    // through to SIMT indirect.
+    // through to SIMT stride_store.
     APInt lastStrideC;
     if (!matchPattern(strides.back(), m_ConstantInt(&lastStrideC)))
         return failure();
@@ -712,6 +1174,10 @@ static LogicalResult tryRewriteBlockPtrStore(triton::StoreOp op,
     }
 
     Value scalarBase = scalarBaseAdj;
+    SmallVector<Value> logicalOffsets;
+    SmallVector<Value> strideOperands;
+    logicalOffsets.reserve(rank);
+    strideOperands.reserve(rank);
     for (int64_t d = 0; d < rank; ++d) {
         Value baseOff = ensureI64Scalar(mtptOffsets[d], loc, rewriter);
         if (!baseOff) return failure();
@@ -720,11 +1186,44 @@ static LogicalResult tryRewriteBlockPtrStore(triton::StoreOp op,
             if (!advStep) return failure();
             baseOff = rewriter.create<arith::AddIOp>(loc, baseOff, advStep);
         }
+        logicalOffsets.push_back(baseOff);
         Value strI64 = ensureI64Scalar(strides[d], loc, rewriter);
         if (!strI64) return failure();
+        strideOperands.push_back(strI64);
         Value prod = rewriter.create<arith::MulIOp>(loc, baseOff, strI64);
         scalarBase = rewriter.create<arith::AddIOp>(loc, scalarBase, prod);
     }
+
+    auto boundaryCheck = op.getBoundaryCheck();
+    if (valueType.getRank() >= 1 &&
+        valueType.getRank() <= 3 && valueType.hasStaticShape()) {
+        FailureOr<SmallVector<Value>> numels = getBlockPtrStrideNumels(
+            op.getOperation(), op.getMask(), boundaryCheck, mtpt, valueType,
+            logicalOffsets, rewriter);
+        if (succeeded(numels)) {
+            Operation *strideStore = createStrideStoreOp(
+                loc, valueType, src, op.getValue(), scalarBase, strideOperands,
+                *numels, rewriter);
+            if (strideStore) {
+                LLVM_DEBUG({
+                    llvm::dbgs()
+                        << "----------------------------------------------\n";
+                    llvm::dbgs() << "StridedLoadStoreRewrite [BlockPtr"
+                                 << (advance ? "+Advance" : "")
+                                 << (boundaryCheck.empty() ? "" : "+Boundary")
+                                 << "/Store]: tt.store -> ttasc.stride_store\n";
+                    llvm::dbgs() << "  last_stride = " << lastStride << "\n";
+                    llvm::dbgs() << *strideStore << "\n";
+                    llvm::dbgs()
+                        << "----------------------------------------------\n";
+                });
+                rewriter.eraseOp(op);
+                return success();
+            }
+        }
+    }
+
+    if (rank <= 3) return failure();
 
     auto i64TensorTy = RankedTensorType::get(shape, i64Ty);
     Value offsetTensor =
@@ -748,7 +1247,6 @@ static LogicalResult tryRewriteBlockPtrStore(triton::StoreOp op,
 
     // ---- boundary_check: build OOB mask (store has no "other") ----
     Value mask = op.getMask();
-    auto boundaryCheck = op.getBoundaryCheck();
     if (!boundaryCheck.empty()) {
         SmallVector<Value> effOffsets;
         for (int64_t d = 0; d < rank; ++d) {

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -2744,6 +2744,95 @@ IndirectLoadConverter::matchAndRewrite(triton::ascend::IndirectLoadOp op, OpAdap
   return success();
 }
 
+LogicalResult StrideLoadConverter::matchAndRewrite(
+    triton::ascend::StrideLoadOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+  auto loc = op.getLoc();
+
+  auto moduleOp = op->getParentOfType<ModuleOp>();
+  rewriter.setInsertionPoint(moduleOp.getBody(),
+                             std::prev(moduleOp.getBody()->end()));
+
+  auto funcName = generateUniqueFuncName(moduleOp, funcNameBase);
+
+  auto src = adaptor.getSrc();
+  auto offset = adaptor.getOffset();
+  auto other = adaptor.getOther();
+  auto strides = adaptor.getStride();
+  auto numels = adaptor.getNumel();
+  auto resTy = op.getResult().getType();
+
+  auto srcTy = dyn_cast<MemRefType>(src.getType());
+  if (!srcTy) {
+    return rewriter.notifyMatchFailure(op, "expected MemRefType for src");
+  }
+
+  SmallVector<Type> inputTypes({srcTy});
+  inputTypes.push_back(offset.getType());
+  inputTypes.push_back(other.getType());
+  for (Value stride : strides)
+    inputTypes.push_back(stride.getType());
+  for (Value numel : numels)
+    inputTypes.push_back(numel.getType());
+  auto libFnType = rewriter.getFunctionType(inputTypes, {resTy});
+  auto funcOp = rewriter.create<func::FuncOp>(loc, funcName.str(), libFnType);
+  SymbolTable::setSymbolVisibility(funcOp, SymbolTable::Visibility::Private);
+
+  SmallVector<Value> inputVals({src});
+  inputVals.push_back(offset);
+  inputVals.push_back(other);
+  inputVals.append(strides.begin(), strides.end());
+  inputVals.append(numels.begin(), numels.end());
+
+  rewriter.setInsertionPoint(op);
+  auto callOp = rewriter.create<func::CallOp>(
+      loc, funcOp.getSymNameAttr(), TypeRange({resTy}), inputVals);
+  rewriter.replaceOp(op, callOp);
+  return success();
+}
+
+LogicalResult StrideStoreConverter::matchAndRewrite(
+    triton::ascend::StrideStoreOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+  auto loc = op.getLoc();
+
+  auto moduleOp = op->getParentOfType<ModuleOp>();
+  rewriter.setInsertionPoint(moduleOp.getBody(),
+                             std::prev(moduleOp.getBody()->end()));
+
+  auto funcName = generateUniqueFuncName(moduleOp, funcNameBase);
+
+  auto dst = adaptor.getDst();
+  auto src = adaptor.getSrc();
+  auto offset = adaptor.getOffset();
+  auto strides = adaptor.getStride();
+  auto numels = adaptor.getNumel();
+
+  auto dstTy = dyn_cast<MemRefType>(dst.getType());
+  if (!dstTy) {
+    return rewriter.notifyMatchFailure(op, "expected MemRefType for dst");
+  }
+
+  SmallVector<Type> inputTypes({dstTy, src.getType(), offset.getType()});
+  for (Value stride : strides)
+    inputTypes.push_back(stride.getType());
+  for (Value numel : numels)
+    inputTypes.push_back(numel.getType());
+  auto libFnType = rewriter.getFunctionType(inputTypes, {});
+  auto funcOp = rewriter.create<func::FuncOp>(loc, funcName.str(), libFnType);
+  SymbolTable::setSymbolVisibility(funcOp, SymbolTable::Visibility::Private);
+
+  SmallVector<Value> inputVals({dst, src, offset});
+  inputVals.append(strides.begin(), strides.end());
+  inputVals.append(numels.begin(), numels.end());
+
+  rewriter.setInsertionPoint(op);
+  rewriter.create<func::CallOp>(loc, funcOp.getSymNameAttr(), TypeRange({}),
+                                inputVals);
+  rewriter.eraseOp(op);
+  return success();
+}
+
 LogicalResult
 IndirectStoreConverter::matchAndRewrite(triton::ascend::IndirectStoreOp op, OpAdaptor adaptor,
                                         ConversionPatternRewriter &rewriter) const

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -206,6 +206,8 @@ static bool isSIMTOp(Operation *op)
       triton::ascend::GatherOutToUbOp,
       triton::ascend::ScatterUbToOutOp,
       triton::ascend::IndirectLoadOp,
+      triton::ascend::StrideLoadOp,
+      triton::ascend::StrideStoreOp,
       triton::ascend::IndirectStoreOp
       >(op);
 }
@@ -805,6 +807,8 @@ void TritonToLinalgPass::populateTritonToLinalgConversionPatterns(
   patterns.add<TTOpConverters::PtrToIntConverter>(patterns.getContext());
 
   patterns.add<TTOpConverters::IndirectLoadConverter>(patterns.getContext());
+  patterns.add<TTOpConverters::StrideLoadConverter>(patterns.getContext());
+  patterns.add<TTOpConverters::StrideStoreConverter>(patterns.getContext());
   patterns.add<TTOpConverters::IndirectStoreConverter>(patterns.getContext());
   patterns.add<TTOpConverters::GatherOutToUbConverter>(patterns.getContext());
   patterns.add<TTOpConverters::ScatterUbToOutConverter>(patterns.getContext());

--- a/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/indirect_load_rewrite.mlir
+++ b/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/indirect_load_rewrite.mlir
@@ -58,9 +58,11 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
 
 // -----
 // V1 rank-1 hit (AddPtr, static non-power-of-two stride 3):
-// tt.addptr(splat ptr, arange*3) -> should become tt.indirect_load.
+// tt.addptr(splat ptr, arange*3) -> should become triton_stride_load call.
 // CHECK-LABEL: func.func @addptr_stride3_1d
-// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}) : (memref<?xf32>, tensor<256xi64>) -> tensor<256xf32>
+// CHECK-NOT: call @triton_indirect_load
+// CHECK: call @triton_stride_load
+// CHECK-SAME: : (memref<?xf32>, i64, f32, i64, i64) -> tensor<256xf32>
 module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
   tt.func public @addptr_stride3_1d(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
                                     %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
@@ -82,6 +84,7 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
 // Runtime stride may be 1 or power-of-two, so keep the structured SIMD path.
 // CHECK-LABEL: func.func @addptr_dynamic_stride_1d
 // CHECK-NOT: call @triton_indirect_load
+// CHECK-NOT: call @triton_stride_load
 module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
   tt.func public @addptr_dynamic_stride_1d(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
                                            %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32},
@@ -104,6 +107,7 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
 // Runtime stride may be 1 or power-of-two, so keep the structured SIMD path.
 // CHECK-LABEL: func.func @addptr_dynamic_stride_store_scalar_base
 // CHECK-NOT: call @triton_indirect_store
+// CHECK-NOT: call @triton_stride_store
 module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
   tt.func public @addptr_dynamic_stride_store_scalar_base(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
                                                           %base_offset: i64,
@@ -117,6 +121,39 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
     %base = tt.splat %scalar_base : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>>
     %ptr = tt.addptr %base, %offsets : tensor<32x!tt.ptr<f32>>, tensor<32xi64>
     tt.store %ptr, %cst : tensor<32x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// -----
+// V1 rank-2 hit (AddPtr, static non-power-of-two stride 3):
+// CHECK-LABEL: func.func @addptr_stride3_2d
+// CHECK-NOT: call @triton_indirect_load
+// CHECK: call @triton_stride_load
+// CHECK-SAME: : (memref<?xf32>, i64, f32, i64, i64, i64, i64) -> tensor<4x8xf32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @addptr_stride3_2d(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                    %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+    %m = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %m_exp = tt.expand_dims %m {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
+    %m_b = tt.broadcast %m_exp : tensor<4x1xi32> -> tensor<4x8xi32>
+    %n = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+    %n_exp = tt.expand_dims %n {axis = 0 : i32} : tensor<8xi32> -> tensor<1x8xi32>
+    %n_b = tt.broadcast %n_exp : tensor<1x8xi32> -> tensor<4x8xi32>
+    %c96 = arith.constant dense<96> : tensor<4x8xi32>
+    %c3 = arith.constant dense<3> : tensor<4x8xi32>
+    %row = arith.muli %m_b, %c96 : tensor<4x8xi32>
+    %col = arith.muli %n_b, %c3 : tensor<4x8xi32>
+    %offset = arith.addi %row, %col : tensor<4x8xi32>
+    %src = tt.splat %arg0 : !tt.ptr<f32> -> tensor<4x8x!tt.ptr<f32>>
+    %ptr = tt.addptr %src, %offset : tensor<4x8x!tt.ptr<f32>>, tensor<4x8xi32>
+    %val = tt.load %ptr : tensor<4x8x!tt.ptr<f32>>
+    %c8 = arith.constant dense<8> : tensor<4x8xi32>
+    %out_row = arith.muli %m_b, %c8 : tensor<4x8xi32>
+    %out_offset = arith.addi %out_row, %n_b : tensor<4x8xi32>
+    %dst = tt.splat %arg1 : !tt.ptr<f32> -> tensor<4x8x!tt.ptr<f32>>
+    %out_ptr = tt.addptr %dst, %out_offset : tensor<4x8x!tt.ptr<f32>>, tensor<4x8xi32>
+    tt.store %out_ptr, %val : tensor<4x8x!tt.ptr<f32>>
     tt.return
   }
 }
@@ -142,10 +179,12 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
 }
 
 // -----
-// V1 hit (make_tensor_ptr, non-permuted, low-dim non-power-of-two stride 5):
-// strides=[256, 5], order=[1,0] -> last-dim stride is not power-of-two, non-permuted -> V1 rewrites
+// V3 hit (make_tensor_ptr, rank-2): non-power-of-two low-dim stride uses
+// triton_stride_load.
 // CHECK-LABEL: func.func @mtpt_low_stride5
-// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}) : (memref<?xf32>, tensor<4x8xi64>) -> tensor<4x8xf32>
+// CHECK-NOT: call @triton_indirect_load
+// CHECK: call @triton_stride_load
+// CHECK-SAME: : (memref<?xf32>, i64, f32, i64, i64, i64, i64) -> tensor<4x8xf32>
 module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
   tt.func public @mtpt_low_stride5(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
                                    %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
@@ -163,6 +202,75 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
     %2 = tt.make_tensor_ptr %arg1, [%sz_out_m, %sz_out_n], [%sz_out_n, %sz1], [%c0, %c0]
          {order = array<i32: 1, 0>} : <tensor<4x8xf32>>
     tt.store %2, %1 : !tt.ptr<tensor<4x8xf32>>
+    tt.return
+  }
+}
+
+// -----
+// V3 hit (make_tensor_ptr, rank-3): non-power-of-two low-dim stride uses
+// triton_stride_load with one base offset, 3 strides and 3 numels.
+// CHECK-LABEL: func.func @mtpt_3d_low_stride3
+// CHECK-NOT: call @triton_indirect_load
+// CHECK: call @triton_stride_load
+// CHECK-SAME: : (memref<?xf32>, i64, f32, i64, i64, i64, i64, i64, i64) -> tensor<2x4x8xf32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @mtpt_3d_low_stride3(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                      %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+    %c0 = arith.constant 0 : i32
+    %size_b = arith.constant 16 : i64
+    %size_m = arith.constant 64 : i64
+    %size_n = arith.constant 256 : i64
+    %stride_b = arith.constant 16384 : i64
+    %stride_m = arith.constant 256 : i64
+    %stride_n = arith.constant 3 : i64
+    %0 = tt.make_tensor_ptr %arg0, [%size_b, %size_m, %size_n], [%stride_b, %stride_m, %stride_n], [%c0, %c0, %c0]
+         {order = array<i32: 2, 1, 0>} : <tensor<2x4x8xf32>>
+    %1 = tt.load %0 : !tt.ptr<tensor<2x4x8xf32>>
+    %sz_b = arith.constant 2 : i64
+    %sz_m = arith.constant 4 : i64
+    %sz_n = arith.constant 8 : i64
+    %out_stride_b = arith.constant 32 : i64
+    %out_stride_m = arith.constant 8 : i64
+    %out_stride_n = arith.constant 1 : i64
+    %2 = tt.make_tensor_ptr %arg1, [%sz_b, %sz_m, %sz_n], [%out_stride_b, %out_stride_m, %out_stride_n], [%c0, %c0, %c0]
+         {order = array<i32: 2, 1, 0>} : <tensor<2x4x8xf32>>
+    tt.store %2, %1 : !tt.ptr<tensor<2x4x8xf32>>
+    tt.return
+  }
+}
+
+// -----
+// V1 rank-4 fallback (make_tensor_ptr): stride_load only supports 1-3D, so
+// rank-4 static non-power-of-two stride still uses triton_indirect_load.
+// CHECK-LABEL: func.func @mtpt_4d_low_stride3_indirect
+// CHECK-NOT: call @triton_stride_load
+// CHECK: call @triton_indirect_load
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @mtpt_4d_low_stride3_indirect(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                               %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+    %c0 = arith.constant 0 : i32
+    %size_b = arith.constant 8 : i64
+    %size_h = arith.constant 16 : i64
+    %size_m = arith.constant 64 : i64
+    %size_n = arith.constant 256 : i64
+    %stride_b = arith.constant 262144 : i64
+    %stride_h = arith.constant 16384 : i64
+    %stride_m = arith.constant 256 : i64
+    %stride_n = arith.constant 3 : i64
+    %0 = tt.make_tensor_ptr %arg0, [%size_b, %size_h, %size_m, %size_n], [%stride_b, %stride_h, %stride_m, %stride_n], [%c0, %c0, %c0, %c0]
+         {order = array<i32: 3, 2, 1, 0>} : <tensor<2x3x4x8xf32>>
+    %1 = tt.load %0 : !tt.ptr<tensor<2x3x4x8xf32>>
+    %sz_b = arith.constant 2 : i64
+    %sz_h = arith.constant 3 : i64
+    %sz_m = arith.constant 4 : i64
+    %sz_n = arith.constant 8 : i64
+    %out_stride_b = arith.constant 96 : i64
+    %out_stride_h = arith.constant 32 : i64
+    %out_stride_m = arith.constant 8 : i64
+    %out_stride_n = arith.constant 1 : i64
+    %2 = tt.make_tensor_ptr %arg1, [%sz_b, %sz_h, %sz_m, %sz_n], [%out_stride_b, %out_stride_h, %out_stride_m, %out_stride_n], [%c0, %c0, %c0, %c0]
+         {order = array<i32: 3, 2, 1, 0>} : <tensor<2x3x4x8xf32>>
+    tt.store %2, %1 : !tt.ptr<tensor<2x3x4x8xf32>>
     tt.return
   }
 }
@@ -215,7 +323,9 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
 // -----
 // V1 rank-1 hit (make_tensor_ptr, static non-power-of-two stride 7):
 // CHECK-LABEL: func.func @mtpt_1d_stride7
-// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}) : (memref<?xf32>, tensor<128xi64>) -> tensor<128xf32>
+// CHECK-NOT: call @triton_indirect_load
+// CHECK: call @triton_stride_load
+// CHECK-SAME: : (memref<?xf32>, i64, f32, i64, i64) -> tensor<128xf32>
 module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
   tt.func public @mtpt_1d_stride7(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
                                   %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
@@ -238,6 +348,7 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
 // Runtime stride may be 1 or power-of-two, so keep the structured SIMD path.
 // CHECK-LABEL: func.func @mtpt_1d_dynamic_stride
 // CHECK-NOT: call @triton_indirect_load
+// CHECK-NOT: call @triton_stride_load
 module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
   tt.func public @mtpt_1d_dynamic_stride(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
                                          %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32},
@@ -283,9 +394,10 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
 
 // -----
 // V2 hit (AddPtr Store, 1D, static non-power-of-two stride 3):
-// tt.store(tt.addptr(splat ptr, arange*3), value) -> tt.indirect_store -> call @triton_indirect_store
+// tt.store(tt.addptr(splat ptr, arange*3), value) -> tt.stride_store -> call @triton_stride_store
 // CHECK-LABEL: func.func @addptr_store_stride3_1d
-// CHECK: call @triton_indirect_store(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?xf32>, tensor<256xi64>, tensor<256xf32>) -> ()
+// CHECK-NOT: call @triton_indirect_store
+// CHECK: call @triton_stride_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (memref<?xf32>, tensor<256xf32>, i64, i64, i64) -> ()
 module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
   tt.func public @addptr_store_stride3_1d(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
                                           %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
@@ -323,7 +435,8 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
 // -----
 // V2 hit (make_tensor_ptr Store, non-permuted, low-dim non-power-of-two stride 5):
 // CHECK-LABEL: func.func @mtpt_store_low_stride5
-// CHECK: call @triton_indirect_store(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?xf32>, tensor<4x8xi64>, tensor<4x8xf32>) -> ()
+// CHECK-NOT: call @triton_indirect_store
+// CHECK: call @triton_stride_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (memref<?xf32>, tensor<4x8xf32>, i64, i64, i64, i64, i64) -> ()
 module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
   tt.func public @mtpt_store_low_stride5(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
                                          %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
@@ -341,6 +454,42 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
     %2 = tt.make_tensor_ptr %arg1, [%size_m, %size_n], [%stride_m, %stride_n], [%c0, %c0]
          {order = array<i32: 1, 0>} : <tensor<4x8xf32>>
     tt.store %2, %1 : !tt.ptr<tensor<4x8xf32>>
+    tt.return
+  }
+}
+
+// -----
+// V2 rank-4 fallback (make_tensor_ptr Store): stride_store only supports 1-3D,
+// so rank-4 static non-power-of-two stride still uses triton_indirect_store.
+// CHECK-LABEL: func.func @mtpt_store_4d_low_stride5_indirect
+// CHECK-NOT: call @triton_stride_store
+// CHECK: call @triton_indirect_store
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @mtpt_store_4d_low_stride5_indirect(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                                     %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+    %c0 = arith.constant 0 : i32
+    %size_b = arith.constant 8 : i64
+    %size_h = arith.constant 16 : i64
+    %size_m = arith.constant 64 : i64
+    %size_n = arith.constant 256 : i64
+    %stride_b = arith.constant 327680 : i64
+    %stride_h = arith.constant 20480 : i64
+    %stride_m = arith.constant 256 : i64
+    %stride_n = arith.constant 5 : i64
+    %sz_b = arith.constant 2 : i64
+    %sz_h = arith.constant 3 : i64
+    %sz_m = arith.constant 4 : i64
+    %sz_n = arith.constant 8 : i64
+    %in_stride_b = arith.constant 96 : i64
+    %in_stride_h = arith.constant 32 : i64
+    %in_stride_m = arith.constant 8 : i64
+    %in_stride_n = arith.constant 1 : i64
+    %0 = tt.make_tensor_ptr %arg0, [%sz_b, %sz_h, %sz_m, %sz_n], [%in_stride_b, %in_stride_h, %in_stride_m, %in_stride_n], [%c0, %c0, %c0, %c0]
+         {order = array<i32: 3, 2, 1, 0>} : <tensor<2x3x4x8xf32>>
+    %1 = tt.load %0 : !tt.ptr<tensor<2x3x4x8xf32>>
+    %2 = tt.make_tensor_ptr %arg1, [%size_b, %size_h, %size_m, %size_n], [%stride_b, %stride_h, %stride_m, %stride_n], [%c0, %c0, %c0, %c0]
+         {order = array<i32: 3, 2, 1, 0>} : <tensor<2x3x4x8xf32>>
+    tt.store %2, %1 : !tt.ptr<tensor<2x3x4x8xf32>>
     tt.return
   }
 }
@@ -390,11 +539,12 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
 }
 
 // -----
-// V1.5 hit (make_tensor_ptr Load + boundary_check + PAD_ZERO, low-dim non-power-of-two stride 5):
-// Block 8x8 covers a 7x5 parent => some lanes OOB. Expected: tt.indirect_load
-// with both mask (tensor<8x8xi1>) and other (tensor<8x8xf32>) zero splat.
+// V3 hit (make_tensor_ptr Load + boundary_check + PAD_ZERO, rank-2):
+// zero padding is represented by per-dimension numel operands.
 // CHECK-LABEL: func.func @mtpt_load_boundary_pad_zero
-// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (memref<?xf32>, tensor<8x8xi64>, tensor<8x8xi1>, tensor<8x8xf32>) -> tensor<8x8xf32>
+// CHECK-NOT: call @triton_indirect_load
+// CHECK: call @triton_stride_load
+// CHECK-SAME: : (memref<?xf32>, i64, f32, i64, i64, i64, i64) -> tensor<8x8xf32>
 module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
   tt.func public @mtpt_load_boundary_pad_zero(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
                                               %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
@@ -420,7 +570,9 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
 // -----
 // V1.5 hit (make_tensor_ptr Load + boundary_check + PAD_NAN, low-dim non-power-of-two stride 5):
 // CHECK-LABEL: func.func @mtpt_load_boundary_pad_nan
-// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (memref<?xf32>, tensor<8x8xi64>, tensor<8x8xi1>, tensor<8x8xf32>) -> tensor<8x8xf32>
+// CHECK-NOT: call @triton_indirect_load
+// CHECK: call @triton_stride_load
+// CHECK-SAME: : (memref<?xf32>, i64, f32, i64, i64, i64, i64) -> tensor<8x8xf32>
 module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
   tt.func public @mtpt_load_boundary_pad_nan(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
                                              %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
@@ -453,7 +605,10 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
 //
 // Regression test for the chunk_local_cumsum precision bug fixed 2026-05-28.
 // CHECK-LABEL: func.func @mtpt_load_scalar_addptr_base
-// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (memref<?xf32>, tensor<128xi64>, tensor<128xi1>, tensor<128xf32>) -> tensor<128xf32>
+// CHECK-NOT: call @triton_indirect_load
+// CHECK-NOT: memref<1xf32
+// CHECK: call @triton_stride_load
+// CHECK-SAME: : (memref<?xf32>, i64, f32, i64, i64) -> tensor<128xf32>
 module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
   tt.func public @mtpt_load_scalar_addptr_base(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
                                                 %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32},
@@ -483,9 +638,10 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
 
 // -----
 // V1.5 hit (make_tensor_ptr Store + boundary_check, low-dim non-power-of-two stride 5):
-// Store with mask but no "other" -- 3 operand call: (src, offset, value, mask).
+// Store boundary is represented by per-dimension numel operands.
 // CHECK-LABEL: func.func @mtpt_store_boundary
-// CHECK: call @triton_indirect_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (memref<?xf32>, tensor<8x8xi64>, tensor<8x8xf32>, tensor<8x8xi1>) -> ()
+// CHECK-NOT: call @triton_indirect_store
+// CHECK: call @triton_stride_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (memref<?xf32>, tensor<8x8xf32>, i64, i64, i64, i64, i64) -> ()
 module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
   tt.func public @mtpt_store_boundary(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
                                       %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {

--- a/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/tile_chunk_coalescing.mlir
+++ b/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/tile_chunk_coalescing.mlir
@@ -62,6 +62,36 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
 }
 
 // -----
+// A one-tile mask has BOUND == tileLen. It is provably all true for the only
+// tile, but the static tile count is one, so there is nothing to coalesce.
+// CHECK-LABEL: module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+// CHECK-NOT: hacc.coalesce_factor
+// CHECK-LABEL: func.func @tile_chunk_single_full_tile
+// CHECK-NOT: sizes: [16, 16]
+// CHECK: sizes: [16]
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @tile_chunk_single_full_tile(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                              %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+    %pid = tt.get_program_id x : i32
+    %c16 = arith.constant 16 : i32
+    %c16_tensor = arith.constant dense<16> : tensor<16xi32>
+    %zero = arith.constant dense<0.000000e+00> : tensor<16xf32>
+    %blk = arith.muli %pid, %c16 : i32
+    %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %blk_splat = tt.splat %blk : i32 -> tensor<16xi32>
+    %offs = arith.addi %blk_splat, %range : tensor<16xi32>
+    %mask = arith.cmpi slt, %offs, %c16_tensor : tensor<16xi32>
+    %src_base = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+    %src_ptr = tt.addptr %src_base, %offs : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+    %val = tt.load %src_ptr, %mask, %zero : tensor<16x!tt.ptr<f32>>
+    %dst_base = tt.splat %arg1 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+    %dst_ptr = tt.addptr %dst_base, %offs : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+    tt.store %dst_ptr, %val, %mask : tensor<16x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// -----
 // Reading num_programs on the coalesced axis is unsafe because the host launcher
 // divides that grid dimension by H. The pass must leave the kernel uncoalesced.
 // CHECK-LABEL: module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {


### PR DESCRIPTION
## Summary

Support the dedicated `stride_load` / `stride_store` route for static
non-power-of-two strided GM accesses, while preserving the existing
`indirect_load` / `indirect_store` behavior where it is still required.

## Why

The existing indirect path can represent irregular accesses, but it is too
general for common strided accesses. For static non-power-of-two stride cases,
the compiler already knows the access can be described as a scalar base offset
plus per-axis stride and valid element counts. Lowering those cases through
`stride_load` / `stride_store` preserves that structure for the SIMT template
instead of first materializing a full per-element offset tensor.

This is especially useful for 1D-3D strided loads and stores, where the stride
ABI directly matches the access pattern and avoids routing performance-sensitive
regular strides through the more general indirect path.

There are still cases where indirect access is the correct representation:

- Dynamic strides must stay on the structured DMA/coalescing path, because they
  may be stride-1 or power-of-two at runtime.
- `stride_load` / `stride_store` only support 1D-3D, so 4D-5D accesses continue
  to use `indirect_load` / `indirect_store`.
- Masked single-tile power-of-two AddPtr cases keep the upstream indirect route
  to avoid the structured strided-copy boundary-size issue.
- Indirect loads now also carry volatility information so the lowering can avoid
  unnecessary volatile calls when no prior same-root store can affect the load.

## Behavior

- Static non-power-of-two 1D-3D load/store accesses route to
  `triton_stride_load` / `triton_stride_store`.
- Dynamic stride and structured DMA-friendly cases remain out of the SIMT stride
  rewrite.
- 4D-5D strided accesses keep the indirect fallback.
- Indirect-load tests cover both volatile and non-volatile cases.
