### PR TITLE
[Unstructure](fix) skip block ptr in simt fast path

### DIFF
--- a/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
@@ -146,6 +146,15 @@ void normalizeDiscreteMaskAccessForFallback(MemAccOpTy &op,
 //    If SIMT indirect lowering cannot be formed for any operation,
 //    conversion gracefully falls back to the legacy scalar-loop lowering path
 // ======================================================================================
+static bool canUseIndirectFastPath(Value srcPtr, Value ptrOffset) {
+  if (!srcPtr || !ptrOffset)
+    return false;
+  auto ptrTy = dyn_cast<triton::PointerType>(srcPtr.getType());
+  if (!ptrTy || isa<ShapedType>(ptrTy.getPointeeType()))
+    return false;
+  return isa<RankedTensorType>(ptrOffset.getType());
+}
+
 template <typename MemAccOpTy>
 LogicalResult tryRewriteIndirectFastPath(MemAccOpTy op, Location loc,
                                          Value srcPtr, Value ptrOffset,
@@ -153,6 +162,15 @@ LogicalResult tryRewriteIndirectFastPath(MemAccOpTy op, Location loc,
                                          PatternRewriter &rewriter)
 {
   bool rankWithinIndirectLoadStoreFastPathLimit = resultShape.size() <= 5;
+
+  if (!canUseIndirectFastPath(srcPtr, ptrOffset)) {
+    LLVM_DEBUG({
+      llvm::dbgs()
+          << "Skip SIMT indirect fast path: src must be scalar elem ptr and "
+             "offset must be an int tensor (reject block_ptr)\n";
+    });
+    return failure();
+  }
 
   if constexpr (std::is_same_v<MemAccOpTy, triton::LoadOp>) {
     if (!rankWithinIndirectLoadStoreFastPathLimit) {

--- a/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/indirect_load.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/indirect_load.mlir
@@ -38,5 +38,21 @@ tt.func public @triton_indirect_load_kernel(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<
 }
 
 // CHECK-LABEL: tt.func public @triton_indirect_load_kernel
-// CHECK: ascend.indirect_load{{.*}} : tensor<8x32xi64> -> tensor<8x32xf32>
+// CHECK: ascend.indirect_load{{.*}} : <f32>, {{.*}} : tensor<8x32xi64> {{.*}}-> tensor<8x32xf32>
 // CHECK: tt.store
+
+// -----
+
+// Block-pointer load with mayDiscretememaccess must not use SIMT indirect_load.
+tt.func public @block_ptr_load_skip_indirect(%arg0: !tt.ptr<f32>) -> tensor<32x32xf32> attributes {noinline = false} {
+  %c32_i64 = arith.constant 32 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %c0_i32 = arith.constant 0 : i32
+  %0 = tt.make_tensor_ptr %arg0, [%c32_i64, %c32_i64], [%c32_i64, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<32x32xf32>>
+  %1 = tt.load %0 : !tt.ptr<tensor<32x32xf32>>
+  annotation.mark %1 {mayDiscretememaccess} : tensor<32x32xf32>
+  tt.return %1 : tensor<32x32xf32>
+}
+
+// CHECK-LABEL: tt.func public @block_ptr_load_skip_indirect
+// CHECK-NOT: ascend.indirect_load


### PR DESCRIPTION
## Summary
Fix a SIGSEGV in `triton-to-unstructure` when `compile-on-910-95=true` and `force-simt-template=true`.

On Ascend 950, unstructured loads may be lowered via the SIMT indirect fast path (`ascend.indirect_load`). That path requires a **scalar element pointer** (`!tt.ptr<elem>`) and a **per-element integer offset tensor**. Block-pointer loads (`!tt.ptr<tensor<...>>` from `tt.make_tensor_ptr`) do not meet this contract.

When a block-ptr load is also marked with `annotation.mark {mayDiscretememaccess}`, the converter forces the access to unstructured and the `sizeInByte < 64` gate incorrectly enables the SIMT fast path. Creating `IndirectLoadOp` with an invalid `src` / `offset` pair corrupts MLIR use-lists and crashes on a subsequent load.

This PR rejects block-ptr (and other ineligible) operands in `tryRewriteIndirectFastPath`, so those loads fall back to the legacy scalar-loop path instead of crashing.

## Root Cause

```text
tt.load %block_ptr : !tt.ptr<tensor<32x32xbf16>>
annotation.mark {mayDiscretememaccess}
        │
        ▼
setUnstructured → sizeInByte = sizeof(bf16) = 2 < 64
        │
        ▼
tryRewriteIndirectFastPath
  srcPtr  = !tt.ptr<tensor<...>>   ✗ (need !tt.ptr<bf16>)
  offset  = scalar i64 / index     ✗ (need tensor<*xi64>)
        │
        ▼
create IndirectLoadOp → SEGV
```

## What Is Included
- Add `canUseIndirectFastPath(srcPtr, ptrOffset)` guard in `UnstructureConversionPass.cpp`
- Reject cases where:
  - `srcPtr` / `ptrOffset` is null
  - `srcPtr` is not a pointer, or pointee is a shaped type (block ptr)
  - `ptrOffset` is not a ranked integer tensor
- On rejection, return `failure()` so the existing scalar-loop lowering is used

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
  - [ ] This PR does not need a test.
  - [x] I have added tests.
- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices).
