### PR TITLE
[ssbuffer](fix) fix cloned op cleanup in CloneOps

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/Utils.h
@@ -62,6 +62,11 @@ int findTcbGroupId(Value v, llvm::DenseMap<int, SmallVector<Value>> &tightlyCoup
 // Returns failure if scopeOp does not have tcore_type attribute
 LogicalResult getScopeType(Operation *scopeOp, bool &isCube, bool &isVector);
 
+// Check if op is a scf.if whose body only contains hivm.hir.sync_block_wait,
+// hivm.hir.sync_block_set and hivm.fixpipe ops (excluding terminators).
+// Returns false if op is not a scf.if or contains any other op.
+bool isIfOpWithOnlySyncOps(Operation *op);
+
 } // namespace triton
 } // namespace mlir
 #endif // TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_UTILS_H

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CloneOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CloneOps.cpp
@@ -231,6 +231,11 @@ static bool shouldEraseOpForCube(Operation *op, const CVPipeline::MemoryDependen
       if (isa<SyncBlockWaitOp>(execOp) || isa<SyncBlockSetOp>(execOp)) {
         return false;
       }
+      // scf.if whose body only contains sync_block_wait/sync_block_set ops will be cleaned up
+      // in its own turn; skip it here so it does not block the current op's erasure.
+      if (isIfOpWithOnlySyncOps(execOp)) {
+        return false;
+      }
       auto execBlockId = CVPipeline::getOpBlockId(execOp);
       return execBlockId && opBlockId && *execBlockId == *opBlockId;
     });

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/Utils.cpp
@@ -228,3 +228,29 @@ LogicalResult triton::getScopeType(Operation *scopeOp, bool &isCube, bool &isVec
 
   return success();
 }
+
+// Check if op is a scf.if whose body only contains hivm.hir.sync_block_wait,
+// hivm.hir.sync_block_set and hivm.fixpipe ops (excluding terminators).
+bool triton::isIfOpWithOnlySyncOps(Operation *op)
+{
+  auto ifOp = dyn_cast<scf::IfOp>(op);
+  if (!ifOp) {
+    return false;
+  }
+
+  WalkResult result = ifOp->walk([&](Operation *innerOp) -> WalkResult {
+    if (innerOp == op) {
+      return WalkResult::advance();
+    }
+    if (innerOp->hasTrait<OpTrait::IsTerminator>()) {
+      return WalkResult::advance();
+    }
+    if (!isa<hivm::SyncBlockWaitOp>(innerOp) && !isa<hivm::SyncBlockSetOp>(innerOp) &&
+        !isa<hivm::FixpipeOp>(innerOp)) {
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+
+  return !result.wasInterrupted();
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/test-clone-ops-if-only-sync.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/test-clone-ops-if-only-sync.mlir
@@ -1,0 +1,64 @@
+// RUN: triton-opt --clone-ops --allow-unregistered-dialect %s | FileCheck %s
+
+// Unit test for CloneOps pass: an scf.if whose body only contains
+// hivm.hir.sync_block_wait/set ops must be skipped in the
+// shouldEraseOpForCube Rule-3 execAfter check, so that earlier cloned
+// ops in the same block_id are not blocked by it.
+//
+// Setup: a CUBE main_loop with two block_ids. Block 10 contains:
+//   - annotation.mark  (op with no results, hits Rule 3)
+//   - scf.if whose body only has sync_block_wait and sync_block_set
+// Block 11 has a sync_block_set (sync op, already skipped by line 232
+// in the existing execAfter lambda).
+//
+// After --clone-ops, block 11 contains (in source order):
+//   [cloned_annotation_mark, cloned_ifOp, sync_block_set]
+//
+// Cleanup processes cloned ops bottom-to-top. For each cloned op,
+// shouldEraseOpForCube rebuilds the memGraph and walks the op's
+// execAfter. Without the isIfOpWithOnlySyncOps short-circuit, the
+// cloned_ifOp would be counted as a same-block_id blocker for the
+// cloned_annotation_mark, preventing its erasure. With the fix the
+// cloned_ifOp is treated like a sync op (skipped), so the cloned
+// annotation_mark is also erased. The cloned_ifOp itself is erased
+// in turn because its execAfter contains only the sync_block_set
+// (already skipped by line 232).
+//
+// Expected output: only the original (block_id=10) ops survive in the
+// forOp body. Both the cloned annotation.mark and the cloned scf.if
+// at block_id=11 are erased.
+
+// CHECK-LABEL: func.func @test_if_with_only_sync_ops_clone_cleanup
+// The original scf.if at block 10 is preserved.
+// CHECK:         scf.if
+// CHECK:           hivm.hir.sync_block_wait
+// CHECK:           hivm.hir.sync_block_set
+// The cloned annotation.mark at block 11 must be erased (the fix is
+// what allows the cloned_ifOp to be skipped in its execAfter check).
+// CHECK-NOT:      annotation.mark
+// The cloned scf.if at block 11 must also be erased.
+// CHECK-NOT:      scf.if
+// CHECK:         return
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_if_with_only_sync_ops_clone_cleanup(%arg0: i1, %arg1: memref<4x2x16x8xf32, #hivm.address_space<cbuf>>) attributes {global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c10_i32 = arith.constant 10 : i32
+    scope.scope : () -> () {
+      %alloc = memref.alloc() {ssbuffer.block_id = 10 : i32} : memref<4x2x16x8xf32, #hivm.address_space<cbuf>>
+      scf.for %arg2 = %c0_i32 to %c10_i32 step %c1_i32 : i32 {
+        // Block 10: annotation.mark (op with no results) + scf.if(only sync ops)
+        annotation.mark %alloc {effects = ["write", "read"], ssbuffer.block_id = 10 : i32} : memref<4x2x16x8xf32, #hivm.address_space<cbuf>>
+        scf.if %arg0 {
+          hivm.hir.sync_block_wait {ssbuffer.block_id = 10 : i32, ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
+          hivm.hir.sync_block_set {ssbuffer.block_id = 10 : i32, ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
+        } {ssbuffer.block_id = 10 : i32}
+        // Block 11: triggers cloning of block 10's ops into block 11
+        hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+      } {ssbuffer.block_id = 10 : i32, ssbuffer.main_loop = 0 : i32}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+    return
+  }
+}


### PR DESCRIPTION
**DynamicCVPipeline: fix cloned op cleanup in CloneOps**

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
