### PR TITLE
[simt](feat) The parsing priority of simt_stack_limit

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -22,6 +22,7 @@ import ctypes
 import functools
 import hashlib
 import glob
+import json
 import os
 import re
 import shlex
@@ -1158,8 +1159,7 @@ def ttir_to_npubin(mod, metadata, opt):
                 _compile_option_list += [
                     f"--enable-bishengir-simt-optimization={opt.enable_bishengir_simt_optimization}"
                 ]
-            if opt.simt_stack_limit:
-                _compile_option_list += [f"--simt-stack-limit={opt.simt_stack_limit}"]
+            _compile_option_list += [f"--simt-stack-limit={get_simt_stack_limit()}"]
             if opt.shared_mem_dynamic_size is not None:
                 _compile_option_list += [f"--shared-mem-dynamic-size={opt.shared_mem_dynamic_size}"]
             if opt.enable_simt_reorder_instruction:
@@ -1199,6 +1199,27 @@ def ttir_to_npubin(mod, metadata, opt):
             print(f"[DEBUG] Stderr:\n{error_msg}")
             raise subprocess.CalledProcessError(ret.returncode, cmd_list, ret.stdout, ret.stderr)
         return Path(bin_path).read_bytes()
+
+
+def get_simt_stack_limit():
+    # simt_stack_limit resolution precedence:
+    #  1.torch_npu's acl_default.json "StackSize":{"simt_stack_size":N}
+    #    takes precedence and the user-specified value is ignored.
+    #  2.if that config key is absent ,fail back to the kernel-time
+    #    default simt_stack_limit=1152
+    _simt_stack_limit = 1152
+    try:
+        import torch_npu
+        torch_npu_basic_path = os.path.dirname(torch_npu.__file__)
+        _acl_cfg_path = os.path.join(torch_npu_basic_path, "acl_default.json")
+        with open(_acl_cfg_path, "r") as f:
+            _acl_cfg = json.load(f)
+        _cfg_stack = _acl_cfg.get("StackSize", {}).get("simt_stack_size", None)
+        if _cfg_stack is not None and _cfg_stack > 0:
+            _simt_stack_limit = _cfg_stack
+    except Exception as e:
+        print(f"[DEBUG] read acl_default.json failed: {e}")
+    return _simt_stack_limit
 
 
 class AscendBackend(BaseBackend):

--- a/third_party/ascend/unittest/pytest_ut/test_compiler.py
+++ b/third_party/ascend/unittest/pytest_ut/test_compiler.py
@@ -1,0 +1,123 @@
+import json
+import os
+import sys
+from unittest.mock import MagicMock
+
+import triton.backends.ascend.compiler as compiler
+
+
+def _make_torch_npu_mock(cfg_dir):
+    """Create a mock torch_npu module whose __file__ is in cfg_dir."""
+    mock = MagicMock()
+    mock.__file__ = os.path.join(cfg_dir, "__init__.py")
+    return mock
+
+
+def _write_acl_config(cfg_dir, config):
+    """Write acl_default.json into cfg_dir."""
+    cfg_path = os.path.join(cfg_dir, "acl_default.json")
+    with open(cfg_path, "w") as f:
+        json.dump(config, f)
+    return cfg_path
+
+
+def test_get_simt_stack_limit_default(monkeypatch):
+    """Without torch_npu installed, should return default 1152."""
+    monkeypatch.setitem(sys.modules, "torch_npu", None)
+    result = compiler.get_simt_stack_limit()
+    assert result == 1152
+
+
+def test_get_simt_stack_limit_from_config(monkeypatch, tmp_path):
+    """When acl_default.json has valid simt_stack_size, return it."""
+    _write_acl_config(str(tmp_path), {"StackSize": {"simt_stack_size": 2048}})
+    mock_npu = _make_torch_npu_mock(str(tmp_path))
+    monkeypatch.setitem(sys.modules, "torch_npu", mock_npu)
+
+    result = compiler.get_simt_stack_limit()
+    assert result == 2048
+
+
+def test_get_simt_stack_limit_no_StackSize_key(monkeypatch, tmp_path):
+    """When acl_default.json has no StackSize key, return default 1152."""
+    _write_acl_config(str(tmp_path), {"OtherConfig": {"foo": 1}})
+    mock_npu = _make_torch_npu_mock(str(tmp_path))
+    monkeypatch.setitem(sys.modules, "torch_npu", mock_npu)
+
+    result = compiler.get_simt_stack_limit()
+    assert result == 1152
+
+
+def test_get_simt_stack_limit_no_simt_stack_size_key(monkeypatch, tmp_path):
+    """When StackSize exists but simt_stack_size is absent, return default 1152."""
+    _write_acl_config(str(tmp_path), {"StackSize": {"other_field": 100}})
+    mock_npu = _make_torch_npu_mock(str(tmp_path))
+    monkeypatch.setitem(sys.modules, "torch_npu", mock_npu)
+
+    result = compiler.get_simt_stack_limit()
+    assert result == 1152
+
+
+def test_get_simt_stack_limit_empty_StackSize(monkeypatch, tmp_path):
+    """When StackSize is an empty dict, return default 1152."""
+    _write_acl_config(str(tmp_path), {"StackSize": {}})
+    mock_npu = _make_torch_npu_mock(str(tmp_path))
+    monkeypatch.setitem(sys.modules, "torch_npu", mock_npu)
+
+    result = compiler.get_simt_stack_limit()
+    assert result == 1152
+
+
+def test_get_simt_stack_limit_empty_config(monkeypatch, tmp_path):
+    """When acl_default.json is an empty dict, return default 1152."""
+    _write_acl_config(str(tmp_path), {})
+    mock_npu = _make_torch_npu_mock(str(tmp_path))
+    monkeypatch.setitem(sys.modules, "torch_npu", mock_npu)
+
+    result = compiler.get_simt_stack_limit()
+    assert result == 1152
+
+
+def test_get_simt_stack_limit_file_not_found(monkeypatch, tmp_path):
+    """When acl_default.json does not exist, return default 1152."""
+    # Do not write acl_default.json; only mock torch_npu.__file__
+    mock_npu = _make_torch_npu_mock(str(tmp_path))
+    monkeypatch.setitem(sys.modules, "torch_npu", mock_npu)
+
+    result = compiler.get_simt_stack_limit()
+    assert result == 1152
+
+
+def test_get_simt_stack_limit_invalid_json(monkeypatch, tmp_path):
+    """When acl_default.json is invalid JSON, return default 1152."""
+    cfg_path = os.path.join(str(tmp_path), "acl_default.json")
+    with open(cfg_path, "w") as f:
+        f.write("{invalid json content}")
+
+    mock_npu = _make_torch_npu_mock(str(tmp_path))
+    monkeypatch.setitem(sys.modules, "torch_npu", mock_npu)
+
+    result = compiler.get_simt_stack_limit()
+    assert result == 1152
+
+
+def test_get_simt_stack_limit_from_config_returns_int(monkeypatch, tmp_path):
+    """Return value from config should be an integer."""
+    _write_acl_config(str(tmp_path), {"StackSize": {"simt_stack_size": 2048}})
+    mock_npu = _make_torch_npu_mock(str(tmp_path))
+    monkeypatch.setitem(sys.modules, "torch_npu", mock_npu)
+
+    result = compiler.get_simt_stack_limit()
+    assert isinstance(result, int)
+    assert result == 2048
+
+
+def test_get_simt_stack_limit_config_overrides_default(monkeypatch, tmp_path):
+    """Config value should take precedence over default 1152."""
+    _write_acl_config(str(tmp_path), {"StackSize": {"simt_stack_size": 9999}})
+    mock_npu = _make_torch_npu_mock(str(tmp_path))
+    monkeypatch.setitem(sys.modules, "torch_npu", mock_npu)
+
+    result = compiler.get_simt_stack_limit()
+    assert result == 9999
+    assert result != 1152


### PR DESCRIPTION
simt_stack_limit resolution precedence:
1.torch_npu's acl_default.json "StackSize":{"simt_stack_size":N} takes precedence and the user-specified value is ignored.
2.if that config key is absent ,fail back to the kernel-time default simt_stack_limit=1152
https://wiki.huawei.com/domains/148244/wiki/296387/WIKI2026052611224469
By default, simt_stack_size is obtained from the PTA. After the configuration in acl_default.json is modified, you do not need to configure simt_stack_limit. The system ensures that the configured value is consistent with the verified data, which is more user-friendly and reduces user operations.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
