### PR TITLE
[Ascend](fix) consume SIMT auto-blockify feedback

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -22,13 +22,14 @@ import ctypes
 import functools
 import hashlib
 import glob
+import json
 import os
 import re
 import shlex
 import subprocess
 import tempfile
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Dict, Optional, Tuple, Union
@@ -434,12 +435,9 @@ def _parse_ttir_metadata(ttir: str, metadata: dict):
     metadata["mix_mode"] = "aiv"
     metadata["kernel_name"] = re.search(KERNEL_NAME_REGEX, ttir).group(1)
     metadata["name"] = metadata["kernel_name"]
-    auto_map_parallel_blocks_enabled = _is_auto_map_parallel_blocks_enabled()
     has_auto_blockify_blacklist_op = metadata.get("has_auto_blockify_blacklist_op")
-    if has_auto_blockify_blacklist_op is None and auto_map_parallel_blocks_enabled:
+    if has_auto_blockify_blacklist_op is None:
         has_auto_blockify_blacklist_op = bool(_get_auto_blockify_blacklist_reasons(ttir))
-    elif has_auto_blockify_blacklist_op is None:
-        has_auto_blockify_blacklist_op = False
     metadata["has_auto_blockify_blacklist_op"] = has_auto_blockify_blacklist_op
     # Parse all tensor kinds from arguments
     metadata["tensor_kinds"] = [int(kind) for _, kind in re.findall(TENSOR_KIND_REGEX, ttir)]
@@ -1109,6 +1107,7 @@ class NPUOptions:
 
     # superblocking factor
     superblock_factor: int = 0
+    npu_device_limit_snapshot: Optional[str] = field(default=None, init=False)
 
     def __post_init__(self):
         from triton.backends.ascend import _apply_ascend_patch
@@ -1125,6 +1124,13 @@ class NPUOptions:
             object.__setattr__(self, "parallel_mode", "simt")
 
         if self.force_simt_only:
+            object.__setattr__(self, "npu_device_limit_snapshot", os.getenv("NPU_DEVICE_LIMIT"))
+            enable_auto_blockify = self.enable_auto_blockify
+            if self.superblock_factor > 1:
+                enable_auto_blockify = True
+            elif enable_auto_blockify is None:
+                enable_auto_blockify = _is_auto_map_parallel_blocks_enabled()
+            object.__setattr__(self, "enable_auto_blockify", enable_auto_blockify)
             if self.shared_mem_dynamic_size is None:
                 object.__setattr__(self, "shared_mem_dynamic_size", 122880)
         else:
@@ -1147,9 +1153,12 @@ def ttir_to_npubin(mod, metadata, opt):
         # prepare output
         bin_file = os.path.join(tmpdir, "kernel")
         bin_path = os.path.join(tmpdir, "kernel.o")
+        triton_metadata_path = os.path.join(tmpdir, "triton-metadata.json")
         # build compile options
         _compile_option_list = get_common_bishengir_compile_options(metadata)
+        enable_auto_blockify = False
         if opt.force_simt_only:
+            _compile_option_list += [f"--triton-metadata-output={triton_metadata_path}"]
             _compile_option_list += ["--enable-hivm-compile=false"]
             _compile_option_list += ["--enable-triton-ir-compile"]
             _compile_option_list += ["--pure-simt"]
@@ -1168,28 +1177,29 @@ def ttir_to_npubin(mod, metadata, opt):
             if opt.disable_fma:
                 _compile_option_list += [f"--disable-fma"]
 
-            # Enable SIMT auto-blockify if user opted in, or if the env var is
-            # set and the user didn't explicitly opt out (matches the SIMD path
-            # at line ~541).
-            enable_auto_blockify = opt.enable_auto_blockify
-            if _is_auto_map_parallel_blocks_enabled():
-                if enable_auto_blockify is None or enable_auto_blockify:
-                    _compile_option_list += ["--enable-auto-blockify-loop"]
-            else:
-                if enable_auto_blockify:
-                    _compile_option_list += ["--enable-auto-blockify-loop"]
+            has_auto_blockify_blacklist_op = metadata.get("has_auto_blockify_blacklist_op", False)
+            if opt.superblock_factor > 1 and has_auto_blockify_blacklist_op:
+                raise ValueError(f"superblock_factor={opt.superblock_factor} requires SIMT auto blockify, "
+                                 "but the kernel contains an operation that is incompatible with auto blockify")
+            enable_auto_blockify = ((bool(opt.enable_auto_blockify) or opt.superblock_factor > 1)
+                                    and not has_auto_blockify_blacklist_op)
+            if enable_auto_blockify:
+                _compile_option_list += ["--enable-auto-blockify-loop"]
+            if opt.superblock_factor > 1:
+                _compile_option_list += [f"--super-block-factor={opt.superblock_factor}"]
+
+            if os.getenv("NPU_DEVICE_LIMIT") != opt.npu_device_limit_snapshot:
+                raise ValueError("NPU_DEVICE_LIMIT changed after the compilation options were created")
+            if opt.npu_device_limit_snapshot is not None:
+                npu_utils = NPUUtils()
+                _compile_option_list += [
+                    f"--custom-aic-number={npu_utils.get_aicore_num()}",
+                    f"--custom-aiv-number={npu_utils.get_aivector_core_num()}",
+                ]
 
             bisheng_options = metadata["bisheng_options"]
             if bisheng_options is not None:
                 _compile_option_list += [f"--append-bisheng-options={bisheng_options}"]
-
-            # Enable SIMT auto-blockify when TRITON_ALL_BLOCKS_PARALLEL is set,
-            # mirroring the SIMD compile paths. driver.py's runtime block-count
-            # cap keys off the same env switch, so the two stay in sync.
-            if _is_auto_map_parallel_blocks_enabled():
-                _compile_option_list += ["--enable-auto-blockify-loop"]
-                if opt.superblock_factor > 0:
-                    _compile_option_list += [f"--super-block-factor={opt.superblock_factor}"]
 
         npu_compiler_path, env = _get_npucompiler_path()
         cmd_list = ([npu_compiler_path, src_path] + _compile_option_list + ["-o", bin_file])
@@ -1199,6 +1209,28 @@ def ttir_to_npubin(mod, metadata, opt):
             print(f"[DEBUG] {bin_path} is not found")
             print(f"[DEBUG] Stderr:\n{error_msg}")
             raise subprocess.CalledProcessError(ret.returncode, cmd_list, ret.stdout, ret.stderr)
+        triton_metadata = json.loads(Path(triton_metadata_path).read_text())
+        if not isinstance(triton_metadata, dict):
+            raise ValueError("Triton metadata must be a JSON object")
+        has_auto_blockified = "auto_blockified" in triton_metadata
+        has_auto_blockify_block_count = "auto_blockify_block_count" in triton_metadata
+        if enable_auto_blockify and not (has_auto_blockified and has_auto_blockify_block_count):
+            raise ValueError("the NPUIR compiler does not provide SIMT auto blockify feedback")
+        auto_blockified = triton_metadata.get("auto_blockified", False)
+        auto_blockify_block_count = triton_metadata.get("auto_blockify_block_count", 0)
+        if not isinstance(auto_blockified, bool):
+            raise ValueError("Triton metadata field 'auto_blockified' must be a boolean")
+        if (isinstance(auto_blockify_block_count, bool) or not isinstance(auto_blockify_block_count, int)
+                or auto_blockify_block_count < 0):
+            raise ValueError("Triton metadata field 'auto_blockify_block_count' must be a non-negative integer")
+        if auto_blockified != (auto_blockify_block_count > 0):
+            raise ValueError("Triton metadata fields 'auto_blockified' and "
+                             "'auto_blockify_block_count' are inconsistent")
+        if opt.superblock_factor > 1 and not auto_blockified:
+            raise ValueError(f"superblock_factor={opt.superblock_factor} requires the compiler "
+                             "to confirm successful SIMT auto blockify")
+        metadata["auto_blockified"] = auto_blockified
+        metadata["auto_blockify_block_count"] = auto_blockify_block_count
         return Path(bin_path).read_bytes()
 
 
@@ -1218,7 +1250,11 @@ class AscendBackend(BaseBackend):
     def parse_options(self, opts) -> Any:
         # TODO: get available targets when building options?
         if self.target.backend == "npu":
-            args = {k: opts[k] for k in NPUOptions.__dataclass_fields__.keys() if k in opts}
+            args = {
+                name: opts[name]
+                for name, option in NPUOptions.__dataclass_fields__.items()
+                if option.init and name in opts
+            }
             args.setdefault("arch", self.target.arch)
             options = NPUOptions(**args)
             # Lazy init compile_on_910_95 if not provided

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -561,9 +561,18 @@ def make_launcher(constants, signature, metadata):
         "has_auto_blockify_blacklist_op",
         False,
     )
-    enable_auto_map_parallel_blocks = (_is_auto_map_parallel_blocks_enabled() and not has_auto_blockify_blacklist_op)
     npu_utils = NPUUtils()
     num_physical_blocks = npu_utils.get_aivector_core_num() if mix_mode == "aiv" else npu_utils.get_aicore_num()
+    if metadata.force_simt_only:
+        enable_auto_map_parallel_blocks = getattr(metadata, "auto_blockified", False)
+        auto_blockify_block_count = getattr(metadata, "auto_blockify_block_count", 0)
+        if enable_auto_map_parallel_blocks and auto_blockify_block_count <= 0:
+            raise ValueError("auto-blockified SIMT kernel is missing a valid block count")
+        block_count_limit = auto_blockify_block_count
+    else:
+        enable_auto_map_parallel_blocks = (_is_auto_map_parallel_blocks_enabled()
+                                           and not has_auto_blockify_blacklist_op)
+        block_count_limit = num_physical_blocks
     task_type, mix_block_dim_ratio = _format_of_msprof_task_type_ratio(bs_task_type, mix_mode)
     is_mix_task_type = "true" if ("MIX" in task_type) else "false"
     LINE_CHANGE_CHAR = chr(10)  # it is \n
@@ -938,7 +947,7 @@ void triton_launch_kernel(
         warned = true;
     }}
     #endif
-    {'blockNum = std::min(blockNum, (uint32_t)' + str(num_physical_blocks) + ');' if enable_auto_map_parallel_blocks else ''}
+    {'blockNum = std::min(blockNum, (uint32_t)' + str(block_count_limit) + ');' if enable_auto_map_parallel_blocks else ''}
     // set mixBlockNumRation for nodeBasicBlockDim for msprof report
     uint32_t mixBlockNumRation = {mix_block_dim_ratio};
     uint32_t nodeBasicBlockDim = (mixBlockNumRation << 16) + blockNum;
@@ -1050,7 +1059,7 @@ static void _launch(const char* kernelName, const void* func, rtStream_t stream,
         warned = true;
     }}
     #endif
-    {'blockNum = std::min(blockNum, (uint32_t)' + str(num_physical_blocks) + ');' if enable_auto_map_parallel_blocks else ''}
+    {'blockNum = std::min(blockNum, (uint32_t)' + str(block_count_limit) + ');' if enable_auto_map_parallel_blocks else ''}
     uint32_t mixBlockNumRation = {mix_block_dim_ratio};
     uint32_t nodeBasicBlockDim = (mixBlockNumRation << 16) + blockNum;
 

--- a/third_party/ascend/unittest/device_ut/test_superblock.py
+++ b/third_party/ascend/unittest/device_ut/test_superblock.py
@@ -446,9 +446,11 @@ def test_superblock_partitions_cross_warp_reduction_state(tmp_path):
     _run_case_with_timeout("shared-partition", tmp_path)
 
 
-def test_soft_barrier_product_64_yields_and_completes(tmp_path):
-    _run_case_with_timeout("product-64-yield", tmp_path)
-
-
 def test_one_warp_superblock_allows_2048_threads(tmp_path):
     _run_case_with_timeout("one-warp-2048", tmp_path)
+
+
+def test_soft_barrier_product_64_yields_and_completes(tmp_path):
+    # Keep the highest-contention case last: a device-side deadlock can poison
+    # the device context even after the host child process is terminated.
+    _run_case_with_timeout("product-64-yield", tmp_path)

--- a/third_party/ascend/unittest/device_ut/test_superblock.py
+++ b/third_party/ascend/unittest/device_ut/test_superblock.py
@@ -1,0 +1,454 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import multiprocessing
+import os
+import queue
+import signal
+import time
+import traceback
+
+import pytest
+import torch
+import torch_npu
+import triton
+import triton.language as tl
+from triton import knobs
+from triton.backends.ascend.driver import NPUUtils
+
+_COMPILE_TIMEOUT_SECONDS = 300
+_RUNTIME_TIMEOUT_SECONDS = 60
+_CHILD_EXIT_TIMEOUT_SECONDS = 30
+_CHILD_STOP_TIMEOUT_SECONDS = 10
+_SENTINEL = -777777
+
+
+@triton.jit
+def count_launches_without_program_id(counter):
+    lanes = tl.arange(0, 32)
+    tl.atomic_add(counter, 1, mask=lanes == 0)
+
+
+@triton.jit
+def task_local_barrier_tail(scratch, out, BLOCK: tl.constexpr):
+    pid = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK)
+    base = pid * BLOCK
+    linear = base + offsets
+
+    tl.store(scratch + linear, linear + 1)
+    tl.debug_barrier()
+    mirrored = tl.load(scratch + base + (BLOCK - 1 - offsets))
+
+    # Different logical tasks deliberately execute different barrier counts.
+    # A physical-block barrier can pair the even task's conditional barrier
+    # with the odd task's common barrier and then deadlock the even task.
+    if (pid % 2) == 0:
+        tl.debug_barrier()
+    tl.debug_barrier()
+    tl.debug_barrier()
+
+    tl.store(out + linear, mirrored)
+
+
+@triton.jit
+def per_task_cross_warp_reduction(out, BLOCK: tl.constexpr):
+    pid = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK)
+    values = (pid + 1) * 1000 + offsets
+    total = tl.sum(values, axis=0)
+    tl.store(out + pid, total)
+
+
+@triton.jit
+def contended_repeated_barrier(scratch, out, BLOCK: tl.constexpr, STEPS: tl.constexpr):
+    pid = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK)
+    base = pid * BLOCK
+    linear = base + offsets
+    value = linear
+
+    for _ in range(STEPS):
+        tl.store(scratch + linear, value)
+        tl.debug_barrier()
+        value = tl.load(scratch + base + ((offsets + 1) % BLOCK))
+        tl.debug_barrier()
+
+    tl.store(out + linear, value)
+
+
+@triton.jit
+def one_warp_fence_boundary(out):
+    pid = tl.program_id(0)
+    lanes = tl.arange(0, 16)
+    tl.debug_barrier()
+    tl.store(out + pid, pid + 1, mask=lanes == 0)
+
+
+def _compile_and_launch(
+    kernel,
+    grid,
+    args,
+    options,
+    result_queue,
+    *,
+    expected_auto_blockified,
+    expected_block_count,
+):
+    compiled = kernel.warmup(*args, grid=grid, **options)
+    metadata = compiled.metadata
+    assert metadata.auto_blockified is expected_auto_blockified
+    assert metadata.auto_blockify_block_count == expected_block_count
+    assert metadata.superblock_factor == options["superblock_factor"]
+    assert metadata.num_warps == options["num_warps"]
+    assert metadata.warp_size == options["warp_size"]
+
+    # Build the launcher and load the binary under the compilation/setup
+    # timeout, before the device-execution deadline begins.
+    _ = compiled.run
+    result_queue.put(("compiled", ""))
+    kernel[grid](*args, **options)
+    torch_npu.npu.synchronize()
+
+
+def _run_feedback_case(result_queue):
+    os.environ["TRITON_ALL_BLOCKS_PARALLEL"] = "1"
+    physical_blocks = NPUUtils().get_aivector_core_num()
+    assert physical_blocks > 0
+    logical_blocks = physical_blocks + 3
+    counter = torch.zeros((1,), dtype=torch.int32, device="npu")
+    options = {
+        "compile_mode": "simt_only",
+        "enable_auto_blockify": True,
+        "superblock_factor": 1,
+        "num_warps": 1,
+        "warp_size": 32,
+        # The atomic gives this no-PID kernel an observable per-launch side
+        # effect. Override Triton-Ascend's conservative blacklist so the
+        # compiler's negative AutoBlockify feedback is exercised.
+        "has_auto_blockify_blacklist_op": False,
+    }
+
+    _compile_and_launch(
+        count_launches_without_program_id,
+        (logical_blocks,),
+        (counter,),
+        options,
+        result_queue,
+        expected_auto_blockified=False,
+        expected_block_count=0,
+    )
+
+    actual = counter.cpu().item()
+    assert actual == logical_blocks, (
+        "AutoBlockify was not applied, so launch feedback must preserve the "
+        f"logical launch count; expected {logical_blocks}, got {actual}"
+    )
+
+
+def _run_tail_barrier_case(result_queue):
+    factor = 2
+    num_warps = 2
+    block = 64
+    physical_blocks = NPUUtils().get_aivector_core_num()
+    assert physical_blocks > 0
+    logical_blocks = physical_blocks * factor - 1
+    num_elements = logical_blocks * block
+    padded_elements = (logical_blocks + 1) * block
+    scratch = torch.full((padded_elements,), _SENTINEL, dtype=torch.int32, device="npu")
+    out = torch.full_like(scratch, _SENTINEL)
+    options = {
+        "compile_mode": "simt_only",
+        # A factor greater than one must override an explicit false value.
+        "enable_auto_blockify": False,
+        "superblock_factor": factor,
+        "num_warps": num_warps,
+        "warp_size": 32,
+    }
+
+    _compile_and_launch(
+        task_local_barrier_tail,
+        (logical_blocks,),
+        (scratch, out, block),
+        options,
+        result_queue,
+        expected_auto_blockified=True,
+        expected_block_count=physical_blocks,
+    )
+
+    expected = torch.arange(1, num_elements + 1, dtype=torch.int32).reshape(logical_blocks, block).flip(1)
+    actual = out.cpu()
+    torch.testing.assert_close(actual[:num_elements].reshape(logical_blocks, block), expected)
+    torch.testing.assert_close(
+        actual[num_elements:],
+        torch.full((block,), _SENTINEL, dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        scratch.cpu()[num_elements:],
+        torch.full((block,), _SENTINEL, dtype=torch.int32),
+    )
+
+
+def _run_product_64_case(result_queue):
+    factor = 16
+    num_warps = 4
+    block = 128
+    steps = 4
+    physical_blocks = NPUUtils().get_aivector_core_num()
+    assert physical_blocks > 0
+    logical_blocks = physical_blocks * factor
+    num_elements = logical_blocks * block
+    scratch = torch.empty((num_elements,), dtype=torch.int32, device="npu")
+    out = torch.empty_like(scratch)
+    options = {
+        "compile_mode": "simt_only",
+        "enable_auto_blockify": False,
+        "superblock_factor": factor,
+        "num_warps": num_warps,
+        "warp_size": 32,
+    }
+
+    _compile_and_launch(
+        contended_repeated_barrier,
+        (logical_blocks,),
+        (scratch, out, block, steps),
+        options,
+        result_queue,
+        expected_auto_blockified=True,
+        expected_block_count=physical_blocks,
+    )
+
+    expected = torch.arange(num_elements, dtype=torch.int32).reshape(logical_blocks, block).roll(-steps, dims=1)
+    torch.testing.assert_close(out.cpu().reshape(logical_blocks, block), expected)
+
+
+def _run_shared_partition_case(result_queue):
+    factor = 2
+    num_warps = 2
+    block = 64
+    physical_blocks = NPUUtils().get_aivector_core_num()
+    assert physical_blocks > 0
+    logical_blocks = physical_blocks * factor
+    out = torch.empty((logical_blocks,), dtype=torch.int32, device="npu")
+    options = {
+        "compile_mode": "simt_only",
+        "enable_auto_blockify": False,
+        "superblock_factor": factor,
+        "num_warps": num_warps,
+        "warp_size": 32,
+    }
+
+    _compile_and_launch(
+        per_task_cross_warp_reduction,
+        (logical_blocks,),
+        (out, block),
+        options,
+        result_queue,
+        expected_auto_blockified=True,
+        expected_block_count=physical_blocks,
+    )
+
+    pids = torch.arange(1, logical_blocks + 1, dtype=torch.int32)
+    expected = pids * (1000 * block) + block * (block - 1) // 2
+    torch.testing.assert_close(out.cpu(), expected)
+
+
+def _run_one_warp_2048_case(result_queue):
+    factor = 128
+    physical_blocks = NPUUtils().get_aivector_core_num()
+    assert physical_blocks > 0
+    out = torch.empty((factor,), dtype=torch.int32, device="npu")
+    options = {
+        "compile_mode": "simt_only",
+        "enable_auto_blockify": False,
+        "superblock_factor": factor,
+        "num_warps": 1,
+        "warp_size": 16,
+    }
+
+    _compile_and_launch(
+        one_warp_fence_boundary,
+        (factor,),
+        (out,),
+        options,
+        result_queue,
+        expected_auto_blockified=True,
+        expected_block_count=physical_blocks,
+    )
+
+    expected = torch.arange(1, factor + 1, dtype=torch.int32)
+    torch.testing.assert_close(out.cpu(), expected)
+
+
+_CASES = {
+    "feedback-no-program-id": _run_feedback_case,
+    "task-local-barrier-tail": _run_tail_barrier_case,
+    "shared-partition": _run_shared_partition_case,
+    "product-64-yield": _run_product_64_case,
+    "one-warp-2048": _run_one_warp_2048_case,
+}
+
+
+def _child_main(case_name, device_id, cache_dir, result_queue):
+    try:
+        os.setsid()
+        result_queue.put(("session-started", ""))
+        os.environ["TRITON_ALL_BLOCKS_PARALLEL"] = "0"
+        os.environ["TRITON_DEVICE_PRINT"] = "0"
+        os.environ["TRITON_DEBUG"] = "0"
+        os.environ["TRITON_ENABLE_TASKQUEUE"] = "0"
+        os.environ["TRITON_ALWAYS_COMPILE"] = "0"
+        os.environ["TRITON_CACHE_DIR"] = cache_dir
+        knobs.cache.dir = cache_dir
+        knobs.compilation.always_compile = False
+        knobs.runtime.debug = False
+        torch.npu.set_device(device_id)
+        _CASES[case_name](result_queue)
+    except BaseException:
+        result_queue.put(("error", traceback.format_exc()))
+    else:
+        result_queue.put(("ok", ""))
+
+
+def _stop_process(process, terminate_group=False):
+    if not process.is_alive():
+        process.join(timeout=0)
+        return True
+
+    if terminate_group:
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+    else:
+        process.terminate()
+    process.join(timeout=_CHILD_STOP_TIMEOUT_SECONDS)
+    if process.is_alive():
+        if terminate_group:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        else:
+            process.kill()
+        process.join(timeout=_CHILD_STOP_TIMEOUT_SECONDS)
+    return not process.is_alive()
+
+
+def _start_with_sanitized_environment(process, cache_dir):
+    child_environment = {
+        "TRITON_ALL_BLOCKS_PARALLEL": "0",
+        "TRITON_ALWAYS_COMPILE": "0",
+        "TRITON_CACHE_DIR": cache_dir,
+        "TRITON_COMPILE_ONLY": "0",
+        "TRITON_DEBUG": "0",
+        "TRITON_DEVICE_PRINT": "0",
+        "TRITON_ENABLE_TASKQUEUE": "0",
+        "TRITON_INTERPRET": "0",
+        "TRITON_KERNEL_OVERRIDE": "0",
+    }
+    previous = {name: os.environ.get(name) for name in child_environment}
+    try:
+        os.environ.update(child_environment)
+        process.start()
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+def _run_case_with_timeout(case_name, tmp_path):
+    device_id = torch.npu.current_device()
+    context = multiprocessing.get_context("spawn")
+    result_queue = context.Queue()
+    cache_dir = str(tmp_path / f"triton-cache-{case_name}")
+    process = context.Process(
+        target=_child_main,
+        args=(case_name, device_id, cache_dir, result_queue),
+    )
+    _start_with_sanitized_environment(process, cache_dir)
+
+    child_session_started = False
+    try:
+        phase = "compilation and runtime setup"
+        deadline = time.monotonic() + _COMPILE_TIMEOUT_SECONDS
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                stopped = _stop_process(process, terminate_group=child_session_started)
+                suffix = "" if stopped else "; child could not be stopped"
+                pytest.fail(f"{case_name} timed out during {phase}{suffix}")
+
+            try:
+                status, payload = result_queue.get(timeout=min(0.5, remaining))
+            except queue.Empty:
+                if process.is_alive():
+                    continue
+                process.join(timeout=0)
+                pytest.fail(f"{case_name} exited with code {process.exitcode} without reporting a result")
+
+            if status == "session-started":
+                child_session_started = True
+                continue
+
+            if status == "compiled":
+                phase = "device execution"
+                deadline = time.monotonic() + _RUNTIME_TIMEOUT_SECONDS
+                continue
+
+            process.join(timeout=_CHILD_EXIT_TIMEOUT_SECONDS)
+            child_still_alive = process.is_alive()
+            if child_still_alive:
+                _stop_process(process, terminate_group=child_session_started)
+
+            if status == "error":
+                pytest.fail(payload)
+            assert status == "ok", f"unexpected child status: {status}"
+            assert not child_still_alive, f"{case_name} reported success but did not exit"
+            assert process.exitcode == 0
+            return
+    finally:
+        _stop_process(process, terminate_group=child_session_started)
+        result_queue.cancel_join_thread()
+        result_queue.close()
+        if not process.is_alive():
+            process.close()
+
+
+def test_auto_blockify_feedback_preserves_grid_without_program_id(tmp_path):
+    _run_case_with_timeout("feedback-no-program-id", tmp_path)
+
+
+def test_superblock_factor_forces_task_local_barrier_for_tail(tmp_path):
+    _run_case_with_timeout("task-local-barrier-tail", tmp_path)
+
+
+def test_superblock_partitions_cross_warp_reduction_state(tmp_path):
+    _run_case_with_timeout("shared-partition", tmp_path)
+
+
+def test_soft_barrier_product_64_yields_and_completes(tmp_path):
+    _run_case_with_timeout("product-64-yield", tmp_path)
+
+
+def test_one_warp_superblock_allows_2048_threads(tmp_path):
+    _run_case_with_timeout("one-warp-2048", tmp_path)

--- a/third_party/ascend/unittest/pytest_ut/test_auto_blockify_feedback.py
+++ b/third_party/ascend/unittest/pytest_ut/test_auto_blockify_feedback.py
@@ -1,0 +1,257 @@
+import importlib
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from collections import namedtuple
+from pathlib import Path
+from types import SimpleNamespace
+
+_ASCEND_PACKAGE_NAME = "triton.backends.ascend"
+_ASCEND_DEPENDENCIES = (
+    (f"{_ASCEND_PACKAGE_NAME}.backend_register", "backend_register", "backend_register.py"),
+    (f"{_ASCEND_PACKAGE_NAME}.utils", "utils", "utils.py"),
+    (f"{_ASCEND_PACKAGE_NAME}.driver", "driver", "driver.py"),
+)
+_COMPILER_MODULE_NAME = "ascend_compiler_auto_blockify_under_test"
+_CHILD_MODE = "--auto-blockify-feedback-child"
+
+
+def _ascend_module_state():
+    return {
+        name: module
+        for name, module in sys.modules.items()
+        if name == _ASCEND_PACKAGE_NAME or name.startswith(f"{_ASCEND_PACKAGE_NAME}.")
+    }
+
+
+def _load_compiler_module():
+    backend_dir = Path(__file__).resolve().parents[2] / "backend"
+    importlib.import_module("triton")
+    ascend_package = importlib.import_module(_ASCEND_PACKAGE_NAME)
+
+    for name, attribute, filename in _ASCEND_DEPENDENCIES:
+        dependency_spec = importlib.util.spec_from_file_location(name, backend_dir / filename)
+        dependency = importlib.util.module_from_spec(dependency_spec)
+        assert dependency_spec.loader is not None
+        sys.modules[name] = dependency
+        setattr(ascend_package, attribute, dependency)
+        dependency_spec.loader.exec_module(dependency)
+
+    spec = importlib.util.spec_from_file_location(_COMPILER_MODULE_NAME, backend_dir / "compiler.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeModule:
+
+    def __str__(self):
+        return "module {}"
+
+
+def _make_fake_run(payload, seen_command):
+
+    def fake_run(command, **kwargs):
+        seen_command.extend(command)
+        output_base = Path(command[command.index("-o") + 1])
+        output_base.with_suffix(".o").write_bytes(b"npubin")
+        metadata_arg = next(arg for arg in command if arg.startswith("--triton-metadata-output="))
+        metadata_path = Path(metadata_arg.split("=", 1)[1])
+        metadata_path.write_text(json.dumps(payload))
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    return fake_run
+
+
+def _compile(compiler, options, payload=None, has_blacklist=False):
+    seen_command = []
+    compiler.subprocess.run = _make_fake_run({} if payload is None else payload, seen_command)
+    metadata = {
+        "bisheng_options": None,
+        "has_auto_blockify_blacklist_op": has_blacklist,
+    }
+    result = compiler.ttir_to_npubin(_FakeModule(), metadata, options)
+    return result, metadata, seen_command
+
+
+def _run_auto_blockify_feedback_child():
+    compiler = _load_compiler_module()
+    compiler._parse_ttir_metadata = lambda code, metadata: metadata
+    compiler.get_common_bishengir_compile_options = lambda metadata: []
+    compiler._get_npucompiler_path = lambda: ("bishengir-compile", {})
+
+    class UnlimitedNPUUtils:
+
+        def has_device_limit(self):
+            return False
+
+    compiler.NPUUtils = UnlimitedNPUUtils
+    os.environ.pop("NPU_DEVICE_LIMIT", None)
+    compiler._is_auto_map_parallel_blocks_enabled = lambda: True
+    compiler.get_cann_version_file_hash = lambda: "fixed-cann"
+    default_options = compiler.NPUOptions(compile_mode="simt_only")
+    assert default_options.enable_auto_blockify is True
+    assert compiler.NPUOptions(compile_mode="simd").enable_auto_blockify is None
+    result, metadata, command = _compile(
+        compiler,
+        default_options,
+        {"auto_blockified": True, "auto_blockify_block_count": 64},
+    )
+    assert result == b"npubin"
+    assert command.count("--enable-auto-blockify-loop") == 1
+    assert metadata["auto_blockified"] is True
+    assert metadata["auto_blockify_block_count"] == 64
+
+    disabled_options = compiler.NPUOptions(
+        compile_mode="simt_only",
+        enable_auto_blockify=False,
+        superblock_factor=1,
+    )
+    assert disabled_options.enable_auto_blockify is False
+    _, metadata, command = _compile(compiler, disabled_options)
+    assert "--enable-auto-blockify-loop" not in command
+    assert not any(arg.startswith("--super-block-factor=") for arg in command)
+    assert metadata["auto_blockified"] is False
+    assert metadata["auto_blockify_block_count"] == 0
+
+    blacklisted_options = compiler.NPUOptions(
+        compile_mode="simt_only",
+        enable_auto_blockify=True,
+    )
+    _, _, command = _compile(compiler, blacklisted_options, has_blacklist=True)
+    assert "--enable-auto-blockify-loop" not in command
+
+    compiler._is_auto_map_parallel_blocks_enabled = lambda: False
+    env_disabled_options = compiler.NPUOptions(compile_mode="simt_only")
+    assert env_disabled_options.enable_auto_blockify is False
+    assert env_disabled_options.hash() != default_options.hash()
+    explicit_options = compiler.NPUOptions(
+        compile_mode="simt_only",
+        enable_auto_blockify=True,
+    )
+    _, _, command = _compile(
+        compiler,
+        explicit_options,
+        {"auto_blockified": True, "auto_blockify_block_count": 64},
+    )
+    assert command.count("--enable-auto-blockify-loop") == 1
+    _, metadata, command = _compile(
+        compiler,
+        explicit_options,
+        {"auto_blockified": False, "auto_blockify_block_count": 0},
+    )
+    assert command.count("--enable-auto-blockify-loop") == 1
+    assert metadata["auto_blockified"] is False
+    assert metadata["auto_blockify_block_count"] == 0
+    try:
+        _compile(compiler, explicit_options)
+    except ValueError as error:
+        assert "does not provide SIMT auto blockify feedback" in str(error)
+    else:
+        raise AssertionError("requested auto blockify without compiler feedback must be rejected")
+
+    os.environ["NPU_DEVICE_LIMIT"] = "20,40"
+    limited_options = compiler.NPUOptions(
+        compile_mode="simt_only",
+        enable_auto_blockify=True,
+    )
+    assert limited_options.hash() != explicit_options.hash()
+    assert str(limited_options) != str(explicit_options)
+    assert "npu_device_limit_snapshot='20,40'" in str(limited_options)
+    metadata_type = namedtuple("KernelMetadata", limited_options.__dict__.keys())
+    metadata_type(**limited_options.__dict__)
+
+    class LimitedNPUUtils:
+
+        def has_device_limit(self):
+            return False
+
+        def get_aicore_num(self):
+            return 20
+
+        def get_aivector_core_num(self):
+            return 40
+
+    compiler.NPUUtils = LimitedNPUUtils
+    _, _, command = _compile(
+        compiler,
+        limited_options,
+        {"auto_blockified": True, "auto_blockify_block_count": 40},
+    )
+    assert command.count("--custom-aic-number=20") == 1
+    assert command.count("--custom-aiv-number=40") == 1
+    os.environ.pop("NPU_DEVICE_LIMIT")
+    compiler.NPUUtils = UnlimitedNPUUtils
+
+    superblock_options = compiler.NPUOptions(
+        compile_mode="simt_only",
+        enable_auto_blockify=False,
+        superblock_factor=2,
+    )
+    assert superblock_options.enable_auto_blockify is True
+    _, _, command = _compile(
+        compiler,
+        superblock_options,
+        {"auto_blockified": True, "auto_blockify_block_count": 64},
+    )
+    assert command.count("--enable-auto-blockify-loop") == 1
+    assert command.count("--super-block-factor=2") == 1
+
+    try:
+        _compile(
+            compiler,
+            superblock_options,
+            {"auto_blockified": False, "auto_blockify_block_count": 0},
+        )
+    except ValueError as error:
+        assert "confirm successful SIMT auto blockify" in str(error)
+    else:
+        raise AssertionError("superblocking without compiler confirmation must be rejected")
+
+    try:
+        _compile(compiler, superblock_options, has_blacklist=True)
+    except ValueError as error:
+        assert "superblock_factor=2" in str(error)
+    else:
+        raise AssertionError("blacklisted superblocking must be rejected")
+
+    invalid_payloads = (
+        ([], "JSON object"),
+        ({"auto_blockified": "true", "auto_blockify_block_count": 64}, "must be a boolean"),
+        ({"auto_blockified": True, "auto_blockify_block_count": True}, "non-negative integer"),
+        ({"auto_blockified": False, "auto_blockify_block_count": 64}, "are inconsistent"),
+    )
+    for payload, expected_message in invalid_payloads:
+        try:
+            _compile(compiler, explicit_options, payload)
+        except ValueError as error:
+            assert expected_message in str(error)
+        else:
+            raise AssertionError(f"invalid metadata payload was accepted: {payload!r}")
+
+
+def test_auto_blockify_feedback_contract():
+    original_ascend_modules = _ascend_module_state()
+    completed = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve()), _CHILD_MODE],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    restored_ascend_modules = _ascend_module_state()
+
+    assert restored_ascend_modules.keys() == original_ascend_modules.keys()
+    assert all(restored_ascend_modules[name] is module for name, module in original_ascend_modules.items())
+    assert completed.returncode == 0, ("auto-blockify feedback child failed\n"
+                                       f"stdout:\n{completed.stdout}\n"
+                                       f"stderr:\n{completed.stderr}")
+
+
+if __name__ == "__main__":
+    if sys.argv[1:] != [_CHILD_MODE]:
+        raise SystemExit(f"expected private child mode {_CHILD_MODE}")
+    _run_auto_blockify_feedback_child()

--- a/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
+++ b/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 
 def _load_driver_module():
     driver_path = Path(__file__).resolve().parents[2] / "backend" / "driver.py"
@@ -34,6 +36,8 @@ def _make_metadata():
         debug=False,
         coalesce_factor=1,
         coalesce_axis=-1,
+        auto_blockified=False,
+        auto_blockify_block_count=0,
     )
 
 
@@ -95,6 +99,48 @@ def test_make_launcher_shrinks_coalesced_grid_for_both_launch_paths(
     )
 
     assert src.count("gridY = gridY / 16;") == 2
+
+
+@patch.object(driver, "NPUUtils")
+@patch.object(driver, "_is_auto_map_parallel_blocks_enabled", return_value=True)
+@patch.object(driver, "force_disable_ffts", return_value=False)
+@patch.object(driver, "is_ffts_supported", return_value=True)
+@patch.object(driver, "get_ascend_arch_from_env", return_value="Ascend910B")
+@patch.object(driver, "get_backend_func", side_effect=_mock_backend_func)
+def test_make_launcher_uses_authoritative_simt_auto_blockify_feedback(
+    _mock_backend_func_patch,
+    _mock_arch,
+    _mock_ffts,
+    _mock_disable_ffts,
+    _mock_auto_map,
+    mock_npu_utils,
+):
+    mock_npu_utils.return_value.get_aivector_core_num.return_value = 40
+    mock_npu_utils.return_value.get_aicore_num.return_value = 20
+
+    simt_metadata = _make_metadata()
+    simt_metadata.force_simt_only = True
+    simt_metadata.parallel_mode = "simt"
+    simt_metadata.auto_blockified = True
+    simt_metadata.auto_blockify_block_count = 64
+    _mock_auto_map.return_value = False
+    src = driver.make_launcher(constants={}, signature={}, metadata=simt_metadata)
+    assert src.count("blockNum = std::min(blockNum, (uint32_t)64);") == 2
+
+    simt_metadata.auto_blockified = False
+    simt_metadata.auto_blockify_block_count = 0
+    _mock_auto_map.return_value = True
+    src = driver.make_launcher(constants={}, signature={}, metadata=simt_metadata)
+    assert "blockNum = std::min(blockNum" not in src
+
+    simd_metadata = _make_metadata()
+    src = driver.make_launcher(constants={}, signature={}, metadata=simd_metadata)
+    assert src.count("blockNum = std::min(blockNum, (uint32_t)40);") == 2
+
+    simt_metadata.auto_blockified = True
+    simt_metadata.auto_blockify_block_count = 0
+    with pytest.raises(ValueError, match="missing a valid block count"):
+        driver.make_launcher(constants={}, signature={}, metadata=simt_metadata)
 
 
 @patch("importlib.util.module_from_spec")


### PR DESCRIPTION
## Why

SIMT auto-blockify is optional: the compiler may decline to transform a kernel, for example when the kernel has no program ID. The launcher previously inferred whether to shrink the physical grid from host-side configuration, so host and compiler decisions could diverge.

## What changed

- Request and validate compiler feedback through `auto_blockified` and `auto_blockify_block_count`.
- Cap pure-SIMT launches only when the compiler confirms the transformation, using the exact reported physical block count.
- Make `superblock_factor > 1` require auto-blockify and reject blacklist, missing, failed, or inconsistent feedback.
- Preserve explicit disable behavior when the factor is 1, and include `NPU_DEVICE_LIMIT` in backend option hashing while forwarding matching core counts to compilation.
- Add no-device regressions for option precedence, blacklist behavior, metadata validation, device limits, failed/no-op transforms, superblock requirements, and both launcher paths.

## Integration and compatibility

This PR requires a compiler that accepts `--triton-metadata-output` and emits both feedback fields. The companion contract is provided by [AscendNPU-IR !2060](https://gitcode.com/Ascend/AscendNPU-IR/merge_requests/2060); merge or deploy that compiler change before this one.

`NPU_DEVICE_LIMIT` and `TRITON_ALL_BLOCKS_PARALLEL` remain process-lifetime configuration. Changing either after a kernel has entered the in-memory JIT cache is unsupported, matching the existing environment-driven behavior.

## Validation

- `python -m pytest -q --noconftest third_party/ascend/unittest/pytest_ut/test_auto_blockify_feedback.py third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py` — 5 passed
- `python -m ruff check` on both changed test files — passed
- `python -m py_compile` on both backend files and both test files — passed
- `pre-commit run --from-ref github-upstream/main --to-ref HEAD` — passed
- `git diff --check github-upstream/main...HEAD` — passed

Device validation was not available on this machine.

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following the linked rules.
- [x] I have run pre-commit for the changed range.
- [x] I have added tests under `third_party/ascend/unittest`.
- [x] I have not added any lit tests.