### PR TITLE
[tools](fix) trim optional dialect registrations

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -28,14 +28,8 @@
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
 #include "bishengir/Dialect/Scope/IR/Scope.h"
 
-#include "amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
-#include "amd/include/TritonAMDGPUTransforms/Passes.h"
 #include "ascend/include/Dialect/TritonAscend/IR/TritonAscendDialect.h"
-#include "nvidia/include/Dialect/NVGPU/IR/Dialect.h"
-#include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
 #include "proton/Dialect/include/Conversion/ProtonGPUToLLVM/Passes.h"
-#include "proton/Dialect/include/Conversion/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/Passes.h"
-#include "proton/Dialect/include/Conversion/ProtonGPUToLLVM/ProtonNvidiaGPUToLLVM/Passes.h"
 #include "proton/Dialect/include/Conversion/ProtonToProtonGPU/Passes.h"
 #include "proton/Dialect/include/Dialect/Proton/IR/Dialect.h"
 #include "proton/Dialect/include/Dialect/ProtonGPU/IR/Dialect.h"
@@ -44,22 +38,13 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonInstrument/IR/Dialect.h"
-#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
 // Below headers will allow registration to ROCm passes
-#include "TritonAMDGPUToLLVM/Passes.h"
-#include "TritonAMDGPUTransforms/Passes.h"
-#include "TritonAMDGPUTransforms/TritonGPUConversion.h"
 
 #include "triton/Dialect/Triton/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonInstrument/Transforms/Passes.h"
-#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 
-#include "nvidia/hopper/include/Transforms/Passes.h"
-#include "nvidia/include/Dialect/NVWS/Transforms/Passes.h"
-#include "nvidia/include/NVGPUToLLVM/Passes.h"
-#include "nvidia/include/TritonNVIDIAGPUToLLVM/Passes.h"
 #include "triton/Conversion/TritonGPUToLLVM/Passes.h"
 #include "triton/Conversion/TritonToTritonGPU/Passes.h"
 #include "triton/Target/LLVMIR/Passes.h"
@@ -69,52 +54,17 @@
 #include "mlir/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.h"
 #include "mlir/InitAllPasses.h"
 
-#include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
-#include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
-#include "mlir/Conversion/MathToLLVM/MathToLLVM.h"
-#include "mlir/Conversion/NVVMToLLVM/NVVMToLLVM.h"
-#include "mlir/Conversion/UBToLLVM/UBToLLVM.h"
-
-namespace mlir {
-namespace test {
-void registerTestAliasPass();
-void registerTestAlignmentPass();
-void registerAMDTestAlignmentPass();
-void registerTestAllocationPass();
-void registerTestMembarPass();
-void registerTestAMDGPUMembarPass();
-void registerTestTritonAMDGPURangeAnalysis();
-void registerTestLoopPeelingPass();
-namespace proton {
-void registerTestScopeIdAllocationPass();
-} // namespace proton
-} // namespace test
-} // namespace mlir
-
 inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerAllPasses();
   mlir::triton::registerTritonPasses();
   mlir::triton::gpu::registerTritonGPUPasses();
-  mlir::triton::nvidia_gpu::registerTritonNvidiaGPUPasses();
   mlir::triton::instrument::registerTritonInstrumentPasses();
   mlir::triton::gluon::registerGluonPasses();
-  mlir::test::registerTestAliasPass();
-  mlir::test::registerTestAlignmentPass();
-  mlir::test::registerAMDTestAlignmentPass();
-  mlir::test::registerTestAllocationPass();
-  mlir::test::registerTestMembarPass();
-  mlir::test::registerTestLoopPeelingPass();
-  mlir::test::registerTestAMDGPUMembarPass();
-  mlir::test::registerTestTritonAMDGPURangeAnalysis();
   mlir::triton::registerConvertTritonToTritonGPUPass();
   mlir::triton::registerRelayoutTritonGPUPass();
   mlir::triton::gpu::registerAllocateSharedMemoryPass();
   mlir::triton::gpu::registerTritonGPUAllocateWarpGroups();
   mlir::triton::gpu::registerTritonGPUGlobalScratchAllocationPass();
-  mlir::triton::registerConvertWarpSpecializeToLLVM();
-  mlir::triton::registerConvertTritonGPUToLLVMPass();
-  mlir::triton::registerConvertNVGPUToLLVMPass();
-  mlir::triton::registerAllocateSharedMemoryNvPass();
   mlir::triton::registerTritonToLinalgPasses();
   mlir::triton::registerTritonControlFlowOptPasses();
   mlir::triton::registerDiscreteMaskAccessConversion();
@@ -133,51 +83,11 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::NVVM::registerInlinerInterface(registry);
   mlir::registerLLVMDILocalVariable();
 
-  // TritonAMDGPUToLLVM passes
-  mlir::triton::registerAllocateAMDGPUSharedMemory();
-  mlir::triton::registerConvertTritonAMDGPUToLLVM();
-  mlir::triton::registerConvertBuiltinFuncToLLVM();
-  mlir::triton::registerOptimizeAMDLDSUsage();
-
-  mlir::ub::registerConvertUBToLLVMInterface(registry);
-  mlir::registerConvertNVVMToLLVMInterface(registry);
-  mlir::registerConvertMathToLLVMInterface(registry);
-  mlir::cf::registerConvertControlFlowToLLVMInterface(registry);
-  mlir::arith::registerConvertArithToLLVMInterface(registry);
-
-  // TritonAMDGPUTransforms passes
-  mlir::registerTritonAMDGPUAccelerateMatmul();
-  mlir::registerTritonAMDGPUOptimizeEpilogue();
-  mlir::registerTritonAMDGPUHoistLayoutConversions();
-  mlir::registerTritonAMDGPUReorderInstructions();
-  mlir::registerTritonAMDGPUBlockPingpong();
-  mlir::registerTritonAMDGPUPipeline();
-  mlir::registerTritonAMDGPUScheduleLoops();
-  mlir::registerTritonAMDGPUCanonicalizePointers();
-  mlir::registerTritonAMDGPUConvertToBufferOps();
-  mlir::registerTritonAMDGPUInThreadTranspose();
-  mlir::registerTritonAMDGPUCoalesceAsyncCopy();
-  mlir::registerTritonAMDGPUUpdateAsyncWaitCount();
-  mlir::triton::registerTritonAMDGPUInsertInstructionSchedHints();
-  mlir::triton::registerTritonAMDGPULowerInstructionSchedHints();
-  mlir::registerTritonAMDFoldTrueCmpI();
-  mlir::triton::amdgpu::registerTritonAMDGPUOptimizeDotOperands();
-
-  // NVWS passes
-  mlir::triton::registerNVWSTransformsPasses();
-
-  // NVGPU transform passes
-  mlir::registerNVHopperTransformsPasses();
-
   // Proton passes
-  mlir::test::proton::registerTestScopeIdAllocationPass();
   mlir::triton::proton::registerConvertProtonToProtonGPU();
-  mlir::triton::proton::gpu::registerConvertProtonNvidiaGPUToLLVM();
-  mlir::triton::proton::gpu::registerConvertProtonAMDGPUToLLVM();
   mlir::triton::proton::gpu::registerAllocateProtonSharedMemoryPass();
   mlir::triton::proton::gpu::registerAllocateProtonGlobalScratchBufferPass();
   mlir::triton::proton::gpu::registerScheduleBufferStorePass();
-  mlir::triton::proton::gpu::registerAddSchedBarriersPass();
 
   // DynamicCVPipeline passes
   mlir::triton::registerAddDynamicCVPipelinePasses();
@@ -195,23 +105,20 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::registerAsyncLoadHoistingPasses();
   mlir::triton::registerAddMultiBufferToGMLoadPasses();
 
-  registry.insert<
-      mlir::triton::TritonDialect, mlir::cf::ControlFlowDialect,
-      mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect,
-      mlir::triton::gpu::TritonGPUDialect,
-      mlir::triton::instrument::TritonInstrumentDialect,
-      mlir::math::MathDialect, mlir::arith::ArithDialect, mlir::scf::SCFDialect,
-      mlir::tensor::TensorDialect, mlir::gpu::GPUDialect,
-      mlir::LLVM::LLVMDialect, mlir::NVVM::NVVMDialect,
-      mlir::triton::nvgpu::NVGPUDialect, mlir::triton::nvws::NVWSDialect,
-      mlir::triton::amdgpu::TritonAMDGPUDialect,
-      mlir::triton::proton::ProtonDialect,
-      mlir::triton::proton::gpu::ProtonGPUDialect, mlir::ROCDL::ROCDLDialect,
-      mlir::triton::gluon::GluonDialect,
-      mlir::triton::ascend::TritonAscendDialect, mlir::hivm::HIVMDialect,
-      mlir::scope::ScopeDialect, mlir::hacc::HACCDialect,
-      mlir::annotation::AnnotationDialect, mlir::hfusion::HFusionDialect,
-      mlir::tensor::TensorDialect, mlir::linalg::LinalgDialect,
-      mlir::memref::MemRefDialect, mlir::bufferization::BufferizationDialect,
-      mlir::func::FuncDialect>();
+  registry.insert<mlir::triton::TritonDialect, mlir::cf::ControlFlowDialect,
+                  mlir::triton::gpu::TritonGPUDialect,
+                  mlir::triton::instrument::TritonInstrumentDialect,
+                  mlir::math::MathDialect, mlir::arith::ArithDialect,
+                  mlir::scf::SCFDialect, mlir::tensor::TensorDialect,
+                  mlir::gpu::GPUDialect, mlir::LLVM::LLVMDialect,
+                  mlir::NVVM::NVVMDialect, mlir::triton::proton::ProtonDialect,
+                  mlir::triton::proton::gpu::ProtonGPUDialect,
+                  mlir::ROCDL::ROCDLDialect, mlir::triton::gluon::GluonDialect,
+                  mlir::triton::ascend::TritonAscendDialect,
+                  mlir::hivm::HIVMDialect, mlir::scope::ScopeDialect,
+                  mlir::hacc::HACCDialect, mlir::annotation::AnnotationDialect,
+                  mlir::hfusion::HFusionDialect, mlir::tensor::TensorDialect,
+                  mlir::linalg::LinalgDialect, mlir::memref::MemRefDialect,
+                  mlir::bufferization::BufferizationDialect,
+                  mlir::func::FuncDialect>();
 }


### PR DESCRIPTION
## Summary
- remove test, AMD, and NVIDIA-specific registrations from the common tool dialect registration helper
- keep the Ascend/tool registration path focused on dialects and passes available in minimal Ascend builds

## Why
The common tool registration header currently pulls in optional test, AMD, and NVIDIA registration symbols. Minimal Ascend-focused tool builds can fail when those optional components are not built. This keeps the tool helper independent of those optional targets.

## Validation
- `python3 -m pre_commit run clang-format --files bin/RegisterTritonDialects.h`
- `git diff --check`