### PR TITLE
[ssbuffer](fix) remove _swa_bwd kernels from split all

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.cpp
@@ -36,17 +36,13 @@ using namespace CVSplit;
 static constexpr const char *DEBUG_TYPE = "PatternMatchRewrites";
 #define LOG_DEBUG(...) LLVM_DEBUG(llvm::dbgs() << "\n[" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
 
-static constexpr llvm::StringLiteral needSplitAllFuncNme[] {
-  "_swa_bwd_dq_kernel",
-  "_swa_bwd_dkdv_kernel"
-};
+static constexpr llvm::StringLiteral needSplitAllFuncNme[] {""};
 
 void PatternMatchRewritePass::runOnOperation()
 {
     auto moduleOp = getOperation();
     LOG_DEBUG("Input mlir:\n" << moduleOp);
 
-    
     bool needSplitAll = false;
     moduleOp.walk([&](func::FuncOp funcOp) -> WalkResult {
         if (!llvm::is_contained(needSplitAllFuncNme, funcOp.getSymName())) {


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
