### PR TITLE
[ssbuffer](fix) unify reinterpret_castOp for copyOp 

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
@@ -334,6 +334,42 @@ static FillInfo splitSCFIfIfNeeded(FillInfo &info) {
 }
 
 /**
+ * @brief Collect source view chain ops from memref.copy's source operand
+ *
+ * For each memref.copy found by penetrating ViewLike direct users (subview of
+ * alloc), trace back the copy's source operand along the ViewLikeOpInterface
+ * chain (e.g., memref.subview -> memref.reinterpret_cast), and collect all
+ * ViewLike ops in the chain. These ops will be unified to the same block_id
+ * as the copy.
+ *
+ * @param directUsers Direct users of alloc result (containing ViewLike ops
+ *                    whose users include memref.copy)
+ * @return SmallVector<Operation*> Collected source view chain ops
+ *
+ */
+static SmallVector<Operation *> collectSourceViewChainOps(ArrayRef<Operation *> directUsers) {
+  SmallVector<Operation *> chainOps;
+  for (Operation *op : directUsers) {
+    if (!isa<ViewLikeOpInterface>(op)) {
+      continue;
+    }
+    for (auto *user : op->getUsers()) {
+      auto copyOp = dyn_cast<memref::CopyOp>(user);
+      if (!copyOp) {
+        continue;
+      }
+      // Trace back the copy's source along the view-like chain
+      Value cur = copyOp.getSource();
+      while (auto viewOp = cur.getDefiningOp<ViewLikeOpInterface>()) {
+        chainOps.push_back(viewOp);
+        cur = viewOp.getViewSource();
+      }
+    }
+  }
+  return chainOps;
+}
+
+/**
  * @brief Try to unify block_id for a single alloc operation
  *
  * @param allocOp The memref.alloc operation to process
@@ -372,17 +408,24 @@ static LogicalResult tryUnifyForAlloc(memref::AllocOp allocOp,
     fillInfo = splitSCFIfIfNeeded(fillInfo);
   }
 
-  // Step5: Collect predecessor_ops for scf.if condition
+  // Step5: Collect source view chain ops from memref.copy's source subview.
+  // Trace back from each copy's source operand along the ViewLikeOpInterface
+  // chain (e.g., subview -> reinterpret_cast) so that the source data
+  // preparation and the copy itself land in the same block.
+  SmallVector<Operation *> sourceViewChainOps = collectSourceViewChainOps(directUsers);
+
+  // Step6: Collect predecessor_ops for scf.if condition
   SmallVector<Operation *> conditionOps =
       collectBlockPredecessors(fillInfo.parentIf.getCondition(), fillInfo.parentIf->getBlock());
 
-  // Step6: Cycle detection and block_id assignment with fallback
+  // Step7: Cycle detection and block_id assignment with fallback
   SmallVector<Operation *> coreOps = {
       allocOp.getOperation(),
       fillInfo.fillOp.getOperation(),
       fillInfo.parentIf.getOperation(),
   };
   coreOps.append(directUsers);
+  coreOps.append(sourceViewChainOps);
   SmallVector<Operation *> allOps = coreOps;
   // allOps include coreOps and scf.if_condition's predecessor_ops
   allOps.append(conditionOps);
@@ -402,6 +445,7 @@ static LogicalResult tryUnifyForAlloc(memref::AllocOp allocOp,
     }
   }
   return success();
+  LOG_DEBUG("Successfully Unify AllocOp: " << *allocOp << " to blockId: " << targetBlockId << "\n");
 }
 
 } // anonymous namespace

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/unify_alloc_block.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/unify_alloc_block.mlir
@@ -196,4 +196,58 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
     }
     return
   }
+
+  //===----------------------------------------------------------------------===//
+  // Test Case: @test_copy_source_subview_traceback
+  //===----------------------------------------------------------------------===//
+  // Pattern: trace back memref.copy's source subview to memref.reinterpret_cast
+  // Key scenario: The copy's source operand (%subview_src) is a subview of
+  //   %reinterpret_cast, which has a DIFFERENT block_id (5) from the copy (2).
+  //   The pass should trace back from the copy's source subview through the
+  //   view-like chain to the reinterpret_cast, and unify them to the copy's
+  //   block_id (2).
+  // Before:
+  //   %reinterpret_cast {block_id=5}                        // source base
+  //   %subview_src = subview %reinterpret_cast {block_id=5} // source subview
+  //   %subview_dst = subview %alloc {block_id=5}            // dst subview
+  //   memref.copy %subview_src, %subview_dst {block_id=2}
+  // After (source view chain unified to block_id=2):
+  //   %reinterpret_cast {block_id=2}
+  //   %subview_src {block_id=2}
+  //   %subview_dst {block_id=2}
+  //   memref.copy {block_id=2}
+  //   (alloc, fill, scf.if, condition deps also unified to block_id=2)
+  //===----------------------------------------------------------------------===//
+  // CHECK-LABEL: func.func @test_copy_source_subview_traceback
+  func.func @test_copy_source_subview_traceback(%arg0: memref<?xf16>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %cst = arith.constant 0.000000e+00 : f16
+
+    scf.for %arg17 = %c0 to %c32 step %c1 iter_args(%arg19 = %c0) -> (index) {
+      %c128 = arith.constant {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE"} 128 : index
+      %cond = arith.cmpi slt, %arg19, %c32 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
+      %alloc = memref.alloc() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16>
+      %140 = arith.addi %arg19, %c128 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
+      scf.if %cond {
+        linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : f16) outs(%alloc : memref<32x32xf16>)
+      } {hivm.unlikely_condition}
+
+      // Source view chain: reinterpret_cast and subview_src have block_id=5,
+      // should be unified to block_id=2 by tracing copy's source subview.
+      // CHECK: %{{.*}} = memref.reinterpret_cast {{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+      %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [%140], sizes: [32, 32], strides: [%c32, %c1] {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE"} : memref<?xf16> to memref<32x32xf16, strided<[?, ?], offset: ?>>
+      // CHECK: %{{.*}} = memref.subview {{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+      %subview_src = memref.subview %reinterpret_cast[0, 0] [%c32, %c32] [1, 1] {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16, strided<[?, ?], offset: ?>> to memref<?x?xf16, strided<[?, ?], offset: ?>>
+      // CHECK: %{{.*}} = memref.subview {{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+      %subview_dst = memref.subview %alloc[0, 0] [%c32, %c32] [1, 1] {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16> to memref<?x?xf16, strided<[32, 1]>>
+      
+      // CHECK: memref.copy{{.*}}{ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+      memref.copy %subview_src, %subview_dst {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<?x?xf16, strided<[?, ?], offset: ?>> to memref<?x?xf16, strided<[32, 1]>>
+
+      scf.yield %140 : index
+    }
+    return
+  }
 }


### PR DESCRIPTION
将copyOp的subviewOp，reinterpret_cast Op一起合并到同一个block。如下：

%reinterpret_cast = memref.reinterpret_cast %arg0 to ... {block_id=5}
%subview_src = memref.subview %reinterpret_cast[...] {block_id=2}
%subview_dst = memref.subview %alloc[...]            {block_id=2}
memref.copy %subview_src, %subview_dst               {block_id=2}

// 溯源后：源链统一到 block_id=2
%reinterpret_cast = memref.reinterpret_cast %arg0 to ... {block_id=2}
%subview_src = memref.subview %reinterpret_cast[...] {block_id=2}
%subview_dst = memref.subview %alloc[...]            {block_id=2}
memref.copy %subview_src, %subview_dst               {block_id=2}

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

