### PR TITLE
[CI](feat) Add open code review process

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1,19 +1,33 @@
-# OpenCodeReview — AI-powered PR auto-review
+# OpenCodeReview - GitHub Actions PR Auto-Review
 #
-# Automatically reviews pull requests and posts inline comments.
-# Also supports on-demand re-review via PR comments starting with
-# '/open-code-review' or '@open-code-review'.
+# Demonstrates invoking the reusable action for both automatic PR review
+# (pull_request_target: opened/synchronize/reopened) and on-demand re-review
+# via comments starting with '/open-code-review' or '@open-code-review'.
 #
-# Required setup (repo Settings → Secrets and variables → Actions):
-#   Secrets:
-#     OCR_LLM_URL          LLM endpoint URL
-#     OCR_LLM_AUTH_TOKEN   API auth token
-#   Variables:
-#     OCR_LLM_MODEL         Model name
-#     OCR_LLM_USE_ANTHROPIC 'true' for Anthropic protocol, 'false' for OpenAI
+# Required secrets/vars (Settings -> Secrets and variables -> Actions):
+#   secret    OCR_LLM_URL            LLM API endpoint
+#   secret    OCR_LLM_AUTH_TOKEN     LLM auth token (mapped to OCR_LLM_TOKEN)
+#   variable  OCR_LLM_MODEL          model name
+#   variable  OCR_LLM_USE_ANTHROPIC  'true' for Anthropic, 'false' for OpenAI-compatible
+#
+# For the full list of action inputs/outputs and the four comment-posting modes
+# (sticky / incremental), see action.yml at the repo root.
 
-name: AI Code Review
+name: OpenCodeReview PR Review
 
+# Conditional concurrency group.
+#
+# GitHub Actions evaluates concurrency BEFORE job-level if-conditions. With a
+# flat group (ocr-<pr_number>), every comment on the PR — even an unrelated
+# conversation reply that will be skipped — enters the same group and, because
+# cancel-in-progress is true, cancels any in-progress review. The result: a
+# single normal comment kills a running review, and you see "two runs, one
+# cancelled" in the Actions tab.
+#
+# Fix: matching events (PR events + /open-code-review comments) share a per-PR
+# group so a new review cancels any stale one for the same PR. Non-matching
+# comments land in a unique noop-<run_id> group that can never collide with a
+# real review, so they are skipped instantly without disrupting anything.
 concurrency:
   group: >-
     ${{
@@ -41,6 +55,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  # Use pull_request_target instead of pull_request so that secrets are
+  # available even for PRs from forks. This is safe because the reusable
+  # action only reads the diff and does not execute any code from the PR.
   pull_request_target:
     types: [opened, synchronize, reopened]
   issue_comment:
@@ -54,6 +71,11 @@ jobs:
   code-review:
     runs-on: linux-amd64-cpu-8-hk
     timeout-minutes: 30
+    # Run on PR events, or on human-authored comments starting with trigger
+    # keywords. Bot comments are excluded as a safety net: GITHUB_TOKEN already
+    # suppresses events from bot-posted comments, but a PAT/App token would not.
+    # issue_comment triggers are further gated on author_association so only
+    # MEMBER/OWNER/COLLABORATOR users can spend LLM quota via re-review.
     if: |
       github.event_name == 'pull_request_target'
       || (
@@ -72,12 +94,15 @@ jobs:
         )
       )
     steps:
-      - name: Get PR context (for comment triggers)
+      - name: Get PR context
         id: pr-context
         if: github.event_name == 'issue_comment'
         uses: actions/github-script@v7
         with:
           script: |
+            // For issue_comment events, resolve PR base/head so the action
+            // can review the right diff (issue_comment has no top-level
+            // pull_request payload fields).
             const prNumber = context.issue.number;
             const { data: pullRequest } = await github.rest.pulls.get({
               owner: context.repo.owner,
@@ -94,5 +119,7 @@ jobs:
           llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
           llm_model: ${{ vars.OCR_LLM_MODEL }}
           llm_use_anthropic: ${{ vars.OCR_LLM_USE_ANTHROPIC }}
+          # For issue_comment triggers, pass the resolved refs; for
+          # pull_request_target the action resolves them from the event.
           base_ref: ${{ steps.pr-context.outputs.base_ref }}
           head_sha: ${{ steps.pr-context.outputs.head_sha }}

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1,0 +1,98 @@
+# OpenCodeReview — AI-powered PR auto-review
+#
+# Automatically reviews pull requests and posts inline comments.
+# Also supports on-demand re-review via PR comments starting with
+# '/open-code-review' or '@open-code-review'.
+#
+# Required setup (repo Settings → Secrets and variables → Actions):
+#   Secrets:
+#     OCR_LLM_URL          LLM endpoint URL
+#     OCR_LLM_AUTH_TOKEN   API auth token
+#   Variables:
+#     OCR_LLM_MODEL         Model name
+#     OCR_LLM_USE_ANTHROPIC 'true' for Anthropic protocol, 'false' for OpenAI
+
+name: AI Code Review
+
+concurrency:
+  group: >-
+    ${{
+      (
+        github.event_name == 'pull_request_target'
+        || (
+          github.event_name == 'issue_comment'
+          && github.event.issue.pull_request
+          && github.event.comment.user.type != 'Bot'
+          && (
+            github.event.comment.author_association == 'MEMBER'
+            || github.event.comment.author_association == 'OWNER'
+            || github.event.comment.author_association == 'COLLABORATOR'
+            || github.event.comment.user.login == github.event.issue.user.login
+          )
+          && (
+            startsWith(github.event.comment.body, '/open-code-review')
+            || startsWith(github.event.comment.body, '@open-code-review')
+          )
+        )
+      )
+      && format('ocr-{0}', github.event.pull_request.number || github.event.issue.number)
+      || format('noop-{0}', github.run_id)
+    }}
+  cancel-in-progress: true
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  code-review:
+    runs-on: linux-amd64-cpu-8-hk
+    timeout-minutes: 30
+    if: |
+      github.event_name == 'pull_request_target'
+      || (
+        github.event_name == 'issue_comment'
+        && github.event.issue.pull_request
+        && github.event.comment.user.type != 'Bot'
+        && (
+          github.event.comment.author_association == 'MEMBER'
+          || github.event.comment.author_association == 'OWNER'
+          || github.event.comment.author_association == 'COLLABORATOR'
+          || github.event.comment.user.login == github.event.issue.user.login
+        )
+        && (
+          startsWith(github.event.comment.body, '/open-code-review')
+          || startsWith(github.event.comment.body, '@open-code-review')
+        )
+      )
+    steps:
+      - name: Get PR context (for comment triggers)
+        id: pr-context
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.issue.number;
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+            core.setOutput('base_ref', pullRequest.base.ref);
+            core.setOutput('head_sha', pullRequest.head.sha);
+
+      - name: Run OpenCodeReview
+        uses: alibaba/open-code-review@main
+        with:
+          llm_url: ${{ secrets.OCR_LLM_URL }}
+          llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+          llm_model: ${{ vars.OCR_LLM_MODEL }}
+          llm_use_anthropic: ${{ vars.OCR_LLM_USE_ANTHROPIC }}
+          base_ref: ${{ steps.pr-context.outputs.base_ref }}
+          head_sha: ${{ steps.pr-context.outputs.head_sha }}


### PR DESCRIPTION
## Summary

Add an AI-powered code review workflow via [OpenCodeReview](https://github.com/alibaba/open-code-review) that automatically reviews pull requests and posts inline suggestions.

## Motivation

Manual code review catches many issues, but reviewers are often bottlenecked by volume. An automated first pass surfaces mechanical defects — resource leaks, bare excepts, dead code, security misconfigurations — so human reviewers can focus on design and logic.

## What This Does

- **Automatic review**: triggers on `pull_request_target` (`opened` / `synchronize` / `reopened`), reviews the diff, and posts inline comments directly in the "Files changed" tab.
- **On-demand re-review**: comment `/open-code-review` or `@open-code-review` on a PR to trigger a fresh review. Only repository collaborators(gated by `author_association`) and the contributors themselves can do this .
- **Self-hosted runner**: runs on `linux-amd64-cpu-8-hk` to keep LLM traffic on-prem.
- **Concurrency control**: a new review cancels any in-progress one for the same PR; unrelated comments don't interfere.
- **Non-destructive**: uses the action's sticky summary + incremental mode so comments are updated in place rather than piling up.

## Setup Required

Before merging, add these to **Settings → Secrets and variables → Actions**:

| Type | Name | Description |
|------|------|-------------|
| Secret | `OCR_LLM_URL` | LLM endpoint (Anthropic‑compatible) |
| Secret | `OCR_LLM_AUTH_TOKEN` | API auth token |
| Variable | `OCR_LLM_MODEL` | Model name |
| Variable | `OCR_LLM_USE_ANTHROPIC` | `true` |
