### PR TITLE
[histogram](feat) Adapt to histogram parameter mask

### DIFF
--- a/third_party/ascend/lib/TritonToHFusion/TritonToHFusion.cpp
+++ b/third_party/ascend/lib/TritonToHFusion/TritonToHFusion.cpp
@@ -61,6 +61,7 @@ struct TritonHistogramToHFusionConversion
                                 PatternRewriter &rewriter) const final {
     auto loc = op.getLoc();
     Value input = op.getSrc();
+    Value mask = op.getMask();
     auto resultType = op.getResult().getType();
 
     int64_t numBins = 256; // 256 is default fallback.
@@ -71,7 +72,7 @@ struct TritonHistogramToHFusionConversion
     auto numBinsAttr = rewriter.getI64IntegerAttr(numBins);
 
     auto newOp = rewriter.create<hfusion::HistogramOp>(loc, resultType, input,
-                                                       numBinsAttr, Value());
+                                                       numBinsAttr, mask);
 
     rewriter.replaceOp(op, newOp.getResult());
     return success();

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -3551,6 +3551,7 @@ HistogramConverter::matchAndRewrite(triton::HistogramOp op, OpAdaptor adaptor,
                                     ConversionPatternRewriter &rewriter) const {
   auto loc = op.getLoc();
   Value input = adaptor.getSrc();
+  Value mask = adaptor.getMask();
   auto resultType = dyn_cast<RankedTensorType>(op.getResult().getType());
   if (!resultType || !resultType.hasStaticShape()) {
     return rewriter.notifyMatchFailure(op,
@@ -3569,10 +3570,14 @@ HistogramConverter::matchAndRewrite(triton::HistogramOp op, OpAdaptor adaptor,
 
   Value numBinsVal = rewriter.create<arith::ConstantIntOp>(loc, numBins, 64);
 
+  SmallVector<Value, 3> inputs = {input, numBinsVal};
+  if (mask) {
+    inputs.push_back(mask);
+  }
+
   auto customOp = rewriter.create<hivm::CustomOp>(
-      loc, TypeRange{resultType}, "__builtin_histogram",
-      ValueRange{input, numBinsVal}, ValueRange{fillOp.getResult(0)},
-      ValueRange{});
+      loc, TypeRange{resultType}, "__builtin_histogram", ValueRange{inputs},
+      ValueRange{fillOp.getResult(0)}, ValueRange{});
 
   customOp->setAttr("symbol", rewriter.getStringAttr("__builtin_histogram"));
   customOp->setAttr(

--- a/third_party/ascend/unittest/pytest_ut/test_histogram.py
+++ b/third_party/ascend/unittest/pytest_ut/test_histogram.py
@@ -35,6 +35,19 @@ def histogram_kernel(x_ptr, z_ptr, M: tl.constexpr, N: tl.constexpr):
     tl.store(z_ptr + offset2, z)
 
 
+@triton.jit
+def histogram_mask_kernel(x_ptr, z_ptr, n_elements, N: tl.constexpr, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(0)
+    block_start = pid * BLOCK_SIZE
+    offset1 = tl.arange(0, BLOCK_SIZE)
+    offset2 = tl.arange(0, N)
+    x_idx = block_start + offset1
+    mask = x_idx < n_elements
+    x = tl.load(x_ptr + x_idx)
+    z = tl.histogram(x, N, mask=mask)
+    tl.atomic_add(z_ptr + offset2, z)
+
+
 @pytest.mark.parametrize("M", [2048])
 @pytest.mark.parametrize("N", [2])
 @pytest.mark.parametrize("ncore", [1])
@@ -64,4 +77,25 @@ def test_histogram_uint(M, N, ncore, dtype):
     # triton结果
     y_ref = torch.empty(N, dtype=eval(f'torch.{dtype}'), device="npu")
     histogram_kernel[(ncore, )](x, y_ref, M=M, N=N)
+    test_common.validate_cmp(dtype, y_cal, y_ref)
+
+
+@pytest.mark.skip(reason="not supported before the NPUIR is updated, and will be fixed later.")
+@pytest.mark.parametrize("M", [2048])
+@pytest.mark.parametrize("N", [4])
+@pytest.mark.parametrize("BLOCK_SIZE", [10])
+@pytest.mark.parametrize("dtype", ["int32", "int64"])
+def test_histogram_with_mask(M, N, BLOCK_SIZE, dtype):
+    torch.manual_seed(42)
+
+    x = torch.randint(low=0, high=N, size=(M, ), dtype=eval(f'torch.{dtype}')).npu()
+    mask = torch.zeros((M, ), dtype=torch.bool)
+    mask[:M // 2] = True
+
+    valid_x = x.cpu()[mask]
+    ref_count = torch.bincount(valid_x, minlength=N)
+    y_cal = ref_count.to(eval(f'torch.{dtype}'))
+    y_ref = torch.zeros(N, dtype=eval(f'torch.{dtype}'), device="npu")
+    grid = lambda meta: (triton.cdiv(M, meta['BLOCK_SIZE']), )
+    histogram_mask_kernel[grid](x, y_ref, n_elements=M // 2, N=N, BLOCK_SIZE=BLOCK_SIZE)
     test_common.validate_cmp(dtype, y_cal, y_ref)


### PR DESCRIPTION
Adapt the new parameter mask for histogram.
A3 related code: third_party/ascend/lib/TritonToHFusion/TritonToHFusion.cpp::TritonHistogramToHFusionConversion；
A5 related code: third_party/ascending/lib/TritonToLinalg/TritonOpConverter.cpp: HistogramConverter
Modification: Add mask when passing to npuir.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
