### PR TITLE
[simt](feat) IndirectLoad support notVolatile mode

### DIFF
--- a/third_party/ascend/include/Dialect/TritonAscend/IR/TritonAscendOps.td
+++ b/third_party/ascend/include/Dialect/TritonAscend/IR/TritonAscendOps.td
@@ -314,13 +314,16 @@ def IndirectLoadOp : TT_Ascend_Op<"indirect_load", [
     - offsets: Tensor of per-element offsets (relative to `src`) for accessing source memory
     - mask (optional):  if mask[idx] is false, do not load the data at address pointer[idx]
     - other (optional): if mask[idx] is false, return other[idx]
+    - isVolatile: defaults to true. Set to false only when analysis proves
+      the source pointer has no prior possible writes.
   }];
 
   let arguments = (
     ins TT_Ptr:$src,
         TT_IntTensor:$offsets,
         Optional<TT_BoolLike>:$mask,
-        Optional<TT_Type>:$other
+        Optional<TT_Type>:$other,
+        DefaultValuedAttr<BoolAttr, "true">:$isVolatile
   );
 
   let results = (outs TT_Tensor:$result);

--- a/third_party/ascend/include/Utils/Utils.h
+++ b/third_party/ascend/include/Utils/Utils.h
@@ -82,6 +82,8 @@ SmallVector<OpFoldResult>
 getBoundarySizes(llvm::ArrayRef<int32_t> boundaryCheck, Value ptr,
                  const Location &loc, ConversionPatternRewriter &rewriter);
 
+bool requiresVolatileIndirectLoad(Value srcPtr, Operation *loadOp);
+
 SmallVector<int64_t> getBroadcastDims(RankedTensorType src,
                                       RankedTensorType dst);
 

--- a/third_party/ascend/lib/TritonToLinalg/StridedLoadStoreRewrite.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/StridedLoadStoreRewrite.cpp
@@ -770,7 +770,8 @@ static LogicalResult tryRewriteAddPtrLoad(triton::LoadOp op,
         addScalarOffsetToTensor(offsetTensor, scalarOffset, loc, rewriter);
 
     auto indirectLoad = rewriter.create<triton::ascend::IndirectLoadOp>(
-        loc, resultType, src, offsetTensor, op.getMask(), op.getOther());
+        loc, resultType, src, offsetTensor, op.getMask(), op.getOther(),
+        ConverterUtils::requiresVolatileIndirectLoad(op.getPtr(), op));
     indirectLoad->setAttr(RewrittenByStridedLoadStoreRewriteTAG,
                           UnitAttr::get(rewriter.getContext()));
 
@@ -971,7 +972,8 @@ static LogicalResult tryRewriteBlockPtrLoad(triton::LoadOp op,
 
     // ---- Emit tt.indirect_load ----
     auto indirectLoad = rewriter.create<triton::ascend::IndirectLoadOp>(
-        loc, resultType, src, offsetTensor, mask, other);
+        loc, resultType, src, offsetTensor, mask, other,
+        ConverterUtils::requiresVolatileIndirectLoad(op.getPtr(), op));
     indirectLoad->setAttr(RewrittenByStridedLoadStoreRewriteTAG,
                           UnitAttr::get(rewriter.getContext()));
 

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -2732,6 +2732,8 @@ IndirectLoadConverter::matchAndRewrite(triton::ascend::IndirectLoadOp op, OpAdap
   auto libFnType = rewriter.getFunctionType(inputTypes, {resTy});
   auto funcOp = rewriter.create<func::FuncOp>(loc, funcName.str(), libFnType);
   SymbolTable::setSymbolVisibility(funcOp, SymbolTable::Visibility::Private);
+  auto isVolatileAttr = rewriter.getBoolAttr(op.getIsVolatile());
+  funcOp->setAttr("isVolatile", isVolatileAttr);
 
   rewriter.setInsertionPoint(op);
   SmallVector<Value> inputVals({src, offsets});
@@ -2740,6 +2742,7 @@ IndirectLoadConverter::matchAndRewrite(triton::ascend::IndirectLoadOp op, OpAdap
   auto callOp = rewriter.create<func::CallOp>(loc, funcOp.getSymNameAttr(),
                                               TypeRange({resTy}),
                                               inputVals);
+  callOp->setAttr("isVolatile", isVolatileAttr);
   rewriter.replaceOp(op, callOp);
   return success();
 }

--- a/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
@@ -173,7 +173,8 @@ LogicalResult tryRewriteIndirectFastPath(MemAccOpTy op, Location loc,
       }
     }
     auto indirect = rewriter.create<triton::ascend::IndirectLoadOp>(
-        loc, resultType, newPtr, ptrOffset, mask, other);
+        loc, resultType, newPtr, ptrOffset, mask, other,
+        ConverterUtils::requiresVolatileIndirectLoad(op.getPtr(), op));
     rewriter.replaceOp(op, indirect.getResult());
     LLVM_DEBUG({
       auto &os = llvm::dbgs();

--- a/third_party/ascend/lib/Utils/Utils.cpp
+++ b/third_party/ascend/lib/Utils/Utils.cpp
@@ -537,7 +537,7 @@ static bool isLocalMemRef(Value value) {
 static bool mayWriteRoot(Operation *op, Value loadRootPtr) {
   auto effectOp = dyn_cast<MemoryEffectOpInterface>(op);
   if (!effectOp) {
-    return false;
+    return !mlir::isMemoryEffectFree(op);
   }
 
   SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>> effects;
@@ -552,7 +552,7 @@ static bool mayWriteRoot(Operation *op, Value loadRootPtr) {
       return true;
     }
     if (!isa<BaseMemRefType>(value.getType())) {
-      continue;
+      return true;
     }
 
     auto rootPtr = getRootPointer(value);

--- a/third_party/ascend/lib/Utils/Utils.cpp
+++ b/third_party/ascend/lib/Utils/Utils.cpp
@@ -22,6 +22,7 @@
 
 #include "ascend/include/Utils/Utils.h"
 
+#include "ascend/include/Dialect/TritonAscend/IR/TritonAscendDialect.h"
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -38,6 +39,9 @@
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Value.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Transforms/DialectConversion.h"
 
 #include "triton/Dialect/Triton/IR/Dialect.h"
@@ -45,6 +49,7 @@
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/SmallVectorExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
@@ -415,6 +420,260 @@ getBoundarySizes(llvm::ArrayRef<int32_t> boundaryCheck, Value ptr,
   }
 
   return boundarySize;
+}
+
+static std::optional<Value> getRootPointer(Value ptr) {
+  llvm::SmallPtrSet<Value, 8> visited;
+  while (true) {
+    if (!visited.insert(ptr).second) {
+      return std::nullopt;
+    }
+
+    if (auto blockArg = dyn_cast<BlockArgument>(ptr)) {
+      // A loop-carried pointer block argument is still rooted at its init
+      // value unless the loop updates it through an unsupported cycle.
+      Operation *parentOp = blockArg.getOwner()->getParentOp();
+      if (auto whileOp = dyn_cast_or_null<scf::WhileOp>(parentOp);
+          whileOp && whileOp.getAfterBody() == blockArg.getOwner()) {
+        auto argNum = blockArg.getArgNumber();
+        auto conditionArgs = whileOp.getConditionOp().getArgs();
+        if (argNum < conditionArgs.size()) {
+          ptr = conditionArgs[argNum];
+          continue;
+        }
+      }
+
+      if (auto loopOp = dyn_cast_or_null<LoopLikeOpInterface>(parentOp)) {
+        if (OpOperand *initArgOperand = loopOp.getTiedLoopInit(blockArg)) {
+          ptr = initArgOperand->get();
+          continue;
+        }
+      }
+
+      return ptr;
+    }
+
+    auto *defOp = ptr.getDefiningOp();
+    if (!defOp) {
+      return ptr;
+    }
+
+    auto nextPtr =
+        llvm::TypeSwitch<Operation *, std::optional<Value>>(defOp)
+            .Case<triton::AddPtrOp>(
+                [](auto op) -> std::optional<Value> { return op.getPtr(); })
+            .Case<triton::SplatOp>(
+                [](auto op) -> std::optional<Value> { return op.getSrc(); })
+            .Case<triton::MakeTensorPtrOp>(
+                [](auto op) -> std::optional<Value> { return op.getBase(); })
+            .Case<triton::AdvanceOp>(
+                [](auto op) -> std::optional<Value> { return op.getPtr(); })
+            .Case<memref::ReinterpretCastOp>(
+                [](auto op) -> std::optional<Value> { return op.getSource(); })
+            .Case<memref::SubViewOp>(
+                [](auto op) -> std::optional<Value> { return op.getSource(); })
+            .Case<memref::CastOp>(
+                [](auto op) -> std::optional<Value> { return op.getSource(); })
+            .Case<UnrealizedConversionCastOp>([](auto op)
+                                                  -> std::optional<Value> {
+              if (op.getInputs().size() != 1) {
+                return std::nullopt;
+              }
+              return op.getInputs().front();
+            })
+            .Default([](Operation *) -> std::optional<Value> {
+              return std::nullopt;
+            });
+    if (!nextPtr) {
+      return std::nullopt;
+    }
+    ptr = *nextPtr;
+  }
+}
+
+struct WritePointerInfo {
+  bool isWrite = false;
+  std::optional<Value> rootPtr;
+};
+
+static WritePointerInfo getKnownWritePointer(Operation *op) {
+  return llvm::TypeSwitch<Operation *, WritePointerInfo>(op)
+      .Case<triton::StoreOp>([](auto storeOp) {
+        return WritePointerInfo{true, getRootPointer(storeOp.getPtr())};
+      })
+      .Case<triton::AtomicRMWOp>([](auto atomicOp) {
+        return WritePointerInfo{true, getRootPointer(atomicOp.getPtr())};
+      })
+      .Case<triton::AtomicCASOp>([](auto atomicOp) {
+        return WritePointerInfo{true, getRootPointer(atomicOp.getPtr())};
+      })
+      .Case<triton::ascend::IndirectStoreOp>([](auto storeOp) {
+        return WritePointerInfo{true, getRootPointer(storeOp.getSrc())};
+      })
+      .Default([](Operation *) { return WritePointerInfo{}; });
+}
+
+static bool isLocalMemRef(Value value) {
+  while (auto *defOp = value.getDefiningOp()) {
+    if (isa<memref::AllocOp, memref::AllocaOp>(defOp)) {
+      return true;
+    }
+    auto source = llvm::TypeSwitch<Operation *, Value>(defOp)
+                      .Case<memref::ReinterpretCastOp>(
+                          [](auto op) { return op.getSource(); })
+                      .Case<memref::SubViewOp>(
+                          [](auto op) { return op.getSource(); })
+                      .Case<memref::CastOp>(
+                          [](auto op) { return op.getSource(); })
+                      .Default([](Operation *) { return Value(); });
+    if (!source) {
+      return false;
+    }
+    value = source;
+  }
+  return false;
+}
+
+static bool mayWriteRoot(Operation *op, Value loadRootPtr) {
+  auto effectOp = dyn_cast<MemoryEffectOpInterface>(op);
+  if (!effectOp) {
+    return false;
+  }
+
+  SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>> effects;
+  effectOp.getEffects(effects);
+  for (auto &effect : effects) {
+    if (!isa<MemoryEffects::Write>(effect.getEffect())) {
+      continue;
+    }
+
+    Value value = effect.getValue();
+    if (!value) {
+      return true;
+    }
+    if (!isa<BaseMemRefType>(value.getType())) {
+      continue;
+    }
+
+    auto rootPtr = getRootPointer(value);
+    if (rootPtr) {
+      if (*rootPtr == loadRootPtr) {
+        return true;
+      }
+      continue;
+    }
+    if (!isLocalMemRef(value)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Keep an indirect load volatile unless its root pointer is proven to have no
+// possible prior write. The analysis scans ordered predecessors in the same
+// and enclosing blocks, nested writes in predecessor structured-control-flow
+// ops, and loop-carried writes where a later store in the loop body may feed a
+// following iteration.
+bool requiresVolatileIndirectLoad(Value srcPtr, Operation *loadOp) {
+  auto loadRootPtr = getRootPointer(srcPtr);
+  if (!loadRootPtr) {
+    return true;
+  }
+
+  auto opMayWriteRoot = [&](Operation *op) {
+    // Device-side diagnostics are modeled as GlobalMemory writes in Triton,
+    // but they do not write through user GM pointers and must not affect the
+    // indirect-load source/root analysis.
+    if (isa<triton::AssertOp, triton::PrintOp>(op)) {
+      return false;
+    }
+
+    auto memRefWriteTarget =
+        llvm::TypeSwitch<Operation *, Value>(op)
+            .Case<memref::CopyOp>([](auto copyOp) {
+              return copyOp.getTarget();
+            })
+            .Case<memref::StoreOp>([](auto storeOp) {
+              return storeOp.getMemRef();
+            })
+            .Default([](Operation *) { return Value(); });
+    if (memRefWriteTarget) {
+      auto rootPtr = getRootPointer(memRefWriteTarget);
+      if (rootPtr) {
+        return *rootPtr == *loadRootPtr;
+      }
+      return !isLocalMemRef(memRefWriteTarget);
+    }
+
+    auto writePtr = getKnownWritePointer(op);
+    if (writePtr.isWrite) {
+      return !writePtr.rootPtr || *writePtr.rootPtr == *loadRootPtr;
+    }
+
+    // For structured control flow, look through regions instead of using the
+    // op-level MemoryEffect summary, otherwise unrelated nested writes would
+    // make this load volatile.
+    if (isa<scf::IfOp>(op) || isa<LoopLikeOpInterface>(op)) {
+      return false;
+    }
+
+    // Unknown side-effecting ops are conservative: they may write through an
+    // alias that is no longer recoverable as a Triton root.
+    return mayWriteRoot(op, *loadRootPtr);
+  };
+
+  auto nestedMayWriteRoot = [&](Operation *container) {
+    bool found = false;
+    container->walk<WalkOrder::PreOrder>([&](Operation *nested) {
+      if (nested == container) {
+        return WalkResult::advance();
+      }
+      if (opMayWriteRoot(nested)) {
+        found = true;
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    return found;
+  };
+
+  Operation *current = loadOp;
+
+  while (current) {
+    Block *block = current->getBlock();
+    if (!block) {
+      return true;
+    }
+
+    // First scan operations that are ordered before the current op in this
+    // block. When such an operation owns regions, its nested writes are also
+    // considered ordered before this load.
+    for (auto it = Block::iterator(current); it != block->begin();) {
+      --it;
+      Operation *op = &*it;
+      if ((op->getNumRegions() > 0 && nestedMayWriteRoot(op)) ||
+          opMayWriteRoot(op)) {
+        return true;
+      }
+    }
+
+    Operation *parentOp = block->getParentOp();
+    if (!parentOp || isa<ModuleOp>(parentOp) ||
+        isa<FunctionOpInterface>(parentOp)) {
+      return false;
+    }
+
+    // If the load is inside a loop, a store that is textually after the load
+    // may still execute before the load in a later iteration. Scan the whole
+    // loop body before climbing further out.
+    if (isa<LoopLikeOpInterface>(parentOp) && nestedMayWriteRoot(parentOp)) {
+      return true;
+    }
+
+    current = parentOp;
+  }
+
+  return false;
 }
 
 SmallVector<int64_t> getBroadcastDims(RankedTensorType src,

--- a/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/indirect_load_rewrite.mlir
+++ b/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/indirect_load_rewrite.mlir
@@ -29,7 +29,7 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
 // The structured strided-copy route would create a dynamic boundary size that
 // can become zero for over-launched programs. Route to indirect_load instead.
 // CHECK-LABEL: func.func @addptr_stride4_masked_single_tile
-// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (memref<?xf16>, tensor<1024xi64>, tensor<1024xi1>, tensor<1024xf16>) -> tensor<1024xf16>
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}){{.*}} : (memref<?xf16>, tensor<1024xi64>, tensor<1024xi1>, tensor<1024xf16>) -> tensor<1024xf16>
 module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
   tt.func public @addptr_stride4_masked_single_tile(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
                                                     %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
@@ -659,6 +659,223 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
     %2 = tt.make_tensor_ptr %arg1, [%parent_m, %parent_n], [%stride_m, %stride_n], [%c0, %c0]
          {order = array<i32: 1, 0>} : <tensor<8x8xf32>>
     tt.store %2, %1 {boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<8x8xf32>>
+    tt.return
+  }
+}
+
+// -----
+// CHECK-LABEL: func.func @indirect_load_without_prior_same_ptr_store
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = false} : (memref<?xi32>, tensor<128xi64>, tensor<128xi1>, tensor<128xi32>) -> tensor<128xi32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @indirect_load_without_prior_same_ptr_store(%arg0: !tt.ptr<i32>,
+                                                             %arg1: !tt.ptr<i32>) {
+    %zero = arith.constant dense<0> : tensor<128xi32>
+    %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %mask = arith.cmpi sge, %range, %zero : tensor<128xi32>
+    %src_splat = tt.splat %arg0 : !tt.ptr<i32> -> tensor<128x!tt.ptr<i32>>
+    %src_ptr = tt.addptr %src_splat, %range : tensor<128x!tt.ptr<i32>>, tensor<128xi32>
+    %dst_splat = tt.splat %arg1 : !tt.ptr<i32> -> tensor<128x!tt.ptr<i32>>
+    %dst_ptr = tt.addptr %dst_splat, %range : tensor<128x!tt.ptr<i32>>, tensor<128xi32>
+    %value = tt.load %src_ptr, %mask, %zero {route_discrete_mask_to_simt} : tensor<128x!tt.ptr<i32>>
+    tt.store %dst_ptr, %value, %mask {route_discrete_mask_to_simt} : tensor<128x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+// CHECK-LABEL: func.func @indirect_load_after_prior_same_ptr_store
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = true} : (memref<?xi32>, tensor<128xi64>, tensor<128xi1>, tensor<128xi32>) -> tensor<128xi32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @indirect_load_after_prior_same_ptr_store(%arg0: !tt.ptr<i32>,
+                                                           %arg1: !tt.ptr<i32>) {
+    %one = arith.constant dense<1> : tensor<128xi32>
+    %zero = arith.constant dense<0> : tensor<128xi32>
+    %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %mask = arith.cmpi sge, %range, %zero : tensor<128xi32>
+    %src_splat = tt.splat %arg0 : !tt.ptr<i32> -> tensor<128x!tt.ptr<i32>>
+    %src_ptr = tt.addptr %src_splat, %range : tensor<128x!tt.ptr<i32>>, tensor<128xi32>
+    %dst_splat = tt.splat %arg1 : !tt.ptr<i32> -> tensor<128x!tt.ptr<i32>>
+    %dst_ptr = tt.addptr %dst_splat, %range : tensor<128x!tt.ptr<i32>>, tensor<128xi32>
+    tt.store %src_ptr, %one, %mask {route_discrete_mask_to_simt} : tensor<128x!tt.ptr<i32>>
+    %value = tt.load %src_ptr, %mask, %zero {route_discrete_mask_to_simt} : tensor<128x!tt.ptr<i32>>
+    tt.store %dst_ptr, %value, %mask {route_discrete_mask_to_simt} : tensor<128x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+// CHECK-LABEL: func.func @indirect_load_unknown_root_int_to_ptr
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = true} : (memref<1xi32, strided<[1]>>, tensor<128xi64>, tensor<128xi1>, tensor<128xi32>) -> tensor<128xi32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @indirect_load_unknown_root_int_to_ptr(%arg0: !tt.ptr<i32>) {
+    %base_i64 = arith.constant 1024 : i64
+    %base = tt.int_to_ptr %base_i64 : i64 -> !tt.ptr<i32>
+    %zero = arith.constant dense<0> : tensor<128xi32>
+    %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %mask = arith.cmpi sge, %range, %zero : tensor<128xi32>
+    %src_splat = tt.splat %base : !tt.ptr<i32> -> tensor<128x!tt.ptr<i32>>
+    %src_ptr = tt.addptr %src_splat, %range : tensor<128x!tt.ptr<i32>>, tensor<128xi32>
+    %dst_splat = tt.splat %arg0 : !tt.ptr<i32> -> tensor<128x!tt.ptr<i32>>
+    %dst_ptr = tt.addptr %dst_splat, %range : tensor<128x!tt.ptr<i32>>, tensor<128xi32>
+    %value = tt.load %src_ptr, %mask, %zero {route_discrete_mask_to_simt} : tensor<128x!tt.ptr<i32>>
+    tt.store %dst_ptr, %value, %mask {route_discrete_mask_to_simt} : tensor<128x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+// CHECK-LABEL: func.func @indirect_load_store_in_preceding_scf_if
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = true} : (memref<?xi32>, tensor<16xi64>, tensor<16xi1>, tensor<16xi32>) -> tensor<16xi32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @indirect_load_store_in_preceding_scf_if(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                          %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                          %cond1: i1,
+                                                          %cond2: i1) {
+    %zero = arith.constant dense<0> : tensor<16xi32>
+    %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %c3 = arith.constant dense<3> : tensor<16xi32>
+    %offsets = arith.muli %range, %c3 : tensor<16xi32>
+    %src_base = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %src_ptr = tt.addptr %src_base, %offsets : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %mask = arith.cmpi sge, %range, %zero : tensor<16xi32>
+    %dst_base = tt.splat %arg1 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %dst_ptr = tt.addptr %dst_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    scf.if %cond1 {
+      %one = arith.constant dense<1> : tensor<16xi32>
+      tt.store %src_ptr, %one, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    }
+    %value = scf.if %cond2 -> tensor<16xi32> {
+      %loaded = tt.load %src_ptr, %mask, %zero {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+      scf.yield %loaded : tensor<16xi32>
+    } else {
+      scf.yield %zero : tensor<16xi32>
+    }
+    tt.store %dst_ptr, %value, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+// CHECK-LABEL: func.func @indirect_load_no_store_in_preceding_scf_if
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = false} : (memref<?xi32>, tensor<16xi64>, tensor<16xi1>, tensor<16xi32>) -> tensor<16xi32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @indirect_load_no_store_in_preceding_scf_if(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                              %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                              %cond1: i1,
+                                                              %cond2: i1) {
+    %zero = arith.constant dense<0> : tensor<16xi32>
+    %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %c3 = arith.constant dense<3> : tensor<16xi32>
+    %offsets = arith.muli %range, %c3 : tensor<16xi32>
+    %src_base = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %src_ptr = tt.addptr %src_base, %offsets : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %mask = arith.cmpi sge, %range, %zero : tensor<16xi32>
+    %other_base = tt.splat %arg1 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %other_ptr = tt.addptr %other_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %dst_base = tt.splat %arg1 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %dst_ptr = tt.addptr %dst_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    scf.if %cond1 {
+      %one = arith.constant dense<1> : tensor<16xi32>
+      tt.store %other_ptr, %one, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    }
+    %value = scf.if %cond2 -> tensor<16xi32> {
+      %loaded = tt.load %src_ptr, %mask, %zero {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+      scf.yield %loaded : tensor<16xi32>
+    } else {
+      scf.yield %zero : tensor<16xi32>
+    }
+    tt.store %dst_ptr, %value, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+// CHECK-LABEL: func.func @indirect_load_store_in_preceding_scf_for
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = true} : (memref<?xi32>, tensor<16xi64>, tensor<16xi1>, tensor<16xi32>) -> tensor<16xi32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @indirect_load_store_in_preceding_scf_for(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                           %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                           %trip: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %zero = arith.constant dense<0> : tensor<16xi32>
+    %one = arith.constant dense<1> : tensor<16xi32>
+    %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %src_base = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %src_ptr = tt.addptr %src_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %dst_base = tt.splat %arg1 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %dst_ptr = tt.addptr %dst_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %mask = arith.cmpi sge, %range, %zero : tensor<16xi32>
+    scf.for %i = %c0_i32 to %trip step %c1_i32 : i32 {
+      tt.store %src_ptr, %one, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    }
+    scf.for %j = %c0_i32 to %trip step %c1_i32 : i32 {
+      %loaded = tt.load %src_ptr, %mask, %zero {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+      tt.store %dst_ptr, %loaded, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    }
+    tt.return
+  }
+}
+
+// -----
+// CHECK-LABEL: func.func @indirect_load_nested_loop_carried_store
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = true} : (memref<?xi32>, tensor<16xi64>, tensor<16xi1>, tensor<16xi32>) -> tensor<16xi32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @indirect_load_nested_loop_carried_store(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                          %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                          %outer: i32,
+                                                          %inner: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %zero = arith.constant dense<0> : tensor<16xi32>
+    %one = arith.constant dense<1> : tensor<16xi32>
+    %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %src_base = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %src_ptr = tt.addptr %src_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %dst_base = tt.splat %arg1 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %dst_ptr = tt.addptr %dst_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %mask = arith.cmpi sge, %range, %zero : tensor<16xi32>
+    scf.for %i = %c0_i32 to %outer step %c1_i32 : i32 {
+      scf.for %j = %c0_i32 to %inner step %c1_i32 : i32 {
+        %loaded = tt.load %src_ptr, %mask, %zero {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+        tt.store %src_ptr, %one, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+        tt.store %dst_ptr, %loaded, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+      }
+    }
+    tt.return
+  }
+}
+
+// -----
+// CHECK-LABEL: func.func @indirect_load_ignores_loop_store_to_different_memref_root
+// CHECK: call @triton_indirect_load_0(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = false} : (memref<?xf32>, tensor<16xi64>, tensor<16xi1>, tensor<16xf32>) -> tensor<16xf32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @indirect_load_ignores_loop_store_to_different_memref_root(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                                                            %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                                                            %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                                                            %trip: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %zero = arith.constant dense<0> : tensor<16xi32>
+    %zero_f = arith.constant dense<0.000000e+00> : tensor<16xf32>
+    %c3 = arith.constant dense<3> : tensor<16xi32>
+    %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %mask = arith.cmpi sge, %range, %zero : tensor<16xi32>
+    %gm_base = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+    %gm_ptr = tt.addptr %gm_base, %range : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+    %src_base = tt.splat %arg1 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+    %src_offsets = arith.muli %range, %c3 : tensor<16xi32>
+    %src_ptr = tt.addptr %src_base, %src_offsets : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+    %dst_base = tt.splat %arg2 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+    %dst_ptr = tt.addptr %dst_base, %range : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+    scf.for %i = %c0_i32 to %trip step %c1_i32 : i32 {
+      %local = tt.load %gm_ptr, %mask, %zero_f {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<f32>>
+      tt.assert %mask, "mask must be true" : tensor<16xi1>
+      %indirect = tt.load %src_ptr, %mask, %zero_f {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<f32>>
+      %sum = arith.addf %local, %indirect : tensor<16xf32>
+      tt.store %gm_ptr, %sum, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<f32>>
+      tt.store %dst_ptr, %indirect, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<f32>>
+    }
     tt.return
   }
 }

--- a/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/indirect_load_rewrite.mlir
+++ b/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/indirect_load_rewrite.mlir
@@ -29,7 +29,7 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
 // The structured strided-copy route would create a dynamic boundary size that
 // can become zero for over-launched programs. Route to indirect_load instead.
 // CHECK-LABEL: func.func @addptr_stride4_masked_single_tile
-// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}){{.*}} : (memref<?xf16>, tensor<1024xi64>, tensor<1024xi1>, tensor<1024xf16>) -> tensor<1024xf16>
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = false} : (memref<?xf16>, tensor<1024xi64>, tensor<1024xi1>, tensor<1024xf16>) -> tensor<1024xf16>
 module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
   tt.func public @addptr_stride4_masked_single_tile(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
                                                     %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {


### PR DESCRIPTION
## Summary

Add `isVolatile` support for the SIMT `IndirectLoad` path and let TA clear it
only when the load source is proven not to depend on an earlier same-root GM
write.

## Why

SIMT indirect loads use a libcall/template path that can read GM data through
runtime-computed offsets. When the same kernel previously writes the GM region
that an indirect load later reads, the load must stay volatile so the generated
code does not observe stale data.

Keeping every indirect load volatile is correct, but overly conservative for
loads from immutable input buffers. Some real kernels have indirect loads whose
source GM pointer is independent from all stores in the kernel. Those loads do
not need volatile semantics, and preserving volatile there unnecessarily limits
optimization.

The important distinction is therefore not whether an op is syntactically an
`IndirectLoad`, but whether its source root pointer may have been written by an
earlier operation that can reach the load.

## What Changed

This PR adds an `isVolatile` attribute to `triton::ascend::IndirectLoadOp` and
propagates it to the generated indirect-load libcall.

TA now computes the attribute from local memory-dependency information:

- keep `isVolatile=true` when the source root is unknown;
- keep `isVolatile=true` when a prior or loop-carried write may target the same
  root pointer;
- set `isVolatile=false` when the analysis can prove there is no possible
  same-root write before the load.

The analysis handles direct Triton stores and atomics, indirect stores, memref
writes introduced by lowering, structured control flow, and loop-carried
dependencies. It remains conservative for unknown side effects, while avoiding
false positives from local scratch memrefs and diagnostic ops that do not write
through user GM pointers.

## Validation

Added targeted MLIR coverage for indirect-load rewriting, including:

- no prior same-root store -> `isVolatile=false`;
- prior same-root store -> `isVolatile=true`;
- unknown root pointer -> `isVolatile=true`;
- stores nested in `scf.if` and `scf.for`;
- nested loop-carried writes;
- unrelated loop stores to a different root pointer;
- diagnostic side effects before the indirect load.
