### PR TITLE
[ssbuffer](fix) fix detecting cloned ops in CloneOps & code warning

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CloneOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CloneOps.cpp
@@ -29,6 +29,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/IRMapping.h"
 
@@ -430,6 +431,9 @@ LogicalResult CloneOpsPass::validateClonedOpsInVector(ModuleOp module)
 
     for (Operation &bodyOp : forOp.getBody()->without_terminator()) {
       if (!bodyOp.hasAttr(CVPipeline::kClone)) {
+        continue;
+      }
+      if (isa<tensor::EmptyOp>(bodyOp)) {
         continue;
       }
       bool hasTensorDep = llvm::any_of(bodyOp.getResults(), [](Value result) {

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateForOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateForOps.cpp
@@ -165,8 +165,10 @@ static scf::ForOp createForOpAndMigrateBody(
   Block *oldBlock = oldForOp.getBody();
   Block *newBlock = newForOp.getBody();
 
-  if (failed(replaceBlockArguments(oldBlock, newBlock)))
+  if (failed(replaceBlockArguments(oldBlock, newBlock))) {
+    newForOp.erase();
     return scf::ForOp();
+  }
 
   for (Operation &op : llvm::make_early_inc_range(oldBlock->without_terminator()))
     op.moveBefore(newBlock, newBlock->end());

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/Utils.cpp
@@ -99,7 +99,14 @@ static LogicalResult dfsTopologicalSort(
   }
 
   if (opOrder && !opOrder->empty()) {
-    llvm::sort(deps, [&](Operation *a, Operation *b) { return (*opOrder)[a] < (*opOrder)[b]; });
+    llvm::sort(deps, [&](Operation *a, Operation *b) {
+      auto itA = opOrder->find(a);
+      auto itB = opOrder->find(b);
+      if (itA == opOrder->end() || itB == opOrder->end()) {
+        return false;
+      }
+      return itA->second < itB->second;
+    });
   }
 
   for (Operation *dep : deps) {

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/check-clone-tensor-empty-ops.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/check-clone-tensor-empty-ops.mlir
@@ -1,0 +1,40 @@
+// RUN: triton-opt --clone-ops --allow-unregistered-dialect %s | FileCheck %s
+
+// Unit test for CloneOps pass: `tensor.empty` is a pure metadata op that
+// allocates a tensor shape but holds no data. When it is cloned into a
+// later block within a VECTOR main_loop, the cloned `tensor.empty` must be
+// allowed (the validator skips it when checking for tensor-typed results).
+// Without this carve-out, `tensor.empty` would be flagged as a tensor-typed
+// result and the pass would signal a failure.
+
+// CHECK-LABEL: func.func @test_vector_clone_tensor_op
+// The cloned `tensor.empty` (clone of the block-11 `tensor.empty`) must be
+// present in block 12 with the `clone = 11` attribute. If the validator
+// incorrectly rejected it, the IR would either be missing this op or the
+// pass would signal a failure.
+// CHECK: tensor.empty() {ssbuffer.block_id = 12 : i32, ssbuffer.clone = 11 : i32} : tensor<256x64xf32>
+// The pre-existing block-12 tensor-typed ops (which are NOT clones) must
+// remain untouched and have no `clone` attribute.
+// CHECK: arith.addf {{%[0-9]+, %[0-9]+}} {ssbuffer.block_id = 12 : i32} : tensor<256x64xf32>
+// CHECK-NOT: arith.addf {{.*}}ssbuffer.clone
+// CHECK: linalg.fill {ssbuffer.block_id = 12 : i32}
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_vector_clone_tensor_op(%arg0: memref<?xi8>, %arg1: memref<?xi8>) attributes {global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c10_i64 = arith.constant 10 : i64
+    %c1_f32 = arith.constant 1.000000e+00 : f32
+    %t1 = tensor.empty() : tensor<256x64xf32>
+    scope.scope : () -> () {
+      %0 = tensor.empty() : tensor<256x64xf32>
+      scf.for %arg2 = %c0_i64 to %c10_i64 step %c1_i64  : i64 {
+        %1 = tensor.empty() {ssbuffer.block_id = 11 : i32} : tensor<256x64xf32>
+        %2 = arith.addf %1, %t1 {ssbuffer.block_id = 12 : i32} : tensor<256x64xf32>
+        %3 = linalg.fill {ssbuffer.block_id = 12 : i32} ins(%c1_f32 : f32) outs(%2 : tensor<256x64xf32>) -> tensor<256x64xf32>
+      } {ssbuffer.block_id = 10 : i32, ssbuffer.main_loop = 0 : i32}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return {ssbuffer.core_type = "VECTOR"}
+  }
+}


### PR DESCRIPTION
**DynamicCVPipeline: fix detecting cloned ops in CloneOps & code warning**

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
