### PR TITLE
[NPU_DEVICE_LIMIT](feat) Increase the aicore and vectorcore ratio check

### DIFF
--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -98,8 +98,7 @@ class NPUUtils(object):
                 input and the hardware actual caps.
         """
         npu_device_limit_str = os.getenv("NPU_DEVICE_LIMIT")
-        num_aic = self.get_device_aicore()
-        num_aiv = num_aic * 2
+        num_aic, num_aiv = self.get_device_core()
         if npu_device_limit_str is None:
             return num_aic, num_aiv
 
@@ -108,6 +107,7 @@ class NPUUtils(object):
             parts = [part.strip() for part in npu_device_limit_str.split(",")]
             num_aic_env = int(parts[0])
             num_aiv_env = int(parts[1])
+
             if num_aic_env <= 0 or num_aiv_env <= 0:
                 raise ValueError(f"[ERROR]NPU_DEVICE_LIMIT={npu_device_limit_str}, which has non-positive value,"
                                  f"both cube_core_num and vector_core_num must be positive.")
@@ -115,19 +115,38 @@ class NPUUtils(object):
                 raise ValueError(
                     f"[ERROR]NPU_DEVICE_LIMIT={npu_device_limit_str}, both cube_core_num and vector_core_num "
                     f"must be less than or equal to device properties ({num_aic},{num_aiv}).")
+            elif num_aic_env * (num_aiv / num_aic) != num_aiv_env:
+                env_quotient = num_aiv_env / num_aic_env
+                env_quotient_decimal = round(env_quotient, 1)
+                quotient = num_aiv / num_aic
+                quotient_decimal = round(quotient, 1)
+                raise ValueError(
+                    f"[ERROR]NPU_DEVICE_LIMIT={npu_device_limit_str}; expected ratio is consistent, actual, "
+                    f"the ratio of vector_core_num/cube_core_num({num_aiv_env}/{num_aic_env}={env_quotient_decimal}) does "
+                    f"not equal device properties vector_core_num/cube_core_num({num_aiv}/{num_aic}={quotient_decimal}) ratio."
+                )
             else:
                 print(f"[INFO]NPU_DEVICE_LIMIT from env: cube_core_num={num_aic_env},vector_core_num={num_aiv_env}).")
                 return num_aic_env, num_aiv_env
         else:
             raise ValueError(f"[ERROR]NPU_DEVICE_LIMIT={npu_device_limit_str}, which has invalid format: "
-                             f"It should be like '14,28' (cube_core_num,vector_core_num).")
+                             f"It should be like '14,28' (cube_core_num,vector_core_num) "
+                             f"and it must be a positive number.")
 
     @functools.lru_cache()
-    def get_device_aicore(self):
-        return self.npu_utils_mod.get_aicore_num()
+    def get_device_core(self):
+        import torch
+        device = torch.npu.current_device()
+        prop = torch.npu.get_device_properties(device)
+        cube_core_num, vector_core_num = prop.cube_core_num, prop.vector_core_num
+        return cube_core_num, vector_core_num
 
     def has_device_limit(self):
-        return self.get_device_aicore() != self.get_aicore_num()
+        num_aic, num_aiv = self.get_device_core()
+        try:
+            return num_aic != self.get_aicore_num() or num_aiv != self.get_aivector_core_num()
+        except ValueError:
+            return False
 
     def get_device_properties(self, device):
         # temperoarily added "max_shared_mem" properties to avoid triton-compiler complain

--- a/third_party/ascend/unittest/pytest_ut/test_driver.py
+++ b/third_party/ascend/unittest/pytest_ut/test_driver.py
@@ -41,7 +41,7 @@ def _make_mock_npu_utils():
     mock = MagicMock()
     # _get_npu_device_limit_form_env calls self.get_device_aicore(); configure it
     # to return a fixed int instead of binding the real lru_cached method.
-    mock.get_device_aicore.return_value = _MOCK_AICORE_NUM
+    mock.get_device_core.return_value = _MOCK_AICORE_NUM, _MOCK_AIVECTOR_NUM
     # Bind real methods (not lru_cached) so the actual parsing/property logic runs.
     mock._get_npu_device_limit_form_env = types.MethodType(NPUUtils._get_npu_device_limit_form_env, mock)
     mock.get_device_properties = types.MethodType(NPUUtils.get_device_properties, mock)
@@ -81,15 +81,24 @@ def test_npu_device_limit_env_var_valid(monkeypatch, env_value, expected_aic, ex
     "env_value",
     [
         # non-positive values
-        "0,48", "24,0", "0,0",
+        "0,48",
+        "24,0",
+        "0,0",
         # exceeds device limit
-        f"{_MOCK_AICORE_NUM + 1},{_MOCK_AIVECTOR_NUM}", f"{_MOCK_AICORE_NUM},{_MOCK_AIVECTOR_NUM + 1}", "100,200",
+        f"{_MOCK_AICORE_NUM + 1},"
+        f"{_MOCK_AIVECTOR_NUM}",
+        f"{_MOCK_AICORE_NUM},"
+        f"{_MOCK_AIVECTOR_NUM + 1}",
+        "100,200",
         # invalid format
-        "abc", "12",  # missing second value
+        "abc",
+        "12",  # missing second value
         "12,24,36",  # too many values
         "12.5,24",  # float not matched
         "",  # empty string
         "-1,48",  # negative sign not matched
+        "2,6",
+        "2,5",
     ],
 )
 def test_npu_device_limit_env_var_invalid(monkeypatch, env_value):


### PR DESCRIPTION
Currently, the NPU AI Core to Vector Core ratio is 1:2. To support future ratios, the system verifies user input by comparing actual physical core counts. If verification fails, an error message displays.


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
