### PR TITLE
[ssbuffer](fix) resolve Value ambiguity between llvm::Value and mlir::Value

### DIFF
--- a/third_party/ascend/ascend_ir.cc
+++ b/third_party/ascend/ascend_ir.cc
@@ -719,7 +719,7 @@ void init_ascend_ir(py::module &&m) {
                  mlir::hivm::FixpipePreReluModeAttr::get(ctx, pre_relu_mode);
              auto channel_split = BoolAttr::get(ctx, false);
              auto op = self.create<hivm::FixpipeOp>(
-                 mlir::TypeRange{}, src, dst, dma_mode_attr, dual_dst_mode_attr,
+                 mlir::TypeRange{}, src, dst, dma_mode_attr, dual_dst_mode_attr, nullptr,
                  pre_quant_mode_attr, pre_relu_mode_attr, channel_split);
            })
       .def("create_annotation_mark",

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/Utils.cpp
@@ -27,6 +27,7 @@
 
 using namespace mlir;
 using namespace llvm;
+using mlir::Value;
 
 // Collect all nested ops within an operation's regions
 LogicalResult triton::collectAllNestedOps(Operation *op, llvm::DenseSet<Operation *> &regionOps)
@@ -90,7 +91,7 @@ static LogicalResult dfsTopologicalSort(
   inStack.insert(op);
 
   SmallVector<Operation *> deps;
-  for (Value operand : op->getOperands()) {
+  for (mlir::Value operand : op->getOperands()) {
     if (Operation *def = operand.getDefiningOp()) {
       if (ops.contains(def)) {
         deps.push_back(def);

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeCubeContolFLowInputChain.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeCubeContolFLowInputChain.cpp
@@ -52,6 +52,7 @@ using namespace llvm;
 using namespace mlir;
 using namespace triton;
 using namespace CVPipeline;
+using mlir::Value;
 
 namespace {
 
@@ -69,14 +70,14 @@ static bool isControlFlowOp(Operation *op)
     return llvm::isa<scf::SCFDialect>(op->getDialect());
 }
 
-static bool hasIncompatibleOpForCondition(Value val, llvm::DenseSet<Value> &visited);
+static bool hasIncompatibleOpForCondition(mlir::Value val, llvm::DenseSet<mlir::Value> &visited);
 
-static inline bool hasIncompatibleUpstream(ValueRange operands, llvm::DenseSet<Value> &visited)
+static inline bool hasIncompatibleUpstream(ValueRange operands, llvm::DenseSet<mlir::Value> &visited)
 {
-    return llvm::any_of(operands, [&](Value operand) { return hasIncompatibleOpForCondition(operand, visited); });
+    return llvm::any_of(operands, [&](mlir::Value operand) { return hasIncompatibleOpForCondition(operand, visited); });
 }
 
-static bool hasIncompatibleOpForCondition(Value val, llvm::DenseSet<Value> &visited)
+static bool hasIncompatibleOpForCondition(mlir::Value val, llvm::DenseSet<mlir::Value> &visited)
 {
     if (visited.contains(val)) {
         return false;
@@ -96,7 +97,7 @@ static bool hasIncompatibleOpForCondition(Value val, llvm::DenseSet<Value> &visi
 
 static bool checkControlFlowOpInputs(Operation *cfOp)
 {
-    llvm::SmallVector<Value> scalarOperands;
+    llvm::SmallVector<mlir::Value> scalarOperands;
     llvm::TypeSwitch<Operation *>(cfOp)
         .Case([&](scf::IfOp ifOp) { scalarOperands.push_back(ifOp.getCondition()); })
         .Case([&](scf::ForOp forOp) {
@@ -114,7 +115,7 @@ static bool checkControlFlowOpInputs(Operation *cfOp)
             scalarOperands.append(operands.begin(), operands.end());
         });
 
-    llvm::DenseSet<Value> visited;
+    llvm::DenseSet<mlir::Value> visited;
     return hasIncompatibleUpstream(scalarOperands, visited);
 }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -859,7 +859,7 @@ Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(OpBuilder &b
     auto fixpipeOp = builder.create<hivm::FixpipeOp>(loc, mlir::TypeRange{}, // No return value
         srcValue,                                                            // src
         cubeAllocOp->getResult(0),                                           // dst
-        mlir::ValueRange{}, dmaModeAttr, nullptr, nullptr, nullptr, nullptr, mlir::ArrayAttr{},
+        mlir::ValueRange{}, dmaModeAttr, nullptr, nullptr, nullptr, nullptr, nullptr, mlir::ArrayAttr{},
         nullptr);
     attachTransferTags(fixpipeOp, cubeBlockId, "CUBE", transferIndex);
     LOG_DEBUG("[fixpipeOp]: " << *fixpipeOp << "\n");

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
@@ -58,10 +58,10 @@
 #include "DynamicCVPipeline/PlanComputeBlock/Common.h"
 #include "bishengir/Dialect/HIVM/IR/HIVMImpl.h"
 
-using namespace llvm;
 using namespace mlir;
 using namespace triton;
 using namespace CVSplit;
+using mlir::Value;
 
 static constexpr const char *DEBUG_TYPE = "SplitMatmul";
 #define LOG_DEBUG(...) LLVM_DEBUG(llvm::dbgs() << "\n[" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
@@ -69,6 +69,8 @@ static constexpr const char *DEBUG_TYPE = "SplitMatmul";
 constexpr llvm::StringLiteral kMatmulAtLeastOnceHint = "matmul_at_least_once";
 
 namespace {
+
+using mlir::Value;
 
 struct MatmulInputs {
     Value a;


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
