### PR TITLE
[CI](fix) update default code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @HEX1A0A
+*       @KanuaK @WuTYSFG @hongziqi
 
 # --------
 # Analyses


### PR DESCRIPTION
## Related ISSUE
https://github.com/triton-lang/triton-ascend/issues/667

## Summary
This PR updates the `.github/CODEOWNERS` default rule (`*`), replacing the inactive owner `@HEX1A0A` with three active core developers: `@KanuaK`, `@WuTYSFG`, and `@hongziqi`.

The `*` rule is the **repository-wide fallback**: it applies to any file that is not matched by a more specific rule later in the file (GitHub uses last-match precedence). Paths such as `third_party/ascend/` already have dedicated entries and are **not** affected by this change.

Before:

```diff
-*       @HEX1A0A
```

After:

```diff
+*       @KanuaK @WuTYSFG @hongziqi
```

## Why this change is needed

1. **`@HEX1A0A` is no longer active on triton-ascend.** As the sole default owner, PRs touching uncovered paths (e.g. root-level configs, docs, CI files) could stall waiting for review from someone who is not available day-to-day.

2. **Single point of failure on the catch-all rule.** One inactive person as the default owner creates a review bottleneck for any path without a dedicated CODEOWNERS entry.

3. **Consistent with ascend maintainer ownership.** The same three maintainers already own `third_party/ascend/`. Using them as the default fallback keeps governance aligned and provides redundancy — any one of the three can review.

## Scope of impact

| Path type | Affected by this PR? | Reviewers after merge |
|---|---|---|
| Files with a more specific rule (e.g. `lib/Analysis/`, `third_party/ascend/`) | No — their dedicated owners still apply | Unchanged |
| Files without a dedicated rule (e.g. root `README`, `.github/workflows/`, top-level docs) | **Yes** | `@KanuaK`, `@WuTYSFG`, `@hongziqi` |

## User Impact

No code change. This is a repository governance update only. PRs that modify paths **without** a more specific CODEOWNERS entry will now request review from three active maintainers instead of one inactive maintainer.

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it only updates the CODEOWNERS governance file; no code or build behavior is affected.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
