### PR TITLE
use sync_block_block_unordered in DiscreteMaskConversion

### DIFF
--- a/third_party/ascend/backend/backend_register.py
+++ b/third_party/ascend/backend/backend_register.py
@@ -299,11 +299,11 @@ def allocate_memory(size, stream):
 @backend_strategy_registry.register("torch_npu", "allocate_memory")
 def allocate_memory(size, stream):
     return f'''init_npu_utils();
-    if (!g_allocate_workspace_legacy) {{
-      fprintf(stderr, "Error: triton_allocate_workspace_legacy is unavailable\\n");
+    if (!g_allocate_workspace) {{
+      fprintf(stderr, "Error: triton_allocate_workspace is unavailable\\n");
       workspace_addr_ptr = nullptr;
     }} else {{
-      workspace_addr_ptr = g_allocate_workspace_legacy({size});
+      workspace_addr_ptr = g_allocate_workspace({size}, &workspace_handle);
     }}'''
 
 

--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -165,7 +165,6 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
         enable_select_analysis = metadata["enable_select_analysis"]
         compile_on_910_95 = metadata["compile_on_910_95"]
         force_simt_template = metadata["force_simt_template"]
-        enable_sync_block_lock = metadata["enable_sync_block_lock"]
         enable_mask_fallback_conversion = metadata["enable_mask_fallback_conversion"]
         optimize_dynamic_offset = metadata["optimize_dynamic_offset"]
         auto_blockify_size = metadata["auto_blockify_size"]
@@ -190,8 +189,7 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
         ascend.passes.ttir.add_discrete_mask_access_conversion(
             pm,
             compile_on_910_95,
-            force_simt_template,
-            enable_sync_block_lock
+            force_simt_template
         )
         ascend.passes.ttir.add_triton_to_annotation(pm)
         ascend.passes.ttir.add_triton_to_unstructure(
@@ -299,11 +297,22 @@ def _parse_linalg_metadata(linalg: str, metadata: dict):
     metadata["shared"] = 1
     # Force disable auto tile and bind subblock if attribute is present in module
     metadata["auto_tile_and_bind_subblock"] = not re.search(DISABLE_AUTO_TILE_AND_BIND_SUBBLOCK_REGEX, linalg)
-    # Turn off auto-blockify when sync_block_lock/unlock was inserted: the lock
-    # protects a cross-block read-modify-write and is incompatible with packing
-    # logical blocks into a sequential auto-blockify loop.
-    if re.search(SYNC_BLOCK_LOCK_REGEX, linalg):
+    # Turn off auto-blockify only for the ORDERED (token-ring) sync_block_lock:
+    if re.search(SYNC_BLOCK_LOCK_REGEX, linalg) and not re.search(
+            r"sync_block_lock_unordered", linalg):
         metadata["has_auto_blockify_blacklist_op"] = True
+    # The unordered (Bakery) discrete-mask lock cannot coexist with CV sub-tiling
+    # (auto-bind-sub-block)
+    has_unordered_sync_block_lock = re.search(r"sync_block_lock_unordered", linalg) is not None
+    metadata["has_unordered_sync_block_lock"] = has_unordered_sync_block_lock
+    if has_unordered_sync_block_lock:
+        metadata["auto_tile_and_bind_subblock"] = False
+        # One metadata cache line for runtime participant_num, plus one
+        # choosing and one ticket cache line per participant. Each cache line is
+        # 8 i64. This fallback is for one lock; the bishengir callback supplies
+        # the exact total after lowering.
+        metadata["lock_num"] = (1 + 2 * 1024) * 8
+        metadata["lock_init_val"] = 0
     # the mix mode is also encoded into metadata['name'] for runtime to distinguish
     metadata["mix_mode"] = re.search(MIX_MODE_REGEX, linalg).group(1)
     metadata["parallel_mode"] = re.search(PARALLEL_MODE_REGEX, linalg).group(1)
@@ -971,7 +980,6 @@ class NPUOptions:
     parallel_mode: str = "simd"
     force_simt_only: bool = False
     force_simt_template: bool = False
-    enable_sync_block_lock: bool = False
     # only take effect on the simt-only & simd-simt-mix scenarios
     shared_mem_dynamic_size: int = None
     # enable_bishengir_simt_optimization is passed as

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -351,6 +351,33 @@ def generate_npu_wrapper_src(constants, signature, metadata):
     )
     lock_num = int(metadata.lock_num) \
                           if hasattr(metadata, 'lock_num') else -1
+    has_unordered_sync_block_lock = bool(getattr(
+        metadata, "has_unordered_sync_block_lock", False))
+    unordered_sync_block_lock_stride_i64 = (1 + 2 * 1024) * 8
+    # Zero the sync_block_lock buffer ON THE COMPUTE STREAM.
+    if has_unordered_sync_block_lock and lock_num > 0:
+        lock_init_stmt = f"""
+    std::vector<int64_t> lockInitData({lock_num}, 0);
+    constexpr uint64_t syncBlockLockStrideI64 = {unordered_sync_block_lock_stride_i64};
+    int64_t syncBlockLockParticipantNum = static_cast<int64_t>(
+        std::min(blockNum, static_cast<uint32_t>(1024)));
+    for (uint64_t lockOffset = 0; lockOffset < {lock_num};
+         lockOffset += syncBlockLockStrideI64) {{
+      lockInitData[lockOffset] = syncBlockLockParticipantNum;
+    }}
+    ret = rtMemcpy(syncBlockLock_ptr, syncBlockLockSize,
+                   reinterpret_cast<void *>(lockInitData.data()),
+                   syncBlockLockSize, RT_MEMCPY_HOST_TO_DEVICE);"""
+    elif lock_init_value == 0:
+        lock_init_stmt = (
+            "ret = rtMemsetAsync(syncBlockLock_ptr, syncBlockLockSize, 0, "
+            "syncBlockLockSize, stream);")
+    else:
+        lock_init_stmt = (
+            f"std::vector<int64_t> lockInitData({lock_num}, {lock_init_value});\n"
+            "    ret = rtMemcpy(syncBlockLock_ptr, syncBlockLockSize, "
+            "reinterpret_cast<void *>(lockInitData.data()), syncBlockLockSize, "
+            "RT_MEMCPY_HOST_TO_DEVICE);")
     bs_task_type = metadata.bs_task_type if hasattr(metadata, 'bs_task_type') else 0
     mix_mode = metadata.mix_mode
     compile_on_910_95 = metadata.compile_on_910_95
@@ -485,18 +512,18 @@ def generate_npu_wrapper_src(constants, signature, metadata):
     npu_utils_mod = getattr(npu_utils_inst, "npu_utils_mod", None)
     npu_utils_so_path = getattr(npu_utils_mod, "__file__", "")
     cpp_npu_utils_dlopen = f"""
-typedef void* (*triton_allocate_workspace_legacy_t)(uint64_t);
+typedef void* (*triton_allocate_workspace_t)(uint64_t, void**);
 typedef void* (*triton_allocate_sync_block_lock_t)(uint64_t, void*, void**);
 typedef void  (*triton_async_launch_t)(void*, const char*);
 typedef void  (*triton_release_retained_tensor_t)(void*);
 
-static triton_allocate_workspace_legacy_t g_allocate_workspace_legacy = nullptr;
+static triton_allocate_workspace_t g_allocate_workspace = nullptr;
 static triton_allocate_sync_block_lock_t g_allocate_sync_block_lock = nullptr;
 static triton_async_launch_t g_async_launch = nullptr;
 static triton_release_retained_tensor_t g_release_retained_tensor = nullptr;
 
 static bool npu_utils_ready() {{
-    return g_allocate_workspace_legacy &&
+    return g_allocate_workspace &&
            g_allocate_sync_block_lock &&
            g_async_launch &&
            g_release_retained_tensor;
@@ -510,7 +537,7 @@ static void init_npu_utils() {{
         fprintf(stderr, "Error: dlopen %s failed: %s\\n", so_path, dlerror());
         return;
     }}
-    g_allocate_workspace_legacy = (triton_allocate_workspace_legacy_t)dlsym(handle, "triton_allocate_workspace_legacy");
+    g_allocate_workspace = (triton_allocate_workspace_t)dlsym(handle, "triton_allocate_workspace");
     g_allocate_sync_block_lock = (triton_allocate_sync_block_lock_t)dlsym(handle, "triton_allocate_sync_block_lock");
     g_async_launch = (triton_async_launch_t)dlsym(handle, "triton_async_launch");
     g_release_retained_tensor = (triton_release_retained_tensor_t)dlsym(handle, "triton_release_retained_tensor");
@@ -842,12 +869,14 @@ void triton_launch_kernel(
   std::string name = "";
   name.append(kernelName);
   void *workspace_addr_ptr = NULL;
+  void *workspace_handle = NULL;
   {coalesce_grid_div}
   uint32_t blockNum4Workspace = gridX * gridY * gridZ;
   {get_backend_func("pre_launch", True)}
   {f'''
   uint64_t totalWorkSpaceSize = {workspace_size} * blockNum4Workspace;
   {get_backend_func("allocate_memory", "totalWorkSpaceSize", "stream")}
+  std::shared_ptr<void> workspace_handle_guard(workspace_handle, release_npu_tensor_handle);
   if (!workspace_addr_ptr) {{
     {workspace_fail_code}
   }}
@@ -883,12 +912,7 @@ void triton_launch_kernel(
     if (!syncBlockLock_ptr) {{
       {alloc_success_code if enable_taskqueue else sync_lock_fail_code}
     }}
-    std::vector<int64_t> lockInitData({lock_num}, {lock_init_value});
-    ret = rtMemcpy(
-        syncBlockLock_ptr, syncBlockLockSize,
-        reinterpret_cast<void *>(lockInitData.data()), syncBlockLockSize,
-        RT_MEMCPY_HOST_TO_DEVICE
-    );
+    {lock_init_stmt}
     if (ret != RT_ERROR_NONE) {{
       return {'ret' if enable_taskqueue else ''};
     }}
@@ -950,12 +974,14 @@ static void _launch(const char* kernelName, const void* func, rtStream_t stream,
   std::string name = "";
   name.append(kernelName);
   void *workspace_addr_ptr = NULL;
+  void *workspace_handle = NULL;
   {coalesce_grid_div}
   uint32_t blockNum4Workspace = gridX * gridY * gridZ;
   {get_backend_func("pre_launch", True)}
   {f'''
   uint64_t totalWorkSpaceSize = {workspace_size} * blockNum4Workspace;
   {get_backend_func("allocate_memory", "totalWorkSpaceSize", "stream")}
+  std::shared_ptr<void> workspace_handle_guard(workspace_handle, release_npu_tensor_handle);
   if (!workspace_addr_ptr) {{
     {workspace_fail_code}
   }}
@@ -989,12 +1015,7 @@ static void _launch(const char* kernelName, const void* func, rtStream_t stream,
     if (!syncBlockLock_ptr) {{
       {alloc_success_code if enable_taskqueue else sync_lock_fail_code}
     }}
-    std::vector<int64_t> lockInitData({lock_num}, {lock_init_value});
-    ret = rtMemcpy(
-        syncBlockLock_ptr, syncBlockLockSize,
-        reinterpret_cast<void *>(lockInitData.data()), syncBlockLockSize,
-        RT_MEMCPY_HOST_TO_DEVICE
-    );
+    {lock_init_stmt}
     if (ret != RT_ERROR_NONE) {{
       return {'ret' if enable_taskqueue else ''};
     }}

--- a/third_party/ascend/backend/npu_utils.cpp
+++ b/third_party/ascend/backend/npu_utils.cpp
@@ -330,29 +330,33 @@ static PyObject* copyMemory(PyObject* self, PyObject* args) {
 
 #ifdef USE_TORCH_NPU
 struct RetainedTensorHandle {
-  explicit RetainedTensorHandle(at::Tensor tensor)
-      : tensor(std::move(tensor)),
+  RetainedTensorHandle(at::Tensor tensor, const char *kind, uint64_t size)
+      : tensor(std::move(tensor)), kind(kind), size(size),
         data(const_cast<void*>(this->tensor.storage().data())) {}
 
   at::Tensor tensor;
+  const char *kind;
+  uint64_t size;
   void *data;
 };
 
-static void *retainTensor(at::Tensor tensor, void **handle) {
+static void *retainTensor(at::Tensor tensor, void **handle, const char *kind, uint64_t size) {
   if (handle == nullptr) {
     return nullptr;
   }
-  auto *retained = new RetainedTensorHandle(std::move(tensor));
+  auto *retained = new RetainedTensorHandle(std::move(tensor), kind, size);
   *handle = retained;
   return retained->data;
 }
 
-extern "C" void* triton_allocate_workspace_legacy(uint64_t size)
+extern "C" void* triton_allocate_workspace(uint64_t size, void **handle)
 {
-  return const_cast<void*>(
-      at::empty(size, at::TensorOptions().device(at::kPrivateUse1).dtype(at::kByte))
-          .storage()
-          .data());
+  if (handle == nullptr) {
+    return nullptr;
+  }
+  *handle = nullptr;
+  auto tensor = at::empty(size, at::TensorOptions().device(at::kPrivateUse1).dtype(at::kByte));
+  return retainTensor(std::move(tensor), handle, "workspace", size);
 }
 
 extern "C" void* triton_allocate_sync_block_lock(uint64_t size, void* stream, void **handle)
@@ -362,7 +366,7 @@ extern "C" void* triton_allocate_sync_block_lock(uint64_t size, void* stream, vo
   }
   *handle = nullptr;
   auto tensor = at_npu::native::allocate_workspace(size, reinterpret_cast<rtStream_t>(stream));
-  return retainTensor(std::move(tensor), handle);
+  return retainTensor(std::move(tensor), handle, "sync_block_lock", size);
 }
 
 extern "C" void triton_release_retained_tensor(void *handle)

--- a/third_party/ascend/include/DiscreteMaskAccessConversion/Passes.td
+++ b/third_party/ascend/include/DiscreteMaskAccessConversion/Passes.td
@@ -17,10 +17,7 @@ def DiscreteMaskAccessConversion : Pass<"discrete-mask-access-conversion", "mlir
         "compile on 910_95">,
     Option<"forceSimtTemplate", "force-simt-template",
         "bool", /*default*/"false",
-        "force to use simt template">,
-    Option<"enableSyncBlockLock", "enable-sync-block-lock",
-        "bool", /*default*/"true",
-        "enable sync block lock/unlock in store">
+        "force to use simt template">
   ];
 }
 

--- a/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
+++ b/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
@@ -53,9 +53,14 @@ using namespace hivm;
 // before pattern application, so that OpRewritePattern subclasses can read them.
 static bool compileOn91095Flag = false;
 static bool forceSimtTemplateFlag = false;
-static bool enableSyncBlockLockFlag = true;
+static bool useSyncBlockLockFlag = true;
 static constexpr const char *routeDiscreteMaskToSimtAttrName =
     "route_discrete_mask_to_simt";
+
+static void markSyncBlockLockUnordered(Operation *op) {
+  op->setAttr(hivm::SyncBlockLockUnorderedAttr::name,
+              UnitAttr::get(op->getContext()));
+}
 
 static bool traceUserToTargetOp(Value val) {
   llvm::SmallVector<Value, 32> worklist;
@@ -289,7 +294,8 @@ struct DiscreteMaskStoreConversion : OpRewritePattern<triton::StoreOp> {
     auto ptr = op.getPtr();
     auto ptrType = dyn_cast<RankedTensorType>(ptr.getType());
     bool rankWithinIndirectFastPathLimit = ptrType && ptrType.getShape().size() <= 5;
-    if (compileOn91095Flag && forceSimtTemplateFlag && rankWithinIndirectFastPathLimit) {
+    if (!useSyncBlockLockFlag && compileOn91095Flag && forceSimtTemplateFlag &&
+        rankWithinIndirectFastPathLimit) {
       return failure();
     }
 
@@ -298,10 +304,14 @@ struct DiscreteMaskStoreConversion : OpRewritePattern<triton::StoreOp> {
     // unguarded full-load from reading past the tail-block boundary.
     auto [contMask, discMask] = decomposeAndMask(op, mask, loc, rewriter);
     if (contMask && discMask) {
-      // insert sync_block_lock
+      // insert sync_block_lock (unordered: see markSyncBlockLockUnordered)
       auto lockVar = MemOpConverter::createSyncBlockLockVar(rewriter, loc);
-      if (enableSyncBlockLockFlag) {
-        rewriter.create<hivm::SyncBlockLockOp>(loc, lockVar);
+      markSyncBlockLockUnordered(lockVar.getOperation());
+      if (useSyncBlockLockFlag) {
+        rewriter.create<hivm::PipeBarrierOp>(
+            loc, hivm::PipeAttr::get(rewriter.getContext(), hivm::PIPE::PIPE_ALL));
+        auto lockOp = rewriter.create<hivm::SyncBlockLockOp>(loc, lockVar);
+        markSyncBlockLockUnordered(lockOp.getOperation());
       }
       auto safeLoad = rewriter.create<triton::LoadOp>(
           loc, dst, contMask, op.getCache(), op.getEvict(), false);
@@ -311,18 +321,23 @@ struct DiscreteMaskStoreConversion : OpRewritePattern<triton::StoreOp> {
           loc, dst, selOp, contMask, op.getCache(), op.getEvict());
       newStore->setAttr(ConverterUtils::discreteMaskAttrName,
                         UnitAttr::get(rewriter.getContext()));
-      if (enableSyncBlockLockFlag) {
-        rewriter.create<hivm::SyncBlockUnlockOp>(loc, lockVar);
+      if (useSyncBlockLockFlag) {
+        auto unlockOp = rewriter.create<hivm::SyncBlockUnlockOp>(loc, lockVar);
+        markSyncBlockLockUnordered(unlockOp.getOperation());
       }
       rewriter.replaceOp(op, newStore);
       return success();
     }
 
     // Fallback: original full load + select (contMask absent, pure discrete).
-    // insert sync_block_lock
+    // insert sync_block_lock (unordered: see markSyncBlockLockUnordered)
     auto lockVar = MemOpConverter::createSyncBlockLockVar(rewriter, loc);
-    if (enableSyncBlockLockFlag) {
-      rewriter.create<hivm::SyncBlockLockOp>(loc, lockVar);
+    markSyncBlockLockUnordered(lockVar.getOperation());
+    if (useSyncBlockLockFlag) {
+      rewriter.create<hivm::PipeBarrierOp>(
+          loc, hivm::PipeAttr::get(rewriter.getContext(), hivm::PIPE::PIPE_ALL));
+      auto lockOp = rewriter.create<hivm::SyncBlockLockOp>(loc, lockVar);
+      markSyncBlockLockUnordered(lockOp.getOperation());
     }
     auto loadFromDstOp = rewriter.create<triton::LoadOp>(
         loc, dst, op.getCache(), op.getEvict(), false);
@@ -332,8 +347,9 @@ struct DiscreteMaskStoreConversion : OpRewritePattern<triton::StoreOp> {
         loc, dst, selOp, op.getCache(), op.getEvict());
     newStore->setAttr(ConverterUtils::discreteMaskAttrName,
                       UnitAttr::get(rewriter.getContext()));
-    if (enableSyncBlockLockFlag) {
-      rewriter.create<hivm::SyncBlockUnlockOp>(loc, lockVar);
+    if (useSyncBlockLockFlag) {
+      auto unlockOp = rewriter.create<hivm::SyncBlockUnlockOp>(loc, lockVar);
+      markSyncBlockLockUnordered(unlockOp.getOperation());
     }
     rewriter.replaceOp(op, newStore);
     return success();
@@ -357,7 +373,8 @@ struct DiscreteMaskLoadConversion : OpRewritePattern<triton::LoadOp> {
 
     auto ptrType = dyn_cast<RankedTensorType>(ptr.getType());
     bool rankWithinIndirectFastPathLimit = ptrType && ptrType.getShape().size() <= 5;
-    if (compileOn91095Flag && forceSimtTemplateFlag && rankWithinIndirectFastPathLimit) {
+    if (!useSyncBlockLockFlag && compileOn91095Flag && forceSimtTemplateFlag &&
+        rankWithinIndirectFastPathLimit) {
       return failure();
     }
 
@@ -462,9 +479,9 @@ DiscreteMaskAccessConversionPass::DiscreteMaskAccessConversionPass(
 void DiscreteMaskAccessConversionPass::runOnOperation() {
   compileOn91095Flag = this->compileOn91095;
   forceSimtTemplateFlag = this->forceSimtTemplate;
-  bool tileNonOverlap = checkAllProgramIdNonOverlap(getOperation());
-  enableSyncBlockLockFlag = !tileNonOverlap;
   auto moduleOp = getOperation();
+  bool tileNonOverlap = checkAllProgramIdNonOverlap(moduleOp);
+  useSyncBlockLockFlag = !tileNonOverlap;
 
   RewritePatternSet patterns(&getContext());
   patterns.add<DiscreteMaskLoadConversion, DiscreteMaskStoreConversion,

--- a/third_party/ascend/triton_ascend.cc
+++ b/third_party/ascend/triton_ascend.cc
@@ -353,11 +353,10 @@ void init_triton_ascend_passes_ttir(py::module &&m) {
   });
 
   m.def("add_discrete_mask_access_conversion", [](mlir::PassManager &pm,
-    bool compileOn91095, bool forceSimtTemplate, bool enableSyncBlockLock) {
+    bool compileOn91095, bool forceSimtTemplate) {
     DiscreteMaskAccessConversionOptions opts;
     opts.compileOn91095 = compileOn91095;
     opts.forceSimtTemplate = forceSimtTemplate;
-    opts.enableSyncBlockLock = enableSyncBlockLock;
     pm.addPass(mlir::triton::createDiscreteMaskAccessConversionPass(opts));});
 
   m.def("add_triton_to_hivm", [](mlir::PassManager &pm) {

--- a/third_party/ascend/unittest/pytest_ut/test_discrete_overlap_mask.py
+++ b/third_party/ascend/unittest/pytest_ut/test_discrete_overlap_mask.py
@@ -181,7 +181,6 @@ def _run_once(BLOCK_N: int, dtype_str: str) -> None:
         C_row_stride=C.stride(0), C_col_stride=C.stride(1),
         BLOCK_N=BLOCK_N,
         HALF=_HALF,
-        enable_sync_block_lock=True,
     )
 
     # Verification


### PR DESCRIPTION
use sync_block_lock_unordered in discrete mask conversion . The lock does't require block must be locked in order , and will not introduce dead lock when working working with autoblockify .

