### PR TITLE
[ascend](fix) allow MemAccOp factory specializations

### DIFF
--- a/third_party/ascend/include/TritonToUnstructure/UnstructureConversionPass.h
+++ b/third_party/ascend/include/TritonToUnstructure/UnstructureConversionPass.h
@@ -111,8 +111,7 @@ private:
 
   template <typename... Args>
   MemAccOpTy createMemAccOp(MemAccOpTy op, Value ptrToAccess, Location loc,
-                            PatternRewriter &rewriter,
-                            Args &&...args) const = delete;
+                            PatternRewriter &rewriter, Args &&...args) const;
 
   const llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap;
   const llvm::SmallDenseMap<Value, bool> &fromTensorArg;


### PR DESCRIPTION
## Summary
- remove the deleted primary declaration for `createMemAccOp` in the Unstructure conversion pass
- allow the intended specialization/definition pattern to compile

## Why
The deleted template declaration prevents the conversion pass from using the specialized memory-access factory overloads. Keeping the declaration available fixes the Ascend conversion build without changing call sites.

## Validation
- `python3 -m pre_commit run clang-format --files third_party/ascend/include/TritonToUnstructure/UnstructureConversionPass.h`
- `git diff --check`