### PR TITLE
[TritonOp](revert) Revert reduce to align with upstream

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2631,9 +2631,9 @@ def reduce(input, axis, combine_fn, keep_dims=False, _semantic=None, _generator=
     ret = _semantic.reduction(input, axis, make_combine_region)
     if keep_dims:
         if axis is not None:
-            ret = builtins.tuple(expand_dims(t, axis, _semantic=_semantic) for t in ret)
+            ret = tuple(expand_dims(t, axis, _semantic=_semantic) for t in ret)
         else:
-            ret = builtins.tuple(expand_ndims(t, len(input[0].shape)) for t in ret)
+            ret = tuple(expand_ndims(t, len(input[0].shape)) for t in ret)
     return ret
 
 


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
### Related Issue
#645 
### Summary

Revert `builtins.tuple` back to `tuple` in the `reduce` op to align with upstream.

### Why

The previous `reduce` implementation prematurely adopted the 3.4 version's Triton `tuple` class. Using the higher-version `tuple` class on 3.2 caused compilation errors in `tl.reduce`. An intrusive workaround was introduced — replacing `tuple(...)` with `builtins.tuple(...)` to use Python's builtin tuple as a stopgap.

After the forward upgrade to 3.5, the Triton `tuple` class is fully functional. Using `tuple(...)` in `reduce` no longer causes compilation issues. Reverting the intrusive change restores alignment with upstream.


# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
