### PR TITLE
[3.6.0](feat) add fp16 dtype support for tl.exp temporarily

### DIFF
--- a/python/triton/language/math.py
+++ b/python/triton/language/math.py
@@ -96,7 +96,8 @@ def umulhi(x, y, _semantic=None):
 
 
 @core.builtin
-@_check_dtype(dtypes=["fp32", "fp64"])
+# TODO: Temporary intrusive modification: add fp16 support and remove it later.
+@_check_dtype(dtypes=["fp16", "fp32", "fp64"])
 @_add_math_1arg_docstr("exponential")
 @core._tensor_member_fn
 def exp(x, _semantic=None):


### PR DESCRIPTION
This commit adds temporary fp16 dtype support for exp to address an urgent issue at a customer site. The specific root cause has not yet been identified; a tracking issue has been filed. This change must be reverted after the fix is available.