### PR TITLE
[MaskAnalysis](fix) extend clampToNonNegativeIndex to dynamic dims fo…

### DIFF
--- a/third_party/ascend/include/TritonToLinalg/MaskAnalysis.h
+++ b/third_party/ascend/include/TritonToLinalg/MaskAnalysis.h
@@ -149,8 +149,8 @@ private:
                           const Location &loc, OpBuilder &builder);
 
   OpFoldResult clampToNonNegativeIndex(const OpFoldResult value,
-                                       const Location &loc,
-                                       OpBuilder &builder) const;
+                                       const Location &loc, OpBuilder &builder,
+                                       bool clampDynamic = false) const;
 
   // Helper functions to parse values to populate MaskState
 

--- a/third_party/ascend/lib/TritonToLinalg/MaskAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/MaskAnalysis.cpp
@@ -67,14 +67,19 @@ std::optional<MaskState> runMaskAnalysisImpl(MemAccOpTy op, OpBuilder &builder)
 
 OpFoldResult MaskState::clampToNonNegativeIndex(const OpFoldResult value,
                                                 const Location &loc,
-                                                OpBuilder &builder) const
+                                                OpBuilder &builder,
+                                                bool clampDynamic) const
 {
   if (auto cst = getConstantIntValue(value)) {
     return builder.getIndexAttr(std::max<int64_t>(0, *cst));
   }
 
-  // For non-constant value, we could generate max(value, 0) to ensure the value is non-negative.
-  // But this caused error in atomic max/min ut test. We need to investigate more on this.
+  // Only minStates needs the dynamic clamp (disjoint intersection -> negative
+  // extent); the cmp paths are already non-negative, and clamping them regressed
+  // the atomic max/min UT.
+  if (clampDynamic) {
+    return maxOpFoldResult(value, builder.getIndexAttr(0), loc, builder);
+  }
   return value;
 }
 
@@ -299,7 +304,8 @@ LogicalResult MaskState::minStates(const MaskState &lhsState,
     auto rhsEnd = addOpFoldResult(rhsOffset, rhsDim, loc, builder);
     auto newEnd = minOpFoldResult(lhsEnd, rhsEnd, loc, builder);
     auto newDim = subOpFoldResult(newEnd, newOffset, loc, builder);
-    auto clampedNewDim = clampToNonNegativeIndex(newDim, loc, builder);
+    auto clampedNewDim =
+        clampToNonNegativeIndex(newDim, loc, builder, /*clampDynamic=*/true);
 
     offsets.push_back(newOffset);
     dims.push_back(clampedNewDim);

--- a/third_party/ascend/unittest/pytest_ut/test_mask_negative_dim_clamp.py
+++ b/third_party/ascend/unittest/pytest_ut/test_mask_negative_dim_clamp.py
@@ -1,0 +1,60 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def kernel_minimal(
+    idx_ptr, table_ptr, out_ptr,
+    y0_numel, x1_numel,
+    Y0BLOCK: tl.constexpr, Y0BLOCK_SUB: tl.constexpr, X1BLOCK_SUB: tl.constexpr,
+):
+    y0_offset = tl.program_id(0) * Y0BLOCK
+    base_y0 = tl.arange(0, Y0BLOCK_SUB)
+    loops_y0 = (Y0BLOCK + Y0BLOCK_SUB - 1) // Y0BLOCK_SUB
+    base_x1 = tl.arange(0, X1BLOCK_SUB)
+    loops_x1 = (x1_numel + X1BLOCK_SUB - 1) // X1BLOCK_SUB
+    for loop_y0 in range(loops_y0):
+        y0 = y0_offset + (loop_y0 * Y0BLOCK_SUB) + base_y0[:, None]
+        y0_mask = y0 < min(Y0BLOCK + y0_offset, y0_numel)
+        for loop_x1 in range(loops_x1):
+            x1 = (loop_x1 * X1BLOCK_SUB) + base_x1[None, :]
+            x1_mask = x1 < x1_numel
+
+            m_lo = (y0 >= 64) & (y0 < 128) & y0_mask
+            idx_lo = tl.load(idx_ptr + ((-64) + y0), m_lo, other=0)
+
+            m_hi = (y0 >= 128) & y0_mask
+            idx_hi = tl.load(idx_ptr + ((-128) + y0), m_hi, other=0)
+
+            val_lo = tl.load(table_ptr + (x1 + 2048 * idx_lo), x1_mask, other=0.0)
+            val_hi = tl.load(table_ptr + (x1 + 2048 * idx_hi), x1_mask, other=0.0)
+
+            result = tl.where(m_hi, val_hi, tl.where(m_lo, val_lo, 0.0))
+            tl.store(out_ptr + (x1 + 2048 * y0), result, x1_mask & y0_mask)
+
+
+def _reference(idx, table):
+    ref = torch.zeros((192, 2048), device=table.device, dtype=table.dtype)
+    flat = idx.flatten()
+    ref[64:128] = table[flat[0:64]]
+    ref[128:192] = table[flat[0:64]]
+    return ref.unsqueeze(0)
+
+
+def test():
+    device = 'npu'
+    idx = torch.randint(0, 95, (1, 64), device=device, dtype=torch.int64)
+    table = torch.randn((96, 2048), device=device, dtype=torch.float32)
+    out = torch.empty((1, 192, 2048), device=device, dtype=torch.float32)
+    kernel_minimal[(36,)](
+        idx, table, out,
+        192, 2048, 6, 4, 2048,
+        multibuffer=False,
+    )
+    torch.npu.synchronize()
+    torch.testing.assert_close(out, _reference(idx, table))
+
+
+if __name__ == "__main__":
+    test()


### PR DESCRIPTION
## Problem
`MaskState::clampToNonNegativeIndex` only lower-bounded **constant** dims; non-constant
(dynamic) dims were returned unmodified. In `minStates` the intersection of two independent
masks can be disjoint, producing a negative extent that corrupts the load/store region.

## Per-call-site analysis
Every dim has `end >= start`. Whether `newDim` can go negative depends on whether both
operands of the subtraction are clamped into `[start, end]`.

| Site | Context | `newDim` formula | Non-negative by construction | Needs dynamic clamp |
|------|---------|------------------|------------------------------|---------------------|
| minStates | intersection (also via parseAnd) | `min(lhsEnd,rhsEnd) − max(lhsOff,rhsOff)` | No — disjoint ranges | Yes |
| parseCmp slt | `lhs < rhs` | `min(end, max(start,scalar)) − start` | Yes — both terms ≥ start | No (redundant) |
| parseCmp sle | `lhs <= rhs` | `min(end, max(start,rhs+1)) − start` | Yes | No (redundant) |
| parseCmp sge | `lhs >= rhs` | `end − min(end, max(start,scalar))` | Yes — newStart ∈ [start,end] | No (redundant) |

The cmp paths already lower-bound via `max(start,…)`/`min(end,…)`, so only `minStates`
can yield a negative dim.

## Fix
Gate a dynamic `max(value, 0)` (via `maxOpFoldResult`) behind a `clampDynamic` flag,
enabled only at the `minStates` call site. The cmp paths keep prior behavior, avoiding the
atomic max/min UT regression that motivated the original const-only clamp.

## Test
`pytest_ut/test_mask_negative_dim_clamp.py`: three-segment cat + indirect int64 indexing
repro whose compound masks go through `parseAnd → minStates`, asserted against an eager
reference.
