### PR TITLE
[TritonToLinalg](fix) Support masked load with tensor-type other

### DIFF
--- a/third_party/ascend/include/TritonToLinalg/LoadStoreConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/LoadStoreConverter.h
@@ -75,8 +75,6 @@ private:
                                      ArrayRef<OpFoldResult> maskDim,
                                      ConversionPatternRewriter &rewriter) const;
 
-  /// Finish continuous masked load with non-scalar tensor `other` via
-  /// insert_slice. Derives mask/other/type/loc from `op`. See .cpp.
   LogicalResult
   replaceMaskedLoadWithTensorOther(triton::LoadOp op, Value alloc,
                                    const MaskState &mstate,

--- a/third_party/ascend/include/TritonToLinalg/LoadStoreConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/LoadStoreConverter.h
@@ -38,7 +38,6 @@
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 
 #include "ascend/include/TritonToLinalg/MaskAnalysis.h"
-#include "triton/Dialect/Triton/IR/Dialect.h"
 
 namespace LoadStoreConverter {
 

--- a/third_party/ascend/include/TritonToLinalg/LoadStoreConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/LoadStoreConverter.h
@@ -37,6 +37,7 @@
 
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 
+#include "ascend/include/TritonToLinalg/MaskAnalysis.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 
 namespace LoadStoreConverter {
@@ -73,6 +74,14 @@ private:
   fillTensorWithOtherForMaskScenario(Value other, Value localMem,
                                      ArrayRef<OpFoldResult> maskDim,
                                      ConversionPatternRewriter &rewriter) const;
+
+  /// Finish continuous masked load with non-scalar tensor `other` via
+  /// insert_slice. Derives mask/other/type/loc from `op`. See .cpp.
+  LogicalResult
+  replaceMaskedLoadWithTensorOther(triton::LoadOp op, Value alloc,
+                                   const MaskState &mstate,
+                                   bool mayImplicitTransposeWithLastAxis,
+                                   ConversionPatternRewriter &rewriter) const;
 
 public:
   explicit LoadConverter(MLIRContext *context);

--- a/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
@@ -261,9 +261,9 @@ LoadConverter::LoadConverter(MLIRContext *context)
 //   %dst_view = memref.subview %alloc[0][%valid][1]     // [SRC]
 //   memref.copy %src_view, %dst_view              // [SRC]  ptr -> %alloc
 //   %loaded = bufferization.to_tensor %alloc      // [SRC]
-//   %zeros  = linalg.fill 0 into tensor.empty     // [OTHER] replaces cast(mask)
-//   %active = tensor.extract_slice %loaded[0][%valid][1]
-//   %x = tensor.insert_slice %active into %zeros  // merge SRC into OTHER base
+//   %zeros  = linalg.fill 0 into tensor.empty     // [OTHER] replaces
+//   cast(mask) %active = tensor.extract_slice %loaded[0][%valid][1] %x =
+//   tensor.insert_slice %active into %zeros  // merge SRC into OTHER base
 //
 // Why %zeros instead of SSA %other: rewriter remaps live uitofp/extui/mask to
 // MemRef and leaves unresolved casts; inactive cast(mask) is always 0, so

--- a/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
@@ -237,39 +237,44 @@ LoadConverter::LoadConverter(MLIRContext *context)
 // Where does OTHER show up in the lowered IR?
 //   Not in %alloc / memref.copy (those only move SRC from ptr).
 //   OTHER is the *destination* of tensor.insert_slice:
-//     Case 1: %zeros  (proxy for TTIR %other = uitofp(mask), all inactive = 0)
+//     Case 1: %zeros  (proxy for TTIR cast(mask); inactive lanes are 0)
 //     Case 2: %other  (TTIR prior load tensor, used as-is)
 //
 // ---------------------------------------------------------------------------
 // Case 1: other = mask   (Python: tl.load(ptr, mask=mask, other=mask))
 //
-// Inputs (TTIR):
+// DSL:
+//   mask = offs < N
+//   x = tl.load(in_ptr + offs, mask=mask, other=mask)
+//   tl.store(out_ptr + offs, x, mask=mask)   # inactive often not observed
+//
+// TTIR (fp — uitofp; int — extui/extsi):
 //   %mask  = arith.cmpi slt, %offs, %N : tensor<Nx i1>
-//   %other = arith.uitofp %mask …                 // <--- OTHER (TTIR)
+//   %other = arith.uitofp %mask …            // or arith.extui for i8
 //   %x     = tt.load %ptr, %mask, %other
 //
-// Lowering:
+// Lowering (linalg):
 //   %ptr_mem = memref.reinterpret_cast %in_ptr …  // [SRC]  global input
-//   %alloc = memref.alloc()                       // [SRC]  local tile (empty)
+//   %alloc = memref.alloc()                       // [SRC]  local tile
 //   %valid = …                                    //       #active lanes
 //   %src_view = memref.subview %ptr_mem[0][%valid][1]   // [SRC]
 //   %dst_view = memref.subview %alloc[0][%valid][1]     // [SRC]
 //   memref.copy %src_view, %dst_view              // [SRC]  ptr -> %alloc
 //   %loaded = bufferization.to_tensor %alloc      // [SRC]
-//   %zeros  = linalg.fill 0 into tensor.empty     // [OTHER]  <--- replaces
-//   %other %active = tensor.extract_slice %loaded[0][%valid][1]  // [SRC] %x =
-//   tensor.insert_slice %active into %zeros  // merge: SRC into OTHER base
+//   %zeros  = linalg.fill 0 into tensor.empty     // [OTHER] replaces cast(mask)
+//   %active = tensor.extract_slice %loaded[0][%valid][1]
+//   %x = tensor.insert_slice %active into %zeros  // merge SRC into OTHER base
 //
-// Why %zeros instead of SSA %other: rewriter remaps live uitofp/mask to MemRef
-// and leaves unresolved casts; inactive uitofp(mask) is 0.0, so equivalent.
-// (Masked store may DCE zeros+insert and keep only the active extract.)
+// Why %zeros instead of SSA %other: rewriter remaps live uitofp/extui/mask to
+// MemRef and leaves unresolved casts; inactive cast(mask) is always 0, so
+// equivalent. (Masked store may DCE zeros+insert and keep only active extract.)
 //
 // ---------------------------------------------------------------------------
 // Case 2: other = prior tensor
 //   (Python: other = tl.load(fill_ptr+offs); x = tl.load(ptr, mask=mask,
-//   other=other))
+//   other=other); tl.store(out, x)  # full store — pad must stay OTHER)
 //
-// Inputs (TTIR):
+// TTIR:
 //   %other = tt.load %fill_ptr
 //   %x     = tt.load %ptr, %mask, %other
 //
@@ -306,13 +311,19 @@ LogicalResult LoadConverter::replaceMaskedLoadWithTensorOther(
                     UnitAttr::get(rewriter.getContext()));
   }
 
-  // Case 1: synthesize zeros; Case 2: keep remapped prior tensor as-is.
+  // Case 1: cast(mask) → inactive is 0. Cover fp (uitofp/sitofp) and int
+  // (extui/extsi, e.g. int8 other=mask). Case 2: keep prior tensor as-is.
   Value otherBase = tensorOtherBase;
   bool otherIsZeroOnInactive = false;
   if (auto uitofp = otherBase.getDefiningOp<arith::UIToFPOp>())
     otherIsZeroOnInactive = (uitofp.getIn() == mask);
   else if (auto sitofp = otherBase.getDefiningOp<arith::SIToFPOp>())
     otherIsZeroOnInactive = (sitofp.getIn() == mask);
+  else if (auto extui = otherBase.getDefiningOp<arith::ExtUIOp>())
+    otherIsZeroOnInactive = (extui.getIn() == mask);
+  else if (auto extsi = otherBase.getDefiningOp<arith::ExtSIOp>())
+    otherIsZeroOnInactive = (extsi.getIn() == mask);
+
   if (otherIsZeroOnInactive) {
     auto empty = rewriter.create<tensor::EmptyOp>(loc, tensorType.getShape(),
                                                   tensorType.getElementType());

--- a/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
@@ -227,6 +227,109 @@ void LoadConverter::fillTensorWithOtherForMaskScenario(
 LoadConverter::LoadConverter(MLIRContext *context)
     : OpConversionPattern<triton::LoadOp>(context) {}
 
+// Continuous masked load whose `other` is a non-scalar tensor.
+//
+// Semantic: result[i] = mask[i] ? SRC[i] : OTHER[i]
+//   SRC   = values from %ptr (mask=true)
+//   OTHER = inactive fill — THIS is tt.load's `other` operand
+// Continuous mask => active prefix/suffix of length %valid (no lane select).
+//
+// Where does OTHER show up in the lowered IR?
+//   Not in %alloc / memref.copy (those only move SRC from ptr).
+//   OTHER is the *destination* of tensor.insert_slice:
+//     Case 1: %zeros  (proxy for TTIR %other = uitofp(mask), all inactive = 0)
+//     Case 2: %other  (TTIR prior load tensor, used as-is)
+//
+// ---------------------------------------------------------------------------
+// Case 1: other = mask   (Python: tl.load(ptr, mask=mask, other=mask))
+//
+// Inputs (TTIR):
+//   %mask  = arith.cmpi slt, %offs, %N : tensor<Nx i1>
+//   %other = arith.uitofp %mask …                 // <--- OTHER (TTIR)
+//   %x     = tt.load %ptr, %mask, %other
+//
+// Lowering:
+//   %ptr_mem = memref.reinterpret_cast %in_ptr …  // [SRC]  global input
+//   %alloc = memref.alloc()                       // [SRC]  local tile (empty)
+//   %valid = …                                    //       #active lanes
+//   %src_view = memref.subview %ptr_mem[0][%valid][1]   // [SRC]
+//   %dst_view = memref.subview %alloc[0][%valid][1]     // [SRC]
+//   memref.copy %src_view, %dst_view              // [SRC]  ptr -> %alloc
+//   %loaded = bufferization.to_tensor %alloc      // [SRC]
+//   %zeros  = linalg.fill 0 into tensor.empty     // [OTHER]  <--- replaces
+//   %other %active = tensor.extract_slice %loaded[0][%valid][1]  // [SRC] %x =
+//   tensor.insert_slice %active into %zeros  // merge: SRC into OTHER base
+//
+// Why %zeros instead of SSA %other: rewriter remaps live uitofp/mask to MemRef
+// and leaves unresolved casts; inactive uitofp(mask) is 0.0, so equivalent.
+// (Masked store may DCE zeros+insert and keep only the active extract.)
+//
+// ---------------------------------------------------------------------------
+// Case 2: other = prior tensor
+//   (Python: other = tl.load(fill_ptr+offs); x = tl.load(ptr, mask=mask,
+//   other=other))
+//
+// Inputs (TTIR):
+//   %other = tt.load %fill_ptr
+//   %x     = tt.load %ptr, %mask, %other
+//
+// Lowering:
+//   %ptr_mem = memref.reinterpret_cast %in_ptr …  // [SRC]
+//   %alloc = memref.alloc()                       // [SRC]
+//   %src_view = memref.subview %ptr_mem[0][%valid][1]
+//   %dst_view = memref.subview %alloc[0][%valid][1]
+//   memref.copy %src_view, %dst_view              // [SRC]
+//   %loaded = bufferization.to_tensor %alloc      // [SRC]
+//   %active = tensor.extract_slice %loaded[0][%valid][1]
+//   %x = tensor.insert_slice %active into %other  // [OTHER]=%other
+// ---------------------------------------------------------------------------
+LogicalResult LoadConverter::replaceMaskedLoadWithTensorOther(
+    triton::LoadOp op, Value alloc, const MaskState &mstate,
+    bool mayImplicitTransposeWithLastAxis,
+    ConversionPatternRewriter &rewriter) const {
+  auto loc = op.getLoc();
+  auto tensorType = cast<RankedTensorType>(op.getResult().getType());
+  Value mask = op.getMask();
+  Value tensorOtherBase = op.getOther();
+  assert(mask && tensorOtherBase &&
+         "replaceMaskedLoadWithTensorOther: mask and other must be non-null");
+
+  Value loadedTensor = rewriter.create<bufferization::ToTensorOp>(
+      loc, tensorType, alloc, true, true);
+  propagateWasBoolToInt8Attr(op.getOperation(), loadedTensor.getDefiningOp(),
+                             rewriter);
+  if (mayImplicitTransposeWithLastAxis) {
+    // Tensor-side mark (memref side already tagged at the alloc). Same as
+    // toTensorAndReplace: HIVM InsertLoadStore looks at to_tensor's result.
+    auto markOp = rewriter.create<annotation::MarkOp>(loc, loadedTensor);
+    markOp->setAttr(MayImplicitTransposeWithLastAxisTAG,
+                    UnitAttr::get(rewriter.getContext()));
+  }
+
+  // Case 1: synthesize zeros; Case 2: keep remapped prior tensor as-is.
+  Value otherBase = tensorOtherBase;
+  bool otherIsZeroOnInactive = false;
+  if (auto uitofp = otherBase.getDefiningOp<arith::UIToFPOp>())
+    otherIsZeroOnInactive = (uitofp.getIn() == mask);
+  else if (auto sitofp = otherBase.getDefiningOp<arith::SIToFPOp>())
+    otherIsZeroOnInactive = (sitofp.getIn() == mask);
+  if (otherIsZeroOnInactive) {
+    auto empty = rewriter.create<tensor::EmptyOp>(loc, tensorType.getShape(),
+                                                  tensorType.getElementType());
+    Value zero = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getZeroAttr(tensorType.getElementType()));
+    otherBase =
+        rewriter
+            .create<linalg::FillOp>(loc, ValueRange{zero}, ValueRange{empty})
+            .getResult(0);
+  }
+
+  auto extracted = mstate.getExtractSlice(loadedTensor, loc, rewriter);
+  auto inserted = mstate.getInsertSlice(extracted, otherBase, loc, rewriter);
+  rewriter.replaceOp(op, inserted.getResult());
+  return success();
+}
+
 LogicalResult
 LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
                                ConversionPatternRewriter &rewriter) const {
@@ -477,15 +580,20 @@ LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
         op, "can not lower uncontinuout masked loads");
   }
 
+  Value tensorOtherBase;
   if (other) {
     auto scalarOther =
         mlir::ConverterUtils::getScalarValue(other, loc, rewriter);
-    assert(
-        scalarOther &&
-        "other value used in masked load produced by unsupported instruction!");
-
-    fillTensorWithOtherForMaskScenario(scalarOther, allocOp, mstate.dims,
-                                       rewriter);
+    if (scalarOther) {
+      fillTensorWithOtherForMaskScenario(scalarOther, allocOp, mstate.dims,
+                                         rewriter);
+    } else if (isa<RankedTensorType>(other.getType())) {
+      tensorOtherBase = other;
+    } else {
+      return rewriter.notifyMatchFailure(
+          op, "other value used in masked load produced by unsupported "
+              "instruction");
+    }
   }
 
   // To enable deinterleave optimization with mask load, mask state along last
@@ -494,7 +602,7 @@ LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
   //
   // The basis is that last dimension range comparison would generate
   // unaccepted discontinuous mask.
-  if (mstate.getRank() == memRefType.getRank() &&
+  if (!tensorOtherBase && mstate.getRank() == memRefType.getRank() &&
       isConstantIntValue(mstate.offsets.back(), 0) &&
       isConstantIntValue(mstate.dims.back(), memRefType.getShape().back())) {
     auto [ptrStrides, ptrOffsets] = memRefType.getStridesAndOffset();
@@ -540,8 +648,15 @@ LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
                       UnitAttr::get(rewriter.getContext()));
     }
   }
-  return this->toTensorAndReplace(
-      op, tensorType, allocOp, mayImplicitTransposeWithLastAxis, loc, rewriter);
+
+  if (!tensorOtherBase) {
+    return this->toTensorAndReplace(op, tensorType, allocOp,
+                                    mayImplicitTransposeWithLastAxis, loc,
+                                    rewriter);
+  }
+
+  return replaceMaskedLoadWithTensorOther(
+      op, allocOp, mstate, mayImplicitTransposeWithLastAxis, rewriter);
 }
 
 AtomicRMWConverter::AtomicRMWConverter(MLIRContext *context)

--- a/third_party/ascend/lib/Utils/Utils.cpp
+++ b/third_party/ascend/lib/Utils/Utils.cpp
@@ -261,6 +261,11 @@ SmallVector<utils::IteratorType> getNParallelLoopsAttrs(unsigned n) {
 
 Value getScalarValue(Value operand, Location loc,
                      ConversionPatternRewriter &rewriter) {
+  // Peel splat / dense-splat / (s|u)itofp / truncf chains looking for a true
+  // scalar. Returns nullptr (no emitError) when the value is a non-splat
+  // tensor so callers can fall back to a tensor-other path — e.g.
+  //   other = arith.uitofp %mask : tensor<Nxi1> to tensor<Nxf32>
+  // peels once to %mask=cmpi, then fails closed with nullptr.
   SmallVector<Operation *> ops;
   auto reconstructScalarValue = [&](Value src) {
     for (auto op = ops.rbegin(); op != ops.rend(); ++op) {
@@ -271,6 +276,13 @@ Value getScalarValue(Value operand, Location loc,
                     resType = shapedType.getElementType();
                   }
                   return rewriter.create<arith::SIToFPOp>(loc, resType, src);
+                })
+                .Case<arith::UIToFPOp>([&](Operation *op) {
+                  auto resType = op->getResults()[0].getType();
+                  if (auto shapedType = dyn_cast<ShapedType>(resType)) {
+                    resType = shapedType.getElementType();
+                  }
+                  return rewriter.create<arith::UIToFPOp>(loc, resType, src);
                 })
                 .Case<arith::TruncFOp>([&](Operation *op) {
                   auto resType = op->getResults()[0].getType();
@@ -292,33 +304,29 @@ Value getScalarValue(Value operand, Location loc,
       return reconstructScalarValue(operand);
     } else if (auto op = operand.getDefiningOp<arith::ConstantOp>()) {
       if (auto attr = dyn_cast<DenseElementsAttr>(op.getValue())) {
-        if (!attr.isSplat()) {
-          InFlightDiagnostic diag = emitError(loc)
-                                    << "other value used in masked load "
-                                       "produced by unsupported instruction";
+        if (!attr.isSplat())
           return nullptr;
-        }
         auto elemValue = attr.getSplatValue<Attribute>();
         auto constOp = arith::ConstantOp::materialize(
             rewriter, elemValue, attr.getElementType(), op.getLoc());
         return reconstructScalarValue(constOp.getResult());
       }
-      InFlightDiagnostic diag = emitError(loc)
-                                << "other value used in masked load produced "
-                                   "by unsupported instruction";
       return nullptr;
     } else if (auto op = operand.getDefiningOp<triton::SplatOp>()) {
       operand = op.getSrc();
     } else if (auto op = operand.getDefiningOp<arith::SIToFPOp>()) {
       ops.push_back(op.getOperation());
       operand = op.getIn();
+    } else if (auto op = operand.getDefiningOp<arith::UIToFPOp>()) {
+      // Peel uitofp of a *scalar/splat* i1 (not tensor cmpi mask).
+      ops.push_back(op.getOperation());
+      operand = op.getIn();
     } else if (auto op = operand.getDefiningOp<arith::TruncFOp>()) {
       ops.push_back(op.getOperation());
       operand = op.getIn();
     } else {
-      InFlightDiagnostic diag = emitError(loc)
-                                << "other value used in masked load produced "
-                                   "by unsupported instruction";
+      // Non-scalar / non-splat other (e.g. uitofp(cmpi(...))). Caller may
+      // fall back to materializing the full tensor into the local buffer.
       return nullptr;
     }
   }

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_load_with_other.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_load_with_other.mlir
@@ -7,6 +7,7 @@
 // CHECK: memref.copy
 // CHECK: bufferization.to_tensor %[[ALLOC]]
 // CHECK: tensor.extract_slice
+// CHECK: tensor.insert_slice
 // CHECK-NOT: arith.select
 
 module attributes {hacc.target = #hacc.target<"Ascend910B4">} {
@@ -26,6 +27,40 @@ module attributes {hacc.target = #hacc.target<"Ascend910B4">} {
     %11 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
     %12 = tt.addptr %11, %4 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
     tt.store %12, %10, %6 : tensor<128x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// -----
+
+// Case 1b: other = extui(mask) for int8 — same zeros + insert_slice.
+// CHECK-LABEL: func.func @load_other_mask_i8
+// CHECK: %[[ALLOC:.*]] = memref.alloc() : memref<128xi8>
+// CHECK: memref.copy
+// CHECK: bufferization.to_tensor %[[ALLOC]]
+// CHECK: %[[CST:.*]] = arith.constant 0 : i8
+// CHECK: linalg.fill ins(%[[CST]] : i8)
+// CHECK: tensor.extract_slice
+// CHECK: tensor.insert_slice
+// CHECK-NOT: arith.select
+
+module attributes {hacc.target = #hacc.target<"Ascend910B4">} {
+  tt.func public @load_other_mask_i8(%arg0: !tt.ptr<i8> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i8> {tt.divisibility = 16 : i32}, %arg2: i32) attributes {noinline = false} {
+    %c128_i32 = arith.constant 128 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c128_i32 : i32
+    %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %3 = tt.splat %1 : i32 -> tensor<128xi32>
+    %4 = arith.addi %3, %2 : tensor<128xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<128xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<128xi32>
+    %7 = tt.splat %arg0 : !tt.ptr<i8> -> tensor<128x!tt.ptr<i8>>
+    %8 = tt.addptr %7, %4 : tensor<128x!tt.ptr<i8>>, tensor<128xi32>
+    %9 = arith.extui %6 : tensor<128xi1> to tensor<128xi8>
+    %10 = tt.load %8, %6, %9 : tensor<128x!tt.ptr<i8>>
+    %11 = tt.splat %arg1 : !tt.ptr<i8> -> tensor<128x!tt.ptr<i8>>
+    %12 = tt.addptr %11, %4 : tensor<128x!tt.ptr<i8>>, tensor<128xi32>
+    tt.store %12, %10, %6 : tensor<128x!tt.ptr<i8>>
     tt.return
   }
 }

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_load_with_other.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_load_with_other.mlir
@@ -1,0 +1,138 @@
+// RUN: triton-opt --discrete-mask-access-conversion "--triton-to-linalg=global-kernel=false named-ops=True" --split-input-file %s | FileCheck %s
+
+// Case 1: other = uitofp(mask).
+// After masked store DCE, zeros+insert_slice may fold away — keep masked copy.
+// CHECK-LABEL: func.func @load_other_mask
+// CHECK: %[[ALLOC:.*]] = memref.alloc() : memref<128xf32>
+// CHECK: memref.copy
+// CHECK: bufferization.to_tensor %[[ALLOC]]
+// CHECK: tensor.extract_slice
+// CHECK-NOT: arith.select
+
+module attributes {hacc.target = #hacc.target<"Ascend910B4">} {
+  tt.func public @load_other_mask(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32) attributes {noinline = false} {
+    %c128_i32 = arith.constant 128 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c128_i32 : i32
+    %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %3 = tt.splat %1 : i32 -> tensor<128xi32>
+    %4 = arith.addi %3, %2 : tensor<128xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<128xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<128xi32>
+    %7 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %8 = tt.addptr %7, %4 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    %9 = arith.uitofp %6 : tensor<128xi1> to tensor<128xf32>
+    %10 = tt.load %8, %6, %9 : tensor<128x!tt.ptr<f32>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %12 = tt.addptr %11, %4 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    tt.store %12, %10, %6 : tensor<128x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// -----
+
+// Case 2: other = prior full load tensor.
+// CHECK-LABEL: func.func @load_other_tensor
+// CHECK: memref.copy
+// CHECK: %[[FILL:.*]] = bufferization.to_tensor
+// CHECK: %[[ALLOC:.*]] = memref.alloc() : memref<128xf32>
+// CHECK: memref.copy
+// CHECK: %[[LOADED:.*]] = bufferization.to_tensor %[[ALLOC]]
+// CHECK: %[[ACTIVE:.*]] = tensor.extract_slice %[[LOADED]]
+// CHECK: tensor.insert_slice %[[ACTIVE]] into %[[FILL]]
+// CHECK-NOT: arith.select
+
+module attributes {hacc.target = #hacc.target<"Ascend910B4">} {
+  tt.func public @load_other_tensor(%in_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %out_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %fill_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %N: i32) attributes {noinline = false} {
+    %c128_i32 = arith.constant 128 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c128_i32 : i32
+    %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %3 = tt.splat %1 : i32 -> tensor<128xi32>
+    %4 = arith.addi %3, %2 : tensor<128xi32>
+    %5 = tt.splat %N : i32 -> tensor<128xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<128xi32>
+    %7 = tt.splat %fill_ptr : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %8 = tt.addptr %7, %4 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    %9 = tt.load %8 : tensor<128x!tt.ptr<f32>>
+    %10 = tt.splat %in_ptr : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %11 = tt.addptr %10, %4 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    %12 = tt.load %11, %6, %9 : tensor<128x!tt.ptr<f32>>
+    %13 = tt.splat %out_ptr : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %14 = tt.addptr %13, %4 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    tt.store %14, %12 : tensor<128x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// -----
+
+// Case 3: Scalar other=0.0
+// CHECK-LABEL: func.func @load_other_scalar_zero
+// CHECK: %[[CST:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK: %[[ALLOC:.*]] = memref.alloc() : memref<128xf32>
+// CHECK: linalg.fill ins(%[[CST]] : f32) outs(%[[ALLOC]] : memref<128xf32>)
+// CHECK: memref.copy
+// CHECK: bufferization.to_tensor %[[ALLOC]]
+
+module attributes {hacc.target = #hacc.target<"Ascend910B4">} {
+  tt.func public @load_other_scalar_zero(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32) attributes {noinline = false} {
+    %c128_i32 = arith.constant 128 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128xf32>
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c128_i32 : i32
+    %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %3 = tt.splat %1 : i32 -> tensor<128xi32>
+    %4 = arith.addi %3, %2 : tensor<128xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<128xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<128xi32>
+    %7 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %8 = tt.addptr %7, %4 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    %9 = tt.load %8, %6, %cst : tensor<128x!tt.ptr<f32>>
+    %10 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %11 = tt.addptr %10, %4 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    tt.store %11, %9, %6 : tensor<128x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// -----
+
+// Case 4: discrete mask (offs % 2 == 0) + other = prior tensor.
+// discrete-mask-access-conversion rewrites to full load + arith.select
+// (not the continuous insert_slice tensor-other path).
+// CHECK-LABEL: func.func @load_other_tensor_discrete_mask
+// CHECK: memref.copy
+// CHECK: %[[OTHER:.*]] = bufferization.to_tensor
+// CHECK: memref.copy
+// CHECK: %[[LOADED:.*]] = bufferization.to_tensor
+// CHECK: arith.select {{.*}}, %[[LOADED]], %[[OTHER]]
+// CHECK-NOT: tensor.insert_slice
+
+module attributes {hacc.target = #hacc.target<"Ascend910B4">} {
+  tt.func public @load_other_tensor_discrete_mask(%in_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %out_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %other_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %N: i32) attributes {noinline = false} {
+    %c128_i32 = arith.constant 128 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c128_i32 : i32
+    %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %3 = tt.splat %1 : i32 -> tensor<128xi32>
+    %4 = arith.addi %3, %2 : tensor<128xi32>
+    %5 = tt.splat %c2_i32 : i32 -> tensor<128xi32>
+    %6 = arith.remsi %4, %5 : tensor<128xi32>
+    %7 = tt.splat %c0_i32 : i32 -> tensor<128xi32>
+    %8 = arith.cmpi eq, %6, %7 : tensor<128xi32>
+    %9 = tt.splat %other_ptr : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %10 = tt.addptr %9, %4 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    %11 = tt.load %10 : tensor<128x!tt.ptr<f32>>
+    %12 = tt.splat %in_ptr : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %13 = tt.addptr %12, %4 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    %14 = tt.load %13, %8, %11 : tensor<128x!tt.ptr<f32>>
+    %15 = tt.splat %out_ptr : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %16 = tt.addptr %15, %4 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    tt.store %16, %14 : tensor<128x!tt.ptr<f32>>
+    tt.return
+  }
+}

--- a/third_party/ascend/unittest/pytest_ut/test_load.py
+++ b/third_party/ascend/unittest/pytest_ut/test_load.py
@@ -152,7 +152,6 @@ def triton_load_other_tensor_discrete_mask(in_ptr, out_ptr, other_ptr, N, BLOCK:
 
 @pytest.mark.parametrize('param_list', [
     ['float32', 1000, 128],
-    ['int8', 1000, 128],
 ])
 def test_load_with_other_mask(param_list):
     dtype, n, block = param_list
@@ -169,7 +168,6 @@ def test_load_with_other_mask(param_list):
 
 @pytest.mark.parametrize('param_list', [
     ['float32', 1000, 128],
-    ['int8', 1000, 128],
 ])
 def test_load_with_other_tensor(param_list):
     dtype, n, block = param_list
@@ -189,7 +187,6 @@ def test_load_with_other_tensor(param_list):
 
 @pytest.mark.parametrize('param_list', [
     ['float32', 1000, 128],
-    ['int8', 1000, 128],
 ])
 def test_load_with_other_tensor_discrete_mask(param_list):
     dtype, n, block = param_list

--- a/third_party/ascend/unittest/pytest_ut/test_load.py
+++ b/third_party/ascend/unittest/pytest_ut/test_load.py
@@ -169,7 +169,7 @@ def test_load_with_other_mask(param_list):
 
 @pytest.mark.parametrize('param_list', [
     ['float32', 1000, 128],
-    ['int8', 500, 128],
+    ['int8', 1000, 128],
 ])
 def test_load_with_other_tensor(param_list):
     dtype, n, block = param_list
@@ -188,8 +188,8 @@ def test_load_with_other_tensor(param_list):
 
 
 @pytest.mark.parametrize('param_list', [
-    ['float32', 128, 128],
-    ['float16', 256, 128],
+    ['float32', 1000, 128],
+    ['int8', 1000, 128],
 ])
 def test_load_with_other_tensor_discrete_mask(param_list):
     dtype, n, block = param_list

--- a/third_party/ascend/unittest/pytest_ut/test_load.py
+++ b/third_party/ascend/unittest/pytest_ut/test_load.py
@@ -114,3 +114,94 @@ def test_load_store_multi_d(param_list):
         shapes.append(1)
     triton_load_store_multi_d[(1, )](x0, y_actual, *blocks, *blocks, *shapes)
     test_common.validate_cmp(dtype, y_actual, y_expect)
+
+
+@triton.jit
+def triton_load_other_mask(in_ptr, out_ptr, N, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < N
+    x = tl.load(in_ptr + offs, mask=mask, other=mask)
+    tl.store(out_ptr + offs, x, mask=mask)
+
+
+@triton.jit
+def triton_load_other_scalar(in_ptr, out_ptr, N, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < N
+    x = tl.load(in_ptr + offs, mask=mask, other=0.0)
+    tl.store(out_ptr + offs, x, mask=mask)
+
+
+@triton.jit
+def triton_load_other_tensor(in_ptr, out_ptr, other_ptr, N, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < N
+    other = tl.load(other_ptr + offs)
+    x = tl.load(in_ptr + offs, mask=mask, other=other)
+    tl.store(out_ptr + offs, x)
+
+
+@triton.jit
+def triton_load_other_tensor_discrete_mask(in_ptr, out_ptr, other_ptr, N, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = (offs % 2) == 0
+    other = tl.load(other_ptr + offs)
+    x = tl.load(in_ptr + offs, mask=mask, other=other)
+    tl.store(out_ptr + offs, x)
+
+
+@pytest.mark.parametrize('param_list', [
+    ['float32', 1000, 128],
+    ['int8', 1000, 128],
+])
+def test_load_with_other_mask(param_list):
+    dtype, n, block = param_list
+    x = test_common.generate_tensor((n, ), dtype).npu()
+    out_mask = torch.empty(n, device='npu', dtype=getattr(torch, dtype))
+    out_zero = torch.empty(n, device='npu', dtype=getattr(torch, dtype))
+    grid = (triton.cdiv(n, block), )
+    triton_load_other_mask[grid](x, out_mask, n, block)
+    triton_load_other_scalar[grid](x, out_zero, n, block)
+    test_common.validate_cmp(dtype, out_mask, x)
+    test_common.validate_cmp(dtype, out_zero, x)
+    test_common.validate_cmp(dtype, out_mask, out_zero)
+
+
+@pytest.mark.parametrize('param_list', [
+    ['float32', 1000, 128],
+    ['int8', 500, 128],
+])
+def test_load_with_other_tensor(param_list):
+    dtype, n, block = param_list
+    grid = (triton.cdiv(n, block), )
+    total = grid[0] * block
+    torch_dtype = getattr(torch, dtype)
+    x = test_common.generate_tensor((n, ), dtype).npu()
+    x_pad = torch.zeros(total, device='npu', dtype=torch_dtype)
+    x_pad[:n] = x
+    other = test_common.generate_tensor((total, ), dtype).npu()
+    out = torch.empty(total, device='npu', dtype=torch_dtype)
+    triton_load_other_tensor[grid](x_pad, out, other, n, block)
+    ref = other.clone()
+    ref[:n] = x
+    test_common.validate_cmp(dtype, out, ref)
+
+
+@pytest.mark.parametrize('param_list', [
+    ['float32', 128, 128],
+    ['float16', 256, 128],
+])
+def test_load_with_other_tensor_discrete_mask(param_list):
+    dtype, n, block = param_list
+    grid = (triton.cdiv(n, block), )
+    total = grid[0] * block
+    torch_dtype = getattr(torch, dtype)
+    x = test_common.generate_tensor((total, ), dtype).npu()
+    other = test_common.generate_tensor((total, ), dtype).npu()
+    out = torch.empty(total, device='npu', dtype=torch_dtype)
+    triton_load_other_tensor_discrete_mask[grid](x, out, other, n, block)
+    offs = torch.arange(total, device='npu')
+    mask = (offs % 2) == 0
+    ref = other.clone()
+    ref[mask] = x[mask]
+    test_common.validate_cmp(dtype, out, ref)


### PR DESCRIPTION

## Summary
Previously, the `LoadConverter` only supported scalar/splatother values for masked `tt.load` via `getScalarValue`. It failed to handle tensor-type other inputs, blocking support for general tensor fill scenarios and `other=mask` (bool mask cast to float) cases.
This PR implements a unified lowering path for continuous masked tt.load with othernon-scalar tensor , adopting a standard `extract_slice + insert_slice` tensor merging paradigm to unify active/inactive lane value assignment.

This PR lowers continuous masked loads with **tensor** `other` as:

```text
result = insert_slice(extract_slice(to_tensor(alloc)), otherBase)
```

- **`%alloc`**: local `memref.alloc()` tile for SRC (active load from ptr) via masked copy; then `to_tensor` / `extract_slice`. Not the `other` buffer.
- **`otherBase`**: insert_slice destination supplying inactive lanes — `%zeros` (Case1) or `%other` (Case2 prior tensor).
- **`other=mask`** (`uitofp`/`sitofp` of the same mask): inactive lanes are 0.0; synthesize a zeros tensor as insert dest (cannot feed `uitofp(mask)` through `ConversionPatternRewriter` without unresolved Tensor→MemRef casts).
- **`other=prior tensor`**: use the already-converted tensor (e.g. prior `tt.load`) as insert dest.
- **`getScalarValue`**: on failure return `nullptr` silently (no `emitError`) so the caller can take the tensor-other path;
## Examples

### 1) `other=mask`

**Python**
```python
mask = offs < N
x = tl.load(in_ptr + offs, mask=mask, other=mask)
tl.store(out_ptr + offs, x, mask=mask)
```

**TTIR**
```mlir
%mask  = arith.cmpi slt, %offs, %N : tensor<128xi1>
%other = arith.uitofp %mask : tensor<128xi1> to tensor<128xf32>
%x     = tt.load %ptr, %mask, %other : tensor<128x!tt.ptr<f32>>
tt.store %out, %x, %mask
```

**After `triton-to-linalg` (typical; masked store may DCE zeros+insert)**
```mlir
%ptr_mem = memref.reinterpret_cast %in_ptr …     // [SRC]
%alloc = memref.alloc() : memref<128xf32>        // [SRC] local tile
%valid = …
%src_view = memref.subview %ptr_mem[0][%valid][1]
%dst_view = memref.subview %alloc[0][%valid][1]
memref.copy %src_view, %dst_view                 // [SRC]
%loaded  = bufferization.to_tensor %alloc
%zeros   = linalg.fill 0 into tensor.empty       // [OTHER] proxy for %other
%active  = tensor.extract_slice %loaded[0][%valid][1]
%x       = tensor.insert_slice %active into %zeros
// (masked store may fold zeros+insert and keep only active extract)
```

Semantic: inactive `uitofp(mask)` lanes are `0.0`; observable store uses only the active region.

### 2) `other=tensor` (prior load)

**Python**
```python
other = tl.load(fill_ptr + offs)
x = tl.load(in_ptr + offs, mask=mask, other=other)
tl.store(out_ptr + offs, x)  # full block so pad is observable
```

**TTIR**
```mlir
%other = tt.load %fill_ptr : ...
%x     = tt.load %ptr, %mask, %other : ...
tt.store %out, %x
```

**After `triton-to-linalg`**
```mlir
%other_t = bufferization.to_tensor …             // [OTHER] from prior load
%ptr_mem = memref.reinterpret_cast %in_ptr …
%alloc = memref.alloc() : memref<128xf32>        // [SRC]
%src_view = memref.subview %ptr_mem[0][%valid][1]
%dst_view = memref.subview %alloc[0][%valid][1]
memref.copy %src_view, %dst_view
%loaded  = bufferization.to_tensor %alloc
%active  = tensor.extract_slice %loaded[0][%valid][1]
%x       = tensor.insert_slice %active into %other_t  // into %other
```

### 3) `other=0.0` (unchanged scalar path)

```mlir
%alloc = memref.alloc()
scf.if %need_pad { linalg.fill 0 outs(%alloc) } {hivm.unlikely_condition}
memref.copy (masked)
bufferization.to_tensor %alloc
```

## Tests
- Lit: `unittest/Conversion/General/TritonToLinalg/test_load_with_other.mlir`
  - `load_other_mask`, `load_other_tensor`, `load_other_scalar_zero`
- Pytest: `unittest/pytest_ut/test_load.py`
  - `test_load_with_other_mask`, `test_load_with_other_tensor`

## Perf note
Large-tensor Event timing (N≈33.6M, BLOCK=4096): `other=mask` vs scalar `other=0` and vs insert_slice path are within noise (~0.49 ms). Prefer the unified insert_slice path for maintainability.

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
	[rules](https://cbea.ms/git-commit/#why-not-how).
- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
	- [ ] This PR does not need a test because …
	- [x] I have added tests.
		- `unittest/pytest_ut` for end-to-end NPU tests
		- `unittest/Conversion/General/TritonToLinalg` lit FileCheck
- Select one of the following.
	- [ ] I have not added any `lit` tests.
	- [x] The `lit` tests I have added follow FileCheck best practices (minimal TTIR kernels).
