### PR TITLE
[docs](feat) Update documents relevant to compile_mode build option

### DIFF
--- a/docs/en/architecture_design_and_core_features.md
+++ b/docs/en/architecture_design_and_core_features.md
@@ -215,9 +215,9 @@ Developers choose the compilation path via `compile_mode`.
 
 | `compile_mode` | Description | Compilation Path |
 |---|---|---|
-| `"simd"` | Pure SIMD: structured access via DMA; unstructured access via scalar loops | `ttir → ttadapter(linalg) → npubin` |
-| `"unstructured_in_simt"` (**default**) | Hybrid: structured access stays on SIMD; discrete / unstructured access prefers SIMT indirect access | `ttir → ttadapter(linalg) → npubin` |
-| `"simt_only"` | Pure SIMT: the entire kernel is compiled as pure SIMT | `ttir → npubin` |
+| `"simd"` | Pure SIMD: structured access via DMA; unstructured access via scalar loops | `Triton IR → Linalg IR → AscendNPU IR` |
+| `"unstructured_in_simt"` (**default**) | Hybrid: structured access stays on SIMD; discrete access prefers SIMT templates | `Triton IR → Linalg IR → AscendNPU IR` |
+| `"simt_only"` | Pure SIMT: send Triton IR directly to AscendNPU IR | `Triton IR → AscendNPU IR` |
 
 Usage examples:
 
@@ -234,35 +234,49 @@ kernel[grid](..., compile_mode="simt_only", num_warps=32)
 
 ##### 3.2.3.2 Compilation Flow by Mode
 
-```text
-                    compile_mode
-                          │
-          ┌───────────────┼───────────────────┐
-          ▼               ▼                   ▼
-       "simd"   "unstructured_in_simt"    "simt_only"
-          │               │                   │
-          │               │                   └─► Direct pure SIMT compilation via NPU IR
-          ▼               ▼
-   Discrete mask handling
-          │               │
-   Split into contiguous/   Mark for downstream
-   discrete parts and       SIMT handling when
-   handle via SIMD          conditions are met
-          ▼               ▼
-   Unstructured access handling
-          │               │
-   Expand to scalar loops   Prefer indirect load/store
-                            SIMT templates; fall back
-                            to scalar loops if needed
-          ▼               ▼
-   TritonToLinalg → npubin
+```mermaid
+flowchart TD
+    A[compile_mode] --> B["simd"]
+    A --> C["unstructured_in_simt"]
+    A --> D["simt_only"]
+
+    %% simt_only branch
+    D --> D1[Send Triton IR directly for pure SIMT compilation, Triton IR → AscendNPU IR]
+
+    %% simd full path
+    B --> B1[discrete-mask-access-conversion]
+    B1 --> B2[Split into contiguous/discrete parts and handle via SIMD]
+    B2 --> B3[triton-to-unstructured]
+    B3 --> B4[Expand discrete access into scalar loops]
+    B4 --> B5[TritonToLinalg]
+    B5 --> B6[AscendNPU IR]
+
+    %% unstructured_in_simt full path
+    C --> C1[discrete-mask-access-conversion]
+    C1 --> C2[Mark when conditions are met and defer to downstream SIMT handling]
+    C2 --> C3[triton-to-unstructured]
+    C3 --> C4{Can discrete access be converted to indirect_load/store SIMT templates?}
+    C4 -- Yes --> B5
+    C4 -- No --> C5[Fall back to scalar loops]
+    C5 --> B5
+
+    %% styling
+    classDef root fill:#e6f7ff,stroke:#1890ff
+    classDef pass fill:#fff7e6,stroke:#fa8c16,stroke-width:2px
+    classDef logic fill:#f0fff4,stroke:#52c41a
+    classDef simtOnly fill:#f0f2f5,stroke:#8c8c8c
+
+    class A root
+    class B1,C1,B3,C3,B5,B6 pass
+    class B2,B4,C2,C4,C5 logic
+    class D,D1 simtOnly
 ```
 
 | Stage | `"simd"` | `"unstructured_in_simt"` | `"simt_only"` |
 |------|----------|--------------------------|---------------|
 | Discrete mask handling | Split into contiguous/discrete bounds and handle with load + select / store | On Ascend 950 with tensor rank ≤ 5: mark and defer to downstream; otherwise same as left | Not run |
 | Unstructured access | Expand to scalar loops | Prefer SIMT indirect access (rank ≤ 5); fall back to scalar loops on failure | Not run |
-| TritonToLinalg | Standard linalg lowering | Standard linalg lowering | Not run |
+| TritonToLinalg | Standard Linalg IR lowering | Standard Linalg IR lowering | Not run |
 
 ##### 3.2.3.3 Hybrid Mode: SIMT Only for Discrete Access
 
@@ -275,15 +289,15 @@ Hybrid mode does **not** move the entire kernel to SIMT. Only discrete / unstruc
 2. **Unstructured access handling**
    - In Ascend 950 hybrid mode, unstructured access or marked discrete access uses the SIMT fast path:
      - `load` / `store` → `indirect_load` / `indirect_store` (rank ≤ 5)
-     - atomic operations → `hivm.custom(symbol="__builtin_indirect_atomic")`
+     - `atomic` operations → `hivm.custom(symbol="__builtin_indirect_atomic")`
    - If conditions are not met, fall back to scalar loops (same as `"simd"`).
 
 3. **TritonToLinalg**
-   - Standard linalg lowering.
+   - Standard Linalg IR lowering.
 
 ##### 3.2.3.4 Pure SIMT (`simt_only`)
 
-`"simt_only"` skips the linalg path and sends TTIR directly to NPU IR for pure SIMT compilation.
+`"simt_only"` sends Triton IR directly to AscendNPU IR for pure SIMT compilation.
 
 #### 3.2.4 Ascend affinitive Operators
 

--- a/docs/en/architecture_design_and_core_features.md
+++ b/docs/en/architecture_design_and_core_features.md
@@ -87,6 +87,7 @@ This project extends the support for Huawei Ascend NPU (using the CANN software 
 | 15  | enable_linearize                              | NPU        | Autotune option. It enables or disables the linearization pass.|
 | 16  | enable_nd2nz_on_vector                        | NPU        | Autotune option (CV-fused kernels only). It enables or disables the ND (n-dimensional) to NZ (non-zero) layout transformation.|
 | 17  | auto_blockify_size                            | NPU        | Autotune option. It enables or disables AutoBlockify pass. It is ignored when TRITON_ALL_BLOCKS_PARALLEL is not set |
+| 18  | compile_mode                                  | NPU (950)  | Compilation mode: `"unstructured_in_simt"` (default) / `"simd"` / `"simt_only"`. |
 
 #### 3.2.2 SIMD Compiler
 
@@ -205,7 +206,86 @@ TritonToLinalg converts ttir to linalg ir.
 | triton-to-hivm | Processes the block synchronization operations (`tl.sync_block_all`, `tl.sync_block_set`, and `tl.sync_block_wait`) of Triton and converts them into the cross-core synchronization instruction in the `HIVM` dialect of Ascend NPU. These instructions are used to manage synchronization and data dependencies in the multi-core pipeline, which is the key to pipeline optimization.| TritonCustomOpToHIVMSyncOpConversion | Converts Triton synchronization instructions to HIVM synchronization instructions.<br>• `sync_block_all`: synchronizes blocks globally.<br>• `sync_block_set`: sets a synchronization point.<br>• `sync_block_wait`: waits for a synchronization point.|
 | triton-to-llvm | Converts the inline assembly operation (`tl.inline_assembly`) in Triton to the inline assembly in the LLVM dialect, and finally maps it to a CCE hardware intrinsic function of Ascend NPU.| ElementwiseInlineAsmOpConversion | Converts `triton::ElementwiseInlineAsmOp` to `LLVM::InlineAsmOp`.|
 
-#### 3.2.3 Ascend affinitive Operators
+#### 3.2.3 SIMT Compiler (Ascend 950)
+
+Ascend 950 adds SIMT support alongside the SIMD path to accelerate **unstructured / discrete** memory access (for example, indirect-index load/store).
+Developers choose the compilation path via `compile_mode`.
+
+##### 3.2.3.1 `compile_mode` Overview
+
+| `compile_mode` | Description | Compilation Path |
+|---|---|---|
+| `"simd"` | Pure SIMD: structured access via DMA; unstructured access via scalar loops | `ttir → ttadapter(linalg) → npubin` |
+| `"unstructured_in_simt"` (**default**) | Hybrid: structured access stays on SIMD; discrete / unstructured access prefers SIMT indirect access | `ttir → ttadapter(linalg) → npubin` |
+| `"simt_only"` | Pure SIMT: the entire kernel is compiled as pure SIMT | `ttir → npubin` |
+
+Usage examples:
+
+```python
+# Pure SIMD
+kernel[grid](..., compile_mode="simd")
+
+# Hybrid (default; discrete access on 950 prefers SIMT)
+kernel[grid](..., compile_mode="unstructured_in_simt")
+
+# Pure SIMT
+kernel[grid](..., compile_mode="simt_only", num_warps=32)
+```
+
+##### 3.2.3.2 Compilation Flow by Mode
+
+```text
+                    compile_mode
+                          │
+          ┌───────────────┼───────────────────┐
+          ▼               ▼                   ▼
+       "simd"   "unstructured_in_simt"    "simt_only"
+          │               │                   │
+          │               │                   └─► Direct pure SIMT compilation via NPU IR
+          ▼               ▼
+   Discrete mask handling
+          │               │
+   Split into contiguous/   Mark for downstream
+   discrete parts and       SIMT handling when
+   handle via SIMD          conditions are met
+          ▼               ▼
+   Unstructured access handling
+          │               │
+   Expand to scalar loops   Prefer indirect load/store
+                            SIMT templates; fall back
+                            to scalar loops if needed
+          ▼               ▼
+   TritonToLinalg → npubin
+```
+
+| Stage | `"simd"` | `"unstructured_in_simt"` | `"simt_only"` |
+|------|----------|--------------------------|---------------|
+| Discrete mask handling | Split into contiguous/discrete bounds and handle with load + select / store | On Ascend 950 with tensor rank ≤ 5: mark and defer to downstream; otherwise same as left | Not run |
+| Unstructured access | Expand to scalar loops | Prefer SIMT indirect access (rank ≤ 5); fall back to scalar loops on failure | Not run |
+| TritonToLinalg | Standard linalg lowering | Standard linalg lowering | Not run |
+
+##### 3.2.3.3 Hybrid Mode: SIMT Only for Discrete Access
+
+Hybrid mode does **not** move the entire kernel to SIMT. Only discrete / unstructured access points use SIMT; the rest stays on SIMD:
+
+1. **Discrete mask handling**
+   - If the mask is non-contiguous and Ascend 950, hybrid mode, and rank ≤ 5 are all satisfied: do not rewrite IR; only mark for downstream SIMT handling.
+   - Otherwise (pure SIMD or conditions not met): split the mask into contiguous / discrete parts, bound global memory access with contiguous bounds, and merge results via select.
+
+2. **Unstructured access handling**
+   - In Ascend 950 hybrid mode, unstructured access or marked discrete access uses the SIMT fast path:
+     - `load` / `store` → `indirect_load` / `indirect_store` (rank ≤ 5)
+     - atomic operations → `hivm.custom(symbol="__builtin_indirect_atomic")`
+   - If conditions are not met, fall back to scalar loops (same as `"simd"`).
+
+3. **TritonToLinalg**
+   - Standard linalg lowering.
+
+##### 3.2.3.4 Pure SIMT (`simt_only`)
+
+`"simt_only"` skips the linalg path and sends TTIR directly to NPU IR for pure SIMT compilation.
+
+#### 3.2.4 Ascend affinitive Operators
 
 | No.| Operator | Description|
 |---|---|---|

--- a/docs/en/environment_variable_and_compiler_options_reference.md
+++ b/docs/en/environment_variable_and_compiler_options_reference.md
@@ -112,3 +112,4 @@ The following table describes the options.
 | **Compiler pass** | `enable_linearize` | Version-dependent | Enables or disables the linearization pass. | `triton.Config` or launch meta-parameter |
 | **CV fusion/layout** | `enable_nd2nz_on_vector` | Default `False` | Enables or disables ND-to-NZ layout transformation on the Vector path. | `triton.Config` or launch meta-parameter |
 | **Large-grid optimization** | `auto_blockify_size` | Default `1` | Enables or disables AutoBlockify pass. Ignored when `TRITON_ALL_BLOCKS_PARALLEL` is not set. | launch meta-parameter or `triton.Config` |
+| **Compilation mode** | `compile_mode` | `"unstructured_in_simt"` (default), `"simd"`, `"simt_only"` | Controls SIMD / SIMT compilation on Ascend 950. `"simd"`: pure SIMD; `"unstructured_in_simt"`: hybrid (structured SIMD, discrete/unstructured access prefers SIMT indirect templates); `"simt_only"`: pure SIMT (`ttir→npubin`). | `triton.Config` or launch meta-parameter |

--- a/docs/zh/architecture_design_and_core_features.md
+++ b/docs/zh/architecture_design_and_core_features.md
@@ -215,9 +215,9 @@ TritonToLinalg converts ttir to linalg ir.
 
 | `compile_mode` | 含义 | 编译路径 |
 |---|---|---|
-| `"simd"` | 纯 SIMD：结构化访存走 DMA；非结构化走标量循环 | `ttir → ttadapter(linalg) → npubin` |
-| `"unstructured_in_simt"`（**默认**） | 混合：结构化仍走 SIMD；离散 / 非结构化尽量走 SIMT 间接访存 | `ttir → ttadapter(linalg) → npubin` |
-| `"simt_only"` | 纯 SIMT：整段 kernel 交 BiSheng 做纯 SIMT 编译 | `ttir → npubin` |
+| `"simd"` | 纯 SIMD：结构化访存走 DMA；非结构化走标量循环 | `Triton IR → Linalg IR → AscendNPU IR` |
+| `"unstructured_in_simt"`（**默认**） | 混合：结构化仍走 SIMD；离散访存尽量走 SIMT 模板 | `Triton IR → Linalg IR → AscendNPU IR` |
+| `"simt_only"` | 纯 SIMT：直接下发 Triton IR 给NPU IR处理 | `Triton IR → AscendNPU IR` |
 
 用法示例：
 
@@ -234,33 +234,50 @@ kernel[grid](..., compile_mode="simt_only", num_warps=32)
 
 ##### 3.2.3.2 三种模式的编译分流
 
-```text
-                    compile_mode
-                          │
-          ┌───────────────┼───────────────────┐
-          ▼               ▼                   ▼
-       "simd"   "unstructured_in_simt"    "simt_only"
-          │               │                   │
-          │               │                   └─► 直接交给 NPU IR 纯 SIMT 编译
-          ▼               ▼
-   离散 mask 处理
-          │               │
-   拆成连续/离散         满足条件则标记为
-   后用 SIMD 方式处理     「交给下游走 SIMT」
-          ▼               ▼
-   非结构化访存处理
-          │               │
-   展开为标量循环        尽量转为 间接 load/store SIMT 模板；
-                         无法转换则回退标量循环
-          ▼               ▼
-   TritonToLinalg → npubin
+```mermaid
+flowchart TD
+    A[compile_mode] --> B["simd"]
+    A --> C["unstructured_in_simt"]
+    A --> D["simt_only"]
+
+    %% simt_only 分支
+    D --> D1[直接下发 Triton IR，纯SIMT编译，Triton IR → AscendNPU IR]
+
+    %% simd 完整链路
+    B --> B1[discrete-mask-access-conversion]
+    B1 --> B2[拆成连续/离散后用 SIMD 方式处理]
+    B2 --> B3[triton-to-unstructured]
+    B3 --> B4[离散访存展开为标量循环]
+    B4 --> B5[TritonToLinalg]
+    B5 --> B6[AscendNPU IR]
+
+    %% unstructured_in_simt 完整链路
+    C --> C1[discrete-mask-access-conversion]
+    C1 --> C2[满足条件打上标记，下发下层SIMT处理]
+    C2 --> C3[triton-to-unstructured]
+    C3 --> C4{离散访存可转为 indirect_load/store SIMT 模板？}
+    C4 -- 是 --> B5
+    C4 -- 否 --> C5[回退标量循环]
+    C5 --> B5
+
+    %% 样式定义
+    classDef root fill:#e6f7ff,stroke:#1890ff
+    classDef pass fill:#fff7e6,stroke:#fa8c16,stroke-width:2px
+    classDef logic fill:#f0fff4,stroke:#52c41a
+    classDef simtOnly fill:#f0f2f5,stroke:#8c8c8c
+
+    %% 绑定样式
+    class A root
+    class B1,C1,B3,C3,B5,B6 pass
+    class B2,B4,C2,C4,C5 logic
+    class D,D1 simtOnly
 ```
 
 | 阶段 | `"simd"` | `"unstructured_in_simt"` | `"simt_only"` |
 |------|----------|--------------------------|---------------|
 | 离散 mask 处理 | 拆成连续/离散边界，用 load + select / store 处理 | Ascend 950 且张量维数 ≤ 5：标记后交给下游；否则同左 | 不运行 |
 | 非结构化访存 | 展开为标量循环 | 尽量转为 SIMT 间接访存（维数 ≤ 5）；失败则回退标量循环 | 不运行 |
-| TritonToLinalg | 常规 linalg 降级 | 常规 linalg 降级 | 不运行 |
+| TritonToLinalg | 常规 Linalg IR 降级 | 常规 Linalg IR 降级 | 不运行 |
 
 ##### 3.2.3.3 混合模式：只对离散访存走 SIMT
 
@@ -277,11 +294,11 @@ kernel[grid](..., compile_mode="simt_only", num_warps=32)
    - 不满足条件则回退为标量循环（与 `"simd"` 一致）。
 
 3. **TritonToLinalg**
-   - 常规 linalg 降级。
+   - 常规 Linalg IR 降级。
 
 ##### 3.2.3.4 纯 SIMT（`simt_only`）
 
-`"simt_only"` 跳过 linalg 路径，将 TTIR 直接交给 NPU IR 做纯 SIMT 编译。
+`"simt_only"` 直接下发 Triton IR 交给 AscendNPU IR 做纯 SIMT 编译。
 
 #### 3.2.4 Ascend affinitive Operators
 

--- a/docs/zh/architecture_design_and_core_features.md
+++ b/docs/zh/architecture_design_and_core_features.md
@@ -87,6 +87,7 @@
 | 15  | enable_linearize                              | NPU        | Autotune option: Enable or disable the linearization pass. |
 | 16  | enable_nd2nz_on_vector                        | NPU        | Autotune option (CV-fused kernels only): Enable or disable the ND (n-dimensional) to NZ (non-zero) layout transformation. |
 | 17  | auto_blockify_size                            | NPU        | Autotune option: Enable or disable AutoBlockify pass. It is ignored when TRITON_ALL_BLOCKS_PARALLEL is not set |
+| 18  | compile_mode                                  | NPU (950)  | Compilation mode: `"unstructured_in_simt"` (default) / `"simd"` / `"simt_only"`. |
 
 #### 3.2.2 SIMD compiler
 
@@ -205,7 +206,84 @@ TritonToLinalg converts ttir to linalg ir.
 | triton-to-hivm | 处理Triton的块同步操作 (`tl.sync_block_all`, `tl.sync_block_set`, `tl.sync_block_wait`)，将其转换为Ascend NPU的`HIVM`方言中的跨核心同步指令。这些指令用于管理多核流水线中的同步与数据依赖，是流水优化的关键。 | TritonCustomOpToHIVMSyncOpConversion | 实现Triton同步指令到HIVM同步指令的转换：<br>• `sync_block_all`：全局块同步<br>• `sync_block_set`：设置同步点<br>• `sync_block_wait`：等待同步点 |
 | triton-to-llvm | 将Triton中的内联汇编操作 (`tl.inline_assembly`) 转换为LLVM方言的内联汇编，并最终映射为Ascend NPU的CCE硬件固有函数（Intrinsics） | ElementwiseInlineAsmOpConversion | 将 `triton::ElementwiseInlineAsmOp` 转换为 `LLVM::InlineAsmOp` |
 
-#### 3.2.3 Ascend affinitive Operators
+#### 3.2.3 SIMT Compiler（Ascend 950）
+
+昇腾 950 在 SIMD 路径之外增加 SIMT 能力，用于加速**非结构化 / 离散**访存（如间接索引的 load/store）。
+开发者通过 `compile_mode` 选择编译路径。
+
+##### 3.2.3.1 `compile_mode` 说明
+
+| `compile_mode` | 含义 | 编译路径 |
+|---|---|---|
+| `"simd"` | 纯 SIMD：结构化访存走 DMA；非结构化走标量循环 | `ttir → ttadapter(linalg) → npubin` |
+| `"unstructured_in_simt"`（**默认**） | 混合：结构化仍走 SIMD；离散 / 非结构化尽量走 SIMT 间接访存 | `ttir → ttadapter(linalg) → npubin` |
+| `"simt_only"` | 纯 SIMT：整段 kernel 交 BiSheng 做纯 SIMT 编译 | `ttir → npubin` |
+
+用法示例：
+
+```python
+# 纯 SIMD
+kernel[grid](..., compile_mode="simd")
+
+# 混合（默认；950 上离散访存优先走 SIMT）
+kernel[grid](..., compile_mode="unstructured_in_simt")
+
+# 纯 SIMT
+kernel[grid](..., compile_mode="simt_only", num_warps=32)
+```
+
+##### 3.2.3.2 三种模式的编译分流
+
+```text
+                    compile_mode
+                          │
+          ┌───────────────┼───────────────────┐
+          ▼               ▼                   ▼
+       "simd"   "unstructured_in_simt"    "simt_only"
+          │               │                   │
+          │               │                   └─► 直接交给 NPU IR 纯 SIMT 编译
+          ▼               ▼
+   离散 mask 处理
+          │               │
+   拆成连续/离散         满足条件则标记为
+   后用 SIMD 方式处理     「交给下游走 SIMT」
+          ▼               ▼
+   非结构化访存处理
+          │               │
+   展开为标量循环        尽量转为 间接 load/store SIMT 模板；
+                         无法转换则回退标量循环
+          ▼               ▼
+   TritonToLinalg → npubin
+```
+
+| 阶段 | `"simd"` | `"unstructured_in_simt"` | `"simt_only"` |
+|------|----------|--------------------------|---------------|
+| 离散 mask 处理 | 拆成连续/离散边界，用 load + select / store 处理 | Ascend 950 且张量维数 ≤ 5：标记后交给下游；否则同左 | 不运行 |
+| 非结构化访存 | 展开为标量循环 | 尽量转为 SIMT 间接访存（维数 ≤ 5）；失败则回退标量循环 | 不运行 |
+| TritonToLinalg | 常规 linalg 降级 | 常规 linalg 降级 | 不运行 |
+
+##### 3.2.3.3 混合模式：只对离散访存走 SIMT
+
+混合模式**不会**把整个 kernel 切到 SIMT，只对离散 / 非结构化访存点走 SIMT，其余仍走 SIMD：
+
+1. **离散 mask 处理**
+   - 若判定为非连续 mask，且满足 Ascend 950、混合模式、维数 ≤ 5：不改写 IR，只标记「下游走 SIMT」。
+   - 否则（纯 SIMD 或不满足条件）：将 mask 拆成连续 / 离散部分，用连续边界限定全局内存访问，再通过 select 合并结果。
+
+2. **非结构化访存处理**
+   - 在 Ascend 950 混合模式下，对非结构化访存或已标记的离散访存走 SIMT 快速通道：
+     - `load` / `store` → `indirect_load` / `indirect_store`（维数 ≤ 5）
+     - `atomic` 操作 → `hivm.custom(symbol="__builtin_indirect_atomic")`
+   - 不满足条件则回退为标量循环（与 `"simd"` 一致）。
+
+3. **TritonToLinalg**
+   - 常规 linalg 降级。
+
+##### 3.2.3.4 纯 SIMT（`simt_only`）
+
+`"simt_only"` 跳过 linalg 路径，将 TTIR 直接交给 NPU IR 做纯 SIMT 编译。
+
+#### 3.2.4 Ascend affinitive Operators
 
 | 序号 | Operator | 功能描述 |
 |---|---|---|

--- a/docs/zh/environment_variable_and_compiler_options_reference.md
+++ b/docs/zh/environment_variable_and_compiler_options_reference.md
@@ -114,3 +114,4 @@ if __name__ == "__main__":
 | **编译 Pass** | `enable_linearize` | 版本相关 | 启用或禁用 linearization pass。 | `triton.Config` 或 launch meta-parameter |
 | **CV 融合/layout** | `enable_nd2nz_on_vector` | 默认 `False` | 启用或禁用 Vector 路径上的 ND 到 NZ 布局转换。 | `triton.Config` 或 launch meta-parameter |
 | **大 grid 优化** | `auto_blockify_size` | 默认 `1` | 启用或禁用 AutoBlockify pass。未设置 `TRITON_ALL_BLOCKS_PARALLEL` 时忽略。 | launch meta-parameter 或 `triton.Config` |
+| **编译模式** | `compile_mode` | `"unstructured_in_simt"`（默认）、`"simd"`、`"simt_only"` | 控制 Ascend 950 上 SIMD / SIMT 编译路径。`"simd"`：纯 SIMD；`"unstructured_in_simt"`：混合（结构化 SIMD，离散/非结构化尽量走 SIMT 间接访存模板）；`"simt_only"`：纯 SIMT （`ttir→npubin`）。| `triton.Config` 或 launch meta-parameter |


### PR DESCRIPTION
## Summary
Add documentation for `compile_mode` on Ascend 950 to help developers understand the three compilation modes (`simd` / `unstructured_in_simt` / `simt_only`) and how compilation is routed.

## Related ISSUE
https://gitcode.com/Ascend/triton-ascend/issues/401

## What Is Included
- `docs/zh/architecture_design_and_core_features.md`: add section 3.2.3 SIMT Compiler with mode descriptions, usage examples, and compilation flow
- `docs/zh/environment_variable_and_compiler_options_reference.md`: add `compile_mode` option description
- `docs/en/architecture_design_and_core_features.md`: same updates as the Chinese version
- `docs/en/environment_variable_and_compiler_options_reference.md`: same updates as the Chinese version

## User Impact
No code behavior change. Documentation only.

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
  - [x] This PR does not need a test because it only updates documentation.
  - [ ] I have added tests.
- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices).
