### PR TITLE
[ssbuffer](fix) FixpipeOpt apply only when hint enable_fast_tf32_mul

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -51,6 +51,7 @@ inline constexpr llvm::StringLiteral kLoopCarriedL0C = "ssbuffer.loop_carried_l0
 inline constexpr llvm::StringLiteral kCrossDeps = "ssbuffer.crossDeps";
 inline constexpr llvm::StringLiteral kMayNotExec = "ssbuffer.may_not_exec";
 inline constexpr llvm::StringLiteral kClone = "ssbuffer.clone";
+static constexpr llvm::StringLiteral kInlinableQuantScaleAttr = "enable_fast_tf32_mul";
 inline constexpr const char *ERRCODE_ATTR = "triton_ascend.dynamic_cv_pipeline.rc";
 static constexpr const int ERRCODE_FAILED = 1;
 static constexpr const int ERRCODE_IGNORED = 2;

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/MemoryEffectsTracker.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/MemoryEffectsTracker.cpp
@@ -35,6 +35,7 @@
 // all prior writers/readers and become the sole writer for every slot.
 
 #include "ascend/include/DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/IR/Block.h"
@@ -288,8 +289,12 @@ SmallVector<MemoryEffects::EffectInstance> MemoryDependenceGraph::collectOuterEf
     unknown = false;
 
     if (auto markOp = dyn_cast<annotation::MarkOp>(op)) {
-        MemoryEffects::EffectInstance scopedWrite(MemoryEffects::Write::get());
-        return {remapEffectValue(scopedWrite, markOp.getSrc())};
+        if (markOp->hasAttr(CVPipeline::kInlinableQuantScaleAttr)) {
+            return {};
+        } else {
+            MemoryEffects::EffectInstance scopedWrite(MemoryEffects::Write::get());
+            return {remapEffectValue(scopedWrite, markOp.getSrc())};
+        }
     }
 
     if (auto allocTensorOp = dyn_cast<bufferization::AllocTensorOp>(op)) {

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
@@ -19,11 +19,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
+ 
+#include <optional>
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
@@ -41,7 +43,6 @@
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Support/LLVM.h"
 #include "triton/Analysis/Utility.h"
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -282,10 +283,25 @@ void transSource(Value value, SetVector<Operation *> &matchedOps, Block *block)
     }
 }
 
+bool hasQuantScaleCompileHint(Operation *op, SetVector<Operation *> &matchedOps)
+{
+    return any_of(op->getUsers(), [&](Operation *userOp) {
+        auto markOp = dyn_cast<annotation::MarkOp>(userOp);
+        if (!markOp) {
+            return false;
+        }
+        matchedOps.insert(markOp);
+        return markOp->hasAttr(CVPipeline::kInlinableQuantScaleAttr);
+    });
+}
+
 bool FixpipeOptPass::isValidMul(Operation *op, Value matmulValue, SetVector<Operation *> &matchedOps)
 {
     // Just filter: arith.mulf/muli(scalar)
     if (!isa<arith::MulFOp>(op) && !isa<arith::MulIOp>(op)) {
+        return false;
+    }
+    if (!hasQuantScaleCompileHint(op, matchedOps)) {
         return false;
     }
     auto quantScalarValue = op->getOperand(0) == matmulValue ? op->getOperand(1) : op->getOperand(0);
@@ -425,6 +441,23 @@ bool FixpipeOptPass::isFixpipeCastPattern(Operation *truncOp, SetVector<Operatio
     return true;
 }
 
+std::optional<Operation *> getOneUserExceptMarkOp(Operation *op)
+{
+    int count = 0;
+    Operation *onlyUser = nullptr;
+    for (auto user : op->getUsers()) {
+        if (!isa<annotation::MarkOp>(user)) {
+            count += 1;
+            onlyUser = user;
+        }
+    }
+    if (count != 1) {
+        return std::nullopt;
+    } else {
+        return onlyUser;
+    }
+}
+
 /** Fixpipe supports scaling, the pattern should be like below:
     linalg.matmul
         ↓
@@ -438,26 +471,25 @@ bool FixpipeOptPass::isFixpipeCastPattern(Operation *truncOp, SetVector<Operatio
 bool FixpipeOptPass::isFixpipeMulPattern(Operation *mulOp, SetVector<Operation *> &matchedOps)
 {
     Value mulResult = mulOp->getResult(0);
-    if (!mulResult.hasOneUse()) {
+    auto maybeExtract = getOneUserExceptMarkOp(mulOp).value_or(nullptr);
+    if (!maybeExtract) {
         LOG_DEBUG("Mul not only one user, NOT match.");
         return false;
     }
-    auto maybeExtract = *mulResult.getUsers().begin();
     tensor::ExtractSliceOp extractSliceOp = nullptr;
-    Value extractResult = mulResult;
     if (auto extract = dyn_cast<tensor::ExtractSliceOp>(maybeExtract)) {
         extractSliceOp = extract;
-        extractResult = extractSliceOp.getResult();
         matchedOps.insert(extractSliceOp);
     }
 
-    if (!extractResult.hasOneUse()) {
+    if (extractSliceOp && !getOneUserExceptMarkOp(extractSliceOp).has_value()) {
         LOG_DEBUG("Extract Slice not only one user, NOT match.");
         return false;
     }
 
+    auto storeOp = extractSliceOp ? getOneUserExceptMarkOp(extractSliceOp).value() : maybeExtract;
     matchedOps.insert(mulOp);
-    if (!isStoreToGM(*extractResult.getUsers().begin(), matchedOps)) {
+    if (!isStoreToGM(storeOp, matchedOps)) {
         LOG_DEBUG("Not store to GM pattern, NOT match.");
         return false;
     }

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -394,6 +394,18 @@ void OpClassifierPass::matchMaterializePattern(Operation *user)
     cubeSeeds.push_back(user);
 }
 
+static bool allResultHasOneUser(Operation *op)
+{
+    bool ret = true;
+    for (Value result : op->getResults()) {
+        if (!result.hasOneUse()) {
+            ret = false;
+            break;
+        }
+    }
+    return ret;
+}
+
 // Pattern matching for CUBE operations
 int OpClassifierPass::patternMatchCUBE()
 {
@@ -434,14 +446,14 @@ int OpClassifierPass::patternMatchCUBE()
 
         // ---- Downstream pattern matching ----
         for (Value result : op->getResults()) {
-            if (!op->hasOneUse()) {
+            if (!result.hasOneUse()) {
                 continue;
             }
             for (Operation *user : result.getUsers()) {
                 // If user is scf.yield, follow the chain to find real users
                 Operation *curUser = user;
                 while (curUser) {
-                    if (!curUser->hasOneUse()) {
+                    if (!allResultHasOneUser(curUser)) {
                         break;
                     }
                     if (auto yieldOp = dyn_cast<scf::YieldOp>(curUser)) {

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/fixpipe_opt.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/fixpipe_opt.mlir
@@ -202,37 +202,39 @@ module {
     return
   }
 
-  // Test 12: mulf with splat constant tensor - should match (scalar-like via constant splat)
+  // Test 12: mulf with splat constant tensor - should NOT match (no hint)
   // CHECK-LABEL: func @test_mulf_with_scalar_constant
   func.func @test_mulf_with_scalar_constant(%arg0: memref<128x64xf32> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>) {
     %c0 = arith.constant 0 : index
     // CHECK: linalg.matmul {ssbuffer.block_id = 111 : i32, ssbuffer.core_type = "CUBE"}
     %matmul = linalg.matmul {ssbuffer.block_id = 111 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
-    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 111 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: arith.constant dense<0.00392{{.*}} : tensor<64x64xf32>
     %scale_tensor = arith.constant dense<0.003921568627> : tensor<64x64xf32>
+    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 112 : i32, ssbuffer.core_type = "VECTOR"}
     %mulf = arith.mulf %matmul, %scale_tensor {ssbuffer.block_id = 112 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
-    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 111 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 113 : i32, ssbuffer.core_type = "VECTOR"}
     %extract = tensor.extract_slice %mulf[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 113 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf32>
-    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 111 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 114 : i32, ssbuffer.core_type = "VECTOR"}
     %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 114 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf32> to memref<64x64xf32, strided<[64, 1]>>
-    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 111 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 115 : i32, ssbuffer.core_type = "VECTOR"}
     bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 115 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf32>, memref<64x64xf32, strided<[64, 1]>>) -> ()
     return
   }
 
-  // Test 13: mulf with splat constant tensor (reversed order) - should match
+  // Test 13: mulf with splat constant tensor (reversed order) - should NOT match (no hint)
   // CHECK-LABEL: func @test_mulf_with_scalar_constant_reversed
   func.func @test_mulf_with_scalar_constant_reversed(%arg0: memref<128x64xf32> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>) {
     // CHECK: linalg.matmul {ssbuffer.block_id = 121 : i32, ssbuffer.core_type = "CUBE"}
     %matmul = linalg.matmul {ssbuffer.block_id = 121 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
-    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 121 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: arith.constant dense<0.00392{{.*}} : tensor<64x64xf32>
     %scale_tensor = arith.constant dense<0.003921568627> : tensor<64x64xf32>
+    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 122 : i32, ssbuffer.core_type = "VECTOR"}
     %mulf = arith.mulf %scale_tensor, %matmul {ssbuffer.block_id = 122 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>  // scale first, matmul second
-    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 121 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 123 : i32, ssbuffer.core_type = "VECTOR"}
     %extract = tensor.extract_slice %mulf[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 123 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf32>
-    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 121 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 124 : i32, ssbuffer.core_type = "VECTOR"}
     %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 124 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf32> to memref<64x64xf32, strided<[64, 1]>>
-    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 121 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 125 : i32, ssbuffer.core_type = "VECTOR"}
     bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 125 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf32>, memref<64x64xf32, strided<[64, 1]>>) -> ()
     return
   }
@@ -268,38 +270,100 @@ module {
     return
   }
 
-  // Test 16: muli with integer dense constant tensor - should match
+  // Test 16: muli with integer dense constant tensor - should NOT match (no hint)
   // CHECK-LABEL: func @test_mulf_with_int_scalar
   func.func @test_mulf_with_int_scalar(%arg0: memref<128x64xi32> {tt.divisibility = 16 : i32}, %A: tensor<64x64xi16>, %B: tensor<64x64xi16>, %init: tensor<64x64xi32>) {
     // CHECK: linalg.matmul {ssbuffer.block_id = 181 : i32, ssbuffer.core_type = "CUBE"}
     %matmul = linalg.matmul {ssbuffer.block_id = 181 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xi16>, tensor<64x64xi16>) outs(%init : tensor<64x64xi32>) -> tensor<64x64xi32>
-    // CHECK: arith.muli %{{.*}} {ssbuffer.block_id = 181 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: arith.constant dense<255> : tensor<64x64xi32>
     %scale_tensor = arith.constant dense<255> : tensor<64x64xi32>
+    // CHECK: arith.muli %{{.*}} {ssbuffer.block_id = 182 : i32, ssbuffer.core_type = "VECTOR"}
     %mulf = arith.muli %matmul, %scale_tensor {ssbuffer.block_id = 182 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xi32>
-    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 181 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 183 : i32, ssbuffer.core_type = "VECTOR"}
     %extract = tensor.extract_slice %mulf[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 183 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xi32> to tensor<64x64xi32>
-    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 181 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 184 : i32, ssbuffer.core_type = "VECTOR"}
     %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 184 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xi32> to memref<64x64xi32, strided<[64, 1]>>
-    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 181 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 185 : i32, ssbuffer.core_type = "VECTOR"}
     bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 185 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xi32>, memref<64x64xi32, strided<[64, 1]>>) -> ()
     return
   }
 
-  // Test 17: mulf with scale from linalg.fill with scalar arg - should match
+  // Test 17: mulf with scale from linalg.fill with scalar arg - should NOT match (no hint)
   // CHECK-LABEL: func @test_mulf_with_fill_scalar_arg
   func.func @test_mulf_with_fill_scalar_arg(%arg0: memref<128x64xf32> {tt.divisibility = 16 : i32}, %scale: f32, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>, %fill_init: tensor<64x64xf32>) {
     // CHECK: linalg.fill {ssbuffer.block_id = 190 : i32, ssbuffer.core_type = "VECTOR"} ins(%{{.*}} : f32) outs(%{{.*}} : tensor<64x64xf32>) {{.*}}
     %fill = linalg.fill {ssbuffer.block_id = 190 : i32, ssbuffer.core_type = "VECTOR"} ins(%scale : f32) outs(%fill_init : tensor<64x64xf32>) -> tensor<64x64xf32>
     // CHECK: linalg.matmul {ssbuffer.block_id = 191 : i32, ssbuffer.core_type = "CUBE"}
     %matmul = linalg.matmul {ssbuffer.block_id = 191 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
-    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 191 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 192 : i32, ssbuffer.core_type = "VECTOR"}
     %mulf = arith.mulf %matmul, %fill {ssbuffer.block_id = 192 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
-    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 191 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 193 : i32, ssbuffer.core_type = "VECTOR"}
     %extract = tensor.extract_slice %mulf[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 193 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf32>
-    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 191 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 194 : i32, ssbuffer.core_type = "VECTOR"}
     %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 194 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf32> to memref<64x64xf32, strided<[64, 1]>>
-    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 191 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 195 : i32, ssbuffer.core_type = "VECTOR"}
     bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 195 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf32>, memref<64x64xf32, strided<[64, 1]>>) -> ()
+    return
+  }
+
+  // Test 18: mulf with hint enable_fast_tf32_mul - should match
+  // CHECK-LABEL: func @test_mulf_with_hint
+  func.func @test_mulf_with_hint(%arg0: memref<128x64xf32> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>) {
+    %c0 = arith.constant 0 : index
+    // CHECK: linalg.matmul {ssbuffer.block_id = 201 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 201 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK: arith.constant dense<0.00392{{.*}} {ssbuffer.block_id = 201 : i32, ssbuffer.core_type = "CUBE"}
+    %scale_tensor = arith.constant dense<0.003921568627> : tensor<64x64xf32>
+    %mulf = arith.mulf %matmul, %scale_tensor {ssbuffer.block_id = 202 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+    annotation.mark %mulf {enable_fast_tf32_mul} : tensor<64x64xf32>
+    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 201 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: annotation.mark %{{.*}} {enable_fast_tf32_mul, ssbuffer.block_id = 201 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 201 : i32, ssbuffer.core_type = "CUBE"}
+    %extract = tensor.extract_slice %mulf[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 203 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf32>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 201 : i32, ssbuffer.core_type = "CUBE"}
+    %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 204 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf32> to memref<64x64xf32, strided<[64, 1]>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 201 : i32, ssbuffer.core_type = "CUBE"}
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 205 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf32>, memref<64x64xf32, strided<[64, 1]>>) -> ()
+    return
+  }
+
+  // Test 19: mulf with MarkOp but wrong attribute - should NOT match
+  // CHECK-LABEL: func @test_mulf_wrong_hint
+  func.func @test_mulf_wrong_hint(%arg0: memref<128x64xf32> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>) {
+    // CHECK: linalg.matmul {ssbuffer.block_id = 211 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 211 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK: arith.constant dense<0.00392{{.*}} : tensor<64x64xf32>
+    %scale_tensor = arith.constant dense<0.003921568627> : tensor<64x64xf32>
+    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 212 : i32, ssbuffer.core_type = "VECTOR"}
+    %mulf = arith.mulf %matmul, %scale_tensor {ssbuffer.block_id = 212 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+    annotation.mark %mulf {other_attribute} : tensor<64x64xf32>
+    // CHECK: annotation.mark %{{.*}} {other_attribute, ssbuffer.block_id = 212 : i32, ssbuffer.core_type = "VECTOR"}
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 213 : i32, ssbuffer.core_type = "VECTOR"}
+    %extract = tensor.extract_slice %mulf[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 213 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf32>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 214 : i32, ssbuffer.core_type = "VECTOR"}
+    %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 214 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf32> to memref<64x64xf32, strided<[64, 1]>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 215 : i32, ssbuffer.core_type = "VECTOR"}
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 215 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf32>, memref<64x64xf32, strided<[64, 1]>>) -> ()
+    return
+  }
+
+  // Test 20: mulf with fill and hint - should match
+  // CHECK-LABEL: func @test_mulf_fill_with_hint
+  func.func @test_mulf_fill_with_hint(%arg0: memref<128x64xf32> {tt.divisibility = 16 : i32}, %scale: f32, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>, %fill_init: tensor<64x64xf32>) {
+    // CHECK: linalg.fill {ssbuffer.block_id = 220 : i32, ssbuffer.core_type = "CUBE"} ins(%{{.*}} : f32) outs(%{{.*}} : tensor<64x64xf32>) {{.*}}
+    %fill = linalg.fill {ssbuffer.block_id = 220 : i32, ssbuffer.core_type = "VECTOR"} ins(%scale : f32) outs(%fill_init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK: linalg.matmul {ssbuffer.block_id = 221 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 221 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    %mulf = arith.mulf %matmul, %fill {ssbuffer.block_id = 222 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+    annotation.mark %mulf {enable_fast_tf32_mul} : tensor<64x64xf32>
+    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 221 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: annotation.mark %{{.*}} {enable_fast_tf32_mul, ssbuffer.block_id = 221 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 221 : i32, ssbuffer.core_type = "CUBE"}
+    %extract = tensor.extract_slice %mulf[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 223 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf32>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 221 : i32, ssbuffer.core_type = "CUBE"}
+    %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 224 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf32> to memref<64x64xf32, strided<[64, 1]>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 221 : i32, ssbuffer.core_type = "CUBE"}
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 225 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf32>, memref<64x64xf32, strided<[64, 1]>>) -> ()
     return
   }
 }


### PR DESCRIPTION
## Apply optimization only when `enable_fast_tf32_mul` hint is enabled

### Summary
This PR restricts the FixpipeOpt optimization to only apply when the `enable_fast_tf32_mul` compilation hint is present, preventing incorrect optimizations in cases where the hint is not enabled.

### Changes
- Added `kInlinableQuantScaleAttr` constant for the `enable_fast_tf32_mul` hint attribute
- Updated `MemoryEffectsTracker` to skip memory effects for operations with the quant scale hint
- Modified `FixpipeOptPass::isValidMul()` to validate the presence of the quant scale compile hint before applying the mul pattern optimization
- Updated `isFixpipeMulPattern()` to properly handle annotation mark operations when checking user patterns
- Fixed user chain traversal logic in `OpClassifier` to correctly check all results have one user

### Files Changed
- `third_party/ascend/include/DynamicCVPipeline/Common/Utils.h`
- `third_party/ascend/lib/DynamicCVPipeline/Common/MemoryEffectsTracker.cpp`
- `third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp`
- `third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp`
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
