### PR TITLE
[ssbuffer](feat) better refine module in  PlanVectorBlockPass

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -82,6 +82,7 @@ inline constexpr llvm::StringLiteral kTightlyCoupledBufferAttr =
     "hivm.tightly_coupled_buffer";
 inline constexpr llvm::StringLiteral kCoreTypeCube = "CUBE";
 inline constexpr llvm::StringLiteral kCoreTypeVector = "VECTOR";
+inline constexpr llvm::StringLiteral kFromMakeRange = "tt.from_make_range";
 
 inline constexpr const char *ERRCODE_ATTR =
     "triton_ascend.dynamic_cv_pipeline.rc";

--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -68,8 +68,6 @@ inline constexpr llvm::StringLiteral kIterCounter = "ssbuffer.iterCounter";
 inline constexpr llvm::StringLiteral kForMayNotExec =
     "ssbuffer.for_may_not_exec";
 inline constexpr llvm::StringLiteral kClone = "ssbuffer.clone";
-inline constexpr llvm::StringLiteral kEnableUbRefineOpt =
-    "ssbuffer.enable_ub_refine_opt";
 inline constexpr llvm::StringLiteral kInsertionOptimization =
     "ssbuffer.insertionOptimization";
 inline constexpr llvm::StringLiteral kArg = "ssbuffer.arg";

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h
@@ -26,6 +26,7 @@
 #include "ascend/include/DynamicCVPipeline/Common/MemoryEffectsTracker.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 #include "llvm/ADT/ArrayRef.h"
 
 namespace mlir {
@@ -74,6 +75,23 @@ bool willCreateCycle(llvm::ArrayRef<Operation *> opsToUnify,
 void cloneScalarOpsForCrossBlockUses(ComputeBlockIdManager &bmOriginal,
                                      SetVector<Operation *> &matchedOps,
                                      int targetBlockId);
+
+/**
+ * @brief Check if a view-like operation originates from global memory (GM)
+ *
+ * Traces back through nested view-like operations (subview, reinterpret_cast,
+ * etc.) to determine if the source is a function argument (block argument in
+ * the entry block). Only view-like operations in the same block as the input
+ * viewOp are collected.
+ *
+ * @param viewOp The view-like operation to check
+ * @param matchedOps SetVector to collect all same-block view-like operations in
+ * the trace
+ * @return bool Returns true if the source is from global memory (function
+ * argument), false otherwise
+ */
+bool isSubviewFromGlobalMemory(ViewLikeOpInterface viewOp,
+                               SetVector<Operation *> &matchedOps);
 
 } // namespace CVPipeline
 } // namespace mlir

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h
@@ -77,21 +77,22 @@ void cloneScalarOpsForCrossBlockUses(ComputeBlockIdManager &bmOriginal,
                                      int targetBlockId);
 
 /**
- * @brief Check if a view-like operation originates from global memory (GM)
+ * @brief Check if a value originates from global memory (GM) and collect
+ * viewOps
  *
  * Traces back through nested view-like operations (subview, reinterpret_cast,
  * etc.) to determine if the source is a function argument (block argument in
  * the entry block). Only view-like operations in the same block as the input
  * viewOp are collected.
  *
- * @param viewOp The view-like operation to check
+ * @param viewValue The value to check
  * @param matchedOps SetVector to collect all same-block view-like operations in
  * the trace
  * @return bool Returns true if the source is from global memory (function
  * argument), false otherwise
  */
-bool isSubviewFromGlobalMemory(ViewLikeOpInterface viewOp,
-                               SetVector<Operation *> &matchedOps);
+bool collectViewOpsAndCheckGlobalMemory(Value viewValue,
+                                        SetVector<Operation *> &matchedOps);
 
 } // namespace CVPipeline
 } // namespace mlir

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h
@@ -72,7 +72,8 @@ bool willCreateCycle(llvm::ArrayRef<Operation *> opsToUnify,
  * @param matchedOps The op set of one pattern (target op first).
  */
 void cloneScalarOpsForCrossBlockUses(ComputeBlockIdManager &bmOriginal,
-                                     SetVector<Operation *> &matchedOps);
+                                     SetVector<Operation *> &matchedOps,
+                                     int targetBlockId);
 
 } // namespace CVPipeline
 } // namespace mlir

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
@@ -41,6 +41,8 @@ void registerMergeCubeForBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createUnifyStoreBlockPass();
 void registerUnifyStoreBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createFixpipeOptPass();
+std::unique_ptr<OperationPass<ModuleOp>> createMergeSmallBlockPass();
+void registerMergeSmallBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createSinkI1ProducersIntoUsersPass();
 std::unique_ptr<OperationPass<ModuleOp>> createBroadcastUBOptPass();
 std::unique_ptr<OperationPass<ModuleOp>> createMoveLoadIntoUserPass();

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
@@ -41,6 +41,9 @@ void registerMergeCubeForBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createUnifyStoreBlockPass();
 void registerUnifyStoreBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createFixpipeOptPass();
+std::unique_ptr<OperationPass<ModuleOp>> createSinkI1ProducersIntoUsersPass();
+std::unique_ptr<OperationPass<ModuleOp>> createBroadcastUBOptPass();
+std::unique_ptr<OperationPass<ModuleOp>> createMoveLoadIntoUserPass();
 
 } // namespace triton
 } // namespace mlir

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
@@ -46,6 +46,7 @@ void registerMergeSmallBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createSinkI1ProducersIntoUsersPass();
 std::unique_ptr<OperationPass<ModuleOp>> createBroadcastUBOptPass();
 std::unique_ptr<OperationPass<ModuleOp>> createMoveLoadIntoUserPass();
+std::unique_ptr<OperationPass<ModuleOp>> createPosMaskPatternPass();
 
 } // namespace triton
 } // namespace mlir

--- a/third_party/ascend/include/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.h
+++ b/third_party/ascend/include/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.h
@@ -43,6 +43,14 @@ private:
   bool needSplitAll;
 };
 
+class FoldExpandExtCollapse
+    : public mlir::OpRewritePattern<mlir::tensor::CollapseShapeOp> {
+public:
+  using OpRewritePattern<mlir::tensor::CollapseShapeOp>::OpRewritePattern;
+  llvm::LogicalResult matchAndRewrite(mlir::tensor::CollapseShapeOp collapseOp,
+                                      PatternRewriter &rewriter) const override;
+};
+
 class PatternMatchRewritePass
     : public PassWrapper<PatternMatchRewritePass, OperationPass<ModuleOp>> {
 public:

--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
@@ -1540,7 +1540,7 @@ static int processDepVal(Value depVal, const MainLoop &loop,
   return 0;
 }
 
-// If `clonedDepVals` is non-null, depVals that were actually cloned 
+// If `clonedDepVals` is non-null, depVals that were actually cloned
 static int cloneDepsToConsumers(
     const MainLoop &loop, DenseMap<Value, InnerBlockInfo> &blocks,
     DenseMap<Value, SmallVector<Value>> &depValueMap,
@@ -1620,13 +1620,11 @@ static int cloneDepsToConsumers(
 // Phase 1: clone empty+fill (and any `ins` defining ops sharing the empty's
 // parentOp) to consumer blocks; runs before dep collection because the cloned
 // fill's `ins` chain may reach a producer-side tensor that Phase 2 must see.
-static int
-cloneEmptyFillsInBlocks(const MainLoop &loop,
-                        DenseMap<Value, InnerBlockInfo> &blocks,
-                        DenseMap<Value, SmallVector<Value>> &depValueMap,
-                        DenseMap<Value, SmallVector<Operation *>> &depUserMap,
-                        OpBuilder &globalBuilder,
-                        DenseSet<Value> *clonedDepVals = nullptr) {
+static int cloneEmptyFillsInBlocks(
+    const MainLoop &loop, DenseMap<Value, InnerBlockInfo> &blocks,
+    DenseMap<Value, SmallVector<Value>> &depValueMap,
+    DenseMap<Value, SmallVector<Operation *>> &depUserMap,
+    OpBuilder &globalBuilder, DenseSet<Value> *clonedDepVals = nullptr) {
   return cloneDepsToConsumers(
       loop, blocks, depValueMap, depUserMap, globalBuilder, isEmptyFillPattern,
       [](IRMapping &mapper, OpBuilder &builder, Value depVal, int userBlockId,
@@ -1635,8 +1633,7 @@ cloneEmptyFillsInBlocks(const MainLoop &loop,
         // outs may come from either tensor::EmptyOp (the original case) or
         // bufferization.alloc_tensor (the new case). Both are "fresh tensor"
         // sources and treated identically below.
-        Operation *origAllocLike =
-            fillOp.getOutputs()[0].getDefiningOp();
+        Operation *origAllocLike = fillOp.getOutputs()[0].getDefiningOp();
 
         // Collect the `ins` operands whose defining op shares the parentOp with
         // the empty/alloc_tensor.
@@ -1688,12 +1685,13 @@ cloneAllocTensorsInBlocks(const MainLoop &loop,
 }
 
 // Process cross-block tensor dependencies for double buffering
-static int processTensorDependencies(
-    const MainLoop &loop, DenseMap<Value, InnerBlockInfo> &blocks,
-    DenseMap<Value, SmallVector<Value>> &depValueMap,
-    DenseMap<Value, SmallVector<Operation *>> &depUserMap, BufferMap &bufferMap,
-    OpBuilder &globalBuilder, int &groupId,
-    const DenseSet<Value> &clonedDepVals) {
+static int
+processTensorDependencies(const MainLoop &loop,
+                          DenseMap<Value, InnerBlockInfo> &blocks,
+                          DenseMap<Value, SmallVector<Value>> &depValueMap,
+                          DenseMap<Value, SmallVector<Operation *>> &depUserMap,
+                          BufferMap &bufferMap, OpBuilder &globalBuilder,
+                          int &groupId, const DenseSet<Value> &clonedDepVals) {
   SmallVector<Operation *> seenOps;
 
   for (auto &blockPair : blocks) {

--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
@@ -1981,6 +1981,12 @@ static int addInnerMultiBuffer(MainLoop mainLoop, OpBuilder &builder,
   if (blocks.empty())
     return -1;
 
+  // Memref-type dep values are not supported here.
+  if (hasMemrefDepValue(depValueMap)) {
+    LDBG("ERROR: Memref type dependent values found in user IR, fallback");
+    return -1;
+  }
+
   // Phase 1: build initial depUserMap and clone empty+fill patterns. We use
   // a fresh user map built from the initial allOps so the clone can find
   // consumer-block users; the cloned fills will rewrite those users' uses.
@@ -2013,12 +2019,20 @@ static int addInnerMultiBuffer(MainLoop mainLoop, OpBuilder &builder,
   if (blocks.empty())
     return -1;
 
-  // Memref-type dep values are not supported here; fail loudly so downstream
-  // passes don't see an unmarked-but-skipped scope.
-  if (hasMemrefDepValue(depValueMap)) {
-    LDBG("Falling Back: Memref type dependent values found!");
-    return -1;
+  // Drop memref-typed deps from Phase 2's collection
+  int droppedMemrefDeps = 0;
+  for (auto &p : depValueMap) {
+    llvm::erase_if(p.second, [&droppedMemrefDeps](Value v) {
+      if (isa<MemRefType>(v.getType())) {
+        ++droppedMemrefDeps;
+        return true;
+      }
+      return false;
+    });
   }
+  if (droppedMemrefDeps > 0)
+    LDBG("Dropped " + std::to_string(droppedMemrefDeps) +
+         " clone-induced memref deps from Phase 2 depValueMap");
 
   auto depUserMap = buildDepUserMap(blocks, allOps, depValueMap);
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
@@ -1407,7 +1407,7 @@ static int processDepVal(Value depVal, const MainLoop &loop,
   // Read the module-level `ssbuffer.insertionOptimization` attribute inline so
   // processDepVal can be called multiple times in the same pass run and stay
   // in sync with whatever the Python caller last wrote onto the ModuleOp.
-  bool enableOpt = false;
+  bool enableOpt = true;
   if (mlir::ModuleOp mod = loop->getParentOfType<mlir::ModuleOp>())
     enableOpt = mod->hasAttr(CVPipeline::kInsertionOptimization);
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
@@ -275,6 +275,14 @@ groupOpsBySsbufferId(SmallVector<Operation *> &allOps,
     }
     opsById[*id].push_back(op);
   }
+  // Also register ops that carry ssbuffer.block_id but have no results
+  for (Operation *op : allOps) {
+    auto id = getOpBlockId(op);
+    if (!id.has_value() || !op->getResults().empty())
+      continue;
+    if (seen.insert(op).second)
+      opsById[*id].push_back(op);
+  }
   return 0;
 }
 
@@ -348,7 +356,16 @@ collectInnerBlockInfo(const MainLoop &loop,
   // (e.g. scf.if) are included so their scalar deps get tracked; cross-block
   // judgment still attributes them to the ifOp via getOutermostSsbufferId.
   for (auto &p : opsById) {
-    Value groupKey = p.second.front()->getResult(0);
+    Operation *keyOp = nullptr;
+    for (Operation *op : p.second) {
+      if (!op->getResults().empty()) {
+        keyOp = op;
+        break;
+      }
+    }
+    if (!keyOp)
+      continue;
+    Value groupKey = keyOp->getResult(0);
     InnerBlockInfo bi;
     bi.blockId = groupKey;
     bi.ops = p.second;
@@ -432,10 +449,7 @@ buildDepUserMap(DenseMap<Value, InnerBlockInfo> &blocks,
   return depUserMap;
 }
 
-// Check if depVal matches the special pattern: linalg::FillOp whose outs comes
-// from a tensor::EmptyOp. When this pattern is detected, the pass can avoid
-// allocating a multi-buffer (alloc + copy + select + to_tensor) by cloning
-// the empty+fill ops to the consumer's position instead.
+// Check if depVal matches the special pattern with linalg::FillOp
 static bool isEmptyFillPattern(Value depVal) {
   Operation *defOp = depVal.getDefiningOp();
   auto fillOp = dyn_cast<linalg::FillOp>(defOp);
@@ -446,10 +460,13 @@ static bool isEmptyFillPattern(Value depVal) {
     return false;
 
   Value outs = fillOp.getOutputs()[0];
-  if (!outs || !isa_and_nonnull<tensor::EmptyOp>(outs.getDefiningOp()))
+  if (!outs)
     return false;
-
-  return true;
+  Operation *outsDef = outs.getDefiningOp();
+  if (!outsDef)
+    return false;
+  return isa<tensor::EmptyOp>(outsDef) ||
+         isa<bufferization::AllocTensorOp>(outsDef);
 }
 
 // Check if depVal is the result of a bufferization.alloc_tensor
@@ -458,7 +475,8 @@ static bool isAllocTensorPattern(Value depVal) {
 }
 
 SmallVector<Value>
-collectBufferValues(DenseMap<Value, SmallVector<Value>> &depValueMap) {
+collectBufferValues(DenseMap<Value, SmallVector<Value>> &depValueMap,
+                    const DenseSet<Value> &clonedDepVals) {
   SmallVector<Value> valueList;
   SmallVector<Operation *> seenOps;
 
@@ -478,9 +496,8 @@ collectBufferValues(DenseMap<Value, SmallVector<Value>> &depValueMap) {
       if (isa<tensor::EmptyOp>(op))
         continue;
 
-      // Skip tensor::EmptyOp + linalg::FillOp pattern - it gets cloned
-      // to the consumer's position instead of being multi-buffered
-      if (isEmptyFillPattern(depVal))
+      // Skip depVals that were already cloned by cloneEmptyFillsInBlocks
+      if (clonedDepVals.contains(depVal))
         continue;
 
       // Skip bufferization.alloc_tensor
@@ -1523,9 +1540,7 @@ static int processDepVal(Value depVal, const MainLoop &loop,
   return 0;
 }
 
-// For each depVal matching `patternCheck`, groups cross-block users by
-// userBlockId and calls `cloneFn` at the first user of each group to clone
-// ops (with kBlockId = userBlockId) and return the replacement Value.
+// If `clonedDepVals` is non-null, depVals that were actually cloned 
 static int cloneDepsToConsumers(
     const MainLoop &loop, DenseMap<Value, InnerBlockInfo> &blocks,
     DenseMap<Value, SmallVector<Value>> &depValueMap,
@@ -1533,7 +1548,8 @@ static int cloneDepsToConsumers(
     llvm::function_ref<bool(Value)> patternCheck,
     llvm::function_ref<Value(IRMapping &, OpBuilder &, Value depVal,
                              int userBlockId, ArrayRef<Operation *> users)>
-        cloneFn) {
+        cloneFn,
+    DenseSet<Value> *clonedDepVals = nullptr) {
   SmallVector<Operation *> seenOps;
 
   for (auto &blockPair : blocks) {
@@ -1590,6 +1606,8 @@ static int cloneDepsToConsumers(
         Value newVal = cloneFn(mapper, builder, depVal, userBlockId, users);
         if (!newVal)
           continue;
+        if (clonedDepVals)
+          clonedDepVals->insert(depVal);
         for (Operation *user : users) {
           user->replaceUsesOfWith(depVal, newVal);
         }
@@ -1607,29 +1625,33 @@ cloneEmptyFillsInBlocks(const MainLoop &loop,
                         DenseMap<Value, InnerBlockInfo> &blocks,
                         DenseMap<Value, SmallVector<Value>> &depValueMap,
                         DenseMap<Value, SmallVector<Operation *>> &depUserMap,
-                        OpBuilder &globalBuilder) {
+                        OpBuilder &globalBuilder,
+                        DenseSet<Value> *clonedDepVals = nullptr) {
   return cloneDepsToConsumers(
       loop, blocks, depValueMap, depUserMap, globalBuilder, isEmptyFillPattern,
       [](IRMapping &mapper, OpBuilder &builder, Value depVal, int userBlockId,
          ArrayRef<Operation *> users) -> Value {
         auto fillOp = cast<linalg::FillOp>(depVal.getDefiningOp());
-        auto origEmpty =
-            cast<tensor::EmptyOp>(fillOp.getOutputs()[0].getDefiningOp());
+        // outs may come from either tensor::EmptyOp (the original case) or
+        // bufferization.alloc_tensor (the new case). Both are "fresh tensor"
+        // sources and treated identically below.
+        Operation *origAllocLike =
+            fillOp.getOutputs()[0].getDefiningOp();
 
         // Collect the `ins` operands whose defining op shares the parentOp with
-        // the tensor::EmptyOp.
+        // the empty/alloc_tensor.
         SmallVector<Value> insToClone;
-        Operation *emptyParent = origEmpty->getParentOp();
+        Operation *allocParent = origAllocLike->getParentOp();
         for (Value insVal : fillOp.getInputs()) {
           Operation *insDef = insVal.getDefiningOp();
-          if (!insDef || insDef->getParentOp() != emptyParent)
+          if (!insDef || insDef->getParentOp() != allocParent)
             continue;
           insToClone.push_back(insVal);
         }
 
-        Operation *newEmpty = builder.clone(*origEmpty, mapper);
-        newEmpty->setAttr(kBlockId, builder.getI32IntegerAttr(userBlockId));
-        mapper.map(origEmpty->getResult(0), newEmpty->getResult(0));
+        Operation *newAllocLike = builder.clone(*origAllocLike, mapper);
+        newAllocLike->setAttr(kBlockId, builder.getI32IntegerAttr(userBlockId));
+        mapper.map(origAllocLike->getResult(0), newAllocLike->getResult(0));
 
         for (Value insVal : insToClone) {
           Operation *insDef = insVal.getDefiningOp();
@@ -1641,7 +1663,8 @@ cloneEmptyFillsInBlocks(const MainLoop &loop,
         Operation *newFill = builder.clone(*fillOp, mapper);
         newFill->setAttr(kBlockId, builder.getI32IntegerAttr(userBlockId));
         return newFill->getResult(0);
-      });
+      },
+      clonedDepVals);
 }
 
 // Clone bufferization.alloc_tensor to each consumer block
@@ -1669,7 +1692,8 @@ static int processTensorDependencies(
     const MainLoop &loop, DenseMap<Value, InnerBlockInfo> &blocks,
     DenseMap<Value, SmallVector<Value>> &depValueMap,
     DenseMap<Value, SmallVector<Operation *>> &depUserMap, BufferMap &bufferMap,
-    OpBuilder &globalBuilder, int &groupId) {
+    OpBuilder &globalBuilder, int &groupId,
+    const DenseSet<Value> &clonedDepVals) {
   SmallVector<Operation *> seenOps;
 
   for (auto &blockPair : blocks) {
@@ -1705,10 +1729,8 @@ static int processTensorDependencies(
       if (parentOp != loop.getOperation())
         continue;
 
-      // The empty+fill pattern has already been cloned by
-      // cloneEmptyFillsInBlocks (run before dep collection). Skip
-      // any remaining occurrences here.
-      if (isEmptyFillPattern(depVal))
+      // Skip depVals that were already cloned by cloneEmptyFillsInBlocks.
+      if (clonedDepVals.contains(depVal))
         continue;
 
       auto userIt = depUserMap.find(depVal);
@@ -1992,8 +2014,9 @@ static int addInnerMultiBuffer(MainLoop mainLoop, OpBuilder &builder,
   // consumer-block users; the cloned fills will rewrite those users' uses.
   DenseMap<Value, SmallVector<Operation *>> initialDepUserMap =
       buildDepUserMap(blocks, allOps, depValueMap);
+  DenseSet<Value> phase1ClonedDepVals;
   if (cloneEmptyFillsInBlocks(mainLoop, blocks, depValueMap, initialDepUserMap,
-                              globalBuilder) != 0)
+                              globalBuilder, &phase1ClonedDepVals) != 0)
     return -1;
 
   rematerializeTensorRootedScalarDeps(mainLoop);
@@ -2040,7 +2063,7 @@ static int addInnerMultiBuffer(MainLoop mainLoop, OpBuilder &builder,
   if (cloneAllocTensorsInBlocks(mainLoop, blocks, depValueMap, depUserMap,
                                 globalBuilder) != 0)
     return -1;
-  auto valueList = collectBufferValues(depValueMap);
+  auto valueList = collectBufferValues(depValueMap, phase1ClonedDepVals);
   LLVM_DEBUG(
       llvm::dbgs()
       << "[addInnerMultiBuffer] before insertBuffersBeforeLoop, valueList.size="
@@ -2059,7 +2082,8 @@ static int addInnerMultiBuffer(MainLoop mainLoop, OpBuilder &builder,
   LLVM_DEBUG(llvm::dbgs()
              << "[addInnerMultiBuffer] before processTensorDependencies\n");
   if (processTensorDependencies(mainLoop, blocks, depValueMap, depUserMap,
-                                bufferMap, globalBuilder, groupId) != 0) {
+                                bufferMap, globalBuilder, groupId,
+                                phase1ClonedDepVals) != 0) {
     return -1;
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
@@ -41,7 +41,8 @@ using namespace triton;
 namespace {
 
 static constexpr llvm::StringLiteral interceptrFunc[]{
-    "_parallel_hstu_attn_bwd", "chunk_gsa_bwd_k_kernel_dqkvg"};
+    "_parallel_hstu_attn_bwd", "chunk_abc_bwd_kernel_dh",
+    "flash_varlen_fwd_kernel", "chunk_gsa_bwd_k_kernel_dqkvg"};
 
 static LogicalResult verifyFuncNames(ModuleOp module) {
   bool intercepted = false;

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/BroadcastUBOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/BroadcastUBOptPass.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+static constexpr const char *DEBUG_TYPE = "broadcast-ub-opt";
+#define LOG_DEBUG(...)                                                         \
+  LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__)
+
+using namespace mlir;
+
+namespace mlir {
+namespace triton {
+
+class BroadcastUBOptPass
+    : public PassWrapper<BroadcastUBOptPass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(BroadcastUBOptPass)
+
+  BroadcastUBOptPass() = default;
+  void runOnOperation() override;
+
+  llvm::StringRef getArgument() const final { return "broadcast-ub-opt"; }
+  llvm::StringRef getDescription() const final {
+    return "Optimize broadcast by moving it to the block of its users when "
+           "safe";
+  }
+};
+
+} // namespace triton
+} // namespace mlir
+
+namespace mlir {
+namespace triton {
+
+void BroadcastUBOptPass::runOnOperation() {
+  ModuleOp moduleOp = getOperation();
+  auto &aa = getAnalysis<AliasAnalysis>();
+  CVPipeline::MemoryDependenceGraph memGraph(moduleOp, aa);
+  CVPipeline::ComputeBlockIdManager bm(moduleOp);
+  LOG_DEBUG("== BroadcastUBOpt Pass Start ==\n");
+  LOG_DEBUG(moduleOp);
+  moduleOp.walk([&](linalg::BroadcastOp op) {
+    SmallVector<Operation *> users(op->getUsers().begin(),
+                                   op->getUsers().end());
+    if (users.empty())
+      return;
+
+    int firstUserBlockId = bm.getBlockIdByOp(users.front());
+    if (CVPipeline::getOpCoreType(users.front()) !=
+        CVPipeline::CoreType::VECTOR_ONLY)
+      return;
+
+    if (CVPipeline::getOpCoreType(op.getOperation()) !=
+        CVPipeline::CoreType::VECTOR_ONLY)
+      return;
+
+    bool allUsersSameBlock = llvm::all_of(users, [&](Operation *user) {
+      return bm.getBlockIdByOp(user) == firstUserBlockId;
+    });
+
+    if (!allUsersSameBlock)
+      return;
+
+    LOG_DEBUG("broadcast " << op << " \n all users in same block "
+                           << firstUserBlockId << "\n");
+
+    int broadcastBlockId = bm.getBlockIdByOp(op.getOperation());
+    if (broadcastBlockId == firstUserBlockId) {
+      LOG_DEBUG("broadcast already in same block, skip\n");
+      return;
+    }
+
+    if (op->getBlock() != users.front()->getBlock()) {
+      return;
+    }
+
+    SmallVector<Operation *> opsToCheck = {op};
+    if (CVPipeline::willCreateCycle(opsToCheck, memGraph, firstUserBlockId,
+                                    bm)) {
+      LOG_DEBUG("would create cycle, skip\n");
+      return;
+    }
+
+    LOG_DEBUG("moving broadcast to block " << firstUserBlockId << "\n");
+    bm.updateBlockId(op, firstUserBlockId);
+  });
+  LOG_DEBUG("== BroadcastUBOpt Pass complete ==\n");
+}
+
+std::unique_ptr<OperationPass<ModuleOp>> createBroadcastUBOptPass() {
+  return std::make_unique<BroadcastUBOptPass>();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/BroadcastUBOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/BroadcastUBOptPass.cpp
@@ -71,40 +71,38 @@ void BroadcastUBOptPass::runOnOperation() {
   auto &aa = getAnalysis<AliasAnalysis>();
   CVPipeline::MemoryDependenceGraph memGraph(moduleOp, aa);
   CVPipeline::ComputeBlockIdManager bm(moduleOp);
-  LOG_DEBUG("== BroadcastUBOpt Pass Start ==\n");
   LOG_DEBUG(moduleOp);
   moduleOp.walk([&](linalg::BroadcastOp op) {
-    SmallVector<Operation *> users(op->getUsers().begin(),
-                                   op->getUsers().end());
-    if (users.empty())
-      return;
-
-    int firstUserBlockId = bm.getBlockIdByOp(users.front());
-    if (CVPipeline::getOpCoreType(users.front()) !=
-        CVPipeline::CoreType::VECTOR_ONLY)
-      return;
-
     if (CVPipeline::getOpCoreType(op.getOperation()) !=
         CVPipeline::CoreType::VECTOR_ONLY)
       return;
-
-    bool allUsersSameBlock = llvm::all_of(users, [&](Operation *user) {
-      return bm.getBlockIdByOp(user) == firstUserBlockId;
-    });
-
-    if (!allUsersSameBlock)
+    if (op->getUsers().empty())
       return;
 
-    LOG_DEBUG("broadcast " << op << " \n all users in same block "
+    // Just Simple scenario:
+    // brc's user all in same Block and in same block id.
+    Operation *oneUser = *op->getUsers().begin();
+    if (oneUser->getBlock() != op->getBlock()) {
+      return;
+    }
+    int firstUserBlockId = bm.getBlockIdByOp(oneUser);
+    if (firstUserBlockId == -1 || CVPipeline::getOpCoreType(oneUser) !=
+                                      CVPipeline::CoreType::VECTOR_ONLY) {
+      // No blcok Id (means control flow) && not vector: skip;
+      // vector only control flow should skip too.
+      return;
+    }
+    bool allUsersSameBlock = llvm::all_of(op->getUsers(), [&](Operation *user) {
+      return bm.getBlockIdByOp(user) == firstUserBlockId;
+    });
+    if (!allUsersSameBlock)
+      return;
+    LOG_DEBUG("broadcast " << *op << " \n all users in same block "
                            << firstUserBlockId << "\n");
 
     int broadcastBlockId = bm.getBlockIdByOp(op.getOperation());
     if (broadcastBlockId == firstUserBlockId) {
       LOG_DEBUG("broadcast already in same block, skip\n");
-      return;
-    }
-
-    if (op->getBlock() != users.front()->getBlock()) {
       return;
     }
 
@@ -114,11 +112,9 @@ void BroadcastUBOptPass::runOnOperation() {
       LOG_DEBUG("would create cycle, skip\n");
       return;
     }
-
     LOG_DEBUG("moving broadcast to block " << firstUserBlockId << "\n");
     bm.updateBlockId(op, firstUserBlockId);
   });
-  LOG_DEBUG("== BroadcastUBOpt Pass complete ==\n");
 }
 
 std::unique_ptr<OperationPass<ModuleOp>> createBroadcastUBOptPass() {

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
@@ -146,6 +146,9 @@ bool collectViewOpsAndCheckGlobalMemory(Value viewValue,
   if (!viewOp) {
     return false;
   }
+  if (!viewOp->hasOneUse()) {
+    return false;
+  }
   auto block = viewOp->getBlock();
   LOG_DEBUG("Check view source: " << viewValue);
   while (true) {
@@ -161,6 +164,9 @@ bool collectViewOpsAndCheckGlobalMemory(Value viewValue,
             dyn_cast<ViewLikeOpInterface>(viewValue.getDefiningOp())) {
       if (viewLike->getBlock() == block) {
         matchedOps.insert(viewLike.getOperation());
+      }
+      if (!viewLike->hasOneUse()) {
+        return false;
       }
       viewValue = viewLike.getViewSource();
       continue;

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
@@ -26,8 +26,11 @@
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
 #include "mlir/Analysis/TopologicalSortUtils.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 #include "triton/Analysis/Utility.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
@@ -114,6 +117,41 @@ void cloneScalarOpsForCrossBlockUses(ComputeBlockIdManager &bmOriginal,
       }
     }
   }
+}
+
+bool isSubviewFromGlobalMemory(ViewLikeOpInterface viewOp,
+                               SetVector<Operation *> &matchedOps) {
+  // Subview ops may be nested many layers deep through reinterpretation or
+  // other subviews. like, subview (subview (reinterpret_cast (subview
+  // (reinterpret_cast (arg0))))) so we need Search and only keep same block
+  // view-like op.
+  Value source = viewOp.getViewSource();
+  auto block = viewOp->getBlock();
+  LOG_DEBUG("Check view source: " << source << "\n");
+  while (true) {
+    if (auto blockArg = dyn_cast<BlockArgument>(source)) {
+      Operation *parentOp = blockArg.getOwner()->getParentOp();
+      if (isa<func::FuncOp>(parentOp)) {
+        return true;
+      } else {
+        LOG_DEBUG(
+            "Subview source block argument is not from func entry block.");
+        return false;
+      }
+    }
+    // From other view-like op
+    if (auto viewLike = dyn_cast<ViewLikeOpInterface>(source.getDefiningOp())) {
+      if (viewLike->getBlock() == block) {
+        matchedOps.insert(viewLike.getOperation());
+      }
+      source = viewLike.getViewSource();
+      continue;
+    }
+    LOG_DEBUG(
+        "Subview source defining op is not ViewLikeOpInterface: " << source);
+    return false;
+  }
+  return false;
 }
 
 } // namespace CVPipeline

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
@@ -81,7 +81,10 @@ bool willCreateCycle(llvm::ArrayRef<Operation *> opsToUnify,
 }
 
 void cloneScalarOpsForCrossBlockUses(ComputeBlockIdManager &bmOriginal,
-                                     SetVector<Operation *> &matchedOps) {
+                                     SetVector<Operation *> &matchedOps,
+                                     int targetBlockId) {
+
+  // This means move matchedOps into targetBlockId
   auto sorted = mlir::topologicalSort(matchedOps);
   for (Operation *op : llvm::reverse(sorted)) {
     if (op->getNumResults() == 1 &&
@@ -96,15 +99,15 @@ void cloneScalarOpsForCrossBlockUses(ComputeBlockIdManager &bmOriginal,
         if (!userInBlock)
           continue;
         if (llvm::find(matchedOps, userInBlock) == matchedOps.end() &&
-            bmOriginal.getBlockIdByOp(userInBlock) !=
-                bmOriginal.getBlockIdByOp(matchedOps[0])) {
+            bmOriginal.getBlockIdByOp(userInBlock) != targetBlockId) {
           otherUses.push_back(&use);
         }
       }
       if (otherUses.size() > 0) {
-        LOG_DEBUG("now cloned: " << *op << "\n");
+        LOG_DEBUG("now cloned: " << *op);
         OpBuilder builder(op);
         auto clonedOp = builder.clone(*op);
+        bmOriginal.updateBlockId(clonedOp, bmOriginal.getBlockIdByOp(op));
         for (auto use : otherUses) {
           (*use).set(clonedOp->getResult(0));
         }

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/Common.cpp
@@ -83,7 +83,7 @@ bool willCreateCycle(llvm::ArrayRef<Operation *> opsToUnify,
   return hasCycle;
 }
 
-void cloneScalarOpsForCrossBlockUses(ComputeBlockIdManager &bmOriginal,
+void cloneScalarOpsForCrossBlockUses(ComputeBlockIdManager &bm,
                                      SetVector<Operation *> &matchedOps,
                                      int targetBlockId) {
 
@@ -102,7 +102,7 @@ void cloneScalarOpsForCrossBlockUses(ComputeBlockIdManager &bmOriginal,
         if (!userInBlock)
           continue;
         if (llvm::find(matchedOps, userInBlock) == matchedOps.end() &&
-            bmOriginal.getBlockIdByOp(userInBlock) != targetBlockId) {
+            bm.getBlockIdByOp(userInBlock) != targetBlockId) {
           otherUses.push_back(&use);
         }
       }
@@ -110,7 +110,7 @@ void cloneScalarOpsForCrossBlockUses(ComputeBlockIdManager &bmOriginal,
         LOG_DEBUG("now cloned: " << *op);
         OpBuilder builder(op);
         auto clonedOp = builder.clone(*op);
-        bmOriginal.updateBlockId(clonedOp, bmOriginal.getBlockIdByOp(op));
+        bm.updateBlockId(clonedOp, bm.getBlockIdByOp(op));
         for (auto use : otherUses) {
           (*use).set(clonedOp->getResult(0));
         }
@@ -119,17 +119,14 @@ void cloneScalarOpsForCrossBlockUses(ComputeBlockIdManager &bmOriginal,
   }
 }
 
-bool isSubviewFromGlobalMemory(ViewLikeOpInterface viewOp,
-                               SetVector<Operation *> &matchedOps) {
+bool collectViewOpsAndCheckGlobalMemory(Value viewValue,
+                                        SetVector<Operation *> &matchedOps) {
   // Subview ops may be nested many layers deep through reinterpretation or
   // other subviews. like, subview (subview (reinterpret_cast (subview
   // (reinterpret_cast (arg0))))) so we need Search and only keep same block
   // view-like op.
-  Value source = viewOp.getViewSource();
-  auto block = viewOp->getBlock();
-  LOG_DEBUG("Check view source: " << source << "\n");
-  while (true) {
-    if (auto blockArg = dyn_cast<BlockArgument>(source)) {
+  auto isFuncArg = [&](Value v) {
+    if (auto blockArg = dyn_cast<BlockArgument>(v)) {
       Operation *parentOp = blockArg.getOwner()->getParentOp();
       if (isa<func::FuncOp>(parentOp)) {
         return true;
@@ -139,16 +136,37 @@ bool isSubviewFromGlobalMemory(ViewLikeOpInterface viewOp,
         return false;
       }
     }
+    return false;
+  };
+  if (isFuncArg(viewValue)) {
+    return true;
+  }
+
+  auto viewOp = viewValue.getDefiningOp<ViewLikeOpInterface>();
+  if (!viewOp) {
+    return false;
+  }
+  auto block = viewOp->getBlock();
+  LOG_DEBUG("Check view source: " << viewValue);
+  while (true) {
+
+    if (isFuncArg(viewValue)) {
+      return true;
+    }
+    if (!viewValue.getDefiningOp()) {
+      return false;
+    }
     // From other view-like op
-    if (auto viewLike = dyn_cast<ViewLikeOpInterface>(source.getDefiningOp())) {
+    if (auto viewLike =
+            dyn_cast<ViewLikeOpInterface>(viewValue.getDefiningOp())) {
       if (viewLike->getBlock() == block) {
         matchedOps.insert(viewLike.getOperation());
       }
-      source = viewLike.getViewSource();
+      viewValue = viewLike.getViewSource();
       continue;
     }
     LOG_DEBUG(
-        "Subview source defining op is not ViewLikeOpInterface: " << source);
+        "Subview source defining op is not ViewLikeOpInterface: " << viewValue);
     return false;
   }
   return false;

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
@@ -492,7 +492,8 @@ void FixpipeOptPass::runOnOperation() {
     for (auto op : closure.scalarOps) {
       matchedOps.insert(op);
     }
-    CVPipeline::cloneScalarOpsForCrossBlockUses(bmOriginal, matchedOps);
+    CVPipeline::cloneScalarOpsForCrossBlockUses(
+        bmOriginal, matchedOps, bmOriginal.getBlockIdByOp(matchedOps[0]));
   }
 
   auto bm = CVPipeline::ComputeBlockIdManager(module);

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
@@ -203,63 +203,21 @@ bool FixpipeOptPass::isValidMul(Operation *op, Value matmulValue,
   return false;
 }
 
-bool FixpipeOptPass::isSubviewFromGlobalMemory(
-    ViewLikeOpInterface viewOp, SetVector<Operation *> &matchedOps) {
-  // Subview ops may be nested many layers deep through reinterpretation or
-  // other subviews. like, subview (subview (reinterpret_cast (subview
-  // (reinterpret_cast (arg0))))) so we need Search and only keep same block
-  // view-like op.
-  Value source = viewOp.getViewSource();
-  auto block = viewOp->getBlock();
-  while (true) {
-    LOG_DEBUG("Check view source: " << source << "\n");
-    if (auto blockArg = dyn_cast<BlockArgument>(source)) {
-      Operation *parentOp = blockArg.getOwner()->getParentOp();
-      if (isa<func::FuncOp>(parentOp)) {
-        return true;
-      } else {
-        LOG_DEBUG(
-            "Subview source block argument is not from func entry block.");
-        return false;
-      }
-    }
-    // From other view-like op
-    if (auto viewLike = dyn_cast<ViewLikeOpInterface>(source.getDefiningOp())) {
-      if (viewLike->getBlock() == block) {
-        matchedOps.insert(viewLike.getOperation());
-      }
-      source = viewLike.getViewSource();
-      continue;
-    }
-    LOG_DEBUG(
-        "Subview source defining op is not ViewLikeOpInterface: " << source);
-    return false;
-  }
-  return false;
-}
-
 bool FixpipeOptPass::isStoreToGM(Operation *storeOp,
                                  SetVector<Operation *> &matchedOps) {
-  ViewLikeOpInterface viewOp = nullptr;
+  Value viewValue = nullptr;
   if (auto materializeOp =
           dyn_cast<bufferization::MaterializeInDestinationOp>(storeOp)) {
-    Value destMemref = materializeOp.getDest();
-    viewOp = destMemref.getDefiningOp<ViewLikeOpInterface>();
+    viewValue = materializeOp.getDest();
   } else if (auto hivmStore = dyn_cast<hivm::StoreOp>(storeOp)) {
-    auto dest = hivmStore.getDst();
-    viewOp = dest.getDefiningOp<ViewLikeOpInterface>();
+    viewValue = hivmStore.getDst();
   } else {
     LOG_DEBUG("Cannot find store op, NOT match");
     return false;
   }
 
-  if (!viewOp) {
-    LOG_DEBUG("store destination is not from ViewLikeOpInterface, NOT match");
-    return false;
-  }
   matchedOps.insert(storeOp);
-  matchedOps.insert(viewOp);
-  if (!isSubviewFromGlobalMemory(viewOp, matchedOps)) {
+  if (!CVPipeline::collectViewOpsAndCheckGlobalMemory(viewValue, matchedOps)) {
     LOG_DEBUG("Subview is not from global memory (GM), NOT match.");
     return false;
   }
@@ -481,7 +439,7 @@ void FixpipeOptPass::runOnOperation() {
           D
       Now we want to fuse A/B/C, so clone A' for D to avoid cycle.
   */
-  auto bmOriginal = CVPipeline::ComputeBlockIdManager(module);
+  auto bm = CVPipeline::ComputeBlockIdManager(module);
   for (auto &matchedOps : allMatchedPatterns) {
     if (matchedOps.empty()) {
       continue;
@@ -493,10 +451,9 @@ void FixpipeOptPass::runOnOperation() {
       matchedOps.insert(op);
     }
     CVPipeline::cloneScalarOpsForCrossBlockUses(
-        bmOriginal, matchedOps, bmOriginal.getBlockIdByOp(matchedOps[0]));
+        bm, matchedOps, bm.getBlockIdByOp(matchedOps[0]));
   }
 
-  auto bm = CVPipeline::ComputeBlockIdManager(module);
   for (auto &matchedOps : allMatchedPatterns) {
     if (!applyFixpipeOpt(matchedOps, memDepGraph, bm)) {
       for (Operation *op : matchedOps) {

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
@@ -411,15 +411,16 @@ void FixpipeOptPass::getDependentDialects(DialectRegistry &registry) const {
 }
 
 void FixpipeOptPass::runOnOperation() {
+  LOG_DEBUG("== FixpipeOpt Pass Start ==\n");
   ModuleOp module = getOperation();
 
   if (CVPipeline::hasFallbackAttr(module)) {
     return;
   }
 
+  LOG_DEBUG(module);
   auto &aliasAnalysis = getAnalysis<AliasAnalysis>();
   CVPipeline::MemoryDependenceGraph memDepGraph(module, aliasAnalysis);
-  LOG_DEBUG("== FixpipeOpt Pass Start ==\n");
   LOG_DEBUG(module);
 
   SmallVector<SetVector<Operation *>> allMatchedPatterns;

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeSmallBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeSmallBlockPass.cpp
@@ -1,0 +1,742 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+#include <optional>
+#include <utility>
+
+static constexpr const char *DEBUG_TYPE = "merge-small-block";
+#define LOG_DEBUG(...)                                                         \
+  LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
+
+using namespace mlir;
+using namespace triton;
+
+namespace mlir {
+namespace triton {
+
+class MergeSmallBlockPass
+    : public PassWrapper<MergeSmallBlockPass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MergeSmallBlockPass)
+
+  MergeSmallBlockPass() = default;
+
+  StringRef getArgument() const override { return "merge-small-block"; }
+
+  StringRef getDescription() const override {
+    return "Merge small compute blocks (<= 3 ops) into their operand or user "
+           "block";
+  }
+  void runOnOperation() override;
+
+private:
+  const int MIN_VF_SIZE = 3;
+};
+
+static int cntComputeOps(const llvm::ArrayRef<Operation *> ops) {
+  int count = 0;
+  for (Operation *op : ops) {
+    if (isa<tensor::CollapseShapeOp, tensor::ExpandShapeOp, tensor::EmptyOp>(
+            op)) {
+      continue;
+    }
+    bool allOperandsTensor = llvm::all_of(op->getOperands(), [](Value operand) {
+      return isa<RankedTensorType>(operand.getType());
+    });
+    bool allResultsTensor = llvm::all_of(op->getResults(), [](Value result) {
+      return isa<RankedTensorType>(result.getType());
+    });
+    if (!allOperandsTensor || !allResultsTensor) {
+      continue;
+    }
+    count++;
+  }
+  return count;
+}
+
+class MergeStrategy {
+public:
+  struct Context {
+    Block *block;
+    CVPipeline::ComputeBlockIdManager &bm;
+    CVPipeline::MemoryDependenceGraph &memGraph;
+    const DenseMap<int, int> &id2order;
+    const SmallVector<Operation *> &smallBlockOps;
+    int smallBlockId;
+  };
+
+  struct UpDownClassification {
+    SmallVector<int> upBlockIds;
+    SmallVector<int> downBlockIds;
+  };
+
+  virtual ~MergeStrategy() = default;
+  virtual void filter(SmallVector<int> &candidates, const Context &ctx) = 0;
+
+  static UpDownClassification
+  classifierUpDown(const SmallVector<int> &candidates, const Context &ctx) {
+    UpDownClassification result;
+
+    for (int blockId : candidates) {
+      if (ctx.id2order.contains(blockId) &&
+          ctx.id2order.lookup(blockId) <
+              ctx.id2order.lookup(ctx.smallBlockId)) {
+        result.upBlockIds.push_back(blockId);
+      } else {
+        result.downBlockIds.push_back(blockId);
+      }
+    }
+
+    return result;
+  }
+};
+
+class IROrderStrategy : public MergeStrategy {
+public:
+  void filter(SmallVector<int> &candidates, const Context &ctx) override {
+    auto classification = classifierUpDown(candidates, ctx);
+
+    if (classification.downBlockIds.empty()) {
+      return;
+    }
+
+    int selectedDownBlock = -1;
+    for (int id : classification.downBlockIds) {
+      if (selectedDownBlock == -1 ||
+          (ctx.id2order.contains(id) &&
+           ctx.id2order.lookup(id) < ctx.id2order.lookup(selectedDownBlock))) {
+        selectedDownBlock = id;
+      }
+    }
+
+    candidates.clear();
+    candidates.append(classification.upBlockIds.begin(),
+                      classification.upBlockIds.end());
+    if (selectedDownBlock != -1) {
+      candidates.push_back(selectedDownBlock);
+    }
+  }
+};
+
+class UBOccupationStrategy : public MergeStrategy {
+private:
+  static constexpr int64_t INF = (1 << 30);
+
+  static int64_t getValueSizeInBytes(Value value) {
+    if (CVPipeline::isScalarLike(value)) {
+      return 0;
+    }
+    Type type = value.getType();
+    auto getElemBytes = [](Type elemType) -> int64_t {
+      if (elemType.isIntOrFloat()) {
+        unsigned bits = elemType.getIntOrFloatBitWidth();
+        return std::max<int64_t>(1, bits / 8);
+      }
+      return 1;
+    };
+    if (auto rankedTensorType = dyn_cast<RankedTensorType>(type)) {
+      if (!rankedTensorType.hasStaticShape()) {
+        return INF;
+      }
+      int64_t numElements = 1;
+      for (int64_t dim : rankedTensorType.getShape()) {
+        if (dim < 0) {
+          return 1;
+        }
+        numElements *= dim;
+      }
+      return std::max<int64_t>(
+          1, numElements * getElemBytes(rankedTensorType.getElementType()));
+    }
+    return INF;
+  }
+
+  static int64_t getOperandUB(const llvm::ArrayRef<Operation *> smallBlockOps,
+                              int blockId,
+                              CVPipeline::ComputeBlockIdManager &bm) {
+    // Merge into blockId, how many UB will be saved.
+    int64_t total = 0;
+    for (Operation *op : smallBlockOps) {
+      for (Value operand : op->getOperands()) {
+        Operation *defOp = operand.getDefiningOp();
+        if (!defOp) {
+          continue;
+        }
+        if (bm.getBlockIdByOp(defOp) == blockId) {
+          int64_t valueSize = getValueSizeInBytes(operand);
+          if (valueSize == INF) {
+            return INF;
+          }
+          total += valueSize;
+        }
+      }
+    }
+    return total;
+  }
+
+  static int64_t getUserUB(const llvm::ArrayRef<Operation *> smallBlockOps,
+                           int blockId, CVPipeline::ComputeBlockIdManager &bm) {
+
+    // Merge into blockId, how many UB will be saved.
+    int64_t total = 0;
+    for (Operation *op : smallBlockOps) {
+      for (Value result : op->getResults()) {
+        // If result have multi users and users' block ids is not the same,
+        // merging cannot save UB.
+        if (llvm::all_of(result.getUsers(), [&](Operation *user) {
+              return bm.getBlockIdByOp(user) == blockId;
+            })) {
+          int64_t valueSize = getValueSizeInBytes(result);
+          if (valueSize == INF) {
+            return INF;
+          }
+          total += valueSize;
+        }
+      }
+    }
+    return total;
+  }
+
+public:
+  void filter(SmallVector<int> &candidates, const Context &ctx) override {
+    auto classification = classifierUpDown(candidates, ctx);
+
+    DenseMap<int, int64_t> blockIdToUB;
+
+    for (int upBlockId : classification.upBlockIds) {
+      int64_t ub = getOperandUB(ctx.smallBlockOps, upBlockId, ctx.bm);
+      blockIdToUB[upBlockId] = ub;
+      LOG_DEBUG("Merge into up block " << upBlockId << " will save UB: " << ub
+                                       << "B.");
+    }
+
+    for (int downBlockId : classification.downBlockIds) {
+      int64_t ub = getUserUB(ctx.smallBlockOps, downBlockId, ctx.bm);
+      blockIdToUB[downBlockId] = ub;
+      LOG_DEBUG("Merge into down block " << downBlockId
+                                         << " will save UB: " << ub << "B.");
+    }
+
+    if (blockIdToUB.empty()) {
+      return;
+    }
+
+    int64_t maxUB = -1;
+    for (auto &entry : blockIdToUB) {
+      if (entry.second > maxUB && entry.second != INF) {
+        maxUB = entry.second;
+      }
+    }
+
+    SmallVector<int> filtered;
+    for (int blockId : candidates) {
+      if (blockIdToUB.contains(blockId) && blockIdToUB[blockId] == maxUB) {
+        filtered.push_back(blockId);
+      }
+    }
+
+    candidates = std::move(filtered);
+  }
+};
+
+class DefaultUpStrategy : public MergeStrategy {
+public:
+  void filter(SmallVector<int> &candidates, const Context &ctx) override {
+    auto classification = classifierUpDown(candidates, ctx);
+
+    if (!classification.upBlockIds.empty()) {
+      candidates.clear();
+      candidates.push_back(classification.upBlockIds[0]);
+      return;
+    }
+
+    if (!classification.downBlockIds.empty()) {
+      candidates.clear();
+      candidates.push_back(classification.downBlockIds[0]);
+      return;
+    }
+  }
+};
+
+// This strategy matches a specific Flash Attention Forward (FaFWD) pattern in
+// small compute blocks. The pattern consists of 3 operations: exp, mulf, and
+// addf, forming a softmax-like computation.
+//
+// Pattern structure:
+//   - exp: computes exp(subf), where subf is from an upstream block
+//   (upBlockIds[0])
+//   - mulf: computes exp_result * arg, where arg is a loop iteration argument
+//   - addf: computes mulf_result + reduce, where reduce is from the same
+//   upstream block
+//
+// Data flow:
+//   1. exp takes subf as input, its result is used by:
+//      - mulf (in the current small block)
+//      - broadcast (in downstream block, downBlockIds[0])
+//
+//   2. mulf takes exp_result and arg (BlockArgument) as inputs, its result is
+//   used by:
+//      - addf (in the current small block, no other users)
+//
+//   3. addf takes mulf_result and reduce as inputs, its result is used by:
+//      - yield (updates the same arg that mulf uses)
+//
+// This pattern typically appears in Flash Attention forward pass where:
+//   - exp computes the exponential of (QK^T - max)
+//   - mulf scales by a running sum
+//   - addf accumulates the result
+//
+// When matched, the strategy recommends merging into the downstream block
+// (downBlockIds[0]).
+class FaFWDPatternStrategy : public MergeStrategy {
+private:
+  bool findTargetOps(math::ExpOp &expOp, arith::MulFOp &mulfOp,
+                     arith::AddFOp &addfOp, const Context &ctx) {
+    for (Operation *op : ctx.smallBlockOps) {
+      if (auto exp = dyn_cast<math::ExpOp>(op)) {
+        expOp = exp;
+      } else if (auto mulf = dyn_cast<arith::MulFOp>(op)) {
+        mulfOp = mulf;
+      } else if (auto addf = dyn_cast<arith::AddFOp>(op)) {
+        addfOp = addf;
+      } else {
+        return false;
+      }
+    }
+    if (!expOp || !mulfOp || !addfOp) {
+      return false;
+    }
+    return true;
+  }
+
+  bool isValidExpOp(math::ExpOp &expOp, arith::MulFOp &mulfOp, int upBlockId,
+                    int downBlockId, const Context &ctx) {
+    Operation *subfDef = expOp.getOperand().getDefiningOp();
+    if (!subfDef || !isa<arith::SubFOp>(subfDef)) {
+      return false;
+    }
+    int subfBlockId = ctx.bm.getBlockIdByOp(subfDef);
+    if (subfBlockId != upBlockId) {
+      return false;
+    }
+
+    auto expResult = expOp.getResult();
+    SmallVector<Operation *, 2> expUsers;
+    for (Operation *user : expResult.getUsers()) {
+      Operation *userInBlock = CVPipeline::getAncestorInBlock(user, ctx.block);
+      if (userInBlock && userInBlock != ctx.block->getTerminator()) {
+        expUsers.push_back(user);
+      }
+    }
+    if (expUsers.size() != 2) {
+      return false;
+    }
+    bool hasMulfUser = false;
+    bool hasBroadcastUser = false;
+    for (Operation *user : expUsers) {
+      if (user == mulfOp) {
+        hasMulfUser = true;
+      } else if (isa<linalg::BroadcastOp>(user) ||
+                 isa<triton::BroadcastOp>(user)) {
+        int broadcastBlockId = ctx.bm.getBlockIdByOp(user);
+        if (broadcastBlockId == downBlockId) {
+          hasBroadcastUser = true;
+        }
+      }
+    }
+    if (!hasMulfUser || !hasBroadcastUser) {
+      return false;
+    }
+    return true;
+  }
+
+  bool isValidMulfOp(math::ExpOp &expOp, arith::MulFOp &mulfOp,
+                     arith::AddFOp &addfOp, const Context &ctx) {
+    Value expResult = expOp->getResults()[0];
+    auto mulfLhs = mulfOp.getLhs();
+    auto mulfRhs = mulfOp.getRhs();
+
+    bool expIsOperand = (mulfLhs == expResult || mulfRhs == expResult);
+    if (!expIsOperand) {
+      return false;
+    }
+
+    Value mulfArgOperand = (mulfLhs == expResult) ? mulfRhs : mulfLhs;
+    BlockArgument mulfArg = dyn_cast<BlockArgument>(mulfArgOperand);
+    if (!mulfArg) {
+      return false;
+    }
+
+    for (Operation *user : mulfOp.getResult().getUsers()) {
+      if (user != addfOp) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool isValidAddfOp(arith::MulFOp &mulfOp, arith::AddFOp &addfOp,
+                     int upBlockId, const Context &ctx) {
+    auto addfLhs = addfOp.getLhs();
+    auto addfRhs = addfOp.getRhs();
+
+    bool mulfIsOperand =
+        (addfLhs == mulfOp.getResult() || addfRhs == mulfOp.getResult());
+    if (!mulfIsOperand) {
+      return false;
+    }
+
+    Value reduceOperand = (addfLhs == mulfOp.getResult()) ? addfRhs : addfLhs;
+    Operation *reduceDef = reduceOperand.getDefiningOp();
+
+    if (!reduceDef || !isa<linalg::ReduceOp, triton::ReduceOp>(reduceDef)) {
+      return false;
+    }
+
+    int reduceBlockId = ctx.bm.getBlockIdByOp(reduceDef);
+    if (reduceBlockId != upBlockId) {
+      return false;
+    }
+
+    auto addfResult = addfOp.getResult();
+    SmallVector<Operation *, 1> addfUsers;
+    for (Operation *user : addfResult.getUsers()) {
+      addfUsers.push_back(user);
+    }
+
+    // Use for updating mulfArg
+    if (addfUsers.size() != 1) {
+      return false;
+    }
+    BlockArgument mulfArg;
+    for (auto v : mulfOp.getOperands()) {
+      if (!v.getDefiningOp()) {
+        mulfArg = dyn_cast<BlockArgument>(v);
+      }
+    }
+    scf::YieldOp yieldOp = dyn_cast<scf::YieldOp>(addfUsers[0]);
+    if (!yieldOp) {
+      return false;
+    }
+    Block *yieldBlock = yieldOp->getBlock();
+    scf::ForOp forOp = dyn_cast<scf::ForOp>(yieldBlock->getParentOp());
+    if (!forOp) {
+      return false;
+    }
+    int yieldOpIndex = -1;
+    auto yieldOperands = yieldOp.getOperands();
+    for (int i = 0; i < yieldOperands.size(); ++i) {
+      if (yieldOperands[i] == addfResult) {
+        yieldOpIndex = i;
+        break;
+      }
+    }
+    if (yieldOpIndex == -1) {
+      return false;
+    }
+    BlockArgument correspondingIterArg = forOp.getRegionIterArg(yieldOpIndex);
+    if (correspondingIterArg != mulfArg) {
+      return false;
+    }
+    return true;
+  }
+
+public:
+  void filter(SmallVector<int> &candidates, const Context &ctx) override {
+    if (ctx.smallBlockOps.size() != 3) {
+      return;
+    }
+    auto classification = classifierUpDown(candidates, ctx);
+    if (classification.upBlockIds.size() != 1 ||
+        classification.downBlockIds.size() != 1) {
+      return;
+    }
+
+    math::ExpOp expOp = nullptr;
+    arith::MulFOp mulfOp = nullptr;
+    arith::AddFOp addfOp = nullptr;
+    if (!findTargetOps(expOp, mulfOp, addfOp, ctx)) {
+      return;
+    }
+
+    if (!isValidExpOp(expOp, mulfOp, classification.upBlockIds[0],
+                      classification.downBlockIds[0], ctx)) {
+      return;
+    }
+
+    if (!isValidMulfOp(expOp, mulfOp, addfOp, ctx)) {
+      return;
+    }
+
+    if (!isValidAddfOp(mulfOp, addfOp, classification.upBlockIds[0], ctx)) {
+      return;
+    }
+    candidates.clear();
+    candidates.push_back(classification.downBlockIds[0]);
+  }
+};
+
+static void collectUpstream(int smallBlockId, Block *block,
+                            CVPipeline::ComputeBlockIdManager &bm,
+                            SmallVector<int> &candidates,
+                            llvm::ArrayRef<Operation *> ops,
+                            const CVPipeline::MemoryDependenceGraph &memGraph) {
+  bool haveCubeLink = false;
+  llvm::SmallDenseSet<int> upBlockIds;
+  for (Operation *op : ops) {
+    for (Value operand : op->getOperands()) {
+      Operation *defOp = operand.getDefiningOp();
+      if (!defOp) {
+        continue;
+      }
+      Operation *defInBlock = CVPipeline::getAncestorInBlock(defOp, block);
+      if (!defInBlock) {
+        continue;
+      }
+      if (bm.getBlockIdByOp(defInBlock) == -1 ||
+          CVPipeline::getOpCoreType(defInBlock) !=
+              CVPipeline::CoreType::VECTOR_ONLY) {
+        haveCubeLink = true;
+        break;
+      }
+      int bid = bm.getBlockIdByOp(defInBlock);
+      if (bid != -1 && bid != smallBlockId) {
+        upBlockIds.insert(bid);
+      }
+    }
+    if (haveCubeLink) {
+      break;
+    }
+  }
+  if (haveCubeLink) {
+    LOG_DEBUG("Block " << smallBlockId
+                       << " has operand defined by CUBE, no up candidates.");
+    upBlockIds.clear();
+  }
+
+  if (upBlockIds.size() == 1) {
+    int upBlockId = *upBlockIds.begin();
+    if (!CVPipeline::willCreateCycle(ops, memGraph, upBlockId, bm)) {
+      candidates.push_back(upBlockId);
+    }
+  }
+}
+
+static void
+collectDownstream(int smallBlockId, Block *block,
+                  CVPipeline::ComputeBlockIdManager &bm,
+                  SmallVector<int> &candidates, llvm::ArrayRef<Operation *> ops,
+                  const CVPipeline::MemoryDependenceGraph &memGraph) {
+  bool haveCubeLink = false;
+  llvm::SmallDenseSet<int> downBlockIds;
+  for (Operation *op : ops) {
+    for (Value result : op->getResults()) {
+      for (Operation *user : result.getUsers()) {
+        Operation *userInBlock = CVPipeline::getAncestorInBlock(user, block);
+        if (!userInBlock || (block->mightHaveTerminator() &&
+                             userInBlock == block->getTerminator())) {
+          continue;
+        }
+        if (bm.getBlockIdByOp(userInBlock) == -1 ||
+            CVPipeline::getOpCoreType(userInBlock) !=
+                CVPipeline::CoreType::VECTOR_ONLY) {
+          haveCubeLink = true;
+          break;
+        }
+        int bid = bm.getBlockIdByOp(userInBlock);
+        if (bid != -1 && bid != smallBlockId) {
+          downBlockIds.insert(bid);
+        }
+      }
+      if (haveCubeLink) {
+        break;
+      }
+    }
+    if (haveCubeLink) {
+      break;
+    }
+  }
+  if (haveCubeLink) {
+    LOG_DEBUG("Block " << smallBlockId
+                       << " has result used by CUBE, no down candidates.");
+    downBlockIds.clear();
+  }
+  for (int downBlockId : downBlockIds) {
+    if (!CVPipeline::willCreateCycle(ops, memGraph, downBlockId, bm)) {
+      candidates.push_back(downBlockId);
+    }
+  }
+}
+
+static SmallVector<int>
+collectMergeCandidates(int smallBlockId, Block *block,
+                       CVPipeline::ComputeBlockIdManager &bm,
+                       const CVPipeline::MemoryDependenceGraph &memGraph) {
+
+  SmallVector<int> candidates;
+  auto ops = bm.getOpsByBlockId(smallBlockId);
+
+  collectUpstream(smallBlockId, block, bm, candidates, ops, memGraph);
+  collectDownstream(smallBlockId, block, bm, candidates, ops, memGraph);
+
+  return candidates;
+}
+
+static std::optional<int>
+selectMergeTarget(SmallVector<int> &candidates,
+                  const SmallVector<Operation *> &ops, Block *block,
+                  CVPipeline::ComputeBlockIdManager &bm,
+                  CVPipeline::MemoryDependenceGraph &memGraph,
+                  const DenseMap<int, int> &id2order, int smallBlockId) {
+  if (candidates.size() == 1) {
+    return candidates[0];
+  }
+  SmallVector<std::unique_ptr<MergeStrategy>> strategies;
+  strategies.push_back(std::make_unique<FaFWDPatternStrategy>());
+  strategies.push_back(std::make_unique<UBOccupationStrategy>());
+  strategies.push_back(std::make_unique<IROrderStrategy>());
+  strategies.push_back(std::make_unique<DefaultUpStrategy>());
+
+  MergeStrategy::Context ctx{block, bm, memGraph, id2order, ops, smallBlockId};
+
+  for (auto &strategy : strategies) {
+    strategy->filter(candidates, ctx);
+    if (candidates.size() == 1) {
+      return candidates[0];
+    }
+  }
+
+  return std::nullopt;
+}
+
+static void getBlockIdsInProgramOrder(Block *block,
+                                      CVPipeline::ComputeBlockIdManager &bm,
+                                      SmallVector<int> &ordered,
+                                      DenseMap<int, int> &id2order) {
+  ordered.clear();
+  id2order.clear();
+  llvm::SmallDenseSet<int, 4> seen;
+  for (Operation &op : *block) {
+    int bid = bm.getBlockIdByOp(&op);
+    if (bid != -1 && seen.insert(bid).second) {
+      id2order[bid] = ordered.size();
+      ordered.push_back(bid);
+    }
+  }
+}
+
+void MergeSmallBlockPass::runOnOperation() {
+  ModuleOp module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
+  LOG_DEBUG("Before: " << *module);
+  auto &aa = getAnalysis<AliasAnalysis>();
+  CVPipeline::MemoryDependenceGraph memGraph(module, aa);
+  auto bm = CVPipeline::ComputeBlockIdManager(module);
+
+  llvm::SmallVector<Block *> blocks;
+  SmallVector<int> orderedBlockIds;
+  DenseMap<int, int> id2order;
+  module.walk([&](Block *block) {
+    getBlockIdsInProgramOrder(block, bm, orderedBlockIds, id2order);
+
+    for (int nowBlockId : orderedBlockIds) {
+      LOG_DEBUG("Processing block " << nowBlockId);
+      auto ops = bm.getOpsByBlockId(nowBlockId);
+      if (ops.empty() || cntComputeOps(ops) > MIN_VF_SIZE) {
+        continue;
+      }
+      if (CVPipeline::getOpCoreType(*ops.begin()) !=
+          CVPipeline::CoreType::VECTOR_ONLY) {
+        continue;
+      }
+
+      LOG_DEBUG("Processing small block " << nowBlockId);
+      for (auto op : ops) {
+        LOG_DEBUG("op:" << *op);
+      }
+
+      SmallVector<int> candidates =
+          collectMergeCandidates(nowBlockId, block, bm, memGraph);
+
+      if (candidates.empty()) {
+        LOG_DEBUG("No candidates for block " << nowBlockId);
+        continue;
+      }
+
+      LLVM_DEBUG({
+        LOG_DEBUG("ready to merge block " << nowBlockId
+                                          << " with candidates: ");
+        for (int candidateId : candidates) {
+          LOG_DEBUG("candidate block " << candidateId);
+        }
+      });
+
+      auto targetBlockId = selectMergeTarget(candidates, ops, block, bm,
+                                             memGraph, id2order, nowBlockId);
+
+      if (targetBlockId.has_value()) {
+        LOG_DEBUG("Merging block " << nowBlockId << " into block "
+                                   << targetBlockId.value());
+        for (Operation *op : ops) {
+          bm.updateBlockId(op, targetBlockId.value());
+        }
+      }
+    }
+  });
+}
+
+std::unique_ptr<OperationPass<ModuleOp>> createMergeSmallBlockPass() {
+  return std::make_unique<MergeSmallBlockPass>();
+}
+
+void registerMergeSmallBlockPass() {
+  PassRegistration<MergeSmallBlockPass> reg;
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeSmallBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeSmallBlockPass.cpp
@@ -203,13 +203,17 @@ private:
         if (!defOp) {
           continue;
         }
+        
         if (bm.getBlockIdByOp(defOp) == blockId) {
-          int64_t valueSize = getValueSizeInBytes(operand);
-          if (valueSize == INF) {
-            return INF;
+          if (!isa<tensor::EmptyOp>(defOp)){
+            int64_t valueSize = getValueSizeInBytes(operand);
+            if (valueSize == INF) {
+              return INF;
+            }
+            total += valueSize;
           }
-          total += valueSize;
         }
+
       }
     }
     return total;
@@ -523,6 +527,7 @@ static void collectUpstream(int smallBlockId, Block *block,
                             llvm::ArrayRef<Operation *> ops,
                             const CVPipeline::MemoryDependenceGraph &memGraph) {
   bool haveCubeLink = false;
+  llvm::SmallVector<Value> allDepValues;
   llvm::SmallDenseSet<int> upBlockIds;
   for (Operation *op : ops) {
     for (Value operand : op->getOperands()) {
@@ -543,6 +548,7 @@ static void collectUpstream(int smallBlockId, Block *block,
       int bid = bm.getBlockIdByOp(defInBlock);
       if (bid != -1 && bid != smallBlockId) {
         upBlockIds.insert(bid);
+        allDepValues.push_back(operand);
       }
     }
     if (haveCubeLink) {
@@ -552,6 +558,14 @@ static void collectUpstream(int smallBlockId, Block *block,
   if (haveCubeLink) {
     LOG_DEBUG("Block " << smallBlockId
                        << " has operand defined by CUBE, no up candidates.");
+    upBlockIds.clear();
+  }
+
+  if (llvm::all_of(allDepValues, [&](Value v){
+    return CVPipeline::isScalarLike(v);
+  })) {
+    LOG_DEBUG("Block " << smallBlockId
+                       << " only has scalar dependency.");
     upBlockIds.clear();
   }
 
@@ -578,13 +592,17 @@ collectDownstream(int smallBlockId, Block *block,
                              userInBlock == block->getTerminator())) {
           continue;
         }
-        if (bm.getBlockIdByOp(userInBlock) == -1 ||
-            CVPipeline::getOpCoreType(userInBlock) !=
-                CVPipeline::CoreType::VECTOR_ONLY) {
+        int bid = bm.getBlockIdByOp(userInBlock);
+        if (bid == smallBlockId) {
+          continue;
+        }
+
+        if (bid == -1 || CVPipeline::getOpCoreType(userInBlock) !=
+                             CVPipeline::CoreType::VECTOR_ONLY) {
+          // FIXME: wait for multi-region
           haveCubeLink = true;
           break;
         }
-        int bid = bm.getBlockIdByOp(userInBlock);
         if (bid != -1 && bid != smallBlockId) {
           downBlockIds.insert(bid);
         }
@@ -605,6 +623,8 @@ collectDownstream(int smallBlockId, Block *block,
   for (int downBlockId : downBlockIds) {
     if (!CVPipeline::willCreateCycle(ops, memGraph, downBlockId, bm)) {
       candidates.push_back(downBlockId);
+    } else {
+      LOG_DEBUG("Block " << smallBlockId << " merge to " << downBlockId << " will create cycle!\n");
     }
   }
 }
@@ -683,6 +703,9 @@ void MergeSmallBlockPass::runOnOperation() {
   DenseMap<int, int> id2order;
   module.walk([&](Block *block) {
     getBlockIdsInProgramOrder(block, bm, orderedBlockIds, id2order);
+    if (orderedBlockIds.size() < 2) {
+      return ;
+    }
 
     for (int nowBlockId : orderedBlockIds) {
       LOG_DEBUG("Processing block " << nowBlockId);

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeSmallBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeSmallBlockPass.cpp
@@ -203,9 +203,9 @@ private:
         if (!defOp) {
           continue;
         }
-        
+
         if (bm.getBlockIdByOp(defOp) == blockId) {
-          if (!isa<tensor::EmptyOp>(defOp)){
+          if (!isa<tensor::EmptyOp>(defOp)) {
             int64_t valueSize = getValueSizeInBytes(operand);
             if (valueSize == INF) {
               return INF;
@@ -213,7 +213,6 @@ private:
             total += valueSize;
           }
         }
-
       }
     }
     return total;
@@ -561,11 +560,9 @@ static void collectUpstream(int smallBlockId, Block *block,
     upBlockIds.clear();
   }
 
-  if (llvm::all_of(allDepValues, [&](Value v){
-    return CVPipeline::isScalarLike(v);
-  })) {
-    LOG_DEBUG("Block " << smallBlockId
-                       << " only has scalar dependency.");
+  if (llvm::all_of(allDepValues,
+                   [&](Value v) { return CVPipeline::isScalarLike(v); })) {
+    LOG_DEBUG("Block " << smallBlockId << " only has scalar dependency.");
     upBlockIds.clear();
   }
 
@@ -624,7 +621,8 @@ collectDownstream(int smallBlockId, Block *block,
     if (!CVPipeline::willCreateCycle(ops, memGraph, downBlockId, bm)) {
       candidates.push_back(downBlockId);
     } else {
-      LOG_DEBUG("Block " << smallBlockId << " merge to " << downBlockId << " will create cycle!\n");
+      LOG_DEBUG("Block " << smallBlockId << " merge to " << downBlockId
+                         << " will create cycle!\n");
     }
   }
 }
@@ -704,7 +702,7 @@ void MergeSmallBlockPass::runOnOperation() {
   module.walk([&](Block *block) {
     getBlockIdsInProgramOrder(block, bm, orderedBlockIds, id2order);
     if (orderedBlockIds.size() < 2) {
-      return ;
+      return;
     }
 
     for (int nowBlockId : orderedBlockIds) {

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MoveLoadIntoUserPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MoveLoadIntoUserPass.cpp
@@ -1,0 +1,320 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/Analysis/TopologicalSortUtils.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+#include <optional>
+
+static constexpr const char *DEBUG_TYPE = "move-load-into-user";
+#define LOG_DEBUG(...)                                                         \
+  LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
+
+using namespace mlir;
+using namespace triton;
+
+namespace mlir {
+namespace triton {
+
+class MoveLoadIntoUserPass
+    : public PassWrapper<MoveLoadIntoUserPass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MoveLoadIntoUserPass)
+
+  MoveLoadIntoUserPass() = default;
+  void runOnOperation() override;
+
+  llvm::StringRef getArgument() const final { return "move-load-into-user"; }
+
+private:
+  struct LoadPatternInfo {
+    SmallVector<Operation *> matchedOps;
+    int commonBlockId;
+  };
+
+  bool matchLoadPattern(memref::CopyOp copyOp,
+                        SmallVector<Operation *> &matchedOps);
+
+  bool checkAllOpsInSameBlock(ArrayRef<Operation *> ops,
+                              CVPipeline::ComputeBlockIdManager &bm);
+};
+
+static Operation *traceCalculateUser(Operation *originUser,
+                                     CVPipeline::ComputeBlockIdManager &bm,
+                                     int totensorId,
+                                     SmallVector<Operation *> &userChain) {
+  // only find single chian
+  //  pattern -> collapse1(totensorId)->collapse2(totensorId)...->user
+  //  (targetblockId), collapse should move together.
+  //         \-> other userChain   -> user (targetblockId)
+  auto retUser = originUser;
+  while (bm.getBlockIdByOp(retUser) == totensorId &&
+         isa<tensor::CollapseShapeOp>(retUser)) {
+    if (retUser->getResult(0).getNumUses() != 1) {
+      break;
+    }
+    userChain.push_back(retUser);
+    retUser = *retUser->getUsers().begin();
+  }
+  return retUser;
+}
+
+static std::optional<Operation *>
+getFirstUser(bufferization::ToTensorOp toTensorOp,
+             CVPipeline::ComputeBlockIdManager &bm,
+             SmallVector<Operation *> &matchedOps) {
+  Operation *firstUser = nullptr;
+  SmallVector<Operation *> fistUserChain;
+
+  for (auto *user : toTensorOp->getUsers()) {
+    auto *userInBlock =
+        CVPipeline::getAncestorInBlock(user, toTensorOp->getBlock());
+    if (userInBlock) {
+      SmallVector<Operation *> userChain;
+      auto calUser = traceCalculateUser(
+          userInBlock, bm, bm.getBlockIdByOp(toTensorOp), userChain);
+      if (!firstUser || calUser->isBeforeInBlock(firstUser)) {
+        // First in ordered IR, it's cblock is first too.
+        firstUser = calUser;
+        fistUserChain = userChain;
+      }
+    }
+  }
+
+  if (!firstUser) {
+    LOG_DEBUG("No users of to_tensor found");
+    return std::nullopt;
+  }
+  LOG_DEBUG("Find first user:\n" << *firstUser);
+
+  int blockId = bm.getBlockIdByOp(firstUser);
+  if (blockId == -1) {
+    LOG_DEBUG("First user has no block_id");
+    return std::nullopt;
+  }
+
+  if (blockId == bm.getBlockIdByOp(toTensorOp)) {
+    LOG_DEBUG("First user in same block");
+    return std::nullopt;
+  }
+  matchedOps.append(fistUserChain.begin(), fistUserChain.end());
+  return firstUser;
+}
+
+bool MoveLoadIntoUserPass::checkAllOpsInSameBlock(
+    ArrayRef<Operation *> ops, CVPipeline::ComputeBlockIdManager &bm) {
+  if (ops.empty()) {
+    return false;
+  }
+
+  int commonBlockId = -1;
+  for (auto *op : ops) {
+    int blockId = bm.getBlockIdByOp(op);
+    if (blockId == -1) {
+      LOG_DEBUG("Op has no block_id");
+      return false;
+    }
+    if (commonBlockId == -1) {
+      commonBlockId = blockId;
+    } else if (blockId != commonBlockId) {
+      LOG_DEBUG("Not all ops in the same block");
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool MoveLoadIntoUserPass::matchLoadPattern(
+    memref::CopyOp copyOp, SmallVector<Operation *> &matchedOps) {
+  // Step 1: Check if source is from global memory
+  Value source = copyOp.getSource();
+  auto viewOp = source.getDefiningOp<ViewLikeOpInterface>();
+  if (!viewOp) {
+    LOG_DEBUG("Copy source is not from ViewLikeOpInterface");
+    return false;
+  }
+
+  SetVector<Operation *> sourceViewOps;
+  if (!CVPipeline::isSubviewFromGlobalMemory(viewOp, sourceViewOps)) {
+    LOG_DEBUG("Copy source is not from global memory");
+    return false;
+  }
+
+  // Step 2: Find the pattern: reinterpret_cast/alloc -> memref.copy ->
+  // to_tensor Get the reinterpret_cast (or alloc)
+  Operation *destOp = nullptr;
+  Value dest = copyOp.getTarget();
+
+  // Check if dest is alloc
+  if (auto allocOp = dest.getDefiningOp<memref::AllocOp>()) {
+    destOp = allocOp;
+  } else {
+    LOG_DEBUG("Copy dest is not from alloc");
+    return false;
+  }
+
+  // Step 3: Find the to_tensor op
+  bufferization::ToTensorOp toTensorOp = nullptr;
+  for (auto *user : destOp->getUsers()) {
+    auto toTensor = dyn_cast<bufferization::ToTensorOp>(user);
+    if (toTensor) {
+      toTensorOp = toTensor;
+      break;
+    }
+  }
+
+  if (!toTensorOp) {
+    LOG_DEBUG("No to_tensor op found after copy");
+    return false;
+  }
+
+  // Collect matched ops: viewOp (source), destOp, copyOp, toTensor
+  matchedOps.push_back(viewOp);
+  matchedOps.push_back(destOp);
+  matchedOps.push_back(copyOp);
+  matchedOps.push_back(toTensorOp);
+
+  return true;
+}
+
+static void collectAllDependencies(Operation *op, SetVector<Operation *> &deps,
+                                   int commonBlockId,
+                                   CVPipeline::ComputeBlockIdManager &bm) {
+  if (deps.contains(op)) {
+    return;
+  }
+
+  int blockId = bm.getBlockIdByOp(op);
+  if (blockId == -1 || blockId != commonBlockId) {
+    return;
+  }
+
+  deps.insert(op);
+  for (auto operand : op->getOperands()) {
+    if (auto definingOp = operand.getDefiningOp()) {
+      collectAllDependencies(definingOp, deps, commonBlockId, bm);
+    }
+  }
+}
+
+void MoveLoadIntoUserPass::runOnOperation() {
+  ModuleOp module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
+  auto &aliasAnalysis = getAnalysis<AliasAnalysis>();
+  CVPipeline::MemoryDependenceGraph memGraph(module, aliasAnalysis);
+  auto bm = CVPipeline::ComputeBlockIdManager(module);
+
+  SmallVector<LoadPatternInfo> validPatterns;
+
+  LOG_DEBUG("before MogeLoadIntoUserPass ....\n" << *module);
+
+  module.walk([&](memref::CopyOp copyOp) {
+    // Step 1: Check if source is from global memory
+    LOG_DEBUG("Check copyOp = " << copyOp);
+    Value source = copyOp.getSource();
+    auto viewOp = source.getDefiningOp<ViewLikeOpInterface>();
+    if (!viewOp) {
+      return;
+    }
+
+    SetVector<Operation *> viewOps;
+    if (!CVPipeline::isSubviewFromGlobalMemory(viewOp, viewOps)) {
+      return;
+    }
+
+    // Step 2: Match the load pattern and collect 4 ops
+    SmallVector<Operation *> matchedOps;
+    if (!matchLoadPattern(copyOp, matchedOps)) {
+      return;
+    }
+
+    // Step 3: Check if all 4 ops are in the same block
+    if (!checkAllOpsInSameBlock(matchedOps, bm)) {
+      return;
+    }
+    LOG_DEBUG("valid pattern.");
+    // Store the valid pattern
+    validPatterns.push_back({matchedOps, bm.getBlockIdByOp(copyOp)});
+  });
+
+  // Process each valid pattern
+  for (auto &pattern : validPatterns) {
+    auto &matchedOps = pattern.matchedOps;
+    int commonBlockId = pattern.commonBlockId;
+
+    // Find first user of to_tensor
+    auto toTensorOp = cast<bufferization::ToTensorOp>(matchedOps.back());
+    auto firstUserOpt = getFirstUser(toTensorOp, bm, matchedOps);
+    if (!firstUserOpt) {
+      continue;
+    }
+
+    Operation *firstUser = firstUserOpt.value();
+    int targetBlockId = bm.getBlockIdByOp(firstUser);
+
+    SetVector<Operation *> opsToMove;
+    for (auto *op : matchedOps) {
+      collectAllDependencies(op, opsToMove, commonBlockId, bm);
+    }
+    CVPipeline::cloneScalarOpsForCrossBlockUses(bm, opsToMove,
+                                                bm.getBlockIdByOp(firstUser));
+    // Check for cycles before moving
+    SmallVector<Operation *> opsVec(opsToMove.begin(), opsToMove.end());
+    if (CVPipeline::willCreateCycle(opsVec, memGraph, targetBlockId, bm)) {
+      LOG_DEBUG("Moving would create a cycle, skip(" << commonBlockId << ")");
+      continue;
+    }
+
+    // Update block_id for all ops
+    for (auto *op : opsToMove) {
+      bm.updateBlockId(op, targetBlockId);
+    }
+
+    LOG_DEBUG("Successfully moved ops to block " << targetBlockId);
+  }
+}
+
+std::unique_ptr<OperationPass<ModuleOp>> createMoveLoadIntoUserPass() {
+  return std::make_unique<MoveLoadIntoUserPass>();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MoveLoadIntoUserPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MoveLoadIntoUserPass.cpp
@@ -63,12 +63,14 @@ private:
   struct LoadPatternInfo {
     SmallVector<Operation *> matchedOps;
     int commonBlockId;
+    bufferization::ToTensorOp toTensorOp;
+    memref::CopyOp copyOp;
+    memref::AllocOp allocOp; // destination
   };
 
-  bool matchLoadPattern(memref::CopyOp copyOp,
-                        SmallVector<Operation *> &matchedOps);
+  bool matchLoadPattern(LoadPatternInfo &info);
 
-  bool checkAllOpsInSameBlock(ArrayRef<Operation *> ops,
+  bool checkAllOpsInSameBlock(LoadPatternInfo &info,
                               CVPipeline::ComputeBlockIdManager &bm);
 };
 
@@ -135,13 +137,13 @@ getFirstUser(bufferization::ToTensorOp toTensorOp,
 }
 
 bool MoveLoadIntoUserPass::checkAllOpsInSameBlock(
-    ArrayRef<Operation *> ops, CVPipeline::ComputeBlockIdManager &bm) {
-  if (ops.empty()) {
+    LoadPatternInfo &info, CVPipeline::ComputeBlockIdManager &bm) {
+  if (info.matchedOps.empty()) {
     return false;
   }
 
   int commonBlockId = -1;
-  for (auto *op : ops) {
+  for (auto *op : info.matchedOps) {
     int blockId = bm.getBlockIdByOp(op);
     if (blockId == -1) {
       LOG_DEBUG("Op has no block_id");
@@ -158,55 +160,45 @@ bool MoveLoadIntoUserPass::checkAllOpsInSameBlock(
   return true;
 }
 
-bool MoveLoadIntoUserPass::matchLoadPattern(
-    memref::CopyOp copyOp, SmallVector<Operation *> &matchedOps) {
+bool MoveLoadIntoUserPass::matchLoadPattern(LoadPatternInfo &info) {
   // Step 1: Check if source is from global memory
-  Value source = copyOp.getSource();
-  auto viewOp = source.getDefiningOp<ViewLikeOpInterface>();
-  if (!viewOp) {
-    LOG_DEBUG("Copy source is not from ViewLikeOpInterface");
-    return false;
-  }
-
   SetVector<Operation *> sourceViewOps;
-  if (!CVPipeline::isSubviewFromGlobalMemory(viewOp, sourceViewOps)) {
+  if (!CVPipeline::collectViewOpsAndCheckGlobalMemory(info.copyOp.getSource(),
+                                                      sourceViewOps)) {
     LOG_DEBUG("Copy source is not from global memory");
     return false;
   }
 
   // Step 2: Find the pattern: reinterpret_cast/alloc -> memref.copy ->
   // to_tensor Get the reinterpret_cast (or alloc)
-  Operation *destOp = nullptr;
-  Value dest = copyOp.getTarget();
+  Value dest = info.copyOp.getTarget();
 
   // Check if dest is alloc
   if (auto allocOp = dest.getDefiningOp<memref::AllocOp>()) {
-    destOp = allocOp;
+    info.allocOp = allocOp;
   } else {
     LOG_DEBUG("Copy dest is not from alloc");
     return false;
   }
 
   // Step 3: Find the to_tensor op
-  bufferization::ToTensorOp toTensorOp = nullptr;
-  for (auto *user : destOp->getUsers()) {
+  for (auto *user : info.allocOp->getUsers()) {
     auto toTensor = dyn_cast<bufferization::ToTensorOp>(user);
     if (toTensor) {
-      toTensorOp = toTensor;
+      info.toTensorOp = toTensor;
       break;
     }
   }
 
-  if (!toTensorOp) {
+  if (!info.toTensorOp) {
     LOG_DEBUG("No to_tensor op found after copy");
     return false;
   }
 
-  // Collect matched ops: viewOp (source), destOp, copyOp, toTensor
-  matchedOps.push_back(viewOp);
-  matchedOps.push_back(destOp);
-  matchedOps.push_back(copyOp);
-  matchedOps.push_back(toTensorOp);
+  // Collect matched ops: destOp, copyOp, toTensor
+  info.matchedOps.push_back(info.allocOp);
+  info.matchedOps.push_back(info.copyOp);
+  info.matchedOps.push_back(info.toTensorOp);
 
   return true;
 }
@@ -247,32 +239,20 @@ void MoveLoadIntoUserPass::runOnOperation() {
   LOG_DEBUG("before MogeLoadIntoUserPass ....\n" << *module);
 
   module.walk([&](memref::CopyOp copyOp) {
-    // Step 1: Check if source is from global memory
-    LOG_DEBUG("Check copyOp = " << copyOp);
-    Value source = copyOp.getSource();
-    auto viewOp = source.getDefiningOp<ViewLikeOpInterface>();
-    if (!viewOp) {
+    // Step 1: Match the load pattern and collect 4 ops
+    LoadPatternInfo info;
+    info.copyOp = copyOp;
+    if (!matchLoadPattern(info)) {
       return;
     }
 
-    SetVector<Operation *> viewOps;
-    if (!CVPipeline::isSubviewFromGlobalMemory(viewOp, viewOps)) {
-      return;
-    }
-
-    // Step 2: Match the load pattern and collect 4 ops
-    SmallVector<Operation *> matchedOps;
-    if (!matchLoadPattern(copyOp, matchedOps)) {
-      return;
-    }
-
-    // Step 3: Check if all 4 ops are in the same block
-    if (!checkAllOpsInSameBlock(matchedOps, bm)) {
+    // Step 2: Check if all 3 ops are in the same block
+    if (!checkAllOpsInSameBlock(info, bm)) {
       return;
     }
     LOG_DEBUG("valid pattern.");
     // Store the valid pattern
-    validPatterns.push_back({matchedOps, bm.getBlockIdByOp(copyOp)});
+    validPatterns.push_back(info);
   });
 
   // Process each valid pattern
@@ -281,8 +261,7 @@ void MoveLoadIntoUserPass::runOnOperation() {
     int commonBlockId = pattern.commonBlockId;
 
     // Find first user of to_tensor
-    auto toTensorOp = cast<bufferization::ToTensorOp>(matchedOps.back());
-    auto firstUserOpt = getFirstUser(toTensorOp, bm, matchedOps);
+    auto firstUserOpt = getFirstUser(pattern.toTensorOp, bm, matchedOps);
     if (!firstUserOpt) {
       continue;
     }
@@ -297,8 +276,8 @@ void MoveLoadIntoUserPass::runOnOperation() {
     CVPipeline::cloneScalarOpsForCrossBlockUses(bm, opsToMove,
                                                 bm.getBlockIdByOp(firstUser));
     // Check for cycles before moving
-    SmallVector<Operation *> opsVec(opsToMove.begin(), opsToMove.end());
-    if (CVPipeline::willCreateCycle(opsVec, memGraph, targetBlockId, bm)) {
+    if (CVPipeline::willCreateCycle(opsToMove.getArrayRef(), memGraph,
+                                    targetBlockId, bm)) {
       LOG_DEBUG("Moving would create a cycle, skip(" << commonBlockId << ")");
       continue;
     }

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/PosMaskPatternPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/PosMaskPatternPass.cpp
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+#include <optional>
+
+static constexpr const char *DEBUG_TYPE = "pos-mask-pattern-opt";
+#define LOG_DEBUG(...)                                                         \
+  LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__)
+
+using namespace mlir;
+
+namespace mlir {
+namespace triton {
+
+class PosMaskPatternPass
+    : public PassWrapper<PosMaskPatternPass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PosMaskPatternPass)
+
+  PosMaskPatternPass() = default;
+  void runOnOperation() override;
+
+  llvm::StringRef getArgument() const final { return "pos-mask-pattern-opt"; }
+  llvm::StringRef getDescription() const final {
+    return "Optimize pos mask pattern (broadcast+cmpi+extui) by moving ops "
+           "to user's block when safe";
+  }
+};
+
+} // namespace triton
+} // namespace mlir
+
+namespace {
+
+struct PosPattern {
+  linalg::BroadcastOp broadcastOp;
+  arith::CmpIOp eqcmpOp;
+  arith::CmpIOp slecmpOp;
+  arith::ExtUIOp eqextOp;
+  arith::ExtUIOp sleextOp;
+
+  llvm::SmallVector<Operation *> getAllOps() const {
+    return {broadcastOp, eqcmpOp, slecmpOp, eqextOp, sleextOp};
+  }
+};
+
+static bool isPosBroadcast(linalg::BroadcastOp broadcastOp) {
+  if (CVPipeline::getOpCoreType(broadcastOp.getOperation()) !=
+      CVPipeline::CoreType::VECTOR_ONLY) {
+    return false;
+  }
+  return true;
+}
+
+static std::optional<PosPattern>
+collectPosPattern(linalg::BroadcastOp broadcastOp,
+                  CVPipeline::ComputeBlockIdManager &bm) {
+  PosPattern pattern;
+  if (llvm::range_size(broadcastOp.getResult().getUsers()) != 2) {
+    return std::nullopt;
+  }
+  if (any_of(broadcastOp->getUsers(),
+             [&](Operation *user) { return !isa<arith::CmpIOp>(user); })) {
+    return std::nullopt;
+  }
+
+  arith::CmpIOp eqcmpOp = nullptr;
+  arith::CmpIOp slecmpOp = nullptr;
+
+  for (Operation *user : broadcastOp->getUsers()) {
+    auto cmpOp = dyn_cast<arith::CmpIOp>(user);
+    auto predicate = cmpOp.getPredicate();
+    if (predicate == arith::CmpIPredicate::eq) {
+      if (eqcmpOp) {
+        return std::nullopt;
+      }
+      eqcmpOp = cmpOp;
+    } else if (predicate == arith::CmpIPredicate::sle) {
+      if (slecmpOp) {
+        return std::nullopt;
+      }
+      slecmpOp = cmpOp;
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  if (!eqcmpOp || !slecmpOp) {
+    return std::nullopt;
+  }
+  if (!eqcmpOp.getResult().hasOneUse() || !slecmpOp.getResult().hasOneUse()) {
+    return std::nullopt;
+  }
+
+  arith::ExtUIOp eqextOp =
+      dyn_cast<arith::ExtUIOp>(*eqcmpOp->getUsers().begin());
+  arith::ExtUIOp sleextOp =
+      dyn_cast<arith::ExtUIOp>(*slecmpOp->getUsers().begin());
+  if (!eqextOp || !sleextOp) {
+    return std::nullopt;
+  }
+
+  pattern.eqextOp = eqextOp;
+  pattern.sleextOp = sleextOp;
+  pattern.eqcmpOp = eqcmpOp;
+  pattern.slecmpOp = slecmpOp;
+  pattern.broadcastOp = broadcastOp;
+
+  auto broadcastBlockId = bm.getBlockIdByOp(broadcastOp);
+  auto broadcastBlock = broadcastOp->getBlock();
+  if (!all_of(pattern.getAllOps(), [&](Operation *op) {
+        return bm.getBlockIdByOp(op) == broadcastBlockId;
+      })) {
+    return std::nullopt;
+  }
+  if (!all_of(pattern.getAllOps(), [&](Operation *op) {
+        return op->getBlock() == broadcastBlock;
+      })) {
+    return std::nullopt;
+  }
+
+  return pattern;
+}
+
+static std::optional<int>
+findTargetBlock(const PosPattern &pattern,
+                CVPipeline::ComputeBlockIdManager &bm) {
+  llvm::SmallVector<Operation *> users;
+
+  for (Operation *user : pattern.eqextOp->getUsers()) {
+    if (user->getBlock() != pattern.broadcastOp->getBlock()) {
+      continue;
+    }
+    users.push_back(user);
+  }
+
+  for (Operation *user : pattern.sleextOp->getUsers()) {
+    if (user->getBlock() != pattern.broadcastOp->getBlock()) {
+      continue;
+    }
+    users.push_back(user);
+  }
+  if (users.size() == 0) {
+    return std::nullopt;
+  }
+
+  int targetBlockId = bm.getBlockIdByOp(users[0]);
+  if (targetBlockId == -1) {
+    return std::nullopt;
+  }
+  for (Operation *user : users) {
+    if (bm.getBlockIdByOp(user) != targetBlockId) {
+      return std::nullopt;
+    }
+  }
+
+  return targetBlockId;
+}
+
+} // namespace
+
+namespace mlir {
+namespace triton {
+
+void PosMaskPatternPass::runOnOperation() {
+  ModuleOp moduleOp = getOperation();
+  LOG_DEBUG("Input mlir:" << moduleOp);
+  auto &aa = getAnalysis<AliasAnalysis>();
+  CVPipeline::MemoryDependenceGraph memGraph(moduleOp, aa);
+  CVPipeline::ComputeBlockIdManager bm(moduleOp);
+
+  llvm::SmallVector<linalg::BroadcastOp> broadcasts;
+  moduleOp.walk([&](linalg::BroadcastOp op) {
+    if (isPosBroadcast(op)) {
+      broadcasts.push_back(op);
+    }
+  });
+
+  for (linalg::BroadcastOp broadcastOp : broadcasts) {
+    auto patternOpt = collectPosPattern(broadcastOp, bm);
+    if (!patternOpt.has_value()) {
+      continue;
+    }
+    auto pattern = patternOpt.value();
+    std::optional<int> targetBlockId = findTargetBlock(pattern, bm);
+    if (!targetBlockId) {
+      LOG_DEBUG("No common target block_id, skip\n");
+      continue;
+    }
+
+    int broadcastBlockId = bm.getBlockIdByOp(pattern.broadcastOp);
+    if (broadcastBlockId == targetBlockId) {
+      LOG_DEBUG("Already in same block, skip\n");
+      continue;
+    }
+
+    llvm::SmallVector<Operation *> allOps = pattern.getAllOps();
+    if (CVPipeline::willCreateCycle(allOps, memGraph, *targetBlockId, bm)) {
+      LOG_DEBUG("Would create cycle, skip\n");
+      continue;
+    }
+
+    LOG_DEBUG("Moving pos pattern ops to block " << *targetBlockId << "\n");
+    for (Operation *op : allOps) {
+      bm.updateBlockId(op, *targetBlockId);
+    }
+  }
+}
+
+std::unique_ptr<OperationPass<ModuleOp>> createPosMaskPatternPass() {
+  return std::make_unique<PosMaskPatternPass>();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/SinkI1ProducersIntoUsersPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/SinkI1ProducersIntoUsersPass.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+static constexpr const char *DEBUG_TYPE = "sink-i1-producers-into-users";
+#define LOG_DEBUG(...)                                                         \
+  LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__)
+
+using namespace mlir;
+
+namespace mlir {
+namespace triton {
+
+class SinkI1ProducersIntoUsersPass
+    : public PassWrapper<SinkI1ProducersIntoUsersPass,
+                         OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SinkI1ProducersIntoUsersPass)
+
+  SinkI1ProducersIntoUsersPass() = default;
+  void runOnOperation() override;
+
+  llvm::StringRef getArgument() const final {
+    return "sink-i1-producers-into-users";
+  }
+  llvm::StringRef getDescription() const final {
+    return "Sink i1-producing ops next to each of their i1 uses";
+  }
+};
+
+} // namespace triton
+} // namespace mlir
+
+namespace {
+
+static bool isI1Producer(Operation *op) {
+  for (auto result : op->getResults()) {
+    if (auto tensorType = dyn_cast<mlir::TensorType>(result.getType())) {
+      mlir::Type elemType = tensorType.getElementType();
+      if (elemType.isInteger(1)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+static bool isPureAndRegionless(Operation *op) {
+  if (op->hasTrait<OpTrait::HasRecursiveMemoryEffects>())
+    return false;
+  if (auto iface = dyn_cast<MemoryEffectOpInterface>(op)) {
+    SmallVector<MemoryEffects::EffectInstance> effects;
+    iface.getEffects(effects);
+    if (!effects.empty())
+      return false;
+  }
+  return true;
+}
+
+} // namespace
+
+namespace mlir {
+namespace triton {
+
+void SinkI1ProducersIntoUsersPass::runOnOperation() {
+  ModuleOp moduleOp = getOperation();
+  auto &aa = getAnalysis<AliasAnalysis>();
+  CVPipeline::MemoryDependenceGraph memGraph(moduleOp, aa);
+  CVPipeline::ComputeBlockIdManager bm(moduleOp);
+  LOG_DEBUG("== SinkI1ProducersIntoUsers Pass Start ==\n");
+  LOG_DEBUG(moduleOp);
+
+  SmallVector<Operation *> producers;
+  // find single-result and regionless op with i1 tensor result-type
+  moduleOp.walk([&](Operation *op) {
+    if (isa<scf::SCFDialect>(op->getDialect())) {
+      LOG_DEBUG("skip scf dialect op: " << op << "\n");
+    }
+    // todo: adapt sinki1 pass with multi-result op
+    else if (op->getNumResults() > 1) {
+      LOG_DEBUG("skip multi-result op: "
+                << op << " with " << op->getNumResults() << " results\n");
+    } else if (isI1Producer(op) && isPureAndRegionless(op)) {
+      LOG_DEBUG("found i1 producer: " << op << "\n");
+      producers.push_back(op);
+    }
+  });
+
+  for (Operation *p : producers) {
+
+    for (OpOperand &use : p->getUses()) {
+      Operation *consumer = use.getOwner();
+
+      if (bm.isSameBlock(p, consumer)) {
+        continue;
+      }
+
+      // clone producer op to consumer block and adapt use
+      int consumerBlockId = bm.getBlockIdByOp(consumer);
+      Operation *cloned = p->clone();
+      consumer->getBlock()->push_back(cloned);
+      cloned->moveBefore(consumer);
+      use.set(cloned->getResult(0));
+      bm.updateBlockId(cloned, consumerBlockId);
+    }
+
+    // erase producer with no user left
+    if (p->use_empty())
+      p->erase();
+  }
+  LOG_DEBUG("== SinkI1ProducersIntoUsers Pass Complete ==\n");
+}
+
+std::unique_ptr<OperationPass<ModuleOp>> createSinkI1ProducersIntoUsersPass() {
+  return std::make_unique<SinkI1ProducersIntoUsersPass>();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/SinkI1ProducersIntoUsersPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/SinkI1ProducersIntoUsersPass.cpp
@@ -25,13 +25,18 @@
 #include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Value.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
 
 static constexpr const char *DEBUG_TYPE = "sink-i1-producers-into-users";
 #define LOG_DEBUG(...)                                                         \
@@ -64,7 +69,13 @@ public:
 
 namespace {
 
-static bool isI1Producer(Operation *op) {
+static bool isValidI1Producer(Operation *op) {
+  if (isa<scf::SCFDialect>(op->getDialect())) {
+    return false;
+  }
+  if (op->getNumResults() > 1) {
+    return false;
+  }
   for (auto result : op->getResults()) {
     if (auto tensorType = dyn_cast<mlir::TensorType>(result.getType())) {
       mlir::Type elemType = tensorType.getElementType();
@@ -101,33 +112,81 @@ void SinkI1ProducersIntoUsersPass::runOnOperation() {
   SmallVector<Operation *> producers;
   // find single-result and regionless op with i1 tensor result-type
   moduleOp.walk([&](Operation *op) {
-    if (isI1Producer(op) && isPureAndRegionless(op)) {
+    if (isValidI1Producer(op) && isPureAndRegionless(op)) {
       LOG_DEBUG("found i1 producer: " << *op << "\n");
-      producers.push_back(op);
+      if (bm.getBlockIdByOp(op) != -1) {
+        producers.push_back(op);
+      }
     }
   });
 
-  for (Operation *p : producers) {
-    DenseSet<int> seenBlockIds;
+  for (Operation *p : llvm::reverse(producers)) {
+    SetVector<Operation *> consumers;
     for (OpOperand &use : p->getUses()) {
       Operation *consumer = use.getOwner();
-      if (bm.isSameBlock(p, consumer)) {
+      auto consumerInblock =
+          CVPipeline::getAncestorInBlock(consumer, p->getBlock());
+      if (!consumerInblock) {
         continue;
       }
-
-      // clone producer op to consumer block and adapt use
-      int consumerBlockId = bm.getBlockIdByOp(consumer);
-      if (!seenBlockIds.insert(consumerBlockId).second) {
-        continue;
+      consumers.insert(consumerInblock);
+    }
+    if (consumers.empty()) {
+      continue;
+    }
+    LOG_DEBUG("Producer: " << *p << "have " << consumers.size() << " consumers.\n");
+    LLVM_DEBUG(
+      for(auto c: consumers){
+        LOG_DEBUG("consumer: "<< *c << "\n");
       }
-      Operation *cloned = OpBuilder(consumer).clone(*p);
-      use.set(cloned->getResult(0));
-      bm.updateBlockId(cloned, consumerBlockId);
+    );
+    DenseSet<int> seenBlockIds;
+    DenseMap<int, Operation*> blockId2Producer;
+    auto orderedConsumuers = mlir::topologicalSort(consumers);
+    // 1. Move into first consumer blockId
+    int consumerBlockId = bm.getBlockIdByOp(orderedConsumuers[0]);
+    if (consumerBlockId == -1) {
+      // if i1 break by one control op, couldn't change. //FIXME: wait for
+      // multi-region...
+      LOG_DEBUG("First consumer's blockid is -1.\n");
+      seenBlockIds.insert(bm.getBlockIdByOp(p));
+      blockId2Producer.insert({bm.getBlockIdByOp(p), p});
+    } else if (bm.isSameBlock(p, orderedConsumuers[0])) {
+      LOG_DEBUG("producer and consumer has same blockId.\n");
+      seenBlockIds.insert(consumerBlockId);
+      blockId2Producer.insert({consumerBlockId, p});
+    } else {
+      p->moveBefore(orderedConsumuers[0]);
+      LOG_DEBUG("move producer " << *p << " to " << consumerBlockId << "\n");
+      bm.updateBlockId(p, consumerBlockId);
+      blockId2Producer.insert({consumerBlockId, p});
     }
 
-    // erase producer with no user left
-    if (p->use_empty())
-      p->erase();
+    // 2. if there are other consumer, then clone producer.
+    for (auto consumerInblock : orderedConsumuers) {
+      int consumerBlockId = bm.getBlockIdByOp(consumerInblock);
+      if (!seenBlockIds.insert(consumerBlockId).second) {
+        auto producer = blockId2Producer[consumerBlockId];
+        for (auto info : llvm::enumerate(p->getResults())) {
+          auto id = info.index();
+          info.value().replaceUsesWithIf(
+              producer->getResult(id),
+              [&](OpOperand &use) { return use.getOwner() == consumerInblock; });
+        }
+        continue;
+      }
+      // Create one producer for now blockid.
+      LOG_DEBUG("clone producer " << *p << " to " << consumerBlockId << "\n");
+      auto cloned = OpBuilder(consumerInblock).clone(*p);
+      blockId2Producer.insert({consumerBlockId, cloned});
+      bm.updateBlockId(cloned, consumerBlockId);
+      for (auto info : llvm::enumerate(p->getResults())) {
+        auto id = info.index();
+        info.value().replaceUsesWithIf(
+            cloned->getResult(id),
+            [&](OpOperand &use) { return use.getOwner() == consumerInblock; });
+      }
+    }
   }
 }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/SinkI1ProducersIntoUsersPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/SinkI1ProducersIntoUsersPass.cpp
@@ -134,14 +134,12 @@ void SinkI1ProducersIntoUsersPass::runOnOperation() {
     if (consumers.empty()) {
       continue;
     }
-    LOG_DEBUG("Producer: " << *p << "have " << consumers.size() << " consumers.\n");
+    LOG_DEBUG("Producer: " << *p << "have " << consumers.size()
+                           << " consumers.\n");
     LLVM_DEBUG(
-      for(auto c: consumers){
-        LOG_DEBUG("consumer: "<< *c << "\n");
-      }
-    );
+        for (auto c : consumers) { LOG_DEBUG("consumer: " << *c << "\n"); });
     DenseSet<int> seenBlockIds;
-    DenseMap<int, Operation*> blockId2Producer;
+    DenseMap<int, Operation *> blockId2Producer;
     auto orderedConsumuers = mlir::topologicalSort(consumers);
     // 1. Move into first consumer blockId
     int consumerBlockId = bm.getBlockIdByOp(orderedConsumuers[0]);
@@ -170,8 +168,9 @@ void SinkI1ProducersIntoUsersPass::runOnOperation() {
         for (auto info : llvm::enumerate(p->getResults())) {
           auto id = info.index();
           info.value().replaceUsesWithIf(
-              producer->getResult(id),
-              [&](OpOperand &use) { return use.getOwner() == consumerInblock; });
+              producer->getResult(id), [&](OpOperand &use) {
+                return use.getOwner() == consumerInblock;
+              });
         }
         continue;
       }

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/SinkI1ProducersIntoUsersPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/SinkI1ProducersIntoUsersPass.cpp
@@ -101,15 +101,8 @@ void SinkI1ProducersIntoUsersPass::runOnOperation() {
   SmallVector<Operation *> producers;
   // find single-result and regionless op with i1 tensor result-type
   moduleOp.walk([&](Operation *op) {
-    if (isa<scf::SCFDialect>(op->getDialect())) {
-      LOG_DEBUG("skip scf dialect op: " << op << "\n");
-    }
-    // todo: adapt sinki1 pass with multi-result op
-    else if (op->getNumResults() > 1) {
-      LOG_DEBUG("skip multi-result op: "
-                << op << " with " << op->getNumResults() << " results\n");
-    } else if (isI1Producer(op) && isPureAndRegionless(op)) {
-      LOG_DEBUG("found i1 producer: " << op << "\n");
+    if (isI1Producer(op) && isPureAndRegionless(op)) {
+      LOG_DEBUG("found i1 producer: " << *op << "\n");
       producers.push_back(op);
     }
   });

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/SinkI1ProducersIntoUsersPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/SinkI1ProducersIntoUsersPass.cpp
@@ -20,13 +20,11 @@
  * THE SOFTWARE.
  */
 
-#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
 #include "DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
 #include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
-#include "mlir/Analysis/AliasAnalysis.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -97,10 +95,7 @@ namespace triton {
 
 void SinkI1ProducersIntoUsersPass::runOnOperation() {
   ModuleOp moduleOp = getOperation();
-  auto &aa = getAnalysis<AliasAnalysis>();
-  CVPipeline::MemoryDependenceGraph memGraph(moduleOp, aa);
   CVPipeline::ComputeBlockIdManager bm(moduleOp);
-  LOG_DEBUG("== SinkI1ProducersIntoUsers Pass Start ==\n");
   LOG_DEBUG(moduleOp);
 
   SmallVector<Operation *> producers;
@@ -120,19 +115,19 @@ void SinkI1ProducersIntoUsersPass::runOnOperation() {
   });
 
   for (Operation *p : producers) {
-
+    DenseSet<int> seenBlockIds;
     for (OpOperand &use : p->getUses()) {
       Operation *consumer = use.getOwner();
-
       if (bm.isSameBlock(p, consumer)) {
         continue;
       }
 
       // clone producer op to consumer block and adapt use
       int consumerBlockId = bm.getBlockIdByOp(consumer);
-      Operation *cloned = p->clone();
-      consumer->getBlock()->push_back(cloned);
-      cloned->moveBefore(consumer);
+      if (!seenBlockIds.insert(consumerBlockId).second) {
+        continue;
+      }
+      Operation *cloned = OpBuilder(consumer).clone(*p);
       use.set(cloned->getResult(0));
       bm.updateBlockId(cloned, consumerBlockId);
     }
@@ -141,7 +136,6 @@ void SinkI1ProducersIntoUsersPass::runOnOperation() {
     if (p->use_empty())
       p->erase();
   }
-  LOG_DEBUG("== SinkI1ProducersIntoUsers Pass Complete ==\n");
 }
 
 std::unique_ptr<OperationPass<ModuleOp>> createSinkI1ProducersIntoUsersPass() {

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UBUsageOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UBUsageOptPass.cpp
@@ -66,14 +66,13 @@ public:
   llvm::StringRef getArgument() const final { return "ub-usage-opt"; }
 
 private:
-  const int MAX_EDGE_SIZE = (1 << 30);
-  const int BLOCK_SMALL_SIZE = 3;
-  int getValueSizeInBytes(Value value);
+  const int64_t MAX_EDGE_SIZE = (1 << 30);
+  int64_t getValueSizeInBytes(Value value);
   void buildUBUsageGraph(Block *block, DenseMap<Operation *, int> &op2nodeId,
                          DenseMap<int, Operation *> &nodeId2op,
                          SmallVector<SmallVector<int>> &linkOut,
                          SmallVector<SmallVector<int>> &linkIn,
-                         SmallVector<int> &linkSize,
+                         SmallVector<int64_t> &linkSize,
                          SmallVector<int> &linkStart, SmallVector<int> &linkEnd,
                          SmallVector<int> &nodeBlockId,
                          SmallVector<int> &nodeCoreType,
@@ -84,26 +83,20 @@ private:
       const SmallVector<SmallVector<int>> &needUbOpts,
       const SmallVector<SmallVector<int>> &linkOut,
       const SmallVector<SmallVector<int>> &linkIn,
-      const SmallVector<int> &linkSize, const SmallVector<int> &linkStart,
+      const SmallVector<int64_t> &linkSize, const SmallVector<int> &linkStart,
       const SmallVector<int> &linkEnd, const SmallVector<int> &nodeBlockId,
       const SmallVector<int> &nodeCoreType,
       DenseMap<int, Operation *> nodeId2op);
-  int sumIncomingLinkSize(int nodeId,
-                          const SmallVector<SmallVector<int>> &linkIn,
-                          const SmallVector<int> &linkSize,
-                          const SmallVector<int> &linkStart,
-                          const SmallVector<int> &linkEnd,
-                          const SmallVector<int> &nodeBlockId);
+  int64_t sumIncomingLinkSize(int nodeId,
+                              const SmallVector<SmallVector<int>> &linkIn,
+                              const SmallVector<int64_t> &linkSize,
+                              const SmallVector<int> &linkStart,
+                              const SmallVector<int> &linkEnd,
+                              const SmallVector<int> &nodeBlockId);
   llvm::LogicalResult
   UBUsageOptimization(Block *block,
                       const CVPipeline::MemoryDependenceGraph &memGraph,
                       CVPipeline::ComputeBlockIdManager &bm);
-  llvm::LogicalResult
-  optBroadcast(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph,
-               CVPipeline::ComputeBlockIdManager &bm);
-  llvm::LogicalResult
-  optSmallBlock(Block *block, const CVPipeline::MemoryDependenceGraph &memGraph,
-                CVPipeline::ComputeBlockIdManager &bm);
 };
 } // namespace triton
 } // namespace mlir
@@ -117,7 +110,7 @@ private:
    not be partitioned here.
     3. Isndex/Other: Set to 0, indicating that it does not occupy any UB.
 */
-int UBUsageOptPass::getValueSizeInBytes(Value value) {
+int64_t UBUsageOptPass::getValueSizeInBytes(Value value) {
   Type type = value.getType();
   auto getElemBytes = [](Type elemType) -> int64_t {
     if (elemType.isIntOrFloat()) {
@@ -138,8 +131,8 @@ int UBUsageOptPass::getValueSizeInBytes(Value value) {
       }
       numElements *= dim;
     }
-    return static_cast<int>(std::max<int64_t>(
-        1, numElements * getElemBytes(rankedTensorType.getElementType())));
+    return std::max<int64_t>(
+        1, numElements * getElemBytes(rankedTensorType.getElementType()));
   }
   // Memref
   if (auto memRefType = dyn_cast<MemRefType>(type)) {
@@ -147,9 +140,8 @@ int UBUsageOptPass::getValueSizeInBytes(Value value) {
   }
   // Vector
   if (auto vectorType = dyn_cast<VectorType>(type)) {
-    return static_cast<int>(
-        std::max<int64_t>(1, vectorType.getNumElements() *
-                                 getElemBytes(vectorType.getElementType())));
+    return std::max<int64_t>(1, vectorType.getNumElements() *
+                                    getElemBytes(vectorType.getElementType()));
   }
   // Index
   if (auto idxTy = dyn_cast<IndexType>(value.getType())) {
@@ -162,7 +154,7 @@ void UBUsageOptPass::buildUBUsageGraph(
     Block *block, DenseMap<Operation *, int> &op2nodeId,
     DenseMap<int, Operation *> &nodeId2op,
     SmallVector<SmallVector<int>> &linkOut,
-    SmallVector<SmallVector<int>> &linkIn, SmallVector<int> &linkSize,
+    SmallVector<SmallVector<int>> &linkIn, SmallVector<int64_t> &linkSize,
     SmallVector<int> &linkStart, SmallVector<int> &linkEnd,
     SmallVector<int> &nodeBlockId, SmallVector<int> &nodeCoreType,
     SmallVector<int> &nodeArgs,
@@ -203,7 +195,7 @@ void UBUsageOptPass::buildUBUsageGraph(
   };
 
   DenseMap<std::pair<int, int>, bool> visited;
-  auto addEdge = [&](int src, int dst, int sizeInBytes) {
+  auto addEdge = [&](int src, int dst, int64_t sizeInBytes) {
     if (visited.contains(std::make_pair(src, dst))) {
       return;
     }
@@ -214,7 +206,7 @@ void UBUsageOptPass::buildUBUsageGraph(
       LOG_DEBUG("op edge from " << *nodeId2op[src] << " to " << *nodeId2op[dst]
                                 << "\n");
     }
-    int edgeId = static_cast<int>(linkSize.size());
+    int edgeId = linkSize.size();
     linkSize.push_back(sizeInBytes);
     linkStart.push_back(src);
     linkEnd.push_back(dst);
@@ -286,7 +278,7 @@ void UBUsageOptPass::buildUBUsageGraph(
         }
 
         int srcNode = getOrCreateNodeId(srcInBlock);
-        int edgeSize = getValueSizeInBytes(operand);
+        int64_t edgeSize = getValueSizeInBytes(operand);
         if (fromArgEdge) {
           edgeSize *= 2;
         }
@@ -329,9 +321,10 @@ void UBUsageOptPass::buildUBUsageGraph(
   }
 }
 
-SmallVector<int> findDependency(int targetNdoe, int preNode,
-                                const SmallVector<SmallVector<int>> &linkIn,
-                                const SmallVector<int> &linkStart) {
+static SmallVector<int>
+findDependency(int targetNdoe, int preNode,
+               const SmallVector<SmallVector<int>> &linkIn,
+               const SmallVector<int> &linkStart) {
   SmallVector<int> dependNodes;
   DenseSet<int> visited;
   std::queue<int> queue;
@@ -355,12 +348,12 @@ SmallVector<int> findDependency(int targetNdoe, int preNode,
   return dependNodes;
 }
 
-bool isActiveEndNode(int srcNode, int endNode,
-                     const SmallVector<SmallVector<int>> &linkIn,
-                     const SmallVector<int> &linkStart,
-                     const SmallVector<int> &nodeBlockId,
-                     const SmallVector<int> &nodeCoreType,
-                     DenseMap<int, Operation *> nodeId2op) {
+static bool isActiveEndNode(int srcNode, int endNode,
+                            const SmallVector<SmallVector<int>> &linkIn,
+                            const SmallVector<int> &linkStart,
+                            const SmallVector<int> &nodeBlockId,
+                            const SmallVector<int> &nodeCoreType,
+                            DenseMap<int, Operation *> nodeId2op) {
   int nodeNum = static_cast<int>(nodeBlockId.size());
   if (nodeCoreType[endNode] != nodeCoreType[srcNode]) {
     return false;
@@ -382,7 +375,9 @@ bool isActiveEndNode(int srcNode, int endNode,
   for (int node : dependNodes) {
     if (nodeBlockId[node] != nodeBlockId[endNode] &&
         nodeBlockId[node] != nodeBlockId[srcNode]) {
-      return false;
+      if (linkIn[node].size() != 0) {
+        return false;
+      }
     }
   }
   return true;
@@ -426,11 +421,11 @@ static SmallVector<SmallVector<int>> collectNeedUbOpts(
   return needUbOpts;
 }
 
-int UBUsageOptPass::sumIncomingLinkSize(
+int64_t UBUsageOptPass::sumIncomingLinkSize(
     int nodeId, const SmallVector<SmallVector<int>> &linkIn,
-    const SmallVector<int> &linkSize, const SmallVector<int> &linkStart,
+    const SmallVector<int64_t> &linkSize, const SmallVector<int> &linkStart,
     const SmallVector<int> &linkEnd, const SmallVector<int> &nodeBlockId) {
-  int totalSize = 0;
+  int64_t totalSize = 0;
   for (int edgeId : linkIn[nodeId]) {
     if (nodeBlockId[linkStart[edgeId]] != nodeBlockId[linkEnd[edgeId]]) {
       if (linkSize[edgeId] == MAX_EDGE_SIZE) {
@@ -472,7 +467,7 @@ DenseMap<int, int> UBUsageOptPass::collectRecordChange(
     const SmallVector<SmallVector<int>> &needUbOpts,
     const SmallVector<SmallVector<int>> &linkOut,
     const SmallVector<SmallVector<int>> &linkIn,
-    const SmallVector<int> &linkSize, const SmallVector<int> &linkStart,
+    const SmallVector<int64_t> &linkSize, const SmallVector<int> &linkStart,
     const SmallVector<int> &linkEnd, const SmallVector<int> &nodeBlockId,
     const SmallVector<int> &nodeCoreType,
     DenseMap<int, Operation *> nodeId2op) {
@@ -496,11 +491,11 @@ DenseMap<int, int> UBUsageOptPass::collectRecordChange(
       LOG_DEBUG("activateSet Size:" << activateSet.size() << "\n");
 
       for (int activateNode : activateSet) {
-        int originUBSize = sumIncomingLinkSize(activateNode, linkIn, linkSize,
-                                               linkStart, linkEnd, nodeBlockId);
+        int64_t originUBSize = sumIncomingLinkSize(
+            activateNode, linkIn, linkSize, linkStart, linkEnd, nodeBlockId);
         LOG_DEBUG("activateNode:" << *nodeId2op.at(activateNode) << "\n");
         LOG_DEBUG("originUBSize:" << originUBSize << "\n");
-        int minUBSize = originUBSize;
+        int64_t minUBSize = originUBSize;
         SmallVector<int> chain;
         chain.push_back(activateNode);
         int bestCutPointIdx = -1;
@@ -518,7 +513,7 @@ DenseMap<int, int> UBUsageOptPass::collectRecordChange(
           chain.push_back(uniqueNextNode);
         }
         for (auto i = 0; i < chain.size(); i++) {
-          auto nowUBSize = 0;
+          auto nowUBSize = 0LL;
           LOG_DEBUG("now chain op = " << *nodeId2op.at(chain[i]) << "\n");
           for (auto cutEdgeId : linkOut[chain[i]]) {
             if (linkSize[cutEdgeId] == MAX_EDGE_SIZE) {
@@ -560,6 +555,11 @@ static void processOpsInblock(Operation *parentOp, int targetId,
   // blocks, we need to change the ops inside its blocks to targetId as well.
   int parentBlockId = bm.getBlockIdByOp(parentOp);
   if (parentBlockId == -1) {
+    return;
+  }
+  // LinalgDialect should have targetId only in prarent, the inner op shouldn't
+  // have blockId.
+  if (isa<linalg::LinalgDialect>(parentOp->getDialect())) {
     return;
   }
 
@@ -627,7 +627,7 @@ llvm::LogicalResult UBUsageOptPass::UBUsageOptimization(
   DenseMap<int, Operation *> nodeId2op;
   SmallVector<SmallVector<int>> linkOut;
   SmallVector<SmallVector<int>> linkIn;
-  SmallVector<int> linkSize;
+  SmallVector<int64_t> linkSize;
   SmallVector<int> linkStart;
   SmallVector<int> linkEnd;
   SmallVector<int> nodeBlockId;
@@ -663,130 +663,6 @@ llvm::LogicalResult UBUsageOptPass::UBUsageOptimization(
   return llvm::success();
 }
 
-llvm::LogicalResult
-UBUsageOptPass::optBroadcast(Block *block,
-                             const CVPipeline::MemoryDependenceGraph &memGraph,
-                             CVPipeline::ComputeBlockIdManager &bm) {
-  if (!isa<scf::ForOp>(block->getParentOp())) {
-    return llvm::success();
-  }
-
-  int errcnt = 0;
-  llvm::SmallVector<Operation *> broadcastOps;
-  for (Operation &op : *block) {
-    if (!isa<linalg::BroadcastOp>(op)) {
-      continue;
-    }
-    auto broadcastOp = dyn_cast<linalg::BroadcastOp>(&op);
-    if (CVPipeline::getOpCoreType(broadcastOp) !=
-        CVPipeline::CoreType::VECTOR_ONLY) {
-      continue;
-    }
-    if (!broadcastOp->hasOneUse()) {
-      continue;
-    }
-
-    llvm::SmallVector<std::pair<Operation *, int>> userBlockIds;
-    Operation *user = *broadcastOp->getUsers().begin();
-    Operation *userInBlock = CVPipeline::getAncestorInBlock(user, block);
-    if (!userInBlock || userInBlock->getBlock() != block) {
-      continue;
-    }
-    if (CVPipeline::getOpCoreType(userInBlock) !=
-        CVPipeline::CoreType::VECTOR_ONLY) {
-      continue;
-    }
-    int userBlockId = bm.getBlockIdByOp(userInBlock);
-    int broadcastBlockId = bm.getBlockIdByOp(broadcastOp);
-    if (userBlockId == broadcastBlockId) {
-      continue;
-    }
-    llvm::SmallVector<Operation *> willaddOps{broadcastOp};
-
-    if (!CVPipeline::willCreateCycle(willaddOps, memGraph, userBlockId, bm)) {
-      bm.updateBlockId(broadcastOp, userBlockId);
-    } else {
-      LOG_DEBUG("Moved" << *broadcastOp << " to blockId: " << userBlockId
-                        << " err!!!\n");
-      errcnt++;
-    }
-  }
-  if (errcnt > 0) {
-    LOG_DEBUG("Failed to move " << errcnt << " broadcast ops.\n");
-    return llvm::failure();
-  }
-  return llvm::success();
-}
-
-llvm::LogicalResult
-UBUsageOptPass::optSmallBlock(Block *block,
-                              const CVPipeline::MemoryDependenceGraph &memGraph,
-                              CVPipeline::ComputeBlockIdManager &bm) {
-  if (!isa<scf::ForOp>(block->getParentOp())) {
-    return llvm::success();
-  }
-
-  int errcnt = 0;
-  int maxBlockId = -1;
-  for (Operation &op : *block) {
-    int blockId = bm.getBlockIdByOp(&op);
-    if (blockId > maxBlockId) {
-      maxBlockId = blockId;
-    }
-  }
-
-  for (int blockId = 0; blockId <= maxBlockId; ++blockId) {
-    auto opsInSmallBlcok = bm.getOpsByBlockId(blockId);
-    if (opsInSmallBlcok.size() > BLOCK_SMALL_SIZE || opsInSmallBlcok.empty()) {
-      continue;
-    }
-
-    SetVector<int> candidateUserBlockIds;
-    for (Operation *op : opsInSmallBlcok) {
-      for (auto operand : op->getOperands()) {
-        auto defOp = operand.getDefiningOp();
-        if (!defOp) {
-          continue;
-        }
-        Operation *defInBlock = CVPipeline::getAncestorInBlock(defOp, block);
-        if (!defInBlock || defInBlock->getBlock() != block) {
-          continue;
-        }
-        if (CVPipeline::getOpCoreType(defInBlock) !=
-            CVPipeline::CoreType::VECTOR_ONLY) {
-          continue;
-        }
-
-        int candidateBlockId = bm.getBlockIdByOp(defInBlock);
-        if (candidateBlockId != blockId && candidateBlockId != -1) {
-          candidateUserBlockIds.insert(candidateBlockId);
-        }
-      }
-    }
-
-    if (candidateUserBlockIds.size() != 1) {
-      continue;
-    }
-    llvm::SmallVector<Operation *> willaddOps(opsInSmallBlcok.begin(),
-                                              opsInSmallBlcok.end());
-    if (willCreateCycle(willaddOps, memGraph, candidateUserBlockIds[0], bm)) {
-      for (Operation *op : opsInSmallBlcok) {
-        bm.updateBlockId(op, candidateUserBlockIds[0]);
-      }
-    } else {
-      LOG_DEBUG("Failed to merge small block "
-                << blockId << " to block " << candidateUserBlockIds[0] << "\n");
-      errcnt++;
-    }
-  }
-
-  if (errcnt > 0) {
-    LOG_DEBUG("Failed to merge " << errcnt << " small blocks.\n");
-    return llvm::failure();
-  }
-  return llvm::success();
-}
-
 void mlir::triton::UBUsageOptPass::runOnOperation() {
   LOG_DEBUG("--- Pass: UBUsageOpt ---\n");
 
@@ -799,11 +675,6 @@ void mlir::triton::UBUsageOptPass::runOnOperation() {
   auto &aliasAnalysis = getAnalysis<AliasAnalysis>();
   CVPipeline::MemoryDependenceGraph memDepGraph(module, aliasAnalysis);
   auto bm = CVPipeline::ComputeBlockIdManager(module);
-  bool isUBRefineOptEnabled = false;
-  auto attr = module->getAttr(CVPipeline::kEnableUbRefineOpt);
-  if (attr) {
-    isUBRefineOptEnabled = true;
-  }
 
   llvm::SmallVector<Block *> blocks;
   module.walk([&](Block *block) { blocks.push_back(block); });
@@ -811,15 +682,6 @@ void mlir::triton::UBUsageOptPass::runOnOperation() {
   for (Block *block : blocks) {
     if (UBUsageOptimization(block, memDepGraph, bm).failed()) {
       LOG_DEBUG("UB usage optimization failed in block.\n");
-    }
-    if (isUBRefineOptEnabled) {
-      if (optBroadcast(block, memDepGraph, bm).failed()) {
-        LOG_DEBUG("Broadcast check failed in block.\n");
-      }
-
-      if (optSmallBlock(block, memDepGraph, bm).failed()) {
-        LOG_DEBUG("Small block optimization failed in block.\n");
-      }
     }
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
@@ -30,6 +30,7 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "llvm/ADT/SmallVector.h"
@@ -197,6 +198,58 @@ static bool hasOtherOpsInIf(const FillInfo &info) {
   return opCount > 1;
 }
 
+/// Trace back along the view-like chain from \p copyOp's source and collect
+/// all ops. Only ops in the same Block as the copyOp are collected.
+static void traceViewChain(memref::CopyOp copyOp,
+                           SmallVectorImpl<Operation *> &result) {
+  for (Value v = copyOp.getSource(); auto *defOp = v.getDefiningOp();) {
+    if (defOp->getBlock() != copyOp->getBlock())
+      break;
+    if (auto viewOp = dyn_cast<ViewLikeOpInterface>(defOp))
+      result.push_back(viewOp), v = viewOp.getViewSource();
+    else if (auto sliceOp = dyn_cast<tensor::ExtractSliceOp>(defOp))
+      result.push_back(sliceOp), v = sliceOp.getSource();
+    else
+      break;
+  }
+}
+
+/**
+ * @brief Collect source view chain ops from memref.copy's source operand
+ *
+ * For each memref.copy found by penetrating ViewLike direct users (subview of
+ * alloc), trace back the copy's source operand along the ViewLikeOpInterface /
+ * tensor.extract_slice chain (e.g., memref.subview -> memref.reinterpret_cast
+ * -> tensor.extract_slice), and collect all ops in the chain.
+ *
+ * @param directUsers Direct users of alloc result (containing ViewLike ops
+ *                    whose users include memref.copy)
+ * @return SmallVector<Operation*> Collected source view chain ops
+ *
+ */
+static SmallVector<Operation *>
+collectSourceViewChainOps(ArrayRef<Operation *> directUsers) {
+  SmallVector<Operation *> chainOps;
+  for (Operation *op : directUsers) {
+    if (!isa<ViewLikeOpInterface, tensor::ExtractSliceOp>(op)) {
+      continue;
+    }
+    // Penetrate through view-like ops to find memref.copy users
+    SmallVector<Operation *> worklist = {op};
+    while (!worklist.empty()) {
+      Operation *cur = worklist.pop_back_val();
+      for (auto *user : cur->getUsers()) {
+        if (auto copyOp = dyn_cast<memref::CopyOp>(user)) {
+          traceViewChain(copyOp, chainOps);
+        } else if (isa<ViewLikeOpInterface, tensor::ExtractSliceOp>(user)) {
+          worklist.push_back(user);
+        }
+      }
+    }
+  }
+  return chainOps;
+}
+
 /**
  * @brief Try to unify block_id for a single alloc operation
  *
@@ -239,18 +292,19 @@ tryUnifyForAlloc(memref::AllocOp allocOp,
     return success();
   }
 
-  // Step5: Cycle detection and block_id assignment
+  // Step5: collect allocOp, ifOp, fillOp, directUsers and ViewChainOps
   SmallVector<Operation *> coreOps = {
       allocOp.getOperation(),
       fillInfo.fillOp.getOperation(),
       fillInfo.parentIf.getOperation(),
   };
   coreOps.append(directUsers);
+  coreOps.append(collectSourceViewChainOps(directUsers));
 
+  // Step6: Cycle detection and block_id assignment
   if (CVPipeline::willCreateCycle(coreOps, memGraph, targetBlockId, bm)) {
-    LOG_DEBUG(
-        "[Cycle detection] Find cycle, have unsupport IR! Should Check!!");
-    return success();
+    LOG_DEBUG("[error] Find cycle, have unsupport IR! Should Check!!");
+    return failure();
   }
   for (auto *op : coreOps) {
     bm.updateBlockId(op, targetBlockId);

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyStoreBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyStoreBlockPass.cpp
@@ -343,7 +343,8 @@ public:
         //          Now we want to fuse D to A, so clone C' scalarOps for
         //          D dependencies to avoid cycle.
         LOG_DEBUG("Producer op = " << *matchedOps[0]);
-        CVPipeline::cloneScalarOpsForCrossBlockUses(bm, matchedOps);
+        CVPipeline::cloneScalarOpsForCrossBlockUses(
+            bm, matchedOps, bm.getBlockIdByOp(matchedOps[0]));
         // Phase 3: for each pattern, cycle detection + block_id update.
         //          Rebuild bm because cloning may have added new ops.
         if (!applyStoreUnify(matchedOps, memGraph, bm)) {

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
@@ -64,6 +64,10 @@ void ComputeBlockOptPass::runOnOperation() {
   pm.addPass(createFixpipeOptPass());
   pm.addPass(createReorderOpsByBlockIdPass());
 
+  pm.addPass(createSinkI1ProducersIntoUsersPass());
+  pm.addPass(createBroadcastUBOptPass());
+  pm.addPass(createMoveLoadIntoUserPass());
+
   if (failed(runPipeline(pm, module))) {
     if (!CVPipeline::hasFallbackAttr(module)) {
       CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
@@ -90,6 +94,9 @@ void registerComputeBlockOptPasses() {
   registerPass(createMergeCubeForBlockPass);
   registerPass(createFixpipeOptPass);
   registerPass(createUnifyStoreBlockPass);
+  registerPass(createSinkI1ProducersIntoUsersPass);
+  registerPass(createBroadcastUBOptPass);
+  registerPass(createMoveLoadIntoUserPass);
 }
 
 } // namespace triton

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
@@ -71,6 +71,8 @@ void ComputeBlockOptPass::runOnOperation() {
   pm.addPass(createMoveLoadIntoUserPass());
   pm.addPass(createUnifyStoreBlockPass());
   pm.addPass(createReorderOpsByBlockIdPass());
+  pm.addPass(createMergeSmallBlockPass());
+  pm.addPass(createReorderOpsByBlockIdPass());
 
   if (failed(runPipeline(pm, module))) {
     if (!CVPipeline::hasFallbackAttr(module)) {

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
@@ -57,6 +57,7 @@ void ComputeBlockOptPass::runOnOperation() {
 
   pm.addPass(createUBUsageOptPass());
   pm.addPass(createBroadcastUBOptPass());
+  pm.addPass(createPosMaskPatternPass());
   pm.addPass(createMergeSameSourceAxisPass());
   pm.addPass(createReorderOpsByBlockIdPass());
   pm.addPass(createMergeSmallBlockPass());
@@ -100,6 +101,7 @@ void registerComputeBlockOptPasses() {
   registerPass(createSinkI1ProducersIntoUsersPass);
   registerPass(createBroadcastUBOptPass);
   registerPass(createMoveLoadIntoUserPass);
+  registerPass(createPosMaskPatternPass);
   registerPass(createMergeSmallBlockPass);
 }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
@@ -25,6 +25,7 @@
 #include "DynamicCVPipeline/PlanComputeBlock/Passes.h"
 #include "DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlockPass.h"
 
 #include "mlir/Pass/PassManager.h"
@@ -51,22 +52,24 @@ void ComputeBlockOptPass::runOnOperation() {
 
   pm.addPass(createMergeVectorIfBlockPass());
   pm.addPass(createReorderOpsByBlockIdPass());
-
-  pm.addPass(createUnifyStoreBlockPass());
-
   pm.addPass(createMergeCubeForBlockPass());
   pm.addPass(createReorderOpsByBlockIdPass());
 
   pm.addPass(createUBUsageOptPass());
+  pm.addPass(createBroadcastUBOptPass());
   pm.addPass(createMergeSameSourceAxisPass());
+  pm.addPass(createReorderOpsByBlockIdPass());
+  pm.addPass(createMergeSmallBlockPass());
+  pm.addPass(createReorderOpsByBlockIdPass());
+
+  pm.addPass(createSinkI1ProducersIntoUsersPass());
   pm.addPass(createReorderOpsByBlockIdPass());
 
   pm.addPass(createFixpipeOptPass());
   pm.addPass(createReorderOpsByBlockIdPass());
-
-  pm.addPass(createSinkI1ProducersIntoUsersPass());
-  pm.addPass(createBroadcastUBOptPass());
   pm.addPass(createMoveLoadIntoUserPass());
+  pm.addPass(createUnifyStoreBlockPass());
+  pm.addPass(createReorderOpsByBlockIdPass());
 
   if (failed(runPipeline(pm, module))) {
     if (!CVPipeline::hasFallbackAttr(module)) {
@@ -97,6 +100,7 @@ void registerComputeBlockOptPasses() {
   registerPass(createSinkI1ProducersIntoUsersPass);
   registerPass(createBroadcastUBOptPass);
   registerPass(createMoveLoadIntoUserPass);
+  registerPass(createMergeSmallBlockPass);
 }
 
 } // namespace triton

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp
@@ -31,6 +31,7 @@
 #include "mlir/IR/Block.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/Support/LLVM.h"
+#include "mlir/Support/WalkResult.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -50,25 +51,9 @@ using namespace mlir;
 using namespace triton;
 using namespace CVPipeline;
 
-namespace mlir {
-namespace triton {
-class PlanVectorBlockPass
-    : public PassWrapper<PlanVectorBlockPass, OperationPass<ModuleOp>> {
-public:
-  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PlanVectorBlockPass)
-
-  PlanVectorBlockPass() = default;
-  void runOnOperation() override;
-
-  llvm::StringRef getArgument() const final { return "plan-vector-block"; }
-};
-
-bool isFusableOp(Operation *op) {
-  if (CVPipeline::getOpCoreType(op) == CVPipeline::CoreType::VECTOR_ONLY) {
-    if (isa<RegionBranchOpInterface>(op)) {
-      // pass control ops like scf::ForOp/scf::IfOp/scf::WhileOp
-      return false;
-    }
+static bool isFusableOp(Operation *op) {
+  if (isVectorSimpleOpOrCf(op)) {
+    // skip terminators
     if (op->getBlock()->mightHaveTerminator() &&
         op == op->getBlock()->getTerminator()) {
       return false;
@@ -78,86 +63,71 @@ bool isFusableOp(Operation *op) {
   return false;
 }
 
-void passAndCollectCandidates(Operation *nowOp,
-                              DenseMap<Operation *, int> &indegree,
-                              SmallVector<Operation *> &candidates,
-                              DenseMap<Operation *, bool> &visited,
-                              const CVPipeline::MemoryDependenceGraph &memGraph,
-                              ComputeBlockIdManager &bm) {
+static void
+passAndCollectCandidates(Operation *nowOp, DenseMap<Operation *, int> &indegree,
+                         SmallVector<Operation *> &candidates,
+                         DenseMap<Operation *, bool> &visited,
+                         const CVPipeline::MemoryDependenceGraph &memGraph,
+                         ComputeBlockIdManager &bm) {
   LOG_DEBUG("Bypassing non-fusable op " << *nowOp << "\nnow candidates size: "
                                         << candidates.size() << "\n");
-  auto block = nowOp->getBlock();
-  SmallVector<Operation *> allusers;
-  allusers.append(nowOp->getUsers().begin(), nowOp->getUsers().end());
-  for (auto memUser : memGraph.getExecAfter(nowOp)) {
-    allusers.push_back(memUser);
-  }
-  for (auto user : allusers) {
-    auto userInBlock = CVPipeline::getAncestorInBlock(user, block);
-    if (!userInBlock) {
-      continue;
-    }
-    if (!bm.isSameBlock(userInBlock, nowOp)) {
-      indegree[userInBlock]--;
+  DependencyHelper depHelper{memGraph};
+  depHelper.forEachUserInSameBlock(nowOp, [&](Operation *user) {
+    if (!bm.isSameBlock(user, nowOp)) {
+      indegree[user]--;
     }
 
-    if (bm.isWholeCubeReady(userInBlock, indegree)) {
-      if (!isFusableOp(userInBlock) && !visited[userInBlock]) {
-        if (bm.getBlockIdByOp(userInBlock) == -1) {
-          visited[userInBlock] =
-              true; // mark as fused to avoid duplicate bypass
-          passAndCollectCandidates(userInBlock, indegree, candidates, visited,
-                                   memGraph, bm);
-        } else {
-          for (auto cubeop :
-               bm.getOpsByBlockId(bm.getBlockIdByOp(userInBlock))) {
-            if (!visited[cubeop]) {
-              visited[cubeop] = true;
-              passAndCollectCandidates(cubeop, indegree, candidates, visited,
-                                       memGraph, bm);
-            }
-          }
-        }
-      } else if (isFusableOp(userInBlock) && !visited[userInBlock]) {
-        visited[userInBlock] = true;
-        candidates.push_back(userInBlock);
+    if (!bm.isWholeCubeReady(user, indegree)) {
+      return;
+    }
+
+    if (visited[user]) {
+      return;
+    }
+
+    if (isFusableOp(user)) {
+      visited[user] = true;
+      candidates.push_back(user);
+      return;
+    }
+
+    for (auto *cubeop : bm.getOpsInSameBlock(user)) {
+      if (!visited[cubeop]) {
+        visited[cubeop] = true;
+        passAndCollectCandidates(cubeop, indegree, candidates, visited,
+                                 memGraph, bm);
       }
     }
-  }
+  });
 
   LOG_DEBUG("After bypassing, candidates size: " << candidates.size() << "\n");
 }
 
-void byPassNonFusable(DenseMap<Operation *, int> &indegree,
-                      SmallVector<Operation *> &candidates,
-                      DenseMap<Operation *, bool> &visited,
-                      const CVPipeline::MemoryDependenceGraph &memGraph,
-                      ComputeBlockIdManager &bm) {
+static void byPassNonFusable(DenseMap<Operation *, int> &indegree,
+                             SmallVector<Operation *> &candidates,
+                             DenseMap<Operation *, bool> &visited,
+                             const CVPipeline::MemoryDependenceGraph &memGraph,
+                             ComputeBlockIdManager &bm) {
   // for every non-fusable candidates, bypass it.
-  for (auto &[op, degree] : indegree) {
-    if (bm.isWholeCubeReady(op, indegree) && !isFusableOp(op) && !visited[op]) {
-      if (bm.getBlockIdByOp(op) == -1) {
-        visited[op] = true; // mark as fused to avoid duplicate bypass
-        passAndCollectCandidates(op, indegree, candidates, visited, memGraph,
-                                 bm);
-      } else {
-        for (auto cubeop : bm.getOpsByBlockId(bm.getBlockIdByOp(op))) {
-          if (!visited[cubeop]) {
-            visited[cubeop] = true;
-            passAndCollectCandidates(cubeop, indegree, candidates, visited,
-                                     memGraph, bm);
-          }
-        }
+  for (auto [op, _] : indegree) {
+    if (!bm.isWholeCubeReady(op, indegree) || isFusableOp(op) || visited[op]) {
+      continue;
+    }
+    for (auto cubeop : bm.getOpsInSameBlock(op)) {
+      if (!visited[cubeop]) {
+        visited[cubeop] = true;
+        passAndCollectCandidates(cubeop, indegree, candidates, visited,
+                                 memGraph, bm);
       }
     }
   }
 }
 
-void updateCandidates(Operation *nextFused,
-                      SmallVector<Operation *> &candidates,
-                      DenseMap<Operation *, int> &indegree,
-                      DenseMap<Operation *, bool> &visited,
-                      const CVPipeline::MemoryDependenceGraph &memGraph) {
+static void
+updateCandidates(Operation *nextFused, SmallVector<Operation *> &candidates,
+                 DenseMap<Operation *, int> &indegree,
+                 DenseMap<Operation *, bool> &visited,
+                 const CVPipeline::MemoryDependenceGraph &memGraph) {
   // 1. Already fuse with nextFused, so remove it from candidates
   for (auto it = candidates.begin(); it != candidates.end(); it++) {
     if (*it == nextFused) {
@@ -167,25 +137,16 @@ void updateCandidates(Operation *nextFused,
   }
 
   // 2. Add new candidates whose indegree becomes 0 after fusing nextFused.
-  auto block = nextFused->getBlock();
-  SmallVector<Operation *> allusers;
-  allusers.append(nextFused->getUsers().begin(), nextFused->getUsers().end());
-  for (auto memUser : memGraph.getExecAfter(nextFused)) {
-    allusers.push_back(memUser);
-  }
-  for (auto user : allusers) {
-    auto userInBlock = CVPipeline::getAncestorInBlock(user, block);
-    if (!userInBlock) {
-      continue;
-    }
-    if (!visited[userInBlock]) {
-      indegree[userInBlock]--;
-      if (indegree[userInBlock] == 0 && isFusableOp(userInBlock)) {
-        visited[userInBlock] = true;
-        candidates.push_back(userInBlock);
+  DependencyHelper depHelper{memGraph};
+  depHelper.forEachUserInSameBlock(nextFused, [&](Operation *user) {
+    if (!visited[user]) {
+      indegree[user]--;
+      if (indegree[user] == 0 && isFusableOp(user)) {
+        visited[user] = true;
+        candidates.push_back(user);
       }
     }
-  }
+  });
 }
 
 void findCandidates(DenseMap<Operation *, int> &indegree,
@@ -213,31 +174,26 @@ findOpsAdjacentToCube(Block *block, const SmallVector<Operation *> &fuseGroup,
                       const CVPipeline::MemoryDependenceGraph &memGraph,
                       CVPipeline::ComputeBlockIdManager &bm) {
   SmallVector<Operation *> toProcess;
+  DependencyHelper depHelper{memGraph};
   // If the nonFusable is contorl, we default first considering.
   // Otheriwe, the smaller blockId, means the matmul is more front in the IR
   // order.
   std::optional<int> minBlockId = std::nullopt;
 
   for (Operation *op : fuseGroup) {
-    SmallVector<Operation *> allUsers;
-    allUsers.append(op->getUsers().begin(), op->getUsers().end());
-    for (auto memUser : memGraph.getExecAfter(op)) {
-      allUsers.push_back(memUser);
-    }
-
-    for (auto user : allUsers) {
-      auto userInBlock = CVPipeline::getAncestorInBlock(user, block);
-      if (!userInBlock || (block->mightHaveTerminator() &&
-                           userInBlock == block->getTerminator())) {
-        continue;
+    depHelper.forEachUserInSameBlock(op, [&](Operation *userInBlock) {
+      if (block->mightHaveTerminator() &&
+          userInBlock == block->getTerminator()) {
+        return WalkResult::advance();
       }
-      if (!isFusableOp(user) && !visited[user]) {
-        auto newBlockId = bm.getBlockIdByOp(user);
+      if (!isFusableOp(userInBlock) && !visited[userInBlock]) {
+        auto newBlockId = bm.getBlockIdByOp(userInBlock);
         if (!minBlockId.has_value() || newBlockId < minBlockId) {
           minBlockId = newBlockId;
         }
       }
-    }
+      return WalkResult::advance();
+    });
   }
 
   if (!minBlockId.has_value()) {
@@ -245,26 +201,21 @@ findOpsAdjacentToCube(Block *block, const SmallVector<Operation *> &fuseGroup,
   }
 
   for (Operation *op : fuseGroup) {
-    SmallVector<Operation *> allUsers;
-    allUsers.append(op->getUsers().begin(), op->getUsers().end());
-    for (auto memUser : memGraph.getExecAfter(op)) {
-      allUsers.push_back(memUser);
-    }
 
-    for (auto user : allUsers) {
-      auto userInBlock = CVPipeline::getAncestorInBlock(user, block);
-      if (!userInBlock || (block->mightHaveTerminator() &&
-                           userInBlock == block->getTerminator())) {
-        continue;
+    depHelper.forEachUserInSameBlock(op, [&](Operation *userInBlock) {
+      if (block->mightHaveTerminator() &&
+          userInBlock == block->getTerminator()) {
+        return WalkResult::advance();
       }
       if (!isFusableOp(userInBlock) && !visited[userInBlock]) {
         auto newBlockId = bm.getBlockIdByOp(userInBlock);
         if (newBlockId == minBlockId) {
           toProcess.push_back(op);
-          break;
+          return WalkResult::interrupt();
         }
       }
-    };
+      return WalkResult::advance();
+    });
   }
   return toProcess;
 }
@@ -274,6 +225,7 @@ collectKeepOpsToCube(Block *block, SmallVector<Operation *> toProcess,
                      const SmallVector<Operation *> &fuseGroup,
                      const CVPipeline::MemoryDependenceGraph &memGraph) {
   SetVector<Operation *> keepOps;
+  DependencyHelper depHelper{memGraph};
   while (!toProcess.empty()) {
     Operation *op = toProcess.front();
     toProcess.erase(toProcess.begin());
@@ -282,41 +234,13 @@ collectKeepOpsToCube(Block *block, SmallVector<Operation *> toProcess,
     }
     keepOps.insert(op);
 
-    // Add all operands to process
-    for (auto operand : op->getOperands()) {
-      if (auto defOp = operand.getDefiningOp()) {
-        if (!keepOps.contains(defOp) && llvm::is_contained(fuseGroup, defOp)) {
-          toProcess.push_back(defOp);
-        }
-        continue;
-      }
-
-      // Loop-carried dependency: block argument -> yielded value
-      int argIdx = CVPipeline::getLoopCarriedArgIndex(operand, block);
-      if (argIdx == -1) {
-        continue;
-      }
-      auto barg = cast<BlockArgument>(operand);
-      auto *terminator = barg.getOwner()->getTerminator();
-      if (!terminator || !isa<scf::YieldOp>(terminator)) {
-        continue;
-      }
-
-      Value yielded = terminator->getOperand(argIdx);
-      Operation *yieldedDef = yielded.getDefiningOp();
-
-      if (yieldedDef && !keepOps.contains(yieldedDef) &&
-          llvm::is_contained(fuseGroup, yieldedDef)) {
-        toProcess.push_back(yieldedDef);
-      }
-    }
-
-    // Memory dependency
-    for (auto memDef : memGraph.getExecBefore(op)) {
-      if (!keepOps.contains(memDef) && llvm::is_contained(fuseGroup, memDef)) {
-        toProcess.push_back(memDef);
-      }
-    }
+    depHelper.forEachSource<DependencyHelper::SourceMode::AcrossIterArg>(
+        op, [&](Operation *source) {
+          if (!keepOps.contains(source) &&
+              llvm::is_contained(fuseGroup, source)) {
+            toProcess.push_back(source);
+          }
+        });
   }
 
   // special case: annotation.mark always follows the defining op
@@ -380,17 +304,19 @@ collectAllDependenciesInFuseGroup(Operation *op,
     return;
   }
   toRemove.insert(op);
-  for (auto operand : op->getOperands()) {
-    if (auto definingOp = operand.getDefiningOp()) {
-      collectAllDependenciesInFuseGroup(definingOp, fuseGroup, toRemove);
+  op->walk([&](Operation *nestedOp) {
+    for (auto operand : nestedOp->getOperands()) {
+      if (auto definingOp = operand.getDefiningOp()) {
+        collectAllDependenciesInFuseGroup(definingOp, fuseGroup, toRemove);
+      }
     }
-  }
+  });
 }
 
 static SmallVector<Operation *>
-extractToProcessFromFuseGroup(Block *block,
-                              const SmallVector<Operation *> &nowFuseGroup,
-                              ComputeBlockIdManager &bm) {
+extractWholeFuseGroup(Block *block,
+                      const SmallVector<Operation *> &nowFuseGroup,
+                      ComputeBlockIdManager &bm) {
   SmallVector<Operation *> toProcess(nowFuseGroup.begin(), nowFuseGroup.end());
 
   if (!hasTensorOperation(nowFuseGroup)) {
@@ -400,20 +326,22 @@ extractToProcessFromFuseGroup(Block *block,
 
   SetVector<Operation *> toRemove;
   auto *terminator = block->getTerminator();
-  if (terminator && isa<scf::YieldOp>(terminator) &&
+  if (llvm::isa_and_present<scf::YieldOp>(terminator) &&
       isa<scf::ForOp, scf::WhileOp>(block->getParentOp())) {
-    for (auto op : nowFuseGroup) {
-      for (auto operand : op->getOperands()) {
-        int argIdx = CVPipeline::getLoopCarriedArgIndex(operand, block);
-        if (argIdx == -1) {
-          continue;
-        }
-        auto yieldOperand = terminator->getOperand(argIdx);
-        auto *defOp = yieldOperand.getDefiningOp();
-        if (defOp && bm.getBlockIdByOp(defOp) == -1 &&
-            !llvm::is_contained(nowFuseGroup, defOp)) {
-          collectAllUsersInFuseGroup(op, nowFuseGroup, toRemove);
-        }
+    for (auto *op : nowFuseGroup) {
+      auto walkResult = op->walk(
+          [block, terminator, &bm, &nowFuseGroup](Operation *nestedOp) {
+            for (auto operand : nestedOp->getOperands()) {
+              auto *defOp = getLoopCarriedDefOp(operand, block);
+              if (defOp && bm.getBlockIdByOp(defOp) == -1 &&
+                  !llvm::is_contained(nowFuseGroup, defOp)) {
+                return WalkResult::interrupt();
+              }
+            }
+            return WalkResult::advance();
+          });
+      if (walkResult.wasInterrupted()) {
+        collectAllUsersInFuseGroup(op, nowFuseGroup, toRemove);
       }
     }
   }
@@ -445,19 +373,11 @@ static void evictAndRestoreState(
   }
   fuseGroup.assign(keepOps.begin(), keepOps.end());
 
+  DependencyHelper depHelper{memGraph};
   // 2. Restore indegree for successors and reset visited for removed ops
   for (Operation *op : toRemove) {
-    SmallVector<Operation *> allUsers;
-    allUsers.append(op->getUsers().begin(), op->getUsers().end());
-    for (auto memUser : memGraph.getExecAfter(op)) {
-      allUsers.push_back(memUser);
-    }
-
-    for (auto user : allUsers) {
-      if (auto userInBlock = CVPipeline::getAncestorInBlock(user, block)) {
-        indegree[userInBlock]++;
-      }
-    }
+    depHelper.forEachUserInSameBlock(
+        op, [&](Operation *user) { indegree[user]++; });
     visited[op] = false;
   }
 
@@ -494,7 +414,7 @@ void refineFuseGroup(Block *block, SmallVector<Operation *> &nowFuseGroup,
   // rules
   if (toProcess.empty()) {
     LOG_DEBUG("No Cube adjacent op, extracting toProcess from fuseGroup.\n");
-    toProcess = extractToProcessFromFuseGroup(block, nowFuseGroup, bm);
+    toProcess = extractWholeFuseGroup(block, nowFuseGroup, bm);
   }
 
   // 3. If still empty after extraction, no op will be cut
@@ -526,32 +446,18 @@ findOpsAdjacentFromCube(Block *block, const SmallVector<Operation *> &fuseGroup,
                         const CVPipeline::MemoryDependenceGraph &memGraph,
                         CVPipeline::ComputeBlockIdManager &bm) {
   SmallVector<Operation *> toProcess;
+  DependencyHelper depHelper{memGraph};
   std::optional<int> minBlockId = std::nullopt;
 
   for (Operation *op : fuseGroup) {
-    SmallVector<Operation *> allDefs;
-    for (auto operand : op->getOperands()) {
-      if (auto defOp = operand.getDefiningOp()) {
-        allDefs.push_back(defOp);
-      }
-    }
-
-    for (auto memDef : memGraph.getExecBefore(op)) {
-      allDefs.push_back(memDef);
-    }
-
-    for (auto defOp : allDefs) {
-      auto defInBlock = CVPipeline::getAncestorInBlock(defOp, block);
-      if (!defInBlock) {
-        continue;
-      }
-      if (!isFusableOp(defInBlock)) {
+    depHelper.forEachSourceInSameBlock(op, [&](Operation *defInBlock) {
+      if (!isFusableOp(defInBlock) && !visited[defInBlock]) {
         auto newBlockId = bm.getBlockIdByOp(defInBlock);
         if (!minBlockId.has_value() || newBlockId < minBlockId) {
           minBlockId = newBlockId;
         }
       }
-    }
+    });
   }
 
   if (!minBlockId.has_value()) {
@@ -559,28 +465,16 @@ findOpsAdjacentFromCube(Block *block, const SmallVector<Operation *> &fuseGroup,
   }
 
   for (Operation *op : fuseGroup) {
-    SmallVector<Operation *> allDefs;
-    for (auto operand : op->getOperands()) {
-      if (auto defOp = operand.getDefiningOp()) {
-        allDefs.push_back(defOp);
-      }
-    }
-    for (auto memDef : memGraph.getExecBefore(op)) {
-      allDefs.push_back(memDef);
-    }
-    for (auto defOp : allDefs) {
-      auto userInBlock = CVPipeline::getAncestorInBlock(defOp, block);
-      if (!userInBlock) {
-        continue;
-      }
-      if (!isFusableOp(userInBlock) && !visited[userInBlock]) {
-        auto newBlockId = bm.getBlockIdByOp(userInBlock);
+    depHelper.forEachSourceInSameBlock(op, [&](Operation *defInBlock) {
+      if (!isFusableOp(defInBlock) && !visited[defInBlock]) {
+        auto newBlockId = bm.getBlockIdByOp(defInBlock);
         if (newBlockId == minBlockId) {
           toProcess.push_back(op);
-          break;
+          return WalkResult::interrupt();
         }
       }
-    }
+      return WalkResult::advance();
+    });
   }
   return toProcess;
 }
@@ -590,6 +484,7 @@ collectKeepOpsFromCube(Block *block, SmallVector<Operation *> toProcess,
                        const SmallVector<Operation *> &fuseGroup,
                        const CVPipeline::MemoryDependenceGraph &memGraph) {
   SetVector<Operation *> keepOps;
+  DependencyHelper depHelper{memGraph};
   while (!toProcess.empty()) {
     Operation *op = toProcess.front();
     toProcess.erase(toProcess.begin());
@@ -599,19 +494,12 @@ collectKeepOpsFromCube(Block *block, SmallVector<Operation *> toProcess,
     keepOps.insert(op);
 
     // Add all users to process
-    for (auto user : op->getUsers()) {
-      if (!keepOps.contains(user) && llvm::is_contained(fuseGroup, user)) {
-        toProcess.push_back(user);
+    depHelper.forEachUserInSameBlock(op, [&](Operation *userInblock) {
+      if (!keepOps.contains(userInblock) &&
+          llvm::is_contained(fuseGroup, userInblock)) {
+        toProcess.push_back(userInblock);
       }
-    }
-
-    // Memory dependency
-    for (auto memUser : memGraph.getExecAfter(op)) {
-      if (!keepOps.contains(memUser) &&
-          llvm::is_contained(fuseGroup, memUser)) {
-        toProcess.push_back(memUser);
-      }
-    }
+    });
   }
   return keepOps;
 }
@@ -650,7 +538,7 @@ planVectorBlockId(Block *block,
   llvm::DenseMap<Operation *, int> indegree;
   llvm::SmallVector<Operation *> queue;
   llvm::DenseMap<Operation *, bool> visited; // has been visited in search
-  initializeIndegreeForBlock(block, indegree, memGraph, bm);
+  initializeIndegreeForBlock(block, indegree, DependencyHelper{memGraph}, bm);
 
   // 2. initialize visited and find initial candidates
   block->walk([&](Operation *op) {
@@ -702,8 +590,22 @@ planVectorBlockId(Block *block,
   return llvm::success();
 }
 
+namespace {
+
+class PlanVectorBlockPass
+    : public PassWrapper<PlanVectorBlockPass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PlanVectorBlockPass)
+
+  PlanVectorBlockPass() = default;
+  void runOnOperation() override;
+
+  [[nodiscard]] llvm::StringRef getArgument() const final {
+    return "plan-vector-block";
+  }
+};
+
 void PlanVectorBlockPass::runOnOperation() {
-  LOG_DEBUG("\n---PlanVectorBlockPass start---\n");
   // 1. Build memory dependence graph
   auto moduleOp = getOperation();
 
@@ -716,21 +618,34 @@ void PlanVectorBlockPass::runOnOperation() {
   auto bm = ComputeBlockIdManager(moduleOp);
 
   // 2. search blocks in topo order and assign block id for each block
-  auto result = moduleOp.walk([&](Block *block) -> WalkResult {
-    if (llvm::failed(planVectorBlockId(block, memDepGraph, bm))) {
-      return WalkResult::interrupt();
-    }
-    return WalkResult::advance();
-  });
+  auto result =
+      moduleOp.walk<WalkOrder::PreOrder>([&](Block *block) -> WalkResult {
+        if (bm.shouldInheritFromParent(block, CoreType::VECTOR_ONLY)) {
+          LOG_DEBUG("Inherit from parentOp: " << block->getParentOp() << "\n");
+          if (llvm::failed(bm.inheritFromParent(block))) {
+            block->getParentOp()->emitError()
+                << "[" << DEBUG_TYPE
+                << "] Sub-blocks failed to inherit block id from parent op";
+            return WalkResult::interrupt();
+          }
+          return WalkResult::advance();
+        }
+        if (llvm::failed(planVectorBlockId(block, memDepGraph, bm))) {
+          return WalkResult::interrupt();
+        }
+        return WalkResult::advance();
+      });
   if (result.wasInterrupted()) {
     LOG_DEBUG("Failed to plan vector block id for block\n");
     CVPipeline::setFallbackAttr(moduleOp, CVPipeline::ERRCODE_FAILED);
   }
 }
 
+} // namespace
+
+namespace mlir::triton {
+
 std::unique_ptr<OperationPass<ModuleOp>> createPlanVectorBlockPass() {
   return std::make_unique<PlanVectorBlockPass>();
 }
-
-} // namespace triton
-} // namespace mlir
+} // namespace mlir::triton

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanVectorBlockPass.cpp
@@ -20,33 +20,27 @@
  * THE SOFTWARE.
  */
 
-#include <memory>
-
+#include "DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Passes.h"
+#include "bishengir/Dialect/Annotation/IR/Annotation.h"
+#include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Block.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Support/LLVM.h"
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
-
-#include "DynamicCVPipeline/Common/DependencyHelper.h"
-#include "mlir/Analysis/AliasAnalysis.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/IR/Block.h"
-#include "mlir/IR/Operation.h"
-#include "mlir/IR/Visitors.h"
-#include "mlir/Interfaces/ControlFlowInterfaces.h"
-#include "mlir/Support/LLVM.h"
-#include "mlir/Support/WalkResult.h"
-
-#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
-#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
-#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Passes.h"
-
-#include "DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
-#include "bishengir/Dialect/Annotation/IR/Annotation.h"
+#include <algorithm>
+#include <memory>
 
 static constexpr const char *DEBUG_TYPE = "plan-vector-block";
 #define LOG_DEBUG(...)                                                         \
@@ -56,9 +50,25 @@ using namespace mlir;
 using namespace triton;
 using namespace CVPipeline;
 
-static bool isFusableOp(Operation *op) {
-  if (isVectorSimpleOpOrCf(op)) {
-    // skip terminators
+namespace mlir {
+namespace triton {
+class PlanVectorBlockPass
+    : public PassWrapper<PlanVectorBlockPass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PlanVectorBlockPass)
+
+  PlanVectorBlockPass() = default;
+  void runOnOperation() override;
+
+  llvm::StringRef getArgument() const final { return "plan-vector-block"; }
+};
+
+bool isFusableOp(Operation *op) {
+  if (CVPipeline::getOpCoreType(op) == CVPipeline::CoreType::VECTOR_ONLY) {
+    if (isa<RegionBranchOpInterface>(op)) {
+      // pass control ops like scf::ForOp/scf::IfOp/scf::WhileOp
+      return false;
+    }
     if (op->getBlock()->mightHaveTerminator() &&
         op == op->getBlock()->getTerminator()) {
       return false;
@@ -68,71 +78,86 @@ static bool isFusableOp(Operation *op) {
   return false;
 }
 
-static void
-passAndCollectCandidates(Operation *nowOp, DenseMap<Operation *, int> &indegree,
-                         SmallVector<Operation *> &candidates,
-                         DenseMap<Operation *, bool> &visited,
-                         const CVPipeline::MemoryDependenceGraph &memGraph,
-                         ComputeBlockIdManager &bm) {
+void passAndCollectCandidates(Operation *nowOp,
+                              DenseMap<Operation *, int> &indegree,
+                              SmallVector<Operation *> &candidates,
+                              DenseMap<Operation *, bool> &visited,
+                              const CVPipeline::MemoryDependenceGraph &memGraph,
+                              ComputeBlockIdManager &bm) {
   LOG_DEBUG("Bypassing non-fusable op " << *nowOp << "\nnow candidates size: "
                                         << candidates.size() << "\n");
-  DependencyHelper depHelper{memGraph};
-  depHelper.forEachUserInSameBlock(nowOp, [&](Operation *user) {
-    if (!bm.isSameBlock(user, nowOp)) {
-      indegree[user]--;
+  auto block = nowOp->getBlock();
+  SmallVector<Operation *> allusers;
+  allusers.append(nowOp->getUsers().begin(), nowOp->getUsers().end());
+  for (auto memUser : memGraph.getExecAfter(nowOp)) {
+    allusers.push_back(memUser);
+  }
+  for (auto user : allusers) {
+    auto userInBlock = CVPipeline::getAncestorInBlock(user, block);
+    if (!userInBlock) {
+      continue;
+    }
+    if (!bm.isSameBlock(userInBlock, nowOp)) {
+      indegree[userInBlock]--;
     }
 
-    if (!bm.isWholeCubeReady(user, indegree)) {
-      return;
-    }
-
-    if (visited[user]) {
-      return;
-    }
-
-    if (isFusableOp(user)) {
-      visited[user] = true;
-      candidates.push_back(user);
-      return;
-    }
-
-    for (auto *cubeop : bm.getOpsInSameBlock(user)) {
-      if (!visited[cubeop]) {
-        visited[cubeop] = true;
-        passAndCollectCandidates(cubeop, indegree, candidates, visited,
-                                 memGraph, bm);
+    if (bm.isWholeCubeReady(userInBlock, indegree)) {
+      if (!isFusableOp(userInBlock) && !visited[userInBlock]) {
+        if (bm.getBlockIdByOp(userInBlock) == -1) {
+          visited[userInBlock] =
+              true; // mark as fused to avoid duplicate bypass
+          passAndCollectCandidates(userInBlock, indegree, candidates, visited,
+                                   memGraph, bm);
+        } else {
+          for (auto cubeop :
+               bm.getOpsByBlockId(bm.getBlockIdByOp(userInBlock))) {
+            if (!visited[cubeop]) {
+              visited[cubeop] = true;
+              passAndCollectCandidates(cubeop, indegree, candidates, visited,
+                                       memGraph, bm);
+            }
+          }
+        }
+      } else if (isFusableOp(userInBlock) && !visited[userInBlock]) {
+        visited[userInBlock] = true;
+        candidates.push_back(userInBlock);
       }
     }
-  });
+  }
 
   LOG_DEBUG("After bypassing, candidates size: " << candidates.size() << "\n");
 }
 
-static void byPassNonFusable(DenseMap<Operation *, int> &indegree,
-                             SmallVector<Operation *> &candidates,
-                             DenseMap<Operation *, bool> &visited,
-                             const CVPipeline::MemoryDependenceGraph &memGraph,
-                             ComputeBlockIdManager &bm) {
+void byPassNonFusable(DenseMap<Operation *, int> &indegree,
+                      SmallVector<Operation *> &candidates,
+                      DenseMap<Operation *, bool> &visited,
+                      const CVPipeline::MemoryDependenceGraph &memGraph,
+                      ComputeBlockIdManager &bm) {
   // for every non-fusable candidates, bypass it.
-  for (auto [op, _] : indegree) {
-    if (!bm.isWholeCubeReady(op, indegree) || isFusableOp(op) || visited[op]) {
-      continue;
-    }
-    for (auto cubeop : bm.getOpsInSameBlock(op)) {
-      if (!visited[cubeop]) {
-        visited[cubeop] = true;
-        passAndCollectCandidates(cubeop, indegree, candidates, visited,
-                                 memGraph, bm);
+  for (auto &[op, degree] : indegree) {
+    if (bm.isWholeCubeReady(op, indegree) && !isFusableOp(op) && !visited[op]) {
+      if (bm.getBlockIdByOp(op) == -1) {
+        visited[op] = true; // mark as fused to avoid duplicate bypass
+        passAndCollectCandidates(op, indegree, candidates, visited, memGraph,
+                                 bm);
+      } else {
+        for (auto cubeop : bm.getOpsByBlockId(bm.getBlockIdByOp(op))) {
+          if (!visited[cubeop]) {
+            visited[cubeop] = true;
+            passAndCollectCandidates(cubeop, indegree, candidates, visited,
+                                     memGraph, bm);
+          }
+        }
       }
     }
   }
 }
 
-static void
-updateCandidates(Operation *nextFused, SmallVector<Operation *> &candidates,
-                 DenseMap<Operation *, int> &indegree,
-                 DenseMap<Operation *, bool> &visited,
-                 const CVPipeline::MemoryDependenceGraph &memGraph) {
+void updateCandidates(Operation *nextFused,
+                      SmallVector<Operation *> &candidates,
+                      DenseMap<Operation *, int> &indegree,
+                      DenseMap<Operation *, bool> &visited,
+                      const CVPipeline::MemoryDependenceGraph &memGraph) {
   // 1. Already fuse with nextFused, so remove it from candidates
   for (auto it = candidates.begin(); it != candidates.end(); it++) {
     if (*it == nextFused) {
@@ -142,27 +167,34 @@ updateCandidates(Operation *nextFused, SmallVector<Operation *> &candidates,
   }
 
   // 2. Add new candidates whose indegree becomes 0 after fusing nextFused.
-  DependencyHelper depHelper{memGraph};
-  depHelper.forEachUserInSameBlock(nextFused, [&](Operation *user) {
-    if (!visited[user]) {
-      indegree[user]--;
-      if (indegree[user] == 0 && isFusableOp(user)) {
-        visited[user] = true;
-        candidates.push_back(user);
+  auto block = nextFused->getBlock();
+  SmallVector<Operation *> allusers;
+  allusers.append(nextFused->getUsers().begin(), nextFused->getUsers().end());
+  for (auto memUser : memGraph.getExecAfter(nextFused)) {
+    allusers.push_back(memUser);
+  }
+  for (auto user : allusers) {
+    auto userInBlock = CVPipeline::getAncestorInBlock(user, block);
+    if (!userInBlock) {
+      continue;
+    }
+    if (!visited[userInBlock]) {
+      indegree[userInBlock]--;
+      if (indegree[userInBlock] == 0 && isFusableOp(userInBlock)) {
+        visited[userInBlock] = true;
+        candidates.push_back(userInBlock);
       }
     }
-  });
+  }
 }
 
-static void findCandidates(DenseMap<Operation *, int> &indegree,
-                           SmallVector<Operation *> &candidates,
-                           DenseMap<Operation *, bool> &visited,
-                           const CVPipeline::MemoryDependenceGraph &memGraph,
-                           ComputeBlockIdManager &bm) {
+void findCandidates(DenseMap<Operation *, int> &indegree,
+                    SmallVector<Operation *> &candidates,
+                    DenseMap<Operation *, bool> &visited,
+                    const CVPipeline::MemoryDependenceGraph &memGraph,
+                    ComputeBlockIdManager &bm) {
   // 1. if no candidate, try to bypass non-fusable
-  LOG_DEBUG("Finding source ops............\n");
   if (candidates.empty()) {
-    LOG_DEBUG("No candidates available, try bypass\n");
     byPassNonFusable(indegree, candidates, visited, memGraph, bm);
   }
   // 2. find candidates whose indegree is 0 and not visited, add them to
@@ -173,47 +205,75 @@ static void findCandidates(DenseMap<Operation *, int> &indegree,
       candidates.push_back(op);
     }
   }
-  LOG_DEBUG("end finding source ops............\n");
 }
 
 static SmallVector<Operation *>
 findOpsAdjacentToCube(Block *block, const SmallVector<Operation *> &fuseGroup,
                       DenseMap<Operation *, bool> &visited,
-                      const CVPipeline::MemoryDependenceGraph &memGraph) {
+                      const CVPipeline::MemoryDependenceGraph &memGraph,
+                      CVPipeline::ComputeBlockIdManager &bm) {
   SmallVector<Operation *> toProcess;
-  std::optional<int> blockId;
-  DependencyHelper depHelper{memGraph};
+  // If the nonFusable is contorl, we default first considering.
+  // Otheriwe, the smaller blockId, means the matmul is more front in the IR
+  // order.
+  std::optional<int> minBlockId = std::nullopt;
+
   for (Operation *op : fuseGroup) {
-    depHelper.forEachUserInSameBlock(op, [&](Operation *user) {
-      if (block->mightHaveTerminator() && user == block->getTerminator()) {
-        return WalkResult::advance();
+    SmallVector<Operation *> allUsers;
+    allUsers.append(op->getUsers().begin(), op->getUsers().end());
+    for (auto memUser : memGraph.getExecAfter(op)) {
+      allUsers.push_back(memUser);
+    }
+
+    for (auto user : allUsers) {
+      auto userInBlock = CVPipeline::getAncestorInBlock(user, block);
+      if (!userInBlock || (block->mightHaveTerminator() &&
+                           userInBlock == block->getTerminator())) {
+        continue;
       }
       if (!isFusableOp(user) && !visited[user]) {
-        auto newBlockId = getOpBlockId(user);
-        if (!newBlockId.has_value()) {
-          newBlockId = getOpBlockId(user); // Some op will be tagged outside
-        }
-
-        if (!blockId.has_value()) {
-          blockId = newBlockId;
-        }
-        if (!newBlockId.has_value() || blockId == newBlockId) {
-          toProcess.push_back(op);
-          return WalkResult::interrupt();
+        auto newBlockId = bm.getBlockIdByOp(user);
+        if (!minBlockId.has_value() || newBlockId < minBlockId) {
+          minBlockId = newBlockId;
         }
       }
-      return WalkResult::advance();
-    });
+    }
+  }
+
+  if (!minBlockId.has_value()) {
+    return {};
+  }
+
+  for (Operation *op : fuseGroup) {
+    SmallVector<Operation *> allUsers;
+    allUsers.append(op->getUsers().begin(), op->getUsers().end());
+    for (auto memUser : memGraph.getExecAfter(op)) {
+      allUsers.push_back(memUser);
+    }
+
+    for (auto user : allUsers) {
+      auto userInBlock = CVPipeline::getAncestorInBlock(user, block);
+      if (!userInBlock || (block->mightHaveTerminator() &&
+                           userInBlock == block->getTerminator())) {
+        continue;
+      }
+      if (!isFusableOp(userInBlock) && !visited[userInBlock]) {
+        auto newBlockId = bm.getBlockIdByOp(userInBlock);
+        if (newBlockId == minBlockId) {
+          toProcess.push_back(op);
+          break;
+        }
+      }
+    };
   }
   return toProcess;
 }
 
 static SetVector<Operation *>
-collectKeepOps(Block *block, SmallVector<Operation *> toProcess,
-               const SmallVector<Operation *> &fuseGroup,
-               const CVPipeline::MemoryDependenceGraph &memGraph) {
+collectKeepOpsToCube(Block *block, SmallVector<Operation *> toProcess,
+                     const SmallVector<Operation *> &fuseGroup,
+                     const CVPipeline::MemoryDependenceGraph &memGraph) {
   SetVector<Operation *> keepOps;
-  DependencyHelper depHelper{memGraph};
   while (!toProcess.empty()) {
     Operation *op = toProcess.front();
     toProcess.erase(toProcess.begin());
@@ -222,24 +282,52 @@ collectKeepOps(Block *block, SmallVector<Operation *> toProcess,
     }
     keepOps.insert(op);
 
-    depHelper.forEachSource<DependencyHelper::SourceMode::AcrossIterArg>(
-        op, [&](Operation *source) {
-          if (!keepOps.contains(source) &&
-              llvm::is_contained(fuseGroup, source)) {
-            toProcess.push_back(source);
-          }
-        });
+    // Add all operands to process
+    for (auto operand : op->getOperands()) {
+      if (auto defOp = operand.getDefiningOp()) {
+        if (!keepOps.contains(defOp) && llvm::is_contained(fuseGroup, defOp)) {
+          toProcess.push_back(defOp);
+        }
+        continue;
+      }
+
+      // Loop-carried dependency: block argument -> yielded value
+      int argIdx = CVPipeline::getLoopCarriedArgIndex(operand, block);
+      if (argIdx == -1) {
+        continue;
+      }
+      auto barg = cast<BlockArgument>(operand);
+      auto *terminator = barg.getOwner()->getTerminator();
+      if (!terminator || !isa<scf::YieldOp>(terminator)) {
+        continue;
+      }
+
+      Value yielded = terminator->getOperand(argIdx);
+      Operation *yieldedDef = yielded.getDefiningOp();
+
+      if (yieldedDef && !keepOps.contains(yieldedDef) &&
+          llvm::is_contained(fuseGroup, yieldedDef)) {
+        toProcess.push_back(yieldedDef);
+      }
+    }
+
+    // Memory dependency
+    for (auto memDef : memGraph.getExecBefore(op)) {
+      if (!keepOps.contains(memDef) && llvm::is_contained(fuseGroup, memDef)) {
+        toProcess.push_back(memDef);
+      }
+    }
   }
 
   // special case: annotation.mark always follows the defining op
-  for (auto *op : fuseGroup) {
+  for (auto op : fuseGroup) {
     auto markOp = llvm::dyn_cast<annotation::MarkOp>(op);
     if (!markOp) {
       continue;
     }
 
     auto src = markOp.getSrc();
-    auto *definingOp = src.getDefiningOp();
+    auto definingOp = src.getDefiningOp();
     if (definingOp && keepOps.contains(definingOp)) {
       keepOps.insert(markOp);
     }
@@ -312,52 +400,24 @@ extractToProcessFromFuseGroup(Block *block,
 
   SetVector<Operation *> toRemove;
   auto *terminator = block->getTerminator();
-  if (llvm::isa_and_present<scf::YieldOp>(terminator) &&
+  if (terminator && isa<scf::YieldOp>(terminator) &&
       isa<scf::ForOp, scf::WhileOp>(block->getParentOp())) {
-    for (auto *op : nowFuseGroup) {
-      auto walkResult = op->walk(
-          [block, terminator, &bm, &nowFuseGroup](Operation *nestedOp) {
-            for (auto operand : nestedOp->getOperands()) {
-              auto *defOp = getLoopCarriedDefOp(operand, block);
-              if (defOp && bm.getBlockIdByOp(defOp) == -1 &&
-                  !llvm::is_contained(nowFuseGroup, defOp)) {
-                return WalkResult::interrupt();
-              }
-            }
-            return WalkResult::advance();
-          });
-      if (walkResult.wasInterrupted()) {
-        collectAllUsersInFuseGroup(op, nowFuseGroup, toRemove);
+    for (auto op : nowFuseGroup) {
+      for (auto operand : op->getOperands()) {
+        int argIdx = CVPipeline::getLoopCarriedArgIndex(operand, block);
+        if (argIdx == -1) {
+          continue;
+        }
+        auto yieldOperand = terminator->getOperand(argIdx);
+        auto *defOp = yieldOperand.getDefiningOp();
+        if (defOp && bm.getBlockIdByOp(defOp) == -1 &&
+            !llvm::is_contained(nowFuseGroup, defOp)) {
+          collectAllUsersInFuseGroup(op, nowFuseGroup, toRemove);
+        }
       }
     }
   }
 
-  for (auto op : nowFuseGroup) {
-    for (auto result : op->getResults()) {
-      if (auto tensorType = dyn_cast<mlir::TensorType>(result.getType())) {
-        mlir::Type elemType = tensorType.getElementType();
-        if (!elemType.isInteger(1)) {
-          continue;
-        }
-      }
-      bool hasExternalUser = false;
-      for (auto user : result.getUsers()) {
-        if (!llvm::is_contained(nowFuseGroup, user)) {
-          hasExternalUser = true;
-          break;
-        }
-      }
-      if (hasExternalUser) {
-        collectAllUsersInFuseGroup(op, nowFuseGroup, toRemove);
-        for (auto operand : op->getOperands()) {
-          if (auto definingOp = operand.getDefiningOp()) {
-            collectAllDependenciesInFuseGroup(definingOp, nowFuseGroup,
-                                              toRemove);
-          }
-        }
-      }
-    }
-  }
   for (auto op : toRemove) {
     LOG_DEBUG("Removing op when refining: " << *op << "\n");
     toProcess.erase(std::remove(toProcess.begin(), toProcess.end(), op),
@@ -385,11 +445,19 @@ static void evictAndRestoreState(
   }
   fuseGroup.assign(keepOps.begin(), keepOps.end());
 
-  DependencyHelper depHelper{memGraph};
   // 2. Restore indegree for successors and reset visited for removed ops
   for (Operation *op : toRemove) {
-    depHelper.forEachUserInSameBlock(
-        op, [&](Operation *user) { indegree[user]++; });
+    SmallVector<Operation *> allUsers;
+    allUsers.append(op->getUsers().begin(), op->getUsers().end());
+    for (auto memUser : memGraph.getExecAfter(op)) {
+      allUsers.push_back(memUser);
+    }
+
+    for (auto user : allUsers) {
+      if (auto userInBlock = CVPipeline::getAncestorInBlock(user, block)) {
+        indegree[userInBlock]++;
+      }
+    }
     visited[op] = false;
   }
 
@@ -412,21 +480,19 @@ static void evictAndRestoreState(
   }
 }
 
-static void refineFuseGroup(Block *block,
-                            SmallVector<Operation *> &nowFuseGroup,
-                            DenseMap<Operation *, bool> &visited,
-                            SmallVector<Operation *> &candidates,
-                            DenseMap<Operation *, int> &indegree,
-                            const CVPipeline::MemoryDependenceGraph &memGraph,
-                            ComputeBlockIdManager &bm,
-                            bool isUBRefineOptEnabled) {
+void refineFuseGroup(Block *block, SmallVector<Operation *> &nowFuseGroup,
+                     DenseMap<Operation *, bool> &visited,
+                     SmallVector<Operation *> &candidates,
+                     DenseMap<Operation *, int> &indegree,
+                     const CVPipeline::MemoryDependenceGraph &memGraph,
+                     ComputeBlockIdManager &bm) {
   // 1.Find ops in fuse group whose next node is a non-fusable (CUBE-only) op
   auto toProcess =
-      findOpsAdjacentToCube(block, nowFuseGroup, visited, memGraph);
+      findOpsAdjacentToCube(block, nowFuseGroup, visited, memGraph, bm);
 
   // 2. If no cube adjacent op, extract toProcess from fuseGroup using fallback
   // rules
-  if (toProcess.empty() && isUBRefineOptEnabled) {
+  if (toProcess.empty()) {
     LOG_DEBUG("No Cube adjacent op, extracting toProcess from fuseGroup.\n");
     toProcess = extractToProcessFromFuseGroup(block, nowFuseGroup, bm);
   }
@@ -436,12 +502,17 @@ static void refineFuseGroup(Block *block,
     LOG_DEBUG("No op will be cut after extraction.\n");
     findCandidates(indegree, candidates, visited, memGraph, bm);
     if (candidates.empty()) {
+      // Even if cut these ops, and add them into next search, they will be cut
+      // again and lead to dead cycle.
+      //  the scenario like this:
+      // v1->v2->yield.
+      // So after findCandidates, no more new ops, need to fuse nowFuseGroup.
       return;
     }
   }
 
   // 4. Collect keepOps transitively (data + memory + loop-carried deps)
-  auto keepOps = collectKeepOps(block, toProcess, nowFuseGroup, memGraph);
+  auto keepOps = collectKeepOpsToCube(block, toProcess, nowFuseGroup, memGraph);
 
   // 5. Remove non-kept ops from fuseGroup and restore BFS state
   evictAndRestoreState(block, keepOps, nowFuseGroup, visited, candidates,
@@ -449,16 +520,137 @@ static void refineFuseGroup(Block *block,
   LOG_DEBUG("After cutting, kept " << keepOps.size() << "\n");
 }
 
+static SmallVector<Operation *>
+findOpsAdjacentFromCube(Block *block, const SmallVector<Operation *> &fuseGroup,
+                        DenseMap<Operation *, bool> &visited,
+                        const CVPipeline::MemoryDependenceGraph &memGraph,
+                        CVPipeline::ComputeBlockIdManager &bm) {
+  SmallVector<Operation *> toProcess;
+  std::optional<int> minBlockId = std::nullopt;
+
+  for (Operation *op : fuseGroup) {
+    SmallVector<Operation *> allDefs;
+    for (auto operand : op->getOperands()) {
+      if (auto defOp = operand.getDefiningOp()) {
+        allDefs.push_back(defOp);
+      }
+    }
+
+    for (auto memDef : memGraph.getExecBefore(op)) {
+      allDefs.push_back(memDef);
+    }
+
+    for (auto defOp : allDefs) {
+      auto defInBlock = CVPipeline::getAncestorInBlock(defOp, block);
+      if (!defInBlock) {
+        continue;
+      }
+      if (!isFusableOp(defInBlock)) {
+        auto newBlockId = bm.getBlockIdByOp(defInBlock);
+        if (!minBlockId.has_value() || newBlockId < minBlockId) {
+          minBlockId = newBlockId;
+        }
+      }
+    }
+  }
+
+  if (!minBlockId.has_value()) {
+    return {};
+  }
+
+  for (Operation *op : fuseGroup) {
+    SmallVector<Operation *> allDefs;
+    for (auto operand : op->getOperands()) {
+      if (auto defOp = operand.getDefiningOp()) {
+        allDefs.push_back(defOp);
+      }
+    }
+    for (auto memDef : memGraph.getExecBefore(op)) {
+      allDefs.push_back(memDef);
+    }
+    for (auto defOp : allDefs) {
+      auto userInBlock = CVPipeline::getAncestorInBlock(defOp, block);
+      if (!userInBlock) {
+        continue;
+      }
+      if (!isFusableOp(userInBlock) && !visited[userInBlock]) {
+        auto newBlockId = bm.getBlockIdByOp(userInBlock);
+        if (newBlockId == minBlockId) {
+          toProcess.push_back(op);
+          break;
+        }
+      }
+    }
+  }
+  return toProcess;
+}
+
+SetVector<Operation *>
+collectKeepOpsFromCube(Block *block, SmallVector<Operation *> toProcess,
+                       const SmallVector<Operation *> &fuseGroup,
+                       const CVPipeline::MemoryDependenceGraph &memGraph) {
+  SetVector<Operation *> keepOps;
+  while (!toProcess.empty()) {
+    Operation *op = toProcess.front();
+    toProcess.erase(toProcess.begin());
+    if (keepOps.contains(op)) {
+      continue;
+    }
+    keepOps.insert(op);
+
+    // Add all users to process
+    for (auto user : op->getUsers()) {
+      if (!keepOps.contains(user) && llvm::is_contained(fuseGroup, user)) {
+        toProcess.push_back(user);
+      }
+    }
+
+    // Memory dependency
+    for (auto memUser : memGraph.getExecAfter(op)) {
+      if (!keepOps.contains(memUser) &&
+          llvm::is_contained(fuseGroup, memUser)) {
+        toProcess.push_back(memUser);
+      }
+    }
+  }
+  return keepOps;
+}
+
+void reverseRefineFuseGroup(Block *block,
+                            SmallVector<Operation *> &nowFuseGroup,
+                            DenseMap<Operation *, bool> &visited,
+                            SmallVector<Operation *> &candidates,
+                            DenseMap<Operation *, int> &indegree,
+                            const CVPipeline::MemoryDependenceGraph &memGraph,
+                            ComputeBlockIdManager &bm) {
+  // 1. Find ops in fuse group whose pre node is a non-fusable op
+  auto toProcess =
+      findOpsAdjacentFromCube(block, nowFuseGroup, visited, memGraph, bm);
+  // 2. If no op from cube, extract toProcess from fuseGroup using fallback
+  // rules
+  if (toProcess.empty()) {
+    LOG_DEBUG("No op from cube, extracting toProcess from fuseGroup.\n");
+    return;
+  }
+  // 3. Collect keepOps transitively (data + memory + loop-carried deps)
+  auto keepOps =
+      collectKeepOpsFromCube(block, toProcess, nowFuseGroup, memGraph);
+  // 4. Remove non-kept ops from fuseGroup and restore BFS state
+  evictAndRestoreState(block, keepOps, nowFuseGroup, visited, candidates,
+                       indegree, memGraph);
+  LOG_DEBUG("After reverse cutting, kept " << keepOps.size() << "\n");
+}
+
 // Main function to plan vector block id for one block
-static llvm::LogicalResult
+llvm::LogicalResult
 planVectorBlockId(Block *block,
                   const CVPipeline::MemoryDependenceGraph &memGraph,
-                  ComputeBlockIdManager &bm, bool isUBRefineOptEnabled) {
+                  ComputeBlockIdManager &bm) {
   // 1. topo initialize
   llvm::DenseMap<Operation *, int> indegree;
   llvm::SmallVector<Operation *> queue;
   llvm::DenseMap<Operation *, bool> visited; // has been visited in search
-  initializeIndegreeForBlock(block, indegree, DependencyHelper{memGraph}, bm);
+  initializeIndegreeForBlock(block, indegree, memGraph, bm);
 
   // 2. initialize visited and find initial candidates
   block->walk([&](Operation *op) {
@@ -482,14 +674,19 @@ planVectorBlockId(Block *block,
       updateCandidates(nextFused, queue, indegree, visited, memGraph);
     }
     if (queue.empty() || nextFused == nullptr) {
-      LOG_DEBUG("Prepare to check this group: \n");
-      for (auto op : nowFuseGroup) {
-        LOG_DEBUG("fuseing: " << *op << "\n");
-      }
+      LLVM_DEBUG({
+        LOG_DEBUG("Prepare to check this group: \n");
+        for (auto op : nowFuseGroup) {
+          LOG_DEBUG("prepare: " << *op << "\n");
+        }
+      });
       // finish one group, assign block id and start next iteration
       // Cut error operations before assigning block id
       refineFuseGroup(block, nowFuseGroup, visited, queue, indegree, memGraph,
-                      bm, isUBRefineOptEnabled);
+                      bm);
+
+      reverseRefineFuseGroup(block, nowFuseGroup, visited, queue, indegree,
+                             memGraph, bm);
       LOG_DEBUG("Group after cutting: \n");
       for (auto op : nowFuseGroup) {
         LOG_DEBUG("fuseing: " << *op << "\n");
@@ -505,22 +702,8 @@ planVectorBlockId(Block *block,
   return llvm::success();
 }
 
-namespace {
-
-class PlanVectorBlockPass
-    : public PassWrapper<PlanVectorBlockPass, OperationPass<ModuleOp>> {
-public:
-  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PlanVectorBlockPass)
-
-  PlanVectorBlockPass() = default;
-  void runOnOperation() override;
-
-  [[nodiscard]] llvm::StringRef getArgument() const final {
-    return "plan-vector-block";
-  }
-};
-
 void PlanVectorBlockPass::runOnOperation() {
+  LOG_DEBUG("\n---PlanVectorBlockPass start---\n");
   // 1. Build memory dependence graph
   auto moduleOp = getOperation();
 
@@ -531,43 +714,23 @@ void PlanVectorBlockPass::runOnOperation() {
   auto &aa = getAnalysis<AliasAnalysis>();
   auto memDepGraph = MemoryDependenceGraph(moduleOp, aa);
   auto bm = ComputeBlockIdManager(moduleOp);
-  bool isUBRefineOptEnabled = false;
-  auto attr = moduleOp->getAttr(CVPipeline::kEnableUbRefineOpt);
-  if (attr) {
-    isUBRefineOptEnabled = true;
-  }
 
   // 2. search blocks in topo order and assign block id for each block
-  auto result =
-      moduleOp.walk<WalkOrder::PreOrder>([&](Block *block) -> WalkResult {
-        if (bm.shouldInheritFromParent(block, CoreType::VECTOR_ONLY)) {
-          LOG_DEBUG("Inherit from parentOp: " << block->getParentOp() << "\n");
-          if (llvm::failed(bm.inheritFromParent(block))) {
-            block->getParentOp()->emitError()
-                << "[" << DEBUG_TYPE
-                << "] Sub-blocks failed to inherit block id from parent op";
-            return WalkResult::interrupt();
-          }
-          return WalkResult::advance();
-        }
-        if (llvm::failed(planVectorBlockId(block, memDepGraph, bm,
-                                           isUBRefineOptEnabled))) {
-          return WalkResult::interrupt();
-        }
-        return WalkResult::advance();
-      });
+  auto result = moduleOp.walk([&](Block *block) -> WalkResult {
+    if (llvm::failed(planVectorBlockId(block, memDepGraph, bm))) {
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
   if (result.wasInterrupted()) {
     LOG_DEBUG("Failed to plan vector block id for block\n");
     CVPipeline::setFallbackAttr(moduleOp, CVPipeline::ERRCODE_FAILED);
   }
 }
 
-} // namespace
-
-namespace mlir::triton {
-
 std::unique_ptr<OperationPass<ModuleOp>> createPlanVectorBlockPass() {
   return std::make_unique<PlanVectorBlockPass>();
 }
 
-} // namespace mlir::triton
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
@@ -51,6 +51,8 @@
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.h"
+#include "bishengir/Dialect/HIVM/IR/HIVMImpl.h"
+#include "bishengir/Dialect/HIVM/Utils/Utils.h"
 
 using namespace mlir;
 static constexpr const char *DEBUG_TYPE = "ReorderOpsByBlockIdPass";
@@ -310,11 +312,13 @@ GroupAdjacencyGraph::computeTopologicalOrder() {
     }
   }
 
-  LOG_DEBUG("Group order: ");
-  for (int id : result) {
-    LOG_DEBUG(id << " ");
-  }
-  LOG_DEBUG("\n");
+  LLVM_DEBUG({
+    LOG_DEBUG("Group order: ");
+    for (int id : result) {
+      LOG_DEBUG(id << " ");
+    }
+    LOG_DEBUG("\n");
+  });
 
   if (result.size() == n) {
     return result;

--- a/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
@@ -53,8 +53,7 @@ static constexpr llvm::StringLiteral kAttrsToRemove[]{
     kMemCrossDeps,      kClone,
     kIntraBufCount,     kInterCoreBufCount,
     kLoadStoreBufCount, kInsertionOptimization,
-    kDepMark,
-    kIntraDeps};
+    kDepMark,           kIntraDeps};
 
 void RemoveSsbufAttrPass::runOnOperation() {
   auto module = getOperation();

--- a/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
@@ -53,7 +53,7 @@ static constexpr llvm::StringLiteral kAttrsToRemove[]{
     kMemCrossDeps,      kClone,
     kIntraBufCount,     kInterCoreBufCount,
     kLoadStoreBufCount, kInsertionOptimization,
-    kEnableUbRefineOpt, kDepMark,
+    kDepMark,
     kIntraDeps};
 
 void RemoveSsbufAttrPass::runOnOperation() {

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/FoldExpandExtCollapse.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/FoldExpandExtCollapse.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/LogicalResult.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/PatternMatch.h"
+
+#include "ascend/include/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.h"
+
+using namespace mlir;
+using namespace triton;
+using namespace CVSplit;
+
+static constexpr const char *DEBUG_TYPE = "FoldExpandExtCollapse";
+#define LOG_DEBUG(...)                                                         \
+  LLVM_DEBUG(llvm::dbgs() << "\n[" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
+
+namespace mlir::triton::CVSplit {
+
+LogicalResult
+FoldExpandExtCollapse::matchAndRewrite(tensor::CollapseShapeOp collapseOp,
+                                       PatternRewriter &rewriter) const {
+  auto collapseReassoc = collapseOp.getReassociationIndices();
+
+  if (collapseReassoc.size() != 1 || collapseReassoc[0].size() != 2 ||
+      collapseReassoc[0][0] != 0 || collapseReassoc[0][1] != 1) {
+    return failure();
+  }
+
+  auto extOp = collapseOp.getSrc().getDefiningOp();
+  if (!extOp) {
+    return failure();
+  }
+
+  auto extUIOp = dyn_cast<arith::ExtUIOp>(extOp);
+  auto extSIOp = dyn_cast<arith::ExtSIOp>(extOp);
+  if (!extUIOp && !extSIOp) {
+    return failure();
+  }
+
+  if (!extOp->hasOneUse()) {
+    return failure();
+  }
+
+  auto expandOp = extOp->getOperand(0).getDefiningOp<tensor::ExpandShapeOp>();
+  if (!expandOp) {
+    return failure();
+  }
+
+  if (!expandOp->hasOneUse()) {
+    return failure();
+  }
+
+  auto expandReassoc = expandOp.getReassociationIndices();
+  if (expandReassoc.size() != 1 || expandReassoc[0].size() != 2 ||
+      expandReassoc[0][0] != 0 || expandReassoc[0][1] != 1) {
+    return failure();
+  }
+
+  Value extInput = expandOp.getSrc();
+  Type resultType = collapseOp.getResult().getType();
+
+  if (extUIOp) {
+    auto newExtUI = rewriter.create<arith::ExtUIOp>(collapseOp.getLoc(),
+                                                    resultType, extInput);
+    rewriter.replaceOp(collapseOp, newExtUI.getResult());
+  } else {
+    auto newExtSI = rewriter.create<arith::ExtSIOp>(collapseOp.getLoc(),
+                                                    resultType, extInput);
+    rewriter.replaceOp(collapseOp, newExtSI.getResult());
+  }
+
+  return success();
+}
+
+} // namespace mlir::triton::CVSplit

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/PatternMatchRewrites.cpp
@@ -63,6 +63,7 @@ void PatternMatchRewritePass::runOnOperation() {
   auto *ctx = &getContext();
   RewritePatternSet patterns(ctx);
   patterns.add<SplitMatmulPattern>(ctx, needSplitAll);
+  patterns.add<FoldExpandExtCollapse>(ctx);
 
   // the way we handle matmul dependencies across for blocks
   // requres the patternmatching to go top-down

--- a/third_party/ascend/triton_ascend.cc
+++ b/third_party/ascend/triton_ascend.cc
@@ -185,12 +185,8 @@ void init_triton_ascend_passes_ttir(py::module &&m) {
   m.def("set_enable_cube_block_merge",
         [](bool enable) { mlir::CVPipeline::setEnableCubeBlockMerge(enable); });
 
-  m.def("set_enable_ub_refine_opt", [](mlir::ModuleOp &moduleop, bool enable) {
-    OpBuilder builder(moduleop.getContext());
-    if (enable) {
-      moduleop->setAttr(CVPipeline::kEnableUbRefineOpt, builder.getUnitAttr());
-    }
-  });
+  m.def("set_enable_ub_refine_opt",
+        [](mlir::ModuleOp &moduleop, bool enable) { return; });
   m.def("set_enable_buffer_insert_optimization", [](mlir::ModuleOp &moduleop) {
     OpBuilder builder(moduleop.getContext());
     moduleop->setAttr(CVPipeline::kInsertionOptimization,

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/unify_alloc_block.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/unify_alloc_block.mlir
@@ -195,4 +195,116 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
     }
     return
   }
+
+  //===----------------------------------------------------------------------===//
+  // Test Case: @test_copy_source_subview_traceback
+  //===----------------------------------------------------------------------===//
+  // Pattern: trace back memref.copy's source subview to memref.reinterpret_cast
+  // Key scenario: The copy's source operand (%subview_src) is a subview of
+  //   %reinterpret_cast, which has a DIFFERENT block_id (5) from the copy (2).
+  //   The pass should trace back from the copy's source subview through the
+  //   view-like chain to the reinterpret_cast, and unify them to the copy's
+  //   block_id (2).
+  // Before:
+  //   %reinterpret_cast {block_id=5}                        // source base
+  //   %subview_src = subview %reinterpret_cast {block_id=5} // source subview
+  //   %subview_dst = subview %alloc {block_id=5}            // dst subview
+  //   memref.copy %subview_src, %subview_dst {block_id=2}
+  // After (source view chain unified to block_id=2):
+  //   %reinterpret_cast {block_id=2}
+  //   %subview_src {block_id=2}
+  //   %subview_dst {block_id=2}
+  //   memref.copy {block_id=2}
+  //   (alloc, fill, scf.if, condition deps also unified to block_id=2)
+  //===----------------------------------------------------------------------===//
+  // CHECK-LABEL: func.func @test_copy_source_subview_traceback
+  func.func @test_copy_source_subview_traceback(%arg0: memref<?xf16>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %cst = arith.constant 0.000000e+00 : f16
+
+    scf.for %arg17 = %c0 to %c32 step %c1 iter_args(%arg19 = %c0) -> (index) {
+      %c128 = arith.constant {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "CUBE"} 128 : index
+      %cond = arith.cmpi slt, %arg19, %c32 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
+      %alloc = memref.alloc() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16>
+      %140 = arith.addi %arg19, %c128 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : index
+      scf.if %cond {
+        linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : f16) outs(%alloc : memref<32x32xf16>)
+      } {hivm.unlikely_condition}
+
+      // Source view chain: reinterpret_cast and subview_src have block_id=5,
+      // should be unified to block_id=2 by tracing copy's source subview.
+      // CHECK: %{{.*}} = memref.reinterpret_cast {{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+      %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [%140], sizes: [32, 32], strides: [%c32, %c1] {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE"} : memref<?xf16> to memref<32x32xf16, strided<[?, ?], offset: ?>>
+      // CHECK: %{{.*}} = memref.subview {{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+      %subview_src = memref.subview %reinterpret_cast[0, 0] [%c32, %c32] [1, 1] {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16, strided<[?, ?], offset: ?>> to memref<?x?xf16, strided<[?, ?], offset: ?>>
+      // CHECK: %{{.*}} = memref.subview {{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+      %subview_dst = memref.subview %alloc[0, 0] [%c32, %c32] [1, 1] {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16> to memref<?x?xf16, strided<[32, 1]>>
+
+      // CHECK: memref.copy{{.*}}{ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+      memref.copy %subview_src, %subview_dst {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<?x?xf16, strided<[?, ?], offset: ?>> to memref<?x?xf16, strided<[32, 1]>>
+
+      scf.yield %140 : index
+    }
+    return
+  }
+
+  //===----------------------------------------------------------------------===//
+  // Test Case: @test_block_boundary_source_chain
+  //===----------------------------------------------------------------------===//
+  // Verify that when the source view chain of a memref.copy spans across MLIR
+  // Block boundaries, only ops in the same Block as the copyOp are collected
+  // and unified. Ops in different Blocks are skipped.
+  //
+  // Scenario:
+  //   - arg_subview/reinterpret_cast from external arg, defined in parent block
+  //   - outer memref.copy (block_id=15) in the same parent block
+  //   - inner memref.copy (block_id=2) inside scf.for, also using arg_subview
+  // Expected:
+  //   - arg_subview/reinterpret_cast unified to block_id=15 (same block as
+  //     outer copy)
+  //   - inner copy does NOT affect arg_subview (different block -> skipped)
+  //===----------------------------------------------------------------------===//
+  // CHECK-LABEL: func.func @test_block_boundary_source_chain
+  func.func @test_block_boundary_source_chain(%arg0: memref<?xf16>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %cst = arith.constant 0.000000e+00 : f16
+
+    %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [32, 32], strides: [%c32, %c1] {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"} : memref<?xf16> to memref<32x32xf16, strided<[?, ?], offset: ?>>
+    // CHECK: %{{.*}} = memref.subview {{.*}} {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "CUBE"}
+    %arg_subview = memref.subview %reinterpret_cast[0, 0] [%c32, %c32] [1, 1] {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16, strided<[?, ?], offset: ?>> to memref<?x?xf16, strided<[?, ?], offset: ?>>
+
+    %outer_cond = arith.constant 1 : i1
+    // CHECK: %{{.*}} = memref.alloc() {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16>
+    %alloc = memref.alloc() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16>
+    // CHECK: scf.if {{.*}} {
+    // CHECK:   linalg.fill {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "CUBE"}
+    scf.if %outer_cond {
+      linalg.fill {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : f16) outs(%alloc : memref<32x32xf16>)
+    } {hivm.unlikely_condition}
+    // CHECK: %{{.*}} = memref.subview {{.*}} {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "CUBE"}
+    %dst_subview = memref.subview %alloc[0, 0] [%c32, %c32] [1, 1] {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16> to memref<?x?xf16, strided<[32, 1]>>
+    // CHECK: memref.copy{{.*}}{ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "CUBE"}
+    memref.copy %arg_subview, %dst_subview {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "CUBE"} : memref<?x?xf16, strided<[?, ?], offset: ?>> to memref<?x?xf16, strided<[32, 1]>>
+
+    scf.for %iv = %c0 to %c1 step %c1 {
+      %inner_cond = arith.constant 1 : i1
+      // CHECK: %{{.*}} = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16>
+      %inner_alloc = memref.alloc() {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16>
+      // CHECK: scf.if {{.*}} {
+      // CHECK:   linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+      scf.if %inner_cond {
+        linalg.fill {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : f16) outs(%inner_alloc : memref<32x32xf16>)
+      } {hivm.unlikely_condition}
+      // CHECK: %{{.*}} = memref.subview {{.*}} {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+      %inner_dst = memref.subview %inner_alloc[0, 0] [%c32, %c32] [1, 1] {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16> to memref<?x?xf16, strided<[32, 1]>>
+      // CHECK: memref.copy{{.*}}{ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+      memref.copy %arg_subview, %inner_dst {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<?x?xf16, strided<[?, ?], offset: ?>> to memref<?x?xf16, strided<[32, 1]>>
+      scf.yield
+    }
+    return
+  }
 }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/unify_store_block.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/unify_store_block.mlir
@@ -166,4 +166,123 @@ module {
     %ext = arith.muli %add, %c64 {ssbuffer.block_id = 13 : i32, ssbuffer.core_type = "VECTOR"} : index
     return
   }
+
+  // ============================================
+  // Test 7: producer and store already share the same block_id, but viewOps
+  // in between have a different block_id. The pass should still collect and
+  // unify those viewOps to the producer's block_id.
+  //
+  // Pattern:
+  //   arith.truncf(VECTOR, block_id=5)                <- producer
+  //     -> tensor.extract_slice(block_id=6)            <- viewOp to unify
+  //     -> bufferization.materialize_in_destination(block_id=5)  <- store
+  //   dest chain: memref.reinterpret_cast(block_id=6)  <- viewOp to unify
+  //             -> memref.subview(block_id=6)           <- viewOp to unify
+  //
+  // All viewOps (extract_slice, reinterpret_cast, subview) at block_id=6
+  // should be unified to block_id=5.
+  // ============================================
+  // CHECK-LABEL: func @test_producer_store_same_block
+  func.func @test_producer_store_same_block(%arg0: memref<?xf16> {tt.divisibility = 16 : i32}, %in: tensor<64x64xf32>) {
+    // %c0: scalar dep at block 6, unified to 5.
+    // CHECK: arith.constant {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    %c0 = arith.constant {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    // producer stays at block 5.
+    // CHECK: arith.truncf %{{.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    %trunc = arith.truncf %in {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    // extract_slice at block 6, unified to 5.
+    // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    %extract = tensor.extract_slice %trunc[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+    // reinterpret_cast at block 6, unified to 5.
+    // CHECK: memref.reinterpret_cast %{{.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+    %reinterpret = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [128, 64], strides: [64, 1] {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+    // subview at block 6, unified to 5.
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    %subview = memref.subview %reinterpret[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    // store stays at block 5.
+    // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+    bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+    return
+  }
+
+  // ============================================
+  // Test 8: Producer outside scf.for, store inside → NO unification
+  //
+  // producer = arith.truncf (VECTOR_ONLY, block_id=5) lives in the function
+  // body, while the store and its data/dest chain are inside scf.for
+  // (block_id=8). traceProducerOp still finds the producer because
+  // %extract_slice directly references %trunc from the outer scope, but
+  // matchStorePattern rejects the match because producer->getBlock() !=
+  // storeOp->getBlock() (different IR blocks).
+  //
+  // All block_ids remain unchanged.
+  // ============================================
+  // CHECK-LABEL: func @test_producer_outside_for
+  func.func @test_producer_outside_for(%arg0: memref<?xf16> {tt.divisibility = 16 : i32}, %in: tensor<64x64xf32>) {
+    // %c0 feeds reinterpret_cast's offset (scalar dep), stays at block 8.
+    // CHECK: arith.constant {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    %c0 = arith.constant {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    // producer outside scf.for, stays at block 5.
+    // CHECK: arith.truncf %{{.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    %trunc = arith.truncf %in {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+    %lb = arith.constant {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    %ub = arith.constant {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} 64 : index
+    %step = arith.constant {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} 1 : index
+    // store and its chain inside scf.for; all stay at block 8.
+    scf.for %i = %lb to %ub step %step {
+      // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+      %extract = tensor.extract_slice %trunc[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+      // CHECK: memref.reinterpret_cast %{{.*}} {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+      %reinterpret = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [128, 64], strides: [64, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+      // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+      %subview = memref.subview %reinterpret[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+      // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+      bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+    }
+    return
+  }
+
+  // ============================================
+  // Test 9: Dest view ops outside scf.for, store and producer inside
+  //         → unification happens
+  //
+  // producer = arith.truncf (VECTOR_ONLY, block_id=5) inside scf.for.
+  // store = bufferization.materialize_in_destination (block_id=8) inside for.
+  // data view = tensor.extract_slice (block_id=8) inside for.
+  // dest views = memref.reinterpret_cast, memref.subview (block_id=8) outside
+  // for.
+  //
+  // producer and store are in the same IR block (inside scf.for) → pattern
+  // matched.  All matched ops unified to producer's block_id=5.  Scalar
+  // deps outside the for loop (%c0, for-loop bounds) stay at their original
+  // block_ids.
+  // ============================================
+  // CHECK-LABEL: func @test_dest_view_outside_for
+  func.func @test_dest_view_outside_for(%arg0: memref<?xf16> {tt.divisibility = 16 : i32}, %in: tensor<64x64xf32>) {
+    // %c0 feeds reinterpret_cast, stays at block 8 (outside for, not collected
+    // by scalar deps).
+    // CHECK: arith.constant {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    %c0 = arith.constant {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    // dest view ops outside scf.for, unified to producer's block 5.
+    // CHECK: memref.reinterpret_cast %{{.*}} {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+    %reinterpret = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [128, 64], strides: [64, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<?xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+    // CHECK: memref.subview %{{.*}} {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    %subview = memref.subview %reinterpret[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x64xf16, strided<[64, 1], offset: ?>> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+    %lb = arith.constant {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    %ub = arith.constant {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} 64 : index
+    %step = arith.constant {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} 1 : index
+    // producer and store inside scf.for.
+    scf.for %i = %lb to %ub step %step {
+      // producer stays at block 5.
+      // CHECK: arith.truncf %{{.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+      %trunc = arith.truncf %in {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xf16>
+      // data view unified to block 5.
+      // CHECK: tensor.extract_slice %{{.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+      %extract = tensor.extract_slice %trunc[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf16> to tensor<64x64xf16>
+      // store unified to block 5.
+      // CHECK: bufferization.materialize_in_destination %{{.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+      bufferization.materialize_in_destination %extract in writable %subview {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64x64xf16>, memref<64x64xf16, strided<[64, 1], offset: ?>>) -> ()
+    }
+    return
+  }
 }


### PR DESCRIPTION
# 1 Problem Description
The original planning strategy preferentially avoids V-to-C dependency but introduces C-to-V dependency. The new requirement adjusts the refining module architecture to resolve this and improve performance.

The preceding method overlooks:
1. Refine operations need not wait for Cube block completion; consequently, Cube blocks block Vector operations.
2. Algorithm determinism: The selection order of adjacent Cube blocks (or non-Vector blocks) is fixed.
This requirement improves the pruning policy and adds a pass to optimize Cube block tiling.

# 2 Solution Design

## 2.1 Refining Module Adjustment

1. Removed isUBRefineOptEnabled Flag
2. Enhanced findOpsAdjacentToCube Logic 
   - Found the first non-fusable (CUBE) op and processed all ops adjacent to it
   - Could handle multiple different CUBE blocks simultaneously


3. Added Reverse Refining: findOpsAdjacentFromCube & reverseRefineFuseGroup
Workflow:
refineFuseGroup(block, ...)        // Cut ops going TO CUBE
    ↓
reverseRefineFuseGroup(block, ...) // Cut ops coming FROM CUBE



## 2.2 MergeSmallVectorPass

Identifies small compute blocks (≤3 tensor operations) and merges them into neighboring blocks to reduce memory pressure and improve scheduling. 
1. Collect neighboring blocks
6. Multi-Strategy filter：  FaFWDPatternStrategy/ UBOccupationStrategy/IROrderStrategy/Default


## 2.3 Other Compute Optimization Pass

- SinkI1ProducersIntoUsersPass: Sinks I1 producers closer to their users to reduce register pressure and improve instruction scheduling.
- MoveLoadIntoUserPass: Moves load operations closer to their consumers to minimize memory latency and optimize data locality.
- BroadcastUBOptPass: Optimizes broadcast operations in UB (Unified Buffer) to reduce redundant data movement and improve vector efficiency

## 2.4 Load / Copy modify in  MTE3

This change ensures that cube data transfers can execute without waiting for store operations to complete, improving overall pipeline efficiency by avoiding MTE3 resource contention.



# 3 New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
