### PR TITLE
[CI](feat) bishengir adaption for ssbuffer unittest.

### DIFF
--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_acf01_mlir_no_loop_independent_cv.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_acf01_mlir_no_loop_independent_cv.py
@@ -26,7 +26,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 # ============================================================================
 # Compile helper: compile Triton Kernel to MLIR (linalg dialect)
@@ -52,7 +58,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_acf02_mlir_loop_pure_cube_cv_outside.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_acf02_mlir_loop_pure_cube_cv_outside.py
@@ -26,7 +26,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 def compile_kernel(kernel, signature, constants):
@@ -36,7 +42,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})
         metadata = {**options.__dict__}

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_acf03_mlir_loop_pure_vector_cv_outside.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_acf03_mlir_loop_pure_vector_cv_outside.py
@@ -26,7 +26,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 def compile_kernel(kernel, signature, constants):
@@ -36,7 +42,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})
         metadata = {**options.__dict__}

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_acf04_mlir_multi_cube_single_vector.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_acf04_mlir_multi_cube_single_vector.py
@@ -26,7 +26,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 def compile_kernel(kernel, signature, constants):
@@ -36,7 +42,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})
         metadata = {**options.__dict__}

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_acf05_mlir_if_cond_cube_to_vector.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_acf05_mlir_if_cond_cube_to_vector.py
@@ -26,7 +26,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 def compile_kernel(kernel, signature, constants):
@@ -36,7 +42,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})
         metadata = {**options.__dict__}

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_acf06_mlir_if_else_cond_vector_to_cv.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_acf06_mlir_if_else_cond_vector_to_cv.py
@@ -26,7 +26,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 def compile_kernel(kernel, signature, constants):
@@ -36,7 +42,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})
         metadata = {**options.__dict__}

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_acf07_mlir_if_else_v2c_dependency.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_acf07_mlir_if_else_v2c_dependency.py
@@ -26,7 +26,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 def compile_kernel(kernel, signature, constants):
@@ -36,7 +42,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})
         metadata = {**options.__dict__}

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb01_mlir_single_cube_single_vector.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb01_mlir_single_cube_single_vector.py
@@ -30,7 +30,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 # ============================================================================
 # MLIR output configuration
@@ -80,7 +86,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         # The normal compilation path obtains this via backend.get_codegen_implementation(options);
         # here we import min_dot_size directly from the Ascend backend and construct it.

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb02_mlir_multi_cube_multi_vector.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb02_mlir_multi_cube_multi_vector.py
@@ -26,7 +26,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -51,7 +57,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb03_mlir_cube_chain_c2c_independent_vector.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb03_mlir_cube_chain_c2c_independent_vector.py
@@ -26,7 +26,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -51,7 +57,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb04_mlir_cube_chain_c2c_vector_chain_v2v.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb04_mlir_cube_chain_c2c_vector_chain_v2v.py
@@ -25,7 +25,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -50,7 +56,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb08_mlir_loop_transpose_c2v_argmax.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb08_mlir_loop_transpose_c2v_argmax.py
@@ -25,7 +25,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -50,7 +56,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb09_mlir_loop_fill_c2v_argmin.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb09_mlir_loop_fill_c2v_argmin.py
@@ -25,7 +25,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -50,7 +56,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb10_mlir_loop_multi_v2c_xor_sum.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb10_mlir_loop_multi_v2c_xor_sum.py
@@ -25,7 +25,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -50,7 +56,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb11_mlir_loop_v2c_shared_vector.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb11_mlir_loop_v2c_shared_vector.py
@@ -25,7 +25,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -50,7 +56,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb12_mlir_while_loop_c_zero_fill.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb12_mlir_while_loop_c_zero_fill.py
@@ -25,7 +25,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -50,7 +56,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb13_mlir_while_loop_c_nonzero.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb13_mlir_while_loop_c_nonzero.py
@@ -25,7 +25,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -50,7 +56,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb14_mlir_while_loop_c_broadcast_scalar.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_pcb14_mlir_while_loop_c_broadcast_scalar.py
@@ -25,7 +25,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -50,7 +56,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf01_mlir_v2c_unaligned.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf01_mlir_v2c_unaligned.py
@@ -25,7 +25,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -50,7 +56,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf02_mlir_c2v_war_memory.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf02_mlir_c2v_war_memory.py
@@ -25,7 +25,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -50,7 +56,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf03_mlir_v2c_raw_memory.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf03_mlir_v2c_raw_memory.py
@@ -25,7 +25,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -50,7 +56,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf04_mlir_c2c_waw_memory.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf04_mlir_c2c_waw_memory.py
@@ -25,7 +25,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -50,7 +56,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf05_mlir_two_layer_independent_cv.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf05_mlir_two_layer_independent_cv.py
@@ -25,7 +25,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -50,7 +56,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf06_mlir_two_layer_inner_cv_only.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf06_mlir_two_layer_inner_cv_only.py
@@ -26,7 +26,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -51,7 +57,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf07_mlir_two_layer_outer_cv_only.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf07_mlir_two_layer_outer_cv_only.py
@@ -26,7 +26,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -51,7 +57,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf08_mlir_two_layer_c2c_outer_dep_inner.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf08_mlir_two_layer_c2c_outer_dep_inner.py
@@ -26,7 +26,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -51,7 +57,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf09_mlir_two_layer_c2c_inner_dep_outer.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf09_mlir_two_layer_c2c_inner_dep_outer.py
@@ -27,7 +27,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -52,7 +58,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf10_mlir_two_layer_v2c_inner_dep_outer.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf10_mlir_two_layer_v2c_inner_dep_outer.py
@@ -25,7 +25,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -50,7 +56,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf11_mlir_two_layer_c2v_outer_dep_inner.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf11_mlir_two_layer_c2v_outer_dep_inner.py
@@ -25,7 +25,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -50,7 +56,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf12_mlir_three_layer_independent_cv.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf12_mlir_three_layer_independent_cv.py
@@ -26,7 +26,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -51,7 +57,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf13_mlir_three_layer_alternating_pure.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf13_mlir_three_layer_alternating_pure.py
@@ -26,7 +26,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -51,7 +57,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf14_mlir_three_layer_c2c_outer_dep_inner.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf14_mlir_three_layer_c2c_outer_dep_inner.py
@@ -27,7 +27,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -52,7 +58,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf15_mlir_three_layer_c2c_inner_dep_outer.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf15_mlir_three_layer_c2c_inner_dep_outer.py
@@ -26,7 +26,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -51,7 +57,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf16_mlir_three_layer_v2c_inner_dep_outer.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf16_mlir_three_layer_v2c_inner_dep_outer.py
@@ -24,7 +24,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -49,7 +55,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf17_mlir_three_layer_c2v_outer_dep_inner.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf17_mlir_three_layer_c2v_outer_dep_inner.py
@@ -25,7 +25,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -50,7 +56,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf18_mlir_four_layer_independent_cv.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf18_mlir_four_layer_independent_cv.py
@@ -25,7 +25,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -50,7 +56,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf19_mlir_four_layer_alternating_pure.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf19_mlir_four_layer_alternating_pure.py
@@ -24,7 +24,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -49,7 +55,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf20_mlir_four_layer_c2c_outer_dep_inner.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf20_mlir_four_layer_c2c_outer_dep_inner.py
@@ -23,7 +23,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 def compile_kernel(kernel, signature, constants):
@@ -32,7 +38,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})
         metadata = {**options.__dict__}

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf21_mlir_four_layer_c2c_inner_dep_outer.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf21_mlir_four_layer_c2c_inner_dep_outer.py
@@ -21,7 +21,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -46,7 +52,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf22_mlir_four_layer_v2c_inner_dep_outer.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf22_mlir_four_layer_v2c_inner_dep_outer.py
@@ -21,7 +21,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -46,7 +52,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf23_mlir_four_layer_c2v_outer_dep_inner.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf23_mlir_four_layer_c2v_outer_dep_inner.py
@@ -21,7 +21,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -46,7 +52,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf24_mlir_five_layer_independent_cv.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf24_mlir_five_layer_independent_cv.py
@@ -21,7 +21,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -46,7 +52,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf25_mlir_five_layer_alternating_pure.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf25_mlir_five_layer_alternating_pure.py
@@ -21,7 +21,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -46,7 +52,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf26_mlir_five_layer_c2c_outer_dep_inner.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf26_mlir_five_layer_c2c_outer_dep_inner.py
@@ -21,7 +21,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 def compile_kernel(kernel, signature, constants):
@@ -30,7 +36,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})
         metadata = {**options.__dict__}

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf27_mlir_five_layer_c2c_inner_dep_outer.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf27_mlir_five_layer_c2c_inner_dep_outer.py
@@ -21,7 +21,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -46,7 +52,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf28_mlir_five_layer_v2c_inner_dep_outer.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf28_mlir_five_layer_v2c_inner_dep_outer.py
@@ -21,7 +21,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -46,7 +52,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf29_mlir_five_layer_c2v_outer_dep_inner.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf29_mlir_five_layer_c2v_outer_dep_inner.py
@@ -21,7 +21,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -46,7 +52,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})

--- a/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf30_mlir_ten_layer_independent_cv.py
+++ b/third_party/ascend/unittest/DynamicCVPipeline_ut/test_sdf30_mlir_ten_layer_independent_cv.py
@@ -21,7 +21,13 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, make_ttir, ttir_to_linalg, min_dot_size
+from triton.backends.ascend import _apply_ascend_patch
 import pytest
+
+# Apply Ascend patch to inject hacc.target attribute into MLIR modules.
+# Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
+# via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
+_apply_ascend_patch()
 
 
 # ============================================================================
@@ -46,7 +52,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions(compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
+        options = NPUOptions(arch="Ascend910_9589", compile_on_910_95=True, enable_dynamic_cv_pipeline=True)
         # Register codegen_fns, including min_dot_size required by tl.dot.
         codegen_fns = {"min_dot_size": min_dot_size(None)}
         ttir = ast_to_ttir(kernel, src, context, options, codegen_fns, {})


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

1. Apply Ascend patch to inject hacc.target attribute into MLIR modules.
2. Required by bishengir FixpipeOp::verify() which checks isAscend950(moduleOp)
3. via the hacc.target attribute; without it, dst=UB fixpipe ops are rejected.
