### PR TITLE
[ssbuffer](fix) support a*b+c, maynotexec case

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/Utils.h
@@ -34,7 +34,6 @@ namespace triton {
 
 // Attribute names for DynamicCV pipeline
 inline constexpr llvm::StringLiteral kSSBufferIfAttr = "ssbuffer.if";
-inline constexpr llvm::StringLiteral kHIVMMatmulLimitedInCubeAttr = "hivm.matmul_limited_in_cube";
 
 // Collect all nested ops within an operation's regions
 LogicalResult collectAllNestedOps(Operation *op, llvm::DenseSet<Operation *> &regionOps);

--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -52,6 +52,8 @@ inline constexpr llvm::StringLiteral kCrossDeps = "ssbuffer.crossDeps";
 inline constexpr llvm::StringLiteral kMayNotExec = "ssbuffer.may_not_exec";
 inline constexpr llvm::StringLiteral kClone = "ssbuffer.clone";
 static constexpr llvm::StringLiteral kInlinableQuantScaleAttr = "enable_fast_tf32_mul";
+inline constexpr llvm::StringLiteral kHIVMMatmulLimitedInCubeAttr = "hivm.matmul_limited_in_cube";
+
 inline constexpr const char *ERRCODE_ATTR = "triton_ascend.dynamic_cv_pipeline.rc";
 static constexpr const int ERRCODE_FAILED = 1;
 static constexpr const int ERRCODE_IGNORED = 2;

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CreateIfOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CreateIfOps.cpp
@@ -20,16 +20,20 @@
  * THE SOFTWARE.
  */
 
+#include "llvm/Support/Debug.h"
+
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/IRMapping.h"
+
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/CreateIfOps.h"
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/Utils.h"
-#include "llvm/Support/Debug.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/IR/IRMapping.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "bishengir/Dialect/Scope/IR/Scope.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "bishengir/Dialect/Scope/IR/Scope.h"
 
 static constexpr const char *DEBUG_TYPE = "CreateIfOps";
 #define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
@@ -227,7 +231,7 @@ static scf::IfOp createIfOpForBlock(OpBuilder &builder, Location loc, int blockI
   ifOp->setAttr(kSSBufferIfAttr, builder.getI32IntegerAttr(blockId));
 
   // notify npuir that of the scenario
-  ifOp->setAttr(kHIVMMatmulLimitedInCubeAttr, builder.getUnitAttr());
+  ifOp->setAttr(CVPipeline::kHIVMMatmulLimitedInCubeAttr, builder.getUnitAttr());
 
   return ifOp;
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
@@ -243,7 +243,7 @@ DenseMap<int, DenseMap<Value, SmallVector<Value>>> UpdateConditionInfoPass::exte
         }
         int tcbGroupId = findTcbGroupId(buffer, tightlyCoupledBufferGroups);
         if (tcbGroupId == -1) {
-          LDBG("Can not find tightly_coupled_buffer id" << "\n");
+          LDBG("Can not find tightly_coupled_buffer id of: " << buffer << "\n");
           return errorMap;
         }
         if (addEquivalentValues(buffer, tightlyCoupledBufferGroups[tcbGroupId], producers) == -1) {
@@ -819,28 +819,28 @@ int UpdateConditionInfoPass::buildTensorIterArgIfOpVarMap(scf::ForOp forOp)
     LDBG("Skip buildTensorIterArgIfOpVarMap: no tensor iter_args info for this forOp\n");
     return UPDATE_CONDITION_INFO_SUCCESS;
   }
-  
+
   auto &depsVec = info->tensorIterArgDepsMap[forOp];
   auto &indicesMap = info->tensorIterArgIndicesMap[forOp];
 
   llvm::DenseMap<scf::IfOp, llvm::DenseSet<Value>> producerVars;
   llvm::DenseMap<scf::IfOp, llvm::DenseSet<Value>> consumerVars;
-  
+
   for (auto &depEntry : depsVec) {
     Value origIterArg = depEntry.iterArg;
     TensorIterArgIfOpRelation &relation = depEntry;
-    
+
     if (!indicesMap.count(origIterArg)) {
       LDBG("[Error]: origIterArg not found in indicesMap\n");
       return UPDATE_CONDITION_INFO_FAILED;
     }
     SmallVector<int> &argIndices = indicesMap[origIterArg];
-    
+
     if (relation.consumers.size() != argIndices.size()) {
       LDBG("[Error]: consumers size mismatch: " << relation.consumers.size() << " vs " << argIndices.size() << "\n");
       return UPDATE_CONDITION_INFO_FAILED;
     }
-    
+
     // Establish a mapping (one-to-one) from consumers to variables
     llvm::DenseMap<scf::IfOp, Value> consumerToVar;
     for (size_t i = 0; i < relation.consumers.size(); ++i) {
@@ -848,20 +848,20 @@ int UpdateConditionInfoPass::buildTensorIterArgIfOpVarMap(scf::ForOp forOp)
       Value var = forOp.getRegionIterArg(argIndices[i]);
       consumerToVar[consumer] = var;
     }
-    
+
     // Add all the variables of the consumers that depend on each producer
     for (scf::IfOp producer : relation.producers) {
       for (auto &[consumer, var] : consumerToVar) {
         producerVars[producer].insert(var);
       }
     }
-    
+
     // Add all the variables of the consumers that depend on each producer
     for (auto &[consumer, var] : consumerToVar) {
       consumerVars[consumer].insert(var);
     }
   }
-  
+
   // Convert the temporary data structure to tensorIfOpVarMap
   for (auto &[producer, vars] : producerVars) {
     auto &ifOpVars = info->tensorIterArgIfOpVars[producer];
@@ -869,7 +869,7 @@ int UpdateConditionInfoPass::buildTensorIterArgIfOpVarMap(scf::ForOp forOp)
       ifOpVars.producerVars.push_back(var);
     }
   }
-  
+
   for (auto &[consumer, vars] : consumerVars) {
     auto &ifOpVars = info->tensorIterArgIfOpVars[consumer];
     for (Value var : vars) {

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
@@ -27,11 +27,13 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/iterator.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Block.h"
@@ -157,6 +159,28 @@ BlockOpGraph::BlockOpGraph(ArrayRef<Operation *> allOps, Block *block, const Mem
     }
 }
 
+// ============================================================================
+// Method: collectBlockIds
+// ============================================================================
+/**
+ * @brief Collects block IDs across operations, traversing nested operations when necessary.
+ *
+ * **Purpose**:
+ * Resolves or assigns unique block IDs for a list of operations, ensuring that sub-operations
+ * within nested regions are accounted for when checking scheduling groups.
+ *
+ * **Inputs & Assumptions**:
+ * - `allOps` (ArrayRef<Operation *>): List of outer operations.
+ * - `bm` (ComputeBlockIdManager &): The block ID manager.
+ *
+ * **Outputs & Guarantees**:
+ * - Returns a `DenseMap<Operation *, int>` associating each operation with its block ID.
+ * - Returns `llvm::failure()` if validation of any operation block ID fails.
+ *
+ * **Safety Boundaries & Constraints**:
+ * - If an operation does not have a block ID assigned directly, performs a recursive walk on its
+ *   nested regions to find a unified block ID. If nested block IDs conflict, assigns a new unique ID.
+ */
 static llvm::FailureOr<DenseMap<Operation *, int>> collectBlockIds(ArrayRef<Operation *> allOps, ComputeBlockIdManager &bm)
 {
     DenseMap<Operation *, int> opBlockId;
@@ -164,10 +188,31 @@ static llvm::FailureOr<DenseMap<Operation *, int>> collectBlockIds(ArrayRef<Oper
         if (llvm::failed(verifyOpBlockId(op))) {
             return llvm::failure();
         }
-        auto blockIdAttrRes = getOpBlockId(op);
-        int64_t blockId =
-            blockIdAttrRes.has_value() ? blockIdAttrRes.value() : bm.getNextId();
-        opBlockId[op] = blockId;
+        auto blockIdOpt = getOpBlockId(op);
+        if (blockIdOpt.has_value()) {
+            opBlockId[op] = blockIdOpt.value();
+            continue;
+        }
+
+        auto result = op->walk([&](Operation *nestedOp) {
+            if (nestedOp != op && !llvm::isa<scf::YieldOp, linalg::FillOp>(nestedOp)) {
+                return WalkResult::interrupt();
+            }
+            auto currBlockIdOpt = getOpBlockId(nestedOp);
+            if (!blockIdOpt.has_value()) {
+                blockIdOpt = getOpBlockId(nestedOp);
+            }
+            if (currBlockIdOpt.has_value() && currBlockIdOpt != blockIdOpt) {
+                return WalkResult::interrupt();
+            }
+            return WalkResult::advance();
+        });
+        if (result.wasInterrupted() || !blockIdOpt.has_value()) {
+            blockIdOpt = bm.getNextId();
+        } else {
+            bm.updateBlockId(op, blockIdOpt.value());
+        }
+        opBlockId[op] = blockIdOpt.value();
     }
     return opBlockId;
 }
@@ -390,14 +435,15 @@ static llvm::LogicalResult reorderOpsInBlock(Block &block, const MemoryDependenc
 
 void ReorderOpsByBlockIdPass::runOnOperation()
 {
-    LOG_DEBUG("\n=== Pass: TuningOpSeq ===\n");
-    OpBuilder const builder(&getContext());
-
     auto moduleOp = getOperation();
+    LOG_DEBUG("Input mlir:\n" << moduleOp << "\n");
+    llvm::dbgs().flush();
+
+    OpBuilder const builder(&getContext());
     auto &aa = getAnalysis<AliasAnalysis>();
     auto memGraph = MemoryDependenceGraph(moduleOp, aa);
     auto bm = ComputeBlockIdManager(moduleOp);
-    moduleOp.walk([&](Block *block) {
+    auto result = moduleOp.walk([&](Block *block) {
         auto *parentOp = block->getParentOp();
         if (!parentOp ||
             // whitelist ops to reorder
@@ -405,12 +451,16 @@ void ReorderOpsByBlockIdPass::runOnOperation()
             return WalkResult::skip();
         }
         if (llvm::failed(reorderOpsInBlock(*block, memGraph, bm))) {
-            signalPassFailure();
+            return WalkResult::interrupt();
         }
         return WalkResult::advance();
     });
 
-    LOG_DEBUG("=== Pass TuningOpSeq complete ===\n");
+    if (result.wasInterrupted()) {
+        signalPassFailure();
+        return;
+    }
+    LOG_DEBUG("Output mlir:\n" << moduleOp << "\n");
 }
 
 std::unique_ptr<OperationPass<ModuleOp>> mlir::triton::createReorderOpsByBlockIdPass()

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
@@ -20,24 +20,27 @@
  * THE SOFTWARE.
  */
 
-#include "ascend/include/DynamicCVPipeline/SplitDataflow/SeparateCVScope.h"
+#include <optional>
 
-#include "bishengir/Dialect/HIVM/IR/HIVM.h"
-#include "bishengir/Dialect/Scope/IR/Scope.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/IRMapping.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Pass/Pass.h"
 
-#include <optional>
-#include "llvm/ADT/SmallPtrSet.h"
-#include "llvm/ADT/SmallVector.h"
-#include "llvm/Support/Debug.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/SplitDataflow/SeparateCVScope.h"
+
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "bishengir/Dialect/Scope/IR/Scope.h"
 
 using namespace mlir;
 
@@ -963,7 +966,7 @@ void mlir::triton::SeparateCVScopePass::runOnOperation()
     }
 
     module.walk([](scope::ScopeOp scopeOp) {
-        scopeOp->setAttr("hivm.matmul_limited_in_cube", UnitAttr::get(scopeOp->getContext()));
+        scopeOp->setAttr(CVPipeline::kHIVMMatmulLimitedInCubeAttr, UnitAttr::get(scopeOp->getContext()));
     });
 
     debugDumpOperation("after SeparateCVScopePass", module.getOperation());

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
@@ -20,20 +20,25 @@
  * THE SOFTWARE.
  */
 
+#include <cstddef>
+#include <optional>
+
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/LogicalResult.h"
-#include <cstddef>
-#include <optional>
+#include "llvm/Support/raw_ostream.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dominance.h"
@@ -43,9 +48,7 @@
 #include "mlir/IR/Value.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Support/LLVM.h"
-#include "llvm/ADT/SmallVector.h"
 
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.h"
@@ -105,6 +108,22 @@ static bool isFloatOrInt(RankedTensorType tensorType)
 {
     auto elmType = tensorType.getElementType();
     return isa<FloatType, IntegerType>(elmType);
+}
+
+static bool scfMayNotExec(Operation *op)
+{
+    return llvm::TypeSwitch<Operation *, bool>(op)
+        .Case([&](scf::ForOp forOp) {
+            IntegerAttr ubAttr;
+            IntegerAttr lbAttr;
+            if (matchPattern(forOp.getUpperBound(), m_Constant(&ubAttr)) &&
+                matchPattern(forOp.getLowerBound(), m_Constant(&lbAttr))) {
+                return ubAttr.getValue().sle(lbAttr.getValue());
+            }
+            return true;
+        })
+        .Case([&](scf::IfOp ifOp) { return !matchPattern(ifOp.getCondition(), m_One()); })
+        .Default([&](auto) { return false; });
 }
 
 /**
@@ -194,23 +213,8 @@ static Value searchInArgsChain(Value nextValueOfC, bool &argsLimitedInMatmul, bo
     if (!argsLimitedInMatmul) {
         return nextValueOfC;
     }
-    // update mayNotExec
-    if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
-        IntegerAttr ubAttr, lbAttr;
-        if (matchPattern(forOp.getUpperBound(), m_Constant(&ubAttr)) &&
-            matchPattern(forOp.getLowerBound(), m_Constant(&lbAttr)))
-        {
-            if (ubAttr.getValue().sle(lbAttr.getValue())) {
-                mayNotExec = true;
-            }
-        } else {
-            mayNotExec = true;
-        }
-    } else if (auto ifOp = dyn_cast<scf::IfOp>(parentOp)) {
-        if (!matchPattern(ifOp.getCondition(), m_One())) {
-            mayNotExec = true;
-        }
-    }
+
+    mayNotExec = mayNotExec || scfMayNotExec(parentOp);
     return searchInArgsChain(nextSearchValue, argsLimitedInMatmul, mayNotExec, outerInValue);
 }
 
@@ -495,6 +499,26 @@ static bool verifyMatmul(linalg::MatmulOp matmulOp)
     return true;
 }
 
+// Supports the most common case, where a loop-carried matmul is
+// directly under a not executed for-loop
+static std::optional<SplitInfo> handleMayNotExec(linalg::MatmulOp matmulOp)
+{
+    auto *parentOp = matmulOp->getBlock()->getParentOp();
+    auto forOp = llvm::dyn_cast<scf::ForOp>(parentOp);
+    auto inputs = parseMatmulInputs(matmulOp);
+    auto bias = inputs.bias;
+    if (!forOp || !scfMayNotExec(forOp)) {
+        return std::nullopt;
+    }
+    auto blockArg = llvm::dyn_cast<BlockArgument>(bias);
+    if (!blockArg || blockArg.getOwner()->getParentOp() != forOp) {
+        return std::nullopt;
+    }
+    auto initVal = forOp.getTiedLoopInit(blockArg)->get();
+    auto result = forOp.getTiedLoopResult(blockArg);
+    return SplitInfo {true, initVal, result, true};
+}
+
 /**
  * Determines whether a matmul operation should be split based on comprehensive analysis.
  * This function performs a complete analysis of the matmul operation's context, including:
@@ -534,6 +558,13 @@ static std::optional<SplitInfo> shouldSplit(linalg::MatmulOp matmulOp, bool need
         return SplitInfo {mayNotExec, outerInValue, outerOutValue, true};
     }
 
+    if (mayNotExec) {
+        auto splitInfoOpt = handleMayNotExec(matmulOp);
+        if (splitInfoOpt.has_value()) {
+            return splitInfoOpt;
+        }
+    }
+
     if (!shouldSplitByInput(matmulOp, outerOutValue, outerInValue) &&
         !shouldSplitByOutput(matmulOp, outerOutValue, outerInValue))
     {
@@ -543,13 +574,13 @@ static std::optional<SplitInfo> shouldSplit(linalg::MatmulOp matmulOp, bool need
     return SplitInfo {mayNotExec, outerInValue, outerOutValue, true};
 }
 
-static void splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rewriter, SplitInfo splitInfo)
+static LogicalResult splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rewriter, SplitInfo splitInfo)
 {
     auto outputType = dyn_cast<RankedTensorType>(parseMatmulInputs(matmulOp).bias.getType());
     if (!outputType) {
         LOG_DEBUG("Not tensor mode: " << matmulOp
                                       << "; the caller does not ensure the assumption. Cowardly doing nothing");
-        return;
+        return failure();
     }
     auto elmType = outputType.getElementType();
 
@@ -566,38 +597,88 @@ static void splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rewriter, Sp
         }
     }
     auto emptyOp = rewriter.create<tensor::EmptyOp>(loc, outputType, dynamicSizes);
-    splitInfo.outerInValue.replaceUsesWithIf(emptyOp->getResult(0),
-                                             [&](OpOperand &opop) { return opop.getOwner() == outerDefOp; });
-
-    // [Step 2] Create new matmul using zero-filled tensor as accumulator
-    // New matmul runs entirely on CUBE with no VECTOR dependency
-    auto inputs = parseMatmulInputs(matmulOp);
-    auto a = inputs.a;
-    auto b = inputs.b;
-    auto bias = inputs.bias;
-    rewriter.setInsertionPoint(matmulOp);
-    auto newMatmul = rewriter.create<linalg::MatmulOp>(loc, ValueRange {a, b}, ValueRange {bias});
-    NamedAttrList attrs(matmulOp->getAttrDictionary());
-    constexpr StringLiteral kShouldRemoveAttrs[] = {"operandSegmentSizes", "res_attrs", "arg_attrs"};
-    for (auto attr : kShouldRemoveAttrs) {
-        attrs.erase(attr);
+    Value zeroValue;
+    if (auto floatType = dyn_cast<FloatType>(elmType)) {
+        APFloat zeroAPFloat = APFloat::getZero(floatType.getFloatSemantics());
+        zeroValue = rewriter.create<arith::ConstantFloatOp>(loc, zeroAPFloat, floatType).getResult();
+    } else if (auto intType = dyn_cast<IntegerType>(elmType)) {
+        zeroValue = rewriter.create<arith::ConstantIntOp>(loc, 0, intType).getResult();
     }
-    newMatmul->setAttrs(attrs);
+    auto fillOp = rewriter.create<linalg::FillOp>(emptyOp.getLoc(), zeroValue, emptyOp.getResult());
+    auto zeroVal = fillOp.getResult(0);
+    splitInfo.outerInValue.replaceUsesWithIf(zeroVal, [&](OpOperand &opop) { return opop.getOwner() == outerDefOp; });
+
+    auto forOp = llvm::dyn_cast_if_present<scf::ForOp>(splitInfo.outerOutValue.getDefiningOp());
+    if (!splitInfo.mayNotExec || !forOp) {
+        // [Step 2] Create new matmul using zero-filled tensor as accumulator
+        // New matmul runs entirely on CUBE with no VECTOR dependency
+        auto inputs = parseMatmulInputs(matmulOp);
+        auto a = inputs.a;
+        auto b = inputs.b;
+        auto bias = inputs.bias;
+        rewriter.setInsertionPoint(matmulOp);
+        auto newMatmul = rewriter.create<linalg::MatmulOp>(loc, ValueRange {a, b}, ValueRange {bias});
+        NamedAttrList attrs(matmulOp->getAttrDictionary());
+        constexpr StringLiteral kShouldRemoveAttrs[] = {"operandSegmentSizes", "res_attrs", "arg_attrs"};
+        for (auto attr : kShouldRemoveAttrs) {
+            attrs.erase(attr);
+        }
+        newMatmul->setAttrs(attrs);
+        if (splitInfo.outerOutValue == matmulOp.getResult(0)) {
+            splitInfo.outerOutValue = newMatmul.getResult(0);
+        }
+        rewriter.replaceOp(matmulOp, newMatmul);
+    }
+
+    auto newOutValue = splitInfo.outerOutValue;
 
     // [Step 3] Create add: add(new_matmul_result, outs_value)
     // This is the "c" in a*b+c, added after the matmul result
     rewriter.setInsertionPointAfterValue(splitInfo.outerOutValue);
+
+    Operation *preservedUser = nullptr;
+    if (splitInfo.mayNotExec && forOp) {
+        auto lb = forOp.getLowerBound();
+        auto ub = forOp.getUpperBound();
+
+        Value executed = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sgt, ub, lb);
+        auto ifOp = rewriter.create<scf::IfOp>(
+            loc,
+            executed,
+            [&](OpBuilder &thenBuilder, Location thenLoc) {
+                thenBuilder.create<scf::YieldOp>(thenLoc, splitInfo.outerOutValue);
+            },
+            [&](OpBuilder &elseBuilder, Location elseLoc) {
+                Value zeroValue;
+                if (auto floatType = dyn_cast<FloatType>(elmType)) {
+                    APFloat zeroAPFloat = APFloat::getZero(floatType.getFloatSemantics());
+                    zeroValue = elseBuilder.create<arith::ConstantFloatOp>(elseLoc, zeroAPFloat, floatType).getResult();
+                } else if (auto intType = dyn_cast<IntegerType>(elmType)) {
+                    zeroValue = elseBuilder.create<arith::ConstantIntOp>(elseLoc, 0, intType).getResult();
+                }
+                auto fillOp = elseBuilder.create<linalg::FillOp>(emptyOp.getLoc(), zeroValue, splitInfo.outerOutValue);
+                elseBuilder.create<scf::YieldOp>(elseLoc, fillOp.getResult(0));
+            });
+        newOutValue = ifOp.getResult(0);
+        preservedUser = ifOp;
+        forOp->setAttr(CVPipeline::kHIVMMatmulLimitedInCubeAttr, rewriter.getUnitAttr());
+    }
+
     Operation *addOp;
     if (isa<FloatType>(elmType)) {
-        addOp = rewriter.create<arith::AddFOp>(loc, splitInfo.outerOutValue, splitInfo.outerInValue).getOperation();
+        addOp = rewriter.create<arith::AddFOp>(loc, newOutValue, splitInfo.outerInValue).getOperation();
     } else {
-        addOp = rewriter.create<arith::AddIOp>(loc, splitInfo.outerOutValue, splitInfo.outerInValue).getOperation();
+        addOp = rewriter.create<arith::AddIOp>(loc, newOutValue, splitInfo.outerInValue).getOperation();
+    }
+    if (preservedUser == nullptr) {
+        preservedUser = addOp;
     }
     addOp->setAttr(CVPipeline::kAddFromMatmul, rewriter.getUnitAttr());
-    splitInfo.outerOutValue.replaceUsesWithIf(addOp->getResult(0),
-                                              [&](OpOperand &opop) { return opop.getOwner() != addOp; });
+    splitInfo.outerOutValue.replaceUsesWithIf(addOp->getResult(0), [preservedUser](OpOperand &operand) {
+        return !preservedUser->isAncestor(operand.getOwner());
+    });
 
-    rewriter.replaceOp(matmulOp, newMatmul);
+    return success();
 }
 
 LogicalResult SplitMatmulPattern::matchAndRewrite(linalg::MatmulOp matmulOp, PatternRewriter &rewriter) const
@@ -616,13 +697,13 @@ LogicalResult SplitMatmulPattern::matchAndRewrite(linalg::MatmulOp matmulOp, Pat
     LOG_DEBUG("shouldSplit = " << splitInfo.shouldSplit);
     LOG_DEBUG("-------------------");
     matmulOp->setAttr(CVPipeline::kLoopCarriedL0C, rewriter.getUnitAttr());
-    
+
+    if (splitInfo.shouldSplit) {
+        return splitMatmul(matmulOp, rewriter, splitInfo);
+    }
+
     if (splitInfo.mayNotExec) {
         matmulOp->setAttr(CVPipeline::kMayNotExec, rewriter.getUnitAttr());
-    }
-    
-    if (splitInfo.shouldSplit) {
-        splitMatmul(matmulOp, rewriter, splitInfo);
     }
 
     return success();

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/StandardizeOp/split_matmul.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/StandardizeOp/split_matmul.mlir
@@ -5,8 +5,10 @@ module {
   // According to Rule 2, its value is unknown, so we split it.
   // CHECK-LABEL: func.func @case1_block_arg_bias
   // CHECK-SAME: (%[[A:.*]]: tensor<32x64xf32>, %[[B:.*]]: tensor<64x32xf32>, %[[BIAS:.*]]: tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[CST:.*]] = arith.constant 0.000000e+00 : f32
   // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%[[A]], %[[B]] : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ZERO:.*]] = linalg.fill ins(%[[CST]] : f32) outs(%[[EMPTY]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%[[A]], %[[B]] : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD:.*]] = arith.addf %[[MM]], %[[BIAS]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // CHECK: return %[[ADD]] : tensor<32x32xf32>
   func.func @case1_block_arg_bias(%A: tensor<32x64xf32>, %B: tensor<64x32xf32>, %bias: tensor<32x32xf32>) -> tensor<32x32xf32> {
@@ -39,7 +41,8 @@ module {
   // CHECK: %[[EMPTY1:.*]] = tensor.empty() : tensor<32x32xf32>
   // CHECK: %[[ZERO1:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[EMPTY2:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[MM1:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ZERO_MM1:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM1:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO_MM1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD:.*]] = arith.addf %[[MM1]], %[[ZERO1]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // CHECK: %[[EMPTY3:.*]] = tensor.empty() : tensor<32x16xf32>
   // CHECK: %[[ZERO2:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY3]] : tensor<32x16xf32>) -> tensor<32x16xf32>
@@ -61,11 +64,13 @@ module {
   // Case 4: Bias is non-zero (filled with a non-zero constant 1.0).
   // It should be split into a zero-initialized matmul followed by an arith.addf.
   // CHECK-LABEL: func.func @case4_nonzero_bias
+  // CHECK: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
   // CHECK: %[[C1:.*]] = arith.constant 1.000000e+00 : f32
   // CHECK: %[[EMPTY1:.*]] = tensor.empty() : tensor<32x32xf32>
   // CHECK: %[[BIAS:.*]] = linalg.fill ins(%[[C1]] : f32) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[EMPTY2:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ZERO:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD:.*]] = arith.addf %[[MM]], %[[BIAS]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // CHECK: return %[[ADD]]
   func.func @case4_nonzero_bias(%A: tensor<32x64xf32>, %B: tensor<64x32xf32>) -> tensor<32x32xf32> {
@@ -80,8 +85,10 @@ module {
   // Splitting should generate integer zero constant and use arith.addi for accumulation.
   // CHECK-LABEL: func.func @case5_integer_bias
   // CHECK-SAME: (%[[A:.*]]: tensor<32x64xi32>, %[[B:.*]]: tensor<64x32xi32>, %[[BIAS:.*]]: tensor<32x32xi32>) -> tensor<32x32xi32>
+  // CHECK: %[[C0_I32:.*]] = arith.constant 0 : i32
   // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xi32>
-  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%[[A]], %[[B]] : tensor<32x64xi32>, tensor<64x32xi32>) outs(%[[EMPTY]] : tensor<32x32xi32>) -> tensor<32x32xi32>
+  // CHECK: %[[ZERO:.*]] = linalg.fill ins(%[[C0_I32]] : i32) outs(%[[EMPTY]] : tensor<32x32xi32>) -> tensor<32x32xi32>
+  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%[[A]], %[[B]] : tensor<32x64xi32>, tensor<64x32xi32>) outs(%[[ZERO]] : tensor<32x32xi32>) -> tensor<32x32xi32>
   // CHECK: %[[ADD:.*]] = arith.addi %[[MM]], %[[BIAS]] {ssbuffer.add_from_matmul} : tensor<32x32xi32>
   func.func @case5_integer_bias(%A: tensor<32x64xi32>, %B: tensor<64x32xi32>, %bias: tensor<32x32xi32>) -> tensor<32x32xi32> {
     %mm = linalg.matmul ins(%A, %B : tensor<32x64xi32>, tensor<64x32xi32>) outs(%bias : tensor<32x32xi32>) -> tensor<32x32xi32>
@@ -92,29 +99,33 @@ module {
   // The split logic should fetch dynamic dimension sizes using tensor.dim.
   // CHECK-LABEL: func.func @case6_dynamic_shape
   // CHECK-SAME: (%[[A:.*]]: tensor<?x?xf32>, %[[B:.*]]: tensor<?x?xf32>, %[[BIAS:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32>
+  // CHECK: %[[CST:.*]] = arith.constant 0.000000e+00 : f32
   // CHECK: %[[C1_IDX:.*]] = arith.constant 1 : index
   // CHECK: %[[C0_IDX:.*]] = arith.constant 0 : index
   // CHECK: %[[DIM0:.*]] = tensor.dim %[[BIAS]], %[[C0_IDX]] : tensor<?x?xf32>
   // CHECK: %[[DIM1:.*]] = tensor.dim %[[BIAS]], %[[C1_IDX]] : tensor<?x?xf32>
   // CHECK: %[[EMPTY:.*]] = tensor.empty(%[[DIM0]], %[[DIM1]]) : tensor<?x?xf32>
-  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%[[A]], %[[B]] : tensor<?x?xf32>, tensor<?x?xf32>) outs(%[[EMPTY]] : tensor<?x?xf32>) -> tensor<?x?xf32>
+  // CHECK: %[[ZERO:.*]] = linalg.fill ins(%[[CST]] : f32) outs(%[[EMPTY]] : tensor<?x?xf32>) -> tensor<?x?xf32>
+  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%[[A]], %[[B]] : tensor<?x?xf32>, tensor<?x?xf32>) outs(%[[ZERO]] : tensor<?x?xf32>) -> tensor<?x?xf32>
   // CHECK: %[[ADD:.*]] = arith.addf %[[MM]], %[[BIAS]] {ssbuffer.add_from_matmul} : tensor<?x?xf32>
   func.func @case6_dynamic_shape(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>, %bias: tensor<?x?xf32>) -> tensor<?x?xf32> {
     %mm = linalg.matmul ins(%A, %B : tensor<?x?xf32>, tensor<?x?xf32>) outs(%bias : tensor<?x?xf32>) -> tensor<?x?xf32>
     return %mm : tensor<?x?xf32>
   }
-  
+
   // Case 7: Matmul inside scf.if with both then and else branches.
   // Both branches have matmul with bias from function argument, so both are split.
   // CHECK-LABEL: func.func @case7_if_else
   // CHECK: scf.if %{{.*}} -> (tensor<32x32xf32>) {
   // CHECK: %[[EMPTY1:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[MM1:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ZERO1:.*]] = linalg.fill ins(%{{.*}} : f32) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM1:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD1:.*]] = arith.addf %[[MM1]], %{{.*}} {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // CHECK: scf.yield %[[ADD1]] : tensor<32x32xf32>
   // CHECK: } else {
   // CHECK: %[[EMPTY2:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[MM2:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ZERO2:.*]] = linalg.fill ins(%{{.*}} : f32) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM2:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD2:.*]] = arith.addf %[[MM2]], %{{.*}} {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // CHECK: scf.yield %[[ADD2]] : tensor<32x32xf32>
   // CHECK: }
@@ -129,7 +140,7 @@ module {
     return %result : tensor<32x32xf32>
   }
 
-// Case 8: Nested scf.for loops with matmul.
+  // Case 8: Nested scf.for loops with matmul.
   // The matmul is in an inner loop with bias as a loop-carried variable with zero initial value.
   // The inner matmul is marked as loop_carried_l0c and not split (no addf).
   // CHECK-LABEL: func.func @case8_nested_for
@@ -147,7 +158,7 @@ module {
     %cst = arith.constant 0.0 : f32
     %empty = tensor.empty() : tensor<32x32xf32>
     %zero_init = linalg.fill ins(%cst : f32) outs(%empty : tensor<32x32xf32>) -> tensor<32x32xf32>
-    
+
     %outer_result = scf.for %outer_iv = %c0 to %c10 step %c1 iter_args(%outer_acc = %zero_init) -> (tensor<32x32xf32>) {
       %inner_result = scf.for %inner_iv = %c0 to %c10 step %c1 iter_args(%bias = %outer_acc) -> (tensor<32x32xf32>) {
         %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias : tensor<32x32xf32>) -> tensor<32x32xf32>
@@ -166,7 +177,8 @@ module {
   // CHECK: %[[EMPTY1:.*]] = tensor.empty() : tensor<32x32xf32>
   // CHECK: %[[NONZERO_INIT:.*]] = linalg.fill ins(%[[CST]] : f32) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[EMPTY2:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[FOR_RESULT:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[EMPTY2]]) -> (tensor<32x32xf32>) {
+  // CHECK: %[[ZERO_FILL:.*]] = linalg.fill ins(%{{.*}} : f32) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[FOR_RESULT:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[ZERO_FILL]]) -> (tensor<32x32xf32>) {
   // CHECK: %[[INNER_RESULT:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %{{.*}}) -> (tensor<32x32xf32>) {
   // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK-NOT: arith.addf
@@ -183,7 +195,7 @@ module {
     %cst = arith.constant 1.0 : f32
     %empty = tensor.empty() : tensor<32x32xf32>
     %nonzero_init = linalg.fill ins(%cst : f32) outs(%empty : tensor<32x32xf32>) -> tensor<32x32xf32>
-    
+
     %outer_result = scf.for %outer_iv = %c0 to %c10 step %c1 iter_args(%outer_acc = %nonzero_init) -> (tensor<32x32xf32>) {
       %inner_result = scf.for %inner_iv = %c0 to %c10 step %c1 iter_args(%bias = %outer_acc) -> (tensor<32x32xf32>) {
         %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias : tensor<32x32xf32>) -> tensor<32x32xf32>
@@ -213,13 +225,16 @@ module {
   // CHECK: %[[EMPTY_D:.*]] = tensor.empty() : tensor<32x32xf32>
   // CHECK: %[[D:.*]] = linalg.fill ins(%[[CST_NONZERO]] : f32) outs(%[[EMPTY_D]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[EMPTY4:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[MM4:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY4]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ZERO4:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY4]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM4:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO4]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD4:.*]] = arith.addf %[[MM4]], %[[D]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // CHECK: %[[EMPTY5:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[MM5:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY5]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ZERO5:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY5]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM5:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO5]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD5:.*]] = arith.addf %[[MM5]], %[[ADD4]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // CHECK: %[[EMPTY6:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[MM6:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY6]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ZERO6:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY6]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM6:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO6]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD6:.*]] = arith.addf %[[MM6]], %[[ADD5]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // Final combination
   // CHECK: %[[RESULT:.*]] = arith.addf %[[MM3]], %[[ADD6]] : tensor<32x32xf32>
@@ -228,20 +243,20 @@ module {
     %cst_zero = arith.constant 0.0 : f32
     %cst_nonzero = arith.constant 1.0 : f32
     %empty = tensor.empty() : tensor<32x32xf32>
-    
+
     // Chain 1: zero initialization
     %c = linalg.fill ins(%cst_zero : f32) outs(%empty : tensor<32x32xf32>) -> tensor<32x32xf32>
     %1 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%c : tensor<32x32xf32>) -> tensor<32x32xf32>
     %2 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%1 : tensor<32x32xf32>) -> tensor<32x32xf32>
     %3 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%2 : tensor<32x32xf32>) -> tensor<32x32xf32>
-    
-    // Chain 2: non-zero initialization  
+
+    // Chain 2: non-zero initialization
     %empty2 = tensor.empty() : tensor<32x32xf32>
     %d = linalg.fill ins(%cst_nonzero : f32) outs(%empty2 : tensor<32x32xf32>) -> tensor<32x32xf32>
     %4 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%d : tensor<32x32xf32>) -> tensor<32x32xf32>
     %5 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%4 : tensor<32x32xf32>) -> tensor<32x32xf32>
     %6 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%5 : tensor<32x32xf32>) -> tensor<32x32xf32>
-    
+
     // Combine the two chains
     %result = arith.addf %3, %6 : tensor<32x32xf32>
     return %result : tensor<32x32xf32>
@@ -260,21 +275,24 @@ module {
   // CHECK: %[[C:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // Chain 1: for loop 1
   // CHECK: %[[EMPTY_FOR1:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[FOR1:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[EMPTY_FOR1]]) -> (tensor<32x32xf32>) {
+  // CHECK: %[[ZERO_FOR1:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY_FOR1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[FOR1:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[ZERO_FOR1]]) -> (tensor<32x32xf32>) {
   // CHECK: %[[MM1:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: scf.yield %[[MM1]] : tensor<32x32xf32>
   // CHECK: }
   // CHECK: %[[ADD1:.*]] = arith.addf %[[FOR1]], %[[C]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // Chain 1: for loop 2
   // CHECK: %[[EMPTY_FOR2:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[FOR2:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[EMPTY_FOR2]]) -> (tensor<32x32xf32>) {
+  // CHECK: %[[ZERO_FOR2:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY_FOR2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[FOR2:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[ZERO_FOR2]]) -> (tensor<32x32xf32>) {
   // CHECK: %[[MM2:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: scf.yield %[[MM2]] : tensor<32x32xf32>
   // CHECK: }
   // CHECK: %[[ADD2:.*]] = arith.addf %[[FOR2]], %[[ADD1]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // Chain 1: for loop 3
   // CHECK: %[[EMPTY_FOR3:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[FOR3:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[EMPTY_FOR3]]) -> (tensor<32x32xf32>) {
+  // CHECK: %[[ZERO_FOR3:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY_FOR3]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[FOR3:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[ZERO_FOR3]]) -> (tensor<32x32xf32>) {
   // CHECK: %[[MM3:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: scf.yield %[[MM3]] : tensor<32x32xf32>
   // CHECK: }
@@ -283,21 +301,24 @@ module {
   // CHECK: %[[EMPTY_D:.*]] = tensor.empty() : tensor<32x32xf32>
   // CHECK: %[[D:.*]] = linalg.fill ins(%[[CST_NONZERO]] : f32) outs(%[[EMPTY_D]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[EMPTY_FOR4:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[FOR4:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[EMPTY_FOR4]]) -> (tensor<32x32xf32>) {
+  // CHECK: %[[ZERO_FOR4:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY_FOR4]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[FOR4:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[ZERO_FOR4]]) -> (tensor<32x32xf32>) {
   // CHECK: %[[MM4:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: scf.yield %[[MM4]] : tensor<32x32xf32>
   // CHECK: }
   // CHECK: %[[ADD4:.*]] = arith.addf %[[FOR4]], %[[D]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // Chain 2: for loop 5
   // CHECK: %[[EMPTY_FOR5:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[FOR5:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[EMPTY_FOR5]]) -> (tensor<32x32xf32>) {
+  // CHECK: %[[ZERO_FOR5:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY_FOR5]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[FOR5:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[ZERO_FOR5]]) -> (tensor<32x32xf32>) {
   // CHECK: %[[MM5:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: scf.yield %[[MM5]] : tensor<32x32xf32>
   // CHECK: }
   // CHECK: %[[ADD5:.*]] = arith.addf %[[FOR5]], %[[ADD4]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // Chain 2: for loop 6
   // CHECK: %[[EMPTY_FOR6:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[FOR6:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[EMPTY_FOR6]]) -> (tensor<32x32xf32>) {
+  // CHECK: %[[ZERO_FOR6:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY_FOR6]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[FOR6:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[ZERO_FOR6]]) -> (tensor<32x32xf32>) {
   // CHECK: %[[MM6:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: scf.yield %[[MM6]] : tensor<32x32xf32>
   // CHECK: }
@@ -309,11 +330,11 @@ module {
     %c0_idx = arith.constant 0 : index
     %c10_idx = arith.constant 10 : index
     %c1_idx = arith.constant 1 : index
-    
+
     %cst_zero = arith.constant 0.0 : f32
     %cst_nonzero = arith.constant 1.0 : f32
     %empty1 = tensor.empty() : tensor<32x32xf32>
-    
+
     // Chain 1: zero initialization, each matmul in a for loop
     %c = linalg.fill ins(%cst_zero : f32) outs(%empty1 : tensor<32x32xf32>) -> tensor<32x32xf32>
     %for1_result = scf.for %i1 = %c0_idx to %c10_idx step %c1_idx iter_args(%bias1 = %c) -> (tensor<32x32xf32>) {
@@ -328,7 +349,7 @@ module {
       %mm3 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias3 : tensor<32x32xf32>) -> tensor<32x32xf32>
       scf.yield %mm3 : tensor<32x32xf32>
     }
-    
+
     // Chain 2: non-zero initialization, each matmul in a for loop
     %empty2 = tensor.empty() : tensor<32x32xf32>
     %d = linalg.fill ins(%cst_nonzero : f32) outs(%empty2 : tensor<32x32xf32>) -> tensor<32x32xf32>
@@ -344,7 +365,7 @@ module {
       %mm6 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias6 : tensor<32x32xf32>) -> tensor<32x32xf32>
       scf.yield %mm6 : tensor<32x32xf32>
     }
-    
+
     // Combine the two chains
     %result = arith.addf %for3_result, %for6_result : tensor<32x32xf32>
     return %result : tensor<32x32xf32>
@@ -354,15 +375,17 @@ module {
   // The then branch has a for loop with matmul, the else branch yields zero initial value directly.
   // Matmul in the for loop is marked as loop_carried_l0c and not split, maintaining the L0C chain.
   // CHECK-LABEL: func.func @case12_if_for
+  // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[ZERO:.*]] = linalg.fill ins(%{{.*}} : f32) outs(%[[EMPTY]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: scf.if %{{.*}} -> (tensor<32x32xf32>) {
-  // CHECK: %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[BIAS:.*]] = %{{.*}}) -> (tensor<32x32xf32>) {
+  // CHECK: %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[BIAS:.*]] = %[[ZERO]]) -> (tensor<32x32xf32>) {
   // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[BIAS]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK-NOT: arith.addf
   // CHECK: scf.yield %[[MM]] : tensor<32x32xf32>
   // CHECK: }
   // CHECK: scf.yield %[[FOR]] : tensor<32x32xf32>
   // CHECK: } else {
-  // CHECK: scf.yield %{{.*}} : tensor<32x32xf32>
+  // CHECK: scf.yield %[[ZERO]] : tensor<32x32xf32>
   // CHECK: }
   func.func @case12_if_for(%cond: i1, %A: tensor<32x64xf32>, %B: tensor<64x32xf32>) -> tensor<32x32xf32> {
     %c0 = arith.constant 0 : index
@@ -371,7 +394,7 @@ module {
     %cst = arith.constant 0.0 : f32
     %empty = tensor.empty() : tensor<32x32xf32>
     %zero_init = linalg.fill ins(%cst : f32) outs(%empty : tensor<32x32xf32>) -> tensor<32x32xf32>
-    
+
     %result = scf.if %cond -> (tensor<32x32xf32>) {
       %for_result = scf.for %iv = %c0 to %c10 step %c1 iter_args(%acc = %zero_init) -> (tensor<32x32xf32>) {
         %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%acc : tensor<32x32xf32>) -> tensor<32x32xf32>
@@ -380,6 +403,46 @@ module {
       scf.yield %for_result : tensor<32x32xf32>
     } else {
       scf.yield %zero_init : tensor<32x32xf32>
+    }
+    return %result : tensor<32x32xf32>
+  }
+
+  // Case 13: scf.for loop where the upper bound is a function argument.
+  // Since one of the bounds is not constant, scfMayNotExec returns true.
+  // The loop has a non-zero initial value, so it is split.
+  // After the split, an scf.if checks if the loop executes (ub > lb).
+  // If so, it yields the loop result; otherwise, it fills with zero.
+  // CHECK-LABEL: func.func @case13_may_not_exec_arg_bound
+  // CHECK-SAME: (%[[UB:.*]]: index, %[[A:.*]]: tensor<32x64xf32>, %[[B:.*]]: tensor<64x32xf32>) -> tensor<32x32xf32>
+  // CHECK-DAG: %[[CST_ZERO:.*]] = arith.constant 0.000000e+00 : f32
+  // CHECK-DAG: %[[CST_ONE:.*]] = arith.constant 1.000000e+00 : f32
+  // CHECK: %[[EMPTY1:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[NONZERO_INIT:.*]] = linalg.fill ins(%[[CST_ONE]] : f32) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[EMPTY2:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[ZERO_INIT:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[FOR_RESULT:.*]] = scf.for %{{.*}} = %{{.*}} to %[[UB]] step %{{.*}} iter_args(%[[ITER_BIAS:.*]] = %[[ZERO_INIT]]) -> (tensor<32x32xf32>) {
+  // CHECK:   %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%[[A]], %[[B]] : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ITER_BIAS]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK:   scf.yield %[[MM]] : tensor<32x32xf32>
+  // CHECK: }
+  // CHECK: %[[COND:.*]] = arith.cmpi sgt, %[[UB]], %{{.*}} : index
+  // CHECK: %[[IF_RESULT:.*]] = scf.if %[[COND]] -> (tensor<32x32xf32>) {
+  // CHECK:   scf.yield %[[FOR_RESULT]] : tensor<32x32xf32>
+  // CHECK: } else {
+  // CHECK:   %[[FILL_ELSE:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[FOR_RESULT]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK:   scf.yield %[[FILL_ELSE]] : tensor<32x32xf32>
+  // CHECK: }
+  // CHECK: %[[ADD:.*]] = arith.addf %[[IF_RESULT]], %[[NONZERO_INIT]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
+  // CHECK: return %[[ADD]] : tensor<32x32xf32>
+  func.func @case13_may_not_exec_arg_bound(%ub: index, %A: tensor<32x64xf32>, %B: tensor<64x32xf32>) -> tensor<32x32xf32> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %cst = arith.constant 1.0 : f32
+    %empty = tensor.empty() : tensor<32x32xf32>
+    %nonzero_init = linalg.fill ins(%cst : f32) outs(%empty : tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    %result = scf.for %iv = %c0 to %ub step %c1 iter_args(%bias = %nonzero_init) -> (tensor<32x32xf32>) {
+      %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias : tensor<32x32xf32>) -> tensor<32x32xf32>
+      scf.yield %mm : tensor<32x32xf32>
     }
     return %result : tensor<32x32xf32>
   }


### PR DESCRIPTION
### [ssbuffer] Support split matmul for $a \times b + c$ case where the loop may not execute

#### Overview
This PR addresses a limitation in the split matmul transformation for the $a \times b + c$ pattern. Previously, when a loop-carried matmul resided inside a loop whose execution was uncertain (e.g., due to dynamic loop bounds), splitting the matmul could lead to incorrect results if the loop did not execute. 

This change introduces detection for loops and conditional blocks that may not execute and safely restructures the generated operations to handle these scenarios.

#### Proposed Changes

1. **Detection of Non-Executing Blocks (`scfMayNotExec`)**:
   * Added a utility function `scfMayNotExec` in `SplitMatmulPattern.cpp` to evaluate if an `scf::ForOp` or `scf::IfOp` has bounds or conditions that might prevent execution (e.g., dynamic bounds or non-constant conditions).

2. **Conditional Splitting Logic**:
   * Integrated `scfMayNotExec` into the decision-making process of `shouldSplit`.
   * Updated `splitMatmul` to handle the uncertain loop execution case:
     * Creates an `scf.if` conditional check (`upper_bound > lower_bound`) after the loop.
     * If the loop executes, it yields the loop-carried result.
     * If the loop does not execute, it yields a zero-initialized tensor.
     * Appends the final tensor addition (`arith.addf` or `arith.addi`) outside this conditional check, ensuring the correct accumulator $c$ is added regardless of whether the loop ran.

3. **Code Cleanup and Robustness**:
   * Standardized attribute names by using `CVPipeline::kHIVMMatmulLimitedInCubeAttr` consistently across `CreateIfOps.cpp` and `SeparateCVScope.cpp`.
   * Improved robustness of block ID collection in `ReorderOpsByBlockId.cpp` by gracefully handling nested region walks and unique ID generation.
   * Added extra debug logs to help diagnose equivalent value mapping issues.

4. **Testing**:
   * Added `case13_may_not_exec_arg_bound` to the unit tests in `split_matmul.mlir` to verify the generated IR structure (the conditional `scf.if` and final `arith.addf`) when the upper bound is a dynamic function argument.