### PR TITLE
[ssbuffer](fix) Consider memref dependency when checking seed only user

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -28,6 +28,8 @@
 #include "mlir/IR/Value.h"
 #include "llvm/ADT/StringRef.h"
 
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+
 namespace mlir {
 namespace CVPipeline {
 
@@ -79,6 +81,7 @@ llvm::LogicalResult verifyOpBlockId(Operation *op);
 int getAvailableBlockId(ModuleOp module);
 void setFallbackAttr(ModuleOp module);
 bool isScfOp(Operation *op);
+bool isOnlyDirectlyUse(Operation *preOp, Operation *nextOp, const CVPipeline::MemoryDependenceGraph &memGraph);
 
 inline bool isCubeOp(Operation *op)
 {

--- a/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlockPass.h
+++ b/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlockPass.h
@@ -45,7 +45,7 @@ class PlanCubeBlockPass : public PassWrapper<PlanCubeBlockPass, OperationPass<Mo
     llvm::StringRef getArgument() const final { return "plan-cube-block"; }
 
   private:
-    SmallVector<Operation *> matchSeed(Operation *dotOp, CVPipeline::ComputeBlockIdManager &bm);
+    SmallVector<Operation *> matchSeed(Operation *dotOp, CVPipeline::ComputeBlockIdManager &bm, const CVPipeline::MemoryDependenceGraph &memGraph);
     llvm::LogicalResult processBlockWithCubeBFS(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph,
                                                 CVPipeline::ComputeBlockIdManager &bm);
 };

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -10,8 +10,10 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Operation.h"
 
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+
 namespace mlir {
 namespace CVPipeline {
 
@@ -29,9 +31,6 @@ CoreType getOpCoreType(Operation *op)
 llvm::LogicalResult verifyOpBlockId(Operation *op)
 {
     if (!op) {
-        assert(false && "Op is nullptr, please check calling function");
-
-        // return failure to signal disabling of CV dynamic pipeline in release mode
         return llvm::failure();
     }
 
@@ -57,6 +56,9 @@ llvm::LogicalResult verifyOpBlockId(Operation *op)
 
 std::optional<int64_t> getOpBlockId(Operation *op)
 {
+    if (!op) {
+        return std::nullopt;
+    }
     auto blockIdAttr = op->getAttrOfType<IntegerAttr>(kBlockId);
     if (!blockIdAttr) {
         return std::nullopt;
@@ -102,6 +104,22 @@ bool isVectorOnlyOp(Operation *op)
 bool isScfOp(Operation *op)
 {
   return llvm::isa<scf::SCFDialect>(op->getDialect());
+}
+
+// Check nextOp is only user of preOp
+bool isOnlyDirectlyUse(Operation *preOp, Operation *nextOp, const CVPipeline::MemoryDependenceGraph &memGraph) {
+    if (!preOp || !nextOp) {
+        return false;
+    }
+    SmallVector<Operation *> allusers;
+    allusers.append(preOp->getUsers().begin(), preOp->getUsers().end());
+    for (auto memUser : memGraph.getExecAfter(preOp)) {
+        allusers.push_back(memUser);
+    }
+    if (allusers.size() != 1) {
+        return false;
+    }
+    return (*allusers.begin()) == nextOp;
 }
 
 } // namespace CVPipeline

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
@@ -113,6 +113,9 @@ bool DependencyCycleDetector::dfs(Operation *cur)
     allusers.append(memGraph.getExecAfter(cur).begin(), memGraph.getExecAfter(cur).end());
     for (auto *user : allusers) {
         auto *userInBlock = CVPipeline::getAncestorInBlock(user, block);
+        if (!userInBlock) {
+            continue;
+        }
         if (bm.getBlockIdByOp(userInBlock) == -1) {
             if (dfs(userInBlock)) {
                 return true;

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.cpp
@@ -81,6 +81,9 @@ int ComputeBlockIdManager::getNextId()
 
 void ComputeBlockIdManager::updateBlockId(Operation *op, int blockId)
 {
+    if (!op) {
+        return;
+    }
     // Force Update.
     MLIRContext *ctx = op->getContext();
     if (blockId == -1) {

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
@@ -535,7 +535,7 @@ static bool checkValidUserSeed(Operation* op) {
     // keep unify to OpClassifer
     return isa<hivm::StoreOp, bufferization::MaterializeInDestinationOp, ViewLikeOpInterface, tensor::ExtractSliceOp>(op);
 }
-SmallVector<Operation*> PlanCubeBlockPass::matchSeed(Operation* dotOp, ComputeBlockIdManager &bm)
+SmallVector<Operation*> PlanCubeBlockPass::matchSeed(Operation* dotOp, ComputeBlockIdManager &bm, const MemoryDependenceGraph &memGraph)
 {
     // match inputs
     SmallVector<Operation*> ret;
@@ -546,7 +546,7 @@ SmallVector<Operation*> PlanCubeBlockPass::matchSeed(Operation* dotOp, ComputeBl
             continue;
         if (checkValidInputSeed(def) && isCubeOp(def) && dotOp->getBlock() == def->getBlock() &&
             bm.getBlockIdByOp(def) == -1) {
-            if (def->hasOneUse()) {
+            if (CVPipeline::isOnlyDirectlyUse(def, dotOp, memGraph)) {
                 ret.push_back(def);
             }
         }
@@ -583,7 +583,7 @@ llvm::LogicalResult PlanCubeBlockPass::processBlockWithCubeBFS(Block *block, con
             continue;
         }
         auto temBlockId = bm.getNextId();
-        llvm::SmallVector<Operation*> dotSeeds = matchSeed(dot, bm);
+        llvm::SmallVector<Operation*> dotSeeds = matchSeed(dot, bm, memGraph);
         if (willCreateCycle(dotSeeds, memGraph, temBlockId, bm)) {
             LOG_DEBUG("Cube Seed already have a cycle!!");
             for(auto seed: dotSeeds) {


### PR DESCRIPTION
## Changes
1. Modification of potential code safety issues
2. Consider memref dependency when checking seed only

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
