### PR TITLE
[TritonToLinalg](fix) Skip maxsi clamp for non-negative constant offsets

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
@@ -1549,6 +1549,10 @@ void BlockDataParser::rewriteMakeTensorPtrOp(
 
   data.getOffsetsRef() =
       std::move(llvm::map_to_vector(op.getOffsets(), [&](Value v) {
+        if (auto constVal = getConstantIntValue(v)) {
+          if (constVal.value() >= 0)
+            return getOpFoldResultOfLayoutInfo(v, rewriter);
+        }
         auto zeroVal = rewriter.create<arith::ConstantOp>(
             loc, rewriter.getI32IntegerAttr(0));
         v = rewriter.create<arith::MaxSIOp>(loc, v, zeroVal);


### PR DESCRIPTION
## Problem

`rewriteMakeTensorPtrOp` unconditionally wraps `tt.make_tensor_ptr` offsets in `arith.maxsi(offset, 0)` to clamp negative offsets (from MR !975, fix negative offset padding for boundary check). For non-negative constant offsets (e.g. `0`), this creates `maxsi(%c0, 0)` which cannot be constant-folded by `getConstifiedMixedOffset()` during pattern application.

This cascades through the boundary check path in `StoreConverter`:

1. `getConstifiedMixedOffset()` returns a `Value` (not `Attribute`) because `maxsi(%c0, 0)` is not a simple constant
2. `getBoundarySizes()` computes `Value`-based boundary sizes (instead of `Attribute`-based)
3. `memref.subview` with `Value` sizes produces `memref<?xi32>` (dynamic shape) instead of `memref<8xi32>` (static)
4. `bufferization.materialize_in_destination` uses the dynamic `subview` result
5. Canonicalizer folds the full-region `subview` but types don't match → inserts spurious `memref.cast`

The bug is introduced in https://gitcode.com/Ascend/triton-ascend/pull/975 

### Error IR (before fix)

```mlir
// reinterpret_cast has static shape but dynamic offset (from maxsi)
%reinterpret_cast = memref.reinterpret_cast %arg1 to offset: [%c0], sizes: [8], strides: [1]
    : memref<?xi32> to memref<8xi32, strided<[1], offset: ?>>

// Canonicalizer folds subview, inserts memref.cast to bridge types
%cast = memref.cast %reinterpret_cast
    : memref<8xi32, strided<[1], offset: ?>> to memref<?xi32, strided<[1], offset: ?>>

bufferization.materialize_in_destination %val in writable %cast
    : (tensor<8xi32>, memref<?xi32, strided<[1], offset: ?>>) -> ()
```

### Correct IR (after fix)

```mlir
%reinterpret_cast = memref.reinterpret_cast %arg1 to offset: [0], sizes: [8], strides: [1]
    : memref<?xi32> to memref<8xi32, strided<[1]>>  // static offset

bufferization.materialize_in_destination %val in writable %reinterpret_cast
    : (tensor<8xi32>, memref<8xi32, strided<[1]>>) -> ()  // no memref.cast
```

## Root Cause

`maxsi(offset, 0)` is an `arith::MaxSIOp` result — a `Value`, not an `Attribute`. `getConstifiedMixedOffset()` cannot fold it to a constant, even when the offset is `0`.

## Fix

In `rewriteMakeTensorPtrOp`, check if the offset is a compile-time non-negative constant before creating `maxsi`. If it is, skip `maxsi` and pass the offset directly to `getOpFoldResultOfLayoutInfo`, which returns an `Attribute`. This allows `getConstifiedMixedOffset()` to fold it to a constant, keeping the entire boundary check chain static.

Runtime or negative offsets still get the `maxsi` clamp for safety.

## Changes

- `third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp`: Skip `maxsi` for non-negative constant offsets in `rewriteMakeTensorPtrOp`

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
