### PR TITLE
[TritonToLinalg](fix) add scope dialect as a legal IR

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -57,6 +57,7 @@
 
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "bishengir/Dialect/Scope/IR/Scope.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
@@ -512,13 +513,13 @@ void TritonToLinalgPass::convertTTFunc(triton::FuncOp func, const bool existDot,
 
 void TritonToLinalgPass::addDynamicLegal(
     ConversionTarget &target, TritonTypeConverter &tritonTypeConverter) {
-  target.addLegalDialect<func::FuncDialect, arith::ArithDialect,
-                         math::MathDialect, linalg::LinalgDialect,
-                         affine::AffineDialect, scf::SCFDialect,
-                         cf::ControlFlowDialect, tensor::TensorDialect,
-                         LLVM::LLVMDialect, bufferization::BufferizationDialect,
-                         memref::MemRefDialect, annotation::AnnotationDialect,
-                         hivm::HIVMDialect, hfusion::HFusionDialect>();
+  target.addLegalDialect<
+      func::FuncDialect, arith::ArithDialect, math::MathDialect,
+      linalg::LinalgDialect, affine::AffineDialect, scf::SCFDialect,
+      cf::ControlFlowDialect, tensor::TensorDialect, LLVM::LLVMDialect,
+      bufferization::BufferizationDialect, memref::MemRefDialect,
+      annotation::AnnotationDialect, hivm::HIVMDialect, hfusion::HFusionDialect,
+      scope::ScopeDialect>();
 
   // add legal dialect on condition
   target.addLegalOp<ModuleOp>();
@@ -756,11 +757,12 @@ void TritonToLinalgPass::populateTritonToLinalgConversionPatterns(
 }
 
 void TritonToLinalgPass::getDependentDialects(DialectRegistry &registry) const {
-  registry.insert<func::FuncDialect, arith::ArithDialect, math::MathDialect,
-                  linalg::LinalgDialect, affine::AffineDialect, scf::SCFDialect,
-                  tensor::TensorDialect, bufferization::BufferizationDialect,
-                  memref::MemRefDialect, hfusion::HFusionDialect,
-                  hivm::HIVMDialect, annotation::AnnotationDialect>();
+  registry
+      .insert<func::FuncDialect, arith::ArithDialect, math::MathDialect,
+              linalg::LinalgDialect, affine::AffineDialect, scf::SCFDialect,
+              tensor::TensorDialect, bufferization::BufferizationDialect,
+              memref::MemRefDialect, hfusion::HFusionDialect, hivm::HIVMDialect,
+              annotation::AnnotationDialect, scope::ScopeDialect>();
 }
 
 LogicalResult


### PR DESCRIPTION
## Background

In simd and simt mix compile scenario, OPs could be wrapped by a "scope.scope" OP like below:
```
...
%7:3 = scope.scope : () -> (tensor<1024xf32>, tensor<1024xf32>, tensor<1024xi8>) {
  %a = tt.splat %M : i32 -> tensor<1024xi32> loc(#loc88)
  %a_24 = arith.cmpi slt, %input_offset_16, %a : tensor<1024xi32> loc(#loc88)
...
  %exp_39 = arith.andi %exp_37, %exp_38 : tensor<1024xi1> loc(#loc104)
  %exp_40 = tt.addptr %a_30, %exp_offset_18 : tensor<1024x!tt.ptr<i8>>, tensor<1024xi32> loc(#loc105)
  %exp_41 = tt.load %exp_40, %exp_39, %cst : tensor<1024x!tt.ptr<i8>> loc(#loc106)
  scope.return %low_fp32_35, %high_fp32_36, %exp_41 : tensor<1024xf32>, tensor<1024xf32>, tensor<1024xi8> loc(#loc106)
} {noinline, vector_type = "simt"} loc(#loc27)
...
```

## Problem
TA considers "scope.scope" as a illegal OP, and trying to lowering it, but failed:
```
[dialect-conversion:1]     //===-------------------------------------------===//
[dialect-conversion:1]
[dialect-conversion:1]     //===-------------------------------------------===//
[dialect-conversion:1]     Legalizing operation : 'scope.scope' (0x55bd83156c30) {
[dialect-conversion:1]       * Fold {
[dialect-conversion:1]       } -> FAILURE : unable to fold
[dialect-conversion:1]
[dialect-conversion:1]       * Pattern : 'scope.scope -> ()' {
[pattern-application PatternApplicator.cpp:209 1] Trying to match "mlir::triton::MetaUseEraser"
Number of user: 3
[dialect-conversion:1]         ** Failure : requires meta ops
[pattern-application PatternApplicator.cpp:224 1]  -> matchAndRewrite failed
[dialect-conversion:1]       } -> FAILURE : pattern failed to match
[dialect-conversion:1]     } -> FAILURE : no matched legalization pattern
[dialect-conversion:1]     //===-------------------------------------------===//
[dialect-conversion:1]   } -> FAILURE : failed to legalize generated operation 'scope.scope'(0x000055BD83156C30)
[dialect-conversion:1] } -> FAILURE : pattern failed to match
[dialect-conversion:1] } -> FAILURE : no matched legalization pattern
[dialect-conversion:1] //===-------------------------------------------===//
[dialect-conversion:1]
[dialect-conversion:1] //===-------------------------------------------===//
```

## What we need
In mix compile, we need "scope.scope" passed straight to lower layer, So TA should consider it as a legal OP, do not convert it.

## Explain
This PR include a extra commit for "pre-commit" pipeline 

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
