### PR TITLE
[ssbuffer](feat) nd2nz unaligned cases

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -36,9 +36,6 @@ namespace CVPipeline {
 inline constexpr llvm::StringLiteral kCoreType = "ssbuffer.core_type";
 inline constexpr llvm::StringLiteral kBlockId = "ssbuffer.block_id";
 inline constexpr llvm::StringLiteral kTransferId = "ssbuffer.transfer_id";
-inline constexpr llvm::StringLiteral kMatmulADep = "ssbuffer.adep";
-inline constexpr llvm::StringLiteral kMatmulBDep = "ssbuffer.bdep";
-inline constexpr llvm::StringLiteral kMatmulExtract = "ssbuffer.matmul_extract";
 inline constexpr llvm::StringLiteral kCubeFirst = "ssbuffer.cube_first";
 inline constexpr llvm::StringLiteral kVectorFirst = "ssbuffer.vector_first";
 inline constexpr llvm::StringLiteral kAddFromMatmul =

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
@@ -58,10 +58,6 @@ struct DependencyInfo {
   int iniConsumerBlockId;
 
   bool isAllTranspoesd = false;
-  // Optional Items for V2CDependencies
-  mlir::Operation *iniMatmulOp = nullptr;
-  bool isMatmulA = false;
-  bool isMatmulB = false;
 
   // Optional Items for memDependencies
   mlir::Operation *predOp;
@@ -155,9 +151,9 @@ private:
   bool isValidShapeForDependency(mlir::Value value);
   bool isValidValueForDependency(mlir::Value value);
   bool isValidScalarDependency(mlir::Value value);
+  bool isAllTransposedInVector(mlir::Value value);
   bool isOuterOpArg(mlir::Value value);
   void processIterArgDependencies();
-  void analyzeV2CMatmulABType(DataDependencyInfo &info);
   llvm::SmallVector<mlir::Operation *>
   collectDiffCoreTypeUsers(mlir::BlockArgument iterArg,
                            llvm::StringRef initCoreType);

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
@@ -85,8 +85,7 @@ private:
   int transferIndex = 0;
   int markAllocIndex = 0;
 
-  llvm::DenseMap<mlir::Value, mlir::Value> vecValueMapping;
-  llvm::DenseMap<mlir::Value, mlir::Value> cubeValueMapping;
+  llvm::DenseMap<mlir::Value, mlir::Value> ndnzValueMapping;
   SSBufferManager ssbufferManager;
 
   mlir::LogicalResult
@@ -94,13 +93,10 @@ private:
                       FlagIdReuseManager &flagIdReuseManager);
   mlir::LogicalResult
   handleVectorToCube(mlir::OpBuilder &builder, DependencyInfo &dep,
-                     llvm::DenseMap<mlir::Value, mlir::Value> vecvalueMapping,
-                     llvm::DenseMap<mlir::Value, mlir::Value> cubeValueMapping,
                      FlagIdManager &flagManager,
                      FlagIdReuseManager &flagIdReuseManager);
   mlir::LogicalResult
   handleCubeToVector(mlir::OpBuilder &builder, DependencyInfo &dep,
-                     llvm::DenseMap<mlir::Value, mlir::Value> cubeValueMapping,
                      FlagIdManager &flagManager,
                      FlagIdReuseManager &flagIdReuseManager);
   mlir::LogicalResult handleMemoryDependency(
@@ -115,41 +111,15 @@ private:
                          mlir::Operation *currConsStart,
                          llvm::SmallVector<DependencyInfo> &memDependencies);
 
-  SmallVector<int64_t> computeExpectedShape(mlir::Value depValue,
-                                            bool isMatmulA, bool isMatmulB,
-                                            bool isOnlyDepInMatmul);
-  std::pair<bool, bool> isExpectedShape(Value value,
-                                        SmallVector<int64_t> &expectedShape,
-                                        bool isMatmulA, bool isMatmulB,
-                                        bool isOnlyDepInMatmul);
-  bool matmulCIsEmpty(mlir::Value acc);
-  void padMatmulInnerDim(OpBuilder &builder, Operation *matmulOp, Location loc,
-                         int matmulIndex, int matmulOpBlockId);
-  void extractMatmulResult(
-      OpBuilder &builder, Operation *matmulOp, Location loc,
-      int matmulOpBlockId,
-      llvm::DenseMap<mlir::Value, mlir::Value> &cubeValueMapping,
-      bool isOnlyDepInMatmul);
-  mlir::Value normalizeIfNeeded(mlir::OpBuilder &builder, DependencyInfo &dep,
-                                mlir::Location loc, mlir::Value origValue,
-                                llvm::SmallVector<int64_t> expectedShape,
-                                int originBlockId, bool matmulpadding,
-                                bool isOnlyDepInMatmul);
+  SmallVector<int64_t> computeExpectedShape(mlir::Value depValue);
+  bool isExpectedShape(Value value, SmallVector<int64_t> &expectedShape);
+  mlir::Value alignShapeByInsertSlice(mlir::OpBuilder &builder,
+                                      DependencyInfo &dep, mlir::Location loc,
+                                      mlir::Value origValue,
+                                      llvm::SmallVector<int64_t> expectedShape,
+                                      int originBlockId);
   void Nd2NzNormalize(mlir::OpBuilder &builder, DependencyInfo &dep,
                       mlir::Location loc);
-  void rewriteMatmulWithNewShape(mlir::OpBuilder &builder,
-                                 mlir::Operation *matmulOp, mlir::Location loc,
-                                 bool isMatmulA, bool isMatmulB,
-                                 bool matmulpadding, bool isOnlyDepInMatmul);
-  void rewriteTransposeWithNewShape(mlir::OpBuilder &builder,
-                                    mlir::Operation *transposeOp,
-                                    mlir::Location loc);
-  llvm::DenseMap<mlir::Value, mlir::Value> getVecValueMapping() {
-    return vecValueMapping;
-  }
-  llvm::DenseMap<mlir::Value, mlir::Value> getCubeValueMapping() {
-    return cubeValueMapping;
-  }
 
   mlir::Operation *annotateTightlyCoupledBuffer(mlir::OpBuilder &builder,
                                                 mlir::Operation *allocOp,

--- a/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
@@ -43,18 +43,24 @@ static constexpr const char *DEBUG_TYPE = "RemoveAttributes";
 
 // if extra attr is needed, add to ut @
 // third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/test-remove-attrs.mlir
-static constexpr llvm::StringLiteral kAttrsToRemove[]{
-    kBlockId,           kCoreType,
-    kTransferId,        kMainLoop,
-    kCubeFirst,         kVectorFirst,
-    kAddFromMatmul,     kIntraBuffer,
-    kAnalyzeFlagId,     kLoopCarriedL0C,
-    kMatmulADep,        kMatmulBDep,
-    kMatmulExtract,     kCrossDeps,
-    kMemCrossDeps,      kClone,
-    kIntraBufCount,     kInterCoreBufCount,
-    kLoadStoreBufCount, kInsertionOptimization,
-    kEnableUbRefineOpt};
+static constexpr llvm::StringLiteral kAttrsToRemove[]{kBlockId,
+                                                      kCoreType,
+                                                      kTransferId,
+                                                      kMainLoop,
+                                                      kCubeFirst,
+                                                      kVectorFirst,
+                                                      kAddFromMatmul,
+                                                      kIntraBuffer,
+                                                      kAnalyzeFlagId,
+                                                      kLoopCarriedL0C,
+                                                      kCrossDeps,
+                                                      kMemCrossDeps,
+                                                      kClone,
+                                                      kIntraBufCount,
+                                                      kInterCoreBufCount,
+                                                      kLoadStoreBufCount,
+                                                      kInsertionOptimization,
+                                                      kEnableUbRefineOpt};
 
 void RemoveSsbufAttrPass::runOnOperation() {
   auto module = getOperation();

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -118,6 +118,24 @@ bool DataDependencyAnalysisPass::isValidScalarDependency(mlir::Value value) {
   return false;
 }
 
+// Check if a value is only used by transpose ops whose users are all vector ops
+bool DataDependencyAnalysisPass::isAllTransposedInVector(mlir::Value value) {
+  if (!isa<linalg::MatmulOp>(value.getDefiningOp())) {
+    return false;
+  }
+  if (!llvm::hasSingleElement(value.getUsers())) {
+    return false;
+  }
+  auto *userOp = *value.getUsers().begin();
+  if (!isa<linalg::TransposeOp>(userOp))
+    return false;
+  for (mlir::Operation *transposeOpUser : userOp->getUsers()) {
+    if (getSsbufferCoreType(transposeOpUser) != ssbufferCoreTypeVectorAttr)
+      return false;
+  }
+  return true;
+}
+
 // Helper: Check if value is a valid tensor for dependency analysis
 // Returns true if value is TensorType and not defined by EmptyOp/FillOp
 bool DataDependencyAnalysisPass::isValidValueForDependency(mlir::Value value) {
@@ -548,26 +566,7 @@ void DataDependencyAnalysisPass::analyzeExternalOutputs(
 
       // if c->v value will be transposed and then used by vector op, the value
       // can be transposed within fixpipe
-      bool isAllTranspoesd = true;
-      for (mlir::Operation *user : output.getUsers()) {
-        if (!isa<linalg::TransposeOp>(user)) {
-          isAllTranspoesd = false;
-          continue;
-        }
-        for (mlir::Operation *transposeOpUser : user->getUsers()) {
-          if (getSsbufferCoreType(transposeOpUser) !=
-              ssbufferCoreTypeVectorAttr) {
-            isAllTranspoesd = false;
-            continue;
-          }
-        }
-      }
-      if (isAllTranspoesd) {
-        for (mlir::Operation *user : output.getUsers()) {
-          auto transposedValue = user->getResults()[0];
-          transposedValue.replaceAllUsesWith(opResult);
-        }
-      }
+      bool isAllTranspoesd = isAllTransposedInVector(output);
 
       for (mlir::Operation *user : output.getUsers()) {
         int outputIndex = 0;
@@ -730,57 +729,6 @@ void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info) {
   LOG_DEBUG("=== mem dep analysis complete ===\n");
 }
 
-void DataDependencyAnalysisPass::analyzeV2CMatmulABType(
-    DataDependencyInfo &info) {
-  auto &v2cDependencies = info.getV2CDependencies();
-  for (DependencyInfo &dep : v2cDependencies) {
-    mlir::Value depValue = dep.value;
-    llvm::DenseSet<mlir::Value> visitedValues;
-    llvm::SmallVector<mlir::Value> worklist;
-    visitedValues.insert(depValue);
-    worklist.push_back(depValue);
-    bool foundMatmul = false;
-
-    while (!worklist.empty() && !foundMatmul) {
-      mlir::Value currentValue = worklist.pop_back_val();
-      for (mlir::Operation *userOp : currentValue.getUsers()) {
-        if (!userOp) {
-          continue;
-        }
-
-        auto userBlockIdOpt = CVPipeline::getOpBlockId(userOp);
-        if (!userBlockIdOpt || *userBlockIdOpt != dep.iniConsumerBlockId) {
-          continue;
-        }
-
-        if (auto matmulOp = dyn_cast<linalg::MatmulOp>(userOp)) {
-          MLIRContext *ctx = matmulOp->getContext();
-          if (matmulOp.getOperand(0) == currentValue) {
-            dep.isMatmulA = true;
-            matmulOp->setAttr(CVPipeline::kMatmulADep, UnitAttr::get(ctx));
-          }
-          if (matmulOp.getOperand(1) == currentValue) {
-            dep.isMatmulB = true;
-            matmulOp->setAttr(CVPipeline::kMatmulBDep, UnitAttr::get(ctx));
-          } else {
-            LOG_DEBUG("[warning]: invalid matmul c dep!\n");
-          }
-          foundMatmul = true;
-          dep.iniMatmulOp = matmulOp;
-          break;
-        }
-
-        for (mlir::Value result : userOp->getResults()) {
-          if (!visitedValues.contains(result)) {
-            visitedValues.insert(result);
-            worklist.push_back(result);
-          }
-        }
-      }
-    }
-  }
-}
-
 // Producer/Consumer Hierarchy Analysis
 std::pair<int, int> DataDependencyAnalysisPass::findCommonLevelBlockIds(
     DataDependencyInfo &info, int producerBlockId, int consumerBlockId) {
@@ -879,7 +827,6 @@ void DataDependencyAnalysisPass::runOnOperation() {
 
   // Step 3: Analyze dependencies (populate v2c, c2v lists)
   analyzeExternalInputs(info);
-  analyzeV2CMatmulABType(info);
 
   analyzeExternalOutputs(info);
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -228,9 +228,8 @@ bool InterCoreTransferAndSyncPass::isOuterLayerDependency(
 }
 
 // Nd2NzNormalizer
-SmallVector<int64_t> InterCoreTransferAndSyncPass::computeExpectedShape(
-    mlir::Value depValue, bool isMatmulA, bool isMatmulB,
-    bool isOnlyDepInMatmul) {
+SmallVector<int64_t>
+InterCoreTransferAndSyncPass::computeExpectedShape(mlir::Value depValue) {
   auto tensorTy = dyn_cast<TensorType>(depValue.getType());
   static constexpr int NdShapeLength = 2;
   if (!tensorTy || tensorTy.getRank() != NdShapeLength) {
@@ -251,18 +250,7 @@ SmallVector<int64_t> InterCoreTransferAndSyncPass::computeExpectedShape(
 
   int mRound = NzDimWidth;
   int nRound = nWidth;
-  if (isMatmulA && isMatmulB) {
-    mRound = std::max<int64_t>(NzDimWidth, nWidth);
-    nRound = std::max<int64_t>(NzDimWidth, nWidth);
-  }
-  if (!isOnlyDepInMatmul && isMatmulA) {
-    nRound = std::max<int64_t>(NzDimWidth, nWidth);
-  }
-  if (!isOnlyDepInMatmul && isMatmulB) {
-    mRound = std::max<int64_t>(NzDimWidth, nWidth);
-  }
-  LOG_DEBUG("mRound: " << mRound << "\n");
-  LOG_DEBUG("nRound: " << nRound << "\n");
+
   // Calculate newM / newN using the formula
   int64_t blM = (M + mRound - 1) / mRound;
   int64_t newM = blM * mRound;
@@ -272,232 +260,27 @@ SmallVector<int64_t> InterCoreTransferAndSyncPass::computeExpectedShape(
   LOG_DEBUG("newM" << newM << "\n");
   LOG_DEBUG("newN" << newN << "\n");
 
-  if (isOnlyDepInMatmul) {
-    if ((isMatmulA && newN != N) || (isMatmulB && newM != M)) {
-      LOG_DEBUG("nd2nz shape is unaligned and matmul A/B is from cube");
-      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_IGNORED);
-      return {};
-    }
-  }
-
   return {newM, newN}; // Return 2D shape
 }
 
-std::pair<bool, bool> InterCoreTransferAndSyncPass::isExpectedShape(
-    Value value, SmallVector<int64_t> &expectedShape, bool isMatmulA,
-    bool isMatmulB, bool isOnlyDepInMatmul) {
+bool InterCoreTransferAndSyncPass::isExpectedShape(
+    Value value, SmallVector<int64_t> &expectedShape) {
   auto tensorTy = dyn_cast<TensorType>(value.getType());
   if (!tensorTy) {
-    return {true, false};
+    return true;
   }
   ArrayRef<int64_t> currShape = tensorTy.getShape();
   bool isEqualedShape = currShape.equals(expectedShape);
-  bool matmulPadding = false;
-  if (isOnlyDepInMatmul) {
-    if (isMatmulA && currShape[1] != expectedShape[1]) {
-      matmulPadding = true;
-    }
-    if (isMatmulB && currShape[0] != expectedShape[0]) {
-      matmulPadding = true;
-    }
-  }
+
   LOG_DEBUG("isEqualedShape" << isEqualedShape << "\n");
-  LOG_DEBUG("matmulPadding" << matmulPadding << "\n");
-  return {isEqualedShape, matmulPadding};
-}
-
-void InterCoreTransferAndSyncPass::padMatmulInnerDim(OpBuilder &builder,
-                                                     Operation *matmulOp,
-                                                     Location loc,
-                                                     int matmulIndex,
-                                                     int matmulOpBlockId) {
-  int paddingDim = 1 - matmulIndex;
-  Value iniValue = matmulOp->getOperands()[matmulIndex];
-  Value transValue = matmulOp->getOperands()[1 - matmulIndex];
-  auto iniValueType = dyn_cast<RankedTensorType>(iniValue.getType());
-  auto transValueType = dyn_cast<RankedTensorType>(transValue.getType());
-  SmallVector<int64_t> paddingShape;
-  if (paddingDim) {
-    paddingShape = {iniValueType.getShape()[0], transValueType.getShape()[0]};
-  } else {
-    paddingShape = {transValueType.getShape()[1], iniValueType.getShape()[1]};
-  }
-
-  builder.setInsertionPoint(matmulOp);
-  auto floatElemTy = cast<FloatType>(iniValueType.getElementType());
-  auto zeroConstOp = builder.create<arith::ConstantFloatOp>(
-      loc, floatElemTy, APFloat::getZero(floatElemTy.getFloatSemantics()));
-  auto tensorEmptyOp = builder.create<tensor::EmptyOp>(
-      loc, paddingShape, iniValueType.getElementType());
-  LOG_DEBUG("[padMatmulInnerDim]" << *tensorEmptyOp << "\n");
-  auto linalgFillOp = builder.create<linalg::FillOp>(
-      loc, zeroConstOp.getResult(), tensorEmptyOp.getResult());
-  SmallVector<OpFoldResult> offsets = {builder.getIndexAttr(0),
-                                       builder.getIndexAttr(0)};
-  SmallVector<OpFoldResult> insertsizes = {
-      builder.getIndexAttr(iniValueType.getShape()[0]),
-      builder.getIndexAttr(iniValueType.getShape()[1])};
-  SmallVector<OpFoldResult> strides = {builder.getIndexAttr(1),
-                                       builder.getIndexAttr(1)};
-  auto tensorInsertSliceOp = builder.create<tensor::InsertSliceOp>(
-      loc, iniValue, linalgFillOp->getResult(0), offsets, insertsizes, strides);
-  matmulOp->setOperand(matmulIndex, tensorInsertSliceOp->getResult(0));
-  attachCommonTags(zeroConstOp, matmulOpBlockId, "CUBE");
-  attachCommonTags(tensorEmptyOp, matmulOpBlockId, "CUBE");
-  attachCommonTags(linalgFillOp, matmulOpBlockId, "CUBE");
-  attachCommonTags(tensorInsertSliceOp, matmulOpBlockId, "CUBE");
-}
-
-bool InterCoreTransferAndSyncPass::matmulCIsEmpty(mlir::Value acc) {
-  auto accDefOp = acc.getDefiningOp();
-  if (accDefOp) {
-    if (isa<tensor::EmptyOp>(accDefOp)) {
-      return true;
-    }
-    if (auto fillOp = dyn_cast<linalg::FillOp>(accDefOp)) {
-      Value fillVal = fillOp.getOperand(0);
-      if (auto constOp = fillVal.getDefiningOp<arith::ConstantOp>()) {
-        Attribute attr = constOp.getValue();
-
-        if ((isa<FloatAttr>(attr) &&
-             cast<FloatAttr>(attr).getValue().isZero()) ||
-            (isa<IntegerAttr>(attr) &&
-             cast<IntegerAttr>(attr).getValue().isZero())) {
-          return true;
-        }
-      }
-    }
-  }
-  return false;
-}
-
-void InterCoreTransferAndSyncPass::extractMatmulResult(
-    OpBuilder &builder, Operation *matmulOp, Location loc, int matmulOpBlockId,
-    llvm::DenseMap<mlir::Value, mlir::Value> &cubeValueMapping,
-    bool isOnlyDepInMatmul) {
-  Value lhs = matmulOp->getOperands()[0];
-  Value rhs = matmulOp->getOperands()[1];
-  Value acc = matmulOp->getOperands()[2];
-  Value originalResult = matmulOp->getResult(0);
-  auto lhsType = cast<RankedTensorType>(lhs.getType());
-  auto rhsType = cast<RankedTensorType>(rhs.getType());
-  auto accType = cast<RankedTensorType>(acc.getType());
-  auto resType = cast<RankedTensorType>(originalResult.getType());
-  if (lhsType.getShape()[0] == accType.getShape()[0] &&
-      rhsType.getShape()[1] == accType.getShape()[1]) {
-    return;
-  }
-
-  ArrayRef<int64_t> accshape = accType.getShape();
-  ArrayRef<int64_t> resshape = resType.getShape();
-  SmallVector<int64_t> expectedShape = {lhsType.getShape()[0],
-                                        rhsType.getShape()[1]};
-  auto expectedType =
-      RankedTensorType::get(expectedShape, resType.getElementType());
-
-  builder.setInsertionPoint(matmulOp);
-
-  auto floatElemTy = cast<FloatType>(resType.getElementType());
-  auto zeroConstOp = builder.create<arith::ConstantFloatOp>(
-      loc, floatElemTy, APFloat::getZero(floatElemTy.getFloatSemantics()));
-  auto tensorEmptyOp = builder.create<tensor::EmptyOp>(
-      loc, expectedShape, resType.getElementType());
-  auto linalgFillOp = builder.create<linalg::FillOp>(
-      loc, zeroConstOp.getResult(), tensorEmptyOp.getResult());
-
-  attachCommonTags(zeroConstOp, matmulOpBlockId, "CUBE");
-  attachCommonTags(tensorEmptyOp, matmulOpBlockId, "CUBE");
-  attachCommonTags(linalgFillOp, matmulOpBlockId, "CUBE");
-
-  mlir::Operation *paddingAccOp = linalgFillOp;
-  if (!matmulCIsEmpty(acc)) {
-    LOG_DEBUG("nd2nz shape is unaligned and matmul C is not empty");
-    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_IGNORED);
-    return;
-  }
-
-  Value newAccResult = paddingAccOp->getResult(0);
-
-  static constexpr int accIndex = 2;
-  matmulOp->setOperand(accIndex, newAccResult);
-  matmulOp->getResult(0).setType(expectedType);
-  auto newMatmulOp = dyn_cast<linalg::MatmulOp>(matmulOp);
-  Value newMatmulResult = newMatmulOp->getResult(0);
-  LOG_DEBUG("newmatmulOp" << newMatmulOp << "\n");
-
-  bool hasMatmulExtract = false;
-  for (Operation *user : matmulOp->getUsers()) {
-    if (isa<tensor::ExtractSliceOp>(user) &&
-        user->hasAttr(CVPipeline::kMatmulExtract)) {
-      hasMatmulExtract = true;
-    }
-  }
-
-  if (isOnlyDepInMatmul || !hasMatmulExtract) {
-    builder.setInsertionPointAfter(matmulOp);
-    SmallVector<OpFoldResult> offsets = {builder.getIndexAttr(0),
-                                         builder.getIndexAttr(0)};
-    SmallVector<OpFoldResult> strides = {builder.getIndexAttr(1),
-                                         builder.getIndexAttr(1)};
-    SmallVector<OpFoldResult> sizes = {
-        builder.getIndexAttr(accType.getShape()[0]),
-        builder.getIndexAttr(accType.getShape()[1])};
-    auto extractSliceOp = builder.create<tensor::ExtractSliceOp>(
-        loc, newMatmulResult, offsets, sizes, strides);
-    attachCommonTags(extractSliceOp, matmulOpBlockId, "CUBE");
-    MLIRContext *ctx = extractSliceOp->getContext();
-    extractSliceOp->setAttr(CVPipeline::kMatmulExtract, UnitAttr::get(ctx));
-    originalResult.replaceUsesWithIf(
-        extractSliceOp.getResult(), [&](OpOperand &use) {
-          return use.getOwner() != extractSliceOp.getOperation();
-        });
-
-    LOG_DEBUG("cubeValueMapping[originalResult]" << originalResult << "\n");
-    LOG_DEBUG("cubeValueMapping[originalResult]extractSliceOp.getResult()   "
-              << extractSliceOp.getResult() << "\n");
-    cubeValueMapping[originalResult] = extractSliceOp.getResult();
-  }
-}
-
-void InterCoreTransferAndSyncPass::rewriteMatmulWithNewShape(
-    OpBuilder &builder, Operation *matmulOp, Location loc, bool isMatmulA,
-    bool isMatmulB, bool matmulPadding, bool isOnlyDepInMatmul) {
-  int matmulOpBlockId = CVPipeline::getOpBlockId(matmulOp).value_or(-1);
-
-  if (matmulPadding) {
-    int matmulIndex = isMatmulA ? 1 : 0;
-    padMatmulInnerDim(builder, matmulOp, loc, matmulIndex, matmulOpBlockId);
-  }
-
-  extractMatmulResult(builder, matmulOp, loc, matmulOpBlockId, cubeValueMapping,
-                      isOnlyDepInMatmul);
-}
-
-void InterCoreTransferAndSyncPass::rewriteTransposeWithNewShape(
-    OpBuilder &builder, Operation *transposeOp, Location loc) {
-  Value inputvalue = transposeOp->getOperands()[0];
-  Value outputvalue = transposeOp->getOperands()[0];
-
-  auto inputTy = dyn_cast<RankedTensorType>(inputvalue.getType());
-  Type elemType = inputTy.getElementType();
-  SmallVector<int64_t> newOutputShape = {inputTy.getShape()[1],
-                                         inputTy.getShape()[0]};
-  auto expectedType = RankedTensorType::get(newOutputShape, elemType);
-  // Create new empty tensor with new shape
-  auto tensorEmptyOp =
-      builder.create<tensor::EmptyOp>(loc, newOutputShape, elemType);
-  attachCommonTags(tensorEmptyOp,
-                   CVPipeline::getOpBlockId(transposeOp).value_or(-1), "CUBE");
-  Value transposeOpResult = transposeOp->getResult(0);
-  transposeOp->setOperand(1, tensorEmptyOp.getResult());
-  transposeOp->getResult(0).setType(expectedType);
+  return isEqualedShape;
 }
 
 // padding v->c tensor
-mlir::Value InterCoreTransferAndSyncPass::normalizeIfNeeded(
+mlir::Value InterCoreTransferAndSyncPass::alignShapeByInsertSlice(
     OpBuilder &builder, DependencyInfo &dep, Location loc,
     mlir::Value origValue, SmallVector<int64_t> expectedShape,
-    int originBlockId, bool matmulPadding, bool isOnlyDepInMatmul) {
+    int originBlockId) {
   auto origTensorType = dyn_cast<RankedTensorType>(origValue.getType());
   if (!origTensorType) {
     return origValue;
@@ -514,9 +297,19 @@ mlir::Value InterCoreTransferAndSyncPass::normalizeIfNeeded(
     builder.setInsertionPointAfter(origValue.getDefiningOp());
   }
 
-  auto floatElemTy = cast<FloatType>(elemType);
-  auto zeroConstOp = builder.create<arith::ConstantFloatOp>(
-      loc, floatElemTy, APFloat::getZero(floatElemTy.getFloatSemantics()));
+  TypedAttr zeroAttr;
+  if (auto floatElemTy = dyn_cast<FloatType>(elemType)) {
+    zeroAttr = FloatAttr::get(
+        floatElemTy, APFloat::getZero(floatElemTy.getFloatSemantics()));
+  } else if (auto intElemTy = dyn_cast<IntegerType>(elemType)) {
+    zeroAttr = IntegerAttr::get(intElemTy, 0);
+  } else {
+    LOG_DEBUG("Unsupported element type for alignShapeByInsertSlice: "
+              << elemType << "\n");
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
+    return origValue;
+  }
+  auto zeroConstOp = builder.create<arith::ConstantOp>(loc, zeroAttr);
   auto tensorEmptyOp =
       builder.create<tensor::EmptyOp>(loc, expectedShape, elemType);
   auto linalgFillOp = builder.create<linalg::FillOp>(
@@ -530,46 +323,8 @@ mlir::Value InterCoreTransferAndSyncPass::normalizeIfNeeded(
   auto tensorInsertSliceOp = builder.create<tensor::InsertSliceOp>(
       loc, origValue, linalgFillOp->getResult(0), offsets, insertsizes,
       strides);
-
-  attachCommonTags(zeroConstOp, originBlockId, "VECTOR");
-  attachCommonTags(tensorEmptyOp, originBlockId, "VECTOR");
-  attachCommonTags(linalgFillOp, originBlockId, "VECTOR");
   attachCommonTags(tensorInsertSliceOp, originBlockId, "VECTOR");
 
-  int cId = dep.iniConsumerBlockId;
-  LOG_DEBUG("int cId = dep.iniConsumerBlockId;" << cId << "\n");
-  for (Operation *user : origValue.getUsers()) {
-    LOG_DEBUG(*user << "\n");
-    auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
-    LOG_DEBUG("int userBlockId = getOpBlockId(user);"
-              << (userBlockIdOpt ? *userBlockIdOpt : -1) << "\n");
-    if (!userBlockIdOpt || *userBlockIdOpt != cId) {
-      continue;
-    }
-    user->replaceUsesOfWith(origValue, tensorInsertSliceOp.getResult());
-    bool isMatmulA = dep.isMatmulA;
-    bool isMatmulB = dep.isMatmulB;
-    if (auto matmulOp = dyn_cast<linalg::MatmulOp>(user)) {
-      rewriteMatmulWithNewShape(builder, matmulOp, loc, isMatmulA, isMatmulB,
-                                matmulPadding, isOnlyDepInMatmul);
-      continue;
-    }
-    if (auto transposeOp = dyn_cast<linalg::TransposeOp>(user)) {
-      LOG_DEBUG("before rewriteTransposeWithNewShape\n");
-      rewriteTransposeWithNewShape(builder, transposeOp, loc);
-      LOG_DEBUG("after rewriteTransposeWithNewShape\n");
-      for (Operation *transposeuser : transposeOp->getUsers()) {
-        auto matmulOp = dyn_cast<linalg::MatmulOp>(transposeuser);
-        if (matmulOp &&
-            CVPipeline::getOpBlockId(matmulOp).value_or(-1) == cId) {
-          rewriteMatmulWithNewShape(builder, matmulOp, loc, isMatmulA,
-                                    isMatmulB, matmulPadding,
-                                    isOnlyDepInMatmul);
-        }
-      }
-    }
-  }
-  cubeValueMapping[origValue] = tensorInsertSliceOp.getResult();
   return tensorInsertSliceOp.getResult();
 }
 
@@ -579,34 +334,20 @@ void InterCoreTransferAndSyncPass::Nd2NzNormalize(OpBuilder &builder,
   Value origValue = dep.value;
   Value newValue = origValue;
   // Step 0: Check if this Value has already been processed
-  auto it = vecValueMapping.find(origValue);
-  if (it != vecValueMapping.end()) {
+  auto it = ndnzValueMapping.find(origValue);
+  if (it != ndnzValueMapping.end()) {
     return;
   }
-  bool valueIsMatmulA = dep.isMatmulA;
-  bool valueIsMatmulB = dep.isMatmulB;
-  bool isOnlyDepInMatmul = true;
-  auto iniDepMatmulOp = dep.iniMatmulOp;
 
-  if (iniDepMatmulOp) {
-    LOG_DEBUG(*iniDepMatmulOp);
-    if (iniDepMatmulOp->hasAttr(CVPipeline::kMatmulADep) &&
-        iniDepMatmulOp->hasAttr(CVPipeline::kMatmulBDep)) {
-      isOnlyDepInMatmul = false;
-    }
-  }
   // Step 1: Compute expected shape
-  SmallVector<int64_t> expectedShape = computeExpectedShape(
-      origValue, valueIsMatmulA, valueIsMatmulB, isOnlyDepInMatmul);
+  SmallVector<int64_t> expectedShape = computeExpectedShape(origValue);
   int originBlockId = dep.iniProducerBlockId;
   // Step 2: If shapes match, return original value
-  auto [isEqualedShape, matmulPadding] =
-      isExpectedShape(origValue, expectedShape, valueIsMatmulA, valueIsMatmulB,
-                      isOnlyDepInMatmul);
+  bool isEqualedShape = isExpectedShape(origValue, expectedShape);
+  LOG_DEBUG("newValue" << newValue << "\n");
   if (!isEqualedShape) {
-    newValue =
-        normalizeIfNeeded(builder, dep, loc, origValue, expectedShape,
-                          originBlockId, matmulPadding, isOnlyDepInMatmul);
+    newValue = alignShapeByInsertSlice(builder, dep, loc, origValue,
+                                       expectedShape, originBlockId);
   }
   // Step 3: insert nd2nz
   auto srcTensorType = cast<RankedTensorType>(newValue.getType());
@@ -655,7 +396,7 @@ void InterCoreTransferAndSyncPass::Nd2NzNormalize(OpBuilder &builder,
   LOG_DEBUG("[reshape3DOp]: " << *reshape3DOp << "\n");
   LOG_DEBUG("[transposeOp]: " << *transposeOp << "\n");
   LOG_DEBUG("[reshape4DOp]: " << *reshape4DOp << "\n");
-  vecValueMapping[origValue] = reshape4DOp.getResult();
+  ndnzValueMapping[origValue] = reshape4DOp.getResult();
 }
 
 // mark memref.alloc
@@ -914,18 +655,16 @@ Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(
       CVPipeline::getOpBlockId(srcValue.getDefiningOp()).value_or(-1);
   int vecBlockId = CVPipeline::getOpBlockId(vectorStartOp).value_or(-1);
 
+  auto targetShape =
+      isAllTranspoesd ? std::vector<int64_t>{N, M} : std::vector<int64_t>{M, N};
+  auto targetTensorType = RankedTensorType::get(targetShape, elemType);
   auto [cubeAllocOp, vecAllocOp] = createTransferAllocs(
-      builder, loc, {M, N}, elemType, hivm::AddressSpace::UB, cubeEndOp,
+      builder, loc, targetShape, elemType, hivm::AddressSpace::UB, cubeEndOp,
       vectorStartOp, cubeBlockId, vecBlockId, "CUBE", "VECTOR", transferIndex);
+  auto dmaModeAttr = FixpipeDMAModeAttr::get(
+      builder.getContext(),
+      isAllTranspoesd ? FixpipeDMAMode::NZ2DN : FixpipeDMAMode::NZ2ND);
 
-  FixpipeDMAModeAttr dmaModeAttr;
-  if (isAllTranspoesd) {
-    dmaModeAttr =
-        FixpipeDMAModeAttr::get(builder.getContext(), FixpipeDMAMode::NZ2DN);
-  } else {
-    dmaModeAttr =
-        FixpipeDMAModeAttr::get(builder.getContext(), FixpipeDMAMode::NZ2ND);
-  }
   auto fixpipeOp = builder.create<hivm::FixpipeOp>(
       loc, mlir::TypeRange{},    // No return value
       srcValue,                  // src
@@ -938,17 +677,25 @@ Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(
   // Vector side: memspace_cast + to_tensor
   builder.setInsertionPoint(vectorStartOp);
 
-  auto plainMemrefType = MemRefType::get({M, N}, elemType);
+  auto plainMemrefType = MemRefType::get(targetShape, elemType);
   auto memspaceCastOp = builder.create<memref::MemorySpaceCastOp>(
       loc, plainMemrefType, vecAllocOp->getResult(0));
 
   auto toTensorOp = builder.create<bufferization::ToTensorOp>(
-      loc, srcTensorType, memspaceCastOp.getResult(), true, true);
+      loc, targetTensorType, memspaceCastOp.getResult(), true, true);
 
   attachTransferTags(memspaceCastOp, vecBlockId, "VECTOR", transferIndex);
   attachTransferTags(toTensorOp, vecBlockId, "VECTOR", transferIndex);
   LOG_DEBUG("[toTensorOp]: " << *toTensorOp << "\n");
 
+  if (isAllTranspoesd) {
+    for (auto *userOp : srcValue.getUsers()) {
+      if (isa<linalg::TransposeOp>(userOp)) {
+        srcValue = userOp->getResults()[0];
+        break;
+      }
+    }
+  }
   llvm::SmallVector<Operation *> users(srcValue.getUsers().begin(),
                                        srcValue.getUsers().end());
   for (Operation *user : users) {
@@ -958,6 +705,7 @@ Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(
       user->replaceUsesOfWith(srcValue, toTensorOp.getResult());
     }
   }
+
   if (consumedDataOp) {
     *consumedDataOp = toTensorOp;
   }
@@ -1228,18 +976,17 @@ static std::optional<hivm::PIPE> getCopyPipeForAnalyze(hivm::CopyOp copyOp) {
 
 // V->C Transfer Logic
 LogicalResult InterCoreTransferAndSyncPass::handleVectorToCube(
-    OpBuilder &builder, DependencyInfo &dep,
-    llvm::DenseMap<mlir::Value, mlir::Value> vecvalueMapping,
-    llvm::DenseMap<mlir::Value, mlir::Value> cubeValueMapping,
-    FlagIdManager &flagManager, FlagIdReuseManager &flagIdReuseManager) {
+    OpBuilder &builder, DependencyInfo &dep, FlagIdManager &flagManager,
+    FlagIdReuseManager &flagIdReuseManager) {
   mlir::Value srcValue = dep.value;
-  auto it = cubeValueMapping.find(srcValue);
-  if (it != cubeValueMapping.end()) {
-    srcValue = it->second;
-  }
   Location loc = dep.value.getLoc();
+  Value normalizedVal = srcValue;
+
   // Step 1: Shape normalization (automatically insert slice)
-  Value normalizedVal = vecvalueMapping[dep.value];
+  auto it = ndnzValueMapping.find(dep.value);
+  if (it != ndnzValueMapping.end()) {
+    normalizedVal = it->second;
+  }
 
   // Get start/end operations for V/C blocks
   auto [prodStart, prodEnd] = getBlockStartEnd(dep.producerBlockId, module);
@@ -1283,14 +1030,10 @@ LogicalResult InterCoreTransferAndSyncPass::handleVectorToCube(
 
 // C->V Transfer Logic
 LogicalResult InterCoreTransferAndSyncPass::handleCubeToVector(
-    OpBuilder &builder, DependencyInfo &dep,
-    llvm::DenseMap<mlir::Value, mlir::Value> cubeValueMapping,
-    FlagIdManager &flagManager, FlagIdReuseManager &flagIdReuseManager) {
+    OpBuilder &builder, DependencyInfo &dep, FlagIdManager &flagManager,
+    FlagIdReuseManager &flagIdReuseManager) {
   mlir::Value srcValue = dep.value;
-  auto it = cubeValueMapping.find(srcValue);
-  if (it != cubeValueMapping.end()) {
-    srcValue = it->second;
-  }
+
   Location loc = srcValue.getLoc();
   auto [prodStart, prodEnd] =
       getBlockStartEnd(dep.producerBlockId, module); // C Block
@@ -1588,16 +1331,12 @@ LogicalResult InterCoreTransferAndSyncPass::processDependencies(
       Nd2NzNormalize(builder, dep, loc);
     }
   }
-  llvm::DenseMap<mlir::Value, mlir::Value> vecvalueMapping =
-      getVecValueMapping();
-  llvm::DenseMap<mlir::Value, mlir::Value> cubevalueMapping =
-      getCubeValueMapping();
+
   for (auto &dep : V2CDependencies) {
     LOG_DEBUG("[V->C] producerBlockId = " << dep.producerBlockId
                                           << ", consumerBlockId = "
                                           << dep.consumerBlockId << "\n");
-    if (failed(handleVectorToCube(builder, dep, vecvalueMapping,
-                                  cubevalueMapping, flagManager,
+    if (failed(handleVectorToCube(builder, dep, flagManager,
                                   flagIdReuseManager))) {
       LOG_DEBUG("[ERROR] V->C failed! producerBlockId = "
                 << dep.producerBlockId
@@ -1616,7 +1355,7 @@ LogicalResult InterCoreTransferAndSyncPass::processDependencies(
     LOG_DEBUG("[C->V] producerBlockId = " << dep.producerBlockId
                                           << ", consumerBlockId = "
                                           << dep.consumerBlockId << "\n");
-    if (failed(handleCubeToVector(builder, dep, cubevalueMapping, flagManager,
+    if (failed(handleCubeToVector(builder, dep, flagManager,
                                   flagIdReuseManager))) {
       LOG_DEBUG("[ERROR] C->V failed!  producerBlockId = "
                 << dep.producerBlockId

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_inner_unaligned_shape.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_inner_unaligned_shape.mlir
@@ -7,7 +7,7 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">}  {
     %fill = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : f8E4M3FN) outs(%t0 : tensor<31x1xf8E4M3FN>) -> tensor<31x1xf8E4M3FN>
     %exp = math.exp %fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<31x1xf8E4M3FN>
     %alloc = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<1x63xf8E4M3FN>
-    %t1 = bufferization.to_tensor %alloc {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<1x63xf8E4M3FN>
+    %t1 = bufferization.to_tensor %alloc {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<1x63xf8E4M3FN> to tensor<1x63xf8E4M3FN>
     %empty = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<31x63xf8E4M3FN>
     %cst_cube = arith.constant {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} 0.0 : f8E4M3FN
     %init = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_cube : f8E4M3FN) outs(%empty : tensor<31x63xf8E4M3FN>) -> tensor<31x63xf8E4M3FN>
@@ -23,40 +23,28 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">}  {
 // CHECK: %[[CST_0:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 0.000000e+00 : f8E4M3FN
 // CHECK: %[[EMPTY_3:[a-z0-9_]+]] = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf8E4M3FN>
 // CHECK: %[[FILL_4:[a-z0-9_]+]] = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%[[CST_0]] : f8E4M3FN) outs(%[[EMPTY_3]] : tensor<32x32xf8E4M3FN>) -> tensor<32x32xf8E4M3FN>
-// CHECK: %[[INSERTED_SLICE:[a-z0-9_]+]] = tensor.insert_slice %[[EXP_2]] into %[[FILL_4]][0, 0] [31, 1] [1, 1] {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<31x1xf8E4M3FN> into tensor<32x32xf8E4M3FN>
+// CHECK: %[[INSERTED_SLICE:[a-z0-9_]+]] = tensor.insert_slice %[[EXP_2]] into %[[FILL_4]][0, 0] [31, 1] [1, 1] {{.*}} : tensor<31x1xf8E4M3FN> into tensor<32x32xf8E4M3FN>
 
-// CHECK: %[[CST_1:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} dense<[32, 1, 32]> : tensor<3xi64>
-// CHECK: %[[RESHAPE:[a-z0-9_]+]] = tensor.reshape %[[INSERTED_SLICE]](%[[CST_1]]) {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<32x32xf8E4M3FN>, tensor<3xi64>) -> tensor<32x1x32xf8E4M3FN>
-// CHECK: %[[EMPTY_5:[a-z0-9_]+]] = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<1x32x32xf8E4M3FN>
-// CHECK: %[[TRANSPOSED:[a-z0-9_]+]] = linalg.transpose ins(%[[RESHAPE]] : tensor<32x1x32xf8E4M3FN>) outs(%[[EMPTY_5]] : tensor<1x32x32xf8E4M3FN>) permutation = [1, 0, 2]  {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"}
-// CHECK: %[[CST_2:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} dense<[1, 2, 16, 32]> : tensor<4xi64>
-// CHECK: %[[RESHAPE_3:[a-z0-9_]+]] = tensor.reshape %[[TRANSPOSED]](%[[CST_2]]) {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<1x32x32xf8E4M3FN>, tensor<4xi64>) -> tensor<1x2x16x32xf8E4M3FN>
-
-// CHECK: %[[ALLOC:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<1x2x16x32xf8E4M3FN, #hivm.address_space<cbuf>>
-// CHECK: annotation.mark %[[ALLOC]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<1x2x16x32xf8E4M3FN, #hivm.address_space<cbuf>>
-// CHECK: hivm.hir.copy ins(%[[RESHAPE_3]] : tensor<1x2x16x32xf8E4M3FN>) outs(%[[ALLOC]] : memref<1x2x16x32xf8E4M3FN, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32}
-// CHECK: hivm.hir.sync_block_set {{.*}} flag = [[FLAG_1:[0-9]+]]
-
-// CHECK: %[[ALLOC_4:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<1x63xf8E4M3FN>
-// CHECK: %[[TENSOR_6:[a-z0-9_]+]] = bufferization.to_tensor %[[ALLOC_4]] {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<1x63xf8E4M3FN>
+// CHECK: arith.constant
+// CHECK: tensor.reshape
+// CHECK: tensor.empty()
+// CHECK: linalg.transpose
+// CHECK: arith.constant
+// CHECK: %[[RESHAPE_3:[a-z0-9_]+]] = tensor.reshape
+// CHECK: %[[ALLOC:[a-z0-9_]+]] = memref.alloc()
+// CHECK: annotation.mark %[[ALLOC]]
+// CHECK: hivm.hir.copy ins(%[[RESHAPE_3]] : tensor<1x2x16x32xf8E4M3FN>) outs(%[[ALLOC]] : memref<1x2x16x32xf8E4M3FN, #hivm.address_space<cbuf>>)
+// CHECK: hivm.hir.sync_block_set
+// CHECK: memref.alloc()
+// CHECK: %[[TENSOR_6:[a-z0-9_]+]] = bufferization.to_tensor
 // CHECK: tensor.empty()
 // CHECK: arith.constant
-// CHECK: linalg.fill
-// CHECK: %[[CST_6:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f8E4M3FN
-// CHECK: %[[EMPTY_9:[a-z0-9_]+]] = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x63xf8E4M3FN>
-// CHECK: %[[FILL_10:[a-z0-9_]+]] = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%[[CST_6]] : f8E4M3FN) outs(%[[EMPTY_9]] : tensor<32x63xf8E4M3FN>) -> tensor<32x63xf8E4M3FN>
-// CHECK: %[[INSERTED_SLICE_7:[a-z0-9_]+]] = tensor.insert_slice %[[TENSOR_6]] into %[[FILL_10]][0, 0] [1, 63] [1, 1] {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<1x63xf8E4M3FN> into tensor<32x63xf8E4M3FN>
-
-// CHECK: %[[CST_8:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f8E4M3FN
-// CHECK: %[[EMPTY_11:[a-z0-9_]+]] = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x63xf8E4M3FN>
-// CHECK: %[[FILL_12:[a-z0-9_]+]] = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%[[CST_8]] : f8E4M3FN) outs(%[[EMPTY_11]] : tensor<32x63xf8E4M3FN>) -> tensor<32x63xf8E4M3FN>
-
-// CHECK: %[[ALLOC_9:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<1x2x16x32xf8E4M3FN, #hivm.address_space<cbuf>>
-// CHECK: annotation.mark %[[ALLOC_9]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<1x2x16x32xf8E4M3FN, #hivm.address_space<cbuf>>
-// CHECK: hivm.hir.sync_block_wait {{.*}} flag = [[FLAG_1]]
-// CHECK: %[[MEM_13:[a-z0-9_]+]] = hivm.hir.convert_layout %[[ALLOC_9]] output_shape [32, 32] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : (memref<1x2x16x32xf8E4M3FN, #hivm.address_space<cbuf>>) -> memref<32x32xf8E4M3FN, #hivm.address_space<cbuf>>
-// CHECK: %[[MEMSPACECAST:[a-z0-9_]+]] = memref.memory_space_cast %[[MEM_13]] {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<32x32xf8E4M3FN, #hivm.address_space<cbuf>> to memref<32x32xf8E4M3FN>
-// CHECK: %[[TENSOR_14:[a-z0-9_]+]] = bufferization.to_tensor %[[MEMSPACECAST]] restrict writable {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<32x32xf8E4M3FN>
-// CHECK: %[[MATMUL_15:[a-z0-9_]+]] = linalg.matmul {ssbuffer.adep, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%[[TENSOR_14]], %[[INSERTED_SLICE_7]] : tensor<32x32xf8E4M3FN>, tensor<32x63xf8E4M3FN>) outs(%[[FILL_12]] : tensor<32x63xf8E4M3FN>) -> tensor<32x63xf8E4M3FN>
-// CHECK: tensor.extract_slice %[[MATMUL_15]][0, 0] [31, 63] [1, 1] {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.matmul_extract} : tensor<32x63xf8E4M3FN> to tensor<31x63xf8E4M3FN>
+// CHECK: %[[FILL_8:[a-z0-9_]+]] = linalg.fill
+// CHECK: %[[ALLOC_6:[a-z0-9_]+]] = memref.alloc()
+// CHECK: annotation.mark %[[ALLOC_6]]
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: %[[MEM_9:[a-z0-9_]+]] = hivm.hir.convert_layout %[[ALLOC_6]] output_shape [31, 1] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>{{.*}}} : (memref<1x2x16x32xf8E4M3FN, #hivm.address_space<cbuf>>) -> memref<31x1xf8E4M3FN, #hivm.address_space<cbuf>>
+// CHECK: %[[MEMSPACECAST:[a-z0-9_]+]] = memref.memory_space_cast %[[MEM_9]]
+// CHECK: %[[TENSOR_10:[a-z0-9_]+]] = bufferization.to_tensor %memspacecast restrict writable {{.*}} : memref<31x1xf8E4M3FN>
+// CHECK: linalg.matmul {{.*}} ins(%[[TENSOR_10]], %[[TENSOR_6]] : tensor<31x1xf8E4M3FN>, tensor<1x63xf8E4M3FN>) outs(%[[FILL_8]] : tensor<31x63xf8E4M3FN>) -> tensor<31x63xf8E4M3FN>
 // CHECK: return

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_multi_unaligned_shape.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_multi_unaligned_shape.mlir
@@ -24,74 +24,69 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">}  {
 // CHECK-LABEL: func.func @test_multi_unaligned_shape
 
 // CHECK: %[[EXP_2:[a-z0-9_]+]] = math.exp
-// CHECK: %[[CST_0:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 0.000000e+00 : f32
-// CHECK: %[[EMPTY_3:[a-z0-9_]+]] = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x16xf32>
-// CHECK: %[[FILL_4:[a-z0-9_]+]] = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%[[CST_0]] : f32) outs(%[[EMPTY_3]] : tensor<64x16xf32>) -> tensor<64x16xf32>
-// CHECK: %[[INSERTED_SLICE:[a-z0-9_]+]] = tensor.insert_slice %[[EXP_2]] into %[[FILL_4]][0, 0] [63, 7] [1, 1] {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<63x7xf32> into tensor<64x16xf32>
+// CHECK: %[[INSERTED_SLICE:[a-z0-9_]+]] = tensor.insert_slice %[[EXP_2]] into {{.*}}[0, 0] [63, 7] [1, 1] {{.*}} : tensor<63x7xf32> into tensor<64x8xf32>
 
 // CHECK: %[[EXP_7:[a-z0-9_]+]] = math.exp
-// CHECK: %[[CST_1:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 0.000000e+00 : f32
-// CHECK: %[[EMPTY_8:[a-z0-9_]+]] = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<16x8xf32>
-// CHECK: %[[FILL_9:[a-z0-9_]+]] = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%[[CST_1]] : f32) outs(%[[EMPTY_8]] : tensor<16x8xf32>) -> tensor<16x8xf32>
-// CHECK: %[[INSERTED_SLICE_2:[a-z0-9_]+]] = tensor.insert_slice %[[EXP_7]] into %[[FILL_9]][0, 0] [7, 7] [1, 1] {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<7x7xf32> into tensor<16x8xf32>
+// CHECK: %[[INSERTED_SLICE_2:[a-z0-9_]+]] = tensor.insert_slice %[[EXP_7]] into {{.*}}[0, 0] [7, 7] [1, 1] {{.*}} : tensor<7x7xf32> into tensor<16x8xf32>
 
-// CHECK: %[[CST_3:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} dense<[64, 2, 8]> : tensor<3xi64>
-// CHECK: %[[RESHAPE:[a-z0-9_]+]] = tensor.reshape %[[INSERTED_SLICE]](%[[CST_3]]) {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x16xf32>, tensor<3xi64>) -> tensor<64x2x8xf32>
-// CHECK: %[[EMPTY_10:[a-z0-9_]+]] = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<2x64x8xf32>
-// CHECK: %[[TRANSPOSED:[a-z0-9_]+]] = linalg.transpose ins(%[[RESHAPE]] : tensor<64x2x8xf32>) outs(%[[EMPTY_10]] : tensor<2x64x8xf32>) permutation = [1, 0, 2]  {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"}
-// CHECK: %[[CST_4:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} dense<[2, 4, 16, 8]> : tensor<4xi64>
-// CHECK: %[[RESHAPE_5:[a-z0-9_]+]] = tensor.reshape %[[TRANSPOSED]](%[[CST_4]]) {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<2x64x8xf32>, tensor<4xi64>) -> tensor<2x4x16x8xf32>
-
-// CHECK: %[[CST_6:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} dense<[16, 1, 8]> : tensor<3xi64>
-// CHECK: %[[RESHAPE_7:[a-z0-9_]+]] = tensor.reshape %[[INSERTED_SLICE_2]](%[[CST_6]]) {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<16x8xf32>, tensor<3xi64>) -> tensor<16x1x8xf32>
-// CHECK: %[[EMPTY_11:[a-z0-9_]+]] = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<1x16x8xf32>
-// CHECK: %[[TRANSPOSED_8:[a-z0-9_]+]] = linalg.transpose ins(%[[RESHAPE_7]] : tensor<16x1x8xf32>) outs(%[[EMPTY_11]] : tensor<1x16x8xf32>) permutation = [1, 0, 2]  {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"}
-// CHECK: %[[CST_9:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} dense<[1, 1, 16, 8]> : tensor<4xi64>
-// CHECK: %[[RESHAPE_10:[a-z0-9_]+]] = tensor.reshape %[[TRANSPOSED_8]](%[[CST_9]]) {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<1x16x8xf32>, tensor<4xi64>) -> tensor<1x1x16x8xf32>
-
-// CHECK: %[[ALLOC:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<2x4x16x8xf32, #hivm.address_space<cbuf>>
-// CHECK: annotation.mark %[[ALLOC]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<2x4x16x8xf32, #hivm.address_space<cbuf>>
-// CHECK: hivm.hir.copy ins(%[[RESHAPE_5]] : tensor<2x4x16x8xf32>) outs(%[[ALLOC]] : memref<2x4x16x8xf32, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32}
-// CHECK: hivm.hir.sync_block_set {{.*}} flag = [[FLAG_1:[0-9]+]]
-
-// CHECK: %[[ALLOC_11:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<1x1x16x8xf32, #hivm.address_space<cbuf>>
-// CHECK: annotation.mark %[[ALLOC_11]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32} : memref<1x1x16x8xf32, #hivm.address_space<cbuf>>
-// CHECK: hivm.hir.copy ins(%[[RESHAPE_10]] : tensor<1x1x16x8xf32>) outs(%[[ALLOC_11]] : memref<1x1x16x8xf32, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 1 : i32}
-// CHECK: hivm.hir.sync_block_set {{.*}} flag = [[FLAG_2:[0-9]+]]
 // CHECK: arith.constant
+// CHECK: tensor.reshape %[[INSERTED_SLICE]]
+// CHECK: linalg.transpose
+// CHECK: arith.constant
+// CHECK: %[[RESHAPE_5:[a-z0-9_]+]] = tensor.reshape {{.*}} : (tensor<1x64x8xf32>, tensor<4xi64>) -> tensor<1x4x16x8xf32>
+
+// CHECK: arith.constant
+// CHECK: tensor.reshape %[[INSERTED_SLICE_2]]
 // CHECK: tensor.empty()
-// CHECK: linalg.fill
-// CHECK: %[[CST_14:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
-// CHECK: %[[EMPTY_16:[a-z0-9_]+]] = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<64x8xf32>
-// CHECK: %[[FILL_17:[a-z0-9_]+]] = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%[[CST_14]] : f32) outs(%[[EMPTY_16]] : tensor<64x8xf32>) -> tensor<64x8xf32>
+// CHECK: linalg.transpose
+// CHECK: arith.constant
+// CHECK: %[[RESHAPE_10:[a-z0-9_]+]] = tensor.reshape {{.*}} : (tensor<1x16x8xf32>, tensor<4xi64>) -> tensor<1x1x16x8xf32>
 
-// CHECK: %[[ALLOC_15:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<2x4x16x8xf32, #hivm.address_space<cbuf>>
-// CHECK: annotation.mark %[[ALLOC_15]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<2x4x16x8xf32, #hivm.address_space<cbuf>>
-// CHECK: hivm.hir.sync_block_wait {{.*}} flag = [[FLAG_1]]
-// CHECK: %[[MEM_18:[a-z0-9_]+]] = hivm.hir.convert_layout %[[ALLOC_15]] output_shape [64, 16] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : (memref<2x4x16x8xf32, #hivm.address_space<cbuf>>) -> memref<64x16xf32, #hivm.address_space<cbuf>>
-// CHECK: %[[MEMSPACECAST:[a-z0-9_]+]] = memref.memory_space_cast %[[MEM_18]] {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<64x16xf32, #hivm.address_space<cbuf>> to memref<64x16xf32>
-// CHECK: %[[TENSOR_19:[a-z0-9_]+]] = bufferization.to_tensor %[[MEMSPACECAST]] restrict writable {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<64x16xf32>
+// CHECK: %[[ALLOC:[a-z0-9_]+]] = memref.alloc()
+// CHECK: annotation.mark %[[ALLOC]]
 
-// CHECK: %[[ALLOC_16:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32} : memref<1x1x16x8xf32, #hivm.address_space<cbuf>>
-// CHECK: annotation.mark %[[ALLOC_16]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<1>, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32} : memref<1x1x16x8xf32, #hivm.address_space<cbuf>>
-// CHECK: hivm.hir.sync_block_wait {{.*}} flag = [[FLAG_2]]
-// CHECK: %[[MEM_20:[a-z0-9_]+]] = hivm.hir.convert_layout %[[ALLOC_16]] output_shape [16, 8] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32} : (memref<1x1x16x8xf32, #hivm.address_space<cbuf>>) -> memref<16x8xf32, #hivm.address_space<cbuf>>
-// CHECK: %[[MEMSPACECAST_17:[a-z0-9_]+]] = memref.memory_space_cast %[[MEM_20]] {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32} : memref<16x8xf32, #hivm.address_space<cbuf>> to memref<16x8xf32>
-// CHECK: %[[TENSOR_21:[a-z0-9_]+]] = bufferization.to_tensor %[[MEMSPACECAST_17]] restrict writable {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 1 : i32} : memref<16x8xf32>
+// CHECK: hivm.hir.copy ins(%[[RESHAPE_5]] : tensor<1x4x16x8xf32>) outs(%[[ALLOC]] : memref<1x4x16x8xf32, #hivm.address_space<cbuf>>)
+// CHECK: hivm.hir.sync_block_set
 
-// CHECK: %[[MATMUL_22:[a-z0-9_]+]] = linalg.matmul {ssbuffer.adep, ssbuffer.bdep, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%[[TENSOR_19]], %[[TENSOR_21]] : tensor<64x16xf32>, tensor<16x8xf32>) outs(%[[FILL_17]] : tensor<64x8xf32>) -> tensor<64x8xf32>
-// CHECK: %[[EXTRACTED_SLICE:[a-z0-9_]+]] = tensor.extract_slice %[[MATMUL_22]][0, 0] [63, 7] [1, 1] {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.matmul_extract} : tensor<64x8xf32> to tensor<63x7xf32>
+// CHECK: %[[ALLOC_11:[a-z0-9_]+]] = memref.alloc()
+// CHECK: annotation.mark %[[ALLOC_11]]
 
-// CHECK: %[[ALLOC_18:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 2 : i32} : memref<63x7xf32, #hivm.address_space<ub>>
-// CHECK: annotation.mark %[[ALLOC_18]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 2 : i32} : memref<63x7xf32, #hivm.address_space<ub>>
-// CHECK: hivm.hir.fixpipe {dma_mode = #hivm.dma_mode<nz2nd>, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 2 : i32} ins(%[[EXTRACTED_SLICE]] : tensor<63x7xf32>) outs(%[[ALLOC_18]] : memref<63x7xf32, #hivm.address_space<ub>>)
-// CHECK: hivm.hir.sync_block_set {{.*}} flag = 3
+// CHECK: hivm.hir.copy ins(%[[RESHAPE_10]] : tensor<1x1x16x8xf32>) outs(%[[ALLOC_11]] : memref<1x1x16x8xf32, #hivm.address_space<cbuf>>)
+// CHECK: hivm.hir.sync_block_set
 
-// CHECK: hivm.hir.sync_block_wait {{.*}} flag = 3
-// CHECK: %[[ALLOC_19:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 2 : i32} : memref<63x7xf32, #hivm.address_space<ub>>
-// CHECK: annotation.mark %[[ALLOC_19]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<2>, ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 2 : i32} : memref<63x7xf32, #hivm.address_space<ub>>
-// CHECK: %[[MEMSPACECAST_20:[a-z0-9_]+]] = memref.memory_space_cast %[[ALLOC_19]] {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 2 : i32} : memref<63x7xf32, #hivm.address_space<ub>> to memref<63x7xf32>
-// CHECK: %[[TENSOR_23:[a-z0-9_]+]] = bufferization.to_tensor %[[MEMSPACECAST_20]] restrict writable {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 2 : i32} : memref<63x7xf32>
-// CHECK: math.exp %[[TENSOR_23]] {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : tensor<63x7xf32>
+// CHECK: tensor.empty()
+// CHECK: arith.constant
+// CHECK: %[[FILL_13:[a-z0-9_]+]] = linalg.fill
 
+// CHECK: %[[ALLOC_13:[a-z0-9_]+]] = memref.alloc()
+// CHECK: annotation.mark %[[ALLOC_13]]
+// CHECK: hivm.hir.sync_block_wait
+
+// CHECK: hivm.hir.convert_layout %[[ALLOC_13]] output_shape [63, 7] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>{{.*}}} : (memref<1x4x16x8xf32, #hivm.address_space<cbuf>>) -> memref<63x7xf32, #hivm.address_space<cbuf>>
+// CHECK: memref.memory_space_cast
+// CHECK: %[[TENSOR_15:[a-z0-9_]+]] = bufferization.to_tensor
+
+// CHECK: %[[ALLOC_14:[a-z0-9_]+]] = memref.alloc()
+// CHECK: annotation.mark %[[ALLOC_14]]
+// CHECK: hivm.hir.sync_block_wait
+
+// CHECK: hivm.hir.convert_layout %[[ALLOC_14]] output_shape [7, 7] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>{{.*}}} : (memref<1x1x16x8xf32, #hivm.address_space<cbuf>>) -> memref<7x7xf32, #hivm.address_space<cbuf>>
+// CHECK: memref.memory_space_cast
+// CHECK: %[[TENSOR_17:[a-z0-9_]+]] = bufferization.to_tensor
+
+// CHECK: %[[MATMUL_18:[a-z0-9_]+]] = linalg.matmul {{.*}} ins(%[[TENSOR_15]], %[[TENSOR_17]] : tensor<63x7xf32>, tensor<7x7xf32>) outs(%[[FILL_13]] : tensor<63x7xf32>) -> tensor<63x7xf32>
+
+// CHECK: %[[ALLOC_16:[a-z0-9_]+]] = memref.alloc()
+// CHECK: annotation.mark %[[ALLOC_16]]
+
+// CHECK: hivm.hir.fixpipe {{.*}} ins(%[[MATMUL_18]] : tensor<63x7xf32>) outs(%[[ALLOC_16]] : memref<63x7xf32, #hivm.address_space<ub>>)
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: %[[ALLOC_17:[a-z0-9_]+]] = memref.alloc()
+// CHECK: annotation.mark %[[ALLOC_17]]
+
+// CHECK: memref.memory_space_cast %[[ALLOC_17]] {{.*}} : memref<63x7xf32, #hivm.address_space<ub>> to memref<63x7xf32>
+// CHECK: %[[TENSOR_19:[a-z0-9_]+]] = bufferization.to_tensor
+// CHECK: math.exp %[[TENSOR_19]]
 // CHECK: return

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_unaligned_shape.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_unaligned_shape.mlir
@@ -7,7 +7,7 @@ module {
     %fill = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : f16) outs(%t0 : tensor<100x64xf16>) -> tensor<100x64xf16>
     %exp = math.exp %fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<100x64xf16>
     %alloc = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xf16>
-    %t1 = bufferization.to_tensor %alloc {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xf16>
+    %t1 = bufferization.to_tensor %alloc {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xf16> to tensor<64x64xf16>
     %empty = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<100x64xf32>
     %cst_cube = arith.constant {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} 0.0 : f16
     %init = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_cube : f16) outs(%empty : tensor<100x64xf32>) -> tensor<100x64xf32>
@@ -17,38 +17,37 @@ module {
 }
 
 // CHECK-LABEL: func.func @test_unaligned_shape
-// CHECK: arith.constant
-// CHECK: tensor.empty()
-// CHECK: linalg.fill
 // CHECK: %[[EXP_2:[a-z0-9_]+]] = math.exp
-// CHECK: %[[CST_1:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 0.000000e+00 : f16
+// CHECK: %[[CST_0:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 0.000000e+00 : f16
 // CHECK: %[[EMPTY_3:[a-z0-9_]+]] = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<112x64xf16>
-// CHECK: %[[FILL_4:[a-z0-9_]+]] = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%[[CST_1]] : f16) outs(%[[EMPTY_3]] : tensor<112x64xf16>) -> tensor<112x64xf16>
+// CHECK: %[[FILL_4:[a-z0-9_]+]] = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%[[CST_0]] : f16) outs(%[[EMPTY_3]] : tensor<112x64xf16>) -> tensor<112x64xf16>
 // CHECK: %[[INSERTED_SLICE:[a-z0-9_]+]] = tensor.insert_slice %[[EXP_2]] into %[[FILL_4]][0, 0] [100, 64] [1, 1] {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<100x64xf16> into tensor<112x64xf16>
-// CHECK: %[[CST_2:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} dense<[112, 4, 16]> : tensor<3xi64>
-// CHECK: %[[RESHAPE:[a-z0-9_]+]] = tensor.reshape %[[INSERTED_SLICE]](%[[CST_2]]) {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<112x64xf16>, tensor<3xi64>) -> tensor<112x4x16xf16>
-// CHECK: %[[EMPTY_5:[a-z0-9_]+]] = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<4x112x16xf16>
-// CHECK: %[[TRANSPOSED:[a-z0-9_]+]] = linalg.transpose ins(%[[RESHAPE]] : tensor<112x4x16xf16>) outs(%[[EMPTY_5]] : tensor<4x112x16xf16>) permutation = [1, 0, 2]  {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"}
-// CHECK: %[[CST_3:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} dense<[4, 7, 16, 16]> : tensor<4xi64>
-// CHECK: %[[RESHAPE_4:[a-z0-9_]+]] = tensor.reshape %[[TRANSPOSED]](%[[CST_3]]) {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<4x112x16xf16>, tensor<4xi64>) -> tensor<4x7x16x16xf16>
-// CHECK: %[[ALLOC:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<4x7x16x16xf16, #hivm.address_space<cbuf>>
-// CHECK: annotation.mark %[[ALLOC]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32} : memref<4x7x16x16xf16, #hivm.address_space<cbuf>>
-// CHECK: hivm.hir.copy ins(%[[RESHAPE_4]] : tensor<4x7x16x16xf16>) outs(%[[ALLOC]] : memref<4x7x16x16xf16, #hivm.address_space<cbuf>>) {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32}
-// CHECK: hivm.hir.sync_block_set {ssbuffer.analyze_flag_id, ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.transfer_id = 0 : i32}[<VECTOR>, <PIPE_MTE3>, <PIPE_MTE1>] flag = [[FLAG_1:[0-9]+]]
-// CHECK: %[[ALLOC_5:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xf16>
-// CHECK: %[[TENSOR_6:[a-z0-9_]+]] = bufferization.to_tensor %[[ALLOC_5]] {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xf16>
+
+// CHECK: arith.constant {{.*}} dense<[112, 4, 16]> : tensor<3xi64>
+// CHECK: %[[RESHAPE:[a-z0-9_]+]] = tensor.reshape %[[INSERTED_SLICE]]{{.*}} : (tensor<112x64xf16>, tensor<3xi64>) -> tensor<112x4x16xf16>
+// CHECK: %[[EMPTY_5:[a-z0-9_]+]] = tensor.empty() {{.*}} : tensor<4x112x16xf16>
+// CHECK: %[[TRANSPOSED:[a-z0-9_]+]] = linalg.transpose ins(%[[RESHAPE]] : tensor<112x4x16xf16>) outs(%[[EMPTY_5]] : tensor<4x112x16xf16>) permutation = [1, 0, 2]
+// CHECK: arith.constant {{.*}} dense<[4, 7, 16, 16]> : tensor<4xi64>
+// CHECK: %[[RESHAPE_3:[a-z0-9_]+]] = tensor.reshape %[[TRANSPOSED]]{{.*}} : (tensor<4x112x16xf16>, tensor<4xi64>) -> tensor<4x7x16x16xf16>
+
+// CHECK: %[[ALLOC:[a-z0-9_]+]] = memref.alloc()
+// CHECK: annotation.mark %[[ALLOC]]
+
+// CHECK: hivm.hir.copy ins(%[[RESHAPE_3]] : tensor<4x7x16x16xf16>) outs(%[[ALLOC]] : memref<4x7x16x16xf16, #hivm.address_space<cbuf>>)
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: memref.alloc()
+// CHECK: %[[TENSOR_6:[a-z0-9_]+]] = bufferization.to_tensor
 // CHECK: tensor.empty()
 // CHECK: arith.constant
-// CHECK: linalg.fill
-// CHECK: %[[CST_7:[a-z0-9_]+]] = arith.constant {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
-// CHECK: %[[EMPTY_9:[a-z0-9_]+]] = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<112x64xf32>
-// CHECK: %[[FILL_10:[a-z0-9_]+]] = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%[[CST_7]] : f32) outs(%[[EMPTY_9]] : tensor<112x64xf32>) -> tensor<112x64xf32>
-// CHECK: %[[ALLOC_8:[a-z0-9_]+]] = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<4x7x16x16xf16, #hivm.address_space<cbuf>>
-// CHECK: annotation.mark %[[ALLOC_8]] {effects = ["write", "read"], hivm.tightly_coupled_buffer = #hivm.tightly_coupled_buffer<0>, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<4x7x16x16xf16, #hivm.address_space<cbuf>>
-// CHECK: hivm.hir.sync_block_wait {ssbuffer.analyze_flag_id, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32}[<CUBE>, <PIPE_MTE3>, <PIPE_MTE1>] flag = [[FLAG_1]]
-// CHECK: %[[MEM_11:[a-z0-9_]+]] = hivm.hir.convert_layout %[[ALLOC_8]] output_shape [112, 64] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : (memref<4x7x16x16xf16, #hivm.address_space<cbuf>>) -> memref<112x64xf16, #hivm.address_space<cbuf>>
-// CHECK: %[[MEMSPACECAST:[a-z0-9_]+]] = memref.memory_space_cast %[[MEM_11]] {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<112x64xf16, #hivm.address_space<cbuf>> to memref<112x64xf16>
-// CHECK: %[[TENSOR_12:[a-z0-9_]+]] = bufferization.to_tensor %[[MEMSPACECAST]] restrict writable {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.transfer_id = 0 : i32} : memref<112x64xf16>
-// CHECK: %[[MATMUL_13:[a-z0-9_]+]] = linalg.matmul {ssbuffer.adep, ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%[[TENSOR_12]], %[[TENSOR_6]] : tensor<112x64xf16>, tensor<64x64xf16>) outs(%[[FILL_10]] : tensor<112x64xf32>) -> tensor<112x64xf32>
-// CHECK: %[[EXTRACTED_SLICE:[a-z0-9_]+]] = tensor.extract_slice %[[MATMUL_13]][0, 0] [100, 64] [1, 1] {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE", ssbuffer.matmul_extract} : tensor<112x64xf32> to tensor<100x64xf32>
+// CHECK: %[[FILL_8:[a-z0-9_]+]] = linalg.fill
+
+// CHECK: %[[ALLOC_6:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<4x7x16x16xf16, #hivm.address_space<cbuf>>
+// CHECK: annotation.mark %[[ALLOC_6]] {{.*}} : memref<4x7x16x16xf16, #hivm.address_space<cbuf>>
+// CHECK: hivm.hir.sync_block_wait
+
+// CHECK: %[[MEM_9:[a-z0-9_]+]] = hivm.hir.convert_layout %[[ALLOC_6]] output_shape [100, 64] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<nZ>{{.*}}} : (memref<4x7x16x16xf16, #hivm.address_space<cbuf>>) -> memref<100x64xf16, #hivm.address_space<cbuf>>
+// CHECK: %[[MEMSPACECAST:[a-z0-9_]+]] = memref.memory_space_cast %[[MEM_9]] {{.*}} : memref<100x64xf16, #hivm.address_space<cbuf>> to memref<100x64xf16>
+// CHECK: %[[TENSOR_10:[a-z0-9_]+]] = bufferization.to_tensor %[[MEMSPACECAST]] restrict writable {{.*}} : memref<100x64xf16>
+// CHECK: linalg.matmul {{.*}} ins(%[[TENSOR_10]], %[[TENSOR_6]] : tensor<100x64xf16>, tensor<64x64xf16>) outs(%[[FILL_8]] : tensor<100x64xf32>) -> tensor<100x64xf32>
 // CHECK: return


### PR DESCRIPTION
## Summary
improves the ssbuffer split-dataflow pipeline for ND2NZ conversion when tensor shapes are unaligned. It simplifies the normalization flow and makes the transfer path more robust for vector-to-cube and cube-to-vector cases, especially when the dependency involves transpose and reshape patterns.

## Motivation
The current implementation has special handling for matmul-related dependencies and padding/extraction logic for certain ND2NZ unaligned cases. This makes the pass more complex and brittle, and it can fail or produce inconsistent IR for some unaligned shapes.

This change aims to:
- handle unaligned ND2NZ cases more generally;
- reduce dependency on matmul-specific annotation logic;
- keep the generated IR consistent with the new transfer and normalization behavior;
- improve coverage and stability of relevant unit tests.


## What changed
### 1. Simplified shape normalization logic
- Removed the previous matmul-specific special-case branches from the ND2NZ normalization path.
- Unified the expected-shape computation and shape comparison logic to work for the general unaligned case.
- Adjusted normalization to support both float and integer zero initialization more generally.

### 2. Simplified dependency analysis
- Removed the old matmul-attribute-based dependency analysis path.
- Replaced it with a more direct helper that checks whether a value is transposed and then consumed by vector-side ops.
- This reduces coupling between dependency analysis and matmul-specific metadata.   

### 3. Refined inter-core transfer handling
- Simplified the vector-to-cube and cube-to-vector transfer logic to use the normalized value mapping more directly.
- Adjusted the cube-to-vector transfer path so that the target tensor shape and DMA mode are selected based on the actual transfer pattern.
- Made the transfer path more consistent for transpose/reshape-driven dependencies.

### 4. Cleanup of temporary attributes and metadata
- Removed several temporary ssbuffer attributes related to matmul dependency tracking and extraction.
- These attributes are no longer needed after simplifying the pass behavior.    

### 5. Updated test coverage
- Adjusted existing MLIR unittest cases to match the new IR structure and expected behavior.
- Covered cases for:
  - inner unaligned shapes;
  - multi-unaligned shapes;
  - general unaligned shapes.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
