### PR TITLE
[ssbuffer](fix) Resolving the order uncertainty in ssbuffer allocation

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.h
@@ -68,10 +68,10 @@ private:
 
     Value getVarValue(scf::ForOp forOp, int varIndex);
 
-    void collectDependencyBuffers(scf::ForOp forOp,
-                                  DenseMap<int, DenseMap<Value, SmallVector<Value> > > &crossCoreBuffers,
-                                  DenseMap<int, DenseMap<Operation*, SmallVector<Operation*>>> &memCrossCoreBuffers,
-                                  DenseMap<int, DenseMap<Value, SmallVector<Value> > > &intraCoreBuffers);
+void collectDependencyBuffers(ModuleOp module, SmallVector<scf::ForOp> &mainLoopForOps,
+                              DenseMap<int, DenseMap<Value, SmallVector<Value> > > &crossCoreBuffers,
+                              DenseMap<int, DenseMap<Operation*, SmallVector<Operation*>>> &memCrossCoreBuffers,
+                              DenseMap<scf::ForOp, DenseMap<int, DenseMap<Value, SmallVector<Value> > > > &intraCoreBuffersMap);
 
     DenseMap<int, DenseMap<Value, SmallVector<Value> > >
     extendCrossCoreBuffersWithEquivalentValues(ModuleOp module,

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
@@ -132,31 +132,47 @@ SmallVector<SmallVector<Value>> UpdateConditionInfoPass::allocSSBuffer(ModuleOp 
 
 // Collect dependency buffer
 void UpdateConditionInfoPass::collectDependencyBuffers(
-    scf::ForOp forOp, DenseMap<int, DenseMap<Value, SmallVector<Value>>> &crossCoreBuffers,
+    ModuleOp module, SmallVector<scf::ForOp> &mainLoopForOps,
+    DenseMap<int, DenseMap<Value, SmallVector<Value>>> &crossCoreBuffers,
     DenseMap<int, DenseMap<Operation*, SmallVector<Operation*>>> &memCrossCoreBuffers,
-    DenseMap<int, DenseMap<Value, SmallVector<Value>>> &intraCoreBuffers)
+    DenseMap<scf::ForOp, DenseMap<int, DenseMap<Value, SmallVector<Value>>>> &intraCoreBuffersMap)
 {
+// Collect crossCoreBuffers and memCrossCoreBuffers by traversing module in deterministic order
   int crossCoreIdx = 0;
-  for (auto &entry : info->crossCoreDependentMap) {
-    crossCoreBuffers[crossCoreIdx][entry.first] = entry.second;
-    crossCoreIdx++;
-  }
-
-  // Collect memCrossCoreDependentMap with offset groupIdx
-  int memCrossCoreOffset = info->crossCoreDependentMap.size();
   int memCrossCoreIdx = 0;
-  for (auto &entry : info->memCrossCoreDependentMap) {
-    int adjustedGroupIdx = memCrossCoreOffset + memCrossCoreIdx;
-    memCrossCoreBuffers[adjustedGroupIdx][entry.first] = entry.second;
-    memCrossCoreIdx++;
-  }
+  int memCrossCoreOffset = info->crossCoreDependentMap.size();
+  module.walk([&](Operation *op) {
+    // Collect crossCoreBuffers for this op's results
+    for (Value result : op->getResults()) {
+      auto it = info->crossCoreDependentMap.find(result);
+      if (it != info->crossCoreDependentMap.end()) {
+        crossCoreBuffers[crossCoreIdx][result] = it->second;
+        crossCoreIdx++;
+      }
+    }
 
-  if (info->intraCoreDependentMap.count(forOp)) {
-    auto &forOpDeps = info->intraCoreDependentMap[forOp];
-    int intraCoreIdx = 0;
-    for (auto &entry : forOpDeps) {
-      intraCoreBuffers[intraCoreIdx][entry.first] = entry.second;
-      intraCoreIdx++;
+    // Collect memCrossCoreBuffers for this op
+    auto memIt = info->memCrossCoreDependentMap.find(op);
+    if (memIt != info->memCrossCoreDependentMap.end()) {
+      int adjustedGroupIdx = memCrossCoreOffset + memCrossCoreIdx;
+      memCrossCoreBuffers[adjustedGroupIdx][op] = memIt->second;
+      memCrossCoreIdx++;
+    }
+
+    return WalkResult::advance();
+  });
+
+  // Collect intraCoreBuffers for all forOps
+  for (scf::ForOp forOp : mainLoopForOps) {
+    if (info->intraCoreDependentMap.count(forOp)) {
+      auto &forOpDeps = info->intraCoreDependentMap[forOp];
+      DenseMap<int, DenseMap<Value, SmallVector<Value>>> intraCoreBuffers;
+      int intraCoreIdx = 0;
+      for (auto &entry : forOpDeps) {
+        intraCoreBuffers[intraCoreIdx][entry.first] = entry.second;
+        intraCoreIdx++;
+      }
+      intraCoreBuffersMap[forOp] = intraCoreBuffers;
     }
   }
 }
@@ -1433,6 +1449,13 @@ int UpdateConditionInfoPass::updateIfConds(ModuleOp module, SmallVector<SmallVec
   if (walkResult.wasInterrupted()) {
     return UPDATE_CONDITION_INFO_FAILED;
   }
+
+  // Step0: Collect dependency buffers once outside the for loop
+  DenseMap<int, DenseMap<Value, SmallVector<Value>>> crossCoreBuffers;
+  DenseMap<int, DenseMap<Operation*, SmallVector<Operation*>>> memCrossCoreBuffers;
+  DenseMap<scf::ForOp, DenseMap<int, DenseMap<Value, SmallVector<Value>>>> intraCoreBuffersMap;
+  collectDependencyBuffers(module, mainLoopForOps, crossCoreBuffers, memCrossCoreBuffers, intraCoreBuffersMap);
+
   for (scf::ForOp forOp : mainLoopForOps) {
     controlVarToLatestValue.clear();
 
@@ -1441,11 +1464,12 @@ int UpdateConditionInfoPass::updateIfConds(ModuleOp module, SmallVector<SmallVec
       return UPDATE_CONDITION_INFO_FAILED;
     }
 
-    DenseMap<int, DenseMap<Value, SmallVector<Value> > > crossCoreBuffers;
-    DenseMap<int, DenseMap<Operation*, SmallVector<Operation*>>> memCrossCoreBuffers;
-    DenseMap<int, DenseMap<Value, SmallVector<Value> > > intraCoreBuffers;
-    // Step1:Collect the dependency buffer info of this forOp
-    collectDependencyBuffers(forOp, crossCoreBuffers, memCrossCoreBuffers, intraCoreBuffers);
+    // Step1: Get intraCoreBuffers from pre-collected map
+    DenseMap<int, DenseMap<Value, SmallVector<Value>>> intraCoreBuffers;
+    if (intraCoreBuffersMap.count(forOp)) {
+      intraCoreBuffers = intraCoreBuffersMap[forOp];
+    }
+
     if (crossCoreBuffers.empty() && memCrossCoreBuffers.empty() && intraCoreBuffers.empty()) {
       LDBG("crossCoreBuffers, memCrossCoreBuffers and intraCoreBuffers are all empty!" << "\n");
       return UPDATE_CONDITION_INFO_FAILED;

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/crossCoreDeps_fixed_ordered_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/crossCoreDeps_fixed_ordered_test.mlir
@@ -1,0 +1,115 @@
+// RUN: triton-opt --add-control-flow-condition %s | FileCheck %s
+
+// Unit Tests for AddControlFlowCondition Pass - Cross Core Dependencies Test
+//
+// This test verifies:
+// 1. ssbuffer initialization at scope start (constants 0, 0, 1024, 4, 1028, 8, 1032)
+// 2. test ssbuffer address is allocated in a fixed order
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @_attn_fwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg3: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg4: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg5: memref<?xf32> {tt.divisibility = 16 : i32}, %arg6: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg7: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg8: memref<?xi32> {tt.divisibility = 16 : i32}, %arg9: i32, %arg10: i32, %arg11: i32, %arg12: i32, %arg13: i32, %arg14: i32, %arg15: i32) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %c8192_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 8192 : i32
+    %c128_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 128 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 0 : i32
+    // ssbuffer init
+    // CHECK:       %[[ZERO:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:       %[[ADDR0:.*]] = llvm.mlir.constant(0 : i64) : i64
+    // CHECK:       %[[ADDR1:.*]] = llvm.mlir.constant(1024 : i64) : i64
+    // CHECK:       %[[PTR0:.*]] = llvm.inttoptr %[[ADDR0]] : i64 to !llvm.ptr<11>
+    // CHECK:       %[[PTR1:.*]] = llvm.inttoptr %[[ADDR1]] : i64 to !llvm.ptr<11>
+    // CHECK:       llvm.store volatile %[[ZERO]], %[[PTR0]] : i32, !llvm.ptr<11>
+    // CHECK:       llvm.store volatile %[[ZERO]], %[[PTR1]] : i32, !llvm.ptr<11>
+    // CHECK:       %[[ADDR2:.*]] = llvm.mlir.constant(4 : i64) : i64
+    // CHECK:       %[[ADDR3:.*]] = llvm.mlir.constant(1028 : i64) : i64
+    // CHECK:       %[[PTR2:.*]] = llvm.inttoptr %[[ADDR2]] : i64 to !llvm.ptr<11>
+    // CHECK:       %[[PTR3:.*]] = llvm.inttoptr %[[ADDR3]] : i64 to !llvm.ptr<11>
+    // CHECK:       llvm.store volatile %[[ZERO]], %[[PTR2]] : i32, !llvm.ptr<11>
+    // CHECK:       llvm.store volatile %[[ZERO]], %[[PTR3]] : i32, !llvm.ptr<11>
+    // CHECK:       %[[ADDR4:.*]] = llvm.mlir.constant(8 : i64) : i64
+    // CHECK:       %[[ADDR5:.*]] = llvm.mlir.constant(1032 : i64) : i64
+    // CHECK:       %[[PTR4:.*]] = llvm.inttoptr %[[ADDR4]] : i64 to !llvm.ptr<11>
+    // CHECK:       %[[PTR5:.*]] = llvm.inttoptr %[[ADDR5]] : i64 to !llvm.ptr<11>
+    // CHECK:       llvm.store volatile %[[ZERO]], %[[PTR4]] : i32, !llvm.ptr<11>
+    // CHECK:       llvm.store volatile %[[ZERO]], %[[PTR5]] : i32, !llvm.ptr<11>
+    scope.scope : () -> () {
+      %alloc = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_5 = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 1 : i32, ssbuffer.crossDeps = [0 : i32, 1 : i32]} : memref<128x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_5 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+      %alloc_6 = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 2 : i32, ssbuffer.crossDeps = [1 : i32, 1 : i32]} : memref<128x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_6 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+      %30:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
+        // CHECK:       scf.if
+        hivm.hir.sync_block_set {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 4
+        %memspacecast_11 = memref.memory_space_cast %alloc_5 {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32, ssbuffer.crossDeps = [0 : i32, 0 : i32]} : memref<128x128xf32, #hivm.address_space<ub>> to memref<128x128xf32>
+        %reshape_13 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<8x8x16x16xf16>
+        hivm.hir.copy ins(%reshape_13 : tensor<8x8x16x16xf16>) outs(%alloc : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 0 : i32}
+        // CHECK:       } {hivm.matmul_limited_in_cube, ssbuffer.if = 5 : i32}
+        // CHECK:       scf.if
+        hivm.hir.sync_block_set {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 4
+        %memspacecast_16 = memref.memory_space_cast %alloc_6 {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 2 : i32, ssbuffer.crossDeps = [1, 0]} : memref<128x128xf32, #hivm.address_space<ub>> to memref<128x128xf32>
+        // CHECK:       } {hivm.matmul_limited_in_cube, ssbuffer.if = 6 : i32}
+        scf.yield %arg17, %arg18 : i32, i32
+      } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    scope.scope : () -> () {
+      %alloc_5 = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 0 : i32, ssbuffer.crossDeps = [2 : i32, 1 : i32]} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_5 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_6 = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_6 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+      %alloc_7 = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_7 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+      %20:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
+        // This block contain a output
+        // in CUBE scope, it need to process two ssbuffer ptr
+        // CHECK:       llvm.load volatile %[[PTR0]] : !llvm.ptr<11> -> i32
+        // CHECK:       llvm.load volatile %[[PTR1]] : !llvm.ptr<11> -> i32
+        // CHECK:       arith.cmpi slt
+        // CHECK:       arith.cmpi slt
+        // CHECK:       scf.if
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 0 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+        %30 = tensor.empty() {ssbuffer.block_id = 0 : i32} : tensor<128x128xf32>
+        hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 0 : i32, ssbuffer.transfer_id = 1 : i32} ins(%30 : tensor<128x128xf32>) outs(%alloc_6 : memref<128x128xf32, #hivm.address_space<ub>>)
+        // CHECK:       llvm.load volatile %[[PTR0]] : !llvm.ptr<11> -> i32
+        // CHECK:       llvm.load volatile %[[PTR1]] : !llvm.ptr<11> -> i32
+        // CHECK:       arith.addi
+        // CHECK:       arith.addi
+        // CHECK:       llvm.store
+        // CHECK:       llvm.store
+        // CHECK:       } {hivm.matmul_limited_in_cube, ssbuffer.if = 0 : i32}
+
+        // This block contain an input and a output
+        // CHECK:       llvm.load volatile %[[PTR4]] : !llvm.ptr<11> -> i32
+        // CHECK:       llvm.load volatile %[[PTR5]] : !llvm.ptr<11> -> i32
+        // CHECK:       arith.cmpi sgt
+        // CHECK:       arith.cmpi sgt
+        // CHECK:       llvm.load volatile %[[PTR2]] : !llvm.ptr<11> -> i32
+        // CHECK:       llvm.load volatile %[[PTR3]] : !llvm.ptr<11> -> i32
+        // CHECK:       arith.cmpi slt
+        // CHECK:       arith.cmpi slt
+        // CHECK:       scf.if
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+        %32 = hivm.hir.convert_layout %alloc_5 output_shape [128, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 0 : i32, ssbuffer.crossDeps = [2 : i32, 0 : i32]} : (memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) -> memref<128x128xf16, #hivm.address_space<cbuf>>
+        %40 = tensor.empty() {ssbuffer.block_id = 1 : i32} : tensor<128x128xf32>
+        hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 2 : i32} ins(%40 : tensor<128x128xf32>) outs(%alloc_7 : memref<128x128xf32, #hivm.address_space<ub>>)
+        // CHECK:       llvm.load volatile %[[PTR4]] : !llvm.ptr<11> -> i32
+        // CHECK:       llvm.load volatile %[[PTR5]] : !llvm.ptr<11> -> i32
+        // CHECK:       arith.subi
+        // CHECK:       arith.subi
+        // CHECK:       llvm.store
+        // CHECK:       llvm.store
+        // CHECK:       llvm.load volatile %[[PTR2]] : !llvm.ptr<11> -> i32
+        // CHECK:       llvm.load volatile %[[PTR3]] : !llvm.ptr<11> -> i32
+        // CHECK:       arith.addi
+        // CHECK:       arith.addi
+        // CHECK:       llvm.store
+        // CHECK:       llvm.store
+        // CHECK:       } {hivm.matmul_limited_in_cube, ssbuffer.if = 1 : i32}
+        scf.yield %arg17, %arg18 : i32, i32
+      } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+    return {ssbuffer.core_type = "VECTOR"}
+  }
+}


### PR DESCRIPTION
[ssbuffer](fix) Resolving the order uncertainty in ssbuffer allocation

The traversal order of the DenseMap within the collectDependencyBuffers function is unstable, which causes variations in the SSBuffer address allocation sequence. Collecting variables for the DenseMap based on MLIR traversal order will get consistent ordering.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
