### PR TITLE
[TensorDescriptor](feat) support descriptor lowing to ptr

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -134,6 +134,8 @@ def make_ttir(mod, metadata, opt):
     pm = ir.pass_manager(mod.context)
     pm.enable_debug()
     passes.common.add_inliner(pm)
+    passes.ttir.add_rewrite_tensor_pointer(pm)
+    passes.ttir.add_rewrite_tensor_descriptor_to_pointer(pm)
     passes.ttir.add_combine(pm)
     passes.common.add_canonicalizer(pm)
     passes.ttir.add_reorder_broadcast(pm)

--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -134,7 +134,7 @@ def make_ttir(mod, metadata, opt):
     pm = ir.pass_manager(mod.context)
     pm.enable_debug()
     passes.common.add_inliner(pm)
-    passes.ttir.add_rewrite_tensor_pointer(pm)
+    # passes.ttir.add_rewrite_tensor_pointer(pm)
     passes.ttir.add_rewrite_tensor_descriptor_to_pointer(pm)
     passes.ttir.add_combine(pm)
     passes.common.add_canonicalizer(pm)

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -183,7 +183,9 @@ class NPULauncher(object):
         spec = importlib.util.spec_from_file_location("__triton_launcher", self.so_launcher_path)
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
-        self.launch = getattr(mod, "launch")
+        cst_key = lambda i: self.src.fn.arg_names.index(i) if isinstance(i, str) else i
+        signature = {cst_key(key): value for key, value in self.src.signature.items()}
+        self.launch = wrap_handle_tensordesc(getattr(mod, "launch"), signature)
 
     def _make_launcher_stub_path(self):
         header_src = generate_npu_header_src()
@@ -424,6 +426,8 @@ def generate_npu_header_src():
 def ty_to_cpp(ty):
     if ty[0] == '*':
         return "void*"
+    if ty.startswith("tensordesc"):
+        return "void*"
     return {
         "i1": "int32_t",
         "i8": "int8_t",
@@ -443,6 +447,34 @@ def ty_to_cpp(ty):
     }[ty]
 
 
+_BASE_ARGS_FORMAT = "iiiKKOOOO"
+_BASE_ARGS_FORMAT_LEN = len(_BASE_ARGS_FORMAT)
+
+
+def make_tensordesc_arg(arg):
+    return [arg.base, *arg.shape, *arg.strides, arg.padding == "nan", *arg.shape, *arg.strides]
+
+
+def wrap_handle_tensordesc(launcher, signature):
+    has_tensor_desc_arg = any(isinstance(sig, str) and sig.startswith("tensordesc") for sig in signature.values())
+    if not has_tensor_desc_arg:
+        return launcher
+
+    tensordesc_indices = set(
+        [i for i, sig in enumerate(signature.values()) if isinstance(sig, str) and sig.startswith("tensordesc")])
+
+    def inner(*args):
+        final_args = list(args[:_BASE_ARGS_FORMAT_LEN])
+        for i, arg in enumerate(args[_BASE_ARGS_FORMAT_LEN:]):
+            if i in tensordesc_indices:
+                final_args.extend(make_tensordesc_arg(arg))
+            else:
+                final_args.append(arg)
+        return launcher(*final_args)
+
+    return inner
+
+
 # the template is from triton-adapter HEAD. Wrapping the generated kernel binary into a python module
 def make_launcher(constants, signature, metadata):
     import os
@@ -458,16 +490,51 @@ def make_launcher(constants, signature, metadata):
     parallel_mode = metadata.parallel_mode
     enable_simt = ("simt" in parallel_mode) or metadata.force_simt_only
 
-    def _serialize_signature(sig):
+    def _expand_signature(signature):
+        output = []
+        # Expand tensor descriptor arguments into base pointer, shape and
+        # strides. Ascend always rewrites tensordesc to pointer (no TMA).
+        for sig in signature:
+            if isinstance(sig, str) and sig.startswith("tensordesc"):
+                match = re.match("tensordesc<([^[>]*)\\[([^]]*)\\]", sig)
+                dtype = match.group(1)
+                shape = match.group(2)
+                ndim = shape.count(",") + 1
+
+                output.append("*" + dtype)
+                # Currently the host side tensor descriptors get passed in as a
+                # tensor desc, shape, and strides. We have no way to use these
+                # shape and strides when processing tensor descriptors which is
+                # why we provide our own decomposition above. Sadly this means
+                # we have to pass the shape and strides twice.
+                for _ in range(2 * ndim):
+                    output.append("i64")
+                output.append("i1")
+
+                for _ in range(ndim):
+                    output.append("i32")
+                for _ in range(ndim):
+                    output.append("i64")
+            else:
+                output.append(sig)
+
+        return output
+
+    def _flatten_signature(sig, output):
+        # Flatten tuples
         if isinstance(sig, tuple):
-            return ','.join(map(_serialize_signature, sig))
-        return sig
+            for x in sig:
+                _flatten_signature(x, output)
+        else:
+            output.append(sig)
 
     def _extracted_type(ty):
         if isinstance(ty, tuple):
             val = ','.join(map(_extracted_type, ty))
             return f"[{val}]"
         if ty[0] == '*':
+            return "PyObject*"
+        if ty.startswith("tensordesc"):
             return "PyObject*"
         if ty in ("constexpr"):
             return "PyObject*"
@@ -478,6 +545,8 @@ def make_launcher(constants, signature, metadata):
             val = ''.join(map(format_of, ty))
             return f"({val})"
         if ty[0] == '*':
+            return "O"
+        if ty.startswith("tensordesc"):
             return "O"
         if ty in ("constexpr"):
             return "O"
@@ -525,11 +594,16 @@ def make_launcher(constants, signature, metadata):
         *args_expand
     """
 
+    expand_signature = _expand_signature(signature.values())
+    signature = {i: s for i, s in enumerate(expand_signature)}
+
     args_format = ''.join([format_of(ty) for ty in signature.values()])
-    format = "iiiKKOOOO" + args_format
-    signature = ','.join(map(_serialize_signature, signature.values()))
-    signature = list(filter(bool, signature.split(',')))
-    signature = {i: s for i, s in enumerate(signature)}
+    format = _BASE_ARGS_FORMAT + args_format
+
+    flat_signature = []
+    for sig in signature.values():
+        _flatten_signature(sig, flat_signature)
+    signature = {i: s for i, s in enumerate(flat_signature)}
     args_list = ', ' + ', '.join(f"&_arg{i}" for i, ty in signature.items()) if len(signature) > 0 else ''
     # Record the end of regular arguments;
     # subsequent arguments are architecture-specific descriptors.
@@ -570,10 +644,10 @@ def make_launcher(constants, signature, metadata):
     alloc_success_code = 'return 1;'
     sync_lock_fail_code = 'fprintf(stderr, "Error: syncBlockLock allocation failed\\n"); return;'
     workspace_fail_code = 'fprintf(stderr, "Error: workspace allocation failed\\n"); return;'
-    launch_signature_items = [(i, ty) for i, ty in signature.items() if i not in constants]
+    launch_signature_items = [(i, ty) for i, ty in signature.items() if ty != "constexpr"]
     launch_arg_count = len(launch_signature_items)
     launch_arg_ptrs = ', '.join(f'static_cast<const void*>(&arg{i})' for i, ty in launch_signature_items)
-    launch_arg_sizes = ', '.join(f'sizeof({ty_to_cpp(ty)})' for i, ty in launch_signature_items if ty != "constexpr")
+    launch_arg_sizes = ', '.join(f'sizeof({ty_to_cpp(ty)})' for i, ty in launch_signature_items)
 
     npu_utils_inst = NPUUtils()
     npu_utils_mod = getattr(npu_utils_inst, "npu_utils_mod", None)
@@ -1083,7 +1157,7 @@ static void _launch(const char* kernelName, const void* func, rtStream_t stream,
       {'void* ffts_addr __attribute__((aligned(8)));' if target_support_ffts else ''}
       {'void* syncBlockLock __attribute__((aligned(8)));' if not metadata.force_simt_only else ''}
       {'void* workspace_addr __attribute__((aligned(8)));' if not metadata.force_simt_only else ''}
-      {' '.join(f'{ty_to_cpp(ty)} arg{i} __attribute__((aligned({4 if ty[0] != "*" and ty[-2:] != "64" else 8})));' for i, ty in signature.items() if i not in constants and ty != "constexpr")}
+      {' '.join(f'{ty_to_cpp(ty)} arg{i} __attribute__((aligned({4 if ty[0] != "*" and ty[-2:] != "64" else 8})));' for i, ty in signature.items() if ty != "constexpr")}
       {' '.join(f'{ty_to_cpp(ty)} grid{mark} __attribute__((aligned(4)));' for mark, ty in grid_info.items())}
       {'void* DTData __attribute__((aligned(8)));' if enable_device_print else ''}
     }} args = {{
@@ -1091,7 +1165,7 @@ static void _launch(const char* kernelName, const void* func, rtStream_t stream,
       {('static_cast<void*>(syncBlockLock_ptr),' if lock_num > 0 else 'nullptr,') if not metadata.force_simt_only else ''}
       {('static_cast<void*>(workspace_addr_ptr),' if workspace_size > 0 else 'nullptr,') if not metadata.force_simt_only else ''}
       {(lambda _rt: (', '.join(_rt) + ',') if _rt else '')(
-        [f'static_cast<{ty_to_cpp(ty)}>(arg{i})' for i, ty in signature.items() if i not in constants and ty != "constexpr"]
+        [f'static_cast<{ty_to_cpp(ty)}>(arg{i})' for i, ty in signature.items() if ty != "constexpr"]
       )}
       {', '.join(f'static_cast<{ty_to_cpp(ty)}>(grid{mark})' for mark, ty in grid_info.items())}
       {', static_cast<void*>(DTData)' if enable_device_print else ''}

--- a/third_party/ascend/lib/Utils/Utils.cpp
+++ b/third_party/ascend/lib/Utils/Utils.cpp
@@ -340,8 +340,9 @@ Value getScalarValue(Value operand, Location loc,
       }
       if (isa<ShapedType>(cond.getType()))
         return nullptr;
-      return rewriter.create<arith::SelectOp>(loc, trueVal.getType(), cond,
-                                              trueVal, falseVal);
+      Value scalarSelect = rewriter.create<arith::SelectOp>(
+          loc, trueVal.getType(), cond, trueVal, falseVal);
+      return reconstructScalarValue(scalarSelect);
     } else if (auto op = operand.getDefiningOp<arith::SIToFPOp>()) {
       ops.push_back(op.getOperation());
       operand = op.getIn();

--- a/third_party/ascend/lib/Utils/Utils.cpp
+++ b/third_party/ascend/lib/Utils/Utils.cpp
@@ -261,6 +261,12 @@ SmallVector<utils::IteratorType> getNParallelLoopsAttrs(unsigned n) {
 
 Value getScalarValue(Value operand, Location loc,
                      ConversionPatternRewriter &rewriter) {
+  // Peel splat / dense-splat / (s|u)itofp / truncf / select(pad, nan, zero)
+  // chains looking for a true scalar. Descriptor-load lowering emits
+  //   other = arith.select %padding, dense<nan>, dense<0>
+  // which must collapse to a scalar select so masked load can fill UB lanes.
+  // Returns nullptr when the value is a non-splat tensor so callers can fall
+  // back to a tensor-other path.
   SmallVector<Operation *> ops;
   auto reconstructScalarValue = [&](Value src) {
     for (auto op = ops.rbegin(); op != ops.rend(); ++op) {
@@ -271,6 +277,13 @@ Value getScalarValue(Value operand, Location loc,
                     resType = shapedType.getElementType();
                   }
                   return rewriter.create<arith::SIToFPOp>(loc, resType, src);
+                })
+                .Case<arith::UIToFPOp>([&](Operation *op) {
+                  auto resType = op->getResults()[0].getType();
+                  if (auto shapedType = dyn_cast<ShapedType>(resType)) {
+                    resType = shapedType.getElementType();
+                  }
+                  return rewriter.create<arith::UIToFPOp>(loc, resType, src);
                 })
                 .Case<arith::TruncFOp>([&](Operation *op) {
                   auto resType = op->getResults()[0].getType();
@@ -292,33 +305,53 @@ Value getScalarValue(Value operand, Location loc,
       return reconstructScalarValue(operand);
     } else if (auto op = operand.getDefiningOp<arith::ConstantOp>()) {
       if (auto attr = dyn_cast<DenseElementsAttr>(op.getValue())) {
-        if (!attr.isSplat()) {
-          InFlightDiagnostic diag = emitError(loc)
-                                    << "other value used in masked load "
-                                       "produced by unsupported instruction";
+        if (!attr.isSplat())
           return nullptr;
-        }
         auto elemValue = attr.getSplatValue<Attribute>();
         auto constOp = arith::ConstantOp::materialize(
             rewriter, elemValue, attr.getElementType(), op.getLoc());
         return reconstructScalarValue(constOp.getResult());
       }
-      InFlightDiagnostic diag = emitError(loc)
-                                << "other value used in masked load produced "
-                                   "by unsupported instruction";
       return nullptr;
     } else if (auto op = operand.getDefiningOp<triton::SplatOp>()) {
       operand = op.getSrc();
+    } else if (auto op = operand.getDefiningOp<arith::SelectOp>()) {
+      // Descriptor padding: select(i1, splat_nan, splat_zero) -> scalar select.
+      Value trueVal = getScalarValue(op.getTrueValue(), loc, rewriter);
+      Value falseVal = getScalarValue(op.getFalseValue(), loc, rewriter);
+      if (!trueVal || !falseVal)
+        return nullptr;
+      Value cond = op.getCondition();
+      if (isa<ShapedType>(cond.getType())) {
+        if (auto splat = cond.getDefiningOp<triton::SplatOp>())
+          cond = splat.getSrc();
+        else if (auto c = cond.getDefiningOp<arith::ConstantOp>()) {
+          if (auto attr = dyn_cast<DenseElementsAttr>(c.getValue());
+              attr && attr.isSplat()) {
+            cond = arith::ConstantOp::materialize(
+                rewriter, attr.getSplatValue<Attribute>(), attr.getElementType(),
+                c.getLoc());
+          } else {
+            return nullptr;
+          }
+        } else {
+          return nullptr;
+        }
+      }
+      if (isa<ShapedType>(cond.getType()))
+        return nullptr;
+      return rewriter.create<arith::SelectOp>(loc, trueVal.getType(), cond,
+                                              trueVal, falseVal);
     } else if (auto op = operand.getDefiningOp<arith::SIToFPOp>()) {
+      ops.push_back(op.getOperation());
+      operand = op.getIn();
+    } else if (auto op = operand.getDefiningOp<arith::UIToFPOp>()) {
       ops.push_back(op.getOperation());
       operand = op.getIn();
     } else if (auto op = operand.getDefiningOp<arith::TruncFOp>()) {
       ops.push_back(op.getOperation());
       operand = op.getIn();
     } else {
-      InFlightDiagnostic diag = emitError(loc)
-                                << "other value used in masked load produced "
-                                   "by unsupported instruction";
       return nullptr;
     }
   }

--- a/third_party/ascend/lib/Utils/Utils.cpp
+++ b/third_party/ascend/lib/Utils/Utils.cpp
@@ -329,8 +329,8 @@ Value getScalarValue(Value operand, Location loc,
           if (auto attr = dyn_cast<DenseElementsAttr>(c.getValue());
               attr && attr.isSplat()) {
             cond = arith::ConstantOp::materialize(
-                rewriter, attr.getSplatValue<Attribute>(), attr.getElementType(),
-                c.getLoc());
+                rewriter, attr.getSplatValue<Attribute>(),
+                attr.getElementType(), c.getLoc());
           } else {
             return nullptr;
           }

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_tensor_descriptor.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_tensor_descriptor.mlir
@@ -1,0 +1,114 @@
+// RUN: triton-opt --triton-rewrite-tensor-descriptor-to-pointer --split-input-file %s | FileCheck %s --check-prefix=CHECK
+// RUN: triton-opt --triton-rewrite-tensor-descriptor-to-pointer --canonicalize "--triton-to-linalg=global-kernel=false named-ops=True" --split-input-file %s | FileCheck %s --check-prefix=CHECK-LINALG
+
+// -----
+
+// Case 1: tt.descriptor_load/store -> tt.load/store (rewrite_tensor_descriptor_to_pointer)
+// CHECK-LABEL: tt.func public @desc_copy_device
+// CHECK-NOT: tt.make_tensor_descriptor
+// CHECK-NOT: tt.descriptor_load
+// CHECK-NOT: tt.descriptor_store
+// CHECK-NOT: !tt.tensordesc
+// CHECK: tt.load {{.*}}, {{.*}}, {{.*}} : tensor<16x32x!tt.ptr<f32>>
+// CHECK: tt.store
+//
+// CHECK-LINALG-LABEL: func.func @desc_copy_device
+// CHECK-LINALG: %[[ZERO:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK-LINALG: %[[ALLOC:.*]] = memref.alloc() : memref<16x32xf32>
+// CHECK-LINALG: scf.if
+// CHECK-LINALG: linalg.fill ins(%[[ZERO]] : f32) outs(%[[ALLOC]] : memref<16x32xf32>)
+// CHECK-LINALG: memref.copy
+// CHECK-LINALG: bufferization.to_tensor %[[ALLOC]]
+
+module attributes {hacc.target = #hacc.target<"Ascend910B4">} {
+  tt.func public @desc_copy_device(%in_ptr: !tt.ptr<f32>, %out_ptr: !tt.ptr<f32>, %M: i32, %N: i32) {
+    %c1 = arith.constant 1 : i64
+    %c0 = arith.constant 0 : i32
+    %Ns = arith.extsi %N : i32 to i64
+    %in_desc = tt.make_tensor_descriptor %in_ptr, [%M, %N], [%Ns, %c1] : <f32>, <tensor<16x32xf32>>
+    %out_desc = tt.make_tensor_descriptor %out_ptr, [%M, %N], [%Ns, %c1] : <f32>, <tensor<16x32xf32>>
+    %tile = tt.descriptor_load %in_desc[%c0, %c0] : !tt.tensordesc<tensor<16x32xf32>> -> tensor<16x32xf32>
+    tt.descriptor_store %out_desc[%c0, %c0], %tile : !tt.tensordesc<tensor<16x32xf32>>, tensor<16x32xf32>
+    tt.return
+  }
+}
+
+// -----
+
+// Case 2: host TensorDescriptor ABI (padding as i1) -> linalg, getScalarValue peels
+//   other = select(padding, nan, zero) into a scalar fill.
+// CHECK-LABEL: tt.func public @host_desc_load
+// CHECK: arith.select %{{.*}}, %{{.*}}, %{{.*}} : tensor<16x32xf32>
+// CHECK: tt.load {{.*}}, {{.*}}, {{.*}} : tensor<16x32x!tt.ptr<f32>>
+// CHECK: tt.store
+//
+// CHECK-LINALG-LABEL: func.func @host_desc_load
+// CHECK-LINALG-DAG: %[[ZERO:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK-LINALG-DAG: %[[NAN:.*]] = arith.constant 0x7FC00000 : f32
+// CHECK-LINALG-DAG: %[[ALLOC:.*]] = memref.alloc() : memref<16x32xf32>
+// CHECK-LINALG: %[[PAD:.*]] = arith.select %{{.*}}, %[[NAN]], %[[ZERO]] : f32
+// CHECK-LINALG: scf.if
+// CHECK-LINALG: linalg.fill ins(%[[PAD]] : f32) outs(%[[ALLOC]] : memref<16x32xf32>)
+// CHECK-LINALG: memref.copy
+// CHECK-LINALG: bufferization.to_tensor %[[ALLOC]]
+
+module attributes {hacc.target = #hacc.target<"Ascend910B4">} {
+  tt.func public @host_desc_load(
+      %ptr: !tt.ptr<f32>,
+      %shape0: i64, %shape1: i64,
+      %stride0: i64, %stride1: i64,
+      %padding: i1,
+      %shape0_i32: i32, %shape1_i32: i32,
+      %stride0_dup: i64, %stride1_dup: i64,
+      %out: !tt.ptr<f32>,
+      %om: i32, %on: i32) {
+    %cst_nan = arith.constant dense<0x7FC00000> : tensor<16x32xf32>
+    %cst_zero = arith.constant dense<0.000000e+00> : tensor<16x32xf32>
+    %other = arith.select %padding, %cst_nan, %cst_zero : tensor<16x32xf32>
+
+    %om64 = arith.extsi %om : i32 to i64
+    %on64 = arith.extsi %on : i32 to i64
+    %offs_m = tt.splat %om64 : i64 -> tensor<16xi64>
+    %range_m = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %range_m64 = arith.extsi %range_m : tensor<16xi32> to tensor<16xi64>
+    %idx_m = arith.addi %offs_m, %range_m64 : tensor<16xi64>
+    %idx_m2 = tt.expand_dims %idx_m {axis = 1 : i32} : tensor<16xi64> -> tensor<16x1xi64>
+
+    %offs_n = tt.splat %on64 : i64 -> tensor<32xi64>
+    %range_n = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %range_n64 = arith.extsi %range_n : tensor<32xi32> to tensor<32xi64>
+    %idx_n = arith.addi %offs_n, %range_n64 : tensor<32xi64>
+    %idx_n2 = tt.expand_dims %idx_n {axis = 0 : i32} : tensor<32xi64> -> tensor<1x32xi64>
+
+    %base = tt.splat %ptr : !tt.ptr<f32> -> tensor<16x32x!tt.ptr<f32>>
+    %s0 = tt.splat %stride0 : i64 -> tensor<16x1xi64>
+    %m0 = arith.muli %idx_m2, %s0 : tensor<16x1xi64>
+    %b0 = tt.broadcast %m0 : tensor<16x1xi64> -> tensor<16x32xi64>
+    %s1 = tt.splat %stride1 : i64 -> tensor<1x32xi64>
+    %m1 = arith.muli %idx_n2, %s1 : tensor<1x32xi64>
+    %b1 = tt.broadcast %m1 : tensor<1x32xi64> -> tensor<16x32xi64>
+    %off = arith.addi %b0, %b1 : tensor<16x32xi64>
+    %ptrs = tt.addptr %base, %off : tensor<16x32x!tt.ptr<f32>>, tensor<16x32xi64>
+
+    %c0 = arith.constant dense<0> : tensor<16x1xi64>
+    %ge0 = arith.cmpi sge, %idx_m2, %c0 : tensor<16x1xi64>
+    %sh0 = tt.splat %shape0 : i64 -> tensor<16x1xi64>
+    %lt0 = arith.cmpi slt, %idx_m2, %sh0 : tensor<16x1xi64>
+    %mmsk = arith.andi %ge0, %lt0 : tensor<16x1xi1>
+    %mmsk2 = tt.broadcast %mmsk : tensor<16x1xi1> -> tensor<16x32xi1>
+    %c0n = arith.constant dense<0> : tensor<1x32xi64>
+    %ge1 = arith.cmpi sge, %idx_n2, %c0n : tensor<1x32xi64>
+    %sh1 = tt.splat %shape1 : i64 -> tensor<1x32xi64>
+    %lt1 = arith.cmpi slt, %idx_n2, %sh1 : tensor<1x32xi64>
+    %nmsk = arith.andi %ge1, %lt1 : tensor<1x32xi1>
+    %nmsk2 = tt.broadcast %nmsk : tensor<1x32xi1> -> tensor<16x32xi1>
+    %mask = arith.andi %mmsk2, %nmsk2 : tensor<16x32xi1>
+
+    %tile = tt.load %ptrs, %mask, %other : tensor<16x32x!tt.ptr<f32>>
+
+    %obase = tt.splat %out : !tt.ptr<f32> -> tensor<16x32x!tt.ptr<f32>>
+    %optrs = tt.addptr %obase, %off : tensor<16x32x!tt.ptr<f32>>, tensor<16x32xi64>
+    tt.store %optrs, %tile, %mask : tensor<16x32x!tt.ptr<f32>>
+    tt.return
+  }
+}

--- a/third_party/ascend/unittest/pytest_ut/test_indirect_load_pointer_cast_precise_size.py
+++ b/third_party/ascend/unittest/pytest_ut/test_indirect_load_pointer_cast_precise_size.py
@@ -59,4 +59,4 @@ def test_indirect_load_pointer_cast_precise_size_e2e():
 
     expected = (block_table_cpu[positions_cpu // block_size] * block_size + positions_cpu % block_size).to(torch.int64)
 
-    assert torch.equal(out.cpu(), expected)
+    assert torch.equal(out.cpu(), expected.cpu())

--- a/third_party/ascend/unittest/pytest_ut/test_tensor_descriptor.py
+++ b/third_party/ascend/unittest/pytest_ut/test_tensor_descriptor.py
@@ -369,3 +369,64 @@ def test_tensor_descriptor_reduce(kind, dtype, M_BLOCK, N_BLOCK):
     expect = REDUCE_OP[kind](inp, out)
     kernel[(grid_m, grid_n)](inp, out, M, N, M_BLOCK, N_BLOCK, kind)
     torch.testing.assert_close(expect, out)
+
+
+@pytest.mark.parametrize("dtype", ["float32"])
+@pytest.mark.parametrize("M,N,BLOCK_M,BLOCK_N", [(64, 128, 16, 32)])
+def test_host_tensor_descriptor_args(dtype, M, N, BLOCK_M, BLOCK_N):
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    @triton.jit
+    def kernel(in_desc, out_desc, M, N, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
+        pid = tl.program_id(0)
+        grid_n = tl.cdiv(N, BLOCK_N)
+        pid_m = pid // grid_n
+        pid_n = pid % grid_n
+        off_m = (pid_m * BLOCK_M).to(tl.int32)
+        off_n = (pid_n * BLOCK_N).to(tl.int32)
+        tile = in_desc.load([off_m, off_n])
+        out_desc.store([off_m, off_n], tile)
+
+    torch_dtype = getattr(torch, dtype)
+    inp = torch.randn((M, N), dtype=torch_dtype, device="npu")
+    out = torch.empty((M, N), dtype=torch_dtype, device="npu")
+    in_desc = TensorDescriptor(inp, list(inp.shape), list(inp.stride()), [BLOCK_M, BLOCK_N])
+    out_desc = TensorDescriptor(out, list(out.shape), list(out.stride()), [BLOCK_M, BLOCK_N])
+
+    grid = (triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N), )
+    kernel[grid](in_desc, out_desc, M, N, BLOCK_M, BLOCK_N)
+    torch.testing.assert_close(inp, out)
+
+
+@pytest.mark.parametrize("padding", ["zero", "nan"])
+def test_host_tensor_descriptor_padding(padding):
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    @triton.jit
+    def kernel(in_desc, out_desc, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
+        moffset = (tl.program_id(0) * BLOCK_M).to(tl.int32)
+        noffset = (tl.program_id(1) * BLOCK_N).to(tl.int32)
+        value = in_desc.load([moffset, noffset])
+        out_desc.store([moffset, noffset], value)
+
+    IM, IN = 48, 48
+    OM, ON = 64, 64
+    BLOCK_M, BLOCK_N = 32, 32
+    inp = torch.arange(IM * IN, device="npu", dtype=torch.float32).reshape(IM, IN)
+    out = torch.zeros((OM, ON), device="npu", dtype=torch.float32)
+
+    in_desc = TensorDescriptor(inp, list(inp.shape), list(inp.stride()), [BLOCK_M, BLOCK_N],
+                               padding=padding)
+    out_desc = TensorDescriptor(out, list(out.shape), list(out.stride()), [BLOCK_M, BLOCK_N])
+
+    grid = (triton.cdiv(OM, BLOCK_M), triton.cdiv(ON, BLOCK_N))
+    kernel[grid](in_desc, out_desc, BLOCK_M, BLOCK_N)
+
+    expected = torch.zeros((OM, ON), device="npu", dtype=torch.float32)
+    expected[0:IM, 0:IN] = inp
+    if padding == "nan":
+        expected[IM:OM, :] = float("nan")
+        expected[:, IN:ON] = float("nan")
+        # corner already nan from both; keep as nan
+        expected[IM:OM, IN:ON] = float("nan")
+    torch.testing.assert_close(expected, out, equal_nan=True)

--- a/third_party/ascend/unittest/pytest_ut/test_tensor_descriptor.py
+++ b/third_party/ascend/unittest/pytest_ut/test_tensor_descriptor.py
@@ -415,8 +415,7 @@ def test_host_tensor_descriptor_padding(padding):
     inp = torch.arange(IM * IN, device="npu", dtype=torch.float32).reshape(IM, IN)
     out = torch.zeros((OM, ON), device="npu", dtype=torch.float32)
 
-    in_desc = TensorDescriptor(inp, list(inp.shape), list(inp.stride()), [BLOCK_M, BLOCK_N],
-                               padding=padding)
+    in_desc = TensorDescriptor(inp, list(inp.shape), list(inp.stride()), [BLOCK_M, BLOCK_N], padding=padding)
     out_desc = TensorDescriptor(out, list(out.shape), list(out.stride()), [BLOCK_M, BLOCK_N])
 
     grid = (triton.cdiv(OM, BLOCK_M), triton.cdiv(ON, BLOCK_N))


### PR DESCRIPTION
## Summary
Enable Ascending kernels to accept Python `triton.tools.tensor_descriptor.TensorDescriptor` as arguments.

1. **`make_ttir`**: add `rewrite_tensor_pointer` + `rewrite_tensor_descriptor_to_pointer` so descriptor load/store become ordinary masked `tt.load` / `tt.store`.
2. **`driver.py`**: expand `tensordesc<...>` launch signature and unwrap host `TensorDescriptor` objects.
3. **`getScalarValue`**: peel `arith.select(padding, splat_nan, splat_zero)` produced by the rewrite, so `LoadConverter` can `linalg.fill` UB lanes.

## Why

Previously Ascend only exercised `tl.make_tensor_descriptor` **inside** the kernel. Passing an external `TensorDescriptor` failed with:

- `KeyError: 'tensordesc<...>'` in the launcher (signature not expanded), and/or
- `other value used in masked load produced by unsupported instruction` in TritonToLinalg (`other` was a tensor `select`).


### Pass roles

| Pass | Role |
|------|------|
| `triton-rewrite-tensor-descriptor-to-pointer` | `make_tensor_descriptor` / `descriptor_load|store` → ptr + shape/strides + padding, then masked load/store |

### Driver (vs NV)

Aligned with NV’s structure (`_expand_signature`, `_flatten_signature`, `make_tensordesc_arg`, `wrap_handle_tensordesc`), with Ascend-only deletions:

- No `tensordesc_meta` / `nvTmaDesc` / `CUtensorMap` (TMA-only on NV).
- Always take the pointer-decomposition branch.
- Filter packed kernel args with `ty != "constexpr"` (same idea as NV; no constant-index remap).

### `getScalarValue` (Utils.cpp)

Rewrite emits:

```mlir
%other = arith.select %padding, dense<nan>, dense<0> : tensor<Bm x Bn x T>
%tile  = tt.load %ptrs, %mask, %other
```

- Device `make_tensor_descriptor` with compile-time padding: canonicalize may fold the select → splat constant → already handled.
- **Host** `TensorDescriptor`: `%padding` is a function-arg `i1` → select cannot fold.

Peel path:

```text
select(i1, splat_nan, splat_zero)
  -> select(i1, scalar_nan, scalar_zero)
  -> scf.if { linalg.fill ins(%scalar_select) outs(%alloc) }
```

## Examples

### Host copy (pytest)

```python
in_desc = TensorDescriptor(x, list(x.shape), list(x.stride()), [BLOCK_M, BLOCK_N])
out_desc = TensorDescriptor(y, list(y.shape), list(y.stride()), [BLOCK_M, BLOCK_N])
kernel[grid](in_desc, out_desc, M, N, BLOCK_M, BLOCK_N)
```

### After rewrite (TTIR sketch)

```mlir
// tensordesc arg -> ptr + shapes + strides + padding (+ host shape/stride dups)
%other = arith.select %padding, dense<nan>, dense<0> : tensor<16x32xf32>
%tile  = tt.load %ptrs, %mask, %other : tensor<16x32x!tt.ptr<f32>>
tt.store %out_ptrs, %tile, %mask
```

### After `triton-to-linalg` (host padding)

```mlir
%nan  = arith.constant 0x7FC00000 : f32
%zero = arith.constant 0.000000e+00 : f32
%pad  = arith.select %padding, %nan, %zero : f32
%alloc = memref.alloc() : memref<16x32xf32>
scf.if %need_pad {
  linalg.fill ins(%pad : f32) outs(%alloc : memref<16x32xf32>)
} {hivm.unlikely_condition}
memref.copy ...   // active region
bufferization.to_tensor %alloc
```

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
	[rules](https://cbea.ms/git-commit/#why-not-how).
- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
	- [ ] This PR does not need a test because …
	- [x] I have added tests.
		- `unittest/pytest_ut` for end-to-end NPU tests
		- `unittest/Conversion/General/TritonToLinalg` lit FileCheck
- Select one of the following.
	- [ ] I have not added any `lit` tests.
	- [x] The `lit` tests I have added follow FileCheck best practices (minimal TTIR kernels + documented lowering Q&A).
