### PR TITLE
[simt](fix) make IndirectLoad volatile analysis barrier-aware

### DIFF
--- a/third_party/ascend/lib/Utils/CMakeLists.txt
+++ b/third_party/ascend/lib/Utils/CMakeLists.txt
@@ -4,5 +4,6 @@ add_triton_library(MLIRTritonNPUUtils
 
   LINK_LIBS PUBLIC
   MLIRIR
+  MLIRGPUDialect
   TritonIR
 )

--- a/third_party/ascend/lib/Utils/Utils.cpp
+++ b/third_party/ascend/lib/Utils/Utils.cpp
@@ -26,6 +26,7 @@
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -569,74 +570,146 @@ static bool mayWriteRoot(Operation *op, Value loadRootPtr) {
   return false;
 }
 
+// A synchronizing barrier (e.g. gpu.barrier, lowered from tl.debug_barrier)
+// acts as a memory fence: every write ordered before it is made globally visible
+// to any access ordered after it. An indirect load placed after such a barrier
+// therefore does not need volatile semantics to observe earlier same-root
+// writes, because the fence already guarantees their visibility.
+static bool isSynchronizingBarrier(Operation *op) {
+  return isa<mlir::gpu::BarrierOp>(op);
+}
+
+// Does `op` itself write through (an alias of) the load's root pointer?
+static bool opMayWriteRoot(Operation *op, Value loadRootPtr) {
+  // Device-side diagnostics are modeled as GlobalMemory writes in Triton, but
+  // they do not write through user GM pointers; ignore them.
+  if (isa<triton::AssertOp, triton::PrintOp>(op)) {
+    return false;
+  }
+
+  auto memRefWriteTarget =
+      llvm::TypeSwitch<Operation *, Value>(op)
+          .Case<memref::CopyOp>([](auto copyOp) { return copyOp.getTarget(); })
+          .Case<memref::StoreOp>(
+              [](auto storeOp) { return storeOp.getMemRef(); })
+          .Default([](Operation *) { return Value(); });
+  if (memRefWriteTarget) {
+    auto rootPtr = getRootPointer(memRefWriteTarget);
+    if (rootPtr) {
+      return *rootPtr == loadRootPtr;
+    }
+    return !isLocalMemRef(memRefWriteTarget);
+  }
+
+  auto writePtr = getKnownWritePointer(op);
+  if (writePtr.isWrite) {
+    return !writePtr.rootPtr || *writePtr.rootPtr == loadRootPtr;
+  }
+
+  // Structured control flow is looked through by the recursive classifier
+  // below, not summarized here.
+  if (isa<scf::IfOp>(op) || isa<LoopLikeOpInterface>(op)) {
+    return false;
+  }
+
+  // Unknown side-effecting ops are conservative.
+  return mayWriteRoot(op, loadRootPtr);
+}
+
+// Any same-root write anywhere inside `container`'s regions.
+static bool anyNestedWrite(Operation *container, Value root) {
+  bool found = false;
+  container->walk<WalkOrder::PreOrder>([&](Operation *nested) {
+    if (nested == container) {
+      return WalkResult::advance();
+    }
+    if (opMayWriteRoot(nested, root)) {
+      found = true;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return found;
+}
+
+// How an op/block affects the load's shielding from earlier same-root writes,
+// when scanning a block from its exit backward:
+//   - WriteEscapes : a same-root write reaches the exit with no barrier after it
+//   - Shielded     : a barrier is reached first (covers writes before it)
+//   - None         : neither (neutral; keep scanning outward)
+enum class BarrierState { None, Shielded, WriteEscapes };
+
+static BarrierState classifyOp(Operation *op, Value root);
+
+// Scan a block from its terminator backward; the first decisive op wins.
+static BarrierState classifyBlock(Block *blk, Value root) {
+  if (!blk || blk->empty()) {
+    return BarrierState::None;
+  }
+  for (Operation *op = blk->getTerminator()->getPrevNode(); op;
+       op = op->getPrevNode()) {
+    BarrierState r = classifyOp(op, root);
+    if (r != BarrierState::None) {
+      return r;
+    }
+  }
+  return BarrierState::None;
+}
+
+static BarrierState classifyOp(Operation *op, Value root) {
+  if (isSynchronizingBarrier(op)) {
+    return BarrierState::Shielded;
+  }
+  if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+    BarrierState t = classifyBlock(ifOp.thenBlock(), root);
+    BarrierState e = ifOp.elseBlock() ? classifyBlock(ifOp.elseBlock(), root)
+                                      : BarrierState::None;
+    // A write escaping either branch forces volatile; a barrier shields only if
+    // present on both branches.
+    if (t == BarrierState::WriteEscapes || e == BarrierState::WriteEscapes) {
+      return BarrierState::WriteEscapes;
+    }
+    if (t == BarrierState::Shielded && e == BarrierState::Shielded) {
+      return BarrierState::Shielded;
+    }
+    return BarrierState::None;
+  }
+  if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+    // The loop may run zero times, so an in-body barrier cannot shield outer
+    // writes; an in-body same-root write is loop-carried -> escapes.
+    return classifyBlock(forOp.getBody(), root) == BarrierState::WriteEscapes
+               ? BarrierState::WriteEscapes
+               : BarrierState::None;
+  }
+  if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+    BarrierState b = classifyBlock(whileOp.getBeforeBody(), root);
+    BarrierState a = classifyBlock(whileOp.getAfterBody(), root);
+    return (b == BarrierState::WriteEscapes || a == BarrierState::WriteEscapes)
+               ? BarrierState::WriteEscapes
+               : BarrierState::None;
+  }
+  if (opMayWriteRoot(op, root)) {
+    return BarrierState::WriteEscapes;
+  }
+  if (op->getNumRegions() > 0 && anyNestedWrite(op, root)) {
+    return BarrierState::WriteEscapes;
+  }
+  return BarrierState::None;
+}
+
 // Keep an indirect load volatile unless its root pointer is proven to have no
 // possible prior write. The analysis scans ordered predecessors in the same
 // and enclosing blocks, nested writes in predecessor structured-control-flow
 // ops, and loop-carried writes where a later store in the loop body may feed a
-// following iteration.
+// following iteration. A synchronizing barrier ordered before the load shields
+// any write ordered before that barrier (see isSynchronizingBarrier).
 bool requiresVolatileIndirectLoad(Value srcPtr, Operation *loadOp) {
   auto loadRootPtr = getRootPointer(srcPtr);
   if (!loadRootPtr) {
     return true;
   }
 
-  auto opMayWriteRoot = [&](Operation *op) {
-    // Device-side diagnostics are modeled as GlobalMemory writes in Triton,
-    // but they do not write through user GM pointers and must not affect the
-    // indirect-load source/root analysis.
-    if (isa<triton::AssertOp, triton::PrintOp>(op)) {
-      return false;
-    }
-
-    auto memRefWriteTarget =
-        llvm::TypeSwitch<Operation *, Value>(op)
-            .Case<memref::CopyOp>([](auto copyOp) {
-              return copyOp.getTarget();
-            })
-            .Case<memref::StoreOp>([](auto storeOp) {
-              return storeOp.getMemRef();
-            })
-            .Default([](Operation *) { return Value(); });
-    if (memRefWriteTarget) {
-      auto rootPtr = getRootPointer(memRefWriteTarget);
-      if (rootPtr) {
-        return *rootPtr == *loadRootPtr;
-      }
-      return !isLocalMemRef(memRefWriteTarget);
-    }
-
-    auto writePtr = getKnownWritePointer(op);
-    if (writePtr.isWrite) {
-      return !writePtr.rootPtr || *writePtr.rootPtr == *loadRootPtr;
-    }
-
-    // For structured control flow, look through regions instead of using the
-    // op-level MemoryEffect summary, otherwise unrelated nested writes would
-    // make this load volatile.
-    if (isa<scf::IfOp>(op) || isa<LoopLikeOpInterface>(op)) {
-      return false;
-    }
-
-    // Unknown side-effecting ops are conservative: they may write through an
-    // alias that is no longer recoverable as a Triton root.
-    return mayWriteRoot(op, *loadRootPtr);
-  };
-
-  auto nestedMayWriteRoot = [&](Operation *container) {
-    bool found = false;
-    container->walk<WalkOrder::PreOrder>([&](Operation *nested) {
-      if (nested == container) {
-        return WalkResult::advance();
-      }
-      if (opMayWriteRoot(nested)) {
-        found = true;
-        return WalkResult::interrupt();
-      }
-      return WalkResult::advance();
-    });
-    return found;
-  };
-
+  Value root = *loadRootPtr;
   Operation *current = loadOp;
 
   while (current) {
@@ -648,12 +721,20 @@ bool requiresVolatileIndirectLoad(Value srcPtr, Operation *loadOp) {
     // First scan operations that are ordered before the current op in this
     // block. When such an operation owns regions, its nested writes are also
     // considered ordered before this load.
+    // Scan predecessors in this block from the load backward. classifyOp
+    // recurses into structured control flow (scf.if/for/while): the first
+    // decisive op wins -- a same-root write reaching the load (WriteEscapes)
+    // forces volatile; a guaranteed barrier (Shielded) covers all earlier
+    // writes. "Shielded" includes a barrier on *both* branches of an scf.if.
     for (auto it = Block::iterator(current); it != block->begin();) {
       --it;
-      Operation *op = &*it;
-      if ((op->getNumRegions() > 0 && nestedMayWriteRoot(op)) ||
-          opMayWriteRoot(op)) {
+      switch (classifyOp(&*it, root)) {
+      case BarrierState::WriteEscapes:
         return true;
+      case BarrierState::Shielded:
+        return false;
+      case BarrierState::None:
+        break;
       }
     }
 
@@ -663,10 +744,15 @@ bool requiresVolatileIndirectLoad(Value srcPtr, Operation *loadOp) {
       return false;
     }
 
-    // If the load is inside a loop, a store that is textually after the load
-    // may still execute before the load in a later iteration. Scan the whole
-    // loop body before climbing further out.
-    if (isa<LoopLikeOpInterface>(parentOp) && nestedMayWriteRoot(parentOp)) {
+    // If the load is inside a loop, a store textually after the load may still
+    // execute before it in a later iteration. classifyOp scans the whole loop
+    // body (and never reports a loop as Shielded, since it may run zero times).
+    if (isa<scf::ForOp, scf::WhileOp>(parentOp)) {
+      if (classifyOp(parentOp, root) == BarrierState::WriteEscapes) {
+        return true;
+      }
+    } else if (isa<LoopLikeOpInterface>(parentOp) &&
+               anyNestedWrite(parentOp, root)) {
       return true;
     }
 

--- a/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/indirect_load_rewrite.mlir
+++ b/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/indirect_load_rewrite.mlir
@@ -879,3 +879,360 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
     tt.return
   }
 }
+
+// -----
+// A synchronizing barrier between a same-root store and the indirect load is a
+// memory fence: the prior write is already visible, so the load does not need
+// volatile semantics.
+// CHECK-LABEL: func.func @indirect_load_after_store_with_barrier
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = false} : (memref<?xi32>, tensor<128xi64>, tensor<128xi1>, tensor<128xi32>) -> tensor<128xi32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @indirect_load_after_store_with_barrier(%arg0: !tt.ptr<i32>,
+                                                         %arg1: !tt.ptr<i32>) {
+    %one = arith.constant dense<1> : tensor<128xi32>
+    %zero = arith.constant dense<0> : tensor<128xi32>
+    %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %mask = arith.cmpi sge, %range, %zero : tensor<128xi32>
+    %src_splat = tt.splat %arg0 : !tt.ptr<i32> -> tensor<128x!tt.ptr<i32>>
+    %src_ptr = tt.addptr %src_splat, %range : tensor<128x!tt.ptr<i32>>, tensor<128xi32>
+    %dst_splat = tt.splat %arg1 : !tt.ptr<i32> -> tensor<128x!tt.ptr<i32>>
+    %dst_ptr = tt.addptr %dst_splat, %range : tensor<128x!tt.ptr<i32>>, tensor<128xi32>
+    tt.store %src_ptr, %one, %mask {route_discrete_mask_to_simt} : tensor<128x!tt.ptr<i32>>
+    gpu.barrier
+    %value = tt.load %src_ptr, %mask, %zero {route_discrete_mask_to_simt} : tensor<128x!tt.ptr<i32>>
+    tt.store %dst_ptr, %value, %mask {route_discrete_mask_to_simt} : tensor<128x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+// A same-root store AFTER the barrier (between barrier and load) is not shielded
+// by the barrier, so the load stays volatile.
+// CHECK-LABEL: func.func @indirect_load_store_after_barrier
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = true} : (memref<?xi32>, tensor<128xi64>, tensor<128xi1>, tensor<128xi32>) -> tensor<128xi32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @indirect_load_store_after_barrier(%arg0: !tt.ptr<i32>,
+                                                    %arg1: !tt.ptr<i32>) {
+    %one = arith.constant dense<1> : tensor<128xi32>
+    %zero = arith.constant dense<0> : tensor<128xi32>
+    %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %mask = arith.cmpi sge, %range, %zero : tensor<128xi32>
+    %src_splat = tt.splat %arg0 : !tt.ptr<i32> -> tensor<128x!tt.ptr<i32>>
+    %src_ptr = tt.addptr %src_splat, %range : tensor<128x!tt.ptr<i32>>, tensor<128xi32>
+    %dst_splat = tt.splat %arg1 : !tt.ptr<i32> -> tensor<128x!tt.ptr<i32>>
+    %dst_ptr = tt.addptr %dst_splat, %range : tensor<128x!tt.ptr<i32>>, tensor<128xi32>
+    gpu.barrier
+    tt.store %src_ptr, %one, %mask {route_discrete_mask_to_simt} : tensor<128x!tt.ptr<i32>>
+    %value = tt.load %src_ptr, %mask, %zero {route_discrete_mask_to_simt} : tensor<128x!tt.ptr<i32>>
+    tt.store %dst_ptr, %value, %mask {route_discrete_mask_to_simt} : tensor<128x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+// Store loop, then a barrier, then a load loop (mirrors the
+// "write cumsum -> tl.debug_barrier() -> binary search read" pattern):
+// the barrier separates the producing stores from the load, so non-volatile.
+// CHECK-LABEL: func.func @indirect_load_after_store_loop_with_barrier
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = false} : (memref<?xi32>, tensor<16xi64>, tensor<16xi1>, tensor<16xi32>) -> tensor<16xi32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @indirect_load_after_store_loop_with_barrier(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                              %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                              %trip: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %zero = arith.constant dense<0> : tensor<16xi32>
+    %one = arith.constant dense<1> : tensor<16xi32>
+    %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %src_base = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %src_ptr = tt.addptr %src_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %dst_base = tt.splat %arg1 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %dst_ptr = tt.addptr %dst_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %mask = arith.cmpi sge, %range, %zero : tensor<16xi32>
+    scf.for %i = %c0_i32 to %trip step %c1_i32 : i32 {
+      tt.store %src_ptr, %one, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    }
+    gpu.barrier
+    scf.for %j = %c0_i32 to %trip step %c1_i32 : i32 {
+      %loaded = tt.load %src_ptr, %mask, %zero {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+      tt.store %dst_ptr, %loaded, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    }
+    tt.return
+  }
+}
+
+// -----
+// A barrier OUTSIDE the loop does not shield a loop-carried same-root store:
+// iteration N's store feeds iteration N+1's load without crossing the barrier,
+// so the load stays volatile.
+// CHECK-LABEL: func.func @indirect_load_loop_carried_store_barrier_outside
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = true} : (memref<?xi32>, tensor<16xi64>, tensor<16xi1>, tensor<16xi32>) -> tensor<16xi32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @indirect_load_loop_carried_store_barrier_outside(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                                   %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                                   %trip: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %zero = arith.constant dense<0> : tensor<16xi32>
+    %one = arith.constant dense<1> : tensor<16xi32>
+    %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %src_base = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %src_ptr = tt.addptr %src_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %dst_base = tt.splat %arg1 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %dst_ptr = tt.addptr %dst_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %mask = arith.cmpi sge, %range, %zero : tensor<16xi32>
+    gpu.barrier
+    scf.for %i = %c0_i32 to %trip step %c1_i32 : i32 {
+      %loaded = tt.load %src_ptr, %mask, %zero {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+      tt.store %dst_ptr, %loaded, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+      tt.store %src_ptr, %one, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    }
+    tt.return
+  }
+}
+
+// -----
+// store, then a barrier on BOTH branches of scf.if, then load: every path
+// crosses a barrier after the write -> non-volatile.
+// CHECK-LABEL: func.func @indirect_load_if_both_branches_barrier
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = false} : (memref<?xi32>, tensor<16xi64>, tensor<16xi1>, tensor<16xi32>) -> tensor<16xi32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @indirect_load_if_both_branches_barrier(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                         %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                         %cond: i1) {
+    %zero = arith.constant dense<0> : tensor<16xi32>
+    %one = arith.constant dense<1> : tensor<16xi32>
+    %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %src_base = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %src_ptr = tt.addptr %src_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %dst_base = tt.splat %arg1 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %dst_ptr = tt.addptr %dst_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %mask = arith.cmpi sge, %range, %zero : tensor<16xi32>
+    tt.store %src_ptr, %one, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    scf.if %cond {
+      gpu.barrier
+    } else {
+      gpu.barrier
+    }
+    %loaded = tt.load %src_ptr, %mask, %zero {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    tt.store %dst_ptr, %loaded, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+// store, then a barrier on only ONE branch of scf.if, then load: the other path
+// has no barrier -> volatile.
+// CHECK-LABEL: func.func @indirect_load_store_then_if_single_barrier
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = true} : (memref<?xi32>, tensor<16xi64>, tensor<16xi1>, tensor<16xi32>) -> tensor<16xi32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @indirect_load_store_then_if_single_barrier(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                             %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                             %cond: i1) {
+    %zero = arith.constant dense<0> : tensor<16xi32>
+    %one = arith.constant dense<1> : tensor<16xi32>
+    %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %src_base = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %src_ptr = tt.addptr %src_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %dst_base = tt.splat %arg1 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %dst_ptr = tt.addptr %dst_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %mask = arith.cmpi sge, %range, %zero : tensor<16xi32>
+    tt.store %src_ptr, %one, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    scf.if %cond {
+      gpu.barrier
+    }
+    %loaded = tt.load %src_ptr, %mask, %zero {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    tt.store %dst_ptr, %loaded, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+// scf.for body store-then-barrier, load after the loop: the in-body barrier
+// orders after the store on every path -> non-volatile.
+// CHECK-LABEL: func.func @indirect_load_for_store_then_barrier
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = false} : (memref<?xi32>, tensor<16xi64>, tensor<16xi1>, tensor<16xi32>) -> tensor<16xi32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @indirect_load_for_store_then_barrier(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                       %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                       %trip: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %zero = arith.constant dense<0> : tensor<16xi32>
+    %one = arith.constant dense<1> : tensor<16xi32>
+    %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %src_base = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %src_ptr = tt.addptr %src_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %dst_base = tt.splat %arg1 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %dst_ptr = tt.addptr %dst_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %mask = arith.cmpi sge, %range, %zero : tensor<16xi32>
+    scf.for %i = %c0_i32 to %trip step %c1_i32 : i32 {
+      tt.store %src_ptr, %one, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+      gpu.barrier
+    }
+    %loaded = tt.load %src_ptr, %mask, %zero {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    tt.store %dst_ptr, %loaded, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+// scf.for body barrier-then-store, load after the loop: the store is after the
+// barrier and reaches the load (next iteration / exit) unshielded -> volatile.
+// CHECK-LABEL: func.func @indirect_load_for_barrier_then_store
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = true} : (memref<?xi32>, tensor<16xi64>, tensor<16xi1>, tensor<16xi32>) -> tensor<16xi32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @indirect_load_for_barrier_then_store(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                       %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                       %trip: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %zero = arith.constant dense<0> : tensor<16xi32>
+    %one = arith.constant dense<1> : tensor<16xi32>
+    %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %src_base = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %src_ptr = tt.addptr %src_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %dst_base = tt.splat %arg1 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %dst_ptr = tt.addptr %dst_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %mask = arith.cmpi sge, %range, %zero : tensor<16xi32>
+    scf.for %i = %c0_i32 to %trip step %c1_i32 : i32 {
+      gpu.barrier
+      tt.store %src_ptr, %one, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    }
+    %loaded = tt.load %src_ptr, %mask, %zero {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    tt.store %dst_ptr, %loaded, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+// scf.while body store-then-barrier, load after the loop: in-body barrier
+// shields the loop-carried store -> non-volatile.
+// CHECK-LABEL: func.func @indirect_load_while_store_then_barrier
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = false} : (memref<?xi32>, tensor<16xi64>, tensor<16xi1>, tensor<16xi32>) -> tensor<16xi32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @indirect_load_while_store_then_barrier(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                         %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                         %trip: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %zero = arith.constant dense<0> : tensor<16xi32>
+    %one = arith.constant dense<1> : tensor<16xi32>
+    %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %src_base = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %src_ptr = tt.addptr %src_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %dst_base = tt.splat %arg1 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %dst_ptr = tt.addptr %dst_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %mask = arith.cmpi sge, %range, %zero : tensor<16xi32>
+    %r = scf.while (%a = %c0_i32) : (i32) -> i32 {
+      %cond = arith.cmpi slt, %a, %trip : i32
+      scf.condition(%cond) %a : i32
+    } do {
+    ^bb0(%x: i32):
+      tt.store %src_ptr, %one, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+      gpu.barrier
+      %next = arith.addi %x, %c1_i32 : i32
+      scf.yield %next : i32
+    }
+    %loaded = tt.load %src_ptr, %mask, %zero {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    tt.store %dst_ptr, %loaded, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+// scf.while body barrier-then-store, load after the loop: store after barrier
+// escapes to the next iteration / exit unshielded -> volatile.
+// CHECK-LABEL: func.func @indirect_load_while_barrier_then_store
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = true} : (memref<?xi32>, tensor<16xi64>, tensor<16xi1>, tensor<16xi32>) -> tensor<16xi32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @indirect_load_while_barrier_then_store(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                         %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                         %trip: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %zero = arith.constant dense<0> : tensor<16xi32>
+    %one = arith.constant dense<1> : tensor<16xi32>
+    %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %src_base = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %src_ptr = tt.addptr %src_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %dst_base = tt.splat %arg1 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %dst_ptr = tt.addptr %dst_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %mask = arith.cmpi sge, %range, %zero : tensor<16xi32>
+    %r = scf.while (%a = %c0_i32) : (i32) -> i32 {
+      %cond = arith.cmpi slt, %a, %trip : i32
+      scf.condition(%cond) %a : i32
+    } do {
+    ^bb0(%x: i32):
+      gpu.barrier
+      tt.store %src_ptr, %one, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+      %next = arith.addi %x, %c1_i32 : i32
+      scf.yield %next : i32
+    }
+    %loaded = tt.load %src_ptr, %mask, %zero {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    tt.store %dst_ptr, %loaded, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+// Same-root store, then a barrier, then a load in doubly-nested scf.for:
+// the barrier shields the prior write even across loop nesting -> non-volatile.
+// CHECK-LABEL: func.func @indirect_load_after_barrier_in_nested_for
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = false} : (memref<?xi32>, tensor<16xi64>, tensor<16xi1>, tensor<16xi32>) -> tensor<16xi32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @indirect_load_after_barrier_in_nested_for(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                            %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                            %outer: i32,
+                                                            %inner: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %zero = arith.constant dense<0> : tensor<16xi32>
+    %one = arith.constant dense<1> : tensor<16xi32>
+    %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %src_base = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %src_ptr = tt.addptr %src_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %dst_base = tt.splat %arg1 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %dst_ptr = tt.addptr %dst_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %mask = arith.cmpi sge, %range, %zero : tensor<16xi32>
+    tt.store %src_ptr, %one, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    gpu.barrier
+    scf.for %i = %c0_i32 to %outer step %c1_i32 : i32 {
+      scf.for %j = %c0_i32 to %inner step %c1_i32 : i32 {
+        %loaded = tt.load %src_ptr, %mask, %zero {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+        tt.store %dst_ptr, %loaded, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+      }
+    }
+    tt.return
+  }
+}
+
+// -----
+// store -> barrier -> scf.if { store(same root) } -> load:
+// the conditional store sits AFTER the barrier (between barrier and load), so it
+// is NOT shielded and the load must stay volatile. Guards against a naive
+// "saw a barrier -> non-volatile" rewrite that would miss the post-barrier write.
+// CHECK-LABEL: func.func @indirect_load_store_in_if_after_barrier
+// CHECK: call @triton_indirect_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = true} : (memref<?xi32>, tensor<16xi64>, tensor<16xi1>, tensor<16xi32>) -> tensor<16xi32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @indirect_load_store_in_if_after_barrier(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                          %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                                                          %cond: i1) {
+    %zero = arith.constant dense<0> : tensor<16xi32>
+    %one = arith.constant dense<1> : tensor<16xi32>
+    %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %src_base = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %src_ptr = tt.addptr %src_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %dst_base = tt.splat %arg1 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %dst_ptr = tt.addptr %dst_base, %range : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %mask = arith.cmpi sge, %range, %zero : tensor<16xi32>
+    tt.store %src_ptr, %one, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    gpu.barrier
+    scf.if %cond {
+      tt.store %src_ptr, %one, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    }
+    %loaded = tt.load %src_ptr, %mask, %zero {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    tt.store %dst_ptr, %loaded, %mask {route_discrete_mask_to_simt} : tensor<16x!tt.ptr<i32>>
+    tt.return
+  }
+}


### PR DESCRIPTION
Let TA clear `isVolatile` on a SIMT indirect load when a synchronizing barrier separates it from earlier same-root GM writes, instead of always keeping such loads volatile.

The volatile analysis keeps an indirect load volatile whenever any prior write may target the same root pointer. That is overly conservative for the common "write -> tl.debug_barrier() -> indirect read" pattern (e.g. binary search over a cumulative-sum buffer the kernel just produced): the barrier is a memory fence, so every write ordered before it is already globally visible to the read ordered after it. Volatile is then unnecessary and only blocks optimization.

There is also a latent issue: `gpu.barrier` (lowered from tl.debug_barrier) is not memory-effect-free, so the old backward write scan treated the barrier itself as a possible write and forced volatile even when no real same-root store exists before it.

## What changed

`requiresVolatileIndirectLoad` now scans predecessors from the load backward through a recursive three-state classification of each op/region (classifyOp/classifyBlock over a block scanned from its exit):

- Shielded     : a barrier is reached (covers all earlier same-root writes);
- WriteEscapes : a same-root write reaches the load with no barrier after it;
- None         : neither (keep scanning outward).

Structured control flow is looked through, not summarized:

- scf.if  : shields only if a barrier is present on BOTH branches; a write escaping either branch forces volatile.
- scf.for / scf.while : never reported as Shielded (the loop may run zero times, so an in-body barrier cannot shield outer writes); an in-body same-root write is treated as loop-carried and escapes.
- other region ops fall back to a conservative nested-write check.

The first decisive op from the load backward wins, so a same-root write between a barrier and the load (even nested in an scf.if/scf.for) is still hit first and keeps the load volatile.

Also: add `isSynchronizingBarrier()` (matches `gpu.barrier`) and link `MLIRGPUDialect` into MLIRTritonNPUUtils.

## Validation

MLIR coverage in indirect_load_rewrite.mlir (isVolatile expectations):
- store -> barrier -> load                                 => false
- barrier -> store -> load                                 => true
- store -> barrier -> scf.if { store } -> load             => true
- store -> scf.if { barrier } else { barrier } -> load     => false
- store -> scf.if { barrier } -> load                      => true
- scf.for  { store; barrier }      ; load                  => false
- scf.for  { barrier; store }      ; load                  => true
- scf.while{ store; barrier }      ; load                  => false
- scf.while{ barrier; store }      ; load                  => true
- store loop -> barrier -> load loop                       => false
- loop-carried store, barrier outside the loop             => true
- store -> barrier -> nested scf.for { load }              => false

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
