### PR TITLE
[testing](feat) update do_bench_npu

### DIFF
--- a/third_party/ascend/backend/testing.py
+++ b/third_party/ascend/backend/testing.py
@@ -23,6 +23,7 @@ import multiprocessing
 import os
 from datetime import datetime, timezone
 from typing import Optional
+import fnmatch
 
 import triton.runtime as runtime
 from triton.knobs import cache
@@ -39,7 +40,7 @@ class ProfilerResultMismatchError(RuntimeError):
             f"target_kernel_name={target_kernel_name!r}, expected_rows={expected_rows}, actual_rows={actual_rows}")
 
 
-def do_bench_npu(
+def do_bench_npu_profiler(
     funcs,
     warmup=5,
     active=30,
@@ -50,7 +51,6 @@ def do_bench_npu(
 ):
     import torch
     import torch_npu
-
     if not isinstance(funcs, list):
         funcs = [funcs]
 
@@ -134,16 +134,17 @@ def _collect_prof_result(
     clear_l2_cache: bool = False,
 ):
     """
-    Collect kernel performance from kernel_details.csv, returned in millisecond.
+    Collect kernel performance from task_time*.csv or kernel_details.csv, returned in millisecond.
+    Uses task_time*.csv by default. If target_kernel_name is provided, scans for kernel_details.csv as a fallback for accuracy.
     The first `num_warmup` rows of each function are warmup data and will be ignored, the next `num_active` rows will be averaged.
 
     :param base_dir: the profiler path
     :type base_dir: str
     :param funcs: a list of Callable being profiled
     :type funcs: List[Callable]
-    :param num_warmup: warmup count in kernel_details.csv of each fn
+    :param num_warmup: warmup count in task_time*.csv or kernel_details.csv of each fn
     :type num_warmup: int
-    :param num_active: active count in kernel_details.csv of each fn
+    :param num_active: active count in task_time*.csv or kernel_details.csv of each fn
     :type num_active: int
     :param target_kernel_name: target triton kernel name reported by profiler
     :type target_kernel_name: Optional[str]
@@ -151,11 +152,14 @@ def _collect_prof_result(
 
     import numpy as np
     import pandas as pd
-
+    use_task_time = (target_kernel_name is None)
     kernel_details_file = None
     for root, _, files in os.walk(base_dir):
         for file in files:
-            if file == "kernel_details.csv":
+            if use_task_time and fnmatch.fnmatch(file, "task_time*.csv"):
+                kernel_details_file = os.path.join(root, file)
+                break
+            elif not use_task_time and file == "kernel_details.csv":
                 kernel_details_file = os.path.join(root, file)
                 break
     num_funcs = len(funcs)
@@ -166,8 +170,15 @@ def _collect_prof_result(
             return [float("inf")] * num_funcs
 
     df = pd.read_csv(kernel_details_file)
+    if use_task_time:
+        # The first and last lines of the task_time*.csv file are PROFILING_DISABLE, which should be deleted.
+        df = df[1:-1]
+        col_time = "task_time(us)"
+        filter_cond = (not clear_l2_cache) | ~df["kernel_name"].str.contains(r"^ReduceSum", case=False, na=False)
+    else:
+        col_time = "Duration(us)"
+        filter_cond = (not clear_l2_cache) | ~df["Type"].str.contains(r"^ReduceSum$", case=False, na=False)
     # filter out l2 cache clearing operation
-    filter_cond = (not clear_l2_cache) | ~df["Type"].str.contains(r"^ReduceSum$", case=False, na=False)
     filter_df = df[filter_cond]
     if target_kernel_name is not None:
         filter_df = filter_df[filter_df["Name"] == target_kernel_name]
@@ -177,14 +188,139 @@ def _collect_prof_result(
     if target_kernel_name is not None and actual_rows != expected_rows:
         raise ProfilerResultMismatchError(target_kernel_name, expected_rows, actual_rows)
 
+    mul = 1
+    if num_funcs == 1:
+        if actual_rows % expected_rows != 0:
+            return float("inf")
+        mul = actual_rows // expected_rows
+        num_warmup = num_warmup * mul
+        num_active = num_active * mul
+
     time_cost = [0] * num_funcs
     for func_idx in np.arange(0, num_funcs):
         for active_index in np.arange(0, num_active):
             row_index = func_idx * (num_warmup + num_active) + num_warmup + active_index
-            time_cost[func_idx] += filter_df.iloc[row_index]["Duration(us)"]
-    time_cost = [x / num_active / 1e3 for x in time_cost]
+            time_cost[func_idx] += filter_df.iloc[row_index][col_time]
+    time_cost = [x * mul / num_active / 1e3 for x in time_cost]
 
     if num_funcs == 1:
         return time_cost[0]
     else:
         return time_cost
+
+
+try:
+    from mspti import KernelMonitor
+except ImportError:
+    KernelMonitor = None
+
+
+# If the CANN version is earlier than 9.1.0, it needs to set libmspti.so in LD_PRELOAD to use mspti.
+def do_bench_npu_mspti(
+    funcs,
+    warmup=5,
+    active=30,
+    clear_l2_cache=False,
+    target_kernel_name: Optional[str] = None,
+):
+    import torch
+    import torch_npu
+    if not isinstance(funcs, list):
+        funcs = [funcs]
+
+    for fn in funcs:
+        fn()
+        torch.npu.synchronize()
+
+    if clear_l2_cache:
+        buffer = runtime.driver.active.get_empty_cache_for_benchmark()
+    else:
+        buffer = None
+
+    all_kernel_durations = []
+
+    def callback(data):
+        if clear_l2_cache and ('zero' in data.name.lower() or 'zeroslike' in data.name.lower()):
+            return
+        if target_kernel_name is not None and target_kernel_name not in data.name:
+            return
+        all_kernel_durations.append(data.end - data.start)
+
+    monitor = KernelMonitor()
+    torch.npu.synchronize()
+
+    monitor.start(callback)
+
+    try:
+        total = warmup + active
+        for fn in funcs:
+            for _ in builtins.range(total):
+                if clear_l2_cache:
+                    buffer.zero_()
+                fn()
+    finally:
+        torch.npu.synchronize()
+        monitor.stop()
+
+    num_funcs = len(funcs)
+    duration_per_kernel = []
+
+    expected_rows = num_funcs * total
+    actual_rows = len(all_kernel_durations)
+    if actual_rows < expected_rows:
+        if num_funcs == 1:
+            return float("inf")
+        return [float("inf")] * num_funcs
+
+    mul = 1
+    if num_funcs == 1:
+        if actual_rows % expected_rows != 0:
+            return float("inf")
+        mul = actual_rows // expected_rows
+        warmup = warmup * mul
+        total = actual_rows
+
+    current_idx = 0
+    for i in range(num_funcs):
+        current_func_records = all_kernel_durations[current_idx:current_idx + total]
+        current_idx += total
+        current_active_records = current_func_records[warmup:total]
+        avg_time = sum(current_active_records) * mul / len(current_active_records)
+        avg_time_ms = avg_time / 1000000.0
+        duration_per_kernel.append(avg_time_ms)
+
+    if num_funcs == 1:
+        return duration_per_kernel[0]
+    else:
+        return duration_per_kernel
+
+
+def do_bench_npu(
+    funcs,
+    warmup=5,
+    active=30,
+    clear_l2_cache=False,
+    prof_dir=None,
+    keep_res=False,
+    target_kernel_name: Optional[str] = None,
+):
+    import math
+    mspti_available = True
+    if KernelMonitor is None:
+        mspti_available = False
+        print(f"[WARNING] mspti package not found. Falling back to torch_npu.profiler.")
+    if not isinstance(funcs, list):
+        funcs = [funcs]
+    results = None
+    need_fallback = True
+    if mspti_available and target_kernel_name is None:
+        try:
+            results = do_bench_npu_mspti(funcs, warmup, active, clear_l2_cache, target_kernel_name)
+            first_val = results[0] if isinstance(results, list) else results
+            if not math.isinf(first_val):
+                need_fallback = False
+        except Exception:
+            pass
+    if need_fallback:
+        results = do_bench_npu_profiler(funcs, warmup, active, clear_l2_cache, prof_dir, keep_res, target_kernel_name)
+    return results


### PR DESCRIPTION
1、do_bench_npu returns inf.
Cause: Some operators do not launch kernels, so there is no relevant information in kernel_details.csv.
Solution: task_time.csv stores NPU task execution time during operator execution. When focusing solely on latency, task_time.csv can be used as a substitute for kernel_details.csv, allowing acquisition of task execution time even when no kernel is present.

2、do_bench_npu takes too long.
Cause: The original method used the Ascend PyTorch Profiler, where operations such as file I/O and offline parsing are relatively time-consuming.
Solution: Use MSPTI APIs. Data collection is performed directly in memory, and it is capable of capturing kernel latency.

3、When the function (fn) passed to do_bench_npu contains multiple kernels, the accurate time information cannot be obtained.
Cause: Do_bench_npu reads only the number of rows calculated by the function, that is, expected_rows. The value of expected_rows is equal to the total number of running times multiplied by the number of passed functions. That is, do_bench_npu considers that each passed function has only one kernel by default.
However, when the function passed to do_bench_npu contains multiple kernels, each kernel has an independent row each time it is run. Therefore, the actual number of rows is greater than the number of rows calculated by Do_bench_npu.
Solution: If the passed function is a single function, the total sum is returned. If the passed function is a list, the output is generated in the original mode.

The do_bench_npu structure after modification is as follows: 
If mspti is available, do_bench_npu_mspti is called. If the result is inf, do_bench_npu_profiler is called. Finally, the result is returned.

Precautions：
If the CANN version is earlier than 9.1.0, it needs to set libmspti.so in LD_PRELOAD to use mspti. like：
```
source /usr/local/Ascend/ascend-toolkit/set_env.sh
export LD_PRELOAD=${ASCEND_HOME_PATH}/lib64/libmspti.so
```



<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
