### PR TITLE
[Interpret](fix) fix intertpret bug of TA  3.6 extension ops 

### DIFF
--- a/python/triton/runtime/ascend_interpreter.py
+++ b/python/triton/runtime/ascend_interpreter.py
@@ -31,7 +31,7 @@ import warnings
 import contextlib
 import numpy as np
 import triton.language as tl
-from .interpreter import InterpreterBuilder, TensorHandle, ReduceOps, _get_np_dtype
+from .interpreter import InterpreterBuilder, TensorHandle, ReduceOps, _get_np_dtype, _patch_builtin, _LangPatchScope
 from .._C.libtriton import interpreter as _interpreter
 
 
@@ -46,9 +46,9 @@ class AscendReduceOps(ReduceOps):
             return self.min_max(input_param[0], val_reduce_op=np.min, idx_reduce_op=np.argmin)
         elif self.combine_fn == tl.standard._argmax_combine_tie_break_left:
             return self.min_max(input_param[0], val_reduce_op=np.max, idx_reduce_op=np.argmax)
-        # Ta has modified the implemention of tl.max
-        elif self.combine_fn == tl.standard._elementwise_max_default:
+        elif self.combine_fn == tl.standard._elementwise_max:
             return self.min_max(input_param[0], val_reduce_op=np.nanmax, idx_reduce_op=None)
+        # TA add function _elementwise_max_propagate_nan
         elif self.combine_fn == tl.standard._elementwise_max_propagate_nan:
             return self.min_max(input_param[0], val_reduce_op=np.max, idx_reduce_op=None)
         elif self.combine_fn == tl.standard._elementwise_min:
@@ -145,7 +145,7 @@ class AscendInterpreterBuilder(InterpreterBuilder):
             # "ascend_option2",
         ]
 
-    def patch_extensions(self, fn):
+    def patch_extensions(self, fn, scope: _LangPatchScope):
         """
         Patch Ascend extension modules for the given function.
 
@@ -154,9 +154,8 @@ class AscendInterpreterBuilder(InterpreterBuilder):
         the function's global namespace.
 
         :param fn: The kernel function to patch extensions for
+        :param scope: The language patch scope to use for patching
         """
-        # Import _patch_builtin from parent module
-        from .interpreter import _patch_builtin
         self._patch_lang_ascend(fn)
 
         # Patch all modules in fn's globals that might be extension modules
@@ -166,12 +165,12 @@ class AscendInterpreterBuilder(InterpreterBuilder):
             try:
                 # Check if it looks like an extension module (has builtin functions)
                 if hasattr(value, '__name__') and 'extension' in str(value.__name__):
-                    _patch_builtin(value, self)
+                    _patch_builtin(value, self, scope)
                 # Also try patching any module-like object that might have builtin functions
                 elif hasattr(value, '__dict__') and not isinstance(value, type):
                     # Try to patch it and ignore if it fails
                     try:
-                        _patch_builtin(value, self)
+                        _patch_builtin(value, self, scope)
                     except Exception:
                         pass
             except Exception:
@@ -180,7 +179,7 @@ class AscendInterpreterBuilder(InterpreterBuilder):
         # Also try importing extension directly as fallback
         try:
             import triton.language.extra.cann.extension as extension
-            _patch_builtin(extension, self)
+            _patch_builtin(extension, self, scope)
         except (ImportError, AttributeError):
             # Extension module not available (e.g., non-Ascend backend)
             pass

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -1220,11 +1220,12 @@ def _patch_lang(fn):
         _patch_lang_tensor(lang.tensor, scope)
         _patch_lang_core(lang, scope)
     _patch_builtin(tl.core.tensor_descriptor_base, interpreter_builder, scope)
-    return scope
 
     # Patch Ascend extensions if using AscendInterpreterBuilder
     if hasattr(interpreter_builder, 'patch_extensions'):
-        interpreter_builder.patch_extensions(fn)
+        interpreter_builder.patch_extensions(fn, scope)
+
+    return scope
 
 
 def _tuple_create(arg, contents):


### PR DESCRIPTION
### Summary
In version 3.6, the implementation of the _patch_builtin function is modified. The extension ops in the TA interpreter mode needs to adapt to this change.
### Changes
1、Fix incorrect changes made during previous migration code modifications in interpreter.py
2、Modify the call to the _patch_builtin function in ascend_interpreter.py

### Tests
<img width="1372" height="215" alt="{B584B02D-9CE2-4034-A6A2-F2F5EFAAF834}" src="https://github.com/user-attachments/assets/8301e382-5418-4b7b-b339-69f8ae731676" />
