### PR TITLE
[release/3.2.2](feat) Sync verified commits from dev to release/3.2.2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @HEX1A0A
+*       @KanuaK @WuTYSFG @hongziqi
 
 # --------
 # Analyses

--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.h
@@ -34,6 +34,7 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include <optional>
 
 namespace mlir {
 namespace triton {
@@ -151,11 +152,11 @@ private:
                          DenseMap<int, Value> &precomputedPtrs,
                          SmallVector<SmallVector<Value> > ssbufferPtrs);
 
-    // Compute pointers for VECTOR core SSBuffer
-    DenseMap<int, Value> computeVectorSSBufferPtrs(OpBuilder &builder, Location loc,
-                                                   Operation *scopeOp,
-                                                   SmallVector<int> crossCoreInputValues,
-                                                   SmallVector<int> crossCoreOutputValues);
+// Compute pointers for VECTOR core SSBuffer
+    std::optional<DenseMap<int, Value>> computeVectorSSBufferPtrs(OpBuilder &builder, Location loc,
+                                                                   Operation *scopeOp,
+                                                                   SmallVector<int> crossCoreInputValues,
+                                                                   SmallVector<int> crossCoreOutputValues);
 
     // Part 2: Add cross-core conditions
     Value addCrossCoreConditions(OpBuilder &builder, Location loc,

--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/Utils.h
@@ -54,7 +54,7 @@ LogicalResult topologicalSort(SmallVector<Operation *> &ops);
 SmallVector<int> getBlockIdsInOrder(scf::ForOp forOp);
 
 // Get the block_id of the immediate child of scf.for that contains op
-std::optional<int64_t> getForDirectChildBlockId(Operation *op);
+std::optional<int> getForDirectChildBlockId(Operation *op);
 
 // Find the tcb group id that contains value v
 int findTcbGroupId(Value v, llvm::DenseMap<int, SmallVector<Value>> &tightlyCoupledBufferGroups);

--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -76,7 +76,7 @@ inline constexpr CoreType fromStrCoreType(std::string_view s)
 
 // Functions for managing core types
 CoreType getOpCoreType(Operation *op);
-std::optional<int64_t> getOpBlockId(Operation *op);
+std::optional<int> getOpBlockId(Operation *op);
 llvm::LogicalResult verifyOpBlockId(Operation *op);
 int getAvailableBlockId(ModuleOp module);
 void setFallbackAttr(ModuleOp module);

--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -28,6 +28,8 @@
 #include "mlir/IR/Value.h"
 #include "llvm/ADT/StringRef.h"
 
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+
 namespace mlir {
 namespace CVPipeline {
 
@@ -79,6 +81,7 @@ llvm::LogicalResult verifyOpBlockId(Operation *op);
 int getAvailableBlockId(ModuleOp module);
 void setFallbackAttr(ModuleOp module);
 bool isScfOp(Operation *op);
+bool isOnlyDirectlyUse(Operation *preOp, Operation *nextOp, const CVPipeline::MemoryDependenceGraph &memGraph);
 
 inline bool isCubeOp(Operation *op)
 {

--- a/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlockPass.h
+++ b/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlockPass.h
@@ -45,7 +45,7 @@ class PlanCubeBlockPass : public PassWrapper<PlanCubeBlockPass, OperationPass<Mo
     llvm::StringRef getArgument() const final { return "plan-cube-block"; }
 
   private:
-    SmallVector<Operation *> matchSeed(Operation *dotOp, CVPipeline::ComputeBlockIdManager &bm);
+    SmallVector<Operation *> matchSeed(Operation *dotOp, CVPipeline::ComputeBlockIdManager &bm, const CVPipeline::MemoryDependenceGraph &memGraph);
     llvm::LogicalResult processBlockWithCubeBFS(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph,
                                                 CVPipeline::ComputeBlockIdManager &bm);
 };

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
@@ -112,6 +112,7 @@ private:
                                         bool isMatmulA,
                                         bool isMatmulB,
                                         bool isOnlyDepInMatmul);
+  bool matmulCIsEmpty(mlir::Value acc);
   void padMatmulInnerDim(OpBuilder &builder, Operation *matmulOp, Location loc, int matmulIndex, int matmulOpBlockId);
   void extractMatmulResult(OpBuilder &builder, Operation *matmulOp, Location loc, int matmulOpBlockId, llvm::DenseMap<mlir::Value, mlir::Value> &cubeValueMapping, bool isOnlyDepInMatmul);
   mlir::Value normalizeIfNeeded(mlir::OpBuilder &builder,

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/Utils.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ADAPTER_SPLIT_DATAFLOW_UTILS_H
+#define TRITON_ADAPTER_SPLIT_DATAFLOW_UTILS_H
+
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace mlir {
+namespace triton {
+
+void setOpBlockId(mlir::Operation *op, int blockId);
+void setOpCoreType(mlir::Operation *op, llvm::StringRef coreType);
+
+}
+}
+
+#endif // TRITON_ADAPTER_SPLIT_DATAFLOW_UTILS_H

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition.cpp
@@ -31,13 +31,7 @@
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
 #include "bishengir/Dialect/Scope/IR/Scope.h"
 #include "mlir/Pass/PassManager.h"
-#include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateForOps.h"
-#include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.h"
-#include "bishengir/Dialect/HIVM/IR/HIVM.h"
-#include "bishengir/Dialect/Scope/IR/Scope.h"
-#include "mlir/Pass/PassManager.h"
 #include "llvm/Support/Debug.h"
-#include "mlir/Pass/PassManager.h"
 
 static constexpr const char *DEBUG_TYPE = "AddControlFlowCondition";
 #define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/InitDependentMap.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/InitDependentMap.cpp
@@ -91,6 +91,12 @@ static int collectDepsByGroup(Operation *rootOp, const char *attrName,
       return;
     }
 
+    if (!isa<IntegerAttr>(depsAttr[0]) || !isa<IntegerAttr>(depsAttr[1])) {
+      LDBG("type of dependency attritbute is not Int! error op:" << *op);
+      ret = -1;
+      return;
+    }
+
     int group = cast<IntegerAttr>(depsAttr[0]).getInt();
     int role = cast<IntegerAttr>(depsAttr[1]).getInt();
     depsByGroup[group].push_back({op, role});

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
@@ -507,12 +507,17 @@ Value UpdateConditionInfoPass::getSSBufferPtr(bool isAIC, int groupIdx, int ptrS
 }
 
 // Compute pointers for VECTOR core SSBuffer
-DenseMap<int, Value> UpdateConditionInfoPass::computeVectorSSBufferPtrs(
+std::optional<DenseMap<int, Value>> UpdateConditionInfoPass::computeVectorSSBufferPtrs(
     OpBuilder &builder, Location loc,
     Operation *scopeOp,
     SmallVector<int> crossCoreInputValues,
     SmallVector<int> crossCoreOutputValues)
 {
+  if (!scopeOp) {
+    LDBG("Scope Op is null pointer!");
+    return std::nullopt;
+  }
+
   // Collect all unique group indices
   SmallVector<int> allGroupIndices;
   DenseSet<int> uniqueIndices;
@@ -711,7 +716,12 @@ int UpdateConditionInfoPass::setCrossCoreCondition(
   // If ifblock is on vector core, compute the required SSBuffer ptrs for vector side
   DenseMap<int, Value> VectorSSBufferPtrs;
   if (!isAIC) {
-    VectorSSBufferPtrs = computeVectorSSBufferPtrs(builder, loc, scopeOp, crossCoreInputValues, crossCoreOutputValues);
+    auto result = computeVectorSSBufferPtrs(builder, loc, scopeOp, crossCoreInputValues, crossCoreOutputValues);
+    if (!result) {
+      LDBG("computeVectorSSBufferPtrs failed!");
+      return UPDATE_CONDITION_INFO_FAILED;
+    }
+    VectorSSBufferPtrs = std::move(*result);
   }
 
   builder.setInsertionPoint(ifOp);

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/Utils.cpp
@@ -166,7 +166,7 @@ SmallVector<int> triton::getBlockIdsInOrder(scf::ForOp forOp)
 // Get the block_id of the immediate child of scf.for that contains op
 // For nested ops inside scf.if/scf.for, returns the block_id of the immediate child of scf.for
 // Only considers scf.for ops that have ssbuffer.main_loop attribute
-std::optional<int64_t> triton::getForDirectChildBlockId(Operation *op) {
+std::optional<int> triton::getForDirectChildBlockId(Operation *op) {
   if (!op) {
     return std::nullopt;
   }

--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
@@ -1640,20 +1640,26 @@ static bool hasMemrefDepValue(DenseMap<Value, SmallVector<Value>> &depValueMap)
 static int addInnerMultiBuffer(mlir::scf::ForOp mainLoopForOp, OpBuilder &builder, scope::ScopeOp vectorScope,
                                int &groupId)
 {
-    // Break tensor-rooted cross-block scalar dependencies before collecting deps
-    rematerializeTensorRootedScalarDeps(mainLoopForOp);
-
     OpBuilder globalBuilder(mainLoopForOp.getContext());
 
-    // First pass: clone tensor::EmptyOp + linalg::FillOp patterns into each
-    // consumer's block. The cloned fill's `ins` chain can introduce fresh
-    // cross-block references (e.g. a producer-side tensor referenced by the
-    // cloned tensor.extract) that need multi-buffering. To avoid missing those
-    // deps, we do dep collection in two phases:
-    //   Phase 1 (initial): collect deps, build user map, then clone.
+    // Two-phase dep collection for empty+fill cloning:
+    //   Phase 1 (initial): collect deps, build user map, then clone the
+    //                      tensor::EmptyOp + linalg::FillOp pattern into each
+    //                      consumer's block. The cloned fill's `ins` chain can
+    //                      introduce fresh cross-block references (e.g. a
+    //                      producer-side tensor referenced by the cloned
+    //                      tensor.extract / arith.extf).
+    //   Scalar rematerialize: trace each cloned fill's `ins` chain. If the
+    //                        chain reaches a producer-side tensor (via
+    //                        tensor.extract / arith.extf), build a fresh
+    //                        block-local chain that reads from a new
+    //                        multi-buffer added in Phase 2.
     //   Phase 2 (re-collect): re-run collectInnerBlockInfo / buildDepUserMap
-    //                        so the new cross-block refs (created by Phase 1's
-    //                        clones) are visible to processTensorDependencies.
+    //                        so the new cross-block refs (from clone + scalar
+    //                        rematerialize) are visible to the multi-buffer
+    //                        pipeline. The multi-buffer transfer structure
+    //                        (allocs, scf.if, intraDeps, intra_buffer) is
+    //                        created here and is not affected by the reorder.
     DenseMap<Value, InnerBlockInfo> blocks;
     DenseMap<Value, SmallVector<Value>> depValueMap;
     SmallVector<Operation *> allOps;
@@ -1670,9 +1676,17 @@ static int addInnerMultiBuffer(mlir::scf::ForOp mainLoopForOp, OpBuilder &builde
     if (cloneEmptyFillsInBlocks(mainLoopForOp, blocks, depValueMap, initialDepUserMap, globalBuilder) != 0)
         return -1;
 
-    // Phase 2: re-collect deps now that cloned ops have created new
-    // cross-block references. depValueMap and allOps are cleared inside
-    // collectInnerBlockInfo, so we re-discover everything from scratch.
+    // Break tensor-rooted cross-block scalar dependencies AFTER the empty+fill
+    // clone. The clone can introduce fresh scalar refs (e.g. a cloned
+    // arith.extf whose operand is a producer-side tensor.extract) that need to
+    // be rematerialized to a block-local chain reading from a Phase-2
+    // multi-buffer. Running this before the clone leaves these refs invisible.
+    rematerializeTensorRootedScalarDeps(mainLoopForOp);
+
+    // Phase 2: re-collect deps now that cloned ops (and rematerialized scalar
+    // chains) have created new cross-block references. depValueMap and allOps
+    // are cleared inside collectInnerBlockInfo, so we re-discover everything
+    // from scratch.
     blocks.clear();
     depValueMap.clear();
     allOps.clear();

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -54,7 +54,7 @@ llvm::LogicalResult verifyOpBlockId(Operation *op)
     return llvm::success();
 }
 
-std::optional<int64_t> getOpBlockId(Operation *op)
+std::optional<int> getOpBlockId(Operation *op)
 {
     if (!op) {
         return std::nullopt;
@@ -73,7 +73,7 @@ int getAvailableBlockId(ModuleOp module)
     module.walk([&](Operation *op) {
         auto blockIdOpt = getOpBlockId(op);
         if (blockIdOpt) {
-            int currentId = static_cast<int>(*blockIdOpt);
+            int currentId = *blockIdOpt;
             if (currentId > maxBlockId) {
                 maxBlockId = currentId;
             }

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -10,8 +10,10 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Operation.h"
 
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+
 namespace mlir {
 namespace CVPipeline {
 
@@ -29,9 +31,6 @@ CoreType getOpCoreType(Operation *op)
 llvm::LogicalResult verifyOpBlockId(Operation *op)
 {
     if (!op) {
-        assert(false && "Op is nullptr, please check calling function");
-
-        // return failure to signal disabling of CV dynamic pipeline in release mode
         return llvm::failure();
     }
 
@@ -57,6 +56,9 @@ llvm::LogicalResult verifyOpBlockId(Operation *op)
 
 std::optional<int64_t> getOpBlockId(Operation *op)
 {
+    if (!op) {
+        return std::nullopt;
+    }
     auto blockIdAttr = op->getAttrOfType<IntegerAttr>(kBlockId);
     if (!blockIdAttr) {
         return std::nullopt;
@@ -102,6 +104,22 @@ bool isVectorOnlyOp(Operation *op)
 bool isScfOp(Operation *op)
 {
   return llvm::isa<scf::SCFDialect>(op->getDialect());
+}
+
+// Check nextOp is only user of preOp
+bool isOnlyDirectlyUse(Operation *preOp, Operation *nextOp, const CVPipeline::MemoryDependenceGraph &memGraph) {
+    if (!preOp || !nextOp) {
+        return false;
+    }
+    SmallVector<Operation *> allusers;
+    allusers.append(preOp->getUsers().begin(), preOp->getUsers().end());
+    for (auto memUser : memGraph.getExecAfter(preOp)) {
+        allusers.push_back(memUser);
+    }
+    if (allusers.size() != 1) {
+        return false;
+    }
+    return (*allusers.begin()) == nextOp;
 }
 
 } // namespace CVPipeline

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
@@ -124,7 +124,7 @@ bool willCreateCycle(llvm::ArrayRef<Operation *> opsToUnify, const MemoryDepende
     DenseMap<Operation *, int> origBlockIdMap;
     for (auto *op : opsToUnify) {
         auto optBlockId = getOpBlockId(op);
-        origBlockIdMap[op] = optBlockId ? static_cast<int>(*optBlockId) : -1;
+        origBlockIdMap[op] = optBlockId ? *optBlockId : -1;
         bm.updateBlockId(op, targetBlockId);
     }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
@@ -113,6 +113,9 @@ bool DependencyCycleDetector::dfs(Operation *cur)
     allusers.append(memGraph.getExecAfter(cur).begin(), memGraph.getExecAfter(cur).end());
     for (auto *user : allusers) {
         auto *userInBlock = CVPipeline::getAncestorInBlock(user, block);
+        if (!userInBlock) {
+            continue;
+        }
         if (bm.getBlockIdByOp(userInBlock) == -1) {
             if (dfs(userInBlock)) {
                 return true;

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
@@ -103,7 +103,7 @@ static LogicalResult getCommonBlockId(ArrayRef<Operation *> ops, int &blockId) {
       for (auto *user : op->getUsers()) {
         if (auto copyOp = dyn_cast<memref::CopyOp>(user)) {
           if (auto blockId = CVPipeline::getOpBlockId(copyOp)) {
-            copyBlockIds.insert(static_cast<int>(*blockId));
+            copyBlockIds.insert(*blockId);
           }
         }
       }

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.cpp
@@ -81,6 +81,9 @@ int ComputeBlockIdManager::getNextId()
 
 void ComputeBlockIdManager::updateBlockId(Operation *op, int blockId)
 {
+    if (!op) {
+        return;
+    }
     // Force Update.
     MLIRContext *ctx = op->getContext();
     if (blockId == -1) {

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
@@ -535,7 +535,7 @@ static bool checkValidUserSeed(Operation* op) {
     // keep unify to OpClassifer
     return isa<hivm::StoreOp, bufferization::MaterializeInDestinationOp, ViewLikeOpInterface, tensor::ExtractSliceOp>(op);
 }
-SmallVector<Operation*> PlanCubeBlockPass::matchSeed(Operation* dotOp, ComputeBlockIdManager &bm)
+SmallVector<Operation*> PlanCubeBlockPass::matchSeed(Operation* dotOp, ComputeBlockIdManager &bm, const MemoryDependenceGraph &memGraph)
 {
     // match inputs
     SmallVector<Operation*> ret;
@@ -546,7 +546,7 @@ SmallVector<Operation*> PlanCubeBlockPass::matchSeed(Operation* dotOp, ComputeBl
             continue;
         if (checkValidInputSeed(def) && isCubeOp(def) && dotOp->getBlock() == def->getBlock() &&
             bm.getBlockIdByOp(def) == -1) {
-            if (def->hasOneUse()) {
+            if (CVPipeline::isOnlyDirectlyUse(def, dotOp, memGraph)) {
                 ret.push_back(def);
             }
         }
@@ -583,7 +583,7 @@ llvm::LogicalResult PlanCubeBlockPass::processBlockWithCubeBFS(Block *block, con
             continue;
         }
         auto temBlockId = bm.getNextId();
-        llvm::SmallVector<Operation*> dotSeeds = matchSeed(dot, bm);
+        llvm::SmallVector<Operation*> dotSeeds = matchSeed(dot, bm, memGraph);
         if (willCreateCycle(dotSeeds, memGraph, temBlockId, bm)) {
             LOG_DEBUG("Cube Seed already have a cycle!!");
             for(auto seed: dotSeeds) {

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/AddBlockIdForControlOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/AddBlockIdForControlOps.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/AddBlockIdForControlOps.h"
+#include "ascend/include/DynamicCVPipeline/SplitDataflow/Utils.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "llvm/Support/Debug.h"
 
@@ -46,16 +47,30 @@ void AddBlockIdForControlOpsPass::runOnOperation()
   // Step 2: add block_id for control flow ops
   module.walk([&](Operation *op) {
     // skip op with block_id
-    if (op->getAttrOfType<IntegerAttr>("ssbuffer.block_id")) {
+    if (op->getAttrOfType<IntegerAttr>(CVPipeline::kBlockId)) {
       return;
     }
 
-    if (isa<scf::ForOp, scf::IfOp, scf::WhileOp>(op)) {
+    if (isa<scf::ForOp, scf::IfOp>(op)) {
       maxBlockId++;
-      static constexpr int kIntegerBitWidth = 32;
-      op->setAttr("ssbuffer.block_id",
-                  IntegerAttr::get(IntegerType::get(module.getContext(), kIntegerBitWidth), maxBlockId));
+      setOpBlockId(op, maxBlockId);
       LOG_DEBUG("Added block_id " << maxBlockId << " to " << *op << "\n");
+    }
+
+    // coretype of scf.yield may not be the same with defining op
+    if (isa<scf::YieldOp>(op) && isa<scf::IfOp>(op->getParentOp())) {
+      Operation *parentOp = op->getParentOp();
+      auto ifBlockIdOpt = CVPipeline::getOpBlockId(parentOp);
+
+      int yieldBlockId;
+      if (ifBlockIdOpt) {
+        yieldBlockId = *ifBlockIdOpt;
+      } else {
+        maxBlockId++;
+        yieldBlockId = maxBlockId;
+      }
+      setOpBlockId(op, yieldBlockId);
+      LOG_DEBUG("Added block_id " << yieldBlockId << " to " << *op << "\n");
     }
   });
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h"
+#include "ascend/include/DynamicCVPipeline/SplitDataflow/Utils.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/Common/MemoryEffectsTracker.h"
 
@@ -52,9 +53,6 @@ using namespace mlir::triton;
 using namespace mlir::CVPipeline;
 
 // Attribute name constants
-static constexpr const char *kBlockIdAttr = "ssbuffer.block_id";
-static constexpr const char *kCoreTypeAttr = "ssbuffer.core_type";
-static constexpr const char *kTransferIdAttr = "ssbuffer.transfer_id";
 static constexpr const char *ssbufferCoreTypeCubeAttr = "CUBE";
 static constexpr const char *ssbufferCoreTypeVectorAttr = "VECTOR";
 static constexpr int ND_SHAPE_LENGTH = 2;
@@ -62,7 +60,7 @@ static constexpr int ND_SHAPE_LENGTH = 2;
 // Helper: ssbuffer.core_type
 llvm::StringRef getSsbufferCoreType(Operation *op)
 {
-    if (auto attr = op->getAttrOfType<mlir::StringAttr>(kCoreTypeAttr)) {
+    if (auto attr = op->getAttrOfType<mlir::StringAttr>(CVPipeline::kCoreType)) {
         return attr.getValue();
     }
     return "";
@@ -90,7 +88,7 @@ bool DataDependencyAnalysisPass::isControlFlowOp(mlir::Operation *op)
 {
     if (!op)
         return false;
-    return isa<scf::ForOp>(op) || isa<scf::IfOp>(op) || isa<scf::WhileOp>(op) || isa<scf::YieldOp>(op);
+    return isa<scf::ForOp>(op) || isa<scf::IfOp>(op) || isa<scf::YieldOp>(op);
 }
 
 bool DataDependencyAnalysisPass::isCubeOrVectorOp(mlir::Operation *op)
@@ -222,7 +220,7 @@ void DataDependencyAnalysisPass::createBlockInfoMap(DataDependencyInfo &info)
     module.walk([&](mlir::Operation *op) {
         auto opBlockIdOpt = CVPipeline::getOpBlockId(op);
         if (opBlockIdOpt) {
-            int opBlockId = static_cast<int>(*opBlockIdOpt);
+            int opBlockId = *opBlockIdOpt;
             // When the id changes, the block ends && Exclude the initial state
             if (opBlockId != currentId && currentId != startCurrId) {
                 collectBlockInfo(info, currentId, currentOps);
@@ -302,8 +300,8 @@ void DataDependencyAnalysisPass::insertProducerAndRecordDeps(scf::ForOp forOp,
     builder.setInsertionPointToStart(&bodyBlock);
     Location loc = forOp.getLoc();
     auto constOp = builder.create<arith::ConstantIntOp>(loc, 0, 32);
-    constOp->setAttr(kBlockIdAttr, IntegerAttr::get(IntegerType::get(builder.getContext(), 32), newId));
-    constOp->setAttr(kCoreTypeAttr, StringAttr::get(builder.getContext(), initCoreType));
+    setOpBlockId(constOp, newId);
+    setOpCoreType(constOp, initCoreType);
 
     BlockInfo blockInfo;
     blockInfo.blockId = newId;
@@ -318,7 +316,7 @@ void DataDependencyAnalysisPass::insertProducerAndRecordDeps(scf::ForOp forOp,
             LOG_DEBUG("Warning: User block ID not found for iterArg user.\n");
             continue;
         }
-        int userBlockId = static_cast<int>(*userBlockIdOpt);
+        int userBlockId = *userBlockIdOpt;
 
         // Determine dependency type based on initCoreType
         DependencyType depType;
@@ -464,7 +462,7 @@ void DataDependencyAnalysisPass::analyzeExternalInputs(DataDependencyInfo &info)
                     LOG_DEBUG("Warning: [v->c] Producer block ID not found for input value.\n");
                     continue;
                 }
-                int producerId = static_cast<int>(*producerIdOpt);
+                int producerId = *producerIdOpt;
                 collectDepInfo(input, DependencyType::VectorToCube, v2cDependencies, producerId, blockInfo.blockId,
                     info);
             }
@@ -526,7 +524,7 @@ void DataDependencyAnalysisPass::analyzeExternalOutputs(DataDependencyInfo &info
                         LOG_DEBUG("Warning: [c->v] Consumer block ID not found for user operation.\n");
                         continue;
                     }
-                    int consumerId = static_cast<int>(*consumerIdOpt);
+                    int consumerId = *consumerIdOpt;
                     auto inserted = handledBlockIds.insert(consumerId).second;
                     if (inserted) {
                       collectDepInfo(output, DependencyType::CubeToVector, c2vDependencies, blockInfo.blockId, consumerId,
@@ -581,7 +579,7 @@ void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info)
         if (!currBlockIdOpt || currCoreType.empty()) {
             return;
         }
-        int currBlockId = static_cast<int>(*currBlockIdOpt);
+        int currBlockId = *currBlockIdOpt;
 
         for (mlir::Operation *predOp : memDepGraph.getExecBefore(op)) {
             if (isa<annotation::MarkOp, gpu::BarrierOp>(predOp)) {
@@ -621,7 +619,7 @@ void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info)
             if (!predBlockIdOpt || predCoreType == currCoreType || predCoreType.empty()) {
                 continue;
             }
-            int predBlockId = static_cast<int>(*predBlockIdOpt);
+            int predBlockId = *predBlockIdOpt;
 
             auto [producerBlockId, consumerBlockId] = findCommonLevelBlockIds(info, predBlockId, currBlockId);
             if (producerBlockId == -1 || consumerBlockId == -1) {
@@ -752,8 +750,8 @@ std::pair<int, int> DataDependencyAnalysisPass::findCommonLevelBlockIds(DataDepe
             mlir::Operation *pPrevOp = pAncestors[pIndex - 1];
             auto pPrevIdOpt = CVPipeline::getOpBlockId(pPrevOp);
             auto cPrevIdOpt = CVPipeline::getOpBlockId(before);
-            int pPrevId = pPrevIdOpt ? static_cast<int>(*pPrevIdOpt) : -1;
-            int cPrevId = cPrevIdOpt ? static_cast<int>(*cPrevIdOpt) : -1;
+            int pPrevId = pPrevIdOpt ? *pPrevIdOpt : -1;
+            int cPrevId = cPrevIdOpt ? *cPrevIdOpt : -1;
             if (!pPrevIdOpt) {
                 LOG_DEBUG("Warning: Producer ancestor operation has no block ID attribute.\n");
             }

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -318,6 +318,28 @@ void InterCoreTransferAndSyncPass::padMatmulInnerDim(OpBuilder &builder, Operati
     attachCommonTags(tensorInsertSliceOp, matmulOpBlockId, "CUBE");
 }
 
+bool InterCoreTransferAndSyncPass::matmulCIsEmpty(mlir::Value acc)
+{
+    auto accDefOp = acc.getDefiningOp();
+    if (accDefOp) {
+        if (isa<tensor::EmptyOp>(accDefOp)) {
+            return true;
+        }
+        if (auto fillOp = dyn_cast<linalg::FillOp>(accDefOp)) {
+            Value fillVal = fillOp.getOperand(0); 
+            if (auto constOp = fillVal.getDefiningOp<arith::ConstantOp>()) {
+                Attribute attr = constOp.getValue();
+
+                if ((isa<FloatAttr>(attr) && cast<FloatAttr>(attr).getValue().isZero()) ||
+                    (isa<IntegerAttr>(attr) && cast<IntegerAttr>(attr).getValue().isZero())) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
 void InterCoreTransferAndSyncPass::extractMatmulResult(
     OpBuilder &builder, Operation *matmulOp, Location loc,
     int matmulOpBlockId, llvm::DenseMap<mlir::Value, mlir::Value> &cubeValueMapping, bool isOnlyDepInMatmul)
@@ -330,6 +352,11 @@ void InterCoreTransferAndSyncPass::extractMatmulResult(
     auto rhsType = dyn_cast<RankedTensorType>(rhs.getType());
     auto accType = dyn_cast<RankedTensorType>(acc.getType());
     auto resType = dyn_cast<RankedTensorType>(originalResult.getType());
+    if (lhsType.getShape()[0] == accType.getShape()[0]
+        && rhsType.getShape()[1] == accType.getShape()[1]) {
+        return;
+    }
+
     ArrayRef<int64_t> accshape = accType.getShape();
     ArrayRef<int64_t> resshape = resType.getShape();
     SmallVector<int64_t> expectedShape = { lhsType.getShape()[0], rhsType.getShape()[1] };
@@ -347,7 +374,13 @@ void InterCoreTransferAndSyncPass::extractMatmulResult(
     attachCommonTags(tensorEmptyOp, matmulOpBlockId, "CUBE");
     attachCommonTags(linalgFillOp, matmulOpBlockId, "CUBE");
 
-    Value newAccResult = linalgFillOp->getResult(0);
+    mlir::Operation *paddingAccOp = linalgFillOp;
+    if (!matmulCIsEmpty(acc)) {
+        LOG_DEBUG("nd2nz shape is unaligned and matmul C is not empty");
+        signalPassFailure();
+    }
+
+    Value newAccResult = paddingAccOp->getResult(0);
 
     static constexpr int accIndex = 2;
     matmulOp->setOperand(accIndex, newAccResult);

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h"
+#include "ascend/include/DynamicCVPipeline/SplitDataflow/Utils.h"
 
 #include <memory>
 #include <optional>
@@ -60,11 +61,6 @@ static constexpr const char *DEBUG_TYPE = "inter-core-transfer-and-sync";
 using namespace mlir::triton;
 using namespace hivm;
 
-// Attribute name constants
-static constexpr const char *kBlockIdAttr = "ssbuffer.block_id";
-static constexpr const char *kCoreTypeAttr = "ssbuffer.core_type";
-static constexpr const char *kTransferIdAttr = "ssbuffer.transfer_id";
-
 static constexpr int kIntegerBitWidth = 32;
 static constexpr int NzDimWidth = 16;
 
@@ -91,10 +87,10 @@ static uint64_t getBlockElemsFor32BAlign(Type elemType)
     constexpr uint64_t kAlignBytes = 32;
     uint64_t elemBytes = getElemBytesForAlign(elemType);
     if (elemBytes == 0) {
-        return -1;
+        return 0;
     }
     if (elemBytes < 0 || kAlignBytes % elemBytes != 0) {
-        return -1;
+        return 0;
     }
     if (elemBytes >= kAlignBytes) {
         return 1;
@@ -105,16 +101,16 @@ static uint64_t getBlockElemsFor32BAlign(Type elemType)
 static void attachCommonTags(Operation *op, int blockId, StringRef coreType)
 {
     MLIRContext *ctx = op->getContext();
-    op->setAttr(kBlockIdAttr, IntegerAttr::get(IntegerType::get(ctx, kIntegerBitWidth), blockId));
-    op->setAttr(kCoreTypeAttr, StringAttr::get(ctx, coreType));
+    setOpBlockId(op, blockId);
+    setOpCoreType(op, coreType);
 }
 
 static void attachTransferTags(Operation *op, int blockId, StringRef coreType, int transferId)
 {
     MLIRContext *ctx = op->getContext();
-    op->setAttr(kBlockIdAttr, IntegerAttr::get(IntegerType::get(ctx, kIntegerBitWidth), blockId));
-    op->setAttr(kCoreTypeAttr, StringAttr::get(ctx, coreType));
-    op->setAttr(kTransferIdAttr, IntegerAttr::get(IntegerType::get(ctx, kIntegerBitWidth), transferId));
+    setOpBlockId(op, blockId);
+    setOpCoreType(op, coreType);
+    op->setAttr(CVPipeline::kTransferId, IntegerAttr::get(IntegerType::get(ctx, kIntegerBitWidth), transferId));
 }
 
 static void attachAnalyzeFlagIdTag(Operation *op)
@@ -128,7 +124,7 @@ std::pair<mlir::Operation *, mlir::Operation *> InterCoreTransferAndSyncPass::ge
     mlir::ModuleOp module)
 {
     mlir::Operation *knownOpInBlock = nullptr;
-    module.walk([&](mlir::Operation *op) {
+    module.walk<WalkOrder::PreOrder>([&](mlir::Operation *op) {
         if (knownOpInBlock) {
             return;
         }
@@ -154,7 +150,7 @@ std::pair<mlir::Operation *, mlir::Operation *> InterCoreTransferAndSyncPass::ge
         if (!blockIdOpt) {
             continue;
         }
-        int blockId = static_cast<int>(*blockIdOpt);
+        int blockId = *blockIdOpt;
         if (!start) {
             if (targetId == blockId) {
                 start = &op;
@@ -269,6 +265,9 @@ std::pair<bool, bool> InterCoreTransferAndSyncPass::isExpectedShape(Value value,
     SmallVector<int64_t> &expectedShape, bool isMatmulA, bool isMatmulB, bool isOnlyDepInMatmul)
 {
     auto tensorTy = dyn_cast<TensorType>(value.getType());
+    if (!tensorTy) {
+        return { true, false };
+    }
     ArrayRef<int64_t> currShape = tensorTy.getShape();
     bool isEqualedShape = currShape.equals(expectedShape);
     bool matmulPadding = false;
@@ -348,10 +347,10 @@ void InterCoreTransferAndSyncPass::extractMatmulResult(
     Value rhs = matmulOp->getOperands()[1];
     Value acc = matmulOp->getOperands()[2];
     Value originalResult = matmulOp->getResult(0);
-    auto lhsType = dyn_cast<RankedTensorType>(lhs.getType());
-    auto rhsType = dyn_cast<RankedTensorType>(rhs.getType());
-    auto accType = dyn_cast<RankedTensorType>(acc.getType());
-    auto resType = dyn_cast<RankedTensorType>(originalResult.getType());
+    auto lhsType = cast<RankedTensorType>(lhs.getType());
+    auto rhsType = cast<RankedTensorType>(rhs.getType());
+    auto accType = cast<RankedTensorType>(acc.getType());
+    auto resType = cast<RankedTensorType>(originalResult.getType());
     if (lhsType.getShape()[0] == accType.getShape()[0]
         && rhsType.getShape()[1] == accType.getShape()[1]) {
         return;
@@ -377,6 +376,7 @@ void InterCoreTransferAndSyncPass::extractMatmulResult(
     mlir::Operation *paddingAccOp = linalgFillOp;
     if (!matmulCIsEmpty(acc)) {
         LOG_DEBUG("nd2nz shape is unaligned and matmul C is not empty");
+        CVPipeline::setFallbackAttr(module);
         signalPassFailure();
     }
 
@@ -418,7 +418,7 @@ void InterCoreTransferAndSyncPass::extractMatmulResult(
 
 void InterCoreTransferAndSyncPass::rewriteMatmulWithNewShape(OpBuilder &builder, Operation *matmulOp, Location loc, bool isMatmulA, bool isMatmulB, bool matmulPadding, bool isOnlyDepInMatmul)
 {
-    int matmulOpBlockId = static_cast<int>(CVPipeline::getOpBlockId(matmulOp).value_or(-1));
+    int matmulOpBlockId = CVPipeline::getOpBlockId(matmulOp).value_or(-1);
 
     if (matmulPadding) {
         int matmulIndex = isMatmulA ? 1 : 0;
@@ -440,7 +440,7 @@ void InterCoreTransferAndSyncPass::rewriteTransposeWithNewShape(OpBuilder &build
     auto expectedType = RankedTensorType::get(newOutputShape, elemType);
     // Create new empty tensor with new shape
     auto tensorEmptyOp = builder.create<tensor::EmptyOp>(loc, newOutputShape, elemType);
-    attachCommonTags(tensorEmptyOp, static_cast<int>(CVPipeline::getOpBlockId(transposeOp).value_or(-1)), "CUBE");
+    attachCommonTags(tensorEmptyOp, CVPipeline::getOpBlockId(transposeOp).value_or(-1), "CUBE");
     Value transposeOpResult = transposeOp->getResult(0);
     transposeOp->setOperand(1, tensorEmptyOp.getResult());
     transposeOp->getResult(0).setType(expectedType);
@@ -451,6 +451,9 @@ mlir::Value InterCoreTransferAndSyncPass::normalizeIfNeeded(OpBuilder &builder, 
     mlir::Value origValue, SmallVector<int64_t> expectedShape, int originBlockId, bool matmulPadding, bool isOnlyDepInMatmul)
 {
     auto origTensorType = dyn_cast<RankedTensorType>(origValue.getType());
+    if (!origTensorType) {
+        return origValue;
+    }
 
     int64_t iniM = origTensorType.getDimSize(0);
     int64_t iniN = origTensorType.getDimSize(1);
@@ -484,7 +487,7 @@ mlir::Value InterCoreTransferAndSyncPass::normalizeIfNeeded(OpBuilder &builder, 
         LOG_DEBUG(*user << "\n");
         auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
         LOG_DEBUG("int userBlockId = getOpBlockId(user);" << (userBlockIdOpt ? *userBlockIdOpt : -1) << "\n");
-        if (!userBlockIdOpt || static_cast<int>(*userBlockIdOpt) != cId) {
+        if (!userBlockIdOpt || *userBlockIdOpt != cId) {
             continue;
         }
         user->replaceUsesOfWith(origValue, tensorInsertSliceOp.getResult());
@@ -636,7 +639,7 @@ std::pair<Operation *, Operation *> InterCoreTransferAndSyncPass::createTransfer
         consAllocOp = builder.create<memref::AllocOp>(loc, allocType);
         auto markConsOp = annotateTightlyCoupledBuffer(builder, consAllocOp, loc);
 
-        int loopBlockId = static_cast<int>(CVPipeline::getOpBlockId(mainLoopOp).value_or(-1));
+        int loopBlockId = CVPipeline::getOpBlockId(mainLoopOp).value_or(-1);
         attachTransferTags(prodAllocOp, loopBlockId, prodTag, transferIndex);
         attachTransferTags(consAllocOp, loopBlockId, consTag, transferIndex);
         attachTransferTags(markProdOp, loopBlockId, prodTag, transferIndex);
@@ -668,14 +671,14 @@ mlir::Operation *InterCoreTransferAndSyncPass::analyzeConsumerReadInsertPoint(
     llvm::DenseSet<mlir::Operation *> consumerOps;
     for (Operation *user : srcValue.getUsers()) {
         auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
-        if (userBlockIdOpt && static_cast<int>(*userBlockIdOpt) == iniConsumerId) {
+        if (userBlockIdOpt && *userBlockIdOpt == iniConsumerId) {
             consumerOps.insert(user);
         }
     }
 
     mlir::Operation* firstFoundOp = nullptr;
 
-    module->walk([&](mlir::Operation* op) {
+    module->walk<WalkOrder::PreOrder>([&](mlir::Operation* op) {
         if (consumerOps.contains(op)) {
             firstFoundOp = op;
             return mlir::WalkResult::interrupt(); 
@@ -689,7 +692,7 @@ mlir::Operation *InterCoreTransferAndSyncPass::analyzeConsumerReadInsertPoint(
 mlir::Operation *InterCoreTransferAndSyncPass::getConsumerWaitPoint(int transferIndex)
 {
     mlir::Operation *consumerWaitPoint = nullptr;
-    module.walk([&](mlir::Operation *op) {
+    module.walk<WalkOrder::PreOrder>([&](mlir::Operation *op) {
         if (consumerWaitPoint) {
             return;
         }
@@ -697,7 +700,7 @@ mlir::Operation *InterCoreTransferAndSyncPass::getConsumerWaitPoint(int transfer
             && !isa<LLVM::LoadOp>(op)) {
             return;
         }
-        auto transferIdAttr = op->getAttrOfType<IntegerAttr>(kTransferIdAttr);
+        auto transferIdAttr = op->getAttrOfType<IntegerAttr>(CVPipeline::kTransferId);
         if (transferIdAttr && transferIdAttr.getInt() == transferIndex) {
             consumerWaitPoint = op;
         }
@@ -713,9 +716,8 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(OpBuilder &b
     mlir::Operation *receiveOp = nullptr;
     Value receiveValue;
 
-    int vecBlockId = static_cast<int>(CVPipeline::getOpBlockId(vectorEndOp).value_or(-1));
-    int cubeBlockId = static_cast<int>(CVPipeline::getOpBlockId(cubeStartOp).value_or(-1));
-    LOG_DEBUG("Inserting [Vector->Cube] transfer for value: " << srcValue << "\n");
+    int vecBlockId = CVPipeline::getOpBlockId(vectorEndOp).value_or(-1);
+    int cubeBlockId = CVPipeline::getOpBlockId(cubeStartOp).value_or(-1);
 
     if (isScaler) {
         builder.setInsertionPointAfter(vectorEndOp);
@@ -798,7 +800,7 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(OpBuilder &b
     for (Operation *user : users) {
         LOG_DEBUG("[v->c user]" << *user << "\n");
         auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
-        if (userBlockIdOpt && static_cast<int>(*userBlockIdOpt) == iniConsumerId) {
+        if (userBlockIdOpt && *userBlockIdOpt == iniConsumerId) {
             user->replaceUsesOfWith(srcValue, receiveValue);
         }
     }
@@ -818,8 +820,8 @@ Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(OpBuilder &b
     int64_t N = srcTensorType.getDimSize(1);
     Type elemType = srcTensorType.getElementType();
 
-    int cubeBlockId = static_cast<int>(CVPipeline::getOpBlockId(srcValue.getDefiningOp()).value_or(-1));
-    int vecBlockId = static_cast<int>(CVPipeline::getOpBlockId(vectorStartOp).value_or(-1));
+    int cubeBlockId = CVPipeline::getOpBlockId(srcValue.getDefiningOp()).value_or(-1);
+    int vecBlockId = CVPipeline::getOpBlockId(vectorStartOp).value_or(-1);
 
     auto [cubeAllocOp, vecAllocOp] = createTransferAllocs(builder, loc, { M, N }, elemType, hivm::AddressSpace::UB,
         cubeEndOp, vectorStartOp, cubeBlockId, vecBlockId, "CUBE", "VECTOR", transferIndex);
@@ -850,7 +852,7 @@ Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(OpBuilder &b
     for (Operation *user : users) {
         LOG_DEBUG("[c->v user]" << *user << "\n");
         auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
-        if (userBlockIdOpt && static_cast<int>(*userBlockIdOpt) == iniConsumerId) {
+        if (userBlockIdOpt && *userBlockIdOpt == iniConsumerId) {
             user->replaceUsesOfWith(srcValue, toTensorOp.getResult());
         }
     }
@@ -914,8 +916,8 @@ void InterCoreTransferAndSyncPass::insertInterCoreSync(
 
     auto flagId = builder.getIntegerAttr(builder.getI64Type(), flag);
 
-    int producerBlockId = static_cast<int>(CVPipeline::getOpBlockId(transferOp).value_or(-1));
-    int consumerBlockId = static_cast<int>(CVPipeline::getOpBlockId(consumerStartOp).value_or(-1));
+    int producerBlockId = CVPipeline::getOpBlockId(transferOp).value_or(-1);
+    int consumerBlockId = CVPipeline::getOpBlockId(consumerStartOp).value_or(-1);
 
     Operation *mainLoopOp = findMainLoopforTransfer(transferOp, consumerStartOp);
 
@@ -1000,11 +1002,11 @@ void InterCoreTransferAndSyncPass::insertMemDepSync(OpBuilder &builder, Operatio
     auto consBlockIdOpt = CVPipeline::getOpBlockId(consumerOp);
     if (prodBlockIdOpt) {
         StringRef prodCoreType = isCubeToVector ? "CUBE" : "VECTOR";
-        attachCommonTags(setOp, static_cast<int>(*prodBlockIdOpt), prodCoreType);
+        attachCommonTags(setOp, *prodBlockIdOpt, prodCoreType);
     }
     if (consBlockIdOpt) {
         StringRef consCoreType = isCubeToVector ? "VECTOR" : "CUBE";
-        attachCommonTags(waitOp, static_cast<int>(*consBlockIdOpt), consCoreType);
+        attachCommonTags(waitOp, *consBlockIdOpt, consCoreType);
     }
     attachAnalyzeFlagIdTag(setOp);
     attachAnalyzeFlagIdTag(waitOp);
@@ -1028,7 +1030,7 @@ static std::optional<hivm::TCoreType> getAnalyzeCoreType(Operation *op)
         }
     }
 
-    auto coreStringAttr = op->getAttrOfType<StringAttr>(kCoreTypeAttr);
+    auto coreStringAttr = op->getAttrOfType<StringAttr>(CVPipeline::kCoreType);
     if (!coreStringAttr) {
         return std::nullopt;
     }
@@ -1301,7 +1303,7 @@ llvm::SmallVector<mlir::Operation *> InterCoreTransferAndSyncPass::insertAnalyze
                     definingOp = blockArgument.getOwner()->getParentOp();
                 }
             }
-            if (relationOpSet.contains(definingOp)) {
+            if (definingOp && relationOpSet.contains(definingOp)) {
                 insertRelation(definingOp, op);
             }
         }
@@ -1355,7 +1357,7 @@ void InterCoreTransferAndSyncPass::sortDependencies(llvm::SmallVector<Dependency
     //         to each operation, representing its position in the IR.
     llvm::DenseMap<mlir::Operation *, unsigned> opOrder;
     unsigned order = 0;
-    module.walk([&](mlir::Operation *op) {
+    module.walk<WalkOrder::PreOrder>([&](mlir::Operation *op) {
         opOrder[op] = order++;
     });
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/MarkMainLoop.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/MarkMainLoop.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/MarkMainLoop.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "mlir/IR/Operation.h"
 #include "llvm/Support/Debug.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
@@ -51,9 +52,9 @@ void MarkMainLoopPass::runOnOperation()
     });
 
     for (scf::ForOp forOp : mainLoops) {
-        if (!forOp->hasAttr("ssbuffer.main_loop")) {
+        if (!forOp->hasAttr(CVPipeline::kMainLoop)) {
             // Add attribute with integer value (current counter ID)
-            forOp->setAttr("ssbuffer.main_loop", Builder(module.getContext()).getI32IntegerAttr(mainLoopIdCounter));
+            forOp->setAttr(CVPipeline::kMainLoop, Builder(module.getContext()).getI32IntegerAttr(mainLoopIdCounter));
             mainLoopIdCounter++;
         }
     }
@@ -62,7 +63,7 @@ void MarkMainLoopPass::runOnOperation()
     // Keep only the innermost main_loop
     SmallVector<scf::ForOp> allMainLoops;
     module.walk([&](scf::ForOp forOp) {
-        if (forOp->hasAttr("ssbuffer.main_loop")) {
+        if (forOp->hasAttr(CVPipeline::kMainLoop)) {
             allMainLoops.push_back(forOp);
         }
     });
@@ -71,13 +72,13 @@ void MarkMainLoopPass::runOnOperation()
         // Check if there's any nested for loop with main_loop attribute
         bool hasNestedMainLoop = false;
         forOp.walk([&](scf::ForOp nestedForOp) {
-            if (nestedForOp != forOp && nestedForOp->hasAttr("ssbuffer.main_loop")) {
+            if (nestedForOp != forOp && nestedForOp->hasAttr(CVPipeline::kMainLoop)) {
                 hasNestedMainLoop = true;
             }
         });
         // Remove attribute from outer loop if inner loop also has it
         if (hasNestedMainLoop) {
-            forOp->removeAttr("ssbuffer.main_loop");
+            forOp->removeAttr(CVPipeline::kMainLoop);
         }
     }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/Utils.cpp
@@ -1,0 +1,43 @@
+
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/DynamicCVPipeline/SplitDataflow/Utils.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/StringRef.h"
+
+using namespace mlir;
+using namespace llvm;
+
+void triton::setOpBlockId(mlir::Operation *op, int blockId)
+{
+    static constexpr int kIntegerBitWidth = 32;
+    op->setAttr(CVPipeline::kBlockId,
+                IntegerAttr::get(IntegerType::get(op->getContext(), kIntegerBitWidth), blockId));
+}
+
+void triton::setOpCoreType(mlir::Operation *op, llvm::StringRef coreType)
+{
+    op->setAttr(CVPipeline::kCoreType, StringAttr::get(op->getContext(), coreType));
+}

--- a/third_party/ascend/lib/TritonToLinalg/TileChunkCoalescing.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TileChunkCoalescing.cpp
@@ -44,50 +44,26 @@ using namespace triton;
 
 namespace {
 
-// Tunables.
-constexpr int64_t kMinContigBytes = 512;  // floor: smallest merged-block size
+constexpr int64_t kMinContigBytes = 512;
 
-// Upper bound on the number of tiles coalesced per program. We now derive it
-// from a UB (Unified Buffer) footprint budget instead of a single flat cap:
-//
-//   maxH = clamp(kUBBytesBudget / per-program-footprint(H=1), 2, kMaxCoalesceTilesCeil)
-//
-// This lets kernels with a small working set (pure 1-D load->store) coalesce far
-// more aggressively -- bigger contiguous DMAs, fewer persistent-loop trips --
-// while kernels carrying a large on-chip tensor (e.g. a 16x16 segsum matrix)
-// automatically back off so the lifted footprint still fits UB.
-//
-// The footprint is the SUM of every lifted region tensor's bytes at H=1. That
-// over-counts (the backend reuses buffers by liveness, so true peak live set is
-// smaller), which is the safe direction: we may pick a smaller H than strictly
-// necessary, but never one that overflows UB (runtime error 341). If on-board
-// profiling shows UB headroom, raise kUBBytesBudget; if it overflows, lower it.
-//
-// UB is ~256 KB/core on this arch (dav-c310, __UB_SIZE = 262144). The budget is
-// a conservative slice that leaves room for double-buffering and alignment.
+// UB footprint budget: derives maxH so that H * footprintUnit <= budget.
+// UB is ~256 KB/core (dav-c310). Budget is conservative to leave room for
+// double-buffering and alignment overhead.
 constexpr int64_t kUBBytesBudget = 96 * 1024;
-// Absolute ceiling regardless of UB headroom: a very large H shrinks the launch
-// grid (the host launcher divides grid[axis] by H) and can starve AI cores, so
-// we never coalesce more than this many tiles per program.
+// Large H starves AI cores (grid[axis] / H shrinks the launch grid).
 constexpr int64_t kMaxCoalesceTilesCeil = 16;
 
 constexpr llvm::StringLiteral kCoalesceFactorAttr = "hacc.coalesce_factor";
-// The grid axis (= program_id axis) whose launch dimension the host launcher
-// divides by the factor. The full TA path owns the grid division: bishengir no
-// longer interprets either attr (see driver.py / compiler.py).
 constexpr llvm::StringLiteral kCoalesceAxisAttr = "hacc.coalesce_axis";
 
 struct TileSeed {
-  triton::GetProgramIdOp pid;  // the (outermost) tile-index program id
-  int32_t axis = 0;            // pid axis == the grid dim the launcher divides
-  int64_t tileLen = 0;         // T  (constexpr tile length / CHUNK_SIZE)
-  int64_t bound = 0;           // BOUND (constexpr problem length / SEQLEN)
-  Value mask;                  // tile OOB mask (cmpi result). It is provably
-                               // all-true (we require bound % tileLen == 0) and
-                               // is dropped from the coalesced load/store.
+  triton::GetProgramIdOp pid;
+  int32_t axis = 0;
+  int64_t tileLen = 0;
+  int64_t bound = 0;
+  Value mask;
 };
 
-// Read a constant integer from a scalar i32 or a splat-of-constant tensor.
 static bool getConstInt(Value v, int64_t &out) {
   APInt ap;
   if (matchPattern(v, m_ConstantInt(&ap))) {
@@ -103,14 +79,7 @@ static bool getConstInt(Value v, int64_t &out) {
   return false;
 }
 
-// The set of ops we know how to lift (prepend an H lane). Anything else in the
-// load->store subgraph makes the pass bail.
-//
-// arith/math ops are all side-effect-free, elementwise (or scalar) and carry no
-// regions, so the generic "prepend H + rebuild" handles them uniformly -- we
-// whitelist those dialects wholesale rather than enumerating ops (so math.exp,
-// math.log, math.sqrt, ... all work). The remaining cases are the triton ops
-// that need shape/axis-aware handling.
+// Whitelist arith/math dialects wholesale (side-effect-free, elementwise).
 static bool isLiftable(Operation *op) {
   if (auto *d = op->getDialect()) {
     StringRef ns = d->getNamespace();
@@ -123,31 +92,21 @@ static bool isLiftable(Operation *op) {
              triton::ScanOp, triton::ReduceOp>(op);
 }
 
-// Detect the tile-index signature:
-//     blk  = muli(program_id_max, C)          (C constexpr, the tile length T)
-//     offs = splat(blk) + make_range[0, C)
-// The boundary mask `cmpi slt(offs, BOUND)` is required: it gives the pass a
-// static tile count and lets the launcher shrink grid[axis] by an exact divisor.
-// Unmasked kernels carry no tile count in the IR; coalescing them would rely on
-// runtime grid[axis] being both >= H and divisible by H, which is not guaranteed.
-// When the mask is present we use it to recover BOUND (and to drop the
-// provably-all-true mask later); when it is a real partial-tile mask
-// (BOUND % C != 0) we must NOT coalesce, so we bail.
+// Detect tile-index signature:
+//   blk  = muli(program_id_max, T)
+//   offs = splat(blk) + make_range[0, T)
+//   mask = cmpi slt(offs, BOUND)  with BOUND % T == 0
+// The mask proves all tiles are full (no partial last tile) and provides the
+// compile-time tile count needed for grid division.
 static std::optional<TileSeed> findSeed(ModuleOp moduleOp) {
-  // The coalesced axis must be the OUTERMOST grid axis: the host launcher
-  // divides grid[axis] by coalesce_factor, and bishengir reconstructs the
-  // outermost (highest-index) program id as the most-significant digit of the
-  // linear block id, so only that axis stays consistent. Coalescing an inner
-  // axis would mis-assign work.
+  // Only the outermost grid axis can be coalesced: bishengir reconstructs the
+  // highest-index program_id as the MSB of the linear block id.
   int32_t maxAxis = -1;
   moduleOp.walk([&](triton::GetProgramIdOp pid) {
     maxAxis = std::max<int32_t>(maxAxis, pid.getAxisAsInt());
   });
 
-  // Only one program-id op may read the coalesced axis: we replace the seed
-  // pid by the per-lane tile vector, but a second (non-CSE'd) pid of the same
-  // axis would keep returning the now-divided block id -> its tile indices
-  // would silently address the wrong tiles. Bail unless unique.
+  // Require exactly one pid op on the coalesced axis (CSE should have merged).
   int32_t maxAxisPids = 0;
   moduleOp.walk([&](triton::GetProgramIdOp pid) {
     if (pid.getAxisAsInt() == maxAxis)
@@ -156,11 +115,7 @@ static std::optional<TileSeed> findSeed(ModuleOp moduleOp) {
   if (maxAxisPids != 1)
     return std::nullopt;
 
-  // Full TA path: the launcher divides grid[maxAxis] by H, so the kernel-visible
-  // num_programs(maxAxis) becomes grid/H instead of grid. If the kernel reads it
-  // (e.g. for its own bound arithmetic) coalescing would silently change that
-  // value -> wrong results. Refuse to coalesce such kernels (they keep the
-  // original, uncoalesced -- but correct -- path).
+  // If kernel reads num_programs(maxAxis), coalescing would silently change it.
   bool readsMaxAxisNumPrograms = false;
   moduleOp.walk([&](triton::GetNumProgramsOp np) {
     if (np.getAxisAsInt() == maxAxis)
@@ -181,9 +136,8 @@ static std::optional<TileSeed> findSeed(ModuleOp moduleOp) {
                                                        : mul.getLhs();
       int64_t T = 0;
       if (!getConstInt(other, T) || T <= 1)
-        continue;  // non-const multiplier (e.g. segsum chunk stride) -> skip
+        continue;
 
-      // muli -> splat -> addi(splat, make_range[0,T))
       for (Operation *mu : mul.getResult().getUsers()) {
         auto sp = dyn_cast<triton::SplatOp>(mu);
         if (!sp)
@@ -198,23 +152,8 @@ static std::optional<TileSeed> findSeed(ModuleOp moduleOp) {
           if (!range || range.getStart() != 0 || range.getEnd() != T)
             continue;
 
-          // Boundary-safety scan: taint everything pid-derived (through
-          // elementwise arith and shape ops) and require that NO tainted value
-          // feeds boundary handling, except the one canonical all-true tile
-          // mask `cmpi slt(offs, BOUND)` directly on offs with constant
-          // BOUND >= T and BOUND % T == 0 (provably all-true, droppable).
-          //
-          // Everything else is real boundary logic on the chunk axis and must
-          // block coalescing:
-          //   * cmpi with a runtime BOUND (kernel arg): a partial last tile may
-          //     exist; the lifted mask `(pid*H+h)*T + t < BOUND` is
-          //     non-separable (MaskAnalysis bails, load stays unconverted) and
-          //     the launcher's grid/H drops remainder tiles -> wrong results.
-          //   * cmpi reached through expand_dims/broadcast/addi/... or with
-          //     other predicates/operand order: same non-separability.
-          //   * min/max clamps and div/rem wraparound on pid-derived offsets:
-          //     the lifted addressing is non-affine across tiles (PtrAnalysis
-          //     bails).
+          // Taint-propagation: ensure no pid-derived value feeds boundary
+          // handling other than the canonical all-true tile mask.
           int64_t bound = 0;
           Value mask;
           bool unsafe = false;
@@ -252,16 +191,16 @@ static std::optional<TileSeed> findSeed(ModuleOp moduleOp) {
                 propagates |= d->getNamespace() ==
                               arith::ArithDialect::getDialectNamespace();
               if (!propagates)
-                continue;  // load/store/scan/... results carry data, not offsets
+                continue;
               for (Value r : tu->getResults())
                 if (taint.insert(r).second)
                   twl.push_back(r);
             }
           }
           if (unsafe)
-            return;  // real boundary handling on the chunk axis; abandon pid
+            return;
           if (!mask)
-            return;  // unmasked kernel: runtime tile count is absent from IR
+            return;
 
           result = TileSeed{pid, maxAxis, T, bound, mask};
           return;
@@ -272,10 +211,8 @@ static std::optional<TileSeed> findSeed(ModuleOp moduleOp) {
   return result;
 }
 
-// Forward slice from the tile pid down to (and including) the stores. Fills
-// `region` (all ops) and `ordered` (region ops in IR order). Returns false and
-// leaves the IR untouched if the slice contains an unliftable op, if a region
-// value escapes the slice, or if there are no store sinks.
+// Forward slice from the tile pid to stores. Returns false if the slice
+// contains an unliftable op, escapes the region, or has no store sinks.
 static bool collectRegion(TileSeed &seed, ModuleOp moduleOp,
                           DenseSet<Operation *> &region,
                           SmallVectorImpl<Operation *> &ordered) {
@@ -289,7 +226,7 @@ static bool collectRegion(TileSeed &seed, ModuleOp moduleOp,
     if (!visited.insert(op).second)
       continue;
     if (!isLiftable(op))
-      return false;  // bail: unknown op in the chain (e.g. tt.dot)
+      return false;
     if (isa<triton::StoreOp>(op))
       hasStore = true;
     region.insert(op);
@@ -300,7 +237,6 @@ static bool collectRegion(TileSeed &seed, ModuleOp moduleOp,
   if (!hasStore)
     return false;
 
-  // No region value (other than store effects) may escape the slice.
   for (Operation *op : region) {
     if (isa<triton::StoreOp>(op))
       continue;
@@ -310,7 +246,6 @@ static bool collectRegion(TileSeed &seed, ModuleOp moduleOp,
           return false;
   }
 
-  // Topological (IR) order, restricted to the region.
   moduleOp.walk([&](Operation *op) {
     if (region.count(op))
       ordered.push_back(op);
@@ -318,14 +253,8 @@ static bool collectRegion(TileSeed &seed, ModuleOp moduleOp,
   return true;
 }
 
-// Pick H (number of tiles coalesced per program). The floor `hMin` is the
-// smallest factor whose merged block reaches kMinContigBytes -- the minimum that
-// fixes the tiny-DMA pathology. `maxH` is the UB-footprint-derived ceiling
-// (see kUBBytesBudget); it has already been clamped to kMaxCoalesceTilesCeil.
-//
-// H must divide the statically known tile count so the launcher's
-// `grid[axis] / H` is exact. Pick the largest divisor in [hMin, maxH] so the
-// already-contiguous transfers get bigger DMAs / fewer loop iterations.
+// Pick the largest divisor of numTiles in [hMin, maxH].
+// H must divide numTiles so grid[axis] / H is exact.
 static int64_t chooseH(int64_t numTiles, int64_t tileLen, int64_t elemBytes,
                        int64_t maxH) {
   int64_t blockBytes = tileLen * elemBytes;
@@ -333,35 +262,17 @@ static int64_t chooseH(int64_t numTiles, int64_t tileLen, int64_t elemBytes,
   if (hMin < 2)
     hMin = 2;
   if (maxH < hMin)
-    return 0;  // UB budget too tight to even reach the contiguity floor
-
+    return 0;
   if (numTiles <= 0)
     return 0;
 
-  int64_t H = 0;
-  for (int64_t c = hMin; c <= numTiles; ++c)
-    if (numTiles % c == 0) {
-      H = c;
-      break;
-    }
-  if (H == 0)
-    return 0;
-
-  for (int64_t c = numTiles; c > H; --c)
-    if (numTiles % c == 0 && c <= maxH) {
-      H = c;
-      break;
-    }
-  return H;
+  for (int64_t c = maxH; c >= hMin; --c)
+    if (numTiles % c == 0)
+      return c;
+  return 0;
 }
 
 static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
-  // Yield to the higher-priority StridedAxisCoalescing: the launcher divides
-  // grid[axis] by a single (hacc.coalesce_factor, hacc.coalesce_axis) pair, so
-  // at most one pass may own it per module. If StridedAxisCoalescing (which runs
-  // first) already claimed it, coalescing again here would lift a second set of
-  // tiles while only one (factor, axis) survives -> wrong block count. Bail and
-  // leave our tiles to the strided dispatch.
   if (moduleOp->hasAttr(kCoalesceFactorAttr))
     return;
 
@@ -374,7 +285,6 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
   if (!collectRegion(*seed, moduleOp, region, ordered))
     return;
 
-  // Element size from the first region load.
   int64_t elemBytes = 0;
   for (Operation *op : ordered)
     if (auto ld = dyn_cast<triton::LoadOp>(op)) {
@@ -386,13 +296,8 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
   if (elemBytes == 0)
     return;
 
-  // Per-program UB footprint at H=1: sum of the bytes of the tensors that
-  // actually live in UB. Each lifts to H copies, so footprint(H) = H *
-  // footprintUnit. We count only DMA'd data (load results, store values) and
-  // floating-point compute results; pointer / integer-offset / i1-mask tensors
-  // are address arithmetic that folds into memref strides and never occupies a
-  // UB data buffer. Summing (vs peak-live) over-counts -- the safe direction:
-  // we may pick a smaller H, never one that overflows UB (runtime error 341).
+  // UB footprint at H=1: sum over DMA'd data and float compute tensors.
+  // Pointer/offset/mask tensors fold into memref strides and skip UB.
   auto tensorBytes = [](Type t) -> int64_t {
     auto rt = dyn_cast<RankedTensorType>(t);
     if (!rt)
@@ -414,12 +319,11 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
           if (isa<FloatType>(rt.getElementType()))
             footprintUnit += tensorBytes(t);
   }
-  // maxH = clamp(budget / footprintUnit, 2, ceil).
   int64_t maxH = kMaxCoalesceTilesCeil;
   if (footprintUnit > 0)
     maxH = std::min<int64_t>(maxH, kUBBytesBudget / footprintUnit);
   if (maxH < 2)
-    maxH = 2;
+    return;  // even H=2 would overflow UB
 
   int64_t numTiles = (seed->bound + seed->tileLen - 1) / seed->tileLen;
   int64_t H = chooseH(numTiles, seed->tileLen, elemBytes, maxH);
@@ -431,12 +335,8 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
   Value seedMask = seed->mask;
   Operation *seedMaskOp = seedMask ? seedMask.getDefiningOp() : nullptr;
 
-  // The all-true tile mask is dropped from the loads/stores it guards and is
-  // never rebuilt (skipped in the loop below). That is only valid if it feeds
-  // *nothing else*: any other consumer (a broadcast before the load mask, a
-  // tt.where, ...) would try to lift the skipped mask and reference a null
-  // value -> invalid IR. Bail in that case (kernel keeps the correct,
-  // uncoalesced path) rather than risk a miscompile.
+  // Seed mask must feed only load/store mask slots; other consumers would
+  // reference the skipped (never-rebuilt) mask value -> invalid IR.
   if (seedMask) {
     for (Operation *u : seedMask.getUsers()) {
       auto ld = dyn_cast<triton::LoadOp>(u);
@@ -448,33 +348,19 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
     }
   }
 
-  // Preflight: from here on we create ops; every op of the region must be
-  // provably rebuildable in lifted form, otherwise the new op would fail the
-  // verifier AFTER the IR is already mutated -- a hard compile error instead
-  // of a silent fallback. Anything we cannot prove safe bails here, while the
-  // IR is still untouched.
+  // Preflight: bail while IR is untouched if any op cannot be lifted safely.
   Block *pidBlock = seed->pid->getBlock();
   for (Operation *op : ordered) {
-    // Straight-line code only: a region op nested in scf.for/scf.if has
-    // loop-carried/branch semantics the elementwise lift does not model.
     if (op->getBlock() != pidBlock)
       return;
-    // Zero-operand ops (constants, make_range) reach the generic rebuild with
-    // a lifted result type but unchanged attributes (e.g. a DenseElementsAttr
-    // of the OLD shape) -> verifier failure.
     if (!isa<triton::LoadOp, triton::StoreOp>(op) && op->getNumOperands() == 0)
       return;
-    // arith.select: the lift turns a scalar condition into tensor<Hxi1>, which
-    // no longer matches the lifted tensor operands -> invalid op.
     if (auto sel = dyn_cast<arith::SelectOp>(op)) {
       bool condTensor = isa<RankedTensorType>(sel.getCondition().getType());
       bool valTensor = isa<RankedTensorType>(sel.getTrueValue().getType());
       if (condTensor != valTensor)
         return;
     }
-    // Lifting bumps the boundary-check axes; only block-pointer accesses carry
-    // them and those never reach here, so any non-empty set means an IR shape
-    // we did not anticipate.
     if (auto ld = dyn_cast<triton::LoadOp>(op))
       if (!ld.getBoundaryCheck().empty())
         return;
@@ -493,8 +379,6 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
     return RankedTensorType::get({H}, t);
   };
 
-  // tileVec = splat(pid * H) + arange(0, H)  : tensor<Hxi32>, the per-lane
-  // global tile index covered by this (now coalesced) program.
   rw.setInsertionPointAfter(seed->pid);
   Value cH = rw.create<arith::ConstantIntOp>(ploc, H, 32);
   Value pidH = rw.create<arith::MulIOp>(ploc, pidVal, cH);
@@ -513,16 +397,12 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
       return it->second;
     Operation *def = v.getDefiningOp();
     if (def && region.count(def)) {
-      // Rebuilt earlier (IR order guarantees dominance). The only region op we
-      // never rebuild is the all-true tile mask, and the precondition above
-      // guarantees it is not used here, so the lookup must succeed.
       auto rebuilt = vmap.find(v);
       assert(rebuilt != vmap.end() && "region value used before its rebuild");
       return rebuilt->second;
     }
     if (!isa<RankedTensorType>(v.getType()))
-      return v;  // region-invariant scalar; caller splats if needed
-    // region-invariant tensor: prepend a size-1 dim then broadcast over H.
+      return v;
     Value e = rw.create<triton::ExpandDimsOp>(v.getLoc(), v, 0);
     Value b = rw.create<triton::BroadcastOp>(v.getLoc(), liftTy(v.getType()), e);
     vmap[v] = b;
@@ -541,7 +421,6 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
   auto bumpBoundary = [&](ArrayRef<int32_t> bc) {
     return llvm::map_to_vector(bc, [](int32_t i) { return i + 1; });
   };
-  // Copy over any extra attrs the typed builder did not already set.
   auto copyAttrs = [&](Operation *from, Operation *to) {
     for (NamedAttribute a : from->getAttrs())
       if (!to->hasAttr(a.getName()))
@@ -549,18 +428,12 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
   };
 
   for (Operation *op : ordered) {
-    // The tile mask is provably all-true (bound % tileLen == 0) and is dropped
-    // from every load/store below, so its (non-separable) lifted form is never
-    // needed -- skip rebuilding it.
     if (op == seedMaskOp)
       continue;
 
     rw.setInsertionPoint(op);
     Location loc = op->getLoc();
 
-    // tt.splat needs a scalar source; if the source became a per-lane tensor
-    // ([H]) we instead expand+broadcast it across the splatted shape (mirrors
-    // PropagateUnrealizedCastDown::rewriteSplat).
     if (auto sp = dyn_cast<triton::SplatOp>(op)) {
       Value lin = lift(sp.getSrc());
       if (!isa<RankedTensorType>(lin.getType())) {
@@ -568,7 +441,7 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
             rw.create<triton::SplatOp>(loc, liftTy(sp.getType()), lin);
       } else {
         int addDims = cast<RankedTensorType>(sp.getType()).getRank();
-        Value cur = lin;  // tensor<Hx...>
+        Value cur = lin;
         for (int k = 0; k < addDims; ++k)
           cur = rw.create<triton::ExpandDimsOp>(
               loc, cur, cast<RankedTensorType>(cur.getType()).getRank());
@@ -611,8 +484,6 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
       continue;
     }
     if (auto ld = dyn_cast<triton::LoadOp>(op)) {
-      // Drop the all-true tile mask (and its `other`) so the coalesced load is
-      // an unmasked contiguous block that PtrAnalysis can fully convert.
       bool dropMask = ld.getMask() == seedMask;
       Value m = dropMask ? Value() : liftOpdOrNull(ld.getMask());
       Value o = dropMask ? Value() : liftOpdOrNull(ld.getOther());
@@ -634,9 +505,6 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
       continue;
     }
 
-    // Elementwise / address arithmetic (arith.*, tt.addptr, ...): generic
-    // rebuild with lifted operands and prepended result type (mirrors
-    // PropagateUnrealizedCastDown::rewriteGeneraleOp).
     SmallVector<Value> operands =
         llvm::map_to_vector(op->getOperands(), [&](Value o) { return liftOpd(o); });
     SmallVector<Type> resTypes = llvm::map_to_vector(
@@ -647,12 +515,9 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
       vmap[oldR] = newR;
   }
 
-  // Drop the original chain (reverse IR order: uses before defs).
   for (auto it = ordered.rbegin(); it != ordered.rend(); ++it)
     rw.eraseOp(*it);
 
-  // Record (factor, axis) for the host launcher. compiler.py reads + strips both
-  // attrs; the launcher then divides grid[axis] by H. bishengir is not involved.
   auto i32Ty = IntegerType::get(moduleOp.getContext(), 32);
   moduleOp->setAttr(kCoalesceFactorAttr, IntegerAttr::get(i32Ty, H));
   moduleOp->setAttr(kCoalesceAxisAttr, IntegerAttr::get(i32Ty, seed->axis));

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_yield_if_dependencies.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_yield_if_dependencies.mlir
@@ -1,0 +1,54 @@
+// RUN: triton-opt --add-block-id-for-control-ops --data-dependency-analysis --inter-core-transfer-and-sync --mark-main-loop %s | FileCheck %s
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_yield_if_dependencies(%arg0: i32) {
+    %cst = arith.constant {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
+    %c128_i32 = arith.constant {MixUse, ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} 128 : i32
+    %c64_i32 = arith.constant {Undefined, ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} 64 : i32
+    %0 = arith.muli %arg0, %c128_i32 {MixUse, ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : i32
+    %1 = arith.addi %arg0, %c64_i32 {Undefined, ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : i32
+    %2 = arith.cmpi sge, %1, %0 {Undefined, ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : i32
+    %3 = tensor.empty() {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
+    %4 = linalg.fill {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : f32) outs(%3 : tensor<128x128xf32>) -> tensor<128x128xf32>
+    %5 = math.exp2 %4 {DataUse, ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
+
+    %6 = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+    %7 = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : f32) outs(%3 : tensor<128x128xf32>) -> tensor<128x128xf32>
+    %alloc = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf32>
+    %8 = bufferization.to_tensor %alloc {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf32>
+    %9 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%8, %8 : tensor<128x128xf32>, tensor<128x128xf32>) outs(%7 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+    %10:2 = scf.if %2 -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+      %12 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
+      scf.yield {Undefined, ssbuffer.core_type = "VECTOR, VECTOR"} %12, %12 : tensor<128x128xf32>, tensor<128x128xf32>
+    } else {
+      scf.yield {Undefined, ssbuffer.core_type = "VECTOR, VECTOR"} %5, %9 : tensor<128x128xf32>, tensor<128x128xf32>
+    } {DataUse, ssbuffer.core_type = "VECTOR, VECTOR"}
+    %11 = arith.mulf %10#0, %10#1 {DataUse, ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
+    return
+  }
+}
+
+// CHECK-LABEL: @test_yield_if_dependencies
+
+// CHECK: %[[EXP_5:[a-z0-9_]+]] = math.exp2
+// CHECK: %[[MATMUL_9:[a-z0-9_]+]] = linalg.matmul
+// CHECK: %[[ALLOC_0:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+// CHECK: annotation.mark %[[ALLOC_0]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+// CHECK: hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} ins(%[[MATMUL_9]] : tensor<128x128xf32>) outs(%[[ALLOC_0]] : memref<128x128xf32, #hivm.address_space<ub>>)
+// CHECK: hivm.hir.sync_block_set {{.*}} flag = 1
+// CHECK: hivm.hir.sync_block_wait {{.*}} flag = 1
+// CHECK: %[[ALLOC_1:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+// CHECK: annotation.mark %[[ALLOC_1]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+// CHECK: %[[MEMSPACECAST:[a-z0-9_]+]] = memref.memory_space_cast %[[ALLOC_1]] {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32, #hivm.address_space<ub>> to memref<128x128xf32>
+// CHECK: %[[TENSOR_10:[a-z0-9_]+]] = bufferization.to_tensor %[[MEMSPACECAST]] restrict writable {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<128x128xf32>
+// CHECK: %[[IF_11:[a-z0-9_]+]]:2 = scf.if
+// CHECK: %[[EMPTY_13:[a-z0-9_]+]] = tensor.empty()
+// CHECK: scf.yield {Undefined, ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR, VECTOR"} %[[EMPTY_13]], %[[EMPTY_13]] : tensor<128x128xf32>, tensor<128x128xf32>
+// CHECK: } else {
+// CHECK: scf.yield {Undefined, ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR, VECTOR"} %[[EXP_5]], %[[TENSOR_10]] : tensor<128x128xf32>, tensor<128x128xf32>
+// CHECK: } {DataUse, ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR, VECTOR"}
+// CHECK: arith.mulf %[[IF_11]]#0, %[[IF_11]]#1 
+// CHECK: return
+
+


### PR DESCRIPTION
**PR Title:**  [release/3.2.2](feat) Sync verified commits from dev to release/3.2.2

**Description:**

This PR synchronizes the following verified commits from the `dev` branch to the `release/3.2.2` branch. All commits have passed CI verification and are ready for integration.

### Synchronized Commits:

| Commit Subject | Author |
|----------------|--------|
| **[CI] update default code owners (#754)** | hongziqi |
| **[ssbuffer] nd2nz matmul C padding (#670)** | lrf22 |
| **[ssbuffer] fix tensor.empty+linalg.fill pos (#759)** | cxtverygood |
| **[ssbuffer] fix some code warnings (#764)** | zhuxinguang33 |
| **[ssbuffer] Modification of potential code safety issues (#769)** | Hsyy04 |
| **[TileChunkCoalescing] chooseH exceeds maxH causing UB overflow (#779)** | Popeyesxs |
| **[ssbuffer] process yield op in scf.if (#476)** | lrf22 |


### Summary of Changes:

- **Bug Fixes**: 
  - Fixed nd2nz matmul C padding issue in ssbuffer
  - Fixed tensor.empty and linalg.fill position issues
  - Fixed various code warnings in ssbuffer
  - Fixed potential code safety issues in ssbuffer
  - Fixed Two bugs in the H selection logic
  - Fixed yield operation handling in scf.if for ssbuffer
  - Skip ND2NZ MatmulC for non-zero matrices requiring padding
- **Documentation**: Updated default code owners in CI
All changes have been cherry-picked from the `dev` branch and verified locally. No conflicts were encountered during integration.