### PR TITLE
[CI](fix) Extend OCR timeout duration

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -70,7 +70,10 @@ permissions:
 jobs:
   code-review:
     runs-on: linux-amd64-cpu-8-hk
-    timeout-minutes: 30
+    timeout-minutes: 35
+    # Job-level timeout is a safety net for non-OCR steps (e.g. Get PR context).
+    # The OCR step uses its own step-level timeout with continue-on-error so a
+    # review timeout doesn't fail the check — Finalize step always exits 0.
     # Run on PR events, or on human-authored comments starting with trigger
     # keywords. Bot comments are excluded as a safety net: GITHUB_TOKEN already
     # suppresses events from bot-posted comments, but a PAT/App token would not.
@@ -114,6 +117,7 @@ jobs:
 
       - name: Run OpenCodeReview
         uses: alibaba/open-code-review@main
+        timeout-minutes: 30
         continue-on-error: true
         with:
           llm_url: ${{ secrets.OCR_LLM_URL }}
@@ -124,3 +128,7 @@ jobs:
           # pull_request_target the action resolves them from the event.
           base_ref: ${{ steps.pr-context.outputs.base_ref }}
           head_sha: ${{ steps.pr-context.outputs.head_sha }}
+
+      - name: Finalize
+        if: always()
+        run: exit 0


### PR DESCRIPTION
### Summary

Some tasks may encounter ocr task timeout issues. Here, also set a timeout period in step to allow it to pass normally.