### PR TITLE
[ssbuffer](feat) UB Overflow estimate

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -67,6 +67,7 @@ inline constexpr llvm::StringLiteral kInsertionOptimization =
 static constexpr llvm::StringLiteral kInlinableQuantScaleAttr =
     "enable_fast_tf32_mul";
 inline constexpr llvm::StringLiteral kGMLoadMultiBufferHintAttr = "gm_load";
+inline constexpr llvm::StringLiteral kGMLoadHintAttr = "gm_load_hint";
 inline constexpr llvm::StringLiteral kHIVMMatmulLimitedInCubeAttr =
     "hivm.matmul_limited_in_cube";
 inline constexpr llvm::StringLiteral kTightlyCoupledBufferAttr =

--- a/third_party/ascend/include/DynamicCVPipeline/SeparateMemoryFromCompute/UBOverflowChecker.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SeparateMemoryFromCompute/UBOverflowChecker.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ADAPTER_UB_OVERFLOW_CHECKER_H
+#define TRITON_ADAPTER_UB_OVERFLOW_CHECKER_H
+
+#include "bishengir/Dialect/Annotation/IR/Annotation.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Types.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LogicalResult.h"
+
+#include "llvm/ADT/SmallVector.h"
+
+#include <cstdint>
+#include <memory>
+
+namespace mlir {
+namespace triton {
+
+struct BufferInfo {
+  enum class Kind {
+    Annot,
+    Unannot,
+  };
+
+  Kind kind = Kind::Unannot;
+  memref::AllocOp allocOp = nullptr;
+  annotation::MarkOp markOp = nullptr;
+  int64_t originalSize = 0;
+  int64_t reducedSize = 0;
+  int64_t alignedSize = 0;
+  scf::ForOp forOp = nullptr;
+  bool fromHint = false;
+};
+
+struct UBEstimateResult {
+  int64_t totalBits = 0;
+};
+
+namespace UBConstants {
+
+/// UB total space in bits (248 KB).
+inline constexpr int64_t UB_SPACE_SIZE_BITS = 2031616;
+
+/// TileAndBindSubBlock halves dim0.
+inline constexpr int64_t K_SUB_BLOCK_DIM = 2;
+
+/// EnableStrideAlign align-to-32-bytes.
+inline constexpr int64_t STRIDE_ALIGN_BYTES = 32;
+
+/// 256-bit align-up unit.
+inline constexpr int64_t ALIGN_UNIT_BITS = 256;
+
+} // namespace UBConstants
+
+int getAlignUnit(Type elementType);
+
+SmallVector<BufferInfo> collectBuffers(ModuleOp module);
+
+void computeBufferSize(BufferInfo &buf);
+
+UBEstimateResult checkUBOverflow(ModuleOp module);
+
+LogicalResult pruneMultiBufferMarks(ModuleOp module);
+
+class UBOverflowCheckerPass
+    : public PassWrapper<UBOverflowCheckerPass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(UBOverflowCheckerPass)
+
+  UBOverflowCheckerPass() = default;
+
+  void runOnOperation() override;
+
+  llvm::StringRef getArgument() const final { return "ub-overflow-check"; }
+
+  llvm::StringRef getDescription() const final {
+    return "Estimate UB usage and prune multi_buffer marks if overflow "
+           "detected";
+  }
+};
+
+std::unique_ptr<OperationPass<ModuleOp>> createUBOverflowCheckerPass();
+void registerUBOverflowCheckerPasses();
+
+} // namespace triton
+} // namespace mlir
+
+#endif // TRITON_ADAPTER_UB_OVERFLOW_CHECKER_H

--- a/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/MarkGMLoadPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/MarkGMLoadPass.cpp
@@ -52,7 +52,7 @@ static constexpr const char *DEBUG_TYPE = "MarkGMLoad";
 
 namespace {
 
-static constexpr int kDefaultVBufferCount = 1;
+static constexpr int kDefaultVBufferCount = 2;
 static constexpr int kDefaultCBufferCount = 1;
 
 struct MarkCandidate {
@@ -60,6 +60,7 @@ struct MarkCandidate {
   memref::AllocOp destAlloc; // dest backing alloc after view-like piercing
   scope::ScopeOp scopeOp;    // nearest enclosing scope, should not be null
   int bufferCount;           // filled in Phase 2
+  bool fromHint = false;     // true if bufferCount came from gm_load hint
 };
 
 // Resolve whether a BlockArgument of func::FuncOp traces to a GM pointer.
@@ -127,6 +128,8 @@ static bool traceSourceToFuncArg(Value v) {
       return false;
     }
     if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
+      if (blockArg.getArgNumber() == 0)
+        return false; // induction variable, cannot be a GM load source
       // iter_arg: trace its init value (skip induction var at index 0).
       v = forOp.getInitArgs()[blockArg.getArgNumber() - 1];
       continue;
@@ -209,6 +212,7 @@ static int resolveHintBufferCount(memref::AllocOp destAlloc) {
     if (!attr)
       return false;
     int val = static_cast<int>(attr.getInt());
+    markOp->removeAttr(CVPipeline::kGMLoadMultiBufferHintAttr);
     if (foundHint && *foundHint != val) {
       LOG_DEBUG("conflicting gm_load hints: " << *foundHint << " vs " << val);
       return true; // signal conflict
@@ -267,12 +271,17 @@ static bool markGMLoadCandidate(MarkCandidate &c) {
   if (existingMarkOp) {
     existingMarkOp->setAttr(hivm::MultiBufferAttr::name,
                             builder.getI32IntegerAttr(c.bufferCount));
+    if (c.fromHint)
+      existingMarkOp->setAttr(CVPipeline::kGMLoadHintAttr,
+                              builder.getUnitAttr());
   } else {
     builder.setInsertionPointAfter(c.destAlloc);
     auto markOp = builder.create<annotation::MarkOp>(c.destAlloc->getLoc(),
                                                      c.destAlloc.getResult());
     markOp->setAttr(hivm::MultiBufferAttr::name,
                     builder.getI32IntegerAttr(c.bufferCount));
+    if (c.fromHint)
+      markOp->setAttr(CVPipeline::kGMLoadHintAttr, builder.getUnitAttr());
   }
   LOG_DEBUG("marked multi_buffer = " << c.bufferCount << " on " << c.destAlloc);
   return true;
@@ -321,6 +330,7 @@ void MarkGMLoadPass::runOnOperation() {
         continue;
       }
       c.bufferCount = hintVal;
+      c.fromHint = true;
       LOG_DEBUG("hint force-on, bufferCount = " << hintVal);
     } else {
       // No hint: automatic resolution.

--- a/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/UBOverflowChecker.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/UBOverflowChecker.cpp
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/DynamicCVPipeline/SeparateMemoryFromCompute/UBOverflowChecker.h"
+#include "ascend/include/DynamicCVPipeline/AddControlFlowCondition/Utils.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "bishengir/Dialect/Scope/IR/Scope.h"
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinTypes.h"
+
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/MathExtras.h"
+
+#include <algorithm>
+#include <limits>
+
+using namespace mlir;
+using namespace triton;
+
+#define DEBUG_TYPE "UBOverflow"
+#define LOG_DEBUG(...)                                                         \
+  LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
+
+static annotation::MarkOp findMarkOp(memref::AllocOp allocOp) {
+  for (auto *user : allocOp.getResult().getUsers()) {
+    if (auto markOp = dyn_cast<annotation::MarkOp>(user))
+      return markOp;
+  }
+  return nullptr;
+}
+
+int triton::getAlignUnit(Type elementType) {
+  unsigned width = elementType.getIntOrFloatBitWidth();
+  if (width == 0 || width > UBConstants::ALIGN_UNIT_BITS)
+    return 1;
+  return static_cast<int>(UBConstants::ALIGN_UNIT_BITS / width);
+}
+
+SmallVector<BufferInfo> triton::collectBuffers(ModuleOp module) {
+  SmallVector<BufferInfo> buffers;
+
+  module.walk([&](scope::ScopeOp scopeOp) {
+    bool isCube = false;
+    bool isVector = false;
+    if (failed(getScopeType(scopeOp, isCube, isVector)))
+      return WalkResult::advance();
+    if (!isVector)
+      return WalkResult::advance();
+
+    scopeOp.walk([&](memref::AllocOp allocOp) {
+      BufferInfo buf;
+      buf.allocOp = allocOp;
+      buf.forOp = allocOp->getParentOfType<scf::ForOp>();
+
+      annotation::MarkOp markOp = findMarkOp(allocOp);
+      if (markOp) {
+        if (markOp->hasAttr(hivm::MultiBufferAttr::name)) {
+          buf.kind = BufferInfo::Kind::Annot;
+          buf.markOp = markOp;
+          buf.fromHint = markOp->hasAttr(CVPipeline::kGMLoadHintAttr);
+          if (buf.fromHint)
+            markOp->removeAttr(CVPipeline::kGMLoadHintAttr);
+        } else {
+          buf.kind = BufferInfo::Kind::Unannot;
+        }
+      } else {
+        buf.kind = BufferInfo::Kind::Unannot;
+      }
+
+      buffers.push_back(buf);
+    });
+
+    return WalkResult::advance();
+  });
+
+  LOG_DEBUG("collected " << buffers.size() << " buffers");
+  return buffers;
+}
+
+void triton::computeBufferSize(BufferInfo &buf) {
+  auto memrefType = mlir::cast<MemRefType>(buf.allocOp.getResult().getType());
+  ArrayRef<int64_t> shape = memrefType.getShape();
+  Type elementType = memrefType.getElementType();
+  unsigned bitWidth = elementType.getIntOrFloatBitWidth();
+
+  for (auto dim : shape) {
+    if (ShapedType::isDynamic(dim)) {
+      LOG_DEBUG("dynamic dim encountered, skipping size computation for "
+                << buf.allocOp);
+      return;
+    }
+  }
+
+  if (shape.empty() || shape[0] == 0) {
+    LOG_DEBUG("zero-sized or rank-0 buffer, skipping size computation");
+    return;
+  }
+
+  int64_t numElements = 1;
+  for (auto dim : shape) {
+    if (numElements > std::numeric_limits<int64_t>::max() / dim) {
+      LOG_DEBUG("overflow in element count computation, clamping");
+      numElements = std::numeric_limits<int64_t>::max();
+      break;
+    }
+    numElements *= dim;
+  }
+  buf.originalSize = numElements * bitWidth;
+
+  // TileAndBindSubBlock: dim0 = ceil(dim0 / K_SUB_BLOCK_DIM)
+  int64_t reducedDim0 = (shape[0] + UBConstants::K_SUB_BLOCK_DIM - 1) /
+                        UBConstants::K_SUB_BLOCK_DIM;
+  int64_t reducedElements = numElements * reducedDim0 / shape[0];
+  buf.reducedSize = reducedElements * bitWidth;
+
+  // EnableStrideAlign: align last dim to 32B
+  int64_t lastDim = (shape.size() == 1) ? reducedDim0 : shape.back();
+  int alignUnit = getAlignUnit(elementType);
+
+  if (lastDim % alignUnit != 0) {
+    int64_t alignedLastDim = (lastDim + alignUnit - 1) / alignUnit * alignUnit;
+    buf.alignedSize =
+        (buf.reducedSize * alignedLastDim + lastDim - 1) / lastDim;
+    buf.alignedSize =
+        llvm::alignTo(buf.alignedSize, UBConstants::ALIGN_UNIT_BITS);
+  } else {
+    buf.alignedSize = buf.reducedSize;
+  }
+}
+
+UBEstimateResult triton::checkUBOverflow(ModuleOp module) {
+  auto buffers = collectBuffers(module);
+  for (auto &buf : buffers)
+    computeBufferSize(buf);
+
+  UBEstimateResult result;
+  int64_t total = 0;
+  for (auto &buf : buffers) {
+    if (buf.alignedSize <= 0)
+      continue;
+    int64_t n = 1;
+    if (buf.kind == BufferInfo::Kind::Annot && buf.markOp)
+      if (auto attr = buf.markOp->getAttrOfType<IntegerAttr>(
+              hivm::MultiBufferAttr::name))
+        n = attr.getInt();
+    // Conservative: assume full expansion (alignedSize × N). Will be
+    // refined with PlanMemory-based for-loop tree model later.
+    total += buf.alignedSize * n;
+  }
+
+  result.totalBits = total;
+
+  LOG_DEBUG("UB = " << result.totalBits << " bits");
+  return result;
+}
+
+LogicalResult triton::pruneMultiBufferMarks(ModuleOp module) {
+  auto buffers = collectBuffers(module);
+  for (auto &buf : buffers)
+    computeBufferSize(buf);
+
+  int64_t total = 0;
+  SmallVector<std::pair<annotation::MarkOp, int64_t>> annotMarks;
+  for (auto &buf : buffers) {
+    if (buf.alignedSize <= 0)
+      continue;
+    int64_t n = 1;
+    if (buf.kind == BufferInfo::Kind::Annot && buf.markOp)
+      if (auto attr = buf.markOp->getAttrOfType<IntegerAttr>(
+              hivm::MultiBufferAttr::name))
+        n = attr.getInt();
+    total += buf.alignedSize * n;
+
+    if (buf.kind == BufferInfo::Kind::Annot && buf.markOp &&
+        buf.alignedSize > 0 && !buf.fromHint) {
+      annotMarks.push_back({buf.markOp, buf.alignedSize});
+    }
+  }
+
+  LOG_DEBUG("initial UB = " << total << " bits, max = "
+                            << UBConstants::UB_SPACE_SIZE_BITS << " bits");
+
+  if (total <= UBConstants::UB_SPACE_SIZE_BITS) {
+    LOG_DEBUG("safe, no pruning needed");
+    return success();
+  }
+
+  if (annotMarks.empty()) {
+    LOG_DEBUG("no computable multi_buffer marks to prune");
+    return success();
+  }
+
+  llvm::sort(annotMarks,
+             [](const auto &a, const auto &b) { return a.second > b.second; });
+
+  LOG_DEBUG("collected " << annotMarks.size() << " annot marks");
+
+  int deleted = 0;
+  for (auto &[markOp, size] : annotMarks) {
+    markOp->removeAttr(hivm::MultiBufferAttr::name);
+    ++deleted;
+
+    auto result = checkUBOverflow(module);
+    LOG_DEBUG("after deleting mark #" << deleted << " (size " << size
+                                      << " bits): UB = " << result.totalBits
+                                      << " bits");
+
+    if (result.totalBits <= UBConstants::UB_SPACE_SIZE_BITS)
+      break;
+  }
+
+  return success();
+}
+
+void UBOverflowCheckerPass::runOnOperation() {
+  ModuleOp module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
+  LOG_DEBUG("Enter UBOverflowChecker pass");
+
+  if (failed(pruneMultiBufferMarks(module))) {
+    LOG_DEBUG("pruneMultiBufferMarks failed (non-fatal)");
+  }
+
+  LOG_DEBUG("Process successfully");
+}
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<OperationPass<ModuleOp>> createUBOverflowCheckerPass() {
+  return std::make_unique<UBOverflowCheckerPass>();
+}
+
+void registerUBOverflowCheckerPasses() {
+  registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return createUBOverflowCheckerPass();
+  });
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromComputePass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromComputePass.cpp
@@ -23,6 +23,7 @@
 #include "ascend/include/DynamicCVPipeline/SeparateMemoryFromComputePass.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/SeparateMemoryFromCompute/MarkGMLoadPass.h"
+#include "ascend/include/DynamicCVPipeline/SeparateMemoryFromCompute/UBOverflowChecker.h"
 #include "mlir/Pass/PassManager.h"
 #include "llvm/Support/Debug.h"
 
@@ -44,12 +45,9 @@ void SeparateMemoryFromComputePass::runOnOperation() {
   LDBG("Enter SeparateMemoryFromCompute pass");
 
   pm.addPass(createMarkGMLoadPass());
+  pm.addPass(createUBOverflowCheckerPass());
 
   if (failed(runPipeline(pm, module))) {
-    module->emitError() << "[" << DEBUG_TYPE << "] Pass failed!";
-    if (!CVPipeline::hasFallbackAttr(module)) {
-      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
-    }
     return;
   }
 
@@ -65,6 +63,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createSeparateMemoryFromComputePass() {
 
 void registerSeparateMemoryFromComputePasses() {
   registerPass(createMarkGMLoadPass);
+  registerPass(createUBOverflowCheckerPass);
 }
 
 } // namespace triton

--- a/third_party/ascend/patch/triton-ascend-3.6.0.patch
+++ b/third_party/ascend/patch/triton-ascend-3.6.0.patch
@@ -227,7 +227,7 @@ diff --git a/bin/RegisterTritonDialects.h b/bin/RegisterTritonDialects.h
 index 48049f026..e96284bc2 100644
 --- a/bin/RegisterTritonDialects.h
 +++ b/bin/RegisterTritonDialects.h
-@@ -1,6 +1,35 @@
+@@ -1,6 +1,36 @@
  #pragma once
 +#include "ascend/include/AutoBlockify/Passes.h"
 +#include "ascend/include/DiscreteMaskAccessConversion/Passes.h"
@@ -238,6 +238,7 @@ index 48049f026..e96284bc2 100644
 +#include "ascend/include/DynamicCVPipeline/ComputeBlockOptPass.h"
 +#include "ascend/include/DynamicCVPipeline/Passes.h"
 +#include "ascend/include/DynamicCVPipeline/RemoveAttributes.h"
++#include "ascend/include/DynamicCVPipeline/SeparateMemoryFromCompute/UBOverflowChecker.h"
 +#include "ascend/include/DynamicCVPipeline/SeparateMemoryFromComputePass.h"
 +#include "ascend/include/DynamicCVPipeline/SplitDataflow/RefineArgsBlockId.h"
 +#include "ascend/include/DynamicCVPipeline/StandardizeOp.h"
@@ -283,7 +284,7 @@ index 48049f026..e96284bc2 100644
    mlir::registerLLVMDIScope();
    mlir::LLVM::registerInlinerInterface(registry);
    mlir::NVVM::registerInlinerInterface(registry);
-@@ -136,16 +178,38 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
+@@ -136,16 +178,39 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
    mlir::triton::proton::gpu::registerScheduleBufferStorePass();
    mlir::triton::proton::gpu::registerAddSchedBarriersPass();
  
@@ -294,6 +295,7 @@ index 48049f026..e96284bc2 100644
 +  mlir::triton::registerAddControlFlowConditionPasses();
 +  mlir::triton::registerAddMultiBufferOuterScopePasses();
 +  mlir::triton::registerAddMultiBufferInnerScopePasses();
++  mlir::triton::registerUBOverflowCheckerPasses();
 +  mlir::triton::registerRemoveSsbufAttrPasses();
 +  mlir::triton::registerAnalyzeDataFlowPasses();
 +  mlir::triton::registerComputeBlockOptPasses();
@@ -331,13 +333,13 @@ index 2d2570771..91ed8b79a 100644
 @@ -1,4 +1,5 @@
  #include "./RegisterTritonDialects.h"
 +#include "ascend/include/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.h"
- 
+
  #include "mlir/Tools/mlir-opt/MlirOptMain.h"
- 
+
 @@ -6,6 +7,9 @@ int main(int argc, char **argv) {
    mlir::DialectRegistry registry;
    registerTritonDialects(registry);
- 
+
 +  // Register AddMultiBufferInnerScope pass
 +  mlir::triton::registerAddMultiBufferInnerScopePasses();
 +

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/test_mark_gm_load_hint.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/test_mark_gm_load_hint.mlir
@@ -17,7 +17,7 @@ func.func @hint_force_on(%arg0: memref<?xf16>) {
       %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [128], strides: [1] : memref<?xf16> to memref<128xf16, strided<[1], offset: ?>>
       %alloc = memref.alloc() : memref<128xf16>
       // CHECK: memref.alloc() : memref<128xf16>
-      // CHECK-NEXT: annotation.mark %{{.*}} {hivm.multi_buffer = 2 : i32} : memref<128xf16>
+      // CHECK-NEXT: annotation.mark %{{.*}} {gm_load_hint, hivm.multi_buffer = 2 : i32} : memref<128xf16>
       memref.copy %reinterpret_cast, %alloc : memref<128xf16, strided<[1], offset: ?>> to memref<128xf16>
       %tensor = bufferization.to_tensor %alloc restrict writable : memref<128xf16> to tensor<128xf16>
       annotation.mark %tensor {gm_load = 2 : i32} : tensor<128xf16>

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/ub_overflow_check.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/ub_overflow_check.mlir
@@ -1,0 +1,136 @@
+// RUN: triton-opt -split-input-file --ub-overflow-check %s | FileCheck %s
+
+// ============================================================================
+// Test 1: Safe — UB estimate under threshold, all marks preserved.
+//   Two 128x128xf32 annot buffers (alignedSize=262144 bits each).
+//   Wave UB = 2 x (262144 x 2) = 1048576 bits < 2031616 => SAFE.
+// ============================================================================
+
+func.func @safe_no_pruning() {
+  %c0_i32 = arith.constant 0 : i32
+  %c8_i32 = arith.constant 8 : i32
+  %c1_i32 = arith.constant 1 : i32
+
+  // CHECK-LABEL: func.func @safe_no_pruning
+
+  scope.scope : () -> () {
+    scf.for %i = %c0_i32 to %c8_i32 step %c1_i32 : i32 {
+      // CHECK: memref.alloc() : memref<128x128xf32>
+      // CHECK-NEXT: annotation.mark %{{.*}} {hivm.multi_buffer = 2 : i32} : memref<128x128xf32>
+      %a1 = memref.alloc() : memref<128x128xf32>
+      annotation.mark %a1 {hivm.multi_buffer = 2 : i32} : memref<128x128xf32>
+      // CHECK: memref.alloc() : memref<128x128xf32>
+      // CHECK-NEXT: annotation.mark %{{.*}} {hivm.multi_buffer = 2 : i32} : memref<128x128xf32>
+      %a2 = memref.alloc() : memref<128x128xf32>
+      annotation.mark %a2 {hivm.multi_buffer = 2 : i32} : memref<128x128xf32>
+    }
+    scope.return
+  } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+  return
+}
+
+// -----
+
+// ============================================================================
+// Test 2: Overflow — largest multi_buffer mark pruned.
+//   One 256x256xf32 (alignedSize=1048576, expanded=2097152)
+//   Two 64x64xf32 (alignedSize=65536 each, expanded=131072 each)
+//   Wave UB = 2097152 + 2x131072 = 2359296 > 2031616 => OVERFLOW.
+//   Prune largest (256x256): annot→131072x2=262144, unannot→1048576.
+//   Wave UB = 1310720 < 2031616 => SAFE.
+// ============================================================================
+
+func.func @overflow_prune_largest() {
+  %c0_i32 = arith.constant 0 : i32
+  %c8_i32 = arith.constant 8 : i32
+  %c1_i32 = arith.constant 1 : i32
+
+  // CHECK-LABEL: func.func @overflow_prune_largest
+
+  scope.scope : () -> () {
+    scf.for %i = %c0_i32 to %c8_i32 step %c1_i32 : i32 {
+      // 256x256 mark pruned: markOp still exists but multi_buffer attr removed.
+      // CHECK: memref.alloc() : memref<256x256xf32>
+      // CHECK-NOT: multi_buffer
+      // CHECK: annotation.mark
+      %huge = memref.alloc() : memref<256x256xf32>
+      annotation.mark %huge {hivm.multi_buffer = 2 : i32} : memref<256x256xf32>
+
+      // Small allocs retain marks.
+      // CHECK: memref.alloc() : memref<64x64xf32>
+      // CHECK-NEXT: annotation.mark %{{.*}} {hivm.multi_buffer = 2 : i32} : memref<64x64xf32>
+      %small1 = memref.alloc() : memref<64x64xf32>
+      annotation.mark %small1 {hivm.multi_buffer = 2 : i32} : memref<64x64xf32>
+
+      // CHECK: memref.alloc() : memref<64x64xf32>
+      // CHECK-NEXT: annotation.mark %{{.*}} {hivm.multi_buffer = 2 : i32} : memref<64x64xf32>
+      %small2 = memref.alloc() : memref<64x64xf32>
+      annotation.mark %small2 {hivm.multi_buffer = 2 : i32} : memref<64x64xf32>
+    }
+    scope.return
+  } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+  return
+}
+
+// -----
+
+// ============================================================================
+// Test 3: CUBE scope skipped (only VECTOR scopes are checked).
+// ============================================================================
+
+func.func @skip_cube_scope() {
+  %c0_i32 = arith.constant 0 : i32
+  %c8_i32 = arith.constant 8 : i32
+  %c1_i32 = arith.constant 1 : i32
+
+  // CHECK-LABEL: func.func @skip_cube_scope
+  // CHECK: annotation.mark %{{.*}} {hivm.multi_buffer = 2 : i32} : memref<256x256xf32>
+
+  scope.scope : () -> () {
+    scf.for %i = %c0_i32 to %c8_i32 step %c1_i32 : i32 {
+      %a1 = memref.alloc() : memref<256x256xf32>
+      annotation.mark %a1 {hivm.multi_buffer = 2 : i32} : memref<256x256xf32>
+    }
+    scope.return
+  } {hivm.tcore_type = #hivm.tcore_type<CUBE>}
+  return
+}
+
+// -----
+
+// ============================================================================
+// Test 4: Hint-protected mark survives pruning; gm_load_hint cleaned up.
+//   A (hint, gm_load_hint + multi_buffer=2): 256x192xf32 (alignedSize=786432)
+//   B (auto, multi_buffer=2): 256x192xf32 (alignedSize=786432)
+//   Wave UB = 2 x 1572864 = 3145728 > 2031616 => OVERFLOW.
+//   A is hint-protected, cannot prune. Prune B.
+//   Wave UB = 1572864 < 2031616 => SAFE.
+// ============================================================================
+
+func.func @hint_protected_kept() {
+  %c0_i32 = arith.constant 0 : i32
+  %c8_i32 = arith.constant 8 : i32
+  %c1_i32 = arith.constant 1 : i32
+
+  // CHECK-LABEL: func.func @hint_protected_kept
+  // CHECK-NOT: gm_load_hint
+
+  scope.scope : () -> () {
+    // Hint-protected (A): mark kept, gm_load_hint removed.
+    scf.for %i = %c0_i32 to %c8_i32 step %c1_i32 : i32 {
+      // CHECK: memref.alloc() : memref<256x192xf32>
+      // CHECK-NEXT: annotation.mark %{{.*}} {hivm.multi_buffer = 2 : i32} : memref<256x192xf32>
+      %a = memref.alloc() : memref<256x192xf32>
+      annotation.mark %a {gm_load_hint, hivm.multi_buffer = 2 : i32} : memref<256x192xf32>
+    }
+    // Auto (B): pruned.
+    scf.for %j = %c0_i32 to %c8_i32 step %c1_i32 : i32 {
+      // CHECK: memref.alloc() : memref<256x192xf32>
+      // CHECK-NEXT: annotation.mark %{{.*}} : memref<256x192xf32>
+      %b = memref.alloc() : memref<256x192xf32>
+      annotation.mark %b {hivm.multi_buffer = 2 : i32} : memref<256x192xf32>
+    }
+    scope.return
+  } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+  return
+}


### PR DESCRIPTION
---
  Summary

  Add a standalone UB Overflow Checker pass that performs IR-only static analysis to estimate UB (Unified Buffer) usage at compile time. When estimated usage exceeds the UB
  capacity (~248 KB), the pass automatically prunes multi_buffer annotations to prevent runtime failures.

  Motivation

  On the Ascend NPU backend, UB space is limited (~248 KB). When multi-buffer optimization is enabled, the total buffer size may exceed UB capacity and cause runtime errors.
  Previously there was no compile-time detection mechanism — users could only discover the issue at runtime, leading to high debugging cost.

  This PR introduces a pure-IR static estimation pass that:

  - Requires no runtime calibration (PlanMemory)
  - Estimates buffer sizes purely from ttadapter IR
  - Automatically prunes multi_buffer marks in descending size order when estimated UB usage exceeds capacity, until usage falls back within safe limits

  Approach

  UB Estimation Model

  1. Buffer Collection (collectBuffers): Walks all Vector scopes to find memref::AllocOp instances, classifying them as Annot (with multi_buffer attribute) or Unannot (without).
  2. Buffer Size Computation (computeBufferSize):
    - originalSize: numElements × bitWidth
    - reducedSize: Accounts for TileAndBindSubBlock halving dim0
    - alignedSize: Accounts for EnableStrideAlign aligning the last dimension to 32 bytes, then rounding up to a 256-bit boundary
  3. UB Usage Aggregation (checkUBOverflow): Conservative estimate — each buffer contributes alignedSize × multi_buffer_num to the total.
  4. Overflow Pruning (pruneMultiBufferMarks):
    - If total ≤ UB_SPACE_SIZE_BITS (2,031,616 bits ≈ 248 KB), the pass declares it safe and exits
    - If overflow is detected, multi_buffer marks are removed one by one in descending alignedSize order (prioritizing large buffers for double-buffer sacrifice). After each
  removal, UB usage is re-evaluated until it falls within the limit
    - Buffers marked fromHint (explicitly specified via compile_hint) are never pruned

  Pass Integration

  - Registered as the ub-overflow-check pass, operating on ModuleOp
  - Integrated into the DynamicCVPipeline flow, running after MarkGMLoadPass
  - Automatically skipped for fallback scenarios (hasFallbackAttr)