### PR TITLE
[ENABLE_UNPUBLISHED_FEATURE](fix) delete useless environment variables.

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -36,7 +36,6 @@ from triton.backends.ascend.utils import (
     _check_bishengir_api_change,
     _check_bishengir_able_save_ir,
     _check_bishengir_is_regbased,
-    _enable_unpublished_feature,
     _enable_print_ub_bits,
     _enable_dump_memory_info,
     _get_kernel_target,

--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -291,10 +291,6 @@ def _warn_auto_blockify_disabled(kernel_name: str, blacklist_reasons) -> None:
     )
 
 
-def _enable_unpublished_feature() -> bool:
-    return os.getenv("ENABLE_UNPUBLISHED_FEATURE", "false").lower() in ("true", "1")
-
-
 def _enable_print_ub_bits() -> bool:
     return os.getenv("ENABLE_PRINT_UB_BITS", "false").lower() in ("true", "1")
 

--- a/third_party/ascend/unittest/costmodel_ut/test_compiler_costmodel_contract.py
+++ b/third_party/ascend/unittest/costmodel_ut/test_compiler_costmodel_contract.py
@@ -31,7 +31,6 @@ class CompilerCostmodelContractTest(unittest.TestCase):
             "_check_bishengir_api_change",
             "_check_bishengir_able_save_ir",
             "_check_bishengir_is_regbased",
-            "_enable_unpublished_feature",
             "_enable_print_ub_bits",
             "_enable_dump_memory_info",
             "_get_kernel_target",


### PR DESCRIPTION
There exists an actual unused environment variable named ENABLE_UNPUBLISHED_FEATURE. This environment variable is used to enable unpublished/unreviewed feature paths and is easily suspected of being a backdoor behavior.
Now delete this environment variables.
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
