### PR TITLE
[TritonToLinalg](fix) Enhance boundary check in tensor descriptor

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/DescriptorConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/DescriptorConverter.cpp
@@ -42,6 +42,7 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -96,6 +97,27 @@ DenseI32ArrayAttr getFullBoundaryCheckAttr(ConversionPatternRewriter &rewriter,
     boundaryCheck.push_back(dim);
   }
   return rewriter.getDenseI32ArrayAttr(boundaryCheck);
+}
+
+// Check whether the block fully covers the tensor from the origin
+static bool isFullCoverage(ArrayRef<int64_t> blockShape,
+                           ArrayRef<Value> tensorShape, ValueRange indices) {
+  if (blockShape.size() != tensorShape.size() ||
+      blockShape.size() != indices.size())
+    return false;
+  for (auto [bs, ts, idx] : llvm::zip(blockShape, tensorShape, indices)) {
+    auto constOp = ts.getDefiningOp<arith::ConstantOp>();
+    if (!constOp)
+      return false;
+    auto intAttr = dyn_cast<IntegerAttr>(constOp.getValue());
+    if (!intAttr || intAttr.getInt() != bs)
+      return false;
+    // Offset must be a statically-known zero
+    APInt offset;
+    if (!matchPattern(idx, m_ConstantInt(&offset)) || !offset.isZero())
+      return false;
+  }
+  return true;
 }
 
 Value expandOffsets(OpBuilder &builder, Location loc,
@@ -268,7 +290,9 @@ LogicalResult DescriptorLoadConverter::matchAndRewrite(
                                                computeOrder(blockShape) // order
       );
   // 3. replace tt.load
-  auto boundaryCheck = getFullBoundaryCheckAttr(rewriter, blockShape);
+  auto boundaryCheck = isFullCoverage(blockShape, desc.shape, indices)
+                           ? rewriter.getDenseI32ArrayAttr({})
+                           : getFullBoundaryCheckAttr(rewriter, blockShape);
   triton::PaddingOptionAttr padding = desc.padding;
   auto cache = triton::CacheModifierAttr::get(rewriter.getContext(),
                                               triton::CacheModifier::NONE);
@@ -326,7 +350,9 @@ LogicalResult DescriptorStoreConverter::matchAndRewrite(
   auto maskType = RankedTensorType::get(blockShape, rewriter.getI1Type());
   rewriter.create<arith::ConstantOp>(loc,
                                      DenseElementsAttr::get(maskType, true));
-  auto boundaryCheck = getFullBoundaryCheckAttr(rewriter, blockShape);
+  auto boundaryCheck = isFullCoverage(blockShape, desc.shape, indices)
+                           ? rewriter.getDenseI32ArrayAttr({})
+                           : getFullBoundaryCheckAttr(rewriter, blockShape);
   auto cacheModifier = triton::CacheModifierAttr::get(
       rewriter.getContext(), triton::CacheModifier::NONE);
   auto evictionPolicy = triton::EvictionPolicyAttr::get(

--- a/third_party/ascend/unittest/pytest_ut/test_tensor_descriptor.py
+++ b/third_party/ascend/unittest/pytest_ut/test_tensor_descriptor.py
@@ -225,6 +225,50 @@ def test_tensor_descriptor_padding(dtype, padding):
     torch.testing.assert_close(expected, out_device_tma, equal_nan=True)
 
 
+@pytest.mark.parametrize("dtype", ['float32', 'int32'])
+@pytest.mark.parametrize("offset", [16, 8])
+def test_tensor_descriptor_load_store_boundary_check(dtype, offset):
+
+    @triton.jit
+    def kernel(out_ptr, a_ptr, off: tl.constexpr, M: tl.constexpr, N: tl.constexpr):
+        in_desc = tl.make_tensor_descriptor(
+            a_ptr,
+            shape=[M, N],
+            strides=[N, 1],
+            block_shape=[M, N],
+            padding_option="zero",
+        )
+        out_desc = tl.make_tensor_descriptor(
+            out_ptr,
+            shape=[M, N],
+            strides=[N, 1],
+            block_shape=[M, N],
+        )
+        # block_shape == [M, N] and shape is constant -> "full coverage" looks
+        # true, but reading from row `off` extends past the last row.
+        block = in_desc.load([off, 0])
+        # offset 0 here IS full coverage -> boundary check may be dropped.
+        out_desc.store([0, 0], block)
+
+    def alloc_fn(size: int, alignment: int, stream):
+        return torch.empty(size, device="npu", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+
+    M, N = 32, 32
+    sentinel_value = 8
+    backing = test_common.generate_tensor((2 * M, N), dtype).npu()
+    backing[M:2 * M, :] = sentinel_value
+    inp = backing[0:M, :]
+    out = inp.new_empty((M, N))
+
+    kernel[(1, )](out, backing, offset, M, N)
+
+    expected = torch.zeros((M, N), dtype=inp.dtype, device=inp.device)
+    expected[0:M - offset, :] = inp[offset:M, :]
+    torch.testing.assert_close(expected, out)
+
+
 @pytest.mark.parametrize("X, Y", [(128, 128)])
 @pytest.mark.parametrize("BLOCK_X, BLOCK_Y", [(32, 32)])
 @pytest.mark.parametrize("dtype", ['float32', 'int32'])


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**
Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
### Summary
`DescriptorLoad` / `DescriptorStore` Converter unconditionally called
`getFullBoundaryCheckAttr` to emit a full `boundaryCheck` attribute during
lowering. This triggered the boundary-check path in pointer analysis and
generated redundant `cast` conversion ops in the IR, causing the affected test
cases to fail.
When the block shape fully covers the tensor size, a boundary check is not
needed in the first place.
### Changes
- Add helper `isFullCoverage(blockShape, tensorShape)`:  check if the
  ranks match and every tensor dimension is a compile-time constant equal to the
  corresponding block dimension.
- In `DescriptorLoadConverter` and `DescriptorStoreConverter`, emit an empty
  `boundaryCheck` (`{}`) when the full-coverage case is hit; otherwise keep the
  existing `getFullBoundaryCheckAttr` behavior.
### Effect
- The full-coverage case no longer produces a redundant boundary check and the
  associated `cast` ops, fixing the failing test cases.
- The non-full-coverage case (block cannot cover the tensor, or the size is
  dynamic) is unchanged and still performs a full boundary check.

### Impact
Only affects the boundaryCheck generation logic for descriptor load/store.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `test case already exists`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
