### PR TITLE
[user](feat) add plan_memory_strategy option

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -700,6 +700,10 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
         if hfusion_enable_multiple_consumer_fusion:
             cmd_list += [f"--hfusion-enable-multiple-consumer-fusion={hfusion_enable_multiple_consumer_fusion}"]
 
+        plan_memory_strategy = metadata["plan_memory_strategy"]
+        if plan_memory_strategy is not None:
+            cmd_list += [f"--plan-memory-strategy={plan_memory_strategy}"]
+
         if opt.debug or os.getenv("TRITON_PRINT_AUTOTUNING", None) == "1":
             print(f"[DEBUG] cmd_list: {' '.join(cmd_list)}")
 
@@ -1047,6 +1051,8 @@ class NPUOptions:
     inter_cache_num: int = None
     load_cache_num: int = None
 
+    # plan memory strategy: "default" (default) or "largest-first"
+    plan_memory_strategy: str = None
     stream: int = None
     parallel_mode: str = "simd"
     force_simt_only: bool = False


### PR DESCRIPTION
<!---

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

Add a option to change mem-plan order form defalut(declaration order) to largest-first(size order), which can reduce memory fragmentation and deal with UB overflow issue in certain cases. After changing the plan order, the set of buffers participating in reuse changes, which leads to changes of sync location and thus affect performance. In some cases, this may result in negative performance impacts. Therefore, we have added an option to control it. 

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
