### PR TITLE
[ubtuner](fix) decide kernel type according to use_bytecode

### DIFF
--- a/third_party/ascend/backend/runtime/ubtuner.py
+++ b/third_party/ascend/backend/runtime/ubtuner.py
@@ -548,14 +548,15 @@ class UBTuner(KernelInterface):
         os.environ[_Config.ENV_ENABLE_PRINT_UB_BITS] = 'true' if mode == _Config.DEFAULT_MODE else 'false'
         try:
             compiled_kernel = self.fn.run(*args, **kwargs)
-            linalg_ir = compiled_kernel.asm.get('ttadapter') if hasattr(compiled_kernel, 'asm') else None
-            if linalg_ir is None:
-                _log_debug("Could not get linalg IR, using default config")
-                return UBConfig()
-
             metadata = dict(compiled_kernel.metadata._asdict()) if hasattr(compiled_kernel, 'metadata') else {}
             npu_options = self._create_npu_options(metadata)
             if npu_options is None:
+                return UBConfig()
+
+            asm_key = 'bcmlir' if metadata.get('use_bytecode') else 'ttadapter'
+            linalg_ir = compiled_kernel.asm.get(asm_key) if hasattr(compiled_kernel, 'asm') else None
+            if linalg_ir is None:
+                _log_debug("Could not get linalg IR, using default config")
                 return UBConfig()
 
             available_options = list(UB_OPTION_METADATA.keys())


### PR DESCRIPTION
problem: ubtuner testcase failed in TA 3.6.0
solution: TA 3.6.0 introduce new transform mode: ttadapter->kernel.mlir->npuir when use_bytecode=True.
   Thus, ubtuner need to fetch bcmlir if use_bytecode=True, otherwise use ttadapter
dts: DTS2026072126233

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
