### PR TITLE
[chore](feat) Sync main from branch main-dev

### DIFF
--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -98,8 +98,7 @@ class NPUUtils(object):
                 input and the hardware actual caps.
         """
         npu_device_limit_str = os.getenv("NPU_DEVICE_LIMIT")
-        num_aic = self.get_device_aicore()
-        num_aiv = num_aic * 2
+        num_aic, num_aiv = self.get_device_core()
         if npu_device_limit_str is None:
             return num_aic, num_aiv
 
@@ -108,6 +107,7 @@ class NPUUtils(object):
             parts = [part.strip() for part in npu_device_limit_str.split(",")]
             num_aic_env = int(parts[0])
             num_aiv_env = int(parts[1])
+
             if num_aic_env <= 0 or num_aiv_env <= 0:
                 raise ValueError(f"[ERROR]NPU_DEVICE_LIMIT={npu_device_limit_str}, which has non-positive value,"
                                  f"both cube_core_num and vector_core_num must be positive.")
@@ -115,19 +115,38 @@ class NPUUtils(object):
                 raise ValueError(
                     f"[ERROR]NPU_DEVICE_LIMIT={npu_device_limit_str}, both cube_core_num and vector_core_num "
                     f"must be less than or equal to device properties ({num_aic},{num_aiv}).")
+            elif num_aic_env * (num_aiv / num_aic) != num_aiv_env:
+                env_quotient = num_aiv_env / num_aic_env
+                env_quotient_decimal = round(env_quotient, 1)
+                quotient = num_aiv / num_aic
+                quotient_decimal = round(quotient, 1)
+                raise ValueError(
+                    f"[ERROR]NPU_DEVICE_LIMIT={npu_device_limit_str}; expected ratio is consistent, actual, "
+                    f"the ratio of vector_core_num/cube_core_num({num_aiv_env}/{num_aic_env}={env_quotient_decimal}) does "
+                    f"not equal device properties vector_core_num/cube_core_num({num_aiv}/{num_aic}={quotient_decimal}) ratio."
+                )
             else:
                 print(f"[INFO]NPU_DEVICE_LIMIT from env: cube_core_num={num_aic_env},vector_core_num={num_aiv_env}).")
                 return num_aic_env, num_aiv_env
         else:
             raise ValueError(f"[ERROR]NPU_DEVICE_LIMIT={npu_device_limit_str}, which has invalid format: "
-                             f"It should be like '14,28' (cube_core_num,vector_core_num).")
+                             f"It should be like '14,28' (cube_core_num,vector_core_num) "
+                             f"and it must be a positive number.")
 
     @functools.lru_cache()
-    def get_device_aicore(self):
-        return self.npu_utils_mod.get_aicore_num()
+    def get_device_core(self):
+        import torch
+        device = torch.npu.current_device()
+        prop = torch.npu.get_device_properties(device)
+        cube_core_num, vector_core_num = prop.cube_core_num, prop.vector_core_num
+        return cube_core_num, vector_core_num
 
     def has_device_limit(self):
-        return self.get_device_aicore() != self.get_aicore_num()
+        num_aic, num_aiv = self.get_device_core()
+        try:
+            return num_aic != self.get_aicore_num() or num_aiv != self.get_aivector_core_num()
+        except ValueError:
+            return False
 
     def get_device_properties(self, device):
         # temperoarily added "max_shared_mem" properties to avoid triton-compiler complain

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -2440,13 +2440,10 @@ DotScaledConverter::matchAndRewrite(triton::DotScaledOp op, OpAdaptor adaptor,
       }
     };
 
-    auto lhsFmt = convertFormat(lhsElemType);
-    auto rhsFmt = convertFormat(rhsElemType);
-
     Value matmulMxResult = rewriter.create<hfusion::MatMulMxOp>(
         loc, dstType, lhs, rhs, lhsScale, rhsScale, acc,
-        /*lhsFormat(optional)*/ nullptr,
-        /*rhsFormat(optional)*/ nullptr);
+        /*lhsFormat(optional)*/ convertFormat(lhsElemType),
+        /*rhsFormat(optional)*/ convertFormat(rhsElemType));
 
     Value finalResult = matmulMxResult;
     if (dstType.getElementType().isBF16()) {

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/dotScaled_fp8.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/dotScaled_fp8.mlir
@@ -53,7 +53,7 @@ module {
 
 
 // CHECK-LABEL: func.func @dot_scale_fp8_kernel
-// CHECK: hfusion.matmul_mx ins
+// CHECK: hfusion.matmul_mx
 // CHECK-DAG: tensor<32x128xf8E4M3FN>
 // CHECK-DAG: tensor<128x32xf8E4M3FN>
 // CHECK-DAG: tensor<32x4xi8>

--- a/third_party/ascend/unittest/pytest_ut/test_driver.py
+++ b/third_party/ascend/unittest/pytest_ut/test_driver.py
@@ -41,7 +41,7 @@ def _make_mock_npu_utils():
     mock = MagicMock()
     # _get_npu_device_limit_form_env calls self.get_device_aicore(); configure it
     # to return a fixed int instead of binding the real lru_cached method.
-    mock.get_device_aicore.return_value = _MOCK_AICORE_NUM
+    mock.get_device_core.return_value = _MOCK_AICORE_NUM, _MOCK_AIVECTOR_NUM
     # Bind real methods (not lru_cached) so the actual parsing/property logic runs.
     mock._get_npu_device_limit_form_env = types.MethodType(NPUUtils._get_npu_device_limit_form_env, mock)
     mock.get_device_properties = types.MethodType(NPUUtils.get_device_properties, mock)
@@ -81,15 +81,24 @@ def test_npu_device_limit_env_var_valid(monkeypatch, env_value, expected_aic, ex
     "env_value",
     [
         # non-positive values
-        "0,48", "24,0", "0,0",
+        "0,48",
+        "24,0",
+        "0,0",
         # exceeds device limit
-        f"{_MOCK_AICORE_NUM + 1},{_MOCK_AIVECTOR_NUM}", f"{_MOCK_AICORE_NUM},{_MOCK_AIVECTOR_NUM + 1}", "100,200",
+        f"{_MOCK_AICORE_NUM + 1},"
+        f"{_MOCK_AIVECTOR_NUM}",
+        f"{_MOCK_AICORE_NUM},"
+        f"{_MOCK_AIVECTOR_NUM + 1}",
+        "100,200",
         # invalid format
-        "abc", "12",  # missing second value
+        "abc",
+        "12",  # missing second value
         "12,24,36",  # too many values
         "12.5,24",  # float not matched
         "",  # empty string
         "-1,48",  # negative sign not matched
+        "2,6",
+        "2,5",
     ],
 )
 def test_npu_device_limit_env_var_invalid(monkeypatch, env_value):


### PR DESCRIPTION
Description:

This PR synchronizes the main branch with main-dev, bringing in two feature enhancements that have been thoroughly reviewed and validated on the development branch.

Included Changes:

[#1284] – Increase the cube_core_num/vector_core_num ratio check

Improves device resource validation by adjusting the ratio check between cube core and vector core counts.

Ensures better compatibility with newer hardware configurations and more accurate device limit enforcement.

[#1159] – Enable format for dot scale in TritonToLinalg

Adds support for format specifiers in dot scale operations during the TritonToLinalg lowering pass.

Enables more flexible tensor contraction patterns and can unlock performance improvements for specific workloads (e.g., mixed-precision matmul with scaling).