### PR TITLE
[CI](feat) Add CI pipeline for API doc examples

### DIFF
--- a/.github/workflows/integration-tests-ascend.yml
+++ b/.github/workflows/integration-tests-ascend.yml
@@ -122,6 +122,16 @@ jobs:
           # that cause CI instability. TODO: Fix flaky kernel tests and re-enable.
           # ${PYTHON} -m pytest -s -v -n "$NUM_PROCS" --dist=loadfile third_party/ascend/unittest/kernels/test_triton_kernel.py
 
+      - name: Run API doc example tests on NPU
+        shell: bash
+        run: |
+          source /usr/local/Ascend/cann/set_env.sh
+          export PATH="/usr/local/bisheng/tools/bishengir/bin:$PATH"
+          ${PYTHON} -m pytest -s -v -n 8 --dist=loadfile \
+            --import-mode=importlib \
+            --override-ini="python_files=triton.*.py" \
+            docs/zh/python-api/_examples/
+
       - name: Run MLIR FileCheck tests
         shell: bash
         run: |

--- a/docs/zh/python-api/_examples/triton.Config.py
+++ b/docs/zh/python-api/_examples/triton.Config.py
@@ -1,3 +1,32 @@
-'''
-class triton.Config(self, kwargs, num_warps, num_stages, num_ctas, maxnreg, pre_hook)
-'''
+import triton
+import triton.language as tl
+import torch
+
+
+@triton.autotune(
+    configs=[triton.Config(kwargs={'BLOCK_SIZE': 64}),
+             triton.Config(kwargs={'BLOCK_SIZE': 128})],
+    key=['n_elements'],
+)
+@triton.jit
+def vec_add_kernel(x_ptr, y_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    tl.store(out_ptr + offsets, x + y, mask=mask)
+
+
+def test_config():
+    N = 128
+    x = torch.randn(N, dtype=torch.float32, device='npu')
+    y = torch.randn(N, dtype=torch.float32, device='npu')
+    out = torch.empty(N, dtype=torch.float32, device='npu')
+    grid = lambda meta: (triton.cdiv(N, meta['BLOCK_SIZE']), )
+    vec_add_kernel[grid](x, y, out, N)
+    torch.testing.assert_close(out.cpu(), (x + y).cpu())
+
+
+if __name__ == "__main__":
+    test_config()

--- a/docs/zh/python-api/_examples/triton.autotune.py
+++ b/docs/zh/python-api/_examples/triton.autotune.py
@@ -1,2 +1,32 @@
-triton.autotune(configs, key, prune_configs_by=None, reset_to_zero=None, restore_value=None, pre_hook=None,
-                post_hook=None, warmup=25, rep=100, use_cuda_graph=False)
+import triton
+import triton.language as tl
+import torch
+
+
+@triton.autotune(
+    configs=[triton.Config(kwargs={'BLOCK_SIZE': 64}),
+             triton.Config(kwargs={'BLOCK_SIZE': 128})],
+    key=['n_elements'],
+)
+@triton.jit
+def add_kernel(x_ptr, y_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    tl.store(out_ptr + offsets, x + y, mask=mask)
+
+
+def test_autotune():
+    N = 128
+    x = torch.randn(N, dtype=torch.float32, device='npu')
+    y = torch.randn(N, dtype=torch.float32, device='npu')
+    out = torch.empty(N, dtype=torch.float32, device='npu')
+    grid = lambda meta: (triton.cdiv(N, meta['BLOCK_SIZE']), )
+    add_kernel[grid](x, y, out, N)
+    torch.testing.assert_close(out.cpu(), (x + y).cpu())
+
+
+if __name__ == "__main__":
+    test_autotune()

--- a/docs/zh/python-api/_examples/triton.extension.buffer.language.alloc.py
+++ b/docs/zh/python-api/_examples/triton.extension.buffer.language.alloc.py
@@ -1,3 +1,9 @@
+import triton
+import triton.language as tl
+import triton.extension.buffer.language as bl
+import triton.language.extra.cann.extension as al
+
+
 @triton.jit
 def allocate_local_buffer(XBLOCK: tl.constexpr):
     bl.alloc(tl.float32, [XBLOCK])

--- a/docs/zh/python-api/_examples/triton.extension.buffer.language.fixpipe.py
+++ b/docs/zh/python-api/_examples/triton.extension.buffer.language.fixpipe.py
@@ -1,3 +1,9 @@
+import triton
+import triton.language as tl
+import triton.extension.buffer.language as bl
+import triton.language.extra.cann.extension as al
+
+
 @triton.jit
 def fixpipe_kernel(
     A_ptr,

--- a/docs/zh/python-api/_examples/triton.extension.buffer.language.to_buffer.py
+++ b/docs/zh/python-api/_examples/triton.extension.buffer.language.to_buffer.py
@@ -1,3 +1,9 @@
+import triton
+import triton.language as tl
+import triton.extension.buffer.language as bl
+import triton.language.extra.cann.extension as al
+
+
 @triton.jit
 def to_buffer_kernel():
     a = tl.full((32, 2, 4), 0, dtype=tl.int64)

--- a/docs/zh/python-api/_examples/triton.extension.buffer.language.to_tensor.py
+++ b/docs/zh/python-api/_examples/triton.extension.buffer.language.to_tensor.py
@@ -1,3 +1,8 @@
+import triton
+import triton.language as tl
+import triton.extension.buffer.language as bl
+
+
 @triton.jit
 def kernel_func(XBLOCK: tl.constexpr):
     buffer1 = bl.alloc(tl.float32, [XBLOCK])

--- a/docs/zh/python-api/_examples/triton.heuristics.py
+++ b/docs/zh/python-api/_examples/triton.heuristics.py
@@ -1,1 +1,28 @@
-triton.heuristics(values)
+import triton
+import triton.language as tl
+import torch
+
+
+@triton.heuristics({'BLOCK_SIZE': lambda args: triton.next_power_of_2(args['n_elements'] // 4)})
+@triton.jit
+def add_kernel(x_ptr, y_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    tl.store(out_ptr + offsets, x + y, mask=mask)
+
+
+def test_heuristics():
+    N = 128
+    x = torch.randn(N, dtype=torch.float32, device='npu')
+    y = torch.randn(N, dtype=torch.float32, device='npu')
+    out = torch.empty(N, dtype=torch.float32, device='npu')
+    grid = lambda meta: (triton.cdiv(N, meta['BLOCK_SIZE']), )
+    add_kernel[grid](x, y, out, N)
+    torch.testing.assert_close(out.cpu(), (x + y).cpu())
+
+
+if __name__ == "__main__":
+    test_heuristics()

--- a/docs/zh/python-api/_examples/triton.jit.py
+++ b/docs/zh/python-api/_examples/triton.jit.py
@@ -1,4 +1,24 @@
-'''
-triton.jit(fn: T) -> JITFunction[T]
-triton.jit(*, version=None, repr: Callable | None = None, launch_metadata: Callable | None = None, do_not_specialize: Iterable[int] | None = None, debug: bool | None = None, noinline: bool | None = None) -> Callable[[T], JITFunction[T]]
-'''
+import triton
+import triton.language as tl
+import torch
+
+
+@triton.jit
+def add_kernel(x_ptr, y_ptr, out_ptr, N: tl.constexpr):
+    offsets = tl.arange(0, N)
+    x = tl.load(x_ptr + offsets)
+    y = tl.load(y_ptr + offsets)
+    tl.store(out_ptr + offsets, x + y)
+
+
+def test_jit():
+    N = 128
+    x = torch.randn(N, dtype=torch.float32, device='npu')
+    y = torch.randn(N, dtype=torch.float32, device='npu')
+    out = torch.empty(N, dtype=torch.float32, device='npu')
+    add_kernel[(1, )](x, y, out, N=N)
+    torch.testing.assert_close(out.cpu(), (x + y).cpu())
+
+
+if __name__ == "__main__":
+    test_jit()

--- a/docs/zh/python-api/_examples/triton.language.add.py
+++ b/docs/zh/python-api/_examples/triton.language.add.py
@@ -1,3 +1,13 @@
+import triton
+import triton.language as tl
+import torch
+
+
+def torch_add(x0, x1):
+    res = x0 + x1
+    return res
+
+
 @triton.jit
 def add_kernel(x_ptr,  # *Pointer* to first input vector.
                y_ptr,  # *Pointer* to second input vector.
@@ -14,3 +24,20 @@ def add_kernel(x_ptr,  # *Pointer* to first input vector.
     y = tl.load(y_ptr + offsets, mask=mask)
     output = x + y  # equivalent to output = tl.add(x,y)
     tl.store(output_ptr + offsets, output, mask=mask)
+
+
+def test_add():
+    param_list = ['float32', (2, 1024, 4), 2, 4096]
+    dtype, shape, ncore, block_size = param_list
+    x0 = torch.randn(size=shape, dtype=eval('torch.' + dtype)).npu()
+    x1 = torch.randn(size=shape, dtype=eval('torch.' + dtype)).npu()
+
+    torch_res = torch_add(x0, x1)
+    triton_res = torch.empty_like(x0)
+    add_kernel[ncore, 1, 1](x0, x1, triton_res, x0.numel(), block_size)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
+
+
+if __name__ == '__main__':
+    test_add()

--- a/docs/zh/python-api/_examples/triton.language.associative_scan.py
+++ b/docs/zh/python-api/_examples/triton.language.associative_scan.py
@@ -3,6 +3,7 @@ import triton
 import triton.language as tl
 
 
+@triton.jit
 def combine_fn_test(a, b):
     return a + b
 

--- a/docs/zh/python-api/_examples/triton.language.broadcast.py
+++ b/docs/zh/python-api/_examples/triton.language.broadcast.py
@@ -5,12 +5,11 @@ import triton.language as tl
 
 @triton.jit
 def broadcast_kernel(output_ptr, BLOCK_SIZE: tl.constexpr):
-    # Broadcast the scalar to the same shape as the vector.
-    scalar = tl.full([], 5.0, dtype=tl.float32)
-    vector = tl.arange(0, BLOCK_SIZE) * 1.0
-    broadcasted_scalar = tl.broadcast(scalar, vector)
-    result = vector + broadcasted_scalar
+    # Broadcast the scalar to the same shape as the vector using broadcast_to.
+    scalar = tl.full([1], 5.0, dtype=tl.float32)
+    broadcasted_scalar = tl.broadcast_to(scalar, (BLOCK_SIZE, ))
     offsets = tl.arange(0, BLOCK_SIZE)
+    result = tl.arange(0, BLOCK_SIZE) + broadcasted_scalar
     tl.store(output_ptr + offsets, result)
 
 
@@ -20,7 +19,6 @@ def test_broadcast():
     broadcast_kernel[(1, )](out, BLOCK_SIZE=BLOCK)
     ref = torch.arange(BLOCK, dtype=torch.float32) + 5.0
     torch.testing.assert_close(out.cpu(), ref)
-    print("Test passed.")
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.compile_hint.py
+++ b/docs/zh/python-api/_examples/triton.language.compile_hint.py
@@ -1,1 +1,4 @@
-triton.language.compile_hint(ptr, hint_name, hint_val=None, _builder=None)
+import triton
+import triton.language as tl
+
+# triton.language.compile_hint(ptr, hint_name, hint_val=None, _builder=None)

--- a/docs/zh/python-api/_examples/triton.language.div.py
+++ b/docs/zh/python-api/_examples/triton.language.div.py
@@ -1,3 +1,13 @@
+import triton
+import triton.language as tl
+import torch
+
+
+def torch_div(x0, x1):
+    res = x0 / x1
+    return res
+
+
 @triton.jit
 def triton_div(in_ptr0, in_ptr1, out_ptr0, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
     offset = tl.program_id(0) * XBLOCK
@@ -9,3 +19,20 @@ def triton_div(in_ptr0, in_ptr1, out_ptr0, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.
         tmp1 = tl.load(in_ptr1 + (x0), None)
         tmp2 = tmp0 / tmp1
         tl.store(out_ptr0 + (x0), tmp2, None)
+
+
+def test_div():
+    param_list = ['float32', (2, 4096, 8), 2, 32768, 1024]
+    dtype, shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=eval('torch.' + dtype)).npu()
+    x1 = torch.randn(size=shape, dtype=eval('torch.' + dtype)).npu()
+
+    torch_res = torch_div(x0, x1)
+    triton_res = torch.empty_like(x0)
+    triton_div[ncore, 1, 1](x0, x1, triton_res, xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
+
+
+if __name__ == '__main__':
+    test_div()

--- a/docs/zh/python-api/_examples/triton.language.expand_dims.py
+++ b/docs/zh/python-api/_examples/triton.language.expand_dims.py
@@ -1,4 +1,5 @@
 import torch
+import torch_npu
 import triton
 import triton.language as tl
 
@@ -17,10 +18,10 @@ def expand_dims_kernel(in_ptr, out_ptr, M: tl.constexpr, N: tl.constexpr):
 def test_expand_dims():
     M, N = 2, 3
     torch.manual_seed(0)
-    x = torch.randn((M, N), dtype=torch.float32).npu()
-    out = torch.empty((M * N, ), dtype=torch.float32, device="npu")
+    x = torch.randn((M, N), dtype=torch.float32, device="npu")
+    out = torch.zeros((M * N, ), dtype=torch.float32, device="npu")
     expand_dims_kernel[(1, )](out, x, M=M, N=N)
-    ref = x.cpu().unsqueeze(1).flatten()
+    ref = x.cpu().flatten()
     torch.testing.assert_close(out.cpu(), ref)
     print("Test passed.")
 

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.extension.ascend_address_space.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.extension.ascend_address_space.py
@@ -1,3 +1,9 @@
+import triton
+import triton.language as tl
+import triton.extension.buffer.language as bl
+import triton.language.extra.cann.extension as al
+
+
 @triton.jit
 def allocate_local_buffer(XBLOCK: tl.constexpr):
     bl.alloc(tl.float32, [XBLOCK])

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.extension.compile_hint.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.extension.compile_hint.py
@@ -1,3 +1,7 @@
+import triton
+import triton.language as tl
+
+
 @triton.jit
 def triton_compile_hint(in_ptr0, out_ptr0, xnumel, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
     xoffset = tl.program_id(0) * XBLOCK

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.extension.copy.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.extension.copy.py
@@ -1,3 +1,9 @@
+import triton
+import triton.language as tl
+import triton.extension.buffer.language as bl
+import triton.language.extra.cann.extension as al
+
+
 @triton.jit
 def copy_kernel(
     A_ptr,

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.extension.copy_from_ub_to_l1.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.extension.copy_from_ub_to_l1.py
@@ -1,3 +1,9 @@
+import triton
+import triton.language as tl
+import triton.extension.buffer.language as bl
+import triton.language.extra.cann.extension as al
+
+
 @triton.jit
 def copy_kernel(
     A_ptr,

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.extension.debug_barrier.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.extension.debug_barrier.py
@@ -1,3 +1,13 @@
+import triton
+import triton.language as tl
+import torch
+
+
+def torch_debug_barrier(x0, x1):
+    res = x0 - x1
+    return res
+
+
 @triton.jit
 def triton_sub(in_ptr0, in_ptr1, out_ptr0, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
     offset = tl.program_id(0) * XBLOCK
@@ -10,3 +20,20 @@ def triton_sub(in_ptr0, in_ptr1, out_ptr0, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.
         tmp2 = tmp0 - tmp1
         tl.debug_barrier()
         tl.store(out_ptr0 + (x0), tmp2, None)
+
+
+def test_debug_barrier():
+    param_list = ['float32', (2, 4096, 8), 2, 32768, 1024]
+    dtype, shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=eval('torch.' + dtype)).npu()
+    x1 = torch.randn(size=shape, dtype=eval('torch.' + dtype)).npu()
+
+    torch_res = torch_debug_barrier(x0, x1)
+    triton_res = torch.empty_like(x0)
+    triton_sub[ncore, 1, 1](x0, x1, triton_res, xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
+
+
+if __name__ == '__main__':
+    test_debug_barrier()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.extension.gather_out_to_ub.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.extension.gather_out_to_ub.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 import triton
 import triton.language as tl
@@ -29,6 +30,8 @@ def kernel(src_ptr, index_ptr, out_ptr):
 
 
 def test_gather_out_to_ub():
+    if not is_compile_on_910_95():
+        pytest.skip("gather_out_to_ub is only supported on Ascend 950")
     # src(4,2) = [[1.,2.],[3.,4.],[5.,6.],[7.,8.]]
     src = torch.tensor([[1., 2.], [3., 4.], [5., 6.], [7., 8.]], device='npu')
     # index(2,2) = [[0,1],[2,3]]
@@ -49,7 +52,4 @@ def test_gather_out_to_ub():
 
 
 if __name__ == "__main__":
-    if not is_compile_on_910_95():
-        print("gather_out_to_ub is only supported on Ascend 950, skipping test.")
-    else:
-        test_gather_out_to_ub()
+    test_gather_out_to_ub()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.extension.index_put.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.extension.index_put.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 import triton
 import triton.language as tl
@@ -26,6 +27,8 @@ def kernel(value_ptr, index_ptr, dst_ptr):
 
 
 def test_index_put():
+    if not is_compile_on_910_95():
+        pytest.skip("index_put is only supported on Ascend 950")
     # dst: (4,2) of zeros
     dst = torch.zeros((4, 2), device='npu', dtype=torch.float32)
     # value = [[1., 2.],
@@ -49,7 +52,4 @@ def test_index_put():
 
 
 if __name__ == "__main__":
-    if not is_compile_on_910_95():
-        print("index_put is only supported on Ascend 950, skipping test.")
-    else:
-        test_index_put()
+    test_index_put()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.extension.scatter_ub_to_out.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.extension.scatter_ub_to_out.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 import triton
 import triton.language as tl
@@ -27,6 +28,8 @@ def kernel(value_ptr, index_ptr, dst_ptr):
 
 
 def test_scatter_ub_to_out():
+    if not is_compile_on_910_95():
+        pytest.skip("scatter_ub_to_out is only supported on Ascend 950")
     # dst: (4,2) of zeros
     dst = torch.zeros((4, 2), device='npu', dtype=torch.float32)
     # value(2,2) = [[1.,2.],[3.,4.]]
@@ -52,7 +55,4 @@ def test_scatter_ub_to_out():
 
 
 if __name__ == "__main__":
-    if not is_compile_on_910_95():
-        print("scatter_ub_to_out is only supported on Ascend 950, skipping test.")
-    else:
-        test_scatter_ub_to_out()
+    test_scatter_ub_to_out()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.extension.scope.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.extension.scope.py
@@ -1,3 +1,8 @@
+import triton
+import triton.language as tl
+import triton.language.extra.cann.extension as al
+
+
 @triton.jit
 def kernel_scope_vector(x_ptr, y_ptr, out_ptr, n, BLOCK: tl.constexpr):
     i = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.extension.sub_vec_id.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.extension.sub_vec_id.py
@@ -1,3 +1,8 @@
+import triton
+import triton.language as tl
+import triton.language.extra.cann.extension as al
+
+
 @triton.jit
 def verify_sub_vec_id_kernel(out_ptr, N: tl.constexpr):
     with al.scope(core_mode="vector"):

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.extension.subview.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.extension.subview.py
@@ -1,3 +1,8 @@
+import triton
+import triton.language as tl
+import triton.extension.buffer.language as bl
+
+
 @triton.jit
 def test_subview_kernel(XBLOCK: tl.constexpr):
     src_buffer = bl.alloc(tl.float32, [XBLOCK, XBLOCK])

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.extension.sync_block_all.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.extension.sync_block_all.py
@@ -1,3 +1,7 @@
+import triton
+import triton.language.extra.cann.extension as al
+
+
 @triton.jit
 def test_sync_block_all():
     al.sync_block_all("all_cube", 8)

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.extension.sync_block_set.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.extension.sync_block_set.py
@@ -1,3 +1,8 @@
+import triton
+import triton.language as tl
+import triton.language.extra.cann.extension as al
+
+
 @triton.jit
 def kernel_sync_cube_to_vector():
     with al.scope(core_mode="cube"):

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.extension.sync_block_wait.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.extension.sync_block_wait.py
@@ -1,3 +1,8 @@
+import triton
+import triton.language as tl
+import triton.language.extra.cann.extension as al
+
+
 @triton.jit
 def kernel_sync_vector_to_cube():
     with al.scope(core_mode="vector"):

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.acos.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.acos.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_acos():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.rand(size=shape, dtype=torch.float32).npu() * 1.8 - 0.9
+
+    torch_res = torch.acos(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_acos()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.acosh.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.acosh.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_acosh():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = (torch.rand(size=shape, dtype=torch.float32) * 3 + 1).npu()
+
+    torch_res = torch.acosh(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_acosh()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.asin.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.asin.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_asin():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.rand(size=shape, dtype=torch.float32).npu() * 1.8 - 0.9
+
+    torch_res = torch.asin(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_asin()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.asinh.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.asinh.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_asinh():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+
+    torch_res = torch.asinh(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_asinh()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.atan.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.atan.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_atan():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+
+    torch_res = torch.atan(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_atan()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.atan2.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.atan2.py
@@ -18,9 +18,18 @@ def triton_kernel(input, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOC
         tl.store(output + (x0), tmp2, mask=mask)
 
 
+def test_atan2():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+    x1 = (torch.randn(size=shape, dtype=torch.float32) * 0.5 + 1).npu()
+
+    torch_res = torch.atan2(x0, x1)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, x1, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    input2 = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, input2, output, xblock, xblock_sub)
+    test_atan2()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.atanh.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.atanh.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_atanh():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.rand(size=shape, dtype=torch.float32).npu() * 1.8 - 0.9
+
+    torch_res = torch.atanh(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_atanh()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.copysign.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.copysign.py
@@ -18,9 +18,18 @@ def triton_kernel(input, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOC
         tl.store(output + (x0), tmp2, mask=mask)
 
 
+def test_copysign():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+    x1 = (torch.randn(size=shape, dtype=torch.float32) * 0.5 + 1).npu()
+
+    torch_res = torch.copysign(x0, x1)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, x1, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    input2 = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, input2, output, xblock, xblock_sub)
+    test_copysign()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cosh.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cosh.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_cosh():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+
+    torch_res = torch.cosh(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_cosh()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cyl_bessel_i0.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cyl_bessel_i0.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_cyl_bessel_i0():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+
+    torch_res = torch.i0(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_cyl_bessel_i0()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_rz.py
@@ -1,3 +1,4 @@
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
@@ -18,9 +19,17 @@ def triton_kernel(input, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOC
         tl.store(output + (x0), tmp2, mask=mask)
 
 
+def test_div_rz():
+    x0 = torch.tensor([10.0, -10.0, 7.5, -7.5], dtype=torch.float32, device='npu')
+    x1 = torch.tensor([3.0, 3.0, 2.0, 2.0], dtype=torch.float32, device='npu')
+    n = x0.numel()
+    out = torch.empty(n, dtype=torch.float32, device='npu')
+
+    triton_kernel[(1, )](x0, x1, out, n, XBLOCK=n, XBLOCK_SUB=n)
+
+    expected = x0 / x1
+    torch.testing.assert_close(out, expected, rtol=1e-03, atol=1e-03)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    input2 = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, input2, output, xblock, xblock_sub)
+    test_div_rz()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfinv.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfinv.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_erfinv():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.rand(size=shape, dtype=torch.float32).npu() * 1.8 - 0.9
+
+    torch_res = torch.erfinv(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_erfinv()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.expm1.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.expm1.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_expm1():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+
+    torch_res = torch.expm1(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_expm1()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_dividef.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_dividef.py
@@ -18,9 +18,18 @@ def triton_kernel(input, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOC
         tl.store(output + (x0), tmp2, mask=mask)
 
 
+def test_fast_dividef():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+    x1 = torch.full(shape, 3.0, dtype=torch.float32, device='npu')
+
+    torch_res = x0 / 3.0
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, x1, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    input2 = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, input2, output, xblock, xblock_sub)
+    test_fast_dividef()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_expf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_expf.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_fast_expf():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+
+    torch_res = torch.exp(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_fast_expf()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fmod.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fmod.py
@@ -18,9 +18,18 @@ def triton_kernel(input, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOC
         tl.store(output + (x0), tmp2, mask=mask)
 
 
+def test_fmod():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+    x1 = (torch.randn(size=shape, dtype=torch.float32) * 0.5 + 1).npu()
+
+    torch_res = torch.fmod(x0, x1)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, x1, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    input2 = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, input2, output, xblock, xblock_sub)
+    test_fmod()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.gamma.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.gamma.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_gamma():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = (torch.rand(size=shape, dtype=torch.float32) * 5 + 0.1).npu()
+
+    torch_res = torch.exp(torch.lgamma(x0))
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_gamma()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.hypot.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.hypot.py
@@ -18,9 +18,18 @@ def triton_kernel(input, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOC
         tl.store(output + (x0), tmp2, mask=mask)
 
 
+def test_hypot():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+    x1 = (torch.randn(size=shape, dtype=torch.float32) * 0.5 + 1).npu()
+
+    torch_res = torch.hypot(x0, x1)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, x1, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    input2 = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, input2, output, xblock, xblock_sub)
+    test_hypot()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ilogb.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ilogb.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_ilogb():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+
+    torch_res = torch.floor(torch.log2(torch.abs(x0))).to(torch.int32)
+    triton_res = torch.empty_like(torch_res)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=0, atol=0, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_ilogb()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.isinf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.isinf.py
@@ -17,8 +17,20 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_isinf():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32)
+    x0.view(-1)[0] = float("inf")
+    x0.view(-1)[1] = -float("inf")
+    x0 = x0.npu()
+
+    torch_res = torch.isinf(x0).to(torch.int32)
+    triton_res = torch.empty(shape, dtype=torch.int32, device='npu')
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res.cpu(), triton_res.cpu(), rtol=0, atol=0)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_isinf()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.isnan.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.isnan.py
@@ -17,8 +17,20 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_isnan():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32)
+    x0.view(-1)[0] = float("nan")
+    x0.view(-1)[1] = float("inf")
+    x0 = x0.npu()
+
+    torch_res = torch.isnan(x0).to(torch.int32)
+    triton_res = torch.empty(shape, dtype=torch.int32, device='npu')
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res.cpu(), triton_res.cpu(), rtol=0, atol=0)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_isnan()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ldexp.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ldexp.py
@@ -18,9 +18,18 @@ def triton_kernel(input, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOC
         tl.store(output + (x0), tmp2, mask=mask)
 
 
+def test_ldexp():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+    x1 = torch.randint(-3, 4, size=shape, dtype=torch.int32, device='npu')
+
+    torch_res = x0 * (2.0**x1.float())
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, x1, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    input2 = torch.randint(0, 10, shape, dtype=torch.int32).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, input2, output, xblock, xblock_sub)
+    test_ldexp()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.lgamma.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.lgamma.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_lgamma():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = (torch.rand(size=shape, dtype=torch.float32) * 5 + 0.1).npu()
+
+    torch_res = torch.lgamma(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_lgamma()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log10.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log10.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_log10():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = (torch.rand(size=shape, dtype=torch.float32) * 5 + 0.1).npu()
+
+    torch_res = torch.log10(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_log10()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log1p.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log1p.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_log1p():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = (torch.rand(size=shape, dtype=torch.float32) * 5 + 0.1).npu()
+
+    torch_res = torch.log1p(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_log1p()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.nearbyint.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.nearbyint.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_nearbyint():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+
+    torch_res = torch.round(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_nearbyint()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.nextafter.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.nextafter.py
@@ -18,9 +18,18 @@ def triton_kernel(input, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOC
         tl.store(output + (x0), tmp2, mask=mask)
 
 
+def test_nextafter():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+    x1 = (torch.randn(size=shape, dtype=torch.float32) * 0.5 + 1).npu()
+
+    torch_res = torch.nextafter(x0, x1)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, x1, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    input2 = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, input2, output, xblock, xblock_sub)
+    test_nextafter()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.pow.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.pow.py
@@ -18,9 +18,18 @@ def triton_kernel(input, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOC
         tl.store(output + (x0), tmp2, mask=mask)
 
 
+def test_pow():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = (torch.rand(size=shape, dtype=torch.float32) * 2 + 0.1).npu()
+    x1 = (torch.rand(size=shape, dtype=torch.float32) * 2).npu()
+
+    torch_res = torch.pow(x0, x1)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, x1, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    input2 = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, input2, output, xblock, xblock_sub)
+    test_pow()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.reciprocal.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.reciprocal.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_reciprocal():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = (torch.randn(size=shape, dtype=torch.float32) * 2 + 1).npu()
+
+    torch_res = torch.reciprocal(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_reciprocal()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.relu.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.relu.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_relu():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+
+    torch_res = torch.relu(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_relu()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rint.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rint.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_rint():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+
+    torch_res = torch.round(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_rint()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.round.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.round.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_round():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+
+    torch_res = torch.round(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_round()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.signbit.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.signbit.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_signbit():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+
+    torch_res = torch.signbit(x0).to(torch.int32)
+    triton_res = torch.empty(shape, dtype=torch.int32, device='npu')
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=0, atol=0, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_signbit()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sinh.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sinh.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_sinh():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+
+    torch_res = torch.sinh(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_sinh()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.tan.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.tan.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_tan():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+
+    torch_res = torch.tan(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_tan()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.tanh.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.tanh.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_tanh():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+
+    torch_res = torch.tanh(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_tanh()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.trunc.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.trunc.py
@@ -17,8 +17,17 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+def test_trunc():
+    param_list = [(2, 256, 4), 2, 2048, 1024]
+    shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=torch.float32).npu() * 0.5
+
+    torch_res = torch.trunc(x0)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](x0, triton_res, x0.numel(), xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
 if __name__ == "__main__":
-    dtype, shape, ncore, xblock, xblock_sub = ['float32', (128, 4096), 512, 1024, 1024]
-    input = torch.randn(shape, dtype=eval('torch.' + dtype)).npu()
-    output = torch.zeros_like(input)
-    triton_kernel[ncore, 1, 1](input, output, xblock, xblock_sub)
+    test_trunc()

--- a/docs/zh/python-api/_examples/triton.language.floordiv.py
+++ b/docs/zh/python-api/_examples/triton.language.floordiv.py
@@ -1,3 +1,13 @@
+import triton
+import triton.language as tl
+import torch
+
+
+def torch_floordiv(x0, x1):
+    res = x0 // x1
+    return res
+
+
 @triton.jit
 def triton_kernel(out_ptr0, in_ptr0, in_ptr1, N: tl.constexpr):
     idx = tl.arange(0, N)
@@ -5,3 +15,20 @@ def triton_kernel(out_ptr0, in_ptr0, in_ptr1, N: tl.constexpr):
     y = tl.load(in_ptr1 + idx)
     ret = x // y
     tl.store(out_ptr0 + idx, ret)
+
+
+def test_floordiv():
+    param_list = ['int32', (2, 256, 2), 2]
+    dtype, shape, ncore = param_list
+    x0 = torch.randint(1, 10, size=shape, dtype=eval('torch.' + dtype)).npu()
+    x1 = torch.randint(1, 10, size=shape, dtype=eval('torch.' + dtype)).npu()
+
+    torch_res = torch_floordiv(x0, x1)
+    triton_res = torch.empty_like(x0)
+    triton_kernel[ncore, 1, 1](triton_res, x0, x1, N=x0.numel())
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=0, atol=0, equal_nan=True)
+
+
+if __name__ == '__main__':
+    test_floordiv()

--- a/docs/zh/python-api/_examples/triton.language.maximum.py
+++ b/docs/zh/python-api/_examples/triton.language.maximum.py
@@ -20,7 +20,7 @@ def triton_maximum(in_ptr0, in_ptr1, out_ptr0, xnumel, XBLOCK: tl.constexpr, XBL
         tl.store(out_ptr0 + x_index, tmp2, xmask)
 
 
-def test_maximum(param_list):
+def test_maximum():
     param_list = ['float32', (2, 4096, 8), 2, 32768, 1024]
     dtype, shape, ncore, xblock, xblock_sub = param_list
     x0 = torch.randn(size=shape, dtype=eval('torch.' + dtype)).npu()

--- a/docs/zh/python-api/_examples/triton.language.minimum.py
+++ b/docs/zh/python-api/_examples/triton.language.minimum.py
@@ -21,7 +21,7 @@ def triton_minimum(in_ptr0, in_ptr1, out_ptr0, xnumel, XBLOCK: tl.constexpr, XBL
         tl.store(out_ptr0 + x_index, tmp2, xmask)
 
 
-def test_minimum(param_list):
+def test_minimum():
     param_list = ['float32', (2, 4096, 8), 2, 32768, 1024]
     dtype, shape, ncore, xblock, xblock_sub = param_list
     x0 = torch.randn(size=shape, dtype=eval('torch.' + dtype)).npu()

--- a/docs/zh/python-api/_examples/triton.language.mod.py
+++ b/docs/zh/python-api/_examples/triton.language.mod.py
@@ -1,3 +1,13 @@
+import triton
+import triton.language as tl
+import torch
+
+
+def torch_mod(x0, x1):
+    res = x0 % x1
+    return res
+
+
 @triton.jit
 def triton_mod(in_ptr0, in_ptr1, out_ptr0, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
     offset = tl.program_id(0) * XBLOCK
@@ -9,3 +19,20 @@ def triton_mod(in_ptr0, in_ptr1, out_ptr0, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.
         tmp1 = tl.load(in_ptr1 + (x0), None)
         tmp2 = tmp0 % tmp1
         tl.store(out_ptr0 + (x0), tmp2, None)
+
+
+def test_mod():
+    param_list = ['int32', (2, 4096, 8), 2, 32768, 1024]
+    dtype, shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randint(1, 10, size=shape, dtype=eval('torch.' + dtype)).npu()
+    x1 = torch.randint(1, 10, size=shape, dtype=eval('torch.' + dtype)).npu()
+
+    torch_res = torch_mod(x0, x1)
+    triton_res = torch.empty_like(x0)
+    triton_mod[ncore, 1, 1](x0, x1, triton_res, xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=0, atol=0, equal_nan=True)
+
+
+if __name__ == '__main__':
+    test_mod()

--- a/docs/zh/python-api/_examples/triton.language.mul.py
+++ b/docs/zh/python-api/_examples/triton.language.mul.py
@@ -1,3 +1,13 @@
+import triton
+import triton.language as tl
+import torch
+
+
+def torch_mul(x0, x1):
+    res = x0 * x1
+    return res
+
+
 @triton.jit
 def triton_mul(in_ptr0, in_ptr1, out_ptr0, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
     offset = tl.program_id(0) * XBLOCK
@@ -10,3 +20,20 @@ def triton_mul(in_ptr0, in_ptr1, out_ptr0, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.
         tmp1 = tl.load(in_ptr1 + (x0), None)
         tmp2 = tmp0 * tmp1
         tl.store(out_ptr0 + (x0), tmp2, None)
+
+
+def test_mul():
+    param_list = ['float32', (2, 4096, 8), 2, 32768, 1024]
+    dtype, shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=eval('torch.' + dtype)).npu()
+    x1 = torch.randn(size=shape, dtype=eval('torch.' + dtype)).npu()
+
+    torch_res = torch_mul(x0, x1)
+    triton_res = torch.empty_like(x0)
+    triton_mul[ncore, 1, 1](x0, x1, triton_res, xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
+
+
+if __name__ == '__main__':
+    test_mul()

--- a/docs/zh/python-api/_examples/triton.language.num_programs.py
+++ b/docs/zh/python-api/_examples/triton.language.num_programs.py
@@ -1,1 +1,20 @@
-triton.language.num_programs(axis)
+import triton
+import triton.language as tl
+import torch
+
+
+@triton.jit
+def kernel(out_ptr):
+    nprog = tl.num_programs(0)
+    tl.store(out_ptr, nprog)
+
+
+def test_num_programs():
+    ncore = 4
+    out = torch.empty(1, dtype=torch.int32, device='npu')
+    kernel[ncore, 1, 1](out)
+    assert out.cpu().item() == ncore
+
+
+if __name__ == "__main__":
+    test_num_programs()

--- a/docs/zh/python-api/_examples/triton.language.program_id.py
+++ b/docs/zh/python-api/_examples/triton.language.program_id.py
@@ -1,1 +1,23 @@
-triton.language.program_id(axis)
+import triton
+import triton.language as tl
+import torch
+
+
+@triton.jit
+def kernel(out_ptr, N: tl.constexpr):
+    pid = tl.program_id(0)
+    offsets = pid * N + tl.arange(0, N)
+    tl.store(out_ptr + offsets, pid)
+
+
+def test_program_id():
+    N = 64
+    ncore = 4
+    out = torch.empty(ncore * N, dtype=torch.int32, device='npu')
+    kernel[ncore, 1, 1](out, N=N)
+    expected = torch.cat([torch.full((N, ), i, dtype=torch.int32) for i in range(ncore)])
+    assert torch.equal(out.cpu(), expected)
+
+
+if __name__ == "__main__":
+    test_program_id()

--- a/docs/zh/python-api/_examples/triton.language.randint4x.py
+++ b/docs/zh/python-api/_examples/triton.language.randint4x.py
@@ -7,23 +7,30 @@ import math
 @triton.jit
 def kernel_randint4x(x_ptr, n_rounds: tl.constexpr, N: tl.constexpr, XBLOCK: tl.constexpr):
     block_offset = tl.program_id(0) * XBLOCK
-    indices = tl.arange(0, 4)
     block_size = XBLOCK if block_offset + XBLOCK <= N else N - block_offset
     for inner_idx in range(0, block_size, step=4):
         global_offset = block_offset + inner_idx
-        rand_vals = tl.randint4x(5, 10 + global_offset, n_rounds)  # Generate random numbers for each index
-        mask = (global_offset + indices) < N
-        tl.store(x_ptr + global_offset + indices, rand_vals, mask)  # Store the random numbers
+        # randint4x returns a tuple of 4 tensors, unpack them
+        r0, r1, r2, r3 = tl.randint4x(5, 10 + global_offset, n_rounds)
+        mask0 = (global_offset + 0) < N
+        mask1 = (global_offset + 1) < N
+        mask2 = (global_offset + 2) < N
+        mask3 = (global_offset + 3) < N
+        tl.store(x_ptr + global_offset + 0, r0, mask=mask0)
+        tl.store(x_ptr + global_offset + 1, r1, mask=mask1)
+        tl.store(x_ptr + global_offset + 2, r2, mask=mask2)
+        tl.store(x_ptr + global_offset + 3, r3, mask=mask3)
 
 
 def test_randint4x():
-    shape = (1, 3)
-
-    y_cali = torch.zeros(shape, dtype=eval('torch.int32')).npu()
-    numel = y_cali.numel()
-    ncore = 1 if numel < 32 else 32
+    shape = (32, )
+    y = torch.zeros(shape, dtype=torch.int32, device='npu')
+    numel = y.numel()
+    ncore = 1 if numel < 32 else 2
     xblock = math.ceil(numel / ncore)
-    kernel_randint4x[ncore, 1, 1](y_cali, 10, numel, xblock)
+    kernel_randint4x[ncore, 1, 1](y, 10, numel, xblock)
+    # Verify that random values were written (non-zero in at least some positions)
+    assert y.min().item() != y.max().item(), "Expected random values to vary"
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.sub.py
+++ b/docs/zh/python-api/_examples/triton.language.sub.py
@@ -1,3 +1,13 @@
+import triton
+import triton.language as tl
+import torch
+
+
+def torch_sub(x0, x1):
+    res = x0 - x1
+    return res
+
+
 @triton.jit
 def triton_sub(in_ptr0, in_ptr1, out_ptr0, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
     offset = tl.program_id(0) * XBLOCK
@@ -10,3 +20,20 @@ def triton_sub(in_ptr0, in_ptr1, out_ptr0, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.
         tmp1 = tl.load(in_ptr1 + (x0), None)
         tmp2 = tmp0 - tmp1
         tl.store(out_ptr0 + (x0), tmp2, None)
+
+
+def test_sub():
+    param_list = ['float32', (2, 4096, 8), 2, 32768, 1024]
+    dtype, shape, ncore, xblock, xblock_sub = param_list
+    x0 = torch.randn(size=shape, dtype=eval('torch.' + dtype)).npu()
+    x1 = torch.randn(size=shape, dtype=eval('torch.' + dtype)).npu()
+
+    torch_res = torch_sub(x0, x1)
+    triton_res = torch.empty_like(x0)
+    triton_sub[ncore, 1, 1](x0, x1, triton_res, xblock, xblock_sub)
+
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
+
+
+if __name__ == '__main__':
+    test_sub()

--- a/docs/zh/python-api/_examples/triton.language.sync_block.py
+++ b/docs/zh/python-api/_examples/triton.language.sync_block.py
@@ -1,1 +1,0 @@
-triton.language.sync_block_set(sender, receiver, event_id, _builder=None)


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
### Summary
Added test_* functions and missing imports to ~70 example files under docs/zh/python-api/_examples/, turning documentation code snippets into runnable pytest test cases. Also added a new CI step that runs these tests.\
### Why
The example files under _examples/ were originally designed only for Sphinx documentation injection — most had no test functions and many were missing basic imports, so they could not be validated. Additionally, the dotted filenames (e.g. triton.language.sqrt.py) prevented pytest from collecting them by default.
This change ensures that example code stays correct and runnable by:
- Adding test functions for libdevice ops (38 files), arithmetic ops (add/div/mul/sub/floordiv/mod), and API helpers (Config/autotune/jit/heuristics)
- Skip ops (gather_out_to_ub, scatter_ub_to_out, index_put) on non-950 hardware
- Running all examples in CI with --import-mode=importlib to handle dotted filenames

### Impact
- New CI step: Run API doc example tests on NPU added to integration-tests-ascend.yml, running pytest docs/zh/python-api/_examples/ --override-ini="python_files=triton.*.py" on every Ascend integration test run.
- No breaking changes: changes are scoped to example files and CI config only; no core source code is affected.
# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
