### PR TITLE
[SSBuffer](feat) add reinterpret_cast sinking to StandardizeOp pass

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/StandardizeOp/ReinterpretCastSinking.h
+++ b/third_party/ascend/include/DynamicCVPipeline/StandardizeOp/ReinterpretCastSinking.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ADAPTER_DYNAMIC_CVPIPELINE_REINTERPRET_CAST_SINKING_H
+#define TRITON_ADAPTER_DYNAMIC_CVPIPELINE_REINTERPRET_CAST_SINKING_H
+
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::triton::CVSplit {
+
+/// Pass that sinks memref.reinterpret_cast ops from their defining block
+/// into each target block where they are used. When an op is defined in one
+/// block but used inside child blocks (e.g. scf.if/scf.for/scf.while), clone
+/// the reinterpret_cast into each child block just before the first use
+/// and erase the original if no uses remain at the defining site.
+class ReinterpretCastSinkingPass
+    : public PassWrapper<ReinterpretCastSinkingPass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ReinterpretCastSinkingPass);
+
+  ReinterpretCastSinkingPass() = default;
+  void runOnOperation() override;
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<memref::MemRefDialect>();
+  }
+
+  llvm::StringRef getArgument() const final {
+    return "ssbuf-sink-reinterpret-cast";
+  }
+};
+
+std::unique_ptr<OperationPass<ModuleOp>> createReinterpretCastSinkingPass();
+
+} // namespace mlir::triton::CVSplit
+
+#endif // TRITON_ADAPTER_DYNAMIC_CVPIPELINE_REINTERPRET_CAST_SINKING_H

--- a/third_party/ascend/include/DynamicCVPipeline/StandardizeOp/ReinterpretCastSinking.h
+++ b/third_party/ascend/include/DynamicCVPipeline/StandardizeOp/ReinterpretCastSinking.h
@@ -29,11 +29,7 @@
 
 namespace mlir::triton::CVSplit {
 
-/// Pass that sinks memref.reinterpret_cast ops from their defining block
-/// into each target block where they are used. When an op is defined in one
-/// block but used inside child blocks (e.g. scf.if/scf.for/scf.while), clone
-/// the reinterpret_cast into each child block just before the first use
-/// and erase the original if no uses remain at the defining site.
+/// Sinks memref.reinterpret_cast into the blocks where they are used.
 class ReinterpretCastSinkingPass
     : public PassWrapper<ReinterpretCastSinkingPass, OperationPass<ModuleOp>> {
 public:

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp.cpp
@@ -31,6 +31,7 @@
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/StandardizeOp.h"
 #include "ascend/include/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.h"
+#include "ascend/include/DynamicCVPipeline/StandardizeOp/ReinterpretCastSinking.h"
 
 using namespace mlir;
 using namespace triton;
@@ -50,7 +51,12 @@ void StandardizeOpPass::runOnOperation() {
   }
 
   LOG_DEBUG("Input mlir:\n" << op);
+
   OpPassManager pm(op.getOperationName());
+
+  // Sink reinterpret_cast ops to their use blocks to eliminate cross-block
+  // memref dependencies.
+  pm.addPass(createReinterpretCastSinkingPass());
   pm.addPass(createPatternMatchRewritePass());
 
   if (llvm::failed(runPipeline(pm, op))) {
@@ -79,6 +85,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createStandardizeOpPass() {
 
 void registerStandardizeOpPasses() {
   registerPass(createStandardizeOpPass);
+  registerPass(createReinterpretCastSinkingPass);
   registerPass(createPatternMatchRewritePass);
 }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/ReinterpretCastSinking.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/ReinterpretCastSinking.cpp
@@ -57,9 +57,8 @@ int sinkReinterpretCastOp(memref::ReinterpretCastOp reinterpretOp) {
   OpBuilder builder(reinterpretOp->getContext());
   int cloned = 0;
 
-  // Clone before every user: an MLIR block may later be split into
-  // multiple block_ids, so users must not share the cast. Redundant
-  // clones are eliminated by a later CSE pass.
+  // Clone per user: block may split into multiple block_ids;
+  // CSE drops redundant clones.
   for (auto *user : users) {
     builder.setInsertionPoint(user);
     Value clonedResult =

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/ReinterpretCastSinking.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/ReinterpretCastSinking.cpp
@@ -25,7 +25,6 @@
 
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/Block.h"
-#include "mlir/IR/Dominance.h"
 #include "mlir/IR/Value.h"
 
 #include "ascend/include/DynamicCVPipeline/StandardizeOp/ReinterpretCastSinking.h"
@@ -37,115 +36,102 @@ static constexpr const char *DEBUG_TYPE = "ReinterpretCastSinking";
 #define LOG_DEBUG(...)                                                         \
   LLVM_DEBUG(llvm::dbgs() << "\n[" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
 
+namespace {
+
+// Find the earliest user of `result` that lives in `block`, scanning the
+// block in IR order. Used as the clone insertion point for that block.
+Operation *findFirstUserInBlock(ArrayRef<Operation *> users, Block *block) {
+  for (auto &op : *block) {
+    for (auto *user : users) {
+      if (user == &op)
+        return user;
+    }
+  }
+  return nullptr;
+}
+
+// Sink a single reinterpret_cast: clone it into every block (other than its
+// defining block) where its result is used, redirecting those users to the
+// clone. Returns the number of clones created; erases `reinterpretOp` if it
+// ends up with no remaining uses.
+//
+// No dominance check is needed: every user of `result` is dominated by
+// `reinterpretOp` (SSA dominance), and `reinterpretOp`'s operands dominate
+// `reinterpretOp`, so by transitivity every operand already dominates the
+// insertion point (just before the first user in the target block).
+int sinkReinterpretCastOp(memref::ReinterpretCastOp reinterpretOp) {
+  Value result = reinterpretOp.getResult();
+  Block *defBlock = reinterpretOp->getBlock();
+
+  // Group users by their parent block.
+  DenseMap<Block *, SmallVector<Operation *>> blockUsers;
+  for (auto *user : result.getUsers()) {
+    blockUsers[user->getBlock()].push_back(user);
+  }
+
+  // If all uses are in the defining block, nothing to do.
+  if (blockUsers.size() == 1 && blockUsers.count(defBlock)) {
+    return 0;
+  }
+
+  LOG_DEBUG("Processing " << reinterpretOp << " with " << blockUsers.size()
+                          << " target blocks");
+
+  OpBuilder builder(reinterpretOp->getContext());
+  int cloned = 0;
+
+  for (auto &[targetBlock, users] : blockUsers) {
+    if (targetBlock == defBlock) {
+      continue;
+    }
+
+    Operation *firstUser = findFirstUserInBlock(users, targetBlock);
+    if (!firstUser) {
+      LOG_DEBUG("  Could not find first user in target block");
+      continue;
+    }
+
+    // Clone the reinterpret_cast before the first user.
+    builder.setInsertionPoint(firstUser);
+    Value clonedResult =
+        builder.clone(*reinterpretOp.getOperation())->getResult(0);
+    LOG_DEBUG("  Cloned before " << *firstUser << " in block");
+
+    // Redirect all users in this block to the cloned result.
+    for (auto *user : users) {
+      user->replaceUsesOfWith(result, clonedResult);
+    }
+
+    ++cloned;
+  }
+
+  // If no uses remain in the defining block, erase the original.
+  if (cloned > 0 && result.use_empty()) {
+    LOG_DEBUG("  Erasing original: " << reinterpretOp);
+    reinterpretOp->erase();
+  }
+
+  return cloned;
+}
+
+} // namespace
+
 namespace mlir::triton::CVSplit {
 
 void ReinterpretCastSinkingPass::runOnOperation() {
   ModuleOp mod = getOperation();
-  DominanceInfo domInfo;
 
   // Collect all reinterpret_cast ops first, since we'll be modifying the IR.
   SmallVector<memref::ReinterpretCastOp> opsToProcess;
   mod->walk([&](memref::ReinterpretCastOp op) { opsToProcess.push_back(op); });
 
-  int totalProcessed = 0;
   int totalCloned = 0;
-
   for (auto reinterpretOp : opsToProcess) {
-    Value result = reinterpretOp.getResult();
-    Block *defBlock = reinterpretOp->getBlock();
-
-    // Group users by their parent block.
-    DenseMap<Block *, SmallVector<Operation *>> blockUsers;
-    for (auto *user : result.getUsers()) {
-      blockUsers[user->getBlock()].push_back(user);
-    }
-
-    // If all uses are in the defining block, nothing to do.
-    if (blockUsers.size() == 1 && blockUsers.count(defBlock))
-      continue;
-
-    LOG_DEBUG("Processing " << reinterpretOp << " with " << blockUsers.size()
-                            << " target blocks");
-
-    // For each target block different from defBlock, clone the op.
-    OpBuilder builder(reinterpretOp->getContext());
-    bool anyCloned = false;
-
-    for (auto &[targetBlock, users] : blockUsers) {
-      if (targetBlock == defBlock)
-        continue;
-
-      // Find the earliest user in this block as insertion point.
-      Operation *firstUser = nullptr;
-      for (auto &op : *targetBlock) {
-        for (auto *user : users) {
-          if (user == &op) {
-            firstUser = user;
-            break;
-          }
-        }
-        if (firstUser)
-          break;
-      }
-
-      if (!firstUser) {
-        LOG_DEBUG("  Could not find first user in target block");
-        continue;
-      }
-
-      // Check that all operands dominate the insertion point.
-      bool operandsDominate = true;
-      for (Value operand : reinterpretOp->getOperands()) {
-        if (auto *operandOp = operand.getDefiningOp()) {
-          if (!domInfo.dominates(operandOp, firstUser)) {
-            LOG_DEBUG("  Operand " << operand << " does not dominate target");
-            operandsDominate = false;
-            break;
-          }
-        } else {
-          // Block arguments always dominate within their region.
-          auto *operandBlock = operand.getParentBlock();
-          if (!domInfo.dominates(operandBlock, targetBlock)) {
-            LOG_DEBUG("  Block arg " << operand
-                                     << " block does not dominate target");
-            operandsDominate = false;
-            break;
-          }
-        }
-      }
-
-      if (!operandsDominate) {
-        LOG_DEBUG("  Skipping target block due to dominance");
-        continue;
-      }
-
-      // Clone the reinterpret_cast before the first user.
-      builder.setInsertionPoint(firstUser);
-      auto *clonedOp = builder.clone(*reinterpretOp.getOperation());
-      Value clonedResult = clonedOp->getResult(0);
-
-      LOG_DEBUG("  Cloned before " << *firstUser << " in block");
-
-      // Redirect all users in this block to the cloned result.
-      for (auto *user : users) {
-        user->replaceUsesOfWith(result, clonedResult);
-      }
-
-      anyCloned = true;
-      totalCloned++;
-    }
-
-    // If no uses remain in the defining block, erase the original.
-    if (anyCloned && result.use_empty()) {
-      LOG_DEBUG("  Erasing original: " << reinterpretOp);
-      reinterpretOp->erase();
-    }
-
-    totalProcessed++;
+    totalCloned += sinkReinterpretCastOp(reinterpretOp);
   }
 
-  LOG_DEBUG("Processed " << totalProcessed << " ops, cloned " << totalCloned
-                         << " times");
+  LOG_DEBUG("Processed " << opsToProcess.size() << " ops, cloned "
+                         << totalCloned << " times");
 }
 
 std::unique_ptr<OperationPass<ModuleOp>> createReinterpretCastSinkingPass() {

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/ReinterpretCastSinking.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/ReinterpretCastSinking.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "llvm/Support/Debug.h"
+#include <memory>
+
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/Block.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/Value.h"
+
+#include "ascend/include/DynamicCVPipeline/StandardizeOp/ReinterpretCastSinking.h"
+
+using namespace mlir;
+using namespace triton;
+
+static constexpr const char *DEBUG_TYPE = "ReinterpretCastSinking";
+#define LOG_DEBUG(...)                                                         \
+  LLVM_DEBUG(llvm::dbgs() << "\n[" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
+
+namespace mlir::triton::CVSplit {
+
+void ReinterpretCastSinkingPass::runOnOperation() {
+  ModuleOp mod = getOperation();
+  DominanceInfo domInfo;
+
+  // Collect all reinterpret_cast ops first, since we'll be modifying the IR.
+  SmallVector<memref::ReinterpretCastOp> opsToProcess;
+  mod->walk(
+      [&](memref::ReinterpretCastOp op) { opsToProcess.push_back(op); });
+
+  int totalProcessed = 0;
+  int totalCloned = 0;
+
+  for (auto reinterpretOp : opsToProcess) {
+    Value result = reinterpretOp.getResult();
+    Block *defBlock = reinterpretOp->getBlock();
+
+    // Group users by their parent block.
+    DenseMap<Block *, SmallVector<Operation *>> blockUsers;
+    for (auto *user : result.getUsers()) {
+      blockUsers[user->getBlock()].push_back(user);
+    }
+
+    // If all uses are in the defining block, nothing to do.
+    if (blockUsers.size() == 1 && blockUsers.count(defBlock))
+      continue;
+
+    LOG_DEBUG("Processing " << reinterpretOp << " with " << blockUsers.size()
+                            << " target blocks");
+
+    // For each target block different from defBlock, clone the op.
+    OpBuilder builder(reinterpretOp->getContext());
+    bool anyCloned = false;
+
+    for (auto &[targetBlock, users] : blockUsers) {
+      if (targetBlock == defBlock)
+        continue;
+
+      // Find the earliest user in this block as insertion point.
+      Operation *firstUser = nullptr;
+      for (auto &op : *targetBlock) {
+        for (auto *user : users) {
+          if (user == &op) {
+            firstUser = user;
+            break;
+          }
+        }
+        if (firstUser)
+          break;
+      }
+
+      if (!firstUser) {
+        LOG_DEBUG("  Could not find first user in target block");
+        continue;
+      }
+
+      // Check that all operands dominate the insertion point.
+      bool operandsDominate = true;
+      for (Value operand : reinterpretOp->getOperands()) {
+        if (auto *operandOp = operand.getDefiningOp()) {
+          if (!domInfo.dominates(operandOp, firstUser)) {
+            LOG_DEBUG("  Operand " << operand << " does not dominate target");
+            operandsDominate = false;
+            break;
+          }
+        } else {
+          // Block arguments always dominate within their region.
+          auto *operandBlock = operand.getParentBlock();
+          if (!domInfo.dominates(operandBlock, targetBlock)) {
+            LOG_DEBUG("  Block arg " << operand
+                                     << " block does not dominate target");
+            operandsDominate = false;
+            break;
+          }
+        }
+      }
+
+      if (!operandsDominate) {
+        LOG_DEBUG("  Skipping target block due to dominance");
+        continue;
+      }
+
+      // Clone the reinterpret_cast before the first user.
+      builder.setInsertionPoint(firstUser);
+      auto *clonedOp = builder.clone(*reinterpretOp.getOperation());
+      Value clonedResult = clonedOp->getResult(0);
+
+      LOG_DEBUG("  Cloned before " << *firstUser << " in block");
+
+      // Redirect all users in this block to the cloned result.
+      for (auto *user : users) {
+        user->replaceUsesOfWith(result, clonedResult);
+      }
+
+      anyCloned = true;
+      totalCloned++;
+    }
+
+    // If no uses remain in the defining block, erase the original.
+    if (anyCloned && result.use_empty()) {
+      LOG_DEBUG("  Erasing original: " << reinterpretOp);
+      reinterpretOp->erase();
+    }
+
+    totalProcessed++;
+  }
+
+  LOG_DEBUG("Processed " << totalProcessed << " ops, cloned " << totalCloned
+                         << " times");
+}
+
+std::unique_ptr<OperationPass<ModuleOp>> createReinterpretCastSinkingPass() {
+  return std::make_unique<ReinterpretCastSinkingPass>();
+}
+
+} // namespace mlir::triton::CVSplit

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/ReinterpretCastSinking.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/ReinterpretCastSinking.cpp
@@ -45,8 +45,7 @@ void ReinterpretCastSinkingPass::runOnOperation() {
 
   // Collect all reinterpret_cast ops first, since we'll be modifying the IR.
   SmallVector<memref::ReinterpretCastOp> opsToProcess;
-  mod->walk(
-      [&](memref::ReinterpretCastOp op) { opsToProcess.push_back(op); });
+  mod->walk([&](memref::ReinterpretCastOp op) { opsToProcess.push_back(op); });
 
   int totalProcessed = 0;
   int totalCloned = 0;

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/ReinterpretCastSinking.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/ReinterpretCastSinking.cpp
@@ -34,76 +34,43 @@ using namespace triton;
 
 static constexpr const char *DEBUG_TYPE = "ReinterpretCastSinking";
 #define LOG_DEBUG(...)                                                         \
-  LLVM_DEBUG(llvm::dbgs() << "\n[" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
+  LLVM_DEBUG(llvm::dbgs() << "[" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
 
 namespace {
 
-// Find the earliest user of `result` that lives in `block`, scanning the
-// block in IR order. Used as the clone insertion point for that block.
-Operation *findFirstUserInBlock(ArrayRef<Operation *> users, Block *block) {
-  for (auto &op : *block) {
-    for (auto *user : users) {
-      if (user == &op)
-        return user;
-    }
-  }
-  return nullptr;
-}
-
-// Sink one reinterpret_cast into child use blocks:
-// 1. Group users by their parent block.
-// 2. Clone before each target block's first user.
-// 3. Redirect that block's users to the clone.
-// 4. Erase original if no remaining uses.
+// Sink one reinterpret_cast: insert a clone immediately before every user.
+// 1. Snapshot all result users.
+// 2. Clone cast before each user.
+// 3. Redirect each user to its clone.
+// 4. Erase original when all uses redirected.
 int sinkReinterpretCastOp(memref::ReinterpretCastOp reinterpretOp) {
   Value result = reinterpretOp.getResult();
-  Block *defBlock = reinterpretOp->getBlock();
 
-  // Group users by their parent block.
-  DenseMap<Block *, SmallVector<Operation *>> blockUsers;
-  for (auto *user : result.getUsers()) {
-    blockUsers[user->getBlock()].push_back(user);
-  }
+  // Snapshot users before mutating uses.
+  SmallVector<Operation *> users;
+  for (Operation *user : result.getUsers())
+    users.push_back(user);
 
-  // If all uses are in the defining block, nothing to do.
-  if (blockUsers.size() == 1 && blockUsers.count(defBlock)) {
-    return 0;
-  }
-
-  LOG_DEBUG("Processing " << reinterpretOp << " with " << blockUsers.size()
-                          << " target blocks");
+  LOG_DEBUG("Processing " << reinterpretOp << " with " << users.size()
+                          << " users");
 
   OpBuilder builder(reinterpretOp->getContext());
   int cloned = 0;
 
-  for (auto &[targetBlock, users] : blockUsers) {
-    if (targetBlock == defBlock) {
-      continue;
-    }
-
-    Operation *firstUser = findFirstUserInBlock(users, targetBlock);
-    if (!firstUser) {
-      LOG_DEBUG("  Could not find first user in target block");
-      continue;
-    }
-
-    // Clone the reinterpret_cast before the first user.
-    builder.setInsertionPoint(firstUser);
+  // Clone before every user: an MLIR block may later be split into
+  // multiple block_ids, so users must not share the cast. Redundant
+  // clones are eliminated by a later CSE pass.
+  for (auto *user : users) {
+    builder.setInsertionPoint(user);
     Value clonedResult =
         builder.clone(*reinterpretOp.getOperation())->getResult(0);
-    LOG_DEBUG("  Cloned before " << *firstUser << " in block");
-
-    // Redirect all users in this block to the cloned result.
-    for (auto *user : users) {
-      user->replaceUsesOfWith(result, clonedResult);
-    }
-
+    user->replaceUsesOfWith(result, clonedResult);
     ++cloned;
   }
 
-  // If no uses remain in the defining block, erase the original.
+  // Erase the original once every use has been redirected.
   if (cloned > 0 && result.use_empty()) {
-    LOG_DEBUG("  Erasing original: " << reinterpretOp);
+    LOG_DEBUG("Erasing original: " << reinterpretOp);
     reinterpretOp->erase();
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/ReinterpretCastSinking.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/ReinterpretCastSinking.cpp
@@ -50,15 +50,11 @@ Operation *findFirstUserInBlock(ArrayRef<Operation *> users, Block *block) {
   return nullptr;
 }
 
-// Sink a single reinterpret_cast: clone it into every block (other than its
-// defining block) where its result is used, redirecting those users to the
-// clone. Returns the number of clones created; erases `reinterpretOp` if it
-// ends up with no remaining uses.
-//
-// No dominance check is needed: every user of `result` is dominated by
-// `reinterpretOp` (SSA dominance), and `reinterpretOp`'s operands dominate
-// `reinterpretOp`, so by transitivity every operand already dominates the
-// insertion point (just before the first user in the target block).
+// Sink one reinterpret_cast into child use blocks:
+// 1. Group users by their parent block.
+// 2. Clone before each target block's first user.
+// 3. Redirect that block's users to the clone.
+// 4. Erase original if no remaining uses.
 int sinkReinterpretCastOp(memref::ReinterpretCastOp reinterpretOp) {
   Value result = reinterpretOp.getResult();
   Block *defBlock = reinterpretOp->getBlock();

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/SinkReinterpretCast.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/SinkReinterpretCast.mlir
@@ -1,0 +1,57 @@
+// RUN: triton-opt --ssbuf-sink-reinterpret-cast %s | FileCheck %s
+
+// Test: Sink memref.reinterpret_cast into child blocks
+//
+// Scenario: A memref.reinterpret_cast is defined in the parent block
+// of two scf.if ops. Each scf.if uses the reinterpret_cast result
+// via memref.subview.
+//
+// Expected: The reinterpret_cast is cloned into each scf.if block
+// just before the first use, and the original definition is erased.
+// This is verified by checking that a memref.reinterpret_cast with
+// sizes: [64], strides: [8] appears exactly twice in the output
+// (once in each scf.if), and each appears inside an scf.if block.
+
+// CHECK-LABEL: func.func @test_sink_reinterpret_cast
+// CHECK: scf.if
+// CHECK-NEXT: %{{.+}} = memref.reinterpret_cast %arg0 to offset: [%{{.+}}], sizes: [64], strides: [8]
+// CHECK-NEXT: %{{.+}} = memref.subview
+// CHECK: scf.if
+// CHECK-NEXT: %{{.+}} = memref.reinterpret_cast %arg0 to offset: [%{{.+}}], sizes: [64], strides: [8]
+// CHECK-NEXT: %{{.+}} = memref.subview
+// CHECK: return
+
+module {
+  func.func @test_sink_reinterpret_cast(%arg0: memref<?xf32>, %arg1: i32) -> index {
+    %c64 = arith.constant 64 : index
+    %c8 = arith.constant 8 : index
+    %c0 = arith.constant 0 : index
+    %c0_i32 = arith.constant 0 : i32
+    %idx = arith.index_cast %arg1 : i32 to index
+    %offset = arith.muli %idx, %c8 : index
+
+    // reinterpret_cast defined in the parent block — should be removed by the pass
+    %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [%offset], sizes: [64], strides: [8] : memref<?xf32> to memref<64xf32, strided<[8], offset: ?>>
+
+    %cond = arith.cmpi ne, %arg1, %c0_i32 : i32
+    %result1 = scf.if %cond -> (index) {
+      %subview = memref.subview %reinterpret_cast[0] [%c64] [1] : memref<64xf32, strided<[8], offset: ?>> to memref<?xf32, strided<[8], offset: ?>>
+      %dim = memref.dim %subview, %c0 : memref<?xf32, strided<[8], offset: ?>>
+      scf.yield %dim : index
+    } else {
+      scf.yield %c0 : index
+    }
+
+    %cond2 = arith.cmpi eq, %arg1, %c0_i32 : i32
+    %result2 = scf.if %cond2 -> (index) {
+      %subview2 = memref.subview %reinterpret_cast[0] [%c64] [1] : memref<64xf32, strided<[8], offset: ?>> to memref<?xf32, strided<[8], offset: ?>>
+      %dim2 = memref.dim %subview2, %c0 : memref<?xf32, strided<[8], offset: ?>>
+      scf.yield %dim2 : index
+    } else {
+      scf.yield %c0 : index
+    }
+
+    %sum = arith.addi %result1, %result2 : index
+    return %sum : index
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/SinkReinterpretCast.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/SinkReinterpretCast.mlir
@@ -1,16 +1,9 @@
 // RUN: triton-opt --ssbuf-sink-reinterpret-cast %s | FileCheck %s
 
-// Test: Sink memref.reinterpret_cast into child blocks
-//
-// Scenario: A memref.reinterpret_cast is defined in the parent block
-// of two scf.if ops. Each scf.if uses the reinterpret_cast result
-// via memref.subview.
-//
-// Expected: The reinterpret_cast is cloned into each scf.if block
-// just before the first use, and the original definition is erased.
-// This is verified by checking that a memref.reinterpret_cast with
-// sizes: [64], strides: [8] appears exactly twice in the output
-// (once in each scf.if), and each appears inside an scf.if block.
+// Test: sink memref.reinterpret_cast before every user.
+// - cast defined in parent block, one user per scf.if (memref.subview)
+// - clone inserted immediately before each user; block may split into block_ids later
+// - original erased once all uses redirected, so cast appears once per scf.if
 
 // CHECK-LABEL: func.func @test_sink_reinterpret_cast
 // CHECK: scf.if


### PR DESCRIPTION
Clone memref.reinterpret_cast ops into each child block where they are used, and erase the original when all uses have been moved. This eliminates cross-block memref dependencies that cause issues in downstream passes.

Co-Authored-By: DeLong code

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
