### PR TITLE
debug npu utils runtime build

### DIFF
--- a/third_party/ascend/backend/backend_register.py
+++ b/third_party/ascend/backend/backend_register.py
@@ -223,6 +223,11 @@ def get_cc_cmd_npu_utils():
         f"-L{os.path.join(torch_npu_path, 'lib')}",
         f"-ltorch_npu",
         "-DUSE_TORCH_NPU",
+        # npu_utils is built at runtime. Keep its debug symbols and stack
+        # frames intact so ASan reports can be resolved reliably.
+        "-g",
+        "-O0",
+        "-fno-omit-frame-pointer",
     ]
     return cc_cmd
 

--- a/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
+++ b/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
@@ -1,11 +1,15 @@
 import importlib.util
 import os
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
 
 DEFAULT_UTILS_PATH = (
     Path(__file__).resolve().parents[2] / "backend" / "utils.py"
+)
+BACKEND_REGISTER_PATH = (
+    Path(__file__).resolve().parents[2] / "backend" / "backend_register.py"
 )
 
 
@@ -24,6 +28,30 @@ def _load_utils_module():
     return module
 
 
+def _load_backend_register_module():
+    spec = importlib.util.spec_from_file_location(
+        "repo_backend_register", BACKEND_REGISTER_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_npu_utils_uses_debug_compilation_flags(monkeypatch):
+    backend_register = _load_backend_register_module()
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(__file__="/torch/__init__.py"))
+    monkeypatch.setitem(
+        sys.modules, "torch_npu", SimpleNamespace(__file__="/torch_npu/__init__.py")
+    )
+    monkeypatch.setattr(backend_register, "get_torch_cxx_abi", lambda: 1)
+
+    flags = backend_register.get_cc_cmd_npu_utils()
+
+    assert "-g" in flags
+    assert "-O0" in flags
+    assert "-fno-omit-frame-pointer" in flags
+
+
 def _assert_npu_utils_uses_special_flags(utils, monkeypatch, tmp_path):
     monkeypatch.setattr(utils, "_get_cxx", lambda: "c++")
     monkeypatch.setattr(utils, "_get_ascend_path", lambda: str(tmp_path / "ascend"))
@@ -37,11 +65,12 @@ def _assert_npu_utils_uses_special_flags(utils, monkeypatch, tmp_path):
     )
 
     calls = []
+    compile_commands = []
 
     def fake_get_backend_func(name, *args, **kwargs):
         calls.append((name, args, kwargs))
         if name == "get_cc_cmd_npu_utils":
-            return ["-DUSE_TORCH_NPU"]
+            return ["-DUSE_TORCH_NPU", "-g", "-O0", "-fno-omit-frame-pointer"]
         if name == "get_cc_cmd":
             return ["-ldl"]
         return []
@@ -50,7 +79,9 @@ def _assert_npu_utils_uses_special_flags(utils, monkeypatch, tmp_path):
     monkeypatch.setattr(
         utils.subprocess,
         "run",
-        lambda *args, **kwargs: SimpleNamespace(returncode=0, stderr=""),
+        lambda *args, **kwargs: (
+            compile_commands.append(args[0]) or SimpleNamespace(returncode=0, stderr="")
+        ),
     )
 
     src_path = tmp_path / "npu_utils.cpp"
@@ -61,6 +92,9 @@ def _assert_npu_utils_uses_special_flags(utils, monkeypatch, tmp_path):
     assert so_path.endswith(".so")
     assert any(name == "get_cc_cmd_npu_utils" for name, _, _ in calls)
     assert not any(name == "get_cc_cmd" for name, _, _ in calls)
+    assert "-g" in compile_commands[0]
+    assert "-O0" in compile_commands[0]
+    assert "-fno-omit-frame-pointer" in compile_commands[0]
 
 
 def test_npu_utils_build_uses_special_flags(monkeypatch, tmp_path):


### PR DESCRIPTION
## What changed

Build the runtime-compiled `npu_utils` extension with debug symbols, no optimization, and preserved frame pointers.

## Why

This makes ASan stack traces from `npu_utils` resolvable and useful without changing the compilation settings of other runtime extensions.

## Validation

- `git diff --check`
- Python syntax compilation for the changed modules
- Direct runtime assertion of the generated compiler flags

`pytest` was unavailable in the local environment.