### PR TITLE
[launch](fix) skip kernel launch for empty girds

### DIFF
--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -877,6 +877,10 @@ void triton_launch_kernel(
     const int64_t* shapes_data, const int* shape_dims, int num_tensors,
     const int* tensor_kinds,
     const void* const* kernel_args, const size_t* arg_sizes, int num_args) {{
+  if (gridX <=0 || gridY <=0 || gridZ <=0) {{
+    printf("WARNING: Skipping launch for kernel '%s' due to empty grid (gridX=%d, gridY=%d, gridZ=%d).\\n", kernelName, gridX, gridY, gridZ);
+    return;
+  }}
   std::vector<std::vector<int64_t>> tensorShapes;
   if (shapes_data != nullptr && shape_dims != nullptr) {{
     int shapes_idx = 0;
@@ -1016,6 +1020,10 @@ void triton_launch_kernel(
 
 static void _launch(const char* kernelName, const void* func, rtStream_t stream, int gridX, int gridY, int gridZ, std::vector<std::vector<int64_t>> &tensorShapes, std::vector<int> &tensorKinds{(', ' + arg_decls) if len(arg_decls) > 0 else ''}) {{
   // Keep Python launcher on the stable local packing path.
+  if (gridX <=0 || gridY <=0 || gridZ <=0) {{
+    printf("WARNING: Skipping launch for kernel '%s' due to empty grid (gridX=%d, gridY=%d, gridZ=%d).\\n", kernelName, gridX, gridY, gridZ);
+    return;
+  }}
   std::string name = "";
   name.append(kernelName);
   void *workspace_addr_ptr = NULL;


### PR DESCRIPTION
For details of the issue, see: triton-lang/triton-ascend/issues/984

Problem:
On the Ascend backend, launching an already compiled Triton kernel with a zero-sized 1D grid (e.g., grid=(0,)) causes a native ACL parameter error and process abort:
```
Invalid_Argument(EE1003): KernelLaunch failed because value 0 for parameter coreDim is invalid.  Expected value: not equal to 0.
```
This is a common edge case in dynamic batch LLM inference where a rank may have zero active requests.

Root Cause:
The generated _launch function in driver.py lacks a guard clause for empty grids. It calculates blockNum = gridX * gridY * gridZ (resulting in 0) and passes it directly to rtKernelLaunch. The CANN driver rejects coreDim=0 as an invalid argument, whereas the CUDA driver gracefully handles empty launches.

Solution:
Added an early return check and warning message printing in the triton_launch_kernel and _launch function generation in driver.py:
```
if (gridX <= 0 || gridY <= 0 || gridZ <= 0) {
    printf("WARNING: Skipping launch for kernel '%s' due to empty grid (gridX=%d, gridY=%d, gridZ=%d).\\n", kernelName, gridX, gridY, gridZ);
    return;
}
```
This mimics the CUDA backend behavior (checking if (gridX*gridY*gridZ > 0)) and skips the hardware launch call entirely for empty grids.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
