### PR TITLE
[triton-to-linalg](feat) Add SIMT row coalescing pass

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -186,7 +186,6 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
             auto_blockify_size
         )
 
-        ascend.passes.ttir.add_row_coalescing(pm)
         ascend.passes.ttir.add_triton_control_flow_opt(pm)
         ascend.passes.ttir.add_triton_to_structure(
             pm,

--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -97,10 +97,15 @@ def _export_coalesce_metadata(mod, metadata):
     # no longer interprets the attrs. Read them into metadata here and strip them
     # from the module so the hacc.* attrs never reach hivmc (which rejects
     # unknown module attrs). Absent attrs -> factor 1 (no-op) / axis -1.
+    # RowCoalescing also records whether the launcher should use ceil-div when
+    # shrinking the grid, because its runtime valid-count guard handles tails.
     factor = _get_then_remove_rc(mod, "hacc.coalesce_factor")
     axis = _get_then_remove_rc(mod, "hacc.coalesce_axis")
+    ceil_div = _get_then_remove_rc(mod, "hacc.coalesce_grid_ceil_div")
     metadata["coalesce_factor"] = factor if isinstance(factor, int) and factor > 1 else 1
     metadata["coalesce_axis"] = axis if isinstance(axis, int) and axis >= 0 else -1
+    metadata["coalesce_grid_ceil_div"] = bool(isinstance(ceil_div, int) and ceil_div > 0)
+    metadata["row_coalescing_applied"] = metadata["coalesce_factor"] > 1
 
 
 def _adjust_metadata_by_module_result(mod, metadata, opt, **kwargs):
@@ -181,6 +186,7 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
             auto_blockify_size
         )
 
+        ascend.passes.ttir.add_row_coalescing(pm)
         ascend.passes.ttir.add_triton_control_flow_opt(pm)
         ascend.passes.ttir.add_triton_to_structure(
             pm,
@@ -1027,6 +1033,13 @@ def ttir_to_npubin(mod, metadata, opt):
     # Get Triton-MLIR as string
     ttir_code = str(mod)
     metadata = _parse_ttir_metadata(ttir_code, metadata)
+    if opt.force_simt_only:
+        pm = ir.pass_manager(mod.context)
+        pm.enable_debug()
+        ascend.passes.ttir.add_row_coalescing(pm)
+        pm.run(mod)
+        _export_coalesce_metadata(mod, metadata)
+        ttir_code = str(mod)
     with tempfile.TemporaryDirectory() as tmpdir:
         # prepare input
         src_path = os.path.join(tmpdir, "kernel.ttir.mlir")
@@ -1064,7 +1077,9 @@ def ttir_to_npubin(mod, metadata, opt):
             # Enable SIMT auto-blockify when TRITON_ALL_BLOCKS_PARALLEL is set,
             # mirroring the SIMD compile paths. driver.py's runtime block-count
             # cap keys off the same env switch, so the two stay in sync.
-            if _is_auto_map_parallel_blocks_enabled():
+            if (_is_auto_map_parallel_blocks_enabled()
+                    and not metadata.get("has_auto_blockify_blacklist_op", False)
+                    and not metadata.get("row_coalescing_applied", False)):
                 _compile_option_list += ["--enable-auto-blockify-loop"]
                 if opt.superblock_factor > 1:
                     _compile_option_list += [f"--super-block-factor={opt.superblock_factor}"]

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -530,16 +530,22 @@ static void release_npu_tensor_handle(void* handle) {{
     # and the program-id/grid axis it applies to. Each program now covers H tiles
     # along that axis, so the host shrinks the matching grid dim by H here (the
     # equivalent of what bishengir AutoBlockify used to do via hacc.coalesce_factor;
-    # bishengir no longer touches it). The division is unconditional and mirrors the
-    # old integer division -- the kernel rewrite assumes grid[axis] % H == 0.
+    # bishengir no longer touches it). RowCoalescing can request ceil-div because
+    # its generated row mask handles tail rows.
     coalesce_factor = int(getattr(metadata, "coalesce_factor", 1) or 1)
     coalesce_axis = int(getattr(metadata, "coalesce_axis", -1))
+    coalesce_grid_ceil_div = bool(getattr(metadata, "coalesce_grid_ceil_div", False))
     if coalesce_factor > 1 and coalesce_axis in (0, 1, 2):
         _coalesce_grid_var = {0: "gridX", 1: "gridY", 2: "gridZ"}[coalesce_axis]
+        _coalesce_grid_expr = (
+            f"({_coalesce_grid_var} + {coalesce_factor} - 1) / {coalesce_factor}"
+            if coalesce_grid_ceil_div
+            else f"{_coalesce_grid_var} / {coalesce_factor}"
+        )
         coalesce_grid_div = (
             f"// coalescing: each program covers {coalesce_factor} tiles along "
             f"axis {coalesce_axis}; shrink that grid dim.\n"
-            f"  {_coalesce_grid_var} = {_coalesce_grid_var} / {coalesce_factor};"
+            f"  {_coalesce_grid_var} = {_coalesce_grid_expr};"
         )
     else:
         coalesce_grid_div = ""

--- a/third_party/ascend/include/TritonToLinalg/RowCoalescing.h
+++ b/third_party/ascend/include/TritonToLinalg/RowCoalescing.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ASCEND_ROW_COALESCING_H
+#define TRITON_ASCEND_ROW_COALESCING_H
+
+#include "mlir/Pass/Pass.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+#include <memory>
+
+// RowCoalescing: fold multiple independent logical rows onto one program.
+//
+// Pattern (phenomenon, not a specific kernel name): program_id(axis) represents
+// a row id, and the row id feeds row-local scalar/gather inputs plus row-local
+// vector load/reduce/store work. Rows are independent, so H adjacent row ids can
+// be evaluated as a lane vector:
+//
+//     row  = program_id(axis)
+//   ->
+//     rows = program_id(axis) * H + arange(0, H)
+//
+// Scalar row values become tensor<H>, row-local data tensors become
+// tensor<H x ...>, and intra-row reductions shift their axis by one. The pass is
+// intentionally conservative: it bails if the row-id slice has side effects,
+// cross-row communication, unsupported control flow, or an unsafe use of
+// num_programs(axis).
+namespace RowCoalescing {
+
+void rewriteRowCoalesce(mlir::ModuleOp moduleOp);
+
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
+createRowCoalescingPass();
+
+}  // namespace RowCoalescing
+
+#endif  // TRITON_ASCEND_ROW_COALESCING_H

--- a/third_party/ascend/lib/TritonToLinalg/CMakeLists.txt
+++ b/third_party/ascend/lib/TritonToLinalg/CMakeLists.txt
@@ -11,6 +11,7 @@ add_triton_library(TritonToLinalg
         ImplicitPermute.cpp
         StridedLoadStoreRewrite.cpp
         StridedAxisCoalescing.cpp
+        RowCoalescing.cpp
         TileChunkCoalescing.cpp
         DescriptorConverter
         MarkTensorKindPass.cpp

--- a/third_party/ascend/lib/TritonToLinalg/RowCoalescing.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/RowCoalescing.cpp
@@ -1,0 +1,599 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "TritonToLinalg/RowCoalescing.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <algorithm>
+#include <functional>
+#include <optional>
+
+namespace RowCoalescing {
+
+using namespace mlir;
+using namespace triton;
+
+namespace {
+
+constexpr llvm::StringLiteral kCoalesceFactorAttr = "hacc.coalesce_factor";
+constexpr llvm::StringLiteral kCoalesceAxisAttr = "hacc.coalesce_axis";
+constexpr llvm::StringLiteral kCoalesceGridCeilDivAttr =
+    "hacc.coalesce_grid_ceil_div";
+
+// Start with the empirically best point for the FBGEMM dense-token case. Later
+// revisions should choose H from row footprint, UB budget and launch-grid size.
+constexpr int64_t kDefaultRowsPerProgram = 8;
+constexpr int64_t kMaxBaseElementsPerLift = 1024;
+
+struct RowSeed {
+  triton::GetProgramIdOp pid;
+  int32_t axis = 0;
+  Value validCount;
+  arith::CmpIOp entryGuard;
+  Block *workBlock = nullptr;
+};
+
+static bool readsAxisNumPrograms(ModuleOp moduleOp, int32_t axis) {
+  bool reads = false;
+  moduleOp.walk([&](triton::GetNumProgramsOp np) {
+    if (np.getAxisAsInt() == axis)
+      reads = true;
+  });
+  return reads;
+}
+
+// Match the canonical rowwise guard:
+//
+//   %pid = tt.get_program_id x
+//   %n   = tt.load %valid_count_ptr
+//   %p   = arith.cmpi sge, %pid, %n
+//   cf.cond_br %p, ^return_block, ^work_block
+//
+// This is intentionally a seed matcher only. It proves that pid is a row id
+// guarded by a runtime row count and identifies the work block that should be
+// lifted. The actual IR rewrite is kept separate.
+static std::optional<RowSeed> matchRowSeed(ModuleOp moduleOp) {
+  if (moduleOp->hasAttr(kCoalesceFactorAttr))
+    return std::nullopt;
+
+  SmallVector<triton::GetProgramIdOp> pids;
+  moduleOp.walk([&](triton::GetProgramIdOp pid) { pids.push_back(pid); });
+  if (pids.size() != 1)
+    return std::nullopt;
+
+  triton::GetProgramIdOp pid = pids.front();
+  int32_t axis = pid.getAxisAsInt();
+  if (readsAxisNumPrograms(moduleOp, axis))
+    return std::nullopt;
+
+  for (Operation *user : pid.getResult().getUsers()) {
+    auto cmp = dyn_cast<arith::CmpIOp>(user);
+    if (!cmp || cmp.getPredicate() != arith::CmpIPredicate::sge ||
+        cmp.getLhs() != pid.getResult())
+      continue;
+
+    Block *cmpBlock = cmp->getBlock();
+    if (!cmpBlock || !cmpBlock->mightHaveTerminator())
+      continue;
+    auto cond = dyn_cast_or_null<cf::CondBranchOp>(cmpBlock->getTerminator());
+    if (!cond || cond.getCondition() != cmp.getResult())
+      continue;
+
+    Block *trueBlock = cond.getTrueDest();
+    Block *falseBlock = cond.getFalseDest();
+    if (!trueBlock || !falseBlock)
+      continue;
+    if (!trueBlock->mightHaveTerminator())
+      continue;
+    if (!isa<triton::ReturnOp>(trueBlock->getTerminator()))
+      continue;
+
+    return RowSeed{pid, axis, cmp.getRhs(), cmp, falseBlock};
+  }
+
+  return std::nullopt;
+}
+
+static bool isRowLiftable(Operation *op) {
+  if (isa<triton::ReturnOp, cf::BranchOp, cf::CondBranchOp>(op))
+    return false;
+  if (auto *dialect = op->getDialect()) {
+    StringRef ns = dialect->getNamespace();
+    if (ns == arith::ArithDialect::getDialectNamespace() ||
+        ns == math::MathDialect::getDialectNamespace())
+      return true;
+  }
+  return isa<triton::SplatOp, triton::AddPtrOp, triton::BroadcastOp,
+             triton::ExpandDimsOp, triton::LoadOp, triton::StoreOp,
+             triton::MakeRangeOp, triton::ScanOp, triton::ReduceOp,
+             triton::ClampFOp, triton::FpToFpOp, scf::ForOp>(op);
+}
+
+static bool collectRowRegion(const RowSeed &seed,
+                             SmallVectorImpl<Operation *> &ordered) {
+  if (!seed.workBlock)
+    return false;
+
+  bool hasStore = false;
+  for (Operation &op : seed.workBlock->without_terminator()) {
+    bool safe = true;
+    op.walk([&](Operation *nested) {
+      if (nested == &op)
+        return;
+      if (isa<scf::YieldOp, triton::ReduceReturnOp, triton::ScanReturnOp>(
+              nested))
+        return;
+      if (!isRowLiftable(nested))
+        safe = false;
+    });
+    if (!safe || !isRowLiftable(&op))
+      return false;
+    if (isa<triton::StoreOp>(op))
+      hasStore = true;
+    ordered.push_back(&op);
+  }
+
+  return hasStore;
+}
+
+static int64_t getMaxStaticTensorElements(ArrayRef<Operation *> ordered) {
+  int64_t maxElements = 1;
+  auto update = [&](Type type) {
+    auto rt = dyn_cast<RankedTensorType>(type);
+    if (!rt)
+      return;
+    if (!rt.hasStaticShape()) {
+      maxElements = kMaxBaseElementsPerLift + 1;
+      return;
+    }
+    maxElements = std::max<int64_t>(maxElements, rt.getNumElements());
+  };
+
+  for (Operation *op : ordered) {
+    for (Value operand : op->getOperands())
+      update(operand.getType());
+    for (Value result : op->getResults())
+      update(result.getType());
+  }
+  return maxElements;
+}
+
+static bool rewriteMatchedRow(ModuleOp moduleOp, const RowSeed &seed,
+                              ArrayRef<Operation *> ordered, IRRewriter &rw) {
+  constexpr int64_t H = kDefaultRowsPerProgram;
+
+  triton::GetProgramIdOp pid = seed.pid;
+  Value pidVal = pid.getResult();
+  Location loc = pid.getLoc();
+  Block *pidBlock = seed.pid->getBlock();
+  if (!pidBlock || !seed.workBlock)
+    return false;
+
+  auto liftTy = [&](Type t) -> RankedTensorType {
+    if (auto rt = dyn_cast<RankedTensorType>(t)) {
+      SmallVector<int64_t> shape;
+      shape.push_back(H);
+      shape.append(rt.getShape().begin(), rt.getShape().end());
+      return RankedTensorType::get(shape, rt.getElementType());
+    }
+    return RankedTensorType::get({H}, t);
+  };
+
+  auto makeZero = [&](Location zloc, Type ty) -> Value {
+    OpBuilder::InsertionGuard guard(rw);
+    auto rt = dyn_cast<RankedTensorType>(ty);
+    Type elemTy = rt ? rt.getElementType() : ty;
+    if (auto intTy = dyn_cast<IntegerType>(elemTy)) {
+      TypedAttr zero = IntegerAttr::get(intTy, 0);
+      if (rt)
+        return rw.create<arith::ConstantOp>(
+            zloc, ty, DenseElementsAttr::get(rt, zero));
+      return rw.create<arith::ConstantOp>(zloc, ty, zero);
+    }
+    if (auto fpTy = dyn_cast<FloatType>(elemTy)) {
+      TypedAttr zero = FloatAttr::get(fpTy, 0.0);
+      if (rt)
+        return rw.create<arith::ConstantOp>(
+            zloc, ty, DenseElementsAttr::get(rt, zero));
+      return rw.create<arith::ConstantOp>(zloc, ty, zero);
+    }
+    return Value();
+  };
+
+  if (Operation *validDef = seed.validCount.getDefiningOp())
+    rw.setInsertionPointAfter(validDef);
+  else
+    rw.setInsertionPointAfter(seed.pid);
+  Value cH = rw.create<arith::ConstantIntOp>(loc, H, 32);
+  Value pidH = rw.create<arith::MulIOp>(loc, pidVal, cH);
+  auto hI32Ty = RankedTensorType::get({H}, rw.getI32Type());
+  Value lane = rw.create<triton::MakeRangeOp>(loc, hI32Ty, 0, H);
+  Value pidHSplat = rw.create<triton::SplatOp>(loc, hI32Ty, pidH);
+  Value rows = rw.create<arith::AddIOp>(loc, pidHSplat, lane);
+  Value validSplat = rw.create<triton::SplatOp>(loc, hI32Ty, seed.validCount);
+  Value rowMask = rw.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::slt, rows, validSplat);
+
+  DenseMap<Value, Value> vmap;
+  vmap[pidVal] = rows;
+  vmap[seed.validCount] = validSplat;
+
+  auto maskForType = [&](Location mloc, Type type) -> Value {
+    auto rt = dyn_cast<RankedTensorType>(type);
+    if (!rt)
+      return Value();
+    if (rt.getRank() == 1)
+      return rowMask;
+    Value cur = rowMask;
+    for (int64_t rank = 1; rank < rt.getRank(); ++rank) {
+      cur = rw.create<triton::ExpandDimsOp>(
+          mloc, cur, cast<RankedTensorType>(cur.getType()).getRank());
+    }
+    auto maskTy = RankedTensorType::get(rt.getShape(), rw.getI1Type());
+    return rw.create<triton::BroadcastOp>(mloc, maskTy, cur);
+  };
+
+  std::function<Value(Value, DenseMap<Value, Value> *)> lift =
+      [&](Value v, DenseMap<Value, Value> *localMap) -> Value {
+    if (localMap) {
+      auto lit = localMap->find(v);
+      if (lit != localMap->end())
+        return lit->second;
+    }
+    auto it = vmap.find(v);
+    if (it != vmap.end())
+      return it->second;
+    if (!isa<RankedTensorType>(v.getType()))
+      return v;
+    Value expanded = rw.create<triton::ExpandDimsOp>(v.getLoc(), v, 0);
+    Value broadcast =
+        rw.create<triton::BroadcastOp>(v.getLoc(), liftTy(v.getType()), expanded);
+    if (localMap)
+      (*localMap)[v] = broadcast;
+    else
+      vmap[v] = broadcast;
+    return broadcast;
+  };
+
+  auto liftOperand = [&](Value v, DenseMap<Value, Value> *localMap) -> Value {
+    Value lv = lift(v, localMap);
+    if (!lv)
+      return Value();
+    if (!isa<RankedTensorType>(lv.getType()))
+      return rw.create<triton::SplatOp>(lv.getLoc(), liftTy(v.getType()), lv);
+    return lv;
+  };
+
+  auto copyAttrs = [&](Operation *from, Operation *to) {
+    for (NamedAttribute attr : from->getAttrs())
+      if (!to->hasAttr(attr.getName()))
+        to->setAttr(attr.getName(), attr.getValue());
+  };
+
+  std::function<bool(Operation *, DenseMap<Value, Value> *, bool)> rebuildOp;
+  rebuildOp = [&](Operation *op, DenseMap<Value, Value> *localMap,
+                  bool resetInsertionPoint) -> bool {
+    if (resetInsertionPoint)
+      rw.setInsertionPoint(op);
+    Location opLoc = op->getLoc();
+
+    if (auto range = dyn_cast<triton::MakeRangeOp>(op)) {
+      Value oneD = rw.create<triton::MakeRangeOp>(
+          opLoc, range.getType(), range.getStart(), range.getEnd());
+      Value expanded = rw.create<triton::ExpandDimsOp>(opLoc, oneD, 0);
+      (*localMap)[range.getResult()] =
+          rw.create<triton::BroadcastOp>(opLoc, liftTy(range.getType()),
+                                         expanded);
+      return true;
+    }
+
+    if (auto sp = dyn_cast<triton::SplatOp>(op)) {
+      Value src = lift(sp.getSrc(), localMap);
+      if (!src)
+        return false;
+      Value result;
+      if (!isa<RankedTensorType>(src.getType())) {
+        result = rw.create<triton::SplatOp>(opLoc, liftTy(sp.getType()), src);
+      } else {
+        Value cur = src;
+        int64_t addDims = cast<RankedTensorType>(sp.getType()).getRank();
+        for (int64_t i = 0; i < addDims; ++i) {
+          cur = rw.create<triton::ExpandDimsOp>(
+              opLoc, cur, cast<RankedTensorType>(cur.getType()).getRank());
+        }
+        result = rw.create<triton::BroadcastOp>(opLoc, liftTy(sp.getType()), cur);
+      }
+      (*localMap)[sp.getResult()] = result;
+      return true;
+    }
+
+    if (auto ed = dyn_cast<triton::ExpandDimsOp>(op)) {
+      Value src = liftOperand(ed.getSrc(), localMap);
+      if (!src)
+        return false;
+      (*localMap)[ed.getResult()] = rw.create<triton::ExpandDimsOp>(
+          opLoc, src, ed.getAxis() + 1);
+      return true;
+    }
+
+    if (auto bc = dyn_cast<triton::BroadcastOp>(op)) {
+      Value src = liftOperand(bc.getSrc(), localMap);
+      if (!src)
+        return false;
+      (*localMap)[bc.getResult()] =
+          rw.create<triton::BroadcastOp>(opLoc, liftTy(bc.getType()), src);
+      return true;
+    }
+
+    if (auto red = dyn_cast<triton::ReduceOp>(op)) {
+      SmallVector<Value> srcs;
+      for (Value src : red.getSrcs()) {
+        Value lifted = liftOperand(src, localMap);
+        if (!lifted)
+          return false;
+        srcs.push_back(lifted);
+      }
+      auto nu = rw.create<triton::ReduceOp>(opLoc, srcs, red.getAxis() + 1);
+      rw.cloneRegionBefore(red.getCombineOp(), nu.getCombineOp(),
+                           nu.getCombineOp().end());
+      copyAttrs(red, nu);
+      for (auto [oldR, newR] : llvm::zip(red.getResults(), nu.getResults()))
+        (*localMap)[oldR] = newR;
+      return true;
+    }
+
+    if (auto scan = dyn_cast<triton::ScanOp>(op)) {
+      SmallVector<Value> srcs;
+      for (Value src : scan.getSrcs()) {
+        Value lifted = liftOperand(src, localMap);
+        if (!lifted)
+          return false;
+        srcs.push_back(lifted);
+      }
+      auto nu = rw.create<triton::ScanOp>(opLoc, srcs, scan.getAxis() + 1,
+                                          scan.getReverse());
+      rw.cloneRegionBefore(scan.getCombineOp(), nu.getCombineOp(),
+                           nu.getCombineOp().end());
+      copyAttrs(scan, nu);
+      for (auto [oldR, newR] : llvm::zip(scan.getResults(), nu.getResults()))
+        (*localMap)[oldR] = newR;
+      return true;
+    }
+
+    if (auto ld = dyn_cast<triton::LoadOp>(op)) {
+      Value ptr = liftOperand(ld.getPtr(), localMap);
+      if (!ptr)
+        return false;
+      Value mask = ld.getMask() ? liftOperand(ld.getMask(), localMap) : Value();
+      Value rowMaskForLoad = maskForType(opLoc, cast<ShapedType>(ptr.getType()));
+      if (rowMaskForLoad) {
+        mask = mask ? rw.create<arith::AndIOp>(opLoc, mask, rowMaskForLoad)
+                    : rowMaskForLoad;
+      }
+      Value other = ld.getOther() ? liftOperand(ld.getOther(), localMap)
+                                  : makeZero(opLoc, liftTy(ld.getResult().getType()));
+      auto nu = rw.create<triton::LoadOp>(opLoc, ptr, mask, other,
+                                          ld.getBoundaryCheck(), ld.getPadding(),
+                                          ld.getCache(), ld.getEvict(),
+                                          ld.getIsVolatile());
+      copyAttrs(ld, nu);
+      (*localMap)[ld.getResult()] = nu.getResult();
+      return true;
+    }
+
+    if (auto st = dyn_cast<triton::StoreOp>(op)) {
+      Value ptr = liftOperand(st.getPtr(), localMap);
+      Value val = liftOperand(st.getValue(), localMap);
+      if (!ptr || !val)
+        return false;
+      Value mask = st.getMask() ? liftOperand(st.getMask(), localMap) : Value();
+      Value rowMaskForStore = maskForType(opLoc, cast<ShapedType>(ptr.getType()));
+      if (rowMaskForStore) {
+        mask = mask ? rw.create<arith::AndIOp>(opLoc, mask, rowMaskForStore)
+                    : rowMaskForStore;
+      }
+      rw.create<triton::StoreOp>(opLoc, ptr, val, mask, st.getBoundaryCheck(),
+                                 st.getCache(), st.getEvict());
+      return true;
+    }
+
+    if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+      OpBuilder::InsertionGuard guard(rw);
+      SmallVector<Value> initArgs;
+      for (Value init : forOp.getInitArgs()) {
+        Value lifted = liftOperand(init, localMap);
+        if (!lifted)
+          return false;
+        initArgs.push_back(lifted);
+      }
+      auto newFor = rw.create<scf::ForOp>(opLoc, forOp.getLowerBound(),
+                                          forOp.getUpperBound(), forOp.getStep(),
+                                          initArgs);
+      copyAttrs(forOp, newFor);
+
+      DenseMap<Value, Value> loopMap = *localMap;
+      loopMap[forOp.getInductionVar()] = newFor.getInductionVar();
+      for (auto [oldArg, newArg] :
+           llvm::zip(forOp.getRegionIterArgs(), newFor.getRegionIterArgs())) {
+        loopMap[oldArg] = newArg;
+      }
+
+      Block *oldBody = forOp.getBody();
+      Block *newBody = newFor.getBody();
+      if (!oldBody || !newBody || !oldBody->mightHaveTerminator())
+        return false;
+      if (!newBody->mightHaveTerminator()) {
+        SmallVector<Value> passthrough;
+        for (Value arg : newFor.getRegionIterArgs())
+          passthrough.push_back(arg);
+        rw.setInsertionPointToEnd(newBody);
+        rw.create<scf::YieldOp>(opLoc, passthrough);
+      }
+      if (!newBody->mightHaveTerminator())
+        return false;
+      Operation *newTerm = newBody->getTerminator();
+      rw.setInsertionPoint(newTerm);
+      for (Operation &bodyOp : oldBody->without_terminator()) {
+        if (!rebuildOp(&bodyOp, &loopMap, false))
+          return false;
+      }
+      auto oldYield = cast<scf::YieldOp>(oldBody->getTerminator());
+      SmallVector<Value> yieldVals;
+      for (Value y : oldYield.getResults()) {
+        auto mapped = loopMap.find(y);
+        if (mapped == loopMap.end() || !mapped->second)
+          return false;
+        yieldVals.push_back(mapped->second);
+      }
+      rw.setInsertionPoint(newTerm);
+      rw.create<scf::YieldOp>(oldYield.getLoc(), yieldVals);
+      rw.eraseOp(newTerm);
+
+      for (auto [oldR, newR] : llvm::zip(forOp.getResults(), newFor.getResults()))
+        (*localMap)[oldR] = newR;
+      rw.setInsertionPointAfter(newFor);
+      return true;
+    }
+
+    SmallVector<Value> operands;
+    for (Value operand : op->getOperands()) {
+      Value lifted = liftOperand(operand, localMap);
+      if (!lifted)
+        return false;
+      operands.push_back(lifted);
+    }
+    SmallVector<Type> resultTypes;
+    for (Type resultTy : op->getResultTypes())
+      resultTypes.push_back(liftTy(resultTy));
+    Operation *nu =
+        rw.create(opLoc, op->getName().getIdentifier(), operands, resultTypes,
+                  op->getAttrs());
+    for (auto [oldR, newR] : llvm::zip(op->getResults(), nu->getResults()))
+      (*localMap)[oldR] = newR;
+    return true;
+  };
+
+  DenseMap<Value, Value> topMap;
+  for (Operation *op : ordered) {
+    if (!rebuildOp(op, &topMap, true))
+      return false;
+  }
+
+  Block *entryBlock = seed.entryGuard->getBlock();
+  if (!entryBlock || !entryBlock->mightHaveTerminator())
+    return false;
+  auto cond = dyn_cast<cf::CondBranchOp>(entryBlock->getTerminator());
+  if (!cond)
+    return false;
+  rw.setInsertionPoint(cond);
+  rw.create<cf::BranchOp>(cond.getLoc(), seed.workBlock);
+  rw.eraseOp(cond);
+
+  std::function<void(Operation *)> eraseNestedOps = [&](Operation *op) {
+    for (Region &region : op->getRegions()) {
+      for (Block &block : llvm::make_early_inc_range(region)) {
+        while (!block.empty()) {
+          Operation &nested = block.back();
+          eraseNestedOps(&nested);
+          nested.dropAllUses();
+          rw.eraseOp(&nested);
+        }
+      }
+    }
+  };
+  for (auto it = ordered.rbegin(); it != ordered.rend(); ++it) {
+    Operation *op = *it;
+    eraseNestedOps(op);
+    op->dropAllUses();
+    rw.eraseOp(op);
+  }
+  if (seed.entryGuard->use_empty())
+    rw.eraseOp(seed.entryGuard);
+
+  (void)moduleOp;
+  return true;
+}
+
+static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
+  auto seed = matchRowSeed(moduleOp);
+  if (!seed)
+    return;
+
+  SmallVector<Operation *> ordered;
+  if (!collectRowRegion(*seed, ordered))
+    return;
+  if (getMaxStaticTensorElements(ordered) > kMaxBaseElementsPerLift)
+    return;
+
+  if (!rewriteMatchedRow(moduleOp, *seed, ordered, rw))
+    return;
+
+  auto i32Ty = IntegerType::get(moduleOp.getContext(), 32);
+  moduleOp->setAttr(kCoalesceFactorAttr,
+                    IntegerAttr::get(i32Ty, kDefaultRowsPerProgram));
+  moduleOp->setAttr(kCoalesceAxisAttr, IntegerAttr::get(i32Ty, seed->axis));
+  moduleOp->setAttr(kCoalesceGridCeilDivAttr, IntegerAttr::get(i32Ty, 1));
+}
+
+}  // namespace
+
+void rewriteRowCoalesce(ModuleOp moduleOp) {
+  IRRewriter rw(moduleOp.getContext());
+  rewriteModule(moduleOp, rw);
+}
+
+namespace {
+
+struct RowCoalescingPass
+    : public PassWrapper<RowCoalescingPass, OperationPass<ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(RowCoalescingPass)
+
+  StringRef getArgument() const final { return "triton-row-coalescing"; }
+  StringRef getDescription() const final {
+    return "Fold adjacent independent logical rows into one Triton program";
+  }
+
+  void runOnOperation() override {
+    RowCoalescing::rewriteRowCoalesce(getOperation());
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>> createRowCoalescingPass() {
+  return std::make_unique<RowCoalescingPass>();
+}
+
+}  // namespace RowCoalescing

--- a/third_party/ascend/lib/TritonToLinalg/RowCoalescing.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/RowCoalescing.cpp
@@ -52,8 +52,7 @@ constexpr llvm::StringLiteral kCoalesceAxisAttr = "hacc.coalesce_axis";
 constexpr llvm::StringLiteral kCoalesceGridCeilDivAttr =
     "hacc.coalesce_grid_ceil_div";
 
-// Start with the empirically best point for the FBGEMM dense-token case. Later
-// revisions should choose H from row footprint, UB budget and launch-grid size.
+// Default to the original FBGEMM dense-token point for very small row tiles.
 constexpr int64_t kDefaultRowsPerProgram = 8;
 constexpr int64_t kMaxBaseElementsPerLift = 1024;
 
@@ -64,6 +63,16 @@ struct RowSeed {
   arith::CmpIOp entryGuard;
   Block *workBlock = nullptr;
 };
+
+static int64_t inferRowsPerProgram(int64_t maxBaseElements) {
+  if (maxBaseElements > kMaxBaseElementsPerLift)
+    return 1;
+  if (maxBaseElements >= 1024)
+    return 2;
+  if (maxBaseElements > 16)
+    return 4;
+  return kDefaultRowsPerProgram;
+}
 
 static bool readsAxisNumPrograms(ModuleOp moduleOp, int32_t axis) {
   bool reads = false;
@@ -201,9 +210,10 @@ static int64_t getMaxStaticTensorElements(ArrayRef<Operation *> ordered) {
 }
 
 static bool rewriteMatchedRow(ModuleOp moduleOp, const RowSeed &seed,
-                              ArrayRef<Operation *> ordered, IRRewriter &rw) {
-  constexpr int64_t H = kDefaultRowsPerProgram;
-
+                              ArrayRef<Operation *> ordered, IRRewriter &rw,
+                              int64_t H) {
+  if (H <= 1)
+    return false;
   triton::GetProgramIdOp pid = seed.pid;
   Value pidVal = pid.getResult();
   Location loc = pid.getLoc();
@@ -602,15 +612,17 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
   SmallVector<Operation *> ordered;
   if (!collectRowRegion(*seed, ordered))
     return;
-  if (getMaxStaticTensorElements(ordered) > kMaxBaseElementsPerLift)
+  int64_t maxBaseElements = getMaxStaticTensorElements(ordered);
+  int64_t rowsPerProgram = inferRowsPerProgram(maxBaseElements);
+  if (rowsPerProgram <= 1)
     return;
 
-  if (!rewriteMatchedRow(moduleOp, *seed, ordered, rw))
+  if (!rewriteMatchedRow(moduleOp, *seed, ordered, rw, rowsPerProgram))
     return;
 
   auto i32Ty = IntegerType::get(moduleOp.getContext(), 32);
   moduleOp->setAttr(kCoalesceFactorAttr,
-                    IntegerAttr::get(i32Ty, kDefaultRowsPerProgram));
+                    IntegerAttr::get(i32Ty, rowsPerProgram));
   moduleOp->setAttr(kCoalesceAxisAttr, IntegerAttr::get(i32Ty, seed->axis));
   moduleOp->setAttr(kCoalesceGridCeilDivAttr, IntegerAttr::get(i32Ty, 1));
 }

--- a/third_party/ascend/lib/TritonToLinalg/RowCoalescing.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/RowCoalescing.cpp
@@ -74,6 +74,14 @@ static bool readsAxisNumPrograms(ModuleOp moduleOp, int32_t axis) {
   return reads;
 }
 
+static bool isScalarIntegerLike(Value value) {
+  Type type = value.getType();
+  if (isa<IndexType>(type))
+    return true;
+  auto intTy = dyn_cast<IntegerType>(type);
+  return intTy && intTy.getWidth() > 1;
+}
+
 // Match the canonical rowwise guard:
 //
 //   %pid = tt.get_program_id x
@@ -118,6 +126,8 @@ static std::optional<RowSeed> matchRowSeed(ModuleOp moduleOp) {
     if (!trueBlock->mightHaveTerminator())
       continue;
     if (!isa<triton::ReturnOp>(trueBlock->getTerminator()))
+      continue;
+    if (!isScalarIntegerLike(cmp.getRhs()))
       continue;
 
     return RowSeed{pid, axis, cmp.getRhs(), cmp, falseBlock};
@@ -302,12 +312,28 @@ static bool rewriteMatchedRow(ModuleOp moduleOp, const RowSeed &seed,
         to->setAttr(attr.getName(), attr.getValue());
   };
 
+  auto liftConstant = [&](arith::ConstantOp cst, Location opLoc,
+                          DenseMap<Value, Value> *localMap) -> bool {
+    Operation *nu = rw.clone(*cst.getOperation());
+    Value result = nu->getResult(0);
+    if (isa<RankedTensorType>(cst.getType())) {
+      Value expanded = rw.create<triton::ExpandDimsOp>(opLoc, result, 0);
+      result = rw.create<triton::BroadcastOp>(opLoc, liftTy(cst.getType()),
+                                              expanded);
+    }
+    (*localMap)[cst.getResult()] = result;
+    return true;
+  };
+
   std::function<bool(Operation *, DenseMap<Value, Value> *, bool)> rebuildOp;
   rebuildOp = [&](Operation *op, DenseMap<Value, Value> *localMap,
                   bool resetInsertionPoint) -> bool {
     if (resetInsertionPoint)
       rw.setInsertionPoint(op);
     Location opLoc = op->getLoc();
+
+    if (auto cst = dyn_cast<arith::ConstantOp>(op))
+      return liftConstant(cst, opLoc, localMap);
 
     if (auto range = dyn_cast<triton::MakeRangeOp>(op)) {
       Value oneD = rw.create<triton::MakeRangeOp>(
@@ -431,6 +457,14 @@ static bool rewriteMatchedRow(ModuleOp moduleOp, const RowSeed &seed,
 
     if (auto forOp = dyn_cast<scf::ForOp>(op)) {
       OpBuilder::InsertionGuard guard(rw);
+      Value lowerBound = lift(forOp.getLowerBound(), localMap);
+      Value upperBound = lift(forOp.getUpperBound(), localMap);
+      Value step = lift(forOp.getStep(), localMap);
+      if (!lowerBound || !upperBound || !step ||
+          isa<RankedTensorType>(lowerBound.getType()) ||
+          isa<RankedTensorType>(upperBound.getType()) ||
+          isa<RankedTensorType>(step.getType()))
+        return false;
       SmallVector<Value> initArgs;
       for (Value init : forOp.getInitArgs()) {
         Value lifted = liftOperand(init, localMap);
@@ -438,9 +472,8 @@ static bool rewriteMatchedRow(ModuleOp moduleOp, const RowSeed &seed,
           return false;
         initArgs.push_back(lifted);
       }
-      auto newFor = rw.create<scf::ForOp>(opLoc, forOp.getLowerBound(),
-                                          forOp.getUpperBound(), forOp.getStep(),
-                                          initArgs);
+      auto newFor =
+          rw.create<scf::ForOp>(opLoc, lowerBound, upperBound, step, initArgs);
       copyAttrs(forOp, newFor);
 
       DenseMap<Value, Value> loopMap = *localMap;
@@ -488,15 +521,30 @@ static bool rewriteMatchedRow(ModuleOp moduleOp, const RowSeed &seed,
     }
 
     SmallVector<Value> operands;
+    bool hasTensorOperand = false;
     for (Value operand : op->getOperands()) {
-      Value lifted = liftOperand(operand, localMap);
+      Value lifted = lift(operand, localMap);
       if (!lifted)
         return false;
+      hasTensorOperand |= isa<RankedTensorType>(lifted.getType());
       operands.push_back(lifted);
     }
+    if (hasTensorOperand) {
+      for (size_t idx = 0; idx < operands.size(); ++idx) {
+        if (isa<RankedTensorType>(operands[idx].getType()))
+          continue;
+        Value operand = op->getOperand(idx);
+        operands[idx] = rw.create<triton::SplatOp>(
+            operands[idx].getLoc(), liftTy(operand.getType()), operands[idx]);
+      }
+    }
     SmallVector<Type> resultTypes;
-    for (Type resultTy : op->getResultTypes())
-      resultTypes.push_back(liftTy(resultTy));
+    for (Type resultTy : op->getResultTypes()) {
+      if (hasTensorOperand)
+        resultTypes.push_back(liftTy(resultTy));
+      else
+        resultTypes.push_back(resultTy);
+    }
     Operation *nu =
         rw.create(opLoc, op->getName().getIdentifier(), operands, resultTypes,
                   op->getAttrs());

--- a/third_party/ascend/triton_ascend.cc
+++ b/third_party/ascend/triton_ascend.cc
@@ -14,6 +14,7 @@
 #include "ascend/include/TritonToAnnotation/Passes.h"
 #include "ascend/include/TritonControlFlowOpt/Passes.h"
 #include "ascend/include/TritonToLinalg/Passes.h"
+#include "ascend/include/TritonToLinalg/RowCoalescing.h"
 #include "ascend/include/Dialect/TritonAscend/IR/TritonAscendDialect.h"
 #include "ascend/include/DiscreteMaskAccessConversion/Passes.h"
 #include "ascend/include/TritonToUnstructure/Passes.h"
@@ -329,6 +330,10 @@ void init_triton_ascend_passes_ttir(py::module &&m) {
 
   m.def("add_triton_control_flow_opt", [](mlir::PassManager &pm) {
     pm.addPass(mlir::triton::createTritonControlFlowOptPass());});
+
+  m.def("add_row_coalescing", [](mlir::PassManager &pm) {
+    pm.addPass(RowCoalescing::createRowCoalescingPass());
+  });
 
   m.def("add_triton_to_annotation", [](mlir::PassManager &pm) {
     pm.addPass(mlir::triton::createTritonToAnnotationPass());});


### PR DESCRIPTION

### Summary

Add a generic SIMT RowCoalescing pass for row-wise kernels.

This pass detects the canonical row-guard pattern:
```
mlir
pid = tt.get_program_id(axis)
valid_count = tt.load(...)
if pid >= valid_count:
  return
```


### Motivation
Some row-wise scalar-heavy kernels, such as FBGEMM dense-token gather/scale/fp8-quant, launch one program per row. On Ascend SIMT this can produce too many small programs and poor per-program work density.
RowCoalescing improves this by packing multiple rows into one program:

```
old: row = pid
new: rows = pid * H + [0, H)
```
Current default:

```
H = 8
coalesce_axis = 0
grid = ceil_div(grid, H)
```

### Changes

- Add RowCoalescing TTIR pass.

- Register add_row_coalescing in the Ascend pass pipeline.

- Enable the pass in compile_mode=simt_only.

- Export metadata:coalesce_factor

      1. coalesce_factor
      2. coalesce_axix 
      3.  coalesce_grid_ceil_div
      4.   row_coalescing_applied


- Update launcher grid calculation to use ceil-div when requested.
- Avoid combining RowCoalescing with SIMT auto-blockify.
- Add a conservative guard to skip row lifting when the base static tensor footprint is too large.

### Matching Conditions
The pass only rewrites when:
There is exactly one tt.get_program_id.
The program id is guarded by pid >= valid_count.
The true branch returns immediately.
The false/work block contains only supported row-liftable ops.
The work block contains at least one store.
The kernel does not query num_programs for the same axis.
The row region static tensor footprint is within the current guard threshold.

Unsupported or unsafe patterns are left unchanged.
### Performance
Measured with test_perf profiler on A5, compile_mode=simt_only
<img width="663" height="250" alt="1783007221286" src="https://github.com/user-attachments/assets/7d9f31cb-ce3d-4d72-8322-aa21c4cbfcaf" />




<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
