### PR TITLE
[build](fix) materialize NVWS transform targets

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
@@ -1,3 +1,21 @@
+if(NOT TARGET NVWSIR)
+  add_subdirectory(
+    ${PROJECT_SOURCE_DIR}/third_party/nvidia/include/Dialect/NVWS/IR
+    ${CMAKE_BINARY_DIR}/third_party/nvidia/include/Dialect/NVWS/IR)
+  add_subdirectory(
+    ${PROJECT_SOURCE_DIR}/third_party/nvidia/lib/Dialect/NVWS/IR
+    ${CMAKE_BINARY_DIR}/third_party/nvidia/lib/Dialect/NVWS/IR)
+endif()
+
+if(NOT TARGET NVWSTransforms)
+  add_subdirectory(
+    ${PROJECT_SOURCE_DIR}/third_party/nvidia/include/Dialect/NVWS/Transforms
+    ${CMAKE_BINARY_DIR}/third_party/nvidia/include/Dialect/NVWS/Transforms)
+  add_subdirectory(
+    ${PROJECT_SOURCE_DIR}/third_party/nvidia/lib/Dialect/NVWS/Transforms
+    ${CMAKE_BINARY_DIR}/third_party/nvidia/lib/Dialect/NVWS/Transforms)
+endif()
+
 add_triton_library(TritonGPUTransforms
   AccelerateMatmul.cpp
   Coalesce.cpp


### PR DESCRIPTION
## Summary
- explicitly add NVWS IR and transform subdirectories when `TritonGPUTransforms` needs those targets
- guard the additions with `NOT TARGET` checks so existing full builds keep their target ownership

## Why
Some build configurations reach `TritonGPUTransforms` without materializing the NVWS targets first. This makes the target dependency ordering explicit while preserving existing full-build behavior.

## Validation
- `git diff --check`

The authoritative validation is the repository CMake/wheel CI.