### PR TITLE
[TritonToLinalg](fix) enhance verification of load with discreteMemAcess

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
@@ -313,7 +313,11 @@ LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
 
   Value allocOp;
   Value allocOpTmp;
-  if (op->hasAttr(ConverterUtils::discreteAttrName)) {
+  auto parentLoop = dyn_cast<scf::ForOp>(op->getParentOp());
+  bool hasValidDiscreteLoop = op->hasAttr(ConverterUtils::discreteAttrName) &&
+                              parentLoop &&
+                              parentLoop->hasAttr("ExtractedLoadOrStore");
+  if (hasValidDiscreteLoop) {
     Operation *loop = op->getParentOp();
     int extractedLoopCount = 1;
     for (auto parentOp = loop->getParentOp();

--- a/third_party/ascend/unittest/pytest_ut/test_gather_gemv.py
+++ b/third_party/ascend/unittest/pytest_ut/test_gather_gemv.py
@@ -1,0 +1,116 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import pytest
+import torch
+import torch_npu
+import triton
+import triton.language as tl
+import test_common
+
+
+def torch_gather_gemv(weight, indices, vector):
+    """Reference: gather matrices from weight by indices (with negative clamping),
+    then do batched matrix-vector multiply.
+
+    Args:
+        weight:  (B, S, S) float16
+        indices: (N,) int64, values in [-B, B-1]
+        vector:  (S,) float16
+    Returns:
+        result:  (N, S) float16
+    """
+    B = weight.shape[0]
+    indices_clamped = torch.where(indices < 0, indices + B, indices)
+    gathered = weight[indices_clamped].float()  # (N, S, S)
+    result = torch.matmul(gathered, vector.float().unsqueeze(-1)).squeeze(-1)
+    return result.to(torch.float16)
+
+
+@triton.jit
+def triton_gather_gemv_kernel(
+    in_ptr0,  # indices: (N,) int64
+    in_ptr1,  # weight:  (B, S, S) float16
+    in_ptr2,  # vector:  (S,) float16
+    out_ptr1,  # output:  (N*S,) float16
+    xnumel,
+    rnumel,
+    XBLOCK: tl.constexpr,
+    RBLOCK: tl.constexpr,
+):
+    xoffset = tl.program_id(0).to(tl.int64) * XBLOCK
+    xindex = xoffset + tl.arange(0, XBLOCK)[:, None].to(tl.int64)
+    rbase = tl.arange(0, RBLOCK)[None, :].to(tl.int64)
+    x0 = xindex
+    tmp0 = tl.load(in_ptr0 + (x0 // rnumel), None, eviction_policy="evict_last")
+    _tmp11 = tl.full([XBLOCK, RBLOCK], 0, tl.float32)
+    for roffset in range(0, rnumel, RBLOCK):
+        rindex = roffset + rbase
+        r1 = rindex
+        tmp7 = tl.load(in_ptr2 + (r1), None, eviction_policy="evict_last").to(tl.float32)
+        tmp1 = tmp0 + 8
+        tmp2 = tmp0 < 0
+        tmp3 = tl.where(tmp2, tmp1, tmp0)
+        tmp4 = tl.load(
+            in_ptr1 + (r1 + (rnumel * (x0 % rnumel)) + (rnumel * rnumel * tmp3)),
+            None,
+            eviction_policy="evict_first",
+        )
+        tmp5 = tmp4.to(tl.float32)
+        tmp8 = tmp7.to(tl.float32)
+        tmp9 = tmp5 * tmp8
+        tmp10 = tl.broadcast_to(tmp9, [XBLOCK, RBLOCK])
+        tmp12 = _tmp11 + tmp10
+        _tmp11 = tmp12
+    tmp11 = tl.sum(_tmp11, 1)[:, None]
+    tmp13 = tmp11.to(tl.float32)
+    tl.store(out_ptr1 + (x0), tmp13, None)
+
+
+@pytest.mark.parametrize('S', [2048])
+@pytest.mark.parametrize('config', [(1, 2048), (64, 8)], ids=['xblock1_rblock2048', 'xblock64_rblock8'])
+def test_gather_gemv(S, config):
+    XBLOCK, RBLOCK = config
+    B = 8
+    N = 2
+
+    indices = torch.randint(0, B, (N, ), dtype=torch.int64).npu()
+    weight = test_common.generate_tensor((B, S, S), 'float16').npu()
+    vector = test_common.generate_tensor((S, ), 'float16').npu()
+
+    xnumel = N * S
+    rnumel = S
+    out = torch.empty((xnumel, ), dtype=torch.float16).npu()
+    grid = (triton.cdiv(xnumel, XBLOCK), )
+    triton_gather_gemv_kernel[grid](
+        indices,
+        weight,
+        vector,
+        out,
+        xnumel,
+        rnumel,
+        XBLOCK=XBLOCK,
+        RBLOCK=RBLOCK,
+        num_stages=1,
+        num_warps=8,
+    )
+    triton_res = out.view(N, S)
+    torch_res = torch_gather_gemv(weight, indices, vector)
+    test_common.validate_cmp("float16", triton_res, torch_res)


### PR DESCRIPTION
### 背景
benchmark 算子仓用例报错，是因为离散访存被被Canonicalize优化掉，变为连续访存，但是load仍然带了DiscreteMemAccess的标志，导致进入了错误的循环，需要在load with DiscreteMemAccess增强校验，避免连续访存进入DiscreteMemAccess 分支。

- 测试case经过TritonToUnstrcure Pass后
  ```
  %tmp4_14 = tt.broadcast %tmp4_13 : tensor<1x1xi64> -> tensor<1x2048xi64> loc(#loc61)
    %_tmp11_15 = scf.for %_tmp11_17 = %c0_i32 to %rnumel step %c2048_i32 iter_args(%_tmp11_18 = %_tmp11) -> (tensor<1x2048xf32>)  : i32 {
      %rindex = arith.extsi %_tmp11_17 : i32 to i64 loc(#loc63)
      %rindex_19 = tt.splat %rindex : i64 -> tensor<1x2048xi64> loc(#loc63)
      %rindex_20 = arith.addi %rindex_19, %rbase_3 : tensor<1x2048xi64> loc(#loc63)
      %tmp7_21 = tt.addptr %tmp7, %rindex_20 : tensor<1x2048x!tt.ptr<bf16>>, tensor<1x2048xi64> loc(#loc52)
      %tmp7_22 = tt.load %tmp7_21 evictionPolicy = evict_last : tensor<1x2048x!tt.ptr<bf16>> loc(#loc64)
      %tmp7_23 = arith.extf %tmp7_22 : tensor<1x2048xbf16> to tensor<1x2048xf32> loc(#loc65)
      %tmp4_24 = arith.addi %rindex_20, %tmp4_9 : tensor<1x2048xi64> loc(#loc58)
      %tmp4_25 = arith.addi %tmp4_24, %tmp4_14 : tensor<1x2048xi64> loc(#loc61)
      %tmp4_26 = tensor.empty() : tensor<1x2048xi8> loc(#loc66)
      %tmp4_27 = scf.for %tmp4_28 = %c0 to %c1 step %c1 iter_args(%tmp4_29 = %tmp4_26) -> (tensor<1x2048xi8>) {
        %tmp4_30 = tensor.extract_slice %tmp4_25[%tmp4_28, 0] [1, 2048] [1, 1] {DiscreteMemAccess} : tensor<1x2048xi64> to tensor<1x2048xi64> loc(#loc66)
        %tmp4_31 = tt.splat %in_ptr1 : !tt.ptr<i8> -> tensor<1x2048x!tt.ptr<i8>> loc(#loc66)
        %tmp4_32 = tt.addptr %tmp4_31, %tmp4_30 : tensor<1x2048x!tt.ptr<i8>>, tensor<1x2048xi64> loc(#loc66)
        %tmp4_33 = tt.load %tmp4_32 evictionPolicy = evict_first {DiscreteMemAccess} : tensor<1x2048x!tt.ptr<i8>> loc(#loc66)
        %tmp4_34 = tensor.insert_slice %tmp4_33 into %tmp4_29[%tmp4_28, 0] [1, 2048] [1, 1] : tensor<1x2048xi8> into tensor<1x2048xi8> loc(#loc66)
        scf.yield {DiscreteMemAccess} %tmp4_34 : tensor<1x2048xi8> loc(#loc66)
      } {ExtractedLoadOrStore} loc(#loc66)
      %tmp5 = arith.sitofp %tmp4_27 : tensor<1x2048xi8> to tensor<1x2048xf32> loc(#loc67)
      %tmp9 = arith.mulf %tmp5, %tmp7_23 : tensor<1x2048xf32> loc(#loc68)
      %tmp12 = arith.addf %_tmp11_18, %tmp9 : tensor<1x2048xf32> loc(#loc69)
      scf.yield %tmp12 : tensor<1x2048xf32> loc(#loc29)
    } loc(#loc62)
    %tmp11 = "tt.reduce"(%_tmp11_15) <{axis = 1 : i32}> ({
但由于第2个for循环step为1，经过Canonicalizer (canonicalize)被优化成

 ```
%tmp4_14 = tt.broadcast %tmp4_13 : tensor<1x1xi64> -> tensor<1x2048xi64> loc(#loc61)
    %_tmp11_15 = scf.for %_tmp11_17 = %c0_i32 to %rnumel step %c2048_i32 iter_args(%_tmp11_18 = %_tmp11) -> (tensor<1x2048xf32>)  : i32 {
      %rindex = arith.extsi %_tmp11_17 : i32 to i64 loc(#loc63)
      %rindex_19 = tt.splat %rindex : i64 -> tensor<1x2048xi64> loc(#loc63)
      %rindex_20 = arith.addi %rindex_19, %rbase_3 : tensor<1x2048xi64> loc(#loc63)
      %tmp7_21 = tt.addptr %tmp7, %rindex_20 : tensor<1x2048x!tt.ptr<bf16>>, tensor<1x2048xi64> loc(#loc52)
      %tmp7_22 = tt.load %tmp7_21 evictionPolicy = evict_last : tensor<1x2048x!tt.ptr<bf16>> loc(#loc64)
      %tmp7_23 = arith.extf %tmp7_22 : tensor<1x2048xbf16> to tensor<1x2048xf32> loc(#loc65)
      %tmp4_24 = arith.addi %rindex_20, %tmp4_9 : tensor<1x2048xi64> loc(#loc58)
      %tmp4_25 = arith.addi %tmp4_24, %tmp4_14 : tensor<1x2048xi64> loc(#loc61)
      %tmp4_26 = tt.splat %in_ptr1 : !tt.ptr<i8> -> tensor<1x2048x!tt.ptr<i8>> loc(#loc66)
      %tmp4_27 = tt.addptr %tmp4_26, %tmp4_25 : tensor<1x2048x!tt.ptr<i8>>, tensor<1x2048xi64> loc(#loc66)
      %tmp4_28 = tt.load %tmp4_27 evictionPolicy = evict_first {DiscreteMemAccess} : tensor<1x2048x!tt.ptr<i8>> loc(#loc66)
      %tmp5 = arith.sitofp %tmp4_28 : tensor<1x2048xi8> to tensor<1x2048xf32> loc(#loc67)
      %tmp9 = arith.mulf %tmp5, %tmp7_23 : tensor<1x2048xf32> loc(#loc68)
      %tmp12 = arith.addf %_tmp11_18, %tmp9 : tensor<1x2048xf32> loc(#loc69)
      scf.yield %tmp12 : tensor<1x2048xf32> loc(#loc29)
    } loc(#loc62)
```
此时已是连续访存，但  %tmp4_28 tt.load带了DiscreteMemAccess的标签，在TritonToLinalg pass 中进入了load with discreteMemAcess分支，会报错，这种场景应该走连续访存的load, 故增强进入load with discreteMemAcess的进入条件，修复此问题



