### PR TITLE
[TritonToUnstructure](fix) Fix bool masked store lowering in Unstructure

### DIFF
--- a/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
@@ -191,6 +191,19 @@ LogicalResult tryRewriteIndirectFastPath(MemAccOpTy op, Location loc,
            "src must be ptr type");
     Value value = op.getValue();
     Value mask = op.getMask();
+
+    // For bool store, unwrap ptr<i1> -> ptr<i8> bitcast before creating
+    // indirect_store. Keep ptr<i1> so TypeConverter can map it to memref<?xi8>.
+    if (auto bitcastOp = srcPtr.getDefiningOp<triton::BitcastOp>()) {
+      auto srcPtrTy =
+          dyn_cast<triton::PointerType>(bitcastOp.getSrc().getType());
+      auto dstPtrTy = dyn_cast<triton::PointerType>(bitcastOp.getType());
+
+      if (srcPtrTy && dstPtrTy && srcPtrTy.getPointeeType().isInteger(1) &&
+          dstPtrTy.getPointeeType().isInteger(8)) {
+        srcPtr = bitcastOp.getSrc();
+      }
+    }
     auto indirect = rewriter.create<triton::ascend::IndirectStoreOp>(
         loc, srcPtr, ptrOffset, value, mask);
     rewriter.eraseOp(op);

--- a/third_party/ascend/unittest/pytest_ut/test_bool_masked_store_cache.py
+++ b/third_party/ascend/unittest/pytest_ut/test_bool_masked_store_cache.py
@@ -1,0 +1,54 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import pytest
+import torch
+import torch_npu
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def bool_masked_store_cache_kernel(x_ptr, y_ptr, mask_ptr):
+    offsets = tl.program_id(0) + tl.arange(0, 1)
+
+    mask = tl.load(mask_ptr + offsets) != 0
+    value = tl.load(x_ptr + offsets)
+
+    tl.store(
+        y_ptr + offsets,
+        value,
+        mask=mask,
+        cache_modifier=".cg",
+        eviction_policy="evict_first",
+    )
+
+
+@pytest.mark.functiontest
+def test_bool_masked_store_with_cache_modifier_and_eviction_policy():
+    x = torch.tensor([True], dtype=torch.bool).npu()
+    y = torch.tensor([False], dtype=torch.bool).npu()
+    mask = torch.tensor([True], dtype=torch.bool).npu()
+
+    bool_masked_store_cache_kernel[(1, )](x, y, mask)
+
+    torch.npu.synchronize()
+
+    assert y.cpu().item() is True


### PR DESCRIPTION
### Background

In the Ascend backend, a masked store on `bool` tensors may fail during the `TritonToLinalg` stage when both `cache_modifier` and `eviction_policy` are specified. A minimal trigger is:

```python
tl.store(
    y_ptr + offsets,
    value,
    mask=mask,
    cache_modifier=".cg",
    eviction_policy="evict_first",
)
```

where `x`, `y`, and `mask` are all `torch.bool` tensors.

For bool memory accesses, Triton may generate a `tt.bitcast` from `ptr<i1>` to `ptr<i8>`:

```mlir
%27 = tt.bitcast %arg1 : !tt.ptr<i1> -> !tt.ptr<i8>
ascend.indirect_store %27 : <i8>, ...
```

During `TritonToUnstructure`, the original logic uses the bitcasted `!tt.ptr<i8>` as the base pointer of `ascend.indirect_store`.

Later, in `TritonToLinalg`, `IndirectStoreConverter` expects `src` to have already been converted by the TypeConverter into a `MemRefType`. However, the actual `src` is still `!tt.ptr<i8>`, which causes the conversion to fail with `expected MemRefType for src`.

### Changes

This PR handles the special bool pointer bitcast before creating `ascend.indirect_store` in `TritonToUnstructure`:

```mlir
tt.bitcast ptr<i1> -> ptr<i8>
```

When this pattern is detected, the bitcasted `ptr<i8>` is no longer used as the base pointer of `ascend.indirect_store`. Instead, the original `ptr<i1>` is used.

This allows the later `TritonToLinalg` TypeConverter to consistently map `ptr<i1>` to `memref<?xi8>`, ensuring that `IndirectStoreConverter` can process the store correctly.

### Result

Before this fix:

```text
failed to legalize unresolved materialization from () to ('!tt.ptr<i8>')
see existing live user here: ascend.indirect_store ...
expected MemRefType for src
```

After this fix:

```mlir
ascend.indirect_store %arg1 : <i1>, ...
```

The subsequent type conversion correctly maps the bool pointer to `memref<?xi8>`, and the related bool masked store case can compile and execute successfully.

### Tests

A minimal regression test is added to cover the following scenario:

* bool input tensor
* bool dynamic mask
* `tl.store` with `cache_modifier`
* `tl.store` with `eviction_policy`

The test reliably reproduces the original issue and verifies that the fixed path compiles and runs successfully.
