### PR TITLE
[FP_TO_FP](fix) Fix scalar RTNE and same-width fp-to-fp lowering

### DIFF
--- a/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
@@ -74,9 +74,14 @@ public:
 Convert `tt.fp_to_fp` operation with RTNE (default) rounding mode to
 `arith.truncf` or `arith.extf` operation.
 
-For fp8 conversions with default RTNE rounding:
+For default RTNE rounding:
 - downcast: tt.fp_to_fp -> arith.truncf
 - upcast: tt.fp_to_fp -> arith.extf
+- same-bitwidth conversions between distinct floating-point formats:
+  tt.fp_to_fp -> arith.extf (to f32) -> arith.truncf
+
+Only an operation whose complete input and result MLIR types are identical can
+be eliminated as an identity conversion.
 
 Note: Non-RTNE rounding modes (e.g., RTZ) are handled by TritonToHFusion pass.
 */

--- a/third_party/ascend/lib/TritonToHFusion/TritonToHFusion.cpp
+++ b/third_party/ascend/lib/TritonToHFusion/TritonToHFusion.cpp
@@ -97,10 +97,11 @@ struct TritonFpToFpToHFusionConversion : OpRewritePattern<triton::FpToFpOp> {
       return failure();
     }
 
-    // Only non-RTNE tensor conversions are lowered to HFusion.
-    auto srcType = dyn_cast<TensorType>(input.getType());
-    auto dstType = dyn_cast<TensorType>(resultType);
-    if (!srcType || !dstType || !srcType.getElementType().isIntOrFloat() ||
+    // HFusion owns only non-RTNE tensor conversions. Keep the tensor
+    // precondition checked here; a scalar must not silently fall through.
+    auto srcType = cast<TensorType>(input.getType());
+    auto dstType = cast<TensorType>(resultType);
+    if (!srcType.getElementType().isIntOrFloat() ||
         !dstType.getElementType().isIntOrFloat()) {
       return failure();
     }

--- a/third_party/ascend/lib/TritonToHFusion/TritonToHFusion.cpp
+++ b/third_party/ascend/lib/TritonToHFusion/TritonToHFusion.cpp
@@ -100,8 +100,7 @@ struct TritonFpToFpToHFusionConversion : OpRewritePattern<triton::FpToFpOp> {
     // Only non-RTNE tensor conversions are lowered to HFusion.
     auto srcType = dyn_cast<TensorType>(input.getType());
     auto dstType = dyn_cast<TensorType>(resultType);
-    if (!srcType || !dstType ||
-        !srcType.getElementType().isIntOrFloat() ||
+    if (!srcType || !dstType || !srcType.getElementType().isIntOrFloat() ||
         !dstType.getElementType().isIntOrFloat()) {
       return failure();
     }

--- a/third_party/ascend/lib/TritonToHFusion/TritonToHFusion.cpp
+++ b/third_party/ascend/lib/TritonToHFusion/TritonToHFusion.cpp
@@ -87,21 +87,22 @@ struct TritonFpToFpToHFusionConversion : OpRewritePattern<triton::FpToFpOp> {
     Value input = op.getSrc();
     auto resultType = op.getResult().getType();
 
-    // Only handle float-to-float conversions with non-RTNE rounding modes
-    // RTNE (default) rounding is handled by TritonToLinalg pass using
-    // arith.truncf/extf
-    auto srcType = cast<TensorType>(input.getType());
-    auto dstType = cast<TensorType>(resultType);
-    if (!srcType.getElementType().isIntOrFloat() ||
-        !dstType.getElementType().isIntOrFloat()) {
-      return failure();
-    }
-
-    // Check if this has a non-RTNE rounding mode
+    // RTNE (default) rounding is handled by TritonToLinalg using
+    // arith.truncf/extf. Check this before querying tensor-only properties:
+    // scalar fp_to_fp operations are valid Triton IR too.
     auto roundingMode = op.getRounding();
     if (!roundingMode.has_value() ||
         roundingMode.value() == triton::RoundingMode::RTNE) {
       // RTNE or no rounding mode specified: let TritonToLinalg handle it
+      return failure();
+    }
+
+    // Only non-RTNE tensor conversions are lowered to HFusion.
+    auto srcType = dyn_cast<TensorType>(input.getType());
+    auto dstType = dyn_cast<TensorType>(resultType);
+    if (!srcType || !dstType ||
+        !srcType.getElementType().isIntOrFloat() ||
+        !dstType.getElementType().isIntOrFloat()) {
       return failure();
     }
 

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -51,6 +51,7 @@
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Interfaces/CallInterfaces.h"
@@ -453,11 +454,10 @@ FpToFpCanonicalizer::matchAndRewrite(triton::FpToFpOp op,
     return failure();
   }
 
-  // Handle RTNE (default) rounding mode with arith.truncf/extf
-  auto srcType = cast<RankedTensorType>(input.getType());
-  auto dstType = cast<RankedTensorType>(resultType);
-  auto srcElemType = srcType.getElementType();
-  auto dstElemType = dstType.getElementType();
+  // Handle RTNE (default) rounding mode with arith.truncf/extf. This can be
+  // either a scalar conversion or a ranked tensor conversion.
+  auto srcElemType = getElementTypeOrSelf(input.getType());
+  auto dstElemType = getElementTypeOrSelf(resultType);
   if (!isa<FloatType>(srcElemType) || !isa<FloatType>(dstElemType)) {
     return op.emitError("FpToFp expects floating point types");
   }
@@ -471,12 +471,12 @@ FpToFpCanonicalizer::matchAndRewrite(triton::FpToFpOp op,
 
   if (srcBitwidth > dstBitwidth) {
     // Downcast: use arith.truncf with round_mode=rint
-    auto truncOp = rewriter.create<arith::TruncFOp>(loc, dstType, input);
+    auto truncOp = rewriter.create<arith::TruncFOp>(loc, resultType, input);
     truncOp->setAttr("round_mode", roundModeAttr);
     rewriter.replaceOp(op, truncOp.getResult());
   } else if (srcBitwidth < dstBitwidth) {
     // Upcast: use arith.extf with round_mode=rint
-    auto extOp = rewriter.create<arith::ExtFOp>(loc, dstType, input);
+    auto extOp = rewriter.create<arith::ExtFOp>(loc, resultType, input);
     extOp->setAttr("round_mode", roundModeAttr);
     rewriter.replaceOp(op, extOp.getResult());
   } else {

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -469,19 +469,51 @@ FpToFpCanonicalizer::matchAndRewrite(triton::FpToFpOp op,
   auto roundModeAttr = hfusion::RoundModeAttr::get(rewriter.getContext(),
                                                    hfusion::RoundMode::RINT);
 
-  if (srcBitwidth > dstBitwidth) {
+  // A no-op conversion is valid only when the complete MLIR type is identical.
+  // Equal element bitwidth alone is insufficient: FP8 formats such as
+  // f8E4M3FN and f8E5M2 have different numerical semantics.
+  if (input.getType() == resultType) {
+    rewriter.replaceOp(op, input);
+    return success();
+  }
+
+  if (srcBitwidth == dstBitwidth) {
+    if (srcElemType == dstElemType) {
+      return op.emitError(
+          "fp_to_fp with identical element types has incompatible "
+          "container or layout types");
+    }
+
+    // arith.extf/truncf require a strict bitwidth change. Materialize an f32
+    // intermediate so the conversion remains a numerical cast in TTAdapter
+    // IR and can follow the normal Bisheng lowering path.
+    Type f32Type;
+    if (auto tensorType = dyn_cast<RankedTensorType>(input.getType())) {
+      f32Type =
+          RankedTensorType::get(tensorType.getShape(), rewriter.getF32Type(),
+                                tensorType.getEncoding());
+    } else if (isa<FloatType>(input.getType())) {
+      f32Type = rewriter.getF32Type();
+    } else {
+      return op.emitError("FpToFp expects a scalar or ranked tensor type");
+    }
+
+    auto extOp = rewriter.create<arith::ExtFOp>(loc, f32Type, input);
+    extOp->setAttr("round_mode", roundModeAttr);
+    auto truncOp =
+        rewriter.create<arith::TruncFOp>(loc, resultType, extOp.getResult());
+    truncOp->setAttr("round_mode", roundModeAttr);
+    rewriter.replaceOp(op, truncOp.getResult());
+  } else if (srcBitwidth > dstBitwidth) {
     // Downcast: use arith.truncf with round_mode=rint
     auto truncOp = rewriter.create<arith::TruncFOp>(loc, resultType, input);
     truncOp->setAttr("round_mode", roundModeAttr);
     rewriter.replaceOp(op, truncOp.getResult());
-  } else if (srcBitwidth < dstBitwidth) {
+  } else {
     // Upcast: use arith.extf with round_mode=rint
     auto extOp = rewriter.create<arith::ExtFOp>(loc, resultType, input);
     extOp->setAttr("round_mode", roundModeAttr);
     rewriter.replaceOp(op, extOp.getResult());
-  } else {
-    // Same bitwidth, should not happen but handle gracefully
-    rewriter.replaceOp(op, input);
   }
 
   return success();

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/fp_to_fp_scalar_rtne.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/fp_to_fp_scalar_rtne.mlir
@@ -1,0 +1,11 @@
+// RUN: triton-opt --triton-to-hfusion --triton-to-linalg %s | FileCheck %s
+
+// CHECK-LABEL: func.func @scalar_fp32_to_fp8_rtne
+// CHECK: %[[CAST:.*]] = arith.truncf %{{.*}} {round_mode = #hfusion.round_mode<rint>} : f32 to f8E4M3FN
+// CHECK: return %[[CAST]] : f8E4M3FN
+module {
+  tt.func @scalar_fp32_to_fp8_rtne(%arg0: f32) -> f8E4M3FN {
+    %0 = tt.fp_to_fp %arg0, rounding = rtne : f32 -> f8E4M3FN
+    tt.return %0 : f8E4M3FN
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/fp_to_fp_scalar_rtne.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/fp_to_fp_scalar_rtne.mlir
@@ -1,11 +1,84 @@
 // RUN: triton-opt --triton-to-hfusion --triton-to-linalg %s | FileCheck %s
 
 // CHECK-LABEL: func.func @scalar_fp32_to_fp8_rtne
+// CHECK-NOT: tt.fp_to_fp
 // CHECK: %[[CAST:.*]] = arith.truncf %{{.*}} {round_mode = #hfusion.round_mode<rint>} : f32 to f8E4M3FN
+// CHECK-NOT: tt.fp_to_fp
 // CHECK: return %[[CAST]] : f8E4M3FN
+// CHECK-LABEL: func.func @scalar_fp8_to_fp32_rtne
+// CHECK-NOT: tt.fp_to_fp
+// CHECK: %[[FP8_TO_F32:.*]] = arith.extf %{{.*}} {round_mode = #hfusion.round_mode<rint>} : f8E4M3FN to f32
+// CHECK-NOT: tt.fp_to_fp
+// CHECK: return %[[FP8_TO_F32]] : f32
+// CHECK-LABEL: func.func @scalar_f8e4m3fn_to_f8e5m2_rtne
+// CHECK-NOT: tt.fp_to_fp
+// CHECK: %[[E4_TO_F32:.*]] = arith.extf %{{.*}} {round_mode = #hfusion.round_mode<rint>} : f8E4M3FN to f32
+// CHECK-NOT: tt.fp_to_fp
+// CHECK: %[[F32_TO_E5:.*]] = arith.truncf %[[E4_TO_F32]] {round_mode = #hfusion.round_mode<rint>} : f32 to f8E5M2
+// CHECK-NOT: tt.fp_to_fp
+// CHECK: return %[[F32_TO_E5]] : f8E5M2
+// CHECK-LABEL: func.func @scalar_f8e5m2_to_f8e4m3fn_default
+// CHECK-NOT: tt.fp_to_fp
+// CHECK: %[[E5_TO_F32:.*]] = arith.extf %{{.*}} {round_mode = #hfusion.round_mode<rint>} : f8E5M2 to f32
+// CHECK-NOT: tt.fp_to_fp
+// CHECK: %[[F32_TO_E4:.*]] = arith.truncf %[[E5_TO_F32]] {round_mode = #hfusion.round_mode<rint>} : f32 to f8E4M3FN
+// CHECK-NOT: tt.fp_to_fp
+// CHECK: return %[[F32_TO_E4]] : f8E4M3FN
+// CHECK-LABEL: func.func @scalar_fp16_to_bf16_rtne
+// CHECK-NOT: tt.fp_to_fp
+// CHECK: %[[F16_TO_F32:.*]] = arith.extf %{{.*}} {round_mode = #hfusion.round_mode<rint>} : f16 to f32
+// CHECK-NOT: tt.fp_to_fp
+// CHECK: %[[F32_TO_BF16:.*]] = arith.truncf %[[F16_TO_F32]] {round_mode = #hfusion.round_mode<rint>} : f32 to bf16
+// CHECK-NOT: tt.fp_to_fp
+// CHECK: return %[[F32_TO_BF16]] : bf16
+// CHECK-LABEL: func.func @tensor_f8e4m3fn_to_f8e5m2_rtne
+// CHECK-NOT: tt.fp_to_fp
+// CHECK: arith.extf %{{.*}} {round_mode = #hfusion.round_mode<rint>} : f8E4M3FN to f32
+// CHECK-NOT: tt.fp_to_fp
+// CHECK: arith.truncf %{{.*}} {round_mode = #hfusion.round_mode<rint>} : f32 to f8E5M2
+// CHECK-NOT: tt.fp_to_fp
+// CHECK: return
+// CHECK-LABEL: func.func @scalar_f8e4m3fn_identity
+// CHECK-NOT: tt.fp_to_fp
+// CHECK: return %{{.*}} : f8E4M3FN
 module {
   tt.func @scalar_fp32_to_fp8_rtne(%arg0: f32) -> f8E4M3FN {
     %0 = tt.fp_to_fp %arg0, rounding = rtne : f32 -> f8E4M3FN
+    tt.return %0 : f8E4M3FN
+  }
+
+  tt.func @scalar_fp8_to_fp32_rtne(%arg0: f8E4M3FN) -> f32 {
+    %0 = tt.fp_to_fp %arg0, rounding = rtne : f8E4M3FN -> f32
+    tt.return %0 : f32
+  }
+
+  tt.func @scalar_f8e4m3fn_to_f8e5m2_rtne(%arg0: f8E4M3FN) -> f8E5M2 {
+    %0 = tt.fp_to_fp %arg0, rounding = rtne : f8E4M3FN -> f8E5M2
+    tt.return %0 : f8E5M2
+  }
+
+  tt.func @scalar_f8e5m2_to_f8e4m3fn_default(%arg0: f8E5M2) -> f8E4M3FN {
+    %0 = tt.fp_to_fp %arg0 : f8E5M2 -> f8E4M3FN
+    tt.return %0 : f8E4M3FN
+  }
+
+  tt.func @scalar_fp16_to_bf16_rtne(%arg0: f16) -> bf16 {
+    %0 = tt.fp_to_fp %arg0, rounding = rtne : f16 -> bf16
+    tt.return %0 : bf16
+  }
+
+  tt.func @tensor_f8e4m3fn_to_f8e5m2_rtne(%arg0: f8E4M3FN, %arg1: !tt.ptr<f8E5M2>) {
+    %input = tt.splat %arg0 : f8E4M3FN -> tensor<8xf8E4M3FN>
+    %0 = tt.fp_to_fp %input, rounding = rtne : tensor<8xf8E4M3FN> -> tensor<8xf8E5M2>
+    %offsets = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+    %output_ptrs = tt.splat %arg1 : !tt.ptr<f8E5M2> -> tensor<8x!tt.ptr<f8E5M2>>
+    %output_addrs = tt.addptr %output_ptrs, %offsets : tensor<8x!tt.ptr<f8E5M2>>, tensor<8xi32>
+    tt.store %output_addrs, %0 : tensor<8x!tt.ptr<f8E5M2>>
+    tt.return
+  }
+
+  tt.func @scalar_f8e4m3fn_identity(%arg0: f8E4M3FN) -> f8E4M3FN {
+    %0 = tt.fp_to_fp %arg0 : f8E4M3FN -> f8E4M3FN
     tt.return %0 : f8E4M3FN
   }
 }


### PR DESCRIPTION
## Summary

- Route scalar RTNE/default tt.fp_to_fp operations past tensor-only HFusion conversion.
- Canonicalize scalar and ranked-tensor RTNE conversions in TritonToLinalg by using getElementTypeOrSelf and preserving resultType.
- Preserve default/RTNE same-bitwidth conversions between distinct floating-point formats by lowering them through an f32 bridge, rather than deleting them as identities.

## FlagGems reproducer

The source workload is FlagGems `pack_seq` with an FP8 output:

- Historical tracked entry: `tests/test_pack_seq.py::test_pack_seq_fp8_basic[6-8-4-lengths_list0]`. It compiles `_pack_seq_kernel` and originally exposed the TA `Casting.h:566` assertion.
- `test_pack_seq_fp8_basic` now explicitly passes `pad_value=0.0`. It checks valid sequence elements only and is a smoke-test workaround for the later CCEC nonzero-FP8-literal limitation; it does not change the public default.
- The public/default and finite-nonzero forms are exercised by `test_pack_seq_fp8_default_inf_padding` and `test_pack_seq_fp8_custom_padding` (`-100.0`, `0.0`, `100.0`). The kernel always contains the padding-initialization statement at compile time, even where a particular runtime shape has no visible padded output region.

Representative commands from the FlagGems checkout:

```bash
pytest -q 'tests/test_pack_seq.py::test_pack_seq_fp8_basic[6-8-4-lengths_list0]'
pytest -q tests/test_pack_seq.py::test_pack_seq_fp8_custom_padding
pytest -q tests/test_pack_seq.py::test_pack_seq_fp8_default_inf_padding
```

After this PR, a nonzero/default FP8-padding compile can progress past the original TA assertion but may still stop in the separate CCEC literal-format issue (`float8e4m3 0xPFF` for `-inf`, or `0xPEC` for `-100.0`). Zero padding is a diagnostic/smoke workaround only, not a replacement for the public `-inf` default.

## Representative DSL and why the conversion is scalar

`pack_seq` passes `pad_value` as `PAD_VALUE: tl.constexpr`; for non-`uint8` output it builds an FP32 padding block and stores it through an output pointer whose dtype follows `x`:

```python
PAD_VALUE: tl.constexpr

# For FP8 x, out_ptr has FP8 element type.
pad_vals = tl.full([BLOCK_T, BLOCK_D], PAD_VALUE, tl.float32)
tl.store(out_row_ptr, pad_vals, mask=...)

# The later x_vals load/store is a separate tensor path.
x_vals = tl.load(x_row_ptr, mask=...)
tl.store(out_row_ptr, x_vals, mask=...)
```

The equivalent standalone reducer is:

```python
@triton.jit
def nonzero_fp8_constant_store(out_ptr, VALUE: tl.constexpr,
                               BLOCK: tl.constexpr):
    offsets = tl.arange(0, BLOCK)
    values = tl.full((BLOCK,), VALUE, tl.float32)
    tl.store(out_ptr + offsets, values)

# signature: out_ptr = *fp8e4nv; VALUE is a nonzero constexpr
```

`tl.full` means “broadcast one scalar value”; it does not make the source constant a tensor. Because the destination pointer element type is FP8, the compiler first converts the single FP32 constant to FP8, then splats that FP8 scalar to the block. The issue is therefore the padding `PAD_VALUE`, not a scalarization of the FP8 input tensor `x`.

## Corresponding TTIR

A captured A5 minimal specialization (using finite `VALUE = -100.0`; `-inf` has the same scalar conversion topology) contains:

```mlir
%cst = arith.constant -1.000000e+02 : f32
%offsets = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
%ptrs = tt.splat %out_ptr : !tt.ptr<f8E4M3FN> -> tensor<64x!tt.ptr<f8E4M3FN>>
%addrs = tt.addptr %ptrs, %offsets : tensor<64x!tt.ptr<f8E4M3FN>>, tensor<64xi32>
%fp8 = tt.fp_to_fp %cst, rounding = rtne : f32 -> f8E4M3FN
%values = tt.splat %fp8 : f8E4M3FN -> tensor<64xf8E4M3FN>
tt.store %addrs, %values : tensor<64x!tt.ptr<f8E4M3FN>>
```

The key facts are:

- `%cst` and `%fp8` are scalar types, so `tt.fp_to_fp` is legally scalar.
- `tt.splat` occurs **after** conversion and creates the tensor value required by `tt.store`.
- A tensor output requirement does not make the preceding conversion a tensor conversion. A lowering that unconditionally uses `cast<TensorType>` or `cast<RankedTensorType>` on this op is therefore invalid.

## Root cause

The pack-seq FP8 path creates this scalar `f32 -> f8E4M3FN` conversion followed by `tt.splat`. Both lowering patterns assumed `TensorType` or `RankedTensorType`, so MLIR `cast` asserted before the scalar conversion could lower.

## TritonToHFusion change

- Move the rounding-mode guard before tensor-only type inspection. For RTNE or an omitted rounding mode, the HFusion rewrite returns `failure()` immediately and leaves the op for TritonToLinalg.
- Keep `cast<TensorType>` after the rounding guard. This is intentional: HFusion owns only non-RTNE tensor conversions, so its tensor-only precondition is a pipeline contract. A scalar non-RTNE `tt.fp_to_fp` is outside that contract and is deliberately rejected by the assertion rather than silently becoming a pattern miss or acquiring unsupported fallback behavior.
- Keep the existing HFusion path for non-RTNE tensor conversions. The `tt.splat` following the scalar conversion is unchanged; it remains responsible for broadcasting the already-converted FP8 scalar to the tensor stored by the kernel.

`failure()` here means that this greedy rewrite pattern did not apply; it does not fail the HFusion pass. `applyPatternsGreedily` continues and later passes can lower the retained operation.

## Risk analysis and boundary

- RTNE/default tensor behavior is unchanged: it was already rejected by this HFusion pattern and handled by TritonToLinalg. The reordered guard simply lets scalar RTNE reach the same decision before any tensor-only cast.
- Non-RTNE tensor behavior is unchanged: it still reaches HFusion after the existing tensor precondition.
- The change only affects dispatch and type handling. It does not alter the requested rounding semantics, the scalar-to-tensor `tt.splat`, or the FP8 store layout.

## Same-bitwidth floating-point conversion follow-up

The prior Linalg equal-width fallback returned the input for every same-bitwidth conversion. That is valid only when the complete input and result MLIR types are identical: bitwidth alone does not preserve FP8 format semantics.

For default/RTNE conversions, this update lowers a distinct same-width scalar or ranked-tensor floating-point conversion through f32:

source -> arith.extf f32 -> arith.truncf destination

This preserves f8E4M3FN -> f8E5M2 and f16 -> bf16 conversions in TTAdapter IR for the normal Bisheng lowering path. Exact identity conversions are still folded. A same-element conversion with an incompatible container or layout is rejected instead of returning a value with the wrong type. The MLIR regression now covers scalar FP8 both directions, scalar f16 -> bf16, a tensor FP8 conversion, and exact identity.

## Unsupported conversion boundaries deliberately retained

The pass ownership remains:

| tt.fp_to_fp form | Intended owner |
| --- | --- |
| RTNE/default | TritonToLinalg |
| non-RTNE (for example RTZ) | TritonToHFusion |

- A scalar non-RTNE conversion is outside the HFusion tensor-only contract. It does not take the RTNE early exit and intentionally reaches `cast<TensorType>`; this PR neither supports it nor turns it into a successful or ignored pattern miss.
- A non-RTNE same-bitwidth conversion remains owned by HFusion and is unchanged by this follow-up.
- A default/RTNE same-bitwidth conversion between distinct formats is no longer treated as an identity. It is materialized through f32 so that the result keeps its requested element type.

The scalar RTNE fix and this follow-up only change default/RTNE Linalg handling; requested non-RTNE semantics remain unchanged.

## Validation

- `git diff --check` and targeted `pre-commit` passed on both branches.
- `TritonToHFusion.cpp` compiled with the project CMake-exported `clang++` command for both `main-dev` and `main` source revisions.
- New MLIR regression:

  ```bash
  triton-opt --triton-to-hfusion --triton-to-linalg \
    third_party/ascend/unittest/Conversion/General/TritonToLinalg/fp_to_fp_scalar_rtne.mlir \
    | FileCheck third_party/ascend/unittest/Conversion/General/TritonToLinalg/fp_to_fp_scalar_rtne.mlir
  ```

  It verifies scalar `f32 -> f8E4M3FN, rounding = rtne` lowers to `arith.truncf` with `round_mode = rint`.
- Direct offline A5 compilation used `triton.compile(..., target=GPUTarget("npu", "Ascend910_9589", 0))`; no NPU kernel was launched. The nonzero `-inf` repro passed the HFusion/Linalg boundary and emitted `arith.truncf`, then stopped only at the independent CCEC `float8e4m3 0xPFF` literal issue. The zero-padding specialization emitted `.npubin`.
- The FlagGems device test is not a compiler verdict in this host: on physical devices 0 and 1 it stops in `torch_npu` `x.to(torch.float8_e4m3fn)` with ACLNN error 561103 before JIT compilation starts.
