### PR TITLE
[ascend](fix) disambiguate dependent getDefiningOp calls

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
@@ -1673,10 +1673,11 @@ BlockDataParser::rewriteTerminator(
       // If this value is a tensor of pointers produced by AddPtrOp,
       // we should have already converted to a ReinterpretCastOp without
       // layout information for the normal cases
-      if (v.getDefiningOp<triton::AddPtrOp>() ||
-          v.getDefiningOp<triton::AdvanceOp>() ||
-          v.getDefiningOp<triton::MakeTensorPtrOp>()) {
-        if (auto castOp = mappedV.getDefiningOp<memref::ReinterpretCastOp>()) {
+      if (v.template getDefiningOp<triton::AddPtrOp>() ||
+          v.template getDefiningOp<triton::AdvanceOp>() ||
+          v.template getDefiningOp<triton::MakeTensorPtrOp>()) {
+        if (auto castOp =
+                mappedV.template getDefiningOp<memref::ReinterpretCastOp>()) {
           v = castOp;
         } else {
           llvm_unreachable("mapped value defined by an unexpected op");
@@ -1701,7 +1702,7 @@ BlockDataParser::rewriteTerminator(
     if (blockArgIdxSet.find(i) == blockArgIdxSet.end())
       continue;
 
-    auto reintCastOp = v.getDefiningOp<memref::ReinterpretCastOp>();
+    auto reintCastOp = v.template getDefiningOp<memref::ReinterpretCastOp>();
     assert(
         reintCastOp ||
         (isa<TensorType>(v.getType()) &&


### PR DESCRIPTION
## Summary
- add the required `template` disambiguator for dependent `getDefiningOp<T>()` calls in Ascend BlockPtrAnalysis

## Why
These calls appear in a templated context. Some compilers reject the unqualified dependent template calls, which breaks the Ascend build path.

## Validation
- `python3 -m pre_commit run clang-format --files third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp`
- `git diff --check`