### PR TITLE
[Launcher](feat) Support specifying device index in tensor

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -696,6 +696,13 @@ class JITFunction(JITCallable, KernelInterface[T]):
         kwargs["debug"] = kwargs.get("debug", self.debug) or knobs.runtime.debug
         kwargs["instrumentation_mode"] = knobs.compilation.instrumentation_mode
 
+        for arg in args:
+            if hasattr(arg, 'device') and str(arg.device).startswith('npu'):
+                target_device = arg.device.index
+                if target_device is not None and target_device != driver.active.get_current_device():
+                    driver.active.set_current_device(target_device)
+                break
+
         # parse options
         device = driver.active.get_current_device()
         stream = driver.active.get_current_stream(device)

--- a/third_party/ascend/unittest/pytest_ut/test_specified_device_index.py
+++ b/third_party/ascend/unittest/pytest_ut/test_specified_device_index.py
@@ -1,0 +1,40 @@
+"""
+Vector Addition on Specified NPU Device Index
+
+Verifies that a Triton kernel can be launched on tensors created with an
+explicit device index (e.g. "npu:2").
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def add_kernel(x_ptr, y_ptr, output_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    output = x + y
+    tl.store(output_ptr + offsets, output, mask=mask)
+
+
+def test_add_kernel_on_specified_device_index():
+    torch.manual_seed(0)
+
+    n_elements = 4096
+    BLOCK_SIZE = 1024
+    device = "npu:2"
+
+    x = torch.rand(n_elements, device=device)
+    y = torch.rand(n_elements, device=device)
+    output = torch.empty_like(x)
+
+    grid = ((n_elements + BLOCK_SIZE - 1) // BLOCK_SIZE, )
+    add_kernel[grid](x, y, output, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+
+    expected = x + y
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

### Summary

Add automatic multi-device context correction in `NPULauncher.__call__`: scan launcher args for NPU tensors to determine the target device, and if it differs from the current device, switch both the device and stream before launching. This enables `torch.rand(device='npu:1')` to work correctly in multi-device environments.

### Why

`torch.rand(device='npu:1')` does not update `torch.npu.current_device()` after creating the tensor — it remains 0. Triton's `JITFunction.run()` determines `device` and `stream` via `get_current_device()` before kernel args are parsed, causing the kernel to launch on device 0 with device 1 pointers, which directly triggers a `DDR address out of range` hardware exception.

Before the kernel is dispatched to hardware, check whether the current device matches the expected execution device. If not, switch both the device and stream so that the tensor computation runs on the intended device.

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
