### PR TITLE
[patch](feat) dot precision: tf32 converted to hf32

### DIFF
--- a/init_code.py
+++ b/init_code.py
@@ -1,0 +1,38 @@
+import os
+import subprocess
+
+def checkout_file(files):
+    try:
+        subprocess.run(["git", "checkout", "--"] + files, check=True, stdout=subprocess.DEVNULL)
+    except subprocess.CalledProcessError:
+        raise RuntimeError(f"init code failed,list:{files}")
+
+
+def init_triton_ascend_code():
+    patch_files = [
+        "CMakeLists.txt",
+        "include/triton/Dialect/Triton/IR/TritonAttrDefs.td",
+        "lib/Dialect/Triton/IR/Traits.cpp",
+        "python/src/ir.cc",
+        "python/triton/_utils.py",
+        "python/triton/compiler/code_generator.py",
+        "python/triton/compiler/compiler.py",
+        "python/triton/compiler/errors.py",
+        "python/triton/language/math.py",
+        "python/triton/language/core.py",
+        "python/triton/language/semantic.py",
+        "python/triton/language/standard.py",
+        "python/triton/runtime/interpreter.py",
+        "python/triton/runtime/jit.py",
+        "bin/RegisterTritonDialects.h",
+        "bin/triton-opt.cpp",
+        "bin/CMakeLists.txt",
+    ]
+    dev_patch_files = [
+        "python/triton/runtime/autotuner.py",
+    ]
+    checkout_file(dev_patch_files)
+    checkout_file(patch_files)
+    print("init triton ascend successfully")
+
+init_triton_ascend_code()

--- a/init_code.py
+++ b/init_code.py
@@ -1,11 +1,11 @@
-import os
 import subprocess
+
 
 def checkout_file(files):
     try:
         subprocess.run(["git", "checkout", "--"] + files, check=True, stdout=subprocess.DEVNULL)
-    except subprocess.CalledProcessError:
-        raise RuntimeError(f"init code failed,list:{files}")
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"init code failed,list:{files}") from e
 
 
 def init_triton_ascend_code():
@@ -34,5 +34,6 @@ def init_triton_ascend_code():
     checkout_file(dev_patch_files)
     checkout_file(patch_files)
     print("init triton ascend successfully")
+
 
 init_triton_ascend_code()

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2019,10 +2019,17 @@ def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_i
       specified (i.e. at least one must be :code:`None`).
     """
     assert input_precision is None or allow_tf32 is None, "Only one of input_precision and allow_tf32 can be specified"
+    assert not allow_tf32, "allow_tf32 is not supported as 'True', please use fp32 on Ascend instead."
     if input_precision is None:
         supports_tf32 = "tf32" in _semantic.builder.options.allowed_dot_input_precisions
         input_precision = knobs.language.fp32_default or ("tf32" if (supports_tf32 and
                                                                      (allow_tf32 or allow_tf32 is None)) else "ieee")
+        # when setting allow_tf32, use input_precision='hf32' on Ascend instead.
+        if allow_tf32:
+            input_precision = "hf32"
+    else:
+        if input_precision == "tf32":
+            input_precision = "hf32"
 
     input_precision = _unwrap_if_constexpr(input_precision)
     out_dtype = _unwrap_if_constexpr(out_dtype)

--- a/third_party/ascend/backend/__init__.py
+++ b/third_party/ascend/backend/__init__.py
@@ -74,5 +74,39 @@ def _apply_ascend_patch():
         _compiler_module.parse = _patched_parse
         _compiler_module._ascend_parse_patch_applied = True
 
+    # Patch TritonSemantic.dot for Ascend-specific HF32 guard and
+    # max_num_imprecise_acc warning.
+    from triton.language.semantic import TritonSemantic
+
+    if not getattr(TritonSemantic, "_ascend_dot_patch_applied", False):
+        _original_dot = TritonSemantic.dot
+
+        def _patched_dot(self, lhs, rhs, acc, input_precision, max_num_imprecise_acc, out_dtype):
+            """
+            Monkey Patch for Ascend:
+            - HF32 precision only works for fp32 x fp32.
+              When either input is not fp32, silently fall back
+              to default precision (ieee).
+            - Warn when max_num_imprecise_acc is explicitly set, since
+              Ascend NPU does not support imprecise accumulation.
+            """
+            # the precision is HF32,convert it to TF32.
+            if input_precision.lower() == "tf32":
+                input_precision = "hf32"
+            
+            # Ascend NPU does not support imprecise accumulation.
+            # Force max_num_imprecise_acc to None so the upstream None
+            # branch handles it (via max_num_imprecise_acc_default = 0),
+            # avoiding the fp8 ValueError path which is NVIDIA-only.
+            if max_num_imprecise_acc is not None:
+                print("max_num_imprecise_acc in tl.dot is not supported on Ascend yet. "
+                      "Thus it is ignored.")
+                max_num_imprecise_acc = None
+
+            return _original_dot(self, lhs, rhs, acc, input_precision, max_num_imprecise_acc, out_dtype)
+
+        TritonSemantic.dot = _patched_dot
+        TritonSemantic._ascend_dot_patch_applied = True
+
 
 __all__ = ["do_bench_npu"]

--- a/third_party/ascend/backend/__init__.py
+++ b/third_party/ascend/backend/__init__.py
@@ -93,7 +93,7 @@ def _apply_ascend_patch():
             # the precision is HF32,convert it to TF32.
             if input_precision.lower() == "tf32":
                 input_precision = "hf32"
-            
+
             # Ascend NPU does not support imprecise accumulation.
             # Force max_num_imprecise_acc to None so the upstream None
             # branch handles it (via max_num_imprecise_acc_default = 0),

--- a/third_party/ascend/unittest/pytest_ut/test_dot.py
+++ b/third_party/ascend/unittest/pytest_ut/test_dot.py
@@ -162,11 +162,10 @@ def test_dot_2_allow_tf32(restore_npu_hf32_setting, sigtype, B, C, D):
     y = test_common.generate_tensor((C, D), sigtype).npu()
     z_ref = torch_dot_None(x, y).to(torch.float32)
     z = torch.zeros((B, D), dtype=torch.float32).npu()
-    try:
-        triton_dot_2_input_tf32[1, 1, 1](z, x, y, B, C, D)
-    except CompilationError as e:
-        assert "input_precision must be one of" in str(e.args)
-
+    triton_dot_2_allow_tf32[1, 1, 1](z, x, y, B, C, D)
+    with pytest.raises(AssertionError) as exc_info:
+        test_common.validate_cmp(sigtype, z, z_ref)
+    assert "Tensor-likes are not close" in str(exc_info.value)
 
 @pytest.mark.parametrize("B, C, D", testlist2)
 @pytest.mark.parametrize("sigtype", typelist)
@@ -175,10 +174,8 @@ def test_dot_2_input_tf32(restore_npu_hf32_setting, sigtype, B, C, D):
     y = test_common.generate_tensor((C, D), sigtype).npu()
     z_ref = torch_dot_None(x, y).to(torch.float32)
     z = torch.zeros((B, D), dtype=torch.float32).npu()
-    try:
-        triton_dot_2_input_tf32[1, 1, 1](z, x, y, B, C, D)
-    except CompilationError as e:
-        assert "input_precision must be one of" in str(e.args)
+    triton_dot_2_input_tf32[1, 1, 1](z, x, y, B, C, D)
+    test_common.validate_cmp(sigtype, z, z_ref)
 
 
 @pytest.mark.parametrize("B, C, D", testlist2)

--- a/third_party/ascend/unittest/pytest_ut/test_dot.py
+++ b/third_party/ascend/unittest/pytest_ut/test_dot.py
@@ -167,6 +167,7 @@ def test_dot_2_allow_tf32(restore_npu_hf32_setting, sigtype, B, C, D):
         test_common.validate_cmp(sigtype, z, z_ref)
     assert "Tensor-likes are not close" in str(exc_info.value)
 
+
 @pytest.mark.parametrize("B, C, D", testlist2)
 @pytest.mark.parametrize("sigtype", typelist)
 def test_dot_2_input_tf32(restore_npu_hf32_setting, sigtype, B, C, D):


### PR DESCRIPTION
When the user inputs tf32, it is converted to hf32 by default.
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
