### PR TITLE
[CI] Replace GitHub cache with OBS backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,9 @@ on:
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-permissions: read-all
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
 

--- a/.github/workflows/integration-tests-ascend.yml
+++ b/.github/workflows/integration-tests-ascend.yml
@@ -7,6 +7,10 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   integration-tests-ascend:
     name: integration-tests-ascend (${{ matrix.config.name }}, py${{ matrix.python_version }})
@@ -37,8 +41,23 @@ jobs:
       - name: Add git safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Cache build dependencies
-        uses: actions/cache@v4
+      - name: Configure Huawei Cloud Credentials
+        id: creds
+        uses: ascend-gha-runners/configure-hwcloud-credentials@3be5794f565c38f9719ef1f6bec28351c929be3c
+        with:
+          region: ap-southeast-1
+          audience: hw-vllm-ascend-audience
+          idp-id: github-vllm-ascend
+          duration-seconds: 3600
+
+      - name: Restore build dependencies cache
+        id: cache-deps
+        uses: runs-on/cache/restore@v5
+        env:
+          RUNS_ON_S3_BUCKET_CACHE: triton-ascend-artifacts
+          RUNS_ON_S3_BUCKET_ENDPOINT: https://obs.cn-southwest-2.myhuaweicloud.com
+          RUNS_ON_S3_FORCE_PATH_STYLE: "true"
+          RUNS_ON_AWS_REGION: cn-southwest-2
         with:
           path: |
             ~/.triton/llvm
@@ -143,3 +162,19 @@ jobs:
             fi
             exit 1
           fi
+
+      - name: Save build dependencies cache
+        if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
+        uses: runs-on/cache/save@v5
+        env:
+          RUNS_ON_S3_BUCKET_CACHE: triton-ascend-artifacts
+          RUNS_ON_S3_BUCKET_ENDPOINT: https://obs.cn-southwest-2.myhuaweicloud.com
+          RUNS_ON_S3_FORCE_PATH_STYLE: "true"
+          RUNS_ON_AWS_REGION: cn-southwest-2
+        with:
+          path: |
+            ~/.triton/llvm
+            ~/.triton/json
+            ~/.triton/nvidia
+            ~/.ccache
+          key: ${{ runner.os }}-${{ runner.arch }}-cann${{ matrix.cann_version }}-${{ matrix.os }}-${{ matrix.config.chip_type }}-py${{ matrix.python_version }}-triton-${{ hashFiles('cmake/llvm-hash.txt', 'cmake/json-version.txt', 'cmake/nvidia-toolchain-version.json', 'third_party/ascend/llvm_patch/*.patch') }}


### PR DESCRIPTION
## Summary

Replace GitHub Actions cache with Huawei Cloud OBS backend for build dependencies cache.

## Changes

- Add id-token: write permission for OIDC authentication
- Add Configure Huawei Cloud Credentials step
- Replace ctions/cache@v4 with uns-on/cache/restore@v5 and uns-on/cache/save@v5
- Use triton-ascend's own OBS bucket: 	riton-ascend-artifacts (cn-southwest-2 region)

## Cached paths

- ~/.triton/llvm
- ~/.triton/json
- ~/.triton/nvidia
- ~/.ccache

## Benefits

- Faster cache access from Huawei Cloud infrastructure
- No GitHub cache storage limits
- Consistent with triton-ascend's existing OBS usage (llvm-build.yml, wheels.yml, etc.)
