### PR TITLE
[ssbuffer](fix) Delay ops with yield users in topological ordering

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
@@ -180,8 +180,10 @@ struct GroupAdjacencyGraph {
     SmallVector<int> groupIds;
     SmallVector<SmallVector<unsigned>> succs;
     SmallVector<unsigned> inDeg;
+    DenseMap<int, SmallVector<Operation *>> groupOps;
     GroupAdjacencyGraph(const BlockOpGraph &g, const DenseMap<Operation *, int> &opBlockId);
     llvm::FailureOr<SmallVector<int>> computeTopologicalOrder();
+    unsigned selectGroup(SmallVector<unsigned> &ready);
 };
 
 } // namespace
@@ -198,6 +200,7 @@ GroupAdjacencyGraph::GroupAdjacencyGraph(const BlockOpGraph &g, const DenseMap<O
     DenseSet<int> seenIds;
     for (Operation *op : g.ops) {
         int id = opBlockId.at(op);
+        groupOps[id].push_back(op);
         if (seenIds.insert(id).second) {
             groupIds.push_back(id);
         }
@@ -240,6 +243,36 @@ GroupAdjacencyGraph::GroupAdjacencyGraph(const BlockOpGraph &g, const DenseMap<O
 }
 
 /**
+ * In order to delay ops that update scf.yield arguments as late as possible, 
+ * prioritizing groups whose ops do not have yield users.
+ */
+unsigned GroupAdjacencyGraph::selectGroup(SmallVector<unsigned> &ready)
+{
+    for (unsigned i = 0; i < ready.size(); ++i) {
+        int groupId = groupIds[ready[i]];
+        auto &ops = groupOps[groupId];
+        bool allUsersNotYield = true;
+        for (Operation *op : ops) {
+            for (Operation *user : op->getUsers()) {
+                if (isa<scf::YieldOp>(user)) {
+                    allUsersNotYield = false;
+                    break;
+                }
+            }
+            if (!allUsersNotYield) {
+                break;
+            }
+        }
+        if (allUsersNotYield) {
+            unsigned selected = ready[i];
+            ready.erase(ready.begin() + i);
+            return selected;
+        }
+    }
+    return ready.pop_back_val();
+}
+
+/**
  * Step 2: Perform a topological sort (Kahn's Algorithm) on the group graph.
  * Returns the group IDs in an order that satisfies all dependencies.
  */
@@ -256,7 +289,7 @@ llvm::FailureOr<SmallVector<int>> GroupAdjacencyGraph::computeTopologicalOrder()
     }
 
     while (!ready.empty()) {
-        auto cur = ready.pop_back_val();
+        auto cur = selectGroup(ready);
 
         result.push_back(groupIds[cur]);
 


### PR DESCRIPTION
# Title: Delay ops with yield users in topological ordering

## Summary
Modify the group selection strategy in `computeTopologicalOrder` to prioritize groups whose operations do not have `scf.yield` users. This delays operations that update yield arguments to execute as late as possible in the schedule.

## Changes
- Added `groupOps` member to `GroupAdjacencyGraph` to track operations belonging to each group
- Added `selectGroup()` method that iterates through ready groups and selects the first group where all operations have no yield users
- Modified `computeTopologicalOrder()` to use `selectGroup()` instead of `pop_back_val()`

## Motivation
Operations that feed `scf.yield` arguments represent values that need to persist across loop iterations. By scheduling these operations later, we can potentially improve register pressure and enable more optimization opportunities.


# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
