### PR TITLE
[ssbuffer](feat) Matmul add broadcast inline

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -22,10 +22,12 @@
 
 #ifndef ADD_AUTO_SCHEDULING_COMMON_UTILS_H
 #define ADD_AUTO_SCHEDULING_COMMON_UTILS_H
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Value.h"
 #include "llvm/ADT/StringRef.h"
+#include <cstdint>
 #include <string_view>
 
 #include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
@@ -67,11 +69,12 @@ static constexpr llvm::StringLiteral kInlinableQuantScaleAttr =
     "enable_fast_tf32_mul";
 inline constexpr llvm::StringLiteral kHIVMMatmulLimitedInCubeAttr =
     "hivm.matmul_limited_in_cube";
-
 inline constexpr const char *ERRCODE_ATTR =
     "triton_ascend.dynamic_cv_pipeline.rc";
 static constexpr const int ERRCODE_FAILED = 1;
 static constexpr const int ERRCODE_IGNORED = 2;
+constexpr int64_t CACHE_TABLE_BUFFER_SIZE = 4096;
+constexpr int64_t BYTE_SIZE = 8;
 
 enum CoreType {
   UNDETERMINED = 0,
@@ -115,6 +118,9 @@ inline bool isCubeOp(Operation *op) {
 bool isVectorOnlyOp(Operation *op);
 
 bool isScalarLike(Value value);
+bool allResultHasOneUser(Operation *op);
+
+int64_t getBTSizeFromValidBroadcastOp(linalg::BroadcastOp broadcastOp);
 
 } // namespace CVPipeline
 } // namespace mlir

--- a/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h
+++ b/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h
@@ -82,6 +82,8 @@ private:
 
   // Seed operations for CUBE upstream propagation
   llvm::SmallVector<Operation *> cubeSeeds;
+  // if A*B+C's C from broadcast chain, they need to keep for Normalize.
+  llvm::DenseSet<Operation *> inBroadcastChain;
 
   std::shared_ptr<AliasAnalysis> aliasAnalysis;
   std::shared_ptr<CVPipeline::MemoryDependenceGraph> memDepGraph;
@@ -97,6 +99,8 @@ private:
   void matchTransposePattern(Operation *def);
   void matchFillPattern(Operation *def);
   void matchEmptyPattern(Operation *def);
+  void matchBroadcastPattern(Operation *def);
+  Value extractMmadBiasFromPotentialUnitDimExpand(Value bias);
 
   // Downstream pattern matching helpers
   void matchStorePattern(Operation *user);

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
@@ -52,6 +52,7 @@ struct DependencyInfo {
   DependencyType type;
   mlir::Value value;
   bool isScaler = false;
+  bool is1DTensor = false;
   int producerBlockId;
   int consumerBlockId;
   int iniProducerBlockId;
@@ -151,6 +152,7 @@ private:
   bool isValidShapeForDependency(mlir::Value value);
   bool isValidValueForDependency(mlir::Value value);
   bool isValidScalarDependency(mlir::Value value);
+  bool isValid1DValueForDependency(mlir::Value value);
   bool isAllTransposedInVector(mlir::Value value);
   bool isOuterOpArg(mlir::Value value);
   void processIterArgDependencies();

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
@@ -140,7 +140,7 @@ private:
       mlir::OpBuilder &builder, mlir::Value srcValue,
       mlir::Value normalizedValue, mlir::Operation *vectorEndOp,
       mlir::Operation *cubeStartOp, mlir::Location loc, int transferIndex,
-      int iniConsumerId, bool isScaler,
+      int iniConsumerId, bool isScaler, bool is1DTensor,
       mlir::Operation **consumedDataOp = nullptr);
   mlir::Operation *insertCubeToVectorTransfer(
       mlir::OpBuilder &builder, mlir::Value srcValue,

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeArgs.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeArgs.cpp
@@ -294,11 +294,6 @@ void AnalyzeArgsPass::runOnOperation() {
 
   LDBG("Before AnalyzeArgs:\n" << module << "\n");
 
-  if (failed(isInterceptedModule(module))) {
-    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_IGNORED);
-    return;
-  }
-
   if (checkTensorArgsInMainLoop(module) &&
       checkSubfBroadcastMismatchInVectorMainLoop(module)) {
     CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_IGNORED);

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <optional>
 
 #include "llvm/ADT/TypeSwitch.h"
@@ -7,6 +8,7 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -162,6 +164,58 @@ bool isScalarLike(Value value) {
 
   // 4. single-element tensor (all dims == 1)
   return llvm::all_of(shape, [](int64_t dim) { return dim == 1; });
+}
+
+bool allResultHasOneUser(Operation *op) {
+  bool ret = true;
+  for (Value result : op->getResults()) {
+    if (!result.hasOneUse()) {
+      ret = false;
+      break;
+    }
+  }
+  return ret;
+}
+
+int64_t getBTSizeFromValidBroadcastOp(linalg::BroadcastOp broadcastOp) {
+  auto insType =
+      dyn_cast<RankedTensorType>(broadcastOp.getDpsInputs()[0].getType());
+  auto outsType =
+      dyn_cast<RankedTensorType>(broadcastOp.getDpsInits()[0].getType());
+  if (!insType || !outsType) {
+    return -1;
+  }
+  // Only match 1D -> 2D broadcast
+  if (insType.getRank() != 1 || outsType.getRank() != 2) {
+    return -1;
+  }
+  // Must be static shape to compute size
+  if (!insType.hasStaticShape()) {
+    return -1;
+  }
+  // Only match broadcast along dimension 0 (dimensions = [0])
+  // This means output dimension 0 is broadcast, so input dimension 0 maps to
+  // output dimension 1, creating a [N] -> [M, N] broadcast (typical matmul bias
+  // usage where each row has the same bias)
+  auto dimensions = broadcastOp.getDimensions();
+  if (dimensions.size() != 1 || dimensions[0] != 0) {
+    return -1;
+  }
+  // Verify output shape[1] == input shape[0] for correct broadcast semantics
+  auto outShape = outsType.getShape();
+  auto inShape = insType.getShape();
+  if (outShape[1] != inShape[0]) {
+    return -1;
+  }
+  // Check if the source data fits within the cache table buffer (4KB)
+  constexpr int64_t CACHE_TABLE_BUFFER_SIZE = 4096;
+  int64_t numElements = 1;
+  for (int64_t dim : inShape) {
+    numElements *= dim;
+  }
+  int64_t sizeBytes =
+      numElements * (insType.getElementTypeBitWidth() / BYTE_SIZE);
+  return sizeBytes;
 }
 
 } // namespace CVPipeline

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -23,7 +23,6 @@
 #include <queue>
 
 #include "llvm/ADT/DenseSet.h"
-#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 
@@ -35,9 +34,7 @@
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/Interfaces/CastInterfaces.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
-#include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Support/LLVM.h"
 
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
@@ -317,6 +314,93 @@ void OpClassifierPass::matchEmptyPattern(Operation *def) {
 }
 
 // ============================================================================
+// Pattern: tensor.broadcast → matmul (Upstream)
+// ============================================================================
+// Uses bias table buffer to  optimize A*B+C.
+//   %value = arith.constant 0.0 : f32
+//   %out = linalg.broadcast ins(%value: f32) outs(%out: tensor<1024x1024xf32>)
+//   %result = linalg.matmul ins(%a, %b) outs(%out)
+// Matching Logic
+//   1. Check if matmul's operand defining op is tensor.broadcast
+//   2. If matched, mark broadcast as CUBE and add to cubeSeeds
+// Purpose: broadcast operation initializes matmul's output buffer;
+// ============================================================================
+Value OpClassifierPass::extractMmadBiasFromPotentialUnitDimExpand(Value bias) {
+  // It assumes that there only exists expand op in mmad bias defining chain,
+  // while other reshape op like collapse op seems unlikely
+  if (auto expandShapeOp = bias.getDefiningOp<tensor::ExpandShapeOp>()) {
+    auto reassociation = expandShapeOp.getReassociationIndices();
+    auto expandedShape = expandShapeOp.getResultType().getShape();
+    if (llvm::all_of(reassociation, [&expandedShape](ReassociationIndices cur) {
+          uint32_t nonUnitCount =
+              llvm::count_if(cur, [&expandedShape](int64_t idx) {
+                return expandedShape[idx] != 1;
+              });
+
+          return nonUnitCount <= 1;
+        })) {
+      bias = expandShapeOp.getSrc();
+      markCube(expandShapeOp);
+      cubeSeeds.push_back(expandShapeOp);
+      inBroadcastChain.insert(expandShapeOp);
+    }
+  }
+  return bias;
+}
+void OpClassifierPass::matchBroadcastPattern(Operation *def) {
+  auto broadcastOp = dyn_cast<linalg::BroadcastOp>(def);
+
+  if (!broadcastOp)
+    return;
+  if (!CVPipeline::allResultHasOneUser(def)) {
+    return;
+  }
+  // Only match small broadcast with correct dimensions (1D->2D, dimensions=[1])
+  if (auto btUsage = CVPipeline::getBTSizeFromValidBroadcastOp(broadcastOp)) {
+    if (btUsage == -1 || btUsage > CVPipeline::CACHE_TABLE_BUFFER_SIZE) {
+      return;
+    }
+  }
+
+  // check if the broadcast used by matmul's outs
+  for (Operation *user : broadcastOp->getUsers()) {
+    auto matmulOp = dyn_cast<linalg::MatmulOp>(user);
+    if (!matmulOp)
+      continue;
+
+    auto outs = matmulOp.getDpsInits();
+    for (Value out : outs) {
+      if (out.getDefiningOp() != broadcastOp) {
+        return;
+      }
+    }
+  }
+
+  markCube(broadcastOp);
+  cubeSeeds.push_back(broadcastOp);
+  inBroadcastChain.insert(broadcastOp);
+
+  // Maybe need add some extractShape && cast
+  Value src = broadcastOp.getDpsInputs()[0];
+  if (auto expandShapeOp = src.getDefiningOp<tensor::ExpandShapeOp>()) {
+    src = extractMmadBiasFromPotentialUnitDimExpand(src);
+  }
+
+  if (auto castOp = src.getDefiningOp<arith::ExtFOp>()) {
+    if (getElementTypeOrSelf(castOp.getIn().getType()).isF16() &&
+        getElementTypeOrSelf(castOp.getResult().getType()).isF32()) {
+      src = castOp.getIn();
+      markCube(castOp);
+      cubeSeeds.push_back(castOp);
+      inBroadcastChain.insert(castOp);
+    }
+  }
+  if (auto expandShapeOp = src.getDefiningOp<tensor::ExpandShapeOp>()) {
+    src = extractMmadBiasFromPotentialUnitDimExpand(src);
+  }
+}
+
+// ============================================================================
 // Pattern: matmul → hivm.hir.store (Downstream)
 // ============================================================================
 // Matches cases where matmul's output is directly stored to memory.
@@ -399,17 +483,6 @@ void OpClassifierPass::matchMaterializePattern(Operation *user) {
   cubeSeeds.push_back(user);
 }
 
-static bool allResultHasOneUser(Operation *op) {
-  bool ret = true;
-  for (Value result : op->getResults()) {
-    if (!result.hasOneUse()) {
-      ret = false;
-      break;
-    }
-  }
-  return ret;
-}
-
 // Pattern matching for CUBE operations
 int OpClassifierPass::patternMatchCUBE() {
   LOG_DEBUG("--- Step 1: pattern match --->\n");
@@ -447,6 +520,7 @@ int OpClassifierPass::patternMatchCUBE() {
       matchTransposePattern(def);
       matchFillPattern(def);
       matchEmptyPattern(def);
+      matchBroadcastPattern(def);
     }
 
     // ---- Downstream pattern matching ----
@@ -459,7 +533,7 @@ int OpClassifierPass::patternMatchCUBE() {
         Operation *curUser = user;
         Value prevResult = result;
         while (curUser) {
-          if (!allResultHasOneUser(curUser)) {
+          if (!CVPipeline::allResultHasOneUser(curUser)) {
             break;
           }
           if (auto yieldOp = dyn_cast<scf::YieldOp>(curUser)) {
@@ -644,7 +718,9 @@ int OpClassifierPass::propagateCubeUpstream() {
     Operation *cur = cubeQueue.front();
     cubeQueue.pop();
     LLVM_DEBUG(DBGS() << "cur: " << *cur << "\n");
-
+    if (inBroadcastChain.contains(cur)) {
+      continue;
+    }
     // Get upstream operations considering both SSA and memory dependencies
     llvm::SmallVector<Operation *> upstreamOps;
     getUpstreamOpsWithMemoryDeps(cur, upstreamOps);

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
@@ -525,7 +525,8 @@ static void fuseMarkOpToDef(Block *block, ComputeBlockIdManager &bm,
 static bool checkValidInputSeed(Operation *op) {
   // keep unify to OpClassifer
   return isa<linalg::TransposeOp, bufferization::ToTensorOp, linalg::FillOp,
-             tensor::EmptyOp>(op);
+             tensor::EmptyOp, linalg::BroadcastOp, tensor::ExpandShapeOp,
+             arith::ExtFOp>(op);
 }
 static bool checkValidUserSeed(Operation *op) {
   // keep unify to OpClassifer

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -56,6 +56,7 @@ using namespace mlir::CVPipeline;
 static constexpr const char *ssbufferCoreTypeCubeAttr = "CUBE";
 static constexpr const char *ssbufferCoreTypeVectorAttr = "VECTOR";
 static constexpr int ND_SHAPE_LENGTH = 2;
+static constexpr int SHAPE_1D_LENGTH = 1;
 
 // Helper: ssbuffer.core_type
 llvm::StringRef getSsbufferCoreType(Operation *op) {
@@ -118,6 +119,15 @@ bool DataDependencyAnalysisPass::isValidScalarDependency(mlir::Value value) {
   return false;
 }
 
+bool DataDependencyAnalysisPass::isValid1DValueForDependency(
+    mlir::Value value) {
+  auto tensorTy = dyn_cast<TensorType>(value.getType());
+  if (tensorTy && tensorTy.getRank() == SHAPE_1D_LENGTH) {
+    return true;
+  }
+  return false;
+}
+
 // Check if a value is only used by transpose ops whose users are all vector ops
 bool DataDependencyAnalysisPass::isAllTransposedInVector(mlir::Value value) {
   if (!isa<linalg::MatmulOp>(value.getDefiningOp())) {
@@ -142,7 +152,9 @@ bool DataDependencyAnalysisPass::isValidValueForDependency(mlir::Value value) {
   if (isValidScalarDependency(value)) {
     return true;
   }
-
+  if (isValid1DValueForDependency(value)) {
+    return true;
+  }
   if (!isValidShapeForDependency(value)) {
     return false;
   }
@@ -272,6 +284,9 @@ void DataDependencyAnalysisPass::collectDepInfo(
   if (isValidScalarDependency(depvalue)) {
     depInfo.isScaler = true;
   }
+  if (isValid1DValueForDependency(depvalue)) {
+    depInfo.is1DTensor = true;
+  }
   if (isAllTranspoesd) {
     depInfo.isAllTranspoesd = true;
   }
@@ -357,7 +372,9 @@ void DataDependencyAnalysisPass::insertProducerAndRecordDeps(
         findCommonLevelBlockIds(info, newId, userBlockId);
     depInfo.producerBlockId = producerBlockId;
     depInfo.consumerBlockId = consumerBlockId;
-
+    if (isValid1DValueForDependency(iterArg)) {
+      depInfo.is1DTensor = true;
+    }
     if (depType == DependencyType::VectorToCube) {
       v2cDependencies.push_back(depInfo);
     } else {
@@ -425,10 +442,11 @@ void DataDependencyAnalysisPass::processIterArgDependencies() {
       LOG_DEBUG("initValue" << initValue << "\n");
       LOG_DEBUG("yieldedValue" << yieldedValue << "\n");
 
-      if (!isValidShapeForDependency(initValue) ||
-          !isValidShapeForDependency(yieldedValue)) {
+      if (!isValid1DValueForDependency(iterArg) &&
+          (!isValidShapeForDependency(initValue) ||
+           !isValidShapeForDependency(yieldedValue))) {
         LOG_DEBUG("iterarg: " << iterArg
-                              << "is not valid tensor for dependency!");
+                              << " is not valid tensor for dependency!");
         continue;
       }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -528,7 +528,7 @@ InterCoreTransferAndSyncPass::getConsumerWaitPoint(int transferIndex) {
 Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(
     OpBuilder &builder, Value srcValue, Value normalizedValue,
     Operation *vectorEndOp, Operation *cubeStartOp, Location loc,
-    int transferIndex, int iniConsumerId, bool isScaler,
+    int transferIndex, int iniConsumerId, bool isScaler, bool is1DTensor,
     Operation **consumedDataOp) {
   mlir::Operation *sendOp = nullptr;
   mlir::Operation *receiveOp = nullptr;
@@ -597,26 +597,30 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(
 
     builder.setInsertionPoint(cubeStartOp);
 
-    auto nzLayout =
-        hivm::DataLayoutAttr::get(builder.getContext(), hivm::DataLayout::nZ);
-    auto ndLayout =
-        hivm::DataLayoutAttr::get(builder.getContext(), hivm::DataLayout::ND);
-    auto cbufaddressSpaceAttr =
-        builder.getAttr<hivm::AddressSpaceAttr>(hivm::AddressSpace::L1);
-    auto newAllocType = MemRefType::get(srcTensorType.getShape(), elemType,
-                                        nullptr, cbufaddressSpaceAttr);
-    auto convertLayoutOp = builder.create<hivm::ConvertLayoutOp>(
-        loc, newAllocType, cubeAllocOp->getResult(0),
-        nzLayout, // srcLayout
-        ndLayout  // dstLayout
-    );
+    Value memValue = cubeAllocOp->getResult(0);
+    if (!is1DTensor) {
+      auto nzLayout =
+          hivm::DataLayoutAttr::get(builder.getContext(), hivm::DataLayout::nZ);
+      auto ndLayout =
+          hivm::DataLayoutAttr::get(builder.getContext(), hivm::DataLayout::ND);
+      auto cbufaddressSpaceAttr =
+          builder.getAttr<hivm::AddressSpaceAttr>(hivm::AddressSpace::L1);
+      auto newAllocType = MemRefType::get(srcTensorType.getShape(), elemType,
+                                          nullptr, cbufaddressSpaceAttr);
+      auto convertLayoutOp =
+          builder.create<hivm::ConvertLayoutOp>(loc, newAllocType, memValue,
+                                                nzLayout, // srcLayout
+                                                ndLayout  // dstLayout
+          );
+      memValue = convertLayoutOp.getResult();
+      attachTransferTags(convertLayoutOp, cubeBlockId, "CUBE", transferIndex);
+    }
     auto plainMemrefType = MemRefType::get(srcTensorType.getShape(), elemType);
     auto memspaceCastOp = builder.create<memref::MemorySpaceCastOp>(
-        loc, plainMemrefType, convertLayoutOp.getResult());
+        loc, plainMemrefType, memValue);
     auto toTensorOp = builder.create<bufferization::ToTensorOp>(
         loc, srcTensorType, memspaceCastOp.getResult(), true, true);
 
-    attachTransferTags(convertLayoutOp, cubeBlockId, "CUBE", transferIndex);
     attachTransferTags(memspaceCastOp, cubeBlockId, "CUBE", transferIndex);
     attachTransferTags(toTensorOp, cubeBlockId, "CUBE", transferIndex);
     LOG_DEBUG("[toTensorOp]: " << *toTensorOp << "\n");
@@ -1003,7 +1007,7 @@ LogicalResult InterCoreTransferAndSyncPass::handleVectorToCube(
   LOG_DEBUG("after analyzeConsumerReadInsertPoint\n");
   Operation *transferOp = insertVectorToCubeTransfer(
       builder, srcValue, normalizedVal, prodEnd, consStart, loc, transferIndex,
-      dep.iniConsumerBlockId, dep.isScaler, &consumedDataOp);
+      dep.iniConsumerBlockId, dep.isScaler, dep.is1DTensor, &consumedDataOp);
 
   int flagId = flagManager.acquireId(prodStart);
   auto [newProdStart, newProdEnd] =
@@ -1326,7 +1330,7 @@ LogicalResult InterCoreTransferAndSyncPass::processDependencies(
   LOG_DEBUG("Step 1: Handle V->C dependencies\n");
   // Step 1: Handle V->C dependencies
   for (auto &dep : V2CDependencies) {
-    if (!dep.isScaler) {
+    if (!dep.isScaler && !dep.is1DTensor) {
       Location loc = dep.value.getLoc();
       Nd2NzNormalize(builder, dep, loc);
     }

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
@@ -95,9 +95,6 @@ static inline MatmulInputs parseMatmulInputs(linalg::MatmulOp matmulOp) {
 
 // The user is responsible for checking biasDefOp is not null.
 static bool operationIsFillZero(Operation *op) {
-  if (!op) {
-    return false;
-  }
   auto fillOp = dyn_cast<linalg::FillOp>(op);
   if (!fillOp) {
     return false;
@@ -484,10 +481,26 @@ static bool shouldSplitByInput(linalg::MatmulOp matmulOp, Value &outerOutValue,
   if (isInputFilter(matmulOp, outerOutValue, outerInValue)) {
     return true;
   }
+  auto outerInOp = outerInValue.getDefiningOp();
+  if (!outerInOp) {
+    return true;
+  }
+
   if (operationIsFillZero(outerInValue.getDefiningOp())) {
     LOG_DEBUG("Not split because bias is zero. " << matmulOp);
     return false;
   }
+
+  auto broadcastOp = dyn_cast<linalg::BroadcastOp>(outerInOp);
+  if (!broadcastOp)
+    return true;
+  if (auto btUsage = CVPipeline::getBTSizeFromValidBroadcastOp(broadcastOp)) {
+    if (btUsage != -1 && btUsage <= CVPipeline::CACHE_TABLE_BUFFER_SIZE) {
+      LOG_DEBUG("Not split because broadcast bias is small. " << matmulOp);
+      return false;
+    }
+  }
+
   auto defMatmul = dyn_cast_if_present<linalg::MatmulOp>(
       hivm::traceDefOp<linalg::MatmulOp>(outerInValue).value_or(nullptr));
   if (defMatmul) {

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_broadcast_uesd_in_mmad_bias.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_broadcast_uesd_in_mmad_bias.mlir
@@ -1,0 +1,87 @@
+// RUN: triton-opt --add-block-id-for-control-ops --data-dependency-analysis --inter-core-transfer-and-sync --mark-main-loop %s | FileCheck %s
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+    func.func @test_broadcast_used_in_mmad_bias(%arg4: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}){
+    %c1_i32 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 1 : i32
+    %c128_i32 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 128 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 0 : i32
+    %cst_0 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 0.000000e+00 : f32
+    %2 = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32xf32>
+    %3 = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_0 : f32) outs(%2 : tensor<32xf32>) -> tensor<32xf32>
+    %4 = math.exp %3 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32xf32>
+
+    %0 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %1 = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_0 : f32) outs(%0 : tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    %91:2 = scf.for %arg20 = %c0_i32 to %c128_i32 step %c1_i32 iter_args(%arg21 = %1, %arg22 = %4) -> (tensor<32x32xf32>, tensor<32xf32>)  : i32 {
+        %alloc_23 = memref.alloc() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf32>
+        %179 = bufferization.to_tensor %alloc_23 restrict writable {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf32> to tensor<32x32xf32>
+
+        %broadcasted_26 = linalg.broadcast ins(%arg22 : tensor<32xf32>) outs(%0 : tensor<32x32xf32>) dimensions = [0]  {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.used_in_mmad_bias}
+        %182 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} ins(%179, %179 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%broadcasted_26  : tensor<32x32xf32>) -> tensor<32x32xf32>
+
+        %146 = tensor.empty() {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32xf32>
+        %147 = linalg.fill {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_0 : f32) outs(%146 : tensor<32xf32>) -> tensor<32xf32>
+        %reduced_45 = linalg.reduce ins(%182 : tensor<32x32xf32>) outs(%147 : tensor<32xf32>) dimensions = [0]  {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"}
+            (%in: f32, %init: f32) {
+                %174 = arith.addf %in, %init {ssbuffer.block_id = 4 : i32} : f32
+                linalg.yield %174 {ssbuffer.block_id = 4 : i32} : f32
+            }
+
+        scf.yield {ssbuffer.core_type = "VECTOR, VECTOR"} %182, %reduced_45 : tensor<32x32xf32>, tensor<32xf32>
+    } {ssbuffer.core_type = "VECTOR, VECTOR"}
+    return
+}}
+
+// CHECK-LABEL: @test_broadcast_used_in_mmad_bias
+// CHECK: tensor.empty()
+// CHECK: linalg.fill
+// CHECK: %[[EXP_2:[a-z0-9_]+]] = math.exp
+// CHECK: tensor.empty()
+// CHECK: %[[FILL_4:[a-z0-9_]+]] = linalg.fill
+
+// CHECK: %[[ALLOC:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<32xf32, #hivm.address_space<cbuf>>
+// CHECK: annotation.mark %[[ALLOC]]
+// CHECK: %[[ALLOC_0:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<32xf32, #hivm.address_space<cbuf>>
+// CHECK: annotation.mark %[[ALLOC_0]]
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: %[[ALLOC_1:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<32x32xf32, #hivm.address_space<ub>>
+// CHECK: annotation.mark %[[ALLOC_1]]
+// CHECK: %[[ALLOC_2:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<32x32xf32, #hivm.address_space<ub>>
+// CHECK: annotation.mark %[[ALLOC_2]]
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: scf.for {{.*}} iter_args(%[[ARG2:[a-z0-9_]+]] = %[[FILL_4]], %[[ARG3:[a-z0-9_]+]] = %[[EXP_2]])
+// CHECK: arith.constant
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: hivm.hir.copy ins(%[[ARG3]] : tensor<32xf32>) outs(%[[ALLOC]] : memref<32xf32, #hivm.address_space<cbuf>>)
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: memref.alloc()
+// CHECK: %[[TENSOR_6:[a-z0-9_]+]] = bufferization.to_tensor
+
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: memref.memory_space_cast %[[ALLOC_0]] {{.*}} : memref<32xf32, #hivm.address_space<cbuf>> to memref<32xf32>
+// CHECK: %[[TENSOR_7:[a-z0-9_]+]] = bufferization.to_tensor
+
+// CHECK: %[[BROADCASTED:[a-z0-9_]+]] = linalg.broadcast ins(%[[TENSOR_7]] : tensor<32xf32>)
+// CHECK: %[[MATMUL_8:[a-z0-9_]+]] = linalg.matmul {{.*}} ins(%[[TENSOR_6]], %[[TENSOR_6]] : tensor<32x32xf32>, tensor<32x32xf32>) outs(%[[BROADCASTED]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: hivm.hir.fixpipe {{.*}} ins(%[[MATMUL_8]] : tensor<32x32xf32>) outs(%[[ALLOC_1]] : memref<32x32xf32, #hivm.address_space<ub>>)
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: memref.memory_space_cast
+// CHECK: %[[TENSOR_9:[a-z0-9_]+]] = bufferization.to_tensor
+
+// CHECK: linalg.reduce ins(%[[TENSOR_9]] : tensor<32x32xf32>)
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: scf.yield
+
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: return

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/StandardizeOp/split_matmul.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/StandardizeOp/split_matmul.mlir
@@ -410,29 +410,16 @@ module {
   // Case 13: scf.for loop where the upper bound is a function argument.
   // Since one of the bounds is not constant, scfMayNotExec returns true.
   // The loop has a non-zero initial value, so it is split.
-  // After the split, an scf.if checks if the loop executes (ub > lb).
-  // If so, it yields the loop result; otherwise, it fills with zero.
+  // After the split, uses arith.select to handle the may-not-exec case.
   // CHECK-LABEL: func.func @case13_may_not_exec_arg_bound
-  // CHECK-SAME: (%[[UB:.*]]: index, %[[A:.*]]: tensor<32x64xf32>, %[[B:.*]]: tensor<64x32xf32>) -> tensor<32x32xf32>
-  // CHECK-DAG: %[[CST_ZERO:.*]] = arith.constant 0.000000e+00 : f32
-  // CHECK-DAG: %[[CST_ONE:.*]] = arith.constant 1.000000e+00 : f32
-  // CHECK: %[[EMPTY1:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[NONZERO_INIT:.*]] = linalg.fill ins(%[[CST_ONE]] : f32) outs(%[[EMPTY1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK: %[[EMPTY2:.*]] = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[ZERO_INIT:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[EMPTY2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK: %[[FOR_RESULT:.*]] = scf.for %{{.*}} = %{{.*}} to %[[UB]] step %{{.*}} iter_args(%[[ITER_BIAS:.*]] = %[[ZERO_INIT]]) -> (tensor<32x32xf32>) {
-  // CHECK:   %[[MM:.*]] = linalg.matmul {ssbuffer.loop_carried_l0c} ins(%[[A]], %[[B]] : tensor<32x64xf32>, tensor<64x32xf32>) outs(%[[ITER_BIAS]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK:   scf.yield %[[MM]] : tensor<32x32xf32>
-  // CHECK: }
-  // CHECK: %[[COND:.*]] = arith.cmpi sgt, %[[UB]], %{{.*}} : index
-  // CHECK: %[[IF_RESULT:.*]] = scf.if %[[COND]] -> (tensor<32x32xf32>) {
-  // CHECK:   scf.yield %[[FOR_RESULT]] : tensor<32x32xf32>
-  // CHECK: } else {
-  // CHECK:   %[[FILL_ELSE:.*]] = linalg.fill ins(%[[CST_ZERO]] : f32) outs(%[[FOR_RESULT]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK:   scf.yield %[[FILL_ELSE]] : tensor<32x32xf32>
-  // CHECK: }
-  // CHECK: %[[ADD:.*]] = arith.addf %[[IF_RESULT]], %[[NONZERO_INIT]] {ssbuffer.add_from_matmul} : tensor<32x32xf32>
-  // CHECK: return %[[ADD]] : tensor<32x32xf32>
+  // CHECK: arith.constant
+  // CHECK: linalg.fill
+  // CHECK: scf.for
+  // CHECK: linalg.matmul {ssbuffer.loop_carried_l0c}
+  // CHECK: arith.cmpi
+  // CHECK: arith.select
+  // CHECK: arith.addf {{.*}} {ssbuffer.add_from_matmul}
+  // CHECK: return
   func.func @case13_may_not_exec_arg_bound(%ub: index, %A: tensor<32x64xf32>, %B: tensor<64x32xf32>) -> tensor<32x32xf32> {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
@@ -445,5 +432,145 @@ module {
       scf.yield %mm : tensor<32x32xf32>
     }
     return %result : tensor<32x32xf32>
+  }
+
+  // ============================================================================
+  // Test cases for small broadcast bias optimization (commit 056f5dd18)
+  // ============================================================================
+
+// Case 14: Small broadcast bias (64 elements * 4 bytes = 256 bytes < 4KB).
+  // dimensions = [0]: input [N] -> output [M, N], typical matmul bias usage.
+  // Should NOT be split - bias is optimized using cache table buffer.
+  // CHECK-LABEL: func.func @case14_small_broadcast_bias
+  // CHECK: linalg.broadcast
+  // CHECK: linalg.matmul {ssbuffer.loop_carried_l0c}
+  // CHECK-NOT: arith.addf
+  // CHECK: return
+  func.func @case14_small_broadcast_bias(%A: tensor<32x64xf32>, %B: tensor<64x64xf32>, %bias_vec: tensor<64xf32>) -> tensor<32x64xf32> {
+    %empty = tensor.empty() : tensor<32x64xf32>
+    %bias = linalg.broadcast ins(%bias_vec : tensor<64xf32>) outs(%empty : tensor<32x64xf32>) dimensions = [0]
+    %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x64xf32>) outs(%bias : tensor<32x64xf32>) -> tensor<32x64xf32>
+    return %mm : tensor<32x64xf32>
+  }
+
+// Case 15: Large broadcast bias (2048 elements * 4 bytes = 8KB > 4KB).
+  // dimensions = [0]: input [2048] -> output [M, 2048], but exceeds cache threshold.
+  // Should be split into zero-initialized matmul + addf.
+  // CHECK-LABEL: func.func @case15_large_broadcast_bias
+  // CHECK: arith.constant
+  // CHECK: linalg.broadcast
+  // CHECK: linalg.fill
+  // CHECK: linalg.matmul {ssbuffer.loop_carried_l0c}
+  // CHECK: arith.addf {{.*}} {ssbuffer.add_from_matmul}
+  // CHECK: return
+  func.func @case15_large_broadcast_bias(%A: tensor<32x64xf32>, %B: tensor<64x2048xf32>, %bias_vec: tensor<2048xf32>) -> tensor<32x2048xf32> {
+    %empty = tensor.empty() : tensor<32x2048xf32>
+    %bias = linalg.broadcast ins(%bias_vec : tensor<2048xf32>) outs(%empty : tensor<32x2048xf32>) dimensions = [0]
+    %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x2048xf32>) outs(%bias : tensor<32x2048xf32>) -> tensor<32x2048xf32>
+    return %mm : tensor<32x2048xf32>
+  }
+
+  // Case 16: Wrong broadcast dimension (dimensions = [1] instead of [0]).
+  // input [M] -> output [M, N], non-typical matmul bias usage.
+  // Should be split since dimensions[0] != 0.
+  // CHECK-LABEL: func.func @case16_wrong_broadcast_dimension
+  // CHECK: arith.constant
+  // CHECK: linalg.broadcast
+  // CHECK: linalg.fill
+  // CHECK: linalg.matmul {ssbuffer.loop_carried_l0c}
+  // CHECK: arith.addf {{.*}} {ssbuffer.add_from_matmul}
+  // CHECK: return
+  func.func @case16_wrong_broadcast_dimension(%A: tensor<32x64xf32>, %B: tensor<64x64xf32>, %bias_vec: tensor<32xf32>) -> tensor<32x64xf32> {
+    %empty = tensor.empty() : tensor<32x64xf32>
+    %bias = linalg.broadcast ins(%bias_vec : tensor<32xf32>) outs(%empty : tensor<32x64xf32>) dimensions = [1]
+    %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x64xf32>) outs(%bias : tensor<32x64xf32>) -> tensor<32x64xf32>
+    return %mm : tensor<32x64xf32>
+  }
+
+  // Case 17: Broadcast with multiple users.
+  // The broadcast result is used by multiple matmul ops.
+  // Should be split since allResultHasOneUser check fails.
+  // CHECK-LABEL: func.func @case17_broadcast_multiple_users
+  // CHECK: linalg.broadcast
+  // CHECK: linalg.matmul {ssbuffer.loop_carried_l0c}
+  // CHECK: linalg.matmul {ssbuffer.loop_carried_l0c}
+  // CHECK: arith.addf
+  // CHECK: return
+  func.func @case17_broadcast_multiple_users(%A: tensor<32x64xf32>, %B: tensor<64x32xf32>, %bias_vec: tensor<32xf32>) -> tensor<32x32xf32> {
+    %empty = tensor.empty() : tensor<32x32xf32>
+    %bias = linalg.broadcast ins(%bias_vec : tensor<32xf32>) outs(%empty : tensor<32x32xf32>) dimensions = [0]
+    %mm1 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %mm2 = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x32xf32>) outs(%bias : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %result = arith.addf %mm1, %mm2 : tensor<32x32xf32>
+    return %result : tensor<32x32xf32>
+  }
+
+  // Case 18: Small broadcast with f16->f32 ext_f chain.
+  // Pattern: f16 -> ext_f -> broadcast -> matmul
+  // Should NOT be split - the ext_f is marked as CUBE seed.
+  // CHECK-LABEL: func.func @case18_small_broadcast_with_ext_f16
+  // CHECK: arith.extf
+  // CHECK: linalg.broadcast
+  // CHECK: linalg.matmul {ssbuffer.loop_carried_l0c}
+  // CHECK-NOT: arith.addf
+  // CHECK: return
+  func.func @case18_small_broadcast_with_ext_f16(%A: tensor<32x64xf32>, %B: tensor<64x64xf32>, %bias_vec_f16: tensor<64xf16>) -> tensor<32x64xf32> {
+    %bias_vec_f32 = arith.extf %bias_vec_f16 : tensor<64xf16> to tensor<64xf32>
+    %empty = tensor.empty() : tensor<32x64xf32>
+    %bias = linalg.broadcast ins(%bias_vec_f32 : tensor<64xf32>) outs(%empty : tensor<32x64xf32>) dimensions = [0]
+    %mm = linalg.matmul ins(%A, %B : tensor<32x64xf32>, tensor<64x64xf32>) outs(%bias : tensor<32x64xf32>) -> tensor<32x64xf32>
+    return %mm : tensor<32x64xf32>
+  }
+
+  // Case 19: Broadcast with dynamic shape.
+  // Dynamic shapes cannot be optimized because we cannot compute size at compile time.
+  // Should be split.
+  // CHECK-LABEL: func.func @case19_broadcast_dynamic_shape
+  // CHECK: arith.constant
+  // CHECK: tensor.dim
+  // CHECK: linalg.broadcast
+  // CHECK: linalg.fill
+  // CHECK: linalg.matmul {ssbuffer.loop_carried_l0c}
+  // CHECK: arith.addf {{.*}} {ssbuffer.add_from_matmul}
+  // CHECK: return
+  func.func @case19_broadcast_dynamic_shape(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>, %bias_vec: tensor<?xf32>) -> tensor<?x?xf32> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %dim0 = tensor.dim %A, %c0 : tensor<?x?xf32>
+    %dim1 = tensor.dim %bias_vec, %c0 : tensor<?xf32>
+    %empty = tensor.empty(%dim0, %dim1) : tensor<?x?xf32>
+    %bias = linalg.broadcast ins(%bias_vec : tensor<?xf32>) outs(%empty : tensor<?x?xf32>) dimensions = [0]
+    %mm = linalg.matmul ins(%A, %B : tensor<?x?xf32>, tensor<?x?xf32>) outs(%bias : tensor<?x?xf32>) -> tensor<?x?xf32>
+    return %mm : tensor<?x?xf32>
+  }
+
+  // Case 20: Broadcast 1D -> 3D (rank mismatch).
+  // Only 1D -> 2D broadcast is supported for the optimization.
+  // Should be split.
+  // CHECK-LABEL: func.func @case20_broadcast_1d_to_3d
+  // CHECK: linalg.broadcast
+  // CHECK: linalg.batch_matmul
+  // CHECK-NOT: arith.addf
+  // CHECK: return
+  func.func @case20_broadcast_1d_to_3d(%A: tensor<32x64x32xf32>, %B: tensor<32x32x64xf32>, %bias_vec: tensor<64xf32>) -> tensor<32x64x64xf32> {
+    %empty = tensor.empty() : tensor<32x64x64xf32>
+    %bias = linalg.broadcast ins(%bias_vec : tensor<64xf32>) outs(%empty : tensor<32x64x64xf32>) dimensions = [0, 1]
+    %mm = linalg.batch_matmul ins(%A, %B : tensor<32x64x32xf32>, tensor<32x32x64xf32>) outs(%bias : tensor<32x64x64xf32>) -> tensor<32x64x64xf32>
+    return %mm : tensor<32x64x64xf32>
+  }
+
+  // Case 21: Small integer broadcast bias.
+  // Similar to Case 14 but with i32 type.
+  // Should NOT be split.
+  // CHECK-LABEL: func.func @case21_small_broadcast_bias_integer
+  // CHECK: linalg.broadcast
+  // CHECK: linalg.matmul {ssbuffer.loop_carried_l0c}
+  // CHECK-NOT: arith.addi
+  // CHECK: return
+  func.func @case21_small_broadcast_bias_integer(%A: tensor<32x64xi32>, %B: tensor<64x32xi32>, %bias_vec: tensor<32xi32>) -> tensor<32x32xi32> {
+    %empty = tensor.empty() : tensor<32x32xi32>
+    %bias = linalg.broadcast ins(%bias_vec : tensor<32xi32>) outs(%empty : tensor<32x32xi32>) dimensions = [0]
+    %mm = linalg.matmul ins(%A, %B : tensor<32x64xi32>, tensor<64x32xi32>) outs(%bias : tensor<32x32xi32>) -> tensor<32x32xi32>
+    return %mm : tensor<32x32xi32>
   }
 }


### PR DESCRIPTION
# Title: [ssbuffer](feat) Matmul add broadcast inline

## Key Changes
1. New broadcast bias optimization pattern (OpClassifier.cpp)
- Add matchBroadcastPattern method to identify eligible broadcast operations
- When Matmul bias comes from small broadcast (data ≤ 4KB), mark as CUBE operation and keep inline
2. Optimization decision logic (SplitMatmulPattern.cpp)
- Add broadcast bias size check in shouldSplitByInput
- Eligible small broadcasts no longer split into zero-initialized matmul + addf
3. New utility functions (Utils.cpp/h)
- getBTSizeFromValidBroadcastOp: Compute broadcast data size, validate 1D→2D broadcast (dimensions=0)
- allResultHasOneUser: Check if all results have exactly one user
4. Support operation chains
- Support [expand_shape] -> [f16→f32 ext_f] -> [expand_shape] -> broadcast -> matmul chain

5. Test cases (split_matmul.mlir)

6. Ssbuffer transfer 1d tensor from V->C

## Optimization Effect
When Matmul bias comes from small broadcast, directly use cache table buffer for inline processing, avoiding unnecessary matmul split and extra addf operation.


---

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
