### PR TITLE
[ssbuffer](fix) check yield definingOp coretype

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -41,8 +41,8 @@
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Support/LLVM.h"
 
-#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
 
@@ -51,7 +51,6 @@ static constexpr const char *DEBUG_TYPE = "op-classifier";
 #define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
 #define LOG_DEBUG(...) LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__)
 using namespace mlir::triton;
-using namespace mlir::CVPipeline;
 
 namespace {
 
@@ -1122,7 +1121,7 @@ bool OpClassifierPass::handleYieldFromElseRegion(std::vector<OpCoreType> &coreTy
     }
 
     // Get the core_type attribute from then region yield
-    auto thenCoreTypeAttr = thenYieldForElse->getAttr(kCoreType);
+    auto thenCoreTypeAttr = thenYieldForElse->getAttr("ssbuffer.core_type");
     if (!thenCoreTypeAttr) {
         return false;
     }
@@ -1215,42 +1214,11 @@ void OpClassifierPass::processYieldOperation(Operation *op, Operation *thenYield
             // iter_arg that is passed through without modification), default to
             // VECTOR since no compute op is associated with it.
             if (Operation *def = operand.getDefiningOp()) {
-                // If def has multiple results, each result may have a different core_type.
-                // We need to find the specific result index and use the corresponding
-                // core_type from the stored multi-value attribute (e.g., "CUBE,VECTOR")
-                if (def->getNumResults() > 1) {
-                    if (!isa<scf::SCFDialect>(def->getDialect())) {
-                        LLVM_DEBUG(DBGS() << "[handleSCFYield] ERROR: def has multiple results but is not scf dialect: "
-                                          << def->getName().getStringRef() << "\n");
-                        return;
-                    }
-                    // Find which result index this operand corresponds to in def
-                    unsigned resultIdx = 0;
-                    for (unsigned idx = 0; idx < def->getNumResults(); ++idx) {
-                        if (def->getResult(idx) == operand) {
-                            resultIdx = idx;
-                            break;
-                        }
-                    }
-
-                    // Get core_type from def's attribute (stored as comma-separated multi-value)
-                    auto ctAttr = def->getAttr(kCoreType);
-                    if (auto ctStrAttr = dyn_cast<StringAttr>(ctAttr)) {
-                        std::string ctStr = ctStrAttr.getValue().str();
-                        coreTypes.push_back(parseCoreTypeFromString(ctStr, resultIdx));
-                    } else {
-                        // Fallback: use getCoreType(def)
-                        OpCoreType ct = getCoreType(def);
-                        coreTypes.push_back(ct == OP_CUBE_ONLY ? OP_CUBE_ONLY : OP_VECTOR_ONLY);
-                    }
+                OpCoreType ct = getCoreType(def);
+                if (ct == OP_CUBE_ONLY) {
+                    coreTypes.push_back(OP_CUBE_ONLY);
                 } else {
-                    // Non-scf operation: use getCoreType directly
-                    OpCoreType ct = getCoreType(def);
-                    if (ct == OP_CUBE_ONLY) {
-                        coreTypes.push_back(OP_CUBE_ONLY);
-                    } else {
-                        coreTypes.push_back(OP_VECTOR_ONLY);
-                    }
+                    coreTypes.push_back(OP_VECTOR_ONLY);
                 }
             } else {
                 // BlockArgument (e.g., iter_arg passed through scf.for) -> VECTOR
@@ -1262,18 +1230,16 @@ void OpClassifierPass::processYieldOperation(Operation *op, Operation *thenYield
     // Write ssbuffer.core_type attribute onto the yield op and its parent scf op
     if (!coreTypes.empty()) {
         std::string coreTypeStr = joinCoreTypes(coreTypes);
-        op->setAttr(kCoreType, StringAttr::get(op->getContext(), coreTypeStr));
+        op->setAttr("ssbuffer.core_type", StringAttr::get(op->getContext(), coreTypeStr));
 
         OpCoreType opCt = (coreTypeStr.find("CUBE") != std::string::npos) ? OP_CUBE_ONLY : OP_VECTOR_ONLY;
         opCoreTypes[op] = opCt;
 
         if (parentOp && llvm::isa<scf::SCFDialect>(parentOp->getDialect())) {
-            parentOp->setAttr(kCoreType, StringAttr::get(parentOp->getContext(), coreTypeStr));
+            parentOp->setAttr("ssbuffer.core_type", StringAttr::get(parentOp->getContext(), coreTypeStr));
             opCoreTypes[parentOp] = opCt;
         }
     }
-
-    return;
 }
 
 // ============================================================================
@@ -1290,19 +1256,44 @@ void OpClassifierPass::processYieldOperation(Operation *op, Operation *thenYield
 // values (derived from the defining ops of each yield operand).
 int OpClassifierPass::handleSCFYield()
 {
-    // Walk all scf.yield operations directly
-    getOperation().walk([&](scf::YieldOp yield) {
-        Operation *parentOp = yield->getParentOp();
-        Operation *thenYieldForElse = nullptr;
+    // Collect all scf.if operations
+    llvm::SmallVector<scf::IfOp> ifOps;
+    for (Operation *op : allOps) {
+        if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+            ifOps.push_back(ifOp);
+        }
+    }
 
-        if (auto ifOp = dyn_cast<scf::IfOp>(parentOp)) {
-            if (yield->getParentRegion() != &ifOp.getThenRegion() && !ifOp.getThenRegion().empty()) {
-                thenYieldForElse = ifOp.getThenRegion().back().getTerminator();
-            }
+    // Process scf.if operations: first then region, then else region
+    for (scf::IfOp ifOp : ifOps) {
+        Operation *thenYield = nullptr;
+        if (!ifOp.getThenRegion().empty()) {
+            thenYield = ifOp.getThenRegion().back().getTerminator();
         }
 
-        processYieldOperation(yield, thenYieldForElse);
-    });
+        if (isa<scf::YieldOp>(thenYield)) {
+            processYieldOperation(thenYield, nullptr);
+        }
+
+        if (!ifOp.getElseRegion().empty()) {
+            Operation *elseYield = ifOp.getElseRegion().back().getTerminator();
+            if (isa<scf::YieldOp>(elseYield)) {
+                processYieldOperation(elseYield, thenYield);
+            }
+        }
+    }
+
+    // Process remaining scf.yield operations (not inside scf.if, e.g. scf.for)
+    for (Operation *op : allOps) {
+        if (!isa<scf::YieldOp>(op))
+            continue;
+
+        Operation *parentOp = op->getParentOp();
+        if (dyn_cast_or_null<scf::IfOp>(parentOp))
+            continue;
+
+        processYieldOperation(op, nullptr);
+    }
 
     return 0;
 }
@@ -1523,7 +1514,7 @@ int OpClassifierPass::stampToIR()
         if (isa<ModuleOp, func::FuncOp>(op))
             continue;
 
-        op->setAttr(kCoreType, StringAttr::get(op->getContext(), coreTypeToString(coreType)));
+        op->setAttr("ssbuffer.core_type", StringAttr::get(op->getContext(), coreTypeToString(coreType)));
     }
 
     return 0;

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -355,6 +355,30 @@ void DataDependencyAnalysisPass::insertProducerAndRecordDeps(scf::ForOp forOp,
     }
 }
 
+bool checkYieldCoreType(mlir::Operation *yieldOp)
+{
+    if (!isa<scf::YieldOp>(yieldOp)) {
+        return false;
+    }
+    for (unsigned index = 0; index < yieldOp->getNumOperands(); ++index) {
+        mlir::Value value = yieldOp->getOperand(index);
+        llvm::StringRef yieldCoreType = getCoreTypeWithIndex(yieldOp, index);
+
+        mlir::Operation *definingOp = value.getDefiningOp();
+        if (!definingOp || !isa<scf::ForOp>(definingOp)) {
+            continue;
+        }
+        auto defResult = dyn_cast<mlir::OpResult>(value);
+        int resultIndex = defResult ? defResult.getResultNumber() : 0;
+        llvm::StringRef definingCoreType = getCoreTypeWithIndex(definingOp, resultIndex);
+
+        if (yieldCoreType != definingCoreType) {
+            return false;
+        }
+    }
+    return true;
+}
+
 // Process iterArg dependencies for all scf.for operations in the module.
 // This function iterates through all for loops and checks each iterArg to determine
 // if there are cross-core-type data dependencies.
@@ -372,7 +396,11 @@ void DataDependencyAnalysisPass::processIterArgDependencies()
     // Step2: Process each iterArg of each scf.for operation
     for (scf::ForOp forOp : forOps) {
         size_t numIterArgs = forOp.getInitArgs().size();
-
+        mlir::Operation *yieldOp = forOp.getBody()->getTerminator();
+        if (!checkYieldCoreType(yieldOp)) {
+            LOG_DEBUG("[ERROR]: Yield core type mismatch defining op\n");
+            signalPassFailure();
+        }
         for (int iterArgIndex = 0; iterArgIndex < numIterArgs; ++iterArgIndex) {
             mlir::Value initValue = forOp.getInits()[iterArgIndex];
             mlir::BlockArgument iterArg = forOp.getRegionIterArg(iterArgIndex);

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
@@ -24,7 +24,6 @@
 #include <optional>
 
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -643,25 +642,31 @@ static LogicalResult splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rew
     // This is the "c" in a*b+c, added after the matmul result
     rewriter.setInsertionPointAfterValue(splitInfo.outerOutValue);
 
-    constexpr size_t kMaxPreservedUsers = 2;
-    SmallPtrSet<Operation *, kMaxPreservedUsers> preservedUsers;
+    Operation *preservedUser = nullptr;
     if (splitInfo.mayNotExec && forOp) {
         auto lb = forOp.getLowerBound();
         auto ub = forOp.getUpperBound();
 
         Value executed = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sgt, ub, lb);
-        Value zeroValue;
-        if (auto floatType = dyn_cast<FloatType>(elmType)) {
-            APFloat zeroAPFloat = APFloat::getZero(floatType.getFloatSemantics());
-            zeroValue = rewriter.create<arith::ConstantFloatOp>(loc, zeroAPFloat, floatType).getResult();
-        } else if (auto intType = dyn_cast<IntegerType>(elmType)) {
-            zeroValue = rewriter.create<arith::ConstantIntOp>(loc, 0, intType).getResult();
-        }
-        auto fillOp = rewriter.create<linalg::FillOp>(loc, zeroValue, splitInfo.outerOutValue);
-        auto selectOp = rewriter.create<arith::SelectOp>(loc, executed, splitInfo.outerOutValue, fillOp.getResult(0));
-        newOutValue = selectOp.getResult();
-        preservedUsers.insert(selectOp);
-        preservedUsers.insert(fillOp);
+        auto ifOp = rewriter.create<scf::IfOp>(
+            loc,
+            executed,
+            [&](OpBuilder &thenBuilder, Location thenLoc) {
+                thenBuilder.create<scf::YieldOp>(thenLoc, splitInfo.outerOutValue);
+            },
+            [&](OpBuilder &elseBuilder, Location elseLoc) {
+                Value zeroValue;
+                if (auto floatType = dyn_cast<FloatType>(elmType)) {
+                    APFloat zeroAPFloat = APFloat::getZero(floatType.getFloatSemantics());
+                    zeroValue = elseBuilder.create<arith::ConstantFloatOp>(elseLoc, zeroAPFloat, floatType).getResult();
+                } else if (auto intType = dyn_cast<IntegerType>(elmType)) {
+                    zeroValue = elseBuilder.create<arith::ConstantIntOp>(elseLoc, 0, intType).getResult();
+                }
+                auto fillOp = elseBuilder.create<linalg::FillOp>(emptyOp.getLoc(), zeroValue, splitInfo.outerOutValue);
+                elseBuilder.create<scf::YieldOp>(elseLoc, fillOp.getResult(0));
+            });
+        newOutValue = ifOp.getResult(0);
+        preservedUser = ifOp;
         forOp->setAttr(CVPipeline::kHIVMMatmulLimitedInCubeAttr, rewriter.getUnitAttr());
     }
 
@@ -671,12 +676,13 @@ static LogicalResult splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rew
     } else {
         addOp = rewriter.create<arith::AddIOp>(loc, newOutValue, splitInfo.outerInValue).getOperation();
     }
-    if (preservedUsers.empty()) {
-        preservedUsers.insert(addOp);
+    if (preservedUser == nullptr) {
+        preservedUser = addOp;
     }
     addOp->setAttr(CVPipeline::kAddFromMatmul, rewriter.getUnitAttr());
-    splitInfo.outerOutValue.replaceUsesWithIf(
-        addOp->getResult(0), [&](OpOperand &operand) { return !preservedUsers.contains(operand.getOwner()); });
+    splitInfo.outerOutValue.replaceUsesWithIf(addOp->getResult(0), [preservedUser](OpOperand &operand) {
+        return !preservedUser->isAncestor(operand.getOwner());
+    });
 
     return success();
 }


### PR DESCRIPTION
# Main Changes
Revert "[ssbuffer](fix) handle multi-value core_type for scf op results in yield" and skip related cases

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
