### PR TITLE
[ssbuffer](fix) process conflict coretype iterarg dependencies

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
@@ -51,8 +51,6 @@ struct BlockInfo {
 struct DependencyInfo {
   DependencyType type;
   mlir::Value value;
-  bool isScaler = false;
-  bool is1DTensor = false;
   int producerBlockId;
   int consumerBlockId;
   int iniProducerBlockId;
@@ -63,6 +61,8 @@ struct DependencyInfo {
   // Optional Items for memDependencies
   mlir::Operation *predOp;
   mlir::Operation *nextOp;
+  // Optional Items for iterarg yield dependency
+  mlir::Operation *consumerYieldOp = nullptr;
 };
 
 class DataDependencyInfo {
@@ -130,8 +130,11 @@ private:
   void createBlockInfoMap(DataDependencyInfo &info);
   void collectBlockInfo(DataDependencyInfo &info, int blockId,
                         llvm::SmallVector<mlir::Operation *> &ops);
+  mlir::Operation *createBlockInfoConstOp(OpBuilder &builder, Location loc,
+                                          llvm::StringRef coreType,
+                                          DataDependencyInfo &info);
 
-  void collectDepInfo(mlir::Value depvalue, DependencyType dependencyType,
+  bool collectDepInfo(mlir::Value depvalue, DependencyType dependencyType,
                       llvm::SmallVector<DependencyInfo> &dependencies,
                       int iniProdId, int iniConsId, DataDependencyInfo &info,
                       bool isAllTranspoesd = false);
@@ -155,6 +158,7 @@ private:
   bool isValid1DValueForDependency(mlir::Value value);
   bool isAllTransposedInVector(mlir::Value value);
   bool isOuterOpArg(mlir::Value value);
+  mlir::Value resolveNestedIterArgInitValue(mlir::Value initValue);
   void processIterArgDependencies();
   llvm::SmallVector<mlir::Operation *>
   collectDiffCoreTypeUsers(mlir::BlockArgument iterArg,
@@ -164,7 +168,16 @@ private:
                               llvm::StringRef initCoreType,
                               llvm::SmallVector<mlir::Operation *> &diffUsers,
                               DataDependencyInfo &info);
-
+  void insertConsumerAndRecordDeps(scf::ForOp forOp, mlir::Value yieldedValue,
+                                   int iterArgIndex,
+                                   llvm::StringRef initCoreType,
+                                   DataDependencyInfo &info);
+  void recordInitValueDeps(scf::ForOp forOp, mlir::Value initValue,
+                           llvm::StringRef yieldCoreType,
+                           DataDependencyInfo &info);
+  void updateCoreTypeAtIndex(Operation *op, int index,
+                             llvm::StringRef newCoreType);
+  void deduplicateDependencies(llvm::SmallVector<DependencyInfo> &dependencies);
   mlir::ModuleOp module;
 };
 

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
@@ -140,13 +140,14 @@ private:
       mlir::OpBuilder &builder, mlir::Value srcValue,
       mlir::Value normalizedValue, mlir::Operation *vectorEndOp,
       mlir::Operation *cubeStartOp, mlir::Location loc, int transferIndex,
-      int iniConsumerId, bool isScaler, bool is1DTensor,
+      DependencyInfo &dep, bool is1DTensor,
       mlir::Operation **consumedDataOp = nullptr);
-  mlir::Operation *insertCubeToVectorTransfer(
-      mlir::OpBuilder &builder, mlir::Value srcValue,
-      mlir::Operation *cubeEndOp, mlir::Operation *vectorStartOp,
-      mlir::Location loc, int transferIndex, int iniConsumerId,
-      bool isAllTranspoesd, mlir::Operation **consumedDataOp = nullptr);
+  mlir::Operation *
+  insertCubeToVectorTransfer(mlir::OpBuilder &builder, mlir::Value srcValue,
+                             mlir::Operation *cubeEndOp,
+                             mlir::Operation *vectorStartOp, mlir::Location loc,
+                             int transferIndex, DependencyInfo &dep,
+                             mlir::Operation **consumedDataOp = nullptr);
   TransferPipeConfig getTransferPipeConfig(Operation *transferOp,
                                            bool isStoreDirectly = false);
   void insertInterCoreSync(mlir::OpBuilder &builder,

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/Utils.h
@@ -31,6 +31,8 @@ namespace triton {
 
 void setOpBlockId(mlir::Operation *op, int blockId);
 void setOpCoreType(mlir::Operation *op, llvm::StringRef coreType);
+bool isScalarDependency(mlir::Value depValue);
+bool is1DTensorDependency(mlir::Value depValue);
 
 } // namespace triton
 } // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -57,6 +57,7 @@ static constexpr const char *ssbufferCoreTypeCubeAttr = "CUBE";
 static constexpr const char *ssbufferCoreTypeVectorAttr = "VECTOR";
 static constexpr int ND_SHAPE_LENGTH = 2;
 static constexpr int SHAPE_1D_LENGTH = 1;
+static constexpr int constantIntType = 32;
 
 // Helper: ssbuffer.core_type
 llvm::StringRef getSsbufferCoreType(Operation *op) {
@@ -81,6 +82,45 @@ llvm::StringRef getCoreTypeWithIndex(Operation *op, int index) {
   }
 
   return typeStr;
+}
+
+void DataDependencyAnalysisPass::updateCoreTypeAtIndex(
+    Operation *op, int index, llvm::StringRef newCoreType) {
+  auto coreTypeAttr =
+      op->getAttrOfType<mlir::StringAttr>(CVPipeline::kCoreType);
+  if (!coreTypeAttr) {
+    LOG_DEBUG("[warning]: failed to rewrite coretype\n");
+    return;
+  }
+
+  llvm::StringRef typeStr = coreTypeAttr.getValue();
+  if (typeStr.contains(", ")) {
+    llvm::SmallVector<llvm::StringRef> types;
+    typeStr.split(types, ", ", -1, false);
+    if (index < static_cast<int>(types.size())) {
+      types[index] = newCoreType;
+    } else {
+      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
+      LOG_DEBUG("[info]: invalid index for updateCoreTypeAtIndex.\n");
+      return;
+    }
+    std::string newTypeStr;
+    for (size_t i = 0; i < types.size(); ++i) {
+      if (i > 0)
+        newTypeStr += ", ";
+      newTypeStr += types[i].str();
+    }
+    op->setAttr(CVPipeline::kCoreType,
+                StringAttr::get(op->getContext(), newTypeStr));
+  } else {
+    if (index != 0) {
+      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
+      LOG_DEBUG("[info]: invalid index for updateCoreTypeAtIndex.\n");
+      return;
+    }
+    op->setAttr(CVPipeline::kCoreType,
+                StringAttr::get(op->getContext(), newCoreType));
+  }
 }
 
 // Helper: Check if operation is control flow
@@ -178,6 +218,38 @@ bool DataDependencyAnalysisPass::isOuterOpArg(mlir::Value value) {
   return false;
 }
 
+// Resolve nested scf.for iterArg init value and return its defining op
+// If `initValue` is a BlockArgument of an outer scf.for iterArg, walk up
+// the enclosing for-loops and return the defining op of the real init value
+// (the corresponding `forOp.getInitArgs()[argIndex]`) until a non-BlockArgument
+// is found.
+mlir::Value DataDependencyAnalysisPass::resolveNestedIterArgInitValue(
+    mlir::Value initValue) {
+  llvm::DenseSet<mlir::Value> visited;
+  mlir::Value currentValue = initValue;
+  while (true) {
+    if (!visited.insert(currentValue).second)
+      break;
+    auto blockArg = dyn_cast<mlir::BlockArgument>(currentValue);
+    if (!blockArg)
+      break;
+    // Parent op of the block containing this argument
+    mlir::Operation *parentOp = blockArg.getOwner()->getParentOp();
+    LOG_DEBUG("parentOp: " << *parentOp << "\n");
+    auto outerFor = dyn_cast<scf::ForOp>(parentOp);
+    if (!outerFor)
+      break;
+    unsigned argIndex = blockArg.getArgNumber() - 1;
+    LOG_DEBUG("argIndex: " << argIndex << "\n");
+    if (argIndex >= outerFor.getInitArgs().size())
+      break;
+    // Move to the init value corresponding to this iterArg
+    currentValue = outerFor.getInitArgs()[argIndex];
+  }
+  LOG_DEBUG("currentValue: " << currentValue << "\n");
+  return currentValue;
+}
+
 // Helper: Build and record BlockInfo
 void DataDependencyAnalysisPass::collectBlockInfo(
     DataDependencyInfo &info, int blockId,
@@ -260,7 +332,25 @@ void DataDependencyAnalysisPass::createBlockInfoMap(DataDependencyInfo &info) {
   }
 }
 
-void DataDependencyAnalysisPass::collectDepInfo(
+mlir::Operation *DataDependencyAnalysisPass::createBlockInfoConstOp(
+    OpBuilder &builder, Location loc, llvm::StringRef coreType,
+    DataDependencyInfo &info) {
+  int newId = CVPipeline::getAvailableBlockId(module);
+  auto constOp = builder.create<arith::ConstantIntOp>(loc, 0, constantIntType);
+  setOpBlockId(constOp, newId);
+  setOpCoreType(constOp, coreType);
+
+  BlockInfo blockInfo;
+  blockInfo.blockId = newId;
+  blockInfo.isCube = (coreType == ssbufferCoreTypeCubeAttr);
+  blockInfo.isControl = false;
+  blockInfo.Operations.push_back(constOp);
+  info.getBlockInfoMap()[newId] = blockInfo;
+
+  return constOp;
+}
+
+bool DataDependencyAnalysisPass::collectDepInfo(
     mlir::Value depvalue, DependencyType dependencyType,
     llvm::SmallVector<DependencyInfo> &dependencies, int iniProdId,
     int iniConsId, DataDependencyInfo &info, bool isAllTranspoesd) {
@@ -276,21 +366,16 @@ void DataDependencyAnalysisPass::collectDepInfo(
     LOG_DEBUG("Could not find common level block IDs for producer and consumer "
               "blocks");
     CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
-    return;
+    return false;
   }
 
   depInfo.producerBlockId = commonLevelIds.first;
   depInfo.consumerBlockId = commonLevelIds.second;
-  if (isValidScalarDependency(depvalue)) {
-    depInfo.isScaler = true;
-  }
-  if (isValid1DValueForDependency(depvalue)) {
-    depInfo.is1DTensor = true;
-  }
   if (isAllTranspoesd) {
     depInfo.isAllTranspoesd = true;
   }
   dependencies.push_back(depInfo);
+  return true;
 }
 
 // Collects users of iterArg that have a different core type than initCoreType.
@@ -326,22 +411,14 @@ void DataDependencyAnalysisPass::insertProducerAndRecordDeps(
   auto &c2vDependencies = info.getC2VDependencies();
   auto &blockInfoMap = info.getBlockInfoMap();
 
-  int newId = CVPipeline::getAvailableBlockId(module);
   OpBuilder builder(forOp);
   Block &bodyBlock = forOp.getRegion().front();
   builder.setInsertionPointToStart(&bodyBlock);
   Location loc = forOp.getLoc();
-  auto constOp = builder.create<arith::ConstantIntOp>(loc, 0, 32);
-  setOpBlockId(constOp, newId);
-  setOpCoreType(constOp, initCoreType);
+  auto constOp = createBlockInfoConstOp(builder, loc, initCoreType, info);
+  int newId = *CVPipeline::getOpBlockId(constOp);
 
-  BlockInfo blockInfo;
-  blockInfo.blockId = newId;
-  blockInfo.isCube = (initCoreType == ssbufferCoreTypeCubeAttr);
-  blockInfo.isControl = false;
-  blockInfo.Operations.push_back(constOp);
-  blockInfoMap[newId] = blockInfo;
-
+  llvm::DenseSet<int> processedUserBlockIds;
   for (auto &user : diffUsers) {
     auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
     if (!userBlockIdOpt) {
@@ -349,36 +426,23 @@ void DataDependencyAnalysisPass::insertProducerAndRecordDeps(
       continue;
     }
     int userBlockId = *userBlockIdOpt;
-
+    if (!processedUserBlockIds.insert(userBlockId).second) {
+      continue;
+    }
     // Determine dependency type based on initCoreType
     DependencyType depType;
     if (initCoreType == ssbufferCoreTypeVectorAttr) {
       depType = DependencyType::VectorToCube;
     } else if (initCoreType == ssbufferCoreTypeCubeAttr) {
       depType = DependencyType::CubeToVector;
-    } else {
-      LOG_DEBUG("Warning: Unknown initCoreType: " << initCoreType << "\n");
+    }
+
+    auto &targetDeps = (depType == DependencyType::VectorToCube)
+                           ? v2cDependencies
+                           : c2vDependencies;
+    if (!collectDepInfo(iterArg, depType, targetDeps, newId, userBlockId,
+                        info)) {
       continue;
-    }
-
-    // Record dependency
-    DependencyInfo depInfo;
-    depInfo.type = depType;
-    depInfo.value = iterArg;
-    depInfo.iniProducerBlockId = newId;
-    depInfo.iniConsumerBlockId = userBlockId;
-
-    auto [producerBlockId, consumerBlockId] =
-        findCommonLevelBlockIds(info, newId, userBlockId);
-    depInfo.producerBlockId = producerBlockId;
-    depInfo.consumerBlockId = consumerBlockId;
-    if (isValid1DValueForDependency(iterArg)) {
-      depInfo.is1DTensor = true;
-    }
-    if (depType == DependencyType::VectorToCube) {
-      v2cDependencies.push_back(depInfo);
-    } else {
-      c2vDependencies.push_back(depInfo);
     }
 
     LOG_DEBUG("Recorded iterArg dependency: "
@@ -389,6 +453,96 @@ void DataDependencyAnalysisPass::insertProducerAndRecordDeps(
               << ", producerBlockId=" << newId
               << ", consumerBlockId=" << userBlockId << "\n");
   }
+}
+
+void DataDependencyAnalysisPass::insertConsumerAndRecordDeps(
+    scf::ForOp forOp, mlir::Value yieldedValue, int iterArgIndex,
+    llvm::StringRef initCoreType, DataDependencyInfo &info) {
+  auto &v2cDependencies = info.getV2CDependencies();
+  auto &c2vDependencies = info.getC2VDependencies();
+  auto &blockInfoMap = info.getBlockInfoMap();
+
+  auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+  OpBuilder builder(yieldOp);
+  Location loc = yieldOp.getLoc();
+  auto constOp = createBlockInfoConstOp(builder, loc, initCoreType, info);
+  int newId = *CVPipeline::getOpBlockId(constOp);
+
+  Operation *yieldedDefOp = yieldedValue.getDefiningOp();
+  auto yieldedDefBlockIdOpt = CVPipeline::getOpBlockId(yieldedDefOp);
+  if (!yieldedDefBlockIdOpt) {
+    LOG_DEBUG("Warning: Yielded defining op block ID not found.\n");
+    return;
+  }
+  int yieldedDefBlockId = *yieldedDefBlockIdOpt;
+
+  DependencyType depType;
+  if (initCoreType == ssbufferCoreTypeVectorAttr) {
+    depType = DependencyType::CubeToVector;
+  } else if (initCoreType == ssbufferCoreTypeCubeAttr) {
+    depType = DependencyType::VectorToCube;
+  }
+
+  auto &targetDeps = (depType == DependencyType::VectorToCube)
+                         ? v2cDependencies
+                         : c2vDependencies;
+  LOG_DEBUG("iniProducerBlockId=" << yieldedDefBlockId
+                                  << ", iniConsumerBlockId=" << newId << "\n");
+  if (!collectDepInfo(yieldedValue, depType, targetDeps, yieldedDefBlockId,
+                      newId, info)) {
+    return;
+  }
+  targetDeps.back().consumerYieldOp = yieldOp;
+
+  updateCoreTypeAtIndex(yieldOp, iterArgIndex, initCoreType);
+  updateCoreTypeAtIndex(forOp, iterArgIndex, initCoreType);
+
+  LOG_DEBUG("Recorded yield producer dependency: "
+            << initCoreType << ", iniProducerBlockId=" << yieldedDefBlockId
+            << ", iniConsumerBlockId=" << newId << "\n");
+}
+
+void DataDependencyAnalysisPass::recordInitValueDeps(
+    scf::ForOp forOp, mlir::Value initValue, llvm::StringRef yieldCoreType,
+    DataDependencyInfo &info) {
+  auto &v2cDependencies = info.getV2CDependencies();
+  auto &c2vDependencies = info.getC2VDependencies();
+
+  Operation *initDefOp = initValue.getDefiningOp();
+  auto initDefBlockIdOpt = CVPipeline::getOpBlockId(initDefOp);
+  if (!initDefBlockIdOpt) {
+    LOG_DEBUG("Warning: Init defining op block ID not found.\n");
+    return;
+  }
+  int initDefBlockId = *initDefBlockIdOpt;
+
+  auto forOpBlockIdOpt = CVPipeline::getOpBlockId(forOp);
+  if (!forOpBlockIdOpt) {
+    LOG_DEBUG("Warning: ForOp block ID not found.\n");
+    return;
+  }
+  int forOpBlockId = *forOpBlockIdOpt;
+
+  DependencyType depType;
+  if (yieldCoreType == ssbufferCoreTypeVectorAttr) {
+    depType = DependencyType::CubeToVector;
+  } else if (yieldCoreType == ssbufferCoreTypeCubeAttr) {
+    depType = DependencyType::VectorToCube;
+  }
+
+  auto &targetDeps = (depType == DependencyType::VectorToCube)
+                         ? v2cDependencies
+                         : c2vDependencies;
+  LOG_DEBUG("iniProducerBlockId=" << initDefBlockId << ", iniConsumerBlockId="
+                                  << forOpBlockId << "\n");
+  if (!collectDepInfo(initValue, depType, targetDeps, initDefBlockId,
+                      forOpBlockId, info)) {
+    return;
+  }
+
+  LOG_DEBUG("Recorded init value dependency: "
+            << yieldCoreType << ", iniProducerBlockId=" << initDefBlockId
+            << ", iniConsumerBlockId=" << forOpBlockId << "\n");
 }
 
 bool checkYieldCoreType(mlir::Operation *yieldOp) {
@@ -452,40 +606,71 @@ void DataDependencyAnalysisPass::processIterArgDependencies() {
 
       Operation *initDefOp = initValue.getDefiningOp();
       Operation *yieldedDefOp = yieldedValue.getDefiningOp();
-      if (!initDefOp) {
-        LOG_DEBUG("warning: nested iterarg!");
-        continue;
-      }
       if (!yieldedDefOp) {
         continue;
       }
-      if (isCubeOrVectorOp(initDefOp) && isCubeOrVectorOp(yieldedDefOp)) {
-        continue;
-      }
-
-      auto initDefResult = dyn_cast<mlir::OpResult>(initValue);
-      auto initCoreType = getCoreTypeWithIndex(
-          initDefOp, initDefResult ? initDefResult.getResultNumber() : 0);
       auto yieldCoreType = getCoreTypeWithIndex(forOp, iterArgIndex);
 
-      // Only process if init and yield have matching core types
-      // Mismatch indicates a more complex dependency pattern that requires
-      // special handling
-      if (initCoreType != yieldCoreType) {
-        if (!isValidValueForDependency(initValue)) {
-          if (collectDiffCoreTypeUsers(iterArg, yieldCoreType).empty()) {
+      if (!initDefOp) {
+        auto realInitValue = resolveNestedIterArgInitValue(initValue);
+        auto realInitDefOp = realInitValue.getDefiningOp();
+        auto realInitDefReuslt = dyn_cast<mlir::OpResult>(realInitValue);
+        if (!realInitDefOp) {
+          continue;
+        }
+        if (getCoreTypeWithIndex(realInitDefOp,
+                                 realInitDefReuslt
+                                     ? realInitDefReuslt.getResultNumber()
+                                     : 0) != yieldCoreType) {
+          CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
+          LOG_DEBUG("[info]: nested conflict iterarg!");
+          return;
+        }
+        initDefOp = realInitDefOp;
+        initValue = realInitValue;
+      }
+      auto initDefReuslt = dyn_cast<mlir::OpResult>(initValue);
+      auto initCoreType = getCoreTypeWithIndex(
+          initDefOp, initDefReuslt ? initDefReuslt.getResultNumber() : 0);
+
+      LOG_DEBUG("[initDefOp]: " << *initDefOp << "\n");
+      if (initCoreType == yieldCoreType || isCubeOrVectorOp(initDefOp)) {
+        auto diffUsers = collectDiffCoreTypeUsers(iterArg, yieldCoreType);
+        if (!diffUsers.empty()) {
+          insertProducerAndRecordDeps(forOp, iterArg, yieldCoreType, diffUsers,
+                                      info);
+        }
+      } else {
+        llvm::SmallVector<mlir::Operation *> initCoreTypeUsers;
+        llvm::SmallVector<mlir::Operation *> yieldCoreTypeUsers;
+
+        for (mlir::Operation *user : iterArg.getUsers()) {
+          if (isa<scf::YieldOp>(user)) {
             continue;
           }
+          if (isControlFlowOp(user)) {
+            LOG_DEBUG("cannot process nested iterarg!");
+            continue;
+          }
+          auto userCoreType = getCoreTypeWithIndex(user, 0);
+          if (userCoreType == initCoreType) {
+            initCoreTypeUsers.push_back(user);
+          } else if (userCoreType == yieldCoreType) {
+            yieldCoreTypeUsers.push_back(user);
+          }
         }
-        LOG_DEBUG("iterarg init core_type conflicts with yield");
-        CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
-        return;
-      }
-
-      auto diffUsers = collectDiffCoreTypeUsers(iterArg, initCoreType);
-      if (!diffUsers.empty()) {
-        insertProducerAndRecordDeps(forOp, iterArg, initCoreType, diffUsers,
-                                    info);
+        if (!initCoreTypeUsers.empty() && !yieldCoreTypeUsers.empty()) {
+          recordInitValueDeps(forOp, initValue, yieldCoreType, info);
+          insertProducerAndRecordDeps(forOp, iterArg, yieldCoreType,
+                                      yieldCoreTypeUsers, info);
+        } else if (!initCoreTypeUsers.empty() && yieldCoreTypeUsers.empty()) {
+          insertConsumerAndRecordDeps(forOp, yieldedValue, iterArgIndex,
+                                      initCoreType, info);
+        } else if (initCoreTypeUsers.empty() && !yieldCoreTypeUsers.empty()) {
+          recordInitValueDeps(forOp, initValue, yieldCoreType, info);
+        } else {
+          LOG_DEBUG("no dependencies with: " << iterArg << "\n");
+        }
       }
     }
   }
@@ -539,8 +724,11 @@ void DataDependencyAnalysisPass::analyzeExternalInputs(
           continue;
         }
         int producerId = *producerIdOpt;
-        collectDepInfo(input, DependencyType::VectorToCube, v2cDependencies,
-                       producerId, blockInfo.blockId, info);
+        if (!collectDepInfo(input, DependencyType::VectorToCube,
+                            v2cDependencies, producerId, blockInfo.blockId,
+                            info)) {
+          continue;
+        }
       }
     }
   }
@@ -614,9 +802,11 @@ void DataDependencyAnalysisPass::analyzeExternalOutputs(
           int consumerId = *consumerIdOpt;
           auto inserted = handledBlockIds.insert(consumerId).second;
           if (inserted) {
-            collectDepInfo(output, DependencyType::CubeToVector,
-                           c2vDependencies, blockInfo.blockId, consumerId, info,
-                           isAllTranspoesd);
+            if (!collectDepInfo(output, DependencyType::CubeToVector,
+                                c2vDependencies, blockInfo.blockId, consumerId,
+                                info, isAllTranspoesd)) {
+              continue;
+            }
           }
         }
         // If user belongs to Cube block, this C->C dependency was handled
@@ -690,7 +880,7 @@ void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info) {
               realPredCoreType.empty()) {
             continue;
           }
-          int realPredBlockId = static_cast<int>(*realPredBlockIdOpt);
+          int realPredBlockId = *realPredBlockIdOpt;
           auto [producerBlockId, consumerBlockId] =
               findCommonLevelBlockIds(info, realPredBlockId, currBlockId);
           if (producerBlockId == -1 || consumerBlockId == -1) {
@@ -827,6 +1017,21 @@ std::pair<int, int> DataDependencyAnalysisPass::findCommonLevelBlockIds(
   return {-1, -1};
 }
 
+// Deduplicate dependencies: remove duplicates with same value,
+// iniConsumerBlockId, and iniProducerBlockId
+void DataDependencyAnalysisPass::deduplicateDependencies(
+    llvm::SmallVector<DependencyInfo> &dependencies) {
+  auto newEnd =
+      std::unique(dependencies.begin(), dependencies.end(),
+                  [](const DependencyInfo &a, const DependencyInfo &b) {
+                    return a.value == b.value &&
+                           a.iniConsumerBlockId == b.iniConsumerBlockId &&
+                           a.iniProducerBlockId == b.iniProducerBlockId;
+                  });
+
+  dependencies.erase(newEnd, dependencies.end());
+}
+
 void DataDependencyAnalysisPass::runOnOperation() {
   LOG_DEBUG("\n--- enter DataDependencyAnalysisPass --->\n");
   module = getOperation();
@@ -842,6 +1047,7 @@ void DataDependencyAnalysisPass::runOnOperation() {
 
   // Step 2: Analyze iter_args dependencies
   processIterArgDependencies();
+  createBlockInfoMap(info);
 
   // Step 3: Analyze dependencies (populate v2c, c2v lists)
   analyzeExternalInputs(info);
@@ -850,6 +1056,12 @@ void DataDependencyAnalysisPass::runOnOperation() {
 
   // Step 4: Analyze memory dependencies (memdep sync)
   analyzeMemoryEffect(info);
+
+  // Step 5: Deduplicate dependencies (remove duplicates with same value,
+  // iniConsumerBlockId, iniProducerBlockId)
+  deduplicateDependencies(info.getV2CDependencies());
+  deduplicateDependencies(info.getC2VDependencies());
+  deduplicateDependencies(info.getMemoryDependencies());
 
   info.setValid(true);
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -539,7 +539,7 @@ InterCoreTransferAndSyncPass::getConsumerWaitPoint(int transferIndex) {
 Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(
     OpBuilder &builder, Value srcValue, Value normalizedValue,
     Operation *vectorEndOp, Operation *cubeStartOp, Location loc,
-    int transferIndex, int iniConsumerId, bool isScaler, bool is1DTensor,
+    int transferIndex, DependencyInfo &dep, bool is1DTensor,
     Operation **consumedDataOp) {
   mlir::Operation *sendOp = nullptr;
   mlir::Operation *receiveOp = nullptr;
@@ -548,7 +548,7 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(
   int vecBlockId = CVPipeline::getOpBlockId(vectorEndOp).value_or(-1);
   int cubeBlockId = CVPipeline::getOpBlockId(cubeStartOp).value_or(-1);
 
-  if (isScaler) {
+  if (isScalarDependency(dep.value)) {
     builder.setInsertionPointAfter(vectorEndOp);
     SmallVector<Operation *> writeOps;
     LOG_DEBUG("before writeToSSBuffer\n");
@@ -652,10 +652,13 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(
 
   llvm::SmallVector<Operation *> users(srcValue.getUsers().begin(),
                                        srcValue.getUsers().end());
+  if (dep.consumerYieldOp) {
+    dep.consumerYieldOp->replaceUsesOfWith(srcValue, receiveValue);
+  }
   for (Operation *user : users) {
     LOG_DEBUG("[v->c user]" << *user << "\n");
     auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
-    if (userBlockIdOpt && *userBlockIdOpt == iniConsumerId) {
+    if (userBlockIdOpt && *userBlockIdOpt == dep.iniConsumerBlockId) {
       user->replaceUsesOfWith(srcValue, receiveValue);
     }
   }
@@ -668,7 +671,7 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(
 Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(
     OpBuilder &builder, Value srcValue, Operation *cubeEndOp,
     Operation *vectorStartOp, Location loc, int transferIndex,
-    int iniConsumerId, bool isAllTranspoesd, Operation **consumedDataOp) {
+    DependencyInfo &dep, Operation **consumedDataOp) {
   LOG_DEBUG("Inserting [Cube->Vector] transfer for value: " << srcValue
                                                             << "\n");
   auto srcTensorType = cast<RankedTensorType>(srcValue.getType());
@@ -680,15 +683,15 @@ Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(
       CVPipeline::getOpBlockId(srcValue.getDefiningOp()).value_or(-1);
   int vecBlockId = CVPipeline::getOpBlockId(vectorStartOp).value_or(-1);
 
-  auto targetShape =
-      isAllTranspoesd ? std::vector<int64_t>{N, M} : std::vector<int64_t>{M, N};
+  auto targetShape = dep.isAllTranspoesd ? std::vector<int64_t>{N, M}
+                                         : std::vector<int64_t>{M, N};
   auto targetTensorType = RankedTensorType::get(targetShape, elemType);
   auto [cubeAllocOp, vecAllocOp] = createTransferAllocs(
       builder, loc, targetShape, elemType, hivm::AddressSpace::UB, cubeEndOp,
       vectorStartOp, cubeBlockId, vecBlockId, "CUBE", "VECTOR", transferIndex);
   auto dmaModeAttr = FixpipeDMAModeAttr::get(
       builder.getContext(),
-      isAllTranspoesd ? FixpipeDMAMode::NZ2DN : FixpipeDMAMode::NZ2ND);
+      dep.isAllTranspoesd ? FixpipeDMAMode::NZ2DN : FixpipeDMAMode::NZ2ND);
 
   auto fixpipeOp = builder.create<hivm::FixpipeOp>(
       loc, mlir::TypeRange{},    // No return value
@@ -717,7 +720,7 @@ Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(
   attachTransferTags(toTensorOp, vecBlockId, "VECTOR", transferIndex);
   LOG_DEBUG("[toTensorOp]: " << *toTensorOp << "\n");
 
-  if (isAllTranspoesd) {
+  if (dep.isAllTranspoesd) {
     for (auto *userOp : srcValue.getUsers()) {
       if (isa<linalg::TransposeOp>(userOp)) {
         srcValue = userOp->getResults()[0];
@@ -727,10 +730,13 @@ Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(
   }
   llvm::SmallVector<Operation *> users(srcValue.getUsers().begin(),
                                        srcValue.getUsers().end());
+  if (dep.consumerYieldOp) {
+    dep.consumerYieldOp->replaceUsesOfWith(srcValue, toTensorOp.getResult());
+  }
   for (Operation *user : users) {
     LOG_DEBUG("[c->v user]" << *user << "\n");
     auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
-    if (userBlockIdOpt && *userBlockIdOpt == iniConsumerId) {
+    if (userBlockIdOpt && *userBlockIdOpt == dep.iniConsumerBlockId) {
       user->replaceUsesOfWith(srcValue, toTensorOp.getResult());
     }
   }
@@ -887,8 +893,7 @@ void InterCoreTransferAndSyncPass::insertInterCoreSync(
         loc, config.srcCoreAttr, config.forWriteTPipe, config.forWritePipe,
         flagId);
 
-    int startEndBlockId =
-        static_cast<int>(CVPipeline::getOpBlockId(mainLoopOp).value_or(-1));
+    int startEndBlockId = CVPipeline::getOpBlockId(mainLoopOp).value_or(-1);
     attachTransferTags(setOpForStart, startEndBlockId, config.dstCoreType,
                        transferIndex);
     attachTransferTags(waitOpForEnd, startEndBlockId, config.srcCoreType,
@@ -1083,7 +1088,7 @@ LogicalResult InterCoreTransferAndSyncPass::handleVectorToCube(
   LOG_DEBUG("after analyzeConsumerReadInsertPoint\n");
   Operation *transferOp = insertVectorToCubeTransfer(
       builder, srcValue, normalizedVal, prodEnd, consStart, loc, transferIndex,
-      dep.iniConsumerBlockId, dep.isScaler, dep.is1DTensor, &consumedDataOp);
+      dep, is1DTensorDependency(dep.value), &consumedDataOp);
 
   int flagId = flagManager.acquireId(prodStart);
   auto [newProdStart, newProdEnd] =
@@ -1124,9 +1129,9 @@ LogicalResult InterCoreTransferAndSyncPass::handleCubeToVector(
   LOG_DEBUG("[newConsStart]" << *consStart << "\n");
   LOG_DEBUG("[newConsEnd]" << *consEnd << "\n");
   Operation *consumedDataOp = nullptr;
-  Operation *transferOp = insertCubeToVectorTransfer(
-      builder, srcValue, prodEnd, consStart, loc, transferIndex,
-      dep.iniConsumerBlockId, dep.isAllTranspoesd, &consumedDataOp);
+  Operation *transferOp =
+      insertCubeToVectorTransfer(builder, srcValue, prodEnd, consStart, loc,
+                                 transferIndex, dep, &consumedDataOp);
 
   auto [newProdStart, newProdEnd] =
       getBlockStartEnd(dep.producerBlockId, module); // C Block
@@ -1359,8 +1364,7 @@ void InterCoreTransferAndSyncPass::sortDependencies(
     unsigned firstOrder = std::numeric_limits<unsigned>::max();
     for (auto *user : dep.value.getUsers()) {
       auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
-      if (userBlockIdOpt &&
-          static_cast<int>(*userBlockIdOpt) == dep.consumerBlockId) {
+      if (userBlockIdOpt && *userBlockIdOpt == dep.consumerBlockId) {
         auto it = opOrder.find(user);
         if (it != opOrder.end() && it->second < firstOrder) {
           firstOrder = it->second;
@@ -1415,7 +1419,7 @@ LogicalResult InterCoreTransferAndSyncPass::processDependencies(
   LOG_DEBUG("Step 1: Handle V->C dependencies\n");
   // Step 1: Handle V->C dependencies
   for (auto &dep : V2CDependencies) {
-    if (!dep.isScaler && !dep.is1DTensor) {
+    if (!isScalarDependency(dep.value) && !is1DTensorDependency(dep.value)) {
       Location loc = dep.value.getLoc();
       Nd2NzNormalize(builder, dep, loc);
     }

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/Utils.cpp
@@ -42,3 +42,16 @@ void triton::setOpCoreType(mlir::Operation *op, llvm::StringRef coreType) {
   op->setAttr(CVPipeline::kCoreType,
               StringAttr::get(op->getContext(), coreType));
 }
+
+bool triton::isScalarDependency(mlir::Value depValue) {
+  return isa<FloatType, IntegerType>(depValue.getType());
+}
+
+bool triton::is1DTensorDependency(mlir::Value depValue) {
+  static constexpr int SHAPE_1D_LENGTH = 1;
+  auto tensorTy = dyn_cast<TensorType>(depValue.getType());
+  if (tensorTy && tensorTy.getRank() == SHAPE_1D_LENGTH) {
+    return true;
+  }
+  return false;
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_iterarg_dependencies_init_conflict.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_iterarg_dependencies_init_conflict.mlir
@@ -1,0 +1,72 @@
+// RUN: triton-opt --add-block-id-for-control-ops --data-dependency-analysis --inter-core-transfer-and-sync --mark-main-loop %s | FileCheck %s
+
+module {
+    func.func @test_iterarg_dependencies_init_conflict(%arg4: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}){
+    %c1_i32 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 1 : i32
+    %c128_i32 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 128 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 0 : i32
+    %cst_0 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 0.000000e+00 : f32
+    %2 = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+    %3 = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_0 : f32) outs(%2 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %4 = math.exp %3 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+
+    %cst_10 = arith.constant {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
+    %20 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %30 = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_10 : f32) outs(%20 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %100 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %10 = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_10 : f32) outs(%100 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %40 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%30, %30 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%10 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %0 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %1 = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_0 : f32) outs(%0 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %91:2 = scf.for %arg20 = %c0_i32 to %c128_i32 step %c1_i32 iter_args(%arg21 = %4, %arg22 = %40) -> (tensor<32x32xf32>, tensor<32x32xf32>)  : i32 {
+
+        %6 = math.exp %arg22 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+
+        %182 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE"} ins(%arg21, %arg21 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%1 : tensor<32x32xf32>) -> tensor<32x32xf32>
+
+        scf.yield {ssbuffer.core_type = "CUBE, VECTOR"} %182, %6 : tensor<32x32xf32>, tensor<32x32xf32>
+    } {ssbuffer.core_type = "CUBE, VECTOR"}
+    return
+}}
+
+
+// CHECK-LABEL: func.func @test_iterarg_dependencies_init_conflict
+
+// CHECK: %[[EXP_2:[a-z0-9_]+]] = math.exp
+
+// CHECK: arith.constant
+// CHECK: %[[RESHAPE:[a-z0-9_]+]] = tensor.reshape %[[EXP_2]]
+// CHECK: tensor.empty()
+// CHECK: linalg.transpose
+// CHECK: arith.constant
+// CHECK: %[[RESHAPE_2:[a-z0-9_]+]] = tensor.reshape
+
+// CHECK: %[[ALLOC:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<4x2x16x8xf32, #hivm.address_space<cbuf>>
+// CHECK: annotation.mark %[[ALLOC]]
+// CHECK: hivm.hir.copy ins(%[[RESHAPE_2]] : tensor<4x2x16x8xf32>) outs(%[[ALLOC]] : memref<4x2x16x8xf32, #hivm.address_space<cbuf>>)
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: %[[MATMUL_8:[a-z0-9_]+]] = linalg.matmul
+
+// CHECK: %[[ALLOC_4:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<32x32xf32, #hivm.address_space<ub>>
+// CHECK: annotation.mark %[[ALLOC_4]]
+// CHECK: hivm.hir.fixpipe {{.*}} ins(%[[MATMUL_8]] : tensor<32x32xf32>) outs(%[[ALLOC_4]] : memref<32x32xf32, #hivm.address_space<ub>>)
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: %[[ALLOC_5:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<32x32xf32, #hivm.address_space<ub>>
+// CHECK: annotation.mark %[[ALLOC_5]]
+// CHECK: memref.memory_space_cast %[[ALLOC_5]]
+// CHECK: %[[TENSOR_11:[a-z0-9_]+]] = bufferization.to_tensor
+
+// CHECK: %[[ALLOC_6:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<4x2x16x8xf32, #hivm.address_space<cbuf>>
+// CHECK: annotation.mark %[[ALLOC_6]]
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: hivm.hir.convert_layout %[[ALLOC_6]]
+// CHECK: memref.memory_space_cast
+// CHECK: %[[TENSOR_13:[a-z0-9_]+]] = bufferization.to_tensor
+
+// CHECK: scf.for {{.*}} iter_args({{.*}} = %[[TENSOR_13]], {{.*}} = %[[TENSOR_11]])
+// CHECK: math.exp
+// CHECK: linalg.matmul
+// CHECK: scf.yield

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_iterarg_dependencies_multi_conflict.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_iterarg_dependencies_multi_conflict.mlir
@@ -1,0 +1,72 @@
+// RUN: triton-opt --add-block-id-for-control-ops --data-dependency-analysis --inter-core-transfer-and-sync --mark-main-loop %s | FileCheck %s
+
+module {
+    func.func @test_iterarg_dependencies_multi_conflict(%arg4: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}){
+    %c1_i32 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} 1 : i32
+    %c128_i32 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} 128 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} 0 : i32
+    %cst_0 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
+    %2 = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %3 = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_0 : f32) outs(%2 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %0 = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %1 = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_0 : f32) outs(%0 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %4 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%3, %3 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%1 : tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    %91 = scf.for %arg20 = %c0_i32 to %c128_i32 step %c1_i32 iter_args(%arg21 = %4) -> (tensor<32x32xf32>)  : i32 {
+        %6 = math.exp %arg21 {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+        %5 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} ins(%arg21, %arg21 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%1 : tensor<32x32xf32>) -> tensor<32x32xf32>
+
+        scf.yield {ssbuffer.core_type = "VECTOR"} %6 : tensor<32x32xf32>
+    } {ssbuffer.core_type = "VECTOR"}
+    return
+}}
+
+
+
+// CHECK-LABEL: func.func @test_iterarg_dependencies_multi_conflict
+
+// CHECK: %[[MATMUL_4:[a-z0-9_]+]] = linalg.matmul
+
+// CHECK: %[[ALLOC:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<32x32xf32, #hivm.address_space<ub>>
+// CHECK: annotation.mark %[[ALLOC]]
+// CHECK: hivm.hir.fixpipe {{.*}} ins(%[[MATMUL_4]] : tensor<32x32xf32>) outs(%[[ALLOC]] : memref<32x32xf32, #hivm.address_space<ub>>)
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: hivm.hir.sync_block_wait
+
+// CHECK: %[[ALLOC_0:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<32x32xf32, #hivm.address_space<ub>>
+// CHECK: annotation.mark %[[ALLOC_0]]
+// CHECK: memref.memory_space_cast %[[ALLOC_0]]
+// CHECK: %[[TENSOR_5:[a-z0-9_]+]] = bufferization.to_tensor
+
+// CHECK: %[[ALLOC_1:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<4x2x16x8xf32, #hivm.address_space<cbuf>>
+// CHECK: annotation.mark %[[ALLOC_1]]
+// CHECK: %[[ALLOC_2:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<4x2x16x8xf32, #hivm.address_space<cbuf>>
+// CHECK: annotation.mark %[[ALLOC_2]]
+
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: scf.for {{.*}} iter_args(%[[ARG_2:[a-z0-9_]+]] = %[[TENSOR_5]])
+// CHECK: arith.constant
+
+// CHECK: arith.constant
+// CHECK: tensor.reshape %[[ARG_2]]
+// CHECK: tensor.empty()
+// CHECK: linalg.transpose
+// CHECK: arith.constant
+// CHECK: %[[RESHAPE_6:[a-z0-9_]+]] = tensor.reshape
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: hivm.hir.copy ins(%[[RESHAPE_6]] : tensor<4x2x16x8xf32>) outs(%[[ALLOC_1]] : memref<4x2x16x8xf32, #hivm.address_space<cbuf>>)
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: hivm.hir.convert_layout %[[ALLOC_2]]
+// CHECK: memref.memory_space_cast
+// CHECK: %[[TENSOR_9:[a-z0-9_]+]] = bufferization.to_tensor
+// CHECK: %[[EXP_10:[a-z0-9_]+]] = math.exp %[[TENSOR_9]]
+// CHECK: hivm.hir.sync_block_set
+// CHECK: linalg.matmul {{.*}} ins(%[[ARG_2]], %[[ARG_2]] : tensor<32x32xf32>, tensor<32x32xf32>)
+// CHECK: scf.yield {ssbuffer.core_type = "VECTOR"} %[[EXP_10]] : tensor<32x32xf32>
+// CHECK: } {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.main_loop = 0 : i32}
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: return

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_iterarg_dependencies_nested.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_iterarg_dependencies_nested.mlir
@@ -1,0 +1,89 @@
+// RUN: triton-opt --add-block-id-for-control-ops --data-dependency-analysis --inter-core-transfer-and-sync --mark-main-loop %s | FileCheck %s
+
+module {
+    func.func @test_iterarg_dependencies_nested(%arg4: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}){
+    %c1_i32 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 1 : i32
+    %c128_i32 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 128 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 0 : i32
+    %cst_0 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 0.000000e+00 : f32
+    %2 = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+    %3 = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_0 : f32) outs(%2 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %4 = math.exp %3 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+
+    %cst_10 = arith.constant {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
+    %20 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %30 = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_10 : f32) outs(%20 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %100 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %10 = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_10 : f32) outs(%100 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %40 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%30, %30 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%10 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %0 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %1 = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_0 : f32) outs(%0 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %92:2 = scf.for %arg2 = %c0_i32 to %c128_i32 step %c1_i32 iter_args(%arg19 = %4, %arg20 = %40) -> (tensor<32x32xf32>, tensor<32x32xf32>)  : i32 {
+        %91:2 = scf.for  %arg3 = %c0_i32 to %c128_i32 step %c1_i32 iter_args(%arg21 = %arg19, %arg22 = %arg20) -> (tensor<32x32xf32>, tensor<32x32xf32>)  : i32 {
+            %60 = math.exp %arg22 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+
+            %182 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE"} ins(%arg21, %arg21 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%1 : tensor<32x32xf32>) -> tensor<32x32xf32>
+
+            scf.yield {ssbuffer.core_type = "VECTOR, CUBE"} %60, %182 : tensor<32x32xf32>, tensor<32x32xf32>
+        } {ssbuffer.core_type = "VECTOR, CUBE"}
+        scf.yield {ssbuffer.core_type = "VECTOR, CUBE"} %91#0, %91#1 : tensor<32x32xf32>, tensor<32x32xf32>
+    } {ssbuffer.core_type = "VECTOR, CUBE"}
+    return
+}}
+
+// CHECK-LABEL: func.func @test_iterarg_dependencies_nested
+
+// CHECK: %[[EXP_2:[a-z0-9_]+]] = math.exp
+
+// CHECK: %[[MATMUL_7:[a-z0-9_]+]] = linalg.matmul
+
+// CHECK: scf.for {{.*}} iter_args(%[[ARG_2:[a-z0-9_]+]] = %[[EXP_2]], %[[ARG_3:[a-z0-9_]+]] = %[[MATMUL_7]])
+// CHECK: %[[ALLOC:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<4x2x16x8xf32, #hivm.address_space<cbuf>>
+// CHECK: annotation.mark %[[ALLOC]]
+// CHECK: %[[ALLOC_1:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<4x2x16x8xf32, #hivm.address_space<cbuf>>
+// CHECK: annotation.mark %[[ALLOC_1]]
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: %[[ALLOC_2:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<32x32xf32, #hivm.address_space<ub>>
+// CHECK: annotation.mark %[[ALLOC_2]]
+// CHECK: %[[ALLOC_3:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<32x32xf32, #hivm.address_space<ub>>
+// CHECK: annotation.mark %[[ALLOC_3]]
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: %[[FOR_11:[a-z0-9_]+]]:2 = scf.for {{.*}} iter_args(%[[ARG_5:[a-z0-9_]+]] = %[[ARG_2]], %[[ARG_6:[a-z0-9_]+]] = %[[ARG_3]])
+// CHECK: arith.constant
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: hivm.hir.fixpipe {{.*}} ins(%[[ARG_6]] : tensor<32x32xf32>) outs(%[[ALLOC_2]] : memref<32x32xf32, #hivm.address_space<ub>>)
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: arith.constant
+// CHECK: arith.constant
+// CHECK: tensor.reshape %[[ARG_5]]
+// CHECK: tensor.empty()
+// CHECK: linalg.transpose
+// CHECK: arith.constant
+// CHECK: %[[RESHAPE_8:[a-z0-9_]+]] = tensor.reshape
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: hivm.hir.copy ins(%[[RESHAPE_8]] : tensor<4x2x16x8xf32>) outs(%[[ALLOC]] : memref<4x2x16x8xf32, #hivm.address_space<cbuf>>)
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: memref.memory_space_cast %[[ALLOC_3]]
+// CHECK: %[[TENSOR_13:[a-z0-9_]+]] = bufferization.to_tensor
+// CHECK: %[[EXP_14:[a-z0-9_]+]] = math.exp %[[TENSOR_13]]
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: hivm.hir.convert_layout %[[ALLOC_1]]
+// CHECK: memref.memory_space_cast
+// CHECK: %[[TENSOR_16:[a-z0-9_]+]] = bufferization.to_tensor
+// CHECK: %[[MATMUL_17:[a-z0-9_]+]] = linalg.matmul {{.*}} ins(%[[TENSOR_16]], %[[TENSOR_16]] : tensor<32x32xf32>, tensor<32x32xf32>)
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: scf.yield {ssbuffer.core_type = "VECTOR, CUBE"} %[[EXP_14]], %[[MATMUL_17]] : tensor<32x32xf32>, tensor<32x32xf32>
+// CHECK: } {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR, CUBE", ssbuffer.main_loop = 0 : i32}
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: scf.yield {ssbuffer.core_type = "VECTOR, CUBE"} %[[FOR_11]]#0, %[[FOR_11]]#1 : tensor<32x32xf32>, tensor<32x32xf32>
+// CHECK: } {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR, CUBE"}
+// CHECK: return

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_iterarg_dependencies_same_init_yield.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_iterarg_dependencies_same_init_yield.mlir
@@ -1,0 +1,87 @@
+// RUN: triton-opt --add-block-id-for-control-ops --data-dependency-analysis --inter-core-transfer-and-sync --mark-main-loop %s | FileCheck %s
+
+module {
+    func.func @test_iterarg_dependencies_same_init_yield(%arg4: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}){
+    %c1_i32 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 1 : i32
+    %c128_i32 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 128 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 0 : i32
+    %cst_0 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 0.000000e+00 : f32
+    %2 = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+    %3 = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_0 : f32) outs(%2 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %4 = math.exp %3 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+
+    %cst_10 = arith.constant {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
+    %20 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %30 = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_10 : f32) outs(%20 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %100 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %10 = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_10 : f32) outs(%100 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %40 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%30, %30 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%10 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %0 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %1 = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_0 : f32) outs(%0 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %91:2 = scf.for %arg20 = %c0_i32 to %c128_i32 step %c1_i32 iter_args(%arg21 = %4, %arg22 = %40) -> (tensor<32x32xf32>, tensor<32x32xf32>)  : i32 {
+
+        %60 = math.exp %arg22 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+
+        %182 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE"} ins(%arg21, %arg21 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%1 : tensor<32x32xf32>) -> tensor<32x32xf32>
+
+        scf.yield {ssbuffer.core_type = "VECTOR, CUBE"} %60, %182 : tensor<32x32xf32>, tensor<32x32xf32>
+    } {ssbuffer.core_type = "VECTOR, CUBE"}
+    return
+}}
+
+
+// CHECK-LABEL: func.func @test_iterarg_dependencies_same_init_yield
+
+// CHECK: %[[EXP_2:[a-z0-9_]+]] = math.exp
+// CHECK: %[[MATMUL_7:[a-z0-9_]+]] = linalg.matmul
+
+// CHECK: %[[ALLOC:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<4x2x16x8xf32, #hivm.address_space<cbuf>>
+// CHECK: annotation.mark %[[ALLOC]]
+// CHECK: %[[ALLOC_1:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<4x2x16x8xf32, #hivm.address_space<cbuf>>
+// CHECK: annotation.mark %[[ALLOC_1]]
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: %[[ALLOC_2:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<32x32xf32, #hivm.address_space<ub>>
+// CHECK: annotation.mark %[[ALLOC_2]]
+// CHECK: %[[ALLOC_3:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<32x32xf32, #hivm.address_space<ub>>
+// CHECK: annotation.mark %[[ALLOC_3]]
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: scf.for {{.*}} iter_args(%[[ARG_2:[a-z0-9_]+]] = %2, %[[ARG_3:[a-z0-9_]+]] = %7)
+
+// CHECK: arith.constant
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: hivm.hir.fixpipe {{.*}} ins(%[[ARG_3]] : tensor<32x32xf32>) outs(%[[ALLOC_2]] : memref<32x32xf32, #hivm.address_space<ub>>)
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: arith.constant
+
+// CHECK: arith.constant
+// CHECK: tensor.reshape %[[ARG_2]]
+// CHECK: tensor.empty()
+// CHECK: linalg.transpose
+// CHECK: arith.constant
+// CHECK: %[[RESHAPE_8:[a-z0-9_]+]] = tensor.reshape
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: hivm.hir.copy ins(%[[RESHAPE_8]] : tensor<4x2x16x8xf32>) outs(%[[ALLOC]] : memref<4x2x16x8xf32, #hivm.address_space<cbuf>>)
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: memref.memory_space_cast %[[ALLOC_3]]
+// CHECK: %[[TENSOR_12:[a-z0-9_]+]] = bufferization.to_tensor
+
+// CHECK: %[[EXP_13:[a-z0-9_]+]] = math.exp %[[TENSOR_12]]
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: hivm.hir.convert_layout %[[ALLOC_1]]
+// CHECK: memref.memory_space_cast
+// CHECK: %[[TENSOR_15:[a-z0-9_]+]] = bufferization.to_tensor
+// CHECK: %[[MATMUL_16:[a-z0-9_]+]] = linalg.matmul {{.*}} ins(%[[TENSOR_15]], %[[TENSOR_15]] : tensor<32x32xf32>, tensor<32x32xf32>)
+
+// CHECK: hivm.hir.sync_block_set
+// CHECK: scf.yield {ssbuffer.core_type = "VECTOR, CUBE"} %[[EXP_13]], %[[MATMUL_16]] : tensor<32x32xf32>, tensor<32x32xf32>
+// CHECK: } {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR, CUBE", ssbuffer.main_loop = 0 : i32}
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: return

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_iterarg_dependencies_yield_conflict.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_iterarg_dependencies_yield_conflict.mlir
@@ -1,0 +1,81 @@
+// RUN: triton-opt --add-block-id-for-control-ops --data-dependency-analysis --inter-core-transfer-and-sync --mark-main-loop %s | FileCheck %s
+
+module {
+    func.func @test_iterarg_dependencies_yield_conflict(%arg4: memref<?xf32> {tt.divisibility = 16 : i32, tt.tensor_kind = 0 : i32}){
+    %c1_i32 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 1 : i32
+    %c128_i32 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 128 : i32
+    %c0_i32 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 0 : i32
+    %cst_0 = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 0.000000e+00 : f32
+    %2 = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+    %3 = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_0 : f32) outs(%2 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %4 = math.exp %3 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+
+    %cst_10 = arith.constant {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
+    %20 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %30 = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_10 : f32) outs(%20 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %100 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %10 = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_10 : f32) outs(%100 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %40 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%30, %30 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%10 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %0 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %1 = linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_0 : f32) outs(%0 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %91:2 = scf.for %arg20 = %c0_i32 to %c128_i32 step %c1_i32 iter_args(%arg21 = %4, %arg22 = %40) -> (tensor<32x32xf32>, tensor<32x32xf32>)  : i32 {
+        %6 = math.exp %arg21 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>
+
+        %182 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE"} ins(%arg22, %arg22 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%1 : tensor<32x32xf32>) -> tensor<32x32xf32>
+
+        scf.yield {ssbuffer.core_type = "CUBE, VECTOR"} %182, %6 : tensor<32x32xf32>, tensor<32x32xf32>
+    } {ssbuffer.core_type = "CUBE, VECTOR"}
+    return
+}}
+
+// CHECK-LABEL: func.func @test_iterarg_dependencies_yield_conflict
+
+// CHECK: %[[EXP_2:[a-z0-9_]+]] = math.exp
+
+// CHECK: %[[MATMUL_7:[a-z0-9_]+]] = linalg.matmul
+
+// CHECK: %[[ALLOC:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<4x2x16x8xf32, #hivm.address_space<cbuf>>
+// CHECK: annotation.mark %[[ALLOC]]
+// CHECK: %[[ALLOC_1:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<4x2x16x8xf32, #hivm.address_space<cbuf>>
+// CHECK: annotation.mark %[[ALLOC_1]]
+// CHECK: hivm.hir.sync_block_set
+// CHECK: %[[ALLOC_2:[a-z0-9_]+]] = memref.alloc() {{.*}}: memref<32x32xf32, #hivm.address_space<ub>>
+// CHECK: annotation.mark %[[ALLOC_2]]
+// CHECK: %[[ALLOC_3:[a-z0-9_]+]] = memref.alloc() {{.*}} : memref<32x32xf32, #hivm.address_space<ub>>
+// CHECK: annotation.mark %[[ALLOC_3]]
+// CHECK: hivm.hir.sync_block_set
+// CHECK: scf.for {{.*}} iter_args(%[[ARG_2:[a-z0-9_]+]] = %[[EXP_2]], %[[ARG_3:[a-z0-9_]+]] = %[[MATMUL_7]])
+// CHECK: %[[EXP_11:[a-z0-9_]+]] = math.exp %[[ARG_2]]
+
+// CHECK: arith.constant
+// CHECK: tensor.reshape %[[EXP_11]]
+// CHECK: tensor.empty()
+// CHECK: linalg.transpose
+// CHECK: arith.constant
+// CHECK: %[[RESHAPE_6:[a-z0-9_]+]] = tensor.reshape
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: hivm.hir.copy ins(%[[RESHAPE_6]] : tensor<4x2x16x8xf32>) outs(%[[ALLOC]] : memref<4x2x16x8xf32, #hivm.address_space<cbuf>>)
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: %[[MATMUL_13:[a-z0-9_]+]] = linalg.matmul {{.*}} ins(%[[ARG_3]], %[[ARG_3]] : tensor<32x32xf32>, tensor<32x32xf32>)
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: hivm.hir.fixpipe {{.*}} ins(%[[MATMUL_13]] : tensor<32x32xf32>) outs(%[[ALLOC_2]] : memref<32x32xf32, #hivm.address_space<ub>>)
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: memref.memory_space_cast %[[ALLOC_3]]
+// CHECK: %[[TENSOR_14:[a-z0-9_]+]] = bufferization.to_tensor
+// CHECK: arith.constant
+// CHECK: hivm.hir.sync_block_set
+
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: hivm.hir.convert_layout %[[ALLOC_1]]
+// CHECK: memref.memory_space_cast
+// CHECK: %[[TENSOR_16:[a-z0-9_]+]] = bufferization.to_tensor
+// CHECK: arith.constant
+// CHECK: hivm.hir.sync_block_set
+// CHECK: scf.yield {ssbuffer.core_type = "VECTOR, CUBE"} %[[TENSOR_14]], %[[TENSOR_16]]
+// CHECK: } {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR, CUBE", ssbuffer.main_loop = 0 : i32}
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: hivm.hir.sync_block_wait
+// CHECK: return


### PR DESCRIPTION
# Summary
Fix the handling of `scf.for` `iter_args` dependency analysis in `DataDependencyAnalysis` to correctly identify and record producer/consumer dependencies when init and yield `core_type` differ. This prevents false fallbacks or missed inter-core transfers in nested or complex scenarios.


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
