### PR TITLE
[Test](fix) fix tests for simd_simt mode

### DIFF
--- a/third_party/ascend/unittest/pytest_ut/test_simd_simt.py
+++ b/third_party/ascend/unittest/pytest_ut/test_simd_simt.py
@@ -107,7 +107,7 @@ def test_indirect_index_load_add_kernel():
     add_src = torch.arange(8, dtype=torch.float32, device='npu')
     print(f"Source data: [{src[0]}, {src[1]}, ..., {src[255]}]")
 
-    indices = torch.tensor([10, 25, 100, 200, 5, 50, 150, 255], dtype=torch.int64, device='npu')
+    indices = torch.tensor([10, 25, 100, 200, 5, 50, 150, 230], dtype=torch.int64, device='npu')
     print(f"Indices: {indices.tolist()}")
 
     output = torch.zeros(8, dtype=torch.float32, device='npu')
@@ -237,7 +237,7 @@ def test_indirect_index_load_mul_kernel():
     add_src = torch.arange(8, dtype=torch.float32, device='npu')
     print(f"Source data: [{src[0]}, {src[1]}, ..., {src[255]}]")
 
-    indices = torch.tensor([10, 25, 100, 200, 5, 50, 150, 255], dtype=torch.int64, device='npu')
+    indices = torch.tensor([10, 25, 100, 200, 5, 50, 150, 230], dtype=torch.int64, device='npu')
     offset1 = torch.arange(8, dtype=torch.int64, device='npu')
     offset2 = torch.full((8, ), 3, dtype=torch.int64, device='npu')
     print(f"Indices: {indices.tolist()}")


### PR DESCRIPTION
## Description
This PR fixes two indirect index load test cases in `test_simd_simt.py` that were failing under `simd_simt` compile mode due to out-of-bounds memory access.

## Problem
- `test_indirect_index_load_mul_kernel`: index computation `indices + offset2 * offset1` exceeded `src` bounds.
- `test_indirect_index_load_add_kernel`: index `indices + 3` exceeded `src` bounds.

## Solution
- Adjust indices to avoid out-of-bounds access

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
