### PR TITLE
[ssbuffer](fix) replace errs with debug logging macros

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
@@ -30,13 +30,13 @@
 #include "ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/Passes.h"
-#include "ascend/include/DynamicCVPipeline/StandardizeOp.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Passes.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlockPass.h"
 #include "ascend/include/DynamicCVPipeline/PreCheckAvailable.h"
 #include "ascend/include/DynamicCVPipeline/RemoveAttributes.h"
 #include "ascend/include/DynamicCVPipeline/SeparateMemoryFromComputePass.h"
 #include "ascend/include/DynamicCVPipeline/SplitDataflowPass.h"
+#include "ascend/include/DynamicCVPipeline/StandardizeOp.h"
 
 static constexpr const char *DEBUG_TYPE = "AddDynamicCVPipeline";
 #define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
@@ -66,9 +66,10 @@ void restoreModuleFromBackup(ModuleOp moduleOp, ModuleOp moduleBackup)
 
 } // namespace
 
-AddDynamicCVPipelinePass::AddDynamicCVPipelinePass(
-    const AddDynamicCVPipelineOptions &options)
-    : AddDynamicCVPipelineBase(options) {}
+AddDynamicCVPipelinePass::AddDynamicCVPipelinePass(const AddDynamicCVPipelineOptions &options)
+    : AddDynamicCVPipelineBase(options)
+{
+}
 
 void AddDynamicCVPipelinePass::runOnOperation()
 {
@@ -101,8 +102,7 @@ void AddDynamicCVPipelinePass::runOnOperation()
     if (failed(runPipeline(pm, moduleOp))) {
         auto errCodeAttr = moduleOp->getAttrOfType<IntegerAttr>(CVPipeline::ERRCODE_ATTR);
         if (!errCodeAttr) {
-            moduleOp->emitWarning() << "[" << DEBUG_TYPE << "] "
-                << "Pass failed; fallback to compilation without dynamic CV pipeline.";
+            LDBG("Pass failed; fallback to compilation without dynamic CV pipeline.\n");
         }
 
         int errCode = errCodeAttr ? static_cast<int>(errCodeAttr.getInt()) : CVPipeline::ERRCODE_FAILED;
@@ -116,8 +116,8 @@ void AddDynamicCVPipelinePass::runOnOperation()
     LDBG("Process successfully");
 }
 
-std::unique_ptr<OperationPass<ModuleOp>> mlir::triton::createAddDynamicCVPipelinePass(
-    const AddDynamicCVPipelineOptions &options)
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::triton::createAddDynamicCVPipelinePass(const AddDynamicCVPipelineOptions &options)
 {
     return std::make_unique<AddDynamicCVPipelinePass>(options);
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
@@ -80,7 +80,7 @@ void AddDynamicCVPipelinePass::runOnOperation()
     moduleOp->removeAttr(CVPipeline::ERRCODE_ATTR);
 
     if (!compileOn91095Flag) {
-        llvm::errs() << "Add-dynamic-cv-pipeline is only supported on 91095 now.\n";
+        LDBG("Add-dynamic-cv-pipeline is only supported on 91095 now.\n");
         return;
     }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
@@ -1064,7 +1064,6 @@ void AddMultiBufferOuterScopePass::runOnOperation()
     LDBG("[FlagBudget] used=" << flagCount << " (max=" << (kMaxTotalFlags + 1) << ")");
     if (flagCount > kMaxTotalFlags) {
         LDBG("[FlagBudget] FATAL: flag count " << flagCount << " > " << kMaxTotalFlags << ", halting pass");
-        module->emitError() << "[FlagBudget] flag count " << flagCount << " > " << kMaxTotalFlags << ", halting pass";
         signalPassFailure();
         return;
     }

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -64,7 +64,7 @@ llvm::LogicalResult verifyOpBlockId(Operation *op)
             default:
                 errorPass = "previous passes";
         }
-        LOG_DEBUG("block id should not be negative! Please report to " << errorPass);
+        LOG_DEBUG("block id should not be negative! Please report to " << errorPass << "\n");
         return llvm::failure();
     }
 
@@ -120,11 +120,12 @@ bool isVectorOnlyOp(Operation *op)
 
 bool isScfOp(Operation *op)
 {
-  return llvm::isa<scf::SCFDialect>(op->getDialect());
+    return llvm::isa<scf::SCFDialect>(op->getDialect());
 }
 
 // Check nextOp is only user of preOp
-bool isOnlyDirectlyUse(Operation *preOp, Operation *nextOp, const CVPipeline::MemoryDependenceGraph &memGraph) {
+bool isOnlyDirectlyUse(Operation *preOp, Operation *nextOp, const CVPipeline::MemoryDependenceGraph &memGraph)
+{
     if (!preOp || !nextOp) {
         return false;
     }

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -1,6 +1,7 @@
 #include <optional>
 
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Debug.h"
 #include "llvm/Support/LogicalResult.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -13,6 +14,9 @@
 #include "mlir/IR/Operation.h"
 
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+
+static constexpr const char *DEBUG_TYPE = "CommonUtils";
+#define LOG_DEBUG(...) LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__)
 
 namespace mlir {
 namespace CVPipeline {
@@ -50,17 +54,17 @@ llvm::LogicalResult verifyOpBlockId(Operation *op)
     auto blockId = op->getAttrOfType<IntegerAttr>(kBlockId);
     if (blockId && blockId.getInt() < 0) {
         std::string_view errorPass = "previous passes";
-        auto diag = op->emitError() << "block id should not be negative! Please report to ";
         switch (getOpCoreType(op)) {
             case CoreType::CUBE_ONLY:
-                diag << "PlanCubePass";
+                errorPass = "PlanCubePass";
                 break;
             case CoreType::VECTOR_ONLY:
-                diag << "PlanVectorPass";
+                errorPass = "PlanVectorPass";
                 break;
             default:
-                diag << "previous passes";
+                errorPass = "previous passes";
         }
+        LOG_DEBUG("block id should not be negative! Please report to " << errorPass);
         return llvm::failure();
     }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UBUsageOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UBUsageOptPass.cpp
@@ -728,7 +728,7 @@ llvm::LogicalResult UBUsageOptPass::UBUsageOptimization(Block *block, const CVPi
 
     if (applyRecordChange(recordChange, nodeId2op, memGraph, bm)) {
         // FIXME: it shouldn't happen....
-        llvm::errs() << "Some skiped when apply UB usage optimization changes.\n";
+        LOG_DEBUG("Some skiped when apply UB usage optimization changes.\n");
     }
     return llvm::success();
 }
@@ -870,15 +870,15 @@ void mlir::triton::UBUsageOptPass::runOnOperation()
 
     for (Block *block : blocks) {
         if (UBUsageOptimization(block, memDepGraph, bm).failed()) {
-            llvm::errs() << "UB usage optimization failed in block.\n";
+            LOG_DEBUG("UB usage optimization failed in block.\n");
         }
         if (isUBRefineOptEnabled) {
             if (optBroadcast(block, memDepGraph, bm).failed()) {
-                llvm::errs() << "Broadcast check failed in block.\n";
+                LOG_DEBUG("Broadcast check failed in block.\n");
             }
 
             if (optSmallBlock(block, memDepGraph, bm).failed()) {
-                llvm::errs() << "Small block optimization failed in block.\n";
+                LOG_DEBUG("Small block optimization failed in block.\n");
             }
         }
     }

--- a/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory.cpp
@@ -55,7 +55,7 @@ void DecoupleComputeAndMemoryPass::runOnOperation()
   pm.addPass(createAddMultiBufferToGMLoadPass());
 
   if (failed(runPipeline(pm, module))) {
-    module->emitError() << "[" << DEBUG_TYPE << "] Pass failed!";
+    LDBG("Pass failed!");
     signalPassFailure();
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoad.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoad.cpp
@@ -20,9 +20,9 @@
  * THE SOFTWARE.
  */
 
+#include "ascend/include/DynamicCVPipeline/Common/BufferCountManager.h"
 #include "ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoadInternal.h"
 #include "ascend/include/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoadPass.h"
-#include "ascend/include/DynamicCVPipeline/Common/BufferCountManager.h"
 
 using namespace mlir;
 using namespace triton;
@@ -151,7 +151,7 @@ void AddMultiBufferToGMLoadPass::runOnOperation()
     // Step 3: Transform each for loop with multi-buffer logic
     allCtxForOps_.clear();
     if (failed(applyMultiBufferToGMLoadLoops())) {
-        LOG_DEBUG("Step 3 applyMultiBufferToGMLoadLoops failed");
+        LOG_DEBUG("Step 3 applyMultiBufferToGMLoadLoops failed\n");
         signalPassFailure();
         return;
     }

--- a/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoad.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/AddMultiBufferToGMLoad.cpp
@@ -151,7 +151,7 @@ void AddMultiBufferToGMLoadPass::runOnOperation()
     // Step 3: Transform each for loop with multi-buffer logic
     allCtxForOps_.clear();
     if (failed(applyMultiBufferToGMLoadLoops())) {
-        module.emitError() << "[" << DEBUG_TYPE << "] Step 3 applyMultiBufferToGMLoadLoops failed";
+        LOG_DEBUG("Step 3 applyMultiBufferToGMLoadLoops failed");
         signalPassFailure();
         return;
     }

--- a/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/LoopTransform.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/LoopTransform.cpp
@@ -161,7 +161,7 @@ FailureOr<scf::ForOp> pruneDeadIterArgs(OpBuilder &builder, scf::ForOp forOp, un
 {
     unsigned numIter = forOp.getNumResults();
     if (candidateCount > numIter) {
-        LOG_DEBUG("candidate iter_arg count " << candidateCount << " exceeds total iter_arg count " << numIter);
+        LOG_DEBUG("candidate iter_arg count " << candidateCount << " exceeds total iter_arg count " << numIter << "\n");
         return failure();
     }
 
@@ -205,7 +205,8 @@ void eraseDeadBodyOps(Block *body)
             continue;
         }
         if (mlir::isMemoryEffectFree(&op) &&
-            llvm::all_of(op.getResults(), [](Value result) { return result.use_empty(); })) {
+            llvm::all_of(op.getResults(), [](Value result) { return result.use_empty(); }))
+        {
             enqueueIfDead(&op);
         }
     }
@@ -231,7 +232,8 @@ void eraseDeadBodyOps(Block *body)
 
         for (Operation *defOp : operandDefs) {
             if (mlir::isMemoryEffectFree(defOp) &&
-                llvm::all_of(defOp->getResults(), [](Value result) { return result.use_empty(); })) {
+                llvm::all_of(defOp->getResults(), [](Value result) { return result.use_empty(); }))
+            {
                 enqueueIfDead(defOp);
             }
         }
@@ -613,15 +615,14 @@ FailureOr<SmallVector<Value>> collectLinearIterArgDeltas(const ExtendedForInfo &
     }
     auto numOrig = static_cast<unsigned>(info.numOrig);
     if (info.oldBody->getNumArguments() < numOrig + kForBodyIterArgOffset) {
-        LOG_DEBUG("old loop body has " << info.oldBody->getNumArguments()
-                  << " arguments, expected at least " << (numOrig + kForBodyIterArgOffset));
+        LOG_DEBUG("old loop body has " << info.oldBody->getNumArguments() << " arguments, expected at least "
+                                       << (numOrig + kForBodyIterArgOffset));
         return failure();
     }
 
     auto oldYieldOp = cast<scf::YieldOp>(info.oldBody->getTerminator());
     if (oldYieldOp->getNumOperands() < numOrig) {
-        LOG_DEBUG("old loop yield has " << oldYieldOp->getNumOperands()
-                 << " operands, expected at least " << numOrig);
+        LOG_DEBUG("old loop yield has " << oldYieldOp->getNumOperands() << " operands, expected at least " << numOrig);
         return failure();
     }
 
@@ -629,7 +630,8 @@ FailureOr<SmallVector<Value>> collectLinearIterArgDeltas(const ExtendedForInfo &
     for (unsigned iterArgIdx = 0; iterArgIdx < numOrig; ++iterArgIdx) {
         Value delta;
         if (getLinearIterArgDelta(info.oldBody->getArgument(iterArgIdx + kForBodyIterArgOffset),
-                                  oldYieldOp->getOperand(iterArgIdx), forOp, delta)) {
+                                  oldYieldOp->getOperand(iterArgIdx), forOp, delta))
+        {
             iterArgDeltas[iterArgIdx] = delta;
         }
     }
@@ -645,9 +647,8 @@ LogicalResult replaceOriginalForResults(scf::ForOp oldForOp, scf::ForOp newForOp
 
     auto numOrigResults = static_cast<unsigned>(numOrig);
     if (oldForOp.getNumResults() < numOrigResults || newForOp.getNumResults() < numOrigResults) {
-        LOG_DEBUG("cannot replace " << numOrigResults
-                 << " loop results; old loop has " << oldForOp.getNumResults() << ", new loop has "
-                 << newForOp.getNumResults());
+        LOG_DEBUG("cannot replace " << numOrigResults << " loop results; old loop has " << oldForOp.getNumResults()
+                                    << ", new loop has " << newForOp.getNumResults());
         return failure();
     }
 
@@ -702,10 +703,10 @@ LogicalResult applyMultiBufferToForLoop(ForBufferCtx &context, const llvm::Dense
         return failure();
     }
 
-    LogicalResult emitBodyStatus = emitMultiBufferLoopBody(
-        builder, loc, context.groups, info, groupValues.indexOnes, groupValues.slotConsts, groupValues.depthConsts,
-        allCtxForOps, loopValues.tripCount, loopValues.lowerBound, loopValues.step, groupValues.trueFlags,
-        *iterArgDeltas, forOp);
+    LogicalResult emitBodyStatus =
+        emitMultiBufferLoopBody(builder, loc, context.groups, info, groupValues.indexOnes, groupValues.slotConsts,
+                                groupValues.depthConsts, allCtxForOps, loopValues.tripCount, loopValues.lowerBound,
+                                loopValues.step, groupValues.trueFlags, *iterArgDeltas, forOp);
     if (failed(emitBodyStatus)) {
         return failure();
     }

--- a/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/LoopTransform.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/LoopTransform.cpp
@@ -610,19 +610,20 @@ GroupInvariantValues emitGroupInvariantValues(OpBuilder &builder, Location loc, 
 FailureOr<SmallVector<Value>> collectLinearIterArgDeltas(const ExtendedForInfo &info, scf::ForOp forOp)
 {
     if (info.numOrig < 0) {
-        LOG_DEBUG("original iter_arg count is negative: " << info.numOrig);
+        LOG_DEBUG("original iter_arg count is negative: " << info.numOrig << "\n");
         return failure();
     }
     auto numOrig = static_cast<unsigned>(info.numOrig);
     if (info.oldBody->getNumArguments() < numOrig + kForBodyIterArgOffset) {
         LOG_DEBUG("old loop body has " << info.oldBody->getNumArguments() << " arguments, expected at least "
-                                       << (numOrig + kForBodyIterArgOffset));
+                                       << (numOrig + kForBodyIterArgOffset) << "\n");
         return failure();
     }
 
     auto oldYieldOp = cast<scf::YieldOp>(info.oldBody->getTerminator());
     if (oldYieldOp->getNumOperands() < numOrig) {
-        LOG_DEBUG("old loop yield has " << oldYieldOp->getNumOperands() << " operands, expected at least " << numOrig);
+        LOG_DEBUG("old loop yield has " << oldYieldOp->getNumOperands() << " operands, expected at least " << numOrig
+                                        << "\n");
         return failure();
     }
 
@@ -641,14 +642,14 @@ FailureOr<SmallVector<Value>> collectLinearIterArgDeltas(const ExtendedForInfo &
 LogicalResult replaceOriginalForResults(scf::ForOp oldForOp, scf::ForOp newForOp, int numOrig)
 {
     if (numOrig < 0) {
-        LOG_DEBUG("original result count is negative: " << numOrig);
+        LOG_DEBUG("original result count is negative: " << numOrig << "\n");
         return failure();
     }
 
     auto numOrigResults = static_cast<unsigned>(numOrig);
     if (oldForOp.getNumResults() < numOrigResults || newForOp.getNumResults() < numOrigResults) {
         LOG_DEBUG("cannot replace " << numOrigResults << " loop results; old loop has " << oldForOp.getNumResults()
-                                    << ", new loop has " << newForOp.getNumResults());
+                                    << ", new loop has " << newForOp.getNumResults() << "\n");
         return failure();
     }
 
@@ -661,7 +662,7 @@ LogicalResult replaceOriginalForResults(scf::ForOp oldForOp, scf::ForOp newForOp
 LogicalResult finalizeMultiBufferLoop(OpBuilder &builder, scf::ForOp newForOp, int numOrig)
 {
     if (numOrig < 0) {
-        LOG_DEBUG("original iter_arg count is negative: " << numOrig);
+        LOG_DEBUG("original iter_arg count is negative: " << numOrig << "\n");
         return failure();
     }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/LoopTransform.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/LoopTransform.cpp
@@ -161,8 +161,7 @@ FailureOr<scf::ForOp> pruneDeadIterArgs(OpBuilder &builder, scf::ForOp forOp, un
 {
     unsigned numIter = forOp.getNumResults();
     if (candidateCount > numIter) {
-        forOp.emitError() << "[" << DEBUG_TYPE << "] candidate iter_arg count " << candidateCount
-                          << " exceeds total iter_arg count " << numIter;
+        LOG_DEBUG("candidate iter_arg count " << candidateCount << " exceeds total iter_arg count " << numIter);
         return failure();
     }
 
@@ -609,20 +608,20 @@ GroupInvariantValues emitGroupInvariantValues(OpBuilder &builder, Location loc, 
 FailureOr<SmallVector<Value>> collectLinearIterArgDeltas(const ExtendedForInfo &info, scf::ForOp forOp)
 {
     if (info.numOrig < 0) {
-        forOp.emitError() << "[" << DEBUG_TYPE << "] original iter_arg count is negative: " << info.numOrig;
+        LOG_DEBUG("original iter_arg count is negative: " << info.numOrig);
         return failure();
     }
     auto numOrig = static_cast<unsigned>(info.numOrig);
     if (info.oldBody->getNumArguments() < numOrig + kForBodyIterArgOffset) {
-        forOp.emitError() << "[" << DEBUG_TYPE << "] old loop body has " << info.oldBody->getNumArguments()
-                          << " arguments, expected at least " << (numOrig + kForBodyIterArgOffset);
+        LOG_DEBUG("old loop body has " << info.oldBody->getNumArguments()
+                  << " arguments, expected at least " << (numOrig + kForBodyIterArgOffset));
         return failure();
     }
 
     auto oldYieldOp = cast<scf::YieldOp>(info.oldBody->getTerminator());
     if (oldYieldOp->getNumOperands() < numOrig) {
-        forOp.emitError() << "[" << DEBUG_TYPE << "] old loop yield has " << oldYieldOp->getNumOperands()
-                          << " operands, expected at least " << numOrig;
+        LOG_DEBUG("old loop yield has " << oldYieldOp->getNumOperands()
+                 << " operands, expected at least " << numOrig);
         return failure();
     }
 
@@ -640,15 +639,15 @@ FailureOr<SmallVector<Value>> collectLinearIterArgDeltas(const ExtendedForInfo &
 LogicalResult replaceOriginalForResults(scf::ForOp oldForOp, scf::ForOp newForOp, int numOrig)
 {
     if (numOrig < 0) {
-        oldForOp.emitError() << "[" << DEBUG_TYPE << "] original result count is negative: " << numOrig;
+        LOG_DEBUG("original result count is negative: " << numOrig);
         return failure();
     }
 
     auto numOrigResults = static_cast<unsigned>(numOrig);
     if (oldForOp.getNumResults() < numOrigResults || newForOp.getNumResults() < numOrigResults) {
-        oldForOp.emitError() << "[" << DEBUG_TYPE << "] cannot replace " << numOrigResults
-                             << " loop results; old loop has " << oldForOp.getNumResults() << ", new loop has "
-                             << newForOp.getNumResults();
+        LOG_DEBUG("cannot replace " << numOrigResults
+                 << " loop results; old loop has " << oldForOp.getNumResults() << ", new loop has "
+                 << newForOp.getNumResults());
         return failure();
     }
 
@@ -661,7 +660,7 @@ LogicalResult replaceOriginalForResults(scf::ForOp oldForOp, scf::ForOp newForOp
 LogicalResult finalizeMultiBufferLoop(OpBuilder &builder, scf::ForOp newForOp, int numOrig)
 {
     if (numOrig < 0) {
-        newForOp.emitError() << "[" << DEBUG_TYPE << "] original iter_arg count is negative: " << numOrig;
+        LOG_DEBUG("original iter_arg count is negative: " << numOrig);
         return failure();
     }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/MultiBufferLoopBodyEmission.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/DecoupleComputeAndMemory/MultiBufferLoopBodyEmission.cpp
@@ -167,14 +167,14 @@ static LogicalResult validateProducerIterArgInputs(scf::ForOp origForOp, Block *
 {
     size_t numOrig = origForOp.getInitArgs().size();
     if (iterArgDeltas.size() < numOrig) {
-        origForOp.emitError() << "[" << DEBUG_TYPE << "] iter_arg delta count " << iterArgDeltas.size()
-                              << " is smaller than original iter_arg count " << numOrig;
+        LOG_DEBUG("iter_arg delta count " << iterArgDeltas.size()
+                  << " is smaller than original iter_arg count " << numOrig);
         return failure();
     }
     if (oldBody->getNumArguments() < numOrig + kForBodyIterArgOffset ||
         newBody->getNumArguments() < numOrig + kForBodyIterArgOffset) {
-        origForOp.emitError() << "[" << DEBUG_TYPE << "] loop body argument count is smaller than expected "
-                              << (numOrig + kForBodyIterArgOffset);
+        LOG_DEBUG("loop body argument count is smaller than expected "
+                 << (numOrig + kForBodyIterArgOffset));
         return failure();
     }
     return success();
@@ -483,17 +483,16 @@ static LogicalResult validateGroupEmissionInputs(ArrayRef<LoadGroup> groups, Ext
     if (info.groupArgs.size() != numGroups || groupTrueFlagVals.size() != numGroups ||
         groupIndexOneVals.size() != numGroups || allGroupDepthConsts.size() != numGroups ||
         allGroupSlotConsts.size() != numGroups) {
-        origForOp.emitError()
-            << "[" << DEBUG_TYPE << "] array size mismatch in multi-buffer emission: groups=" << numGroups
+        LOG_DEBUG("array size mismatch in multi-buffer emission: groups=" << numGroups
             << ", groupArgs=" << info.groupArgs.size() << ", groupTrueFlagVals=" << groupTrueFlagVals.size()
             << ", groupIndexOneVals=" << groupIndexOneVals.size()
             << ", allGroupDepthConsts=" << allGroupDepthConsts.size()
-            << ", allGroupSlotConsts=" << allGroupSlotConsts.size();
+            << ", allGroupSlotConsts=" << allGroupSlotConsts.size());
         return failure();
     }
     if (groupIdx < 0 || static_cast<size_t>(groupIdx) >= numGroups) {
-        origForOp.emitError() << "[" << DEBUG_TYPE << "] load group index " << groupIdx
-                              << " is out of range for multi-buffer emission (numGroups=" << numGroups << ")";
+        LOG_DEBUG("load group index " << groupIdx
+                 << " is out of range for multi-buffer emission (numGroups=" << numGroups << ")");
         return failure();
     }
     return success();
@@ -513,8 +512,8 @@ static LogicalResult emitProducerAndSelectSlots(
         return failure();
     }
     if (static_cast<size_t>(groupIdx) >= state.prefixEmitted.size()) {
-        origForOp.emitError() << "[" << DEBUG_TYPE << "] load group index " << groupIdx
-                              << " exceeds multi-buffer state size " << state.prefixEmitted.size();
+        LOG_DEBUG("load group index " << groupIdx
+                 << " exceeds multi-buffer state size " << state.prefixEmitted.size());
         return failure();
     }
     if (state.prefixEmitted[groupIdx]) {

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock.cpp
@@ -62,7 +62,7 @@ void PlanComputeBlockPass::runOnOperation()
         auto errCodeAttr = module->getAttrOfType<IntegerAttr>(CVPipeline::ERRCODE_ATTR);
         int errCode = errCodeAttr ? static_cast<int>(errCodeAttr.getInt()) : CVPipeline::ERRCODE_FAILED;
         if (errCode != CVPipeline::ERRCODE_IGNORED) {
-            module->emitError() << "[" << DEBUG_TYPE << "] Pass failed!";
+            LOG_DEBUG("Pass failed!");
         }
         signalPassFailure();
         return;

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.cpp
@@ -28,6 +28,9 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/LogicalResult.h"
 
+static constexpr const char *DEBUG_TYPE = "ComputeBlockIdManager";
+#define LOG_DEBUG(...) LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__)
+
 namespace mlir {
 namespace CVPipeline {
 
@@ -135,8 +138,8 @@ llvm::LogicalResult ComputeBlockIdManager::markAndRecord(Operation *op, int bloc
     op->setAttr(kBlockId, IntegerAttr::get(IntegerType::get(ctx, blockIdWidth), blockId));
     auto itOld = opToBlockId.find(op);
     if (itOld != opToBlockId.end() && itOld->second != -1) {
-        llvm::errs() << "Error: Operation already has a block id. Op: " << *op << ", old block id: " << itOld->second
-                     << ", new block id: " << blockId << "\n";
+        LOG_DEBUG("Error: Operation already has a block id. Op: " << *op << ", old block id: " << itOld->second
+                     << ", new block id: " << blockId << "\n");
         return llvm::failure();
     }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
@@ -354,7 +354,7 @@ llvm::LogicalResult TopologicalPartitionPlanner::removeReadyNonCubeOps()
     }
     if (!mapsAreDiff(indegreeBefore, indegree) && beforeVisitedSize == bypassVisited.size()) {
         if (Operation *parentOp = block->getParentOp()) {
-            parentOp->emitError("PlanCubeBlock cannot make progress while scheduling cube operations");
+            LOG_DEBUG("PlanCubeBlock cannot make progress while scheduling cube operations");
         }
         dumpQueueAndIndegreeInfo();
         return llvm::failure();
@@ -375,27 +375,22 @@ bool TopologicalPartitionPlanner::canExpandTo(Operation *op)
 // Encountered error. Need to print failure reason, so no need for LLVM_DEBUG
 void TopologicalPartitionPlanner::dumpQueueAndIndegreeInfo()
 {
-    // simply print a debug header in a new line
-    auto errs = []() -> llvm::raw_ostream& {
-        return llvm::errs() << "\n[" << DEBUG_TYPE << "] ";
-    };
+    LOG_DEBUG("\nfailed to make progress while planning cube blocks.");
+    LOG_DEBUG("remaining cube count: " << nonAssignedCubeCnt);
 
-    errs() << "failed to make progress while planning cube blocks.";
-    errs() << "remaining cube count: " << nonAssignedCubeCnt;
-
-    errs() << "ready queue";
+    LOG_DEBUG("ready queue");
     if (queue.empty()) {
-        llvm::errs() << " is empty.";
+        LOG_DEBUG(" is empty.");
     } else {
-        llvm::errs() << ":\n";
+        LOG_DEBUG(":\n");
         while (!queue.empty()) {
             Operation *op = queue.front();
             queue.pop();
-            llvm::errs() << "  " << *op << "\n";
+            LOG_DEBUG("  " << *op << "\n");
         }
     }
 
-    errs() << "remaining unassigned cube ops:\n";
+    LOG_DEBUG("remaining unassigned cube ops:\n");
     bool foundRemainingCube = false;
     for (auto &p : indegree) {
         Operation *op = p.first;
@@ -404,10 +399,10 @@ void TopologicalPartitionPlanner::dumpQueueAndIndegreeInfo()
             continue;
         }
         foundRemainingCube = true;
-        llvm::errs() << "  indegree=" << p.second << " op=" << *op << "\n";
+        LOG_DEBUG("  indegree=" << p.second << " op=" << *op << "\n");
     }
     if (!foundRemainingCube) {
-        llvm::errs() << "  <none>\n";
+        LOG_DEBUG("  <none>\n");
     }
 }
 
@@ -415,7 +410,7 @@ llvm::LogicalResult TopologicalPartitionPlanner::populateQueueWithReadyOps()
 {
     for (auto [op, indegree] : indegree) {
         if (indegree < 0) {
-            op->emitError("Indegree cannot be negative");
+            LOG_DEBUG("Indegree cannot be negative");
             return llvm::failure();
         }
         if (indegree == 0 && !newassigned.contains(op) && isCubeOp(op) && !assigned.contains(op)) {

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp
@@ -568,7 +568,7 @@ void PlanVectorBlockPass::runOnOperation()
     llvm::SmallVector<Block *> blocks;
     moduleOp.walk([&](Block *block) {
         if (llvm::failed(planVectorBlockId(block, memDepGraph, bm, isUBRefineOptEnabled))) {
-            moduleOp.emitError() << "[" << DEBUG_TYPE << "] Failed to plan vector block id for block";
+            LOG_DEBUG("Failed to plan vector block id for block");
             signalPassFailure();
             return;
         }

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
@@ -324,7 +324,7 @@ llvm::FailureOr<SmallVector<int>> GroupAdjacencyGraph::computeTopologicalOrder()
     Operation *op = block->getParentOp();
     constexpr std::string_view kErrorPrefix = "Failed to compute topological order for ";
     if (!op) {
-        llvm::errs() << kErrorPrefix << "an unknown block that is not contained in an op";
+        LOG_DEBUG(kErrorPrefix << "an unknown block that is not contained in an op");
         return llvm::failure();
     }
     size_t regionIdx = 0;
@@ -336,7 +336,7 @@ llvm::FailureOr<SmallVector<int>> GroupAdjacencyGraph::computeTopologicalOrder()
             }
         }
     }
-    op->emitError(kErrorPrefix) << "block in region " << regionIdx;
+    LOG_DEBUG(kErrorPrefix << "block in region " << regionIdx);
     return llvm::failure();
 }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/AddMultiBufferToGMLoad.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/AddMultiBufferToGMLoad.cpp
@@ -151,7 +151,7 @@ void AddMultiBufferToGMLoadPass::runOnOperation()
     // Step 3: Transform each for loop with multi-buffer logic
     allCtxForOps_.clear();
     if (failed(applyMultiBufferToGMLoadLoops())) {
-        module.emitError() << "[" << DEBUG_TYPE << "] Step 3 applyMultiBufferToGMLoadLoops failed";
+        LOG_DEBUG("Step 3 applyMultiBufferToGMLoadLoops failed");
         signalPassFailure();
         return;
     }

--- a/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/LoopTransform.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/LoopTransform.cpp
@@ -161,8 +161,7 @@ FailureOr<scf::ForOp> pruneDeadIterArgs(OpBuilder &builder, scf::ForOp forOp, un
 {
     unsigned numIter = forOp.getNumResults();
     if (candidateCount > numIter) {
-        forOp.emitError() << "[" << DEBUG_TYPE << "] candidate iter_arg count " << candidateCount
-                          << " exceeds total iter_arg count " << numIter;
+        LOG_DEBUG("candidate iter_arg count " << candidateCount << " exceeds total iter_arg count " << numIter);
         return failure();
     }
 
@@ -608,20 +607,20 @@ GroupInvariantValues emitGroupInvariantValues(OpBuilder &builder, Location loc, 
 FailureOr<SmallVector<Value>> collectLinearIterArgDeltas(const ExtendedForInfo &info, scf::ForOp forOp)
 {
     if (info.numOrig < 0) {
-        forOp.emitError() << "[" << DEBUG_TYPE << "] original iter_arg count is negative: " << info.numOrig;
+        LOG_DEBUG("original iter_arg count is negative: " << info.numOrig);
         return failure();
     }
     auto numOrig = static_cast<unsigned>(info.numOrig);
     if (info.oldBody->getNumArguments() < numOrig + kForBodyIterArgOffset) {
-        forOp.emitError() << "[" << DEBUG_TYPE << "] old loop body has " << info.oldBody->getNumArguments()
-                          << " arguments, expected at least " << (numOrig + kForBodyIterArgOffset);
+        LOG_DEBUG("old loop body has " << info.oldBody->getNumArguments()
+                  << " arguments, expected at least " << (numOrig + kForBodyIterArgOffset));
         return failure();
     }
 
     auto oldYieldOp = cast<scf::YieldOp>(info.oldBody->getTerminator());
     if (oldYieldOp->getNumOperands() < numOrig) {
-        forOp.emitError() << "[" << DEBUG_TYPE << "] old loop yield has " << oldYieldOp->getNumOperands()
-                          << " operands, expected at least " << numOrig;
+        LOG_DEBUG("old loop yield has " << oldYieldOp->getNumOperands()
+                 << " operands, expected at least " << numOrig);
         return failure();
     }
 
@@ -639,15 +638,15 @@ FailureOr<SmallVector<Value>> collectLinearIterArgDeltas(const ExtendedForInfo &
 LogicalResult replaceOriginalForResults(scf::ForOp oldForOp, scf::ForOp newForOp, int numOrig)
 {
     if (numOrig < 0) {
-        oldForOp.emitError() << "[" << DEBUG_TYPE << "] original result count is negative: " << numOrig;
+        LOG_DEBUG("original result count is negative: " << numOrig);
         return failure();
     }
 
     auto numOrigResults = static_cast<unsigned>(numOrig);
     if (oldForOp.getNumResults() < numOrigResults || newForOp.getNumResults() < numOrigResults) {
-        oldForOp.emitError() << "[" << DEBUG_TYPE << "] cannot replace " << numOrigResults
-                             << " loop results; old loop has " << oldForOp.getNumResults() << ", new loop has "
-                             << newForOp.getNumResults();
+        LOG_DEBUG("cannot replace " << numOrigResults
+                 << " loop results; old loop has " << oldForOp.getNumResults() << ", new loop has "
+                 << newForOp.getNumResults());
         return failure();
     }
 
@@ -660,7 +659,7 @@ LogicalResult replaceOriginalForResults(scf::ForOp oldForOp, scf::ForOp newForOp
 LogicalResult finalizeMultiBufferLoop(OpBuilder &builder, scf::ForOp newForOp, int numOrig)
 {
     if (numOrig < 0) {
-        newForOp.emitError() << "[" << DEBUG_TYPE << "] original iter_arg count is negative: " << numOrig;
+        LOG_DEBUG("original iter_arg count is negative: " << numOrig);
         return failure();
     }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/MultiBufferLoopBodyEmission.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/MultiBufferLoopBodyEmission.cpp
@@ -167,20 +167,20 @@ static LogicalResult validateProducerIterArgInputs(scf::ForOp origForOp, Block *
 {
     int numOrig = static_cast<int>(origForOp.getInitArgs().size());
     if (numOrig < 0) {
-        origForOp.emitError() << "[" << DEBUG_TYPE << "] original iter_arg count is negative: " << numOrig;
+        LOG_DEBUG("original iter_arg count is negative: " << numOrig);
         return failure();
     }
 
     auto numOrigArgs = static_cast<unsigned>(numOrig);
     if (iterArgDeltas.size() < numOrigArgs) {
-        origForOp.emitError() << "[" << DEBUG_TYPE << "] iter_arg delta count " << iterArgDeltas.size()
-                              << " is smaller than original iter_arg count " << numOrigArgs;
+        LOG_DEBUG("iter_arg delta count " << iterArgDeltas.size()
+                  << " is smaller than original iter_arg count " << numOrigArgs);
         return failure();
     }
     if (oldBody->getNumArguments() < numOrigArgs + kForBodyIterArgOffset ||
         newBody->getNumArguments() < numOrigArgs + kForBodyIterArgOffset) {
-        origForOp.emitError() << "[" << DEBUG_TYPE << "] loop body argument count is smaller than expected "
-                              << (numOrigArgs + kForBodyIterArgOffset);
+        LOG_DEBUG("loop body argument count is smaller than expected "
+                 << (numOrigArgs + kForBodyIterArgOffset));
         return failure();
     }
     return success();
@@ -491,8 +491,8 @@ static LogicalResult validateGroupEmissionInputs(ArrayRef<LoadGroup> groups, Ext
         static_cast<size_t>(groupIdx) >= groupIndexOneVals.size() ||
         static_cast<size_t>(groupIdx) >= allGroupDepthConsts.size() ||
         static_cast<size_t>(groupIdx) >= allGroupSlotConsts.size()) {
-        origForOp.emitError() << "[" << DEBUG_TYPE << "] load group index " << groupIdx
-                              << " is out of range for multi-buffer emission";
+        LOG_DEBUG("load group index " << groupIdx
+                 << " is out of range for multi-buffer emission");
         return failure();
     }
     return success();
@@ -512,8 +512,8 @@ static LogicalResult emitProducerAndSelectSlots(
         return failure();
     }
     if (static_cast<size_t>(groupIdx) >= state.prefixEmitted.size()) {
-        origForOp.emitError() << "[" << DEBUG_TYPE << "] load group index " << groupIdx
-                              << " exceeds multi-buffer state size " << state.prefixEmitted.size();
+        LOG_DEBUG("load group index " << groupIdx
+                 << " exceeds multi-buffer state size " << state.prefixEmitted.size());
         return failure();
     }
     if (state.prefixEmitted[groupIdx]) {

--- a/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromComputePass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromComputePass.cpp
@@ -55,7 +55,7 @@ void SeparateMemoryFromComputePass::runOnOperation()
   pm.addPass(createAddMultiBufferToGMLoadPass());
 
   if (failed(runPipeline(pm, module))) {
-    module->emitError() << "[" << DEBUG_TYPE << "] Pass failed!";
+    LDBG("Pass failed!");
     signalPassFailure();
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow.cpp
@@ -68,7 +68,7 @@ void SplitDataflowPass::runOnOperation()
     pm.addPass(createRefineArgsBlockIdPass());
 
     if (failed(runPipeline(pm, module))) {
-        module->emitError() << "[" << DEBUG_TYPE << "] Pass failed!";
+        LDBG("Pass failed!");
         signalPassFailure();
     }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/PreserveControlAttrsCanonicalize.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/PreserveControlAttrsCanonicalize.cpp
@@ -156,7 +156,7 @@ void mlir::triton::PreserveControlAttrsCanonicalizePass::runOnOperation()
     if (failed(applyPatternsAndFoldGreedily(getOperation(),
                                             FrozenRewritePatternSet(std::move(patterns)),
                                             config))) {
-        getOperation()->emitError("PreserveControlAttrsCanonicalizePass failed");
+        LOG_DEBUG("PreserveControlAttrsCanonicalizePass failed");
         signalPassFailure();
         return;
     }

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
@@ -188,7 +188,6 @@ static FailureOr<std::pair<scope::ScopeOp, scope::ScopeOp>> createTwoFullScopes(
 {
     if (!llvm::hasSingleElement(funcOp.getBody())) {
         logDebug("createTwoFullScopes failed for func '", funcOp.getName(), "': expected single block");
-        funcOp.emitError("SeparateCVScope only supports single-block functions");
         return failure();
     }
 
@@ -814,7 +813,6 @@ static LogicalResult normalizeNonRegionOp(Operation *op, StringRef scopeType)
     if (!infoOpt) {
         logDebug("normalizeNonRegionOp failed for op '", op->getName().getStringRef(),
                  "': missing ssbuffer.core_type in scope ", scopeType);
-        op->emitError("missing ssbuffer.core_type");
         return failure();
     }
 


### PR DESCRIPTION
Replace all emitError() calls in DynamicCVPipeline with LOG_DEBUG/LDBG/logDebug macros, and similarly replace llvm::errs() calls with debug logging macros. This change converts hard errors to debug-level logging for non-fatal conditions.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
