### PR TITLE
[Sync](feat) Add env var to sync workflow for controlling workflow

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -29,6 +29,18 @@ on:
         description: 'Upstream triton commit SHA (leave empty for latest)'
         required: false
         default: ''
+      skip_baseline_llvm:
+        description: 'Skip baseline LLVM compilation'
+        required: false
+        default: 'false'
+      skip_build:
+        description: 'Skip TA build'
+        required: false
+        default: 'false'
+      skip_e2e_test:
+        description: 'Skip end-to-end tests'
+        required: false
+        default: 'false'
   schedule:
     # Weekly, Monday 03:17 UTC — off the :00 mark on purpose.
     - cron: '17 3 * * 1'
@@ -225,6 +237,10 @@ jobs:
           LLVM_INSTALL_PREFIX_SYNC: ~/llvm-install-sync
           # Enable single-step per-commit merge → build → test → fix pipeline.
           TA_SINGLE_STEP_MODE: "true"
+          # Optional skip flags (configure via workflow_dispatch inputs).
+          SKIP_BASELINE_LLVM: ${{ inputs.skip_baseline_llvm }}
+          SKIP_BUILD: ${{ inputs.skip_build }}
+          SKIP_E2E_TEST: ${{ inputs.skip_e2e_test }}
           # Push branch + open PR when everything passes.
           PUSH_TO_GITHUB: "true"
           GITHUB_REPO: triton-lang/triton-ascend


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
### Summary
Add optional skip_baseline_llvm, skip_build, and skip_e2e_test inputs to the sync upstream workflow, allowing faster iteration test by skipping selected stages when triggered manually.

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
