### PR TITLE
[DiscreteMaskAccess](fix) preserve masked atomic semantics across modes

### DIFF
--- a/third_party/ascend/include/Utils/Utils.h
+++ b/third_party/ascend/include/Utils/Utils.h
@@ -47,6 +47,7 @@ namespace ConverterUtils {
 
 const std::string GeneratedByMakeTensorPtrTAG = "GeneratedByMakeTensorPtr";
 const std::string discreteMaskAttrName = "DiscreteMask";
+const std::string preserveAtomicMaskAttrName = "PreserveAtomicMask";
 const std::string discreteAttrName = "DiscreteMemAccess";
 const std::string continuousAttrName = "ContinuousMemAccess";
 const std::string customSrcPtrIndexAttrName = "SrcPtrIndex";

--- a/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
+++ b/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
@@ -173,7 +173,8 @@ static bool checkAllProgramIdNonOverlap(ModuleOp module) {
 
 LogicalResult isDiscreteMask(Operation *op, Value mask,
                              PatternRewriter &rewriter) {
-  if (!mask || op->hasAttr(routeDiscreteMaskToSimtAttrName)) {
+  if (!mask || op->hasAttr(routeDiscreteMaskToSimtAttrName) ||
+      op->hasAttr(ConverterUtils::preserveAtomicMaskAttrName)) {
     return failure();
   }
 
@@ -404,60 +405,18 @@ struct DiscreteMaskAtomicConversion
 
   LogicalResult matchAndRewrite(mlir::triton::AtomicRMWOp op,
                                 PatternRewriter &rewriter) const final {
-    auto loc = op.getLoc();
-    auto ptr = op.getPtr();
-    auto src = op.getVal();
     auto mask = op.getMask();
-    RMWOp rmwOp = op.getAtomicRmwOp();
 
     if (failed(isDiscreteMask(op, mask, rewriter)))
       return failure();
 
-    // Keep the original lane mask for A5 SIMT indirect atomic lowering.
-    // Replacing it with a select here would leave the indirect atomic without
-    // the predicate that prevents inactive lanes from dereferencing ptr.
-    if (compileOn91095Flag && forceSimtTemplateFlag) {
-      op->setAttr(routeDiscreteMaskToSimtAttrName, rewriter.getUnitAttr());
-      return failure();
-    }
-
-    const std::map<RMWOp, TypelessValue> initMap = {
-        {RMWOp::FADD, TypelessValue::Zero},
-        {RMWOp::ADD, TypelessValue::Zero},
-        {RMWOp::UMAX, TypelessValue::Zero},
-        {RMWOp::OR, TypelessValue::Zero},
-        {RMWOp::MIN, TypelessValue::Max},
-        {RMWOp::UMIN, TypelessValue::Max},
-        {RMWOp::AND, TypelessValue::Max},
-        {RMWOp::MAX, TypelessValue::Min},
-        {RMWOp::XOR, TypelessValue::Zero},
-        {RMWOp::XCHG, TypelessValue::Undefined},
-    };
-    assert(initMap.find(rmwOp) != initMap.end());
-    auto typelessVal = initMap.at(rmwOp);
-    if (typelessVal == TypelessValue::Undefined) {
-      // Undefined default value atomic op will be decomposed in AscendNPU-IR
-      op->setAttr(ConverterUtils::discreteMaskAttrName,
-                  UnitAttr::get(rewriter.getContext()));
-      return failure();
-    }
-
-    FailureOr<mlir::Value> fill = specializeTypelessValueToConstant(
-        typelessVal, src.getType(), loc, rewriter);
-    if (failed(fill)) {
-      LLVM_DEBUG({
-        llvm::dbgs() << "Unsupported type for constant creation: "
-                     << src.getType() << "\n";
-      });
-      op->emitError("Unsupported atomic operation.");
-      return failure();
-    }
-
-    auto maskedValue = rewriter.create<arith::SelectOp>(loc, mask, src, *fill);
-    auto newAtomicOp = rewriter.create<mlir::triton::AtomicRMWOp>(
-        loc, src.getType(), rmwOp, ptr, maskedValue, mlir::Value(), op.getSem(),
-        op.getScope());
-    rewriter.replaceOp(op, newAtomicOp);
+    // A zero-valued update is not equivalent to a masked atomic: the false
+    // lane must not dereference ptr or participate in the RMW operation.
+    // Preserve the complete original mask for target-independent lowering.
+    rewriter.modifyOpInPlace(op, [&]() {
+      op->setAttr(ConverterUtils::preserveAtomicMaskAttrName,
+                  rewriter.getUnitAttr());
+    });
     return success();
   }
 };

--- a/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
+++ b/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
@@ -413,6 +413,14 @@ struct DiscreteMaskAtomicConversion
     if (failed(isDiscreteMask(op, mask, rewriter)))
       return failure();
 
+    // Keep the original lane mask for A5 SIMT indirect atomic lowering.
+    // Replacing it with a select here would leave the indirect atomic without
+    // the predicate that prevents inactive lanes from dereferencing ptr.
+    if (compileOn91095Flag && forceSimtTemplateFlag) {
+      op->setAttr(routeDiscreteMaskToSimtAttrName, rewriter.getUnitAttr());
+      return failure();
+    }
+
     const std::map<RMWOp, TypelessValue> initMap = {
         {RMWOp::FADD, TypelessValue::Zero},
         {RMWOp::ADD, TypelessValue::Zero},

--- a/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
@@ -471,6 +471,8 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
   auto ptr = op.getPtr();
   auto ptrType = resolvePtrTensorType(ptr);
   auto routeDiscreteMaskToSimt = op->hasAttr(kRouteDiscreteMaskToSimtAttrName);
+  auto preserveAtomicMask =
+      op->hasAttr(ConverterUtils::preserveAtomicMaskAttrName);
 
   if (!ptrType || op->hasAttr(ConverterUtils::discreteAttrName))
     return failure();
@@ -482,7 +484,15 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
   if (checkUnstructureAnnotated(op, rewriter))
     ptrOffsetInfo.setUnstructured(ptrOffsetInfo.getRank());
 
+  // A masked atomic must retain the complete lane predicate. Force it through
+  // the scalarized path unless the A5 indirect-atomic fast path can consume
+  // the mask explicitly. A select(value, identity) is not an equivalent
+  // replacement because it still dereferences ptr on a false lane.
+  if (preserveAtomicMask)
+    ptrOffsetInfo.setUnstructured(ptrOffsetInfo.getRank());
+
   if (ptrOffsetInfo.isStructured() && !routeDiscreteMaskToSimt &&
+      !preserveAtomicMask &&
       (!ptrOffsetInfo.isScalarLike() ||
        llvm::all_of(ptrType.getShape(), [](int64_t dim) { return dim == 1; })))
     return failure();
@@ -551,7 +561,7 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
   bool indirectFastPathEnabled =
       compileOn91095Flag && forceSimtTemplateFlag &&
       ((!ptrOffsetInfo.isStructured() && sizeInByte < 64) ||
-       routeDiscreteMaskToSimt);
+       routeDiscreteMaskToSimt || preserveAtomicMask);
   bool rankWithinIndirectLoadStoreFastPathLimit = resultShape.size() <= 5;
   if (indirectFastPathEnabled &&
       succeeded(tryRewriteIndirectFastPath(op, loc, srcPtr, ptrOffset,
@@ -710,10 +720,53 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
   accessedOp->setAttr(ConverterUtils::discreteAttrName,
                       UnitAttr::get(rewriter.getContext()));
 
+  // For the generic fallback, materialize the original mask as control flow
+  // around the actual atomic. The false branch yields an arbitrary result
+  // value when the old value is used, matching Triton's masked-atomic
+  // semantics; importantly, it never evaluates an atomic operation.
+  Value predicatedAtomicResult;
+  if constexpr (std::is_same_v<MemAccOpTy, triton::AtomicRMWOp>) {
+    if (preserveAtomicMask && isLoadLike && fullyUnstructured &&
+        accessedOp.getMask()) {
+      auto mask =
+          createExtractOp(loc, accessedOp.getMask(), rewriter,
+                          SmallVector<OpFoldResult>(ptrOffsetInfo.getRank(),
+                                                    rewriter.getIndexAttr(0)));
+      Type atomicResultType = accessedOp.getResult().getType();
+      auto ifOp = rewriter.create<scf::IfOp>(loc, TypeRange{atomicResultType},
+                                             mask, /*withElseRegion=*/true);
+      {
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
+        auto atomic = rewriter.create<triton::AtomicRMWOp>(
+            loc, accessedOp.getType(), accessedOp.getAtomicRmwOp(),
+            accessedOp.getPtr(), accessedOp.getVal(), nullptr,
+            accessedOp.getSem(), accessedOp.getScope());
+        atomic->setAttr(ConverterUtils::discreteAttrName,
+                        UnitAttr::get(rewriter.getContext()));
+        rewriter.create<scf::YieldOp>(loc, atomic.getResult());
+
+        rewriter.setInsertionPointToStart(&ifOp.getElseRegion().front());
+        if (auto tensorType = dyn_cast<RankedTensorType>(atomicResultType)) {
+          auto empty = rewriter.create<tensor::EmptyOp>(
+              loc, tensorType.getShape(), tensorType.getElementType());
+          rewriter.create<scf::YieldOp>(loc, empty.getResult());
+        } else {
+          auto zero = rewriter.create<arith::ConstantOp>(
+              loc, rewriter.getZeroAttr(atomicResultType));
+          rewriter.create<scf::YieldOp>(loc, zero.getResult());
+        }
+      }
+      predicatedAtomicResult = ifOp.getResult(0);
+      rewriter.eraseOp(accessedOp);
+    }
+  }
+
   if (isLoadLike) {
     assert(iterArg && "Load case must have iterArg in for loop");
 
-    Value value = accessedOp->getResult(0);
+    Value value = predicatedAtomicResult ? predicatedAtomicResult
+                                         : accessedOp->getResult(0);
     Value result;
     if (!isa<RankedTensorType>(value.getType()) &&
         (std::is_same_v<MemAccOpTy, triton::AtomicRMWOp> ||
@@ -750,7 +803,8 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
     }
   } else {
     if constexpr (std::is_same_v<MemAccOpTy, triton::AtomicRMWOp>) {
-      if (fullyUnstructured && accessedOp.getMask()) {
+      if (!predicatedAtomicResult && fullyUnstructured &&
+          accessedOp.getMask()) {
         auto mask = createExtractOp(
             loc, accessedOp.getMask(), rewriter,
             SmallVector<OpFoldResult>(ptrOffsetInfo.getRank(),

--- a/third_party/ascend/unittest/Conversion/General/DiscreteMaskAccess/atomic.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DiscreteMaskAccess/atomic.mlir
@@ -1,9 +1,8 @@
 // RUN: triton-opt --discrete-mask-access-conversion --split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: tt.func @atomic_add_i32
-// CHECK: %[[default:.*]] = arith.constant dense<0> : tensor<1024xi32>
-// CHECK: %[[value:.*]] = arith.select %[[mask:.*]], %[[origin:.*]], %[[default]]
-// CHECK: %[[result:.*]] = tt.atomic_rmw add, acq_rel, gpu, %[[ptr:.*]], %[[value]]
+// CHECK-NOT: arith.select
+// CHECK: tt.atomic_rmw add, acq_rel, gpu, {{.*}}, {{.*}}, {{.*}} {PreserveAtomicMask} : (tensor<1024x!tt.ptr<i32>>, tensor<1024xi32>, tensor<1024xi1>) -> tensor<1024xi32>
 tt.func @atomic_add_i32(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
   %cst = arith.constant dense<200> : tensor<1024xi32>
   %cst_0 = arith.constant dense<400> : tensor<1024xi32>
@@ -21,9 +20,8 @@ tt.func @atomic_add_i32(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
 }
 
 // CHECK-LABEL: tt.func @atomic_fadd_f32
-// CHECK: %[[default:.*]] = arith.constant dense<0.000000e+00> : tensor<1024xf32>
-// CHECK: %[[value:.*]] = arith.select %[[mask:.*]], %[[origin:.*]], %[[default]]
-// CHECK: %[[result:.*]] = tt.atomic_rmw fadd, acq_rel, gpu, %[[ptr:.*]], %[[value]]
+// CHECK-NOT: arith.select
+// CHECK: tt.atomic_rmw fadd, acq_rel, gpu, {{.*}}, {{.*}}, {{.*}} {PreserveAtomicMask} : (tensor<1024x!tt.ptr<f32>>, tensor<1024xf32>, tensor<1024xi1>) -> tensor<1024xf32>
 tt.func @atomic_fadd_f32(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>) {
   %cst = arith.constant dense<200> : tensor<1024xi32>
   %cst_0 = arith.constant dense<400> : tensor<1024xi32>
@@ -41,9 +39,8 @@ tt.func @atomic_fadd_f32(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>) {
 }
 
 // CHECK-LABEL: tt.func @atomic_max_i32
-// CHECK: %[[default:.*]] = arith.constant dense<-2147483648> : tensor<1024xi32>
-// CHECK: %[[value:.*]] = arith.select %[[mask:.*]], %[[origin:.*]], %[[default]]
-// CHECK: %[[result:.*]] = tt.atomic_rmw max, acq_rel, gpu, %[[ptr:.*]], %[[value]]
+// CHECK-NOT: arith.select
+// CHECK: tt.atomic_rmw max, acq_rel, gpu, {{.*}}, {{.*}}, {{.*}} {PreserveAtomicMask} : (tensor<1024x!tt.ptr<i32>>, tensor<1024xi32>, tensor<1024xi1>) -> tensor<1024xi32>
 tt.func @atomic_max_i32(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
   %cst = arith.constant dense<200> : tensor<1024xi32>
   %cst_0 = arith.constant dense<400> : tensor<1024xi32>
@@ -61,9 +58,8 @@ tt.func @atomic_max_i32(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
 }
 
 // CHECK-LABEL: tt.func @atomic_umax_i32
-// CHECK: %[[default:.*]] = arith.constant dense<0> : tensor<1024xi32>
-// CHECK: %[[value:.*]] = arith.select %[[mask:.*]], %[[origin:.*]], %[[default]]
-// CHECK: %[[result:.*]] = tt.atomic_rmw umax, acq_rel, gpu, %[[ptr:.*]], %[[value]]
+// CHECK-NOT: arith.select
+// CHECK: tt.atomic_rmw umax, acq_rel, gpu, {{.*}}, {{.*}}, {{.*}} {PreserveAtomicMask} : (tensor<1024x!tt.ptr<i32>>, tensor<1024xi32>, tensor<1024xi1>) -> tensor<1024xi32>
 tt.func @atomic_umax_i32(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
   %cst = arith.constant dense<200> : tensor<1024xi32>
   %cst_0 = arith.constant dense<400> : tensor<1024xi32>
@@ -81,9 +77,8 @@ tt.func @atomic_umax_i32(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
 }
 
 // CHECK-LABEL: tt.func @atomic_min_i32
-// CHECK: %[[default:.*]] = arith.constant dense<2147483647> : tensor<1024xi32>
-// CHECK: %[[value:.*]] = arith.select %[[mask:.*]], %[[origin:.*]], %[[default]]
-// CHECK: %[[result:.*]] = tt.atomic_rmw min, acq_rel, gpu, %[[ptr:.*]], %[[value]]
+// CHECK-NOT: arith.select
+// CHECK: tt.atomic_rmw min, acq_rel, gpu, {{.*}}, {{.*}}, {{.*}} {PreserveAtomicMask} : (tensor<1024x!tt.ptr<i32>>, tensor<1024xi32>, tensor<1024xi1>) -> tensor<1024xi32>
 tt.func @atomic_min_i32(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
   %cst = arith.constant dense<200> : tensor<1024xi32>
   %cst_0 = arith.constant dense<400> : tensor<1024xi32>
@@ -101,9 +96,8 @@ tt.func @atomic_min_i32(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
 }
 
 // CHECK-LABEL: tt.func @atomic_umin_i32
-// CHECK: %[[default:.*]] = arith.constant dense<2147483647> : tensor<1024xi32>
-// CHECK: %[[value:.*]] = arith.select %[[mask:.*]], %[[origin:.*]], %[[default]]
-// CHECK: %[[result:.*]] = tt.atomic_rmw umin, acq_rel, gpu, %[[ptr:.*]], %[[value]]
+// CHECK-NOT: arith.select
+// CHECK: tt.atomic_rmw umin, acq_rel, gpu, {{.*}}, {{.*}}, {{.*}} {PreserveAtomicMask} : (tensor<1024x!tt.ptr<i32>>, tensor<1024xi32>, tensor<1024xi1>) -> tensor<1024xi32>
 tt.func @atomic_umin_i32(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
   %cst = arith.constant dense<200> : tensor<1024xi32>
   %cst_0 = arith.constant dense<400> : tensor<1024xi32>
@@ -121,9 +115,8 @@ tt.func @atomic_umin_i32(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
 }
 
 // CHECK-LABEL: tt.func @atomic_and_i32
-// CHECK: %[[default:.*]] = arith.constant dense<2147483647> : tensor<1024xi32>
-// CHECK: %[[value:.*]] = arith.select %[[mask:.*]], %[[origin:.*]], %[[default]]
-// CHECK: %[[result:.*]] = tt.atomic_rmw and, acq_rel, gpu, %[[ptr:.*]], %[[value]]
+// CHECK-NOT: arith.select
+// CHECK: tt.atomic_rmw and, acq_rel, gpu, {{.*}}, {{.*}}, {{.*}} {PreserveAtomicMask} : (tensor<1024x!tt.ptr<i32>>, tensor<1024xi32>, tensor<1024xi1>) -> tensor<1024xi32>
 tt.func @atomic_and_i32(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
   %cst = arith.constant dense<200> : tensor<1024xi32>
   %cst_0 = arith.constant dense<400> : tensor<1024xi32>
@@ -141,9 +134,8 @@ tt.func @atomic_and_i32(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
 }
 
 // CHECK-LABEL: tt.func @atomic_or_i32
-// CHECK: %[[default:.*]] = arith.constant dense<0> : tensor<1024xi32>
-// CHECK: %[[value:.*]] = arith.select %[[mask:.*]], %[[origin:.*]], %[[default]]
-// CHECK: %[[result:.*]] = tt.atomic_rmw or, acq_rel, gpu, %[[ptr:.*]], %[[value]]
+// CHECK-NOT: arith.select
+// CHECK: tt.atomic_rmw or, acq_rel, gpu, {{.*}}, {{.*}}, {{.*}} {PreserveAtomicMask} : (tensor<1024x!tt.ptr<i32>>, tensor<1024xi32>, tensor<1024xi1>) -> tensor<1024xi32>
 tt.func @atomic_or_i32(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
   %cst = arith.constant dense<200> : tensor<1024xi32>
   %cst_0 = arith.constant dense<400> : tensor<1024xi32>
@@ -161,9 +153,8 @@ tt.func @atomic_or_i32(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
 }
 
 // CHECK-LABEL: tt.func @atomic_max_i16
-// CHECK: %[[default:.*]] = arith.constant dense<-32768> : tensor<1024xi16>
-// CHECK: %[[value:.*]] = arith.select %[[mask:.*]], %[[origin:.*]], %[[default]]
-// CHECK: %[[result:.*]] = tt.atomic_rmw max, acq_rel, gpu, %[[ptr:.*]], %[[value]]
+// CHECK-NOT: arith.select
+// CHECK: tt.atomic_rmw max, acq_rel, gpu, {{.*}}, {{.*}}, {{.*}} {PreserveAtomicMask} : (tensor<1024x!tt.ptr<i16>>, tensor<1024xi16>, tensor<1024xi1>) -> tensor<1024xi16>
 tt.func @atomic_max_i16(%arg0: !tt.ptr<i16>, %arg1: !tt.ptr<i16>) {
   %cst = arith.constant dense<200> : tensor<1024xi32>
   %cst_0 = arith.constant dense<400> : tensor<1024xi32>
@@ -181,9 +172,8 @@ tt.func @atomic_max_i16(%arg0: !tt.ptr<i16>, %arg1: !tt.ptr<i16>) {
 }
 
 // CHECK-LABEL: tt.func @atomic_max_f16
-// CHECK: %[[default:.*]] = arith.constant dense<0xFC00> : tensor<1024xf16>
-// CHECK: %[[value:.*]] = arith.select %[[mask:.*]], %[[origin:.*]], %[[default]]
-// CHECK: %[[result:.*]] = tt.atomic_rmw max, acq_rel, gpu, %[[ptr:.*]], %[[value]]
+// CHECK-NOT: arith.select
+// CHECK: tt.atomic_rmw max, acq_rel, gpu, {{.*}}, {{.*}}, {{.*}} {PreserveAtomicMask} : (tensor<1024x!tt.ptr<f16>>, tensor<1024xf16>, tensor<1024xi1>) -> tensor<1024xf16>
 tt.func @atomic_max_f16(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>) {
   %cst = arith.constant dense<200> : tensor<1024xi32>
   %cst_0 = arith.constant dense<400> : tensor<1024xi32>

--- a/third_party/ascend/unittest/Conversion/General/DiscreteMaskAccess/indirect_atomic.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DiscreteMaskAccess/indirect_atomic.mlir
@@ -1,8 +1,8 @@
 // RUN: triton-opt '--discrete-mask-access-conversion=compile-on-910-95=True force-simt-template=True' --split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: tt.func @structured_disc_mask_atomic_add_2d
-// CHECK: arith.select {{.*}} : tensor<4x4xi1>, tensor<4x4xi32>
-// CHECK: tt.atomic_rmw add, acq_rel, gpu, {{.*}} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>) -> tensor<4x4xi32>
+// CHECK-NOT: arith.select
+// CHECK: tt.atomic_rmw add, acq_rel, gpu, {{.*}} {route_discrete_mask_to_simt} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
 // CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<4x4x!tt.ptr<i32>>
 tt.func @structured_disc_mask_atomic_add_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>, %arg2: !tt.ptr<i32>) {
 	%cst = arith.constant dense<16> : tensor<4x4xi32>
@@ -32,8 +32,8 @@ tt.func @structured_disc_mask_atomic_add_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<
 // -----
 
 // CHECK-LABEL: tt.func @structured_disc_mask_atomic_and_2d
-// CHECK: arith.select {{.*}} : tensor<4x4xi1>, tensor<4x4xi32>
-// CHECK: tt.atomic_rmw and, acq_rel, gpu, {{.*}} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>) -> tensor<4x4xi32>
+// CHECK-NOT: arith.select
+// CHECK: tt.atomic_rmw and, acq_rel, gpu, {{.*}} {route_discrete_mask_to_simt} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
 // CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<4x4x!tt.ptr<i32>>
 tt.func @structured_disc_mask_atomic_and_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>, %arg2: !tt.ptr<i32>) {
 	%cst = arith.constant dense<16> : tensor<4x4xi32>
@@ -63,8 +63,8 @@ tt.func @structured_disc_mask_atomic_and_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<
 // -----
 
 // CHECK-LABEL: tt.func @structured_disc_mask_atomic_or_2d
-// CHECK: arith.select {{.*}} : tensor<4x4xi1>, tensor<4x4xi32>
-// CHECK: tt.atomic_rmw or, acq_rel, gpu, {{.*}} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>) -> tensor<4x4xi32>
+// CHECK-NOT: arith.select
+// CHECK: tt.atomic_rmw or, acq_rel, gpu, {{.*}} {route_discrete_mask_to_simt} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
 // CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<4x4x!tt.ptr<i32>>
 tt.func @structured_disc_mask_atomic_or_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>, %arg2: !tt.ptr<i32>) {
 	%cst = arith.constant dense<16> : tensor<4x4xi32>
@@ -94,8 +94,8 @@ tt.func @structured_disc_mask_atomic_or_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i
 // -----
 
 // CHECK-LABEL: tt.func @structured_disc_mask_atomic_xor_2d
-// CHECK: arith.select {{.*}} : tensor<4x4xi1>, tensor<4x4xi32>
-// CHECK: tt.atomic_rmw xor, acq_rel, gpu, {{.*}} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>) -> tensor<4x4xi32>
+// CHECK-NOT: arith.select
+// CHECK: tt.atomic_rmw xor, acq_rel, gpu, {{.*}} {route_discrete_mask_to_simt} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
 // CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<4x4x!tt.ptr<i32>>
 tt.func @structured_disc_mask_atomic_xor_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>, %arg2: !tt.ptr<i32>) {
 	%cst = arith.constant dense<16> : tensor<4x4xi32>
@@ -125,7 +125,8 @@ tt.func @structured_disc_mask_atomic_xor_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<
 // -----
 
 // CHECK-LABEL: tt.func @structured_disc_mask_atomic_xchg_2d
-// CHECK: tt.atomic_rmw exch, acq_rel, gpu, {{.*}} {DiscreteMask} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
+// CHECK-NOT: arith.select
+// CHECK: tt.atomic_rmw exch, acq_rel, gpu, {{.*}} {route_discrete_mask_to_simt} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
 // CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<4x4x!tt.ptr<i32>>
 tt.func @structured_disc_mask_atomic_xchg_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>, %arg2: !tt.ptr<i32>) {
 	%cst = arith.constant dense<16> : tensor<4x4xi32>
@@ -155,8 +156,8 @@ tt.func @structured_disc_mask_atomic_xchg_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr
 // -----
 
 // CHECK-LABEL: tt.func @structured_disc_mask_atomic_max_2d
-// CHECK: arith.select {{.*}} : tensor<4x4xi1>, tensor<4x4xi32>
-// CHECK: tt.atomic_rmw max, acq_rel, gpu, {{.*}} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>) -> tensor<4x4xi32>
+// CHECK-NOT: arith.select
+// CHECK: tt.atomic_rmw max, acq_rel, gpu, {{.*}} {route_discrete_mask_to_simt} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
 // CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<4x4x!tt.ptr<i32>>
 tt.func @structured_disc_mask_atomic_max_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>, %arg2: !tt.ptr<i32>) {
 	%cst = arith.constant dense<16> : tensor<4x4xi32>
@@ -186,8 +187,8 @@ tt.func @structured_disc_mask_atomic_max_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<
 // -----
 
 // CHECK-LABEL: tt.func @structured_disc_mask_atomic_min_2d
-// CHECK: arith.select {{.*}} : tensor<4x4xi1>, tensor<4x4xi32>
-// CHECK: tt.atomic_rmw min, acq_rel, gpu, {{.*}} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>) -> tensor<4x4xi32>
+// CHECK-NOT: arith.select
+// CHECK: tt.atomic_rmw min, acq_rel, gpu, {{.*}} {route_discrete_mask_to_simt} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
 // CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<4x4x!tt.ptr<i32>>
 tt.func @structured_disc_mask_atomic_min_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>, %arg2: !tt.ptr<i32>) {
 	%cst = arith.constant dense<16> : tensor<4x4xi32>

--- a/third_party/ascend/unittest/Conversion/General/DiscreteMaskAccess/indirect_atomic.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DiscreteMaskAccess/indirect_atomic.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: tt.func @structured_disc_mask_atomic_add_2d
 // CHECK-NOT: arith.select
-// CHECK: tt.atomic_rmw add, acq_rel, gpu, {{.*}} {route_discrete_mask_to_simt} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
+// CHECK: tt.atomic_rmw add, acq_rel, gpu, {{.*}} {PreserveAtomicMask} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
 // CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<4x4x!tt.ptr<i32>>
 tt.func @structured_disc_mask_atomic_add_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>, %arg2: !tt.ptr<i32>) {
 	%cst = arith.constant dense<16> : tensor<4x4xi32>
@@ -33,7 +33,7 @@ tt.func @structured_disc_mask_atomic_add_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<
 
 // CHECK-LABEL: tt.func @structured_disc_mask_atomic_and_2d
 // CHECK-NOT: arith.select
-// CHECK: tt.atomic_rmw and, acq_rel, gpu, {{.*}} {route_discrete_mask_to_simt} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
+// CHECK: tt.atomic_rmw and, acq_rel, gpu, {{.*}} {PreserveAtomicMask} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
 // CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<4x4x!tt.ptr<i32>>
 tt.func @structured_disc_mask_atomic_and_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>, %arg2: !tt.ptr<i32>) {
 	%cst = arith.constant dense<16> : tensor<4x4xi32>
@@ -64,7 +64,7 @@ tt.func @structured_disc_mask_atomic_and_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<
 
 // CHECK-LABEL: tt.func @structured_disc_mask_atomic_or_2d
 // CHECK-NOT: arith.select
-// CHECK: tt.atomic_rmw or, acq_rel, gpu, {{.*}} {route_discrete_mask_to_simt} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
+// CHECK: tt.atomic_rmw or, acq_rel, gpu, {{.*}} {PreserveAtomicMask} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
 // CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<4x4x!tt.ptr<i32>>
 tt.func @structured_disc_mask_atomic_or_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>, %arg2: !tt.ptr<i32>) {
 	%cst = arith.constant dense<16> : tensor<4x4xi32>
@@ -95,7 +95,7 @@ tt.func @structured_disc_mask_atomic_or_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i
 
 // CHECK-LABEL: tt.func @structured_disc_mask_atomic_xor_2d
 // CHECK-NOT: arith.select
-// CHECK: tt.atomic_rmw xor, acq_rel, gpu, {{.*}} {route_discrete_mask_to_simt} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
+// CHECK: tt.atomic_rmw xor, acq_rel, gpu, {{.*}} {PreserveAtomicMask} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
 // CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<4x4x!tt.ptr<i32>>
 tt.func @structured_disc_mask_atomic_xor_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>, %arg2: !tt.ptr<i32>) {
 	%cst = arith.constant dense<16> : tensor<4x4xi32>
@@ -126,7 +126,7 @@ tt.func @structured_disc_mask_atomic_xor_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<
 
 // CHECK-LABEL: tt.func @structured_disc_mask_atomic_xchg_2d
 // CHECK-NOT: arith.select
-// CHECK: tt.atomic_rmw exch, acq_rel, gpu, {{.*}} {route_discrete_mask_to_simt} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
+// CHECK: tt.atomic_rmw exch, acq_rel, gpu, {{.*}} {PreserveAtomicMask} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
 // CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<4x4x!tt.ptr<i32>>
 tt.func @structured_disc_mask_atomic_xchg_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>, %arg2: !tt.ptr<i32>) {
 	%cst = arith.constant dense<16> : tensor<4x4xi32>
@@ -157,7 +157,7 @@ tt.func @structured_disc_mask_atomic_xchg_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr
 
 // CHECK-LABEL: tt.func @structured_disc_mask_atomic_max_2d
 // CHECK-NOT: arith.select
-// CHECK: tt.atomic_rmw max, acq_rel, gpu, {{.*}} {route_discrete_mask_to_simt} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
+// CHECK: tt.atomic_rmw max, acq_rel, gpu, {{.*}} {PreserveAtomicMask} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
 // CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<4x4x!tt.ptr<i32>>
 tt.func @structured_disc_mask_atomic_max_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>, %arg2: !tt.ptr<i32>) {
 	%cst = arith.constant dense<16> : tensor<4x4xi32>
@@ -188,7 +188,7 @@ tt.func @structured_disc_mask_atomic_max_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<
 
 // CHECK-LABEL: tt.func @structured_disc_mask_atomic_min_2d
 // CHECK-NOT: arith.select
-// CHECK: tt.atomic_rmw min, acq_rel, gpu, {{.*}} {route_discrete_mask_to_simt} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
+// CHECK: tt.atomic_rmw min, acq_rel, gpu, {{.*}} {PreserveAtomicMask} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
 // CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<4x4x!tt.ptr<i32>>
 tt.func @structured_disc_mask_atomic_min_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>, %arg2: !tt.ptr<i32>) {
 	%cst = arith.constant dense<16> : tensor<4x4xi32>

--- a/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/indirect_atomic.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/indirect_atomic.mlir
@@ -1,5 +1,67 @@
 // RUN: triton-opt '--discrete-mask-access-conversion=compile-on-910-95=True force-simt-template=True' '--triton-to-unstructure=compile-on-910-95=True force-simt-template=True' --split-input-file %s | FileCheck %s
 
+// CHECK-LABEL: tt.func public @structured_disc_mask_atomic_add_2d
+// CHECK-NOT: arith.select
+// CHECK: %[[OFFSET_I64:.*]] = arith.extsi {{.*}} : tensor<4x4xi32> to tensor<4x4xi64>
+// CHECK: %[[OFFSET_FLAT:.*]] = tt.reshape %[[OFFSET_I64]] : tensor<4x4xi64> -> tensor<16xi64>
+// CHECK: %[[VALUE_FLAT:.*]] = tt.reshape {{.*}} : tensor<4x4xi32> -> tensor<16xi32>
+// CHECK: %[[MASK_I8:.*]] = arith.extui {{.*}} : tensor<4x4xi1> to tensor<4x4xi8>
+// CHECK: %[[MASK_FLAT:.*]] = tt.reshape %[[MASK_I8]] : tensor<4x4xi8> -> tensor<16xi8>
+// CHECK: %[[OLD_FLAT:.*]] = hivm.hir.custom {extra_attr = "operate=add"{{.*}}} "__builtin_indirect_atomic" ins(%arg1, %[[OFFSET_FLAT]], %[[VALUE_FLAT]], %[[MASK_FLAT]]
+// CHECK: %[[OLD:.*]] = tt.reshape %[[OLD_FLAT]] : tensor<16xi32> -> tensor<4x4xi32>
+// CHECK: ascend.indirect_store %arg2 : <i32>, %[[OFFSET_I64]] : tensor<4x4xi64>, %[[OLD]] : tensor<4x4xi32>,
+tt.func public @structured_disc_mask_atomic_add_2d(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<i32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+  %cst = arith.constant dense<16> : tensor<4x4xi32>
+  %cst_0 = arith.constant dense<2> : tensor<4x4xi32>
+  %cst_1 = arith.constant dense<4> : tensor<4x1xi32>
+  %0 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+  %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
+  %2 = tt.expand_dims %0 {axis = 0 : i32} : tensor<4xi32> -> tensor<1x4xi32>
+  %3 = arith.muli %1, %cst_1 : tensor<4x1xi32>
+  %4 = tt.broadcast %3 : tensor<4x1xi32> -> tensor<4x4xi32>
+  %5 = tt.broadcast %2 : tensor<1x4xi32> -> tensor<4x4xi32>
+  %6 = arith.addi %4, %5 : tensor<4x4xi32>
+  %7 = arith.muli %6, %cst_0 : tensor<4x4xi32>
+  %8 = arith.cmpi slt, %7, %cst : tensor<4x4xi32>
+  %9 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<4x4x!tt.ptr<i32>>
+  %10 = tt.addptr %9, %6 : tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>
+  %11 = tt.load %10 : tensor<4x4x!tt.ptr<i32>>
+  %12 = tt.splat %arg1 : !tt.ptr<i32> -> tensor<4x4x!tt.ptr<i32>>
+  %13 = tt.addptr %12, %6 : tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>
+  %14 = tt.atomic_rmw add, acq_rel, gpu, %13, %11, %8 : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
+  %15 = tt.splat %arg2 : !tt.ptr<i32> -> tensor<4x4x!tt.ptr<i32>>
+  %16 = tt.addptr %15, %6 : tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>
+  tt.store %16, %14, %8 : tensor<4x4x!tt.ptr<i32>>
+  tt.return
+}
+
+// -----
+
+// CHECK-LABEL: tt.func @structured_disc_mask_atomic_max_i16_fallback
+// CHECK-NOT: arith.select
+// CHECK-NOT: hivm.hir.custom
+// CHECK: tt.atomic_rmw max, acq_rel, gpu, {{.*}} {DiscreteMemAccess} : (tensor<1024x!tt.ptr<i16>>, tensor<1024xi16>, tensor<1024xi1>) -> tensor<1024xi16>
+// CHECK-NOT: arith.select
+// CHECK-NOT: hivm.hir.custom
+// CHECK: tt.return
+tt.func @structured_disc_mask_atomic_max_i16_fallback(%arg0: !tt.ptr<i16>, %arg1: !tt.ptr<i16>) {
+  %cst = arith.constant dense<200> : tensor<1024xi32>
+  %cst_0 = arith.constant dense<400> : tensor<1024xi32>
+  %0 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+  %1 = arith.cmpi slt, %0, %cst : tensor<1024xi32>
+  %2 = arith.cmpi sgt, %0, %cst_0 : tensor<1024xi32>
+  %3 = arith.ori %1, %2 : tensor<1024xi1>
+  %4 = tt.splat %arg0 : !tt.ptr<i16> -> tensor<1024x!tt.ptr<i16>>
+  %5 = tt.addptr %4, %0 : tensor<1024x!tt.ptr<i16>>, tensor<1024xi32>
+  %6 = tt.splat %arg1 : !tt.ptr<i16> -> tensor<1024x!tt.ptr<i16>>
+  %7 = tt.addptr %6, %0 : tensor<1024x!tt.ptr<i16>>, tensor<1024xi32>
+  %8 = tt.load %7 : tensor<1024x!tt.ptr<i16>>
+  %9 = tt.atomic_rmw max, acq_rel, gpu, %5, %8, %3 : (tensor<1024x!tt.ptr<i16>>, tensor<1024xi16>, tensor<1024xi1>) -> tensor<1024xi16>
+  tt.return
+}
+
+// -----
+
 // CHECK-LABEL: tt.func public @fully_unstructured_atomic_add_2d
 // CHECK: %[[MASK_TRUE:.*]] = arith.constant dense<1> : tensor<16xi8>
 // CHECK: %[[OFFSET_FLAT:.*]] = tt.reshape {{.*}} : tensor<4x4xi64> -> tensor<16xi64>

--- a/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/indirect_atomic.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/indirect_atomic.mlir
@@ -40,7 +40,8 @@ tt.func public @structured_disc_mask_atomic_add_2d(%arg0: !tt.ptr<i32> {tt.divis
 // CHECK-LABEL: tt.func @structured_disc_mask_atomic_max_i16_fallback
 // CHECK-NOT: arith.select
 // CHECK-NOT: hivm.hir.custom
-// CHECK: tt.atomic_rmw max, acq_rel, gpu, {{.*}} {DiscreteMemAccess} : (tensor<1024x!tt.ptr<i16>>, tensor<1024xi16>, tensor<1024xi1>) -> tensor<1024xi16>
+// CHECK: scf.if
+// CHECK: tt.atomic_rmw max, acq_rel, gpu, {{.*}} {DiscreteMemAccess} : (tensor<1x!tt.ptr<i16>>, tensor<1xi16>) -> tensor<1xi16>
 // CHECK-NOT: arith.select
 // CHECK-NOT: hivm.hir.custom
 // CHECK: tt.return

--- a/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/masked_atomic_modes.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/masked_atomic_modes.mlir
@@ -1,0 +1,33 @@
+// RUN: triton-opt '--discrete-mask-access-conversion=compile-on-910-95=False force-simt-template=False' '--triton-to-unstructure=compile-on-910-95=False force-simt-template=False' %s | FileCheck %s --check-prefix=FALLBACK
+// RUN: triton-opt '--discrete-mask-access-conversion=compile-on-910-95=False force-simt-template=True' '--triton-to-unstructure=compile-on-910-95=False force-simt-template=True' %s | FileCheck %s --check-prefix=FALLBACK
+// RUN: triton-opt '--discrete-mask-access-conversion=compile-on-910-95=True force-simt-template=False' '--triton-to-unstructure=compile-on-910-95=True force-simt-template=False' %s | FileCheck %s --check-prefix=FALLBACK
+// RUN: triton-opt '--discrete-mask-access-conversion=compile-on-910-95=True force-simt-template=True' '--triton-to-unstructure=compile-on-910-95=True force-simt-template=True' %s | FileCheck %s --check-prefix=A5-SIMT
+
+// All non-pure-SIMT fallback modes must guard the actual atomic operation.
+// A false lane therefore reaches the scalar atomic only through scf.if.
+// FALLBACK-LABEL: tt.func @masked_atomic_mode_matrix
+// FALLBACK-NOT: hivm.hir.custom
+// FALLBACK: scf.if
+// FALLBACK: tt.atomic_rmw add, acq_rel, gpu, {{.*}} {DiscreteMemAccess} : (tensor<1x!tt.ptr<i32>>, tensor<1xi32>) -> tensor<1xi32>
+
+// The A5 SIMT-template fast path keeps the complete mask as the fourth
+// indirect-atomic operand; it does not replace the mask with an identity
+// update.
+// A5-SIMT-LABEL: tt.func @masked_atomic_mode_matrix
+// A5-SIMT: hivm.hir.custom{{.*}}"__builtin_indirect_atomic"
+// A5-SIMT-SAME: tensor<16xi8>
+// A5-SIMT-NOT: scf.if
+tt.func @masked_atomic_mode_matrix(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
+  %cst = arith.constant dense<8> : tensor<16xi32>
+  %cst_0 = arith.constant dense<2> : tensor<16xi32>
+  %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %1 = arith.muli %0, %cst_0 : tensor<16xi32>
+  %2 = arith.cmpi slt, %1, %cst : tensor<16xi32>
+  %3 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+  %4 = tt.addptr %3, %1 : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+  %5 = tt.splat %arg1 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+  %6 = tt.addptr %5, %1 : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+  %7 = tt.load %6 : tensor<16x!tt.ptr<i32>>
+  %8 = tt.atomic_rmw add, acq_rel, gpu, %4, %7, %2 : (tensor<16x!tt.ptr<i32>>, tensor<16xi32>, tensor<16xi1>) -> tensor<16xi32>
+  tt.return
+}


### PR DESCRIPTION
## Summary

Fix masked `tt.atomic_rmw` lowering for discrete lane masks across the non-pure-SIMT compilation paths.

Previously, the discrete-mask conversion replaced a masked atomic with `select(value, identity)` followed by an unmasked atomic. A lane with `mask=false` could therefore still dereference the pointer and participate in the RMW operation. The old `compileOn91095 && forceSimtTemplate` exception only preserved the mask for one A5 path and did not provide target-independent semantics.

## Changes

- Add `PreserveAtomicMask` to keep the original atomic lane mask intact.
- Lower the generic fallback through `scf.if`, placing the unmasked atomic only in the true branch.
- Pass the complete mask to the A5 SIMT-template indirect-atomic fast path.
- Add coverage for A2/A3 and A5 SIMD/SIMT-template option combinations.
- Leave continuous/structured non-discrete masks and the pure-SIMT (`force_simt_only`) pipeline unchanged.

## Reproducer

The issue is exercised by the FlagGems index-add test:

```bash
cd /home/w00609825/triton_workspace/FlagGems_new
pytest -sv 'tests/test_index_add.py::test_index_add_[dtype0-0-shape2]'
```

The corresponding Triton kernel is `_index_add_contiguous_suffix_flat_kernel` in `src/flag_gems/runtime/backend/_ascend/ops/index_add.py`, whose `tt.atomic_rmw` uses the dynamic `valid` lane mask.

## Validation

- Targeted pre-commit hooks passed on all six changed files, including clang-format v19.1.6.
- `main-dev` worktree completed the full `setup.py build_ext` build with the local LLVM toolchain; both modified C++ passes compiled and `triton-opt` linked successfully.
- The new `masked_atomic_modes.mlir` FileCheck passed for:
  - A2/A3 SIMD;
  - A2/A3 SIMT-template;
  - A5 SIMD;
  - A5 SIMT-template.
- Existing `DiscreteMaskAccess/indirect_atomic.mlir` and `TritonToUnstructure/indirect_atomic.mlir` checks also passed.

Device execution of the FlagGems pytest is separately blocked in the current environment by the CANN/OPP `aclnnInplaceNormal` dynamic-shape configuration; this PR is validated at the compiler and MLIR lowering stages.
