### PR TITLE
[ssbuffer](fix) insert copyop before storeop

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
@@ -154,6 +154,9 @@ private:
   mlir::Operation *analyzeConsumerReadInsertPoint(Value srcValue,
                                                   int iniConsumerId);
   mlir::Operation *getConsumerWaitPoint(int transferIndex);
+  mlir::Operation *getCopyPointBeforeStore(Value depValue,
+                                           Operation *vectorEndOp,
+                                           int iniProducerBlockId);
   mlir::Operation *insertVectorToCubeTransfer(
       mlir::OpBuilder &builder, mlir::Value srcValue,
       mlir::Value normalizedValue, mlir::Operation *vectorEndOp,

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -283,6 +283,29 @@ bool InterCoreTransferAndSyncPass::isExpectedShape(
   return isEqualedShape;
 }
 
+// insert copyop before store to avoid mte3 blocking
+mlir::Operation *InterCoreTransferAndSyncPass::getCopyPointBeforeStore(
+    Value depValue, Operation *vectorEndOp, int iniProducerBlockId) {
+  Operation *curr = vectorEndOp;
+  Operation *firstStoreOpAfterProducer = nullptr;
+  while (curr) {
+    auto blockIdOpt = CVPipeline::getOpBlockId(curr);
+    if (!blockIdOpt || *blockIdOpt != iniProducerBlockId) {
+      break;
+    }
+    if (curr == depValue.getDefiningOp()) {
+      break;
+    }
+    if (CVPipeline::isStoreLike(curr)) {
+      firstStoreOpAfterProducer = curr->getPrevNode();
+      LOG_DEBUG("firstStoreOpAfterProducer: " << *firstStoreOpAfterProducer
+                                              << "\n");
+    }
+    curr = curr->getPrevNode();
+  }
+  return firstStoreOpAfterProducer;
+}
+
 // padding v->c tensor
 mlir::Value InterCoreTransferAndSyncPass::alignShapeByInsertSlice(
     OpBuilder &builder, DependencyInfo &dep, Location loc,
@@ -382,6 +405,13 @@ void InterCoreTransferAndSyncPass::Nd2NzNormalize(OpBuilder &builder,
 
   auto [newProdStart, newProdEnd] =
       getBlockStartEnd(dep.producerBlockId, module);
+  if (dep.iniProducerBlockId == dep.producerBlockId) {
+    auto producerPoint =
+        getCopyPointBeforeStore(newValue, newProdEnd, dep.iniProducerBlockId);
+    if (producerPoint) {
+      newProdEnd = producerPoint;
+    }
+  }
   builder.setInsertionPointAfter(newProdEnd);
 
   auto reshape3Dcst =
@@ -1294,14 +1324,19 @@ LogicalResult InterCoreTransferAndSyncPass::handleVectorToCube(
       consStart = consumerPoint;
     }
   }
+  if (dep.iniProducerBlockId == dep.producerBlockId) {
+    auto producerPoint =
+        getCopyPointBeforeStore(normalizedVal, prodEnd, dep.iniProducerBlockId);
+    if (producerPoint) {
+      prodEnd = producerPoint;
+    }
+  }
   LOG_DEBUG("after analyzeConsumerReadInsertPoint\n");
   Operation *transferOp = insertVectorToCubeTransfer(
       builder, srcValue, normalizedVal, prodEnd, consStart, loc, transferIndex,
       dep, is1DTensorDependency(dep.value), &consumedDataOp);
 
   int flagId = flagManager.acquireId();
-  auto [newProdStart, newProdEnd] =
-      getBlockStartEnd(dep.producerBlockId, module);
   auto [newConsStart, newConsEnd] =
       getBlockStartEnd(dep.consumerBlockId, module);
 


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
