### PR TITLE
[safe](fix)  Fix code redundancy and spelling errors

### DIFF
--- a/python/triton/extension/buffer/language/core.py
+++ b/python/triton/extension/buffer/language/core.py
@@ -276,7 +276,7 @@ def check_subview(src, offsets, sizes, strides):
     length = len(strides)
     src_strides = [1] * length
     if length == 1:
-        if offset[0] % base_byte != 0:
+        if offsets[0] % base_byte != 0:
             raise TypeError(f"all strides should be 1 and the offset value should be 32-bytes aligned.")
         return
     for i in range(length - 2, -1, -1):

--- a/third_party/ascend/include/TritonToLinalg/ArgMinMaxConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/ArgMinMaxConverter.h
@@ -176,11 +176,6 @@ public:
     } else {
       return failure();
     }
-    if (!indexSelectOp || indexSelectOp.getCondition() != shouldUpdate ||
-        currIndex != indexSelectOp.getTrueValue() ||
-        reduceIndex != indexSelectOp.getFalseValue()) {
-      return failure();
-    }
 
     LLVM_DEBUG(llvm::dbgs() << "Matching: " << *opsIt << "\n");
     auto termOp = dyn_cast<triton::ReduceReturnOp>(*opsIt++);


### PR DESCRIPTION
According to LibingAI's investigation, the issues of poor code quality and redundant checks have been modified.
https://lingxiaobing.huawei.com/review/feedback?requestId=70ae2789-c481-40d4-8288-bea1eb8cfc3c

Issue Description:
triton-ascend/python/triton/extension/buffer/language/core.py
The function parameter is named "offsets," but line 279 incorrectly uses the undefined variable "offset" (missing the trailing's'), which will cause a NameError exception and lead to program crash during runtime.

triton-ascend/third_party/ascend/include/TritonToLinalg/ArgMinMaxConverter.h
In the match function, the if-else block from lines 170 to 178 has already performed a validity check on indexSelectOp and returns failure() when there is no match. The code from lines 179 to 183 is identical to the logic in lines 170 to 178 and is unreachable dead code. Although this is not a direct security vulnerability, it indicates an error in the code logic, which may mask the actual matching logic issue. It is recommended to remove the redundant check in lines 179 to 183.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
