### PR TITLE
[ssbuffer](fix) fixpipe need to add when there are many users

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -434,10 +434,16 @@ int OpClassifierPass::patternMatchCUBE()
 
         // ---- Downstream pattern matching ----
         for (Value result : op->getResults()) {
+            if (!op->hasOneUse()) {
+                continue;
+            }
             for (Operation *user : result.getUsers()) {
                 // If user is scf.yield, follow the chain to find real users
                 Operation *curUser = user;
                 while (curUser) {
+                    if (!curUser->hasOneUse()) {
+                        break;
+                    }
                     if (auto yieldOp = dyn_cast<scf::YieldOp>(curUser)) {
                         if (Operation *scfOp = yieldOp->getParentOp()) {
                             // Find which operand index the previous result corresponds to in the yield


### PR DESCRIPTION
# Title: fixpipe need to add when there are many users

## Summary:
Fix an issue in patternMatchCUBE where downstream pattern matching incorrectly processed operations with multiple users. The fixpipe optimization should only apply when there is a single-user chain.

## Changes:
- Skip downstream pattern matching if the operation has multiple users (!op->hasOneUse())
- Break out of the yield chain traversal if an intermediate operation has multiple users

## Rationale:
When an operation result has multiple users, following the downstream chain for pattern matching can lead to incorrect fixpipe insertion. This patch ensures we only traverse single-use chains during downstream analysis.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
