### PR TITLE
[ssbuffer](fix) sync for may not excute

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -64,6 +64,8 @@ inline constexpr llvm::StringLiteral kMemCrossDeps = "ssbuffer.memCrossDeps";
 inline constexpr llvm::StringLiteral kDepMark = "ssbuffer.dep_mark";
 inline constexpr llvm::StringLiteral kMayNotExec = "ssbuffer.may_not_exec";
 inline constexpr llvm::StringLiteral kIterCounter = "ssbuffer.iterCounter";
+inline constexpr llvm::StringLiteral kForMayNotExec =
+    "ssbuffer.for_may_not_exec";
 inline constexpr llvm::StringLiteral kClone = "ssbuffer.clone";
 inline constexpr llvm::StringLiteral kEnableUbRefineOpt =
     "ssbuffer.enable_ub_refine_opt";
@@ -234,6 +236,7 @@ bool isViewLike(Operation *op);
 // 0 scalar constant. Used to detect the "add 0" operand of VECTOR pseudo-ops
 // (`arith.addf` / `arith.addi` carrying `ssbuffer.add_from_matmul`).
 bool isZeroFillValue(Value v);
+bool isZeroAdd(mlir::Operation *op);
 
 // Read the `hivm.tightly_coupled_buffer<N>` id attached to a `memref.alloc`
 // via its `annotation.mark` user. Returns nullopt when no annotation with

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
@@ -41,7 +41,7 @@ using namespace triton;
 namespace {
 
 static constexpr llvm::StringLiteral interceptrFunc[]{
-    "_multi_head_jagged_flash_attention_bwd_kernel", "_parallel_hstu_attn_bwd"};
+    "_parallel_hstu_attn_bwd"};
 
 static LogicalResult verifyFuncNames(ModuleOp module) {
   bool intercepted = false;

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -206,6 +206,18 @@ bool isZeroFillValue(mlir::Value v) {
   return false;
 }
 
+bool isZeroAdd(mlir::Operation *op) {
+  if (isa<arith::AddFOp, arith::AddIOp>(op)) {
+    Value lhs = op->getOperand(0);
+    Value rhs = op->getOperand(1);
+    if (isZeroFillValue(lhs) || isZeroFillValue(rhs)) {
+      return true;
+    }
+    return false;
+  }
+  return false;
+}
+
 // Read the `hivm.tightly_coupled_buffer<N>` id attached to a `memref.alloc`
 // via its `annotation.mark` user. Returns nullopt when no annotation with
 // a concrete id is present, or when `allocVal` is null.

--- a/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
@@ -53,7 +53,8 @@ static constexpr llvm::StringLiteral kAttrsToRemove[]{
     kMemCrossDeps,      kClone,
     kIntraBufCount,     kInterCoreBufCount,
     kLoadStoreBufCount, kInsertionOptimization,
-    kEnableUbRefineOpt, kDepMark};
+    kEnableUbRefineOpt, kDepMark,
+    kIntraDeps};
 
 void RemoveSsbufAttrPass::runOnOperation() {
   auto module = getOperation();

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -825,7 +825,8 @@ bool InterCoreTransferAndSyncPass::isStoreDirectlyInUserChain(
       }
 
       // Check if user is in skip range
-      if (CVPipeline::isViewLike(user)) {
+      if (CVPipeline::isViewLike(user) || CVPipeline::isZeroAdd(user) ||
+          user->hasAttr(CVPipeline::kForMayNotExec)) {
         // Continue traversing through skip ops
         for (Value result : user->getResults()) {
           if (!visited.count(result)) {

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
@@ -720,6 +720,8 @@ static LogicalResult splitMatmul(linalg::MatmulOp matmulOp,
                                                   splitInfo.outerOutValue);
     auto selectOp = rewriter.create<arith::SelectOp>(
         loc, executed, splitInfo.outerOutValue, fillOp.getResult(0));
+    fillOp->setAttr(CVPipeline::kForMayNotExec, rewriter.getUnitAttr());
+    selectOp->setAttr(CVPipeline::kForMayNotExec, rewriter.getUnitAttr());
     newOutValue = selectOp.getResult();
     preservedUsers.insert(selectOp);
     preservedUsers.insert(fillOp);


### PR DESCRIPTION
# Summary
- mark and skip `linalg.fill` &` arith.select` created for  cases in which loop may not excute when analyzing vector op
- add `<PIPE_FIX> <PIPE_MTE3>` `sync_block_set`&`sync_block_wait ` if a value is fixpiped to ub and then stored to gm directly.
- remove `_multi_head_jagged_flash_attention_bwd_kernel` in ssbuffer blocklist



<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
