### PR TITLE
[ssbuffer](feat) add 3 ComputeBlockOpt Passes and adapt dependencies

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h
@@ -26,6 +26,7 @@
 #include "ascend/include/DynamicCVPipeline/Common/MemoryEffectsTracker.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 #include "llvm/ADT/ArrayRef.h"
 
 namespace mlir {
@@ -73,6 +74,23 @@ bool willCreateCycle(llvm::ArrayRef<Operation *> opsToUnify,
  */
 void cloneScalarOpsForCrossBlockUses(ComputeBlockIdManager &bmOriginal,
                                      SetVector<Operation *> &matchedOps);
+
+/**
+ * @brief Check if a view-like operation originates from global memory (GM)
+ *
+ * Traces back through nested view-like operations (subview, reinterpret_cast,
+ * etc.) to determine if the source is a function argument (block argument in
+ * the entry block). Only view-like operations in the same block as the input
+ * viewOp are collected.
+ *
+ * @param viewOp The view-like operation to check
+ * @param matchedOps SetVector to collect all same-block view-like operations in
+ * the trace
+ * @return bool Returns true if the source is from global memory (function
+ * argument), false otherwise
+ */
+bool isSubviewFromGlobalMemory(ViewLikeOpInterface viewOp,
+                               SetVector<Operation *> &matchedOps);
 
 } // namespace CVPipeline
 } // namespace mlir

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
@@ -39,6 +39,9 @@ void registerMergeCubeForBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createUnifyStoreBlockPass();
 void registerUnifyStoreBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createFixpipeOptPass();
+std::unique_ptr<OperationPass<ModuleOp>> createSinkI1ProducersIntoUsersPass();
+std::unique_ptr<OperationPass<ModuleOp>> createBroadcastUBOptPass();
+std::unique_ptr<OperationPass<ModuleOp>> createMoveLoadIntoUserPass();
 
 } // namespace triton
 } // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/BroadcastUBOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/BroadcastUBOptPass.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+static constexpr const char *DEBUG_TYPE = "broadcast-ub-opt";
+#define LOG_DEBUG(...)                                                         \
+  LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__)
+
+using namespace mlir;
+
+namespace mlir {
+namespace triton {
+
+class BroadcastUBOptPass
+    : public PassWrapper<BroadcastUBOptPass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(BroadcastUBOptPass)
+
+  BroadcastUBOptPass() = default;
+  void runOnOperation() override;
+
+  llvm::StringRef getArgument() const final { return "broadcast-ub-opt"; }
+  llvm::StringRef getDescription() const final {
+    return "Optimize broadcast by moving it to the block of its users when "
+           "safe";
+  }
+};
+
+} // namespace triton
+} // namespace mlir
+
+namespace mlir {
+namespace triton {
+
+void BroadcastUBOptPass::runOnOperation() {
+  ModuleOp moduleOp = getOperation();
+  auto &aa = getAnalysis<AliasAnalysis>();
+  CVPipeline::MemoryDependenceGraph memGraph(moduleOp, aa);
+  CVPipeline::ComputeBlockIdManager bm(moduleOp);
+  LOG_DEBUG("== BroadcastUBOpt Pass Start ==\n");
+  LOG_DEBUG(moduleOp);
+  moduleOp.walk([&](linalg::BroadcastOp op) {
+    SmallVector<Operation *> users(op->getUsers().begin(),
+                                   op->getUsers().end());
+    if (users.empty())
+      return;
+
+    int firstUserBlockId = bm.getBlockIdByOp(users.front());
+    if (CVPipeline::getOpCoreType(users.front()) !=
+        CVPipeline::CoreType::VECTOR_ONLY)
+      return;
+
+    if (CVPipeline::getOpCoreType(op.getOperation()) !=
+        CVPipeline::CoreType::VECTOR_ONLY)
+      return;
+
+    bool allUsersSameBlock = llvm::all_of(users, [&](Operation *user) {
+      return bm.getBlockIdByOp(user) == firstUserBlockId;
+    });
+
+    if (!allUsersSameBlock)
+      return;
+
+    LOG_DEBUG("broadcast " << op << " \n all users in same block "
+                           << firstUserBlockId << "\n");
+
+    int broadcastBlockId = bm.getBlockIdByOp(op.getOperation());
+    if (broadcastBlockId == firstUserBlockId) {
+      LOG_DEBUG("broadcast already in same block, skip\n");
+      return;
+    }
+
+    if (op->getBlock() != users.front()->getBlock()) {
+      return;
+    }
+
+    SmallVector<Operation *> opsToCheck = {op};
+    if (CVPipeline::willCreateCycle(opsToCheck, memGraph, firstUserBlockId,
+                                    bm)) {
+      LOG_DEBUG("would create cycle, skip\n");
+      return;
+    }
+
+    LOG_DEBUG("moving broadcast to block " << firstUserBlockId << "\n");
+    bm.updateBlockId(op, firstUserBlockId);
+  });
+  LOG_DEBUG("== BroadcastUBOpt Pass complete ==\n");
+}
+
+std::unique_ptr<OperationPass<ModuleOp>> createBroadcastUBOptPass() {
+  return std::make_unique<BroadcastUBOptPass>();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
@@ -24,8 +24,11 @@
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
 #include "mlir/Analysis/TopologicalSortUtils.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 #include "triton/Analysis/Utility.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
@@ -181,7 +184,10 @@ bool willCreateCycle(llvm::ArrayRef<Operation *> opsToUnify,
 }
 
 void cloneScalarOpsForCrossBlockUses(ComputeBlockIdManager &bmOriginal,
-                                     SetVector<Operation *> &matchedOps) {
+                                     SetVector<Operation *> &matchedOps,
+                                     int targetBlockId) {
+
+  // This means move matchedOps into targetBlockId
   auto sorted = mlir::topologicalSort(matchedOps);
   for (Operation *op : llvm::reverse(sorted)) {
     if (op->getNumResults() == 1 &&
@@ -196,21 +202,56 @@ void cloneScalarOpsForCrossBlockUses(ComputeBlockIdManager &bmOriginal,
         if (!userInBlock)
           continue;
         if (llvm::find(matchedOps, userInBlock) == matchedOps.end() &&
-            bmOriginal.getBlockIdByOp(userInBlock) !=
-                bmOriginal.getBlockIdByOp(matchedOps[0])) {
+            bmOriginal.getBlockIdByOp(userInBlock) != targetBlockId) {
           otherUses.push_back(&use);
         }
       }
       if (otherUses.size() > 0) {
-        LOG_DEBUG("now cloned: " << *op << "\n");
+        LOG_DEBUG("now cloned: " << *op);
         OpBuilder builder(op);
         auto clonedOp = builder.clone(*op);
+        bmOriginal.updateBlockId(clonedOp, bmOriginal.getBlockIdByOp(op));
         for (auto use : otherUses) {
           (*use).set(clonedOp->getResult(0));
         }
       }
     }
   }
+}
+
+bool isSubviewFromGlobalMemory(ViewLikeOpInterface viewOp,
+                               SetVector<Operation *> &matchedOps) {
+  // Subview ops may be nested many layers deep through reinterpretation or
+  // other subviews. like, subview (subview (reinterpret_cast (subview
+  // (reinterpret_cast (arg0))))) so we need Search and only keep same block
+  // view-like op.
+  Value source = viewOp.getViewSource();
+  auto block = viewOp->getBlock();
+  LOG_DEBUG("Check view source: " << source << "\n");
+  while (true) {
+    if (auto blockArg = dyn_cast<BlockArgument>(source)) {
+      Operation *parentOp = blockArg.getOwner()->getParentOp();
+      if (isa<func::FuncOp>(parentOp)) {
+        return true;
+      } else {
+        LOG_DEBUG(
+            "Subview source block argument is not from func entry block.");
+        return false;
+      }
+    }
+    // From other view-like op
+    if (auto viewLike = dyn_cast<ViewLikeOpInterface>(source.getDefiningOp())) {
+      if (viewLike->getBlock() == block) {
+        matchedOps.insert(viewLike.getOperation());
+      }
+      source = viewLike.getViewSource();
+      continue;
+    }
+    LOG_DEBUG(
+        "Subview source defining op is not ViewLikeOpInterface: " << source);
+    return false;
+  }
+  return false;
 }
 
 } // namespace CVPipeline

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MoveLoadIntoUserPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MoveLoadIntoUserPass.cpp
@@ -1,0 +1,320 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/Analysis/TopologicalSortUtils.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+#include <optional>
+
+static constexpr const char *DEBUG_TYPE = "move-load-into-user";
+#define LOG_DEBUG(...)                                                         \
+  LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
+
+using namespace mlir;
+using namespace triton;
+
+namespace mlir {
+namespace triton {
+
+class MoveLoadIntoUserPass
+    : public PassWrapper<MoveLoadIntoUserPass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MoveLoadIntoUserPass)
+
+  MoveLoadIntoUserPass() = default;
+  void runOnOperation() override;
+
+  llvm::StringRef getArgument() const final { return "move-load-into-user"; }
+
+private:
+  struct LoadPatternInfo {
+    SmallVector<Operation *> matchedOps;
+    int commonBlockId;
+  };
+
+  bool matchLoadPattern(memref::CopyOp copyOp,
+                        SmallVector<Operation *> &matchedOps);
+
+  bool checkAllOpsInSameBlock(ArrayRef<Operation *> ops,
+                              CVPipeline::ComputeBlockIdManager &bm);
+};
+
+static Operation *traceCalculateUser(Operation *originUser,
+                                     CVPipeline::ComputeBlockIdManager &bm,
+                                     int totensorId,
+                                     SmallVector<Operation *> &userChain) {
+  // only find single chian
+  //  pattern -> collapse1(totensorId)->collapse2(totensorId)...->user
+  //  (targetblockId), collapse should move together.
+  //         \-> other userChain   -> user (targetblockId)
+  auto retUser = originUser;
+  while (bm.getBlockIdByOp(retUser) == totensorId &&
+         isa<tensor::CollapseShapeOp>(retUser)) {
+    if (retUser->getResult(0).getNumUses() != 1) {
+      break;
+    }
+    userChain.push_back(retUser);
+    retUser = *retUser->getUsers().begin();
+  }
+  return retUser;
+}
+
+static std::optional<Operation *>
+getFirstUser(bufferization::ToTensorOp toTensorOp,
+             CVPipeline::ComputeBlockIdManager &bm,
+             SmallVector<Operation *> &matchedOps) {
+  Operation *firstUser = nullptr;
+  SmallVector<Operation *> fistUserChain;
+
+  for (auto *user : toTensorOp->getUsers()) {
+    auto *userInBlock =
+        CVPipeline::getAncestorInBlock(user, toTensorOp->getBlock());
+    if (userInBlock) {
+      SmallVector<Operation *> userChain;
+      auto calUser = traceCalculateUser(
+          userInBlock, bm, bm.getBlockIdByOp(toTensorOp), userChain);
+      if (!firstUser || calUser->isBeforeInBlock(firstUser)) {
+        // First in ordered IR, it's cblock is first too.
+        firstUser = calUser;
+        fistUserChain = userChain;
+      }
+    }
+  }
+
+  if (!firstUser) {
+    LOG_DEBUG("No users of to_tensor found");
+    return std::nullopt;
+  }
+  LOG_DEBUG("Find first user:\n" << *firstUser);
+
+  int blockId = bm.getBlockIdByOp(firstUser);
+  if (blockId == -1) {
+    LOG_DEBUG("First user has no block_id");
+    return std::nullopt;
+  }
+
+  if (blockId == bm.getBlockIdByOp(toTensorOp)) {
+    LOG_DEBUG("First user in same block");
+    return std::nullopt;
+  }
+  matchedOps.append(fistUserChain.begin(), fistUserChain.end());
+  return firstUser;
+}
+
+bool MoveLoadIntoUserPass::checkAllOpsInSameBlock(
+    ArrayRef<Operation *> ops, CVPipeline::ComputeBlockIdManager &bm) {
+  if (ops.empty()) {
+    return false;
+  }
+
+  int commonBlockId = -1;
+  for (auto *op : ops) {
+    int blockId = bm.getBlockIdByOp(op);
+    if (blockId == -1) {
+      LOG_DEBUG("Op has no block_id");
+      return false;
+    }
+    if (commonBlockId == -1) {
+      commonBlockId = blockId;
+    } else if (blockId != commonBlockId) {
+      LOG_DEBUG("Not all ops in the same block");
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool MoveLoadIntoUserPass::matchLoadPattern(
+    memref::CopyOp copyOp, SmallVector<Operation *> &matchedOps) {
+  // Step 1: Check if source is from global memory
+  Value source = copyOp.getSource();
+  auto viewOp = source.getDefiningOp<ViewLikeOpInterface>();
+  if (!viewOp) {
+    LOG_DEBUG("Copy source is not from ViewLikeOpInterface");
+    return false;
+  }
+
+  SetVector<Operation *> sourceViewOps;
+  if (!CVPipeline::isSubviewFromGlobalMemory(viewOp, sourceViewOps)) {
+    LOG_DEBUG("Copy source is not from global memory");
+    return false;
+  }
+
+  // Step 2: Find the pattern: reinterpret_cast/alloc -> memref.copy ->
+  // to_tensor Get the reinterpret_cast (or alloc)
+  Operation *destOp = nullptr;
+  Value dest = copyOp.getTarget();
+
+  // Check if dest is alloc
+  if (auto allocOp = dest.getDefiningOp<memref::AllocOp>()) {
+    destOp = allocOp;
+  } else {
+    LOG_DEBUG("Copy dest is not from alloc");
+    return false;
+  }
+
+  // Step 3: Find the to_tensor op
+  bufferization::ToTensorOp toTensorOp = nullptr;
+  for (auto *user : destOp->getUsers()) {
+    auto toTensor = dyn_cast<bufferization::ToTensorOp>(user);
+    if (toTensor) {
+      toTensorOp = toTensor;
+      break;
+    }
+  }
+
+  if (!toTensorOp) {
+    LOG_DEBUG("No to_tensor op found after copy");
+    return false;
+  }
+
+  // Collect matched ops: viewOp (source), destOp, copyOp, toTensor
+  matchedOps.push_back(viewOp);
+  matchedOps.push_back(destOp);
+  matchedOps.push_back(copyOp);
+  matchedOps.push_back(toTensorOp);
+
+  return true;
+}
+
+static void collectAllDependencies(Operation *op, SetVector<Operation *> &deps,
+                                   int commonBlockId,
+                                   CVPipeline::ComputeBlockIdManager &bm) {
+  if (deps.contains(op)) {
+    return;
+  }
+
+  int blockId = bm.getBlockIdByOp(op);
+  if (blockId == -1 || blockId != commonBlockId) {
+    return;
+  }
+
+  deps.insert(op);
+  for (auto operand : op->getOperands()) {
+    if (auto definingOp = operand.getDefiningOp()) {
+      collectAllDependencies(definingOp, deps, commonBlockId, bm);
+    }
+  }
+}
+
+void MoveLoadIntoUserPass::runOnOperation() {
+  ModuleOp module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
+  auto &aliasAnalysis = getAnalysis<AliasAnalysis>();
+  CVPipeline::MemoryDependenceGraph memGraph(module, aliasAnalysis);
+  auto bm = CVPipeline::ComputeBlockIdManager(module);
+
+  SmallVector<LoadPatternInfo> validPatterns;
+
+  LOG_DEBUG("before MogeLoadIntoUserPass ....\n" << *module);
+
+  module.walk([&](memref::CopyOp copyOp) {
+    // Step 1: Check if source is from global memory
+    LOG_DEBUG("Check copyOp = " << copyOp);
+    Value source = copyOp.getSource();
+    auto viewOp = source.getDefiningOp<ViewLikeOpInterface>();
+    if (!viewOp) {
+      return;
+    }
+
+    SetVector<Operation *> viewOps;
+    if (!CVPipeline::isSubviewFromGlobalMemory(viewOp, viewOps)) {
+      return;
+    }
+
+    // Step 2: Match the load pattern and collect 4 ops
+    SmallVector<Operation *> matchedOps;
+    if (!matchLoadPattern(copyOp, matchedOps)) {
+      return;
+    }
+
+    // Step 3: Check if all 4 ops are in the same block
+    if (!checkAllOpsInSameBlock(matchedOps, bm)) {
+      return;
+    }
+    LOG_DEBUG("valid pattern.");
+    // Store the valid pattern
+    validPatterns.push_back({matchedOps, bm.getBlockIdByOp(copyOp)});
+  });
+
+  // Process each valid pattern
+  for (auto &pattern : validPatterns) {
+    auto &matchedOps = pattern.matchedOps;
+    int commonBlockId = pattern.commonBlockId;
+
+    // Find first user of to_tensor
+    auto toTensorOp = cast<bufferization::ToTensorOp>(matchedOps.back());
+    auto firstUserOpt = getFirstUser(toTensorOp, bm, matchedOps);
+    if (!firstUserOpt) {
+      continue;
+    }
+
+    Operation *firstUser = firstUserOpt.value();
+    int targetBlockId = bm.getBlockIdByOp(firstUser);
+
+    SetVector<Operation *> opsToMove;
+    for (auto *op : matchedOps) {
+      collectAllDependencies(op, opsToMove, commonBlockId, bm);
+    }
+    CVPipeline::cloneScalarOpsForCrossBlockUses(bm, opsToMove,
+                                                bm.getBlockIdByOp(firstUser));
+    // Check for cycles before moving
+    SmallVector<Operation *> opsVec(opsToMove.begin(), opsToMove.end());
+    if (CVPipeline::willCreateCycle(opsVec, memGraph, targetBlockId, bm)) {
+      LOG_DEBUG("Moving would create a cycle, skip(" << commonBlockId << ")");
+      continue;
+    }
+
+    // Update block_id for all ops
+    for (auto *op : opsToMove) {
+      bm.updateBlockId(op, targetBlockId);
+    }
+
+    LOG_DEBUG("Successfully moved ops to block " << targetBlockId);
+  }
+}
+
+std::unique_ptr<OperationPass<ModuleOp>> createMoveLoadIntoUserPass() {
+  return std::make_unique<MoveLoadIntoUserPass>();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/SinkI1ProducersIntoUsersPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/SinkI1ProducersIntoUsersPass.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+static constexpr const char *DEBUG_TYPE = "sink-i1-producers-into-users";
+#define LOG_DEBUG(...)                                                         \
+  LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__)
+
+using namespace mlir;
+
+namespace mlir {
+namespace triton {
+
+class SinkI1ProducersIntoUsersPass
+    : public PassWrapper<SinkI1ProducersIntoUsersPass,
+                         OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SinkI1ProducersIntoUsersPass)
+
+  SinkI1ProducersIntoUsersPass() = default;
+  void runOnOperation() override;
+
+  llvm::StringRef getArgument() const final {
+    return "sink-i1-producers-into-users";
+  }
+  llvm::StringRef getDescription() const final {
+    return "Sink i1-producing ops next to each of their i1 uses";
+  }
+};
+
+} // namespace triton
+} // namespace mlir
+
+namespace {
+
+static bool isI1Producer(Operation *op) {
+  for (auto result : op->getResults()) {
+    if (auto tensorType = dyn_cast<mlir::TensorType>(result.getType())) {
+      mlir::Type elemType = tensorType.getElementType();
+      if (elemType.isInteger(1)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+static bool isPureAndRegionless(Operation *op) {
+  if (op->hasTrait<OpTrait::HasRecursiveMemoryEffects>())
+    return false;
+  if (auto iface = dyn_cast<MemoryEffectOpInterface>(op)) {
+    SmallVector<MemoryEffects::EffectInstance> effects;
+    iface.getEffects(effects);
+    if (!effects.empty())
+      return false;
+  }
+  return true;
+}
+
+} // namespace
+
+namespace mlir {
+namespace triton {
+
+void SinkI1ProducersIntoUsersPass::runOnOperation() {
+  ModuleOp moduleOp = getOperation();
+  auto &aa = getAnalysis<AliasAnalysis>();
+  CVPipeline::MemoryDependenceGraph memGraph(moduleOp, aa);
+  CVPipeline::ComputeBlockIdManager bm(moduleOp);
+  LOG_DEBUG("== SinkI1ProducersIntoUsers Pass Start ==\n");
+  LOG_DEBUG(moduleOp);
+
+  SmallVector<Operation *> producers;
+  // find single-result and regionless op with i1 tensor result-type
+  moduleOp.walk([&](Operation *op) {
+    if (isa<scf::SCFDialect>(op->getDialect())) {
+      LOG_DEBUG("skip scf dialect op: " << op << "\n");
+    }
+    // todo: adapt sinki1 pass with multi-result op
+    else if (op->getNumResults() > 1) {
+      LOG_DEBUG("skip multi-result op: "
+                << op << " with " << op->getNumResults() << " results\n");
+    } else if (isI1Producer(op) && isPureAndRegionless(op)) {
+      LOG_DEBUG("found i1 producer: " << op << "\n");
+      producers.push_back(op);
+    }
+  });
+
+  for (Operation *p : producers) {
+
+    for (OpOperand &use : p->getUses()) {
+      Operation *consumer = use.getOwner();
+
+      if (bm.isSameBlock(p, consumer)) {
+        continue;
+      }
+
+      // clone producer op to consumer block and adapt use
+      int consumerBlockId = bm.getBlockIdByOp(consumer);
+      Operation *cloned = p->clone();
+      consumer->getBlock()->push_back(cloned);
+      cloned->moveBefore(consumer);
+      use.set(cloned->getResult(0));
+      bm.updateBlockId(cloned, consumerBlockId);
+    }
+
+    // erase producer with no user left
+    if (p->use_empty())
+      p->erase();
+  }
+  LOG_DEBUG("== SinkI1ProducersIntoUsers Pass Complete ==\n");
+}
+
+std::unique_ptr<OperationPass<ModuleOp>> createSinkI1ProducersIntoUsersPass() {
+  return std::make_unique<SinkI1ProducersIntoUsersPass>();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
@@ -63,6 +63,10 @@ void ComputeBlockOptPass::runOnOperation() {
   pm.addPass(createFixpipeOptPass());
   pm.addPass(createReorderOpsByBlockIdPass());
 
+  pm.addPass(createSinkI1ProducersIntoUsersPass());
+  pm.addPass(createBroadcastUBOptPass());
+  pm.addPass(createMoveLoadIntoUserPass());
+
   if (failed(runPipeline(pm, module))) {
     if (!CVPipeline::hasFallbackAttr(module)) {
       CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
@@ -88,6 +92,9 @@ void registerComputeBlockOptPasses() {
   registerPass(createMergeCubeForBlockPass);
   registerPass(createFixpipeOptPass);
   registerPass(createUnifyStoreBlockPass);
+  registerPass(createSinkI1ProducersIntoUsersPass);
+  registerPass(createBroadcastUBOptPass);
+  registerPass(createMoveLoadIntoUserPass);
 }
 
 } // namespace triton


### PR DESCRIPTION
## Summary

Add 3 new ComputeBlockOpt passes:

### SinkI1ProducersIntoUsersPass
- **Pass**: `sink-i1-producers-into-users`
- **Function**: Sink i1-producing ops next to each of their i1 uses, cloning producers across block boundaries to localize i1 computation

### BroadcastUBOptPass
- **Pass**: `broadcast-ub-opt`
- **Function**: Optimize broadcast by moving it to the block of its users when safe

### MoveLoadIntoUserPass
- **Pass**: `move-load-into-user`
- **Function**: Move load operations into user blocks for optimization

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
