### PR TITLE
[ssbuffer](fix) Normalize logs

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UBUsageOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UBUsageOptPass.cpp
@@ -776,8 +776,7 @@ llvm::LogicalResult UBUsageOptPass::UBUsageOptimization(
   }
 
   if (applyRecordChange(recordChange, nodeId2op, memGraph, bm)) {
-    // FIXME: it shouldn't happen....
-    llvm::errs() << "Some skiped when apply UB usage optimization changes.\n";
+    LOG_DEBUG("Some skiped when apply UB usage optimization changes.\n");
   }
   return llvm::success();
 }
@@ -932,15 +931,15 @@ void mlir::triton::UBUsageOptPass::runOnOperation() {
 
   for (Block *block : blocks) {
     if (UBUsageOptimization(block, memDepGraph, bm).failed()) {
-      llvm::errs() << "UB usage optimization failed in block.\n";
+      LOG_DEBUG("UB usage optimization failed in block.\n");
     }
     if (isUBRefineOptEnabled) {
       if (optBroadcast(block, memDepGraph, bm).failed()) {
-        llvm::errs() << "Broadcast check failed in block.\n";
+        LOG_DEBUG("Broadcast check failed in block.\n");
       }
 
       if (optSmallBlock(block, memDepGraph, bm).failed()) {
-        llvm::errs() << "Small block optimization failed in block.\n";
+        LOG_DEBUG("Small block optimization failed in block.\n");
       }
     }
   }


### PR DESCRIPTION

[ssbuffer](fix) Normalize logs in UBUsageOpt
not use llvm::errs() when correct scenario


# New contributor declaration
- [ x ] I am not making a trivial change, such as fixing a typo in a comment.

- [ x ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ x ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ x ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ x ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
