### PR TITLE
[CI](fix) Merge tasks into one job

### DIFF
--- a/.github/workflows/auto-labeling.yml
+++ b/.github/workflows/auto-labeling.yml
@@ -13,13 +13,16 @@ concurrency:
 permissions: {}
 
 jobs:
-  # ── Ensure all expected labels exist in the repo ──
-  ensure-labels:
+  label:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
+      pull-requests: write
     steps:
-      - uses: actions/github-script@v7
+      # ── Ensure all expected labels exist in the repo ──
+      - name: Ensure labels
+        uses: actions/github-script@v7
         with:
           script: |
             const DESIRED = {
@@ -37,7 +40,6 @@ jobs:
               'release':         'Changes to release process or versioning',
             };
 
-            // Fetch existing labels
             const { data: existing } = await github.rest.issues.listLabelsForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -45,7 +47,6 @@ jobs:
             });
             const existingNames = new Set(existing.map(l => l.name));
 
-            // Create missing labels
             for (const [name, desc] of Object.entries(DESIRED)) {
               if (!existingNames.has(name)) {
                 await github.rest.issues.createLabel({
@@ -60,30 +61,17 @@ jobs:
             }
             console.log('All labels present');
 
-  # ── Regex-based issue labeling ──
-  issue:
-    if: github.event_name == 'issues'
-    needs: ensure-labels
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - uses: jimschubert/labeler-action@v2
+      # ── Issue labeling (regex match on title + body) ──
+      - if: github.event_name == 'issues'
+        uses: jimschubert/labeler-action@v2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           config_path: .github/actions/issue-labeler.yml
 
-  # ── File-path-based PR labeling ──
-  pr:
-    if: github.event_name == 'pull_request_target'
-    needs: ensure-labels
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/labeler@v5
+      # ── PR labeling (file-path glob match) ──
+      - if: github.event_name == 'pull_request_target'
+        uses: actions/labeler@v5
         with:
           configuration-path: .github/actions/labeler.yml
           sync-labels: true


### PR DESCRIPTION
### Summary

Flatten auto-labeling workflow into a single job.

Three separate jobs (`ensure-labels`, `issue`, `pr`) each had their own runner, permissions block, and `needs` dependency— unnecessary overhead for steps that never run concurrently. Merge them into one `label` job where `ensure-labels` always runs and the two labeling steps are gated by `if: github.event_name`.
