### PR TITLE
[release/3.2.2](fix) Fix boundary size calculation for make_block_ptr

### DIFF
--- a/third_party/ascend/include/Utils/Utils.h
+++ b/third_party/ascend/include/Utils/Utils.h
@@ -44,6 +44,11 @@ namespace mlir {
 
 namespace ConverterUtils {
 
+struct TensorPtrAxisInfo {
+  SmallVector<Value> shape;
+  SmallVector<Value> offsets;
+};
+
 const std::string GeneratedByMakeTensorPtrTAG = "GeneratedByMakeTensorPtr";
 const std::string discreteMaskAttrName = "DiscreteMask";
 const std::string discreteAttrName = "DiscreteMemAccess";
@@ -77,6 +82,24 @@ tensor::ExtractSliceOp makeExtractSliceOp(Value src,
 
 std::optional<Operation *> getFullShapeOp(Value val,
                                           ConversionPatternRewriter &rewriter);
+
+std::optional<TensorPtrAxisInfo>
+traceTensorPtrAxisInfo(Value ptr, ConversionPatternRewriter &rewriter,
+             Location loc);
+
+SmallVector<OpFoldResult>
+getBoundarySizesForTensorPtrInfo(llvm::ArrayRef<Value> shape,
+                                 llvm::ArrayRef<Value> offsets,
+                                 llvm::ArrayRef<int32_t> boundaryCheck,
+                                 Value ptr, const Location &loc,
+                                 ConversionPatternRewriter &rewriter);
+
+SmallVector<OpFoldResult>
+getBoundarySizesFromTensorPtrInfoOrFallback(
+  Value originalPtr, Value loweredPtr,
+  llvm::ArrayRef<int32_t> boundaryCheck, const Location &loc,
+  ConversionPatternRewriter &rewriter,
+  std::optional<TensorPtrAxisInfo> &tensorPtrInfo);
 
 SmallVector<OpFoldResult>
 getBoundarySizes(llvm::ArrayRef<int32_t> boundaryCheck, Value ptr,

--- a/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
@@ -344,16 +344,16 @@ LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
   // boundary check
   auto boundaryCheck = op.getBoundaryCheck();
   if (!boundaryCheck.empty()) {
-    auto makeTensorPtrOp = op.getPtr().getDefiningOp<triton::MakeTensorPtrOp>();
-    auto boundarySizes = mlir::ConverterUtils::getBoundarySizes(
-        boundaryCheck, /*remapped*/ ptr, loc, rewriter);
+    std::optional<mlir::ConverterUtils::TensorPtrAxisInfo> tensorPtrInfo;
+    auto boundarySizes = mlir::ConverterUtils::getBoundarySizesFromTensorPtrInfoOrFallback(
+        op.getPtr(), ptr, boundaryCheck, loc, rewriter, tensorPtrInfo);
     // handle the padding
     auto padding = op.getPadding();
     SmallVector<OpFoldResult> srcOffsets(boundarySizes.size(), rewriter.getIndexAttr(0));
     SmallVector<OpFoldResult> dstOffsets;
-    if (makeTensorPtrOp) {
+    if (tensorPtrInfo) {
       auto zeroVal = rewriter.createOrFold<arith::ConstantOp>(loc, rewriter.getI32IntegerAttr(0));
-      for (auto [idx, offVal] : llvm::enumerate(makeTensorPtrOp.getOffsets())) {
+      for (auto [idx, offVal] : llvm::enumerate(tensorPtrInfo->offsets)) {
         if (llvm::find(boundaryCheck, idx) == boundaryCheck.end()) {
           dstOffsets.push_back(srcOffsets[idx]);
           continue;
@@ -1043,14 +1043,14 @@ StoreConverter::matchAndRewrite(triton::StoreOp op, OpAdaptor adaptor,
   // 1. boundary size check
   auto boundaryCheck = op.getBoundaryCheck();
   if (!boundaryCheck.empty()) {
-    auto makeTensorPtrOp = op.getPtr().getDefiningOp<triton::MakeTensorPtrOp>();
-    auto boundarySizes = mlir::ConverterUtils::getBoundarySizes(
-        boundaryCheck, /*remapped*/ ptr, loc, rewriter);
+    std::optional<mlir::ConverterUtils::TensorPtrAxisInfo> tensorPtrInfo;
+    auto boundarySizes = mlir::ConverterUtils::getBoundarySizesFromTensorPtrInfoOrFallback(
+        op.getPtr(), ptr, boundaryCheck, loc, rewriter, tensorPtrInfo);
     SmallVector<OpFoldResult> srcOffsets;
     SmallVector<OpFoldResult> dstOffsets(boundarySizes.size(), rewriter.getIndexAttr(0));
-    if (makeTensorPtrOp) {
+    if (tensorPtrInfo) {
       auto zeroVal = rewriter.createOrFold<arith::ConstantOp>(loc, rewriter.getI32IntegerAttr(0));
-      for (auto [idx, offVal] : llvm::enumerate(makeTensorPtrOp.getOffsets())) {
+      for (auto [idx, offVal] : llvm::enumerate(tensorPtrInfo->offsets)) {
         if (llvm::find(boundaryCheck, idx) == boundaryCheck.end()) {
           srcOffsets.push_back(dstOffsets[idx]);
           continue;

--- a/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
@@ -1072,13 +1072,35 @@ StoreConverter::matchAndRewrite(triton::StoreOp op, OpAdaptor adaptor,
     } else {
       srcOffsets = dstOffsets;
     }
-    auto srcSlice = mlir::ConverterUtils::makeExtractSliceOp(
-        val, srcOffsets, boundarySizes, loc, rewriter);
     auto dstSubview = mlir::ConverterUtils::makeSubViewOp(
         ptr, dstOffsets, boundarySizes, loc, rewriter);
-    auto storeOp = rewriter.create<bufferization::MaterializeInDestinationOp>(
-        loc, srcSlice, dstSubview);
-    storeOp.setWritable(true);
+
+    bool isCheckedAxisPrefix = !boundaryCheck.empty();
+    for (auto [expectedAxis, checkedAxis] : llvm::enumerate(boundaryCheck)) {
+      if (checkedAxis != static_cast<int32_t>(expectedAxis)) {
+        isCheckedAxisPrefix = false;
+        break;
+      }
+    }
+
+    // Keep boundary-check stores on a pure memref.copy path when the dynamic
+    // portion stays on the leading axes of a rank>1 tile.
+    if (isCheckedAxisPrefix && dstOffsets.size() > 1u) {
+      auto tensorValueType = cast<RankedTensorType>(val.getType());
+      auto valueMemRefType = MemRefType::get(tensorValueType.getShape(),
+                                             tensorValueType.getElementType());
+      Value valueMemRef =
+          rewriter.create<bufferization::ToMemrefOp>(loc, valueMemRefType, val);
+      auto srcSubview = mlir::ConverterUtils::makeSubViewOp(
+          valueMemRef, srcOffsets, boundarySizes, loc, rewriter);
+      rewriter.create<memref::CopyOp>(loc, srcSubview, dstSubview);
+    } else {
+      auto srcSlice = mlir::ConverterUtils::makeExtractSliceOp(
+          val, srcOffsets, boundarySizes, loc, rewriter);
+      auto storeOp = rewriter.create<bufferization::MaterializeInDestinationOp>(
+          loc, srcSlice, dstSubview);
+      storeOp.setWritable(true);
+    }
     rewriter.eraseOp(op);
     return success();
   }

--- a/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
@@ -1083,9 +1083,31 @@ StoreConverter::matchAndRewrite(triton::StoreOp op, OpAdaptor adaptor,
       }
     }
 
-    // Keep boundary-check stores on a pure memref.copy path when the dynamic
-    // portion stays on the leading axes of a rank>1 tile.
-    if (isCheckedAxisPrefix && dstOffsets.size() > 1u) {
+    auto hasSingleLeadingDynamicDim = [](MemRefType subviewType) {
+      if (subviewType.getRank() <= 1)
+        return false;
+      auto shape = subviewType.getShape();
+      if (!ShapedType::isDynamic(shape[0]))
+        return false;
+      for (int64_t i = 1, e = subviewType.getRank(); i < e; ++i) {
+        if (ShapedType::isDynamic(shape[i]))
+          return false;
+      }
+      return true;
+    };
+
+    bool isLoopCarriedTensorPtr =
+        isa<BlockArgument>(op.getPtr()) &&
+        isa<scf::ForOp>(op.getPtr().getParentBlock()->getParentOp());
+    bool insideScfFor = static_cast<bool>(op->getParentOfType<scf::ForOp>());
+    auto dstSubviewType = cast<MemRefType>(dstSubview.getType());
+
+    // Prefix boundary_check stores on rank>1 tiles lower to memref.copy when
+    // outside scf.for, or when the effective tile is ?xSxS... . Loop-carried
+    // tensor pointers always stay on the materialize path.
+    if (!isLoopCarriedTensorPtr &&
+        (hasSingleLeadingDynamicDim(dstSubviewType) ||
+         (isCheckedAxisPrefix && dstOffsets.size() > 1u && !insideScfFor))) {
       auto tensorValueType = cast<RankedTensorType>(val.getType());
       auto valueMemRefType = MemRefType::get(tensorValueType.getShape(),
                                              tensorValueType.getElementType());

--- a/third_party/ascend/lib/Utils/Utils.cpp
+++ b/third_party/ascend/lib/Utils/Utils.cpp
@@ -320,6 +320,142 @@ std::optional<Operation *> getFullShapeOp(Value val,
   }
 }
 
+// Trace tensor-ptr axis metadata from the current SSA value back to its
+// logical source. The goal is to recover per-axis `shape` and `offsets`
+// so boundary sizes can be computed directly in logical-axis space.
+//
+// Control flow:
+//
+//   ptr
+//    |
+//    +-- MakeTensorPtrOp --------> return {shape, offsets}
+//    |
+//    +-- AdvanceOp --------------> trace(base)
+//    |                               then offsets := baseOffsets + advance
+//    |
+//    +-- scf.for BlockArgument --> trace(tied loop init)
+//    |
+//    +-- otherwise --------------> std::nullopt
+//
+// Why AdvanceOp matters:
+//   advance does not destroy logical-axis meaning; it only adds a per-axis
+//   delta to the existing tensor-ptr offsets, so we accumulate that delta.
+//
+// Why scf.for BlockArgument matters:
+//   loop-carried tensor pointers lose their direct defining op in the loop
+//   body, but their source is still recoverable through the tied init value.
+std::optional<TensorPtrAxisInfo>
+traceTensorPtrAxisInfo(Value ptr, ConversionPatternRewriter &rewriter,
+                       Location loc) {
+  if (auto makeTensorPtrOp = ptr.getDefiningOp<triton::MakeTensorPtrOp>()) {
+    TensorPtrAxisInfo info;
+    info.shape.assign(makeTensorPtrOp.getShape().begin(),
+                      makeTensorPtrOp.getShape().end());
+    info.offsets.assign(makeTensorPtrOp.getOffsets().begin(),
+                        makeTensorPtrOp.getOffsets().end());
+    return info;
+  }
+
+  if (auto advanceOp = ptr.getDefiningOp<triton::AdvanceOp>()) {
+    auto baseInfo = traceTensorPtrAxisInfo(advanceOp.getPtr(), rewriter, loc);
+    if (!baseInfo || baseInfo->offsets.size() != advanceOp.getOffsets().size())
+      return std::nullopt;
+
+    TensorPtrAxisInfo info;
+    info.shape = baseInfo->shape;
+    info.offsets.reserve(baseInfo->offsets.size());
+    for (auto [baseOffset, advanceOffset] :
+         llvm::zip(baseInfo->offsets, advanceOp.getOffsets())) {
+      info.offsets.push_back(
+          rewriter.createOrFold<arith::AddIOp>(loc, baseOffset, advanceOffset));
+    }
+    return info;
+  }
+
+  if (auto blockArg = dyn_cast<BlockArgument>(ptr)) {
+    if (auto forOp = dyn_cast_or_null<scf::ForOp>(
+            blockArg.getOwner()->getParentOp())) {
+      auto init = forOp.getTiedLoopInit(blockArg);
+      if (!init)
+        return std::nullopt;
+      return traceTensorPtrAxisInfo(init->get(), rewriter, loc);
+    }
+  }
+
+  return std::nullopt;
+}
+
+// Compute boundary sizes directly from logical tensor-ptr metadata instead
+// of reconstructing offsets from a flattened linear address.
+//
+// For every axis `i` listed in boundary_check:
+//   leftSize_i     = max(shape_i - offset_i, 0)
+//   boundarySize_i = min(blockShape_i, leftSize_i)
+//
+// Meanings:
+//   shape_i      : full logical extent of axis i
+//   offset_i     : current block start offset on axis i
+//   blockShape_i : current lowered block size on axis i
+//   leftSize_i   : remaining valid elements from offset_i to the boundary
+//
+// Example make_block_ptr state:
+//   shape       = (17, 13, 11)
+//   offsets     = (12, 10, 9)
+//   block_shape = (8, 4, 4)
+//   boundary_check = (0, 1, 2)
+// Then:
+//   axis0: leftSize = max(17 - 12, 0) = 5  -> boundarySize = min(8, 5) = 5
+//   axis1: leftSize = max(13 - 10, 0) = 3  -> boundarySize = min(4, 3) = 3
+//   axis2: leftSize = max(11 - 9, 0) = 2   -> boundarySize = min(4, 2) = 2
+// So the final per-axis boundary size array is [5, 3, 2].
+SmallVector<OpFoldResult>
+getBoundarySizesForTensorPtrInfo(llvm::ArrayRef<Value> shape,
+                                 llvm::ArrayRef<Value> offsets,
+                                 llvm::ArrayRef<int32_t> boundaryCheck,
+                                 Value ptr, const Location &loc,
+                                 ConversionPatternRewriter &rewriter) {
+  auto shapedType = cast<ShapedType>(ptr.getType());
+  auto boundarySizes =
+      getAsIndexOpFoldResult(rewriter.getContext(), shapedType.getShape());
+
+  for (int32_t axis : boundaryCheck) {
+    if (axis < 0 || axis >= static_cast<int32_t>(shapedType.getRank()) ||
+        axis >= static_cast<int32_t>(shape.size()) ||
+        axis >= static_cast<int32_t>(offsets.size()))
+      continue;
+
+    OpFoldResult fullShape =
+        getOpFoldResultOfLayoutInfo(shape[axis], rewriter);
+    OpFoldResult curOffset =
+        getOpFoldResultOfLayoutInfo(offsets[axis], rewriter);
+    curOffset =
+        maxOpFoldResult(curOffset, rewriter.getIndexAttr(0), loc, rewriter);
+    OpFoldResult curLeftSize = maxOpFoldResult(
+        subOpFoldResult(fullShape, curOffset, loc, rewriter),
+        rewriter.getIndexAttr(0), loc, rewriter);
+    boundarySizes[axis] =
+        minOpFoldResult(boundarySizes[axis], curLeftSize, loc, rewriter);
+  }
+
+  return boundarySizes;
+}
+
+SmallVector<OpFoldResult>
+getBoundarySizesFromTensorPtrInfoOrFallback(
+    Value originalPtr, Value loweredPtr, llvm::ArrayRef<int32_t> boundaryCheck,
+    const Location &loc, ConversionPatternRewriter &rewriter,
+    std::optional<TensorPtrAxisInfo> &tensorPtrInfo) {
+  tensorPtrInfo = traceTensorPtrAxisInfo(originalPtr, rewriter, loc);
+  if (tensorPtrInfo) {
+    return getBoundarySizesForTensorPtrInfo(tensorPtrInfo->shape,
+                                            tensorPtrInfo->offsets,
+                                            boundaryCheck, loweredPtr, loc,
+                                            rewriter);
+  }
+
+  return getBoundarySizes(boundaryCheck, loweredPtr, loc, rewriter);
+}
+
 SmallVector<OpFoldResult>
 getBoundarySizes(llvm::ArrayRef<int32_t> boundaryCheck, Value ptr,
                  const Location &loc, ConversionPatternRewriter &rewriter) {
@@ -395,22 +531,29 @@ getBoundarySizes(llvm::ArrayRef<int32_t> boundaryCheck, Value ptr,
       curPtrOffset, fullShapeReCast.getConstifiedMixedOffset(), loc, rewriter);
 
   for (int i = 0; i < shapedType.getRank(); ++i) {
+    OpFoldResult curStride = fullShapeReCast.getConstifiedMixedStrides()[i];
     if (llvm::find(boundaryCheck, i) != boundaryCheck.end()) {
-      auto fullShape = fullShapeReCast.getConstifiedMixedSizes()[i];
+      if (isZero(curStride)) {
+        emitWarning(loc)
+            << "getBoundarySizes() cannot reconstruct boundary on checked "
+               "zero-stride axis "
+            << i << "; keep current block size for this axis";
+        continue;
+      }
 
-      OpFoldResult curOffset = divOpFoldResult(
-          offsetShift, fullShapeReCast.getConstifiedMixedStrides()[i], loc,
-          rewriter);
+      OpFoldResult curOffset = divOpFoldResult(offsetShift, curStride, loc,
+                                               rewriter);
+      auto fullShape = fullShapeReCast.getConstifiedMixedSizes()[i];
       OpFoldResult curLeftSize =
           maxOpFoldResult(subOpFoldResult(fullShape, curOffset, loc, rewriter),
                           rewriter.getIndexAttr(0), loc, rewriter);
 
       boundarySize[i] =
           minOpFoldResult(boundarySize[i], curLeftSize, loc, rewriter);
+    }
 
-      offsetShift = remOpFoldResult(
-          offsetShift, fullShapeReCast.getConstifiedMixedStrides()[i], loc,
-          rewriter);
+    if (!isZero(curStride)) {
+      offsetShift = remOpFoldResult(offsetShift, curStride, loc, rewriter);
     }
   }
 

--- a/third_party/ascend/lib/Utils/Utils.cpp
+++ b/third_party/ascend/lib/Utils/Utils.cpp
@@ -320,6 +320,21 @@ std::optional<Operation *> getFullShapeOp(Value val,
   }
 }
 
+
+// Return true if `value` is `root`, or is computed from ops that (transitively)
+// use `root`. Used to detect loop-carried advance deltas that vary per-iteration.
+bool valueTransitivelyDependsOn(Value value, Value root) {
+  if (value == root)
+    return true;
+  Operation *defOp = value.getDefiningOp();
+  if (!defOp || isa<arith::ConstantOp>(defOp))
+    return false;
+  return llvm::any_of(defOp->getOperands(), [&](Value operand) {
+    return valueTransitivelyDependsOn(operand, root);
+  });
+}
+
+
 // Trace tensor-ptr axis metadata from the current SSA value back to its
 // logical source. The goal is to recover per-axis `shape` and `offsets`
 // so boundary sizes can be computed directly in logical-axis space.
@@ -333,7 +348,10 @@ std::optional<Operation *> getFullShapeOp(Value val,
 //    +-- AdvanceOp --------------> trace(base)
 //    |                               then offsets := baseOffsets + advance
 //    |
-//    +-- scf.for BlockArgument --> trace(tied loop init)
+//    +-- scf.for BlockArgument --> trace(tied loop init), or if yield is
+//    |                               advance(iter_arg, fixed_delta):
+//    |                               offsets := init + iterCount * delta
+//    |                               (nullopt if delta depends on iv)
 //    |
 //    +-- otherwise --------------> std::nullopt
 //
@@ -397,9 +415,17 @@ traceTensorPtrAxisInfo(Value ptr, ConversionPatternRewriter &rewriter,
           baseInfo->offsets.size() != advanceOp.getOffsets().size())
         return std::nullopt;
 
+      Value loopIv = forOp.getInductionVar();
+      // Only model yield advance(iter_arg, fixed_delta). Per-iteration deltas
+      // that depend on the induction variable need a different accumulation
+      // than iterCount * delta, so fall back to getBoundarySizes().
+      for (Value advanceOffset : advanceOp.getOffsets()) {
+        if (valueTransitivelyDependsOn(advanceOffset, loopIv))
+          return std::nullopt;
+      }
+
       Value loopLb = forOp.getLowerBound();
       Value loopStep = forOp.getStep();
-      Value loopIv = forOp.getInductionVar();
       Value iterDistance =
           rewriter.createOrFold<arith::SubIOp>(loc, loopIv, loopLb);
       Value iterCount =

--- a/third_party/ascend/lib/Utils/Utils.cpp
+++ b/third_party/ascend/lib/Utils/Utils.cpp
@@ -378,7 +378,49 @@ traceTensorPtrAxisInfo(Value ptr, ConversionPatternRewriter &rewriter,
       auto init = forOp.getTiedLoopInit(blockArg);
       if (!init)
         return std::nullopt;
-      return traceTensorPtrAxisInfo(init->get(), rewriter, loc);
+      auto yieldOp = dyn_cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+      if (!yieldOp)
+        return std::nullopt;
+      unsigned iterArgIndex = blockArg.getArgNumber() - 1;
+      if (iterArgIndex >= yieldOp.getNumOperands())
+        return std::nullopt;
+      Value yieldedValue = yieldOp.getOperand(iterArgIndex);
+      if (yieldedValue == blockArg)
+        return traceTensorPtrAxisInfo(init->get(), rewriter, loc);
+
+      auto advanceOp = yieldedValue.getDefiningOp<triton::AdvanceOp>();
+      if (!advanceOp || advanceOp.getPtr() != blockArg)
+        return std::nullopt;
+
+      auto baseInfo = traceTensorPtrAxisInfo(init->get(), rewriter, loc);
+      if (!baseInfo ||
+          baseInfo->offsets.size() != advanceOp.getOffsets().size())
+        return std::nullopt;
+
+      Value loopLb = forOp.getLowerBound();
+      Value loopStep = forOp.getStep();
+      Value loopIv = forOp.getInductionVar();
+      Value iterDistance =
+          rewriter.createOrFold<arith::SubIOp>(loc, loopIv, loopLb);
+      Value iterCount =
+          rewriter.createOrFold<arith::DivSIOp>(loc, iterDistance, loopStep);
+
+      TensorPtrAxisInfo info;
+      info.shape = baseInfo->shape;
+      info.offsets.reserve(baseInfo->offsets.size());
+      for (auto [baseOffset, advanceOffset] :
+           llvm::zip(baseInfo->offsets, advanceOp.getOffsets())) {
+        Value iterCountTyped = iterCount;
+        if (iterCountTyped.getType() != advanceOffset.getType()) {
+          iterCountTyped = rewriter.createOrFold<arith::IndexCastOp>(
+              loc, advanceOffset.getType(), iterCountTyped);
+        }
+        Value totalAdvance = rewriter.createOrFold<arith::MulIOp>(
+            loc, iterCountTyped, advanceOffset);
+        info.offsets.push_back(
+            rewriter.createOrFold<arith::AddIOp>(loc, baseOffset, totalAdvance));
+      }
+      return info;
     }
   }
 
@@ -533,17 +575,19 @@ getBoundarySizes(llvm::ArrayRef<int32_t> boundaryCheck, Value ptr,
   for (int i = 0; i < shapedType.getRank(); ++i) {
     OpFoldResult curStride = fullShapeReCast.getConstifiedMixedStrides()[i];
     if (llvm::find(boundaryCheck, i) != boundaryCheck.end()) {
+      auto fullShape = fullShapeReCast.getConstifiedMixedSizes()[i];
       if (isZero(curStride)) {
+        boundarySize[i] =
+            minOpFoldResult(boundarySize[i], fullShape, loc, rewriter);
         emitWarning(loc)
             << "getBoundarySizes() cannot reconstruct boundary on checked "
                "zero-stride axis "
-            << i << "; keep current block size for this axis";
+            << i << "; clamp boundary to the full logical axis size";
         continue;
       }
 
       OpFoldResult curOffset = divOpFoldResult(offsetShift, curStride, loc,
                                                rewriter);
-      auto fullShape = fullShapeReCast.getConstifiedMixedSizes()[i];
       OpFoldResult curLeftSize =
           maxOpFoldResult(subOpFoldResult(fullShape, curOffset, loc, rewriter),
                           rewriter.getIndexAttr(0), loc, rewriter);

--- a/third_party/ascend/unittest/pytest_ut/test_boundary_check_arbitrary_axes.py
+++ b/third_party/ascend/unittest/pytest_ut/test_boundary_check_arbitrary_axes.py
@@ -1,0 +1,582 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import pytest
+import torch
+import torch_npu
+import triton
+import triton.language as tl
+
+
+# =============================================================================
+# boundary_check regression suite
+#
+# Broad layout classes:
+# 1. Direct layout: the kernel directly builds the target block_ptr view.
+# 2. Implicit permute layout: the block_ptr shape/stride mapping follows the
+#    same reverse-axes style as the implicit-permute repro path.
+#
+# Test matrix:
+#
+#  | case group | layout class  | rank | boundary_check |
+#  |------------|---------------|------|----------------|
+#  | (A2)       | direct layout | 2-D  | partial axes   |
+#  | (A3)       | direct layout | 3-D  | partial axes   |
+#  | (B2)       | direct layout | 2-D  | all axes       |
+#  | (B3)       | direct layout | 3-D  | all axes       |
+#  | (C2)       | implicit permute layout | 2-D  | partial axes   |
+#  | (C3)       | implicit permute layout | 3-D  | all axes       |
+#  | (D2)       | direct layout + tl.advance | 2-D | partial axes |
+#  | (E2)       | direct layout + loop-carried for | 2-D | partial axes |
+#
+# Notes:
+# 1. A2/A3 exercise plain direct-layout make_block_ptr with boundary_check on a
+#    later axis, proving the partial-axis issue is not limited to the implicit
+#    implicit-permute-style path.
+# 2. B2/B3 exercise direct-layout remapped views with boundary_check on all
+#    axes, covering the make_tensor_ptr full-boundary lowering issue.
+# 3. C2/C3 mirror the original implicit-permute reverse-axes repro style:
+#    C2 for partial-axis checking, C3 for all-axis checking.
+# 4. D2/E2 extend the suite to explicit tl.advance and runtime loop-carried
+#    block_ptr flows, covering the newly added tensor-ptr tracing paths.
+# =============================================================================
+
+
+SHAPE_2D = (32, 50, 8, 8)
+SHAPE_3D_PARTIAL = (8, 8, 11, 4, 4, 8)
+SHAPE_3D_FULL = (5, 9, 11, 4, 4, 8)
+SHAPE_2D_ADVANCE = (32, 50, 8, 8, 45)
+SHAPE_2D_LOOP = (32, 50, 8, 8, 38, 6, 2)
+
+
+def ceil_div(lhs: int, rhs: int) -> int:
+    return (lhs + rhs - 1) // rhs
+
+
+def make_input(shape: tuple[int, ...]) -> torch.Tensor:
+    numel = 1
+    for dim in shape:
+        numel *= dim
+    return torch.arange(numel, dtype=torch.float32, device="npu").reshape(shape)
+
+
+def assert_equal(actual: torch.Tensor, expected: torch.Tensor) -> None:
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=0.0, atol=0.0)
+
+
+def make_partial_copy_expected(
+    src: torch.Tensor,
+    start_col: int,
+    col_block: int,
+    step_col: int = 0,
+    num_steps: int = 1,
+) -> torch.Tensor:
+    expected = torch.full_like(src, -1.0)
+    cols = src.shape[1]
+    for step in range(num_steps):
+        col_begin = start_col + step * step_col
+        col_end = min(col_begin + col_block, cols)
+        if col_begin < cols:
+            expected[:, col_begin:col_end] = src[:, col_begin:col_end]
+    return expected
+
+
+@triton.jit
+def bc_a2_direct_2d_partial(
+    in_ptr,
+    out_ptr,
+    rows,
+    cols,
+    stride_row,
+    stride_col,
+    ROWBLOCK: tl.constexpr,
+    COLBLOCK: tl.constexpr,
+):
+    row0 = tl.program_id(0) * ROWBLOCK
+    col0 = tl.program_id(1) * COLBLOCK
+    in_block_ptr = tl.make_block_ptr(
+        base=in_ptr,
+        shape=(rows, cols),
+        strides=(stride_row, stride_col),
+        offsets=(row0, col0),
+        block_shape=(ROWBLOCK, COLBLOCK),
+        order=(1, 0),
+    )
+    value = tl.load(in_block_ptr, boundary_check=(1,), padding_option="zero")
+
+    out_block_ptr = tl.make_block_ptr(
+        base=out_ptr,
+        shape=(rows, cols),
+        strides=(stride_row, stride_col),
+        offsets=(row0, col0),
+        block_shape=(ROWBLOCK, COLBLOCK),
+        order=(1, 0),
+    )
+    tl.store(out_block_ptr, value, boundary_check=(1,))
+
+
+@triton.jit
+def bc_a3_direct_3d_partial(
+    in_ptr,
+    out_ptr,
+    d0,
+    d1,
+    d2,
+    stride0,
+    stride1,
+    stride2,
+    B0: tl.constexpr,
+    B1: tl.constexpr,
+    B2: tl.constexpr,
+):
+    i0 = tl.program_id(0) * B0
+    i1 = tl.program_id(1) * B1
+    i2 = tl.program_id(2) * B2
+    in_block_ptr = tl.make_block_ptr(
+        base=in_ptr,
+        shape=(d0, d1, d2),
+        strides=(stride0, stride1, stride2),
+        offsets=(i0, i1, i2),
+        block_shape=(B0, B1, B2),
+        order=(2, 1, 0),
+    )
+    value = tl.load(in_block_ptr, boundary_check=(2,), padding_option="zero")
+
+    out_block_ptr = tl.make_block_ptr(
+        base=out_ptr,
+        shape=(d0, d1, d2),
+        strides=(stride0, stride1, stride2),
+        offsets=(i0, i1, i2),
+        block_shape=(B0, B1, B2),
+        order=(2, 1, 0),
+    )
+    tl.store(out_block_ptr, value, boundary_check=(2,))
+
+
+@triton.jit
+def bc_b2_direct_2d_full(
+    in_ptr,
+    out_ptr,
+    rows,
+    cols,
+    stride_row,
+    stride_col,
+    out_stride0,
+    out_stride1,
+    ROWBLOCK: tl.constexpr,
+    COLBLOCK: tl.constexpr,
+):
+    col0 = tl.program_id(0) * COLBLOCK
+    row0 = tl.program_id(1) * ROWBLOCK
+    in_block_ptr = tl.make_block_ptr(
+        base=in_ptr,
+        shape=(cols, rows),
+        strides=(stride_col, stride_row),
+        offsets=(col0, row0),
+        block_shape=(COLBLOCK, ROWBLOCK),
+        order=(0, 1),
+    )
+    value = tl.load(in_block_ptr, boundary_check=(0, 1), padding_option="zero")
+
+    out_block_ptr = tl.make_block_ptr(
+        base=out_ptr,
+        shape=(cols, rows),
+        strides=(out_stride0, out_stride1),
+        offsets=(col0, row0),
+        block_shape=(COLBLOCK, ROWBLOCK),
+        order=(1, 0),
+    )
+    tl.store(out_block_ptr, value, boundary_check=(0, 1))
+
+
+@triton.jit
+def bc_b3_direct_3d_full(
+    in_ptr,
+    out_ptr,
+    d0,
+    d1,
+    d2,
+    stride0,
+    stride1,
+    stride2,
+    out_stride0,
+    out_stride1,
+    out_stride2,
+    B0: tl.constexpr,
+    B1: tl.constexpr,
+    B2: tl.constexpr,
+):
+    i0 = tl.program_id(0) * B0
+    i1 = tl.program_id(1) * B1
+    i2 = tl.program_id(2) * B2
+    in_block_ptr = tl.make_block_ptr(
+        base=in_ptr,
+        shape=(d2, d0, d1),
+        strides=(stride2, stride0, stride1),
+        offsets=(i0, i1, i2),
+        block_shape=(B0, B1, B2),
+        order=(0, 2, 1),
+    )
+    value = tl.load(in_block_ptr, boundary_check=(0, 1, 2), padding_option="zero")
+
+    out_block_ptr = tl.make_block_ptr(
+        base=out_ptr,
+        shape=(d2, d0, d1),
+        strides=(out_stride0, out_stride1, out_stride2),
+        offsets=(i0, i1, i2),
+        block_shape=(B0, B1, B2),
+        order=(2, 1, 0),
+    )
+    tl.store(out_block_ptr, value, boundary_check=(0, 1, 2))
+
+
+@triton.jit
+def bc_c2_implicit_permute_2d_partial(
+    in_ptr,
+    out_ptr,
+    rows,
+    cols,
+    stride_row,
+    stride_col,
+    out_stride0,
+    out_stride1,
+    ROWBLOCK: tl.constexpr,
+    COLBLOCK: tl.constexpr,
+):
+    col0 = tl.program_id(0) * COLBLOCK
+    row0 = tl.program_id(1) * ROWBLOCK
+    in_block_ptr = tl.make_block_ptr(
+        base=in_ptr,
+        shape=(cols, rows),
+        strides=(stride_col, stride_row),
+        offsets=(col0, row0),
+        block_shape=(COLBLOCK, ROWBLOCK),
+        order=(0, 1),
+    )
+    value = tl.load(in_block_ptr, boundary_check=(0,), padding_option="zero")
+
+    out_block_ptr = tl.make_block_ptr(
+        base=out_ptr,
+        shape=(cols, rows),
+        strides=(out_stride0, out_stride1),
+        offsets=(col0, row0),
+        block_shape=(COLBLOCK, ROWBLOCK),
+        order=(1, 0),
+    )
+    tl.store(out_block_ptr, value, boundary_check=(0,))
+
+
+@triton.jit
+def bc_c3_implicit_permute_3d_full(
+    in_ptr,
+    out_ptr,
+    d0,
+    d1,
+    d2,
+    stride0,
+    stride1,
+    stride2,
+    out_stride0,
+    out_stride1,
+    out_stride2,
+    B0: tl.constexpr,
+    B1: tl.constexpr,
+    B2: tl.constexpr,
+):
+    i0 = tl.program_id(0) * B0
+    i1 = tl.program_id(1) * B1
+    i2 = tl.program_id(2) * B2
+    in_block_ptr = tl.make_block_ptr(
+        base=in_ptr,
+        shape=(d2, d1, d0),
+        strides=(stride2, stride1, stride0),
+        offsets=(i0, i1, i2),
+        block_shape=(B0, B1, B2),
+        order=(0, 1, 2),
+    )
+    value = tl.load(in_block_ptr, boundary_check=(0, 1, 2), padding_option="zero")
+
+    out_block_ptr = tl.make_block_ptr(
+        base=out_ptr,
+        shape=(d2, d1, d0),
+        strides=(out_stride0, out_stride1, out_stride2),
+        offsets=(i0, i1, i2),
+        block_shape=(B0, B1, B2),
+        order=(2, 1, 0),
+    )
+    tl.store(out_block_ptr, value, boundary_check=(0, 1, 2))
+
+
+@triton.jit
+def bc_d2_direct_2d_advance_partial(
+    in_ptr,
+    out_ptr,
+    rows,
+    cols,
+    stride_row,
+    stride_col,
+    advance_col,
+    ROWBLOCK: tl.constexpr,
+    COLBLOCK: tl.constexpr,
+):
+    row0 = tl.program_id(0) * ROWBLOCK
+    in_block_ptr = tl.make_block_ptr(
+        base=in_ptr,
+        shape=(rows, cols),
+        strides=(stride_row, stride_col),
+        offsets=(row0, 0),
+        block_shape=(ROWBLOCK, COLBLOCK),
+        order=(1, 0),
+    )
+    out_block_ptr = tl.make_block_ptr(
+        base=out_ptr,
+        shape=(rows, cols),
+        strides=(stride_row, stride_col),
+        offsets=(row0, 0),
+        block_shape=(ROWBLOCK, COLBLOCK),
+        order=(1, 0),
+    )
+    in_block_ptr = tl.advance(in_block_ptr, (0, advance_col))
+    out_block_ptr = tl.advance(out_block_ptr, (0, advance_col))
+    value = tl.load(in_block_ptr, boundary_check=(1,), padding_option="zero")
+    tl.store(out_block_ptr, value, boundary_check=(1,))
+
+
+@triton.jit
+def bc_e2_direct_2d_for_partial(
+    in_ptr,
+    out_ptr,
+    rows,
+    cols,
+    stride_row,
+    stride_col,
+    start_col,
+    step_col,
+    num_steps,
+    ROWBLOCK: tl.constexpr,
+    COLBLOCK: tl.constexpr,
+):
+    row0 = tl.program_id(0) * ROWBLOCK
+    in_block_ptr = tl.make_block_ptr(
+        base=in_ptr,
+        shape=(rows, cols),
+        strides=(stride_row, stride_col),
+        offsets=(row0, start_col),
+        block_shape=(ROWBLOCK, COLBLOCK),
+        order=(1, 0),
+    )
+    out_block_ptr = tl.make_block_ptr(
+        base=out_ptr,
+        shape=(rows, cols),
+        strides=(stride_row, stride_col),
+        offsets=(row0, start_col),
+        block_shape=(ROWBLOCK, COLBLOCK),
+        order=(1, 0),
+    )
+    for _ in range(num_steps):
+        value = tl.load(in_block_ptr, boundary_check=(1,), padding_option="zero")
+        tl.store(out_block_ptr, value, boundary_check=(1,))
+        in_block_ptr = tl.advance(in_block_ptr, (0, step_col))
+        out_block_ptr = tl.advance(out_block_ptr, (0, step_col))
+
+
+def test_bc_a2_direct_2d_partial():
+    rows, cols, row_block, col_block = SHAPE_2D
+    src = make_input((rows, cols))
+    out = torch.full_like(src, -1.0)
+
+    grid = (ceil_div(rows, row_block), ceil_div(cols, col_block))
+    bc_a2_direct_2d_partial[grid](
+        src,
+        out,
+        rows,
+        cols,
+        src.stride(0),
+        src.stride(1),
+        ROWBLOCK=row_block,
+        COLBLOCK=col_block,
+    )
+
+    assert_equal(out, src)
+
+
+def test_bc_a3_direct_3d_partial():
+    d0, d1, d2, b0, b1, b2 = SHAPE_3D_PARTIAL
+    src = make_input((d0, d1, d2))
+    out = torch.full_like(src, -1.0)
+
+    grid = (ceil_div(d0, b0), ceil_div(d1, b1), ceil_div(d2, b2))
+    bc_a3_direct_3d_partial[grid](
+        src,
+        out,
+        d0,
+        d1,
+        d2,
+        src.stride(0),
+        src.stride(1),
+        src.stride(2),
+        B0=b0,
+        B1=b1,
+        B2=b2,
+    )
+
+    assert_equal(out, src)
+
+
+def test_bc_b2_direct_2d_full():
+    rows, cols, row_block, col_block = SHAPE_2D
+    src = make_input((rows, cols))
+    out = torch.full((cols, rows), -1.0, device="npu", dtype=src.dtype)
+
+    grid = (ceil_div(cols, col_block), ceil_div(rows, row_block))
+    bc_b2_direct_2d_full[grid](
+        src,
+        out,
+        rows,
+        cols,
+        src.stride(0),
+        src.stride(1),
+        out.stride(0),
+        out.stride(1),
+        ROWBLOCK=row_block,
+        COLBLOCK=col_block,
+    )
+
+    assert_equal(out, src.transpose(0, 1).contiguous())
+
+
+def test_bc_b3_direct_3d_full():
+    d0, d1, d2, b0, b1, b2 = SHAPE_3D_FULL
+    src = make_input((d0, d1, d2))
+    out = torch.full((d2, d0, d1), -1.0, device="npu", dtype=src.dtype)
+
+    grid = (ceil_div(d2, b0), ceil_div(d0, b1), ceil_div(d1, b2))
+    bc_b3_direct_3d_full[grid](
+        src,
+        out,
+        d0,
+        d1,
+        d2,
+        src.stride(0),
+        src.stride(1),
+        src.stride(2),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        B0=b0,
+        B1=b1,
+        B2=b2,
+    )
+
+    assert_equal(out, src.permute(2, 0, 1).contiguous())
+
+
+def test_bc_c2_implicit_permute_2d_partial():
+    rows, cols, row_block, col_block = SHAPE_2D
+    src = make_input((rows, cols))
+    out = torch.full((cols, rows), -1.0, device="npu", dtype=src.dtype)
+
+    grid = (ceil_div(cols, col_block), ceil_div(rows, row_block))
+    bc_c2_implicit_permute_2d_partial[grid](
+        src,
+        out,
+        rows,
+        cols,
+        src.stride(0),
+        src.stride(1),
+        out.stride(0),
+        out.stride(1),
+        ROWBLOCK=row_block,
+        COLBLOCK=col_block,
+    )
+
+    assert_equal(out, src.transpose(0, 1).contiguous())
+
+
+def test_bc_c3_implicit_permute_3d_full():
+    d0, d1, d2, b0, b1, b2 = SHAPE_3D_FULL
+    src = make_input((d0, d1, d2))
+    out = torch.full((d2, d1, d0), -1.0, device="npu", dtype=src.dtype)
+
+    grid = (ceil_div(d2, b0), ceil_div(d1, b1), ceil_div(d0, b2))
+    bc_c3_implicit_permute_3d_full[grid](
+        src,
+        out,
+        d0,
+        d1,
+        d2,
+        src.stride(0),
+        src.stride(1),
+        src.stride(2),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        B0=b0,
+        B1=b1,
+        B2=b2,
+    )
+
+    assert_equal(out, src.permute(2, 1, 0).contiguous())
+
+
+def test_bc_d2_direct_2d_advance_partial():
+    rows, cols, row_block, col_block, advance_col = SHAPE_2D_ADVANCE
+    src = make_input((rows, cols))
+    out = torch.full_like(src, -1.0)
+
+    grid = (ceil_div(rows, row_block),)
+    bc_d2_direct_2d_advance_partial[grid](
+        src,
+        out,
+        rows,
+        cols,
+        src.stride(0),
+        src.stride(1),
+        advance_col,
+        ROWBLOCK=row_block,
+        COLBLOCK=col_block,
+    )
+
+    expected = make_partial_copy_expected(src, advance_col, col_block)
+    assert_equal(out, expected)
+
+
+def test_bc_e2_direct_2d_for_partial():
+    rows, cols, row_block, col_block, start_col, step_col, num_steps = SHAPE_2D_LOOP
+    src = make_input((rows, cols))
+    out = torch.full_like(src, -1.0)
+
+    grid = (ceil_div(rows, row_block),)
+    bc_e2_direct_2d_for_partial[grid](
+        src,
+        out,
+        rows,
+        cols,
+        src.stride(0),
+        src.stride(1),
+        start_col,
+        step_col,
+        num_steps,
+        ROWBLOCK=row_block,
+        COLBLOCK=col_block,
+    )
+
+    expected = make_partial_copy_expected(src, start_col, col_block, step_col, num_steps)
+    assert_equal(out, expected)


### PR DESCRIPTION
## Summary
This PR fixes **incorrect boundary_check lowering** for block pointer paths by reworking the core computation strategy.
The key change: **prefer direct logical-axis boundary size calculation using traced tensor pointer metadata** as the main path, while keeping the linear offset-based method as a safe fallback. The fallback path’s partial boundary_check bug is also fixed.
## Problem
`boundary_check` is a **block-pointer-native semantic** that requires per-axis valid element counts (`boundarySizes`):

$$
boundarySizes = [size_0, size_1, \dots, size_{n-1}]
$$

where each entry says how many elements are still valid on that logical axis.

The previous implementation suffered from **two critical flaws**:
### 1. Wrong Primary Abstraction
Block pointers carry full logical-axis metadata (shape, offsets, block shape) by design.
However, the old code **overused linear offset reconstruction** (via div/rem + memref strides) as the primary way to recover per-axis offsets.
This method is **not generally correct** for block pointers, especially with implicit permute or non-standard layouts.
### 2. Partial Boundary Check Bug in getBoundarySizes

`getBoundarySizes` incorrectly stripped `offsetShift` **only on boundary-checked axes**, allowing unchecked axes to pollute checked axes.

This caused wrong out-of-bounds detection and excessive zero-padding.
## Incorrect vs Correct Behavior

### Example 1: Partial boundary_check
Consider a 2D row-major tensor:
- `shape = (32, 50)`
- `strides = (50, 1)`
- `block_shape = (8, 8)`
- `offsets = (10, 40)`
- `boundary_check = (1,)`

The flattened linear offset is:

$$
linear\_offset = offset_0 \times stride_0 + offset_1 \times stride_1 = 10 \times 50 + 40 \times 1 = 540
$$

Old fallback incorrectly computes axis 1 offset as:

$$
curOffset_1 = \frac{linear\_offset}{stride_1} = \frac{540}{1} = 540
$$

What it should do is peel off the higher-axis contribution before recovering axis 1:

$$
curOffset_1 = \frac{linear\_offset \bmod stride_0}{stride_1} = \frac{540 \bmod 50}{1} = 40
$$
### Example 2: Full boundary_check on a real block pointer

Consider a 3D block pointer with logical metadata:
- `shape = (17, 13, 11)`
- `offsets = (12, 10, 9)`
- `block_shape = (8, 4, 4)`
- `boundary_check = (0, 1, 2)`

>The old design still tended to route this through linear offset reconstruction from layout information. That is fragile because full-axis validity is fundamentally a logical-axis question, not a memref-layout question.

The new primary path computes each checked axis directly:

$$
leftSize_i = \max(shape_i - offset_i, 0)  \qquad
boundarySize_i = \min(blockShape_i, leftSize_i)
$$

Substituting values:
- axis 0: `leftSize_0 = max(17 - 12, 0) = 5`, so `boundarySize_0 = min(8, 5) = 5`
- axis 1: `leftSize_1 = max(13 - 10, 0) = 3`, so `boundarySize_1 = min(4, 3) = 3`
- axis 2: `leftSize_2 = max(11 - 9, 0) = 2`, so `boundarySize_2 = min(4, 2) = 2`

Therefore:

$$
boundarySizes = [5, 3, 2]
$$
## Solution

When logical-axis metadata can be traced:
1. Use `traceTensorPtrAxisInfo` to recover `shape` and `offsets`
2. Use `getBoundarySizesForTensorPtrInfo` to compute valid sizes directly
   Formula: $$boundarySize_i = min(blockShape_i, max(shape_i - offset_i, 0))$$
If metadata is lost (e.g., lowered memref view):
- Fall back to `getBoundarySizes`
- Fixed to strip offsetShift across all axes, not just checked ones
### Lowering Workflow

```mermaid
flowchart TD
    A[Load/Store with boundary_check] --> B[Trace tensor-ptr axis info]
    B -->|success| C[Compute boundarySizes from logical shape/offsets]
    B -->|fail| D[Fallback to memref-based getBoundarySizes]
    C --> E[Create subview or slice with boundarySizes]
    D --> E
    E --> F[Lower copy or materialize_in_destination]
```
## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)