### PR TITLE
[ssbuffer](fix) refactor cleanup ops in CloneOps

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CloneOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CloneOps.cpp
@@ -185,8 +185,15 @@ LogicalResult CloneOpsPass::cloneOpsInMainLoop(scf::ForOp forOp)
 }
 
 // Check if an op should be erased during cleanup (for cube)
-// memGraph: optional pointer to MemoryDependenceGraph for checking exec-after dependencies
-static bool shouldEraseOpForCube(Operation *op, const CVPipeline::MemoryDependenceGraph *memGraph = nullptr)
+// sameBlockIdExecAfter: precomputed map from cloned op to its same-block-id exec-after ops
+//   (already filtered to skip SyncBlockWaitOp/SyncBlockSetOp), built once per block from a
+//   single MemoryDependenceGraph.
+// erasedOps: set of cloned ops already erased in this cleanup pass; an exec-after entry
+//   that has been erased no longer pins the current op (equivalent to the original
+//   per-op graph rebuild reflecting the post-erasure IR).
+static bool shouldEraseOpForCube(Operation *op,
+    const llvm::DenseMap<Operation *, llvm::SmallPtrSet<Operation *, 4>> &sameBlockIdExecAfter,
+    const llvm::DenseSet<Operation *> &erasedOps)
 {
   // Rule 1: SyncBlockWaitOp, SyncBlockSetOp, FixpipeOp -> directly erase
   if (isa<SyncBlockWaitOp>(op) || isa<SyncBlockSetOp>(op) ||
@@ -222,29 +229,28 @@ static bool shouldEraseOpForCube(Operation *op, const CVPipeline::MemoryDependen
     return true;
   }
 
-  // Rule 3: If op has no results, check getExecAfter for same block_id dependencies
-  if (memGraph) {
-    auto execAfterOps = memGraph->getExecAfter(op);
-    bool hasCloneExecAfterInSameBlockId = llvm::any_of(execAfterOps, [&](Operation *execOp) {
-      // sync_block_wait/sync_block_set ops are not memory side effects in analyzing cleanup ops,
-      // therefore, we need to skip their judgments
-      if (isa<SyncBlockWaitOp>(execOp) || isa<SyncBlockSetOp>(execOp)) {
+  // Rule 3: If op has no results, consult the precomputed same-block-id exec-after set.
+  // An exec-after op that has already been erased in this pass is no longer live and
+  // does not require keeping this op.
+  auto it = sameBlockIdExecAfter.find(op);
+  if (it != sameBlockIdExecAfter.end()) {
+    for (Operation *execOp : it->second) {
+      if (!erasedOps.contains(execOp)) {
         return false;
       }
       // scf.if whose body only contains sync_block_wait/sync_block_set ops will be cleaned up
       // in its own turn; skip it here so it does not block the current op's erasure.
       if (isIfOpWithOnlySyncOps(execOp)) {
-        return false;
+        continue;
       }
       auto execBlockId = CVPipeline::getOpBlockId(execOp);
-      return execBlockId && opBlockId && *execBlockId == *opBlockId;
-    });
-    if (hasCloneExecAfterInSameBlockId) {
-      return false;
+      if (execBlockId && opBlockId && *execBlockId == *opBlockId) {
+        return false;
+      }
     }
   }
 
-  // Can erase if no results and no exec-after dependencies in same block
+  // Can erase if no results and no live exec-after dependencies in same block
   return true;
 }
 
@@ -281,19 +287,80 @@ static LogicalResult cleanupClonedOps(scf::ForOp forOp,
       continue;
     }
 
-    // Erase cloned ops from bottom to top
-    // This ensures that when checking if an op can be erased, its users in same block_id
-    // have already been processed (and erased if applicable)
-    for (int j = startIdx; j >= 0; --j) {
-      Operation *op = curOps[j];
-      if (!op->hasAttr(CVPipeline::kClone)) {
+    // Locate the start of the contiguous cloned-op suffix. The original cleanup
+    // loop broke on the first non-cloned op; preserve that behavior so we only
+    // consider ops that the previous implementation would have considered,
+    // regardless of how topologicalSort interleaves cloned and non-cloned ops.
+    int firstClonedIdx = 0;
+    for (int j = startIdx - 1; j >= 0; --j) {
+      if (!curOps[j]->hasAttr(CVPipeline::kClone)) {
+        firstClonedIdx = j + 1;
         break;
       }
-      // Rebuild memGraph after each erasure to reflect current IR state
-      auto memGraph = memGraphFactory(forOp);
-      bool shouldErase = isCube ? shouldEraseOpForCube(op, memGraph.get()) : shouldEraseOpForVector(op);
+    }
+
+    // Collect the cloned ops in the contiguous suffix (in execution order).
+    SmallVector<Operation *> clonedOps;
+    clonedOps.reserve(startIdx - firstClonedIdx + 1);
+    for (int j = firstClonedIdx; j <= startIdx; ++j) {
+      clonedOps.push_back(curOps[j]);
+    }
+
+    // Build the MemoryDependenceGraph at most once per block, and only if at
+    // least one cloned op has no results (Rule 3 is the only path that needs it;
+    // Rule 2 is a pure SSA check and Rule 1 is type-based).
+    std::unique_ptr<MemDepGraphT> memGraph;
+    if (isCube) {
+      bool needsMemGraph = llvm::any_of(clonedOps, [](Operation *o) {
+        return o->getNumResults() == 0;
+      });
+      if (needsMemGraph) {
+        memGraph = memGraphFactory(forOp);
+      }
+    }
+
+    // Precompute, for each cloned op, the set of its exec-after ops that share
+    // its block_id. Building the memGraph was the expensive part; we now do
+    // getExecAfter once per op up front and reuse the result during cleanup.
+    // An erased op is filtered out at check time (see shouldEraseOpForCube),
+    // which reproduces the original "rebuild after each erasure" effect.
+    llvm::DenseMap<Operation *, llvm::SmallPtrSet<Operation *, 4>> sameBlockIdExecAfter;
+    if (memGraph) {
+      for (Operation *op : clonedOps) {
+        if (op->getNumResults() > 0) {
+          // Rule 2 path: memgraph is not consulted.
+          continue;
+        }
+        auto opBlockId = getForDirectChildBlockId(op);
+        if (!opBlockId) {
+          continue;
+        }
+        for (Operation *execOp : memGraph->getExecAfter(op)) {
+          // sync_block_wait/sync_block_set ops are not memory side effects in
+          // analyzing cleanup ops, therefore we skip them.
+          if (isa<SyncBlockWaitOp>(execOp) || isa<SyncBlockSetOp>(execOp)) {
+            continue;
+          }
+          auto execBlockId = CVPipeline::getOpBlockId(execOp);
+          if (execBlockId && *execBlockId == *opBlockId) {
+            sameBlockIdExecAfter[op].insert(execOp);
+          }
+        }
+      }
+    }
+
+    // Erase cloned ops from bottom to top, matching the original ordering.
+    // erasedOps mirrors the effect of the per-iteration graph rebuild: an op
+    // already erased in this pass is treated as absent from the precomputed
+    // exec-after sets.
+    llvm::DenseSet<Operation *> erasedOps;
+    for (int j = startIdx; j >= firstClonedIdx; --j) {
+      Operation *op = curOps[j];
+      bool shouldErase = isCube ? shouldEraseOpForCube(op, sameBlockIdExecAfter, erasedOps)
+                                : shouldEraseOpForVector(op);
       if (shouldErase) {
         op->erase();
+        erasedOps.insert(op);
       }
     }
   }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/create-if-ops.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/create-if-ops.mlir
@@ -59,7 +59,7 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
           // CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 2
           // CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 1
           // CHECK: hivm.hir.copy ins(%reshape_12 : tensor<8x8x16x16xf16>) outs(%alloc : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 0 : i32}
-          // CHECK: } {ssbuffer.if = 5 : i32}
+          // CHECK: } {{.*}}ssbuffer.if = 5 : i32{{.*}}
           hivm.hir.sync_block_wait {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 2
           %memspacecast_11 = memref.memory_space_cast %alloc_5 {ssbuffer.block_id = 5 : i32, ssbuffer.crossDeps = [0 : i32, 0 : i32], ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>> to memref<128x128xf32>
           %33 = bufferization.to_tensor %memspacecast_11 restrict writable {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32>
@@ -116,7 +116,7 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
           // CHECK: %17 = arith.mulf %arg19, %broadcasted {ssbuffer.block_id = 6 : i32}
           // CHECK: %18 = arith.addf %12, %17 {ssbuffer.block_id = 6 : i32}
           // CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 2 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 3
-          // CHECK: } {ssbuffer.if = 6 : i32}
+          // CHECK: } {{.*}}ssbuffer.if = 6 : i32{{.*}}
           hivm.hir.sync_block_wait {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 2 : i32}[<VECTOR>, <PIPE_FIX>, <PIPE_V>] flag = 3
           %memspacecast_16 = memref.memory_space_cast %alloc_6 {ssbuffer.block_id = 6 : i32, ssbuffer.crossDeps = [1, 0], ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32, #hivm.address_space<ub>> to memref<128x128xf32>
           %48 = bufferization.to_tensor %memspacecast_16 restrict writable {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32>


### PR DESCRIPTION
**DynaminCVPipeline: refactor cleanup ops in CloneOps, speed up compile time.**

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
