### PR TITLE
[ssbuffer](fix) delete all specific func name.

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition.h
@@ -57,6 +57,7 @@ struct ControlFlowConditionInfo {
   llvm::DenseMap<scf::ForOp, SmallVector<int>> innerDepConds;
 
   llvm::DenseMap<Value, SmallVector<Value>> crossCoreDependentMap;
+  llvm::DenseMap<Operation*, SmallVector<Operation*>> memCrossCoreDependentMap;
   llvm::DenseMap<scf::ForOp, llvm::DenseMap<Value, SmallVector<Value>>> intraCoreDependentMap;
   // Used to store the producer/consumer relationship between the tensor type iter_args in the main_loop and ssbuffer.if
   // Note: vector index corresponds to iter arg index in the for op

--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition.h
@@ -36,10 +36,10 @@
 namespace mlir {
 namespace triton {
 
-// Indicates the relationship between a tensor iter_args and ssbuffer.if in the main_loop
+// Indicates the relationship between a tensor iter_arg and ssbuffer.if in the main_loop
 struct TensorIterArgIfOpRelation {
   Value iterArg;
-  llvm::SmallVector<scf::IfOp> producers;
+  scf::IfOp producer;
   llvm::SmallVector<scf::IfOp> consumers;
 };
 
@@ -64,9 +64,6 @@ struct ControlFlowConditionInfo {
   llvm::DenseMap<scf::ForOp, llvm::SmallVector<TensorIterArgIfOpRelation>> tensorIterArgDepsMap;
   // Used to record the index of the control condition variable for the newly created iter_args for tensor iter_args
   llvm::DenseMap<scf::ForOp, llvm::DenseMap<Value, SmallVector<int>>> tensorIterArgIndicesMap;
-  
-  // Record each ifOp as the variables that need to be controlled when it acts as a consumer or a producer
-  llvm::DenseMap<scf::IfOp, TensorIterArgIfOpVars> tensorIterArgIfOpVars;
   
   // unique counter value for each ifblock
   llvm::DenseMap<scf::IfOp, Value> cntArgs;

--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.h
@@ -70,6 +70,7 @@ private:
 
     void collectDependencyBuffers(scf::ForOp forOp,
                                   DenseMap<int, DenseMap<Value, SmallVector<Value> > > &crossCoreBuffers,
+                                  DenseMap<int, DenseMap<Operation*, SmallVector<Operation*>>> &memCrossCoreBuffers,
                                   DenseMap<int, DenseMap<Value, SmallVector<Value> > > &intraCoreBuffers);
 
     DenseMap<int, DenseMap<Value, SmallVector<Value> > >
@@ -81,6 +82,7 @@ private:
                          DenseMap<int, Value> &idxToVar);
 
     int getInputOutputValues(scf::IfOp ifOp, DenseMap<int, DenseMap<Value, SmallVector<Value> > > crossCoreBuffers,
+                              DenseMap<int, DenseMap<Operation*, SmallVector<Operation*>>> memCrossCoreBuffers,
                               DenseMap<int, DenseMap<Value, SmallVector<Value> > > intraCoreBuffers,
                               SmallVector<int> &crossCoreInputValues, SmallVector<int> &crossCoreOutputValues,
                               SmallVector<int> &intraCoreInputValues, SmallVector<int> &intraCoreOutputValues);
@@ -144,8 +146,9 @@ private:
                           size_t &usedCounterNum, DenseMap<Value, VarUpdateType> &varUpdateTypes);
 
     int setCrossCoreCondition(SmallVector<int> crossCoreInputValues, SmallVector<int> crossCoreOutputValues,
-                               DenseMap<int, DenseMap<Value, SmallVector<Value> > > &crossCoreBuffers, scf::IfOp ifOp,
-                               SmallVector<SmallVector<Value> > ssbufferPtrs, Value &crossCoreCond);
+                               DenseMap<int, DenseMap<Value, SmallVector<Value> > > &crossCoreBuffers,
+                               DenseMap<int, DenseMap<Operation*, SmallVector<Operation*>>> &memCrossCoreBuffers,
+                               scf::IfOp ifOp, SmallVector<SmallVector<Value> > ssbufferPtrs, Value &crossCoreCond);
 
     // Helper function to get pointer based on core type
     Value getSSBufferPtr(bool isAIC, int groupIdx, int ptrSetIdx,
@@ -162,6 +165,7 @@ private:
     Value addCrossCoreConditions(OpBuilder &builder, Location loc,
                                  SmallVector<int> crossCoreInputValues, SmallVector<int> crossCoreOutputValues,
                                  DenseMap<int, DenseMap<Value, SmallVector<Value> > > &crossCoreBuffers,
+                                 DenseMap<int, DenseMap<Operation*, SmallVector<Operation*>>> &memCrossCoreBuffers,
                                  bool isAIC, Value zeroConst,
                                  DenseMap<int, Value> &precomputedPtrs,
                                  SmallVector<SmallVector<Value> > ssbufferPtrs);

--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.h
@@ -181,6 +181,8 @@ private:
     DenseMap<Value, Value> controlVarToLatestValue;
     SmallVector<Value> currentUsedVars;
     ControlFlowConditionInfo *info = nullptr;
+    // Record each ifOp as the variables that need to be controlled when it acts as a consumer or a producer
+    llvm::DenseMap<scf::IfOp, TensorIterArgIfOpVars> tensorIterArgIfOpVars;
 };
 
 std::unique_ptr<OperationPass<ModuleOp> > createUpdateConditionInfoPass();

--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.h
@@ -101,6 +101,17 @@ private:
       DenseMap<Operation *, int> &ifOpIndex,
       DenseMap<Value, SmallVector<Value>> &crossDeps);
 
+  // Calculate factor based on iteration dependencies (tensor iter_args dependencies)
+  // For iter deps: consumer and producer are IfOps within the same forOp
+  // Returns {maxRequiredBuffers, maxX} where:
+  //   - maxRequiredBuffers: maximum (m - n + 1) across all dependencies
+  //   - maxX: the x value corresponding to maxRequiredBuffers
+  //   - returns {-1, -1} on error
+  std::pair<int, int> calculateIterDepsFactor(
+      scf::ForOp forOp,
+      SmallVector<scf::IfOp> &ifOps,
+      DenseMap<Operation *, int> &ifOpIndex);
+
   // Extend for loop iteration count
   scf::ForOp extendForOpIterationCount(scf::ForOp oldForOp, int ifCount,
                                        int requiredBuffers, int x,

--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -49,6 +49,7 @@ inline constexpr llvm::StringLiteral kIntraBuffer = "ssbuffer.intra_buffer";
 inline constexpr llvm::StringLiteral kAnalyzeFlagId = "ssbuffer.analyze_flag_id";
 inline constexpr llvm::StringLiteral kLoopCarriedL0C = "ssbuffer.loop_carried_l0c";
 inline constexpr llvm::StringLiteral kCrossDeps = "ssbuffer.crossDeps";
+inline constexpr llvm::StringLiteral kIntraDeps = "ssbuffer.intraDeps";
 inline constexpr llvm::StringLiteral kMemCrossDeps = "ssbuffer.memCrossDeps";
 inline constexpr llvm::StringLiteral kMayNotExec = "ssbuffer.may_not_exec";
 inline constexpr llvm::StringLiteral kClone = "ssbuffer.clone";

--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -49,6 +49,7 @@ inline constexpr llvm::StringLiteral kIntraBuffer = "ssbuffer.intra_buffer";
 inline constexpr llvm::StringLiteral kAnalyzeFlagId = "ssbuffer.analyze_flag_id";
 inline constexpr llvm::StringLiteral kLoopCarriedL0C = "ssbuffer.loop_carried_l0c";
 inline constexpr llvm::StringLiteral kCrossDeps = "ssbuffer.crossDeps";
+inline constexpr llvm::StringLiteral kMemCrossDeps = "ssbuffer.memCrossDeps";
 inline constexpr llvm::StringLiteral kMayNotExec = "ssbuffer.may_not_exec";
 inline constexpr llvm::StringLiteral kClone = "ssbuffer.clone";
 static constexpr llvm::StringLiteral kInlinableQuantScaleAttr = "enable_fast_tf32_mul";

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
@@ -57,6 +57,7 @@ struct DependencyInfo {
   int iniProducerBlockId;
   int iniConsumerBlockId;
 
+  bool isAllTranspoesd = false;
   // Optional Items for V2CDependencies
   mlir::Operation *iniMatmulOp = nullptr;
   bool isMatmulA = false;
@@ -129,7 +130,8 @@ private:
 
     void collectDepInfo(mlir::Value depvalue, DependencyType dependencyType,
                         llvm::SmallVector<DependencyInfo> &dependencies,
-                        int iniProdId, int iniConsId, DataDependencyInfo &info);
+                        int iniProdId, int iniConsId, DataDependencyInfo &info,
+                        bool isAllTranspoesd = false);
     void collectMemDepInfo(
       llvm::StringRef predCoreType,
       int producerBlockId, int consumerBlockId, int predBlockId, int currBlockId,

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
@@ -62,6 +62,10 @@ struct DependencyInfo {
   mlir::Operation *iniMatmulOp = nullptr;
   bool isMatmulA = false;
   bool isMatmulB = false;
+
+  // Optional Items for memDependencies
+  mlir::Operation *predOp;
+  mlir::Operation *nextOp;
 };
 
 class DataDependencyInfo {
@@ -135,7 +139,7 @@ private:
     void collectMemDepInfo(
       llvm::StringRef predCoreType,
       int producerBlockId, int consumerBlockId, int predBlockId, int currBlockId,
-      llvm::SmallVector<DependencyInfo> &memoryDependencies);
+      llvm::SmallVector<DependencyInfo> &memoryDependencies, mlir::Operation *predOp, mlir::Operation *nextOp);
     void analyzeExternalInputs(DataDependencyInfo &info);
     void analyzeExternalOutputs(DataDependencyInfo &info);
 

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
@@ -157,7 +157,7 @@ private:
     int transferIndex, int iniConsumerId, bool isScaler, mlir::Operation **consumedDataOp = nullptr);
   mlir::Operation *insertCubeToVectorTransfer(mlir::OpBuilder &builder, mlir::Value srcValue,
     mlir::Operation *cubeEndOp, mlir::Operation *vectorStartOp, mlir::Location loc, int transferIndex,
-    int iniConsumerId, mlir::Operation **consumedDataOp = nullptr);
+    int iniConsumerId, bool isAllTranspoesd, mlir::Operation **consumedDataOp = nullptr);
   TransferPipeConfig getTransferPipeConfig(Operation *transferOp);
   void insertInterCoreSync(mlir::OpBuilder &builder, mlir::Operation *transferOp, mlir::Operation *consumerStartOp,
     mlir::Operation *consumerEndOp, int flag, mlir::Location loc, int transferIndex, FlagIdReuseManager &flagIdReuseManager,

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/InitDependentMap.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/InitDependentMap.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/InitDependentMap.h"
+#include "third_party/ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
@@ -51,7 +52,7 @@ static int isConsumerInMainLoop(Operation *consumer, scf::ForOp mainLoop,
   // Traverse up the parent chain until we reach the top (nullptr)
   while (current != nullptr) {
     if (auto forOp = dyn_cast<scf::ForOp>(current)) {
-      if (forOp->hasAttr("ssbuffer.main_loop") && forOp != mainLoop) {
+      if (forOp->hasAttr(CVPipeline::kMainLoop) && forOp != mainLoop) {
         // comsumer Op not in the current mainloop
         return 0;
       }
@@ -165,6 +166,146 @@ static int buildProducerConsumerMapping(
   return 0;
 }
 
+// Function: Build mapping from consumer Operation to producer Operation
+// Input: Ops grouped by group ID, format: group -> [(op, role), ...]
+//        role: 1=producer, 0=consumer
+//        mainLoop: if not nullptr, only include consumers inside this mainLoop
+// Output: result - Mapping from consumer Operation* to list of producer Operation*
+// Return: 0 for success, -1 for failure
+static int buildProducerConsumerMappingForOps(
+    llvm::DenseMap<int, SmallVector<std::pair<Operation *, int>>> &depsByGroup,
+    llvm::DenseMap<Operation *, SmallVector<Operation *>> &result,
+    scf::ForOp mainLoop = nullptr)
+{
+  for (auto &groupEntry : depsByGroup) {
+    auto &ops = groupEntry.second;
+
+    // Collect all producers and consumers in this group
+    SmallVector<Operation *> producers;
+    SmallVector<Operation *> consumers;
+
+    for (auto &opRole : ops) {
+      Operation *op = opRole.first;
+      int role = opRole.second;
+      if (role == producerId) {
+        producers.push_back(op);
+      } else if (role == consumerId) {
+        // For intra-core mapping, only include consumers inside mainLoop
+        if (mainLoop != nullptr) {
+          if (isConsumerInMainLoop(op, mainLoop, consumers) != 0) {
+            LDBG("isConsumerInMainLoop failed");
+            return -1;
+          }
+        } else {
+          consumers.push_back(op);
+        }
+      } else {
+        LDBG("Get error role id in dependency attribute: OP: " << *op << ", role: " << role);
+        return -1;
+      }
+    }
+
+    // Skip if no consumers (for intra-core mapping with mainLoop filter)
+    if (mainLoop != nullptr && consumers.empty())
+      continue;
+
+    // For each consumer, build mapping to all producers
+    for (Operation *consumer : consumers) {
+      result[consumer] = producers;
+    }
+  }
+
+  return 0;
+}
+
+static int collectMainLoopById(ModuleOp module, llvm::DenseMap<int, scf::ForOp> &mainLoopById)
+{
+  int ret = 0;
+  module.walk([&](scf::ForOp forOp) {
+    if (!forOp->hasAttr(CVPipeline::kMainLoop))
+      return;
+    auto mainLoopIdAttr = forOp->getAttrOfType<IntegerAttr>(CVPipeline::kMainLoop);
+    if (mainLoopIdAttr) {
+      mainLoopById[mainLoopIdAttr.getInt()] = forOp;
+    }
+  });
+  return ret;
+}
+
+static int findMainLoopIdContainingOp(Operation *op, llvm::DenseMap<int, scf::ForOp> &mainLoopById)
+{
+  for (auto &idLoopEntry : mainLoopById) {
+    if (idLoopEntry.second->isAncestor(op)) {
+      return idLoopEntry.first;
+    }
+  }
+  return -1;
+}
+
+static int filterMemCrossCoreDepsByMainLoop(
+    ModuleOp module,
+    llvm::DenseMap<Operation *, SmallVector<Operation *>> &initialDepsMap,
+    llvm::DenseMap<Operation *, SmallVector<Operation *>> &filteredDepsMap)
+{
+  LDBG("memCrossCore dependencies before filter: " << initialDepsMap.size());
+
+  // Step 1: Collect all main_loop forOps and their ids
+  llvm::DenseMap<int, scf::ForOp> mainLoopById;
+  if (collectMainLoopById(module, mainLoopById) != 0) {
+    LDBG("collectMainLoopById Failed!");
+    return -1;
+  }
+
+  // Step 2: Filter mapping - only keep producer/consumer pairs in the same main_loop
+  for (auto &entry : initialDepsMap) {
+    Operation *consumer = entry.first;
+    SmallVector<Operation *> &producers = entry.second;
+    if (producers.empty()) {
+      LDBG("Producers list is empty!");
+      return -1;
+    }
+
+    // Find the main_loop id containing the consumer
+    int consumerMainLoopId = findMainLoopIdContainingOp(consumer, mainLoopById);
+    if (consumerMainLoopId == -1) {
+      LDBG("Consumer op is not in any main_loop, skip: " << *consumer);
+      continue;
+    }
+
+    // Find the main_loop id containing the producer
+    int producerMainLoopId = findMainLoopIdContainingOp(producers[0], mainLoopById);
+    if (producerMainLoopId == -1) {
+      LDBG("producer op is not in any main_loop: " << *producers[0]);
+      continue;
+    }
+
+    // Check all producers in the same mainloop
+    for (size_t i = 1; i < producers.size(); i++) {
+      int otherProducerMainLoopId = findMainLoopIdContainingOp(producers[i], mainLoopById);
+      if (otherProducerMainLoopId != producerMainLoopId) {
+        LDBG("Producers are not in the same main_loop. "
+             << "First producer main_loop id: " << producerMainLoopId
+             << ", Producer[" << i << "] main_loop id: " << otherProducerMainLoopId);
+        return -1;
+      }
+    }
+
+    // Check if consumer and producers are in the same main_loop
+    if (consumerMainLoopId != producerMainLoopId) {
+      LDBG("Consumer and producers are in different main_loop, skip. "
+           << "Consumer main_loop id: " << consumerMainLoopId
+           << ", Producer main_loop id: " << producerMainLoopId);
+      continue;
+    }
+
+    filteredDepsMap[consumer] = producers;
+  }
+
+  LDBG("memCrossCore dependencies after filter: " << filteredDepsMap.size());
+
+  return 0;
+}
+
 // Initialize crossCoreDependentMap (cross-core data dependency)
 // Find ops with ssbuffer.crossDeps attribute
 // Attribute value is a list: [group, role], role: 1=producer, 0=consumer
@@ -173,7 +314,7 @@ static int buildProducerConsumerMapping(
 int initCrossCoreDependentMap(ModuleOp module, ControlFlowConditionInfo *info)
 {
   llvm::DenseMap<int, SmallVector<std::pair<Operation *, int>>> crossDepsByGroup;
-  if (collectDepsByGroup(module, "ssbuffer.crossDeps", crossDepsByGroup) != 0) {
+  if (collectDepsByGroup(module, CVPipeline::kCrossDeps.data(), crossDepsByGroup) != 0) {
     LDBG("collectDepsByGroup on crossDeps Failed!");
     return -1;
   }
@@ -187,6 +328,39 @@ int initCrossCoreDependentMap(ModuleOp module, ControlFlowConditionInfo *info)
   return 0;
 }
 
+// Initialize memCrossCoreDependentMap (memory cross-core data dependency)
+// Find ops with ssbuffer.memCrossDeps attribute
+// Attribute value is a list: [group, role], role: 1=producer, 0=consumer
+// Map key is consumer Operation*, value is list of all producer Operation* in the same group
+// Constraint: consumer and producer must be in the same main_loop (with same id)
+// Return: 0 for success, -1 for failure
+int initMemCrossCoreDependentMap(ModuleOp module, ControlFlowConditionInfo *info)
+{
+  // Step 1: Collect all memcrossDeps by group
+  llvm::DenseMap<int, SmallVector<std::pair<Operation *, int>>> memcrossDepsByGroup;
+  if (collectDepsByGroup(module, CVPipeline::kMemCrossDeps.data(), memcrossDepsByGroup) != 0) {
+    LDBG("collectDepsByGroup on memcrossDeps Failed!");
+    return -1;
+  }
+
+  // Step 2: Build initial mapping (all producers for each consumer)
+  llvm::DenseMap<Operation *, SmallVector<Operation *>> initialMemcrossDepsMap;
+  if (buildProducerConsumerMappingForOps(memcrossDepsByGroup, initialMemcrossDepsMap) != 0) {
+    LDBG("buildProducerConsumerMappingForOps on memcrossDeps Failed!");
+    return -1;
+  }
+
+  // Step 3: Filter by main_loop constraint
+  llvm::DenseMap<Operation *, SmallVector<Operation *>> filteredMemcrossDepsMap;
+  if (filterMemCrossCoreDepsByMainLoop(module, initialMemcrossDepsMap, filteredMemcrossDepsMap) != 0) {
+    LDBG("filterMemCrossCoreDepsByMainLoop Failed!");
+    return -1;
+  }
+
+  info->memCrossCoreDependentMap = filteredMemcrossDepsMap;
+  return 0;
+}
+
 // Initialize intraCoreDependentMap (intra-core data dependency)
 // Find forOp with ssbuffer.main_loop attribute
 // Collect all intra-core deps from module (producers may be outside the loop)
@@ -196,7 +370,7 @@ int initIntraCoreDependentMap(ModuleOp module, ControlFlowConditionInfo *info)
 {
   // Collect all intra-core deps from the entire module
   llvm::DenseMap<int, SmallVector<std::pair<Operation *, int>>> allIntraDepsByGroup;
-  if (collectDepsByGroup(module, "ssbuffer.intraDeps", allIntraDepsByGroup) != 0) {
+  if (collectDepsByGroup(module, CVPipeline::kIntraDeps.data(), allIntraDepsByGroup) != 0) {
     LDBG("collectDepsByGroup on intraDeps Failed!");
     return -1;
   }
@@ -204,7 +378,7 @@ int initIntraCoreDependentMap(ModuleOp module, ControlFlowConditionInfo *info)
   // For each mainLoop, build mapping with consumers inside it
   int ret = 0;
   module.walk([&](Operation* op) {
-    if (!op->hasAttr("ssbuffer.main_loop"))
+    if (!op->hasAttr(CVPipeline::kMainLoop))
       return;
     auto forOp = dyn_cast<scf::ForOp>(op);
     if (!forOp) {
@@ -240,6 +414,18 @@ static void printDependentMaps(ControlFlowConditionInfo *info)
       LDBG("    Consumer: " << consumer << " (producers count: " << producers.size() << ")");
       for (Value producer : producers) {
           LDBG("      Producer: " << producer);
+      }
+  }
+
+  // Print memCrossCoreDependentMap
+  LDBG("memCrossCoreDependentMap size: " << info->memCrossCoreDependentMap.size());
+  LDBG("memCrossCoreDependentMap contents:");
+  for (auto &entry : info->memCrossCoreDependentMap) {
+      Operation *consumer = entry.first;
+      SmallVector<Operation*> &producers = entry.second;
+      LDBG("    Consumer: " << *consumer << " (producers count: " << producers.size() << ")");
+      for (Operation *producer : producers) {
+          LDBG("      Producer: " << *producer);
       }
   }
 
@@ -280,7 +466,14 @@ void InitDependentMapPass::runOnOperation()
         return;
     }
 
-    // Step 2: Initialize intraCoreDependentMap
+    // Step 2: Initialize memCrossCoreDependentMap
+    if (initMemCrossCoreDependentMap(module, info) != 0) {
+        LDBG("initMemCrossCoreDependentMap failed!");
+        signalPassFailure();
+        return;
+    }
+
+    // Step 3: Initialize intraCoreDependentMap
     if (initIntraCoreDependentMap(module, info) != 0) {
         LDBG("initIntraCoreDependentMap failed!");
         signalPassFailure();
@@ -288,7 +481,7 @@ void InitDependentMapPass::runOnOperation()
     }
 
     // Print all dependent maps for verification
-    printDependentMaps(info);
+    LLVM_DEBUG(printDependentMaps(info));
 
     LDBG("Exit InitDependentMap pass.");
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
@@ -92,7 +92,7 @@ SmallVector<SmallVector<Value>> UpdateConditionInfoPass::allocSSBuffer(ModuleOp 
   SmallVector<SmallVector<Value>> ssbufferPtrs;
   SmallVector<Value> ssbufferVec0Ptrs;
   SmallVector<Value> ssbufferVec1Ptrs;
-  int numBuffers = info->crossCoreDependentMap.size();
+  int numBuffers = info->crossCoreDependentMap.size() + info->memCrossCoreDependentMap.size();
   if (numBuffers == 0) {
       LDBG("crossCoreDependentMap is empty!" << "\n");
       return ssbufferPtrs;
@@ -133,12 +133,22 @@ SmallVector<SmallVector<Value>> UpdateConditionInfoPass::allocSSBuffer(ModuleOp 
 // Collect dependency buffer
 void UpdateConditionInfoPass::collectDependencyBuffers(
     scf::ForOp forOp, DenseMap<int, DenseMap<Value, SmallVector<Value>>> &crossCoreBuffers,
+    DenseMap<int, DenseMap<Operation*, SmallVector<Operation*>>> &memCrossCoreBuffers,
     DenseMap<int, DenseMap<Value, SmallVector<Value>>> &intraCoreBuffers)
 {
   int crossCoreIdx = 0;
   for (auto &entry : info->crossCoreDependentMap) {
     crossCoreBuffers[crossCoreIdx][entry.first] = entry.second;
     crossCoreIdx++;
+  }
+
+  // Collect memCrossCoreDependentMap with offset groupIdx
+  int memCrossCoreOffset = info->crossCoreDependentMap.size();
+  int memCrossCoreIdx = 0;
+  for (auto &entry : info->memCrossCoreDependentMap) {
+    int adjustedGroupIdx = memCrossCoreOffset + memCrossCoreIdx;
+    memCrossCoreBuffers[adjustedGroupIdx][entry.first] = entry.second;
+    memCrossCoreIdx++;
   }
 
   if (info->intraCoreDependentMap.count(forOp)) {
@@ -313,6 +323,24 @@ static int buildBufferDependencyMappings(
   return UPDATE_CONDITION_INFO_SUCCESS;
 }
 
+// Helper function to build buffer dependency mappings for Operation* type (memCrossCore)
+static int buildBufferDependencyMappingsForOps(
+    DenseMap<int, DenseMap<Operation*, SmallVector<Operation*>>> &buffers,
+    DenseMap<Operation*, int> &consumerToGroup,
+    DenseMap<Operation*, int> &producerToGroup)
+{
+  for (auto &[groupIdx, deps] : buffers) {
+    for (auto &[consumer, producers] : deps) {
+      consumerToGroup[consumer] = groupIdx;
+
+      for (Operation *producer : producers) {
+        producerToGroup[producer] = groupIdx;
+      }
+    }
+  }
+  return UPDATE_CONDITION_INFO_SUCCESS;
+}
+
 // getInputOutputValues - Analyze the input/output buffer groups used in a single ifOp
 // This function traverses all operations within ifOp, identifies FixpipeOp, CopyOp and
 // MaterializeInDestinationOp, and extracts cross-core and intra-core buffer group indices
@@ -333,9 +361,10 @@ static int buildBufferDependencyMappings(
 //   4. Deduplicate and output four groups of index values
 int UpdateConditionInfoPass::getInputOutputValues(
     scf::IfOp ifOp, DenseMap<int, DenseMap<Value, SmallVector<Value>>> crossCoreBuffers,
-    DenseMap<int, DenseMap<Value, SmallVector<Value>>> intraCoreBuffers, SmallVector<int> &crossCoreInputValues,
-    SmallVector<int> &crossCoreOutputValues, SmallVector<int> &intraCoreInputValues,
-    SmallVector<int> &intraCoreOutputValues)
+    DenseMap<int, DenseMap<Operation*, SmallVector<Operation*>>> memCrossCoreBuffers,
+    DenseMap<int, DenseMap<Value, SmallVector<Value>>> intraCoreBuffers,
+    SmallVector<int> &crossCoreInputValues, SmallVector<int> &crossCoreOutputValues,
+    SmallVector<int> &intraCoreInputValues, SmallVector<int> &intraCoreOutputValues)
 {
   DenseSet<int> crossCoreInputSet;
   DenseSet<int> crossCoreOutputSet;
@@ -351,9 +380,19 @@ int UpdateConditionInfoPass::getInputOutputValues(
   DenseMap<Operation*, int> crossCoreConsumerToGroup;
   DenseMap<Operation*, int> intraCoreConsumerToGroup;
 
+  // Build memCrossCore mappings (Operation* based)
+  DenseMap<Operation*, int> memCrossCoreConsumerToGroup;
+  DenseMap<Operation*, int> memCrossCoreProducerToGroup;
+
   // Build cross-core mappings
   if (buildBufferDependencyMappings(crossCoreBuffers, crossCoreConsumerToGroup,
                                      crossCoreOutputToGroups) == UPDATE_CONDITION_INFO_FAILED) {
+    return UPDATE_CONDITION_INFO_FAILED;
+  }
+
+  // Build memCrossCore mappings
+  if (buildBufferDependencyMappingsForOps(memCrossCoreBuffers, memCrossCoreConsumerToGroup,
+                                           memCrossCoreProducerToGroup) == UPDATE_CONDITION_INFO_FAILED) {
     return UPDATE_CONDITION_INFO_FAILED;
   }
 
@@ -372,8 +411,17 @@ int UpdateConditionInfoPass::getInputOutputValues(
     if (crossCoreConsumerToGroup.count(op)) {
       crossCoreInputSet.insert(crossCoreConsumerToGroup[op]);
     }
+    // Check if this op is a memCrossCore consumer (merge into crossCoreInputSet)
+    if (memCrossCoreConsumerToGroup.count(op)) {
+      crossCoreInputSet.insert(memCrossCoreConsumerToGroup[op]);
+    }
     if (intraCoreConsumerToGroup.count(op)) {
       intraCoreInputSet.insert(intraCoreConsumerToGroup[op]);
+    }
+
+    // Check if this op is a memCrossCore producer (merge into crossCoreOutputSet)
+    if (memCrossCoreProducerToGroup.count(op)) {
+      crossCoreOutputSet.insert(memCrossCoreProducerToGroup[op]);
     }
 
     bool isFixpipeOrCopy = dyn_cast<hivm::FixpipeOp>(op) || dyn_cast<hivm::CopyOp>(op);
@@ -557,6 +605,7 @@ Value UpdateConditionInfoPass::addCrossCoreConditions(
     OpBuilder &builder, Location loc,
     SmallVector<int> crossCoreInputValues, SmallVector<int> crossCoreOutputValues,
     DenseMap<int, DenseMap<Value, SmallVector<Value>>> &crossCoreBuffers,
+    DenseMap<int, DenseMap<Operation*, SmallVector<Operation*>>> &memCrossCoreBuffers,
     bool isAIC, Value zeroConst,
     DenseMap<int, Value> &VectorSSBufferPtrs,
     SmallVector<SmallVector<Value>> ssbufferPtrs)
@@ -591,8 +640,18 @@ Value UpdateConditionInfoPass::addCrossCoreConditions(
 
   for (int outputGroupIdx : crossCoreOutputValues) {
     int outputCount = 0;
-    for (auto &entry : crossCoreBuffers[outputGroupIdx]) {
-      outputCount += entry.second.size();
+    // Check if outputGroupIdx belongs to crossCoreBuffers or memCrossCoreBuffers
+    if (crossCoreBuffers.count(outputGroupIdx)) {
+      for (auto &entry : crossCoreBuffers[outputGroupIdx]) {
+        outputCount += entry.second.size();
+      }
+    } else if (memCrossCoreBuffers.count(outputGroupIdx)) {
+      for (auto &entry : memCrossCoreBuffers[outputGroupIdx]) {
+        outputCount += entry.second.size();
+      }
+    } else {
+      LDBG("outputGroupIdx " << outputGroupIdx << " not found in any buffers map!" << "\n");
+      return nullptr;
     }
     Value bufferNum = builder.create<arith::ConstantIntOp>(loc, outputCount, CONST_INT_TYPE);
     Value cond = nullptr;
@@ -674,8 +733,9 @@ void UpdateConditionInfoPass::updateCrossCoreControlVars(
 // Set the crossCore condition
 int UpdateConditionInfoPass::setCrossCoreCondition(
     SmallVector<int> crossCoreInputValues, SmallVector<int> crossCoreOutputValues,
-    DenseMap<int, DenseMap<Value, SmallVector<Value>>> &crossCoreBuffers, scf::IfOp ifOp,
-    SmallVector<SmallVector<Value>> ssbufferPtrs, Value &crossCoreCond)
+    DenseMap<int, DenseMap<Value, SmallVector<Value>>> &crossCoreBuffers,
+    DenseMap<int, DenseMap<Operation*, SmallVector<Operation*>>> &memCrossCoreBuffers,
+    scf::IfOp ifOp, SmallVector<SmallVector<Value>> ssbufferPtrs, Value &crossCoreCond)
 {
   OpBuilder builder(ifOp);
   Location loc = ifOp.getLoc();
@@ -728,7 +788,7 @@ int UpdateConditionInfoPass::setCrossCoreCondition(
 
   // ========== Part 2: Add cross-core conditions ==========
   crossCoreCond = addCrossCoreConditions(builder, loc, crossCoreInputValues, crossCoreOutputValues,
-                                         crossCoreBuffers, isAIC, zeroConst,
+                                         crossCoreBuffers, memCrossCoreBuffers, isAIC, zeroConst,
                                          VectorSSBufferPtrs, ssbufferPtrs);
 
   // ========== Part 3: Update control variables ==========
@@ -1361,11 +1421,12 @@ int UpdateConditionInfoPass::updateIfConds(ModuleOp module, SmallVector<SmallVec
     }
 
     DenseMap<int, DenseMap<Value, SmallVector<Value> > > crossCoreBuffers;
+    DenseMap<int, DenseMap<Operation*, SmallVector<Operation*>>> memCrossCoreBuffers;
     DenseMap<int, DenseMap<Value, SmallVector<Value> > > intraCoreBuffers;
     // Step1:Collect the dependency buffer info of this forOp
-    collectDependencyBuffers(forOp, crossCoreBuffers, intraCoreBuffers);
-    if (crossCoreBuffers.empty() && intraCoreBuffers.empty()) {
-      LDBG("crossCoreBuffers and intraCoreBuffers are both empty!" << "\n");
+    collectDependencyBuffers(forOp, crossCoreBuffers, memCrossCoreBuffers, intraCoreBuffers);
+    if (crossCoreBuffers.empty() && memCrossCoreBuffers.empty() && intraCoreBuffers.empty()) {
+      LDBG("crossCoreBuffers, memCrossCoreBuffers and intraCoreBuffers are all empty!" << "\n");
       return UPDATE_CONDITION_INFO_FAILED;
     }
 
@@ -1418,16 +1479,17 @@ int UpdateConditionInfoPass::updateIfConds(ModuleOp module, SmallVector<SmallVec
       SmallVector<int> intraCoreInputValues;
       SmallVector<int> intraCoreOutputValues;
 
-      if (getInputOutputValues(ifOp, extendedCrossCoreBuffers, intraCoreBuffers, crossCoreInputValues,
-                               crossCoreOutputValues, intraCoreInputValues, intraCoreOutputValues) != 0) {
+      if (getInputOutputValues(ifOp, extendedCrossCoreBuffers, memCrossCoreBuffers, intraCoreBuffers,
+                               crossCoreInputValues, crossCoreOutputValues,
+                               intraCoreInputValues, intraCoreOutputValues) != 0) {
         LDBG("getInputOutputValues failed!" << "\n");
         return UPDATE_CONDITION_INFO_FAILED;
       }
 
       // Step3:Set the crossCore condition
       Value crossCoreCond;
-      if (setCrossCoreCondition(crossCoreInputValues, crossCoreOutputValues, crossCoreBuffers, ifOp,
-                                ssbufferPtrs, crossCoreCond) != 0) {
+      if (setCrossCoreCondition(crossCoreInputValues, crossCoreOutputValues, crossCoreBuffers,
+                               memCrossCoreBuffers, ifOp, ssbufferPtrs, crossCoreCond) != 0) {
         LDBG("setCrossCoreCondition failed!" << "\n");
         return UPDATE_CONDITION_INFO_FAILED;
       }

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
@@ -875,6 +875,9 @@ int UpdateConditionInfoPass::collectIntraCoreOutputConditions(
 // Build the ifOp variable mapping for the tensor iter_args
 int UpdateConditionInfoPass::buildTensorIterArgIfOpVarMap(scf::ForOp forOp)
 {
+  // Clear any previous data
+  tensorIterArgIfOpVars.clear();
+  
   if (!info->tensorIterArgDepsMap.count(forOp) || !info->tensorIterArgIndicesMap.count(forOp)) {
     LDBG("Skip buildTensorIterArgIfOpVarMap: no tensor iter_args info for this forOp\n");
     return UPDATE_CONDITION_INFO_SUCCESS;
@@ -908,11 +911,11 @@ int UpdateConditionInfoPass::buildTensorIterArgIfOpVarMap(scf::ForOp forOp)
       Value var = forOp.getRegionIterArg(argIndices[i]);
       consumerToVar[consumer] = var;
     }
-
-    // Add all the variables of the consumers that depend on each producer
-    for (scf::IfOp producer : relation.producers) {
+    
+    // Add all the variables of the consumers that depend on the producer
+    if (relation.producer) {
       for (auto &[consumer, var] : consumerToVar) {
-        producerVars[producer].insert(var);
+        producerVars[relation.producer].insert(var);
       }
     }
 
@@ -924,14 +927,14 @@ int UpdateConditionInfoPass::buildTensorIterArgIfOpVarMap(scf::ForOp forOp)
 
   // Convert the temporary data structure to tensorIfOpVarMap
   for (auto &[producer, vars] : producerVars) {
-    auto &ifOpVars = info->tensorIterArgIfOpVars[producer];
+    auto &ifOpVars = tensorIterArgIfOpVars[producer];
     for (Value var : vars) {
       ifOpVars.producerVars.push_back(var);
     }
   }
 
   for (auto &[consumer, vars] : consumerVars) {
-    auto &ifOpVars = info->tensorIterArgIfOpVars[consumer];
+    auto &ifOpVars = tensorIterArgIfOpVars[consumer];
     for (Value var : vars) {
       ifOpVars.consumerVars.push_back(var);
     }
@@ -945,11 +948,11 @@ void UpdateConditionInfoPass::collectTensorIterArgInputConditions(
     SmallVector<Value> &conditions, DenseSet<Value> &usedVarsSet,
     DenseMap<Value, VarUpdateType> &varUpdateTypes)
 {
-  if (!info->tensorIterArgIfOpVars.count(ifOp)) {
+  if (!tensorIterArgIfOpVars.count(ifOp)) {
     return;
   }
 
-  auto &ifOpVars = info->tensorIterArgIfOpVars[ifOp];
+  auto &ifOpVars = tensorIterArgIfOpVars[ifOp];
   for (Value var : ifOpVars.consumerVars) {
     Value varToUse = var;
     auto latestIt = controlVarToLatestValue.find(var);
@@ -972,11 +975,11 @@ void UpdateConditionInfoPass::collectTensorIterArgOutputConditions(
     SmallVector<Value> &conditions, DenseSet<Value> &usedVarsSet,
     DenseMap<Value, VarUpdateType> &varUpdateTypes)
 {
-  if (!info->tensorIterArgIfOpVars.count(ifOp)) {
+  if (!tensorIterArgIfOpVars.count(ifOp)) {
     return;
   }
 
-  auto &ifOpVars = info->tensorIterArgIfOpVars[ifOp];
+  auto &ifOpVars = tensorIterArgIfOpVars[ifOp];
   for (Value var : ifOpVars.producerVars) {
     Value varToUse = var;
     auto latestIt = controlVarToLatestValue.find(var);
@@ -1378,11 +1381,29 @@ int UpdateConditionInfoPass::combineConditions(ModuleOp module, Value crossCoreC
     info->cntArgs[newIfOp] = counter;
   }
 
+  // Update mappings that refer to the old ifOp BEFORE erasing it
   // Update the tensorIterArgIfOpVars mapping
-  if (info->tensorIterArgIfOpVars.count(ifOp)) {
-    auto ifOpVars = info->tensorIterArgIfOpVars[ifOp];
-    info->tensorIterArgIfOpVars.erase(ifOp);
-    info->tensorIterArgIfOpVars[newIfOp] = ifOpVars;
+  if (tensorIterArgIfOpVars.count(ifOp)) {
+    auto ifOpVars = tensorIterArgIfOpVars[ifOp];
+    tensorIterArgIfOpVars.erase(ifOp);
+    tensorIterArgIfOpVars[newIfOp] = ifOpVars;
+  }
+  
+  // Update tensorIterArgDepsMap with new ifOp
+  if (info->tensorIterArgDepsMap.count(forOp)) {
+    auto &depsVec = info->tensorIterArgDepsMap[forOp];
+    for (auto &relation : depsVec) {
+      // Update producer ifOp - use pointer comparison
+      if (relation.producer.getOperation() == ifOp.getOperation()) {
+        relation.producer = newIfOp;
+      }
+      // Update consumer ifOps
+      for (auto &consumerIfOp : relation.consumers) {
+        if (consumerIfOp.getOperation() == ifOp.getOperation()) {
+          consumerIfOp = newIfOp;
+        }
+      }
+    }
   }
 
   updateControlVarToLatestValue(newIfOp, ifOp, hasCounter, counter);

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateForOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateForOps.cpp
@@ -450,6 +450,7 @@ LogicalResult UpdateForOpsPass::insertInterCorePipeS(ModuleOp module)
 // Analyze the producer/consumer relationship between the tensor type iter_args in the main_loop and ssbuffer.if
 LogicalResult UpdateForOpsPass::analyzeTensorIterArgDependencies(ModuleOp module, ControlFlowConditionInfo *info)
 {
+  bool failed = false;
   module.walk([&](Operation *op) -> WalkResult {
     if (!op->hasAttr(kSsbufferMainLoop)) {
       return WalkResult::advance();
@@ -457,6 +458,7 @@ LogicalResult UpdateForOpsPass::analyzeTensorIterArgDependencies(ModuleOp module
     auto forOp = dyn_cast<scf::ForOp>(op);
     if (!forOp) {
       LDBG("[Error]: op with ssbuffer.main_loop is not a scf::ForOp\n");
+      failed = true;
       return WalkResult::interrupt();
     }
 
@@ -468,7 +470,7 @@ LogicalResult UpdateForOpsPass::analyzeTensorIterArgDependencies(ModuleOp module
       }
 
       LDBG("Found tensor type iter_arg: " << iterArg << "\n");
-      llvm::SmallVector<scf::IfOp> producerIfOps;
+      scf::IfOp producerIfOp = nullptr;
       llvm::SmallVector<scf::IfOp> consumerIfOps;
 
       for (auto &use : iterArg.getUses()) {
@@ -502,47 +504,61 @@ LogicalResult UpdateForOpsPass::analyzeTensorIterArgDependencies(ModuleOp module
           }
         }
 
-        // Check current status of ifOp
-        bool inProducer = llvm::is_contained(producerIfOps, ifOp);
-        bool inConsumer = llvm::is_contained(consumerIfOps, ifOp);
-
-        if (!inProducer && !inConsumer) {
-          // First time seeing this ifOp
-          if (isProducer) {
-            producerIfOps.push_back(ifOp);
-            LDBG("  Found producer ifOp (first time): " << ifOp << "\n");
-          } else {
-            consumerIfOps.push_back(ifOp);
-            LDBG("  Found consumer ifOp (first time): " << ifOp << "\n");
+        // Check and update status of ifOp
+        if (isProducer) {
+          if (producerIfOp && producerIfOp != ifOp) {
+            // Found a different producer ifOp! This is an error.
+            LDBG("[Error]: tensor iter_arg " << iterArg << " has multiple different producers!\n");
+            LDBG("Existing producer: " << producerIfOp << "\n");
+            LDBG("New producer: " << ifOp << "\n");
+            failed = true;
+            return WalkResult::interrupt();
           }
-        } else if (inConsumer && isProducer) {
-          // Was consumer, now need to upgrade to producer (this is the only update case)
-          consumerIfOps.erase(llvm::find(consumerIfOps, ifOp));
-          producerIfOps.push_back(ifOp);
-          LDBG("  ifOp was consumer, now updated to producer: " << ifOp << "\n");
+          if (!producerIfOp) {
+            // First producer, or upgrade from consumer
+            auto it = llvm::find(consumerIfOps, ifOp);
+            if (it != consumerIfOps.end()) {
+              consumerIfOps.erase(it);
+              LDBG("This ifOp was consumer, now updated to producer: " << ifOp << "\n");
+            } else {
+              LDBG("Found producer ifOp (first time): " << ifOp << "\n");
+            }
+            producerIfOp = ifOp;
+          }
+          // Else: already is this producer, do nothing
+        } else {
+          // isConsumer
+          if (producerIfOp == ifOp) {
+            // Already a producer, even if current use is consumer, do nothing
+            continue;
+          }
+          if (!llvm::is_contained(consumerIfOps, ifOp)) {
+            consumerIfOps.push_back(ifOp);
+            LDBG("Found consumer ifOp (first time): " << ifOp << "\n");
+          }
+          // Else: already a consumer, do nothing
         }
-        // Note: if already in producer, do nothing even if current use is consumer
       }
       // Check: must have both producers AND consumers
-      if (producerIfOps.empty() || consumerIfOps.empty()) {
-        LDBG("[Warning]: tensor iter_arg " << iterArg << " has only "
-                                           << (producerIfOps.empty() ? "consumers" : "producers") << ", skipped\n");
+      if (!producerIfOp || consumerIfOps.empty()) {
+        LDBG("tensor iter_arg " << iterArg << " has only "
+                                           << (!producerIfOp ? "consumers" : "producers") << ", skipped\n");
         continue;
       }
       TensorIterArgIfOpRelation relation;
       relation.iterArg = iterArg;
-      relation.producers = producerIfOps;
+      relation.producer = producerIfOp;
       relation.consumers = consumerIfOps;
 
       info->tensorIterArgDepsMap[forOp].push_back(relation);
-      LDBG("Recorded tensor iter_arg dependency: " << iterArg << " has " << relation.producers.size() << " producers, "
+      LDBG("Recorded tensor iter_arg dependency: " << iterArg << " has 1 producer, "
                                                    << relation.consumers.size() << " consumers\n");
     }
 
     return WalkResult::advance();
   });
 
-  return success();
+  return failed ? failure() : success();
 }
 
 void UpdateForOpsPass::runOnOperation() {

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.cpp
@@ -422,6 +422,25 @@ std::pair<int, int> UpdateLoopIterTimesPass::calculateFactor(scf::ForOp forOp)
     }
   }
 
+  // Step3: Calculate factor based on iteration dependencies (tensor iter_args dependencies)
+  bool hasIterDeps = info->tensorIterArgDepsMap.count(forOp) &&
+                     !info->tensorIterArgDepsMap[forOp].empty();
+
+  if (hasIterDeps) {
+    LDBG("find cross-iteration dependency, size: " << info->tensorIterArgDepsMap[forOp].size());
+    auto [iterRequiredBuffers, iterX] = calculateIterDepsFactor(forOp, ifOps, ifOpIndex);
+    if (iterRequiredBuffers == -1 || iterX == -1) {
+      LDBG("calculateIterDepsFactor failed!");
+      return {-1, -1};
+    }
+    // Compare iterRequiredBuffers/iterX vs maxRequiredBuffers/maxX
+    // Take the larger fraction
+    if (iterRequiredBuffers * maxX > maxRequiredBuffers * iterX) {
+      maxRequiredBuffers = iterRequiredBuffers;
+      maxX = iterX;
+    }
+  }
+
   return {maxRequiredBuffers, maxX};
 }
 
@@ -651,6 +670,82 @@ std::pair<int, int> UpdateLoopIterTimesPass::calculateCrossDepsFactor(
     if (requiredBuffers * maxX > maxRequiredBuffers * x) {
       maxRequiredBuffers = requiredBuffers;
       maxX = x;
+    }
+  }
+
+  return {maxRequiredBuffers, maxX};
+}
+
+// calculateIterDepsFactor computes the buffer factor based on iteration dependencies
+// For iter deps: consumer and producer are IfOps within the same forOp
+// Core idea: iteration dependencies are special - consume first, then produce
+// So if consumer ifOp (m) and producer ifOp (n) have dependency,
+// we need (n - m) buffers to support the loop extension
+// This function iterates all dependencies from tensorIterArgDepsMap and finds the maximum required buffer count
+std::pair<int, int> UpdateLoopIterTimesPass::calculateIterDepsFactor(
+    scf::ForOp forOp,
+    SmallVector<scf::IfOp> &ifOps,
+    DenseMap<Operation *, int> &ifOpIndex)
+{
+  int maxRequiredBuffers = 1;
+  int maxX = 1;
+
+  // Check if this forOp has iteration dependencies
+  if (!info->tensorIterArgDepsMap.count(forOp)) {
+    return {maxRequiredBuffers, maxX};
+  }
+
+  auto &iterArgDepsVec = info->tensorIterArgDepsMap[forOp];
+
+  // Iterate all tensor iter_args dependencies in this forOp
+  // tensorIterArgDepsMap now stores a SmallVector of TensorIterArgIfOpRelation
+  for (TensorIterArgIfOpRelation &relation : iterArgDepsVec) {
+    scf::IfOp producerIfOp = relation.producer;
+    llvm::SmallVector<scf::IfOp> &consumerIfOps = relation.consumers;
+
+    // Skip if no producer or consumers
+    if (!producerIfOp || consumerIfOps.empty()) {
+      continue;
+    }
+
+    // x is the number of producer buffers (1 for iteration dependencies)
+    int x = 1;
+
+    // Get producer IfOp index (n)
+    auto producerIt = ifOpIndex.find(producerIfOp.getOperation());
+    if (producerIt == ifOpIndex.end()) {
+      LDBG("Producer IfOp not found in ifOps list!");
+      return {-1, -1};
+    }
+    int n = producerIt->second;
+
+    // For each consumer IfOp, find its index (m)
+    // Calculate requiredBuffers = n - m (consume first, then produce)
+    for (scf::IfOp consumerIfOp : consumerIfOps) {
+      // Find consumer IfOp index in ifOps list
+      auto consumerIt = ifOpIndex.find(consumerIfOp.getOperation());
+      if (consumerIt == ifOpIndex.end()) {
+        LDBG("Consumer IfOp not found in ifOps list!");
+        return {-1, -1};
+      }
+      int m = consumerIt->second;
+
+      if (n <= m) {
+        LDBG("Producer IfOp index (n) is not greater than consumer IfOp index (m)!");
+        LDBG("arg value: " << relation.iterArg);
+        LDBG("Producer IfOp index n: " << n);
+        LDBG("consumer IfOp index m: " << m);
+        return {-1, -1};
+      }
+      int requiredBuffers = n - m + 1;
+      LDBG("consumerIfOp : " << consumerIfOp);
+      LDBG("consumer m: " << m << ", n: " << n);
+      LDBG("requiredBuffers: " << requiredBuffers);
+
+      if (requiredBuffers * maxX > maxRequiredBuffers * x) {
+        maxRequiredBuffers = requiredBuffers;
+        maxX = x;
+      }
     }
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache.cpp
@@ -53,7 +53,6 @@ void AllocMultiCachePass::runOnOperation()
     pm.addPass(createAddMultiBufferOuterScopePass());
 
     if (failed(runPipeline(pm, module))) {
-        module->emitError() << "[" << DEBUG_TYPE << "] Pass failed!";
         signalPassFailure();
     }
     

--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
@@ -205,9 +205,16 @@ scf::ForOp findMainloopInScope(scope::ScopeOp scope)
 // outermost id so inner ops of a multi-region op (e.g. subview at block 3
 // inside ifOp at block 4) are not treated as cross-block consumers of a
 // same-block producer.
+//
+// i1Found is set to true when the operand is a tensor with element type i1,
+// signaling the caller to fall back (set ERRCODE_IGNORED + signalPassFailure)
+// rather than process the dep through the multi-buffer pipeline. The operand
+// is intentionally NOT added to depValueMap in that case.
+// i1 return is done temporarily.
 static void collectDepValue(Value operand, Block *body, Operation *currentOp,
                             DenseMap<Value, int> &outputToBlockId,
-                            DenseMap<Value, SmallVector<Value>> &depValueMap, Value groupKey)
+                            DenseMap<Value, SmallVector<Value>> &depValueMap, Value groupKey,
+                            bool &i1Found)
 {
     if (auto barg = dyn_cast<BlockArgument>(operand)) {
         if (barg.getOwner() == body && !llvm::is_contained(depValueMap[groupKey], barg))
@@ -217,10 +224,24 @@ static void collectDepValue(Value operand, Block *body, Operation *currentOp,
 
     if (!outputToBlockId.count(operand))
         return;
+
     auto currentOutermost = getOutermostSsbufferId(currentOp);
     auto operandOutermost = getOutermostSsbufferId(operand.getDefiningOp());
     if (currentOutermost.has_value() && currentOutermost == operandOutermost)
         return;
+
+    // i1 tensor deps: trigger fallback only for cross-block deps that are
+    // actually about to be multi-buffered. Same-block i1 tensors (e.g. a
+    // condition operand of an arith.select inside the same block) are
+    // filtered out by the same-block check above and never enter the
+    // multi-buffer pipeline, so they do not need the fallback.
+    if (auto shapedType = dyn_cast<ShapedType>(operand.getType())) {
+        if (shapedType.getElementType().isInteger(1)) {
+            i1Found = true;
+            return;
+        }
+    }
+
     if (!llvm::is_contained(depValueMap[groupKey], operand))
         depValueMap[groupKey].push_back(operand);
 }
@@ -334,9 +355,12 @@ static void forEachYieldedCrossBlockDep(Operation *op,
 }
 
 // Returns 0=success (including normal skip when blocks empty), -1=invalid negative block ID
+// Returns 0=success (including normal skip when blocks empty), -1=invalid negative block ID.
+// i1Found is set to true when any tensor dep collected here has element type i1;
+// the caller is expected to abort and trigger fallback in that case.
 static int collectInnerBlockInfo(scf::ForOp forOp, DenseMap<Value, InnerBlockInfo> &blocks,
                                  DenseMap<Value, SmallVector<Value>> &depValueMap,
-                                 SmallVector<Operation *> &allOps)
+                                 SmallVector<Operation *> &allOps, bool &i1Found)
 {
     depValueMap.clear();
     Block *body = forOp.getBody();
@@ -370,7 +394,7 @@ static int collectInnerBlockInfo(scf::ForOp forOp, DenseMap<Value, InnerBlockInf
 
         for (Operation *op : bi.ops)
             for (Value operand : op->getOperands())
-                collectDepValue(operand, body, op, outputToBlockId, depValueMap, groupKey);
+                collectDepValue(operand, body, op, outputToBlockId, depValueMap, groupKey, i1Found);
     }
 
     // Additional pass: collect deps from yield ops of multi-region consumers
@@ -1638,7 +1662,7 @@ static bool hasMemrefDepValue(DenseMap<Value, SmallVector<Value>> &depValueMap)
 }
 
 static int addInnerMultiBuffer(mlir::scf::ForOp mainLoopForOp, OpBuilder &builder, scope::ScopeOp vectorScope,
-                               int &groupId)
+                               int &groupId, bool &i1Found)
 {
     OpBuilder globalBuilder(mainLoopForOp.getContext());
 
@@ -1663,7 +1687,7 @@ static int addInnerMultiBuffer(mlir::scf::ForOp mainLoopForOp, OpBuilder &builde
     DenseMap<Value, InnerBlockInfo> blocks;
     DenseMap<Value, SmallVector<Value>> depValueMap;
     SmallVector<Operation *> allOps;
-    if (collectInnerBlockInfo(mainLoopForOp, blocks, depValueMap, allOps) != 0)
+    if (collectInnerBlockInfo(mainLoopForOp, blocks, depValueMap, allOps, i1Found) != 0)
         return -1;
 
     if (blocks.empty())
@@ -1690,8 +1714,15 @@ static int addInnerMultiBuffer(mlir::scf::ForOp mainLoopForOp, OpBuilder &builde
     blocks.clear();
     depValueMap.clear();
     allOps.clear();
-    if (collectInnerBlockInfo(mainLoopForOp, blocks, depValueMap, allOps) != 0)
+    if (collectInnerBlockInfo(mainLoopForOp, blocks, depValueMap, allOps, i1Found) != 0)
         return -1;
+
+    // Phase 2 may surface i1 tensor deps that the clone introduced (e.g. a
+    // cloned scalar chain reaching a producer-side i1 tensor). Abort here too.
+    if (i1Found) {
+        LDBG("i1 tensor dep found in Phase 2, falling back");
+        return -1;
+    }
 
     if (blocks.empty())
         return -1;
@@ -1767,8 +1798,22 @@ void AddMultiBufferInnerScopePass::runOnOperation()
                 signalPassFailure();
                 return WalkResult::interrupt();
             }
-            if (addInnerMultiBuffer(mainLoopForOp, builder, scope, groupId) != 0) {
-                LDBG("addInnerMultiBuffer failed");
+            // i1Found is reset per main_loop so it only triggers fallback for
+            // the current scope's deps.
+            bool i1Found = false;
+            int ret = addInnerMultiBuffer(mainLoopForOp, builder, scope, groupId, i1Found);
+            if (i1Found) {
+                // i1 tensor deps are not safe to multi-buffer; mark the module
+                // with ERRCODE_IGNORED and bail out so downstream passes see the
+                // fallback attribute. Mirrors the AnalyzeName pass pattern:
+                // setFallbackAttr(module) + signalPassFailure() + return.
+                LDBG("i1 tensor dep found, setting fallback attribute");
+                CVPipeline::setFallbackAttr(module);
+                signalPassFailure();
+                return WalkResult::interrupt();
+            }
+            if (ret != 0) {
+                LDBG("addInnerMultiBuffer failed for main_loop; signaling pass failure");
                 signalPassFailure();
                 return WalkResult::interrupt();
             }

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
@@ -40,15 +40,7 @@ using namespace triton;
 
 namespace {
 
-static constexpr llvm::StringLiteral interceptrFunc[] {
-    "_attn_bwd",
-    "lightning_indexer_grad_kernel",
-    "bwd_qkv_kernel",
-    "parallel_nsa_compression_fwd_kernel",
-    "parallel_nsa_compression_bwd_kernel_dq",
-    "kernel_sdpa_bwd_kv",
-    "fused_swiglu_fwd_kernel",
-};
+static constexpr llvm::StringLiteral interceptrFunc[] {""};
 
 static LogicalResult verifyFuncNames(ModuleOp module)
 {

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeScope.cpp
@@ -134,6 +134,65 @@ static bool checkVecScopeMainLoop(ModuleOp module) {
   return hasMainLoopFor && allForSatisfy;
 }
 
+// For every main_loop id, gather all forOps sharing that id and count the
+// hivm.hir.copy and hivm.hir.fixpipe ops within them. Only when ALL main_loop
+// ids have either count equal to zero (every id has only copy or only
+// fixpipe, none has both), the dynamic CV pipeline cannot be applied and we
+// fall back to the original workflow.
+//   - hivm::CopyOp    typically appears in VECTOR scope main_loops
+//   - hivm::FixpipeOp typically appears in CUBE scope main_loops
+// Nested regions inside the main_loop forOp are also walked, and scf.yield
+// terminators are skipped.
+static bool isMainLoopOnlyCopyOrFixpipe(ModuleOp module)
+{
+  // main_loop id -> (countCopy, countFixpipe)
+  llvm::DenseMap<int, std::pair<int, int>> idToCounts;
+
+  module.walk([&](scf::ForOp forOp) -> WalkResult {
+    auto mainLoopAttr = forOp->getAttrOfType<IntegerAttr>(CVPipeline::kMainLoop);
+    if (!mainLoopAttr) {
+      return WalkResult::advance();
+    }
+
+    int id = mainLoopAttr.getInt();
+    auto &counts = idToCounts[id];
+
+    forOp.walk([&](mlir::Operation *op) -> WalkResult {
+      // Skip the forOp itself (the walk visits it first)
+      if (op == forOp) {
+        return WalkResult::advance();
+      }
+      // Skip yield terminators (they are not real ops)
+      if (isa<scf::YieldOp>(op)) {
+        return WalkResult::advance();
+      }
+      if (isa<hivm::CopyOp>(op)) {
+        ++counts.first;
+      } else if (isa<hivm::FixpipeOp>(op)) {
+        ++counts.second;
+      }
+      return WalkResult::advance();
+    });
+
+    return WalkResult::advance();
+  });
+
+  // Only trigger fallback when EVERY main_loop id has only copy or only
+  // fixpipe (one count is zero). If at least one id has both copy and
+  // fixpipe ops, the dynamic CV pipeline still be applicable.
+  if (idToCounts.empty()) {
+    return false;
+  }
+
+  for (const auto &entry : idToCounts) {
+    if (entry.second.first != 0 && entry.second.second != 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 static LogicalResult verifyMainLoop(ModuleOp module)
 {
   // Only skip if ALL forOps lack main_loop attr
@@ -155,6 +214,12 @@ static LogicalResult verifyMainLoop(ModuleOp module)
     CVPipeline::setFallbackAttr(module);
     return failure();
   };
+
+  if (isMainLoopOnlyCopyOrFixpipe(module)) {
+    LDBG("[INFO]: All main_loop only contains hivm.hir.copy or hivm.hir.fixpipe ops.");
+    CVPipeline::setFallbackAttr(module);
+    return failure();
+  }
 
   return success();
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
@@ -31,10 +31,8 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/OpDefinition.h"
-#include "mlir/Interfaces/CastInterfaces.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/TypeSize.h"
@@ -50,7 +48,6 @@ namespace {
 struct FillInfo {
   linalg::FillOp fillOp;
   scf::IfOp parentIf;
-  bool needsSplit;
 };
 
 /**
@@ -128,74 +125,6 @@ static LogicalResult getCommonBlockId(ArrayRef<Operation *> ops, int &blockId) {
 
   blockId = *copyBlockIds.begin();
   return success();
-}
-
-/**
- * @brief Collect predecessor operations in a block for a given value
- *
- * This function traces back through SSA dependencies to find all operations
- * that affect the given startValue within a specific block.
- *
- * Special handling for scf.for loop-carried dependencies:
- * When an operand is a BlockArgument from scf.for iter_arg, we also trace
- * through the yieldOp to find the operation that provides the yielded value.
- * This ensures we capture operations that update loop-carried variables
- * (e.g., %79 that updates %arg19).
- *
- * @param startValue The value to trace back from
- * @param block The block to search within
- * @return SmallVector<Operation*> List of predecessor operations
- */
-static SmallVector<Operation *> collectBlockPredecessors(Value startValue, Block *block) {
-  SmallVector<Operation *> result;
-  SmallVector<Operation *> toProcess;
-
-  auto addToProcess = [&](Operation *op) {
-    if (auto *ancestorInBlock = CVPipeline::getAncestorInBlock(op, block)) {
-      if (!llvm::is_contained(result, ancestorInBlock)) {
-        toProcess.push_back(ancestorInBlock);
-      }
-    }
-  };
-
-  if (auto *condDefOp = startValue.getDefiningOp()) {
-    addToProcess(condDefOp);
-  }
-
-  while (!toProcess.empty()) {
-    auto *op = toProcess.pop_back_val();
-    if (llvm::is_contained(result, op)) {
-      continue;
-    }
-    result.push_back(op);
-
-    for (auto operand : op->getOperands()) {
-      if (auto *defOp = operand.getDefiningOp()) {
-        // SSA operand: trace to its defining operation
-        addToProcess(defOp);
-      } else if (auto blockArg = dyn_cast<BlockArgument>(operand)) {
-        // Block argument: check if it's from scf.for iter_arg
-        Operation *parentOp = blockArg.getOwner()->getParentOp();
-        if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
-          unsigned argIdx = blockArg.getArgNumber();
-          // argIdx == 0 is the loop variable, not iter_arg; skip invalid indices
-          if (argIdx == 0 || argIdx > forOp.getInitArgs().size()) {
-            continue;
-          }
-          Operation *yieldOp = forOp.getBody()->getTerminator();
-          if (!isa<scf::YieldOp>(yieldOp) || argIdx > yieldOp->getNumOperands()) {
-            continue;
-          }
-          // Get the value yielded for this iter_arg and trace its defining op
-          Value yieldedValue = yieldOp->getOperand(argIdx - 1);
-          if (auto *yieldedDef = yieldedValue.getDefiningOp()) {
-            addToProcess(yieldedDef);
-          }
-        }
-      }
-    }
-  }
-  return result;
 }
 
 /**
@@ -372,35 +301,22 @@ static LogicalResult tryUnifyForAlloc(memref::AllocOp allocOp,
     fillInfo = splitSCFIfIfNeeded(fillInfo);
   }
 
-  // Step5: Collect predecessor_ops for scf.if condition
-  SmallVector<Operation *> conditionOps =
-      collectBlockPredecessors(fillInfo.parentIf.getCondition(), fillInfo.parentIf->getBlock());
-
-  // Step6: Cycle detection and block_id assignment with fallback
+  // Step5: Cycle detection and block_id assignment
   SmallVector<Operation *> coreOps = {
       allocOp.getOperation(),
       fillInfo.fillOp.getOperation(),
       fillInfo.parentIf.getOperation(),
   };
   coreOps.append(directUsers);
-  SmallVector<Operation *> allOps = coreOps;
-  // allOps include coreOps and scf.if_condition's predecessor_ops
-  allOps.append(conditionOps);
 
-  if (CVPipeline::willCreateCycle(allOps, memGraph, targetBlockId, bm)) {
-    LOG_DEBUG("[Cycle detection] First time: Find cycle with conditionOps, retry without conditionOps");
-    if (CVPipeline::willCreateCycle(coreOps, memGraph, targetBlockId, bm)) {
-      LOG_DEBUG("[Cycle detection] Second time: Find Cycle, have unsupport IR! Should Check!!");
-      return success();
-    }
-    for (auto *op : coreOps) {
-      bm.updateBlockId(op, targetBlockId);
-    }
-  } else {
-    for (auto *op : allOps) {
-      bm.updateBlockId(op, targetBlockId);
-    }
+  if (CVPipeline::willCreateCycle(coreOps, memGraph, targetBlockId, bm)) {
+    LOG_DEBUG("[Cycle detection] Find cycle, have unsupport IR! Should Check!!");
+    return success();
   }
+  for (auto *op : coreOps) {
+    bm.updateBlockId(op, targetBlockId);
+  }
+  LOG_DEBUG("[tryUnifyForAlloc] Successfully unify block_id to " << targetBlockId << " for allocOp: " << *allocOp);
   return success();
 }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -40,8 +40,8 @@
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Support/LLVM.h"
 
-#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h"
 
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
 
@@ -50,6 +50,7 @@ static constexpr const char *DEBUG_TYPE = "op-classifier";
 #define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
 #define LOG_DEBUG(...) LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__)
 using namespace mlir::triton;
+using namespace mlir::CVPipeline;
 
 namespace {
 
@@ -1034,7 +1035,7 @@ bool OpClassifierPass::handleYieldFromElseRegion(std::vector<OpCoreType> &coreTy
     }
 
     // Get the core_type attribute from then region yield
-    auto thenCoreTypeAttr = thenYieldForElse->getAttr("ssbuffer.core_type");
+    auto thenCoreTypeAttr = thenYieldForElse->getAttr(kCoreType);
     if (!thenCoreTypeAttr) {
         return false;
     }
@@ -1127,11 +1128,42 @@ void OpClassifierPass::processYieldOperation(Operation *op, Operation *thenYield
             // iter_arg that is passed through without modification), default to
             // VECTOR since no compute op is associated with it.
             if (Operation *def = operand.getDefiningOp()) {
-                OpCoreType ct = getCoreType(def);
-                if (ct == OP_CUBE_ONLY) {
-                    coreTypes.push_back(OP_CUBE_ONLY);
+                // If def has multiple results, each result may have a different core_type.
+                // We need to find the specific result index and use the corresponding
+                // core_type from the stored multi-value attribute (e.g., "CUBE,VECTOR")
+                if (def->getNumResults() > 1) {
+                    if (!isa<scf::SCFDialect>(def->getDialect())) {
+                        LLVM_DEBUG(DBGS() << "[handleSCFYield] ERROR: def has multiple results but is not scf dialect: "
+                                          << def->getName().getStringRef() << "\n");
+                        return;
+                    }
+                    // Find which result index this operand corresponds to in def
+                    unsigned resultIdx = 0;
+                    for (unsigned idx = 0; idx < def->getNumResults(); ++idx) {
+                        if (def->getResult(idx) == operand) {
+                            resultIdx = idx;
+                            break;
+                        }
+                    }
+
+                    // Get core_type from def's attribute (stored as comma-separated multi-value)
+                    auto ctAttr = def->getAttr(kCoreType);
+                    if (auto ctStrAttr = dyn_cast<StringAttr>(ctAttr)) {
+                        std::string ctStr = ctStrAttr.getValue().str();
+                        coreTypes.push_back(parseCoreTypeFromString(ctStr, resultIdx));
+                    } else {
+                        // Fallback: use getCoreType(def)
+                        OpCoreType ct = getCoreType(def);
+                        coreTypes.push_back(ct == OP_CUBE_ONLY ? OP_CUBE_ONLY : OP_VECTOR_ONLY);
+                    }
                 } else {
-                    coreTypes.push_back(OP_VECTOR_ONLY);
+                    // Non-scf operation: use getCoreType directly
+                    OpCoreType ct = getCoreType(def);
+                    if (ct == OP_CUBE_ONLY) {
+                        coreTypes.push_back(OP_CUBE_ONLY);
+                    } else {
+                        coreTypes.push_back(OP_VECTOR_ONLY);
+                    }
                 }
             } else {
                 // BlockArgument (e.g., iter_arg passed through scf.for) -> VECTOR
@@ -1143,16 +1175,18 @@ void OpClassifierPass::processYieldOperation(Operation *op, Operation *thenYield
     // Write ssbuffer.core_type attribute onto the yield op and its parent scf op
     if (!coreTypes.empty()) {
         std::string coreTypeStr = joinCoreTypes(coreTypes);
-        op->setAttr("ssbuffer.core_type", StringAttr::get(op->getContext(), coreTypeStr));
+        op->setAttr(kCoreType, StringAttr::get(op->getContext(), coreTypeStr));
 
         OpCoreType opCt = (coreTypeStr.find("CUBE") != std::string::npos) ? OP_CUBE_ONLY : OP_VECTOR_ONLY;
         opCoreTypes[op] = opCt;
 
         if (parentOp && llvm::isa<scf::SCFDialect>(parentOp->getDialect())) {
-            parentOp->setAttr("ssbuffer.core_type", StringAttr::get(parentOp->getContext(), coreTypeStr));
+            parentOp->setAttr(kCoreType, StringAttr::get(parentOp->getContext(), coreTypeStr));
             opCoreTypes[parentOp] = opCt;
         }
     }
+
+    return;
 }
 
 // ============================================================================
@@ -1169,44 +1203,19 @@ void OpClassifierPass::processYieldOperation(Operation *op, Operation *thenYield
 // values (derived from the defining ops of each yield operand).
 int OpClassifierPass::handleSCFYield()
 {
-    // Collect all scf.if operations
-    llvm::SmallVector<scf::IfOp> ifOps;
-    for (Operation *op : allOps) {
-        if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
-            ifOps.push_back(ifOp);
-        }
-    }
+    // Walk all scf.yield operations directly
+    getOperation().walk([&](scf::YieldOp yield) {
+        Operation *parentOp = yield->getParentOp();
+        Operation *thenYieldForElse = nullptr;
 
-    // Process scf.if operations: first then region, then else region
-    for (scf::IfOp ifOp : ifOps) {
-        Operation *thenYield = nullptr;
-        if (!ifOp.getThenRegion().empty()) {
-            thenYield = ifOp.getThenRegion().back().getTerminator();
-        }
-
-        if (isa<scf::YieldOp>(thenYield)) {
-            processYieldOperation(thenYield, nullptr);
-        }
-
-        if (!ifOp.getElseRegion().empty()) {
-            Operation *elseYield = ifOp.getElseRegion().back().getTerminator();
-            if (isa<scf::YieldOp>(elseYield)) {
-                processYieldOperation(elseYield, thenYield);
+        if (auto ifOp = dyn_cast<scf::IfOp>(parentOp)) {
+            if (yield->getParentRegion() != &ifOp.getThenRegion() && !ifOp.getThenRegion().empty()) {
+                thenYieldForElse = ifOp.getThenRegion().back().getTerminator();
             }
         }
-    }
 
-    // Process remaining scf.yield operations (not inside scf.if, e.g. scf.for)
-    for (Operation *op : allOps) {
-        if (!isa<scf::YieldOp>(op))
-            continue;
-
-        Operation *parentOp = op->getParentOp();
-        if (dyn_cast_or_null<scf::IfOp>(parentOp))
-            continue;
-
-        processYieldOperation(op, nullptr);
-    }
+        processYieldOperation(yield, thenYieldForElse);
+    });
 
     return 0;
 }
@@ -1427,7 +1436,7 @@ int OpClassifierPass::stampToIR()
         if (isa<ModuleOp, func::FuncOp>(op))
             continue;
 
-        op->setAttr("ssbuffer.core_type", StringAttr::get(op->getContext(), coreTypeToString(coreType)));
+        op->setAttr(kCoreType, StringAttr::get(op->getContext(), coreTypeToString(coreType)));
     }
 
     return 0;

--- a/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
@@ -42,7 +42,7 @@ static constexpr const char *DEBUG_TYPE = "RemoveAttributes";
 
 // if extra attr is needed, add to ut @
 // third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/test-remove-attrs.mlir
-static constexpr llvm::StringLiteral kAttrsToRemove[] {kBlockId, kCoreType, kTransferId, kMainLoop, kCubeFirst, kVectorFirst, kAddFromMatmul, kIntraBuffer, kAnalyzeFlagId, kLoopCarriedL0C, kMatmulADep, kMatmulBDep, kMatmulExtract, kCrossDeps, kClone};
+static constexpr llvm::StringLiteral kAttrsToRemove[] {kBlockId, kCoreType, kTransferId, kMainLoop, kCubeFirst, kVectorFirst, kAddFromMatmul, kIntraBuffer, kAnalyzeFlagId, kLoopCarriedL0C, kMatmulADep, kMatmulBDep, kMatmulExtract, kCrossDeps, kMemCrossDeps, kClone};
 
 void RemoveSsbufAttrPass::runOnOperation()
 {

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -237,7 +237,7 @@ void DataDependencyAnalysisPass::createBlockInfoMap(DataDependencyInfo &info)
 }
 
 void DataDependencyAnalysisPass::collectDepInfo(mlir::Value depvalue, DependencyType dependencyType,
-    llvm::SmallVector<DependencyInfo> &dependencies, int iniProdId, int iniConsId, DataDependencyInfo &info)
+    llvm::SmallVector<DependencyInfo> &dependencies, int iniProdId, int iniConsId, DataDependencyInfo &info, bool isAllTranspoesd)
 {
     DependencyInfo depInfo;
     depInfo.type = dependencyType;
@@ -255,6 +255,9 @@ void DataDependencyAnalysisPass::collectDepInfo(mlir::Value depvalue, Dependency
     depInfo.consumerBlockId = commonLevelIds.second;
     if (isValidScalarDependency(depvalue)) {
         depInfo.isScaler = true;
+    }
+    if (isAllTranspoesd) {
+        depInfo.isAllTranspoesd = true;
     }
     dependencies.push_back(depInfo);
 }
@@ -502,6 +505,28 @@ void DataDependencyAnalysisPass::analyzeExternalOutputs(DataDependencyInfo &info
 
             // Check who is using this output
             llvm::DenseSet<int> handledBlockIds;
+
+            // if c->v value will be transposed and then used by vector op, the value can be transposed within fixpipe
+            bool isAllTranspoesd = true;
+            for (mlir::Operation *user : output.getUsers()) {
+                if (!isa<linalg::TransposeOp>(user)) {
+                    isAllTranspoesd = false;
+                    continue;
+                }
+                for (mlir::Operation *transposeOpUser : user->getUsers()) {
+                    if (getSsbufferCoreType(transposeOpUser) != ssbufferCoreTypeVectorAttr) {
+                        isAllTranspoesd = false;
+                        continue;
+                    }
+                }
+            }
+            if (isAllTranspoesd) {
+                for (mlir::Operation *user : output.getUsers()) {
+                    auto transposedValue = user->getResults()[0];
+                    transposedValue.replaceAllUsesWith(opResult);
+                }
+            }
+
             for (mlir::Operation *user : output.getUsers()) {
                 int outputIndex = 0;
                 if (isControlFlowOp(user)) {
@@ -527,8 +552,8 @@ void DataDependencyAnalysisPass::analyzeExternalOutputs(DataDependencyInfo &info
                     int consumerId = *consumerIdOpt;
                     auto inserted = handledBlockIds.insert(consumerId).second;
                     if (inserted) {
-                      collectDepInfo(output, DependencyType::CubeToVector, c2vDependencies, blockInfo.blockId, consumerId,
-                          info);
+                        collectDepInfo(output, DependencyType::CubeToVector, c2vDependencies, blockInfo.blockId, consumerId,
+                            info, isAllTranspoesd);
                     }
                 }
                 // If user belongs to Cube block, this C->C dependency was handled

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -567,7 +567,8 @@ void DataDependencyAnalysisPass::analyzeExternalOutputs(DataDependencyInfo &info
 void DataDependencyAnalysisPass::collectMemDepInfo(
     llvm::StringRef predCoreType,
     int producerBlockId, int consumerBlockId, int predBlockId, int currBlockId,
-    llvm::SmallVector<DependencyInfo> &memoryDependencies)
+    llvm::SmallVector<DependencyInfo> &memoryDependencies,
+    mlir::Operation *predOp, mlir::Operation *nextOp)
 {
     DependencyInfo depInfo;
 
@@ -580,6 +581,9 @@ void DataDependencyAnalysisPass::collectMemDepInfo(
     depInfo.consumerBlockId = consumerBlockId;
     depInfo.iniProducerBlockId = predBlockId;
     depInfo.iniConsumerBlockId = currBlockId;
+
+    depInfo.predOp = predOp;
+    depInfo.nextOp = nextOp;
 
     memoryDependencies.push_back(depInfo);
 }
@@ -630,7 +634,7 @@ void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info)
                         LOG_DEBUG("Could not find common level block IDs for producer and consumer blocks");
                         signalPassFailure();
                     }
-                    collectMemDepInfo(realPredCoreType, producerBlockId, consumerBlockId, realPredBlockId, currBlockId, memoryDependencies);
+                    collectMemDepInfo(realPredCoreType, producerBlockId, consumerBlockId, realPredBlockId, currBlockId, memoryDependencies, realPredOp, op);
 
                     LOG_DEBUG("\n=op with region mem dep analysis= "
                         << "\nrealpredcoretype" << realPredCoreType
@@ -655,7 +659,8 @@ void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info)
                 continue;
             }
 
-            collectMemDepInfo(predCoreType, producerBlockId, consumerBlockId, predBlockId, currBlockId, memoryDependencies);
+            collectMemDepInfo(predCoreType, producerBlockId, consumerBlockId, predBlockId, currBlockId, memoryDependencies,
+                              predOp, op);
 
             LOG_DEBUG("\n=mem dep analysis= "
                 << "\npredcoretype" << predCoreType

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -821,7 +821,7 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(OpBuilder &b
 
 Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(OpBuilder &builder, Value srcValue,
     Operation *cubeEndOp, Operation *vectorStartOp, Location loc, int transferIndex, int iniConsumerId,
-    Operation **consumedDataOp)
+    bool isAllTranspoesd, Operation **consumedDataOp)
 {
     LOG_DEBUG("Inserting [Cube->Vector] transfer for value: " << srcValue << "\n");
     auto srcTensorType = cast<RankedTensorType>(srcValue.getType());
@@ -835,7 +835,12 @@ Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(OpBuilder &b
     auto [cubeAllocOp, vecAllocOp] = createTransferAllocs(builder, loc, { M, N }, elemType, hivm::AddressSpace::UB,
         cubeEndOp, vectorStartOp, cubeBlockId, vecBlockId, "CUBE", "VECTOR", transferIndex);
 
-    FixpipeDMAModeAttr dmaModeAttr = FixpipeDMAModeAttr::get(builder.getContext(), FixpipeDMAMode::NZ2ND);
+    FixpipeDMAModeAttr dmaModeAttr;
+    if (isAllTranspoesd) {
+        dmaModeAttr = FixpipeDMAModeAttr::get(builder.getContext(), FixpipeDMAMode::NZ2DN);
+    } else {
+        dmaModeAttr = FixpipeDMAModeAttr::get(builder.getContext(), FixpipeDMAMode::NZ2ND);
+    }
     auto fixpipeOp = builder.create<hivm::FixpipeOp>(loc, mlir::TypeRange{}, // No return value
         srcValue,                                                            // src
         cubeAllocOp->getResult(0),                                           // dst
@@ -1165,7 +1170,7 @@ LogicalResult InterCoreTransferAndSyncPass::handleCubeToVector(OpBuilder &builde
     LOG_DEBUG("[newConsEnd]" << *consEnd << "\n");
     Operation *consumedDataOp = nullptr;
     Operation *transferOp =
-        insertCubeToVectorTransfer(builder, srcValue, prodEnd, consStart, loc, transferIndex, dep.iniConsumerBlockId,
+        insertCubeToVectorTransfer(builder, srcValue, prodEnd, consStart, loc, transferIndex, dep.iniConsumerBlockId, dep.isAllTranspoesd,
             &consumedDataOp);
 
     auto [newProdStart, newProdEnd] = getBlockStartEnd(dep.producerBlockId, module); // C Block

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -113,6 +113,14 @@ static void attachTransferTags(Operation *op, int blockId, StringRef coreType, i
     op->setAttr(CVPipeline::kTransferId, IntegerAttr::get(IntegerType::get(ctx, kIntegerBitWidth), transferId));
 }
 
+static void attachMemCrossDeps(Operation *op, int tid, int seqId, OpBuilder &builder)
+{
+    op->setAttr(CVPipeline::kMemCrossDeps, builder.getArrayAttr({
+                    builder.getI32IntegerAttr(tid),
+                    builder.getI32IntegerAttr(seqId)
+                }));
+}
+
 static void attachAnalyzeFlagIdTag(Operation *op)
 {
     MLIRContext *ctx = op->getContext();
@@ -1205,7 +1213,10 @@ LogicalResult InterCoreTransferAndSyncPass::handleMemoryDependency(OpBuilder &bu
             dep.consumerBlockId << "\n");
         return success();
     }
-
+    int predId = 1;
+    int nextId = 0;
+    attachMemCrossDeps(dep.predOp, transferIndex, predId, builder);
+    attachMemCrossDeps(dep.nextOp, transferIndex, nextId, builder);
     // Get flag ID
     int flagId = flagManager.acquireId(prodStart);
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
@@ -665,6 +665,18 @@ static bool needsLoopCarryPreserve(Operation *owner, unsigned slotIndex, StringR
     return false;
 }
 
+// Returns true when the producer op has no result belonging to scopeType .
+static bool isProducedByForeignScope(Value operand, StringRef scopeType)
+{
+    Operation *producer = operand.getDefiningOp();
+    if (!producer->hasAttr(kCoreType)) {
+        return false;
+    }
+
+    // Only treat as foreign when the producer has NO result in the current scope.
+    return !matchesScope(producer, scopeType);
+}
+
 static LogicalResult neutralizeYieldInRegion(Operation *op, const CoreTypeInfo &info, StringRef scopeType, Location loc)
 {
     if (op->getNumRegions() == 0) {
@@ -687,12 +699,18 @@ static LogicalResult neutralizeYieldInRegion(Operation *op, const CoreTypeInfo &
                 if (info.getResultType(i) == scopeType) {
                     continue;
                 }
+
+                 // First defense: skip neutralization when an in-loop consumer reads the carried value through an iter_arg.
                 if (needsLoopCarryPreserve(op, i, scopeType)) {
                     continue;
                 }
 
                 Value oldOperand = yieldOp.getOperand(i);
-                if (i < op->getNumResults()) {
+
+                 // Second defense: skip the result-user check when the value is produced by a foreign-scope op to prevent it from being trapped.
+                bool isLoopOp = isa<scf::ForOp, scf::WhileOp>(op);
+                if ((!isLoopOp || !isProducedByForeignScope(oldOperand, scopeType)) &&
+                    i < op->getNumResults()) {
                     if (Operation *resultUser = findLiveUser(op->getResult(i), scopeType)) {
                         logDebug("skip neutralizing yield operand #", i, " for scope ", scopeType,
                                  " because parent result #", i, " still has live user '",

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
@@ -669,7 +669,7 @@ static bool needsLoopCarryPreserve(Operation *owner, unsigned slotIndex, StringR
 static bool isProducedByForeignScope(Value operand, StringRef scopeType)
 {
     Operation *producer = operand.getDefiningOp();
-    if (!producer->hasAttr(kCoreType)) {
+    if (!producer->hasAttr(CVPipeline::kCoreType)) {
         return false;
     }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
@@ -24,6 +24,7 @@
 #include <optional>
 
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -636,31 +637,25 @@ static LogicalResult splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rew
     // This is the "c" in a*b+c, added after the matmul result
     rewriter.setInsertionPointAfterValue(splitInfo.outerOutValue);
 
-    Operation *preservedUser = nullptr;
+    constexpr size_t kMaxPreservedUsers = 2;
+    SmallPtrSet<Operation *, kMaxPreservedUsers> preservedUsers;
     if (splitInfo.mayNotExec && forOp) {
         auto lb = forOp.getLowerBound();
         auto ub = forOp.getUpperBound();
 
         Value executed = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sgt, ub, lb);
-        auto ifOp = rewriter.create<scf::IfOp>(
-            loc,
-            executed,
-            [&](OpBuilder &thenBuilder, Location thenLoc) {
-                thenBuilder.create<scf::YieldOp>(thenLoc, splitInfo.outerOutValue);
-            },
-            [&](OpBuilder &elseBuilder, Location elseLoc) {
-                Value zeroValue;
-                if (auto floatType = dyn_cast<FloatType>(elmType)) {
-                    APFloat zeroAPFloat = APFloat::getZero(floatType.getFloatSemantics());
-                    zeroValue = elseBuilder.create<arith::ConstantFloatOp>(elseLoc, zeroAPFloat, floatType).getResult();
-                } else if (auto intType = dyn_cast<IntegerType>(elmType)) {
-                    zeroValue = elseBuilder.create<arith::ConstantIntOp>(elseLoc, 0, intType).getResult();
-                }
-                auto fillOp = elseBuilder.create<linalg::FillOp>(emptyOp.getLoc(), zeroValue, splitInfo.outerOutValue);
-                elseBuilder.create<scf::YieldOp>(elseLoc, fillOp.getResult(0));
-            });
-        newOutValue = ifOp.getResult(0);
-        preservedUser = ifOp;
+        Value zeroValue;
+        if (auto floatType = dyn_cast<FloatType>(elmType)) {
+            APFloat zeroAPFloat = APFloat::getZero(floatType.getFloatSemantics());
+            zeroValue = rewriter.create<arith::ConstantFloatOp>(loc, zeroAPFloat, floatType).getResult();
+        } else if (auto intType = dyn_cast<IntegerType>(elmType)) {
+            zeroValue = rewriter.create<arith::ConstantIntOp>(loc, 0, intType).getResult();
+        }
+        auto fillOp = rewriter.create<linalg::FillOp>(loc, zeroValue, splitInfo.outerOutValue);
+        auto selectOp = rewriter.create<arith::SelectOp>(loc, executed, splitInfo.outerOutValue, fillOp.getResult(0));
+        newOutValue = selectOp.getResult();
+        preservedUsers.insert(selectOp);
+        preservedUsers.insert(fillOp);
         forOp->setAttr(CVPipeline::kHIVMMatmulLimitedInCubeAttr, rewriter.getUnitAttr());
     }
 
@@ -670,13 +665,12 @@ static LogicalResult splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rew
     } else {
         addOp = rewriter.create<arith::AddIOp>(loc, newOutValue, splitInfo.outerInValue).getOperation();
     }
-    if (preservedUser == nullptr) {
-        preservedUser = addOp;
+    if (preservedUsers.empty()) {
+        preservedUsers.insert(addOp);
     }
     addOp->setAttr(CVPipeline::kAddFromMatmul, rewriter.getUnitAttr());
-    splitInfo.outerOutValue.replaceUsesWithIf(addOp->getResult(0), [preservedUser](OpOperand &operand) {
-        return !preservedUser->isAncestor(operand.getOwner());
-    });
+    splitInfo.outerOutValue.replaceUsesWithIf(
+        addOp->getResult(0), [&](OpOperand &operand) { return !preservedUsers.contains(operand.getOwner()); });
 
     return success();
 }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/iter_args_has_multi_producer.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/iter_args_has_multi_producer.mlir
@@ -1,0 +1,48 @@
+// RUN: triton-opt --update-for-ops --debug %s 2>&1 | FileCheck %s
+
+// Test for tensor iter_arg with two if producers - should fail with error
+// CHECK: [Error]: tensor iter_arg <block argument> of type 'tensor<64x64xf32>' at index: 1 has multiple different producers!
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_iter_args_multi_producer(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %cst = arith.constant {ssbuffer.block_id = 1} 0.0 : f32
+    %c0 = arith.constant {ssbuffer.block_id = 1} 0 : i32
+    %c1 = arith.constant {ssbuffer.block_id = 1} 1 : i32
+    %c5 = arith.constant {ssbuffer.block_id = 1} 5 : i32
+    %true = arith.constant true
+    %false = arith.constant false
+    
+    scope.scope : () -> () {
+      // Create initial tensor
+      %tensor_init = tensor.empty() {ssbuffer.block_id = 1} : tensor<64x64xf32>
+      %filled_tensor = linalg.fill {ssbuffer.block_id = 1} ins(%cst : f32) outs(%tensor_init : tensor<64x64xf32>) -> tensor<64x64xf32>
+      
+      // Loop with tensor iter_arg
+      %result = scf.for %i = %c0 to %c5 step %c1 iter_args(%iter_arg = %filled_tensor) -> (tensor<64x64xf32>) : i32 {
+        // First if that yields the tensor
+        %val1 = scf.if %true -> (tensor<64x64xf32>) {
+          %new_tensor1 = tensor.empty() {ssbuffer.block_id = 2} : tensor<64x64xf32>
+          %filled1 = linalg.fill {ssbuffer.block_id = 2} ins(%cst : f32) outs(%new_tensor1 : tensor<64x64xf32>) -> tensor<64x64xf32>
+          scf.yield %filled1 : tensor<64x64xf32>
+        } else {
+          scf.yield %iter_arg : tensor<64x64xf32>
+        } {ssbuffer.if = 2 : i32}
+        
+        // Second if that also yields the tensor
+        %val2 = scf.if %false -> (tensor<64x64xf32>) {
+          %new_tensor2 = tensor.empty() {ssbuffer.block_id = 3} : tensor<64x64xf32>
+          %filled2 = linalg.fill {ssbuffer.block_id = 3} ins(%cst : f32) outs(%new_tensor2 : tensor<64x64xf32>) -> tensor<64x64xf32>
+          scf.yield %filled2 : tensor<64x64xf32>
+        } else {
+          scf.yield %iter_arg : tensor<64x64xf32>
+        } {ssbuffer.if = 3 : i32}
+        
+        // Yield from loop
+        scf.yield %val2 : tensor<64x64xf32>
+      } {ssbuffer.block_id = 10, ssbuffer.main_loop = 0 : i32}
+      
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    
+    return {ssbuffer.core_type = "VECTOR"}
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/iter_args_only_consumer.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/iter_args_only_consumer.mlir
@@ -1,0 +1,47 @@
+// RUN: triton-opt --update-for-ops --debug %s 2>&1 | FileCheck %s
+
+// Test for tensor iter_arg with only consumer if ops
+// CHECK: tensor iter_arg <block argument> of type 'tensor<64x64xf32>' at index: 1 has only consumers, skipped
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_iter_args_only_consumer(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %cst = arith.constant {ssbuffer.block_id = 1} 0.0 : f32
+    %c0 = arith.constant {ssbuffer.block_id = 1} 0 : i32
+    %c1 = arith.constant {ssbuffer.block_id = 1} 1 : i32
+    %c5 = arith.constant {ssbuffer.block_id = 1} 5 : i32
+    %true = arith.constant true
+    %false = arith.constant false
+    %empty_tensor = tensor.empty() : tensor<64x64xf32>
+
+    scope.scope : () -> () {
+      // Create initial tensor
+      %tensor_init = tensor.empty() {ssbuffer.block_id = 1} : tensor<64x64xf32>
+      %filled_tensor = linalg.fill {ssbuffer.block_id = 1} ins(%cst : f32) outs(%tensor_init : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+      // Loop with tensor iter_arg
+      %result = scf.for %i = %c0 to %c5 step %c1 iter_args(%iter_arg = %filled_tensor) -> (tensor<64x64xf32>) : i32 {
+        // Create a separate tensor for yield
+        %yield_tensor = tensor.empty() {ssbuffer.block_id = 2} : tensor<64x64xf32>
+        %filled_yield = linalg.fill {ssbuffer.block_id = 2} ins(%cst : f32) outs(%yield_tensor : tensor<64x64xf32>) -> tensor<64x64xf32>
+        
+        // Only consumer if op 1 - uses iter_arg but yields other value
+        %val1 = scf.if %true -> (tensor<64x64xf32>) {
+          // Use iter_arg in some operation (consumer) - use broadcast with empty dimensions
+          %broadcasted = linalg.broadcast {ssbuffer.block_id = 2 : i32} ins(%iter_arg : tensor<64x64xf32>) outs(%yield_tensor : tensor<64x64xf32>) dimensions = []
+          // Yield a different value
+          scf.yield %filled_yield : tensor<64x64xf32>
+        } else {
+          // Also use iter_arg in another way
+          %broadcasted2 = linalg.broadcast {ssbuffer.block_id = 2 : i32} ins(%iter_arg : tensor<64x64xf32>) outs(%yield_tensor : tensor<64x64xf32>) dimensions = []
+          scf.yield %filled_yield : tensor<64x64xf32>
+        } {ssbuffer.if = 2 : i32}
+
+        // Yield from loop - yield the same value that came from if
+        scf.yield %val1 : tensor<64x64xf32>
+      } {ssbuffer.block_id = 10, ssbuffer.main_loop = 0 : i32}
+
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+
+    return {ssbuffer.core_type = "VECTOR"}
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/iter_args_only_producer.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/iter_args_only_producer.mlir
@@ -1,0 +1,40 @@
+// RUN: triton-opt --update-for-ops %s --debug %s 2>&1 | FileCheck %s
+
+// Test for tensor iter_arg with only producer if ops
+// CHECK: tensor iter_arg <block argument> of type 'tensor<64x64xf32>' at index: 1 has only producers, skipped
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_iter_args_only_producer(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %cst = arith.constant {ssbuffer.block_id = 1} 0.0 : f32
+    %c0 = arith.constant {ssbuffer.block_id = 1} 0 : i32
+    %c1 = arith.constant {ssbuffer.block_id = 1} 1 : i32
+    %c5 = arith.constant {ssbuffer.block_id = 1} 5 : i32
+    %true = arith.constant true
+
+    scope.scope : () -> () {
+      // Create initial tensor
+      %tensor_init = tensor.empty() {ssbuffer.block_id = 1} : tensor<64x64xf32>
+      %filled_tensor = linalg.fill {ssbuffer.block_id = 1} ins(%cst : f32) outs(%tensor_init : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+      // Loop with tensor iter_arg
+      %result = scf.for %i = %c0 to %c5 step %c1 iter_args(%iter_arg = %filled_tensor) -> (tensor<64x64xf32>) : i32 {
+        // Only producer if op - yields new tensor value
+        %val1 = scf.if %true -> (tensor<64x64xf32>) {
+          %new_tensor1 = tensor.empty() {ssbuffer.block_id = 2} : tensor<64x64xf32>
+          %filled1 = linalg.fill {ssbuffer.block_id = 2} ins(%cst : f32) outs(%new_tensor1 : tensor<64x64xf32>) -> tensor<64x64xf32>
+          scf.yield %filled1 : tensor<64x64xf32>
+        } else {
+          %new_tensor2 = tensor.empty() {ssbuffer.block_id = 2} : tensor<64x64xf32>
+          %filled2 = linalg.fill {ssbuffer.block_id = 2} ins(%cst : f32) outs(%new_tensor2 : tensor<64x64xf32>) -> tensor<64x64xf32>
+          scf.yield %iter_arg : tensor<64x64xf32>
+        } {ssbuffer.if = 2 : i32}
+
+        // Yield from loop
+        scf.yield %val1 : tensor<64x64xf32>
+      } {ssbuffer.block_id = 10, ssbuffer.main_loop = 0 : i32}
+
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+
+    return {ssbuffer.core_type = "VECTOR"}
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/multi_crossdeps_not_in_mainloop_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/multi_crossdeps_not_in_mainloop_test.mlir
@@ -1,0 +1,119 @@
+// RUN: triton-opt --add-control-flow-condition %s | FileCheck %s
+
+// ============================================================================
+// TC-04: multiple crossdependent multicache
+// ============================================================================
+// CrossCore Data Dependency:
+// V1 -> C1
+// C1 -> V2
+// V2 -> C2
+// C2 -> V3
+// there a memrefcrossdep not in mainloop, will be ignored
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @_attn_fwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg3: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg4: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg5: memref<?xf32> {tt.divisibility = 16 : i32}, %arg6: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg7: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg8: memref<?xi32> {tt.divisibility = 16 : i32}, %arg9: i32, %arg10: i32, %arg11: i32, %arg12: i32, %arg13: i32, %arg14: i32, %arg15: i32) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %c8192_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 8192 : i32
+    %c128_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 128 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 0 : i32
+    scope.scope : () -> () {
+      %alloc = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_11 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_11 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_12 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_12 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_13 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [3 : i32, 1 : i32], ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_13 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<3>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 4
+      %alloc_14 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [4 : i32, 1 : i32], ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_14 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<4>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+
+      // CHECK:       %[[IFCOUNT:.*]] = arith.constant 3
+      // CHECK:       %[[REQUIRENUM:.*]] = arith.constant 1
+      // CHECK:       %[[BUFFERNUM:.*]] = arith.constant 1
+      // CHECK:       arith.subi
+      // CHECK:       arith.ceildivui
+      // CHECK:       arith.muli %{{.*}}, %[[REQUIRENUM]]
+      // CHECK:       arith.ceildivui %{{.*}}, %[[BUFFERNUM]]
+      // CHECK:       arith.addi %{{.*}}, %[[IFCOUNT]]
+      // CHECK:       arith.muli
+      // CHECK:       arith.addi
+      // CHECK:       scf.for
+      // CHECK:       iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32, %[[CNT0:.*]] = %{{.+}}, %[[CNT1:.*]] = %{{.+}}, %[[CNT2:.*]] = %{{.+}})
+      %30:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
+        %42 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<128xf32>
+        // CHECK:       arith.divui %[[CNT0]], %c128_i32 {ssbuffer.block_id = 5 : i32} : i32
+        %43 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 5 : i32} : i32
+        %c0_i32_15 = arith.constant {ssbuffer.block_id = 5 : i32} 0 : i32
+        %c2_i32 = arith.constant {ssbuffer.block_id = 5 : i32} 2 : i32
+        %44 = arith.remsi %43, %c2_i32 {ssbuffer.block_id = 5 : i32} : i32
+        %45 = arith.cmpi eq, %44, %c0_i32_15 {ssbuffer.block_id = 5 : i32} : i32
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+        %reshape_40 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<4x1x16x16xf16>
+        hivm.hir.copy ins(%reshape_40 : tensor<4x1x16x16xf16>) outs(%alloc : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}
+        %reshape_41 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<8x4x16x16xf16>
+        hivm.hir.copy ins(%reshape_41 : tensor<8x4x16x16xf16>) outs(%alloc_11 : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}
+        %offset = arith.constant {ssbuffer.block_id = 5 : i32} 0 : index
+        %reinterpret_cast_26 = memref.reinterpret_cast %arg4 to offset: [%offset], sizes: [1, 128], strides: [128, 1] {ssbuffer.block_id = 5 : i32, ssbuffer.memCrossDeps = [1 : i32, 1 : i32]} : memref<?xf16> to memref<1x128xf16, strided<[?, 1], offset: ?>>
+
+        // CHECK:       arith.divui %[[CNT1]], %c128_i32 {ssbuffer.block_id = 6 : i32} : i32
+        %46 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 6 : i32} : i32
+        %c0_i32_16 = arith.constant {ssbuffer.block_id = 6 : i32} 0 : i32
+        %c2_i32_6 = arith.constant {ssbuffer.block_id = 6 : i32} 2 : i32
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+        %memspacecast_11 = memref.memory_space_cast %alloc_13 {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 1 : i32, ssbuffer.crossDeps = [3 : i32, 0 : i32]} : memref<16x128xf32, #hivm.address_space<ub>> to memref<16x128xf32>
+        %reshape_42 = tensor.empty() {ssbuffer.block_id = 6 : i32} : tensor<4x8x16x16xf16>
+        hivm.hir.copy ins(%reshape_42 : tensor<4x8x16x16xf16>) outs(%alloc_12 : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 1 : i32}
+
+
+        // CHECK:       arith.divui %[[CNT2]], %c128_i32 {ssbuffer.block_id = 7 : i32} : i32
+        %49 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 7 : i32} : i32
+        %c2_i32_17 = arith.constant {ssbuffer.block_id = 7 : i32} 2 : i32
+        %50 = arith.remsi %49, %c2_i32_17 {ssbuffer.block_id = 7 : i32} : i32
+        %c0_i32_18 = arith.constant {ssbuffer.block_id = 7 : i32} 0 : i32
+        %51 = arith.cmpi eq, %50, %c0_i32_18 {ssbuffer.block_id = 7 : i32} : i32
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+        %memspacecast_12 = memref.memory_space_cast %alloc_14 {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 1 : i32, ssbuffer.crossDeps = [4 : i32, 0 : i32]} : memref<16x64xf32, #hivm.address_space<ub>> to memref<16x64xf32>
+        scf.yield %arg17, %arg18 : i32, i32
+      } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+
+    scope.scope : () -> () {
+      %alloc_10 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [0 : i32, 1 : i32], ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_10 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+      %alloc_11 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_11 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+      %alloc_12 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32, ssbuffer.crossDeps = [2 : i32, 1 : i32]} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_12 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 3
+      %alloc_13 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_13 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<3>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      %alloc_14 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_14 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<4>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+      %30:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
+
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+        %50 = hivm.hir.convert_layout %alloc_10 output_shape [16, 64] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 2 : i32, ssbuffer.crossDeps = [0 : i32, 0 : i32], ssbuffer.transfer_id = 0 : i32} : (memref<4x1x16x16xf16, #hivm.address_space<cbuf>>) -> memref<16x64xf16, #hivm.address_space<cbuf>>
+        %54 = tensor.empty() {ssbuffer.block_id = 2 : i32} : tensor<16x128xf32>
+        hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 3 : i32} ins(%54 : tensor<16x128xf32>) outs(%alloc_13 : memref<16x128xf32, #hivm.address_space<ub>>)
+
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 3 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+        %45 = hivm.hir.convert_layout %alloc_12 output_shape [128, 64] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 3 : i32, ssbuffer.crossDeps = [2 : i32, 0 : i32], ssbuffer.transfer_id = 2 : i32} : (memref<4x8x16x16xf16, #hivm.address_space<cbuf>>) -> memref<128x64xf16, #hivm.address_space<cbuf>>
+        // %48 = hivm.hir.convert_layout %alloc_11 output_shape [64, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 3 : i32, ssbuffer.crossDeps = [1 : i32, 0 : i32], ssbuffer.transfer_id = 1 : i32} : (memref<8x4x16x16xf16, #hivm.address_space<cbuf>>) -> memref<64x128xf16, #hivm.address_space<cbuf>>
+        %47 = tensor.empty() {ssbuffer.block_id = 3 : i32} : tensor<16x64xf32>
+        hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 3 : i32, ssbuffer.transfer_id = 4 : i32} ins(%47 : tensor<16x64xf32>) outs(%alloc_14 : memref<16x64xf32, #hivm.address_space<ub>>)
+
+        scf.yield %arg17, %arg18 : i32, i32
+      } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
+      %offset = arith.constant {ssbuffer.block_id = 3 : i32} 0 : index
+      %reinterpret_cast_61 = memref.reinterpret_cast %arg4 to offset: [%offset], sizes: [1, 128], strides: [128, 1] {ssbuffer.block_id = 3 : i32} : memref<?xf16> to memref<1x128xf16, strided<[128, 1], offset: ?>>
+      %136 = tensor.empty() {ssbuffer.block_id = 3 : i32} : tensor<1x128xf16>
+      bufferization.materialize_in_destination %136 in writable %reinterpret_cast_61 {ssbuffer.block_id = 3 : i32, ssbuffer.memCrossDeps = [1 : i32, 0 : i32]} : (tensor<1x128xf16>, memref<1x128xf16, strided<[128, 1], offset: ?>>) -> ()
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+    return {ssbuffer.core_type = "VECTOR"}
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/multi_deps_add_condition_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/multi_deps_add_condition_test.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">}
 // CHECK-LABEL: func.func @_attn_fwd(
-// CHECK-DAG: [[C3:%[^ ]+]] = arith.constant 3 : i32
+// CHECK-DAG: [[C3:%[^ ]+]] = arith.constant 2 : i32
 
 // CHECK-DAG: arith.cmpi slt
 // CHECK-DAG: arith.cmpi slt
@@ -133,7 +133,7 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
           %c0_i32_18 = arith.constant {ssbuffer.block_id = 6 : i32} 0 : i32
           %51 = arith.cmpi eq, %50, %c0_i32_18 {ssbuffer.block_id = 6 : i32} : i32
           %producer_buf = memref.alloc() {ssbuffer.block_id = 6 : i32} : memref<128xf32, #hivm.address_space<ub>>
-          %producer_cast = memref.memory_space_cast %producer_buf {ssbuffer.block_id = 6 : i32, ssbuffer.intraDeps = [0 : i32, 1 : i32]} : memref<128xf32, #hivm.address_space<ub>> to memref<128xf32>
+          %producer_cast = memref.memory_space_cast %producer_buf {ssbuffer.block_id = 6 : i32} : memref<128xf32, #hivm.address_space<ub>> to memref<128xf32>
           %producer_tensor = bufferization.to_tensor %producer_cast writable {ssbuffer.block_id = 6 : i32} : memref<128xf32>
 
           %c1_buf = memref.alloc() {ssbuffer.block_id = 6 : i32} : memref<128xf32, #hivm.address_space<ub>>

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/updateLoopIterTimes_insufficient_multi_crossdeps_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/updateLoopIterTimes_insufficient_multi_crossdeps_test.mlir
@@ -1,0 +1,120 @@
+// RUN: triton-opt --add-control-flow-condition %s | FileCheck %s
+
+// ============================================================================
+// TC-04: insufficient multiple crossdependent multicache
+// ============================================================================
+// CrossCore Data Dependency:
+// V1 -> C1 C2
+// C1 -> V2
+// V2 -> C2
+// C2 -> V3
+// V1 -> C2 data dependency is a speical dependency, V1 write into GM, and C2 read from the GM
+// if only allocate one buffer for V1 -> C2 dependency, need to double the loop iteration times
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @_attn_fwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg3: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg4: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg5: memref<?xf32> {tt.divisibility = 16 : i32}, %arg6: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg7: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg8: memref<?xi32> {tt.divisibility = 16 : i32}, %arg9: i32, %arg10: i32, %arg11: i32, %arg12: i32, %arg13: i32, %arg14: i32, %arg15: i32) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %c8192_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 8192 : i32
+    %c128_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 128 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 0 : i32
+    scope.scope : () -> () {
+      %alloc = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_11 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_11 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_12 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_12 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_13 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [3 : i32, 1 : i32], ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_13 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<3>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 4
+      %alloc_14 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [4 : i32, 1 : i32], ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_14 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<4>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+
+      // CHECK:       %[[IFCOUNT:.*]] = arith.constant 3
+      // CHECK:       %[[REQUIRENUM:.*]] = arith.constant 1
+      // CHECK:       %[[BUFFERNUM:.*]] = arith.constant 1
+      // CHECK:       arith.subi
+      // CHECK:       arith.ceildivui
+      // CHECK:       arith.muli %{{.*}}, %[[REQUIRENUM]]
+      // CHECK:       arith.ceildivui %{{.*}}, %[[BUFFERNUM]]
+      // CHECK:       arith.addi %{{.*}}, %[[IFCOUNT]]
+      // CHECK:       arith.muli
+      // CHECK:       arith.addi
+      // CHECK:       scf.for
+      // CHECK:       iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32, %[[CNT0:.*]] = %{{.+}}, %[[CNT1:.*]] = %{{.+}}, %[[CNT2:.*]] = %{{.+}})
+      %30:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
+        %42 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<128xf32>
+        // CHECK:       arith.divui %[[CNT0]], %c128_i32 {ssbuffer.block_id = 5 : i32} : i32
+        %43 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 5 : i32} : i32
+        %c0_i32_15 = arith.constant {ssbuffer.block_id = 5 : i32} 0 : i32
+        %c2_i32 = arith.constant {ssbuffer.block_id = 5 : i32} 2 : i32
+        %44 = arith.remsi %43, %c2_i32 {ssbuffer.block_id = 5 : i32} : i32
+        %45 = arith.cmpi eq, %44, %c0_i32_15 {ssbuffer.block_id = 5 : i32} : i32
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+        %reshape_40 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<4x1x16x16xf16>
+        hivm.hir.copy ins(%reshape_40 : tensor<4x1x16x16xf16>) outs(%alloc : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}
+        %reshape_41 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<8x4x16x16xf16>
+        hivm.hir.copy ins(%reshape_41 : tensor<8x4x16x16xf16>) outs(%alloc_11 : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32}
+        %offset = arith.constant {ssbuffer.block_id = 5 : i32} 0 : index
+        %reinterpret_cast_26 = memref.reinterpret_cast %arg4 to offset: [%offset], sizes: [1, 128], strides: [128, 1] {ssbuffer.block_id = 5 : i32, ssbuffer.memCrossDeps = [2 : i32, 1 : i32]} : memref<?xf16> to memref<1x128xf16, strided<[?, 1], offset: ?>>
+
+        // CHECK:       arith.divui %[[CNT1]], %c128_i32 {ssbuffer.block_id = 6 : i32} : i32
+        %46 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 6 : i32} : i32
+        %c0_i32_16 = arith.constant {ssbuffer.block_id = 6 : i32} 0 : i32
+        %c2_i32_6 = arith.constant {ssbuffer.block_id = 6 : i32} 2 : i32
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+        %memspacecast_11 = memref.memory_space_cast %alloc_13 {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 1 : i32, ssbuffer.crossDeps = [3 : i32, 0 : i32]} : memref<16x128xf32, #hivm.address_space<ub>> to memref<16x128xf32>
+        %reshape_42 = tensor.empty() {ssbuffer.block_id = 6 : i32} : tensor<4x8x16x16xf16>
+        hivm.hir.copy ins(%reshape_42 : tensor<4x8x16x16xf16>) outs(%alloc_12 : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 1 : i32}
+
+
+        // CHECK:       arith.divui %[[CNT2]], %c128_i32 {ssbuffer.block_id = 7 : i32} : i32
+        %49 = arith.divui %arg16, %c128_i32 {ssbuffer.block_id = 7 : i32} : i32
+        %c2_i32_17 = arith.constant {ssbuffer.block_id = 7 : i32} 2 : i32
+        %50 = arith.remsi %49, %c2_i32_17 {ssbuffer.block_id = 7 : i32} : i32
+        %c0_i32_18 = arith.constant {ssbuffer.block_id = 7 : i32} 0 : i32
+        %51 = arith.cmpi eq, %50, %c0_i32_18 {ssbuffer.block_id = 7 : i32} : i32
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 1 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+        %memspacecast_12 = memref.memory_space_cast %alloc_14 {ssbuffer.block_id = 7 : i32, ssbuffer.transfer_id = 1 : i32, ssbuffer.crossDeps = [4 : i32, 0 : i32]} : memref<16x64xf32, #hivm.address_space<ub>> to memref<16x64xf32>
+        scf.yield %arg17, %arg18 : i32, i32
+      } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+
+    scope.scope : () -> () {
+      %alloc_10 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.crossDeps = [0 : i32, 1 : i32], ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_10 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x1x16x16xf16, #hivm.address_space<cbuf>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+      %alloc_11 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_11 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32} : memref<8x4x16x16xf16, #hivm.address_space<cbuf>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 2
+      %alloc_12 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32, ssbuffer.crossDeps = [2 : i32, 1 : i32]} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_12 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32} : memref<4x8x16x16xf16, #hivm.address_space<cbuf>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 2 : i32}[<CUBE>, <PIPE_M>, <PIPE_MTE3>] flag = 3
+      %alloc_13 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_13 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<3>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 3 : i32} : memref<16x128xf32, #hivm.address_space<ub>>
+      %alloc_14 = memref.alloc() {ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_14 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<4>, ssbuffer.block_id = 11 : i32, ssbuffer.transfer_id = 4 : i32} : memref<16x64xf32, #hivm.address_space<ub>>
+      %30:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
+
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+        %50 = hivm.hir.convert_layout %alloc_10 output_shape [16, 64] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 2 : i32, ssbuffer.crossDeps = [0 : i32, 0 : i32], ssbuffer.transfer_id = 0 : i32} : (memref<4x1x16x16xf16, #hivm.address_space<cbuf>>) -> memref<16x64xf16, #hivm.address_space<cbuf>>
+        %54 = tensor.empty() {ssbuffer.block_id = 2 : i32} : tensor<16x128xf32>
+        hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 2 : i32, ssbuffer.transfer_id = 3 : i32} ins(%54 : tensor<16x128xf32>) outs(%alloc_13 : memref<16x128xf32, #hivm.address_space<ub>>)
+
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 3 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+        // %48 = hivm.hir.convert_layout %alloc_11 output_shape [64, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 3 : i32, ssbuffer.crossDeps = [1 : i32, 0 : i32], ssbuffer.transfer_id = 1 : i32} : (memref<8x4x16x16xf16, #hivm.address_space<cbuf>>) -> memref<64x128xf16, #hivm.address_space<cbuf>>
+        %45 = hivm.hir.convert_layout %alloc_12 output_shape [128, 64] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 3 : i32, ssbuffer.crossDeps = [2 : i32, 0 : i32], ssbuffer.transfer_id = 2 : i32} : (memref<4x8x16x16xf16, #hivm.address_space<cbuf>>) -> memref<128x64xf16, #hivm.address_space<cbuf>>
+        %offset = arith.constant {ssbuffer.block_id = 3 : i32} 0 : index
+        %47 = tensor.empty() {ssbuffer.block_id = 3 : i32} : tensor<16x64xf32>
+        %reinterpret_cast_61 = memref.reinterpret_cast %arg4 to offset: [%offset], sizes: [1, 128], strides: [128, 1] {ssbuffer.block_id = 3 : i32} : memref<?xf16> to memref<1x128xf16, strided<[128, 1], offset: ?>>
+        %136 = tensor.empty() {ssbuffer.block_id = 3 : i32} : tensor<1x128xf16>
+        bufferization.materialize_in_destination %136 in writable %reinterpret_cast_61 {ssbuffer.block_id = 3 : i32, ssbuffer.memCrossDeps = [2 : i32, 0 : i32]} : (tensor<1x128xf16>, memref<1x128xf16, strided<[128, 1], offset: ?>>) -> ()
+        hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 3 : i32, ssbuffer.transfer_id = 4 : i32} ins(%47 : tensor<16x64xf32>) outs(%alloc_14 : memref<16x64xf32, #hivm.address_space<ub>>)
+
+        scf.yield %arg17, %arg18 : i32, i32
+      } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+    return {ssbuffer.core_type = "VECTOR"}
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/Inner_scope_i1_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/Inner_scope_i1_test.mlir
@@ -1,0 +1,39 @@
+// RUN: (triton-opt --add_multi_buffer_inner_scope %s 2>&1 || echo "PASS") | FileCheck %s
+// CHECK: PASS
+
+// T-i1: i1 Tensor Dependency Triggers Fallback
+// Test: When a tensor dep with element type i1 is produced in one block and
+//       consumed in another inside the main_loop body (via a normal
+//       cross-block tensor ref, NOT the tensor.empty + linalg.fill clone
+//       pattern), the pass should detect this during dep collection and
+//       fall back (set ERRCODE_IGNORED=2 + signalPassFailure).
+//
+// Setup:
+//   - VECTOR scope with main_loop.
+//   - Producer block_id = 7 (inside main_loop): memref.alloc +
+//     bufferization.to_tensor to produce tensor<128xi1>.
+//   - Consumer block_id = 10 (inside main_loop, different from 7):
+//     arith.ori reads %prod cross-block.
+//   - The cross-block dep is %prod (tensor<i1>, block 7) -> %consumed (block 10).
+//   - This is a NORMAL tensor dep (would normally go through the multi-buffer
+//     pipeline), not the empty+fill clone path.
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_i1_tensor_dep_fallback() {
+    %c0_i32 = arith.constant 0 : i32
+    %c100_i32 = arith.constant 100 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %cst_true = arith.constant true
+    scope.scope : () -> () {
+      scf.for %i = %c0_i32 to %c100_i32 step %c1_i32  : i32 {
+        // Producer: tensor<128xi1> in block 7 (NOT empty+fill pattern)
+        %alloc = memref.alloc() {ssbuffer.block_id = 7 : i32} : memref<128xi1>
+        %prod = bufferization.to_tensor %alloc restrict writable {ssbuffer.block_id = 7 : i32} : memref<128xi1>
+        // Consumer in block 10 (cross-block)
+        %consumed = arith.ori %prod, %prod {ssbuffer.block_id = 10 : i32} : tensor<128xi1>
+      } {ssbuffer.main_loop = 1 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-main-loop-only-copy-or-fixpipe.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-main-loop-only-copy-or-fixpipe.mlir
@@ -1,0 +1,42 @@
+// RUN: triton-opt --analyze-scope --verify-diagnostics
+
+// Unit test for AnalyzeScopePass: when every main_loop id lacks either
+// hivm.hir.copy or hivm.hir.fixpipe, the new isMainLoopOnlyCopyOrFixpipe
+// check must trigger setFallbackAttr so the dynamic CV pipeline falls
+// back to the original workflow.
+//
+// In this test the VECTOR main_loop (id 0) has only hivm.hir.copy with
+// transfer_id (to satisfy checkVecScopeMainLoop) and no fixpipe ops; the
+// CUBE main_loop (id 0) has only sync_block ops and no copy or fixpipe.
+// For id 0: countCopy > 0 and countFixpipe == 0, so the rule
+// (countCopy == 0 || countFixpipe == 0) is satisfied for the only id and
+// isMainLoopOnlyCopyOrFixpipe returns true -- fallback is set.
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_main_loop_only_copy(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xbf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg3: memref<?xbf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg4: memref<?xbf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg5: memref<?xbf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg6: memref<?xbf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg7: memref<?xbf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg8: memref<?xbf16> {tt.divisibility = 16 : i32}, %arg9: memref<?xbf16> {tt.divisibility = 16 : i32}, %arg10: i32, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32, %arg14: i32, %arg15: i32, %arg16: i32, %arg17: i32, %arg18: i32) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %c0_i32 = arith.constant {ssbuffer.block_id = 14 : i32} 0 : i32
+    %c1_i32 = arith.constant {Undefined, ssbuffer.block_id = 14 : i32} 1 : i32
+    %c32_i32 = arith.constant {ssbuffer.block_id = 14 : i32} 32 : i32
+    %cst = arith.constant {ssbuffer.block_id = 14 : i32} 0.000000e+00 : bf16
+    %reshape = tensor.empty() {ssbuffer.block_id = 14 : i32} : tensor<4x4x16x16xbf16>
+    scope.scope : () -> () {
+      %alloc = memref.alloc() {ssbuffer.block_id = 22 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x4x16x16xbf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 22 : i32, ssbuffer.transfer_id = 0 : i32} : memref<4x4x16x16xbf16, #hivm.address_space<cbuf>>
+      hivm.hir.sync_block_set {ssbuffer.block_id = 22 : i32, ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
+      scf.for %arg19 = %c0_i32 to %c32_i32 step %c1_i32  : i32 {
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 22 : i32, ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_M>, <PIPE_MTE3>] flag = 1
+        hivm.hir.copy ins(%reshape : tensor<4x4x16x16xbf16>) outs(%alloc : memref<4x4x16x16xbf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 22 : i32, ssbuffer.transfer_id = 0 : i32}
+        hivm.hir.sync_block_set {ssbuffer.block_id = 22 : i32, ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 1
+      } {ssbuffer.block_id = 22 : i32, ssbuffer.main_loop = 0 : i32}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    scope.scope : () -> () {
+      scf.for %arg19 = %c0_i32 to %c32_i32 step %c1_i32  : i32 {
+        hivm.hir.sync_block_set {ssbuffer.block_id = 22 : i32}[<CUBE>, <PIPE_V>, <PIPE_FIX>] flag = 2
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 22 : i32}[<CUBE>, <PIPE_V>, <PIPE_FIX>] flag = 2
+      } {ssbuffer.block_id = 22 : i32, ssbuffer.main_loop = 0 : i32}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+    return
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/unify_alloc_block.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/unify_alloc_block.mlir
@@ -8,14 +8,13 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
   // - When memref.alloc, linalg.fill (inside scf.if), and memref.copy exist
   //   with different block_ids, the pass should unify them to the same block_id
   // - Target block_id is determined by the memref.copy's block_id
-  // - The scf.if operation itself (including its condition dependencies) will
-  //   also be assigned the target block_id to maintain consistency
+  // - Only coreOps (alloc, fill, scf.if, directUsers) are unified;
+  //   condition dependencies are NOT updated
   // - Two scenarios are tested:
-  //   1. VECTOR core: alloc(block_id=7) + fill(block_id=6) + copy(block_id=8) 
-  //      → unified to block_id=8 (including scf.if condition but exit for create
-  //      cycle)
-  //   2. CUBE core: alloc(block_id=3) + fill(block_id=1) + copy(block_id=2) 
-  //      → unified to block_id=2 (including scf.if condition)
+  //   1. VECTOR core: alloc(block_id=7) + fill(block_id=6) + copy(block_id=8)
+  //      → coreOps unified to block_id=8, conditionOps unchanged
+  //   2. CUBE core: alloc(block_id=3) + fill(block_id=1) + copy(block_id=2)
+  //      → coreOps unified to block_id=2, conditionOps unchanged
   // ============================================
   func.func @_sgemm_lora_a_kernel(%arg2: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg3: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32) {
     %cst = arith.constant {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"} 0.000000e+00 : f16
@@ -65,37 +64,37 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
       memref.copy %subview_17, %subview_18 {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<?x?xf16, strided<[?, ?], offset: ?>> to memref<?x?xf16, strided<[16, 1]>>
       annotation.mark %alloc {MayImplicitTransposeWithLastAxis, ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<256x16xf16>
       %82 = bufferization.to_tensor %alloc restrict writable {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<256x16xf16>
-      // CHECK: %{{.*}} = arith.muli %arg{{.*}}, %c256_i32 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : i32
+      // CHECK: %{{.*}} = arith.muli %arg{{.*}}, %c256_i32 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : i32
       %83 = arith.muli %arg22, %c256_i32 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : i32
-      // CHECK: %{{.*}} = arith.subi %arg{{.*}}, %{{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : i32
+      // CHECK: %{{.*}} = arith.subi %arg{{.*}}, %{{.*}} {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : i32
       %84 = arith.subi %arg6, %83 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : i32
       // CHECK: %{{.*}} = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<16x256xf16>
       %alloc_19 = memref.alloc() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<16x256xf16>
-      // CHECK: %{{.*}} = arith.addi %{{.*}}, %c16 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : index
+      // CHECK: %{{.*}} = arith.addi %{{.*}}, %c16 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
       %85 = arith.addi %41, %c16 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
-      // CHECK: %{{.*}} = arith.index_cast %{{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : i32 to index
+      // CHECK: %{{.*}} = arith.index_cast %{{.*}} {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : i32 to index
       %86 = arith.index_cast %arg5 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : i32 to index
-      // CHECK: %{{.*}} = arith.maxsi %{{.*}}, %{{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : index
+      // CHECK: %{{.*}} = arith.maxsi %{{.*}}, %{{.*}} {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
       %87 = arith.maxsi %41, %86 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
-      // CHECK: %{{.*}} = arith.minsi %{{.*}}, %{{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : index
+      // CHECK: %{{.*}} = arith.minsi %{{.*}}, %{{.*}} {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
       %88 = arith.minsi %85, %87 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
-      // CHECK: %{{.*}} = arith.subi %{{.*}}, %{{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : index
+      // CHECK: %{{.*}} = arith.subi %{{.*}}, %{{.*}} {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
       %89 = arith.subi %88, %41 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
-      // CHECK: %{{.*}} = arith.index_cast %{{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : i32 to index
+      // CHECK: %{{.*}} = arith.index_cast %{{.*}} {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : i32 to index
       %90 = arith.index_cast %84 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : i32 to index
-      // CHECK: %{{.*}} = arith.maxsi %{{.*}}, %c0 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : index
+      // CHECK: %{{.*}} = arith.maxsi %{{.*}}, %c0 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
       %91 = arith.maxsi %90, %c0 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
-      // CHECK: %{{.*}} = arith.minsi %{{.*}}, %c256 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : index
+      // CHECK: %{{.*}} = arith.minsi %{{.*}}, %c256 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
       %92 = arith.minsi %91, %c256 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
-      // CHECK: %{{.*}} = arith.minsi %{{.*}}, %c16 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : index
+      // CHECK: %{{.*}} = arith.minsi %{{.*}}, %c16 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
       %93 = arith.minsi %89, %c16 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
-      // CHECK: %{{.*}} = arith.minsi %{{.*}}, %c256 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : index
+      // CHECK: %{{.*}} = arith.minsi %{{.*}}, %c256 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
       %94 = arith.minsi %92, %c256 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
-      // CHECK: %{{.*}} = arith.cmpi slt, %{{.*}}, %c16 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : index
+      // CHECK: %{{.*}} = arith.cmpi slt, %{{.*}}, %c16 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
       %95 = arith.cmpi slt, %93, %c16 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
-      // CHECK: %{{.*}} = arith.cmpi slt, %{{.*}}, %c256 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : index
+      // CHECK: %{{.*}} = arith.cmpi slt, %{{.*}}, %c256 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
       %96 = arith.cmpi slt, %94, %c256 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
-      // CHECK: %{{.*}} = arith.ori %{{.*}}, %{{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : i1
+      // CHECK: %{{.*}} = arith.ori %{{.*}}, %{{.*}} {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : i1
       %97 = arith.ori %95, %96 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : i1
 
       // CHECK: scf.if %{{.*}} {
@@ -168,14 +167,14 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
     %cst = arith.constant 0.000000e+00 : f16
 
     scf.for %arg17 = %c0 to %c32 step %c1 iter_args(%arg19 = %c0) -> (index) {
-      // CHECK: arith.constant {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} 128 : index
+      // CHECK: arith.constant {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE"} 128 : index
       %c128 = arith.constant {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE"} 128 : index
-      // CHECK: arith.cmpi {{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : index
+      // CHECK: arith.cmpi {{.*}} {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
       %cond = arith.cmpi slt, %arg19, %c32 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
 
       // CHECK: memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16>
       %alloc = memref.alloc() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16>
-      // CHECK: arith.addi {{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : index
+      // CHECK: arith.addi {{.*}} {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
       %140 = arith.addi %arg19, %c128 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
 
       // CHECK: scf.if %{{.*}} {

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_inline_transpose.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_inline_transpose.mlir
@@ -1,0 +1,24 @@
+// RUN: triton-opt --add-block-id-for-control-ops --data-dependency-analysis --inter-core-transfer-and-sync --mark-main-loop %s | FileCheck %s
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">}  {
+  func.func @test_inline_transpose(%arg0: memref<256x256xf16>) {
+    %alloc = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<256x256xf16>
+    %t0 = bufferization.to_tensor %alloc {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<256x256xf16>
+    %cst = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} 0.0 : f16
+    %empty = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : tensor<256x256xf32>
+    %init = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : f16) outs(%empty : tensor<256x256xf32>) -> tensor<256x256xf32>
+    %mat = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%t0, %t0 : tensor<256x256xf16>, tensor<256x256xf16>) outs(%init : tensor<256x256xf32>) -> tensor<256x256xf32>
+    %empty1 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : tensor<256x256xf32>
+    %transposed = linalg.transpose ins(%mat : tensor<256x256xf32>) outs(%empty1 : tensor<256x256xf32>) permutation = [1, 0]  {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"}
+    %exp = math.exp %transposed {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : tensor<256x256xf32>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @test_inline_transpose
+// CHECK: %[[MATMUL_3:[a-z0-9_]+]] = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%0, %0 : tensor<256x256xf16>, tensor<256x256xf16>) outs(%2 : tensor<256x256xf32>) -> tensor<256x256xf32>
+// CHECK: hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2dn> {{.*}} ins(%[[MATMUL_3]] : tensor<256x256xf32>)
+// CHECK: %[[TENSOR_4:[a-z0-9_]+]] = bufferization.to_tensor
+// CHECK: %transposed = linalg.transpose ins(%[[TENSOR_4]] : tensor<256x256xf32>)
+// CHECK: %6 = math.exp %[[TENSOR_4]] {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : tensor<256x256xf32>
+// CHECK: return

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_memref_dependency.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_memref_dependency.mlir
@@ -1,5 +1,5 @@
 module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">}  {
-func.func @sparse_flash_attention_prefill_kernel(%arg3: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg7: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 2 : i32}, %arg8: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 2 : i32}) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+func.func @@test_memref_dependency(%arg3: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg7: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 2 : i32}, %arg8: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 2 : i32}) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
   %c8_i32 = arith.constant {Undefined, ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"} 8 : i32
   %c0_i32 = arith.constant {Undefined, ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"} 0 : i32
   %c1_i32 = arith.constant {Undefined, ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"} 1 : i32
@@ -43,15 +43,24 @@ func.func @sparse_flash_attention_prefill_kernel(%arg3: memref<?xf16> {tt.divisi
 }
 }
 
-// CHECK-LABEL: func.func @sparse_flash_attention_prefill_kernel
+// CHECK-LABEL: func.func @test_memref_dependency
 // CHECK: scf.for
 // CHECK: scf.for
+// CHECK: bufferization.materialize_in_destination %1 in writable %reinterpret_cast_2 {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.memCrossDeps = [0 : i32, 1 : i32]} : (tensor<576xf16>, memref<576xf16, strided<[1], offset: ?>>) -> ()
 // CHECK: } {Undefined, ssbuffer.block_id = 14 : i32}
-// CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 14 : i32, ssbuffer.core_type = "VECTOR"}[<VECTOR>, <PIPE_MTE3>, <PIPE_MTE2>] flag = [[FLAG_1:[0-9]+]]
-// CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE2>] flag = [[FLAG_1]]
+
+// CHECK: hivm.hir.sync_block_set {ssbuffer.analyze_flag_id, ssbuffer.block_id = 14 : i32, ssbuffer.core_type = "VECTOR"}[<VECTOR>, <PIPE_MTE3>, <PIPE_MTE2>] flag = [[FLAG_1:[0-9]+]]
+// CHECK: hivm.hir.sync_block_wait {ssbuffer.analyze_flag_id, ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE2>] flag = [[FLAG_1]]
+
 // CHECK: scf.for
+// CHECK: memref.copy %reinterpret_cast_0, %alloc_1 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.memCrossDeps = [0 : i32, 0 : i32]} : memref<128x576xf16, strided<[?, 1], offset: ?>> to memref<128x576xf16>
+// CHECK: bufferization.materialize_in_destination %2 in writable %reinterpret_cast_4 {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE", ssbuffer.memCrossDeps = [1 : i32, 1 : i32]} : (tensor<576xf16>, memref<576xf16, strided<[1], offset: ?>>) -> ()
 // CHECK: } {Undefined, ssbuffer.block_id = 16 : i32}
-// CHECK: hivm.hir.sync_block_set {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"}[<CUBE>, <PIPE_FIX>, <PIPE_MTE2>] flag = [[FLAG_2:[0-9]+]]
-// CHECK: hivm.hir.sync_block_wait {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"}[<VECTOR>, <PIPE_FIX>, <PIPE_MTE2>] flag = [[FLAG_2]]
-// CHECK: memref.reinterpret_cast 
+
+// CHECK: hivm.hir.sync_block_set {ssbuffer.analyze_flag_id, ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"}[<CUBE>, <PIPE_FIX>, <PIPE_MTE2>] flag = [[FLAG_2:[0-9]+]]
+// CHECK: hivm.hir.sync_block_wait {ssbuffer.analyze_flag_id, ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"}[<VECTOR>, <PIPE_FIX>, <PIPE_MTE2>] flag = [[FLAG_2]]
+
+// CHECK: memref.copy %reinterpret_cast, %alloc {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.memCrossDeps = [1 : i32, 0 : i32]} : memref<128x576xf16, strided<[?, 1], offset: ?>> to memref<128x576xf16>
+// CHECK: } {Undefined, ssbuffer.block_id = 17 : i32}
+// CHECK: return
 

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/separate_cv_scope_canonicalize_ut.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/separate_cv_scope_canonicalize_ut.mlir
@@ -693,3 +693,154 @@ module {
   }
 }
 
+// -----
+
+// Regression: isProducedByForeignScope gate must only apply to loop ops
+// (scf.for/scf.while), never to scf.if. The isLoopOp guard prevents the
+// gate from firing on scf.if. A VECTOR-only scf.if feeding a mixed
+// CUBE/VECTOR scf.while must stay live in the CUBE scope.
+// CHECK-LABEL: func.func @if_into_while_preserved_in_cube(
+// VECTOR scope: if preserved with real branch ops, then mixed while + store.
+// CHECK:      scope.scope : () -> () {
+// CHECK-NEXT:   %[[IF:.*]] = scf.if
+// CHECK-NEXT:     arith.addi
+// CHECK-NEXT:     scf.yield
+// CHECK-NEXT:   } else {
+// CHECK-NEXT:     arith.subi
+// CHECK-NEXT:     scf.yield
+// CHECK-NEXT:   }
+// CHECK-NEXT:   %[[WHILE_SMALL:.*]] = scf.while
+// CHECK-NEXT:     arith.addi
+// CHECK-NEXT:     arith.cmpi
+// CHECK-NEXT:     scf.condition
+// CHECK-NEXT:   } do {
+// CHECK-NEXT:   ^bb0({{.*}}):
+// CHECK-NEXT:     arith.addi
+// CHECK-NEXT:     scf.yield
+// CHECK-NEXT:   }
+// CHECK-NEXT:   memref.store
+// CHECK-NEXT:   scope.return
+// CHECK-NEXT: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CUBE scope: if preserved, mixed while preserved with CUBE arith.addi in body.
+// CHECK-NEXT: scope.scope : () -> () {
+// CHECK-NEXT:   %[[IFC:.*]] = scf.if
+// CHECK-NEXT:     arith.addi
+// CHECK-NEXT:     scf.yield
+// CHECK-NEXT:   } else {
+// CHECK-NEXT:     arith.subi
+// CHECK-NEXT:     scf.yield
+// CHECK-NEXT:   }
+// CHECK-NEXT:   %[[WHILEC:.*]]:{{[0-9]+}} = scf.while
+// CHECK-NEXT:     arith.addi
+// CHECK-NEXT:     arith.cmpi
+// CHECK-NEXT:     scf.condition
+// CHECK-NEXT:   } do {
+// CHECK-NEXT:   ^bb0({{.*}}):
+// CHECK-NEXT:     arith.addi
+// CHECK-NEXT:     arith.addi
+// CHECK-NEXT:     scf.yield
+// CHECK-NEXT:   }
+// CHECK-NEXT:   arith.addi
+// CHECK-NEXT:   memref.store
+// CHECK-NEXT:   scope.return
+// CHECK-NEXT: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<CUBE>}
+module {
+  func.func @if_into_while_preserved_in_cube(%cond: i1, %vinit: i64, %cinit: i64, %limit: i64, %outv: memref<1xi64>, %outc: memref<1xi64>) {
+    %idxv = arith.constant {ssbuffer.core_type = "VECTOR"} 0 : index
+    %idxc = arith.constant {ssbuffer.core_type = "CUBE"} 0 : index
+    %c1v = arith.constant {ssbuffer.core_type = "VECTOR"} 1 : i64
+    %c2c = arith.constant {ssbuffer.core_type = "CUBE"} 2 : i64
+    %c1c = arith.constant {ssbuffer.core_type = "CUBE"} 1 : i64
+    %0 = scf.if %cond -> (i64) {
+      %1 = arith.addi %vinit, %c1v {ssbuffer.core_type = "VECTOR"} : i64
+      scf.yield {ssbuffer.core_type = "VECTOR"} %1 : i64
+    } else {
+      %1 = arith.subi %limit, %c1v {ssbuffer.core_type = "VECTOR"} : i64
+      scf.yield {ssbuffer.core_type = "VECTOR"} %1 : i64
+    } {ssbuffer.core_type = "VECTOR"}
+    %1:2 = scf.while (%a = %0, %b = %cinit) : (i64, i64) -> (i64, i64) {
+      %2 = arith.addi %a, %c1v {ssbuffer.core_type = "VECTOR"} : i64
+      %3 = arith.cmpi slt, %2, %limit {ssbuffer.core_type = "VECTOR"} : i64
+      scf.condition(%3) %2, %b : i64, i64
+    } do {
+    ^bb0(%a_iter: i64, %b_iter: i64):
+      %2 = arith.addi %a_iter, %c1v {ssbuffer.core_type = "VECTOR"} : i64
+      %3 = arith.addi %b_iter, %c2c {ssbuffer.core_type = "CUBE"} : i64
+      scf.yield {ssbuffer.core_type = "VECTOR, CUBE"} %2, %3 : i64, i64
+    } attributes {ssbuffer.core_type = "VECTOR, CUBE"}
+    %2 = arith.addi %1#1, %c1c {ssbuffer.core_type = "CUBE"} : i64
+    memref.store %1#0, %outv[%idxv] {ssbuffer.core_type = "VECTOR"} : memref<1xi64>
+    memref.store %2, %outc[%idxc] {ssbuffer.core_type = "CUBE"} : memref<1xi64>
+    func.return
+  }
+}
+
+// -----
+
+// Regression: in a 2-layer nested scf.for where the inner iter_arg flows
+// directly into a CUBE accumulator (arith.mulf), needsLoopCarryPreserve on the
+// inner for cannot find VECTOR users because same-slot yield blocks SSA
+// propagation. The producer-scope gate (guarded by isLoopOp on scf.for) detects
+// the foreign CUBE producer and skips findLiveUser so the slot is neutralized
+// in VECTOR scope, erasing the CUBE op from the VECTOR clone while keeping it
+// in the CUBE clone. An independent CUBE consumer of the outer loop result
+// ensures the CUBE scope is not optimized away.
+// CHECK-LABEL: func.func @nested_for_cube_acc_not_trapped_in_vector(
+// VECTOR scope: outer+inner for survive, arith.addf{VECTOR} present
+//               but arith.mulf{CUBE} absent, scalar CUBE consumer absent.
+// CHECK:      scope.scope : () -> () {
+// CHECK-NEXT:   [[OUTER:%.+]]:2 = scf.for
+// CHECK:        [[INNER:%.+]]:2 = scf.for
+// CHECK:          arith.addf
+// CHECK-NOT:      arith.mulf
+// CHECK:          scf.yield
+// CHECK:        }
+// CHECK:        scf.yield
+// CHECK:        arith.addf
+// CHECK:        tensor.extract
+// CHECK:        memref.store
+// CHECK-NEXT:   scope.return
+// CHECK-NEXT: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+// CUBE scope: outer+inner for survive, arith.mulf{CUBE} present, and
+//             the independent CUBE arith.addf consumer is present.
+// CHECK-NEXT: scope.scope : () -> () {
+// CHECK-NEXT:   [[OUTERC:%.+]]:2 = scf.for
+// CHECK:        [[INNERC:%.+]]:2 = scf.for
+// CHECK:          arith.mulf
+// CHECK:          scf.yield
+// CHECK:        }
+// CHECK:        scf.yield
+// CHECK:        arith.addf
+// CHECK:        tensor.extract
+// CHECK:        memref.store
+// CHECK-NEXT:   scope.return
+// CHECK-NEXT: } {hivm.matmul_limited_in_cube, hivm.tcore_type = #hivm.tcore_type<CUBE>}
+module {
+  func.func @nested_for_cube_acc_not_trapped_in_vector(
+      %lb: index, %ub: index, %step: index,
+      %acc_init: tensor<4xf32>, %vec_init: tensor<4xf32>,
+      %ck: tensor<4xf32>, %vk: tensor<4xf32>, %cc_init: tensor<4xf32>,
+      %outv: memref<1xf32>, %outc: memref<1xf32>) {
+    %idx = arith.constant {ssbuffer.core_type = "VECTOR"} 0 : index
+    %idxc = arith.constant {ssbuffer.core_type = "CUBE"} 0 : index
+    %1:2 = scf.for %a = %lb to %ub step %step
+        iter_args(%oa = %acc_init, %ov = %vec_init) -> (tensor<4xf32>, tensor<4xf32>) : index {
+      %2:2 = scf.for %b = %lb to %ub step %step
+          iter_args(%ia = %oa, %iv = %ov) -> (tensor<4xf32>, tensor<4xf32>) : index {
+        %3 = arith.mulf %ia, %ck {ssbuffer.core_type = "CUBE"} : tensor<4xf32>
+        %4 = arith.addf %iv, %vk {ssbuffer.core_type = "VECTOR"} : tensor<4xf32>
+        scf.yield {ssbuffer.core_type = "CUBE, VECTOR"} %3, %4 : tensor<4xf32>, tensor<4xf32>
+      } {ssbuffer.core_type = "CUBE, VECTOR"}
+      scf.yield {ssbuffer.core_type = "CUBE, VECTOR"} %2#0, %2#1 : tensor<4xf32>, tensor<4xf32>
+    } {ssbuffer.core_type = "CUBE, VECTOR"}
+    %sv = arith.addf %1#0, %vk {ssbuffer.core_type = "VECTOR"} : tensor<4xf32>
+    %ev = tensor.extract %sv[%idx] {ssbuffer.core_type = "VECTOR"} : tensor<4xf32>
+    memref.store %ev, %outv[%idx] {ssbuffer.core_type = "VECTOR"} : memref<1xf32>
+    %sc = arith.addf %1#0, %cc_init {ssbuffer.core_type = "CUBE"} : tensor<4xf32>
+    %ec = tensor.extract %sc[%idxc] {ssbuffer.core_type = "CUBE"} : tensor<4xf32>
+    memref.store %ec, %outc[%idxc] {ssbuffer.core_type = "CUBE"} : memref<1xf32>
+    func.return
+  }
+}
+
+


### PR DESCRIPTION
## Initiative                                                                                                                                        
                                                                  
  SSBuffer optimization pass has multiple edge case issues when handling complex control flow and cross-core dependencies, causing compilation      
  failures or requiring fallback.                                 
                                                                                                                                                    
## Solution                                                                                                                                          
   
  Core Changes:                                                                                                                                     
                                                                  
  1. Cross-core dependency enhancement - Added data structures to track iter_args and ssbuffer.if ops relationships; extended dependency condition  
  computation functions to handle multi producer-consumer scenarios
  2. Iteration dependency factor - Added calculateIterDepsFactor to compute cross-iteration dependency factors; triggers fallback when insufficient 
  for cross-core sync                                                                                                                               
  3. Memref dependency attributes - Added ssbuffer.cross_dep, ssbuffer.intra_dep, ssbuffer.mem_dep attributes; collectMemDepInfo now supports
  isAllTransposed flag for transpose handling                                                                                                       
  4. Edge case fixes:                                             
    - Skip findLiveUser for foreign-scope producers                                                                                                 
    - Fallback on i1 type tensor dependencies                                                                                                       
    - Unify ifOp conditions in multi-dependency scenarios                                                                                           
    - Inline transpose with fixpipe optimization                                                                                                    
    - Handle multi-value core_type in scf op results yield                                                                                          
  5. Code cleanup - Removed hardcoded function name interception logic in AnalyzeName.cpp                                                           
                                                                                                                                                    
## Files Changed                                                                                                                                     
                                                                                                                                                    
  - 6 header files                                                                                                                                  
  - 15 implementation files                                       
  - 12 test files (MLIR unit tests)                                                                                                                 
                                                                                                                                                    
## Test Coverage                                                                                                                                     
                                                                                                                                                    
  12 new MLIR unit tests covering multi-producer/consumer scenarios, cross-iteration dependencies, i1 type handling, transpose inline, and memref   
  dependencies.          

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
