### PR TITLE
[ssbuffer](fix) fix bug in pr508

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
@@ -610,13 +610,14 @@ LogicalResult SplitMatmulPattern::matchAndRewrite(linalg::MatmulOp matmulOp, Pat
     LOG_DEBUG("shouldSplit = " << splitInfo.shouldSplit);
     LOG_DEBUG("-------------------");
     matmulOp->setAttr(CVPipeline::kLoopCarriedL0C, rewriter.getUnitAttr());
-
+    
+    if (splitInfo.mayNotExec) {
+        matmulOp->setAttr(CVPipeline::kMayNotExec, rewriter.getUnitAttr());
+    }
+    
     if (splitInfo.shouldSplit) {
         splitMatmul(matmulOp, rewriter, splitInfo);
     }
 
-    if (splitInfo.mayNotExec) {
-        matmulOp->setAttr(CVPipeline::kMayNotExec, rewriter.getUnitAttr());
-    }
     return success();
 }


### PR DESCRIPTION
Add  kMayNotExec Attr before rewrite matmul.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
