### PR TITLE
[MixCompile](fix) correct MetaUse marking for UnstructuredLoad/StoreOp operands

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -2963,19 +2963,11 @@ LogicalResult UnstructuredLoadConverter::matchAndRewrite(
   if (isSimdSimtMode) {
     auto burstLen = rewriter.create<arith::ConstantIntOp>(loc, burstlen, 32);
 
-    Value scalarOther;
-    if (other) {
-      scalarOther = mlir::ConverterUtils::getScalarValue(other, loc, rewriter);
-      assert(scalarOther &&
-             "other value used in masked unstructured_load produced by "
-             "unsupported instruction!");
-    }
-
     Value dst = rewriter.create<tensor::EmptyOp>(
         loc, resultShape, cast<RankedTensorType>(resTy).getElementType());
 
     auto gatherLoadOp = rewriter.create<hfusion::GatherLoadOp>(
-        loc, baseMem, offsets, burstLen, mask, scalarOther, dst,
+        loc, baseMem, offsets, burstLen, mask, other, dst,
         hfusion::CacheModifierAttr{}, hfusion::EvictionPolicyAttr{},
         mlir::BoolAttr{});
     rewriter.replaceOp(op, gatherLoadOp.getResult());

--- a/third_party/ascend/lib/TritonToLinalg/UseAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/UseAnalysis.cpp
@@ -389,11 +389,7 @@ LogicalResult triton::runUseAnalysis(triton::FuncOp &funcOp) {
             })
             .Case<triton::ascend::UnstructuredLoadOp>([&](auto unstrucLoad) {
               auto base = unstrucLoad.getBase();
-              auto indices = unstrucLoad.getIndices();
-              auto mask = unstrucLoad.getMask();
-              auto other = unstrucLoad.getOther();
-              if (result == base || result == indices || result == mask ||
-                  result == other)
+              if (result == base)
                 metaUsers.insert(user);
             })
             .Case<triton::StoreOp>([&](auto store) {
@@ -405,9 +401,7 @@ LogicalResult triton::runUseAnalysis(triton::FuncOp &funcOp) {
             })
             .Case<triton::ascend::UnstructuredStoreOp>([&](auto unstrucStore) {
               auto base = unstrucStore.getBase();
-              auto indices = unstrucStore.getIndices();
-              auto mask = unstrucStore.getMask();
-              if (result == base || result == indices || result == mask)
+              if (result == base)
                 metaUsers.insert(user);
             })
             .Case<triton::AtomicRMWOp>([&](auto atomicOp) {

--- a/third_party/ascend/unittest/pytest_ut/test_simd_simt.py
+++ b/third_party/ascend/unittest/pytest_ut/test_simd_simt.py
@@ -687,3 +687,100 @@ def test_simple_indirect_store():
         torch.testing.assert_close(dst[p], values[i], rtol=1e-5, atol=1e-5)
 
     return True
+
+
+@triton.jit
+def gather_then_tldot_2d_kernel(
+    a_ptr,          # [M, K_src]
+    b_ptr,          # [K_src, N]
+    indices_ptr,    # [BLOCK_K]
+    out_ptr,        # [M, N]
+    M,
+    N,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_om,
+    stride_on,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)   # [BLOCK_M]
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)   # [BLOCK_N]
+    offs_k = tl.arange(0, BLOCK_K)                     # [BLOCK_K]
+
+    # gather 的 K 下标
+    gather_k = tl.load(indices_ptr + offs_k)           # [BLOCK_K]
+
+    # A: [BLOCK_M, BLOCK_K]
+    # 从 src_a[offs_m, gather_k] 取值
+    a_ptrs = a_ptr + offs_m[:, None] * stride_am + gather_k[None, :] * stride_ak
+    a_mask = offs_m[:, None] < M
+    a = tl.load(a_ptrs, mask=a_mask, other=0.0)
+
+    # B: [BLOCK_K, BLOCK_N]
+    # 从 src_b[gather_k, offs_n] 取值
+    b_ptrs = b_ptr + gather_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
+    b_mask = offs_n[None, :] < N
+    b = tl.load(b_ptrs, mask=b_mask, other=0.0)
+
+    # 2D tl.dot: [BLOCK_M, BLOCK_K] x [BLOCK_K, BLOCK_N] -> [BLOCK_M, BLOCK_N]
+    c = tl.dot(a, b)
+
+    # store 输出
+    out_ptrs = out_ptr + offs_m[:, None] * stride_om + offs_n[None, :] * stride_on
+    out_mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    tl.store(out_ptrs, c, mask=out_mask)
+
+
+@simd_simt_910_95_only
+def test_gather_then_tldot_2d():
+    device = "npu"
+    # 这里用 float16 更适合 tl.dot
+    # 若你环境里 fp32 的 tl.dot 可用，也可以改回 float32
+    M = 16
+    K_SRC = 256
+    N = 16
+    BLOCK_M = 16
+    BLOCK_N = 16
+    BLOCK_K = 16   # 通常需要 >= 16
+
+    # 源矩阵
+    src_a = torch.arange(M * K_SRC, dtype=torch.float16, device=device).reshape(M, K_SRC)
+    src_b = torch.arange(K_SRC * N, dtype=torch.float16, device=device).reshape(K_SRC, N)
+
+    # 沿 K 维 gather 的索引
+    indices = torch.tensor(
+        [10, 25, 100, 200, 5, 50, 150, 255,
+         1, 2, 3, 4, 6, 7, 8, 9],
+        dtype=torch.int32,
+        device=device
+    )
+
+    output = torch.empty((M, N), dtype=torch.float32, device=device)
+
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    gather_then_tldot_2d_kernel[grid](
+        src_a, src_b, indices, output,
+        M, N,
+        src_a.stride(0), src_a.stride(1),
+        src_b.stride(0), src_b.stride(1),
+        output.stride(0), output.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        compile_mode="simd_simt"
+    )
+
+    # PyTorch 参考结果
+    expected = torch.matmul(src_a[:, indices].to(torch.float32),
+                            src_b[indices, :].to(torch.float32))
+
+    torch.testing.assert_close(output, expected, rtol=1e-2, atol=1e-2)
+    print("\n2D gather + tl.dot test PASSED")


### PR DESCRIPTION
This PR fixes an issue in `UseAnalysis` where all operands of `UnstructuredLoadOp` and `UnstructuredStoreOp` were incorrectly marked as `MetaUse`.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
