### PR TITLE
[ssbuffer](fix) fix ssbuffer rollback debug

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -90,7 +90,8 @@ CoreType getOpCoreType(Operation *op);
 std::optional<int> getOpBlockId(Operation *op);
 llvm::LogicalResult verifyOpBlockId(Operation *op);
 int getAvailableBlockId(ModuleOp module);
-void setFallbackAttr(ModuleOp module);
+void setFallbackAttr(ModuleOp module, int errorCode);
+bool hasFallbackAttr(ModuleOp module);
 bool isScfOp(Operation *op);
 bool isOnlyDirectlyUse(Operation *preOp, Operation *nextOp,
                        const CVPipeline::MemoryDependenceGraph &memGraph);

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition.cpp
@@ -29,6 +29,7 @@
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.h"
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateForOps.h"
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
 #include "bishengir/Dialect/Scope/IR/Scope.h"
 #include "mlir/Pass/PassManager.h"
@@ -64,6 +65,10 @@ static LogicalResult verifyControlFlowPrerequisites(ModuleOp module) {
 
 void AddControlFlowConditionPass::runOnOperation() {
   ModuleOp module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
 
   LDBG("Enter add controlflow condition pass.\n");
   LDBG("before AddControlFlowCondition:");
@@ -122,7 +127,9 @@ void AddControlFlowConditionPass::runOnOperation() {
 
   if (failed(runPipeline(pm, module))) {
     LDBG("Pass failed!");
-    signalPassFailure();
+    if (!CVPipeline::hasFallbackAttr(module)) {
+      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
+    }
   }
 
   LDBG("Exit add controlflow condition pass.");

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CloneOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CloneOps.cpp
@@ -476,44 +476,49 @@ LogicalResult CloneOpsPass::validateClonedOpsInVector(ModuleOp module) {
 void CloneOpsPass::runOnOperation() {
   ModuleOp module = getOperation();
 
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   LDBG("before cloneOps:\n" << module << "\n");
 
   // Validate block_ids are consecutive before cloning
   if (failed(validateBlockIdsConsecutive(module))) {
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
     return;
   }
 
   // Clone ops in vector/cube to ensure that each block_id has its own
   // ops without sharing
-  module.walk([&](Operation *op) -> WalkResult {
+  auto walkResult = module.walk([&](Operation *op) -> WalkResult {
     if (!op->hasAttr(CVPipeline::kMainLoop)) {
       return WalkResult::advance();
     }
     auto forOp = dyn_cast<scf::ForOp>(op);
     if (!forOp) {
       LDBG("[Error]: op with ssbuffer.main_loop is not a scf::ForOp\n");
-      signalPassFailure();
       return WalkResult::interrupt();
     }
 
     if (failed(cloneOpsInMainLoop(forOp))) {
-      signalPassFailure();
       return WalkResult::interrupt();
     }
 
     if (failed(cleanupClonedOpsInMainLoop(forOp))) {
-      signalPassFailure();
       return WalkResult::interrupt();
     }
     return WalkResult::advance();
   });
+  if (walkResult.wasInterrupted()) {
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
+    return;
+  }
 
   LDBG("after cloneOps:\n" << module << "\n");
 
   // Validate no cloned tensor ops remaining in VECTOR main_loop forOp
   if (failed(validateClonedOpsInVector(module))) {
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
     return;
   }
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CreateIfOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/CreateIfOps.cpp
@@ -22,6 +22,11 @@
 
 #include "llvm/Support/Debug.h"
 
+#include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/CreateIfOps.h"
+#include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/Utils.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "bishengir/Dialect/Scope/IR/Scope.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -315,23 +320,25 @@ LogicalResult CreateIfOpsPass::createIfInMainLoop(
 void CreateIfOpsPass::runOnOperation() {
   ModuleOp module = getOperation();
 
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   LDBG("before createIfOps:\n" << module << "\n");
 
-  module.walk([&](Operation *op) -> WalkResult {
+  auto walkResult = module.walk([&](Operation *op) -> WalkResult {
     if (!op->hasAttr("ssbuffer.main_loop")) {
       return WalkResult::advance();
     }
     auto forOp = dyn_cast<scf::ForOp>(op);
     if (!forOp) {
       LDBG("[Error]: op with ssbuffer.main_loop is not a scf::ForOp\n");
-      signalPassFailure();
       return WalkResult::interrupt();
     }
 
     // Create if ops (scf.if %true) by block_id
     llvm::DenseMap<int, SmallVector<Operation *>> blockOps;
     if (failed(collectOpsByBlockId(forOp, blockOps))) {
-      signalPassFailure();
       return WalkResult::interrupt();
     }
 
@@ -344,17 +351,19 @@ void CreateIfOpsPass::runOnOperation() {
 
     if (failed(computeYieldValues(forOp, blockOps, thenYieldValues,
                                   elseYieldValues))) {
-      signalPassFailure();
       return WalkResult::interrupt();
     }
 
     if (failed(createIfInMainLoop(forOp, blockOps, thenYieldValues,
                                   elseYieldValues))) {
-      signalPassFailure();
       return WalkResult::interrupt();
     }
     return WalkResult::advance();
   });
+  if (walkResult.wasInterrupted()) {
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
+    return;
+  }
 
   LDBG("after createIfOps:\n" << module << "\n");
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/FlowOpt.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/FlowOpt.cpp
@@ -240,6 +240,10 @@ scf::IfOp FlowOptPass::createNewIfOpWithFlowOptCondition(scf::IfOp oldIfOp,
 void FlowOptPass::runOnOperation() {
   ModuleOp module = getOperation();
 
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   LDBG("Enter FlowOpt pass.\n");
   SmallVector<scf::ForOp> mainLoopForOps;
   module.walk([&](scf::ForOp forOp) {
@@ -258,7 +262,7 @@ void FlowOptPass::runOnOperation() {
     scf::IfOp secondIfOp = nullptr;
     if (findIfOpsInForOp(forOp, firstIfOp, secondIfOp) != FLOW_OPT_SUCCESS) {
       LDBG("Failed to find first and second ssbuffer.if IfOps.\n");
-      signalPassFailure();
+      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
       return;
     }
 
@@ -266,7 +270,7 @@ void FlowOptPass::runOnOperation() {
     Value originalCondition = secondIfOp.getCondition();
     if (!originalCondition) {
       LDBG("Second IfOp has no condition.\n");
-      signalPassFailure();
+      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
       return;
     }
 
@@ -277,7 +281,7 @@ void FlowOptPass::runOnOperation() {
                                                originalCondition);
     if (!newCondition) {
       LDBG("Failed to build flow optimization condition.\n");
-      signalPassFailure();
+      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
       return;
     }
 
@@ -286,7 +290,7 @@ void FlowOptPass::runOnOperation() {
         createNewIfOpWithFlowOptCondition(secondIfOp, newCondition);
     if (!newIfOp) {
       LDBG("Failed to create new IfOp.\n");
-      signalPassFailure();
+      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
       return;
     }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/InitDependentMap.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/InitDependentMap.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/InitDependentMap.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "llvm/ADT/DenseMap.h"
@@ -272,19 +273,24 @@ static void printDependentMaps(ControlFlowConditionInfo *info) {
 
 void InitDependentMapPass::runOnOperation() {
   ModuleOp module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   LDBG("Enter InitDependentMap pass.");
 
   // Step 1: Initialize crossCoreDependentMap
   if (initCrossCoreDependentMap(module, info) != 0) {
     LDBG("initCrossCoreDependentMap failed!");
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
     return;
   }
 
   // Step 2: Initialize intraCoreDependentMap
   if (initIntraCoreDependentMap(module, info) != 0) {
     LDBG("initIntraCoreDependentMap failed!");
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
     return;
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/ProcessArgs.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/ProcessArgs.cpp
@@ -23,6 +23,7 @@
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/ProcessArgs.h"
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition.h"
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/Utils.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/IRMapping.h"
@@ -509,10 +510,14 @@ LogicalResult ProcessArgsPass::processSharedIterArgs(ModuleOp module) {
 void ProcessArgsPass::runOnOperation() {
   ModuleOp module = getOperation();
 
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   LDBG("before processArgs:\n" << module << "\n");
 
   if (failed(processSharedIterArgs(module))) {
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
     return;
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
@@ -21,6 +21,7 @@
  */
 #include "third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.h"
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
 #include "bishengir/Dialect/HIVM/IR/HIVMImpl.h"
 #include "bishengir/Dialect/HIVM/IR/HIVMInterfaces.h"
@@ -1638,6 +1639,10 @@ int UpdateConditionInfoPass::updateIfConds(
 void UpdateConditionInfoPass::runOnOperation() {
   ModuleOp module = getOperation();
 
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   LDBG("Enter UpdateConditionInfo pass." << "\n");
   // Step1:Init the ssbufferPtrs
   SmallVector<SmallVector<Value>> ssbufferPtrs = allocSSBuffer(module);
@@ -1648,7 +1653,7 @@ void UpdateConditionInfoPass::runOnOperation() {
 
   if (updateResult != UPDATE_CONDITION_INFO_SUCCESS) {
     LDBG("updateIfConds failed!");
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
   }
 
   LDBG("Exit UpdateConditionInfo pass." << "\n");

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateForOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateForOps.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateForOps.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
 #include "bishengir/Dialect/Scope/IR/Scope.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -579,6 +580,10 @@ LogicalResult UpdateForOpsPass::analyzeTensorIterArgDependencies(
 void UpdateForOpsPass::runOnOperation() {
   ModuleOp module = getOperation();
 
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   LDBG("before updateForOps:\n" << module << "\n");
 
   // Use provided info, or create a local one if not available
@@ -588,14 +593,14 @@ void UpdateForOpsPass::runOnOperation() {
   // Analyze the dependencies of the tensor type iter_args in the main_loop with
   // the ssbuffer.if ops
   if (failed(analyzeTensorIterArgDependencies(module, infoToUse))) {
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
     return;
   }
 
   // Derive block counters from ssbuffer.if if blockCounterNums is empty
   if (infoToUse->blockCounterNums.empty()) {
     if (failed(deriveBlockCountersFromIfOps(module, infoToUse))) {
-      signalPassFailure();
+      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
       return;
     }
   }
@@ -605,13 +610,13 @@ void UpdateForOpsPass::runOnOperation() {
                     !infoToUse->intraCoreDependentMap.empty() ||
                     !infoToUse->tensorIterArgDepsMap.empty()))
     if (failed(addBlockCountersAndInnerDepConds(module, infoToUse))) {
-      signalPassFailure();
+      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
       return;
     }
 
   // Insert PIPE_S inter-core synchronization
   if (failed(insertInterCorePipeS(module))) {
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
     return;
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.cpp
@@ -1129,6 +1129,10 @@ int UpdateLoopIterTimesPass::UpdateForLoopIteration(
 void UpdateLoopIterTimesPass::runOnOperation() {
   ModuleOp module = getOperation();
 
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   LDBG("before updateloopitertimes:\n" << module);
   LDBG("\nEnter UpdateLoopIterTimesPass!");
 
@@ -1140,7 +1144,7 @@ void UpdateLoopIterTimesPass::runOnOperation() {
   ret = GetMainLoopIdToLoopOpMap(module, cmap, vmap);
   if (ret != 0) {
     LDBG("GetMainLoopIdToLoopOpMap Failed!");
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
   }
 
   // step2: Calculate info for each loop operation, store into the same
@@ -1149,12 +1153,12 @@ void UpdateLoopIterTimesPass::runOnOperation() {
   ret = ComputeMainLoopTimes(cmap, infoMap);
   if (ret != 0) {
     LDBG("ComputeMainLoopTimes from cube Failed!");
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
   }
   ret = ComputeMainLoopTimes(vmap, infoMap);
   if (ret != 0) {
     LDBG("ComputeMainLoopTimes from vector Failed!");
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
   }
 
   // step3: Update loop iteration count (process loop operations with same id
@@ -1162,7 +1166,7 @@ void UpdateLoopIterTimesPass::runOnOperation() {
   ret = UpdateForLoopIteration(cmap, vmap, infoMap);
   if (ret != 0) {
     LDBG("Update ForLoop Iteration Failed!");
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
   }
   LDBG("after UpdateForLoopIteration:\n" << module);
 
@@ -1170,7 +1174,7 @@ void UpdateLoopIterTimesPass::runOnOperation() {
   ret = replaceForOpCounterInIfOps();
   if (ret != 0) {
     LDBG("replaceForOpCounterInIfOps Failed!");
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
   }
 
   LDBG("after updateloopitertimes:\n" << module);

--- a/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
@@ -96,12 +96,19 @@ void AddDynamicCVPipelinePass::runOnOperation() {
   pm.addPass(createAddControlFlowConditionPass());
   pm.addPass(createRemoveSsbufAttrPass());
 
-  if (failed(runPipeline(pm, moduleOp))) {
+  if (failed(runPipeline(pm, moduleOp)) ||
+      CVPipeline::hasFallbackAttr(moduleOp)) {
     auto errCodeAttr =
         moduleOp->getAttrOfType<IntegerAttr>(CVPipeline::ERRCODE_ATTR);
     if (!errCodeAttr) {
       moduleOp->emitWarning() << "[" << DEBUG_TYPE << "] "
-                              << "Pass failed; fallback to compilation without "
+                              << "Unexpected pass failure (no fallback attr "
+                                 "set); fallback to compilation without "
+                                 "dynamic CV pipeline.";
+    } else {
+      moduleOp->emitWarning() << "[" << DEBUG_TYPE << "] "
+                              << "Pass failed, "
+                              << "fallback to compilation without "
                                  "dynamic CV pipeline.";
     }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache.cpp
@@ -23,6 +23,7 @@
 #include "ascend/include/DynamicCVPipeline/AllocMultiCache.h"
 #include "ascend/include/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.h"
 #include "ascend/include/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 
 #include "mlir/Pass/PassManager.h"
 #include "llvm/Support/Debug.h"
@@ -42,6 +43,11 @@ using namespace triton;
 // Run the pass
 void AllocMultiCachePass::runOnOperation() {
   ModuleOp module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   OpPassManager pm(module.getOperationName());
   LDBG("Enter pass.");
   LDBG("before innerscope:\n" << module << "\n");
@@ -53,7 +59,10 @@ void AllocMultiCachePass::runOnOperation() {
 
   if (failed(runPipeline(pm, module))) {
     module->emitError() << "[" << DEBUG_TYPE << "] Pass failed!";
-    signalPassFailure();
+    if (!CVPipeline::hasFallbackAttr(module)) {
+      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
+    }
+    return;
   }
 
   LDBG("Process successfully");

--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
@@ -1808,11 +1808,16 @@ void AddMultiBufferInnerScopePass::getDependentDialects(
 
 void AddMultiBufferInnerScopePass::runOnOperation() {
   auto module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   OpBuilder builder(module.getContext());
 
   LDBG("Enter pass.");
 
-  module.walk([&](scope::ScopeOp scope) -> WalkResult {
+  auto walkResult = module.walk([&](scope::ScopeOp scope) -> WalkResult {
     // Step 1: Check if scope has coreType attribute
     auto coreTypeAttr =
         scope->getAttrOfType<hivm::TCoreTypeAttr>(hivm::TCoreTypeAttr::name);
@@ -1832,7 +1837,6 @@ void AddMultiBufferInnerScopePass::runOnOperation() {
         collectMainLoopsRecursively(scope.getBodyRegion(), mainLoopForOps);
     if (foundCount < 0) {
       LDBG("collectMainLoopsRecursively failed");
-      signalPassFailure();
       return WalkResult::interrupt();
     }
     if (foundCount == 0)
@@ -1844,18 +1848,20 @@ void AddMultiBufferInnerScopePass::runOnOperation() {
       scf::ForOp nestedMainloop = findNestedMainloopInForOp(mainLoopForOp);
       if (nestedMainloop) {
         LDBG("Nested main_loop found, this is not allowed");
-        signalPassFailure();
         return WalkResult::interrupt();
       }
       if (addInnerMultiBuffer(mainLoopForOp, builder, scope, groupId) != 0) {
         LDBG("addInnerMultiBuffer failed");
-        signalPassFailure();
         return WalkResult::interrupt();
       }
     }
 
     return WalkResult::advance();
   });
+  if (walkResult.wasInterrupted()) {
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
+    return;
+  }
 
   LDBG("Process successfully");
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
@@ -18,6 +18,7 @@
 
 #include "ascend/include/DynamicCVPipeline/Common/BufferCountManager.h"
 #include "ascend/include/DynamicCVPipeline/Common/FlagIdManager.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 
 static constexpr const char *DEBUG_TYPE = "AddMultiBufferOuterScope";
 static constexpr const char *kTransferId = "ssbuffer.transfer_id";
@@ -1144,6 +1145,11 @@ static int addPollingControlFlow(DenseMap<int, TransferGroupInfo> &groups) {
 
 void AddMultiBufferOuterScopePass::runOnOperation() {
   ModuleOp module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   LDBG("============================================================");
   LDBG("[AddMultiBufferOuterScope] ENTER");
   LDBG("============================================================");
@@ -1156,7 +1162,7 @@ void AddMultiBufferOuterScopePass::runOnOperation() {
   DenseMap<int, TransferGroupInfo> groups;
   if (collectTransferGroupData(module, opsByTid, flagIdMgr, groups)) {
     LDBG("[Step 1/3] FAILED: no valid transfer groups found");
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
     return;
   }
   LDBG("[Step 1/3] Done: " << groups.size() << " transfer groups");
@@ -1194,7 +1200,7 @@ void AddMultiBufferOuterScopePass::runOnOperation() {
          << flagCount << " > " << kMaxTotalFlags << ", halting pass");
     module->emitError() << "[FlagBudget] flag count " << flagCount << " > "
                         << kMaxTotalFlags << ", halting pass";
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
     return;
   }
   if (flagCount > kFlagThresholdSingleBuffer) {
@@ -1208,7 +1214,7 @@ void AddMultiBufferOuterScopePass::runOnOperation() {
     LDBG("[Step 2/3] Start: output buffer creation");
     if (createOutputBuffers(groups, module)) {
       LDBG("[Step 2/3] FAILED: output buffer creation failed");
-      signalPassFailure();
+      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
       return;
     }
     LDBG("[Step 2/3] Done");
@@ -1216,7 +1222,7 @@ void AddMultiBufferOuterScopePass::runOnOperation() {
     LDBG("[Step 3/3] Start: polling control flow");
     if (addPollingControlFlow(groups)) {
       LDBG("[Step 3/3] FAILED: polling control flow failed");
-      signalPassFailure();
+      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
       return;
     }
     LDBG("[Step 3/3] Done");

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "mlir/Pass/PassManager.h"
 #include "llvm/Support/Debug.h"
 
@@ -33,6 +34,10 @@ using namespace triton;
 
 void AnalyzeDataFlowPass::runOnOperation() {
   ModuleOp module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
 
   LDBG("Enter AnalyzeDataFlow pass.");
 
@@ -51,7 +56,10 @@ void AnalyzeDataFlowPass::runOnOperation() {
   pm.addPass(createAnalyzeCubeContolFLowInputChainPass());
 
   if (failed(runPipeline(pm, module))) {
-    signalPassFailure();
+    if (!CVPipeline::hasFallbackAttr(module)) {
+      LDBG("Pass failed; fallback to compilation without dynamic CV pipeline.");
+      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
+    }
   }
 
   LDBG("Exit AnalyzeDataFlow pass.");

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeArgs.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeArgs.cpp
@@ -204,6 +204,10 @@ bool checkTensorArgsInMainLoop(ModuleOp module) {
 void AnalyzeArgsPass::runOnOperation() {
   ModuleOp module = getOperation();
 
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   LDBG("Before AnalyzeArgs:\n" << module << "\n");
 
   if (failed(isInterceptedModule(module))) {
@@ -211,8 +215,7 @@ void AnalyzeArgsPass::runOnOperation() {
   }
 
   if (checkTensorArgsInMainLoop(module)) {
-    CVPipeline::setFallbackAttr(module);
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_IGNORED);
     return;
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeCubeContolFLowInputChain.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeCubeContolFLowInputChain.cpp
@@ -161,11 +161,14 @@ bool checkCubeControlFlowInputChain(ModuleOp module) {
 void AnalyzeCubeControlFlowInputChainPass::runOnOperation() {
   ModuleOp module = getOperation();
 
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   LDBG("Enter AnalyzeCubeControlFlowInputChainPass.");
 
   if (checkCubeControlFlowInputChain(module)) {
-    setFallbackAttr(module);
-    signalPassFailure();
+    setFallbackAttr(module, ERRCODE_IGNORED);
     return;
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeFlag.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeFlag.cpp
@@ -81,9 +81,12 @@ void AnalyzeFlagPass::runOnOperation() {
 
   LDBG("Before AnalyzeFlag:\n" << module << "\n");
 
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   if (checkFlagIdValidity(module)) {
-    setFallbackAttr(module);
-    signalPassFailure();
+    setFallbackAttr(module, ERRCODE_IGNORED);
     return;
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
@@ -81,11 +81,14 @@ static LogicalResult verifyFuncNames(ModuleOp module) {
 void AnalyzeNamePass::runOnOperation() {
   ModuleOp module = getOperation();
 
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   LDBG("Before AnalyzeName:\n" << module << "\n");
 
   if (failed(verifyFuncNames(module))) {
-    CVPipeline::setFallbackAttr(module);
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_IGNORED);
     return;
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeScope.cpp
@@ -147,13 +147,13 @@ static LogicalResult verifyMainLoop(ModuleOp module) {
   if (!hasMainLoopForOp) {
     LDBG("[INFO]: No cycle of multiple iterations, the DynamicCVPipeline pass "
          "will be interrupted, and resumed to the original workflow.");
-    CVPipeline::setFallbackAttr(module);
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_IGNORED);
     return failure();
   }
 
   if (!checkVecScopeMainLoop(module)) {
     LDBG("[INFO]: No op beside matmul add in vector main loop.");
-    CVPipeline::setFallbackAttr(module);
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_IGNORED);
     return failure();
   };
 
@@ -165,10 +165,13 @@ static LogicalResult verifyMainLoop(ModuleOp module) {
 void AnalyzeScopePass::runOnOperation() {
   ModuleOp module = getOperation();
 
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   LDBG("Before AnalyzeScope:\n" << module << "\n");
 
   if (failed(verifyMainLoop(module))) {
-    signalPassFailure();
     return;
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -85,10 +85,14 @@ int getAvailableBlockId(ModuleOp module) {
   return maxBlockId + 1;
 }
 
-void setFallbackAttr(ModuleOp module) {
+void setFallbackAttr(ModuleOp module, int errorCode) {
   OpBuilder builder(module.getContext());
   module->setAttr(CVPipeline::ERRCODE_ATTR,
-                  builder.getI32IntegerAttr(CVPipeline::ERRCODE_IGNORED));
+                  builder.getI32IntegerAttr(errorCode));
+}
+
+bool hasFallbackAttr(ModuleOp module) {
+  return module->hasAttr(CVPipeline::ERRCODE_ATTR);
 }
 
 bool isVectorOnlyOp(Operation *op) {

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
@@ -604,6 +604,11 @@ void FixpipeOptPass::getDependentDialects(DialectRegistry &registry) const {
 
 void FixpipeOptPass::runOnOperation() {
   ModuleOp module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   auto &aliasAnalysis = getAnalysis<AliasAnalysis>();
   CVPipeline::MemoryDependenceGraph memDepGraph(module, aliasAnalysis);
   LOG_DEBUG("== FixpipeOpt Pass Start ==\n");

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeVectorIfBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeVectorIfBlockPass.cpp
@@ -242,6 +242,11 @@ public:
 
   void runOnOperation() override {
     ModuleOp module = getOperation();
+
+    if (CVPipeline::hasFallbackAttr(module)) {
+      return;
+    }
+
     LOG_DEBUG("Before: " << *module);
     auto &aa = getAnalysis<AliasAnalysis>();
     CVPipeline::MemoryDependenceGraph memGraph(module, aa);

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UBUsageOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UBUsageOptPass.cpp
@@ -776,6 +776,11 @@ void mlir::triton::UBUsageOptPass::runOnOperation() {
   LOG_DEBUG("--- Pass: UBUsageOpt ---\n");
 
   ModuleOp module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   auto &aliasAnalysis = getAnalysis<AliasAnalysis>();
   CVPipeline::MemoryDependenceGraph memDepGraph(module, aliasAnalysis);
   auto bm = CVPipeline::ComputeBlockIdManager(module);

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
@@ -434,6 +434,11 @@ public:
 
   void runOnOperation() override {
     ModuleOp module = getOperation();
+
+    if (CVPipeline::hasFallbackAttr(module)) {
+      return;
+    }
+
     LOG_DEBUG("Before: " << *module << "\n");
     auto &aa = getAnalysis<AliasAnalysis>();
     CVPipeline::MemoryDependenceGraph memGraph(module, aa);
@@ -445,7 +450,8 @@ public:
 
     for (memref::AllocOp allocOp : allocOps) {
       if (failed(tryUnifyForAlloc(allocOp, memGraph, bm))) {
-        signalPassFailure();
+        CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
+        return;
       }
     }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
@@ -35,6 +35,10 @@ using namespace triton;
 void ComputeBlockOptPass::runOnOperation() {
   ModuleOp module = getOperation();
 
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   OpPassManager pm(module.getOperationName());
 
   /**
@@ -58,7 +62,9 @@ void ComputeBlockOptPass::runOnOperation() {
   pm.addPass(createReorderOpsByBlockIdPass());
 
   if (failed(runPipeline(pm, module))) {
-    signalPassFailure();
+    if (!CVPipeline::hasFallbackAttr(module)) {
+      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
+    }
     return;
   }
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory.cpp
@@ -56,7 +56,7 @@ void DecoupleComputeAndMemoryPass::runOnOperation() {
 
   if (failed(runPipeline(pm, module))) {
     module->emitError() << "[" << DEBUG_TYPE << "] Pass failed!";
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
   }
 
   LDBG("Process successfully");

--- a/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoad.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoad.cpp
@@ -153,7 +153,7 @@ void AddMultiBufferToGMLoadPass::runOnOperation() {
   if (failed(applyMultiBufferToGMLoadLoops())) {
     module.emitError() << "[" << DEBUG_TYPE
                        << "] Step 3 applyMultiBufferToGMLoadLoops failed";
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
     return;
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock.cpp
@@ -43,6 +43,11 @@ static constexpr const char *DEBUG_TYPE = "plan-compute-block";
 // Run the pass
 void PlanComputeBlockPass::runOnOperation() {
   ModuleOp module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   OpPassManager pm(module.getOperationName());
   LOG_DEBUG("Enter pass.\n");
 
@@ -59,14 +64,10 @@ void PlanComputeBlockPass::runOnOperation() {
   pm.addPass(createReorderOpsByBlockIdPass());
 
   if (failed(runPipeline(pm, module))) {
-    auto errCodeAttr =
-        module->getAttrOfType<IntegerAttr>(CVPipeline::ERRCODE_ATTR);
-    int errCode = errCodeAttr ? static_cast<int>(errCodeAttr.getInt())
-                              : CVPipeline::ERRCODE_FAILED;
-    if (errCode != CVPipeline::ERRCODE_IGNORED) {
-      module->emitError() << "[" << DEBUG_TYPE << "] Pass failed!";
+    if (!CVPipeline::hasFallbackAttr(module)) {
+      LOG_DEBUG("Pass failed!\n");
+      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
     }
-    signalPassFailure();
     return;
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -1556,6 +1556,10 @@ int OpClassifierPass::stampToIR() {
 void OpClassifierPass::runOnOperation() {
   ModuleOp module = getOperation();
 
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   LLVM_DEBUG(DBGS() << "\n--- Before Plan Compute Block  --->\n");
   LLVM_DEBUG(DBGS() << module << "\n");
 
@@ -1571,13 +1575,13 @@ void OpClassifierPass::runOnOperation() {
 
   // Step 1: Pattern match around each linalg.matmul to find CUBE seeds
   if (patternMatchCUBE() != 0) {
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
     return;
   }
 
   // Step 2: CUBE upstream BFS from seed loads
   if (propagateCubeUpstream() != 0) {
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
     return;
   }
 
@@ -1590,31 +1594,31 @@ void OpClassifierPass::runOnOperation() {
 
   // Step 4: Mark remaining operations as VECTOR
   if (markRemainingAsVector() != 0) {
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
     return;
   }
 
   // Step 5: VECTOR upstream BFS
   if (propagateVectorUpstream() != 0) {
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
     return;
   }
 
   // Step 6: Handle CUBE_AND_VECTOR operations
   if (handleCubeAndVector() != 0) {
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
     return;
   }
 
   // Step 7: Process SCF yield results
   if (handleSCFYield() != 0) {
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
     return;
   }
 
   // Step 8: Stamp to IR
   if (stampToIR() != 0) {
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
     return;
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -1588,7 +1588,7 @@ void OpClassifierPass::runOnOperation() {
   // Step 3: Penetrate CUBE coloring into pure loader for-loops.
   if (CVPipeline::isCubeBlockMergeEnabled() &&
       penetrateCubeIntoForLoops() != 0) {
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
     return;
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
@@ -618,6 +618,11 @@ void mlir::triton::PlanCubeBlockPass::runOnOperation() {
   LOG_DEBUG(
       "\n--- Step 2: Partitioning compute blocks for cube operations --->\n");
   auto moduleOp = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(moduleOp)) {
+    return;
+  }
+
   auto &aa = getAnalysis<AliasAnalysis>();
   auto memGraph = MemoryDependenceGraph(moduleOp, aa);
   auto bm = ComputeBlockIdManager(moduleOp);
@@ -631,7 +636,7 @@ void mlir::triton::PlanCubeBlockPass::runOnOperation() {
     return WalkResult::advance();
   });
   if (result.wasInterrupted()) {
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(moduleOp, CVPipeline::ERRCODE_FAILED);
   }
   LOG_DEBUG("\n--- Step 2: end --->\n");
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp
@@ -456,20 +456,27 @@ void PlanVectorBlockPass::runOnOperation() {
   LOG_DEBUG("\n---PlanVectorBlockPass start---\n");
   // 1. Build memory dependence graph
   auto moduleOp = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(moduleOp)) {
+    return;
+  }
+
   auto &aa = getAnalysis<AliasAnalysis>();
   auto memDepGraph = MemoryDependenceGraph(moduleOp, aa);
   auto bm = ComputeBlockIdManager(moduleOp);
 
   // 2. search blocks in topo order and assign block id for each block
   llvm::SmallVector<Block *> blocks;
-  moduleOp.walk([&](Block *block) {
+  auto result = moduleOp.walk([&](Block *block) {
     if (llvm::failed(planVectorBlockId(block, memDepGraph, bm))) {
-      moduleOp.emitError() << "[" << DEBUG_TYPE
-                           << "] Failed to plan vector block id for block";
-      signalPassFailure();
-      return;
+      return WalkResult::interrupt();
     }
+    return WalkResult::advance();
   });
+  if (result.wasInterrupted()) {
+    LOG_DEBUG("Failed to plan vector block id for block\n");
+    CVPipeline::setFallbackAttr(moduleOp, CVPipeline::ERRCODE_FAILED);
+  }
 }
 
 std::unique_ptr<OperationPass<ModuleOp>> createPlanVectorBlockPass() {

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
@@ -397,14 +397,13 @@ void ReorderOpsByBlockIdPass::runOnOperation() {
   OpBuilder const builder(&getContext());
 
   auto moduleOp = getOperation();
-  
+
   if (CVPipeline::hasFallbackAttr(moduleOp)) {
     return;
   }
 
   LOG_DEBUG("Input mlir:\n" << moduleOp << "\n");
   llvm::dbgs().flush();
-
 
   auto &aa = getAnalysis<AliasAnalysis>();
   auto memGraph = MemoryDependenceGraph(moduleOp, aa);
@@ -424,7 +423,7 @@ void ReorderOpsByBlockIdPass::runOnOperation() {
   });
 
   if (result.wasInterrupted()) {
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(moduleOp, CVPipeline::ERRCODE_FAILED);
     return;
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
@@ -397,8 +397,14 @@ void ReorderOpsByBlockIdPass::runOnOperation() {
   OpBuilder const builder(&getContext());
 
   auto moduleOp = getOperation();
+  
+  if (CVPipeline::hasFallbackAttr(moduleOp)) {
+    return;
+  }
+
   LOG_DEBUG("Input mlir:\n" << moduleOp << "\n");
   llvm::dbgs().flush();
+
 
   auto &aa = getAnalysis<AliasAnalysis>();
   auto memGraph = MemoryDependenceGraph(moduleOp, aa);

--- a/third_party/ascend/lib/DynamicCVPipeline/PreCheckAvailable.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PreCheckAvailable.cpp
@@ -44,6 +44,10 @@ static constexpr const char *DEBUG_TYPE =
 void PreCheckAvailablePass::runOnOperation() {
   ModuleOp module = getOperation();
 
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   LDBG("Enter PreCheckAvailable pass.");
   PassManager pm(&getContext(), module.getOperationName());
 
@@ -52,8 +56,8 @@ void PreCheckAvailablePass::runOnOperation() {
   pm.addPass(createPreCheckMatmulPass());
 
   if (failed(runPipeline(pm, module))) {
-    CVPipeline::setFallbackAttr(module);
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_IGNORED);
+    return;
   }
 
   LDBG("Exit PreCheckAvailable pass.");

--- a/third_party/ascend/lib/DynamicCVPipeline/PreCheckAvailable/PreCheckBlacklist.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PreCheckAvailable/PreCheckBlacklist.cpp
@@ -52,6 +52,11 @@ void PreCheckBlacklistPass::getDependentDialects(
 
 void PreCheckBlacklistPass::runOnOperation() {
   ModuleOp module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   Operation *foundBlacklistOp = nullptr;
   llvm::StringRef foundOpName;
 
@@ -75,7 +80,7 @@ void PreCheckBlacklistPass::runOnOperation() {
        << foundOpName
        << " operation was found, which indicates that it has been optimized "
           "for the Ascend.");
-  signalPassFailure();
+  CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_IGNORED);
 }
 
 namespace mlir {

--- a/third_party/ascend/lib/DynamicCVPipeline/PreCheckAvailable/PreCheckMatmul.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PreCheckAvailable/PreCheckMatmul.cpp
@@ -37,6 +37,11 @@ static constexpr const char *DEBUG_TYPE = "pre-check-matmul";
 
 void PreCheckMatmul::runOnOperation() {
   ModuleOp module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   linalg::MatmulOp firstMatmulOp = nullptr;
 
   module.walk([&](linalg::MatmulOp matmulOp) -> WalkResult {
@@ -51,7 +56,7 @@ void PreCheckMatmul::runOnOperation() {
 
   LDBG("SSBUFFER will be skipped because no linalg.matmul operation was found, "
        "which indicating that this op is a pure vector computation.");
-  signalPassFailure();
+  CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_IGNORED);
 }
 
 namespace mlir {

--- a/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
@@ -51,6 +51,11 @@ static constexpr llvm::StringLiteral kAttrsToRemove[]{
 
 void RemoveSsbufAttrPass::runOnOperation() {
   auto module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   module->walk([](Operation *op) {
     LOG_DEBUG("Removing ssbuf attrs of " << *op);
     for (auto attrName : kAttrsToRemove) {

--- a/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/AddMultiBufferToGMLoad.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/AddMultiBufferToGMLoad.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "ascend/include/DynamicCVPipeline/Common/BufferCountManager.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/SeparateMemoryFromCompute/AddMultiBufferToGMLoadInternal.h"
 #include "ascend/include/DynamicCVPipeline/SeparateMemoryFromCompute/AddMultiBufferToGMLoadPass.h"
 
@@ -135,6 +136,11 @@ void AddMultiBufferToGMLoadPass::cleanupTransformedIR() {
 
 void AddMultiBufferToGMLoadPass::runOnOperation() {
   auto module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   LOG_DEBUG("Enter add-multi-buffer-to-gm-load pass\n");
   LOG_DEBUG("Before add-multi-buffer-to-gm-load:\n" << module << "\n");
 
@@ -153,7 +159,7 @@ void AddMultiBufferToGMLoadPass::runOnOperation() {
   if (failed(applyMultiBufferToGMLoadLoops())) {
     module.emitError() << "[" << DEBUG_TYPE
                        << "] Step 3 applyMultiBufferToGMLoadLoops failed";
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
     return;
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/AsyncLoadHoisting.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/AsyncLoadHoisting.cpp
@@ -20,6 +20,7 @@
  * THE SOFTWARE.
  */
 
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/SeparateMemoryFromCompute/AsyncLoadHoistingPass.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -346,6 +347,10 @@ static void asyncLoadHoistingImpl(Region &region) {
 
 void AsyncLoadHoistingPass::runOnOperation() {
   auto module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
 
   LLVM_DEBUG({
     llvm::dbgs() << "[async-load-hoisting] Before AsyncLoadHoistingPass:\n"

--- a/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromComputePass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromComputePass.cpp
@@ -22,6 +22,7 @@
 
 #include "ascend/include/DynamicCVPipeline/SeparateMemoryFromComputePass.h"
 #include "ascend/include/DynamicCVPipeline/Common/BufferCountManager.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/SeparateMemoryFromCompute/AddMultiBufferToGMLoadPass.h"
 #include "ascend/include/DynamicCVPipeline/SeparateMemoryFromCompute/AsyncLoadHoistingPass.h"
 #include "mlir/Pass/PassManager.h"
@@ -36,6 +37,10 @@ using namespace triton;
 
 void SeparateMemoryFromComputePass::runOnOperation() {
   ModuleOp module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
 
   int depth = BufferCountManager::getInstance().getBufferCountByType(
       BufferCountManager::DepType::LoadStore);
@@ -56,7 +61,10 @@ void SeparateMemoryFromComputePass::runOnOperation() {
 
   if (failed(runPipeline(pm, module))) {
     module->emitError() << "[" << DEBUG_TYPE << "] Pass failed!";
-    signalPassFailure();
+    if (!CVPipeline::hasFallbackAttr(module)) {
+      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
+    }
+    return;
   }
 
   LDBG("Process successfully");

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/AddBlockIdForControlOps.h"
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h"
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h"
@@ -42,6 +43,11 @@ using namespace triton;
 // Run the pass
 void SplitDataflowPass::runOnOperation() {
   ModuleOp module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   OpPassManager pm(module.getOperationName());
   LDBG("Enter pass.");
 
@@ -68,8 +74,11 @@ void SplitDataflowPass::runOnOperation() {
   pm.addPass(createReorderOpsByBlockIdPass());
 
   if (failed(runPipeline(pm, module))) {
-    module->emitError() << "[" << DEBUG_TYPE << "] Pass failed!";
-    signalPassFailure();
+    if (!CVPipeline::hasFallbackAttr(module)) {
+      module->emitError() << "[" << DEBUG_TYPE << "] Pass failed!";
+      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
+    }
+    return;
   }
 
   LDBG("Process successfully");

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/AddBlockIdForControlOps.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/AddBlockIdForControlOps.cpp
@@ -39,6 +39,10 @@ void AddBlockIdForControlOpsPass::runOnOperation() {
   LOG_DEBUG("\n--- enter AddBlockIdForControlOpsPass --->\n");
   ModuleOp module = getOperation();
 
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   // Step 1: find the max block_id
   int maxBlockId = CVPipeline::getAvailableBlockId(module) - 1;
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -246,7 +246,8 @@ void DataDependencyAnalysisPass::collectDepInfo(
   if (commonLevelIds.first == -1 || commonLevelIds.second == -1) {
     LOG_DEBUG("Could not find common level block IDs for producer and consumer "
               "blocks");
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
+    return;
   }
 
   depInfo.producerBlockId = commonLevelIds.first;
@@ -411,7 +412,8 @@ void DataDependencyAnalysisPass::processIterArgDependencies() {
           }
         }
         LOG_DEBUG("iterarg init core_type conflicts with yield");
-        signalPassFailure();
+        CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
+        return;
       }
 
       auto diffUsers = collectDiffCoreTypeUsers(iterArg, initCoreType);
@@ -580,17 +582,17 @@ void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info) {
   auto &aliasAnalysis = getAnalysis<mlir::AliasAnalysis>();
   MemoryDependenceGraph memDepGraph(module, aliasAnalysis);
 
-  module.walk([&](mlir::Operation *op) {
+  auto walkResult = module.walk([&](mlir::Operation *op) -> WalkResult {
     if (op->getNumRegions() > 0) {
-      return;
+      return WalkResult::advance();
     }
     if (isa<annotation::MarkOp, gpu::BarrierOp>(op)) {
-      return;
+      return WalkResult::advance();
     }
     auto currBlockIdOpt = CVPipeline::getOpBlockId(op);
     llvm::StringRef currCoreType = getSsbufferCoreType(op);
     if (!currBlockIdOpt || currCoreType.empty()) {
-      return;
+      return WalkResult::advance();
     }
     int currBlockId = static_cast<int>(*currBlockIdOpt);
 
@@ -601,7 +603,7 @@ void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info) {
       if (predOp->getNumRegions() > 0) {
         auto realdeps = memDepGraph.getRealDependency(predOp, op);
         if (realdeps.empty()) {
-          return;
+          return WalkResult::advance();
         }
         for (mlir::Operation *realPredOp : realdeps) {
           if (isa<annotation::MarkOp, gpu::BarrierOp>(realPredOp)) {
@@ -619,7 +621,7 @@ void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info) {
           if (producerBlockId == -1 || consumerBlockId == -1) {
             LOG_DEBUG("Could not find common level block IDs for producer and "
                       "consumer blocks");
-            signalPassFailure();
+            return WalkResult::interrupt();
           }
           collectMemDepInfo(realPredCoreType, producerBlockId, consumerBlockId,
                             realPredBlockId, currBlockId, memoryDependencies);
@@ -645,7 +647,7 @@ void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info) {
       if (producerBlockId == -1 || consumerBlockId == -1) {
         LOG_DEBUG("Could not find common level block IDs for producer and "
                   "consumer blocks");
-        signalPassFailure();
+        return WalkResult::interrupt();
       }
       if (producerBlockId == consumerBlockId) {
         continue;
@@ -660,7 +662,11 @@ void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info) {
                                         << "\nconsumer Block: " << currBlockId
                                         << "\nconsumer Op: " << *op << "\n");
     }
+    return WalkResult::advance();
   });
+  if (walkResult.wasInterrupted()) {
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
+  }
   LOG_DEBUG("=== mem dep analysis complete ===\n");
 }
 
@@ -798,6 +804,10 @@ std::pair<int, int> DataDependencyAnalysisPass::findCommonLevelBlockIds(
 void DataDependencyAnalysisPass::runOnOperation() {
   LOG_DEBUG("\n--- enter DataDependencyAnalysisPass --->\n");
   module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
 
   auto &info = getAnalysis<DataDependencyInfo>();
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -268,8 +268,8 @@ SmallVector<int64_t> InterCoreTransferAndSyncPass::computeExpectedShape(
   if (isOnlyDepInMatmul) {
     if ((isMatmulA && newN != N) || (isMatmulB && newM != M)) {
       LOG_DEBUG("nd2nz shape is unaligned and matmul A/B is from cube");
-      CVPipeline::setFallbackAttr(module);
-      signalPassFailure();
+      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_IGNORED);
+      return {};
     }
   }
 
@@ -405,8 +405,8 @@ void InterCoreTransferAndSyncPass::extractMatmulResult(
   mlir::Operation *paddingAccOp = linalgFillOp;
   if (!matmulCIsEmpty(acc)) {
     LOG_DEBUG("nd2nz shape is unaligned and matmul C is not empty");
-    CVPipeline::setFallbackAttr(module);
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_IGNORED);
+    return;
   }
 
   Value newAccResult = paddingAccOp->getResult(0);

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -228,7 +228,8 @@ SmallVector<int64_t> InterCoreTransferAndSyncPass::computeExpectedShape(
   static constexpr int NdShapeLength = 2;
   if (!tensorTy || tensorTy.getRank() != NdShapeLength) {
     LOG_DEBUG("source shape is not 2-dim!");
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
+    return {};
   }
 
   int64_t M = tensorTy.getDimSize(0);
@@ -674,7 +675,7 @@ InterCoreTransferAndSyncPass::findMainLoopforTransfer(Operation *endOp,
   if (lca != startOp->getParentOp()) {
     LOG_DEBUG("startOp and endOp are not in the same parent block, which is "
               "unexpected.");
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
   }
   Operation *current = lca;
   while (current) {
@@ -1660,14 +1661,18 @@ void InterCoreTransferAndSyncPass::runOnOperation() {
   LOG_DEBUG("\n--- enter InterCoreTransferAndSyncPass --->\n");
   module = getOperation();
 
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   // Phase 1: Initialize FlagIdManager as local variable
   FlagIdManager flagManager(module);
   FlagIdReuseManager flagIdReuseManager;
 
   // Phase 2: Execute transfer and sync insertion
   if (failed(processDependencies(flagManager, flagIdReuseManager))) {
-    signalPassFailure();
     LOG_DEBUG("Error: Inter-core transfer and sync failed.\n");
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
     return;
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/MarkMainLoop.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/MarkMainLoop.cpp
@@ -39,6 +39,10 @@ void MarkMainLoopPass::runOnOperation() {
   LOG_DEBUG("\n--- enter MarkMainLoopPass --->\n");
   ModuleOp module = getOperation();
 
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   int mainLoopIdCounter = 0;
   SmallVector<scf::ForOp> mainLoops;
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/PreserveControlAttrsCanonicalize.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/PreserveControlAttrsCanonicalize.cpp
@@ -136,6 +136,10 @@ static void populateCanonicalizationPatterns(MLIRContext *ctx,
 } // namespace
 
 void mlir::triton::PreserveControlAttrsCanonicalizePass::runOnOperation() {
+  if (CVPipeline::hasFallbackAttr(getOperation())) {
+    return;
+  }
+
   debugDumpIr("before PreserveControlAttrsCanonicalizePass", getOperation());
 
   RewritePatternSet patterns(&getContext());
@@ -149,7 +153,7 @@ void mlir::triton::PreserveControlAttrsCanonicalizePass::runOnOperation() {
                                    FrozenRewritePatternSet(std::move(patterns)),
                                    config))) {
     getOperation()->emitError("PreserveControlAttrsCanonicalizePass failed");
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(getOperation(), CVPipeline::ERRCODE_FAILED);
     return;
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/RefineArgsBlockId.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/RefineArgsBlockId.cpp
@@ -22,6 +22,7 @@
 
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/RefineArgsBlockId.h"
 #include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -152,6 +153,11 @@ void processOnefor(scf::ForOp forOp, CVPipeline::ComputeBlockIdManager &bm,
 void RefineArgsBlockIdPass::runOnOperation() {
   LOG_DEBUG("\n--- enter RefineArgsBlockIdPass --->\n");
   ModuleOp moduleOp = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(moduleOp)) {
+    return;
+  }
+
   CVPipeline::ComputeBlockIdManager bm(moduleOp);
   auto &aa = getAnalysis<AliasAnalysis>();
   auto memDepGraph = CVPipeline::MemoryDependenceGraph(moduleOp, aa);

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
@@ -26,6 +26,9 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
 
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "bishengir/Dialect/Scope/IR/Scope.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -967,6 +970,11 @@ void mlir::triton::SeparateCVScopePass::getDependentDialects(
 
 void mlir::triton::SeparateCVScopePass::runOnOperation() {
   auto module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
   SmallVector<func::FuncOp> funcOps;
   module.walk([&](func::FuncOp funcOp) { funcOps.push_back(funcOp); });
 
@@ -978,7 +986,7 @@ void mlir::triton::SeparateCVScopePass::runOnOperation() {
     }
     if (failed(separateScopes(funcOp))) {
       logDebug("SeparateCVScopePass failed on func '", funcOp.getName(), "'");
-      signalPassFailure();
+      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
       return;
     }
   }

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp.cpp
@@ -44,13 +44,19 @@ namespace mlir::triton {
 
 void StandardizeOpPass::runOnOperation() {
   auto op = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(op)) {
+    return;
+  }
+
   LOG_DEBUG("Input mlir:\n" << op);
   OpPassManager pm(op.getOperationName());
   pm.addPass(createPatternMatchRewritePass());
 
   if (llvm::failed(runPipeline(pm, op))) {
     LOG_DEBUG("Pipeline Failed!");
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(op, CVPipeline::ERRCODE_FAILED);
+    return;
   }
 
   bool findMayNotExec = false;
@@ -62,8 +68,8 @@ void StandardizeOpPass::runOnOperation() {
 
   if (findMayNotExec) {
     LOG_DEBUG("Matmul may not execute!");
-    CVPipeline::setFallbackAttr(op);
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(op, CVPipeline::ERRCODE_IGNORED);
+    return;
   }
 }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.cpp
@@ -43,6 +43,11 @@ static constexpr llvm::StringLiteral needSplitAllFuncNme[]{""};
 
 void PatternMatchRewritePass::runOnOperation() {
   auto moduleOp = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(moduleOp)) {
+    return;
+  }
+
   LOG_DEBUG("Input mlir:\n" << moduleOp);
 
   bool needSplitAll = false;
@@ -65,7 +70,7 @@ void PatternMatchRewritePass::runOnOperation() {
   if (llvm::failed(
           applyPatternsGreedily(moduleOp, std::move(patterns), config))) {
     LOG_DEBUG("matchAndRewrite does not converge!");
-    signalPassFailure();
+    CVPipeline::setFallbackAttr(moduleOp, CVPipeline::ERRCODE_FAILED);
     return;
   }
   LOG_DEBUG("Output mlir:\n" << moduleOp);

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
@@ -738,6 +738,10 @@ static LogicalResult splitMatmul(linalg::MatmulOp matmulOp,
 LogicalResult
 SplitMatmulPattern::matchAndRewrite(linalg::MatmulOp matmulOp,
                                     PatternRewriter &rewriter) const {
+  if (CVPipeline::hasFallbackAttr(matmulOp->getParentOfType<ModuleOp>())) {
+    return failure();
+  }
+
   LOG_DEBUG("check matmulOp = " << matmulOp);
   auto splitInfoOpt = shouldSplit(matmulOp, needSplitAll);
   if (!splitInfoOpt.has_value()) {


### PR DESCRIPTION
### Background
DynamicCVPipeline's pass failure handling previously relied on MLIR's signalPassFailure() + PassManager crash recovery, which triggers side effects such as IR dumps from the crash reproducer. This change switches to propagating failure state via the module attribute triton_ascend.dynamic_cv_pipeline.rc .

### Main Changes
1. Abstract fallback detection helper
   
   - Added hasFallbackAttr(ModuleOp) in Common/Utils to uniformly detect whether a preceding pass has already set the fallback attribute.
   - Changed setFallbackAttr signature to take an errorCode parameter; all call sites now explicitly pass ERRCODE_FAILED / ERRCODE_IGNORED .
2. Early return at sub-pass entry (short-circuit chain)
   
   - Every pass's runOnOperation() now starts with a hasFallbackAttr check and returns immediately on hit.
   - Forms a short-circuit chain: once a pass sets the fallback, all subsequent passes skip execution, avoiding duplicate attribute setting and further processing of a marked-failed module.
3. Replace signalPassFailure() with setFallbackAttr()
   
   - Removed signalPassFailure() across the entire pipeline; failure state is now carried by the module attribute.
   - Error code semantics:
     - ERRCODE_IGNORED (2): intentional give-up, e.g. blacklist match, non-matmul kernel, nd2nz alignment issues.
     - ERRCODE_FAILED (1): unexpected failure, e.g. BFS failure, non-converging pattern match, topological sort failure.
   - The failed(runPipeline) branch in wrapper passes is kept as a defensive fallback that sets ERRCODE_FAILED when the sub-pass did not.
   - Failures inside walk callbacks use WalkResult::interrupt() to stop traversal, followed by a single setFallbackAttr after the walk.
### Scope
All 9 pass chains: PreCheckAvailable, StandardizeOp, PlanComputeBlock, SplitDataflow, AnalyzeDataFlow, SeparateMemoryFromCompute, AllocMultiCache, AddControlFlowCondition, RemoveAttributes.
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
