### PR TITLE
[CI](feat) Add DCO check

### DIFF
--- a/.github/workflows/Ascend950-ci.yml
+++ b/.github/workflows/Ascend950-ci.yml
@@ -24,7 +24,7 @@ on:
       # CI itself
       - '.github/workflows/Ascend950-ci.yml'
   push:
-    branches: [main, release/**]
+    branches: [main, 'release/**', '**-dev']
     paths: *paths
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ on:
       - '.github/workflows/integration-tests-ascend.yml'
       - '.github/workflows/runner-preparation.yml'
   merge_group:
-    branches: [main, 'dev-**']
+    branches: [main, 'release/**', '**-dev']
     types: [checks_requested]
   push:
-    branches: [main, 'release/**']
+    branches: [main, 'release/**', '**-dev']
     paths: *ci-paths
 concurrency:
   group: ${{ github.ref }}

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -1,0 +1,28 @@
+name: DCO Check
+
+on:
+  pull_request_target:
+  merge_group:
+    branches: [main, 'release/**', '**-dev']
+    types: [checks_requested]
+  push:
+    branches: [main, 'release/**', '**-dev']
+
+concurrency:
+  group: dco-check-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dco:
+    name: Developer Certificate of Origin
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: KineticCafe/actions-dco@v3.1.0
+        with:
+          config: |
+            comment = true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
   pull_request:
   merge_group:
-    branches: [main, 'dev-**']
+    branches: [main, 'release/**', '**-dev']
     types: [checks_requested]
   push:
-    branches: [main, 'release/**']
+    branches: [main, 'release/**', '**-dev']
 
 concurrency:
   group: pre-commit-${{ github.ref }}


### PR DESCRIPTION
### Summary
This pr is used to synchronize the [DCO check CI](https://github.com/triton-lang/triton-ascend/pull/1197/changes) in the main-dev branch.