### PR TITLE
[Test](fix) Add explicit other=0.0 to masked load

### DIFF
--- a/third_party/ascend/unittest/pytest_ut/test_linearize.py
+++ b/third_party/ascend/unittest/pytest_ut/test_linearize.py
@@ -468,11 +468,11 @@ def save_cache_to_buffer_with_mask(buffer_ptr, cache_ptr1, cache_ptr2, mask_int_
     mask_int = tl.load(mask_int_ptr + pid_loc)
     if pid_loc % 2 == 0:
         tmp = tl.load(cache_ptr1 + (2*BLOCK*cache_index_0 + cache_index_1), \
-            ((2*BLOCK*cache_index_0 + cache_index_1) < buffer_offset * 2 + MASK_NUM))
+            ((2*BLOCK*cache_index_0 + cache_index_1) < buffer_offset * 2 + MASK_NUM), other=0.0)
         tl.store(buffer_ptr + index, tmp)
     if pid_loc % 2 == 1:
         tmp = tl.load(cache_ptr2 + (2*BLOCK*cache_index_0 + cache_index_1), \
-            (buffer_index < MASK_NUM) & (buffer_index < mask_int))
+            (buffer_index < MASK_NUM) & (buffer_index < mask_int), other=0.0)
         tl.store(buffer_ptr + index, tmp)
 
 


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

## Summary

Fix the probabilistic precision error of `test_linearize_jump_load_with_mask`. Explicitly add `other=0.0` to the `tl.load` calls in the `save_cache_to_buffer_with_mask` kernel to guarantee that masked-out elements return zero.

## Why

Before the `care_padding` parameter was removed, the frontend in `semantic.py` would automatically fill `other = 0.0` when `tl.load(ptr, mask=mask)` was called without an explicit `other` argument. After that logic was removed, `other` defaults to `None`. Triton semantics require that masked-out elements (mask=False) yield the `other` value, and when `other` is unspecified the behavior is undefined.

The `save_cache_to_buffer_with_mask` kernel relied on `tl.load` masks to filter elements but did not explicitly specify `other`. After the `care_padding` removal, elements whose mask evaluates to False are no longer guaranteed to be zero — on certain Ascend backend lowering paths they may read random values from uninitialized memory, causing probabilistic precision errors.

**Before** (implicitly relying on the removed auto-fill behavior):
```python
tmp = tl.load(cache_ptr + offset, mask=condition)
```

**After** (explicit default value):
```python
tmp = tl.load(cache_ptr + offset, mask=condition, other=0.0)
```


# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
