### PR TITLE
[Autotune](feat) autotune disk cache capability support

### DIFF
--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -222,6 +222,7 @@ class AutoTilingTuner(Autotuner):
         rep=None,
         use_cuda_graph=False,
         do_bench=None,
+        cache_results=False,
         auto_profile_dir=None,
         hints=None,
     ):
@@ -251,6 +252,7 @@ class AutoTilingTuner(Autotuner):
             rep,
             use_cuda_graph,
             do_bench,
+            cache_results=cache_results,
         )
         self.user_defined_do_bench = do_bench is not None
         self.hints = reserved_hints
@@ -2050,15 +2052,35 @@ class AutoTilingTuner(Autotuner):
             # prune configs
             pruned_configs = self.prune_configs(kwargs)
             if self.enable_ubtuner or len(pruned_configs) > 1:
-                used_cached_result = False
-                bench_start = time.time()
-                timings = self._batch_bench(*args, configs=pruned_configs, **kwargs)
-                bench_end = time.time()
-                self.bench_time = bench_end - bench_start
-                self.cache[key] = builtins.min(timings, key=timings.get)
-                full_nargs = {**self.nargs, **kwargs, **self.cache[key].all_kwargs()}
-                self.pre_hook(full_nargs, reset_only=True)
-                self.configs_timings = timings
+
+                def benchmark():
+                    nonlocal used_cached_result
+                    used_cached_result = False
+                    bench_start = time.time()
+                    timings = self._batch_bench(*args, configs=pruned_configs, **kwargs)
+                    bench_end = time.time()
+                    self.bench_time = bench_end - bench_start
+                    self.cache[key] = builtins.min(timings, key=timings.get)
+                    full_nargs = {**self.nargs, **kwargs, **self.cache[key].all_kwargs()}
+                    self.pre_hook(full_nargs, reset_only=True)
+                    self.configs_timings = timings
+
+                if self.cache_results:
+                    if self.enable_ubtuner:
+                        warnings.warn(
+                            "Autotune disk cache is disabled because UB-tuner is enabled "
+                            "(TRITON_ENABLE_UBTUNER is set). UB-tuner may dynamically add "
+                            "compile-time fixes to configs that cannot be safely cached to disk. "
+                            "To enable disk caching, unset TRITON_ENABLE_UBTUNER.",
+                            RuntimeWarning,
+                            stacklevel=2,
+                        )
+                        benchmark()
+                    else:
+                        used_cached_result = self.check_disk_cache(key, pruned_configs, benchmark)
+                else:
+                    benchmark()
+
                 config = self.cache[key]
             else:
                 config = pruned_configs[0]
@@ -2509,7 +2531,8 @@ class AutoTilingTuner(Autotuner):
 
 
 def autotune(configs, key, prune_configs_by=None, reset_to_zero=None, restore_value=None, pre_hook=None, post_hook=None,
-             warmup=None, rep=None, use_cuda_graph=False, do_bench=None, *, auto_prof_dir=None, hints=None):
+             warmup=None, rep=None, use_cuda_graph=False, do_bench=None, cache_results=False, *, auto_prof_dir=None,
+             hints=None):
     """
     Decorator for auto-tuning a :code:`triton.jit`'d function.
 
@@ -2563,6 +2586,8 @@ def autotune(configs, key, prune_configs_by=None, reset_to_zero=None, restore_va
     :type rep: int
     :param do_bench: a benchmark function to measure the time of each run.
     :type do_bench: lambda fn, quantiles
+    :param cache_results: whether to cache autotune timings to disk.  Defaults to False.
+    :type cache_results: bool
     :param auto_prof_dir: the specified directory to store the profiling results of the best config.
         If this parameter is None or the best config is retrieved from cache, the profiling process will be ignored.
     :type auto_prof_dir: str
@@ -2572,8 +2597,8 @@ def autotune(configs, key, prune_configs_by=None, reset_to_zero=None, restore_va
     def decorator(fn):
         return AutoTilingTuner(fn, fn.arg_names, configs, key, reset_to_zero, restore_value, pre_hook=pre_hook,
                                post_hook=post_hook, prune_configs_by=prune_configs_by, warmup=warmup, rep=rep,
-                               use_cuda_graph=use_cuda_graph, do_bench=do_bench, auto_profile_dir=auto_prof_dir,
-                               hints=hints)
+                               use_cuda_graph=use_cuda_graph, do_bench=do_bench, cache_results=cache_results,
+                               auto_profile_dir=auto_prof_dir, hints=hints)
 
     return decorator
 


### PR DESCRIPTION
## Background

Issue [#1345](https://github.com/triton-lang/triton-ascend/issues/1345) revealed that triton-ascend's autotune mechanism lacks cross-process disk caching: autotune results are stored only in Python process memory (`self.cache` dict), meaning every new process must re-run the full benchmark even for the same kernel with the same inputs.

This capability was introduced in upstream triton v3.4.0 (PR [#6261](https://github.com/triton-lang/triton/pull/6261)) via `Autotuner.check_disk_cache()` and the `cache_results` parameter / `TRITON_CACHE_AUTOTUNING` environment variable. triton-ascend has recently upgraded to the upstream v3.6 codebase, but the Ascend `AutoTilingTuner` — which overrides `Autotuner.run()` for NPU-specific auto-tiling — did not integrate this disk cache capability during the upgrade.

## Gap Analysis

### Upstream Triton Flow

```mermaid
flowchart LR
    A[run] --> B{configs > 1?}
    B -->|no| C[use single config]
    B -->|yes| D[build tuning key]
    D --> E{memory cache hit?}
    E -->|hit| F[use cached best config]
    E -->|miss| G[prune configs]
    G --> H{cache_results enabled?}
    H -->|yes| I[check_disk_cache]
    I --> J{disk cache hit?}
    J -->|hit| K[restore from JSON]
    J -->|miss| L[run benchmark]
    L --> M[write JSON to disk]
    K --> F
    H -->|no| L
    F --> N[execute kernel with best config]
    C --> N
```

### Triton-Ascend Flow (Before This PR)

```mermaid
flowchart LR
    A[run] --> B[generate_key_and_configs]
    B --> C{memory cache hit?}
    C -->|hit| D[use cached best config]
    C -->|miss| E[prune configs]
    E --> F{>1 config or ubtuner?}
    F -->|yes| G["_batch_bench (parallel compile + benchmark)"]
    G --> H[store to memory cache]
    H --> D
    F -->|no| I[use single config]
    D --> J[execute kernel with best config]
```

The gap is clear: Triton-Ascend's `run()` has **no disk cache path**. When `cache_results` is enabled (via `TRITON_CACHE_AUTOTUNING=1` or the decorator parameter), the upstream flow checks disk before benchmarking; the Ascend flow always benchmarks on memory miss, never persists results, and never reads them back.

## Changes

All changes are in a single file: `third_party/ascend/backend/runtime/autotuner.py`.

### 1. `AutoTilingTuner.__init__` — accept and forward `cache_results`

Add `cache_results=False` parameter and pass it through to `super().__init__()`. The parent `Autotuner` already handles `cache_results` (including the `TRITON_CACHE_AUTOTUNING` env var fallback via `knobs.autotuning.cache`), so no new logic is needed.

### 2. Ascend `autotune()` decorator — accept `cache_results`

Add the `cache_results=False` keyword argument to the Ascend `autotune()` decorator and forward it to `AutoTilingTuner`. This allows per-kernel opt-in (`@triton.autotune(..., cache_results=True)`) in addition to the global `TRITON_CACHE_AUTOTUNING=1`.

### 3. `AutoTilingTuner.run()` — integrate `check_disk_cache()`

Wrap the existing `_batch_bench` + cache-store logic into a `benchmark()` closure, then conditionally route through the parent's `check_disk_cache()`:

```python
if self.cache_results:
    used_cached_result = self.check_disk_cache(key, pruned_configs, benchmark)
else:
    benchmark()
```

On disk hit, `check_disk_cache()` restores `self.cache[key]` and `self.configs_timings` from JSON; `benchmark()` is never called. On miss, it calls `benchmark()` then writes the JSON.

### After This PR

```mermaid
flowchart LR
    A[run] --> B[generate_key_and_configs]
    B --> C{memory cache hit?}
    C -->|hit| D[use cached best config]
    C -->|miss| E[prune configs]
    E --> F{>1 config or ubtuner?}
    F -->|yes| G{cache_results enabled?}
    G -->|no| K["_batch_bench (parallel compile + benchmark)"]
    G -->|yes| UB{UB-tuner enabled?}
    UB -->|yes| WARN[emit Warning, skip disk cache]
    WARN --> K
    UB -->|no| H["check_disk_cache(key, configs, benchmark)"]
    H --> I{disk cache hit?}
    I -->|hit| J[restore from JSON]
    I -->|miss| K
    K --> L[store to memory cache]
    L --> M[write JSON to disk]
    J --> D
    M --> D
    F -->|no| N[use single config]
    D --> O[execute kernel with best config]

    style G fill:#4CAF50,stroke:#2E7D32,color:#fff
    style UB fill:#4CAF50,stroke:#2E7D32,color:#fff
    style WARN fill:#FF9800,stroke:#E65100,color:#fff
    style H fill:#4CAF50,stroke:#2E7D32,color:#fff
    style I fill:#4CAF50,stroke:#2E7D32,color:#fff
    style J fill:#4CAF50,stroke:#2E7D32,color:#fff
    style M fill:#4CAF50,stroke:#2E7D32,color:#fff
```

The added path mirrors the upstream flow exactly, reusing the parent class's existing `check_disk_cache()` implementation.

## Functional Tests

All tests use `third_party/ascend/unittest/autotune_ut/01-vector-add.py`, which already contains `@triton.autotune(configs=[], key=["n_elements"])` (auto-gen config mode).

### Test 1: Enable disk cache via environment variable

```bash
export TRITON_CACHE_AUTOTUNING=1

# Step 1: Clear cache, first run — should run benchmark and write disk cache
rm -rf ~/.triton/cache
python third_party/ascend/unittest/autotune_ut/01-vector-add.py

# Step 2: Keep cache, second run (new process) — should hit disk cache, skip benchmark
python third_party/ascend/unittest/autotune_ut/01-vector-add.py
```

**Expected**: Step 1 takes ~8s (benchmark runs), Step 2 takes ~0.6s (cache hit), both output `Vector Add 98432 PASSED!`.

<img width="865" height="267" alt="image" src="https://github.com/user-attachments/assets/ff50cd71-46a8-463f-9830-e90a94d4eec4" />


### Test 2: Enable disk cache via decorator parameter

Modify `01-vector-add.py` line 35, add `cache_results=True` to `@triton.autotune(...)`:

```python
# Before:
@triton.autotune(configs=[], key=["n_elements"])

# After:
@triton.autotune(configs=[], key=["n_elements"], cache_results=True)
```

```bash
# Step 1: First run
rm -rf ~/.triton/cache
python third_party/ascend/unittest/autotune_ut/01-vector-add.py

# Step 2: Second run (new process)
python third_party/ascend/unittest/autotune_ut/01-vector-add.py
```

**Expected**: Same behavior as Test 1. Revert `cache_results=True` when done.

<img width="865" height="410" alt="image" src="https://github.com/user-attachments/assets/c805f297-4930-46f0-bdff-19af84efac2e" />


### Test 3: UB-tuner coexistence

```bash
export TRITON_CACHE_AUTOTUNING=1
export TRITON_ENABLE_UBTUNER=compile

rm -rf ~/.triton/cache
python third_party/ascend/unittest/autotune_ut/01-vector-add.py
```

**Expected**: Outputs a RuntimeWarning indicating disk cache is disabled due to UB-tuner, and completes benchmarking normally:

```
RuntimeWarning: Autotune disk cache is disabled because UB-tuner is enabled ...
```

<img width="865" height="241" alt="image" src="https://github.com/user-attachments/assets/2d49279a-5ef2-4aa9-a661-8a7d48ed621f" />


## Usage

```bash
# Global: all autotune kernels cache to disk
export TRITON_CACHE_AUTOTUNING=1

# Per-kernel: only this kernel caches to disk
@triton.autotune(configs=[...], key=[...], cache_results=True)
```

## Limitations

UB-tuner (`TRITON_ENABLE_UBTUNER`) dynamically modifies config objects (injecting `ubtune_cfg` attribute) at runtime to fix UB overflow compilation failures. This attribute cannot be safely handled by the community `check_disk_cache()` JSON serialization/deserialization path (`Config.__init__` does not accept `ubtune_cfg` as a keyword argument).

Therefore, **disk cache is automatically disabled when UB-tuner is enabled**, with the following Warning:

```
RuntimeWarning: Autotune disk cache is disabled because UB-tuner is enabled
(TRITON_ENABLE_UBTUNER is set). UB-tuner may dynamically add compile-time
fixes to configs that cannot be safely cached to disk.
To enable disk caching, unset TRITON_ENABLE_UBTUNER.
```

To enable disk caching, unset `TRITON_ENABLE_UBTUNER`.
