### PR TITLE
[TritonToStructured](fix) Preserve hoistable zero-stride pointer broadcasts

### DIFF
--- a/third_party/ascend/include/Utils/Utils.h
+++ b/third_party/ascend/include/Utils/Utils.h
@@ -90,6 +90,11 @@ SmallVector<int64_t> getBroadcastDims(RankedTensorType src,
 SmallVector<int64_t> getUnbroadcastDims(RankedTensorType src,
                                         RankedTensorType dst);
 
+// Return true when a pointer broadcast can be lowered by the dedicated
+// pointer-broadcast hoister. Keep this predicate shared with earlier memory
+// rewrites so they do not destroy a legal form expected by that lowering.
+bool isHoistablePointerBroadcast(triton::BroadcastOp op);
+
 } // namespace ConverterUtils
 
 class ConversionPatternRewriter;

--- a/third_party/ascend/lib/TritonToLinalg/HoistBroadcast.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/HoistBroadcast.cpp
@@ -207,21 +207,13 @@ BroadcastHoister::replaceBroadcastOp(triton::BroadcastOp op,
 }
 
 bool BroadcastHoister::canBroadcast() {
-  auto resultType = dyn_cast<RankedTensorType>(opToHoist.getType());
-  auto srcType = dyn_cast<RankedTensorType>(opToHoist.getSrc().getType());
-  int broadcastedDims = 0;
-  for (size_t i = 0; i < resultType.getShape().size(); ++i) {
-    if (srcType.getShape()[i] == 1 && resultType.getShape()[i] != 1) {
-      broadcastedDims++;
-    }
-  }
-  if (broadcastedDims != 1) {
+  if (!ConverterUtils::isHoistablePointerBroadcast(opToHoist)) {
     LLVM_DEBUG({
       llvm::dbgs() << "Now cannot handle broadcast for ptr tensor with multi "
                       "broadcasted dimension.\n";
     });
     return false;
   }
-  return source != nullptr && isa<triton::PointerType>(source.getType());
+  return true;
 }
 } // namespace HoistBroadcast

--- a/third_party/ascend/lib/TritonToStructured/MemOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToStructured/MemOpConverter.cpp
@@ -134,6 +134,17 @@ LogicalResult StoreConverter::matchAndRewrite(triton::StoreOp op,
   auto oldMask = op.getMask();
   auto oldValue = op.getValue();
 
+  // AddPtrSplatConverter can preserve a non-singleton zero-stride dimension
+  // as a pointer broadcast. TritonToLinalg has a dedicated lowering for this
+  // legal form; rebuilding it here drops the zero-stride dimension from the
+  // pointer and mask while the value remains full-rank.
+  if (auto ptrBroadcast = oldPtr.getDefiningOp<triton::BroadcastOp>();
+      ptrBroadcast &&
+      ConverterUtils::isHoistablePointerBroadcast(ptrBroadcast)) {
+    return rewriter.notifyMatchFailure(
+        op, "defer hoistable pointer broadcast store to TritonToLinalg");
+  }
+
   MemOpTransformer tf(MemOpTransformer::MemType::store, optimizeDynamicOffset);
 
   auto newPtr = tf.createNewPtr(oldPtr, loc, rewriter);

--- a/third_party/ascend/lib/Utils/Utils.cpp
+++ b/third_party/ascend/lib/Utils/Utils.cpp
@@ -47,6 +47,7 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/SmallVectorExtras.h"
@@ -709,6 +710,38 @@ SmallVector<int64_t> getUnbroadcastDims(RankedTensorType src,
     }
   }
   return unbroadcastDims;
+}
+
+bool isHoistablePointerBroadcast(triton::BroadcastOp op) {
+  auto resultType = dyn_cast<RankedTensorType>(op.getType());
+  auto sourceType = dyn_cast<RankedTensorType>(op.getSrc().getType());
+  if (!resultType || !sourceType ||
+      !isa<triton::PointerType>(resultType.getElementType()) ||
+      resultType.getRank() != sourceType.getRank()) {
+    return false;
+  }
+
+  int broadcastedDims = 0;
+  for (auto [srcDim, resultDim] :
+       llvm::zip(sourceType.getShape(), resultType.getShape())) {
+    if (srcDim == 1 && resultDim != 1) {
+      ++broadcastedDims;
+      continue;
+    }
+    if (srcDim != resultDim) {
+      return false;
+    }
+  }
+  if (broadcastedDims != 1) {
+    return false;
+  }
+
+  Value source = op.getSrc();
+  while (auto addPtr = source.getDefiningOp<triton::AddPtrOp>()) {
+    source = addPtr.getPtr();
+  }
+  auto splat = source.getDefiningOp<triton::SplatOp>();
+  return splat && isa<triton::PointerType>(splat.getSrc().getType());
 }
 
 } // namespace ConverterUtils

--- a/third_party/ascend/unittest/Conversion/General/TritonToStructured/zero_stride_store_broadcast.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToStructured/zero_stride_store_broadcast.mlir
@@ -1,0 +1,24 @@
+// RUN: triton-opt --triton-to-structured="enable-mask-fallback-conversion=false optimize-dynamic-offset=false" %s | FileCheck %s
+
+// The pointer is the canonical form of a non-singleton zero-stride dimension:
+// an addptr over the non-zero-stride axis, followed by a one-dimensional
+// pointer broadcast. StoreConverter must defer this legal form to the later
+// pointer-broadcast lowering instead of rebuilding a lower-rank store.
+module {
+  tt.func public @zero_stride_store_broadcast(
+      %arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %offsets = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
+    %offsets_2d = tt.expand_dims %offsets {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32>
+    %ptr_splat = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1x64x!tt.ptr<f32>>
+    %ptr_small = tt.addptr %ptr_splat, %offsets_2d : tensor<1x64x!tt.ptr<f32>>, tensor<1x64xi32>
+    %ptr = tt.broadcast %ptr_small : tensor<1x64x!tt.ptr<f32>> -> tensor<16x64x!tt.ptr<f32>>
+    %value = arith.constant dense<0.000000e+00> : tensor<16x64xf32>
+    %mask = arith.constant dense<true> : tensor<16x64xi1>
+    tt.store %ptr, %value, %mask : tensor<16x64x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: tt.func public @zero_stride_store_broadcast
+// CHECK: %[[PTR:.*]] = tt.broadcast {{.*}} : tensor<1x64x!tt.ptr<f32>> -> tensor<16x64x!tt.ptr<f32>>
+// CHECK: tt.store %[[PTR]], {{.*}} : tensor<16x64x!tt.ptr<f32>>


### PR DESCRIPTION
## Summary

Fix the `TritonToStructured` lowering of a `tt.store` whose pointer is the
canonical broadcast form created for a non-singleton zero-stride dimension.

The triggering FlagGems case is
`tests/test_tril.py::test_tril_inplace_expanded_view`. Expanding `(1, 4)` to
`(3, 4)` gives the kernel `STRIDE_M=0`, `STRIDE_N=1`. Its pointer path is:

```text
tensor<1x64x!tt.ptr<f32>> --tt.broadcast--> tensor<16x64x!tt.ptr<f32>>
```

Previously `StoreConverter` rebuilt the pointer and mask with the broadcasted
zero-stride axis removed, while the store value remained `16x64`. The rebuilt
`tt.store` therefore failed verification because its value and pointer types
no longer matched.

## Design

1. Add a shared `ConverterUtils::isHoistablePointerBroadcast` predicate. It
   accepts exactly one broadcast dimension on a ranked pointer tensor, with an
   `addptr* -> splat(pointer)` source chain.
2. Let `StoreConverter` defer this legal pointer-broadcast store instead of
   rebuilding it. The existing `TritonToLinalg` broadcast hoister is then able
   to lower the form with its full rank intact.
3. Make `BroadcastHoister` use the same predicate, so the early deferral and
   later lowering agree on their accepted IR shape.

This deliberately does not broaden generic zero-stride lowering: only the
form already supported by the dedicated pointer-broadcast hoister is deferred.

## Regression cases

- New MLIR regression:
  `third_party/ascend/unittest/Conversion/General/TritonToStructured/zero_stride_store_broadcast.mlir`
  checks that the legal `1x64 -> 16x64` pointer broadcast and matching store
  survive the Structured conversion.
- FlagGems integration:
  `tests/test_tril.py::test_tril_inplace_expanded_view`.
- Offline Ascend 91095 compile matrix: zero `STRIDE_M`, shapes `(3, 4)`,
  `(16, 64)`, `(17, 65)`, diagonals `-1/0/1`, `debug=False/True`, plus a
  non-zero-stride control. This is 19 direct-compilation cases in total.

## Commands

### MLIR regression

```bash
triton-opt --triton-to-structured="enable-mask-fallback-conversion=false optimize-dynamic-offset=false" \
  third_party/ascend/unittest/Conversion/General/TritonToStructured/zero_stride_store_broadcast.mlir \
  | FileCheck third_party/ascend/unittest/Conversion/General/TritonToStructured/zero_stride_store_broadcast.mlir
```

### FlagGems runtime integration

```bash
source /usr/local/Ascend/driver/bin/setenv.bash
source /home/yixuan/triton/pkg/cann9.0.0/ascend-toolkit/set_env.sh
ASCEND_RT_VISIBLE_DEVICES=3 \
PYTHONPATH=/home/w00609825/triton_workspace/FlagGems_new/src \
python -m pytest -q tests/test_tril.py::test_tril_inplace_expanded_view --ref cpu
```

### Explicit A5 offline compilation

The local matrix harness imports FlagGems'
`_tril_inplace_zero_strided_tile_kernel` and calls only
`triton.compile(ASTSource(...), target=GPUTarget("npu", "Ascend910_9589", 0))`:

```bash
source /usr/local/Ascend/driver/bin/setenv.bash
source /home/yixuan/triton/pkg/cann9.0.0/ascend-toolkit/set_env.sh
PYTHONPATH=/home/w00609825/triton_workspace/FlagGems_new/src \
TRITON_ALWAYS_COMPILE=1 TRITON_KERNEL_DUMP=1 \
TRIL_A5_VALIDATION_DIR=<output-dir> \
python <local-validation-dir>/compile_flaggems_tril_a5.py
```

The harness does not create a launcher, load a binary, or invoke a kernel.

## Local results

- The new MLIR regression passed on both target-branch worktrees.
- All 19 explicit A5 compile cases emitted `ttir`, `ttadapter`, `mlirbc`,
  `bcmlir`, and `npubin`.
- `test_tril_inplace_expanded_view --ref cpu`: `9 passed`.
- `test_01_vector_add.py::test_vector_addition`: `1 passed` as a TA smoke test.
