### PR TITLE
[patch](feat) dot precision: tf32 converted to hf32

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2023,12 +2023,6 @@ def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_i
         supports_tf32 = "tf32" in _semantic.builder.options.allowed_dot_input_precisions
         input_precision = knobs.language.fp32_default or ("tf32" if (supports_tf32 and
                                                                      (allow_tf32 or allow_tf32 is None)) else "ieee")
-        # when setting allow_tf32, use input_precision='hf32' on Ascend instead.
-        if allow_tf32:
-            input_precision = "hf32"
-    else:
-        if input_precision == "tf32":
-            input_precision = "hf32"
 
     input_precision = _unwrap_if_constexpr(input_precision)
     out_dtype = _unwrap_if_constexpr(out_dtype)

--- a/third_party/ascend/backend/__init__.py
+++ b/third_party/ascend/backend/__init__.py
@@ -89,15 +89,9 @@ def _apply_ascend_patch():
             - Warn when max_num_imprecise_acc is explicitly set, since
               Ascend NPU does not support imprecise accumulation.
             """
-            # HF32 guard: only valid for fp32 x fp32.
-            # When lhs is fp32 ret_scalar_ty is guaranteed fp32 by upstream,
-            # so checking lhs and rhs alone is sufficient.
-            # input_precision is still a string at this point (set by core.py),
-            # so we compare as strings rather than with the MLIR enum.
-            if input_precision is not None and input_precision.lower() == "hf32":
-                if not lhs.dtype.is_fp32() or not rhs.dtype.is_fp32():
-                    input_precision = self.builder.options.default_dot_input_precision
-
+            # Ascend does not support tf32, tf32 is converted to hf32. Avoid tf32 verification interception
+            if input_precision == "tf32":
+                input_precision = "hf32"
             # Ascend NPU does not support imprecise accumulation.
             # Force max_num_imprecise_acc to None so the upstream None
             # branch handles it (via max_num_imprecise_acc_default = 0),

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -2220,7 +2220,20 @@ MatmulConverter::matchAndRewrite(triton::DotOp op, OpAdaptor adaptor,
   auto dstType = cast<RankedTensorType>(op.getType());
   auto elemTy = dstType.getElementType();
   auto inputPrec = op.getInputPrecision();
-
+  // Ascend does not support tf32;  map it to hf32 which provides similar
+  // functionality.HF32 is only valid for fp32 x fp32 inputs; for other
+  // dtypes, fall back to ieee.
+  if (inputPrec == InputPrecision::TF32) {
+    op->emitWarning("Ascend does not support tf32; map it to hf32.");
+    inputPrec = InputPrecision::HF32;
+  }
+  if (inputPrec == InputPrecision::HF32) {
+    auto opaElemTy = cast<RankedTensorType>(opa.getType()).getElementType();
+    auto opbElemTy = cast<RankedTensorType>(opb.getType()).getElementType();
+    if (!opaElemTy.isF32() || !opbElemTy.isF32()) {
+      inputPrec = InputPrecision::IEEE;
+    }
+  }
   auto createOp = [&](auto &&rewriter, ValueRange operands,
                       ValueRange results) -> Operation * {
     if (dstType.getRank() == 2)

--- a/third_party/ascend/unittest/pytest_ut/test_dot.py
+++ b/third_party/ascend/unittest/pytest_ut/test_dot.py
@@ -74,7 +74,9 @@ def triton_dot_2_allow_tf32(output_ptr, x_ptr, y_ptr, B: tl.constexpr, C: tl.con
     Yidx = cidx[:, None] * D + didx[None, :]
     X = tl.load(x_ptr + Xidx, mask=x_mask, other=0.0)
     Y = tl.load(y_ptr + Yidx, mask=y_mask, other=0.0)
-    ret = tl.dot(X, Y, allow_tf32=True)
+    # when allow_tf32=True; input_precision=tf32
+    # After removing invasive modifications,input_precision needs to be passed.
+    ret = tl.dot(X, Y, input_precision="tf32")
     oidx = bidx[:, None] * D + didx[None, :]
     tl.store(output_ptr + oidx, ret, mask=out_mask)
 
@@ -126,7 +128,6 @@ typelist = [
 ]
 
 
-@pytest.mark.skip(reason="not supported after the NPUIR is updated in April, and will be fixed later")
 @pytest.mark.parametrize("B, C, D", testlist2)
 @pytest.mark.parametrize("sigtype", typelist)
 def test_dot_2(restore_npu_hf32_setting, sigtype, B, C, D):
@@ -135,11 +136,9 @@ def test_dot_2(restore_npu_hf32_setting, sigtype, B, C, D):
     z_ref = torch_dot_None(x, y).to(torch.float32)
     z = torch.zeros((B, D), dtype=torch.float32).npu()
     triton_dot_2_None[1, 1, 1](z, x, y, B, C, D)
-    test_common.validate_cmp(sigtype, z, z_ref)
+    torch.testing.assert_close(z, z_ref, rtol=3e-02, atol=3e-02, equal_nan=True)
 
 
-@pytest.mark.xfail(
-    reason="Temporarily disabled: TA backend does not support allow_tf32 yet. Will be fixed in follow-up.")
 @pytest.mark.parametrize("B, C, D", testlist2)
 @pytest.mark.parametrize("sigtype", typelist)
 def test_dot_2_allow_tf32(restore_npu_hf32_setting, sigtype, B, C, D):
@@ -148,10 +147,9 @@ def test_dot_2_allow_tf32(restore_npu_hf32_setting, sigtype, B, C, D):
     z_ref = torch_dot_None(x, y).to(torch.float32)
     z = torch.zeros((B, D), dtype=torch.float32).npu()
     triton_dot_2_allow_tf32[1, 1, 1](z, x, y, B, C, D)
-    test_common.validate_cmp(sigtype, z, z_ref)
+    torch.testing.assert_close(z, z_ref, rtol=3e-02, atol=3e-02, equal_nan=True)
 
 
-@pytest.mark.skip(reason="not supported after the NPUIR is updated in April, and will be fixed later")
 @pytest.mark.parametrize("B, C, D", testlist2)
 @pytest.mark.parametrize("sigtype", typelist)
 def test_dot_2_input_tf32(restore_npu_hf32_setting, sigtype, B, C, D):
@@ -160,7 +158,7 @@ def test_dot_2_input_tf32(restore_npu_hf32_setting, sigtype, B, C, D):
     z_ref = torch_dot_None(x, y).to(torch.float32)
     z = torch.zeros((B, D), dtype=torch.float32).npu()
     triton_dot_2_input_tf32[1, 1, 1](z, x, y, B, C, D)
-    test_common.validate_cmp(sigtype, z, z_ref)
+    torch.testing.assert_close(z, z_ref, rtol=3e-02, atol=3e-02, equal_nan=True)
 
 
 @pytest.mark.parametrize("B, C, D", testlist2)
@@ -180,7 +178,7 @@ def test_dot_2_ignore_tf32(sigtype, B, C, D):
         torch_npu.npu.matmul.allow_hf32 = original_allow_hf32
 
     triton_dot_2_ignore_tf32[1, 1, 1](z, x, y, B, C, D)
-    test_common.validate_cmp(sigtype, z, z_ref)
+    torch.testing.assert_close(z, z_ref, rtol=3e-02, atol=3e-02, equal_nan=True)
 
 
 # =============================================================================
@@ -256,21 +254,6 @@ class TestDotAscendPatch:
             rhs = _mock_tensor(tl.float32)
             patched(semantic, lhs, rhs, None, "hf32", None, tl.float32)
             assert mock_original.call_args[0][4] == "hf32"
-        finally:
-            cell.cell_contents = saved
-
-    def test_hf32_fp16_inputs_fallback_to_ieee(self, semantic):
-        """fp16 x fp16 + hf32 → falls back to ieee."""
-        patched = TritonSemantic.dot
-        mock_original = MagicMock(return_value=MagicMock())
-        cell = patched.__closure__[0]
-        saved = cell.cell_contents
-        cell.cell_contents = mock_original
-        try:
-            lhs = _mock_tensor(tl.float16)
-            rhs = _mock_tensor(tl.float16)
-            patched(semantic, lhs, rhs, None, "hf32", None, tl.float32)
-            assert mock_original.call_args[0][4] == "ieee"
         finally:
             cell.cell_contents = saved
 


### PR DESCRIPTION
The original logic is changed after the review, and the logic of the community is retained.
When allow_tf32 is set to True, the default value is hf32.
When allow_tf32 is set to True, the default value is ieee. If hf32 is required, you need to specify it.
|# |input_precision|fp32_default |allow_tf32|supports_tf32|Original Precision|Precision After Modification|Modification Scheme|
|----|---------------|--------------------|----------|-------------|------|------|------|
|1 | None | TRITON_F32_DEFAULT| - | - |TRITON_F32_DEFAULT|NA|TRITON_F32_DEFAULT|
|2 | None | None | True | False |hf32 |ieee|input_precision=hf32 is specified. |
|3 | None | None | False/None| False |ieee |ieee|NA|
|6 | ieee |- |- |- |ieee |ieee|NA|
|7 | tf32 |- |- |- |hf32 |hf32 |NA|
|9 | hf32 |- |- |- |hf32 |hf32 |NA|

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
