### PR TITLE
[TritonToLinalg](fix) Fix dynamic memref offset mismatch

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -1202,16 +1202,12 @@ void TritonToLinalgPass::runOnOperation() {
       markOp->setAttr(hivm::AddressSpaceAttr::getMnemonic(),
                       {hivm::AddressSpaceAttr::get(rewriter.getContext(),
                                                    hivm::AddressSpace::GM)});
-      auto oldMemrefType =
-          cast<MemRefType>(reinterpretCastOp.getResult().getType());
-      auto newMemrefType = MemRefType::get(
-          oldMemrefType.getShape(), oldMemrefType.getElementType(),
-          StridedLayoutAttr::get(&getContext(), ShapedType::kDynamic,
-                                 staticStrides));
       rewriter.replaceOpWithNewOp<memref::ReinterpretCastOp>(
-          reinterpretCastOp, newMemrefType, newCastOp, ValueRange({}),
-          reinterpretCastOp.getSizes(), reinterpretCastOp.getStrides(),
-          SmallVector<int64_t>({0}), reinterpretCastOp.getStaticSizes(),
+          reinterpretCastOp,
+          cast<MemRefType>(reinterpretCastOp.getResult().getType()), newCastOp,
+          ValueRange({}), reinterpretCastOp.getSizes(),
+          reinterpretCastOp.getStrides(), SmallVector<int64_t>({0}),
+          reinterpretCastOp.getStaticSizes(),
           reinterpretCastOp.getStaticStrides());
     }
     rewriter.eraseOp(op);

--- a/third_party/ascend/unittest/pytest_ut/test_indirect_load_pointer_cast_precise_size.py
+++ b/third_party/ascend/unittest/pytest_ut/test_indirect_load_pointer_cast_precise_size.py
@@ -1,0 +1,62 @@
+import torch
+import torch_npu  # noqa: F401
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _indirect_load_from_i64_ptr_kernel(
+    block_table_ptrs,
+    positions,
+    out,
+    BLOCK_SIZE: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    offsets = tl.arange(0, BLOCK)
+
+    block_table_ptr = tl.load(block_table_ptrs).to(tl.pointer_type(tl.int32))
+
+    pos = tl.load(positions + offsets)
+    block_indices = pos // BLOCK_SIZE
+
+    # Regression point:
+    # int64 runtime address -> pointer<i32> -> vector indirect load.
+    block_numbers = tl.load(block_table_ptr + block_indices)
+
+    slot_ids = block_numbers * BLOCK_SIZE + pos % BLOCK_SIZE
+    tl.store(out + offsets, slot_ids.to(tl.int64))
+
+
+def test_indirect_load_pointer_cast_precise_size_e2e():
+    block_size = 4
+    block = 8
+
+    block_table_cpu = torch.tensor([10, 11, 12, 13], dtype=torch.int32)
+    positions_cpu = torch.tensor(
+        [0, 1, 4, 7, 8, 11, 12, 15],
+        dtype=torch.int32,
+    )
+
+    block_table = block_table_cpu.npu()
+    positions = positions_cpu.npu()
+    out = torch.empty((block, ), dtype=torch.int64, device="npu")
+
+    block_table_ptrs = torch.tensor(
+        [block_table.data_ptr()],
+        dtype=torch.int64,
+    ).npu()
+
+    _indirect_load_from_i64_ptr_kernel[(1, )](
+        block_table_ptrs,
+        positions,
+        out,
+        BLOCK_SIZE=block_size,
+        BLOCK=block,
+    )
+
+    torch.npu.synchronize()
+
+    expected = (block_table_cpu[positions_cpu // block_size] * block_size + positions_cpu % block_size).to(torch.int64)
+
+    assert torch.equal(out.cpu(), expected)


### PR DESCRIPTION
### Background

Some Triton kernels in the Ascend backend may fail during the `TritonToLinalg` pipeline when a runtime address is loaded from an integer tensor, cast to a pointer type, and then used as the base pointer of a vector memory access.

Typical patterns include:

```python
data_ptr = tl.load(data_ptrs + bid)
data_ptr = tl.cast(data_ptr, tl.pointer_type(tl.uint8))

value = tl.load(
    data_ptr + src_locs[:, None] * stride + copy_offset[None, :],
    mask=mask,
)
```

and:

```python
block_table_ptr = tl.load(block_table_ptrs).to(tl.pointer_type(tl.int32))
block_numbers = tl.load(block_table_ptr + block_indices)
```

These patterns are lowered through `hivm.hir.pointer_cast` and `memref.reinterpret_cast`. Later, the PointerCast precise-size rewrite recalculates the pointer cast size and replaces the original `memref.reinterpret_cast`.

### Root cause

The previous implementation rebuilt the result memref type of `memref.reinterpret_cast` and unconditionally set the layout offset to dynamic:

```cpp
StridedLayoutAttr::get(&getContext(), ShapedType::kDynamic, staticStrides)
```

This changed a type such as:

```mlir
memref<1xi32, strided<[1]>>
```

into:

```mlir
memref<1xi32, strided<[1], offset: ?>>
```

For `triton_indirect_load`, the call was originally created with the expected operand type:

```mlir
memref<1xi32, strided<[1]>>
```

After the PointerCast precise-size rewrite changed the defining `reinterpret_cast` result type to use `offset:?`, the operand type no longer matched the callee signature, causing verifier errors such as:

```text
'func.call' op operand type mismatch:
expected operand type 'memref<1xi32, strided<[1]>>',
but provided 'memref<1xi32, strided<[1], offset: ?>>'
```

However, simply forcing the layout offset to `0` is also incorrect. Some kernels, such as 2D `uint8` copy kernels, originally produce memref types with dynamic layout offset:

```mlir
memref<1x128xi8, strided<[?, 1], offset: ?>>
```

Forcing these types to `offset = 0` breaks downstream `memref.subview` layout inference and causes verifier failures.

Therefore, the issue is not that the offset should always be dynamic or always zero. The real problem is that the precise-size rewrite should not change the original `memref.reinterpret_cast` result layout.

### Fix

This PR updates the PointerCast precise-size rewrite to preserve the original result memref type of `memref.reinterpret_cast`.

Instead of reconstructing a new memref type with a newly chosen layout offset, the rewrite now reuses the original result type:

```cpp
      rewriter.replaceOpWithNewOp<memref::ReinterpretCastOp>(
          reinterpretCastOp,
          cast<MemRefType>(reinterpretCastOp.getResult().getType()), newCastOp,
          ValueRange({}), reinterpretCastOp.getSizes(),
          reinterpretCastOp.getStrides(), SmallVector<int64_t>({0}),
          reinterpretCastOp.getStaticSizes(),
          reinterpretCastOp.getStaticStrides());
```

The rewrite still folds the original reinterpret offset into the newly computed pointer address, but it no longer changes the result memref layout.

This preserves both cases correctly:

1. For `triton_indirect_load`, an original type like `memref<1xi32, strided<[1]>>` remains unchanged, so the `func.call` operand type continues to match the callee signature.
2. For dynamic-layout copy kernels, an original type like `memref<1x128xi8, strided<[?, 1], offset: ?>>` also remains unchanged, so downstream `memref.subview` operations keep valid layout inference.
