### PR TITLE
[TritonToLinalg](feat) Enable format for dot scale

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -2437,13 +2437,10 @@ DotScaledConverter::matchAndRewrite(triton::DotScaledOp op, OpAdaptor adaptor,
       }
     };
 
-    auto lhsFmt = convertFormat(lhsElemType);
-    auto rhsFmt = convertFormat(rhsElemType);
-
     Value matmulMxResult = rewriter.create<hfusion::MatMulMxOp>(
         loc, dstType, lhs, rhs, lhsScale, rhsScale, acc,
-        /*lhsFormat(optional)*/ nullptr,
-        /*rhsFormat(optional)*/ nullptr);
+        /*lhsFormat(optional)*/ convertFormat(lhsElemType),
+        /*rhsFormat(optional)*/ convertFormat(rhsElemType));
 
     Value finalResult = matmulMxResult;
     if (dstType.getElementType().isBF16()) {

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/dotScaled_fp8.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/dotScaled_fp8.mlir
@@ -53,7 +53,7 @@ module {
 
 
 // CHECK-LABEL: func.func @dot_scale_fp8_kernel
-// CHECK: hfusion.matmul_mx ins
+// CHECK: hfusion.matmul_mx
 // CHECK-DAG: tensor<32x128xf8E4M3FN>
 // CHECK-DAG: tensor<128x32xf8E4M3FN>
 // CHECK-DAG: tensor<32x4xi8>


### PR DESCRIPTION
In Ascend950 series, we supported hardware MatmulMx instruction in fp4 and fp8. To support tl.dot_scaled lowering to this instruction, we need to enable format use to keep information to lower component about the real semantic of the i8 input, whether it's fp8e5m2, fp8e4m3 or fp4x2.


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
