### PR TITLE
[OffsetAnalysis](fix) Fix params in parseClampF

### DIFF
--- a/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
@@ -765,11 +765,11 @@ void parseClampF(triton::ClampFOp op, const Location &loc,
   parse(src, op.getLoc(), rewriter, offsetMap);
   PtrOffsetInfo srcOffsetInfo = offsetMap.at(src);
   // Get clampF min
-  auto clampMin = op.getX();
+  auto clampMin = op.getMin();
   parse(clampMin, op.getLoc(), rewriter, offsetMap);
   PtrOffsetInfo minOffsetInfo = offsetMap.at(clampMin);
   // Get clampF max
-  auto clampMax = op.getX();
+  auto clampMax = op.getMax();
   parse(clampMax, op.getLoc(), rewriter, offsetMap);
   PtrOffsetInfo maxOffsetInfo = offsetMap.at(clampMax);
   // Set clampF offset map


### PR DESCRIPTION
Use properly getX(), getMin(), and getMax() in parseClampF() instead of using getX() 3 times.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it's a minor fix.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
