### PR TITLE
[dot](feat) rollback dot modify

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2019,10 +2019,17 @@ def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_i
       specified (i.e. at least one must be :code:`None`).
     """
     assert input_precision is None or allow_tf32 is None, "Only one of input_precision and allow_tf32 can be specified"
+    assert not allow_tf32, "allow_tf32 is not supported as 'True', please use fp32 on Ascend instead."
     if input_precision is None:
         supports_tf32 = "tf32" in _semantic.builder.options.allowed_dot_input_precisions
         input_precision = knobs.language.fp32_default or ("tf32" if (supports_tf32 and
                                                                      (allow_tf32 or allow_tf32 is None)) else "ieee")
+        # when setting allow_tf32, use input_precision='hf32' on Ascend instead.
+        if allow_tf32:
+            input_precision = "hf32"
+    else:
+        if input_precision == "tf32":
+            input_precision = "hf32"
 
     input_precision = _unwrap_if_constexpr(input_precision)
     out_dtype = _unwrap_if_constexpr(out_dtype)


### PR DESCRIPTION
Objective: The pass will handle invasive dot operator modifications uniformly.
Status quo: Post-processing, some test cases fail in specific scenarios, causing accuracy issues.
Solution: Invasive modifications are currently added to ensure test case passage; the solution will be implemented after refinement.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
