### PR TITLE
[ssbuffer](feat) add UnifyStoreBlockPass

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -117,6 +117,8 @@ inline bool isCubeOp(Operation *op) {
 
 bool isVectorOnlyOp(Operation *op);
 
+bool isScalarLike(Value value);
+
 } // namespace CVPipeline
 } // namespace mlir
 

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h
@@ -57,20 +57,19 @@ bool willCreateCycle(llvm::ArrayRef<Operation *> opsToUnify,
                      ComputeBlockIdManager &bm);
 
 /**
- * @brief Clone scalar-producing ops shared between a fixpipe pattern and other
- * blocks
+ * @brief Clone scalar-producing ops shared between a pattern and other blocks
  *
  * Walks the pattern's scalar-producing ops in reverse topological order. If
  * such an op's result is used by an op that is outside both the pattern and
- * the matmul's original block, clones the op and redirects those external uses
- * to the clone, keeping the original for pattern-internal use. This prevents
- * the cross-block dependency cycle that would otherwise appear after the
- * fixpipe fusion moves the pattern ops into the matmul's block_id.
+ * the target's original block (matchedOps[0]), clones the op and redirects
+ * those external uses to the clone, keeping the original for pattern-internal
+ * use. This prevents the cross-block dependency cycle that would otherwise
+ * appear after unifying the pattern ops into matchedOps[0]'s block_id.
  *
  * @param bmOriginal "Original" block_id view (before any fusion happens in the
  *                   caller); used to decide whether a user is in a different
- *                   block than the matmul (matchedOps[0]).
- * @param matchedOps The op set of one fixpipe pattern (matmul first).
+ *                   block than the target (matchedOps[0]).
+ * @param matchedOps The op set of one pattern (target op first).
  */
 void cloneScalarOpsForCrossBlockUses(ComputeBlockIdManager &bmOriginal,
                                      SetVector<Operation *> &matchedOps);

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h
@@ -56,6 +56,25 @@ bool willCreateCycle(llvm::ArrayRef<Operation *> opsToUnify,
                      const MemoryDependenceGraph &memGraph, int targetBlockId,
                      ComputeBlockIdManager &bm);
 
+/**
+ * @brief Clone scalar-producing ops shared between a fixpipe pattern and other
+ * blocks
+ *
+ * Walks the pattern's scalar-producing ops in reverse topological order. If
+ * such an op's result is used by an op that is outside both the pattern and
+ * the matmul's original block, clones the op and redirects those external uses
+ * to the clone, keeping the original for pattern-internal use. This prevents
+ * the cross-block dependency cycle that would otherwise appear after the
+ * fixpipe fusion moves the pattern ops into the matmul's block_id.
+ *
+ * @param bmOriginal "Original" block_id view (before any fusion happens in the
+ *                   caller); used to decide whether a user is in a different
+ *                   block than the matmul (matchedOps[0]).
+ * @param matchedOps The op set of one fixpipe pattern (matmul first).
+ */
+void cloneScalarOpsForCrossBlockUses(ComputeBlockIdManager &bmOriginal,
+                                     SetVector<Operation *> &matchedOps);
+
 } // namespace CVPipeline
 } // namespace mlir
 

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
@@ -36,6 +36,8 @@ std::unique_ptr<OperationPass<ModuleOp>> createMergeVectorIfBlockPass();
 void registerMergeVectorIfBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createMergeCubeForBlockPass();
 void registerMergeCubeForBlockPass();
+std::unique_ptr<OperationPass<ModuleOp>> createUnifyStoreBlockPass();
+void registerUnifyStoreBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createFixpipeOptPass();
 
 } // namespace triton

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -10,6 +10,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/IR/Operation.h"
 
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
@@ -128,6 +129,39 @@ bool isOnlyDirectlyUse(Operation *preOp, Operation *nextOp,
     return false;
   }
   return (*allusers.begin()) == nextOp;
+}
+
+/** Determines if a value is "scalar-like" based on the following criteria:
+ 1. True scalar types (integer, index, or float)
+ 2. Tensor types with empty shape (e.g., tensor<f32>)
+ 3. Constant tensors where all elements have the same value (splat constants)
+ 4. Tensors with shape where all dimensions equal 1 (single-element tensors)
+ */
+bool isScalarLike(Value value) {
+  Type type = value.getType();
+  auto shapedType = dyn_cast<ShapedType>(type);
+
+  // 1. true scalar (int / index / float)
+  if (!shapedType) {
+    return type.isIntOrIndexOrFloat();
+  }
+
+  // 2. tensor with empty shape (e.g. tensor<f32>)
+  ArrayRef<int64_t> shape = shapedType.getShape();
+  if (shape.empty()) {
+    return true;
+  }
+
+  // 3. splat constant tensor (all elements identical)
+  Attribute attr;
+  if (matchPattern(value, m_Constant(&attr))) {
+    auto denseAttr = dyn_cast<DenseIntOrFPElementsAttr>(attr);
+    return denseAttr && denseAttr.isSplat() &&
+           denseAttr.getElementType().isIntOrIndexOrFloat();
+  }
+
+  // 4. single-element tensor (all dims == 1)
+  return llvm::all_of(shape, [](int64_t dim) { return dim == 1; });
 }
 
 } // namespace CVPipeline

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
@@ -23,9 +23,13 @@
 #include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
+#include "mlir/Analysis/TopologicalSortUtils.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/Operation.h"
+#include "triton/Analysis/Utility.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
 
@@ -174,6 +178,39 @@ bool willCreateCycle(llvm::ArrayRef<Operation *> opsToUnify,
   }
 
   return hasCycle;
+}
+
+void cloneScalarOpsForCrossBlockUses(ComputeBlockIdManager &bmOriginal,
+                                     SetVector<Operation *> &matchedOps) {
+  auto sorted = mlir::topologicalSort(matchedOps);
+  for (Operation *op : llvm::reverse(sorted)) {
+    if (op->getNumResults() == 1 &&
+        CVPipeline::isScalarLike(op->getResult(0))) {
+      // replace op not in matchedOps with cloned op, and keep original op for
+      // other pattern.
+      SmallVector<OpOperand *> otherUses;
+      for (auto &use : op->getResult(0).getUses()) {
+        Operation *userOp = use.getOwner();
+        auto userInBlock =
+            CVPipeline::getAncestorInBlock(userOp, op->getBlock());
+        if (!userInBlock)
+          continue;
+        if (llvm::find(matchedOps, userInBlock) == matchedOps.end() &&
+            bmOriginal.getBlockIdByOp(userInBlock) !=
+                bmOriginal.getBlockIdByOp(matchedOps[0])) {
+          otherUses.push_back(&use);
+        }
+      }
+      if (otherUses.size() > 0) {
+        LOG_DEBUG("now cloned: " << *op << "\n");
+        OpBuilder builder(op);
+        auto clonedOp = builder.clone(*op);
+        for (auto use : otherUses) {
+          (*use).set(clonedOp->getResult(0));
+        }
+      }
+    }
+  }
 }
 
 } // namespace CVPipeline

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
@@ -43,6 +43,7 @@
 #include "mlir/Support/LLVM.h"
 
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
 #include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
@@ -241,42 +242,9 @@ bool FixpipeOptPass::isValidTrunc(Operation *op) {
   return false;
 }
 
-/** Determines if a value is "scalar-like" based on the following criteria:
- 1. True scalar types (integer, index, or float)
- 2. Tensor types with empty shape (e.g., tensor<f32>)
- 3. Constant tensors where all elements have the same value (splat constants)
- 4. Tensors with shape where all dimensions equal 1 (single-element tensors)
- */
-static bool isScalarLike(Value value) {
-  Type type = value.getType();
-  auto shapedType = dyn_cast<ShapedType>(type);
-
-  // 1. scalar
-  if (!shapedType) {
-    return type.isIntOrIndexOrFloat();
-  }
-
-  // 2. tensor<f32> with empty shape is also considered scalar-like
-  ArrayRef<int64_t> shape = shapedType.getShape();
-  if (shape.empty()) {
-    return true;
-  }
-
-  // 3. tensor with constant value
-  Attribute attr;
-  if (matchPattern(value, m_Constant(&attr))) {
-    auto denseAttr = dyn_cast<DenseIntOrFPElementsAttr>(attr);
-    return denseAttr && denseAttr.isSplat() &&
-           denseAttr.getElementType().isIntOrIndexOrFloat();
-  }
-
-  // 4. tensor with one element
-  return llvm::all_of(shape, [](int64_t dim) { return dim == 1; });
-}
-
 void transSource(Value value, SetVector<Operation *> &matchedOps,
                  Block *block) {
-  if (!isScalarLike(value)) {
+  if (!CVPipeline::isScalarLike(value)) {
     return;
   }
 
@@ -324,7 +292,7 @@ bool FixpipeOptPass::isValidMul(Operation *op, Value matmulValue,
   }
   auto quantScalarValue =
       op->getOperand(0) == matmulValue ? op->getOperand(1) : op->getOperand(0);
-  if (isScalarLike(quantScalarValue)) {
+  if (CVPipeline::isScalarLike(quantScalarValue)) {
     transSource(quantScalarValue, matchedOps, op->getBlock());
     return true;
   }
@@ -335,7 +303,7 @@ bool FixpipeOptPass::isValidMul(Operation *op, Value matmulValue,
       auto operands = fillOp->getOperands();
       if (!operands.empty()) {
         Value fillValue = operands[0];
-        if (isScalarLike(fillValue)) {
+        if (CVPipeline::isScalarLike(fillValue)) {
           if (llvm::find(matchedOps, fillOp) == matchedOps.end() &&
               fillOp.getBlock() == op->getBlock()) {
             matchedOps.insert(fillOp);
@@ -633,32 +601,7 @@ void FixpipeOptPass::runOnOperation() {
   */
   auto bmOriginal = CVPipeline::ComputeBlockIdManager(module);
   for (auto &matchedOps : allMatchedPatterns) {
-    auto sorted = mlir::topologicalSort(matchedOps);
-    for (Operation *op : llvm::reverse(sorted)) {
-      if (op->getNumResults() == 1 && isScalarLike(op->getResult(0))) {
-        // replace op not in matchedOps with cloned op, and keep original op for
-        // other pattern.
-        SmallVector<OpOperand *> otherUses;
-        for (auto &use : op->getResult(0).getUses()) {
-          Operation *userOp = use.getOwner();
-          auto userInBlock =
-              CVPipeline::getAncestorInBlock(userOp, op->getBlock());
-          if (llvm::find(matchedOps, userInBlock) == matchedOps.end() &&
-              bmOriginal.getBlockIdByOp(userInBlock) !=
-                  bmOriginal.getBlockIdByOp(matchedOps[0])) {
-            otherUses.push_back(&use);
-          }
-        }
-        if (otherUses.size() > 0) {
-          LOG_DEBUG("now cloned: " << *op << "\n");
-          OpBuilder builder(op);
-          auto clonedOp = builder.clone(*op);
-          for (auto use : otherUses) {
-            (*use).set(clonedOp->getResult(0));
-          }
-        }
-      }
-    }
+    CVPipeline::cloneScalarOpsForCrossBlockUses(bmOriginal, matchedOps);
   }
 
   auto bm = CVPipeline::ComputeBlockIdManager(module);

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyStoreBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyStoreBlockPass.cpp
@@ -52,7 +52,7 @@ using namespace triton;
 
 namespace {
 
-static bool isStoreOp(Operation *op) {
+static bool isStoreOp(const Operation *op) {
   return isa<bufferization::MaterializeInDestinationOp>(op) ||
          isa<hivm::StoreOp>(op);
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyStoreBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyStoreBlockPass.cpp
@@ -1,0 +1,380 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+static constexpr const char *DEBUG_TYPE = "unify-store-block";
+#define LOG_DEBUG(...)                                                         \
+  LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
+
+using namespace mlir;
+using namespace triton;
+
+namespace {
+
+static bool isStoreOp(Operation *op) {
+  return isa<bufferization::MaterializeInDestinationOp>(op) ||
+         isa<hivm::StoreOp>(op);
+}
+
+static Value getStoreSource(Operation *storeOp) {
+  if (auto materialize =
+          dyn_cast<bufferization::MaterializeInDestinationOp>(storeOp)) {
+    return materialize.getSource();
+  }
+  if (auto hivmStore = dyn_cast<hivm::StoreOp>(storeOp)) {
+    return hivmStore.getSrc();
+  }
+  return Value();
+}
+
+static Value getStoreDest(Operation *storeOp) {
+  if (auto materialize =
+          dyn_cast<bufferization::MaterializeInDestinationOp>(storeOp)) {
+    return materialize.getDest();
+  }
+  if (auto hivmStore = dyn_cast<hivm::StoreOp>(storeOp)) {
+    return hivmStore.getDst();
+  }
+  return Value();
+}
+
+static bool isViewOrExtractSliceOp(Operation *op) {
+  return isa<ViewLikeOpInterface>(op) || isa<tensor::ExtractSliceOp>(op);
+}
+
+static Value getViewSourceValue(Operation *viewOp) {
+  if (auto viewLike = dyn_cast<ViewLikeOpInterface>(viewOp)) {
+    return viewLike.getViewSource();
+  }
+  if (auto extract = dyn_cast<tensor::ExtractSliceOp>(viewOp)) {
+    return extract.getSource();
+  }
+  return Value();
+}
+
+static Operation *traceProducerOp(Operation *storeOp,
+                                  SmallVector<Operation *> &dataViewOps) {
+  Value cur = getStoreSource(storeOp);
+  while (Operation *defOp = cur.getDefiningOp()) {
+    // view-like op (incl. tensor.extract_slice): transparent, pierce through
+    if (isViewOrExtractSliceOp(defOp)) {
+      dataViewOps.push_back(defOp);
+      cur = getViewSourceValue(defOp);
+      continue;
+    }
+    // scalar-producing op: skip
+    if (CVPipeline::isScalarLike(cur)) {
+      return nullptr; // producer is a scalar-like op
+    }
+    // hit: a real compute op; only unifiable if it has the same core type as
+    // storeOp
+    if (CVPipeline::getOpCoreType(defOp) !=
+        CVPipeline::getOpCoreType(storeOp)) {
+      LOG_DEBUG("Producer op is not VECTOR_ONLY: " << *defOp << "\n");
+      return nullptr;
+    }
+    LOG_DEBUG("Find producer op: " << *defOp);
+    return defOp;
+  }
+  LOG_DEBUG("Could not find producer op!");
+  return nullptr; // reached a block argument (iter_arg / gm arg)
+}
+
+/**
+ * @brief Collect view ops (data chain + dest chain) to unify, filtered by
+ * block_id.
+ *
+ * Only view ops whose current block_id equals storeBlockId are appended to
+ * @p ops (per design §5.1 block_id filter rule).
+ */
+static void collectViewOpsToUnify(SmallVector<Operation *> &ops,
+                                  Operation *storeOp,
+                                  const SmallVector<Operation *> &dataViewOps,
+                                  CVPipeline::ComputeBlockIdManager &bm,
+                                  SmallPtrSet<Operation *, 16> &seen) {
+  auto addIfMatch = [&](Operation *op) {
+    if (bm.getBlockIdByOp(op) == bm.getBlockIdByOp(storeOp) &&
+        seen.insert(op).second) {
+      ops.push_back(op);
+    }
+  };
+
+  for (Operation *viewOp : dataViewOps) {
+    addIfMatch(viewOp);
+  }
+
+  // dest-chain view ops: walk up the dest memref's view chain and unify each
+  // view op whose block_id matches storeOp's block_id.
+  Value cur = getStoreDest(storeOp);
+  while (Operation *defOp = cur.getDefiningOp()) {
+    if (!isViewOrExtractSliceOp(defOp)) {
+      break;
+    }
+    addIfMatch(defOp);
+    cur = getViewSourceValue(defOp);
+  }
+}
+
+/**
+ * @brief Recursively collect scalar-like dependencies within the same big
+ * block.
+ *
+ * For every scalar-like operand of each op in @p ops (and of @p storeOp's
+ * control-flow ancestor ops, e.g. scf.for lb/ub/step), append its defining op
+ * only if it lives in the same big block as @p storeOp. Scalars defined in
+ * outer blocks (e.g. func-level constants) are skipped, because moving them
+ * across blocks is unsafe and they are typically shared by many blocks.
+ */
+static void collectScalarDeps(SmallVector<Operation *> &ops, Operation *storeOp,
+                              CVPipeline::ComputeBlockIdManager &bm,
+                              SmallPtrSet<Operation *, 16> &seen) {
+  SmallVector<Operation *> worklist(ops.begin(), ops.end());
+
+  for (Operation *p = storeOp->getParentOp(); p && !isa<ModuleOp>(p);
+       p = p->getParentOp()) {
+    if (isa<LoopLikeOpInterface>(p) || isa<scf::IfOp>(p)) {
+      worklist.push_back(p);
+    }
+  }
+
+  while (!worklist.empty()) {
+    Operation *cur = worklist.pop_back_val();
+    for (Value operand : cur->getOperands()) {
+      // only scalar-like operands are collected; non-scalar operands
+      // belong to data/dest chains or external blocks
+      if (!CVPipeline::isScalarLike(operand)) {
+        continue;
+      }
+      Operation *defOp = operand.getDefiningOp();
+      if (!defOp) {
+        continue; // block argument, no block_id to change
+      }
+      // only collect scalar ops in the same big block as storeOp;
+      // outer-block scalars (e.g. func-level constants) are skipped.
+      if (defOp->getBlock() != storeOp->getBlock()) {
+        continue;
+      }
+      if (!seen.insert(defOp).second) {
+        continue;
+      }
+      ops.push_back(defOp);
+      worklist.push_back(defOp); // recurse on its operands
+    }
+  }
+}
+
+/**
+ * @brief Assemble the full set of ops whose block_id should be unified.
+ *
+ * opsToUnify = {store} + viewOps (data + dest, block_id filtered) +
+ *              scalarDeps (recursively collected, block_id filtered).
+ */
+static SmallVector<Operation *>
+collectOpsToUnify(Operation *storeOp,
+                  const SmallVector<Operation *> &dataViewOps,
+                  CVPipeline::ComputeBlockIdManager &bm) {
+  SmallVector<Operation *> opsToUnify;
+  opsToUnify.push_back(storeOp);
+
+  SmallPtrSet<Operation *, 16> seen;
+  seen.insert(storeOp);
+
+  collectViewOpsToUnify(opsToUnify, storeOp, dataViewOps, bm, seen);
+  collectScalarDeps(opsToUnify, storeOp, bm, seen);
+
+  for (Operation *op : opsToUnify) {
+    LOG_DEBUG("opToUnify: " << *op);
+  }
+  return opsToUnify;
+}
+
+/**
+ * @brief Match a store pattern: trace producer, collect ops to unify.
+ *
+ * @return true if the pattern is matched and ready for apply, false to skip.
+ *
+ * @note producer is inserted as the first element of @p matchedOps (required
+ *       by cloneScalarOpsForCrossBlockUses to identify the target block),
+ *       followed by the store op, view ops, and scalar dependencies.
+ */
+static bool matchStorePattern(Operation *storeOp,
+                              CVPipeline::ComputeBlockIdManager &bm,
+                              SetVector<Operation *> &matchedOps) {
+  LOG_DEBUG("Start from storeOp: " << *storeOp);
+  int storeBlockId = bm.getBlockIdByOp(storeOp);
+  if (storeBlockId == -1) {
+    LOG_DEBUG("storeOp has no block_id, cannot unify! ");
+    return false;
+  }
+
+  // Step 1: trace producer op from store.source, skipping views + scalars,
+  //         and collect all viewops in the data chain.
+  SmallVector<Operation *> dataViewOps;
+  Operation *producer = traceProducerOp(storeOp, dataViewOps);
+  if (!producer) {
+    return false; // block argument / fully-scalar chain / core_type mismatch ->
+                  // skip
+  }
+
+  int targetBlockId = bm.getBlockIdByOp(producer);
+  if (targetBlockId == -1 || targetBlockId == storeBlockId) {
+    LOG_DEBUG("ProducerOp has no block_id, or block_id is the same as "
+              "storeOp's, no need to unify\n");
+    return false; // producer has no block_id, cannot unify
+  }
+
+  // Step 2: build matchedOps = {producer} + {store} + viewOps + scalarDeps.
+  //         producer first is required by cloneScalarOpsForCrossBlockUses.
+  matchedOps.insert(producer);
+  SmallVector<Operation *> opsToUnify =
+      collectOpsToUnify(storeOp, dataViewOps, bm);
+  matchedOps.insert(opsToUnify.begin(), opsToUnify.end());
+  return true;
+}
+
+/**
+ * @brief Apply store unify: cycle detection + block_id update.
+ *
+ * @return true on success, false if cycle detected (pattern is skipped).
+ */
+static bool applyStoreUnify(const SetVector<Operation *> &matchedOps,
+                            const CVPipeline::MemoryDependenceGraph &memGraph,
+                            CVPipeline::ComputeBlockIdManager &bm) {
+  Operation *producer = matchedOps[0];
+  int targetBlockId = bm.getBlockIdByOp(producer);
+
+  SmallVector<Operation *> opsToUnifyList(matchedOps.begin(), matchedOps.end());
+  if (CVPipeline::willCreateCycle(opsToUnifyList, memGraph, targetBlockId,
+                                  bm)) {
+    LOG_DEBUG("Cycle detected, cannot unify storeOp to producer!\n");
+    return false;
+  }
+
+  for (Operation *op : matchedOps) {
+    bm.updateBlockId(op, targetBlockId);
+  }
+  LOG_DEBUG("Successfully unify storeOps\n");
+  return true;
+}
+
+} // anonymous namespace
+
+class UnifyStoreBlockPass
+    : public PassWrapper<UnifyStoreBlockPass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(UnifyStoreBlockPass)
+
+  UnifyStoreBlockPass() = default;
+
+  StringRef getArgument() const override { return "unify-store-block"; }
+
+  StringRef getDescription() const override {
+    return "Merge store-semantic operations into the producer vector compute "
+           "block";
+  }
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    LOG_DEBUG("Before UnifyStoreBlock: " << *module);
+
+    auto &aa = getAnalysis<AliasAnalysis>();
+    CVPipeline::MemoryDependenceGraph memGraph(module, aa);
+    auto bm = CVPipeline::ComputeBlockIdManager(module);
+
+    // Phase 1: collect all matched store patterns (read-only, no modification).
+    //          Only VECTOR-core stores are candidates.
+    SmallVector<SetVector<Operation *>> allMatchedPatterns;
+    module.walk([&](Operation *op) {
+      if (isStoreOp(op) &&
+          CVPipeline::getOpCoreType(op) == CVPipeline::CoreType::VECTOR_ONLY) {
+        SetVector<Operation *> matchedOps;
+        if (matchStorePattern(op, bm, matchedOps)) {
+          allMatchedPatterns.push_back(std::move(matchedOps));
+        }
+      }
+    });
+    LOG_DEBUG("Found " << allMatchedPatterns.size() << " store patterns");
+
+    // Phase 2: clone scalar ops shared between a pattern and other blocks,
+    //          so that moving pattern ops into the producer's block_id does
+    //          not create cross-block dependency cycles.
+    //          In order to avoid cycle, clone scalar-like ops.
+    //          A   ->   D
+    //           ↘      ↗
+    //            B -> C
+    //          Now we want to fuse D to A, so clone C' scalarOps for
+    //          D dependencies to avoid cycle.
+    auto bmOriginal = CVPipeline::ComputeBlockIdManager(module);
+    for (auto &matchedOps : allMatchedPatterns) {
+      CVPipeline::cloneScalarOpsForCrossBlockUses(bmOriginal, matchedOps);
+    }
+
+    // Phase 3: for each pattern, cycle detection + block_id update.
+    //          Rebuild bm because cloning may have added new ops.
+    auto bmNew = CVPipeline::ComputeBlockIdManager(module);
+    for (auto &matchedOps : allMatchedPatterns) {
+      if (!applyStoreUnify(matchedOps, memGraph, bmNew)) {
+        for (Operation *op : matchedOps) {
+          LOG_DEBUG("Cannot set block id for ops: " << *op);
+        }
+      }
+    }
+
+    LOG_DEBUG("After UnifyStoreBlock: " << *module);
+  }
+};
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<OperationPass<ModuleOp>> createUnifyStoreBlockPass() {
+  return std::make_unique<UnifyStoreBlockPass>();
+}
+
+void registerUnifyStoreBlockPass() {
+  PassRegistration<UnifyStoreBlockPass> reg;
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
@@ -52,6 +52,8 @@ void ComputeBlockOptPass::runOnOperation() {
   pm.addPass(createMergeVectorIfBlockPass());
   pm.addPass(createReorderOpsByBlockIdPass());
 
+  pm.addPass(createUnifyStoreBlockPass());
+
   pm.addPass(createMergeCubeForBlockPass());
   pm.addPass(createReorderOpsByBlockIdPass());
 
@@ -85,6 +87,7 @@ void registerComputeBlockOptPasses() {
   registerPass(createMergeVectorIfBlockPass);
   registerPass(createMergeCubeForBlockPass);
   registerPass(createFixpipeOptPass);
+  registerPass(createUnifyStoreBlockPass);
 }
 
 } // namespace triton

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/unify_store_block.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/unify_store_block.mlir
@@ -1,0 +1,169 @@
+// RUN: triton-opt --unify-store-block %s | FileCheck %s
+
+module {
+  // ============================================
+  // Test 1: VECTOR producer hit - basic unification
+  //
+  // Pattern (from real kernel IR):
+  //   arith.truncf(VECTOR, block_id=7)
+  //     -> tensor.extract_slice(block_id=8)
+  //     -> bufferization.materialize_in_destination(block_id=8)
+  //   dest chain: memref.reinterpret_cast(block_id=8) ->
+  //   memref.subview(block_id=8)
+  //
+  // producer = arith.truncf (VECTOR_ONLY, block_id=7).
+  // The store chain (extract_slice, reinterpret_cast, subview, materialize)
+  // and the scalar dep (%c0 used by reinterpret_cast) are all at block_id=8.
+  // After pass: all unified to producer's block_id=7.
+  // ============================================
+  // CHECK-LABEL: func @test_vector_producer_hit
+  func.func @test_vector_producer_hit(%arg0: memref<?xf16> {tt.divisibility = 16 : i32}, %in: tensor<64x64xf32>) {
+    // CHECK: arith.constant {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    %c0 = arith.constant {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    // CHECK: arith.truncf %{{.*}} {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    %trunc = arith.truncf %in {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    %extract = tensor.extract_slice %trunc[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    // CHECK: memref.reinterpret_cast %{{.*}} {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+    %reinterpret = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [128, 64], strides: [64, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    %subview = memref.subview %reinterpret[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+    return
+  }
+
+  // ============================================
+  // Test 2: CUBE producer skip - no unification
+  //
+  // Pattern:
+  //   linalg.matmul(CUBE, block_id=1) -> tensor.extract_slice(block_id=2)
+  //     -> bufferization.materialize_in_destination(block_id=2)
+  //   (no truncf; producer traced directly to matmul)
+  //
+  // producer = linalg.matmul (CUBE_ONLY) -> pass skips this store.
+  // All block_ids remain unchanged.
+  // ============================================
+  // CHECK-LABEL: func @test_cube_producer_skip
+  func.func @test_cube_producer_skip(%arg0: memref<?xf16> {tt.divisibility = 16 : i32}, %A: tensor<64x64xf16>, %B: tensor<64x64xf16>, %init: tensor<64x64xf16>) {
+    // CHECK: arith.constant {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    %c0 = arith.constant {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    // CHECK: linalg.matmul {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"}
+    %matmul = linalg.matmul {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>) outs(%init : tensor<64x64xf16>) -> tensor<64x64xf16>
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    %extract = tensor.extract_slice %matmul[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    // CHECK: memref.reinterpret_cast %{{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+    %reinterpret = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [128, 64], strides: [64, 1] {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    %subview = memref.subview %reinterpret[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+    return
+  }
+
+  // ============================================
+  // Test 4: hivm.hir.store use case
+  //
+  // Same shape as Test 1 but using hivm.hir.store instead of
+  // bufferization.materialize_in_destination. Store source operand is the
+  // tensor %extract (getSrc()), dest is the memref %subview (getDst()).
+  //
+  // producer = arith.truncf (VECTOR_ONLY, block_id=57).
+  // store + extract_slice + subview chain unify to 57.
+  // ============================================
+  // CHECK-LABEL: func @test_hivm_store
+  func.func @test_hivm_store(%arg0: memref<?xf16> {tt.divisibility = 16 : i32}, %in: tensor<64x64xf32>) {
+    // %c0 feeds reinterpret_cast's offset (scalar dep), unified to 57.
+    // CHECK: arith.constant {ssbuffer.block_id = 57 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    %c0 = arith.constant {ssbuffer.block_id = 58 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    // CHECK: arith.truncf %{{.*}} {ssbuffer.block_id = 57 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    %trunc = arith.truncf %in {ssbuffer.block_id = 57 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 57 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    %extract = tensor.extract_slice %trunc[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 58 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    // CHECK: memref.reinterpret_cast %{{.*}} {ssbuffer.block_id = 57 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+    %reinterpret = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [128, 64], strides: [64, 1] {ssbuffer.block_id = 58 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 57 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    %subview = memref.subview %reinterpret[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 58 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    // CHECK: hivm.hir.store ins({{.*}} : tensor<64x64xf16>) outs({{.*}} : memref<64x64xf16, strided<[64, 1], offset: ?>>) {ssbuffer.block_id = 57 : i32, ssbuffer.core_type = "VECTOR"}
+    hivm.hir.store ins(%extract : tensor<64x64xf16>) outs(%subview : memref<64x64xf16, strided<[64, 1], offset: ?>>) {ssbuffer.block_id = 58 : i32, ssbuffer.core_type = "VECTOR"}
+    return
+  }
+
+  // ============================================
+  // Test 5: Multiple vector ops in chain - producer is the first vector
+  // encountered when tracing back from store (closest to store), not the
+  // upstream one.
+  //
+  // Data chain:
+  //   %v1 = truncf (id=67) -> %v2 = addf (id=68) -> extract_slice (id=69) -> store (id=69)
+  //
+  // traceProducerOp pierces extract_slice (view), hits %v2 (VECTOR_ONLY) and
+  // returns immediately. %v1 is NOT reached, so:
+  //   producer = %v2 (id=68), stays 68
+  //   %v1 stays 67 (not producer, not collected)
+  //   store + extract_slice + dest view chain + %c0 unify to 68
+  // ============================================
+  // CHECK-LABEL: func @test_multiple_vector_producer_first
+  func.func @test_multiple_vector_producer_first(%arg0: memref<?xf16> {tt.divisibility = 16 : i32}, %in: tensor<64x64xf32>) {
+    // %c0 feeds reinterpret_cast's offset (scalar dep), unified to 68.
+    // CHECK: arith.constant {ssbuffer.block_id = 68 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    %c0 = arith.constant {ssbuffer.block_id = 69 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    // upstream vector op, NOT the producer; stays 67.
+    // CHECK: arith.truncf %{{.*}} {ssbuffer.block_id = 67 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    %v1 = arith.truncf %in {ssbuffer.block_id = 67 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    // downstream vector op (closest to store), IS the producer; stays 68.
+    // CHECK: arith.addf %{{.*}}, %{{.*}} {ssbuffer.block_id = 68 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16>
+    %v2 = arith.addf %v1, %v1 {ssbuffer.block_id = 68 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16>
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 68 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    %extract = tensor.extract_slice %v2[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 69 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    // CHECK: memref.reinterpret_cast %{{.*}} {ssbuffer.block_id = 68 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+    %reinterpret = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [128, 64], strides: [64, 1] {ssbuffer.block_id = 69 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 68 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    %subview = memref.subview %reinterpret[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 69 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 68 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 69 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+    return
+  }
+
+  // ============================================
+  // Test 6: clone chained scalar ops (incl. constant) shared between store
+  // pattern and external block.
+  // ============================================
+  // CHECK-LABEL: func @test_clone_scalar_cross_block
+  func.func @test_clone_scalar_cross_block(%arg0: memref<?xf16> {tt.divisibility = 16 : i32}, %in: tensor<64x64xf32>, %idx: index) {
+    %step = arith.constant {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"} 64 : index
+    %c64 = arith.constant {ssbuffer.block_id = 13 : i32, ssbuffer.core_type = "VECTOR"} 32 : index
+    // clone of %step (inserted before original): keeps block 12, feeds clones of %sub/%add.
+    // CHECK: arith.constant {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"} 64 : index
+    // original %step: stays block 12, feeds originals of %sub/%add.
+    // CHECK: arith.constant {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"} 64 : index
+    // %c64 (external constant): stays block 13, feeds %ext.
+    // CHECK: arith.constant {ssbuffer.block_id = 13 : i32, ssbuffer.core_type = "VECTOR"} 32 : index
+    // producer stays block 12.
+    // CHECK: arith.truncf %{{.*}} {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    %trunc = arith.truncf %in {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    %extract = tensor.extract_slice %trunc[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 14 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    // clone of %sub: keeps block 13 (inserted before original, feeds clone of %add).
+    // CHECK: arith.subi %{{.*}}, %{{.*}} {ssbuffer.block_id = 13 : i32, ssbuffer.core_type = "VECTOR"} : index
+    // original %sub: unified to producer's block 12 (feeds original %add).
+    // CHECK: arith.subi %{{.*}}, %{{.*}} {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"} : index
+    %sub = arith.subi %idx, %step {ssbuffer.block_id = 13 : i32, ssbuffer.core_type = "VECTOR"} : index
+    // clone of %add: keeps block 13 (inserted before original, feeds external %ext).
+    // CHECK: arith.addi %{{.*}}, %{{.*}} {ssbuffer.block_id = 13 : i32, ssbuffer.core_type = "VECTOR"} : index
+    // original %add: unified to producer's block 12 (feeds dest chain).
+    // CHECK: arith.addi %{{.*}}, %{{.*}} {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"} : index
+    %add = arith.addi %sub, %step {ssbuffer.block_id = 13 : i32, ssbuffer.core_type = "VECTOR"} : index
+    // dest chain uses original %add, unified to block 12.
+    // CHECK: memref.reinterpret_cast %{{.*}} to offset: [%{{.*}}] {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+    %reinterpret = memref.reinterpret_cast %arg0 to offset: [%add], sizes: [128, 64], strides: [64, 1] {ssbuffer.block_id = 14 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    %subview = memref.subview %reinterpret[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 14 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 14 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+    // external user stays block 13, now uses the clone of %add.
+    // CHECK: arith.muli %{{.*}}, %{{.*}} {ssbuffer.block_id = 13 : i32, ssbuffer.core_type = "VECTOR"} : index
+    %ext = arith.muli %add, %c64 {ssbuffer.block_id = 13 : i32, ssbuffer.core_type = "VECTOR"} : index
+    return
+  }
+}


### PR DESCRIPTION
What this pass does
UnifyStoreBlockPass merges store-semantic operations ( bufferization.materialize_in_destination / hivm.hir.store ) into the producer vector compute block of their data source.

Workflow
Iterate store ops : scan all block_id -annotated store-semantic ops in a function.
Trace producer : starting from the store's source tensor, walk up through view ops ( extract_slice / ViewLikeOpInterface ) to find the first VECTOR_ONLY compute op as the producer; skip if the source comes from a block argument or a non-VECTOR_ONLY op.
Collect ops to unify (only ops with block_id == storeBlockId are collected):
Data-chain view ops : tensor-side view ops collected while tracing the producer
Dest-chain view ops : memref-side view ops ( subview / reinterpret_cast ) collected by walking up from the store's dest memref
Scalar deps : scalar compute ops used by store / view ops / control-flow ancestors (e.g. scf.for lb/ub/step), collected recursively
Unify block_id : update the block_id of all collected ops to the producer's block_id , so that the store and its dependencies land in the same vector block as the producer.
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
