### PR TITLE
[runtime](fix) skip missing backend entry points

### DIFF
--- a/python/test/unit/runtime/test_backend_discovery.py
+++ b/python/test/unit/runtime/test_backend_discovery.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+
+import triton.backends as triton_backends
+
+
+class _EntryPoints:
+
+    def __init__(self, entries):
+        self.entries = entries
+
+    def select(self, group):
+        assert group == "triton.backends"
+        return self.entries
+
+
+def test_discover_backends_skips_missing_backend_package(monkeypatch):
+    missing_backend = SimpleNamespace(name="missing", value="missing_backend")
+
+    monkeypatch.setattr(
+        triton_backends,
+        "entry_points",
+        lambda: _EntryPoints([missing_backend]),
+    )
+
+    assert triton_backends._discover_backends() == {}

--- a/python/triton/backends/__init__.py
+++ b/python/triton/backends/__init__.py
@@ -37,8 +37,13 @@ class Backend:
 def _discover_backends() -> dict[str, Backend]:
     backends = dict()
     for ep in entry_points().select(group="triton.backends"):
-        compiler = importlib.import_module(f"{ep.value}.compiler")
-        driver = importlib.import_module(f"{ep.value}.driver")
+        try:
+            compiler = importlib.import_module(f"{ep.value}.compiler")
+            driver = importlib.import_module(f"{ep.value}.driver")
+        except ModuleNotFoundError as exc:
+            if exc.name and exc.name.startswith(ep.value):
+                continue
+            raise
         backends[ep.name] = Backend(_find_concrete_subclasses(compiler, BaseBackend),  # type: ignore
                                     _find_concrete_subclasses(driver, DriverBase))  # type: ignore
     return backends


### PR DESCRIPTION
## Summary
- skip backend entry points whose backend package is not importable
- keep raising `ModuleNotFoundError` for missing nested dependencies inside an importable backend
- add a regression test for a stale/missing backend entry point

## Why
A source checkout or environment can contain entry point metadata for a backend package that is not present on `PYTHONPATH`. In that case backend discovery currently fails the whole `triton.backends` import. Skipping only the entry point whose package is absent lets the remaining installed backends continue to load while preserving real dependency failures inside installed backends.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 - <<PY ... ast.parse(...) ... PY` on the changed files
- `git diff --check`

`PYTHONPATH=python python3 -m pytest python/test/unit/runtime/test_backend_discovery.py -q` could not run in my local checkout because the existing local `python/triton/_C/libtriton.so` requires `GLIBC_2.38`, which is newer than this host glibc.