### PR TITLE
[npu-device-limit](feat) support NPU_DEVICE_LIMIT env var

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -1,4 +1,4 @@
-﻿# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -569,6 +569,15 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
         _compile_option_list += [
             f"--enable-auto-bind-sub-block={get_auto_bind_sub_block_option(metadata)}",
         ]
+
+        npu_utils = NPUUtils()
+        if npu_utils.has_device_limit():
+            _compile_option_list += [
+                f"--custom-aic-number={npu_utils.get_aicore_num()}",
+            ]
+            _compile_option_list += [
+                f"--custom-aiv-number={npu_utils.get_aivector_core_num()}",
+            ]
 
         if force_disable_ffts():
             _compile_option_list += ["--disable-ffts"]

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -75,12 +75,63 @@ class NPUUtils(object):
         return self.npu_utils_mod.load_kernel_binary(name, kernel, shared, device, mix_mode)
 
     @functools.lru_cache()
+    def has_device_limit(self):
+        return self.get_aicore_num() < self._load_mod().get_aicore_num()
+
+    @functools.lru_cache()
     def get_device_properties(self, device):
-        # temperoarily added "max_shared_mem" properties to avoid triton-compiler complain
-        # fetch available memory at runtime
-        num_aic = self.get_aicore_num()
-        num_aiv = num_aic * 2
-        return {"max_shared_mem": 1, "num_aicore": num_aic, "num_vectorcore": num_aiv}
+        # Temporarily added "max_shared_mem" to satisfy triton-compiler.
+        original_num_aic = self._load_mod().get_aicore_num()
+        original_num_aiv = original_num_aic * 2
+
+        num_aic = original_num_aic
+        num_aiv = original_num_aiv
+
+        if device_limit := os.getenv("NPU_DEVICE_LIMIT"):
+            try:
+                values = device_limit.split(",")
+                if len(values) != 2:
+                    raise ValueError
+
+                aic_limit, aiv_limit = (
+                    int(value.strip()) for value in values
+                )
+            except ValueError:
+                raise ValueError(
+                    'NPU_DEVICE_LIMIT must have the format "C,V", '
+                    "where C and V are positive integers"
+                ) from None
+
+            if aic_limit <= 0 or aiv_limit <= 0:
+                raise ValueError(
+                    "NPU_DEVICE_LIMIT values must be greater than zero"
+                )
+
+            if aic_limit > original_num_aic:
+                raise ValueError(
+                    f"NPU_DEVICE_LIMIT AIC limit ({aic_limit}) exceeds "
+                    f"the available AIC count ({original_num_aic})"
+                )
+
+            if aiv_limit > original_num_aiv:
+                raise ValueError(
+                    f"NPU_DEVICE_LIMIT AIV limit ({aiv_limit}) exceeds "
+                    f"the available AIV count ({original_num_aiv})"
+                )
+            if aiv_limit // aic_limit != 2:
+                raise ValueError(
+                    f"NPU_DEVICE_LIMIT C:V ratio should be 2:1"
+                )
+
+
+            num_aic = aic_limit
+            num_aiv = aiv_limit
+        return {
+            "max_shared_mem": 1,
+            "num_aicore": num_aic,
+            "num_vectorcore": num_aiv,
+        }
+
 
     @functools.lru_cache()
     def get_arch(self):
@@ -90,7 +141,7 @@ class NPUUtils(object):
     @functools.lru_cache()
     def get_aicore_num(self):
         # temporarily return empty arch descriptor
-        return self.npu_utils_mod.get_aicore_num()
+        return self.get_device_properties("npu")["num_aicore"]
 
     @functools.lru_cache()
     def get_aivector_core_num(self):


### PR DESCRIPTION
# Summary
Add support for the `NPU_DEVICE_LIMIT="<Cube_Core_Num>,<Vector_Core_Num>"` environment variable to limit NPU compute resources available to a workload.

This MR:

* Parses and validates the configured Cube and Vector core counts.
* Enforces the required 1:2 Cube-to-Vector ratio and physical device limits.
* Propagates the values to the compilation flow through `custom-aic-number` and `custom-aiv-number`.
* Preserves the existing resource allocation behavior when `NPU_DEVICE_LIMIT` is not set.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because we can check if this feature works only using msprof simulator.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
