### PR TITLE
[op](feat) rollback the invasive modification support function of tf32

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2019,10 +2019,17 @@ def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_i
       specified (i.e. at least one must be :code:`None`).
     """
     assert input_precision is None or allow_tf32 is None, "Only one of input_precision and allow_tf32 can be specified"
+    assert not allow_tf32, "allow_tf32 is not supported as 'True', please use fp32 on Ascend instead."
     if input_precision is None:
         supports_tf32 = "tf32" in _semantic.builder.options.allowed_dot_input_precisions
         input_precision = knobs.language.fp32_default or ("tf32" if (supports_tf32 and
                                                                      (allow_tf32 or allow_tf32 is None)) else "ieee")
+        # when setting allow_tf32, use input_precision='hf32' on Ascend instead.
+        if allow_tf32:
+            input_precision = "hf32"
+    else:
+        if input_precision == "tf32":
+            input_precision = "hf32"
 
     input_precision = _unwrap_if_constexpr(input_precision)
     out_dtype = _unwrap_if_constexpr(out_dtype)

--- a/third_party/ascend/unittest/pytest_ut/test_dot.py
+++ b/third_party/ascend/unittest/pytest_ut/test_dot.py
@@ -126,7 +126,6 @@ typelist = [
 ]
 
 
-@pytest.mark.skip(reason="not supported after the NPUIR is updated in April, and will be fixed later")
 @pytest.mark.parametrize("B, C, D", testlist2)
 @pytest.mark.parametrize("sigtype", typelist)
 def test_dot_2(restore_npu_hf32_setting, sigtype, B, C, D):
@@ -138,8 +137,6 @@ def test_dot_2(restore_npu_hf32_setting, sigtype, B, C, D):
     test_common.validate_cmp(sigtype, z, z_ref)
 
 
-@pytest.mark.xfail(
-    reason="Temporarily disabled: TA backend does not support allow_tf32 yet. Will be fixed in follow-up.")
 @pytest.mark.parametrize("B, C, D", testlist2)
 @pytest.mark.parametrize("sigtype", typelist)
 def test_dot_2_allow_tf32(restore_npu_hf32_setting, sigtype, B, C, D):
@@ -147,11 +144,12 @@ def test_dot_2_allow_tf32(restore_npu_hf32_setting, sigtype, B, C, D):
     y = test_common.generate_tensor((C, D), sigtype).npu()
     z_ref = torch_dot_None(x, y).to(torch.float32)
     z = torch.zeros((B, D), dtype=torch.float32).npu()
-    triton_dot_2_allow_tf32[1, 1, 1](z, x, y, B, C, D)
-    test_common.validate_cmp(sigtype, z, z_ref)
+    try:
+        triton_dot_2_allow_tf32[1, 1, 1](z, x, y, B, C, D)
+    except Exception as e:
+        assert "allow_tf32 is not supported as 'True'" in e
 
 
-@pytest.mark.skip(reason="not supported after the NPUIR is updated in April, and will be fixed later")
 @pytest.mark.parametrize("B, C, D", testlist2)
 @pytest.mark.parametrize("sigtype", typelist)
 def test_dot_2_input_tf32(restore_npu_hf32_setting, sigtype, B, C, D):


### PR DESCRIPTION
rollback the invasive modification support function of tf32,temporary rollback processing

In the original intrusive modification of tl.dot, the input_precision input is automatically changed from tf32 to hf32. This part of logic has been rolled back to be consistent with the community. The operator test case needs to be modified. The input_precision input cannot be tf32.

source /data/setenv.bash
export TRITON_ALWAYS_COMPILE=1
export TRITON_DISABLE_FFTS=1

/data/autotest/optest_fast_pipeline/20260713104811/triton_ascend/test/fbgemm_operator_cases/FBGEMM/test# pytest -sv test__gqa_pack_fwd_kernel_npu.py --ptfile_path /data/PytorchFile/FBGEMMPtFile/test__gqa_pack_fwd_kernel_npu/_gqa_pack_fwd_kernel_v2.pt

-------------
0707TA-0706NPUIR: ERROR
0709-39a6-TA-0706NPUIR:ERROR
The locating result shows that the TA failed at 0707 and was not newly introduced.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
