### PR TITLE
[ssbuffer](fix) Opt for more a*b+c cases

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -453,6 +453,7 @@ int OpClassifierPass::patternMatchCUBE()
             for (Operation *user : result.getUsers()) {
                 // If user is scf.yield, follow the chain to find real users
                 Operation *curUser = user;
+                Value prevResult = result;
                 while (curUser) {
                     if (!allResultHasOneUser(curUser)) {
                         break;
@@ -461,7 +462,6 @@ int OpClassifierPass::patternMatchCUBE()
                         if (Operation *scfOp = yieldOp->getParentOp()) {
                             // Find which operand index the previous result corresponds to in the yield
                             unsigned yieldOperandIdx = 0;
-                            Value prevResult = result;
                             for (unsigned i = 0; i < yieldOp->getNumOperands(); ++i) {
                                 if (yieldOp->getOperand(i) == prevResult) {
                                     yieldOperandIdx = i;

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
@@ -34,6 +34,7 @@
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include "bishengir/Dialect/Utils/Util.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -64,6 +65,8 @@ using namespace CVSplit;
 
 static constexpr const char *DEBUG_TYPE = "SplitMatmul";
 #define LOG_DEBUG(...) LLVM_DEBUG(llvm::dbgs() << "\n[" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
+
+constexpr llvm::StringLiteral kMatmulAtLeastOnceHint = "matmul_at_least_once";
 
 namespace {
 
@@ -554,6 +557,9 @@ static std::optional<SplitInfo> shouldSplit(linalg::MatmulOp matmulOp, bool need
     bool mayNotExec = false;
     Value outerInValue = matmulInput.bias;
     auto outerOutValue = searchInArgsChain(matmulOp.getResult(0), argsLimitedInMatmul, mayNotExec, outerInValue);
+    if (utils::getAnnotateOpWithAttr(outerOutValue, kMatmulAtLeastOnceHint).has_value()) {
+        mayNotExec = false;
+    }
     if (!argsLimitedInMatmul) {
         LOG_DEBUG("Split because bias is not limited in args" << matmulOp); // S25
         return SplitInfo {mayNotExec, outerInValue, outerOutValue, true};
@@ -691,6 +697,17 @@ LogicalResult SplitMatmulPattern::matchAndRewrite(linalg::MatmulOp matmulOp, Pat
     LOG_DEBUG("shouldSplit = " << splitInfo.shouldSplit);
     LOG_DEBUG("-------------------");
     matmulOp->setAttr(CVPipeline::kLoopCarriedL0C, rewriter.getUnitAttr());
+
+    if (auto markOpOpt = utils::getAnnotateOpWithAttr(splitInfo.outerOutValue, kMatmulAtLeastOnceHint);
+        markOpOpt.has_value())
+    {
+        auto markOp = markOpOpt.value();
+        markOp->removeAttr(kMatmulAtLeastOnceHint);
+        if (markOp->getAttrs().empty()) {
+            rewriter.eraseOp(markOpOpt.value());
+        }
+        matmulOp->getParentOp()->setAttr(CVPipeline::kHIVMMatmulLimitedInCubeAttr, rewriter.getUnitAttr());
+    }
 
     if (splitInfo.shouldSplit) {
         return splitMatmul(matmulOp, rewriter, splitInfo);


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
