### PR TITLE
[TritonToLinalg](fix) Lower static multi-input Welford reductions

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -678,8 +678,13 @@ MakeTensorPtrCanonicalizer::matchAndRewrite(triton::MakeTensorPtrOp op,
 LogicalResult
 ReduceSingleCanonicalizer::matchAndRewrite(triton::ReduceOp reduceOp,
                                            PatternRewriter &rewriter) const {
-  assert(reduceOp.getSrcs().size() <= 2 &&
-         "Only reduce or reduce with index are supported");
+  // This canonicalization only handles value reductions and value/index
+  // reductions.  Multi-input reductions, such as Welford's
+  // (mean, count, m2) reduction, must fall through to ReduceConverter's
+  // extended lowering instead of terminating the compiler here.
+  if (reduceOp.getSrcs().size() > 2)
+    return rewriter.notifyMatchFailure(
+        reduceOp, "only canonicalizes value and value/index reductions");
   auto src = reduceOp.getSrcs()[0];
   auto srcType = cast<RankedTensorType>(src.getType());
   auto srcShape = srcType.getShape();
@@ -1160,6 +1165,79 @@ LogicalResult ReduceConverter::convertToTargetOpExtended(
     triton::ReduceOp op, typename triton::ReduceOp::Adaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
   auto loc = op.getLoc();
+  auto operands = adaptor.getOperands();
+
+  // BiShengIR's VReduce lowering only supports a single value input (or a
+  // value/index pair).  A multi-input `tt.reduce`, such as Welford's
+  // (mean, count, m2) reduction, cannot be represented by that VReduceOp.
+  // Keep the current reduction body, but lower the static rank-1 scalar case
+  // to an explicit scalar loop so it never reaches the variadic VReduce path.
+  if (operands.size() > 2) {
+    auto inputType = dyn_cast<RankedTensorType>(operands.front().getType());
+    if (!inputType || inputType.getRank() != 1 || adaptor.getAxis() != 0 ||
+        ShapedType::isDynamic(inputType.getShape()[0]) ||
+        inputType.getShape()[0] < 1) {
+      return rewriter.notifyMatchFailure(
+          op, "multi-input reduce fallback requires static rank-1 axis-0 "
+              "inputs");
+    }
+    if (op.getResult().size() != operands.size()) {
+      return rewriter.notifyMatchFailure(
+          op, "multi-input reduce results do not match input count");
+    }
+
+    for (auto [i, operand] : llvm::enumerate(operands)) {
+      auto operandType = dyn_cast<RankedTensorType>(operand.getType());
+      if (!operandType || operandType.getShape() != inputType.getShape() ||
+          op.getResult()[i].getType() != operandType.getElementType()) {
+        return rewriter.notifyMatchFailure(
+            op, "multi-input reduce fallback requires matching scalar "
+                "results");
+      }
+    }
+
+    auto reduceBlock = op.getBody();
+    if (reduceBlock->getNumArguments() != 2 * operands.size() ||
+        reduceBlock->getTerminator()->getNumOperands() != operands.size()) {
+      return rewriter.notifyMatchFailure(
+          op, "unexpected multi-input reduce combine region");
+    }
+
+    Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value one = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value upper =
+        rewriter.create<arith::ConstantIndexOp>(loc, inputType.getShape()[0]);
+    SmallVector<Value> initialValues;
+    initialValues.reserve(operands.size());
+    for (Value operand : operands)
+      initialValues.push_back(
+          rewriter.create<tensor::ExtractOp>(loc, operand, zero));
+
+    auto loop = rewriter.create<scf::ForOp>(
+        loc, one, upper, one, initialValues,
+        [&](OpBuilder &builder, Location loopLoc, Value inductionVar,
+            ValueRange iterArgs) {
+          IRMapping mapping;
+          for (auto [i, operand] : llvm::enumerate(operands)) {
+            Value current = builder.create<tensor::ExtractOp>(loopLoc, operand,
+                                                              inductionVar);
+            mapping.map(reduceBlock->getArgument(i), current);
+            mapping.map(reduceBlock->getArgument(i + operands.size()),
+                        iterArgs[i]);
+          }
+          for (Operation &innerOp : reduceBlock->without_terminator())
+            builder.clone(innerOp, mapping);
+
+          SmallVector<Value> yielded;
+          yielded.reserve(operands.size());
+          for (Value value : reduceBlock->getTerminator()->getOperands())
+            yielded.push_back(mapping.lookup(value));
+          builder.create<scf::YieldOp>(loopLoc, yielded);
+        });
+    rewriter.replaceOp(op, loop.getResults());
+    return success();
+  }
+
   auto elemTypes = op.getElementTypes();
 
   auto valueResultType = dyn_cast<RankedTensorType>(op.getType(0));

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/multi_input_reduce.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/multi_input_reduce.mlir
@@ -1,0 +1,32 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+
+// CHECK-LABEL: func.func @three_input_reduce
+// CHECK-NOT: linalg.reduce
+// CHECK: scf.for
+// CHECK: scf.yield
+// CHECK-NOT: linalg.reduce
+// CHECK: return
+
+module attributes {hacc.target = #hacc.target<"Ascend910_9589">} {
+  tt.func public @three_input_reduce(%a_ptr: !tt.ptr<f32>, %b_ptr: !tt.ptr<f32>, %c_ptr: !tt.ptr<f32>, %out_ptr: !tt.ptr<f32>) attributes {noinline = false} {
+    %offsets = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %a_ptrs = tt.splat %a_ptr : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %b_ptrs = tt.splat %b_ptr : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %c_ptrs = tt.splat %c_ptr : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %a_addrs = tt.addptr %a_ptrs, %offsets : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    %b_addrs = tt.addptr %b_ptrs, %offsets : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    %c_addrs = tt.addptr %c_ptrs, %offsets : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    %a = tt.load %a_addrs : tensor<4x!tt.ptr<f32>>
+    %b = tt.load %b_addrs : tensor<4x!tt.ptr<f32>>
+    %c = tt.load %c_addrs : tensor<4x!tt.ptr<f32>>
+    %0:3 = "tt.reduce"(%a, %b, %c) <{axis = 0 : i32}> ({
+    ^bb0(%a0: f32, %b0: f32, %c0: f32, %a1: f32, %b1: f32, %c1: f32):
+      %a_sum = arith.addf %a0, %a1 : f32
+      %b_sum = arith.addf %b0, %b1 : f32
+      %c_sum = arith.addf %c0, %c1 : f32
+      tt.reduce.return %a_sum, %b_sum, %c_sum : f32, f32, f32
+    }) : (tensor<4xf32>, tensor<4xf32>, tensor<4xf32>) -> (f32, f32, f32)
+    tt.store %out_ptr, %0#2 : !tt.ptr<f32>
+    tt.return
+  }
+}


### PR DESCRIPTION
## Problem and root cause

The second stage of global variance in FlagGems `tests/test_var.py` uses a Welford merge:

```python
tl.reduce((average, count, acc), axis=0, combine_fn=welford_func)
```

This produces a `tt.reduce` with three inputs and three results. TA currently has two consecutive limitations:

1. `ReduceSingleCanonicalizer` uses a hard assertion when `srcs > 2`, which terminates compilation in the `TritonToLinalg` stage.
2. Even if that assertion is bypassed, the generic extended lowering produces a variadic `linalg.reduce` that BiShengIR cannot lower through `VReduce`. The `VReduce` lowering supports only a single value or a value/index pair.

Therefore, the root cause is the three-part Welford state `(mean, count, m2)`, rather than `tl.where` or the `correction` scalar.

## Approach

- Let `ReduceSingleCanonicalizer` report a normal pattern miss for multi-input reductions, while preserving the existing canonicalization for one-input and value/index reductions.
- Add a fallback only for multi-input reductions with static rank-1 inputs, `axis = 0`, matching input shapes, and one scalar result per input. It initializes the reduction state from element 0 and builds an explicit `scf.for` loop over elements `[1, N)`.
- Inside the loop, clone the original reduce combine region: map the current elements to the first half of its block arguments and the loop-carried state to the second half.
- This avoids generating a variadic `linalg.reduce`, and therefore avoids the unsupported BiShengIR `VReduce` path.

The fallback is intentionally limited to this static scalar-reduction form; it is not a general multi-input reduction implementation. The sequential merge prioritizes compilability and semantics. Performance evaluation is left for follow-up work.

## Coverage

- New MLIR regression: `third_party/ascend/unittest/Conversion/General/TritonToLinalg/multi_input_reduce.mlir`
  - Constructs a `tt.reduce` with three `tensor<4xf32>` inputs.
  - Verifies that lowering produces `scf.for` / `scf.yield` and does not produce `linalg.reduce`.
- FlagGems end-to-end case: `tests/test_var.py::test_accuracy_var[dtype1-True-0-shape1]`
  - `dtype1 = float32`, `shape1 = (4096, 256)`.
  - Covers the global Welford second stage across multiple blocks.

## How to test

MLIR regression:

```bash
triton-opt --triton-to-linalg \
  third_party/ascend/unittest/Conversion/General/TritonToLinalg/multi_input_reduce.mlir \
  | FileCheck third_party/ascend/unittest/Conversion/General/TritonToLinalg/multi_input_reduce.mlir
```

Strict A5 offline compilation (explicit `GPUTarget("npu", "Ascend910_9589", 0)`; invokes only `triton.compile`, without warm-up, binary loading, or kernel execution):

```bash
source /usr/local/Ascend/driver/bin/setenv.bash
source /home/yixuan/triton/pkg/cann9.0.0/ascend-toolkit/set_env.sh
VAR_A5_ROOT=/path/to/var_a5_output \
PYTHONPATH=/path/to/FlagGems_new/src \
PYTHONDONTWRITEBYTECODE=1 TRITON_ALWAYS_COMPILE=1 TRITON_KERNEL_DUMP=1 \
python /path/to/compile_var_a5.py
```

FlagGems device test:

```bash
cd /path/to/FlagGems_new
PYTHONPATH=src TRITON_ALWAYS_COMPILE=1 \
  python -m pytest -q \
  'tests/test_var.py::test_accuracy_var[dtype1-True-0-shape1]' --maxfail=1
```

## Validation

- The new MLIR regression passes `triton-opt | FileCheck`.
- A5 offline coverage includes fp32 global first- and second-stage kernels (`BLOCK_N=1/1024`), non-global Welford reductions, and the corresponding fp16/bf16 paths. All cases generate `ttir`, `ttadapter`, `mlirbc`, `bcmlir`, and `.npubin`.
- The FlagGems device case above passes: `1 passed`.

## Fallback eligibility and limits

For clarity, let `K` be the number of converted reduce operands, `O[i]` the i-th operand, `T[i] = type(O[i])`, `Res[i]` the i-th reduction result, and `L = shape(T[0])[0]`. Let `R` be the number of live, non-cast operations in the combine region: it is computed by walking backward from `tt.reduce.return` and excluding `arith.extf`, `arith.truncf`, and `arith.bitcast`.

The explicit `scf.for` fallback is selected only when all of the following hold:

- `K > 2`. Multi-input reductions first bypass `ReduceSingleCanonicalizer`; one-input and value/index reductions retain their existing handling.
- `R != 1`. This is the converter routing condition: a combine region with exactly one real operation continues through the existing `convertToTargetOp` path and does not use this fallback.
- The first input is a ranked tensor with a valid reduction axis; the fallback further requires `rank(T[0]) == 1`, `axis == 0`, a static `L`, and `L >= 1`.
- Every `T[i]` is a ranked tensor with `shape(T[i]) == shape(T[0])`.
- The number of results is `K`, and `type(Res[i]) == element_type(T[i])` for every i. The fallback requires matching shapes, but does not require all inputs to have the same element type.
- The combine region has exactly `2 * K` block arguments and `tt.reduce.return` yields exactly `K` values.

The fallback therefore does not cover dynamic-length reductions, rank greater than 1, axes other than 0, empty reductions, mismatched input shapes, tensor-valued results, or results whose type does not match the corresponding input element type. It clones the combine body without introducing a new operation whitelist, so the cloned operations must still be legal for later conversion and backend lowering. The resulting loop also cannot carry Triton pointer values.

## Expected TTIR-to-TTAdapter form

For the static rank-1 Welford case, the input TTIR remains a three-input, three-result reduction. The following is the expected reduction shape; the omitted arithmetic is the original Welford combine body:

```mlir
%state:3 = "tt.reduce"(%average, %count, %acc) <{axis = 0 : i32}> ({
^bb0(%mean_x: f32, %count_x: f32, %m2_x: f32,
     %mean_y: f32, %count_y: f32, %m2_y: f32):
  // cloned Welford combine arithmetic
  tt.reduce.return %mean, %count, %m2 : f32, f32, f32
}) : (tensor<Lxf32>, tensor<Lxf32>, tensor<Lxf32>) -> (f32, f32, f32)
```

The fallback must replace that operation in TTAdapter IR with a scalar loop. It initializes the three loop-carried states from element 0, then combines elements 1 through L-1:

```mlir
%mean0 = tensor.extract %average[%c0] : tensor<Lxf32>
%count0 = tensor.extract %count[%c0] : tensor<Lxf32>
%m20 = tensor.extract %acc[%c0] : tensor<Lxf32>
%state:3 = scf.for %i = %c1 to %L step %c1
    iter_args(%mean_acc = %mean0, %count_acc = %count0, %m2_acc = %m20)
    -> (f32, f32, f32) {
  %mean_i = tensor.extract %average[%i] : tensor<Lxf32>
  %count_i = tensor.extract %count[%i] : tensor<Lxf32>
  %m2_i = tensor.extract %acc[%i] : tensor<Lxf32>
  // cloned Welford combine arithmetic, with current values first
  // and loop-carried accumulated values second
  scf.yield %mean, %count, %m2 : f32, f32, f32
}
```

Thus the first half of the original combine block arguments receives the current extracted values, the second half receives `iter_args`, and the original `tt.reduce.return` values become `scf.yield` values. The expected TTAdapter form contains `scf.for` and `scf.yield`, and contains no variadic `linalg.reduce`.

A direct offline artifact for the global second-stage fp32 case with `BLOCK_N=1024` has this form: the loop runs from 1 to 1024, carries three f32 states, and clones the Welford arithmetic into its body.
