### PR TITLE
[ssbuffer](fix) fixes precision error of #958

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
@@ -24,6 +24,7 @@
 #include <optional>
 
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -642,31 +643,25 @@ static LogicalResult splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rew
     // This is the "c" in a*b+c, added after the matmul result
     rewriter.setInsertionPointAfterValue(splitInfo.outerOutValue);
 
-    Operation *preservedUser = nullptr;
+    constexpr size_t kMaxPreservedUsers = 2;
+    SmallPtrSet<Operation *, kMaxPreservedUsers> preservedUsers;
     if (splitInfo.mayNotExec && forOp) {
         auto lb = forOp.getLowerBound();
         auto ub = forOp.getUpperBound();
 
         Value executed = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sgt, ub, lb);
-        auto ifOp = rewriter.create<scf::IfOp>(
-            loc,
-            executed,
-            [&](OpBuilder &thenBuilder, Location thenLoc) {
-                thenBuilder.create<scf::YieldOp>(thenLoc, splitInfo.outerOutValue);
-            },
-            [&](OpBuilder &elseBuilder, Location elseLoc) {
-                Value zeroValue;
-                if (auto floatType = dyn_cast<FloatType>(elmType)) {
-                    APFloat zeroAPFloat = APFloat::getZero(floatType.getFloatSemantics());
-                    zeroValue = elseBuilder.create<arith::ConstantFloatOp>(elseLoc, zeroAPFloat, floatType).getResult();
-                } else if (auto intType = dyn_cast<IntegerType>(elmType)) {
-                    zeroValue = elseBuilder.create<arith::ConstantIntOp>(elseLoc, 0, intType).getResult();
-                }
-                auto fillOp = elseBuilder.create<linalg::FillOp>(emptyOp.getLoc(), zeroValue, splitInfo.outerOutValue);
-                elseBuilder.create<scf::YieldOp>(elseLoc, fillOp.getResult(0));
-            });
-        newOutValue = ifOp.getResult(0);
-        preservedUser = ifOp;
+        Value zeroValue;
+        if (auto floatType = dyn_cast<FloatType>(elmType)) {
+            APFloat zeroAPFloat = APFloat::getZero(floatType.getFloatSemantics());
+            zeroValue = rewriter.create<arith::ConstantFloatOp>(loc, zeroAPFloat, floatType).getResult();
+        } else if (auto intType = dyn_cast<IntegerType>(elmType)) {
+            zeroValue = rewriter.create<arith::ConstantIntOp>(loc, 0, intType).getResult();
+        }
+        auto fillOp = rewriter.create<linalg::FillOp>(loc, zeroValue, splitInfo.outerOutValue);
+        auto selectOp = rewriter.create<arith::SelectOp>(loc, executed, splitInfo.outerOutValue, fillOp.getResult(0));
+        newOutValue = selectOp.getResult();
+        preservedUsers.insert(selectOp);
+        preservedUsers.insert(fillOp);
         forOp->setAttr(CVPipeline::kHIVMMatmulLimitedInCubeAttr, rewriter.getUnitAttr());
     }
 
@@ -676,13 +671,12 @@ static LogicalResult splitMatmul(linalg::MatmulOp matmulOp, PatternRewriter &rew
     } else {
         addOp = rewriter.create<arith::AddIOp>(loc, newOutValue, splitInfo.outerInValue).getOperation();
     }
-    if (preservedUser == nullptr) {
-        preservedUser = addOp;
+    if (preservedUsers.empty()) {
+        preservedUsers.insert(addOp);
     }
     addOp->setAttr(CVPipeline::kAddFromMatmul, rewriter.getUnitAttr());
-    splitInfo.outerOutValue.replaceUsesWithIf(addOp->getResult(0), [preservedUser](OpOperand &operand) {
-        return !preservedUser->isAncestor(operand.getOwner());
-    });
+    splitInfo.outerOutValue.replaceUsesWithIf(
+        addOp->getResult(0), [&](OpOperand &operand) { return !preservedUsers.contains(operand.getOwner()); });
 
     return success();
 }


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
