### PR TITLE
[TritonToLinalg](feat) Support masked load with tensor-type other

### DIFF
--- a/third_party/ascend/include/TritonToLinalg/LoadStoreConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/LoadStoreConverter.h
@@ -37,8 +37,6 @@
 
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 
-#include "triton/Dialect/Triton/IR/Dialect.h"
-
 namespace LoadStoreConverter {
 
 using namespace mlir;
@@ -73,6 +71,11 @@ private:
   fillTensorWithOtherForMaskScenario(Value other, Value localMem,
                                      ArrayRef<OpFoldResult> maskDim,
                                      ConversionPatternRewriter &rewriter) const;
+
+  LogicalResult
+  replaceMaskedLoadWithTensorOther(triton::LoadOp op, Value alloc,
+                                   bool mayImplicitTransposeWithLastAxis,
+                                   ConversionPatternRewriter &rewriter) const;
 
 public:
   explicit LoadConverter(MLIRContext *context);

--- a/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
@@ -227,6 +227,101 @@ void LoadConverter::fillTensorWithOtherForMaskScenario(
 LoadConverter::LoadConverter(MLIRContext *context)
     : OpConversionPattern<triton::LoadOp>(context) {}
 
+// Masked load whose `other` is a non-scalar tensor.
+// ---------------------------------------------------------------------------
+// Case 1: other = mask   (Python: tl.load(ptr, mask=mask, other=mask))
+//
+// DSL:
+//   mask = offs < N
+//   x = tl.load(in_ptr + offs, mask=mask, other=mask)
+//   tl.store(out_ptr + offs, x, mask=mask)
+//
+// TTIR (fp — uitofp; int — extui/extsi):
+//   %mask  = arith.cmpi slt, %offs, %N : tensor<Nx i1>
+//   %other = arith.uitofp %mask …            // or arith.extui for i8
+//   %x     = tt.load %ptr, %mask, %other
+//
+// Lowering (linalg):
+//   %alloc = memref.alloc()
+//   memref.copy %src_view, %dst_view         // active SRC only
+//   %loaded = bufferization.to_tensor %alloc
+//   %zeros  = linalg.fill 0                  // [OTHER] cast(mask)→0 on pad
+//   %x = arith.select %mask, %loaded, %zeros
+// ---------------------------------------------------------------------------
+// Case 2: other = prior tensor
+//   (Python: other = tl.load(fill_ptr+offs); x = tl.load(ptr, mask=mask,
+//   other=other); tl.store(out, x)  # full store — pad must stay OTHER)
+//
+// TTIR:
+//   %other = tt.load %fill_ptr
+//   %x     = tt.load %ptr, %mask, %other
+//
+// Lowering:
+//   %other_t = bufferization.to_tensor …    // prior load
+//   %alloc = memref.alloc()
+//   memref.copy …                           // active SRC
+//   %loaded = bufferization.to_tensor %alloc
+//   %x = arith.select %mask, %loaded, %other_t
+// ---------------------------------------------------------------------------
+LogicalResult LoadConverter::replaceMaskedLoadWithTensorOther(
+    triton::LoadOp op, Value alloc, bool mayImplicitTransposeWithLastAxis,
+    ConversionPatternRewriter &rewriter) const {
+  auto loc = op.getLoc();
+  auto tensorType = cast<RankedTensorType>(op.getResult().getType());
+  Value mask = op.getMask();
+  Value tensorOther = op.getOther();
+  if (!mask || !tensorOther) {
+    return rewriter.notifyMatchFailure(
+        op,
+        "replaceMaskedLoadWithTensorOther requires non-null mask and other");
+  }
+
+  Value loadedTensor = rewriter.create<bufferization::ToTensorOp>(
+      loc, tensorType, alloc, true, true);
+  propagateWasBoolToInt8Attr(op.getOperation(), loadedTensor.getDefiningOp(),
+                             rewriter);
+  if (mayImplicitTransposeWithLastAxis) {
+    auto markOp = rewriter.create<annotation::MarkOp>(loc, loadedTensor);
+    markOp->setAttr(MayImplicitTransposeWithLastAxisTAG,
+                    UnitAttr::get(rewriter.getContext()));
+  }
+
+  // Case 1: cast(mask) → inactive is 0. Cover fp (uitofp/sitofp) and int
+  // (extui/extsi). Case 2: keep prior tensor as-is.
+  Value otherVal = tensorOther;
+  if (Value remappedOther = rewriter.getRemappedValue(tensorOther))
+    otherVal = remappedOther;
+
+  bool otherIsZeroOnInactive = false;
+  if (auto uitofp = tensorOther.getDefiningOp<arith::UIToFPOp>())
+    otherIsZeroOnInactive = (uitofp.getIn() == mask);
+  else if (auto sitofp = tensorOther.getDefiningOp<arith::SIToFPOp>())
+    otherIsZeroOnInactive = (sitofp.getIn() == mask);
+  else if (auto extui = tensorOther.getDefiningOp<arith::ExtUIOp>())
+    otherIsZeroOnInactive = (extui.getIn() == mask);
+  else if (auto extsi = tensorOther.getDefiningOp<arith::ExtSIOp>())
+    otherIsZeroOnInactive = (extsi.getIn() == mask);
+
+  if (otherIsZeroOnInactive) {
+    auto empty = rewriter.create<tensor::EmptyOp>(loc, tensorType.getShape(),
+                                                  tensorType.getElementType());
+    Value zero = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getZeroAttr(tensorType.getElementType()));
+    otherVal =
+        rewriter
+            .create<linalg::FillOp>(loc, ValueRange{zero}, ValueRange{empty})
+            .getResult(0);
+  }
+
+  if (Value remappedMask = rewriter.getRemappedValue(mask))
+    mask = remappedMask;
+
+  Value result =
+      rewriter.create<arith::SelectOp>(loc, mask, loadedTensor, otherVal);
+  rewriter.replaceOp(op, result);
+  return success();
+}
+
 LogicalResult
 LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
                                ConversionPatternRewriter &rewriter) const {
@@ -477,15 +572,20 @@ LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
         op, "can not lower uncontinuout masked loads");
   }
 
+  Value tensorOtherBase;
   if (other) {
     auto scalarOther =
         mlir::ConverterUtils::getScalarValue(other, loc, rewriter);
-    assert(
-        scalarOther &&
-        "other value used in masked load produced by unsupported instruction!");
-
-    fillTensorWithOtherForMaskScenario(scalarOther, allocOp, mstate.dims,
-                                       rewriter);
+    if (scalarOther) {
+      fillTensorWithOtherForMaskScenario(scalarOther, allocOp, mstate.dims,
+                                         rewriter);
+    } else if (isa<RankedTensorType>(other.getType())) {
+      tensorOtherBase = other;
+    } else {
+      return rewriter.notifyMatchFailure(
+          op, "other value used in masked load produced by unsupported "
+              "instruction");
+    }
   }
 
   // To enable deinterleave optimization with mask load, mask state along last
@@ -494,7 +594,7 @@ LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
   //
   // The basis is that last dimension range comparison would generate
   // unaccepted discontinuous mask.
-  if (mstate.getRank() == memRefType.getRank() &&
+  if (!tensorOtherBase && mstate.getRank() == memRefType.getRank() &&
       isConstantIntValue(mstate.offsets.back(), 0) &&
       isConstantIntValue(mstate.dims.back(), memRefType.getShape().back())) {
     auto [ptrStrides, ptrOffsets] = memRefType.getStridesAndOffset();
@@ -540,8 +640,15 @@ LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
                       UnitAttr::get(rewriter.getContext()));
     }
   }
-  return this->toTensorAndReplace(
-      op, tensorType, allocOp, mayImplicitTransposeWithLastAxis, loc, rewriter);
+
+  if (!tensorOtherBase) {
+    return this->toTensorAndReplace(op, tensorType, allocOp,
+                                    mayImplicitTransposeWithLastAxis, loc,
+                                    rewriter);
+  }
+
+  return replaceMaskedLoadWithTensorOther(
+      op, allocOp, mayImplicitTransposeWithLastAxis, rewriter);
 }
 
 AtomicRMWConverter::AtomicRMWConverter(MLIRContext *context)

--- a/third_party/ascend/lib/TritonToLinalg/UseAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/UseAnalysis.cpp
@@ -553,6 +553,24 @@ LogicalResult triton::runUseAnalysis(triton::FuncOp &funcOp) {
       op->removeAttr("MetaUse");
     }
   });
+  // Masked load with non-scalar tensor `other` lowers as
+  // arith.select(mask, loaded, other) so the mask SSA must stay live.
+  funcOp.walk([&](triton::LoadOp load) {
+    Value mask = load.getMask();
+    Value other = load.getOther();
+    if (!mask || !other)
+      return;
+    if (other.getDefiningOp<triton::SplatOp>())
+      return;
+    if (auto c = other.getDefiningOp<arith::ConstantOp>()) {
+      if (auto dense = dyn_cast<DenseElementsAttr>(c.getValue())) {
+        if (dense.isSplat())
+          return;
+      }
+    }
+    if (auto *def = mask.getDefiningOp())
+      setMixUseRecursively(def);
+  });
   // hivm.custom present library call, shouldn't be metause
   funcOp.walk([&](hivm::CustomOp op) {
     if (isMetaUse(op)) {

--- a/third_party/ascend/lib/Utils/Utils.cpp
+++ b/third_party/ascend/lib/Utils/Utils.cpp
@@ -261,12 +261,7 @@ SmallVector<utils::IteratorType> getNParallelLoopsAttrs(unsigned n) {
 
 Value getScalarValue(Value operand, Location loc,
                      ConversionPatternRewriter &rewriter) {
-  // Peel splat / dense-splat / (s|u)itofp / truncf / select(pad, nan, zero)
-  // chains looking for a true scalar. Descriptor-load lowering emits
-  //   other = arith.select %padding, dense<nan>, dense<0>
-  // which must collapse to a scalar select so masked load can fill UB lanes.
-  // Returns nullptr when the value is a non-splat tensor so callers can fall
-  // back to a tensor-other path.
+  // Peel splat / cast / select chains down to a scalar; nullptr if non-splat tensor.
   SmallVector<Operation *> ops;
   auto reconstructScalarValue = [&](Value src) {
     for (auto op = ops.rbegin(); op != ops.rend(); ++op) {

--- a/third_party/ascend/lib/Utils/Utils.cpp
+++ b/third_party/ascend/lib/Utils/Utils.cpp
@@ -261,7 +261,8 @@ SmallVector<utils::IteratorType> getNParallelLoopsAttrs(unsigned n) {
 
 Value getScalarValue(Value operand, Location loc,
                      ConversionPatternRewriter &rewriter) {
-  // Peel splat / cast / select chains down to a scalar; nullptr if non-splat tensor.
+  // Peel splat / cast / select chains down to a scalar; nullptr if non-splat
+  // tensor.
   SmallVector<Operation *> ops;
   auto reconstructScalarValue = [&](Value src) {
     for (auto op = ops.rbegin(); op != ops.rend(); ++op) {

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_load_with_other.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_load_with_other.mlir
@@ -1,0 +1,173 @@
+// RUN: triton-opt --discrete-mask-access-conversion "--triton-to-linalg=global-kernel=false named-ops=True" --split-input-file %s | FileCheck %s
+
+// Case 1: other = uitofp(mask) -> select(mask, loaded, zeros)
+// CHECK-LABEL: func.func @load_other_mask
+// CHECK: %[[CST:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK: %[[MASK:.*]] = arith.cmpi slt
+// CHECK: %[[ALLOC:.*]] = memref.alloc() : memref<128xf32>
+// CHECK: memref.copy
+// CHECK: %[[LOADED:.*]] = bufferization.to_tensor %[[ALLOC]]
+// CHECK: linalg.fill ins(%[[CST]] : f32)
+// CHECK: arith.select %[[MASK]], %[[LOADED]], {{.*}}
+// CHECK-NOT: tensor.insert_slice
+
+module attributes {hacc.target = #hacc.target<"Ascend910B4">} {
+  tt.func public @load_other_mask(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32) attributes {noinline = false} {
+    %c128_i32 = arith.constant 128 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c128_i32 : i32
+    %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %3 = tt.splat %1 : i32 -> tensor<128xi32>
+    %4 = arith.addi %3, %2 : tensor<128xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<128xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<128xi32>
+    %7 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %8 = tt.addptr %7, %4 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    %9 = arith.uitofp %6 : tensor<128xi1> to tensor<128xf32>
+    %10 = tt.load %8, %6, %9 : tensor<128x!tt.ptr<f32>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %12 = tt.addptr %11, %4 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    tt.store %12, %10, %6 : tensor<128x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// -----
+
+// Case 1b: other = extui(mask) for int8 — same select with zeros.
+// CHECK-LABEL: func.func @load_other_mask_i8
+// CHECK: %[[CST:.*]] = arith.constant 0 : i8
+// CHECK: %[[MASK:.*]] = arith.cmpi slt
+// CHECK: %[[ALLOC:.*]] = memref.alloc() : memref<128xi8>
+// CHECK: memref.copy
+// CHECK: %[[LOADED:.*]] = bufferization.to_tensor %[[ALLOC]]
+// CHECK: linalg.fill ins(%[[CST]] : i8)
+// CHECK: arith.select %[[MASK]], %[[LOADED]], {{.*}}
+// CHECK-NOT: tensor.insert_slice
+
+module attributes {hacc.target = #hacc.target<"Ascend910B4">} {
+  tt.func public @load_other_mask_i8(%arg0: !tt.ptr<i8> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i8> {tt.divisibility = 16 : i32}, %arg2: i32) attributes {noinline = false} {
+    %c128_i32 = arith.constant 128 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c128_i32 : i32
+    %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %3 = tt.splat %1 : i32 -> tensor<128xi32>
+    %4 = arith.addi %3, %2 : tensor<128xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<128xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<128xi32>
+    %7 = tt.splat %arg0 : !tt.ptr<i8> -> tensor<128x!tt.ptr<i8>>
+    %8 = tt.addptr %7, %4 : tensor<128x!tt.ptr<i8>>, tensor<128xi32>
+    %9 = arith.extui %6 : tensor<128xi1> to tensor<128xi8>
+    %10 = tt.load %8, %6, %9 : tensor<128x!tt.ptr<i8>>
+    %11 = tt.splat %arg1 : !tt.ptr<i8> -> tensor<128x!tt.ptr<i8>>
+    %12 = tt.addptr %11, %4 : tensor<128x!tt.ptr<i8>>, tensor<128xi32>
+    tt.store %12, %10, %6 : tensor<128x!tt.ptr<i8>>
+    tt.return
+  }
+}
+
+// -----
+
+// Case 2: other = prior full load tensor -> select(mask, loaded, other)
+// CHECK-LABEL: func.func @load_other_tensor
+// CHECK: %[[MASK:.*]] = arith.cmpi slt
+// CHECK: memref.copy
+// CHECK: %[[OTHER:.*]] = bufferization.to_tensor
+// CHECK: %[[ALLOC:.*]] = memref.alloc() : memref<128xf32>
+// CHECK: memref.copy
+// CHECK: %[[LOADED:.*]] = bufferization.to_tensor %[[ALLOC]]
+// CHECK: arith.select %[[MASK]], %[[LOADED]], %[[OTHER]]
+// CHECK-NOT: tensor.insert_slice
+
+module attributes {hacc.target = #hacc.target<"Ascend910B4">} {
+  tt.func public @load_other_tensor(%in_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %out_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %fill_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %N: i32) attributes {noinline = false} {
+    %c128_i32 = arith.constant 128 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c128_i32 : i32
+    %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %3 = tt.splat %1 : i32 -> tensor<128xi32>
+    %4 = arith.addi %3, %2 : tensor<128xi32>
+    %5 = tt.splat %N : i32 -> tensor<128xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<128xi32>
+    %7 = tt.splat %fill_ptr : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %8 = tt.addptr %7, %4 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    %9 = tt.load %8 : tensor<128x!tt.ptr<f32>>
+    %10 = tt.splat %in_ptr : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %11 = tt.addptr %10, %4 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    %12 = tt.load %11, %6, %9 : tensor<128x!tt.ptr<f32>>
+    %13 = tt.splat %out_ptr : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %14 = tt.addptr %13, %4 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    tt.store %14, %12 : tensor<128x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// -----
+
+// Case 3: Scalar other=0.0 (unchanged fill path)
+// CHECK-LABEL: func.func @load_other_scalar_zero
+// CHECK: %[[CST:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK: %[[ALLOC:.*]] = memref.alloc() : memref<128xf32>
+// CHECK: linalg.fill ins(%[[CST]] : f32) outs(%[[ALLOC]] : memref<128xf32>)
+// CHECK: memref.copy
+// CHECK: bufferization.to_tensor %[[ALLOC]]
+
+module attributes {hacc.target = #hacc.target<"Ascend910B4">} {
+  tt.func public @load_other_scalar_zero(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32) attributes {noinline = false} {
+    %c128_i32 = arith.constant 128 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128xf32>
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c128_i32 : i32
+    %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %3 = tt.splat %1 : i32 -> tensor<128xi32>
+    %4 = arith.addi %3, %2 : tensor<128xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<128xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<128xi32>
+    %7 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %8 = tt.addptr %7, %4 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    %9 = tt.load %8, %6, %cst : tensor<128x!tt.ptr<f32>>
+    %10 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %11 = tt.addptr %10, %4 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    tt.store %11, %9, %6 : tensor<128x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// -----
+
+// Case 4: discrete mask (offs % 2 == 0) + other = prior tensor.
+// discrete-mask-access-conversion already rewrites to full load + arith.select.
+// CHECK-LABEL: func.func @load_other_tensor_discrete_mask
+// CHECK: memref.copy
+// CHECK: %[[OTHER:.*]] = bufferization.to_tensor
+// CHECK: memref.copy
+// CHECK: %[[LOADED:.*]] = bufferization.to_tensor
+// CHECK: arith.select {{.*}}, %[[LOADED]], %[[OTHER]]
+// CHECK-NOT: tensor.insert_slice
+
+module attributes {hacc.target = #hacc.target<"Ascend910B4">} {
+  tt.func public @load_other_tensor_discrete_mask(%in_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %out_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %other_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %N: i32) attributes {noinline = false} {
+    %c128_i32 = arith.constant 128 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c128_i32 : i32
+    %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %3 = tt.splat %1 : i32 -> tensor<128xi32>
+    %4 = arith.addi %3, %2 : tensor<128xi32>
+    %5 = tt.splat %c2_i32 : i32 -> tensor<128xi32>
+    %6 = arith.remsi %4, %5 : tensor<128xi32>
+    %7 = tt.splat %c0_i32 : i32 -> tensor<128xi32>
+    %8 = arith.cmpi eq, %6, %7 : tensor<128xi32>
+    %9 = tt.splat %other_ptr : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %10 = tt.addptr %9, %4 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    %11 = tt.load %10 : tensor<128x!tt.ptr<f32>>
+    %12 = tt.splat %in_ptr : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %13 = tt.addptr %12, %4 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    %14 = tt.load %13, %8, %11 : tensor<128x!tt.ptr<f32>>
+    %15 = tt.splat %out_ptr : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %16 = tt.addptr %15, %4 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    tt.store %16, %14 : tensor<128x!tt.ptr<f32>>
+    tt.return
+  }
+}

--- a/third_party/ascend/unittest/pytest_ut/test_load.py
+++ b/third_party/ascend/unittest/pytest_ut/test_load.py
@@ -114,3 +114,94 @@ def test_load_store_multi_d(param_list):
         shapes.append(1)
     triton_load_store_multi_d[(1, )](x0, y_actual, *blocks, *blocks, *shapes)
     test_common.validate_cmp(dtype, y_actual, y_expect)
+
+
+@triton.jit
+def triton_load_other_mask(in_ptr, out_ptr, N, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < N
+    x = tl.load(in_ptr + offs, mask=mask, other=mask)
+    tl.store(out_ptr + offs, x, mask=mask)
+
+
+@triton.jit
+def triton_load_other_scalar(in_ptr, out_ptr, N, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < N
+    x = tl.load(in_ptr + offs, mask=mask, other=0.0)
+    tl.store(out_ptr + offs, x, mask=mask)
+
+
+@triton.jit
+def triton_load_other_tensor(in_ptr, out_ptr, other_ptr, N, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < N
+    other = tl.load(other_ptr + offs)
+    x = tl.load(in_ptr + offs, mask=mask, other=other)
+    tl.store(out_ptr + offs, x)
+
+
+@triton.jit
+def triton_load_other_tensor_discrete_mask(in_ptr, out_ptr, other_ptr, N, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = (offs % 2) == 0
+    other = tl.load(other_ptr + offs)
+    x = tl.load(in_ptr + offs, mask=mask, other=other)
+    tl.store(out_ptr + offs, x)
+
+
+@pytest.mark.parametrize('param_list', [
+    ['float32', 1000, 128],
+    ['int8', 1000, 128],
+])
+def test_load_with_other_mask(param_list):
+    dtype, n, block = param_list
+    x = test_common.generate_tensor((n, ), dtype).npu()
+    out_mask = torch.empty(n, device='npu', dtype=getattr(torch, dtype))
+    out_zero = torch.empty(n, device='npu', dtype=getattr(torch, dtype))
+    grid = (triton.cdiv(n, block), )
+    triton_load_other_mask[grid](x, out_mask, n, block)
+    triton_load_other_scalar[grid](x, out_zero, n, block)
+    test_common.validate_cmp(dtype, out_mask, x)
+    test_common.validate_cmp(dtype, out_zero, x)
+    test_common.validate_cmp(dtype, out_mask, out_zero)
+
+
+@pytest.mark.parametrize('param_list', [
+    ['float32', 1000, 128],
+    ['int8', 1000, 128],
+])
+def test_load_with_other_tensor(param_list):
+    dtype, n, block = param_list
+    grid = (triton.cdiv(n, block), )
+    total = grid[0] * block
+    torch_dtype = getattr(torch, dtype)
+    x = test_common.generate_tensor((n, ), dtype).npu()
+    x_pad = torch.zeros(total, device='npu', dtype=torch_dtype)
+    x_pad[:n] = x
+    other = test_common.generate_tensor((total, ), dtype).npu()
+    out = torch.empty(total, device='npu', dtype=torch_dtype)
+    triton_load_other_tensor[grid](x_pad, out, other, n, block)
+    ref = other.clone()
+    ref[:n] = x
+    test_common.validate_cmp(dtype, out, ref)
+
+
+@pytest.mark.parametrize('param_list', [
+    ['float32', 1000, 128],
+    ['int8', 1000, 128],
+])
+def test_load_with_other_tensor_discrete_mask(param_list):
+    dtype, n, block = param_list
+    grid = (triton.cdiv(n, block), )
+    total = grid[0] * block
+    torch_dtype = getattr(torch, dtype)
+    x = test_common.generate_tensor((total, ), dtype).npu()
+    other = test_common.generate_tensor((total, ), dtype).npu()
+    out = torch.empty(total, device='npu', dtype=torch_dtype)
+    triton_load_other_tensor_discrete_mask[grid](x, out, other, n, block)
+    offs = torch.arange(total, device='npu')
+    mask = (offs % 2) == 0
+    ref = other.clone()
+    ref[mask] = x[mask]
+    test_common.validate_cmp(dtype, out, ref)


### PR DESCRIPTION
## Summary
`LoadConverter` previously only accepted scalar / splat `other` via `getScalarValue`, and failed on non-scalar tensor `other`.

This PR lowers masked `tt.load` with tensor `other` as:

```text
result = arith.select(mask, loaded, otherBase)
```

- **`mask`**: original `cmpi` mask; UseAnalysis clears `MetaUse` on this chain so it stays live for `select`
- **`loaded`**: active tile after masked copy (`memref.alloc` → masked `memref.copy` → `bufferization.to_tensor`); inactive lanes may be garbage and are ignored by `select`
- **`otherBase`**: false-arm — synthesized zeros when `other=mask`, otherwise the remapped prior tensor

> Prefer `select` over data `extract_slice` / `insert_slice`: continuous mask only copies the active prefix into the local tile; on the last (misaligned) tile, insert_slice is fragile through HIVM, while `select` keeps pad lanes as OTHER.

```mermaid
flowchart TD
  A["tt.load ptr, mask, other : tensor&lt;?xT&gt;"] --> B{"other = cast(mask)?"}
  B -->|yes Case1| C["otherBase = zeros"]
  B -->|no Case2| D["otherBase = other"]
  C --> E["select(mask, loaded, <br>otherBase)"]
  D --> E
```

>`getScalarValue` returns `nullptr` on non-splat tensor so the converter can enter this path.

## Examples

### 1) `other=mask`

**Python**
```python
mask = offs < N
x = tl.load(in_ptr + offs, mask=mask, other=mask)
tl.store(out_ptr + offs, x, mask=mask)
```

**TTIR**
```mlir
%mask  = arith.cmpi slt, %offs, %N : tensor<128xi1>
%other = arith.uitofp %mask : tensor<128xi1> to tensor<128xf32>
%x     = tt.load %ptr, %mask, %other : tensor<128x!tt.ptr<f32>>
tt.store %out, %x, %mask
```

**After `triton-to-linalg`**
```mlir
%mask = arith.cmpi slt, …              // kept live (MetaUse cleared)
%tile = memref.alloc() : memref<128xf32>
memref.copy %src_view, %dst_view       // active region only
%loaded = bufferization.to_tensor %tile
%zeros  = linalg.fill 0 into tensor.empty
%x      = arith.select %mask, %loaded, %zeros
```

### 2) `other=tensor` (prior load)

**Python**
```python
other = tl.load(fill_ptr + offs)
x = tl.load(in_ptr + offs, mask=mask, other=other)
tl.store(out_ptr + offs, x)  # full store — pad must stay OTHER
```

**After `triton-to-linalg`**
```mlir
%other_t = bufferization.to_tensor …   // prior load
%tile = memref.alloc()
memref.copy …                          // active SRC
%loaded = bufferization.to_tensor %tile
%x = arith.select %mask, %loaded, %other_t
```

### 3) `other=0.0` (unchanged scalar path)

```mlir
%tile = memref.alloc()
scf.if %need_pad { linalg.fill 0 outs(%tile) } {hivm.unlikely_condition}
memref.copy (masked)
bufferization.to_tensor %tile
```

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
	[rules](https://cbea.ms/git-commit/#why-not-how).
- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
	- [ ] This PR does not need a test because …
	- [x] I have added tests.
		- `unittest/pytest_ut` for end-to-end NPU tests
		- `unittest/Conversion/General/TritonToLinalg` lit FileCheck
- Select one of the following.
	- [ ] I have not added any `lit` tests.
	- [x] The `lit` tests I have added follow FileCheck best practices (minimal TTIR kernels).
