### PR TITLE
[libdevice](fix) Libdevice operations support scalar and multi-dim te…

### DIFF
--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -586,11 +586,6 @@ def triton_support_ffts():
     return is_ffts_supported(arch) and (not force_disable_ffts())
 
 
-def triton_enable_libdevice_simt():
-    enable_libdevice_simt = os.getenv("TRITON_ENABLE_LIBDEVICE_SIMT", False)
-    return enable_libdevice_simt and is_compile_on_910_95()
-
-
 def get_cann_version_file_hash():
     ascend_path = _get_ascend_path()
     arch = get_machine_arch()

--- a/third_party/ascend/language/cann/__init__.py
+++ b/third_party/ascend/language/cann/__init__.py
@@ -19,14 +19,11 @@
 # THE SOFTWARE.
 
 from triton.language import math
-from triton.backends.ascend.utils import triton_enable_libdevice_simt
 
 from . import libdevice
 from . import extension
 
 extension.parallel = extension.aux_ops.parallel
-if not triton_enable_libdevice_simt():
-    libdevice.atan2 = extension.math_ops.atan2
 libdevice.isfinited = extension.math_ops.isfinited
 libdevice.finitef = extension.math_ops.finitef
 libdevice.flip = extension.flip

--- a/third_party/ascend/language/cann/libdevice.py
+++ b/third_party/ascend/language/cann/libdevice.py
@@ -1,4 +1,4 @@
-﻿# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,1227 +22,95 @@ from math import pi as math_pi
 from triton.language import core, math, semantic
 from triton._C.libtriton import ir
 from triton.runtime.jit import jit
-from triton.backends.ascend.utils import get_ascend_arch_from_env, triton_enable_libdevice_simt
+from triton.backends.ascend.utils import get_ascend_arch_from_env, is_compile_on_910_95 as _is_compile_on_910_95
 
 
-@core.extern
-def reciprocal(arg0, _semantic=None):
-    """
-    Computes the element-wise reciprocal (1/x) of the input tensor.
-
-    :param arg0: The input tensor. Supported dtypes: fp32, fp16.
-    :type arg0: tl.tensor
-    """
-    if triton_enable_libdevice_simt():
-        return core.extern_elementwise("", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_reciprocal_fp32", core.dtype("fp32")),
-        }, is_pure=True, _semantic=_semantic)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_recipf", core.dtype("fp32")),
-            (core.dtype("fp16"), ): ("__hmf_recipDh", core.dtype("fp16")),
-        }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def log1p(arg0, _semantic=None):
-    """
-    Computes the element-wise natural logarithm of (1 + x).
-
-    :param arg0: The input tensor. Supported dtypes: fp32, fp16.
-    :type arg0: tl.tensor
-    """
-    if triton_enable_libdevice_simt():
-        return core.extern_elementwise("", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_log1p_fp32", core.dtype("fp32")),
-        }, is_pure=True, _semantic=_semantic)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_log1pf", core.dtype("fp32")),
-            (core.dtype("fp16"), ): ("__hmf_log1pDh", core.dtype("fp16")),
-        }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def relu(arg0, _semantic=None):
-    """
-    Computes the element-wise ReLU activation: max(0, x).
-
-    :param arg0: The input tensor. Supported dtypes: fp32, fp16.
-    :type arg0: tl.tensor
-    """
-    if triton_enable_libdevice_simt():
-        return core.extern_elementwise("", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_relu_fp32", core.dtype("fp32")),
-        }, is_pure=True, _semantic=_semantic)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_reluf", core.dtype("fp32")),
-            (core.dtype("fp16"), ): ("__hmf_reluDh", core.dtype("fp16")),
-        }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def isinf(arg0, _semantic=None):
-    """
-    Tests whether each element of the input tensor is infinity.
-
-    :param arg0: The input tensor. Supported dtypes: fp32, fp16, bf16.
-    :type arg0: tl.tensor
-    """
-    if triton_enable_libdevice_simt():
-        return core.extern_elementwise("", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_isinf_fp32", core.dtype("int1")),
-        }, is_pure=True, _semantic=_semantic)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_isinf", core.dtype("int1")),
-            (core.dtype("fp16"), ): ("__hmf_isinf", core.dtype("int1")),
-            (core.dtype("bf16"), ): ("__hmf_isinf", core.dtype("int1")),
-        }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def tan(arg0, _semantic=None):
-    """
-    Computes the element-wise tangent of the input tensor.
-
-    :param arg0: The input tensor in radians. Supported dtypes: fp32, fp16.
-    :type arg0: tl.tensor
-    """
-    if triton_enable_libdevice_simt():
-        return core.extern_elementwise("", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_tan_fp32", core.dtype("fp32")),
-        }, is_pure=True, _semantic=_semantic)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_tanf", core.dtype("fp32")),
-            (core.dtype("fp16"), ): ("__hmf_tanDh", core.dtype("fp16")),
-        }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def atan(arg0, _semantic=None):
-    """
-    Computes the element-wise arctangent (inverse tangent) of the input tensor.
-
-    :param arg0: The input tensor. Supported dtypes: fp32, fp16.
-    :type arg0: tl.tensor
-    """
-    if triton_enable_libdevice_simt():
-        return core.extern_elementwise("", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_atan_fp32", core.dtype("fp32")),
-        }, is_pure=True, _semantic=_semantic)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_atanf", core.dtype("fp32")),
-            (core.dtype("fp16"), ): ("__hmf_atanDh", core.dtype("fp16")),
-        }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def tanh(arg0, _semantic=None):
-    """
-    Computes the element-wise hyperbolic tangent of the input tensor.
-
-    :param arg0: The input tensor. Supported dtypes: fp32, fp16, bf16.
-    :type arg0: tl.tensor
-    """
-    arg0 = _semantic.to_tensor(arg0)
-    original_dtype = arg0.dtype
-    if original_dtype == core.dtype("bf16"):
-        arg0 = _semantic.cast(arg0, core.float32)
-
-    if triton_enable_libdevice_simt():
-        dispatch = {
-            (core.dtype("fp32"), ): ("__hmf_tanh_fp32", core.dtype("fp32")),
-        }
-    else:
-        dispatch = {
-            (core.dtype("fp32"), ): ("__hmf_tanhf", core.dtype("fp32")),
-            (core.dtype("fp16"), ): ("__hmf_tanhDh", core.dtype("fp16")),
-        }
-
-    res = core.extern_elementwise("", "", [arg0], dispatch, is_pure=True, _semantic=_semantic)
-    if original_dtype == core.dtype("bf16"):
-        return _semantic.cast(res, core.dtype("bf16"))
-    return res
-
-
-@core.extern
-def ilogb(arg0, _semantic=None):
-    """
-    Returns the integer binary exponent of the input tensor.
-
-    :param arg0: The input tensor. Supported dtypes: fp32, fp16.
-    :type arg0: tl.tensor
-    """
-    if triton_enable_libdevice_simt():
-        return core.extern_elementwise("", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_ilogb_fp32", core.dtype("fp32")),
-        }, is_pure=True, _semantic=_semantic)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_ilogbf", core.dtype("fp32")),
-            (core.dtype("fp16"), ): ("__hmf_ilogbDh", core.dtype("fp16")),
-        }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def logb(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.logb for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_logb_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def ldexp(arg0, arg1, _semantic=None):
-    """
-    Computes x * 2^exp from a mantissa and an exponent.
-
-    :param arg0: The mantissa tensor. Supported dtypes: fp32, fp16.
-    :type arg0: tl.tensor
-    :param arg1: The exponent tensor. Supported dtype: int32.
-    :type arg1: tl.tensor
-    """
-    if triton_enable_libdevice_simt():
-        return core.extern_elementwise("", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("int32")): ("__hmf_ldexp_fp32", core.dtype("fp32")),
-        }, is_pure=True, _semantic=_semantic)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("int32")): ("__hmf_ldexpf", core.dtype("fp32")),
-            (core.dtype("fp16"), core.dtype("int32")): ("__hmf_ldexpDh", core.dtype("fp16")),
-        }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def scalbn(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.scalbn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("int32")): ("__hmf_scalbn_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def pow(arg0, arg1, _semantic=None):
-    """
-    Computes arg0 raised to the power of arg1.
-
-    :param arg0: The base tensor. Supported dtypes: fp32, fp16, bf16.
-    :type arg0: tl.tensor
-    :param arg1: The exponent tensor. Supported dtypes: fp32, fp16, bf16.
-    :type arg1: tl.tensor
-    """
-    if triton_enable_libdevice_simt():
-        return core.extern_elementwise("", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_pow_fp32", core.dtype("fp32")),
-        }, is_pure=True, _semantic=_semantic)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_powf", core.dtype("fp32")),
-            (core.dtype("fp16"), core.dtype("fp16")): ("__hmf_powDh", core.dtype("fp16")),
-            (core.dtype("bf16"), core.dtype("bf16")): ("__hmf_powDb", core.dtype("bf16")),
-        }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def finitef(arg0, _semantic=None):
-    if triton_enable_libdevice_simt():
-        return core.extern_elementwise("", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_finite_fp32", core.dtype("int1")),
-        }, is_pure=True, _semantic=_semantic)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_finitef", core.dtype("int1")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def isnan(arg0, _semantic=None):
-    """
-    Tests whether each element of the input tensor is NaN.
-
-    :param arg0: The input tensor. Supported dtypes: fp32, fp16, bf16.
-    :type arg0: tl.tensor
-    """
-    if triton_enable_libdevice_simt():
-        return core.extern_elementwise("", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_isnan_fp32", core.dtype("int1")),
-        }, is_pure=True, _semantic=_semantic)
-    return core.extern_elementwise(
-        "", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_isnan", core.dtype("int1")),
-            (core.dtype("fp16"), ): ("__hmf_isnan", core.dtype("int1")),
-            (core.dtype("bf16"), ): ("__hmf_isnan", core.dtype("int1")),
-        }, is_pure=True, _semantic=_semantic)
+is_compile_on_910_95 = _is_compile_on_910_95()
 
 
 @core.extern
 def clz(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.clz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("int32"), ): ("__hmf_clz_i32", core.dtype("int32")),
-    }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("int32"), ): ("__hmf_clz_i32", core.dtype("int32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.clz for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 @core.extern
 def popc(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.popc for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("int32"), ): ("__hmf_popc_i32", core.dtype("int32")),
-    }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("int32"), ): ("__hmf_popc_i32", core.dtype("int32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.popc for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 @core.extern
 def byte_perm(arg0, arg1, arg2, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.byte_perm for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1, arg2], {
-        (core.dtype("int32"), core.dtype("int32"), core.dtype("int32")): ("__hmf_byte_perm_i32", core.dtype("int32")),
-    }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1, arg2], {
+            (core.dtype("int32"), core.dtype("int32"), core.dtype("int32")):
+            ("__hmf_byte_perm_i32", core.dtype("int32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.byte_perm for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 @core.extern
 def mulhi(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.mulhi for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("int32"), core.dtype("int32")): ("__hmf_mulhi_i32", core.dtype("int32")),
-    }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("int32"), core.dtype("int32")): ("__hmf_mulhi_i32", core.dtype("int32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.mulhi for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 @core.extern
 def mul24(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.mul24 for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("int32"), core.dtype("int32")): ("__hmf_mul24_i32", core.dtype("int32")),
-    }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("int32"), core.dtype("int32")): ("__hmf_mul24_i32", core.dtype("int32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.mul24 for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 @core.extern
 def brev(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.brev for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("int32"), ): ("__hmf_brev_i32", core.dtype("int32")),
-    }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("int32"), ): ("__hmf_brev_i32", core.dtype("int32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.brev for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 @core.extern
 def sad(arg0, arg1, arg2, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.sad for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1, arg2], {
-        (core.dtype("int32"), core.dtype("int32"), core.dtype("int32")): ("__hmf_sad_i32", core.dtype("int32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def ffs(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.ffs for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("int32"), ): ("__hmf_ffs_i32", core.dtype("int32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def saturatef(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.saturatef for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_saturate_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def hadd(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.hadd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("int32"), core.dtype("int32")): ("__hmf_hadd_i32", core.dtype("int32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def rhadd(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.rhadd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("int32"), core.dtype("int32")): ("__hmf_rhadd_i32", core.dtype("int32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def fdim(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fdim for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fdim_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def exp10(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.exp10 for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_exp10_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def add_rn(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.add_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_add_rn_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def add_rz(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.add_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_add_rz_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def add_rd(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.add_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_add_rd_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def add_ru(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.add_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_add_ru_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def sub_rn(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.sub_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_sub_rn_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def sub_rz(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.sub_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_sub_rz_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def sub_rd(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.sub_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_sub_rd_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def sub_ru(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.sub_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_sub_ru_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def mul_rn(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.mul_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_mul_rn_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def mul_rz(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.mul_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_mul_rz_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def mul_ru(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.mul_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_mul_ru_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def mul_rd(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.mul_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_mul_rd_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def div_rd(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.div_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_div_rd_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def div_ru(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.div_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_div_ru_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def div_rz(arg0, arg1, _semantic=None):
-    """
-    Computes the division with round-toward-zero mode.
-
-    :param arg0: The dividend tensor. Supported dtype: fp32.
-    :type arg0: tl.tensor
-    :param arg1: The divisor tensor. Supported dtype: fp32.
-    :type arg1: tl.tensor
-    """
-    if not triton_enable_libdevice_simt():
-        arg0 = _semantic.to_tensor(arg0)
-        arg1 = _semantic.to_tensor(arg1)
-        ret = _semantic.fdiv(arg0, arg1, False)
-        return ret
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_div_rz_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def rcp_rn(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.rcp_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_rcp_rn_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def rcp_rz(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.rcp_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_rcp_rz_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def rcp_rd(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.rcp_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_rcp_rd_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def rcp_ru(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.rcp_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_rcp_ru_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def sqrt_rn(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.sqrt_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_sqrt_rn_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def sqrt_rz(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.sqrt_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_sqrt_rz_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def sqrt_rd(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.sqrt_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_sqrt_rd_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def sqrt_ru(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.sqrt_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_sqrt_ru_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def rsqrt_rn(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.rsqrt_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_rsqrt_rn_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def fma_rn(arg0, arg1, arg2, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fma_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1, arg2], {
-        (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fma_rn_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def fma_rz(arg0, arg1, arg2, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fma_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1, arg2], {
-        (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fma_rz_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def fma_rd(arg0, arg1, arg2, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fma_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1, arg2], {
-        (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fma_rd_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def fma_ru(arg0, arg1, arg2, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fma_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1, arg2], {
-        (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fma_ru_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.builtin
-def fast_dividef(arg0, arg1, _semantic=None):
-    """
-    Computes a fast floating-point division.
-
-    :param arg0: The dividend tensor.
-    :type arg0: tl.tensor
-    :param arg1: The divisor tensor.
-    :type arg1: tl.tensor
-    """
-    if triton_enable_libdevice_simt():
-        return core.extern_elementwise("", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fast_divide_fp32", core.dtype("fp32")),
-        }, is_pure=True, _semantic=_semantic)
     arg0 = _semantic.to_tensor(arg0)
-    arg1 = _semantic.to_tensor(arg1)
-    ret = _semantic.fdiv(arg0, arg1, False)
-    return ret
-
-
-@core.builtin
-def fast_expf(arg0, _semantic=None):
-    """
-    Computes a fast exponential (e^x) of the input tensor.
-
-    :param arg0: The input tensor.
-    :type arg0: tl.tensor
-    """
-    if triton_enable_libdevice_simt():
-        return core.extern_elementwise("", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_fast_exp_fp32", core.dtype("fp32")),
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1, arg2], {
+            (core.dtype("int32"), core.dtype("int32"), core.dtype("int32")): ("__hmf_sad_i32", core.dtype("int32")),
         }, is_pure=True, _semantic=_semantic)
-    arg0 = _semantic.to_tensor(arg0)
-    ret = core.tensor(_semantic.builder.create_exp(arg0.handle), arg0.type)
-    return ret
-
-
-@core.builtin
-def fast_exp10f(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fast_exp10f for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_fast_exp10_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.builtin
-def fast_sinf(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fast_sinf for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_fast_sin_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.builtin
-def fast_cosf(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fast_cosf for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_fast_cos_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.builtin
-def fast_tanf(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fast_tanf for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_fast_tan_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.builtin
-def fast_tanhf(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fast_tanhf for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_fast_tanh_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.builtin
-def fast_log2f(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fast_log2f for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_fast_log2_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.builtin
-def fast_logf(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fast_logf for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_fast_log_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.builtin
-def fast_log10f(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fast_log10f for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_fast_log10_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.builtin
-def fast_powf(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.fast_powf for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fast_pow_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def fmod(arg0, arg1, _semantic=None):
-    """
-    Computes the floating-point remainder of arg0 / arg1.
-
-    :param arg0: The dividend tensor. Supported dtype: fp32.
-    :type arg0: tl.tensor
-    :param arg1: The divisor tensor. Supported dtype: fp32.
-    :type arg1: tl.tensor
-    """
-    if not triton_enable_libdevice_simt():
-        arg0 = _semantic.to_tensor(arg0)
-        arg1 = _semantic.to_tensor(arg1)
-        ret = _semantic.mod(arg0, arg1)
-        return ret
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fmod_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def remainder(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.remainder for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_remainder_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def float_as_int(arg0, _semantic=None):
-    """
-    Reinterprets the bits of a float32 value as an int32.
-
-    :param arg0: The input tensor. Supported dtype: fp32.
-    :type arg0: tl.tensor
-    """
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float_as_int for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_float_as_int_fp32", core.dtype("int32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def int_as_float(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.int_as_float for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("int32"), ): ("__hmf_int_as_float_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def float_as_uint(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float_as_uint for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_float_as_uint_fp32", core.dtype("uint32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def uint_as_float(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.uint_as_float for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("uint32"), ): ("__hmf_uint_as_float_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def float2int_rn(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2int_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_float2int_rn_fp32", core.dtype("int32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def float2int_rz(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2int_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_float2int_rz_fp32", core.dtype("int32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def float2int_rd(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2int_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_float2int_rd_fp32", core.dtype("int32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def float2int_ru(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2int_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_float2int_ru_fp32", core.dtype("int32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def int2float_rn(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.int2float_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("int32"), ): ("__hmf_int2float_rn_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def int2float_rz(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.int2float_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("int32"), ): ("__hmf_int2float_rz_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def int2float_rd(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.int2float_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("int32"), ): ("__hmf_int2float_rd_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def int2float_ru(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.int2float_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("int32"), ): ("__hmf_int2float_ru_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def float2uint_rn(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2uint_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_float2uint_rn_fp32", core.dtype("uint32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def float2uint_rz(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2uint_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_float2uint_rz_fp32", core.dtype("uint32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def float2uint_rd(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2uint_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_float2uint_rd_fp32", core.dtype("uint32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def float2uint_ru(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2uint_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_float2uint_ru_fp32", core.dtype("uint32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def uint2float_rn(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.uint2float_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("uint32"), ): ("__hmf_uint2float_rn_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def uint2float_rz(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.uint2float_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("uint32"), ): ("__hmf_uint2float_rz_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def uint2float_rd(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.uint2float_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("uint32"), ): ("__hmf_uint2float_rd_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def uint2float_ru(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.uint2float_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("uint32"), ): ("__hmf_uint2float_ru_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def float2ll_rn(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2ll_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_float2ll_rn_fp32", core.dtype("int64")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def float2ll_rz(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2ll_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_float2ll_rz_fp32", core.dtype("int64")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def float2ll_rd(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2ll_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_float2ll_rd_fp32", core.dtype("int64")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def float2ll_ru(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2ll_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_float2ll_ru_fp32", core.dtype("int64")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def ll2float_rn(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.ll2float_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("int64"), ): ("__hmf_ll2float_rn_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def ll2float_rz(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.ll2float_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("int64"), ): ("__hmf_ll2float_rz_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def ll2float_rd(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.ll2float_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("int64"), ): ("__hmf_ll2float_rd_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def ll2float_ru(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.ll2float_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("int64"), ): ("__hmf_ll2float_ru_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def float2ull_rn(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2ull_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_float2ull_rn_fp32", core.dtype("uint64")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def float2ull_rz(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2ull_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_float2ull_rz_fp32", core.dtype("uint64")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def float2ull_rd(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2ull_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_float2ull_rd_fp32", core.dtype("uint64")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def float2ull_ru(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.float2ull_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_float2ull_ru_fp32", core.dtype("uint64")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def ull2float_rn(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.ull2float_rn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("uint64"), ): ("__hmf_ull2float_rn_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def ull2float_rz(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.ull2float_rz for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("uint64"), ): ("__hmf_ull2float_rz_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def ull2float_rd(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.ull2float_rd for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("uint64"), ): ("__hmf_ull2float_rd_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def ull2float_ru(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.ull2float_ru for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("uint64"), ): ("__hmf_ull2float_ru_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def atan2(arg0, arg1, _semantic):
-    """
-    Computes the arctangent of arg0/arg1, using signs to determine the quadrant.
-
-    :param arg0: The y-coordinate tensor. Supported dtypes: fp32, fp16.
-    :type arg0: tl.tensor
-    :param arg1: The x-coordinate tensor. Supported dtypes: fp32, fp16.
-    :type arg1: tl.tensor
-    """
-    if arg0.dtype == core.dtype("bf16") or arg1.dtype == core.dtype("bf16"):
-        core.static_print("extern livdevice.atan2 for dtype bf16 is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("fp16"), core.dtype("fp16")): ("__hmf_atan2_fp16", core.dtype("fp16")),
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_atan2_fp32", core.dtype("fp32")),
-        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.sad for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 @core.builtin
@@ -1255,12 +123,12 @@ def trunc(arg0, _semantic=None):
     :param arg0: The input tensor. Supported dtype: fp32.
     :type arg0: tl.tensor
     """
-    if triton_enable_libdevice_simt():
-        return core.extern_elementwise(
-            "", "", [arg0], {
-                (core.dtype("fp16"), ): ("__hmf_trunc_fp16", core.dtype("fp16")),
-                (core.dtype("fp32"), ): ("__hmf_trunc_fp32", core.dtype("fp32")),
-            }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_trunc_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
     else:
         arg0 = _semantic.to_tensor(arg0)
 
@@ -1274,20 +142,1549 @@ def trunc(arg0, _semantic=None):
 
 
 @core.extern
-def round(arg0, _semantic=None):
+def saturatef(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_saturate_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.saturatef for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def fma_rn(arg0, arg1, arg2, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1, arg2], {
+            (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fma_rn_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.fma_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def fma_rz(arg0, arg1, arg2, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1, arg2], {
+            (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fma_rz_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.fma_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def fma_rd(arg0, arg1, arg2, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1, arg2], {
+            (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fma_rd_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.fma_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def fma_ru(arg0, arg1, arg2, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1, arg2], {
+            (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fma_ru_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.fma_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.builtin
+def fast_dividef(arg0, arg1, _semantic=None):
     """
-    Rounds the input tensor to the nearest integer.
+    Computes a fast floating-point division.
+
+    :param arg0: The dividend tensor.
+    :type arg0: tl.tensor
+    :param arg1: The divisor tensor.
+    :type arg1: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fast_divide_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    arg1 = _semantic.to_tensor(arg1)
+    ret = _semantic.fdiv(arg0, arg1, False)
+    return ret
+
+
+@core.extern
+def div_rz(arg0, arg1, _semantic=None):
+    """
+    Computes the division with round-toward-zero mode.
+
+    :param arg0: The dividend tensor. Supported dtype: fp32.
+    :type arg0: tl.tensor
+    :param arg1: The divisor tensor. Supported dtype: fp32.
+    :type arg1: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_div_rz_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    arg0 = semantic.to_tensor(arg0, _semantic)
+    arg1 = semantic.to_tensor(arg1, _semantic)
+    ret = semantic.fdiv(arg0, arg1, False, _semantic)
+    return ret
+
+
+@core.extern
+def div_rd(arg0, arg1, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_div_rd_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.div_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def div_ru(arg0, arg1, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_div_ru_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.div_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def rcp_rn(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_rcp_rn_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.rcp_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def rcp_rz(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_rcp_rz_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.rcp_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def rcp_rd(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_rcp_rd_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.rcp_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def rcp_ru(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_rcp_ru_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.rcp_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def sqrt_rn(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_sqrt_rn_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.sqrt_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def sqrt_rz(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_sqrt_rz_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.sqrt_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def sqrt_rd(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_sqrt_rd_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.sqrt_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def sqrt_ru(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_sqrt_ru_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.sqrt_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def add_rn(arg0, arg1, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_add_rn_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.add_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def add_rz(arg0, arg1, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_add_rz_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.add_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def add_rd(arg0, arg1, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_add_rd_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.add_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def add_ru(arg0, arg1, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_add_ru_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.add_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def mul_rn(arg0, arg1, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_mul_rn_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.mul_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def mul_rz(arg0, arg1, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_mul_rz_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.mul_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def mul_rd(arg0, arg1, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_mul_rd_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.mul_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def mul_ru(arg0, arg1, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_mul_ru_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.mul_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def float2int_rn(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_float2int_rn_fp32", core.dtype("int32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.float2int_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def float2int_rz(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_float2int_rz_fp32", core.dtype("int32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.float2int_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def float2int_rd(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_float2int_rd_fp32", core.dtype("int32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.float2int_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def float2int_ru(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_float2int_ru_fp32", core.dtype("int32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.float2int_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def float2uint_rn(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_float2uint_rn_fp32", core.dtype("uint32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.float2uint_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def float2uint_rz(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_float2uint_rz_fp32", core.dtype("uint32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.float2uint_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def float2uint_rd(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_float2uint_rd_fp32", core.dtype("uint32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.float2uint_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def float2uint_ru(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_float2uint_ru_fp32", core.dtype("uint32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.float2uint_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def int2float_rn(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("int32"), ): ("__hmf_int2float_rn_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.int2float_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def int2float_rz(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("int32"), ): ("__hmf_int2float_rz_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.int2float_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def int2float_rd(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("int32"), ): ("__hmf_int2float_rd_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.int2float_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def int2float_ru(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("int32"), ): ("__hmf_int2float_ru_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.int2float_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def uint2float_rn(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("uint32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("uint32"), ): ("__hmf_uint2float_rn_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.uint2float_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def uint2float_rz(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("uint32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("uint32"), ): ("__hmf_uint2float_rz_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.uint2float_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def uint2float_rd(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("uint32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("uint32"), ): ("__hmf_uint2float_rd_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.uint2float_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def uint2float_ru(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("uint32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("uint32"), ): ("__hmf_uint2float_ru_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.uint2float_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def float2ll_rn(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_float2ll_rn_fp32", core.dtype("int64")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.float2ll_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def float2ll_rz(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_float2ll_rz_fp32", core.dtype("int64")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.float2ll_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def float2ll_rd(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_float2ll_rd_fp32", core.dtype("int64")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.float2ll_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def float2ll_ru(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_float2ll_ru_fp32", core.dtype("int64")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.float2ll_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def float2ull_rn(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_float2ull_rn_fp32", core.dtype("uint64")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.float2ull_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def float2ull_rz(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_float2ull_rz_fp32", core.dtype("uint64")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.float2ull_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def float2ull_rd(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_float2ull_rd_fp32", core.dtype("uint64")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.float2ull_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def float2ull_ru(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_float2ull_ru_fp32", core.dtype("uint64")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.float2ull_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def ll2float_rn(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int64") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("int64"), ): ("__hmf_ll2float_rn_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.ll2float_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def ll2float_rz(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int64") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("int64"), ): ("__hmf_ll2float_rz_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.ll2float_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def ll2float_rd(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int64") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("int64"), ): ("__hmf_ll2float_rd_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.ll2float_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def ll2float_ru(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int64") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("int64"), ): ("__hmf_ll2float_ru_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.ll2float_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def ull2float_rn(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("uint64") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("uint64"), ): ("__hmf_ull2float_rn_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.ull2float_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def ull2float_rz(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("uint64") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("uint64"), ): ("__hmf_ull2float_rz_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.ull2float_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def ull2float_rd(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("uint64") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("uint64"), ): ("__hmf_ull2float_rd_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.ull2float_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def ull2float_ru(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("uint64") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("uint64"), ): ("__hmf_ull2float_ru_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.ull2float_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def int_as_float(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("int32"), ): ("__hmf_int_as_float_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.int_as_float for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def float_as_int(arg0, _semantic=None):
+    """
+    Reinterprets the bits of a float32 value as an int32.
 
     :param arg0: The input tensor. Supported dtype: fp32.
     :type arg0: tl.tensor
     """
-    if triton_enable_libdevice_simt():
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise("", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_round_fp32", core.dtype("fp32")),
+            (core.dtype("fp32"), ): ("__hmf_float_as_int_fp32", core.dtype("int32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.float_as_int for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def uint_as_float(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("uint32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("uint32"), ): ("__hmf_uint_as_float_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.uint_as_float for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def float_as_uint(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_float_as_uint_fp32", core.dtype("uint32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.float_as_uint for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.builtin
+def fast_sinf(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_fast_sin_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.fast_sinf for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.builtin
+def fast_cosf(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_fast_cos_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.fast_cosf for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.builtin
+def fast_log2f(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_fast_log2_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.fast_log2f for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.builtin
+def fast_logf(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_fast_log_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.fast_logf for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.builtin
+def fast_expf(arg0, _semantic=None):
+    """
+    Computes a fast exponential (e^x) of the input tensor.
+
+    :param arg0: The input tensor.
+    :type arg0: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_fast_exp_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    ret = core.tensor(_semantic.builder.create_exp(arg0.handle), arg0.type)
+    return ret
+
+
+@core.builtin
+def fast_tanf(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_fast_tan_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.fast_tanf for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.builtin
+def fast_exp10f(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_fast_exp10_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.fast_exp10f for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.builtin
+def fast_log10f(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_fast_log10_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.fast_log10f for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.builtin
+def fast_powf(arg0, arg1, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fast_pow_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.fast_powf for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def hadd(arg0, arg1, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("int32"), core.dtype("int32")): ("__hmf_hadd_i32", core.dtype("int32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.hadd for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def rhadd(arg0, arg1, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("int32"), core.dtype("int32")): ("__hmf_rhadd_i32", core.dtype("int32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.rhadd for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def sub_rn(arg0, arg1, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_sub_rn_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.sub_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def sub_rz(arg0, arg1, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_sub_rz_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.sub_rz for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def sub_rd(arg0, arg1, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_sub_rd_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.sub_rd for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def sub_ru(arg0, arg1, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_sub_ru_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.sub_ru for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def rsqrt_rn(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_rsqrt_rn_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.rsqrt_rn for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def ffs(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("int32"), ): ("__hmf_ffs_i32", core.dtype("int32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.ffs for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+if get_ascend_arch_from_env() == "Ascend910_9589":
+    # if we have hardware support
+    @core.extern
+    def rint(arg0, _semantic=None):
+        """
+        Rounds the input tensor to the nearest integer using round-to-nearest-even.
+
+        :param arg0: The input tensor. Supported dtypes: fp32, fp16, bf16.
+        :type arg0: tl.tensor
+        """
+        arg0 = _semantic.to_tensor(arg0)
+        dtype = arg0.dtype
+        if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+            return core.extern_elementwise("", "", [
+                arg0,
+            ], {
+                (core.dtype("fp32"), ): ("__hmf_rint_fp32", core.dtype("fp32")),
+            }, is_pure=True, _semantic=_semantic)
+        return core.extern_elementwise(
+            "", "", [arg0], {
+                (core.dtype("fp32"), ): ("__hmf_rint", core.dtype("fp32")),
+                (core.dtype("fp16"), ): ("__hmf_rint", core.dtype("fp16")),
+                (core.dtype("bf16"), ): ("__hmf_rint", core.dtype("bf16")),
+            }, is_pure=True, _semantic=_semantic)
+else:
+
+    @core.builtin
+    @math._check_dtype(dtypes=["fp16", "fp32", "bf16"])
+    @math._add_math_1arg_docstr("rint")
+    def rint(arg0: core.tensor, _semantic=None):
+        """
+        Rounds the input tensor to the nearest integer using round-to-nearest-even.
+
+        :param arg0: The input tensor. Supported dtypes: fp32, fp16, bf16.
+        :type arg0: tl.tensor
+        """
+        arg0 = _semantic.to_tensor(arg0)
+        dtype = arg0.dtype
+        if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+            return core.extern_elementwise("", "", [
+                arg0,
+            ], {
+                (core.dtype("fp32"), ): ("__hmf_rint_fp32", core.dtype("fp32")),
+            }, is_pure=True, _semantic=_semantic)
+        arg0 = _semantic.to_tensor(arg0)
+
+        floor_x = math.floor(arg0, _semantic=_semantic)
+        fractional = _semantic.sub(arg0, floor_x, True)
+
+        half = _semantic.full(arg0.shape, 0.5, arg0.type.scalar)
+        eps = _semantic.full(arg0.shape, 1e-8, arg0.type.scalar)
+        is_half = _semantic.less_than(math.abs(_semantic.sub(fractional, half, True), _semantic=_semantic), eps)
+
+        floor_int = floor_x.to(core.int32, _semantic=_semantic) if hasattr(floor_x, "to") else _semantic.cast(
+            floor_x, core.int32)
+        two_i32 = _semantic.full(arg0.shape, 2, core.int32)
+        is_even = _semantic.equal(_semantic.mod(floor_int, two_i32), _semantic.full(arg0.shape, 0, core.int32))
+
+        zero = _semantic.full(arg0.shape, 0.0, arg0.type.scalar)
+        is_pos = _semantic.greater_equal(arg0, zero)
+
+        round_pos = math.floor(_semantic.add(arg0, half, True), _semantic=_semantic)
+        round_neg = math.ceil(_semantic.sub(arg0, half, True), _semantic=_semantic)
+        normal_round = _semantic.where(is_pos, round_pos, round_neg)
+
+        half_round = _semantic.where(is_even, floor_x, _semantic.add(floor_x, 1.0, True))
+
+        return _semantic.where(is_half, half_round, normal_round)
+
+
+@core.extern
+def llrint(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_llrint_fp32", core.dtype("int64")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.llrint for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.builtin
+@math._check_dtype(dtypes=[
+    "fp32",
+])
+@math._add_math_1arg_docstr("nearbyint")
+def nearbyint(arg0: core.tensor, _semantic=None):
+    """
+    Rounds the input tensor to the nearest integer using round-to-nearest-even.
+
+    :param arg0: The input tensor. Supported dtype: fp32.
+    :type arg0: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_nearbyint_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    else:
+        """
+        Round argument x to an integer value in floating-point format.
+
+        Uses the current rounding mode (round-to-nearest-even, aka banker's rounding).
+        """
+        arg0 = _semantic.to_tensor(arg0)
+
+        half = _semantic.full(arg0.shape, 0.5, arg0.type.scalar)
+
+        positive_adjust = _semantic.add(arg0, half, True)
+        negative_adjust = _semantic.sub(arg0, half, True)
+
+        positive_result = core.tensor(_semantic.builder.create_floor(positive_adjust.handle), arg0.type)
+        negative_result = core.tensor(_semantic.builder.create_ceil(negative_adjust.handle), arg0.type)
+
+        zero = _semantic.full(arg0.shape, 0.0, arg0.type.scalar)
+        is_positive = _semantic.greater_equal(arg0, zero)
+        basic_round = _semantic.where(is_positive, positive_result, negative_result)
+
+        # Banker's rounding special treatment: For values exactly in the middle, round to the nearest even number.
+        fractional = _semantic.sub(arg0, basic_round, True)
+        abs_fractional = core.tensor(_semantic.builder.create_fabs(fractional.handle), fractional.type)
+
+        is_half = _semantic.equal(abs_fractional, half)
+
+        two = _semantic.full(arg0.shape, 2.0, arg0.type.scalar)
+
+        half_value = math.fdiv(basic_round, two, _semantic=_semantic)
+        half_floor = core.tensor(_semantic.builder.create_floor(half_value.handle), half_value.type)
+        double_half = _semantic.mul(half_floor, two, True)
+
+        is_even = _semantic.equal(basic_round, double_half)
+
+        adjustment = _semantic.where(is_positive, _semantic.full(arg0.shape, -1.0, arg0.type.scalar),
+                                     _semantic.full(arg0.shape, 1.0, arg0.type.scalar))
+
+        banker_result = _semantic.where(
+            is_even,
+            basic_round,
+            _semantic.add(basic_round, adjustment, True),
+        )
+
+        # Final result: Use banker's rounding for cases exactly at 0.5, otherwise use basic rounding.
+        return _semantic.where(is_half, banker_result, basic_round)
+
+
+@core.extern
+def isnan(arg0, _semantic=None):
+    """
+    Tests whether each element of the input tensor is NaN.
+
+    :param arg0: The input tensor. Supported dtypes: fp32, fp16, bf16.
+    :type arg0: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_isnan_fp32", core.dtype("int1")),
+        }, is_pure=True, _semantic=_semantic)
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_isnan", core.dtype("int1")),
+            (core.dtype("fp16"), ): ("__hmf_isnan", core.dtype("int1")),
+            (core.dtype("bf16"), ): ("__hmf_isnan", core.dtype("int1")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+@math._check_dtype(dtypes=["fp16", "fp32"])
+def signbit(arg0, _semantic=None):
+    """
+    Returns the sign bit of the input tensor.
+
+    :param arg0: The input tensor. Supported dtypes: fp32, fp16.
+    :type arg0: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_signbit_fp32", core.dtype("int32")),
+        }, is_pure=True, _semantic=_semantic)
+    else:
+        arg0_scalar_ty = arg0.type.scalar
+        if arg0_scalar_ty == core.float32:
+            int_ty = core.int32
+        else:  # arg0 type: float16 / bfloat16
+            int_ty = core.int16
+
+        arg0 = _semantic.to_tensor(arg0)
+        int_tensor = _semantic.bitcast(arg0, int_ty)
+        if int_ty == core.int32:
+            shift = 31
+        elif int_ty == core.int16:
+            shift = 15
+
+        shift = _semantic.full(arg0.shape, shift, int_ty)
+        sign_bit_tensor = _semantic.lshr(int_tensor, shift)
+        sign_bit_tensor = _semantic.and_(sign_bit_tensor, _semantic.full(arg0.shape, 1, int_ty))
+        return _semantic.equal(sign_bit_tensor, 1)
+
+
+@core.builtin
+@math._check_dtype(dtypes=[
+    "fp32",
+])
+@math._add_math_2arg_docstr("copysign")
+def copysign(arg0: core.tensor, arg1: core.tensor, _semantic=None):
+    """
+    Creates a value with the magnitude of arg0 and the sign of arg1.
+
+    :param arg0: The magnitude tensor. Supported dtype: fp32.
+    :type arg0: tl.tensor
+    :param arg1: The sign tensor. Supported dtype: fp32.
+    :type arg1: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_copysign_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    else:
+        """
+        Create a floating-point value with the magnitude of x and the sign of y.
+        """
+        x = _semantic.to_tensor(arg0)
+        y = _semantic.to_tensor(arg1)
+
+        magnitude = core.tensor(_semantic.builder.create_fabs(x.handle), x.type)
+
+        zero = _semantic.full(y.shape, 0.0, y.type.scalar)
+        one = _semantic.full(y.shape, 1.0, y.type.scalar)
+
+        is_zero = _semantic.equal(y, zero)
+        y_reciprocal = math.fdiv(one, y, _semantic=_semantic)
+        is_negative_reciprocal = _semantic.less_than(y_reciprocal, zero)
+        is_negative_zero = _semantic.and_(is_zero, is_negative_reciprocal)
+
+        is_negative_nonzero = _semantic.less_than(y, zero)
+        is_negative = _semantic.or_(is_negative_zero, is_negative_nonzero)
+
+        neg_magnitude = _semantic.mul(magnitude, _semantic.full(magnitude.shape, -1.0, magnitude.type.scalar), True)
+
+        return _semantic.where(is_negative, neg_magnitude, magnitude)
+
+
+@core.extern
+def finitef(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_finite_fp32", core.dtype("int1")),
         }, is_pure=True, _semantic=_semantic)
     return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_roundf", core.dtype("fp32")),
+        (core.dtype("fp32"), ): ("__hmf_finitef", core.dtype("int1")),
     }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def isinf(arg0, _semantic=None):
+    """
+    Tests whether each element of the input tensor is infinity.
+
+    :param arg0: The input tensor. Supported dtypes: fp32, fp16, bf16.
+    :type arg0: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_isinf_fp32", core.dtype("int1")),
+        }, is_pure=True, _semantic=_semantic)
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_isinf", core.dtype("int1")),
+            (core.dtype("fp16"), ): ("__hmf_isinf", core.dtype("int1")),
+            (core.dtype("bf16"), ): ("__hmf_isinf", core.dtype("int1")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.builtin
+@math._check_dtype(dtypes=["fp16", "fp32"])
+@math._add_math_2arg_docstr("nextafter")
+def nextafter(arg0: core.tensor, arg1: core.tensor, _semantic=None):
+    """
+    Returns the next representable floating-point value after arg0 toward arg1.
+
+    :param arg0: The starting value tensor. Supported dtypes: fp32, fp16, bf16.
+    :type arg0: tl.tensor
+    :param arg1: The direction value tensor. Supported dtypes: fp32, fp16, bf16.
+    :type arg1: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_nextafter_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    else:
+        x = _semantic.to_tensor(arg0)
+        y = _semantic.to_tensor(arg1)
+        dtype_map = {"bf16": core.int16, "fp16": core.int16, "fp32": core.int32}
+        min_pos_bit = {"bf16": 0x0001, "fp16": 0x0001, "fp32": 0x00000001}
+        max_neg_bit = {"bf16": 0x8001, "fp16": 0x8001, "fp32": 0x80000001}
+        int_type = dtype_map[x.type.scalar.name]
+        x_eq_y = _semantic.equal(x, y)
+        x_gt_0 = _semantic.greater_than(x, 0)
+        y_gt_x = _semantic.greater_than(y, x)
+        next_neg = _semantic.xor_(x_gt_0, y_gt_x)
+        next_pos = _semantic.not_(next_neg)
+
+        p1 = _semantic.full(x.shape, 1, int_type)
+        n1 = _semantic.full(x.shape, -1, int_type)
+        dir_xy = _semantic.where(next_pos, p1, n1)
+        x_abs = math.abs(x, _semantic=_semantic)
+        x_is_0 = _semantic.equal(x_abs, 0)
+
+        min_pos = _semantic.full(x.shape, min_pos_bit[x.type.scalar.name], int_type)
+        max_neg = _semantic.full(x.shape, max_neg_bit[x.type.scalar.name], int_type)
+        min_pos = _semantic.bitcast(min_pos, x.dtype)
+        max_neg = _semantic.bitcast(max_neg, x.dtype)
+        bits_x = _semantic.bitcast(x, int_type)
+        bits_next = _semantic.add(bits_x, dir_xy, True)
+        next_val = _semantic.bitcast(bits_next, x.dtype)
+
+        need_min_pos = _semantic.logical_and(x_is_0, next_pos)
+        need_max_neg = _semantic.logical_and(x_is_0, next_neg)
+        next_val = _semantic.where(need_min_pos, min_pos, next_val)
+        next_val = _semantic.where(need_max_neg, max_neg, next_val)
+        return _semantic.where(x_eq_y, x, next_val)
+
+
+@core.extern
+def sinpi(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_sinpi_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.sinpi for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def cospi(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_cospi_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.cospi for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def tan(arg0, _semantic=None):
+    """
+    Computes the element-wise tangent of the input tensor.
+
+    :param arg0: The input tensor in radians. Supported dtypes: fp32, fp16.
+    :type arg0: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_tan_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_tanf", core.dtype("fp32")),
+            (core.dtype("fp16"), ): ("__hmf_tanDh", core.dtype("fp16")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def exp10(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_exp10_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.exp10 for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.builtin
+@math._check_dtype(dtypes=["bf16", "fp16", "fp32"])
+@math._add_math_1arg_docstr("cosh")
+def cosh(arg0: core.tensor, _semantic=None):
+    """
+    Computes the element-wise hyperbolic cosine of the input tensor.
+
+    :param arg0: The input tensor. Supported dtypes: fp32, fp16, bf16.
+    :type arg0: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_cosh_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    else:
+        arg0 = _semantic.to_tensor(arg0)
+        exp0 = core.tensor(_semantic.builder.create_exp(arg0.handle), arg0.type)
+        exp1 = _semantic.truediv(1.0, exp0)
+        tmp = _semantic.add(exp0, exp1, True)
+        ret = _semantic.truediv(tmp, 2.0)
+        return ret
+
+
+@core.builtin
+@math._check_dtype(dtypes=["bf16", "fp16", "fp32"])
+@math._add_math_1arg_docstr("sinh")
+def sinh(arg0: core.tensor, _semantic=None):
+    """
+    Computes the element-wise hyperbolic sine of the input tensor.
+
+    :param arg0: The input tensor. Supported dtypes: fp32, fp16, bf16.
+    :type arg0: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_sinh_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    else:
+        arg0 = _semantic.to_tensor(arg0)
+        exp0 = core.tensor(_semantic.builder.create_exp(arg0.handle), arg0.type)
+        exp1 = _semantic.truediv(1.0, exp0)
+        tmp = _semantic.sub(exp0, exp1, True)
+        ret = _semantic.truediv(tmp, 2.0)
+        return ret
+
+
+@core.extern
+def tanh(arg0, _semantic=None):
+    """
+    Computes the element-wise hyperbolic tangent of the input tensor.
+
+    :param arg0: The input tensor. Supported dtypes: fp32, fp16, bf16.
+    :type arg0: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    original_dtype = arg0.dtype
+    if original_dtype == core.dtype("bf16"):
+        arg0 = _semantic.cast(arg0, core.float32)
+
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_tanh_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    else:
+        dispatch = {
+            (core.dtype("fp32"), ): ("__hmf_tanhf", core.dtype("fp32")),
+            (core.dtype("fp16"), ): ("__hmf_tanhDh", core.dtype("fp16")),
+        }
+
+    res = core.extern_elementwise("", "", [arg0], dispatch, is_pure=True, _semantic=_semantic)
+    if original_dtype == core.dtype("bf16"):
+        return _semantic.cast(res, core.dtype("bf16"))
+    return res
+
+
+@core.extern
+@math._add_math_2arg_docstr("atan2")
+def atan2(arg0, arg1, _semantic=None):
+    """
+    Computes the arctangent of arg0/arg1, using signs to determine the quadrant.
+
+    :param arg0: The y-coordinate tensor. Supported dtypes: fp32, fp16.
+    :type arg0: tl.tensor
+    :param arg1: The x-coordinate tensor. Supported dtypes: fp32, fp16.
+    :type arg1: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if dtype == core.dtype('fp32') and is_compile_on_910_95:
+        return core.extern_elementwise('', '', [arg0, arg1], {(core.dtype('fp32'), core.dtype('fp32')):
+                                                              ('__hmf_atan2_fp32', core.dtype('fp32'))}, is_pure=True,
+                                       _semantic=_semantic)
+    else:
+        arg1 = _semantic.to_tensor(arg1)
+        pi = 3.1415926536
+        _is_int8_type_x: core.constexpr = arg1.dtype.is_int8()
+        core.static_assert(not _is_int8_type_x, f'Expected dtype fp16/fp32/bf16, but got int8 or int1',
+                           _semantic=_semantic)
+        _is_int8_type_y: core.constexpr = arg0.dtype.is_int8()
+        core.static_assert(not _is_int8_type_y, f'Expected dtype fp16/fp32/bf16, but got int8 or int1',
+                           _semantic=_semantic)
+        _is_floating_type_x: core.constexpr = arg1.dtype.is_floating()
+        core.static_assert(_is_floating_type_x == True,
+                           f'Expected dtype fp16/fp32/bf16, but got {core.constexpr(arg1.dtype)}', _semantic=_semantic)
+        _is_floating_type_y: core.constexpr = arg0.dtype.is_floating()
+        core.static_assert(_is_floating_type_y == True,
+                           f'Expected dtype fp16/fp32/bf16, but got {core.constexpr(arg0.dtype)}', _semantic=_semantic)
+        half_pi: core.constexpr = 0.5 * pi
+        arg0_fp32 = arg0.to(core.dtype('fp32'), _semantic=_semantic)
+        arg1_fp32 = arg1.to(core.dtype('fp32'), _semantic=_semantic)
+        atan_input = _semantic.truediv(arg0_fp32, arg1_fp32)
+        x_eq_zero = _semantic.equal(arg1, 0)
+        y_gt_zero = _semantic.greater_than(arg0, 0)
+        y_lt_zero = _semantic.less_than(arg0, 0)
+        x_lt_zero = _semantic.less_than(arg1, 0)
+        y_ge_zero = _semantic.greater_equal(arg0, 0)
+        base = _semantic.where(x_eq_zero, 0.0, atan(atan_input, _semantic=_semantic))
+        base = _semantic.where(_semantic.logical_and(x_eq_zero, y_gt_zero), half_pi, base)
+        base = _semantic.where(_semantic.logical_and(x_eq_zero, y_lt_zero), -half_pi, base)
+        add_pi = _semantic.where(_semantic.logical_and(x_lt_zero, y_ge_zero), pi, 0.0)
+        sub_pi = _semantic.where(_semantic.logical_and(x_lt_zero, y_lt_zero), -pi, 0.0)
+        ret = _semantic.add(_semantic.add(base, add_pi, True), sub_pi, True)
+        return ret.to(arg1.dtype, _semantic=_semantic)
+
+
+@core.extern
+def atan(arg0, _semantic=None):
+    """
+    Computes the element-wise arctangent (inverse tangent) of the input tensor.
+
+    :param arg0: The input tensor. Supported dtypes: fp32, fp16.
+    :type arg0: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_atan_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_atanf", core.dtype("fp32")),
+            (core.dtype("fp16"), ): ("__hmf_atanDh", core.dtype("fp16")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.builtin
+@math._check_dtype(dtypes=[
+    "fp32",
+])
+@math._add_math_1arg_docstr("arcsine")
+def asin(arg0: core.tensor, _semantic=None):
+    """
+    Computes the element-wise arcsine (inverse sine) of the input tensor.
+
+    :param arg0: The input tensor. Supported dtype: fp32.
+    :type arg0: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_asin_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    else:
+        """
+        Calculate the principal value of the arc sine of the input argument x.
+
+        Returns result in radians, in the interval [-π/2, +π/2] for x inside [-1, +1].
+        Returns NaN for x outside [-1, +1].
+        """
+        arg0 = _semantic.to_tensor(arg0)
+
+        # asin(x) = π/2 - acos(x)
+        half_pi = _semantic.full(arg0.shape, 1.5707963267948966, arg0.type.scalar)  # π/2
+        acos_val = acos(arg0, _semantic=_semantic)
+        return _semantic.sub(half_pi, acos_val, True)
 
 
 @core.builtin
@@ -1300,15 +1697,12 @@ def acos(arg0: core.tensor, _semantic=None):
     :param arg0: The input tensor. Supported dtypes: fp32, fp16, bf16.
     :type arg0: tl.tensor
     """
-    if triton_enable_libdevice_simt():
-        if arg0.dtype == core.dtype("bf16"):
-            core.static_print("extern livdevice.acos for dtype bf16 is unspported for now.")
-            core.static_assert(False)
-        return core.extern_elementwise(
-            "", "", [arg0], {
-                (core.dtype("fp16"), ): ("__hmf_acos_fp16", core.dtype("fp16")),
-                (core.dtype("fp32"), ): ("__hmf_acos_fp32", core.dtype("fp32")),
-            }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_acos_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
     else:
         pi = 3.1415926536
         pi_half = 1.5707963268
@@ -1358,59 +1752,57 @@ def acos(arg0: core.tensor, _semantic=None):
 
 
 @core.builtin
-@math._check_dtype(dtypes=["bf16", "fp16", "fp32"])
-@math._add_math_1arg_docstr("sinh")
-def sinh(arg0: core.tensor, _semantic=None):
+@math._check_dtype(dtypes=[
+    "fp32",
+])
+@math._add_math_1arg_docstr("base-10 logarithm")
+def log10(arg0: core.tensor, _semantic=None):
     """
-    Computes the element-wise hyperbolic sine of the input tensor.
+    Computes the element-wise base-10 logarithm of the input tensor.
 
-    :param arg0: The input tensor. Supported dtypes: fp32, fp16, bf16.
+    :param arg0: The input tensor. Supported dtype: fp32.
     :type arg0: tl.tensor
     """
-    if triton_enable_libdevice_simt():
-        if arg0.dtype == core.dtype("bf16"):
-            core.static_print("extern livdevice.sinh for dtype bf16 is unspported for now.")
-            core.static_assert(False)
-        return core.extern_elementwise(
-            "", "", [arg0], {
-                (core.dtype("fp16"), ): ("__hmf_sinh_fp16", core.dtype("fp16")),
-                (core.dtype("fp32"), ): ("__hmf_sinh_fp32", core.dtype("fp32")),
-            }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_log10_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
     else:
+        """
+        Calculate the base 10 logarithm of the input argument x.
+
+        Returns NaN for x < 0, -inf for x = 0, and +0 for x = 1.
+        log10(x) = log(x) / log(10)
+        """
         arg0 = _semantic.to_tensor(arg0)
-        exp0 = core.tensor(_semantic.builder.create_exp(arg0.handle), arg0.type)
-        exp1 = _semantic.truediv(1.0, exp0)
-        tmp = _semantic.sub(exp0, exp1, True)
-        ret = _semantic.truediv(tmp, 2.0)
-        return ret
+
+        log_val = math.log(arg0, _semantic=_semantic)
+        log10_const = _semantic.full(arg0.shape, 2.302585092994046, arg0.type.scalar)
+
+        return math.fdiv(log_val, log10_const, _semantic=_semantic)
 
 
-@core.builtin
-@math._check_dtype(dtypes=["bf16", "fp16", "fp32"])
-@math._add_math_1arg_docstr("cosh")
-def cosh(arg0: core.tensor, _semantic=None):
+@core.extern
+def log1p(arg0, _semantic=None):
     """
-    Computes the element-wise hyperbolic cosine of the input tensor.
+    Computes the element-wise natural logarithm of (1 + x).
 
-    :param arg0: The input tensor. Supported dtypes: fp32, fp16, bf16.
+    :param arg0: The input tensor. Supported dtypes: fp32, fp16.
     :type arg0: tl.tensor
     """
-    if triton_enable_libdevice_simt():
-        if arg0.dtype == core.dtype("bf16"):
-            core.static_print("extern livdevice.cosh for dtype bf16 is unspported for now.")
-            core.static_assert(False)
-        return core.extern_elementwise(
-            "", "", [arg0], {
-                (core.dtype("fp16"), ): ("__hmf_cosh_fp16", core.dtype("fp16")),
-                (core.dtype("fp32"), ): ("__hmf_cosh_fp32", core.dtype("fp32")),
-            }, is_pure=True, _semantic=_semantic)
-    else:
-        arg0 = _semantic.to_tensor(arg0)
-        exp0 = core.tensor(_semantic.builder.create_exp(arg0.handle), arg0.type)
-        exp1 = _semantic.truediv(1.0, exp0)
-        tmp = _semantic.add(exp0, exp1, True)
-        ret = _semantic.truediv(tmp, 2.0)
-        return ret
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_log1p_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_log1pf", core.dtype("fp32")),
+            (core.dtype("fp16"), ): ("__hmf_log1pDh", core.dtype("fp16")),
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.builtin
@@ -1423,15 +1815,12 @@ def acosh(arg0: core.tensor, _semantic=None):
     :param arg0: The input tensor. Supported dtypes: fp32, fp16, bf16.
     :type arg0: tl.tensor
     """
-    if triton_enable_libdevice_simt():
-        if arg0.dtype == core.dtype("bf16"):
-            core.static_print("extern livdevice.acosh for dtype bf16 is unspported for now.")
-            core.static_assert(False)
-        return core.extern_elementwise(
-            "", "", [arg0], {
-                (core.dtype("fp16"), ): ("__hmf_acosh_fp16", core.dtype("fp16")),
-                (core.dtype("fp32"), ): ("__hmf_acosh_fp32", core.dtype("fp32")),
-            }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_acosh_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
     else:
         arg0 = _semantic.to_tensor(arg0)
         tmp = _semantic.sub(_semantic.mul(arg0, arg0, True), 1.0, True)
@@ -1450,15 +1839,12 @@ def asinh(arg0: core.tensor, _semantic=None):
     :param arg0: The input tensor. Supported dtypes: fp32, fp16, bf16.
     :type arg0: tl.tensor
     """
-    if triton_enable_libdevice_simt():
-        if arg0.dtype == core.dtype("bf16"):
-            core.static_print("extern livdevice.asinh for dtype bf16 is unspported for now.")
-            core.static_assert(False)
-        return core.extern_elementwise(
-            "", "", [arg0], {
-                (core.dtype("fp16"), ): ("__hmf_asinh_fp16", core.dtype("fp16")),
-                (core.dtype("fp32"), ): ("__hmf_asinh_fp32", core.dtype("fp32")),
-            }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_asinh_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
     else:
         arg0 = _semantic.to_tensor(arg0)
         tmp = _semantic.add(_semantic.mul(arg0, arg0, True), 1.0, True)
@@ -1477,15 +1863,12 @@ def atanh(arg0: core.tensor, _semantic=None):
     :param arg0: The input tensor. Supported dtypes: fp32, fp16, bf16.
     :type arg0: tl.tensor
     """
-    if triton_enable_libdevice_simt():
-        if arg0.dtype == core.dtype("bf16"):
-            core.static_print("extern livdevice.atanh for dtype bf16 is unspported for now.")
-            core.static_assert(False)
-        return core.extern_elementwise(
-            "", "", [arg0], {
-                (core.dtype("fp16"), ): ("__hmf_atanh_fp16", core.dtype("fp16")),
-                (core.dtype("fp32"), ): ("__hmf_atanh_fp32", core.dtype("fp32")),
-            }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_atanh_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
     else:
         arg0 = _semantic.to_tensor(arg0)
         a = _semantic.add(1.0, arg0, True)
@@ -1506,71 +1889,16 @@ def expm1(arg0: core.tensor, _semantic=None):
     :param arg0: The input tensor. Supported dtypes: fp32, fp16, bf16.
     :type arg0: tl.tensor
     """
-    if triton_enable_libdevice_simt():
-        if arg0.dtype == core.dtype("bf16"):
-            core.static_print("extern livdevice.expm1 for dtype bf16 is unspported for now.")
-            core.static_assert(False)
-        return core.extern_elementwise(
-            "", "", [arg0], {
-                (core.dtype("fp16"), ): ("__hmf_expm1_fp16", core.dtype("fp16")),
-                (core.dtype("fp32"), ): ("__hmf_expm1_fp32", core.dtype("fp32")),
-            }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_expm1_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
     else:
         arg0 = _semantic.to_tensor(arg0)
         tmp = core.tensor(_semantic.builder.create_exp(arg0.handle), arg0.type)
         return _semantic.sub(tmp, 1, True)
-
-
-@core.builtin
-@math._check_dtype(dtypes=["fp16", "fp32"])
-@math._add_math_2arg_docstr("nextafter")
-def nextafter(arg0: core.tensor, arg1: core.tensor, _semantic=None):
-    """
-    Returns the next representable floating-point value after arg0 toward arg1.
-
-    :param arg0: The starting value tensor. Supported dtypes: fp32, fp16, bf16.
-    :type arg0: tl.tensor
-    :param arg1: The direction value tensor. Supported dtypes: fp32, fp16, bf16.
-    :type arg1: tl.tensor
-    """
-    if triton_enable_libdevice_simt():
-        return core.extern_elementwise(
-            "", "", [arg0, arg1], {
-                (core.dtype("fp16"), core.dtype("fp16")): ("__hmf_nextafter_fp16", core.dtype("fp16")),
-                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_nextafter_fp32", core.dtype("fp32")),
-            }, is_pure=True, _semantic=_semantic)
-    else:
-        x = _semantic.to_tensor(arg0)
-        y = _semantic.to_tensor(arg1)
-        dtype_map = {"bf16": core.int16, "fp16": core.int16, "fp32": core.int32}
-        min_pos_bit = {"bf16": 0x0001, "fp16": 0x0001, "fp32": 0x00000001}
-        max_neg_bit = {"bf16": 0x8001, "fp16": 0x8001, "fp32": 0x80000001}
-        int_type = dtype_map[x.type.scalar.name]
-        x_eq_y = _semantic.equal(x, y)
-        x_gt_0 = _semantic.greater_than(x, 0)
-        y_gt_x = _semantic.greater_than(y, x)
-        next_neg = _semantic.xor_(x_gt_0, y_gt_x)
-        next_pos = _semantic.not_(next_neg)
-
-        p1 = _semantic.full(x.shape, 1, int_type)
-        n1 = _semantic.full(x.shape, -1, int_type)
-        dir_xy = _semantic.where(next_pos, p1, n1)
-        x_abs = math.abs(x, _semantic=_semantic)
-        x_is_0 = _semantic.equal(x_abs, 0)
-
-        min_pos = _semantic.full(x.shape, min_pos_bit[x.type.scalar.name], int_type)
-        max_neg = _semantic.full(x.shape, max_neg_bit[x.type.scalar.name], int_type)
-        min_pos = _semantic.bitcast(min_pos, x.dtype)
-        max_neg = _semantic.bitcast(max_neg, x.dtype)
-        bits_x = _semantic.bitcast(x, int_type)
-        bits_next = _semantic.add(bits_x, dir_xy, True)
-        next_val = _semantic.bitcast(bits_next, x.dtype)
-
-        need_min_pos = _semantic.logical_and(x_is_0, next_pos)
-        need_max_neg = _semantic.logical_and(x_is_0, next_neg)
-        next_val = _semantic.where(need_min_pos, min_pos, next_val)
-        next_val = _semantic.where(need_max_neg, max_neg, next_val)
-        return _semantic.where(x_eq_y, x, next_val)
 
 
 @core.builtin
@@ -1585,15 +1913,12 @@ def hypot(arg0: core.tensor, arg1: core.tensor, _semantic=None):
     :param arg1: The second input tensor. Supported dtypes: fp32, fp16, bf16.
     :type arg1: tl.tensor
     """
-    if triton_enable_libdevice_simt():
-        if arg0.dtype == core.dtype("bf16"):
-            core.static_print("extern livdevice.hypot for dtype bf16 is unspported for now.")
-            core.static_assert(False)
-        return core.extern_elementwise(
-            "", "", [arg0, arg1], {
-                (core.dtype("fp16"), core.dtype("fp16")): ("__hmf_hypot_fp16", core.dtype("fp16")),
-                (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_hypot_fp32", core.dtype("fp32")),
-            }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_hypot_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
     else:
         arg0 = _semantic.to_tensor(arg0)
         arg1 = _semantic.to_tensor(arg1)
@@ -1604,137 +1929,163 @@ def hypot(arg0: core.tensor, arg1: core.tensor, _semantic=None):
 
 
 @core.extern
-def cbrt(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.cbrt for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_cbrt_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def rcbrt(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.rcbrt for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_rcbrt_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
 def rhypot(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.rhypot for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_rhypot_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_rhypot_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.rhypot for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 @core.extern
 def norm3d(arg0, arg1, arg2, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.norm3d for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1, arg2], {
-        (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_norm3d_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1, arg2], {
+            (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_norm3d_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.norm3d for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 @core.extern
 def rnorm3d(arg0, arg1, arg2, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.rnorm3d for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1, arg2], {
-        (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_rnorm3d_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1, arg2], {
+            (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_rnorm3d_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.rnorm3d for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 @core.extern
 def norm4d(arg0, arg1, arg2, arg3, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.norm4d for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1, arg2, arg3], {
-            (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")):
-            ("__hmf_norm4d_fp32", core.dtype("fp32")),
-        }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1, arg2, arg3], {
+                (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")):
+                ("__hmf_norm4d_fp32", core.dtype("fp32")),
+            }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.norm4d for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 @core.extern
 def rnorm4d(arg0, arg1, arg2, arg3, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.rnorm4d for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise(
-        "", "", [arg0, arg1, arg2, arg3], {
-            (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")):
-            ("__hmf_rnorm4d_fp32", core.dtype("fp32")),
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise(
+            "", "", [arg0, arg1, arg2, arg3], {
+                (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")):
+                ("__hmf_rnorm4d_fp32", core.dtype("fp32")),
+            }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.rnorm4d for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def cbrt(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_cbrt_fp32", core.dtype("fp32")),
         }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.cbrt for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def rcbrt(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_rcbrt_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.rcbrt for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 @core.extern
 def j0(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.j0 for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_j0_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_j0_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.j0 for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 @core.extern
 def j1(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.j1 for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_j1_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def jn(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.jn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("int32"), core.dtype("fp32")): ("__hmf_jn_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_j1_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.j1 for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 @core.extern
 def y0(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.y0 for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_y0_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_y0_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.y0 for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 @core.extern
 def y1(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.y1 for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_y1_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_y1_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.y1 for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 @core.extern
 def yn(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.yn for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("int32"), core.dtype("fp32")): ("__hmf_yn_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("int32"), core.dtype("fp32")): ("__hmf_yn_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.yn for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def jn(arg0, arg1, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("int32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("int32"), core.dtype("fp32")): ("__hmf_jn_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.jn for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 # This function is derived from the Cephes Math Library release 2.8: June, 2000
@@ -1751,10 +2102,9 @@ def cyl_bessel_i0(arg0: core.tensor, _semantic=None):
     :param arg0: The input tensor. Supported dtypes: fp32, fp16.
     :type arg0: tl.tensor
     """
-    if triton_enable_libdevice_simt():
-        if arg0.dtype == core.dtype("fp16"):
-            core.static_print("extern livdevice.cyl_bessel_i0 for dtype bf16 is unspported for now.")
-            core.static_assert(False)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise("", "", [arg0], {
             (core.dtype("fp32"), ): ("__hmf_cyl_bessel_i0_fp32", core.dtype("fp32")),
         }, is_pure=True, _semantic=_semantic)
@@ -1852,87 +2202,26 @@ def cyl_bessel_i0(arg0: core.tensor, _semantic=None):
 
 @core.extern
 def cyl_bessel_i1(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.cyl_bessel_i1 for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_cyl_bessel_i1_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-@math._check_dtype(dtypes=["fp16", "fp32"])
-def signbit(arg0, _semantic=None):
-    """
-    Returns the sign bit of the input tensor.
-
-    :param arg0: The input tensor. Supported dtypes: fp32, fp16.
-    :type arg0: tl.tensor
-    """
-    if triton_enable_libdevice_simt():
-        return core.extern_elementwise(
-            "", "", [arg0], {
-                (core.dtype("fp16"), ): ("__hmf_signbit_fp16", core.dtype("int32")),
-                (core.dtype("fp32"), ): ("__hmf_signbit_fp32", core.dtype("int32")),
-            }, is_pure=True, _semantic=_semantic)
-    else:
-        arg0_scalar_ty = arg0.type.scalar
-        if arg0_scalar_ty == core.float32:
-            int_ty = core.int32
-        else:  # arg0 type: float16 / bfloat16
-            int_ty = core.int16
-
-        arg0 = _semantic.to_tensor(arg0)
-        int_tensor = _semantic.bitcast(arg0, int_ty)
-        if int_ty == core.int32:
-            shift = 31
-        elif int_ty == core.int16:
-            shift = 15
-
-        shift = _semantic.full(arg0.shape, shift, int_ty)
-        sign_bit_tensor = _semantic.lshr(int_tensor, shift)
-        sign_bit_tensor = _semantic.and_(sign_bit_tensor, _semantic.full(arg0.shape, 1, int_ty))
-        return _semantic.equal(sign_bit_tensor, 1)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_cyl_bessel_i1_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.cyl_bessel_i1 for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 @core.extern
 def erf(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.erf for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_erf_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def erfc(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.erfc for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_erfc_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def erfcx(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.erfcx for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_erfcx_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def erfcinv(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.erfcxinv for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_erfcinv_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_erf_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.erf for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 # Note:
@@ -1950,7 +2239,9 @@ def erfinv(arg0, _semantic=None):
     :param arg0: The input tensor. Supported dtype: fp32.
     :type arg0: tl.tensor
     """
-    if triton_enable_libdevice_simt():
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise("", "", [arg0], {
             (core.dtype("fp32"), ): ("__hmf_erfinv_fp32", core.dtype("fp32")),
         }, is_pure=True, _semantic=_semantic)
@@ -2054,23 +2345,63 @@ def erfinv(arg0, _semantic=None):
 
 
 @core.extern
-def normcdf(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.normcdf for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_normcdf_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
+def erfc(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_erfc_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.erfc for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def erfcx(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_erfcx_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.erfcx for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def erfcinv(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_erfcinv_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.erfcxinv for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 @core.extern
 def normcdfinv(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.normcdfinv for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_normcdfinv_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_normcdfinv_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.normcdfinv for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def normcdf(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_normcdf_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.normcdf for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 # Note:
@@ -2089,7 +2420,9 @@ def gamma(arg0, _semantic=None):
     :param arg0: The input tensor. Supported dtype: fp32.
     :type arg0: tl.tensor
     """
-    if triton_enable_libdevice_simt():
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise("", "", [arg0], {
             (core.dtype("fp32"), ): ("__hmf_tgamma_fp32", core.dtype("fp32")),
         }, is_pure=True, _semantic=_semantic)
@@ -2139,16 +2472,6 @@ def gamma(arg0, _semantic=None):
         return _semantic.where(is_pos_inf_input, pos_inf_tensor, _semantic.where(is_neg_inf_input, neg_inf_tensor, res))
 
 
-@core.extern
-def tgamma(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.tgamma for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_tgamma_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
 # Note:
 # The lgamma function computes the natural logarithm of the absolute value of the gamma function.
 # Since it uses gamma(x) internally, it inherits the same numerical instability near negative integers:
@@ -2166,7 +2489,9 @@ def lgamma(arg0, _semantic=None):
     :param arg0: The input tensor. Supported dtype: fp32.
     :type arg0: tl.tensor
     """
-    if triton_enable_libdevice_simt():
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise("", "", [arg0], {
             (core.dtype("fp32"), ): ("__hmf_lgamma_fp32", core.dtype("fp32")),
         }, is_pure=True, _semantic=_semantic)
@@ -2182,597 +2507,228 @@ def lgamma(arg0, _semantic=None):
         return _semantic.where(is_inf, inf_tensor, core.tensor(lgamma_res, arg0.type))
 
 
-@core.builtin
-@math._check_dtype(dtypes=[
-    "fp32",
-])
-@math._add_math_1arg_docstr("nearbyint")
-def nearbyint(arg0: core.tensor, _semantic=None):
-    """
-    Rounds the input tensor to the nearest integer using round-to-nearest-even.
-
-    :param arg0: The input tensor. Supported dtype: fp32.
-    :type arg0: tl.tensor
-    """
-    if triton_enable_libdevice_simt():
-        return core.extern_elementwise("", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_nearbyint_fp32", core.dtype("fp32")),
-        }, is_pure=True, _semantic=_semantic)
-    else:
-        """
-        Round argument x to an integer value in floating-point format.
-
-        Uses the current rounding mode (round-to-nearest-even, aka banker's rounding).
-        """
-        arg0 = _semantic.to_tensor(arg0)
-
-        half = _semantic.full(arg0.shape, 0.5, arg0.type.scalar)
-
-        positive_adjust = _semantic.add(arg0, half, True)
-        negative_adjust = _semantic.sub(arg0, half, True)
-
-        positive_result = core.tensor(_semantic.builder.create_floor(positive_adjust.handle), arg0.type)
-        negative_result = core.tensor(_semantic.builder.create_ceil(negative_adjust.handle), arg0.type)
-
-        zero = _semantic.full(arg0.shape, 0.0, arg0.type.scalar)
-        is_positive = _semantic.greater_equal(arg0, zero)
-        basic_round = _semantic.where(is_positive, positive_result, negative_result)
-
-        # Banker's rounding special treatment: For values exactly in the middle, round to the nearest even number.
-        fractional = _semantic.sub(arg0, basic_round, True)
-        abs_fractional = core.tensor(_semantic.builder.create_fabs(fractional.handle), fractional.type)
-
-        is_half = _semantic.equal(abs_fractional, half)
-
-        two = _semantic.full(arg0.shape, 2.0, arg0.type.scalar)
-
-        half_value = math.fdiv(basic_round, two, _semantic=_semantic)
-        half_floor = core.tensor(_semantic.builder.create_floor(half_value.handle), half_value.type)
-        double_half = _semantic.mul(half_floor, two, True)
-
-        is_even = _semantic.equal(basic_round, double_half)
-
-        adjustment = _semantic.where(is_positive, _semantic.full(arg0.shape, -1.0, arg0.type.scalar),
-                                     _semantic.full(arg0.shape, 1.0, arg0.type.scalar))
-
-        banker_result = _semantic.where(
-            is_even,
-            basic_round,
-            _semantic.add(basic_round, adjustment, True),
-        )
-
-        # Final result: Use banker's rounding for cases exactly at 0.5, otherwise use basic rounding.
-        return _semantic.where(is_half, banker_result, basic_round)
-
-
 @core.extern
-def sinpi(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.sinpi for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_sinpi_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def cospi(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.cospi for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_cospi_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.builtin
-@math._check_dtype(dtypes=[
-    "fp32",
-])
-@math._add_math_1arg_docstr("arcsine")
-def asin(arg0: core.tensor, _semantic=None):
+def ldexp(arg0, arg1, _semantic=None):
     """
-    Computes the element-wise arcsine (inverse sine) of the input tensor.
+    Computes x * 2^exp from a mantissa and an exponent.
 
-    :param arg0: The input tensor. Supported dtype: fp32.
+    :param arg0: The mantissa tensor. Supported dtypes: fp32, fp16.
     :type arg0: tl.tensor
-    """
-    if triton_enable_libdevice_simt():
-        return core.extern_elementwise(
-            "", "", [arg0], {
-                (core.dtype("fp16"), ): ("__hmf_asin_fp16", core.dtype("fp16")),
-                (core.dtype("fp32"), ): ("__hmf_asin_fp32", core.dtype("fp32")),
-            }, is_pure=True, _semantic=_semantic)
-    else:
-        """
-        Calculate the principal value of the arc sine of the input argument x.
-
-        Returns result in radians, in the interval [-π/2, +π/2] for x inside [-1, +1].
-        Returns NaN for x outside [-1, +1].
-        """
-        arg0 = _semantic.to_tensor(arg0)
-
-        # asin(x) = π/2 - acos(x)
-        half_pi = _semantic.full(arg0.shape, 1.5707963267948966, arg0.type.scalar)  # π/2
-        acos_val = acos(arg0, _semantic=_semantic)
-        return _semantic.sub(half_pi, acos_val, True)
-
-
-@core.builtin
-@math._check_dtype(dtypes=[
-    "fp32",
-])
-@math._add_math_1arg_docstr("base-10 logarithm")
-def log10(arg0: core.tensor, _semantic=None):
-    """
-    Computes the element-wise base-10 logarithm of the input tensor.
-
-    :param arg0: The input tensor. Supported dtype: fp32.
-    :type arg0: tl.tensor
-    """
-    if triton_enable_libdevice_simt():
-        return core.extern_elementwise("", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_log10_fp32", core.dtype("fp32")),
-        }, is_pure=True, _semantic=_semantic)
-    else:
-        """
-        Calculate the base 10 logarithm of the input argument x.
-
-        Returns NaN for x < 0, -inf for x = 0, and +0 for x = 1.
-        log10(x) = log(x) / log(10)
-        """
-        arg0 = _semantic.to_tensor(arg0)
-
-        log_val = math.log(arg0, _semantic=_semantic)
-        log10_const = _semantic.full(arg0.shape, 2.302585092994046, arg0.type.scalar)
-
-        return math.fdiv(log_val, log10_const, _semantic=_semantic)
-
-
-@core.builtin
-@math._check_dtype(dtypes=[
-    "fp32",
-])
-@math._add_math_2arg_docstr("copysign")
-def copysign(arg0: core.tensor, arg1: core.tensor, _semantic=None):
-    """
-    Creates a value with the magnitude of arg0 and the sign of arg1.
-
-    :param arg0: The magnitude tensor. Supported dtype: fp32.
-    :type arg0: tl.tensor
-    :param arg1: The sign tensor. Supported dtype: fp32.
+    :param arg1: The exponent tensor. Supported dtype: int32.
     :type arg1: tl.tensor
     """
-    if triton_enable_libdevice_simt():
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
         return core.extern_elementwise("", "", [arg0, arg1], {
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_copysign_fp32", core.dtype("fp32")),
+            (core.dtype("fp32"), core.dtype("int32")): ("__hmf_ldexp_fp32", core.dtype("fp32")),
         }, is_pure=True, _semantic=_semantic)
-    else:
-        """
-        Create a floating-point value with the magnitude of x and the sign of y.
-        """
-        x = _semantic.to_tensor(arg0)
-        y = _semantic.to_tensor(arg1)
-
-        magnitude = core.tensor(_semantic.builder.create_fabs(x.handle), x.type)
-
-        zero = _semantic.full(y.shape, 0.0, y.type.scalar)
-        one = _semantic.full(y.shape, 1.0, y.type.scalar)
-
-        is_zero = _semantic.equal(y, zero)
-        y_reciprocal = math.fdiv(one, y, _semantic=_semantic)
-        is_negative_reciprocal = _semantic.less_than(y_reciprocal, zero)
-        is_negative_zero = _semantic.and_(is_zero, is_negative_reciprocal)
-
-        is_negative_nonzero = _semantic.less_than(y, zero)
-        is_negative = _semantic.or_(is_negative_zero, is_negative_nonzero)
-
-        neg_magnitude = _semantic.mul(magnitude, _semantic.full(magnitude.shape, -1.0, magnitude.type.scalar), True)
-
-        return _semantic.where(is_negative, neg_magnitude, magnitude)
-
-
-if get_ascend_arch_from_env() == "Ascend910_9589":
-    # if we have hardware support
-    @core.extern
-    def rint(arg0, _semantic=None):
-        """
-        Rounds the input tensor to the nearest integer using round-to-nearest-even.
-
-        :param arg0: The input tensor. Supported dtypes: fp32, fp16, bf16.
-        :type arg0: tl.tensor
-        """
-        return core.extern_elementwise(
-            "", "", [arg0], {
-                (core.dtype("fp32"), ): ("__hmf_rint", core.dtype("fp32")),
-                (core.dtype("fp16"), ): ("__hmf_rint", core.dtype("fp16")),
-                (core.dtype("bf16"), ): ("__hmf_rint", core.dtype("bf16")),
-            }, is_pure=True, _semantic=_semantic)
-else:
-
-    @core.builtin
-    @math._check_dtype(dtypes=["fp16", "fp32", "bf16"])
-    @math._add_math_1arg_docstr("rint")
-    def rint(arg0: core.tensor, _semantic=None):
-        """
-        Rounds the input tensor to the nearest integer using round-to-nearest-even.
-
-        :param arg0: The input tensor. Supported dtypes: fp32, fp16, bf16.
-        :type arg0: tl.tensor
-        """
-        if triton_enable_libdevice_simt():
-            return core.extern_elementwise("", "", [
-                arg0,
-            ], {
-                (core.dtype("fp32"), ): ("__hmf_rint_fp32", core.dtype("fp32")),
-            }, is_pure=True, _semantic=_semantic)
-        arg0 = _semantic.to_tensor(arg0)
-
-        floor_x = math.floor(arg0, _semantic=_semantic)
-        fractional = _semantic.sub(arg0, floor_x, True)
-
-        half = _semantic.full(arg0.shape, 0.5, arg0.type.scalar)
-        eps = _semantic.full(arg0.shape, 1e-8, arg0.type.scalar)
-        is_half = _semantic.less_than(math.abs(_semantic.sub(fractional, half, True), _semantic=_semantic), eps)
-
-        floor_int = floor_x.to(core.int32, _semantic=_semantic) if hasattr(floor_x, "to") else _semantic.cast(
-            floor_x, core.int32)
-        two_i32 = _semantic.full(arg0.shape, 2, core.int32)
-        is_even = _semantic.equal(_semantic.mod(floor_int, two_i32), _semantic.full(arg0.shape, 0, core.int32))
-
-        zero = _semantic.full(arg0.shape, 0.0, arg0.type.scalar)
-        is_pos = _semantic.greater_equal(arg0, zero)
-
-        round_pos = math.floor(_semantic.add(arg0, half, True), _semantic=_semantic)
-        round_neg = math.ceil(_semantic.sub(arg0, half, True), _semantic=_semantic)
-        normal_round = _semantic.where(is_pos, round_pos, round_neg)
-
-        half_round = _semantic.where(is_even, floor_x, _semantic.add(floor_x, 1.0, True))
-
-        return _semantic.where(is_half, half_round, normal_round)
+    return core.extern_elementwise(
+        "", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("int32")): ("__hmf_ldexpf", core.dtype("fp32")),
+            (core.dtype("fp16"), core.dtype("int32")): ("__hmf_ldexpDh", core.dtype("fp16")),
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def llrint(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.llrint for simd is unspported for now.")
-        core.static_assert(False)
+def scalbn(arg0, arg1, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("int32")): ("__hmf_scalbn_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.scalbn for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def fmod(arg0, arg1, _semantic=None):
+    """
+    Computes the floating-point remainder of arg0 / arg1.
+
+    :param arg0: The dividend tensor. Supported dtype: fp32.
+    :type arg0: tl.tensor
+    :param arg1: The divisor tensor. Supported dtype: fp32.
+    :type arg1: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fmod_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    arg0 = semantic.to_tensor(arg0, _semantic)
+    arg1 = semantic.to_tensor(arg1, _semantic)
+    ret = semantic.mod(arg0, arg1, _semantic)
+    return ret
+
+
+@core.extern
+def remainder(arg0, arg1, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_remainder_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.remainder for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def pow(arg0, arg1, _semantic=None):
+    """
+    Computes arg0 raised to the power of arg1.
+
+    :param arg0: The base tensor. Supported dtypes: fp32, fp16, bf16.
+    :type arg0: tl.tensor
+    :param arg1: The exponent tensor. Supported dtypes: fp32, fp16, bf16, int32.
+    :type arg1: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    arg1 = _semantic.to_tensor(arg1)
+    if arg1.dtype == core.dtype("int32"):
+        arg1 = _semantic.cast(arg1, arg0.dtype)
+
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_pow_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    return core.extern_elementwise(
+        "", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_powf", core.dtype("fp32")),
+            (core.dtype("fp16"), core.dtype("fp16")): ("__hmf_powDh", core.dtype("fp16")),
+            (core.dtype("bf16"), core.dtype("bf16")): ("__hmf_powDb", core.dtype("bf16")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def tgamma(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_tgamma_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.tgamma for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def round(arg0, _semantic=None):
+    """
+    Rounds the input tensor to the nearest integer.
+
+    :param arg0: The input tensor. Supported dtype: fp32.
+    :type arg0: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_round_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
     return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_llrint_fp32", core.dtype("int64")),
+        (core.dtype("fp32"), ): ("__hmf_roundf", core.dtype("fp32")),
     }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
 def llround(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("livdevice.llround for simd is unspported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_llround_fp32", core.dtype("int64")),
-    }, is_pure=True, _semantic=_semantic)
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_llround_fp32", core.dtype("int64")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.llround for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 @core.extern
-def abs(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.abs for simd is unsupported for now.")
-        core.static_assert(False)
+def fdim(arg0, arg1, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fdim_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.fdim for {dtype} is unspported for now.")
+    core.static_assert(False)
+
+
+@core.extern
+def ilogb(arg0, _semantic=None):
+    """
+    Returns the integer binary exponent of the input tensor.
+
+    :param arg0: The input tensor. Supported dtypes: fp32, fp16.
+    :type arg0: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_ilogb_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
     return core.extern_elementwise(
         "", "", [arg0], {
-            (core.dtype("fp32"), ): ("__hmf_abs_fp32", core.dtype("fp32")),
-            (core.dtype("int32"), ): ("__hmf_abs_i32", core.dtype("int32")),
+            (core.dtype("fp32"), ): ("__hmf_ilogbf", core.dtype("fp32")),
+            (core.dtype("fp16"), ): ("__hmf_ilogbDh", core.dtype("fp16")),
         }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def brevll(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.brevll for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("int64"), ): ("__hmf_brevll_i64", core.dtype("int64")),
-    }, is_pure=True, _semantic=_semantic)
+def logb(arg0, _semantic=None):
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_logb_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+    core.static_print(f"libdevice.logb for {dtype} is unspported for now.")
+    core.static_assert(False)
 
 
 @core.extern
-def ceil(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.ceil for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_ceil_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
+def reciprocal(arg0, _semantic=None):
+    """
+    Computes the element-wise reciprocal (1/x) of the input tensor.
 
-
-@core.extern
-def clzll(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.clzll for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("int64"), ): ("__hmf_clzll_i64", core.dtype("int32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def cos(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.cos for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_cos_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def div_rn(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.div_rn for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_div_rn_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def exp(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.exp for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_exp_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def exp2(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.exp2 for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_exp2_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def fast_exp2f(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.fast_exp2f for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_fast_exp2_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def ffsll(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.ffsll for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("int64"), ): ("__hmf_ffsll_i64", core.dtype("int32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def float2half_rn(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.float2half_rn for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_float2half_rn_fp32", core.dtype("fp16")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def floor(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.floor for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_floor_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def fma(arg0, arg1, arg2, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.fma for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1, arg2], {
-        (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fma_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def max(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.max for simd is unsupported for now.")
-        core.static_assert(False)
+    :param arg0: The input tensor. Supported dtypes: fp32, fp16.
+    :type arg0: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_reciprocal_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
     return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("int32"), core.dtype("int32")): ("__hmf_max_i32", core.dtype("int32")),
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fmax_fp32", core.dtype("fp32")),
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_recipf", core.dtype("fp32")),
+            (core.dtype("fp16"), ): ("__hmf_recipDh", core.dtype("fp16")),
         }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def min(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.min for simd is unsupported for now.")
-        core.static_assert(False)
+def relu(arg0, _semantic=None):
+    """
+    Computes the element-wise ReLU activation: max(0, x).
+
+    :param arg0: The input tensor. Supported dtypes: fp32, fp16.
+    :type arg0: tl.tensor
+    """
+    arg0 = _semantic.to_tensor(arg0)
+    dtype = arg0.dtype
+    if (dtype == core.dtype("fp32") and is_compile_on_910_95):
+        return core.extern_elementwise("", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_relu_fp32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
     return core.extern_elementwise(
-        "", "", [arg0, arg1], {
-            (core.dtype("int32"), core.dtype("int32")): ("__hmf_min_i32", core.dtype("int32")),
-            (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_fmin_fp32", core.dtype("fp32")),
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__hmf_reluf", core.dtype("fp32")),
+            (core.dtype("fp16"), ): ("__hmf_reluDh", core.dtype("fp16")),
         }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def half2float(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.half2float for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp16"), ): ("__hmf_half2float_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def llabs(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.llabs for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("int64"), ): ("__hmf_llabs_i64", core.dtype("int64")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def log(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.log for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_log_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def log2(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.log2 for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_log2_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def mul64hi(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.mul64hi for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("int64"), core.dtype("int64")): ("__hmf_mul64hi_i64", core.dtype("int64")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def nan(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.nan for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_nanf_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def popcll(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.popcll for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("int64"), ): ("__hmf_popcll_i64", core.dtype("int32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def powif(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.powif for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("fp32"), core.dtype("int32")): ("__hmf_powi_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def rsqrt(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.rsqrt for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_rsqrt_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def sin(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.sin for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_sin_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def sqrt(arg0, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.sqrt for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_sqrt_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def uhadd(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.uhadd for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("uint32"), core.dtype("uint32")): ("__hmf_uhadd_u32_u32", core.dtype("uint32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def umul24(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.umul24 for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("uint32"), core.dtype("uint32")): ("__hmf_umul24_u32", core.dtype("uint32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def umul64hi(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.umul64hi for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("uint64"), core.dtype("uint64")): ("__hmf_umul64hi_u64", core.dtype("uint64")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def umulhi(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.umulhi for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("uint32"), core.dtype("uint32")): ("__hmf_umulhi_u32", core.dtype("uint32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def urhadd(arg0, arg1, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.urhadd for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1], {
-        (core.dtype("uint32"), core.dtype("uint32")): ("__hmf_urhadd_u32_u32", core.dtype("uint32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
-def usad(arg0, arg1, arg2, _semantic=None):
-    if not triton_enable_libdevice_simt():
-        core.static_print("libdevice.usad for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0, arg1, arg2], {
-        (core.dtype("uint32"), core.dtype("uint32"), core.dtype("uint32")): ("__hmf_usad_u32", core.dtype("uint32")),
-    }, is_pure=True, _semantic=_semantic)

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -1700,11 +1700,11 @@ LogicalResult ExternElementwiseClOpConverter::matchAndRewrite(
     // extern libdevice ops -> hivm.hir.custom
     static constexpr llvm::StringLiteral simtLibdeviceSuffixes[] = {
         "_fp32", "_fp16", "_bf16", "_i32", "_i64", "_u32", "_u64"};
-    bool isSimtLibdeviceOp =
+    bool isLibdeviceOp =
         llvm::any_of(simtLibdeviceSuffixes, [&](llvm::StringRef suffix) {
           return op.getSymbol().ends_with(suffix);
         });
-    if (isSimtLibdeviceOp) {
+    if (isLibdeviceOp) {
       auto originalTensorType = isDstScalar
                                     ? RankedTensorType::get({1}, dstElemTy)
                                     : cast<RankedTensorType>(dstTy);
@@ -1795,6 +1795,7 @@ LogicalResult ExternElementwiseClOpConverter::matchAndRewrite(
       auto customOp = rewriter.create<hivm::CustomOp>(
           op.getLoc(), sym, ValueRange{collapsedInputs},
           ValueRange{outputTensor});
+      customOp.setInlineMode(hivm::InlineMode::AlwaysInline);
 
       auto argAttrsArray = mlir::ArrayAttr::get(customOp->getContext(), {});
       auto pipeAttr =


### PR DESCRIPTION
## Initiative
1. External Libdevice library operators cannot support scalar input.
2. External Libdevice library operators cannot support multi-dimensional tensor input.

## Solution
1. For scalar input/output, convert it to a 1-dimensional tensor for computation, then extract the scalar data.
2. For multi-dimensional tensor inputs, flatten them into a 1-dimensional tensor for computation, then reshape the result to the original shape.

## Additional Modify
1. Replace the "tensor.empty" relied on by CustomOp with "memref.alloc" to optimize the life-cycle management.
2. Switch the commit of the submodule "AscendNPU-IR" to 97f7c320, which ensures that the external Libdevice library operators are correctly inlined during compilation.