### PR TITLE
[launcher](fix) fix autotune async launch oom bug

### DIFF
--- a/third_party/ascend/backend/backend_register.py
+++ b/third_party/ascend/backend/backend_register.py
@@ -298,7 +298,13 @@ def allocate_memory(size, stream):
 
 @backend_strategy_registry.register("torch_npu", "allocate_memory")
 def allocate_memory(size, stream):
-    return f"init_npu_utils(); workspace_addr_ptr = g_allocate_workspace({size}, &workspace_handle);"
+    return f'''init_npu_utils();
+    if (!g_allocate_workspace_legacy) {{
+      fprintf(stderr, "Error: triton_allocate_workspace_legacy is unavailable\\n");
+      workspace_addr_ptr = nullptr;
+    }} else {{
+      workspace_addr_ptr = g_allocate_workspace_legacy({size});
+    }}'''
 
 
 @backend_strategy_registry.register("mindspore", "allocate_sync_block_lock")
@@ -309,7 +315,13 @@ def allocate_sync_block_lock(size, stream):
 
 @backend_strategy_registry.register("torch_npu", "allocate_sync_block_lock")
 def allocate_sync_block_lock(size, stream):
-    return f"init_npu_utils(); syncBlockLock_ptr = g_allocate_sync_block_lock({size}, {stream}, &syncBlockLock_handle);"
+    return f'''init_npu_utils();
+    if (!g_allocate_sync_block_lock) {{
+      fprintf(stderr, "Error: triton_allocate_sync_block_lock is unavailable\\n");
+      syncBlockLock_ptr = nullptr;
+    }} else {{
+      syncBlockLock_ptr = g_allocate_sync_block_lock({size}, {stream}, &syncBlockLock_handle);
+    }}'''
 
 
 @backend_strategy_registry.register("mindspore", "pre_launch")
@@ -333,4 +345,9 @@ def async_launch(func):
 
 @backend_strategy_registry.register("torch_npu", "async_launch")
 def async_launch(func):
-    return f"init_npu_utils(); g_async_launch(static_cast<void*>(&{func}), name.c_str());"
+    return f'''init_npu_utils();
+   if (!g_async_launch) {{
+     fprintf(stderr, "Error: triton_async_launch is unavailable\\n");
+     return;
+   }}
+   g_async_launch(static_cast<void*>(&{func}), name.c_str());'''

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -486,17 +486,27 @@ def generate_npu_wrapper_src(constants, signature, metadata):
     npu_utils_so_path = getattr(npu_utils_mod, "__file__", "")
     cpp_npu_utils_dlopen = f"""
 typedef void* (*triton_allocate_workspace_t)(uint64_t, void**);
+typedef void* (*triton_allocate_workspace_legacy_t)(uint64_t);
 typedef void* (*triton_allocate_sync_block_lock_t)(uint64_t, void*, void**);
 typedef void  (*triton_async_launch_t)(void*, const char*);
 typedef void  (*triton_release_retained_tensor_t)(void*);
 
 static triton_allocate_workspace_t g_allocate_workspace = nullptr;
+static triton_allocate_workspace_legacy_t g_allocate_workspace_legacy = nullptr;
 static triton_allocate_sync_block_lock_t g_allocate_sync_block_lock = nullptr;
 static triton_async_launch_t g_async_launch = nullptr;
 static triton_release_retained_tensor_t g_release_retained_tensor = nullptr;
 
+static bool npu_utils_ready() {{
+    return g_allocate_workspace &&
+           g_allocate_workspace_legacy &&
+           g_allocate_sync_block_lock &&
+           g_async_launch &&
+           g_release_retained_tensor;
+}}
+
 static void init_npu_utils() {{
-    if (g_allocate_workspace) return;
+    if (npu_utils_ready()) return;
     const char* so_path = "{npu_utils_so_path}";
     void* handle = dlopen(so_path, RTLD_LAZY);
     if (!handle) {{
@@ -504,6 +514,7 @@ static void init_npu_utils() {{
         return;
     }}
     g_allocate_workspace = (triton_allocate_workspace_t)dlsym(handle, "triton_allocate_workspace");
+    g_allocate_workspace_legacy = (triton_allocate_workspace_legacy_t)dlsym(handle, "triton_allocate_workspace_legacy");
     g_allocate_sync_block_lock = (triton_allocate_sync_block_lock_t)dlsym(handle, "triton_allocate_sync_block_lock");
     g_async_launch = (triton_async_launch_t)dlsym(handle, "triton_async_launch");
     g_release_retained_tensor = (triton_release_retained_tensor_t)dlsym(handle, "triton_release_retained_tensor");
@@ -837,20 +848,17 @@ void triton_launch_kernel(
   std::string name = "";
   name.append(kernelName);
   void *workspace_addr_ptr = NULL;
-  void *workspace_handle = NULL;
   {coalesce_grid_div}
   uint32_t blockNum4Workspace = gridX * gridY * gridZ;
   {get_backend_func("pre_launch", True)}
   {f'''
   uint64_t totalWorkSpaceSize = {workspace_size} * blockNum4Workspace;
   {get_backend_func("allocate_memory", "totalWorkSpaceSize", "stream")}
-  std::shared_ptr<void> workspace_handle_guard(workspace_handle, release_npu_tensor_handle);
   if (!workspace_addr_ptr) {{
     {workspace_fail_code}
   }}
   ''' if workspace_size > 0 else ''}
   {'std::function<rtError_t()> launch_call = [=]() -> rtError_t' if enable_taskqueue else ''} {{
-    {f'(void)workspace_handle_guard;' if workspace_size > 0 else ''}
     {get_backend_func("pre_launch", False)}
     uint32_t blockNum = gridX * gridY * gridZ;
 
@@ -948,20 +956,17 @@ static void _launch(const char* kernelName, const void* func, rtStream_t stream,
   std::string name = "";
   name.append(kernelName);
   void *workspace_addr_ptr = NULL;
-  void *workspace_handle = NULL;
   {coalesce_grid_div}
   uint32_t blockNum4Workspace = gridX * gridY * gridZ;
   {get_backend_func("pre_launch", True)}
   {f'''
   uint64_t totalWorkSpaceSize = {workspace_size} * blockNum4Workspace;
   {get_backend_func("allocate_memory", "totalWorkSpaceSize", "stream")}
-  std::shared_ptr<void> workspace_handle_guard(workspace_handle, release_npu_tensor_handle);
   if (!workspace_addr_ptr) {{
     {workspace_fail_code}
   }}
   ''' if workspace_size > 0 else ''}
   {'std::function<rtError_t()> launch_call = [=]() -> rtError_t' if enable_taskqueue else ''} {{
-    {f'(void)workspace_handle_guard;' if workspace_size > 0 else ''}
     {get_backend_func("pre_launch", False)}
     uint32_t blockNum = gridX * gridY * gridZ;
 

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -485,21 +485,18 @@ def generate_npu_wrapper_src(constants, signature, metadata):
     npu_utils_mod = getattr(npu_utils_inst, "npu_utils_mod", None)
     npu_utils_so_path = getattr(npu_utils_mod, "__file__", "")
     cpp_npu_utils_dlopen = f"""
-typedef void* (*triton_allocate_workspace_t)(uint64_t, void**);
 typedef void* (*triton_allocate_workspace_legacy_t)(uint64_t);
 typedef void* (*triton_allocate_sync_block_lock_t)(uint64_t, void*, void**);
 typedef void  (*triton_async_launch_t)(void*, const char*);
 typedef void  (*triton_release_retained_tensor_t)(void*);
 
-static triton_allocate_workspace_t g_allocate_workspace = nullptr;
 static triton_allocate_workspace_legacy_t g_allocate_workspace_legacy = nullptr;
 static triton_allocate_sync_block_lock_t g_allocate_sync_block_lock = nullptr;
 static triton_async_launch_t g_async_launch = nullptr;
 static triton_release_retained_tensor_t g_release_retained_tensor = nullptr;
 
 static bool npu_utils_ready() {{
-    return g_allocate_workspace &&
-           g_allocate_workspace_legacy &&
+    return g_allocate_workspace_legacy &&
            g_allocate_sync_block_lock &&
            g_async_launch &&
            g_release_retained_tensor;
@@ -513,7 +510,6 @@ static void init_npu_utils() {{
         fprintf(stderr, "Error: dlopen %s failed: %s\\n", so_path, dlerror());
         return;
     }}
-    g_allocate_workspace = (triton_allocate_workspace_t)dlsym(handle, "triton_allocate_workspace");
     g_allocate_workspace_legacy = (triton_allocate_workspace_legacy_t)dlsym(handle, "triton_allocate_workspace_legacy");
     g_allocate_sync_block_lock = (triton_allocate_sync_block_lock_t)dlsym(handle, "triton_allocate_sync_block_lock");
     g_async_launch = (triton_async_launch_t)dlsym(handle, "triton_async_launch");

--- a/third_party/ascend/backend/npu_utils.cpp
+++ b/third_party/ascend/backend/npu_utils.cpp
@@ -330,21 +330,19 @@ static PyObject* copyMemory(PyObject* self, PyObject* args) {
 
 #ifdef USE_TORCH_NPU
 struct RetainedTensorHandle {
-  RetainedTensorHandle(at::Tensor tensor, const char *kind, uint64_t size)
-      : tensor(std::move(tensor)), kind(kind), size(size),
+  explicit RetainedTensorHandle(at::Tensor tensor)
+      : tensor(std::move(tensor)),
         data(const_cast<void*>(this->tensor.storage().data())) {}
 
   at::Tensor tensor;
-  const char *kind;
-  uint64_t size;
   void *data;
 };
 
-static void *retainTensor(at::Tensor tensor, void **handle, const char *kind, uint64_t size) {
+static void *retainTensor(at::Tensor tensor, void **handle) {
   if (handle == nullptr) {
     return nullptr;
   }
-  auto *retained = new RetainedTensorHandle(std::move(tensor), kind, size);
+  auto *retained = new RetainedTensorHandle(std::move(tensor));
   *handle = retained;
   return retained->data;
 }
@@ -357,16 +355,6 @@ extern "C" void* triton_allocate_workspace_legacy(uint64_t size)
           .data());
 }
 
-extern "C" void* triton_allocate_workspace(uint64_t size, void **handle)
-{
-  if (handle == nullptr) {
-    return nullptr;
-  }
-  *handle = nullptr;
-  auto tensor = at::empty(size, at::TensorOptions().device(at::kPrivateUse1).dtype(at::kByte));
-  return retainTensor(std::move(tensor), handle, "workspace", size);
-}
-
 extern "C" void* triton_allocate_sync_block_lock(uint64_t size, void* stream, void **handle)
 {
   if (handle == nullptr) {
@@ -374,7 +362,7 @@ extern "C" void* triton_allocate_sync_block_lock(uint64_t size, void* stream, vo
   }
   *handle = nullptr;
   auto tensor = at_npu::native::allocate_workspace(size, reinterpret_cast<rtStream_t>(stream));
-  return retainTensor(std::move(tensor), handle, "sync_block_lock", size);
+  return retainTensor(std::move(tensor), handle);
 }
 
 extern "C" void triton_release_retained_tensor(void *handle)

--- a/third_party/ascend/backend/npu_utils.cpp
+++ b/third_party/ascend/backend/npu_utils.cpp
@@ -349,6 +349,14 @@ static void *retainTensor(at::Tensor tensor, void **handle, const char *kind, ui
   return retained->data;
 }
 
+extern "C" void* triton_allocate_workspace_legacy(uint64_t size)
+{
+  return const_cast<void*>(
+      at::empty(size, at::TensorOptions().device(at::kPrivateUse1).dtype(at::kByte))
+          .storage()
+          .data());
+}
+
 extern "C" void* triton_allocate_workspace(uint64_t size, void **handle)
 {
   if (handle == nullptr) {


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

# Restore Legacy Workspace Lifetime Without ATen in Launcher

## Summary

This PR restores the legacy lifetime behavior for regular Torch NPU workspace allocation while keeping generated launcher code free of direct ATen dependencies.

Regular workspace allocation no longer uses the retained Tensor handle path. Instead, the launcher resolves a lightweight C ABI helper from `npu_utils.so` and receives a raw workspace pointer whose owning temporary Tensor is released immediately, matching the old successful launcher behavior.

## Background

The previous retained workspace implementation allocated regular workspace through:

```cpp
g_allocate_workspace(size, &workspace_handle);
std::shared_ptr<void> workspace_handle_guard(workspace_handle, release_npu_tensor_handle);
```

That path retained an `at::Tensor` through `RetainedTensorHandle`. In taskqueue mode, the launch lambda captured the guard, so workspace Tensor lifetime could be extended by the asynchronous launch queue. Repeated launches could therefore accumulate active workspace Tensor references.

The old working launcher allocated regular workspace with:

```cpp
at::empty(...).storage().data()
```

The temporary Tensor was destroyed at the end of the allocation statement, leaving only a raw pointer in the launcher. That avoided active Tensor accumulation for regular workspace, but directly putting this code back into `launcher.cpp` would require `#include <ATen/ATen.h>` and Torch include paths in launcher compilation.

## Approach

The fix keeps the old lifetime semantics but moves the ATen dependency out of generated launcher code:

- `npu_utils.cpp` exports `triton_allocate_workspace_legacy(uint64_t size)`.
- The generated launcher loads this symbol with `dlsym`.
- Regular workspace calls `g_allocate_workspace_legacy(totalWorkSpaceSize)`.
- The launcher does not generate `at::empty`, does not include `ATen/ATen.h`, and does not retain a workspace handle.

This preserves the legacy behavior while keeping ATen usage isolated inside `npu_utils.cpp`.

## Changes

### `backend_register.py`

- Changed Torch NPU regular workspace allocation to call:

```cpp
init_npu_utils();
g_allocate_workspace_legacy(totalWorkSpaceSize);
```

- Added null-symbol checks for:
  - `g_allocate_workspace_legacy`
  - `g_allocate_sync_block_lock`
  - `g_async_launch`

- Kept generated launcher headers limited to:

```cpp
#include <dlfcn.h>
#include <functional>
```

### `driver.py`

- Added `triton_allocate_workspace_legacy_t` and `g_allocate_workspace_legacy`.
- Loads `triton_allocate_workspace_legacy` from `npu_utils.so` with `dlsym`.
- Removed regular workspace retained handle generation:
  - `workspace_handle`
  - `workspace_handle_guard`
  - `(void)workspace_handle_guard`
- Removed the obsolete retained regular workspace symbol:
  - `triton_allocate_workspace_t`
  - `g_allocate_workspace`
  - `dlsym(handle, "triton_allocate_workspace")`
- Kept `syncBlockLock_handle_guard` because sync block lock still needs retained Tensor lifetime.

### `npu_utils.cpp`

- Replaced the retained regular workspace export with:

```cpp
extern "C" void* triton_allocate_workspace_legacy(uint64_t size)
```

- The legacy helper returns:

```cpp
at::empty(size, ...).storage().data()
```

- It does not accept a handle and does not call `retainTensor`.
- Simplified `RetainedTensorHandle` by removing unused `kind` and `size` fields.
- Kept retained Tensor support for `triton_allocate_sync_block_lock`.

