### PR TITLE
[ci](feat) Add Dynamic-CV-Pipeline ci

### DIFF
--- a/.github/workflows/DynamicCVPipeline-ci.yml
+++ b/.github/workflows/DynamicCVPipeline-ci.yml
@@ -1,0 +1,115 @@
+name: DynamicCVPipeline PreCheck Tests
+
+on:
+  pull_request:
+    paths:
+      - 'third_party/ascend/lib/DynamicCVPipeline/**'
+      - 'third_party/ascend/include/DynamicCVPipeline/**'
+      - 'third_party/ascend/unittest/DynamicCVPipeline_ut/**'
+
+  workflow_dispatch:
+    inputs:
+      pr_id:
+        description: PR number to (re)trigger test against
+        required: true
+
+concurrency:
+  group: dcv-pipeline-${{ github.event_name == 'workflow_dispatch' && github.run_id || 'queue' }}--${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  build-check:
+    if: >-
+      github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: linux-amd64-cpu-16
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/triton:8.5.0-910b-ubuntu22.04-py3.11-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+    steps:
+      - name: Add git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Cache build dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.triton/llvm
+            ~/.triton/json
+            ~/.triton/nvidia
+            ${{ github.workspace }}/.ccache
+          key: ${{ runner.os }}-${{ runner.arch }}-cann8.5.0-ubuntu22.04-910b-py3.11-dcv-${{ hashFiles('cmake/llvm-hash.txt', 'cmake/json-version.txt', 'cmake/nvidia-toolchain-version.json', 'third_party/ascend/llvm_patch/*.patch') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-cann8.5.0-ubuntu22.04-910b-py3.11-dcv
+
+      - name: Checkout base
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: "true"
+          ref: ${{ github.base_ref }}
+          path: base
+
+      - name: Checkout pr
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: "true"
+          path: pr
+
+      - name: Build triton-ascend base
+        shell: bash
+        env:
+          TRITON_BUILD_WITH_CCACHE: "true"
+          TRITON_BUILD_WITH_CLANG_LLD: "TRUE"
+          TRITON_DISABLE_LINE_INFO: 1
+          CCACHE_COMPRESS: "true"
+          CCACHE_DIR: ${{ github.workspace }}/.ccache
+          TRITON_BUILD_WITH_O1: true
+          TRITON_BUILD_PROTON: OFF
+          TRITON_WHEEL_NAME: triton-ascend
+          TRITON_APPEND_CMAKE_ARGS: "-DTRITON_BUILD_UT=OFF"
+        run: |
+          mkdir -p "$CCACHE_DIR"
+          ccache --zero-stats
+          NUM_PROCS=$(( $(nproc) / 3 ))
+          if [ "$NUM_PROCS" -lt 1 ]; then NUM_PROCS=1; fi
+          cd base
+          MAX_JOBS="$NUM_PROCS" python setup.py bdist_wheel --dist-dir="${GITHUB_WORKSPACE}/base/wheelhouse"
+
+      - name: Build triton-ascend pr
+        shell: bash
+        env:
+          TRITON_BUILD_WITH_CCACHE: "true"
+          TRITON_BUILD_WITH_CLANG_LLD: "TRUE"
+          TRITON_DISABLE_LINE_INFO: 1
+          CCACHE_COMPRESS: "true"
+          CCACHE_DIR: ${{ github.workspace }}/.ccache
+          TRITON_BUILD_WITH_O1: true
+          TRITON_BUILD_PROTON: OFF
+          TRITON_WHEEL_NAME: triton-ascend
+          TRITON_APPEND_CMAKE_ARGS: "-DTRITON_BUILD_UT=OFF"
+        run: |
+          mkdir -p "$CCACHE_DIR"
+          ccache --zero-stats
+          NUM_PROCS=$(( $(nproc) / 3 ))
+          if [ "$NUM_PROCS" -lt 1 ]; then NUM_PROCS=1; fi
+          cd pr
+          MAX_JOBS="$NUM_PROCS" python setup.py bdist_wheel --dist-dir="${GITHUB_WORKSPACE}/pr/wheelhouse"
+
+      - name: generate ttadapter
+        shell: bash
+        env:
+          TRITON_ALWAYS_COMPILE: 1
+          TRITON_COMPILE_ONLY: 1
+        run: |
+          cd pr/third_party/ascend/unittest/DynamicCVPipeline_ut
+          bash dynamic-cv-pipeline-ci.sh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: run_result
+          path: ${{ github.workspace }}/result/

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/dynamic-cv-pipeline-ci.sh
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/dynamic-cv-pipeline-ci.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+
+set -e
+
+# define color
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUTPUT_DIR="${GITHUB_WORKSPACE}/result"
+TEST_FILE_PATH="${SCRIPT_DIR}"
+
+# test files are named with pattern 'test_*.py'
+TEST_FILES=$(find "${TEST_FILE_PATH}" -maxdepth 1 -type f -name "test_*.py")
+
+function install_triton_ascend_build_output() {
+    WHL_DIR=$1
+    readarray -d '' WHL_FILES < <(find "$WHL_DIR" -maxdepth 1 -type f -name "*.whl" -print0)
+
+    WHL_COUNT=${#WHL_FILES[@]}
+
+    # ensure only one .whl file built
+    if [ "$WHL_COUNT" -eq 0 ]; then
+        echo -e "${RED}ERROR: no .whl file found.${NC}"
+        return 1
+
+    elif [ "$WHL_COUNT" -gt 1 ]; then
+        echo -e "${RED}ERROR: expected 1 .whl file, find $WHL_COUNT files.${NC}"
+        for file in "${WHL_FILES[@]}"; do
+            echo -e "${RED}  - $(basename "$file")${NC}"
+        done
+        return 1
+
+    else
+        TARGET_WHL="${WHL_FILES[0]}"
+        pip install --force-reinstall --no-deps "$TARGET_WHL"
+
+        if [ $? -eq 0 ]; then
+            echo -e "${GREEN}install $TARGET_WHL success!${NC}"
+            return 0
+        else
+            echo -e "${RED}install $TARGET_WHL failed!${NC}"
+            return 1
+        fi
+    fi
+}
+
+function run_test_cases() {
+    echo "Start running dynamic-cv-pipeline test cases..."
+    echo "-----------------------------------------------"
+
+    SUCCESS_COUNT=0
+    FAILURE_COUNT=0
+
+    for file in $TEST_FILES; do
+        filename=$(basename "$file")
+        pytest -sv --confcutdir="${TEST_FILE_PATH}" "$file"
+
+        if [ $? -eq 0 ]; then
+            echo -e "${GREEN}test case $filename success!${NC}"
+            SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+        else
+            echo -e "${RED}test case $filename failed!${NC}"
+            FAILURE_COUNT=$((FAILURE_COUNT + 1))
+        fi
+        echo "-----------------------------------------------"
+    done
+
+    echo -e "${RED}Reports:${NC}"
+    echo -e "${RED}  Success cases count: $SUCCESS_COUNT${NC}"
+    echo -e "${RED}  Failed cases count: $FAILURE_COUNT${NC}"
+
+    if [ $FAILURE_COUNT -gt 0 ]; then
+        return 1
+    fi
+}
+
+function compare_mlir() {
+    arg_num="$#"
+    if [ $arg_num -lt 2 ]; then
+        echo -e "${RED}ERROR: invalid argument number: $arg_num < 2${NC}"
+        return 1
+    fi
+
+    BASE_DIR="$1"
+    PR_DIR="$2"
+    DIFF_OUTPUT_DIR=${3:-"${OUTPUT_DIR}/diff"}
+
+    if ! [ -d "$BASE_DIR" ]; then
+        echo -e "${RED}ERROR: base directory does not exist -> $BASE_DIR${NC}"
+        return 1
+    fi
+
+    if ! [ -d "$PR_DIR" ]; then
+        echo -e "${RED}ERROR: pr directory does not exist -> $PR_DIR${NC}"
+        return 1
+    fi
+
+    BASE_DIR="${BASE_DIR%/}"
+    PR_DIR="${PR_DIR%/}"
+
+    python3 "$SCRIPT_DIR/mlir_diff.py" "$BASE_DIR" "$PR_DIR" "$DIFF_OUTPUT_DIR"
+
+    echo -e "\n${GREEN}==================================================${NC}"
+    echo -e "${GREEN}  Compare and diff finished${NC}"
+    echo -e "${GREEN}==================================================${NC}"
+}
+
+function main() {
+    rm -rf "${OUTPUT_DIR}"
+
+    echo " Creating output dir ${OUTPUT_DIR}"
+    mkdir -p "${OUTPUT_DIR}"
+
+    # End if there are no test cases
+    if [ -z "$TEST_FILES" ]; then
+        echo -e "${YELLOW}No test cases found in $TEST_FILE_PATH${NC}"
+        return 0
+    fi
+
+    # mlir output dir created by test cases
+    TESTCASE_MLIR_OUTPUT=${TEST_FILE_PATH}/mlir_output
+
+    PR_MLIR_DIR=${OUTPUT_DIR}/mlir/pr
+    BASE_MLIR_DIR=${OUTPUT_DIR}/mlir/base
+    rm -rf "${PR_MLIR_DIR}"
+    rm -rf "${BASE_MLIR_DIR}"
+
+    PR_PKG=${GITHUB_WORKSPACE}/pr/wheelhouse
+    install_triton_ascend_build_output "$PR_PKG"
+
+    if ! run_test_cases; then
+        echo -e "${RED} Run test cases on pr package failed!${NC}"
+        return 1
+    fi
+
+    mkdir -p "${PR_MLIR_DIR}"
+    cp -r "${TESTCASE_MLIR_OUTPUT}/." "${PR_MLIR_DIR}/"
+
+    BASE_PKG=${GITHUB_WORKSPACE}/base/wheelhouse
+    install_triton_ascend_build_output "$BASE_PKG"
+
+    # re-run test cases after installing base package
+    # Will not return on failure
+    if ! run_test_cases; then
+        echo -e "${YELLOW} Run test cases on base package failed!${NC}"
+    fi
+
+    mkdir -p "${BASE_MLIR_DIR}"
+    cp -r "${TESTCASE_MLIR_OUTPUT}/." "${BASE_MLIR_DIR}/"
+
+    cd "${OUTPUT_DIR}"
+    compare_mlir "${BASE_MLIR_DIR}" "${PR_MLIR_DIR}"
+}
+
+main "$@"

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/mlir_diff.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/mlir_diff.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Compare two folders and output differences to a file."""
+
+import argparse
+import difflib
+import os
+import sys
+
+
+def get_relative_paths(folder):
+    result = set()
+    for root, _, files in os.walk(folder):
+        for f in files:
+            full = os.path.join(root, f)
+            rel = os.path.relpath(full, folder)
+            result.add(rel)
+    return result
+
+
+def is_binary(filepath):
+    try:
+        with open(filepath, 'rb') as f:
+            chunk = f.read(8192)
+            return b'\x00' in chunk
+    except IOError:
+        return True
+
+
+def read_lines(filepath):
+    try:
+        with open(filepath, 'r', encoding='utf-8', errors='replace') as f:
+            return f.readlines()
+    except IOError:
+        return []
+
+
+def compare_folders(folder_base, folder_pr, output_dir):
+    base_paths = get_relative_paths(folder_base)
+    pr_paths = get_relative_paths(folder_pr)
+
+    only_in_base = sorted(base_paths - pr_paths)
+    only_in_pr = sorted(pr_paths - base_paths)
+    common = sorted(base_paths & pr_paths)
+
+    diff_files = []
+    skipped_files = []
+    unchanged_mlir_files = []
+    same_count = 0
+
+    # Ensure output directory exists
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir, exist_ok=True)
+
+    for rel in common:
+        # compare .mlir files only
+        if not rel.endswith('.mlir'):
+            print(f" Not a mlir file: {rel}, skipped")
+            continue
+
+        full_name_base = os.path.join(folder_base, rel)
+        full_name_pr = os.path.join(folder_pr, rel)
+        if is_binary(full_name_base) or is_binary(full_name_pr):
+            # skip binary file
+            print(f" Encountered binary file, skipped: {rel}")
+            skipped_files.append(rel)
+            continue
+        else:
+            try:
+                # Text files can be read into lines for difflib
+                lines_base = read_lines(full_name_base)
+                lines_pr = read_lines(full_name_pr)
+
+                if lines_base != lines_pr:
+                    diff_files.append(rel)
+                    diff = difflib.unified_diff(lines_base, lines_pr, fromfile=f'base/{rel}', tofile=f'pr/{rel}',
+                                                lineterm='')
+                    diff_text = ''.join(diff)
+                    if diff_text:
+                        _write_diff_file(rel, diff_text + "\n", output_dir)
+                else:
+                    same_count += 1
+                    unchanged_mlir_files.append(rel)
+            except IOError:
+                diff_files.append(rel)
+                _write_diff_file(rel, f"  Cannot read: {rel}\n", output_dir)
+
+    # names of unchanged .mlir files will be written into unchanged_cases.txt
+    if unchanged_mlir_files:
+        changed_txt_path = os.path.join(output_dir, "unchanged_cases.txt")
+        print(f"\nUnchanged mlir files written to : '{changed_txt_path}/'")
+        with open(changed_txt_path, 'w', encoding='utf-8') as f:
+            f.write('\n'.join(unchanged_mlir_files) + '\n')
+
+    # Print summary to console
+    print(f"\n{'='*40}")
+    print(f"Comparison Summary")
+    print(f"{'='*40}")
+    print(f"  Only in base count: {len(only_in_base)}")
+    print(f"  Only in pr count: {len(only_in_pr)}")
+    print(f"  Identical count: {same_count}")
+    print(f"  Different count: {len(diff_files)}")
+    print(f"  Skipped (binary) count: {len(skipped_files)}")
+
+    if diff_files:
+        print(f"\nDifferences written to directory: '{output_dir}/'")
+
+
+def _write_diff_file(rel_path, content, output_dir):
+    # Helper to write diff content to a specific file based on its base name.
+    base_name = os.path.basename(rel_path)
+    diff_filename = os.path.splitext(base_name)[0] + '.diff'
+    diff_path = os.path.join(output_dir, diff_filename)
+
+    try:
+        with open(diff_path, 'w', encoding='utf-8') as f:
+            f.write(content)
+    except Exception as e:
+        print(f"Writing diff file {diff_filename} failed, exception is : {e}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Compare base and base+pr mlir folders and output differences to a file.')
+    parser.add_argument('folder_base', help='Path to base folder')
+    parser.add_argument('folder_pr', help='Path to pr folder')
+    parser.add_argument('output',
+                        help='Path to output directory where diff files and unchanged_cases.txt will be stored')
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.folder_base):
+        print(f"Error: '{args.folder_base}' is not a directory", file=sys.stderr)
+        sys.exit(1)
+    if not os.path.isdir(args.folder_pr):
+        print(f"Error: '{args.folder_pr}' is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    compare_folders(args.folder_base, args.folder_pr, args.output)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

This PR merges the contents of #954 into the main-dev branch. The following is an overview of the function of this PR:

This PR adds a new CI workflow. This workflow is triggered only when files regarding dynamic-cv-pipeline feature are modified due to:

- Modifications within the current PR.

- Updates pushed to the current PR's target branch by other PRs.

The workflow consists of one job：

- build-check: This job is triggered when the PR code modifies files mentioned above or when it is manually restarted. It will run dynamic-cv-pipeline unit tests and archive test results. 
