### PR TITLE
[ascend](feat) add dot_s4

### DIFF
--- a/third_party/ascend/language/cann/extension/__init__.py
+++ b/third_party/ascend/language/cann/extension/__init__.py
@@ -40,6 +40,7 @@ from .core import (
     sync_block_wait,
     SYNC_IN_VF,
     conv1d,
+    dot_s4,
 )
 
 from .scope import scope
@@ -98,6 +99,7 @@ __all__ = [
     "sync_block_all",
     "SYNC_IN_VF",
     "conv1d",
+    "dot_s4",
 
     # address space
     "ascend_address_space",

--- a/third_party/ascend/language/cann/extension/core.py
+++ b/third_party/ascend/language/cann/extension/core.py
@@ -24,7 +24,7 @@ __all__ = [
     "ascend_address_space", "builtin", "CORE", "copy_from_ub_to_l1", "copy", "debug_barrier", "fixpipe",
     "FixpipeDMAMode", "FixpipeDualDstMode", "FixpipePreQuantMode", "FixpipePreReluMode", "int64", "is_builtin", "MODE",
     "PIPE", "IteratorType", "sub_vec_id", "sub_vec_num", "sync_block_all", "sync_block_set", "sync_block_wait",
-    "SYNC_IN_VF", "conv1d"
+    "SYNC_IN_VF", "conv1d", "dot_s4"
 ]
 
 import enum
@@ -563,3 +563,21 @@ def conv1d(input: tl.tensor, weight: tl.tensor, bias: tl.tensor = None, stride=N
         output_shape = [C_out, L_out_val]
 
     return semantic.conv1d(input, weight, bias, stride, padding_size_int, dilation, groups, output_shape, _semantic)
+
+
+@builtin
+def dot_s4(input: tl.tensor, other: tl.tensor, acc: tl.tensor = None, _semantic=None) -> tl.tensor:
+    """
+    Returns the matrix product of two blocks.
+
+    The two blocks must both be two-dimensional and have compatible (for s4) inner dimensions.
+
+    :param input: The first tensor to be multiplied.
+    :type input: 2D tensor of scalar-type in {:code:`int8`}
+    :param other: The second tensor to be multiplied.
+    :type other: 2D tensor of scalar-type in {:code:`int8`}
+    :param acc: The accumulator tensor. If not None, the result is added to this tensor.
+    :type acc: 2D tensor of scalar-type in {:code:`int32`}
+    """
+    acc = _unwrap_if_constexpr(acc)
+    return semantic.dot_s4(input, other, acc, _semantic)

--- a/third_party/ascend/language/cann/extension/semantic.py
+++ b/third_party/ascend/language/cann/extension/semantic.py
@@ -177,3 +177,38 @@ def conv1d(input_tensor: tl.tensor, weight_tensor: tl.tensor, bias: Union[tl.ten
     out = _semantic.builder.create_conv1d(input_tensor.handle, weight_tensor.handle, bias_handle, stride, padding_size,
                                           dilation, groups, output_ty.to_ir(_semantic.builder))
     return tl.tensor(out, output_ty)
+
+
+def dot_s4(lhs: tl.tensor, rhs: tl.tensor, acc: tl.tensor, _semantic=None) -> tl.tensor:
+    assert lhs.type.is_block() and rhs.type.is_block()
+    out_dtype = tl.int32
+    lhs_rank = len(lhs.shape)
+    rhs_rank = len(rhs.shape)
+
+    assert lhs_rank == rhs_rank == 2 or lhs_rank == rhs_rank == 3, f"Both inputs must be either 2D or 3D; (lhs: {lhs.shape} vs rhs: {rhs.shape})"
+    assert lhs.type.scalar == tl.int8, "only int8 supported!"
+    assert lhs.shape[-1].value * 2 == rhs.shape[
+        -2].value, f"First input shape ({lhs.shape}) and second input shape {rhs.shape} are not compatible for matmul" \
+        " (doubled second index of first shape ({lhs.shape[-1].value}) must be equal to first index of second shape ({rhs.shape[-2].value})"
+    assert _semantic.builder.codegen_fns.get(
+        "min_dot_size") is not None, "target doesn't provide lower shape bounds for dot."
+    min_dot_size = _semantic.builder.codegen_fns["min_dot_size"](lhs.type, rhs.type)
+    assert lhs.shape[-2].value >= min_dot_size[0] and lhs.shape[-1].value >= min_dot_size[2] \
+        and rhs.shape[-1].value >= min_dot_size[1], \
+        f"Input shapes should have M >= {min_dot_size[0]}, N >= {min_dot_size[1]} and K >= {min_dot_size[2]}"
+
+    _0 = _semantic.builder.get_int32(0)
+    ret_scalar_ty = tl.int32
+
+    M = lhs.type.shape[-2]
+    N = rhs.type.shape[-1]
+    ret_ty = tl.block_type(ret_scalar_ty, [M, 2 * N])
+    if acc is None:
+        acc_handle = _semantic.builder.create_splat(ret_ty.to_ir(_semantic.builder), _0)
+    else:
+        acc_handle = acc.handle
+        assert acc.type.shape == ret_ty.shape and acc.type.element_ty == tl.int32
+
+    res = _semantic.tensor(_semantic.builder._ascend_builder.create_dot_s4(lhs.handle, rhs.handle, acc_handle), ret_ty)
+    al.compile_hint(res, "enable_i4", _semantic=_semantic)
+    return res

--- a/third_party/ascend/triton_ascend.cc
+++ b/third_party/ascend/triton_ascend.cc
@@ -329,6 +329,40 @@ void init_triton_ascend_ir(py::module &&m) {
              auto annotationOp = self.create<triton::ascend::AnnotationOp>(ptr);
              annotationOp->setAttr(self.getBuilder().getStringAttr(attrKey),
                                    attrVal);
+           })
+      // Add dot_s4
+      .def("create_dot_s4",
+           [](TritonOpBuilder &self, mlir::Value &a, mlir::Value &b,
+              mlir::Value &c) -> mlir::Value {
+             auto ctx = self.getBuilder().getContext();
+             auto aType = mlir::cast<mlir::RankedTensorType>(a.getType());
+             auto bType = mlir::cast<mlir::RankedTensorType>(b.getType());
+             auto cType = mlir::cast<mlir::RankedTensorType>(c.getType());
+
+             int64_t M = aType.getDimSize(0);
+             int64_t Khalf = aType.getDimSize(1);
+             int64_t Nhalf = bType.getDimSize(1);
+             int64_t K = Khalf * 2;
+             int64_t N = Nhalf * 2;
+
+             auto i4Type = mlir::IntegerType::get(ctx, 4);
+             auto i32Type = mlir::IntegerType::get(ctx, 32);
+             auto newVecTypeA = mlir::RankedTensorType::get({M, K}, i4Type);
+             auto newVecTypeB = mlir::RankedTensorType::get({K, N}, i4Type);
+             auto newVecTypeC = mlir::RankedTensorType::get({M, N}, i32Type);
+
+             auto aCast =
+                 self.create<mlir::UnrealizedConversionCastOp>(newVecTypeA, a)
+                     .getResult(0);
+             auto bCast =
+                 self.create<mlir::UnrealizedConversionCastOp>(newVecTypeB, b)
+                     .getResult(0);
+             auto cCast =
+                 self.create<mlir::UnrealizedConversionCastOp>(newVecTypeC, c)
+                     .getResult(0);
+
+             return self.create<DotOp>(cCast.getType(), aCast, bCast, cCast,
+                                       InputPrecision::IEEE, 0);
            });
 }
 


### PR DESCRIPTION
Add a new operation dot_s4 that performs matrix multiplication on 4‑bit integer data, leveraging the hardware mmad_s4 instruction. The operation takes packed int4 values (stored in int8 tensors) and produces an int32 result. More details in user doc: https://github.com/triton-lang/triton-ascend/pull/828


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
