### PR TITLE
[compiler](feat) Normalize debug line locations

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -225,7 +225,7 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
             ascend.passes.ttir.set_enable_buffer_insert_optimization(mod, metadata["enable_buffer_insert_optimization"])
             ascend.passes.ttir.add_dynamic_cv_pipeline(pm, compile_on_910_95)
 
-        if not _is_debug_line_info_disabled():
+        if _enable_msdebug():
             ascend.passes.ttir.add_normalize_debug_line_locations(pm)
 
         _intra_val = metadata.get("intra_cache_num")

--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -225,6 +225,9 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
             ascend.passes.ttir.set_enable_buffer_insert_optimization(mod, metadata["enable_buffer_insert_optimization"])
             ascend.passes.ttir.add_dynamic_cv_pipeline(pm, compile_on_910_95)
 
+        if not _is_debug_line_info_disabled():
+            ascend.passes.ttir.add_normalize_debug_line_locations(pm)
+
         _intra_val = metadata.get("intra_cache_num")
         if _intra_val is not None:
             ascend.passes.ttir.set_buffer_count(mod, "INTRA", _intra_val)

--- a/third_party/ascend/include/TritonToLLVM/Passes.h
+++ b/third_party/ascend/include/TritonToLLVM/Passes.h
@@ -17,6 +17,10 @@ namespace triton {
 /// Creates a pass to convert Triton dialect to LLVM dialect.
 std::unique_ptr<OperationPass<ModuleOp>> createTritonToLLVMPass();
 
+/// Creates a pass to normalize locations for debug line table generation.
+std::unique_ptr<OperationPass<ModuleOp>>
+createNormalizeDebugLineLocationsPass();
+
 #define GEN_PASS_REGISTRATION
 #include "ascend/include/TritonToLLVM/Passes.h.inc"
 

--- a/third_party/ascend/include/TritonToLLVM/Passes.td
+++ b/third_party/ascend/include/TritonToLLVM/Passes.td
@@ -14,4 +14,19 @@ def TritonToLLVM : Pass<"triton-to-llvm", "mlir::ModuleOp"> {
   let dependentDialects = ["LLVM::LLVMDialect", "tensor::TensorDialect", "arith::ArithDialect"];
 }
 
+def NormalizeDebugLineLocations : Pass<"normalize-debug-line-locations", "mlir::ModuleOp"> {
+  let summary = "Normalize locations for source-level debug line tables.";
+  let description = [{
+    This pass classifies operations as semantic, control, or synthetic from the
+    perspective of source-level debug line table generation. It preserves or
+    canonicalizes source locations for semantic/control operations, records the
+    selected class in attributes, and moves synthetic lowering-only operations to
+    non-user line anchors while preserving original provenance in attributes.
+    Some synthetic address/value preparation operations may be retargeted to the
+    associated user-visible store location when that better reflects the source
+    line. The pass must not change IR semantics or codegen.
+  }];
+  let constructor = "triton::createNormalizeDebugLineLocationsPass()";
+}
+
 #endif // TRITON_TO_LLVM_CONVERSION_PASSES

--- a/third_party/ascend/lib/TritonToLLVM/CMakeLists.txt
+++ b/third_party/ascend/lib/TritonToLLVM/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_triton_library(TritonToLLVM
+  NormalizeDebugLineLocations.cpp
   TritonToLLVM.cpp
 
   DEPENDS

--- a/third_party/ascend/lib/TritonToLLVM/NormalizeDebugLineLocations.cpp
+++ b/third_party/ascend/lib/TritonToLLVM/NormalizeDebugLineLocations.cpp
@@ -1,0 +1,553 @@
+#include "TritonToLLVM/Passes.h"
+
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/OperationSupport.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSwitch.h"
+
+#include <optional>
+#include <string>
+
+namespace mlir {
+namespace triton {
+#define GEN_PASS_DEF_NORMALIZEDEBUGLINELOCATIONS
+#include "ascend/include/TritonToLLVM/Passes.h.inc"
+} // namespace triton
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+
+constexpr llvm::StringLiteral kOriginAttr = "triton.debug_line.origin";
+constexpr llvm::StringLiteral kClassAttr = "triton.debug_line.class";
+
+enum class DebugLineLocClass { Semantic, Control, Synthetic };
+
+struct SourceLine {
+  StringAttr file;
+  unsigned line = 0;
+
+  explicit operator bool() const { return file && line != 0; }
+
+  bool operator==(const SourceLine &rhs) const {
+    return file == rhs.file && line == rhs.line;
+  }
+
+  std::string getKey() const {
+    if (!*this)
+      return {};
+
+    std::string key = file.getValue().str();
+    key += ":";
+    key += std::to_string(line);
+    return key;
+  }
+};
+
+bool isContainerOp(Operation *op) {
+  return llvm::StringSwitch<bool>(op->getName().getStringRef())
+      .Case("builtin.module", true)
+      .Case("func.func", true)
+      .Case("llvm.func", true)
+      .Case("tt.func", true)
+      .Default(false);
+}
+
+bool hasRealFileLineColLoc(Location loc) {
+  return static_cast<bool>(loc->findInstanceOf<FileLineColLoc>());
+}
+
+SourceLine getSourceLine(Location loc) {
+  if (auto fileLoc = loc->findInstanceOf<FileLineColLoc>())
+    return {fileLoc.getFilename(), fileLoc.getLine()};
+
+  return {};
+}
+
+bool isInternalName(StringRef name) {
+  return name.contains("synthetic") || name.contains("lowering") ||
+         name.contains("helper") || name.contains("tmp") ||
+         name.contains("__") || name.starts_with("llvm.") ||
+         name.starts_with("triton.");
+}
+
+Location canonicalizeSourceLoc(Location loc) {
+  if (isa<UnknownLoc>(loc))
+    return loc;
+
+  // If debug scopes were already materialized, keep the fused metadata intact.
+  if (loc->findInstanceOf<FusedLocWith<LLVM::DIScopeAttr>>())
+    return loc;
+
+  if (auto nameLoc = dyn_cast<NameLoc>(loc)) {
+    Location child = nameLoc.getChildLoc();
+    if (hasRealFileLineColLoc(child) &&
+        isInternalName(nameLoc.getName().getValue()))
+      return child;
+  }
+
+  return loc;
+}
+
+bool hasSourceLikeLocation(Operation *op) {
+  Location loc = canonicalizeSourceLoc(op->getLoc());
+  return !isa<UnknownLoc>(loc) && hasRealFileLineColLoc(loc);
+}
+
+bool isControlOp(Operation *op) {
+  StringRef name = op->getName().getStringRef();
+
+  return llvm::StringSwitch<bool>(name)
+      .Case("scf.for", true)
+      .Case("scf.while", true)
+      .Case("scf.if", true)
+      .Case("scf.condition", true)
+      .Case("cf.br", true)
+      .Case("cf.cond_br", true)
+      .Case("cf.switch", true)
+      .Case("llvm.br", true)
+      .Case("llvm.cond_br", true)
+      .Case("llvm.switch", true)
+      .Case("llvm.return", true)
+      .Case("func.return", true)
+      .Default(false);
+}
+
+bool isAlwaysSyntheticOp(Operation *op) {
+  StringRef name = op->getName().getStringRef();
+
+  return llvm::StringSwitch<bool>(name)
+      .Case("scf.yield", true)
+      .Case("builtin.unrealized_conversion_cast", true)
+      .Case("memref.copy", true)
+      .Case("llvm.mlir.undef", true)
+      .Case("llvm.mlir.zero", true)
+      .Case("llvm.mlir.constant", true)
+      .Case("llvm.mlir.poison", true)
+      .Case("llvm.mlir.none", true)
+      .Default(false);
+}
+
+bool isMaybeHelperConstant(Operation *op) {
+  return op->getName().getStringRef() == "arith.constant";
+}
+
+bool isTensorOnlyLinalgFillOp(Operation *op) {
+  if (op->getName().getStringRef() != "linalg.fill")
+    return false;
+
+  if (op->getNumResults() == 0)
+    return false;
+
+  return llvm::all_of(op->getResultTypes(),
+                      [](Type type) { return isa<TensorType>(type); });
+}
+
+bool isExplicitlyMarkedSynthetic(Operation *op) {
+  if (auto classAttr = op->getAttrOfType<StringAttr>(kClassAttr))
+    return classAttr.getValue() == "synthetic";
+
+  for (NamedAttribute attr : op->getAttrs()) {
+    StringRef name = attr.getName().getValue();
+    if ((name.contains("synthetic") || name.contains("lowering")) &&
+        (isa<UnitAttr>(attr.getValue()) ||
+         (isa<BoolAttr>(attr.getValue()) &&
+          cast<BoolAttr>(attr.getValue()).getValue())))
+      return true;
+  }
+
+  return false;
+}
+
+bool isRealMemoryOrCallOp(Operation *op) {
+  StringRef name = op->getName().getStringRef();
+
+  return name.ends_with(".load") || name.ends_with(".store") ||
+         name.contains("atomic") || name.ends_with(".call") ||
+         name == "func.call" || name == "llvm.call";
+}
+
+bool isArithmeticOrCastOp(Operation *op) {
+  StringRef name = op->getName().getStringRef();
+
+  return name.starts_with("arith.") || name.ends_with(".add") ||
+         name.ends_with(".sub") || name.ends_with(".mul") ||
+         name.ends_with(".div") || name.ends_with(".rem") ||
+         name.ends_with(".and") || name.ends_with(".or") ||
+         name.ends_with(".xor") || name.ends_with(".shl") ||
+         name.ends_with(".shr") || name.contains(".cmp") ||
+         name.contains("cast") || name.contains("ext") ||
+         name.contains("trunc");
+}
+
+bool isUserVisibleStoreAnchorOp(Operation *op) {
+  return op->getName().getStringRef() ==
+         "bufferization.materialize_in_destination";
+}
+
+bool isDestinationViewOp(Operation *op) {
+  StringRef name = op->getName().getStringRef();
+
+  return name == "memref.reinterpret_cast" || name == "memref.subview";
+}
+
+std::optional<Location>
+getUserVisibleStoreLocForDestinationView(Operation *op) {
+  if (!isDestinationViewOp(op))
+    return std::nullopt;
+
+  if (op->getNumResults() != 1)
+    return std::nullopt;
+
+  SourceLine opLine = getSourceLine(canonicalizeSourceLoc(op->getLoc()));
+  if (!opLine)
+    return std::nullopt;
+
+  Value result = op->getResult(0);
+
+  for (Operation *user : result.getUsers()) {
+    if (!isUserVisibleStoreAnchorOp(user))
+      continue;
+
+    SourceLine userLine = getSourceLine(canonicalizeSourceLoc(user->getLoc()));
+
+    if (!userLine || !(userLine == opLine))
+      continue;
+
+    for (OpOperand &operand : user->getOpOperands()) {
+      if (operand.get() != result)
+        continue;
+
+      // bufferization.materialize_in_destination:
+      //   operand #0 = source tensor/value
+      //   operand #1 = destination memref/view
+      if (operand.getOperandNumber() == 1)
+        return canonicalizeSourceLoc(user->getLoc());
+    }
+  }
+
+  return std::nullopt;
+}
+
+bool isDestinationViewForUserVisibleStore(Operation *op) {
+  return getUserVisibleStoreLocForDestinationView(op).has_value();
+}
+
+bool isValuePreparationOp(Operation *op) {
+  StringRef name = op->getName().getStringRef();
+
+  return llvm::StringSwitch<bool>(name)
+             .Case("arith.constant", true)
+             .Case("tensor.empty", true)
+             .Case("tensor.from_elements", true)
+             .Case("bufferization.alloc_tensor", true)
+             .Case("bufferization.to_tensor", true)
+             .Case("bufferization.to_buffer", true)
+             .Default(false) ||
+         isTensorOnlyLinalgFillOp(op);
+}
+
+bool isAddressComputationOp(Operation *op) {
+  StringRef name = op->getName().getStringRef();
+
+  return llvm::StringSwitch<bool>(name)
+             .Case("memref.reinterpret_cast", true)
+             .Case("memref.subview", true)
+             .Case("memref.memory_space_cast", true)
+             .Default(false) ||
+         name.contains("cast") || name.contains("ext") ||
+         name.contains("trunc");
+}
+
+std::optional<Location>
+getUserVisibleStoreLocThroughDestinationView(Operation *op) {
+  if (op->getNumResults() != 1)
+    return std::nullopt;
+
+  Value result = op->getResult(0);
+
+  for (Operation *viewUser : result.getUsers()) {
+    if (!isDestinationViewForUserVisibleStore(viewUser))
+      continue;
+
+    return getUserVisibleStoreLocForDestinationView(viewUser);
+  }
+
+  return std::nullopt;
+}
+
+std::optional<Location>
+getUserVisibleStoreLocThroughTensorInsert(Operation *op) {
+  if (op->getNumResults() != 1)
+    return std::nullopt;
+
+  Value result = op->getResult(0);
+
+  for (Operation *insertUser : result.getUsers()) {
+    if (insertUser->getName().getStringRef() != "tensor.insert")
+      continue;
+
+    // tensor.insert:
+    //   operand #0 = scalar/value being inserted
+    if (insertUser->getNumOperands() == 0 ||
+        insertUser->getOperand(0) != result)
+      continue;
+
+    if (insertUser->getNumResults() != 1)
+      continue;
+
+    SourceLine insertLine =
+        getSourceLine(canonicalizeSourceLoc(insertUser->getLoc()));
+    if (!insertLine)
+      continue;
+
+    Value insertedTensor = insertUser->getResult(0);
+
+    for (Operation *storeUser : insertedTensor.getUsers()) {
+      if (!isUserVisibleStoreAnchorOp(storeUser))
+        continue;
+
+      SourceLine storeLine =
+          getSourceLine(canonicalizeSourceLoc(storeUser->getLoc()));
+
+      if (!storeLine || !(storeLine == insertLine))
+        continue;
+
+      for (OpOperand &operand : storeUser->getOpOperands()) {
+        if (operand.get() != insertedTensor)
+          continue;
+
+        // bufferization.materialize_in_destination:
+        //   operand #0 = source tensor/value
+        //   operand #1 = destination memref/view
+        if (operand.getOperandNumber() == 0)
+          return canonicalizeSourceLoc(storeUser->getLoc());
+      }
+    }
+  }
+
+  return std::nullopt;
+}
+
+DebugLineLocClass
+classifyOperation(Operation *op,
+                  const llvm::StringMap<unsigned> &semanticAnchors) {
+  if (isContainerOp(op))
+    return DebugLineLocClass::Semantic;
+
+  if (isControlOp(op))
+    return DebugLineLocClass::Control;
+
+  if (isExplicitlyMarkedSynthetic(op))
+    return DebugLineLocClass::Synthetic;
+
+  if (!hasSourceLikeLocation(op))
+    return DebugLineLocClass::Synthetic;
+
+  if (isUserVisibleStoreAnchorOp(op))
+    return DebugLineLocClass::Semantic;
+
+  if (isRealMemoryOrCallOp(op))
+    return DebugLineLocClass::Semantic;
+
+  SourceLine line = getSourceLine(canonicalizeSourceLoc(op->getLoc()));
+  bool hasSemanticAnchorOnSameLine =
+      line && semanticAnchors.lookup(line.getKey()) > 0;
+
+  if (isValuePreparationOp(op))
+    return DebugLineLocClass::Synthetic;
+
+  if (isAddressComputationOp(op))
+    return DebugLineLocClass::Synthetic;
+
+  if (isArithmeticOrCastOp(op)) {
+    if (hasSemanticAnchorOnSameLine)
+      return DebugLineLocClass::Synthetic;
+    return DebugLineLocClass::Semantic;
+  }
+
+  if (isAlwaysSyntheticOp(op))
+    return DebugLineLocClass::Synthetic;
+
+  return DebugLineLocClass::Semantic;
+}
+
+StringRef stringifyClass(DebugLineLocClass locClass) {
+  switch (locClass) {
+  case DebugLineLocClass::Semantic:
+    return "semantic";
+  case DebugLineLocClass::Control:
+    return "control";
+  case DebugLineLocClass::Synthetic:
+    return "synthetic";
+  }
+  llvm_unreachable("unknown debug line location class");
+}
+
+bool isReorderedBackwardStep(Operation *op, DebugLineLocClass locClass,
+                             SourceLine previousLine) {
+  if (locClass == DebugLineLocClass::Control || !previousLine)
+    return false;
+
+  SourceLine line = getSourceLine(canonicalizeSourceLoc(op->getLoc()));
+  if (!line || line.file != previousLine.file || line.line >= previousLine.line)
+    return false;
+
+  return isMaybeHelperConstant(op) || isArithmeticOrCastOp(op) ||
+         isValuePreparationOp(op) || isAddressComputationOp(op) ||
+         isAlwaysSyntheticOp(op);
+}
+
+Location makeSyntheticDebugLoc(Operation *op, Location originalLoc) {
+  MLIRContext *context = op->getContext();
+
+  Location sourceLoc = canonicalizeSourceLoc(originalLoc);
+
+  if (auto fileLoc = sourceLoc->findInstanceOf<FileLineColLoc>()) {
+    // Do not use UnknownLoc here: downstream LLVM/Ascend debug-info lowering
+    // expects a file-like location for some operations and may fail on
+    // UnknownLoc.
+    //
+    // DWARF line 0 is used as a non-user source anchor: it preserves a valid
+    // file identity while preventing synthetic/helper ops from being associated
+    // with real Python source lines.
+    return FileLineColLoc::get(context, fileLoc.getFilename().getValue(), 0, 0);
+  }
+
+  return originalLoc;
+}
+
+void preserveOrigin(Operation *op, Location originalLoc) {
+  if (!isa<UnknownLoc>(originalLoc) && !op->hasAttr(kOriginAttr))
+    op->setAttr(kOriginAttr, originalLoc);
+}
+
+void markRetargetedSyntheticOp(Operation *op, Location originalLoc,
+                               Location storeLoc) {
+  MLIRContext *context = op->getContext();
+
+  op->setAttr(
+      kClassAttr,
+      StringAttr::get(context, stringifyClass(DebugLineLocClass::Semantic)));
+  preserveOrigin(op, originalLoc);
+  op->setLoc(storeLoc);
+}
+
+bool retargetSyntheticOpToStoreLoc(Operation *op, Location originalLoc) {
+  if (isAddressComputationOp(op) || isArithmeticOrCastOp(op)) {
+    if (std::optional<Location> storeLoc =
+            getUserVisibleStoreLocForDestinationView(op)) {
+      markRetargetedSyntheticOp(op, originalLoc, *storeLoc);
+      return true;
+    }
+
+    if (std::optional<Location> storeLoc =
+            getUserVisibleStoreLocThroughDestinationView(op)) {
+      markRetargetedSyntheticOp(op, originalLoc, *storeLoc);
+      return true;
+    }
+  }
+
+  if (isArithmeticOrCastOp(op)) {
+    if (std::optional<Location> storeLoc =
+            getUserVisibleStoreLocThroughTensorInsert(op)) {
+      markRetargetedSyntheticOp(op, originalLoc, *storeLoc);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void markOperation(Operation *op, DebugLineLocClass locClass) {
+  MLIRContext *context = op->getContext();
+
+  Location originalLoc = op->getLoc();
+  Location loc = canonicalizeSourceLoc(originalLoc);
+
+  op->setAttr(kClassAttr, StringAttr::get(context, stringifyClass(locClass)));
+
+  if (locClass == DebugLineLocClass::Synthetic) {
+    if (retargetSyntheticOpToStoreLoc(op, originalLoc))
+      return;
+
+    preserveOrigin(op, originalLoc);
+
+    op->setLoc(makeSyntheticDebugLoc(op, originalLoc));
+    return;
+  }
+
+  if (loc != originalLoc)
+    op->setLoc(loc);
+}
+
+void collectSemanticAnchors(Block &block,
+                            llvm::StringMap<unsigned> &semanticAnchors) {
+  for (Operation &op : block) {
+    if (isContainerOp(&op) || isControlOp(&op) ||
+        isExplicitlyMarkedSynthetic(&op) || !hasSourceLikeLocation(&op))
+      continue;
+
+    if (!isUserVisibleStoreAnchorOp(&op) && !isRealMemoryOrCallOp(&op))
+      continue;
+
+    if (SourceLine line = getSourceLine(canonicalizeSourceLoc(op.getLoc())))
+      ++semanticAnchors[line.getKey()];
+  }
+}
+
+struct NormalizeDebugLineLocationsPass
+    : public triton::impl::NormalizeDebugLineLocationsBase<
+          NormalizeDebugLineLocationsPass> {
+  void processBlock(Block &block) {
+    llvm::StringMap<unsigned> semanticAnchors;
+    collectSemanticAnchors(block, semanticAnchors);
+
+    SourceLine previousLine;
+    for (Operation &op : block) {
+      if (isContainerOp(&op))
+        continue;
+
+      DebugLineLocClass locClass = classifyOperation(&op, semanticAnchors);
+      if (isReorderedBackwardStep(&op, locClass, previousLine))
+        locClass = DebugLineLocClass::Synthetic;
+
+      markOperation(&op, locClass);
+
+      if (locClass == DebugLineLocClass::Semantic ||
+          locClass == DebugLineLocClass::Control) {
+        if (SourceLine line = getSourceLine(op.getLoc()))
+          previousLine = line;
+      }
+    }
+  }
+
+  void processRegions(Operation *op) {
+    for (Region &region : op->getRegions()) {
+      for (Block &block : region) {
+        processBlock(block);
+        for (Operation &nestedOp : block)
+          processRegions(&nestedOp);
+      }
+    }
+  }
+
+  void runOnOperation() override { processRegions(getOperation()); }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::triton::createNormalizeDebugLineLocationsPass() {
+  return std::make_unique<NormalizeDebugLineLocationsPass>();
+}

--- a/third_party/ascend/lib/TritonToLLVM/NormalizeDebugLineLocations.cpp
+++ b/third_party/ascend/lib/TritonToLLVM/NormalizeDebugLineLocations.cpp
@@ -129,11 +129,13 @@ bool isControlOp(Operation *op) {
 
 bool isAlwaysSyntheticOp(Operation *op) {
   StringRef name = op->getName().getStringRef();
-
+  // Do not classify memref.copy as always synthetic. In TTIR-to-TTAdapter
+  // lowering, a user-visible tt.load may become a memref.copy-based sequence.
+  // Keeping memref.copy source locations preserves stable DWARF anchors for
+  // load lines that otherwise may disappear from the final line table.
   return llvm::StringSwitch<bool>(name)
       .Case("scf.yield", true)
       .Case("builtin.unrealized_conversion_cast", true)
-      .Case("memref.copy", true)
       .Case("llvm.mlir.undef", true)
       .Case("llvm.mlir.zero", true)
       .Case("llvm.mlir.constant", true)

--- a/third_party/ascend/lib/TritonToLLVM/NormalizeDebugLineLocations.cpp
+++ b/third_party/ascend/lib/TritonToLLVM/NormalizeDebugLineLocations.cpp
@@ -142,10 +142,6 @@ bool isAlwaysSyntheticOp(Operation *op) {
       .Default(false);
 }
 
-bool isMaybeHelperConstant(Operation *op) {
-  return op->getName().getStringRef() == "arith.constant";
-}
-
 bool isTensorOnlyLinalgFillOp(Operation *op) {
   if (op->getName().getStringRef() != "linalg.fill")
     return false;
@@ -231,18 +227,19 @@ bool isAddressComputationOp(Operation *op) {
          name.contains("trunc");
 }
 
+// `previousLine` is the last seen source line of a semantic or control
+// operation. A semantic arithmetic operation that points to an earlier source
+// line was likely reordered by lowering, so treat it as synthetic.
 bool isReorderedBackwardStep(Operation *op, DebugLineLocClass locClass,
                              SourceLine previousLine) {
-  if (locClass == DebugLineLocClass::Control || !previousLine)
+  if (locClass != DebugLineLocClass::Semantic || !previousLine)
     return false;
 
   SourceLine line = getSourceLine(canonicalizeSourceLoc(op->getLoc()));
   if (!line || line.file != previousLine.file || line.line >= previousLine.line)
     return false;
 
-  return isMaybeHelperConstant(op) || isArithmeticOrCastOp(op) ||
-         isValuePreparationOp(op) || isAddressComputationOp(op) ||
-         isAlwaysSyntheticOp(op);
+  return isArithmeticOrCastOp(op);
 }
 
 std::optional<Location> getUniqueStoreLoc(llvm::ArrayRef<Location> candidates) {
@@ -379,15 +376,15 @@ classifyOperation(Operation *op,
   if (isRealMemoryOrCallOp(op))
     return DebugLineLocClass::Semantic;
 
-  SourceLine line = getSourceLine(canonicalizeSourceLoc(op->getLoc()));
-  bool hasSemanticAnchorOnSameLine =
-      line && semanticAnchors.lookup(line.getKey()) > 0;
-
   if (isValuePreparationOp(op))
     return DebugLineLocClass::Synthetic;
 
   if (isAddressComputationOp(op))
     return DebugLineLocClass::Synthetic;
+
+  SourceLine line = getSourceLine(canonicalizeSourceLoc(op->getLoc()));
+  bool hasSemanticAnchorOnSameLine =
+      line && semanticAnchors.lookup(line.getKey()) > 0;
 
   if (isArithmeticOrCastOp(op)) {
     if (hasSemanticAnchorOnSameLine)

--- a/third_party/ascend/lib/TritonToLLVM/NormalizeDebugLineLocations.cpp
+++ b/third_party/ascend/lib/TritonToLLVM/NormalizeDebugLineLocations.cpp
@@ -9,7 +9,9 @@
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Pass/Pass.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
@@ -43,6 +45,8 @@ struct SourceLine {
     return file == rhs.file && line == rhs.line;
   }
 
+  bool operator!=(const SourceLine &rhs) const { return !(*this == rhs); }
+
   std::string getKey() const {
     if (!*this)
       return {};
@@ -54,31 +58,15 @@ struct SourceLine {
   }
 };
 
-bool isContainerOp(Operation *op) {
-  return llvm::StringSwitch<bool>(op->getName().getStringRef())
-      .Case("builtin.module", true)
-      .Case("func.func", true)
-      .Case("llvm.func", true)
-      .Case("tt.func", true)
-      .Default(false);
-}
-
-bool hasRealFileLineColLoc(Location loc) {
-  return static_cast<bool>(loc->findInstanceOf<FileLineColLoc>());
-}
-
-SourceLine getSourceLine(Location loc) {
-  if (auto fileLoc = loc->findInstanceOf<FileLineColLoc>())
-    return {fileLoc.getFilename(), fileLoc.getLine()};
-
-  return {};
-}
-
 bool isInternalName(StringRef name) {
   return name.contains("synthetic") || name.contains("lowering") ||
          name.contains("helper") || name.contains("tmp") ||
          name.contains("__") || name.starts_with("llvm.") ||
          name.starts_with("triton.");
+}
+
+bool hasRealFileLineColLoc(Location loc) {
+  return static_cast<bool>(loc->findInstanceOf<FileLineColLoc>());
 }
 
 Location canonicalizeSourceLoc(Location loc) {
@@ -99,9 +87,25 @@ Location canonicalizeSourceLoc(Location loc) {
   return loc;
 }
 
+SourceLine getSourceLine(Location loc) {
+  if (auto fileLoc = loc->findInstanceOf<FileLineColLoc>())
+    return {fileLoc.getFilename(), fileLoc.getLine()};
+
+  return {};
+}
+
 bool hasSourceLikeLocation(Operation *op) {
   Location loc = canonicalizeSourceLoc(op->getLoc());
   return !isa<UnknownLoc>(loc) && hasRealFileLineColLoc(loc);
+}
+
+bool isContainerOp(Operation *op) {
+  return llvm::StringSwitch<bool>(op->getName().getStringRef())
+      .Case("builtin.module", true)
+      .Case("func.func", true)
+      .Case("llvm.func", true)
+      .Case("tt.func", true)
+      .Default(false);
 }
 
 bool isControlOp(Operation *op) {
@@ -201,48 +205,6 @@ bool isDestinationViewOp(Operation *op) {
   return name == "memref.reinterpret_cast" || name == "memref.subview";
 }
 
-std::optional<Location>
-getUserVisibleStoreLocForDestinationView(Operation *op) {
-  if (!isDestinationViewOp(op))
-    return std::nullopt;
-
-  if (op->getNumResults() != 1)
-    return std::nullopt;
-
-  SourceLine opLine = getSourceLine(canonicalizeSourceLoc(op->getLoc()));
-  if (!opLine)
-    return std::nullopt;
-
-  Value result = op->getResult(0);
-
-  for (Operation *user : result.getUsers()) {
-    if (!isUserVisibleStoreAnchorOp(user))
-      continue;
-
-    SourceLine userLine = getSourceLine(canonicalizeSourceLoc(user->getLoc()));
-
-    if (!userLine || !(userLine == opLine))
-      continue;
-
-    for (OpOperand &operand : user->getOpOperands()) {
-      if (operand.get() != result)
-        continue;
-
-      // bufferization.materialize_in_destination:
-      //   operand #0 = source tensor/value
-      //   operand #1 = destination memref/view
-      if (operand.getOperandNumber() == 1)
-        return canonicalizeSourceLoc(user->getLoc());
-    }
-  }
-
-  return std::nullopt;
-}
-
-bool isDestinationViewForUserVisibleStore(Operation *op) {
-  return getUserVisibleStoreLocForDestinationView(op).has_value();
-}
-
 bool isValuePreparationOp(Operation *op) {
   StringRef name = op->getName().getStringRef();
 
@@ -269,27 +231,86 @@ bool isAddressComputationOp(Operation *op) {
          name.contains("trunc");
 }
 
-std::optional<Location>
-getUserVisibleStoreLocThroughDestinationView(Operation *op) {
+bool isReorderedBackwardStep(Operation *op, DebugLineLocClass locClass,
+                             SourceLine previousLine) {
+  if (locClass == DebugLineLocClass::Control || !previousLine)
+    return false;
+
+  SourceLine line = getSourceLine(canonicalizeSourceLoc(op->getLoc()));
+  if (!line || line.file != previousLine.file || line.line >= previousLine.line)
+    return false;
+
+  return isMaybeHelperConstant(op) || isArithmeticOrCastOp(op) ||
+         isValuePreparationOp(op) || isAddressComputationOp(op) ||
+         isAlwaysSyntheticOp(op);
+}
+
+std::optional<Location> getUniqueStoreLoc(llvm::ArrayRef<Location> candidates) {
+  std::optional<Location> uniqueLoc;
+
+  for (Location candidate : candidates) {
+    Location canonicalLoc = canonicalizeSourceLoc(candidate);
+    if (!uniqueLoc) {
+      uniqueLoc = canonicalLoc;
+      continue;
+    }
+
+    if (*uniqueLoc != canonicalLoc)
+      return std::nullopt;
+  }
+
+  return uniqueLoc;
+}
+
+void collectUserVisibleStoreLocsForDestinationView(
+    Operation *view, llvm::SmallVectorImpl<Location> &candidates) {
+  if (!isDestinationViewOp(view) || view->getNumResults() != 1)
+    return;
+
+  SourceLine viewLine = getSourceLine(canonicalizeSourceLoc(view->getLoc()));
+  if (!viewLine)
+    return;
+
+  Value result = view->getResult(0);
+
+  for (Operation *user : result.getUsers()) {
+    if (!isUserVisibleStoreAnchorOp(user))
+      continue;
+
+    SourceLine userLine = getSourceLine(canonicalizeSourceLoc(user->getLoc()));
+
+    if (!userLine || userLine != viewLine)
+      continue;
+
+    for (OpOperand &operand : user->getOpOperands()) {
+      if (operand.get() != result)
+        continue;
+
+      // bufferization.materialize_in_destination:
+      //   operand #0 = source tensor/value
+      //   operand #1 = destination memref/view
+      if (operand.getOperandNumber() == 1)
+        candidates.push_back(user->getLoc());
+    }
+  }
+}
+
+void collectUserVisibleStoreLocsThroughDestinationView(
+    Operation *op, llvm::SmallVectorImpl<Location> &candidates) {
   if (op->getNumResults() != 1)
-    return std::nullopt;
+    return;
 
   Value result = op->getResult(0);
 
   for (Operation *viewUser : result.getUsers()) {
-    if (!isDestinationViewForUserVisibleStore(viewUser))
-      continue;
-
-    return getUserVisibleStoreLocForDestinationView(viewUser);
+    collectUserVisibleStoreLocsForDestinationView(viewUser, candidates);
   }
-
-  return std::nullopt;
 }
 
-std::optional<Location>
-getUserVisibleStoreLocThroughTensorInsert(Operation *op) {
+void collectUserVisibleStoreLocsThroughTensorInsert(
+    Operation *op, llvm::SmallVectorImpl<Location> &candidates) {
   if (op->getNumResults() != 1)
-    return std::nullopt;
+    return;
 
   Value result = op->getResult(0);
 
@@ -320,7 +341,7 @@ getUserVisibleStoreLocThroughTensorInsert(Operation *op) {
       SourceLine storeLine =
           getSourceLine(canonicalizeSourceLoc(storeUser->getLoc()));
 
-      if (!storeLine || !(storeLine == insertLine))
+      if (!storeLine || storeLine != insertLine)
         continue;
 
       for (OpOperand &operand : storeUser->getOpOperands()) {
@@ -331,12 +352,10 @@ getUserVisibleStoreLocThroughTensorInsert(Operation *op) {
         //   operand #0 = source tensor/value
         //   operand #1 = destination memref/view
         if (operand.getOperandNumber() == 0)
-          return canonicalizeSourceLoc(storeUser->getLoc());
+          candidates.push_back(storeUser->getLoc());
       }
     }
   }
-
-  return std::nullopt;
 }
 
 DebugLineLocClass
@@ -394,20 +413,6 @@ StringRef stringifyClass(DebugLineLocClass locClass) {
   llvm_unreachable("unknown debug line location class");
 }
 
-bool isReorderedBackwardStep(Operation *op, DebugLineLocClass locClass,
-                             SourceLine previousLine) {
-  if (locClass == DebugLineLocClass::Control || !previousLine)
-    return false;
-
-  SourceLine line = getSourceLine(canonicalizeSourceLoc(op->getLoc()));
-  if (!line || line.file != previousLine.file || line.line >= previousLine.line)
-    return false;
-
-  return isMaybeHelperConstant(op) || isArithmeticOrCastOp(op) ||
-         isValuePreparationOp(op) || isAddressComputationOp(op) ||
-         isAlwaysSyntheticOp(op);
-}
-
 Location makeSyntheticDebugLoc(Operation *op, Location originalLoc) {
   MLIRContext *context = op->getContext();
 
@@ -444,26 +449,19 @@ void markRetargetedSyntheticOp(Operation *op, Location originalLoc,
 }
 
 bool retargetSyntheticOpToStoreLoc(Operation *op, Location originalLoc) {
-  if (isAddressComputationOp(op) || isArithmeticOrCastOp(op)) {
-    if (std::optional<Location> storeLoc =
-            getUserVisibleStoreLocForDestinationView(op)) {
-      markRetargetedSyntheticOp(op, originalLoc, *storeLoc);
-      return true;
-    }
+  llvm::SmallVector<Location> candidates;
 
-    if (std::optional<Location> storeLoc =
-            getUserVisibleStoreLocThroughDestinationView(op)) {
-      markRetargetedSyntheticOp(op, originalLoc, *storeLoc);
-      return true;
-    }
+  if (isAddressComputationOp(op) || isArithmeticOrCastOp(op)) {
+    collectUserVisibleStoreLocsForDestinationView(op, candidates);
+    collectUserVisibleStoreLocsThroughDestinationView(op, candidates);
   }
 
-  if (isArithmeticOrCastOp(op)) {
-    if (std::optional<Location> storeLoc =
-            getUserVisibleStoreLocThroughTensorInsert(op)) {
-      markRetargetedSyntheticOp(op, originalLoc, *storeLoc);
-      return true;
-    }
+  if (isArithmeticOrCastOp(op))
+    collectUserVisibleStoreLocsThroughTensorInsert(op, candidates);
+
+  if (std::optional<Location> storeLoc = getUniqueStoreLoc(candidates)) {
+    markRetargetedSyntheticOp(op, originalLoc, *storeLoc);
+    return true;
   }
 
   return false;

--- a/third_party/ascend/lib/TritonToLLVM/NormalizeDebugLineLocations.cpp
+++ b/third_party/ascend/lib/TritonToLLVM/NormalizeDebugLineLocations.cpp
@@ -130,7 +130,7 @@ bool isControlOp(Operation *op) {
 bool isAlwaysSyntheticOp(Operation *op) {
   StringRef name = op->getName().getStringRef();
   // Do not classify memref.copy as always synthetic. In TTIR-to-TTAdapter
-  // lowering, a user-visible tt.load may become a memref.copy-based sequence.
+  // lowering, a user-visible `tt.load` may become a memref.copy-based sequence.
   // Keeping memref.copy source locations preserves stable DWARF anchors for
   // load lines that otherwise may disappear from the final line table.
   return llvm::StringSwitch<bool>(name)

--- a/third_party/ascend/triton_ascend.cc
+++ b/third_party/ascend/triton_ascend.cc
@@ -413,6 +413,10 @@ void init_triton_ascend_passes_ttir(py::module &&m) {
     pm.addPass(mlir::triton::createTritonToLLVMPass());
   });
 
+  m.def("add_normalize_debug_line_locations", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::createNormalizeDebugLineLocationsPass());
+  });
+
   m.def("add_bubble_up_operation", [](mlir::PassManager &pm) {
     pm.addPass(mlir::triton::createBubbleUpOperationPass());
   });

--- a/third_party/ascend/unittest/Conversion/General/TritonToLLVM/normalize_debug_line_locations.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLLVM/normalize_debug_line_locations.mlir
@@ -355,3 +355,216 @@ return %r : i32 loc("shape.py":6:3)
 // CHECK-DAG: #[[SHAPE_LOAD_LOC]] = loc("shape.py":3:5)
 // CHECK-DAG: #[[SHAPE_ADDI_LOC]] = loc("shape.py":5:5)
 // CHECK-DAG: #[[SHAPE_RETURN_LOC]] = loc("shape.py":6:3)
+
+// -----
+
+module {
+func.func @direct_destination_view_ambiguity(%src: tensor<4xf32>, %dst: memref<8xf32>, %idx: index) {
+%view = memref.subview %dst[%idx] [4] [1] : memref<8xf32> to memref<4xf32, strided<[1], offset: ?>> loc("direct_ambiguity.py":10:5)
+bufferization.materialize_in_destination %src in writable %view : (tensor<4xf32>, memref<4xf32, strided<[1], offset: ?>>) -> () loc("direct_ambiguity.py":10:20)
+bufferization.materialize_in_destination %src in writable %view : (tensor<4xf32>, memref<4xf32, strided<[1], offset: ?>>) -> () loc("direct_ambiguity.py":10:30)
+func.return loc("direct_ambiguity.py":11:3)
+}
+}
+
+// CHECK-DAG: #[[$DIRECT_AMBIGUITY_ORIGIN:[A-Za-z0-9_]+]] = loc("direct_ambiguity.py":10:5)
+
+// CHECK-LABEL: func.func @direct_destination_view_ambiguity
+// CHECK: %[[DIRECT_AMBIGUOUS_VIEW:[A-Za-z0-9_]+]] = memref.subview
+// CHECK-SAME: triton.debug_line.class = "synthetic"
+// CHECK-SAME: triton.debug_line.origin = #[[$DIRECT_AMBIGUITY_ORIGIN]]
+// CHECK-SAME: loc(#[[DIRECT_AMBIGUITY_SYNTH_LOC:[A-Za-z0-9_]+]])
+// CHECK: bufferization.materialize_in_destination %{{.*}} in writable %[[DIRECT_AMBIGUOUS_VIEW]]
+// CHECK-SAME: triton.debug_line.class = "semantic"
+// CHECK-SAME: loc(#[[DIRECT_STORE_0_LOC:[A-Za-z0-9_]+]])
+// CHECK: bufferization.materialize_in_destination %{{.*}} in writable %[[DIRECT_AMBIGUOUS_VIEW]]
+// CHECK-SAME: triton.debug_line.class = "semantic"
+// CHECK-SAME: loc(#[[DIRECT_STORE_1_LOC:[A-Za-z0-9_]+]])
+
+// CHECK-DAG: #[[DIRECT_AMBIGUITY_SYNTH_LOC]] = loc("direct_ambiguity.py":0:0)
+// CHECK-DAG: #[[DIRECT_STORE_0_LOC]] = loc("direct_ambiguity.py":10:20)
+// CHECK-DAG: #[[DIRECT_STORE_1_LOC]] = loc("direct_ambiguity.py":10:30)
+
+// -----
+
+module {
+func.func @through_destination_view_ambiguity(%src: tensor<4xf32>, %dst0: memref<8xf32>, %dst1: memref<8xf32>, %offset: i32) {
+%idx = arith.index_cast %offset : i32 to index loc("through_view_ambiguity.py":20:5)
+%view0 = memref.subview %dst0[%idx] [4] [1] : memref<8xf32> to memref<4xf32, strided<[1], offset: ?>> loc("through_view_ambiguity.py":21:5)
+bufferization.materialize_in_destination %src in writable %view0 : (tensor<4xf32>, memref<4xf32, strided<[1], offset: ?>>) -> () loc("through_view_ambiguity.py":21:20)
+%view1 = memref.subview %dst1[%idx] [4] [1] : memref<8xf32> to memref<4xf32, strided<[1], offset: ?>> loc("through_view_ambiguity.py":22:5)
+bufferization.materialize_in_destination %src in writable %view1 : (tensor<4xf32>, memref<4xf32, strided<[1], offset: ?>>) -> () loc("through_view_ambiguity.py":22:20)
+func.return loc("through_view_ambiguity.py":23:3)
+}
+}
+
+// CHECK-DAG: #[[$THROUGH_VIEW_AMBIGUITY_ORIGIN:[A-Za-z0-9_]+]] = loc("through_view_ambiguity.py":20:5)
+
+// CHECK-LABEL: func.func @through_destination_view_ambiguity
+// CHECK: %[[THROUGH_VIEW_IDX:[A-Za-z0-9_]+]] = arith.index_cast
+// CHECK-SAME: triton.debug_line.class = "synthetic"
+// CHECK-SAME: triton.debug_line.origin = #[[$THROUGH_VIEW_AMBIGUITY_ORIGIN]]
+// CHECK-SAME: loc(#[[THROUGH_VIEW_AMBIGUITY_SYNTH_LOC:[A-Za-z0-9_]+]])
+// CHECK: %[[THROUGH_VIEW_0:[A-Za-z0-9_]+]] = memref.subview {{.*}}[%[[THROUGH_VIEW_IDX]]]
+// CHECK-SAME: triton.debug_line.class = "semantic"
+// CHECK-SAME: loc(#[[THROUGH_VIEW_STORE_0_LOC:[A-Za-z0-9_]+]])
+// CHECK: %[[THROUGH_VIEW_1:[A-Za-z0-9_]+]] = memref.subview {{.*}}[%[[THROUGH_VIEW_IDX]]]
+// CHECK-SAME: triton.debug_line.class = "semantic"
+// CHECK-SAME: loc(#[[THROUGH_VIEW_STORE_1_LOC:[A-Za-z0-9_]+]])
+
+// CHECK-DAG: #[[THROUGH_VIEW_AMBIGUITY_SYNTH_LOC]] = loc("through_view_ambiguity.py":0:0)
+// CHECK-DAG: #[[THROUGH_VIEW_STORE_0_LOC]] = loc("through_view_ambiguity.py":21:20)
+// CHECK-DAG: #[[THROUGH_VIEW_STORE_1_LOC]] = loc("through_view_ambiguity.py":22:20)
+
+// -----
+
+module {
+func.func @through_tensor_insert_ambiguity(%lhs: f32, %rhs: f32, %base0: tensor<1xf32>, %base1: tensor<1xf32>, %dst0: memref<1xf32>, %dst1: memref<1xf32>, %idx: index) {
+%sum = arith.addf %lhs, %rhs : f32 loc("tensor_insert_ambiguity.py":30:5)
+%inserted0 = tensor.insert %sum into %base0[%idx] : tensor<1xf32> loc("tensor_insert_ambiguity.py":30:10)
+bufferization.materialize_in_destination %inserted0 in writable %dst0 : (tensor<1xf32>, memref<1xf32>) -> () loc("tensor_insert_ambiguity.py":30:30)
+%inserted1 = tensor.insert %sum into %base1[%idx] : tensor<1xf32> loc("tensor_insert_ambiguity.py":30:11)
+bufferization.materialize_in_destination %inserted1 in writable %dst1 : (tensor<1xf32>, memref<1xf32>) -> () loc("tensor_insert_ambiguity.py":30:40)
+func.return loc("tensor_insert_ambiguity.py":31:3)
+}
+}
+
+// CHECK-DAG: #[[$TENSOR_INSERT_AMBIGUITY_ORIGIN:[A-Za-z0-9_]+]] = loc("tensor_insert_ambiguity.py":30:5)
+
+// CHECK-LABEL: func.func @through_tensor_insert_ambiguity
+// CHECK: %[[TENSOR_INSERT_SUM:[A-Za-z0-9_]+]] = arith.addf
+// CHECK-SAME: triton.debug_line.class = "synthetic"
+// CHECK-SAME: triton.debug_line.origin = #[[$TENSOR_INSERT_AMBIGUITY_ORIGIN]]
+// CHECK-SAME: loc(#[[TENSOR_INSERT_AMBIGUITY_SYNTH_LOC:[A-Za-z0-9_]+]])
+// CHECK: %[[TENSOR_INSERTED_0:[A-Za-z0-9_]+]] = tensor.insert %[[TENSOR_INSERT_SUM]]
+// CHECK: bufferization.materialize_in_destination %[[TENSOR_INSERTED_0]]
+// CHECK-SAME: loc(#[[TENSOR_INSERT_STORE_0_LOC:[A-Za-z0-9_]+]])
+// CHECK: %[[TENSOR_INSERTED_1:[A-Za-z0-9_]+]] = tensor.insert %[[TENSOR_INSERT_SUM]]
+// CHECK: bufferization.materialize_in_destination %[[TENSOR_INSERTED_1]]
+// CHECK-SAME: loc(#[[TENSOR_INSERT_STORE_1_LOC:[A-Za-z0-9_]+]])
+
+// CHECK-DAG: #[[TENSOR_INSERT_AMBIGUITY_SYNTH_LOC]] = loc("tensor_insert_ambiguity.py":0:0)
+// CHECK-DAG: #[[TENSOR_INSERT_STORE_0_LOC]] = loc("tensor_insert_ambiguity.py":30:30)
+// CHECK-DAG: #[[TENSOR_INSERT_STORE_1_LOC]] = loc("tensor_insert_ambiguity.py":30:40)
+
+// -----
+
+module {
+func.func @duplicate_canonical_store_candidates(%src: tensor<4xf32>, %dst: memref<8xf32>, %idx: index) {
+%view = memref.subview %dst[%idx] [4] [1] : memref<8xf32> to memref<4xf32, strided<[1], offset: ?>> loc("duplicate_candidates.py":40:5)
+bufferization.materialize_in_destination %src in writable %view : (tensor<4xf32>, memref<4xf32, strided<[1], offset: ?>>) -> () loc("synthetic_store"("duplicate_candidates.py":40:30))
+bufferization.materialize_in_destination %src in writable %view : (tensor<4xf32>, memref<4xf32, strided<[1], offset: ?>>) -> () loc("duplicate_candidates.py":40:30)
+func.return loc("duplicate_candidates.py":41:3)
+}
+}
+
+// CHECK-DAG: #[[$DUPLICATE_VIEW_ORIGIN:[A-Za-z0-9_]+]] = loc("duplicate_candidates.py":40:5)
+
+// CHECK-LABEL: func.func @duplicate_canonical_store_candidates
+// CHECK: %[[DUPLICATE_VIEW:[A-Za-z0-9_]+]] = memref.subview
+// CHECK-SAME: triton.debug_line.class = "semantic"
+// CHECK-SAME: triton.debug_line.origin = #[[$DUPLICATE_VIEW_ORIGIN]]
+// CHECK-SAME: loc(#[[DUPLICATE_STORE_LOC:[A-Za-z0-9_]+]])
+// CHECK: bufferization.materialize_in_destination %{{.*}} in writable %[[DUPLICATE_VIEW]]
+// CHECK-SAME: triton.debug_line.class = "semantic"
+// CHECK-SAME: loc(#[[DUPLICATE_STORE_LOC]])
+// CHECK: bufferization.materialize_in_destination %{{.*}} in writable %[[DUPLICATE_VIEW]]
+// CHECK-SAME: triton.debug_line.class = "semantic"
+// CHECK-SAME: loc(#[[DUPLICATE_STORE_LOC]])
+
+// CHECK-DAG: #[[DUPLICATE_STORE_LOC]] = loc("duplicate_candidates.py":40:30)
+
+// -----
+
+module {
+func.func @direct_and_nested_destination_view_ambiguity(%src: tensor<4xf32>, %dst: memref<8xf32>, %idx: index) {
+%view = memref.subview %dst[%idx] [4] [1] : memref<8xf32> to memref<4xf32, strided<[1], offset: ?>> loc("cross_view_ambiguity.py":50:5)
+bufferization.materialize_in_destination %src in writable %view : (tensor<4xf32>, memref<4xf32, strided<[1], offset: ?>>) -> () loc("cross_view_ambiguity.py":50:20)
+bufferization.materialize_in_destination %src in writable %view : (tensor<4xf32>, memref<4xf32, strided<[1], offset: ?>>) -> () loc("cross_view_ambiguity.py":50:30)
+%nested = memref.subview %view[0] [4] [1] : memref<4xf32, strided<[1], offset: ?>> to memref<4xf32, strided<[1], offset: ?>> loc("cross_view_ambiguity.py":51:5)
+bufferization.materialize_in_destination %src in writable %nested : (tensor<4xf32>, memref<4xf32, strided<[1], offset: ?>>) -> () loc("cross_view_ambiguity.py":51:20)
+func.return loc("cross_view_ambiguity.py":52:3)
+}
+}
+
+// CHECK-DAG: #[[$CROSS_VIEW_ORIGIN:[A-Za-z0-9_]+]] = loc("cross_view_ambiguity.py":50:5)
+
+// CHECK-LABEL: func.func @direct_and_nested_destination_view_ambiguity
+// CHECK: %[[CROSS_VIEW:[A-Za-z0-9_]+]] = memref.subview
+// CHECK-SAME: triton.debug_line.class = "synthetic"
+// CHECK-SAME: triton.debug_line.origin = #[[$CROSS_VIEW_ORIGIN]]
+// CHECK-SAME: loc(#[[CROSS_VIEW_SYNTH_LOC:[A-Za-z0-9_]+]])
+// CHECK: bufferization.materialize_in_destination %{{.*}} in writable %[[CROSS_VIEW]]
+// CHECK-SAME: loc(#[[CROSS_VIEW_STORE_A:[A-Za-z0-9_]+]])
+// CHECK: bufferization.materialize_in_destination %{{.*}} in writable %[[CROSS_VIEW]]
+// CHECK-SAME: loc(#[[CROSS_VIEW_STORE_B:[A-Za-z0-9_]+]])
+// CHECK: %[[CROSS_NESTED:[A-Za-z0-9_]+]] = memref.subview %[[CROSS_VIEW]]
+// CHECK: bufferization.materialize_in_destination %{{.*}} in writable %[[CROSS_NESTED]]
+// CHECK-SAME: loc(#[[CROSS_VIEW_STORE_C:[A-Za-z0-9_]+]])
+
+// CHECK-DAG: #[[CROSS_VIEW_SYNTH_LOC]] = loc("cross_view_ambiguity.py":0:0)
+// CHECK-DAG: #[[CROSS_VIEW_STORE_A]] = loc("cross_view_ambiguity.py":50:20)
+// CHECK-DAG: #[[CROSS_VIEW_STORE_B]] = loc("cross_view_ambiguity.py":50:30)
+// CHECK-DAG: #[[CROSS_VIEW_STORE_C]] = loc("cross_view_ambiguity.py":51:20)
+
+// -----
+
+module {
+func.func @destination_view_and_tensor_insert_ambiguity(%offset: i32, %src: tensor<1xindex>, %base: tensor<1xindex>, %dst0: memref<4xindex>, %dst1: memref<1xindex>) {
+%c0 = arith.constant 0 : index loc("cross_path_ambiguity.py":60:3)
+%idx = arith.index_cast %offset : i32 to index loc("cross_path_ambiguity.py":60:5)
+%view = memref.subview %dst0[%idx] [1] [1] : memref<4xindex> to memref<1xindex, strided<[1], offset: ?>> loc("cross_path_ambiguity.py":61:5)
+bufferization.materialize_in_destination %src in writable %view : (tensor<1xindex>, memref<1xindex, strided<[1], offset: ?>>) -> () loc("cross_path_ambiguity.py":61:20)
+%inserted = tensor.insert %idx into %base[%c0] : tensor<1xindex> loc("cross_path_ambiguity.py":62:5)
+bufferization.materialize_in_destination %inserted in writable %dst1 : (tensor<1xindex>, memref<1xindex>) -> () loc("cross_path_ambiguity.py":62:20)
+func.return loc("cross_path_ambiguity.py":63:3)
+}
+}
+
+// CHECK-DAG: #[[$CROSS_PATH_AMBIGUITY_ORIGIN:[A-Za-z0-9_]+]] = loc("cross_path_ambiguity.py":60:5)
+
+// CHECK-LABEL: func.func @destination_view_and_tensor_insert_ambiguity
+// CHECK: %[[CROSS_PATH_IDX:[A-Za-z0-9_]+]] = arith.index_cast
+// CHECK-SAME: triton.debug_line.class = "synthetic"
+// CHECK-SAME: triton.debug_line.origin = #[[$CROSS_PATH_AMBIGUITY_ORIGIN]]
+// CHECK-SAME: loc(#[[CROSS_PATH_SYNTH_LOC:[A-Za-z0-9_]+]])
+// CHECK: %[[CROSS_PATH_VIEW:[A-Za-z0-9_]+]] = memref.subview {{.*}}[%[[CROSS_PATH_IDX]]]
+// CHECK: bufferization.materialize_in_destination %{{.*}} in writable %[[CROSS_PATH_VIEW]]
+// CHECK-SAME: loc(#[[CROSS_PATH_STORE_A:[A-Za-z0-9_]+]])
+// CHECK: %[[CROSS_PATH_INSERTED:[A-Za-z0-9_]+]] = tensor.insert %[[CROSS_PATH_IDX]]
+// CHECK: bufferization.materialize_in_destination %[[CROSS_PATH_INSERTED]]
+// CHECK-SAME: loc(#[[CROSS_PATH_STORE_B:[A-Za-z0-9_]+]])
+
+// CHECK-DAG: #[[CROSS_PATH_SYNTH_LOC]] = loc("cross_path_ambiguity.py":0:0)
+// CHECK-DAG: #[[CROSS_PATH_STORE_A]] = loc("cross_path_ambiguity.py":61:20)
+// CHECK-DAG: #[[CROSS_PATH_STORE_B]] = loc("cross_path_ambiguity.py":62:20)
+
+// -----
+
+module {
+func.func @matching_destination_view_and_tensor_insert_candidates(%offset: i32, %src: tensor<1xindex>, %base: tensor<1xindex>, %dst0: memref<4xindex>, %dst1: memref<1xindex>) {
+%c0 = arith.constant 0 : index loc("cross_path_unique.py":70:3)
+%idx = arith.index_cast %offset : i32 to index loc("cross_path_unique.py":70:5)
+%view = memref.subview %dst0[%idx] [1] [1] : memref<4xindex> to memref<1xindex, strided<[1], offset: ?>> loc("cross_path_unique.py":71:5)
+bufferization.materialize_in_destination %src in writable %view : (tensor<1xindex>, memref<1xindex, strided<[1], offset: ?>>) -> () loc("synthetic_store"("cross_path_unique.py":71:20))
+%inserted = tensor.insert %idx into %base[%c0] : tensor<1xindex> loc("cross_path_unique.py":71:6)
+bufferization.materialize_in_destination %inserted in writable %dst1 : (tensor<1xindex>, memref<1xindex>) -> () loc("cross_path_unique.py":71:20)
+func.return loc("cross_path_unique.py":72:3)
+}
+}
+
+// CHECK-DAG: #[[$CROSS_PATH_UNIQUE_ORIGIN:[A-Za-z0-9_]+]] = loc("cross_path_unique.py":70:5)
+
+// CHECK-LABEL: func.func @matching_destination_view_and_tensor_insert_candidates
+// CHECK: %[[CROSS_PATH_UNIQUE_IDX:[A-Za-z0-9_]+]] = arith.index_cast
+// CHECK-SAME: triton.debug_line.class = "semantic"
+// CHECK-SAME: triton.debug_line.origin = #[[$CROSS_PATH_UNIQUE_ORIGIN]]
+// CHECK-SAME: loc(#[[CROSS_PATH_UNIQUE_STORE:[A-Za-z0-9_]+]])
+// CHECK: %[[CROSS_PATH_UNIQUE_VIEW:[A-Za-z0-9_]+]] = memref.subview {{.*}}[%[[CROSS_PATH_UNIQUE_IDX]]]
+// CHECK: bufferization.materialize_in_destination %{{.*}} in writable %[[CROSS_PATH_UNIQUE_VIEW]]
+// CHECK-SAME: loc(#[[CROSS_PATH_UNIQUE_STORE]])
+// CHECK: %[[CROSS_PATH_UNIQUE_INSERTED:[A-Za-z0-9_]+]] = tensor.insert %[[CROSS_PATH_UNIQUE_IDX]]
+// CHECK: bufferization.materialize_in_destination %[[CROSS_PATH_UNIQUE_INSERTED]]
+// CHECK-SAME: loc(#[[CROSS_PATH_UNIQUE_STORE]])
+
+// CHECK-DAG: #[[CROSS_PATH_UNIQUE_STORE]] = loc("cross_path_unique.py":71:20)

--- a/third_party/ascend/unittest/Conversion/General/TritonToLLVM/normalize_debug_line_locations.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLLVM/normalize_debug_line_locations.mlir
@@ -1,5 +1,13 @@
 // RUN: triton-opt %s -split-input-file --normalize-debug-line-locations --allow-unregistered-dialect --mlir-print-debuginfo | FileCheck %s
 
+//===----------------------------------------------------------------------===//
+// control_ops
+//
+// Verifies that control-flow operations remain user-visible debug anchors.
+// cf.br, scf.if, scf.for, and func.return must be classified as
+// "control" and must keep their original real source locations.
+//===----------------------------------------------------------------------===//
+
 module {
 func.func @control_ops(%cond: i1) {
 cf.br ^bb1 loc("control.py":2:3)
@@ -35,6 +43,16 @@ func.return loc("control.py":6:3)
 
 // -----
 
+//===----------------------------------------------------------------------===//
+// synthetic_glue
+//
+// Verifies the default handling of helper/glue operations that do not have a
+// unique user-visible store anchor. unrealized_conversion_cast and
+// memref.subview must be classified as "synthetic", preserve their original
+// location in triton.debug_line.origin, and move to glue.py:0:0. The
+// surrounding control operations must remain at their real source locations.
+//===----------------------------------------------------------------------===//
+
 module {
 func.func @synthetic_glue(%arg0: memref<8xf32>, %idx: index, %cond: i1) {
 %cast = builtin.unrealized_conversion_cast %idx : index to i64 loc("glue.py":2:5)
@@ -69,6 +87,17 @@ func.return loc("glue.py":5:3)
 // CHECK-DAG: #[[GLUE_RETURN_LOC]] = loc("glue.py":5:3)
 
 // -----
+
+//===----------------------------------------------------------------------===//
+// source_line_write_anchor
+//
+// Verifies the main write-anchor normalization case modeled after the loop
+// reordering problem. Address/view computations that uniquely feed a
+// user-visible store are retargeted to the store source location, while pure
+// value/tensor preparation remains synthetic and is moved to
+// loop_reordering.py:0:0. The test also covers NameLoc preservation for the
+// ticket load and retargeting through tensor.insert for the next-ticket store.
+//===----------------------------------------------------------------------===//
 
 module {
 func.func @source_line_write_anchor(%trace: memref<8xi32>, %counter: memref<1xi32>) {
@@ -159,6 +188,15 @@ func.return loc("loop_reordering.py":26:3)
 
 // -----
 
+//===----------------------------------------------------------------------===//
+// memref_fill_anchor
+//
+// Verifies that linalg.fill writing directly to a memref is treated as a real
+// semantic memory write anchor. The scalar constant used as the fill value is
+// synthetic and is moved to memfill.py:0:0, while the memref fill keeps its
+// user-visible source location.
+//===----------------------------------------------------------------------===//
+
 module {
 func.func @memref_fill_anchor(%dst: memref<4xf32>) {
 %cst = arith.constant 0.000000e+00 : f32 loc("memfill.py":3:5)
@@ -187,6 +225,15 @@ func.return loc("memfill.py":4:3)
 // CHECK-DAG: #[[MEMFILL_RETURN_LOC]] = loc("memfill.py":4:3)
 
 // -----
+
+//===----------------------------------------------------------------------===//
+// future_line_constant
+//
+// Verifies the backward-step heuristic and helper constant handling. Constants
+// and reordered arithmetic that would otherwise introduce misleading source
+// locations are classified as synthetic and moved to future.py:0:0, while the
+// real load and return keep their visible locations.
+//===----------------------------------------------------------------------===//
 
 module {
 func.func @future_line_constant(%arg0: memref<4xf32>) {
@@ -231,6 +278,15 @@ func.return loc("future.py":14:3)
 
 // -----
 
+//===----------------------------------------------------------------------===//
+// llvm_constant
+//
+// Verifies LLVM dialect helper constants. llvm.mlir.constant is classified as
+// synthetic, its original location is preserved in triton.debug_line.origin,
+// and the operation location is rewritten to llvm.py:0:0. llvm.return remains
+// a control operation at its real source location.
+//===----------------------------------------------------------------------===//
+
 module {
 llvm.func @llvm_constant() {
 %0 = llvm.mlir.constant(7 : i32) : i32 loc("llvm.py":20:5)
@@ -253,6 +309,16 @@ llvm.return loc("llvm.py":21:3)
 // CHECK-DAG: #[[LLVM_RETURN_LOC]] = loc("llvm.py":21:3)
 
 // -----
+
+//===----------------------------------------------------------------------===//
+// nameloc_is_source / fused_scope_is_preserved
+//
+// Verifies location canonicalization rules for semantic operations. A
+// non-internal NameLoc such as "trace_ptr" must be preserved as source-like
+// metadata. A fused location carrying an LLVM DIScope must also be preserved
+// intact, so already materialized debug-scope metadata is not stripped. Helper
+// constants in both functions still become synthetic zero-line operations.
+//===----------------------------------------------------------------------===//
 
 #di_file = #llvm.di_file<"scope.py" in "/tmp">
 #di_cu = #llvm.di_compile_unit<id = distinct[0]<>, sourceLanguage = DW_LANG_C, file = #di_file, producer = "triton", isOptimized = true, emissionKind = LineTablesOnly>
@@ -310,6 +376,15 @@ func.return loc("scope.py":8:3)
 
 // -----
 
+//===----------------------------------------------------------------------===//
+// shape_is_unchanged
+//
+// Verifies that the pass does not change IR semantics or structure. The test
+// captures function arguments, result types, operands, produced values, and the
+// returned value. Only operation locations and diagnostic debug-line
+// attributes are expected to change.
+//===----------------------------------------------------------------------===//
+
 module {
 func.func @shape_is_unchanged(%arg0: memref<8xf32>, %arg1: memref<8xf32>, %idx: index) -> i32 {
 %sub = memref.subview %arg0[%idx] [4] [1] : memref<8xf32> to memref<4xf32, strided<[1], offset: ?>> loc("shape.py":2:5)
@@ -358,6 +433,16 @@ return %r : i32 loc("shape.py":6:3)
 
 // -----
 
+//===----------------------------------------------------------------------===//
+// direct_destination_view_ambiguity
+//
+// Verifies deterministic behavior when one destination view has multiple
+// direct materialize_in_destination users with distinct store locations. The
+// view must not be retargeted based on getUsers() iteration order; it remains
+// synthetic and moves to direct_ambiguity.py:0:0, while each store keeps its
+// own semantic location.
+//===----------------------------------------------------------------------===//
+
 module {
 func.func @direct_destination_view_ambiguity(%src: tensor<4xf32>, %dst: memref<8xf32>, %idx: index) {
 %view = memref.subview %dst[%idx] [4] [1] : memref<8xf32> to memref<4xf32, strided<[1], offset: ?>> loc("direct_ambiguity.py":10:5)
@@ -386,6 +471,16 @@ func.return loc("direct_ambiguity.py":11:3)
 // CHECK-DAG: #[[DIRECT_STORE_1_LOC]] = loc("direct_ambiguity.py":10:30)
 
 // -----
+
+//===----------------------------------------------------------------------===//
+// through_destination_view_ambiguity
+//
+// Verifies deterministic behavior when one operation feeds multiple
+// destination views. The shared index_cast has two distinct store candidates
+// through different subviews, so it must remain synthetic instead of choosing
+// an arbitrary user. Each subview has a unique store and may be retargeted to
+// its own semantic store location.
+//===----------------------------------------------------------------------===//
 
 module {
 func.func @through_destination_view_ambiguity(%src: tensor<4xf32>, %dst0: memref<8xf32>, %dst1: memref<8xf32>, %offset: i32) {
@@ -418,6 +513,15 @@ func.return loc("through_view_ambiguity.py":23:3)
 
 // -----
 
+//===----------------------------------------------------------------------===//
+// through_tensor_insert_ambiguity
+//
+// Verifies deterministic behavior for the tensor.insert retargeting path. The
+// same arithmetic result is inserted into two tensors and reaches two distinct
+// stores. Because there is no unique canonical store location, the arithmetic
+// operation remains synthetic and moves to tensor_insert_ambiguity.py:0:0.
+//===----------------------------------------------------------------------===//
+
 module {
 func.func @through_tensor_insert_ambiguity(%lhs: f32, %rhs: f32, %base0: tensor<1xf32>, %base1: tensor<1xf32>, %dst0: memref<1xf32>, %dst1: memref<1xf32>, %idx: index) {
 %sum = arith.addf %lhs, %rhs : f32 loc("tensor_insert_ambiguity.py":30:5)
@@ -449,6 +553,16 @@ func.return loc("tensor_insert_ambiguity.py":31:3)
 
 // -----
 
+//===----------------------------------------------------------------------===//
+// duplicate_canonical_store_candidates
+//
+// Verifies that duplicate candidates with the same canonical source location
+// are treated as one unique store anchor. One store location is wrapped in an
+// internal NameLoc and the other is a direct FileLineColLoc, but both
+// canonicalize to duplicate_candidates.py:40:30, so the view can be safely
+// retargeted there.
+//===----------------------------------------------------------------------===//
+
 module {
 func.func @duplicate_canonical_store_candidates(%src: tensor<4xf32>, %dst: memref<8xf32>, %idx: index) {
 %view = memref.subview %dst[%idx] [4] [1] : memref<8xf32> to memref<4xf32, strided<[1], offset: ?>> loc("duplicate_candidates.py":40:5)
@@ -475,6 +589,16 @@ func.return loc("duplicate_candidates.py":41:3)
 // CHECK-DAG: #[[DUPLICATE_STORE_LOC]] = loc("duplicate_candidates.py":40:30)
 
 // -----
+
+//===----------------------------------------------------------------------===//
+// direct_and_nested_destination_view_ambiguity
+//
+// Verifies ambiguity detection across direct and nested destination-view
+// paths. The base view has several distinct possible store anchors, including
+// direct stores and a store through a nested subview. The pass must not select
+// one arbitrarily, so the base view remains synthetic and moves to
+// cross_view_ambiguity.py:0:0.
+//===----------------------------------------------------------------------===//
 
 module {
 func.func @direct_and_nested_destination_view_ambiguity(%src: tensor<4xf32>, %dst: memref<8xf32>, %idx: index) {
@@ -509,6 +633,16 @@ func.return loc("cross_view_ambiguity.py":52:3)
 
 // -----
 
+//===----------------------------------------------------------------------===//
+// destination_view_and_tensor_insert_ambiguity
+//
+// Verifies ambiguity detection across different retargeting mechanisms. The
+// same index_cast feeds both a destination-view store path and a tensor.insert
+// store path, and the two paths resolve to different store locations. Since the
+// combined candidate set is not unique, the index_cast remains synthetic and
+// moves to cross_path_ambiguity.py:0:0.
+//===----------------------------------------------------------------------===//
+
 module {
 func.func @destination_view_and_tensor_insert_ambiguity(%offset: i32, %src: tensor<1xindex>, %base: tensor<1xindex>, %dst0: memref<4xindex>, %dst1: memref<1xindex>) {
 %c0 = arith.constant 0 : index loc("cross_path_ambiguity.py":60:3)
@@ -540,6 +674,16 @@ func.return loc("cross_path_ambiguity.py":63:3)
 // CHECK-DAG: #[[CROSS_PATH_STORE_B]] = loc("cross_path_ambiguity.py":62:20)
 
 // -----
+
+//===----------------------------------------------------------------------===//
+// matching_destination_view_and_tensor_insert_candidates
+//
+// Verifies the positive cross-path case. The same index_cast feeds both a
+// destination-view store path and a tensor.insert store path, but all collected
+// candidates canonicalize to cross_path_unique.py:71:20. Because there is
+// exactly one distinct canonical store location, the index_cast is classified
+// as semantic and retargeted to that store anchor.
+//===----------------------------------------------------------------------===//
 
 module {
 func.func @matching_destination_view_and_tensor_insert_candidates(%offset: i32, %src: tensor<1xindex>, %base: tensor<1xindex>, %dst0: memref<4xindex>, %dst1: memref<1xindex>) {

--- a/third_party/ascend/unittest/Conversion/General/TritonToLLVM/normalize_debug_line_locations.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLLVM/normalize_debug_line_locations.mlir
@@ -1,0 +1,357 @@
+// RUN: triton-opt %s -split-input-file --normalize-debug-line-locations --allow-unregistered-dialect --mlir-print-debuginfo | FileCheck %s
+
+module {
+func.func @control_ops(%cond: i1) {
+cf.br ^bb1 loc("control.py":2:3)
+^bb1:
+scf.if %cond {
+} else {
+} loc("control.py":3:5)
+%c0 = arith.constant 0 : index loc("control.py":4:5)
+%c1 = arith.constant 1 : index loc("control.py":4:9)
+scf.for %i = %c0 to %c1 step %c1 {
+scf.yield loc("control.py":5:9)
+} loc("control.py":5:5)
+func.return loc("control.py":6:3)
+}
+}
+
+// CHECK-LABEL: func.func @control_ops
+// CHECK: cf.br
+// CHECK-SAME: triton.debug_line.class = "control"
+// CHECK-SAME: loc(#[[CONTROL_BR_LOC:[A-Za-z0-9_]+]])
+// CHECK: scf.if
+// CHECK: } {triton.debug_line.class = "control"} loc(#[[CONTROL_IF_LOC:[A-Za-z0-9_]+]])
+// CHECK: scf.for
+// CHECK: } {triton.debug_line.class = "control"} loc(#[[CONTROL_FOR_LOC:[A-Za-z0-9_]+]])
+// CHECK: return
+// CHECK-SAME: triton.debug_line.class = "control"
+// CHECK-SAME: loc(#[[CONTROL_RETURN_LOC:[A-Za-z0-9_]+]])
+
+// CHECK-DAG: #[[CONTROL_BR_LOC]] = loc("control.py":2:3)
+// CHECK-DAG: #[[CONTROL_IF_LOC]] = loc("control.py":3:5)
+// CHECK-DAG: #[[CONTROL_FOR_LOC]] = loc("control.py":5:5)
+// CHECK-DAG: #[[CONTROL_RETURN_LOC]] = loc("control.py":6:3)
+
+// -----
+
+module {
+func.func @synthetic_glue(%arg0: memref<8xf32>, %idx: index, %cond: i1) {
+%cast = builtin.unrealized_conversion_cast %idx : index to i64 loc("glue.py":2:5)
+%sub = memref.subview %arg0[%idx] [4] [1] : memref<8xf32> to memref<4xf32, strided<[1], offset: ?>> loc("glue.py":3:5)
+scf.if %cond {
+} loc("glue.py":4:5)
+func.return loc("glue.py":5:3)
+}
+}
+
+// CHECK-DAG: #[[$GLUE_CAST_ORIGIN:[A-Za-z0-9_]+]] = loc("glue.py":2:5)
+// CHECK-DAG: #[[$GLUE_SUBVIEW_ORIGIN:[A-Za-z0-9_]+]] = loc("glue.py":3:5)
+
+// CHECK-LABEL: func.func @synthetic_glue
+// CHECK: builtin.unrealized_conversion_cast
+// CHECK-SAME: triton.debug_line.class = "synthetic"
+// CHECK-SAME: triton.debug_line.origin = #[[$GLUE_CAST_ORIGIN]]
+// CHECK-SAME: loc(#[[GLUE_SYNTH_LOC:[A-Za-z0-9_]+]])
+// CHECK: memref.subview
+// CHECK-SAME: triton.debug_line.class = "synthetic"
+// CHECK-SAME: triton.debug_line.origin = #[[$GLUE_SUBVIEW_ORIGIN]]
+// CHECK-SAME: : memref<8xf32> to memref<4xf32, strided<[1], offset: ?>>
+// CHECK-SAME: loc(#[[GLUE_SYNTH_LOC]])
+// CHECK: scf.if
+// CHECK: } {triton.debug_line.class = "control"} loc(#[[GLUE_IF_LOC:[A-Za-z0-9_]+]])
+// CHECK: return
+// CHECK-SAME: triton.debug_line.class = "control"
+// CHECK-SAME: loc(#[[GLUE_RETURN_LOC:[A-Za-z0-9_]+]])
+
+// CHECK-DAG: #[[GLUE_SYNTH_LOC]] = loc("glue.py":0:0)
+// CHECK-DAG: #[[GLUE_IF_LOC]] = loc("glue.py":4:5)
+// CHECK-DAG: #[[GLUE_RETURN_LOC]] = loc("glue.py":5:3)
+
+// -----
+
+module {
+func.func @source_line_write_anchor(%trace: memref<8xi32>, %counter: memref<1xi32>) {
+%c0 = arith.constant 0 : index loc("loop_reordering.py":23:21)
+%ticket = memref.load %counter[%c0] : memref<1xi32> loc("ticket"("loop_reordering.py":23:21))
+%ticket_idx = arith.index_cast %ticket : i32 to index loc("ticket"("loop_reordering.py":23:21))
+%c200_i32 = arith.constant 200 : i32 loc("loop_reordering.py":24:33)
+%empty = tensor.empty() : tensor<1xi32> loc("loop_reordering.py":24:33)
+%filled = linalg.fill ins(%c200_i32 : i32) outs(%empty : tensor<1xi32>) -> tensor<1xi32> loc("loop_reordering.py":24:33)
+%view = memref.reinterpret_cast %trace to offset: [%ticket_idx], sizes: [1], strides: [1] : memref<8xi32> to memref<1xi32, strided<[1], offset: ?>> loc("loop_reordering.py":24:33)
+bufferization.materialize_in_destination %filled in writable %view : (tensor<1xi32>, memref<1xi32, strided<[1], offset: ?>>) -> () loc("loop_reordering.py":24:33)
+%c1_i32 = arith.constant 1 : i32 loc("loop_reordering.py":25:35)
+%next_ticket = arith.addi %ticket, %c1_i32 : i32 loc("loop_reordering.py":25:35)
+%inserted = tensor.insert %next_ticket into %empty[%c0] : tensor<1xi32> loc("loop_reordering.py":25:26)
+bufferization.materialize_in_destination %inserted in writable %counter : (tensor<1xi32>, memref<1xi32>) -> () loc("loop_reordering.py":25:26)
+func.return loc("loop_reordering.py":26:3)
+}
+}
+
+// CHECK-DAG: #[[$LOOP_TICKET_FILE_LOC:[A-Za-z0-9_]+]] = loc("loop_reordering.py":23:21)
+// CHECK-DAG: #[[$LOOP_TICKET_LOC:[A-Za-z0-9_]+]] = loc("ticket"(#[[$LOOP_TICKET_FILE_LOC]]))
+// CHECK-DAG: #[[$LOOP_WRITE_LOC:[A-Za-z0-9_]+]] = loc("loop_reordering.py":24:33)
+// CHECK-DAG: #[[$LOOP_NEXT_VALUE_LOC:[A-Za-z0-9_]+]] = loc("loop_reordering.py":25:35)
+
+// CHECK-LABEL: func.func @source_line_write_anchor
+// CHECK: %[[LOOP_TICKET:[A-Za-z0-9_]+]] = memref.load
+// CHECK-SAME: triton.debug_line.class = "semantic"
+// CHECK-SAME: : memref<1xi32>
+// CHECK-SAME: loc(#[[$LOOP_TICKET_LOC]])
+
+// CHECK: %[[LOOP_TICKET_IDX:[A-Za-z0-9_]+]] = arith.index_cast %[[LOOP_TICKET]]
+// CHECK-SAME: triton.debug_line.class = "semantic"
+// CHECK-SAME: triton.debug_line.origin = #[[$LOOP_TICKET_LOC]]
+// CHECK-SAME: : i32 to index
+// CHECK-SAME: loc(#[[$LOOP_WRITE_LOC]])
+
+// CHECK: %[[LOOP_C200:[A-Za-z0-9_]+]] = arith.constant
+// CHECK-SAME: triton.debug_line.class = "synthetic"
+// CHECK-SAME: triton.debug_line.origin = #[[$LOOP_WRITE_LOC]]
+// CHECK-SAME: 200 : i32
+// CHECK-SAME: loc(#[[LOOP_SYNTH_LOC:[A-Za-z0-9_]+]])
+
+// CHECK: %[[LOOP_EMPTY:[A-Za-z0-9_]+]] = tensor.empty
+// CHECK-SAME: triton.debug_line.class = "synthetic"
+// CHECK-SAME: triton.debug_line.origin = #[[$LOOP_WRITE_LOC]]
+// CHECK-SAME: tensor<1xi32>
+// CHECK-SAME: loc(#[[LOOP_SYNTH_LOC]])
+
+// CHECK: %[[LOOP_FILLED:[A-Za-z0-9_]+]] = linalg.fill
+// CHECK-SAME: triton.debug_line.class = "synthetic"
+// CHECK-SAME: triton.debug_line.origin = #[[$LOOP_WRITE_LOC]]
+// CHECK-SAME: loc(#[[LOOP_SYNTH_LOC]])
+
+// CHECK: %[[LOOP_VIEW:[A-Za-z0-9_]+]] = memref.reinterpret_cast
+// CHECK-SAME: %[[LOOP_TICKET_IDX]]
+// CHECK-SAME: triton.debug_line.class = "semantic"
+// CHECK-SAME: triton.debug_line.origin = #[[$LOOP_WRITE_LOC]]
+// CHECK-SAME: memref<8xi32> to memref<1xi32, strided<[1], offset: ?>>
+// CHECK-SAME: loc(#[[$LOOP_WRITE_LOC]])
+
+// CHECK: bufferization.materialize_in_destination %[[LOOP_FILLED]] in writable %[[LOOP_VIEW]]
+// CHECK-SAME: triton.debug_line.class = "semantic"
+// CHECK-SAME: loc(#[[$LOOP_WRITE_LOC]])
+
+// CHECK: %[[LOOP_C1:[A-Za-z0-9_]+]] = arith.constant
+// CHECK-SAME: triton.debug_line.class = "synthetic"
+// CHECK-SAME: triton.debug_line.origin = #[[$LOOP_NEXT_VALUE_LOC]]
+// CHECK-SAME: 1 : i32
+// CHECK-SAME: loc(#[[LOOP_SYNTH_LOC]])
+
+// CHECK: %[[LOOP_NEXT:[A-Za-z0-9_]+]] = arith.addi %[[LOOP_TICKET]], %[[LOOP_C1]]
+// CHECK-SAME: triton.debug_line.class = "semantic"
+// CHECK-SAME: triton.debug_line.origin = #[[$LOOP_NEXT_VALUE_LOC]]
+// CHECK-SAME: : i32
+// CHECK-SAME: loc(#[[LOOP_NEXT_STORE_LOC:[A-Za-z0-9_]+]])
+
+// CHECK: %[[LOOP_INSERTED:[A-Za-z0-9_]+]] = tensor.insert %[[LOOP_NEXT]] into %[[LOOP_EMPTY]]
+// CHECK-SAME: triton.debug_line.class = "semantic"
+// CHECK-SAME: tensor<1xi32>
+// CHECK-SAME: loc(#[[LOOP_NEXT_STORE_LOC]])
+
+// CHECK: bufferization.materialize_in_destination %[[LOOP_INSERTED]] in writable
+// CHECK-SAME: triton.debug_line.class = "semantic"
+// CHECK-SAME: loc(#[[LOOP_NEXT_STORE_LOC]])
+
+// CHECK-DAG: #[[LOOP_SYNTH_LOC]] = loc("loop_reordering.py":0:0)
+// CHECK-DAG: #[[LOOP_NEXT_STORE_LOC]] = loc("loop_reordering.py":25:26)
+
+// -----
+
+module {
+func.func @memref_fill_anchor(%dst: memref<4xf32>) {
+%cst = arith.constant 0.000000e+00 : f32 loc("memfill.py":3:5)
+linalg.fill ins(%cst : f32) outs(%dst : memref<4xf32>) loc("memfill.py":3:7)
+func.return loc("memfill.py":4:3)
+}
+}
+
+// CHECK-DAG: #[[$MEMFILL_CONST_ORIGIN:[A-Za-z0-9_]+]] = loc("memfill.py":3:5)
+
+// CHECK-LABEL: func.func @memref_fill_anchor
+// CHECK: arith.constant
+// CHECK-SAME: triton.debug_line.class = "synthetic"
+// CHECK-SAME: triton.debug_line.origin = #[[$MEMFILL_CONST_ORIGIN]]
+// CHECK-SAME: loc(#[[MEMFILL_SYNTH_LOC:[A-Za-z0-9_]+]])
+// CHECK: linalg.fill
+// CHECK-SAME: triton.debug_line.class = "semantic"
+// CHECK-SAME: outs
+// CHECK-SAME: loc(#[[MEMFILL_LOC:[A-Za-z0-9_]+]])
+// CHECK: return
+// CHECK-SAME: triton.debug_line.class = "control"
+// CHECK-SAME: loc(#[[MEMFILL_RETURN_LOC:[A-Za-z0-9_]+]])
+
+// CHECK-DAG: #[[MEMFILL_SYNTH_LOC]] = loc("memfill.py":0:0)
+// CHECK-DAG: #[[MEMFILL_LOC]] = loc("memfill.py":3:7)
+// CHECK-DAG: #[[MEMFILL_RETURN_LOC]] = loc("memfill.py":4:3)
+
+// -----
+
+module {
+func.func @future_line_constant(%arg0: memref<4xf32>) {
+%c0 = arith.constant 0 : index loc("future.py":8:5)
+%c1 = arith.constant 1 : index loc("future.py":24:5)
+%v = memref.load %arg0[%c0] : memref<4xf32> loc("future.py":24:7)
+%sum = arith.addi %c0, %c1 : index loc("future.py":13:5)
+func.return loc("future.py":14:3)
+}
+}
+
+// CHECK-DAG: #[[$FUTURE_C0_ORIGIN:[A-Za-z0-9_]+]] = loc("future.py":8:5)
+// CHECK-DAG: #[[$FUTURE_C1_ORIGIN:[A-Za-z0-9_]+]] = loc("future.py":24:5)
+// CHECK-DAG: #[[$FUTURE_ADDI_ORIGIN:[A-Za-z0-9_]+]] = loc("future.py":13:5)
+
+// CHECK-LABEL: func.func @future_line_constant
+// CHECK: arith.constant
+// CHECK-SAME: triton.debug_line.class = "synthetic"
+// CHECK-SAME: triton.debug_line.origin = #[[$FUTURE_C0_ORIGIN]]
+// CHECK-SAME: 0 : index
+// CHECK-SAME: loc(#[[FUTURE_SYNTH_LOC:[A-Za-z0-9_]+]])
+// CHECK: arith.constant
+// CHECK-SAME: triton.debug_line.class = "synthetic"
+// CHECK-SAME: triton.debug_line.origin = #[[$FUTURE_C1_ORIGIN]]
+// CHECK-SAME: 1 : index
+// CHECK-SAME: loc(#[[FUTURE_SYNTH_LOC]])
+// CHECK: memref.load
+// CHECK-SAME: triton.debug_line.class = "semantic"
+// CHECK-SAME: loc(#[[FUTURE_LOAD_LOC:[A-Za-z0-9_]+]])
+// CHECK: arith.addi
+// CHECK-SAME: triton.debug_line.class = "synthetic"
+// CHECK-SAME: triton.debug_line.origin = #[[$FUTURE_ADDI_ORIGIN]]
+// CHECK-SAME: : index
+// CHECK-SAME: loc(#[[FUTURE_SYNTH_LOC]])
+// CHECK: return
+// CHECK-SAME: triton.debug_line.class = "control"
+// CHECK-SAME: loc(#[[FUTURE_RETURN_LOC:[A-Za-z0-9_]+]])
+
+// CHECK-DAG: #[[FUTURE_SYNTH_LOC]] = loc("future.py":0:0)
+// CHECK-DAG: #[[FUTURE_LOAD_LOC]] = loc("future.py":24:7)
+// CHECK-DAG: #[[FUTURE_RETURN_LOC]] = loc("future.py":14:3)
+
+// -----
+
+module {
+llvm.func @llvm_constant() {
+%0 = llvm.mlir.constant(7 : i32) : i32 loc("llvm.py":20:5)
+llvm.return loc("llvm.py":21:3)
+}
+}
+
+// CHECK-DAG: #[[$LLVM_CONST_ORIGIN:[A-Za-z0-9_]+]] = loc("llvm.py":20:5)
+
+// CHECK-LABEL: llvm.func @llvm_constant
+// CHECK: llvm.mlir.constant
+// CHECK-SAME: triton.debug_line.class = "synthetic"
+// CHECK-SAME: triton.debug_line.origin = #[[$LLVM_CONST_ORIGIN]]
+// CHECK-SAME: loc(#[[LLVM_SYNTH_LOC:[A-Za-z0-9_]+]])
+// CHECK: llvm.return
+// CHECK-SAME: triton.debug_line.class = "control"
+// CHECK-SAME: loc(#[[LLVM_RETURN_LOC:[A-Za-z0-9_]+]])
+
+// CHECK-DAG: #[[LLVM_SYNTH_LOC]] = loc("llvm.py":0:0)
+// CHECK-DAG: #[[LLVM_RETURN_LOC]] = loc("llvm.py":21:3)
+
+// -----
+
+#di_file = #llvm.di_file<"scope.py" in "/tmp">
+#di_cu = #llvm.di_compile_unit<id = distinct[0]<>, sourceLanguage = DW_LANG_C, file = #di_file, producer = "triton", isOptimized = true, emissionKind = LineTablesOnly>
+#di_sp = #llvm.di_subprogram<compileUnit = #di_cu, scope = #di_file, name = "scoped", file = #di_file, subprogramFlags = "Definition|Optimized">
+
+module {
+func.func @nameloc_is_source(%arg0: memref<4xf32>) {
+%c0 = arith.constant 0 : index loc("name.py":2:5)
+%v = memref.load %arg0[%c0] : memref<4xf32> loc("trace_ptr"("name.py":7:9))
+func.return loc("name.py":8:3)
+}
+
+func.func @fused_scope_is_preserved(%arg0: memref<4xf32>) {
+%c0 = arith.constant 0 : index loc("scope.py":2:5)
+%v = memref.load %arg0[%c0] : memref<4xf32> loc(fused<#di_sp>["scope.py":7:9])
+func.return loc("scope.py":8:3)
+}
+}
+
+// CHECK-DAG: #[[$NAME_CONST_ORIGIN:[A-Za-z0-9_]+]] = loc("name.py":2:5)
+// CHECK-DAG: #[[$SCOPE_CONST_ORIGIN:[A-Za-z0-9_]+]] = loc("scope.py":2:5)
+
+// CHECK-LABEL: func.func @nameloc_is_source
+// CHECK: arith.constant
+// CHECK-SAME: triton.debug_line.class = "synthetic"
+// CHECK-SAME: triton.debug_line.origin = #[[$NAME_CONST_ORIGIN]]
+// CHECK-SAME: loc(#[[$NAME_SYNTH_LOC:[A-Za-z0-9_]+]])
+// CHECK: memref.load
+// CHECK-SAME: triton.debug_line.class = "semantic"
+// CHECK-SAME: loc(#[[$TRACE_LOC:[A-Za-z0-9_]+]])
+// CHECK: return
+// CHECK-SAME: triton.debug_line.class = "control"
+// CHECK-SAME: loc(#[[$NAME_RETURN_LOC:[A-Za-z0-9_]+]])
+
+// CHECK-LABEL: func.func @fused_scope_is_preserved
+// CHECK: arith.constant
+// CHECK-SAME: triton.debug_line.class = "synthetic"
+// CHECK-SAME: triton.debug_line.origin = #[[$SCOPE_CONST_ORIGIN]]
+// CHECK-SAME: loc(#[[SCOPE_SYNTH_LOC:[A-Za-z0-9_]+]])
+// CHECK: memref.load
+// CHECK-SAME: triton.debug_line.class = "semantic"
+// CHECK-SAME: loc(#[[FUSED_LOC:[A-Za-z0-9_]+]])
+// CHECK: return
+// CHECK-SAME: triton.debug_line.class = "control"
+// CHECK-SAME: loc(#[[SCOPE_RETURN_LOC:[A-Za-z0-9_]+]])
+
+// CHECK-DAG: #[[$NAME_SYNTH_LOC]] = loc("name.py":0:0)
+// CHECK-DAG: #[[$NAME_FILE_LOC:[A-Za-z0-9_]+]] = loc("name.py":7:9)
+// CHECK-DAG: #[[$TRACE_LOC]] = loc("trace_ptr"(#[[$NAME_FILE_LOC]]))
+// CHECK-DAG: #[[$NAME_RETURN_LOC]] = loc("name.py":8:3)
+// CHECK-DAG: #[[SCOPE_SYNTH_LOC]] = loc("scope.py":0:0)
+// CHECK-DAG: #[[SCOPE_FILE_LOC:[A-Za-z0-9_]+]] = loc("scope.py":7:9)
+// CHECK-DAG: #[[FUSED_LOC]] = loc(fused<{{.*}}>[#[[SCOPE_FILE_LOC]]])
+// CHECK-DAG: #[[SCOPE_RETURN_LOC]] = loc("scope.py":8:3)
+
+// -----
+
+module {
+func.func @shape_is_unchanged(%arg0: memref<8xf32>, %arg1: memref<8xf32>, %idx: index) -> i32 {
+%sub = memref.subview %arg0[%idx] [4] [1] : memref<8xf32> to memref<4xf32, strided<[1], offset: ?>> loc("shape.py":2:5)
+%v = memref.load %arg1[%idx] : memref<8xf32> loc("shape.py":3:5)
+%c1 = arith.constant 1 : i32 loc("shape.py":4:5)
+%r = arith.addi %c1, %c1 : i32 loc("shape.py":5:5)
+return %r : i32 loc("shape.py":6:3)
+}
+}
+
+// CHECK-DAG: #[[$SHAPE_SUBVIEW_ORIGIN:[A-Za-z0-9_]+]] = loc("shape.py":2:5)
+// CHECK-DAG: #[[$SHAPE_CONST_ORIGIN:[A-Za-z0-9_]+]] = loc("shape.py":4:5)
+
+// CHECK-LABEL: func.func @shape_is_unchanged(
+// CHECK-SAME: %[[SHAPE_ARG0:[A-Za-z0-9_]+]]: memref<8xf32>
+// CHECK-SAME: %[[SHAPE_ARG1:[A-Za-z0-9_]+]]: memref<8xf32>
+// CHECK-SAME: %[[SHAPE_IDX:[A-Za-z0-9_]+]]: index
+// CHECK-SAME: -> i32
+// CHECK: %[[SHAPE_SUB:[A-Za-z0-9_]+]] = memref.subview %[[SHAPE_ARG0]][%[[SHAPE_IDX]]] [4] [1]
+// CHECK-SAME: triton.debug_line.class = "synthetic"
+// CHECK-SAME: triton.debug_line.origin = #[[$SHAPE_SUBVIEW_ORIGIN]]
+// CHECK-SAME: : memref<8xf32> to memref<4xf32, strided<[1], offset: ?>>
+// CHECK-SAME: loc(#[[SHAPE_SYNTH_LOC:[A-Za-z0-9_]+]])
+// CHECK: %[[SHAPE_V:[A-Za-z0-9_]+]] = memref.load %[[SHAPE_ARG1]][%[[SHAPE_IDX]]]
+// CHECK-SAME: triton.debug_line.class = "semantic"
+// CHECK-SAME: : memref<8xf32>
+// CHECK-SAME: loc(#[[SHAPE_LOAD_LOC:[A-Za-z0-9_]+]])
+// CHECK: %[[SHAPE_C1:[A-Za-z0-9_]+]] = arith.constant
+// CHECK-SAME: triton.debug_line.class = "synthetic"
+// CHECK-SAME: triton.debug_line.origin = #[[$SHAPE_CONST_ORIGIN]]
+// CHECK-SAME: 1 : i32
+// CHECK-SAME: loc(#[[SHAPE_SYNTH_LOC]])
+// CHECK: %[[SHAPE_R:[A-Za-z0-9_]+]] = arith.addi %[[SHAPE_C1]], %[[SHAPE_C1]]
+// CHECK-SAME: triton.debug_line.class = "semantic"
+// CHECK-SAME: : i32
+// CHECK-SAME: loc(#[[SHAPE_ADDI_LOC:[A-Za-z0-9_]+]])
+// CHECK: return
+// CHECK-SAME: triton.debug_line.class = "control"
+// CHECK-SAME: %[[SHAPE_R]] : i32
+// CHECK-SAME: loc(#[[SHAPE_RETURN_LOC:[A-Za-z0-9_]+]])
+
+// CHECK-DAG: #[[SHAPE_SYNTH_LOC]] = loc("shape.py":0:0)
+// CHECK-DAG: #[[SHAPE_LOAD_LOC]] = loc("shape.py":3:5)
+// CHECK-DAG: #[[SHAPE_ADDI_LOC]] = loc("shape.py":5:5)
+// CHECK-DAG: #[[SHAPE_RETURN_LOC]] = loc("shape.py":6:3)


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)


## Summary

Add `normalize-debug-line-locations`, an MLIR pass registered in the TritonToLLVM pass infrastructure and inserted into the Ascend TTIR pipeline for source-level debug line table generation.

The pass classifies operations as `semantic`, `control`, or `synthetic`, records the selected class in `triton.debug_line.class`, and preserves original provenance in `triton.debug_line.origin` when a synthetic operation is moved away from its original source location.

Semantic and control operations keep their real source locations, with limited canonicalization of internal location wrappers. In particular, internal `NameLoc` wrappers may be stripped when the child location already contains a real file/line/column location, while fused debug scope metadata is preserved intact.

Synthetic lowering-only operations are moved to non-user-visible line anchors, usually `file:0:0`, so they do not create misleading Python source-level debug line entries. Some synthetic address/value preparation operations may instead be retargeted to an associated user-visible store location when that location is a better source-level anchor. This retargeting is deterministic: the pass collects all matching store-location candidates and retargets only when there is exactly one distinct candidate, so the result does not depend on SSA use-list traversal order.

The pass is intended to affect debug locations and diagnostic attributes only. It must not change IR semantics, operands, results, types, regions, control flow, or code generation.

## When It Runs

The pass is added to the Ascend TTIR pipeline only when debug line information is enabled.

Currently, this happens when `LLVM_EXTRACT_DI_LOCAL_VARIABLES` is set to `true` or `1`.

## Changes

* Register the new `normalize-debug-line-locations` pass in the TritonToLLVM pass definitions.
* Add the C++ implementation and include it in the TritonToLLVM build.
* Expose `add_normalize_debug_line_locations` through the Ascend Python pass bindings.
* Insert the pass into the Ascend compiler pipeline when debug line information is enabled.
* Add deterministic store-location retargeting for selected synthetic destination/view/tensor-insert helper patterns.
* Preserve fused debug scope metadata during location canonicalization.
* Add lit coverage for control operations, semantic memory/call anchors, synthetic helper operations, deterministic store retargeting, fused debug scopes, and IR-shape preservation.

## Testing

Added `normalize_debug_line_locations.mlir` lit tests covering debug-location normalization behavior.

The tests verify that:

* semantic operations keep user-visible source locations;
* control operations remain valid source-level anchors;
* synthetic helper operations are moved away from user source lines;
* original locations of synthetic operations are preserved in `triton.debug_line.origin`;
* operation classification is recorded in `triton.debug_line.class`;
* store-location retargeting is deterministic and does not depend on `Value::getUsers()` order;
* fused debug scope metadata is not accidentally stripped;
* the pass changes only locations and debug-line diagnostic attributes, not the IR shape or semantics.
