### PR TITLE
[CI](feat) Add DCO check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ on:
       - '.github/workflows/runner-preparation.yml'
       - '.github/workflows/wheels.yml'
   merge_group:
-    branches: [main, 'dev-**']
+    branches: [main, 'release/**', '**-dev']
     types: [checks_requested]
   push:
-    branches: [main, 'release/**']
+    branches: [main, 'release/**', '**-dev']
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -1,7 +1,7 @@
 name: DCO Check
 
 on:
-  pull_request:
+  pull_request_target:
   merge_group:
     branches: [main, 'release/**', '**-dev']
     types: [checks_requested]
@@ -14,6 +14,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   dco:
@@ -21,54 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
+      - uses: KineticCafe/actions-dco@v3.1.0
         with:
-          fetch-depth: 0
-
-      - name: Check DCO sign-off
-        shell: bash
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          BEFORE_SHA: ${{ github.event.before }}
-        run: |
-          set -euo pipefail
-
-          # Determine the range of commits to check.
-          # For PRs: everything from the merge base to the PR head.
-          # For pushes / merge_group: the pushed commits.
-          if [ -n "${BASE_REF:-}" ]; then
-            RANGE="${BASE_REF}..HEAD"
-          else
-            # Push event on main/release — check the pushed commits.
-            if [ "${BEFORE_SHA}" = "0000000000000000000000000000000000000000" ]; then
-              # New branch push: check all commits on the branch.
-              RANGE="HEAD"
-            else
-              RANGE="${BEFORE_SHA:-HEAD~1}..HEAD"
-            fi
-          fi
-
-          echo "Checking commits in range: ${RANGE}"
-
-          FAILED=0
-          while IFS= read -r commit; do
-            if ! git log --format="%B" -n 1 "${commit}" | grep -qE '^Signed-off-by: .+ <.+@.+>'; then
-              echo "::error::Commit ${commit} is missing a Signed-off-by line."
-              echo "  Add it with: git commit --amend -s"
-              FAILED=1
-            fi
-          done < <(git rev-list --no-merges "${RANGE}")
-
-          if [ "${FAILED}" -eq 1 ]; then
-            echo ""
-            echo "All commits must include a Signed-off-by: line certifying the"
-            echo "Developer Certificate of Origin (https://developercertificate.org/)."
-            echo ""
-            echo "To sign off your commit, use:"
-            echo "  git commit -s -m \"your message\""
-            echo "  or amend an existing commit: git commit --amend -s"
-            exit 1
-          fi
-
-          echo "All commits have a valid Signed-off-by line."
+          config: |
+            comment = true

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -1,19 +1,19 @@
 name: DCO Check
 
 on:
-  workflow_dispatch:
   pull_request:
   merge_group:
-    branches: [main, 'dev-**']
+    branches: [main, 'release/**', '**-dev']
     types: [checks_requested]
   push:
-    branches: [main, 'release/**']
+    branches: [main, 'release/**', '**-dev']
 
 concurrency:
   group: dco-check-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   dco:
@@ -41,7 +41,12 @@ jobs:
             RANGE="${BASE_REF}..HEAD"
           else
             # Push event on main/release — check the pushed commits.
-            RANGE="${BEFORE_SHA:-HEAD~1}..HEAD"
+            if [ "${BEFORE_SHA}" = "0000000000000000000000000000000000000000" ]; then
+              # New branch push: check all commits on the branch.
+              RANGE="HEAD"
+            else
+              RANGE="${BEFORE_SHA:-HEAD~1}..HEAD"
+            fi
           fi
 
           echo "Checking commits in range: ${RANGE}"

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -1,0 +1,69 @@
+name: DCO Check
+
+on:
+  workflow_dispatch:
+  pull_request:
+  merge_group:
+    branches: [main, 'dev-**']
+    types: [checks_requested]
+  push:
+    branches: [main, 'release/**']
+
+concurrency:
+  group: dco-check-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions: read-all
+
+jobs:
+  dco:
+    name: Developer Certificate of Origin
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check DCO sign-off
+        shell: bash
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          # Determine the range of commits to check.
+          # For PRs: everything from the merge base to the PR head.
+          # For pushes / merge_group: the pushed commits.
+          if [ -n "${BASE_REF:-}" ]; then
+            RANGE="${BASE_REF}..HEAD"
+          else
+            # Push event on main/release — check the pushed commits.
+            RANGE="${BEFORE_SHA:-HEAD~1}..HEAD"
+          fi
+
+          echo "Checking commits in range: ${RANGE}"
+
+          FAILED=0
+          while IFS= read -r commit; do
+            if ! git log --format="%B" -n 1 "${commit}" | grep -qE '^Signed-off-by: .+ <.+@.+>'; then
+              echo "::error::Commit ${commit} is missing a Signed-off-by line."
+              echo "  Add it with: git commit --amend -s"
+              FAILED=1
+            fi
+          done < <(git rev-list --no-merges "${RANGE}")
+
+          if [ "${FAILED}" -eq 1 ]; then
+            echo ""
+            echo "All commits must include a Signed-off-by: line certifying the"
+            echo "Developer Certificate of Origin (https://developercertificate.org/)."
+            echo ""
+            echo "To sign off your commit, use:"
+            echo "  git commit -s -m \"your message\""
+            echo "  or amend an existing commit: git commit --amend -s"
+            exit 1
+          fi
+
+          echo "All commits have a valid Signed-off-by line."

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
   pull_request:
   merge_group:
-    branches: [main, 'dev-**']
+    branches: [main, 'release/**', '**-dev']
     types: [checks_requested]
   push:
-    branches: [main, 'release/**']
+    branches: [main, 'release/**', '**-dev']
 
 concurrency:
   group: pre-commit-${{ github.ref }}


### PR DESCRIPTION
### Summary
Add a DCO (Developer Certificate of Origin) check to the CI pipeline. Every commit in a pull request must now include a `Signed-off-by:` line to pass this check.

### Motivation
DCO sign-off certifies that the contributor has the right to submit the code under the project's license. This is a standard requirement in many open-source projects (Linux kernel, CNCF projects, etc.) and helps establish a clear contribution provenance trail.

### What this PR does
Adds dco-check.yml, a new standalone workflow that:

- Triggers on pull requests, merge_group, and pushes to main/release branches
- Iterates over all non-merge commits in the range and verifies each has a `Signed-off-by:` line matching the format Name `<email>`
- Reports the specific offending commit(s) and remediation steps on failure

### How to comply
Developers should sign off commits using the -s flag:
```
  # New commit
  git commit -s -m "your message"
  # Amend the last commit
  git commit --amend -s
```
### Checklist

- [x]  I am not making a trivial change
- [x]  I have `run pre-commit run --from-ref origin/main --to-ref HEAD`
- [x]  This PR does not need a test because it adds a CI workflow whose correctness is verified by running it
- [x]  I have not added any `lit` tests