### PR TITLE
[build](fix) drop test libs from production tools

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -30,11 +30,6 @@ target_link_libraries(triton-opt PRIVATE
   BiShengIRScopeDialect
   BiShengIRSymbolDialect
   BiShengIRTensorDialect
-  # tests
-  TritonTestAnalysis
-  TritonTestDialect
-  TritonAMDGPUTestAnalysis
-  TritonTestProton
   # MLIR core
   MLIROptLib
   MLIRPass
@@ -70,11 +65,6 @@ target_link_libraries(triton-reduce PRIVATE
   BiShengIRScopeDialect
   BiShengIRSymbolDialect
   BiShengIRTensorDialect
-  # tests
-  TritonTestAnalysis
-  TritonTestDialect
-  TritonAMDGPUTestAnalysis
-  TritonTestProton
   # MLIR core
   MLIRReduceLib
   MLIRPass
@@ -109,11 +99,6 @@ target_link_libraries(triton-lsp PRIVATE
   BiShengIRScopeDialect
   BiShengIRSymbolDialect
   BiShengIRTensorDialect
-  # tests
-  TritonTestAnalysis
-  TritonTestDialect
-  TritonAMDGPUTestAnalysis
-  TritonTestProton
   # MLIR core
   MLIRLspServerLib
   MLIRPass
@@ -167,11 +152,6 @@ target_link_libraries(triton-tensor-layout PRIVATE
   BiShengIRScopeDialect
   BiShengIRSymbolDialect
   BiShengIRTensorDialect
-  # tests
-  TritonTestAnalysis
-  TritonTestDialect
-  TritonTestProton
-  TritonAMDGPUTestAnalysis
   MLIRRegisterAllDialects
   MLIRRegisterAllPasses
   MLIRTransforms


### PR DESCRIPTION
## Summary
- remove test-only Triton libraries from production tool link lines
- keep `triton-opt`, `triton-reduce`, `triton-lsp`, and `triton-tensor-layout` independent of test targets

## Why
Production tools should not require test dialect/analysis targets to be built. This helps minimal or Ascend-focused builds that do not materialize test libraries.

## Validation
- `git diff --check`
- verified `bin/CMakeLists.txt` no longer references `TritonTestAnalysis`, `TritonTestDialect`, `TritonAMDGPUTestAnalysis`, or `TritonTestProton`