### PR TITLE
[ssbuffer](fix) Fix the ordering issue in cutting of PlanVectorBlockPass

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <optional>
 #include "DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
@@ -194,10 +195,12 @@ void findCandidates(DenseMap<Operation *, int> &indegree, SmallVector<Operation 
 
 static SmallVector<Operation *> findOpsAdjacentToCube(Block *block, const SmallVector<Operation *> &fuseGroup,
                                                       DenseMap<Operation *, bool> &visited,
-                                                      const CVPipeline::MemoryDependenceGraph &memGraph)
+                                                      const CVPipeline::MemoryDependenceGraph &memGraph,
+                                                      CVPipeline::ComputeBlockIdManager &bm)
 {
     SmallVector<Operation *> toProcess;
-    std::optional<int> blockId;
+    std::optional<int> minBlockId = std::nullopt;
+
     for (Operation *op : fuseGroup) {
         SmallVector<Operation *> allUsers;
         allUsers.append(op->getUsers().begin(), op->getUsers().end());
@@ -211,16 +214,35 @@ static SmallVector<Operation *> findOpsAdjacentToCube(Block *block, const SmallV
                 continue;
             }
             if (!isFusableOp(userInBlock) && !visited[userInBlock]) {
-                auto newBlockId = getOpBlockId(user);
-                if (!newBlockId.has_value()) {
-                    newBlockId = getOpBlockId(userInBlock); // Some op will be tagged outside
+                auto newBlockId = bm.getBlockIdByOp(userInBlock);
+                if (!minBlockId.has_value() || newBlockId < minBlockId) {
+                    minBlockId = newBlockId;
                 }
+            }
+        }
+    }
 
-                if (!blockId.has_value()) {
-                    blockId = newBlockId;
-                }
-                if (!newBlockId.has_value() || blockId == newBlockId) {
+    if (!minBlockId.has_value()) {
+        return {};
+    }
+
+    for (Operation *op : fuseGroup) {
+        SmallVector<Operation *> allUsers;
+        allUsers.append(op->getUsers().begin(), op->getUsers().end());
+        for (auto memUser : memGraph.getExecAfter(op)) {
+            allUsers.push_back(memUser);
+        }
+
+        for (auto user : allUsers) {
+            auto userInBlock = CVPipeline::getAncestorInBlock(user, block);
+            if (!userInBlock || (block->mightHaveTerminator() && userInBlock == block->getTerminator())) {
+                continue;
+            }
+            if (!isFusableOp(userInBlock) && !visited[userInBlock]) {
+                auto newBlockId = bm.getBlockIdByOp(userInBlock);
+                if (newBlockId == minBlockId) {
                     toProcess.push_back(op);
+                    break;
                 }
             }
         }
@@ -354,10 +376,10 @@ void refineFuseGroup(Block *block, SmallVector<Operation *> &nowFuseGroup, Dense
                      const CVPipeline::MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
 {
     // 1.Find ops in fuse group whose next node is a non-fusable (CUBE-only) op
-    auto toProcess = findOpsAdjacentToCube(block, nowFuseGroup, visited, memGraph);
+    auto toProcess = findOpsAdjacentToCube(block, nowFuseGroup, visited, memGraph, bm);
     // 2. early return: if cannot find one node which next node is CUBE, need to check if return or not;
     if (toProcess.empty()) {
-        LOG_DEBUG("No Cube adjacent op, no op will be cut.");
+        LOG_DEBUG("No Cube adjacent op, no op will be cut.\n");
         findCandidates(indegree, candidates, visited, memGraph, bm);
         if (candidates.empty()) {
             return;
@@ -369,7 +391,7 @@ void refineFuseGroup(Block *block, SmallVector<Operation *> &nowFuseGroup, Dense
 
     // 4. Remove non-kept ops from fuseGroup and restore BFS state
     evictAndRestoreState(block, keepOps, nowFuseGroup, visited, candidates, indegree, memGraph);
-    LOG_DEBUG("After cutting, kept " << keepOps.size() << "\n");
+    LOG_DEBUG("After cutting, kept " << keepOps.size() << " nowFuseGroup: "<< nowFuseGroup.size() << "\n");
 }
 
 // Main function to plan vector block id for one block
@@ -405,7 +427,7 @@ llvm::LogicalResult planVectorBlockId(Block *block, const CVPipeline::MemoryDepe
         if (queue.empty() || nextFused == nullptr) {
             LOG_DEBUG("Prepare to check this group: \n");
             for (auto op: nowFuseGroup) {
-                LOG_DEBUG("fuseing: " << *op << "\n");
+                LOG_DEBUG("check: " << *op << "\n");
             }
             // finish one group, assign block id and start next iteration
             // Cut error operations before assigning block id


### PR DESCRIPTION
# Fixed the ordering issue in fuse group cutting in PlanVectorBlockPass.
## Changes
Modified the logic in findOpsAdjacentToCube function to ensure operations are processed in the correct order during cutting:
- Ordered cutting: First iterate to find the minimum blockId among all adjacent CUBE operations, then prioritize operations with that blockId
- Avoid random selection: The original implementation might randomly select when multiple candidate operations are found, now explicitly prioritizes operations with the minimum blockId
- Performance optimization: Break immediately after finding the target operation to avoid unnecessary traversal

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
