### PR TITLE
[tests](fix) set concrete Ascend targets for UB fixpipe

### DIFF
--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/flag_reuse_cross_direction.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/flag_reuse_cross_direction.mlir
@@ -12,7 +12,7 @@
 // Here a long Vector->Cube->Vector matmul chain needs more than MAX_FLAG_ID
 // flags, forcing reuse; the result must partition strictly by direction.
 
-module {
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
   func.func @flag_reuse_cross_direction() {
     %cst = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 0.000000e+00 : f32
     %e0 = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<32x32xf32>

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/flag_reuse_over_limit.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/flag_reuse_over_limit.mlir
@@ -1,6 +1,6 @@
 // RUN: triton-opt --add-block-id-for-control-ops --data-dependency-analysis --inter-core-transfer-and-sync --mark-main-loop %s | FileCheck %s --implicit-check-not="flag = -1" --implicit-check-not="flag = 15" --implicit-check-not="<PIPE_FIX>, <PIPE_V>] flag = 2" --implicit-check-not="<PIPE_MTE3>, <PIPE_MTE1>] flag = 1"
 
-module {
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
   func.func @flag_reuse_over_limit() {
     %cst = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
     %alloc = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf32>

--- a/third_party/ascend/unittest/pytest_ut/test_cann_extension.py
+++ b/third_party/ascend/unittest/pytest_ut/test_cann_extension.py
@@ -31,8 +31,11 @@ from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir, buffer_ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.compiler.errors import MLIRCompilationError
+from triton.backends.ascend import _apply_ascend_patch
 
 os.environ["TORCH_DEVICE_BACKEND_AUTOLOAD"] = "0"
+
+_apply_ascend_patch()
 
 
 class Options:
@@ -42,7 +45,7 @@ class Options:
     cluster_dims = (1, 1, 1)
     enable_fp_fusion = True
     debug = False
-    arch = "Ascend910_95"
+    arch = "Ascend910_9589"
 
 
 def compile_kernel(kernel, signature, constants):

--- a/third_party/ascend/unittest/pytest_ut/test_fixpipe.py
+++ b/third_party/ascend/unittest/pytest_ut/test_fixpipe.py
@@ -28,8 +28,11 @@ from triton.compiler.compiler import ASTSource
 from triton.compiler.code_generator import ast_to_ttir
 from triton._C.libtriton import ir
 from triton._C.libtriton.ascend import ir as ascend_ir
+from triton.backends.ascend import _apply_ascend_patch
 
 os.environ["TORCH_DEVICE_BACKEND_AUTOLOAD"] = "0"
+
+_apply_ascend_patch()
 
 
 class Options:
@@ -39,7 +42,7 @@ class Options:
     cluster_dims = (1, 1, 1)
     enable_fp_fusion = True
     debug = False
-    arch = "Ascend910_95"
+    arch = "Ascend910_9589"
     sanitize_overflow = True
 
 


### PR DESCRIPTION
## Summary

- Apply the Ascend target-injection patch in two direct AST-to-TTIR tests.
- Replace the non-concrete Python test target with `Ascend910_9589`.
- Annotate two DynamicCVPipeline MLIR fixtures with `Ascend950PR_9579`.

## Why

The updated AscendNPU-IR `FixpipeOp` verifier rejects UB destinations when the module target is missing or cannot be resolved to a concrete Ascend950 device. The affected Python fixtures used the non-concrete `Ascend910_95` target, while the two MLIR fixtures had no `hacc.target` attribute. As a result, test-generated `hivm.hir.fixpipe` operations failed verification before their intended assertions ran.

## Validation

- Parsed both modified Python files with Python's AST parser.
- `git diff --check` passes.
- Confirmed the PR contains one commit and only the four affected test files.
- Full Ascend pytest and lit execution is left to CI because the local Windows workspace has no runnable `triton-opt` or NPU environment.
- `pre-commit` is not installed in the local environment.

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] This PR does not need additional tests because it fixes the target configuration of existing Python and lit tests.
- [x] I have not added any `lit` tests.
