### PR TITLE
[patch](feat) rollback intrusive modifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,6 @@ third_party/nvidia/backend/lib/cupti
 
 # Docs
 docs/_build/
-docs/**/_build/
 docs/python-api/generated/
 docs/dialects/
 docs/getting-started/tutorials
@@ -87,7 +86,6 @@ docs/sg_execution_times.rst
 /compile_commands.json
 .vscode
 .vs
-.idea/
 .cursor
 
 # Vim
@@ -95,23 +93,3 @@ docs/sg_execution_times.rst
 
 # macOS
 .DS_Store
-triton_ascend.egg-info/
-
-# cann
-fusion_result.json
-kernel_meta/
-
-# compilation
-/triton/
-build/
-
-# artifact
-dist/
-*.egg-info/
-.eggs/
-docs/zh/python-api/generated/
-
-# Docs PR gate: checker bundle is fetched at run time, not vendored;
-# output.md / result.json are generated reports.
-/output.md
-/result.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,151 +1,70 @@
-# Contribution Guide
+# Governance Structure
 
-- [Getting Started](#getting-started.md)
-- [Developer Certificate of Origin (DCO)](#DCO.md)
-- [Developer Guide](#developer-guide.md)
-  - [Coding Style](#coding-style.md)
-  - [Fork-Pull Mode](#fork-pull-mode.md)
-  - [Troubleshooting Gated Commit](#troubleshooting-gated-commit.md)
-  - [Issue Specifications](#issue-specifications.md)
-  - [Pull Request Proposal](#pull-request-proposal.md)
+Triton adopts the following hierarchical technical governance structure:
+* A community of **contributors** who file issues and submit pull requests
+* A group of **module maintainers** who own parts of Triton and drive their development
+* A body of **core maintainers** who own Triton overall and drive its development
+* A **lead core maintainer** who is the catch-all decision maker when consensus cannot be reached by core maintainers
 
-<h2 id="getting-started.md">Getting Started</h2>
+All contributions are expected to follow Triton’s design principles, as enforced by module and core maintainers. While high-quality pull requests are appreciated and encouraged, all maintainers reserve the right to prioritize their own work over code reviews at-will, hence contributors should not expect their work to be reviewed promptly.
 
-- Fork the Triton Ascend repository on [GitHub](https://github.com/triton-lang/triton-ascend).
-- Check the [README.md](https://github.com/triton-lang/triton-ascend/blob/main/README.md) file to obtain the project information and build the development environment.
+Contributors can maximize the chances of their work being accepted by maintainers by meeting a high quality bar before sending a PR to maintainers.  We encourage maintainers who contribute to Triton on behalf of a company to get reviews from senior developers within their company before sending to maintainers.
+Module maintainers
+We aim to make the Triton codebase as modular as possible, such that different components (e.g., subdirectories) can be improved in parallel under the supervision of different module maintainers.
 
-<h2 id="DCO.md">Developer Certificate of Origin (DCO)</h2>
+What constitutes (or not) a module is up to the core maintainers. Core maintainers also reserve the right to decide whether the development of a module should happen – or keep happening – in-tree or not.
 
-All commits must include a `Signed-off-by:` line. Use `git commit -s` to add it automatically:
+**List of in-tree modules (as of 05/12/2024, alphabetical order):**
+* AMD backend (Lei Zhang)
+* Interpreter (Keren Zhou)
+* Profiler (Keren Zhou)
 
-```bash
-git commit -s -m "your commit message"
-```
+Note: Parts of Triton that are not listed above (e.g., Nvidia backend) are assumed to be owned by core maintainers.
 
-This will automatically add a line `Signed-off-by: Your Name <your.email@example.com>` at the end of your commit message, indicating that you certify the origin and authorization of the contribution.
+Note: Some important parts of the Triton eco-system (e.g., Intel XPU backend) may be maintained out-of-tree and advertised in our repository. The governance rules described in this document do not carry over to these modules.
 
-<h2 id="developer-guide.md">Developer Guide</h2>
+__List of out-of-tree modules (as of 05/12/2024, alphabetical order):__
+* CPU backend (Bert Maher, Ilya Enkovich)
+* Intel backend (Ettore Tiotto, Whitney Tsang)
 
-- **[Coding Style](#coding-style.md)**
-- **[Fork-Pull Mode](#fork-pull-mode.md)**
-- **[Troubleshooting Gated Commit](#troubleshooting-gated-commit.md)**
-- **[Issue Specifications](#issue-specifications.md)**
-- **[Pull Request Proposal](#pull-request-proposal.md)**
 
-<h2 id="coding-style.md">Coding Style</h2>
+## Core maintainers
+The core maintainers drive the development of Triton at large and set the roadmap for the project. As such, they have the following responsibilities:
+* Proposing, implementing and reviewing profound changes to user-facing APIs, IR specifications and/or pass infrastructures
+* Enforcing code quality standards and adherence to core design principles
+* Drawing module boundaries and resolving disputes between module maintainers
 
-Follow the coding style below to make Triton Ascend easy to develop, maintain, and review.
 
-- Coding Guide
+The core maintainers as a group have the power to veto any decision made at a Module maintainer level.
 
-  Use the unified coding style of the Triton Ascend community. The recommended coding style for Python is [PEP 8 Coding Style](https://pep8.org/), and that for C++ is [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html). You can use [clang-tidy](https://github.com/llvm/llvm-project/blob/main/.clang-tidy), [CppLint](https://github.com/cpplint/cpplint), [CppCheck](http://cppcheck.sourceforge.net/), [CMakeLint](https://github.com/cmake-lint/cmake-lint), [CodeSpell](https://github.com/codespell-project/codespell), [ShellCheck](https://github.com/koalaman/shellcheck), and [pylint](https://pylint.org/) to check the code format. You are advised to install these plug-ins in your IDE.
+The core maintainers should publicly articulate their decision-making, and share the reasoning behind their decisions, vetoes, and dispute resolution.
 
-- Unit Test Guide
+__List of core maintainers (as of 01/30/2025, alphabetical order):__
+* Jeff Niu
+* Keren Zhou
+* Mario Lezcano-Casado
+* Pawel Szczerbuk
+* Peter Bell
+* Phil Tillet
+* Thomas Raoux
+* Zahi Moudallal
 
-  Use the unified unit test style of the Triton Ascend community. The recommended unit test style for Python is [pytest](http://www.pytest.org/en/latest/), and that for C++ is [GoogleTest Primer](https://github.com/google/googletest/blob/main/docs/primer.md). The design intent of a test case should be reflected by its annotation name. For details about how to design test cases, see the [gather_load test case](https://github.com/triton-lang/triton-ascend/blob/main/third_party/ascend/unittest/custom_op/test_gather_load.py) and [layer_norm test case](https://github.com/triton-lang/triton-ascend/blob/main/third_party/ascend/tutorials/05-layer-norm.py).
+## Lead core maintainer
+When core maintainers cannot come to a consensus, a publicly declared lead maintainer is expected to settle the debate and make executive decisions.
 
-- Refactoring Guide
+The Lead Core Maintainer should publicly articulate their decision-making, and give a clear reasoning for their decisions.
 
-  We encourage developers to refactor our code to eliminate code smells. The refactored code should also comply with the coding style and testing style requirements. When receiving a warning, refactor the code to be merged.
+The Lead Core Maintainer is also responsible for confirming or removing core maintainers.
 
-<h2 id="fork-pull-mode.md">Fork-Pull Mode</h2>
+**Lead maintainer (as of 05/12/2024)**
+* Phil Tillet
 
-1.Fork the Triton Ascend project.
+# Decision Making
 
-Before committing your code to the Triton Ascend project, ensure that you have forked the Triton Ascend project to your own repository. You will then develop the project in your own forked repository and merge it to the Triton Ascend project through a pull request (PR). This means that there is parallel development between the Triton Ascend repository and your own repository. Be careful to avoid inconsistency between repositories.
+## Uncontroversial Changes
 
-2.Clone a remote repository.
+We are committed to accepting functional bug fixes that meet our quality standards – and include minimized unit tests to avoid future regressions. Performance improvements generally fall under the same category, with the caveat that they may be rejected if the trade-off between usefulness and complexity is deemed unfavorable by core maintainers (e.g., complex swizzling logic to improve the performance of non-tensor-cores matrix multiplications). Design changes that neither fix known functional nor performance issues are automatically considered controversial.
 
-Use git to clone the Triton Ascend project you have forked and add the upstream repository.
+## Controversial Changes
 
-```shell
-git clone https://github.com/{your_forked_repo}/triton-ascend.git && cd triton-ascend && git submodule update --init --depth 1
-git remote add upstream https://github.com/triton-lang/triton-ascend.git
-```
-
-3.Develop code locally.
-
-Before developing your code, you need to set up the development environment according to the [Triton Ascend Installation Guide](https://github.com/triton-lang/triton-ascend/blob/main/docs/en/installation_guide.md).
-
-To avoid inconsistency between branches, create a new local development branch for new features.
-
-```shell
-git checkout -b {new_branch_name} origin/main
-git fetch upstream       # Fetch the latest code from the upstream repository
-git rebase upstream/main # Rebase onto the latest upstream trunk
-```
-
-Taking the main branch as an example, Triton Ascend may create release branches or downstream development branches as required. After creating a branch and synchronizing the upstream main branch, you can start developing your code.
-
-4.Perform a self-test.
-
-After the code is modified, check whether the changes can pass the test.
-
-Write a test script for the developed code in the **ascend/examples/pytest_ut** directory of your local code branch, and verify the test script in the local environment to ensure that the changes can pass the test.
-
-5.Push code to the remote repository.
-
-After updating and testing the code, push your commit to the remote repository.
-
-```shell
-git add .
-git status #Check the updated files
-git commit -s -m "your commit message"
-git push origin {your_new_branch_name}
-```
-
-6.Create a pull request to the Triton Ascend main repository.
-
-After pushing code to your remote repository, create a pull request between your new branch and the Triton Ascend main branch. After the merge request is created, Jenkins CI will be automatically set to build your pipeline test. You are advised to merge your pull request to the upstream main branch as soon as possible to reduce the merge risk.
-
-<h2 id="troubleshooting-gated-commit.md">Troubleshooting Gated Commit</h2>
-
-Gated commit may encounter the following exceptions. Rectify the exceptions according to the related information.
-
-- Compilation failed
-
-  Check the cause of the compilation failure as prompted, and then recompile the code.
-
-- Static check failed
-
-  Find and fix the exception information in the code as prompted.
-
-- CI pipeline failed
-
-  Find the failed test cases of the CI pipeline as prompted, and then check the cause. After the fault is rectified, run the CI pipeline again.
-
-<h2 id="issue-specifications.md">Issue Specifications</h2>
-
-A good way to contribute to the project is to send a detailed report when you encounter a problem. We are always very grateful for detailed and thorough bug reports, and we will be very grateful to you for that!
-
-Please include the following information when you file an issue:
-
-- What is the software version (Triton Ascend, Python, OS, etc.) used in your environment?
-- Is it a bug report or a functional request?
-- What kind of issue are you reporting? Add the corresponding tag to highlight it on the issue dashboard.
-- What's happened?
-- What did you expect to happen?
-- How to reproduce the issue? (As accurately as possible)
-
-You can choose from one of the pre-defined templates when [submitting issues of different categories](https://github.com/triton-lang/triton-ascend/issues/new/choose).
-
-Notes for contributors:
-
-- If you find an unresolved issue that is exactly what you are trying to solve, comment on the issue and tell others that you will be responsible for handling it.
-- If the issue has existed for a period of time, it is recommended that you perform a pre-check before solving the issue.
-- If you have resolved the issue you report, inform others before closing the issue.
-
-<h2 id="pull-request-proposal.md">Pull Request Proposal</h2>
-
-- Propose your ideas as issues.
-- If the new feature to be developed requires a large number of design details, you should also commit the design solution.
-- After reaching a consensus in the issue discussion and design solution review, fork the project and commit a PR.
-- No PR is allowed until you receive 2+LGTM (Looks Good To Me) from the approver. Note that you are not allowed to add LGTM to your own PRs.
-- After the PR is fully discussed, it will be merged, rejected, or abandoned based on the discussion result.
-
-## Notes
-
-- Avoid any irrelevant changes.
-- Ensure that your commit history is concise and orderly.
-- Before creating a PR, please rebase the latest code from the upstream repository.
-- For a bug-fixing PR, ensure that all related issues and PRs are linked.
+More controversial design changes (e.g., changes in our IRs/APIs/Passes) are evaluated on a case-by-case basis under the subjective judgment of core maintainers. While it is possible for contributors to propose and land deep design changes upstream (see https://github.com/triton-lang/triton/pull/1305), the community should expect such occurrences to be relatively rare.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "cmake>=3.20,<4.0", "ninja>=1.11.1", "pybind11>=2.13.1", "nanobind>=2.4"]
+requires = ["setuptools>=40.8.0", "cmake>=3.20,<4.0", "ninja>=1.11.1", "pybind11>=2.13.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.mypy]

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -394,7 +394,7 @@ void init_triton_llvm(py::module &&m) {
           [](llvm::Module::FunctionListType &s) {
             return py::make_iterator(s.begin(), s.end());
           },
-          py::keep_alive<0, 1>(), py::call_guard<py::gil_scoped_release>());
+          py::keep_alive<0, 1>());
 
   // Module Flag behavior. See
   // https://llvm.org/doxygen/classllvm_1_1Module.html#a0a5c55e12c97b80021330fe82b642293

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 import hashlib
 import json
-from .._C.libtriton import get_cache_invalidating_env_vars, ir, buffer_ir
-from .._C.libtriton.ascend import ir as ascend_ir
+from .._C.libtriton import get_cache_invalidating_env_vars, ir
 from ..backends import backends
 from ..backends.compiler import Language
 from ..backends.compiler import BaseBackend, GPUTarget
@@ -298,8 +297,6 @@ def compile(src, target=None, options=None, _env_vars=None):
     if not isinstance(src, IRSource):
         context = ir.context()
         ir.load_dialects(context)
-        buffer_ir.load_dialects(context)
-        ascend_ir.load_dialects(context)
         backend.load_dialects(context)
 
     codegen_fns = backend.get_codegen_implementation(options)

--- a/python/triton/language/math.py
+++ b/python/triton/language/math.py
@@ -96,8 +96,7 @@ def umulhi(x, y, _semantic=None):
 
 
 @core.builtin
-# TODO: Temporary intrusive modification: add fp16 support and remove it later.
-@_check_dtype(dtypes=["fp16", "fp32", "fp64"])
+@_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("exponential")
 @core._tensor_member_fn
 def exp(x, _semantic=None):

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -193,11 +193,7 @@ def max(input, axis=None, return_indices=False, return_indices_tie_break_left=Tr
                 input = input.to(core.float32)
             else:
                 assert input.dtype.is_int(), "Expecting input to be integer type"
-                # FIXME: Skip int8/int16 -> int32 promotion on Ascend.
-                # Converting small integer types (e.g., int8) to int32 consumes excessive UB (Unified Buffer) memory,
-                # which can lead to "UB overflow" errors during kernel execution.
-                # Therefore, we keep the original narrow integer type and rely on backend support.
-                pass  # Do not promote to int32
+                input = input.to(core.int32)
         if propagate_nan == core.PropagateNan.NONE:
             return core.reduce(input, axis, _elementwise_max, keep_dims=keep_dims)
         else:

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -1280,13 +1280,6 @@ else:
     interpreter_builder = InterpreterBuilder()
 interpreter_semantic = TritonSemantic(interpreter_builder)
 
-# These keywords are not supported by the interpreter
-RESERVED_KWS = ["num_warps", "num_stages", "num_ctas", "enable_fp_fusion", "grid", "maxnreg"]
-
-# Allow Ascend interpreter to extend reserved keywords
-if hasattr(interpreter_builder, 'get_additional_reserved_keywords'):
-    RESERVED_KWS.extend(interpreter_builder.get_additional_reserved_keywords())
-
 
 def _unwrap_tensor(t):
     if isinstance(t, triton.runtime.jit.TensorWrapper):

--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -1241,6 +1241,10 @@ class AscendBackend(BaseBackend):
         return codegen_fns
 
     def load_dialects(self, ctx):
+        from triton._C.libtriton import buffer_ir
+        from triton._C.libtriton.ascend import ir as ascend_ir
+        buffer_ir.load_dialects(ctx)
+        ascend_ir.load_dialects(ctx)
         ascend.load_dialects(ctx)
 
     def add_stages(self, stages, options, language):


### PR DESCRIPTION
rollback intrusive modifications
1. python/src/llvm.cc   Redundancy modification
2. python/triton/compiler/compiler.py  Migrate to third_party
3. third_party/ascend/backend/compiler.py  add load_dialects
4. .gitignore  Redundancy modification,rollback
5. CONTRIBUTING.md  Redundancy modification,rollback
6. pyproject.toml   Redundancy modification,rollback
7. python/triton/language/standard.py  rollback max op , Skip int8/int16 -> int32 
8. python/triton/runtime/interpreter.py  Redundancy modification,rollback
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
