### PR TITLE
[language](fix) support PropagateNan enum in JITFunction kwargs and t…

### DIFF
--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1336,7 +1336,7 @@ class CodeGenerator(ast.NodeVisitor):
         args = inspect.getcallargs(fn.fn, *args, **kwargs)
         args = [args[name] for name in fn.arg_names]
         for i, arg in enumerate(args):
-            if isinstance(arg, (language.dtype, float, int, bool, JITFunction)):
+            if isinstance(arg, (language.dtype, float, int, bool, JITFunction, language.PropagateNan)):
                 args[i] = language.core.constexpr(arg)
         args_cst = find_paths_if(args, lambda _, x: _is_constexpr(x))
         args_cst = {path: get_iterable_path(args, path) for path in args_cst}

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -180,7 +180,7 @@ def _elementwise_max_propagate_nan(a, b):
 @core._add_reduction_docstr("maximum", return_indices_arg="return_indices",
                             tie_break_arg="return_indices_tie_break_left")
 def max(input, axis=None, return_indices=False, return_indices_tie_break_left=True, keep_dims=False,
-        propagate_nan=False):
+        propagate_nan: core.constexpr=core.PropagateNan.NONE):
     input = core._promote_bfloat16_to_float32(input)
     if return_indices:
         if return_indices_tie_break_left:
@@ -198,7 +198,7 @@ def max(input, axis=None, return_indices=False, return_indices_tie_break_left=Tr
                 # which can lead to "UB overflow" errors during kernel execution.
                 # Therefore, we keep the original narrow integer type and rely on backend support.
                 pass  # Do not promote to int32
-        if not propagate_nan:
+        if propagate_nan == core.PropagateNan.NONE:
             return core.reduce(input, axis, _elementwise_max, keep_dims=keep_dims)
         else:
             return core.reduce(input, axis, _elementwise_max_propagate_nan, keep_dims=keep_dims)

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -180,7 +180,7 @@ def _elementwise_max_propagate_nan(a, b):
 @core._add_reduction_docstr("maximum", return_indices_arg="return_indices",
                             tie_break_arg="return_indices_tie_break_left")
 def max(input, axis=None, return_indices=False, return_indices_tie_break_left=True, keep_dims=False,
-        propagate_nan: core.constexpr=core.PropagateNan.NONE):
+        propagate_nan: core.constexpr = core.PropagateNan.NONE):
     input = core._promote_bfloat16_to_float32(input)
     if return_indices:
         if return_indices_tie_break_left:

--- a/third_party/ascend/unittest/pytest_ut/test_max_propagate_nan.py
+++ b/third_party/ascend/unittest/pytest_ut/test_max_propagate_nan.py
@@ -5,13 +5,45 @@ import triton.language as tl
 import pytest
 
 
-def test_max_propagate_nan():
+def test_max_default_behavior():
 
     @triton.jit
     def func(in_ptr, out_ptr):
         a = tl.load(in_ptr + tl.arange(0, 8)[:, None] * 8 + tl.arange(0, 8)[None, :])
         a = tl.max(a, 0)
         tl.store(out_ptr + tl.arange(0, 8), a)
+
+    a = torch.randn((8, 8), device="npu")
+    std = a.max(0)[0]
+    ans = torch.zeros((8, ), dtype=torch.float32, device="npu")
+    func[1, 1, 1](a, ans)
+    torch.testing.assert_close(std, ans)
+
+def test_max_propagate_nan_all():
+
+    @triton.jit
+    def func(in_ptr, out_ptr):
+        a = tl.load(in_ptr + tl.arange(0, 8)[:, None] * 8 + tl.arange(0, 8)[None, :])
+        a = tl.max(a, 0, propagate_nan = tl.PropagateNan.ALL)
+        tl.store(out_ptr + tl.arange(0, 8), a)
+
+    a = torch.randn((8, 8), device="npu")
+    std = a.max(0)[0]
+    ans = torch.zeros((8, ), dtype=torch.float32, device="npu")
+    func[1, 1, 1](a, ans)
+    torch.testing.assert_close(std, ans)
+
+def test_max_propagate_nan_via_subfunction():
+
+    @triton.jit
+    def sub_max(x, dim: tl.constexpr, propagatenan: tl.constexpr):
+        return tl.max(x, dim, propagate_nan = propagatenan)
+
+    @triton.jit
+    def func(in_ptr, out_ptr):
+        a = tl.load(in_ptr + tl.arange(0, 8)[:, None] * 8 + tl.arange(0, 8)[None, :])
+        res = sub_max(a, 0, tl.PropagateNan.ALL)
+        tl.store(out_ptr + tl.arange(0, 8), res)
 
     a = torch.randn((8, 8), device="npu")
     std = a.max(0)[0]

--- a/third_party/ascend/unittest/pytest_ut/test_max_propagate_nan.py
+++ b/third_party/ascend/unittest/pytest_ut/test_max_propagate_nan.py
@@ -19,12 +19,13 @@ def test_max_default_behavior():
     func[1, 1, 1](a, ans)
     torch.testing.assert_close(std, ans)
 
+
 def test_max_propagate_nan_all():
 
     @triton.jit
     def func(in_ptr, out_ptr):
         a = tl.load(in_ptr + tl.arange(0, 8)[:, None] * 8 + tl.arange(0, 8)[None, :])
-        a = tl.max(a, 0, propagate_nan = tl.PropagateNan.ALL)
+        a = tl.max(a, 0, propagate_nan=tl.PropagateNan.ALL)
         tl.store(out_ptr + tl.arange(0, 8), a)
 
     a = torch.randn((8, 8), device="npu")
@@ -33,11 +34,12 @@ def test_max_propagate_nan_all():
     func[1, 1, 1](a, ans)
     torch.testing.assert_close(std, ans)
 
+
 def test_max_propagate_nan_via_subfunction():
 
     @triton.jit
     def sub_max(x, dim: tl.constexpr, propagatenan: tl.constexpr):
-        return tl.max(x, dim, propagate_nan = propagatenan)
+        return tl.max(x, dim, propagate_nan=propagatenan)
 
     @triton.jit
     def func(in_ptr, out_ptr):


### PR DESCRIPTION
…l.max propagate_nan

- code_generator.py: extend the constexpr-wrapping isinstance tuple in call_JitFunction to include language.PropagateNan. Without this, when a user passes propagate_nan=tl.PropagateNan.ALL as a kwarg to a @jit function, the pybind11 enum value is not wrapped in constexpr and ends up in args_val, where [arg.type for arg in args_val] raises AttributeError: triton._C.libtriton.ir.PROPAGATE_NAN object has no attribute 'type'.

- standard.py: change tl.max's propagate_nan parameter from bool to PropagateNan enum (constexpr-annotated)

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

## Summary

Fix `AttributeError: triton._C.libtriton.ir.PROPAGATE_NAN object has no attribute 'type'` raised when `tl.PropagateNan` enum values are passed as kwargs to a `@triton.jit` function, and align `tl.max`'s `propagate_nan` parameter type with the rest of the `tl.maximum` / `tl.minimum` / `tl.clamp` family.

## Background

On `release/3.2.2`, the following kernel works:

```python
@triton.jit
def my_kernel(x, y, propagate_nan: tl.constexpr):
    z = tl.minimum(x, y, propagate_nan=propagate_nan)
    tl.store(z_ptr, z)

my_kernel(x, y, propagate_nan=tl.PropagateNan.ALL)   # ok
```

After syncing Triton 3.6.0 (commit `50c50cc7d`), the same call raises:

```
AttributeError: triton._C.libtriton.ir.PROPAGATE_NAN object has no attribute 'type'
```

This is most visible in kernels that nest a `tl.max` reduction inside `tl.maximum`:

```python
m_ij = tl.maximum(
    m_i,
    tl.max(qk, 1, propagate_nan=tl.PropagateNan.ALL),  # <-- triggers the error
    propagate_nan=tl.PropagateNan.ALL,
)
```

## Root cause

Triton 3.4+ (upstream PR #5220, commit `9743ec0dc`) changed `CodeGenerator.call_JitFunction` from a blanket `_is_triton_value` check to a positive `isinstance` whitelist:

```python
# Before (3.2.2 and earlier):
args = [arg if _is_triton_value(arg) else constexpr(arg) for arg in args]

# After (#5220, present in 3.6.0):
for i, arg in enumerate(args):
    if isinstance(arg, (language.dtype, float, int, bool, JITFunction)):
        args[i] = language.core.constexpr(arg)
```

Pybind11 enums (`PROPAGATE_NAN`, `CACHE_MODIFIER`, `EVICTION_POLICY`, `ROUNDING_MODE`, `ATOMIC_OP`, `PADDING_OPTION`, ...) are not in the whitelist. As a result:

1. `PROPAGATE_NAN.ALL` is not wrapped in `constexpr`.
2. `find_paths_if(args, lambda _, x: not _is_constexpr(x))` puts it in `args_val` (the "runtime args" list).
3. `mangle_fn(..., [arg.type for arg in args_val], ...)` calls `.type` on the pybind11 enum, which has no such attribute.

`release/3.2.2` does not exhibit this because the branch was forked before PR #5220 landed upstream.

The new error path is triggered any time a pybind11 enum crosses a `@jit` function boundary as a kwarg, but `PropagateNan` is the most common offender because it is exposed through user-facing APIs (`tl.maximum` / `tl.minimum` / `tl.clamp` / now `tl.max`).


## New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
