### PR TITLE
[libdevice](fix) Libdevice op support scalar and multi-dim tensor input

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -1,4 +1,4 @@
-# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+﻿# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -51,7 +51,6 @@ from triton.backends.ascend.utils import (
     _warn_auto_blockify_disabled,
     downgrade_llir,
     force_disable_ffts,
-    triton_enable_libdevice_simt,
     get_cann_version_file_hash,
 )
 from triton.backends.ascend.driver import (
@@ -1064,13 +1063,11 @@ def ttir_to_npubin(mod, metadata, opt):
             if opt.disable_fma:
                 _compile_option_list += [f"--disable-fma"]
 
-            enable_libdevice_simt = triton_enable_libdevice_simt()
-            if (enable_libdevice_simt):
-                bisheng_options = metadata["bisheng_options"]
-                if bisheng_options is not None:
-                    _compile_option_list += [
-                        f"--append-bisheng-options={bisheng_options}"
-                    ]
+            bisheng_options = metadata["bisheng_options"]
+            if bisheng_options is not None:
+                _compile_option_list += [
+                    f"--append-bisheng-options={bisheng_options}"
+                ]
 
             # Enable SIMT auto-blockify when TRITON_ALL_BLOCKS_PARALLEL is set,
             # mirroring the SIMD compile paths. driver.py's runtime block-count

--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -509,11 +509,6 @@ def triton_support_ffts():
     return is_ffts_supported(arch) and (not force_disable_ffts())
 
 
-def triton_enable_libdevice_simt():
-    enable_libdevice_simt = os.getenv("TRITON_ENABLE_LIBDEVICE_SIMT", False)
-    return enable_libdevice_simt and is_compile_on_910_95
-
-
 def get_cann_version_file_hash():
     ascend_path = _get_ascend_path()
     arch = get_machine_arch()

--- a/third_party/ascend/language/cann/__init__.py
+++ b/third_party/ascend/language/cann/__init__.py
@@ -19,14 +19,11 @@
 # THE SOFTWARE.
 
 from triton.language import math
-from triton.backends.ascend.utils import triton_enable_libdevice_simt
 
 from . import libdevice
 from . import extension
 
 extension.parallel = extension.aux_ops.parallel
-if not triton_enable_libdevice_simt():
-    libdevice.atan2 = extension.math_ops.atan2
 libdevice.isfinited = extension.math_ops.isfinited
 libdevice.finitef = extension.math_ops.finitef
 libdevice.flip = extension.flip

--- a/third_party/ascend/language/cann/libdevice.py
+++ b/third_party/ascend/language/cann/libdevice.py
@@ -1,4 +1,4 @@
-# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+﻿# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,11 +22,14 @@ from math import pi as math_pi
 from triton.language import core, math, semantic
 from triton._C.libtriton import ir
 from triton.runtime.jit import jit
-from triton.backends.ascend.utils import get_ascend_arch_from_env, triton_enable_libdevice_simt
+from triton.backends.ascend.utils import get_ascend_arch_from_env
+from triton.tools.get_ascend_devices import is_compile_on_910_95
 
 @core.extern
 def reciprocal(arg0, _builder=None):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
                 (core.dtype("fp32"),): ("__hmf_reciprocal_fp32", core.dtype("fp32")),
@@ -39,7 +42,9 @@ def reciprocal(arg0, _builder=None):
 
 @core.extern
 def log1p(arg0, _builder=None):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
                 (core.dtype("fp32"),): ("__hmf_log1p_fp32", core.dtype("fp32")),
@@ -50,10 +55,11 @@ def log1p(arg0, _builder=None):
             (core.dtype("fp16"),): ("__hmf_log1pDh", core.dtype("fp16")),
         }, is_pure=True, _builder=_builder)
 
-
 @core.extern
 def relu(arg0, _builder=None):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
                 (core.dtype("fp32"),): ("__hmf_relu_fp32", core.dtype("fp32")),
@@ -64,10 +70,11 @@ def relu(arg0, _builder=None):
             (core.dtype("fp16"),): ("__hmf_reluDh", core.dtype("fp16")),
         }, is_pure=True, _builder=_builder)
 
-
 @core.extern
 def isinf(arg0, _builder=None):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
                 (core.dtype("fp32"),): ("__hmf_isinf_fp32", core.dtype("int1")),
@@ -79,10 +86,11 @@ def isinf(arg0, _builder=None):
             (core.dtype("bf16"),): ("__hmf_isinf", core.dtype("int1")),
         }, is_pure=True, _builder=_builder)
 
-
 @core.extern
 def tan(arg0, _builder=None):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
                 (core.dtype("fp32"),): ("__hmf_tan_fp32", core.dtype("fp32")),
@@ -93,10 +101,11 @@ def tan(arg0, _builder=None):
             (core.dtype("fp16"),): ("__hmf_tanDh", core.dtype("fp16")),
         }, is_pure=True, _builder=_builder)
 
-
 @core.extern
 def atan(arg0, _builder=None):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
                 (core.dtype("fp32"),): ("__hmf_atan_fp32", core.dtype("fp32")),
@@ -109,7 +118,9 @@ def atan(arg0, _builder=None):
 
 @core.extern
 def tanh(arg0, _builder=None):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
                 (core.dtype("fp32"),): ("__hmf_tanh_fp32", core.dtype("fp32")),
@@ -122,7 +133,9 @@ def tanh(arg0, _builder=None):
 
 @core.extern
 def ilogb(arg0, _builder=None):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
                 (core.dtype("fp32"),): ("__hmf_ilogb_fp32", core.dtype("fp32")),
@@ -135,17 +148,21 @@ def ilogb(arg0, _builder=None):
 
 @core.extern
 def logb(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.logb for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_logb_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_logb_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.logb for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def ldexp(arg0, arg1, _builder=None):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0, arg1], {
                 (core.dtype("fp32"), core.dtype("int32")): ("__hmf_ldexp_fp32", core.dtype("fp32")),
@@ -158,17 +175,21 @@ def ldexp(arg0, arg1, _builder=None):
 
 @core.extern
 def scalbn(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.scalbn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("int32")): ("__hmf_scalbn_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("fp32"), core.dtype("int32")): ("__hmf_scalbn_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.scalbn for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def pow(arg0, arg1, _builder=None):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_pow_fp32", core.dtype("fp32")),
@@ -182,7 +203,9 @@ def pow(arg0, arg1, _builder=None):
 
 @core.extern
 def finitef(arg0, _builder=None):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
                 (core.dtype("fp32"),): ("__hmf_finite_fp32", core.dtype("int1")),
@@ -194,7 +217,9 @@ def finitef(arg0, _builder=None):
 
 @core.extern
 def isnan(arg0, _builder=None):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
                 (core.dtype("fp32"),): ("__hmf_isnan_fp32", core.dtype("int1")),
@@ -208,421 +233,504 @@ def isnan(arg0, _builder=None):
 
 @core.extern
 def clz(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.clz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("int32"),): ("__hmf_clz_i32", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("int32"),): ("__hmf_clz_i32", core.dtype("int32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.clz for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def popc(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.popc for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("int32"),): ("__hmf_popc_i32", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("int32"),): ("__hmf_popc_i32", core.dtype("int32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.popc for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def byte_perm(arg0, arg1, arg2, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.byte_perm for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1, arg2], {
-            (core.dtype("int32"), core.dtype("int32"), core.dtype("int32")): ("__hmf_byte_perm_i32", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1, arg2], {
+                (core.dtype("int32"), core.dtype("int32"), core.dtype("int32")): ("__hmf_byte_perm_i32", core.dtype("int32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.byte_perm for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def mulhi(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.mulhi for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("int32"), core.dtype("int32")): ("__hmf_mulhi_i32", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("int32"), core.dtype("int32")): ("__hmf_mulhi_i32", core.dtype("int32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.mulhi for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def mul24(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.mul24 for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("int32"), core.dtype("int32")): ("__hmf_mul24_i32", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("int32"), core.dtype("int32")): ("__hmf_mul24_i32", core.dtype("int32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.mul24 for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def brev(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.brev for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("int32"),): ("__hmf_brev_i32", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("int32"),): ("__hmf_brev_i32", core.dtype("int32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.brev for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def sad(arg0, arg1, arg2, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.sad for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1, arg2], {
-            (core.dtype("int32"), core.dtype("int32"), core.dtype("int32")): ("__hmf_sad_i32", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1, arg2], {
+                (core.dtype("int32"), core.dtype("int32"), core.dtype("int32")): ("__hmf_sad_i32", core.dtype("int32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.sad for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def ffs(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.ffs for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("int32"),): ("__hmf_ffs_i32", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("int32"),): ("__hmf_ffs_i32", core.dtype("int32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.ffs for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def saturatef(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.saturatef for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_saturate_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_saturate_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.saturatef for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def hadd(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.hadd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], { 
-            (core.dtype("int32"), core.dtype("int32")): ("__hmf_hadd_i32", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], { 
+                (core.dtype("int32"), core.dtype("int32")): ("__hmf_hadd_i32", core.dtype("int32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.hadd for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def rhadd(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.rhadd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], { 
-            (core.dtype("int32"), core.dtype("int32")): ("__hmf_rhadd_i32", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
-
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], { 
+                (core.dtype("int32"), core.dtype("int32")): ("__hmf_rhadd_i32", core.dtype("int32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.rhadd for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def fdim(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fdim for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], { 
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fdim_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], { 
+                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fdim_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.fdim for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def exp10(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.exp10 for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], { 
-            (core.dtype("fp32"),): ("__hmf_exp10_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], { 
+                (core.dtype("fp32"),): ("__hmf_exp10_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.exp10 for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 @core.extern
 def add_rn(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.add_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_add_rn_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_add_rn_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.add_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def add_rz(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.add_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_add_rz_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_add_rz_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.add_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def add_rd(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.add_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_add_rd_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_add_rd_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.add_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def add_ru(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.add_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_add_ru_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_add_ru_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.add_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def sub_rn(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.sub_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_sub_rn_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_sub_rn_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.sub_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def sub_rz(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.sub_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_sub_rz_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_sub_rz_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.sub_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def sub_rd(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.sub_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_sub_rd_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_sub_rd_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.sub_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def sub_ru(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.sub_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_sub_ru_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_sub_ru_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.sub_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def mul_rn(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.mul_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_mul_rn_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_mul_rn_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.mul_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def mul_rz(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.mul_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_mul_rz_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_mul_rz_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.mul_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def mul_ru(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.mul_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_mul_ru_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_mul_ru_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.mul_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def mul_rd(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.mul_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_mul_rd_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_mul_rd_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.mul_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def div_rd(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.div_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_div_rd_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_div_rd_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.div_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def div_ru(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.div_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_div_ru_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_div_ru_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.div_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def div_rz(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        arg0 = semantic.to_tensor(arg0, _builder)
-        arg1 = semantic.to_tensor(arg1, _builder)
-        ret = semantic.fdiv(arg0, arg1, False, _builder)
-        return ret
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_div_rz_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
-        
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_div_rz_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    arg1 = semantic.to_tensor(arg1, _builder)
+    ret = semantic.fdiv(arg0, arg1, False, _builder)
+    return ret
+
 @core.extern
 def rcp_rn(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.rcp_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_rcp_rn_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_rcp_rn_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.rcp_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def rcp_rz(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.rcp_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_rcp_rz_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_rcp_rz_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.rcp_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def rcp_rd(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.rcp_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_rcp_rd_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_rcp_rd_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.rcp_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def rcp_ru(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.rcp_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_rcp_ru_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_rcp_ru_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.rcp_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def sqrt_rn(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.sqrt_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_sqrt_rn_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_sqrt_rn_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.sqrt_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def sqrt_rz(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.sqrt_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_sqrt_rz_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_sqrt_rz_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.sqrt_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def sqrt_rd(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.sqrt_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_sqrt_rd_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_sqrt_rd_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.sqrt_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def sqrt_ru(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.sqrt_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_sqrt_ru_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_sqrt_ru_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.sqrt_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def rsqrt_rn(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.rsqrt_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_rsqrt_rn_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_rsqrt_rn_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.rsqrt_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def fma_rn(arg0, arg1, arg2, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fma_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1, arg2], {
-            (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fma_rn_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1, arg2], {
+                (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fma_rn_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.fma_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def fma_rz(arg0, arg1, arg2, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fma_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1, arg2], {
-            (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fma_rz_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1, arg2], {
+                (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fma_rz_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.fma_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def fma_rd(arg0, arg1, arg2, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fma_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1, arg2], {
-            (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fma_rd_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1, arg2], {
+                (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fma_rd_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.fma_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def fma_ru(arg0, arg1, arg2, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fma_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1, arg2], {
-            (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fma_ru_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1, arg2], {
+                (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fma_ru_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.fma_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.builtin
 def fast_dividef(arg0, arg1, _builder=None):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0, arg1], {
                 (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fast_divide_fp32", core.dtype("fp32")),
@@ -634,7 +742,9 @@ def fast_dividef(arg0, arg1, _builder=None):
 
 @core.builtin
 def fast_expf(arg0, _builder=None):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
                 (core.dtype("fp32"),): ("__hmf_fast_exp_fp32", core.dtype("fp32")),
@@ -645,486 +755,607 @@ def fast_expf(arg0, _builder=None):
 
 @core.builtin
 def fast_exp10f(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fast_exp10f for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_fast_exp10_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_fast_exp10_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.fast_exp10f for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.builtin
 def fast_sinf(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fast_sinf for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_fast_sin_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_fast_sin_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.fast_sinf for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.builtin
 def fast_cosf(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fast_cosf for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_fast_cos_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_fast_cos_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.fast_cosf for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.builtin
 def fast_tanf(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fast_tanf for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_fast_tan_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_fast_tan_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.fast_tanf for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.builtin
 def fast_log2f(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fast_log2f for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_fast_log2_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_fast_log2_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.fast_log2f for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.builtin
 def fast_logf(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fast_logf for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_fast_log_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_fast_log_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.fast_logf for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.builtin
 def fast_log10f(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fast_log10f for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_fast_log10_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_fast_log10_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.fast_log10f for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.builtin
 def fast_powf(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fast_powf for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fast_pow_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fast_pow_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.fast_powf for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def fmod(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        arg0 = semantic.to_tensor(arg0, _builder)
-        arg1 = semantic.to_tensor(arg1, _builder)
-        ret = semantic.mod(arg0, arg1, _builder)
-        return ret
-    return core.extern_elementwise(
-    "", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fmod_fp32", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+        "", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fmod_fp32", core.dtype("fp32")),
+        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    arg1 = semantic.to_tensor(arg1, _builder)
+    ret = semantic.mod(arg0, arg1, _builder)
+    return ret
 
 @core.extern
 def remainder(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.remainder for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-    "", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_remainder_fp32", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_remainder_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.remainder for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def float_as_int(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float_as_int for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_float_as_int_fp32", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_float_as_int_fp32", core.dtype("int32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.float_as_int for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def int_as_float(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.int_as_float for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("int32"),): ("__hmf_int_as_float_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("int32"),): ("__hmf_int_as_float_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.int_as_float for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def float_as_uint(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float_as_uint for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_float_as_uint_fp32", core.dtype("uint32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_float_as_uint_fp32", core.dtype("uint32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.float_as_uint for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def uint_as_float(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.uint_as_float for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("uint32"),): ("__hmf_uint_as_float_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("uint32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("uint32"),): ("__hmf_uint_as_float_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.uint_as_float for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def float2int_rn(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2int_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_float2int_rn_fp32", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_float2int_rn_fp32", core.dtype("int32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.float2int_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def float2int_rz(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2int_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_float2int_rz_fp32", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_float2int_rz_fp32", core.dtype("int32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.float2int_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def float2int_rd(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2int_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_float2int_rd_fp32", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_float2int_rd_fp32", core.dtype("int32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.float2int_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def float2int_ru(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2int_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_float2int_ru_fp32", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_float2int_ru_fp32", core.dtype("int32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.float2int_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def int2float_rn(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.int2float_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("int32"),): ("__hmf_int2float_rn_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("int32"),): ("__hmf_int2float_rn_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.int2float_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def int2float_rz(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.int2float_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("int32"),): ("__hmf_int2float_rz_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("int32"),): ("__hmf_int2float_rz_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.int2float_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def int2float_rd(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.int2float_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("int32"),): ("__hmf_int2float_rd_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("int32"),): ("__hmf_int2float_rd_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.int2float_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def int2float_ru(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.int2float_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("int32"),): ("__hmf_int2float_ru_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("int32"),): ("__hmf_int2float_ru_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.int2float_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def float2uint_rn(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2uint_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_float2uint_rn_fp32", core.dtype("uint32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_float2uint_rn_fp32", core.dtype("uint32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.float2uint_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def float2uint_rz(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2uint_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_float2uint_rz_fp32", core.dtype("uint32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_float2uint_rz_fp32", core.dtype("uint32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.float2uint_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def float2uint_rd(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2uint_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_float2uint_rd_fp32", core.dtype("uint32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_float2uint_rd_fp32", core.dtype("uint32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.float2uint_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def float2uint_ru(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2uint_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_float2uint_ru_fp32", core.dtype("uint32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_float2uint_ru_fp32", core.dtype("uint32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.float2uint_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def uint2float_rn(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.uint2float_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("uint32"),): ("__hmf_uint2float_rn_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("uint32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("uint32"),): ("__hmf_uint2float_rn_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.uint2float_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def uint2float_rz(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.uint2float_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("uint32"),): ("__hmf_uint2float_rz_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("uint32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("uint32"),): ("__hmf_uint2float_rz_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.uint2float_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def uint2float_rd(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.uint2float_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("uint32"),): ("__hmf_uint2float_rd_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("uint32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("uint32"),): ("__hmf_uint2float_rd_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.uint2float_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def uint2float_ru(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.uint2float_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("uint32"),): ("__hmf_uint2float_ru_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("uint32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("uint32"),): ("__hmf_uint2float_ru_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.uint2float_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def float2ll_rn(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2ll_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_float2ll_rn_fp32", core.dtype("int64")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_float2ll_rn_fp32", core.dtype("int64")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.float2ll_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def float2ll_rz(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2ll_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_float2ll_rz_fp32", core.dtype("int64")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_float2ll_rz_fp32", core.dtype("int64")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.float2ll_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def float2ll_rd(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2ll_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_float2ll_rd_fp32", core.dtype("int64")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_float2ll_rd_fp32", core.dtype("int64")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.float2ll_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def float2ll_ru(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2ll_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_float2ll_ru_fp32", core.dtype("int64")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_float2ll_ru_fp32", core.dtype("int64")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.float2ll_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def ll2float_rn(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.ll2float_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("int64"),): ("__hmf_ll2float_rn_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int64") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("int64"),): ("__hmf_ll2float_rn_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.ll2float_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def ll2float_rz(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.ll2float_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("int64"),): ("__hmf_ll2float_rz_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int64") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("int64"),): ("__hmf_ll2float_rz_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.ll2float_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def ll2float_rd(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.ll2float_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("int64"),): ("__hmf_ll2float_rd_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int64") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("int64"),): ("__hmf_ll2float_rd_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.ll2float_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def ll2float_ru(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.ll2float_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("int64"),): ("__hmf_ll2float_ru_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int64") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("int64"),): ("__hmf_ll2float_ru_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.ll2float_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def float2ull_rn(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2ull_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_float2ull_rn_fp32", core.dtype("uint64")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_float2ull_rn_fp32", core.dtype("uint64")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.float2ull_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def float2ull_rz(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2ull_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_float2ull_rz_fp32", core.dtype("uint64")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_float2ull_rz_fp32", core.dtype("uint64")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.float2ull_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def float2ull_rd(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2ull_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_float2ull_rd_fp32", core.dtype("uint64")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_float2ull_rd_fp32", core.dtype("uint64")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.float2ull_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def float2ull_ru(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2ull_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_float2ull_ru_fp32", core.dtype("uint64")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_float2ull_ru_fp32", core.dtype("uint64")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.float2ull_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def ull2float_rn(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.ull2float_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("uint64"),): ("__hmf_ull2float_rn_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("uint64") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("uint64"),): ("__hmf_ull2float_rn_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.ull2float_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def ull2float_rz(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.ull2float_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("uint64"),): ("__hmf_ull2float_rz_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("uint64") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("uint64"),): ("__hmf_ull2float_rz_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.ull2float_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def ull2float_rd(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.ull2float_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("uint64"),): ("__hmf_ull2float_rd_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("uint64") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("uint64"),): ("__hmf_ull2float_rd_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.ull2float_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def ull2float_ru(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.ull2float_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("uint64"),): ("__hmf_ull2float_ru_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("uint64") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("uint64"),): ("__hmf_ull2float_ru_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.ull2float_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
-def atan2(arg0, arg1, _builder):
-    if arg0.dtype == core.dtype("bf16") or arg1.dtype == core.dtype("bf16"):
-        core.static_print("extern livdevice.atan2 for dtype bf16 is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp16"), core.dtype("fp16")): ("__hmf_atan2_fp16", core.dtype("fp16")),
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_atan2_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+@math._add_math_2arg_docstr("atan2")
+def atan2(arg0, arg1, _builder=None):
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_atan2_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    else:
+        arg1 = semantic.to_tensor(arg1, _builder)
+        pi = 3.1415926536
+        _is_int8_type_x: core.constexpr = arg1.dtype.is_int8()
+        core.static_assert(not _is_int8_type_x, f"Expected dtype fp16/fp32/bf16, but got int8 or int1", _builder=_builder)
+        _is_int8_type_y: core.constexpr = arg0.dtype.is_int8()
+        core.static_assert(not _is_int8_type_y, f"Expected dtype fp16/fp32/bf16, but got int8 or int1", _builder=_builder)
+        _is_floating_type_x: core.constexpr = arg1.dtype.is_floating()
+        core.static_assert(_is_floating_type_x == True, f"Expected dtype fp16/fp32/bf16, but got {core.constexpr(arg1.dtype)}", _builder=_builder)
+        _is_floating_type_y: core.constexpr = arg0.dtype.is_floating()
+        core.static_assert(_is_floating_type_y == True, f"Expected dtype fp16/fp32/bf16, but got {core.constexpr(arg0.dtype)}", _builder=_builder)
+        half_pi: core.constexpr = 0.5 * pi
+        arg0_fp32 = arg0.to(core.dtype("fp32"), _builder=_builder)
+        arg1_fp32 = arg1.to(core.dtype("fp32"), _builder=_builder)
+        atan_input = semantic.truediv(arg0_fp32, arg1_fp32, _builder)
+        x_eq_zero = semantic.equal(arg1, 0, _builder)
+        y_gt_zero = semantic.greater_than(arg0, 0, _builder)
+        y_lt_zero = semantic.less_than(arg0, 0, _builder)
+        x_lt_zero = semantic.less_than(arg1, 0, _builder)
+        y_ge_zero = semantic.greater_equal(arg0, 0, _builder)
 
+        base = semantic.where(x_eq_zero, 0.0, atan(atan_input, _builder=_builder), _builder)
+        base = semantic.where(semantic.logical_and(x_eq_zero, y_gt_zero, _builder), half_pi, base, _builder)
+        base = semantic.where(semantic.logical_and(x_eq_zero, y_lt_zero, _builder), -half_pi, base, _builder)
+
+        add_pi = semantic.where(semantic.logical_and(x_lt_zero, y_ge_zero, _builder), pi, 0.0, _builder)
+        sub_pi = semantic.where(semantic.logical_and(x_lt_zero, y_lt_zero, _builder), -pi, 0.0, _builder)
+        ret = semantic.add(semantic.add(base, add_pi, True, _builder), sub_pi, True, _builder)
+        return ret.to(arg1.dtype, _builder=_builder)
 
 @core.builtin 
 @math._check_dtype(dtypes=["fp32"]) 
 @math._add_math_1arg_docstr("trunc")
 def trunc(arg0, _builder=None):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
-                (core.dtype("fp16"),): ("__hmf_trunc_fp16", core.dtype("fp16")),
                 (core.dtype("fp32"),): ("__hmf_trunc_fp32", core.dtype("fp32")),
             }, is_pure=True, _builder=_builder)
     else:
@@ -1143,7 +1374,9 @@ def trunc(arg0, _builder=None):
 
 @core.extern
 def round(arg0, _builder=None):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
                 (core.dtype("fp32"),): ("__hmf_round_fp32", core.dtype("fp32")),
@@ -1157,13 +1390,11 @@ def round(arg0, _builder=None):
 @math._check_dtype(dtypes=["bf16", "fp16", "fp32"])
 @math._add_math_1arg_docstr("acos")
 def acos(arg0: core.tensor, _builder: ir.builder):
-    if triton_enable_libdevice_simt():
-        if arg0.dtype == core.dtype("bf16"):
-            core.static_print("extern livdevice.acos for dtype bf16 is unspported for now.")
-            core.static_assert(False)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
-                (core.dtype("fp16"),): ("__hmf_acos_fp16", core.dtype("fp16")),
                 (core.dtype("fp32"),): ("__hmf_acos_fp32", core.dtype("fp32")),
             }, is_pure=True, _builder=_builder)
     else:
@@ -1217,13 +1448,11 @@ def acos(arg0: core.tensor, _builder: ir.builder):
 @math._check_dtype(dtypes=["bf16", "fp16", "fp32"])
 @math._add_math_1arg_docstr("sinh")
 def sinh(arg0: core.tensor, _builder: ir.builder):
-    if triton_enable_libdevice_simt():
-        if arg0.dtype == core.dtype("bf16"):
-            core.static_print("extern livdevice.sinh for dtype bf16 is unspported for now.")
-            core.static_assert(False)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
-                (core.dtype("fp16"),): ("__hmf_sinh_fp16", core.dtype("fp16")),
                 (core.dtype("fp32"),): ("__hmf_sinh_fp32", core.dtype("fp32")),
             }, is_pure=True, _builder=_builder)
     else:
@@ -1238,13 +1467,11 @@ def sinh(arg0: core.tensor, _builder: ir.builder):
 @math._check_dtype(dtypes=["bf16", "fp16", "fp32"])
 @math._add_math_1arg_docstr("cosh")
 def cosh(arg0: core.tensor, _builder: ir.builder):
-    if triton_enable_libdevice_simt():
-        if arg0.dtype == core.dtype("bf16"):
-            core.static_print("extern livdevice.cosh for dtype bf16 is unspported for now.")
-            core.static_assert(False)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
-                (core.dtype("fp16"),): ("__hmf_cosh_fp16", core.dtype("fp16")),
                 (core.dtype("fp32"),): ("__hmf_cosh_fp32", core.dtype("fp32")),
             }, is_pure=True, _builder=_builder)
     else:
@@ -1259,13 +1486,11 @@ def cosh(arg0: core.tensor, _builder: ir.builder):
 @math._check_dtype(dtypes=["bf16", "fp16", "fp32"])
 @math._add_math_1arg_docstr("acosh")
 def acosh(arg0: core.tensor, _builder: ir.builder):
-    if triton_enable_libdevice_simt():
-        if arg0.dtype == core.dtype("bf16"):
-            core.static_print("extern livdevice.acosh for dtype bf16 is unspported for now.")
-            core.static_assert(False)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
-                (core.dtype("fp16"), ): ("__hmf_acosh_fp16", core.dtype("fp16")),
                 (core.dtype("fp32"), ): ("__hmf_acosh_fp32", core.dtype("fp32")),
             }, is_pure=True, _builder=_builder)
     else:
@@ -1279,13 +1504,11 @@ def acosh(arg0: core.tensor, _builder: ir.builder):
 @math._check_dtype(dtypes=["bf16", "fp16", "fp32"])
 @math._add_math_1arg_docstr("asinh")
 def asinh(arg0: core.tensor, _builder: ir.builder):
-    if triton_enable_libdevice_simt():
-        if arg0.dtype == core.dtype("bf16"):
-            core.static_print("extern livdevice.asinh for dtype bf16 is unspported for now.")
-            core.static_assert(False)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
-                (core.dtype("fp16"), ): ("__hmf_asinh_fp16", core.dtype("fp16")),
                 (core.dtype("fp32"), ): ("__hmf_asinh_fp32", core.dtype("fp32")),
             }, is_pure=True, _builder=_builder)
     else:
@@ -1299,13 +1522,11 @@ def asinh(arg0: core.tensor, _builder: ir.builder):
 @math._check_dtype(dtypes=["bf16", "fp16", "fp32"])
 @math._add_math_1arg_docstr("atanh")
 def atanh(arg0: core.tensor, _builder: ir.builder):
-    if triton_enable_libdevice_simt():
-        if arg0.dtype == core.dtype("bf16"):
-            core.static_print("extern livdevice.atanh for dtype bf16 is unspported for now.")
-            core.static_assert(False)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
-                (core.dtype("fp16"), ): ("__hmf_atanh_fp16", core.dtype("fp16")),
                 (core.dtype("fp32"), ): ("__hmf_atanh_fp32", core.dtype("fp32")),
             }, is_pure=True, _builder=_builder)
     else:
@@ -1321,13 +1542,11 @@ def atanh(arg0: core.tensor, _builder: ir.builder):
 @math._check_dtype(dtypes=["bf16", "fp16", "fp32"])
 @math._add_math_1arg_docstr("expm1")
 def expm1(arg0: core.tensor, _builder: ir.builder):
-    if triton_enable_libdevice_simt():
-        if arg0.dtype == core.dtype("bf16"):
-            core.static_print("extern livdevice.expm1 for dtype bf16 is unspported for now.")
-            core.static_assert(False)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
-                (core.dtype("fp16"),): ("__hmf_expm1_fp16", core.dtype("fp16")),
                 (core.dtype("fp32"),): ("__hmf_expm1_fp32", core.dtype("fp32")),
             }, is_pure=True, _builder=_builder)
     else:
@@ -1339,10 +1558,11 @@ def expm1(arg0: core.tensor, _builder: ir.builder):
 @math._check_dtype(dtypes=["fp16", "fp32"])
 @math._add_math_2arg_docstr("nextafter")
 def nextafter(arg0: core.tensor, arg1: core.tensor, _builder: ir.builder):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0, arg1], {
-                (core.dtype("fp16"), core.dtype("fp16")): ("__hmf_nextafter_fp16", core.dtype("fp16")),
                 (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_nextafter_fp32", core.dtype("fp32")),
             }, is_pure=True, _builder=_builder)
     else:
@@ -1394,13 +1614,11 @@ def nextafter(arg0: core.tensor, arg1: core.tensor, _builder: ir.builder):
 @math._check_dtype(dtypes=["bf16", "fp16", "fp32"])
 @math._add_math_2arg_docstr("hypot(Euclidean Distance)")
 def hypot(arg0: core.tensor, arg1: core.tensor, _builder: ir.builder):
-    if triton_enable_libdevice_simt():
-        if arg0.dtype == core.dtype("bf16"):
-            core.static_print("extern livdevice.hypot for dtype bf16 is unspported for now.")
-            core.static_assert(False)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0, arg1], {
-                (core.dtype("fp16"), core.dtype("fp16")): ("__hmf_hypot_fp16", core.dtype("fp16")),
                 (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_hypot_fp32", core.dtype("fp32")),
             }, is_pure=True, _builder=_builder)
     else:
@@ -1413,133 +1631,159 @@ def hypot(arg0: core.tensor, arg1: core.tensor, _builder: ir.builder):
 
 @core.extern
 def cbrt(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.cbrt for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_cbrt_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_cbrt_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.cbrt for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def rcbrt(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.rcbrt for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_rcbrt_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_rcbrt_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.rcbrt for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def rhypot(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.rhypot for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_rhypot_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_rhypot_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.rhypot for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def norm3d(arg0, arg1, arg2, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.norm3d for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1, arg2], {
-            (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_norm3d_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1, arg2], {
+                (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_norm3d_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.norm3d for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def rnorm3d(arg0, arg1, arg2, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.rnorm3d for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1, arg2], {
-            (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_rnorm3d_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1, arg2], {
+                (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_rnorm3d_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.rnorm3d for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def norm4d(arg0, arg1, arg2, arg3, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.norm4d for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1, arg2, arg3], {
-            (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_norm4d_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1, arg2, arg3], {
+                (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_norm4d_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.norm4d for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def rnorm4d(arg0, arg1, arg2, arg3, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.rnorm4d for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1, arg2, arg3], {
-            (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_rnorm4d_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1, arg2, arg3], {
+                (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_rnorm4d_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.rnorm4d for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def j0(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.j0 for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_j0_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_j0_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.j0 for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def j1(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.j1 for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_j1_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_j1_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.j1 for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def jn(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.jn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("int32"), core.dtype("fp32")): ("__hmf_jn_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("int32"), core.dtype("fp32")): ("__hmf_jn_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.jn for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def y0(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.y0 for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_y0_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_y0_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.y0 for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def y1(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.y1 for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_y1_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_y1_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.y1 for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def yn(arg0, arg1, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.yn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("int32"), core.dtype("fp32")): ("__hmf_yn_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1], {
+                (core.dtype("int32"), core.dtype("fp32")): ("__hmf_yn_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.yn for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 # This function is derived from the Cephes Math Library release 2.8: June, 2000
 # https://netlib.org/cephes/
@@ -1549,10 +1793,9 @@ def yn(arg0, arg1, _builder=None):
 @math._check_dtype(dtypes=["fp16", "fp32"])
 @math._add_math_2arg_docstr("besseli0 (Modified Bessel function of the first kind, order 0).")
 def cyl_bessel_i0(arg0: core.tensor, _builder: ir.builder):
-    if triton_enable_libdevice_simt():
-        if arg0.dtype == core.dtype("fp16"):
-            core.static_print("extern livdevice.cyl_bessel_i0 for dtype bf16 is unspported for now.")
-            core.static_assert(False)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
                 (core.dtype("fp32"), ): ("__hmf_cyl_bessel_i0_fp32", core.dtype("fp32")),
@@ -1650,21 +1893,24 @@ def cyl_bessel_i0(arg0: core.tensor, _builder: ir.builder):
 
 @core.extern
 def cyl_bessel_i1(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.cyl_bessel_i1 for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_cyl_bessel_i1_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_cyl_bessel_i1_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.cyl_bessel_i1 for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 @math._check_dtype(dtypes=["fp16", "fp32"])
 def signbit(arg0, _builder=None):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
-                (core.dtype("fp16"),): ("__hmf_signbit_fp16", core.dtype("int32")),
                 (core.dtype("fp32"),): ("__hmf_signbit_fp32", core.dtype("int32")),
             }, is_pure=True, _builder=_builder)
     else:
@@ -1689,43 +1935,51 @@ def signbit(arg0, _builder=None):
 
 @core.extern
 def erf(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.erf for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_erf_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_erf_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.erf for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def erfc(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.erfc for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-    "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_erfc_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_erfc_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.erfc for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def erfcx(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.erfcx for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_erfcx_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_erfcx_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.erfcx for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def erfcinv(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.erfcxinv for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_erfcinv_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_erfcinv_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.erfcxinv for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 # Note:
 # For inputs x very close to ±1 (criterion: 1 - |x| < 1.1e-4), erfinv(x) → ±∞ and the
@@ -1736,7 +1990,9 @@ def erfcinv(arg0, _builder=None):
 @core.extern
 @math._check_dtype(dtypes=["fp32"])
 def erfinv(arg0, _builder=None):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
                 (core.dtype("fp32"), ): ("__hmf_erfinv_fp32", core.dtype("fp32")),
@@ -1868,23 +2124,27 @@ def erfinv(arg0, _builder=None):
 
 @core.extern
 def normcdf(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.normcdf for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-    "", "", [arg0], {
-        (core.dtype("fp32"),): ("__hmf_normcdf_fp32", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_normcdf_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.normcdf for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def normcdfinv(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.normcdfinv for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_normcdfinv_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_normcdfinv_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.normcdfinv for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 # Note:
 # The gamma function is implemented using the reflection formula for negative inputs:
@@ -1896,7 +2156,9 @@ def normcdfinv(arg0, _builder=None):
 @core.extern
 @math._check_dtype(dtypes=["fp32"])
 def gamma(arg0, _builder=None):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
                 (core.dtype("fp32"),): ("__hmf_tgamma_fp32", core.dtype("fp32")),
@@ -1969,13 +2231,15 @@ def gamma(arg0, _builder=None):
 
 @core.extern
 def tgamma(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.tgamma for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_tgamma_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_tgamma_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.tgamma for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 # Note:
 # The lgamma function computes the natural logarithm of the absolute value of the gamma function.
@@ -1988,7 +2252,9 @@ def tgamma(arg0, _builder=None):
 @core.extern
 @math._check_dtype(dtypes=["fp32"])
 def lgamma(arg0, _builder=None):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
                 (core.dtype("fp32"), ): ("__hmf_lgamma_fp32", core.dtype("fp32")),
@@ -2011,7 +2277,9 @@ def lgamma(arg0, _builder=None):
 @math._check_dtype(dtypes=["fp32",])
 @math._add_math_1arg_docstr("nearbyint")
 def nearbyint(arg0: core.tensor, _builder: ir.builder):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
                 (core.dtype("fp32"),): ("__hmf_nearbyint_fp32", core.dtype("fp32")),
@@ -2064,32 +2332,37 @@ def nearbyint(arg0: core.tensor, _builder: ir.builder):
 
 @core.extern
 def sinpi(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.sinpi for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_sinpi_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_sinpi_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.sinpi for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def cospi(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.cospi for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_cospi_fp32", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_cospi_fp32", core.dtype("fp32")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.cospi for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.builtin
 @math._check_dtype(dtypes=["fp32",])
 @math._add_math_1arg_docstr("arcsine")
 def asin(arg0: core.tensor, _builder: ir.builder):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
-                (core.dtype("fp16"),): ("__hmf_asin_fp16", core.dtype("fp16")),
                 (core.dtype("fp32"),): ("__hmf_asin_fp32", core.dtype("fp32")),
             }, is_pure=True, _builder=_builder)
     else:
@@ -2106,12 +2379,13 @@ def asin(arg0: core.tensor, _builder: ir.builder):
         acos_val = acos(arg0, _builder=_builder)
         return semantic.sub(half_pi, acos_val, True, _builder)
 
-
 @core.builtin
 @math._check_dtype(dtypes=["fp32",])
 @math._add_math_1arg_docstr("base-10 logarithm")
 def log10(arg0: core.tensor, _builder: ir.builder):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0], {
                 (core.dtype("fp32"),): ("__hmf_log10_fp32", core.dtype("fp32")),
@@ -2134,7 +2408,9 @@ def log10(arg0: core.tensor, _builder: ir.builder):
 @math._check_dtype(dtypes=["fp32",])
 @math._add_math_2arg_docstr("copysign")
 def copysign(arg0: core.tensor, arg1: core.tensor, _builder: ir.builder):
-    if triton_enable_libdevice_simt():
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise(
             "", "", [arg0, arg1], {
                 (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_copysign_fp32", core.dtype("fp32")),
@@ -2179,7 +2455,9 @@ else:
     @math._check_dtype(dtypes=["fp16", "fp32", "bf16"])
     @math._add_math_1arg_docstr("rint")
     def rint(arg0: core.tensor, _builder: ir.builder):
-        if triton_enable_libdevice_simt():
+        arg0 = semantic.to_tensor(arg0, _builder)
+        dtype = arg0.dtype
+        if (dtype == core.dtype("fp32") and is_compile_on_910_95):
             return core.extern_elementwise(
                 "", "", [arg0,], {
                     (core.dtype("fp32"),): ("__hmf_rint_fp32", core.dtype("fp32")),
@@ -2210,20 +2488,24 @@ else:
 
 @core.extern
 def llrint(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.llrint for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_llrint_fp32", core.dtype("int64")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_llrint_fp32", core.dtype("int64")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.llrint for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 @core.extern
 def llround(arg0, _builder=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.llround for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"),): ("__hmf_llround_fp32", core.dtype("int64")),
-        }, is_pure=True, _builder=_builder)
+    arg0 = semantic.to_tensor(arg0, _builder)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"),): ("__hmf_llround_fp32", core.dtype("int64")),
+            }, is_pure=True, _builder=_builder)
+    core.static_print(f"libdevice.llround for {dtype} is unspported for now.")
+    core.static_assert(False)

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -37,6 +37,7 @@
 #include <algorithm>
 #include <utility>
 #include <cstdlib>
+#include <optional>
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
@@ -1579,65 +1580,8 @@ LogicalResult ExternElementwiseClOpConverter::matchAndRewrite(
     return failure();
   }
   if (op.getSymbol().contains("__hmf_")) {
-    // libdevice -> hivm.hir.custom
+    // libdevice -> hivm.hir.custom 
     bool is_libdevice = llvm::is_contained(libdeviceOps, op.getSymbol());
-    if (is_libdevice) {
-      SmallVector<Value> newOuts;
-      SmallVector<Type> originalOutputTypes;
-      for (auto newOut : op->getResults()) {
-        originalOutputTypes.push_back(newOut.getType());
-        auto tensorType = dyn_cast<RankedTensorType>(newOut.getType());
-        Type elemType = tensorType.getElementType();
-        if (elemType.isInteger(1)) {
-          elemType = rewriter.getI32Type();
-        }
-        auto src = rewriter.create<tensor::EmptyOp>(
-              op->getLoc(), tensorType.getShape(), elemType);
-        newOuts.push_back(src);
-      }
-      ValueRange inputs{op->getOperands()};
-      ValueRange outputs{newOuts};
-      ValueRange temp_buffers{};
-      TypeRange res_types{outputs};
-      std::string sym = llvm::join(llvm::split(op.getSymbol().str(), "__hmf_"), "");
-      auto customRes = rewriter.create<hivm::CustomOp>(op.getLoc(), res_types, sym, inputs, outputs, temp_buffers);
-      auto arg_attrs_array = mlir::ArrayAttr::get(customRes->getContext(), {});
-      auto pipeAttr = hivm::PipeAttr::get(customRes->getContext(), hivm::PIPE::PIPE_V);
-      auto tcoreTypeAttr = hivm::TCoreTypeAttr::get(customRes->getContext(), hivm::TCoreType::VECTOR);
-      auto vfModeAttr = hivm::VFModeAttr::get(customRes->getContext(), hivm::VFMode::SIMD);
-      customRes->setAttr("arg_attrs", arg_attrs_array);
-      customRes->setAttr("bitcode", mlir::StringAttr::get(customRes->getContext(), ""));
-      customRes->setAttr("hivm.pipe", pipeAttr);
-      customRes->setAttr("hivm.tcore_type", tcoreTypeAttr);
-      customRes->setAttr("hivm.vf_mode", vfModeAttr);
-      customRes->setAttr("symbol", mlir::StringAttr::get(customRes->getContext(), sym));
-      SmallVector<Value> finalResults;
-      for (auto [customResult, origType] : llvm::zip(customRes.getResults(), originalOutputTypes)) {
-        auto origTensorType = dyn_cast<RankedTensorType>(origType);
-        Type targetElemType = rewriter.getI8Type();
-        Type targetTensorType = RankedTensorType::get(
-          origTensorType.getShape(),
-          targetElemType
-        );
-
-        if (origTensorType.getElementType().isInteger(1)) {
-          auto i32ElemType = rewriter.getI32Type();
-          auto denseZeroAttr = DenseElementsAttr::get(
-              RankedTensorType::get(origTensorType.getShape(), i32ElemType), 0);
-          auto zeroTensor = rewriter.create<arith::ConstantOp>(
-              loc, denseZeroAttr);
-          auto cmp = rewriter.create<arith::CmpIOp>(
-            loc, arith::CmpIPredicate::ne, customResult, zeroTensor);
-
-          finalResults.push_back(cmp);
-        } else {
-          finalResults.push_back(customResult);
-        }
-      }
-      rewriter.replaceOp(op, finalResults);
-      return success();
-    }
-    // 1. get or create the declaration of external elementwise function
     Type dstTy = op.getResult().getType();
     bool isDstScalar = !isa<RankedTensorType>(dstTy);
     Type dstElemTy =
@@ -1654,6 +1598,208 @@ LogicalResult ExternElementwiseClOpConverter::matchAndRewrite(
       srcElemTys.push_back(
           cast<RankedTensorType>(src.getType()).getElementType());
     }
+    if (is_libdevice) {
+      SmallVector<Value> newOuts;
+      SmallVector<Type> originalOutputTypes;
+      SmallVector<bool> originalOutputIsScalar;
+      SmallVector<ReassociationIndices> outputReassociation;
+      SmallVector<SmallVector<int64_t>> originalShapes;
+      SmallVector<bool> needsCollapse;
+      SmallVector<std::optional<size_t>> inplaceOutputToInput;
+
+      // ========== Step 1: Preprocess all inputs uniformly, flatten everything to 1D + build mapping ==========
+      SmallVector<Value> collapsedInputs;
+      DenseMap<Value, Value> orig2CollapsedMap;
+      SmallVector<SmallVector<int64_t>> inputOriginalShapes;
+      SmallVector<bool> inputNeedsCollapse;
+      SmallVector<ReassociationIndices> inputReassociation;
+
+      for (Value operand : srcs) {
+        RankedTensorType tensorTy = cast<RankedTensorType>(operand.getType());
+        if (tensorTy.getRank() <= 1) {
+          // Already 1-dimensional, no need for flattening
+          collapsedInputs.push_back(operand);
+          orig2CollapsedMap[operand] = operand;
+          inputNeedsCollapse.push_back(false);
+          inputOriginalShapes.push_back({});
+          inputReassociation.emplace_back();
+          continue;
+        }
+
+        inputNeedsCollapse.push_back(true);
+        inputOriginalShapes.push_back(llvm::to_vector(tensorTy.getShape()));
+
+        int64_t totalSize = 1;
+        for (int64_t dim : tensorTy.getShape()) {
+          if (ShapedType::isDynamic(dim)) {
+            totalSize = ShapedType::kDynamic;
+            break;
+          }
+          totalSize *= dim;
+        }
+
+        ReassociationIndices indices;
+        for (int i = 0; i < tensorTy.getRank(); ++i)
+          indices.push_back(i);
+        inputReassociation.push_back(indices);
+
+        RankedTensorType collapse1DTy = RankedTensorType::get({totalSize}, tensorTy.getElementType());
+        Value collapsedVal = rewriter.create<tensor::CollapseShapeOp>(op.getLoc(), collapse1DTy, operand, indices);
+        collapsedInputs.push_back(collapsedVal);
+        orig2CollapsedMap[operand] = collapsedVal;
+      }
+
+      SmallVector<bool> usedInputForInplace(collapsedInputs.size(), false);
+
+      // ========== Step 2: Iterate over outputs, compute the 1D type for each output individually to match the buffer ==========
+      for (Value newOut : op->getResults()) {
+        originalOutputTypes.push_back(newOut.getType());
+        originalOutputIsScalar.push_back(!isa<RankedTensorType>(newOut.getType()));
+        RankedTensorType tensorType = dyn_cast<RankedTensorType>(newOut.getType());
+        if (!tensorType) {
+          tensorType = RankedTensorType::get({1}, newOut.getType());
+        }
+
+        Type elemType = tensorType.getElementType();
+        originalShapes.push_back(llvm::to_vector(tensorType.getShape()));
+        bool needCollapse = tensorType.getRank() != 1;
+        needsCollapse.push_back(needCollapse);
+
+        if (elemType.isInteger(1)) {
+          elemType = rewriter.getI32Type();
+        }
+
+        // Calculate the 1D type of the current output after flattening (the actual type used for buffer matching, replacing the original global dstTy)
+        int64_t outTotalSize = 1;
+        for (int64_t dim : tensorType.getShape()) {
+          if (ShapedType::isDynamic(dim)) {
+            outTotalSize = ShapedType::kDynamic;
+            break;
+          }
+          outTotalSize *= dim;
+        }
+        RankedTensorType target1DTy = RankedTensorType::get({outTotalSize}, elemType);
+
+        Value outputBuffer = nullptr;
+        std::optional<size_t> inplaceInputIdx;
+        // Reuse buffers with the same 1D type from the flattened inputs
+        for (auto [inputIdx, src] : llvm::enumerate(srcs)) {
+          if (usedInputForInplace[inputIdx]) continue;
+          Value collapseSrc = orig2CollapsedMap.lookup(src);
+          if (!collapseSrc) continue;
+          if (collapseSrc.getType() == target1DTy) {
+            outputBuffer = collapseSrc;
+            inplaceInputIdx = inputIdx;
+            usedInputForInplace[inputIdx] = true;
+            break;
+          }
+        }
+
+        // No reusable buffer found, create a new 1D Empty tensor
+        if (!outputBuffer) {
+          outputBuffer = rewriter.create<tensor::EmptyOp>(op.getLoc(), target1DTy.getShape(), elemType);
+        }
+
+        newOuts.push_back(outputBuffer);
+        inplaceOutputToInput.push_back(inplaceInputIdx);
+        if (needCollapse) {
+          ReassociationIndices indices;
+          for (int i = 0; i < tensorType.getRank(); ++i)
+            indices.push_back(i);
+          outputReassociation.push_back(indices);
+        } else {
+          outputReassociation.emplace_back();
+        }
+      }
+
+      // ========== CustomOp creation, shape restoration, i1 conversion and scalar result extraction ==========
+      ValueRange inputs{collapsedInputs};
+      ValueRange outputs{newOuts};
+      ValueRange temp_buffers{};
+      TypeRange res_types{outputs};
+
+      std::string sym = llvm::join(llvm::split(op.getSymbol().str(), "__hmf_"), "");
+      auto customRes = rewriter.create<hivm::CustomOp>(
+          op.getLoc(), res_types, sym, inputs, outputs, temp_buffers);
+      customRes.setInlineMode(hivm::InlineMode::AlwaysInline);
+
+      SmallVector<Attribute> argAttrs(
+          collapsedInputs.size(), DictionaryAttr::get(rewriter.getContext()));
+      bool hasInplaceMapping = false;
+      for (auto [outputIdx, inputIdx] : llvm::enumerate(inplaceOutputToInput)) {
+        if (!inputIdx.has_value())
+          continue;
+
+        NamedAttrList attrs;
+        attrs.append("inplace_outs",
+                     rewriter.getI32IntegerAttr(static_cast<int32_t>(outputIdx)));
+        argAttrs[*inputIdx] = attrs.getDictionary(rewriter.getContext());
+        hasInplaceMapping = true;
+      }
+      auto argAttrsArray =
+          mlir::ArrayAttr::get(customRes->getContext(), argAttrs);
+      auto pipeAttr = hivm::PipeAttr::get(customRes->getContext(), hivm::PIPE::PIPE_V);
+      auto tcoreTypeAttr = hivm::TCoreTypeAttr::get(customRes->getContext(), hivm::TCoreType::VECTOR);
+      auto vfModeAttr = hivm::VFModeAttr::get(customRes->getContext(), hivm::VFMode::SIMD);
+
+      customRes->setAttr("bitcode", mlir::StringAttr::get(customRes->getContext(), ""));
+      customRes->setAttr("hivm.pipe", pipeAttr);
+      customRes->setAttr("hivm.tcore_type", tcoreTypeAttr);
+      customRes->setAttr("hivm.vf_mode", vfModeAttr);
+      customRes->setAttr("symbol", mlir::StringAttr::get(customRes->getContext(), sym));
+      if (hasInplaceMapping)
+        customRes->setAttr("arg_attrs", argAttrsArray);
+
+      SmallVector<Value> finalResults;
+      for (size_t idx = 0; idx < customRes.getResults().size(); ++idx) {
+        auto customResultVal = customRes.getResults()[idx];
+        auto origTypeVal = originalOutputTypes[idx];
+        auto origTensorType = dyn_cast<RankedTensorType>(origTypeVal);
+        auto resultTensorType = dyn_cast<RankedTensorType>(customResultVal.getType());
+
+        Value expandedResult = customResultVal;
+        if (needsCollapse[idx]) {
+          auto expandedType = RankedTensorType::get(
+              originalShapes[idx], resultTensorType.getElementType());
+          expandedResult = rewriter.create<tensor::ExpandShapeOp>(
+              op->getLoc(), expandedType, customResultVal, outputReassociation[idx]);
+        }
+
+        bool isI1Result = origTypeVal.isInteger(1) ||
+                          (origTensorType &&
+                           origTensorType.getElementType().isInteger(1));
+        if (isI1Result) {
+          auto i32ElemType = rewriter.getI32Type();
+          auto expandedTensorType =
+              cast<RankedTensorType>(expandedResult.getType());
+          auto shape = llvm::to_vector(expandedTensorType.getShape());
+          auto denseZeroAttr = DenseElementsAttr::get(
+              RankedTensorType::get(shape, i32ElemType), 0);
+          auto zeroTensor = rewriter.create<arith::ConstantOp>(op->getLoc(), denseZeroAttr);
+          auto cmp = rewriter.create<arith::CmpIOp>(
+              op->getLoc(), arith::CmpIPredicate::ne, expandedResult, zeroTensor);
+          expandedResult = cmp;
+        }
+
+        if (originalOutputIsScalar[idx]) {
+          Value zero =
+              rewriter.create<arith::ConstantOp>(op->getLoc(),
+                                                 rewriter.getIndexAttr(0));
+          expandedResult =
+              rewriter.create<tensor::ExtractOp>(op->getLoc(), expandedResult,
+                                                 zero);
+        }
+        finalResults.push_back(expandedResult);
+      }
+
+      rewriter.replaceOp(op, finalResults);
+      return success();
+    } else {
+      if (op.getSymbol().contains("fp32") || op.getSymbol().contains("i32")) {
+        llvm::report_fatal_error("unsupported libdevice op symbol: " + op.getSymbol());
+      }
+    }
+    // 1. get or create the declaration of external elementwise function
     FunctionType elemFuncType =
         FunctionType::get(rewriter.getContext(), srcElemTys, {dstElemTy});
     auto mod = SymbolTable::getNearestSymbolTable(op);

--- a/third_party/ascend/unittest/costmodel_ut/test_compiler_costmodel_contract.py
+++ b/third_party/ascend/unittest/costmodel_ut/test_compiler_costmodel_contract.py
@@ -45,7 +45,6 @@ class CompilerCostmodelContractTest(unittest.TestCase):
             "_warn_auto_blockify_disabled",
             "downgrade_llir",
             "force_disable_ffts",
-            "triton_enable_libdevice_simt",
             "get_cann_version_file_hash",
         ]:
             setattr(utils_mod, name, lambda *args, **kwargs: False)


### PR DESCRIPTION
## Initiative
1. External Libdevice library operators cannot support scalar input.
2. External Libdevice library operators cannot support multi-dimensional tensor input.
3. External Libdevice library operators cannot support memory reuse for input and output, which causes by CustomOp.

## Solution
1. For scalar input/output, convert it to a 1-dimensional tensor for computation, then extract the scalar data.
2. For multi-dimensional tensor inputs, flatten them into a 1-dimensional tensor for computation, then reshape the result to the original shape.
3. For inputs and output with the same dtype, add the ”arg_attrs“ attribute to CustomOp to indicate that the input memory is used to store the computation result.
4. Switch the commit of the submodule "AscendNPU-IR" to 97f7c320, which ensures that the external Libdevice library operators are correctly inlined during compilation.