### PR TITLE
[dot](feat) add al.dot with per-operand fractal (zN) layout

### DIFF
--- a/docs/zh/python-api/_ascend_constraints.py
+++ b/docs/zh/python-api/_ascend_constraints.py
@@ -1018,6 +1018,18 @@ CONSTRAINTS = {
         ],
         "example": "triton.language.extra.cann.extension.sort",
     },
+    "triton.language.extra.cann.extension.dot": {
+        "constraints": [
+            "DataType: Ascend supports f16, bf16, f32, int8. A and B must have the same dtype.",
+            "format_a/b/c: must be ``\"fractal\"`` (zN 4D), ``\"nd\"`` (2D), or ``\"\"`` (default ND).",
+            "Fractal operand must be 4D (zN); ND operand must be 2D.",
+            "Fractal block_col must be 32/elem_bytes (f16/bf16→16, f32→8, int8→32).",
+            "Fractal block_row must be 16; for int8 the right operand requires 32 (zN[N/32, K/32, 32, 32]).",
+            "Output dtype: f32 for float inputs, i32 for int8 (cube L0C accumulator dtype).",
+        ],
+        "example":
+        "triton.language.extra.cann.extension.dot",
+    },
     "triton.language.split": {
         "constraints": [
             "DataType: Ascend A2/A3 does not support fp64, fp8e4, fp8e5, uint16, uint32, uint64.",

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.extension.dot.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.extension.dot.py
@@ -1,0 +1,52 @@
+import torch
+import triton
+import triton.language as tl
+import triton.language.extra.cann.extension as al
+
+
+@triton.jit
+def dot_fractal_a_kernel(
+    a_ptr,
+    b_ptr,
+    out_ptr,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+):
+    K1: tl.constexpr = K // 16
+    M1: tl.constexpr = M // 16
+    a0 = tl.arange(0, K1)[:, None, None, None]
+    a1 = tl.arange(0, M1)[None, :, None, None]
+    a2 = tl.arange(0, 16)[None, None, :, None]
+    a3 = tl.arange(0, 16)[None, None, None, :]
+    a = tl.load(a_ptr + (a0 * (M1 * 256) + a1 * 256 + a2 * 16 + a3))
+    ob = tl.arange(0, K)[:, None] * N + tl.arange(0, N)[None, :]
+    b = tl.load(b_ptr + ob)
+    d = al.dot(a, b, format_a="fractal", format_b="nd", format_c="nd")
+    oo = tl.arange(0, M)[:, None] * N + tl.arange(0, N)[None, :]
+    tl.store(out_ptr + oo, d)
+
+
+def _to_zN(t: torch.Tensor) -> torch.Tensor:
+    M, K = t.shape
+    return t.reshape(M // 16, 16, K // 16, 16).permute(2, 0, 1, 3).contiguous()
+
+
+def test_dot_a_fractal():
+    M, K, N = 32, 64, 32
+    a_nd = torch.randn(M, K, dtype=torch.float16)
+    b_nd = torch.randn(K, N, dtype=torch.float16)
+
+    a_zN = _to_zN(a_nd)
+    a_npu = a_zN.npu()
+    b_npu = b_nd.npu()
+    out_npu = torch.empty(M, N, dtype=torch.float16).npu()
+
+    dot_fractal_a_kernel[(1, )](a_npu, b_npu, out_npu, M, N, K)
+
+    gold = torch.mm(a_nd.to(torch.float32), b_nd.to(torch.float32)).to(torch.float16)
+    torch.testing.assert_close(out_npu.cpu(), gold, rtol=1e-2, atol=1e-2)
+
+
+if __name__ == "__main__":
+    test_dot_a_fractal()

--- a/docs/zh/python-api/triton.language.extra.cann.extension.rst
+++ b/docs/zh/python-api/triton.language.extra.cann.extension.rst
@@ -51,6 +51,7 @@ Vector Operations
     sub_vec_id
     sub_vec_num
     conv1d
+    dot
 
 Enums
 -----

--- a/third_party/ascend/ascend_ir.cc
+++ b/third_party/ascend/ascend_ir.cc
@@ -902,6 +902,20 @@ void init_ascend_ir(py::module &&m) {
           py::arg("input"), py::arg("weight"), py::arg("bias"),
           py::arg("stride"), py::arg("padding_size"), py::arg("dilation"),
           py::arg("groups"), py::arg("output_type"))
+      // dot: D = A * B with per-operand fractal (zN) flags; result type
+      // inferred from A, B and the flags.
+      .def(
+          "create_dot",
+          [](AscendNPUIROpBuilder &self, Value &a, Value &b, bool fractalA,
+             bool fractalB, bool fractalC) -> Value {
+            auto &builder = self.getBuilder();
+            auto op = self.create<triton::ascend::DotOp>(
+                a, b, builder.getBoolAttr(fractalA),
+                builder.getBoolAttr(fractalB), builder.getBoolAttr(fractalC));
+            return op.getResult();
+          },
+          py::arg("a"), py::arg("b"), py::arg("fractal_a"),
+          py::arg("fractal_b"), py::arg("fractal_c"))
       // Add sort
       .def("create_sort",
            [](AscendNPUIROpBuilder &self, Value src, int64_t dim,

--- a/third_party/ascend/include/Dialect/TritonAscend/IR/TritonAscendOps.td
+++ b/third_party/ascend/include/Dialect/TritonAscend/IR/TritonAscendOps.td
@@ -542,4 +542,50 @@ def Conv1dOp : TT_Ascend_Op<"conv1d", [
     let hasVerifier = 1;
 }
 
+//
+// Dot Op
+//
+def DotOp : TT_Ascend_Op<"dot", [
+    Pure,
+    DeclareOpInterfaceMethods<InferTypeOpInterface>
+]> {
+    let summary = "Matmul D = A * B with per-operand fractal (zN) control";
+    let description = [{
+        Computes `D = A * B`, declaring per operand whether it is stored in a
+        fractal (zN) layout: `fractal_a` / `fractal_b` mark input A / B as
+        fractal (converted to ND before the multiply); `fractal_c` produces D in
+        fractal layout. The result carries the cube accumulator dtype (f32 for
+        float inputs, i32 for int8), and its type is inferred from A, B and
+        these flags.
+
+        zN convention (non-transpose; inner block [16, b], b = 32 / elem_bytes,
+        i.e. f16/bf16 -> b=16, f32 -> b=8, int8 -> b=32):
+          A [M,K] <-> [K1, M1, 16, b]     (ND = [d1*d2, d0*d3])
+          B [K,N] <-> [N1, K1, 16, b]     (ND = [d1*d2, d0*d3])
+          C [M,N] <-> [N1, M1, 16, 16]    (L0C accumulator, block 16x16)
+
+        Example (fractal_a + fractal_c, f16 in -> f32 accumulator out):
+        ```mlir
+        %d = ascend.dot %a, %b {fractal_a = true, fractal_c = true}
+             : tensor<1x1x16x16xf16>, tensor<16x16xf16> -> tensor<1x1x16x16xf32>
+        ```
+    }];
+
+    let arguments = (ins
+        TT_Tensor:$a,
+        TT_Tensor:$b,
+        DefaultValuedAttr<BoolAttr, "false">:$fractal_a,
+        DefaultValuedAttr<BoolAttr, "false">:$fractal_b,
+        DefaultValuedAttr<BoolAttr, "false">:$fractal_c
+    );
+
+    let results = (outs TT_Tensor:$d);
+
+    let assemblyFormat = [{
+        $a `,` $b attr-dict `:` type($a) `,` type($b) `->` type($d)
+    }];
+
+    let hasVerifier = 1;
+}
+
 #endif // TRITON_ASCEND_OPS

--- a/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
@@ -689,6 +689,14 @@ struct MatmulConverter : public OpConversionPattern<triton::DotOp> {
                   ConversionPatternRewriter &rewriter) const override;
 };
 
+struct DotConverter : public OpConversionPattern<triton::ascend::DotOp> {
+  using OpConversionPattern<triton::ascend::DotOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::ascend::DotOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override;
+};
+
 struct FlipOpConverter : public OpConversionPattern<triton::ascend::FlipOp> {
   using OpConversionPattern<triton::ascend::FlipOp>::OpConversionPattern;
 

--- a/third_party/ascend/include/Utils/Utils.h
+++ b/third_party/ascend/include/Utils/Utils.h
@@ -199,6 +199,21 @@ ModuleOp getModuleOpFromOperation(Operation *op);
 
 bool isTensorPtrType(Type type);
 
+namespace ascend {
+
+// Fractal (zN) block geometry shared by ascend.dot's type inference/verifier
+// (DotOp::inferReturnTypes) and its lowering (DotConverter). The inner block is
+// [kFractalBlock, b] with b = kBytesPerFractalCol / elemBytes, i.e. f16/bf16 ->
+// 16, f32 -> 8, int8 -> 32; fractal_c is the L0C accumulator fractal, always
+// [kFractalBlock, kFractalBlock].
+inline constexpr int64_t kFractalBlock = 16;
+inline constexpr int64_t kBytesPerFractalCol = 32;
+inline constexpr unsigned kBitsPerByte = 8;
+// Cube accumulator width for integer inputs (int8 -> i32).
+inline constexpr unsigned kDotAccIntWidth = 32;
+
+} // namespace ascend
+
 } // namespace triton
 
 class OpBuilder;

--- a/third_party/ascend/language/cann/extension/__init__.py
+++ b/third_party/ascend/language/cann/extension/__init__.py
@@ -42,6 +42,7 @@ from .core import (
     sync_block_wait,
     SYNC_IN_VF,
     conv1d,
+    dot,
 )
 
 from .scope import scope
@@ -158,4 +159,7 @@ __all__ = [
 
     # utils
     "is_compile_on_910_95",
+
+    # dot ops
+    "dot",
 ]

--- a/third_party/ascend/language/cann/extension/core.py
+++ b/third_party/ascend/language/cann/extension/core.py
@@ -24,7 +24,7 @@ __all__ = [
     "ascend_address_space", "builtin", "CORE", "copy_from_ub_to_l1", "copy", "debug_barrier", "fixpipe",
     "FixpipeDMAMode", "FixpipeDualDstMode", "FixpipePreQuantMode", "FixpipePreReluMode", "int64", "is_builtin", "MODE",
     "PIPE", "SYNC_HINT", "EVENT_ID", "IteratorType", "sub_vec_id", "sub_vec_num", "sync_block_all", "sync_block_set",
-    "sync_block_wait", "SYNC_IN_VF", "conv1d"
+    "sync_block_wait", "SYNC_IN_VF", "conv1d", "dot"
 ]
 
 import enum
@@ -567,3 +567,111 @@ def conv1d(input: tl.tensor, weight: tl.tensor, bias: tl.tensor = None, stride=N
         output_shape = [C_out, L_out_val]
 
     return semantic.conv1d(input, weight, bias, stride, padding_size_int, dilation, groups, output_shape, _semantic)
+
+
+def _dot_to_nd_shape(shape, fractal, is_lhs):
+    """A fractal operand's ND shape; lhs -> [M,K], rhs -> [K,N]. 2D is already ND.
+
+    Both operands use the zN fractal (non-transpose): A [M,K] <-> [K1,M1,16,b]
+    and B [K,N] <-> [N1,K1,16,b]. In each the two logical dims are
+    [d1*d2, d0*d3] (block rows on d2, block cols on d3)."""
+    if not (fractal and len(shape) == 4):
+        return [shape[0], shape[1]]
+    return [shape[1] * shape[2], shape[0] * shape[3]]
+
+
+def _check_dot_fractal_block(name, shape, is_lhs, dtype):
+    """Validate an nZ operand's trailing block [.., block_row, block_col].
+
+    block_col must equal 32 / elem_bytes. block_row must be 16, except for int8
+    where the cube fractal is per-operand: a non-transpose left operand is 16
+    and a non-transpose right operand is 32.
+    """
+    elem_bytes = dtype.primitive_bitwidth // 8
+    expected_col = 32 // elem_bytes
+    block_row = _unwrap_if_constexpr(shape[-2])
+    block_col = _unwrap_if_constexpr(shape[-1])
+
+    if block_col != expected_col:
+        raise ValueError(f"dot nZ operand `{name}`: block col dim is {block_col}, expected "
+                         f"{expected_col} (= 32 / {elem_bytes} bytes per {dtype} element)")
+
+    if elem_bytes != 1:
+        if block_row != 16:
+            raise ValueError(f"dot nZ operand `{name}`: block row dim is {block_row}, expected 16")
+        return
+
+    if block_row not in (16, 32):
+        raise ValueError(f"dot int8 nZ operand `{name}`: block row dim is {block_row}, expected 16 or 32")
+    if not is_lhs and block_row == 16:
+        raise ValueError(f"dot int8 right operand `{name}`: block row dim is 16, but a non-transpose "
+                         f"`{name}` needs 32 (block [32,32], i.e. zN[N/32, K/32, 32, 32]); a [16,32] "
+                         f"block forces an unsupported layout conversion in the backend")
+
+
+def _dot_operand_is_fractal(name, fmt):
+    """Resolve operand ``name``'s layout from its ``format_*`` string:
+
+      ``"fractal"``             -> fractal (zN)
+      ``"nd"`` / ``""`` / unset -> non-fractal (ND)
+      anything else             -> ValueError
+    """
+    fmt = _unwrap_if_constexpr(fmt)
+    if fmt is None or fmt == "" or fmt == "nd":
+        return False
+    if fmt == "fractal":
+        return True
+    raise ValueError(f"dot `{name}`: format must be 'fractal', 'nd', or '' "
+                     f"(empty/unset = non-fractal ND); got {fmt!r}")
+
+
+@builtin
+def dot(a: tl.tensor, b: tl.tensor, format_a="", format_b="", format_c="", _semantic=None) -> tl.tensor:
+    """
+    Matrix multiply ``D = A * B`` with per-operand layout format.
+
+    ``format_a`` / ``format_b`` / ``format_c`` select each operand's layout:
+      - ``"fractal"``: zN fractal (4D)
+      - ``"nd"`` / ``""`` / unset: ND (non-fractal, 2D)
+      - any other value raises ``ValueError``.
+
+    zN convention (non-transpose, block [16, b], b = 32 / elem_bytes):
+        A [M,K] <-> [K1, M1, 16, b]      (ND = [d1*d2, d0*d3])
+        B [K,N] <-> [N1, K1, 16, b]      (ND = [d1*d2, d0*d3])
+        C [M,N] <-> [N1, M1, 16, 16]     (L0C accumulator, block 16x16)
+
+    :param a: left matrix A (2D ND, or 4D fractal when ``format_a="fractal"``).
+    :param b: right matrix B (2D ND, or 4D fractal when ``format_b="fractal"``).
+    :param format_a: layout of A: "fractal" | "nd" | "" (default ND).
+    :param format_b: layout of B: "fractal" | "nd" | "" (default ND).
+    :param format_c: layout of D: "fractal" | "nd" | "" (default ND).
+
+    :return: D = A * B (fractal 4D if ``format_c="fractal"`` else 2D ND).
+    :rtype: tensor
+    """
+    fractal_a = _dot_operand_is_fractal("a", format_a)
+    fractal_b = _dot_operand_is_fractal("b", format_b)
+    fractal_c = _dot_operand_is_fractal("c", format_c)
+
+    for name, operand, is_frac, is_lhs in (("a", a, fractal_a, True), ("b", b, fractal_b, False)):
+        if not isinstance(operand, tl.tensor):
+            raise TypeError(f"dot operand `{name}` must be a tensor, got {type(operand)}")
+        if len(operand.shape) not in (2, 4):
+            raise ValueError(f"dot operand `{name}` must be 2D (ND) or 4D (fractal zN), "
+                             f"got rank {len(operand.shape)}")
+        if is_frac and len(operand.shape) == 4:
+            _check_dot_fractal_block(name, operand.shape, is_lhs, operand.dtype)
+
+    # cube mmad requires both inputs share the element dtype (the output takes
+    # the accumulator dtype separately, see semantic.dot).
+    if a.dtype != b.dtype:
+        raise TypeError(f"dot operands must have the same dtype, got {a.dtype} and {b.dtype}")
+
+    a_nd = _dot_to_nd_shape([_unwrap_if_constexpr(s) for s in a.shape], fractal_a, True)
+    b_nd = _dot_to_nd_shape([_unwrap_if_constexpr(s) for s in b.shape], fractal_b, False)
+    m, n = a_nd[0], b_nd[1]
+    # The result carries the cube accumulator dtype (f32/i32, see semantic.dot);
+    # fractal_c is the L0C accumulator fractal, whose block is 16x16.
+    output_shape = [n // 16, m // 16, 16, 16] if fractal_c else [m, n]
+
+    return semantic.dot(a, b, fractal_a, fractal_b, fractal_c, output_shape, _semantic=_semantic)

--- a/third_party/ascend/language/cann/extension/semantic.py
+++ b/third_party/ascend/language/cann/extension/semantic.py
@@ -194,3 +194,18 @@ def conv1d(input_tensor: tl.tensor, weight_tensor: tl.tensor, bias: Union[tl.ten
     out = _semantic.builder.create_conv1d(input_tensor.handle, weight_tensor.handle, bias_handle, stride, padding_size,
                                           dilation, groups, output_ty.to_ir(_semantic.builder))
     return tl.tensor(out, output_ty)
+
+
+def dot(a: tl.tensor, b: tl.tensor, fractal_a: bool, fractal_b: bool, fractal_c: bool, output_shape,
+        _semantic=None) -> tl.tensor:
+    # Go through `_ascend_builder` explicitly rather than the unified-builder
+    # allow-list (builder.py:setup_unified_builder): `create_dot` collides with
+    # upstream `ir.builder.create_dot`, so attaching it to the main builder
+    # would shadow the one `tl.dot` uses.
+    out = _semantic.builder._ascend_builder.create_dot(a.handle, b.handle, bool(fractal_a), bool(fractal_b),
+                                                       bool(fractal_c))
+    # Result carries the cube accumulator dtype: f32 for float inputs, i32 for int8.
+    in_ty = a.type.element_ty
+    acc_ty = tl.float32 if in_ty.is_floating() else tl.int32
+    output_ty = tl.block_type(acc_ty, output_shape)
+    return tl.tensor(out, output_ty)

--- a/third_party/ascend/lib/Dialect/TritonAscend/IR/TritonAscendOps.cpp
+++ b/third_party/ascend/lib/Dialect/TritonAscend/IR/TritonAscendOps.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ascend/include/Dialect/TritonAscend/IR/TritonAscendDialect.h"
+#include "ascend/include/Utils/Utils.h"
 #include "mlir/Dialect/SPIRV/IR/TargetAndABI.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "triton/Tools/Sys/GetEnv.hpp"
@@ -37,6 +38,73 @@ void StrideLoadOp::getEffects(
         &effects) {
   effects.emplace_back(MemoryEffects::Read::get(), &getSrcMutable(),
                        triton::GlobalMemory::get());
+}
+
+//-- DotOp --
+// Fractal (zN) block geometry (kFractalBlock / kDotAccIntWidth) comes from
+// Utils.h, shared with DotConverter's lowering.
+LogicalResult
+DotOp::inferReturnTypes(MLIRContext *context, std::optional<Location> location,
+                        ValueRange operands, DictionaryAttr attributes,
+                        OpaqueProperties properties, RegionRange regions,
+                        SmallVectorImpl<Type> &inferredReturnTypes) {
+  DotOpAdaptor adaptor(operands, attributes, properties, regions);
+  auto aTy = dyn_cast<RankedTensorType>(adaptor.getA().getType());
+  auto bTy = dyn_cast<RankedTensorType>(adaptor.getB().getType());
+  if (!aTy || !bTy)
+    return failure();
+
+  // A fractal operand's ND shape. Both operands are zN (non-transpose):
+  // lhs [K1,M1,16,b] -> [M,K], rhs [N1,K1,16,b] -> [K,N], each [d1*d2, d0*d3].
+  auto toND = [](ArrayRef<int64_t> shape, bool fractal,
+                 bool isLhs) -> SmallVector<int64_t> {
+    if (!fractal || shape.size() != 4)
+      return {shape[0], shape[1]};
+    return {shape[1] * shape[2], shape[0] * shape[3]};
+  };
+  int64_t m = toND(aTy.getShape(), adaptor.getFractalA(), /*isLhs=*/true)[0];
+  int64_t n = toND(bTy.getShape(), adaptor.getFractalB(), /*isLhs=*/false)[1];
+
+  // The result carries the cube accumulator dtype (f32 for float inputs, i32
+  // for int8), not the input dtype. fractal_c produces the L0C accumulator
+  // fractal, whose block is 16x16 regardless of dtype.
+  Type inElemTy = aTy.getElementType();
+  Type accTy =
+      isa<IntegerType>(inElemTy)
+          ? static_cast<Type>(IntegerType::get(context, kDotAccIntWidth))
+          : static_cast<Type>(Float32Type::get(context));
+  SmallVector<int64_t> resShape{m, n};
+  if (adaptor.getFractalC())
+    // ND [M,N] -> zN accumulator [N1, M1, 16, 16].
+    resShape = {n / kFractalBlock, m / kFractalBlock, kFractalBlock,
+                kFractalBlock};
+  inferredReturnTypes.push_back(RankedTensorType::get(resShape, accTy));
+  return success();
+}
+
+// Verify operand ranks match their fractal flags: a fractal operand must be 4D
+// (zN), a non-fractal operand must be 2D (ND). Anything else (e.g. rank > 4) is
+// a compile error.
+LogicalResult DotOp::verify() {
+  auto aTy = dyn_cast<RankedTensorType>(getA().getType());
+  auto bTy = dyn_cast<RankedTensorType>(getB().getType());
+  if (!aTy || !bTy)
+    return emitOpError("operands must be ranked tensors");
+  auto checkRank = [&](RankedTensorType ty, bool fractal,
+                       StringRef name) -> LogicalResult {
+    int64_t rank = ty.getRank();
+    if (fractal && rank != 4)
+      return emitOpError() << "fractal operand '" << name
+                           << "' must be 4D (zN), got rank " << rank;
+    if (!fractal && rank != 2)
+      return emitOpError() << "non-fractal operand '" << name
+                           << "' must be 2D (ND), got rank " << rank;
+    return success();
+  };
+  if (failed(checkRank(aTy, getFractalA(), "a")) ||
+      failed(checkRank(bTy, getFractalB(), "b")))
+    return failure();
+  return success();
 }
 
 //-- IndexSelectSimdOp --

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -2230,6 +2230,207 @@ MatmulConverter::matchAndRewrite(triton::DotOp op, OpAdaptor adaptor,
   return success();
 }
 
+// Fractal (zN) block geometry for ascend.dot lowering comes from Utils.h,
+// shared with DotOp::inferReturnTypes.
+
+// zN block column count b = 32 bytes / element bytes.
+static int64_t nzBlockCol(Type elemTy) {
+  return triton::ascend::kBytesPerFractalCol /
+         (elemTy.getIntOrFloatBitWidth() / triton::ascend::kBitsPerByte);
+}
+
+static hivm::DataLayoutAttr dotNdLayout(MLIRContext *ctx) {
+  return hivm::DataLayoutAttr::get(ctx, hivm::DataLayout::ND);
+}
+
+static hivm::DataLayoutAttr dotFractalLayout(MLIRContext *ctx, int64_t blockRow,
+                                             int64_t blockCol) {
+  return hivm::DataLayoutAttr::get(
+      ctx, hivm::DataLayout::Fractal, /*transpose=*/nullptr,
+      DenseI64ArrayAttr::get(ctx, {blockRow, blockCol}));
+}
+
+// A 4D fractal dot operand -> 2D ND (no-op if already ND). Both operands are zN
+// (non-transpose): lhs [K1,M1,16,b] -> [M,K] and rhs [N1,K1,16,b] -> [K,N],
+// each = [d1*d2, d0*d3].
+static Value dotFractalToND(ConversionPatternRewriter &rewriter, Location loc,
+                            Value operand, bool isLhs) {
+  auto operandTy = cast<RankedTensorType>(operand.getType());
+  if (operandTy.getRank() != 4)
+    return operand;
+  auto blockedShape = operandTy.getShape();
+  SmallVector<int64_t> ndShape{blockedShape[1] * blockedShape[2],
+                               blockedShape[0] * blockedShape[3]};
+  MLIRContext *ctx = rewriter.getContext();
+  return rewriter.create<hivm::ConvertLayoutOp>(
+      loc, RankedTensorType::get(ndShape, operandTy.getElementType()), operand,
+      /*srcLayout=*/dotFractalLayout(ctx, blockedShape[2], blockedShape[3]),
+      /*dstLayout=*/dotNdLayout(ctx), DenseI64ArrayAttr::get(ctx, ndShape),
+      /*output_shape=*/ValueRange{});
+}
+
+// If `v` is a freshly-loaded buffer used only here -- to_tensor of an alloc
+// with a single writer copy (the load) -- return that load copy so its DMA can
+// be retargeted into the padded buffer (one copy, not load-then-copy); else
+// null.
+static memref::CopyOp findRedirectableLoad(Value v) {
+  auto toTensor = v.getDefiningOp<bufferization::ToTensorOp>();
+  if (!toTensor || v.hasNUsesOrMore(2))
+    return nullptr;
+  Value srcBuf = toTensor.getBuffer();
+  if (!srcBuf.getDefiningOp<memref::AllocOp>())
+    return nullptr;
+  memref::CopyOp loadCopy = nullptr;
+  for (Operation *user : srcBuf.getUsers()) {
+    if (user == toTensor.getOperation())
+      continue;
+    // Bail on a non-copy user, a source-use of srcBuf, or a second writer.
+    auto copyOp = dyn_cast<memref::CopyOp>(user);
+    if (!copyOp || copyOp.getTarget() != srcBuf || loadCopy)
+      return nullptr;
+    loadCopy = copyOp;
+  }
+  return loadCopy;
+}
+
+// Zero-pad `v`'s dimension `dim` up to `target` (no-op if already that size).
+// Uses memref.alloc + fill(0) + subview + copy, NOT tensor.insert_slice: the
+// latter lowers (in AscendNPU-IR AutoVectorizeV2) to a scalar copy loop that
+// blows up cbuf.
+static Value zeroPadDimTo(Value v, int64_t dim, int64_t target,
+                          ConversionPatternRewriter &rewriter, Location loc) {
+  auto t = cast<RankedTensorType>(v.getType());
+  if (t.getShape()[dim] == target)
+    return v;
+  Type elemTy = t.getElementType();
+
+  // Push the pad through a transpose (pad the mapped input dim, re-transpose).
+  if (auto trans = v.getDefiningOp<linalg::TransposeOp>()) {
+    ArrayRef<int64_t> perm = trans.getPermutation();
+    Value paddedInput =
+        zeroPadDimTo(trans.getInput(), perm[dim], target, rewriter, loc);
+    SmallVector<int64_t> outShape(t.getShape().begin(), t.getShape().end());
+    outShape[dim] = target;
+    Value init = rewriter.create<tensor::EmptyOp>(loc, outShape, elemTy);
+    return rewriter.create<linalg::TransposeOp>(loc, paddedInput, init, perm)
+        .getResults()[0];
+  }
+
+  SmallVector<int64_t> paddedShape(t.getShape().begin(), t.getShape().end());
+  paddedShape[dim] = target;
+
+  // Allocate the padded buffer and zero-fill it.
+  auto paddedMemTy = MemRefType::get(paddedShape, elemTy);
+  Value padded = rewriter.create<memref::AllocOp>(loc, paddedMemTy);
+  Value zero =
+      rewriter.create<arith::ConstantOp>(loc, rewriter.getZeroAttr(elemTy));
+  rewriter.create<linalg::FillOp>(loc, ValueRange{zero}, ValueRange{padded});
+
+  // Subview covering the real (unpadded) region, then fill it with one copy.
+  int64_t rank = t.getRank();
+  SmallVector<OpFoldResult> offsets(rank, rewriter.getIndexAttr(0));
+  SmallVector<OpFoldResult> strides(rank, rewriter.getIndexAttr(1));
+  SmallVector<OpFoldResult> sizes;
+  for (int64_t d : t.getShape())
+    sizes.push_back(rewriter.getIndexAttr(d));
+  auto subviewTy =
+      memref::SubViewOp::inferResultType(paddedMemTy, offsets, sizes, strides);
+  Value subview = rewriter.create<memref::SubViewOp>(
+      loc, cast<MemRefType>(subviewTy), padded, offsets, sizes, strides);
+
+  if (memref::CopyOp loadCopy = findRedirectableLoad(v)) {
+    rewriter.create<memref::CopyOp>(loc, loadCopy.getSource(), subview);
+    rewriter.eraseOp(loadCopy);
+  } else {
+    auto srcBufferTy = MemRefType::get(t.getShape(), elemTy);
+    Value srcBuffer =
+        rewriter.create<bufferization::ToBufferOp>(loc, srcBufferTy, v);
+    rewriter.create<memref::CopyOp>(loc, srcBuffer, subview);
+  }
+
+  return rewriter.create<bufferization::ToTensorOp>(
+      loc, RankedTensorType::get(paddedShape, elemTy), padded,
+      /*restrict=*/true, /*writable=*/true);
+}
+
+// Reconcile the ND operands' contraction (K) dim (a/b mutated in place). When
+// exactly one operand is fractal, its K is block-rounded while the ND side may
+// be shorter; zero-padding the ND side to the block-aligned K is safe (the
+// extra K products are * 0). Only an in-one-block gap is padding; else error.
+static LogicalResult
+reconcileDotContractionK(triton::ascend::DotOp op, Value &a, Value &b,
+                         Type elemTy, ConversionPatternRewriter &rewriter,
+                         Location loc) {
+  if (op.getFractalA() == op.getFractalB())
+    return success();
+  int64_t kA = cast<RankedTensorType>(a.getType()).getShape()[1]; // A_nd [M,kA]
+  int64_t kB = cast<RankedTensorType>(b.getType()).getShape()[0]; // B_nd [kB,N]
+  if (kA == kB)
+    return success();
+  int64_t paddedK = std::max(kA, kB), shortK = std::min(kA, kB);
+  int64_t blockK = nzBlockCol(elemTy);
+  if (paddedK % blockK != 0 || paddedK - shortK >= blockK)
+    return op.emitError()
+           << "dot: contraction dim mismatch (A K=" << kA << ", B K=" << kB
+           << ") is larger than fractal padding; pad the operand "
+              "explicitly";
+  op.emitWarning() << "dot: auto zero-padding the non-fractal operand's K from "
+                   << shortK << " to " << paddedK
+                   << " to match the fractal operand's block-aligned K";
+  a = zeroPadDimTo(a, /*dim=*/1, paddedK, rewriter, loc); // A_nd [M,K]
+  b = zeroPadDimTo(b, /*dim=*/0, paddedK, rewriter, loc); // B_nd [K,N]
+  return success();
+}
+
+// Decompose `ascend.dot` (D = A * B): fractal inputs -> ND, a plain
+// linalg.matmul, then (if fractal_c) the ND result back to fractal.
+LogicalResult
+DotConverter::matchAndRewrite(triton::ascend::DotOp op, OpAdaptor adaptor,
+                              ConversionPatternRewriter &rewriter) const {
+  Location loc = op.getLoc();
+  MLIRContext *ctx = rewriter.getContext();
+  auto resTy = cast<RankedTensorType>(op.getType());
+  // The result carries the cube accumulator dtype (f32/i32); the matmul inputs
+  // and K-padding use the operands' own (input) dtype.
+  Type accTy = resTy.getElementType();
+
+  Value a = op.getFractalA()
+                ? dotFractalToND(rewriter, loc, adaptor.getA(), /*isLhs=*/true)
+                : adaptor.getA();
+  Value b = op.getFractalB()
+                ? dotFractalToND(rewriter, loc, adaptor.getB(), /*isLhs=*/false)
+                : adaptor.getB();
+  Type inElemTy = cast<RankedTensorType>(a.getType()).getElementType();
+  if (failed(reconcileDotContractionK(op, a, b, inElemTy, rewriter, loc)))
+    return failure();
+
+  // Uninitialized accumulator (accTy): mmadL1 (accumulate=false) overwrites it.
+  int64_t numRows = cast<RankedTensorType>(a.getType()).getShape()[0];
+  int64_t numCols = cast<RankedTensorType>(b.getType()).getShape()[1];
+  auto ndResultTy = RankedTensorType::get({numRows, numCols}, accTy);
+  Value acc = rewriter.create<tensor::EmptyOp>(
+      loc, ArrayRef<int64_t>{numRows, numCols}, accTy);
+  auto matmul = rewriter.create<linalg::MatmulOp>(
+      loc, TypeRange{ndResultTy}, ValueRange{a, b}, ValueRange{acc});
+  matmul->setAttr("input_precision", rewriter.getStringAttr("ieee"));
+  Value ndResult = matmul->getResult(0);
+
+  if (!op.getFractalC()) {
+    rewriter.replaceOp(op, ndResult);
+    return success();
+  }
+  // fractal_c: ND result -> the L0C accumulator fractal (block [16, 16]).
+  Value fractalResult = rewriter.create<hivm::ConvertLayoutOp>(
+      loc, resTy, ndResult, /*srcLayout=*/dotNdLayout(ctx),
+      /*dstLayout=*/
+      dotFractalLayout(ctx, triton::ascend::kFractalBlock,
+                       triton::ascend::kFractalBlock),
+      DenseI64ArrayAttr::get(ctx, resTy.getShape()), /*output_shape=*/
+      ValueRange{});
+  rewriter.replaceOp(op, fractalResult);
+  return success();
+}
+
 LogicalResult
 FlipOpConverter::matchAndRewrite(triton::ascend::FlipOp op, OpAdaptor adaptor,
                                  ConversionPatternRewriter &rewriter) const {

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -719,6 +719,7 @@ void TritonToLinalgPass::populateTritonToLinalgConversionPatterns(
   patterns.add<TTOpConverters::DeviceAssertConverter>(patterns.getContext());
   patterns.add<TTOpConverters::DevicePrintConverter>(patterns.getContext());
   patterns.add<TTOpConverters::MatmulConverter>(patterns.getContext());
+  patterns.add<TTOpConverters::DotConverter>(patterns.getContext());
   patterns.add<TTOpConverters::DotScaledConverter>(patterns.getContext());
   patterns.add<TTOpConverters::PtrToIntConverter>(patterns.getContext());
 
@@ -938,6 +939,13 @@ void TritonToLinalgPass::runOnOperation() {
     return WalkResult::interrupt();
   });
   moduleOp.walk([&](triton::DotScaledOp dotScaledOp) {
+    existDot = true;
+    return WalkResult::interrupt();
+  });
+  // dot decomposes into a cube linalg.matmul, so a kernel containing it is
+  // a cube (mix) kernel, not a pure-AIV one. Without this the func gets tagged
+  // mix_mode="aiv" and the cube tile-and-slice fails (cbuf overflow).
+  moduleOp.walk([&](triton::ascend::DotOp dotOp) {
     existDot = true;
     return WalkResult::interrupt();
   });

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/dot_fractal.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/dot_fractal.mlir
@@ -1,0 +1,398 @@
+// RUN: triton-opt --triton-to-linalg="named-ops=True" --split-input-file %s | FileCheck %s
+
+module {
+  tt.func public @case1_a_fractal(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f16>) attributes {noinline = false} {
+    %cst = arith.constant dense<80> : tensor<160x1xi32>
+    %cst_0 = arith.constant dense<80> : tensor<320x1xi32>
+    %cst_1 = arith.constant dense<16> : tensor<1x1x16x1xi32>
+    %cst_2 = arith.constant dense<256> : tensor<1x10x1x1xi32>
+    %cst_3 = arith.constant dense<2560> : tensor<20x1x1x1xi32>
+    %0 = tt.make_range {end = 20 : i32, start = 0 : i32} : tensor<20xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<20xi32> -> tensor<20x1xi32>
+    %2 = tt.expand_dims %1 {axis = 2 : i32} : tensor<20x1xi32> -> tensor<20x1x1xi32>
+    %3 = tt.expand_dims %2 {axis = 3 : i32} : tensor<20x1x1xi32> -> tensor<20x1x1x1xi32>
+    %4 = tt.make_range {end = 10 : i32, start = 0 : i32} : tensor<10xi32>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<10xi32> -> tensor<1x10xi32>
+    %6 = tt.expand_dims %5 {axis = 2 : i32} : tensor<1x10xi32> -> tensor<1x10x1xi32>
+    %7 = tt.expand_dims %6 {axis = 3 : i32} : tensor<1x10x1xi32> -> tensor<1x10x1x1xi32>
+    %8 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %9 = tt.expand_dims %8 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+    %10 = tt.expand_dims %9 {axis = 1 : i32} : tensor<1x16xi32> -> tensor<1x1x16xi32>
+    %11 = tt.expand_dims %10 {axis = 3 : i32} : tensor<1x1x16xi32> -> tensor<1x1x16x1xi32>
+    %12 = tt.expand_dims %10 {axis = 2 : i32} : tensor<1x1x16xi32> -> tensor<1x1x1x16xi32>
+    %13 = arith.muli %3, %cst_3 : tensor<20x1x1x1xi32>
+    %14 = arith.muli %7, %cst_2 : tensor<1x10x1x1xi32>
+    %15 = tt.broadcast %13 : tensor<20x1x1x1xi32> -> tensor<20x10x1x1xi32>
+    %16 = tt.broadcast %14 : tensor<1x10x1x1xi32> -> tensor<20x10x1x1xi32>
+    %17 = arith.addi %15, %16 : tensor<20x10x1x1xi32>
+    %18 = arith.muli %11, %cst_1 : tensor<1x1x16x1xi32>
+    %19 = tt.broadcast %17 : tensor<20x10x1x1xi32> -> tensor<20x10x16x1xi32>
+    %20 = tt.broadcast %18 : tensor<1x1x16x1xi32> -> tensor<20x10x16x1xi32>
+    %21 = arith.addi %19, %20 : tensor<20x10x16x1xi32>
+    %22 = tt.broadcast %21 : tensor<20x10x16x1xi32> -> tensor<20x10x16x16xi32>
+    %23 = tt.broadcast %12 : tensor<1x1x1x16xi32> -> tensor<20x10x16x16xi32>
+    %24 = arith.addi %22, %23 : tensor<20x10x16x16xi32>
+    %25 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<20x10x16x16x!tt.ptr<f16>>
+    %26 = tt.addptr %25, %24 : tensor<20x10x16x16x!tt.ptr<f16>>, tensor<20x10x16x16xi32>
+    %27 = tt.load %26 : tensor<20x10x16x16x!tt.ptr<f16>>
+    %28 = tt.make_range {end = 320 : i32, start = 0 : i32} : tensor<320xi32>
+    %29 = tt.expand_dims %28 {axis = 1 : i32} : tensor<320xi32> -> tensor<320x1xi32>
+    %30 = arith.muli %29, %cst_0 : tensor<320x1xi32>
+    %31 = tt.make_range {end = 80 : i32, start = 0 : i32} : tensor<80xi32>
+    %32 = tt.expand_dims %31 {axis = 0 : i32} : tensor<80xi32> -> tensor<1x80xi32>
+    %33 = tt.broadcast %30 : tensor<320x1xi32> -> tensor<320x80xi32>
+    %34 = tt.broadcast %32 : tensor<1x80xi32> -> tensor<320x80xi32>
+    %35 = arith.addi %33, %34 : tensor<320x80xi32>
+    %36 = tt.splat %arg1 : !tt.ptr<f16> -> tensor<320x80x!tt.ptr<f16>>
+    %37 = tt.addptr %36, %35 : tensor<320x80x!tt.ptr<f16>>, tensor<320x80xi32>
+    %38 = tt.load %37 : tensor<320x80x!tt.ptr<f16>>
+    %39 = ascend.dot %27, %38 {fractal_a = true} : tensor<20x10x16x16xf16>, tensor<320x80xf16> -> tensor<160x80xf32>
+    %40 = tt.make_range {end = 160 : i32, start = 0 : i32} : tensor<160xi32>
+    %41 = tt.expand_dims %40 {axis = 1 : i32} : tensor<160xi32> -> tensor<160x1xi32>
+    %42 = arith.muli %41, %cst : tensor<160x1xi32>
+    %43 = tt.broadcast %42 : tensor<160x1xi32> -> tensor<160x80xi32>
+    %44 = tt.broadcast %32 : tensor<1x80xi32> -> tensor<160x80xi32>
+    %45 = arith.addi %43, %44 : tensor<160x80xi32>
+    %46 = tt.splat %arg2 : !tt.ptr<f16> -> tensor<160x80x!tt.ptr<f16>>
+    %47 = tt.addptr %46, %45 : tensor<160x80x!tt.ptr<f16>>, tensor<160x80xi32>
+    %48 = arith.truncf %39 : tensor<160x80xf32> to tensor<160x80xf16>
+    tt.store %47, %48 : tensor<160x80x!tt.ptr<f16>>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: func.func @case1_a_fractal
+// CHECK-SAME:    mix_mode = "mix"
+// CHECK:         hivm.hir.convert_layout %{{.*}} output_shape [160, 320] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<Fractal, fractalSizes = [16, 16]>} : (tensor<20x10x16x16xf16>) -> tensor<160x320xf16>
+// CHECK:         %[[ACC:.*]] = tensor.empty() : tensor<160x80xf32>
+// CHECK:         linalg.matmul {input_precision = "ieee"} ins(%{{.*}}, %{{.*}} : tensor<160x320xf16>, tensor<320x80xf16>) outs(%[[ACC]] : tensor<160x80xf32>) -> tensor<160x80xf32>
+// ND result: no ND->Fractal convert afterwards.
+// CHECK-NOT:     hivm.hir.convert_layout
+
+// -----
+
+module {
+  tt.func public @s_C1_pure_cube(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f16>) attributes {noinline = false} {
+    %cst = arith.constant dense<2560> : tensor<5x1x1x1xi32>
+    %cst_0 = arith.constant dense<256> : tensor<1x20x1x1xi32>
+    %cst_1 = arith.constant dense<5120> : tensor<5x1x1x1xi32>
+    %cst_2 = arith.constant dense<16> : tensor<1x1x16x1xi32>
+    %cst_3 = arith.constant dense<256> : tensor<1x10x1x1xi32>
+    %cst_4 = arith.constant dense<2560> : tensor<20x1x1x1xi32>
+    %0 = tt.make_range {end = 20 : i32, start = 0 : i32} : tensor<20xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<20xi32> -> tensor<20x1xi32>
+    %2 = tt.expand_dims %1 {axis = 2 : i32} : tensor<20x1xi32> -> tensor<20x1x1xi32>
+    %3 = tt.expand_dims %2 {axis = 3 : i32} : tensor<20x1x1xi32> -> tensor<20x1x1x1xi32>
+    %4 = arith.muli %3, %cst_4 : tensor<20x1x1x1xi32>
+    %5 = tt.make_range {end = 10 : i32, start = 0 : i32} : tensor<10xi32>
+    %6 = tt.expand_dims %5 {axis = 0 : i32} : tensor<10xi32> -> tensor<1x10xi32>
+    %7 = tt.expand_dims %6 {axis = 2 : i32} : tensor<1x10xi32> -> tensor<1x10x1xi32>
+    %8 = tt.expand_dims %7 {axis = 3 : i32} : tensor<1x10x1xi32> -> tensor<1x10x1x1xi32>
+    %9 = arith.muli %8, %cst_3 : tensor<1x10x1x1xi32>
+    %10 = tt.broadcast %4 : tensor<20x1x1x1xi32> -> tensor<20x10x1x1xi32>
+    %11 = tt.broadcast %9 : tensor<1x10x1x1xi32> -> tensor<20x10x1x1xi32>
+    %12 = arith.addi %10, %11 : tensor<20x10x1x1xi32>
+    %13 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %14 = tt.expand_dims %13 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+    %15 = tt.expand_dims %14 {axis = 1 : i32} : tensor<1x16xi32> -> tensor<1x1x16xi32>
+    %16 = tt.expand_dims %15 {axis = 3 : i32} : tensor<1x1x16xi32> -> tensor<1x1x16x1xi32>
+    %17 = arith.muli %16, %cst_2 : tensor<1x1x16x1xi32>
+    %18 = tt.broadcast %12 : tensor<20x10x1x1xi32> -> tensor<20x10x16x1xi32>
+    %19 = tt.broadcast %17 : tensor<1x1x16x1xi32> -> tensor<20x10x16x1xi32>
+    %20 = arith.addi %18, %19 : tensor<20x10x16x1xi32>
+    %21 = tt.expand_dims %15 {axis = 2 : i32} : tensor<1x1x16xi32> -> tensor<1x1x1x16xi32>
+    %22 = tt.broadcast %20 : tensor<20x10x16x1xi32> -> tensor<20x10x16x16xi32>
+    %23 = tt.broadcast %21 : tensor<1x1x1x16xi32> -> tensor<20x10x16x16xi32>
+    %24 = arith.addi %22, %23 : tensor<20x10x16x16xi32>
+    %25 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<20x10x16x16x!tt.ptr<f16>>
+    %26 = tt.addptr %25, %24 : tensor<20x10x16x16x!tt.ptr<f16>>, tensor<20x10x16x16xi32>
+    %27 = tt.load %26 : tensor<20x10x16x16x!tt.ptr<f16>>
+    %28 = tt.make_range {end = 5 : i32, start = 0 : i32} : tensor<5xi32>
+    %29 = tt.expand_dims %28 {axis = 1 : i32} : tensor<5xi32> -> tensor<5x1xi32>
+    %30 = tt.expand_dims %29 {axis = 2 : i32} : tensor<5x1xi32> -> tensor<5x1x1xi32>
+    %31 = tt.expand_dims %30 {axis = 3 : i32} : tensor<5x1x1xi32> -> tensor<5x1x1x1xi32>
+    %32 = arith.muli %31, %cst_1 : tensor<5x1x1x1xi32>
+    %33 = tt.expand_dims %0 {axis = 0 : i32} : tensor<20xi32> -> tensor<1x20xi32>
+    %34 = tt.expand_dims %33 {axis = 2 : i32} : tensor<1x20xi32> -> tensor<1x20x1xi32>
+    %35 = tt.expand_dims %34 {axis = 3 : i32} : tensor<1x20x1xi32> -> tensor<1x20x1x1xi32>
+    %36 = arith.muli %35, %cst_0 : tensor<1x20x1x1xi32>
+    %37 = tt.broadcast %32 : tensor<5x1x1x1xi32> -> tensor<5x20x1x1xi32>
+    %38 = tt.broadcast %36 : tensor<1x20x1x1xi32> -> tensor<5x20x1x1xi32>
+    %39 = arith.addi %37, %38 : tensor<5x20x1x1xi32>
+    %40 = tt.broadcast %39 : tensor<5x20x1x1xi32> -> tensor<5x20x16x1xi32>
+    %41 = tt.broadcast %17 : tensor<1x1x16x1xi32> -> tensor<5x20x16x1xi32>
+    %42 = arith.addi %40, %41 : tensor<5x20x16x1xi32>
+    %43 = tt.broadcast %42 : tensor<5x20x16x1xi32> -> tensor<5x20x16x16xi32>
+    %44 = tt.broadcast %21 : tensor<1x1x1x16xi32> -> tensor<5x20x16x16xi32>
+    %45 = arith.addi %43, %44 : tensor<5x20x16x16xi32>
+    %46 = tt.splat %arg1 : !tt.ptr<f16> -> tensor<5x20x16x16x!tt.ptr<f16>>
+    %47 = tt.addptr %46, %45 : tensor<5x20x16x16x!tt.ptr<f16>>, tensor<5x20x16x16xi32>
+    %48 = tt.load %47 : tensor<5x20x16x16x!tt.ptr<f16>>
+    %49 = ascend.dot %27, %48 {fractal_a = true, fractal_b = true, fractal_c = true} : tensor<20x10x16x16xf16>, tensor<5x20x16x16xf16> -> tensor<5x10x16x16xf32>
+    %50 = arith.muli %31, %cst : tensor<5x1x1x1xi32>
+    %51 = tt.broadcast %50 : tensor<5x1x1x1xi32> -> tensor<5x10x1x1xi32>
+    %52 = tt.broadcast %9 : tensor<1x10x1x1xi32> -> tensor<5x10x1x1xi32>
+    %53 = arith.addi %51, %52 : tensor<5x10x1x1xi32>
+    %54 = tt.broadcast %53 : tensor<5x10x1x1xi32> -> tensor<5x10x16x1xi32>
+    %55 = tt.broadcast %17 : tensor<1x1x16x1xi32> -> tensor<5x10x16x1xi32>
+    %56 = arith.addi %54, %55 : tensor<5x10x16x1xi32>
+    %57 = tt.broadcast %56 : tensor<5x10x16x1xi32> -> tensor<5x10x16x16xi32>
+    %58 = tt.broadcast %21 : tensor<1x1x1x16xi32> -> tensor<5x10x16x16xi32>
+    %59 = arith.addi %57, %58 : tensor<5x10x16x16xi32>
+    %60 = tt.splat %arg2 : !tt.ptr<f16> -> tensor<5x10x16x16x!tt.ptr<f16>>
+    %61 = tt.addptr %60, %59 : tensor<5x10x16x16x!tt.ptr<f16>>, tensor<5x10x16x16xi32>
+    %62 = arith.truncf %49 : tensor<5x10x16x16xf32> to tensor<5x10x16x16xf16>
+    tt.store %61, %62 : tensor<5x10x16x16x!tt.ptr<f16>>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: func.func @s_C1_pure_cube
+// CHECK-SAME:    mix_mode = "mix"
+// CHECK:         hivm.hir.convert_layout %{{.*}} output_shape [160, 320] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<Fractal, fractalSizes = [16, 16]>} : (tensor<20x10x16x16xf16>) -> tensor<160x320xf16>
+// CHECK:         hivm.hir.convert_layout %{{.*}} output_shape [320, 80] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<Fractal, fractalSizes = [16, 16]>} : (tensor<5x20x16x16xf16>) -> tensor<320x80xf16>
+// CHECK:         tensor.empty() : tensor<160x80xf32>
+// CHECK:         %[[MM:.*]] = linalg.matmul {input_precision = "ieee"} ins(%{{.*}}, %{{.*}} : tensor<160x320xf16>, tensor<320x80xf16>) outs(%{{.*}} : tensor<160x80xf32>) -> tensor<160x80xf32>
+// fractal_c: ND [M,N] -> [N/16, M/16, 16, 16], carrying the f32 accumulator dtype.
+// CHECK:         hivm.hir.convert_layout %[[MM]] output_shape [5, 10, 16, 16] {dstLayout = #hivm.data_layout<Fractal, fractalSizes = [16, 16]>, srcLayout = #hivm.data_layout<ND>} : (tensor<160x80xf32>) -> tensor<5x10x16x16xf32>
+
+// -----
+
+module {
+  tt.func public @s_C_bothND_fracC(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f16>) attributes {noinline = false} {
+    %cst = arith.constant dense<16> : tensor<1x1x16x1xi32>
+    %cst_0 = arith.constant dense<256> : tensor<1x10x1x1xi32>
+    %cst_1 = arith.constant dense<2560> : tensor<5x1x1x1xi32>
+    %cst_2 = arith.constant dense<80> : tensor<320x1xi32>
+    %cst_3 = arith.constant dense<320> : tensor<160x1xi32>
+    %0 = tt.make_range {end = 160 : i32, start = 0 : i32} : tensor<160xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<160xi32> -> tensor<160x1xi32>
+    %2 = arith.muli %1, %cst_3 : tensor<160x1xi32>
+    %3 = tt.make_range {end = 320 : i32, start = 0 : i32} : tensor<320xi32>
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : tensor<320xi32> -> tensor<1x320xi32>
+    %5 = tt.broadcast %2 : tensor<160x1xi32> -> tensor<160x320xi32>
+    %6 = tt.broadcast %4 : tensor<1x320xi32> -> tensor<160x320xi32>
+    %7 = arith.addi %5, %6 : tensor<160x320xi32>
+    %8 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<160x320x!tt.ptr<f16>>
+    %9 = tt.addptr %8, %7 : tensor<160x320x!tt.ptr<f16>>, tensor<160x320xi32>
+    %10 = tt.load %9 : tensor<160x320x!tt.ptr<f16>>
+    %11 = tt.expand_dims %3 {axis = 1 : i32} : tensor<320xi32> -> tensor<320x1xi32>
+    %12 = arith.muli %11, %cst_2 : tensor<320x1xi32>
+    %13 = tt.make_range {end = 80 : i32, start = 0 : i32} : tensor<80xi32>
+    %14 = tt.expand_dims %13 {axis = 0 : i32} : tensor<80xi32> -> tensor<1x80xi32>
+    %15 = tt.broadcast %12 : tensor<320x1xi32> -> tensor<320x80xi32>
+    %16 = tt.broadcast %14 : tensor<1x80xi32> -> tensor<320x80xi32>
+    %17 = arith.addi %15, %16 : tensor<320x80xi32>
+    %18 = tt.splat %arg1 : !tt.ptr<f16> -> tensor<320x80x!tt.ptr<f16>>
+    %19 = tt.addptr %18, %17 : tensor<320x80x!tt.ptr<f16>>, tensor<320x80xi32>
+    %20 = tt.load %19 : tensor<320x80x!tt.ptr<f16>>
+    %21 = ascend.dot %10, %20 {fractal_c = true} : tensor<160x320xf16>, tensor<320x80xf16> -> tensor<5x10x16x16xf32>
+    %22 = tt.make_range {end = 5 : i32, start = 0 : i32} : tensor<5xi32>
+    %23 = tt.expand_dims %22 {axis = 1 : i32} : tensor<5xi32> -> tensor<5x1xi32>
+    %24 = tt.expand_dims %23 {axis = 2 : i32} : tensor<5x1xi32> -> tensor<5x1x1xi32>
+    %25 = tt.expand_dims %24 {axis = 3 : i32} : tensor<5x1x1xi32> -> tensor<5x1x1x1xi32>
+    %26 = arith.muli %25, %cst_1 : tensor<5x1x1x1xi32>
+    %27 = tt.make_range {end = 10 : i32, start = 0 : i32} : tensor<10xi32>
+    %28 = tt.expand_dims %27 {axis = 0 : i32} : tensor<10xi32> -> tensor<1x10xi32>
+    %29 = tt.expand_dims %28 {axis = 2 : i32} : tensor<1x10xi32> -> tensor<1x10x1xi32>
+    %30 = tt.expand_dims %29 {axis = 3 : i32} : tensor<1x10x1xi32> -> tensor<1x10x1x1xi32>
+    %31 = arith.muli %30, %cst_0 : tensor<1x10x1x1xi32>
+    %32 = tt.broadcast %26 : tensor<5x1x1x1xi32> -> tensor<5x10x1x1xi32>
+    %33 = tt.broadcast %31 : tensor<1x10x1x1xi32> -> tensor<5x10x1x1xi32>
+    %34 = arith.addi %32, %33 : tensor<5x10x1x1xi32>
+    %35 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %36 = tt.expand_dims %35 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+    %37 = tt.expand_dims %36 {axis = 1 : i32} : tensor<1x16xi32> -> tensor<1x1x16xi32>
+    %38 = tt.expand_dims %37 {axis = 3 : i32} : tensor<1x1x16xi32> -> tensor<1x1x16x1xi32>
+    %39 = arith.muli %38, %cst : tensor<1x1x16x1xi32>
+    %40 = tt.broadcast %34 : tensor<5x10x1x1xi32> -> tensor<5x10x16x1xi32>
+    %41 = tt.broadcast %39 : tensor<1x1x16x1xi32> -> tensor<5x10x16x1xi32>
+    %42 = arith.addi %40, %41 : tensor<5x10x16x1xi32>
+    %43 = tt.expand_dims %37 {axis = 2 : i32} : tensor<1x1x16xi32> -> tensor<1x1x1x16xi32>
+    %44 = tt.broadcast %42 : tensor<5x10x16x1xi32> -> tensor<5x10x16x16xi32>
+    %45 = tt.broadcast %43 : tensor<1x1x1x16xi32> -> tensor<5x10x16x16xi32>
+    %46 = arith.addi %44, %45 : tensor<5x10x16x16xi32>
+    %47 = tt.splat %arg2 : !tt.ptr<f16> -> tensor<5x10x16x16x!tt.ptr<f16>>
+    %48 = tt.addptr %47, %46 : tensor<5x10x16x16x!tt.ptr<f16>>, tensor<5x10x16x16xi32>
+    %49 = arith.truncf %21 : tensor<5x10x16x16xf32> to tensor<5x10x16x16xf16>
+    tt.store %48, %49 : tensor<5x10x16x16x!tt.ptr<f16>>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: func.func @s_C_bothND_fracC
+// CHECK-SAME:    mix_mode = "mix"
+// ND operands: no Fractal->ND convert is emitted before the matmul.
+// CHECK-NOT:     hivm.hir.convert_layout
+// CHECK:         tensor.empty() : tensor<160x80xf32>
+// CHECK:         %[[MM:.*]] = linalg.matmul {input_precision = "ieee"} ins(%{{.*}}, %{{.*}} : tensor<160x320xf16>, tensor<320x80xf16>) outs(%{{.*}} : tensor<160x80xf32>) -> tensor<160x80xf32>
+// CHECK:         hivm.hir.convert_layout %[[MM]] output_shape [5, 10, 16, 16] {dstLayout = #hivm.data_layout<Fractal, fractalSizes = [16, 16]>, srcLayout = #hivm.data_layout<ND>} : (tensor<160x80xf32>) -> tensor<5x10x16x16xf32>
+
+// -----
+
+module {
+  tt.func public @s_mix_f32(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>) attributes {noinline = false} {
+    %cst = arith.constant dense<80> : tensor<160x1xi32>
+    %cst_0 = arith.constant dense<80> : tensor<320x1xi32>
+    %cst_1 = arith.constant dense<8> : tensor<1x1x16x1xi32>
+    %cst_2 = arith.constant dense<128> : tensor<1x10x1x1xi32>
+    %cst_3 = arith.constant dense<1280> : tensor<40x1x1x1xi32>
+    %0 = tt.make_range {end = 40 : i32, start = 0 : i32} : tensor<40xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<40xi32> -> tensor<40x1xi32>
+    %2 = tt.expand_dims %1 {axis = 2 : i32} : tensor<40x1xi32> -> tensor<40x1x1xi32>
+    %3 = tt.expand_dims %2 {axis = 3 : i32} : tensor<40x1x1xi32> -> tensor<40x1x1x1xi32>
+    %4 = arith.muli %3, %cst_3 : tensor<40x1x1x1xi32>
+    %5 = tt.make_range {end = 10 : i32, start = 0 : i32} : tensor<10xi32>
+    %6 = tt.expand_dims %5 {axis = 0 : i32} : tensor<10xi32> -> tensor<1x10xi32>
+    %7 = tt.expand_dims %6 {axis = 2 : i32} : tensor<1x10xi32> -> tensor<1x10x1xi32>
+    %8 = tt.expand_dims %7 {axis = 3 : i32} : tensor<1x10x1xi32> -> tensor<1x10x1x1xi32>
+    %9 = arith.muli %8, %cst_2 : tensor<1x10x1x1xi32>
+    %10 = tt.broadcast %4 : tensor<40x1x1x1xi32> -> tensor<40x10x1x1xi32>
+    %11 = tt.broadcast %9 : tensor<1x10x1x1xi32> -> tensor<40x10x1x1xi32>
+    %12 = arith.addi %10, %11 : tensor<40x10x1x1xi32>
+    %13 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %14 = tt.expand_dims %13 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+    %15 = tt.expand_dims %14 {axis = 1 : i32} : tensor<1x16xi32> -> tensor<1x1x16xi32>
+    %16 = tt.expand_dims %15 {axis = 3 : i32} : tensor<1x1x16xi32> -> tensor<1x1x16x1xi32>
+    %17 = arith.muli %16, %cst_1 : tensor<1x1x16x1xi32>
+    %18 = tt.broadcast %12 : tensor<40x10x1x1xi32> -> tensor<40x10x16x1xi32>
+    %19 = tt.broadcast %17 : tensor<1x1x16x1xi32> -> tensor<40x10x16x1xi32>
+    %20 = arith.addi %18, %19 : tensor<40x10x16x1xi32>
+    %21 = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+    %22 = tt.expand_dims %21 {axis = 0 : i32} : tensor<8xi32> -> tensor<1x8xi32>
+    %23 = tt.expand_dims %22 {axis = 1 : i32} : tensor<1x8xi32> -> tensor<1x1x8xi32>
+    %24 = tt.expand_dims %23 {axis = 2 : i32} : tensor<1x1x8xi32> -> tensor<1x1x1x8xi32>
+    %25 = tt.broadcast %20 : tensor<40x10x16x1xi32> -> tensor<40x10x16x8xi32>
+    %26 = tt.broadcast %24 : tensor<1x1x1x8xi32> -> tensor<40x10x16x8xi32>
+    %27 = arith.addi %25, %26 : tensor<40x10x16x8xi32>
+    %28 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<40x10x16x8x!tt.ptr<f32>>
+    %29 = tt.addptr %28, %27 : tensor<40x10x16x8x!tt.ptr<f32>>, tensor<40x10x16x8xi32>
+    %30 = tt.load %29 : tensor<40x10x16x8x!tt.ptr<f32>>
+    %31 = tt.make_range {end = 320 : i32, start = 0 : i32} : tensor<320xi32>
+    %32 = tt.expand_dims %31 {axis = 1 : i32} : tensor<320xi32> -> tensor<320x1xi32>
+    %33 = arith.muli %32, %cst_0 : tensor<320x1xi32>
+    %34 = tt.make_range {end = 80 : i32, start = 0 : i32} : tensor<80xi32>
+    %35 = tt.expand_dims %34 {axis = 0 : i32} : tensor<80xi32> -> tensor<1x80xi32>
+    %36 = tt.broadcast %33 : tensor<320x1xi32> -> tensor<320x80xi32>
+    %37 = tt.broadcast %35 : tensor<1x80xi32> -> tensor<320x80xi32>
+    %38 = arith.addi %36, %37 : tensor<320x80xi32>
+    %39 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<320x80x!tt.ptr<f32>>
+    %40 = tt.addptr %39, %38 : tensor<320x80x!tt.ptr<f32>>, tensor<320x80xi32>
+    %41 = tt.load %40 : tensor<320x80x!tt.ptr<f32>>
+    %42 = ascend.dot %30, %41 {fractal_a = true} : tensor<40x10x16x8xf32>, tensor<320x80xf32> -> tensor<160x80xf32>
+    %43 = tt.make_range {end = 160 : i32, start = 0 : i32} : tensor<160xi32>
+    %44 = tt.expand_dims %43 {axis = 1 : i32} : tensor<160xi32> -> tensor<160x1xi32>
+    %45 = arith.muli %44, %cst : tensor<160x1xi32>
+    %46 = tt.broadcast %45 : tensor<160x1xi32> -> tensor<160x80xi32>
+    %47 = tt.broadcast %35 : tensor<1x80xi32> -> tensor<160x80xi32>
+    %48 = arith.addi %46, %47 : tensor<160x80xi32>
+    %49 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<160x80x!tt.ptr<f32>>
+    %50 = tt.addptr %49, %48 : tensor<160x80x!tt.ptr<f32>>, tensor<160x80xi32>
+    tt.store %50, %42 : tensor<160x80x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: func.func @s_mix_f32
+// CHECK-SAME:    mix_mode = "mix"
+// CHECK:         hivm.hir.convert_layout %{{.*}} output_shape [160, 320] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<Fractal, fractalSizes = [16, 8]>} : (tensor<40x10x16x8xf32>) -> tensor<160x320xf32>
+// CHECK:         tensor.empty() : tensor<160x80xf32>
+// CHECK:         linalg.matmul {input_precision = "ieee"} ins(%{{.*}}, %{{.*}} : tensor<160x320xf32>, tensor<320x80xf32>) outs(%{{.*}} : tensor<160x80xf32>) -> tensor<160x80xf32>
+
+// -----
+
+module {
+  tt.func public @s_C_int8(%arg0: !tt.ptr<i8>, %arg1: !tt.ptr<i8>, %arg2: !tt.ptr<i32>) attributes {noinline = false} {
+    %cst = arith.constant dense<16> : tensor<1x1x16x1xi32>
+    %cst_0 = arith.constant dense<256> : tensor<1x10x1x1xi32>
+    %cst_1 = arith.constant dense<2560> : tensor<4x1x1x1xi32>
+    %cst_2 = arith.constant dense<32> : tensor<1x1x32x1xi32>
+    %cst_3 = arith.constant dense<1024> : tensor<1x10x1x1xi32>
+    %cst_4 = arith.constant dense<10240> : tensor<2x1x1x1xi32>
+    %cst_5 = arith.constant dense<32> : tensor<1x1x16x1xi32>
+    %cst_6 = arith.constant dense<512> : tensor<1x10x1x1xi32>
+    %cst_7 = arith.constant dense<5120> : tensor<10x1x1x1xi32>
+    %0 = tt.make_range {end = 10 : i32, start = 0 : i32} : tensor<10xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<10xi32> -> tensor<10x1xi32>
+    %2 = tt.expand_dims %1 {axis = 2 : i32} : tensor<10x1xi32> -> tensor<10x1x1xi32>
+    %3 = tt.expand_dims %2 {axis = 3 : i32} : tensor<10x1x1xi32> -> tensor<10x1x1x1xi32>
+    %4 = arith.muli %3, %cst_7 : tensor<10x1x1x1xi32>
+    %5 = tt.expand_dims %0 {axis = 0 : i32} : tensor<10xi32> -> tensor<1x10xi32>
+    %6 = tt.expand_dims %5 {axis = 2 : i32} : tensor<1x10xi32> -> tensor<1x10x1xi32>
+    %7 = tt.expand_dims %6 {axis = 3 : i32} : tensor<1x10x1xi32> -> tensor<1x10x1x1xi32>
+    %8 = arith.muli %7, %cst_6 : tensor<1x10x1x1xi32>
+    %9 = tt.broadcast %4 : tensor<10x1x1x1xi32> -> tensor<10x10x1x1xi32>
+    %10 = tt.broadcast %8 : tensor<1x10x1x1xi32> -> tensor<10x10x1x1xi32>
+    %11 = arith.addi %9, %10 : tensor<10x10x1x1xi32>
+    %12 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %13 = tt.expand_dims %12 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+    %14 = tt.expand_dims %13 {axis = 1 : i32} : tensor<1x16xi32> -> tensor<1x1x16xi32>
+    %15 = tt.expand_dims %14 {axis = 3 : i32} : tensor<1x1x16xi32> -> tensor<1x1x16x1xi32>
+    %16 = arith.muli %15, %cst_5 : tensor<1x1x16x1xi32>
+    %17 = tt.broadcast %11 : tensor<10x10x1x1xi32> -> tensor<10x10x16x1xi32>
+    %18 = tt.broadcast %16 : tensor<1x1x16x1xi32> -> tensor<10x10x16x1xi32>
+    %19 = arith.addi %17, %18 : tensor<10x10x16x1xi32>
+    %20 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %21 = tt.expand_dims %20 {axis = 0 : i32} : tensor<32xi32> -> tensor<1x32xi32>
+    %22 = tt.expand_dims %21 {axis = 1 : i32} : tensor<1x32xi32> -> tensor<1x1x32xi32>
+    %23 = tt.expand_dims %22 {axis = 2 : i32} : tensor<1x1x32xi32> -> tensor<1x1x1x32xi32>
+    %24 = tt.broadcast %19 : tensor<10x10x16x1xi32> -> tensor<10x10x16x32xi32>
+    %25 = tt.broadcast %23 : tensor<1x1x1x32xi32> -> tensor<10x10x16x32xi32>
+    %26 = arith.addi %24, %25 : tensor<10x10x16x32xi32>
+    %27 = tt.splat %arg0 : !tt.ptr<i8> -> tensor<10x10x16x32x!tt.ptr<i8>>
+    %28 = tt.addptr %27, %26 : tensor<10x10x16x32x!tt.ptr<i8>>, tensor<10x10x16x32xi32>
+    %29 = tt.load %28 : tensor<10x10x16x32x!tt.ptr<i8>>
+    %30 = tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32>
+    %31 = tt.expand_dims %30 {axis = 1 : i32} : tensor<2xi32> -> tensor<2x1xi32>
+    %32 = tt.expand_dims %31 {axis = 2 : i32} : tensor<2x1xi32> -> tensor<2x1x1xi32>
+    %33 = tt.expand_dims %32 {axis = 3 : i32} : tensor<2x1x1xi32> -> tensor<2x1x1x1xi32>
+    %34 = arith.muli %33, %cst_4 : tensor<2x1x1x1xi32>
+    %35 = arith.muli %7, %cst_3 : tensor<1x10x1x1xi32>
+    %36 = tt.broadcast %34 : tensor<2x1x1x1xi32> -> tensor<2x10x1x1xi32>
+    %37 = tt.broadcast %35 : tensor<1x10x1x1xi32> -> tensor<2x10x1x1xi32>
+    %38 = arith.addi %36, %37 : tensor<2x10x1x1xi32>
+    %39 = tt.expand_dims %22 {axis = 3 : i32} : tensor<1x1x32xi32> -> tensor<1x1x32x1xi32>
+    %40 = arith.muli %39, %cst_2 : tensor<1x1x32x1xi32>
+    %41 = tt.broadcast %38 : tensor<2x10x1x1xi32> -> tensor<2x10x32x1xi32>
+    %42 = tt.broadcast %40 : tensor<1x1x32x1xi32> -> tensor<2x10x32x1xi32>
+    %43 = arith.addi %41, %42 : tensor<2x10x32x1xi32>
+    %44 = tt.broadcast %43 : tensor<2x10x32x1xi32> -> tensor<2x10x32x32xi32>
+    %45 = tt.broadcast %23 : tensor<1x1x1x32xi32> -> tensor<2x10x32x32xi32>
+    %46 = arith.addi %44, %45 : tensor<2x10x32x32xi32>
+    %47 = tt.splat %arg1 : !tt.ptr<i8> -> tensor<2x10x32x32x!tt.ptr<i8>>
+    %48 = tt.addptr %47, %46 : tensor<2x10x32x32x!tt.ptr<i8>>, tensor<2x10x32x32xi32>
+    %49 = tt.load %48 : tensor<2x10x32x32x!tt.ptr<i8>>
+    %50 = ascend.dot %29, %49 {fractal_a = true, fractal_b = true, fractal_c = true} : tensor<10x10x16x32xi8>, tensor<2x10x32x32xi8> -> tensor<4x10x16x16xi32>
+    %51 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %52 = tt.expand_dims %51 {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
+    %53 = tt.expand_dims %52 {axis = 2 : i32} : tensor<4x1xi32> -> tensor<4x1x1xi32>
+    %54 = tt.expand_dims %53 {axis = 3 : i32} : tensor<4x1x1xi32> -> tensor<4x1x1x1xi32>
+    %55 = arith.muli %54, %cst_1 : tensor<4x1x1x1xi32>
+    %56 = arith.muli %7, %cst_0 : tensor<1x10x1x1xi32>
+    %57 = tt.broadcast %55 : tensor<4x1x1x1xi32> -> tensor<4x10x1x1xi32>
+    %58 = tt.broadcast %56 : tensor<1x10x1x1xi32> -> tensor<4x10x1x1xi32>
+    %59 = arith.addi %57, %58 : tensor<4x10x1x1xi32>
+    %60 = arith.muli %15, %cst : tensor<1x1x16x1xi32>
+    %61 = tt.broadcast %59 : tensor<4x10x1x1xi32> -> tensor<4x10x16x1xi32>
+    %62 = tt.broadcast %60 : tensor<1x1x16x1xi32> -> tensor<4x10x16x1xi32>
+    %63 = arith.addi %61, %62 : tensor<4x10x16x1xi32>
+    %64 = tt.expand_dims %14 {axis = 2 : i32} : tensor<1x1x16xi32> -> tensor<1x1x1x16xi32>
+    %65 = tt.broadcast %63 : tensor<4x10x16x1xi32> -> tensor<4x10x16x16xi32>
+    %66 = tt.broadcast %64 : tensor<1x1x1x16xi32> -> tensor<4x10x16x16xi32>
+    %67 = arith.addi %65, %66 : tensor<4x10x16x16xi32>
+    %68 = tt.splat %arg2 : !tt.ptr<i32> -> tensor<4x10x16x16x!tt.ptr<i32>>
+    %69 = tt.addptr %68, %67 : tensor<4x10x16x16x!tt.ptr<i32>>, tensor<4x10x16x16xi32>
+    tt.store %69, %50 : tensor<4x10x16x16x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: func.func @s_C_int8
+// CHECK-SAME:    mix_mode = "mix"
+// CHECK:         hivm.hir.convert_layout %{{.*}} output_shape [160, 320] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<Fractal, fractalSizes = [16, 32]>} : (tensor<10x10x16x32xi8>) -> tensor<160x320xi8>
+// CHECK:         hivm.hir.convert_layout %{{.*}} output_shape [320, 64] {dstLayout = #hivm.data_layout<ND>, srcLayout = #hivm.data_layout<Fractal, fractalSizes = [32, 32]>} : (tensor<2x10x32x32xi8>) -> tensor<320x64xi8>
+// i32 accumulator for an int8 input.
+// CHECK:         tensor.empty() : tensor<160x64xi32>
+// CHECK:         %[[MM:.*]] = linalg.matmul {input_precision = "ieee"} ins(%{{.*}}, %{{.*}} : tensor<160x320xi8>, tensor<320x64xi8>) outs(%{{.*}} : tensor<160x64xi32>) -> tensor<160x64xi32>
+// fractal_c block stays [16, 16] even though the int8 input block is [16, 32].
+// CHECK:         hivm.hir.convert_layout %[[MM]] output_shape [4, 10, 16, 16] {dstLayout = #hivm.data_layout<Fractal, fractalSizes = [16, 16]>, srcLayout = #hivm.data_layout<ND>} : (tensor<160x64xi32>) -> tensor<4x10x16x16xi32>


### PR DESCRIPTION
Added Ascend extended operator `al.dot` (MLIR `ascend.dot`) supporting matrix multiplication `D = A · B` by declaring operand types (zN)

https://github.com/triton-lang/triton-ascend/pull/1352

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
