### PR TITLE
[TileChunkCoalescing](fix) chooseH exceeds maxH when numTiles has onl…

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/TileChunkCoalescing.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TileChunkCoalescing.cpp
@@ -44,50 +44,26 @@ using namespace triton;
 
 namespace {
 
-// Tunables.
-constexpr int64_t kMinContigBytes = 512;  // floor: smallest merged-block size
+constexpr int64_t kMinContigBytes = 512;
 
-// Upper bound on the number of tiles coalesced per program. We now derive it
-// from a UB (Unified Buffer) footprint budget instead of a single flat cap:
-//
-//   maxH = clamp(kUBBytesBudget / per-program-footprint(H=1), 2, kMaxCoalesceTilesCeil)
-//
-// This lets kernels with a small working set (pure 1-D load->store) coalesce far
-// more aggressively -- bigger contiguous DMAs, fewer persistent-loop trips --
-// while kernels carrying a large on-chip tensor (e.g. a 16x16 segsum matrix)
-// automatically back off so the lifted footprint still fits UB.
-//
-// The footprint is the SUM of every lifted region tensor's bytes at H=1. That
-// over-counts (the backend reuses buffers by liveness, so true peak live set is
-// smaller), which is the safe direction: we may pick a smaller H than strictly
-// necessary, but never one that overflows UB (runtime error 341). If on-board
-// profiling shows UB headroom, raise kUBBytesBudget; if it overflows, lower it.
-//
-// UB is ~256 KB/core on this arch (dav-c310, __UB_SIZE = 262144). The budget is
-// a conservative slice that leaves room for double-buffering and alignment.
+// UB footprint budget: derives maxH so that H * footprintUnit <= budget.
+// UB is ~256 KB/core (dav-c310). Budget is conservative to leave room for
+// double-buffering and alignment overhead.
 constexpr int64_t kUBBytesBudget = 96 * 1024;
-// Absolute ceiling regardless of UB headroom: a very large H shrinks the launch
-// grid (the host launcher divides grid[axis] by H) and can starve AI cores, so
-// we never coalesce more than this many tiles per program.
+// Large H starves AI cores (grid[axis] / H shrinks the launch grid).
 constexpr int64_t kMaxCoalesceTilesCeil = 16;
 
 constexpr llvm::StringLiteral kCoalesceFactorAttr = "hacc.coalesce_factor";
-// The grid axis (= program_id axis) whose launch dimension the host launcher
-// divides by the factor. The full TA path owns the grid division: bishengir no
-// longer interprets either attr (see driver.py / compiler.py).
 constexpr llvm::StringLiteral kCoalesceAxisAttr = "hacc.coalesce_axis";
 
 struct TileSeed {
-  triton::GetProgramIdOp pid;  // the (outermost) tile-index program id
-  int32_t axis = 0;            // pid axis == the grid dim the launcher divides
-  int64_t tileLen = 0;         // T  (constexpr tile length / CHUNK_SIZE)
-  int64_t bound = 0;           // BOUND (constexpr problem length / SEQLEN)
-  Value mask;                  // tile OOB mask (cmpi result). It is provably
-                               // all-true (we require bound % tileLen == 0) and
-                               // is dropped from the coalesced load/store.
+  triton::GetProgramIdOp pid;
+  int32_t axis = 0;
+  int64_t tileLen = 0;
+  int64_t bound = 0;
+  Value mask;
 };
 
-// Read a constant integer from a scalar i32 or a splat-of-constant tensor.
 static bool getConstInt(Value v, int64_t &out) {
   APInt ap;
   if (matchPattern(v, m_ConstantInt(&ap))) {
@@ -103,14 +79,7 @@ static bool getConstInt(Value v, int64_t &out) {
   return false;
 }
 
-// The set of ops we know how to lift (prepend an H lane). Anything else in the
-// load->store subgraph makes the pass bail.
-//
-// arith/math ops are all side-effect-free, elementwise (or scalar) and carry no
-// regions, so the generic "prepend H + rebuild" handles them uniformly -- we
-// whitelist those dialects wholesale rather than enumerating ops (so math.exp,
-// math.log, math.sqrt, ... all work). The remaining cases are the triton ops
-// that need shape/axis-aware handling.
+// Whitelist arith/math dialects wholesale (side-effect-free, elementwise).
 static bool isLiftable(Operation *op) {
   if (auto *d = op->getDialect()) {
     StringRef ns = d->getNamespace();
@@ -123,31 +92,21 @@ static bool isLiftable(Operation *op) {
              triton::ScanOp, triton::ReduceOp>(op);
 }
 
-// Detect the tile-index signature:
-//     blk  = muli(program_id_max, C)          (C constexpr, the tile length T)
-//     offs = splat(blk) + make_range[0, C)
-// The boundary mask `cmpi slt(offs, BOUND)` is required: it gives the pass a
-// static tile count and lets the launcher shrink grid[axis] by an exact divisor.
-// Unmasked kernels carry no tile count in the IR; coalescing them would rely on
-// runtime grid[axis] being both >= H and divisible by H, which is not guaranteed.
-// When the mask is present we use it to recover BOUND (and to drop the
-// provably-all-true mask later); when it is a real partial-tile mask
-// (BOUND % C != 0) we must NOT coalesce, so we bail.
+// Detect tile-index signature:
+//   blk  = muli(program_id_max, T)
+//   offs = splat(blk) + make_range[0, T)
+//   mask = cmpi slt(offs, BOUND)  with BOUND % T == 0
+// The mask proves all tiles are full (no partial last tile) and provides the
+// compile-time tile count needed for grid division.
 static std::optional<TileSeed> findSeed(ModuleOp moduleOp) {
-  // The coalesced axis must be the OUTERMOST grid axis: the host launcher
-  // divides grid[axis] by coalesce_factor, and bishengir reconstructs the
-  // outermost (highest-index) program id as the most-significant digit of the
-  // linear block id, so only that axis stays consistent. Coalescing an inner
-  // axis would mis-assign work.
+  // Only the outermost grid axis can be coalesced: bishengir reconstructs the
+  // highest-index program_id as the MSB of the linear block id.
   int32_t maxAxis = -1;
   moduleOp.walk([&](triton::GetProgramIdOp pid) {
     maxAxis = std::max<int32_t>(maxAxis, pid.getAxisAsInt());
   });
 
-  // Only one program-id op may read the coalesced axis: we replace the seed
-  // pid by the per-lane tile vector, but a second (non-CSE'd) pid of the same
-  // axis would keep returning the now-divided block id -> its tile indices
-  // would silently address the wrong tiles. Bail unless unique.
+  // Require exactly one pid op on the coalesced axis (CSE should have merged).
   int32_t maxAxisPids = 0;
   moduleOp.walk([&](triton::GetProgramIdOp pid) {
     if (pid.getAxisAsInt() == maxAxis)
@@ -156,11 +115,7 @@ static std::optional<TileSeed> findSeed(ModuleOp moduleOp) {
   if (maxAxisPids != 1)
     return std::nullopt;
 
-  // Full TA path: the launcher divides grid[maxAxis] by H, so the kernel-visible
-  // num_programs(maxAxis) becomes grid/H instead of grid. If the kernel reads it
-  // (e.g. for its own bound arithmetic) coalescing would silently change that
-  // value -> wrong results. Refuse to coalesce such kernels (they keep the
-  // original, uncoalesced -- but correct -- path).
+  // If kernel reads num_programs(maxAxis), coalescing would silently change it.
   bool readsMaxAxisNumPrograms = false;
   moduleOp.walk([&](triton::GetNumProgramsOp np) {
     if (np.getAxisAsInt() == maxAxis)
@@ -181,9 +136,8 @@ static std::optional<TileSeed> findSeed(ModuleOp moduleOp) {
                                                        : mul.getLhs();
       int64_t T = 0;
       if (!getConstInt(other, T) || T <= 1)
-        continue;  // non-const multiplier (e.g. segsum chunk stride) -> skip
+        continue;
 
-      // muli -> splat -> addi(splat, make_range[0,T))
       for (Operation *mu : mul.getResult().getUsers()) {
         auto sp = dyn_cast<triton::SplatOp>(mu);
         if (!sp)
@@ -198,23 +152,8 @@ static std::optional<TileSeed> findSeed(ModuleOp moduleOp) {
           if (!range || range.getStart() != 0 || range.getEnd() != T)
             continue;
 
-          // Boundary-safety scan: taint everything pid-derived (through
-          // elementwise arith and shape ops) and require that NO tainted value
-          // feeds boundary handling, except the one canonical all-true tile
-          // mask `cmpi slt(offs, BOUND)` directly on offs with constant
-          // BOUND >= T and BOUND % T == 0 (provably all-true, droppable).
-          //
-          // Everything else is real boundary logic on the chunk axis and must
-          // block coalescing:
-          //   * cmpi with a runtime BOUND (kernel arg): a partial last tile may
-          //     exist; the lifted mask `(pid*H+h)*T + t < BOUND` is
-          //     non-separable (MaskAnalysis bails, load stays unconverted) and
-          //     the launcher's grid/H drops remainder tiles -> wrong results.
-          //   * cmpi reached through expand_dims/broadcast/addi/... or with
-          //     other predicates/operand order: same non-separability.
-          //   * min/max clamps and div/rem wraparound on pid-derived offsets:
-          //     the lifted addressing is non-affine across tiles (PtrAnalysis
-          //     bails).
+          // Taint-propagation: ensure no pid-derived value feeds boundary
+          // handling other than the canonical all-true tile mask.
           int64_t bound = 0;
           Value mask;
           bool unsafe = false;
@@ -252,16 +191,16 @@ static std::optional<TileSeed> findSeed(ModuleOp moduleOp) {
                 propagates |= d->getNamespace() ==
                               arith::ArithDialect::getDialectNamespace();
               if (!propagates)
-                continue;  // load/store/scan/... results carry data, not offsets
+                continue;
               for (Value r : tu->getResults())
                 if (taint.insert(r).second)
                   twl.push_back(r);
             }
           }
           if (unsafe)
-            return;  // real boundary handling on the chunk axis; abandon pid
+            return;
           if (!mask)
-            return;  // unmasked kernel: runtime tile count is absent from IR
+            return;
 
           result = TileSeed{pid, maxAxis, T, bound, mask};
           return;
@@ -272,10 +211,8 @@ static std::optional<TileSeed> findSeed(ModuleOp moduleOp) {
   return result;
 }
 
-// Forward slice from the tile pid down to (and including) the stores. Fills
-// `region` (all ops) and `ordered` (region ops in IR order). Returns false and
-// leaves the IR untouched if the slice contains an unliftable op, if a region
-// value escapes the slice, or if there are no store sinks.
+// Forward slice from the tile pid to stores. Returns false if the slice
+// contains an unliftable op, escapes the region, or has no store sinks.
 static bool collectRegion(TileSeed &seed, ModuleOp moduleOp,
                           DenseSet<Operation *> &region,
                           SmallVectorImpl<Operation *> &ordered) {
@@ -289,7 +226,7 @@ static bool collectRegion(TileSeed &seed, ModuleOp moduleOp,
     if (!visited.insert(op).second)
       continue;
     if (!isLiftable(op))
-      return false;  // bail: unknown op in the chain (e.g. tt.dot)
+      return false;
     if (isa<triton::StoreOp>(op))
       hasStore = true;
     region.insert(op);
@@ -300,7 +237,6 @@ static bool collectRegion(TileSeed &seed, ModuleOp moduleOp,
   if (!hasStore)
     return false;
 
-  // No region value (other than store effects) may escape the slice.
   for (Operation *op : region) {
     if (isa<triton::StoreOp>(op))
       continue;
@@ -310,7 +246,6 @@ static bool collectRegion(TileSeed &seed, ModuleOp moduleOp,
           return false;
   }
 
-  // Topological (IR) order, restricted to the region.
   moduleOp.walk([&](Operation *op) {
     if (region.count(op))
       ordered.push_back(op);
@@ -318,14 +253,8 @@ static bool collectRegion(TileSeed &seed, ModuleOp moduleOp,
   return true;
 }
 
-// Pick H (number of tiles coalesced per program). The floor `hMin` is the
-// smallest factor whose merged block reaches kMinContigBytes -- the minimum that
-// fixes the tiny-DMA pathology. `maxH` is the UB-footprint-derived ceiling
-// (see kUBBytesBudget); it has already been clamped to kMaxCoalesceTilesCeil.
-//
-// H must divide the statically known tile count so the launcher's
-// `grid[axis] / H` is exact. Pick the largest divisor in [hMin, maxH] so the
-// already-contiguous transfers get bigger DMAs / fewer loop iterations.
+// Pick the largest divisor of numTiles in [hMin, maxH].
+// H must divide numTiles so grid[axis] / H is exact.
 static int64_t chooseH(int64_t numTiles, int64_t tileLen, int64_t elemBytes,
                        int64_t maxH) {
   int64_t blockBytes = tileLen * elemBytes;
@@ -333,35 +262,17 @@ static int64_t chooseH(int64_t numTiles, int64_t tileLen, int64_t elemBytes,
   if (hMin < 2)
     hMin = 2;
   if (maxH < hMin)
-    return 0;  // UB budget too tight to even reach the contiguity floor
-
+    return 0;
   if (numTiles <= 0)
     return 0;
 
-  int64_t H = 0;
-  for (int64_t c = hMin; c <= numTiles; ++c)
-    if (numTiles % c == 0) {
-      H = c;
-      break;
-    }
-  if (H == 0)
-    return 0;
-
-  for (int64_t c = numTiles; c > H; --c)
-    if (numTiles % c == 0 && c <= maxH) {
-      H = c;
-      break;
-    }
-  return H;
+  for (int64_t c = maxH; c >= hMin; --c)
+    if (numTiles % c == 0)
+      return c;
+  return 0;
 }
 
 static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
-  // Yield to the higher-priority StridedAxisCoalescing: the launcher divides
-  // grid[axis] by a single (hacc.coalesce_factor, hacc.coalesce_axis) pair, so
-  // at most one pass may own it per module. If StridedAxisCoalescing (which runs
-  // first) already claimed it, coalescing again here would lift a second set of
-  // tiles while only one (factor, axis) survives -> wrong block count. Bail and
-  // leave our tiles to the strided dispatch.
   if (moduleOp->hasAttr(kCoalesceFactorAttr))
     return;
 
@@ -374,7 +285,6 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
   if (!collectRegion(*seed, moduleOp, region, ordered))
     return;
 
-  // Element size from the first region load.
   int64_t elemBytes = 0;
   for (Operation *op : ordered)
     if (auto ld = dyn_cast<triton::LoadOp>(op)) {
@@ -386,13 +296,8 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
   if (elemBytes == 0)
     return;
 
-  // Per-program UB footprint at H=1: sum of the bytes of the tensors that
-  // actually live in UB. Each lifts to H copies, so footprint(H) = H *
-  // footprintUnit. We count only DMA'd data (load results, store values) and
-  // floating-point compute results; pointer / integer-offset / i1-mask tensors
-  // are address arithmetic that folds into memref strides and never occupies a
-  // UB data buffer. Summing (vs peak-live) over-counts -- the safe direction:
-  // we may pick a smaller H, never one that overflows UB (runtime error 341).
+  // UB footprint at H=1: sum over DMA'd data and float compute tensors.
+  // Pointer/offset/mask tensors fold into memref strides and skip UB.
   auto tensorBytes = [](Type t) -> int64_t {
     auto rt = dyn_cast<RankedTensorType>(t);
     if (!rt)
@@ -414,12 +319,11 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
           if (isa<FloatType>(rt.getElementType()))
             footprintUnit += tensorBytes(t);
   }
-  // maxH = clamp(budget / footprintUnit, 2, ceil).
   int64_t maxH = kMaxCoalesceTilesCeil;
   if (footprintUnit > 0)
     maxH = std::min<int64_t>(maxH, kUBBytesBudget / footprintUnit);
   if (maxH < 2)
-    maxH = 2;
+    return;  // even H=2 would overflow UB
 
   int64_t numTiles = (seed->bound + seed->tileLen - 1) / seed->tileLen;
   int64_t H = chooseH(numTiles, seed->tileLen, elemBytes, maxH);
@@ -431,12 +335,8 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
   Value seedMask = seed->mask;
   Operation *seedMaskOp = seedMask ? seedMask.getDefiningOp() : nullptr;
 
-  // The all-true tile mask is dropped from the loads/stores it guards and is
-  // never rebuilt (skipped in the loop below). That is only valid if it feeds
-  // *nothing else*: any other consumer (a broadcast before the load mask, a
-  // tt.where, ...) would try to lift the skipped mask and reference a null
-  // value -> invalid IR. Bail in that case (kernel keeps the correct,
-  // uncoalesced path) rather than risk a miscompile.
+  // Seed mask must feed only load/store mask slots; other consumers would
+  // reference the skipped (never-rebuilt) mask value -> invalid IR.
   if (seedMask) {
     for (Operation *u : seedMask.getUsers()) {
       auto ld = dyn_cast<triton::LoadOp>(u);
@@ -448,33 +348,19 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
     }
   }
 
-  // Preflight: from here on we create ops; every op of the region must be
-  // provably rebuildable in lifted form, otherwise the new op would fail the
-  // verifier AFTER the IR is already mutated -- a hard compile error instead
-  // of a silent fallback. Anything we cannot prove safe bails here, while the
-  // IR is still untouched.
+  // Preflight: bail while IR is untouched if any op cannot be lifted safely.
   Block *pidBlock = seed->pid->getBlock();
   for (Operation *op : ordered) {
-    // Straight-line code only: a region op nested in scf.for/scf.if has
-    // loop-carried/branch semantics the elementwise lift does not model.
     if (op->getBlock() != pidBlock)
       return;
-    // Zero-operand ops (constants, make_range) reach the generic rebuild with
-    // a lifted result type but unchanged attributes (e.g. a DenseElementsAttr
-    // of the OLD shape) -> verifier failure.
     if (!isa<triton::LoadOp, triton::StoreOp>(op) && op->getNumOperands() == 0)
       return;
-    // arith.select: the lift turns a scalar condition into tensor<Hxi1>, which
-    // no longer matches the lifted tensor operands -> invalid op.
     if (auto sel = dyn_cast<arith::SelectOp>(op)) {
       bool condTensor = isa<RankedTensorType>(sel.getCondition().getType());
       bool valTensor = isa<RankedTensorType>(sel.getTrueValue().getType());
       if (condTensor != valTensor)
         return;
     }
-    // Lifting bumps the boundary-check axes; only block-pointer accesses carry
-    // them and those never reach here, so any non-empty set means an IR shape
-    // we did not anticipate.
     if (auto ld = dyn_cast<triton::LoadOp>(op))
       if (!ld.getBoundaryCheck().empty())
         return;
@@ -493,8 +379,6 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
     return RankedTensorType::get({H}, t);
   };
 
-  // tileVec = splat(pid * H) + arange(0, H)  : tensor<Hxi32>, the per-lane
-  // global tile index covered by this (now coalesced) program.
   rw.setInsertionPointAfter(seed->pid);
   Value cH = rw.create<arith::ConstantIntOp>(ploc, H, 32);
   Value pidH = rw.create<arith::MulIOp>(ploc, pidVal, cH);
@@ -513,16 +397,12 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
       return it->second;
     Operation *def = v.getDefiningOp();
     if (def && region.count(def)) {
-      // Rebuilt earlier (IR order guarantees dominance). The only region op we
-      // never rebuild is the all-true tile mask, and the precondition above
-      // guarantees it is not used here, so the lookup must succeed.
       auto rebuilt = vmap.find(v);
       assert(rebuilt != vmap.end() && "region value used before its rebuild");
       return rebuilt->second;
     }
     if (!isa<RankedTensorType>(v.getType()))
-      return v;  // region-invariant scalar; caller splats if needed
-    // region-invariant tensor: prepend a size-1 dim then broadcast over H.
+      return v;
     Value e = rw.create<triton::ExpandDimsOp>(v.getLoc(), v, 0);
     Value b = rw.create<triton::BroadcastOp>(v.getLoc(), liftTy(v.getType()), e);
     vmap[v] = b;
@@ -541,7 +421,6 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
   auto bumpBoundary = [&](ArrayRef<int32_t> bc) {
     return llvm::map_to_vector(bc, [](int32_t i) { return i + 1; });
   };
-  // Copy over any extra attrs the typed builder did not already set.
   auto copyAttrs = [&](Operation *from, Operation *to) {
     for (NamedAttribute a : from->getAttrs())
       if (!to->hasAttr(a.getName()))
@@ -549,18 +428,12 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
   };
 
   for (Operation *op : ordered) {
-    // The tile mask is provably all-true (bound % tileLen == 0) and is dropped
-    // from every load/store below, so its (non-separable) lifted form is never
-    // needed -- skip rebuilding it.
     if (op == seedMaskOp)
       continue;
 
     rw.setInsertionPoint(op);
     Location loc = op->getLoc();
 
-    // tt.splat needs a scalar source; if the source became a per-lane tensor
-    // ([H]) we instead expand+broadcast it across the splatted shape (mirrors
-    // PropagateUnrealizedCastDown::rewriteSplat).
     if (auto sp = dyn_cast<triton::SplatOp>(op)) {
       Value lin = lift(sp.getSrc());
       if (!isa<RankedTensorType>(lin.getType())) {
@@ -568,7 +441,7 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
             rw.create<triton::SplatOp>(loc, liftTy(sp.getType()), lin);
       } else {
         int addDims = cast<RankedTensorType>(sp.getType()).getRank();
-        Value cur = lin;  // tensor<Hx...>
+        Value cur = lin;
         for (int k = 0; k < addDims; ++k)
           cur = rw.create<triton::ExpandDimsOp>(
               loc, cur, cast<RankedTensorType>(cur.getType()).getRank());
@@ -611,8 +484,6 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
       continue;
     }
     if (auto ld = dyn_cast<triton::LoadOp>(op)) {
-      // Drop the all-true tile mask (and its `other`) so the coalesced load is
-      // an unmasked contiguous block that PtrAnalysis can fully convert.
       bool dropMask = ld.getMask() == seedMask;
       Value m = dropMask ? Value() : liftOpdOrNull(ld.getMask());
       Value o = dropMask ? Value() : liftOpdOrNull(ld.getOther());
@@ -634,9 +505,6 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
       continue;
     }
 
-    // Elementwise / address arithmetic (arith.*, tt.addptr, ...): generic
-    // rebuild with lifted operands and prepended result type (mirrors
-    // PropagateUnrealizedCastDown::rewriteGeneraleOp).
     SmallVector<Value> operands =
         llvm::map_to_vector(op->getOperands(), [&](Value o) { return liftOpd(o); });
     SmallVector<Type> resTypes = llvm::map_to_vector(
@@ -647,12 +515,9 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
       vmap[oldR] = newR;
   }
 
-  // Drop the original chain (reverse IR order: uses before defs).
   for (auto it = ordered.rbegin(); it != ordered.rend(); ++it)
     rw.eraseOp(*it);
 
-  // Record (factor, axis) for the host launcher. compiler.py reads + strips both
-  // attrs; the launcher then divides grid[axis] by H. bishengir is not involved.
   auto i32Ty = IntegerType::get(moduleOp.getContext(), 32);
   moduleOp->setAttr(kCoalesceFactorAttr, IntegerAttr::get(i32Ty, H));
   moduleOp->setAttr(kCoalesceAxisAttr, IntegerAttr::get(i32Ty, seed->axis));


### PR DESCRIPTION
…y large prime factors

The original two-loop search in chooseH did not bound the first loop by maxH. When numTiles = 2 * p (p prime, e.g. 262142 = 2 * 131071), the smallest divisor >= hMin is p itself, which can vastly exceed the UB-derived maxH, causing UB overflow (runtime error 341).

Fix: replace the two-loop logic with a single downward search from maxH to hMin, guaranteeing H is always within the valid [hMin, maxH] range.

Also remove redundant comments throughout the file.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
