### PR TITLE
[ssbuffer](fix) Optimize RefineArgsBlockId.cpp

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow.cpp
@@ -66,7 +66,6 @@ void SplitDataflowPass::runOnOperation()
 
     // Step 7: Refine block id for iteration variables in main loops
     pm.addPass(createRefineArgsBlockIdPass());
-    pm.addPass(createReorderOpsByBlockIdPass());
 
     if (failed(runPipeline(pm, module))) {
         module->emitError() << "[" << DEBUG_TYPE << "] Pass failed!";

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/RefineArgsBlockId.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/RefineArgsBlockId.cpp
@@ -141,6 +141,17 @@ void processOnefor(scf::ForOp forOp, CVPipeline::ComputeBlockIdManager &bm,
         if (firstUserBlockId != -1 && updateBlockId != firstUserBlockId) {
             LOG_DEBUG("Moving update op from block " << updateBlockId << " to block " << firstUserBlockId << "\n");
             bm.updateBlockId(yieldDefOp, firstUserBlockId);
+            // Move yieldDefOp to the end of the first user block
+            auto firstUserOps = bm.getOpsByBlockId(firstUserBlockId);
+            Operation *lastOpInFirstUserBlock = nullptr;
+            for (Operation *op : firstUserOps) {
+                if (!lastOpInFirstUserBlock || op->isBeforeInBlock(lastOpInFirstUserBlock)) {
+                    lastOpInFirstUserBlock = op;
+                }
+            }
+            if (lastOpInFirstUserBlock) {
+                yieldDefOp->moveAfter(lastOpInFirstUserBlock);
+            }
         }
     }
 }
@@ -151,10 +162,10 @@ void RefineArgsBlockIdPass::runOnOperation()
     ModuleOp moduleOp = getOperation();
     CVPipeline::ComputeBlockIdManager bm(moduleOp);
     auto &aa = getAnalysis<AliasAnalysis>();
-    auto memDepGraph = CVPipeline::MemoryDependenceGraph(moduleOp, aa);
     LOG_DEBUG(*moduleOp);
     moduleOp.walk([&](scf::ForOp forOp) {
         if (forOp->hasAttr("ssbuffer.main_loop")) {
+            auto memDepGraph = CVPipeline::MemoryDependenceGraph(forOp, aa);
             processOnefor(forOp, bm, memDepGraph);
         }
     });


### PR DESCRIPTION
This pull request move the reorder logic to the RefineArgsBlockIdPass to shorten the compilition time cost.
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
