### PR TITLE
[Language](feat) Support for tl.map_elementwise Op

### DIFF
--- a/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
@@ -128,6 +128,12 @@ public:
       return rewriter.notifyMatchFailure(
           op, "ScalarMathCanonicalizer handles op not within tt.scan.");
     }
+    if (auto linalgOp =
+            op->template getParentOfType<triton::MapElementwiseOp>()) {
+      return rewriter.notifyMatchFailure(
+          op,
+          "ScalarMathCanonicalizer handles op not within tt.map_elementwise.");
+    }
     auto loc = op.getLoc();
     llvm::SmallVector<Value> inputs;
     for (auto input : op->getOperands()) {
@@ -479,6 +485,36 @@ protected:
   convertToTargetOpExtended(triton::ScanOp op,
                             typename triton::ScanOp::Adaptor adaptor,
                             ConversionPatternRewriter &rewriter) const override;
+};
+
+/*
+ * Decompose tt.map_elementwise region body into tensor-level Named Ops.
+ * Each scalar op (arith, math, scf.if, etc.) is promoted to its tensor
+ * counterpart, producing a chain of independent Named Ops.
+ */
+class MapElementwiseDecomposeConverter
+    : public OpConversionPattern<triton::MapElementwiseOp> {
+public:
+  using OpConversionPattern<triton::MapElementwiseOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::MapElementwiseOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override;
+
+private:
+  // Promote a single scalar op to tensor-level and record the result in
+  // valueMap.  Returns the tensor result values (one per op result).
+  SmallVector<Value> promoteOp(Operation *op,
+                               llvm::DenseMap<Value, Value> &valueMap,
+                               OpBuilder &builder, Location loc,
+                               ArrayRef<int64_t> tensorShape) const;
+
+  // Promote ops in a region body (excluding terminator), return the yielded
+  // tensor values from the terminator.
+  SmallVector<Value> promoteRegionBody(Region &region,
+                                       llvm::DenseMap<Value, Value> &valueMap,
+                                       OpBuilder &builder, Location loc,
+                                       ArrayRef<int64_t> tensorShape) const;
 };
 
 class ExternElementwiseClOpConverter

--- a/third_party/ascend/lib/TritonControlFlowOpt/TritonControlFlowOptPass.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/TritonControlFlowOptPass.cpp
@@ -49,7 +49,8 @@ using namespace triton;
 namespace {
 
 static bool isSupportedReturn(Operation *op) {
-  return isa<triton::ReturnOp, func::ReturnOp>(op);
+  return isa<triton::ReturnOp, func::ReturnOp, triton::MapElementwiseReturnOp>(
+      op);
 }
 
 static SmallVector<Block *> getCfgSuccessors(Block *block) {
@@ -2097,7 +2098,7 @@ void TritonControlFlowOptPass::runOnOperation() {
   ModuleOp moduleOp = getOperation();
   SmallVector<Operation *> funcs;
   moduleOp.walk([&](Operation *op) {
-    if (isa<triton::FuncOp, func::FuncOp>(op))
+    if (isa<triton::FuncOp, func::FuncOp, triton::MapElementwiseOp>(op))
       funcs.push_back(op);
   });
 
@@ -2116,6 +2117,14 @@ void TritonControlFlowOptPass::runOnOperation() {
     if (auto funcOp = dyn_cast<func::FuncOp>(op)) {
       if (!funcOp.isDeclaration() &&
           failed(structureFunctionBody(funcOp, funcOp.getBody()))) {
+        signalPassFailure();
+        return;
+      }
+      continue;
+    }
+
+    if (auto mapOp = dyn_cast<triton::MapElementwiseOp>(op)) {
+      if (failed(structureFunctionBody(mapOp, mapOp.getRegion()))) {
         signalPassFailure();
         return;
       }

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -28,6 +28,10 @@
 #include "ascend/include/Utils/Utils.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -42,6 +46,7 @@
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -3338,6 +3343,284 @@ HistogramConverter::matchAndRewrite(triton::HistogramOp op, OpAdaptor adaptor,
                     DenseI32ArrayAttr::get(rewriter.getContext(), {}));
 
   rewriter.replaceOp(op, customOp->getResult(0));
+  return success();
+}
+// ===----------------------------------------------------------------------===
+// MapElementwiseDecomposeConverter
+// ===----------------------------------------------------------------------===
+
+// Promote a single scalar op to tensor-level.  Returns the tensor result
+// values after recording them in valueMap.
+SmallVector<Value> MapElementwiseDecomposeConverter::promoteOp(
+    Operation *op, llvm::DenseMap<Value, Value> &valueMap, OpBuilder &builder,
+    Location loc, ArrayRef<int64_t> tensorShape) const {
+
+  // ---- helpers ----
+  auto getTensorType = [&](Type scalarTy) -> RankedTensorType {
+    return RankedTensorType::get(tensorShape, scalarTy);
+  };
+
+  auto createInit = [&](Type scalarTy) -> Value {
+    return builder.create<tensor::EmptyOp>(loc, tensorShape, scalarTy);
+  };
+
+  auto getOperand = [&](Value v) -> Value {
+    auto it = valueMap.find(v);
+    if (it != valueMap.end())
+      return it->second;
+    // External constant defined outside the region — promote on first use
+    if (auto cst = v.getDefiningOp<arith::ConstantOp>()) {
+      auto scalarTy = cst.getResult().getType();
+      Value init = createInit(scalarTy);
+      auto fill = builder.create<linalg::FillOp>(loc, cst.getResult(), init);
+      valueMap[v] = fill.getResult(0);
+      return fill.getResult(0);
+    }
+    llvm_unreachable("operand not in valueMap and not a constant");
+  };
+
+  auto record = [&](Value oldVal, Value newVal) -> SmallVector<Value> {
+    valueMap[oldVal] = newVal;
+    return {newVal};
+  };
+
+  // ---- binary arith: Op(lhs, rhs) → tensor Op(lhs, rhs) ----
+#define PROMOTE_BINARY(OpTy)                                                   \
+  if (auto a = dyn_cast<OpTy>(op)) {                                           \
+    auto r = builder.create<OpTy>(loc, getOperand(a.getLhs()),                 \
+                                  getOperand(a.getRhs()));                     \
+    return record(a.getResult(), r.getResult());                               \
+  }
+
+  PROMOTE_BINARY(arith::AddIOp)
+  PROMOTE_BINARY(arith::SubIOp)
+  PROMOTE_BINARY(arith::MulIOp)
+  PROMOTE_BINARY(arith::DivSIOp)
+  PROMOTE_BINARY(arith::DivUIOp)
+  PROMOTE_BINARY(arith::RemSIOp)
+  PROMOTE_BINARY(arith::RemUIOp)
+  PROMOTE_BINARY(arith::MaxSIOp)
+  PROMOTE_BINARY(arith::MinSIOp)
+  PROMOTE_BINARY(arith::MaxUIOp)
+  PROMOTE_BINARY(arith::MinUIOp)
+  PROMOTE_BINARY(arith::AddFOp)
+  PROMOTE_BINARY(arith::SubFOp)
+  PROMOTE_BINARY(arith::MulFOp)
+  PROMOTE_BINARY(arith::DivFOp)
+  PROMOTE_BINARY(arith::RemFOp)
+  PROMOTE_BINARY(arith::MaxNumFOp)
+  PROMOTE_BINARY(arith::MinNumFOp)
+  PROMOTE_BINARY(arith::MaximumFOp)
+  PROMOTE_BINARY(arith::MinimumFOp)
+  PROMOTE_BINARY(arith::AndIOp)
+  PROMOTE_BINARY(arith::OrIOp)
+  PROMOTE_BINARY(arith::XOrIOp)
+  PROMOTE_BINARY(arith::ShLIOp)
+  PROMOTE_BINARY(arith::ShRSIOp)
+  PROMOTE_BINARY(arith::ShRUIOp)
+#undef PROMOTE_BINARY
+
+  // ---- unary arith: Op(operand) → tensor Op(operand) ----
+  if (auto a = dyn_cast<arith::NegFOp>(op)) {
+    auto r = builder.create<arith::NegFOp>(loc, getOperand(a.getOperand()));
+    return record(a.getResult(), r.getResult());
+  }
+
+  // ---- comparisons: preserve predicate ----
+  if (auto a = dyn_cast<arith::CmpIOp>(op)) {
+    auto r = builder.create<arith::CmpIOp>(
+        loc, a.getPredicate(), getOperand(a.getLhs()), getOperand(a.getRhs()));
+    return record(a.getResult(), r.getResult());
+  }
+  if (auto a = dyn_cast<arith::CmpFOp>(op)) {
+    auto r = builder.create<arith::CmpFOp>(
+        loc, a.getPredicate(), getOperand(a.getLhs()), getOperand(a.getRhs()));
+    return record(a.getResult(), r.getResult());
+  }
+
+  // ---- select ----
+  if (auto a = dyn_cast<arith::SelectOp>(op)) {
+    auto r = builder.create<arith::SelectOp>(loc, getOperand(a.getCondition()),
+                                             getOperand(a.getTrueValue()),
+                                             getOperand(a.getFalseValue()));
+    return record(a.getResult(), r.getResult());
+  }
+
+  // ---- type casts: Op(in) → Op(in) with tensor result type ----
+#define PROMOTE_CAST(OpTy)                                                     \
+  if (auto a = dyn_cast<OpTy>(op)) {                                           \
+    auto r = builder.create<OpTy>(loc, getTensorType(a.getOut().getType()),    \
+                                  getOperand(a.getIn()));                      \
+    return record(a.getResult(), r.getResult());                               \
+  }
+
+  PROMOTE_CAST(arith::SIToFPOp)
+  PROMOTE_CAST(arith::UIToFPOp)
+  PROMOTE_CAST(arith::FPToSIOp)
+  PROMOTE_CAST(arith::FPToUIOp)
+  PROMOTE_CAST(arith::ExtSIOp)
+  PROMOTE_CAST(arith::ExtUIOp)
+  PROMOTE_CAST(arith::ExtFOp)
+  PROMOTE_CAST(arith::TruncIOp)
+  PROMOTE_CAST(arith::TruncFOp)
+#undef PROMOTE_CAST
+
+  // ---- constant: splat via linalg.fill ----
+  if (auto a = dyn_cast<arith::ConstantOp>(op)) {
+    auto scalarTy = a.getResult().getType();
+    Value init = createInit(scalarTy);
+    auto fill = builder.create<linalg::FillOp>(loc, a.getResult(), init);
+    return record(a.getResult(), fill.getResult(0));
+  }
+
+  // ---- math ops: directly on tensors (same as PROMOTE_BINARY) ----
+#define PROMOTE_MATH(OpTy)                                                     \
+  if (auto a = dyn_cast<OpTy>(op)) {                                           \
+    auto r = builder.create<OpTy>(loc, getOperand(a.getOperand()));            \
+    return record(a.getResult(), r.getResult());                               \
+  }
+
+  PROMOTE_MATH(math::ExpOp)
+  PROMOTE_MATH(math::Exp2Op)
+  PROMOTE_MATH(math::SqrtOp)
+  PROMOTE_MATH(math::RsqrtOp)
+  PROMOTE_MATH(math::LogOp)
+  PROMOTE_MATH(math::Log2Op)
+  PROMOTE_MATH(math::SinOp)
+  PROMOTE_MATH(math::CosOp)
+  PROMOTE_MATH(math::ErfOp)
+  PROMOTE_MATH(math::CeilOp)
+  PROMOTE_MATH(math::FloorOp)
+  PROMOTE_MATH(math::AbsFOp)
+  PROMOTE_MATH(math::AbsIOp)
+#undef PROMOTE_MATH
+
+  // ---- scf.if → arith.select ----
+  if (auto a = dyn_cast<scf::IfOp>(op)) {
+    Value cond = getOperand(a.getCondition());
+    // Process then/else regions with inherited valueMap
+    SmallVector<Value> thenResults = promoteRegionBody(
+        a.getThenRegion(), valueMap, builder, loc, tensorShape);
+    SmallVector<Value> elseResults = promoteRegionBody(
+        a.getElseRegion(), valueMap, builder, loc, tensorShape);
+    for (unsigned i = 0; i < thenResults.size(); i++) {
+      auto sel = builder.create<arith::SelectOp>(loc, cond, thenResults[i],
+                                                 elseResults[i]);
+      valueMap[a.getResult(i)] = sel.getResult();
+    }
+    SmallVector<Value> results;
+    for (unsigned i = 0; i < thenResults.size(); i++)
+      results.push_back(valueMap[a.getResult(i)]);
+    return results;
+  }
+
+  // ---- scf.for ----
+  if (auto a = dyn_cast<scf::ForOp>(op)) {
+    SmallVector<Value> tensorInits;
+    for (Value v : a.getInitArgs())
+      tensorInits.push_back(getOperand(v));
+    auto newFor = builder.create<scf::ForOp>(
+        loc, a.getLowerBound(), a.getUpperBound(), a.getStep(), tensorInits,
+        [&](OpBuilder &b, Location l, Value iv, ValueRange iterArgs) {
+          llvm::DenseMap<Value, Value> loopMap = valueMap;
+          loopMap[a.getInductionVar()] = iv;
+          for (auto [oldArg, newArg] :
+               llvm::zip(a.getRegionIterArgs(), iterArgs))
+            loopMap[oldArg] = newArg;
+          SmallVector<Value> yielded =
+              promoteRegionBody(a.getRegion(), loopMap, b, l, tensorShape);
+          b.create<scf::YieldOp>(l, yielded);
+        });
+    for (auto [oldR, newR] : llvm::zip(a.getResults(), newFor.getResults()))
+      valueMap[oldR] = newR;
+    SmallVector<Value> results;
+    for (auto r : newFor.getResults())
+      results.push_back(r);
+    return results;
+  }
+
+  if (isa<scf::WhileOp>(op)) {
+    op->emitError(
+        "scf.while is not supported inside map_elementwise "
+        "(scf.condition requires scalar i1, cannot promote to tensor)");
+    llvm_unreachable("");
+  }
+  op->emitError("MapElementwiseDecomposeConverter: unsupported op");
+  llvm_unreachable("unhandled op in map_elementwise region");
+  llvm_unreachable("unhandled op in map_elementwise region");
+}
+
+SmallVector<Value> MapElementwiseDecomposeConverter::promoteRegionBody(
+    Region &region, llvm::DenseMap<Value, Value> &valueMap, OpBuilder &builder,
+    Location loc, ArrayRef<int64_t> tensorShape) const {
+  llvm::DenseMap<Value, Value> localMap = valueMap;
+  Block &block = region.front();
+  for (Operation &op : block.without_terminator())
+    promoteOp(&op, localMap, builder, loc, tensorShape);
+
+  // Helper to get-or-create a tensor version of any value (external
+  // constants are promoted on first use).
+  auto getTensorValue = [&](Value v) -> Value {
+    auto it = localMap.find(v);
+    if (it != localMap.end())
+      return it->second;
+    // External constant — promote to tensor
+    if (auto cst = v.getDefiningOp<arith::ConstantOp>()) {
+      auto scalarTy = cst.getResult().getType();
+      Value init = builder.create<tensor::EmptyOp>(loc, tensorShape, scalarTy);
+      auto fill = builder.create<linalg::FillOp>(loc, cst.getResult(), init);
+      localMap[v] = fill.getResult(0);
+      return fill.getResult(0);
+    }
+    // External but not a constant — use as-is (e.g., SSA values from
+    // enclosing scope that are already tensors or valid in this context).
+    return v;
+  };
+
+  Operation *term = block.getTerminator();
+  SmallVector<Value> results;
+  for (Value v : term->getOperands())
+    results.push_back(getTensorValue(v));
+  return results;
+}
+
+LogicalResult MapElementwiseDecomposeConverter::matchAndRewrite(
+    triton::MapElementwiseOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+  Location loc = op.getLoc();
+
+  auto tensorType = cast<RankedTensorType>(op.getOperand(0).getType());
+  auto shape = tensorType.getShape();
+  int64_t rank = shape.size();
+  int64_t pack = op.getPack();
+  int64_t numInputs = op.getNumOperands();
+  int64_t numOutputs = op.getNumResults();
+
+  assert(rank > 0 && "map_elementwise requires ranked tensor inputs");
+
+  Region &region = op.getRegion();
+  assert(region.hasOneBlock() && "expected single-block region");
+  Block &body = region.getBlocks().front();
+  unsigned numRegionArgs = body.getNumArguments();
+
+  // Build initial ValueMap: block_arg[i] → input_tensor[i/pack]
+  llvm::DenseMap<Value, Value> valueMap;
+  for (unsigned i = 0; i < numRegionArgs; i++) {
+    unsigned inputIdx = i / pack;
+    valueMap[body.getArgument(i)] = adaptor.getOperands()[inputIdx];
+  }
+
+  // Promote all non-terminator ops
+  for (Operation &innerOp : body.without_terminator())
+    promoteOp(&innerOp, valueMap, rewriter, loc, shape);
+
+  // Terminator → results
+  Operation *terminator = body.getTerminator();
+  SmallVector<Value> results;
+  for (unsigned i = 0; i < numOutputs; i++)
+    results.push_back(valueMap[terminator->getOperand(i * pack)]);
+
+  rewriter.replaceOp(op, results);
   return success();
 }
 

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -691,6 +691,8 @@ void TritonToLinalgPass::populateTritonToLinalgConversionPatterns(
   patterns.add<TTOpConverters::ArgMaxConverter>(patterns.getContext());
   patterns.add<TTOpConverters::ReduceConverter>(patterns.getContext());
   patterns.add<TTOpConverters::ScanConverter>(patterns.getContext());
+  patterns.add<TTOpConverters::MapElementwiseDecomposeConverter>(
+      patterns.getContext());
   patterns.add<TTOpConverters::ReshapeConverter>(patterns.getContext());
   patterns.add<TTOpConverters::ExpandDimsConverter>(patterns.getContext());
   patterns.add<TTOpConverters::BroadcastConverter>(patterns.getContext());
@@ -1046,6 +1048,7 @@ void TritonToLinalgPass::runOnOperation() {
   };
 
   target.addIllegalOp<triton::ScanOp>();
+  target.addIllegalOp<triton::MapElementwiseOp>();
   target.addDynamicallyLegalOp<scf::ForOp>(loopOpLegalFn);
   target.addDynamicallyLegalOp<scf::WhileOp>(loopOpLegalFn);
 

--- a/third_party/ascend/unittest/pytest_ut/test_map_elementwise_ops.py
+++ b/third_party/ascend/unittest/pytest_ut/test_map_elementwise_ops.py
@@ -1,0 +1,387 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+Coverage tests for tl.map_elementwise decomposition.
+One test per op category / control-flow scenario.
+"""
+import torch
+import triton
+import triton.language as tl
+
+# ---- integer arith ----
+
+
+@triton.jit
+def _add_i(a, b):
+    return tl.add(a, b, sanitize_overflow=False)
+
+
+def test_map_arith_add_i():
+
+    @triton.jit
+    def kernel(X, Y, Z, N: tl.constexpr):
+        offs = tl.arange(0, N)
+        x = tl.load(X + offs)
+        y = tl.load(Y + offs)
+        z = tl.map_elementwise(_add_i, x, y)
+        tl.store(Z + offs, z)
+
+    N = 128
+    x = torch.randint(-100, 100, (N, ), dtype=torch.int32, device='npu')
+    y = torch.randint(-100, 100, (N, ), dtype=torch.int32, device='npu')
+    z = torch.zeros(N, dtype=torch.int32, device='npu')
+    kernel[(1, )](x, y, z, N=N)
+    assert torch.equal(z, x + y)
+
+
+# ---- float arith ----
+
+
+@triton.jit
+def _mul_f(a, b):
+    return a * b
+
+
+def test_map_arith_mul_f():
+
+    @triton.jit
+    def kernel(X, Y, Z, N: tl.constexpr):
+        offs = tl.arange(0, N)
+        x = tl.load(X + offs)
+        y = tl.load(Y + offs)
+        z = tl.map_elementwise(_mul_f, x, y)
+        tl.store(Z + offs, z)
+
+    N = 128
+    x = torch.randn(N, dtype=torch.float32, device='npu')
+    y = torch.randn(N, dtype=torch.float32, device='npu')
+    z = torch.zeros(N, dtype=torch.float32, device='npu')
+    kernel[(1, )](x, y, z, N=N)
+    assert torch.allclose(z, x * y)
+
+
+# ---- bitwise ----
+
+
+@triton.jit
+def _bitwise(a, b):
+    return a & b, a | b, a ^ b
+
+
+def test_map_arith_bitwise():
+
+    @triton.jit
+    def kernel(A, B, C, D, E, N: tl.constexpr):
+        offs = tl.arange(0, N)
+        a = tl.load(A + offs)
+        b = tl.load(B + offs)
+        c, d, e = tl.map_elementwise(_bitwise, a, b)
+        tl.store(C + offs, c)
+        tl.store(D + offs, d)
+        tl.store(E + offs, e)
+
+    N = 128
+    a = torch.randint(0, 255, (N, ), dtype=torch.int32, device='npu')
+    b = torch.randint(0, 255, (N, ), dtype=torch.int32, device='npu')
+    c, d, e = [torch.zeros(N, dtype=torch.int32, device='npu') for _ in range(3)]
+    kernel[(1, )](a, b, c, d, e, N=N)
+    assert torch.equal(c, a & b) and torch.equal(d, a | b) and torch.equal(e, a ^ b)
+
+
+# ---- neg ----
+
+
+@triton.jit
+def _neg(a):
+    return -a
+
+
+def test_map_arith_neg_f():
+
+    @triton.jit
+    def kernel(X, Z, N: tl.constexpr):
+        offs = tl.arange(0, N)
+        x = tl.load(X + offs)
+        z = tl.map_elementwise(_neg, x)
+        tl.store(Z + offs, z)
+
+    N = 128
+    x = torch.randn(N, dtype=torch.float32, device='npu')
+    z = torch.zeros(N, dtype=torch.float32, device='npu')
+    kernel[(1, )](x, z, N=N)
+    assert torch.allclose(z, -x)
+
+
+# ---- comparison + external constant ----
+
+
+@triton.jit
+def _gt_zero(a):
+    if a > 0:
+        return 1
+    else:
+        return 0
+
+
+def test_map_cmp_i():
+
+    @triton.jit
+    def kernel(X, Z, N: tl.constexpr):
+        offs = tl.arange(0, N)
+        x = tl.load(X + offs)
+        z = tl.map_elementwise(_gt_zero, x)
+        tl.store(Z + offs, z)
+
+    N = 128
+    x = torch.randint(-10, 10, (N, ), dtype=torch.int32, device='npu')
+    z = torch.zeros(N, dtype=torch.int32, device='npu')
+    kernel[(1, )](x, z, N=N)
+    expected = (x > 0).to(torch.int32)
+    assert torch.equal(z, expected)
+
+
+# ---- type cast ----
+
+
+@triton.jit
+def _cast(a):
+    return a.to(tl.float32)
+
+
+def test_map_cast_sitofp():
+
+    @triton.jit
+    def kernel(X, Z, N: tl.constexpr):
+        offs = tl.arange(0, N)
+        x = tl.load(X + offs)
+        z = tl.map_elementwise(_cast, x)
+        tl.store(Z + offs, z)
+
+    N = 128
+    x = torch.randint(-100, 100, (N, ), dtype=torch.int32, device='npu')
+    z = torch.zeros(N, dtype=torch.float32, device='npu')
+    kernel[(1, )](x, z, N=N)
+    assert torch.allclose(z, x.float())
+
+
+# ---- math (float) ----
+
+
+@triton.jit
+def _exp(a):
+    return tl.exp(a)
+
+
+def test_map_math_exp():
+
+    @triton.jit
+    def kernel(X, Z, N: tl.constexpr):
+        offs = tl.arange(0, N)
+        x = tl.load(X + offs)
+        z = tl.map_elementwise(_exp, x)
+        tl.store(Z + offs, z)
+
+    N = 128
+    x = torch.randn(N, dtype=torch.float32, device='npu') * 0.5
+    z = torch.zeros(N, dtype=torch.float32, device='npu')
+    kernel[(1, )](x, z, N=N)
+    assert torch.allclose(z, torch.exp(x), atol=1e-4)
+
+
+# ---- math (integer) ----
+
+
+@triton.jit
+def _abs_i(a):
+    return tl.abs(a)
+
+
+def test_map_math_abs_i():
+
+    @triton.jit
+    def kernel(X, Z, N: tl.constexpr):
+        offs = tl.arange(0, N)
+        x = tl.load(X + offs)
+        z = tl.map_elementwise(_abs_i, x)
+        tl.store(Z + offs, z)
+
+    N = 128
+    x = torch.randint(-100, 100, (N, ), dtype=torch.int32, device='npu')
+    z = torch.zeros(N, dtype=torch.int32, device='npu')
+    kernel[(1, )](x, z, N=N)
+    assert torch.equal(z, torch.abs(x))
+
+
+# ---- select ----
+
+
+@triton.jit
+def _where_max(a, b):
+    return tl.where(a > b, a, b)
+
+
+def test_map_select_direct():
+
+    @triton.jit
+    def kernel(X, Y, Z, N: tl.constexpr):
+        offs = tl.arange(0, N)
+        x = tl.load(X + offs)
+        y = tl.load(Y + offs)
+        z = tl.map_elementwise(_where_max, x, y)
+        tl.store(Z + offs, z)
+
+    N = 128
+    x = torch.randint(0, 100, (N, ), dtype=torch.int32, device='npu')
+    y = torch.randint(0, 100, (N, ), dtype=torch.int32, device='npu')
+    z = torch.zeros(N, dtype=torch.int32, device='npu')
+    kernel[(1, )](x, y, z, N=N)
+    assert torch.equal(z, torch.maximum(x, y))
+
+
+# ---- 2D tensor ----
+
+
+@triton.jit
+def _add(a, b):
+    return a + b
+
+
+def test_map_2d():
+
+    @triton.jit
+    def kernel(X, Y, Z, ROWS: tl.constexpr, COLS: tl.constexpr):
+        offs = tl.arange(0, ROWS)[:, None] * COLS + tl.arange(0, COLS)[None, :]
+        x = tl.load(X + offs)
+        y = tl.load(Y + offs)
+        z = tl.map_elementwise(_add, x, y)
+        tl.store(Z + offs, z)
+
+    rows, cols = 4, 8
+    x = torch.randint(-100, 100, (rows, cols), dtype=torch.int32, device='npu')
+    y = torch.randint(-100, 100, (rows, cols), dtype=torch.int32, device='npu')
+    z = torch.zeros((rows, cols), dtype=torch.int32, device='npu')
+    kernel[(1, )](x, y, z, ROWS=rows, COLS=cols)
+    assert torch.equal(z, x + y)
+
+
+# ---- for loop ----
+
+
+@triton.jit
+def _accumulate(a):
+    result = 0
+    for i in range(5):
+        result = result + a
+    return result
+
+
+def test_map_for_loop():
+
+    @triton.jit
+    def kernel(X, Z, N: tl.constexpr):
+        offs = tl.arange(0, N)
+        x = tl.load(X + offs)
+        z = tl.map_elementwise(_accumulate, x)
+        tl.store(Z + offs, z)
+
+    N = 128
+    x = torch.randint(-10, 10, (N, ), dtype=torch.int32, device='npu')
+    z = torch.zeros(N, dtype=torch.int32, device='npu')
+    kernel[(1, )](x, z, N=N)
+    assert torch.equal(z, x * 5)
+
+
+# ---- community tests (from test_core.py) ----
+
+
+@triton.jit
+def _compare(x, y):
+    if x < y:
+        return -1
+    elif x == y:
+        return 0
+    else:
+        return 1
+
+
+def test_map_elementwise():
+
+    @triton.jit
+    def kernel(X, Y, Z, BLOCK: tl.constexpr):
+        x = tl.load(X + tl.arange(0, BLOCK))
+        y = tl.load(Y + tl.arange(0, BLOCK))
+        z = tl.map_elementwise(_compare, x, y)
+        tl.store(Z + tl.arange(0, BLOCK), z)
+
+    shape = (128, )
+    x = torch.randint(-100, 100, shape, dtype=torch.int32, device='npu')
+    y = torch.randint(-100, 100, shape, dtype=torch.int32, device='npu')
+    z = torch.zeros(shape, dtype=torch.int32, device='npu')
+    kernel[(1, )](x, y, z, BLOCK=shape[0])
+    expected = (x > y).int() - (y > x).int()
+    assert torch.equal(z, expected)
+
+
+@triton.jit
+def _divmod(a, b):
+    return a // b, a % b
+
+
+def test_map_elementwise_multiple_outputs():
+
+    @triton.jit
+    def kernel(A, B, C, D, BLOCK: tl.constexpr):
+        a = tl.load(A + tl.arange(0, BLOCK))
+        b = tl.load(B + tl.arange(0, BLOCK))
+        c, d = tl.map_elementwise(_divmod, a, b)
+        tl.store(C + tl.arange(0, BLOCK), c)
+        tl.store(D + tl.arange(0, BLOCK), d)
+
+    shape = (512, )
+    A = torch.randint(1, 100, shape, dtype=torch.int32, device='npu')
+    B = torch.randint(1, 10, shape, dtype=torch.int32, device='npu')
+    C = torch.zeros(shape, dtype=torch.int32, device='npu')
+    D = torch.zeros(shape, dtype=torch.int32, device='npu')
+    kernel[(1, )](A, B, C, D, BLOCK=shape[0])
+    assert torch.equal(C, A // B) and torch.equal(D, A % B)
+
+
+@triton.jit
+def _divmod_pack2(a0, a1, b0, b1):
+    return a0 // b0, a1 // b1, a0 % b0, a1 % b1
+
+
+def test_map_elementwise_pack():
+
+    @triton.jit
+    def kernel(A, B, C, D, BLOCK: tl.constexpr):
+        a = tl.load(A + tl.arange(0, BLOCK))
+        b = tl.load(B + tl.arange(0, BLOCK))
+        c, d = tl.map_elementwise(_divmod_pack2, a, b, pack=2)
+        tl.store(C + tl.arange(0, BLOCK), c)
+        tl.store(D + tl.arange(0, BLOCK), d)
+
+    shape = (512, )
+    A = torch.randint(1, 100, shape, dtype=torch.int32, device='npu')
+    B = torch.randint(1, 10, shape, dtype=torch.int32, device='npu')
+    C = torch.zeros(shape, dtype=torch.int32, device='npu')
+    D = torch.zeros(shape, dtype=torch.int32, device='npu')
+    kernel[(1, )](A, B, C, D, BLOCK=shape[0])
+    assert torch.equal(C, A // B) and torch.equal(D, A % B)


### PR DESCRIPTION
## 1. Background
issue: #1230

### 1.1 What is `tl.map_elementwise`

Introduced in Triton 3.6 (commit `fdd694d48a`). It takes a `@triton.jit` scalar function and maps it over every element of a tensor.

**Core motivation**: enable true control flow in element-wise computation. `tl.where(cond, a, b)` computes both branches then selects (`arith.select`), while `tl.map_elementwise`'s `if/else` only executes the taken branch.

```python
@triton.jit
def selu_scalar(x, alpha):
    if x > 0:
        return x
    else:
        return alpha * (tl.exp(x) - 1)

def selu(x, alpha):
    return tl.map_elementwise(selu_scalar, x, alpha)
```

### 1.2 Op IR Structure

**pack=1 (with if/elif/else control flow)**: 2 inputs, 1 output, block args = `2 × 1 = 2`:

```mlir
%z = "tt.map_elementwise"(%x, %y) <{pack = 1 : i32}> ({
^bb0(%a: i32, %b: i32):
  %lt = arith.cmpi slt, %a, %b : i32
  cf.cond_br %lt, ^bb2(%c_neg1 : i32), ^bb1
^bb1:
  %eq = arith.cmpi eq, %a, %b : i32
  cf.cond_br %eq, ^bb2(%c_zero : i32), ^bb2(%c_one : i32)
^bb2(%r: i32):
  tt.map_elementwise.return %r : i32
}) : (tensor<128xi32>, tensor<128xi32>) -> tensor<128xi32>
```

**pack=2 (interleaved semantics)**: 2 inputs, 2 outputs, block args = `2 × 2 = 4`, layout `[A[0], A[1], B[0], B[1]]`:

```mlir
%q, %r = "tt.map_elementwise"(%a, %b) <{pack = 2 : i32}> ({
^bb0(%a0: i32, %a1: i32, %b0: i32, %b1: i32):
  %q0 = arith.divui %a0, %b0 : i32
  %q1 = arith.divui %a1, %b1 : i32
  %r0 = arith.remui %a0, %b0 : i32
  %r1 = arith.remui %a1, %b1 : i32
  tt.map_elementwise.return %q0, %q1, %r0, %r1 : i32, i32, i32, i32
}) : (tensor<512xi32>, tensor<512xi32>) -> (tensor<512xi32>, tensor<512xi32>)
```

### 1.3 Op Constraints

| Constraint | Rule | Enforced By |
|-----------|------|------------|
| numInputs ≥ 1 | `MapElementwiseOp::verify()` | Upstream |
| pack is a power of 2 | `MapElementwiseOp::verify()` | Upstream |
| region args = numInputs × pack | `verifyRegions()` | Upstream |
| region returns = numOutputs × pack | `verifyRegions()` | Upstream |
| No Write inside region | `verifyRegions()` | Upstream |
| Same shape | `SameOperandsAndResultShape` trait | Upstream |

---

## 2. Approach Analysis

### 2.1 Problem Statement

After eliminating pack (handled at the converter level, no impact on final IR), the core semantics of `tt.map_elementwise` are:

> Multi-input, multi-output element-wise computation with arbitrary scalar operations (including control flow `scf.if`) inside the region.

### 2.2 Analysis Principles

Approach viability is evaluated from the triton-ascend perspective, based solely on op capability — not whether NPUIR currently supports it:
- **Semantic feasibility**: can the op express multi-output and control flow by definition
- **Implementation complexity**: converter development cost
- **Performance**: runtime efficiency and how easily NPUIR can recognize/optimize the IR

### 2.3 Approaches

#### A. `linalg::MapOp`

Element-wise mapping — scalar compute in region body + `linalg.yield`.

- Semantics: **single output is a hard limitation** — MapOp yields only one value; multi-output requires multiple MapOps iterating separately
- Implementation: simple, IRMapping clone region body → mapper body
- Performance: structured op, easy for backend optimization; but LinalgToHFusion only recognizes `func::CallOp(__hmf_*)` patterns

#### B. `linalg::GenericOp`

`iterator_types = ["parallel"]` + identity `indexing_maps`; body cloned from region.

- Semantics: **perfect match** — GenericOp's "execute scalar function per iteration point" is identical to map_elementwise
- Implementation: simple, IRMapping clone + identity maps + `tensor::EmptyOp` init
- Performance: `parallel` declares independent elements; backend can freely vectorize/fuse
- Blocker: NPUIR marks `linalg::GenericOp` as illegal, requires a new pattern

#### C. `scf.for` + `tensor.extract/insert`

Loop over elements, extract scalars, insert results.

- Semantics: functionally expressible but loses "element independence" information
- Implementation: more complex — nested loops + multi-dimensional extract/insert
- Performance: `tensor.insert` introduces false cross-iteration dependencies, hindering fusion

#### D. `scf.for` + `memref.load/store`

Similar to C, using memref instead of tensor.

- Semantics: same as C
- Implementation: additional memref allocation + bufferization management

#### E. Region Decomposition (Selected)

**Promote each scalar operation individually to a tensor-level Named Op**, rather than enclosing the entire body in a single op.

```
map_elementwise region:              Output:
  arith.addi                        arith.addi %A, %B       ← direct tensor
  math.exp                          math.exp %A             ← direct tensor
  scf.if                            arith.select            ← branch expansion
       ↓                                   ↓
  One op (body hidden)              Multiple independent Named Ops
                                    (fully supported)
```

- Semantics: each scalar op has a corresponding tensor-level named op
- Implementation: body traversal + op mapping + scalar→tensor promotion, ~200 lines
- Performance: output is element-wise vector instructions, naturally matching Ascend SIMD
- **Zero NPUIR changes**: arith on tensor (legal), math directly on tensor (legal, same as arith), arith.select (legal)

### 2.4 Comparison

| Approach | Rationale | triton-ascend Work | npuir Work | Feasible |
|---------|-----------|-------------------|-----------|----------|
| A. linalg::MapOp | Single-output limitation | Simple: IRMapping clone | Support non-`__hmf_*` inline body | ❌ |
| B. linalg::GenericOp | Semantically perfect | Simple: identity maps + init + clone ~80 lines | Add new pattern, difficult | ✅ |
| C. scf.for + tensor | Loses independence info | Complex: nested loops + extract/insert | None needed, but hard to fuse | ❌ |
| D. scf.for + memref | Same as C | Complex: memref management | Same as C | ❌ |
| **E. Region Decomposition** | **Direct scalar→tensor mapping, arith/math as named tensor ops, control as select/for** | Medium: body traversal + op mapping ~200 lines | **None** | ✅ |

### 2.5 Conclusion

Approach E (Region Decomposition) is selected because:

1. **Zero NPUIR changes**: all output ops are already supported by the NPUIR pipeline
2. **Natural SIMD fit**: vector instructions are the most natural expression for Ascend hardware
3. **Manageable implementation**: converter core logic is op traversal + type mapping
4. **CFG reuse**: Phase 1 reuses `structureFunctionBody`, identical to Approach B

---

## 3. Lowering Design

### 3.1 Overall Flow

```mermaid
flowchart LR
    subgraph pass1["TritonControlFlowOptPass"]
        A["tt.map_elementwise<br/>multi-block CFG"] --> B["structureFunctionBody"] --> C["single block + scf.if"]
    end
    C --> D
    subgraph pass2["TritonToLinalgPass"]
        D["MapElementwiseDecomposeConverter"] --> E["Named Op chain"]
    end
```

- **Phase 1** (`TritonControlFlowOptPass`): Reuse `structureFunctionBody` to convert multi-block CFG in the region into single-block + nested `scf.if`
- **Phase 2** (`TritonToLinalgPass`): `MapElementwiseDecomposeConverter` decomposes the single-block region into multiple tensor-level Named Ops

### 3.2 Phase 1: CFG Canonicalization (Reusing structureFunctionBody)

After inlining the `scalar_fn`, the `map_elementwise` region contains multi-block CFG (`cf.cond_br` / `cf.br`). `structureFunctionBody` already has full CFG structuring capability (`cf.br` chain inlining, `cf.cond_br` → `scf.if`, cycle detection, multi-exit-block convergence, etc.). It just needs to include `map_elementwise` regions in its scope.

Two changes in `TritonControlFlowOptPass.cpp`:

**1. `isSupportedReturn`**: add `MapElementwiseReturnOp`

```cpp
static bool isSupportedReturn(Operation *op) {
    return isa<triton::ReturnOp, func::ReturnOp,
               triton::MapElementwiseReturnOp>(op);
}
```

**2. `runOnOperation()`**: collect `MapElementwiseOp` and call `structureFunctionBody`

```cpp
// walk:
if (isa<triton::FuncOp, func::FuncOp, triton::MapElementwiseOp>(op))
    funcs.push_back(op);

// process:
if (auto mapOp = dyn_cast<triton::MapElementwiseOp>(op)) {
    if (failed(structureFunctionBody(mapOp, mapOp.getRegion()))) { ... }
}
```

`createReturnLike` needs no changes — it creates ops via `sampleReturn->getName()`, which works generically for any return-like op.

### 3.3 MapElementwiseDecomposeConverter

Maintains a `scalar Value → tensor Value` mapping table, traverses the region body, and promotes each scalar op to a tensor-level Named Op. Pack handling is the same as before: `block_arg[i] → operand[i/pack]`.

```mermaid
flowchart TB
    subgraph phase1["Init"]
        direction LR
        A["1. Extract metadata<br/>numInputs, pack, rank, shape"] --> B["2. Build ValueMap<br/>block_arg[i] → operand[i/pack]"]
    end
    B --> C
    subgraph phase2["Traverse body (topological order)"]
        direction LR
        C["3. For each non-terminator op:"] --> D{"op type"}
        D -->|"arith arithmetic/cast"| E["4a. Map operands<br/>emit same-named tensor op<br/>write result to ValueMap"]
        D -->|"arith.constant"| F["4b. linalg.fill<br/>splat to target shape"]
        D -->|"math.xxx"| G["4c. Emit same-named<br/>math op directly<br/>on tensor"]
        D -->|"scf.if"| H["4d. Recursively process<br/>both branches<br/>arith.select merge"]
        D -->|"scf.for"| I["4e. Preserve structure<br/>iter_args promoted<br/>to tensor"]
    end
    phase2 --> J["5. Look up terminator<br/>operands via ValueMap<br/>rewriter.replaceOp"]
```

Op dispatch across six categories:

| op type | Processing | Output |
|---------|-----------|--------|
| arith arithmetic/cast | Map operands, emit same-named tensor op | `arith.addi %A, %B : tensor<...>` |
| arith.constant | Create `tensor.empty` + `linalg.fill` | `linalg.fill ins(%c) outs(...)` |
| math.xxx | Map operands, emit same-named tensor op | `math.exp %A : tensor<...>` |
| scf.if | Recursively process branches, emit `arith.select` | `arith.select %cond, %then, %else` |
| scf.for | Preserve structure, iter_args promoted to tensor | `scf.for ... iter_args(%tensor)` |

**Detailed handling per category:**

**Binary arith** (add/sub/mul/div/rem/neg/max/min): arith ops accept tensor operands directly.

```
scalar:  %s = arith.addi %a, %b : i32
         ↓
tensor:  %s_t = arith.addi %A, %B : tensor<128xi32>
```

Coverage: `addi/addf/subi/subf/muli/mulf/divsi/divui/divf/remsi/remui/remf/negf/maxf/minf/maxsi/minsi/maxui/minui`

**Type casts** (sitofp/uitofp/fptosi/fptoui/ext/trunc): also accept tensor operands directly.

```
scalar:  %s = arith.sitofp %a : i32 to f32
         ↓
tensor:  %s_t = arith.sitofp %A : tensor<128xi32> to tensor<128xf32>
```

Coverage: `sitofp/uitofp/fptosi/fptoui/extsi/extui/extf/trunci/truncf`

**Math functions** (exp/sqrt/log/sin/cos/erf/ceil/floor/absf, etc.): just like arith, `math.xxx` directly accepts tensor operands — no wrapping needed.

```
scalar:  %e = math.exp %a : f32
         ↓
tensor:  %e_t = math.exp %A : tensor<128xf32>
```

Coverage: `exp/exp2/log/log2/sqrt/rsqrt/sin/cos/erf/ceil/floor/absf/absi`

**Control flow** (scf.if → arith.select): both branches are fully expanded into tensor chains, merged with `arith.select`. On SIMD hardware both branches execute, matching `arith.select` semantics exactly. Nested `scf.if` is handled recursively.

```
scalar:
  %res = scf.if %cmp -> i32 {
    scf.yield %then_val : i32
  } else {
    %e = math.exp %x : i32
    scf.yield %e : i32
  }

tensor:
  %then_t = ...                         // then branch tensor chain
  %e_t = math.exp %X : tensor<128xf32>    // else branch tensor chain
  %res_t = arith.select %cmp_t, %then_t, %e_t : tensor<128xi32>
```

**Constants** (arith.constant): splatted to a same-shape constant tensor.

```
scalar:  %c = arith.constant 0 : i32
         ↓
tensor:  %init = tensor.empty() : tensor<128xi32>
         %c_t = linalg.fill ins(%c) outs(%init)
```

**Structured loops** (scf.for): the `scf.for` structure is preserved, `iter_args` are promoted from scalar to tensor. (`scf.while` is not directly supported because `scf.condition` requires a scalar `i1`, which cannot be promoted to tensor.)

```
scalar:
  %r = scf.for %i = %c0 to %cN step %c1
       iter_args(%acc = %init_s) -> i32 {
    %new = arith.addi %acc, %x : i32
    scf.yield %new
  }

tensor:
  %r_t = scf.for %i = %c0 to %cN step %c1
         iter_args(%acc_t = %init_t) -> tensor<128xi32> {
    %new_t = arith.addi %acc_t, %X : tensor<128xi32>
    scf.yield %new_t
  }
```

### 3.4 Code Changes

| File | Change |
|------|--------|
| `TritonControlFlowOptPass.cpp` | `isSupportedReturn` + `MapElementwiseReturnOp`; `runOnOperation()` + `MapElementwiseOp` |
| `TritonOpConverter.h` | Delete `MapElementwiseCFGCanonicalizer` and `MapElementwiseToGenericConverter`; add `MapElementwiseDecomposeConverter` |
| `TritonOpConverter.cpp` | Delete old implementation; implement `MapElementwiseDecomposeConverter` |
| `TritonToLinalgPass.cpp` | Delete `MapElementwiseCFGCanonicalizer` registration; register `MapElementwiseDecomposeConverter` |

---

## 4. NPUIR Downstream Dependencies

**None.** All output ops are supported by the current NPUIR pipeline:

| Output Op | NPUIR Handling |
|-----------|---------------|
| `arith.*` on tensor | `arith` dialect is globally legal in LinalgToHFusion |
| `math.xxx` on tensor | `math` dialect is globally legal in LinalgToHFusion |
| `arith.select` | legal |
| `linalg.fill` | named op, already supported |
| `scf.for` | legal |

---

## 5. Test Design

### 5.1 End-to-End Python Tests

Test file: `third_party/ascend/unittest/pytest_ut/test_map_elementwise_ops.py`

| Test | Scenario | Verification |
|------|----------|-------------|
| `test_map_arith_add_i` | Integer binary op | `arith.addi` directly on tensor |
| `test_map_arith_mul_f` | Float binary op | `arith.mulf` on tensor |
| `test_map_arith_bitwise` | Bitwise (and/or/xor) | `arith.andi/ori/xori` on tensor |
| `test_map_cmp_i` | Comparison + external constant | `arith.cmpi` on tensor |
| `test_map_cast_sitofp` | Type cast | `arith.sitofp` on tensor |
| `test_map_math_exp` | Float math | `math.exp` directly on tensor |
| `test_map_math_abs_i` | Integer math | `math.absi` directly on tensor |
| `test_map_select_direct` | arith.select | `arith.select` on tensor |
| `test_map_2d` | Multi-dim tensor | rank-independent, arith works directly |
| `test_map_for_loop` | scf.for | iter_args promoted to tensor |
| `test_map_elementwise` | if/elif/else control flow | `scf.if` → `arith.select` |
| `test_map_elementwise_multiple_outputs` | Multi-output divmod | `arith.divsi/remsi` on tensor |
| `test_map_elementwise_pack` | pack=2 | pack elimination |

Note: the last three are upstream community tests, also retained in `test_core.py`. `uint32` is not supported on NPU devices; the test file uses `int32` instead.
