### PR TITLE
[launch](fix) fix error when all kernel parameters are constants

### DIFF
--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -967,7 +967,7 @@ void triton_launch_kernel(
 }}
 }} // extern "C"
 
-static void _launch(const char* kernelName, const void* func, rtStream_t stream, int gridX, int gridY, int gridZ, std::vector<std::vector<int64_t>> &tensorShapes, std::vector<int> &tensorKinds{', ' + arg_decls if len(signature) > 0 else ''}) {{
+static void _launch(const char* kernelName, const void* func, rtStream_t stream, int gridX, int gridY, int gridZ, std::vector<std::vector<int64_t>> &tensorShapes, std::vector<int> &tensorKinds{(', ' + arg_decls) if len(arg_decls) > 0 else ''}) {{
   // Keep Python launcher on the stable local packing path.
   std::string name = "";
   name.append(kernelName);

--- a/third_party/ascend/unittest/pytest_ut/test_launcher_empty_signature.py
+++ b/third_party/ascend/unittest/pytest_ut/test_launcher_empty_signature.py
@@ -35,3 +35,22 @@ def test_launcher_empty_signature():
     grid = (1, )
     _empty_kernel[grid]()
     assert True
+
+
+# Regression test for commit 6365783a:
+# When all kernel parameters are constexpr, the launcher generated invalid
+# C++ code with a trailing comma in the _launch function signature because
+# it checked len(signature) > 0 instead of len(arg_decls) > 0.
+@triton.jit
+def _all_constexpr_kernel(VAL: tl.constexpr):
+    tl.static_assert(VAL == 42)
+    pass
+
+
+@pytest.mark.interpreter
+def test_launcher_all_params_constexpr():
+    grid = (1, )
+    # All params are constexpr -> arg_decls is empty but signature is not.
+    # Before the fix this produced: void _launch(..., )  /* trailing comma */
+    _all_constexpr_kernel[grid](VAL=42)
+    assert True


### PR DESCRIPTION
TRITON_DEBUG=1 TRITON_ALWAYS_COMPILE=1 python3.11 -m pytest -sv python/test/unit/language/test_core.py::test_constexpr_assignment

error:
E           RuntimeError: Failed to compile /tmp/tmpbjmnrwwy/launcher_cxx11abi1.cxx, error: /tmp/tmpbjmnrwwy/launcher_cxx11abi1.cxx:399:195: error: expected parameter declarator
E           static void _launch(const char* kernelName, const void* func, rtStream_t stream, int gridX, int gridY, int gridZ, std::vector<std::vector<int64_t>> &tensorShapes, std::vector<int> &tensorKinds, ) {
E                                                                                                                                                                                                             ^
E           1 error generated.


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
