### PR TITLE
[compile](fix) always print IR and stack trace on bishengir-compile f…

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -688,6 +688,8 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
         if mix_mode in ["aic"]:
             _compile_option_list += ["--disable-hfusion-vectorize=true"]
 
+        _compile_option_list += ["--mlir-print-ir-after-failure"]
+        _compile_option_list += ["--mlir-print-stacktrace-on-diagnostic"]
         if opt.debug:
             _compile_option_list += ["--bishengir-print-ir-after=hivm-graph-sync-solver"]
 
@@ -912,8 +914,9 @@ def linalg_to_bin_enable_npu_compile_A2_A3(linalg: str, metadata, opt):
                 "--enable-triton-kernel-compile=true",
             ]
 
+        _compile_option_list += ["--mlir-print-ir-after-failure"]
+        _compile_option_list += ["--mlir-print-stacktrace-on-diagnostic"]
         if opt.debug:
-            _compile_option_list += ["--mlir-print-ir-after-failure"]
             _compile_option_list += ["--bishengir-print-ir-after=hivm-graph-sync-solver"]
 
         cmd_list = ([npu_compiler_path, ttadapter_path] + _compile_option_list + ["-o", bin_file])


### PR DESCRIPTION
…ailure
Add --mlir-print-ir-after-failure and --mlir-print-stacktrace-on-diagnostic to the default compile options so failure diagnostics are emitted without requiring TRITON_DEBUG=1. Reproducing a failure is expensive, and these flags are essentially free on the success path.
For issue #1044
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
### Summary
Enable `--mlir-print-ir-after-failure` and `--mlir-print-stacktrace-on-diagnostic` by default in the Ascend `bishengir-compile` invocation. This makes MLIR diagnostics useful in production-style runs without forcing users to set `TRITON_DEBUG=1` and
re-run the failing job to capture the same information.
### Motivation
When a kernel fails to compile, users currently see only a brief "BiShengIR pipeline failed" message. The MLIR IR right before the failing pass and the C++ stack trace are only printed when `TRITON_DEBUG=1` is set. Because compilation can take a long time and is not always easily reproducible (e.g. depending on device state or the specific kernel being compiled), asking users to rerun with `TRITON_DEBUG=1` to gather the necessary information is impractical. We should print the failure information by default.
### Change
Append the following two flags to the default compile option list passed to `bishengir-compile`:
- `--mlir-print-ir-after-failure`: dump the MLIR module to stderr when a pass fails verification or crashes.
- `--mlir-print-stacktrace-on-diagnostic`: when a diagnostic is emitted, also print the C++ stack trace via `llvm::sys::PrintStackTrace`.
### Performance impact
Both options are off the hot path:
- `--mlir-print-ir-after-failure` is a no-op on successful compilations; it only triggers when a pass fails.
- `--mlir-print-stacktrace-on-diagnostic` adds a single boolean check per emitted diagnostic; the trace is only printed on failure. Successful compilations should see no measurable overhead.

### New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
