### PR TITLE
[Docs](feat) Add debug documents in zh/index.rst

### DIFF
--- a/docs/zh/index.rst
+++ b/docs/zh/index.rst
@@ -53,6 +53,8 @@ Triton Ascend
     max_autotune_guide.md
     debug_guide/debugging.md
     debug_guide/profiling.md
+    debug_guide/precision.md
+    debug_guide/ub_overflow.md
 
 .. toctree::
     :maxdepth: 3


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# PR Induction

This PR adds two new debugging guide documents to the Triton-Ascend documentation, specifically focusing on common development challenges.

**Changes:**
1.  **Precision Debugging Guide:** Added `debug_guide/precision.md` to assist developers in analyzing and resolving precision discrepancy issues between different devices (e.g., GPU vs. NPU).
2.  **UB Overflow Debugging Guide:** Added `debug_guide/ub_overflow.md` to address memory-related issues, particularly Out-of-Bounds (OOB) access and Unified Buffer (UB) overflow problems.

**Impact:**
These documents are included in the `index.rst` file, making them accessible under the debugging section of the Read the Docs website.

---

- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
