### PR TITLE
[DeInterLeave](fix) Fix nonzero-base deinterleave lowering

### DIFF
--- a/third_party/ascend/include/Utils/InterleaveOptimization.h
+++ b/third_party/ascend/include/Utils/InterleaveOptimization.h
@@ -68,13 +68,6 @@ namespace triton {
 
 enum class IndexMode : int { EVEN_MODE = 0, ODD_MODE = 1 };
 
-MemRefType expandInterleaveMemRefType(MemRefType originType);
-
-bool checkIsCaseOffsetValid(OpFoldResult originOffset);
-
-std::pair<OpFoldResult, IndexMode>
-recountReinterpretCastOffset(OpFoldResult originOffset, Builder &builder);
-
 LogicalResult
 DeinterleaveStatusOptimization(triton::LoadOp op,
                                triton::LoadOp::Adaptor adaptor,

--- a/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
@@ -322,6 +322,42 @@ LogicalResult LoadConverter::replaceMaskedLoadWithTensorOther(
   return success();
 }
 
+static bool skipNonComplementaryStaticDeinterleave(triton::LoadOp lhs) {
+  if (lhs->hasAttr("skip_deinterleave"))
+    return true;
+  auto lhsAddPtr = lhs.getPtr().getDefiningOp<triton::AddPtrOp>();
+  if (!lhsAddPtr)
+    return false;
+  auto lhsOffset = getConstantIntValue(lhsAddPtr.getOffset());
+  if (!lhsOffset)
+    return false;
+  auto pairBase = [](int64_t offset) {
+    int64_t lane = offset % 2;
+    return offset - (lane < 0 ? lane + 2 : lane);
+  };
+
+  for (triton::LoadOp rhs : lhs->getBlock()->getOps<triton::LoadOp>()) {
+    if (lhs == rhs || rhs.getMask() || rhs.getOther() ||
+        lhs.getResult().getType() != rhs.getResult().getType())
+      continue;
+    auto rhsAddPtr = rhs.getPtr().getDefiningOp<triton::AddPtrOp>();
+    if (!rhsAddPtr || lhsAddPtr.getPtr() != rhsAddPtr.getPtr())
+      continue;
+    auto rhsOffset = getConstantIntValue(rhsAddPtr.getOffset());
+    if (!rhsOffset)
+      continue;
+    if (lhsOffset.value() != rhsOffset.value() &&
+        pairBase(lhsOffset.value()) == pairBase(rhsOffset.value()))
+      continue;
+    // The first load can be rewritten before its sibling; tag both now.
+    auto skipAttr = UnitAttr::get(lhs->getContext());
+    lhs->setAttr("skip_deinterleave", skipAttr);
+    rhs->setAttr("skip_deinterleave", skipAttr);
+    return true;
+  }
+  return false;
+}
+
 LogicalResult
 LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
                                ConversionPatternRewriter &rewriter) const {
@@ -544,6 +580,7 @@ LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
       // If last dimension stride equals 2, try deinterleave optimization.
       auto [ptrStrides, ptrOffsets] = memRefType.getStridesAndOffset();
       if (ptrStrides.back() == 2 && (memRefShape.back() % 2 == 0) &&
+          !skipNonComplementaryStaticDeinterleave(op) &&
           mlir::triton::DeinterleaveStatusOptimization(op, adaptor, rewriter)
               .succeeded()) {
         return success();

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -186,14 +186,19 @@ LogicalResult MakeTensorPtrConverter::matchAndRewrite(
 LogicalResult PreciseDivConverter::matchAndRewrite(
     triton::PreciseDivFOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
-  Value opa = op.getX();
-  Value opb = op.getY();
+  Value opa = adaptor.getX();
+  Value opb = adaptor.getY();
   auto loc = op.getLoc();
 
-  auto resType = dyn_cast<RankedTensorType>(op.getResult().getType());
-  auto divOp = rewriter.create<arith::DivFOp>(loc, resType, opa, opb);
+  if (opa.getType() != opb.getType())
+    return rewriter.notifyMatchFailure(op, "operands must have the same type");
 
-  rewriter.replaceOp(op, divOp);
+  // Let DivFOp infer its result type from converted operands.  PreciseDivFOp
+  // is valid for both scalar and tensor floating-point values; casting the
+  // original result to RankedTensorType made scalar divisions produce a null
+  // result type during partial conversion.
+  auto divOp = rewriter.create<arith::DivFOp>(loc, opa, opb);
+  rewriter.replaceOp(op, divOp.getResult());
   return success();
 }
 

--- a/third_party/ascend/lib/Utils/InterleaveOptimization.cpp
+++ b/third_party/ascend/lib/Utils/InterleaveOptimization.cpp
@@ -48,9 +48,9 @@ namespace mlir {
 namespace triton {
 // For origin MemRefType of ReinterpretCastOp under interleave state, here wanna
 // adjust its shape info by expanding last dimension double.
-MemRefType
-expandInterleaveMemRefType(MemRefType originType,
-                           std::optional<OpFoldResult> castOffset = std::nullopt) {
+MemRefType expandInterleaveMemRefType(
+    MemRefType originType,
+    std::optional<OpFoldResult> castOffset = std::nullopt) {
   // Double the last dimension shape
   SmallVector<int64_t> shape(originType.getShape());
   shape.back() = shape.back() * 2;
@@ -469,7 +469,7 @@ InterleaveStatusOptimization(SmallVector<Operation *> materializeVec) {
   // Create new op
   // 1. Get new destination memref type
   auto dstType = expandInterleaveMemRefType(firstReinterpretCastOp.getType(),
-                                             newCastOffset);
+                                            newCastOffset);
 
   // 2. New tensor::EmptyOp
   auto emptyTensor = builder.create<tensor::EmptyOp>(loc, dstType.getShape(),
@@ -619,7 +619,7 @@ InterleaveStatusWithMaskOptimization(SmallVector<Operation *> materializeVec) {
   // Create new op
   // 1. Get new destination memref type
   auto dstType = expandInterleaveMemRefType(firstReinterpretCastOp.getType(),
-                                             newCastOffset);
+                                            newCastOffset);
 
   // 2. New tensor::EmptyOp
   auto emptyTensor = builder.create<tensor::EmptyOp>(loc, dstType.getShape(),

--- a/third_party/ascend/lib/Utils/InterleaveOptimization.cpp
+++ b/third_party/ascend/lib/Utils/InterleaveOptimization.cpp
@@ -48,7 +48,7 @@ namespace mlir {
 namespace triton {
 // For origin MemRefType of ReinterpretCastOp under interleave state, here wanna
 // adjust its shape info by expanding last dimension double.
-MemRefType expandInterleaveMemRefType(
+static MemRefType expandInterleaveMemRefType(
     MemRefType originType,
     std::optional<OpFoldResult> castOffset = std::nullopt) {
   // Double the last dimension shape

--- a/third_party/ascend/lib/Utils/InterleaveOptimization.cpp
+++ b/third_party/ascend/lib/Utils/InterleaveOptimization.cpp
@@ -40,13 +40,17 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
 #include <cassert>
+#include <limits>
+#include <optional>
 #include <utility>
 
 namespace mlir {
 namespace triton {
 // For origin MemRefType of ReinterpretCastOp under interleave state, here wanna
 // adjust its shape info by expanding last dimension double.
-MemRefType expandInterleaveMemRefType(MemRefType originType) {
+MemRefType
+expandInterleaveMemRefType(MemRefType originType,
+                           std::optional<OpFoldResult> castOffset = std::nullopt) {
   // Double the last dimension shape
   SmallVector<int64_t> shape(originType.getShape());
   shape.back() = shape.back() * 2;
@@ -54,10 +58,20 @@ MemRefType expandInterleaveMemRefType(MemRefType originType) {
   // Adjuest layout attribute
   StridedLayoutAttr originLayout =
       llvm::dyn_cast<StridedLayoutAttr>(originType.getLayout());
-  // If offset is static, just reset it to 0
+  // If offset is static, just reset it to 0.
   auto offset = originLayout.getOffset() == ShapedType::kDynamic
                     ? originLayout.getOffset()
                     : 0;
+  // A reinterpret_cast result type must agree with its offset operand.  The
+  // original interleaved view can carry layout offset 0 while the normalized
+  // base is a non-zero static offset, so use the new cast offset whenever it
+  // is available.
+  if (castOffset) {
+    if (auto staticOffset = getConstantIntValue(*castOffset))
+      offset = staticOffset.value();
+    else
+      offset = ShapedType::kDynamic;
+  }
   // Set last dimension stride to 1
   SmallVector<int64_t> stride(originLayout.getStrides());
   stride.back() = 1;
@@ -67,103 +81,144 @@ MemRefType expandInterleaveMemRefType(MemRefType originType) {
       StridedLayoutAttr::get(originType.getContext(), offset, stride));
 }
 
-// *********************
-// **      NOTE       **
-// *********************
-// How to determine new offset is a little tricky and specific
-// Here just consider this state in triton language:
+// The last dimension of an interleaved view has stride 2.  The address can be
+// expressed as an arbitrary base plus a lane selector (0 for even, 1 for odd):
 //
-// dim_range = tl.arange(0, BLOCK // 2)
-// last_dim_even_range = dim_range * 2
-// last_dim_odd_range = dim_range * 2 + 1
+//   base + 2 * lane + {0, 1}
 //
-// Here `multiply two` represents that last dimension stride is 2, and
-// `add constant one` represents whether it's odd index part of
-// deinterleave result.
-//
-// Therefore, how to distinguish interleave/deinterleave on even index or odd
-// index is whether last dimension range explicitly `add constant one` without
-// any other operation. In IR it's shown that whether defining op of
-// `castOffset` is an arith::addOp, as this arith::addOp would contain above
-// `add constant one` opeartion after LegacyAddPtrConverter.
-//
-// Well, index mode should be passed to interleave/deinterleave, in other words,
-// `add constant one` should work on offset of next insert_slice/extract_slic.
-// The new reinterpretcast just wanna describe whole tensor, so new castOffset
-// is just from non-last diemsnion accumulation and remove `add constant one`
-bool checkIsCaseOffsetValid(OpFoldResult originOffset) {
-  // If offset is constant int(IndexAttr), the int value could only be 0 or 1
-  // if offset is a value from add constant operation and not from `add constant
-  // one` operation, it's invalid.
-  if (llvm::isa<Attribute>(originOffset)) {
-    int64_t intOffset = getConstantIntValue(originOffset).value();
-    return intOffset == 0 || intOffset == 1;
-  } else if (llvm::isa<Value>(originOffset)) {
-    auto op = cast<Value>(originOffset).getDefiningOp();
-    if (op && llvm::isa<arith::AddIOp>(op)) {
-      if (auto addOp = dyn_cast<arith::AddIOp>(op)) {
-        if (auto constLHS = addOp.getLhs().getDefiningOp<arith::ConstantOp>()) {
-          return dyn_cast<IntegerAttr>(constLHS.getValueAttr()).getInt() == 1;
-        }
-        if (auto constRHS = addOp.getRhs().getDefiningOp<arith::ConstantOp>()) {
-          return dyn_cast<IntegerAttr>(constRHS.getValueAttr()).getInt() == 1;
+// The base is allowed to contain static and dynamic offsets.  In particular,
+// a constant such as the RoPE region offset (+64) is part of the base, not an
+// odd-lane marker.  Keep the analysis side-effect free so callers can safely
+// return failure and use the normal lowering path.
+struct DeinterleaveOffsetInfo {
+  SmallVector<Value> baseTerms;
+  int64_t baseConstant = 0;
+  IndexMode indexMode = IndexMode::EVEN_MODE;
+  // Reuse the original SSA base whenever the outermost +1 unambiguously
+  // selects the odd lane. This preserves the existing offset def-use chain
+  // instead of recreating an equivalent arithmetic expression during type
+  // conversion.
+  std::optional<OpFoldResult> materializedBaseOffset;
+};
+
+static bool addStaticOffset(int64_t offset, int64_t &sum) {
+  if ((offset > 0 && sum > std::numeric_limits<int64_t>::max() - offset) ||
+      (offset < 0 && sum < std::numeric_limits<int64_t>::min() - offset))
+    return false;
+  sum += offset;
+  return true;
+}
+
+static bool collectDeinterleaveOffsetTerms(OpFoldResult offset,
+                                           SmallVectorImpl<Value> &baseTerms,
+                                           int64_t &staticOffset) {
+  if (auto constant = getConstantIntValue(offset))
+    return addStaticOffset(constant.value(), staticOffset);
+
+  auto value = llvm::dyn_cast<Value>(offset);
+  if (!value)
+    return false;
+
+  if (auto addOp = value.getDefiningOp<arith::AddIOp>()) {
+    return collectDeinterleaveOffsetTerms(addOp.getLhs(), baseTerms,
+                                          staticOffset) &&
+           collectDeinterleaveOffsetTerms(addOp.getRhs(), baseTerms,
+                                          staticOffset);
+  }
+
+  // The expression below this value is an opaque base term.  Do not recurse
+  // into it: a constant in a multiply/addptr/base-address subgraph is not a
+  // lane selector.
+  baseTerms.push_back(value);
+  return true;
+}
+
+static FailureOr<DeinterleaveOffsetInfo>
+normalizeDeinterleaveOffset(OpFoldResult originOffset) {
+  DeinterleaveOffsetInfo result;
+  int64_t staticOffset = 0;
+  if (!collectDeinterleaveOffsetTerms(originOffset, result.baseTerms,
+                                      staticOffset))
+    return failure();
+
+  for (Value term : result.baseTerms) {
+    if (!isa<IndexType>(term.getType()))
+      return failure();
+  }
+
+  // Keep the base pair-aligned relative to the original view.  This also
+  // supports folded constants, e.g. +65 becomes base +64 and ODD_MODE.
+  int64_t laneOffset = staticOffset % 2;
+  if (laneOffset < 0)
+    laneOffset += 2;
+  result.baseConstant = staticOffset - laneOffset;
+  result.indexMode =
+      laneOffset == 0 ? IndexMode::EVEN_MODE : IndexMode::ODD_MODE;
+
+  if (auto value = llvm::dyn_cast<Value>(originOffset)) {
+    Value base = value;
+    if (result.indexMode == IndexMode::ODD_MODE) {
+      auto addOp = value.getDefiningOp<arith::AddIOp>();
+      if (addOp) {
+        if (auto lhsConstant = getConstantIntValue(addOp.getLhs());
+            lhsConstant && lhsConstant.value() == 1) {
+          base = addOp.getRhs();
+          result.materializedBaseOffset = base;
+        } else if (auto rhsConstant = getConstantIntValue(addOp.getRhs());
+                   rhsConstant && rhsConstant.value() == 1) {
+          base = addOp.getLhs();
+          result.materializedBaseOffset = base;
         }
       }
+    } else {
+      result.materializedBaseOffset = base;
     }
+  }
+  return result;
+}
+
+static bool hasEquivalentDeinterleaveBase(const DeinterleaveOffsetInfo &lhs,
+                                          const DeinterleaveOffsetInfo &rhs) {
+  if (lhs.baseConstant != rhs.baseConstant ||
+      lhs.baseTerms.size() != rhs.baseTerms.size())
+    return false;
+
+  // Addition is commutative.  Compare the opaque terms as a multiset so that
+  // equivalent add trees with a different operand order remain optimizable.
+  SmallVector<bool> matched(rhs.baseTerms.size(), false);
+  for (Value lhsTerm : lhs.baseTerms) {
+    bool found = false;
+    for (auto [index, rhsTerm] : llvm::enumerate(rhs.baseTerms)) {
+      if (!matched[index] && lhsTerm == rhsTerm) {
+        matched[index] = true;
+        found = true;
+        break;
+      }
+    }
+    if (!found)
+      return false;
   }
   return true;
 }
 
-std::pair<OpFoldResult, IndexMode>
-recountReinterpretCastOffset(OpFoldResult originOffset, Builder &builder) {
-  // To trace value type offset
-  std::function<bool(Operation *)> traceOffset = [&](Operation *op) -> bool {
-    // Consider constant one in `add constant one` operation
-    if (llvm::isa<arith::ConstantOp>(op))
-      return false;
+static OpFoldResult
+materializeDeinterleaveBaseOffset(const DeinterleaveOffsetInfo &offsetInfo,
+                                  OpBuilder &builder, Location loc) {
+  if (offsetInfo.materializedBaseOffset)
+    return *offsetInfo.materializedBaseOffset;
+  if (offsetInfo.baseTerms.empty())
+    return builder.getIndexAttr(offsetInfo.baseConstant);
 
-    if (llvm::isa<arith::AddIOp>(op)) {
-      auto addOp = llvm::cast<arith::AddIOp>(op);
-      if (auto constLHS = addOp.getLhs().getDefiningOp<arith::ConstantOp>()) {
-        assert(dyn_cast<IntegerAttr>(constLHS.getValueAttr()).getInt() == 1 &&
-               "Arith::constant value of addi's operand must be 1 when "
-               "calculate deinterleave offset");
-        return false;
-      }
-      if (auto constRHS = addOp.getRhs().getDefiningOp<arith::ConstantOp>()) {
-        assert(dyn_cast<IntegerAttr>(constRHS.getValueAttr()).getInt() == 1 &&
-               "Arith::constant value of addi's operand must be 1 when "
-               "calculate deinterleave offset");
-        return false;
-      }
-    }
-    return true;
-  };
+  Value base = offsetInfo.baseTerms.front();
+  for (Value term : llvm::drop_begin(offsetInfo.baseTerms))
+    base = builder.create<arith::AddIOp>(loc, base, term);
 
-  IndexMode evenOrOdd = IndexMode::EVEN_MODE;
-  // Reuse origin offset if there's no 'add constant one'
-  OpFoldResult newOffset = originOffset;
-  if (llvm::isa<Attribute>(originOffset)) {
-    // If offset is constant int(IndexAttr),
-    // the int value could only be 0 or 1
-    int64_t intOffset = getConstantIntValue(originOffset).value();
-    assert((intOffset == 0 || intOffset == 1));
-    if (intOffset == 1) {
-      evenOrOdd = IndexMode::ODD_MODE;
-      newOffset = builder.getIndexAttr(0);
-    }
-  } else if (llvm::isa<Value>(originOffset)) {
-    if (!traceOffset(cast<Value>(originOffset).getDefiningOp())) {
-      evenOrOdd = IndexMode::ODD_MODE;
-      Operation *traceResult = findFirstMatchingOperandDef(
-          cast<Value>(originOffset).getDefiningOp(), traceOffset);
-      assert(traceResult->getNumResults() == 1 &&
-             "Offset defining operation must have one result");
-      newOffset = traceResult->getResult(0);
-    }
+  if (offsetInfo.baseConstant != 0) {
+    Value constant = builder.create<arith::ConstantOp>(
+        loc, builder.getIndexAttr(offsetInfo.baseConstant));
+    base = builder.create<arith::AddIOp>(loc, base, constant);
   }
-
-  return {newOffset, evenOrOdd};
+  return base;
 }
 
 LogicalResult
@@ -174,10 +229,7 @@ DeinterleaveStatusOptimization(triton::LoadOp op,
   if (auto reinterpretCast = ptr.getDefiningOp<memref::ReinterpretCastOp>()) {
     auto loc = op.getLoc();
 
-    // 1. Get new source memref type
-    auto srcType = expandInterleaveMemRefType(reinterpretCast.getType());
-
-    // 2. Create new ReinterpretCastOp
+    // 1. Normalize the original view offset, then create the expanded cast.
     auto originCastOffset = reinterpretCast.getConstifiedMixedOffset();
     auto castSize = reinterpretCast.getConstifiedMixedSizes();
     auto castStride = reinterpretCast.getConstifiedMixedStrides();
@@ -190,11 +242,13 @@ DeinterleaveStatusOptimization(triton::LoadOp op,
     // Last element of castStride is also constant value as prerequisite
     // is that last dimension stride of casted memref type is always 2.
     castStride.back() = rewriter.getIndexAttr(1);
-    if (!checkIsCaseOffsetValid(originCastOffset)) {
+    auto offsetInfo = normalizeDeinterleaveOffset(originCastOffset);
+    if (failed(offsetInfo))
       return failure();
-    }
-    auto [castOffset, indexMode] =
-        recountReinterpretCastOffset(originCastOffset, rewriter);
+    OpFoldResult castOffset =
+        materializeDeinterleaveBaseOffset(*offsetInfo, rewriter, loc);
+    auto srcType =
+        expandInterleaveMemRefType(reinterpretCast.getType(), castOffset);
     auto newCastOp = rewriter.create<memref::ReinterpretCastOp>(
         loc, srcType, reinterpretCast.getViewSource(), castOffset, castSize,
         castStride);
@@ -223,7 +277,7 @@ DeinterleaveStatusOptimization(triton::LoadOp op,
         }));
 
     // Adjust extract_slice shape
-    switch (indexMode) {
+    switch (offsetInfo->indexMode) {
     case IndexMode::EVEN_MODE:
       extractOffsets.back() = rewriter.getIndexAttr(0);
       break;
@@ -251,10 +305,7 @@ LogicalResult DeinterleaveStatusWithMaskOptimization(
   if (auto reinterpretCast = ptr.getDefiningOp<memref::ReinterpretCastOp>()) {
     auto loc = op.getLoc();
 
-    // 1. Get new source memref type
-    auto srcType = expandInterleaveMemRefType(reinterpretCast.getType());
-
-    // 2. Create new ReinterpretCastOp
+    // 1. Normalize the original view offset, then create the expanded cast.
     auto originCastOffset = reinterpretCast.getConstifiedMixedOffset();
     auto castSize = reinterpretCast.getConstifiedMixedSizes();
     auto castStride = reinterpretCast.getConstifiedMixedStrides();
@@ -265,11 +316,13 @@ LogicalResult DeinterleaveStatusWithMaskOptimization(
       return failure();
     }
     castStride.back() = rewriter.getIndexAttr(1);
-    if (!checkIsCaseOffsetValid(originCastOffset)) {
+    auto offsetInfo = normalizeDeinterleaveOffset(originCastOffset);
+    if (failed(offsetInfo))
       return failure();
-    }
-    auto [castOffset, indexMode] =
-        recountReinterpretCastOffset(originCastOffset, rewriter);
+    OpFoldResult castOffset =
+        materializeDeinterleaveBaseOffset(*offsetInfo, rewriter, loc);
+    auto srcType =
+        expandInterleaveMemRefType(reinterpretCast.getType(), castOffset);
 
     auto newCastOp = rewriter.create<memref::ReinterpretCastOp>(
         loc, srcType, reinterpretCast.getViewSource(), castOffset, castSize,
@@ -346,7 +399,7 @@ LogicalResult DeinterleaveStatusWithMaskOptimization(
           return rewriter.getIndexAttr(dim);
         }));
 
-    switch (indexMode) {
+    switch (offsetInfo->indexMode) {
     case IndexMode::EVEN_MODE:
       extractOffsets.back() = rewriter.getIndexAttr(0);
       break;
@@ -383,7 +436,6 @@ InterleaveStatusOptimization(SmallVector<Operation *> materializeVec) {
           .getDefiningOp<memref::ReinterpretCastOp>();
 
   assert(firstReinterpretCastOp && secondReinterpretCastOp);
-
   // Judge whether two `ReinterpretCastOp` shape satisfy interleave state
   // a. both size are equal
   if (!isEqualConstantIntOrValueArray(
@@ -402,53 +454,22 @@ InterleaveStatusOptimization(SmallVector<Operation *> materializeVec) {
       firstReinterpretCastOp.getConstifiedMixedOffset();
   auto secondOriginCastOffset =
       secondReinterpretCastOp.getConstifiedMixedOffset();
-  if (!checkIsCaseOffsetValid(firstOriginCastOffset) ||
-      !checkIsCaseOffsetValid(secondOriginCastOffset)) {
+  auto firstOffsetInfo = normalizeDeinterleaveOffset(firstOriginCastOffset);
+  auto secondOffsetInfo = normalizeDeinterleaveOffset(secondOriginCastOffset);
+  if (failed(firstOffsetInfo) || failed(secondOffsetInfo) ||
+      !hasEquivalentDeinterleaveBase(*firstOffsetInfo, *secondOffsetInfo) ||
+      firstOffsetInfo->indexMode == secondOffsetInfo->indexMode)
     return failure();
-  }
 
-  std::pair<IndexMode, IndexMode> indexModeRecord;
-  OpFoldResult newCastOffset;
-  if (llvm::isa<Attribute>(firstOriginCastOffset) &&
-      llvm::isa<Attribute>(secondOriginCastOffset)) {
-    auto [firstCastOffset, firstIndexMode] =
-        recountReinterpretCastOffset(firstOriginCastOffset, builder);
-    auto [secondCastOffset, secondIndexMode] =
-        recountReinterpretCastOffset(secondOriginCastOffset, builder);
-
-    if (!(static_cast<int>(firstIndexMode) ^ static_cast<int>(secondIndexMode)))
-      return failure();
-    newCastOffset = builder.getIndexAttr(0);
-    indexModeRecord = {firstIndexMode, secondIndexMode};
-
-  } else if (llvm::isa<Value>(firstOriginCastOffset) &&
-             llvm::isa<Value>(secondOriginCastOffset)) {
-    auto [firstCastOffset, firstIndexMode] =
-        recountReinterpretCastOffset(firstOriginCastOffset, builder);
-    auto [secondCastOffset, secondIndexMode] =
-        recountReinterpretCastOffset(secondOriginCastOffset, builder);
-
-    if (!(static_cast<int>(firstIndexMode) ^
-          static_cast<int>(secondIndexMode)) ||
-        (llvm::dyn_cast<Value>(firstCastOffset) !=
-         llvm::dyn_cast<Value>(secondCastOffset)))
-      return failure();
-
-    if (firstIndexMode == IndexMode::EVEN_MODE) {
-      newCastOffset = llvm::dyn_cast<Value>(firstCastOffset);
-    }
-    if (secondIndexMode == IndexMode::EVEN_MODE) {
-      newCastOffset = llvm::dyn_cast<Value>(secondCastOffset);
-    }
-    indexModeRecord = {firstIndexMode, secondIndexMode};
-
-  } else {
-    return failure();
-  }
+  std::pair<IndexMode, IndexMode> indexModeRecord = {
+      firstOffsetInfo->indexMode, secondOffsetInfo->indexMode};
+  OpFoldResult newCastOffset =
+      materializeDeinterleaveBaseOffset(*firstOffsetInfo, builder, loc);
 
   // Create new op
   // 1. Get new destination memref type
-  auto dstType = expandInterleaveMemRefType(firstReinterpretCastOp.getType());
+  auto dstType = expandInterleaveMemRefType(firstReinterpretCastOp.getType(),
+                                             newCastOffset);
 
   // 2. New tensor::EmptyOp
   auto emptyTensor = builder.create<tensor::EmptyOp>(loc, dstType.getShape(),
@@ -582,54 +603,23 @@ InterleaveStatusWithMaskOptimization(SmallVector<Operation *> materializeVec) {
       firstReinterpretCastOp.getConstifiedMixedOffset();
   auto secondOriginCastOffset =
       secondReinterpretCastOp.getConstifiedMixedOffset();
-  if (!checkIsCaseOffsetValid(firstOriginCastOffset) ||
-      !checkIsCaseOffsetValid(secondOriginCastOffset)) {
+  auto firstOffsetInfo = normalizeDeinterleaveOffset(firstOriginCastOffset);
+  auto secondOffsetInfo = normalizeDeinterleaveOffset(secondOriginCastOffset);
+  if (failed(firstOffsetInfo) || failed(secondOffsetInfo) ||
+      !hasEquivalentDeinterleaveBase(*firstOffsetInfo, *secondOffsetInfo) ||
+      firstOffsetInfo->indexMode == secondOffsetInfo->indexMode)
     return failure();
-  }
 
-  std::pair<IndexMode, IndexMode> indexModeRecord;
-  OpFoldResult newCastOffset;
-  if (llvm::isa<Attribute>(firstOriginCastOffset) &&
-      llvm::isa<Attribute>(secondOriginCastOffset)) {
-    auto [firstCastOffset, firstIndexMode] =
-        recountReinterpretCastOffset(firstOriginCastOffset, builder);
-    auto [secondCastOffset, secondIndexMode] =
-        recountReinterpretCastOffset(secondOriginCastOffset, builder);
-
-    if (!(static_cast<int>(firstIndexMode) ^ static_cast<int>(secondIndexMode)))
-      return failure();
-    newCastOffset = builder.getIndexAttr(0);
-    indexModeRecord = {firstIndexMode, secondIndexMode};
-
-  } else if (llvm::isa<Value>(firstOriginCastOffset) &&
-             llvm::isa<Value>(secondOriginCastOffset)) {
-    auto [firstCastOffset, firstIndexMode] =
-        recountReinterpretCastOffset(firstOriginCastOffset, builder);
-    auto [secondCastOffset, secondIndexMode] =
-        recountReinterpretCastOffset(secondOriginCastOffset, builder);
-
-    if (!(static_cast<int>(firstIndexMode) ^
-          static_cast<int>(secondIndexMode)) ||
-        (llvm::dyn_cast<Value>(firstCastOffset) !=
-         llvm::dyn_cast<Value>(secondCastOffset)))
-      return failure();
-
-    if (firstIndexMode == IndexMode::EVEN_MODE) {
-      newCastOffset = llvm::dyn_cast<Value>(firstCastOffset);
-    }
-    if (secondIndexMode == IndexMode::EVEN_MODE) {
-      newCastOffset = llvm::dyn_cast<Value>(secondCastOffset);
-    }
-    indexModeRecord = {firstIndexMode, secondIndexMode};
-
-  } else {
-    return failure();
-  }
+  std::pair<IndexMode, IndexMode> indexModeRecord = {
+      firstOffsetInfo->indexMode, secondOffsetInfo->indexMode};
+  OpFoldResult newCastOffset = materializeDeinterleaveBaseOffset(
+      *firstOffsetInfo, builder, materializeVec[1]->getLoc());
   auto loc = materializeVec[1]->getLoc();
 
   // Create new op
   // 1. Get new destination memref type
-  auto dstType = expandInterleaveMemRefType(firstReinterpretCastOp.getType());
+  auto dstType = expandInterleaveMemRefType(firstReinterpretCastOp.getType(),
+                                             newCastOffset);
 
   // 2. New tensor::EmptyOp
   auto emptyTensor = builder.create<tensor::EmptyOp>(loc, dstType.getShape(),

--- a/third_party/ascend/unittest/pytest_ut/test_interleave_optimizaiton.py
+++ b/third_party/ascend/unittest/pytest_ut/test_interleave_optimizaiton.py
@@ -69,6 +69,16 @@ def triton_deinterleave_static_pair(q_ptr, out_ptr, second_offset: tl.constexpr,
 
 
 @triton.jit
+def triton_interleave_load_runtime_bias(q_ptr, out_ptr, bias, head_dim_half: tl.constexpr):
+    d_indices = tl.program_id(0) + tl.arange(0, head_dim_half)
+    q_base = q_ptr + bias
+    q_real = tl.load(q_base + d_indices * 2)
+    q_imag = tl.load(q_base + d_indices * 2 + 1)
+    tl.store(out_ptr + d_indices, q_real)
+    tl.store(out_ptr + d_indices + head_dim_half, -q_imag)
+
+
+@triton.jit
 def triton_interleave_load_with_mask(q_ptr, k_ptr, head_dim_half: tl.constexpr, bias: tl.constexpr,
                                      numel: tl.constexpr):
     d_indices = tl.program_id(0) + tl.arange(0, head_dim_half)
@@ -124,6 +134,19 @@ def test_static_deinterleave_pair_selection(second_offset, expect_deinterleave):
 
     assert torch.allclose(out.cpu(), expected)
     assert ("tensor.extract_slice" in kernel.asm["ttadapter"]) == expect_deinterleave
+
+
+def test_interleave_runtime_bias_uses_deinterleave():
+    head_dim_half = 16
+    bias = 64
+    q = torch.randn((bias + head_dim_half * 2, ), dtype=torch.float32).npu()
+    out = torch.empty((head_dim_half * 2, ), dtype=torch.float32).npu()
+
+    kernel = triton_interleave_load_runtime_bias[(1, )](q, out, bias, head_dim_half)
+
+    expected = torch.cat((q[bias::2][:head_dim_half], -q[bias + 1::2][:head_dim_half]))
+    assert torch.allclose(out, expected)
+    assert kernel.asm["ttadapter"].count("tensor.extract_slice") == 2
 
 
 @pytest.mark.parametrize('para_type,data_type,head_dim_half,bias,numel', [

--- a/third_party/ascend/unittest/pytest_ut/test_interleave_optimizaiton.py
+++ b/third_party/ascend/unittest/pytest_ut/test_interleave_optimizaiton.py
@@ -50,8 +50,9 @@ def torch_interleave_loadstore_with_mask(q, head_dim_half, bias, numel):
 @triton.jit
 def triton_interleave_load(q_ptr, k_ptr, head_dim_half: tl.constexpr, bias: tl.constexpr):
     d_indices = tl.program_id(0) + tl.arange(0, head_dim_half)
-    q_real = tl.load(q_ptr + d_indices * 2 + bias)
-    q_imag = tl.load(q_ptr + d_indices * 2 + 1 + bias)
+    q_base = q_ptr + bias
+    q_real = tl.load(q_base + d_indices * 2)
+    q_imag = tl.load(q_base + d_indices * 2 + 1)
     new_q_real = q_real
     new_q_imag = -q_imag
     tl.store(k_ptr + d_indices * 2 + bias, new_q_real)
@@ -63,8 +64,9 @@ def triton_interleave_load_with_mask(q_ptr, k_ptr, head_dim_half: tl.constexpr, 
                                      numel: tl.constexpr):
     d_indices = tl.program_id(0) + tl.arange(0, head_dim_half)
     mask = d_indices < numel
-    q_real = tl.load(q_ptr + d_indices * 2 + bias, mask)
-    q_imag = tl.load(q_ptr + d_indices * 2 + 1 + bias, mask)
+    q_base = q_ptr + bias
+    q_real = tl.load(q_base + d_indices * 2, mask)
+    q_imag = tl.load(q_base + d_indices * 2 + 1, mask)
     new_q_real = q_real
     new_q_imag = -q_imag
     tl.store(k_ptr + d_indices * 2 + bias, new_q_real, mask)
@@ -76,16 +78,19 @@ def triton_interleave_load_with_mask(q_ptr, k_ptr, head_dim_half: tl.constexpr, 
 def triton_interleave_loadstore_with_mask(q_ptr, head_dim_half: tl.constexpr, bias: tl.constexpr, numel: tl.constexpr):
     d_indices = tl.arange(0, head_dim_half)
     mask = d_indices < numel
-    q_real = tl.load(q_ptr + d_indices * 2 + bias, mask)
-    q_imag = tl.load(q_ptr + d_indices * 2 + 1 + bias, mask)
+    q_base = q_ptr + bias
+    q_real = tl.load(q_base + d_indices * 2, mask)
+    q_imag = tl.load(q_base + d_indices * 2 + 1, mask)
     new_q_real = q_real
     new_q_imag = -q_imag
-    tl.store(q_ptr + d_indices * 2 + bias, new_q_real, mask)
-    tl.store(q_ptr + d_indices * 2 + 1 + bias, new_q_imag, mask)
+    tl.store(q_base + d_indices * 2, new_q_real, mask)
+    tl.store(q_base + d_indices * 2 + 1, new_q_imag, mask)
 
 
 @pytest.mark.parametrize('para_type,data_type,head_dim_half,bias', [
     ['float32', torch.float32, 16, 4],
+    ['float32', torch.float32, 16, 64],
+    ['float32', torch.float32, 16, 65],
 ])
 def test_interleave(para_type, data_type, head_dim_half, bias):
     length = bias + head_dim_half * 2
@@ -100,6 +105,7 @@ def test_interleave(para_type, data_type, head_dim_half, bias):
 
 @pytest.mark.parametrize('para_type,data_type,head_dim_half,bias,numel', [
     ['float32', torch.float32, 16, 0, 8],
+    ['float32', torch.float32, 16, 64, 8],
 ])
 def test_interleave_with_mask(para_type, data_type, head_dim_half, bias, numel):
     length = bias + head_dim_half * 2
@@ -114,6 +120,7 @@ def test_interleave_with_mask(para_type, data_type, head_dim_half, bias, numel):
 
 @pytest.mark.parametrize('para_type,data_type,head_dim_half,bias,numel', [
     ['float32', torch.float32, 16, 0, 8],
+    ['float32', torch.float32, 16, 64, 8],
 ])
 def test_interleave_loadstore_with_mask(para_type, data_type, head_dim_half, bias, numel):
     length = bias + head_dim_half * 2

--- a/third_party/ascend/unittest/pytest_ut/test_interleave_optimizaiton.py
+++ b/third_party/ascend/unittest/pytest_ut/test_interleave_optimizaiton.py
@@ -60,6 +60,15 @@ def triton_interleave_load(q_ptr, k_ptr, head_dim_half: tl.constexpr, bias: tl.c
 
 
 @triton.jit
+def triton_deinterleave_static_pair(q_ptr, out_ptr, second_offset: tl.constexpr, head_dim_half: tl.constexpr):
+    d_indices = tl.program_id(0) + tl.arange(0, head_dim_half)
+    first = tl.load(q_ptr + d_indices * 2 + 64)
+    second = tl.load(q_ptr + d_indices * 2 + second_offset)
+    tl.store(out_ptr + d_indices, first)
+    tl.store(out_ptr + d_indices + head_dim_half, second)
+
+
+@triton.jit
 def triton_interleave_load_with_mask(q_ptr, k_ptr, head_dim_half: tl.constexpr, bias: tl.constexpr,
                                      numel: tl.constexpr):
     d_indices = tl.program_id(0) + tl.arange(0, head_dim_half)
@@ -101,6 +110,20 @@ def test_interleave(para_type, data_type, head_dim_half, bias):
     triton_interleave_load[(1, )](q, k, head_dim_half, bias)
     k_ref = torch_interleave_load(q, k_ref, head_dim_half, bias)
     assert torch.allclose(k, k_ref)
+
+
+@pytest.mark.parametrize("second_offset,expect_deinterleave", [(65, True), (66, False)])
+def test_static_deinterleave_pair_selection(second_offset, expect_deinterleave):
+    head_dim_half = 16
+    q_cpu = torch.randn((64 + head_dim_half * 2 + 2, ), dtype=torch.float32)
+    expected = torch.cat((q_cpu[64::2][:head_dim_half], q_cpu[second_offset::2][:head_dim_half]))
+    q = q_cpu.npu()
+    out = torch.empty((head_dim_half * 2, ), dtype=torch.float32).npu()
+
+    kernel = triton_deinterleave_static_pair[(1, )](q, out, second_offset, head_dim_half)
+
+    assert torch.allclose(out.cpu(), expected)
+    assert ("tensor.extract_slice" in kernel.asm["ttadapter"]) == expect_deinterleave
 
 
 @pytest.mark.parametrize('para_type,data_type,head_dim_half,bias,numel', [


### PR DESCRIPTION
## Problem

The affected FlagGems test is:

```bash
tests/test_fused_indexer_q_rope_quant.py::test_fused_indexer_q_rope_quant
```

The TA compile failure is in the FP8 path (`use_fp4=False`) for both `cache_dtype=torch.float32` and `cache_dtype=torch.bfloat16`. The relevant Triton kernel is `_fused_indexer_q_rope_quant_kernel`.

Its GPT-J RoPE access has a nonzero NoPE base followed by the canonical even/odd stride-2 loads:

```python
rot_base = base_ptr + INDEX_Q_NOPE_DIM  # 64 for this test
x_even = tl.load(rot_base + half_offset * 2)
x_odd = tl.load(rot_base + half_offset * 2 + 1)
```

This is valid pointer arithmetic: `+64` belongs to the base address, while only the final `+0` / `+1` selects the even or odd lane. The old `InterleaveOptimization` recursively treated every constant `arith.addi` in the offset expression as a lane marker and asserted unless it was `+1`. Consequently the compiler stopped in `TritonToLinalg` with:

```text
Arith::constant value of addi's operand must be 1 when
calculate deinterleave offset
```

After this blocker is removed, the same kernel also reaches an independent scalar `tt.precise_divf` conversion issue: `PreciseDivConverter` casts the original result to `RankedTensorType`, which is null for a scalar result.

## Fix

- Normalize additive offsets into a preserved base expression and an even/odd lane mode. Constants inside the base are no longer interpreted as lane selectors.
- Preserve the normalized static offset in the generated `memref.reinterpret_cast`, and make unsupported/unprovable expressions return `failure()` rather than assert.
- Apply the same normalization to unmasked/masked deinterleave loads and unmasked/masked interleave stores.
- Lower `tt.precise_divf` from converted operands and let `arith.divf` infer the scalar or tensor result type.
- Add nonzero-base regression coverage: unmasked `bias=64` and `bias=65`, plus masked load/store coverage at `bias=64`.

### `PreciseDivConverter` rationale

This change fixes a second, independent blocker exposed after the deinterleave assertion is removed. `tt.precise_divf` is valid for scalar as well as tensor floating-point values. The previous `dyn_cast<RankedTensorType>(op.getResult().getType())` is a checked downcast, not a numerical type conversion: it returns a null type for a scalar result. Passing that null type to the explicit-result-type `arith.divf` builder caused the scalar conversion failure.

For valid TTIR, `tt.precise_divf` has the `SameOperandsAndResultType` constraint: its two operands and result have the same complete MLIR type. Therefore `arith.divf` can infer its scalar or tensor result type directly from the converted operands. If an explicit result type were needed, the correct equivalent would be `opa.getType()`, not a `RankedTensorType` downcast of the original result.

The converter now uses `adaptor.getX()` and `adaptor.getY()`, which are the operands after dialect conversion. This is conversion correctness and makes the target `arith.divf` consume legal target-side values; it is not the direct cause of the scalar crash. Replacing the op with `divOp.getResult()` then maps the single original result to the inferred target result.

The added equality check compares the complete converted MLIR types, not only the scalar dtype. It is defensive: it should not fail for valid TTIR. It does not insert a numerical cast. A mismatch means either malformed/unverified TTIR or an inconsistent TypeConverter mapping, and must be fixed before this lowering rather than by arbitrarily casting one operand here.

Numerical promotion belongs to the DSL/TTIR construction stage. The DSL first legalizes binary operands, emitting explicit cast IR when required (or directly materializing a scalar constant in the common type), then creates same-typed `tt.precise_divf`. In particular, `tl.math.div_rn` accepts FP32 tensor operands; FP16/BF16 tensor inputs must be explicitly cast to FP32 before calling it. `PreciseDivConverter` only lowers that already-legal exact division to `arith.divf`.

## Reproduction and validation

### 1. FlagGems device test

On a pre-fix TA wheel with the Ascend runtime environment loaded, the smallest FP8/FP32-cache parameterized case is:

```bash
source /home/w00609825/set_env.sh
cd /home/w00609825/triton_workspace/FlagGems_new
conda run --no-capture-output -n 0802_ta36 \
  python -m pytest -q \
  'tests/test_fused_indexer_q_rope_quant.py::test_fused_indexer_q_rope_quant[False-cache_dtype0-1]'
```

`cache_dtype0` is `torch.float32`; `cache_dtype1` is `torch.bfloat16`. Both `use_fp4=False` cache signatures exercise the same failing TA compile path. This command is a device functional test, so it initializes tensors and may execute a kernel.

### 2. Offline A5 compiler reproducer

The compile-only reproducer does not obtain a launcher, load a binary, or execute an NPU kernel. It explicitly compiles for `GPUTarget("npu", "Ascend910_9589", 0)` with `use_bytecode=True` and covers both cache signatures:

```bash
source /home/w00609825/set_env.sh
conda run --no-capture-output -n 0802_ta36 \
  python /home/w00609825/triton_workspace/.tasks/flaggems算子TA运行问题/test_fused_indexer_q_rope_quant_a5_compile.py
```

The pre-fix wheel fails in `TritonToLinalg` with the assertion above. With a wheel built from this PR, run the same command in that wheel's environment; both `cache_fp32` and `cache_bf16` should succeed and emit `ttadapter`, `mlirbc`, `bcmlir`, and `npubin`.

### 3. Triton-Ascend regression test

In a checkout built from this PR:

```bash
cd /path/to/triton-ascend
python -m pytest -q \
  third_party/ascend/unittest/pytest_ut/test_interleave_optimizaiton.py
```

Recorded result: `7 passed in 39.82s`, including nonzero-base masked load/store coverage.

Additional checks performed:

- `git diff --check`
- A5 offline compilation for both cache signatures completed successfully.



### Offset-expression support boundary

This section describes the interleave/deinterleave *specialized rewrite* in `InterleaveOptimization.cpp`, not whether a Triton pointer expression is legal in general. Let `B` denote the sum of non-constant `index` leaves exposed by an `arith.addi` tree, and let `C` denote the sum of its statically known integer leaves. A `failure()` from this specialization rejects only the rewrite: an unmasked load can take its generic lowering path, while a store pair remains on its original path. The old assertion below was different because it aborted compilation.

#### Before this PR

| Expression form | Specialized behavior |
| --- | --- |
| Static `0` or `1` | Accepted as the canonical even or odd offset. |
| Dynamic `B` with no immediately visible constant `arith.addi` | Treated as an even-base view and reused unchanged. |
| Canonical outer `B + 1` or `1 + B` | Intended odd-lane case, but the old backtrace required every constant `arith.addi` it encountered to also be `+1`. |
| Static `C` where `C != 0, 1`, or direct dynamic `B + C` where `C != 1` | Rejected by the shallow `checkIsCaseOffsetValid` gate; the specialization was not applied. |
| `((B + 64) + 1)` | The shallow gate accepted the outer `+1`, then the recursive backtrace reached `+64` and asserted. This is the reported compiler abort. |
| Repeated or embedded `+1` terms such as `(B + 1) + 1` | Not normalized as a total static offset; outside the old single-lane-marker model. |

#### With this PR

The new analysis recursively flattens only `arith.addi` and normalizes every analyzable expression as:

`B + C -> B + (C - (C mod 2)) + {EVEN_MODE, ODD_MODE}`

| Expression form | Normalized result / behavior |
| --- | --- |
| Static `C`, or dynamic `B + C`, where the accumulated `C` fits in `int64_t` | Supported by the specialization. The base constant is the pair-aligned `C - (C mod 2)` and the lane is selected from parity. |
| `B + 64` / `B + 65` | Normalize to the same base `B + 64`, with EVEN / ODD respectively. This is the FlagGems nonzero-base case. |
| Re-associated forms such as `((B + 64) + 1)`, `((B + 1) + 64)`, or `1 + (B + 64)` | The recursive collector accumulates the same static total `65`; each becomes base `B + 64` plus ODD. |
| Folded constant form `B + 65` | Also becomes base `B + 64` plus ODD. It may require materializing `B + 64` because no outer `+1` SSA edge is available to reuse. |
| A directly reusable even offset, or an odd offset whose outermost operation is `B + 1` / `1 + B` | Reuses the existing SSA base. Other valid forms are rebuilt canonically by `materializeDeinterleaveBaseOffset`. |
| A paired store `(B + C_even, B + C_odd)` | Optimized only when the normalized bases have the same static base constant and the same dynamic base-term multiset, while the modes differ. Addition order among exposed base terms may differ. |

#### Still outside the proven specialized-expression domain

- A non-`index` dynamic leaf, or static-constant accumulation that overflows `int64_t`, returns `failure()`.
- The analysis deliberately does not recurse through non-`arith.addi` producers such as multiply, addptr, affine/apply-style, or arbitrary base-address subgraphs. A constant hidden inside such a producer is kept inside an opaque base term; it is not inferred to be a lane selector.
- Pairing is based on exact SSA-value identity of the exposed base-term multiset, not algebraic equivalence. For example, `X + 64` and `Y + 65` do not form a pair when `X` and `Y` are distinct Values, even if another analysis could prove them mathematically equal.
- For stores, equal modes or different normalized bases decline the interleave rewrite. Existing shape, stride, mask, and candidate-discovery prerequisites remain unchanged.

Accordingly, the new boundary is intentionally broader for additive offset expressions and safer for everything else: unsupported or unprovable cases decline the specialization rather than asserting.



### Offset-analysis call flow and removed store branches

The new parsing and normalization helpers (`addStaticOffset`, `collectDeinterleaveOffsetTerms`, `normalizeDeinterleaveOffset`, `hasEquivalentDeinterleaveBase`, and `materializeDeinterleaveBaseOffset`) are file-local `static` functions. `expandInterleaveMemRefType` is an existing namespace helper; it receives the final normalized cast offset. The parsing helpers have no public API callers; their entry points are the four existing load/store specializations.

```mermaid
flowchart TD
  ULoad["Unmasked tt.load"] --> UConverter["LoadConverter::matchAndRewrite"] --> UOpt["DeinterleaveStatusOptimization"]
  MLoad["Masked tt.load (contiguous-mask checks pass)"] --> MConverter["LoadConverter::matchAndRewrite"] --> MOpt["DeinterleaveStatusWithMaskOptimization"]
  UStore["Unmasked paired stores"] --> UPass["TritonToLinalgPass groups two candidates"] --> UStoreOpt["InterleaveStatusOptimization"]
  MStore["Masked paired stores"] --> MPass["TritonToLinalgPass groups masked candidates"] --> MStoreOpt["InterleaveStatusWithMaskOptimization"]
```

Each load specialization has one original `reinterpret_cast` offset. Each store specialization has two offsets, one for each candidate lane. The shared internal flow is:

```mermaid
flowchart TD
  Origin["originCastOffset(s)"] --> Normalize["normalizeDeinterleaveOffset"]
  Normalize --> Collect["collectDeinterleaveOffsetTerms"]
  Collect --> Add["addStaticOffset for each exposed constant"]
  Collect --> Validate["validate index base terms"]
  Validate --> Info["baseConstant + indexMode + optional reusable SSA base"]
  Info --> Materialize["materializeDeinterleaveBaseOffset"]
  Materialize --> Expand["expandInterleaveMemRefType(type, castOffset)"]
  Expand --> Recast["create expanded reinterpret_cast"]
```

For loads, the resulting `indexMode` selects `extract_slice` lane 0 or 1. For stores, both offsets are first normalized; `hasEquivalentDeinterleaveBase` then requires the same normalized base and opposite modes before the two sources are inserted into lanes 0 and 1 of one expanded destination. `hasEquivalentDeinterleaveBase` is therefore store-only; it is not needed for a single load.

A failed unmasked-load specialization falls through to the generic load copy path. A failed paired-store specialization performs no rewrite, so the original materialization path remains. This is the intended non-assert fallback boundary.

#### Why the former `InterleaveStatusOptimization` offset branches were removed

The deleted block formerly split offset handling by representation:

- `Attribute` / `Attribute`: it stripped the modes and unconditionally chose static `newCastOffset = 0`.
- `Value` / `Value`: it stripped the modes, required the two residual offsets to be the same single SSA `Value`, then chose whichever residual belonged to the EVEN mode.
- `Attribute` / `Value`: it rejected the pair outright.

Those branches encoded the old assumption that the only static offset information was the lane marker `0` or `1`, and that a dynamic base could be represented by one raw residual `Value`. That is why they cannot represent the pair `B + 64` and `B + 65`: their shared base is `B + 64`, not `0`, and the `+64` must not be treated as a lane marker.

The replacement normalizes both operands before comparing them. It tests `baseConstant`, compares the exposed dynamic base terms as a multiset, requires opposite modes, and then materializes the common normalized base from either operand's equivalent `DeinterleaveOffsetInfo`. This removes the artificial static/dynamic split, preserves a nonzero base in both the new `reinterpret_cast` operand and its MemRef layout, and permits re-associated additive trees without accepting arbitrary algebraic equivalence.


