### PR TITLE
[ssbuffer](feat) enable_ub_refine_opt && insertionOptimization

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -224,6 +224,7 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
             metadata["enable_mixed_cv"] = True
             metadata["disable_auto_inject_block_sync"] = True
             ascend.passes.ttir.set_enable_cube_block_merge(metadata["enable_cube_block_merge"])
+            ascend.passes.ttir.set_enable_ub_refine_opt(mod, metadata["enable_ub_refine_opt"])
 
             ascend.passes.ttir.add_dynamic_cv_pipeline(pm, compile_on_910_95)
 
@@ -972,6 +973,7 @@ class NPUOptions:
     # default so existing scenarios are unaffected; opt in per kernel to fuse a
     # matmul's loader for-loop into the matmul's cube compute block.
     enable_cube_block_merge: bool = False
+    enable_ub_refine_opt: bool = False
     hfusion_enable_multiple_consumer_fusion: bool = False
     enable_cross_if_fusion: bool = False
     has_auto_blockify_blacklist_op: Optional[bool] = None

--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -226,6 +226,10 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
             ascend.passes.ttir.set_enable_cube_block_merge(metadata["enable_cube_block_merge"])
             ascend.passes.ttir.set_enable_ub_refine_opt(mod, metadata["enable_ub_refine_opt"])
 
+            # Must run before add_dynamic_cv_pipeline because the driven
+            # AddMultiBufferInnerScope pass reads the module-level
+            # `ssbuffer.insertionOptimization` attribute (set here) at run time.
+            ascend.passes.ttir.set_enable_buffer_insert_optimization(mod, metadata["enable_buffer_insert_optimization"])
             ascend.passes.ttir.add_dynamic_cv_pipeline(pm, compile_on_910_95)
 
         _intra_val = metadata.get("intra_cache_num")
@@ -974,6 +978,8 @@ class NPUOptions:
     # matmul's loader for-loop into the matmul's cube compute block.
     enable_cube_block_merge: bool = False
     enable_ub_refine_opt: bool = False
+    # Multi-cache insertion optimization: avoid redundant tensor compute in the middle of an `if`.
+    enable_buffer_insert_optimization: bool = False
     hfusion_enable_multiple_consumer_fusion: bool = False
     enable_cross_if_fusion: bool = False
     has_auto_blockify_blacklist_op: Optional[bool] = None

--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -56,6 +56,8 @@ inline constexpr llvm::StringLiteral kIntraDeps = "ssbuffer.intraDeps";
 inline constexpr llvm::StringLiteral kMemCrossDeps = "ssbuffer.memCrossDeps";
 inline constexpr llvm::StringLiteral kMayNotExec = "ssbuffer.may_not_exec";
 inline constexpr llvm::StringLiteral kClone = "ssbuffer.clone";
+inline constexpr llvm::StringLiteral kEnableUbRefineOpt = "ssbuffer.enable_ub_refine_opt";
+inline constexpr llvm::StringLiteral kInsertionOptimization = "ssbuffer.insertionOptimization";
 static constexpr llvm::StringLiteral kInlinableQuantScaleAttr = "enable_fast_tf32_mul";
 inline constexpr llvm::StringLiteral kHIVMMatmulLimitedInCubeAttr = "hivm.matmul_limited_in_cube";
 
@@ -84,6 +86,9 @@ inline constexpr CoreType fromStrCoreType(std::string_view s)
 
 void setEnableCubeBlockMerge(bool enable);
 bool isCubeBlockMergeEnabled();
+
+void setEnableUBRefineOpt(bool enable);
+bool isUBRefineOptEnabled();
 
 // Functions for managing core types
 CoreType getOpCoreType(Operation *op);

--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
@@ -57,6 +57,21 @@ using BufferMap = DenseMap<Value, SmallVector<BufferPair>>;
 // Buffer count constants
 constexpr int kBufferCountOne = 1;
 
+// Toggle: when true, producer / consumer buffer chains are inserted at the
+// boundary of the contiguous `ssbuffer.block_id = X` region instead of right
+// after the dep def op / right before the dep user op.
+//
+//   - producer chain: inserted AFTER the last op in depDefinedOp's block that
+//     carries the same `ssbuffer.block_id` as depDefinedOp. If depDefinedOp has
+//     no direct block_id attribute, falls back to "right after depDefinedOp".
+//   - consumer chain: inserted BEFORE the first op in depUser's block that
+//     carries the same `ssbuffer.block_id` as depUser. If depUser has no direct
+//     block_id attribute, falls back to "right before depUser".
+//
+// This keeps the producer/consumer chains grouped with their block_id region
+// rather than interleaved with intermediate compute ops.
+constexpr bool kInsertAtBlockIdBoundary = true;
+
 namespace mlir {
 namespace triton {
 
@@ -1303,6 +1318,41 @@ static int processMultiRegionAllYields(OpBuilder &consumedBuilder, Value depVal,
     return 0;
 }
 
+// Find the last op in `anchorOp->getBlock()` whose `ssbuffer.block_id` attribute
+// matches `blockId`. Returns nullptr if anchorOp is null or has no block, or if
+// no such op is found.
+static Operation *findLastOpWithBlockIdInBlock(Operation *anchorOp, int blockId)
+{
+    if (!anchorOp)
+        return nullptr;
+    Block *block = anchorOp->getBlock();
+    if (!block)
+        return nullptr;
+    Operation *result = nullptr;
+    for (Operation &op : *block) {
+        if (auto id = getOpBlockId(&op); id.has_value() && *id == blockId)
+            result = &op;
+    }
+    return result;
+}
+
+// Find the first op in `anchorOp->getBlock()` whose `ssbuffer.block_id` attribute
+// matches `blockId`. Returns nullptr if anchorOp is null or has no block, or if
+// no such op is found.
+static Operation *findFirstOpWithBlockIdInBlock(Operation *anchorOp, int blockId)
+{
+    if (!anchorOp)
+        return nullptr;
+    Block *block = anchorOp->getBlock();
+    if (!block)
+        return nullptr;
+    for (Operation &op : *block) {
+        if (auto id = getOpBlockId(&op); id.has_value() && *id == blockId)
+            return &op;
+    }
+    return nullptr;
+}
+
 // Process producer and consumer for a single dependency value
 static int processDepVal(Value depVal, mlir::scf::ForOp mainLoopForOp, BufferMap &bufferMap,
                          DenseMap<Value, SmallVector<Operation *>> &depUserMap, OpBuilder &globalBuilder,
@@ -1321,7 +1371,17 @@ static int processDepVal(Value depVal, mlir::scf::ForOp mainLoopForOp, BufferMap
 
     // Create producer
     OpBuilder producedBuffers(mainLoopForOp.getContext());
-    producedBuffers.setInsertionPointAfter(depDefinedOp);
+    // When kInsertAtBlockIdBoundary is on, place the producer chain at the end
+    // of depDefinedOp's block_id=X region (after the last op with that
+    // block_id). Otherwise keep the original "right after depDefinedOp" anchor.
+    Operation *producerAnchor = depDefinedOp;
+    if (kInsertAtBlockIdBoundary) {
+        if (auto prodId = getOpBlockId(depDefinedOp); prodId.has_value()) {
+            if (Operation *lastInRegion = findLastOpWithBlockIdInBlock(depDefinedOp, *prodId))
+                producerAnchor = lastInRegion;
+        }
+    }
+    producedBuffers.setInsertionPointAfter(producerAnchor);
     SmallVector<Operation *> producerNewOps = insertProducerLogic(producedBuffers, depVal, buffers, mainLoopForOp);
     addBlockAttrForOps(producerNewOps, producerId, globalBuilder);
     if (buffers.size() > kBufferCountOne) {
@@ -1348,7 +1408,17 @@ static int processDepVal(Value depVal, mlir::scf::ForOp mainLoopForOp, BufferMap
         if (isMultiRegionConsumerFromYield(depUser, depVal)) {
             // Multi-region op: process independently
             OpBuilder consumedBuilder(mainLoopForOp.getContext());
-            consumedBuilder.setInsertionPoint(depUser);
+            // When kInsertAtBlockIdBoundary is on, place the consumer chain at
+            // the start of depUser's block_id=X region (before the first op
+            // with that block_id). Otherwise keep "right before depUser".
+            Operation *consumerAnchor = depUser;
+            if (kInsertAtBlockIdBoundary) {
+                if (auto userId = getOpBlockId(depUser); userId.has_value()) {
+                    if (Operation *firstInRegion = findFirstOpWithBlockIdInBlock(depUser, *userId))
+                        consumerAnchor = firstInRegion;
+                }
+            }
+            consumedBuilder.setInsertionPoint(consumerAnchor);
 
             if (int ret = processMultiRegionAllYields(consumedBuilder, depVal, buffers, mainLoopForOp,
                                                      depUser, *userBlockId, groupId))
@@ -1384,7 +1454,17 @@ static int processDepVal(Value depVal, mlir::scf::ForOp mainLoopForOp, BufferMap
 
             Operation *firstOp = opsInRegion.front();
             OpBuilder consumedBuilder(mainLoopForOp.getContext());
-            consumedBuilder.setInsertionPoint(firstOp);
+            // When kInsertAtBlockIdBoundary is on, place the consumer chain at
+            // the start of the dep user's block_id=X region (before the first
+            // op with that block_id). Otherwise keep "right before firstOp".
+            Operation *consumerAnchor = firstOp;
+            if (kInsertAtBlockIdBoundary) {
+                if (auto userId = getOpBlockId(firstOp); userId.has_value()) {
+                    if (Operation *firstInRegion = findFirstOpWithBlockIdInBlock(firstOp, *userId))
+                        consumerAnchor = firstInRegion;
+                }
+            }
+            consumedBuilder.setInsertionPoint(consumerAnchor);
 
             if (int ret = processNormalConsumerBlock(consumedBuilder, depVal, buffers, mainLoopForOp,
                                                    opsInRegion, userBlockId, groupId, globalBuilder))

--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
@@ -70,8 +70,12 @@ constexpr int kBufferCountOne = 1;
 //
 // This keeps the producer/consumer chains grouped with their block_id region
 // rather than interleaved with intermediate compute ops.
-constexpr bool kInsertAtBlockIdBoundary = true;
-
+//
+// The toggle is read from a module-level attribute
+// `CVPipeline::kInsertionOptimization` (i.e. "ssbuffer.insertionOptimization").
+// Python callers set it via `set_enable_buffer_insert_optimization` in
+// `triton_ascend.cc`, which writes the attribute onto the ModuleOp. The
+// attribute is checked inline at each `processDepVal` call site below.
 namespace mlir {
 namespace triton {
 
@@ -1369,13 +1373,20 @@ static int processDepVal(Value depVal, mlir::scf::ForOp mainLoopForOp, BufferMap
         return 0;
     SmallVector<Operation *> depUsers = userIt->second;
 
+    // Read the module-level `ssbuffer.insertionOptimization` attribute inline so
+    // processDepVal can be called multiple times in the same pass run and stay
+    // in sync with whatever the Python caller last wrote onto the ModuleOp.
+    bool enableOpt = false;
+    if (mlir::ModuleOp mod = mainLoopForOp->getParentOfType<mlir::ModuleOp>())
+        enableOpt = mod->hasAttr(CVPipeline::kInsertionOptimization);
+
     // Create producer
     OpBuilder producedBuffers(mainLoopForOp.getContext());
-    // When kInsertAtBlockIdBoundary is on, place the producer chain at the end
+    // When enable_buffer_insert_optimization is on, place the producer chain at the end
     // of depDefinedOp's block_id=X region (after the last op with that
     // block_id). Otherwise keep the original "right after depDefinedOp" anchor.
     Operation *producerAnchor = depDefinedOp;
-    if (kInsertAtBlockIdBoundary) {
+    if (enableOpt) {
         if (auto prodId = getOpBlockId(depDefinedOp); prodId.has_value()) {
             if (Operation *lastInRegion = findLastOpWithBlockIdInBlock(depDefinedOp, *prodId))
                 producerAnchor = lastInRegion;
@@ -1408,11 +1419,11 @@ static int processDepVal(Value depVal, mlir::scf::ForOp mainLoopForOp, BufferMap
         if (isMultiRegionConsumerFromYield(depUser, depVal)) {
             // Multi-region op: process independently
             OpBuilder consumedBuilder(mainLoopForOp.getContext());
-            // When kInsertAtBlockIdBoundary is on, place the consumer chain at
+            // When enable_buffer_insert_optimization is on, place the consumer chain at
             // the start of depUser's block_id=X region (before the first op
             // with that block_id). Otherwise keep "right before depUser".
             Operation *consumerAnchor = depUser;
-            if (kInsertAtBlockIdBoundary) {
+            if (enableOpt) {
                 if (auto userId = getOpBlockId(depUser); userId.has_value()) {
                     if (Operation *firstInRegion = findFirstOpWithBlockIdInBlock(depUser, *userId))
                         consumerAnchor = firstInRegion;
@@ -1454,11 +1465,11 @@ static int processDepVal(Value depVal, mlir::scf::ForOp mainLoopForOp, BufferMap
 
             Operation *firstOp = opsInRegion.front();
             OpBuilder consumedBuilder(mainLoopForOp.getContext());
-            // When kInsertAtBlockIdBoundary is on, place the consumer chain at
+            // When enable_buffer_insert_optimization is on, place the consumer chain at
             // the start of the dep user's block_id=X region (before the first
             // op with that block_id). Otherwise keep "right before firstOp".
             Operation *consumerAnchor = firstOp;
-            if (kInsertAtBlockIdBoundary) {
+            if (enableOpt) {
                 if (auto userId = getOpBlockId(firstOp); userId.has_value()) {
                     if (Operation *firstInRegion = findFirstOpWithBlockIdInBlock(firstOp, *userId))
                         consumerAnchor = firstInRegion;

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -18,6 +18,7 @@ namespace mlir {
 namespace CVPipeline {
 
 static bool g_enableCubeBlockMerge = true;
+static bool g_enableUBRefineOpt = false;
 
 void setEnableCubeBlockMerge(bool enable)
 {

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UBUsageOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UBUsageOptPass.cpp
@@ -25,13 +25,16 @@
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
 #include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Block.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Operation.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
@@ -59,6 +62,7 @@ class UBUsageOptPass : public PassWrapper<UBUsageOptPass, OperationPass<ModuleOp
 
   private:
     const int MAX_EDGE_SIZE = (1 << 30);
+    const int BLOCK_SMALL_SIZE = 3;
     int getValueSizeInBytes(Value value);
     void buildUBUsageGraph(Block *block, DenseMap<Operation *, int> &op2nodeId, DenseMap<int, Operation *> &nodeId2op,
                            SmallVector<SmallVector<int>> &linkOut, SmallVector<SmallVector<int>> &linkIn,
@@ -76,6 +80,10 @@ class UBUsageOptPass : public PassWrapper<UBUsageOptPass, OperationPass<ModuleOp
                             const SmallVector<int> &nodeBlockId);
     llvm::LogicalResult UBUsageOptimization(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph,
                                             CVPipeline::ComputeBlockIdManager &bm);
+    llvm::LogicalResult optBroadcast(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph,
+                                 CVPipeline::ComputeBlockIdManager &bm);
+    llvm::LogicalResult optSmallBlock(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph,
+                                  CVPipeline::ComputeBlockIdManager &bm);
 };
 } // namespace triton
 } // namespace mlir
@@ -725,6 +733,124 @@ llvm::LogicalResult UBUsageOptPass::UBUsageOptimization(Block *block, const CVPi
     return llvm::success();
 }
 
+llvm::LogicalResult UBUsageOptPass::optBroadcast(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph,
+                                 CVPipeline::ComputeBlockIdManager &bm)
+{
+    if (!isa<scf::ForOp>(block->getParentOp())) {
+        return llvm::success();
+    }
+
+    int errcnt = 0;
+    llvm::SmallVector<Operation *> broadcastOps;
+    for (Operation &op : *block) {
+        if (!isa<linalg::BroadcastOp>(op)) {
+            continue;
+        }
+        auto broadcastOp = dyn_cast<linalg::BroadcastOp>(&op);
+        if (CVPipeline::getOpCoreType(broadcastOp) != CVPipeline::CoreType::VECTOR_ONLY) {
+            continue;
+        }
+        if (!broadcastOp->hasOneUse()) {
+            continue;
+        }
+        
+        llvm::SmallVector<std::pair<Operation *, int>> userBlockIds;
+        Operation* user = *broadcastOp->getUsers().begin();
+        Operation *userInBlock = CVPipeline::getAncestorInBlock(user, block);
+        if (!userInBlock || userInBlock->getBlock() != block) {
+            continue;
+        }
+        if(CVPipeline::getOpCoreType(userInBlock) != CVPipeline::CoreType::VECTOR_ONLY) {
+            continue;
+        }
+        int userBlockId = bm.getBlockIdByOp(userInBlock);
+        int broadcastBlockId = bm.getBlockIdByOp(broadcastOp);
+        if (userBlockId == broadcastBlockId) {
+            continue;
+        }
+        llvm::SmallVector<Operation *> willaddOps{broadcastOp};
+
+        if (!willCreateCycle(willaddOps, block, memGraph, userBlockId, bm).value_or(true)) {
+            bm.updateBlockId(broadcastOp, userBlockId);
+        } else {
+            LOG_DEBUG("Moved" << *broadcastOp << " to blockId: " << userBlockId << " err!!!\n");
+            errcnt++;
+        }
+
+    }
+    if (errcnt > 0) {
+        LOG_DEBUG("Failed to move " << errcnt << " broadcast ops.\n");
+        return llvm::failure();
+    }
+    return llvm::success();
+}
+
+llvm::LogicalResult UBUsageOptPass::optSmallBlock(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph,
+                                 CVPipeline::ComputeBlockIdManager &bm)
+{
+    if (!isa<scf::ForOp>(block->getParentOp())) {
+        return llvm::success();
+    }
+
+    int errcnt = 0;
+    int maxBlockId = -1;
+    for (Operation &op : *block) {
+        int blockId = bm.getBlockIdByOp(&op);
+        if (blockId > maxBlockId) {
+            maxBlockId = blockId;
+        }
+    }
+
+    for (int blockId = 0; blockId <= maxBlockId; ++blockId) {
+        auto opsInSmallBlcok = bm.getOpsByBlockId(blockId);
+        if (opsInSmallBlcok.size() > BLOCK_SMALL_SIZE || opsInSmallBlcok.empty()) {
+            continue;
+        }
+
+        
+        SetVector<int> candidateUserBlockIds;
+        for (Operation *op : opsInSmallBlcok) {
+            for (auto operand : op->getOperands()) {
+                auto defOp = operand.getDefiningOp();
+                if(!defOp) {
+                    continue;
+                }
+                Operation *defInBlock = CVPipeline::getAncestorInBlock(defOp, block);
+                if (!defInBlock || defInBlock->getBlock() != block) {
+                    continue;
+                }
+                if(CVPipeline::getOpCoreType(defInBlock) != CVPipeline::CoreType::VECTOR_ONLY) {
+                    continue;
+                }
+                
+                int candidateBlockId = bm.getBlockIdByOp(defInBlock);
+                if (candidateBlockId != blockId && candidateBlockId != -1) {
+                    candidateUserBlockIds.insert(candidateBlockId);
+                }
+            }
+        }
+
+        if (candidateUserBlockIds.size()!=1) {
+            continue;
+        }
+        llvm::SmallVector<Operation *> willaddOps(opsInSmallBlcok.begin(), opsInSmallBlcok.end());
+        if (!willCreateCycle(willaddOps, block, memGraph, candidateUserBlockIds[0], bm).value_or(true)) {
+            for (Operation *op : opsInSmallBlcok) {
+                bm.updateBlockId(op, candidateUserBlockIds[0]);
+            }
+        } else {
+            LOG_DEBUG("Failed to merge small block " << blockId << " to block " << candidateUserBlockIds[0] << "\n");
+            errcnt++;
+        }
+    }
+
+    if (errcnt > 0) {
+        LOG_DEBUG("Failed to merge " << errcnt << " small blocks.\n");
+        return llvm::failure();
+    }
+    return llvm::success();
+}
+
 void mlir::triton::UBUsageOptPass::runOnOperation()
 {
     LOG_DEBUG("--- Pass: UBUsageOpt ---\n");
@@ -733,13 +859,27 @@ void mlir::triton::UBUsageOptPass::runOnOperation()
     auto &aliasAnalysis = getAnalysis<AliasAnalysis>();
     CVPipeline::MemoryDependenceGraph memDepGraph(module, aliasAnalysis);
     auto bm = CVPipeline::ComputeBlockIdManager(module);
+    bool isUBRefineOptEnabled = false;
+    auto attr = module->getAttr(CVPipeline::kEnableUbRefineOpt);
+    if (attr) {
+        isUBRefineOptEnabled = true;
+    }
 
     llvm::SmallVector<Block *> blocks;
     module.walk([&](Block *block) { blocks.push_back(block); });
 
     for (Block *block : blocks) {
         if (UBUsageOptimization(block, memDepGraph, bm).failed()) {
-            llvm::errs() << "UB usage optimization failed in block:\n";
+            llvm::errs() << "UB usage optimization failed in block.\n";
+        }
+        if (isUBRefineOptEnabled) {
+            if (optBroadcast(block, memDepGraph, bm).failed()) {
+                llvm::errs() << "Broadcast check failed in block.\n";
+            }
+
+            if (optSmallBlock(block, memDepGraph, bm).failed()) {
+                llvm::errs() << "Small block optimization failed in block.\n";
+            }
         }
     }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp
@@ -301,6 +301,123 @@ static SetVector<Operation *> collectKeepOps(Block *block, SmallVector<Operation
     return keepOps;
 }
 
+static bool isTensorOperation(Operation *op)
+{
+    for (auto result : op->getResults()) {
+        if (isa<RankedTensorType>(result.getType())) {
+            return true;
+        }
+    }
+    for (auto operand : op->getOperands()) {
+        if (isa<RankedTensorType>(operand.getType())) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool hasTensorOperation(const SmallVector<Operation *> &fuseGroup)
+{
+    for (auto op : fuseGroup) {
+        if (isTensorOperation(op)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void collectAllUsersInFuseGroup(Operation *op, const SmallVector<Operation *> &fuseGroup,
+                                               SetVector<Operation *> &toRemove)
+{
+    if (toRemove.contains(op) || !llvm::is_contained(fuseGroup, op)) {
+        return;
+    }
+    toRemove.insert(op);
+    for (auto user : op->getUsers()) {
+        collectAllUsersInFuseGroup(user, fuseGroup, toRemove);
+    }
+}
+
+static void collectAllDependenciesInFuseGroup(Operation *op, const SmallVector<Operation *> &fuseGroup,
+                                              SetVector<Operation *> &toRemove)
+{
+    if (toRemove.contains(op) || !llvm::is_contained(fuseGroup, op)) {
+        return;
+    }
+    toRemove.insert(op);
+    for (auto operand : op->getOperands()) {
+        if (auto definingOp = operand.getDefiningOp()) {
+            collectAllDependenciesInFuseGroup(definingOp, fuseGroup, toRemove);
+        }
+    }
+}
+
+static SmallVector<Operation *> extractToProcessFromFuseGroup(Block *block,
+                                                               const SmallVector<Operation *> &nowFuseGroup, ComputeBlockIdManager &bm)
+{
+    SmallVector<Operation *> toProcess(nowFuseGroup.begin(), nowFuseGroup.end());
+
+    if (!hasTensorOperation(nowFuseGroup)) {
+        LOG_DEBUG("no tensor operation in nowFuseGroup.....\n");
+        return toProcess;
+    }
+
+    SetVector<Operation *> toRemove;
+    auto forOp = dyn_cast<scf::ForOp>(block->getParentOp());
+    if (forOp) {
+        for (auto op : nowFuseGroup) {
+            for (auto operand : op->getOperands()) {
+                int argIdx = getLoopCarriedArgIndex(operand, block);
+                if (argIdx <= 0) {
+                    continue;
+                }
+                auto *yieldOp = block->getTerminator();
+                auto yieldOperand = yieldOp->getOperand(argIdx - 1);
+                auto *defOp = yieldOperand.getDefiningOp();
+                if (defOp && bm.getBlockIdByOp(defOp)==-1 && !llvm::is_contained(nowFuseGroup, defOp)) {
+                    collectAllUsersInFuseGroup(op, nowFuseGroup, toRemove);
+                }
+            }
+        }
+    }
+
+    for (auto op : nowFuseGroup) {
+        for (auto result : op->getResults()) {
+            if (auto tensorType = dyn_cast<mlir::TensorType>(result.getType())) {
+                mlir::Type elemType = tensorType.getElementType();
+                if (!elemType.isInteger(1)) {
+                    continue;
+                }
+            }
+            bool hasExternalUser = false;
+            for (auto user : result.getUsers()) {
+                if (!llvm::is_contained(nowFuseGroup, user)) {
+                    hasExternalUser = true;
+                    break;
+                }
+            }
+            if (hasExternalUser) {
+                collectAllUsersInFuseGroup(op, nowFuseGroup, toRemove);
+                for (auto operand : op->getOperands()) {
+                    if (auto definingOp = operand.getDefiningOp()) {
+                        collectAllDependenciesInFuseGroup(definingOp, nowFuseGroup, toRemove);
+                    }
+                }
+            }
+        }
+    }
+    for (auto op : toRemove) {
+        LOG_DEBUG("Removing op when refining: "<< *op << "\n");
+        toProcess.erase(std::remove(toProcess.begin(), toProcess.end(), op), toProcess.end());
+    }
+
+     if ( !toProcess.empty() && !hasTensorOperation(toProcess)) {
+        LOG_DEBUG("no tensor operation in toProcess.....\n");
+        return {};
+    }
+    return toProcess;
+}
+
 static void evictAndRestoreState(Block *block, const SetVector<Operation *> &keepOps,
                                  SmallVector<Operation *> &fuseGroup, DenseMap<Operation *, bool> &visited,
                                  SmallVector<Operation *> &candidates, DenseMap<Operation *, int> &indegree,
@@ -351,29 +468,36 @@ static void evictAndRestoreState(Block *block, const SetVector<Operation *> &kee
 
 void refineFuseGroup(Block *block, SmallVector<Operation *> &nowFuseGroup, DenseMap<Operation *, bool> &visited,
                      SmallVector<Operation *> &candidates, DenseMap<Operation *, int> &indegree,
-                     const CVPipeline::MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
+                     const CVPipeline::MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm, bool isUBRefineOptEnabled)
 {
     // 1.Find ops in fuse group whose next node is a non-fusable (CUBE-only) op
     auto toProcess = findOpsAdjacentToCube(block, nowFuseGroup, visited, memGraph);
-    // 2. early return: if cannot find one node which next node is CUBE, need to check if return or not;
+
+    // 2. If no cube adjacent op, extract toProcess from fuseGroup using fallback rules
+    if (toProcess.empty() && isUBRefineOptEnabled) {
+        LOG_DEBUG("No Cube adjacent op, extracting toProcess from fuseGroup.\n");
+        toProcess = extractToProcessFromFuseGroup(block, nowFuseGroup, bm);
+    }
+
+    // 3. If still empty after extraction, no op will be cut
     if (toProcess.empty()) {
-        LOG_DEBUG("No Cube adjacent op, no op will be cut.");
+        LOG_DEBUG("No op will be cut after extraction.\n");
         findCandidates(indegree, candidates, visited, memGraph, bm);
         if (candidates.empty()) {
             return;
         }
     }
 
-    // 3. Collect keepOps transitively (data + memory + loop-carried deps)
+    // 4. Collect keepOps transitively (data + memory + loop-carried deps)
     auto keepOps = collectKeepOps(block, toProcess, nowFuseGroup, memGraph);
 
-    // 4. Remove non-kept ops from fuseGroup and restore BFS state
+    // 5. Remove non-kept ops from fuseGroup and restore BFS state
     evictAndRestoreState(block, keepOps, nowFuseGroup, visited, candidates, indegree, memGraph);
     LOG_DEBUG("After cutting, kept " << keepOps.size() << "\n");
 }
 
 // Main function to plan vector block id for one block
-llvm::LogicalResult planVectorBlockId(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm)
+llvm::LogicalResult planVectorBlockId(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm, bool isUBRefineOptEnabled)
 {
     // 1. topo initialize
     llvm::DenseMap<Operation *, int> indegree;
@@ -409,7 +533,7 @@ llvm::LogicalResult planVectorBlockId(Block *block, const CVPipeline::MemoryDepe
             }
             // finish one group, assign block id and start next iteration
             // Cut error operations before assigning block id
-            refineFuseGroup(block, nowFuseGroup, visited, queue, indegree, memGraph, bm);
+            refineFuseGroup(block, nowFuseGroup, visited, queue, indegree, memGraph, bm, isUBRefineOptEnabled);
             LOG_DEBUG("Group after cutting: \n");
             for (auto op: nowFuseGroup) {
                 LOG_DEBUG("fuseing: " << *op << "\n");
@@ -433,12 +557,17 @@ void PlanVectorBlockPass::runOnOperation()
     auto &aa = getAnalysis<AliasAnalysis>();
     auto memDepGraph = MemoryDependenceGraph(moduleOp, aa);
     auto bm = ComputeBlockIdManager(moduleOp);
+    bool isUBRefineOptEnabled = false;
+    auto attr = moduleOp->getAttr(CVPipeline::kEnableUbRefineOpt);
+    if (attr) {
+        isUBRefineOptEnabled = true;
+    }
 
 
     // 2. search blocks in topo order and assign block id for each block
     llvm::SmallVector<Block *> blocks;
     moduleOp.walk([&](Block *block) {
-        if (llvm::failed(planVectorBlockId(block, memDepGraph, bm))) {
+        if (llvm::failed(planVectorBlockId(block, memDepGraph, bm, isUBRefineOptEnabled))) {
             moduleOp.emitError() << "[" << DEBUG_TYPE << "] Failed to plan vector block id for block";
             signalPassFailure();
             return;

--- a/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
@@ -42,7 +42,7 @@ static constexpr const char *DEBUG_TYPE = "RemoveAttributes";
 
 // if extra attr is needed, add to ut @
 // third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/test-remove-attrs.mlir
-static constexpr llvm::StringLiteral kAttrsToRemove[] {kBlockId, kCoreType, kTransferId, kMainLoop, kCubeFirst, kVectorFirst, kAddFromMatmul, kIntraBuffer, kAnalyzeFlagId, kLoopCarriedL0C, kMatmulADep, kMatmulBDep, kMatmulExtract, kCrossDeps, kMemCrossDeps, kClone, kIntraBufCount, kInterCoreBufCount, kLoadStoreBufCount};
+static constexpr llvm::StringLiteral kAttrsToRemove[] {kBlockId, kCoreType, kTransferId, kMainLoop, kCubeFirst, kVectorFirst, kAddFromMatmul, kIntraBuffer, kAnalyzeFlagId, kLoopCarriedL0C, kMatmulADep, kMatmulBDep, kMatmulExtract, kCrossDeps, kMemCrossDeps, kClone, kIntraBufCount, kInterCoreBufCount, kLoadStoreBufCount, kEnableUbRefineOpt};
 
 void RemoveSsbufAttrPass::runOnOperation()
 {

--- a/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
@@ -42,7 +42,7 @@ static constexpr const char *DEBUG_TYPE = "RemoveAttributes";
 
 // if extra attr is needed, add to ut @
 // third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/test-remove-attrs.mlir
-static constexpr llvm::StringLiteral kAttrsToRemove[] {kBlockId, kCoreType, kTransferId, kMainLoop, kCubeFirst, kVectorFirst, kAddFromMatmul, kIntraBuffer, kAnalyzeFlagId, kLoopCarriedL0C, kMatmulADep, kMatmulBDep, kMatmulExtract, kCrossDeps, kMemCrossDeps, kClone, kIntraBufCount, kInterCoreBufCount, kLoadStoreBufCount, kEnableUbRefineOpt};
+static constexpr llvm::StringLiteral kAttrsToRemove[] {kBlockId, kCoreType, kTransferId, kMainLoop, kCubeFirst, kVectorFirst, kAddFromMatmul, kIntraBuffer, kAnalyzeFlagId, kLoopCarriedL0C, kMatmulADep, kMatmulBDep, kMatmulExtract, kCrossDeps, kMemCrossDeps, kClone, kIntraBufCount, kInterCoreBufCount, kLoadStoreBufCount, kInsertionOptimization, kEnableUbRefineOpt};
 
 void RemoveSsbufAttrPass::runOnOperation()
 {

--- a/third_party/ascend/triton_ascend.cc
+++ b/third_party/ascend/triton_ascend.cc
@@ -398,6 +398,13 @@ void init_triton_ascend_passes_ttir(py::module &&m) {
       moduleop->setAttr(CVPipeline::kEnableUbRefineOpt, builder.getUnitAttr());
     }
   });
+  m.def("set_enable_buffer_insert_optimization", [](mlir::ModuleOp &moduleop, bool enable) {
+    OpBuilder builder(moduleop.getContext());
+    if (enable){
+      moduleop->setAttr(CVPipeline::kInsertionOptimization, builder.getUnitAttr());
+    }
+  });
+
 }
 
 #if TRITON_ASCEND_HAS_INPROC_COSTMODEL

--- a/third_party/ascend/triton_ascend.cc
+++ b/third_party/ascend/triton_ascend.cc
@@ -391,6 +391,13 @@ void init_triton_ascend_passes_ttir(py::module &&m) {
   m.def("set_enable_cube_block_merge", [](bool enable) {
     mlir::CVPipeline::setEnableCubeBlockMerge(enable);
   });
+
+  m.def("set_enable_ub_refine_opt", [](mlir::ModuleOp &moduleop, bool enable) {
+    OpBuilder builder(moduleop.getContext());
+    if (enable){
+      moduleop->setAttr(CVPipeline::kEnableUbRefineOpt, builder.getUnitAttr());
+    }
+  });
 }
 
 #if TRITON_ASCEND_HAS_INPROC_COSTMODEL

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/Inner-scope.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/Inner-scope.mlir
@@ -748,7 +748,7 @@ func.func @test_t23_scf_if_else_branch_yield() {
         } else {
           scf.yield %to_tensor : tensor<16x32xf16>
         } {ssbuffer.block_id = 20 : i32}
-        %new_prod = arith.addf %if_result, %if_result {ssbuffer.block_id = 11 : i32} : tensor<16x32xf16>
+        %new_prod = arith.addf %if_result, %if_result {ssbuffer.block_id = 12 : i32} : tensor<16x32xf16>
         scf.yield %new_prod : tensor<16x32xf16>
       } {ssbuffer.main_loop = 1 : i64}
       scope.return


### PR DESCRIPTION
# Add 2 optimization attributes:

1. enable_ub_refine_opt: 
    faster block planning with smaller UB.
2. insertionOptimization: 
   designed to move multi_buffer pos and add compile option 'enable_buffer_insert_optimization' to control. To enable this function, switch the compile option 'enable_buffer_insert_optimization' to True.


# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
