### PR TITLE
[Autotune](feat) print per-config benchmark timings

### DIFF
--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -80,6 +80,14 @@ def _inject_default_simt_stack_limit(options: Dict[str, object], stack_limit: in
         options["simt_stack_limit"] = stack_limit
 
 
+def _format_autotune_timing(timing) -> str:
+    """Format the timing returned by the active autotune benchmarker."""
+    if isinstance(timing, (tuple, list)):
+        labels = ("p50", "p20", "p80")
+        return ", ".join(f"{label}={value:.4f} ms" for label, value in zip(labels, timing))
+    return f"mean={timing:.4f} ms"
+
+
 def _get_constexpr_candidates_from_fn(fn) -> List[str]:
     """
     Returns all constexpr parameter names from the kernel function definition.
@@ -2140,6 +2148,7 @@ class AutoTilingTuner(Autotuner):
         if self.print_autotuning and did_benchmark:
             print(f"Triton autotuning for function {self.base_fn.__name__} finished after "
                   f"{self.bench_time:.2f}s; best config selected: {self.best_config};")
+            self._print_benchmark_results(self.configs_timings)
 
         if did_benchmark and self.auto_profile_dir is not None:
             self._profile(*args, config=self.best_config, **kwargs)
@@ -2179,6 +2188,15 @@ class AutoTilingTuner(Autotuner):
         except Exception as e:
             if self.print_autotuning:
                 print(f"[WARN] encounter exception when try ubtune, Details: {e}")
+
+    def _print_benchmark_results(self, timings) -> None:
+        if not self.print_autotuning:
+            return
+
+        print(f"Triton autotuning benchmark results for function {self.base_fn.__name__}:")
+        for config, timing in timings.items():
+            selected = " [selected]" if config == self.best_config else ""
+            print(f"  config={config}; {_format_autotune_timing(timing)}{selected}")
 
     def _batch_bench(self, *args, configs, **kwargs):
         from triton.compiler.errors import CompileTimeAssertionFailure, MLIRCompilationError
@@ -2614,7 +2632,8 @@ def autotune(configs, key, prune_configs_by=None, reset_to_zero=None, restore_va
 
     If the environment variable :code:`TRITON_PRINT_AUTOTUNING` is set to
     :code:`"1"`, Triton will print a message to stdout after autotuning each
-    kernel, including the time spent autotuning and the best configuration.
+    kernel, including the benchmark timing for each valid configuration, the
+    time spent autotuning, and the best configuration.
 
     :param configs: a list of :code:`triton.Config` objects
     :type configs: list[triton.Config]

--- a/third_party/ascend/unittest/autotune_ut/test_do_bench_compat.py
+++ b/third_party/ascend/unittest/autotune_ut/test_do_bench_compat.py
@@ -170,6 +170,62 @@ def test_autotilingtuner_marks_user_defined_do_bench():
     assert marker["called"] is False
 
 
+def test_print_benchmark_results_formats_quantiles_and_selected_config(capsys):
+
+    def _dummy_kernel():
+        return None
+
+    selected = Config({"BLOCK_SIZE": 128}, num_warps=4)
+    other = Config({"BLOCK_SIZE": 256}, num_warps=8)
+    tuner = object.__new__(AutoTilingTuner)
+    tuner.print_autotuning = True
+    tuner.base_fn = _dummy_kernel
+    tuner.best_config = selected
+
+    tuner._print_benchmark_results({
+        selected: (1.23456, 1.0, 1.8),
+        other: 2.34567,
+    })
+
+    output = capsys.readouterr().out
+    assert "Triton autotuning benchmark results for function _dummy_kernel:" in output
+    assert "config=BLOCK_SIZE: 128, num_warps: 4" in output
+    assert "p50=1.2346 ms, p20=1.0000 ms, p80=1.8000 ms [selected]" in output
+    assert "config=BLOCK_SIZE: 256, num_warps: 8" in output
+    assert "mean=2.3457 ms" in output
+
+
+def test_print_benchmark_results_is_disabled_without_debug_flag(capsys):
+    tuner = object.__new__(AutoTilingTuner)
+    tuner.print_autotuning = False
+
+    tuner._print_benchmark_results({Config({"BLOCK_SIZE": 128}): 1.0})
+
+    assert capsys.readouterr().out == ""
+
+
+def test_run_prints_benchmark_results_after_tuning(capsys):
+
+    def _dummy_kernel():
+        return None
+
+    selected = Config({"BLOCK_SIZE": 128}, num_warps=4)
+    other = Config({"BLOCK_SIZE": 256}, num_warps=8)
+    tuner, _ = _make_run_tuner([selected, other])
+    tuner.cache_results = False
+    tuner.print_autotuning = True
+    tuner.base_fn = _dummy_kernel
+    tuner._batch_bench = lambda *args, configs, **kwargs: {
+        selected: (1.0, 0.9, 1.1),
+        other: (2.0, 1.8, 2.2),
+    }
+
+    assert tuner.run() == "kernel-result"
+    output = capsys.readouterr().out
+    assert "Triton autotuning benchmark results for function _dummy_kernel:" in output
+    assert "p50=1.0000 ms, p20=0.9000 ms, p80=1.1000 ms [selected]" in output
+
+
 def test_ascend_autotune_decorator_forwards_do_bench(monkeypatch):
     import triton.backends.ascend.runtime.autotuner as ascend_autotuner
 


### PR DESCRIPTION
## What changed

- Print each valid autotune configuration's benchmark timing when `TRITON_PRINT_AUTOTUNING=1` is enabled.
- Format default benchmark results as `p50`, `p20`, and `p80`; format NPU profiler results as the mean time in milliseconds.
- Mark the configuration selected by autotune and add unit coverage for formatting, flag gating, and the `AutoTilingTuner.run()` integration.

## Why

The Ascend autotuner already stores the per-configuration results in `configs_timings`, but only reported the total tuning time and selected configuration. This makes the candidate performance comparison visible without changing the benchmark selection logic.

## Output format

Enable the output before the autotuner is constructed:

```bash
export TRITON_PRINT_AUTOTUNING=1
```

After an actual benchmark run, the autotuner writes the summary and per-configuration timings to stdout:

```text
Triton autotuning for function <function_name> finished after <total_seconds:.2f>s; best config selected: <best_config>;
Triton autotuning benchmark results for function <function_name>:
  config=<config>; p50=<p50_ms:.4f> ms, p20=<p20_ms:.4f> ms, p80=<p80_ms:.4f> ms [selected]
  config=<config>; mean=<mean_ms:.4f> ms
```

- Tuple/list benchmark results are labeled `p50`, `p20`, and `p80`, in that order, with four decimal places.
- Scalar benchmark results are labeled `mean`, also with four decimal places.
- The selected configuration is suffixed with ` [selected]`.
- Only valid, benchmarked configurations are listed. The block is not printed on an in-memory/disk cache hit or when no benchmark is needed.

