### PR TITLE
[ssbuffer](fix) set fallback when CV has only one-way interaction

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeScope.cpp
@@ -134,6 +134,65 @@ static bool checkVecScopeMainLoop(ModuleOp module) {
   return hasMainLoopFor && allForSatisfy;
 }
 
+// For every main_loop id, gather all forOps sharing that id and count the
+// hivm.hir.copy and hivm.hir.fixpipe ops within them. Only when ALL main_loop
+// ids have either count equal to zero (every id has only copy or only
+// fixpipe, none has both), the dynamic CV pipeline cannot be applied and we
+// fall back to the original workflow.
+//   - hivm::CopyOp    typically appears in VECTOR scope main_loops
+//   - hivm::FixpipeOp typically appears in CUBE scope main_loops
+// Nested regions inside the main_loop forOp are also walked, and scf.yield
+// terminators are skipped.
+static bool isMainLoopOnlyCopyOrFixpipe(ModuleOp module)
+{
+  // main_loop id -> (countCopy, countFixpipe)
+  llvm::DenseMap<int, std::pair<int, int>> idToCounts;
+
+  module.walk([&](scf::ForOp forOp) -> WalkResult {
+    auto mainLoopAttr = forOp->getAttrOfType<IntegerAttr>(CVPipeline::kMainLoop);
+    if (!mainLoopAttr) {
+      return WalkResult::advance();
+    }
+
+    int id = mainLoopAttr.getInt();
+    auto &counts = idToCounts[id];
+
+    forOp.walk([&](mlir::Operation *op) -> WalkResult {
+      // Skip the forOp itself (the walk visits it first)
+      if (op == forOp) {
+        return WalkResult::advance();
+      }
+      // Skip yield terminators (they are not real ops)
+      if (isa<scf::YieldOp>(op)) {
+        return WalkResult::advance();
+      }
+      if (isa<hivm::CopyOp>(op)) {
+        ++counts.first;
+      } else if (isa<hivm::FixpipeOp>(op)) {
+        ++counts.second;
+      }
+      return WalkResult::advance();
+    });
+
+    return WalkResult::advance();
+  });
+
+  // Only trigger fallback when EVERY main_loop id has only copy or only
+  // fixpipe (one count is zero). If at least one id has both copy and
+  // fixpipe ops, the dynamic CV pipeline still be applicable.
+  if (idToCounts.empty()) {
+    return false;
+  }
+
+  for (const auto &entry : idToCounts) {
+    if (entry.second.first != 0 && entry.second.second != 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 static LogicalResult verifyMainLoop(ModuleOp module)
 {
   // Only skip if ALL forOps lack main_loop attr
@@ -155,6 +214,12 @@ static LogicalResult verifyMainLoop(ModuleOp module)
     CVPipeline::setFallbackAttr(module);
     return failure();
   };
+
+  if (isMainLoopOnlyCopyOrFixpipe(module)) {
+    LDBG("[INFO]: All main_loop only contains hivm.hir.copy or hivm.hir.fixpipe ops.");
+    CVPipeline::setFallbackAttr(module);
+    return failure();
+  }
 
   return success();
 }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-main-loop-only-copy-or-fixpipe.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-main-loop-only-copy-or-fixpipe.mlir
@@ -1,0 +1,42 @@
+// RUN: triton-opt --analyze-scope --verify-diagnostics
+
+// Unit test for AnalyzeScopePass: when every main_loop id lacks either
+// hivm.hir.copy or hivm.hir.fixpipe, the new isMainLoopOnlyCopyOrFixpipe
+// check must trigger setFallbackAttr so the dynamic CV pipeline falls
+// back to the original workflow.
+//
+// In this test the VECTOR main_loop (id 0) has only hivm.hir.copy with
+// transfer_id (to satisfy checkVecScopeMainLoop) and no fixpipe ops; the
+// CUBE main_loop (id 0) has only sync_block ops and no copy or fixpipe.
+// For id 0: countCopy > 0 and countFixpipe == 0, so the rule
+// (countCopy == 0 || countFixpipe == 0) is satisfied for the only id and
+// isMainLoopOnlyCopyOrFixpipe returns true -- fallback is set.
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_main_loop_only_copy(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xbf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg3: memref<?xbf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg4: memref<?xbf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg5: memref<?xbf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg6: memref<?xbf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg7: memref<?xbf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg8: memref<?xbf16> {tt.divisibility = 16 : i32}, %arg9: memref<?xbf16> {tt.divisibility = 16 : i32}, %arg10: i32, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32, %arg14: i32, %arg15: i32, %arg16: i32, %arg17: i32, %arg18: i32) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %c0_i32 = arith.constant {ssbuffer.block_id = 14 : i32} 0 : i32
+    %c1_i32 = arith.constant {Undefined, ssbuffer.block_id = 14 : i32} 1 : i32
+    %c32_i32 = arith.constant {ssbuffer.block_id = 14 : i32} 32 : i32
+    %cst = arith.constant {ssbuffer.block_id = 14 : i32} 0.000000e+00 : bf16
+    %reshape = tensor.empty() {ssbuffer.block_id = 14 : i32} : tensor<4x4x16x16xbf16>
+    scope.scope : () -> () {
+      %alloc = memref.alloc() {ssbuffer.block_id = 22 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x4x16x16xbf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 22 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x4x16x16xbf16, #hivm.address_space<cbuf>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 22 : i32, ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
+      scf.for %arg19 = %c0_i32 to %c32_i32 step %c1_i32  : i32 {
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 22 : i32, ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+        hivm.hir.copy ins(%reshape : tensor<4x4x16x16xbf16>) outs(%alloc : memref<4x4x16x16xbf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 22 : i32, ssbuffer.transfer_id = 0 : i32}
+        hivm.hir.sync_block_set {ssbuffer.block_id = 22 : i32, ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
+      } {ssbuffer.block_id = 22 : i32, ssbuffer.main_loop = 0 : i32}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    scope.scope : () -> () {
+      scf.for %arg19 = %c0_i32 to %c32_i32 step %c1_i32  : i32 {
+        hivm.hir.sync_block_set {ssbuffer.block_id = 22 : i32}[<CUBE>, <PIPE_V>, <PIPE_FIX>] flag = 2
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 22 : i32}[<CUBE>, <PIPE_V>, <PIPE_FIX>] flag = 2
+      } {ssbuffer.block_id = 22 : i32, ssbuffer.main_loop = 0 : i32}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+    return
+  }
+}


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
