### PR TITLE
[Compile](fix) Update npuir commit to d4405ac and fix compile error

### DIFF
--- a/third_party/ascend/ascend_ir.cc
+++ b/third_party/ascend/ascend_ir.cc
@@ -1108,7 +1108,7 @@ void init_ascend_ir(py::module &&m) {
                return py::cast<Value>(
                    self.create<hivm::FixpipeOp>(
                            mlir::TypeRange{dstValue.getType()}, src, dstValue,
-                           dma_mode_attr, dual_dst_mode_attr,
+                           dma_mode_attr, dual_dst_mode_attr, nullptr,
                            pre_quant_mode_attr, pre_relu_mode_attr,
                            channel_split)
                        .getResult(0));
@@ -1116,7 +1116,7 @@ void init_ascend_ir(py::module &&m) {
              } else {
                self.create<hivm::FixpipeOp>(mlir::TypeRange{}, src, dstValue,
                                             dma_mode_attr, dual_dst_mode_attr,
-                                            pre_quant_mode_attr,
+                                            nullptr, pre_quant_mode_attr,
                                             pre_relu_mode_attr, channel_split);
                return py::none();
              }

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -695,7 +695,7 @@ Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(
       srcValue,                  // src
       cubeAllocOp->getResult(0), // dst
       mlir::ValueRange{}, dmaModeAttr, nullptr, nullptr, nullptr, nullptr,
-      mlir::ArrayAttr{}, nullptr);
+      nullptr, mlir::ArrayAttr{}, nullptr);
   attachTransferTags(fixpipeOp, cubeBlockId, "CUBE", transferIndex);
   attachCrossCoreDeps(fixpipeOp, transferIndex, CVPipeline::crossCoreProducerId,
                       builder);


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
### Summary
1. Update npuir commit to d4405acb6159d2203889ae4527a735c310da9a3e
2. Fix compile error for switching npuir d4405acb6159d2203889ae4527a735c310da9a3e

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
