### PR TITLE
[PlanMemory](feat) Add compile options for dynamic tcb memory reuse.

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/Common/MemoryEffectsTracker.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/MemoryEffectsTracker.cpp
@@ -37,6 +37,8 @@
 #include "ascend/include/DynamicCVPipeline/Common/MemoryEffectsTracker.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -52,6 +54,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/MathExtras.h"
 
 using namespace mlir;
 static constexpr const char *DEBUG_TYPE = "memory-effects-tracker";
@@ -135,6 +138,63 @@ void collectLeafOps(Operation *op, SmallVectorImpl<Operation *> &leafOps) {
       }
     }
   }
+}
+
+using AddressRange = std::pair<int64_t, int64_t>;
+
+static std::optional<int64_t> getArithConstantInt(Value value) {
+  auto constantOp = value.getDefiningOp<arith::ConstantOp>();
+  if (!constantOp) {
+    return std::nullopt;
+  }
+  auto integerAttr = dyn_cast<IntegerAttr>(constantOp.getValue());
+  if (!integerAttr) {
+    return std::nullopt;
+  }
+  return integerAttr.getInt();
+}
+
+static std::optional<SmallVector<AddressRange>>
+getConstantAddressRanges(hivm::PointerCastOp pointerCast) {
+  auto memrefType = cast<MemRefType>(pointerCast.getResult().getType());
+  int64_t sizeInBits = memrefType.getElementTypeBitWidth();
+
+  // Dynamic shape should be predicted by the input constant value.
+  auto dynamicSize = pointerCast.getDynamicSizes().begin();
+  for (int64_t dim : memrefType.getShape()) {
+    int64_t dimSize = dim;
+    if (ShapedType::isDynamic(dim)) {
+      auto constantSize = getArithConstantInt(*dynamicSize++);
+      if (!constantSize) {
+        return std::nullopt;
+      }
+      dimSize = *constantSize;
+    }
+    int64_t newSizeInBits = -1;
+    if (llvm::MulOverflow(sizeInBits, dimSize, newSizeInBits)) {
+      return std::nullopt;
+    }
+    sizeInBits = newSizeInBits;
+  }
+
+  SmallVector<AddressRange> ranges;
+  ranges.reserve(pointerCast.getAddrs().size());
+  constexpr int64_t bitsPerByte = 8;
+  int64_t sizeInBytes = sizeInBits / bitsPerByte +
+                        (sizeInBits % bitsPerByte != 0);
+  for (Value address : pointerCast.getAddrs()) {
+    auto constantAddress = getArithConstantInt(address);
+    if (!constantAddress) {
+      return std::nullopt;
+    }
+    int64_t begin = *constantAddress;
+    int64_t end;
+    if (llvm::AddOverflow(begin, sizeInBytes, end)) {
+      return std::nullopt;
+    }
+    ranges.emplace_back(begin, end);
+  }
+  return ranges;
 }
 
 } // namespace
@@ -345,12 +405,14 @@ MemoryDependenceGraph::collectOuterEffects(Operation *op, bool &unknown,
   return filtered;
 }
 
+// Entry of checking whether lhs's memory overlaps with rhs's memory.
 AliasResult MemoryDependenceGraph::queryAlias(Value lhs, Value rhs) {
   auto lhsSource = getViewSource(lhs);
   auto rhsSource = getViewSource(rhs);
   if (!rhsSource) {
     rhsSource = rhs;
   }
+  // Case 1: Entry args are considered with unique memory space.
   auto isFuncEntryArg = [](const Value &val) -> bool {
     auto arg = llvm::dyn_cast<BlockArgument>(val);
     if (!arg) {
@@ -363,6 +425,33 @@ AliasResult MemoryDependenceGraph::queryAlias(Value lhs, Value rhs) {
   if (isFuncEntryArg(getViewSource(lhs)) &&
       isFuncEntryArg(getViewSource(rhs))) {
     return lhs == rhs ? AliasResult::MustAlias : AliasResult::NoAlias;
+  }
+
+  // Case 2: Pointer casts with compile-time constant ranges are checked by
+  // their addresses. Unknown addresses/sizes conservatively may alias.
+  auto lhsPointerCast = lhs.getDefiningOp<hivm::PointerCastOp>();
+  auto rhsPointerCast = rhs.getDefiningOp<hivm::PointerCastOp>();
+  if (lhsPointerCast && rhsPointerCast) {
+    auto lhsType = cast<MemRefType>(lhsPointerCast.getResult().getType());
+    auto rhsType = cast<MemRefType>(rhsPointerCast.getResult().getType());
+    if (lhsType.getMemorySpace() != rhsType.getMemorySpace()) {
+      return AliasResult::NoAlias;
+    }
+
+    auto lhsRanges = getConstantAddressRanges(lhsPointerCast);
+    auto rhsRanges = getConstantAddressRanges(rhsPointerCast);
+    if (!lhsRanges || !rhsRanges) {
+      return AliasResult::MayAlias;
+    }
+
+    for (const auto &[lhsBegin, lhsEnd] : *lhsRanges) {
+      for (const auto &[rhsBegin, rhsEnd] : *rhsRanges) {
+        if (lhsBegin < rhsEnd && rhsBegin < lhsEnd) {
+          return AliasResult::MustAlias;
+        }
+      }
+    }
+    return AliasResult::NoAlias;
   }
   return aa.alias(lhsSource, rhsSource);
 }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_pointer_cast_address_alias.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_pointer_cast_address_alias.mlir
@@ -1,0 +1,81 @@
+// RUN: triton-opt --debug-only=memory-effects-tracker --plan-compute-block %s 2>&1 | FileCheck %s
+
+module {
+  // The second store only depends on its own allocation: [0, 16) and [16, 32)
+  // are adjacent but do not overlap.
+  // CHECK-LABEL: Analyzing op func.func @constant_disjoint_pointer_casts
+  // CHECK: Analyzing op %[[DISJOINT_RHS:[A-Za-z0-9_]+]] = hivm.hir.pointer_cast(%c16_i64)
+  // CHECK: Analyzing op memref.store {{.*}}, %[[DISJOINT_RHS]][{{.*}}]
+  // CHECK-NEXT: [memory-effects-tracker] Defs:
+  // CHECK-NEXT: [memory-effects-tracker] Preds:
+  // CHECK-NEXT: [memory-effects-tracker] %[[DISJOINT_RHS]] = hivm.hir.pointer_cast(%c16_i64)
+  func.func @constant_disjoint_pointer_casts() {
+    %c0_i64 = arith.constant 0 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %c0 = arith.constant 0 : index
+    %value = arith.constant 1 : i32
+    %lhs = hivm.hir.pointer_cast(%c0_i64) : memref<4xi32, #hivm.address_space<ub>>
+    %rhs = hivm.hir.pointer_cast(%c16_i64) : memref<4xi32, #hivm.address_space<ub>>
+    memref.store %value, %lhs[%c0] : memref<4xi32, #hivm.address_space<ub>>
+    memref.store %value, %rhs[%c0] : memref<4xi32, #hivm.address_space<ub>>
+    return
+  }
+
+  // [0, 16) and [8, 24) overlap, so the second store depends on the first.
+  // CHECK-LABEL: Analyzing op func.func @constant_overlapping_pointer_casts
+  // CHECK: Analyzing op memref.store %c1_i32, %[[OVERLAP_LHS:[A-Za-z0-9_]+]][%c0]
+  // CHECK: Analyzing op memref.store %c1_i32, %{{[A-Za-z0-9_]+}}[%c0]
+  // CHECK-NEXT: [memory-effects-tracker] Defs:
+  // CHECK-NEXT: [memory-effects-tracker] Preds:
+  // CHECK-NEXT: [memory-effects-tracker] memref.store %c1_i32, %[[OVERLAP_LHS]][%c0]
+  func.func @constant_overlapping_pointer_casts() {
+    %c0_i64 = arith.constant 0 : i64
+    %c8_i64 = arith.constant 8 : i64
+    %c0 = arith.constant 0 : index
+    %value = arith.constant 1 : i32
+    %lhs = hivm.hir.pointer_cast(%c0_i64) : memref<4xi32, #hivm.address_space<ub>>
+    %rhs = hivm.hir.pointer_cast(%c8_i64) : memref<4xi32, #hivm.address_space<ub>>
+    memref.store %value, %lhs[%c0] : memref<4xi32, #hivm.address_space<ub>>
+    memref.store %value, %rhs[%c0] : memref<4xi32, #hivm.address_space<ub>>
+    return
+  }
+
+  // A non-arith.constant address conservatively aliases the constant range.
+  // CHECK-LABEL: Analyzing op func.func @variable_pointer_cast_may_alias
+  // CHECK: Analyzing op memref.store %c1_i32, %[[VARIABLE_LHS:[A-Za-z0-9_]+]][%c0]
+  // CHECK: Analyzing op memref.store %c1_i32, %{{[A-Za-z0-9_]+}}[%c0]
+  // CHECK-NEXT: [memory-effects-tracker] Defs:
+  // CHECK-NEXT: [memory-effects-tracker] Preds:
+  // CHECK-NEXT: [memory-effects-tracker] memref.store %c1_i32, %[[VARIABLE_LHS]][%c0]
+  func.func @variable_pointer_cast_may_alias(%address: i64) {
+    %c0_i64 = arith.constant 0 : i64
+    %c0 = arith.constant 0 : index
+    %value = arith.constant 1 : i32
+    %lhs = hivm.hir.pointer_cast(%c0_i64) : memref<4xi32, #hivm.address_space<ub>>
+    %rhs = hivm.hir.pointer_cast(%address) : memref<4xi32, #hivm.address_space<ub>>
+    memref.store %value, %lhs[%c0] : memref<4xi32, #hivm.address_space<ub>>
+    memref.store %value, %rhs[%c0] : memref<4xi32, #hivm.address_space<ub>>
+    return
+  }
+
+  // memref<8xi1> occupies ceil(8 / 8) = 1 byte. The byte addresses 0 and 1
+  // therefore map to the adjacent, non-overlapping ranges [0, 1) and [1, 2).
+  // CHECK-LABEL: Analyzing op func.func @total_bit_size_rounds_up_to_bytes
+  // CHECK: Analyzing op %[[BIT_RHS:[A-Za-z0-9_]+]] = hivm.hir.pointer_cast(%c1_i64)
+  // CHECK: Analyzing op memref.store {{.*}}, %[[BIT_RHS]][{{.*}}]
+  // CHECK-NEXT: [memory-effects-tracker] Defs:
+  // CHECK-NEXT: [memory-effects-tracker] Preds:
+  // CHECK-NEXT: [memory-effects-tracker] %[[BIT_RHS]] = hivm.hir.pointer_cast(%c1_i64)
+  func.func @total_bit_size_rounds_up_to_bytes() {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c0 = arith.constant 0 : index
+    %value = arith.constant true
+    %lhs = hivm.hir.pointer_cast(%c0_i64) : memref<8xi1, #hivm.address_space<ub>>
+    %rhs = hivm.hir.pointer_cast(%c1_i64) : memref<8xi1, #hivm.address_space<ub>>
+    memref.store %value, %lhs[%c0] : memref<8xi1, #hivm.address_space<ub>>
+    memref.store %value, %rhs[%c0] : memref<8xi1, #hivm.address_space<ub>>
+    return
+  }
+
+}


### PR DESCRIPTION


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

增加编译选项透传，使能 VF Inplace Dynamic tcb  复用
