### PR TITLE
[TritonToLinalg](NFC) Extract descriptor-op conversion into its own pass

### DIFF
--- a/third_party/ascend/include/TritonToLinalg/ConvertDescriptorOpsPass.h
+++ b/third_party/ascend/include/TritonToLinalg/ConvertDescriptorOpsPass.h
@@ -20,18 +20,40 @@
  * THE SOFTWARE.
  */
 
-#ifndef TRITON_ADAPTER_TRITON_TO_LINALG_CONVERSION_PASSES_H
-#define TRITON_ADAPTER_TRITON_TO_LINALG_CONVERSION_PASSES_H
+#ifndef TRITON_ADAPTER_CONVERSION_CONVERTDESCRIPTOROPSPASS_H
+#define TRITON_ADAPTER_CONVERSION_CONVERTDESCRIPTOROPSPASS_H
 
-#include "ConvertDescriptorOpsPass.h"
-#include "MarkTensorKindPass.h"
-#include "TritonToLinalgPass.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
 
-namespace mlir::triton {
-
-#define GEN_PASS_REGISTRATION
+#define GEN_PASS_DEF_CONVERTDESCRIPTOROPS
 #include "ascend/include/TritonToLinalg/Passes.h.inc"
 
-} // namespace mlir::triton
+namespace mlir {
+namespace triton {
 
-#endif // TRITON_ADAPTER_TRITON_TO_LINALG_CONVERSION_PASSES_H
+std::unique_ptr<OperationPass<ModuleOp>> createConvertDescriptorOpsPass();
+
+} // namespace triton
+} // namespace mlir
+
+using namespace mlir;
+using namespace triton;
+
+// Lowers Triton tensor descriptor operations (tt.make_tensor_descriptor and
+// tt.descriptor_load/store/gather/scatter/reduce) to plain Triton
+// block-pointer, tt.load/tt.store, and scf.for based IR. This is a
+// Triton-to-Triton desugaring pass, not a Triton-to-Linalg conversion: it
+// runs as a preparation step before the main TritonToLinalg conversion.
+class ConvertDescriptorOpsPass
+    : public ::impl::ConvertDescriptorOpsBase<ConvertDescriptorOpsPass> {
+public:
+  ConvertDescriptorOpsPass() = default;
+
+  void getDependentDialects(DialectRegistry &registry) const override;
+
+  void runOnOperation() override;
+};
+
+#endif // TRITON_ADAPTER_CONVERSION_CONVERTDESCRIPTOROPSPASS_H

--- a/third_party/ascend/include/TritonToLinalg/Passes.td
+++ b/third_party/ascend/include/TritonToLinalg/Passes.td
@@ -30,4 +30,15 @@ def MarkTensorKind : Pass<"mark-tensor-kind", "mlir::ModuleOp"> {
     let constructor = "triton::createMarkTensorKindPass()";
 }
 
+def ConvertDescriptorOps : Pass<"convert-descriptor-ops", "mlir::ModuleOp"> {
+    let summary = "Lower Triton tensor descriptor operations to plain Triton IR";
+    let description = [{
+        Converts `tt.descriptor_load`, `tt.descriptor_store`, `tt.descriptor_gather`,
+        `tt.descriptor_scatter`, and `tt.descriptor_reduce` operations (which operate
+        on `!tt.tensordesc` values produced by `tt.make_tensor_descriptor`) into
+        equivalent Triton block-pointer, `tt.load`/`tt.store`, and `scf.for` based
+        IR that no longer references `!tt.tensordesc`.
+    }];
+    let constructor = "triton::createConvertDescriptorOpsPass()";
+}
 #endif // TRITON_TO_LINALG_CONVERSION_PASSES

--- a/third_party/ascend/include/TritonToLinalg/TritonToLinalgPass.h
+++ b/third_party/ascend/include/TritonToLinalg/TritonToLinalgPass.h
@@ -89,7 +89,6 @@ private:
                                                 RewritePatternSet &patterns,
                                                 unsigned int launchGridRank);
 
-  LogicalResult processDescriptorOperations(ModuleOp moduleOp);
   LogicalResult processPtrBroadcastOperations(ModuleOp moduleOp);
   LogicalResult processImplicitPermuteOperations(ModuleOp moduleOp);
   LogicalResult processStridedLoadStoreRewriteOperations(ModuleOp moduleOp);

--- a/third_party/ascend/lib/TritonToLinalg/CMakeLists.txt
+++ b/third_party/ascend/lib/TritonToLinalg/CMakeLists.txt
@@ -13,6 +13,7 @@ add_triton_library(TritonToLinalg
         StridedAxisCoalescing.cpp
         TileChunkCoalescing.cpp
         DescriptorConverter.cpp
+        ConvertDescriptorOpsPass.cpp
         MarkTensorKindPass.cpp
         DevicePrintOffsetRewrite.cpp
 

--- a/third_party/ascend/lib/TritonToLinalg/ConvertDescriptorOpsPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/ConvertDescriptorOpsPass.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/TritonToLinalg/ConvertDescriptorOpsPass.h"
+#include "ascend/include/TritonToLinalg/DescriptorConverter.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+using namespace mlir;
+using namespace triton;
+
+void ConvertDescriptorOpsPass::getDependentDialects(
+    DialectRegistry &registry) const {
+  // Matches the dialects that DescriptorConverter patterns actually read
+  // from and create ops in (arith/scf/tensor/triton).
+  registry.insert<arith::ArithDialect, scf::SCFDialect, tensor::TensorDialect,
+                  triton::TritonDialect>();
+}
+
+void ConvertDescriptorOpsPass::runOnOperation() {
+  ModuleOp moduleOp = getOperation();
+
+  // --- ConversionTarget: dynamic legality checks ---
+  mlir::ConversionTarget target(getContext());
+  target.addLegalDialect<mlir::tensor::TensorDialect>();
+
+  // Dialect-level dynamic legality: ops are legal if none of their
+  // operands/results use TensorDescType.
+  target.addDynamicallyLegalDialect<
+      mlir::arith::ArithDialect, mlir::scf::SCFDialect, triton::TritonDialect>(
+      [](mlir::Operation *op) {
+        return !DescriptorConverter::hasATensorDescriptorType(
+                   op->getOperandTypes()) &&
+               !DescriptorConverter::hasATensorDescriptorType(
+                   op->getResultTypes());
+      });
+  // Function signature legality: Triton FuncOp is legal if its inputs/outputs
+  // contain no TensorDescType.
+  target.addDynamicallyLegalOp<triton::FuncOp>([](triton::FuncOp funcOp) {
+    return !DescriptorConverter::hasATensorDescriptorType(
+               funcOp.getFunctionType().getInputs()) &&
+           !DescriptorConverter::hasATensorDescriptorType(
+               funcOp.getFunctionType().getResults());
+  });
+  target.addLegalOp<triton::MakeTensorDescOp>();
+  target.addIllegalOp<triton::DescriptorLoadOp, triton::DescriptorStoreOp,
+                      triton::DescriptorScatterOp, triton::DescriptorGatherOp,
+                      triton::DescriptorReduceOp>();
+
+  // --- Patterns ---
+  mlir::RewritePatternSet patterns(&getContext());
+  patterns.add<DescriptorConverter::DescriptorLoadConverter>(
+      patterns.getContext());
+  patterns.add<DescriptorConverter::DescriptorStoreConverter>(
+      patterns.getContext());
+  patterns.add<DescriptorConverter::DescriptorScatterConverter>(
+      patterns.getContext());
+  patterns.add<DescriptorConverter::DescriptorGatherConverter>(
+      patterns.getContext());
+  patterns.add<DescriptorConverter::DescriptorReduceConverter>(
+      patterns.getContext());
+
+  mlir::ConversionConfig config;
+  config.buildMaterializations = true;
+  if (failed(applyPartialConversion(moduleOp, target, std::move(patterns),
+                                    config))) {
+    moduleOp->emitError("failed to convert tensor descriptor operations");
+    signalPassFailure();
+  }
+}
+
+std::unique_ptr<OperationPass<ModuleOp>>
+triton::createConvertDescriptorOpsPass() {
+  return std::make_unique<ConvertDescriptorOpsPass>();
+}

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -26,7 +26,7 @@
 #include "TritonToLinalg/BlockPtrAnalysis.h"
 #include "ascend/include/Dialect/TritonAscend/IR/TritonAscendDialect.h"
 #include "ascend/include/TritonToLinalg/ArgMinMaxConverter.h"
-#include "ascend/include/TritonToLinalg/DescriptorConverter.h"
+#include "ascend/include/TritonToLinalg/ConvertDescriptorOpsPass.h"
 #include "ascend/include/TritonToLinalg/DevicePrintOffsetRewrite.h"
 #include "ascend/include/TritonToLinalg/FunctionConverter.h"
 #include "ascend/include/TritonToLinalg/HoistBroadcast.h"
@@ -757,59 +757,6 @@ void TritonToLinalgPass::getDependentDialects(DialectRegistry &registry) const {
 }
 
 LogicalResult
-TritonToLinalgPass::processDescriptorOperations(ModuleOp moduleOp) {
-  // --- ConversionTarget: dynamic legality checks ---
-  mlir::ConversionTarget target(getContext());
-  target.addLegalDialect<mlir::tensor::TensorDialect>();
-
-  // Dialect-level dynamic legality: ops are legal if none of their
-  // operands/results use TensorDescType.
-  target.addDynamicallyLegalDialect<
-      mlir::arith::ArithDialect, mlir::scf::SCFDialect, triton::TritonDialect>(
-      [](mlir::Operation *op) {
-        return !DescriptorConverter::hasATensorDescriptorType(
-                   op->getOperandTypes()) &&
-               !DescriptorConverter::hasATensorDescriptorType(
-                   op->getResultTypes());
-      });
-  // Function signature legality: Triton FuncOp is legal if its inputs/outputs
-  // contain no TensorDescType.
-  target.addDynamicallyLegalOp<triton::FuncOp>([](triton::FuncOp funcOp) {
-    return !DescriptorConverter::hasATensorDescriptorType(
-               funcOp.getFunctionType().getInputs()) &&
-           !DescriptorConverter::hasATensorDescriptorType(
-               funcOp.getFunctionType().getResults());
-  });
-  target.addLegalOp<triton::MakeTensorDescOp>();
-  target.addIllegalOp<triton::DescriptorLoadOp, triton::DescriptorStoreOp,
-                      triton::DescriptorScatterOp, triton::DescriptorGatherOp,
-                      triton::DescriptorReduceOp>();
-
-  // --- Patterns ---
-  mlir::RewritePatternSet patterns(&getContext());
-  patterns.add<DescriptorConverter::DescriptorLoadConverter>(
-      patterns.getContext());
-  patterns.add<DescriptorConverter::DescriptorStoreConverter>(
-      patterns.getContext());
-  patterns.add<DescriptorConverter::DescriptorScatterConverter>(
-      patterns.getContext());
-  patterns.add<DescriptorConverter::DescriptorGatherConverter>(
-      patterns.getContext());
-  patterns.add<DescriptorConverter::DescriptorReduceConverter>(
-      patterns.getContext());
-
-  mlir::ConversionConfig config;
-  config.buildMaterializations = true;
-  if (failed(applyPartialConversion(moduleOp, target, std::move(patterns),
-                                    config))) {
-    moduleOp->emitError("failed to convert tensor descriptor operations");
-    return failure();
-  }
-
-  return success();
-}
-
-LogicalResult
 TritonToLinalgPass::processPtrBroadcastOperations(ModuleOp moduleOp) {
   // --- ConversionTarget: dynamic legality checks ---
   mlir::ConversionTarget target(getContext());
@@ -952,8 +899,13 @@ void TritonToLinalgPass::runOnOperation() {
   bool existSIMTOp = false;
 
   // Execute tensor descriptor operations conversion
-  if (failed(processDescriptorOperations(moduleOp))) {
-    signalPassFailure();
+  {
+    PassManager pm(&getContext(), moduleOp.getOperationName());
+    pm.addPass(triton::createConvertDescriptorOpsPass());
+    if (failed(runPipeline(pm, moduleOp))) {
+      signalPassFailure();
+      return;
+    }
   }
 
   // Execute implicit permute

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/ConvertDescriptorOps/test_parse_descriptor_gather.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/ConvertDescriptorOps/test_parse_descriptor_gather.mlir
@@ -1,0 +1,23 @@
+// RUN: triton-opt --convert-descriptor-ops --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: tt.func public @tensor_descriptor_gather_rows
+// CHECK-NOT: tt.descriptor_gather
+// CHECK: %[[DIM:.*]] = tensor.dim %{{.*}}, %{{.*}} : tensor<32xi32>
+// CHECK: %[[INIT:.*]] = tensor.empty() : tensor<32x32xf32>
+// CHECK: scf.for %{{.*}} = %{{.*}} to %[[DIM]] step %{{.*}} iter_args(%{{.*}} = %[[INIT]]) -> (tensor<32x32xf32>)
+// CHECK: %[[EXTRACTED:.*]] = tensor.extract %{{.*}}[%{{.*}}] : tensor<32xi32>
+// CHECK: %[[PTR:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}], [%[[EXTRACTED]], %{{.*}}] {order = array<i32: 1, 0>} : <tensor<1x32xf32>>
+// CHECK: %[[ROW:.*]] = tt.load %[[PTR]] {DiscreteMemAccess, boundaryCheck = array<i32: 0, 1>, padding = 1 : i32} : !tt.ptr<tensor<1x32xf32>>
+// CHECK: tensor.insert_slice %[[ROW]] into %{{.*}}[%{{.*}}, 0] [1, 32] [1, 1] {DiscreteMemAccess} : tensor<1x32xf32> into tensor<32x32xf32>
+// CHECK: scf.yield
+
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @tensor_descriptor_gather_rows(%in_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %idx: tensor<32xi32>, %y: i32) attributes {noinline = false} {
+    %desc = arith.constant 1 : i64
+    %desc_0 = arith.constant 128 : i64
+    %c128_i32 = arith.constant 128 : i32
+    %desc_4 = tt.make_tensor_descriptor %in_ptr, [%c128_i32, %c128_i32], [%desc_0, %desc] : <f32>, <tensor<1x32xf32>>
+    %out = tt.descriptor_gather %desc_4[%idx, %y] : (!tt.tensordesc<tensor<1x32xf32>>, tensor<32xi32>, i32) -> tensor<32x32xf32>
+    tt.return
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/ConvertDescriptorOps/test_parse_descriptor_load.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/ConvertDescriptorOps/test_parse_descriptor_load.mlir
@@ -1,0 +1,17 @@
+// RUN: triton-opt --convert-descriptor-ops --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: tt.func public @tensor_descriptor_load
+// CHECK-NOT: tt.descriptor_load
+// CHECK: %[[PTR:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}] {order = array<i32: 1, 0>} : <tensor<128x128xf32>>
+// CHECK: tt.load %[[PTR]] {boundaryCheck = array<i32: 0, 1>, padding = 1 : i32} : !tt.ptr<tensor<128x128xf32>>
+
+module {
+  tt.func public @tensor_descriptor_load(%in_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %row_idx: i32, %col_idx: i32) {
+    %c1_i64 = arith.constant 1 : i64
+    %c256_i64 = arith.constant 256 : i64
+    %c256_i32 = arith.constant 256 : i32
+    %desc = tt.make_tensor_descriptor %in_ptr, [%c256_i32, %c256_i32], [%c256_i64, %c1_i64] : <f32>, <tensor<128x128xf32>>
+    %out = tt.descriptor_load %desc[%row_idx, %col_idx] : !tt.tensordesc<tensor<128x128xf32>> -> tensor<128x128xf32>
+    tt.return
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/ConvertDescriptorOps/test_parse_descriptor_reduce.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/ConvertDescriptorOps/test_parse_descriptor_reduce.mlir
@@ -1,0 +1,16 @@
+// RUN: triton-opt --convert-descriptor-ops --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: tt.func public @kernel
+// CHECK-NOT: tt.descriptor_reduce
+// CHECK: %[[MASK:.*]] = arith.andi %{{.*}}, %{{.*}} : tensor<2x16xi1>
+// CHECK: tt.atomic_rmw add, acq_rel, gpu, %{{.*}}, %{{.*}}, %[[MASK]] : (tensor<2x16x!tt.ptr<i32>>, tensor<2x16xi32>, tensor<2x16xi1>) -> tensor<2x16xi32>
+
+module {
+  tt.func public @kernel(%out_ptr: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %val: tensor<2x16xi32>, %M: i32, %N: i32 {tt.divisibility = 16 : i32}, %moffset: i32, %noffset: i32) attributes {noinline = false} {
+    %desc = arith.constant 1 : i64
+    %desc_14 = arith.extsi %N : i32 to i64
+    %desc_15 = tt.make_tensor_descriptor %out_ptr, [%M, %N], [%desc_14, %desc] : <i32>, <tensor<2x16xsi32>>
+    tt.descriptor_reduce add, %desc_15[%moffset, %noffset], %val : !tt.tensordesc<tensor<2x16xsi32>>, tensor<2x16xi32>
+    tt.return
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/ConvertDescriptorOps/test_parse_descriptor_scatter.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/ConvertDescriptorOps/test_parse_descriptor_scatter.mlir
@@ -1,0 +1,20 @@
+// RUN: triton-opt --convert-descriptor-ops --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: tt.func public @tensor_descriptor_scatter_rows_kernel
+// CHECK-NOT: tt.descriptor_scatter
+// CHECK: scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}}
+// CHECK: %[[EXTRACTED:.*]] = tensor.extract %{{.*}}[%{{.*}}] : tensor<32xi32>
+// CHECK: %[[PTR:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}], [%[[EXTRACTED]], %{{.*}}] {order = array<i32: 1, 0>} : <tensor<1x32xf32>>
+// CHECK: %[[ROW:.*]] = tensor.extract_slice %{{.*}}[%{{.*}}, 0] [1, 32] [1, 1] : tensor<32x32xf32> to tensor<1x32xf32>
+// CHECK: tt.store %[[PTR]], %[[ROW]] {DiscreteMemAccess, boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<1x32xf32>>
+
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @tensor_descriptor_scatter_rows_kernel(%out_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %idx: tensor<32xi32>, %data: tensor<32x32xf32>, %y: i32) attributes {noinline = false} {
+    %desc = arith.constant 1 : i64
+    %desc_0 = arith.constant 128 : i64
+    %c128_i32 = arith.constant 128 : i32
+    %desc_13 = tt.make_tensor_descriptor %out_ptr, [%c128_i32, %c128_i32], [%desc_0, %desc] : <f32>, <tensor<1x32xf32>>
+    tt.descriptor_scatter %desc_13[%idx, %y], %data : !tt.tensordesc<tensor<1x32xf32>>, tensor<32xi32>, i32, tensor<32x32xf32>
+    tt.return
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/ConvertDescriptorOps/test_parse_descriptor_store.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/ConvertDescriptorOps/test_parse_descriptor_store.mlir
@@ -1,0 +1,17 @@
+// RUN: triton-opt --convert-descriptor-ops --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: tt.func public @tensor_descriptor_store
+// CHECK-NOT: tt.descriptor_store
+// CHECK: %[[PTR:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}] {order = array<i32: 1, 0>} : <tensor<128x128xf32>>
+// CHECK: tt.store %[[PTR]], %{{.*}} {boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<128x128xf32>>
+
+module {
+  tt.func public @tensor_descriptor_store(%out_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %val: tensor<128x128xf32>, %row_idx: i32, %col_idx: i32) {
+    %c1_i64 = arith.constant 1 : i64
+    %c256_i64 = arith.constant 256 : i64
+    %c256_i32 = arith.constant 256 : i32
+    %desc = tt.make_tensor_descriptor %out_ptr, [%c256_i32, %c256_i32], [%c256_i64, %c1_i64] : <f32>, <tensor<128x128xf32>>
+    tt.descriptor_store %desc[%row_idx, %col_idx], %val : !tt.tensordesc<tensor<128x128xf32>>, tensor<128x128xf32>
+    tt.return
+  }
+}


### PR DESCRIPTION
## Why

`tt.descriptor_*` op conversion (make_tensor_descriptor / load / store / gather / scatter / reduce) previously lived as a private sub-step (`TritonToLinalgPass::processDescriptorOperations`) inside the monolithic `TritonToLinalgPass`, only reachable as part of the full `--triton-to-linalg` pipeline. This made it impossible to test or reason about the descriptor lowering in isolation.

## What changed

- Extracted the conversion into a standalone, independently-registered `ConvertDescriptorOpsPass` (`--convert-descriptor-ops`). No behavior change to the `--triton-to-linalg` pipeline.
- Added 5 focused `lit` tests under `unittest/Conversion/General/TritonToLinalg/ConvertDescriptorOps/`, one per `DescriptorConverter` pattern (load/store/gather/scatter/reduce).
- The pre-existing gather/scatter/reduce tests in the `TritonToLinalg/` directory are kept as-is; they still validate the same ops end-to-end through the full `--triton-to-linalg` pipeline.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices), including the "tests should be minimal" section. (Usually running Python code and using the instructions it generates is not minimal.)
