### PR TITLE
[ssbuffer](feat) Add pass for merge-cube-for-block

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -222,8 +222,8 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
             metadata["set_workspace_multibuffer"] = 0
             metadata["enable_mixed_cv"] = True
             metadata["disable_auto_inject_block_sync"] = True
-            _enable_opt = metadata["enable_dynamic_cv_flow_opt"]
-            ascend.passes.ttir.set_enable_dynamic_cv_flow_optimization(_enable_opt)
+            ascend.passes.ttir.set_enable_dynamic_cv_flow_optimization(metadata["enable_dynamic_cv_flow_opt"])
+            ascend.passes.ttir.set_enable_cube_block_merge(metadata["enable_cube_block_merge"])
 
             ascend.passes.ttir.add_dynamic_cv_pipeline(pm, compile_on_910_95)
 
@@ -965,6 +965,10 @@ class NPUOptions:
     enable_vf_fusion: bool = None
     enable_dynamic_cv_pipeline: bool = True if is_compile_on_910_95 else False
     enable_dynamic_cv_flow_opt: bool = False
+    # Gates the cube-loader penetration + cube-for block merge feature. Off by
+    # default so existing scenarios are unaffected; opt in per kernel to fuse a
+    # matmul's loader for-loop into the matmul's cube compute block.
+    enable_cube_block_merge: bool = False
     hfusion_enable_multiple_consumer_fusion: bool = False
     has_auto_blockify_blacklist_op: Optional[bool] = None
     intra_cache_num: int = None

--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -80,6 +80,9 @@ inline constexpr CoreType fromStrCoreType(std::string_view s)
     return CoreType::UNDETERMINED;
 }
 
+void setEnableCubeBlockMerge(bool enable);
+bool isCubeBlockMergeEnabled();
+
 // Functions for managing core types
 CoreType getOpCoreType(Operation *op);
 std::optional<int> getOpBlockId(Operation *op);

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
@@ -34,6 +34,8 @@ std::unique_ptr<OperationPass<ModuleOp>> createUnifyAllocBlockPass();
 void registerUnifyAllocBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createMergeVectorIfBlockPass();
 void registerMergeVectorIfBlockPass();
+std::unique_ptr<OperationPass<ModuleOp>> createMergeCubeForBlockPass();
+void registerMergeCubeForBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createFixpipeOptPass();
 
 } // namespace triton

--- a/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h
+++ b/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h
@@ -116,6 +116,13 @@ class OpClassifierPass : public PassWrapper<OpClassifierPass, OperationPass<Modu
     // Step 4: Propagate VECTOR core type upstream
     int propagateVectorUpstream();
 
+    // Step 4.5: Penetrate CUBE coloring into pure loader scf.for loops whose
+    // results are consumed exclusively by CUBE ops.
+    int penetrateCubeIntoForLoops();
+
+    // Helper: decide whether an scf.for is a pure cube-loader loop
+    bool isCubeLoaderForOp(scf::ForOp forOp);
+
     // Initialize the pass
     void initializePass(ModuleOp module);
 

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -17,6 +17,18 @@
 namespace mlir {
 namespace CVPipeline {
 
+static bool g_enableCubeBlockMerge = true;
+
+void setEnableCubeBlockMerge(bool enable)
+{
+    g_enableCubeBlockMerge = enable;
+}
+
+bool isCubeBlockMergeEnabled()
+{
+    return g_enableCubeBlockMerge;
+}
+
 CoreType getOpCoreType(Operation *op)
 {
     if (!op) {

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeCubeForBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeCubeForBlockPass.cpp
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "DynamicCVPipeline/Common/Utils.h"
+#include "DynamicCVPipeline/PlanComputeBlock/OpClassifier.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Debug.h"
+
+static constexpr const char *DEBUG_TYPE = "merge-cube-for-block";
+#define LOG_DEBUG(...) LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
+
+using namespace mlir;
+using namespace triton;
+
+namespace {
+
+static bool isCubeForOp(scf::ForOp forOp)
+{
+    if (CVPipeline::getOpBlockId(forOp.getOperation()).has_value()) {
+        return false;
+    }
+    auto attr = forOp->getAttrOfType<StringAttr>(CVPipeline::kCoreType);
+    if (!attr) {
+        return false;
+    }
+    llvm::SmallVector<llvm::StringRef, 4> parts;
+    attr.getValue().split(parts, ',');
+    if (parts.empty()) {
+        return false;
+    }
+    for (llvm::StringRef part : parts) {
+        if (part.trim() != "CUBE") {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * @brief Collect the block_ids of the cube ops that consume the loop results,
+ *        ordered by their first appearance in the parent block.
+ */
+static SmallVector<int> collectDownstreamCubeBlockIds(scf::ForOp forOp, CVPipeline::ComputeBlockIdManager &bm)
+{
+    Block *parent = forOp->getBlock();
+    llvm::DenseSet<Operation *> userAnchors;
+    for (Value res : forOp->getResults()) {
+        for (Operation *user : res.getUsers()) {
+            if (auto *anc = CVPipeline::getAncestorInBlock(user, parent)) {
+                if (CVPipeline::getOpCoreType(anc) != CVPipeline::CoreType::CUBE_ONLY) {
+                    continue;
+                }
+                userAnchors.insert(anc);
+            }
+        }
+    }
+
+    SmallVector<int> ordered;
+    llvm::SmallDenseSet<int, CVPipeline::INIT_SIZE> seen;
+    for (Operation &op : *parent) {
+        if (!userAnchors.contains(&op)) {
+            continue;
+        }
+        int bid = bm.getBlockIdByOp(&op);
+        if (bid == -1) {
+            continue;
+        }
+        if (seen.insert(bid).second) {
+            ordered.push_back(bid);
+        }
+    }
+    return ordered;
+}
+
+static void applyMerge(scf::ForOp forOp, int target, CVPipeline::ComputeBlockIdManager &bm)
+{
+    bm.updateBlockId(forOp.getOperation(), target);
+    forOp.getBody()->walk([&](Operation *op) {
+        if (op == forOp.getOperation()) {
+            return;
+        }
+        if (CVPipeline::getOpBlockId(op).has_value()) {
+            bm.updateBlockId(op, target);
+        }
+    });
+}
+
+/**
+ * @brief Try to merge one cube-loader scf.for with a downstream consumer block
+ */
+static void tryMergeCubeFor(scf::ForOp forOp, const CVPipeline::MemoryDependenceGraph &memGraph,
+                            CVPipeline::ComputeBlockIdManager &bm)
+{
+    SmallVector<int> downstream = collectDownstreamCubeBlockIds(forOp, bm);
+    if (downstream.empty()) {
+        LOG_DEBUG("[tryMergeCubeFor] no downstream cube consumer block for " << *forOp);
+        return;
+    }
+
+    SmallVector<Operation *> forOnly = {forOp.getOperation()};
+    for (int bid : downstream) {
+        if (!CVPipeline::willCreateCycle(forOnly, memGraph, bid, bm)) {
+            LOG_DEBUG("[tryMergeCubeFor] merging loader for into downstream block_id " << bid);
+            applyMerge(forOp, bid, bm); // Only merge with the first consumer cube block.
+            return;
+        }
+        LOG_DEBUG("[tryMergeCubeFor] downstream block_id " << bid << " would create a cycle, skip");
+    }
+}
+
+} // anonymous namespace
+
+class MergeCubeForBlockPass : public PassWrapper<MergeCubeForBlockPass, OperationPass<ModuleOp>> {
+  public:
+    MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MergeCubeForBlockPass)
+
+    MergeCubeForBlockPass() = default;
+
+    StringRef getArgument() const override { return "merge-cube-for-block"; }
+
+    StringRef getDescription() const override
+    {
+        return "Merge cube loader scf.for loops with their downstream consuming "
+               "matmul compute block";
+    }
+
+    void runOnOperation() override
+    {
+        // Gated by the enable_cube_block_merge compile option so other scenarios
+        // are unaffected unless the feature is explicitly turned on.
+        if (!CVPipeline::isCubeBlockMergeEnabled()) {
+            return;
+        }
+
+        ModuleOp module = getOperation();
+        LOG_DEBUG("Before: " << *module);
+        auto &aa = getAnalysis<AliasAnalysis>();
+        CVPipeline::MemoryDependenceGraph memGraph(module, aa);
+        auto bm = CVPipeline::ComputeBlockIdManager(module);
+
+        llvm::SmallVector<scf::ForOp> cubeForOps;
+        module.walk([&](scf::ForOp forOp) {
+            if (isCubeForOp(forOp)) {
+                cubeForOps.push_back(forOp);
+            }
+        });
+
+        for (scf::ForOp forOp : cubeForOps) {
+            tryMergeCubeFor(forOp, memGraph, bm);
+        }
+
+        LOG_DEBUG("After: " << *module);
+    }
+};
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<OperationPass<ModuleOp>> createMergeCubeForBlockPass()
+{
+    return std::make_unique<MergeCubeForBlockPass>();
+}
+
+void registerMergeCubeForBlockPass()
+{
+    PassRegistration<MergeCubeForBlockPass> reg;
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
@@ -48,6 +48,9 @@ void ComputeBlockOptPass::runOnOperation()
     pm.addPass(createMergeVectorIfBlockPass());
     pm.addPass(createReorderOpsByBlockIdPass());
 
+    pm.addPass(createMergeCubeForBlockPass());
+    pm.addPass(createReorderOpsByBlockIdPass());
+
     pm.addPass(createUBUsageOptPass());
     pm.addPass(createReorderOpsByBlockIdPass());
 
@@ -74,6 +77,7 @@ void registerComputeBlockOptPasses()
     registerPass(createUBUsageOptPass);
     registerPass(createUnifyAllocBlockPass);
     registerPass(createMergeVectorIfBlockPass);
+    registerPass(createMergeCubeForBlockPass);
     registerPass(createFixpipeOptPass);
 }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -30,6 +30,7 @@
 #include "bishengir/Dialect/Utils/Util.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -898,6 +899,92 @@ int OpClassifierPass::propagateVectorUpstream()
     return 0;
 }
 
+namespace {
+
+// A loader loop may only contain data-movement and (scalar) index computation.
+// Any tensor-producing compute op means the loop does real vector work and must
+// not be swallowed into the cube pipe.
+bool isDisqualifyingLoaderOp(Operation *op)
+{
+    if (isa<linalg::MatmulOp, linalg::ReduceOp, linalg::BroadcastOp, linalg::GenericOp, linalg::MapOp>(op)) {
+        return true;
+    }
+    if (isa<math::MathDialect>(op->getDialect())) {
+        return true;
+    }
+    // Elementwise arith on tensors is vector compute; scalar index math is fine.
+    if (isa<arith::ArithDialect>(op->getDialect())) {
+        for (Value result : op->getResults()) {
+            if (isa<RankedTensorType>(result.getType())) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+bool OpClassifierPass::isCubeLoaderForOp(scf::ForOp forOp)
+{
+    // Every result must be live and used only by CUBE consumers. A single
+    // non-cube (or scf.yield) user disqualifies the loop.
+    bool hasCubeConsumer = false;
+    for (Value result : forOp.getResults()) {
+        for (Operation *user : result.getUsers()) {
+            if (isa<linalg::MatmulOp>(user) || getCoreType(user) == OP_CUBE_ONLY) {
+                hasCubeConsumer = true;
+                continue;
+            }
+            return false;
+        }
+    }
+    if (!hasCubeConsumer) {
+        return false;
+    }
+
+    // The body (including nested regions) must be pure data movement.
+    bool disqualified = false;
+    forOp.getBody()->walk([&](Operation *op) {
+        if (op == forOp.getOperation()) {
+            return WalkResult::advance();
+        }
+        if (isDisqualifyingLoaderOp(op)) {
+            disqualified = true;
+            return WalkResult::interrupt();
+        }
+        return WalkResult::advance();
+    });
+    return !disqualified;
+}
+
+int OpClassifierPass::penetrateCubeIntoForLoops()
+{
+    // Collect first so recoloring earlier loops cannot perturb the scan.
+    llvm::SmallVector<scf::ForOp> loaderLoops;
+    getOperation().walk([&](scf::ForOp forOp) {
+        if (isCubeLoaderForOp(forOp)) {
+            loaderLoops.push_back(forOp);
+        }
+    });
+
+    for (scf::ForOp forOp : loaderLoops) {
+        // Set core_type to OP_CUBE_ONLY for scf.for.
+        forOp.getBody()->walk([&](Operation *op) {
+            if (op == forOp.getOperation() || isa<scf::SCFDialect>(op->getDialect())) {
+                return;
+            }
+            auto it = opCoreTypes.find(op);
+            if (it != opCoreTypes.end()) {
+                it->second = OP_CUBE_ONLY;
+            }
+        });
+        opCoreTypes[forOp] = OP_CUBE_ONLY;
+    }
+
+    return 0;
+}
+
 // ============================================================================
 // Helper Functions
 // ============================================================================
@@ -1471,31 +1558,37 @@ void OpClassifierPass::runOnOperation()
         return;
     }
 
-    // Step 3: Mark remaining operations as VECTOR
+    // Step 3: Penetrate CUBE coloring into pure loader for-loops.
+    if (CVPipeline::isCubeBlockMergeEnabled() && penetrateCubeIntoForLoops() != 0) {
+        signalPassFailure();
+        return;
+    }
+
+    // Step 4: Mark remaining operations as VECTOR
     if (markRemainingAsVector() != 0) {
         signalPassFailure();
         return;
     }
 
-    // Step 4: VECTOR upstream BFS
+    // Step 5: VECTOR upstream BFS
     if (propagateVectorUpstream() != 0) {
         signalPassFailure();
         return;
     }
 
-    // Step 5: Handle CUBE_AND_VECTOR operations
+    // Step 6: Handle CUBE_AND_VECTOR operations
     if (handleCubeAndVector() != 0) {
         signalPassFailure();
         return;
     }
 
-    // Step 6: Process SCF yield results
+    // Step 7: Process SCF yield results
     if (handleSCFYield() != 0) {
         signalPassFailure();
         return;
     }
 
-    // Step 7: Stamp to IR
+    // Step 8: Stamp to IR
     if (stampToIR() != 0) {
         signalPassFailure();
         return;

--- a/third_party/ascend/triton_ascend.cc
+++ b/third_party/ascend/triton_ascend.cc
@@ -23,6 +23,7 @@
 
 #include "ascend/include/DynamicCVPipeline/Passes.h"
 #include "ascend/include/DynamicCVPipeline/Common/BufferCountManager.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h"
 
 #include "triton/Dialect/Triton/IR/Dialect.h"
@@ -392,6 +393,10 @@ void init_triton_ascend_passes_ttir(py::module &&m) {
 
   m.def("set_enable_dynamic_cv_flow_optimization", [](bool enable) {
     mlir::triton::setEnableDynamicFlowOptimization(enable);
+  });
+
+  m.def("set_enable_cube_block_merge", [](bool enable) {
+    mlir::CVPipeline::setEnableCubeBlockMerge(enable);
   });
 }
 


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

Adapted to L1 cache optimization:
1. Added support for for coloring of pure Cube.
2. Added the logic for for fusion and consumer Cube block fusion of pure Cube.