### PR TITLE
[build](feat) fix patch error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -491,6 +491,7 @@ class CMakeBuild(build_ext):
         os.environ['LD_LIBRARY_PATH'] = f'{hitest_home}:{current_ld_path}'
 
     def run(self):
+        download_and_copy_dependencies()
         apply_triton_ascend_patch()
 
         try:
@@ -989,6 +990,7 @@ def apply_triton_ascend_patch():
         "python/triton/_utils.py",
         "python/triton/compiler/code_generator.py",
         "python/triton/compiler/compiler.py",
+        "python/triton/compiler/errors.py",
         "python/triton/language/math.py",
         "python/triton/language/semantic.py",
         "python/triton/language/standard.py",
@@ -999,8 +1001,6 @@ def apply_triton_ascend_patch():
         "bin/CMakeLists.txt",
         "bin/RegisterTritonDialects.h",
         "bin/triton-opt.cpp",
-        "python/triton/compiler/compiler.py",
-        "python/triton/compiler/errors.py",
         "python/triton/runtime/autotuner.py",
     ]
     if not bool(is_manylinux):


### PR DESCRIPTION
During the second compilation of the service patch, the errors.py file is not initialized. As a result, the patch fails to be installed.


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
