### PR TITLE
[ssbuffer](fix) flagid reuse for inter core multibuffer

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/FlagIdManager.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/FlagIdManager.h
@@ -35,6 +35,7 @@ class FlagIdManager {
 public:
   // Maximum flag count (hardware limitation)
   static constexpr int MAX_FLAG_ID = 14;
+  static constexpr int MULTI_MAX_FLAG_ID = 7;
   static constexpr int INVALID_FLAG_ID = -1;
 
   // Constructor: initialize with Module for scanning
@@ -46,7 +47,7 @@ public:
   // linear comparison in reuse analysis. Can be nullptr.
   int acquireId(Operation* insertionPoint);
 
-  int checkCurrentId();
+  bool checkCurrentId();
 
 private:
   // Scan existing Flag IDs

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/FlagIdManager.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/FlagIdManager.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "ascend/include/DynamicCVPipeline/Common/FlagIdManager.h"
+#include "ascend/include/DynamicCVPipeline/Common/BufferCountManager.h"
 #include "mlir/IR/Operation.h"
 #include "llvm/Support/Debug.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
@@ -63,7 +64,12 @@ int FlagIdManager::acquireId(Operation* insertionPoint)
     return ++currentMaxId;
 }
 
-int FlagIdManager::checkCurrentId()
+bool FlagIdManager::checkCurrentId()
 {
+    BufferCountManager::DepType depType = BufferCountManager::DepType::InterCore;
+    int outerBufferCount = BUFFER_COUNT.getBufferCountByType(depType);
+    if (outerBufferCount > 1) {
+        return currentMaxId <= MULTI_MAX_FLAG_ID;
+    }
     return currentMaxId <= MAX_FLAG_ID;
 }


### PR DESCRIPTION
# Main Changes
Enhance flag ID reuse when inter-core multi-buffer is enabled.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
