### PR TITLE
[ssbuffer](fix) unify the view/tile ops in computeBlockOpt

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h
@@ -72,7 +72,8 @@ bool willCreateCycle(llvm::ArrayRef<Operation *> opsToUnify,
  * @param matchedOps The op set of one pattern (target op first).
  */
 void cloneScalarOpsForCrossBlockUses(ComputeBlockIdManager &bmOriginal,
-                                     SetVector<Operation *> &matchedOps);
+                                     SetVector<Operation *> &matchedOps,
+                                     int targetBlockId);
 
 } // namespace CVPipeline
 } // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
@@ -181,7 +181,10 @@ bool willCreateCycle(llvm::ArrayRef<Operation *> opsToUnify,
 }
 
 void cloneScalarOpsForCrossBlockUses(ComputeBlockIdManager &bmOriginal,
-                                     SetVector<Operation *> &matchedOps) {
+                                     SetVector<Operation *> &matchedOps,
+                                     int targetBlockId) {
+
+  // This means move matchedOps into targetBlockId
   auto sorted = mlir::topologicalSort(matchedOps);
   for (Operation *op : llvm::reverse(sorted)) {
     if (op->getNumResults() == 1 &&
@@ -196,15 +199,15 @@ void cloneScalarOpsForCrossBlockUses(ComputeBlockIdManager &bmOriginal,
         if (!userInBlock)
           continue;
         if (llvm::find(matchedOps, userInBlock) == matchedOps.end() &&
-            bmOriginal.getBlockIdByOp(userInBlock) !=
-                bmOriginal.getBlockIdByOp(matchedOps[0])) {
+            bmOriginal.getBlockIdByOp(userInBlock) != targetBlockId) {
           otherUses.push_back(&use);
         }
       }
       if (otherUses.size() > 0) {
-        LOG_DEBUG("now cloned: " << *op << "\n");
+        LOG_DEBUG("now cloned: " << *op);
         OpBuilder builder(op);
         auto clonedOp = builder.clone(*op);
+        bmOriginal.updateBlockId(clonedOp, bmOriginal.getBlockIdByOp(op));
         for (auto use : otherUses) {
           (*use).set(clonedOp->getResult(0));
         }

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
@@ -601,7 +601,8 @@ void FixpipeOptPass::runOnOperation() {
   */
   auto bmOriginal = CVPipeline::ComputeBlockIdManager(module);
   for (auto &matchedOps : allMatchedPatterns) {
-    CVPipeline::cloneScalarOpsForCrossBlockUses(bmOriginal, matchedOps);
+    CVPipeline::cloneScalarOpsForCrossBlockUses(
+        bmOriginal, matchedOps, bmOriginal.getBlockIdByOp(matchedOps[0]));
   }
 
   auto bm = CVPipeline::ComputeBlockIdManager(module);

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
@@ -30,6 +30,7 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "llvm/ADT/SmallVector.h"
@@ -197,6 +198,58 @@ static bool hasOtherOpsInIf(const FillInfo &info) {
   return opCount > 1;
 }
 
+/// Trace back along the view-like chain from \p copyOp's source and collect
+/// all ops. Only ops in the same Block as the copyOp are collected.
+static void traceViewChain(memref::CopyOp copyOp,
+                           SmallVectorImpl<Operation *> &result) {
+  for (Value v = copyOp.getSource(); auto *defOp = v.getDefiningOp();) {
+    if (defOp->getBlock() != copyOp->getBlock())
+      break;
+    if (auto viewOp = dyn_cast<ViewLikeOpInterface>(defOp))
+      result.push_back(viewOp), v = viewOp.getViewSource();
+    else if (auto sliceOp = dyn_cast<tensor::ExtractSliceOp>(defOp))
+      result.push_back(sliceOp), v = sliceOp.getSource();
+    else
+      break;
+  }
+}
+
+/**
+ * @brief Collect source view chain ops from memref.copy's source operand
+ *
+ * For each memref.copy found by penetrating ViewLike direct users (subview of
+ * alloc), trace back the copy's source operand along the ViewLikeOpInterface /
+ * tensor.extract_slice chain (e.g., memref.subview -> memref.reinterpret_cast
+ * -> tensor.extract_slice), and collect all ops in the chain.
+ *
+ * @param directUsers Direct users of alloc result (containing ViewLike ops
+ *                    whose users include memref.copy)
+ * @return SmallVector<Operation*> Collected source view chain ops
+ *
+ */
+static SmallVector<Operation *>
+collectSourceViewChainOps(ArrayRef<Operation *> directUsers) {
+  SmallVector<Operation *> chainOps;
+  for (Operation *op : directUsers) {
+    if (!isa<ViewLikeOpInterface, tensor::ExtractSliceOp>(op)) {
+      continue;
+    }
+    // Penetrate through view-like ops to find memref.copy users
+    SmallVector<Operation *> worklist = {op};
+    while (!worklist.empty()) {
+      Operation *cur = worklist.pop_back_val();
+      for (auto *user : cur->getUsers()) {
+        if (auto copyOp = dyn_cast<memref::CopyOp>(user)) {
+          traceViewChain(copyOp, chainOps);
+        } else if (isa<ViewLikeOpInterface, tensor::ExtractSliceOp>(user)) {
+          worklist.push_back(user);
+        }
+      }
+    }
+  }
+  return chainOps;
+}
+
 /**
  * @brief Try to unify block_id for a single alloc operation
  *
@@ -239,18 +292,19 @@ tryUnifyForAlloc(memref::AllocOp allocOp,
     return success();
   }
 
-  // Step5: Cycle detection and block_id assignment
+  // Step5: collect allocOp, ifOp, fillOp, directUsers and ViewChainOps
   SmallVector<Operation *> coreOps = {
       allocOp.getOperation(),
       fillInfo.fillOp.getOperation(),
       fillInfo.parentIf.getOperation(),
   };
   coreOps.append(directUsers);
+  coreOps.append(collectSourceViewChainOps(directUsers));
 
+  // Step6: Cycle detection and block_id assignment
   if (CVPipeline::willCreateCycle(coreOps, memGraph, targetBlockId, bm)) {
-    LOG_DEBUG(
-        "[Cycle detection] Find cycle, have unsupport IR! Should Check!!");
-    return success();
+    LOG_DEBUG("[error] Find cycle, have unsupport IR! Should Check!!");
+    return failure();
   }
   for (auto *op : coreOps) {
     bm.updateBlockId(op, targetBlockId);

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyStoreBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyStoreBlockPass.cpp
@@ -122,20 +122,17 @@ static Operation *traceProducerOp(Operation *storeOp,
 }
 
 /**
- * @brief Collect view ops (data chain + dest chain) to unify, filtered by
- * block_id.
+ * @brief Collect view ops (data chain + dest chain) to unify.
  *
- * Only view ops whose current block_id equals storeBlockId are appended to
- * @p ops (per design §5.1 block_id filter rule).
+ * All view ops reachable from @p dataViewOps and the dest chain are appended
+ * to @p ops. Duplicates are skipped via @p seen.
  */
 static void collectViewOpsToUnify(SmallVector<Operation *> &ops,
                                   Operation *storeOp,
                                   const SmallVector<Operation *> &dataViewOps,
-                                  CVPipeline::ComputeBlockIdManager &bm,
                                   SmallPtrSet<Operation *, 16> &seen) {
   auto addIfMatch = [&](Operation *op) {
-    if (bm.getBlockIdByOp(op) == bm.getBlockIdByOp(storeOp) &&
-        seen.insert(op).second) {
+    if (seen.insert(op).second && op->getBlock() == storeOp->getBlock()) {
       ops.push_back(op);
     }
   };
@@ -144,8 +141,7 @@ static void collectViewOpsToUnify(SmallVector<Operation *> &ops,
     addIfMatch(viewOp);
   }
 
-  // dest-chain view ops: walk up the dest memref's view chain and unify each
-  // view op whose block_id matches storeOp's block_id.
+  // dest-chain view ops: walk up the dest memref's view chain.
   Value cur = getStoreDest(storeOp);
   while (Operation *defOp = cur.getDefiningOp()) {
     if (!isViewOrExtractSliceOp(defOp)) {
@@ -167,7 +163,6 @@ static void collectViewOpsToUnify(SmallVector<Operation *> &ops,
  * across blocks is unsafe and they are typically shared by many blocks.
  */
 static void collectScalarDeps(SmallVector<Operation *> &ops, Operation *storeOp,
-                              CVPipeline::ComputeBlockIdManager &bm,
                               SmallPtrSet<Operation *, 16> &seen) {
   SmallVector<Operation *> worklist(ops.begin(), ops.end());
 
@@ -207,8 +202,8 @@ static void collectScalarDeps(SmallVector<Operation *> &ops, Operation *storeOp,
 /**
  * @brief Assemble the full set of ops whose block_id should be unified.
  *
- * opsToUnify = {store} + viewOps (data + dest, block_id filtered) +
- *              scalarDeps (recursively collected, block_id filtered).
+ * opsToUnify = {store} + viewOps (data + dest) +
+ *              scalarDeps (recursively collected).
  */
 static SmallVector<Operation *>
 collectOpsToUnify(Operation *storeOp,
@@ -220,8 +215,8 @@ collectOpsToUnify(Operation *storeOp,
   SmallPtrSet<Operation *, 16> seen;
   seen.insert(storeOp);
 
-  collectViewOpsToUnify(opsToUnify, storeOp, dataViewOps, bm, seen);
-  collectScalarDeps(opsToUnify, storeOp, bm, seen);
+  collectViewOpsToUnify(opsToUnify, storeOp, dataViewOps, seen);
+  collectScalarDeps(opsToUnify, storeOp, seen);
 
   for (Operation *op : opsToUnify) {
     LOG_DEBUG("opToUnify: " << *op);
@@ -257,10 +252,10 @@ static bool matchStorePattern(Operation *storeOp,
                   // skip
   }
 
-  int targetBlockId = bm.getBlockIdByOp(producer);
-  if (targetBlockId == -1 || targetBlockId == storeBlockId) {
-    LOG_DEBUG("ProducerOp has no block_id, or block_id is the same as "
-              "storeOp's, no need to unify\n");
+  if (bm.getBlockIdByOp(producer) == -1 ||
+      producer->getBlock() != storeOp->getBlock()) {
+    LOG_DEBUG("ProducerOp has no block_id or not in the same block as storeOp, "
+              "cannot unify! ");
     return false; // producer has no block_id, cannot unify
   }
 
@@ -324,39 +319,38 @@ public:
 
     // Phase 1: collect all matched store patterns (read-only, no modification).
     //          Only VECTOR-core stores are candidates.
-    SmallVector<SetVector<Operation *>> allMatchedPatterns;
+    SmallVector<Operation *> storeOps;
     module.walk([&](Operation *op) {
       if (isStoreOp(op) &&
           CVPipeline::getOpCoreType(op) == CVPipeline::CoreType::VECTOR_ONLY) {
-        SetVector<Operation *> matchedOps;
-        if (matchStorePattern(op, bm, matchedOps)) {
-          allMatchedPatterns.push_back(std::move(matchedOps));
-        }
+        storeOps.push_back(op);
       }
     });
-    LOG_DEBUG("Found " << allMatchedPatterns.size() << " store patterns");
 
-    // Phase 2: clone scalar ops shared between a pattern and other blocks,
-    //          so that moving pattern ops into the producer's block_id does
-    //          not create cross-block dependency cycles.
-    //          In order to avoid cycle, clone scalar-like ops.
-    //          A   ->   D
-    //           ↘      ↗
-    //            B -> C
-    //          Now we want to fuse D to A, so clone C' scalarOps for
-    //          D dependencies to avoid cycle.
-    auto bmOriginal = CVPipeline::ComputeBlockIdManager(module);
-    for (auto &matchedOps : allMatchedPatterns) {
-      CVPipeline::cloneScalarOpsForCrossBlockUses(bmOriginal, matchedOps);
-    }
-
-    // Phase 3: for each pattern, cycle detection + block_id update.
-    //          Rebuild bm because cloning may have added new ops.
-    auto bmNew = CVPipeline::ComputeBlockIdManager(module);
-    for (auto &matchedOps : allMatchedPatterns) {
-      if (!applyStoreUnify(matchedOps, memGraph, bmNew)) {
-        for (Operation *op : matchedOps) {
-          LOG_DEBUG("Cannot set block id for ops: " << *op);
+    for (auto op : storeOps) {
+      SetVector<Operation *> matchedOps;
+      // Phase 1: collect all matched store patterns (read-only, no
+      // modification).
+      //          Only VECTOR-core stores are candidates.
+      if (matchStorePattern(op, bm, matchedOps)) {
+        // Phase 2: clone scalar ops shared between a pattern and other blocks,
+        //          so that moving pattern ops into the producer's block_id does
+        //          not create cross-block dependency cycles.
+        //          In order to avoid cycle, clone scalar-like ops.
+        //          A   ->   D
+        //           ↘      ↗
+        //            B -> C
+        //          Now we want to fuse D to A, so clone C' scalarOps for
+        //          D dependencies to avoid cycle.
+        LOG_DEBUG("Producer op = " << *matchedOps[0]);
+        CVPipeline::cloneScalarOpsForCrossBlockUses(
+            bm, matchedOps, bm.getBlockIdByOp(matchedOps[0]));
+        // Phase 3: for each pattern, cycle detection + block_id update.
+        //          Rebuild bm because cloning may have added new ops.
+        if (!applyStoreUnify(matchedOps, memGraph, bm)) {
+          for (Operation *op : matchedOps) {
+            LOG_DEBUG("Cannot set block id for ops: " << *op);
+          }
         }
       }
     }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/unify_alloc_block.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/unify_alloc_block.mlir
@@ -195,4 +195,116 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
     }
     return
   }
+
+  //===----------------------------------------------------------------------===//
+  // Test Case: @test_copy_source_subview_traceback
+  //===----------------------------------------------------------------------===//
+  // Pattern: trace back memref.copy's source subview to memref.reinterpret_cast
+  // Key scenario: The copy's source operand (%subview_src) is a subview of
+  //   %reinterpret_cast, which has a DIFFERENT block_id (5) from the copy (2).
+  //   The pass should trace back from the copy's source subview through the
+  //   view-like chain to the reinterpret_cast, and unify them to the copy's
+  //   block_id (2).
+  // Before:
+  //   %reinterpret_cast {block_id=5}                        // source base
+  //   %subview_src = subview %reinterpret_cast {block_id=5} // source subview
+  //   %subview_dst = subview %alloc {block_id=5}            // dst subview
+  //   memref.copy %subview_src, %subview_dst {block_id=2}
+  // After (source view chain unified to block_id=2):
+  //   %reinterpret_cast {block_id=2}
+  //   %subview_src {block_id=2}
+  //   %subview_dst {block_id=2}
+  //   memref.copy {block_id=2}
+  //   (alloc, fill, scf.if, condition deps also unified to block_id=2)
+  //===----------------------------------------------------------------------===//
+  // CHECK-LABEL: func.func @test_copy_source_subview_traceback
+  func.func @test_copy_source_subview_traceback(%arg0: memref<?xf16>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %cst = arith.constant 0.000000e+00 : f16
+
+    scf.for %arg17 = %c0 to %c32 step %c1 iter_args(%arg19 = %c0) -> (index) {
+      %c128 = arith.constant {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE"} 128 : index
+      %cond = arith.cmpi slt, %arg19, %c32 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
+      %alloc = memref.alloc() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16>
+      %140 = arith.addi %arg19, %c128 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
+      scf.if %cond {
+        linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : f16) outs(%alloc : memref<32x32xf16>)
+      } {hivm.unlikely_condition}
+
+      // Source view chain: reinterpret_cast and subview_src have block_id=5,
+      // should be unified to block_id=2 by tracing copy's source subview.
+      // CHECK: %{{.*}} = memref.reinterpret_cast {{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+      %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [%140], sizes: [32, 32], strides: [%c32, %c1] {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE"} : memref<?xf16> to memref<32x32xf16, strided<[?, ?], offset: ?>>
+      // CHECK: %{{.*}} = memref.subview {{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+      %subview_src = memref.subview %reinterpret_cast[0, 0] [%c32, %c32] [1, 1] {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16, strided<[?, ?], offset: ?>> to memref<?x?xf16, strided<[?, ?], offset: ?>>
+      // CHECK: %{{.*}} = memref.subview {{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+      %subview_dst = memref.subview %alloc[0, 0] [%c32, %c32] [1, 1] {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16> to memref<?x?xf16, strided<[32, 1]>>
+
+      // CHECK: memref.copy{{.*}}{ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+      memref.copy %subview_src, %subview_dst {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<?x?xf16, strided<[?, ?], offset: ?>> to memref<?x?xf16, strided<[32, 1]>>
+
+      scf.yield %140 : index
+    }
+    return
+  }
+
+  //===----------------------------------------------------------------------===//
+  // Test Case: @test_block_boundary_source_chain
+  //===----------------------------------------------------------------------===//
+  // Verify that when the source view chain of a memref.copy spans across MLIR
+  // Block boundaries, only ops in the same Block as the copyOp are collected
+  // and unified. Ops in different Blocks are skipped.
+  //
+  // Scenario:
+  //   - arg_subview/reinterpret_cast from external arg, defined in parent block
+  //   - outer memref.copy (block_id=15) in the same parent block
+  //   - inner memref.copy (block_id=2) inside scf.for, also using arg_subview
+  // Expected:
+  //   - arg_subview/reinterpret_cast unified to block_id=15 (same block as
+  //     outer copy)
+  //   - inner copy does NOT affect arg_subview (different block -> skipped)
+  //===----------------------------------------------------------------------===//
+  // CHECK-LABEL: func.func @test_block_boundary_source_chain
+  func.func @test_block_boundary_source_chain(%arg0: memref<?xf16>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %cst = arith.constant 0.000000e+00 : f16
+
+    %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [32, 32], strides: [%c32, %c1] {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"} : memref<?xf16> to memref<32x32xf16, strided<[?, ?], offset: ?>>
+    // CHECK: %{{.*}} = memref.subview {{.*}} {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "CUBE"}
+    %arg_subview = memref.subview %reinterpret_cast[0, 0] [%c32, %c32] [1, 1] {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16, strided<[?, ?], offset: ?>> to memref<?x?xf16, strided<[?, ?], offset: ?>>
+
+    %outer_cond = arith.constant 1 : i1
+    // CHECK: %{{.*}} = memref.alloc() {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16>
+    %alloc = memref.alloc() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16>
+    // CHECK: scf.if {{.*}} {
+    // CHECK:   linalg.fill {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "CUBE"}
+    scf.if %outer_cond {
+      linalg.fill {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : f16) outs(%alloc : memref<32x32xf16>)
+    } {hivm.unlikely_condition}
+    // CHECK: %{{.*}} = memref.subview {{.*}} {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "CUBE"}
+    %dst_subview = memref.subview %alloc[0, 0] [%c32, %c32] [1, 1] {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16> to memref<?x?xf16, strided<[32, 1]>>
+    // CHECK: memref.copy{{.*}}{ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "CUBE"}
+    memref.copy %arg_subview, %dst_subview {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "CUBE"} : memref<?x?xf16, strided<[?, ?], offset: ?>> to memref<?x?xf16, strided<[32, 1]>>
+
+    scf.for %iv = %c0 to %c1 step %c1 {
+      %inner_cond = arith.constant 1 : i1
+      // CHECK: %{{.*}} = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16>
+      %inner_alloc = memref.alloc() {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16>
+      // CHECK: scf.if {{.*}} {
+      // CHECK:   linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+      scf.if %inner_cond {
+        linalg.fill {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : f16) outs(%inner_alloc : memref<32x32xf16>)
+      } {hivm.unlikely_condition}
+      // CHECK: %{{.*}} = memref.subview {{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+      %inner_dst = memref.subview %inner_alloc[0, 0] [%c32, %c32] [1, 1] {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16> to memref<?x?xf16, strided<[32, 1]>>
+      // CHECK: memref.copy{{.*}}{ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+      memref.copy %arg_subview, %inner_dst {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<?x?xf16, strided<[?, ?], offset: ?>> to memref<?x?xf16, strided<[32, 1]>>
+      scf.yield
+    }
+    return
+  }
 }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/unify_store_block.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/unify_store_block.mlir
@@ -166,4 +166,123 @@ module {
     %ext = arith.muli %add, %c64 {ssbuffer.block_id = 13 : i32, ssbuffer.core_type = "VECTOR"} : index
     return
   }
+
+  // ============================================
+  // Test 7: producer and store already share the same block_id, but viewOps
+  // in between have a different block_id. The pass should still collect and
+  // unify those viewOps to the producer's block_id.
+  //
+  // Pattern:
+  //   arith.truncf(VECTOR, block_id=5)                <- producer
+  //     -> tensor.extract_slice(block_id=6)            <- viewOp to unify
+  //     -> bufferization.materialize_in_destination(block_id=5)  <- store
+  //   dest chain: memref.reinterpret_cast(block_id=6)  <- viewOp to unify
+  //             -> memref.subview(block_id=6)           <- viewOp to unify
+  //
+  // All viewOps (extract_slice, reinterpret_cast, subview) at block_id=6
+  // should be unified to block_id=5.
+  // ============================================
+  // CHECK-LABEL: func @test_producer_store_same_block
+  func.func @test_producer_store_same_block(%arg0: memref<?xf16> {tt.divisibility = 16 : i32}, %in: tensor<64x64xf32>) {
+    // %c0: scalar dep at block 6, unified to 5.
+    // CHECK: arith.constant {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    %c0 = arith.constant {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    // producer stays at block 5.
+    // CHECK: arith.truncf %{{.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    %trunc = arith.truncf %in {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    // extract_slice at block 6, unified to 5.
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    %extract = tensor.extract_slice %trunc[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    // reinterpret_cast at block 6, unified to 5.
+    // CHECK: memref.reinterpret_cast %{{.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+    %reinterpret = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [128, 64], strides: [64, 1] {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+    // subview at block 6, unified to 5.
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    %subview = memref.subview %reinterpret[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    // store stays at block 5.
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+    return
+  }
+
+  // ============================================
+  // Test 8: Producer outside scf.for, store inside → NO unification
+  //
+  // producer = arith.truncf (VECTOR_ONLY, block_id=5) lives in the function
+  // body, while the store and its data/dest chain are inside scf.for
+  // (block_id=8). traceProducerOp still finds the producer because
+  // %extract_slice directly references %trunc from the outer scope, but
+  // matchStorePattern rejects the match because producer->getBlock() !=
+  // storeOp->getBlock() (different IR blocks).
+  //
+  // All block_ids remain unchanged.
+  // ============================================
+  // CHECK-LABEL: func @test_producer_outside_for
+  func.func @test_producer_outside_for(%arg0: memref<?xf16> {tt.divisibility = 16 : i32}, %in: tensor<64x64xf32>) {
+    // %c0 feeds reinterpret_cast's offset (scalar dep), stays at block 8.
+    // CHECK: arith.constant {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    %c0 = arith.constant {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    // producer outside scf.for, stays at block 5.
+    // CHECK: arith.truncf %{{.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    %trunc = arith.truncf %in {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    %lb = arith.constant {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    %ub = arith.constant {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} 64 : index
+    %step = arith.constant {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} 1 : index
+    // store and its chain inside scf.for; all stay at block 8.
+    scf.for %i = %lb to %ub step %step {
+      // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+      %extract = tensor.extract_slice %trunc[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+      // CHECK: memref.reinterpret_cast %{{.*}} {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+      %reinterpret = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [128, 64], strides: [64, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+      // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+      %subview = memref.subview %reinterpret[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+      // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+      bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+    }
+    return
+  }
+
+  // ============================================
+  // Test 9: Dest view ops outside scf.for, store and producer inside
+  //         → unification happens
+  //
+  // producer = arith.truncf (VECTOR_ONLY, block_id=5) inside scf.for.
+  // store = bufferization.materialize_in_destination (block_id=8) inside for.
+  // data view = tensor.extract_slice (block_id=8) inside for.
+  // dest views = memref.reinterpret_cast, memref.subview (block_id=8) outside
+  // for.
+  //
+  // producer and store are in the same IR block (inside scf.for) → pattern
+  // matched.  All matched ops unified to producer's block_id=5.  Scalar
+  // deps outside the for loop (%c0, for-loop bounds) stay at their original
+  // block_ids.
+  // ============================================
+  // CHECK-LABEL: func @test_dest_view_outside_for
+  func.func @test_dest_view_outside_for(%arg0: memref<?xf16> {tt.divisibility = 16 : i32}, %in: tensor<64x64xf32>) {
+    // %c0 feeds reinterpret_cast, stays at block 8 (outside for, not collected
+    // by scalar deps).
+    // CHECK: arith.constant {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    %c0 = arith.constant {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    // dest view ops outside scf.for, unified to producer's block 5.
+    // CHECK: memref.reinterpret_cast %{{.*}} {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+    %reinterpret = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [128, 64], strides: [64, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    %subview = memref.subview %reinterpret[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    %lb = arith.constant {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    %ub = arith.constant {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} 64 : index
+    %step = arith.constant {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} 1 : index
+    // producer and store inside scf.for.
+    scf.for %i = %lb to %ub step %step {
+      // producer stays at block 5.
+      // CHECK: arith.truncf %{{.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+      %trunc = arith.truncf %in {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+      // data view unified to block 5.
+      // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+      %extract = tensor.extract_slice %trunc[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+      // store unified to block 5.
+      // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+      bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+    }
+    return
+  }
 }


### PR DESCRIPTION
[ssbuffer] 修复 store/alloc block_id 统一中 viewOp 遗漏的问题

描述 :

- UnifyStoreBlockPass : 移除 collectViewOpsToUnify 中 viewOp 必须与 storeOp 同 block_id 的过滤条件，以及 matchStorePattern 中 targetBlockId == storeBlockId 的提前返回。确保 producer 和 store 已同 block_id 时，中间的 viewOp（extract_slice、subview 等）仍能统一
- UnifyAllocBlockPass : 新增 collectSourceViewChainOps ，沿 memref.copy 的 source 回溯 ViewLikeOpInterface / tensor.extract_slice 链并统一其 block_id；修复 cycle 检测失败时 return success() 的 bug
- 新增对应 UT

[ssbuffer] Fix missed viewOp unification in store/alloc block_id unify

Description :

- UnifyStoreBlockPass : Remove the block_id equality filter on viewOps in collectViewOpsToUnify , and the targetBlockId == storeBlockId early return in matchStorePattern , so that intermediate viewOps (extract_slice, subview, etc.) are still unified even when producer and store already share the same block_id
- UnifyAllocBlockPass : Add collectSourceViewChainOps to trace memref.copy 's source through ViewLikeOpInterface / tensor.extract_slice chains and unify their block_ids; fix a bug where cycle detection failure incorrectly returned success()
- Add corresponding unit tests

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
