### PR TITLE
[parallel_mode](fix) fix the incorrect parallel_mode

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -349,6 +349,47 @@ def __get_metadata_attr_by_callback(lib, postfix: str, metadata, meta_key: str):
         metadata[meta_key] = callback_func()
 
 
+# Mapping from vf_mode enum value to parallel_mode string.
+# vf_mode is inferred by InferVFModePass during bishengir-compile
+#   0 = SIMD, 1 = SIMT, 2 = MIX
+_VF_MODE_TO_PARALLEL_MODE = {
+    0: "simd",
+    1: "simt",
+    2: "mix_simd_simt",
+}
+
+
+def _adjust_parallel_mode_by_vf_mode(metadata: dict):
+    """
+    Override metadata['parallel_mode'] with the value derived from vf_mode.
+
+    Background: parallel_mode is initially extracted from Linalg IR text by
+    _parse_linalg_metadata (value set by TritonToLinalgPass in the frontend);
+    vf_mode is inferred by bishengir-compile's InferVFModePass in the backend
+    based on the complete HIVM IR. The backend judgement is more precise, so
+    once vf_mode is read via callback, it is used to override parallel_mode.
+
+    - No 'vf_mode' key in metadata: keep original parallel_mode unchanged
+    - vf_mode value is None: keep original parallel_mode unchanged
+    - vf_mode value out of {0, 1, 2}: keep original parallel_mode and warn
+    - vf_mode value is valid: override parallel_mode with the mapped value
+    """
+    vf_mode = metadata.get("vf_mode", None)
+    if vf_mode is None:
+        return
+
+    new_parallel_mode = _VF_MODE_TO_PARALLEL_MODE.get(vf_mode)
+    if new_parallel_mode is None:
+        print(f"[WARN] Unexpected vf_mode={vf_mode}, keep parallel_mode="
+              f"{metadata.get('parallel_mode', 'simd')!r}")
+        return
+
+    old_parallel_mode = metadata.get("parallel_mode", None)
+    print(f"[DEBUG] vf_mode={vf_mode}, parallel_mode: {old_parallel_mode!r} -> "
+          f"{new_parallel_mode!r}")
+    metadata["parallel_mode"] = new_parallel_mode
+
+
 def _parse_linalg_metadata(linalg: str, metadata: dict):
     """
     Parse Linalg IR to extract metadata required for NPU compilation.
@@ -737,6 +778,8 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
             __get_metadata_attr_by_callback(lib, "_infer_workspace_shape_function", metadata, "workspace_size")
             __get_metadata_attr_by_callback(lib, "_infer_sync_block_lock_num_function", metadata, "lock_num")
             __get_metadata_attr_by_callback(lib, "_infer_sync_block_lock_init_function", metadata, "lock_init_val")
+            __get_metadata_attr_by_callback(lib, "_infer_vf_mode_function", metadata, "vf_mode")
+            _adjust_parallel_mode_by_vf_mode(metadata)
 
         return Path(bin_path).read_bytes()
 


### PR DESCRIPTION
## Summary
Add _adjust_parallel_mode_by_vf_mode in compiler.py . After the _infer_vf_mode_function host callback is read on the A5 path, it overrides metadata["parallel_mode"] with the backend-inferred vf_mode ( 0=SIMD , 1=SIMT , 2=MIX ). driver.py is unchanged and consumes the corrected value transparently.

## Why
parallel_mode is set by TritonToLinalgPass in the frontend (pre-lowering) and regex-extracted from IR text. This judgement is conservative and can miss SIMT/MIX cases that only emerge after HIVM lowering. On register-based archs (A5), bishengir-compile runs InferVFModePass over the complete HIVM IR and produces a more precise vf_mode , exposed via the <kernel>_infer_vf_mode_function callback. This backend answer is authoritative and should win at launch time.

## What Changed
- compiler.py — Add _VF_MODE_TO_PARALLEL_MODE map and _adjust_parallel_mode_by_vf_mode(metadata) . Reads vf_mode , maps to parallel_mode string, prints [DEBUG] vf_mode=..., parallel_mode: <old> -> <new> before overriding.
- A5 path — Call the helper at compiler.py:716 , right after reading the _infer_vf_mode_function callback.
- driver.py — No change; reads metadata.parallel_mode as before.


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
