### PR TITLE
[ssbuffer](fix) revert changes in AnalyzeArgs

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeArgs.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeArgs.cpp
@@ -22,11 +22,7 @@
 
 #include "ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
-#include "bishengir/Dialect/HIVM/IR/HIVM.h"
-#include "bishengir/Dialect/Scope/IR/Scope.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/DenseMap.h"
@@ -47,6 +43,29 @@ using namespace mlir;
 using namespace triton;
 
 namespace {
+
+static constexpr llvm::StringLiteral containedFunc[]{
+    "chunk_gated_delta_rule_bwd_kernel_dhu_k128_blockdim128",
+    "fused_chunk_fwd_kernel",
+};
+
+static LogicalResult isInterceptedModule(ModuleOp module) {
+  bool intercepted = false;
+
+  module.walk([&](func::FuncOp funcOp) -> WalkResult {
+    if (!llvm::is_contained(containedFunc, funcOp.getSymName())) {
+      return WalkResult::advance();
+    }
+    intercepted = true;
+    return WalkResult::interrupt();
+  });
+
+  if (!intercepted) {
+    return success();
+  }
+
+  return failure();
+}
 
 // Check if a value is a tensor-type iter_arg and return its index, -1
 // otherwise.
@@ -182,87 +201,6 @@ bool checkTensorArgsInMainLoop(ModuleOp module) {
   return shouldReturn;
 }
 
-// Check VECTOR main_loop forOps: if a tensor arith.subf op has both operands
-// from linalg.broadcast ops sharing the same source, and the subf op's
-// block_id differs from the source op's block_id, fallback.
-static bool checkSubfBroadcastMismatchInVectorMainLoop(ModuleOp module) {
-  bool shouldFallback = false;
-
-  module.walk([&](Operation *op) -> WalkResult {
-    if (!op->hasAttr(CVPipeline::kMainLoop)) {
-      return WalkResult::advance();
-    }
-    auto forOp = dyn_cast<scf::ForOp>(op);
-    if (!forOp) {
-      return WalkResult::advance();
-    }
-
-    scope::ScopeOp scopeOp = forOp->getParentOfType<scope::ScopeOp>();
-    if (!scopeOp) {
-      return WalkResult::advance();
-    }
-    auto tcoreAttr =
-        scopeOp->getAttrOfType<hivm::TCoreTypeAttr>(CVPipeline::kTcoreType);
-    if (!tcoreAttr || tcoreAttr.getTcoretype() != hivm::TCoreType::VECTOR) {
-      return WalkResult::advance();
-    }
-
-    Block *body = forOp.getBody();
-    if (!body) {
-      return WalkResult::advance();
-    }
-
-    for (Operation &bodyOp : body->without_terminator()) {
-      auto subfOp = dyn_cast<arith::SubFOp>(&bodyOp);
-      if (!subfOp || !isa<RankedTensorType>(subfOp.getType())) {
-        continue;
-      }
-
-      Operation *lhsDef = subfOp.getLhs().getDefiningOp();
-      Operation *rhsDef = subfOp.getRhs().getDefiningOp();
-      if (!lhsDef || !rhsDef) {
-        continue;
-      }
-
-      auto lhsBroadcast = dyn_cast<linalg::BroadcastOp>(lhsDef);
-      auto rhsBroadcast = dyn_cast<linalg::BroadcastOp>(rhsDef);
-      if (!lhsBroadcast || !rhsBroadcast) {
-        continue;
-      }
-
-      Value lhsInput = lhsBroadcast.getInput();
-      Value rhsInput = rhsBroadcast.getInput();
-      if (lhsInput != rhsInput) {
-        continue;
-      }
-
-      Operation *sourceOp = lhsInput.getDefiningOp();
-      if (!sourceOp) {
-        continue;
-      }
-
-      auto subfBlockIdAttr =
-          subfOp->getAttrOfType<IntegerAttr>(CVPipeline::kBlockId);
-      auto sourceBlockIdAttr =
-          sourceOp->getAttrOfType<IntegerAttr>(CVPipeline::kBlockId);
-      if (!subfBlockIdAttr || !sourceBlockIdAttr) {
-        continue;
-      }
-
-      if (subfBlockIdAttr.getInt() != sourceBlockIdAttr.getInt()) {
-        LDBG("[INFO]: Found subf and broadcast source with different "
-             "block_ids in VECTOR main_loop!\n");
-        shouldFallback = true;
-        return WalkResult::interrupt();
-      }
-    }
-
-    return WalkResult::advance();
-  });
-
-  return shouldFallback;
-}
-
 void AnalyzeArgsPass::runOnOperation() {
   ModuleOp module = getOperation();
 
@@ -272,8 +210,11 @@ void AnalyzeArgsPass::runOnOperation() {
 
   LDBG("Before AnalyzeArgs:\n" << module << "\n");
 
-  if (checkTensorArgsInMainLoop(module) &&
-      checkSubfBroadcastMismatchInVectorMainLoop(module)) {
+  if (failed(isInterceptedModule(module))) {
+    return;
+  }
+
+  if (checkTensorArgsInMainLoop(module)) {
     CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_IGNORED);
     return;
   }


### PR DESCRIPTION
**DynamicCVPipeline: revert changes in AnalyzeArgs**

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
