### PR TITLE
[ssbuffer](feat) merge computeBlock for swa kernel

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -225,6 +225,7 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
             metadata["disable_auto_inject_block_sync"] = True
             ascend.passes.ttir.set_enable_cube_block_merge(metadata["enable_cube_block_merge"])
             ascend.passes.ttir.set_enable_ub_refine_opt(mod, metadata["enable_ub_refine_opt"])
+            ascend.passes.ttir.set_enable_merge_compute_block(metadata["enable_merge_compute_block"])
 
             # Must run before add_dynamic_cv_pipeline because the driven
             # AddMultiBufferInnerScope pass reads the module-level
@@ -990,6 +991,7 @@ class NPUOptions:
     # matmul's loader for-loop into the matmul's cube compute block.
     enable_cube_block_merge: bool = False
     enable_ub_refine_opt: bool = False
+    enable_merge_compute_block: bool = False
     # Multi-cache insertion optimization: avoid redundant tensor compute in the middle of an `if`.
     enable_buffer_insert_optimization: bool = False
     hfusion_enable_multiple_consumer_fusion: bool = False

--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -90,6 +90,9 @@ bool isCubeBlockMergeEnabled();
 void setEnableUBRefineOpt(bool enable);
 bool isUBRefineOptEnabled();
 
+void setEnableMergeComputeBlock(bool enable);
+bool isMergeComputeBlockEnabled();
+
 // Functions for managing core types
 CoreType getOpCoreType(Operation *op);
 std::optional<int> getOpBlockId(Operation *op);

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
@@ -37,6 +37,7 @@ void registerMergeVectorIfBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createMergeCubeForBlockPass();
 void registerMergeCubeForBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createFixpipeOptPass();
+std::unique_ptr<OperationPass<ModuleOp>> createMergeComputeBlockPass();
 
 } // namespace triton
 } // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -19,6 +19,7 @@ namespace CVPipeline {
 
 static bool g_enableCubeBlockMerge = true;
 static bool g_enableUBRefineOpt = false;
+static bool g_enableMergeComputeBlock = false;
 
 void setEnableCubeBlockMerge(bool enable)
 {
@@ -28,6 +29,16 @@ void setEnableCubeBlockMerge(bool enable)
 bool isCubeBlockMergeEnabled()
 {
     return g_enableCubeBlockMerge;
+}
+
+void setEnableMergeComputeBlock(bool enable)
+{
+    g_enableMergeComputeBlock = enable;
+}
+
+bool isMergeComputeBlockEnabled()
+{
+    return g_enableMergeComputeBlock;
 }
 
 CoreType getOpCoreType(Operation *op)

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeComputeBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeComputeBlockPass.cpp
@@ -1,0 +1,490 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+
+#include "DynamicCVPipeline/Common/Utils.h"
+
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+static constexpr const char *DEBUG_TYPE = "merge-compute-block";
+#define LOG_DEBUG(...) LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
+
+using namespace mlir;
+using namespace triton;
+
+// ============================================================================
+// Data Structures
+// ============================================================================
+
+/// Represents a ComputeBlock: a group of ops sharing the same block_id
+struct ComputeBlock {
+    int id;                            // block_id value
+    CVPipeline::CoreType coreType;     // CUBE_ONLY / VECTOR_ONLY
+    SmallVector<Operation *> ops;      // all ops in the group (in IR order)
+};
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/// Trace upward from value along its definition chain (through view-like ops), collecting ops within C2
+static void traceUpwardFromValue(Value value,
+                                 const DenseMap<int, ComputeBlock> &computeBlocks,
+                                 int c2Id, SmallPtrSet<Operation *, 16> &collected)
+{
+    auto c2It = computeBlocks.find(c2Id);
+    if (c2It == computeBlocks.end()) {
+        return;
+    }
+    DenseSet<Operation *> c2OpsSet(c2It->second.ops.begin(), c2It->second.ops.end());
+
+    Value cur = value;
+    while (Operation *defOp = cur.getDefiningOp()) {
+        if (!c2OpsSet.contains(defOp)) {
+            break;  // not in C2, stop
+        }
+        if (!collected.insert(defOp).second) {
+            break;  // already collected
+        }
+
+        if (auto viewLike = dyn_cast<ViewLikeOpInterface>(defOp)) {
+            Value source = viewLike.getViewSource();
+            // trace other operands of the view (e.g. scalar ops like offset/size for subview)
+            for (Value operand : defOp->getOperands()) {
+                if (operand != source) {
+                    traceUpwardFromValue(operand, computeBlocks, c2Id, collected);
+                }
+            }
+            cur = source;  // pass through source, continue upward
+            continue;
+        }
+
+        // non-view op, recursively trace each operand
+        for (Value subOperand : defOp->getOperands()) {
+            traceUpwardFromValue(subOperand, computeBlocks, c2Id, collected);
+        }
+        break;
+    }
+}
+
+// ============================================================================
+// Sub-function Implementations
+// ============================================================================
+
+/// Collect the body Blocks of the innermost scf::ForOp that contain linalg::MatmulOp in ModuleOp (deduplicated).
+static void collectInnermostMatmulLoopBlocks(ModuleOp module, SmallVectorImpl<Block *> &blocks)
+{
+    DenseSet<Block *> seen;
+    module->walk([&](linalg::MatmulOp matmul) {
+        Operation *parent = matmul->getParentOp();
+        while (parent) {
+            if (auto forOp = dyn_cast<scf::ForOp>(parent)) {
+                Block *body = forOp.getBody();
+                if (seen.insert(body).second) {
+                    blocks.push_back(body);
+                }
+                break;
+            }
+            parent = parent->getParentOp();
+        }
+    });
+}
+
+/// Step 1+2: Group ops and build block-level SSA dependency graph.
+/// computeBlocks: output, block_id → ComputeBlock
+/// succs/preds: output, block_id → successor/predecessor block_id list
+static void groupAndBuildGraph(Block *block, DenseMap<int, ComputeBlock> &computeBlocks,
+                               DenseMap<int, SmallVector<int>> &succs,
+                               DenseMap<int, SmallVector<int>> &preds)
+{
+    // Step 1: Walk all ops in the body block and its nested regions, group by block_id
+    block->walk([&](Operation *op) {
+        if (op->hasTrait<OpTrait::IsTerminator>()) {
+            return;
+        }
+        auto optId = CVPipeline::getOpBlockId(op);
+        if (!optId.has_value()) {
+            return;
+        }
+        int bid = *optId;
+        auto it = computeBlocks.find(bid);
+        if (it == computeBlocks.end()) {
+            computeBlocks[bid] = {bid, CVPipeline::getOpCoreType(op), {}};
+        }
+        computeBlocks[bid].ops.push_back(op);
+    });
+
+    if (computeBlocks.empty()) {
+        return;
+    }
+
+    // Step 2: Build SSA dependency graph between ComputeBlocks
+    DenseSet<std::pair<int, int>> seenEdges;
+    for (auto &kv : computeBlocks) {
+        int curId = kv.first;
+        for (Operation *op : kv.second.ops) {
+            for (Value operand : op->getOperands()) {
+                Operation *defOp = operand.getDefiningOp();
+                if (!defOp) {
+                    continue; // block argument
+                }
+                Operation *ancestor = CVPipeline::getAncestorInBlock(defOp, block);
+                if (!ancestor) {
+                    continue; // not in this block
+                }
+                auto ancIdOpt = CVPipeline::getOpBlockId(ancestor);
+                if (!ancIdOpt.has_value()) {
+                    continue;
+                }
+                int ancId = *ancIdOpt;
+                if (ancId == curId) {
+                    continue; // same ComputeBlock internal edge
+                }
+
+                if (!seenEdges.insert({ancId, curId}).second) {
+                    continue;
+                }
+                succs[ancId].push_back(curId);
+                preds[curId].push_back(ancId);
+            }
+        }
+    }
+}
+
+/// Step 3: Find exactly 2 candidate VECTOR blocks, and determine pred / succ.
+/// pred: source of the VECTOR → VECTOR edge, succ: destination
+/// Returns true if valid pred/succ found, false otherwise
+static bool findPredAndSuccVec(const DenseMap<int, ComputeBlock> &computeBlocks,
+                            const DenseMap<int, SmallVector<int>> &succs,
+                            const DenseMap<int, SmallVector<int>> &preds,
+                            int &predVId, int &succVId)
+{
+    auto hasCUBEPred = [&](int bid) {
+        auto it = preds.find(bid);
+        if (it == preds.end()) return false;
+        for (int p : it->second) {
+            if (computeBlocks.lookup(p).coreType == CVPipeline::CoreType::CUBE_ONLY) {
+                return true;
+            }
+        }
+        return false;
+    };
+    auto hasCUBESucc = [&](int bid) {
+        auto it = succs.find(bid);
+        if (it == succs.end()) return false;
+        for (int s : it->second) {
+            if (computeBlocks.lookup(s).coreType == CVPipeline::CoreType::CUBE_ONLY) {
+                return true;
+            }
+        }
+        return false;
+    };
+    auto hasTensorResult = [&](const ComputeBlock &blk) {
+        for (Operation *op : blk.ops) {
+            for (Value result : op->getResults()) {
+                if (isa<TensorType>(result.getType())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    };
+
+    // Collect candidates
+    DenseSet<int> candidates;
+    for (auto &kv : computeBlocks) {
+        if (kv.second.coreType != CVPipeline::CoreType::VECTOR_ONLY) {
+            continue;
+        }
+        if (!hasCUBEPred(kv.first) || !hasCUBESucc(kv.first)) {
+            continue;
+        }
+        if (!hasTensorResult(kv.second)) {
+            continue;
+        }
+        candidates.insert(kv.first);
+    }
+
+    if (candidates.size() != 2) {
+        LOG_DEBUG("Found " << candidates.size() << " candidate(s), need exactly 2");
+        return false;
+    }
+
+    // Determine pred / succ: along the VECTOR → VECTOR edge, source is pred
+    for (int u : candidates) {
+        if (auto it = succs.find(u); it != succs.end()) {
+            for (int v : it->second) {
+                if (candidates.contains(v)) { // successor v is also a candidate VECTOR block
+                    predVId = u;
+                    succVId = v;
+                    LOG_DEBUG("pred=" << predVId << ", succ=" << succVId);
+                    return true;
+                }
+            }
+        }
+    }
+
+    LOG_DEBUG("Two candidate VECTOR blocks have no direct edge between them");
+    return false;
+}
+
+/// Step 4: Determine C2 and C3
+/// C2: the direct CUBE successor of pred
+/// C3: the direct CUBE successor of C2
+/// Returns true if C2/C3 successfully found
+static bool findC2AndC3(const DenseMap<int, ComputeBlock> &computeBlocks,
+                        const DenseMap<int, SmallVector<int>> &succs,
+                        int predVId, int &c2Id, int &c3Id)
+{
+    // Find C2: predVector's CUBE successor
+    c2Id = -1;
+    if (auto it = succs.find(predVId); it != succs.end()) {
+        for (int s : it->second) {
+            if (computeBlocks.lookup(s).coreType == CVPipeline::CoreType::CUBE_ONLY) {
+                c2Id = s; // get predVector's cube_succs
+                break;
+            }
+        }
+    }
+    if (c2Id == -1) {
+        LOG_DEBUG("pred " << predVId << " has no CUBE successor (C2)");
+        return false;
+    }
+
+    // Find C3: C2's CUBE successor
+    c3Id = -1;
+    if (auto it = succs.find(c2Id); it != succs.end()) {
+        for (int s : it->second) {
+            if (computeBlocks.lookup(s).coreType == CVPipeline::CoreType::CUBE_ONLY) {
+                c3Id = s; // get c2's succs: c3
+                break;
+            }
+        }
+    }
+    if (c3Id == -1) {
+        LOG_DEBUG("C2 " << c2Id << " has no CUBE successor (C3)");
+        return false;
+    }
+
+    LOG_DEBUG("C2=" << c2Id << ", C3=" << c3Id);
+    return true;
+}
+
+/// Find the first bufferization::ToTensorOp in C2
+static Operation *findToTensorInC2(const ComputeBlock &c2Block) {
+    for (Operation *op : c2Block.ops) {
+        if (isa<bufferization::ToTensorOp>(op)) {
+            return op;
+        }
+    }
+    return nullptr;
+}
+
+/// Step 5: Clone ops from C2 that C3 depends on into C3
+static void cloneOpsToC3(const DenseMap<int, ComputeBlock> &computeBlocks,
+                         int c2Id, int c3Id, Block *block,
+                         CVPipeline::ComputeBlockIdManager &bm)
+{
+    LOG_DEBUG("cloneOpsToC3: c2Id=" << c2Id << ", c3Id=" << c3Id);
+
+    auto c2It = computeBlocks.find(c2Id);
+    auto c3It = computeBlocks.find(c3Id);
+    if (c2It == computeBlocks.end() || c3It == computeBlocks.end()) {
+        LOG_DEBUG("C2 or C3 not found in computeBlocks");
+        return;
+    }
+    const auto &c2Block = c2It->second;
+    const auto &c3Block = c3It->second;
+
+    if (c3Block.ops.empty()) {
+        LOG_DEBUG("C3 block has no ops, skip");
+        return;
+    }
+
+    // Step 5.1: Find the first bufferization.to_tensor op that C3 depends on (defined in C2)
+    Operation *toTensor = findToTensorInC2(c2Block);
+    if (!toTensor) {
+        LOG_DEBUG("C3 does not depend on any to_tensor from C2");
+        return;
+    }
+
+    // Step 5.2: Collect ops that need to be cloned (to_tensor + memref.copy and their upstream)
+    SmallPtrSet<Operation *, 16> opsToClone;
+    opsToClone.insert(toTensor);
+
+    for (Operation *op : c2Block.ops) {
+        if (!isa<memref::CopyOp>(op)) {
+            continue;
+        }
+        opsToClone.insert(op);  // copy itself
+        // trace upward from each operand of copy
+        for (Value operand : op->getOperands()) {
+            traceUpwardFromValue(operand, computeBlocks, c2Id, opsToClone);
+        }
+    }
+
+    if (opsToClone.size() == 1) {
+        LOG_DEBUG("Only to_tensor ops to clone, no memref.copy found, skip");
+        return;
+    }
+
+    Operation *insertBefore = c3Block.ops.front();
+    OpBuilder builder(insertBefore);
+    IRMapping mapper;
+    for (Operation *op : c2Block.ops) {
+        if (!opsToClone.contains(op)) continue;
+        Operation *cloned = builder.clone(*op, mapper);
+        bm.updateBlockId(cloned, c3Id);
+    }
+
+    // Remap C3's original ops' operands: replace references to old C2 values
+    // with the corresponding cloned values now in C3.
+    for (Operation *op : c3Block.ops) {
+        if (opsToClone.contains(op)) {
+            continue;
+        }
+        for (auto &operand : op->getOpOperands()) {
+            if (Value mapped = mapper.lookupOrNull(operand.get())) {
+                operand.set(mapped);
+            }
+        }
+    }
+
+    LOG_DEBUG("Cloned " << opsToClone.size() << " ops from C2(" << c2Id
+                        << ") to C3(" << c3Id << ")");
+}
+
+/// Execute the merge pipeline on a Block: group → build graph → find pred/succ → determine C2/C3 → clone ops → merge VECTOR
+///   c1 → c2 → c3 → c4
+///    ↓    ↑    ↓    ↑
+///      v1   →    v2
+static void tryMergeInBlock(Block *block, CVPipeline::ComputeBlockIdManager &bm)
+{
+    // Step 1+2: Group and build dependency graph
+    DenseMap<int, ComputeBlock> computeBlocks;
+    DenseMap<int, SmallVector<int>> succs;
+    DenseMap<int, SmallVector<int>> preds;
+    groupAndBuildGraph(block, computeBlocks, succs, preds);
+
+    if (computeBlocks.empty()) {
+        return;
+    }
+
+    // Step 3: Find two candidate VECTOR blocks and determine pred / succ
+    int predVId = -1, succVId = -1;
+    if (!findPredAndSuccVec(computeBlocks, succs, preds, predVId, succVId)) {
+        return;
+    }
+
+    // Step 4: Determine C2, C3
+    int c2Id = -1, c3Id = -1;
+    if (!findC2AndC3(computeBlocks, succs, predVId, c2Id, c3Id)) {
+        return;
+    }
+
+    // Step 5: Clone ops from C2 that C3 depends on into C3
+    cloneOpsToC3(computeBlocks, c2Id, c3Id, block, bm);
+
+    // Step 6: Merge adjacent VECTOR blocks (rewrite succVId's block_id to predVId)
+    auto succIt = computeBlocks.find(succVId);
+    if (succIt != computeBlocks.end()) {
+        for (Operation *op : succIt->second.ops) {
+            bm.updateBlockId(op, predVId);
+        }
+    }
+    LOG_DEBUG("Merged VECTOR blocks: pred=" << predVId << ", succ=" << succVId
+              << " -> target=" << predVId);
+}
+
+// ============================================================================
+// Pass Definition
+// ============================================================================
+
+namespace {
+
+class MergeComputeBlockPass : public PassWrapper<MergeComputeBlockPass, OperationPass<ModuleOp>> {
+  public:
+    MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MergeComputeBlockPass)
+
+    MergeComputeBlockPass() = default;
+
+    StringRef getArgument() const override { return "merge-compute-block"; }
+
+    StringRef getDescription() const override
+    {
+        return "Merge adjacent vector compute blocks between CUBE blocks";
+    }
+
+    void runOnOperation() override
+    {
+        ModuleOp module = getOperation();
+
+        SmallVector<Block *> blocksToProcess;
+        collectInnermostMatmulLoopBlocks(module, blocksToProcess);
+
+        CVPipeline::ComputeBlockIdManager bm(module);
+        for (Block *block : blocksToProcess) {
+            tryMergeInBlock(block, bm);
+        }
+
+        LOG_DEBUG("After: " << *module);
+    }
+};
+
+} // namespace
+
+// ============================================================================
+// Pass Registration
+// ============================================================================
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<OperationPass<ModuleOp>> createMergeComputeBlockPass()
+{
+    return std::make_unique<MergeComputeBlockPass>();
+}
+
+void registerMergeComputeBlockPass()
+{
+    PassRegistration<MergeComputeBlockPass> reg;
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
@@ -57,6 +57,9 @@ void ComputeBlockOptPass::runOnOperation()
     pm.addPass(createFixpipeOptPass());
     pm.addPass(createReorderOpsByBlockIdPass());
 
+    pm.addPass(createMergeComputeBlockPass());
+    pm.addPass(createReorderOpsByBlockIdPass());
+
     if (failed(runPipeline(pm, module))) {
         signalPassFailure();
         return;
@@ -78,6 +81,7 @@ void registerComputeBlockOptPasses()
     registerPass(createUnifyAllocBlockPass);
     registerPass(createMergeVectorIfBlockPass);
     registerPass(createMergeCubeForBlockPass);
+    registerPass(createMergeComputeBlockPass);
     registerPass(createFixpipeOptPass);
 }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
@@ -57,8 +57,10 @@ void ComputeBlockOptPass::runOnOperation()
     pm.addPass(createFixpipeOptPass());
     pm.addPass(createReorderOpsByBlockIdPass());
 
-    pm.addPass(createMergeComputeBlockPass());
-    pm.addPass(createReorderOpsByBlockIdPass());
+    if (CVPipeline::isMergeComputeBlockEnabled()) {
+        pm.addPass(createMergeComputeBlockPass());
+        pm.addPass(createReorderOpsByBlockIdPass());
+    }
 
     if (failed(runPipeline(pm, module))) {
         signalPassFailure();

--- a/third_party/ascend/triton_ascend.cc
+++ b/third_party/ascend/triton_ascend.cc
@@ -404,6 +404,9 @@ void init_triton_ascend_passes_ttir(py::module &&m) {
       moduleop->setAttr(CVPipeline::kInsertionOptimization, builder.getUnitAttr());
     }
   });
+  m.def("set_enable_merge_compute_block", [](bool enable) {
+    mlir::CVPipeline::setEnableMergeComputeBlock(enable);
+  });
 
 }
 

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_compute_block.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_compute_block.mlir
@@ -1,0 +1,129 @@
+// RUN: triton-opt --allow-unregistered-dialect --merge-compute-block %s | FileCheck %s
+
+// Test merge-compute-block pass: merges adjacent VECTOR blocks between CUBE blocks,
+// cloning CUBE ops that downstream blocks depend on.
+//
+// Pattern: C1(6,CUBE) → V1(32,VECTOR) → C2(8,CUBE) → V2(33,VECTOR) → C3(10,CUBE) → C4(12,CUBE)
+// After pass:
+//   - V2(33) merged into V1(32): all block_id 33 → 32
+//   - C3(10) gets cloned alloc/copy/to_tensor chain from C2(8)
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @merge_compute_blocks(
+    %arg0: memref<?xbf16> {tt.tensor_kind = 0 : i32},
+    %arg1: memref<?xbf16> {tt.tensor_kind = 0 : i32},
+    %arg2: i32 {tt.divisibility = 16 : i32}
+  ) attributes {global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %cst_bf16 = arith.constant 0.000000e+00 : bf16
+    %cst_f32 = arith.constant 0.000000e+00 : f32
+    %cst_scale = arith.constant 0.0883883461 : f32
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %c64_i32 = arith.constant 64 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+
+    %empty_2d_bf16 = tensor.empty() : tensor<64x64xbf16>
+
+    // VECTOR block constants
+    %cst_v = arith.constant {ssbuffer.block_id = 49 : i32, ssbuffer.core_type = "VECTOR"} 0.000000e+00 : f32
+    %empty_v = tensor.empty() {ssbuffer.block_id = 49 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+    %scale = linalg.fill {ssbuffer.block_id = 49 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_scale : f32) outs(%empty_v : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+    // CUBE block constants
+    %cst_bf16_cube = arith.constant {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : bf16
+    %cst_f32_cube = arith.constant {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
+    %empty_cube_f32 = tensor.empty() {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "CUBE"} : tensor<64x64xf32>
+    %cube_init = linalg.fill {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_f32_cube : f32) outs(%empty_cube_f32 : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+    scf.for %iv = %c0_i32 to %c64_i32 step %c1_i32  : i32 {
+      // Shared index computations used by C1 and C4
+      %iv_idx = arith.index_cast %iv {ssbuffer.block_id = 26 : i32, ssbuffer.core_type = "CUBE"} : i32 to index
+      %offset64 = arith.muli %iv_idx, %c64 {ssbuffer.block_id = 26 : i32, ssbuffer.core_type = "CUBE"} : index
+      %stride_idx = arith.index_cast %arg2 {ssbuffer.block_id = 26 : i32, ssbuffer.core_type = "CUBE"} : i32 to index
+
+      // ==========================================
+      // C1: Block 6 (CUBE) — produces %tensor_c1 used by V1(32) and C4(12)
+      // ==========================================
+      // CHECK: memref.alloc() {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"}
+      %alloc_c1 = memref.alloc() {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16>
+      %reint_c1 = memref.reinterpret_cast %arg0 to offset: [%offset64], sizes: [64, 64], strides: [%stride_idx, 1] {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<?xbf16> to memref<64x64xbf16, strided<[?, 1], offset: ?>>
+      %subv_c1_src = memref.subview %reint_c1[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16, strided<[?, 1], offset: ?>> to memref<64x64xbf16, strided<[?, 1], offset: ?>>
+      %subv_c1_dst = memref.subview %alloc_c1[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16> to memref<64x64xbf16, strided<[64, 1]>>
+      memref.copy %subv_c1_src, %subv_c1_dst {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16, strided<[?, 1], offset: ?>> to memref<64x64xbf16, strided<[64, 1]>>
+      %tensor_c1 = bufferization.to_tensor %alloc_c1 restrict writable {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16>
+      %matmul_c1 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE", ssbuffer.loop_carried_l0c} ins(%tensor_c1, %tensor_c1 : tensor<64x64xbf16>, tensor<64x64xbf16>) outs(%cube_init : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+      // ==========================================
+      // V1: Block 32 (VECTOR) — CUBE pred=6, CUBE succ=8, edge 32→33 via %v1_exp
+      // ==========================================
+      // CHECK: arith.mulf {{%.*}}, {{%.*}} {ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"}
+      %v1_mul = arith.mulf %matmul_c1, %scale {ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+      // CHECK: math.exp {{%.*}} {ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"}
+      %v1_exp = math.exp %v1_mul {ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+      // CHECK: arith.truncf {{%.*}} {ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"}
+      %v1_trunc = arith.truncf %v1_exp {ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xbf16>
+
+      // ==========================================
+      // C2: Block 8 (CUBE) — has copy chain with dedicated arith ops that C3(10) depends on
+      // ==========================================
+      // CHECK: memref.alloc() {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"}
+      %alloc_c2 = memref.alloc() {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16>
+      // Dedicated arith ops in C2 for the reinterpret_cast offset computation
+      %c2_stride = arith.index_cast %arg2 {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : i32 to index
+      %c2_mul = arith.muli %iv_idx, %c2_stride {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : index
+      %c2_offset = arith.addi %offset64, %c2_mul {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : index
+      %reint_c2 = memref.reinterpret_cast %arg1 to offset: [%c2_offset], sizes: [64, 64], strides: [%c2_stride, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : memref<?xbf16> to memref<64x64xbf16, strided<[?, 1], offset: ?>>
+      %subv_c2_src = memref.subview %reint_c2[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16, strided<[?, 1], offset: ?>> to memref<64x64xbf16, strided<[?, 1], offset: ?>>
+      %subv_c2_dst = memref.subview %alloc_c2[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16> to memref<64x64xbf16, strided<[64, 1]>>
+      // CHECK: memref.copy {{%.*}}, {{%.*}} {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"}
+      memref.copy %subv_c2_src, %subv_c2_dst {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16, strided<[?, 1], offset: ?>> to memref<64x64xbf16, strided<[64, 1]>>
+      // CHECK: bufferization.to_tensor {{%.*}} {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"}
+      %tensor_c2 = bufferization.to_tensor %alloc_c2 restrict writable {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16>
+      %transposed_v1 = linalg.transpose ins(%v1_trunc : tensor<64x64xbf16>) outs(%empty_2d_bf16 : tensor<64x64xbf16>) permutation = [1, 0]  {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"}
+      %matmul_c2 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE", ssbuffer.loop_carried_l0c} ins(%transposed_v1, %tensor_c2 : tensor<64x64xbf16>, tensor<64x64xbf16>) outs(%cube_init : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+      // ==========================================
+      // C3: Block 10 (CUBE) — uses %tensor_c2 from C2, triggers clone from C2
+      // After pass: cloned alloc/index_cast/muli/addi/reinterpret_cast/subview×2/copy/to_tensor from C2
+      // ==========================================
+      // CHECK: memref.alloc() {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: arith.index_cast {{%.*}} {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: arith.muli {{%.*}}, {{%.*}} {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: arith.addi {{%.*}}, {{%.*}} {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: memref.reinterpret_cast {{%.*}} to offset: [{{%.*}}], sizes: [64, 64], strides: [{{%.*}}, 1] {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: memref.subview {{%.*}}[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: memref.subview {{%.*}}[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: memref.copy {{%.*}}, {{%.*}} {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: bufferization.to_tensor {{%.*}} {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: linalg.matmul {{.*}}ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"
+      %matmul_c3 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE", ssbuffer.loop_carried_l0c} ins(%tensor_c2, %tensor_c2 : tensor<64x64xbf16>, tensor<64x64xbf16>) outs(%cube_init : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+      // ==========================================
+      // V2: Block 33 (VECTOR) — uses %v1_exp (edge 32→33), %matmul_c3 (edge 10→33)
+      // After pass: merged into V1(32), all block_id 33 → 32
+      // ==========================================
+      // CHECK: arith.subf {{%.*}}, {{%.*}} {{{.*}}ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"}
+      %v2_sub = arith.subf %matmul_c3, %v1_exp {ssbuffer.block_id = 33 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+      // CHECK: arith.mulf {{%.*}}, {{%.*}} {{{.*}}ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"}
+      %v2_mul = arith.mulf %v1_exp, %v2_sub {ssbuffer.block_id = 33 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+      // CHECK: arith.mulf {{%.*}}, {{%.*}} {{{.*}}ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"}
+      %v2_mul2 = arith.mulf %v2_mul, %scale {ssbuffer.block_id = 33 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+      // CHECK: arith.truncf {{%.*}} {{{.*}}ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"}
+      %v2_trunc = arith.truncf %v2_mul2 {ssbuffer.block_id = 33 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xbf16>
+
+      // ==========================================
+      // C4: Block 12 (CUBE) — uses %v2_trunc (edge 33→12) and %tensor_c1 (edge 6→12)
+      // ==========================================
+      %transposed_v2 = linalg.transpose ins(%v2_trunc : tensor<64x64xbf16>) outs(%empty_2d_bf16 : tensor<64x64xbf16>) permutation = [1, 0]  {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: linalg.matmul {{.*}}ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "CUBE"
+      %matmul_c4 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "CUBE", ssbuffer.loop_carried_l0c} ins(%transposed_v2, %tensor_c1 : tensor<64x64xbf16>, tensor<64x64xbf16>) outs(%cube_init : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+      // Store output to prevent DCE
+      %reint_out = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [64, 64], strides: [%stride_idx, 1] {ssbuffer.block_id = 14 : i32, ssbuffer.core_type = "CUBE"} : memref<?xbf16> to memref<64x64xbf16, strided<[?, 1], offset: ?>>
+      %trunc_c4 = arith.truncf %matmul_c4 {ssbuffer.block_id = 14 : i32, ssbuffer.core_type = "CUBE"} : tensor<64x64xf32> to tensor<64x64xbf16>
+      bufferization.materialize_in_destination %trunc_c4 in writable %reint_out {ssbuffer.block_id = 14 : i32, ssbuffer.core_type = "CUBE"} : (tensor<64x64xbf16>, memref<64x64xbf16, strided<[?, 1], offset: ?>>) -> ()
+    }
+    return
+  }
+}


### PR DESCRIPTION

## PR 描述


**背景：**
- swa中出现 `C1 → V1 → C2 , C3 → V2 → C4, V1 -> V2` 的模式，其中 V1 和 V2 是两个相互依赖但分离的 VECTOR 块，核内多缓存导致了ub overflow 所以新增enable_merge_compute_block开关来合并 v1, v2。

**改动内容：**
1. **收集目标 Block**：遍历 ModuleOp，找到包含 `linalg::MatmulOp` 的最内层 `scf::ForOp` 的 body block。
2. **按 block_id 分组并建图**：将 block 内所有带 block_id 的 op 按 id 分组为 ComputeBlock，并基于 SSA 依赖构建块间依赖图。
3. **识别候选 VECTOR 块**：找出恰好 2 个同时有 CUBE 前驱和后继、且产生 tensor 结果的 VECTOR 块，确定 pred(V1) 和 succ(V2)。
4. **定位 C2、C3**：找出 pred 的 CUBE 后继作为 C2，再找出 C2 的 CUBE 后继作为 C3。
5. **克隆依赖 ops**：将 C2 中被 C3 依赖的 ops（`bufferization::to_tensor`、`memref::copy` 及其上游计算链）克隆到 C3 中，并重映射 C3 原有 ops 的操作数引用。
6. **合并 VECTOR 块**：将 succ(V2) 中所有 ops 的 block_id 改写为 pred(V1) 的 id，完成合并。


---

### English

**Background:**
- A pattern  `C1 → V1 → C2 , C3→ V2 → C4, V1 -> V2` can occur in swa dkdv  kernel, where V1 and V2 are two separate adjacent VECTOR blocks, add enable_merge_compute_block to merge compute block v1 and v2.

**Changes:**
1. **Collect target blocks**: Walk the `ModuleOp` to find the innermost `scf::ForOp` body blocks containing `linalg::MatmulOp`.
2. **Group by block_id and build graph**: Partition ops by `block_id` into ComputeBlocks and construct an SSA dependency graph between blocks.
3. **Identify candidate VECTOR blocks**: Find exactly 2 VECTOR blocks that have both a CUBE predecessor and successor, and produce tensor results, designating them as pred (V1) and succ (V2).
4. **Locate C2 and C3**: Identify C2 as pred's CUBE successor, and C3 as C2's CUBE successor.
5. **Clone dependent ops**: Clone ops from C2 that C3 depends on (`bufferization::to_tensor`, `memref::copy`, and their upstream chains) into C3, then remap operand references of C3's original ops.
6. **Merge VECTOR blocks**: Rewrite all ops in succ (V2) to use pred's (V1) `block_id`, completing the merge.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
