### PR TITLE
[ssbuffer](fix) Operand add into seed only when def have oneUses

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
@@ -544,8 +544,11 @@ SmallVector<Operation*> PlanCubeBlockPass::matchSeed(Operation* dotOp, ComputeBl
         Operation *def = operand.getDefiningOp();
         if (!def)
             continue;
-        if (checkValidInputSeed(def) && isCubeOp(def) && dotOp->getBlock() == def->getBlock() && bm.getBlockIdByOp(def) == -1) {
-            ret.push_back(def);
+        if (checkValidInputSeed(def) && isCubeOp(def) && dotOp->getBlock() == def->getBlock() &&
+            bm.getBlockIdByOp(def) == -1) {
+            if (def->hasOneUse()) {
+                ret.push_back(def);
+            }
         }
     }
     // match outputs
@@ -583,6 +586,9 @@ llvm::LogicalResult PlanCubeBlockPass::processBlockWithCubeBFS(Block *block, con
         llvm::SmallVector<Operation*> dotSeeds = matchSeed(dot, bm);
         if (willCreateCycle(dotSeeds, memGraph, temBlockId, bm)) {
             LOG_DEBUG("Cube Seed already have a cycle!!");
+            for(auto seed: dotSeeds) {
+                LOG_DEBUG("Seed: " << *seed << "\n");
+            }
             return llvm::failure();
         }
         llvm::SmallVector<Operation *> newGroup;


### PR DESCRIPTION
fix: To avoid error: ""Cube Seed already have a cycle!!",  add limits: matmul's operand add into seed only when def have oneUses

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
