### PR TITLE
[ControlFlow/StridedAxisCoalesce](feat) Support predicate for OneTrip ForOp and StridedAxisCoalesce pattern for addptr

### DIFF
--- a/third_party/ascend/lib/TritonControlFlowOpt/TritonControlFlowOptPass.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/TritonControlFlowOptPass.cpp
@@ -1255,6 +1255,204 @@ static bool isRangeFromZeroByOne(scf::ForOp forOp) {
          isConstantIndex(forOp.getStep(), 1);
 }
 
+static bool canPredicateOneTripLoopBody(scf::ForOp forOp) {
+  for (Operation &op : forOp.getBody()->without_terminator()) {
+    if (op.getNumRegions() != 0)
+      return false;
+    if (isa<triton::LoadOp, triton::StoreOp>(op))
+      continue;
+    if (isa<triton::AddPtrOp, triton::SplatOp, triton::MakeRangeOp,
+            triton::ExpandDimsOp, triton::BroadcastOp, triton::TransOp,
+            triton::ReshapeOp, triton::IntToPtrOp, triton::PtrToIntOp,
+            triton::BitcastOp>(op))
+      continue;
+    if (!isMemoryEffectFree(&op))
+      return false;
+  }
+  return true;
+}
+
+static LogicalResult clonePredicatedBodyOp(Operation &op, IRRewriter &rewriter,
+                                           IRMapping &mapping,
+                                           Value condition) {
+  Location loc = op.getLoc();
+  auto createZero = [&](Type type) -> Value {
+    if (type.isIndex())
+      return rewriter.create<arith::ConstantIndexOp>(loc, 0);
+
+    if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
+      Attribute zero = rewriter.getZeroAttr(tensorType.getElementType());
+      return rewriter.create<arith::ConstantOp>(
+          loc, DenseElementsAttr::get(tensorType, zero));
+    }
+
+    if (isa<IntegerType, FloatType>(type))
+      return rewriter.create<arith::ConstantOp>(loc, type,
+                                                rewriter.getZeroAttr(type));
+
+    return nullptr;
+  };
+  auto addLoopPredicate = [&](Value mask, Type valueType) -> Value {
+    Type maskType = rewriter.getI1Type();
+    if (auto tensorType = dyn_cast<RankedTensorType>(valueType))
+      maskType = RankedTensorType::get(tensorType.getShape(),
+                                       rewriter.getI1Type(),
+                                       tensorType.getEncoding());
+
+    Value predMask = condition;
+    if (condition.getType() != maskType) {
+      auto tensorType = dyn_cast<RankedTensorType>(maskType);
+      if (!tensorType || tensorType.getElementType() != rewriter.getI1Type())
+        return nullptr;
+      predMask = rewriter.create<triton::SplatOp>(loc, tensorType, condition);
+    }
+
+    if (!mask)
+      return predMask;
+    if (mask.getType() != maskType)
+      return nullptr;
+    return rewriter.create<arith::AndIOp>(loc, mask, predMask);
+  };
+
+  if (auto loadOp = dyn_cast<triton::LoadOp>(op)) {
+    Value ptr = mapping.lookupOrDefault(loadOp.getPtr());
+    Value mask = nullptr;
+    if (loadOp.getMask())
+      mask = mapping.lookupOrDefault(loadOp.getMask());
+    Value other = nullptr;
+    if (loadOp.getOther())
+      other = mapping.lookupOrDefault(loadOp.getOther());
+    else
+      other = createZero(loadOp.getType());
+    if (!other)
+      return failure();
+
+    Value predicatedMask = addLoopPredicate(mask, loadOp.getType());
+    if (!predicatedMask)
+      return failure();
+
+    auto newLoad = rewriter.create<triton::LoadOp>(
+        loc, ptr, predicatedMask, other, loadOp.getBoundaryCheck(),
+        loadOp.getPadding(), loadOp.getCache(), loadOp.getEvict(),
+        loadOp.getIsVolatile());
+    for (auto attr : loadOp->getAttrs()) {
+      if (!newLoad->hasAttr(attr.getName()))
+        newLoad->setAttr(attr.getName(), attr.getValue());
+    }
+    mapping.map(loadOp.getResult(), newLoad.getResult());
+    return success();
+  }
+
+  if (auto storeOp = dyn_cast<triton::StoreOp>(op)) {
+    Value ptr = mapping.lookupOrDefault(storeOp.getPtr());
+    Value value = mapping.lookupOrDefault(storeOp.getValue());
+    Value mask = nullptr;
+    if (storeOp.getMask())
+      mask = mapping.lookupOrDefault(storeOp.getMask());
+
+    Value predicatedMask =
+        addLoopPredicate(mask, storeOp.getValue().getType());
+    if (!predicatedMask)
+      return failure();
+
+    auto newStore = rewriter.create<triton::StoreOp>(
+        loc, ptr, value, predicatedMask, storeOp.getBoundaryCheck(),
+        storeOp.getCache(), storeOp.getEvict());
+    for (auto attr : storeOp->getAttrs()) {
+      if (!newStore->hasAttr(attr.getName()))
+        newStore->setAttr(attr.getName(), attr.getValue());
+    }
+    return success();
+  }
+
+  rewriter.clone(op, mapping);
+  return success();
+}
+
+static LogicalResult predicateOneTripForOp(scf::ForOp forOp,
+                                           IRRewriter &rewriter) {
+  auto isOne = [](Value value) {
+    if (auto constIndex = value.getDefiningOp<arith::ConstantIndexOp>())
+      return constIndex.value() == 1;
+
+    APInt intValue;
+    if (matchPattern(value, m_ConstantInt(&intValue)))
+      return intValue.isOne();
+
+    Attribute attr;
+    if (!matchPattern(value, m_Constant(&attr)))
+      return false;
+    auto intAttr = dyn_cast<IntegerAttr>(attr);
+    return intAttr && intAttr.getValue().isOne();
+  };
+
+  auto canSelect = [](Value value) {
+    Type type = value.getType();
+    if (isa<IntegerType, IndexType, FloatType>(type))
+      return true;
+    auto tensorType = dyn_cast<RankedTensorType>(type);
+    return tensorType &&
+           isa<IntegerType, IndexType, FloatType>(
+               tensorType.getElementType());
+  };
+
+  auto minOp = forOp.getUpperBound().getDefiningOp<arith::MinSIOp>();
+  if (!isOne(forOp.getStep()) || !minOp ||
+      (!isOne(minOp.getLhs()) && !isOne(minOp.getRhs())) ||
+      !canPredicateOneTripLoopBody(forOp))
+    return failure();
+
+  auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+  if (yieldOp.getNumOperands() != forOp.getInitArgs().size())
+    return failure();
+
+  for (auto [result, initArg] :
+       llvm::zip(forOp.getResults(), forOp.getInitArgs())) {
+    if (result.use_empty())
+      continue;
+    if (initArg.getType() != result.getType() ||
+        !canSelect(result))
+      return failure();
+  }
+
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(forOp);
+  Value condition = rewriter.create<arith::CmpIOp>(
+      forOp.getLoc(), arith::CmpIPredicate::slt, forOp.getLowerBound(),
+      forOp.getUpperBound());
+
+  IRMapping mapping;
+  mapping.map(forOp.getInductionVar(), forOp.getLowerBound());
+  for (auto [iterArg, initArg] :
+       llvm::zip(forOp.getRegionIterArgs(), forOp.getInitArgs()))
+    mapping.map(iterArg, initArg);
+
+  for (Operation &op : forOp.getBody()->without_terminator()) {
+    if (failed(clonePredicatedBodyOp(op, rewriter, mapping, condition)))
+      return failure();
+  }
+
+  SmallVector<Value> replacements;
+  replacements.reserve(forOp.getNumResults());
+  for (auto [idx, result] : llvm::enumerate(forOp.getResults())) {
+    Value initArg = forOp.getInitArgs()[idx];
+    if (result.use_empty()) {
+      replacements.push_back(initArg);
+      continue;
+    }
+
+    Value yielded = mapping.lookupOrDefault(yieldOp.getOperand(idx));
+    if (yielded.getType() != initArg.getType())
+      return failure();
+    replacements.push_back(
+        rewriter.create<arith::SelectOp>(yieldOp.getLoc(), condition, yielded,
+                                         initArg));
+  }
+
+  rewriter.replaceOp(forOp, replacements);
+  return success();
+}
+
 static bool isDefinedOutside(Operation *scope, Value value) {
   if (Operation *defOp = value.getDefiningOp())
     return !scope->isAncestor(defOp);
@@ -2136,6 +2334,17 @@ void TritonControlFlowOptPass::runOnOperation() {
     }
   }
 
+  SmallVector<scf::ForOp> oneTripForOps;
+  moduleOp.walk<WalkOrder::PostOrder>(
+      [&](scf::ForOp forOp) { oneTripForOps.push_back(forOp); });
+
+  IRRewriter rewriter(moduleOp.getContext());
+  for (scf::ForOp forOp : oneTripForOps) {
+    if (forOp->getParentOp() == nullptr)
+      continue;
+    (void)predicateOneTripForOp(forOp, rewriter);
+  }
+
   SmallVector<Operation *> targets;
   moduleOp.walk<WalkOrder::PostOrder>([&](Operation *op) {
     if (isa<scf::ForOp, scf::WhileOp, scf::IfOp>(op))
@@ -2147,7 +2356,6 @@ void TritonControlFlowOptPass::runOnOperation() {
                  << " structured control-flow targets for later decoupling\n";
   });
 
-  IRRewriter rewriter(moduleOp.getContext());
   for (Operation *op : targets) {
     if (op->getParentOp() == nullptr)
       continue;

--- a/third_party/ascend/lib/TritonToLinalg/StridedAxisCoalescing.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/StridedAxisCoalescing.cpp
@@ -20,14 +20,37 @@
  * THE SOFTWARE.
  */
 
+// This pass folds a launch-grid split of a short contiguous logical axis back
+// into the per-program tile. Kernels in this family originally launch one
+// program per logical lane, e.g. `pid -> (batch, h, col_tile)`, then each program
+// executes the same scalar-heavy compute for a single `h`. Coalescing rewrites
+// such rank-1 load/compute/store chains to rank-2 `[tile, h]` chains and records
+// `hacc.coalesce_factor`/`hacc.coalesce_axis` so the launcher divides that grid
+// dimension by the folded factor.
+//
+// Supported patterns are intentionally local MLIR rewrite patterns:
+//   * BlockPtrPattern is rooted at `tt.load` over
+//     make_tensor_ptr(base + pid % S, stride S).
+//   * AddPtrPattern is rooted at the vector `tt.addptr` address produced by
+//     kernels that compute `output_row = pid / grid_dim`, `h = output_row % S`,
+//     and vector columns from `pid % grid_dim`.
+//
+// The shared rewrite only handles the common load->store dataflow contract:
+// every seed in one rewrite must have the same factor, tile size, and launch
+// axis; every intermediate op must be lane-independent; every sink store must
+// match the same concrete pattern as the root load.
+
 #include "TritonToLinalg/StridedAxisCoalescing.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #include <functional>
 
@@ -36,118 +59,35 @@ namespace StridedAxisCoalescing {
 using namespace mlir;
 using namespace triton;
 
-// Detects the FLA per-head strided base `base + (pid % S)` produced by
-// splitting the H axis (the contiguous axis folded onto the grid). Returns the
-// matching AddPtrOp, or a null AddPtrOp if `base` is not such an ih-split ptr.
-static triton::AddPtrOp findIhAddPtr(Value base, int64_t S) {
-    Value src = base;
-    while (auto addptr = src.getDefiningOp<triton::AddPtrOp>()) {
-        if (isa<RankedTensorType>(addptr.getPtr().getType())) break;
-        if (auto rem = addptr.getOffset().getDefiningOp<arith::RemSIOp>()) {
-            APInt cC;
-            if (matchPattern(rem.getRhs(), m_ConstantInt(&cC)) &&
-                std::abs(cC.getSExtValue()) == S) {
-                Value lhs = rem.getLhs();
-                while (true) {
-                    if (auto e = lhs.getDefiningOp<arith::ExtSIOp>()) { lhs = e.getIn(); continue; }
-                    if (auto t = lhs.getDefiningOp<arith::TruncIOp>()) { lhs = t.getIn(); continue; }
-                    break;
-                }
-                if (lhs.getDefiningOp<triton::GetProgramIdOp>()) return addptr;
-            }
-        }
-        src = addptr.getPtr();
-    }
-    return triton::AddPtrOp();
-}
-
-// Mirror of findIhAddPtr that returns the program_id axis driving the ih split
-// (i.e. the grid dim the host launcher must divide by S), or -1 if `base` is
-// not such an ih-split ptr. Whenever findIhAddPtr succeeds this does too.
-static int32_t findIhAxis(Value base, int64_t S) {
-    Value src = base;
-    while (auto addptr = src.getDefiningOp<triton::AddPtrOp>()) {
-        if (isa<RankedTensorType>(addptr.getPtr().getType())) break;
-        if (auto rem = addptr.getOffset().getDefiningOp<arith::RemSIOp>()) {
-            APInt cC;
-            if (matchPattern(rem.getRhs(), m_ConstantInt(&cC)) &&
-                std::abs(cC.getSExtValue()) == S) {
-                Value lhs = rem.getLhs();
-                while (true) {
-                    if (auto e = lhs.getDefiningOp<arith::ExtSIOp>()) { lhs = e.getIn(); continue; }
-                    if (auto t = lhs.getDefiningOp<arith::TruncIOp>()) { lhs = t.getIn(); continue; }
-                    break;
-                }
-                if (auto pid = lhs.getDefiningOp<triton::GetProgramIdOp>())
-                    return pid.getAxisAsInt();
-            }
-        }
-        src = addptr.getPtr();
-    }
-    return -1;
-}
-
-// Returns the i_h value `pid % S` (the per-head index feeding the ih split), or
-// null. Mirror of findIhAddPtr but yields the RemSIOp result itself, used to
-// check whether i_h also feeds a per-head scalar load (which coalescing cannot
-// lane-expand -- see the correctness guard in rewriteStridedAxisCoalesce).
-static Value findIhRem(Value base, int64_t S) {
-    Value src = base;
-    while (auto addptr = src.getDefiningOp<triton::AddPtrOp>()) {
-        if (isa<RankedTensorType>(addptr.getPtr().getType())) break;
-        if (auto rem = addptr.getOffset().getDefiningOp<arith::RemSIOp>()) {
-            APInt cC;
-            if (matchPattern(rem.getRhs(), m_ConstantInt(&cC)) &&
-                std::abs(cC.getSExtValue()) == S)
-                return rem.getResult();
-        }
-        src = addptr.getPtr();
-    }
-    return Value();
-}
-
-static Value build2DBlockPtr(IRRewriter &rw, triton::MakeTensorPtrOp m1d,
-                             int64_t S, int64_t BT) {
-    triton::AddPtrOp ih = findIhAddPtr(m1d.getBase(), S);
-    if (!ih) return Value();
-    auto loc = m1d.getLoc();
-    rw.setInsertionPoint(m1d);
-    Value newBase = ih.getPtr();
-    Value cH = rw.create<arith::ConstantOp>(loc, rw.getI64IntegerAttr(S));
-    Value c1 = rw.create<arith::ConstantOp>(loc, rw.getI64IntegerAttr(1));
-    Value c0 = rw.create<arith::ConstantOp>(loc, rw.getI32IntegerAttr(0));
-    SmallVector<Value, 2> shape{m1d.getShape()[0], cH};
-    SmallVector<Value, 2> strides{m1d.getStrides()[0], c1};
-    SmallVector<Value, 2> offsets{m1d.getOffsets()[0], c0};
-    SmallVector<int32_t, 2> blockShape{static_cast<int32_t>(BT), static_cast<int32_t>(S)};
-    SmallVector<int32_t, 2> order{1, 0};
-    auto p = rw.create<triton::MakeTensorPtrOp>(loc, newBase, shape, strides,
-                                                offsets, blockShape, order);
-    return p.getResult();
-}
-
-// Lift a rank-1 tensor type tensor<BTxe> to tensor<BTxSxe> (append the folded
-// H axis as the inner lane). Scalars / non-rank-1 types pass through unchanged.
-static Type lift2D(Type t, int64_t S) {
+// Lift a rank-1 tensor type tensor<BTxe> to rank-2. Block-pointer kernels keep
+// the folded H axis inner ([BT,S]); addptr jagged kernels keep the column tile
+// inner ([S,BT]) so GM copies remain contiguous on the column dimension.
+static Type lift2D(Type t, int64_t S, bool laneInner) {
     auto rt = dyn_cast<RankedTensorType>(t);
     if (!rt || rt.getRank() != 1) return t;
-    return RankedTensorType::get({rt.getShape()[0], S}, rt.getElementType());
+    int64_t BT = rt.getShape()[0];
+    SmallVector<int64_t, 2> shape =
+        laneInner ? SmallVector<int64_t, 2>{BT, S}
+                  : SmallVector<int64_t, 2>{S, BT};
+    return RankedTensorType::get(shape, rt.getElementType());
 }
 
-// An op is safe to 2D-ify (lane-parallel over the appended H axis) iff every
+// An op is safe to 2D-ify (lane-parallel over the folded H axis) iff every
 // lane s computes independently: a pure elementwise arith/math op, a cast, a
 // splat, or a scan/reduce ALONG THE T axis (axis 0). On the 2D tile [BT,S] a
-// T-axis reduce is per-lane (the S lanes stay independent, output [S]) and a
-// T-axis scan likewise, so both lift directly -- no need to pre-collapse the
-// reverse-cumsum idiom into a single scan. Ops that mix or move the lane
-// (transpose, tt.dot, reshape, reduce/scan along the lane) are NOT here, so the
-// caller bails and keeps the original (indirect) path.
+// T-axis reduce is per-lane; on [S,BT] the rewrite remaps that axis to 1. In
+// both layouts the S lanes stay independent (output [S]) and a T-axis scan does
+// likewise, so both lift directly -- no need to pre-collapse the reverse-cumsum
+// idiom into a single scan. Ops that mix or move the lane (transpose, tt.dot,
+// reshape, reduce/scan along the lane) are NOT here, so the caller bails and
+// keeps the original (indirect) path.
 static bool is2DSafe(Operation *op) {
     if (isa<arith::AddFOp, arith::SubFOp, arith::MulFOp, arith::DivFOp,
             arith::NegFOp, arith::MaximumFOp, arith::MinimumFOp,
             arith::MaxNumFOp, arith::MinNumFOp, arith::CmpFOp, arith::SelectOp,
             arith::ExtFOp, arith::TruncFOp, arith::SIToFPOp, arith::UIToFPOp,
-            arith::FPToSIOp, arith::FPToUIOp>(op))
+            arith::FPToSIOp, arith::FPToUIOp, arith::CmpIOp, arith::AndIOp,
+            arith::OrIOp>(op))
         return true;
     // Every math dialect op (exp/log/sqrt/tanh/erf/...) is a per-lane scalar
     // elementwise map -> 2D-safe. This covers gate activations expressed as
@@ -163,37 +103,36 @@ static bool is2DSafe(Operation *op) {
     return false;
 }
 
-void rewriteStridedAxisCoalesce(ModuleOp moduleOp) {
-    IRRewriter rw(moduleOp.getContext());
+using LiftValueFn = std::function<Value(Value)>;
+
+template <typename PatternT>
+static LogicalResult rewriteCoalescedRegion(ModuleOp moduleOp,
+                                            const PatternT &pattern,
+                                            const typename PatternT::Seed &rootSeed,
+                                            PatternRewriter &rw) {
+    if (moduleOp->hasAttr("hacc.coalesce_factor"))
+        return failure();
+    constexpr bool laneInner = PatternT::kLaneInner;
 
     // Collect the strided ih-base 1D loads (seeds). All must share one stride S
     // (the folded H axis); BT is the per-chunk tile length.
-    SmallVector<triton::LoadOp> seeds;
-    int64_t S = 0, BT = 0;
-    moduleOp.walk([&](triton::LoadOp l) {
-        auto m = l.getPtr().getDefiningOp<triton::MakeTensorPtrOp>();
-        if (!m) return;
-        auto rt = dyn_cast<RankedTensorType>(l.getResult().getType());
-        if (!rt || rt.getRank() != 1) return;
-        auto strides = m.getStrides();
-        if (strides.empty()) return;
-        APInt sC;
-        if (!matchPattern(strides.back(), m_ConstantInt(&sC))) return;
-        int64_t s = std::abs(sC.getSExtValue());
-        if (s <= 1) return;
-        if (!findIhAddPtr(m.getBase(), s)) return;
-        if (S == 0) { S = s; BT = rt.getShape()[0]; }
-        if (s != S) return;
-        seeds.push_back(l);
+    SmallVector<typename PatternT::Seed> seeds{rootSeed};
+    int64_t S = rootSeed.S, BT = rootSeed.BT;
+    int32_t coalesceAxis = rootSeed.coalesceAxis;
+    if (S <= 1 || BT <= 0 || coalesceAxis < 0)
+        return failure();
+
+    moduleOp.walk([&](triton::LoadOp load) {
+        if (load == rootSeed.load) return;
+        typename PatternT::Seed seed;
+        if (!pattern.matchLoad(load, seed)) return;
+        if (seed.S != S || seed.BT != BT ||
+            seed.coalesceAxis != coalesceAxis)
+            return;
+        seeds.push_back(seed);
     });
-    if (seeds.empty()) return;
 
     // The grid axis the launcher will divide by S (the pid feeding `pid % S`).
-    int32_t coalesceAxis = -1;
-    if (auto m0 = seeds.front().getPtr().getDefiningOp<triton::MakeTensorPtrOp>())
-        coalesceAxis = findIhAxis(m0.getBase(), S);
-    if (coalesceAxis < 0) return;  // cannot identify the axis -> do not coalesce
-
     // Full TA path: the launcher divides grid[coalesceAxis] by S, so the
     // kernel-visible num_programs(coalesceAxis) becomes grid/S. If the kernel
     // reads it, coalescing would change that value -> wrong results. Bail (the
@@ -202,76 +141,59 @@ void rewriteStridedAxisCoalesce(ModuleOp moduleOp) {
     moduleOp.walk([&](triton::GetNumProgramsOp np) {
         if (np.getAxisAsInt() == coalesceAxis) readsAxisNumPrograms = true;
     });
-    if (readsAxisNumPrograms) return;
+    if (readsAxisNumPrograms)
+        return failure();
 
-    // The H axis is folded into the inner lane, so every per-head value must be
-    // expanded across the S lanes. Block-ptr loads are lane-expanded by
-    // build2DBlockPtr; a per-head SCALAR load (A_log[i_h] / dt_bias[i_h] in
-    // gdn-style gates) is collected here and later lifted to an [S] per-lane
-    // vector load (lane s -> base[s], matching the folded i_h = s). The scalar
-    // chain on top of it (exp/neg/...) is lifted to [S] by get2D, and the splat
-    // that feeds it into the tile becomes an [S]->[BT,S] broadcast. Bail only if
-    // i_h reaches something we cannot lane-expand: a scalar load feeding an
-    // address (indirect gather), or a tensor load not via make_tensor_ptr.
+    // The H axis is folded into the coalesced tile, so every per-head value
+    // must be expanded across the S lanes. Pattern-specific collectors find
+    // scalar loads that are safe to lane-expand; they bail when an H-dependent
+    // value reaches something that cannot be represented as independent lanes.
     SmallVector<triton::LoadOp> headLoads;
-    if (auto m0 = seeds.front().getPtr().getDefiningOp<triton::MakeTensorPtrOp>()) {
-        if (Value ihRem = findIhRem(m0.getBase(), S)) {
-            SmallVector<Operation *> wl2(ihRem.getUsers().begin(),
-                                         ihRem.getUsers().end());
-            DenseSet<Operation *> seen2;
-            while (!wl2.empty()) {
-                Operation *u = wl2.pop_back_val();
-                if (!seen2.insert(u).second) continue;
-                if (isa<triton::MakeTensorPtrOp>(u)) continue;  // block-ptr path: fine
-                if (auto ld = dyn_cast<triton::LoadOp>(u)) {
-                    // per-head scalar load: must be scalar and must not itself feed
-                    // an address (indirect gather). Then it is liftable to [S].
-                    if (isa<RankedTensorType>(ld.getResult().getType())) return;
-                    for (Operation *ru : ld.getResult().getUsers())
-                        if (isa<triton::AddPtrOp>(ru)) return;  // indirect -> bail
-                    headLoads.push_back(ld);
-                    continue;
-                }
-                if (isa<triton::AddPtrOp, arith::ExtSIOp, arith::TruncIOp,
-                        arith::RemSIOp, arith::AddIOp, arith::MulIOp>(u))
-                    for (Operation *uu : u->getResult(0).getUsers())
-                        wl2.push_back(uu);
-            }
-        }
+    SmallVector<triton::LoadOp> flatDenseLoads;
+    DenseMap<Operation *, Value> flatDenseBases;
+    DenseMap<Operation *, unsigned> flatDenseSeedIndex;
+    DenseSet<Operation *> seedOps;
+    for (auto &seed : seeds)
+        seedOps.insert(seed.load.getOperation());
+    DenseSet<Operation *> seenFlatLoads;
+    for (unsigned i = 0; i < seeds.size(); ++i) {
+        if (failed(pattern.collectExtraLoads(moduleOp, seeds, i, seedOps,
+                                             headLoads, flatDenseLoads,
+                                             flatDenseBases,
+                                             flatDenseSeedIndex,
+                                             seenFlatLoads)))
+            return failure();
     }
 
     // Discover the load->store subgraph by forward reachability from the seeds.
     // Every op on the way must be 2D-safe (elementwise / cast / splat / T-axis
-    // scan or reduce); stores are the sinks. A T-axis reduce is kept as-is and
-    // lifted in place (no idiom-specific pre-collapse) -- see is2DSafe.
-    // Any unsafe op (or a value escaping to one) aborts the whole rewrite.
+    // scan or reduce); stores are the sinks. Any unsafe op (or a value escaping
+    // to one) aborts the whole rewrite.
     DenseSet<Operation *> region;
     SmallVector<triton::StoreOp> sinks;
     DenseSet<Operation *> visited;
     SmallVector<Operation *> wl;
     for (auto s : seeds)
-        for (Operation *u : s.getResult().getUsers()) wl.push_back(u);
+        for (Operation *u : s.load.getResult().getUsers()) wl.push_back(u);
     while (!wl.empty()) {
         Operation *op = wl.pop_back_val();
         if (!visited.insert(op).second) continue;
         if (auto st = dyn_cast<triton::StoreOp>(op)) { sinks.push_back(st); continue; }
-        if (!is2DSafe(op)) return;  // bail: unsafe consumer in the chain
+        if (!is2DSafe(op)) return failure();
         region.insert(op);
         for (Value r : op->getResults())
             for (Operation *u : r.getUsers()) wl.push_back(u);
     }
-    if (sinks.empty()) return;
+    if (sinks.empty()) return failure();
 
-    // Every sink store must also be a matching 1D stride-S ih-base block ptr.
+    // Every sink store must also match the same concrete addressing family as
+    // the root load: block-ptr stride-S, or addptr jagged/dense row addressing.
+    SmallVector<typename PatternT::Store> coalescedStores;
     for (auto st : sinks) {
-        auto m = st.getPtr().getDefiningOp<triton::MakeTensorPtrOp>();
-        if (!m || !findIhAddPtr(m.getBase(), S)) return;
-        auto os = m.getStrides();
-        if (os.empty()) return;
-        APInt soC;
-        if (!matchPattern(os.back(), m_ConstantInt(&soC)) ||
-            std::abs(soC.getSExtValue()) != S)
-            return;
+        typename PatternT::Store store;
+        if (!pattern.matchStore(st, seeds, S, store))
+            return failure();
+        coalescedStores.push_back(store);
     }
 
     // Map each 1D value to its 2D counterpart, materializing splats/constants
@@ -332,14 +254,20 @@ void rewriteStridedAxisCoalesce(ModuleOp moduleOp) {
             if (isa<RankedTensorType>(src2.getType())) {
                 // src2 is the per-lane reduce result [S] (the 1D scalar source
                 // became a vector once the reduce was 2D-ified). Broadcast it
-                // across T: [S] -> expand_dims(0) -> [1,S] -> broadcast [BT,S].
-                Value ex = rw.create<triton::ExpandDimsOp>(sp.getLoc(), src2, 0);
+                // across T: [S] -> [1,S] -> [BT,S] for block-ptr, or
+                // [S] -> [S,1] -> [S,BT] for addptr.
+                Value ex = rw.create<triton::ExpandDimsOp>(
+                    sp.getLoc(), src2, laneInner ? 0 : 1);
                 n = rw.create<triton::BroadcastOp>(sp.getLoc(),
-                                                   lift2D(sp.getType(), S), ex);
+                                                   lift2D(sp.getType(), S,
+                                                          laneInner),
+                                                   ex);
             } else {
-                // True scalar splat: lift to a 2D splat over [BT,S].
+                // True scalar splat: lift to a 2D splat over the coalesced tile.
                 n = rw.create<triton::SplatOp>(sp.getLoc(),
-                                               lift2D(sp.getType(), S), src2);
+                                               lift2D(sp.getType(), S,
+                                                      laneInner),
+                                               src2);
             }
             vmap[v] = n;
             return n;
@@ -347,7 +275,8 @@ void rewriteStridedAxisCoalesce(ModuleOp moduleOp) {
         if (auto c = v.getDefiningOp<arith::ConstantOp>()) {
             if (auto dea = dyn_cast<DenseElementsAttr>(c.getValue())) {
                 if (dea.isSplat()) {
-                    auto nt = cast<RankedTensorType>(lift2D(c.getType(), S));
+                    auto nt = cast<RankedTensorType>(
+                        lift2D(c.getType(), S, laneInner));
                     rw.setInsertionPointAfter(c);
                     Value n = rw.create<arith::ConstantOp>(
                         c.getLoc(), nt,
@@ -357,33 +286,50 @@ void rewriteStridedAxisCoalesce(ModuleOp moduleOp) {
                 }
             }
         }
+        if (Operation *def = v.getDefiningOp()) {
+            if (is2DSafe(def) && def->getNumResults() == 1) {
+                SmallVector<Value> operands;
+                bool any2D = false;
+                for (Value o : def->getOperands()) {
+                    Value n = get2D(o);
+                    if (!n) return Value();
+                    if (isa<RankedTensorType>(n.getType())) any2D = true;
+                    operands.push_back(n);
+                }
+                if (any2D) {
+                    rw.setInsertionPointAfter(def);
+                    OperationState st(def->getLoc(), def->getName());
+                    st.addOperands(operands);
+                    st.addAttributes(def->getAttrs());
+                    st.addTypes(lift2D(def->getResult(0).getType(), S,
+                                       laneInner));
+                    Operation *nu = rw.create(st);
+                    vmap[v] = nu->getResult(0);
+                    return nu->getResult(0);
+                }
+            }
+        }
         return Value();
     };
 
     // Build 2D loads for the seeds.
-    for (auto l : seeds) {
-        auto m = l.getPtr().getDefiningOp<triton::MakeTensorPtrOp>();
-        Value p2 = build2DBlockPtr(rw, m, S, BT);
-        if (!p2) return;
-        rw.setInsertionPoint(l);
-        auto nl = rw.create<triton::LoadOp>(
-            l.getLoc(), p2, ArrayRef<int32_t>{0, 1}, l.getPadding(),
-            l.getCache(), l.getEvict(), l.getIsVolatile());
-        vmap[l.getResult()] = nl.getResult();
+    for (auto seed : seeds) {
+        Value load2D = pattern.buildLoad2D(rw, seed, get2D);
+        if (!load2D) return failure();
+        vmap[seed.load.getResult()] = load2D;
     }
 
     // Lift each per-head scalar load to an [S] per-lane vector load: base[0:S]
-    // (lane s = base[s], matching the folded i_h = s). The offset must be exactly
-    // i_h = pid % S so that lane s maps to base[s]; otherwise bail.
+    // (lane s = base[s], matching the folded i_h = s). The offset must be
+    // exactly i_h = pid % S so that lane s maps to base[s]; otherwise bail.
     for (auto ld : headLoads) {
         auto ap = ld.getPtr().getDefiningOp<triton::AddPtrOp>();
-        if (!ap) return;
+        if (!ap) return failure();
         Value off = ap.getOffset();
         while (auto e = off.getDefiningOp<arith::ExtSIOp>()) off = e.getIn();
         while (auto t = off.getDefiningOp<arith::TruncIOp>()) off = t.getIn();
-        if (!off.getDefiningOp<arith::RemSIOp>()) return;  // offset not pure i_h
+        if (!off.getDefiningOp<arith::RemSIOp>()) return failure();
         Value base = ap.getPtr();
-        Type elemTy = ld.getResult().getType();
         rw.setInsertionPoint(ld);
         auto loc = ld.getLoc();
         Value cS = rw.create<arith::ConstantOp>(loc, rw.getI64IntegerAttr(S));
@@ -396,8 +342,20 @@ void rewriteStridedAxisCoalesce(ModuleOp moduleOp) {
         auto vl = rw.create<triton::LoadOp>(
             loc, p.getResult(), ArrayRef<int32_t>{0}, triton::PaddingOption::PAD_ZERO,
             triton::CacheModifier::NONE, triton::EvictionPolicy::NORMAL, false);
-        (void)elemTy;
         vmap[ld.getResult()] = vl.getResult();
+    }
+
+    // AddPtrPattern dense row loads use output_row in the original IR. Folded
+    // form loads all H lanes for one batch as a vector [S].
+    for (auto ld : flatDenseLoads) {
+        auto baseIt = flatDenseBases.find(ld.getOperation());
+        auto seedIt = flatDenseSeedIndex.find(ld.getOperation());
+        if (baseIt == flatDenseBases.end() ||
+            seedIt == flatDenseSeedIndex.end())
+            return failure();
+        vmap[ld.getResult()] =
+            pattern.buildDenseLoad2D(rw, ld, seeds[seedIt->second],
+                                     baseIt->second);
     }
 
     // Rebuild the region ops in IR (topological) order as 2D.
@@ -407,10 +365,10 @@ void rewriteStridedAxisCoalesce(ModuleOp moduleOp) {
         rw.setInsertionPoint(op);
         if (auto scan = dyn_cast<triton::ScanOp>(op)) {
             Value in = get2D(scan.getOperand(0));
-            if (!in) return;
+            if (!in) return failure();
+            int axis = laneInner ? scan.getAxis() : scan.getAxis() + 1;
             auto ns = rw.create<triton::ScanOp>(scan.getLoc(), ValueRange{in},
-                                                static_cast<int>(scan.getAxis()),
-                                                scan.getReverse());
+                                                axis, scan.getReverse());
             rw.cloneRegionBefore(scan.getCombineOp(), ns.getCombineOp(),
                                  ns.getCombineOp().end());
             vmap[scan->getResult(0)] = ns->getResult(0);
@@ -418,13 +376,14 @@ void rewriteStridedAxisCoalesce(ModuleOp moduleOp) {
         }
         if (auto reduce = dyn_cast<triton::ReduceOp>(op)) {
             Value in = get2D(reduce.getOperand(0));
-            if (!in) return;
-            // T-axis reduce on the 2D tile [BT,S] -> [S]: one independent
-            // reduction per lane (the S lanes do not mix). The 1D result was a
-            // scalar; its 2D counterpart is the per-lane vector [S], which a
-            // downstream splat turns into an expand_dims+broadcast (see get2D).
+            if (!in) return failure();
+            // T-axis reduce on the 2D tile -> [S]: one independent reduction
+            // per lane (the S lanes do not mix). The 1D result was a scalar;
+            // its 2D counterpart is the per-lane vector [S], which a downstream
+            // splat turns into an expand_dims+broadcast (see get2D).
+            int axis = laneInner ? reduce.getAxis() : reduce.getAxis() + 1;
             auto nr = rw.create<triton::ReduceOp>(reduce.getLoc(), ValueRange{in},
-                                                  static_cast<int>(reduce.getAxis()));
+                                                  axis);
             rw.cloneRegionBefore(reduce.getCombineOp(), nr.getCombineOp(),
                                  nr.getCombineOp().end());
             vmap[reduce->getResult(0)] = nr->getResult(0);
@@ -437,64 +396,899 @@ void rewriteStridedAxisCoalesce(ModuleOp moduleOp) {
         SmallVector<Value> operands;
         for (Value o : op->getOperands()) {
             Value n = get2D(o);
-            if (!n) return;
+            if (!n) return failure();
             operands.push_back(n);
         }
         OperationState st(op->getLoc(), op->getName());
         st.addOperands(operands);
         st.addAttributes(op->getAttrs());
-        for (Value r : op->getResults()) st.addTypes(lift2D(r.getType(), S));
+        for (Value r : op->getResults())
+            st.addTypes(lift2D(r.getType(), S, laneInner));
         Operation *nu = rw.create(st);
         for (auto [oldR, newR] : llvm::zip(op->getResults(), nu->getResults()))
             vmap[oldR] = newR;
     }
 
     // Build the 2D stores.
-    for (auto st : sinks) {
+    for (const auto &store : coalescedStores) {
+        triton::StoreOp st = store.store;
         Value val = get2D(st.getValue());
-        if (!val) return;
-        auto m = st.getPtr().getDefiningOp<triton::MakeTensorPtrOp>();
-        Value p2 = build2DBlockPtr(rw, m, S, BT);
-        if (!p2) return;
-        rw.setInsertionPoint(st);
-        rw.create<triton::StoreOp>(st.getLoc(), p2, val, ArrayRef<int32_t>{0, 1},
-                                   st.getCache(), st.getEvict());
+        if (!val) return failure();
+        if (!pattern.buildStore2D(rw, store, val, S, BT))
+            return failure();
     }
 
     // i_b = divsi(get_program_id, S): with the H axis folded into the inner
-    // tile the per-instance i_b becomes the raw program id. Redirect it (this
-    // also fixes the new 2D block ptr bases, which reuse i_b).
-    if (auto m0 = seeds.front().getPtr().getDefiningOp<triton::MakeTensorPtrOp>()) {
-        if (triton::AddPtrOp ihA = findIhAddPtr(m0.getBase(), S)) {
-            if (auto rem = ihA.getOffset().getDefiningOp<arith::RemSIOp>()) {
-                Value lhs = rem.getLhs();
-                while (true) {
-                    if (auto e = lhs.getDefiningOp<arith::ExtSIOp>()) { lhs = e.getIn(); continue; }
-                    if (auto t = lhs.getDefiningOp<arith::TruncIOp>()) { lhs = t.getIn(); continue; }
-                    break;
-                }
-                SmallVector<arith::DivSIOp, 2> divs;
-                for (Operation *u : lhs.getUsers())
-                    if (auto dv = dyn_cast<arith::DivSIOp>(u)) {
-                        APInt dC;
-                        if (dv.getLhs() == lhs &&
-                            matchPattern(dv.getRhs(), m_ConstantInt(&dC)) &&
-                            std::abs(dC.getSExtValue()) == S)
-                            divs.push_back(dv);
-                    }
-                for (auto dv : divs) rw.replaceAllUsesWith(dv.getResult(), lhs);
-            }
-        }
-    }
+    // tile the per-instance i_b becomes the raw program id. Redirect it when
+    // the concrete pattern has such a folded batch id.
+    pattern.rewriteFoldedBatchId(rw, seeds.front(), S);
 
     // Erase the original chain (sinks, then region in reverse order, then seeds).
     for (auto st : sinks) rw.eraseOp(st);
     for (auto it = ordered.rbegin(); it != ordered.rend(); ++it) rw.eraseOp(*it);
-    for (auto l : seeds) rw.eraseOp(l);
+    for (auto seed : seeds) rw.eraseOp(seed.load);
 
     auto i32t = IntegerType::get(moduleOp.getContext(), 32);
     moduleOp->setAttr("hacc.coalesce_factor", IntegerAttr::get(i32t, S));
     moduleOp->setAttr("hacc.coalesce_axis", IntegerAttr::get(i32t, coalesceAxis));
+    return success();
+}
+
+// Coalesces block-pointer kernels that split a contiguous H axis onto the launch
+// grid:
+//   before: tt.load make_tensor_ptr(base + (pid % S), ..., stride S), tile [BT]
+//   after:  tt.load make_tensor_ptr(base, ..., shape [BT,S], stride inner 1)
+// The rewrite also redirects `pid / S` users to `pid`, because the launcher will
+// divide that grid dimension by S after `hacc.coalesce_factor` is set.
+struct BlockPtrPattern final : public OpRewritePattern<triton::LoadOp> {
+    using OpRewritePattern<triton::LoadOp>::OpRewritePattern;
+    static constexpr bool kLaneInner = true;
+
+    struct Seed {
+        triton::LoadOp load;
+        int64_t S = 0;
+        int64_t BT = 0;
+        int32_t coalesceAxis = -1;
+        triton::MakeTensorPtrOp blockPtr;
+    };
+    struct Store {
+        triton::StoreOp store;
+        triton::MakeTensorPtrOp blockPtr;
+    };
+
+    LogicalResult matchAndRewrite(triton::LoadOp load,
+                                  PatternRewriter &rewriter) const override {
+        ModuleOp moduleOp = load->getParentOfType<ModuleOp>();
+        if (!moduleOp || moduleOp->hasAttr("hacc.coalesce_factor"))
+            return failure();
+
+        Seed seed;
+        if (!matchLoad(load, seed))
+            return failure();
+        return rewriteCoalescedRegion(moduleOp, *this, seed, rewriter);
+    }
+
+    bool matchLoad(triton::LoadOp load, Seed &seed) const {
+        auto m = load.getPtr().getDefiningOp<triton::MakeTensorPtrOp>();
+        if (!m) return false;
+        auto rt = dyn_cast<RankedTensorType>(load.getResult().getType());
+        if (!rt || rt.getRank() != 1) return false;
+        auto strides = m.getStrides();
+        if (strides.empty()) return false;
+        APInt sC;
+        if (!matchPattern(strides.back(), m_ConstantInt(&sC))) return false;
+        int64_t s = std::abs(sC.getSExtValue());
+        if (s <= 1 || !findIhAddPtr(m.getBase(), s)) return false;
+
+        seed.load = load;
+        seed.S = s;
+        seed.BT = rt.getShape()[0];
+        seed.coalesceAxis = findIhAxis(m.getBase(), s);
+        seed.blockPtr = m;
+        return seed.coalesceAxis >= 0;
+    }
+
+    bool matchStore(triton::StoreOp store, ArrayRef<Seed> seeds, int64_t S,
+                    Store &sink) const {
+        auto m = store.getPtr().getDefiningOp<triton::MakeTensorPtrOp>();
+        if (!m || !findIhAddPtr(m.getBase(), S)) return false;
+        auto strides = m.getStrides();
+        if (strides.empty()) return false;
+        APInt sC;
+        if (!matchPattern(strides.back(), m_ConstantInt(&sC)) ||
+            std::abs(sC.getSExtValue()) != S)
+            return false;
+
+        sink.store = store;
+        sink.blockPtr = m;
+        return true;
+    }
+
+    LogicalResult collectExtraLoads(ModuleOp, ArrayRef<Seed> seeds,
+                                    unsigned seedIndex,
+                                    DenseSet<Operation *> &,
+                                    SmallVectorImpl<triton::LoadOp> &headLoads,
+                                    SmallVectorImpl<triton::LoadOp> &,
+                                    DenseMap<Operation *, Value> &,
+                                    DenseMap<Operation *, unsigned> &,
+                                    DenseSet<Operation *> &) const {
+        const Seed &seed = seeds[seedIndex];
+        triton::MakeTensorPtrOp blockPtr = seed.blockPtr;
+        Value ihRem = findIhRem(blockPtr.getBase(), seed.S);
+        if (!ihRem) return success();
+
+        SmallVector<Operation *> worklist(ihRem.getUsers().begin(),
+                                          ihRem.getUsers().end());
+        DenseSet<Operation *> seen;
+        while (!worklist.empty()) {
+            Operation *user = worklist.pop_back_val();
+            if (!seen.insert(user).second) continue;
+            if (isa<triton::MakeTensorPtrOp>(user)) continue;
+            if (auto load = dyn_cast<triton::LoadOp>(user)) {
+                // Per-head scalar load: must be scalar and must not itself feed
+                // an address (indirect gather). Then it is liftable to [S].
+                if (isa<RankedTensorType>(load.getResult().getType()))
+                    return failure();
+                for (Operation *resultUser : load.getResult().getUsers())
+                    if (isa<triton::AddPtrOp>(resultUser))
+                        return failure();
+                headLoads.push_back(load);
+                continue;
+            }
+            if (isa<triton::AddPtrOp, arith::ExtSIOp, arith::TruncIOp,
+                    arith::RemSIOp, arith::AddIOp, arith::MulIOp>(user))
+                for (Operation *nextUser : user->getResult(0).getUsers())
+                    worklist.push_back(nextUser);
+        }
+        return success();
+    }
+
+    Value buildLoad2D(RewriterBase &rw, const Seed &seed, LiftValueFn &) const {
+        triton::LoadOp load = seed.load;
+        Value ptr = build2DBlockPtr(rw, seed.blockPtr, seed.S, seed.BT);
+        if (!ptr) return Value();
+        rw.setInsertionPoint(load);
+        return rw.create<triton::LoadOp>(
+                     load.getLoc(), ptr, ArrayRef<int32_t>{0, 1},
+                     load.getPadding(), load.getCache(), load.getEvict(),
+                     load.getIsVolatile())
+            .getResult();
+    }
+
+    Value buildDenseLoad2D(RewriterBase &, triton::LoadOp, const Seed &,
+                           Value) const {
+        return Value();
+    }
+
+    bool buildStore2D(RewriterBase &rw, const Store &sink, Value value,
+                      int64_t S, int64_t BT) const {
+        triton::StoreOp store = sink.store;
+        Value ptr = build2DBlockPtr(rw, sink.blockPtr, S, BT);
+        if (!ptr) return false;
+        rw.setInsertionPoint(store);
+        rw.create<triton::StoreOp>(store.getLoc(), ptr, value,
+                                   ArrayRef<int32_t>{0, 1}, store.getCache(),
+                                   store.getEvict());
+        return true;
+    }
+
+    void rewriteFoldedBatchId(RewriterBase &rw, const Seed &seed,
+                              int64_t S) const {
+        triton::MakeTensorPtrOp blockPtr = seed.blockPtr;
+        triton::AddPtrOp ih = findIhAddPtr(blockPtr.getBase(), S);
+        if (!ih) return;
+        auto rem = ih.getOffset().getDefiningOp<arith::RemSIOp>();
+        if (!rem) return;
+        Value lhs = rem.getLhs();
+        while (true) {
+            if (auto e = lhs.getDefiningOp<arith::ExtSIOp>()) { lhs = e.getIn(); continue; }
+            if (auto t = lhs.getDefiningOp<arith::TruncIOp>()) { lhs = t.getIn(); continue; }
+            break;
+        }
+        SmallVector<arith::DivSIOp, 2> divs;
+        for (Operation *user : lhs.getUsers())
+            if (auto div = dyn_cast<arith::DivSIOp>(user)) {
+                APInt dC;
+                if (div.getLhs() == lhs &&
+                    matchPattern(div.getRhs(), m_ConstantInt(&dC)) &&
+                    std::abs(dC.getSExtValue()) == S)
+                    divs.push_back(div);
+            }
+        for (auto div : divs)
+            rw.replaceAllUsesWith(div.getResult(), lhs);
+    }
+
+private:
+    // Detects the FLA per-head strided base `base + (pid % S)` produced by
+    // splitting the H axis (the contiguous axis folded onto the grid). Returns the
+    // matching AddPtrOp, or a null AddPtrOp if `base` is not such an ih-split ptr.
+    static triton::AddPtrOp findIhAddPtr(Value base, int64_t S) {
+        Value src = base;
+        while (auto addptr = src.getDefiningOp<triton::AddPtrOp>()) {
+            if (isa<RankedTensorType>(addptr.getPtr().getType())) break;
+            if (auto rem = addptr.getOffset().getDefiningOp<arith::RemSIOp>()) {
+                APInt cC;
+                if (matchPattern(rem.getRhs(), m_ConstantInt(&cC)) &&
+                    std::abs(cC.getSExtValue()) == S) {
+                    Value lhs = rem.getLhs();
+                    while (true) {
+                        if (auto e = lhs.getDefiningOp<arith::ExtSIOp>()) { lhs = e.getIn(); continue; }
+                        if (auto t = lhs.getDefiningOp<arith::TruncIOp>()) { lhs = t.getIn(); continue; }
+                        break;
+                    }
+                    if (lhs.getDefiningOp<triton::GetProgramIdOp>())
+                        return addptr;
+                }
+            }
+            src = addptr.getPtr();
+        }
+        return triton::AddPtrOp();
+    }
+
+    // Mirror of findIhAddPtr that returns the program_id axis driving the ih split
+    // (i.e. the grid dim the host launcher must divide by S), or -1 if `base` is
+    // not such an ih-split ptr. Whenever findIhAddPtr succeeds this does too.
+    static int32_t findIhAxis(Value base, int64_t S) {
+        Value src = base;
+        while (auto addptr = src.getDefiningOp<triton::AddPtrOp>()) {
+            if (isa<RankedTensorType>(addptr.getPtr().getType())) break;
+            if (auto rem = addptr.getOffset().getDefiningOp<arith::RemSIOp>()) {
+                APInt cC;
+                if (matchPattern(rem.getRhs(), m_ConstantInt(&cC)) &&
+                    std::abs(cC.getSExtValue()) == S) {
+                    Value lhs = rem.getLhs();
+                    while (true) {
+                        if (auto e = lhs.getDefiningOp<arith::ExtSIOp>()) { lhs = e.getIn(); continue; }
+                        if (auto t = lhs.getDefiningOp<arith::TruncIOp>()) { lhs = t.getIn(); continue; }
+                        break;
+                    }
+                    if (auto pid = lhs.getDefiningOp<triton::GetProgramIdOp>())
+                        return pid.getAxisAsInt();
+                }
+            }
+            src = addptr.getPtr();
+        }
+        return -1;
+    }
+
+    // Returns the i_h value `pid % S` (the per-head index feeding the ih split), or
+    // null. Mirror of findIhAddPtr but yields the RemSIOp result itself, used to
+    // check whether i_h also feeds a per-head scalar load (which coalescing cannot
+    // lane-expand -- see the correctness guard in rewriteStridedAxisCoalesce).
+    static Value findIhRem(Value base, int64_t S) {
+        Value src = base;
+        while (auto addptr = src.getDefiningOp<triton::AddPtrOp>()) {
+            if (isa<RankedTensorType>(addptr.getPtr().getType())) break;
+            if (auto rem = addptr.getOffset().getDefiningOp<arith::RemSIOp>()) {
+                APInt cC;
+                if (matchPattern(rem.getRhs(), m_ConstantInt(&cC)) &&
+                    std::abs(cC.getSExtValue()) == S)
+                    return rem.getResult();
+            }
+            src = addptr.getPtr();
+        }
+        return Value();
+    }
+
+    static Value build2DBlockPtr(RewriterBase &rw,
+                                 triton::MakeTensorPtrOp m1d,
+                                 int64_t S, int64_t BT) {
+        triton::AddPtrOp ih = findIhAddPtr(m1d.getBase(), S);
+        if (!ih) return Value();
+        auto loc = m1d.getLoc();
+        rw.setInsertionPoint(m1d);
+        Value newBase = ih.getPtr();
+        Value cH = rw.create<arith::ConstantOp>(loc, rw.getI64IntegerAttr(S));
+        Value c1 = rw.create<arith::ConstantOp>(loc, rw.getI64IntegerAttr(1));
+        Value c0 = rw.create<arith::ConstantOp>(loc, rw.getI32IntegerAttr(0));
+        SmallVector<Value, 2> shape{m1d.getShape()[0], cH};
+        SmallVector<Value, 2> strides{m1d.getStrides()[0], c1};
+        SmallVector<Value, 2> offsets{m1d.getOffsets()[0], c0};
+        SmallVector<int32_t, 2> blockShape{static_cast<int32_t>(BT),
+                                           static_cast<int32_t>(S)};
+        SmallVector<int32_t, 2> order{1, 0};
+        auto p = rw.create<triton::MakeTensorPtrOp>(
+            loc, newBase, shape, strides, offsets, blockShape, order);
+        return p.getResult();
+    }
+};
+
+// Coalesces addptr-addressed jagged/dense kernels where the launch grid flattens
+// `(batch, h, column-tile)` into one pid:
+//   before: output_row = pid / cdiv(D, BT), h = output_row % S,
+//           ptr = splat(base + begin + h * D) + (range(0, BT) + group * BT)
+//   after:  materialize [S,BT] offsets so one program computes every h lane for
+//           the same batch and column tile while keeping columns contiguous.
+//           Per-row dense scalar loads become [S] vector loads and are broadcast
+//           through the shared 2D rewrite.
+struct AddPtrPattern final : public OpRewritePattern<triton::AddPtrOp> {
+    using OpRewritePattern<triton::AddPtrOp>::OpRewritePattern;
+    static constexpr bool kLaneInner = false;
+
+    struct Access {
+        enum class RowKind { Jagged, Dense };
+
+        Value outputRow;
+        Value batch;
+        Value lane;
+        Value d;
+        Value cols;
+        Value colMask;
+        Value rowMask;
+        Value begin;
+        Value base;
+        RowKind rowKind = RowKind::Jagged;
+    };
+    struct Seed {
+        triton::LoadOp load;
+        int64_t S = 0;
+        int64_t BT = 0;
+        int32_t coalesceAxis = -1;
+        Access access;
+    };
+    struct Store {
+        triton::StoreOp store;
+        Access access;
+        Value base;
+        Value baseOffset;
+        bool includeBatch = true;
+    };
+
+    LogicalResult matchAndRewrite(triton::AddPtrOp addPtr,
+                                  PatternRewriter &rewriter) const override {
+        ModuleOp moduleOp = addPtr->getParentOfType<ModuleOp>();
+        if (!moduleOp || moduleOp->hasAttr("hacc.coalesce_factor"))
+            return failure();
+
+        Seed seed;
+        if (!matchLoadAddress(addPtr, seed))
+            return failure();
+        return rewriteCoalescedRegion(moduleOp, *this, seed, rewriter);
+    }
+
+    bool matchLoad(triton::LoadOp load, Seed &seed) const {
+        auto addPtr = load.getPtr().getDefiningOp<triton::AddPtrOp>();
+        if (!addPtr) return false;
+        return matchLoadAddress(addPtr, load, seed);
+    }
+
+    bool matchLoadAddress(triton::AddPtrOp addPtr, Seed &seed) const {
+        bool found = false;
+        for (Operation *user : addPtr.getResult().getUsers()) {
+            auto load = dyn_cast<triton::LoadOp>(user);
+            if (!load || load.getPtr() != addPtr.getResult())
+                return false;
+
+            Seed candidate;
+            if (!matchLoadAddress(addPtr, load, candidate))
+                return false;
+            if (!found) {
+                seed = candidate;
+                found = true;
+            }
+        }
+        return found;
+    }
+
+    bool matchLoadAddress(triton::AddPtrOp addPtr, triton::LoadOp load,
+                          Seed &seed) const {
+        return matchStridedLoad(addPtr, load, seed);
+    }
+
+    bool matchStore(triton::StoreOp store, ArrayRef<Seed> seeds, int64_t,
+                    Store &sink) const {
+        const Access *access = nullptr;
+        Value base;
+        for (const Seed &seed : seeds) {
+            auto addPtr = store.getPtr().getDefiningOp<triton::AddPtrOp>();
+            if (!addPtr || addPtr.getOffset() != seed.access.cols) continue;
+            Value rowPtr;
+            if (auto splat = addPtr.getPtr().getDefiningOp<triton::SplatOp>())
+                rowPtr = splat.getSrc();
+            if (!rowPtr) continue;
+            if (store.getMask() != seed.access.colMask) continue;
+            Value baseOffset;
+            bool includeBatch = true;
+            if (!matchDenseRowPtr(rowPtr, seed.access.outputRow,
+                                  seed.access.d, base)) {
+                if (!seed.access.begin ||
+                    !matchJaggedRowPtr(rowPtr, seed.access.begin,
+                                       seed.access.lane, seed.access.d, base))
+                    continue;
+                baseOffset = seed.access.begin;
+                includeBatch = false;
+            }
+            access = &seed.access;
+            sink.baseOffset = baseOffset;
+            sink.includeBatch = includeBatch;
+            break;
+        }
+        if (!access) return false;
+
+        sink.store = store;
+        sink.access = *access;
+        sink.base = base;
+        return true;
+    }
+
+    LogicalResult collectExtraLoads(ModuleOp moduleOp, ArrayRef<Seed> seeds,
+                                    unsigned seedIndex,
+                                    DenseSet<Operation *> &seedOps,
+                                    SmallVectorImpl<triton::LoadOp> &,
+                                    SmallVectorImpl<triton::LoadOp> &denseLoads,
+                                    DenseMap<Operation *, Value> &denseBases,
+                                    DenseMap<Operation *, unsigned> &denseSeedIndex,
+                                    DenseSet<Operation *> &seenDenseLoads) const {
+        const Seed &seed = seeds[seedIndex];
+        // Dense side inputs indexed by output_row are scalar in the original
+        // kernel. After folding H into the tile they become [S] lane loads.
+        moduleOp.walk([&](triton::LoadOp load) {
+            if (seedOps.contains(load.getOperation())) return;
+            if (isa<RankedTensorType>(load.getType())) return;
+            Value ptr = load.getPtr();
+            if (auto addPtr = ptr.getDefiningOp<triton::AddPtrOp>()) {
+                auto zero = getConstantIntValue(addPtr.getOffset());
+                if (zero && *zero == 0)
+                    ptr = addPtr.getPtr();
+            }
+            auto addPtr = ptr.getDefiningOp<triton::AddPtrOp>();
+            if (!addPtr || addPtr.getOffset() != seed.access.outputRow) return;
+            if (load.getMask() && seed.access.rowMask &&
+                load.getMask() != seed.access.rowMask)
+                return;
+            if (!seenDenseLoads.insert(load.getOperation()).second) return;
+            denseLoads.push_back(load);
+            denseBases[load.getOperation()] = addPtr.getPtr();
+            denseSeedIndex[load.getOperation()] = seedIndex;
+        });
+        return success();
+    }
+
+    Value buildLoad2D(RewriterBase &rw, const Seed &seed,
+                      LiftValueFn &get2D) const {
+        triton::LoadOp load = seed.load;
+        rw.setInsertionPoint(load);
+        Value other = load.getOther() ? get2D(load.getOther()) : Value();
+        if (load.getOther() && !other) return Value();
+        const Access &access = seed.access;
+        Location loc = load.getLoc();
+        auto resultType = cast<RankedTensorType>(load.getType());
+        auto tileType = cast<RankedTensorType>(
+            lift2D(resultType, seed.S, kLaneInner));
+        auto tilePtrType =
+            RankedTensorType::get({seed.S, seed.BT}, access.base.getType());
+        auto tileI1Ty =
+            RankedTensorType::get({seed.S, seed.BT}, rw.getI1Type());
+
+        // Row offsets supply the coalesced H dimension, cols supplies the
+        // column tile. Broadcast both into [S,BT] before rebuilding addptr.
+        Value offsets = buildOffsets2D(
+            rw, loc, access, seed.S, seed.BT,
+            access.rowKind == Access::RowKind::Jagged
+                                 ? access.begin
+                                 : Value(),
+            access.rowKind == Access::RowKind::Dense);
+        Value base = rw.create<triton::SplatOp>(loc, tilePtrType, access.base);
+        Value ptrs =
+            rw.create<triton::AddPtrOp>(loc, tilePtrType, base, offsets);
+
+        Value expandedColMask =
+            rw.create<triton::ExpandDimsOp>(loc, access.colMask, 0);
+        Value colMask2d =
+            rw.create<triton::BroadcastOp>(loc, tileI1Ty, expandedColMask);
+        Value mask = colMask2d;
+        if (access.rowMask) {
+            Value rowMask2d = rw.create<triton::SplatOp>(
+                loc, RankedTensorType::get({seed.S, seed.BT}, rw.getI1Type()),
+                access.rowMask);
+            mask = rw.create<arith::AndIOp>(loc, colMask2d, rowMask2d);
+        }
+        if (!other) {
+            Attribute zero = rw.getZeroAttr(tileType.getElementType());
+            other = rw.create<arith::ConstantOp>(
+                loc, DenseElementsAttr::get(tileType, zero));
+        }
+        return rw.create<triton::LoadOp>(
+                     loc, ptrs, mask, other, ArrayRef<int32_t>{}, nullptr,
+                     load.getCache(), load.getEvict(), load.getIsVolatile())
+            .getResult();
+    }
+
+    Value buildDenseLoad2D(RewriterBase &rw, triton::LoadOp load,
+                           const Seed &seed, Value base) const {
+        rw.setInsertionPoint(load);
+        const Access &access = seed.access;
+        Location loc = load.getLoc();
+        Type elemTy = load.getType();
+        Type i32Ty = rw.getI32Type();
+        auto hI32Ty = RankedTensorType::get({seed.S}, i32Ty);
+        auto hElemTy = RankedTensorType::get({seed.S}, elemTy);
+        auto hPtrTy = RankedTensorType::get({seed.S}, base.getType());
+
+        // Dense row load: original base[output_row] becomes base[batch*S + h].
+        Value cS = rw.create<arith::ConstantIntOp>(loc, seed.S, 32);
+        Value hs = rw.create<triton::MakeRangeOp>(loc, hI32Ty, 0, seed.S);
+        Value batchS = rw.create<arith::MulIOp>(loc, access.batch, cS);
+        Value batchSplat = rw.create<triton::SplatOp>(
+            loc, RankedTensorType::get({seed.S}, i32Ty), batchS);
+        Value offsets = rw.create<arith::AddIOp>(loc, batchSplat, hs);
+        Value baseSplat = rw.create<triton::SplatOp>(loc, hPtrTy, base);
+        Value ptrs =
+            rw.create<triton::AddPtrOp>(loc, hPtrTy, baseSplat, offsets);
+        Value mask = Value();
+        if (access.rowMask)
+            mask = rw.create<triton::SplatOp>(
+                loc, RankedTensorType::get({seed.S}, rw.getI1Type()),
+                access.rowMask);
+        Attribute zero = rw.getZeroAttr(hElemTy.getElementType());
+        Value other = rw.create<arith::ConstantOp>(
+            loc, DenseElementsAttr::get(hElemTy, zero));
+        return rw.create<triton::LoadOp>(
+                     loc, ptrs, mask, other, ArrayRef<int32_t>{}, nullptr,
+                     load.getCache(), load.getEvict(), load.getIsVolatile())
+            .getResult();
+    }
+
+    bool buildStore2D(RewriterBase &rw, const Store &sink, Value value,
+                      int64_t S, int64_t BT) const {
+        triton::StoreOp store = sink.store;
+        rw.setInsertionPoint(store);
+        const Access &access = sink.access;
+        Location loc = store.getLoc();
+        auto tilePtrType =
+            RankedTensorType::get({S, BT}, sink.base.getType());
+        auto tileI1Ty =
+            RankedTensorType::get({S, BT}, rw.getI1Type());
+        // Stores may use either dense output_row rows or the same jagged row
+        // form as loads; the matched store carries that choice.
+        Value offsets = buildOffsets2D(rw, loc, access, S, BT, sink.baseOffset,
+                                       sink.includeBatch);
+        Value baseSplat =
+            rw.create<triton::SplatOp>(loc, tilePtrType, sink.base);
+        Value ptrs =
+            rw.create<triton::AddPtrOp>(loc, tilePtrType, baseSplat, offsets);
+        Value expandedMask =
+            rw.create<triton::ExpandDimsOp>(loc, access.colMask, 0);
+        Value mask =
+            rw.create<triton::BroadcastOp>(loc, tileI1Ty, expandedMask);
+        rw.create<triton::StoreOp>(loc, ptrs, value, mask);
+        return true;
+    }
+
+    void rewriteFoldedBatchId(RewriterBase &rw, const Seed &seed,
+                              int64_t) const {
+        // Before coalescing:
+        //   output_row = pid / grid_dim
+        //   batch      = output_row / S
+        //   lane       = output_row % S
+        // After the launcher divides the pid axis by S, output_row already is
+        // the folded batch id. Leaving `batch = output_row / S` would make the
+        // rewritten kernel read/write only one out of every S batches.
+        rw.replaceAllUsesWith(seed.access.batch, seed.access.outputRow);
+    }
+
+private:
+    // Recognizes the launch-grid flattening:
+    // pid -> output_row = pid / grid_dim, group = pid % grid_dim,
+    // output_row -> batch = output_row / S, optional lane = output_row % S.
+    // Dense row addresses only need the batch split; jagged row addresses check
+    // the lane value when matching their row pointer.
+    bool matchFlattenedRowAndLane(triton::GetProgramIdOp pidOp,
+                                  Value &gridDim, Value &outputRow,
+                                  Value &group, Value &batch, Value &lane,
+                                  int64_t &S) const {
+        for (Operation *user : pidOp.getResult().getUsers()) {
+            auto div = dyn_cast<arith::DivSIOp>(user);
+            if (!div || div.getLhs() != pidOp.getResult()) continue;
+
+            Value candidateGridDim = div.getRhs();
+            Value candidateGroup;
+            for (Operation *maybeRemUser : pidOp.getResult().getUsers()) {
+                auto rem = dyn_cast<arith::RemSIOp>(maybeRemUser);
+                if (rem && rem.getLhs() == pidOp.getResult() &&
+                    rem.getRhs() == candidateGridDim) {
+                    candidateGroup = rem.getResult();
+                    break;
+                }
+            }
+            if (!candidateGroup) continue;
+
+            for (Operation *rowUser : div.getResult().getUsers()) {
+                auto batchDiv = dyn_cast<arith::DivSIOp>(rowUser);
+                if (!batchDiv || batchDiv.getLhs() != div.getResult())
+                    continue;
+                auto candidateS = getConstantIntValue(batchDiv.getRhs());
+                if (!candidateS || *candidateS <= 1) continue;
+
+                Value candidateLane;
+                for (Operation *maybeLaneUser : div.getResult().getUsers()) {
+                    auto rem = dyn_cast<arith::RemSIOp>(maybeLaneUser);
+                    if (rem && rem.getLhs() == div.getResult() &&
+                        getConstantIntValue(rem.getRhs()) &&
+                        *getConstantIntValue(rem.getRhs()) == *candidateS) {
+                        candidateLane = rem.getResult();
+                        break;
+                    }
+                }
+
+                gridDim = candidateGridDim;
+                outputRow = div.getResult();
+                group = candidateGroup;
+                batch = batchDiv.getResult();
+                lane = candidateLane;
+                S = *candidateS;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Matches `range(0, BT) + group * BT` and the companion `cols < D` mask.
+    bool matchColumnOffsets(Value cols, Value group, Value &d,
+                            Value &colMask, int64_t &BT) const {
+        auto add = cols.getDefiningOp<arith::AddIOp>();
+        if (!add) return false;
+
+        triton::MakeRangeOp range;
+        Value colBase;
+        if ((range = add.getLhs().getDefiningOp<triton::MakeRangeOp>())) {
+            if (auto splat = add.getRhs().getDefiningOp<triton::SplatOp>())
+                colBase = splat.getSrc();
+        } else if ((range = add.getRhs().getDefiningOp<triton::MakeRangeOp>())) {
+            if (auto splat = add.getLhs().getDefiningOp<triton::SplatOp>())
+                colBase = splat.getSrc();
+        }
+        if (!range || range.getStart() != 0 || !colBase) return false;
+
+        BT = range.getEnd();
+        auto colBaseMul = colBase.getDefiningOp<arith::MulIOp>();
+        if (BT <= 1 || !colBaseMul)
+            return false;
+        auto lhsConst = getConstantIntValue(colBaseMul.getLhs());
+        auto rhsConst = getConstantIntValue(colBaseMul.getRhs());
+        if (!((colBaseMul.getLhs() == group && rhsConst && *rhsConst == BT) ||
+              (colBaseMul.getRhs() == group && lhsConst && *lhsConst == BT)))
+            return false;
+
+        for (Operation *user : cols.getUsers()) {
+            auto cmp = dyn_cast<arith::CmpIOp>(user);
+            if (!cmp || cmp.getPredicate() != arith::CmpIPredicate::slt ||
+                cmp.getLhs() != cols)
+                continue;
+            auto splat = cmp.getRhs().getDefiningOp<triton::SplatOp>();
+            if (!splat) continue;
+            d = splat.getSrc();
+            colMask = cmp.getResult();
+            return true;
+        }
+        return false;
+    }
+
+    // Finds the row pointer table accesses `begin = offsets[batch]` and
+    // `end = offsets[batch + 1]`; begin is needed for the jagged data address.
+    bool matchBeginEnd(Value batch, Value &begin) const {
+        for (Operation *user : batch.getUsers()) {
+            auto beginPtr = dyn_cast<triton::AddPtrOp>(user);
+            if (!beginPtr || beginPtr.getOffset() != batch) continue;
+
+            triton::LoadOp beginLoad;
+            for (Operation *ptrUser : beginPtr.getResult().getUsers()) {
+                beginLoad = dyn_cast<triton::LoadOp>(ptrUser);
+                if (beginLoad) break;
+            }
+            if (!beginLoad) continue;
+
+            Value base = beginPtr.getPtr();
+            for (Operation *batchUser : batch.getUsers()) {
+                auto add = dyn_cast<arith::AddIOp>(batchUser);
+                if (!add ||
+                    !((add.getLhs() == batch &&
+                       getConstantIntValue(add.getRhs()) &&
+                       *getConstantIntValue(add.getRhs()) == 1) ||
+                      (add.getRhs() == batch &&
+                       getConstantIntValue(add.getLhs()) &&
+                       *getConstantIntValue(add.getLhs()) == 1)))
+                    continue;
+                for (Operation *nextUser : add.getResult().getUsers()) {
+                    auto endPtr = dyn_cast<triton::AddPtrOp>(nextUser);
+                    if (!endPtr || endPtr.getPtr() != base ||
+                        endPtr.getOffset() != add.getResult())
+                        continue;
+                    for (Operation *ptrUser : endPtr.getResult().getUsers()) {
+                        auto endLoad = dyn_cast<triton::LoadOp>(ptrUser);
+                        if (!endLoad) continue;
+                        begin = beginLoad.getResult();
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    // Matches the jagged row base `base + begin + lane * D`.
+    bool matchJaggedRowPtr(Value rowPtr, Value begin, Value lane, Value d,
+                           Value &base) const {
+        auto addPtr = rowPtr.getDefiningOp<triton::AddPtrOp>();
+        if (!addPtr) return false;
+        auto add = addPtr.getOffset().getDefiningOp<arith::AddIOp>();
+        if (!add) return false;
+
+        Value laneOffset = add.getLhs() == begin ? add.getRhs() : add.getLhs();
+        while (true) {
+            if (auto e = laneOffset.getDefiningOp<arith::ExtSIOp>()) { laneOffset = e.getIn(); continue; }
+            if (auto t = laneOffset.getDefiningOp<arith::TruncIOp>()) { laneOffset = t.getIn(); continue; }
+            break;
+        }
+        auto laneMul = laneOffset.getDefiningOp<arith::MulIOp>();
+        if (!((add.getLhs() == begin || add.getRhs() == begin) && laneMul &&
+              ((laneMul.getLhs() == lane && laneMul.getRhs() == d) ||
+               (laneMul.getLhs() == d && laneMul.getRhs() == lane))))
+            return false;
+
+        base = addPtr.getPtr();
+        return true;
+    }
+
+    // Matches a dense row base `base + output_row * D`.
+    bool matchDenseRowPtr(Value rowPtr, Value outputRow, Value d,
+                          Value &base) const {
+        auto addPtr = rowPtr.getDefiningOp<triton::AddPtrOp>();
+        auto mul = addPtr ? addPtr.getOffset().getDefiningOp<arith::MulIOp>()
+                          : arith::MulIOp();
+        if (!addPtr || !mul ||
+            !((mul.getLhs() == outputRow && mul.getRhs() == d) ||
+              (mul.getLhs() == d && mul.getRhs() == outputRow)))
+            return false;
+        base = addPtr.getPtr();
+        return true;
+    }
+
+    // Splits the load mask into the required column mask and an optional row
+    // mask. The row mask is kept scalar and later splatted across the tile.
+    bool matchLoadMask(Value mask, Value colMask, Value &rowMask) const {
+        if (mask == colMask) return true;
+        auto andOp = mask.getDefiningOp<arith::AndIOp>();
+        if (!andOp) return false;
+        if (andOp.getLhs() == colMask) {
+            if (auto splat = andOp.getRhs().getDefiningOp<triton::SplatOp>())
+                rowMask = splat.getSrc();
+            return static_cast<bool>(rowMask);
+        }
+        if (andOp.getRhs() == colMask) {
+            if (auto splat = andOp.getLhs().getDefiningOp<triton::SplatOp>())
+                rowMask = splat.getSrc();
+            return static_cast<bool>(rowMask);
+        }
+        return false;
+    }
+
+    // Combines the local checks above into one addptr seed. This deliberately
+    // accepts any matching pid in the entry block, so the pattern is tied to
+    // address structure rather than a specific kernel name or argument order.
+    bool matchStridedLoad(triton::AddPtrOp addPtr, triton::LoadOp load,
+                          Seed &seed) const {
+        auto vectorType = dyn_cast<RankedTensorType>(load.getType());
+        if (!vectorType || vectorType.getRank() != 1) return false;
+        Value rowPtr;
+        if (auto splat = addPtr.getPtr().getDefiningOp<triton::SplatOp>())
+            rowPtr = splat.getSrc();
+        if (!rowPtr) return false;
+
+        auto func = load->getParentOfType<triton::FuncOp>();
+        if (!func) return false;
+        Block &body = func.getBody().front();
+        for (Operation &op : body) {
+            auto pid = dyn_cast<triton::GetProgramIdOp>(op);
+            if (!pid) continue;
+
+            Access candidate;
+            Value gridDim;
+            Value group;
+            int64_t S = 0;
+            int64_t BT = 0;
+            if (!matchFlattenedRowAndLane(pid, gridDim, candidate.outputRow,
+                                          group, candidate.batch,
+                                          candidate.lane, S))
+                continue;
+            if (!matchColumnOffsets(addPtr.getOffset(), group, candidate.d,
+                                    candidate.colMask, BT))
+                continue;
+            auto gridDiv = gridDim.getDefiningOp<arith::DivSIOp>();
+            auto gridBiasAdd = gridDiv
+                                   ? gridDiv.getLhs().getDefiningOp<arith::AddIOp>()
+                                   : arith::AddIOp();
+            int64_t bias = BT - 1;
+            bool isCdiv = false;
+            if (gridDiv && gridBiasAdd) {
+                auto gridDivisor = getConstantIntValue(gridDiv.getRhs());
+                auto lhsBias = getConstantIntValue(gridBiasAdd.getRhs());
+                auto rhsBias = getConstantIntValue(gridBiasAdd.getLhs());
+                isCdiv = gridDivisor && *gridDivisor == BT &&
+                         ((gridBiasAdd.getLhs() == candidate.d && lhsBias &&
+                           *lhsBias == bias) ||
+                          (gridBiasAdd.getRhs() == candidate.d && rhsBias &&
+                           *rhsBias == bias));
+            }
+            if (vectorType.getShape()[0] != BT || !isCdiv)
+                continue;
+            if (!load.getMask() ||
+                !matchLoadMask(load.getMask(), candidate.colMask,
+                               candidate.rowMask))
+                continue;
+            if (matchDenseRowPtr(rowPtr, candidate.outputRow, candidate.d,
+                                 candidate.base)) {
+                candidate.rowKind = Access::RowKind::Dense;
+            } else {
+                if (!matchBeginEnd(candidate.batch, candidate.begin)) continue;
+                if (!matchJaggedRowPtr(rowPtr, candidate.begin, candidate.lane,
+                                       candidate.d, candidate.base))
+                    continue;
+                candidate.rowKind = Access::RowKind::Jagged;
+            }
+
+            candidate.cols = addPtr.getOffset();
+            seed.load = load;
+            seed.S = S;
+            seed.BT = BT;
+            seed.coalesceAxis = pid.getAxisAsInt();
+            seed.access = candidate;
+            return true;
+        }
+        return false;
+    }
+
+    // Constructs the [S,BT] byte/element offsets shared by addptr loads and
+    // stores. `baseOffset` is jagged begin for input loads; `includeBatch`
+    // switches stores to dense output_row addressing.
+    Value buildOffsets2D(RewriterBase &rw, Location loc, const Access &access,
+                         int64_t S, int64_t BT, Value baseOffset,
+                         bool includeBatch) const {
+        Type i32Ty = rw.getI32Type();
+        Type i64Ty = rw.getI64Type();
+        auto hI32Ty = RankedTensorType::get({S}, i32Ty);
+        auto hI64Ty = RankedTensorType::get({S}, i64Ty);
+        auto tileI64Ty = RankedTensorType::get({S, BT}, i64Ty);
+
+        Value cS = rw.create<arith::ConstantIntOp>(loc, S, 32);
+        Value hs = rw.create<triton::MakeRangeOp>(loc, hI32Ty, 0, S);
+        Value rowBase = hs;
+        if (includeBatch) {
+            Value batchS = rw.create<arith::MulIOp>(loc, access.batch, cS);
+            Value batchSplat = rw.create<triton::SplatOp>(
+                loc, RankedTensorType::get({S}, i32Ty), batchS);
+            rowBase = rw.create<arith::AddIOp>(loc, batchSplat, hs);
+        }
+        Value dRows = rw.create<triton::SplatOp>(
+            loc, RankedTensorType::get({S}, i32Ty), access.d);
+        Value rowTimesD = rw.create<arith::MulIOp>(loc, rowBase, dRows);
+        Value rowTimesD64 = rw.create<arith::ExtSIOp>(loc, hI64Ty, rowTimesD);
+        Value expandedRows =
+            rw.create<triton::ExpandDimsOp>(loc, rowTimesD64, 1);
+        Value rowOffsets2d =
+            rw.create<triton::BroadcastOp>(loc, tileI64Ty, expandedRows);
+
+        auto colI64Ty = RankedTensorType::get({BT}, i64Ty);
+        Value cols64 = rw.create<arith::ExtSIOp>(loc, colI64Ty, access.cols);
+        Value expandedCols = rw.create<triton::ExpandDimsOp>(loc, cols64, 0);
+        Value cols2d =
+            rw.create<triton::BroadcastOp>(loc, tileI64Ty, expandedCols);
+        Value offsets = rw.create<arith::AddIOp>(loc, rowOffsets2d, cols2d);
+        if (baseOffset) {
+            Value base2d = rw.create<triton::SplatOp>(
+                loc, RankedTensorType::get({S, BT}, i64Ty),
+                baseOffset);
+            offsets = rw.create<arith::AddIOp>(loc, base2d, offsets);
+        }
+        return offsets;
+    }
+
+};
+
+void rewriteStridedAxisCoalesce(ModuleOp moduleOp) {
+    RewritePatternSet patterns(moduleOp.getContext());
+    patterns.add<BlockPtrPattern, AddPtrPattern>(moduleOp.getContext());
+    (void)applyPatternsAndFoldGreedily(moduleOp, std::move(patterns));
 }
 
 }  // namespace StridedAxisCoalescing

--- a/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/strided_axis_coalescing.mlir
+++ b/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/strided_axis_coalescing.mlir
@@ -1,0 +1,248 @@
+// RUN: triton-opt %s --triton-control-flow-opt \
+// RUN:                --triton-to-unstructure='compile-on-910-95=true force-simt-template=true' \
+// RUN:                --triton-to-linalg='compile-on-910-95=true' \
+// RUN:                --split-input-file \
+// RUN: | FileCheck %s
+
+// BlockPtrPattern: fold `pid % S` from the scalar block-pointer base into an
+// inner [S] block dimension.
+// CHECK-LABEL: module attributes {hacc.coalesce_axis = 0 : i32, hacc.coalesce_factor = 4 : i32
+// CHECK-LABEL: func.func @block_ptr_h_axis
+// CHECK-NOT:   arith.divsi %{{.*}}, %{{.*}} : i32 loc
+// CHECK:       sizes: [16, 4]
+// CHECK:       tensor<16x4xf32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @block_ptr_h_axis(%src: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                   %dst: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+    %pid = tt.get_program_id x : i32
+    %c0 = arith.constant 0 : i32
+    %c4 = arith.constant 4 : i32
+    %c128 = arith.constant 128 : i32
+    %size = arith.constant 128 : i64
+    %stride = arith.constant 4 : i64
+    %h = arith.remsi %pid, %c4 : i32
+    %batch = arith.divsi %pid, %c4 : i32
+    %batch_offset = arith.muli %batch, %c128 : i32
+    %src_batch = tt.addptr %src, %batch_offset : !tt.ptr<f32>, i32
+    %dst_batch = tt.addptr %dst, %batch_offset : !tt.ptr<f32>, i32
+    %src_base = tt.addptr %src_batch, %h : !tt.ptr<f32>, i32
+    %dst_base = tt.addptr %dst_batch, %h : !tt.ptr<f32>, i32
+    %src_ptr = tt.make_tensor_ptr %src_base, [%size], [%stride], [%c0]
+              {order = array<i32: 0>} : <tensor<16xf32>>
+    %val = tt.load %src_ptr {boundaryCheck = array<i32: 0>, padding = 1 : i32}
+           : !tt.ptr<tensor<16xf32>>
+    %sum = arith.addf %val, %val : tensor<16xf32>
+    %dst_ptr = tt.make_tensor_ptr %dst_base, [%size], [%stride], [%c0]
+              {order = array<i32: 0>} : <tensor<16xf32>>
+    tt.store %dst_ptr, %sum : !tt.ptr<tensor<16xf32>>
+    tt.return
+  }
+}
+
+// -----
+// AddPtrPattern: fold the H lane out of output_row in a jagged load plus dense
+// scalar side-input kernel.
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @dense_vec_jagged_h_fuse(%jagged: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                          %dense: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                          %offsets: !tt.ptr<i64> {tt.divisibility = 16 : i32},
+                                          %d: i32 {tt.divisibility = 16 : i32},
+                                          %out: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c31_i32 = arith.constant 31 : i32
+    %zero = arith.constant dense<0.000000e+00> : tensor<32xf32>
+    %c8_i32 = arith.constant 8 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %pid = tt.get_program_id x : i32
+    %grid_num = arith.addi %d, %c31_i32 : i32
+    %grid_dim_col = arith.divsi %grid_num, %c32_i32 : i32
+    %output_row = arith.divsi %pid, %grid_dim_col : i32
+    %batch = arith.divsi %output_row, %c8_i32 : i32
+    %h = arith.remsi %output_row, %c8_i32 : i32
+    %group = arith.remsi %pid, %grid_dim_col : i32
+    %col_base = arith.muli %group, %c32_i32 : i32
+    %range = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %col_base_splat = tt.splat %col_base : i32 -> tensor<32xi32>
+    %cols = arith.addi %col_base_splat, %range : tensor<32xi32>
+    %begin_ptr = tt.addptr %offsets, %batch : !tt.ptr<i64>, i32
+    %begin = tt.load %begin_ptr : !tt.ptr<i64>
+    %batch_next = arith.addi %batch, %c1_i32 : i32
+    %end_ptr = tt.addptr %offsets, %batch_next : !tt.ptr<i64>, i32
+    %end = tt.load %end_ptr : !tt.ptr<i64>
+    %dense_ptr = tt.addptr %dense, %output_row : !tt.ptr<f32>, i32
+    %h_d = arith.muli %h, %d : i32
+    %h_d_i64 = arith.extsi %h_d : i32 to i64
+    %jagged_scalar_off = arith.addi %begin, %h_d_i64 : i64
+    %jagged_ptr = tt.addptr %jagged, %jagged_scalar_off : !tt.ptr<f32>, i64
+    %out_scalar_off = arith.muli %d, %output_row : i32
+    %out_ptr = tt.addptr %out, %out_scalar_off : !tt.ptr<f32>, i32
+    %len = arith.subi %end, %begin : i64
+    %len_index = arith.index_cast %len : i64 to index
+    %trip = arith.minsi %len_index, %c1 : index
+    %d_splat = tt.splat %d : i32 -> tensor<32xi32>
+    %col_mask = arith.cmpi slt, %cols, %d_splat : tensor<32xi32>
+    %res:2 = scf.for %iv = %c0 to %trip step %c1 iter_args(%acc = %zero, %ptr = %jagged_ptr) -> (tensor<32xf32>, !tt.ptr<f32>) {
+      %iv_i64 = arith.index_cast %iv : index to i64
+      %scalar_ptr = tt.addptr %dense_ptr, %iv_i64 : !tt.ptr<f32>, i64
+      %scalar = tt.load %scalar_ptr : !tt.ptr<f32>
+      %jagged_splat = tt.splat %ptr : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>>
+      %vec_ptr = tt.addptr %jagged_splat, %cols : tensor<32x!tt.ptr<f32>>, tensor<32xi32>
+      %vec = tt.load %vec_ptr, %col_mask, %zero : tensor<32x!tt.ptr<f32>>
+      %scalar_splat = tt.splat %scalar : f32 -> tensor<32xf32>
+      %prod = arith.mulf %scalar_splat, %vec : tensor<32xf32>
+      %sum = arith.addf %acc, %prod : tensor<32xf32>
+      %next = tt.addptr %ptr, %c1_i32 : !tt.ptr<f32>, i32
+      scf.yield %sum, %next : tensor<32xf32>, !tt.ptr<f32>
+    }
+    %out_splat = tt.splat %out_ptr : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>>
+    %store_ptr = tt.addptr %out_splat, %cols : tensor<32x!tt.ptr<f32>>, tensor<32xi32>
+    tt.store %store_ptr, %res#0, %col_mask : tensor<32x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: module attributes {hacc.coalesce_axis = 0 : i32, hacc.coalesce_factor = 8 : i32
+// CHECK-LABEL: func.func @dense_vec_jagged_h_fuse
+// CHECK-NOT:   scf.for
+// CHECK:       %[[GRID0:.*]] = arith.divsi %{{.*}}, %{{.*}} : i32
+// CHECK:       %[[BATCH0:.*]] = arith.divsi %{{.*}}, %[[GRID0]] : i32
+// CHECK-NOT:   arith.divsi %[[BATCH0]], %{{.*}} : i32
+// CHECK:       sizes: [8]
+// CHECK:       sizes: [8, 32]
+// CHECK:       strides: [{{.*}}, 1]
+// CHECK:       tensor<8x32xf32>
+// CHECK:       linalg.generic
+// CHECK:       tensor<8x32xf32>
+
+// -----
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @dense_vec_jagged_h_fuse_permuted_args(%dense: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                                        %out: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                                        %d: i32 {tt.divisibility = 16 : i32},
+                                                        %offsets: !tt.ptr<i64> {tt.divisibility = 16 : i32},
+                                                        %jagged: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c15_i32 = arith.constant 15 : i32
+    %zero = arith.constant dense<0.000000e+00> : tensor<16xf32>
+    %c4_i32 = arith.constant 4 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c16_i32 = arith.constant 16 : i32
+    %pid = tt.get_program_id x : i32
+    %grid_num = arith.addi %d, %c15_i32 : i32
+    %grid_dim_col = arith.divsi %grid_num, %c16_i32 : i32
+    %output_row = arith.divsi %pid, %grid_dim_col : i32
+    %batch = arith.divsi %output_row, %c4_i32 : i32
+    %h = arith.remsi %output_row, %c4_i32 : i32
+    %group = arith.remsi %pid, %grid_dim_col : i32
+    %col_base = arith.muli %group, %c16_i32 : i32
+    %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %col_base_splat = tt.splat %col_base : i32 -> tensor<16xi32>
+    %cols = arith.addi %range, %col_base_splat : tensor<16xi32>
+    %begin_ptr = tt.addptr %offsets, %batch : !tt.ptr<i64>, i32
+    %begin = tt.load %begin_ptr : !tt.ptr<i64>
+    %batch_next = arith.addi %c1_i32, %batch : i32
+    %end_ptr = tt.addptr %offsets, %batch_next : !tt.ptr<i64>, i32
+    %end = tt.load %end_ptr : !tt.ptr<i64>
+    %dense_ptr = tt.addptr %dense, %output_row : !tt.ptr<f32>, i32
+    %h_d = arith.muli %d, %h : i32
+    %h_d_i64 = arith.extsi %h_d : i32 to i64
+    %jagged_scalar_off = arith.addi %h_d_i64, %begin : i64
+    %jagged_ptr = tt.addptr %jagged, %jagged_scalar_off : !tt.ptr<f32>, i64
+    %out_scalar_off = arith.muli %output_row, %d : i32
+    %out_ptr = tt.addptr %out, %out_scalar_off : !tt.ptr<f32>, i32
+    %len = arith.subi %end, %begin : i64
+    %len_index = arith.index_cast %len : i64 to index
+    %trip = arith.minsi %len_index, %c1 : index
+    %d_splat = tt.splat %d : i32 -> tensor<16xi32>
+    %col_mask = arith.cmpi slt, %cols, %d_splat : tensor<16xi32>
+    %res:2 = scf.for %iv = %c0 to %trip step %c1 iter_args(%acc = %zero, %ptr = %jagged_ptr) -> (tensor<16xf32>, !tt.ptr<f32>) {
+      %iv_i64 = arith.index_cast %iv : index to i64
+      %scalar_ptr = tt.addptr %dense_ptr, %iv_i64 : !tt.ptr<f32>, i64
+      %scalar = tt.load %scalar_ptr : !tt.ptr<f32>
+      %jagged_splat = tt.splat %ptr : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+      %vec_ptr = tt.addptr %jagged_splat, %cols : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      %vec = tt.load %vec_ptr, %col_mask, %zero : tensor<16x!tt.ptr<f32>>
+      %scalar_splat = tt.splat %scalar : f32 -> tensor<16xf32>
+      %prod = arith.mulf %vec, %scalar_splat : tensor<16xf32>
+      %sum = arith.addf %prod, %acc : tensor<16xf32>
+      %next = tt.addptr %ptr, %c1_i32 : !tt.ptr<f32>, i32
+      scf.yield %sum, %next : tensor<16xf32>, !tt.ptr<f32>
+    }
+    %out_splat = tt.splat %out_ptr : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+    %store_ptr = tt.addptr %out_splat, %cols : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+    tt.store %store_ptr, %res#0, %col_mask : tensor<16x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: module attributes {hacc.coalesce_axis = 0 : i32, hacc.coalesce_factor = 4 : i32
+// CHECK-LABEL: func.func @dense_vec_jagged_h_fuse_permuted_args
+// CHECK-NOT:   scf.for
+// CHECK:       %[[GRID1:.*]] = arith.divsi %{{.*}}, %{{.*}} : i32
+// CHECK:       %[[BATCH1:.*]] = arith.divsi %{{.*}}, %[[GRID1]] : i32
+// CHECK-NOT:   arith.divsi %[[BATCH1]], %{{.*}} : i32
+// CHECK:       sizes: [4]
+// CHECK:       sizes: [4, 16]
+// CHECK:       strides: [{{.*}}, 1]
+// CHECK:       tensor<4x16xf32>
+// CHECK:       linalg.generic
+// CHECK:       tensor<4x16xf32>
+
+// -----
+
+// AddPtrPattern also handles dense row bases:
+//   splat(base + output_row * D) + (range(0, BT) + group * BT)
+// This uses the same launch decomposition as the jagged case but has no
+// offsets-table begin/end loads.
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @dense_vec_dense_h_fuse(%src: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                         %scale: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                         %out: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                         %d: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c7_i32 = arith.constant 7 : i32
+    %zero = arith.constant dense<0.000000e+00> : tensor<8xf32>
+    %c2_i32 = arith.constant 2 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %pid = tt.get_program_id x : i32
+    %grid_num = arith.addi %d, %c7_i32 : i32
+    %grid_dim_col = arith.divsi %grid_num, %c8_i32 : i32
+    %output_row = arith.divsi %pid, %grid_dim_col : i32
+    %batch = arith.divsi %output_row, %c2_i32 : i32
+    %h = arith.remsi %output_row, %c2_i32 : i32
+    %group = arith.remsi %pid, %grid_dim_col : i32
+    %col_base = arith.muli %group, %c8_i32 : i32
+    %range = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+    %col_base_splat = tt.splat %col_base : i32 -> tensor<8xi32>
+    %cols = arith.addi %col_base_splat, %range : tensor<8xi32>
+    %src_scalar_off = arith.muli %output_row, %d : i32
+    %src_ptr = tt.addptr %src, %src_scalar_off : !tt.ptr<f32>, i32
+    %scale_ptr = tt.addptr %scale, %batch : !tt.ptr<f32>, i32
+    %scale_val = tt.load %scale_ptr : !tt.ptr<f32>
+    %out_scalar_off = arith.muli %d, %output_row : i32
+    %out_ptr = tt.addptr %out, %out_scalar_off : !tt.ptr<f32>, i32
+    %d_splat = tt.splat %d : i32 -> tensor<8xi32>
+    %col_mask = arith.cmpi slt, %cols, %d_splat : tensor<8xi32>
+    %src_splat = tt.splat %src_ptr : !tt.ptr<f32> -> tensor<8x!tt.ptr<f32>>
+    %src_vec_ptr = tt.addptr %src_splat, %cols : tensor<8x!tt.ptr<f32>>, tensor<8xi32>
+    %vec = tt.load %src_vec_ptr, %col_mask, %zero : tensor<8x!tt.ptr<f32>>
+    %scale_splat = tt.splat %scale_val : f32 -> tensor<8xf32>
+    %sum = arith.mulf %vec, %scale_splat : tensor<8xf32>
+    %out_splat = tt.splat %out_ptr : !tt.ptr<f32> -> tensor<8x!tt.ptr<f32>>
+    %store_ptr = tt.addptr %out_splat, %cols : tensor<8x!tt.ptr<f32>>, tensor<8xi32>
+    tt.store %store_ptr, %sum, %col_mask : tensor<8x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: module attributes {hacc.coalesce_axis = 0 : i32, hacc.coalesce_factor = 2 : i32
+// CHECK-LABEL: func.func @dense_vec_dense_h_fuse
+// CHECK:       %[[GRID2:.*]] = arith.divsi %{{.*}}, %{{.*}} : i32
+// CHECK:       %[[BATCH2:.*]] = arith.divsi %{{.*}}, %[[GRID2]] : i32
+// CHECK-NOT:   arith.divsi %[[BATCH2]], %{{.*}} : i32
+// CHECK:       sizes: [2, 8]
+// CHECK:       strides: [{{.*}}, 1]
+// CHECK:       tensor<2x8xf32>

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scf_pointer_decouple.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scf_pointer_decouple.mlir
@@ -691,3 +691,62 @@ module {
 // CHECK:         scf.yield %[[INNER_PTR]] : !tt.ptr<tensor<16xf32>>
 // CHECK:       }
 // CHECK:       tt.return %[[OUTER]] : !tt.ptr<tensor<16xf32>>
+
+// -----
+
+module {
+  tt.func public @predicate_one_trip_loads(%base: !tt.ptr<f32>, %dense: !tt.ptr<f32>, %len: index, %offsets: tensor<4xi32>, %col_mask: tensor<4xi1>) -> tensor<4xf32> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c1_i32 = arith.constant 1 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<4xf32>
+    %trip = arith.minsi %len, %c1 : index
+    %res:2 = scf.for %iv = %c0 to %trip step %c1 iter_args(%acc = %cst, %ptr = %base) -> (tensor<4xf32>, !tt.ptr<f32>) {
+      %iv_i64 = arith.index_cast %iv : index to i64
+      %scalar_ptr = tt.addptr %dense, %iv_i64 : !tt.ptr<f32>, i64
+      %scalar = tt.load %scalar_ptr : !tt.ptr<f32>
+      %splat_ptr = tt.splat %ptr : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+      %vec_ptr = tt.addptr %splat_ptr, %offsets : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      %vec = tt.load %vec_ptr, %col_mask, %cst : tensor<4x!tt.ptr<f32>>
+      %splat_scalar = tt.splat %scalar : f32 -> tensor<4xf32>
+      %prod = arith.mulf %splat_scalar, %vec : tensor<4xf32>
+      %sum = arith.addf %acc, %prod : tensor<4xf32>
+      %next = tt.addptr %ptr, %c1_i32 : !tt.ptr<f32>, i32
+      scf.yield %sum, %next : tensor<4xf32>, !tt.ptr<f32>
+    }
+    tt.return %res#0 : tensor<4xf32>
+  }
+}
+
+// CHECK-LABEL: tt.func public @predicate_one_trip_loads
+// CHECK-NOT:   scf.for
+// CHECK:       %[[COND:.*]] = arith.cmpi slt, %{{.*}}, %{{.*}} : index
+// CHECK:       %[[SCALAR_ZERO:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:       tt.load %{{.*}}, %[[COND]], %[[SCALAR_ZERO]] : !tt.ptr<f32>
+// CHECK:       %[[PRED_MASK:.*]] = tt.splat %[[COND]] : i1 -> tensor<4xi1>
+// CHECK:       %[[COMBINED_MASK:.*]] = arith.andi %{{.*}}, %[[PRED_MASK]] : tensor<4xi1>
+// CHECK:       tt.load %{{.*}}, %[[COMBINED_MASK]], %{{.*}} : tensor<4x!tt.ptr<f32>>
+// CHECK:       arith.select %[[COND]], %{{.*}}, %{{.*}} : tensor<4xf32>
+// CHECK:       tt.return
+
+// -----
+
+module {
+  tt.func public @predicate_one_trip_store(%ptrs: tensor<4x!tt.ptr<f32>>, %value: tensor<4xf32>, %len: index, %mask: tensor<4xi1>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %trip = arith.minsi %len, %c1 : index
+    scf.for %iv = %c0 to %trip step %c1 {
+      tt.store %ptrs, %value, %mask : tensor<4x!tt.ptr<f32>>
+    }
+    tt.return
+  }
+}
+
+// CHECK-LABEL: tt.func public @predicate_one_trip_store
+// CHECK-NOT:   scf.for
+// CHECK:       %[[COND:.*]] = arith.cmpi slt, %{{.*}}, %{{.*}} : index
+// CHECK:       %[[PRED_MASK:.*]] = tt.splat %[[COND]] : i1 -> tensor<4xi1>
+// CHECK:       %[[COMBINED_MASK:.*]] = arith.andi %{{.*}}, %[[PRED_MASK]] : tensor<4xi1>
+// CHECK:       tt.store %{{.*}}, %{{.*}}, %[[COMBINED_MASK]] : tensor<4x!tt.ptr<f32>>
+// CHECK:       tt.return


### PR DESCRIPTION
## Why

Some Triton kernels launch one program per short logical lane, for example
`pid -> (batch, h, col_tile)`, and then perform scalar-heavy work for each
`h` lane independently. This shape is unfriendly to Ascend NPU execution:
the useful vector work is split across many small programs, while scalar
addressing and control-flow overhead remain high.

`StridedAxisCoalescing` already handled the block-pointer form of this
pattern, where the folded axis is visible in `tt.make_tensor_ptr`. However,
dense-vector/jagged-row kernels often express the same logical layout through
`tt.addptr`:

- `output_row = pid / cdiv(D, BT)`
- `batch = output_row / S`
- `h = output_row % S`
- `cols = range(0, BT) + group * BT`
- row address is either dense `base + output_row * D` or jagged
  `base + begin + h * D`

Before this MR, those kernels could not be coalesced, even though each `h`
lane is independent and can be computed as one `[S, BT]` tile.

There is also a control-flow obstacle before coalescing: some kernels contain
an `scf.for` whose trip count is at most one. Keeping that loop hides the
straight-line load/compute/store region from later pattern matching, although
the loop can be represented safely with predication.

## What Changed

This MR contains two commits:

1. Add one-trip `scf.for` predication in `TritonControlFlowOpt`

   Loops with a provable `0..min(dynamic, 1)` shape are rewritten into
   predicated straight-line code. This removes control-flow that is not
   semantically useful for vectorization while preserving the zero-trip case.

2. Extend `StridedAxisCoalescing` to addptr-addressed kernels

   The pass now recognizes addptr-addressed dense and jagged row layouts that
   flatten `(batch, h, col_tile)` into one program id. When the matched region
   is lane-independent, it folds the `h` axis into the per-program tile and
   emits `[S, BT]` loads/stores so the column dimension remains contiguous.

## Correctness Constraints

The addptr coalescing path is intentionally guarded. It only fires when the
matched loads and stores agree on:

- the same coalesce factor `S`
- the same column tile size `BT`
- the same launch axis
- a recognized `cdiv(D, BT)` column grid
- dense row addressing `base + output_row * D`, or jagged row addressing
  `base + begin + h * D`
- lane-independent intermediate operations

The pass also bails out if the kernel reads `num_programs` on the coalesced
axis, because the launcher changes that grid dimension after setting
`hacc.coalesce_factor`.

The folded batch id is rewritten so the post-coalescing program id still
indexes the original batch correctly.

## Tests

Added lit coverage for:

- one-trip loop predication with loads
- one-trip loop predication with stores
- existing block-pointer strided-axis coalescing
- addptr jagged row coalescing
- addptr jagged row coalescing with permuted argument/order variants
- addptr dense row coalescing
