### PR TITLE
[ssbuffer](feat) add scalar V->C dependency detection in DataDependencyAnalysis

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
@@ -141,6 +141,7 @@ private:
                          mlir::Operation *predOp, mlir::Operation *nextOp);
   void analyzeExternalInputs(DataDependencyInfo &info);
   void analyzeExternalOutputs(DataDependencyInfo &info);
+  void analyzeScalarVToCDependencies(DataDependencyInfo &info);
 
   void analyzeMemoryEffect(DataDependencyInfo &info);
   std::pair<int, int> findCommonLevelBlockIds(DataDependencyInfo &info,

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -106,7 +106,7 @@ bool isVectorOnlyOp(Operation *op) {
 
   return llvm::TypeSwitch<Operation *, bool>(op)
       .Case([](linalg::ReduceOp) { return true; })
-      .Case<arith::SelectOp, math::FloorOp>([](Operation *op) {
+      .Case<arith::SelectOp, math::FloorOp, math::CeilOp>([](Operation *op) {
         return isa<RankedTensorType>(op->getResult(0).getType());
       })
       .Default([](auto) { return false; });

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -655,7 +655,7 @@ int OpClassifierPass::propagateCubeUpstream() {
 
       // Skip arith dialect ops with tensor results (they should be VECTOR, not
       // CUBE)
-      if (isa<arith::ArithDialect>(def->getDialect())) {
+      if (isa<arith::ArithDialect>(def->getDialect()) || isa<math::MathDialect>(def->getDialect())) {
         bool hasTensorResult = false;
         for (Value result : def->getResults()) {
           if (isa<RankedTensorType>(result.getType())) {
@@ -850,6 +850,8 @@ void OpClassifierPass::propagateCubeUpstreamForOp(Operation *startOp) {
       if (!upstreamOp || cubeVisited.count(upstreamOp))
         continue;
       if (isa<linalg::MatmulOp>(upstreamOp))
+        continue;
+      if (isa<arith::ArithDialect>(upstreamOp->getDialect()) || isa<math::MathDialect>(upstreamOp->getDialect()))
         continue;
 
       cubeVisited.insert(upstreamOp);

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -652,9 +652,18 @@ void DataDependencyAnalysisPass::collectMemDepInfo(
 
 // Trace defining op chain to check if any upstream op is vector-only.
 // Returns true if a vector-only op is found in the chain.
+// Values in `stopValues` are treated as already-handled scalar dependencies;
+// the trace stops when it hits one, avoiding redundant detection of downstream
+// scalars whose upstream values have already been transferred via SSBuffer.
 // This mirrors AnalyzeCubeControlFlowInputChain's hasIncompatibleOpForCondition.
-static bool hasVectorOpInDefChain(mlir::Value val,
-                                  llvm::DenseSet<mlir::Operation *> &visited) {
+static bool hasVectorOpInDefChain(
+    mlir::Value val,
+    llvm::DenseSet<mlir::Operation *> &visited,
+    const llvm::DenseSet<mlir::Value> *stopValues = nullptr) {
+  if (stopValues && stopValues->contains(val)) {
+    return false;
+  }
+
   mlir::Operation *defOp = val.getDefiningOp();
   if (!defOp || visited.contains(defOp)) {
     return false;
@@ -666,7 +675,7 @@ static bool hasVectorOpInDefChain(mlir::Value val,
   }
 
   for (mlir::Value operand : defOp->getOperands()) {
-    if (hasVectorOpInDefChain(operand, visited)) {
+    if (hasVectorOpInDefChain(operand, visited, stopValues)) {
       return true;
     }
   }
@@ -717,10 +726,19 @@ static bool ifOpHasCubeOps(
 // Detects when scf.for loop bounds or scf.if conditions are scalar values whose
 // defining chain traces back to vector-only ops (e.g. math.floor/math.ceil on
 // tensors, linalg.reduce). These scalars must be transferred from VECTOR to CUBE.
+//
+// To avoid redundant transfers, scalars already recorded as dependencies are
+// tracked in a stop-set: downstream scalars whose defining chain only reaches
+// vector-only ops through an already-handled scalar are NOT re-recorded.
 void DataDependencyAnalysisPass::analyzeScalarVToCDependencies(
     DataDependencyInfo &info) {
   auto &blockInfoMap = info.getBlockInfoMap();
   auto &v2cDependencies = info.getV2CDependencies();
+
+  // Scalars already recorded as V->C deps — downstream values depending on
+  // these don't need separate transfer since the upstream value will be
+  // available on the CUBE side after SSBuffer transfer.
+  llvm::DenseSet<mlir::Value> handledScalarValues;
 
   LOG_DEBUG("Analyzing scalar V->C dependencies from control flow ops...\n");
 
@@ -750,7 +768,7 @@ void DataDependencyAnalysisPass::analyzeScalarVToCDependencies(
       }
 
       llvm::DenseSet<mlir::Operation *> visited;
-      if (!hasVectorOpInDefChain(bound, visited)) {
+      if (!hasVectorOpInDefChain(bound, visited, &handledScalarValues)) {
         continue;
       }
 
@@ -783,6 +801,7 @@ void DataDependencyAnalysisPass::analyzeScalarVToCDependencies(
                        producerId, consumerId, info);
         v2cDependencies.back().isScaler = true;
       }
+      handledScalarValues.insert(bound);
     }
   });
 
@@ -803,7 +822,7 @@ void DataDependencyAnalysisPass::analyzeScalarVToCDependencies(
     }
 
     llvm::DenseSet<mlir::Operation *> visited;
-    if (!hasVectorOpInDefChain(condition, visited)) {
+    if (!hasVectorOpInDefChain(condition, visited, &handledScalarValues)) {
       return;
     }
 
@@ -829,6 +848,7 @@ void DataDependencyAnalysisPass::analyzeScalarVToCDependencies(
     collectDepInfo(condition, DependencyType::VectorToCube, v2cDependencies,
                    producerId, consumerId, info);
     v2cDependencies.back().isScaler = true;
+    handledScalarValues.insert(condition);
   });
 
   LOG_DEBUG("Scalar V->C dependency analysis complete.\n");

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -781,26 +781,23 @@ void DataDependencyAnalysisPass::analyzeScalarVToCDependencies(
       LOG_DEBUG("Found scalar V->C dependency from forOp bounds: "
                 << bound << "\n");
 
-      // Record a V->C dependency for each CUBE block that consumes this scalar.
-      llvm::DenseSet<int> handledConsumers;
-      for (mlir::Operation *user : bound.getUsers()) {
-        auto consumerIdOpt = CVPipeline::getOpBlockId(user);
-        if (!consumerIdOpt) {
-          continue;
-        }
-        int consumerId = *consumerIdOpt;
-        auto it = blockInfoMap.find(consumerId);
-        if (it == blockInfoMap.end() || !it->second.isCube) {
-          continue;
-        }
-        if (!handledConsumers.insert(consumerId).second) {
-          continue;
-        }
-
-        collectDepInfo(bound, DependencyType::VectorToCube, v2cDependencies,
-                       producerId, consumerId, info);
-        v2cDependencies.back().isScaler = true;
+      // Record a single V->C dependency using the for-loop op's own block_id
+      // as the consumer.  The bound is also used by ops inside the loop body,
+      // but those are in the same CUBE scope after CV separation and will use
+      // the transferred value via normal SSA dominance — no separate transfer
+      // needed per inner consumer.
+      auto forBlockIdOpt = CVPipeline::getOpBlockId(forOp.getOperation());
+      if (!forBlockIdOpt) {
+        continue;
       }
+      int forBlockId = *forBlockIdOpt;
+      auto it = blockInfoMap.find(forBlockId);
+      if (it == blockInfoMap.end() || !it->second.isCube) {
+        continue;
+      }
+      collectDepInfo(bound, DependencyType::VectorToCube, v2cDependencies,
+                     producerId, forBlockId, info);
+      v2cDependencies.back().isScaler = true;
       handledScalarValues.insert(bound);
     }
   });

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -123,7 +123,11 @@ bool DataDependencyAnalysisPass::isValid1DValueForDependency(
     mlir::Value value) {
   auto tensorTy = dyn_cast<TensorType>(value.getType());
   if (tensorTy && tensorTy.getRank() == SHAPE_1D_LENGTH) {
-    return true;
+    // 只有被 linalg.broadcast 消费的 1-D tensor 才视为有效跨核依赖。
+    // 被 tensor.extract 消费的 1-D tensor 会先被标量化，由标量 SSBuffer
+    // 依赖通道传递，不需要单独的 1-D tensor CopyOp。
+    return llvm::all_of(value.getUsers(),
+                        [](mlir::Operation *u) { return isa<linalg::BroadcastOp>(u); });
   }
   return false;
 }
@@ -747,6 +751,77 @@ void DataDependencyAnalysisPass::analyzeScalarVToCDependencies(
 
   LOG_DEBUG("Analyzing scalar V->C dependencies from control flow ops...\n");
 
+  // ---- tensor.extract ops ----
+  // Detect scalars extracted from VECTOR-produced tensors and consumed by CUBE
+  // blocks.  The extract result is the natural scalar dependency boundary:
+  // transferring it via SSBuffer avoids the need for 1-D tensor CopyOps.
+  module.walk([&](tensor::ExtractOp extractOp) {
+    mlir::Value sourceTensor = extractOp.getTensor();
+    mlir::Operation *tensorDefOp = sourceTensor.getDefiningOp();
+    if (!tensorDefOp) {
+      return;
+    }
+
+    // Only handle extracts whose source tensor is produced in a VECTOR block.
+    auto tensorBlockIdOpt = CVPipeline::getOpBlockId(tensorDefOp);
+    if (!tensorBlockIdOpt) {
+      return;
+    }
+    auto tensorBlockIt = blockInfoMap.find(*tensorBlockIdOpt);
+    if (tensorBlockIt == blockInfoMap.end() || tensorBlockIt->second.isCube) {
+      return;
+    }
+    // tensorDefOp must be a VECTOR-only op on tensor (e.g. math.floor/ceil).
+    if (!CVPipeline::isVectorOnlyOp(tensorDefOp)) {
+      return;
+    }
+
+    mlir::Value scalarResult = extractOp.getResult();
+    if (!isa<mlir::IntegerType, mlir::FloatType>(scalarResult.getType())) {
+      return;
+    }
+
+    // The scalar must be consumed in at least one CUBE block.
+    // Use the extract op's own block as the producer so the SSBuffer store can
+    // reference the extracted scalar (it must dominate the store insertion
+    // point).  The tensor source is in a VECTOR block, making this a V->C dep.
+    auto extractBlockIdOpt = CVPipeline::getOpBlockId(extractOp.getOperation());
+    int producerId = extractBlockIdOpt.value_or(*tensorBlockIdOpt);
+    llvm::DenseSet<int> handledConsumers;
+    bool hasCubConsumer = false;
+    for (mlir::Operation *user : scalarResult.getUsers()) {
+      auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
+      if (!userBlockIdOpt) {
+        continue;
+      }
+      auto it = blockInfoMap.find(*userBlockIdOpt);
+      if (it != blockInfoMap.end() && it->second.isCube) {
+        hasCubConsumer = true;
+        if (handledConsumers.insert(*userBlockIdOpt).second) {
+          collectDepInfo(scalarResult, DependencyType::VectorToCube,
+                         v2cDependencies, producerId, *userBlockIdOpt, info);
+          v2cDependencies.back().isScaler = true;
+        }
+      }
+    }
+    if (hasCubConsumer) {
+      LOG_DEBUG("Found scalar V->C dependency from tensor.extract: "
+                << scalarResult << "\n");
+      handledScalarValues.insert(scalarResult);
+      // Mark any enclosing for-loop as handled: its bounds and any ifOp
+      // conditions inside derive from this transferred scalar, so they don't
+      // need separate transfers.
+      mlir::Operation *parent = extractOp->getParentOp();
+      while (parent) {
+        if (auto parentForOp = dyn_cast<scf::ForOp>(parent)) {
+          handledForOps.insert(parentForOp);
+          break;
+        }
+        parent = parent->getParentOp();
+      }
+    }
+  });
+
   // ---- scf.for loop bounds ----
   module.walk([&](scf::ForOp forOp) {
     if (!forOpHasCubeOps(forOp, blockInfoMap)) {
@@ -773,7 +848,19 @@ void DataDependencyAnalysisPass::analyzeScalarVToCDependencies(
       }
 
       llvm::DenseSet<mlir::Operation *> visited;
-      if (!hasVectorOpInDefChain(bound, visited, &handledScalarValues)) {
+      bool hasVectorDep =
+          hasVectorOpInDefChain(bound, visited, &handledScalarValues);
+      if (!hasVectorDep) {
+        // The trace may have been stopped by an already-handled scalar
+        // (e.g. a tensor.extract result transferred by the extract pass).
+        // In that case the bound itself needs no new transfer, but the
+        // enclosing loop still becomes "handled" so that ifOp conditions
+        // inside it are not redundantly detected.
+        llvm::DenseSet<mlir::Operation *> visitedNoStop;
+        if (!hasVectorOpInDefChain(bound, visitedNoStop)) {
+          continue;
+        }
+        handledForOps.insert(forOp);
         continue;
       }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -740,6 +740,11 @@ void DataDependencyAnalysisPass::analyzeScalarVToCDependencies(
   // available on the CUBE side after SSBuffer transfer.
   llvm::DenseSet<mlir::Value> handledScalarValues;
 
+  // For-loops whose bounds have been handled — ifOp conditions inside these
+  // loops will be computable on CUBE via the induction variable after the
+  // bounds are transferred, so they don't need separate scalar deps.
+  llvm::DenseSet<scf::ForOp> handledForOps;
+
   LOG_DEBUG("Analyzing scalar V->C dependencies from control flow ops...\n");
 
   // ---- scf.for loop bounds ----
@@ -781,6 +786,11 @@ void DataDependencyAnalysisPass::analyzeScalarVToCDependencies(
       LOG_DEBUG("Found scalar V->C dependency from forOp bounds: "
                 << bound << "\n");
 
+      // Mark this for-loop as handled so that ifOp conditions nested inside
+      // it are skipped — they will be computable on CUBE via the induction
+      // variable once the bounds are transferred.
+      handledForOps.insert(forOp);
+
       // Record a single V->C dependency using the for-loop op's own block_id
       // as the consumer.  The bound is also used by ops inside the loop body,
       // but those are in the same CUBE scope after CV separation and will use
@@ -806,6 +816,19 @@ void DataDependencyAnalysisPass::analyzeScalarVToCDependencies(
   module.walk([&](scf::IfOp ifOp) {
     if (!ifOpHasCubeOps(ifOp, blockInfoMap)) {
       return;
+    }
+
+    // Skip if this ifOp is nested inside a for-loop whose bounds have already
+    // been transferred.  The induction variable carries the transferred values,
+    // so any scalar condition computed from it is already available on CUBE.
+    mlir::Operation *parent = ifOp->getParentOp();
+    while (parent) {
+      if (auto parentForOp = dyn_cast<scf::ForOp>(parent)) {
+        if (handledForOps.contains(parentForOp)) {
+          return;
+        }
+      }
+      parent = parent->getParentOp();
     }
 
     mlir::Value condition = ifOp.getCondition();

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -650,6 +650,190 @@ void DataDependencyAnalysisPass::collectMemDepInfo(
   memoryDependencies.push_back(depInfo);
 }
 
+// Trace defining op chain to check if any upstream op is vector-only.
+// Returns true if a vector-only op is found in the chain.
+// This mirrors AnalyzeCubeControlFlowInputChain's hasIncompatibleOpForCondition.
+static bool hasVectorOpInDefChain(mlir::Value val,
+                                  llvm::DenseSet<mlir::Operation *> &visited) {
+  mlir::Operation *defOp = val.getDefiningOp();
+  if (!defOp || visited.contains(defOp)) {
+    return false;
+  }
+  visited.insert(defOp);
+
+  if (CVPipeline::isVectorOnlyOp(defOp)) {
+    return true;
+  }
+
+  for (mlir::Value operand : defOp->getOperands()) {
+    if (hasVectorOpInDefChain(operand, visited)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Check if a scf.for body contains CUBE operations.
+static bool forOpHasCubeOps(
+    scf::ForOp forOp,
+    llvm::DenseMap<int, BlockInfo> &blockInfoMap) {
+  bool hasCube = false;
+  forOp.walk([&](mlir::Operation *op) {
+    auto blockIdOpt = CVPipeline::getOpBlockId(op);
+    if (!blockIdOpt) {
+      return mlir::WalkResult::advance();
+    }
+    auto it = blockInfoMap.find(*blockIdOpt);
+    if (it != blockInfoMap.end() && it->second.isCube) {
+      hasCube = true;
+      return mlir::WalkResult::interrupt();
+    }
+    return mlir::WalkResult::advance();
+  });
+  return hasCube;
+}
+
+// Check if any region of an scf.if contains CUBE operations.
+static bool ifOpHasCubeOps(
+    scf::IfOp ifOp,
+    llvm::DenseMap<int, BlockInfo> &blockInfoMap) {
+  bool hasCube = false;
+  ifOp.walk([&](mlir::Operation *op) {
+    auto blockIdOpt = CVPipeline::getOpBlockId(op);
+    if (!blockIdOpt) {
+      return mlir::WalkResult::advance();
+    }
+    auto it = blockInfoMap.find(*blockIdOpt);
+    if (it != blockInfoMap.end() && it->second.isCube) {
+      hasCube = true;
+      return mlir::WalkResult::interrupt();
+    }
+    return mlir::WalkResult::advance();
+  });
+  return hasCube;
+}
+
+// Analyze scalar V->C dependencies from control flow ops.
+// Detects when scf.for loop bounds or scf.if conditions are scalar values whose
+// defining chain traces back to vector-only ops (e.g. math.floor/math.ceil on
+// tensors, linalg.reduce). These scalars must be transferred from VECTOR to CUBE.
+void DataDependencyAnalysisPass::analyzeScalarVToCDependencies(
+    DataDependencyInfo &info) {
+  auto &blockInfoMap = info.getBlockInfoMap();
+  auto &v2cDependencies = info.getV2CDependencies();
+
+  LOG_DEBUG("Analyzing scalar V->C dependencies from control flow ops...\n");
+
+  // ---- scf.for loop bounds ----
+  module.walk([&](scf::ForOp forOp) {
+    if (!forOpHasCubeOps(forOp, blockInfoMap)) {
+      return;
+    }
+
+    llvm::SmallVector<mlir::Value> bounds;
+    bounds.push_back(forOp.getLowerBound());
+    bounds.push_back(forOp.getUpperBound());
+    // Step is typically a constant; still check it for completeness.
+    bounds.push_back(forOp.getStep());
+
+    for (mlir::Value bound : bounds) {
+      // Only handle scalar types (int/float/index). Tensor types cannot be
+      // transferred through the SSBuffer scalar channel.
+      if (!isa<mlir::IntegerType, mlir::FloatType, mlir::IndexType>(
+              bound.getType())) {
+        continue;
+      }
+
+      mlir::Operation *defOp = bound.getDefiningOp();
+      if (!defOp) {
+        continue;
+      }
+
+      llvm::DenseSet<mlir::Operation *> visited;
+      if (!hasVectorOpInDefChain(bound, visited)) {
+        continue;
+      }
+
+      auto producerIdOpt = CVPipeline::getOpBlockId(defOp);
+      if (!producerIdOpt) {
+        continue;
+      }
+      int producerId = *producerIdOpt;
+
+      LOG_DEBUG("Found scalar V->C dependency from forOp bounds: "
+                << bound << "\n");
+
+      // Record a V->C dependency for each CUBE block that consumes this scalar.
+      llvm::DenseSet<int> handledConsumers;
+      for (mlir::Operation *user : bound.getUsers()) {
+        auto consumerIdOpt = CVPipeline::getOpBlockId(user);
+        if (!consumerIdOpt) {
+          continue;
+        }
+        int consumerId = *consumerIdOpt;
+        auto it = blockInfoMap.find(consumerId);
+        if (it == blockInfoMap.end() || !it->second.isCube) {
+          continue;
+        }
+        if (!handledConsumers.insert(consumerId).second) {
+          continue;
+        }
+
+        collectDepInfo(bound, DependencyType::VectorToCube, v2cDependencies,
+                       producerId, consumerId, info);
+        v2cDependencies.back().isScaler = true;
+      }
+    }
+  });
+
+  // ---- scf.if condition ----
+  module.walk([&](scf::IfOp ifOp) {
+    if (!ifOpHasCubeOps(ifOp, blockInfoMap)) {
+      return;
+    }
+
+    mlir::Value condition = ifOp.getCondition();
+    if (!isa<mlir::IntegerType>(condition.getType())) {
+      return;
+    }
+
+    mlir::Operation *defOp = condition.getDefiningOp();
+    if (!defOp) {
+      return;
+    }
+
+    llvm::DenseSet<mlir::Operation *> visited;
+    if (!hasVectorOpInDefChain(condition, visited)) {
+      return;
+    }
+
+    auto producerIdOpt = CVPipeline::getOpBlockId(defOp);
+    if (!producerIdOpt) {
+      return;
+    }
+    int producerId = *producerIdOpt;
+
+    auto consumerIdOpt = CVPipeline::getOpBlockId(ifOp.getOperation());
+    if (!consumerIdOpt) {
+      return;
+    }
+    int consumerId = *consumerIdOpt;
+    auto it = blockInfoMap.find(consumerId);
+    if (it == blockInfoMap.end() || !it->second.isCube) {
+      return;
+    }
+
+    LOG_DEBUG("Found scalar V->C dependency from ifOp condition: "
+              << condition << "\n");
+
+    collectDepInfo(condition, DependencyType::VectorToCube, v2cDependencies,
+                   producerId, consumerId, info);
+    v2cDependencies.back().isScaler = true;
+  });
+
+  LOG_DEBUG("Scalar V->C dependency analysis complete.\n");
+}
+
 void DataDependencyAnalysisPass::analyzeMemoryEffect(DataDependencyInfo &info) {
   auto &memoryDependencies = info.getMemoryDependencies();
   LOG_DEBUG("\n=== start mem dep analysis ===\n");
@@ -847,6 +1031,8 @@ void DataDependencyAnalysisPass::runOnOperation() {
   analyzeExternalInputs(info);
 
   analyzeExternalOutputs(info);
+
+  analyzeScalarVToCDependencies(info);
 
   // Step 4: Analyze memory dependencies (memdep sync)
   analyzeMemoryEffect(info);

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -549,7 +549,15 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(
   int cubeBlockId = CVPipeline::getOpBlockId(cubeStartOp).value_or(-1);
 
   if (isScaler) {
-    builder.setInsertionPointAfter(vectorEndOp);
+    // Insert the store right after srcValue's defining op (when it has one)
+    // so that the store dominates the load and the scalar consumers.  Falling
+    // back to vectorEndOp keeps behavior for block-argument / external values.
+    mlir::Operation *srcDefOp = srcValue.getDefiningOp();
+    if (srcDefOp) {
+      builder.setInsertionPointAfter(srcDefOp);
+    } else {
+      builder.setInsertionPointAfter(vectorEndOp);
+    }
     SmallVector<Operation *> writeOps;
     LOG_DEBUG("before writeToSSBuffer\n");
     auto addrOpt = ssbufferManager.writeToSSBuffer(srcValue, builder, writeOps);
@@ -570,7 +578,16 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(
     attachCrossCoreDeps(sendOp, transferIndex, CVPipeline::crossCoreProducerId,
                         builder);
     LOG_DEBUG("before readFromSSBuffer\n");
-    builder.setInsertionPoint(cubeStartOp);
+    // Place the load after the store when both are in the same MLIR block,
+    // otherwise the load would read an uninitialized SSBuffer slot (store and
+    // load can share a block when producer block == consumer block).
+    if (sendOp && cubeStartOp &&
+        sendOp->getBlock() == cubeStartOp->getBlock() &&
+        !sendOp->isBeforeInBlock(cubeStartOp)) {
+      builder.setInsertionPointAfter(sendOp);
+    } else {
+      builder.setInsertionPoint(cubeStartOp);
+    }
     SmallVector<Operation *> readOps;
     auto loadedValueOpt =
         ssbufferManager.readFromSSBuffer(addr, builder, readOps);
@@ -654,6 +671,12 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(
                                        srcValue.getUsers().end());
   for (Operation *user : users) {
     LOG_DEBUG("[v->c user]" << *user << "\n");
+    // Do not rewrite the store/send op itself: it must keep referencing the
+    // original srcValue, otherwise the value stored into SSBuffer would be the
+    // just-loaded receiveValue (a store→load self loop).
+    if (user == sendOp) {
+      continue;
+    }
     auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
     if (userBlockIdOpt && *userBlockIdOpt == iniConsumerId) {
       user->replaceUsesOfWith(srcValue, receiveValue);

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
@@ -22,8 +22,6 @@
 
 #include <optional>
 
-#include <map>
-
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
@@ -36,13 +34,11 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Pass/Pass.h"
-#include "mlir/Transforms/RegionUtils.h"
 
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/SeparateCVScope.h"
@@ -956,234 +952,6 @@ static void cleanupSsbufferAttrs(Operation *rootOp) {
   rootOp->walk([](Operation *op) { removeSsbufferAttrs(op); });
 }
 
-// Record, for every value produced along the forward use-chain rooted at
-// `root`, the sequence of op names that led to it.  This lets us pair up a
-// value on the VECTOR side (from a SSBuffer store) with the structurally
-// identical value on the CUBE side (from the matching SSBuffer load).
-static void collectChainPaths(
-    Value root, llvm::DenseMap<Value, std::string> &paths) {
-  llvm::SmallVector<Value> worklist;
-  worklist.push_back(root);
-  paths[root] = "";
-  while (!worklist.empty()) {
-    Value cur = worklist.pop_back_val();
-    std::string curPath = paths[cur];
-    Region *rootRegion = root.getParentRegion();
-    for (Operation *user : cur.getUsers()) {
-      if (user->getNumResults() == 0) {
-        continue;
-      }
-      // Only follow single-result pure-compute ops; stop at anything with
-      // regions or side effects.
-      if (user->getNumRegions() > 0 ||
-          !mlir::wouldOpBeTriviallyDead(user)) {
-        continue;
-      }
-      // Do not cross into nested regions (e.g. a scf.for body): a use inside a
-      // loop is not a candidate for the boundary-mapping used here, and
-      // substituting a value defined there would break dominance.
-      if (user->getBlock()->getParent() != rootRegion) {
-        continue;
-      }
-      Value res = user->getResult(0);
-      if (paths.contains(res)) {
-        continue;
-      }
-      paths[res] = curPath + user->getName().getStringRef().str() + ";";
-      worklist.push_back(res);
-    }
-  }
-}
-
-// Rewrite uses in the CUBE scope that reference values computed on the VECTOR
-// side (boundary scalars derived from math.floor/math.ceil via tensor.extract).
-//
-// Such references are left-over copies of the VECTOR boundary chain that
-// SeparateCVScope cloned into the CUBE scope's mixed for-loop.  The CUBE scope
-// already has an equivalent chain rooted at the SSBuffer load for the same
-// transfer_id (e.g. load %79 -> fptosi -> muli -> %89 vs VECTOR
-// store %extracted_12 -> fptosi -> muli -> %35).  Rewriting the reference makes
-// the VECTOR chain dead so retainNeededOpsInScope can drop it (and the
-// math.floor/math.ceil feeding it), which is required for
-// AnalyzeCubeControlFlowInputChain not to reject the module.
-static void replaceVectorRefsInCubeScope(scope::ScopeOp cubeScope,
-                                         scope::ScopeOp vecScope) {
-  // Map (block_id, op_name) of a VECTOR-side math op to its transfer_id by
-  // walking the store value back to the tensor.extract tensor operand.
-  std::map<std::pair<int, std::string>, int64_t> vecMathToTid;
-  vecScope.walk([&](LLVM::StoreOp storeOp) {
-    auto tidAttr =
-        storeOp->getAttrOfType<mlir::IntegerAttr>(CVPipeline::kTransferId);
-    if (!tidAttr) {
-      return;
-    }
-    Value storeVal = storeOp.getValue();
-    if (auto ext = dyn_cast<tensor::ExtractOp>(storeVal.getDefiningOp())) {
-      Operation *tensorDef = ext.getTensor().getDefiningOp();
-      if (tensorDef) {
-        auto blockIdOpt = CVPipeline::getOpBlockId(tensorDef);
-        if (blockIdOpt) {
-          vecMathToTid[{*blockIdOpt,
-                        tensorDef->getName().getStringRef().str()}] =
-              tidAttr.getInt();
-        }
-      }
-    }
-  });
-
-  // CUBE-side chains rooted at SSBuffer loads: (transfer, path) -> value.
-  std::map<int64_t, std::map<std::string, Value>> cubePathsByTid;
-  cubeScope.walk([&](LLVM::LoadOp loadOp) {
-    auto tidAttr =
-        loadOp->getAttrOfType<mlir::IntegerAttr>(CVPipeline::kTransferId);
-    if (!tidAttr) {
-      return;
-    }
-    llvm::DenseMap<Value, std::string> paths;
-    collectChainPaths(loadOp.getResult(), paths);
-    for (auto &pk : paths) {
-      cubePathsByTid[tidAttr.getInt()][pk.second] = pk.first;
-    }
-  });
-
-  // Boundary scalars in the CUBE scope derived from VECTOR math ops: value ->
-  // (transfer, path).  The path is measured from the extracted scalar, so it
-  // aligns with the load-rooted chain path (both skip tensor.extract).
-  llvm::DenseMap<Value, std::pair<int64_t, std::string>> cubeVecBoundary;
-  cubeScope.walk([&](Operation *op) {
-    if (!isa<math::MathDialect>(op->getDialect())) {
-      return;
-    }
-    auto blockIdOpt = CVPipeline::getOpBlockId(op);
-    if (!blockIdOpt) {
-      return;
-    }
-    std::string opName = op->getName().getStringRef().str();
-    auto mIt = vecMathToTid.find({*blockIdOpt, opName});
-    if (mIt == vecMathToTid.end()) {
-      return;
-    }
-    for (Value result : op->getResults()) {
-      for (Operation *user : result.getUsers()) {
-        auto ext = dyn_cast<tensor::ExtractOp>(user);
-        if (!ext) {
-          continue;
-        }
-        llvm::DenseMap<Value, std::string> paths;
-        collectChainPaths(ext.getResult(), paths);
-        for (auto &pk : paths) {
-          cubeVecBoundary[pk.first] = {mIt->second, pk.second};
-        }
-      }
-    }
-  });
-
-  llvm::SmallVector<std::pair<mlir::OpOperand *, mlir::Value>> rewrites;
-  cubeScope.walk([&](Operation *op) {
-    for (mlir::OpOperand &operand : op->getOpOperands()) {
-      Value v = operand.get();
-      auto bIt = cubeVecBoundary.find(v);
-      if (bIt == cubeVecBoundary.end()) {
-        continue;
-      }
-      int64_t tid = bIt->second.first;
-      const std::string &path = bIt->second.second;
-      auto tIt = cubePathsByTid.find(tid);
-      if (tIt == cubePathsByTid.end()) {
-        continue;
-      }
-      auto pIt = tIt->second.find(path);
-      if (pIt == tIt->second.end()) {
-        continue;
-      }
-      mlir::Value replacement = pIt->second;
-      if (replacement.getType() != v.getType()) {
-        continue;
-      }
-      rewrites.push_back({&operand, replacement});
-    }
-  });
-  for (auto &rw : rewrites) {
-    rw.first->set(rw.second);
-  }
-}
-
-// Keep only the ops a scope actually needs, erasing the rest if trivially dead.
-//
-// After InterCoreTransferAndSync replaces tensor.extract results with SSBuffer
-// loads, the extract op and its upstream VECTOR-only chain (math.floor/ceil,
-// boundary computation) may be left behind in the CUBE scope.  Each op in that
-// chain references the next one, so a plain use_empty() check never triggers
-// and the VECTOR-only ops keep leaking into the CUBE scope (later rejected by
-// AnalyzeCubeControlFlowInputChain).
-//
-// Seeds the retained set with ops whose core_type matches the scope, then
-// transitively retains every op feeding a retained op.  Everything else that is
-// trivially dead gets erased.
-static void retainNeededOpsInScope(scope::ScopeOp scopeOp, StringRef scopeType) {
-  llvm::SmallVector<Operation *> ops;
-  scopeOp.walk([&](Operation *op) {
-    if (op->getNumRegions() == 0) {
-      ops.push_back(op);
-    }
-  });
-
-  llvm::DenseSet<Operation *> retained;
-  for (Operation *op : ops) {
-    if (matchesScope(op, scopeType)) {
-      retained.insert(op);
-    }
-  }
-
-  bool changed = true;
-  while (changed) {
-    changed = false;
-    for (Operation *op : ops) {
-      if (retained.contains(op)) {
-        continue;
-      }
-      for (Value result : op->getResults()) {
-        for (Operation *user : result.getUsers()) {
-          if (retained.contains(user)) {
-            retained.insert(op);
-            changed = true;
-            break;
-          }
-        }
-        if (retained.contains(op)) {
-          break;
-        }
-      }
-    }
-  }
-
-  // Iteratively erase use-free ops.  This includes ops that matched the scope
-  // (retained as seeds): a tensor.extract that used to feed a cross-core scalar
-  // may have had all its uses rewritten to the SSBuffer load and is now dead;
-  // keeping it would keep the VECTOR-only math op it consumes alive in this
-  // scope.  Ops with side effects (memref/llvm ops, etc.) are left alone by
-  // wouldOpBeTriviallyDead.
-  bool erased = true;
-  while (erased) {
-    erased = false;
-    llvm::SmallVector<Operation *> toErase;
-    scopeOp.walk([&](Operation *op) {
-      if (op->getNumRegions() > 0) {
-        return;
-      }
-      if (op->use_empty() && mlir::wouldOpBeTriviallyDead(op)) {
-        toErase.push_back(op);
-      }
-    });
-    for (Operation *op : toErase) {
-      if (op->getBlock() && op->use_empty()) {
-        op->erase();
-        erased = true;
-      }
-    }
-  }
-}
-
 static LogicalResult separateScopes(func::FuncOp funcOp) {
   debugDumpOperation("before SeparateCVScope on func", funcOp.getOperation());
 
@@ -1206,13 +974,6 @@ static LogicalResult separateScopes(func::FuncOp funcOp) {
              funcOp.getName(), "'");
     return failure();
   }
-
-  // Rewrite leftover VECTOR-boundary references in the CUBE scope to their
-  // CUBE-side equivalents, then drop the now-dead chains so VECTOR-only ops do
-  // not leak into the CUBE scope.
-  replaceVectorRefsInCubeScope(cubeScope, vecScope);
-  retainNeededOpsInScope(cubeScope, "CUBE");
-  retainNeededOpsInScope(vecScope, "VECTOR");
 
   cleanupSsbufferAttrs(funcOp);
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
@@ -22,6 +22,8 @@
 
 #include <optional>
 
+#include <map>
+
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
@@ -34,11 +36,13 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/RegionUtils.h"
 
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/SeparateCVScope.h"
@@ -952,6 +956,234 @@ static void cleanupSsbufferAttrs(Operation *rootOp) {
   rootOp->walk([](Operation *op) { removeSsbufferAttrs(op); });
 }
 
+// Record, for every value produced along the forward use-chain rooted at
+// `root`, the sequence of op names that led to it.  This lets us pair up a
+// value on the VECTOR side (from a SSBuffer store) with the structurally
+// identical value on the CUBE side (from the matching SSBuffer load).
+static void collectChainPaths(
+    Value root, llvm::DenseMap<Value, std::string> &paths) {
+  llvm::SmallVector<Value> worklist;
+  worklist.push_back(root);
+  paths[root] = "";
+  while (!worklist.empty()) {
+    Value cur = worklist.pop_back_val();
+    std::string curPath = paths[cur];
+    Region *rootRegion = root.getParentRegion();
+    for (Operation *user : cur.getUsers()) {
+      if (user->getNumResults() == 0) {
+        continue;
+      }
+      // Only follow single-result pure-compute ops; stop at anything with
+      // regions or side effects.
+      if (user->getNumRegions() > 0 ||
+          !mlir::wouldOpBeTriviallyDead(user)) {
+        continue;
+      }
+      // Do not cross into nested regions (e.g. a scf.for body): a use inside a
+      // loop is not a candidate for the boundary-mapping used here, and
+      // substituting a value defined there would break dominance.
+      if (user->getBlock()->getParent() != rootRegion) {
+        continue;
+      }
+      Value res = user->getResult(0);
+      if (paths.contains(res)) {
+        continue;
+      }
+      paths[res] = curPath + user->getName().getStringRef().str() + ";";
+      worklist.push_back(res);
+    }
+  }
+}
+
+// Rewrite uses in the CUBE scope that reference values computed on the VECTOR
+// side (boundary scalars derived from math.floor/math.ceil via tensor.extract).
+//
+// Such references are left-over copies of the VECTOR boundary chain that
+// SeparateCVScope cloned into the CUBE scope's mixed for-loop.  The CUBE scope
+// already has an equivalent chain rooted at the SSBuffer load for the same
+// transfer_id (e.g. load %79 -> fptosi -> muli -> %89 vs VECTOR
+// store %extracted_12 -> fptosi -> muli -> %35).  Rewriting the reference makes
+// the VECTOR chain dead so retainNeededOpsInScope can drop it (and the
+// math.floor/math.ceil feeding it), which is required for
+// AnalyzeCubeControlFlowInputChain not to reject the module.
+static void replaceVectorRefsInCubeScope(scope::ScopeOp cubeScope,
+                                         scope::ScopeOp vecScope) {
+  // Map (block_id, op_name) of a VECTOR-side math op to its transfer_id by
+  // walking the store value back to the tensor.extract tensor operand.
+  std::map<std::pair<int, std::string>, int64_t> vecMathToTid;
+  vecScope.walk([&](LLVM::StoreOp storeOp) {
+    auto tidAttr =
+        storeOp->getAttrOfType<mlir::IntegerAttr>(CVPipeline::kTransferId);
+    if (!tidAttr) {
+      return;
+    }
+    Value storeVal = storeOp.getValue();
+    if (auto ext = dyn_cast<tensor::ExtractOp>(storeVal.getDefiningOp())) {
+      Operation *tensorDef = ext.getTensor().getDefiningOp();
+      if (tensorDef) {
+        auto blockIdOpt = CVPipeline::getOpBlockId(tensorDef);
+        if (blockIdOpt) {
+          vecMathToTid[{*blockIdOpt,
+                        tensorDef->getName().getStringRef().str()}] =
+              tidAttr.getInt();
+        }
+      }
+    }
+  });
+
+  // CUBE-side chains rooted at SSBuffer loads: (transfer, path) -> value.
+  std::map<int64_t, std::map<std::string, Value>> cubePathsByTid;
+  cubeScope.walk([&](LLVM::LoadOp loadOp) {
+    auto tidAttr =
+        loadOp->getAttrOfType<mlir::IntegerAttr>(CVPipeline::kTransferId);
+    if (!tidAttr) {
+      return;
+    }
+    llvm::DenseMap<Value, std::string> paths;
+    collectChainPaths(loadOp.getResult(), paths);
+    for (auto &pk : paths) {
+      cubePathsByTid[tidAttr.getInt()][pk.second] = pk.first;
+    }
+  });
+
+  // Boundary scalars in the CUBE scope derived from VECTOR math ops: value ->
+  // (transfer, path).  The path is measured from the extracted scalar, so it
+  // aligns with the load-rooted chain path (both skip tensor.extract).
+  llvm::DenseMap<Value, std::pair<int64_t, std::string>> cubeVecBoundary;
+  cubeScope.walk([&](Operation *op) {
+    if (!isa<math::MathDialect>(op->getDialect())) {
+      return;
+    }
+    auto blockIdOpt = CVPipeline::getOpBlockId(op);
+    if (!blockIdOpt) {
+      return;
+    }
+    std::string opName = op->getName().getStringRef().str();
+    auto mIt = vecMathToTid.find({*blockIdOpt, opName});
+    if (mIt == vecMathToTid.end()) {
+      return;
+    }
+    for (Value result : op->getResults()) {
+      for (Operation *user : result.getUsers()) {
+        auto ext = dyn_cast<tensor::ExtractOp>(user);
+        if (!ext) {
+          continue;
+        }
+        llvm::DenseMap<Value, std::string> paths;
+        collectChainPaths(ext.getResult(), paths);
+        for (auto &pk : paths) {
+          cubeVecBoundary[pk.first] = {mIt->second, pk.second};
+        }
+      }
+    }
+  });
+
+  llvm::SmallVector<std::pair<mlir::OpOperand *, mlir::Value>> rewrites;
+  cubeScope.walk([&](Operation *op) {
+    for (mlir::OpOperand &operand : op->getOpOperands()) {
+      Value v = operand.get();
+      auto bIt = cubeVecBoundary.find(v);
+      if (bIt == cubeVecBoundary.end()) {
+        continue;
+      }
+      int64_t tid = bIt->second.first;
+      const std::string &path = bIt->second.second;
+      auto tIt = cubePathsByTid.find(tid);
+      if (tIt == cubePathsByTid.end()) {
+        continue;
+      }
+      auto pIt = tIt->second.find(path);
+      if (pIt == tIt->second.end()) {
+        continue;
+      }
+      mlir::Value replacement = pIt->second;
+      if (replacement.getType() != v.getType()) {
+        continue;
+      }
+      rewrites.push_back({&operand, replacement});
+    }
+  });
+  for (auto &rw : rewrites) {
+    rw.first->set(rw.second);
+  }
+}
+
+// Keep only the ops a scope actually needs, erasing the rest if trivially dead.
+//
+// After InterCoreTransferAndSync replaces tensor.extract results with SSBuffer
+// loads, the extract op and its upstream VECTOR-only chain (math.floor/ceil,
+// boundary computation) may be left behind in the CUBE scope.  Each op in that
+// chain references the next one, so a plain use_empty() check never triggers
+// and the VECTOR-only ops keep leaking into the CUBE scope (later rejected by
+// AnalyzeCubeControlFlowInputChain).
+//
+// Seeds the retained set with ops whose core_type matches the scope, then
+// transitively retains every op feeding a retained op.  Everything else that is
+// trivially dead gets erased.
+static void retainNeededOpsInScope(scope::ScopeOp scopeOp, StringRef scopeType) {
+  llvm::SmallVector<Operation *> ops;
+  scopeOp.walk([&](Operation *op) {
+    if (op->getNumRegions() == 0) {
+      ops.push_back(op);
+    }
+  });
+
+  llvm::DenseSet<Operation *> retained;
+  for (Operation *op : ops) {
+    if (matchesScope(op, scopeType)) {
+      retained.insert(op);
+    }
+  }
+
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (Operation *op : ops) {
+      if (retained.contains(op)) {
+        continue;
+      }
+      for (Value result : op->getResults()) {
+        for (Operation *user : result.getUsers()) {
+          if (retained.contains(user)) {
+            retained.insert(op);
+            changed = true;
+            break;
+          }
+        }
+        if (retained.contains(op)) {
+          break;
+        }
+      }
+    }
+  }
+
+  // Iteratively erase use-free ops.  This includes ops that matched the scope
+  // (retained as seeds): a tensor.extract that used to feed a cross-core scalar
+  // may have had all its uses rewritten to the SSBuffer load and is now dead;
+  // keeping it would keep the VECTOR-only math op it consumes alive in this
+  // scope.  Ops with side effects (memref/llvm ops, etc.) are left alone by
+  // wouldOpBeTriviallyDead.
+  bool erased = true;
+  while (erased) {
+    erased = false;
+    llvm::SmallVector<Operation *> toErase;
+    scopeOp.walk([&](Operation *op) {
+      if (op->getNumRegions() > 0) {
+        return;
+      }
+      if (op->use_empty() && mlir::wouldOpBeTriviallyDead(op)) {
+        toErase.push_back(op);
+      }
+    });
+    for (Operation *op : toErase) {
+      if (op->getBlock() && op->use_empty()) {
+        op->erase();
+        erased = true;
+      }
+    }
+  }
+}
+
 static LogicalResult separateScopes(func::FuncOp funcOp) {
   debugDumpOperation("before SeparateCVScope on func", funcOp.getOperation());
 
@@ -974,6 +1206,13 @@ static LogicalResult separateScopes(func::FuncOp funcOp) {
              funcOp.getName(), "'");
     return failure();
   }
+
+  // Rewrite leftover VECTOR-boundary references in the CUBE scope to their
+  // CUBE-side equivalents, then drop the now-dead chains so VECTOR-only ops do
+  // not leak into the CUBE scope.
+  replaceVectorRefsInCubeScope(cubeScope, vecScope);
+  retainNeededOpsInScope(cubeScope, "CUBE");
+  retainNeededOpsInScope(vecScope, "VECTOR");
 
   cleanupSsbufferAttrs(funcOp);
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
@@ -31,6 +31,7 @@
 #include "bishengir/Dialect/Scope/IR/Scope.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"
@@ -1013,6 +1014,58 @@ void mlir::triton::SeparateCVScopePass::runOnOperation() {
   module.walk([](scope::ScopeOp scopeOp) {
     scopeOp->setAttr(CVPipeline::kHIVMMatmulLimitedInCubeAttr,
                      UnitAttr::get(scopeOp->getContext()));
+  });
+
+  // Eliminate redundant store→load pairs in VECTOR scopes.
+  // InterCoreTransferAndSync inserts llvm.store (send to SSBuffer) followed by
+  // llvm.load (receive on the consumer side).  After scope separation the
+  // VECTOR scope contains both: the store sends the value, and the load re-reads
+  // it for use as a for-loop bound.  The load is redundant — the stored value
+  // is already live — so replace loaded values with the stored value.
+  module.walk([](scope::ScopeOp scopeOp) {
+    auto coreTypeAttr =
+        scopeOp->getAttrOfType<hivm::TCoreTypeAttr>(hivm::TCoreTypeAttr::name);
+    if (!coreTypeAttr || coreTypeAttr.getTcoretype() != hivm::TCoreType::VECTOR) {
+      return;
+    }
+
+    llvm::DenseMap<int64_t, mlir::Value> storedValues;
+    scopeOp.walk([&](LLVM::StoreOp storeOp) {
+      auto transferIdAttr =
+          storeOp->getAttrOfType<mlir::IntegerAttr>(CVPipeline::kTransferId);
+      if (!transferIdAttr) {
+        return;
+      }
+      int64_t tid = transferIdAttr.getInt();
+      storedValues[tid] = storeOp.getValue();
+    });
+
+    if (storedValues.empty()) {
+      return;
+    }
+
+    llvm::SmallVector<LLVM::LoadOp> deadLoads;
+    scopeOp.walk([&](LLVM::LoadOp loadOp) {
+      auto transferIdAttr =
+          loadOp->getAttrOfType<mlir::IntegerAttr>(CVPipeline::kTransferId);
+      if (!transferIdAttr) {
+        return;
+      }
+      int64_t tid = transferIdAttr.getInt();
+      auto it = storedValues.find(tid);
+      if (it == storedValues.end()) {
+        return;
+      }
+      mlir::Value storeVal = it->second;
+      if (storeVal == loadOp.getResult()) {
+        return;
+      }
+      loadOp.replaceAllUsesWith(storeVal);
+      deadLoads.push_back(loadOp);
+    });
+    for (LLVM::LoadOp loadOp : deadLoads) {
+      loadOp->erase();
+    }
   });
 
   debugDumpOperation("after SeparateCVScopePass", module.getOperation());


### PR DESCRIPTION
Add analyzeScalarVToCDependencies to detect when scf.for loop bounds or scf.if conditions are scalar values whose defining chain traces back to vector-only ops (math.floor, math.ceil on tensors, linalg.reduce, etc.).

Also extend isVectorOnlyOp to include math::CeilOp.

Co-Authored-By: DeLong code

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
