### PR TITLE
[compiler](fix) modify jit to fix specialization issue

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -398,14 +398,15 @@ def create_function_from_signature(sig, kparams, backend):
     assert len(sig.parameters) == len(kparams)
     # Create the function argument list and the dict entries for the return statement
     specialization = []
+    integer_annotation_types = {"i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64"}
     # signature
     for name, kp in zip(sig.parameters.keys(), kparams):
         if kp.is_constexpr:
             specialization.append(f'("constexpr", {name})')
         else:
-            is_const = 'True' if kp.is_const else 'False'
-            specialize = 'False' if kp.do_not_specialize else 'True'
-            align = 'False' if kp.do_not_specialize_on_alignment else 'True'
+            is_const = kp.is_const
+            specialize = not kp.do_not_specialize
+            align = not kp.do_not_specialize_on_alignment
             ret = f"specialize_impl(backend, {name}, {is_const}, {specialize}, {align})"
             if kp.annotation_type:
                 if isinstance(kp.annotation_type, str):
@@ -413,7 +414,13 @@ def create_function_from_signature(sig, kparams, backend):
                         # we do not specialize non-constexpr floats and bools:
                         specialize = False
                 if specialize:
-                    specialization.append(f'("{kp.annotation_type}",) + {ret}[1:]')
+                    if kp.annotation_type in integer_annotation_types:
+                        # An integer annotation constrains the type of runtime values, but must not discard a
+                        # constexpr classification already produced by the value specializer (for example, 1).
+                        specialization.append(f'(lambda ret: ret if ret[0] == "constexpr" '
+                                              f'else ("{kp.annotation_type}",) + ret[1:])({ret})')
+                    else:
+                        specialization.append(f'("{kp.annotation_type}",) + {ret}[1:]')
                 else:
                     # skip runtime specialization:
                     specialization.append(f'("{kp.annotation_type}", None)')


### PR DESCRIPTION
## Summary

Preserve value-based `constexpr` specialization when an integer kernel argument has an explicit Triton type annotation.

## Problem

`native_specialize_impl()` classifies a Python integer with value `1` as:

```python
("constexpr", 1)
```

For an argument annotated with an integer type such as `tl.int64`, `create_function_from_signature()` currently overwrites the first tuple element and produces:

```python
("i64", 1)
```

The value still participates in the specialization/cache key, but `_pack_args()` no longer recognizes the argument as a compiler constant. It therefore remains a dynamic kernel argument.

On the Ascend backend, this prevents downstream constant folding and range narrowing. In the original reproducer, the resulting dynamic index expression could trigger a UB overflow diagnostic with a large block size.

## Changes

- Preserve a `constexpr` classification already returned by the value specializer for explicitly annotated integer arguments.
- Apply the declared integer type only when the argument is not a specialized constant.
- Use actual booleans for `is_const`, `specialize`, and `align`, so Python control flow correctly honors `do_not_specialize`.-

| Input | Before | After |
| --- | --- | --- |
| `arg: tl.int64`, value `1` | `("i64", 1)` | `("constexpr", 1)` |
| `arg: tl.int64`, value `2` | `("i64", "")` | unchanged |
| `arg: tl.int64`, value `1`, `do_not_specialize=True` | `("i64", None)` | unchanged |
