### PR TITLE
[op](feat) commit dot_scaled fp8 case

### DIFF
--- a/third_party/ascend/unittest/pytest_ut/test_common.py
+++ b/third_party/ascend/unittest/pytest_ut/test_common.py
@@ -67,6 +67,126 @@ def generate_tensor(shape, dtype):
         raise ValueError('Invalid parameter \"dtype\" is found : {}'.format(dtype))
 
 
+def generate_tensor_fp4_fp8(
+        shape, dtype, seed=None, data_range=None,
+        special_ratio=0.05,  # Ratio of inf/-inf/nan values (only takes effect when dtype is float type)
+        precision_ratio=0.35,  # Ratio of precision small floats (only takes effect when dtype is float type)
+        extreme_ratio=0.1,  # Ratio of extreme value region (20% for min~min+10, max-10~max, 80% for min and max themselves) (no effect when dtype is bool)
+        zero_ratio=0,  # Extra ratio of zeros (no effect when dtype is bool)
+        bool_true_ratio=0.5,  # Ratio of True (only takes effect when dtype is bool)
+):
+    middle_range_dict = {
+        'fp8e4m3': [-50, 50],
+        'fp8e5m2': [-500, 500],
+        'fp8e5b16': [-500, 500],
+        'fp4': [-6, 6],
+    }
+
+    float_precision_dict = {
+        'fp8e4m3': [-1, 1],
+        'fp8e5m2': [-1, 1],
+        'fp8e5b16': [-1, 1],
+        'fp4': [-2, 2],
+    }
+
+    extreme_range_dict = {
+        'fp8e4m3': [-448, 448],
+        'fp8e5m2': [-57344, 57344],
+        'fp8e5b16': [-57344, 57344],
+        'fp4': [-6, 6],
+    }
+
+    ddtype_dict = {
+        'fp8e4m3': torch.float8_e4m3fn,
+        'fp8e5m2': torch.float8_e5m2,
+        'fp8e5b16': None,
+        'fp4': None,
+    }
+
+    if seed is not None:
+        torch.manual_seed(seed)
+        np.random.seed(seed)
+
+    if dtype not in ddtype_dict:
+        raise ValueError(f"Unsupported dtype: {dtype}")
+
+    min_val, max_val = extreme_range_dict[dtype]
+    total = np.prod(shape)
+
+    if dtype == 'fp4':
+        left_range = (min_val, min_val + 1)
+        right_range = (max_val - 1, max_val)
+    else:
+        left_range = (min_val, min_val + 10)
+        right_range = (max_val - 10, max_val)
+
+    if data_range == None:
+        mid_range = middle_range_dict[dtype]
+    else:
+        mid_range = data_range
+
+    # Process float types
+    if dtype in ('float16', 'float32', 'bfloat16', 'fp8e4m3', 'fp8e5m2'):
+
+        # Specified distribution probability and handling when exceeding 100%
+        if (extreme_ratio + precision_ratio + zero_ratio + special_ratio > 1):
+            raise ValueError(f"Total ratio over 100%, unable to allocate sampling:{extreme_ratio + precision_ratio}")
+
+        # Read dictionary to get precision small float data range
+        precision_range = float_precision_dict[dtype]
+
+        # Generate initial 1D zero data, float32 to prevent overflow
+        data = np.zeros(total, dtype=np.float32)
+
+        # Calculate counts for each interval (extreme region cumulative: near min, exact min, near max, exact max order)
+        left_count = int(total * extreme_ratio / 10)
+        left_accumulate_count = int(total * extreme_ratio / 2)
+        left_right_count = int(total * extreme_ratio * 3 / 5)
+        left_right_accmulate_count = int(total * extreme_ratio)
+        precision_count = int(total * precision_ratio)
+        zero_count = int(total * zero_ratio)
+        special_count = int(total * special_ratio)
+
+        # Generate shuffled index mapping array
+        indices = np.random.choice(total, size=total, replace=False)
+
+        # Partition interval indices by counts
+        left_idx = indices[:left_count]
+        left_min_idx = indices[left_count:left_accumulate_count]
+        right_idx = indices[left_accumulate_count:left_right_count]
+        right_max_idx = indices[left_right_count:left_right_accmulate_count]
+        precision_idx = indices[left_right_accmulate_count:left_right_accmulate_count + precision_count]
+        zero_idx = indices[left_right_accmulate_count + precision_count:left_right_accmulate_count + precision_count +
+                           zero_count]
+        special_idx = indices[left_right_accmulate_count + precision_count + zero_count:left_right_accmulate_count +
+                              precision_count + zero_count + special_count]
+        mid_idx = indices[left_right_accmulate_count + precision_count + zero_count + special_count:]
+
+        # Generate data by interval indices
+        data[left_idx] = np.random.uniform(left_range[0], left_range[1], size=len(left_idx))
+        data[left_min_idx] = min_val
+        data[right_idx] = np.random.uniform(right_range[0], right_range[1], size=len(right_idx))
+        data[right_max_idx] = max_val
+        data[precision_idx] = np.random.uniform(precision_range[0], precision_range[1], size=len(precision_idx))
+        data[zero_idx] = 0
+        for idx in special_idx:
+            r = np.random.rand()
+            if r < 1 / 3:
+                data[idx] = float('inf')
+            elif r < 2 / 3:
+                data[idx] = float('-inf')
+            else:
+                data[idx] = float('nan')
+        data[mid_idx] = np.random.uniform(mid_range[0], mid_range[1], size=len(mid_idx))
+
+        tensor = torch.from_numpy(data.reshape(shape)).to(ddtype_dict[dtype])
+
+    else:
+        raise ValueError(f"Unsupported dtype: {dtype}")
+
+    return tensor
+
+
 def get_triton_sig_typename(dtype):
     if dtype == 'float32':
         tyname = "*fp32"

--- a/third_party/ascend/unittest/pytest_ut/test_dot_scaled_fp8.py
+++ b/third_party/ascend/unittest/pytest_ut/test_dot_scaled_fp8.py
@@ -1,0 +1,122 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import pytest
+import torch
+import triton
+import triton.language as tl
+import numpy as np
+import test_common
+from triton.tools.get_ascend_devices import is_compile_on_910_95
+
+# Chained dot_scaled: first matmul with zero init, second accumulates via acc=.
+# Mirrors normalize-matmul.mlir @test_mmadmx_chain_no_elemwise_decompose:
+#   mmadmxL1(init=true,  outs=empty) -> mmadmxL1(init=false, outs=first)
+# No transpose. Result should equal 2 * dot_scaled(lhs, rhs, scales).
+
+
+def ub_overflow_check(M, N, K):
+    bytes_of_dtype = 4
+    M32 = ((M + 31) // 32) * 32
+    N32 = ((N + 31) // 32) * 32
+    cond1 = M32 * K * bytes_of_dtype <= 60 * 1024
+    cond2 = K * N32 * bytes_of_dtype <= 60 * 1024
+    cond3 = M32 * N32 * bytes_of_dtype <= 256 * 1024
+    return cond1 and cond2 and cond3
+
+
+def torch_dot_scaled(a, b, sa, sb):
+    sa = torch.exp2(sa - 127).repeat_interleave(32, dim=1)
+    sb = torch.exp2(sb - 127).repeat_interleave(32, dim=1).T
+    return torch.matmul(a * sa, b * sb)
+
+
+@triton.jit
+def dot_scale_chain_kernel(
+    lhs_ptr,
+    lhs_scale_ptr,
+    rhs_ptr,
+    rhs_scale_ptr,
+    out_ptr,
+    lhs_format: tl.constexpr,
+    rhs_format: tl.constexpr,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+):
+    Midx = tl.arange(0, M)
+    Nidx = tl.arange(0, N)
+    Kidx = tl.arange(0, K)
+    K1idx = tl.arange(0, K // 32)
+
+    lhs = tl.load(lhs_ptr + Midx[:, None] * K + Kidx[None, :])
+    lhs_scale = tl.load(lhs_scale_ptr + Midx[:, None] * (K // 32) + K1idx[None, :])
+    rhs = tl.load(rhs_ptr + Kidx[:, None] * N + Nidx[None, :])
+    rhs_scale = tl.load(rhs_scale_ptr + Nidx[:, None] * (K // 32) + K1idx[None, :])
+
+    # First mmad: init=true equivalent (fresh accumulation).
+    first = tl.dot_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format)
+    # Second mmad: init=false equivalent (accumulate into L0C).
+    result = tl.dot_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc=first)
+    tl.store(out_ptr + Midx[:, None] * N + Nidx[None, :], result)
+
+
+testlist = [
+    (1, 7, 64),
+    (15, 128, 64),
+    (128, 64, 64),
+    (189, 175, 64),
+    (1, 1, 128),
+    (35, 37, 128),
+    (62, 64, 192),
+    (31, 27, 256),
+]
+
+
+@pytest.mark.skipif(not is_compile_on_910_95, reason="only support in A5")
+@pytest.mark.parametrize("dtype", ["fp8e4m3", "fp8e5m2"])
+@pytest.mark.parametrize("M, N, K", testlist)
+def test_2D_scaled_dot_chain(M, N, K, dtype):
+    if not ub_overflow_check(M, N, K):
+        pytest.skip("UB overflow")
+
+    lhs_format = dtype[3:]
+    rhs_format = lhs_format
+
+    lhs = test_common.generate_tensor_fp4_fp8(shape=(M, K), dtype=dtype).npu()
+    rhs = test_common.generate_tensor_fp4_fp8(shape=(K, N), dtype=dtype).npu()
+    lhs_scale = torch.randint(low=110, high=128, size=(M, K // 32), dtype=torch.int8).npu()
+    rhs_scale = torch.randint(low=110, high=128, size=(N, K // 32), dtype=torch.int8).npu()
+
+    lhs_f32 = lhs.cpu().to(torch.float32)
+    rhs_f32 = rhs.cpu().to(torch.float32)
+    lhs_scale_f32 = lhs_scale.cpu().to(torch.float32)
+    rhs_scale_f32 = rhs_scale.cpu().to(torch.float32)
+
+    triton_res = torch.zeros((M, N), dtype=torch.float32).npu()
+    dot_scale_chain_kernel[(1, )](lhs, lhs_scale, rhs, rhs_scale, triton_res, lhs_format, rhs_format, M, N, K)
+
+    single = torch_dot_scaled(lhs_f32, rhs_f32, lhs_scale_f32, rhs_scale_f32)
+    torch_ref = (single + single).to(torch.float32)
+
+    if dtype == "fp8e4m3":
+        torch.testing.assert_close(triton_res.cpu(), torch_ref.cpu(), rtol=125e-03, atol=125e-03, equal_nan=True)
+    elif dtype == "fp8e5m2":
+        torch.testing.assert_close(triton_res.cpu(), torch_ref.cpu(), rtol=75e-02, atol=75e-02, equal_nan=True)


### PR DESCRIPTION
The ut test result is here:
root@triton:/home/l30058175/ta0718_main/test_0722# pytest -sv test_dot_scaled_fp8.py
====================================================================================================================== test session starts =======================================================================================================================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/python3.11.13/bin/python3.11
cachedir: .pytest_cache
rootdir: /home/l30058175/ta0718_main/test_0722
plugins: anyio-4.10.0, rerunfailures-16.4, xdist-3.8.0, repeat-0.9.4
collected 16 items

test_dot_scaled_fp8.py::test_2D_scaled_dot_chain[1-7-64-fp8e4m3] [W722 07:04:29.825051308 NPUCachingAllocator.cpp:198] Warning: The current CANN and Soc Version require processing for 32 padding size, with memory allocation. (function operator())
PASSED
test_dot_scaled_fp8.py::test_2D_scaled_dot_chain[1-7-64-fp8e5m2] PASSED
test_dot_scaled_fp8.py::test_2D_scaled_dot_chain[15-128-64-fp8e4m3] PASSED
test_dot_scaled_fp8.py::test_2D_scaled_dot_chain[15-128-64-fp8e5m2] PASSED
test_dot_scaled_fp8.py::test_2D_scaled_dot_chain[128-64-64-fp8e4m3] PASSED
test_dot_scaled_fp8.py::test_2D_scaled_dot_chain[128-64-64-fp8e5m2] PASSED
test_dot_scaled_fp8.py::test_2D_scaled_dot_chain[189-175-64-fp8e4m3] PASSED
test_dot_scaled_fp8.py::test_2D_scaled_dot_chain[189-175-64-fp8e5m2] PASSED
test_dot_scaled_fp8.py::test_2D_scaled_dot_chain[1-1-128-fp8e4m3] PASSED
test_dot_scaled_fp8.py::test_2D_scaled_dot_chain[1-1-128-fp8e5m2] PASSED
test_dot_scaled_fp8.py::test_2D_scaled_dot_chain[35-37-128-fp8e4m3] PASSED
test_dot_scaled_fp8.py::test_2D_scaled_dot_chain[35-37-128-fp8e5m2] PASSED
test_dot_scaled_fp8.py::test_2D_scaled_dot_chain[62-64-192-fp8e4m3] PASSED
test_dot_scaled_fp8.py::test_2D_scaled_dot_chain[62-64-192-fp8e5m2] PASSED
test_dot_scaled_fp8.py::test_2D_scaled_dot_chain[31-27-256-fp8e4m3] PASSED
test_dot_scaled_fp8.py::test_2D_scaled_dot_chain[31-27-256-fp8e5m2] PASSED

====================================================================================================================== 16 passed in 20.98s =======================================================================================================================
root@triton:/home/l30058175/ta0718_main/test_0722#


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
