### PR TITLE
[ssbuffer](fix) fix core dump issue in RefineArgsBlockId Pass

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/RefineArgsBlockId.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/RefineArgsBlockId.cpp
@@ -150,6 +150,8 @@ void processOnefor(scf::ForOp forOp, CVPipeline::ComputeBlockIdManager &bm,
       auto firstUserOps = bm.getOpsByBlockId(firstUserBlockId);
       Operation *lastOpInFirstUserBlock = nullptr;
       for (Operation *op : firstUserOps) {
+        if (op->getBlock() != forBlock)
+          continue;
         if (!lastOpInFirstUserBlock ||
             op->isBeforeInBlock(lastOpInFirstUserBlock)) {
           lastOpInFirstUserBlock = op;


### PR DESCRIPTION
## Summary

Fix a bug in `RefineArgsBlockId.cpp` where `lastOpInFirstUserBlock` could be incorrectly set to an op that is not in the target `forBlock`.

## Changes

- Add a check `if(op->getBlock() != forBlock) continue;` when iterating over `firstUserOps` to skip ops that are not in the same block as `forBlock`
- This ensures the last operation is correctly identified within the target block


Filter out ops that don't belong to `forBlock` before checking their position in the block.
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
