### PR TITLE
[CI](fix) Reopen the pre-commit check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,6 @@ jobs:
   runner-preparation:
     uses: ./.github/workflows/runner-preparation.yml
 
-  # pre-commit:
-  #   uses: ./.github/workflows/pre-commit.yml
-
   integration-tests-ascend:
     needs: runner-preparation
     if: needs.runner-preparation.outputs.matrix-ASCEND != ''

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,8 +1,19 @@
 name: Pre-Commit Check
 
 on:
-  workflow_call:
+  workflow_dispatch:
+  pull_request:
+  merge_group:
+    branches: [main, 'dev-**']
+    types: [checks_requested]
+  push:
+    branches: [main, 'release/**']
 
+concurrency:
+  group: pre-commit-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions: read-all
 jobs:
   pre-commit:
     name: pre-commit (code formatting)


### PR DESCRIPTION
## Summary

Here, synchronize the content of the [main branch](https://github.com/triton-lang/triton-ascend/pull/454) and open the pre-commit of the release/3.2.2-dev branch.
