### PR TITLE
[ControlFlowOpt](fix) enhance CFO generalization ability

### DIFF
--- a/third_party/ascend/lib/TritonControlFlowOpt/TritonControlFlowOptPass.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/TritonControlFlowOptPass.cpp
@@ -842,6 +842,7 @@ struct TensorPtrInfo {
   Type resultType;
   Value base;
   Value offset;
+  Value scalarOffset;
   bool scalarBase = false;
 };
 
@@ -931,6 +932,21 @@ static Value createZeroOffset(OpBuilder &builder, Location loc, Type ptrType) {
     return createZeroLike(builder, loc,
                           RankedTensorType::get(tensorType.getShape(), i32));
   return createZeroLike(builder, loc, i32);
+}
+
+static bool isScalarIntegerLike(Type type) {
+  return type.isIndex() || isa<IntegerType>(type);
+}
+
+static Type getTensorElementType(Type type) {
+  if (auto tensorType = dyn_cast<RankedTensorType>(type))
+    return tensorType.getElementType();
+  return type;
+}
+
+static Value createZeroScalarOffset(OpBuilder &builder, Location loc,
+                                    Type offsetType) {
+  return createZeroLike(builder, loc, getTensorElementType(offsetType));
 }
 
 static Value castIntegerLike(OpBuilder &builder, Location loc, Value value,
@@ -1038,6 +1054,75 @@ static Value createAddWithWiderType(OpBuilder &builder, Location loc, Value lhs,
   return builder.create<arith::AddIOp>(loc, lhs, rhs);
 }
 
+static FailureOr<Value>
+getUniformScalarOffset(Value offset, OpBuilder &builder, Location loc) {
+  Type offsetType = offset.getType();
+  if (isScalarIntegerLike(offsetType))
+    return offset;
+
+  auto tensorType = dyn_cast<RankedTensorType>(offsetType);
+  if (!tensorType || !isScalarIntegerLike(tensorType.getElementType()))
+    return failure();
+
+  if (auto splatOp = offset.getDefiningOp<triton::SplatOp>()) {
+    if (splatOp.getSrc().getType() == tensorType.getElementType())
+      return splatOp.getSrc();
+  }
+
+  Attribute constAttr;
+  if (!matchPattern(offset, m_Constant(&constAttr)))
+    return failure();
+
+  auto denseAttr = dyn_cast<DenseElementsAttr>(constAttr);
+  if (!denseAttr || !denseAttr.isSplat())
+    return failure();
+
+  if (auto intAttr =
+          dyn_cast<IntegerAttr>(denseAttr.getSplatValue<Attribute>())) {
+    return builder
+        .create<arith::ConstantIntOp>(
+            loc, intAttr.getValue().getSExtValue(),
+            cast<IntegerType>(tensorType.getElementType()))
+        .getResult();
+  }
+
+  return failure();
+}
+
+static bool hasStructuredScalarOffset(const TensorPtrInfo &parts) {
+  return parts.scalarBase && parts.scalarOffset &&
+         isa<RankedTensorType>(parts.offset.getType());
+}
+
+static bool areEquivalentValues(Value lhs, Value rhs) {
+  if (lhs == rhs)
+    return true;
+
+  Attribute lhsAttr;
+  Attribute rhsAttr;
+  if (!matchPattern(lhs, m_Constant(&lhsAttr)) ||
+      !matchPattern(rhs, m_Constant(&rhsAttr)))
+    return false;
+  return lhsAttr == rhsAttr;
+}
+
+static Value materializeTensorOffset(OpBuilder &builder, Location loc,
+                                     const TensorPtrInfo &parts) {
+  if (!hasStructuredScalarOffset(parts))
+    return parts.offset;
+
+  auto offsetType = cast<RankedTensorType>(parts.offset.getType());
+  Value scalarOffset =
+      castIntegerLike(builder, loc, parts.scalarOffset,
+                      offsetType.getElementType());
+  if (!scalarOffset)
+    return nullptr;
+
+  Value splatOffset =
+      builder.create<triton::SplatOp>(loc, offsetType, scalarOffset);
+  return createAdd(builder, loc, parts.offset, splatOffset);
+}
+
 static Value createMul(OpBuilder &builder, Location loc, Value lhs,
                        Value rhs) {
   if (!lhs || !rhs)
@@ -1078,6 +1163,28 @@ analyzeTensorPtr(Value value, const RewriteEnv &env, OpBuilder &builder,
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPoint(addPtrOp);
     Value offset = addPtrOp.getOffset();
+    if (hasStructuredScalarOffset(tensor)) {
+      FailureOr<Value> scalarDelta =
+          getUniformScalarOffset(offset, builder, addPtrOp.getLoc());
+      if (succeeded(scalarDelta)) {
+        Value newScalarOffset = createAddWithWiderType(
+            builder, addPtrOp.getLoc(), tensor.scalarOffset, *scalarDelta);
+        if (!newScalarOffset)
+          return failure();
+        tensor.scalarOffset = newScalarOffset;
+        tensor.resultType = value.getType();
+        return tensor;
+      }
+
+      Value newLaneOffset = createAddWithWiderType(
+          builder, addPtrOp.getLoc(), tensor.offset, offset);
+      if (!newLaneOffset)
+        return failure();
+      tensor.offset = newLaneOffset;
+      tensor.resultType = value.getType();
+      return tensor;
+    }
+
     Value newOffset = createAddWithWiderType(builder, addPtrOp.getLoc(),
                                              tensor.offset, offset);
     if (!newOffset)
@@ -1098,6 +1205,10 @@ analyzeTensorPtr(Value value, const RewriteEnv &env, OpBuilder &builder,
     builder.setInsertionPoint(splatOp);
     parts.offset = createZeroOffset(builder, splatOp.getLoc(), value.getType());
     if (!parts.offset)
+      return failure();
+    parts.scalarOffset = createZeroScalarOffset(builder, splatOp.getLoc(),
+                                                parts.offset.getType());
+    if (!parts.scalarOffset)
       return failure();
     return parts;
   }
@@ -1202,8 +1313,14 @@ static Value rebuildTensorPtr(OpBuilder &builder, Location loc,
   Value ptrBase = base;
   if (parts.scalarBase && isTensorPointerType(parts.resultType))
     ptrBase = builder.create<triton::SplatOp>(loc, parts.resultType, base);
+  TensorPtrInfo materializedParts = parts;
+  materializedParts.offset = offset;
+  Value materializedOffset =
+      materializeTensorOffset(builder, loc, materializedParts);
+  if (!materializedOffset)
+    return nullptr;
   return builder.create<triton::AddPtrOp>(loc, parts.resultType, ptrBase,
-                                          offset);
+                                          materializedOffset);
 }
 
 static Value rebuildBlockPtr(OpBuilder &builder, Location loc,
@@ -1228,12 +1345,16 @@ static Value rebuildPtr(OpBuilder &builder, Location loc,
 static void recordPointer(Value oldPtr, const CFPtrInfo &info, Value rebuiltPtr,
                           RewriteEnv &env) {
   env.pointerComponents[oldPtr] = info;
+  env.pointerComponents[rebuiltPtr] = info;
   env.valueMapping.map(oldPtr, rebuiltPtr);
 }
 
 static SmallVector<Value> getLoopComponentValues(const CFPtrInfo &info) {
-  if (info.kind == PtrKind::Tensor)
+  if (info.kind == PtrKind::Tensor) {
+    if (hasStructuredScalarOffset(info.tensor))
+      return {info.tensor.scalarOffset};
     return {info.tensor.offset};
+  }
   return info.block.offsets;
 }
 
@@ -1249,6 +1370,10 @@ static CFPtrInfo withLoopComponentValues(CFPtrInfo info,
   if (info.kind == PtrKind::Tensor) {
     if (values.size() != 1)
       return info;
+    if (hasStructuredScalarOffset(info.tensor)) {
+      info.tensor.scalarOffset = values[0];
+      return info;
+    }
     info.tensor.offset = values[0];
     return info;
   }
@@ -1262,12 +1387,20 @@ static bool areLoopCompatible(const CFPtrInfo &initInfo,
                               const CFPtrInfo &nextInfo) {
   if (initInfo.kind != nextInfo.kind)
     return false;
-  if (initInfo.kind == PtrKind::Tensor)
-    return initInfo.tensor.resultType == nextInfo.tensor.resultType &&
-           initInfo.tensor.base == nextInfo.tensor.base &&
-           initInfo.tensor.scalarBase == nextInfo.tensor.scalarBase &&
-           haveSameTypes(getLoopComponentValues(initInfo),
+  if (initInfo.kind == PtrKind::Tensor) {
+    if (initInfo.tensor.resultType != nextInfo.tensor.resultType ||
+        initInfo.tensor.base != nextInfo.tensor.base ||
+        initInfo.tensor.scalarBase != nextInfo.tensor.scalarBase)
+      return false;
+    if (hasStructuredScalarOffset(initInfo.tensor) !=
+        hasStructuredScalarOffset(nextInfo.tensor))
+      return false;
+    if (hasStructuredScalarOffset(initInfo.tensor) &&
+        !areEquivalentValues(initInfo.tensor.offset, nextInfo.tensor.offset))
+      return false;
+    return haveSameTypes(getLoopComponentValues(initInfo),
                          getLoopComponentValues(nextInfo));
+  }
 
   return initInfo.block.resultType == nextInfo.block.resultType &&
          initInfo.block.base == nextInfo.block.base &&
@@ -1277,10 +1410,6 @@ static bool areLoopCompatible(const CFPtrInfo &initInfo,
          initInfo.block.offsets.size() == nextInfo.block.offsets.size() &&
          haveSameTypes(getLoopComponentValues(initInfo),
                        getLoopComponentValues(nextInfo));
-}
-
-static bool isScalarIntegerLike(Type type) {
-  return type.isIndex() || isa<IntegerType>(type);
 }
 
 static bool isConstantIndex(Value value, int64_t expected) {
@@ -1761,6 +1890,22 @@ addIfTensorComponents(const TensorPtrInfo &thenParts,
                       SmallVectorImpl<IfComponent> &components) {
   if (thenParts.base != elseParts.base)
     return failure();
+
+  bool thenStructured = hasStructuredScalarOffset(thenParts);
+  bool elseStructured = hasStructuredScalarOffset(elseParts);
+  if (thenStructured != elseStructured)
+    return failure();
+
+  if (thenStructured) {
+    if (!areEquivalentValues(thenParts.offset, elseParts.offset) ||
+        thenParts.scalarOffset.getType() != elseParts.scalarOffset.getType())
+      return failure();
+    components.push_back(
+        {IfComponentKind::TensorOffset, 0,
+         thenParts.scalarOffset.getType()});
+    return success();
+  }
+
   if (thenParts.offset.getType() != elseParts.offset.getType())
     return failure();
   components.push_back(
@@ -1864,6 +2009,37 @@ analyzeNestedIfResultForPlanning(scf::IfOp ifOp, unsigned resultIndex,
 }
 
 static FailureOr<CFPtrInfo>
+analyzeNestedForResultForPlanning(scf::ForOp forOp, unsigned resultIndex,
+                                  const RewriteEnv &env, OpBuilder &builder,
+                                  Location loc) {
+  if (resultIndex >= forOp.getNumResults() ||
+      resultIndex >= forOp.getInitArgs().size() ||
+      resultIndex >= forOp.getRegionIterArgs().size())
+    return failure();
+
+  scf::YieldOp yieldOp =
+      dyn_cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+  if (!yieldOp || resultIndex >= yieldOp.getNumOperands())
+    return failure();
+
+  FailureOr<CFPtrInfo> initInfo = analyzePtrForIfPlanning(
+      forOp.getInitArgs()[resultIndex], env, builder, loc);
+  if (failed(initInfo))
+    return failure();
+
+  RewriteEnv bodyEnv = env;
+  bodyEnv.pointerComponents[forOp.getRegionIterArgs()[resultIndex]] =
+      *initInfo;
+
+  FailureOr<CFPtrInfo> nextInfo = analyzePtrForIfPlanning(
+      yieldOp.getOperand(resultIndex), bodyEnv, builder, yieldOp.getLoc());
+  if (failed(nextInfo) || !areLoopCompatible(*initInfo, *nextInfo))
+    return failure();
+
+  return *initInfo;
+}
+
+static FailureOr<CFPtrInfo>
 analyzePtrForIfPlanning(Value value, const RewriteEnv &env,
                         OpBuilder &builder, Location loc) {
   if (auto it = env.pointerComponents.find(value);
@@ -1878,6 +2054,12 @@ analyzePtrForIfPlanning(Value value, const RewriteEnv &env,
       if (succeeded(nestedInfo))
         return nestedInfo;
     }
+    if (auto nestedFor = dyn_cast<scf::ForOp>(result.getOwner())) {
+      FailureOr<CFPtrInfo> nestedInfo = analyzeNestedForResultForPlanning(
+          nestedFor, result.getResultNumber(), env, builder, loc);
+      if (succeeded(nestedInfo))
+        return nestedInfo;
+    }
   }
 
   return analyzePtr(value, env, builder, loc);
@@ -1886,8 +2068,12 @@ analyzePtrForIfPlanning(Value value, const RewriteEnv &env,
 static Value getComponentValue(const CFPtrInfo &info,
                                const IfComponent &component) {
   if (info.kind == PtrKind::Tensor) {
-    if (component.kind == IfComponentKind::TensorOffset)
+    if (component.kind == IfComponentKind::TensorOffset) {
+      if (hasStructuredScalarOffset(info.tensor) &&
+          info.tensor.scalarOffset.getType() == component.type)
+        return info.tensor.scalarOffset;
       return info.tensor.offset;
+    }
     return nullptr;
   }
 
@@ -1921,7 +2107,11 @@ makeIfResultInfo(const IfPointerInfo &info, ArrayRef<Value> componentValues) {
       Value value = componentValues[componentIndex++];
       switch (component.kind) {
       case IfComponentKind::TensorOffset:
-        resultInfo.tensor.offset = value;
+        if (hasStructuredScalarOffset(resultInfo.tensor) &&
+            resultInfo.tensor.scalarOffset.getType() == value.getType())
+          resultInfo.tensor.scalarOffset = value;
+        else
+          resultInfo.tensor.offset = value;
         break;
       default:
         return failure();
@@ -2134,6 +2324,21 @@ static LogicalResult tryDecoupleControlFlowOp(Operation *op,
   return success();
 }
 
+static bool decoupleControlFlowTree(Operation *op, IRRewriter &rewriter) {
+  if (isa<scf::ForOp, scf::WhileOp, scf::IfOp>(op) &&
+      succeeded(tryDecoupleControlFlowOp(op, rewriter)))
+    return true;
+
+  bool changed = false;
+  for (Region &region : op->getRegions()) {
+    for (Block &block : region) {
+      for (Operation &nestedOp : llvm::make_early_inc_range(block))
+        changed |= decoupleControlFlowTree(&nestedOp, rewriter);
+    }
+  }
+  return changed;
+}
+
 } // namespace
 
 namespace mlir::triton {
@@ -2174,24 +2379,12 @@ void TritonControlFlowOptPass::runOnOperation() {
     }
   }
 
-  SmallVector<Operation *> targets;
-  moduleOp.walk<WalkOrder::PostOrder>([&](Operation *op) {
-    if (isa<scf::ForOp, scf::WhileOp, scf::IfOp>(op))
-      targets.push_back(op);
-  });
-
-  LLVM_DEBUG({
-    llvm::dbgs() << "TritonControlFlowOpt collected " << targets.size()
-                 << " structured control-flow targets for later decoupling\n";
-  });
-
   IRRewriter rewriter(moduleOp.getContext());
-  for (Operation *op : targets) {
-    if (op->getParentOp() == nullptr)
-      continue;
-
-    (void)tryDecoupleControlFlowOp(op, rewriter);
-  }
+  bool changed = decoupleControlFlowTree(moduleOp, rewriter);
+  LLVM_DEBUG({
+    llvm::dbgs() << "TritonControlFlowOpt decoupling changed module: "
+                 << changed << "\n";
+  });
 
   if (failed(verify(moduleOp)))
     signalPassFailure();

--- a/third_party/ascend/lib/TritonControlFlowOpt/TritonControlFlowOptPass.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/TritonControlFlowOptPass.cpp
@@ -1967,6 +1967,48 @@ addIfBlockComponents(const BlockPtrInfo &thenParts,
   return success();
 }
 
+static bool hasIfComponent(ArrayRef<IfComponent> components,
+                           IfComponentKind kind, unsigned dim = 0) {
+  return llvm::any_of(components, [&](const IfComponent &component) {
+    return component.kind == kind && component.dim == dim;
+  });
+}
+
+static void addIfComponentIfMissing(SmallVectorImpl<IfComponent> &components,
+                                    IfComponent component) {
+  if (!hasIfComponent(components, component.kind, component.dim))
+    components.push_back(component);
+}
+
+static LogicalResult
+addLoopCarriedIfComponents(const CFPtrInfo &info,
+                           SmallVectorImpl<IfComponent> &components) {
+  if (info.kind == PtrKind::Tensor) {
+    Type offsetType = hasStructuredScalarOffset(info.tensor)
+                          ? info.tensor.scalarOffset.getType()
+                          : info.tensor.offset.getType();
+    addIfComponentIfMissing(
+        components, {IfComponentKind::TensorOffset, 0, offsetType});
+    return success();
+  }
+
+  for (auto [idx, offset] : llvm::enumerate(info.block.offsets)) {
+    addIfComponentIfMissing(
+        components,
+        {IfComponentKind::BlockOffset, static_cast<unsigned>(idx),
+         offset.getType()});
+  }
+  return success();
+}
+
+// Nested loop results may look like their init pointer during planning, but
+// the real result is produced by the loop-carried components after rewriting.
+static bool isNestedForResult(Value value, const RewriteEnv &env) {
+  Value mapped = remapValue(value, env);
+  auto result = dyn_cast<OpResult>(mapped);
+  return result && isa<scf::ForOp>(result.getOwner());
+}
+
 static FailureOr<CFPtrInfo>
 analyzePtrForIfPlanning(Value value, const RewriteEnv &env,
                         OpBuilder &builder, Location loc);
@@ -2180,6 +2222,11 @@ static LogicalResult rewriteIfOp(scf::IfOp ifOp, OpBuilder &builder,
     } else {
       if (failed(addIfBlockComponents(info.thenInfo.block,
                                       info.elseInfo.block, info.components)))
+        continue;
+    }
+    if (isNestedForResult(thenYield.getOperand(idx), env) ||
+        isNestedForResult(elseYield.getOperand(idx), env)) {
+      if (failed(addLoopCarriedIfComponents(info.thenInfo, info.components)))
         continue;
     }
     pointerInfos.push_back(info);

--- a/third_party/ascend/lib/TritonControlFlowOpt/TritonControlFlowOptPass.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/TritonControlFlowOptPass.cpp
@@ -737,6 +737,40 @@ static LogicalResult validateSupportedCfg(Region &body) {
   return success();
 }
 
+static void collectReachableBlocks(Block *block,
+                                   SmallPtrSetImpl<Block *> &reachable) {
+  if (!reachable.insert(block).second)
+    return;
+
+  for (Block *successor : getCfgSuccessors(block)) {
+    if (successor->getParent() == block->getParent())
+      collectReachableBlocks(successor, reachable);
+  }
+}
+
+static void eraseUnreachableBlocks(Region &body) {
+  if (body.empty() || body.hasOneBlock())
+    return;
+
+  SmallPtrSet<Block *, 16> reachable;
+  collectReachableBlocks(&body.front(), reachable);
+
+  SmallVector<Block *> eraseBlocks;
+  for (Block &block : body) {
+    if (!reachable.contains(&block))
+      eraseBlocks.push_back(&block);
+  }
+  if (eraseBlocks.empty())
+    return;
+
+  for (Block *block : eraseBlocks) {
+    for (Operation &op : *block)
+      op.dropAllReferences();
+  }
+  for (Block *block : llvm::reverse(eraseBlocks))
+    block->erase();
+}
+
 static LogicalResult rejectCyclicCfg(Block *block,
                                      SmallPtrSetImpl<Block *> &visiting,
                                      SmallPtrSetImpl<Block *> &visited) {
@@ -759,6 +793,10 @@ static LogicalResult rejectCyclicCfg(Block *block,
 
 static LogicalResult structureFunctionBody(Operation *funcOp, Region &body) {
   if (body.empty() || body.hasOneBlock())
+    return success();
+
+  eraseUnreachableBlocks(body);
+  if (body.hasOneBlock())
     return success();
 
   if (failed(validateSupportedCfg(body)))

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -69,6 +69,7 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/Visitors.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -190,6 +191,85 @@ static bool isSIMTOp(Operation *op)
       triton::ascend::StrideStoreOp,
       triton::ascend::IndirectStoreOp
       >(op);
+}
+
+static bool isZeroSplat(DenseElementsAttr attr) {
+  if (!attr.isSplat())
+    return false;
+
+  if (auto intAttr = dyn_cast<IntegerAttr>(attr.getSplatValue<Attribute>()))
+    return intAttr.getValue().isZero();
+
+  if (auto floatAttr = dyn_cast<FloatAttr>(attr.getSplatValue<Attribute>()))
+    return floatAttr.getValue().isZero();
+
+  return false;
+}
+
+static FailureOr<DenseElementsAttr> getZeroTensorReturn(triton::FuncOp func) {
+  if (!func.isPrivate() || func.getNumArguments() != 0 ||
+      func.getFunctionType().getNumResults() != 1 ||
+      !isa<RankedTensorType>(func.getFunctionType().getResult(0)) ||
+      !func.getBody().hasOneBlock())
+    return failure();
+
+  Block &body = func.getBody().front();
+  auto returnOp = dyn_cast<triton::ReturnOp>(body.getTerminator());
+  if (!returnOp || returnOp->getNumOperands() != 1)
+    return failure();
+
+  Value returnValue = returnOp->getOperand(0);
+  auto constOp = returnValue.getDefiningOp<arith::ConstantOp>();
+  if (!constOp)
+    return failure();
+
+  auto denseAttr = dyn_cast<DenseElementsAttr>(constOp.getValue());
+  if (!denseAttr || !isZeroSplat(denseAttr))
+    return failure();
+
+  return denseAttr;
+}
+
+static LogicalResult inlineZeroTensorHelpers(ModuleOp moduleOp) {
+  DenseMap<StringAttr, DenseElementsAttr> zeroHelpers;
+  SmallVector<triton::FuncOp> eraseFuncs;
+  for (triton::FuncOp func : moduleOp.getOps<triton::FuncOp>()) {
+    FailureOr<DenseElementsAttr> zeroAttr = getZeroTensorReturn(func);
+    if (failed(zeroAttr))
+      continue;
+
+    zeroHelpers[func.getSymNameAttr()] = *zeroAttr;
+    eraseFuncs.push_back(func);
+  }
+
+  if (zeroHelpers.empty())
+    return success();
+
+  SmallVector<triton::CallOp> eraseCalls;
+  moduleOp.walk([&](triton::CallOp callOp) {
+    auto it = zeroHelpers.find(callOp.getCalleeAttr().getRootReference());
+    if (it == zeroHelpers.end())
+      return;
+
+    if (callOp->getNumOperands() != 0 || callOp->getNumResults() != 1)
+      return;
+
+    OpBuilder builder(callOp);
+    Value replacement =
+        builder.create<arith::ConstantOp>(callOp.getLoc(), it->second);
+    callOp.getResult(0).replaceAllUsesWith(replacement);
+    eraseCalls.push_back(callOp);
+  });
+
+  for (triton::CallOp callOp : eraseCalls)
+    callOp.erase();
+
+  for (triton::FuncOp func : eraseFuncs) {
+    if (SymbolTable::symbolKnownUseEmpty(func, moduleOp))
+      func.erase();
+  }
+
+  return success();
 }
 
 TritonTypeConverter::TritonTypeConverter() {
@@ -982,6 +1062,12 @@ void TritonToLinalgPass::runOnOperation() {
       signalPassFailure();
       return;
     }
+  }
+
+  if (failed(inlineZeroTensorHelpers(moduleOp))) {
+    moduleOp->emitError("failed to inline zero tensor helper functions");
+    signalPassFailure();
+    return;
   }
 
   // 2. Perform use analysis on FuncOp.

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/cf_terminal_return.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/cf_terminal_return.mlir
@@ -80,6 +80,22 @@ module {
 // -----
 
 module {
+  tt.func private @entry_return_with_unreachable_block() -> tensor<32xf32> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<32xf32>
+    tt.return %cst : tensor<32xf32>
+  ^bb1:
+    %poison = ub.poison : tensor<32xf32>
+    tt.return %poison : tensor<32xf32>
+  }
+}
+
+// CHECK-LABEL: tt.func private @entry_return_with_unreachable_block
+// CHECK:       tt.return
+// CHECK-NOT:   ^bb1
+
+// -----
+
+module {
   tt.func public @terminal_return_branch_args(%cond: i1, %lhs: i32, %rhs: i32, %bias: i32) -> i32 {
     cf.cond_br %cond, ^bb1(%lhs : i32), ^bb2(%rhs : i32)
   ^bb1(%v1: i32):

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scf_pointer_decouple.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scf_pointer_decouple.mlir
@@ -142,13 +142,14 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @if_tensor_ptr_same_base_offsets
-// CHECK:       %[[OFF:.*]] = scf.if %{{.*}} -> (tensor<4xi32>) {
-// CHECK:         scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:       %[[OFF:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:         scf.yield %{{.*}} : i32
 // CHECK:       } else {
-// CHECK:         scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:         scf.yield %{{.*}} : i32
 // CHECK:       }
 // CHECK:       tt.splat %{{.*}} : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
-// CHECK:       tt.addptr %{{.*}}, %[[OFF]] : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+// CHECK:       %[[OFF_SPLAT:.*]] = tt.splat %[[OFF]] : i32 -> tensor<4xi32>
+// CHECK:       tt.addptr %{{.*}}, %{{.*}} : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
 
 // -----
 
@@ -202,12 +203,15 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @while_tensor_ptr_addptr_step
+// CHECK-DAG:   %[[C4:.*]] = arith.constant 4 : i32
 // CHECK:       scf.while
-// CHECK-SAME:  tensor<4xi32>
+// CHECK-SAME:  (i32, i32) -> (i32, i32)
 // CHECK:       } do {
-// CHECK:         %[[STEP:.*]] = tt.splat %{{.*}} : i32 -> tensor<4xi32>
-// CHECK:         %[[NEXT_OFF:.*]] = arith.addi %{{.*}}, %[[STEP]] : tensor<4xi32>
-// CHECK:         scf.yield %{{.*}}, %[[NEXT_OFF]] : i32, tensor<4xi32>
+// CHECK:         %[[STEP:.*]] = tt.splat %[[C4]] : i32 -> tensor<4xi32>
+// CHECK-NEXT:    %[[NEXT_OFF:.*]] = arith.addi %{{.*}}, %{{.*}} : i32
+// CHECK:         scf.yield %{{.*}}, %[[NEXT_OFF]] : i32, i32
+// CHECK:       }
+// CHECK:       tt.splat %{{.*}} : i32 -> tensor<4xi32>
 
 // -----
 
@@ -232,12 +236,13 @@ module {
 // CHECK-LABEL: tt.func public @for_tensor_ptr_preserves_wide_loop_offset
 // CHECK:       %[[STEP32:.*]] = tt.splat %{{.*}} : i32 -> tensor<4xi32>
 // CHECK:       %[[FOR:.*]] = scf.for
-// CHECK-SAME:  -> (tensor<4xi64>) {
-// CHECK:         %[[STEP64:.*]] = arith.extsi %[[STEP32]] : tensor<4xi32> to tensor<4xi64>
-// CHECK:         %[[NEXT:.*]] = arith.addi %{{.*}}, %[[STEP64]] : tensor<4xi64>
-// CHECK:         scf.yield %[[NEXT]] : tensor<4xi64>
+// CHECK-SAME:  -> (i64) {
+// CHECK:         %[[STEP64:.*]] = arith.extsi %{{.*}} : i32 to i64
+// CHECK:         %[[NEXT:.*]] = arith.addi %{{.*}}, %[[STEP64]] : i64
+// CHECK:         scf.yield %[[NEXT]] : i64
 // CHECK:       }
-// CHECK:       tt.addptr %{{.*}}, %[[FOR]] : tensor<4x!tt.ptr<f32>>, tensor<4xi64>
+// CHECK:       %[[FOR32:.*]] = arith.trunci %[[FOR]] : i64 to i32
+// CHECK:       tt.splat %[[FOR32]] : i32 -> tensor<4xi32>
 
 // -----
 
@@ -360,20 +365,19 @@ module {
 // CHECK-LABEL: tt.func public @for_if_tensor_ptr_same_base_post_addptr
 // CHECK-DAG:   %[[C2:.*]] = arith.constant 2 : i32
 // CHECK-DAG:   %[[POST_STEP:.*]] = tt.splat %[[C2]] : i32 -> tensor<4xi32>
-// CHECK:       %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[OFF:.*]] = %{{.*}}) -> (tensor<4xi32>) {
-// CHECK:         %[[CARRIED:.*]] = arith.addi %{{.*}}, %[[OFF]] : tensor<4xi32>
-// CHECK:         %[[SELECTED:.*]] = scf.if %{{.*}} -> (tensor<4xi32>) {
-// CHECK:           arith.addi %{{.*}}, %{{.*}} : tensor<4xi32>
-// CHECK:           scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:       %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[OFF:.*]] = %{{.*}}) -> (i32) {
+// CHECK:         %[[OFF_SPLAT:.*]] = tt.splat %[[OFF]] : i32 -> tensor<4xi32>
+// CHECK:         %[[SELECTED:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:           arith.addi %[[OFF]], %{{.*}} : i32
+// CHECK:           scf.yield %{{.*}} : i32
 // CHECK:         } else {
-// CHECK:           arith.addi %{{.*}}, %{{.*}} : tensor<4xi32>
-// CHECK:           scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:           arith.addi %[[OFF]], %{{.*}} : i32
+// CHECK:           scf.yield %{{.*}} : i32
 // CHECK:         }
-// CHECK:         %[[MERGED:.*]] = arith.addi %[[CARRIED]], %[[SELECTED]] : tensor<4xi32>
-// CHECK:         %[[NEXT:.*]] = arith.addi %{{.*}}, %[[POST_STEP]] : tensor<4xi32>
-// CHECK:         scf.yield %[[NEXT]] : tensor<4xi32>
+// CHECK:         %[[NEXT:.*]] = arith.addi %[[SELECTED]], %[[C2]] : i32
+// CHECK:         scf.yield %[[NEXT]] : i32
 // CHECK:       }
-// CHECK:       tt.addptr %{{.*}}, %[[FOR]] : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+// CHECK:       tt.splat %[[FOR]] : i32 -> tensor<4xi32>
 
 // -----
 
@@ -573,28 +577,26 @@ module {
 
 // CHECK-LABEL: tt.func public @for_nested_if_tensor_ptr_load_after_post_addptr
 // CHECK:       %[[FOR:.*]]:2 = scf.for
-// CHECK-SAME:  tensor<4xi32>
-// CHECK:         %[[SELECTED:.*]] = scf.if %{{.*}} -> (tensor<4xi32>) {
-// CHECK:           %[[THEN_INNER:.*]] = scf.if %{{.*}} -> (tensor<4xi32>) {
-// CHECK:             scf.yield %{{.*}} : tensor<4xi32>
+// CHECK-SAME:  (i32, tensor<4xf32>)
+// CHECK:         %[[SELECTED:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:           %[[THEN_INNER:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:             scf.yield %{{.*}} : i32
 // CHECK:           } else {
-// CHECK:             scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:             scf.yield %{{.*}} : i32
 // CHECK:           }
-// CHECK:           arith.addi %{{.*}}, %[[THEN_INNER]] : tensor<4xi32>
-// CHECK:           scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:           scf.yield %[[THEN_INNER]] : i32
 // CHECK:         } else {
-// CHECK:           %[[ELSE_INNER:.*]] = scf.if %{{.*}} -> (tensor<4xi32>) {
-// CHECK:             scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:           %[[ELSE_INNER:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:             scf.yield %{{.*}} : i32
 // CHECK:           } else {
-// CHECK:             scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:             scf.yield %{{.*}} : i32
 // CHECK:           }
-// CHECK:           arith.addi %{{.*}}, %[[ELSE_INNER]] : tensor<4xi32>
-// CHECK:           scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:           scf.yield %[[ELSE_INNER]] : i32
 // CHECK:         }
-// CHECK:         arith.addi %{{.*}}, %{{.*}} : tensor<4xi32>
+// CHECK:         arith.addi %[[SELECTED]], %{{.*}} : i32
 // CHECK:         tt.addptr %{{.*}}, %{{.*}} : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
 // CHECK:         %[[LOADED:.*]] = tt.load %{{.*}} : tensor<4x!tt.ptr<f32>>
-// CHECK:         scf.yield %{{.*}}, %[[LOADED]] : tensor<4xi32>, tensor<4xf32>
+// CHECK:         scf.yield %{{.*}}, %[[LOADED]] : i32, tensor<4xf32>
 // CHECK:       }
 // CHECK:       tt.return %[[FOR]]#1 : tensor<4xf32>
 
@@ -691,3 +693,59 @@ module {
 // CHECK:         scf.yield %[[INNER_PTR]] : !tt.ptr<tensor<16xf32>>
 // CHECK:       }
 // CHECK:       tt.return %[[OUTER]] : !tt.ptr<tensor<16xf32>>
+
+// -----
+
+module {
+  tt.func public @for_if_nested_for_tensor_ptr_store_scalar_offset(%base: !tt.ptr<f32>, %out: !tt.ptr<f32>, %cond: i1, %outer_ub: index, %inner_ub: index) -> tensor<4x!tt.ptr<f32>> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %range = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %step1 = tt.splat %c1_i32 : i32 -> tensor<4xi32>
+    %step2 = tt.splat %c2_i32 : i32 -> tensor<4xi32>
+    %base_splat = tt.splat %base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %ptr0 = tt.addptr %base_splat, %range : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    %src = tt.load %ptr0 : tensor<4x!tt.ptr<f32>>
+    %final = scf.for %iv = %c0 to %outer_ub step %c1 iter_args(%ptr = %ptr0) -> (tensor<4x!tt.ptr<f32>>) {
+      %selected = scf.if %cond -> (tensor<4x!tt.ptr<f32>>) {
+        %inner = scf.for %j = %c0 to %inner_ub step %c1 iter_args(%inner_ptr = %ptr) -> (tensor<4x!tt.ptr<f32>>) {
+          %next = tt.addptr %inner_ptr, %step1 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+          tt.store %next, %src : tensor<4x!tt.ptr<f32>>
+          scf.yield %next : tensor<4x!tt.ptr<f32>>
+        }
+        scf.yield %inner : tensor<4x!tt.ptr<f32>>
+      } else {
+        %inner = scf.for %j = %c0 to %inner_ub step %c1 iter_args(%inner_ptr = %ptr) -> (tensor<4x!tt.ptr<f32>>) {
+          %next = tt.addptr %inner_ptr, %step2 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+          tt.store %next, %src : tensor<4x!tt.ptr<f32>>
+          scf.yield %next : tensor<4x!tt.ptr<f32>>
+        }
+        scf.yield %inner : tensor<4x!tt.ptr<f32>>
+      }
+      scf.yield %selected : tensor<4x!tt.ptr<f32>>
+    }
+    tt.return %final : tensor<4x!tt.ptr<f32>>
+  }
+}
+
+// CHECK-LABEL: tt.func public @for_if_nested_for_tensor_ptr_store_scalar_offset
+// CHECK:       %[[OUTER:.*]] = scf.for {{.*}} iter_args(%[[OUTER_OFF:.*]] = %{{.*}}) -> (i32) {
+// CHECK:         %[[SELECTED:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:           %[[THEN_INNER:.*]] = scf.for {{.*}} iter_args(%[[THEN_OFF:.*]] = %[[OUTER_OFF]]) -> (i32) {
+// CHECK:             tt.store
+// CHECK:             scf.yield %{{.*}} : i32
+// CHECK:           }
+// CHECK:           scf.yield %[[THEN_INNER]] : i32
+// CHECK:         } else {
+// CHECK:           %[[ELSE_INNER:.*]] = scf.for {{.*}} iter_args(%[[ELSE_OFF:.*]] = %[[OUTER_OFF]]) -> (i32) {
+// CHECK:             tt.store
+// CHECK:             scf.yield %{{.*}} : i32
+// CHECK:           }
+// CHECK:           scf.yield %[[ELSE_INNER]] : i32
+// CHECK:         }
+// CHECK:         scf.yield %[[SELECTED]] : i32
+// CHECK:       }
+// CHECK:       tt.splat %[[OUTER]] : i32 -> tensor<4xi32>

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scf_pointer_decouple.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scf_pointer_decouple.mlir
@@ -749,3 +749,54 @@ module {
 // CHECK:         scf.yield %[[SELECTED]] : i32
 // CHECK:       }
 // CHECK:       tt.splat %[[OUTER]] : i32 -> tensor<4xi32>
+
+// -----
+
+module {
+  tt.func public @if_nested_for_block_ptr_store_then_load(%base: !tt.ptr<f16>, %cond: i1, %ub: index) -> tensor<32xf16> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c64_i64 = arith.constant 64 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %ptr0 = tt.make_tensor_ptr %base, [%c64_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : <tensor<32xf16>>
+    %src = tt.load %ptr0 : !tt.ptr<tensor<32xf16>>
+    %selected = scf.if %cond -> (!tt.ptr<tensor<32xf16>>) {
+      %inner = scf.for %iv = %c0 to %ub step %c1 iter_args(%ptr = %ptr0) -> (!tt.ptr<tensor<32xf16>>) {
+        %next = tt.advance %ptr, [%c1_i32] : <tensor<32xf16>>
+        tt.store %next, %src : !tt.ptr<tensor<32xf16>>
+        scf.yield %next : !tt.ptr<tensor<32xf16>>
+      }
+      scf.yield %inner : !tt.ptr<tensor<32xf16>>
+    } else {
+      %inner = scf.for %iv = %c0 to %ub step %c1 iter_args(%ptr = %ptr0) -> (!tt.ptr<tensor<32xf16>>) {
+        %next = tt.advance %ptr, [%c2_i32] : <tensor<32xf16>>
+        tt.store %next, %src : !tt.ptr<tensor<32xf16>>
+        scf.yield %next : !tt.ptr<tensor<32xf16>>
+      }
+      scf.yield %inner : !tt.ptr<tensor<32xf16>>
+    }
+    %out = tt.load %selected : !tt.ptr<tensor<32xf16>>
+    tt.return %out : tensor<32xf16>
+  }
+}
+
+// CHECK-LABEL: tt.func public @if_nested_for_block_ptr_store_then_load
+// CHECK:       %[[SELECTED:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:         %[[THEN_INNER:.*]] = scf.for {{.*}} iter_args(%[[THEN_OFF:.*]] = %{{.*}}) -> (i32) {
+// CHECK:           tt.store
+// CHECK:           scf.yield %{{.*}} : i32
+// CHECK:         }
+// CHECK:         scf.yield %[[THEN_INNER]] : i32
+// CHECK:       } else {
+// CHECK:         %[[ELSE_INNER:.*]] = scf.for {{.*}} iter_args(%[[ELSE_OFF:.*]] = %{{.*}}) -> (i32) {
+// CHECK:           tt.store
+// CHECK:           scf.yield %{{.*}} : i32
+// CHECK:         }
+// CHECK:         scf.yield %[[ELSE_INNER]] : i32
+// CHECK:       }
+// CHECK:       %[[FINAL_PTR:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[SELECTED]]] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:       %[[OUT:.*]] = tt.load %[[FINAL_PTR]] : !tt.ptr<tensor<32xf16>>
+// CHECK:       tt.return %[[OUT]] : tensor<32xf16>


### PR DESCRIPTION
## Summary

This PR adds follow-up fixes for complex control-flow pointer handling in the Ascend backend, solving unreachable CFG return blocks, scalar tensor-pointer offsets, zero tensor helper functions, and nested loop pointer results yielded through an outer `scf.if`.

A representative case is:

```python
if cond:
    for _ in range(n):
        ptr = tl.advance(ptr, [step0])
        tl.store(ptr, src)
else:
    for _ in range(n):
        ptr = tl.advance(ptr, [step1])
        tl.store(ptr, src)

out = tl.load(ptr)
```

The important point is that the selected pointer after the `if` must carry the loop-updated offset, not the initial pointer offset observed during planning.

Related to #148 and follows up the complex control-flow support in #134.

## Changes

- Removes unreachable CFG blocks before CFG-to-SCF structuring, avoiding failures from dead terminal-return blocks.
- Preserves scalar tensor-pointer offsets when a tensor pointer is represented as a stable vector offset plus a scalar loop-carried offset.
- Extends `scf.if` planning for nested `scf.for` results so loop-carried pointer offsets are explicitly yielded through the parent `if`.
- Handles both tensor pointer and block pointer offset components in nested-loop `if` results.
- Inlines private zero-tensor helper functions before Triton-to-Linalg use analysis and conversion, so helper calls do not survive into later lowering.

## Impact

- Fixes correctness issues where nested loop pointer updates inside `if` branches were dropped when the pointer result was used after the branch merge.
- Improves robustness for complex control-flow memory access patterns generated by Triton kernels.
- Avoids unnecessary failures on dead CFG blocks emitted by frontend/lowering paths.
