### PR TITLE
[ssbuffer](fix) move linalg.fill pattern clone before scalar clone

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
@@ -1640,20 +1640,26 @@ static bool hasMemrefDepValue(DenseMap<Value, SmallVector<Value>> &depValueMap)
 static int addInnerMultiBuffer(mlir::scf::ForOp mainLoopForOp, OpBuilder &builder, scope::ScopeOp vectorScope,
                                int &groupId)
 {
-    // Break tensor-rooted cross-block scalar dependencies before collecting deps
-    rematerializeTensorRootedScalarDeps(mainLoopForOp);
-
     OpBuilder globalBuilder(mainLoopForOp.getContext());
 
-    // First pass: clone tensor::EmptyOp + linalg::FillOp patterns into each
-    // consumer's block. The cloned fill's `ins` chain can introduce fresh
-    // cross-block references (e.g. a producer-side tensor referenced by the
-    // cloned tensor.extract) that need multi-buffering. To avoid missing those
-    // deps, we do dep collection in two phases:
-    //   Phase 1 (initial): collect deps, build user map, then clone.
+    // Two-phase dep collection for empty+fill cloning:
+    //   Phase 1 (initial): collect deps, build user map, then clone the
+    //                      tensor::EmptyOp + linalg::FillOp pattern into each
+    //                      consumer's block. The cloned fill's `ins` chain can
+    //                      introduce fresh cross-block references (e.g. a
+    //                      producer-side tensor referenced by the cloned
+    //                      tensor.extract / arith.extf).
+    //   Scalar rematerialize: trace each cloned fill's `ins` chain. If the
+    //                        chain reaches a producer-side tensor (via
+    //                        tensor.extract / arith.extf), build a fresh
+    //                        block-local chain that reads from a new
+    //                        multi-buffer added in Phase 2.
     //   Phase 2 (re-collect): re-run collectInnerBlockInfo / buildDepUserMap
-    //                        so the new cross-block refs (created by Phase 1's
-    //                        clones) are visible to processTensorDependencies.
+    //                        so the new cross-block refs (from clone + scalar
+    //                        rematerialize) are visible to the multi-buffer
+    //                        pipeline. The multi-buffer transfer structure
+    //                        (allocs, scf.if, intraDeps, intra_buffer) is
+    //                        created here and is not affected by the reorder.
     DenseMap<Value, InnerBlockInfo> blocks;
     DenseMap<Value, SmallVector<Value>> depValueMap;
     SmallVector<Operation *> allOps;
@@ -1670,9 +1676,17 @@ static int addInnerMultiBuffer(mlir::scf::ForOp mainLoopForOp, OpBuilder &builde
     if (cloneEmptyFillsInBlocks(mainLoopForOp, blocks, depValueMap, initialDepUserMap, globalBuilder) != 0)
         return -1;
 
-    // Phase 2: re-collect deps now that cloned ops have created new
-    // cross-block references. depValueMap and allOps are cleared inside
-    // collectInnerBlockInfo, so we re-discover everything from scratch.
+    // Break tensor-rooted cross-block scalar dependencies AFTER the empty+fill
+    // clone. The clone can introduce fresh scalar refs (e.g. a cloned
+    // arith.extf whose operand is a producer-side tensor.extract) that need to
+    // be rematerialized to a block-local chain reading from a Phase-2
+    // multi-buffer. Running this before the clone leaves these refs invisible.
+    rematerializeTensorRootedScalarDeps(mainLoopForOp);
+
+    // Phase 2: re-collect deps now that cloned ops (and rematerialized scalar
+    // chains) have created new cross-block references. depValueMap and allOps
+    // are cleared inside collectInnerBlockInfo, so we re-discover everything
+    // from scratch.
     blocks.clear();
     depValueMap.clear();
     allOps.clear();


### PR DESCRIPTION
This pull request is designed to move tensor.empty + linalg.fill pattern clone before scalar clone.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
