### PR TITLE
[TritonToLinalg](feat) default masked load to zero when `other`/`padd…

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1065,8 +1065,6 @@ class TritonSemantic(Generic[TensorTy]):
         # Check `boundary_check` argument
         boundary_check = self._canonicalize_boundary_check(boundary_check, dst_ty.get_block_shapes())
 
-        if boundary_check and padding is None:
-            padding = ir.PADDING_OPTION.PAD_ZERO
         # Build IR
         return self.tensor(
             self.builder.create_tensor_pointer_load(ptr.handle, boundary_check, padding, cache, eviction, is_volatile),
@@ -1084,12 +1082,7 @@ class TritonSemantic(Generic[TensorTy]):
             raise ValueError("`padding_option` or `boundary_check` argument is not supported for loading a tensor of"
                              "pointers or loading a scalar. Because the compiler does not know the boundary; please "
                              "use block pointers (defined by `make_block_ptr`) instead")
-        if mask is not None and other is None:
-            # Get element type to determine default padding value
-            elt_ty = ptr.type.scalar.element_ty
-            # Use 0.0 for floating point types, 0 for integer types
-            default_value = 0.0 if elt_ty.is_floating() else 0
-            other = self.to_tensor(default_value)
+
         # For a pointer of scalar, check the type of `mask` and `other`
         if not ptr.type.is_block():
             if mask and mask.type.is_block():

--- a/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
@@ -401,21 +401,21 @@ LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
     } else {
       dstOffsets = srcOffsets;
     }
-    if (padding.has_value()) {
-      TypedAttr padAttr = rewriter.getZeroAttr(memRefElementType);
-      // triton already ensure only NAN and ZERO are passed in
-      if (padding.value() == triton::PaddingOption::PAD_NAN) {
-        // FIXME: Why NaN requires elemTy to be non-int or non-index?
-        assert(!memRefElementType.isIntOrIndex());
-        auto apNaN = llvm::APFloat::getNaN(
-            cast<FloatAttr>(padAttr).getValue().getSemantics());
-        padAttr = rewriter.getFloatAttr(memRefElementType, apNaN);
-      }
-      auto padVal = rewriter.create<arith::ConstantOp>(loc, padAttr);
-
-      fillTensorWithOtherForMaskScenario(padVal, allocOp, boundarySizes,
-                                         rewriter);
+    // When `padding` is not specified, default to zero. Both PAD_ZERO and
+    // unset (nullopt) map to 0; only PAD_NAN maps to NaN.
+    TypedAttr padAttr = rewriter.getZeroAttr(memRefElementType);
+    if (padding.value_or(triton::PaddingOption::PAD_ZERO) ==
+        triton::PaddingOption::PAD_NAN) {
+      // FIXME: Why NaN requires elemTy to be non-int or non-index?
+      assert(!memRefElementType.isIntOrIndex());
+      auto apNaN = llvm::APFloat::getNaN(
+          cast<FloatAttr>(padAttr).getValue().getSemantics());
+      padAttr = rewriter.getFloatAttr(memRefElementType, apNaN);
     }
+    auto padVal = rewriter.create<arith::ConstantOp>(loc, padAttr);
+
+    fillTensorWithOtherForMaskScenario(padVal, allocOp, boundarySizes,
+                                       rewriter);
     auto srcSubView = mlir::ConverterUtils::makeSubViewOp(
         ptr, srcOffsets, boundarySizes, loc, rewriter);
     auto dstSubview = mlir::ConverterUtils::makeSubViewOp(
@@ -477,16 +477,20 @@ LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
         op, "can not lower uncontinuout masked loads");
   }
 
+  // When mask is provided but no `other`, default the masked-out elements
+  // to zero.
+  Value effectiveOther;
   if (other) {
-    auto scalarOther =
-        mlir::ConverterUtils::getScalarValue(other, loc, rewriter);
-    assert(
-        scalarOther &&
-        "other value used in masked load produced by unsupported instruction!");
-
-    fillTensorWithOtherForMaskScenario(scalarOther, allocOp, mstate.dims,
-                                       rewriter);
+    effectiveOther = mlir::ConverterUtils::getScalarValue(other, loc, rewriter);
+    assert(effectiveOther &&
+           "other value used in masked load produced by unsupported "
+           "instruction!");
+  } else {
+    effectiveOther = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getZeroAttr(memRefElementType));
   }
+  fillTensorWithOtherForMaskScenario(effectiveOther, allocOp, mstate.dims,
+                                     rewriter);
 
   // To enable deinterleave optimization with mask load, mask state along last
   // dimension couldn't be split, which means `dims.back()` must be equal to

--- a/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
@@ -163,6 +163,16 @@ LogicalResult tryRewriteIndirectFastPath(MemAccOpTy op, Location loc,
     Value mask = op.getMask();
     Value other = op.getOther();
     auto resultType = op.getType();
+    // when mask is set but `other` is null, default the masked-out elements to 0
+    // so the library function called by IndirectLoadConverter::matchAndRewrite
+    // sees a well-defined fallback value.
+    if (mask && !other) {
+      Type elemTy = (isa<RankedTensorType>(resultType))
+                        ? cast<RankedTensorType>(resultType).getElementType()
+                        : resultType;
+      other = rewriter.create<arith::ConstantOp>(
+          loc, rewriter.getZeroAttr(elemTy));
+    }
     auto newPtr = srcPtr;
     if (auto *defOp = srcPtr.getDefiningOp()) {
       if (auto intToPtrOp = dyn_cast<triton::IntToPtrOp>(defOp)) {
@@ -417,10 +427,22 @@ void UnstructuredMemAccessConverter<triton::LoadOp>::splatAndLoadScenario<
       /*PaddingOptionAttr=*/nullptr);
   loadedValue = rewriter.create<triton::SplatOp>(loc, op.getResult().getType(),
                                                  loadedValue);
-  if (mask)
+  if (mask) {
+    // when mask is set but `other` is null, default the masked-out elements
+    // to 0. Without this, `arith::SelectOp` would be constructed with a null
+    // false-value, which is illegal.
+    if (!other) {
+      auto resTy = loadedValue.getType();
+      Type elemTy = (isa<RankedTensorType>(resTy))
+                        ? cast<RankedTensorType>(resTy).getElementType()
+                        : resTy;
+      other = rewriter.create<arith::ConstantOp>(
+          loc, rewriter.getZeroAttr(elemTy));
+    }
     rewriter.replaceOpWithNewOp<arith::SelectOp>(op, mask, loadedValue, other);
-  else
+  } else {
     rewriter.replaceOp(op, loadedValue);
+  }
 }
 
 template <typename MemAccOpTy>
@@ -705,10 +727,21 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
                   UnitAttr::get(rewriter.getContext()));
     rewriter.restoreInsertionPoint(insertPoint);
     if constexpr (std::is_same_v<MemAccOpTy, triton::LoadOp>) {
-      if (op.getMask() && op.getOther()) {
+      if (op.getMask()) {
+        Value other = op.getOther();
+        // when mask is set but `other` is null, default the masked-out 
+        // elements to 0 so the mask semantics are preserved end-to-end.
+        if (!other) {
+          auto resTy = newOpResult.getType();
+          Type elemTy = (isa<RankedTensorType>(resTy))
+                            ? cast<RankedTensorType>(resTy).getElementType()
+                            : resTy;
+          other = rewriter.create<arith::ConstantOp>(
+              loc, rewriter.getZeroAttr(elemTy));
+        }
         rewriter
             .replaceOpWithNewOp<arith::SelectOp>(op, op.getMask(), newOpResult,
-                                                 op.getOther())
+                                                 other)
             ->setAttr(ConverterUtils::discreteAttrName,
                       UnitAttr::get(rewriter.getContext()));
       } else {

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_mask_load_without_other.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_mask_load_without_other.mlir
@@ -1,0 +1,44 @@
+// RUN: triton-opt --triton-to-linalg --split-input-file %s | FileCheck %s
+
+// CHECK: %[[CST:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK: %[[ALLOC:.*]] = memref.alloc() : memref<4096xf32>
+// CHECK: %[[IF:.*]] = arith.cmpi slt, {{.*}}, {{.*}} : index
+// CHECK: scf.if %[[IF]] {
+// CHECK-NEXT: linalg.fill ins(%[[CST]] : f32) outs(%[[ALLOC]] : memref<4096xf32>)
+// CHECK-NEXT: } {hivm.unlikely_condition}
+tt.func public @tensor_load_with_no_other(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32) attributes {noinline = false} {
+  %c4096_i32 = arith.constant 4096 : i32
+  %0 = tt.get_program_id x : i32
+  %1 = arith.muli %0, %c4096_i32 : i32
+  %2 = tt.make_range {end = 4096 : i32, start = 0 : i32} : tensor<4096xi32>
+  %3 = tt.splat %1 : i32 -> tensor<4096xi32>
+  %4 = arith.addi %3, %2 : tensor<4096xi32>
+  %5 = tt.splat %arg2 : i32 -> tensor<4096xi32>
+  %6 = arith.cmpi slt, %4, %5 : tensor<4096xi32>
+  %7 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<4096x!tt.ptr<f32>>
+  %8 = tt.addptr %7, %4 : tensor<4096x!tt.ptr<f32>>, tensor<4096xi32>
+  %9 = tt.load %8, %6 : tensor<4096x!tt.ptr<f32>>
+  %10 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<4096x!tt.ptr<f32>>
+  %11 = tt.addptr %10, %4 : tensor<4096x!tt.ptr<f32>>, tensor<4096xi32>
+  tt.store %11, %9, %6 : tensor<4096x!tt.ptr<f32>>
+  tt.return
+}
+
+// CHECK: %[[CST:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK: %[[ALLOC:.*]] = memref.alloc() : memref<4096xf32>
+// CHECK: %[[IF:.*]] = arith.cmpi slt, {{.*}}, {{.*}} : index
+// CHECK: scf.if %[[IF]] {
+// CHECK-NEXT: linalg.fill ins(%[[CST]] : f32) outs(%[[ALLOC]] : memref<4096xf32>)
+// CHECK-NEXT: } {hivm.unlikely_condition}
+tt.func public @load_with_boundary_check(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32) attributes {noinline = false} {
+  %c1_i64 = arith.constant 1 : i64
+  %c4096_i32 = arith.constant 4096 : i32
+  %0 = tt.get_program_id x : i32
+  %1 = arith.muli %0, %c4096_i32 : i32
+  %2 = arith.extsi %arg2 : i32 to i64
+  %3 = tt.make_tensor_ptr %arg0, [%2], [%c1_i64], [%1] {order = array<i32: 0>} : <tensor<4096xf32>>
+  %4 = tt.make_tensor_ptr %arg1, [%2], [%c1_i64], [%1] {order = array<i32: 0>} : <tensor<4096xf32>>
+  %5 = tt.load %3 {boundaryCheck = array<i32: 0>} : !tt.ptr<tensor<4096xf32>>
+  tt.store %4, %5 {boundaryCheck = array<i32: 0>} : !tt.ptr<tensor<4096xf32>>
+  tt.return
+}


### PR DESCRIPTION
…ing` is unset on Ascend

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
## Summary
The Ascend backend's `TritonToLinalg` pass used to leave the destination buffer uninitialized for masked `triton::LoadOp` when no `other` argument was provided, and for block-pointer loads with `boundary_check` when no `padding_option` was provided. The mask-out / out-of-bound lanes then contained whatever values were in the freshly-allocated memref, which is undefined behavior.
The NVIDIA backend already handles this case by emitting `mov.u{N} %r, 0` as the pre-init of the predicate-load destination (`LoadStoreOpToLLVM.cpp`, `initOperand`). This PR aligns the Ascend backend with that contract.
## Changes
**File:** `third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp`
### 1. Masked load without `other` (around line 480)
Mask path (LoadStoreConverter.cpp): when `mask` is set but `other` is null, build a zero constant of the element type and pass it to `fillTensorWithOtherForMaskScenario` as the fallback value. The subsequent subview + `memref.copy` only overwrites in-bounds lanes,  so the remaining lanes keep the zero fill.
**Before:**
```cpp
if (other) {
  auto scalarOther = mlir::ConverterUtils::getScalarValue(other, loc, rewriter);
  assert(scalarOther && "other value used in masked load ...");
  fillTensorWithOtherForMaskScenario(scalarOther, allocOp, mstate.dims, rewriter);
}
```
**After:**
```
Value effectiveOther;
if (other) {
  effectiveOther = mlir::ConverterUtils::getScalarValue(other, loc, rewriter);
  assert(effectiveOther && "other value used in masked load ...");
} else {
  effectiveOther = rewriter.create<arith::ConstantOp>(loc, rewriter.getZeroAttr(memRefElementType));
}
fillTensorWithOtherForMaskScenario(effectiveOther, allocOp, mstate.dims, rewriter);
```
### 2. Block-pointer load with boundary_check but no padding (around line 404)
Boundary-check path (LoadStoreConverter.cpp): drop the `if (padding.has_value())` guard and use `padding.value_or(PAD_ZERO) == PAD_NAN` to choose the fill value. Unset and explicit `zero` both produce zero; only explicit `nan` produces NaN. `getZeroAttr` is correct for both integer and floating-point element types.
**Before:**
```
if (padding.has_value()) {
  TypedAttr padAttr = rewriter.getZeroAttr(memRefElementType);
  if (padding.value() == triton::PaddingOption::PAD_NAN) {
    ...
  }
  ...
  fillTensorWithOtherForMaskScenario(padVal, allocOp, boundarySizes, rewriter);
}
```
**After:**
```
TypedAttr padAttr = rewriter.getZeroAttr(memRefElementType);
if (padding.value_or(triton::PaddingOption::PAD_ZERO) ==
    triton::PaddingOption::PAD_NAN) {
  ...
}
...
fillTensorWithOtherForMaskScenario(padVal, allocOp, boundarySizes, rewriter);
```
The value_or(PAD_ZERO) idiom treats nullopt as PAD_ZERO, so only an explicit padding_option="nan" produces NaN; both "zero" and unset now produce zero.
### Why it's safe
- The mask path is reached only when mask != null — the no-mask early return at line 436 guarantees that. So unconditional fill is always meaningful here.
- rewriter.getZeroAttr(Type) returns the right IntegerAttr / FloatAttr for all element types (int, fp16, bf16, fp32, fp64).
- The downstream memref::SubViewOp + memref::CopyOp only overwrites the in-bounds subview, so the mask-out / out-of-bound lanes keep whatever was filled in.
### Performance impact
A microbenchmark was run on an Ascend NPU to measure the overhead introduced by the unconditional zero-fill on the masked-load path. The benchmark issues a tl.load(ptr, mask=m) over a contiguous 1-D tensor with BLOCK=4096, weeping three tensor sizes that span the L2 / HBM boundary. Numbers are wall-clock kernel time (microseconds), median over do_bench runs:
#### case1
| lens | grid |no fill (us) | fill zero (us) | Δ (us) | relative overhead |
|---|---|---|---|---|---|
| 65537 | (17,) | 2.125 | 2.321 | +0.196 | +9.22 % |
| 1048577 | (257,) | 5.447 | 5.893 | +0.446 | +8.19 % |
| 16777217 | (4097,) | 80.971 | 84.941 | +3.970 | +4.90 % |

```python
@triton.jit
def load_mask_other_zero(x_ptr, out_ptr, N, BLOCK: tl.constexpr):
    pid = tl.program_id(0)
    offs = pid * BLOCK + tl.arange(0, BLOCK)
    v = tl.load(x_ptr + offs, mask=offs < N, other=0.0)
    tl.store(out_ptr + offs, v, mask=offs < N)

@triton.jit
def load_without_other(x_ptr, out_ptr, N, BLOCK: tl.constexpr):
    pid = tl.program_id(0)
    offs = pid * BLOCK + tl.arange(0, BLOCK)
    # In this case scene, mask load without other will not fill zero
    v = tl.load(x_ptr + offs, mask=offs < N)
    tl.store(out_ptr + offs, v, mask=offs < N)
```
#### case2
| lens | grid |no fill (us) | fill zero (us) | Δ (us) | relative overhead |
|---|---|---|---|---|---|
| 65537 | (1,) | 3.813 | 3.964 | +0.151 | +3.96 % |
| 1048577 | (1,) | 45.229 | 45.428 | +0.199 | +0.44 % |
| 16777217 | (1,) | 1561.113 | 1563.951 | +2.838 | +0.18 % |

```python
@triton.jit
def load_mask_other_zero_loop(x_ptr, out_ptr, N, BLOCK: tl.constexpr):
    for idx in tl.range(0, N, BLOCK):
        offs = idx + tl.arange(0, BLOCK)
        v = tl.load(x_ptr + offs, mask=offs < N, other=0.0)
        tl.store(out_ptr + offs, v, mask=offs < N)

@triton.jit
def load_without_other_loop(x_ptr, out_ptr, N, BLOCK: tl.constexpr):
    for idx in tl.range(0, N, BLOCK):
        offs = idx + tl.arange(0, BLOCK)
        # In this case scene, mask load without other will not fill zero
        v = tl.load(x_ptr + offs, mask=offs < N)
        tl.store(out_ptr + offs, v, mask=offs < N)
```
**Observations:**
1. Relative overhead shrinks as len grows (9.22 % → 4.90 %). This is the expected behaviour: the copy itself is bandwidth-bound and its cost grows linearly with N, while the fill is a single linear write of the same size and therefore scales identically. The fixed part of the cost (kernel launch, subview, IR scheduling) is the same in both runs, so it dilutes the relative percentage at larger len.
2. **When doing it on separate cores, only one core handles fill zero while the others don't, making this an important factor. But when a single core does it in a loop, the impact of fill zero gets evened out**.

---

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
