### PR TITLE
[Docs](fix) Fix libdevice document issues

### DIFF
--- a/docs/en/libdevice/libdevice_developer_guide.md
+++ b/docs/en/libdevice/libdevice_developer_guide.md
@@ -24,7 +24,7 @@ def triton_kernel(input, output, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr)
 dtype, shape, ncore, xblock, xblock_sub = ['int32', (128, 4096), 512, 1024, 1024]
 input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
 output = torch.zeros_like(input)
-# Enable SIMT compilaiton with option "force_simt_only=True"
+# Enable SIMT compilation with option "force_simt_only=True"
 triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub, force_simt_only=True)
 ```
 

--- a/docs/zh/libdevice/libdevice_developer_guide.md
+++ b/docs/zh/libdevice/libdevice_developer_guide.md
@@ -25,7 +25,7 @@ def triton_kernel(input, output, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr)
 dtype, shape, ncore, xblock, xblock_sub = ['int32', (128, 4096), 512, 1024, 1024]
 input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
 output = torch.zeros_like(input)
-# Enable SIMT compilaiton with option "force_simt_only=True"
+# Enable SIMT compilation with option "force_simt_only=True"
 triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub, force_simt_only=True)
 ```
 


### PR DESCRIPTION
### Summary
Fix the typos in the Libdevice documentation.

### Document Render Preview
libdevice_developer_guide
<img width="1095" height="1207" alt="image" src="https://github.com/user-attachments/assets/53cfdd3a-7a67-4322-af12-493ac013b4c9" />
