### PR TITLE
[backend](feat) add plugin hooks to Ascend compile path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ option(TRITON_BUILD_TUTORIALS "Build C++ Triton tutorials" ON)
 option(TRITON_BUILD_PYTHON_MODULE "Build Python Triton bindings" OFF)
 option(TRITON_BUILD_PROTON "Build the Triton Proton profiler" ON)
 option(TRITON_BUILD_UT "Build C++ Triton Unit Tests" ON)
+option(TRITON_EXT_ENABLED "Build with default visibility for Triton+LLVM symbol exposure to plugin extensions" OFF)
 set(TRITON_CODEGEN_BACKENDS "" CACHE STRING "Enable different codegen backends")
 
 # Ensure Python3 vars are set correctly
@@ -123,7 +124,11 @@ endfunction()
 
 
 # Disable warnings that show up in external code (gtest;pybind11)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-covered-switch-default -fvisibility=hidden")
+if(NOT TRITON_EXT_ENABLED)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-covered-switch-default -fvisibility=hidden")
+else()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-covered-switch-default -DTRITON_EXT_ENABLED=1")
+endif()
 
 include_directories(".")
 include_directories(${MLIR_INCLUDE_DIRS})
@@ -303,7 +308,7 @@ if(TRITON_BUILD_PYTHON_MODULE)
   add_library(entryC SHARED ${PROJECT_SOURCE_DIR}/lib/runtime/libentry/libentry.cpp)
 endif()
 
-if (UNIX AND NOT APPLE)
+if (UNIX AND NOT APPLE AND NOT TRITON_EXT_ENABLED)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--exclude-libs,ALL")
 endif()
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -565,6 +565,11 @@ class CMakeBuild(build_ext):
         else:
             cmake_args += ["-DTRITON_BUILD_PROTON=OFF"]
 
+        if check_env_flag("TRITON_EXT_ENABLED"):
+            cmake_args += ["-DTRITON_EXT_ENABLED=1"]
+        else:
+            cmake_args += ["-DTRITON_EXT_ENABLED=0"]
+
         if is_offline_build():
             # unit test builds fetch googletests from GitHub
             cmake_args += ["-DTRITON_BUILD_UT=OFF"]

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -216,6 +216,11 @@ class CodeGenerator(ast.NodeVisitor):
             self.builder = ir.builder(context, compile_mode="simt")
         else:
             self.builder = ir.builder(context, compile_mode="simd")
+
+        # Allow plugins to plug in a custom op builder that extends the default triton builder.
+        op_builder_factory = getattr(options, "op_builder_factory", None)
+        if op_builder_factory is not None:
+            self.builder = op_builder_factory(context)
         self.file_name = file_name
         # node.lineno starts from 1, so we need to subtract 1
         self.begin_line = begin_line - 1

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -276,6 +276,12 @@ def compile(src, target=None, options=None, _env_vars=None):
     buffer_ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     backend.load_dialects(context)
+
+    # Allow plugins to register extra dialects into the MLIR context.
+    load_extra_dialects = getattr(options, "load_extra_dialects", None)
+    if load_extra_dialects is not None:
+        load_extra_dialects(context)
+
     codegen_fns = backend.get_codegen_implementation()
     module_map = backend.get_module_map()
     try:

--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -29,7 +29,7 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 from triton._C.libtriton import ir, passes, ascend
 from triton.backends.ascend.utils import (
@@ -175,6 +175,11 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
             auto_blockify_size = 1
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
+
+        # Allow plugins to install extra conversion passes before the Ascend ttir -> linalg lowering.
+        add_pre_ttadapter_passes = getattr(opt, "add_pre_ttadapter_passes", None)
+        if add_pre_ttadapter_passes is not None:
+            add_pre_ttadapter_passes(pm)
         ascend.passes.ttir.add_auto_blockify(
             pm,
             auto_blockify_size
@@ -990,6 +995,13 @@ class NPUOptions:
     # superblocking factor
     superblock_factor: int = 0
 
+    # Plugin hooks (invoked in CodeGenerator/compile()/ttir_to_linalg()) +
+    # a non-callable build key that hash() includes.
+    op_builder_factory: Optional[Callable] = None
+    load_extra_dialects: Optional[Callable] = None
+    add_pre_ttadapter_passes: Optional[Callable] = None
+    plugin_build_key: str = ""
+
     def __post_init__(self):
         # Parse compile_mode and set related fields
         if self.compile_mode == "simd":
@@ -1008,7 +1020,9 @@ class NPUOptions:
             object.__setattr__(self, "shared_mem_dynamic_size", 221184)
 
     def hash(self):
-        key = "_".join([f"{name}-{val}" for name, val in self.__dict__.items()])
+        # Skip callable values (hooks) so the cache key is stable across Python sessions.
+        key = "_".join([f"{name}-{val}" for name, val in self.__dict__.items()
+                        if not callable(val)])
         key = "_".join([key, get_cann_version_file_hash()])
         return hashlib.sha256(key.encode("utf-8")).hexdigest()
 


### PR DESCRIPTION
Please refer to https://github.com/triton-lang/triton-ascend/pull/1011 for plugin mechanism

Allow downstreamconsumers to plug into the Ascend compile/runtime path:

- code_generator.py: op_builder_factory hook to override the default builder
- compiler.py: load_extra_dialects hook to register extra MLIR dialects
- ascend/compiler.py: add_pre_ttadapter_passes hook before ttir->linalg; NPUOptions gains op_builder_factory / load_extra_dialects / add_pre_ttadapter_passes / launch_cooperative_grid fields
- ascend/compiler.py hash(): skip callable hooks so the cache key stays stable across Python sessions
- jit.py: exclude callable option values from specialization serialization

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
