### PR TITLE
[MaskAccess](fix) Canonicalize null 'other' to zero for masked load

### DIFF
--- a/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
+++ b/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
@@ -149,6 +149,34 @@ static MaskDecomposition decomposeAndMask(Operation *op, Value mask,
   return {contMask, discMask};
 }
 
+// Canonicalize triton::LoadOp that has a mask but no 'other' value by
+// supplying a zero-filled 'other'.
+struct MaskedLoadOtherCanonicalizer : OpRewritePattern<triton::LoadOp> {
+  using OpRewritePattern<triton::LoadOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(triton::LoadOp op,
+                                PatternRewriter &rewriter) const final {
+    auto mask = op.getMask();
+    auto other = op.getOther();
+    if (!mask || other)
+      return failure();
+
+    auto loc = op.getLoc();
+    auto ptr = op.getPtr();
+
+    FailureOr<Value> zeroConst = specializeTypelessValueToConstant(
+        TypelessValue::Zero, ptr.getType(), loc, rewriter);
+    if (failed(zeroConst))
+      return failure();
+
+    auto newLoadOp = rewriter.create<triton::LoadOp>(
+        loc, ptr, mask, *zeroConst, op.getCache(), op.getEvict(),
+        op.getIsVolatile());
+    rewriter.replaceOp(op, newLoadOp.getResult());
+    return success();
+  }
+};
+
 struct DiscreteMaskStoreConversion : OpRewritePattern<triton::StoreOp> {
   using OpRewritePattern<triton::StoreOp>::OpRewritePattern;
 
@@ -357,8 +385,9 @@ void DiscreteMaskAccessConversionPass::runOnOperation() {
   auto moduleOp = getOperation();
 
   RewritePatternSet patterns(&getContext());
-  patterns.add<DiscreteMaskLoadConversion, DiscreteMaskStoreConversion,
-               DiscreteMaskAtomicConversion>(patterns.getContext());
+  patterns.add<MaskedLoadOtherCanonicalizer, DiscreteMaskLoadConversion,
+               DiscreteMaskStoreConversion, DiscreteMaskAtomicConversion>(
+      patterns.getContext());
   if (failed(applyPatternsGreedily(moduleOp, std::move(patterns)))) {
     moduleOp->emitError("failed to apply discrete mask access patterns");
     signalPassFailure();


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
## Summary

Fix the probabilistic precision error of `test_linearize_jump_load_with_mask`. Added a `MaskedLoadOtherCanonicalizer` pattern in `DiscreteMaskAccessConversionPass` that automatically fills `other = 0` for masked `LoadOp` with `other = None`, ensuring consistent behavior with the pre-care_padding-removal semantics — out-of-bounds elements default to zero — across all lowering paths.

## Why

The frontend removal of the `care_padding`-related intrusive modification from `semantic.py` previously auto-filled `other = 0.0` when `tl.load(ptr, mask=mask)` was called without an explicit `other` argument. After its removal, the IR-level `triton::LoadOp` carries `other = null`.

Ascend backend lowering passes handle `other = null` inconsistently:

- **`DiscreteMaskLoadConversion`** (discrete mask path): handled correctly, auto-fills zero.
- **`TritonToLinalg/LoadStoreConverter`** (continuous mask path): the `if (other)` branch is skipped, leaving the unmasked region of `allocOp` with uninitialized memory. The random garbage values manifest as probabilistic precision errors.

## Fix

Added handling logic for `other = null` in `DiscreteMaskAccessConversionPass`. For any `LoadOp` where `mask != null && other == null`, the `other` value is canonicalized to zero.

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
