### PR TITLE
[TritonToLinalg](fix) Lower static multi-input Welford reductions

### DIFF
--- a/docs/zh/python-api/_ascend_constraints.py
+++ b/docs/zh/python-api/_ascend_constraints.py
@@ -732,11 +732,12 @@ CONSTRAINTS = {
         "constraints": [
             "DataType: Ascend A2/A3 does not support uint16, uint32, uint64; Ascend 950 does not fp8e4(E4M3), fp8e5(E5M2) (hardware limitation).",
             "``keep_dims=True`` requires more test coverage; currently verified for 3D tensor with dim=2.",
-            "多输入 ``reduce`` 的 ``scf.for`` fallback 不是通用路径：仅当输入数 ``K > 2`` 且 combine region 的有效归约操作数 ``R != 1`` 时尝试。``R`` 只统计从返回值反向可达、且不是 ``ext/trunc/bitcast`` 的操作；``R = 1`` 仍走既有单归约 lowering。",
-            "输入形状与轴：所有 ``T[i]`` 必须是相同静态形状的 rank-1 ``RankedTensor``，``axis = 0``；``L = shape(T[0])[0]`` 必须为静态正整数。",
-            "结果：结果数必须等于 ``K``，且每个 ``Res[i]`` 必须是元素类型与 ``T[i]`` 相同的标量；不同 ``T[i]`` 之间不要求元素类型相同。",
-            "combine region：必须有 ``2K`` 个 block 参数和 ``K`` 个 ``tt.reduce.return`` 返回值。fallback 从每个输入的第 0 个元素初始化，再按 ``i = 1 ... L - 1`` 的顺序合并。",
-            "语义与性能：该路径克隆 combine region 并生成顺序 ``scf.for``；它可能与树形归约具有不同的浮点舍入顺序，且不保证任意多输入 ``reduce`` 都能完成后续 lowering 或具有同等性能。",
+            "Multi-input reduce fallback notation: ``K`` is the number of input tensors; ``T[i]`` and ``Res[i]`` are input tensor ``i`` and its scalar result, respectively; ``L = shape(T[0])[0]`` is the reduction length; ``x[i]`` is the current element passed to combine-region argument ``i``; and ``s[i]`` is the carried state passed to argument ``K + i`` (``0 <= i < K``).",
+            "``R`` is the number of effective combine-region operations: only operations backward-reachable from ``tt.reduce.return`` are counted, while ``ext``, ``trunc``, and ``bitcast`` are ignored. The explicit ``scf.for`` fallback is attempted only when ``K > 2`` and ``R != 1``; ``R = 1`` keeps the existing single-reduction lowering.",
+            "Input shape and axis: every ``T[i]`` must be a ``RankedTensor`` with the same static rank-1 shape, ``axis = 0``, and a positive static ``L``. Different ``T[i]`` values may have different element types.",
+            "Results: there must be exactly ``K`` results, and every ``Res[i]`` must be a scalar with the same element type as its corresponding ``T[i]``.",
+            "Combine region: it must have exactly ``2K`` block arguments and ``K`` ``tt.reduce.return`` operands. The fallback initializes ``s[i]`` from ``T[i][0]`` and combines elements in order for ``i = 1 ... L - 1``.",
+            "Semantics and performance: this path clones the combine region into a sequential ``scf.for``. It can have a different floating-point rounding order from a tree reduction, and it does not guarantee that every multi-input ``reduce`` will pass later lowering or have equivalent performance.",
         ],
         "example":
         "triton.language.reduce",

--- a/docs/zh/python-api/_ascend_constraints.py
+++ b/docs/zh/python-api/_ascend_constraints.py
@@ -732,6 +732,11 @@ CONSTRAINTS = {
         "constraints": [
             "DataType: Ascend A2/A3 does not support uint16, uint32, uint64; Ascend 950 does not fp8e4(E4M3), fp8e5(E5M2) (hardware limitation).",
             "``keep_dims=True`` requires more test coverage; currently verified for 3D tensor with dim=2.",
+            "多输入 ``reduce`` 的 ``scf.for`` fallback 不是通用路径：仅当输入数 ``K > 2`` 且 combine region 的有效归约操作数 ``R != 1`` 时尝试。``R`` 只统计从返回值反向可达、且不是 ``ext/trunc/bitcast`` 的操作；``R = 1`` 仍走既有单归约 lowering。",
+            "输入形状与轴：所有 ``T[i]`` 必须是相同静态形状的 rank-1 ``RankedTensor``，``axis = 0``；``L = shape(T[0])[0]`` 必须为静态正整数。",
+            "结果：结果数必须等于 ``K``，且每个 ``Res[i]`` 必须是元素类型与 ``T[i]`` 相同的标量；不同 ``T[i]`` 之间不要求元素类型相同。",
+            "combine region：必须有 ``2K`` 个 block 参数和 ``K`` 个 ``tt.reduce.return`` 返回值。fallback 从每个输入的第 0 个元素初始化，再按 ``i = 1 ... L - 1`` 的顺序合并。",
+            "语义与性能：该路径克隆 combine region 并生成顺序 ``scf.for``；它可能与树形归约具有不同的浮点舍入顺序，且不保证任意多输入 ``reduce`` 都能完成后续 lowering 或具有同等性能。",
         ],
         "example":
         "triton.language.reduce",

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -716,8 +716,13 @@ MakeTensorPtrCanonicalizer::matchAndRewrite(triton::MakeTensorPtrOp op,
 LogicalResult
 ReduceSingleCanonicalizer::matchAndRewrite(triton::ReduceOp reduceOp,
                                            PatternRewriter &rewriter) const {
-  assert(reduceOp.getSrcs().size() <= 2 &&
-         "Only reduce or reduce with index are supported");
+  // This canonicalization only handles value reductions and value/index
+  // reductions.  Multi-input reductions, such as Welford's
+  // (mean, count, m2) reduction, must fall through to ReduceConverter's
+  // extended lowering instead of terminating the compiler here.
+  if (reduceOp.getSrcs().size() > 2)
+    return rewriter.notifyMatchFailure(
+        reduceOp, "only canonicalizes value and value/index reductions");
   auto src = reduceOp.getSrcs()[0];
   auto srcType = cast<RankedTensorType>(src.getType());
   auto srcShape = srcType.getShape();
@@ -1198,6 +1203,79 @@ LogicalResult ReduceConverter::convertToTargetOpExtended(
     triton::ReduceOp op, typename triton::ReduceOp::Adaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
   auto loc = op.getLoc();
+  auto operands = adaptor.getOperands();
+
+  // BiShengIR's VReduce lowering only supports a single value input (or a
+  // value/index pair).  A multi-input `tt.reduce`, such as Welford's
+  // (mean, count, m2) reduction, cannot be represented by that VReduceOp.
+  // Keep the current reduction body, but lower the static rank-1 scalar case
+  // to an explicit scalar loop so it never reaches the variadic VReduce path.
+  if (operands.size() > 2) {
+    auto inputType = dyn_cast<RankedTensorType>(operands.front().getType());
+    if (!inputType || inputType.getRank() != 1 || adaptor.getAxis() != 0 ||
+        ShapedType::isDynamic(inputType.getShape()[0]) ||
+        inputType.getShape()[0] < 1) {
+      return rewriter.notifyMatchFailure(
+          op, "multi-input reduce fallback requires static rank-1 axis-0 "
+              "inputs");
+    }
+    if (op.getResult().size() != operands.size()) {
+      return rewriter.notifyMatchFailure(
+          op, "multi-input reduce results do not match input count");
+    }
+
+    for (auto [i, operand] : llvm::enumerate(operands)) {
+      auto operandType = dyn_cast<RankedTensorType>(operand.getType());
+      if (!operandType || operandType.getShape() != inputType.getShape() ||
+          op.getResult()[i].getType() != operandType.getElementType()) {
+        return rewriter.notifyMatchFailure(
+            op, "multi-input reduce fallback requires matching scalar "
+                "results");
+      }
+    }
+
+    auto reduceBlock = op.getBody();
+    if (reduceBlock->getNumArguments() != 2 * operands.size() ||
+        reduceBlock->getTerminator()->getNumOperands() != operands.size()) {
+      return rewriter.notifyMatchFailure(
+          op, "unexpected multi-input reduce combine region");
+    }
+
+    Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value one = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value upper =
+        rewriter.create<arith::ConstantIndexOp>(loc, inputType.getShape()[0]);
+    SmallVector<Value> initialValues;
+    initialValues.reserve(operands.size());
+    for (Value operand : operands)
+      initialValues.push_back(
+          rewriter.create<tensor::ExtractOp>(loc, operand, zero));
+
+    auto loop = rewriter.create<scf::ForOp>(
+        loc, one, upper, one, initialValues,
+        [&](OpBuilder &builder, Location loopLoc, Value inductionVar,
+            ValueRange iterArgs) {
+          IRMapping mapping;
+          for (auto [i, operand] : llvm::enumerate(operands)) {
+            Value current = builder.create<tensor::ExtractOp>(loopLoc, operand,
+                                                              inductionVar);
+            mapping.map(reduceBlock->getArgument(i), current);
+            mapping.map(reduceBlock->getArgument(i + operands.size()),
+                        iterArgs[i]);
+          }
+          for (Operation &innerOp : reduceBlock->without_terminator())
+            builder.clone(innerOp, mapping);
+
+          SmallVector<Value> yielded;
+          yielded.reserve(operands.size());
+          for (Value value : reduceBlock->getTerminator()->getOperands())
+            yielded.push_back(mapping.lookup(value));
+          builder.create<scf::YieldOp>(loopLoc, yielded);
+        });
+    rewriter.replaceOp(op, loop.getResults());
+    return success();
+  }
+
   auto elemTypes = op.getElementTypes();
 
   auto valueResultType = dyn_cast<RankedTensorType>(op.getType(0));

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/multi_input_reduce.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/multi_input_reduce.mlir
@@ -1,0 +1,32 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+
+// CHECK-LABEL: func.func @three_input_reduce
+// CHECK-NOT: linalg.reduce
+// CHECK: scf.for
+// CHECK: scf.yield
+// CHECK-NOT: linalg.reduce
+// CHECK: return
+
+module attributes {hacc.target = #hacc.target<"Ascend910_9589">} {
+  tt.func public @three_input_reduce(%a_ptr: !tt.ptr<f32>, %b_ptr: !tt.ptr<f32>, %c_ptr: !tt.ptr<f32>, %out_ptr: !tt.ptr<f32>) attributes {noinline = false} {
+    %offsets = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %a_ptrs = tt.splat %a_ptr : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %b_ptrs = tt.splat %b_ptr : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %c_ptrs = tt.splat %c_ptr : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %a_addrs = tt.addptr %a_ptrs, %offsets : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    %b_addrs = tt.addptr %b_ptrs, %offsets : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    %c_addrs = tt.addptr %c_ptrs, %offsets : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    %a = tt.load %a_addrs : tensor<4x!tt.ptr<f32>>
+    %b = tt.load %b_addrs : tensor<4x!tt.ptr<f32>>
+    %c = tt.load %c_addrs : tensor<4x!tt.ptr<f32>>
+    %0:3 = "tt.reduce"(%a, %b, %c) <{axis = 0 : i32}> ({
+    ^bb0(%a0: f32, %b0: f32, %c0: f32, %a1: f32, %b1: f32, %c1: f32):
+      %a_sum = arith.addf %a0, %a1 : f32
+      %b_sum = arith.addf %b0, %b1 : f32
+      %c_sum = arith.addf %c0, %c1 : f32
+      tt.reduce.return %a_sum, %b_sum, %c_sum : f32, f32, f32
+    }) : (tensor<4xf32>, tensor<4xf32>, tensor<4xf32>) -> (f32, f32, f32)
+    tt.store %out_ptr, %0#2 : !tt.ptr<f32>
+    tt.return
+  }
+}


### PR DESCRIPTION
## Problem and root cause

The FlagGems variance/Welford path produces a multi-input reduction, for example:

```python
mean, _, nvar = tl.reduce(
    (average, count, acc),
    axis=0,
    combine_fn=welford_func,
)
```

`(average, count, acc)` is one coupled Welford state: `average` is the partial mean, `count` is the number of samples already merged, and `acc` (`M2`) is the sum of squared deviations. They must be merged by one combine region as a whole; they cannot be lowered as independent single-input reductions.

The original path had two blockers:

1. `ReduceSingleCanonicalizer` only handles value and value/index reductions. More than two inputs hit a hard assertion before reaching the general converter.
2. Even after extended lowering, BiShengIR `VReduce` represents only a single value input or a value/index pair. A variadic `tt.reduce` cannot be represented by that operation, so lowering it as a variadic `linalg.reduce` eventually fails.

## What this PR changes

1. Replace the multi-input hard assertion in `ReduceSingleCanonicalizer` with `notifyMatchFailure`, allowing `ReduceConverter` to handle the operation.
2. In extended lowering, replace the variadic `linalg.reduce` with an explicit `scf.for` when a multi-input reduction satisfies the constraints below.
3. Initialize the loop state from element zero of every input. On each iteration, map the current elements and loop-carried state to the original `tt.reduce` combine region, clone that region, and yield the values returned by `tt.reduce.return`.
4. Add a three-input MLIR regression and document the fallback constraints in `docs/zh/python-api/_ascend_constraints.py`.

## Symbols and state

| Symbol / parameter | Meaning | Role in this fallback |
| --- | --- | --- |
| `K` | Number of `tt.reduce` input tensors, i.e. `operands.size()`. | This fallback only handles `K > 2`; Welford commonly has `K = 3`. |
| `R` | `getRealReductionOps(op).size()`: the number of effective combine-region operations backward-reachable from `tt.reduce.return`; `ext`, `trunc`, and `bitcast` are excluded. | The base converter chooses extended lowering when `R != 1`. The multi-input fallback in this PR is reached through that path. |
| `axis` | The dimension reduced from each input tensor. | It must be `0`. |
| `T[i]` | Input tensor `i`, where `0 <= i < K`. | All `T[i]` values must have the same static rank-1 shape. Different inputs may have different element types. |
| `L` | `shape(T[0])[0]`, the reduction length. | It must be a positive static integer; the loop iterates over `1 ... L - 1`. |
| `Res[i]` | Result `i` of `tt.reduce`. | There must be `K` results, and `Res[i]` must be a scalar with the same element type as `T[i]`. |
| `x[i]` | Combine-region block argument `i` among the first `K` arguments. | It is bound to the current input element `T[i][iv]`. |
| `s[i]` | Combine-region block argument `K + i` and `scf.for` iter_arg `i`. | It is initialized from `T[i][0]` and carries the previous iteration's result. |
| combine result | Operand `i` of `tt.reduce.return`. | There must be `K` returned values; they become the `scf.yield` values and the final `Res[i]` values. |

Equivalently, initialize `s[i] = T[i][0]`, then for each `iv in [1, L)` run `s = combine(T[0][iv], ..., T[K-1][iv], s[0], ..., s[K-1])`, and return every `s[i]`.

## Fallback eligibility and limits

| Check | Constraint | Behavior or consequence |
| --- | --- | --- |
| Entry path | `K > 2` and the reduction has already reached extended lowering (`R != 1`). | This is not a general multi-input reduction implementation. `R = 1` does not select this fallback and retains the existing single-reduction lowering. |
| Input type | Every operand is a `RankedTensorType`. | A non-ranked operand causes a match failure. |
| Shape and axis | All inputs have the same static rank-1 shape and `axis = 0`. | Multi-dimensional inputs, mismatched shapes, and other axes do not use this fallback. |
| Reduction length | `L` is static and `L >= 1`. | Dynamic lengths and empty inputs are unsupported. |
| Results | There are exactly `K` scalar results, each type-matched with its corresponding input. | Inputs do not need a common dtype, but every `T[i]` / `Res[i]` pair must match. |
| Combine region | The region has exactly `2K` block arguments and `K` `tt.reduce.return` operands. | A region with a different argument or return structure causes a match failure. |
| Downstream lowerability | The cloned combine region must still be accepted by later passes. | This fallback solves the variadic-`VReduce` representation problem only; it does not guarantee that every combine region compiles end-to-end. |
| Numerics and performance | The implementation emits an element-order `scf.for`. | Floating-point rounding can differ from a tree reduction, and performance must be evaluated separately from native vector reduction. |

The same constraints are recorded in the `triton.language.reduce` entry of `docs/zh/python-api/_ascend_constraints.py`.

## Expected TTIR to TTAdapter IR

Input TTIR (schematic, `K = 3`):

```mlir
%res:3 = "tt.reduce"(%t0, %t1, %t2) <{axis = 0 : i32}> ({
^bb0(%x0: f32, %x1: f32, %x2: f32, %s0: f32, %s1: f32, %s2: f32):
  // Welford or another three-state combine computation
  tt.reduce.return %r0, %r1, %r2 : f32, f32, f32
}) : (tensor<Lxf32>, tensor<Lxf32>, tensor<Lxf32>) -> (f32, f32, f32)
```

TritonToLinalg / TTAdapter form (schematic):

```mlir
%init0 = tensor.extract %t0[%c0]
%init1 = tensor.extract %t1[%c0]
%init2 = tensor.extract %t2[%c0]
%res0:3 = scf.for %iv = %c1 to %L step %c1
    iter_args(%s0 = %init0, %s1 = %init1, %s2 = %init2) -> (f32, f32, f32) {
  %x0 = tensor.extract %t0[%iv]
  %x1 = tensor.extract %t1[%iv]
  %x2 = tensor.extract %t2[%iv]
  // Clone the original combine region after mapping x* and s*.
  scf.yield %r0, %r1, %r2
}
```

The expected fallback output contains no `linalg.reduce`, so it cannot reach the unsupported variadic `VReduce` path.

## Regression and validation

- `third_party/ascend/unittest/Conversion/General/TritonToLinalg/multi_input_reduce.mlir` adds three `tensor<4xf32>` inputs and three scalar results. FileCheck requires `scf.for` and `scf.yield`, and rejects `linalg.reduce`.
- `docs/zh/python-api/_ascend_constraints.py` records the API constraint and notation.
- Local checks completed: Python AST parsing of the documentation file and `git diff --check`.
- MLIR regression command:

```bash
triton-opt --triton-to-linalg third_party/ascend/unittest/Conversion/General/TritonToLinalg/multi_input_reduce.mlir | FileCheck third_party/ascend/unittest/Conversion/General/TritonToLinalg/multi_input_reduce.mlir
```

The isolated worktree does not contain a `triton-opt` executable, so the MLIR command is left to CI or an environment with build artifacts.
