### PR TITLE
[WIP][Launcher](fix) resolve premature memory deallocation issue in workspace

### DIFF
--- a/third_party/ascend/backend/npu_utils.cpp
+++ b/third_party/ascend/backend/npu_utils.cpp
@@ -349,10 +349,9 @@ static void *retainTensor(at::Tensor tensor, void **handle) {
 
 extern "C" void* triton_allocate_workspace_legacy(uint64_t size)
 {
-  return const_cast<void*>(
-      at::empty(size, at::TensorOptions().device(at::kPrivateUse1).dtype(at::kByte))
-          .storage()
-          .data());
+  auto optionsWorkspace = at::TensorOptions().device(at::kPrivateUse1).dtype(at::kByte);
+  at::Tensor workspace_tensor = at::empty(size, optionsWorkspace);
+  return const_cast<void*>(workspace_tensor.storage().data());
 }
 
 extern "C" void* triton_allocate_sync_block_lock(uint64_t size, void* stream, void **handle)


### PR DESCRIPTION
Fix the lifecycle management issue in framework-side NPU global memory allocation, which causes premature release of pre-allocated memory, which can be detected by mssanitizer tools.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
