### PR TITLE
[OP](feat) Revert  roll back the intrusive modification (#1232)

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1362,28 +1362,9 @@ class TritonSemantic(Generic[TensorTy]):
                 return self.tensor(
                     self.builder.create_atomic_rmw(ir.ATOMIC_OP.UMAX, ptr.handle, val.handle, mask.handle, sem, scope),
                     val.type)
-        # for float
-        # return atomic_smax(i_ptr, i_val) if val >= 0
-        # return atomic_umin(i_ptr, i_val) if val < 0
-        if sca_ty not in {tl.float32, tl.float64}:
-            raise TypeError(f"atomic_max not supported for dtype {sca_ty}")
-
-        i_type = tl.int32 if sca_ty == tl.float32 else tl.int64
-        i_val = self.bitcast(val, i_type)
-        i_ptr = self.bitcast(ptr, tl.pointer_type(i_type, 1))
-        ui_type = tl.uint32 if sca_ty == tl.float32 else tl.uint64
-        ui_val = self.bitcast(val, ui_type)
-        ui_ptr = self.bitcast(ptr, tl.pointer_type(ui_type, 1))
-        neg = self._signbit(val)
-        pos = self.not_(neg)
-        pos_ret = self.tensor(
-            self.builder.create_atomic_rmw(ir.ATOMIC_OP.MAX, i_ptr.handle, i_val.handle,
-                                           self.and_(mask, pos).handle, sem, scope), i_val.type)
-        neg_ret = self.tensor(
-            self.builder.create_atomic_rmw(ir.ATOMIC_OP.UMIN, ui_ptr.handle, ui_val.handle,
-                                           self.and_(mask, neg).handle, sem, scope), ui_val.type)
-        ret = self.where(pos, pos_ret, neg_ret)
-        return self.bitcast(ret, sca_ty)
+        # Design for NPU
+        return self.tensor(
+            self.builder.create_atomic_rmw(ir.ATOMIC_OP.MAX, ptr.handle, val.handle, mask.handle, sem, scope), val.type)
 
     def atomic_min(self, ptr: TensorTy, val: TensorTy, mask: TensorTy, sem: str, scope: str) -> TensorTy:
         ptr, val, mask = self.atom_red_typechecking_impl(ptr, val, mask, 'min')
@@ -1400,28 +1381,9 @@ class TritonSemantic(Generic[TensorTy]):
                 return self.tensor(
                     self.builder.create_atomic_rmw(ir.ATOMIC_OP.UMIN, ptr.handle, val.handle, mask.handle, sem, scope),
                     val.type)
-        # for float
-        # return atomic_smin(i_ptr, i_val) if val >= 0
-        # return atomic_umax(i_ptr, i_val) if val < 0
-        if sca_ty not in {tl.float32, tl.float64}:
-            raise TypeError(f"atomic_min not supported for dtype {sca_ty}")
-
-        i_type = tl.int32 if sca_ty == tl.float32 else tl.int64
-        i_val = self.bitcast(val, i_type)
-        i_ptr = self.bitcast(ptr, tl.pointer_type(i_type, 1))
-        ui_type = tl.uint32 if sca_ty == tl.float32 else tl.uint64
-        ui_val = self.bitcast(val, ui_type)
-        ui_ptr = self.bitcast(ptr, tl.pointer_type(ui_type, 1))
-        neg = self._signbit(val)
-        pos = self.not_(neg)
-        pos_ret = self.tensor(
-            self.builder.create_atomic_rmw(ir.ATOMIC_OP.MIN, i_ptr.handle, i_val.handle,
-                                           self.and_(mask, pos).handle, sem, scope), i_val.type)
-        neg_ret = self.tensor(
-            self.builder.create_atomic_rmw(ir.ATOMIC_OP.UMAX, ui_ptr.handle, ui_val.handle,
-                                           self.and_(mask, neg).handle, sem, scope), ui_ptr.type)
-        ret = self.where(pos, pos_ret, neg_ret)
-        return self.bitcast(ret, sca_ty)
+        # Design for NPU
+        return self.tensor(
+            self.builder.create_atomic_rmw(ir.ATOMIC_OP.MIN, ptr.handle, val.handle, mask.handle, sem, scope), val.type)
 
     def atomic_add(self, ptr: TensorTy, val: TensorTy, mask: TensorTy, sem: str, scope: str) -> TensorTy:
         ptr, val, mask = self.atom_red_typechecking_impl(ptr, val, mask, 'add')

--- a/third_party/ascend/unittest/pytest_ut/test_atomic_max.py
+++ b/third_party/ascend/unittest/pytest_ut/test_atomic_max.py
@@ -54,6 +54,8 @@ def triton_test_fn_atomic_max_dma_supply(in_ptr0, out_ptr0, n_elements: tl.const
 
 # torch.max do not support int
 @pytest.mark.parametrize('param_list', [
+    ['float32', (128, 128), 8],
+    ['float32', (32768, 16), 32],
     ['int32', (32, 32), 2],
     ['int32', (128, 128), 8],
     ['int32', (32768, 16), 32],
@@ -85,7 +87,7 @@ def test_atomic_max(param_list):
 
 
 @pytest.mark.parametrize('shape', [(3, 1), (13, 1), (32, 1), (256, 1)])
-@pytest.mark.parametrize('dtype', ['int32'])
+@pytest.mark.parametrize('dtype', ['float32'])
 def test_atomic_max_2d_supply(dtype, shape):
     # old size: (32768, 256)
     # tensor of (1024, 256) is too big, and it will lead to failure in the backend

--- a/third_party/ascend/unittest/pytest_ut/test_atomic_min.py
+++ b/third_party/ascend/unittest/pytest_ut/test_atomic_min.py
@@ -52,6 +52,8 @@ def triton_test_fn_atomic_min_dma_supply(in_ptr0, out_ptr0, n_elements: tl.const
 
 
 @pytest.mark.parametrize('param_list', [
+    ['float32', (128, 128), 8],
+    ['float32', (32768, 16), 32],
     ['int32', (32, 32), 2],
     ['int32', (128, 128), 8],
     ['int32', (32768, 16), 32],
@@ -80,7 +82,7 @@ def test_atomic_min(param_list):
 
 
 @pytest.mark.parametrize('shape', [(3, 1), (13, 1), (32, 1), (256, 1)])
-@pytest.mark.parametrize('dtype', ['int32'])
+@pytest.mark.parametrize('dtype', ['float32'])
 def test_atomic_min_2d_supply(dtype, shape):
     x0 = test_common.generate_tensor(shape, dtype).npu()
     x1 = test_common.generate_tensor(shape, dtype).npu()


### PR DESCRIPTION
This reverts commit 839c8ae3a2dcf626511ccbf6a5420906d8b2336a.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
