### PR TITLE
[structured](fix) support cat pointer memory operations

### DIFF
--- a/third_party/ascend/lib/TritonToStructured/MemOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToStructured/MemOpConverter.cpp
@@ -33,6 +33,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Passes.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/Attributes.h"
@@ -75,12 +76,167 @@ using namespace mlir;
 using namespace triton;
 using namespace TritonToStructured;
 
+namespace {
+
+struct CatPointerShape {
+  int64_t lhsSize;
+  int64_t rhsSize;
+
+  int64_t totalSize() const { return lhsSize + rhsSize; }
+};
+
+struct SplitValues {
+  Value lhs;
+  Value rhs;
+};
+
+FailureOr<CatPointerShape> getCatPointerShape(triton::CatOp catOp) {
+  auto lhsType = dyn_cast<RankedTensorType>(catOp.getLhs().getType());
+  auto rhsType = dyn_cast<RankedTensorType>(catOp.getRhs().getType());
+  auto resultType = dyn_cast<RankedTensorType>(catOp.getType());
+  if (!lhsType || !rhsType || !resultType || lhsType.getRank() != 1 ||
+      rhsType.getRank() != 1 || resultType.getRank() != 1 ||
+      !lhsType.hasStaticShape() || !rhsType.hasStaticShape() ||
+      !resultType.hasStaticShape() ||
+      !isa<triton::PointerType>(lhsType.getElementType()) ||
+      lhsType.getElementType() != rhsType.getElementType() ||
+      lhsType.getElementType() != resultType.getElementType()) {
+    return failure();
+  }
+
+  CatPointerShape shape{lhsType.getDimSize(0), rhsType.getDimSize(0)};
+  if (shape.lhsSize != shape.rhsSize ||
+      resultType.getDimSize(0) != shape.totalSize())
+    return failure();
+  return shape;
+}
+
+bool isCatAlignedValue(Value value, int64_t totalSize) {
+  if (!value)
+    return true;
+  auto type = dyn_cast<RankedTensorType>(value.getType());
+  return type && type.getRank() == 1 && type.hasStaticShape() &&
+         type.getDimSize(0) == totalSize;
+}
+
+SplitValues splitCatAlignedValue(Value value, const CatPointerShape &shape,
+                                 Location loc, PatternRewriter &rewriter) {
+  if (!value)
+    return {};
+
+  auto valueType = cast<RankedTensorType>(value.getType());
+  Type elementType = valueType.getElementType();
+  // Ascend's downstream tensor layout requires byte-aligned mask slices.
+  // Convert back to i1 only after selecting the contiguous halves.
+  if (elementType.isInteger(1)) {
+    auto byteType = valueType.clone(rewriter.getI8Type());
+    Value byteValue = rewriter.create<arith::ExtUIOp>(loc, byteType, value);
+    auto byteHalfType =
+        RankedTensorType::get({shape.lhsSize}, rewriter.getI8Type());
+    SmallVector<OpFoldResult> offsets{rewriter.getIndexAttr(0)};
+    SmallVector<OpFoldResult> sizes{rewriter.getIndexAttr(shape.lhsSize)};
+    SmallVector<OpFoldResult> strides{rewriter.getIndexAttr(1)};
+    Value lhsByte = rewriter.create<tensor::ExtractSliceOp>(
+        loc, byteHalfType, byteValue, offsets, sizes, strides);
+    offsets[0] = rewriter.getIndexAttr(shape.lhsSize);
+    Value rhsByte = rewriter.create<tensor::ExtractSliceOp>(
+        loc, byteHalfType, byteValue, offsets, sizes, strides);
+    auto maskHalfType =
+        RankedTensorType::get({shape.lhsSize}, rewriter.getI1Type());
+    Value lhs = rewriter.create<arith::TruncIOp>(loc, maskHalfType, lhsByte);
+    Value rhs = rewriter.create<arith::TruncIOp>(loc, maskHalfType, rhsByte);
+    return {lhs, rhs};
+  }
+  auto reshapedType = RankedTensorType::get({2, shape.lhsSize}, elementType);
+  auto transposedType = RankedTensorType::get({shape.lhsSize, 2}, elementType);
+  auto halfType = RankedTensorType::get({shape.lhsSize}, elementType);
+
+  Value reshaped = rewriter.create<triton::ReshapeOp>(loc, reshapedType, value);
+  SmallVector<int32_t> order{1, 0};
+  Value transposed =
+      rewriter.create<triton::TransOp>(loc, transposedType, reshaped, order);
+  auto split =
+      rewriter.create<triton::SplitOp>(loc, halfType, halfType, transposed);
+  return {split.getOutLHS(), split.getOutRHS()};
+}
+
+void copyMissingAttrs(Operation *source, Operation *target) {
+  for (NamedAttribute attr : source->getAttrs()) {
+    if (!target->hasAttr(attr.getName()))
+      target->setAttr(attr.getName(), attr.getValue());
+  }
+}
+
+LogicalResult rewriteCatPointerLoad(triton::LoadOp op, triton::CatOp catOp,
+                                    PatternRewriter &rewriter) {
+  FailureOr<CatPointerShape> shape = getCatPointerShape(catOp);
+  if (failed(shape) || !isCatAlignedValue(op.getMask(), shape->totalSize()) ||
+      !isCatAlignedValue(op.getOther(), shape->totalSize())) {
+    return failure();
+  }
+
+  Location loc = op.getLoc();
+  SplitValues masks = splitCatAlignedValue(op.getMask(), *shape, loc, rewriter);
+  SplitValues others =
+      splitCatAlignedValue(op.getOther(), *shape, loc, rewriter);
+  auto lhsLoad = rewriter.create<triton::LoadOp>(
+      loc, catOp.getLhs(), masks.lhs, others.lhs, op.getBoundaryCheck(),
+      op.getPadding(), op.getCache(), op.getEvict(), op.getIsVolatile());
+  auto rhsLoad = rewriter.create<triton::LoadOp>(
+      loc, catOp.getRhs(), masks.rhs, others.rhs, op.getBoundaryCheck(),
+      op.getPadding(), op.getCache(), op.getEvict(), op.getIsVolatile());
+  copyMissingAttrs(op.getOperation(), lhsLoad.getOperation());
+  copyMissingAttrs(op.getOperation(), rhsLoad.getOperation());
+
+  auto result = rewriter.create<triton::CatOp>(
+      loc, op.getType(), ValueRange{lhsLoad.getResult(), rhsLoad.getResult()});
+  copyMissingAttrs(catOp.getOperation(), result.getOperation());
+  rewriter.replaceOp(op, result.getResult());
+  if (catOp.getResult().use_empty())
+    rewriter.eraseOp(catOp);
+  return success();
+}
+
+LogicalResult rewriteCatPointerStore(triton::StoreOp op, triton::CatOp catOp,
+                                     PatternRewriter &rewriter) {
+  FailureOr<CatPointerShape> shape = getCatPointerShape(catOp);
+  if (failed(shape) || !isCatAlignedValue(op.getValue(), shape->totalSize()) ||
+      !isCatAlignedValue(op.getMask(), shape->totalSize())) {
+    return failure();
+  }
+
+  Location loc = op.getLoc();
+  SplitValues values =
+      splitCatAlignedValue(op.getValue(), *shape, loc, rewriter);
+  SplitValues masks = splitCatAlignedValue(op.getMask(), *shape, loc, rewriter);
+  auto lhsStore = rewriter.create<triton::StoreOp>(
+      loc, catOp.getLhs(), values.lhs, masks.lhs, op.getBoundaryCheck(),
+      op.getCache(), op.getEvict());
+  auto rhsStore = rewriter.create<triton::StoreOp>(
+      loc, catOp.getRhs(), values.rhs, masks.rhs, op.getBoundaryCheck(),
+      op.getCache(), op.getEvict());
+  copyMissingAttrs(op.getOperation(), lhsStore.getOperation());
+  copyMissingAttrs(op.getOperation(), rhsStore.getOperation());
+
+  rewriter.eraseOp(op);
+  if (catOp.getResult().use_empty())
+    rewriter.eraseOp(catOp);
+  return success();
+}
+
+} // namespace
+
 LogicalResult LoadConverter::matchAndRewrite(triton::LoadOp op,
                                              PatternRewriter &rewriter) const {
   auto loc = op.getLoc();
   auto oldPtr = op.getPtr();
   auto oldMask = op.getMask();
   auto oldOther = op.getOther();
+
+  if (auto catOp = oldPtr.getDefiningOp<triton::CatOp>()) {
+    if (succeeded(rewriteCatPointerLoad(op, catOp, rewriter)))
+      return success();
+  }
 
   MemOpTransformer tf(MemOpTransformer::MemType::load, optimizeDynamicOffset);
 
@@ -133,6 +289,11 @@ LogicalResult StoreConverter::matchAndRewrite(triton::StoreOp op,
   auto oldPtr = op.getPtr();
   auto oldMask = op.getMask();
   auto oldValue = op.getValue();
+
+  if (auto catOp = oldPtr.getDefiningOp<triton::CatOp>()) {
+    if (succeeded(rewriteCatPointerStore(op, catOp, rewriter)))
+      return success();
+  }
 
   MemOpTransformer tf(MemOpTransformer::MemType::store, optimizeDynamicOffset);
 

--- a/third_party/ascend/unittest/pytest_ut/test_cat.py
+++ b/third_party/ascend/unittest/pytest_ut/test_cat.py
@@ -59,3 +59,84 @@ def test_cat(shape, dtype):
     fn_npu_[1, 1, 1](output, x, y, m)
 
     test_common.validate_cmp(dtype, ans, output)
+
+
+@triton.jit
+def cat_pointer_load_kernel(
+    left_ptr,
+    right_ptr,
+    output_ptr,
+    BLOCK_SIZE: tl.constexpr,
+    MASKED: tl.constexpr,
+):
+    offsets = tl.arange(0, BLOCK_SIZE)
+    pointers = tl.cat(left_ptr + offsets, right_ptr + offsets, can_reorder=True)
+    output_offsets = tl.arange(0, BLOCK_SIZE * 2)
+
+    if MASKED:
+        mask = (output_offsets != 2) & (output_offsets != BLOCK_SIZE + 3)
+        other = output_offsets.to(tl.float32) + 1000.0
+        values = tl.load(pointers, mask=mask, other=other)
+    else:
+        values = tl.load(pointers)
+
+    tl.store(output_ptr + output_offsets, values)
+
+
+@triton.jit
+def cat_pointer_store_kernel(
+    left_ptr,
+    right_ptr,
+    BLOCK_SIZE: tl.constexpr,
+    MASKED: tl.constexpr,
+):
+    offsets = tl.arange(0, BLOCK_SIZE)
+    pointers = tl.cat(left_ptr + offsets, right_ptr + offsets, can_reorder=True)
+    input_offsets = tl.arange(0, BLOCK_SIZE * 2)
+    values = input_offsets.to(tl.float32) + 200.0
+
+    if MASKED:
+        mask = (input_offsets != 1) & (input_offsets != BLOCK_SIZE + 5)
+        tl.store(pointers, values, mask=mask)
+    else:
+        tl.store(pointers, values)
+
+
+@pytest.mark.parametrize("masked", [False, True], ids=["unmasked", "masked_tensor_other"])
+def test_cat_pointer_load(masked):
+    block_size = 16
+    total_size = block_size * 2
+    left = torch.arange(block_size, dtype=torch.float32, device="npu") + 10.0
+    right = torch.arange(block_size, dtype=torch.float32, device="npu") + 100.0
+    output = torch.empty(total_size, dtype=torch.float32, device="npu")
+
+    cat_pointer_load_kernel[(1, )](left, right, output, BLOCK_SIZE=block_size, MASKED=masked)
+
+    expected = torch.cat((left, right))
+    if masked:
+        offsets = torch.arange(total_size, dtype=torch.int32, device="npu")
+        mask = (offsets != 2) & (offsets != block_size + 3)
+        other = offsets.to(torch.float32) + 1000.0
+        expected = torch.where(mask, expected, other)
+
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("masked", [False, True], ids=["unmasked", "masked"])
+def test_cat_pointer_store(masked):
+    block_size = 16
+    total_size = block_size * 2
+    sentinel = -1.0
+    left = torch.full((block_size, ), sentinel, dtype=torch.float32, device="npu")
+    right = torch.full((block_size, ), sentinel, dtype=torch.float32, device="npu")
+
+    cat_pointer_store_kernel[(1, )](left, right, BLOCK_SIZE=block_size, MASKED=masked)
+
+    offsets = torch.arange(total_size, dtype=torch.int32, device="npu")
+    values = offsets.to(torch.float32) + 200.0
+    if masked:
+        mask = (offsets != 1) & (offsets != block_size + 5)
+        values = torch.where(mask, values, torch.full_like(values, sentinel))
+
+    torch.testing.assert_close(left, values[:block_size], rtol=0, atol=0)
+    torch.testing.assert_close(right, values[block_size:], rtol=0, atol=0)


### PR DESCRIPTION
## Summary

- Support load and store operations on pointer tensors produced by `tl.cat`.
- Split cat-aligned value, mask, and other tensors while preserving memory attributes.
- Use byte-aligned mask slicing for the Ascend lowering path.

## Testing

- Ascend950PR_9579 with CANN 9.1.0-beta.1: build passed.
- Torch NPU add and minimal Triton vector-add smoke tests passed.
- `third_party/ascend/unittest/pytest_ut/test_cat.py`: 6 passed.
- `git diff --check origin/main-dev...HEAD`: passed.

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description explaining why the change is needed.
- [ ] I have run `pre-commit run --from-ref origin/main-dev --to-ref HEAD`.
- [x] I have added end-to-end tests under `third_party/ascend/unittest/pytest_ut/`.
- [x] I have not added any lit tests.
