### PR TITLE
[Autotune](fix) Backport L2 cache clearing for NPU autotune

### DIFF
--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -2382,7 +2382,7 @@ class AutoTilingTuner(Autotuner):
                     list(run_fns.values()),
                     warmup=warmup,
                     active=active,
-                    clear_l2_cache=False,
+                    clear_l2_cache=True,
                     target_kernel_name=target_kernel_name,
                 )
                 assert len(time_cost) == len(run_fns)


### PR DESCRIPTION
## Summary

- Backport #969 to `release/3.2.2`.
- Clear L2 cache before each NPU autotune profiling run.

## Motivation

Sequential candidate benchmarks can inherit L2 cache state, making autotune selection depend on candidate order. Clearing L2 produces fairer measurements.

## Validation

- `python3 -m py_compile third_party/ascend/backend/runtime/autotuner.py`
- `git diff --check origin/release/3.2.2...HEAD`

Original PR: #969
