### PR TITLE
[revert](feat) wrap associative_scan (#1256)  

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/CMakeLists.txt
+++ b/third_party/ascend/lib/TritonToLinalg/CMakeLists.txt
@@ -29,7 +29,6 @@ add_triton_library(TritonToLinalg
   MLIRTransforms
   MLIRSupport
   BiShengIRHIVMDialect
-  BiShengIRScopeDialect
   TritonIR
   TritonTransforms
   TritonAnalysis

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -58,7 +58,6 @@
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "bishengir/Dialect/HFusion/IR/HFusion.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
-#include "bishengir/Dialect/Scope/IR/Scope.h"
 
 namespace TTOpConverters {
 using namespace mlir;
@@ -1332,18 +1331,7 @@ ScanConverter::convertToTargetOp(triton::ScanOp op,
     auto memrefType = MemRefType::get(shape, elementType);
     Value inputMemRef =
         rewriter.create<bufferization::ToBufferOp>(loc, memrefType, scanInput);
-
-    // Wrap scan logic in a scope with UB address space for the output buffer.
-    auto tensorResultType = RankedTensorType::get(shape, elementType);
-    auto scopeOp =
-        rewriter.create<scope::ScopeOp>(loc, TypeRange{tensorResultType});
-    scopeOp.getBodyRegion().emplaceBlock();
-    rewriter.setInsertionPointToEnd(&scopeOp.getBodyRegion().front());
-
-    auto ubMemRefType = MemRefType::get(
-        shape, elementType, nullptr,
-        rewriter.getAttr<hivm::AddressSpaceAttr>(hivm::AddressSpace::UB));
-    Value outputMemRef = rewriter.create<memref::AllocOp>(loc, ubMemRefType);
+    Value outputMemRef = rewriter.create<memref::AllocOp>(loc, memrefType);
 
     auto processDimension = [&](ArrayRef<Value> baseIdxsArray) {
       auto startInd = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
@@ -1440,17 +1428,13 @@ ScanConverter::convertToTargetOp(triton::ScanOp op,
     createSimpleNestedLoops(rewriter, loc, outputMemRef, nonScanDims,
                             processDimension);
 
+    rewriter.setInsertionPointAfter(op);
+
     mlir::Type resultType = mlir::memref::getTensorTypeFromMemRefType(
         dyn_cast<mlir::MemRefType>(outputMemRef.getType()));
     Value outputTensor = rewriter.create<bufferization::ToTensorOp>(
         loc, resultType, outputMemRef, true);
-    rewriter.create<scope::ReturnOp>(loc, ValueRange{outputTensor});
-
-    scopeOp->setAttr(hivm::TCoreTypeAttr::name,
-                     hivm::TCoreTypeAttr::get(rewriter.getContext(),
-                                              hivm::TCoreType::VECTOR));
-
-    rewriter.replaceOp(op, scopeOp.getResult(0));
+    rewriter.replaceOp(op, outputTensor);
     return success();
   }
 }

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -57,7 +57,6 @@
 
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
-#include "bishengir/Dialect/Scope/IR/Scope.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
@@ -511,13 +510,13 @@ void TritonToLinalgPass::convertTTFunc(triton::FuncOp func, const bool existDot,
 
 void TritonToLinalgPass::addDynamicLegal(
     ConversionTarget &target, TritonTypeConverter &tritonTypeConverter) {
-  target.addLegalDialect<
-      func::FuncDialect, arith::ArithDialect, math::MathDialect,
-      linalg::LinalgDialect, affine::AffineDialect, scf::SCFDialect,
-      cf::ControlFlowDialect, tensor::TensorDialect, LLVM::LLVMDialect,
-      bufferization::BufferizationDialect, memref::MemRefDialect,
-      annotation::AnnotationDialect, hivm::HIVMDialect, hfusion::HFusionDialect,
-      scope::ScopeDialect>();
+  target.addLegalDialect<func::FuncDialect, arith::ArithDialect,
+                         math::MathDialect, linalg::LinalgDialect,
+                         affine::AffineDialect, scf::SCFDialect,
+                         cf::ControlFlowDialect, tensor::TensorDialect,
+                         LLVM::LLVMDialect, bufferization::BufferizationDialect,
+                         memref::MemRefDialect, annotation::AnnotationDialect,
+                         hivm::HIVMDialect, hfusion::HFusionDialect>();
 
   // add legal dialect on condition
   target.addLegalOp<ModuleOp>();
@@ -752,12 +751,11 @@ void TritonToLinalgPass::populateTritonToLinalgConversionPatterns(
 }
 
 void TritonToLinalgPass::getDependentDialects(DialectRegistry &registry) const {
-  registry
-      .insert<func::FuncDialect, arith::ArithDialect, math::MathDialect,
-              linalg::LinalgDialect, affine::AffineDialect, scf::SCFDialect,
-              tensor::TensorDialect, bufferization::BufferizationDialect,
-              memref::MemRefDialect, hfusion::HFusionDialect, hivm::HIVMDialect,
-              annotation::AnnotationDialect, scope::ScopeDialect>();
+  registry.insert<func::FuncDialect, arith::ArithDialect, math::MathDialect,
+                  linalg::LinalgDialect, affine::AffineDialect, scf::SCFDialect,
+                  tensor::TensorDialect, bufferization::BufferizationDialect,
+                  memref::MemRefDialect, hfusion::HFusionDialect,
+                  hivm::HIVMDialect, annotation::AnnotationDialect>();
 }
 
 LogicalResult


### PR DESCRIPTION
Revert "[TritonToLinalg](feat) wrap associative_scan with scope and add UB/tcore_type attributes (#1256)"

This reverts commit 2cd9bff94347ca8dec5de86e1e2b9dd4104400b3.
