### PR TITLE
[costmodel](fix) optimize costmodel precision

### DIFF
--- a/third_party/ascend/backend/runtime/costmodel_runtime.py
+++ b/third_party/ascend/backend/runtime/costmodel_runtime.py
@@ -74,7 +74,7 @@ def make_costmodel_cache_key(ttir: str, extra_args: Optional[List[str]]) -> str:
     if extra_args:
         h.update(" ".join(extra_args).encode("utf-8"))
     h.update(b"|")
-    h.update(b"inproc_costmodel_v1")
+    h.update(b"inproc_costmodel_v2_loop_weighted")
     return h.hexdigest()
 
 

--- a/third_party/ascend/costmodel/configs/ascend_910b.json
+++ b/third_party/ascend/costmodel/configs/ascend_910b.json
@@ -305,5 +305,466 @@
     "wave_overhead": {
       "description": "Observed aiv_time decreases monotonically with fewer AIV waves: BM=16(3 waves)->BM=32(2 waves)->BM=48(1 wave). BM=64 also 1 wave but with lower program count, making BM=48 and BM=64 near-equal (exception to the monotonic trend). The wave count multiplier N_waves=ceil(N_programs/N_AIV) is applied to per-program cycles to produce kernel-level time."
     }
+  },
+
+  "tilesim": {
+    "description": "Knobs for the tilesim-migrated micro-architecture model (root cause 1/2).",
+    "active_bandwidth_cores": 48,
+    "enable_small_packet_bw": true,
+    "small_packet": {
+      "description": "Global small-packet bandwidth fitting coefficients (tilesim 910B1.yaml pkt_param). Applied to EVERY mover when enable_small_packet_bw is on, mirroring tilesim's single global pkt_param dict; a per-table bandwidth_tables[*].small_packet entry overrides these. Bucket selection: <64B -> 64B, <128B -> 128B, <256B -> 256B; formula bw = b/(a*b + pktBytes/(1024^3)).",
+      "threshold_bytes": 256,
+      "64B": [
+        0.295,
+        12.061
+      ],
+      "128B": [
+        0.272,
+        16.820
+      ],
+      "256B": [
+        0.322,
+        24.004
+      ]
+    },
+    "mutex_groups": {
+      "description": "Hardware units that share a physical pipeline and cannot execute in parallel (tilesim MutexComponents / pipe_exclusive_config). Each clique is an array of costmodel unit names (cube/cube_mte2/fixpipe/vector/vec_mte2/mte3/scalar). 910B: AIV MTE2 (vec load) and MTE3 (vec store) share one pipeline -> they serialize, so the vector-path roofline uses max(vector, vec_mte2 + mte3) instead of max(vector, vec_mte2, mte3).",
+      "cliques": [
+        [
+          "vec_mte2",
+          "mte3"
+        ]
+      ]
+    }
+  },
+
+  "cube_model": {
+    "description": "Cube (GEMM) L1-pipe roofline parameters (tilesim 910B1 cube_config).",
+    "throughput": [
+      16,
+      32,
+      16
+    ],
+    "repeat_cycles": {
+      "fp32": 2,
+      "fp16": 1,
+      "bf16": 1,
+      "int8": 1
+    },
+    "l0_tile_limit_kb": 32
+  },
+
+  "bandwidth_tables": {
+    "description": "Per-(src:dst[,corenum,pkt]) bandwidth in GB/s, migrated from tilesim bandwidth_910B1.csv (GM->hbm, SHM->l2). Costmodel space names: hbm/l2/l1/l0a/l0b/l0c/ub. Core-dependent movers carry per_core_gbps (1..48); others use bandwidth_gbps.",
+    "hbm:ub": {
+      "per_core_gbps": {
+        "1": 100.9,
+        "2": 64.5,
+        "3": 88.29666667,
+        "4": 77.945,
+        "5": 84.852,
+        "6": 80.82666667,
+        "7": 73.31571429,
+        "8": 68.93375,
+        "9": 73.22888889,
+        "10": 67.586,
+        "11": 71.13727273,
+        "12": 68.08833333,
+        "13": 69.14615385,
+        "14": 72.60785714,
+        "15": 74.99866667,
+        "16": 73.26375,
+        "17": 72.05058824,
+        "18": 70.66833333,
+        "19": 73.27,
+        "20": 68.7705,
+        "21": 68.72190476,
+        "22": 66.07909091,
+        "23": 66.33826087,
+        "24": 65.08041667,
+        "25": 65.3448,
+        "26": 62.61884615,
+        "27": 62.15148148,
+        "28": 58.95964286,
+        "29": 58.23,
+        "30": 56.146,
+        "31": 56.48,
+        "32": 53.3059375,
+        "33": 51.55151515,
+        "34": 49.97264706,
+        "35": 48.51342857,
+        "36": 46.525,
+        "37": 46.06621622,
+        "38": 43.74315789,
+        "39": 42.97435897,
+        "40": 41.5595,
+        "41": 40.44609756,
+        "42": 39.31904762,
+        "43": 38.47302326,
+        "44": 37.03886364,
+        "45": 36.33777778,
+        "46": 35.40717391,
+        "47": 34.83446809,
+        "48": 33.68666667
+      }
+    },
+    "ub:hbm": {
+      "per_core_gbps": {
+        "1": 188.46,
+        "2": 210.53,
+        "3": 117.2733333,
+        "4": 130.295,
+        "5": 108.964,
+        "6": 119.54,
+        "7": 117.280446425,
+        "8": 115.02089285,
+        "9": 112.761339275,
+        "10": 110.5017857,
+        "11": 108.242232125,
+        "12": 105.98267855,
+        "13": 103.723124975,
+        "14": 101.4635714,
+        "15": 100.0593333,
+        "16": 100.373125,
+        "17": 96.81470588,
+        "18": 98.78555556,
+        "19": 90.44578947,
+        "20": 88.896,
+        "21": 83.38571429,
+        "22": 83.77727273,
+        "23": 77.92608696,
+        "24": 76.65166667,
+        "25": 71.0792,
+        "26": 70.58615385,
+        "27": 66.58407407,
+        "28": 66.42357143,
+        "29": 61.56655172,
+        "30": 59.854,
+        "31": 56.1083871,
+        "32": 55.9315625,
+        "33": 53.0,
+        "34": 51.53,
+        "35": 49.45828571,
+        "36": 48.11111111,
+        "37": 46.14540541,
+        "38": 45.26947368,
+        "39": 43.51512821,
+        "40": 42.56075,
+        "41": 40.9797561,
+        "42": 40.19857143,
+        "43": 38.46488372,
+        "44": 38.07454545,
+        "45": 36.684,
+        "46": 36.17608696,
+        "47": 34.70893617,
+        "48": 34.34291667
+      }
+    },
+    "hbm:l1": {
+      "bandwidth_gbps": 135
+    },
+    "hbm:l2": {
+      "bandwidth_gbps": 33.68666667
+    },
+    "l2:hbm": {
+      "bandwidth_gbps": 34.34291667
+    },
+    "l2:ub": {
+      "bandwidth_gbps": 137
+    },
+    "ub:l2": {
+      "bandwidth_gbps": 93
+    },
+    "l2:l1": {
+      "bandwidth_gbps": 221
+    },
+    "l1:l2": {
+      "bandwidth_gbps": 221
+    },
+    "l1:l0a": {
+      "bandwidth_gbps": 441
+    },
+    "l1:l0b": {
+      "bandwidth_gbps": 220.5
+    },
+    "hbm:l0b": {
+      "bandwidth_gbps": 104.5
+    },
+    "l0c:hbm": {
+      "bandwidth_gbps": 70
+    },
+    "l0c:l2": {
+      "bandwidth_gbps": 70
+    },
+    "l0c:l1": {
+      "bandwidth_gbps": 70
+    },
+    "hbm:l2_agg": {
+      "bandwidth_gbps": 1638.4
+    }
+  },
+
+  "vec_cycle_tables": {
+    "description": "Per-(intrinsic,dtype) vector cycle triplets {compute,head,interval}, migrated from tilesim vec_cycle_910B1.csv. dtype keys fp16 (covers fp16/bf16) and fp32. cycles = compute * repeats + startup, repeats = ceil(numElems*elemBytes/256).",
+    "VADD": {
+      "fp16": {
+        "compute": 2,
+        "head": 13,
+        "interval": 18
+      },
+      "fp32": {
+        "compute": 2,
+        "head": 13,
+        "interval": 18
+      }
+    },
+    "VSUB": {
+      "fp16": {
+        "compute": 2,
+        "head": 13,
+        "interval": 18
+      },
+      "fp32": {
+        "compute": 2,
+        "head": 13,
+        "interval": 18
+      }
+    },
+    "VMUL": {
+      "fp16": {
+        "compute": 2,
+        "head": 13,
+        "interval": 19
+      },
+      "fp32": {
+        "compute": 2,
+        "head": 13,
+        "interval": 19
+      }
+    },
+    "VDIV": {
+      "fp16": {
+        "compute": 8,
+        "head": 13,
+        "interval": 25
+      },
+      "fp32": {
+        "compute": 4,
+        "head": 13,
+        "interval": 25
+      }
+    },
+    "VMAX": {
+      "fp16": {
+        "compute": 2,
+        "head": 14,
+        "interval": 16
+      },
+      "fp32": {
+        "compute": 2,
+        "head": 14,
+        "interval": 16
+      }
+    },
+    "VMIN": {
+      "fp16": {
+        "compute": 2,
+        "head": 14,
+        "interval": 16
+      },
+      "fp32": {
+        "compute": 2,
+        "head": 14,
+        "interval": 16
+      }
+    },
+    "VEXP": {
+      "fp16": {
+        "compute": 4,
+        "head": 13,
+        "interval": 24
+      },
+      "fp32": {
+        "compute": 2,
+        "head": 13,
+        "interval": 24
+      }
+    },
+    "VSQRT": {
+      "fp16": {
+        "compute": 2,
+        "head": 14,
+        "interval": 25
+      },
+      "fp32": {
+        "compute": 2,
+        "head": 14,
+        "interval": 25
+      }
+    },
+    "VABS": {
+      "fp16": {
+        "compute": 1,
+        "head": 13,
+        "interval": 16
+      },
+      "fp32": {
+        "compute": 1,
+        "head": 14,
+        "interval": 16
+      }
+    },
+    "RELU": {
+      "fp16": {
+        "compute": 1,
+        "head": 14,
+        "interval": 16
+      },
+      "fp32": {
+        "compute": 1,
+        "head": 14,
+        "interval": 16
+      }
+    },
+    "LOG": {
+      "fp16": {
+        "compute": 2,
+        "head": 26,
+        "interval": 14
+      },
+      "fp32": {
+        "compute": 2,
+        "head": 26,
+        "interval": 14
+      }
+    },
+    "VSEL": {
+      "fp16": {
+        "compute": 2,
+        "head": 13,
+        "interval": 13
+      },
+      "fp32": {
+        "compute": 2,
+        "head": 13,
+        "interval": 14
+      }
+    },
+    "VBRCB": {
+      "fp16": {
+        "compute": 0,
+        "head": 0,
+        "interval": 18
+      },
+      "fp32": {
+        "compute": 0,
+        "head": 0,
+        "interval": 18
+      }
+    },
+    "VCMPV_NE": {
+      "fp16": {
+        "compute": 2,
+        "head": 14,
+        "interval": 22
+      },
+      "fp32": {
+        "compute": 2,
+        "head": 14,
+        "interval": 22
+      }
+    },
+    "VCMPV_GE": {
+      "fp16": {
+        "compute": 2,
+        "head": 14,
+        "interval": 22
+      },
+      "fp32": {
+        "compute": 2,
+        "head": 14,
+        "interval": 22
+      }
+    },
+    "CMPV_EQ": {
+      "fp16": {
+        "compute": 2,
+        "head": 13,
+        "interval": 22
+      },
+      "fp32": {
+        "compute": 2,
+        "head": 13,
+        "interval": 22
+      }
+    },
+    "VCGADD": {
+      "fp32": {
+        "compute": 1,
+        "head": 14,
+        "interval": 24
+      }
+    },
+    "VCGMAX": {
+      "fp32": {
+        "compute": 1,
+        "head": 14,
+        "interval": 17
+      }
+    },
+    "VCGMIN": {
+      "fp32": {
+        "compute": 1,
+        "head": 14,
+        "interval": 17
+      }
+    },
+    "VREDUCEV2": {
+      "fp32": {
+        "compute": 14,
+        "head": 14,
+        "interval": 20
+      }
+    },
+    "VCOPY": {
+      "fp16": {
+        "compute": 1,
+        "head": 11,
+        "interval": 13
+      },
+      "fp32": {
+        "compute": 1,
+        "head": 11,
+        "interval": 13
+      }
+    },
+    "CONV_F322F16": {
+      "fp32": {
+        "compute": 1,
+        "head": 16,
+        "interval": 14
+      }
+    },
+    "CONV_F162F32": {
+      "fp16": {
+        "compute": 2,
+        "head": 13,
+        "interval": 15
+      }
+    },
+    "CONV_F322BF16": {
+      "fp32": {
+        "compute": 1,
+        "head": 14,
+        "interval": 16
+      }
+    },
+    "CONV_BF162F32": {
+      "fp16": {
+        "compute": 2,
+        "head": 14,
+        "interval": 18
+      }
+    }
   }
 }

--- a/third_party/ascend/costmodel/include/AscendModel/Analysis/HardwareConfig.h
+++ b/third_party/ascend/costmodel/include/AscendModel/Analysis/HardwareConfig.h
@@ -11,6 +11,7 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/JSON.h"
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
@@ -106,6 +107,56 @@ struct DataMover {
 };
 
 //===----------------------------------------------------------------------===//
+// tilesim-style micro-architecture tables (migrated from tilesim 910B1)
+//===----------------------------------------------------------------------===//
+
+/// One row of the per-(intrinsic, dtype) vector instruction cycle table.
+/// Mirrors tilesim VecIntrinsics: computing/head/interval cycles per repeat.
+struct VecCycleEntry {
+  int compute = 0;
+  int head = 0;
+  int interval = 0;
+};
+
+/// Small-packet bandwidth fitting coefficients (tilesim pkt_param).
+/// Applied when the transfer packet size is below ``thresholdBytes``.
+struct SmallPacketCoeffs {
+  bool enabled = false;
+  int thresholdBytes = 256;
+  // Bucket selection mirrors tilesim: <64B -> "64B", <128B -> "128B",
+  // <256B -> "256B". Each bucket has (a, b) fitting coefficients.
+  double a64 = 0, b64 = 0;
+  double a128 = 0, b128 = 0;
+  double a256 = 0, b256 = 0;
+};
+
+/// A bandwidth entry keyed by "src:dst" memory spaces.
+/// Either core-independent (singleGbps) or per-core (degrades as more cores
+/// contend for the same off-chip port, e.g. GM<->UB on 910B).
+struct BandwidthTable {
+  bool hasPerCore = false;
+  double singleGbps = 0.0;           // core-independent bandwidth (GB/s)
+  std::map<int, double> perCoreGbps; // core_num -> GB/s (1..N)
+  SmallPacketCoeffs smallPacket;
+};
+
+/// Cube (GEMM) micro-architecture parameters migrated from tilesim
+/// (cube_throughput, cube_repeat_cycles, L0 tile limit for best_k0).
+struct CubeModelConfig {
+  // basic throughput per repeat: [basicM, basicK, basicN].
+  // tilesim stores cube_throughput as [16, 32, 16]; the K value is a
+  // numerator divided by the element byte size, i.e. basicK = 32/elemBytes
+  // (fp16->16, fp32->8, int8->32), which equals the fractal K dimension.
+  int basicM = 16;
+  int basicKNumerator = 32; // basicK = basicKNumerator / (elemBytes)
+  int basicN = 16;
+  // repeat cycles per dtype key ("fp32","fp16","bf16","int8")
+  llvm::StringMap<int> repeatCycles;
+  // L0 tile footprint limit (bytes) controlling best_k0 selection.
+  int l0TileLimitKb = 32;
+};
+
+//===----------------------------------------------------------------------===//
 // Pipeline Stage
 //===----------------------------------------------------------------------===//
 
@@ -118,6 +169,15 @@ struct PipelinePath {
 //===----------------------------------------------------------------------===//
 // HardwareConfig
 //===----------------------------------------------------------------------===//
+
+/// Result of a bandwidth lookup, mirroring tilesim ``lookup_bw``.
+/// ``bwGBs`` is the per-(src,dst,corenum,pkt) bandwidth in GB/s using the
+/// tilesim GiB convention (1 GB = 1024^3 B). ``isSmallPacket`` records
+/// whether the small-packet fitting branch was taken.
+struct BandwidthEntry {
+  double bwGBs = 0.0;
+  bool isSmallPacket = false;
+};
 
 class HardwareConfig {
 public:
@@ -215,6 +275,55 @@ public:
   int64_t estimateMemoryCyclesWithLatency(llvm::StringRef space,
                                           int64_t bytes) const;
 
+  //===--------------------------------------------------------------------===//
+  // tilesim-migrated micro-architecture queries (root cause ①/②)
+  //===--------------------------------------------------------------------===//
+
+  /// Look up the per-(src,dst,corenum,pkt) bandwidth in GB/s, mirroring
+  /// tilesim ``ArcConfig.lookup_bw``. ``coreNum<=0`` falls back to the
+  /// hardware default active core count (see ``getActiveBandwidthCores``).
+  /// ``pktBytes>0`` enables the small-packet fitting branch when configured.
+  /// Unknown (src,dst) pairs fall back to the aggregate HBM bandwidth so the
+  /// estimate degrades gracefully instead of failing.
+  BandwidthEntry lookupBandwidth(llvm::StringRef src, llvm::StringRef dst,
+                                 int coreNum, int64_t pktBytes) const;
+
+  /// Look up the per-(intrinsic,dtype) vector cycle triplet
+  /// {compute, head, interval}, mirroring tilesim ``lookup_vec_cycle``.
+  /// ``elementBits`` selects the dtype bucket; unknown (intrinsic,dtype)
+  /// falls back to fp32 then to a sensible per-intrinsic default.
+  VecCycleEntry lookupVecCycle(llvm::StringRef intrinsic,
+                               int elementBits) const;
+
+  /// Estimate transfer cycles for moving ``bytes`` from ``src`` to ``dst``
+  /// across ``coreNum`` concurrent cores, using the tilesim GiB bandwidth
+  /// convention and clock frequency. Includes small-packet fitting.
+  int64_t estimateTransferCycles(llvm::StringRef src, llvm::StringRef dst,
+                                 int64_t bytes, int coreNum) const;
+
+  /// Default number of concurrent cores used for bandwidth degradation of
+  /// vector transfers (GM<->UB). Defaults to the 910B1 saturation point (48).
+  int getActiveBandwidthCores() const { return activeBandwidthCores; }
+  void setActiveBandwidthCores(int cores) { activeBandwidthCores = cores; }
+
+  /// Whether small-packet bandwidth fitting is enabled (tilesim
+  /// ``enable_small_package``). Defaults to false to match tilesim.
+  bool getEnableSmallPacketBw() const { return enableSmallPacketBw; }
+  void setEnableSmallPacketBw(bool v) { enableSmallPacketBw = v; }
+
+  /// Whether two hardware units (by costmodel name, e.g. "vec_mte2"/"mte3")
+  /// are mutex partners: they share a physical pipeline and cannot execute in
+  /// parallel (tilesim ``MutexComponents`` / ``pipe_exclusive_config``). On
+  /// 910B the AIV MTE2 (vector load) and MTE3 (vector store) share one
+  /// pipeline.
+  bool areMutexUnits(llvm::StringRef a, llvm::StringRef b) const;
+
+  // Cube (GEMM) micro-architecture: migrated from tilesim cube_config.
+  void getCubeModelThroughput(int elementBits, int &basicM, int &basicK,
+                              int &basicN) const;
+  int getCubeModelRepeatCycles(int elementBits) const;
+  int getCubeModelL0TileLimitBytes() const;
+
   // Pipeline info
   const PipelinePath *getPipelinePath(llvm::StringRef name) const;
   bool canRunInParallel(llvm::StringRef path1, llvm::StringRef path2) const;
@@ -226,6 +335,10 @@ public:
 
 private:
   bool parseJSON(const llvm::json::Value &json, std::string &error);
+
+  /// Populate the tilesim-migrated tables with 910B1 measured values
+  /// (hardcoded-fallback path; JSON is authoritative in production).
+  void populateTilesimDefaults910B();
 
   std::string name;
   std::string vendor;
@@ -241,6 +354,26 @@ private:
 
   // Parallelism info
   llvm::StringMap<bool> parallelismFlags;
+
+  // tilesim-migrated micro-architecture tables.
+  // Bandwidth keyed by "src:dst" (costmodel space names: hbm/l2/l1/l0a/l0b/
+  // l0c/ub). Vector instruction cycles keyed by intrinsic -> dtype -> entry.
+  llvm::StringMap<BandwidthTable> bandwidthTables;
+  llvm::StringMap<llvm::StringMap<VecCycleEntry>> vecCycleTables;
+  CubeModelConfig cubeModel;
+  int activeBandwidthCores = 48; // 910B1 vec_core_num saturation point
+  bool enableSmallPacketBw = false;
+  // Global small-packet coefficients (tilesim pkt_param): a single (a,b) set
+  // per size bucket applied to ANY mover lookup when enableSmallPacketBw is on
+  // and the mover's own table has no per-table small_packet entry. tilesim
+  // keeps one global pkt_param dict on ArcConfig (910B1.yaml); per-table
+  // overrides it.
+  SmallPacketCoeffs globalSmallPacket;
+  bool hasGlobalSmallPacket = false;
+  // Mutex unit groups (tilesim MutexComponents): each group is a clique of
+  // unit-name strings that share a pipeline and cannot run in parallel.
+  // Default 910B: {"vec_mte2", "mte3"} (AIV MTE2<->MTE3).
+  std::vector<std::vector<std::string>> mutexGroups;
 };
 
 //===----------------------------------------------------------------------===//

--- a/third_party/ascend/costmodel/include/AscendModel/IR/AscendModelInterfaces.td
+++ b/third_party/ascend/costmodel/include/AscendModel/IR/AscendModelInterfaces.td
@@ -85,6 +85,37 @@ def EstimateCyclesOpInterface : OpInterface<"EstimateCyclesOpInterface"> {
       /*args=*/(ins),
       /*methodBody=*/"",
       /*defaultImplementation=*/"return 1;"
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Get the source memory space for a transfer operation, used to select
+        the per-(src,dst,corenum) bandwidth (tilesim migration, root cause 1).
+        Transfer ops override this from their optional ``src_space`` attribute;
+        the default ("hbm") preserves legacy behaviour when absent. Named
+        ``getSrcMemSpace`` (not ``getSrcSpace``) to avoid colliding with the
+        MLIR auto-generated ``StrAttr`` value accessor ``getSrcSpace()``.
+      }],
+      /*retTy=*/"llvm::StringRef",
+      /*methodName=*/"getSrcMemSpace",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return "hbm";
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Get the destination memory space for a transfer operation.
+        Transfer ops override this; default "ub" preserves legacy behaviour.
+        Named ``getDstMemSpace`` to avoid the ``getDstSpace()`` attr collision.
+      }],
+      /*retTy=*/"llvm::StringRef",
+      /*methodName=*/"getDstMemSpace",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return "ub";
+      }]
     >
   ];
 

--- a/third_party/ascend/costmodel/include/AscendModel/IR/AscendModelOps.td
+++ b/third_party/ascend/costmodel/include/AscendModel/IR/AscendModelOps.td
@@ -45,15 +45,19 @@ def Ascend_MatmulOp : AscendModel_Op<"matmul", [Pure, DeclareOpInterfaceMethods<
 // Memory Transfer Operations
 //===----------------------------------------------------------------------===//
 
-def Ascend_CubeLoadOp : AscendModel_Op<"cube_load", [DeclareOpInterfaceMethods<EstimateCyclesOpInterface, ["getTransferBytes"]>]> {
+def Ascend_CubeLoadOp : AscendModel_Op<"cube_load", [DeclareOpInterfaceMethods<EstimateCyclesOpInterface, ["getTransferBytes", "getSrcMemSpace", "getDstMemSpace"]>]> {
   let summary = "Load data for Cube Core via MTE2";
   let description = [{
     Loads tensor data from memory to Cube Core's local buffer via MTE2.
+    ``src_space``/``dst_space`` select the per-(src,dst,corenum) bandwidth
+    (tilesim migration). Defaults: hbm -> l1.
   }];
 
   let arguments = (ins
     AnyType:$source,
     I64Attr:$bytes,
+    OptionalAttr<StrAttr>:$src_space,
+    OptionalAttr<StrAttr>:$dst_space,
     OptionalAttr<I64Attr>:$estimated_cycles,
     OptionalAttr<I64Attr>:$op_id
   );
@@ -65,15 +69,19 @@ def Ascend_CubeLoadOp : AscendModel_Op<"cube_load", [DeclareOpInterfaceMethods<E
   }];
 }
 
-def Ascend_CubeStoreOp : AscendModel_Op<"cube_store", [DeclareOpInterfaceMethods<EstimateCyclesOpInterface, ["getTransferBytes"]>]> {
+def Ascend_CubeStoreOp : AscendModel_Op<"cube_store", [DeclareOpInterfaceMethods<EstimateCyclesOpInterface, ["getTransferBytes", "getSrcMemSpace", "getDstMemSpace"]>]> {
   let summary = "Store Cube Core result via FixPipe";
   let description = [{
     Stores Cube Core computation results to memory via FixPipe.
+    ``src_space``/``dst_space`` select the bandwidth (tilesim migration).
+    Defaults: l0c -> hbm.
   }];
 
   let arguments = (ins
     AnyType:$data,
     I64Attr:$bytes,
+    OptionalAttr<StrAttr>:$src_space,
+    OptionalAttr<StrAttr>:$dst_space,
     OptionalAttr<I64Attr>:$estimated_cycles,
     OptionalAttr<I64Attr>:$op_id
   );
@@ -85,15 +93,19 @@ def Ascend_CubeStoreOp : AscendModel_Op<"cube_store", [DeclareOpInterfaceMethods
   }];
 }
 
-def Ascend_VectorLoadOp : AscendModel_Op<"vector_load", [DeclareOpInterfaceMethods<EstimateCyclesOpInterface, ["getTransferBytes"]>]> {
+def Ascend_VectorLoadOp : AscendModel_Op<"vector_load", [DeclareOpInterfaceMethods<EstimateCyclesOpInterface, ["getTransferBytes", "getSrcMemSpace", "getDstMemSpace"]>]> {
   let summary = "Load data for Vector Core via VecMTE2";
   let description = [{
     Loads tensor data for Vector Core operations via dedicated MTE2.
+    ``src_space``/``dst_space`` select the per-(src,dst,corenum) bandwidth
+    (tilesim migration). Defaults: hbm -> ub.
   }];
 
   let arguments = (ins
     AnyType:$source,
     I64Attr:$bytes,
+    OptionalAttr<StrAttr>:$src_space,
+    OptionalAttr<StrAttr>:$dst_space,
     OptionalAttr<I64Attr>:$estimated_cycles,
     OptionalAttr<I64Attr>:$op_id
   );
@@ -105,15 +117,19 @@ def Ascend_VectorLoadOp : AscendModel_Op<"vector_load", [DeclareOpInterfaceMetho
   }];
 }
 
-def Ascend_VectorStoreOp : AscendModel_Op<"vector_store", [DeclareOpInterfaceMethods<EstimateCyclesOpInterface, ["getTransferBytes"]>]> {
+def Ascend_VectorStoreOp : AscendModel_Op<"vector_store", [DeclareOpInterfaceMethods<EstimateCyclesOpInterface, ["getTransferBytes", "getSrcMemSpace", "getDstMemSpace"]>]> {
   let summary = "Store Vector Core result via MTE3";
   let description = [{
     Stores Vector Core computation results to memory via MTE3.
+    ``src_space``/``dst_space`` select the bandwidth (tilesim migration).
+    Defaults: ub -> hbm.
   }];
 
   let arguments = (ins
     AnyType:$data,
     I64Attr:$bytes,
+    OptionalAttr<StrAttr>:$src_space,
+    OptionalAttr<StrAttr>:$dst_space,
     OptionalAttr<I64Attr>:$estimated_cycles,
     OptionalAttr<I64Attr>:$op_id
   );

--- a/third_party/ascend/costmodel/lib/AscendModel/Analysis/HardwareConfig.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Analysis/HardwareConfig.cpp
@@ -152,6 +152,157 @@ std::unique_ptr<HardwareConfig> HardwareConfig::getDefault910B() {
   return createHardcodedDefault910B();
 }
 
+/// Populate the tilesim-migrated micro-architecture tables with the 910B1
+/// measured values (bandwidth_910B1.csv / vec_cycle_910B1.csv / 910B1.yaml).
+/// Used by the hardcoded fallback so the migrated model is available even
+/// when the JSON config file cannot be located. The JSON config is the
+/// authoritative source in production; this mirrors the same numbers.
+void HardwareConfig::populateTilesimDefaults910B() {
+  // ---- Bandwidth tables (GB/s) ----
+  // Core-independent movers.
+  auto addScalar = [&](llvm::StringRef key, double gbps) {
+    BandwidthTable t;
+    t.singleGbps = gbps;
+    bandwidthTables[key.str()] = std::move(t);
+  };
+  addScalar("hbm:l2", 33.68666667); // GM->SHM(L2)
+  addScalar("l2:hbm", 34.34291667); // SHM->GM
+  addScalar("l2:ub", 137.0);        // L2->UB
+  addScalar("ub:l2", 93.0);         // UB->L2
+  addScalar("hbm:l1", 135.0);       // GM->L1 (cube MTE2)
+  addScalar("l2:l1", 221.0);        // L2->L1
+  addScalar("l1:l2", 221.0);        // L1->L2
+  addScalar("l1:l0a", 441.0);       // MTE1 A
+  addScalar("l1:l0b", 220.5);       // MTE1 B
+  addScalar("hbm:l0b", 104.5);
+  addScalar("l0c:hbm", 70.0); // FixPipe
+  addScalar("l0c:l2", 70.0);
+  addScalar("l0c:l1", 70.0);
+  addScalar("hbm:l2_agg", 1638.4); // aggregate HBM bandwidth
+
+  // GM->UB per-core (vector MTE2): bandwidth degrades as cores contend.
+  {
+    static const double gmUb[] = {
+        100.9,       64.5,        88.29666667, 77.945,      84.852,
+        80.82666667, 73.31571429, 68.93375,    73.22888889, 67.586,
+        71.13727273, 68.08833333, 69.14615385, 72.60785714, 74.99866667,
+        73.26375,    72.05058824, 70.66833333, 73.27,       68.7705,
+        68.72190476, 66.07909091, 66.33826087, 65.08041667, 65.3448,
+        62.61884615, 62.15148148, 58.95964286, 58.23,       56.146,
+        56.48,       53.3059375,  51.55151515, 49.97264706, 48.51342857,
+        46.525,      46.06621622, 43.74315789, 42.97435897, 41.5595,
+        40.44609756, 39.31904762, 38.47302326, 37.03886364, 36.33777778,
+        35.40717391, 34.83446809, 33.68666667};
+    BandwidthTable t;
+    t.hasPerCore = true;
+    for (int c = 1; c <= 48; ++c)
+      t.perCoreGbps[c] = gmUb[c - 1];
+    t.singleGbps = gmUb[47];
+    bandwidthTables["hbm:ub"] = std::move(t);
+  }
+  // UB->GM per-core (MTE3).
+  {
+    static const double ubGm[] = {
+        188.46,        210.53,        117.2733333,   130.295,       108.964,
+        119.54,        117.280446425, 115.02089285,  112.761339275, 110.5017857,
+        108.242232125, 105.98267855,  103.723124975, 101.4635714,   100.0593333,
+        100.373125,    96.81470588,   98.78555556,   90.44578947,   88.896,
+        83.38571429,   83.77727273,   77.92608696,   76.65166667,   71.0792,
+        70.58615385,   66.58407407,   66.42357143,   61.56655172,   59.854,
+        56.1083871,    55.9315625,    53.0,          51.53,         49.45828571,
+        48.11111111,   46.14540541,   45.26947368,   43.51512821,   42.56075,
+        40.9797561,    40.19857143,   38.46488372,   38.07454545,   36.684,
+        36.17608696,   34.70893617,   34.34291667};
+    BandwidthTable t;
+    t.hasPerCore = true;
+    for (int c = 1; c <= 48; ++c)
+      t.perCoreGbps[c] = ubGm[c - 1];
+    t.singleGbps = ubGm[47];
+    bandwidthTables["ub:hbm"] = std::move(t);
+  }
+
+  // ---- Vector instruction cycle tables (intrinsic -> dtype -> triplet) ----
+  auto addVec = [&](llvm::StringRef inst, int bits, int compute, int head,
+                    int interval) {
+    llvm::StringRef dt = (bits == 32) ? "fp32" : "fp16";
+    vecCycleTables[inst.str()][dt.str()] =
+        VecCycleEntry{compute, head, interval};
+  };
+  // (intrinsic, dtype, computing, head, interval) from vec_cycle_910B1.csv.
+  addVec("VADD", 16, 2, 13, 18);
+  addVec("VADD", 32, 2, 13, 18);
+  addVec("VSUB", 16, 2, 13, 18);
+  addVec("VSUB", 32, 2, 13, 18);
+  addVec("VMUL", 16, 2, 13, 19);
+  addVec("VMUL", 32, 2, 13, 19);
+  addVec("VDIV", 16, 8, 13, 25);
+  addVec("VDIV", 32, 4, 13, 25);
+  addVec("VMAX", 16, 2, 14, 16);
+  addVec("VMAX", 32, 2, 14, 16);
+  addVec("VMIN", 16, 2, 14, 16);
+  addVec("VMIN", 32, 2, 14, 16);
+  addVec("VEXP", 16, 4, 13, 24);
+  addVec("VEXP", 32, 2, 13, 24);
+  addVec("VSQRT", 16, 2, 14, 25);
+  addVec("VSQRT", 32, 2, 14, 25);
+  addVec("VABS", 16, 1, 13, 16);
+  addVec("VABS", 32, 1, 14, 16);
+  addVec("RELU", 16, 1, 14, 16);
+  addVec("RELU", 32, 1, 14, 16);
+  addVec("LOG", 16, 2, 26, 14);
+  addVec("LOG", 32, 2, 26, 14);
+  addVec("VSEL", 16, 2, 13, 13);
+  addVec("VSEL", 32, 2, 13, 14);
+  addVec("VBRCB", 16, 0, 0, 18);
+  addVec("VBRCB", 32, 0, 0, 18);
+  addVec("VCMPV_NE", 16, 2, 14, 22);
+  addVec("VCMPV_NE", 32, 2, 14, 22);
+  addVec("VCMPV_GE", 16, 2, 14, 22);
+  addVec("VCMPV_GE", 32, 2, 14, 22);
+  addVec("CMPV_EQ", 16, 2, 13, 22);
+  addVec("CMPV_EQ", 32, 2, 13, 22);
+  addVec("VCGADD", 32, 1, 14, 24);
+  addVec("VCGMAX", 32, 1, 14, 17);
+  addVec("VCGMIN", 32, 1, 14, 17);
+  addVec("VREDUCEV2", 32, 14, 14, 20);
+  addVec("VCOPY", 16, 1, 11, 13);
+  addVec("VCOPY", 32, 1, 11, 13);
+  addVec("CONV_F322F16", 32, 1, 16, 14);
+  addVec("CONV_F162F32", 16, 2, 13, 15);
+  addVec("CONV_F322BF16", 32, 1, 14, 16);
+  addVec("CONV_BF162F32", 16, 2, 14, 18);
+
+  // ---- Cube (GEMM) model ----
+  cubeModel.basicM = 16;
+  cubeModel.basicKNumerator = 32;
+  cubeModel.basicN = 16;
+  cubeModel.l0TileLimitKb = 32;
+  cubeModel.repeatCycles["fp32"] = 2;
+  cubeModel.repeatCycles["fp16"] = 1;
+  cubeModel.repeatCycles["bf16"] = 1;
+  cubeModel.repeatCycles["int8"] = 1;
+
+  activeBandwidthCores = 48;
+  // tilesim's engineering by-rule-pipeline path (eval_by_rule_pipe.py, the
+  // "main simulation loop" this costmodel is aligned to) sets
+  // enable_small_pkt_bw=True; the base config default (False) is not the
+  // accuracy target. Global pkt_param mirrors tilesim 910B1.yaml.
+  enableSmallPacketBw = true;
+  globalSmallPacket.enabled = true;
+  globalSmallPacket.thresholdBytes = 256;
+  globalSmallPacket.a64 = 0.295;
+  globalSmallPacket.b64 = 12.061;
+  globalSmallPacket.a128 = 0.272;
+  globalSmallPacket.b128 = 16.820;
+  globalSmallPacket.a256 = 0.322;
+  globalSmallPacket.b256 = 24.004;
+  hasGlobalSmallPacket = true;
+  // Mutex unit cliques (tilesim MutexComponents / pipe_exclusive_config).
+  // 910B: AIV MTE2 (vec load) and MTE3 (vec store) share one pipeline.
+  mutexGroups.clear();
+  mutexGroups.push_back({"vec_mte2", "mte3"});
+}
+
 /// Hardcoded fallback configuration (used when JSON file not found)
 std::unique_ptr<HardwareConfig> HardwareConfig::createHardcodedDefault910B() {
   auto config = std::make_unique<HardwareConfig>();
@@ -388,6 +539,9 @@ std::unique_ptr<HardwareConfig> HardwareConfig::createHardcodedDefault910B() {
   config->parallelismFlags["cube_and_vector"] = true;
   config->parallelismFlags["cube_mte2_and_fixpipe"] = true;
   config->parallelismFlags["vector_mte2_and_mte3"] = true;
+
+  // tilesim-migrated micro-architecture tables (bandwidth/vec/cube).
+  config->populateTilesimDefaults910B();
 
   return config;
 }
@@ -650,6 +804,150 @@ bool HardwareConfig::parseJSON(const llvm::json::Value &json,
       readInt("sqrt", "vsqrt");
       readInt("rsqrt", "vrsqrt");
       readInt("div", "vdiv");
+    }
+  }
+
+  //===------------------------------------------------------------------===//
+  // tilesim-migrated micro-architecture tables (root cause ①/②)
+  // All fields are optional; absence leaves the (less accurate) legacy
+  // estimation path intact, preserving backward compatibility.
+  //===------------------------------------------------------------------===//
+
+  // Bandwidth tables keyed by "src:dst". Supports core-independent
+  // ("bandwidth_gbps") and per-core ("per_core_gbps": {coreNum: gbps})
+  // forms, plus optional small-packet fitting coefficients.
+  if (const auto *bwTables = root->getObject("bandwidth_tables")) {
+    for (const auto &kv : *bwTables) {
+      const auto *obj = kv.second.getAsObject();
+      if (!obj)
+        continue;
+      BandwidthTable tbl;
+      if (auto gbps = obj->getNumber("bandwidth_gbps")) {
+        tbl.singleGbps = *gbps;
+      } else if (const auto *perCore = obj->getObject("per_core_gbps")) {
+        tbl.hasPerCore = true;
+        for (const auto &pkv : *perCore) {
+          if (auto v = pkv.second.getAsNumber()) {
+            int cores = std::stoi(pkv.first.str());
+            tbl.perCoreGbps[cores] = *v;
+          }
+        }
+        // singleGbps fallback = the largest (most-saturated) core entry.
+        if (!tbl.perCoreGbps.empty())
+          tbl.singleGbps = tbl.perCoreGbps.rbegin()->second;
+      }
+      if (const auto *sp = obj->getObject("small_packet")) {
+        tbl.smallPacket.enabled = true;
+        if (auto t = sp->getInteger("threshold_bytes"))
+          tbl.smallPacket.thresholdBytes = *t;
+        auto readPair = [&](llvm::StringRef key, double &a, double &b) {
+          if (const auto *arr = sp->getArray(key); arr && arr->size() >= 2) {
+            if (auto va = (*arr)[0].getAsNumber())
+              a = *va;
+            if (auto vb = (*arr)[1].getAsNumber())
+              b = *vb;
+          }
+        };
+        readPair("64B", tbl.smallPacket.a64, tbl.smallPacket.b64);
+        readPair("128B", tbl.smallPacket.a128, tbl.smallPacket.b128);
+        readPair("256B", tbl.smallPacket.a256, tbl.smallPacket.b256);
+      }
+      bandwidthTables[kv.first.str()] = std::move(tbl);
+    }
+  }
+
+  // Vector instruction cycle tables: intrinsic -> dtype ->
+  // {compute,head,interval}.
+  if (const auto *vecTables = root->getObject("vec_cycle_tables")) {
+    for (const auto &kv : *vecTables) {
+      const auto *byDtype = kv.second.getAsObject();
+      if (!byDtype)
+        continue;
+      llvm::StringMap<VecCycleEntry> inner;
+      for (const auto &dkv : *byDtype) {
+        const auto *entry = dkv.second.getAsObject();
+        if (!entry)
+          continue;
+        VecCycleEntry e;
+        if (auto v = entry->getInteger("compute"))
+          e.compute = *v;
+        if (auto v = entry->getInteger("head"))
+          e.head = *v;
+        if (auto v = entry->getInteger("interval"))
+          e.interval = *v;
+        inner[dkv.first.str()] = e;
+      }
+      vecCycleTables[kv.first.str()] = std::move(inner);
+    }
+  }
+
+  // Cube (GEMM) micro-architecture: throughput [m,k,n], repeat cycles, L0
+  // limit.
+  if (const auto *cube = root->getObject("cube_model")) {
+    if (const auto *arr = cube->getArray("throughput");
+        arr && arr->size() >= 3) {
+      if (auto v = (*arr)[0].getAsInteger())
+        cubeModel.basicM = *v;
+      if (auto v = (*arr)[1].getAsInteger())
+        cubeModel.basicKNumerator = *v;
+      if (auto v = (*arr)[2].getAsInteger())
+        cubeModel.basicN = *v;
+    }
+    if (const auto *rc = cube->getObject("repeat_cycles")) {
+      for (const auto &rkv : *rc) {
+        if (auto v = rkv.second.getAsInteger())
+          cubeModel.repeatCycles[rkv.first.str()] = static_cast<int>(*v);
+      }
+    }
+    if (auto v = cube->getInteger("l0_tile_limit_kb"))
+      cubeModel.l0TileLimitKb = *v;
+  }
+
+  // tilesim tuning knobs.
+  if (const auto *ts = root->getObject("tilesim")) {
+    if (auto v = ts->getInteger("active_bandwidth_cores"))
+      activeBandwidthCores = *v;
+    if (auto v = ts->getBoolean("enable_small_packet_bw"))
+      enableSmallPacketBw = *v;
+    // Global pkt_param (tilesim 910B1.yaml pkt_param): one (a,b) set per size
+    // bucket applied to every mover. Sits behind any per-table small_packet
+    // entry parsed above from bandwidth_tables.
+    if (const auto *sp = ts->getObject("small_packet")) {
+      SmallPacketCoeffs c;
+      c.enabled = true;
+      if (auto t = sp->getInteger("threshold_bytes"))
+        c.thresholdBytes = *t;
+      auto readPair = [&](llvm::StringRef key, double &a, double &b) {
+        if (const auto *arr = sp->getArray(key); arr && arr->size() >= 2) {
+          if (auto va = (*arr)[0].getAsNumber())
+            a = *va;
+          if (auto vb = (*arr)[1].getAsNumber())
+            b = *vb;
+        }
+      };
+      readPair("64B", c.a64, c.b64);
+      readPair("128B", c.a128, c.b128);
+      readPair("256B", c.a256, c.b256);
+      globalSmallPacket = c;
+      hasGlobalSmallPacket = true;
+    }
+    // Mutex unit cliques (tilesim MutexComponents): object with a "cliques"
+    // array of unit-name arrays, e.g. {"cliques":[["vec_mte2","mte3"]]}.
+    // Units in a clique share a pipeline and cannot run in parallel.
+    if (const auto *mg = ts->getObject("mutex_groups")) {
+      mutexGroups.clear();
+      if (const auto *cliques = mg->getArray("cliques")) {
+        for (const auto &clique : *cliques) {
+          if (const auto *units = clique.getAsArray()) {
+            std::vector<std::string> group;
+            for (const auto &u : *units)
+              if (auto s = u.getAsString())
+                group.push_back(s->str());
+            if (group.size() >= 2)
+              mutexGroups.push_back(std::move(group));
+          }
+        }
+      }
     }
   }
 
@@ -923,6 +1221,169 @@ int64_t HardwareConfig::estimateMemoryCyclesWithLatency(llvm::StringRef space,
   return std::max<int64_t>(1, mem->latencyCycles +
                                   static_cast<int64_t>(std::ceil(
                                       bytes / mem->bandwidthBytesPerCycle)));
+}
+
+//===----------------------------------------------------------------------===//
+// tilesim-migrated micro-architecture queries (root cause ①/②)
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Map an element bit width to the dtype key used in the migrated tables.
+/// 16-bit types (fp16/bf16) share the FP16 bucket, matching tilesim's CSV.
+llvm::StringRef elementBitsToDtypeKey(int elementBits) {
+  if (elementBits == 8)
+    return "int8";
+  if (elementBits == 32)
+    return "fp32";
+  if (elementBits == 64)
+    return "fp64";
+  return "fp16"; // fp16 / bf16
+}
+
+/// tilesim small-packet bandwidth convention: 1 GB/s == 1073.741824 B/us
+/// (it treats "GB" as GiB when converting the measured GB/s figures).
+constexpr double kBytesPerUsPerGbs =
+    (1024.0 * 1024.0 * 1024.0) / 1e6; // 1073.74...
+} // namespace
+
+BandwidthEntry HardwareConfig::lookupBandwidth(llvm::StringRef src,
+                                               llvm::StringRef dst, int coreNum,
+                                               int64_t pktBytes) const {
+  BandwidthEntry result;
+  std::string key = (src + ":" + dst).str();
+  auto it = bandwidthTables.find(key);
+  if (it != bandwidthTables.end()) {
+    const BandwidthTable &tbl = it->second;
+    double gbps = tbl.singleGbps;
+    if (tbl.hasPerCore && !tbl.perCoreGbps.empty()) {
+      // tilesim selects the exact core-count row; clamp out-of-range counts
+      // to the nearest tabulated value (no interpolation, matching tilesim).
+      int cores = coreNum > 0 ? coreNum : activeBandwidthCores;
+      int minCores = tbl.perCoreGbps.begin()->first;
+      int maxCores = tbl.perCoreGbps.rbegin()->first;
+      if (cores <= minCores) {
+        gbps = tbl.perCoreGbps.begin()->second;
+      } else if (cores >= maxCores) {
+        gbps = tbl.perCoreGbps.rbegin()->second;
+      } else {
+        auto eit = tbl.perCoreGbps.find(cores);
+        gbps = (eit != tbl.perCoreGbps.end())
+                   ? eit->second
+                   : tbl.perCoreGbps.rbegin()->second;
+      }
+    }
+    result.bwGBs = gbps;
+
+    // Small-packet fitting (tilesim pkt_param). tilesim keeps a single global
+    // pkt_param applied to every mover; a per-table small_packet entry
+    // overrides it. Opt-in via enableSmallPacketBw.
+    if (enableSmallPacketBw && pktBytes > 0) {
+      const SmallPacketCoeffs *sp = nullptr;
+      if (tbl.smallPacket.enabled)
+        sp = &tbl.smallPacket;
+      else if (hasGlobalSmallPacket && globalSmallPacket.enabled)
+        sp = &globalSmallPacket;
+      if (sp && pktBytes < sp->thresholdBytes) {
+        double a = 0, b = 0;
+        if (pktBytes < 64) {
+          a = sp->a64;
+          b = sp->b64;
+        } else if (pktBytes < 128) {
+          a = sp->a128;
+          b = sp->b128;
+        } else {
+          a = sp->a256;
+          b = sp->b256;
+        }
+        if (b > 0) {
+          // tilesim: bw[B/us] = b / (a*b + pkt_GB) * 1024^3/1e6
+          double pktGb =
+              static_cast<double>(pktBytes) / (1024.0 * 1024.0 * 1024.0);
+          double bwBus = b / (a * b + pktGb) * kBytesPerUsPerGbs;
+          result.bwGBs = bwBus / kBytesPerUsPerGbs; // back to GB/s
+          result.isSmallPacket = true;
+        }
+      }
+    }
+  } else {
+    // Unknown (src,dst): fall back to aggregate HBM bandwidth so estimates
+    // degrade gracefully instead of returning zero.
+    result.bwGBs = getHBMBandwidthGBs();
+  }
+  return result;
+}
+
+VecCycleEntry HardwareConfig::lookupVecCycle(llvm::StringRef intrinsic,
+                                             int elementBits) const {
+  auto it = vecCycleTables.find(intrinsic);
+  if (it != vecCycleTables.end()) {
+    const auto &byDtype = it->second;
+    llvm::StringRef dt = elementBitsToDtypeKey(elementBits);
+    auto dit = byDtype.find(dt);
+    if (dit != byDtype.end())
+      return dit->second;
+    // tilesim falls back to FP32 then warns; we silently fall back.
+    auto fp32 = byDtype.find("fp32");
+    if (fp32 != byDtype.end())
+      return fp32->second;
+  }
+  return VecCycleEntry{1, 0, 0};
+}
+
+int64_t HardwareConfig::estimateTransferCycles(llvm::StringRef src,
+                                               llvm::StringRef dst,
+                                               int64_t bytes,
+                                               int coreNum) const {
+  BandwidthEntry bw = lookupBandwidth(src, dst, coreNum, bytes);
+  if (bw.bwGBs <= 0)
+    bw.bwGBs = getHBMBandwidthGBs();
+  if (bw.bwGBs <= 0)
+    bw.bwGBs = 1600.0;
+  // Replicate tilesim: latency[us] = bytes / (bw[B/us]); cycles = latency *
+  // clock[MHz].
+  double bwBus = bw.bwGBs * kBytesPerUsPerGbs;
+  double latencyUs = static_cast<double>(bytes) / bwBus;
+  double cycles = latencyUs * (clockFreqGHz * 1000.0);
+  return static_cast<int64_t>(std::ceil(cycles));
+}
+
+void HardwareConfig::getCubeModelThroughput(int elementBits, int &basicM,
+                                            int &basicK, int &basicN) const {
+  basicM = cubeModel.basicM;
+  int elemBytes = (elementBits + 7) / 8;
+  basicK = elemBytes > 0 ? cubeModel.basicKNumerator / elemBytes
+                         : cubeModel.basicKNumerator;
+  basicN = cubeModel.basicN;
+}
+
+int HardwareConfig::getCubeModelRepeatCycles(int elementBits) const {
+  llvm::StringRef dt = elementBitsToDtypeKey(elementBits);
+  auto it = cubeModel.repeatCycles.find(dt);
+  if (it != cubeModel.repeatCycles.end())
+    return it->second;
+  // tilesim: fp32 -> 2, fp16/bf16/int8 -> 1.
+  return (elementBits == 32) ? 2 : 1;
+}
+
+int HardwareConfig::getCubeModelL0TileLimitBytes() const {
+  return cubeModel.l0TileLimitKb * 1024;
+}
+
+bool HardwareConfig::areMutexUnits(llvm::StringRef a, llvm::StringRef b) const {
+  if (a.empty() || b.empty() || a == b)
+    return false;
+  for (const auto &group : mutexGroups) {
+    bool hasA = false, hasB = false;
+    for (const auto &u : group) {
+      if (u == a)
+        hasA = true;
+      if (u == b)
+        hasB = true;
+    }
+    if (hasA && hasB)
+      return true;
+  }
+  return false;
 }
 
 //===----------------------------------------------------------------------===//

--- a/third_party/ascend/costmodel/lib/AscendModel/IR/AscendModelOps.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/IR/AscendModelOps.cpp
@@ -18,6 +18,12 @@
 using namespace mlir;
 using namespace mlir::ascend;
 
+namespace {
+/// tilesim bandwidth convention: 1 GB/s == (1024^3)/1e6 B/us. Must match
+/// HardwareConfig::estimateTransferCycles / lookupBandwidth exactly.
+constexpr double kBytesPerUsPerGbs = (1024.0 * 1024.0 * 1024.0) / 1e6;
+} // namespace
+
 //===----------------------------------------------------------------------===//
 // Helper functions
 //===----------------------------------------------------------------------===//
@@ -78,6 +84,24 @@ static int64_t estimateMemoryCycles(int64_t bytes, const HardwareConfig &config,
   return static_cast<int64_t>(cycles) + startupLatency;
 }
 
+/// tilesim-migrated vector estimate (root cause 1, vector side):
+///   repeats = ceil(numElems * elemBytes / 256B)   (vec_size_single_repeat)
+///   cycles  = compute_cycles(intrinsic, dtype) * repeats + startup
+/// Mirrors tilesim plain_simple_op_based_on_cce. The calibrated
+/// getVectorStartupLatency() is retained as the per-op pipeline startup
+/// anchor; intrinsic compute costs come from the migrated 910B1 table.
+static int64_t estimateVectorFromTable(Type type, llvm::StringRef intrinsic,
+                                       const HardwareConfig &config) {
+  int64_t n = getNumElementsFromType(type);
+  int bits = getElementBitsFromType(type);
+  int elemBytes = (bits + 7) / 8;
+  // 256 B per repeat == 2048 bits / elementBits elements per repeat.
+  int64_t repeats = (n * elemBytes + 255) / 256;
+  VecCycleEntry e = config.lookupVecCycle(intrinsic, bits);
+  int64_t compute = static_cast<int64_t>(e.compute) * repeats;
+  return compute + config.getVectorStartupLatency();
+}
+
 //===----------------------------------------------------------------------===//
 // Include generated definitions
 //===----------------------------------------------------------------------===//
@@ -113,37 +137,83 @@ int64_t EstimateCyclesOpInterface::getNumElements() {
 // MatmulOp Interface Implementation
 //===----------------------------------------------------------------------===//
 
+//===----------------------------------------------------------------------===//
+// MatmulOp Interface Implementation (L1-pipe roofline — root cause 2)
+//===----------------------------------------------------------------------===//
+//
+// Migrated from tilesim plain_gemm_based_on_l1_pipe. Models the Cube core as a
+// real pipeline: the steady-state latency is the max of (L1->L0 input copy) and
+// (cube compute), then the first-tile warmup (pipeline fill) is added on top.
+// Input copy uses per-mover L1->L0A/L0B bandwidth (441/220.5 GB/s) instead of
+// aggregate HBM. HBM->L1 copy is accounted by the separate cube_load op, so it
+// is NOT double-counted here (design 4.2.3 option b).
+//
+//   k0          = best_k0(m, n)            # largest k0 fitting 32KB L0 tiles
+//   copy_time   = m*k*dt/L0A_bw + n*k*dt/L0B_bw
+//   compute     = ceil(m/bm)*ceil(k/bk)*ceil(n/bn) * repeat_cycles[dt] / clock
+//   first_tile  = (m*k0 + k0*n)*dt / bw
+//   latency     = max(copy_time - first_tile, compute) + first_tile
+
 int64_t MatmulOp::estimateCycles(const HardwareConfig &config) {
   int64_t m = getM();
   int64_t n = getN();
   int64_t k = getK();
 
-  // Get element type bit width
   int elemBits = getElementBitsFromType(getLhs().getType());
+  double dtBytes = (elemBits + 7) / 8;
+  double clockMHz = config.getClockFrequencyGHz() * 1000.0;
 
-  // Get fractal dimensions from hardware config based on data type
-  int fracM, fracN, fracK;
-  config.getCubeFractalSize(elemBits, fracM, fracN, fracK);
+  // best_k0: tilesim _calculate_best_k0 — largest k0 whose (m,k0) and (k0,n)
+  // tiles fit the L0 footprint limit (tilesim uses a fixed *2 byte factor).
+  int64_t tileLimit = config.getCubeModelL0TileLimitBytes();
+  auto fits = [&](int64_t k0) {
+    return m * k0 * 2 <= tileLimit && n * k0 * 2 <= tileLimit;
+  };
+  int64_t k0 = 32;
+  if (fits(256))
+    k0 = 256;
+  else if (fits(128))
+    k0 = 128;
+  else if (fits(64))
+    k0 = 64;
 
-  // Calculate number of fractals needed in each dimension
-  // Each fractal computes fracM x fracN x fracK multiply-accumulate
-  int64_t numFracM = (m + fracM - 1) / fracM;
-  int64_t numFracN = (n + fracN - 1) / fracN;
-  int64_t numFracK = (k + fracK - 1) / fracK;
+  int64_t sizeA0 = m * k0 * (int64_t)dtBytes;
+  int64_t sizeB0 = k0 * n * (int64_t)dtBytes;
 
-  // Total number of fractal operations
-  // For a full matmul, we need numFracM * numFracN output tiles,
-  // each requiring numFracK accumulation steps
-  int64_t totalFractals = numFracM * numFracN * numFracK;
+  // L1 -> L0A / L0B copy bandwidth (MTE1), in B/us (tilesim GiB convention).
+  // tilesim cube_op passes the k0-tile sizes (size_a0/size_b0) as pkt_size so
+  // the small-packet fitting can apply to tiny L1->L0 tiles; mirror that here.
+  auto bwBus = [&](llvm::StringRef src, llvm::StringRef dst,
+                   int64_t pktBytes) -> double {
+    BandwidthEntry bw = config.lookupBandwidth(src, dst, 1, pktBytes);
+    double gbps = bw.bwGBs > 0 ? bw.bwGBs : config.getHBMBandwidthGBs();
+    return gbps * kBytesPerUsPerGbs;
+  };
+  double l0aBw = bwBus("l1", "l0a", sizeA0);
+  double l0bBw = bwBus("l1", "l0b", sizeB0);
 
-  // Each fractal operation takes 1 cycle on the Cube Core
-  // (this is the fundamental unit of computation)
-  int64_t computeCycles = totalFractals;
+  double copyTime = (m * k * dtBytes) / l0aBw + (n * k * dtBytes) / l0bBw;
 
-  // Add startup latency
-  computeCycles += config.getCubeStartupLatency();
+  // Cube compute (L1-pipe roofline).
+  int basicM = 16, basicK = 16, basicN = 16;
+  config.getCubeModelThroughput(elemBits, basicM, basicK, basicN);
+  int repeatCycles = config.getCubeModelRepeatCycles(elemBits);
+  auto ceilDiv = [](int64_t a, int64_t b) -> int64_t {
+    return b > 0 ? (a + b - 1) / b : 0;
+  };
+  int64_t repeats =
+      ceilDiv(m, basicM) * ceilDiv(k, basicK) * ceilDiv(n, basicN);
+  double computeTime = static_cast<double>(repeats * repeatCycles) / clockMHz;
 
-  return computeCycles;
+  // First-tile warmup (pipeline fill).
+  double firstTile =
+      static_cast<double>(sizeA0) / l0aBw + static_cast<double>(sizeB0) / l0bBw;
+
+  double latency = std::max(copyTime - firstTile, computeTime) + firstTile;
+  int64_t cycles = static_cast<int64_t>(latency * clockMHz);
+  if (cycles <= 0)
+    cycles = 1;
+  return cycles + config.getCubeStartupLatency();
 }
 
 HWUnit MatmulOp::getHWUnit() { return HWUnit::Cube; }
@@ -153,123 +223,168 @@ int64_t MatmulOp::getFlops() { return 2 * getM() * getN() * getK(); }
 //===----------------------------------------------------------------------===//
 // Memory Operations Interface Implementation
 //===----------------------------------------------------------------------===//
+//
+// Migrated to tilesim per-(src,dst,corenum) bandwidth lookup (root cause 1).
+// Each transfer op carries optional src_space/dst_space attributes (defaulting
+// to the op's natural memory path) so estimateTransferCycles can pick the
+// correct mover bandwidth instead of the aggregate HBM figure.
 
 int64_t CubeLoadOp::estimateCycles(const HardwareConfig &config) {
-  return estimateMemoryCycles(getBytes(), config,
-                              config.getMTE2StartupLatency());
+  return config.estimateTransferCycles(getSrcMemSpace(), getDstMemSpace(),
+                                       getBytes(),
+                                       config.getActiveBandwidthCores()) +
+         config.getMTE2StartupLatency();
+}
+llvm::StringRef CubeLoadOp::getSrcMemSpace() {
+  if (auto a = getSrcSpaceAttr())
+    return a.getValue();
+  return "hbm";
+}
+llvm::StringRef CubeLoadOp::getDstMemSpace() {
+  if (auto a = getDstSpaceAttr())
+    return a.getValue();
+  return "l1";
 }
 HWUnit CubeLoadOp::getHWUnit() { return HWUnit::CubeMTE2; }
 int64_t CubeLoadOp::getTransferBytes() { return getBytes(); }
 
 int64_t CubeStoreOp::estimateCycles(const HardwareConfig &config) {
-  return estimateMemoryCycles(getBytes(), config,
-                              config.getFixPipeStartupLatency());
+  return config.estimateTransferCycles(getSrcMemSpace(), getDstMemSpace(),
+                                       getBytes(),
+                                       config.getActiveBandwidthCores()) +
+         config.getFixPipeStartupLatency();
+}
+llvm::StringRef CubeStoreOp::getSrcMemSpace() {
+  if (auto a = getSrcSpaceAttr())
+    return a.getValue();
+  return "l0c";
+}
+llvm::StringRef CubeStoreOp::getDstMemSpace() {
+  if (auto a = getDstSpaceAttr())
+    return a.getValue();
+  return "hbm";
 }
 HWUnit CubeStoreOp::getHWUnit() { return HWUnit::FixPipe; }
 int64_t CubeStoreOp::getTransferBytes() { return getBytes(); }
 
 int64_t VectorLoadOp::estimateCycles(const HardwareConfig &config) {
-  return estimateMemoryCycles(getBytes(), config,
-                              config.getMTE2StartupLatency());
+  return config.estimateTransferCycles(getSrcMemSpace(), getDstMemSpace(),
+                                       getBytes(),
+                                       config.getActiveBandwidthCores()) +
+         config.getMTE2StartupLatency();
+}
+llvm::StringRef VectorLoadOp::getSrcMemSpace() {
+  if (auto a = getSrcSpaceAttr())
+    return a.getValue();
+  return "hbm";
+}
+llvm::StringRef VectorLoadOp::getDstMemSpace() {
+  if (auto a = getDstSpaceAttr())
+    return a.getValue();
+  return "ub";
 }
 HWUnit VectorLoadOp::getHWUnit() { return HWUnit::VecMTE2; }
 int64_t VectorLoadOp::getTransferBytes() { return getBytes(); }
 
 int64_t VectorStoreOp::estimateCycles(const HardwareConfig &config) {
-  return estimateMemoryCycles(getBytes(), config,
-                              config.getMTE3StartupLatency());
+  return config.estimateTransferCycles(getSrcMemSpace(), getDstMemSpace(),
+                                       getBytes(),
+                                       config.getActiveBandwidthCores()) +
+         config.getMTE3StartupLatency();
+}
+llvm::StringRef VectorStoreOp::getSrcMemSpace() {
+  if (auto a = getSrcSpaceAttr())
+    return a.getValue();
+  return "ub";
+}
+llvm::StringRef VectorStoreOp::getDstMemSpace() {
+  if (auto a = getDstSpaceAttr())
+    return a.getValue();
+  return "hbm";
 }
 HWUnit VectorStoreOp::getHWUnit() { return HWUnit::MTE3; }
 int64_t VectorStoreOp::getTransferBytes() { return getBytes(); }
 
 //===----------------------------------------------------------------------===//
-// Simple Vector Binary Operations (1 cycle per vector op)
+// Simple Vector Binary Operations
 //===----------------------------------------------------------------------===//
+// Migrated to tilesim per-(intrinsic,dtype) cycle table (root cause 1).
 
-#define IMPL_SIMPLE_VECTOR_BINARY(OpClass)                                     \
+#define IMPL_VEC_BINARY(OpClass, Intrinsic)                                    \
   int64_t OpClass::estimateCycles(const HardwareConfig &config) {              \
-    int64_t n = getNumElementsFromType(getLhs().getType());                    \
-    int bits = getElementBitsFromType(getLhs().getType());                     \
-    return estimateVectorCycles(n, 1, bits, config.getVectorStartupLatency()); \
+    return estimateVectorFromTable(getLhs().getType(), Intrinsic, config);     \
   }                                                                            \
   HWUnit OpClass::getHWUnit() { return HWUnit::Vector; }                       \
   int64_t OpClass::getFlops() {                                                \
     return getNumElementsFromType(getLhs().getType());                         \
   }
 
-IMPL_SIMPLE_VECTOR_BINARY(AddOp)
-IMPL_SIMPLE_VECTOR_BINARY(SubOp)
-IMPL_SIMPLE_VECTOR_BINARY(MulOp)
-IMPL_SIMPLE_VECTOR_BINARY(MaxOp)
-IMPL_SIMPLE_VECTOR_BINARY(MinOp)
+IMPL_VEC_BINARY(AddOp, "VADD")
+IMPL_VEC_BINARY(SubOp, "VSUB")
+IMPL_VEC_BINARY(MulOp, "VMUL")
+IMPL_VEC_BINARY(MaxOp, "VMAX")
+IMPL_VEC_BINARY(MinOp, "VMIN")
+// Division is latency-limited; tilesim VDIV table value (fp16:8, fp32:4).
+IMPL_VEC_BINARY(DivOp, "VDIV")
+// DivOp (VectorBinaryComplex) declares getCyclesPerVectorOp; the macro above
+// already provides estimateCycles/getHWUnit/getFlops, so only the latency hook
+// is defined separately. tilesim VDIV table value (fp16:8, fp32:4).
+int DivOp::getCyclesPerVectorOp() { return 4; }
 
-#undef IMPL_SIMPLE_VECTOR_BINARY
-
-//===----------------------------------------------------------------------===//
-// Complex Vector Binary Operations
-//===----------------------------------------------------------------------===//
-
-int64_t DivOp::estimateCycles(const HardwareConfig &config) {
-  int64_t n = getNumElementsFromType(getLhs().getType());
-  int bits = getElementBitsFromType(getLhs().getType());
-  // Calibrated: 12 cycles (was 4). Division is latency-limited on Ascend 910B.
-  return estimateVectorCycles(n, 12, bits, config.getVectorStartupLatency());
-}
-HWUnit DivOp::getHWUnit() { return HWUnit::Vector; }
-int DivOp::getCyclesPerVectorOp() { return 12; }
-int64_t DivOp::getFlops() { return getNumElementsFromType(getLhs().getType()); }
+#undef IMPL_VEC_BINARY
 
 //===----------------------------------------------------------------------===//
-// Vector Comparison Operations (1 cycle per vector op)
+// Vector Comparison Operations
 //===----------------------------------------------------------------------===//
+// tilesim maps equal->CMPV_EQ, not-equal->VCMPV_NE, comparisons->VCMPV_GE
+// (all ~2 compute cycles/repeat).
 
-#define IMPL_VECTOR_CMP(OpClass)                                               \
+#define IMPL_VEC_CMP(OpClass, Intrinsic)                                       \
   int64_t OpClass::estimateCycles(const HardwareConfig &config) {              \
-    int64_t n = getNumElementsFromType(getLhs().getType());                    \
-    int bits = getElementBitsFromType(getLhs().getType());                     \
-    return estimateVectorCycles(n, 1, bits, config.getVectorStartupLatency()); \
+    return estimateVectorFromTable(getLhs().getType(), Intrinsic, config);     \
   }                                                                            \
   HWUnit OpClass::getHWUnit() { return HWUnit::Vector; }                       \
   int64_t OpClass::getFlops() {                                                \
     return getNumElementsFromType(getLhs().getType());                         \
   }
 
-IMPL_VECTOR_CMP(CmpEqOp)
-IMPL_VECTOR_CMP(CmpNeOp)
-IMPL_VECTOR_CMP(CmpLtOp)
-IMPL_VECTOR_CMP(CmpLeOp)
-IMPL_VECTOR_CMP(CmpGtOp)
-IMPL_VECTOR_CMP(CmpGeOp)
+IMPL_VEC_CMP(CmpEqOp, "CMPV_EQ")
+IMPL_VEC_CMP(CmpNeOp, "VCMPV_NE")
+IMPL_VEC_CMP(CmpLtOp, "VCMPV_NE")
+IMPL_VEC_CMP(CmpLeOp, "VCMPV_NE")
+IMPL_VEC_CMP(CmpGtOp, "VCMPV_GE")
+IMPL_VEC_CMP(CmpGeOp, "VCMPV_GE")
 
-#undef IMPL_VECTOR_CMP
+#undef IMPL_VEC_CMP
 
 //===----------------------------------------------------------------------===//
-// Simple Vector Unary Operations (1 cycle per vector op)
+// Simple Vector Unary Operations
 //===----------------------------------------------------------------------===//
 
-#define IMPL_SIMPLE_VECTOR_UNARY(OpClass)                                      \
+#define IMPL_VEC_UNARY_TABLE(OpClass, Intrinsic)                               \
   int64_t OpClass::estimateCycles(const HardwareConfig &config) {              \
-    int64_t n = getNumElementsFromType(getInput().getType());                  \
-    int bits = getElementBitsFromType(getInput().getType());                   \
-    return estimateVectorCycles(n, 1, bits, config.getVectorStartupLatency()); \
+    return estimateVectorFromTable(getInput().getType(), Intrinsic, config);   \
   }                                                                            \
   HWUnit OpClass::getHWUnit() { return HWUnit::Vector; }                       \
   int64_t OpClass::getFlops() {                                                \
     return getNumElementsFromType(getInput().getType());                       \
   }
 
-IMPL_SIMPLE_VECTOR_UNARY(NegOp)
-IMPL_SIMPLE_VECTOR_UNARY(AbsOp)
-IMPL_SIMPLE_VECTOR_UNARY(ReluOp)
-IMPL_SIMPLE_VECTOR_UNARY(CastOp)
+IMPL_VEC_UNARY_TABLE(AbsOp, "VABS")
+IMPL_VEC_UNARY_TABLE(ReluOp, "RELU")
+IMPL_VEC_UNARY_TABLE(ExpOp, "VEXP")
+IMPL_VEC_UNARY_TABLE(LogOp, "LOG")
+IMPL_VEC_UNARY_TABLE(SqrtOp, "VSQRT")
 
-#undef IMPL_SIMPLE_VECTOR_UNARY
+#undef IMPL_VEC_UNARY_TABLE
 
-//===----------------------------------------------------------------------===//
-// Complex Vector Unary Operations
-//===----------------------------------------------------------------------===//
-
-#define IMPL_COMPLEX_VECTOR_UNARY(OpClass, CyclesPerOp)                        \
+// Ops without a direct tilesim intrinsic keep the legacy calibrated estimate
+// (Neg, Cast, Rsqrt, Tanh, Sigmoid). These are minor contributors; the
+// bandwidth migration (root cause 1) is the dominant accuracy win. The macro
+// deliberately omits getCyclesPerVectorOp: Neg/Cast are VectorUnarySimple and
+// do not declare it, so defining it would be an error. The Complex unary ops
+// that DO declare it provide it standalone below.
+#define IMPL_VEC_UNARY_LEGACY(OpClass, CyclesPerOp)                            \
   int64_t OpClass::estimateCycles(const HardwareConfig &config) {              \
     int64_t n = getNumElementsFromType(getInput().getType());                  \
     int bits = getElementBitsFromType(getInput().getType());                   \
@@ -277,29 +392,30 @@ IMPL_SIMPLE_VECTOR_UNARY(CastOp)
                                 config.getVectorStartupLatency());             \
   }                                                                            \
   HWUnit OpClass::getHWUnit() { return HWUnit::Vector; }                       \
-  int OpClass::getCyclesPerVectorOp() { return CyclesPerOp; }                  \
   int64_t OpClass::getFlops() {                                                \
     return getNumElementsFromType(getInput().getType());                       \
   }
 
-IMPL_COMPLEX_VECTOR_UNARY(SqrtOp, 6)
-IMPL_COMPLEX_VECTOR_UNARY(RsqrtOp, 6)
-// Calibrated transcendental costs for Ascend 910B Vector unit.
-// Profiling of _attn_fwd (flash attention) across BLOCK_M={16,32,48,64}
-// showed the model underestimated vector time by ~3-4x vs. observed
-// aiv_vec_time. Root cause: each vector instruction in a dependency chain
-// stalls until the previous result is written back to UB (read-after-write
-// penalty), and the Triton-Ascend compiler emits more instructions than the
-// idealised model counts. Calibration factor: 3x applied uniformly to all
-// transcendental ops. exp: 9 cycles  (was 3, hardware-accelerated but
-// latency-limited in chains) log: 12 cycles (was 4) tanh: 18 cycles (was 6,
-// internally uses multiple exp steps) sigmoid: 15 cycles (was 5, 1/(1+exp(-x)))
-IMPL_COMPLEX_VECTOR_UNARY(ExpOp, 9)
-IMPL_COMPLEX_VECTOR_UNARY(LogOp, 12)
-IMPL_COMPLEX_VECTOR_UNARY(TanhOp, 18)
-IMPL_COMPLEX_VECTOR_UNARY(SigmoidOp, 15)
+IMPL_VEC_UNARY_LEGACY(NegOp, 1)
+IMPL_VEC_UNARY_LEGACY(CastOp, 1)
+IMPL_VEC_UNARY_LEGACY(RsqrtOp, 6)
+IMPL_VEC_UNARY_LEGACY(TanhOp, 18)
+IMPL_VEC_UNARY_LEGACY(SigmoidOp, 15)
 
-#undef IMPL_COMPLEX_VECTOR_UNARY
+#undef IMPL_VEC_UNARY_LEGACY
+
+// VectorUnaryComplex ops (Sqrt/Rsqrt/Exp/Log/Tanh/Sigmoid) declare
+// getCyclesPerVectorOp via their ODS base, so a definition is required for the
+// link to succeed. estimateCycles above is table/legacy-based and does not set
+// it; values retained from the pre-migration transcendental calibration.
+// (getCyclesPerVectorOp is a separate interface hook not consumed by the
+// current pipeline metric.)
+int SqrtOp::getCyclesPerVectorOp() { return 6; }
+int RsqrtOp::getCyclesPerVectorOp() { return 6; }
+int ExpOp::getCyclesPerVectorOp() { return 9; }
+int LogOp::getCyclesPerVectorOp() { return 12; }
+int TanhOp::getCyclesPerVectorOp() { return 18; }
+int SigmoidOp::getCyclesPerVectorOp() { return 15; }
 
 //===----------------------------------------------------------------------===//
 // Reduce Operations

--- a/third_party/ascend/costmodel/lib/AscendModel/Transforms/ConvertTritonToAscend.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Transforms/ConvertTritonToAscend.cpp
@@ -190,13 +190,16 @@ struct ConvertTritonDot : public RewritePattern {
 
       int64_t bytes = getByteSize(tensorType);
 
-      // Vector store (write from vector core to L1/UB)
-      rewriter.create<VectorStoreOp>(loc, operand, bytes, nullptr, nullptr);
+      // Vector store (write from vector core to HBM via MTE3)
+      rewriter.create<VectorStoreOp>(
+          loc, operand, bytes, rewriter.getStringAttr("ub"),
+          rewriter.getStringAttr("hbm"), nullptr, nullptr);
 
-      // Cube load (read into cube core)
+      // Cube load (read into cube core L1 via MTE2)
       Value placeholder = createPlaceholderSource(tensorType, loc, rewriter);
       auto cubeLoad = rewriter.create<CubeLoadOp>(
-          loc, tensorType, placeholder ? placeholder : operand, bytes, nullptr,
+          loc, tensorType, placeholder ? placeholder : operand, bytes,
+          rewriter.getStringAttr("hbm"), rewriter.getStringAttr("l1"), nullptr,
           nullptr);
 
       return cubeLoad.getResult();
@@ -232,10 +235,11 @@ struct ConvertTritonDot : public RewritePattern {
     auto matmul = rewriter.create<MatmulOp>(loc, resultType, lhsInput, rhsInput,
                                             M, N, K, nullptr, nullptr);
 
-    // Output: cube_store (write from cube to L1/UB)
+    // Output: cube_store (write from cube L0C to HBM via FixPipe)
     int64_t resultBytes = getByteSize(resultType);
-    rewriter.create<CubeStoreOp>(loc, matmul.getResult(), resultBytes, nullptr,
-                                 nullptr);
+    rewriter.create<CubeStoreOp>(
+        loc, matmul.getResult(), resultBytes, rewriter.getStringAttr("l0c"),
+        rewriter.getStringAttr("hbm"), nullptr, nullptr);
 
     // Check if result is used by vector operations (or loop yield)
     // If so, insert vector_load to bring data into vector core
@@ -250,12 +254,13 @@ struct ConvertTritonDot : public RewritePattern {
     }
 
     if (usedByVectorOps) {
-      // Vector load (read into vector core for subsequent vector ops)
+      // Vector load (read from HBM into vector core UB via MTE2)
       auto resultTensorType = dyn_cast<RankedTensorType>(resultType);
       Value placeholder = createPlaceholderSource(resultType, loc, rewriter);
       auto vecLoad = rewriter.create<VectorLoadOp>(
           loc, resultType, placeholder ? placeholder : matmul.getResult(),
-          resultBytes, nullptr, nullptr);
+          resultBytes, rewriter.getStringAttr("hbm"),
+          rewriter.getStringAttr("ub"), nullptr, nullptr);
       rewriter.replaceOp(op, vecLoad.getResult());
     } else {
       rewriter.replaceOp(op, matmul.getResult());
@@ -300,12 +305,14 @@ struct ConvertTritonLoad : public RewritePattern {
     bool usedByDot = op->hasAttr("ascend.used_by_dot");
 
     if (usedByDot) {
-      auto cubeLoad = rewriter.create<CubeLoadOp>(loc, resultType, source,
-                                                  bytes, nullptr, nullptr);
+      auto cubeLoad = rewriter.create<CubeLoadOp>(
+          loc, resultType, source, bytes, rewriter.getStringAttr("hbm"),
+          rewriter.getStringAttr("l1"), nullptr, nullptr);
       rewriter.replaceOp(op, cubeLoad.getResult());
     } else {
-      auto vecLoad = rewriter.create<VectorLoadOp>(loc, resultType, source,
-                                                   bytes, nullptr, nullptr);
+      auto vecLoad = rewriter.create<VectorLoadOp>(
+          loc, resultType, source, bytes, rewriter.getStringAttr("hbm"),
+          rewriter.getStringAttr("ub"), nullptr, nullptr);
       rewriter.replaceOp(op, vecLoad.getResult());
     }
     return success();
@@ -363,7 +370,9 @@ struct ConvertTritonStore : public RewritePattern {
     Value data = op->getOperand(1);
     int64_t bytes = getByteSize(data.getType());
 
-    rewriter.create<VectorStoreOp>(op->getLoc(), data, bytes, nullptr, nullptr);
+    rewriter.create<VectorStoreOp>(
+        op->getLoc(), data, bytes, rewriter.getStringAttr("ub"),
+        rewriter.getStringAttr("hbm"), nullptr, nullptr);
     rewriter.eraseOp(op);
     return success();
   }

--- a/third_party/ascend/costmodel/lib/AscendModel/Transforms/InsertDataTransfers.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Transforms/InsertDataTransfers.cpp
@@ -106,6 +106,11 @@ struct InsertDataTransfersPass
 
       // Null attrs for optional parameters
       ::mlir::IntegerAttr nullAttr;
+      // Memory-space attrs for transfer ops (tilesim migration, root cause 1).
+      auto hbm = builder.getStringAttr("hbm");
+      auto l1 = builder.getStringAttr("l1");
+      auto l0c = builder.getStringAttr("l0c");
+      auto ub = builder.getStringAttr("ub");
 
       // === Step 1: Handle inputs to Cube ===
       // MatmulOp has lhs and rhs operands
@@ -140,9 +145,8 @@ struct InsertDataTransfersPass
             hbmValue = it->second;
           } else {
             // Insert vector_store: UB → HBM (MTE3)
-            // VectorStoreOp: (data, bytes, estimated_cycles, op_id)
-            builder.create<VectorStoreOp>(loc, operand, bytes, nullAttr,
-                                          nullAttr);
+            builder.create<VectorStoreOp>(loc, operand, bytes, ub, hbm,
+                                          nullAttr, nullAttr);
             hbmValue = operand; // After store, conceptually in HBM
             vectorToHBM[operand] = hbmValue;
           }
@@ -154,9 +158,8 @@ struct InsertDataTransfersPass
             l1Value = it2->second;
           } else {
             // Insert cube_load: HBM → L1 (MTE2)
-            // CubeLoadOp: (result_type, source, bytes, estimated_cycles, op_id)
             auto cubeLoad = builder.create<CubeLoadOp>(
-                loc, tensorType, hbmValue, bytes, nullAttr, nullAttr);
+                loc, tensorType, hbmValue, bytes, hbm, l1, nullAttr, nullAttr);
             l1Value = cubeLoad.getResult();
             hbmToL1[hbmValue] = l1Value;
           }
@@ -193,13 +196,12 @@ struct InsertDataTransfersPass
       uint64_t bytes = static_cast<uint64_t>(getByteSize(resultType));
 
       // Insert cube_store: L0C → HBM (FixPipe)
-      // CubeStoreOp: (data, bytes, estimated_cycles, op_id)
-      builder.create<CubeStoreOp>(loc, matmulResult, bytes, nullAttr, nullAttr);
+      builder.create<CubeStoreOp>(loc, matmulResult, bytes, l0c, hbm, nullAttr,
+                                  nullAttr);
 
       // Insert vector_load: HBM → UB (MTE2)
-      // VectorLoadOp: (result_type, source, bytes, estimated_cycles, op_id)
       auto vectorLoad = builder.create<VectorLoadOp>(
-          loc, resultType, matmulResult, bytes, nullAttr, nullAttr);
+          loc, resultType, matmulResult, bytes, hbm, ub, nullAttr, nullAttr);
 
       // Replace uses in Vector operations
       for (OpOperand *use : vectorUsers) {

--- a/third_party/ascend/costmodel/lib/AscendModel/Transforms/PerfReportPass.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Transforms/PerfReportPass.cpp
@@ -126,8 +126,12 @@ struct PerfReportPass : public impl::PerfReportPassBase<PerfReportPass> {
 
     auto scheduledCyclesAttr =
         module->getAttrOfType<IntegerAttr>("ascend.scheduled_cycles");
+    auto rooflineCyclesAttr =
+        module->getAttrOfType<IntegerAttr>("ascend.roofline_cycles");
     int64_t scheduledCycles =
-        scheduledCyclesAttr ? scheduledCyclesAttr.getInt() : totalCycles;
+        scheduledCyclesAttr
+            ? scheduledCyclesAttr.getInt()
+            : (rooflineCyclesAttr ? rooflineCyclesAttr.getInt() : totalCycles);
 
     // Ascend 910B clock: 1.85 GHz = 1850 cycles/us
     constexpr double CYCLES_PER_US = 1850.0;

--- a/third_party/ascend/costmodel/lib/AscendModel/Transforms/PipelineAnalysisPass.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Transforms/PipelineAnalysisPass.cpp
@@ -187,18 +187,28 @@ struct PipelineAnalysisPass
           pipelineOp.duration * pipelineOp.loopMultiplier;
     }
 
-    // Group by path and apply roofline model
-    // Cube path: max(Cube, CubeMTE2, FixPipe)
+    // Group by path and apply roofline model.
+    // Cube path: max(Cube, CubeMTE2, FixPipe). No cube-side mutex on 910B
+    // (tilesim pipe_exclusive_config only pairs AIV MTE2<->MTE3).
     int64_t cubePathCycles =
         std::max({hwUnitCycles[HWUnit::Cube], hwUnitCycles[HWUnit::CubeMTE2],
                   hwUnitCycles[HWUnit::FixPipe]});
 
-    // Vector path: max(Vector, VecMTE2, MTE3)
+    // Vector path. Vector compute overlaps with load/store transfers, but on
+    // 910B AIV the MTE2 (load) and MTE3 (store) units share one physical
+    // pipeline (tilesim MutexComponents) and must serialize. With the mutex
+    // the transfer time is VecMTE2 + MTE3; without it (legacy) they are
+    // assumed to overlap (max). This is root cause 3.
+    int64_t vecTransfer;
+    if (config.areMutexUnits("vec_mte2", "mte3"))
+      vecTransfer = hwUnitCycles[HWUnit::VecMTE2] + hwUnitCycles[HWUnit::MTE3];
+    else
+      vecTransfer =
+          std::max(hwUnitCycles[HWUnit::VecMTE2], hwUnitCycles[HWUnit::MTE3]);
     int64_t vectorPathCycles =
-        std::max({hwUnitCycles[HWUnit::Vector], hwUnitCycles[HWUnit::VecMTE2],
-                  hwUnitCycles[HWUnit::MTE3]});
+        std::max(hwUnitCycles[HWUnit::Vector], vecTransfer);
 
-    // Total: max of paths (assuming Cube and Vector can overlap)
+    // Total: max of paths (Cube and Vector paths overlap)
     int64_t rooflineTotalCycles = std::max(cubePathCycles, vectorPathCycles);
 
     // Also calculate simple sum for comparison
@@ -210,6 +220,13 @@ struct PipelineAnalysisPass
                     IntegerAttr::get(IntegerType::get(module.getContext(), 64),
                                      oneIterCycles));
     module->setAttr("ascend.roofline_cycles",
+                    IntegerAttr::get(IntegerType::get(module.getContext(), 64),
+                                     rooflineTotalCycles));
+    // Public summary consumed by the in-process Python costmodel bridge.
+    // This must include loop multipliers; otherwise configs with many inner
+    // loop iterations are under-estimated and can incorrectly outrank faster
+    // configs during costmodel prefiltering.
+    module->setAttr("ascend.scheduled_cycles",
                     IntegerAttr::get(IntegerType::get(module.getContext(), 64),
                                      rooflineTotalCycles));
     module->setAttr("ascend.simple_sum_cycles",

--- a/third_party/ascend/triton_ascend.cc
+++ b/third_party/ascend/triton_ascend.cc
@@ -7,7 +7,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Parser/Parser.h"
-#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/Passes.h" // createInlinerPass
 
 #include "ascend/include/AutoBlockify/Passes.h"
 #include "ascend/include/Dialect/TritonAscend/IR/TritonAscendDialect.h"
@@ -41,7 +41,9 @@
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 
+#include <algorithm>
 #include <cstring>
+#include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <vector>
@@ -280,16 +282,32 @@ parseAscendCostmodelArgs(const std::vector<std::string> &extraArgs) {
 
 static double extractEstimatedTimeUs(mlir::ModuleOp module) {
   constexpr double CYCLES_PER_US = 1850.0;
-  if (auto scheduledCyclesAttr =
-          module->getAttrOfType<mlir::IntegerAttr>("ascend.scheduled_cycles")) {
-    return static_cast<double>(scheduledCyclesAttr.getInt()) / CYCLES_PER_US;
-  }
+
+  auto getCycleAttr = [&](llvm::StringRef name) -> std::optional<int64_t> {
+    if (auto attr = module->getAttrOfType<mlir::IntegerAttr>(name))
+      return attr.getInt();
+    return std::nullopt;
+  };
+
+  // PipelineAnalysisPass computes loop-multiplied roofline cycles.  Older
+  // callers looked for ascend.scheduled_cycles, so keep that first for
+  // compatibility, then fall back to the weighted roofline summary.
+  if (auto cycles = getCycleAttr("ascend.scheduled_cycles"))
+    return static_cast<double>(*cycles) / CYCLES_PER_US;
+  if (auto cycles = getCycleAttr("ascend.roofline_cycles"))
+    return static_cast<double>(*cycles) / CYCLES_PER_US;
+  if (auto cycles = getCycleAttr("ascend.simple_sum_cycles"))
+    return static_cast<double>(*cycles) / CYCLES_PER_US;
 
   int64_t fallbackCycles = 0;
   module.walk([&](mlir::Operation *op) {
     if (auto cyclesAttr =
             op->getAttrOfType<mlir::IntegerAttr>("estimated_cycles")) {
-      fallbackCycles += cyclesAttr.getInt();
+      int64_t multiplier = 1;
+      if (auto multiplierAttr =
+              op->getAttrOfType<mlir::IntegerAttr>("loop_multiplier"))
+        multiplier = std::max<int64_t>(1, multiplierAttr.getInt());
+      fallbackCycles += cyclesAttr.getInt() * multiplier;
     }
   });
   return static_cast<double>(fallbackCycles) / CYCLES_PER_US;
@@ -328,6 +346,16 @@ runAscendCostModelInProcess(const std::string &mlirText,
   }
 
   mlir::PassManager pm(&context);
+  // Inline tt.call helpers (e.g. softmax's @max/@sum reduce helpers) into the
+  // calling kernel BEFORE conversion/estimation. Without this, ops in a helper
+  // invoked from inside a loop are estimated at the helper's top level (outside
+  // the loop) and get loopMultiplier=1 instead of the caller's trip count, so
+  // per-iteration ops like reductions are under-counted. TritonDialect
+  // registers TritonInlinerInterface, so the generic MLIR inliner handles
+  // tt.call (CallOpInterface). SymbolDCE then erases the now-dead private
+  // helpers so their ops are not double-counted alongside the inlined copies.
+  pm.addPass(mlir::createInlinerPass());
+  pm.addPass(mlir::createSymbolDCEPass());
   pm.addPass(mlir::ascend::createConvertTritonToAscendPass());
   pm.addPass(mlir::ascend::createInsertDataTransfersPass());
   pm.addPass(mlir::ascend::createAssignOpIDsPass());

--- a/third_party/ascend/unittest/costmodel_ut/test_compiler_costmodel_contract.py
+++ b/third_party/ascend/unittest/costmodel_ut/test_compiler_costmodel_contract.py
@@ -23,10 +23,13 @@ class CompilerCostmodelContractTest(unittest.TestCase):
 
         triton_mod = types.ModuleType("triton")
         triton_c_mod = types.ModuleType("triton._C")
+        ascend_backend_mod = types.ModuleType("triton.backends.ascend")
+        ascend_backend_mod._apply_ascend_patch = lambda: None
         libtriton_mod = types.ModuleType("triton._C.libtriton")
         libtriton_mod.ir = Dummy()
         libtriton_mod.passes = Dummy()
         libtriton_mod.ascend = Dummy()
+        libtriton_mod.buffer_ir = Dummy()
 
         utils_mod = types.ModuleType("triton.backends.ascend.utils")
         for name in [
@@ -35,11 +38,15 @@ class CompilerCostmodelContractTest(unittest.TestCase):
                 "_check_bishengir_is_regbased",
                 "_enable_print_ub_bits",
                 "_enable_dump_memory_info",
+                "_enable_msdebug",
                 "_get_kernel_target",
                 "_get_llvm_path",
                 "_get_mlir_path",
                 "_get_npucompiler_path",
                 "_get_triton_adapter_opt_path",
+                "_get_triton_mlir_opt_path",
+                "_get_triton_opt_path",
+                "_get_bishengir_opt_path",
                 "_is_ascend_sanitizer_enabled",
                 "_is_debug_line_info_disabled",
                 "_is_auto_map_parallel_blocks_enabled",
@@ -91,6 +98,7 @@ class CompilerCostmodelContractTest(unittest.TestCase):
 
         dump_mgr = DumpManager()
         cache_mod.get_dump_manager = lambda *args, **kwargs: dump_mgr
+        cache_mod._base32 = lambda value: value
 
         utils_mod.is_compile_on_910_95 = lambda: False
 
@@ -98,6 +106,7 @@ class CompilerCostmodelContractTest(unittest.TestCase):
             "triton": triton_mod,
             "triton._C": triton_c_mod,
             "triton._C.libtriton": libtriton_mod,
+            "triton.backends.ascend": ascend_backend_mod,
             "triton.backends.ascend.utils": utils_mod,
             "triton.backends.ascend.driver": driver_mod,
             "triton.backends.compiler": compiler_base_mod,
@@ -118,7 +127,7 @@ class CompilerCostmodelContractTest(unittest.TestCase):
         backend = cmplr.AscendBackend(GPUTarget(backend="npu", arch="910B"))
 
         opt_plain = backend.parse_options({})
-        self.assertFalse(hasattr(opt_plain, "use_bytecode"))
+        self.assertTrue(opt_plain.use_bytecode)
 
         opt_costmodel = backend.parse_options({"enable_costmodel_backend": True})
         self.assertTrue(opt_costmodel.enable_costmodel_backend)


### PR DESCRIPTION
## Motivation

The previous costmodel could significantly under-estimate kernels where important work is hidden behind helper functions called inside loops. This affected configuration ranking during costmodel-based filtering and could cause slower configs to be selected.

By inlining helper functions before estimation and using the loop-weighted roofline summary, the reported estimate better reflects the actual repeated work in the kernel.

## Summary

This PR improves the precision of the Ascend cost model by aligning the in-process estimation pipeline with loop-aware pipeline analysis and Ascend 910B hardware behavior.

The main fix is to avoid under-estimating operations that are placed in Triton helper functions, such as reduction helpers used by softmax. These helpers can be called from inside loops, but without inlining their operations are analyzed at helper-function scope and receive a loop multiplier of `1`. This causes per-iteration work to be under-counted during costmodel prefiltering.

## Changes

- Run MLIR inlining and symbol DCE before the in-process costmodel conversion pipeline.
  - This lets `tt.call` helper bodies be analyzed at the actual call site.
  - Dead helper symbols are removed after inlining to avoid double-counting.

- Make costmodel result extraction prefer module-level scheduled/roofline summaries.
  - `ascend.scheduled_cycles`
  - `ascend.roofline_cycles`
  - `ascend.simple_sum_cycles`
  - fallback to per-op `estimated_cycles * loop_multiplier`

- Update pipeline analysis to publish loop-multiplied roofline cycles as `ascend.scheduled_cycles`.

- Model Ascend 910B vector-side transfer serialization more accurately by accounting for the mutex between vector MTE2 load and MTE3 store paths.

- Add memory-space information to inserted transfer ops so transfer modeling can distinguish source and destination spaces.