### PR TITLE
[ssbuffer](fix) fix multi output in multi-buffer innerscope

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
@@ -507,14 +507,15 @@ static bool isEmptyFillPattern(Value depVal) {
 SmallVector<Value>
 collectBufferValues(DenseMap<Value, SmallVector<Value>> &depValueMap) {
   SmallVector<Value> valueList;
-  SmallVector<Operation *> seenOps;
+  llvm::DenseSet<Value> seenVals;
 
   for (auto &p : depValueMap) {
     for (Value depVal : p.second) {
       Operation *op = depVal.getDefiningOp();
-      if (!op || llvm::is_contained(seenOps, op))
+      if (!op)
         continue;
-      seenOps.push_back(op);
+      if (!seenVals.insert(depVal).second)
+        continue;
 
       auto shapedType = dyn_cast<ShapedType>(depVal.getType());
       if (!shapedType)
@@ -1716,7 +1717,7 @@ static int processTensorDependencies(
     DenseMap<Value, SmallVector<Value>> &depValueMap,
     DenseMap<Value, SmallVector<Operation *>> &depUserMap, BufferMap &bufferMap,
     OpBuilder &globalBuilder, int &groupId) {
-  SmallVector<Operation *> seenOps;
+  llvm::DenseSet<Value> seenVals;
 
   for (auto &blockPair : blocks) {
     Value blockKey = blockPair.first;
@@ -1728,9 +1729,8 @@ static int processTensorDependencies(
 
     for (Value depVal : depValues) {
       // Skip if already processed
-      if (llvm::is_contained(seenOps, depVal.getDefiningOp()))
+      if (!seenVals.insert(depVal).second)
         continue;
-      seenOps.push_back(depVal.getDefiningOp());
 
       // Validate dependency value (skip BlockArgument, null definingOp,
       // non-ShapedType)


### PR DESCRIPTION
This pull request is designed to fix the scenario where one op has multiple outputs which are tensor-type dependent values.