### PR TITLE
[release/3.2.2](feat) Sync verified commits from dev to release/3.2.2

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -8,6 +8,8 @@
 #include "ascend/include/DiscreteMaskAccessConversion/Passes.h"
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition.h"
 #include "ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h"
+#include "ascend/include/DynamicCVPipeline/SeparateMemoryFromCompute/AsyncLoadHoistingPass.h"
+#include "ascend/include/DynamicCVPipeline/SeparateMemoryFromCompute/AddMultiBufferToGMLoadPass.h"
 #include "ascend/include/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.h"
 #include "ascend/include/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.h"
 #include "ascend/include/DynamicCVPipeline/Passes.h"
@@ -115,6 +117,8 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::registerPlanComputeBlockPasses();
   mlir::triton::registerOpClassifierPass();
   mlir::triton::registerRefineArgsBlockIdPasses();
+  mlir::triton::registerAsyncLoadHoistingPasses();
+  mlir::triton::registerAddMultiBufferToGMLoadPasses();
 
 
   // TODO: register Triton & TritonGPU passes

--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -989,7 +989,7 @@ class NPUOptions:
     disable_fma: bool = False
 
     # superblocking factor
-    superblock_factor: int = 0
+    superblock_factor: int = 1
 
     def __post_init__(self):
         # Parse compile_mode and set related fields
@@ -1066,7 +1066,7 @@ def ttir_to_npubin(mod, metadata, opt):
             # cap keys off the same env switch, so the two stay in sync.
             if _is_auto_map_parallel_blocks_enabled():
                 _compile_option_list += ["--enable-auto-blockify-loop"]
-                if opt.superblock_factor > 0:
+                if opt.superblock_factor > 1:
                     _compile_option_list += [f"--super-block-factor={opt.superblock_factor}"]
 
         npu_compiler_path, env = _get_npucompiler_path()

--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/Utils.h
@@ -34,7 +34,6 @@ namespace triton {
 
 // Attribute names for DynamicCV pipeline
 inline constexpr llvm::StringLiteral kSSBufferIfAttr = "ssbuffer.if";
-inline constexpr llvm::StringLiteral kHIVMMatmulLimitedInCubeAttr = "hivm.matmul_limited_in_cube";
 
 // Collect all nested ops within an operation's regions
 LogicalResult collectAllNestedOps(Operation *op, llvm::DenseSet<Operation *> &regionOps);

--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -51,6 +51,7 @@ inline constexpr llvm::StringLiteral kLoopCarriedL0C = "ssbuffer.loop_carried_l0
 inline constexpr llvm::StringLiteral kCrossDeps = "ssbuffer.crossDeps";
 inline constexpr llvm::StringLiteral kMayNotExec = "ssbuffer.may_not_exec";
 inline constexpr llvm::StringLiteral kClone = "ssbuffer.clone";
+static constexpr llvm::StringLiteral kInlinableQuantScaleAttr = "enable_fast_tf32_mul";
 inline constexpr const char *ERRCODE_ATTR = "triton_ascend.dynamic_cv_pipeline.rc";
 static constexpr const int ERRCODE_FAILED = 1;
 static constexpr const int ERRCODE_IGNORED = 2;

--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -52,6 +52,8 @@ inline constexpr llvm::StringLiteral kCrossDeps = "ssbuffer.crossDeps";
 inline constexpr llvm::StringLiteral kMayNotExec = "ssbuffer.may_not_exec";
 inline constexpr llvm::StringLiteral kClone = "ssbuffer.clone";
 static constexpr llvm::StringLiteral kInlinableQuantScaleAttr = "enable_fast_tf32_mul";
+inline constexpr llvm::StringLiteral kHIVMMatmulLimitedInCubeAttr = "hivm.matmul_limited_in_cube";
+
 inline constexpr const char *ERRCODE_ATTR = "triton_ascend.dynamic_cv_pipeline.rc";
 static constexpr const int ERRCODE_FAILED = 1;
 static constexpr const int ERRCODE_IGNORED = 2;

--- a/third_party/ascend/include/DynamicCVPipeline/SeparateMemoryFromCompute/AddMultiBufferToGMLoadPass.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SeparateMemoryFromCompute/AddMultiBufferToGMLoadPass.h
@@ -63,6 +63,9 @@ private:
 // Create the pass
 std::unique_ptr<OperationPass<ModuleOp>> createAddMultiBufferToGMLoadPass();
 
+// Register the pass so it is available as --gm-load-multi-buffer on the command line
+void registerAddMultiBufferToGMLoadPasses();
+
 } // namespace triton
 } // namespace mlir
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CloneOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CloneOps.cpp
@@ -29,6 +29,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/IRMapping.h"
 
@@ -430,6 +431,9 @@ LogicalResult CloneOpsPass::validateClonedOpsInVector(ModuleOp module)
 
     for (Operation &bodyOp : forOp.getBody()->without_terminator()) {
       if (!bodyOp.hasAttr(CVPipeline::kClone)) {
+        continue;
+      }
+      if (isa<tensor::EmptyOp>(bodyOp)) {
         continue;
       }
       bool hasTensorDep = llvm::any_of(bodyOp.getResults(), [](Value result) {

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CreateIfOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CreateIfOps.cpp
@@ -20,16 +20,20 @@
  * THE SOFTWARE.
  */
 
+#include "llvm/Support/Debug.h"
+
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/IRMapping.h"
+
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/CreateIfOps.h"
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/Utils.h"
-#include "llvm/Support/Debug.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/IR/IRMapping.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "bishengir/Dialect/Scope/IR/Scope.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "bishengir/Dialect/Scope/IR/Scope.h"
 
 static constexpr const char *DEBUG_TYPE = "CreateIfOps";
 #define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
@@ -227,7 +231,7 @@ static scf::IfOp createIfOpForBlock(OpBuilder &builder, Location loc, int blockI
   ifOp->setAttr(kSSBufferIfAttr, builder.getI32IntegerAttr(blockId));
 
   // notify npuir that of the scenario
-  ifOp->setAttr(kHIVMMatmulLimitedInCubeAttr, builder.getUnitAttr());
+  ifOp->setAttr(CVPipeline::kHIVMMatmulLimitedInCubeAttr, builder.getUnitAttr());
 
   return ifOp;
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
@@ -243,7 +243,7 @@ DenseMap<int, DenseMap<Value, SmallVector<Value>>> UpdateConditionInfoPass::exte
         }
         int tcbGroupId = findTcbGroupId(buffer, tightlyCoupledBufferGroups);
         if (tcbGroupId == -1) {
-          LDBG("Can not find tightly_coupled_buffer id" << "\n");
+          LDBG("Can not find tightly_coupled_buffer id of: " << buffer << "\n");
           return errorMap;
         }
         if (addEquivalentValues(buffer, tightlyCoupledBufferGroups[tcbGroupId], producers) == -1) {
@@ -819,28 +819,28 @@ int UpdateConditionInfoPass::buildTensorIterArgIfOpVarMap(scf::ForOp forOp)
     LDBG("Skip buildTensorIterArgIfOpVarMap: no tensor iter_args info for this forOp\n");
     return UPDATE_CONDITION_INFO_SUCCESS;
   }
-  
+
   auto &depsVec = info->tensorIterArgDepsMap[forOp];
   auto &indicesMap = info->tensorIterArgIndicesMap[forOp];
 
   llvm::DenseMap<scf::IfOp, llvm::DenseSet<Value>> producerVars;
   llvm::DenseMap<scf::IfOp, llvm::DenseSet<Value>> consumerVars;
-  
+
   for (auto &depEntry : depsVec) {
     Value origIterArg = depEntry.iterArg;
     TensorIterArgIfOpRelation &relation = depEntry;
-    
+
     if (!indicesMap.count(origIterArg)) {
       LDBG("[Error]: origIterArg not found in indicesMap\n");
       return UPDATE_CONDITION_INFO_FAILED;
     }
     SmallVector<int> &argIndices = indicesMap[origIterArg];
-    
+
     if (relation.consumers.size() != argIndices.size()) {
       LDBG("[Error]: consumers size mismatch: " << relation.consumers.size() << " vs " << argIndices.size() << "\n");
       return UPDATE_CONDITION_INFO_FAILED;
     }
-    
+
     // Establish a mapping (one-to-one) from consumers to variables
     llvm::DenseMap<scf::IfOp, Value> consumerToVar;
     for (size_t i = 0; i < relation.consumers.size(); ++i) {
@@ -848,20 +848,20 @@ int UpdateConditionInfoPass::buildTensorIterArgIfOpVarMap(scf::ForOp forOp)
       Value var = forOp.getRegionIterArg(argIndices[i]);
       consumerToVar[consumer] = var;
     }
-    
+
     // Add all the variables of the consumers that depend on each producer
     for (scf::IfOp producer : relation.producers) {
       for (auto &[consumer, var] : consumerToVar) {
         producerVars[producer].insert(var);
       }
     }
-    
+
     // Add all the variables of the consumers that depend on each producer
     for (auto &[consumer, var] : consumerToVar) {
       consumerVars[consumer].insert(var);
     }
   }
-  
+
   // Convert the temporary data structure to tensorIfOpVarMap
   for (auto &[producer, vars] : producerVars) {
     auto &ifOpVars = info->tensorIterArgIfOpVars[producer];
@@ -869,7 +869,7 @@ int UpdateConditionInfoPass::buildTensorIterArgIfOpVarMap(scf::ForOp forOp)
       ifOpVars.producerVars.push_back(var);
     }
   }
-  
+
   for (auto &[consumer, vars] : consumerVars) {
     auto &ifOpVars = info->tensorIterArgIfOpVars[consumer];
     for (Value var : vars) {

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateForOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateForOps.cpp
@@ -165,8 +165,10 @@ static scf::ForOp createForOpAndMigrateBody(
   Block *oldBlock = oldForOp.getBody();
   Block *newBlock = newForOp.getBody();
 
-  if (failed(replaceBlockArguments(oldBlock, newBlock)))
+  if (failed(replaceBlockArguments(oldBlock, newBlock))) {
+    newForOp.erase();
     return scf::ForOp();
+  }
 
   for (Operation &op : llvm::make_early_inc_range(oldBlock->without_terminator()))
     op.moveBefore(newBlock, newBlock->end());

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/Utils.cpp
@@ -99,7 +99,14 @@ static LogicalResult dfsTopologicalSort(
   }
 
   if (opOrder && !opOrder->empty()) {
-    llvm::sort(deps, [&](Operation *a, Operation *b) { return (*opOrder)[a] < (*opOrder)[b]; });
+    llvm::sort(deps, [&](Operation *a, Operation *b) {
+      auto itA = opOrder->find(a);
+      auto itB = opOrder->find(b);
+      if (itA == opOrder->end() || itB == opOrder->end()) {
+        return false;
+      }
+      return itA->second < itB->second;
+    });
   }
 
   for (Operation *dep : deps) {

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/MemoryEffectsTracker.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/MemoryEffectsTracker.cpp
@@ -35,6 +35,7 @@
 // all prior writers/readers and become the sole writer for every slot.
 
 #include "ascend/include/DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/IR/Block.h"
@@ -288,8 +289,12 @@ SmallVector<MemoryEffects::EffectInstance> MemoryDependenceGraph::collectOuterEf
     unknown = false;
 
     if (auto markOp = dyn_cast<annotation::MarkOp>(op)) {
-        MemoryEffects::EffectInstance scopedWrite(MemoryEffects::Write::get());
-        return {remapEffectValue(scopedWrite, markOp.getSrc())};
+        if (markOp->hasAttr(CVPipeline::kInlinableQuantScaleAttr)) {
+            return {};
+        } else {
+            MemoryEffects::EffectInstance scopedWrite(MemoryEffects::Write::get());
+            return {remapEffectValue(scopedWrite, markOp.getSrc())};
+        }
     }
 
     if (auto allocTensorOp = dyn_cast<bufferization::AllocTensorOp>(op)) {

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
@@ -19,11 +19,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
+ 
+#include <optional>
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
@@ -41,7 +43,6 @@
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Support/LLVM.h"
 #include "triton/Analysis/Utility.h"
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -282,10 +283,25 @@ void transSource(Value value, SetVector<Operation *> &matchedOps, Block *block)
     }
 }
 
+bool hasQuantScaleCompileHint(Operation *op, SetVector<Operation *> &matchedOps)
+{
+    return any_of(op->getUsers(), [&](Operation *userOp) {
+        auto markOp = dyn_cast<annotation::MarkOp>(userOp);
+        if (!markOp) {
+            return false;
+        }
+        matchedOps.insert(markOp);
+        return markOp->hasAttr(CVPipeline::kInlinableQuantScaleAttr);
+    });
+}
+
 bool FixpipeOptPass::isValidMul(Operation *op, Value matmulValue, SetVector<Operation *> &matchedOps)
 {
     // Just filter: arith.mulf/muli(scalar)
     if (!isa<arith::MulFOp>(op) && !isa<arith::MulIOp>(op)) {
+        return false;
+    }
+    if (!hasQuantScaleCompileHint(op, matchedOps)) {
         return false;
     }
     auto quantScalarValue = op->getOperand(0) == matmulValue ? op->getOperand(1) : op->getOperand(0);
@@ -425,6 +441,23 @@ bool FixpipeOptPass::isFixpipeCastPattern(Operation *truncOp, SetVector<Operatio
     return true;
 }
 
+std::optional<Operation *> getOneUserExceptMarkOp(Operation *op)
+{
+    int count = 0;
+    Operation *onlyUser = nullptr;
+    for (auto user : op->getUsers()) {
+        if (!isa<annotation::MarkOp>(user)) {
+            count += 1;
+            onlyUser = user;
+        }
+    }
+    if (count != 1) {
+        return std::nullopt;
+    } else {
+        return onlyUser;
+    }
+}
+
 /** Fixpipe supports scaling, the pattern should be like below:
     linalg.matmul
         ↓
@@ -438,26 +471,25 @@ bool FixpipeOptPass::isFixpipeCastPattern(Operation *truncOp, SetVector<Operatio
 bool FixpipeOptPass::isFixpipeMulPattern(Operation *mulOp, SetVector<Operation *> &matchedOps)
 {
     Value mulResult = mulOp->getResult(0);
-    if (!mulResult.hasOneUse()) {
+    auto maybeExtract = getOneUserExceptMarkOp(mulOp).value_or(nullptr);
+    if (!maybeExtract) {
         LOG_DEBUG("Mul not only one user, NOT match.");
         return false;
     }
-    auto maybeExtract = *mulResult.getUsers().begin();
     tensor::ExtractSliceOp extractSliceOp = nullptr;
-    Value extractResult = mulResult;
     if (auto extract = dyn_cast<tensor::ExtractSliceOp>(maybeExtract)) {
         extractSliceOp = extract;
-        extractResult = extractSliceOp.getResult();
         matchedOps.insert(extractSliceOp);
     }
 
-    if (!extractResult.hasOneUse()) {
+    if (extractSliceOp && !getOneUserExceptMarkOp(extractSliceOp).has_value()) {
         LOG_DEBUG("Extract Slice not only one user, NOT match.");
         return false;
     }
 
+    auto storeOp = extractSliceOp ? getOneUserExceptMarkOp(extractSliceOp).value() : maybeExtract;
     matchedOps.insert(mulOp);
-    if (!isStoreToGM(*extractResult.getUsers().begin(), matchedOps)) {
+    if (!isStoreToGM(storeOp, matchedOps)) {
         LOG_DEBUG("Not store to GM pattern, NOT match.");
         return false;
     }

--- a/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/LoopTransform.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/LoopTransform.cpp
@@ -342,14 +342,14 @@ ExtendedForInfo buildExtendedFor(OpBuilder &builder, Location loc, scf::ForOp fo
                                  ConstantCache &cache)
 {
     builder.setInsertionPoint(forOp);
-    int numOrig = static_cast<int>(forOp.getInitArgs().size());
+    size_t numOrig = forOp.getInitArgs().size();
     int depth = groups.empty() ? 0 : groups[0].depth;
 
     Value falseVal = cache.getFalse(builder, loc);
     Value zeroIndex = cache.getIndex(builder, loc, 0);
 
     SmallVector<Value> inits;
-    inits.reserve(numOrig + static_cast<int>(groups.size()) * (depth + kLoadGroupCounterIterArgCount));
+    inits.reserve(numOrig + groups.size() * (depth + kLoadGroupCounterIterArgCount));
     for (Value initArg : forOp.getInitArgs()) {
         inits.push_back(initArg);
     }
@@ -379,7 +379,7 @@ ExtendedForInfo buildExtendedFor(OpBuilder &builder, Location loc, scf::ForOp fo
     builder.setInsertionPointToEnd(newBody);
 
     SmallVector<GroupIterArgs> groupArgs;
-    int argOffset = numOrig;
+    size_t argOffset = numOrig;
     for (auto &group : groups) {
         GroupIterArgs groupIterArgs;
         for (int slotIdx = 0; slotIdx < group.depth; ++slotIdx) {
@@ -393,7 +393,8 @@ ExtendedForInfo buildExtendedFor(OpBuilder &builder, Location loc, scf::ForOp fo
         groupArgs.push_back(std::move(groupIterArgs));
     }
 
-    return {newFor, oldBody, newBody, std::move(mapping), std::move(groupArgs), falseVal, numOrig, depth};
+    return {newFor, oldBody, newBody, std::move(mapping), std::move(groupArgs), falseVal, static_cast<int>(numOrig),
+            depth};
 }
 
 // ============================================================================

--- a/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/MultiBufferLoopBodyEmission.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/MultiBufferLoopBodyEmission.cpp
@@ -165,22 +165,16 @@ static ProducerLoopPosition mapProducerLoopPosition(OpBuilder &builder, Location
 static LogicalResult validateProducerIterArgInputs(scf::ForOp origForOp, Block *oldBody, Block *newBody,
                                                    ArrayRef<Value> iterArgDeltas)
 {
-    int numOrig = static_cast<int>(origForOp.getInitArgs().size());
-    if (numOrig < 0) {
-        origForOp.emitError() << "[" << DEBUG_TYPE << "] original iter_arg count is negative: " << numOrig;
-        return failure();
-    }
-
-    auto numOrigArgs = static_cast<unsigned>(numOrig);
-    if (iterArgDeltas.size() < numOrigArgs) {
+    size_t numOrig = origForOp.getInitArgs().size();
+    if (iterArgDeltas.size() < numOrig) {
         origForOp.emitError() << "[" << DEBUG_TYPE << "] iter_arg delta count " << iterArgDeltas.size()
-                              << " is smaller than original iter_arg count " << numOrigArgs;
+                              << " is smaller than original iter_arg count " << numOrig;
         return failure();
     }
-    if (oldBody->getNumArguments() < numOrigArgs + kForBodyIterArgOffset ||
-        newBody->getNumArguments() < numOrigArgs + kForBodyIterArgOffset) {
+    if (oldBody->getNumArguments() < numOrig + kForBodyIterArgOffset ||
+        newBody->getNumArguments() < numOrig + kForBodyIterArgOffset) {
         origForOp.emitError() << "[" << DEBUG_TYPE << "] loop body argument count is smaller than expected "
-                              << (numOrigArgs + kForBodyIterArgOffset);
+                              << (numOrig + kForBodyIterArgOffset);
         return failure();
     }
     return success();
@@ -485,14 +479,21 @@ static LogicalResult validateGroupEmissionInputs(ArrayRef<LoadGroup> groups, Ext
                                                  ArrayRef<Value> allGroupDepthConsts,
                                                  ArrayRef<SmallVector<Value>> allGroupSlotConsts, scf::ForOp origForOp)
 {
-    if (groupIdx < 0 || static_cast<size_t>(groupIdx) >= groups.size() ||
-        static_cast<size_t>(groupIdx) >= info.groupArgs.size() ||
-        static_cast<size_t>(groupIdx) >= groupTrueFlagVals.size() ||
-        static_cast<size_t>(groupIdx) >= groupIndexOneVals.size() ||
-        static_cast<size_t>(groupIdx) >= allGroupDepthConsts.size() ||
-        static_cast<size_t>(groupIdx) >= allGroupSlotConsts.size()) {
+    size_t numGroups = groups.size();
+    if (info.groupArgs.size() != numGroups || groupTrueFlagVals.size() != numGroups ||
+        groupIndexOneVals.size() != numGroups || allGroupDepthConsts.size() != numGroups ||
+        allGroupSlotConsts.size() != numGroups) {
+        origForOp.emitError()
+            << "[" << DEBUG_TYPE << "] array size mismatch in multi-buffer emission: groups=" << numGroups
+            << ", groupArgs=" << info.groupArgs.size() << ", groupTrueFlagVals=" << groupTrueFlagVals.size()
+            << ", groupIndexOneVals=" << groupIndexOneVals.size()
+            << ", allGroupDepthConsts=" << allGroupDepthConsts.size()
+            << ", allGroupSlotConsts=" << allGroupSlotConsts.size();
+        return failure();
+    }
+    if (groupIdx < 0 || static_cast<size_t>(groupIdx) >= numGroups) {
         origForOp.emitError() << "[" << DEBUG_TYPE << "] load group index " << groupIdx
-                              << " is out of range for multi-buffer emission";
+                              << " is out of range for multi-buffer emission (numGroups=" << numGroups << ")";
         return failure();
     }
     return success();

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -394,6 +394,18 @@ void OpClassifierPass::matchMaterializePattern(Operation *user)
     cubeSeeds.push_back(user);
 }
 
+static bool allResultHasOneUser(Operation *op)
+{
+    bool ret = true;
+    for (Value result : op->getResults()) {
+        if (!result.hasOneUse()) {
+            ret = false;
+            break;
+        }
+    }
+    return ret;
+}
+
 // Pattern matching for CUBE operations
 int OpClassifierPass::patternMatchCUBE()
 {
@@ -434,10 +446,16 @@ int OpClassifierPass::patternMatchCUBE()
 
         // ---- Downstream pattern matching ----
         for (Value result : op->getResults()) {
+            if (!result.hasOneUse()) {
+                continue;
+            }
             for (Operation *user : result.getUsers()) {
                 // If user is scf.yield, follow the chain to find real users
                 Operation *curUser = user;
                 while (curUser) {
+                    if (!allResultHasOneUser(curUser)) {
+                        break;
+                    }
                     if (auto yieldOp = dyn_cast<scf::YieldOp>(curUser)) {
                         if (Operation *scfOp = yieldOp->getParentOp()) {
                             // Find which operand index the previous result corresponds to in the yield

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
@@ -27,11 +27,13 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/iterator.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Block.h"
@@ -157,6 +159,28 @@ BlockOpGraph::BlockOpGraph(ArrayRef<Operation *> allOps, Block *block, const Mem
     }
 }
 
+// ============================================================================
+// Method: collectBlockIds
+// ============================================================================
+/**
+ * @brief Collects block IDs across operations, traversing nested operations when necessary.
+ *
+ * **Purpose**:
+ * Resolves or assigns unique block IDs for a list of operations, ensuring that sub-operations
+ * within nested regions are accounted for when checking scheduling groups.
+ *
+ * **Inputs & Assumptions**:
+ * - `allOps` (ArrayRef<Operation *>): List of outer operations.
+ * - `bm` (ComputeBlockIdManager &): The block ID manager.
+ *
+ * **Outputs & Guarantees**:
+ * - Returns a `DenseMap<Operation *, int>` associating each operation with its block ID.
+ * - Returns `llvm::failure()` if validation of any operation block ID fails.
+ *
+ * **Safety Boundaries & Constraints**:
+ * - If an operation does not have a block ID assigned directly, performs a recursive walk on its
+ *   nested regions to find a unified block ID. If nested block IDs conflict, assigns a new unique ID.
+ */
 static llvm::FailureOr<DenseMap<Operation *, int>> collectBlockIds(ArrayRef<Operation *> allOps, ComputeBlockIdManager &bm)
 {
     DenseMap<Operation *, int> opBlockId;
@@ -164,10 +188,31 @@ static llvm::FailureOr<DenseMap<Operation *, int>> collectBlockIds(ArrayRef<Oper
         if (llvm::failed(verifyOpBlockId(op))) {
             return llvm::failure();
         }
-        auto blockIdAttrRes = getOpBlockId(op);
-        int64_t blockId =
-            blockIdAttrRes.has_value() ? blockIdAttrRes.value() : bm.getNextId();
-        opBlockId[op] = blockId;
+        auto blockIdOpt = getOpBlockId(op);
+        if (blockIdOpt.has_value()) {
+            opBlockId[op] = blockIdOpt.value();
+            continue;
+        }
+
+        auto result = op->walk([&](Operation *nestedOp) {
+            if (nestedOp != op && !llvm::isa<scf::YieldOp, linalg::FillOp>(nestedOp)) {
+                return WalkResult::interrupt();
+            }
+            auto currBlockIdOpt = getOpBlockId(nestedOp);
+            if (!blockIdOpt.has_value()) {
+                blockIdOpt = getOpBlockId(nestedOp);
+            }
+            if (currBlockIdOpt.has_value() && currBlockIdOpt != blockIdOpt) {
+                return WalkResult::interrupt();
+            }
+            return WalkResult::advance();
+        });
+        if (result.wasInterrupted() || !blockIdOpt.has_value()) {
+            blockIdOpt = bm.getNextId();
+        } else {
+            bm.updateBlockId(op, blockIdOpt.value());
+        }
+        opBlockId[op] = blockIdOpt.value();
     }
     return opBlockId;
 }
@@ -357,14 +402,15 @@ static llvm::LogicalResult reorderOpsInBlock(Block &block, const MemoryDependenc
 
 void ReorderOpsByBlockIdPass::runOnOperation()
 {
-    LOG_DEBUG("\n=== Pass: TuningOpSeq ===\n");
-    OpBuilder const builder(&getContext());
-
     auto moduleOp = getOperation();
+    LOG_DEBUG("Input mlir:\n" << moduleOp << "\n");
+    llvm::dbgs().flush();
+
+    OpBuilder const builder(&getContext());
     auto &aa = getAnalysis<AliasAnalysis>();
     auto memGraph = MemoryDependenceGraph(moduleOp, aa);
     auto bm = ComputeBlockIdManager(moduleOp);
-    moduleOp.walk([&](Block *block) {
+    auto result = moduleOp.walk([&](Block *block) {
         auto *parentOp = block->getParentOp();
         if (!parentOp ||
             // whitelist ops to reorder
@@ -372,12 +418,16 @@ void ReorderOpsByBlockIdPass::runOnOperation()
             return WalkResult::skip();
         }
         if (llvm::failed(reorderOpsInBlock(*block, memGraph, bm))) {
-            signalPassFailure();
+            return WalkResult::interrupt();
         }
         return WalkResult::advance();
     });
 
-    LOG_DEBUG("=== Pass TuningOpSeq complete ===\n");
+    if (result.wasInterrupted()) {
+        signalPassFailure();
+        return;
+    }
+    LOG_DEBUG("Output mlir:\n" << moduleOp << "\n");
 }
 
 std::unique_ptr<OperationPass<ModuleOp>> mlir::triton::createReorderOpsByBlockIdPass()

--- a/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/AddMultiBufferToGMLoad.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/AddMultiBufferToGMLoad.cpp
@@ -171,5 +171,10 @@ std::unique_ptr<OperationPass<ModuleOp>> createAddMultiBufferToGMLoadPass()
     return std::make_unique<AddMultiBufferToGMLoadPass>();
 }
 
+void registerAddMultiBufferToGMLoadPasses()
+{
+  registerPass([]() -> std::unique_ptr<mlir::Pass> { return createAddMultiBufferToGMLoadPass(); });
+}
+
 } // namespace triton
 } // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/AsyncLoadHoisting.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/AsyncLoadHoisting.cpp
@@ -202,7 +202,7 @@ static void collectAddressGenerationOps(Operation* op, int64_t expectedBlockId, 
           for (auto result : user->getResults()) {
             for (auto* subviewUser : result.getUsers()) {
               if (auto copyOp = llvm::dyn_cast<memref::CopyOp>(subviewUser);
-                  visited.insert(copyOp).second) {
+                  copyOp && visited.insert(copyOp).second) {
                 chain.push_back(copyOp);
                 collectAddressGenerationOps(copyOp, expectedBlockId, visited, chain);
               }
@@ -213,10 +213,10 @@ static void collectAddressGenerationOps(Operation* op, int64_t expectedBlockId, 
       }
     }
 
-    visited.insert(defOp);
-    chain.push_back(defOp);
-
-    collectAddressGenerationOps(defOp, expectedBlockId, visited, chain);
+    if (visited.insert(defOp).second) {
+      chain.push_back(defOp);
+      collectAddressGenerationOps(defOp, expectedBlockId, visited, chain);
+    }
   }
 }
 // Returns full chain and filtered chain (only ops with same block_id)

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -258,6 +258,15 @@ SmallVector<int64_t> InterCoreTransferAndSyncPass::computeExpectedShape(mlir::Va
     int64_t newN = blN * nRound;
     LOG_DEBUG("newM" << newM << "\n");
     LOG_DEBUG("newN" << newN << "\n");
+
+    if (isOnlyDepInMatmul) {
+        if ((isMatmulA && newN != N) || (isMatmulB && newM != M)) {
+            LOG_DEBUG("nd2nz shape is unaligned and matmul A/B is from cube");
+            CVPipeline::setFallbackAttr(module);
+            signalPassFailure();
+        }
+    }
+
     return { newM, newN }; // Return 2D shape
 }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
@@ -20,24 +20,27 @@
  * THE SOFTWARE.
  */
 
-#include "ascend/include/DynamicCVPipeline/SplitDataflow/SeparateCVScope.h"
+#include <optional>
 
-#include "bishengir/Dialect/HIVM/IR/HIVM.h"
-#include "bishengir/Dialect/Scope/IR/Scope.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/IRMapping.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Pass/Pass.h"
 
-#include <optional>
-#include "llvm/ADT/SmallPtrSet.h"
-#include "llvm/ADT/SmallVector.h"
-#include "llvm/Support/Debug.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/SplitDataflow/SeparateCVScope.h"
+
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "bishengir/Dialect/Scope/IR/Scope.h"
 
 using namespace mlir;
 
@@ -963,7 +966,7 @@ void mlir::triton::SeparateCVScopePass::runOnOperation()
     }
 
     module.walk([](scope::ScopeOp scopeOp) {
-        scopeOp->setAttr("hivm.matmul_limited_in_cube", UnitAttr::get(scopeOp->getContext()));
+        scopeOp->setAttr(CVPipeline::kHIVMMatmulLimitedInCubeAttr, UnitAttr::get(scopeOp->getContext()));
     });
 
     debugDumpOperation("after SeparateCVScopePass", module.getOperation());

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
@@ -549,7 +549,7 @@ static UseCheckResult checkConditionUse(OpOperand &use, Operation *owner, unsign
     }
 
     unsigned idx = use.getOperandNumber();
-    if (conditionOp->getParentOp() != owner || idx == 0 || idx - 1 != slotIndex) {
+    if (conditionOp->getParentOp() != owner || idx == 0 || idx != slotIndex + 1) {
         Operation *parentOp = conditionOp->getParentOp();
         if (parentOp && !matchesScope(parentOp, scopeType)) {
             return UseCheckResult::Continue;

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
@@ -20,20 +20,25 @@
  * THE SOFTWARE.
  */
 
+#include <cstddef>
+#include <optional>
+
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/LogicalResult.h"
-#include <cstddef>
-#include <optional>
+#include "llvm/Support/raw_ostream.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dominance.h"
@@ -43,9 +48,7 @@
 #include "mlir/IR/Value.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Support/LLVM.h"
-#include "llvm/ADT/SmallVector.h"
 
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.h"
@@ -105,6 +108,22 @@ static bool isFloatOrInt(RankedTensorType tensorType)
 {
     auto elmType = tensorType.getElementType();
     return isa<FloatType, IntegerType>(elmType);
+}
+
+static bool scfMayNotExec(Operation *op)
+{
+    return llvm::TypeSwitch<Operation *, bool>(op)
+        .Case([&](scf::ForOp forOp) {
+            IntegerAttr ubAttr;
+            IntegerAttr lbAttr;
+            if (matchPattern(forOp.getUpperBound(), m_Constant(&ubAttr)) &&
+                matchPattern(forOp.getLowerBound(), m_Constant(&lbAttr))) {
+                return ubAttr.getValue().sle(lbAttr.getValue());
+            }
+            return true;
+        })
+        .Case([&](scf::IfOp ifOp) { return !matchPattern(ifOp.getCondition(), m_One()); })
+        .Default([&](auto) { return false; });
 }
 
 /**
@@ -194,23 +213,8 @@ static Value searchInArgsChain(Value nextValueOfC, bool &argsLimitedInMatmul, bo
     if (!argsLimitedInMatmul) {
         return nextValueOfC;
     }
-    // update mayNotExec
-    if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
-        IntegerAttr ubAttr, lbAttr;
-        if (matchPattern(forOp.getUpperBound(), m_Constant(&ubAttr)) &&
-            matchPattern(forOp.getLowerBound(), m_Constant(&lbAttr)))
-        {
-            if (ubAttr.getValue().sle(lbAttr.getValue())) {
-                mayNotExec = true;
-            }
-        } else {
-            mayNotExec = true;
-        }
-    } else if (auto ifOp = dyn_cast<scf::IfOp>(parentOp)) {
-        if (!matchPattern(ifOp.getCondition(), m_One())) {
-            mayNotExec = true;
-        }
-    }
+
+    mayNotExec = mayNotExec || scfMayNotExec(parentOp);
     return searchInArgsChain(nextSearchValue, argsLimitedInMatmul, mayNotExec, outerInValue);
 }
 
@@ -495,6 +499,26 @@ static bool verifyMatmul(linalg::MatmulOp matmulOp)
     return true;
 }
 
+// Supports the most common case, where a loop-carried matmul is
+// directly under a not executed for-loop
+static std::optional<SplitInfo> handleMayNotExec(linalg::MatmulOp matmulOp)
+{
+    auto *parentOp = matmulOp->getBlock()->getParentOp();
+    auto forOp = llvm::dyn_cast<scf::ForOp>(parentOp);
+    auto inputs = parseMatmulInputs(matmulOp);
+    auto bias = inputs.bias;
+    if (!forOp || !scfMayNotExec(forOp)) {
+        return std::nullopt;
+    }
+    auto blockArg = llvm::dyn_cast<BlockArgument>(bias);
+    if (!blockArg || blockArg.getOwner()->getParentOp() != forOp) {
+        return std::nullopt;
+    }
+    auto initVal = forOp.getTiedLoopInit(blockArg)->get();
+    auto result = forOp.getTiedLoopResult(blockArg);
+    return SplitInfo {true, initVal, result, true};
+}
+
 /**
  * Determines whether a matmul operation should be split based on comprehensive analysis.
  * This function performs a complete analysis of the matmul operation's context, including:
@@ -534,6 +558,13 @@ static std::optional<SplitInfo> shouldSplit(linalg::MatmulOp matmulOp, bool need
         return SplitInfo {mayNotExec, outerInValue, outerOutValue, true};
     }
 
+    if (mayNotExec) {
+        auto splitInfoOpt = handleMayNotExec(matmulOp);
+        if (splitInfoOpt.has_value()) {
+            return splitInfoOpt;
+        }
+    }
+
     if (!shouldSplitByInput(matmulOp, outerOutValue, outerInValue) &&
         !shouldSplitByOutput(matmulOp, outerOutValue, outerInValue))
     {
@@ -543,13 +574,13 @@ static std::optional<SplitInfo> shouldSplit(linalg::MatmulOp matmulOp, bool need
     return SplitInfo {mayNotExec, outerInValue, outerOutValue, true};
 }
 
-static void splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rewriter, SplitInfo splitInfo)
+static LogicalResult splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rewriter, SplitInfo splitInfo)
 {
     auto outputType = dyn_cast<RankedTensorType>(parseMatmulInputs(matmulOp).bias.getType());
     if (!outputType) {
         LOG_DEBUG("Not tensor mode: " << matmulOp
                                       << "; the caller does not ensure the assumption. Cowardly doing nothing");
-        return;
+        return failure();
     }
     auto elmType = outputType.getElementType();
 
@@ -566,38 +597,88 @@ static void splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rewriter, Sp
         }
     }
     auto emptyOp = rewriter.create<tensor::EmptyOp>(loc, outputType, dynamicSizes);
-    splitInfo.outerInValue.replaceUsesWithIf(emptyOp->getResult(0),
-                                             [&](OpOperand &opop) { return opop.getOwner() == outerDefOp; });
-
-    // [Step 2] Create new matmul using zero-filled tensor as accumulator
-    // New matmul runs entirely on CUBE with no VECTOR dependency
-    auto inputs = parseMatmulInputs(matmulOp);
-    auto a = inputs.a;
-    auto b = inputs.b;
-    auto bias = inputs.bias;
-    rewriter.setInsertionPoint(matmulOp);
-    auto newMatmul = rewriter.create<linalg::MatmulOp>(loc, ValueRange {a, b}, ValueRange {bias});
-    NamedAttrList attrs(matmulOp->getAttrDictionary());
-    constexpr StringLiteral kShouldRemoveAttrs[] = {"operandSegmentSizes", "res_attrs", "arg_attrs"};
-    for (auto attr : kShouldRemoveAttrs) {
-        attrs.erase(attr);
+    Value zeroValue;
+    if (auto floatType = dyn_cast<FloatType>(elmType)) {
+        APFloat zeroAPFloat = APFloat::getZero(floatType.getFloatSemantics());
+        zeroValue = rewriter.create<arith::ConstantFloatOp>(loc, zeroAPFloat, floatType).getResult();
+    } else if (auto intType = dyn_cast<IntegerType>(elmType)) {
+        zeroValue = rewriter.create<arith::ConstantIntOp>(loc, 0, intType).getResult();
     }
-    newMatmul->setAttrs(attrs);
+    auto fillOp = rewriter.create<linalg::FillOp>(emptyOp.getLoc(), zeroValue, emptyOp.getResult());
+    auto zeroVal = fillOp.getResult(0);
+    splitInfo.outerInValue.replaceUsesWithIf(zeroVal, [&](OpOperand &opop) { return opop.getOwner() == outerDefOp; });
+
+    auto forOp = llvm::dyn_cast_if_present<scf::ForOp>(splitInfo.outerOutValue.getDefiningOp());
+    if (!splitInfo.mayNotExec || !forOp) {
+        // [Step 2] Create new matmul using zero-filled tensor as accumulator
+        // New matmul runs entirely on CUBE with no VECTOR dependency
+        auto inputs = parseMatmulInputs(matmulOp);
+        auto a = inputs.a;
+        auto b = inputs.b;
+        auto bias = inputs.bias;
+        rewriter.setInsertionPoint(matmulOp);
+        auto newMatmul = rewriter.create<linalg::MatmulOp>(loc, ValueRange {a, b}, ValueRange {bias});
+        NamedAttrList attrs(matmulOp->getAttrDictionary());
+        constexpr StringLiteral kShouldRemoveAttrs[] = {"operandSegmentSizes", "res_attrs", "arg_attrs"};
+        for (auto attr : kShouldRemoveAttrs) {
+            attrs.erase(attr);
+        }
+        newMatmul->setAttrs(attrs);
+        if (splitInfo.outerOutValue == matmulOp.getResult(0)) {
+            splitInfo.outerOutValue = newMatmul.getResult(0);
+        }
+        rewriter.replaceOp(matmulOp, newMatmul);
+    }
+
+    auto newOutValue = splitInfo.outerOutValue;
 
     // [Step 3] Create add: add(new_matmul_result, outs_value)
     // This is the "c" in a*b+c, added after the matmul result
     rewriter.setInsertionPointAfterValue(splitInfo.outerOutValue);
+
+    Operation *preservedUser = nullptr;
+    if (splitInfo.mayNotExec && forOp) {
+        auto lb = forOp.getLowerBound();
+        auto ub = forOp.getUpperBound();
+
+        Value executed = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sgt, ub, lb);
+        auto ifOp = rewriter.create<scf::IfOp>(
+            loc,
+            executed,
+            [&](OpBuilder &thenBuilder, Location thenLoc) {
+                thenBuilder.create<scf::YieldOp>(thenLoc, splitInfo.outerOutValue);
+            },
+            [&](OpBuilder &elseBuilder, Location elseLoc) {
+                Value zeroValue;
+                if (auto floatType = dyn_cast<FloatType>(elmType)) {
+                    APFloat zeroAPFloat = APFloat::getZero(floatType.getFloatSemantics());
+                    zeroValue = elseBuilder.create<arith::ConstantFloatOp>(elseLoc, zeroAPFloat, floatType).getResult();
+                } else if (auto intType = dyn_cast<IntegerType>(elmType)) {
+                    zeroValue = elseBuilder.create<arith::ConstantIntOp>(elseLoc, 0, intType).getResult();
+                }
+                auto fillOp = elseBuilder.create<linalg::FillOp>(emptyOp.getLoc(), zeroValue, splitInfo.outerOutValue);
+                elseBuilder.create<scf::YieldOp>(elseLoc, fillOp.getResult(0));
+            });
+        newOutValue = ifOp.getResult(0);
+        preservedUser = ifOp;
+        forOp->setAttr(CVPipeline::kHIVMMatmulLimitedInCubeAttr, rewriter.getUnitAttr());
+    }
+
     Operation *addOp;
     if (isa<FloatType>(elmType)) {
-        addOp = rewriter.create<arith::AddFOp>(loc, splitInfo.outerOutValue, splitInfo.outerInValue).getOperation();
+        addOp = rewriter.create<arith::AddFOp>(loc, newOutValue, splitInfo.outerInValue).getOperation();
     } else {
-        addOp = rewriter.create<arith::AddIOp>(loc, splitInfo.outerOutValue, splitInfo.outerInValue).getOperation();
+        addOp = rewriter.create<arith::AddIOp>(loc, newOutValue, splitInfo.outerInValue).getOperation();
+    }
+    if (preservedUser == nullptr) {
+        preservedUser = addOp;
     }
     addOp->setAttr(CVPipeline::kAddFromMatmul, rewriter.getUnitAttr());
-    splitInfo.outerOutValue.replaceUsesWithIf(addOp->getResult(0),
-                                              [&](OpOperand &opop) { return opop.getOwner() != addOp; });
+    splitInfo.outerOutValue.replaceUsesWithIf(addOp->getResult(0), [preservedUser](OpOperand &operand) {
+        return !preservedUser->isAncestor(operand.getOwner());
+    });
 
-    rewriter.replaceOp(matmulOp, newMatmul);
+    return success();
 }
 
 LogicalResult SplitMatmulPattern::matchAndRewrite(linalg::MatmulOp matmulOp, PatternRewriter &rewriter) const
@@ -616,13 +697,13 @@ LogicalResult SplitMatmulPattern::matchAndRewrite(linalg::MatmulOp matmulOp, Pat
     LOG_DEBUG("shouldSplit = " << splitInfo.shouldSplit);
     LOG_DEBUG("-------------------");
     matmulOp->setAttr(CVPipeline::kLoopCarriedL0C, rewriter.getUnitAttr());
-    
+
+    if (splitInfo.shouldSplit) {
+        return splitMatmul(matmulOp, rewriter, splitInfo);
+    }
+
     if (splitInfo.mayNotExec) {
         matmulOp->setAttr(CVPipeline::kMayNotExec, rewriter.getUnitAttr());
-    }
-    
-    if (splitInfo.shouldSplit) {
-        splitMatmul(matmulOp, rewriter, splitInfo);
     }
 
     return success();

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/check-clone-tensor-empty-ops.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/check-clone-tensor-empty-ops.mlir
@@ -1,0 +1,40 @@
+// RUN: triton-opt --clone-ops --allow-unregistered-dialect %s | FileCheck %s
+
+// Unit test for CloneOps pass: `tensor.empty` is a pure metadata op that
+// allocates a tensor shape but holds no data. When it is cloned into a
+// later block within a VECTOR main_loop, the cloned `tensor.empty` must be
+// allowed (the validator skips it when checking for tensor-typed results).
+// Without this carve-out, `tensor.empty` would be flagged as a tensor-typed
+// result and the pass would signal a failure.
+
+// CHECK-LABEL: func.func @test_vector_clone_tensor_op
+// The cloned `tensor.empty` (clone of the block-11 `tensor.empty`) must be
+// present in block 12 with the `clone = 11` attribute. If the validator
+// incorrectly rejected it, the IR would either be missing this op or the
+// pass would signal a failure.
+// CHECK: tensor.empty() {ssbuffer.block_id = 12 : i32, ssbuffer.clone = 11 : i32} : tensor<256x64xf32>
+// The pre-existing block-12 tensor-typed ops (which are NOT clones) must
+// remain untouched and have no `clone` attribute.
+// CHECK: arith.addf {{%[0-9]+, %[0-9]+}} {ssbuffer.block_id = 12 : i32} : tensor<256x64xf32>
+// CHECK-NOT: arith.addf {{.*}}ssbuffer.clone
+// CHECK: linalg.fill {ssbuffer.block_id = 12 : i32}
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_vector_clone_tensor_op(%arg0: memref<?xi8>, %arg1: memref<?xi8>) attributes {global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c10_i64 = arith.constant 10 : i64
+    %c1_f32 = arith.constant 1.000000e+00 : f32
+    %t1 = tensor.empty() : tensor<256x64xf32>
+    scope.scope : () -> () {
+      %0 = tensor.empty() : tensor<256x64xf32>
+      scf.for %arg2 = %c0_i64 to %c10_i64 step %c1_i64  : i64 {
+        %1 = tensor.empty() {ssbuffer.block_id = 11 : i32} : tensor<256x64xf32>
+        %2 = arith.addf %1, %t1 {ssbuffer.block_id = 12 : i32} : tensor<256x64xf32>
+        %3 = linalg.fill {ssbuffer.block_id = 12 : i32} ins(%c1_f32 : f32) outs(%2 : tensor<256x64xf32>) -> tensor<256x64xf32>
+      } {ssbuffer.block_id = 10 : i32, ssbuffer.main_loop = 0 : i32}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return {ssbuffer.core_type = "VECTOR"}
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/fixpipe_opt.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/fixpipe_opt.mlir
@@ -202,37 +202,39 @@ module {
     return
   }
 
-  // Test 12: mulf with splat constant tensor - should match (scalar-like via constant splat)
+  // Test 12: mulf with splat constant tensor - should NOT match (no hint)
   // CHECK-LABEL: func @test_mulf_with_scalar_constant
   func.func @test_mulf_with_scalar_constant(%arg0: memref<128x64xf32> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>) {
     %c0 = arith.constant 0 : index
     // CHECK: linalg.matmul {ssbuffer.block_id = 111 : i32, ssbuffer.core_type = "CUBE"}
     %matmul = linalg.matmul {ssbuffer.block_id = 111 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
-    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 111 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: arith.constant dense<0.00392{{.*}} : tensor<64x64xf32>
     %scale_tensor = arith.constant dense<0.003921568627> : tensor<64x64xf32>
+    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 112 : i32, ssbuffer.core_type = "VECTOR"}
     %mulf = arith.mulf %matmul, %scale_tensor {ssbuffer.block_id = 112 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
-    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 111 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 113 : i32, ssbuffer.core_type = "VECTOR"}
     %extract = tensor.extract_slice %mulf[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 113 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf32>
-    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 111 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 114 : i32, ssbuffer.core_type = "VECTOR"}
     %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 114 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf32> to memref<64x64xf32, strided<[64, 1]>>
-    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 111 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 115 : i32, ssbuffer.core_type = "VECTOR"}
     bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 115 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf32>, memref<64x64xf32, strided<[64, 1]>>) -> ()
     return
   }
 
-  // Test 13: mulf with splat constant tensor (reversed order) - should match
+  // Test 13: mulf with splat constant tensor (reversed order) - should NOT match (no hint)
   // CHECK-LABEL: func @test_mulf_with_scalar_constant_reversed
   func.func @test_mulf_with_scalar_constant_reversed(%arg0: memref<128x64xf32> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>) {
     // CHECK: linalg.matmul {ssbuffer.block_id = 121 : i32, ssbuffer.core_type = "CUBE"}
     %matmul = linalg.matmul {ssbuffer.block_id = 121 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
-    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 121 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: arith.constant dense<0.00392{{.*}} : tensor<64x64xf32>
     %scale_tensor = arith.constant dense<0.003921568627> : tensor<64x64xf32>
+    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 122 : i32, ssbuffer.core_type = "VECTOR"}
     %mulf = arith.mulf %scale_tensor, %matmul {ssbuffer.block_id = 122 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>  // scale first, matmul second
-    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 121 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 123 : i32, ssbuffer.core_type = "VECTOR"}
     %extract = tensor.extract_slice %mulf[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 123 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf32>
-    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 121 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 124 : i32, ssbuffer.core_type = "VECTOR"}
     %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 124 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf32> to memref<64x64xf32, strided<[64, 1]>>
-    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 121 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 125 : i32, ssbuffer.core_type = "VECTOR"}
     bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 125 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf32>, memref<64x64xf32, strided<[64, 1]>>) -> ()
     return
   }
@@ -268,38 +270,100 @@ module {
     return
   }
 
-  // Test 16: muli with integer dense constant tensor - should match
+  // Test 16: muli with integer dense constant tensor - should NOT match (no hint)
   // CHECK-LABEL: func @test_mulf_with_int_scalar
   func.func @test_mulf_with_int_scalar(%arg0: memref<128x64xi32> {tt.divisibility = 16 : i32}, %A: tensor<64x64xi16>, %B: tensor<64x64xi16>, %init: tensor<64x64xi32>) {
     // CHECK: linalg.matmul {ssbuffer.block_id = 181 : i32, ssbuffer.core_type = "CUBE"}
     %matmul = linalg.matmul {ssbuffer.block_id = 181 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xi16>, tensor<64x64xi16>) outs(%init : tensor<64x64xi32>) -> tensor<64x64xi32>
-    // CHECK: arith.muli %{{.*}} {ssbuffer.block_id = 181 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: arith.constant dense<255> : tensor<64x64xi32>
     %scale_tensor = arith.constant dense<255> : tensor<64x64xi32>
+    // CHECK: arith.muli %{{.*}} {ssbuffer.block_id = 182 : i32, ssbuffer.core_type = "VECTOR"}
     %mulf = arith.muli %matmul, %scale_tensor {ssbuffer.block_id = 182 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xi32>
-    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 181 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 183 : i32, ssbuffer.core_type = "VECTOR"}
     %extract = tensor.extract_slice %mulf[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 183 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xi32> to tensor<64x64xi32>
-    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 181 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 184 : i32, ssbuffer.core_type = "VECTOR"}
     %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 184 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xi32> to memref<64x64xi32, strided<[64, 1]>>
-    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 181 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 185 : i32, ssbuffer.core_type = "VECTOR"}
     bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 185 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xi32>, memref<64x64xi32, strided<[64, 1]>>) -> ()
     return
   }
 
-  // Test 17: mulf with scale from linalg.fill with scalar arg - should match
+  // Test 17: mulf with scale from linalg.fill with scalar arg - should NOT match (no hint)
   // CHECK-LABEL: func @test_mulf_with_fill_scalar_arg
   func.func @test_mulf_with_fill_scalar_arg(%arg0: memref<128x64xf32> {tt.divisibility = 16 : i32}, %scale: f32, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>, %fill_init: tensor<64x64xf32>) {
     // CHECK: linalg.fill {ssbuffer.block_id = 190 : i32, ssbuffer.core_type = "VECTOR"} ins(%{{.*}} : f32) outs(%{{.*}} : tensor<64x64xf32>) {{.*}}
     %fill = linalg.fill {ssbuffer.block_id = 190 : i32, ssbuffer.core_type = "VECTOR"} ins(%scale : f32) outs(%fill_init : tensor<64x64xf32>) -> tensor<64x64xf32>
     // CHECK: linalg.matmul {ssbuffer.block_id = 191 : i32, ssbuffer.core_type = "CUBE"}
     %matmul = linalg.matmul {ssbuffer.block_id = 191 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
-    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 191 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 192 : i32, ssbuffer.core_type = "VECTOR"}
     %mulf = arith.mulf %matmul, %fill {ssbuffer.block_id = 192 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
-    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 191 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 193 : i32, ssbuffer.core_type = "VECTOR"}
     %extract = tensor.extract_slice %mulf[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 193 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf32>
-    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 191 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 194 : i32, ssbuffer.core_type = "VECTOR"}
     %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 194 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf32> to memref<64x64xf32, strided<[64, 1]>>
-    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 191 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 195 : i32, ssbuffer.core_type = "VECTOR"}
     bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 195 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf32>, memref<64x64xf32, strided<[64, 1]>>) -> ()
+    return
+  }
+
+  // Test 18: mulf with hint enable_fast_tf32_mul - should match
+  // CHECK-LABEL: func @test_mulf_with_hint
+  func.func @test_mulf_with_hint(%arg0: memref<128x64xf32> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>) {
+    %c0 = arith.constant 0 : index
+    // CHECK: linalg.matmul {ssbuffer.block_id = 201 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 201 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK: arith.constant dense<0.00392{{.*}} {ssbuffer.block_id = 201 : i32, ssbuffer.core_type = "CUBE"}
+    %scale_tensor = arith.constant dense<0.003921568627> : tensor<64x64xf32>
+    %mulf = arith.mulf %matmul, %scale_tensor {ssbuffer.block_id = 202 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+    annotation.mark %mulf {enable_fast_tf32_mul} : tensor<64x64xf32>
+    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 201 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: annotation.mark %{{.*}} {enable_fast_tf32_mul, ssbuffer.block_id = 201 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 201 : i32, ssbuffer.core_type = "CUBE"}
+    %extract = tensor.extract_slice %mulf[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 203 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf32>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 201 : i32, ssbuffer.core_type = "CUBE"}
+    %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 204 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf32> to memref<64x64xf32, strided<[64, 1]>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 201 : i32, ssbuffer.core_type = "CUBE"}
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 205 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf32>, memref<64x64xf32, strided<[64, 1]>>) -> ()
+    return
+  }
+
+  // Test 19: mulf with MarkOp but wrong attribute - should NOT match
+  // CHECK-LABEL: func @test_mulf_wrong_hint
+  func.func @test_mulf_wrong_hint(%arg0: memref<128x64xf32> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>) {
+    // CHECK: linalg.matmul {ssbuffer.block_id = 211 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 211 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK: arith.constant dense<0.00392{{.*}} : tensor<64x64xf32>
+    %scale_tensor = arith.constant dense<0.003921568627> : tensor<64x64xf32>
+    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 212 : i32, ssbuffer.core_type = "VECTOR"}
+    %mulf = arith.mulf %matmul, %scale_tensor {ssbuffer.block_id = 212 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+    annotation.mark %mulf {other_attribute} : tensor<64x64xf32>
+    // CHECK: annotation.mark %{{.*}} {other_attribute, ssbuffer.block_id = 212 : i32, ssbuffer.core_type = "VECTOR"}
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 213 : i32, ssbuffer.core_type = "VECTOR"}
+    %extract = tensor.extract_slice %mulf[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 213 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf32>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 214 : i32, ssbuffer.core_type = "VECTOR"}
+    %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 214 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf32> to memref<64x64xf32, strided<[64, 1]>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 215 : i32, ssbuffer.core_type = "VECTOR"}
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 215 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf32>, memref<64x64xf32, strided<[64, 1]>>) -> ()
+    return
+  }
+
+  // Test 20: mulf with fill and hint - should match
+  // CHECK-LABEL: func @test_mulf_fill_with_hint
+  func.func @test_mulf_fill_with_hint(%arg0: memref<128x64xf32> {tt.divisibility = 16 : i32}, %scale: f32, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf32>, %fill_init: tensor<64x64xf32>) {
+    // CHECK: linalg.fill {ssbuffer.block_id = 220 : i32, ssbuffer.core_type = "CUBE"} ins(%{{.*}} : f32) outs(%{{.*}} : tensor<64x64xf32>) {{.*}}
+    %fill = linalg.fill {ssbuffer.block_id = 220 : i32, ssbuffer.core_type = "VECTOR"} ins(%scale : f32) outs(%fill_init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK: linalg.matmul {ssbuffer.block_id = 221 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 221 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    %mulf = arith.mulf %matmul, %fill {ssbuffer.block_id = 222 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+    annotation.mark %mulf {enable_fast_tf32_mul} : tensor<64x64xf32>
+    // CHECK: arith.mulf %{{.*}} {ssbuffer.block_id = 221 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: annotation.mark %{{.*}} {enable_fast_tf32_mul, ssbuffer.block_id = 221 : i32, ssbuffer.core_type = "CUBE"}
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 221 : i32, ssbuffer.core_type = "CUBE"}
+    %extract = tensor.extract_slice %mulf[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 223 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf32>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 221 : i32, ssbuffer.core_type = "CUBE"}
+    %subview = memref.subview %arg0[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 224 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf32> to memref<64x64xf32, strided<[64, 1]>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 221 : i32, ssbuffer.core_type = "CUBE"}
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 225 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf32>, memref<64x64xf32, strided<[64, 1]>>) -> ()
     return
   }
 }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/async_load_hoisting_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/async_load_hoisting_test.mlir
@@ -1,0 +1,212 @@
+// RUN: triton-opt --allow-unregistered-dialect --async-load-hoisting %s | FileCheck %s
+
+// CHECK-LABEL: func.func @test_gm_load_cube_marked
+// Test 1: GM loads feeding Cube compute should be marked
+// GM loads feeding linalg.matmul (Cube compute) need gm_load_bufferable mark
+// Complex scene with subview: memref.copy from subview to subview
+func.func @test_gm_load_cube_marked(
+  %arg0: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %arg1: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %arg2: tensor<128x128xf32>
+) {
+  %c0_i32 = arith.constant {ssbuffer.block_id = 5 : i32} 0 : i32
+  %c128_i32 = arith.constant {ssbuffer.block_id = 5 : i32} 128 : i32
+  %c0 = arith.constant {ssbuffer.block_id = 5 : i32} 0 : index
+  %c1 = arith.constant {ssbuffer.block_id = 5 : i32} 1 : index
+
+  // Load Q from GM - feeds linalg.matmul (Cube compute)
+  // Complex scene: use subview for copy
+  %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [128, 128], strides: [128, 1] {ssbuffer.block_id = 5 : i32} : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+  %alloc = memref.alloc() {ssbuffer.block_id = 5 : i32} : memref<128x128xf16>
+  // subview copy: from reinterpret_cast subview to alloc subview
+  %subview_src = memref.subview %reinterpret_cast[0, 0] [128, 128] [1, 1] {ssbuffer.block_id = 5 : i32} : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+  %subview_dst = memref.subview %alloc[0, 0] [128, 128] [1, 1] {ssbuffer.block_id = 5 : i32} : memref<128x128xf16> to memref<128x128xf16, strided<[128, 1]>>
+  memref.copy %subview_src, %subview_dst {ssbuffer.block_id = 5 : i32} : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16, strided<[128, 1]>>
+  // CHECK: bufferization.to_tensor
+  // CHECK-SAME: gm_load_bufferable
+  %to_tensor = bufferization.to_tensor %alloc {ssbuffer.block_id = 5 : i32} : memref<128x128xf16>
+
+  // Load K from GM - feeds linalg.matmul (Cube compute)
+  // Complex scene: use subview for copy, similar to real code pattern
+  %reinterpret_cast_2 = memref.reinterpret_cast %arg1 to offset: [%c0], sizes: [128, 128], strides: [128, 1] {ssbuffer.block_id = 5 : i32} : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+  %alloc_2 = memref.alloc() {ssbuffer.block_id = 5 : i32} : memref<128x128xf16>
+  // subview copy: from reinterpret_cast subview to alloc subview
+  %subview_src_2 = memref.subview %reinterpret_cast_2[0, 0] [128, 128] [1, 1] {ssbuffer.block_id = 5 : i32} : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+  %subview_dst_2 = memref.subview %alloc_2[0, 0] [128, 128] [1, 1] {ssbuffer.block_id = 5 : i32} : memref<128x128xf16> to memref<128x128xf16, strided<[128, 1]>>
+  memref.copy %subview_src_2, %subview_dst_2 {ssbuffer.block_id = 5 : i32} : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16, strided<[128, 1]>>
+  // CHECK: bufferization.to_tensor
+  // CHECK-SAME: gm_load_bufferable
+  %to_tensor_2 = bufferization.to_tensor %alloc_2 {ssbuffer.block_id = 5 : i32} : memref<128x128xf16>
+
+  // Cube compute: matmul (128x128) x (128x128) = (128x128)
+  %matmul = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 5 : i32} ins(%to_tensor, %to_tensor_2 : tensor<128x128xf16>, tensor<128x128xf16>) outs(%arg2 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+  return
+}
+
+// CHECK-LABEL: func.func @test_gm_load_mask_not_marked
+// Test 2: GM loads feeding arith mask operations (maximumf/minimumf/select) should NOT be marked
+// Element-wise mask ops do not feed Cube, should not be marked
+func.func @test_gm_load_mask_not_marked(
+  %arg0: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %arg1: tensor<128xf32>
+) {
+  %c0 = arith.constant {ssbuffer.block_id = 7 : i32} 0 : index
+
+  // Load from GM feeding arith.maximumf (mask operation) - should NOT be marked
+  %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [128], strides: [1] {ssbuffer.block_id = 7 : i32} : memref<?xf32> to memref<128xf32, strided<[1], offset: ?>>
+  %alloc = memref.alloc() {ssbuffer.block_id = 7 : i32} : memref<128xf32>
+  memref.copy %reinterpret_cast, %alloc {ssbuffer.block_id = 7 : i32} : memref<128xf32, strided<[1], offset: ?>> to memref<128xf32>
+  // CHECK-NOT: gm_load_bufferable
+  %to_tensor = bufferization.to_tensor %alloc {ssbuffer.block_id = 7 : i32} : memref<128xf32>
+
+  // arith.maximumf is a mask operation - result not fed to Cube
+  %max = arith.maximumf %to_tensor, %arg1 {ssbuffer.block_id = 7 : i32} : tensor<128xf32>
+
+  return
+}
+
+// CHECK-LABEL: func.func @test_gm_load_scalar_index_not_marked
+// Test 3: memref.load with scalar (constant) indices should NOT be marked
+// Scalar index load does not mark - memref.load with constant index is not marked
+func.func @test_gm_load_scalar_index_not_marked(
+  %arg0: memref<128x128xf16>,
+  %arg1: tensor<128x128xf32>
+) {
+  %c0 = arith.constant {ssbuffer.block_id = 10 : i32} 0 : index
+
+  // memref.load with scalar indices (constant %c0) - should NOT be marked
+  // This is reading a scalar value from memory, not a GM data tile
+  %loaded = memref.load %arg0[%c0, %c0] {ssbuffer.block_id = 10 : i32} : memref<128x128xf16>
+
+  // The loaded scalar value used in element-wise computation
+  %ext = arith.extf %loaded {ssbuffer.block_id = 10 : i32} : f16 to f32
+  %add = arith.addf %ext, %ext {ssbuffer.block_id = 10 : i32} : f32
+
+  // CHECK-NOT: gm_load_bufferable
+  return
+}
+
+// CHECK-LABEL: func.func @test_gm_load_nonlinear_cast_not_marked
+// Test 4: GM loads with non-linear reinterpret_cast offset should NOT be marked
+// Address that cannot be linearly projected is not marked - reinterpret_cast offset depends on:
+// 1. memref.load reading index as offset
+// 2. scf.for/scf.while iter_arg drives address and yield value is non-linear
+// Complex scene with subview, result feeds Cube (not mask), exclude scenario 2 interference
+func.func @test_gm_load_nonlinear_cast_not_marked(
+  %arg0: memref<1xi64>,
+  %arg1: memref<128x128xf16>,
+  %arg2: tensor<32x128xf16>
+) {
+  %c0 = arith.constant {ssbuffer.block_id = 8 : i32} 0 : index
+  %c1 = arith.constant {ssbuffer.block_id = 8 : i32} 1 : index
+  %c128_i64 = arith.constant {ssbuffer.block_id = 8 : i32} 128 : i64
+  %c128 = arith.constant {ssbuffer.block_id = 8 : i32} 128 : index
+  %c32 = arith.constant {ssbuffer.block_id = 8 : i32} 32 : index
+
+  // ========== Scene 4a: memref.load causes non-linear offset ==========
+  // Step 1: memref.load reads control flow indices from %arg0 (not GM data)
+  %reinterpret_cast_idx = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [1], strides: [1] {ssbuffer.block_id = 8 : i32} : memref<1xi64> to memref<1xi64, strided<[1], offset: ?>>
+  %loaded_idx = memref.load %reinterpret_cast_idx[%c0] {ssbuffer.block_id = 8 : i32} : memref<1xi64, strided<[1], offset: ?>>
+
+  // Step 2: Compute offset using the loaded index - this makes address non-linear
+  %multiplied = arith.muli %loaded_idx, %c128_i64 {ssbuffer.block_id = 8 : i32} : i64
+  %base_offset = arith.index_cast %multiplied {ssbuffer.block_id = 8 : i32} : i64 to index
+
+  // Step 3: reinterpret_cast offset depends on memref.load result - NON-LINEAR
+  %reinterpret_cast = memref.reinterpret_cast %arg1 to offset: [%base_offset], sizes: [32, 128], strides: [128, 1] {ssbuffer.block_id = 8 : i32} : memref<128x128xf16> to memref<32x128xf16, strided<[128, 1], offset: ?>>
+
+  // Step 4: Allocate buffer
+  %alloc = memref.alloc() {ssbuffer.block_id = 8 : i32} : memref<32x128xf16>
+
+  // Step 5: Create subviews
+  %subview_src = memref.subview %reinterpret_cast[0, 0] [%c32, 128] [1, 1] {ssbuffer.block_id = 8 : i32} : memref<32x128xf16, strided<[128, 1], offset: ?>> to memref<?x128xf16, strided<[128, 1], offset: ?>>
+  %subview_dst = memref.subview %alloc[0, 0] [%c32, 128] [1, 1] {ssbuffer.block_id = 8 : i32} : memref<32x128xf16> to memref<?x128xf16, strided<[128, 1]>>
+
+  // Step 6: memref.copy through subviews
+  memref.copy %subview_src, %subview_dst {ssbuffer.block_id = 8 : i32} : memref<?x128xf16, strided<[128, 1], offset: ?>> to memref<?x128xf16, strided<[128, 1]>>
+
+  // Step 7: bufferization.to_tensor - should NOT be marked because offset is non-linear (memref.load)
+  // CHECK-NOT: gm_load_bufferable
+  %to_tensor = bufferization.to_tensor %alloc {ssbuffer.block_id = 8 : i32} : memref<32x128xf16>
+
+  // ========== Scene 4b: scf.for iter_arg causes non-linear offset ==========
+  %for_result:2 = scf.for %i = %c0 to %c128 step %c1 iter_args(%arg_iter = %arg1, %alloc_iter = %alloc) -> (memref<128x128xf16>, memref<32x128xf16>) {
+    %for_offset = arith.index_cast %i {ssbuffer.block_id = 8 : i32} : index to i64
+    %for_offset_index = arith.index_cast %for_offset {ssbuffer.block_id = 8 : i32} : i64 to index
+    %reinterpret_for = memref.reinterpret_cast %arg_iter to offset: [%for_offset_index], sizes: [32, 128], strides: [128, 1] {ssbuffer.block_id = 8 : i32} : memref<128x128xf16> to memref<32x128xf16, strided<[128, 1], offset: ?>>
+    %alloc_for = memref.alloc() {ssbuffer.block_id = 8 : i32} : memref<32x128xf16>
+    memref.copy %reinterpret_for, %alloc_for {ssbuffer.block_id = 8 : i32} : memref<32x128xf16, strided<[128, 1], offset: ?>> to memref<32x128xf16>
+    scf.yield %arg_iter, %alloc_for : memref<128x128xf16>, memref<32x128xf16>
+  }
+  // CHECK-NOT: gm_load_bufferable
+  %to_tensor_for = bufferization.to_tensor %for_result#1 {ssbuffer.block_id = 8 : i32} : memref<32x128xf16>
+
+  // ========== Scene 4c: scf.while causes non-linear offset ==========
+  %while_result:2 = scf.while (%arg_while = %arg1, %arg_while_alloc = %alloc) : (memref<128x128xf16>, memref<32x128xf16>) -> (memref<128x128xf16>, memref<32x128xf16>) {
+    %cond = arith.constant {ssbuffer.block_id = 8 : i32} true
+    scf.condition(%cond) %arg_while, %arg_while_alloc : memref<128x128xf16>, memref<32x128xf16>
+  } do {
+  ^bb0(%arg_while_prev: memref<128x128xf16>, %arg_while_alloc_prev: memref<32x128xf16>):
+    %while_offset_base = arith.constant {ssbuffer.block_id = 8 : i32} 0 : index
+    %reinterpret_while = memref.reinterpret_cast %arg_while_prev to offset: [%while_offset_base], sizes: [32, 128], strides: [128, 1] {ssbuffer.block_id = 8 : i32} : memref<128x128xf16> to memref<32x128xf16, strided<[128, 1], offset: ?>>
+    %alloc_while = memref.alloc() {ssbuffer.block_id = 8 : i32} : memref<32x128xf16>
+    memref.copy %reinterpret_while, %alloc_while {ssbuffer.block_id = 8 : i32} : memref<32x128xf16, strided<[128, 1], offset: ?>> to memref<32x128xf16>
+    scf.yield %arg_while_prev, %alloc_while : memref<128x128xf16>, memref<32x128xf16>
+  }
+  // CHECK-NOT: gm_load_bufferable
+  %to_tensor_while = bufferization.to_tensor %while_result#1 {ssbuffer.block_id = 8 : i32} : memref<32x128xf16>
+
+  // ========== Feeds Cube compute ==========
+  %add = arith.addf %to_tensor, %to_tensor {ssbuffer.block_id = 8 : i32} : tensor<32x128xf16>
+
+  return
+}
+
+// CHECK-LABEL: func.func @test_gm_load_non_gm_source_not_marked
+// Test 5: bufferization.to_tensor with non-GM source should NOT be marked
+// Data from non-GM is not marked - readback from internal compute (non-GM load) is not marked
+func.func @test_gm_load_non_gm_source_not_marked(
+  %arg0: tensor<32x256xf32>
+) {
+  // Step 1: Allocate a new buffer (NOT loaded from GM)
+  %alloc = memref.alloc() {ssbuffer.block_id = 26 : i32} : memref<32x256xf32>
+
+  // Step 2: bufferization.to_tensor from internal alloc (NOT from GM) - should NOT be marked
+  // CHECK-NOT: gm_load_bufferable
+  %to_tensor = bufferization.to_tensor %alloc {ssbuffer.block_id = 26 : i32} : memref<32x256xf32>
+
+  // The loaded data is used in element-wise operations (not Cube compute)
+  %broadcasted = linalg.broadcast ins(%to_tensor : tensor<32x256xf32>) outs(%arg0 : tensor<32x256xf32>) dimensions = [] {ssbuffer.block_id = 26 : i32}
+
+  return
+}
+
+// CHECK-LABEL: func.func @test_gm_load_cross_block_marked
+// Test 6: Cross-block chain with block argument source should be marked
+// Cross-block address generation chain but source is block argument (%arg), should be marked
+// Scene: bufferization.to_tensor -> memref.copy -> memref.subview -> reinterpret_cast -> %arg
+// alloc's block_id differs from copy's block_id, but since source is %arg, hasBlockArg=true
+func.func @test_gm_load_cross_block_marked(
+  %arg0: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32},
+  %arg1: tensor<128x128xf32>
+) {
+  %c0_i32 = arith.constant {ssbuffer.block_id = 10 : i32} 0 : i32
+  %c128_i32 = arith.constant {ssbuffer.block_id = 10 : i32} 128 : i32
+  %c0 = arith.constant {ssbuffer.block_id = 10 : i32} 0 : index
+  %c1 = arith.constant {ssbuffer.block_id = 10 : i32} 1 : index
+
+  // GM load chain: bufferization.to_tensor -> copy -> subview -> reinterpret_cast -> %arg0
+  // Note: alloc block_id=10, copy block_id=11, subview block_id=11
+  // But since source is %arg0 (block argument), hasBlockArg=true, should be marked
+  %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [128, 128], strides: [128, 1] {ssbuffer.block_id = 11 : i32} : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+  %alloc = memref.alloc() {ssbuffer.block_id = 10 : i32} : memref<128x128xf16>
+  %subview_src = memref.subview %reinterpret_cast[0, 0] [128, 128] [1, 1] {ssbuffer.block_id = 11 : i32} : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16, strided<[128, 1], offset: ?>>
+  %subview_dst = memref.subview %alloc[0, 0] [128, 128] [1, 1] {ssbuffer.block_id = 11 : i32} : memref<128x128xf16> to memref<128x128xf16, strided<[128, 1]>>
+  memref.copy %subview_src, %subview_dst {ssbuffer.block_id = 11 : i32} : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16, strided<[128, 1]>>
+  // CHECK: bufferization.to_tensor
+  // CHECK-SAME: gm_load_bufferable
+  %0 = bufferization.to_tensor %alloc {ssbuffer.block_id = 11 : i32} : memref<128x128xf16>
+
+  return
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/basic_transform_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/basic_transform_test.mlir
@@ -47,7 +47,7 @@ func.func @tc_b01_double_buffer_basic(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %qk : tensor<128x128xf32>
   }
@@ -83,7 +83,7 @@ func.func @tc_b02_no_marker_pass_through(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable : memref<128x128xf16>
   }
   return
 }
@@ -114,7 +114,7 @@ func.func @tc_b03_trip_count_too_small(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
   }
   return
 }
@@ -142,7 +142,7 @@ func.func @tc_b03b_trip_count_minimal_valid(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
   }
   return
 }
@@ -174,7 +174,7 @@ func.func @tc_b13_no_backing_alloc_skip(
     %row_off = arith.muli %iv_idx, %c128 : index
     // No alloc - direct reinterpret_cast used as to_tensor source
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
-    %q_tensor = bufferization.to_tensor %q_src_rc restrict writable {gm_load_bufferable} : memref<128x128xf16, strided<[128, 1], offset: ?>> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_src_rc restrict writable {gm_load_bufferable} : memref<128x128xf16, strided<[128, 1], offset: ?>>
   }
   return
 }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/complex_scenarios_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/complex_scenarios_test.mlir
@@ -40,12 +40,12 @@ func.func @tc_b10_multiple_loads_same_loop(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
 
     %k_src_rc = memref.reinterpret_cast %arg1 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %k_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %k_src_rc, %k_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %k_tensor = bufferization.to_tensor %k_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %k_tensor = bufferization.to_tensor %k_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
 
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %k_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %qk : tensor<128x128xf32>
@@ -89,7 +89,7 @@ func.func @tc_b11_nested_loops_inner_first(
       %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
       %q_alloc = memref.alloc () : memref<128x128xf16>
       memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-      %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+      %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
       %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%inner_acc : tensor<128x128xf32>) -> tensor<128x128xf32>
       scf.yield %qk : tensor<128x128xf32>
     }
@@ -126,7 +126,7 @@ func.func @tc_b12_linear_iter_arg_delta(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
     %acc_dummy = tensor.empty() : tensor<128x128xf32>
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc_dummy : tensor<128x128xf32>) -> tensor<128x128xf32>
 
@@ -141,7 +141,7 @@ func.func @tc_b12_linear_iter_arg_delta(
   %final_view = memref.reinterpret_cast %arg0 to offset: [%final_row], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
   %final_alloc = memref.alloc() : memref<128x128xf16>
   memref.copy %final_view, %final_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-  %final_tensor = bufferization.to_tensor %final_alloc restrict writable : memref<128x128xf16> to tensor<128x128xf16>
+  %final_tensor = bufferization.to_tensor %final_alloc restrict writable : memref<128x128xf16>
   %ext = arith.extf %final_tensor : tensor<128x128xf16> to tensor<128x128xf32>
   %sum = arith.addf %ext, %arg1 : tensor<128x128xf32>
   return %sum : tensor<128x128xf32>
@@ -185,12 +185,12 @@ func.func @tc_b18_multi_load_with_orig_iter_args(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
 
     %k_src_rc = memref.reinterpret_cast %arg1 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %k_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %k_src_rc, %k_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %k_tensor = bufferization.to_tensor %k_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %k_tensor = bufferization.to_tensor %k_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
 
     %acc_new = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %k_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %acc_new, %lse : tensor<128x128xf32>, tensor<128xf32>
@@ -226,7 +226,7 @@ func.func @tc_b19_bf16_data_type(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xbf16> to memref<128x128xbf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xbf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xbf16, strided<[128, 1], offset: ?>> to memref<128x128xbf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xbf16> to tensor<128x128xbf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xbf16>
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %qk : tensor<128x128xf32>
   }
@@ -266,7 +266,7 @@ func.func @tc_b20_outer_loop_marked_only(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%outer_acc : tensor<128x128xf32>) -> tensor<128x128xf32>
 
     // Inner loop with no marked load
@@ -307,7 +307,7 @@ func.func @tc_b21_index_iv_type(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %qk : tensor<128x128xf32>
   }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/gm_load_multi_buffer_block_id_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/gm_load_multi_buffer_block_id_test.mlir
@@ -160,14 +160,14 @@ func.func @_attn_bwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf
       %14:2 = scf.for %arg19 = %c0_i32 to %c128_i32 step %c1_i32 iter_args(%arg20 = %1, %arg21 = %1) -> (tensor<64x128xf32>, tensor<64x128xf32>)  : i32 {
         hivm.hir.sync_block_wait {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 4
         %memspacecast = memref.memory_space_cast %alloc_4 {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 3 : i32} : memref<64x64xf32, #hivm.address_space<ub>> to memref<64x64xf32>
-        %23 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 3 : i32} : memref<64x64xf32> to tensor<64x64xf32>
+        %23 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 3 : i32} : memref<64x64xf32>
         %24 = arith.muli %arg19, %c64_i32 {MixUse, ssbuffer.block_id = 7 : i32} : i32
         %25 = arith.index_cast %24 {ssbuffer.block_id = 7 : i32} : i32 to index
         %26 = arith.addi %13, %25 {ssbuffer.block_id = 7 : i32} : index
         %reinterpret_cast_10 = memref.reinterpret_cast %arg9 to offset: [%26], sizes: [64], strides: [1] {ssbuffer.block_id = 7 : i32} : memref<?xf32> to memref<64xf32, strided<[1], offset: ?>>
         %alloc_11 = memref.alloc() {ssbuffer.block_id = 7 : i32} : memref<64xf32>
         memref.copy %reinterpret_cast_10, %alloc_11 {ssbuffer.block_id = 7 : i32} : memref<64xf32, strided<[1], offset: ?>> to memref<64xf32>
-        %27 = bufferization.to_tensor %alloc_11 restrict writable {gm_load_bufferable, ssbuffer.block_id = 7 : i32} : memref<64xf32> to tensor<64xf32>
+        %27 = bufferization.to_tensor %alloc_11 restrict writable {gm_load_bufferable, ssbuffer.block_id = 7 : i32} : memref<64xf32>
         %28 = arith.addf %23, %3 {ssbuffer.block_id = 7 : i32} : tensor<64x64xf32>
         %29 = arith.mulf %28, %4 {DataUse, ssbuffer.block_id = 7 : i32} : tensor<64x64xf32>
         %broadcasted = linalg.broadcast ins(%27 : tensor<64xf32>) outs(%2 : tensor<64x64xf32>) dimensions = [1]  {ssbuffer.block_id = 7 : i32}
@@ -184,11 +184,11 @@ func.func @_attn_bwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf
         hivm.hir.sync_block_set {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 4
         hivm.hir.sync_block_wait {ssbuffer.block_id = 8 : i32, ssbuffer.transfer_id = 4 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 5
         %memspacecast_13 = memref.memory_space_cast %alloc_5 {ssbuffer.block_id = 8 : i32, ssbuffer.transfer_id = 4 : i32} : memref<64x64xf32, #hivm.address_space<ub>> to memref<64x64xf32>
-        %34 = bufferization.to_tensor %memspacecast_13 restrict writable {ssbuffer.block_id = 8 : i32, ssbuffer.transfer_id = 4 : i32} : memref<64x64xf32> to tensor<64x64xf32>
+        %34 = bufferization.to_tensor %memspacecast_13 restrict writable {ssbuffer.block_id = 8 : i32, ssbuffer.transfer_id = 4 : i32} : memref<64x64xf32>
         %reinterpret_cast_14 = memref.reinterpret_cast %arg10 to offset: [%26], sizes: [64], strides: [1] {ssbuffer.block_id = 8 : i32} : memref<?xf32> to memref<64xf32, strided<[1], offset: ?>>
         %alloc_15 = memref.alloc() {ssbuffer.block_id = 8 : i32} : memref<64xf32>
         memref.copy %reinterpret_cast_14, %alloc_15 {ssbuffer.block_id = 8 : i32} : memref<64xf32, strided<[1], offset: ?>> to memref<64xf32>
-        %35 = bufferization.to_tensor %alloc_15 restrict writable {gm_load_bufferable, ssbuffer.block_id = 8 : i32} : memref<64xf32> to tensor<64xf32>
+        %35 = bufferization.to_tensor %alloc_15 restrict writable {gm_load_bufferable, ssbuffer.block_id = 8 : i32} : memref<64xf32>
         %36 = arith.addf %34, %3 {ssbuffer.block_id = 8 : i32} : tensor<64x64xf32>
         %broadcasted_16 = linalg.broadcast ins(%35 : tensor<64xf32>) outs(%2 : tensor<64x64xf32>) dimensions = [1]  {ssbuffer.block_id = 8 : i32}
         %37 = arith.subf %36, %broadcasted_16 {DataUse, ssbuffer.block_id = 8 : i32} : tensor<64x64xf32>
@@ -209,13 +209,13 @@ func.func @_attn_bwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf
         hivm.hir.sync_block_set {ssbuffer.block_id = 8 : i32, ssbuffer.transfer_id = 4 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 5
         hivm.hir.sync_block_wait {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 7 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 8
         %memspacecast_20 = memref.memory_space_cast %alloc_8 {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 7 : i32} : memref<64x128xf32, #hivm.address_space<ub>> to memref<64x128xf32>
-        %43 = bufferization.to_tensor %memspacecast_20 restrict writable {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 7 : i32} : memref<64x128xf32> to tensor<64x128xf32>
+        %43 = bufferization.to_tensor %memspacecast_20 restrict writable {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 7 : i32} : memref<64x128xf32>
         hivm.hir.sync_block_wait {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 6 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 7
         %memspacecast_21 = memref.memory_space_cast %alloc_7 {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 6 : i32} : memref<64x128xf32, #hivm.address_space<ub>> to memref<64x128xf32>
-        %44 = bufferization.to_tensor %memspacecast_21 restrict writable {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 6 : i32} : memref<64x128xf32> to tensor<64x128xf32>
+        %44 = bufferization.to_tensor %memspacecast_21 restrict writable {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 6 : i32} : memref<64x128xf32>
         hivm.hir.sync_block_wait {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 5 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 6
         %memspacecast_22 = memref.memory_space_cast %alloc_6 {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 5 : i32} : memref<64x128xf32, #hivm.address_space<ub>> to memref<64x128xf32>
-        %45 = bufferization.to_tensor %memspacecast_22 restrict writable {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 5 : i32} : memref<64x128xf32> to tensor<64x128xf32>
+        %45 = bufferization.to_tensor %memspacecast_22 restrict writable {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 5 : i32} : memref<64x128xf32>
         %46 = arith.muli %25, %c128 {ssbuffer.block_id = 9 : i32} : index
         %47 = arith.addi %12, %46 {ssbuffer.block_id = 9 : i32} : index
         %48 = arith.addf %44, %arg21 {ssbuffer.block_id = 9 : i32} : tensor<64x128xf32>
@@ -487,17 +487,17 @@ func.func @_attn_bwd_complex(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: me
 
         hivm.hir.sync_block_wait {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 7 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 8
         %memspacecast = memref.memory_space_cast %alloc_9 {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 7 : i32} : memref<64x32xf32, #hivm.address_space<ub>> to memref<64x32xf32>
-        %132 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 7 : i32} : memref<64x32xf32> to tensor<64x32xf32>
+        %132 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 7 : i32} : memref<64x32xf32>
         hivm.hir.sync_block_wait {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 5 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 6
         %memspacecast_25 = memref.memory_space_cast %alloc_7 {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 5 : i32} : memref<64x32xf32, #hivm.address_space<ub>> to memref<64x32xf32>
-        %133 = bufferization.to_tensor %memspacecast_25 restrict writable {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 5 : i32} : memref<64x32xf32> to tensor<64x32xf32>
+        %133 = bufferization.to_tensor %memspacecast_25 restrict writable {ssbuffer.block_id = 13 : i32, ssbuffer.transfer_id = 5 : i32} : memref<64x32xf32>
         %134 = arith.addf %133, %1 {ssbuffer.block_id = 13 : i32} : tensor<64x32xf32>
         %135 = arith.addf %132, %134 {ssbuffer.block_id = 13 : i32} : tensor<64x32xf32>
         %reinterpret_cast_26 = memref.reinterpret_cast %arg3 to offset: [%107], sizes: [64, 32], strides: [4096, 1] {ssbuffer.block_id = 13 : i32} : memref<?xbf16> to memref<64x32xbf16, strided<[4096, 1], offset: ?>>
         %subview_27 = memref.subview %reinterpret_cast_26[0, 0] [%118, %120] [1, 1] {ssbuffer.block_id = 13 : i32} : memref<64x32xbf16, strided<[4096, 1], offset: ?>> to memref<?x?xbf16, strided<[4096, 1], offset: ?>>
         %subview_28 = memref.subview %alloc_23[%117, %119] [%118, %120] [1, 1] {ssbuffer.block_id = 13 : i32} : memref<64x32xbf16> to memref<?x?xbf16, strided<[32, 1], offset: ?>>
         memref.copy %subview_27, %subview_28 {ssbuffer.block_id = 13 : i32} : memref<?x?xbf16, strided<[4096, 1], offset: ?>> to memref<?x?xbf16, strided<[32, 1], offset: ?>>
-        %136 = bufferization.to_tensor %alloc_23 restrict writable {gm_load_bufferable, ssbuffer.block_id = 13 : i32} : memref<64x32xbf16> to tensor<64x32xbf16>
+        %136 = bufferization.to_tensor %alloc_23 restrict writable {gm_load_bufferable, ssbuffer.block_id = 13 : i32} : memref<64x32xbf16>
         %137 = arith.extf %136 {DataUse, ssbuffer.block_id = 13 : i32} : tensor<64x32xbf16> to tensor<64x32xf32>
         %138 = arith.subf %137, %135 {DataUse, ssbuffer.block_id = 13 : i32} : tensor<64x32xf32>
         %reinterpret_cast_29 = memref.reinterpret_cast %arg5 to offset: [%107], sizes: [64, 32], strides: [4096, 1] {ssbuffer.block_id = 13 : i32} : memref<?xbf16> to memref<64x32xbf16, strided<[4096, 1], offset: ?>>
@@ -520,7 +520,7 @@ func.func @_attn_bwd_complex(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: me
         %subview_34 = memref.subview %reinterpret_cast_33[0] [%130] [1] {ssbuffer.block_id = 13 : i32} : memref<64xf32, strided<[32], offset: ?>> to memref<?xf32, strided<[32], offset: ?>>
         %subview_35 = memref.subview %alloc_24[%129] [%130] [1] {ssbuffer.block_id = 13 : i32} : memref<64xf32> to memref<?xf32, strided<[1], offset: ?>>
         memref.copy %subview_34, %subview_35 {ssbuffer.block_id = 13 : i32} : memref<?xf32, strided<[32], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-        %150 = bufferization.to_tensor %alloc_24 restrict writable {gm_load_bufferable, ssbuffer.block_id = 13 : i32} : memref<64xf32> to tensor<64xf32>
+        %150 = bufferization.to_tensor %alloc_24 restrict writable {gm_load_bufferable, ssbuffer.block_id = 13 : i32} : memref<64xf32>
         %151 = linalg.fill {ssbuffer.block_id = 13 : i32} ins(%148 : f32) outs(%2 : tensor<64xf32>) -> tensor<64xf32>
         %152 = arith.subf %151, %150 {DataUse, ssbuffer.block_id = 13 : i32} : tensor<64xf32>
         %153 = math.exp2 %152 {DataUse, ssbuffer.block_id = 13 : i32} : tensor<64xf32>
@@ -558,10 +558,10 @@ func.func @_attn_bwd_complex(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: me
 
         hivm.hir.sync_block_wait {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 6 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 7
         %memspacecast_40 = memref.memory_space_cast %alloc_8 {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 6 : i32} : memref<64x32xf32, #hivm.address_space<ub>> to memref<64x32xf32>
-        %163 = bufferization.to_tensor %memspacecast_40 restrict writable {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 6 : i32} : memref<64x32xf32> to tensor<64x32xf32>
+        %163 = bufferization.to_tensor %memspacecast_40 restrict writable {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 6 : i32} : memref<64x32xf32>
         hivm.hir.sync_block_wait {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 4 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 5
         %memspacecast_41 = memref.memory_space_cast %alloc_6 {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 4 : i32} : memref<64x32xf32, #hivm.address_space<ub>> to memref<64x32xf32>
-        %164 = bufferization.to_tensor %memspacecast_41 restrict writable {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 4 : i32} : memref<64x32xf32> to tensor<64x32xf32>
+        %164 = bufferization.to_tensor %memspacecast_41 restrict writable {ssbuffer.block_id = 14 : i32, ssbuffer.transfer_id = 4 : i32} : memref<64x32xf32>
         %165 = tensor.empty() {ssbuffer.block_id = 14 : i32} : tensor<1xf32>
         %inserted = tensor.insert %148 into %165[%c0] {ssbuffer.block_id = 14 : i32} : tensor<1xf32>
         %166 = math.exp2 %inserted {DataUse, ssbuffer.block_id = 14 : i32} : tensor<1xf32>
@@ -680,7 +680,7 @@ func.func @_attn_fwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf
         %6:5 = scf.for %arg17 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg18 = %1, %arg19 = %5, %arg20 = %4, %arg21 = %c0_i32, %arg22 = %c0_i32) -> (tensor<128x128xf32>, tensor<128xf32>, tensor<128xf32>, i32, i32)  : i32 {
           hivm.hir.sync_block_wait {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 2
           %memspacecast = memref.memory_space_cast %alloc_5 {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>> to memref<128x128xf32>
-          %30 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32> to tensor<128x128xf32>
+          %30 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32>
           %31 = arith.mulf %30, %2 {ssbuffer.block_id = 5 : i32} : tensor<128x128xf32>
           %reduced = linalg.reduce ins(%31 : tensor<128x128xf32>) outs(%4 : tensor<128xf32>) dimensions = [1]  {ssbuffer.block_id = 5 : i32}
             (%in: f32, %init: f32) {
@@ -704,7 +704,7 @@ func.func @_attn_fwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf
           hivm.hir.sync_block_set {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 2
           hivm.hir.sync_block_wait {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 2 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 3
           %memspacecast_10 = memref.memory_space_cast %alloc_6 {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32, #hivm.address_space<ub>> to memref<128x128xf32>
-          %37 = bufferization.to_tensor %memspacecast_10 restrict writable {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32> to tensor<128x128xf32>
+          %37 = bufferization.to_tensor %memspacecast_10 restrict writable {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32>
           %38 = linalg.fill {ssbuffer.block_id = 7 : i32} ins(%cst_1 : f32) outs(%3 : tensor<128xf32>) -> tensor<128xf32>
           %reduced_11 = linalg.reduce ins(%34 : tensor<128x128xf32>) outs(%38 : tensor<128xf32>) dimensions = [1]  {ssbuffer.block_id = 7 : i32}
             (%in: f32, %init: f32) {
@@ -846,7 +846,7 @@ func.func @_attn_fwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf
         %22 = arith.index_cast %15 {ssbuffer.block_id = 2 : i32} : i64 to index
         %alloc = memref.alloc() {ssbuffer.block_id = 2 : i32} : memref<128x128xf16>
         memref.copy %reinterpret_cast, %alloc {ssbuffer.block_id = 2 : i32} : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-        %23 = bufferization.to_tensor %alloc restrict writable {gm_load_bufferable, ssbuffer.block_id = 2 : i32} : memref<128x128xf16> to tensor<128x128xf16>
+        %23 = bufferization.to_tensor %alloc restrict writable {gm_load_bufferable, ssbuffer.block_id = 2 : i32} : memref<128x128xf16>
         %alloc_5 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
         annotation.mark %alloc_5 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
         hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 1
@@ -861,7 +861,7 @@ func.func @_attn_fwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf
           %reinterpret_cast_8 = memref.reinterpret_cast %arg3 to offset: [%27], sizes: [128, 128], strides: [128, 1] {ssbuffer.block_id = 0 : i32} : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
           %alloc_9 = memref.alloc() {ssbuffer.block_id = 0 : i32} : memref<128x128xf16>
           memref.copy %reinterpret_cast_8, %alloc_9 {ssbuffer.block_id = 0 : i32} : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-          %28 = bufferization.to_tensor %alloc_9 restrict writable {gm_load_bufferable, ssbuffer.block_id = 0 : i32} : memref<128x128xf16> to tensor<128x128xf16>
+          %28 = bufferization.to_tensor %alloc_9 restrict writable {gm_load_bufferable, ssbuffer.block_id = 0 : i32} : memref<128x128xf16>
           %29 = tensor.empty() {ssbuffer.block_id = 0 : i32} : tensor<128x128xf16>
           %transposed = linalg.transpose ins(%28 : tensor<128x128xf16>) outs(%29 : tensor<128x128xf16>) permutation = [1, 0]  {ssbuffer.block_id = 0 : i32}
           %30 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 0 : i32} ins(%23, %transposed : tensor<128x128xf16>, tensor<128x128xf16>) outs(%1 : tensor<128x128xf32>) -> tensor<128x128xf32>
@@ -871,14 +871,14 @@ func.func @_attn_fwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf
           hivm.hir.sync_block_wait {ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
           %31 = hivm.hir.convert_layout %alloc_5 output_shape [128, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 0 : i32} : (memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) -> memref<128x128xf16, #hivm.address_space<cbuf>>
           %memspacecast = memref.memory_space_cast %31 {ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 0 : i32} : memref<128x128xf16, #hivm.address_space<cbuf>> to memref<128x128xf16>
-          %32 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 0 : i32} : memref<128x128xf16> to tensor<128x128xf16>
+          %32 = bufferization.to_tensor %memspacecast restrict writable {ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 0 : i32} : memref<128x128xf16>
           %33 = arith.index_cast %arg19 {ssbuffer.block_id = 1 : i32} : i32 to index
           %34 = arith.muli %33, %c128 {ssbuffer.block_id = 1 : i32} : index
           %35 = arith.addi %34, %22 {ssbuffer.block_id = 1 : i32} : index
           %reinterpret_cast_10 = memref.reinterpret_cast %arg4 to offset: [%35], sizes: [128, 128], strides: [128, 1] {ssbuffer.block_id = 1 : i32} : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
           %alloc_11 = memref.alloc() {ssbuffer.block_id = 1 : i32} : memref<128x128xf16>
           memref.copy %reinterpret_cast_10, %alloc_11 {ssbuffer.block_id = 1 : i32} : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-          %36 = bufferization.to_tensor %alloc_11 restrict writable {gm_load_bufferable, ssbuffer.block_id = 1 : i32} : memref<128x128xf16> to tensor<128x128xf16>
+          %36 = bufferization.to_tensor %alloc_11 restrict writable {gm_load_bufferable, ssbuffer.block_id = 1 : i32} : memref<128x128xf16>
           %37 = tensor.empty() {ssbuffer.block_id = 1 : i32} : tensor<128x128xf32>
           %38 = linalg.fill {ssbuffer.block_id = 1 : i32} ins(%cst_1 : f32) outs(%37 : tensor<128x128xf32>) -> tensor<128x128xf32>
           %39 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 1 : i32} ins(%32, %36 : tensor<128x128xf16>, tensor<128x128xf16>) outs(%38 : tensor<128x128xf32>) -> tensor<128x128xf32>

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/producer_consumer_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/producer_consumer_test.mlir
@@ -32,7 +32,7 @@ func.func @tc_b04_iv_projection(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %qk : tensor<128x128xf32>
   }
@@ -71,7 +71,7 @@ func.func @tc_b04b_iv_projection_runtime_lb(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %qk : tensor<128x128xf32>
   }
@@ -107,7 +107,7 @@ func.func @tc_b06_preserve_original_iter_args(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
     %acc_new = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %acc_new, %lse : tensor<128x128xf32>, tensor<128xf32>
   }
@@ -151,12 +151,12 @@ func.func @tc_b07_dead_dma_elimination(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
 
     %k_src_rc = memref.reinterpret_cast %arg1 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %k_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %k_src_rc, %k_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %k_tensor = bufferization.to_tensor %k_alloc restrict writable : memref<128x128xf16> to tensor<128x128xf16>
+    %k_tensor = bufferization.to_tensor %k_alloc restrict writable : memref<128x128xf16>
 
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %k_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %qk : tensor<128x128xf32>
@@ -195,7 +195,7 @@ func.func @tc_b16_flag_counter_init(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %qk : tensor<128x128xf32>
   }
@@ -230,7 +230,7 @@ func.func @tc_b17_producer_condition_structure(
     %q_src_rc = memref.reinterpret_cast %arg0 to offset: [%row_off], sizes: [128, 128], strides: [128, 1] : memref<?xf16> to memref<128x128xf16, strided<[128, 1], offset: ?>>
     %q_alloc = memref.alloc () : memref<128x128xf16>
     memref.copy %q_src_rc, %q_alloc : memref<128x128xf16, strided<[128, 1], offset: ?>> to memref<128x128xf16>
-    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16> to tensor<128x128xf16>
+    %q_tensor = bufferization.to_tensor %q_alloc restrict writable {gm_load_bufferable} : memref<128x128xf16>
     %qk = linalg.matmul {input_precision = "ieee"} ins(%q_tensor, %q_tensor : tensor<128x128xf16>, tensor<128x128xf16>) outs(%acc : tensor<128x128xf32>) -> tensor<128x128xf32>
     scf.yield %qk : tensor<128x128xf32>
   }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/subview_noncopy_user.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/subview_noncopy_user.mlir
@@ -1,0 +1,39 @@
+// RUN: triton-opt --allow-unregistered-dialect --async-load-hoisting %s | FileCheck %s
+
+// Unit Test: SubViewOp with non-CopyOp users
+// Regression test for: segfault when a SubViewOp result has users that are
+// NOT memref::CopyOp (e.g., bufferization.to_tensor).
+// Previously, llvm::dyn_cast<memref::CopyOp> would return nullptr, and
+// visited.insert(nullptr).second would succeed, passing nullptr down the
+// recursion chain, causing a crash.
+
+module {
+  func.func @subview_noncopy_users(%arg0: memref<?xf16>, %arg1: i64) {
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %c32 = arith.constant 32 : index
+
+    // block_id=10: cache group with annotation.mark
+    %alloc = memref.alloc() {ssbuffer.block_id = 10 : i32} : memref<128x32xf16>
+
+    %offset = arith.index_cast %arg1 {ssbuffer.block_id = 10 : i32} : i64 to index
+    %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [%offset], sizes: [1, 32], strides: [32, 1] {ssbuffer.block_id = 10 : i32} : memref<?xf16> to memref<1x32xf16, strided<[32, 1], offset: ?>>
+    %subview = memref.subview %alloc[%c0, %c0] [1, 32] [1, 1] {ssbuffer.block_id = 10 : i32} : memref<128x32xf16> to memref<1x32xf16, strided<[32, 1], offset: ?>>
+    memref.copy %reinterpret_cast, %subview {ssbuffer.block_id = 10 : i32} : memref<1x32xf16, strided<[32, 1], offset: ?>> to memref<1x32xf16, strided<[32, 1], offset: ?>>
+
+    // Key: bufferization.to_tensor uses %subview but is NOT a CopyOp
+    // CHECK: bufferization.to_tensor
+    %tensor = bufferization.to_tensor %subview {ssbuffer.block_id = 10 : i32} : memref<1x32xf16, strided<[32, 1], offset: ?>>
+
+    // annotation.mark uses %alloc — triggers chainContainsBlockArg path
+    annotation.mark %alloc {MayImplicitTransposeWithLastAxis, ssbuffer.block_id = 10 : i32} : memref<128x32xf16>
+
+    // Load from subview using data loaded by CopyOp — should get gm_load_bufferable
+    // CHECK: bufferization.to_tensor
+    // CHECK-SAME: gm_load_bufferable
+    %subview_2 = memref.subview %alloc[%c0, %c0] [1, 32] [1, 1] {ssbuffer.block_id = 10 : i32} : memref<128x32xf16> to memref<1x32xf16, strided<[32, 1], offset: ?>>
+    %loaded = bufferization.to_tensor %subview_2 {ssbuffer.block_id = 10 : i32} : memref<1x32xf16, strided<[32, 1], offset: ?>>
+
+    return
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/StandardizeOp/split_matmul.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/StandardizeOp/split_matmul.mlir
@@ -5,8 +5,10 @@ module {
   // According to Rule 2, its value is unknown, so we split it.
   // CHECK-LABEL: func.func @case1_block_arg_bias
   // CHECK-SAME: (%[[A:.*]]: tensor<32x64xf32>, %[[B:.*]]: tensor<64x32xf32>, %[[BIAS:.*]]: tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[CST:.*]] = arith.constant 0.000000e+00 : f32
   // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%[[A]], %[[B]] : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ZERO:.*]] = linalg.fill ins(%[[CST]] : f32) outs(%[[EMPTY]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%[[A]], %[[B]] : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD:.*]] = arith.addf %[[MM]], %[[BIAS]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // CHECK: return %[[ADD]] : tensor<32x32xf32>
   func.func @case1_block_arg_bias(%A: tensor<32x64xf32>, %B: tensor<64x32xf32>, %bias: tensor<32x32xf32>) -> tensor<32x32xf32> {
@@ -39,7 +41,8 @@ module {
   // CHECK: %[[EMPTY1:.*]] = tensor.empty() : tensor<32x32xf32>
   // CHECK: %[[ZERO1:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[EMPTY2:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[MM1:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ZERO_MM1:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM1:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO_MM1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD:.*]] = arith.addf %[[MM1]], %[[ZERO1]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // CHECK: %[[EMPTY3:.*]] = tensor.empty() : tensor<32x16xf32>
   // CHECK: %[[ZERO2:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY3]] : tensor<32x16xf32>) -> tensor<32x16xf32>
@@ -61,11 +64,13 @@ module {
   // Case 4: Bias is non-zero (filled with a non-zero constant 1.0).
   // It should be split into a zero-initialized matmul followed by an arith.addf.
   // CHECK-LABEL: func.func @case4_nonzero_bias
+  // CHECK: %[[C0:.*]] = arith.constant 0.000000e+00 : f32
   // CHECK: %[[C1:.*]] = arith.constant 1.000000e+00 : f32
   // CHECK: %[[EMPTY1:.*]] = tensor.empty() : tensor<32x32xf32>
   // CHECK: %[[BIAS:.*]] = linalg.fill ins(%[[C1]] : f32) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[EMPTY2:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ZERO:.*]] = linalg.fill ins(%[[C0]] : f32) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD:.*]] = arith.addf %[[MM]], %[[BIAS]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // CHECK: return %[[ADD]]
   func.func @case4_nonzero_bias(%A: tensor<32x64xf32>, %B: tensor<64x32xf32>) -> tensor<32x32xf32> {
@@ -80,8 +85,10 @@ module {
   // Splitting should generate integer zero constant and use arith.addi for accumulation.
   // CHECK-LABEL: func.func @case5_integer_bias
   // CHECK-SAME: (%[[A:.*]]: tensor<32x64xi32>, %[[B:.*]]: tensor<64x32xi32>, %[[BIAS:.*]]: tensor<32x32xi32>) -> tensor<32x32xi32>
+  // CHECK: %[[C0_I32:.*]] = arith.constant 0 : i32
   // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xi32>
-  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%[[A]], %[[B]] : tensor<32x64xi32>, tensor<64x32xi32>) outs(%[[EMPTY]] : tensor<32x32xi32>) -> tensor<32x32xi32>
+  // CHECK: %[[ZERO:.*]] = linalg.fill ins(%[[C0_I32]] : i32) outs(%[[EMPTY]] : tensor<32x32xi32>) -> tensor<32x32xi32>
+  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%[[A]], %[[B]] : tensor<32x64xi32>, tensor<64x32xi32>) outs(%[[ZERO]] : tensor<32x32xi32>) -> tensor<32x32xi32>
   // CHECK: %[[ADD:.*]] = arith.addi %[[MM]], %[[BIAS]] {ssbuffer.add_from_matmul} : tensor<32x32xi32>
   func.func @case5_integer_bias(%A: tensor<32x64xi32>, %B: tensor<64x32xi32>, %bias: tensor<32x32xi32>) -> tensor<32x32xi32> {
     %mm = linalg.matmul ins(%A, %B : tensor<32x64xi32>, tensor<64x32xi32>) outs(%bias : tensor<32x32xi32>) -> tensor<32x32xi32>
@@ -92,29 +99,33 @@ module {
   // The split logic should fetch dynamic dimension sizes using tensor.dim.
   // CHECK-LABEL: func.func @case6_dynamic_shape
   // CHECK-SAME: (%[[A:.*]]: tensor<?x?xf32>, %[[B:.*]]: tensor<?x?xf32>, %[[BIAS:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32>
+  // CHECK: %[[CST:.*]] = arith.constant 0.000000e+00 : f32
   // CHECK: %[[C1_IDX:.*]] = arith.constant 1 : index
   // CHECK: %[[C0_IDX:.*]] = arith.constant 0 : index
   // CHECK: %[[DIM0:.*]] = tensor.dim %[[BIAS]], %[[C0_IDX]] : tensor<?x?xf32>
   // CHECK: %[[DIM1:.*]] = tensor.dim %[[BIAS]], %[[C1_IDX]] : tensor<?x?xf32>
   // CHECK: %[[EMPTY:.*]] = tensor.empty(%[[DIM0]], %[[DIM1]]) : tensor<?x?xf32>
-  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%[[A]], %[[B]] : tensor<?x?xf32>, tensor<?x?xf32>) outs(%[[EMPTY]] : tensor<?x?xf32>) -> tensor<?x?xf32>
+  // CHECK: %[[ZERO:.*]] = linalg.fill ins(%[[CST]] : f32) outs(%[[EMPTY]] : tensor<?x?xf32>) -> tensor<?x?xf32>
+  // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%[[A]], %[[B]] : tensor<?x?xf32>, tensor<?x?xf32>) outs(%[[ZERO]] : tensor<?x?xf32>) -> tensor<?x?xf32>
   // CHECK: %[[ADD:.*]] = arith.addf %[[MM]], %[[BIAS]] {ssbuffer.add_from_matmul} : tensor<?x?xf32>
   func.func @case6_dynamic_shape(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>, %bias: tensor<?x?xf32>) -> tensor<?x?xf32> {
     %mm = linalg.matmul ins(%A, %B : tensor<?x?xf32>, tensor<?x?xf32>) outs(%bias : tensor<?x?xf32>) -> tensor<?x?xf32>
     return %mm : tensor<?x?xf32>
   }
-  
+
   // Case 7: Matmul inside scf.if with both then and else branches.
   // Both branches have matmul with bias from function argument, so both are split.
   // CHECK-LABEL: func.func @case7_if_else
   // CHECK: scf.if %{{.*}} -> (tensor<32x32xf32>) {
   // CHECK: %[[EMPTY1:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[MM1:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ZERO1:.*]] = linalg.fill ins(%{{.*}} : f32) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM1:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD1:.*]] = arith.addf %[[MM1]], %{{.*}} {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // CHECK: scf.yield %[[ADD1]] : tensor<32x32xf32>
   // CHECK: } else {
   // CHECK: %[[EMPTY2:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[MM2:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ZERO2:.*]] = linalg.fill ins(%{{.*}} : f32) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM2:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD2:.*]] = arith.addf %[[MM2]], %{{.*}} {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // CHECK: scf.yield %[[ADD2]] : tensor<32x32xf32>
   // CHECK: }
@@ -129,7 +140,7 @@ module {
     return %result : tensor<32x32xf32>
   }
 
-// Case 8: Nested scf.for loops with matmul.
+  // Case 8: Nested scf.for loops with matmul.
   // The matmul is in an inner loop with bias as a loop-carried variable with zero initial value.
   // The inner matmul is marked as loop_carried_l0c and not split (no addf).
   // CHECK-LABEL: func.func @case8_nested_for
@@ -147,7 +158,7 @@ module {
     %cst = arith.constant 0.0 : f32
     %empty = tensor.empty() : tensor<32x32xf32>
     %zero_init = linalg.fill ins(%cst : f32) outs(%empty : tensor<32x32xf32>) -> tensor<32x32xf32>
-    
+
     %outer_result = scf.for %outer_iv = %c0 to %c10 step %c1 iter_args(%outer_acc = %zero_init) -> (tensor<32x32xf32>) {
       %inner_result = scf.for %inner_iv = %c0 to %c10 step %c1 iter_args(%bias = %outer_acc) -> (tensor<32x32xf32>) {
         %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias : tensor<32x32xf32>) -> tensor<32x32xf32>
@@ -166,7 +177,8 @@ module {
   // CHECK: %[[EMPTY1:.*]] = tensor.empty() : tensor<32x32xf32>
   // CHECK: %[[NONZERO_INIT:.*]] = linalg.fill ins(%[[CST]] : f32) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[EMPTY2:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[FOR_RESULT:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[EMPTY2]]) -> (tensor<32x32xf32>) {
+  // CHECK: %[[ZERO_FILL:.*]] = linalg.fill ins(%{{.*}} : f32) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[FOR_RESULT:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[ZERO_FILL]]) -> (tensor<32x32xf32>) {
   // CHECK: %[[INNER_RESULT:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %{{.*}}) -> (tensor<32x32xf32>) {
   // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK-NOT: arith.addf
@@ -183,7 +195,7 @@ module {
     %cst = arith.constant 1.0 : f32
     %empty = tensor.empty() : tensor<32x32xf32>
     %nonzero_init = linalg.fill ins(%cst : f32) outs(%empty : tensor<32x32xf32>) -> tensor<32x32xf32>
-    
+
     %outer_result = scf.for %outer_iv = %c0 to %c10 step %c1 iter_args(%outer_acc = %nonzero_init) -> (tensor<32x32xf32>) {
       %inner_result = scf.for %inner_iv = %c0 to %c10 step %c1 iter_args(%bias = %outer_acc) -> (tensor<32x32xf32>) {
         %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias : tensor<32x32xf32>) -> tensor<32x32xf32>
@@ -213,13 +225,16 @@ module {
   // CHECK: %[[EMPTY_D:.*]] = tensor.empty() : tensor<32x32xf32>
   // CHECK: %[[D:.*]] = linalg.fill ins(%[[CST_NONZERO]] : f32) outs(%[[EMPTY_D]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[EMPTY4:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[MM4:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY4]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ZERO4:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY4]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM4:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO4]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD4:.*]] = arith.addf %[[MM4]], %[[D]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // CHECK: %[[EMPTY5:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[MM5:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY5]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ZERO5:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY5]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM5:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO5]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD5:.*]] = arith.addf %[[MM5]], %[[ADD4]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // CHECK: %[[EMPTY6:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[MM6:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[EMPTY6]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ZERO6:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY6]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[MM6:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ZERO6]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[ADD6:.*]] = arith.addf %[[MM6]], %[[ADD5]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // Final combination
   // CHECK: %[[RESULT:.*]] = arith.addf %[[MM3]], %[[ADD6]] : tensor<32x32xf32>
@@ -228,20 +243,20 @@ module {
     %cst_zero = arith.constant 0.0 : f32
     %cst_nonzero = arith.constant 1.0 : f32
     %empty = tensor.empty() : tensor<32x32xf32>
-    
+
     // Chain 1: zero initialization
     %c = linalg.fill ins(%cst_zero : f32) outs(%empty : tensor<32x32xf32>) -> tensor<32x32xf32>
     %1 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%c : tensor<32x32xf32>) -> tensor<32x32xf32>
     %2 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%1 : tensor<32x32xf32>) -> tensor<32x32xf32>
     %3 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%2 : tensor<32x32xf32>) -> tensor<32x32xf32>
-    
-    // Chain 2: non-zero initialization  
+
+    // Chain 2: non-zero initialization
     %empty2 = tensor.empty() : tensor<32x32xf32>
     %d = linalg.fill ins(%cst_nonzero : f32) outs(%empty2 : tensor<32x32xf32>) -> tensor<32x32xf32>
     %4 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%d : tensor<32x32xf32>) -> tensor<32x32xf32>
     %5 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%4 : tensor<32x32xf32>) -> tensor<32x32xf32>
     %6 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%5 : tensor<32x32xf32>) -> tensor<32x32xf32>
-    
+
     // Combine the two chains
     %result = arith.addf %3, %6 : tensor<32x32xf32>
     return %result : tensor<32x32xf32>
@@ -260,21 +275,24 @@ module {
   // CHECK: %[[C:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // Chain 1: for loop 1
   // CHECK: %[[EMPTY_FOR1:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[FOR1:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[EMPTY_FOR1]]) -> (tensor<32x32xf32>) {
+  // CHECK: %[[ZERO_FOR1:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY_FOR1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[FOR1:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[ZERO_FOR1]]) -> (tensor<32x32xf32>) {
   // CHECK: %[[MM1:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: scf.yield %[[MM1]] : tensor<32x32xf32>
   // CHECK: }
   // CHECK: %[[ADD1:.*]] = arith.addf %[[FOR1]], %[[C]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // Chain 1: for loop 2
   // CHECK: %[[EMPTY_FOR2:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[FOR2:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[EMPTY_FOR2]]) -> (tensor<32x32xf32>) {
+  // CHECK: %[[ZERO_FOR2:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY_FOR2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[FOR2:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[ZERO_FOR2]]) -> (tensor<32x32xf32>) {
   // CHECK: %[[MM2:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: scf.yield %[[MM2]] : tensor<32x32xf32>
   // CHECK: }
   // CHECK: %[[ADD2:.*]] = arith.addf %[[FOR2]], %[[ADD1]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // Chain 1: for loop 3
   // CHECK: %[[EMPTY_FOR3:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[FOR3:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[EMPTY_FOR3]]) -> (tensor<32x32xf32>) {
+  // CHECK: %[[ZERO_FOR3:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY_FOR3]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[FOR3:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[ZERO_FOR3]]) -> (tensor<32x32xf32>) {
   // CHECK: %[[MM3:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: scf.yield %[[MM3]] : tensor<32x32xf32>
   // CHECK: }
@@ -283,21 +301,24 @@ module {
   // CHECK: %[[EMPTY_D:.*]] = tensor.empty() : tensor<32x32xf32>
   // CHECK: %[[D:.*]] = linalg.fill ins(%[[CST_NONZERO]] : f32) outs(%[[EMPTY_D]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: %[[EMPTY_FOR4:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[FOR4:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[EMPTY_FOR4]]) -> (tensor<32x32xf32>) {
+  // CHECK: %[[ZERO_FOR4:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY_FOR4]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[FOR4:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[ZERO_FOR4]]) -> (tensor<32x32xf32>) {
   // CHECK: %[[MM4:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: scf.yield %[[MM4]] : tensor<32x32xf32>
   // CHECK: }
   // CHECK: %[[ADD4:.*]] = arith.addf %[[FOR4]], %[[D]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // Chain 2: for loop 5
   // CHECK: %[[EMPTY_FOR5:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[FOR5:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[EMPTY_FOR5]]) -> (tensor<32x32xf32>) {
+  // CHECK: %[[ZERO_FOR5:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY_FOR5]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[FOR5:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[ZERO_FOR5]]) -> (tensor<32x32xf32>) {
   // CHECK: %[[MM5:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: scf.yield %[[MM5]] : tensor<32x32xf32>
   // CHECK: }
   // CHECK: %[[ADD5:.*]] = arith.addf %[[FOR5]], %[[ADD4]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
   // Chain 2: for loop 6
   // CHECK: %[[EMPTY_FOR6:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[FOR6:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[EMPTY_FOR6]]) -> (tensor<32x32xf32>) {
+  // CHECK: %[[ZERO_FOR6:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY_FOR6]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[FOR6:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[ZERO_FOR6]]) -> (tensor<32x32xf32>) {
   // CHECK: %[[MM6:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%{{.*}} : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: scf.yield %[[MM6]] : tensor<32x32xf32>
   // CHECK: }
@@ -309,11 +330,11 @@ module {
     %c0_idx = arith.constant 0 : index
     %c10_idx = arith.constant 10 : index
     %c1_idx = arith.constant 1 : index
-    
+
     %cst_zero = arith.constant 0.0 : f32
     %cst_nonzero = arith.constant 1.0 : f32
     %empty1 = tensor.empty() : tensor<32x32xf32>
-    
+
     // Chain 1: zero initialization, each matmul in a for loop
     %c = linalg.fill ins(%cst_zero : f32) outs(%empty1 : tensor<32x32xf32>) -> tensor<32x32xf32>
     %for1_result = scf.for %i1 = %c0_idx to %c10_idx step %c1_idx iter_args(%bias1 = %c) -> (tensor<32x32xf32>) {
@@ -328,7 +349,7 @@ module {
       %mm3 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias3 : tensor<32x32xf32>) -> tensor<32x32xf32>
       scf.yield %mm3 : tensor<32x32xf32>
     }
-    
+
     // Chain 2: non-zero initialization, each matmul in a for loop
     %empty2 = tensor.empty() : tensor<32x32xf32>
     %d = linalg.fill ins(%cst_nonzero : f32) outs(%empty2 : tensor<32x32xf32>) -> tensor<32x32xf32>
@@ -344,7 +365,7 @@ module {
       %mm6 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias6 : tensor<32x32xf32>) -> tensor<32x32xf32>
       scf.yield %mm6 : tensor<32x32xf32>
     }
-    
+
     // Combine the two chains
     %result = arith.addf %for3_result, %for6_result : tensor<32x32xf32>
     return %result : tensor<32x32xf32>
@@ -354,15 +375,17 @@ module {
   // The then branch has a for loop with matmul, the else branch yields zero initial value directly.
   // Matmul in the for loop is marked as loop_carried_l0c and not split, maintaining the L0C chain.
   // CHECK-LABEL: func.func @case12_if_for
+  // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[ZERO:.*]] = linalg.fill ins(%{{.*}} : f32) outs(%[[EMPTY]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: scf.if %{{.*}} -> (tensor<32x32xf32>) {
-  // CHECK: %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[BIAS:.*]] = %{{.*}}) -> (tensor<32x32xf32>) {
+  // CHECK: %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[BIAS:.*]] = %[[ZERO]]) -> (tensor<32x32xf32>) {
   // CHECK: %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%{{.*}}, %{{.*}} : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[BIAS]] : tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK-NOT: arith.addf
   // CHECK: scf.yield %[[MM]] : tensor<32x32xf32>
   // CHECK: }
   // CHECK: scf.yield %[[FOR]] : tensor<32x32xf32>
   // CHECK: } else {
-  // CHECK: scf.yield %{{.*}} : tensor<32x32xf32>
+  // CHECK: scf.yield %[[ZERO]] : tensor<32x32xf32>
   // CHECK: }
   func.func @case12_if_for(%cond: i1, %A: tensor<32x64xf32>, %B: tensor<64x32xf32>) -> tensor<32x32xf32> {
     %c0 = arith.constant 0 : index
@@ -371,7 +394,7 @@ module {
     %cst = arith.constant 0.0 : f32
     %empty = tensor.empty() : tensor<32x32xf32>
     %zero_init = linalg.fill ins(%cst : f32) outs(%empty : tensor<32x32xf32>) -> tensor<32x32xf32>
-    
+
     %result = scf.if %cond -> (tensor<32x32xf32>) {
       %for_result = scf.for %iv = %c0 to %c10 step %c1 iter_args(%acc = %zero_init) -> (tensor<32x32xf32>) {
         %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%acc : tensor<32x32xf32>) -> tensor<32x32xf32>
@@ -380,6 +403,46 @@ module {
       scf.yield %for_result : tensor<32x32xf32>
     } else {
       scf.yield %zero_init : tensor<32x32xf32>
+    }
+    return %result : tensor<32x32xf32>
+  }
+
+  // Case 13: scf.for loop where the upper bound is a function argument.
+  // Since one of the bounds is not constant, scfMayNotExec returns true.
+  // The loop has a non-zero initial value, so it is split.
+  // After the split, an scf.if checks if the loop executes (ub > lb).
+  // If so, it yields the loop result; otherwise, it fills with zero.
+  // CHECK-LABEL: func.func @case13_may_not_exec_arg_bound
+  // CHECK-SAME: (%[[UB:.*]]: index, %[[A:.*]]: tensor<32x64xf32>, %[[B:.*]]: tensor<64x32xf32>) -> tensor<32x32xf32>
+  // CHECK-DAG: %[[CST_ZERO:.*]] = arith.constant 0.000000e+00 : f32
+  // CHECK-DAG: %[[CST_ONE:.*]] = arith.constant 1.000000e+00 : f32
+  // CHECK: %[[EMPTY1:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[NONZERO_INIT:.*]] = linalg.fill ins(%[[CST_ONE]] : f32) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[EMPTY2:.*]] = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[ZERO_INIT:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[FOR_RESULT:.*]] = scf.for %{{.*}} = %{{.*}} to %[[UB]] step %{{.*}} iter_args(%[[ITER_BIAS:.*]] = %[[ZERO_INIT]]) -> (tensor<32x32xf32>) {
+  // CHECK:   %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%[[A]], %[[B]] : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ITER_BIAS]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK:   scf.yield %[[MM]] : tensor<32x32xf32>
+  // CHECK: }
+  // CHECK: %[[COND:.*]] = arith.cmpi sgt, %[[UB]], %{{.*}} : index
+  // CHECK: %[[IF_RESULT:.*]] = scf.if %[[COND]] -> (tensor<32x32xf32>) {
+  // CHECK:   scf.yield %[[FOR_RESULT]] : tensor<32x32xf32>
+  // CHECK: } else {
+  // CHECK:   %[[FILL_ELSE:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[FOR_RESULT]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK:   scf.yield %[[FILL_ELSE]] : tensor<32x32xf32>
+  // CHECK: }
+  // CHECK: %[[ADD:.*]] = arith.addf %[[IF_RESULT]], %[[NONZERO_INIT]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
+  // CHECK: return %[[ADD]] : tensor<32x32xf32>
+  func.func @case13_may_not_exec_arg_bound(%ub: index, %A: tensor<32x64xf32>, %B: tensor<64x32xf32>) -> tensor<32x32xf32> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %cst = arith.constant 1.0 : f32
+    %empty = tensor.empty() : tensor<32x32xf32>
+    %nonzero_init = linalg.fill ins(%cst : f32) outs(%empty : tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    %result = scf.for %iv = %c0 to %ub step %c1 iter_args(%bias = %nonzero_init) -> (tensor<32x32xf32>) {
+      %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias : tensor<32x32xf32>) -> tensor<32x32xf32>
+      scf.yield %mm : tensor<32x32xf32>
     }
     return %result : tensor<32x32xf32>
   }


### PR DESCRIPTION
**PR Title:**  
[release/3.2.2](feat) Sync additional verified commits from dev to release/3.2.2

**Description:**

This PR synchronizes the following additional verified commits from the `dev` branch to the `release/3.2.2` branch. All commits have passed CI verification and are ready for integration.

### Synchronized Commits:

| Commit Subject | Author |
|----------------|--------|
| [ssbuffer](fix) support a*b+c case, where the for loop may not execute (#739) | olivervnc |
| [ssbuffer](fix) FixpipeOpt apply only when hint enable_fast_tf32_mul (#802) | Hsyy04 |
| [ssbuffer](fix) Delay ops with yield users in topological ordering (#774) | Hsyy04 |
| [ssbuffer](fix) unaligned dot operand from v with the other from c (#795) | lrf22 |
| [release/3.2.2](fix) Fix boundary size calculation for make_block_ptr (#740) | hongziqi |
| [SSBuffer](feat) code review fixes and test compatibility (#778) | ohblacks |
| [CompileOps](feat) Revise superblock factor value (#747) | darkbuck |
| [ssbuffer](fix) fix detecting cloned ops in CloneOps & code warning (#738) | m-everglow |
| [ssbuffer](fix): avoid unsigned underflow in condition use check (#761) | (author) |

*(Note: Author for the last commit will be filled from the actual commit metadata.)*

### Summary of Changes:

- **Bug Fixes**:
  - Fixed a*b+c scenarios where for loop may not execute.
  - Applied FixpipeOpt only when `enable_fast_tf32_mul` hint is enabled.
  - Delayed ops with yield users in topological ordering to ensure correct scheduling.
  - Fixed unaligned dot operand handling when one operand is from v and the other from c.
  - Corrected boundary size calculation for `make_block_ptr`.
  - Fixed detection of cloned ops in CloneOps and resolved code warnings.
  - Avoided unsigned underflow in condition use check.
- **Features/Enhancements**:
  - Code review fixes and test compatibility improvements for SSBuffer.
  - Revised superblock factor value in CompileOps.

All changes have been cherry-picked from the `dev` branch and verified locally. No conflicts were encountered during integration.