### PR TITLE
[ssbuffer](feat) add flowOpt pass for data flow optimization

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -222,6 +222,9 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
             metadata["set_workspace_multibuffer"] = 0
             metadata["enable_mixed_cv"] = True
             metadata["disable_auto_inject_block_sync"] = True
+            _enable_opt = metadata["enable_dynamic_cv_flow_opt"]
+            ascend.passes.ttir.set_enable_dynamic_cv_flow_optimization(_enable_opt)
+
             ascend.passes.ttir.add_dynamic_cv_pipeline(pm, compile_on_910_95)
 
         _intra_val = metadata.get("intra_cache_num")
@@ -961,6 +964,7 @@ class NPUOptions:
     enable_mixed_cv: bool = None
     enable_vf_fusion: bool = None
     enable_dynamic_cv_pipeline: bool = True if is_compile_on_910_95 else False
+    enable_dynamic_cv_flow_opt: bool = False
     hfusion_enable_multiple_consumer_fusion: bool = False
     has_auto_blockify_blacklist_op: Optional[bool] = None
     intra_cache_num: int = None

--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/FlowOpt.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/FlowOpt.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ADAPTER_FLOW_OPT_H
+#define TRITON_ADAPTER_FLOW_OPT_H
+
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Pass/Pass.h"
+#include "third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir {
+namespace triton {
+
+class FlowOptPass : public PassWrapper<FlowOptPass, OperationPass<ModuleOp>> {
+public:
+    FlowOptPass() = default;
+
+    void runOnOperation() override;
+
+    void setConditionInfo(ControlFlowConditionInfo *info) { this->info = info; }
+
+    llvm::StringRef getArgument() const override { return "flow-opt"; }
+
+private:
+    // Create new IfOp with updated condition
+    scf::IfOp createNewIfOpWithFlowOptCondition(scf::IfOp oldIfOp, Value newCondition);
+
+    // Build the flow optimization condition
+    Value buildFlowOptCondition(OpBuilder &builder, Location loc, scf::IfOp firstIfOp, 
+                                scf::ForOp forOp, Value originalCondition);
+
+    ControlFlowConditionInfo *info = nullptr;
+};
+
+std::unique_ptr<OperationPass<ModuleOp>> createFlowOptPass();
+
+} // namespace triton
+} // namespace mlir
+
+#endif // TRITON_ADAPTER_FLOW_OPT_H

--- a/third_party/ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h
@@ -121,12 +121,30 @@ public:
   }
 };
 
+// Pass for analyzing flow optimization
+class AnalyzeFlowOptPass : public PassWrapper<AnalyzeFlowOptPass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(AnalyzeFlowOptPass)
+
+  AnalyzeFlowOptPass() = default;
+
+  void runOnOperation() override;
+
+  llvm::StringRef getArgument() const override { return "analyze-flow-opt"; }
+  llvm::StringRef getDescription() const override {
+    return "Analyze and mark flow optimization for main_loop forOps";
+  }
+};
+
 std::unique_ptr<OperationPass<ModuleOp>> createAnalyzeArgsPass();
 std::unique_ptr<OperationPass<ModuleOp>> createAnalyzeFlagPass();
 std::unique_ptr<OperationPass<ModuleOp>> createAnalyzeNamePass();
 std::unique_ptr<OperationPass<ModuleOp>> createAnalyzeCubeContolFLowInputChainPass();
 std::unique_ptr<OperationPass<ModuleOp>> createAnalyzeDataFlowPass();
 std::unique_ptr<OperationPass<ModuleOp>> createAnalyzeScopePass();
+std::unique_ptr<OperationPass<ModuleOp>> createAnalyzeFlowOptPass();
+
+void setEnableDynamicFlowOptimization(bool enable);
 
 void registerAnalyzeDataFlowPasses();
 

--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -53,6 +53,7 @@ inline constexpr llvm::StringLiteral kIntraDeps = "ssbuffer.intraDeps";
 inline constexpr llvm::StringLiteral kMemCrossDeps = "ssbuffer.memCrossDeps";
 inline constexpr llvm::StringLiteral kMayNotExec = "ssbuffer.may_not_exec";
 inline constexpr llvm::StringLiteral kClone = "ssbuffer.clone";
+inline constexpr llvm::StringLiteral kFlowOpt = "ssbuffer.flowOpt";
 static constexpr llvm::StringLiteral kInlinableQuantScaleAttr = "enable_fast_tf32_mul";
 inline constexpr llvm::StringLiteral kHIVMMatmulLimitedInCubeAttr = "hivm.matmul_limited_in_cube";
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition.cpp
@@ -25,6 +25,7 @@
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/CreateIfOps.h"
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/InitDependentMap.h"
  #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/ProcessArgs.h"
+#include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/FlowOpt.h"
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.h"
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateForOps.h"
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.h"
@@ -107,7 +108,12 @@ void AddControlFlowConditionPass::runOnOperation()
   updatePass->setConditionInfo(&info);
   pm.addPass(std::move(updatePass));
 
-  // Step6: Update for loop iteration times based on intraCoreDependentMap
+  // Step6: Apply flow optimization for flow optimization buffers
+  std::unique_ptr<FlowOptPass> flowOptPass(new FlowOptPass());
+  flowOptPass->setConditionInfo(&info);
+  pm.addPass(std::move(flowOptPass));
+
+  // Step7: Update for loop iteration times based on intraCoreDependentMap
   std::unique_ptr<UpdateLoopIterTimesPass> updateLoopIterTimesPass(new UpdateLoopIterTimesPass());
   updateLoopIterTimesPass->setConditionInfo(&info);
   pm.addPass(std::move(updateLoopIterTimesPass));
@@ -134,6 +140,7 @@ void registerAddControlFlowConditionPasses()
     registerPass(createCreateIfOpsPass);
     registerPass(createProcessArgsPass);
     registerPass(createUpdateForOpsPass);
+    registerPass(createFlowOptPass);
     registerPass(createAddControlFlowConditionPass);
 }
 } // namespace triton

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/FlowOpt.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/FlowOpt.cpp
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/FlowOpt.h"
+#include "ascend/include/DynamicCVPipeline/AddControlFlowCondition.h"
+#include "ascend/include/DynamicCVPipeline/Common/BufferCountManager.h"
+#include "third_party/ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
+#include "llvm/Support/Debug.h"
+
+static constexpr const char *DEBUG_TYPE = "FlowOptPass";
+static constexpr int FLOW_OPT_SUCCESS = 0;
+static constexpr int FLOW_OPT_FAILED = -1;
+
+#define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
+#define LDBG(...) \
+  LLVM_DEBUG({ \
+    DBGS(); \
+    llvm::dbgs() << __VA_ARGS__; \
+  })
+
+using namespace mlir;
+using namespace triton;
+
+// Check if IfOp contains sync_block_wait or sync_block_set op
+static bool containsSyncBlockOp(scf::IfOp ifOp) {
+    bool containsSyncBlock = false;
+    ifOp.walk([&](Operation *innerOp) {
+        if (isa<hivm::SyncBlockWaitOp>(innerOp) || isa<hivm::SyncBlockSetOp>(innerOp)) {
+            containsSyncBlock = true;
+            return WalkResult::interrupt();
+        }
+        return WalkResult::advance();
+    });
+    return containsSyncBlock;
+}
+
+// Find ssbuffer.if IfOps in a forOp (non-recursive)
+// Only collects IfOps that contain sync_block_wait or sync_block_set
+// Returns first and second IfOp found in one traversal
+static int findIfOpsInForOp(scf::ForOp forOp, scf::IfOp &firstIfOp, scf::IfOp &secondIfOp)
+{
+    Block *body = forOp.getBody();
+    if (!body) {
+        LDBG("ForOp body is null.\n");
+        return FLOW_OPT_FAILED;
+    }
+
+    int count = 0;
+    for (Operation &op : *body) {
+        // Skip nested operations - only check direct children
+        if (op.getBlock() != body) {
+            continue;
+        }
+
+        if (op.hasAttr(CVPipeline::kIf)) {
+            auto ifOp = dyn_cast<scf::IfOp>(&op);
+            if (!ifOp) {
+                LDBG("Op with ssbuffer.if is not an IfOp: " << op << "\n");
+                return FLOW_OPT_FAILED;
+            }
+            
+            // Only collect IfOps that contain sync_block_wait or sync_block_set
+            if (!containsSyncBlockOp(ifOp)) {
+                continue;
+            }
+            
+            count++;
+            if (count == 1) {
+                firstIfOp = ifOp;
+            } else if (count == 2) {
+                secondIfOp = ifOp;
+                return FLOW_OPT_SUCCESS;
+            }
+        }
+    }
+
+    if (count == 0) {
+        LDBG("No ssbuffer.if IfOp found.\n");
+        return FLOW_OPT_FAILED;
+    } else if (count == 1) {
+        LDBG("Only one ssbuffer.if IfOp found.\n");
+        return FLOW_OPT_FAILED;
+    }
+
+    return FLOW_OPT_SUCCESS;
+}
+
+// Build the flow optimization condition
+Value FlowOptPass::buildFlowOptCondition(OpBuilder &builder, Location loc, 
+                                         scf::IfOp firstIfOp, scf::ForOp forOp, 
+                                         Value originalCondition)
+{
+    // Get counter and loop bounds
+    if (!info || !info->cntArgs.count(firstIfOp)) {
+        LDBG("No counter found for first IfOp in cntArgs.\n");
+        return nullptr;
+    }
+
+    Value counter = info->cntArgs[firstIfOp];
+    Value lowerBound = forOp.getLowerBound();
+    Value upperBound = forOp.getUpperBound();
+    Value step = forOp.getStep();
+
+    // Build condition: counter >= upperBound
+    Value cond1 = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sge, 
+                                                counter, upperBound);
+
+    // Build condition: counter >= lowerBound + step*(opt_num)
+    // opt_num = min(intra-buffer size - 1, cross-buffer size)
+    using BufferCountManager = mlir::triton::BufferCountManager;
+    int intraBufNum = BufferCountManager::getInstance().getBufferCountByType(BufferCountManager::DepType::IntraCore);
+    int crossBufNum = BufferCountManager::getInstance().getBufferCountByType(BufferCountManager::DepType::InterCore);
+    int optInt = std::min(intraBufNum - 1, crossBufNum);
+
+    Value optNum = builder.create<arith::ConstantIntOp>(loc, optInt, step.getType());
+    Value optOffset = builder.create<arith::MulIOp>(loc, step, optNum);
+    Value lowerPlusOffset = builder.create<arith::AddIOp>(loc, lowerBound, optOffset);
+    Value cond2 = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sge,
+                                                counter, lowerPlusOffset);
+
+    // Combine: original AND (cond1 OR cond2)
+    Value orCond = builder.create<arith::OrIOp>(loc, cond1, cond2);
+    Value finalCond = builder.create<arith::AndIOp>(loc, originalCondition, orCond);
+
+    return finalCond;
+}
+
+// Create new IfOp with updated condition
+scf::IfOp FlowOptPass::createNewIfOpWithFlowOptCondition(scf::IfOp oldIfOp, Value newCondition)
+{
+    Location loc = oldIfOp.getLoc();
+    OpBuilder builder(oldIfOp);
+
+    // Get result types and create new IfOp
+    SmallVector<Type> resultTypes;
+    for (Value result : oldIfOp.getResults()) {
+        resultTypes.push_back(result.getType());
+    }
+
+    bool hasElse = oldIfOp.getElseRegion().hasOneBlock();
+    scf::IfOp newIfOp = builder.create<scf::IfOp>(loc, resultTypes, newCondition, hasElse);
+
+    // Copy attributes
+    for (auto &attr : oldIfOp->getAttrs()) {
+        newIfOp->setAttr(attr.getName(), attr.getValue());
+    }
+
+    // Move then block operations
+    Block &oldThenBlock = oldIfOp.getThenRegion().front();
+    Block &newThenBlock = newIfOp.getThenRegion().front();
+
+    Operation *oldThenYield = nullptr;
+    SmallVector<Value> thenYieldOperands;
+    for (Operation &op : oldThenBlock) {
+        if (isa<scf::YieldOp>(op)) {
+            oldThenYield = &op;
+            auto yieldOp = cast<scf::YieldOp>(op);
+            thenYieldOperands.assign(yieldOp.getOperands().begin(), 
+                                     yieldOp.getOperands().end());
+            break;
+        }
+    }
+
+    for (Operation &op : llvm::make_early_inc_range(oldThenBlock)) {
+        if (&op != oldThenYield) {
+            op.moveBefore(&newThenBlock, newThenBlock.end());
+        }
+    }
+
+    OpBuilder thenBuilder(&newThenBlock, newThenBlock.end());
+    thenBuilder.create<scf::YieldOp>(loc, thenYieldOperands);
+
+    // Move else block operations if exists
+    if (hasElse) {
+        Block &oldElseBlock = oldIfOp.getElseRegion().front();
+        Block &newElseBlock = newIfOp.getElseRegion().front();
+
+        Operation *oldElseYield = nullptr;
+        SmallVector<Value> elseYieldOperands;
+        for (Operation &op : oldElseBlock) {
+            if (isa<scf::YieldOp>(op)) {
+                oldElseYield = &op;
+                auto yieldOp = cast<scf::YieldOp>(op);
+                elseYieldOperands.assign(yieldOp.getOperands().begin(), 
+                                         yieldOp.getOperands().end());
+                break;
+            }
+        }
+
+        for (Operation &op : llvm::make_early_inc_range(oldElseBlock)) {
+            if (&op != oldElseYield) {
+                op.moveBefore(&newElseBlock, newElseBlock.end());
+            }
+        }
+
+        OpBuilder elseBuilder(&newElseBlock, newElseBlock.end());
+        elseBuilder.create<scf::YieldOp>(loc, elseYieldOperands);
+    }
+
+    // Replace all uses of old IfOp results with new IfOp results
+    for (size_t i = 0; i < oldIfOp.getNumResults(); ++i) {
+        oldIfOp.getResult(i).replaceAllUsesWith(newIfOp.getResult(i));
+    }
+
+    return newIfOp;
+}
+
+void FlowOptPass::runOnOperation()
+{
+    ModuleOp module = getOperation();
+
+    LDBG("Enter FlowOpt pass.\n");
+    SmallVector<scf::ForOp> mainLoopForOps;
+    module.walk([&](scf::ForOp forOp) {
+        if (forOp->hasAttr(CVPipeline::kMainLoop)) {
+            mainLoopForOps.push_back(forOp);
+        }
+    });
+
+    for (scf::ForOp forOp : mainLoopForOps) {
+        // Step 1: Check if this forOp has ssbuffer.flowOpt attribute
+        if (!forOp->hasAttr(CVPipeline::kFlowOpt)) {
+            continue;
+        }
+        // Step 2: Find first and second ssbuffer.if IfOps
+        scf::IfOp firstIfOp = nullptr;
+        scf::IfOp secondIfOp = nullptr;
+        if (findIfOpsInForOp(forOp, firstIfOp, secondIfOp) != FLOW_OPT_SUCCESS) {
+            LDBG("Failed to find first and second ssbuffer.if IfOps.\n");
+            signalPassFailure();
+            return;
+        }
+
+        // Step 3: Get the original condition of the second IfOp
+        Value originalCondition = secondIfOp.getCondition();
+        if (!originalCondition) {
+            LDBG("Second IfOp has no condition.\n");
+            signalPassFailure();
+            return;
+        }
+
+        // Step 4: Build the new flow optimization condition
+        OpBuilder builder(secondIfOp);
+        Location loc = secondIfOp.getLoc();
+        Value newCondition = buildFlowOptCondition(builder, loc, firstIfOp, 
+                                                    forOp, originalCondition);
+        if (!newCondition) {
+            LDBG("Failed to build flow optimization condition.\n");
+            signalPassFailure();
+            return;
+        }
+
+        // Step 5: Create new IfOp with the updated condition
+        scf::IfOp newIfOp = createNewIfOpWithFlowOptCondition(secondIfOp, newCondition);
+        if (!newIfOp) {
+            LDBG("Failed to create new IfOp.\n");
+            signalPassFailure();
+            return;
+        }
+
+        // Step 6: Update cntArgs mapping if the second IfOp has a counter
+        if (info->cntArgs.count(secondIfOp)) {
+            Value counter = info->cntArgs[secondIfOp];
+            info->cntArgs.erase(secondIfOp);
+            info->cntArgs[newIfOp] = counter;
+        }
+
+        secondIfOp.erase();
+    }
+
+    LDBG("Exit FlowOpt pass.\n");
+}
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<OperationPass<ModuleOp>> createFlowOptPass()
+{
+    return std::make_unique<FlowOptPass>();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
@@ -314,6 +314,7 @@ static int collectTransferChains(const SmallVector<Operation *> &ops,
             info.receiver.transferOp = op;
             info.receiver.waitOp = findSyncOpWithFlag(block, op, originalFlag, false, true);
             info.receiver.setOp = findSyncOpWithFlag(block, op, originalFlag, true, false);
+            info.receiver.toTensorOp = findToTensorAfter(block, op);
             LDBG("Receiver chain (CUBE): convert_layout, flag=" << originalFlag);
         }
     }
@@ -511,6 +512,7 @@ static int attachSsbufferTags(Operation *op, int blockId, int transferId)
     MLIRContext* ctx = op->getContext();
     op->setAttr("ssbuffer.block_id", IntegerAttr::get(IntegerType::get(ctx, kBits32), blockId));
     op->setAttr("ssbuffer.transfer_id", IntegerAttr::get(IntegerType::get(ctx, kBits32), transferId));
+    op->setAttr("ssbuffer.analyze_flag_id", UnitAttr::get(ctx));
     return 0;
 }
 
@@ -704,6 +706,10 @@ static Operation *wrapSyncOpWithScfIf(Operation *op, Value cond, int outputFlag,
         cloned->setAttr("ssbuffer.transfer_id", builder.getI32IntegerAttr(tid));
         altOp->setAttr("ssbuffer.transfer_id", builder.getI32IntegerAttr(tid));
     }
+    if (op->hasAttr("ssbuffer.analyze_flag_id")) {
+        cloned->setAttr("ssbuffer.analyze_flag_id", builder.getUnitAttr());
+        altOp->setAttr("ssbuffer.analyze_flag_id", builder.getUnitAttr());
+    }
 
     op->replaceAllUsesWith(ifOp.getOperation());
     op->erase();
@@ -803,6 +809,94 @@ static Operation *wrapTransferOpWithScfIfSimple(Operation *transferOp, Value con
     return ifOp.getOperation();
 }
 
+/// Wrap a receiver transfer chain (transferOp + trailing memspace_cast + to_tensor)
+/// in scf.if so that the if returns tensor type directly.
+static Operation *wrapReceiverChainWithScfIf(Operation *transferOp, Operation *toTensorOp,
+    Value cond, Value inputBuffer, Value outputBuffer,
+    int bid, int tid, OpBuilder &builder)
+{
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPoint(transferOp);
+    Location loc = transferOp->getLoc();
+
+    // Collect the chain from transferOp to toTensorOp: ops whose result flows
+    // into toTensorOp (e.g. memref.memory_space_cast between convert_layout and
+    // bufferization.to_tensor for V→C transfers).
+    SmallVector<Operation *> trailingOps;
+    Value curVal = transferOp->getResult(0);
+    while (curVal != toTensorOp->getOperand(0)) {
+        bool found = false;
+        for (auto &use : curVal.getUses()) {
+            Operation *user = use.getOwner();
+            if (user->isBeforeInBlock(toTensorOp) || user == toTensorOp) {
+                curVal = user->getResult(0);
+                if (user != toTensorOp)
+                    trailingOps.push_back(user);
+                found = true;
+                break;
+            }
+        }
+        if (!found) break;
+    }
+
+    auto tensorType = toTensorOp->getResult(0).getType();
+    auto ifOp = builder.create<scf::IfOp>(loc, tensorType, cond, true /* withElseRegion */);
+
+    // then branch: use inputBuffer → clone chain + to_tensor
+    {
+        auto thenBuilder = ifOp.getThenBodyBuilder();
+        IRMapping inputMap;
+        if (transferOp->getNumOperands() > 0)
+            inputMap.map(transferOp->getOperand(transferOp->getNumOperands() - 1), inputBuffer);
+        Operation *clonedTransfer = thenBuilder.clone(*transferOp, inputMap);
+        Value chainResult = clonedTransfer->getResult(0);
+        auto thenMapper = inputMap;
+        thenMapper.map(transferOp->getResult(0), chainResult);
+        for (Operation *op : trailingOps) {
+            Operation *cloned = thenBuilder.clone(*op, thenMapper);
+            thenMapper.map(op->getResult(0), cloned->getResult(0));
+        }
+        Operation *clonedToTensor = thenBuilder.clone(*toTensorOp, thenMapper);
+        thenBuilder.create<scf::YieldOp>(loc, clonedToTensor->getResult(0));
+    }
+
+    // else branch: use outputBuffer → clone chain + to_tensor
+    {
+        auto elseBuilder = ifOp.getElseBodyBuilder();
+        IRMapping outputMap;
+        if (transferOp->getNumOperands() > 0)
+            outputMap.map(transferOp->getOperand(transferOp->getNumOperands() - 1), outputBuffer);
+        Operation *clonedTransfer = elseBuilder.clone(*transferOp, outputMap);
+        Value chainResult = clonedTransfer->getResult(0);
+        auto elseMapper = outputMap;
+        elseMapper.map(transferOp->getResult(0), chainResult);
+        for (Operation *op : trailingOps) {
+            Operation *cloned = elseBuilder.clone(*op, elseMapper);
+            elseMapper.map(op->getResult(0), cloned->getResult(0));
+        }
+        Operation *clonedToTensor = elseBuilder.clone(*toTensorOp, elseMapper);
+        elseBuilder.create<scf::YieldOp>(loc, clonedToTensor->getResult(0));
+    }
+
+    // Tag
+    ifOp->setAttr("ssbuffer.block_id", builder.getI32IntegerAttr(bid));
+    ifOp->setAttr("ssbuffer.transfer_id", builder.getI32IntegerAttr(tid));
+    ifOp->setAttr("ssbuffer.cross_buffer", builder.getI32IntegerAttr(1));
+    ifOp->setAttr("ssbuffer.crossDeps", builder.getArrayAttr({
+        builder.getI32IntegerAttr(tid),
+        builder.getI32IntegerAttr(0)
+    }));
+
+    // Replace and erase from outermost to innermost to avoid use-after-free
+    toTensorOp->getResult(0).replaceAllUsesWith(ifOp.getResult(0));
+    toTensorOp->erase();
+    for (Operation *op : llvm::reverse(trailingOps))
+        op->erase();
+    transferOp->erase();
+
+    return ifOp.getOperation();
+}
+
 /// Process polling for a sender or receiver transfer chain
 static int processTransferChain(TransferOpChain &chain, Value cond,
     Value inputBuffer, Value outputBuffer,
@@ -826,15 +920,26 @@ static int processTransferChain(TransferOpChain &chain, Value cond,
     if (chain.transferOp) {
         int bid = getBlockId(chain.transferOp);
         int tid = getTransferId(chain.transferOp);
-        bool hasExternalUses = !chain.transferOp->getResults().empty() &&
-                               !chain.transferOp->getResult(0).getUses().empty();
 
-        LDBG("transferOp: " << chain.transferOp->getName()
-                     << ", hasExternalUses=" << hasExternalUses);
+        // For receiver chains with toTensorOp, wrap the full chain
+        // (transferOp → memspace_cast → to_tensor) so the scf.if returns tensor.
+        if (!isProducer && chain.toTensorOp) {
+            LDBG("transferOp: " << chain.transferOp->getName() << " (receiver, wrapping to_tensor)");
+            chain.transferOp = wrapReceiverChainWithScfIf(
+                chain.transferOp, chain.toTensorOp,
+                cond, inputBuffer, outputBuffer, bid, tid, builder);
+            chain.toTensorOp = nullptr;
+        } else {
+            bool hasExternalUses = !chain.transferOp->getResults().empty() &&
+                                   !chain.transferOp->getResult(0).getUses().empty();
 
-        chain.transferOp = hasExternalUses
-            ? wrapTransferOpWithScfIfYield(chain.transferOp, cond, inputBuffer, outputBuffer, bid, tid, isProducer, builder)
-            : wrapTransferOpWithScfIfSimple(chain.transferOp, cond, inputBuffer, outputBuffer, bid, tid, isProducer, builder);
+            LDBG("transferOp: " << chain.transferOp->getName()
+                         << ", hasExternalUses=" << hasExternalUses);
+
+            chain.transferOp = hasExternalUses
+                ? wrapTransferOpWithScfIfYield(chain.transferOp, cond, inputBuffer, outputBuffer, bid, tid, isProducer, builder)
+                : wrapTransferOpWithScfIfSimple(chain.transferOp, cond, inputBuffer, outputBuffer, bid, tid, isProducer, builder);
+        }
     }
 
     // 3. Wrap setOp in polling if

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow.cpp
@@ -47,6 +47,8 @@ void AnalyzeDataFlowPass::runOnOperation()
 
   pm.addPass(createAnalyzeFlagPass());
 
+  pm.addPass(createAnalyzeFlowOptPass());
+
   pm.addPass(createAnalyzeCubeContolFLowInputChainPass());
 
   if (failed(runPipeline(pm, module))) {
@@ -72,6 +74,7 @@ void registerAnalyzeDataFlowPasses()
   registerPass(createAnalyzeScopePass);
   registerPass(createAnalyzeDataFlowPass);
   registerPass(createAnalyzeCubeContolFLowInputChainPass);
+  registerPass(createAnalyzeFlowOptPass);
 }
 
 } // namespace triton

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeFlowOpt.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeFlowOpt.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/Common/BufferCountManager.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "bishengir/Dialect/Scope/IR/Scope.h"
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Debug.h"
+
+static constexpr const char *DEBUG_TYPE = "analyze-flow-opt";
+#define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
+#define LDBG(...)                    \
+    LLVM_DEBUG({                     \
+        DBGS();                      \
+        llvm::dbgs() << __VA_ARGS__; \
+        llvm::dbgs() << "\n";        \
+    })
+
+using namespace mlir;
+using namespace triton;
+using namespace CVPipeline;
+
+// Global flag to control whether flow optimization is enabled
+// Defined in mlir::triton namespace, accessible via using namespace
+namespace mlir {
+namespace triton {
+static bool g_enableFlowOptimization = false;
+} // namespace triton
+} // namespace mlir
+
+namespace {
+
+// Check if scopeOp has CUBE tcore_type
+static bool isCubeScope(scope::ScopeOp scopeOp)
+{
+    auto coreTypeAttr = scopeOp->getAttrOfType<hivm::TCoreTypeAttr>(hivm::TCoreTypeAttr::name);
+    if (!coreTypeAttr) {
+        return false;
+    }
+    return coreTypeAttr.getTcoretype() == hivm::TCoreType::CUBE;
+}
+
+// Add flowOpt attribute to main_loop forOps inside CUBE scope
+static void addFlowOptAttrToMainLoop(ModuleOp module)
+{
+    module.walk([&](scope::ScopeOp scopeOp) {
+        // Check if this scope is CUBE
+        if (!isCubeScope(scopeOp)) {
+            return;
+        }
+        
+        LDBG("[INFO]: Found CUBE scope, adding flowOpt attribute to main_loop forOps inside");
+        
+        // Walk inside the scope to find main_loop forOps
+        scopeOp.walk([&](scf::ForOp forOp) {
+            if (forOp->hasAttr(CVPipeline::kMainLoop)) {
+                LDBG("[INFO]: Adding flowOpt attribute to main_loop forOp in CUBE scope");
+                forOp->setAttr(CVPipeline::kFlowOpt, Builder(module.getContext()).getUnitAttr());
+            }
+        });
+    });
+}
+
+} // namespace
+
+void AnalyzeFlowOptPass::runOnOperation()
+{
+    ModuleOp module = getOperation();
+
+    if (g_enableFlowOptimization) {
+        LDBG("[INFO]: Flow optimization is enabled!");
+        LDBG("Before AnalyzeFlowOpt:\n" << module << "\n");
+        addFlowOptAttrToMainLoop(module);
+        LDBG("After AnalyzeFlowOpt:\n" << module << "\n");
+    }
+}
+
+namespace mlir {
+namespace triton {
+
+// Set the global flag for flow optimization
+void setEnableDynamicFlowOptimization(bool enable)
+{
+    g_enableFlowOptimization = enable;
+    LLVM_DEBUG({
+        llvm::dbgs() << "[analyze-flow-opt] [INFO]: setEnableDynamicFlowOptimization called with value: " << enable << "\n";
+    });
+}
+
+std::unique_ptr<OperationPass<ModuleOp>> createAnalyzeFlowOptPass()
+{
+    return std::make_unique<AnalyzeFlowOptPass>();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/triton_ascend.cc
+++ b/third_party/ascend/triton_ascend.cc
@@ -23,6 +23,7 @@
 
 #include "ascend/include/DynamicCVPipeline/Passes.h"
 #include "ascend/include/DynamicCVPipeline/Common/BufferCountManager.h"
+#include "ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h"
 
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "ir.h" // TritonOpBuilder
@@ -387,6 +388,10 @@ void init_triton_ascend_passes_ttir(py::module &&m) {
       mlir::triton::BufferCountManager::getInstance().setBufferCount(
           mlir::triton::BufferCountManager::DepType::LoadStore, count);
     }
+  });
+
+  m.def("set_enable_dynamic_cv_flow_optimization", [](bool enable) {
+    mlir::triton::setEnableDynamicFlowOptimization(enable);
   });
 }
 

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/crossCoreDeps_flow_opt_test.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddControlFlowCondition/crossCoreDeps_flow_opt_test.mlir
@@ -1,0 +1,143 @@
+// RUN: triton-opt --add-control-flow-condition %s | FileCheck %s
+
+// Unit Tests for AddControlFlowCondition Pass - Cross Core Dependencies Test
+//
+// This test verifies:
+// 1. ssbuffer initialization at scope start (constants 0, 0, 1024, 4, 1028, 8, 1032)
+// 2. if condition calculation before scf.if (llvm.load, arith.cmpi)
+// 3. update operations at end of wrapped compute ops (llvm.load, arith.subi/arith.addi, llvm.store)
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @_attn_fwd(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %arg2: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg3: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg4: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}, %arg5: memref<?xf32> {tt.divisibility = 16 : i32}, %arg6: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg7: memref<?xf16> {tt.divisibility = 16 : i32, tt.tensor_kind = 1 : i32}, %arg8: memref<?xi32> {tt.divisibility = 16 : i32}, %arg9: i32, %arg10: i32, %arg11: i32, %arg12: i32, %arg13: i32, %arg14: i32, %arg15: i32) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %c8192_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 8192 : i32
+    %c128_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 128 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 8 : i32} 0 : i32
+    // ssbuffer init
+    // CHECK:       %[[ZERO:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:       %[[ADDR0:.*]] = llvm.mlir.constant(0 : i64) : i64
+    // CHECK:       %[[ADDR1:.*]] = llvm.mlir.constant(1024 : i64) : i64
+    // CHECK:       %[[PTR0:.*]] = llvm.inttoptr %[[ADDR0]] : i64 to !llvm.ptr<11>
+    // CHECK:       %[[PTR1:.*]] = llvm.inttoptr %[[ADDR1]] : i64 to !llvm.ptr<11>
+    // CHECK:       llvm.store volatile %[[ZERO]], %[[PTR0]] : i32, !llvm.ptr<11>
+    // CHECK:       llvm.store volatile %[[ZERO]], %[[PTR1]] : i32, !llvm.ptr<11>
+    // CHECK:       %[[ADDR2:.*]] = llvm.mlir.constant(4 : i64) : i64
+    // CHECK:       %[[ADDR3:.*]] = llvm.mlir.constant(1028 : i64) : i64
+    // CHECK:       %[[PTR2:.*]] = llvm.inttoptr %[[ADDR2]] : i64 to !llvm.ptr<11>
+    // CHECK:       %[[PTR3:.*]] = llvm.inttoptr %[[ADDR3]] : i64 to !llvm.ptr<11>
+    // CHECK:       llvm.store volatile %[[ZERO]], %[[PTR2]] : i32, !llvm.ptr<11>
+    // CHECK:       llvm.store volatile %[[ZERO]], %[[PTR3]] : i32, !llvm.ptr<11>
+    // CHECK:       %[[ADDR4:.*]] = llvm.mlir.constant(8 : i64) : i64
+    // CHECK:       %[[ADDR5:.*]] = llvm.mlir.constant(1032 : i64) : i64
+    // CHECK:       %[[PTR4:.*]] = llvm.inttoptr %[[ADDR4]] : i64 to !llvm.ptr<11>
+    // CHECK:       %[[PTR5:.*]] = llvm.inttoptr %[[ADDR5]] : i64 to !llvm.ptr<11>
+    // CHECK:       llvm.store volatile %[[ZERO]], %[[PTR4]] : i32, !llvm.ptr<11>
+    // CHECK:       llvm.store volatile %[[ZERO]], %[[PTR5]] : i32, !llvm.ptr<11>
+    scope.scope : () -> () {
+      // Vector scope only process each vector core's ssbuffer ptr
+      // CHECK:       arith.constant 1024
+      // CHECK:       hivm.hir.get_sub_block_idx
+      // CHECK:       arith.muli
+      // CHECK:       arith.addi
+      // CHECK:       llvm.inttoptr
+      %alloc = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_5 = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 1 : i32, ssbuffer.crossDeps = [0 : i32, 1 : i32]} : memref<128x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_5 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+      %alloc_6 = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 2 : i32, ssbuffer.crossDeps = [1 : i32, 1 : i32]} : memref<128x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_6 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+      %30:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
+        // This block contain an input and a output
+        // CHECK:       llvm.load
+        // CHECK:       arith.cmpi sgt
+        // CHECK:       llvm.load
+        // CHECK:       arith.cmpi slt
+        // CHECK:       scf.if
+        hivm.hir.sync_block_set {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 4
+        %memspacecast_11 = memref.memory_space_cast %alloc_5 {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 1 : i32, ssbuffer.crossDeps = [0 : i32, 0 : i32]} : memref<128x128xf32, #hivm.address_space<ub>> to memref<128x128xf32>
+        %reshape_13 = tensor.empty() {ssbuffer.block_id = 5 : i32} : tensor<8x8x16x16xf16>
+        hivm.hir.copy ins(%reshape_13 : tensor<8x8x16x16xf16>) outs(%alloc : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 5 : i32, ssbuffer.transfer_id = 0 : i32}
+        // CHECK:       llvm.load
+        // CHECK:       arith.subi
+        // CHECK:       llvm.store
+        // CHECK:       llvm.load
+        // CHECK:       arith.addi
+        // CHECK:       llvm.store
+        // CHECK:       } {hivm.matmul_limited_in_cube, ssbuffer.if = 5 : i32}
+
+        // This block only contain an input
+        // CHECK:       llvm.load
+        // CHECK:       arith.cmpi sgt
+        // CHECK:       scf.if
+        hivm.hir.sync_block_set {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 3 : i32}[<VECTOR>, <PIPE_V>, <PIPE_FIX>] flag = 4
+        %memspacecast_16 = memref.memory_space_cast %alloc_6 {ssbuffer.block_id = 6 : i32, ssbuffer.transfer_id = 2 : i32, ssbuffer.crossDeps = [1, 0]} : memref<128x128xf32, #hivm.address_space<ub>> to memref<128x128xf32>
+        // CHECK:       llvm.load
+        // CHECK:       arith.subi
+        // CHECK:       llvm.store
+        // CHECK:       } {hivm.matmul_limited_in_cube, ssbuffer.if = 6 : i32}
+        scf.yield %arg17, %arg18 : i32, i32
+      } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    scope.scope : () -> () {
+      %alloc_5 = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 0 : i32, ssbuffer.crossDeps = [2 : i32, 1 : i32]} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+      annotation.mark %alloc_5 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 0 : i32} : memref<8x8x16x16xf16, #hivm.address_space<cbuf>>
+      %alloc_6 = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_6 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 1 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+      %alloc_7 = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+      annotation.mark %alloc_7 {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 9 : i32, ssbuffer.transfer_id = 2 : i32} : memref<128x128xf32, #hivm.address_space<ub>>
+      %20:2 = scf.for %arg16 = %c0_i32 to %c8192_i32 step %c128_i32 iter_args(%arg17 = %c0_i32, %arg18 = %c0_i32) -> (i32, i32)  : i32 {
+        // This block contain a output
+        // in CUBE scope, it need to process two ssbuffer ptr
+        // CHECK:       llvm.load
+        // CHECK:       llvm.load
+        // CHECK:       arith.cmpi slt
+        // CHECK:       arith.cmpi slt
+        // CHECK:       scf.if
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 0 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+        %30 = tensor.empty() {ssbuffer.block_id = 0 : i32} : tensor<128x128xf32>
+        hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 0 : i32, ssbuffer.transfer_id = 1 : i32} ins(%30 : tensor<128x128xf32>) outs(%alloc_6 : memref<128x128xf32, #hivm.address_space<ub>>)
+        // CHECK:       llvm.load
+        // CHECK:       llvm.load
+        // CHECK:       arith.addi
+        // CHECK:       arith.addi
+        // CHECK:       llvm.store
+        // CHECK:       llvm.store
+        // CHECK:       } {hivm.matmul_limited_in_cube, ssbuffer.if = 0 : i32}
+
+        // This block contain an input and a output
+        // CHECK:       llvm.load
+        // CHECK:       llvm.load
+        // CHECK:       arith.cmpi sgt
+        // CHECK:       arith.cmpi sgt
+        // CHECK:       llvm.load
+        // CHECK:       llvm.load
+        // CHECK:       arith.cmpi slt
+        // CHECK:       arith.cmpi slt
+        // CHECK:       arith.cmpi sge
+        // CHECK:       arith.cmpi sge
+        // CHECK:       arith.ori
+        // CHECK:       scf.if
+        hivm.hir.sync_block_wait {ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 1 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = 2
+        %32 = hivm.hir.convert_layout %alloc_5 output_shape [128, 128] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 0 : i32, ssbuffer.crossDeps = [2 : i32, 0 : i32]} : (memref<8x8x16x16xf16, #hivm.address_space<cbuf>>) -> memref<128x128xf16, #hivm.address_space<cbuf>>
+        %40 = tensor.empty() {ssbuffer.block_id = 1 : i32} : tensor<128x128xf32>
+        hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 1 : i32, ssbuffer.transfer_id = 2 : i32} ins(%40 : tensor<128x128xf32>) outs(%alloc_7 : memref<128x128xf32, #hivm.address_space<ub>>)
+        // CHECK:       llvm.load
+        // CHECK:       llvm.load
+        // CHECK:       arith.subi
+        // CHECK:       arith.subi
+        // CHECK:       llvm.store
+        // CHECK:       llvm.store
+        // CHECK:       llvm.load
+        // CHECK:       llvm.load
+        // CHECK:       arith.addi
+        // CHECK:       arith.addi
+        // CHECK:       llvm.store
+        // CHECK:       llvm.store
+        // CHECK:       } {hivm.matmul_limited_in_cube, ssbuffer.if = 1 : i32}
+        scf.yield %arg17, %arg18 : i32, i32
+      } {ssbuffer.block_id = 9 : i32, ssbuffer.main_loop = 0 : i64, ssbuffer.flowOpt}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+    return {ssbuffer.core_type = "VECTOR"}
+  }
+}


### PR DESCRIPTION
[ssbuffer](feat) add flowOpt pass for data flow optimization
1. Fix the failure of vector splitting into two kernel caused by incorrect op placement when multiple cross-core buffers exist.
2. Add pipeline optimization for SSBuffer under scenarios with multiple intra-core and cross-core buffers.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
