### PR TITLE
[ssbuffer](fix) fix flag id requirement calculation logic

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
@@ -34,7 +34,6 @@ namespace triton {
 // Maximum number of flag allocation attempts per transfer group
 static constexpr int kMaxFlagAttempts = 16;
 static constexpr int kMaxTotalFlags = 15;
-static constexpr int kFlagThresholdSingleBuffer = 7;
 
 // --- Attribute helpers ---
 
@@ -1050,7 +1049,10 @@ void AddMultiBufferOuterScopePass::runOnOperation()
     tagLoadStoreOpsWithCrossDeps(loadStoreByTid);
 
     // Check flag ID budget: hardware supports 16 flags (0-15).
-    // Each cross-core double-buffer group needs 2 flags (input + output).
+    // Each cross-core double-buffer group needs 1 additional output flag
+    // (in the worst case, ignoring output flag reuse). Module flags that
+    // are unrelated to fixpipe/copy multi-buffer must not trigger a
+    // downgrade, so we compare (maxFlagId + groupCount) against 15.
     std::set<int> usedFlags;
     module.walk([&](Operation *op) {
         if (isa<hivm::SyncBlockSetOp>(op) || isa<hivm::SyncBlockWaitOp>(op)) {
@@ -1066,8 +1068,21 @@ void AddMultiBufferOuterScopePass::runOnOperation()
         signalPassFailure();
         return;
     }
-    if (flagCount > kFlagThresholdSingleBuffer) {
-        LDBG("[FlagBudget] flag count " << flagCount << " > " << kFlagThresholdSingleBuffer << ", forcing single-buffer");
+    // Soft downgrade: only fixpipe/copy transfer groups consume new
+    // output flags. If (maxFlagId + groupCount) >= kMaxTotalFlags,
+    // the budget cannot accommodate all groups.
+    int maxFlagId = -1;
+    for (int f : usedFlags) {
+        if (f > maxFlagId) maxFlagId = f;
+    }
+    int groupCount = static_cast<int>(groups.size());
+    int sum = maxFlagId + groupCount;
+    LDBG("[FlagBudget] maxFlagId=" << maxFlagId
+                 << " groupCount=" << groupCount
+                 << " sum=" << sum << " (need < " << kMaxTotalFlags << ")");
+    if (sum >= kMaxTotalFlags) {
+        LDBG("[FlagBudget] budget exceeded (maxFlagId + groupCount >= "
+                     << kMaxTotalFlags << "), forcing single-buffer");
         isDoubleBuf = false;
     }
 


### PR DESCRIPTION
This pull request is to fix flag id requirement calculation logic for outer scope multi buffer module in ssbuffer.
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
