### PR TITLE
[SSBuffer](feat) Add SplitIfByBlockIdPass to pipeline

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "ascend/include/DynamicCVPipeline/ComputeBlockOptPass.h"
+#include "ascend/include/DynamicCVPipeline/SplitIfByBlockIdPass.h"
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/RefineArgsBlockId.h"
 #include "ascend/include/DynamicCVPipeline/Passes.h"
 #include "ascend/include/DynamicCVPipeline/StandardizeOp.h"
@@ -112,6 +113,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::registerRemoveSsbufAttrPasses();
   mlir::triton::registerAnalyzeDataFlowPasses();
   mlir::triton::registerComputeBlockOptPasses();
+  mlir::triton::registerSplitIfByBlockIdPasses();
   mlir::triton::registerPlanComputeBlockPasses();
   mlir::triton::registerOpClassifierPass();
   mlir::triton::registerRefineArgsBlockIdPasses();

--- a/third_party/ascend/include/DynamicCVPipeline/SplitIfByBlockIdPass.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitIfByBlockIdPass.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ADAPTER_DYNAMIC_CVPIPELINE_SPLIT_IF_BY_BLOCK_ID_H
+#define TRITON_ADAPTER_DYNAMIC_CVPIPELINE_SPLIT_IF_BY_BLOCK_ID_H
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace triton {
+
+class SplitIfByBlockIdPass : public PassWrapper<SplitIfByBlockIdPass, OperationPass<ModuleOp>> {
+public:
+    MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SplitIfByBlockIdPass)
+
+    SplitIfByBlockIdPass() = default;
+
+    void runOnOperation() override;
+
+    llvm::StringRef getArgument() const final {
+      return "split-if-by-block-id";
+    }
+
+    llvm::StringRef getDescription() const final {
+      return "Split scf.if operations so that each if contains only ops of a single block_id";
+    }
+
+    void getDependentDialects(DialectRegistry &registry) const override;
+};
+
+std::unique_ptr<OperationPass<ModuleOp>> createSplitIfByBlockIdPass();
+void registerSplitIfByBlockIdPasses();
+
+} // namespace triton
+} // namespace mlir
+
+#endif // TRITON_ADAPTER_DYNAMIC_CVPIPELINE_SPLIT_IF_BY_BLOCK_ID_H

--- a/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
@@ -37,6 +37,7 @@
 #include "ascend/include/DynamicCVPipeline/RemoveAttributes.h"
 #include "ascend/include/DynamicCVPipeline/SeparateMemoryFromComputePass.h"
 #include "ascend/include/DynamicCVPipeline/SplitDataflowPass.h"
+#include "ascend/include/DynamicCVPipeline/SplitIfByBlockIdPass.h"
 
 static constexpr const char *DEBUG_TYPE = "AddDynamicCVPipeline";
 #define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
@@ -93,6 +94,7 @@ void AddDynamicCVPipelinePass::runOnOperation()
     pm.addPass(createComputeBlockOptPass());
     pm.addPass(createSplitDataflowPass());
     pm.addPass(createAnalyzeDataFlowPass());
+    pm.addPass(createSplitIfByBlockIdPass());
     pm.addPass(createSeparateMemoryFromComputePass());
     pm.addPass(createAllocMultiCachePass());
     pm.addPass(createAddControlFlowConditionPass());

--- a/third_party/ascend/lib/DynamicCVPipeline/CMakeLists.txt
+++ b/third_party/ascend/lib/DynamicCVPipeline/CMakeLists.txt
@@ -37,6 +37,7 @@ file(GLOB PRE_CHECK_AVAILABLE_SRC_FILES CONFIGURE_DEPENDS
 add_triton_library(DynamicCVPipeline
   AddDynamicCVPipeline.cpp
   PreCheckAvailable.cpp
+  SplitIfByBlockId.cpp
 
   StandardizeOp.cpp
   ${STANDARDIZE_OP_PASS_SRC}

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitIfByBlockId.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitIfByBlockId.cpp
@@ -1,0 +1,1600 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include "ascend/include/DynamicCVPipeline/SplitIfByBlockIdPass.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/IRMapping.h"
+#include "llvm/Support/Debug.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+
+static constexpr const char *DEBUG_TYPE = "SplitIfByBlockId";
+#define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
+#define LDBG(...)                             \
+  LLVM_DEBUG({                                \
+    DBGS();                                   \
+    llvm::dbgs() << __VA_ARGS__ << "\n";      \
+  })
+
+using namespace mlir;
+using namespace triton;
+
+// ============================================================================
+// Part1: Discovery & Grouping (merged Part1 + Part2)
+// ============================================================================
+//
+// Walk the entire module.  For each scf::IfOp whose body contains ops from
+// >= 2 different ssbuffer.block_id values (excluding block 16 and absent),
+// group the contained ops by block_id so that later parts can materialize
+// one split if per group.
+
+namespace {
+
+/// One group of ops sharing the same block_id inside an scf.if.
+/// N=0: all storage is heap-allocated, keeping sizeof small.
+struct BlockGroup {
+    int64_t blockId;
+    SmallVector<Operation *, 0> ops;       // ops in this group (original order)
+    SmallVector<scf::IfOp, 0> nestedIfs;   // nested ifs that belong to this group
+};
+
+} // namespace
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Return true if \p op is a zero-cost memref view operation that can be
+/// cheaply cloned instead of being passed through the yield chain.
+static bool isCheapAliasOp(Operation *op) {
+    return isa<memref::ReinterpretCastOp, memref::CastOp,
+               memref::SubViewOp, memref::AssumeAlignmentOp>(op);
+}
+
+/// Register a cross-group SSA dependency: a value defined in one group
+/// is consumed by an op in a different group.
+static void addCrossGroupDependency(
+    Value val, Operation *consumer, unsigned consumerGroup,
+    llvm::SmallDenseMap<Operation *, unsigned> &opToGroup,
+    llvm::SmallDenseMap<Value,
+        std::pair<unsigned, llvm::SmallPtrSet<Operation *, 4>>> &crossValueMap)
+{
+    auto *defOp = val.getDefiningOp();
+    if (!defOp) return;
+    auto it = opToGroup.find(defOp);
+    if (it == opToGroup.end() || it->second == consumerGroup) return;
+
+    auto &entry = crossValueMap[val];
+    entry.first = it->second;
+    entry.second.insert(consumer);
+}
+
+// ============================================================================
+// Part2 data structures (CrossGroupValue, YieldAugmentation)
+// ============================================================================
+
+/// A value-level cross-group SSA dependency.
+/// Tracks which group produces a value and which groups consume it.
+struct CrossGroupValue {
+    Value value;                              // the SSA value crossing groups
+    unsigned fromGroupIdx;                    // producer group index
+    SmallVector<unsigned, 0> toGroupIndices;  // consumer group indices
+};
+
+/// Part3 yield plan for a candidate.
+/// Both Case A and Case B use unified yield augmentation:
+///   Slots 0..N-1:  original yield slots (Case A: N=0; Case B: N=original yield count)
+///   Slots N..N+M-1: augmented cross-group values not in original yield
+struct YieldAugmentation {
+    /// Cross-group values (deduplicated, in yield slot order for Case A).
+    SmallVector<CrossGroupValue, 0> crossValues;
+
+    /// For each group (indexed by group order, NOT raw group index):
+    ///   per-slot action: -1 = passthrough, >=0 = splitIf idx (oi) that produces this slot
+    SmallVector<SmallVector<int, 0>, 0> groupSlotActions;
+
+    /// Number of original yield slots (0 for Case A, N for Case B).
+    unsigned numOriginalSlots = 0;
+
+    /// Augmented cross-group values NOT in original yield (Case B only).
+    SmallVector<Value, 0> augmentedValues;
+
+    bool empty() const { return crossValues.empty(); }
+};
+
+/// Computed slot metadata for Part3 materialization.
+/// Bundles everything Step 3.1 derives from CandidateIf + YieldAugmentation.
+struct SlotPlan {
+    unsigned nSlots = 0;
+    SmallVector<Type, 0> resultTypes;
+    SmallVector<Value, 0> slotValues;       // the SSA value each slot represents
+    llvm::SmallDenseMap<Value, unsigned> valueToSlot;  // cross-group val -> slot idx
+
+    /// Case B only: original other-region yield values for first-if passthrough.
+    SmallVector<Value, 4> origOtherYieldValues;
+
+    unsigned nResultIfs = 0;
+    bool lastIsVoid = false;
+};
+
+struct CandidateIf {
+    scf::IfOp ifOp;
+    int64_t selfBlockId;                       // block_id on the if op itself
+    bool hasYield;                             // Case A (false) vs Case B (true)
+    SmallVector<BlockGroup, 0> thenGroups;     // groups in then region
+    SmallVector<BlockGroup, 0> elseGroups;     // groups in else region
+
+    // Part2 fills this:
+    YieldAugmentation yieldAug;                   // value-level cross-group + yield plan
+
+    /// True when any single branch (then or else) contains >= 2 distinct
+    /// block_ids — only then is there something to split within that branch.
+    bool needsSplit() const {
+        return thenGroups.size() >= 2 || elseGroups.size() >= 2;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Debug helpers
+// ---------------------------------------------------------------------------
+
+static bool hasNestedIfs(const CandidateIf &c)
+{
+    for (auto &g : c.thenGroups)
+        if (!g.nestedIfs.empty()) return true;
+    for (auto &g : c.elseGroups)
+        if (!g.nestedIfs.empty()) return true;
+    return false;
+}
+
+static void dumpCandidates(const SmallVector<CandidateIf> &candidates)
+{
+    for (unsigned i = 0; i < candidates.size(); ++i) {
+        auto &c = candidates[i];
+        LDBG("  [" << i << "] scf.if  selfBlockId=" << c.selfBlockId
+             << "  groups(then=" << static_cast<unsigned>(c.thenGroups.size())
+             << " else=" << static_cast<unsigned>(c.elseGroups.size())
+             << ")  yield=" << c.hasYield
+             << "  nested=" << hasNestedIfs(c));
+        for (auto &g : c.thenGroups)
+            LDBG("      then block_id=" << g.blockId
+                 << "  ops=" << static_cast<unsigned>(g.ops.size())
+                 << "  nestedIfs=" << static_cast<unsigned>(g.nestedIfs.size()));
+        for (auto &g : c.elseGroups)
+            LDBG("      else block_id=" << g.blockId
+                 << "  ops=" << static_cast<unsigned>(g.ops.size())
+                 << "  nestedIfs=" << static_cast<unsigned>(g.nestedIfs.size()));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Standalone helpers
+// ---------------------------------------------------------------------------
+
+/// Walk a single block (then or else body), grouping ops by block_id.
+/// Nested ifs attach to the nearest preceding group.
+/// Ops without a splittable id are kept in the current active group.
+static SmallVector<BlockGroup> groupOpsInBlock(Block &block)
+{
+    SmallVector<BlockGroup> groups;
+    llvm::SmallDenseMap<int64_t, unsigned> idToIdx; // block_id -> index in groups
+
+    auto getOrCreateGroup = [&](int64_t bid) -> BlockGroup & {
+        auto it = idToIdx.find(bid);
+        if (it != idToIdx.end())
+            return groups[it->second];
+        idToIdx[bid] = groups.size();
+        groups.push_back({bid, {}, {}});
+        return groups.back();
+    };
+
+    int64_t currentId = -1; // which group nested / ambient ops attach to
+    SmallVector<Operation *, 0> pendingAmbient; // ambient ops before first real group
+
+    auto flushPending = [&](int64_t targetBid) {
+        if (pendingAmbient.empty()) return;
+        auto &g = getOrCreateGroup(targetBid);
+        for (auto *op : pendingAmbient)
+            g.ops.push_back(op);
+        pendingAmbient.clear();
+    };
+
+    for (auto &op : block) {
+        if (isa<scf::YieldOp>(op))
+            continue;
+
+        if (auto nestedIf = dyn_cast<scf::IfOp>(op)) {
+            // Nested ifs form their own group based on their block_id so
+            // that the parent if can be split when inner ifs of different
+            // block_ids coexist in the same region after earlier iterations.
+            auto bid = CVPipeline::getOpBlockId(nestedIf);
+            if (bid.has_value() && *bid != -1) {
+                flushPending(*bid);
+                getOrCreateGroup(*bid).nestedIfs.push_back(nestedIf);
+                currentId = *bid;
+            } else if (currentId != -1) {
+                getOrCreateGroup(currentId).nestedIfs.push_back(nestedIf);
+            } else {
+                pendingAmbient.push_back(&op);
+            }
+            continue;
+        }
+
+        auto bid = CVPipeline::getOpBlockId(&op);
+        if (bid.has_value() && *bid != -1) {
+            flushPending(*bid);
+            getOrCreateGroup(*bid).ops.push_back(&op);
+            currentId = *bid;
+        } else if (currentId != -1) {
+            // ambient op (id == -1 or 16): keep in the current group
+            getOrCreateGroup(currentId).ops.push_back(&op);
+        } else {
+            pendingAmbient.push_back(&op);
+        }
+    }
+
+    // Flush remaining pending ambient ops into the first real group (if any),
+    // otherwise they're the only content and don't need splitting.
+    if (!pendingAmbient.empty() && !groups.empty()) {
+        for (auto *op : pendingAmbient)
+            groups[0].ops.push_back(op);
+    }
+
+    return groups;
+}
+
+/// Return true if \p op is nested inside a scf.for with the main_loop attribute.
+/// Only if-ops inside the main loop should be split; prologue/epilogue ifs
+/// outside the main loop are not candidates for this optimization.
+static bool isInsideMainLoop(Operation *op)
+{
+    for (auto *parent = op->getParentOp(); parent; parent = parent->getParentOp()) {
+        if (auto forOp = dyn_cast<scf::ForOp>(parent))
+            if (forOp->hasAttr(CVPipeline::kMainLoop))
+                return true;
+    }
+    return false;
+}
+
+static SmallVector<CandidateIf> discoverCandidates(ModuleOp module)
+{
+    SmallVector<CandidateIf> result;
+
+    module.walk([&](scf::IfOp ifOp) {
+        if (!isInsideMainLoop(ifOp))
+            return;
+
+        CandidateIf cand;
+        cand.ifOp = ifOp;
+        cand.hasYield = (ifOp->getNumResults() > 0);
+
+        // self block_id
+        auto selfBlockId = CVPipeline::getOpBlockId(ifOp);
+        cand.selfBlockId = selfBlockId.value_or(-1);
+
+        // Group then region
+        cand.thenGroups = groupOpsInBlock(*ifOp.thenBlock());
+
+        // Group else region
+        Block *elseBlk = ifOp.elseBlock();
+        if (elseBlk)
+            cand.elseGroups = groupOpsInBlock(*elseBlk);
+
+        if (cand.needsSplit())
+            result.push_back(cand);
+    });
+
+    return result;
+}
+
+// ============================================================================
+// Part2: Dependency Analysis & Yield Planning
+// ============================================================================
+//
+// For each candidate, in a single pass over operands:
+//   - Group-level: detect cross-group SSA dependencies (for topo sort).
+//   - Value-level: track which specific SSA values cross group boundaries.
+//
+// Then plan yield augmentation:
+//   - Case A: promote all cross-group values to new yield slots.
+//   - Case B: augment yield with extra slots for cross-group values
+//     not in original yield (→ unified yield chain, no memref bridges).
+//   - Compute slot actions for each split if.
+//   - Topo sort groups so producers execute before consumers.
+//
+// Part4 consumes the resulting YieldAugmentation plan.
+
+static void dumpYieldAugmentation(const CandidateIf &c)
+{
+    auto &ya = c.yieldAug;
+    bool splitThen = c.thenGroups.size() >= 2;
+    auto &groups = splitThen ? c.thenGroups : c.elseGroups;
+    const char *region = splitThen ? "then" : "else";
+
+    if (ya.crossValues.empty()) {
+        LDBG("    [Part2] no cross-group values (region=" << region << ")");
+        return;
+    }
+
+    // --- value-level cross-group deps ---
+    if (!ya.crossValues.empty()) {
+        LDBG("    [Part2] value-level cross-group deps ("
+             << region << ", " << ya.crossValues.size() << " values):");
+        for (auto &cv : ya.crossValues) {
+            std::string consumerStr;
+            for (unsigned toG : cv.toGroupIndices) {
+                if (!consumerStr.empty()) consumerStr += ", ";
+                consumerStr += std::to_string(groups[toG].blockId);
+            }
+            LDBG("      val from block_id=" << groups[cv.fromGroupIdx].blockId
+                 << " -> consumed by block_id(s): [" << consumerStr << "]"
+                 << "  type=" << cv.value.getType());
+        }
+    }
+
+    // --- yield augmentation plan ---
+    if (!ya.crossValues.empty()) {
+        if (!c.hasYield) {
+            LDBG("    [Part2] Case A yield augmentation: "
+                 << ya.crossValues.size() << " new yield slot(s)");
+            for (unsigned si = 0; si < ya.crossValues.size(); ++si)
+                LDBG("      slot[" << si << "] = " << ya.crossValues[si].value
+                     << "  (producer=block_id "
+                     << groups[ya.crossValues[si].fromGroupIdx].blockId << ")");
+        } else if (!ya.augmentedValues.empty()) {
+            LDBG("    [Part2] Case B yield augmentation: "
+                 << ya.augmentedValues.size() << " additional yield slot(s) on top of "
+                 << ya.numOriginalSlots << " original");
+            for (unsigned si = 0; si < ya.augmentedValues.size(); ++si)
+                LDBG("      slot[" << (ya.numOriginalSlots + si)
+                     << "] = " << ya.augmentedValues[si]
+                     << "  (type=" << ya.augmentedValues[si].getType() << ")");
+        }
+    }
+
+    // --- per-group slot actions ---
+    if (!ya.groupSlotActions.empty()) {
+        unsigned nCols = ya.groupSlotActions[0].size();
+        unsigned nSplitIfs = splitThen ? c.thenGroups.size() : c.elseGroups.size();
+        LDBG("    [Part2] per-group slot actions (" << nSplitIfs
+             << " split ifs x " << nCols << " slots):");
+        for (unsigned gi = 0; gi < nSplitIfs; ++gi) {
+            std::string slotStr;
+            for (int action : ya.groupSlotActions[gi]) {
+                if (!slotStr.empty()) slotStr += ", ";
+                slotStr += std::to_string(action);
+            }
+            LDBG("      splitIf[" << gi << "] (block_id="
+                 << groups[gi].blockId << "): slots = [" << slotStr << "]");
+        }
+    }
+
+}
+
+/// Single-pass scan: value-level crossValueMap only.
+/// Group order is implicitly the natural discovery order (block_ids appear
+/// in dependency order within a sequential basic block).
+/// Used for both then and else regions.
+static void scanRegion(SmallVector<BlockGroup, 0> &groups,
+                       llvm::SmallDenseMap<Operation *, unsigned> &opToGroup,
+                       llvm::SmallDenseMap<Value,
+                           std::pair<unsigned, llvm::SmallPtrSet<Operation *, 4>>> &crossValueMap)
+{
+    unsigned n = groups.size();
+    if (n < 2) return;
+
+    for (unsigned gi = 0; gi < n; ++gi) {
+        // Scan regular ops' operands
+        for (auto *op : groups[gi].ops) {
+            for (auto &operand : op->getOpOperands()) {
+                addCrossGroupDependency(operand.get(), op, gi,
+                                        opToGroup, crossValueMap);
+            }
+            // Walk nested regions (e.g., scf.for body) to find cross-group
+            // SSA uses hidden inside region-bearing ops.
+            for (auto &region : op->getRegions()) {
+                region.walk([&](Operation *nestedOp) {
+                    for (auto &nestedOperand : nestedOp->getOpOperands()) {
+                        addCrossGroupDependency(nestedOperand.get(), op, gi,
+                                                opToGroup, crossValueMap);
+                    }
+                });
+            }
+        }
+        // Scan nested ifs' own operands (e.g., their condition) which may be
+        // defined in a different group.
+        for (auto nestedIf : groups[gi].nestedIfs) {
+            for (auto &operand : nestedIf->getOpOperands()) {
+                addCrossGroupDependency(operand.get(), nestedIf.getOperation(),
+                                        gi, opToGroup, crossValueMap);
+            }
+        }
+        // Walk into nested ifs' bodies (then/else regions) to find
+        // cross-group SSA uses hidden inside (e.g., an else block's yield
+        // referencing a placeholder defined in a different group).
+        for (auto nestedIf : groups[gi].nestedIfs) {
+            nestedIf->walk([&](Operation *innerOp) {
+                for (auto &innerOperand : innerOp->getOpOperands()) {
+                    addCrossGroupDependency(innerOperand.get(),
+                                            nestedIf.getOperation(), gi,
+                                            opToGroup, crossValueMap);
+                }
+            });
+        }
+        // Scan nested if results for cross-group consumers.
+        // A nested if in group[gi] may produce values consumed by ops
+        // or nested ifs in a different group. Walk up from each user to
+        // find the nearest ancestor tracked in opToGroup.
+        for (auto nestedIf : groups[gi].nestedIfs) {
+            for (auto result : nestedIf->getResults()) {
+                for (auto *user : result.getUsers()) {
+                    Operation *trackedOp = user;
+                    while (trackedOp) {
+                        auto it = opToGroup.find(trackedOp);
+                        if (it != opToGroup.end()) {
+                            if (it->second != gi)
+                                addCrossGroupDependency(result, trackedOp,
+                                                        it->second, opToGroup,
+                                                        crossValueMap);
+                            break;
+                        }
+                        trackedOp = trackedOp->getParentOp();
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Compute slotOwner vector and groupSlotActions matrix for Case B.
+/// N original yield slots + M augmented slots (crossValues not in yield).
+static void planYieldCaseB(CandidateIf &c,
+                           bool splitThen,
+                           ArrayRef<BlockGroup> groups,
+                           llvm::SmallDenseMap<Operation *, unsigned> &opToGroup)
+{
+    unsigned nGroups = groups.size();
+    auto &ya = c.yieldAug;
+
+    auto splitYieldOp = cast<scf::YieldOp>(
+        splitThen ? c.ifOp.thenBlock()->getTerminator()
+                  : c.ifOp.elseBlock()->getTerminator());
+    SmallPtrSet<Value, 8> yieldValues;
+    for (auto operand : splitYieldOp->getOperands())
+        yieldValues.insert(operand);
+
+    ya.numOriginalSlots = splitYieldOp->getNumOperands();
+    ya.augmentedValues.clear();
+    for (auto &cv : ya.crossValues) {
+        if (!yieldValues.contains(cv.value))
+            ya.augmentedValues.push_back(cv.value);
+    }
+
+    unsigned N = ya.numOriginalSlots;
+    unsigned M = ya.augmentedValues.size();
+    unsigned nSlots = N + M;
+
+    SmallVector<int, 0> slotOwner(nSlots, -1);
+    for (unsigned slot = 0; slot < N; ++slot) {
+        auto *defOp = splitYieldOp->getOperand(slot).getDefiningOp();
+        if (!defOp) continue;
+        auto it = opToGroup.find(defOp);
+        if (it != opToGroup.end())
+            slotOwner[slot] = static_cast<int>(it->second);
+    }
+
+    llvm::SmallDenseMap<Value, unsigned> augValueToSlot;
+    for (unsigned si = 0; si < M; ++si)
+        augValueToSlot[ya.augmentedValues[si]] = N + si;
+    for (unsigned gi = 0; gi < nGroups; ++gi) {
+        for (auto *op : groups[gi].ops) {
+            for (auto result : op->getResults()) {
+                auto it = augValueToSlot.find(result);
+                if (it != augValueToSlot.end())
+                    slotOwner[it->second] = static_cast<int>(gi);
+            }
+        }
+        // Scan nestedIf results too: a nestedIf may produce a cross-group
+        // value consumed by a downstream group.
+        for (auto nestedIf : groups[gi].nestedIfs) {
+            for (auto result : nestedIf->getResults()) {
+                auto it = augValueToSlot.find(result);
+                if (it != augValueToSlot.end())
+                    slotOwner[it->second] = static_cast<int>(gi);
+            }
+        }
+    }
+
+    for (unsigned gi = 0; gi < nGroups; ++gi) {
+        SmallVector<int> actions(nSlots, -1);
+        for (unsigned slot = 0; slot < nSlots; ++slot) {
+            if (slotOwner[slot] == static_cast<int>(gi))
+                actions[slot] = static_cast<int>(gi);
+        }
+        ya.groupSlotActions.push_back(std::move(actions));
+    }
+}
+
+/// Compute groupSlotActions matrix for Case A.
+/// All crossValues are promoted to new yield slots.
+static void planYieldCaseA(CandidateIf &c,
+                           ArrayRef<BlockGroup> groups)
+{
+    unsigned nGroups = groups.size();
+    auto &ya = c.yieldAug;
+
+    llvm::SmallDenseMap<Value, unsigned> valueToSlot;
+    for (unsigned si = 0; si < ya.crossValues.size(); ++si)
+        valueToSlot[ya.crossValues[si].value] = si;
+
+    for (unsigned gi = 0; gi < nGroups; ++gi) {
+        SmallVector<int> actions(ya.crossValues.size(), -1);
+        for (auto *op : groups[gi].ops) {
+            for (auto result : op->getResults()) {
+                auto it = valueToSlot.find(result);
+                if (it != valueToSlot.end())
+                    actions[it->second] = static_cast<int>(gi);
+            }
+        }
+        // Scan nestedIf results too: a nestedIf may produce a cross-group
+        // value consumed by a downstream group.
+        for (auto nestedIf : groups[gi].nestedIfs) {
+            for (auto result : nestedIf->getResults()) {
+                auto it = valueToSlot.find(result);
+                if (it != valueToSlot.end())
+                    actions[it->second] = static_cast<int>(gi);
+            }
+        }
+        ya.groupSlotActions.push_back(std::move(actions));
+    }
+}
+
+/// Plan yield augmentation from the collected crossValueMap.
+/// Groups are already in natural dependency order (block_ids appear in
+/// execution order within a sequential basic block), so group index gi
+/// is used directly as split-if position.
+static void planYield(CandidateIf &c,
+                      bool splitThen,
+                      ArrayRef<BlockGroup> groups,
+                      llvm::SmallDenseMap<Operation *, unsigned> &opToGroup,
+                      llvm::SmallDenseMap<Value,
+                          std::pair<unsigned, llvm::SmallPtrSet<Operation *, 4>>> &crossValueMap)
+{
+    unsigned nGroups = groups.size();
+    auto &ya = c.yieldAug;
+    ya.crossValues.clear();
+    ya.augmentedValues.clear();
+    ya.groupSlotActions.clear();
+
+    // Step 2.3.1: convert crossValueMap to CrossGroupValue list
+    for (auto &[val, info] : crossValueMap) {
+        unsigned fromG = info.first;
+        SmallVector<unsigned, 2> toGroups;
+        SmallVector<bool, 8> groupHasConsumer(nGroups, false);
+        for (auto *consumerOp : info.second) {
+            auto git = opToGroup.find(consumerOp);
+            if (git != opToGroup.end() && !groupHasConsumer[git->second]) {
+                groupHasConsumer[git->second] = true;
+                toGroups.push_back(git->second);
+            }
+        }
+        ya.crossValues.push_back({val, fromG, std::move(toGroups)});
+    }
+
+    // Stable sort for deterministic slot order: by producer group, then value ptr.
+    llvm::sort(ya.crossValues, [](const CrossGroupValue &a,
+                                   const CrossGroupValue &b) {
+        if (a.fromGroupIdx != b.fromGroupIdx)
+            return a.fromGroupIdx < b.fromGroupIdx;
+        return a.value.getAsOpaquePointer() < b.value.getAsOpaquePointer();
+    });
+
+    // Step 2.3.2: Case B groupSlotActions first (must have dimensions even when
+    // crossValues is empty, for Part3 to iterate over).
+    if (c.hasYield)
+        planYieldCaseB(c, splitThen, groups, opToGroup);
+
+    if (ya.crossValues.empty())
+        return;
+
+    if (!c.hasYield)
+        planYieldCaseA(c, groups);
+}
+
+static void analyzeDependencies(SmallVector<CandidateIf> &candidates)
+{
+    for (auto &c : candidates) {
+        // Step 2.1: Build op → group index maps (including nested ifs)
+        llvm::SmallDenseMap<Operation *, unsigned> opToThenGroup;
+        for (unsigned gi = 0; gi < c.thenGroups.size(); ++gi) {
+            for (auto *op : c.thenGroups[gi].ops)
+                opToThenGroup[op] = gi;
+            for (auto nestedIf : c.thenGroups[gi].nestedIfs)
+                opToThenGroup[nestedIf.getOperation()] = gi;
+        }
+
+        llvm::SmallDenseMap<Operation *, unsigned> opToElseGroup;
+        for (unsigned gi = 0; gi < c.elseGroups.size(); ++gi) {
+            for (auto *op : c.elseGroups[gi].ops)
+                opToElseGroup[op] = gi;
+            for (auto nestedIf : c.elseGroups[gi].nestedIfs)
+                opToElseGroup[nestedIf.getOperation()] = gi;
+        }
+
+        // Step 2.2: Single-pass scan — value-level crossValueMap only
+        llvm::SmallDenseMap<Value,
+            std::pair<unsigned, llvm::SmallPtrSet<Operation *, 4>>> thenValueMap, elseValueMap;
+
+        scanRegion(c.thenGroups, opToThenGroup, thenValueMap);
+        scanRegion(c.elseGroups, opToElseGroup, elseValueMap);
+
+        // Step 2.3: Plan yield augmentation for the active region
+        // Groups are in natural discovery order (block_ids appear in
+        // dependency order within a sequential basic block).
+        bool splitThen = c.thenGroups.size() >= 2;
+        if (splitThen) {
+            planYield(c, /*splitThen=*/true,
+                      ArrayRef(c.thenGroups), opToThenGroup, thenValueMap);
+        } else if (c.elseGroups.size() >= 2) {
+            planYield(c, /*splitThen=*/false,
+                      ArrayRef(c.elseGroups), opToElseGroup, elseValueMap);
+        }
+
+        // Step 2.4: Debug yield augmentation
+        dumpYieldAugmentation(c);
+    }
+}
+
+// ============================================================================
+// Part3: Materialization
+// ============================================================================
+//
+// Unified yield-chain approach for both Case A and Case B.
+// For each candidate, create a chain of split ifs.  Each if has the same
+// result types; non-producing slots passthrough from the previous if.
+// Case A: cross-group values become new yield slots; first if's else
+//   uses zero placeholders (since original if has no else values).
+// Case B: original yield slots preserved; first if's else passes through
+//   original else values.
+
+/// Walk through reinterpret_cast and subview ops to find the root memref.
+/// Returns the ultimate source (typically a function argument = GM, or an
+/// alloc/alloca) that downstream provenance analyses should see.
+static Value getRootMemRef(Value v) {
+    while (v) {
+        if (auto *op = v.getDefiningOp()) {
+            if (isa<memref::ReinterpretCastOp, memref::SubViewOp>(op)) {
+                v = op->getOperand(0);
+                continue;
+            }
+            // Trace through split-if chain results: the then branch carries
+            // the real computation, whose root we want for the placeholder.
+            if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+                unsigned resultIdx = cast<OpResult>(v).getResultNumber();
+                auto thenTerm = ifOp.thenBlock()->getTerminator();
+                if (auto thenYield = dyn_cast<scf::YieldOp>(thenTerm)) {
+                    v = thenYield->getOperand(resultIdx);
+                    continue;
+                }
+            }
+        }
+        break;
+    }
+    return v;
+}
+
+/// Walk through scf.if (then branch) and scf.for (init args) to find the
+/// ultimate source tensor. This allows tensor placeholders to preserve
+/// provenance instead of creating a fresh tensor.empty().
+static Value getRootTensor(Value v) {
+    while (v) {
+        if (auto *op = v.getDefiningOp()) {
+            // Trace through split-if chain: then branch carries the real
+            // computation whose source we want for the placeholder.
+            if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+                unsigned resultIdx = cast<OpResult>(v).getResultNumber();
+                auto thenTerm = ifOp.thenBlock()->getTerminator();
+                if (auto thenYield = dyn_cast<scf::YieldOp>(thenTerm)) {
+                    v = thenYield->getOperand(resultIdx);
+                    continue;
+                }
+            }
+            // Trace through scf.for: init arg is the source before the loop.
+            if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+                unsigned resultIdx = cast<OpResult>(v).getResultNumber();
+                v = forOp.getInitArgs()[resultIdx];
+                continue;
+            }
+        }
+        break;
+    }
+    return v;
+}
+
+/// Create a zero/default SSA value of the given type.
+/// Used for placeholder values in Case A else blocks when the original
+/// scf.if has no yield results to passthrough.
+/// When \p referenceValue traces to a function argument, the placeholder
+/// preserves that provenance instead of creating a fresh alloca.
+static Value createPlaceholderValue(OpBuilder &builder, Location loc, Type type,
+                                     Value referenceValue = Value())
+{
+    Value result;
+    bool usedTrace = false;
+    if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
+        // When a reference value traces to a real tensor source (not a
+        // tensor.empty placeholder we created), use it directly so downstream
+        // provenance analyses see the same origin in both branches.
+        // The traced root must dominate the placeholder insertion point:
+        // its parent region must contain (be ancestor of, or equal to)
+        // the builder's region. Values defined inside inner regions
+        // (e.g. scf.if then-blocks) or sibling regions are rejected.
+        if (referenceValue) {
+            Value root = getRootTensor(referenceValue);
+            auto *rootRegion = root.getParentRegion();
+            auto *builderRegion = builder.getBlock()->getParent();
+            bool dominates = (rootRegion == builderRegion) ||
+                             rootRegion->isAncestor(builderRegion);
+            if (dominates) {
+                if (auto *rootOp = root.getDefiningOp()) {
+                    auto existingId = rootOp->getAttrOfType<IntegerAttr>(
+                        CVPipeline::kBlockId);
+                    if (!existingId || existingId.getInt() != -1) {
+                        result = root;
+                        usedTrace = true;
+                    }
+                }
+            }
+        }
+        if (!usedTrace) {
+            result = builder.create<tensor::EmptyOp>(loc, tensorType.getShape(),
+                                                      tensorType.getElementType());
+        }
+    } else if (auto floatType = dyn_cast<FloatType>(type)) {
+        result = builder.create<arith::ConstantOp>(loc,
+            builder.getFloatAttr(floatType, 0.0));
+    } else if (auto intType = dyn_cast<IntegerType>(type)) {
+        result = builder.create<arith::ConstantOp>(loc,
+            builder.getIntegerAttr(intType, 0));
+    } else if (type.isIndex()) {
+        result = builder.create<arith::ConstantOp>(loc,
+            builder.getIndexAttr(0));
+    } else if (auto memrefType = dyn_cast<MemRefType>(type)) {
+        // Create a base memref placeholder.
+        // For memrefs with address_space (cbuf/ub), use alloca since these
+        // special memory spaces require a valid allocation.
+        // For plain memrefs, use a non-alloc-like placeholder (tensor.empty +
+        // to_memref) so that downstream traceback (e.g. bisheng's
+        // tracebackMemRefToAlloc) doesn't stop here prematurely and pick the
+        // wrong alloc when both branches yield alloc-like values.
+        Value baseMemref;
+        bool usedReference = false;
+        // When a reference value traces to a function argument (GM), use that
+        // argument as the base memref so downstream provenance analysis sees
+        // the same memory space in both branches of the split-if chain.
+        // Only applicable for strided memrefs without explicit memory_space
+        // (which would require a specific allocation).
+        if (referenceValue && !memrefType.getMemorySpace() &&
+            isa<StridedLayoutAttr>(memrefType.getLayout())) {
+            Value root = getRootMemRef(referenceValue);
+            if (auto blockArg = dyn_cast<BlockArgument>(root)) {
+                if (blockArg.getOwner()->isEntryBlock()) {
+                    baseMemref = root;
+                    usedReference = true;
+                }
+            }
+        }
+        if (!usedReference) {
+            if (memrefType.getMemorySpace()) {
+                SmallVector<Value> allocaSizes;
+                for (int64_t i = 0; i < memrefType.getRank(); ++i)
+                    if (memrefType.isDynamicDim(i))
+                        allocaSizes.push_back(builder.create<arith::ConstantOp>(loc,
+                            builder.getIndexAttr(1)).getResult());
+                auto simpleType = MemRefType::get(memrefType.getShape(),
+                                                  memrefType.getElementType());
+                baseMemref = builder.create<memref::AllocaOp>(loc, simpleType,
+                                                              allocaSizes).getResult();
+            } else {
+                // For plain memrefs without address_space, use memref.alloc()
+                // for static shapes and memref.alloca() for dynamic shapes.
+                // The else branch is dead (never executed), and DCE will
+                // eliminate it. block_id = -1 marks it as a placeholder.
+                bool hasDynamic = llvm::any_of(memrefType.getShape(),
+                                               ShapedType::isDynamic);
+                if (hasDynamic) {
+                    SmallVector<Value> allocaSizes;
+                    for (int64_t i = 0; i < memrefType.getRank(); ++i)
+                        if (memrefType.isDynamicDim(i))
+                            allocaSizes.push_back(builder.create<arith::ConstantOp>(loc,
+                                builder.getIndexAttr(1)).getResult());
+                    auto simpleType = MemRefType::get(memrefType.getShape(),
+                                                      memrefType.getElementType());
+                    baseMemref = builder.create<memref::AllocaOp>(loc, simpleType,
+                                                                  allocaSizes).getResult();
+                } else {
+                    baseMemref = builder.create<memref::AllocOp>(loc, memrefType).getResult();
+                }
+            }
+        }
+        // Apply strided layout via reinterpret_cast if needed.
+        auto layout = memrefType.getLayout();
+        if (auto stridedLayout = dyn_cast<StridedLayoutAttr>(layout)) {
+            SmallVector<int64_t> staticOffsets, staticSizes, staticStrides;
+            SmallVector<Value> dynOffsets, dynSizes, dynStrides;
+            // Offset
+            int64_t off = stridedLayout.getOffset();
+            staticOffsets.push_back(off);
+            if (ShapedType::isDynamic(off))
+                dynOffsets.push_back(builder.create<arith::ConstantOp>(loc,
+                    builder.getIndexAttr(0)).getResult());
+            // Sizes
+            for (int64_t sz : memrefType.getShape()) {
+                staticSizes.push_back(sz);
+                if (ShapedType::isDynamic(sz))
+                    dynSizes.push_back(builder.create<arith::ConstantOp>(loc,
+                        builder.getIndexAttr(1)).getResult());
+            }
+            // Strides
+            for (int64_t stride : stridedLayout.getStrides()) {
+                staticStrides.push_back(stride);
+                if (ShapedType::isDynamic(stride))
+                    dynStrides.push_back(builder.create<arith::ConstantOp>(loc,
+                        builder.getIndexAttr(1)).getResult());
+            }
+            OperationState state(loc, memref::ReinterpretCastOp::getOperationName());
+            state.addTypes(memrefType);
+            state.addOperands(baseMemref);
+            state.addOperands(dynOffsets);
+            state.addOperands(dynSizes);
+            state.addOperands(dynStrides);
+            state.addAttribute("operandSegmentSizes",
+                builder.getDenseI32ArrayAttr({
+                    1,
+                    static_cast<int32_t>(dynOffsets.size()),
+                    static_cast<int32_t>(dynSizes.size()),
+                    static_cast<int32_t>(dynStrides.size())
+                }));
+            state.addAttribute("static_offsets",
+                builder.getDenseI64ArrayAttr(staticOffsets));
+            state.addAttribute("static_sizes",
+                builder.getDenseI64ArrayAttr(staticSizes));
+            state.addAttribute("static_strides",
+                builder.getDenseI64ArrayAttr(staticStrides));
+            result = builder.create(state)->getResult(0);
+        } else {
+            result = baseMemref;
+        }
+    } else {
+        llvm_unreachable("unsupported type for placeholder value in Case A else block");
+    }
+    // Seed placeholders are ambient (don't belong to any specific block_id group).
+    // Tag them with block_id = -1 so downstream passes scanning for block_id
+    // attributes (e.g. AddControlFlowCondition) won't complain.
+    // When usedTrace is true, result is a traced source tensor that already
+    // carries meaningful block_id — don't overwrite it.
+    if (!usedTrace)
+        result.getDefiningOp()->setAttr(CVPipeline::kBlockId,
+            builder.getI32IntegerAttr(-1));
+    return result;
+}
+
+// ============================================================================
+// Part3 helpers
+// ============================================================================
+
+/// Get or create a zero/default placeholder of the given type.
+/// Placeholders are cached by type and inserted before `insertBefore` so they
+/// dominate every split-if in the chain.
+/// When \p referenceValue traces to a function argument, the placeholder
+/// preserves that provenance.
+static Value getOrCreatePlaceholder(Type type,
+                                    llvm::SmallDenseMap<Type, Value> &cache,
+                                    Operation *insertBefore,
+                                    Location loc,
+                                    OpBuilder &builder,
+                                    Value referenceValue = Value())
+{
+    auto it = cache.find(type);
+    if (it != cache.end())
+        return it->second;
+    auto savedPoint = builder.saveInsertionPoint();
+    builder.setInsertionPoint(insertBefore);
+    Value val = createPlaceholderValue(builder, loc, type, referenceValue);
+    cache[type] = val;
+    builder.restoreInsertionPoint(savedPoint);
+    return val;
+}
+
+/// 3.1 Compute slot metadata from CandidateIf + YieldAugmentation.
+static SlotPlan buildSlotPlan(CandidateIf &c, bool splitThen)
+{
+    auto originalIf = c.ifOp;
+    auto &ya = c.yieldAug;
+    SlotPlan plan;
+
+    if (!c.hasYield) {
+        // Case A: slots = cross-group values
+        plan.nSlots = ya.crossValues.size();
+        for (unsigned s = 0; s < plan.nSlots; ++s) {
+            plan.resultTypes.push_back(ya.crossValues[s].value.getType());
+            plan.slotValues.push_back(ya.crossValues[s].value);
+            plan.valueToSlot[ya.crossValues[s].value] = s;
+        }
+    } else {
+        // Case B: slots = original yield results + augmented cross-group values
+        unsigned N = ya.numOriginalSlots;
+        unsigned M = ya.augmentedValues.size();
+        plan.nSlots = N + M;
+
+        for (unsigned s = 0; s < N; ++s)
+            plan.resultTypes.push_back(originalIf.getResult(s).getType());
+        for (unsigned s = 0; s < M; ++s)
+            plan.resultTypes.push_back(ya.augmentedValues[s].getType());
+
+        auto thenYield = cast<scf::YieldOp>(
+            splitThen ? originalIf.thenBlock()->getTerminator()
+                      : originalIf.elseBlock()->getTerminator());
+        for (unsigned s = 0; s < N; ++s)
+            plan.slotValues.push_back(thenYield->getOperand(s));
+        for (unsigned s = 0; s < M; ++s)
+            plan.slotValues.push_back(ya.augmentedValues[s]);
+
+        for (auto &cv : ya.crossValues) {
+            for (unsigned i = 0; i < N; ++i) {
+                if (plan.slotValues[i] == cv.value) {
+                    plan.valueToSlot[cv.value] = i;
+                    break;
+                }
+            }
+            for (unsigned i = 0; i < M; ++i) {
+                if (ya.augmentedValues[i] == cv.value) {
+                    plan.valueToSlot[cv.value] = N + i;
+                    break;
+                }
+            }
+        }
+
+        // Snapshot original other-region yield values for Case B first-if passthrough
+        Block *otherBlk = splitThen ? originalIf.elseBlock() : originalIf.thenBlock();
+        LDBG("    [Part3.1] snapshot otherBlock=" << (otherBlk ? "yes" : "null"));
+        if (otherBlk) {
+            auto otherYield = cast<scf::YieldOp>(otherBlk->getTerminator());
+            LDBG("    [Part3.1] got otherYield with " << otherYield->getNumOperands() << " operands");
+            for (unsigned s = 0; s < N; ++s)
+                plan.origOtherYieldValues.push_back(otherYield->getOperand(s));
+        }
+    }
+
+    unsigned nGroups = splitThen ? c.thenGroups.size() : c.elseGroups.size();
+    plan.lastIsVoid = !c.hasYield;
+    plan.nResultIfs = plan.lastIsVoid ? nGroups - 1 : nGroups;
+
+    return plan;
+}
+
+/// Rewire cross-group SSA uses in a group's ops and nested ifs, then move
+/// them into the target block.
+static void rewireAndMoveOps(BlockGroup &group,
+                             llvm::SmallDenseMap<Value, Value> &crossValueReplacement,
+                             Block &targetBlock)
+{
+    auto rewireOperand = [&](OpOperand &operand) {
+        auto it = crossValueReplacement.find(operand.get());
+        if (it != crossValueReplacement.end())
+            operand.set(it->second);
+    };
+
+    for (auto *op : group.ops) {
+        for (auto &operand : op->getOpOperands())
+            rewireOperand(operand);
+
+        // Walk nested regions of non-if region-bearing ops (e.g. scf.for)
+        // to rewire cross-group SSA uses inside their bodies.
+        // Use region walk (not op->walk) to avoid re-visiting the parent op
+        // whose operands were already rewired above.
+        if (!isa<scf::IfOp>(op)) {
+            for (auto &region : op->getRegions())
+                region.walk([&](Operation *nestedOp) {
+                    for (auto &operand : nestedOp->getOpOperands())
+                        rewireOperand(operand);
+                });
+        }
+    }
+    for (auto nestedIf : group.nestedIfs) {
+        for (auto &operand : nestedIf->getOpOperands())
+            rewireOperand(operand);
+
+        for (auto &region : nestedIf->getRegions())
+            region.walk([&](Operation *nestedOp) {
+                for (auto &operand : nestedOp->getOpOperands())
+                    rewireOperand(operand);
+            });
+    }
+
+    // Merge ops and nestedIfs, then sort by original position to preserve
+    // interleaving order before moving into the split-if's then block.
+    SmallVector<Operation *> allOps;
+    allOps.reserve(group.ops.size() + group.nestedIfs.size());
+    allOps.append(group.ops.begin(), group.ops.end());
+    for (auto nestedIf : group.nestedIfs)
+        allOps.push_back(nestedIf.getOperation());
+    llvm::sort(allOps, [](Operation *a, Operation *b) {
+        return a->isBeforeInBlock(b);
+    });
+    for (auto *op : allOps)
+        op->moveBefore(&targetBlock, targetBlock.end());
+}
+
+/// Fill one result-bearing split-if: rewire & move ops to then block,
+/// build then+else yields, and update cross-group SSA replacements.
+/// oi == split-if position in the chain (also == group index).
+/// Step 3.5.2: Build then yield — decide whether to fill true value,
+/// passthrough from previous if, or use placeholder for each slot.
+static void buildThenYield(
+    unsigned oi, bool firstIf,
+    const SlotPlan &plan, const YieldAugmentation &ya,
+    bool hasYield, bool otherSideHasOps,
+    SmallVector<scf::IfOp, 4> &splitIfs,
+    llvm::SmallDenseMap<Type, Value> &placeholderCache,
+    Operation *placeholderInsertBefore,
+    Block &thenBlock, Location loc, OpBuilder &builder)
+{
+    builder.setInsertionPointToEnd(&thenBlock);
+    SmallVector<Value, 4> yieldVals;
+    for (unsigned slot = 0; slot < plan.nSlots; ++slot) {
+        int action = ya.groupSlotActions[oi][slot];
+        if (action == static_cast<int>(oi)) {
+            yieldVals.push_back(plan.slotValues[slot]);
+        } else if (firstIf && !hasYield) {
+            yieldVals.push_back(getOrCreatePlaceholder(
+                plan.resultTypes[slot], placeholderCache,
+                placeholderInsertBefore, loc, builder,
+                plan.slotValues[slot]));
+        } else if (firstIf && hasYield) {
+            if (slot < ya.numOriginalSlots && !otherSideHasOps &&
+                !plan.origOtherYieldValues.empty())
+                yieldVals.push_back(plan.origOtherYieldValues[slot]);
+            else
+                yieldVals.push_back(getOrCreatePlaceholder(
+                    plan.resultTypes[slot], placeholderCache,
+                    placeholderInsertBefore, loc, builder,
+                    plan.slotValues[slot]));
+        } else {
+            yieldVals.push_back(splitIfs[oi - 1].getResult(slot));
+        }
+    }
+    builder.create<scf::YieldOp>(loc, yieldVals);
+}
+
+/// Ensure a value can be safely yielded from the else block.
+/// Clones cheap alias ops (reinterpret_cast, subview, etc.) and allocs
+/// locally in the else block so the else branch doesn't reference values
+/// defined outside the if ("即插即用").
+/// Constants (arith::ConstantOp) are NOT cloned — the pre-created placeholder
+/// already dominates and cloning would perturb the cross-group slot plan.
+/// Other values are returned unchanged.
+static Value ensureLocalValue(Value val, Block &elseBlock, OpBuilder &builder) {
+    // Block arguments always dominate
+    if (isa<BlockArgument>(val))
+        return val;
+
+    auto *defOp = val.getDefiningOp();
+    if (!defOp)
+        return val;
+
+    // Already inside the else block (e.g. other-side ops absorbed by Scene 3/4)
+    if (defOp->getBlock() == &elseBlock)
+        return val;
+
+    // Clone cheap alias ops and allocs locally
+    if (isCheapAliasOp(defOp) ||
+        isa<memref::AllocOp, memref::AllocaOp>(defOp)) {
+        OpBuilder::InsertionGuard guard(builder);
+        builder.setInsertionPointToEnd(&elseBlock);
+        auto *cloned = builder.clone(*defOp);
+        cloned->setAttr(CVPipeline::kBlockId, builder.getI32IntegerAttr(-1));
+        return cloned->getResult(0);
+    }
+
+    return val;
+}
+
+/// Create placeholders directly inside the else block ("即插即用").
+/// Returns one placeholder per slot, each created locally in the else block
+/// with block_id = -1.
+static SmallVector<Value, 4> buildElsePlaceholders(
+    const SlotPlan &plan, Block &elseBlock,
+    Location loc, OpBuilder &builder)
+{
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToEnd(&elseBlock);
+    SmallVector<Value, 4> result;
+    for (unsigned slot = 0; slot < plan.nSlots; ++slot) {
+        auto placeholder = createPlaceholderValue(
+            builder, loc, plan.resultTypes[slot], plan.slotValues[slot]);
+        result.push_back(placeholder);
+    }
+    return result;
+}
+
+/// Step 3.5.3: Build else yield.  The else block is always passthrough —
+/// no ops are ever moved into it except for Scene 3/4 (last if absorbs
+/// the other side's ops).
+static void buildElseYield(
+    unsigned oi, bool firstIf, bool isLastIf,
+    const SlotPlan &plan, const YieldAugmentation &ya,
+    bool hasYield, bool otherSideHasOps,
+    ArrayRef<Operation *> otherSideOps,
+    ArrayRef<Value> otherSideYieldValues,
+    SmallVector<scf::IfOp, 4> &splitIfs,
+    Block &elseBlock,
+    llvm::SmallDenseMap<Type, Value> &placeholderCache,
+    Operation *placeholderInsertBefore,
+    Location loc, OpBuilder &builder)
+{
+    if (elseBlock.mightHaveTerminator())
+        elseBlock.getTerminator()->erase();
+
+    builder.setInsertionPointToEnd(&elseBlock);
+    SmallVector<Value, 4> yieldVals;
+
+    if (isLastIf && otherSideHasOps) {
+        // Scene 3/4: last split-if's else absorbs other side ops.
+        for (auto *op : otherSideOps)
+            op->moveBefore(&elseBlock, elseBlock.end());
+        auto elsePlaceholders = buildElsePlaceholders(plan, elseBlock, loc, builder);
+        for (unsigned slot = 0; slot < plan.nSlots; ++slot) {
+            if (hasYield && slot < ya.numOriginalSlots &&
+                slot < otherSideYieldValues.size())
+                yieldVals.push_back(ensureLocalValue(
+                    otherSideYieldValues[slot], elseBlock, builder));
+            else
+                yieldVals.push_back(elsePlaceholders[slot]);
+        }
+    } else if (firstIf && !hasYield) {
+        // "即插即用"：Case A first-if else, placeholders created locally.
+        yieldVals = buildElsePlaceholders(plan, elseBlock, loc, builder);
+    } else if (firstIf && hasYield) {
+        if (!otherSideHasOps && !plan.origOtherYieldValues.empty()) {
+            yieldVals = plan.origOtherYieldValues;
+            for (auto &v : yieldVals)
+                v = ensureLocalValue(v, elseBlock, builder);
+            auto elsePlaceholders = buildElsePlaceholders(plan, elseBlock, loc, builder);
+            for (unsigned slot = ya.numOriginalSlots; slot < plan.nSlots; ++slot)
+                yieldVals.push_back(elsePlaceholders[slot]);
+        } else {
+            // "即插即用"：Case B first-if else, all slots as placeholders.
+            yieldVals = buildElsePlaceholders(plan, elseBlock, loc, builder);
+        }
+    } else {
+        for (unsigned slot = 0; slot < plan.nSlots; ++slot)
+            yieldVals.push_back(splitIfs[oi - 1].getResult(slot));
+    }
+    builder.create<scf::YieldOp>(loc, yieldVals);
+}
+
+/// Step 3.5.4: Register the split-if's produced slots so downstream
+/// groups can rewire their cross-group SSA uses to the new results.
+static void updateCrossValueReplacement(
+    unsigned oi,
+    const SlotPlan &plan, const YieldAugmentation &ya,
+    scf::IfOp splitIf, Block &thenBlock,
+    llvm::SmallDenseMap<Value, Value> &crossValueReplacement)
+{
+    SmallPtrSet<Block *, 4> thenBlocks;
+    thenBlock.walk([&](Block *b) { thenBlocks.insert(b); });
+
+    for (unsigned slot = 0; slot < plan.nSlots; ++slot) {
+        if (ya.groupSlotActions[oi][slot] == static_cast<int>(oi)) {
+            Value oldVal = plan.slotValues[slot];
+            if (plan.valueToSlot.count(oldVal)) {
+                Value newVal = splitIf.getResult(slot);
+                oldVal.replaceUsesWithIf(newVal, [&](OpOperand &operand) {
+                    return !thenBlocks.contains(
+                        operand.getOwner()->getBlock());
+                });
+                crossValueReplacement[oldVal] = newVal;
+            }
+        }
+    }
+}
+
+/// Fill a single split-if with ops and yield.
+/// Orchestrates: rewireAndMoveOps → then yield → else yield → register results.
+static void materializeResultIf(
+    unsigned oi,
+    BlockGroup &group,
+    const SlotPlan &plan,
+    const CandidateIf &c,
+    bool otherSideHasOps,
+    bool isLastIf,
+    ArrayRef<Operation *> otherSideOps,
+    ArrayRef<Value> otherSideYieldValues,
+    SmallVector<scf::IfOp, 4> &splitIfs,
+    llvm::SmallDenseMap<Value, Value> &crossValueReplacement,
+    llvm::SmallDenseMap<Type, Value> &placeholderCache,
+    Operation *placeholderInsertBefore,
+    Location loc,
+    OpBuilder &builder)
+{
+    auto &ya = c.yieldAug;
+    auto splitIf = splitIfs[oi];
+    bool firstIf = (oi == 0);
+
+    // Step 3.5.1: Rewire cross-group SSA & move ops into then block
+    Block &thenBlock = splitIf.getThenRegion().front();
+    if (thenBlock.mightHaveTerminator())
+        thenBlock.getTerminator()->erase();
+    rewireAndMoveOps(group, crossValueReplacement, thenBlock);
+
+    // Step 3.5.2: Build then yield
+    buildThenYield(oi, firstIf, plan, ya, c.hasYield, otherSideHasOps,
+                   splitIfs, placeholderCache, placeholderInsertBefore,
+                   thenBlock, loc, builder);
+
+    // Step 3.5.3: Build else yield
+    if (plan.nSlots > 0) {
+        Block &elseBlock = splitIf.getElseRegion().front();
+        buildElseYield(oi, firstIf, isLastIf, plan, ya, c.hasYield,
+                       otherSideHasOps, otherSideOps, otherSideYieldValues,
+                       splitIfs, elseBlock,
+                       placeholderCache, placeholderInsertBefore, loc, builder);
+    }
+
+    // Step 3.5.4: Update cross-group SSA replacements for downstream groups
+    // Runs AFTER rewireAndMoveOps so intra-group SSA uses inside thenBlock
+    // are not replaced (they should keep using direct SSA values).
+    updateCrossValueReplacement(oi, plan, ya, splitIf, thenBlock,
+                                crossValueReplacement);
+}
+
+/// Create a trailing void split-if for Case A's last group.
+/// When hasElse is true (Scene 3/4), the else block absorbs the other side's ops.
+static void materializeVoidIf(
+    BlockGroup &group,
+    scf::IfOp insertAfter,
+    Value condition,
+    bool hasElse,
+    ArrayRef<Operation *> otherSideOps,
+    ArrayRef<Value> otherSideYieldValues,
+    llvm::SmallDenseMap<Value, Value> &crossValueReplacement,
+    Location loc,
+    OpBuilder &builder,
+    CVPipeline::ComputeBlockIdManager &bm)
+{
+    LDBG("    [Part3.6] creating void split-if for last group hasElse=" << hasElse);
+
+    builder.setInsertionPointAfter(insertAfter);
+    auto voidIf = builder.create<scf::IfOp>(loc, condition, hasElse);
+    voidIf->setAttr(CVPipeline::kBlockId,
+                    builder.getI32IntegerAttr(bm.getNextId()));
+    if (voidIf.getThenRegion().empty())
+        voidIf.getThenRegion().emplaceBlock();
+    Block &thenBlock = voidIf.getThenRegion().front();
+    if (thenBlock.mightHaveTerminator())
+        thenBlock.getTerminator()->erase();
+
+    rewireAndMoveOps(group, crossValueReplacement, thenBlock);
+
+    builder.setInsertionPointToEnd(&thenBlock);
+    builder.create<scf::YieldOp>(loc);
+
+    // Scene 3/4: else block absorbs other side's ops
+    if (hasElse) {
+        if (voidIf.getElseRegion().empty())
+            voidIf.getElseRegion().emplaceBlock();
+        Block &elseBlock = voidIf.getElseRegion().front();
+        if (elseBlock.mightHaveTerminator())
+            elseBlock.getTerminator()->erase();
+
+        for (auto *op : otherSideOps)
+            op->moveBefore(&elseBlock, elseBlock.end());
+
+        builder.setInsertionPointToEnd(&elseBlock);
+        builder.create<scf::YieldOp>(loc);
+    }
+}
+
+// ============================================================================
+// Part3 helpers: other-side collection & placeholders
+// ============================================================================
+
+struct OtherSideContext {
+    bool hasOps;
+    SmallVector<Operation *> ops;
+    SmallVector<Value> yieldValues;
+};
+
+/// Collect ops (and yield values for Case B) from the side that is NOT being
+/// split.  In Scene 3/4 the last split-if's else block absorbs them.
+static OtherSideContext collectOtherSideInfo(const CandidateIf &c, bool splitThen)
+{
+    OtherSideContext ctx;
+    auto &otherGroups = splitThen ? c.elseGroups : c.thenGroups;
+    ctx.hasOps = !otherGroups.empty();
+    if (!ctx.hasOps)
+        return ctx;
+
+    auto originalIf = c.ifOp;
+    for (auto &g : otherGroups) {
+        for (auto *op : g.ops)
+            ctx.ops.push_back(op);
+        for (auto nestedIf : g.nestedIfs)
+            ctx.ops.push_back(nestedIf.getOperation());
+    }
+    llvm::sort(ctx.ops, [](Operation *a, Operation *b) {
+        return a->isBeforeInBlock(b);
+    });
+
+    if (c.hasYield) {
+        Block *otherBlk = splitThen ? originalIf.elseBlock()
+                                    : originalIf.thenBlock();
+        auto otherYield = cast<scf::YieldOp>(otherBlk->getTerminator());
+        for (auto v : otherYield->getOperands())
+            ctx.yieldValues.push_back(v);
+    }
+    return ctx;
+}
+
+/// Pre-create placeholder values so they dominate every split-if.
+/// Case A: all slots need placeholders (original if has no yield).
+/// Case B: only augmented slots (indices >= numOriginalSlots) need placeholders;
+///   original slots get their passthrough from else values.
+/// When the other side has ops, non-last split ifs use placeholders for
+///   original slots too (origOtherYieldValues may dangle after erase).
+static void preCreatePlaceholders(
+    const SlotPlan &plan, const CandidateIf &c,
+    bool otherSideHasOps,
+    llvm::SmallDenseMap<Type, Value> &cache,
+    Operation *insertBefore, Location loc, OpBuilder &builder)
+{
+    auto &ya = c.yieldAug;
+    if (c.hasYield) {
+        for (unsigned slot = ya.numOriginalSlots; slot < plan.nSlots; ++slot)
+            getOrCreatePlaceholder(plan.resultTypes[slot], cache,
+                                   insertBefore, loc, builder,
+                                   plan.slotValues[slot]);
+        if (otherSideHasOps) {
+            for (unsigned slot = 0; slot < ya.numOriginalSlots; ++slot)
+                getOrCreatePlaceholder(plan.resultTypes[slot], cache,
+                                       insertBefore, loc, builder,
+                                       plan.slotValues[slot]);
+        }
+    } else {
+        for (unsigned slot = 0; slot < plan.nSlots; ++slot)
+            getOrCreatePlaceholder(plan.resultTypes[slot], cache,
+                                   insertBefore, loc, builder,
+                                   plan.slotValues[slot]);
+    }
+}
+
+// ============================================================================
+// Part3: Materialization (orchestrator)
+// ============================================================================
+
+/// Unified materialization for Case A and Case B.
+/// Creates a chain of split ifs.  Each if yields the slots it produces
+/// and passthroughs the rest from the previous if.
+/// Cross-group SSA uses are rewired to previous split if results.
+static void materializeCandidate(CandidateIf &c, OpBuilder &builder,
+                                  CVPipeline::ComputeBlockIdManager &bm)
+{
+    auto originalIf = c.ifOp;
+    auto loc = originalIf.getLoc();
+    Value condition = originalIf.getCondition();
+    auto &ya = c.yieldAug;
+
+    LDBG("    [Part3] enter materializeCandidate hasYield=" << c.hasYield);
+
+    // Determine active region
+    bool splitThen = c.thenGroups.size() >= 2;
+    auto &groups = splitThen ? c.thenGroups : c.elseGroups;
+    unsigned nGroups = groups.size();
+    if (nGroups < 2) return;
+
+    // Collect other-side ops (scene 3/4: absorbed into last split-if's else)
+    auto otherCtx = collectOtherSideInfo(c, splitThen);
+
+    LDBG("    [Part3.1] splitThen=" << splitThen << " nGroups=" << nGroups
+         << " otherSideHasOps=" << otherCtx.hasOps);
+
+    // Step 3.1: Compute slot metadata
+    SlotPlan plan = buildSlotPlan(c, splitThen);
+
+    LDBG("    [Part3.1] nSlots=" << plan.nSlots << " nGroups=" << nGroups
+         << " nResultIfs=" << plan.nResultIfs << " lastIsVoid=" << plan.lastIsVoid);
+
+    builder.setInsertionPoint(originalIf);
+
+    // Step 3.2: Negate condition when splitting else — ops originally in
+    // the else branch (condition=false) are placed in the split if's then
+    // branch, so the condition must be inverted to preserve semantics.
+    if (!splitThen) {
+        auto trueVal = builder.create<arith::ConstantOp>(
+            loc, builder.getIntegerAttr(builder.getI1Type(), 1));
+        condition = builder.create<arith::XOrIOp>(loc, condition, trueVal).getResult();
+    }
+
+    // Step 3.3: Pre-create placeholders (dominate every split-if)
+    llvm::SmallDenseMap<Type, Value> placeholderCache;
+    preCreatePlaceholders(plan, c, otherCtx.hasOps, placeholderCache,
+                          originalIf, loc, builder);
+
+    // Step 3.4: Create empty split-if shells
+    SmallVector<scf::IfOp, 4> splitIfs;
+    for (unsigned gi = 0; gi < plan.nResultIfs; ++gi) {
+        auto newIf = builder.create<scf::IfOp>(loc, plan.resultTypes, condition,
+                                               /*hasElse=*/plan.nSlots > 0);
+        newIf->setAttr(CVPipeline::kBlockId,
+                        builder.getI32IntegerAttr(bm.getNextId()));
+        if (newIf.getThenRegion().empty())
+            newIf.getThenRegion().emplaceBlock();
+        if (plan.nSlots > 0 && newIf.getElseRegion().empty())
+            newIf.getElseRegion().emplaceBlock();
+        splitIfs.push_back(newIf);
+    }
+
+    // Step 3.5: Fill each result-bearing split if
+    llvm::SmallDenseMap<Value, Value> crossValueReplacement;
+    for (unsigned gi = 0; gi < plan.nResultIfs; ++gi) {
+        bool isLastResultIf = (gi == plan.nResultIfs - 1) && !plan.lastIsVoid;
+        materializeResultIf(gi, groups[gi],
+                            plan, c,
+                            otherCtx.hasOps, isLastResultIf,
+                            otherCtx.ops, otherCtx.yieldValues,
+                            splitIfs,
+                            crossValueReplacement, placeholderCache,
+                            originalIf, loc, builder);
+    }
+
+    // Step 3.6: Last void split-if (Case A only)
+    if (plan.lastIsVoid) {
+        materializeVoidIf(groups.back(),
+                          splitIfs.back(), condition,
+                          otherCtx.hasOps,
+                          otherCtx.ops, otherCtx.yieldValues,
+                          crossValueReplacement, loc, builder, bm);
+    }
+
+    // Step 3.7: Replace original if uses & erase
+    if (c.hasYield) {
+        auto lastIf = splitIfs.back();
+        for (unsigned ri = 0; ri < ya.numOriginalSlots; ++ri)
+            originalIf.getResult(ri).replaceAllUsesWith(lastIf.getResult(ri));
+    }
+
+    originalIf->erase();
+}
+
+/// Count the number of ancestor scf::IfOps; used to sort outermost-first so
+/// that nested-if groups still hold valid pointers when an outer candidate
+/// is materialized.
+static unsigned ifDepth(Operation *op) {
+    unsigned d = 0;
+    for (auto *parent = op->getParentOp(); parent;
+         parent = parent->getParentOp())
+        if (isa<scf::IfOp>(parent))
+            ++d;
+    return d;
+}
+
+static void materializeCandidates(SmallVector<CandidateIf> &candidates, bool &changed,
+                                   CVPipeline::ComputeBlockIdManager &bm)
+{
+    if (candidates.empty())
+        return;
+
+    // Process outermost first: when the inner if is moved as a whole into an
+    // outer split-if, its internal ops stay valid.  If we did inner first,
+    // its originalIf would be erased, leaving dangling pointers in the outer
+    // candidate's group.nestedIfs.
+    llvm::stable_sort(candidates, [](const CandidateIf &a, const CandidateIf &b) {
+        return ifDepth(a.ifOp) < ifDepth(b.ifOp);
+    });
+
+    OpBuilder builder(candidates[0].ifOp.getContext());
+
+    for (auto &c : candidates) {
+        LDBG("    [Part3] materializing candidate (hasYield=" << c.hasYield << ")");
+        materializeCandidate(c, builder, bm);
+    }
+
+    changed = true;
+}
+
+// ============================================================================
+// Pass entry point
+// ============================================================================
+
+void SplitIfByBlockIdPass::runOnOperation()
+{
+    ModuleOp module = getOperation();
+    LDBG("SplitIfByBlockIdPass entered.");
+
+    // Dump the pre-split IR in debug builds
+    LDBG("//===--- Before SplitIfByBlockId ---\n" << module);
+    LDBG("//===--- End Before SplitIfByBlockId ---");
+
+    bool changed = true;
+    for (unsigned iteration = 1; changed; ++iteration) {
+        changed = false;
+
+        // Part1: Discovery & Grouping
+        auto candidates = discoverCandidates(module);
+        LDBG("  iter=" << iteration
+             << "  candidates=" << candidates.size());
+
+        if (candidates.empty())
+            break;
+
+        dumpCandidates(candidates);
+
+        // Part2: Dependency Analysis & Yield Planning
+        analyzeDependencies(candidates);
+
+        // Part3: Materialization
+        CVPipeline::ComputeBlockIdManager bm(module);
+        materializeCandidates(candidates, changed, bm);
+    }
+
+    // Dump the post-split IR in debug builds
+    LDBG("//===--- After SplitIfByBlockId ---\n" << module);
+    LDBG("//===--- End After SplitIfByBlockId ---");
+
+    LDBG("SplitIfByBlockIdPass completed.");
+}
+
+// ============================================================================
+// Pass registration
+// ============================================================================
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<OperationPass<ModuleOp>> createSplitIfByBlockIdPass()
+{
+    return std::make_unique<SplitIfByBlockIdPass>();
+}
+
+void registerSplitIfByBlockIdPasses()
+{
+    registerPass([]() -> std::unique_ptr<mlir::Pass> {
+        return createSplitIfByBlockIdPass();
+    });
+}
+
+void SplitIfByBlockIdPass::getDependentDialects(DialectRegistry &registry) const
+{
+    registry.insert<arith::ArithDialect, bufferization::BufferizationDialect,
+                    linalg::LinalgDialect, memref::MemRefDialect,
+                    scf::SCFDialect, tensor::TensorDialect>();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitIfByBlockId/test_else_split.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitIfByBlockId/test_else_split.mlir
@@ -1,0 +1,153 @@
+// RUN: triton-opt --split-if-by-block-id %s | FileCheck %s
+
+module {
+  // ============================================================================
+  // Else split (Case A): then is empty, else region has block_id={5, 3}
+  // Expected: negate condition, remove original empty outer if, wrap else ops with negated condition and split
+  // ============================================================================
+
+  // CHECK-LABEL: func.func @test_else_split_basic
+  // for inside main_loop:
+  // CHECK: scf.for
+  // negated condition
+  // CHECK: arith.xori
+  // first split if (block_id=5): augmented yield slot
+  // CHECK: [[R0:%.*]] = scf.if
+  // CHECK-SAME: -> (i32)
+  // CHECK-NEXT: arith.maxsi {{.*}} {ssbuffer.block_id = 5 : i32}
+  // CHECK: scf.yield
+  // CHECK: else
+  // CHECK: scf.yield
+  // second split if (block_id=3): void, consumes [[R0]]
+  // CHECK: scf.if
+  // CHECK-NOT: ->
+  // CHECK-NEXT: arith.index_cast [[R0]] {ssbuffer.block_id = 3 : i32}
+  // CHECK: memref.dealloc {{.*}} {ssbuffer.block_id = 3 : i32}
+  // Note: original empty then if is gone, no nested scf.if wrapping at outer level
+
+  func.func @test_else_split_basic(%cond: i1) {
+    %c64_i32 = arith.constant {ssbuffer.block_id = 14 : i32} 64 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 14 : i32} 0 : i32
+    %c64 = arith.constant {ssbuffer.block_id = 14 : i32} 64 : index
+    %c0 = arith.constant {ssbuffer.block_id = 14 : i32} 0 : index
+    %alloc = memref.alloc() {ssbuffer.block_id = 14 : i32} : memref<64x64xf16>
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
+    scf.for %iv = %lb to %ub step %step {
+      scf.if %cond {
+      } else {
+        %v1 = arith.maxsi %c64_i32, %c0_i32 {ssbuffer.block_id = 5 : i32} : i32
+        %v2 = arith.index_cast %v1 {ssbuffer.block_id = 3 : i32} : i32 to index
+        %v3 = arith.muli %v2, %c64 {ssbuffer.block_id = 3 : i32} : index
+        memref.dealloc %alloc {ssbuffer.block_id = 3 : i32} : memref<64x64xf16>
+      } {ssbuffer.block_id = 17 : i32}
+    } {ssbuffer.main_loop = 0 : i64}
+    memref.dealloc %alloc {ssbuffer.block_id = 14 : i32} : memref<64x64xf16>
+    return
+  }
+
+  // ============================================================================
+  // Else split (Case B): original if has yield (N=2), then yields original empty-then values
+  // else region has block_id={10, 11}, cross-group dep: block 10 → block 11 (via slot 0)
+  // ============================================================================
+
+  // CHECK-LABEL: func.func @test_else_split_with_yield
+  // for inside main_loop:
+  // CHECK: scf.for
+  // negate condition
+  // CHECK: arith.xori
+  // first split if (block_id=10): replaces original else→then
+  // CHECK: [[R0:%.*]]:2 = scf.if
+  // CHECK-NEXT: arith.addf {{.*}} {ssbuffer.block_id = 10 : i32}
+  // CHECK: scf.yield
+  // second split if (block_id=11): consumes [[R0]]#0
+  // CHECK: [[R1:%.*]]:2 = scf.if
+  // CHECK-NEXT: arith.mulf [[R0]]#0, {{.*}} {ssbuffer.block_id = 11 : i32}
+  // CHECK: scf.yield [[R0]]#0,
+  // for yields the last split if's result:
+  // CHECK: scf.yield [[R1]]#0, [[R1]]#1
+  // CHECK: return
+
+  func.func @test_else_split_with_yield(%cond: i1) -> (tensor<16xf32>, tensor<16xf32>) {
+    %cst = arith.constant {ssbuffer.block_id = 14 : i32} 0.0 : f32
+    %t0 = tensor.empty() {ssbuffer.block_id = 14 : i32} : tensor<16xf32>
+    %f0 = linalg.fill {ssbuffer.block_id = 14 : i32} ins(%cst : f32) outs(%t0 : tensor<16xf32>) -> tensor<16xf32>
+    %cst2 = arith.constant {ssbuffer.block_id = 14 : i32} 1.0 : f32
+    %t1 = tensor.empty() {ssbuffer.block_id = 14 : i32} : tensor<16xf32>
+    %f1 = linalg.fill {ssbuffer.block_id = 14 : i32} ins(%cst2 : f32) outs(%t1 : tensor<16xf32>) -> tensor<16xf32>
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
+    %for:2 = scf.for %iv = %lb to %ub step %step iter_args(%a0 = %f0, %a1 = %f0) -> (tensor<16xf32>, tensor<16xf32>) {
+      %4:2 = scf.if %cond -> (tensor<16xf32>, tensor<16xf32>) {
+        scf.yield %f0, %f0 : tensor<16xf32>, tensor<16xf32>
+      } else {
+        %v1 = arith.addf %f1, %f0 {ssbuffer.block_id = 10 : i32} : tensor<16xf32>
+        %v2 = arith.mulf %v1, %f1 {ssbuffer.block_id = 11 : i32} : tensor<16xf32>
+        scf.yield %v1, %v2 : tensor<16xf32>, tensor<16xf32>
+      } {ssbuffer.block_id = 17 : i32}
+      scf.yield %4#0, %4#1 : tensor<16xf32>, tensor<16xf32>
+    } {ssbuffer.main_loop = 0 : i64}
+    return %for#0, %for#1 : tensor<16xf32>, tensor<16xf32>
+  }
+
+  // ============================================================================
+  // Nested else split: outer if else region has a nested if, which has different block_id ops in its else.
+  // Iteration 1: inner if split into bid=5 and bid=3 split-ifs.
+  // Iteration 2: outer if's else block now has multiple block_id nested ifs → outer also splits,
+  //         outer result if wraps inner bid=5 split-if, outer void if wraps inner bid=3.
+  // ============================================================================
+
+  // CHECK-LABEL: func.func @test_nested_else_split
+  // for inside main_loop:
+  // CHECK: scf.for
+  // outer negated condition
+  // CHECK: arith.xori
+  // outer result if: wraps block_id=5 split-if + inner condition + inner result
+  // CHECK: [[R0:%.*]]:2 = scf.if
+  // CHECK-SAME: -> (i1, i32)
+  // inner negated condition
+  // CHECK: [[INNER_COND:%.*]] = arith.xori
+  // inner result if (block_id=5)
+  // CHECK: [[INNER_R:%.*]] = scf.if [[INNER_COND]] -> (i32)
+  // CHECK: arith.maxsi {{.*}} {ssbuffer.block_id = 5 : i32}
+  // CHECK: scf.yield
+  // CHECK: else
+  // CHECK: scf.yield
+  // outer then yield: inner condition + inner result
+  // CHECK: scf.yield [[INNER_COND]], [[INNER_R]]
+  // CHECK: else
+  // CHECK: scf.yield
+  // outer void if wrapping block_id=3 void if: consumes [[R0]]#0 (inner cond) + [[R0]]#1
+  // CHECK: scf.if
+  // CHECK-NOT: ->
+  // inner void if (block_id=3)
+  // CHECK: scf.if [[R0]]#0
+  // CHECK: arith.index_cast [[R0]]#1 {ssbuffer.block_id = 3 : i32}
+
+  func.func @test_nested_else_split(%outer: i1, %inner: i1) {
+    %c64_i32 = arith.constant {ssbuffer.block_id = 14 : i32} 64 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 14 : i32} 0 : i32
+    %c64 = arith.constant {ssbuffer.block_id = 14 : i32} 64 : index
+    %c0 = arith.constant {ssbuffer.block_id = 14 : i32} 0 : index
+    %alloc = memref.alloc() {ssbuffer.block_id = 14 : i32} : memref<64x64xf16>
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
+    scf.for %iv = %lb to %ub step %step {
+      scf.if %outer {
+      } else {
+        scf.if %inner {
+        } else {
+          %v1 = arith.maxsi %c64_i32, %c0_i32 {ssbuffer.block_id = 5 : i32} : i32
+          %v2 = arith.index_cast %v1 {ssbuffer.block_id = 3 : i32} : i32 to index
+          %v3 = arith.muli %v2, %c64 {ssbuffer.block_id = 3 : i32} : index
+          memref.dealloc %alloc {ssbuffer.block_id = 3 : i32} : memref<64x64xf16>
+        } {ssbuffer.block_id = 16 : i32}
+      } {ssbuffer.block_id = 17 : i32}
+    } {ssbuffer.main_loop = 0 : i64}
+    memref.dealloc %alloc {ssbuffer.block_id = 14 : i32} : memref<64x64xf16>
+    return
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitIfByBlockId/test_nested_if.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitIfByBlockId/test_nested_if.mlir
@@ -1,0 +1,118 @@
+// RUN: triton-opt --split-if-by-block-id %s | FileCheck %s
+
+module {
+  // ============================================================================
+  // Nested then split: outer if then region has block_id={18, 9} + inner if
+  // Inner if then region has block_id={7, 8}
+  // Cross-group deps: block 18→9 (outer), block 7→8 (inner)
+  // Iteration 1: outer split (bid=18 result if + bid=9 wraps inner if),
+  //              inner split (bid=7 result if + bid=8 void if)
+  // Iteration 2: bid=9 region gets nested split-ifs (bid=23,24) → split again
+  // Result: each outer split-if contains only one block_id
+  // ============================================================================
+
+  // CHECK-LABEL: func.func @test_nested_then_split
+  // CHECK: scf.for
+  // outer split-if 1: bid=18, result if, 1 result
+  // CHECK: [[R0:%.*]] = scf.if
+  // CHECK-SAME: -> (index)
+  // CHECK: arith.addi {{.*}} {ssbuffer.block_id = 18 : i32}
+  // CHECK: scf.yield
+  // CHECK: else
+  // CHECK: scf.yield
+  // outer split-if 2: bid=9, result if, 1 result, consumes R0
+  // CHECK: [[R1:%.*]] = scf.if
+  // CHECK-SAME: -> (index)
+  // CHECK: arith.muli [[R0]], {{.*}} {ssbuffer.block_id = 9 : i32}
+  // CHECK: scf.yield
+  // CHECK: else
+  // CHECK: scf.yield
+  // outer split-if 3: wraps inner result if (bid=7), 1 result, else passthrough R1
+  // CHECK: [[R2:%.*]] = scf.if
+  // CHECK-SAME: -> (index)
+  // inner result if (bid=7)
+  // CHECK: [[R3:%.*]] = scf.if
+  // CHECK-SAME: -> (index)
+  // CHECK: arith.addi [[R0]], {{.*}} {ssbuffer.block_id = 7 : i32}
+  // CHECK: scf.yield
+  // CHECK: else
+  // CHECK: scf.yield
+  // CHECK: scf.yield [[R3]]
+  // CHECK: else
+  // CHECK: scf.yield [[R1]]
+  // outer split-if 4: void if wraps inner void if (bid=8), consumes R2
+  // CHECK: scf.if
+  // CHECK-NOT: ->
+  // CHECK: scf.if
+  // CHECK: arith.muli [[R2]], {{.*}} {ssbuffer.block_id = 8 : i32}
+
+  func.func @test_nested_then_split(%cond1: i1, %cond2: i1) {
+    %c0 = arith.constant {ssbuffer.block_id = 13 : i32} 0 : index
+    %c1 = arith.constant {ssbuffer.block_id = 13 : i32} 1 : index
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
+    scf.for %iv = %lb to %ub step %step {
+      scf.if %cond1 {
+        // block 18: produce %v1
+        %v1 = arith.addi %c0, %c1 {ssbuffer.block_id = 18 : i32} : index
+        // block 9: consume %v1 (cross-group)
+        %v2 = arith.muli %v1, %c1 {ssbuffer.block_id = 9 : i32} : index
+        // nested if
+        scf.if %cond2 {
+          // block 7: produce %v3, also uses %v1 from outer scope
+          %v3 = arith.addi %v1, %c1 {ssbuffer.block_id = 7 : i32} : index
+          // block 8: consume %v3 (cross-group)
+          %v4 = arith.muli %v3, %c1 {ssbuffer.block_id = 8 : i32} : index
+        }
+      }
+    } {ssbuffer.main_loop = 0 : i64}
+    return
+  }
+
+  // ============================================================================
+  // Nested then split (no cross-group deps): outer block_id={18, 9}, inner block_id={7, 8}
+  // Each group is independent (no data deps) → after iteration 2, inner ifs are wrapped by outer void ifs
+  // ============================================================================
+
+  // CHECK-LABEL: func.func @test_nested_then_no_cross_dep
+  // for inside main_loop:
+  // CHECK: scf.for
+  // outer: block 18 void if
+  // CHECK: scf.if
+  // CHECK-NOT: ->
+  // CHECK: arith.addi {{.*}} {ssbuffer.block_id = 18 : i32}
+  // outer: block 9 void if (inner already separated)
+  // CHECK: scf.if
+  // CHECK-NOT: ->
+  // CHECK: arith.muli {{.*}} {ssbuffer.block_id = 9 : i32}
+  // outer void if wrapping inner block 7 void if
+  // CHECK: scf.if
+  // CHECK-NOT: ->
+  // CHECK: scf.if
+  // CHECK: arith.addi {{.*}} {ssbuffer.block_id = 7 : i32}
+  // outer void if wrapping inner block 8 void if
+  // CHECK: scf.if
+  // CHECK-NOT: ->
+  // CHECK: scf.if
+  // CHECK: arith.muli {{.*}} {ssbuffer.block_id = 8 : i32}
+
+  func.func @test_nested_then_no_cross_dep(%cond1: i1, %cond2: i1) {
+    %c0 = arith.constant {ssbuffer.block_id = 13 : i32} 0 : index
+    %c1 = arith.constant {ssbuffer.block_id = 13 : i32} 1 : index
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
+    scf.for %iv = %lb to %ub step %step {
+      scf.if %cond1 {
+        %v1 = arith.addi %c0, %c1 {ssbuffer.block_id = 18 : i32} : index
+        %v2 = arith.muli %c0, %c1 {ssbuffer.block_id = 9 : i32} : index
+        scf.if %cond2 {
+          %v3 = arith.addi %c0, %c1 {ssbuffer.block_id = 7 : i32} : index
+          %v4 = arith.muli %c0, %c1 {ssbuffer.block_id = 8 : i32} : index
+        }
+      }
+    } {ssbuffer.main_loop = 0 : i64}
+    return
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitIfByBlockId/test_nested_if_cross_group_use.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitIfByBlockId/test_nested_if_cross_group_use.mlir
@@ -1,0 +1,112 @@
+// RUN: triton-opt --split-if-by-block-id %s | FileCheck %s
+
+module {
+  // ============================================================================
+  // Case A: outer if has no yield, then region has block_id={40, 26}
+  // block 40's first op is a nested scf.if (no prior op to set currentId),
+  // its result is consumed by block 26
+  // Key: (1) groupOpsInBlock must use nested if's own block_id to create group
+  // when currentId==-1; (2) planYieldCaseA must scan nestedIfs' results
+  // Expected: split into 2 chained ifs, group 40 passes nested result via augmented yield slot
+  // ============================================================================
+
+  // CHECK-LABEL: func.func @test_nested_if_result_cross_group_use
+  // for inside main_loop:
+  // CHECK: scf.for
+  // first split if: group 40, -> (index), yields nested if's result
+  // CHECK: [[FIRST:%.*]] = scf.if
+  // CHECK-SAME: -> (index)
+  // CHECK: [[NESTED:%.*]] = scf.if
+  // CHECK-SAME: -> (index)
+  // CHECK: arith.addi {{.*}} {ssbuffer.block_id = 18 : i32}
+  // CHECK: scf.yield {{.*}} : index
+  // CHECK: else
+  // CHECK: scf.yield {{.*}} : index
+  // CHECK: scf.yield [[NESTED]] : index
+  // CHECK: else
+  // CHECK: scf.yield
+  // second split if: group 26, void, consumes first if's result
+  // CHECK: scf.if
+  // CHECK-NOT: ->
+  // CHECK: arith.muli [[FIRST]], {{.*}} {ssbuffer.block_id = 26 : i32}
+
+  func.func @test_nested_if_result_cross_group_use(%cond1: i1, %cond2: i1) {
+    %c0 = arith.constant {ssbuffer.block_id = 13 : i32} 0 : index
+    %c1 = arith.constant {ssbuffer.block_id = 13 : i32} 1 : index
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
+    scf.for %iv = %lb to %ub step %step {
+      scf.if %cond1 {
+        // block 40: nested if as first op in thenBlock (no prior op to set currentId)
+        %nested_res = scf.if %cond2 -> (index) {
+          %v = arith.addi %c0, %c1 {ssbuffer.block_id = 18 : i32} : index
+          scf.yield %v : index
+        } else {
+          scf.yield %c0 : index
+        } {ssbuffer.block_id = 40 : i32}
+        // block 26: consumes nested_res (cross-group)
+        %v2 = arith.muli %nested_res, %c1 {ssbuffer.block_id = 26 : i32} : index
+      }
+    } {ssbuffer.main_loop = 0 : i64}
+    return
+  }
+
+  // ============================================================================
+  // Case B: outer if has 1 original yield slot (N=1), then region has block_id={40, 26}
+  // block 40 contains nested if + op producing original yield slot, nested if result consumed by block 26
+  // Key: planYieldCaseB must scan nestedIfs' results
+  // Expected: K=2 (N=1 original + M=1 augmented), nested result in augmented slot
+  // ============================================================================
+
+  // CHECK-LABEL: func.func @test_nested_if_result_cross_group_case_b
+  // for inside main_loop:
+  // CHECK: scf.for
+  // first split if: K=2, group 40, slot 0 original + slot 1 augmented (nested result)
+  // CHECK: [[FIRST_B:%.*]]:2 = scf.if
+  // CHECK-SAME: -> (index, index)
+  // CHECK: arith.addi {{.*}} {ssbuffer.block_id = 40 : i32}
+  // CHECK: [[NESTED_B:%.*]] = scf.if
+  // CHECK-SAME: -> (index)
+  // CHECK: arith.addi {{.*}} {ssbuffer.block_id = 18 : i32}
+  // CHECK: scf.yield {{.*}} : index
+  // CHECK: else
+  // CHECK: scf.yield {{.*}} : index
+  // CHECK: scf.yield {{.*}}, [[NESTED_B]] : index, index
+  // CHECK: else
+  // CHECK: scf.yield
+  // second split if: K=2, group 26, consumes augmented slot [[FIRST_B]]#1
+  // CHECK: [[SECOND_B:%.*]]:2 = scf.if
+  // CHECK-SAME: -> (index, index)
+  // CHECK: arith.muli [[FIRST_B]]#1, {{.*}} {ssbuffer.block_id = 26 : i32}
+  // for yields last split if's slot 0, slot 1 is passthrough initial value:
+  // CHECK: scf.yield [[SECOND_B]]#0,
+  // CHECK: return
+
+  func.func @test_nested_if_result_cross_group_case_b(%cond1: i1, %cond2: i1) -> index {
+    %c0 = arith.constant {ssbuffer.block_id = 13 : i32} 0 : index
+    %c1 = arith.constant {ssbuffer.block_id = 13 : i32} 1 : index
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
+    %for:2 = scf.for %iv = %lb to %ub step %step iter_args(%a0 = %c0, %a1 = %c0) -> (index, index) {
+      %result = scf.if %cond1 -> (index) {
+        // block 40: produces original yield slot + nested if result
+        %orig_yield = arith.addi %c0, %c1 {ssbuffer.block_id = 40 : i32} : index
+        %nested_res = scf.if %cond2 -> (index) {
+          %v = arith.addi %c0, %c1 {ssbuffer.block_id = 18 : i32} : index
+          scf.yield %v : index
+        } else {
+          scf.yield %c0 : index
+        } {ssbuffer.block_id = 40 : i32}
+        // block 26: consumes nested_res (cross-group)
+        %v2 = arith.muli %nested_res, %c1 {ssbuffer.block_id = 26 : i32} : index
+        scf.yield %orig_yield : index
+      } else {
+        scf.yield %c0 : index
+      } {ssbuffer.block_id = 16 : i32}
+      scf.yield %result, %c0 : index, index
+    } {ssbuffer.main_loop = 0 : i64}
+    return %for#0 : index
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitIfByBlockId/test_placeholder_gm_provenance.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitIfByBlockId/test_placeholder_gm_provenance.mlir
@@ -1,0 +1,90 @@
+// RUN: triton-opt --split-if-by-block-id %s | FileCheck %s
+
+module {
+  // ============================================================================
+  // GM provenance for placeholder in void-if split across block_id groups.
+  // block_id=3 produces a strided memref from a function argument (GM).
+  // The placeholder in the passthrough branch MUST use the same function
+  // argument (memref.reinterpret_cast %arg1), NOT memref.alloca (UB).
+  // The else block creates its own local reinterpret_cast (place-and-use)
+  // instead of referencing the pre-created placeholder from outside.
+  // The then branch keeps yielding the reinterpret_cast through the yield chain.
+  // ============================================================================
+
+  // CHECK-LABEL: func.func @test_gm_placeholder
+  // for inside main_loop:
+  // CHECK: scf.for
+  // block_id=3 result if: reinterpret_cast in then, local clone in else:
+  // CHECK: scf.if
+  // CHECK: memref.reinterpret_cast %arg1 {{.*}} {ssbuffer.block_id = 3 : i32}
+  // else block: local reinterpret_cast cloned inside else block (block_id=-1):
+  // CHECK: else
+  // CHECK: memref.reinterpret_cast %arg1 {{.*}} {ssbuffer.block_id = -1 : i32}
+  // block_id=4 void if: reinterpret_cast from yield-chain result, keeps block_id=4:
+  // CHECK: scf.if
+  // CHECK: memref.reinterpret_cast {{.*}} {ssbuffer.block_id = 4 : i32}
+  // No memref.alloca placeholder anywhere:
+  // CHECK-NOT: memref.alloca
+
+  func.func @test_gm_placeholder(%cond: i1, %arg0: memref<?xf32>) {
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
+    scf.for %iv = %lb to %ub step %step {
+      scf.if %cond {
+      } else {
+        %r = memref.reinterpret_cast %arg0 to offset: [0], sizes: [8], strides: [1]
+            {ssbuffer.block_id = 3 : i32} : memref<?xf32> to memref<?xf32, strided<[1]>>
+        %r2 = memref.reinterpret_cast %r to offset: [0], sizes: [8], strides: [1]
+            {ssbuffer.block_id = 4 : i32} : memref<?xf32, strided<[1]>> to memref<?xf32, strided<[1]>>
+      }
+    } {ssbuffer.main_loop = 0 : i64}
+    return
+  }
+
+  // ============================================================================
+  // Nested if: outer void if contains inner scf.if with block_id groups.
+  // Inner if produces a strided memref from a function argument (GM).
+  // The inner if is then itself split. Placeholders at BOTH levels
+  // (outer split-if chain and inner split-if chain) MUST use the function
+  // argument, NOT memref.alloca.
+  // The then branch keeps yielding reinterpret_cast through the yield chain;
+  // the else branch creates local reinterpret_cast from function arg (place-and-use).
+  // ============================================================================
+
+  // CHECK-LABEL: func.func @test_nested_gm_placeholder
+  // for inside main_loop:
+  // CHECK: scf.for
+  // No memref.alloca placeholder anywhere:
+  // CHECK-NOT: memref.alloca
+  // reinterpret_cast cloned at both outer and inner levels, preserving %arg2 provenance.
+  // First outer split-if wraps inner if with block_id=7:
+  // CHECK: scf.if
+  // CHECK: scf.if %arg1
+  // CHECK: memref.reinterpret_cast %arg2 {{.*}} {ssbuffer.block_id = 7 : i32}
+  // else block of first outer split-if: local reinterpret_cast from %arg2:
+  // CHECK: else
+  // CHECK: memref.reinterpret_cast %arg2 {{.*}} {ssbuffer.block_id = -1 : i32}
+  // Second outer split-if: inner if with block_id=8:
+  // CHECK: scf.if
+  // CHECK: scf.if %arg1
+  // CHECK: memref.reinterpret_cast {{.*}} {ssbuffer.block_id = 8 : i32}
+
+  func.func @test_nested_gm_placeholder(%cond1: i1, %cond2: i1, %arg0: memref<?xf32>) {
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
+    scf.for %iv = %lb to %ub step %step {
+      scf.if %cond1 {
+      } else {
+        scf.if %cond2 {
+          %r = memref.reinterpret_cast %arg0 to offset: [0], sizes: [8], strides: [1]
+              {ssbuffer.block_id = 7 : i32} : memref<?xf32> to memref<?xf32, strided<[1]>>
+          %r2 = memref.reinterpret_cast %r to offset: [0], sizes: [8], strides: [1]
+              {ssbuffer.block_id = 8 : i32} : memref<?xf32, strided<[1]>> to memref<?xf32, strided<[1]>>
+        }
+      }
+    } {ssbuffer.main_loop = 0 : i64}
+    return
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitIfByBlockId/test_scene3_case_a.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitIfByBlockId/test_scene3_case_a.mlir
@@ -1,0 +1,68 @@
+// RUN: triton-opt --split-if-by-block-id %s | FileCheck %s
+
+module {
+  // ============================================================================
+  // Scene 3 Case A: then has block_id={5, 3}, else has block_id={8} actual ops
+  // Original if has no yield (void if), pure side effects
+  // Cross-group dep: block 5 produces maxsi result, block 3 consumes → augmented yield slot
+  // then splits into 2 split-ifs, last if's else absorbs block_id=8 ops
+  // ============================================================================
+
+  // CHECK-LABEL: func.func @test_scene3_case_a
+
+  func.func @test_scene3_case_a(%cond: i1) {
+    %c64_i32 = arith.constant {ssbuffer.block_id = 14 : i32} 64 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 14 : i32} 0 : i32
+    %c64 = arith.constant {ssbuffer.block_id = 14 : i32} 64 : index
+    %c0 = arith.constant {ssbuffer.block_id = 14 : i32} 0 : index
+    %alloc = memref.alloc() {ssbuffer.block_id = 14 : i32} : memref<64x64xf16>
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
+    scf.for %iv = %lb to %ub step %step {
+      scf.if %cond {
+        // block_id=5: then group A
+        %v1 = arith.maxsi %c64_i32, %c0_i32 {ssbuffer.block_id = 5 : i32} : i32
+        // block_id=3: then group B (uses %v1 -> cross-group dep)
+        %v2 = arith.index_cast %v1 {ssbuffer.block_id = 3 : i32} : i32 to index
+        %v3 = arith.muli %v2, %c64 {ssbuffer.block_id = 3 : i32} : index
+        memref.dealloc %alloc {ssbuffer.block_id = 3 : i32} : memref<64x64xf16>
+      } else {
+        // block_id=8: else group C (single group)
+        %v4 = arith.maxsi %c0_i32, %c64_i32 {ssbuffer.block_id = 8 : i32} : i32
+        memref.dealloc %alloc {ssbuffer.block_id = 8 : i32} : memref<64x64xf16>
+      } {ssbuffer.block_id = 12 : i32}
+    } {ssbuffer.main_loop = 0 : i64}
+    memref.dealloc %alloc {ssbuffer.block_id = 14 : i32} : memref<64x64xf16>
+    return
+  }
+
+  // Expected structure:
+  //
+  // Round 1 — split then side (block_id=5, 3), else side (block_id=8) absorbed:
+  // for inside main_loop:
+  // CHECK: scf.for
+  //
+  // Placeholder seed:
+  // CHECK: arith.constant {ssbuffer.block_id = -1 : i32}
+  //
+  // first split if: block_id=5, result-bearing (cross-group dep augmented slot)
+  // CHECK: [[R1:%.*]] = scf.if
+  // CHECK-SAME: -> (i32)
+  // CHECK-NEXT: arith.maxsi {{.*}} {ssbuffer.block_id = 5 : i32}
+  // CHECK: scf.yield
+  // CHECK: else
+  // CHECK: scf.yield
+  //
+  // second split if: block_id=3 (void if), else absorbs block_id=8
+  // CHECK: scf.if
+  // CHECK-NOT: ->
+  // then side = block_id=3 ops:
+  // CHECK-NEXT: arith.index_cast [[R1]] {ssbuffer.block_id = 3 : i32}
+  // CHECK: arith.muli {{.*}} {ssbuffer.block_id = 3 : i32}
+  // CHECK: memref.dealloc {{.*}} {ssbuffer.block_id = 3 : i32}
+  // else side = absorbed block_id=8 ops:
+  // CHECK: else
+  // CHECK-NEXT: arith.maxsi {{.*}} {ssbuffer.block_id = 8 : i32}
+  // CHECK: memref.dealloc {{.*}} {ssbuffer.block_id = 8 : i32}
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitIfByBlockId/test_scene3_case_b.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitIfByBlockId/test_scene3_case_b.mlir
@@ -1,0 +1,60 @@
+// RUN: triton-opt --split-if-by-block-id %s | FileCheck %s
+
+module {
+  // ============================================================================
+  // Scene 3 Case B: then has block_id={10, 11}, else has block_id={5} actual ops
+  // then splits into 2 split-ifs, last if's else absorbs block_id=5 ops
+  // ============================================================================
+
+  // CHECK-LABEL: func.func @test_scene3_case_b
+  // for inside main_loop:
+  // CHECK: scf.for
+  // Placeholder:
+  // CHECK: tensor.empty() {ssbuffer.block_id = -1 : i32}
+  // first split if (block_id=10, group A):
+  // CHECK: [[SF0:%.*]]:2 = scf.if
+  // CHECK-NEXT: arith.addf {{.*}} {ssbuffer.block_id = 10 : i32}
+  // CHECK: scf.yield
+  // CHECK: else
+  // CHECK: scf.yield
+  // second split if (block_id=11, group B): then normal, else absorbs C
+  // CHECK: [[SF1:%.*]]:2 = scf.if
+  // CHECK-NEXT: arith.mulf [[SF0]]#0, {{.*}} {ssbuffer.block_id = 11 : i32}
+  // CHECK: scf.yield [[SF0]]#0,
+  // CHECK: else
+  // C's ops absorbed into last if's else:
+  // CHECK-NEXT: arith.subf {{.*}} {ssbuffer.block_id = 5 : i32}
+  // CHECK: scf.yield
+  // for yields the last split if's result:
+  // CHECK: scf.yield [[SF1]]#0, [[SF1]]#1
+  // CHECK: return
+
+  func.func @test_scene3_case_b(%cond: i1) -> (tensor<16xf32>, tensor<16xf32>) {
+    %cst = arith.constant {ssbuffer.block_id = 13 : i32} 0.0 : f32
+    %0 = tensor.empty() {ssbuffer.block_id = 13 : i32} : tensor<16xf32>
+    %1 = linalg.fill {ssbuffer.block_id = 13 : i32} ins(%cst : f32) outs(%0 : tensor<16xf32>) -> tensor<16xf32>
+    %cst2 = arith.constant {ssbuffer.block_id = 13 : i32} 1.0 : f32
+    %2 = tensor.empty() {ssbuffer.block_id = 13 : i32} : tensor<16xf32>
+    %f0 = linalg.fill {ssbuffer.block_id = 13 : i32} ins(%cst2 : f32) outs(%2 : tensor<16xf32>) -> tensor<16xf32>
+
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
+    %for:2 = scf.for %iv = %lb to %ub step %step iter_args(%a0 = %1, %a1 = %1) -> (tensor<16xf32>, tensor<16xf32>) {
+      %res:2 = scf.if %cond -> (tensor<16xf32>, tensor<16xf32>) {
+        // block_id=10: then ops group A
+        %a = arith.addf %1, %f0 {ssbuffer.block_id = 10 : i32} : tensor<16xf32>
+        // block_id=11: then ops group B (uses %a -> cross-group dep)
+        %b = arith.mulf %a, %f0 {ssbuffer.block_id = 11 : i32} : tensor<16xf32>
+        scf.yield %a, %b : tensor<16xf32>, tensor<16xf32>
+      } else {
+        // block_id=5: else ops (group C)
+        %c = arith.subf %f0, %f0 {ssbuffer.block_id = 5 : i32} : tensor<16xf32>
+        scf.yield %c, %c : tensor<16xf32>, tensor<16xf32>
+      } {ssbuffer.block_id = 12 : i32}
+      scf.yield %res#0, %res#1 : tensor<16xf32>, tensor<16xf32>
+    } {ssbuffer.main_loop = 0 : i64}
+
+    return %for#0, %for#1 : tensor<16xf32>, tensor<16xf32>
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitIfByBlockId/test_scene4_both_sides_multi_group.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitIfByBlockId/test_scene4_both_sides_multi_group.mlir
@@ -1,0 +1,86 @@
+// RUN: triton-opt --split-if-by-block-id %s | FileCheck %s
+
+module {
+  // ============================================================================
+  // Scene 4 Case B: then has block_id={10, 11}, else has block_id={5, 3}
+  // Both sides have >=2 groups, needs two iterations:
+  //   Round 1: split then side, last split if's else absorbs all else-side ops
+  //   Round 2: after absorption, else has 2 groups, triggers else-side split
+  // ============================================================================
+
+  // CHECK-LABEL: func.func @test_scene4_case_b
+
+  func.func @test_scene4_case_b(%cond: i1) -> (tensor<16xf32>, tensor<16xf32>) {
+    %cst = arith.constant {ssbuffer.block_id = 13 : i32} 0.0 : f32
+    %0 = tensor.empty() {ssbuffer.block_id = 13 : i32} : tensor<16xf32>
+    %1 = linalg.fill {ssbuffer.block_id = 13 : i32} ins(%cst : f32) outs(%0 : tensor<16xf32>) -> tensor<16xf32>
+    %cst2 = arith.constant {ssbuffer.block_id = 13 : i32} 1.0 : f32
+    %2 = tensor.empty() {ssbuffer.block_id = 13 : i32} : tensor<16xf32>
+    %f0 = linalg.fill {ssbuffer.block_id = 13 : i32} ins(%cst2 : f32) outs(%2 : tensor<16xf32>) -> tensor<16xf32>
+
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
+    %for:2 = scf.for %iv = %lb to %ub step %step iter_args(%a0 = %1, %a1 = %1) -> (tensor<16xf32>, tensor<16xf32>) {
+      %res:2 = scf.if %cond -> (tensor<16xf32>, tensor<16xf32>) {
+        // block_id=10: then group A
+        %a = arith.addf %1, %f0 {ssbuffer.block_id = 10 : i32} : tensor<16xf32>
+        // block_id=11: then group B (uses %a -> cross-group dep)
+        %b = arith.mulf %a, %f0 {ssbuffer.block_id = 11 : i32} : tensor<16xf32>
+        scf.yield %a, %b : tensor<16xf32>, tensor<16xf32>
+      } else {
+        // block_id=5: else group C
+        %c = arith.subf %f0, %f0 {ssbuffer.block_id = 5 : i32} : tensor<16xf32>
+        // block_id=3: else group D (uses %c -> cross-group dep)
+        %d = arith.addf %c, %1 {ssbuffer.block_id = 3 : i32} : tensor<16xf32>
+        scf.yield %c, %d : tensor<16xf32>, tensor<16xf32>
+      } {ssbuffer.block_id = 12 : i32}
+      scf.yield %res#0, %res#1 : tensor<16xf32>, tensor<16xf32>
+    } {ssbuffer.main_loop = 0 : i64}
+
+    return %for#0, %for#1 : tensor<16xf32>, tensor<16xf32>
+  }
+
+  // Round 1 + Round 2 expected structure:
+  //
+  // for inside main_loop:
+  // CHECK: scf.for
+  //
+  // Round 1 — split then side (block_id=10, 11):
+  //
+  // CHECK: tensor.empty() {ssbuffer.block_id = -1 : i32}
+  //
+  // Round 1 first split if: block_id=10 (then)
+  // CHECK: [[R1:%.*]]:2 = scf.if
+  // CHECK-NEXT: arith.addf {{.*}} {ssbuffer.block_id = 10 : i32}
+  // CHECK: scf.yield
+  // CHECK: else
+  // CHECK: scf.yield
+  //
+  // Round 2 — split else side (block_id=5, 3), negated condition:
+  //
+  // CHECK: arith.constant true
+  // CHECK: [[NEG:%.*]] = arith.xori
+  // CHECK: tensor.empty() {ssbuffer.block_id = -1 : i32}
+  //
+  // Round 2 first split if: block_id=5 (then, negated condition)
+  // CHECK: [[R2:%.*]]:2 = scf.if [[NEG]]
+  // CHECK-NEXT: arith.subf {{.*}} {ssbuffer.block_id = 5 : i32}
+  // CHECK: scf.yield
+  // CHECK: else
+  // CHECK: scf.yield
+  //
+  // Round 2 second split if: block_id=3 (then) + block_id=11 absorbed into else
+  // CHECK: [[R3:%.*]]:2 = scf.if [[NEG]]
+  // CHECK-NEXT: arith.addf [[R2]]#0, {{.*}} {ssbuffer.block_id = 3 : i32}
+  // CHECK: scf.yield [[R2]]#0,
+  // CHECK: else
+  // original then-side block_id=11 ops absorbed here as else:
+  // CHECK-NEXT: arith.mulf [[R1]]#0, {{.*}} {ssbuffer.block_id = 11 : i32}
+  // CHECK: scf.yield [[R1]]#0,
+  //
+  // for yields the last split if's result:
+  // CHECK: scf.yield [[R3]]#0, [[R3]]#1
+  // final return:
+  // CHECK: return
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitIfByBlockId/test_scene4_case_a.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitIfByBlockId/test_scene4_case_a.mlir
@@ -1,0 +1,87 @@
+// RUN: triton-opt --split-if-by-block-id %s | FileCheck %s
+
+module {
+  // ============================================================================
+  // Scene 4 Case A: then has block_id={5, 3}, else has block_id={8, 9}
+  // Both sides have >=2 groups, void if (no yield), pure side effects
+  // Two iterations:
+  //   Round 1: split then side, last if's else absorbs all else-side ops
+  //   Round 2: after absorption, else has 2 groups, triggers else-side split
+  // ============================================================================
+
+  // CHECK-LABEL: func.func @test_scene4_case_a
+
+  func.func @test_scene4_case_a(%cond: i1) {
+    %c64_i32 = arith.constant {ssbuffer.block_id = 14 : i32} 64 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 14 : i32} 0 : i32
+    %c64 = arith.constant {ssbuffer.block_id = 14 : i32} 64 : index
+    %c0 = arith.constant {ssbuffer.block_id = 14 : i32} 0 : index
+    %alloc = memref.alloc() {ssbuffer.block_id = 14 : i32} : memref<64x64xf16>
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
+    scf.for %iv = %lb to %ub step %step {
+      scf.if %cond {
+        // block_id=5: then group A
+        %v1 = arith.maxsi %c64_i32, %c0_i32 {ssbuffer.block_id = 5 : i32} : i32
+        // block_id=3: then group B (uses %v1 -> cross-group dep)
+        %v2 = arith.index_cast %v1 {ssbuffer.block_id = 3 : i32} : i32 to index
+        %v3 = arith.muli %v2, %c64 {ssbuffer.block_id = 3 : i32} : index
+        memref.dealloc %alloc {ssbuffer.block_id = 3 : i32} : memref<64x64xf16>
+      } else {
+        // block_id=8: else group C
+        %v4 = arith.maxsi %c0_i32, %c64_i32 {ssbuffer.block_id = 8 : i32} : i32
+        // block_id=9: else group D
+        %v5 = arith.index_cast %v4 {ssbuffer.block_id = 9 : i32} : i32 to index
+        memref.dealloc %alloc {ssbuffer.block_id = 9 : i32} : memref<64x64xf16>
+      } {ssbuffer.block_id = 12 : i32}
+    } {ssbuffer.main_loop = 0 : i64}
+    memref.dealloc %alloc {ssbuffer.block_id = 14 : i32} : memref<64x64xf16>
+    return
+  }
+
+  // Expected structure:
+  //
+  // Round 1 — split then side (block_id=5, 3):
+  // for inside main_loop:
+  // CHECK: scf.for
+  //
+  // Placeholder seed for round 1:
+  // CHECK: arith.constant {ssbuffer.block_id = -1 : i32}
+  //
+  // Round 1 first split if: block_id=5, result-bearing (cross-group dep augmented)
+  // CHECK: [[R1:%.*]] = scf.if
+  // CHECK-SAME: -> (i32)
+  // CHECK-NEXT: arith.maxsi {{.*}} {ssbuffer.block_id = 5 : i32}
+  // CHECK: scf.yield
+  // CHECK: else
+  // CHECK: scf.yield
+  //
+  // Round 2 — split else side (block_id=8, 9), negated condition:
+  //
+  // CHECK: arith.constant true
+  // CHECK: [[NEG:%.*]] = arith.xori
+  //
+  // Placeholder seed for round 2:
+  // CHECK: arith.constant {ssbuffer.block_id = -1 : i32}
+  //
+  // Round 2 first split if: block_id=8, result-bearing (negated condition)
+  // CHECK: [[R2:%.*]] = scf.if [[NEG]]
+  // CHECK-SAME: -> (i32)
+  // CHECK-NEXT: arith.maxsi {{.*}} {ssbuffer.block_id = 8 : i32}
+  // CHECK: scf.yield
+  // CHECK: else
+  // CHECK: scf.yield
+  //
+  // Round 2 second split if: block_id=9 (void), else absorbs block_id=3
+  // CHECK: scf.if [[NEG]]
+  // CHECK-NOT: ->
+  // then side = block_id=9:
+  // CHECK-NEXT: arith.index_cast [[R2]] {ssbuffer.block_id = 9 : i32}
+  // CHECK: memref.dealloc {{.*}} {ssbuffer.block_id = 9 : i32}
+  // else side = absorbed original then block_id=3 ops:
+  // CHECK: else
+  // CHECK-NEXT: arith.index_cast [[R1]] {ssbuffer.block_id = 3 : i32}
+  // CHECK: arith.muli {{.*}} {ssbuffer.block_id = 3 : i32}
+  // CHECK: memref.dealloc {{.*}} {ssbuffer.block_id = 3 : i32}
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitIfByBlockId/test_split_if.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitIfByBlockId/test_split_if.mlir
@@ -1,0 +1,208 @@
+// RUN: triton-opt --split-if-by-block-id %s | FileCheck %s
+
+module {
+  // ============================================================================
+  // Case B: original if with 2 yield slots, then region has block_id={10, 11}
+  // Cross-group dependency: block 10 produces %addf, block 11 consumes %addf (in yield slot 0)
+  // Expected: split into 2 chained ifs, K=2 (no augmentation)
+  // ============================================================================
+
+  // CHECK-LABEL: func.func @test_case_b_basic
+  // for inside main_loop:
+  // CHECK: scf.for
+  // first split if: only block_id=10
+  // CHECK: [[R0:%.*]]:2 = scf.if
+  // CHECK-NEXT: arith.addf {{.*}} {ssbuffer.block_id = 10 : i32}
+  // CHECK: scf.yield
+  // CHECK: else
+  // CHECK: scf.yield
+  // second split if: only block_id=11, consumes [[R0]]#0
+  // CHECK: [[R1:%.*]]:2 = scf.if
+  // CHECK-NEXT: arith.mulf [[R0]]#0, {{.*}} {ssbuffer.block_id = 11 : i32}
+  // CHECK: scf.yield [[R0]]#0,
+  // CHECK: else
+  // CHECK: scf.yield [[R0]]#0, [[R0]]#1
+  // for yields the last split if's result:
+  // CHECK: scf.yield [[R1]]#0, [[R1]]#1
+  // original uses replaced with last if's result
+  // CHECK: return
+
+  func.func @test_case_b_basic(%cond: i1) -> (tensor<16xf32>, tensor<16xf32>) {
+    %cst = arith.constant {ssbuffer.block_id = 13 : i32} 0.0 : f32
+    %0 = tensor.empty() {ssbuffer.block_id = 13 : i32} : tensor<16xf32>
+    %1 = linalg.fill {ssbuffer.block_id = 13 : i32} ins(%cst : f32) outs(%0 : tensor<16xf32>) -> tensor<16xf32>
+    %cst2 = arith.constant {ssbuffer.block_id = 13 : i32} 1.0 : f32
+    %2 = tensor.empty() {ssbuffer.block_id = 13 : i32} : tensor<16xf32>
+    %3 = linalg.fill {ssbuffer.block_id = 13 : i32} ins(%cst2 : f32) outs(%2 : tensor<16xf32>) -> tensor<16xf32>
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
+    %for:2 = scf.for %iv = %lb to %ub step %step iter_args(%a0 = %1, %a1 = %1) -> (tensor<16xf32>, tensor<16xf32>) {
+      %4:2 = scf.if %cond -> (tensor<16xf32>, tensor<16xf32>) {
+        %v1 = arith.addf %3, %1 {ssbuffer.block_id = 10 : i32} : tensor<16xf32>
+        %v2 = arith.mulf %v1, %3 {ssbuffer.block_id = 11 : i32} : tensor<16xf32>
+        scf.yield %v1, %v2 : tensor<16xf32>, tensor<16xf32>
+      } else {
+        scf.yield %1, %1 : tensor<16xf32>, tensor<16xf32>
+      } {ssbuffer.block_id = 16 : i32}
+      scf.yield %4#0, %4#1 : tensor<16xf32>, tensor<16xf32>
+    } {ssbuffer.main_loop = 0 : i64}
+    return %for#0, %for#1 : tensor<16xf32>, tensor<16xf32>
+  }
+
+  // ============================================================================
+  // Case A: original if has no yield, then region has block_id={5, 3}, pure side effects
+  // Cross-group dependency: block 5 produces maxsi result, block 3 consumes it → needs 1 augmented yield slot
+  // ============================================================================
+
+  // CHECK-LABEL: func.func @test_case_a_basic
+  // for inside main_loop:
+  // CHECK: scf.for
+  // first split if: augmented yield slot for cross-group value (block_id=5)
+  // CHECK: [[R0:%.*]] = scf.if
+  // CHECK-SAME: -> (i32)
+  // CHECK-NEXT: arith.maxsi {{.*}} {ssbuffer.block_id = 5 : i32}
+  // CHECK: scf.yield
+  // CHECK: else
+  // CHECK: scf.yield
+  // second split if: void, consumes [[R0]] (block_id=3)
+  // CHECK: scf.if
+  // CHECK-NOT: ->
+  // CHECK-NEXT: arith.index_cast [[R0]] {ssbuffer.block_id = 3 : i32}
+  // CHECK: memref.dealloc {{.*}} {ssbuffer.block_id = 3 : i32}
+
+  func.func @test_case_a_basic(%cond: i1) {
+    %cst = arith.constant {ssbuffer.block_id = 13 : i32} 0.0 : f16
+    %c64_i32 = arith.constant {ssbuffer.block_id = 13 : i32} 64 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 13 : i32} 0 : i32
+    %c64 = arith.constant {ssbuffer.block_id = 13 : i32} 64 : index
+    %c0 = arith.constant {ssbuffer.block_id = 13 : i32} 0 : index
+    %alloc = memref.alloc() {ssbuffer.block_id = 13 : i32} : memref<64x64xf16>
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
+    scf.for %iv = %lb to %ub step %step {
+      scf.if %cond {
+        %v1 = arith.maxsi %c64_i32, %c0_i32 {ssbuffer.block_id = 5 : i32} : i32
+        %v2 = arith.index_cast %v1 {ssbuffer.block_id = 3 : i32} : i32 to index
+        %v3 = arith.muli %v2, %c64 {ssbuffer.block_id = 3 : i32} : index
+        memref.dealloc %alloc {ssbuffer.block_id = 3 : i32} : memref<64x64xf16>
+      }
+    } {ssbuffer.main_loop = 0 : i64}
+    memref.dealloc %alloc {ssbuffer.block_id = 13 : i32} : memref<64x64xf16>
+    return
+  }
+
+  // ============================================================================
+  // Case B + augmentation: N=2 original yield slots, M=1 cross-group value not in yield
+  // then region has block_id={10, 11}, K=3 (N+M)
+  // block 10 produces %cross consumed by block 11, but not in original yield
+  // ============================================================================
+
+  // CHECK-LABEL: func.func @test_case_b_augment
+  // for inside main_loop:
+  // CHECK: scf.for
+  // first split if: K=3, block_id=10, augmented slot 2 holds %cross
+  // CHECK: [[R0:%.*]]:3 = scf.if
+  // CHECK-NEXT: arith.addf {{.*}} {ssbuffer.block_id = 10 : i32}
+  // CHECK: arith.mulf {{.*}} {ssbuffer.block_id = 10 : i32}
+  // CHECK: scf.yield {{.*}}, {{.*}}, {{.*}}
+  // second split if: K=3, block_id=11, consumes augmented slot [[R0]]#2
+  // CHECK: [[R1:%.*]]:3 = scf.if
+  // CHECK-NEXT: arith.addf [[R0]]#2, {{.*}} {ssbuffer.block_id = 11 : i32}
+  // for yields first N=2 results of the last split if:
+  // CHECK: scf.yield [[R1]]#0, [[R1]]#1
+  // original uses → return:
+  // CHECK: return
+
+  func.func @test_case_b_augment(%cond: i1) -> (tensor<16xf32>, tensor<16x64xf32>) {
+    %cst = arith.constant {ssbuffer.block_id = 13 : i32} 0.0 : f32
+    %t0 = tensor.empty() {ssbuffer.block_id = 13 : i32} : tensor<16xf32>
+    %f0 = linalg.fill {ssbuffer.block_id = 13 : i32} ins(%cst : f32) outs(%t0 : tensor<16xf32>) -> tensor<16xf32>
+    %t1 = tensor.empty() {ssbuffer.block_id = 13 : i32} : tensor<16x64xf32>
+    %f1 = linalg.fill {ssbuffer.block_id = 13 : i32} ins(%cst : f32) outs(%t1 : tensor<16x64xf32>) -> tensor<16x64xf32>
+    %cst1 = arith.constant {ssbuffer.block_id = 13 : i32} 1.0 : f32
+    %t2 = tensor.empty() {ssbuffer.block_id = 13 : i32} : tensor<16xf32>
+    %f2 = linalg.fill {ssbuffer.block_id = 13 : i32} ins(%cst1 : f32) outs(%t2 : tensor<16xf32>) -> tensor<16xf32>
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
+    %for:2 = scf.for %iv = %lb to %ub step %step iter_args(%a0 = %f0, %a1 = %f1) -> (tensor<16xf32>, tensor<16x64xf32>) {
+      %4:2 = scf.if %cond -> (tensor<16xf32>, tensor<16x64xf32>) {
+        %v1 = arith.addf %f2, %f0 {ssbuffer.block_id = 10 : i32} : tensor<16xf32>
+        %cross = arith.mulf %f1, %f1 {ssbuffer.block_id = 10 : i32} : tensor<16x64xf32>
+        %v2 = arith.addf %cross, %f1 {ssbuffer.block_id = 11 : i32} : tensor<16x64xf32>
+        scf.yield %v1, %v2 : tensor<16xf32>, tensor<16x64xf32>
+      } else {
+        scf.yield %f0, %f1 : tensor<16xf32>, tensor<16x64xf32>
+      } {ssbuffer.block_id = 16 : i32}
+      scf.yield %4#0, %4#1 : tensor<16xf32>, tensor<16x64xf32>
+    } {ssbuffer.main_loop = 0 : i64}
+    return %for#0, %for#1 : tensor<16xf32>, tensor<16x64xf32>
+  }
+
+  // ============================================================================
+  // Edge case: if not in main_loop is skipped by the pass (isInsideMainLoop)
+  // ============================================================================
+
+  // CHECK-LABEL: func.func @test_not_in_main_loop_skip
+  // only one scf.if, not split (skipped because not inside main_loop)
+  // CHECK: %{{.*}}:2 = scf.if
+  // CHECK: arith.addf {{.*}} {ssbuffer.block_id = 10 : i32}
+  // CHECK: arith.mulf {{.*}} {ssbuffer.block_id = 10 : i32}
+  // CHECK: scf.yield
+  // CHECK-NOT: scf.if
+
+  func.func @test_not_in_main_loop_skip(%cond: i1) -> (tensor<16xf32>, tensor<16xf32>) {
+    %cst = arith.constant {ssbuffer.block_id = 13 : i32} 0.0 : f32
+    %0 = tensor.empty() {ssbuffer.block_id = 13 : i32} : tensor<16xf32>
+    %1 = linalg.fill {ssbuffer.block_id = 13 : i32} ins(%cst : f32) outs(%0 : tensor<16xf32>) -> tensor<16xf32>
+    %cst2 = arith.constant {ssbuffer.block_id = 13 : i32} 1.0 : f32
+    %2 = tensor.empty() {ssbuffer.block_id = 13 : i32} : tensor<16xf32>
+    %3 = linalg.fill {ssbuffer.block_id = 13 : i32} ins(%cst2 : f32) outs(%2 : tensor<16xf32>) -> tensor<16xf32>
+    %4:2 = scf.if %cond -> (tensor<16xf32>, tensor<16xf32>) {
+      %v1 = arith.addf %3, %1 {ssbuffer.block_id = 10 : i32} : tensor<16xf32>
+      %v2 = arith.mulf %v1, %3 {ssbuffer.block_id = 10 : i32} : tensor<16xf32>
+      scf.yield %v1, %v2 : tensor<16xf32>, tensor<16xf32>
+    } else {
+      scf.yield %1, %1 : tensor<16xf32>, tensor<16xf32>
+    } {ssbuffer.block_id = 16 : i32}
+    return %4#0, %4#1 : tensor<16xf32>, tensor<16xf32>
+  }
+
+  // ============================================================================
+  // Edge case: same block_id in main_loop → needsSplit() returns false, no split
+  // ============================================================================
+
+  // CHECK-LABEL: func.func @test_same_block_id_in_main_loop_no_split
+  // inside main_loop, but all ops share block_id=10, only one if, not split
+  // CHECK: scf.for
+  // CHECK: %{{.*}}:2 = scf.if
+  // CHECK: arith.addf {{.*}} {ssbuffer.block_id = 10 : i32}
+  // CHECK: arith.mulf {{.*}} {ssbuffer.block_id = 10 : i32}
+  // CHECK: scf.yield
+  // CHECK-NOT: scf.if
+
+  func.func @test_same_block_id_in_main_loop_no_split(%cond: i1) -> (tensor<16xf32>, tensor<16xf32>) {
+    %cst = arith.constant {ssbuffer.block_id = 13 : i32} 0.0 : f32
+    %0 = tensor.empty() {ssbuffer.block_id = 13 : i32} : tensor<16xf32>
+    %1 = linalg.fill {ssbuffer.block_id = 13 : i32} ins(%cst : f32) outs(%0 : tensor<16xf32>) -> tensor<16xf32>
+    %cst2 = arith.constant {ssbuffer.block_id = 13 : i32} 1.0 : f32
+    %2 = tensor.empty() {ssbuffer.block_id = 13 : i32} : tensor<16xf32>
+    %3 = linalg.fill {ssbuffer.block_id = 13 : i32} ins(%cst2 : f32) outs(%2 : tensor<16xf32>) -> tensor<16xf32>
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
+    %for:2 = scf.for %iv = %lb to %ub step %step iter_args(%a0 = %1, %a1 = %1) -> (tensor<16xf32>, tensor<16xf32>) {
+      %4:2 = scf.if %cond -> (tensor<16xf32>, tensor<16xf32>) {
+        %v1 = arith.addf %3, %1 {ssbuffer.block_id = 10 : i32} : tensor<16xf32>
+        %v2 = arith.mulf %v1, %3 {ssbuffer.block_id = 10 : i32} : tensor<16xf32>
+        scf.yield %v1, %v2 : tensor<16xf32>, tensor<16xf32>
+      } else {
+        scf.yield %1, %1 : tensor<16xf32>, tensor<16xf32>
+      } {ssbuffer.block_id = 16 : i32}
+      scf.yield %4#0, %4#1 : tensor<16xf32>, tensor<16xf32>
+    } {ssbuffer.main_loop = 0 : i64}
+    return %for#0, %for#1 : tensor<16xf32>, tensor<16xf32>
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitIfByBlockId/test_void_if_memref.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitIfByBlockId/test_void_if_memref.mlir
@@ -1,0 +1,167 @@
+// RUN: triton-opt --split-if-by-block-id %s | FileCheck %s
+
+module {
+  // Void if with cross-group memref dependency: two block_id groups in else,
+  // one produces a memref.alloc, the other consumes it.
+  // The else branch creates a local memref.alloc placeholder (place-and-use)
+  // with block_id = -1. No memref.alloca should appear.
+
+  // CHECK-LABEL: func.func @test_void_if_memref_placeholder
+  // CHECK: scf.for
+  // block_id=8 result if:
+  // CHECK: scf.if
+  // CHECK: memref.alloc() {{.*}}ssbuffer.block_id = 8 : i32
+  // else: local memref.alloc placeholder (place-and-use), block_id = -1
+  // CHECK: else
+  // CHECK: memref.alloc() {{.*}}ssbuffer.block_id = -1 : i32
+  // block_id=9 void if:
+  // CHECK: scf.if
+  // Placeholder branch must NOT use memref.alloca
+  // CHECK-NOT: memref.alloca
+
+  func.func @test_void_if_memref_placeholder(%cond: i1) {
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
+    scf.for %iv = %lb to %ub step %step {
+      scf.if %cond {
+      } else {
+        %alloc = memref.alloc() {ssbuffer.block_id = 8 : i32} : memref<16xi32>
+        memref.dealloc %alloc {ssbuffer.block_id = 9 : i32} : memref<16xi32>
+      }
+    } {ssbuffer.main_loop = 0 : i64}
+    return
+  }
+
+  // ============================================================================
+  // Void if with dynamic-dim memref cross-group dependency.
+  // Block 5 produces a memref<?xi32, strided<[1]>> (dynamic dim),
+  // block 3 consumes it. Placeholder must substitute dynamic dims with 1
+  // when creating tensor.empty (tensor::EmptyOp requires static shapes).
+  // ============================================================================
+
+  // CHECK-LABEL: func.func @test_dynamic_memref_placeholder
+  // for inside main_loop:
+  // CHECK: scf.for
+  // reinterpret_cast is yielded through the yield chain (then branch),
+  // and cloned locally in the else branch with block_id=-1 (place-and-use).
+  // block_id=5 result if: reinterpret_cast in then, local clone in else:
+  // CHECK: scf.if
+  // CHECK: memref.reinterpret_cast {{.*}} {ssbuffer.block_id = 5 : i32}
+  // else block: local reinterpret_cast cloned with block_id=-1:
+  // CHECK: else
+  // CHECK: memref.reinterpret_cast {{.*}} {ssbuffer.block_id = -1 : i32}
+  // block_id=3 void if: reinterpret_cast from yield-chain result, block_id=3:
+  // CHECK: scf.if
+  // CHECK: memref.reinterpret_cast {{.*}} {ssbuffer.block_id = 3 : i32}
+
+  func.func @test_dynamic_memref_placeholder(%cond: i1) {
+    %alloc = memref.alloc() {ssbuffer.block_id = 13 : i32} : memref<16xi32>
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
+    scf.for %iv = %lb to %ub step %step {
+      scf.if %cond {
+      } else {
+        %r = memref.reinterpret_cast %alloc to offset: [0], sizes: [8], strides: [1]
+            {ssbuffer.block_id = 5 : i32} : memref<16xi32> to memref<?xi32, strided<[1]>>
+        %r2 = memref.reinterpret_cast %r to offset: [0], sizes: [8], strides: [1]
+            {ssbuffer.block_id = 3 : i32} : memref<?xi32, strided<[1]>> to memref<8xi32, strided<[1]>>
+      }
+    } {ssbuffer.main_loop = 0 : i64}
+    return
+  }
+
+  // ============================================================================
+  // Static memref placeholder MUST carry s sbuffer.block_id = -1
+  // so downstream passes can identify it as a placeholder (not a real alloc).
+  // ============================================================================
+
+  // CHECK-LABEL: func.func @test_placeholder_block_id_attr
+  // CHECK: scf.for
+  // block_id=8 result if:
+  // CHECK: scf.if
+  // CHECK: memref.alloc() {{.*}}ssbuffer.block_id = 8 : i32
+  // else: local memref.alloc placeholder (place-and-use), block_id = -1
+  // CHECK: else
+  // CHECK: memref.alloc() {{.*}}ssbuffer.block_id = -1 : i32
+  // block_id=9 void if:
+  // CHECK: scf.if
+
+  func.func @test_placeholder_block_id_attr(%cond: i1) {
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
+    scf.for %iv = %lb to %ub step %step {
+      scf.if %cond {
+      } else {
+        %alloc = memref.alloc() {ssbuffer.block_id = 8 : i32} : memref<16xi32>
+        memref.dealloc %alloc {ssbuffer.block_id = 9 : i32} : memref<16xi32>
+      }
+    } {ssbuffer.main_loop = 0 : i64}
+    return
+  }
+
+  // ============================================================================
+  // Void if consuming GM memref (function arg) with 5 groups and
+  // intermediate arith ops. Verifies place-and-use for arg-sourced memref
+  // placeholders: the first split-if creates local reinterpret_cast
+  // placeholders with block_id=-1, and subsequent split-ifs pass
+  // through via the yield chain.
+  // ============================================================================
+
+  // CHECK-LABEL: func.func @test_void_if_gm_arg_multi_group
+  // for inside main_loop:
+  // CHECK: scf.for
+  // negated condition (else-side split):
+  // CHECK: arith.xori
+  // block_id=5 result if: reinterpret_cast in then, local clone in else:
+  // CHECK: scf.if
+  // CHECK: memref.reinterpret_cast {{.*}} {ssbuffer.block_id = 5 : i32}
+  // else: local clone, block_id=-1 (place-and-use):
+  // CHECK: else
+  // CHECK: memref.reinterpret_cast {{.*}} {ssbuffer.block_id = -1 : i32}
+  // block_id=6 result if:
+  // CHECK: scf.if
+  // CHECK: memref.reinterpret_cast {{.*}} {ssbuffer.block_id = 6 : i32}
+  // else: yield chain, passes through previous split-if results:
+  // CHECK: else
+  // CHECK: scf.yield
+  // block_id=7 result if (memref.load):
+  // CHECK: scf.if
+  // CHECK: memref.load {{.*}} {ssbuffer.block_id = 7 : i32}
+  // else: yield chain:
+  // CHECK: else
+  // CHECK: scf.yield
+  // block_id=8 result if (arith.mulf):
+  // CHECK: scf.if
+  // CHECK: arith.mulf {{.*}} {ssbuffer.block_id = 8 : i32}
+  // else: yield chain:
+  // CHECK: else
+  // CHECK: scf.yield
+  // block_id=9 void if (arith.addf):
+  // CHECK: scf.if
+  // CHECK: arith.addf {{.*}} {ssbuffer.block_id = 9 : i32}
+  // No memref.alloca:
+  // CHECK-NOT: memref.alloca
+
+  func.func @test_void_if_gm_arg_multi_group(%cond: i1, %arg0: memref<?xf32>) {
+    %c0 = arith.constant 0 : index
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
+    scf.for %iv = %lb to %ub step %step {
+      scf.if %cond {
+      } else {
+        %r1 = memref.reinterpret_cast %arg0 to offset: [0], sizes: [8], strides: [1]
+            {ssbuffer.block_id = 5 : i32} : memref<?xf32> to memref<?xf32, strided<[1]>>
+        %r2 = memref.reinterpret_cast %r1 to offset: [0], sizes: [4], strides: [2]
+            {ssbuffer.block_id = 6 : i32} : memref<?xf32, strided<[1]>> to memref<?xf32, strided<[2]>>
+        %val = memref.load %r2[%c0] {ssbuffer.block_id = 7 : i32} : memref<?xf32, strided<[2]>>
+        %tmp = arith.mulf %val, %val {ssbuffer.block_id = 8 : i32} : f32
+        %result = arith.addf %tmp, %val {ssbuffer.block_id = 9 : i32} : f32
+      }
+    } {ssbuffer.main_loop = 0 : i64}
+    return
+  }
+}


### PR DESCRIPTION
- Add a new MLIR pass --split-if-by-block-id that splits scf.if operations inside the main loop into a chain of scf.ifs, each containing only operations     
  belonging to a single ssbuffer.block_id
  - Support nested scf.if regions via a fixed-point iteration loop (outermost-first ordering)                                                                  
  - Support else-region splitting: when only the else branch has ops to split, the condition is inverted and the else ops are materialized as if they were in  
  the then branch                                                                                                                                              
  - Handle cross-group SSA dependencies by augmenting yield chains with additional slots, propagating values across the newly created split-if chain           
  - Add 10 lit unit tests covering basic split, augmented yield, else-only split, nested if split, cross-group use through nested if, void-if memref           
  dependencies, placeholder GM provenance, and scene 3/4 multi-group cases                                                                                     
                                                                                                                                                               
  Details                                                                                                                                                      
                  
  Problem                                                                                                                                                      
   
  After block-id assignment, a single scf.if may contain operations tagged with different ssbuffer.block_id values. Downstream passes (e.g.,                   
  plan-compute-block, separate-cv-scope) assume each if region belongs to exactly one compute block, so these mixed-region ifs must be split.
                                                                                                                                                               
  Solution                                                                                                                                                     
   
  The pass operates in three parts, executed in an iterative fixed-point loop:                                                                                 
                  
  1. Discovery & Grouping — Walk the module looking for scf.if operations inside the main loop. For each candidate, group its ops by block_id, attaching       
  ambient (no block_id) ops to the nearest preceding group and nested scf.if ops to their own group.
  2. Dependency Analysis & Yield Planning — Detect SSA values whose defining op is in one group but consumed by ops in a different group. Plan yield slot      
  augmentation: original yield slots (Case B, N > 0) or all-cross-group slots (Case A, N = 0), plus additional augmented slots for cross-group values not      
  already in the original yield.
  3. Materialization — Create one split scf.if per group, fill then/else regions, route cross-group values through the yield chain using replacement maps, and 
  erase the original if. Else-split cases negate the condition so the else-region ops (originally gated on !cond) land in the then branch of the split ifs.    
   
  The outermost-first ordering ensures nested-if groups inside outer candidates still hold valid pointers at materialization time.                             
                  