### PR TITLE
[driver](feat) aicore and verctorcore passed to npu-ir

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -569,6 +569,14 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
         _compile_option_list += [
             f"--enable-auto-bind-sub-block={get_auto_bind_sub_block_option(metadata)}",
         ]
+        npu_utils = NPUUtils()
+        if npu_utils.has_device_limit():
+            _compile_option_list += [
+                f"--custom-aic-number={npu_utils.get_aicore_num()}",
+            ]
+            _compile_option_list += [
+                f"--custom-aiv-number={npu_utils.get_aivector_core_num()}",
+            ]
 
         if force_disable_ffts():
             _compile_option_list += ["--disable-ffts"]

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -103,7 +103,7 @@ class NPUUtils(object):
         if npu_device_limit_str is None:
             return num_aic, num_aiv
 
-        is_valid = re.match(r'^\d+(,\d+)$', npu_device_limit_str.strip())
+        is_valid = re.match(r'^\d+ *, *\d+$', npu_device_limit_str.strip())
         if is_valid:
             parts = [part.strip() for part in npu_device_limit_str.split(",")]
             num_aic_env = int(parts[0])
@@ -116,7 +116,7 @@ class NPUUtils(object):
                     f"[ERROR]NPU_DEVICE_LIMIT={npu_device_limit_str}, both cube_core_num and vector_core_num "
                     f"must be less than or equal to device properties ({num_aic},{num_aiv}).")
             else:
-                print(f"[INFO]NPU_DEVICE_LIMIT from env: cube_core_num={num_aic_env},vector_core_num={num_aic_env}).")
+                print(f"[INFO]NPU_DEVICE_LIMIT from env: cube_core_num={num_aic_env},vector_core_num={num_aiv_env}).")
                 return num_aic_env, num_aiv_env
         else:
             raise ValueError(f"[ERROR]NPU_DEVICE_LIMIT={npu_device_limit_str}, which has invalid format: "
@@ -125,6 +125,9 @@ class NPUUtils(object):
     @functools.lru_cache()
     def get_device_aicore(self):
         return self.npu_utils_mod.get_aicore_num()
+
+    def has_device_limit(self):
+        return self.get_device_aicore() != self.get_aicore_num()
 
     def get_device_properties(self, device):
         # temperoarily added "max_shared_mem" properties to avoid triton-compiler complain

--- a/third_party/ascend/unittest/pytest_ut/test_driver.py
+++ b/third_party/ascend/unittest/pytest_ut/test_driver.py
@@ -59,6 +59,8 @@ def _make_mock_npu_utils():
         ("1,2", 1, 2),
         # leading/trailing spaces are stripped by .strip()
         ("  12,24  ", 12, 24),
+        ("12 , 24  ", 12, 24),
+        ("12, 24", 12, 24),
     ],
 )
 def test_npu_device_limit_env_var_valid(monkeypatch, env_value, expected_aic, expected_aiv):
@@ -88,7 +90,6 @@ def test_npu_device_limit_env_var_valid(monkeypatch, env_value, expected_aic, ex
         "12.5,24",  # float not matched
         "",  # empty string
         "-1,48",  # negative sign not matched
-        "12, 24",  # space after comma breaks regex
     ],
 )
 def test_npu_device_limit_env_var_invalid(monkeypatch, env_value):


### PR DESCRIPTION
1. A5 scenario adds the logic of passing parameters to NPU-IR after control and verification,
2. add has_device_limit method:Whether to control nuclear power
3. enhances the generalization of environment variable value formats, supporting spaces.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
