### PR TITLE
[ssbuffer](fix) fix detecting cloned ops in CloneOps

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CloneOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CloneOps.cpp
@@ -401,8 +401,8 @@ LogicalResult CloneOpsPass::validateBlockIdsConsecutive(ModuleOp module)
   return success();
 }
 
-// Check that no op in a VECTOR scope's main_loop forOp has a tensor or
-// memref result carrying the ssbuffer.clone attribute.
+// Check that no op in a VECTOR scope's main_loop forOp has a tensor result \
+// carrying the ssbuffer.clone attribute.
 LogicalResult CloneOpsPass::validateClonedOpsInVector(ModuleOp module)
 {
   WalkResult result = module.walk([&](Operation *op) -> WalkResult {
@@ -433,11 +433,11 @@ LogicalResult CloneOpsPass::validateClonedOpsInVector(ModuleOp module)
       if (!bodyOp.hasAttr(CVPipeline::kClone)) {
         continue;
       }
-      bool hasTensorOrMemref = llvm::any_of(bodyOp.getResults(), [](Value result) {
-        return isa<RankedTensorType, MemRefType>(result.getType());
+      bool hasTensorDep = llvm::any_of(bodyOp.getResults(), [](Value result) {
+        return isa<RankedTensorType>(result.getType());
       });
-      if (hasTensorOrMemref) {
-        LDBG("[Error]: VECTOR main_loop contains cloned op with tensor/memref type: "
+      if (hasTensorDep) {
+        LDBG("[Error]: VECTOR main_loop contains cloned op with tensor type: "
              << bodyOp.getName() << "\n");
         return WalkResult::interrupt();
       }
@@ -491,7 +491,7 @@ void CloneOpsPass::runOnOperation()
   
   LDBG("after cloneOps:\n" << module << "\n");
 
-  // Validate no cloned tensor/memref ops remaining in VECTOR main_loop forOp
+  // Validate no cloned tensor ops remaining in VECTOR main_loop forOp
   if (failed(validateClonedOpsInVector(module))) {
     signalPassFailure();
     return;


### PR DESCRIPTION
**DynamicCVPipeline: fix detecting in CloneOps**

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
