### PR TITLE
[SSBuffer](feat)  add null checks for SeparateMemoryFromCompute pass

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -8,6 +8,8 @@
 #include "ascend/include/DiscreteMaskAccessConversion/Passes.h"
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition.h"
 #include "ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h"
+#include "ascend/include/DynamicCVPipeline/SeparateMemoryFromCompute/AsyncLoadHoistingPass.h"
+#include "ascend/include/DynamicCVPipeline/SeparateMemoryFromCompute/AddMultiBufferToGMLoadPass.h"
 #include "ascend/include/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.h"
 #include "ascend/include/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.h"
 #include "ascend/include/DynamicCVPipeline/Passes.h"
@@ -115,6 +117,8 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::registerPlanComputeBlockPasses();
   mlir::triton::registerOpClassifierPass();
   mlir::triton::registerRefineArgsBlockIdPasses();
+  mlir::triton::registerAsyncLoadHoistingPasses();
+  mlir::triton::registerAddMultiBufferToGMLoadPasses();
 
 
   // TODO: register Triton & TritonGPU passes

--- a/third_party/ascend/include/DynamicCVPipeline/SeparateMemoryFromCompute/AddMultiBufferToGMLoadPass.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SeparateMemoryFromCompute/AddMultiBufferToGMLoadPass.h
@@ -63,6 +63,9 @@ private:
 // Create the pass
 std::unique_ptr<OperationPass<ModuleOp>> createAddMultiBufferToGMLoadPass();
 
+// Register the pass so it is available as --gm-load-multi-buffer on the command line
+void registerAddMultiBufferToGMLoadPasses();
+
 } // namespace triton
 } // namespace mlir
 

--- a/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/LoopTransform.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/LoopTransform.cpp
@@ -342,14 +342,14 @@ ExtendedForInfo buildExtendedFor(OpBuilder &builder, Location loc, scf::ForOp fo
                                  ConstantCache &cache)
 {
     builder.setInsertionPoint(forOp);
-    int numOrig = static_cast<int>(forOp.getInitArgs().size());
+    size_t numOrig = forOp.getInitArgs().size();
     int depth = groups.empty() ? 0 : groups[0].depth;
 
     Value falseVal = cache.getFalse(builder, loc);
     Value zeroIndex = cache.getIndex(builder, loc, 0);
 
     SmallVector<Value> inits;
-    inits.reserve(numOrig + static_cast<int>(groups.size()) * (depth + kLoadGroupCounterIterArgCount));
+    inits.reserve(numOrig + groups.size() * (depth + kLoadGroupCounterIterArgCount));
     for (Value initArg : forOp.getInitArgs()) {
         inits.push_back(initArg);
     }
@@ -379,7 +379,7 @@ ExtendedForInfo buildExtendedFor(OpBuilder &builder, Location loc, scf::ForOp fo
     builder.setInsertionPointToEnd(newBody);
 
     SmallVector<GroupIterArgs> groupArgs;
-    int argOffset = numOrig;
+    size_t argOffset = numOrig;
     for (auto &group : groups) {
         GroupIterArgs groupIterArgs;
         for (int slotIdx = 0; slotIdx < group.depth; ++slotIdx) {
@@ -393,7 +393,8 @@ ExtendedForInfo buildExtendedFor(OpBuilder &builder, Location loc, scf::ForOp fo
         groupArgs.push_back(std::move(groupIterArgs));
     }
 
-    return {newFor, oldBody, newBody, std::move(mapping), std::move(groupArgs), falseVal, numOrig, depth};
+    return {newFor, oldBody, newBody, std::move(mapping), std::move(groupArgs), falseVal, static_cast<int>(numOrig),
+            depth};
 }
 
 // ============================================================================

--- a/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/MultiBufferLoopBodyEmission.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/MultiBufferLoopBodyEmission.cpp
@@ -165,22 +165,16 @@ static ProducerLoopPosition mapProducerLoopPosition(OpBuilder &builder, Location
 static LogicalResult validateProducerIterArgInputs(scf::ForOp origForOp, Block *oldBody, Block *newBody,
                                                    ArrayRef<Value> iterArgDeltas)
 {
-    int numOrig = static_cast<int>(origForOp.getInitArgs().size());
-    if (numOrig < 0) {
-        origForOp.emitError() << "[" << DEBUG_TYPE << "] original iter_arg count is negative: " << numOrig;
-        return failure();
-    }
-
-    auto numOrigArgs = static_cast<unsigned>(numOrig);
-    if (iterArgDeltas.size() < numOrigArgs) {
+    size_t numOrig = origForOp.getInitArgs().size();
+    if (iterArgDeltas.size() < numOrig) {
         origForOp.emitError() << "[" << DEBUG_TYPE << "] iter_arg delta count " << iterArgDeltas.size()
-                              << " is smaller than original iter_arg count " << numOrigArgs;
+                              << " is smaller than original iter_arg count " << numOrig;
         return failure();
     }
-    if (oldBody->getNumArguments() < numOrigArgs + kForBodyIterArgOffset ||
-        newBody->getNumArguments() < numOrigArgs + kForBodyIterArgOffset) {
+    if (oldBody->getNumArguments() < numOrig + kForBodyIterArgOffset ||
+        newBody->getNumArguments() < numOrig + kForBodyIterArgOffset) {
         origForOp.emitError() << "[" << DEBUG_TYPE << "] loop body argument count is smaller than expected "
-                              << (numOrigArgs + kForBodyIterArgOffset);
+                              << (numOrig + kForBodyIterArgOffset);
         return failure();
     }
     return success();
@@ -485,14 +479,21 @@ static LogicalResult validateGroupEmissionInputs(ArrayRef<LoadGroup> groups, Ext
                                                  ArrayRef<Value> allGroupDepthConsts,
                                                  ArrayRef<SmallVector<Value>> allGroupSlotConsts, scf::ForOp origForOp)
 {
-    if (groupIdx < 0 || static_cast<size_t>(groupIdx) >= groups.size() ||
-        static_cast<size_t>(groupIdx) >= info.groupArgs.size() ||
-        static_cast<size_t>(groupIdx) >= groupTrueFlagVals.size() ||
-        static_cast<size_t>(groupIdx) >= groupIndexOneVals.size() ||
-        static_cast<size_t>(groupIdx) >= allGroupDepthConsts.size() ||
-        static_cast<size_t>(groupIdx) >= allGroupSlotConsts.size()) {
+    size_t numGroups = groups.size();
+    if (info.groupArgs.size() != numGroups || groupTrueFlagVals.size() != numGroups ||
+        groupIndexOneVals.size() != numGroups || allGroupDepthConsts.size() != numGroups ||
+        allGroupSlotConsts.size() != numGroups) {
+        origForOp.emitError()
+            << "[" << DEBUG_TYPE << "] array size mismatch in multi-buffer emission: groups=" << numGroups
+            << ", groupArgs=" << info.groupArgs.size() << ", groupTrueFlagVals=" << groupTrueFlagVals.size()
+            << ", groupIndexOneVals=" << groupIndexOneVals.size()
+            << ", allGroupDepthConsts=" << allGroupDepthConsts.size()
+            << ", allGroupSlotConsts=" << allGroupSlotConsts.size();
+        return failure();
+    }
+    if (groupIdx < 0 || static_cast<size_t>(groupIdx) >= numGroups) {
         origForOp.emitError() << "[" << DEBUG_TYPE << "] load group index " << groupIdx
-                              << " is out of range for multi-buffer emission";
+                              << " is out of range for multi-buffer emission (numGroups=" << numGroups << ")";
         return failure();
     }
     return success();

--- a/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/AddMultiBufferToGMLoad.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/AddMultiBufferToGMLoad.cpp
@@ -171,5 +171,10 @@ std::unique_ptr<OperationPass<ModuleOp>> createAddMultiBufferToGMLoadPass()
     return std::make_unique<AddMultiBufferToGMLoadPass>();
 }
 
+void registerAddMultiBufferToGMLoadPasses()
+{
+  registerPass([]() -> std::unique_ptr<mlir::Pass> { return createAddMultiBufferToGMLoadPass(); });
+}
+
 } // namespace triton
 } // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/AsyncLoadHoisting.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/AsyncLoadHoisting.cpp
@@ -202,7 +202,7 @@ static void collectAddressGenerationOps(Operation* op, int64_t expectedBlockId, 
           for (auto result : user->getResults()) {
             for (auto* subviewUser : result.getUsers()) {
               if (auto copyOp = llvm::dyn_cast<memref::CopyOp>(subviewUser);
-                  visited.insert(copyOp).second) {
+                  copyOp && visited.insert(copyOp).second) {
                 chain.push_back(copyOp);
                 collectAddressGenerationOps(copyOp, expectedBlockId, visited, chain);
               }
@@ -213,10 +213,10 @@ static void collectAddressGenerationOps(Operation* op, int64_t expectedBlockId, 
       }
     }
 
-    visited.insert(defOp);
-    chain.push_back(defOp);
-
-    collectAddressGenerationOps(defOp, expectedBlockId, visited, chain);
+    if (visited.insert(defOp).second) {
+      chain.push_back(defOp);
+      collectAddressGenerationOps(defOp, expectedBlockId, visited, chain);
+    }
   }
 }
 // Returns full chain and filtered chain (only ops with same block_id)

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/async_load_hoisting_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/async_load_hoisting_test.mlir
@@ -1,0 +1,212 @@
+// RUN: triton-opt --allow-unregistered-dialect --async-load-hoisting %s | FileCheck %s
+
+// CHECK-LABEL: func.func @test_gm_load_cube_marked
+// Test 1: GM loads feeding Cube compute should be marked
+// GM loads feeding linalg.matmul (Cube compute) need gm_load_bufferable mark
+// Complex scene with subview: memref.copy from subview to subview
+func.func @test_gm_load_cube_marked(
+  %arg0: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %arg1: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %arg2: tensor<128x128xf32>
+) {
+  %c0_i32 = arith.constant {ssbuffer.block_id = 5 : i32} 0 : i32
+  %c128_i32 = arith.constant {ssbuffer.block_id = 5 : i32} 128 : i32
+  %c0 = arith.constant {ssbuffer.block_id = 5 : i32} 0 : index
+  %c1 = arith.constant {ssbuffer.block_id = 5 : i32} 1 : index
+
+  // Load Q from GM - feeds linalg.matmul (Cube compute)
+  // Complex scene: use subview for copy
+  %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [128, 128], strides: [128, 1] {ssbuffer.block_id = 5 : i32} : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+  %alloc = memref.alloc() {ssbuffer.block_id = 5 : i32} : memref<128x128xf16>
+  // subview copy: from reinterpret_cast subview to alloc subview
+  %subview_src = memref.subview %reinterpret_cast[0, 0] [128, 128] [1, 1] {ssbuffer.block_id = 5 : i32} : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+  %subview_dst = memref.subview %alloc[0, 0] [128, 128] [1, 1] {ssbuffer.block_id = 5 : i32} : memref<128x128xf16> to memref<128x128xf16, strided<[128, 1]>>
+  memref.copy %subview_src, %subview_dst {ssbuffer.block_id = 5 : i32} : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16, strided<[128, 1]>>
+  // CHECK: bufferization.to_tensor
+  // CHECK-SAME: gm_load_bufferable
+  %to_tensor = bufferization.to_tensor %alloc {ssbuffer.block_id = 5 : i32} : memref<128x128xf16>
+
+  // Load K from GM - feeds linalg.matmul (Cube compute)
+  // Complex scene: use subview for copy, similar to real code pattern
+  %reinterpret_cast_2 = memref.reinterpret_cast %arg1 to offset: [%c0], sizes: [128, 128], strides: [128, 1] {ssbuffer.block_id = 5 : i32} : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+  %alloc_2 = memref.alloc() {ssbuffer.block_id = 5 : i32} : memref<128x128xf16>
+  // subview copy: from reinterpret_cast subview to alloc subview
+  %subview_src_2 = memref.subview %reinterpret_cast_2[0, 0] [128, 128] [1, 1] {ssbuffer.block_id = 5 : i32} : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+  %subview_dst_2 = memref.subview %alloc_2[0, 0] [128, 128] [1, 1] {ssbuffer.block_id = 5 : i32} : memref<128x128xf16> to memref<128x128xf16, strided<[128, 1]>>
+  memref.copy %subview_src_2, %subview_dst_2 {ssbuffer.block_id = 5 : i32} : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16, strided<[128, 1]>>
+  // CHECK: bufferization.to_tensor
+  // CHECK-SAME: gm_load_bufferable
+  %to_tensor_2 = bufferization.to_tensor %alloc_2 {ssbuffer.block_id = 5 : i32} : memref<128x128xf16>
+
+  // Cube compute: matmul (128x128) x (128x128) = (128x128)
+  %matmul = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 5 : i32} ins(%to_tensor, %to_tensor_2 : tensor<128x128xf16>, tensor<128x128xf16>) outs(%arg2 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+  return
+}
+
+// CHECK-LABEL: func.func @test_gm_load_mask_not_marked
+// Test 2: GM loads feeding arith mask operations (maximumf/minimumf/select) should NOT be marked
+// Element-wise mask ops do not feed Cube, should not be marked
+func.func @test_gm_load_mask_not_marked(
+  %arg0: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %arg1: tensor<128xf32>
+) {
+  %c0 = arith.constant {ssbuffer.block_id = 7 : i32} 0 : index
+
+  // Load from GM feeding arith.maximumf (mask operation) - should NOT be marked
+  %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [128], strides: [1] {ssbuffer.block_id = 7 : i32} : memref<?xf32> to memref<128xf32, strided<[1], offset: ?>>
+  %alloc = memref.alloc() {ssbuffer.block_id = 7 : i32} : memref<128xf32>
+  memref.copy %reinterpret_cast, %alloc {ssbuffer.block_id = 7 : i32} : memref<128xf32, strided<[1], offset: ?>> to memref<128xf32>
+  // CHECK-NOT: gm_load_bufferable
+  %to_tensor = bufferization.to_tensor %alloc {ssbuffer.block_id = 7 : i32} : memref<128xf32>
+
+  // arith.maximumf is a mask operation - result not fed to Cube
+  %max = arith.maximumf %to_tensor, %arg1 {ssbuffer.block_id = 7 : i32} : tensor<128xf32>
+
+  return
+}
+
+// CHECK-LABEL: func.func @test_gm_load_scalar_index_not_marked
+// Test 3: memref.load with scalar (constant) indices should NOT be marked
+// Scalar index load does not mark - memref.load with constant index is not marked
+func.func @test_gm_load_scalar_index_not_marked(
+  %arg0: memref<128x128xf16>,
+  %arg1: tensor<128x128xf32>
+) {
+  %c0 = arith.constant {ssbuffer.block_id = 10 : i32} 0 : index
+
+  // memref.load with scalar indices (constant %c0) - should NOT be marked
+  // This is reading a scalar value from memory, not a GM data tile
+  %loaded = memref.load %arg0[%c0, %c0] {ssbuffer.block_id = 10 : i32} : memref<128x128xf16>
+
+  // The loaded scalar value used in element-wise computation
+  %ext = arith.extf %loaded {ssbuffer.block_id = 10 : i32} : f16 to f32
+  %add = arith.addf %ext, %ext {ssbuffer.block_id = 10 : i32} : f32
+
+  // CHECK-NOT: gm_load_bufferable
+  return
+}
+
+// CHECK-LABEL: func.func @test_gm_load_nonlinear_cast_not_marked
+// Test 4: GM loads with non-linear reinterpret_cast offset should NOT be marked
+// Address that cannot be linearly projected is not marked - reinterpret_cast offset depends on:
+// 1. memref.load reading index as offset
+// 2. scf.for/scf.while iter_arg drives address and yield value is non-linear
+// Complex scene with subview, result feeds Cube (not mask), exclude scenario 2 interference
+func.func @test_gm_load_nonlinear_cast_not_marked(
+  %arg0: memref<1xi64>,
+  %arg1: memref<128x128xf16>,
+  %arg2: tensor<32x128xf16>
+) {
+  %c0 = arith.constant {ssbuffer.block_id = 8 : i32} 0 : index
+  %c1 = arith.constant {ssbuffer.block_id = 8 : i32} 1 : index
+  %c128_i64 = arith.constant {ssbuffer.block_id = 8 : i32} 128 : i64
+  %c128 = arith.constant {ssbuffer.block_id = 8 : i32} 128 : index
+  %c32 = arith.constant {ssbuffer.block_id = 8 : i32} 32 : index
+
+  // ========== Scene 4a: memref.load causes non-linear offset ==========
+  // Step 1: memref.load reads control flow indices from %arg0 (not GM data)
+  %reinterpret_cast_idx = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [1], strides: [1] {ssbuffer.block_id = 8 : i32} : memref<1xi64> to memref<1xi64, strided<[1], offset: ?>>
+  %loaded_idx = memref.load %reinterpret_cast_idx[%c0] {ssbuffer.block_id = 8 : i32} : memref<1xi64, strided<[1], offset: ?>>
+
+  // Step 2: Compute offset using the loaded index - this makes address non-linear
+  %multiplied = arith.muli %loaded_idx, %c128_i64 {ssbuffer.block_id = 8 : i32} : i64
+  %base_offset = arith.index_cast %multiplied {ssbuffer.block_id = 8 : i32} : i64 to index
+
+  // Step 3: reinterpret_cast offset depends on memref.load result - NON-LINEAR
+  %reinterpret_cast = memref.reinterpret_cast %arg1 to offset: [%base_offset], sizes: [32, 128], strides: [128, 1] {ssbuffer.block_id = 8 : i32} : memref<128x128xf16> to memref<32x128xf16, strided<[128, 1], offset: ?>>
+
+  // Step 4: Allocate buffer
+  %alloc = memref.alloc() {ssbuffer.block_id = 8 : i32} : memref<32x128xf16>
+
+  // Step 5: Create subviews
+  %subview_src = memref.subview %reinterpret_cast[0, 0] [%c32, 128] [1, 1] {ssbuffer.block_id = 8 : i32} : memref<32x128xf16, strided<[128, 1], offset: ?>> to memref<?x128xf16, strided<[128, 1], offset: ?>>
+  %subview_dst = memref.subview %alloc[0, 0] [%c32, 128] [1, 1] {ssbuffer.block_id = 8 : i32} : memref<32x128xf16> to memref<?x128xf16, strided<[128, 1]>>
+
+  // Step 6: memref.copy through subviews
+  memref.copy %subview_src, %subview_dst {ssbuffer.block_id = 8 : i32} : memref<?x128xf16, strided<[128, 1], offset: ?>> to memref<?x128xf16, strided<[128, 1]>>
+
+  // Step 7: bufferization.to_tensor - should NOT be marked because offset is non-linear (memref.load)
+  // CHECK-NOT: gm_load_bufferable
+  %to_tensor = bufferization.to_tensor %alloc {ssbuffer.block_id = 8 : i32} : memref<32x128xf16>
+
+  // ========== Scene 4b: scf.for iter_arg causes non-linear offset ==========
+  %for_result:2 = scf.for %i = %c0 to %c128 step %c1 iter_args(%arg_iter = %arg1, %alloc_iter = %alloc) -> (memref<128x128xf16>, memref<32x128xf16>) {
+    %for_offset = arith.index_cast %i {ssbuffer.block_id = 8 : i32} : index to i64
+    %for_offset_index = arith.index_cast %for_offset {ssbuffer.block_id = 8 : i32} : i64 to index
+    %reinterpret_for = memref.reinterpret_cast %arg_iter to offset: [%for_offset_index], sizes: [32, 128], strides: [128, 1] {ssbuffer.block_id = 8 : i32} : memref<128x128xf16> to memref<32x128xf16, strided<[128, 1], offset: ?>>
+    %alloc_for = memref.alloc() {ssbuffer.block_id = 8 : i32} : memref<32x128xf16>
+    memref.copy %reinterpret_for, %alloc_for {ssbuffer.block_id = 8 : i32} : memref<32x128xf16, strided<[128, 1], offset: ?>> to memref<32x128xf16>
+    scf.yield %arg_iter, %alloc_for : memref<128x128xf16>, memref<32x128xf16>
+  }
+  // CHECK-NOT: gm_load_bufferable
+  %to_tensor_for = bufferization.to_tensor %for_result#1 {ssbuffer.block_id = 8 : i32} : memref<32x128xf16>
+
+  // ========== Scene 4c: scf.while causes non-linear offset ==========
+  %while_result:2 = scf.while (%arg_while = %arg1, %arg_while_alloc = %alloc) : (memref<128x128xf16>, memref<32x128xf16>) -> (memref<128x128xf16>, memref<32x128xf16>) {
+    %cond = arith.constant {ssbuffer.block_id = 8 : i32} true
+    scf.condition(%cond) %arg_while, %arg_while_alloc : memref<128x128xf16>, memref<32x128xf16>
+  } do {
+  ^bb0(%arg_while_prev: memref<128x128xf16>, %arg_while_alloc_prev: memref<32x128xf16>):
+    %while_offset_base = arith.constant {ssbuffer.block_id = 8 : i32} 0 : index
+    %reinterpret_while = memref.reinterpret_cast %arg_while_prev to offset: [%while_offset_base], sizes: [32, 128], strides: [128, 1] {ssbuffer.block_id = 8 : i32} : memref<128x128xf16> to memref<32x128xf16, strided<[128, 1], offset: ?>>
+    %alloc_while = memref.alloc() {ssbuffer.block_id = 8 : i32} : memref<32x128xf16>
+    memref.copy %reinterpret_while, %alloc_while {ssbuffer.block_id = 8 : i32} : memref<32x128xf16, strided<[128, 1], offset: ?>> to memref<32x128xf16>
+    scf.yield %arg_while_prev, %alloc_while : memref<128x128xf16>, memref<32x128xf16>
+  }
+  // CHECK-NOT: gm_load_bufferable
+  %to_tensor_while = bufferization.to_tensor %while_result#1 {ssbuffer.block_id = 8 : i32} : memref<32x128xf16>
+
+  // ========== Feeds Cube compute ==========
+  %add = arith.addf %to_tensor, %to_tensor {ssbuffer.block_id = 8 : i32} : tensor<32x128xf16>
+
+  return
+}
+
+// CHECK-LABEL: func.func @test_gm_load_non_gm_source_not_marked
+// Test 5: bufferization.to_tensor with non-GM source should NOT be marked
+// Data from non-GM is not marked - readback from internal compute (non-GM load) is not marked
+func.func @test_gm_load_non_gm_source_not_marked(
+  %arg0: tensor<32x256xf32>
+) {
+  // Step 1: Allocate a new buffer (NOT loaded from GM)
+  %alloc = memref.alloc() {ssbuffer.block_id = 26 : i32} : memref<32x256xf32>
+
+  // Step 2: bufferization.to_tensor from internal alloc (NOT from GM) - should NOT be marked
+  // CHECK-NOT: gm_load_bufferable
+  %to_tensor = bufferization.to_tensor %alloc {ssbuffer.block_id = 26 : i32} : memref<32x256xf32>
+
+  // The loaded data is used in element-wise operations (not Cube compute)
+  %broadcasted = linalg.broadcast ins(%to_tensor : tensor<32x256xf32>) outs(%arg0 : tensor<32x256xf32>) dimensions = [] {ssbuffer.block_id = 26 : i32}
+
+  return
+}
+
+// CHECK-LABEL: func.func @test_gm_load_cross_block_marked
+// Test 6: Cross-block chain with block argument source should be marked
+// Cross-block address generation chain but source is block argument (%arg), should be marked
+// Scene: bufferization.to_tensor -> memref.copy -> memref.subview -> reinterpret_cast -> %arg
+// alloc's block_id differs from copy's block_id, but since source is %arg, hasBlockArg=true
+func.func @test_gm_load_cross_block_marked(
+  %arg0: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %arg1: tensor<128x128xf32>
+) {
+  %c0_i32 = arith.constant {ssbuffer.block_id = 10 : i32} 0 : i32
+  %c128_i32 = arith.constant {ssbuffer.block_id = 10 : i32} 128 : i32
+  %c0 = arith.constant {ssbuffer.block_id = 10 : i32} 0 : index
+  %c1 = arith.constant {ssbuffer.block_id = 10 : i32} 1 : index
+
+  // GM load chain: bufferization.to_tensor -> copy -> subview -> reinterpret_cast -> %arg0
+  // Note: alloc block_id=10, copy block_id=11, subview block_id=11
+  // But since source is %arg0 (block argument), hasBlockArg=true, should be marked
+  %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [128, 128], strides: [128, 1] {ssbuffer.block_id = 11 : i32} : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+  %alloc = memref.alloc() {ssbuffer.block_id = 10 : i32} : memref<128x128xf16>
+  %subview_src = memref.subview %reinterpret_cast[0, 0] [128, 128] [1, 1] {ssbuffer.block_id = 11 : i32} : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+  %subview_dst = memref.subview %alloc[0, 0] [128, 128] [1, 1] {ssbuffer.block_id = 11 : i32} : memref<128x128xf16> to memref<128x128xf16, strided<[128, 1]>>
+  memref.copy %subview_src, %subview_dst {ssbuffer.block_id = 11 : i32} : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16, strided<[128, 1]>>
+  // CHECK: bufferization.to_tensor
+  // CHECK-SAME: gm_load_bufferable
+  %0 = bufferization.to_tensor %alloc {ssbuffer.block_id = 11 : i32} : memref<128x128xf16>
+
+  return
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/basic_transform_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/basic_transform_test.mlir
@@ -47,7 +47,7 @@ func.func @tc_b01_double_buffer_basic(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %qk : tensor<128x128xf32>
   }
@@ -83,7 +83,7 @@ func.func @tc_b02_no_marker_pass_through(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable : memref<128x128xf16>
   }
   return
 }
@@ -114,7 +114,7 @@ func.func @tc_b03_trip_count_too_small(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
   }
   return
 }
@@ -142,7 +142,7 @@ func.func @tc_b03b_trip_count_minimal_valid(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
   }
   return
 }
@@ -174,7 +174,7 @@ func.func @tc_b13_no_backing_alloc_skip(
     %row_off = arith.muli %iv_idx, %c128 : index
     // No alloc - direct reinterpret_cast used as to_tensor source
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
-    %q_tensor = bufferization.to_tensor %q_src_rc restrict writable {gm_load_bufferable} : memref<128x128xf16, strided<[128, 1], offset: ?>> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_src_rc restrict writable {gm_load_bufferable} : memref<128x128xf16, strided<[128, 1], offset: ?>>
   }
   return
 }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/complex_scenarios_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/complex_scenarios_test.mlir
@@ -40,12 +40,12 @@ func.func @tc_b10_multiple_loads_same_loop(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
 
     %k_src_rc = memref.reinterpret_cast %arg1 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %k_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %k_src_rc, %k_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %k_tensor = bufferization.to_tensor %k_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %k_tensor = bufferization.to_tensor %k_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
 
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %k_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %qk : tensor<128x128xf32>
@@ -89,7 +89,7 @@ func.func @tc_b11_nested_loops_inner_first(
       %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
       %q_alloc = memref.alloc () : memref<128x128xf16>
       memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-      %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+      %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
       %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%inner_acc : tensor<128x128xf32>) -> tensor<128x128xf32>
       scf.yield %qk : tensor<128x128xf32>
     }
@@ -126,7 +126,7 @@ func.func @tc_b12_linear_iter_arg_delta(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
     %acc_dummy = tensor.empty() : tensor<128x128xf32>
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc_dummy : tensor<128x128xf32>) -> tensor<128x128xf32>
 
@@ -141,7 +141,7 @@ func.func @tc_b12_linear_iter_arg_delta(
   %final_view = memref.reinterpret_cast %arg0 to offset: [%final_row], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
   %final_alloc = memref.alloc() : memref<128x128xf16>
   memref.copy %final_view, %final_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-  %final_tensor = bufferization.to_tensor %final_alloc restrict writable : memref<128x128xf16> to tensor<128x128xf16>
+  %final_tensor = bufferization.to_tensor %final_alloc restrict writable : memref<128x128xf16>
   %ext = arith.extf %final_tensor : tensor<128x128xf16> to tensor<128x128xf32>
   %sum = arith.addf %ext, %arg1 : tensor<128x128xf32>
   return %sum : tensor<128x128xf32>
@@ -185,12 +185,12 @@ func.func @tc_b18_multi_load_with_orig_iter_args(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
 
     %k_src_rc = memref.reinterpret_cast %arg1 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %k_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %k_src_rc, %k_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %k_tensor = bufferization.to_tensor %k_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %k_tensor = bufferization.to_tensor %k_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
 
     %acc_new = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %k_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %acc_new, %lse : tensor<128x128xf32>, tensor<128xf32>
@@ -226,7 +226,7 @@ func.func @tc_b19_bf16_data_type(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xbf16> to memref<128x128xbf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xbf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xbf16, strided<[128, 1], offset: ?>> to memref<128x128xbf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xbf16> to tensor<128x128xbf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xbf16>
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %qk : tensor<128x128xf32>
   }
@@ -266,7 +266,7 @@ func.func @tc_b20_outer_loop_marked_only(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%outer_acc : tensor<128x128xf32>) -> tensor<128x128xf32>
 
     // Inner loop with no marked load
@@ -307,7 +307,7 @@ func.func @tc_b21_index_iv_type(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %qk : tensor<128x128xf32>
   }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/gm_load_multi_buffer_block_id_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/gm_load_multi_buffer_block_id_test.mlir
@@ -160,14 +160,14 @@ func.func @_attn_bwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf
       %14:2 = scf.for %arg19 = %c0_i32 to %c128_i32 step %c1_i32 iter_args(%arg20 = %1, %arg21 = %1) -> (tensor<64x128xf32>, tensor<64x128xf32>)  : i32 {
         hivm.hir.sync_block_wait {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 4
         %memspacecast = memref.memory_space_cast %alloc_4 {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 3 : i32} : memref<64x64xf32, #hivm.address_space<ub>> to memref<64x64xf32>
-        %23 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 3 : i32} : memref<64x64xf32> to tensor<64x64xf32>
+        %23 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 3 : i32} : memref<64x64xf32>
         %24 = arith.muli %arg19, %c64_i32 {MixUse, ssbuffer.block_id = 7 : i32} : i32
         %25 = arith.index_cast %24 {ssbuffer.block_id = 7 : i32} : i32 to index
         %26 = arith.addi %13, %25 {ssbuffer.block_id = 7 : i32} : index
         %reinterpret_cast_10 = memref.reinterpret_cast %arg9 to offset: [%26], sizes: [64], strides: [1] {ssbuffer.block_id = 7 : i32} : memref<?xf32> to memref<64xf32, strided<[1], offset: ?>>
         %alloc_11 = memref.alloc() {ssbuffer.block_id = 7 : i32} : memref<64xf32>
         memref.copy %reinterpret_cast_10, %alloc_11 {ssbuffer.block_id = 7 : i32} : memref<64xf32, strided<[1], offset: ?>> to memref<64xf32>
-        %27 = bufferization.to_tensor %alloc_11 restrict writable {gm_load_bufferable, ssbuffer.block_id = 7 : i32} : memref<64xf32> to tensor<64xf32>
+        %27 = bufferization.to_tensor %alloc_11 restrict writable {gm_load_bufferable, ssbuffer.block_id = 7 : i32} : memref<64xf32>
         %28 = arith.addf %23, %3 {ssbuffer.block_id = 7 : i32} : tensor<64x64xf32>
         %29 = arith.mulf %28, %4 {DataUse, ssbuffer.block_id = 7 : i32} : tensor<64x64xf32>
         %broadcasted = linalg.broadcast ins(%27 : tensor<64xf32>) outs(%2 : tensor<64x64xf32>) dimensions = [1]  {ssbuffer.block_id = 7 : i32}
@@ -184,11 +184,11 @@ func.func @_attn_bwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf
         hivm.hir.sync_block_set {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 4
         hivm.hir.sync_block_wait {ssbuffer.block_id = 8 : i32, ssbuffer.transfer_id = 4 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 5
         %memspacecast_13 = memref.memory_space_cast %alloc_5 {ssbuffer.block_id = 8 : i32, ssbuffer.transfer_id = 4 : i32} : memref<64x64xf32, #hivm.address_space<ub>> to memref<64x64xf32>
-        %34 = bufferization.to_tensor %memspacecast_13 restrict writable {ssbuffer.block_id = 8 : i32, ssbuffer.transfer_id = 4 : i32} : memref<64x64xf32> to tensor<64x64xf32>
+        %34 = bufferization.to_tensor %memspacecast_13 restrict writable {ssbuffer.block_id = 8 : i32, ssbuffer.transfer_id = 4 : i32} : memref<64x64xf32>
         %reinterpret_cast_14 = memref.reinterpret_cast %arg10 to offset: [%26], sizes: [64], strides: [1] {ssbuffer.block_id = 8 : i32} : memref<?xf32> to memref<64xf32, strided<[1], offset: ?>>
         %alloc_15 = memref.alloc() {ssbuffer.block_id = 8 : i32} : memref<64xf32>
         memref.copy %reinterpret_cast_14, %alloc_15 {ssbuffer.block_id = 8 : i32} : memref<64xf32, strided<[1], offset: ?>> to memref<64xf32>
-        %35 = bufferization.to_tensor %alloc_15 restrict writable {gm_load_bufferable, ssbuffer.block_id = 8 : i32} : memref<64xf32> to tensor<64xf32>
+        %35 = bufferization.to_tensor %alloc_15 restrict writable {gm_load_bufferable, ssbuffer.block_id = 8 : i32} : memref<64xf32>
         %36 = arith.addf %34, %3 {ssbuffer.block_id = 8 : i32} : tensor<64x64xf32>
         %broadcasted_16 = linalg.broadcast ins(%35 : tensor<64xf32>) outs(%2 : tensor<64x64xf32>) dimensions = [1]  {ssbuffer.block_id = 8 : i32}
         %37 = arith.subf %36, %broadcasted_16 {DataUse, ssbuffer.block_id = 8 : i32} : tensor<64x64xf32>
@@ -209,13 +209,13 @@ func.func @_attn_bwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf
         hivm.hir.sync_block_set {ssbuffer.block_id = 8 : i32, ssbuffer.transfer_id = 4 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 5
         hivm.hir.sync_block_wait {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 7 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 8
         %memspacecast_20 = memref.memory_space_cast %alloc_8 {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 7 : i32} : memref<64x128xf32, #hivm.address_space<ub>> to memref<64x128xf32>
-        %43 = bufferization.to_tensor %memspacecast_20 restrict writable {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 7 : i32} : memref<64x128xf32> to tensor<64x128xf32>
+        %43 = bufferization.to_tensor %memspacecast_20 restrict writable {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 7 : i32} : memref<64x128xf32>
         hivm.hir.sync_block_wait {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 6 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 7
         %memspacecast_21 = memref.memory_space_cast %alloc_7 {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 6 : i32} : memref<64x128xf32, #hivm.address_space<ub>> to memref<64x128xf32>
-        %44 = bufferization.to_tensor %memspacecast_21 restrict writable {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 6 : i32} : memref<64x128xf32> to tensor<64x128xf32>
+        %44 = bufferization.to_tensor %memspacecast_21 restrict writable {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 6 : i32} : memref<64x128xf32>
         hivm.hir.sync_block_wait {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 5 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 6
         %memspacecast_22 = memref.memory_space_cast %alloc_6 {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 5 : i32} : memref<64x128xf32, #hivm.address_space<ub>> to memref<64x128xf32>
-        %45 = bufferization.to_tensor %memspacecast_22 restrict writable {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 5 : i32} : memref<64x128xf32> to tensor<64x128xf32>
+        %45 = bufferization.to_tensor %memspacecast_22 restrict writable {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 5 : i32} : memref<64x128xf32>
         %46 = arith.muli %25, %c128 {ssbuffer.block_id = 9 : i32} : index
         %47 = arith.addi %12, %46 {ssbuffer.block_id = 9 : i32} : index
         %48 = arith.addf %44, %arg21 {ssbuffer.block_id = 9 : i32} : tensor<64x128xf32>
@@ -487,17 +487,17 @@ func.func @_attn_bwd_complex(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: me
 
         hivm.hir.sync_block_wait {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 7 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 8
         %memspacecast = memref.memory_space_cast %alloc_9 {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 7 : i32} : memref<64x32xf32, #hivm.address_space<ub>> to memref<64x32xf32>
-        %132 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 7 : i32} : memref<64x32xf32> to tensor<64x32xf32>
+        %132 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 7 : i32} : memref<64x32xf32>
         hivm.hir.sync_block_wait {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 5 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 6
         %memspacecast_25 = memref.memory_space_cast %alloc_7 {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 5 : i32} : memref<64x32xf32, #hivm.address_space<ub>> to memref<64x32xf32>
-        %133 = bufferization.to_tensor %memspacecast_25 restrict writable {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 5 : i32} : memref<64x32xf32> to tensor<64x32xf32>
+        %133 = bufferization.to_tensor %memspacecast_25 restrict writable {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 5 : i32} : memref<64x32xf32>
         %134 = arith.addf %133, %1 {ssbuffer.block_id = 13 : i32} : tensor<64x32xf32>
         %135 = arith.addf %132, %134 {ssbuffer.block_id = 13 : i32} : tensor<64x32xf32>
         %reinterpret_cast_26 = memref.reinterpret_cast %arg3 to offset: [%107], sizes: [64, 32], strides: [4096, 1] {ssbuffer.block_id = 13 : i32} : memref<?xbf16> to memref<64x32xbf16, strided<[4096, 1], offset: ?>>
         %subview_27 = memref.subview %reinterpret_cast_26[0, 0] [%118, %120] [1, 1] {ssbuffer.block_id = 13 : i32} : memref<64x32xbf16, strided<[4096, 1], offset: ?>> to memref<?x?xbf16, strided<[4096, 1], offset: ?>>
         %subview_28 = memref.subview %alloc_23[%117, %119] [%118, %120] [1, 1] {ssbuffer.block_id = 13 : i32} : memref<64x32xbf16> to memref<?x?xbf16, strided<[32, 1], offset: ?>>
         memref.copy %subview_27, %subview_28 {ssbuffer.block_id = 13 : i32} : memref<?x?xbf16, strided<[4096, 1], offset: ?>> to memref<?x?xbf16, strided<[32, 1], offset: ?>>
-        %136 = bufferization.to_tensor %alloc_23 restrict writable {gm_load_bufferable, ssbuffer.block_id = 13 : i32} : memref<64x32xbf16> to tensor<64x32xbf16>
+        %136 = bufferization.to_tensor %alloc_23 restrict writable {gm_load_bufferable, ssbuffer.block_id = 13 : i32} : memref<64x32xbf16>
         %137 = arith.extf %136 {DataUse, ssbuffer.block_id = 13 : i32} : tensor<64x32xbf16> to tensor<64x32xf32>
         %138 = arith.subf %137, %135 {DataUse, ssbuffer.block_id = 13 : i32} : tensor<64x32xf32>
         %reinterpret_cast_29 = memref.reinterpret_cast %arg5 to offset: [%107], sizes: [64, 32], strides: [4096, 1] {ssbuffer.block_id = 13 : i32} : memref<?xbf16> to memref<64x32xbf16, strided<[4096, 1], offset: ?>>
@@ -520,7 +520,7 @@ func.func @_attn_bwd_complex(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: me
         %subview_34 = memref.subview %reinterpret_cast_33[0] [%130] [1] {ssbuffer.block_id = 13 : i32} : memref<64xf32, strided<[32], offset: ?>> to memref<?xf32, strided<[32], offset: ?>>
         %subview_35 = memref.subview %alloc_24[%129] [%130] [1] {ssbuffer.block_id = 13 : i32} : memref<64xf32> to memref<?xf32, strided<[1], offset: ?>>
         memref.copy %subview_34, %subview_35 {ssbuffer.block_id = 13 : i32} : memref<?xf32, strided<[32], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-        %150 = bufferization.to_tensor %alloc_24 restrict writable {gm_load_bufferable, ssbuffer.block_id = 13 : i32} : memref<64xf32> to tensor<64xf32>
+        %150 = bufferization.to_tensor %alloc_24 restrict writable {gm_load_bufferable, ssbuffer.block_id = 13 : i32} : memref<64xf32>
         %151 = linalg.fill {ssbuffer.block_id = 13 : i32} ins(%148 : f32) outs(%2 : tensor<64xf32>) -> tensor<64xf32>
         %152 = arith.subf %151, %150 {DataUse, ssbuffer.block_id = 13 : i32} : tensor<64xf32>
         %153 = math.exp2 %152 {DataUse, ssbuffer.block_id = 13 : i32} : tensor<64xf32>
@@ -558,10 +558,10 @@ func.func @_attn_bwd_complex(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: me
 
         hivm.hir.sync_block_wait {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 6 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 7
         %memspacecast_40 = memref.memory_space_cast %alloc_8 {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 6 : i32} : memref<64x32xf32, #hivm.address_space<ub>> to memref<64x32xf32>
-        %163 = bufferization.to_tensor %memspacecast_40 restrict writable {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 6 : i32} : memref<64x32xf32> to tensor<64x32xf32>
+        %163 = bufferization.to_tensor %memspacecast_40 restrict writable {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 6 : i32} : memref<64x32xf32>
         hivm.hir.sync_block_wait {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 4 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 5
         %memspacecast_41 = memref.memory_space_cast %alloc_6 {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 4 : i32} : memref<64x32xf32, #hivm.address_space<ub>> to memref<64x32xf32>
-        %164 = bufferization.to_tensor %memspacecast_41 restrict writable {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 4 : i32} : memref<64x32xf32> to tensor<64x32xf32>
+        %164 = bufferization.to_tensor %memspacecast_41 restrict writable {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 4 : i32} : memref<64x32xf32>
         %165 = tensor.empty() {ssbuffer.block_id = 14 : i32} : tensor<1xf32>
         %inserted = tensor.insert %148 into %165[%c0] {ssbuffer.block_id = 14 : i32} : tensor<1xf32>
         %166 = math.exp2 %inserted {DataUse, ssbuffer.block_id = 14 : i32} : tensor<1xf32>
@@ -680,7 +680,7 @@ func.func @_attn_fwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf
         %6:5 = scf.for %arg17 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg18 = %1, %arg19 = %5, %arg20 = %4, %arg21 = %c0_i32, %arg22 = %c0_i32) -> (tensor<128x128xf32>, tensor<128xf32>, tensor<128xf32>, i32, i32)  : i32 {
           hivm.hir.sync_block_wait {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 2
           %memspacecast = memref.memory_space_cast %alloc_5 {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>> to memref<128x128xf32>
-          %30 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32> to tensor<128x128xf32>
+          %30 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32>
           %31 = arith.mulf %30, %2 {ssbuffer.block_id = 5 : i32} : tensor<128x128xf32>
           %reduced = linalg.reduce ins(%31 : tensor<128x128xf32>) outs(%4 : tensor<128xf32>) dimensions = [1]  {ssbuffer.block_id = 5 : i32}
             (%in: f32, %init: f32) {
@@ -704,7 +704,7 @@ func.func @_attn_fwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf
           hivm.hir.sync_block_set {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 2
           hivm.hir.sync_block_wait {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 2 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 3
           %memspacecast_10 = memref.memory_space_cast %alloc_6 {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32, #hivm.address_space<ub>> to memref<128x128xf32>
-          %37 = bufferization.to_tensor %memspacecast_10 restrict writable {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32> to tensor<128x128xf32>
+          %37 = bufferization.to_tensor %memspacecast_10 restrict writable {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32>
           %38 = linalg.fill {ssbuffer.block_id = 7 : i32} ins(%cst_1 : f32) outs(%3 : tensor<128xf32>) -> tensor<128xf32>
           %reduced_11 = linalg.reduce ins(%34 : tensor<128x128xf32>) outs(%38 : tensor<128xf32>) dimensions = [1]  {ssbuffer.block_id = 7 : i32}
             (%in: f32, %init: f32) {
@@ -846,7 +846,7 @@ func.func @_attn_fwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf
         %22 = arith.index_cast %15 {ssbuffer.block_id = 2 : i32} : i64 to index
         %alloc = memref.alloc() {ssbuffer.block_id = 2 : i32} : memref<128x128xf16>
         memref.copy %reinterpret_cast, %alloc {ssbuffer.block_id = 2 : i32} : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-        %23 = bufferization.to_tensor %alloc restrict writable {gm_load_bufferable, ssbuffer.block_id = 2 : i32} : memref<128x128xf16> to tensor<128x128xf16>
+        %23 = bufferization.to_tensor %alloc restrict writable {gm_load_bufferable, ssbuffer.block_id = 2 : i32} : memref<128x128xf16>
         %alloc_5 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
         annotation.mark %alloc_5 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
         hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 1
@@ -861,7 +861,7 @@ func.func @_attn_fwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf
           %reinterpret_cast_8 = memref.reinterpret_cast %arg3 to offset: [%27], sizes: [128, 128], strides: [128, 1] {ssbuffer.block_id = 0 : i32} : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
           %alloc_9 = memref.alloc() {ssbuffer.block_id = 0 : i32} : memref<128x128xf16>
           memref.copy %reinterpret_cast_8, %alloc_9 {ssbuffer.block_id = 0 : i32} : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-          %28 = bufferization.to_tensor %alloc_9 restrict writable {gm_load_bufferable, ssbuffer.block_id = 0 : i32} : memref<128x128xf16> to tensor<128x128xf16>
+          %28 = bufferization.to_tensor %alloc_9 restrict writable {gm_load_bufferable, ssbuffer.block_id = 0 : i32} : memref<128x128xf16>
           %29 = tensor.empty() {ssbuffer.block_id = 0 : i32} : tensor<128x128xf16>
           %transposed = linalg.transpose ins(%28 : tensor<128x128xf16>) outs(%29 : tensor<128x128xf16>) permutation = [1, 0]  {ssbuffer.block_id = 0 : i32}
           %30 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 0 : i32} ins(%23, %transposed : tensor<128x128xf16>, tensor<128x128xf16>) outs(%1 : tensor<128x128xf32>) -> tensor<128x128xf32>
@@ -871,14 +871,14 @@ func.func @_attn_fwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf
           hivm.hir.sync_block_wait {ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
           %31 = hivm.hir.convert_layout %alloc_5 output_shape [128, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 0 : i32} : (memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) -> memref<128x128xf16, #hivm.address_space<cbuf>>
           %memspacecast = memref.memory_space_cast %31 {ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 0 : i32} : memref<128x128xf16, #hivm.address_space<cbuf>> to memref<128x128xf16>
-          %32 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 0 : i32} : memref<128x128xf16> to tensor<128x128xf16>
+          %32 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 0 : i32} : memref<128x128xf16>
           %33 = arith.index_cast %arg19 {ssbuffer.block_id = 1 : i32} : i32 to index
           %34 = arith.muli %33, %c128 {ssbuffer.block_id = 1 : i32} : index
           %35 = arith.addi %34, %22 {ssbuffer.block_id = 1 : i32} : index
           %reinterpret_cast_10 = memref.reinterpret_cast %arg4 to offset: [%35], sizes: [128, 128], strides: [128, 1] {ssbuffer.block_id = 1 : i32} : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
           %alloc_11 = memref.alloc() {ssbuffer.block_id = 1 : i32} : memref<128x128xf16>
           memref.copy %reinterpret_cast_10, %alloc_11 {ssbuffer.block_id = 1 : i32} : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-          %36 = bufferization.to_tensor %alloc_11 restrict writable {gm_load_bufferable, ssbuffer.block_id = 1 : i32} : memref<128x128xf16> to tensor<128x128xf16>
+          %36 = bufferization.to_tensor %alloc_11 restrict writable {gm_load_bufferable, ssbuffer.block_id = 1 : i32} : memref<128x128xf16>
           %37 = tensor.empty() {ssbuffer.block_id = 1 : i32} : tensor<128x128xf32>
           %38 = linalg.fill {ssbuffer.block_id = 1 : i32} ins(%cst_1 : f32) outs(%37 : tensor<128x128xf32>) -> tensor<128x128xf32>
           %39 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 1 : i32} ins(%32, %36 : tensor<128x128xf16>, tensor<128x128xf16>) outs(%38 : tensor<128x128xf32>) -> tensor<128x128xf32>

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/producer_consumer_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/producer_consumer_test.mlir
@@ -32,7 +32,7 @@ func.func @tc_b04_iv_projection(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %qk : tensor<128x128xf32>
   }
@@ -71,7 +71,7 @@ func.func @tc_b04b_iv_projection_runtime_lb(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %qk : tensor<128x128xf32>
   }
@@ -107,7 +107,7 @@ func.func @tc_b06_preserve_original_iter_args(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
     %acc_new = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %acc_new, %lse : tensor<128x128xf32>, tensor<128xf32>
   }
@@ -151,12 +151,12 @@ func.func @tc_b07_dead_dma_elimination(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
 
     %k_src_rc = memref.reinterpret_cast %arg1 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %k_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %k_src_rc, %k_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %k_tensor = bufferization.to_tensor %k_alloc restrict writable : memref<128x128xf16> to tensor<128x128xf16>
+    %k_tensor = bufferization.to_tensor %k_alloc restrict writable : memref<128x128xf16>
 
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %k_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %qk : tensor<128x128xf32>
@@ -195,7 +195,7 @@ func.func @tc_b16_flag_counter_init(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %qk : tensor<128x128xf32>
   }
@@ -230,7 +230,7 @@ func.func @tc_b17_producer_condition_structure(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %qk : tensor<128x128xf32>
   }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/subview_noncopy_user.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/subview_noncopy_user.mlir
@@ -1,0 +1,39 @@
+// RUN: triton-opt --allow-unregistered-dialect --async-load-hoisting %s | FileCheck %s
+
+// Unit Test: SubViewOp with non-CopyOp users
+// Regression test for: segfault when a SubViewOp result has users that are
+// NOT memref::CopyOp (e.g., bufferization.to_tensor).
+// Previously, llvm::dyn_cast<memref::CopyOp> would return nullptr, and
+// visited.insert(nullptr).second would succeed, passing nullptr down the
+// recursion chain, causing a crash.
+
+module {
+  func.func @subview_noncopy_users(%arg0: memref<?xf16>, %arg1: i64) {
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %c32 = arith.constant 32 : index
+
+    // block_id=10: cache group with annotation.mark
+    %alloc = memref.alloc() {ssbuffer.block_id = 10 : i32} : memref<128x32xf16>
+
+    %offset = arith.index_cast %arg1 {ssbuffer.block_id = 10 : i32} : i64 to index
+    %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [%offset], sizes: [1, 32], strides: [32, 1] {ssbuffer.block_id = 10 : i32} : memref<?xf16> to memref<1x32xf16, strided<[32, 1], offset: ?>>
+    %subview = memref.subview %alloc[%c0, %c0] [1, 32] [1, 1] {ssbuffer.block_id = 10 : i32} : memref<128x32xf16> to memref<1x32xf16, strided<[32, 1], offset: ?>>
+    memref.copy %reinterpret_cast, %subview {ssbuffer.block_id = 10 : i32} : memref<1x32xf16, strided<[32, 1], offset: ?>> to memref<1x32xf16, strided<[32, 1], offset: ?>>
+
+    // Key: bufferization.to_tensor uses %subview but is NOT a CopyOp
+    // CHECK: bufferization.to_tensor
+    %tensor = bufferization.to_tensor %subview {ssbuffer.block_id = 10 : i32} : memref<1x32xf16, strided<[32, 1], offset: ?>>
+
+    // annotation.mark uses %alloc — triggers chainContainsBlockArg path
+    annotation.mark %alloc {MayImplicitTransposeWithLastAxis, ssbuffer.block_id = 10 : i32} : memref<128x32xf16>
+
+    // Load from subview using data loaded by CopyOp — should get gm_load_bufferable
+    // CHECK: bufferization.to_tensor
+    // CHECK-SAME: gm_load_bufferable
+    %subview_2 = memref.subview %alloc[%c0, %c0] [1, 32] [1, 1] {ssbuffer.block_id = 10 : i32} : memref<128x32xf16> to memref<1x32xf16, strided<[32, 1], offset: ?>>
+    %loaded = bufferization.to_tensor %subview_2 {ssbuffer.block_id = 10 : i32} : memref<1x32xf16, strided<[32, 1], offset: ?>>
+
+    return
+  }
+}


### PR DESCRIPTION
Add null pointer validation in AsyncLoadHoisting to prevent crashes, and add corresponding unit tests for edge case coverage.

Technical Updates & Improvements
1. Registration of Passes
Files: bin/RegisterTritonDialects.h, AddMultiBufferToGMLoadPass.h, AddMultiBufferToGMLoad.cpp

Description: Added registration entries for AsyncLoadHoisting and gm-load-multi-buffer passes, enabling them to be invoked as independent CLI arguments.

2. AsyncLoadHoisting Null Pointer & Logic Fix
File: AsyncLoadHoisting.cpp

Changes:

Null Pointer Validation: Added checks for llvm::dyn_cast<memref::CopyOp>. Previously, the code would crash when a SubViewOp had users other than CopyOp (e.g., bufferization.to_tensor), causing the cast to return nullptr.

Recursion Safety: Fixed a defect where the return value of visited.insert(defOp) was not checked, ensuring proper handling of the recursion entry point.

Action Item: Corresponding unit tests have been added to cover these edge cases, specifically targeting scenarios with non-CopyOp users and re-visited operations.

3. Type Safety Optimizations
File: MultiBufferLoopBodyEmission.cpp

Simplified validateProducerIterArgInputs by removing redundant int/unsigned conversions, standardizing on size_t.

In validateGroupEmissionInputs, added consistency checks for the sizes of the 6 arrays prior to performing a unified bounds check.

File: LoopTransform.cpp

Updated argOffset from int to size_t in buildExtendedFor to prevent potential overflow during accumulation.