### PR TITLE
[Autotune](fix) Enable L2 cache clearing for NPU autotune

### DIFF
--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -2382,7 +2382,7 @@ class AutoTilingTuner(Autotuner):
                     list(run_fns.values()),
                     warmup=warmup,
                     active=active,
-                    clear_l2_cache=False,
+                    clear_l2_cache=True,
                     target_kernel_name=target_kernel_name,
                 )
                 assert len(time_cost) == len(run_fns)


### PR DESCRIPTION
## Summary

- Enable L2 cache clearing for NPU profiling used by autotune config selection.
- Keep the change scoped to the autotune `do_bench_npu` call path.

## Motivation

Autotune results for NPU profiling were sensitive to candidate ordering because configs were benchmarked sequentially with L2 cache state carried between candidates. Clearing L2 before each profiled kernel run makes the comparison fairer and reduces order-dependent selection.

## Validation

- `python3 -m py_compile third_party/ascend/backend/runtime/autotuner.py`
- `git diff --check`
