### PR TITLE
[TritonToLinalg](feat) preserve addresses across pointer bitcasts

### DIFF
--- a/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
@@ -100,14 +100,18 @@ public:
 };
 
 /*
- * Move tt.bitcast to a previous location if tt.bitcast is not directly applied
- * on function arguments
+ * Preserve different-width pointer bitcasts as exact address boundaries and
+ * canonicalize only same-width pointer shape operations.
  */
 class BitcastCanonicalizer : public OpRewritePattern<triton::BitcastOp> {
 public:
-  using OpRewritePattern<triton::BitcastOp>::OpRewritePattern;
+  BitcastCanonicalizer(MLIRContext *context, bool &hadError)
+      : OpRewritePattern<triton::BitcastOp>(context), hadError(hadError) {}
   LogicalResult matchAndRewrite(triton::BitcastOp bitcastOp,
                                 PatternRewriter &rewriter) const override;
+
+private:
+  bool &hadError;
 };
 
 template <typename MathOp>

--- a/third_party/ascend/include/TritonToLinalg/TritonToLinalgPass.h
+++ b/third_party/ascend/include/TritonToLinalg/TritonToLinalgPass.h
@@ -83,7 +83,8 @@ private:
                        TritonTypeConverter &tritonTypeConverter);
 
   void
-  populateTritonToLinalgCanonicalizationPatterns(RewritePatternSet &patterns);
+  populateTritonToLinalgCanonicalizationPatterns(RewritePatternSet &patterns,
+                                                 bool &hadError);
 
   void populateTritonToLinalgConversionPatterns(TypeConverter &typeConverter,
                                                 RewritePatternSet &patterns,

--- a/third_party/ascend/include/TritonToUnstructure/OffsetAnalysis.h
+++ b/third_party/ascend/include/TritonToUnstructure/OffsetAnalysis.h
@@ -29,6 +29,7 @@
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Value.h"
+#include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "llvm/ADT/DenseMap.h"
@@ -95,6 +96,7 @@ public:
   SmallVector<Value> getOffsets() const;
   SmallVector<Value> &getOffsetsRef();
   bool isScalarLike() const;
+  bool isByteAddressed() const;
   SmallVector<AxisInfo> &getStructuredRef();
   const SmallVector<AxisInfo> &getStructured() const;
   int getRank() const;
@@ -110,6 +112,7 @@ public:
   void setStructured(ArrayRef<AxisInfo> structured);
   void setStructured(const PtrOffsetInfo &other);
   void setScalarLike(bool scalarLike);
+  void setByteAddressed(bool byteAddressed = true);
 
   bool isStructured(int dim) const;
   bool isStructured() const;
@@ -120,157 +123,181 @@ public:
 
 private:
   Value ptr;
+  // The offset normally uses the pointee element as its unit, matching
+  // tt.addptr. After a different-width pointer bitcast, combining offsets in
+  // either the source or destination element unit can lose address bits. In
+  // that case byteAddressed is set and this same field stores an exact signed
+  // byte offset from ptr. Every later AddPtr contributes
+  // offset * sizeof(current pointee), while Bitcast itself contributes zero.
+  // Consumers must inspect byteAddressed before interpreting offset.
   Value offset;
   SmallVector<Value> tptOffsets;
 
   bool scalarLike = false;
+  bool byteAddressed = false;
 
   SmallVector<AxisInfo> structured;
 };
 
 PtrOffsetInfo combineInfo(const PtrOffsetInfo &lhs, const PtrOffsetInfo &rhs);
 
+// Compatibility entry point for legacy argument reconstruction. New analysis
+// code must use parseChecked so diagnostics stop the enclosing pass.
 void parse(Value operand, const Location &loc, RewriterBase &rewriter,
            llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
-void parseLoopRegionIterArg(LoopLikeOpInterface loopOp, const Location &loc,
+LogicalResult parseChecked(Value operand, const Location &loc,
+                           RewriterBase &rewriter,
+                           llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+
+LogicalResult
+parseLoopRegionIterArg(LoopLikeOpInterface loopOp, const Location &loc,
+                       RewriterBase &rewriter,
+                       llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap,
+                       BlockArgument regionIterArg);
+
+LogicalResult parseArithOp(Operation *arithOp, const Location &loc,
+                           RewriterBase &rewriter,
+                           llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+
+LogicalResult parseTritonOp(Operation *tritonOp, const Location &loc,
                             RewriterBase &rewriter,
-                            llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap,
-                            BlockArgument regionIterArg);
+                            llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
-void parseArithOp(Operation *arithOp, const Location &loc,
-                  RewriterBase &rewriter,
-                  llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+LogicalResult parseAddPtr(triton::AddPtrOp op, const Location &loc,
+                          RewriterBase &rewriter,
+                          llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
-void parseTritonOp(Operation *tritonOp, const Location &loc,
-                   RewriterBase &rewriter,
-                   llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
-
-void parseTritonOp(Operation *tritonOp, const Location &loc,
-                   RewriterBase &rewriter,
-                   llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
-
-void parseAddPtr(triton::AddPtrOp op, const Location &loc,
-                 RewriterBase &rewriter,
-                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
-
-void parseSplat(triton::SplatOp op, const Location &loc, RewriterBase &rewriter,
-                llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+LogicalResult parseSplat(triton::SplatOp op, const Location &loc,
+                         RewriterBase &rewriter,
+                         llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
 template <typename BinOpTy>
-void parseBinaryOp(BinOpTy op, const Location &loc, RewriterBase &rewriter,
-                   llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+LogicalResult parseBinaryOp(BinOpTy op, const Location &loc,
+                            RewriterBase &rewriter,
+                            llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
-void parseAddI(arith::AddIOp op, const Location &loc, RewriterBase &rewriter,
-               llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+LogicalResult parseAddI(arith::AddIOp op, const Location &loc,
+                        RewriterBase &rewriter,
+                        llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
-void parseSubI(arith::SubIOp op, const Location &loc, RewriterBase &rewriter,
-               llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+LogicalResult parseSubI(arith::SubIOp op, const Location &loc,
+                        RewriterBase &rewriter,
+                        llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
-void parseIndexCast(arith::IndexCastOp op, const Location &loc,
-                    RewriterBase &rewriter,
-                    llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+LogicalResult parseIndexCast(arith::IndexCastOp op, const Location &loc,
+                             RewriterBase &rewriter,
+                             llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
 template <typename ConstOpTy>
-void parseConstantOp(ConstOpTy dst, const Location &loc, RewriterBase &rewriter,
-                     llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+LogicalResult parseConstantOp(ConstOpTy dst, const Location &loc,
+                              RewriterBase &rewriter,
+                              llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
-void parseMakeRange(triton::MakeRangeOp op, const Location &loc,
-                    RewriterBase &rewriter,
-                    llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+LogicalResult parseMakeRange(triton::MakeRangeOp op, const Location &loc,
+                             RewriterBase &rewriter,
+                             llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
-void parseExtSI(arith::ExtSIOp op, const Location &loc, RewriterBase &rewriter,
-                llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+LogicalResult parseExtSI(arith::ExtSIOp op, const Location &loc,
+                         RewriterBase &rewriter,
+                         llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
-void parseBitcast(triton::BitcastOp op, const Location &loc,
-                  RewriterBase &rewriter,
-                  llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+LogicalResult parseBitcast(triton::BitcastOp op, const Location &loc,
+                           RewriterBase &rewriter,
+                           llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
-void parseLoad(triton::LoadOp op, const Location &loc, RewriterBase &rewriter,
-               llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+LogicalResult parseLoad(triton::LoadOp op, const Location &loc,
+                        RewriterBase &rewriter,
+                        llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
-void parseMulI(arith::MulIOp op, const Location &loc, RewriterBase &rewriter,
-               llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+LogicalResult parseMulI(arith::MulIOp op, const Location &loc,
+                        RewriterBase &rewriter,
+                        llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
-void parseBroadcast(triton::BroadcastOp op, const Location &loc,
-                    RewriterBase &rewriter,
-                    llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+LogicalResult parseBroadcast(triton::BroadcastOp op, const Location &loc,
+                             RewriterBase &rewriter,
+                             llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
-void parseExpandDims(triton::ExpandDimsOp op, const Location &loc,
-                     RewriterBase &rewriter,
-                     llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+LogicalResult parseExpandDims(triton::ExpandDimsOp op, const Location &loc,
+                              RewriterBase &rewriter,
+                              llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
-void parseClampF(triton::ClampFOp op, const Location &loc,
-                 RewriterBase &rewriter,
-                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+LogicalResult parseClampF(triton::ClampFOp op, const Location &loc,
+                          RewriterBase &rewriter,
+                          llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
-void parseSelect(arith::SelectOp op, const Location &loc,
-                 RewriterBase &rewriter,
-                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+LogicalResult parseSelect(arith::SelectOp op, const Location &loc,
+                          RewriterBase &rewriter,
+                          llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
-void parseFPToSI(arith::FPToSIOp op, const Location &loc,
-                 RewriterBase &rewriter,
-                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+LogicalResult parseFPToSI(arith::FPToSIOp op, const Location &loc,
+                          RewriterBase &rewriter,
+                          llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
-void parseSIToFP(arith::SIToFPOp op, const Location &loc,
-                 RewriterBase &rewriter,
-                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+LogicalResult parseSIToFP(arith::SIToFPOp op, const Location &loc,
+                          RewriterBase &rewriter,
+                          llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
 // FIXME:Z|wait triton version upgrade to 3.4
 // void parseMakeTensorDesc(triton::MakeTensorDescOp op, const Location &loc,
 //                          RewriterBase &rewriter,
 //                          llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
-void parseMakeTensorPtr(triton::MakeTensorPtrOp op, const Location &loc,
-                        RewriterBase &rewriter,
-                        llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
-
-void parseAdvance(triton::AdvanceOp op, const Location &loc,
-                  RewriterBase &rewriter,
-                  llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
-
-void parseReduce(triton::ReduceOp op, const Location &loc,
-                 RewriterBase &rewriter,
-                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
-
-void parseReduceReturn(triton::ReduceReturnOp op, const Location &loc,
-                       RewriterBase &rewriter,
-                       llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
-
-void parseIf(scf::IfOp op, const Location &loc, RewriterBase &rewriter,
-             llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap, Value dst);
-
-void parseYield(scf::YieldOp op, const Location &loc, RewriterBase &rewriter,
-                llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
-
-void parseLoopOp(LoopLikeOpInterface op, const Location &loc,
-                 RewriterBase &rewriter,
-                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap, Value dst);
-
-void parseExtractSlice(tensor::ExtractSliceOp op, const Location &loc,
-                       RewriterBase &rewriter,
-                       llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
-
-void parseInsertSlice(tensor::InsertSliceOp op, const Location &loc,
-                      RewriterBase &rewriter,
-                      llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
-
-void parseExtract(tensor::ExtractOp op, const Location &loc,
-                  RewriterBase &rewriter,
-                  llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
-
-void parseInsert(tensor::InsertOp op, const Location &loc,
-                 RewriterBase &rewriter,
-                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
-
-void parseIntToPtr(triton::IntToPtrOp op, const Location &loc,
+LogicalResult
+parseMakeTensorPtr(triton::MakeTensorPtrOp op, const Location &loc,
                    RewriterBase &rewriter,
                    llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
 
-void parseStructuredCustomOp(Operation *op, const Location &loc,
-                             RewriterBase &rewriter,
-                             llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap,
-                             unsigned resultIdx);
+LogicalResult parseAdvance(triton::AdvanceOp op, const Location &loc,
+                           RewriterBase &rewriter,
+                           llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+
+LogicalResult parseReduce(triton::ReduceOp op, const Location &loc,
+                          RewriterBase &rewriter,
+                          llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+
+LogicalResult
+parseReduceReturn(triton::ReduceReturnOp op, const Location &loc,
+                  RewriterBase &rewriter,
+                  llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+
+LogicalResult parseIf(scf::IfOp op, const Location &loc, RewriterBase &rewriter,
+                      llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap,
+                      Value dst);
+
+LogicalResult parseYield(scf::YieldOp op, const Location &loc,
+                         RewriterBase &rewriter,
+                         llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+
+LogicalResult parseLoopOp(LoopLikeOpInterface op, const Location &loc,
+                          RewriterBase &rewriter,
+                          llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap,
+                          Value dst);
+
+LogicalResult
+parseExtractSlice(tensor::ExtractSliceOp op, const Location &loc,
+                  RewriterBase &rewriter,
+                  llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+
+LogicalResult parseInsertSlice(tensor::InsertSliceOp op, const Location &loc,
+                               RewriterBase &rewriter,
+                               llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+
+LogicalResult parseExtract(tensor::ExtractOp op, const Location &loc,
+                           RewriterBase &rewriter,
+                           llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+
+LogicalResult parseInsert(tensor::InsertOp op, const Location &loc,
+                          RewriterBase &rewriter,
+                          llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+
+LogicalResult parseIntToPtr(triton::IntToPtrOp op, const Location &loc,
+                            RewriterBase &rewriter,
+                            llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap);
+
+LogicalResult parseStructuredCustomOp(
+    Operation *op, const Location &loc, RewriterBase &rewriter,
+    llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap, unsigned resultIdx);
 } // namespace triton
 
 } // namespace mlir

--- a/third_party/ascend/include/TritonToUnstructure/UnstructureConversionPass.h
+++ b/third_party/ascend/include/TritonToUnstructure/UnstructureConversionPass.h
@@ -114,7 +114,8 @@ private:
 
   template <typename... Args>
   MemAccOpTy createMemAccOp(MemAccOpTy op, Value ptrToAccess, Location loc,
-                            PatternRewriter &rewriter, Args &&...args) const;
+                            PatternRewriter &rewriter, bool preserveLoadMask,
+                            Args &&...args) const;
 
   const llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap;
   const llvm::SmallDenseMap<Value, bool> &fromTensorArg;

--- a/third_party/ascend/include/Utils/Utils.h
+++ b/third_party/ascend/include/Utils/Utils.h
@@ -50,6 +50,8 @@ const std::string discreteMaskAttrName = "DiscreteMask";
 const std::string discreteAttrName = "DiscreteMemAccess";
 const std::string continuousAttrName = "ContinuousMemAccess";
 const std::string customSrcPtrIndexAttrName = "SrcPtrIndex";
+inline constexpr llvm::StringLiteral pointerBitcastPointerCastAttrName =
+    "tt.pointer_bitcast_pointer_cast";
 
 bool isaPermutedMemRefType(MemRefType);
 

--- a/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
+++ b/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
@@ -58,6 +58,109 @@ static bool enableSyncBlockLockFlag = true;
 static constexpr const char *routeDiscreteMaskToSimtAttrName =
     "route_discrete_mask_to_simt";
 
+static triton::PointerType getScalarPointerType(Type type) {
+  if (auto shapedType = dyn_cast<ShapedType>(type))
+    type = shapedType.getElementType();
+  return dyn_cast<triton::PointerType>(type);
+}
+
+static unsigned getPointerPointeeByteWidth(Type type) {
+  auto pointerType = getScalarPointerType(type);
+  if (!pointerType)
+    return 0;
+
+  Type pointeeType = pointerType.getPointeeType();
+  if (auto shapedType = dyn_cast<ShapedType>(pointeeType))
+    pointeeType = shapedType.getElementType();
+  if (!pointeeType.isIntOrFloat())
+    return 0;
+
+  unsigned bitWidth = pointeeType.getIntOrFloatBitWidth();
+  if (bitWidth == 1)
+    bitWidth = 8;
+  if (bitWidth < 8 || bitWidth % 8 != 0)
+    return 0;
+  return bitWidth / 8;
+}
+
+static bool isPointerValue(Type type) {
+  if (auto shapedType = dyn_cast<ShapedType>(type))
+    type = shapedType.getElementType();
+  return isa<triton::PointerType>(type);
+}
+
+// Discrete-mask fallback may replace a masked memory operation with an
+// unmasked one followed by a select. That is not safe for exact byte addresses:
+// a false lane may contain an address that must never be accessed. Follow only
+// pointer-typed operands so ordinary value bitcasts cannot activate this gate.
+// Region operands are included because control-flow results and block arguments
+// carry their pointer provenance through terminators instead of direct
+// operands.
+static bool isDerivedFromDifferentWidthPointerBitcast(Value pointer) {
+  llvm::SmallVector<Value, 8> worklist;
+  llvm::SmallPtrSet<Value, 8> visited;
+  worklist.push_back(pointer);
+
+  auto enqueuePointerOperands = [&](Operation *operation) {
+    for (Value operand : operation->getOperands()) {
+      if (isPointerValue(operand.getType()))
+        worklist.push_back(operand);
+    }
+  };
+
+  while (!worklist.empty()) {
+    Value value = worklist.pop_back_val();
+    if (!visited.insert(value).second)
+      continue;
+
+    Operation *definingOp = value.getDefiningOp();
+    if (!definingOp) {
+      auto blockArgument = dyn_cast<BlockArgument>(value);
+      if (!blockArgument)
+        continue;
+      Operation *parentOp = blockArgument.getOwner()->getParentOp();
+      if (!parentOp || isa<triton::FuncOp>(parentOp))
+        continue;
+      enqueuePointerOperands(parentOp);
+      parentOp->walk([&](Operation *nestedOp) {
+        if (nestedOp != parentOp)
+          enqueuePointerOperands(nestedOp);
+      });
+      continue;
+    }
+
+    if (auto bitcastOp = dyn_cast<triton::BitcastOp>(definingOp)) {
+      unsigned sourceWidth =
+          getPointerPointeeByteWidth(bitcastOp.getSrc().getType());
+      unsigned targetWidth = getPointerPointeeByteWidth(bitcastOp.getType());
+      if (sourceWidth && targetWidth && sourceWidth != targetWidth)
+        return true;
+    }
+
+    enqueuePointerOperands(definingOp);
+    definingOp->walk([&](Operation *nestedOp) {
+      if (nestedOp != definingOp)
+        enqueuePointerOperands(nestedOp);
+    });
+  }
+  return false;
+}
+
+static LogicalResult
+rejectDifferentWidthPointerBitcastDiscreteMask(Operation *op, Value pointer,
+                                               bool &rejectedUnsafeMask) {
+  if (!isDerivedFromDifferentWidthPointerBitcast(pointer))
+    return success();
+
+  if (!rejectedUnsafeMask) {
+    op->emitError(
+        "different-width pointer bitcast does not support discrete masked "
+        "memory access");
+  }
+  rejectedUnsafeMask = true;
+  return failure();
+}
+
 static bool traceUserToTargetOp(Value val) {
   llvm::SmallVector<Value, 32> worklist;
   llvm::SmallPtrSet<Value, 32> visited;
@@ -264,7 +367,9 @@ static MaskDecomposition decomposeAndMask(Operation *op, Value mask,
 }
 
 struct DiscreteMaskStoreConversion : OpRewritePattern<triton::StoreOp> {
-  using OpRewritePattern<triton::StoreOp>::OpRewritePattern;
+  DiscreteMaskStoreConversion(MLIRContext *context, bool &rejectedUnsafeMask)
+      : OpRewritePattern<triton::StoreOp>(context),
+        rejectedUnsafeMask(rejectedUnsafeMask) {}
 
   LogicalResult matchAndRewrite(triton::StoreOp op,
                                 PatternRewriter &rewriter) const final {
@@ -285,6 +390,9 @@ struct DiscreteMaskStoreConversion : OpRewritePattern<triton::StoreOp> {
       op->setAttr(routeDiscreteMaskToSimtAttrName, rewriter.getUnitAttr());
       return failure();
     }
+    if (failed(rejectDifferentWidthPointerBitcastDiscreteMask(
+            op, dst, rejectedUnsafeMask)))
+      return failure();
 
     // When mask = contMask & discMask, use contMask to bound GM accesses and
     // discMask to select the final per-element value. This prevents the
@@ -332,10 +440,15 @@ struct DiscreteMaskStoreConversion : OpRewritePattern<triton::StoreOp> {
     rewriter.replaceOp(op, newStore);
     return success();
   }
+
+private:
+  bool &rejectedUnsafeMask;
 };
 
 struct DiscreteMaskLoadConversion : OpRewritePattern<triton::LoadOp> {
-  using OpRewritePattern<triton::LoadOp>::OpRewritePattern;
+  DiscreteMaskLoadConversion(MLIRContext *context, bool &rejectedUnsafeMask)
+      : OpRewritePattern<triton::LoadOp>(context),
+        rejectedUnsafeMask(rejectedUnsafeMask) {}
 
   LogicalResult matchAndRewrite(triton::LoadOp op,
                                 PatternRewriter &rewriter) const final {
@@ -355,6 +468,9 @@ struct DiscreteMaskLoadConversion : OpRewritePattern<triton::LoadOp> {
       op->setAttr(routeDiscreteMaskToSimtAttrName, rewriter.getUnitAttr());
       return failure();
     }
+    if (failed(rejectDifferentWidthPointerBitcastDiscreteMask(
+            op, ptr, rejectedUnsafeMask)))
+      return failure();
 
     // SIMD path: when mask = contMask & discMask, load only the safe range
     // defined by contMask and use discMask for the per-element select,
@@ -396,11 +512,16 @@ struct DiscreteMaskLoadConversion : OpRewritePattern<triton::LoadOp> {
     rewriter.replaceOp(op, discreteMaskOp);
     return success();
   }
+
+private:
+  bool &rejectedUnsafeMask;
 };
 
 struct DiscreteMaskAtomicConversion
     : OpRewritePattern<mlir::triton::AtomicRMWOp> {
-  using OpRewritePattern<mlir::triton::AtomicRMWOp>::OpRewritePattern;
+  DiscreteMaskAtomicConversion(MLIRContext *context, bool &rejectedUnsafeMask)
+      : OpRewritePattern<mlir::triton::AtomicRMWOp>(context),
+        rejectedUnsafeMask(rejectedUnsafeMask) {}
 
   LogicalResult matchAndRewrite(mlir::triton::AtomicRMWOp op,
                                 PatternRewriter &rewriter) const final {
@@ -411,6 +532,9 @@ struct DiscreteMaskAtomicConversion
     RMWOp rmwOp = op.getAtomicRmwOp();
 
     if (failed(isDiscreteMask(op, mask, rewriter)))
+      return failure();
+    if (failed(rejectDifferentWidthPointerBitcastDiscreteMask(
+            op, ptr, rejectedUnsafeMask)))
       return failure();
 
     const std::map<RMWOp, TypelessValue> initMap = {
@@ -452,6 +576,9 @@ struct DiscreteMaskAtomicConversion
     rewriter.replaceOp(op, newAtomicOp);
     return success();
   }
+
+private:
+  bool &rejectedUnsafeMask;
 };
 
 DiscreteMaskAccessConversionPass::DiscreteMaskAccessConversionPass(
@@ -465,12 +592,18 @@ void DiscreteMaskAccessConversionPass::runOnOperation() {
   enableSyncBlockLockFlag = !tileNonOverlap;
   auto moduleOp = getOperation();
 
+  bool rejectedUnsafeMask = false;
   RewritePatternSet patterns(&getContext());
   patterns.add<DiscreteMaskLoadConversion, DiscreteMaskStoreConversion,
-               DiscreteMaskAtomicConversion>(patterns.getContext());
-  if (failed(applyPatternsGreedily(moduleOp, std::move(patterns)))) {
-    moduleOp->emitError("failed to apply discrete mask access patterns");
+               DiscreteMaskAtomicConversion>(patterns.getContext(),
+                                             rejectedUnsafeMask);
+  LogicalResult rewriteResult =
+      applyPatternsGreedily(moduleOp, std::move(patterns));
+  if (failed(rewriteResult) || rejectedUnsafeMask) {
+    if (!rejectedUnsafeMask)
+      moduleOp->emitError("failed to apply discrete mask access patterns");
     signalPassFailure();
+    return;
   }
 
   // Clean up dead analysis ops left behind by MaskState::parse().

--- a/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
@@ -59,6 +59,21 @@
 namespace mlir {
 namespace triton {
 
+static hivm::PointerCastOp
+createPointerCastFromIntToPtr(triton::IntToPtrOp intToPtrOp,
+                              ConversionPatternRewriter &rewriter) {
+  auto pointerType =
+      cast<triton::PointerType>(intToPtrOp.getResult().getType());
+  auto memrefType =
+      MemRefType::get({ShapedType::kDynamic}, pointerType.getPointeeType());
+  auto pointerCast = rewriter.create<hivm::PointerCastOp>(
+      intToPtrOp.getLoc(), memrefType, ValueRange{intToPtrOp.getSrc()});
+  if (intToPtrOp->hasAttr(ConverterUtils::pointerBitcastPointerCastAttrName))
+    pointerCast->setAttr(ConverterUtils::pointerBitcastPointerCastAttrName,
+                         rewriter.getUnitAttr());
+  return pointerCast;
+}
+
 // MemAccType selectMaxMemAccTy(const MemAccType &v1, const MemAccType &v2) {
 //   return (v1 > v2) ? v1 : v2;
 // }
@@ -312,6 +327,8 @@ void BlockData::divBlock(BlockData &lBlock, BlockData &rBlock, Location loc,
   assert(this->isEmpty() && lBlock.getRank() == rBlock.getRank());
 
   assert(!(lBlock.hasSource() && rBlock.hasSource()));
+  // Integer division is not affine over a tensor block. For example,
+  // (1 + i) / 2 cannot be represented as 1 / 2 + i * (1 / 2).
   assert(lBlock.isScalar() && rBlock.isScalar());
 
   auto rScalar = rBlock.getScalar();
@@ -337,6 +354,38 @@ memref::ReinterpretCastOp BlockData::createCastOp(ArrayRef<int64_t> resultShape,
                                                   const Location &loc,
                                                   OpBuilder &builder) const {
   OpFoldResult resOffset = this->inferBlockOffset(loc, builder);
+  Value castSource = this->source;
+
+  // A pointer bitcast changes the unit in which offsets are expressed. Fold
+  // the already-rescaled offset into the typed pointer address before creating
+  // the memref view. This keeps the reinterpret_cast operand offset and its
+  // result layout consistent, and prevents the PointerCast post-processing
+  // from changing a type that is already consumed by downstream operations.
+  if (auto pointerCast = castSource.getDefiningOp<hivm::PointerCastOp>();
+      pointerCast &&
+      pointerCast->hasAttr(ConverterUtils::pointerBitcastPointerCastAttrName)) {
+    Value offset = getValueOrCreateConstantIndexOp(builder, loc, resOffset);
+    Value address = pointerCast.getAddrs().front();
+    if (offset.getType() != address.getType())
+      offset =
+          builder.create<arith::IndexCastOp>(loc, address.getType(), offset);
+
+    auto elementType =
+        cast<BaseMemRefType>(castSource.getType()).getElementType();
+    int64_t elementByteWidth = (elementType.getIntOrFloatBitWidth() + 7) / 8;
+    Value byteWidth = builder.create<arith::ConstantOp>(
+        loc, builder.getIntegerAttr(address.getType(), elementByteWidth));
+    Value byteOffset = builder.create<arith::MulIOp>(loc, offset, byteWidth);
+    Value rebasedAddress =
+        builder.create<arith::AddIOp>(loc, address, byteOffset);
+    auto rebasedPointerCast = builder.create<hivm::PointerCastOp>(
+        loc, castSource.getType(), ValueRange{rebasedAddress});
+    rebasedPointerCast->setAttr(
+        ConverterUtils::pointerBitcastPointerCastAttrName,
+        builder.getUnitAttr());
+    castSource = rebasedPointerCast.getResult();
+    resOffset = builder.getIndexAttr(0);
+  }
   auto resultType = this->getResultMemrefType(
       isa<Attribute>(resOffset) ? getConstantIntValue(resOffset).value()
                                 : ShapedType::kDynamic,
@@ -355,7 +404,7 @@ memref::ReinterpretCastOp BlockData::createCastOp(ArrayRef<int64_t> resultShape,
   }
 
   return builder.create<memref::ReinterpretCastOp>(
-      loc, resultType, this->source, resOffset, this->sizes, strides);
+      loc, resultType, castSource, resOffset, this->sizes, strides);
 }
 
 void BlockData::dump() const {
@@ -596,6 +645,7 @@ void BlockDataParser::parseDiv(
   BlockData lBlock, rBlock;
   parse(op.getLhs(), lBlock, loc, rewriter, known);
   parse(op.getRhs(), rBlock, loc, rewriter, known);
+
   data.divBlock(lBlock, rBlock, loc, rewriter);
 }
 
@@ -731,9 +781,9 @@ void BlockDataParser::parseBitcast(
         cast<triton::PointerType>(op.getSrc().getType()).getPointeeType();
     auto resPointeeType = cast<triton::PointerType>(resType).getPointeeType();
 
-    // Handling special case
-    // If Op is MetaUse or src is i1 block argument and dst is i8,
-    // it should be converted to UnrealizedConversionCast
+    // Keep the established same-storage pointer conversion path. Different
+    // storage widths are canonicalized to an exact integer address before
+    // BlockPtrAnalysis and therefore do not rely on this remapping.
     if (op->hasAttr("MetaUse") ||
         (isa<BlockArgument>(op.getSrc()) &&
          srcPointeeType == rewriter.getIntegerType(1) &&
@@ -1355,22 +1405,16 @@ void BlockDataParser::rewriteAddPtr(
 
   if (auto intToPtrOp = dyn_cast_or_null<triton::IntToPtrOp>(
           data.getSourceRef().getDefiningOp())) {
-    auto rtype = cast<triton::PointerType>(intToPtrOp.getResult().getType());
-    auto memrefType =
-        MemRefType::get({ShapedType::kDynamic}, rtype.getPointeeType());
-    auto hivmPointCastOp = rewriter.create<hivm::PointerCastOp>(
-        intToPtrOp.getLoc(), memrefType, ValueRange{intToPtrOp.getSrc()});
-    data.setSource(hivmPointCastOp.getResult());
+    data.setSource(
+        createPointerCastFromIntToPtr(intToPtrOp, rewriter).getResult());
   }
 
   if (data.hasResElemTy()) {
-    // Handle bitcast scenario
     auto memrefType = dyn_cast<BaseMemRefType>(data.getSourceRef().getType())
                           .cloneWith(std::nullopt, data.getResElemTyRef());
-    UnrealizedConversionCastOp castOp =
-        rewriter.create<mlir::UnrealizedConversionCastOp>(
-            op.getLoc(), memrefType, data.getSourceRef());
-    data.setSource(castOp.getOutputs()[0]);
+    auto castOp = rewriter.create<UnrealizedConversionCastOp>(
+        op.getLoc(), memrefType, data.getSourceRef());
+    data.setSource(castOp.getOutputs().front());
   }
 
   // ToDo: need to handle module scenario
@@ -1416,11 +1460,6 @@ void BlockDataParser::rewriteCustomOp(
   auto convertIntToPtr = [&rewriter](BlockData &data) {
     if (auto intToPtrOp = dyn_cast_or_null<triton::IntToPtrOp>(
             data.getSourceRef().getDefiningOp())) {
-      auto rtype = cast<triton::PointerType>(intToPtrOp.getResult().getType());
-      auto memrefType =
-          MemRefType::get({ShapedType::kDynamic}, rtype.getPointeeType());
-      auto hivmPointCastOp = rewriter.create<hivm::PointerCastOp>(
-          intToPtrOp.getLoc(), memrefType, ValueRange{intToPtrOp.getSrc()});
       if (data.getSizesRef().size() == 0) {
         data.getSizesRef().push_back(rewriter.getIndexAttr(1));
         if (data.getScalarRef().isNull()) {
@@ -1430,7 +1469,8 @@ void BlockDataParser::rewriteCustomOp(
         }
         data.getStridesRef().push_back(rewriter.getIndexAttr(1));
       }
-      data.setSource(hivmPointCastOp.getResult());
+      data.setSource(
+          createPointerCastFromIntToPtr(intToPtrOp, rewriter).getResult());
     }
   };
   for (auto in : op.getInputs()) {
@@ -1540,17 +1580,25 @@ void BlockDataParser::rewriteMakeTensorPtrOp(
 
   auto orderSize = op.getOrder().size();
 
-  // Handle base is defined by tt.bitcast
-  BlockDataParser::parse(op.getBase(), data, loc, rewriter, known);
-  if (data.hasResElemTy()) {
-    auto memrefType = dyn_cast<BaseMemRefType>(data.getSourceRef().getType())
-                          .cloneWith(std::nullopt, data.getResElemTyRef());
-    UnrealizedConversionCastOp castOp =
-        rewriter.create<mlir::UnrealizedConversionCastOp>(loc, memrefType,
-                                                          data.getSourceRef());
-    data.setSource(castOp.getOutputs()[0]);
+  // Only compiler-generated IntToPtr carries an exact byte address across a
+  // different-width pointer bitcast. Every other base, including same-width
+  // bitcasts and user IntToPtr operations, retains the main-dev path.
+  if (auto intToPtrOp = op.getBase().getDefiningOp<triton::IntToPtrOp>();
+      intToPtrOp &&
+      intToPtrOp->hasAttr(ConverterUtils::pointerBitcastPointerCastAttrName)) {
+    data.setSource(
+        createPointerCastFromIntToPtr(intToPtrOp, rewriter).getResult());
   } else {
-    data.setSource(rewriter.getRemappedValue(op.getBase()));
+    BlockDataParser::parse(op.getBase(), data, loc, rewriter, known);
+    if (data.hasResElemTy()) {
+      auto memrefType = dyn_cast<BaseMemRefType>(data.getSourceRef().getType())
+                            .cloneWith(std::nullopt, data.getResElemTyRef());
+      auto castOp = rewriter.create<UnrealizedConversionCastOp>(
+          loc, memrefType, data.getSourceRef());
+      data.setSource(castOp.getOutputs().front());
+    } else {
+      data.setSource(rewriter.getRemappedValue(op.getBase()));
+    }
   }
 
   data.getOffsetsRef() =
@@ -2504,17 +2552,24 @@ void BlockDataParser::rewriteAddPtrToUnstrucMemAcc(
       rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(1));
   auto addptrRes = op.getResult();
   assert(addptrRes.hasOneUse() && "Invalid: tt.addptr has multiple users");
-  auto loadOp = *(addptrRes.user_begin());
+  Operation *memoryOp = *(addptrRes.user_begin());
+  auto loadOp = dyn_cast<triton::LoadOp>(memoryOp);
+  auto storeOp = dyn_cast<triton::StoreOp>(memoryOp);
+  if (!loadOp && !storeOp) {
+    op.emitError("unstructured addptr result must be consumed by a load or "
+                 "store");
+    return;
+  }
 
-  // Prepare empty tensor for loop based scalar load
-  // FIXME: We use cast here because addptr must return tensor<?x!tt.ptr<f32>>.
-  // True?
-  auto resTy = cast<ShapedType>(addptrRes.getType());
-  auto resEPtrTy = resTy.getElementType();
-  auto resETy = cast<triton::PointerType>(resEPtrTy).getPointeeType();
-  Value loaded = rewriter.create<tensor::EmptyOp>(loc, blockSizes, resETy);
   SmallVector<Value> initArgs;
-  initArgs.push_back(loaded);
+  if (loadOp) {
+    // The load converter fills this tensor one scalar lane at a time.
+    auto resTy = cast<ShapedType>(addptrRes.getType());
+    auto resEPtrTy = resTy.getElementType();
+    auto resETy = cast<triton::PointerType>(resEPtrTy).getPointeeType();
+    initArgs.push_back(
+        rewriter.create<tensor::EmptyOp>(loc, blockSizes, resETy));
+  }
 
   SmallVector<Value> forLBs;
   SmallVector<Value> forUBs;
@@ -2529,9 +2584,17 @@ void BlockDataParser::rewriteAddPtrToUnstrucMemAcc(
     forSteps.push_back(oneIdx);
   }
   SmallVector<Value> ivs;
-  OpBuilder builder(op);
+  // Stores need the active conversion listener because their replacement is
+  // cloned into a new region. Loads retain the original local builder path;
+  // their loop-carried result handling is not part of the store fallback.
+  ConversionPatternRewriter::InsertionGuard insertionGuard(rewriter);
+  OpBuilder loadBuilder(op);
+  if (storeOp)
+    rewriter.setInsertionPoint(memoryOp);
+  OpBuilder &loopBuilder =
+      storeOp ? static_cast<OpBuilder &>(rewriter) : loadBuilder;
   auto loop = createNestedLoops(
-      builder, loc, 0, blockSizes.size(), forLBs, forUBs, forSteps, ivs,
+      loopBuilder, loc, 0, blockSizes.size(), forLBs, forUBs, forSteps, ivs,
       initArgs,
       [&](OpBuilder &bB, Location bLoc, SmallVector<Value> &allIVs,
           ValueRange iterArgs) {
@@ -2540,8 +2603,10 @@ void BlockDataParser::rewriteAddPtrToUnstrucMemAcc(
 
         Value scalarOffsetRaw =
             bB.create<tensor::ExtractOp>(bLoc, ptrOffset, allIVs);
+
         Value scalarOffset = bB.create<arith::IndexCastOp>(
             bLoc, bB.getIndexType(), scalarOffsetRaw);
+
         OpFoldResult baseOffset = bB.getIndexAttr(0);
         for (auto ofr : data.getOffsetsRef()) {
           baseOffset =
@@ -2558,12 +2623,45 @@ void BlockDataParser::rewriteAddPtrToUnstrucMemAcc(
         data.getStridesRef().clear();
         data.getStridesRef().push_back(bB.getIndexAttr(1));
         memref::ReinterpretCastOp castOp = data.createCastOp({1}, bLoc, bB);
-        rewriter.replaceOp(op, castOp);
-        // Move tt.load using this tt.addptr into this block
-        loadOp->moveAfter(castOp);
-        loadOp->setAttr("IndirectLoad", UnitAttr::get(op.getContext()));
-        bB.create<scf::YieldOp>(bLoc, iterArgs);
+        if (storeOp) {
+          // Moving an existing illegal store into a newly created loop crosses
+          // dialect-conversion transaction boundaries. Clone it with the
+          // loop-local pointer instead, then remove the original operation.
+          auto yieldOp = bB.create<scf::YieldOp>(bLoc, iterArgs);
+          IRMapping mapping;
+          mapping.map(addptrRes, castOp.getResult());
+          // Keep value and mask attached to their original SSA producers.
+          // Some producers are converted after this addptr pattern; eagerly
+          // asking dialect conversion for remapped values would capture
+          // temporary unrealized casts instead of the eventual replacements.
+          for (Value operand : storeOp->getOperands())
+            if (operand != addptrRes)
+              mapping.map(operand, operand);
+          // Use the loop builder so operands remain ordinary SSA uses instead
+          // of being eagerly remapped to conversion materializations.
+          bB.setInsertionPoint(yieldOp);
+          Operation *scalarStore = bB.clone(*storeOp, mapping);
+          scalarStore->setAttr("IndirectStore", rewriter.getUnitAttr());
+          rewriter.replaceOp(storeOp, scalarStore);
+        } else {
+          // Preserve the pre-existing load lowering: it depends on the local
+          // builder and direct move for loop-carried result reconstruction.
+          rewriter.replaceOp(op, castOp);
+          memoryOp->moveAfter(castOp);
+          memoryOp->setAttr("IndirectLoad", rewriter.getUnitAttr());
+          bB.create<scf::YieldOp>(bLoc, iterArgs);
+        }
+        if (storeOp)
+          rewriter.replaceOp(op, castOp);
       });
+  if (storeOp && loop) {
+    // These loops implement scalarized memory lanes. Keep the generic loop
+    // converter from treating them as user control flow and rewriting the
+    // already converted pointer state a second time.
+    loop.walk([&](scf::ForOp forOp) {
+      forOp->setAttr("ExtractedLoadOrStore", rewriter.getUnitAttr());
+    });
+  }
 }
 
 } // namespace triton

--- a/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
@@ -39,6 +39,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Passes.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/Attributes.h"
@@ -75,6 +76,16 @@ using namespace triton;
 
 const std::string MayImplicitTransposeWithLastAxisTAG =
     "MayImplicitTransposeWithLastAxis";
+
+static bool hasPointerBitcastProvenance(Value pointer) {
+  if (auto intToPtr = pointer.getDefiningOp<triton::IntToPtrOp>())
+    return intToPtr->hasAttr(ConverterUtils::pointerBitcastPointerCastAttrName);
+  if (auto addPtr = pointer.getDefiningOp<triton::AddPtrOp>())
+    return hasPointerBitcastProvenance(addPtr.getPtr());
+  if (auto bitcast = pointer.getDefiningOp<triton::BitcastOp>())
+    return hasPointerBitcastProvenance(bitcast.getSrc());
+  return false;
+}
 
 LogicalResult
 AddPtrConverter::matchAndRewrite(triton::AddPtrOp op, OpAdaptor adaptor,
@@ -379,6 +390,39 @@ LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
     auto resTy = op.getResult().getType();
     auto idxZero =
         rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
+
+    // A mask on the exact-address pointer-bitcast path is a correctness guard,
+    // not only a value-selection hint. Keep the physical load inside the true
+    // branch so a false lane never touches its potentially invalid address.
+    // Ordinary scalar loads retain the main-dev lowering below.
+    bool requiresGuardedLoad =
+        op->hasAttr(ConverterUtils::pointerBitcastPointerCastAttrName) ||
+        hasPointerBitcastProvenance(op.getPtr());
+    if (requiresGuardedLoad && adaptor.getMask()) {
+      Value fallback = adaptor.getOther();
+      if (!fallback)
+        fallback = rewriter.create<arith::ConstantOp>(
+            loc, rewriter.getZeroAttr(resTy));
+      auto ifOp = rewriter.create<scf::IfOp>(loc, TypeRange{resTy},
+                                             adaptor.getMask(), true);
+      {
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPointToStart(ifOp.thenBlock());
+        auto loadedValue = rewriter.create<memref::LoadOp>(
+            loc, resTy, scalarMemref, idxZero.getResult());
+        propagateWasBoolToInt8Attr(op.getOperation(),
+                                   loadedValue.getOperation(), rewriter);
+        rewriter.create<scf::YieldOp>(loc, ValueRange{loadedValue.getResult()});
+      }
+      {
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPointToStart(ifOp.elseBlock());
+        rewriter.create<scf::YieldOp>(loc, ValueRange{fallback});
+      }
+      rewriter.replaceOp(op, ifOp.getResult(0));
+      return success();
+    }
+
     auto loadedValue = rewriter
                            .create<memref::LoadOp>(loc, resTy, scalarMemref,
                                                    idxZero.getResult())
@@ -1250,6 +1294,65 @@ StoreConverter::matchAndRewrite(triton::StoreOp op, OpAdaptor adaptor,
   auto loc = op.getLoc();
   auto ptr = adaptor.getPtr();
   auto val = adaptor.getValue();
+
+  // BlockPtrAnalysis lowers an unstructured tensor of pointers to a scalar
+  // loop whose current target is memref<1xT>. Keep the value and mask on the
+  // same lane as the pointer offset instead of reusing the generic contiguous
+  // store path, which would slice every iteration from source lane zero.
+  if (op->hasAttr("IndirectStore")) {
+    auto forOp = op->getParentOfType<scf::ForOp>();
+    if (!forOp)
+      return rewriter.notifyMatchFailure(
+          op, "indirect store is not nested in a scalar loop");
+
+    auto offsetExtract = dyn_cast<tensor::ExtractOp>(&forOp.getBody()->front());
+    if (!offsetExtract)
+      return rewriter.notifyMatchFailure(
+          op, "indirect store loop does not start with an offset extract");
+    ValueRange ivs = offsetExtract.getIndices();
+
+    auto extractLane = [&](Value value) -> Value {
+      if (!isa<ShapedType>(value.getType()))
+        return value;
+      return rewriter.create<tensor::ExtractOp>(loc, value, ivs);
+    };
+
+    Value scalarVal = extractLane(val);
+    Value zeroIdx = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    auto createStore = [&]() {
+      rewriter.create<memref::StoreOp>(loc, scalarVal, ptr, zeroIdx);
+    };
+
+    if (Value convertedMask = adaptor.getMask()) {
+      Value condition;
+      if (auto maskType = dyn_cast<RankedTensorType>(convertedMask.getType())) {
+        // Dynamic extraction from a packed i1 tensor is not lane-correct on
+        // the SIMD backend. Widen outside the loop, then extract an i8 lane.
+        Value widenedMask;
+        {
+          OpBuilder::InsertionGuard guard(rewriter);
+          rewriter.setInsertionPoint(forOp);
+          widenedMask = rewriter.create<arith::ExtUIOp>(
+              loc, maskType.clone(rewriter.getI8Type()), convertedMask);
+        }
+        Value scalarMask = extractLane(widenedMask);
+        Value zero = rewriter.create<arith::ConstantIntOp>(loc, 0, 8);
+        condition = rewriter.create<arith::CmpIOp>(
+            loc, arith::CmpIPredicate::ne, scalarMask, zero);
+      } else {
+        condition = convertedMask;
+      }
+      auto ifOp = rewriter.create<scf::IfOp>(loc, condition);
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
+      createStore();
+    } else {
+      createStore();
+    }
+
+    rewriter.eraseOp(op);
+    return success();
+  }
 
   // 1. boundary size check
   auto boundaryCheck = op.getBoundaryCheck();

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -26,6 +26,7 @@
 #include "ascend/include/TritonToLinalg/MaskAnalysis.h"
 #include "ascend/include/TritonToLinalg/TritonToLinalgPass.h"
 #include "ascend/include/Utils/Utils.h"
+
 #include "triton/Dialect/Triton/IR/Dialect.h"
 
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
@@ -39,7 +40,9 @@
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
+#include <cstdint>
 #include <cstdlib>
+
 #include <utility>
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -59,10 +62,91 @@
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "bishengir/Dialect/HFusion/IR/HFusion.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "llvm/ADT/APInt.h"
 
 namespace TTOpConverters {
 using namespace mlir;
 using namespace triton;
+
+static triton::PointerType getScalarPointerType(Type type) {
+  if (auto shapedType = dyn_cast<ShapedType>(type))
+    type = shapedType.getElementType();
+  return dyn_cast<triton::PointerType>(type);
+}
+
+static unsigned getNormalizedPointeeBitWidth(triton::PointerType pointerType) {
+  Type pointeeType = pointerType.getPointeeType();
+  if (auto shapedType = dyn_cast<ShapedType>(pointeeType))
+    pointeeType = shapedType.getElementType();
+  if (!pointeeType.isIntOrFloat())
+    return 0;
+  unsigned bitWidth = pointeeType.getIntOrFloatBitWidth();
+  return bitWidth == 1 ? 8 : bitWidth;
+}
+
+static bool isKernelEntryArgument(Value value) {
+  auto blockArgument = dyn_cast<BlockArgument>(value);
+  if (!blockArgument || !blockArgument.getOwner())
+    return false;
+  Operation *parentOp = blockArgument.getOwner()->getParentOp();
+  auto funcOp = dyn_cast_or_null<triton::FuncOp>(parentOp);
+  return funcOp && funcOp.getVisibility() == SymbolTable::Visibility::Public;
+}
+
+static FailureOr<Value>
+materializeScalarPointerAddress(Value pointer, Location location,
+                                PatternRewriter &rewriter) {
+  if (isa<ShapedType>(pointer.getType()))
+    return failure();
+
+  if (auto intToPtrOp = pointer.getDefiningOp<triton::IntToPtrOp>())
+    return intToPtrOp.getSrc();
+  if (auto bitcastOp = pointer.getDefiningOp<triton::BitcastOp>())
+    return materializeScalarPointerAddress(bitcastOp.getSrc(), location,
+                                           rewriter);
+
+  if (auto addPtrOp = pointer.getDefiningOp<triton::AddPtrOp>()) {
+    FailureOr<Value> baseAddress =
+        materializeScalarPointerAddress(addPtrOp.getPtr(), location, rewriter);
+    if (failed(baseAddress))
+      return failure();
+
+    Value offset = addPtrOp.getOffset();
+    auto offsetType = dyn_cast<IntegerType>(offset.getType());
+    if (!offsetType || offsetType.getWidth() > 64)
+      return failure();
+    if (offsetType.getWidth() < 64)
+      offset = rewriter.create<arith::ExtSIOp>(location, rewriter.getI64Type(),
+                                               offset);
+
+    auto pointerType =
+        dyn_cast<triton::PointerType>(addPtrOp.getPtr().getType());
+    if (!pointerType)
+      return failure();
+    unsigned pointeeBitWidth = getNormalizedPointeeBitWidth(pointerType);
+    if (!pointeeBitWidth || pointeeBitWidth % 8 != 0)
+      return failure();
+    uint64_t pointeeByteWidth = pointeeBitWidth / 8;
+    if (pointeeByteWidth != 1) {
+      Value scale =
+          rewriter.create<arith::ConstantIntOp>(location, pointeeByteWidth, 64);
+      offset = rewriter.create<arith::MulIOp>(location, offset, scale);
+    }
+    return rewriter.create<arith::AddIOp>(location, *baseAddress, offset)
+        .getResult();
+  }
+
+  // PtrToInt lowering extracts only the aligned base from a converted memref.
+  // That is exact for a kernel argument, but not for a descriptor produced by
+  // control flow or another operation whose logical offset may be non-zero.
+  // Reject those producers until their descriptor offset can be materialized.
+  if (!isKernelEntryArgument(pointer))
+    return failure();
+
+  return rewriter
+      .create<triton::PtrToIntOp>(location, rewriter.getI64Type(), pointer)
+      .getResult();
+}
 
 /**
  * Retrieves a boolean environment variable.
@@ -112,33 +196,53 @@ BitcastConverter::matchAndRewrite(triton::BitcastOp op, OpAdaptor adaptor,
   Value result;
   auto loc = op.getLoc();
 
-  if (auto dstPtrTy = dyn_cast<triton::PointerType>(op.getType())) {
-    auto srcPtrTy = cast<triton::PointerType>(op.getSrc().getType());
-    auto resType =
-        MemRefType::get({ShapedType::kDynamic}, dstPtrTy.getPointeeType());
+  if (adaptor.getOperands().size() != 1 || !adaptor.getOperands().front())
+    return op.emitError(
+        "pointer bitcast expected exactly one converted source operand");
+  Value convertedSrc = adaptor.getOperands().front();
 
-    auto i1Ty = rewriter.getIntegerType(1);
-    auto i8Ty = rewriter.getIntegerType(8);
-    bool isI1toI8 = (srcPtrTy.getPointeeType() == i1Ty) &&
-                    (dstPtrTy.getPointeeType() == i8Ty);
-    // handling special case: ptr<i1> -> ptr<i8>, directly forward without
-    // arith.bitcast
+  auto srcPtrTy = getScalarPointerType(op.getSrc().getType());
+  auto dstPtrTy = getScalarPointerType(op.getType());
+  auto i1Ty = rewriter.getIntegerType(1);
+  auto i8Ty = rewriter.getIntegerType(8);
+  if (srcPtrTy && dstPtrTy && srcPtrTy.getPointeeType() != i1Ty &&
+      dstPtrTy.getPointeeType() == i1Ty)
+    return op.emitError(
+        "pointer bitcast to i1 from a different pointee type is unsupported "
+        "because i1 pointers use i8 storage");
+
+  if (auto scalarDstPtrTy = dyn_cast<triton::PointerType>(op.getType())) {
+    auto scalarSrcPtrTy = cast<triton::PointerType>(op.getSrc().getType());
+    unsigned srcBitWidth = getNormalizedPointeeBitWidth(scalarSrcPtrTy);
+    unsigned dstBitWidth = getNormalizedPointeeBitWidth(scalarDstPtrTy);
+    if (srcBitWidth != dstBitWidth)
+      return op.emitError(
+          "different-width pointer bitcast was not canonicalized to an "
+          "exact integer address");
+
+    bool isI1toI8 = (scalarSrcPtrTy.getPointeeType() == i1Ty) &&
+                    (scalarDstPtrTy.getPointeeType() == i8Ty);
+    // TypeConverter has already converted i1 pointer storage to i8.
     if (isI1toI8) {
-      // TypeConverter has already converted i1 to i8 memref,
-      LLVM_DEBUG({
-        llvm::dbgs()
-            << "[BitcastConverter] Special i1->i8 pointer bitcast. Forward "
-               "without arith.bitcast. srcConvertedTy="
-            << adaptor.getSrc().getType() << "\n";
-      });
-      rewriter.replaceOp(op, adaptor.getSrc());
+      rewriter.replaceOp(op, convertedSrc);
       return success();
     }
-    result = rewriter.create<arith::BitcastOp>(loc, resType, adaptor.getSrc());
+
+    auto resultType = MemRefType::get({ShapedType::kDynamic},
+                                      scalarDstPtrTy.getPointeeType());
+    result = rewriter.create<arith::BitcastOp>(loc, resultType, convertedSrc);
   } else {
     // handling normal case: bitcast between tensors/memrefs
-    result =
-        rewriter.create<arith::BitcastOp>(loc, op.getType(), adaptor.getSrc());
+    auto srcPtrTy = getScalarPointerType(op.getSrc().getType());
+    auto tensorDstPtrTy = getScalarPointerType(op.getType());
+    if (srcPtrTy && tensorDstPtrTy &&
+        getNormalizedPointeeBitWidth(srcPtrTy) !=
+            getNormalizedPointeeBitWidth(tensorDstPtrTy)) {
+      return op.emitError(
+          "different-width tensor pointer bitcast was not canonicalized to a "
+          "scalar base pointer");
+    }
+    result = rewriter.create<arith::BitcastOp>(loc, op.getType(), convertedSrc);
   }
   rewriter.replaceOp(op, result);
   return success();
@@ -366,65 +470,119 @@ SelectCanonicalizer::matchAndRewrite(arith::SelectOp op,
 }
 
 /*
- * Move tt.bitcast to a previous location if tt.bitcast is not directly applied
- * on function arguments
+ * Preserve different-width pointer bitcasts as address boundaries. Scalar
+ * pointers are materialized as integer addresses here; tensor pointers remain
+ * for the unstructured memory lowering, which tracks their offset in bytes.
+ * Same-width bitcasts may still move through shape-only pointer operations.
  */
 LogicalResult
 BitcastCanonicalizer::matchAndRewrite(triton::BitcastOp bitcastOp,
                                       PatternRewriter &rewriter) const {
   Value castSrc = bitcastOp.getSrc();
   Value castRes = bitcastOp.getResult();
-  Type castSrcTy = castSrc.getType();
-  Type castSrcPtrTy = isa<ShapedType>(castSrcTy)
-                          ? cast<ShapedType>(castSrcTy).getElementType()
-                          : castSrcTy;
-  if (!isa<triton::PointerType>(castSrcPtrTy))
+  auto srcPtrTy = getScalarPointerType(castSrc.getType());
+  auto dstPtrTy = getScalarPointerType(castRes.getType());
+  if (!srcPtrTy || !dstPtrTy)
     return failure();
-
-  auto origBitwidth = getPointeeBitWidth(castSrc.getType());
-  auto castBitwidth = getPointeeBitWidth(castRes.getType());
-
-  if (origBitwidth == 1)
-    origBitwidth = 8;
-  if (castBitwidth == 1)
-    castBitwidth = 8;
-  if (origBitwidth != castBitwidth) {
-    bitcastOp.emitError() << "Casting pointers with unmatched bitwidth!\n";
+  auto failWithError = [&](llvm::StringRef message) {
+    if (!hadError)
+      bitcastOp.emitError(message);
+    hadError = true;
     return failure();
+  };
+
+  unsigned srcBitWidth = getNormalizedPointeeBitWidth(srcPtrTy);
+  unsigned dstBitWidth = getNormalizedPointeeBitWidth(dstPtrTy);
+  bool differentBitWidth = srcBitWidth != dstBitWidth;
+  if (srcPtrTy.getAddressSpace() != dstPtrTy.getAddressSpace())
+    return failWithError(
+        "cannot bitcast pointers between different address spaces");
+
+  if (srcPtrTy.getPointeeType() != rewriter.getIntegerType(1) &&
+      dstPtrTy.getPointeeType() == rewriter.getIntegerType(1)) {
+    return failWithError(
+        "pointer bitcast to i1 from a different pointee type is unsupported "
+        "because i1 pointers use i8 storage");
+  }
+
+  if (differentBitWidth) {
+    Type srcPointeeType = srcPtrTy.getPointeeType();
+    Type dstPointeeType = dstPtrTy.getPointeeType();
+    if (isa<ShapedType>(srcPointeeType) || isa<ShapedType>(dstPointeeType) ||
+        !srcBitWidth || !dstBitWidth || srcBitWidth < 8 || dstBitWidth < 8 ||
+        srcBitWidth % 8 != 0 || dstBitWidth % 8 != 0) {
+      return failWithError(
+          "different-width pointer bitcast requires byte-addressable scalar "
+          "integer or floating-point pointee types");
+    }
+
+    // Tensor pointer offsets are materialized one lane at a time by
+    // TritonToUnstructure. For scalar pointers (including make_block_ptr
+    // bases), calculate every pre-cast AddPtr in the element unit visible at
+    // that AddPtr and cross the bitcast boundary with an exact byte address.
+    if (isa<ShapedType>(castSrc.getType()))
+      return failure();
+    FailureOr<Value> address =
+        materializeScalarPointerAddress(castSrc, bitcastOp.getLoc(), rewriter);
+    if (failed(address)) {
+      if (Operation *producer = castSrc.getDefiningOp()) {
+        std::string message =
+            "different-width pointer bitcast cannot preserve the exact "
+            "address from unsupported producer '";
+        message += producer->getName().getStringRef().str();
+        message += "'";
+        return failWithError(message);
+      }
+      return failWithError(
+          "different-width pointer bitcast requires a public kernel argument "
+          "or a supported addptr/bitcast/inttoptr source chain");
+    }
+    Operation *sourceOp = castSrc.getDefiningOp();
+    auto intToPtrOp = rewriter.replaceOpWithNewOp<triton::IntToPtrOp>(
+        bitcastOp, castRes.getType(), *address);
+    // Only compiler-generated IntToPtr operations carry this provenance. It
+    // tells BlockPtrAnalysis that subsequent target-element offsets must be
+    // folded into this exact integer address before constructing a memref.
+    intToPtrOp->setAttr(ConverterUtils::pointerBitcastPointerCastAttrName,
+                        rewriter.getUnitAttr());
+    if (sourceOp && sourceOp->use_empty())
+      rewriter.eraseOp(sourceOp);
+    return success();
   }
 
   Operation *beforeCastOp = castSrc.getDefiningOp();
-  if (beforeCastOp == nullptr) {
+  if (beforeCastOp == nullptr)
     return failure();
-  }
 
   auto newRes =
       TypeSwitch<Operation *, FailureOr<Operation *>>(beforeCastOp)
-          // before: addptr - bitcast - load/store
-          // after: bitcast - addptr - load/store
-          .Case<triton::AddPtrOp>([&](triton::AddPtrOp addptrOp) {
-            auto newCastOp = rewriter.create<triton::BitcastOp>(
-                bitcastOp.getLoc(), castRes.getType(), addptrOp.getPtr());
-            return rewriter.create<triton::AddPtrOp>(
-                bitcastOp.getLoc(), castRes.getType(), newCastOp.getResult(),
-                addptrOp.getOffset());
-          })
-          .Case<triton::SplatOp>([&](triton::SplatOp splatOp) {
-            Type newCastSrcTy =
-                cast<RankedTensorType>(castRes.getType()).getElementType();
-
-            Value splatSrc = splatOp.getSrc();
-            Type splatSrcTy = splatSrc.getType();
-            if (auto splatSrcTensorTy = dyn_cast<RankedTensorType>(splatSrcTy))
-              newCastSrcTy =
-                  splatSrcTensorTy.cloneWith(std::nullopt, newCastSrcTy);
-            auto newCastOp = rewriter.create<triton::BitcastOp>(
-                bitcastOp.getLoc(), newCastSrcTy, splatSrc);
-            return rewriter.create<triton::SplatOp>(
-                bitcastOp.getLoc(), castRes.getType(), newCastOp);
-          })
-          // before: bitcast - bitcast
-          // after(fusion optimization): bitcast
+          .Case<triton::AddPtrOp>(
+              [&](triton::AddPtrOp addptrOp) -> FailureOr<Operation *> {
+                auto newCastOp = rewriter.create<triton::BitcastOp>(
+                    bitcastOp.getLoc(), castRes.getType(), addptrOp.getPtr());
+                return rewriter
+                    .create<triton::AddPtrOp>(
+                        bitcastOp.getLoc(), castRes.getType(),
+                        newCastOp.getResult(), addptrOp.getOffset())
+                    .getOperation();
+              })
+          .Case<triton::SplatOp>(
+              [&](triton::SplatOp splatOp) -> FailureOr<Operation *> {
+                Type newCastSrcTy =
+                    cast<RankedTensorType>(castRes.getType()).getElementType();
+                Value splatSrc = splatOp.getSrc();
+                Type splatSrcTy = splatSrc.getType();
+                if (auto splatSrcTensorTy =
+                        dyn_cast<RankedTensorType>(splatSrcTy))
+                  newCastSrcTy =
+                      splatSrcTensorTy.cloneWith(std::nullopt, newCastSrcTy);
+                auto newCastOp = rewriter.create<triton::BitcastOp>(
+                    bitcastOp.getLoc(), newCastSrcTy, splatSrc);
+                return rewriter
+                    .create<triton::SplatOp>(bitcastOp.getLoc(),
+                                             castRes.getType(), newCastOp)
+                    .getOperation();
+              })
           .Case<triton::BitcastOp>([&](triton::BitcastOp prevCastOp) {
             return rewriter.create<triton::BitcastOp>(
                 bitcastOp.getLoc(), castRes.getType(), prevCastOp.getSrc());
@@ -435,9 +593,8 @@ BitcastCanonicalizer::matchAndRewrite(triton::BitcastOp bitcastOp,
           });
   if (succeeded(newRes)) {
     rewriter.replaceOp(bitcastOp, newRes.value());
-    if (beforeCastOp->use_empty()) {
+    if (beforeCastOp->use_empty())
       rewriter.eraseOp(beforeCastOp);
-    }
     return success();
   }
   return failure();

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -42,6 +42,7 @@
 #include "ascend/include/TritonToStructured/CannonicalizerConverter.h"
 #include "ascend/include/TritonToUnstructure/UnstructureConversionPass.h"
 #include "ascend/include/Utils/InterleaveOptimization.h"
+#include "ascend/include/Utils/Utils.h"
 
 #include "bishengir/Dialect/HFusion/IR/HFusion.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
@@ -85,8 +86,10 @@
 
 #include <cassert>
 #include <cstdint>
+#include <memory>
 #include <optional>
 
+#include <utility>
 #define DEBUG_TYPE "triton-to-linalg"
 
 using namespace mlir;
@@ -595,13 +598,14 @@ void TritonToLinalgPass::addDynamicLegal(
 }
 
 void TritonToLinalgPass::populateTritonToLinalgCanonicalizationPatterns(
-    RewritePatternSet &patterns) {
+    RewritePatternSet &patterns, bool &hadError) {
   patterns.add<LoadStoreConverter::LoadStoreCanonicalizer<triton::LoadOp>,
                LoadStoreConverter::LoadStoreCanonicalizer<triton::StoreOp>,
                LoadStoreConverter::LoadStoreCanonicalizer<triton::AtomicRMWOp>,
                LoadStoreConverter::LoadStoreCanonicalizer<triton::AtomicCASOp>>(
       patterns.getContext());
-  patterns.add<TTOpConverters::BitcastCanonicalizer>(patterns.getContext());
+  patterns.add<TTOpConverters::BitcastCanonicalizer>(patterns.getContext(),
+                                                     hadError);
   patterns.add<TTOpConverters::FpToFpCanonicalizer>(patterns.getContext());
   patterns.add<LoadStoreConverter::ScalarStoreCanonicalizer>(
       patterns.getContext());
@@ -1013,12 +1017,17 @@ void TritonToLinalgPass::runOnOperation() {
   }
 
   RewritePatternSet canonicalizerPatterns(&getContext());
+  bool hadCanonicalizationError = false;
   // 1. Canonicalize load/store related patterns.
-  this->populateTritonToLinalgCanonicalizationPatterns(canonicalizerPatterns);
-  if (failed(
-          applyPatternsGreedily(moduleOp, std::move(canonicalizerPatterns)))) {
-    moduleOp->emitError("failed to apply Canonicalizer Patterns");
+  this->populateTritonToLinalgCanonicalizationPatterns(
+      canonicalizerPatterns, hadCanonicalizationError);
+  LogicalResult canonicalizationResult =
+      applyPatternsGreedily(moduleOp, std::move(canonicalizerPatterns));
+  if (failed(canonicalizationResult) || hadCanonicalizationError) {
+    if (!hadCanonicalizationError)
+      moduleOp->emitError("failed to apply Canonicalizer Patterns");
     signalPassFailure();
+    return;
   }
 
   // 2.1 Pre-clean dead control-flow before use analysis.
@@ -1143,6 +1152,21 @@ void TritonToLinalgPass::runOnOperation() {
   for (auto op : castOps) {
     SmallVector<Operation *> userOps(op->getUsers().begin(),
                                      op->getUsers().end());
+    bool isPointerBitcast =
+        op->hasAttr(ConverterUtils::pointerBitcastPointerCastAttrName);
+
+    if (isPointerBitcast && op.getAddrs().size() != 1) {
+      op.emitError("PointerCastOp must have exactly one address operand");
+      signalPassFailure();
+      return;
+    }
+    if (isPointerBitcast && llvm::any_of(userOps, [](Operation *userOp) {
+          return !isa<memref::ReinterpretCastOp>(userOp);
+        })) {
+      op.emitError("PointerCastOp must be consumed by memref.reinterpret_cast");
+      signalPassFailure();
+      return;
+    }
     IRRewriter rewriter(&getContext());
     rewriter.setInsertionPointAfter(op);
     Value addr = op.getAddrs()[0];
@@ -1162,33 +1186,110 @@ void TritonToLinalgPass::runOnOperation() {
     }
 
     for (auto userOp : userOps) {
-      auto reinterpretCastOp = cast<memref::ReinterpretCastOp>(userOp);
+      auto reinterpretCastOp = isPointerBitcast
+                                   ? dyn_cast<memref::ReinterpretCastOp>(userOp)
+                                   : cast<memref::ReinterpretCastOp>(userOp);
+      if (isPointerBitcast && !reinterpretCastOp) {
+        userOp->emitError("PointerCastOp user must be memref.reinterpret_cast");
+        signalPassFailure();
+        return;
+      }
       auto sizes = reinterpretCastOp.getStaticSizes();
       auto staticStrides = reinterpretCastOp.getStaticStrides();
       auto strides = reinterpretCastOp.getStrides();
-      if (reinterpretCastOp.getStaticOffsets().size() != 1)
+      if (reinterpretCastOp.getStaticOffsets().size() != 1) {
         userOp->emitError("IntToPtrOp must converted to PointerCastOp of "
                           "memref<?xdtype> type");
-      int64_t castOpSize = 0;
-      SmallVector<int64_t> dynamicSizes;
-      for (const auto &[size, stride] : llvm::zip_equal(sizes, staticStrides)) {
-        assert(!ShapedType::isDynamic(size));
-        if (ShapedType::isDynamic(stride))
-          dynamicSizes.push_back(size);
-        else
-          castOpSize = size * stride;
+        if (isPointerBitcast) {
+          signalPassFailure();
+          return;
+        }
       }
       rewriter.setInsertionPoint(reinterpretCastOp);
-      Value dynamicSize = rewriter.create<arith::ConstantOp>(
-          op.getLoc(), rewriter.getIndexAttr(castOpSize));
-      for (const auto &[size, stride] :
-           llvm::zip_equal(dynamicSizes, strides)) {
-        Value axisSize = rewriter.create<arith::ConstantOp>(
-            op.getLoc(), rewriter.getIndexAttr(size));
-        axisSize =
-            rewriter.create<arith::MulIOp>(op.getLoc(), stride, axisSize);
-        dynamicSize =
-            rewriter.create<arith::AddIOp>(op.getLoc(), dynamicSize, axisSize);
+      Value dynamicSize;
+      if (!isPointerBitcast) {
+        // Keep the main-dev size calculation byte-for-byte for ordinary
+        // PointerCastOp instances.
+        int64_t castOpSize = 0;
+        SmallVector<int64_t> dynamicSizes;
+        for (const auto &[size, stride] :
+             llvm::zip_equal(sizes, staticStrides)) {
+          assert(!ShapedType::isDynamic(size));
+          if (ShapedType::isDynamic(stride))
+            dynamicSizes.push_back(size);
+          else
+            castOpSize = size * stride;
+        }
+        dynamicSize = rewriter.create<arith::ConstantOp>(
+            op.getLoc(), rewriter.getIndexAttr(castOpSize));
+        for (const auto &[size, stride] :
+             llvm::zip_equal(dynamicSizes, strides)) {
+          Value axisSize = rewriter.create<arith::ConstantOp>(
+              op.getLoc(), rewriter.getIndexAttr(size));
+          axisSize =
+              rewriter.create<arith::MulIOp>(op.getLoc(), stride, axisSize);
+          dynamicSize = rewriter.create<arith::AddIOp>(op.getLoc(), dynamicSize,
+                                                       axisSize);
+        }
+      } else {
+        SmallVector<std::pair<int64_t, Value>> dynamicAxes;
+        auto dynamicStride = strides.begin();
+        bool hasZeroSize = false;
+        int64_t staticSpan = 1;
+        for (const auto &[size, stride] :
+             llvm::zip_equal(sizes, staticStrides)) {
+          if (ShapedType::isDynamic(size)) {
+            reinterpretCastOp.emitError(
+                "PointerCastOp requires statically known access sizes");
+            signalPassFailure();
+            return;
+          }
+          hasZeroSize |= size == 0;
+          if (ShapedType::isDynamic(stride)) {
+            if (dynamicStride == strides.end()) {
+              reinterpretCastOp.emitError(
+                  "PointerCastOp has inconsistent dynamic strides");
+              signalPassFailure();
+              return;
+            }
+            dynamicAxes.emplace_back(size, *dynamicStride++);
+            continue;
+          }
+          // Keep PointerCast at the user-computed logical element-zero address:
+          // rebasing it would require a compensating nonzero memref offset and
+          // would otherwise change the address. ReinterpretCast retains the
+          // signed stride; PointerCast size only needs its magnitude so the
+          // extent metadata cannot become negative.
+          int64_t strideMagnitude = stride < 0 ? -stride : stride;
+          staticSpan += (size - 1) * strideMagnitude;
+        }
+        if (dynamicStride != strides.end()) {
+          reinterpretCastOp.emitError(
+              "PointerCastOp has inconsistent dynamic strides");
+          signalPassFailure();
+          return;
+        }
+
+        // A strided view spans one element plus the distance from the first
+        // element to the last one along every dimension.
+        dynamicSize = rewriter.create<arith::ConstantOp>(
+            op.getLoc(), rewriter.getIndexAttr(hasZeroSize ? 0 : staticSpan));
+        if (!hasZeroSize) {
+          Value zero = rewriter.create<arith::ConstantOp>(
+              op.getLoc(), rewriter.getIndexAttr(0));
+          for (const auto &[size, stride] : dynamicAxes) {
+            Value axisExtent = rewriter.create<arith::ConstantOp>(
+                op.getLoc(), rewriter.getIndexAttr(size - 1));
+            Value negatedStride =
+                rewriter.create<arith::SubIOp>(op.getLoc(), zero, stride);
+            Value strideMagnitude = rewriter.create<arith::MaxSIOp>(
+                op.getLoc(), stride, negatedStride);
+            Value axisSpan = rewriter.create<arith::MulIOp>(
+                op.getLoc(), strideMagnitude, axisExtent);
+            dynamicSize = rewriter.create<arith::AddIOp>(op.getLoc(),
+                                                         dynamicSize, axisSpan);
+          }
+        }
       }
       Value offsetValue;
       auto staticOffset = reinterpretCastOp.getStaticOffsets()[0];

--- a/third_party/ascend/lib/TritonToLinalg/UseAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/UseAnalysis.cpp
@@ -38,6 +38,31 @@ using namespace dataflow;
 
 #define DEBUG_TYPE "triton-use-analysis"
 
+static bool hasPointerBitcastProvenance(Value pointer) {
+  // Different-width tensor pointers are materialized per lane as exact integer
+  // addresses and converted back with tt.int_to_ptr. Load/store
+  // canonicalization may wrap that pointer in a zero-offset AddPtr (and
+  // same-width bitcasts may also remain), so follow only address-preserving
+  // pointer operations.
+  if (auto intToPtr = pointer.getDefiningOp<triton::IntToPtrOp>())
+    return intToPtr->hasAttr(ConverterUtils::pointerBitcastPointerCastAttrName);
+  if (auto addPtr = pointer.getDefiningOp<triton::AddPtrOp>())
+    return hasPointerBitcastProvenance(addPtr.getPtr());
+  if (auto bitcast = pointer.getDefiningOp<triton::BitcastOp>())
+    return hasPointerBitcastProvenance(bitcast.getSrc());
+  return false;
+}
+
+static bool requiresPointerBitcastScalarStoreMask(triton::StoreOp store) {
+  return store->hasAttr(ConverterUtils::pointerBitcastPointerCastAttrName) ||
+         hasPointerBitcastProvenance(store.getPtr());
+}
+
+static bool requiresPointerBitcastScalarLoadOperands(triton::LoadOp load) {
+  return load->hasAttr(ConverterUtils::pointerBitcastPointerCastAttrName) ||
+         hasPointerBitcastProvenance(load.getPtr());
+}
+
 std::string stringifyUseType(UseType useTy) {
   std::string ret;
   if (useTy == UseType::MetaUse) {
@@ -76,12 +101,16 @@ void triton::UseAnalysis::visitOperation(Operation *op,
         propagateUse(operands[0], UseType::MetaUse);
         auto mask = load.getMask();
         auto other = load.getOther();
+        bool preserveRuntimeOperands =
+            requiresPointerBitcastScalarLoadOperands(load);
         if (mask) {
           assert(mask != other && "mask and other cannot be the same");
-          propagateUse(operands[1], UseType::MetaUse);
+          propagateUse(operands[1], preserveRuntimeOperands ? UseType::DataUse
+                                                            : UseType::MetaUse);
         }
         if (other) {
-          propagateUse(operands[2], UseType::MetaUse);
+          propagateUse(operands[2], preserveRuntimeOperands ? UseType::DataUse
+                                                            : UseType::MetaUse);
         }
       })
       .Case<triton::PrintOp>([&](auto print) {
@@ -97,7 +126,13 @@ void triton::UseAnalysis::visitOperation(Operation *op,
         auto mask = store.getMask();
         if (mask) {
           assert(mask != value && "mask and data cannot be the same");
-          propagateUse(operands[2], UseType::MetaUse);
+          // BlockPtrAnalysis scalarizes a different-width pointer-bitcast
+          // store after use analysis and extracts its mask at the current
+          // loop IV. Keep only that mask producer alive as runtime data.
+          auto maskUse = requiresPointerBitcastScalarStoreMask(store)
+                             ? UseType::DataUse
+                             : UseType::MetaUse;
+          propagateUse(operands[2], maskUse);
         }
       })
       .Case<triton::ascend::IndirectStoreOp>([&](auto store) {
@@ -380,14 +415,19 @@ LogicalResult triton::runUseAnalysis(triton::FuncOp &funcOp) {
               auto ptr = load.getPtr();
               auto mask = load.getMask();
               auto other = load.getOther();
-              if (result == ptr || result == mask || result == other) {
+              bool preserveRuntimeOperands =
+                  requiresPointerBitcastScalarLoadOperands(load);
+              if (result == ptr || (!preserveRuntimeOperands &&
+                                    (result == mask || result == other))) {
                 metaUsers.insert(user);
               }
             })
             .Case<triton::StoreOp>([&](auto store) {
               auto ptr = store.getPtr();
               auto mask = store.getMask();
-              if (result == ptr || result == mask) {
+              bool preserveMaskAsData =
+                  mask && requiresPointerBitcastScalarStoreMask(store);
+              if (result == ptr || (result == mask && !preserveMaskAsData)) {
                 metaUsers.insert(user);
               }
             })

--- a/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
@@ -77,6 +77,7 @@ PtrOffsetInfo &PtrOffsetInfo::operator=(const PtrOffsetInfo &other) {
   setOffsets(other.getOffsets());
   setStructured(other.getStructured());
   setScalarLike(other.isScalarLike());
+  setByteAddressed(other.isByteAddressed());
   return *this;
 }
 
@@ -88,6 +89,7 @@ SmallVector<Value> PtrOffsetInfo::getOffsets() const {
 SmallVector<Value> &PtrOffsetInfo::getOffsetsRef() { return this->tptOffsets; }
 
 bool PtrOffsetInfo::isScalarLike() const { return this->scalarLike; }
+bool PtrOffsetInfo::isByteAddressed() const { return this->byteAddressed; }
 
 SmallVector<PtrOffsetInfo::AxisInfo> &PtrOffsetInfo::getStructuredRef() {
   return this->structured;
@@ -151,6 +153,10 @@ void PtrOffsetInfo::setScalarLike(bool scalarLike) {
   this->scalarLike = scalarLike;
 }
 
+void PtrOffsetInfo::setByteAddressed(bool byteAddressed) {
+  this->byteAddressed = byteAddressed;
+}
+
 bool PtrOffsetInfo::isStructured(int dim) const {
   return this->scalarLike || structured[dim] == AxisInfo::structured ||
          structured[dim] == AxisInfo::scalar;
@@ -209,12 +215,17 @@ PtrOffsetInfo combineInfo(const PtrOffsetInfo &lhs, const PtrOffsetInfo &rhs) {
 
 void parse(Value operand, const Location &loc, RewriterBase &rewriter,
            llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+  (void)parseChecked(operand, loc, rewriter, offsetMap);
+}
+LogicalResult parseChecked(Value operand, const Location &loc,
+                           RewriterBase &rewriter,
+                           llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   if (offsetMap.contains(operand)) {
     LLVM_DEBUG({
       auto &os = llvm::dbgs();
       os << "found\n" << operand << '\n';
     });
-    return;
+    return success();
   }
 
   LLVM_DEBUG({
@@ -222,33 +233,34 @@ void parse(Value operand, const Location &loc, RewriterBase &rewriter,
     os << "parse\n" << operand << '\n';
   });
 
+  LogicalResult result = success();
   if (auto *defOp = operand.getDefiningOp()) {
     if (isa<arith::ArithDialect>(defOp->getDialect())) {
-      parseArithOp(defOp, loc, rewriter, offsetMap);
+      result = parseArithOp(defOp, loc, rewriter, offsetMap);
     } else if (isa<triton::TritonDialect>(defOp->getDialect())) {
-      parseTritonOp(defOp, loc, rewriter, offsetMap);
-    } else {
-      if (auto ifOp = dyn_cast<scf::IfOp>(defOp)) {
-        parseIf(ifOp, loc, rewriter, offsetMap, operand);
-      } else if (auto yieldOp = dyn_cast<scf::YieldOp>(defOp)) {
-        parseYield(yieldOp, loc, rewriter, offsetMap);
-      } else if (auto loopOp = dyn_cast<LoopLikeOpInterface>(defOp)) {
-        parseLoopOp(loopOp, loc, rewriter, offsetMap, operand);
-      } else if (auto extractOp = dyn_cast<tensor::ExtractOp>(defOp)) {
-        parseExtract(extractOp, loc, rewriter, offsetMap);
-      } else if (auto insertOp = dyn_cast<tensor::InsertOp>(defOp)) {
-        parseInsert(insertOp, loc, rewriter, offsetMap);
-      } else if (auto extractSliceOp =
-                     dyn_cast<tensor::ExtractSliceOp>(defOp)) {
-        parseExtractSlice(extractSliceOp, loc, rewriter, offsetMap);
-      } else if (auto insertSliceOp = dyn_cast<tensor::InsertSliceOp>(defOp)) {
-        parseInsertSlice(insertSliceOp, loc, rewriter, offsetMap);
-      } else if (isDistributedTypeCustomOp(defOp)) {
-        auto opResult = dyn_cast<OpResult>(operand);
-        assert(opResult && "Expected operand to be an OpResult");
-        parseStructuredCustomOp(defOp, loc, rewriter, offsetMap,
-                                opResult.getResultNumber());
+      result = parseTritonOp(defOp, loc, rewriter, offsetMap);
+    } else if (auto ifOp = dyn_cast<scf::IfOp>(defOp)) {
+      result = parseIf(ifOp, loc, rewriter, offsetMap, operand);
+    } else if (auto yieldOp = dyn_cast<scf::YieldOp>(defOp)) {
+      result = parseYield(yieldOp, loc, rewriter, offsetMap);
+    } else if (auto loopOp = dyn_cast<LoopLikeOpInterface>(defOp)) {
+      result = parseLoopOp(loopOp, loc, rewriter, offsetMap, operand);
+    } else if (auto extractOp = dyn_cast<tensor::ExtractOp>(defOp)) {
+      result = parseExtract(extractOp, loc, rewriter, offsetMap);
+    } else if (auto insertOp = dyn_cast<tensor::InsertOp>(defOp)) {
+      result = parseInsert(insertOp, loc, rewriter, offsetMap);
+    } else if (auto extractSliceOp = dyn_cast<tensor::ExtractSliceOp>(defOp)) {
+      result = parseExtractSlice(extractSliceOp, loc, rewriter, offsetMap);
+    } else if (auto insertSliceOp = dyn_cast<tensor::InsertSliceOp>(defOp)) {
+      result = parseInsertSlice(insertSliceOp, loc, rewriter, offsetMap);
+    } else if (isDistributedTypeCustomOp(defOp)) {
+      auto opResult = dyn_cast<OpResult>(operand);
+      if (!opResult) {
+        defOp->emitError("expected distributed custom-op result");
+        return failure();
       }
+      result = parseStructuredCustomOp(defOp, loc, rewriter, offsetMap,
+                                       opResult.getResultNumber());
     }
   } else if (auto blockArgument = dyn_cast<BlockArgument>(operand)) {
     auto parentOp = blockArgument.getOwner()->getParentOp();
@@ -257,18 +269,19 @@ void parse(Value operand, const Location &loc, RewriterBase &rewriter,
       os << "Handling block argument\n" << *blockArgument.getOwner() << '\n';
     });
     if (isa<FunctionOpInterface>(parentOp)) {
-      if (auto ptrType = dyn_cast<triton::PointerType>(operand.getType())) {
+      if (isa<triton::PointerType>(operand.getType()))
         offsetMap[operand] =
             PtrOffsetInfo(operand, PtrOffsetInfo::AxisInfo::scalar);
-      } else {
-        offsetMap[operand] = PtrOffsetInfo();
-      }
     } else if (auto loopOp = dyn_cast<LoopLikeOpInterface>(parentOp)) {
-      parseLoopRegionIterArg(loopOp, loc, rewriter, offsetMap, blockArgument);
+      result = parseLoopRegionIterArg(loopOp, loc, rewriter, offsetMap,
+                                      blockArgument);
     }
   } else {
     llvm_unreachable("Unreachable");
   }
+
+  if (failed(result))
+    return failure();
 
   if (!offsetMap.contains(operand)) {
     offsetMap[operand] = PtrOffsetInfo();
@@ -285,115 +298,118 @@ void parse(Value operand, const Location &loc, RewriterBase &rewriter,
     os << "\n";
   });
 
-  if (auto tensorType = dyn_cast<RankedTensorType>(operand.getType());
-      tensorType && isa<triton::PointerType>(tensorType.getElementType())) {
-    auto data = offsetMap.at(operand);
-    assert(data.getPtr() && "pointer type should be parsed");
-  }
+  // Missing scalar roots are diagnosed by the memory converter. Keeping
+  // analysis non-fatal here turns unsupported tensor-pointer arguments into a
+  // regular compilation error instead of terminating the compiler.
+  return success();
 }
-
-void parseLoopRegionIterArg(LoopLikeOpInterface loopOp, const Location &loc,
-                            RewriterBase &rewriter,
-                            llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap,
-                            BlockArgument regionIterArg) {
+LogicalResult
+parseLoopRegionIterArg(LoopLikeOpInterface loopOp, const Location &loc,
+                       RewriterBase &rewriter,
+                       llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap,
+                       BlockArgument regionIterArg) {
   if (auto whileOp = dyn_cast<scf::WhileOp>(loopOp.getOperation());
       whileOp && whileOp.getAfterBody() == regionIterArg.getOwner()) {
     auto argNum = regionIterArg.getArgNumber();
     auto conditionArg = whileOp.getConditionOp().getArgs()[argNum];
-    parse(conditionArg, loc, rewriter, offsetMap);
+    if (failed(parseChecked(conditionArg, loc, rewriter, offsetMap)))
+      return failure();
     auto tmp = offsetMap[conditionArg];
     offsetMap[regionIterArg] = tmp;
-    return;
+    return success();
   }
   OpOperand *initArgOperand = loopOp.getTiedLoopInit(regionIterArg);
   if (!initArgOperand)
-    return;
+    return success();
   Value initArg = initArgOperand->get();
-  parse(initArg, loc, rewriter, offsetMap);
+  if (failed(parseChecked(initArg, loc, rewriter, offsetMap)))
+    return failure();
   auto tmp = offsetMap[initArg];
   offsetMap[regionIterArg] = tmp;
+  return success();
 }
 
-void parseArithOp(Operation *arithOp, const Location &loc,
-                  RewriterBase &rewriter,
-                  llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseArithOp(Operation *arithOp, const Location &loc,
+                           RewriterBase &rewriter,
+                           llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   assert(isa<arith::ArithDialect>(arithOp->getDialect()));
   if (auto addIOp = dyn_cast<arith::AddIOp>(arithOp)) {
-    parseAddI(addIOp, loc, rewriter, offsetMap);
+    return parseAddI(addIOp, loc, rewriter, offsetMap);
   } else if (auto subIOp = dyn_cast<arith::SubIOp>(arithOp)) {
-    parseSubI(subIOp, loc, rewriter, offsetMap);
+    return parseSubI(subIOp, loc, rewriter, offsetMap);
   } else if (auto indexCastOp = dyn_cast<arith::IndexCastOp>(arithOp)) {
-    parseIndexCast(indexCastOp, loc, rewriter, offsetMap);
+    return parseIndexCast(indexCastOp, loc, rewriter, offsetMap);
   } else if (auto constantFloatOp = dyn_cast<arith::ConstantFloatOp>(arithOp)) {
-    parseConstantOp(constantFloatOp, loc, rewriter, offsetMap);
+    return parseConstantOp(constantFloatOp, loc, rewriter, offsetMap);
   } else if (auto constantIntOp = dyn_cast<arith::ConstantIntOp>(arithOp)) {
-    parseConstantOp(constantIntOp, loc, rewriter, offsetMap);
+    return parseConstantOp(constantIntOp, loc, rewriter, offsetMap);
   } else if (auto constantOp = dyn_cast<arith::ConstantOp>(arithOp)) {
-    parseConstantOp(constantOp, loc, rewriter, offsetMap);
+    return parseConstantOp(constantOp, loc, rewriter, offsetMap);
   } else if (auto extSIOp = dyn_cast<arith::ExtSIOp>(arithOp)) {
-    parseExtSI(extSIOp, loc, rewriter, offsetMap);
+    return parseExtSI(extSIOp, loc, rewriter, offsetMap);
   } else if (auto mulIOp = dyn_cast<arith::MulIOp>(arithOp)) {
-    parseMulI(mulIOp, loc, rewriter, offsetMap);
+    return parseMulI(mulIOp, loc, rewriter, offsetMap);
   } else if (auto remSIOp = dyn_cast<arith::RemSIOp>(arithOp)) {
-    parseBinaryOp(remSIOp, loc, rewriter, offsetMap);
+    return parseBinaryOp(remSIOp, loc, rewriter, offsetMap);
   } else if (auto divSIOp = dyn_cast<arith::DivSIOp>(arithOp)) {
-    parseBinaryOp(divSIOp, loc, rewriter, offsetMap);
+    return parseBinaryOp(divSIOp, loc, rewriter, offsetMap);
   } else if (auto selectOp = dyn_cast<arith::SelectOp>(arithOp)) {
-    parseSelect(selectOp, loc, rewriter, offsetMap);
+    return parseSelect(selectOp, loc, rewriter, offsetMap);
   } else if (auto fPToSIOp = dyn_cast<arith::FPToSIOp>(arithOp)) {
-    parseFPToSI(fPToSIOp, loc, rewriter, offsetMap);
+    return parseFPToSI(fPToSIOp, loc, rewriter, offsetMap);
   } else if (auto sIToFPOp = dyn_cast<arith::SIToFPOp>(arithOp)) {
-    parseSIToFP(sIToFPOp, loc, rewriter, offsetMap);
+    return parseSIToFP(sIToFPOp, loc, rewriter, offsetMap);
   } else if (auto mulFOp = dyn_cast<arith::MulFOp>(arithOp)) {
-    parseBinaryOp(mulFOp, loc, rewriter, offsetMap);
+    return parseBinaryOp(mulFOp, loc, rewriter, offsetMap);
   } else if (auto divFOp = dyn_cast<arith::DivFOp>(arithOp)) {
-    parseBinaryOp(divFOp, loc, rewriter, offsetMap);
+    return parseBinaryOp(divFOp, loc, rewriter, offsetMap);
   } else if (auto addFOp = dyn_cast<arith::AddFOp>(arithOp)) {
-    parseBinaryOp(addFOp, loc, rewriter, offsetMap);
+    return parseBinaryOp(addFOp, loc, rewriter, offsetMap);
   } else if (auto subFOp = dyn_cast<arith::SubFOp>(arithOp)) {
-    parseBinaryOp(subFOp, loc, rewriter, offsetMap);
+    return parseBinaryOp(subFOp, loc, rewriter, offsetMap);
   } else if (auto minNumFOp = dyn_cast<arith::MinNumFOp>(arithOp)) {
-    parseBinaryOp(minNumFOp, loc, rewriter, offsetMap);
+    return parseBinaryOp(minNumFOp, loc, rewriter, offsetMap);
   } else if (auto maxNumFOp = dyn_cast<arith::MaxNumFOp>(arithOp)) {
-    parseBinaryOp(maxNumFOp, loc, rewriter, offsetMap);
+    return parseBinaryOp(maxNumFOp, loc, rewriter, offsetMap);
   } else if (auto maxSIOp = dyn_cast<arith::MaxSIOp>(arithOp)) {
-    parseBinaryOp(maxSIOp, loc, rewriter, offsetMap);
+    return parseBinaryOp(maxSIOp, loc, rewriter, offsetMap);
   } else if (auto minSIOp = dyn_cast<arith::MinSIOp>(arithOp)) {
-    parseBinaryOp(minSIOp, loc, rewriter, offsetMap);
+    return parseBinaryOp(minSIOp, loc, rewriter, offsetMap);
   } else if (auto cmpIOp = dyn_cast<arith::CmpIOp>(arithOp)) {
-    parseBinaryOp(cmpIOp, loc, rewriter, offsetMap);
+    return parseBinaryOp(cmpIOp, loc, rewriter, offsetMap);
   } else if (auto andIOp = dyn_cast<arith::AndIOp>(arithOp)) {
-    parseBinaryOp(andIOp, loc, rewriter, offsetMap);
+    return parseBinaryOp(andIOp, loc, rewriter, offsetMap);
   } else if (auto orIOp = dyn_cast<arith::OrIOp>(arithOp)) {
-    parseBinaryOp(orIOp, loc, rewriter, offsetMap);
+    return parseBinaryOp(orIOp, loc, rewriter, offsetMap);
   }
+  return success();
 }
 
-void parseTritonOp(Operation *tritonOp, const Location &loc,
-                   RewriterBase &rewriter,
-                   llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseTritonOp(Operation *tritonOp, const Location &loc,
+                            RewriterBase &rewriter,
+                            llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   assert(isa<triton::TritonDialect>(tritonOp->getDialect()));
   if (auto addPtrOp = dyn_cast<triton::AddPtrOp>(tritonOp)) {
-    parseAddPtr(addPtrOp, loc, rewriter, offsetMap);
+    return parseAddPtr(addPtrOp, loc, rewriter, offsetMap);
   } else if (auto splatOp = dyn_cast<triton::SplatOp>(tritonOp)) {
-    parseSplat(splatOp, loc, rewriter, offsetMap);
+    return parseSplat(splatOp, loc, rewriter, offsetMap);
   } else if (auto getProgramIdOp = dyn_cast<triton::GetProgramIdOp>(tritonOp)) {
-    parseConstantOp(getProgramIdOp, loc, rewriter, offsetMap);
+    return parseConstantOp(getProgramIdOp, loc, rewriter, offsetMap);
   } else if (auto getNumProgramsOp =
                  dyn_cast<triton::GetNumProgramsOp>(tritonOp)) {
-    parseConstantOp(getNumProgramsOp, loc, rewriter, offsetMap);
+    return parseConstantOp(getNumProgramsOp, loc, rewriter, offsetMap);
   } else if (auto makeRangeOp = dyn_cast<triton::MakeRangeOp>(tritonOp)) {
-    parseMakeRange(makeRangeOp, loc, rewriter, offsetMap);
+    return parseMakeRange(makeRangeOp, loc, rewriter, offsetMap);
   } else if (auto bitcastOp = dyn_cast<triton::BitcastOp>(tritonOp)) {
-    parseBitcast(bitcastOp, loc, rewriter, offsetMap);
+    return parseBitcast(bitcastOp, loc, rewriter, offsetMap);
   } else if (auto loadOp = dyn_cast<triton::LoadOp>(tritonOp)) {
-    parseLoad(loadOp, loc, rewriter, offsetMap);
+    return parseLoad(loadOp, loc, rewriter, offsetMap);
   } else if (auto broadcastOp = dyn_cast<triton::BroadcastOp>(tritonOp)) {
-    parseBroadcast(broadcastOp, loc, rewriter, offsetMap);
+    return parseBroadcast(broadcastOp, loc, rewriter, offsetMap);
   } else if (auto expandDimsOp = dyn_cast<triton::ExpandDimsOp>(tritonOp)) {
-    parseExpandDims(expandDimsOp, loc, rewriter, offsetMap);
+    return parseExpandDims(expandDimsOp, loc, rewriter, offsetMap);
   } else if (auto clampFOp = dyn_cast<triton::ClampFOp>(tritonOp)) {
-    parseClampF(clampFOp, loc, rewriter, offsetMap);
+    return parseClampF(clampFOp, loc, rewriter, offsetMap);
   }
   // FIXME:Z|wait triton version upgrade to 3.4
   // else if (auto makeTensorDescOp =
@@ -401,31 +417,84 @@ void parseTritonOp(Operation *tritonOp, const Location &loc,
   //   parseMakeTensorDesc(makeTensorDescOp, loc, rewriter, offsetMap);
   // }
   else if (auto makeTensorPtrOp = dyn_cast<triton::MakeTensorPtrOp>(tritonOp)) {
-    parseMakeTensorPtr(makeTensorPtrOp, loc, rewriter, offsetMap);
+    return parseMakeTensorPtr(makeTensorPtrOp, loc, rewriter, offsetMap);
   } else if (auto reduceOp = dyn_cast<triton::ReduceOp>(tritonOp)) {
-    parseReduce(reduceOp, loc, rewriter, offsetMap);
+    return parseReduce(reduceOp, loc, rewriter, offsetMap);
   } else if (auto reduceReturnOp = dyn_cast<triton::ReduceReturnOp>(tritonOp)) {
-    parseReduceReturn(reduceReturnOp, loc, rewriter, offsetMap);
+    return parseReduceReturn(reduceReturnOp, loc, rewriter, offsetMap);
   } else if (auto advanceOp = dyn_cast<triton::AdvanceOp>(tritonOp)) {
-    parseAdvance(advanceOp, loc, rewriter, offsetMap);
+    return parseAdvance(advanceOp, loc, rewriter, offsetMap);
   } else if (auto intToPtrOp = dyn_cast<triton::IntToPtrOp>(tritonOp)) {
-    parseIntToPtr(intToPtrOp, loc, rewriter, offsetMap);
+    return parseIntToPtr(intToPtrOp, loc, rewriter, offsetMap);
   }
+  return success();
 }
 
-void parseAddPtr(triton::AddPtrOp op, const Location &loc,
-                 RewriterBase &rewriter,
-                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+static triton::PointerType getScalarPointerType(Type type) {
+  if (auto shapedType = dyn_cast<ShapedType>(type))
+    type = shapedType.getElementType();
+  return dyn_cast<triton::PointerType>(type);
+}
+
+static unsigned getPointeeByteWidth(Type pointerType) {
+  auto scalarPointerType = getScalarPointerType(pointerType);
+  if (!scalarPointerType)
+    return 0;
+  Type pointeeType = scalarPointerType.getPointeeType();
+  if (auto shapedType = dyn_cast<ShapedType>(pointeeType))
+    pointeeType = shapedType.getElementType();
+  if (!pointeeType.isIntOrFloat())
+    return 0;
+  unsigned bitWidth = pointeeType.getIntOrFloatBitWidth();
+  if (bitWidth == 1)
+    bitWidth = 8;
+  if (bitWidth < 8 || bitWidth % 8 != 0)
+    return 0;
+  return bitWidth / 8;
+}
+
+static Value scaleOffsetToBytes(Value offset, unsigned byteWidth, Location loc,
+                                RewriterBase &rewriter) {
+  if (byteWidth == 1)
+    return offset;
+  Type elementType = offset.getType();
+  if (auto shapedType = dyn_cast<ShapedType>(elementType))
+    elementType = shapedType.getElementType();
+  auto integerType = cast<IntegerType>(elementType);
+  TypedAttr factor = rewriter.getIntegerAttr(integerType, byteWidth);
+  if (auto shapedType = dyn_cast<ShapedType>(offset.getType()))
+    factor = DenseElementsAttr::get(shapedType, factor);
+  Value factorValue = rewriter.create<arith::ConstantOp>(loc, factor);
+  return rewriter.create<arith::MulIOp>(loc, offset, factorValue);
+}
+
+LogicalResult parseAddPtr(triton::AddPtrOp op, const Location &loc,
+                          RewriterBase &rewriter,
+                          llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Get addPtr base_ptr
   Value ptr = op.getPtr();
-  parse(ptr, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(ptr, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   // Get addPtr offset
   Value offsetValue = op.getOffset();
-  parse(offsetValue, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(offsetValue, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo ptrOffsetInfo = offsetMap.at(ptr);
   PtrOffsetInfo offsetOffsetInfo = offsetMap.at(offsetValue);
-  // Modify IR
 
+  // A tensor pointer argument has no scalar root from which an exact address
+  // can be materialized. Keep the unit marker and structural information so the
+  // memory converter can reject it with a stable diagnostic instead of trying
+  // to perform arithmetic on an absent offset.
+  if (!ptrOffsetInfo.getPtr() || !ptrOffsetInfo.getOffset()) {
+    auto dstOffsetInfo = combineInfo(ptrOffsetInfo, offsetOffsetInfo);
+    dstOffsetInfo.setPtr(ptrOffsetInfo.getPtr());
+    dstOffsetInfo.setByteAddressed(ptrOffsetInfo.isByteAddressed());
+    offsetMap[op.getResult()] = dstOffsetInfo;
+    return success();
+  }
+
+  // Modify IR
   RewriterBase::InsertionGuard guard(rewriter);
   rewriter.setInsertionPoint(op);
   if (auto offsetType = dyn_cast<RankedTensorType>(offsetValue.getType())) {
@@ -443,6 +512,16 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
           op.getLoc(), rewriter.getIntegerType(64), offsetValue);
     }
   }
+  if (ptrOffsetInfo.isByteAddressed()) {
+    unsigned byteWidth = getPointeeByteWidth(ptr.getType());
+    if (!byteWidth) {
+      op.emitError("byte-addressed AddPtr requires a byte-addressable scalar "
+                   "integer or floating-point pointee type");
+      return failure();
+    }
+    offsetValue =
+        scaleOffsetToBytes(offsetValue, byteWidth, op.getLoc(), rewriter);
+  }
   LLVM_DEBUG({
     auto &os = llvm::dbgs();
     os << "[parseAddPtr] Adding offset\n";
@@ -459,6 +538,7 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
   auto dstOffsetInfo = combineInfo(ptrOffsetInfo, offsetOffsetInfo);
   dstOffsetInfo.setPtr(ptrOffsetInfo.getPtr());
   dstOffsetInfo.setOffset(offset);
+  dstOffsetInfo.setByteAddressed(ptrOffsetInfo.isByteAddressed());
   offsetMap[dst] = dstOffsetInfo;
   LLVM_DEBUG({
     auto &os = llvm::dbgs();
@@ -473,17 +553,21 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
       os << static_cast<int>(offsetStructured[i]);
     os << "\n";
   });
+  return success();
 }
 
-void parseSplat(triton::SplatOp op, const Location &loc, RewriterBase &rewriter,
-                llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseSplat(triton::SplatOp op, const Location &loc,
+                         RewriterBase &rewriter,
+                         llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Get splat src
   auto src = op.getSrc();
-  parse(src, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(src, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo srcOffsetInfo = offsetMap.at(src);
   auto dst = op.getResult();
   auto dstType = cast<RankedTensorType>(dst.getType());
   PtrOffsetInfo dstOffsetInfo(srcOffsetInfo.getPtr());
+  dstOffsetInfo.setByteAddressed(srcOffsetInfo.isByteAddressed());
   // Modify IR
   LLVM_DEBUG({
     auto &os = llvm::dbgs();
@@ -506,17 +590,21 @@ void parseSplat(triton::SplatOp op, const Location &loc, RewriterBase &rewriter,
                                      : PtrOffsetInfo::AxisInfo::scalarlike);
   dstOffsetInfo.setScalarLike(true);
   offsetMap[dst] = dstOffsetInfo;
+  return success();
 }
 
 template <typename BinOpTy>
-void parseBinaryOp(BinOpTy op, const Location &loc, RewriterBase &rewriter,
-                   llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseBinaryOp(BinOpTy op, const Location &loc,
+                            RewriterBase &rewriter,
+                            llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   auto lhs = op.getLhs();
-  parse(lhs, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(lhs, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo lhsOffsetInfo = offsetMap.at(lhs);
   auto &lhsStructured = lhsOffsetInfo.getStructuredRef();
   auto rhs = op.getRhs();
-  parse(rhs, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(rhs, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo rhsOffsetInfo = offsetMap.at(rhs);
   auto &rhsStructured = rhsOffsetInfo.getStructuredRef();
   auto dst = op->getResult(0);
@@ -529,32 +617,40 @@ void parseBinaryOp(BinOpTy op, const Location &loc, RewriterBase &rewriter,
   else
     dstOffsetInfo.setUnstructured(lhsStructured.size());
   offsetMap[dst] = dstOffsetInfo;
+  return success();
 }
 
-void parseAddI(arith::AddIOp op, const Location &loc, RewriterBase &rewriter,
-               llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseAddI(arith::AddIOp op, const Location &loc,
+                        RewriterBase &rewriter,
+                        llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Get addi lhs
   auto lhs = op.getLhs();
-  parse(lhs, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(lhs, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo lhsOffsetInfo = offsetMap.at(lhs);
   // Get addi rhs
   auto rhs = op.getRhs();
-  parse(rhs, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(rhs, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo rhsOffsetInfo = offsetMap.at(rhs);
   // Set addi offset map
   auto dst = op.getResult();
   offsetMap[dst] = combineInfo(lhsOffsetInfo, rhsOffsetInfo);
+  return success();
 }
 
-void parseSubI(arith::SubIOp op, const Location &loc, RewriterBase &rewriter,
-               llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseSubI(arith::SubIOp op, const Location &loc,
+                        RewriterBase &rewriter,
+                        llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Get addi lhs
   auto lhs = op.getLhs();
-  parse(lhs, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(lhs, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo lhsOffsetInfo = offsetMap.at(lhs);
   // Get addi rhs
   auto rhs = op.getRhs();
-  parse(rhs, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(rhs, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo rhsOffsetInfo = offsetMap.at(rhs);
   // Set addi offset map
   auto dst = op.getResult();
@@ -562,23 +658,27 @@ void parseSubI(arith::SubIOp op, const Location &loc, RewriterBase &rewriter,
   if (!(lhsOffsetInfo.isStructured() && rhsOffsetInfo.isScalarLike())) {
     offsetMap[dst].setUnstructured(offsetMap[dst].getRank());
   }
+  return success();
 }
 
-void parseIndexCast(arith::IndexCastOp op, const Location &loc,
-                    RewriterBase &rewriter,
-                    llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseIndexCast(arith::IndexCastOp op, const Location &loc,
+                             RewriterBase &rewriter,
+                             llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Get indexCast input
   auto src = op.getIn();
-  parse(src, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(src, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   // Set indexCast offset map
   auto dst = op.getOut();
   auto srcOffsetInfo = offsetMap.at(src);
   offsetMap[dst] = srcOffsetInfo;
+  return success();
 }
 
 template <typename ConstOpTy>
-void parseConstantOp(ConstOpTy dst, const Location &loc, RewriterBase &rewriter,
-                     llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseConstantOp(ConstOpTy dst, const Location &loc,
+                              RewriterBase &rewriter,
+                              llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Set constant offset map
   offsetMap[dst] = PtrOffsetInfo();
   offsetMap[dst].setScalarLike(true);
@@ -589,78 +689,141 @@ void parseConstantOp(ConstOpTy dst, const Location &loc, RewriterBase &rewriter,
       dstStructured.push_back(dim == 1 ? PtrOffsetInfo::AxisInfo::scalar
                                        : PtrOffsetInfo::AxisInfo::scalarlike);
   }
+  return success();
 }
 
-void parseMakeRange(triton::MakeRangeOp op, const Location &loc,
-                    RewriterBase &rewriter,
-                    llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseMakeRange(triton::MakeRangeOp op, const Location &loc,
+                             RewriterBase &rewriter,
+                             llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Set makeRange offset map
   auto dst = op.getResult();
   offsetMap[dst] = PtrOffsetInfo();
   offsetMap[dst].setStructured(1);
+  return success();
 }
 
-void parseExtSI(arith::ExtSIOp op, const Location &loc, RewriterBase &rewriter,
-                llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseExtSI(arith::ExtSIOp op, const Location &loc,
+                         RewriterBase &rewriter,
+                         llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Get extSI input
   auto src = op.getIn();
-  parse(src, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(src, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   // Set extSI offset map
   auto dst = op.getOut();
   auto srcOffsetInfo = offsetMap.at(src);
   offsetMap[dst] = srcOffsetInfo;
+  return success();
 }
 
-void parseBitcast(triton::BitcastOp op, const Location &loc,
-                  RewriterBase &rewriter,
-                  llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
-  // Get bitcast src
-  auto src = op.getSrc();
-  parse(src, op.getLoc(), rewriter, offsetMap);
+LogicalResult parseBitcast(triton::BitcastOp op, const Location &loc,
+                           RewriterBase &rewriter,
+                           llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+  Value src = op.getSrc();
+  if (failed(parseChecked(src, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo srcOffsetInfo = offsetMap.at(src);
-  auto &srcStructured = srcOffsetInfo.getStructuredRef();
-  // Set extSI offset map
-  auto dst = op.getResult();
-  if (auto ptr = srcOffsetInfo.getPtr()) {
-    Type ptrType = dst.getType();
-    if (auto tensorType = dyn_cast<RankedTensorType>(ptrType))
-      ptrType = tensorType.getElementType();
-    rewriter.setInsertionPoint(op);
-    ptr = rewriter.create<triton::BitcastOp>(loc, ptrType, ptr);
-    offsetMap[dst] =
-        PtrOffsetInfo(ptr, srcOffsetInfo.getOffset(), srcStructured);
-  } else {
-    offsetMap[dst] = PtrOffsetInfo(srcStructured);
-  }
-  offsetMap[dst].setScalarLike(srcOffsetInfo.isScalarLike());
-}
+  Value dst = op.getResult();
 
-void parseLoad(triton::LoadOp op, const Location &loc, RewriterBase &rewriter,
-               llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+  auto srcPtrType = getScalarPointerType(src.getType());
+  auto dstPtrType = getScalarPointerType(dst.getType());
+  if (!srcPtrType || !dstPtrType) {
+    // This analysis also sees ordinary value bitcasts. Keep their established
+    // behavior and do not attach pointer-address unit state to numeric values.
+    offsetMap[dst] = PtrOffsetInfo(srcOffsetInfo.getStructured());
+    offsetMap[dst].setScalarLike(srcOffsetInfo.isScalarLike());
+    return success();
+  }
+  if (srcPtrType.getAddressSpace() != dstPtrType.getAddressSpace()) {
+    op.emitError("cannot bitcast pointers between different address spaces");
+    return failure();
+  }
+  MLIRContext *context = op.getContext();
+  if (srcPtrType.getPointeeType() != IntegerType::get(context, 1) &&
+      dstPtrType.getPointeeType() == IntegerType::get(context, 1)) {
+    op.emitError(
+        "pointer bitcast to i1 from a different pointee type is unsupported "
+        "because i1 pointers use i8 storage");
+    return failure();
+  }
+  if (srcPtrType == dstPtrType) {
+    offsetMap[dst] = srcOffsetInfo;
+    return success();
+  }
+
+  unsigned srcByteWidth = getPointeeByteWidth(src.getType());
+  unsigned dstByteWidth = getPointeeByteWidth(dst.getType());
+  if (!srcByteWidth || !dstByteWidth) {
+    op.emitError(
+        "different-width pointer bitcast requires byte-addressable scalar "
+        "integer or floating-point pointee types");
+    return failure();
+  }
+
+  offsetMap[dst] = srcOffsetInfo;
+  if (srcByteWidth == dstByteWidth) {
+    // The offset unit is unchanged. Keep the live source root in analysis and
+    // materialize the target pointee type only when rewriting a real memory
+    // operation. An analysis-map entry is not an SSA use, so creating a cast
+    // here can leave a dangling Value after greedy canonicalization.
+    return success();
+  }
+
+  // Record the different-width boundary even when analysis cannot recover a
+  // scalar root (for example, a tensor pointer function argument). The memory
+  // converter owns the structural diagnostic for that unsupported form.
+  if (!srcOffsetInfo.getPtr() || !srcOffsetInfo.getOffset()) {
+    offsetMap[dst].setByteAddressed();
+    return success();
+  }
+
+  // A different-width bitcast is an address boundary, not an offset
+  // conversion. Convert the accumulated source-element offset to bytes once,
+  // without division or alignment assumptions. Later AddPtr operations add
+  // their own offset multiplied by the pointee width visible at that operation.
+  // This preserves the exact address even across multiple bitcasts.
+  if (!srcOffsetInfo.isByteAddressed()) {
+    RewriterBase::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(op);
+    Value byteOffset = scaleOffsetToBytes(srcOffsetInfo.getOffset(),
+                                          srcByteWidth, op.getLoc(), rewriter);
+    offsetMap[dst].setOffset(byteOffset);
+  }
+  offsetMap[dst].setByteAddressed();
+  return success();
+}
+LogicalResult parseLoad(triton::LoadOp op, const Location &loc,
+                        RewriterBase &rewriter,
+                        llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Get load ptr
   auto ptr = op.getPtr();
-  parse(ptr, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(ptr, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   // Set load offset map
   auto dst = op.getResult();
   offsetMap[dst] = PtrOffsetInfo();
   offsetMap[dst].setScalarLike(offsetMap[ptr].isScalarLike());
   auto tensorType = dyn_cast<RankedTensorType>(dst.getType());
   if (!tensorType)
-    return;
+    return success();
   offsetMap[dst].setUnstructured(tensorType.getRank());
+  return success();
 }
 
-void parseMulI(arith::MulIOp op, const Location &loc, RewriterBase &rewriter,
-               llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseMulI(arith::MulIOp op, const Location &loc,
+                        RewriterBase &rewriter,
+                        llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Get muli lhs
   auto lhs = op.getLhs();
-  parse(lhs, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(lhs, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo lhsOffsetInfo = offsetMap.at(lhs);
   auto &lhsStructured = lhsOffsetInfo.getStructuredRef();
   bool lhsScalarLike = lhsOffsetInfo.isScalarLike();
   // Get muli rhs
   auto rhs = op.getRhs();
-  parse(rhs, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(rhs, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo rhsOffsetInfo = offsetMap.at(rhs);
   auto &rhsStructured = rhsOffsetInfo.getStructuredRef();
   bool rhsScalarLike = rhsOffsetInfo.isScalarLike();
@@ -678,14 +841,16 @@ void parseMulI(arith::MulIOp op, const Location &loc, RewriterBase &rewriter,
       dstStructured[i] = lhsStructured[i];
     else
       dstStructured[i] = PtrOffsetInfo::AxisInfo::unstructured;
+  return success();
 }
 
-void parseBroadcast(triton::BroadcastOp op, const Location &loc,
-                    RewriterBase &rewriter,
-                    llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseBroadcast(triton::BroadcastOp op, const Location &loc,
+                             RewriterBase &rewriter,
+                             llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Get broadcast src
   auto src = op.getSrcMutable().get();
-  parse(src, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(src, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo srcOffsetInfo = offsetMap.at(src);
   auto &srcStructured = srcOffsetInfo.getStructuredRef();
   // Get broadcast dim
@@ -700,6 +865,7 @@ void parseBroadcast(triton::BroadcastOp op, const Location &loc,
   // Set broadcast offset map
   offsetMap[dst] = PtrOffsetInfo(srcOffsetInfo.getPtr());
   offsetMap[dst].setScalarLike(srcOffsetInfo.isScalarLike());
+  offsetMap[dst].setByteAddressed(srcOffsetInfo.isByteAddressed());
 
   if (srcOffsetInfo.getPtr()) {
     RewriterBase::InsertionGuard guard(rewriter);
@@ -722,20 +888,23 @@ void parseBroadcast(triton::BroadcastOp op, const Location &loc,
     } else {
       dstStructured[i] = srcStructured[i];
     }
+  return success();
 }
 
-void parseExpandDims(triton::ExpandDimsOp op, const Location &loc,
-                     RewriterBase &rewriter,
-                     llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseExpandDims(triton::ExpandDimsOp op, const Location &loc,
+                              RewriterBase &rewriter,
+                              llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Get expandDims src
   auto src = op.getSrc();
-  parse(src, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(src, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo srcOffsetInfo = offsetMap.at(src);
   auto &srcStructured = srcOffsetInfo.getStructuredRef();
   // Set expandDims offset map
   auto dst = op.getResult();
   offsetMap[dst] = PtrOffsetInfo(srcOffsetInfo.getPtr());
   offsetMap[dst].setScalarLike(srcOffsetInfo.isScalarLike());
+  offsetMap[dst].setByteAddressed(srcOffsetInfo.isByteAddressed());
   if (srcOffsetInfo.getPtr()) {
     RewriterBase::InsertionGuard guard(rewriter);
     rewriter.setInsertionPoint(op);
@@ -755,22 +924,26 @@ void parseExpandDims(triton::ExpandDimsOp op, const Location &loc,
       dstStructured[i] = srcStructured[j];
       j++;
     }
+  return success();
 }
 
-void parseClampF(triton::ClampFOp op, const Location &loc,
-                 RewriterBase &rewriter,
-                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseClampF(triton::ClampFOp op, const Location &loc,
+                          RewriterBase &rewriter,
+                          llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Get clampF src
   auto src = op.getX();
-  parse(src, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(src, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo srcOffsetInfo = offsetMap.at(src);
   // Get clampF min
   auto clampMin = op.getMin();
-  parse(clampMin, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(clampMin, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo minOffsetInfo = offsetMap.at(clampMin);
   // Get clampF max
   auto clampMax = op.getMax();
-  parse(clampMax, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(clampMax, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo maxOffsetInfo = offsetMap.at(clampMax);
   // Set clampF offset map
   auto dst = op.getResult();
@@ -780,27 +953,31 @@ void parseClampF(triton::ClampFOp op, const Location &loc,
                                maxOffsetInfo.isScalarLike());
   auto dstType = dyn_cast<ShapedType>(dst.getType());
   if (!dstType)
-    return;
+    return success();
   offsetMap[dst].setUnstructured(dstType.getRank());
+  return success();
 }
 
-void parseSelect(arith::SelectOp op, const Location &loc,
-                 RewriterBase &rewriter,
-                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseSelect(arith::SelectOp op, const Location &loc,
+                          RewriterBase &rewriter,
+                          llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Get select condition
   auto condition = op.getCondition();
-  parse(condition, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(condition, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo conditionOffsetInfo = offsetMap.at(condition);
   bool conditionScalarLike = conditionOffsetInfo.isScalarLike();
   // Get select trueValue
   auto trueValue = op.getTrueValue();
-  parse(trueValue, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(trueValue, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo trueValueOffsetInfo = offsetMap.at(trueValue);
   auto &trueValueStructured = trueValueOffsetInfo.getStructuredRef();
   bool trueValueScalarLike = trueValueOffsetInfo.isScalarLike();
   // Get select falseValue
   auto falseValue = op.getFalseValue();
-  parse(falseValue, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(falseValue, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo falseValueOffsetInfo = offsetMap.at(falseValue);
   auto &falseValueStructured = falseValueOffsetInfo.getStructuredRef();
   bool falseValueScalarLike = falseValueOffsetInfo.isScalarLike();
@@ -809,7 +986,7 @@ void parseSelect(arith::SelectOp op, const Location &loc,
   offsetMap[dst] = PtrOffsetInfo();
   auto dstType = dyn_cast<ShapedType>(dst.getType());
   if (!dstType)
-    return;
+    return success();
 
   auto dstIsScalar =
       trueValueScalarLike && falseValueScalarLike && conditionScalarLike;
@@ -820,14 +997,16 @@ void parseSelect(arith::SelectOp op, const Location &loc,
   for (size_t i = 0; i < dstStructured.size(); i++)
     dstStructured[i] = (dstIsScalar) ? PtrOffsetInfo::AxisInfo::scalarlike
                                      : PtrOffsetInfo::AxisInfo::unstructured;
+  return success();
 }
 
-void parseFPToSI(arith::FPToSIOp op, const Location &loc,
-                 RewriterBase &rewriter,
-                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseFPToSI(arith::FPToSIOp op, const Location &loc,
+                          RewriterBase &rewriter,
+                          llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Get FPToSI src
   auto src = op.getIn();
-  parse(src, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(src, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo srcOffsetInfo = offsetMap.at(src);
   // Set FPToSI offset map
   auto dst = op.getResult();
@@ -835,20 +1014,22 @@ void parseFPToSI(arith::FPToSIOp op, const Location &loc,
   offsetMap[dst].setScalarLike(srcOffsetInfo.isScalarLike());
   auto dstType = dyn_cast<ShapedType>(dst.getType());
   if (!dstType)
-    return;
+    return success();
   if (offsetMap[dst].isScalarLike())
     offsetMap[dst].setStructured(dstType.getRank(),
                                  PtrOffsetInfo::AxisInfo::scalarlike);
   else
     offsetMap[dst].setUnstructured(dstType.getRank());
+  return success();
 }
 
-void parseSIToFP(arith::SIToFPOp op, const Location &loc,
-                 RewriterBase &rewriter,
-                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseSIToFP(arith::SIToFPOp op, const Location &loc,
+                          RewriterBase &rewriter,
+                          llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Get SIToFP src
   auto src = op.getIn();
-  parse(src, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(src, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo srcOffsetInfo = offsetMap.at(src);
   // Set SIToFP offset map
   auto dst = op.getResult();
@@ -856,12 +1037,13 @@ void parseSIToFP(arith::SIToFPOp op, const Location &loc,
   offsetMap[dst].setScalarLike(srcOffsetInfo.isScalarLike());
   auto dstType = dyn_cast<ShapedType>(dst.getType());
   if (!dstType)
-    return;
+    return success();
   if (offsetMap[dst].isScalarLike())
     offsetMap[dst].setStructured(dstType.getRank(),
                                  PtrOffsetInfo::AxisInfo::scalarlike);
   else
     offsetMap[dst].setUnstructured(dstType.getRank());
+  return success();
 }
 
 // FIXME:Z|wait triton version upgrade to 3.4
@@ -877,33 +1059,36 @@ void parseSIToFP(arith::SIToFPOp op, const Location &loc,
 //   offsetMap[dst].setStructured(dstType.getRank());
 // }
 
-void parseMakeTensorPtr(triton::MakeTensorPtrOp op, const Location &loc,
-                        RewriterBase &rewriter,
-                        llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult
+parseMakeTensorPtr(triton::MakeTensorPtrOp op, const Location &loc,
+                   RewriterBase &rewriter,
+                   llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Set MakeTensorPtr offset map
   auto dst = op.getResult();
   offsetMap[dst] = PtrOffsetInfo(dst);
   auto dstType = dyn_cast<ShapedType>(
       cast<triton::PointerType>(dst.getType()).getPointeeType());
   if (!dstType)
-    return;
+    return success();
   offsetMap[dst].setStructured(dstType.getRank());
   offsetMap[dst].setOffsets(op.getOffsets());
+  return success();
 }
 
-void parseAdvance(triton::AdvanceOp op, const Location &loc,
-                  RewriterBase &rewriter,
-                  llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseAdvance(triton::AdvanceOp op, const Location &loc,
+                           RewriterBase &rewriter,
+                           llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Set Advance offset map
   auto ptr = op.getPtr();
-  parse(ptr, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(ptr, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   auto dst = op.getResult();
   auto ptrOffsetInfo = offsetMap.at(ptr);
   offsetMap[dst] = ptrOffsetInfo;
   auto dstType = dyn_cast<ShapedType>(
       cast<triton::PointerType>(dst.getType()).getPointeeType());
   if (!dstType)
-    return;
+    return success();
   offsetMap[dst].setStructured(dstType.getRank());
   auto &offsets = offsetMap[dst].getOffsetsRef();
 
@@ -913,14 +1098,16 @@ void parseAdvance(triton::AdvanceOp op, const Location &loc,
     curOffset =
         rewriter.create<arith::AddIOp>(op.getLoc(), curOffset, opOffset);
   }
+  return success();
 }
 
-void parseReduce(triton::ReduceOp op, const Location &loc,
-                 RewriterBase &rewriter,
-                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseReduce(triton::ReduceOp op, const Location &loc,
+                          RewriterBase &rewriter,
+                          llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Get reduce src
   Value src = op->getOperand(0);
-  parse(src, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(src, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo srcOffsetInfo = offsetMap.at(src);
   auto &srcStructured = srcOffsetInfo.getStructuredRef();
   // Set reduce offset map
@@ -929,7 +1116,7 @@ void parseReduce(triton::ReduceOp op, const Location &loc,
   offsetMap[dst] = PtrOffsetInfo();
   offsetMap[dst].setScalarLike(srcOffsetInfo.isScalarLike());
   if (!dstType)
-    return;
+    return success();
   auto &dstStructured = offsetMap[dst].getStructuredRef();
   auto dstShape = dstType.getShape();
   dstStructured.resize(dstShape.size());
@@ -938,14 +1125,17 @@ void parseReduce(triton::ReduceOp op, const Location &loc,
       dstStructured[i] = PtrOffsetInfo::AxisInfo::scalar;
     else
       dstStructured[i] = srcStructured[i];
+  return success();
 }
 
-void parseReduceReturn(triton::ReduceReturnOp op, const Location &loc,
-                       RewriterBase &rewriter,
-                       llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult
+parseReduceReturn(triton::ReduceReturnOp op, const Location &loc,
+                  RewriterBase &rewriter,
+                  llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Get reduce src
   Value src = op->getOperand(0);
-  parse(src, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(src, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo srcOffsetInfo = offsetMap.at(src);
   auto &srcStructured = srcOffsetInfo.getStructuredRef();
   // Set reduce offset map
@@ -954,7 +1144,7 @@ void parseReduceReturn(triton::ReduceReturnOp op, const Location &loc,
   offsetMap[dst] = PtrOffsetInfo();
   offsetMap[dst].setScalarLike(srcOffsetInfo.isScalarLike());
   if (!dstType)
-    return;
+    return success();
   auto &dstStructured = offsetMap[dst].getStructuredRef();
   auto dstShape = dstType.getShape();
   dstStructured.resize(dstShape.size());
@@ -963,83 +1153,109 @@ void parseReduceReturn(triton::ReduceReturnOp op, const Location &loc,
       dstStructured[i] = PtrOffsetInfo::AxisInfo::scalar;
     else
       dstStructured[i] = srcStructured[i];
+  return success();
 }
 
-void parseIf(scf::IfOp op, const Location &loc, RewriterBase &rewriter,
-             llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap, Value dst) {
+LogicalResult parseIf(scf::IfOp op, const Location &loc, RewriterBase &rewriter,
+                      llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap,
+                      Value dst) {
   const unsigned int index = cast<OpResult>(dst).getResultNumber();
-  // Get if then region
   Block &thenBlock = op.getThenRegion().front();
   Value thenYieldedValue = thenBlock.getTerminator()->getOperand(index);
-  parse(thenYieldedValue, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(thenYieldedValue, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   PtrOffsetInfo thenOffsetInfo = offsetMap.at(thenYieldedValue);
   auto &thenStructured = thenOffsetInfo.getStructuredRef();
-  auto thenSrcPtr = thenOffsetInfo.getPtr();
-  // Get if else region
+  Value thenSrcPtr = thenOffsetInfo.getPtr();
   bool dstIsScalar = thenOffsetInfo.isScalarLike();
-  SmallVector<PtrOffsetInfo::AxisInfo> elseStructured;
+
   if (op.elseBlock()) {
     Block &elseBlock = op.getElseRegion().front();
     Value elseYieldedValue = elseBlock.getTerminator()->getOperand(index);
-    parse(elseYieldedValue, op.getLoc(), rewriter, offsetMap);
+    if (failed(
+            parseChecked(elseYieldedValue, op.getLoc(), rewriter, offsetMap)))
+      return failure();
     PtrOffsetInfo elseOffsetInfo = offsetMap.at(elseYieldedValue);
-    elseStructured = elseOffsetInfo.getStructuredRef();
-    dstIsScalar = dstIsScalar && elseOffsetInfo.isScalarLike();
-    if (thenSrcPtr != elseOffsetInfo.getPtr()) {
+    if (thenOffsetInfo.isByteAddressed() || elseOffsetInfo.isByteAddressed()) {
+      if (thenOffsetInfo.isByteAddressed() !=
+          elseOffsetInfo.isByteAddressed()) {
+        op.emitError(
+            "cannot merge pointer offsets with different address units");
+        return failure();
+      }
+      if (thenSrcPtr != elseOffsetInfo.getPtr()) {
+        op.emitError("cannot merge pointers from different scalar roots");
+        return failure();
+      }
+    } else if (thenSrcPtr != elseOffsetInfo.getPtr()) {
+      // Preserve the legacy element-addressed behavior. Different roots were
+      // already unsupported there, but byte-address validation must not turn
+      // unrelated control flow into a new hard analysis failure.
       emitError(loc)
           << "Currently ptr type from different source not supported";
     }
+    dstIsScalar = dstIsScalar && elseOffsetInfo.isScalarLike();
   }
 
-  // Set if offset map
+  // Populate the result only after every branch has been validated. A failure
+  // must not leave a partially usable pointer state in the analysis map.
   offsetMap[dst] = PtrOffsetInfo();
   offsetMap[dst].setPtr(thenSrcPtr);
+  offsetMap[dst].setByteAddressed(thenOffsetInfo.isByteAddressed());
   offsetMap[dst].setScalarLike(dstIsScalar);
   auto &dstStructured = offsetMap[dst].getStructuredRef();
   dstStructured.resize(thenStructured.size());
-  for (size_t i = 0; i < dstStructured.size(); i++)
+  for (size_t i = 0; i < dstStructured.size(); i++) {
     if (op.elseBlock())
-      dstStructured[i] = (dstIsScalar) ? PtrOffsetInfo::AxisInfo::scalarlike
-                                       : PtrOffsetInfo::AxisInfo::unstructured;
+      dstStructured[i] = dstIsScalar ? PtrOffsetInfo::AxisInfo::scalarlike
+                                     : PtrOffsetInfo::AxisInfo::unstructured;
     else
       dstStructured[i] = thenStructured[i];
+  }
   SmallVector<Value> dstOffsets(thenOffsetInfo.getOffsetsRef().size());
-  if (!dstOffsets.empty()) {
-    // Assumes ifOp is already rewritten
+  if (!dstOffsets.empty() && op->getNumResults() >= index + dstOffsets.size()) {
+    // replacePtrArguments expands block-pointer offsets into extra results.
+    // Keep the expanded results as the materializable offset state.
     for (size_t i = 0; i < dstOffsets.size(); i++)
       dstOffsets[i] = op->getResult(index + i);
     offsetMap[dst].setOffsets(dstOffsets);
   }
+  return success();
 }
-
-void parseYield(scf::YieldOp op, const Location &loc, RewriterBase &rewriter,
-                llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseYield(scf::YieldOp op, const Location &loc,
+                         RewriterBase &rewriter,
+                         llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Get yield src
   for (auto src : op->getOperands())
-    parse(src, op.getLoc(), rewriter, offsetMap);
+    if (failed(parseChecked(src, op.getLoc(), rewriter, offsetMap)))
+      return failure();
+  return success();
 }
 
-void parseLoopOp(LoopLikeOpInterface op, const Location &loc,
-                 RewriterBase &rewriter,
-                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap, Value dst) {
+LogicalResult parseLoopOp(LoopLikeOpInterface op, const Location &loc,
+                          RewriterBase &rewriter,
+                          llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap,
+                          Value dst) {
   auto resNum = cast<OpResult>(dst).getResultNumber();
-  Value yieldedValue = nullptr;
-  if (auto whileOp = dyn_cast<scf::WhileOp>(op.getOperation())) {
+  Value yieldedValue;
+  if (auto whileOp = dyn_cast<scf::WhileOp>(op.getOperation()))
     yieldedValue = whileOp.getConditionOp().getArgs()[resNum];
-  } else {
+  else
     yieldedValue = op.getYieldedValues()[resNum];
-  }
-  parse(yieldedValue, op.getLoc(), rewriter, offsetMap);
-  auto yieldOffsetInfo = offsetMap.at(yieldedValue);
-  offsetMap[dst] = yieldOffsetInfo;
+  if (failed(parseChecked(yieldedValue, op.getLoc(), rewriter, offsetMap)))
+    return failure();
+  offsetMap[dst] = offsetMap.at(yieldedValue);
+  return success();
 }
 
-void parseExtractSlice(tensor::ExtractSliceOp op, const Location &loc,
-                       RewriterBase &rewriter,
-                       llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult
+parseExtractSlice(tensor::ExtractSliceOp op, const Location &loc,
+                  RewriterBase &rewriter,
+                  llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   // Get extractSlice src
   auto src = op.getSource();
-  parse(src, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(src, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   // Set extractSlice offset map
   auto dst = op.getResult();
   auto srcPtrInfo = offsetMap.at(src);
@@ -1062,56 +1278,112 @@ void parseExtractSlice(tensor::ExtractSliceOp op, const Location &loc,
       dstStructured.push_back(srcStructured[i]);
   }
   offsetMap[dst] = PtrOffsetInfo(srcPtr, srcOffset, dstStructured);
+  offsetMap[dst].setByteAddressed(srcPtrInfo.isByteAddressed());
+  return success();
 }
 
-void parseInsertSlice(tensor::InsertSliceOp op, const Location &loc,
-                      RewriterBase &rewriter,
-                      llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
-  // Get insertSlice src and dst
+static bool isPointerTensor(Type type) {
+  auto tensorType = dyn_cast<RankedTensorType>(type);
+  return tensorType && isa<triton::PointerType>(tensorType.getElementType());
+}
+
+static LogicalResult validatePointerInsertState(Operation *op,
+                                                llvm::StringRef operationName,
+                                                const PtrOffsetInfo &srcInfo,
+                                                const PtrOffsetInfo &dstInfo) {
+  if (!srcInfo.getPtr() || !srcInfo.getOffset() || !dstInfo.getPtr() ||
+      !dstInfo.getOffset()) {
+    op->emitError() << operationName
+                    << " requires complete source and destination pointer "
+                       "states";
+    return failure();
+  }
+  if (srcInfo.isByteAddressed() != dstInfo.isByteAddressed()) {
+    op->emitError() << operationName
+                    << " cannot merge pointer offsets with different address "
+                       "units";
+    return failure();
+  }
+  if (srcInfo.getPtr() != dstInfo.getPtr()) {
+    op->emitError() << operationName
+                    << " cannot merge pointers from different scalar roots";
+    return failure();
+  }
+  return success();
+}
+
+LogicalResult
+parseInsertSlice(tensor::InsertSliceOp op, const Location &loc,
+                 RewriterBase &rewriter,
+                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   auto src = op.getSource();
-  parse(src, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(src, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   auto dst = op.getDest();
-  parse(dst, op.getLoc(), rewriter, offsetMap);
-  // Set insertSlice offset map
+  if (failed(parseChecked(dst, op.getLoc(), rewriter, offsetMap)))
+    return failure();
+
   auto res = op.getResult();
   auto srcPtrInfo = offsetMap.at(src);
   auto dstPtrInfo = offsetMap.at(dst);
+  const bool pointerResult = isPointerTensor(res.getType());
+  const bool byteAddressedPointerResult =
+      pointerResult &&
+      (srcPtrInfo.isByteAddressed() || dstPtrInfo.isByteAddressed());
+  if (byteAddressedPointerResult &&
+      failed(validatePointerInsertState(
+          op.getOperation(), "tensor.insert_slice", srcPtrInfo, dstPtrInfo)))
+    return failure();
+
   PtrOffsetInfo resPtrInfo;
-  if (auto srcOffset = srcPtrInfo.getOffset()) {
+  if (byteAddressedPointerResult) {
+    // Validation must precede construction: tensor ops cannot be built with an
+    // absent destination offset, and a rejected merge must leave no new SSA.
     RewriterBase::InsertionGuard guard(rewriter);
     rewriter.setInsertionPoint(op);
-    auto resOffset = rewriter.create<tensor::InsertSliceOp>(
+    Value resOffset = rewriter.create<tensor::InsertSliceOp>(
+        op.getLoc(), srcPtrInfo.getOffset(), dstPtrInfo.getOffset(),
+        op.getMixedOffsets(), op.getMixedSizes(), op.getMixedStrides());
+    resPtrInfo.setPtr(srcPtrInfo.getPtr());
+    resPtrInfo.setOffset(resOffset);
+    resPtrInfo.setByteAddressed(srcPtrInfo.isByteAddressed());
+  } else if (Value srcOffset = srcPtrInfo.getOffset()) {
+    // Preserve the main-dev behavior for every non-byte-addressed value.
+    RewriterBase::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(op);
+    Value resOffset = rewriter.create<tensor::InsertSliceOp>(
         op.getLoc(), srcOffset, dstPtrInfo.getOffset(), op.getMixedOffsets(),
         op.getMixedSizes(), op.getMixedStrides());
-    auto srcPtr = srcPtrInfo.getPtr();
-    auto dstPtr = dstPtrInfo.getPtr();
+    Value srcPtr = srcPtrInfo.getPtr();
+    Value dstPtr = dstPtrInfo.getPtr();
     assert(srcPtr == dstPtr && "ptrInfo for insert slice should be consistent");
     resPtrInfo.setPtr(srcPtr);
     resPtrInfo.setOffset(resOffset);
   }
+
   auto droppedDims = op.getDroppedDims();
   auto srcStructuredIter = srcPtrInfo.getStructured().begin();
   SmallVector<PtrOffsetInfo::AxisInfo> resStructured;
   auto srcShape = op.getStaticSizes();
   auto dstShape = cast<RankedTensorType>(dst.getType()).getShape();
   for (size_t i = 0; i < dstShape.size(); i++) {
-    if (!ShapedType::isDynamic(srcShape[i]) && srcShape[i] == dstShape[i]) {
+    if (!ShapedType::isDynamic(srcShape[i]) && srcShape[i] == dstShape[i])
       resStructured.push_back(*srcStructuredIter);
-    } else {
+    else
       resStructured.push_back(PtrOffsetInfo::AxisInfo::unstructured);
-    }
     if (!droppedDims[i])
       ++srcStructuredIter;
   }
   resPtrInfo.setStructured(resStructured);
   offsetMap[res] = resPtrInfo;
+  return success();
 }
-
-void parseExtract(tensor::ExtractOp op, const Location &loc,
-                  RewriterBase &rewriter,
-                  llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseExtract(tensor::ExtractOp op, const Location &loc,
+                           RewriterBase &rewriter,
+                           llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   auto parentValue = op.getTensor();
-  parse(parentValue, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(parentValue, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   auto dst = op.getResult();
   offsetMap[dst] = PtrOffsetInfo();
   if (isa<triton::PointerType>(dst.getType())) {
@@ -1119,52 +1391,73 @@ void parseExtract(tensor::ExtractOp op, const Location &loc,
     offsetMap[dst].setZeroOffset();
   }
   offsetMap[dst].setScalarLike(true);
+  return success();
 }
 
-void parseInsert(tensor::InsertOp op, const Location &loc,
-                 RewriterBase &rewriter,
-                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseInsert(tensor::InsertOp op, const Location &loc,
+                          RewriterBase &rewriter,
+                          llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   auto src = op.getScalar();
-  parse(src, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(src, op.getLoc(), rewriter, offsetMap)))
+    return failure();
   auto dst = op.getDest();
-  parse(dst, op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(dst, op.getLoc(), rewriter, offsetMap)))
+    return failure();
 
   auto res = op.getResult();
   auto srcPtrInfo = offsetMap.at(src);
   auto dstPtrInfo = offsetMap.at(dst);
+  const bool pointerResult = isPointerTensor(res.getType());
+  const bool byteAddressedPointerResult =
+      pointerResult &&
+      (srcPtrInfo.isByteAddressed() || dstPtrInfo.isByteAddressed());
+  if (byteAddressedPointerResult &&
+      failed(validatePointerInsertState(op.getOperation(), "tensor.insert",
+                                        srcPtrInfo, dstPtrInfo)))
+    return failure();
 
   PtrOffsetInfo resPtrInfo;
-  if (auto srcOffset = srcPtrInfo.getOffset()) {
+  if (byteAddressedPointerResult) {
     RewriterBase::InsertionGuard guard(rewriter);
     rewriter.setInsertionPoint(op);
-    auto resOffset = rewriter.create<tensor::InsertOp>(
+    Value resOffset = rewriter.create<tensor::InsertOp>(
+        op.getLoc(), srcPtrInfo.getOffset(), dstPtrInfo.getOffset(),
+        op.getIndices());
+    resPtrInfo.setPtr(srcPtrInfo.getPtr());
+    resPtrInfo.setOffset(resOffset);
+    resPtrInfo.setByteAddressed(srcPtrInfo.isByteAddressed());
+  } else if (Value srcOffset = srcPtrInfo.getOffset()) {
+    // Preserve the main-dev behavior for every non-byte-addressed value.
+    RewriterBase::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(op);
+    Value resOffset = rewriter.create<tensor::InsertOp>(
         op.getLoc(), srcOffset, dstPtrInfo.getOffset(), op.getIndices());
-    auto srcPtr = srcPtrInfo.getPtr();
-    auto dstPtr = dstPtrInfo.getPtr();
-    resPtrInfo.setPtr(srcPtr);
+    resPtrInfo.setPtr(srcPtrInfo.getPtr());
     resPtrInfo.setOffset(resOffset);
   }
   resPtrInfo.setUnstructured(dstPtrInfo.getRank());
   offsetMap[res] = resPtrInfo;
+  return success();
 }
-
-void parseIntToPtr(triton::IntToPtrOp op, const Location &loc,
-                   RewriterBase &rewriter,
-                   llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+LogicalResult parseIntToPtr(triton::IntToPtrOp op, const Location &loc,
+                            RewriterBase &rewriter,
+                            llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   auto dst = op.getResult();
   offsetMap[dst] = PtrOffsetInfo(dst);
   offsetMap[dst].setScalarLike(true);
+  return success();
 }
 
 namespace {
 template <typename CustomOpT>
-void parseStructuredCustomOpImpl(
+LogicalResult parseStructuredCustomOpImpl(
     CustomOpT op, const Location &loc, RewriterBase &rewriter,
-    llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap, unsigned int resultIdx) {
-  for (auto operand : op.getInputs()) {
-    parse(operand, op->getLoc(), rewriter, offsetMap);
+    llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap, unsigned resultIdx) {
+  for (Value operand : op.getInputs()) {
+    if (failed(parseChecked(operand, op->getLoc(), rewriter, offsetMap)))
+      return failure();
   }
-  auto dst = op->getResult(resultIdx);
+  Value dst = op->getResult(resultIdx);
   offsetMap[dst] = PtrOffsetInfo();
   auto tensorType = dyn_cast<RankedTensorType>(dst.getType());
   if (!tensorType) {
@@ -1174,12 +1467,14 @@ void parseStructuredCustomOpImpl(
     } else if (isa<IntegerType>(dst.getType())) {
       offsetMap[dst].setOffset(dst);
     } else {
-      emitError(loc) << "Unsupported return type for hivm custom op: "
+      emitError(loc) << "unsupported return type for hivm custom op: "
                      << dst.getType();
+      offsetMap.erase(dst);
+      return failure();
     }
-    return;
+    return success();
   }
-  if (llvm::isa<triton::PointerType>(tensorType.getElementType())) {
+  if (isa<triton::PointerType>(tensorType.getElementType())) {
     if (checkStructureAnnotated(op, rewriter)) {
       auto srcValArrayAttr = op->template getAttrOfType<DenseI32ArrayAttr>(
           ConverterUtils::customSrcPtrIndexAttrName);
@@ -1188,30 +1483,30 @@ void parseStructuredCustomOpImpl(
       auto srcValArray = srcValArrayAttr.asArrayRef();
       assert(srcValArray[resultIdx] != -1 &&
              "tensor<tt.ptr> result should map to src tensor<tt.ptr>");
-      auto srcOffsetInfo = offsetMap[op->getOperand(srcValArray[resultIdx])];
-      offsetMap[dst] = srcOffsetInfo;
-      return;
+      offsetMap[dst] = offsetMap[op->getOperand(srcValArray[resultIdx])];
+      return success();
     }
-    emitError(loc) << "Unsupported return unstructure RankedTensor of tt.ptr "
-                      "for hivm custom op: "
+    emitError(loc) << "unsupported unstructured RankedTensor of tt.ptr "
+                      "return for hivm custom op: "
                    << dst;
+    offsetMap.erase(dst);
+    return failure();
   }
   offsetMap[dst].setUnstructured(tensorType.getRank());
+  return success();
 }
 } // namespace
 
-void parseStructuredCustomOp(Operation *op, const Location &loc,
-                             RewriterBase &rewriter,
-                             llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap,
-                             unsigned int resultIdx) {
-  if (auto customOp = dyn_cast<hivm::CustomOp>(op)) {
-    parseStructuredCustomOpImpl(customOp, loc, rewriter, offsetMap, resultIdx);
-  } else if (auto macroOp = dyn_cast<hivm::CustomMacroOp>(op)) {
-    parseStructuredCustomOpImpl(macroOp, loc, rewriter, offsetMap, resultIdx);
-  } else {
-    llvm_unreachable("expected hivm custom op");
-  }
+LogicalResult parseStructuredCustomOp(
+    Operation *op, const Location &loc, RewriterBase &rewriter,
+    llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap, unsigned resultIdx) {
+  if (auto customOp = dyn_cast<hivm::CustomOp>(op))
+    return parseStructuredCustomOpImpl(customOp, loc, rewriter, offsetMap,
+                                       resultIdx);
+  if (auto macroOp = dyn_cast<hivm::CustomMacroOp>(op))
+    return parseStructuredCustomOpImpl(macroOp, loc, rewriter, offsetMap,
+                                       resultIdx);
+  llvm_unreachable("expected hivm custom op");
 }
-
 } // namespace triton
 } // namespace mlir

--- a/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
@@ -37,7 +37,9 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
 
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
 
 #define DEBUG_TYPE "triton-unstructure-converter"
 
@@ -83,6 +85,109 @@ static int64_t getTypeSizeInByte(Type type) {
     return floatType.getWidth() / kBitsPerByte;
   }
   llvm_unreachable("Unhandled element type of tensor");
+}
+
+static unsigned getPointeeByteWidth(triton::PointerType pointerType) {
+  if (!pointerType)
+    return 0;
+  Type pointeeType = pointerType.getPointeeType();
+  if (auto shapedType = dyn_cast<ShapedType>(pointeeType))
+    pointeeType = shapedType.getElementType();
+  if (!pointeeType.isIntOrFloat())
+    return 0;
+  unsigned bitWidth = pointeeType.getIntOrFloatBitWidth();
+  if (bitWidth == 1)
+    bitWidth = kBitsPerByte;
+  if (bitWidth < kBitsPerByte || bitWidth % kBitsPerByte != 0)
+    return 0;
+  return bitWidth / kBitsPerByte;
+}
+
+static triton::PointerType getScalarPointerType(Type type) {
+  if (auto shapedType = dyn_cast<ShapedType>(type))
+    type = shapedType.getElementType();
+  return dyn_cast<triton::PointerType>(type);
+}
+
+static bool isDifferentWidthPointerBitcast(triton::BitcastOp op) {
+  auto sourceType = getScalarPointerType(op.getSrc().getType());
+  auto targetType = getScalarPointerType(op.getType());
+  unsigned sourceWidth = getPointeeByteWidth(sourceType);
+  unsigned targetWidth = getPointeeByteWidth(targetType);
+  return sourceWidth && targetWidth && sourceWidth != targetWidth;
+}
+
+static bool isPointerValue(Type type) {
+  auto shapedType = dyn_cast<ShapedType>(type);
+  return isa<triton::PointerType>(shapedType ? shapedType.getElementType()
+                                             : type);
+}
+
+// Byte-addressed offsets cannot be reconstructed by ReplaceArguments, whose
+// tt.addptr rebuilding interprets every offset in the root pointee's element
+// unit. Track only SSA values derived from a different-width pointer bitcast
+// and reject an actual structured-control-flow transfer. Capturing such a value
+// inside a region remains valid because no pointer state is reconstructed.
+static LogicalResult rejectByteAddressedControlFlow(ModuleOp moduleOp) {
+  SmallVector<Value> worklist;
+  llvm::DenseSet<Value> visited;
+  moduleOp.walk([&](triton::BitcastOp op) {
+    if (isDifferentWidthPointerBitcast(op))
+      worklist.push_back(op.getResult());
+  });
+
+  while (!worklist.empty()) {
+    Value value = worklist.pop_back_val();
+    if (!visited.insert(value).second)
+      continue;
+
+    for (OpOperand &use : value.getUses()) {
+      Operation *user = use.getOwner();
+      if (isa<scf::YieldOp, scf::ConditionOp, triton::ReturnOp, triton::CallOp>(
+              user) ||
+          isa<LoopLikeOpInterface>(user)) {
+        user->emitError(
+            "byte-addressed pointer cannot cross structured control flow or "
+            "a function boundary");
+        return failure();
+      }
+
+      // Memory operations consume the address but do not forward it. For all
+      // other operations, conservatively propagate provenance through every
+      // pointer result so an unfamiliar pointer-shaping op cannot hide a later
+      // control-flow transfer.
+      if (isa<triton::LoadOp, triton::StoreOp, triton::AtomicRMWOp,
+              triton::AtomicCASOp, triton::PtrToIntOp>(user))
+        continue;
+      for (Value result : user->getResults())
+        if (isPointerValue(result.getType()))
+          worklist.push_back(result);
+    }
+  }
+  return success();
+}
+
+static LogicalResult
+validateByteAddressedPointerTypes(triton::PointerType sourceType,
+                                  triton::PointerType targetType,
+                                  Operation *diagnosticOp) {
+  if (!sourceType || !targetType) {
+    diagnosticOp->emitError(
+        "byte-addressed pointer access requires a scalar root pointer");
+    return failure();
+  }
+  if (!getPointeeByteWidth(sourceType) || !getPointeeByteWidth(targetType)) {
+    diagnosticOp->emitError(
+        "different-width pointer bitcast requires byte-addressable scalar "
+        "integer or floating-point pointee types");
+    return failure();
+  }
+  if (sourceType.getAddressSpace() != targetType.getAddressSpace()) {
+    diagnosticOp->emitError(
+        "cannot bitcast pointers between different address spaces");
+    return failure();
+  }
+  return success();
 }
 
 template <typename MemAccOpTy>
@@ -342,7 +447,16 @@ template <>
 template <typename... Args>
 triton::LoadOp UnstructuredMemAccessConverter<triton::LoadOp>::createMemAccOp(
     triton::LoadOp op, Value ptrToAccess, Location loc,
-    PatternRewriter &rewriter, Args &&...args) const {
+    PatternRewriter &rewriter, bool preserveLoadMask, Args &&...args) const {
+  if (preserveLoadMask) {
+    Value mask = createExtractOp(loc, op.getMask(), rewriter,
+                                 std::forward<Args>(args)...);
+    Value other = createExtractOp(loc, op.getOther(), rewriter,
+                                  std::forward<Args>(args)...);
+    return rewriter.create<triton::LoadOp>(loc, ptrToAccess, mask, other,
+                                           op.getCache(), op.getEvict(),
+                                           op.getIsVolatile());
+  }
   return rewriter.create<triton::LoadOp>(loc, ptrToAccess, op.getCache(),
                                          op.getEvict(), op.getIsVolatile());
 }
@@ -352,7 +466,8 @@ template <typename... Args>
 triton::AtomicRMWOp
 UnstructuredMemAccessConverter<triton::AtomicRMWOp>::createMemAccOp(
     triton::AtomicRMWOp op, Value ptrToAccess, Location loc,
-    PatternRewriter &rewriter, Args &&...args) const {
+    PatternRewriter &rewriter, bool /*preserveLoadMask*/,
+    Args &&...args) const {
   auto extractedValue =
       createExtractOp(loc, op.getVal(), rewriter, std::forward<Args>(args)...);
   auto extractedMask =
@@ -389,7 +504,8 @@ template <typename... Args>
 triton::AtomicCASOp
 UnstructuredMemAccessConverter<triton::AtomicCASOp>::createMemAccOp(
     triton::AtomicCASOp op, Value ptrToAccess, Location loc,
-    PatternRewriter &rewriter, Args &&...args) const {
+    PatternRewriter &rewriter, bool /*preserveLoadMask*/,
+    Args &&...args) const {
   auto extractedCmp =
       createExtractOp(loc, op.getCmp(), rewriter, std::forward<Args>(args)...);
   auto extractedValue =
@@ -423,7 +539,8 @@ template <>
 template <typename... Args>
 triton::StoreOp UnstructuredMemAccessConverter<triton::StoreOp>::createMemAccOp(
     triton::StoreOp op, Value ptrToAccess, Location loc,
-    PatternRewriter &rewriter, Args &&...args) const {
+    PatternRewriter &rewriter, bool /*preserveLoadMask*/,
+    Args &&...args) const {
   auto extractedValue = createExtractOp(loc, op.getValue(), rewriter,
                                         std::forward<Args>(args)...);
   auto extractedMask =
@@ -474,13 +591,34 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
 
   if (!ptrType || op->hasAttr(ConverterUtils::discreteAttrName))
     return failure();
+  // Structural analysis failures are diagnosed once by the pass before greedy
+  // rewriting. Returning failure here remains a plain pattern non-match.
   if (!offsetMap.contains(ptr))
-    return op.emitError() << "PtrOffsetInfo should be computed\n" << ptr;
+    return failure();
 
   auto ptrOffsetInfo = offsetMap.at(ptr);
 
-  if (checkUnstructureAnnotated(op, rewriter))
+  auto srcPtr = ptrOffsetInfo.getPtr();
+  auto sourcePointerType =
+      srcPtr ? dyn_cast<triton::PointerType>(srcPtr.getType()) : nullptr;
+  auto targetPointerType =
+      dyn_cast<triton::PointerType>(ptrType.getElementType());
+  if (!srcPtr)
+    return failure();
+  bool byteAddressed = ptrOffsetInfo.isByteAddressed();
+  if (byteAddressed &&
+      failed(validateByteAddressedPointerTypes(
+          sourcePointerType, targetPointerType, op.getOperation())))
+    return failure();
+
+  if (checkUnstructureAnnotated(op, rewriter) || byteAddressed)
     ptrOffsetInfo.setUnstructured(ptrOffsetInfo.getRank());
+  if (byteAddressed) {
+    // The byte offset is exact but no longer affine in the target element
+    // unit. Keep every lane opaque until it is materialized as an integer
+    // address below. In particular, do not route atomics through BlockData.
+    ptrOffsetInfo.setScalarLike(false);
+  }
 
   if (ptrOffsetInfo.isStructured() && !routeDiscreteMaskToSimt &&
       (!ptrOffsetInfo.isScalarLike() ||
@@ -504,6 +642,27 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
     }
   }
 
+  // Same-width pointer bitcasts do not change the offset unit, so analysis
+  // deliberately keeps the original scalar root. Create the typed view here,
+  // where the cast immediately has a real memory-rewrite use and cannot become
+  // a dangling analysis-only SSA value. targetPointerType is present only for
+  // tensor-of-pointers; block pointers have a data tensor pointee and must stay
+  // on the existing make_tensor_ptr path. Different-width boundaries use the
+  // byte-addressed path below and must not be handled here.
+  if (!byteAddressed && targetPointerType &&
+      sourcePointerType != targetPointerType) {
+    if (!sourcePointerType || !targetPointerType ||
+        sourcePointerType.getAddressSpace() !=
+            targetPointerType.getAddressSpace() ||
+        getPointeeByteWidth(sourcePointerType) !=
+            getPointeeByteWidth(targetPointerType)) {
+      return op.emitError(
+          "element-addressed pointer access requires matching pointer widths "
+          "and address spaces");
+    }
+    srcPtr = rewriter.create<triton::BitcastOp>(loc, targetPointerType, srcPtr);
+  }
+
   std::optional<MaskState> mstate = runMaskAnalysis(op, rewriter);
 
   normalizeDiscreteMaskAccessForFallback(op, ptrOffsetInfo, rewriter);
@@ -513,7 +672,6 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
     ptrOffsetInfo.setUnstructured(ptrOffsetInfo.getRank());
   }
 
-  auto srcPtr = ptrOffsetInfo.getPtr();
   auto ptrOffset = ptrOffsetInfo.getOffset();
 
   // LoadLike is operation with result
@@ -553,7 +711,10 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
       ((!ptrOffsetInfo.isStructured() && sizeInByte < 64) ||
        routeDiscreteMaskToSimt);
   bool rankWithinIndirectLoadStoreFastPathLimit = resultShape.size() <= 5;
-  if (indirectFastPathEnabled &&
+  // TODO: Preserve the indirect SIMT fast path by materializing a vectorized
+  // typed view from the exact byte addresses. Until that representation is
+  // supported, use the existing scalar-loop lowering.
+  if (indirectFastPathEnabled && !byteAddressed &&
       succeeded(tryRewriteIndirectFastPath(op, loc, srcPtr, ptrOffset,
                                            resultShape, rewriter))) {
     return success();
@@ -564,6 +725,10 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
       auto &os = llvm::dbgs();
       os << "Skip SIMT indirect fast path because continuous shape product is "
          << sizeInByte << " (>=64)\n";
+    }
+    if (indirectFastPathEnabled && byteAddressed) {
+      llvm::dbgs() << "Skip SIMT indirect fast path for a different-width "
+                      "pointer bitcast\n";
     }
     if constexpr (std::is_same_v<MemAccOpTy, triton::LoadOp> ||
                   std::is_same_v<MemAccOpTy, triton::StoreOp>) {
@@ -586,6 +751,15 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
   Value newOpResult = nullptr;
 
   auto insertPoint = rewriter.saveInsertionPoint();
+
+  Value byteBaseAddress;
+  if (byteAddressed) {
+    // PtrOffsetInfo::offset is a signed byte displacement in this mode. Hoist
+    // conversion of the root pointer out of the generated scalar loops, then
+    // add only the per-lane byte displacement inside the loop body.
+    byteBaseAddress =
+        rewriter.create<triton::PtrToIntOp>(loc, rewriter.getI64Type(), srcPtr);
+  }
 
   SmallVector<OpFoldResult> offsets;
   SmallVector<OpFoldResult> sizes;
@@ -692,23 +866,40 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
   });
 
   assert(isa<triton::PointerType>(srcPtr.getType()) && "src must be ptr type");
-  if (!fullyUnstructured) {
+  if (!fullyUnstructured && !byteAddressed) {
     srcPtr = rewriter.create<triton::SplatOp>(
         loc, RankedTensorType::get(extractedShape, srcPtr.getType()), srcPtr);
   }
-  Value ptrToAccess = rewriter.create<triton::AddPtrOp>(
-      loc, srcPtr.getType(), srcPtr, extractedOffset);
+  Value ptrToAccess;
+  if (byteAddressed) {
+    assert(fullyUnstructured &&
+           "byte-addressed pointer access must be scalarized");
+    Value exactAddress =
+        rewriter.create<arith::AddIOp>(loc, byteBaseAddress, extractedOffset);
+    auto intToPtr = rewriter.create<triton::IntToPtrOp>(loc, targetPointerType,
+                                                        exactAddress);
+    intToPtr->setAttr(ConverterUtils::pointerBitcastPointerCastAttrName,
+                      rewriter.getUnitAttr());
+    ptrToAccess = intToPtr;
+  } else {
+    ptrToAccess = rewriter.create<triton::AddPtrOp>(loc, srcPtr.getType(),
+                                                    srcPtr, extractedOffset);
+  }
 
   MemAccOpTy accessedOp;
   if (fullyUnstructured) {
-    accessedOp = createMemAccOp(op, ptrToAccess, loc, rewriter, offsets);
-  } else {
     accessedOp =
-        createMemAccOp(op, ptrToAccess, loc, rewriter, offsets, sizes, strides);
+        createMemAccOp(op, ptrToAccess, loc, rewriter, byteAddressed, offsets);
+  } else {
+    accessedOp = createMemAccOp(op, ptrToAccess, loc, rewriter, byteAddressed,
+                                offsets, sizes, strides);
   }
 
   accessedOp->setAttr(ConverterUtils::discreteAttrName,
                       UnitAttr::get(rewriter.getContext()));
+  if (byteAddressed)
+    accessedOp->setAttr(ConverterUtils::pointerBitcastPointerCastAttrName,
+                        rewriter.getUnitAttr());
 
   if (isLoadLike) {
     assert(iterArg && "Load case must have iterArg in for loop");
@@ -779,9 +970,12 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
   return success();
 }
 
-void TritonToUnstructurePass::runPreparse(LoopLikeOpInterface op) {
-  IRRewriter rewriter(&getContext());
-  auto loc = op.getLoc();
+static LogicalResult
+runPreparseChecked(LoopLikeOpInterface op, MLIRContext *context,
+                   llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap,
+                   llvm::DenseMap<Value, PtrOffsetInfo> &offsetMapForLoopArgs) {
+  IRRewriter rewriter(context);
+  Location loc = op.getLoc();
 
   LLVM_DEBUG({
     auto &os = llvm::dbgs();
@@ -799,20 +993,27 @@ void TritonToUnstructurePass::runPreparse(LoopLikeOpInterface op) {
   }
 
   for (auto [arg, yield] : llvm::zip_equal(args, yields)) {
-    if (auto tensorType = dyn_cast<RankedTensorType>(yield.getType())) {
-      parse(yield, loc, rewriter, offsetMapForLoopArgs);
-      offsetMap[arg] = offsetMapForLoopArgs.at(yield);
-      LLVM_DEBUG({
-        auto &os = llvm::dbgs();
-        os << "Pre-parsing result of\n" << arg << "\nis ";
-        for (auto structured : offsetMap[arg].getStructuredRef())
-          os << static_cast<int>(structured);
-        os << '\n';
-      });
-    }
+    if (!isa<RankedTensorType>(yield.getType()))
+      continue;
+    if (failed(parseChecked(yield, loc, rewriter, offsetMapForLoopArgs)))
+      return failure();
+    offsetMap[arg] = offsetMapForLoopArgs.at(yield);
+    LLVM_DEBUG({
+      auto &os = llvm::dbgs();
+      os << "Pre-parsing result of\n" << arg << "\nis ";
+      for (auto structured : offsetMap[arg].getStructuredRef())
+        os << static_cast<int>(structured);
+      os << '\n';
+    });
   }
+  return success();
 }
 
+void TritonToUnstructurePass::runPreparse(LoopLikeOpInterface op) {
+  if (failed(runPreparseChecked(op, &getContext(), offsetMap,
+                                offsetMapForLoopArgs)))
+    signalPassFailure();
+}
 static bool isFromTensorArg(Value v,
                             llvm::SmallDenseMap<Value, bool> &fromTensorArg) {
   if (fromTensorArg.contains(v))
@@ -832,17 +1033,27 @@ static bool isFromTensorArg(Value v,
   return false;
 }
 
-template <typename MemAccOpTy, typename>
-void TritonToUnstructurePass::runParse(MemAccOpTy op) {
-  IRRewriter rewriter(&getContext());
+template <typename MemAccOpTy>
+static LogicalResult
+runParseChecked(MemAccOpTy op, MLIRContext *context,
+                llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap,
+                llvm::SmallDenseMap<Value, bool> &fromTensorArg) {
+  IRRewriter rewriter(context);
   LLVM_DEBUG({
     auto &os = llvm::dbgs();
     os << "Parsing " << op->getName() << "\n" << op << "\n";
   });
-  parse(op.getPtr(), op.getLoc(), rewriter, offsetMap);
+  if (failed(parseChecked(op.getPtr(), op.getLoc(), rewriter, offsetMap)))
+    return failure();
   isFromTensorArg(op.getPtr(), fromTensorArg);
+  return success();
 }
 
+template <typename MemAccOpTy, typename>
+void TritonToUnstructurePass::runParse(MemAccOpTy op) {
+  if (failed(runParseChecked(op, &getContext(), offsetMap, fromTensorArg)))
+    signalPassFailure();
+}
 LogicalResult
 TritonToUnstructurePass::processIfYieldAddHoistOperations(ModuleOp moduleOp) {
   mlir::RewritePatternSet patterns(&getContext());
@@ -872,6 +1083,10 @@ void TritonToUnstructurePass::runOnOperation() {
 
   ModuleOp moduleOp = getOperation();
   MLIRContext *ctx = &getContext();
+  if (failed(rejectByteAddressedControlFlow(moduleOp))) {
+    signalPassFailure();
+    return;
+  }
 
   moduleOp->walk([this](triton::FuncOp funcOp) {
     replacePtrArguments(funcOp, offsetMapForLoopArgs);
@@ -882,18 +1097,72 @@ void TritonToUnstructurePass::runOnOperation() {
     moduleOp.emitWarning("Failed to process IfYieldAddHoist operations");
   }
 
-  moduleOp->walk([this](LoopLikeOpInterface op) { runPreparse(op); });
-  moduleOp->walk([this](Operation *op) {
-    if (auto loadOp = dyn_cast<triton::LoadOp>(op)) {
-      runParse(loadOp);
-    } else if (auto storeOp = dyn_cast<triton::StoreOp>(op)) {
-      runParse(storeOp);
-    } else if (auto atomicRMWOp = dyn_cast<triton::AtomicRMWOp>(op)) {
-      runParse(atomicRMWOp);
-    } else if (auto atomicCASOp = dyn_cast<triton::AtomicCASOp>(op)) {
-      runParse(atomicCASOp);
-    }
+  WalkResult preparseResult =
+      moduleOp->walk([&](LoopLikeOpInterface op) -> WalkResult {
+        if (failed(
+                runPreparseChecked(op, ctx, offsetMap, offsetMapForLoopArgs)))
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      });
+  if (preparseResult.wasInterrupted()) {
+    signalPassFailure();
+    return;
+  }
+
+  WalkResult parseResult = moduleOp->walk([&](Operation *op) -> WalkResult {
+    LogicalResult result = success();
+    if (auto loadOp = dyn_cast<triton::LoadOp>(op))
+      result = runParseChecked(loadOp, ctx, offsetMap, fromTensorArg);
+    else if (auto storeOp = dyn_cast<triton::StoreOp>(op))
+      result = runParseChecked(storeOp, ctx, offsetMap, fromTensorArg);
+    else if (auto atomicRMWOp = dyn_cast<triton::AtomicRMWOp>(op))
+      result = runParseChecked(atomicRMWOp, ctx, offsetMap, fromTensorArg);
+    else if (auto atomicCASOp = dyn_cast<triton::AtomicCASOp>(op))
+      result = runParseChecked(atomicCASOp, ctx, offsetMap, fromTensorArg);
+    return failed(result) ? WalkResult::interrupt() : WalkResult::advance();
   });
+  if (parseResult.wasInterrupted()) {
+    signalPassFailure();
+    return;
+  }
+  // A rewrite-pattern failure only means "not matched" to the greedy driver;
+  // diagnostics emitted from matchAndRewrite do not make the pass fail. Check
+  // this structural requirement after parsing so an unsupported tensor-root
+  // access cannot survive the pass while triton-opt still exits successfully.
+  WalkResult memoryAccessValidation =
+      moduleOp->walk([&](Operation *op) -> WalkResult {
+        Value ptr;
+        if (auto loadOp = dyn_cast<triton::LoadOp>(op)) {
+          ptr = loadOp.getPtr();
+        } else if (auto storeOp = dyn_cast<triton::StoreOp>(op)) {
+          ptr = storeOp.getPtr();
+        } else if (auto atomicRMWOp = dyn_cast<triton::AtomicRMWOp>(op)) {
+          ptr = atomicRMWOp.getPtr();
+        } else if (auto atomicCASOp = dyn_cast<triton::AtomicCASOp>(op)) {
+          ptr = atomicCASOp.getPtr();
+        } else {
+          return WalkResult::advance();
+        }
+
+        if (!resolvePtrTensorType(ptr) ||
+            op->hasAttr(ConverterUtils::discreteAttrName))
+          return WalkResult::advance();
+        auto ptrInfo = offsetMap.find(ptr);
+        // This validation was added for the different-width bitcast path. Do
+        // not turn missing information in a legacy pointer analysis into a new
+        // non-bitcast compilation failure.
+        if (ptrInfo == offsetMap.end() || !ptrInfo->second.isByteAddressed() ||
+            ptrInfo->second.getPtr())
+          return WalkResult::advance();
+
+        op->emitError(
+            "unstructured pointer access requires a scalar root pointer");
+        return WalkResult::interrupt();
+      });
+  if (memoryAccessValidation.wasInterrupted()) {
+    signalPassFailure();
+    return;
+  }
 
   RewritePatternSet patterns(ctx);
 
@@ -911,6 +1180,7 @@ void TritonToUnstructurePass::runOnOperation() {
   if (failed(applyPatternsGreedily(moduleOp, std::move(patterns)))) {
     moduleOp->emitError("failed to apply Patterns");
     signalPassFailure();
+    return;
   }
 
   PassManager pm(&getContext(), moduleOp.getOperationName());

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/pointer_bitcast_address_preservation.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/pointer_bitcast_address_preservation.mlir
@@ -1,0 +1,173 @@
+// RUN: triton-opt --triton-to-unstructure --triton-to-linalg="named-ops=True" --split-input-file %s | FileCheck %s --implicit-check-not="arith.divsi" --implicit-check-not="arith.remsi" --implicit-check-not="tt.assert" --implicit-check-not="triton_assert" --implicit-check-not="builtin.unrealized_conversion_cast" --implicit-check-not="tt.pointer_bitcast_rescaled_offset" --implicit-check-not="tt.pointer_bitcast_offset_divisor"
+
+// CHECK-LABEL: func.func @dynamic_scalar_address
+// CHECK-NOT: arith.remsi
+// CHECK-NOT: arith.divsi
+// CHECK-NOT: triton_assert
+// CHECK: arith.muli
+// CHECK: arith.addi
+// CHECK: hivm.hir.pointer_cast{{.*}} : memref<?xi32>
+// CHECK: return
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @dynamic_scalar_address(
+      %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+      %pre_bytes: i32,
+      %post_elements: i32) attributes {noinline = false} {
+    %byte_ptr = tt.addptr %src, %pre_bytes : !tt.ptr<i8>, i32
+    %wide_ptr = tt.bitcast %byte_ptr : !tt.ptr<i8> -> !tt.ptr<i32>
+    %final_ptr = tt.addptr %wide_ptr, %post_elements : !tt.ptr<i32>, i32
+    %value = tt.load %final_ptr : !tt.ptr<i32>
+    tt.store %dst, %value : !tt.ptr<i32>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @tensor_offsets_before_and_after_bitcast
+// CHECK-NOT: arith.remsi
+// CHECK-NOT: arith.divsi
+// CHECK-NOT: triton_assert
+// CHECK: scf.for
+// CHECK: arith.muli
+// CHECK: arith.addi
+// CHECK: hivm.hir.pointer_cast{{.*}} : memref<?xi32>
+// CHECK-NOT: builtin.unrealized_conversion_cast
+// CHECK: return
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @tensor_offsets_before_and_after_bitcast(
+      %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+      %offset_src: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32})
+      attributes {noinline = false} {
+    %range = tt.make_range {start = 0 : i32, end = 4 : i32}
+        : tensor<4xi32>
+    %four = arith.constant dense<4> : tensor<4xi32>
+    %pre_bytes = arith.muli %range, %four : tensor<4xi32>
+    %srcs = tt.splat %src : !tt.ptr<i8> -> tensor<4x!tt.ptr<i8>>
+    %byte_ptrs = tt.addptr %srcs, %pre_bytes
+        : tensor<4x!tt.ptr<i8>>, tensor<4xi32>
+    %wide_ptrs = tt.bitcast %byte_ptrs
+        : tensor<4x!tt.ptr<i8>> -> tensor<4x!tt.ptr<i32>>
+    %offset_bases = tt.splat %offset_src
+        : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+    %offset_ptrs = tt.addptr %offset_bases, %range
+        : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+    %post_elements = tt.load %offset_ptrs : tensor<4x!tt.ptr<i32>>
+    %final_ptrs = tt.addptr %wide_ptrs, %post_elements
+        : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+    %values = tt.load %final_ptrs : tensor<4x!tt.ptr<i32>>
+    %dsts = tt.splat %dst : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+    %dst_ptrs = tt.addptr %dsts, %range
+        : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+    tt.store %dst_ptrs, %values : tensor<4x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @multiple_address_boundaries
+// CHECK-NOT: arith.remsi
+// CHECK-NOT: arith.divsi
+// CHECK-NOT: triton_assert
+// CHECK-COUNT-2: arith.muli
+// CHECK: hivm.hir.pointer_cast{{.*}} : memref<?xi32>
+// CHECK: return
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @multiple_address_boundaries(
+      %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+      %pre_bytes: i32,
+      %half_elements: i32,
+      %word_elements: i32) attributes {noinline = false} {
+    %byte_ptr = tt.addptr %src, %pre_bytes : !tt.ptr<i8>, i32
+    %half_ptr = tt.bitcast %byte_ptr : !tt.ptr<i8> -> !tt.ptr<i16>
+    %half_offset_ptr = tt.addptr %half_ptr, %half_elements
+        : !tt.ptr<i16>, i32
+    %wide_ptr = tt.bitcast %half_offset_ptr
+        : !tt.ptr<i16> -> !tt.ptr<i32>
+    %final_ptr = tt.addptr %wide_ptr, %word_elements
+        : !tt.ptr<i32>, i32
+    %value = tt.load %final_ptr : !tt.ptr<i32>
+    tt.store %dst, %value : !tt.ptr<i32>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @static_pre_and_post_offsets_preserve_address
+// CHECK-NOT: arith.remsi
+// CHECK-NOT: arith.divsi
+// CHECK-NOT: triton_assert
+// CHECK: hivm.hir.pointer_cast{{.*}} : memref<?xbf16>
+// CHECK: return
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @static_pre_and_post_offsets_preserve_address(
+      %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<bf16> {tt.divisibility = 16 : i32})
+      attributes {noinline = false} {
+    %four_bytes = arith.constant 4 : i32
+    %one_element = arith.constant 1 : i32
+    %byte_ptr = tt.addptr %src, %four_bytes : !tt.ptr<i8>, i32
+    %bf16_ptr = tt.bitcast %byte_ptr : !tt.ptr<i8> -> !tt.ptr<bf16>
+    %final_ptr = tt.addptr %bf16_ptr, %one_element
+        : !tt.ptr<bf16>, i32
+    %value = tt.load %final_ptr : !tt.ptr<bf16>
+    tt.store %dst, %value : !tt.ptr<bf16>
+    tt.return
+  }
+}
+
+// -----
+
+// A non-divisible byte address is intentionally not diagnosed. This is a
+// compile-only contract: executing an unaligned device access is the caller's
+// responsibility.
+// CHECK-LABEL: func.func @static_nondivisible_offset_is_unchecked
+// CHECK: arith.addi
+// CHECK: hivm.hir.pointer_cast{{.*}} : memref<?xi32>
+// CHECK: return
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @static_nondivisible_offset_is_unchecked(
+      %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32})
+      attributes {noinline = false} {
+    %one_byte = arith.constant 1 : i32
+    %byte_ptr = tt.addptr %src, %one_byte : !tt.ptr<i8>, i32
+    %wide_ptr = tt.bitcast %byte_ptr : !tt.ptr<i8> -> !tt.ptr<i32>
+    %value = tt.load %wide_ptr : !tt.ptr<i32>
+    tt.store %dst, %value : !tt.ptr<i32>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @value_bitcast_is_unchanged
+// CHECK: arith.bitcast {{.*}} : tensor<4xi32> to tensor<4xf32>
+// CHECK-NOT: triton_assert
+// CHECK: return
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @value_bitcast_is_unchanged(
+      %src: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<f32> {tt.divisibility = 16 : i32})
+      attributes {noinline = false} {
+    %range = tt.make_range {start = 0 : i32, end = 4 : i32}
+        : tensor<4xi32>
+    %src_bases = tt.splat %src
+        : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+    %src_ptrs = tt.addptr %src_bases, %range
+        : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+    %values = tt.load %src_ptrs : tensor<4x!tt.ptr<i32>>
+    %bits = tt.bitcast %values : tensor<4xi32> -> tensor<4xf32>
+    %dst_bases = tt.splat %dst
+        : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %dst_ptrs = tt.addptr %dst_bases, %range
+        : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    tt.store %dst_ptrs, %bits : tensor<4x!tt.ptr<f32>>
+    tt.return
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/pointer_bitcast_different_width.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/pointer_bitcast_different_width.mlir
@@ -1,0 +1,117 @@
+// RUN: triton-opt --triton-to-unstructure --triton-to-linalg="named-ops=True" --split-input-file %s | FileCheck %s --implicit-check-not="arith.divsi" --implicit-check-not="arith.remsi" --implicit-check-not="tt.assert" --implicit-check-not="triton_assert" --implicit-check-not="builtin.unrealized_conversion_cast" --implicit-check-not="tt.pointer_bitcast_rescaled_offset" --implicit-check-not="tt.pointer_bitcast_offset_divisor"
+
+// CHECK-LABEL: func.func @widen_scalar_multi_addptr
+// CHECK: arith.addi
+// CHECK: hivm.hir.pointer_cast{{.*}} : memref<?xbf16>
+// CHECK: return
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @widen_scalar_multi_addptr(
+      %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<bf16> {tt.divisibility = 16 : i32},
+      %block: i64,
+      %position: i64,
+      %block_stride: i64 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c576_i64 = arith.constant 576 : i64
+    %c448_i64 = arith.constant 448 : i64
+    %block_offset = arith.muli %block, %block_stride : i64
+    %block_base = tt.addptr %src, %block_offset : !tt.ptr<i8>, i64
+    %token_offset = arith.muli %position, %c576_i64 : i64
+    %token_base = tt.addptr %block_base, %token_offset : !tt.ptr<i8>, i64
+    %rope_bytes = tt.addptr %token_base, %c448_i64 : !tt.ptr<i8>, i64
+    %rope_bf16 = tt.bitcast %rope_bytes : !tt.ptr<i8> -> !tt.ptr<bf16>
+    %value = tt.load %rope_bf16 : !tt.ptr<bf16>
+    tt.store %dst, %value : !tt.ptr<bf16>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @widen_tensor_offset
+// CHECK: scf.for
+// CHECK: hivm.hir.pointer_cast{{.*}} : memref<?xi32>
+// CHECK: return
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @widen_tensor_offset(
+      %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %range = tt.make_range {start = 0 : i32, end = 8 : i32} : tensor<8xi32>
+    %four = arith.constant dense<4> : tensor<8xi32>
+    %offsets = arith.muli %range, %four : tensor<8xi32>
+    %srcs = tt.splat %src : !tt.ptr<i8> -> tensor<8x!tt.ptr<i8>>
+    %byte_ptrs = tt.addptr %srcs, %offsets : tensor<8x!tt.ptr<i8>>, tensor<8xi32>
+    %i32_ptrs = tt.bitcast %byte_ptrs : tensor<8x!tt.ptr<i8>> -> tensor<8x!tt.ptr<i32>>
+    %values = tt.load %i32_ptrs : tensor<8x!tt.ptr<i32>>
+    %dsts = tt.splat %dst : !tt.ptr<i32> -> tensor<8x!tt.ptr<i32>>
+    %dst_ptrs = tt.addptr %dsts, %range : tensor<8x!tt.ptr<i32>>, tensor<8xi32>
+    tt.store %dst_ptrs, %values : tensor<8x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @narrow_scalar_pointer
+// CHECK: arith.muli
+// CHECK: arith.addi
+// CHECK: hivm.hir.pointer_cast{{.*}} : memref<?xi8>
+// CHECK: return
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @narrow_scalar_pointer(
+      %src: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+      %offset: i32) attributes {noinline = false} {
+    %source_element = tt.addptr %src, %offset : !tt.ptr<i32>, i32
+    %byte_ptr = tt.bitcast %source_element : !tt.ptr<i32> -> !tt.ptr<i8>
+    %value = tt.load %byte_ptr : !tt.ptr<i8>
+    tt.store %dst, %value : !tt.ptr<i8>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @direct_base_pointer
+// CHECK: hivm.hir.pointer_cast{{.*}} : memref<?xbf16>
+// CHECK: return
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @direct_base_pointer(
+      %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<bf16> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %bf16_ptr = tt.bitcast %src : !tt.ptr<i8> -> !tt.ptr<bf16>
+    %value = tt.load %bf16_ptr : !tt.ptr<bf16>
+    tt.store %dst, %value : !tt.ptr<bf16>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @widen_pointer_inside_loop
+// CHECK: scf.for
+// CHECK: hivm.hir.pointer_cast{{.*}} : memref<?xbf16>
+// CHECK: return
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @widen_pointer_inside_loop(
+      %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<bf16> {tt.divisibility = 16 : i32},
+      %count: i64) attributes {noinline = false} {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c1024_i64 = arith.constant 1024 : i64
+    %c576_i64 = arith.constant 576 : i64
+    %c448_i64 = arith.constant 448 : i64
+    scf.for %position = %c0_i64 to %count step %c1_i64 : i64 {
+      %block_offset = arith.muli %position, %c1024_i64 : i64
+      %block_base = tt.addptr %src, %block_offset : !tt.ptr<i8>, i64
+      %token_offset = arith.muli %position, %c576_i64 : i64
+      %token_base = tt.addptr %block_base, %token_offset : !tt.ptr<i8>, i64
+      %rope_bytes = tt.addptr %token_base, %c448_i64 : !tt.ptr<i8>, i64
+      %rope_bf16 = tt.bitcast %rope_bytes : !tt.ptr<i8> -> !tt.ptr<bf16>
+      %value = tt.load %rope_bf16 : !tt.ptr<bf16>
+      %dst_ptr = tt.addptr %dst, %position : !tt.ptr<bf16>, i64
+      tt.store %dst_ptr, %value : !tt.ptr<bf16>
+    }
+    tt.return
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/pointer_bitcast_different_width_invalid.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/pointer_bitcast_different_width_invalid.mlir
@@ -1,0 +1,14 @@
+// RUN: not triton-opt --triton-to-linalg="named-ops=True" %s 2>&1 | FileCheck %s
+
+// CHECK: different-width pointer bitcast requires byte-addressable scalar integer or floating-point pointee types
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @reject_non_byte_addressable_pointee(
+      %src: !tt.ptr<i4> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<i16> {tt.divisibility = 16 : i32})
+      attributes {noinline = false} {
+    %wide_ptr = tt.bitcast %src : !tt.ptr<i4> -> !tt.ptr<i16>
+    %value = tt.load %wide_ptr : !tt.ptr<i16>
+    tt.store %dst, %value : !tt.ptr<i16>
+    tt.return
+  }
+}

--- a/third_party/ascend/unittest/pytest_ut/test_pointer_bitcast_address.py
+++ b/third_party/ascend/unittest/pytest_ut/test_pointer_bitcast_address.py
@@ -1,0 +1,709 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import struct
+
+import torch
+import torch_npu
+import triton
+import triton.language as tl
+
+
+def _sync_npu():
+    torch.npu.synchronize()
+
+
+def _write_u32_le(buf, byte_offsets, values):
+    for byte_offset, value in zip(byte_offsets, values):
+        payload = struct.pack("<I", int(value))
+        for byte_idx, byte_value in enumerate(payload):
+            buf[int(byte_offset) + byte_idx] = byte_value
+
+
+def _float_to_bf16_bits(value):
+    f32_bits = struct.unpack("<I", struct.pack("<f", float(value)))[0]
+    return f32_bits >> 16
+
+
+def _write_bf16_le(buf, byte_offset, values):
+    for idx, value in enumerate(values):
+        bits = _float_to_bf16_bits(value)
+        buf[int(byte_offset) + idx * 2] = bits & 0xFF
+        buf[int(byte_offset) + idx * 2 + 1] = (bits >> 8) & 0xFF
+
+
+def _ttadapter(compiled):
+    assert "ttadapter" in compiled.asm, compiled.asm.keys()
+    return compiled.asm["ttadapter"]
+
+
+def _require_no_runtime_check(compiled):
+    ttadapter = _ttadapter(compiled)
+    assert "arith.remsi" not in ttadapter, ttadapter
+    assert "triton_assert" not in ttadapter, ttadapter
+
+
+def _require_no_pointer_bitcast_assert(compiled):
+    ttadapter = _ttadapter(compiled)
+    assert "triton_assert" not in ttadapter, ttadapter
+
+
+@triton.jit
+def _runtime_paged_scale_load(kv_ptr, block_tables_ptr, out_ptr, n_positions, stride_kvblk, stride_kvpos, stride_kvbyte,
+                              DIM: tl.constexpr, CACHE_BLOCK_SIZE: tl.constexpr, BLOCK: tl.constexpr):
+    kv_global_pos = tl.arange(0, BLOCK)
+    valid = kv_global_pos < n_positions
+    logical_block = kv_global_pos // CACHE_BLOCK_SIZE
+    intra_block_pos = kv_global_pos % CACHE_BLOCK_SIZE
+    physical_block = tl.load(block_tables_ptr + logical_block, mask=valid, other=0)
+    kv_base = (physical_block * stride_kvblk + intra_block_pos * stride_kvpos)
+    scale_addr = kv_base + DIM * stride_kvbyte
+    scale_ptr = (kv_ptr + scale_addr).to(tl.pointer_type(tl.uint32, 1), bitcast=True)
+    scale_u32 = tl.load(scale_ptr, mask=valid, other=0)
+    tl.store(out_ptr + kv_global_pos, scale_u32, mask=valid)
+
+
+@triton.jit
+def _runtime_scalar_bf16_load(src, byte_offset_ptr, out, N: tl.constexpr, BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    byte_offset = tl.load(byte_offset_ptr)
+    bf16_ptr = (src + byte_offset).to(tl.pointer_type(tl.bfloat16), bitcast=True)
+    values = tl.load(bf16_ptr + lanes, mask=lanes < N, other=0.0)
+    tl.store(out + lanes, values, mask=lanes < N)
+
+
+@triton.jit
+def _runtime_tensor_u32_load(src, byte_offsets_ptr, out, N: tl.constexpr, BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    mask = lanes < N
+    byte_offsets = tl.load(byte_offsets_ptr + lanes, mask=mask, other=0)
+    u32_ptrs = (src + byte_offsets).to(tl.pointer_type(tl.uint32, 1), bitcast=True)
+    values = tl.load(u32_ptrs, mask=mask, other=0)
+    tl.store(out + lanes, values, mask=mask)
+
+
+@triton.jit
+def _runtime_tensor_u32_store(src, dst, byte_offsets_ptr, N: tl.constexpr, BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    mask = lanes < N
+    byte_offsets = tl.load(byte_offsets_ptr + lanes, mask=mask, other=0)
+    values = tl.load(src + lanes, mask=mask, other=0)
+    u32_ptrs = (dst + byte_offsets).to(tl.pointer_type(tl.uint32, 1), bitcast=True)
+    tl.store(u32_ptrs, values, mask=mask)
+
+
+@triton.jit
+def _runtime_2d_tensor_u32_load(src, byte_offsets_ptr, out, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
+    rows = tl.arange(0, BLOCK_M)[:, None]
+    cols = tl.arange(0, BLOCK_N)[None, :]
+    linear = rows * BLOCK_N + cols
+    byte_offsets = tl.load(byte_offsets_ptr + linear)
+    u32_ptrs = (src + byte_offsets).to(tl.pointer_type(tl.uint32, 1), bitcast=True)
+    values = tl.load(u32_ptrs)
+    tl.store(out + linear, values)
+
+
+@triton.jit
+def _runtime_2d_tensor_u32_store(src, dst, byte_offsets_ptr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
+    rows = tl.arange(0, BLOCK_M)[:, None]
+    cols = tl.arange(0, BLOCK_N)[None, :]
+    linear = rows * BLOCK_N + cols
+    byte_offsets = tl.load(byte_offsets_ptr + linear)
+    values = tl.load(src + linear)
+    u32_ptrs = (dst + byte_offsets).to(tl.pointer_type(tl.uint32, 1), bitcast=True)
+    tl.store(u32_ptrs, values)
+
+
+@triton.jit
+def _runtime_2d_block_ptr_bf16_load(src, byte_offset_ptr, out, ROWS: tl.constexpr, COLS: tl.constexpr,
+                                    ROW_STRIDE: tl.constexpr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
+    byte_offset = tl.load(byte_offset_ptr)
+    bf16_base = (src + byte_offset).to(tl.pointer_type(tl.bfloat16), bitcast=True)
+    block_ptr = tl.make_block_ptr(
+        base=bf16_base,
+        shape=(ROWS, COLS),
+        strides=(ROW_STRIDE, 1),
+        offsets=(1, 2),
+        block_shape=(BLOCK_M, BLOCK_N),
+        order=(1, 0),
+    )
+    values = tl.load(block_ptr)
+    rows = tl.arange(0, BLOCK_M)[:, None]
+    cols = tl.arange(0, BLOCK_N)[None, :]
+    tl.store(out + rows * BLOCK_N + cols, values)
+
+
+@triton.jit
+def _runtime_2d_block_ptr_bf16_store(src, dst, byte_offset_ptr, row_stride, ROWS: tl.constexpr, COLS: tl.constexpr,
+                                     BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
+    rows = tl.arange(0, BLOCK_M)[:, None]
+    cols = tl.arange(0, BLOCK_N)[None, :]
+    values = tl.load(src + rows * BLOCK_N + cols)
+    byte_offset = tl.load(byte_offset_ptr)
+    bf16_base = (dst + byte_offset).to(tl.pointer_type(tl.bfloat16), bitcast=True)
+    block_ptr = tl.make_block_ptr(
+        base=bf16_base,
+        shape=(ROWS, COLS),
+        strides=(row_stride, 1),
+        offsets=(1, 2),
+        block_shape=(BLOCK_M, BLOCK_N),
+        order=(1, 0),
+    )
+    tl.store(block_ptr, values)
+
+
+@triton.jit
+def _runtime_pointer_then_value_bitcast(src, byte_offsets_ptr, out, N: tl.constexpr, BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    mask = lanes < N
+    byte_offsets = tl.load(byte_offsets_ptr + lanes, mask=mask, other=0)
+    u32_ptrs = (src + byte_offsets).to(tl.pointer_type(tl.uint32, 1), bitcast=True)
+    scale_u32 = tl.load(u32_ptrs, mask=mask, other=0)
+    scale_f32 = scale_u32.to(tl.float32, bitcast=True)
+    tl.store(out + lanes, scale_f32, mask=mask)
+
+
+@triton.jit
+def _loaded_offset_division_without_pointer_bitcast(src, offsets_ptr, out, N: tl.constexpr, DIVISOR: tl.constexpr,
+                                                    BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    mask = lanes < N
+    loaded_offsets = tl.load(offsets_ptr + lanes, mask=mask, other=0)
+    element_offsets = loaded_offsets // DIVISOR
+    values = tl.load(src + element_offsets, mask=mask, other=0)
+    tl.store(out + lanes, values, mask=mask)
+
+
+@triton.jit
+def _runtime_scalar_bf16_store(src, dst, byte_offset_ptr, N: tl.constexpr, BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    mask = lanes < N
+    byte_offset = tl.load(byte_offset_ptr)
+    values = tl.load(src + lanes, mask=mask, other=0.0)
+    bf16_ptr = (dst + byte_offset).to(tl.pointer_type(tl.bfloat16), bitcast=True)
+    tl.store(bf16_ptr + lanes, values, mask=mask)
+
+
+@triton.jit
+def _static_byte_offset_u32_load(src, out, N: tl.constexpr, BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    mask = lanes < N
+    byte_offsets = lanes * 4
+    u32_ptrs = (src + byte_offsets).to(tl.pointer_type(tl.uint32, 1), bitcast=True)
+    values = tl.load(u32_ptrs, mask=mask, other=0)
+    tl.store(out + lanes, values, mask=mask)
+
+
+@triton.jit
+def _runtime_multi_addptr_bf16_load(src, params_ptr, out, N: tl.constexpr, BLOCK: tl.constexpr):
+    block_idx = tl.load(params_ptr + 0)
+    token_pos = tl.load(params_ptr + 1)
+    block_stride = tl.load(params_ptr + 2)
+    token_bytes = tl.load(params_ptr + 3)
+    bf16_offset = tl.load(params_ptr + 4)
+    block_base = src + block_idx * block_stride
+    token_base = block_base + token_pos * token_bytes
+    bf16_ptr = (token_base + bf16_offset).to(tl.pointer_type(tl.bfloat16), bitcast=True)
+    lanes = tl.arange(0, BLOCK)
+    mask = lanes < N
+    values = tl.load(bf16_ptr + lanes, mask=mask, other=0.0)
+    tl.store(out + lanes, values, mask=mask)
+
+
+@triton.jit
+def _runtime_scalar_u32_load(src, byte_offset_ptr, out):
+    byte_offset = tl.load(byte_offset_ptr)
+    u32_ptr = (src + byte_offset).to(tl.pointer_type(tl.uint32, 1), bitcast=True)
+    value = tl.load(u32_ptr)
+    tl.store(out, value)
+
+
+@triton.jit
+def _runtime_tensor_pre_post_u32_load(src, element_offsets, out, BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    pre_cast_byte_offsets = lanes * 8
+    post_cast_element_offsets = tl.load(element_offsets + lanes)
+    ptrs = (src + pre_cast_byte_offsets).to(tl.pointer_type(tl.uint32, 1), bitcast=True)
+    values = tl.load(ptrs + post_cast_element_offsets)
+    tl.store(out + lanes, values)
+
+
+@triton.jit
+def _runtime_scalar_pre_post_u32_load(src, offsets, out):
+    pre_cast_byte_offset = tl.load(offsets + 0)
+    post_cast_element_offset = tl.load(offsets + 1)
+    ptr = (src + pre_cast_byte_offset).to(tl.pointer_type(tl.uint32, 1), bitcast=True)
+    tl.store(out, tl.load(ptr + post_cast_element_offset))
+
+
+@triton.jit
+def _runtime_multiple_bitcast_boundaries_load(src, offsets, out):
+    pre_bytes = tl.load(offsets + 0)
+    u16_elements = tl.load(offsets + 1)
+    u8_bytes = tl.load(offsets + 2)
+    u32_elements = tl.load(offsets + 3)
+    p16 = (src + pre_bytes).to(tl.pointer_type(tl.uint16, 1), bitcast=True)
+    p8 = (p16 + u16_elements).to(tl.pointer_type(tl.uint8, 1), bitcast=True)
+    p32 = (p8 + u8_bytes).to(tl.pointer_type(tl.uint32, 1), bitcast=True)
+    tl.store(out, tl.load(p32 + u32_elements))
+
+
+@triton.jit
+def _runtime_negative_post_bitcast_u32_load(src, element_offset, out):
+    p32 = src.to(tl.pointer_type(tl.uint32, 1), bitcast=True)
+    tl.store(out, tl.load(p32 + tl.load(element_offset)))
+
+
+@triton.jit
+def _runtime_tensor_pre_post_u32_store(values, dst, element_offsets, BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    pre_cast_byte_offsets = lanes * 8
+    post_cast_element_offsets = tl.load(element_offsets + lanes)
+    ptrs = (dst + pre_cast_byte_offsets).to(tl.pointer_type(tl.uint32, 1), bitcast=True)
+    tl.store(ptrs + post_cast_element_offsets, tl.load(values + lanes))
+
+
+@triton.jit
+def _runtime_tensor_pre_post_atomic_add(values, dst, element_offsets, BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    pre_cast_byte_offsets = lanes * 8
+    post_cast_element_offsets = tl.load(element_offsets + lanes)
+    ptrs = (dst + pre_cast_byte_offsets).to(tl.pointer_type(tl.int32, 1), bitcast=True)
+    tl.atomic_add(ptrs + post_cast_element_offsets, tl.load(values + lanes))
+
+
+def test_runtime_paged_mqa_scale_preserves_address():
+    cache_block_size = 4
+    dim = 8
+    record_bytes = dim + 4
+    stride_kvpos = record_bytes
+    stride_kvblk = cache_block_size * record_bytes
+    stride_kvbyte = 1
+    n_positions = 8
+    block = 8
+    block_table = [2, 0]
+    values = [100 + idx for idx in range(n_positions)]
+
+    host = torch.zeros(3 * stride_kvblk, dtype=torch.uint8)
+    byte_offsets = []
+    for logical_pos in range(n_positions):
+        logical_block = logical_pos // cache_block_size
+        intra_block_pos = logical_pos % cache_block_size
+        physical_block = block_table[logical_block]
+        byte_offsets.append(physical_block * stride_kvblk + intra_block_pos * stride_kvpos + dim)
+    _write_u32_le(host, byte_offsets, values)
+
+    kv = host.npu()
+    block_tables = torch.tensor(block_table, dtype=torch.int32).npu()
+    out = torch.empty((block, ), device="npu", dtype=torch.int32)
+    args = (kv, block_tables, out, n_positions, stride_kvblk, stride_kvpos, stride_kvbyte)
+    meta = {"DIM": dim, "CACHE_BLOCK_SIZE": cache_block_size, "BLOCK": block}
+
+    compiled = _runtime_paged_scale_load.warmup(*args, **meta, grid=(1, ))
+    _require_no_pointer_bitcast_assert(compiled)
+    _runtime_paged_scale_load[(1, )](*args, **meta)
+    _sync_npu()
+
+    torch.testing.assert_close(out.cpu(), torch.tensor(values, dtype=torch.int32), rtol=0, atol=0)
+
+
+def test_runtime_scalar_bf16_load_preserves_address():
+    byte_offset = 18
+    values = [1.0, 2.0, 4.0, 8.0]
+    host = torch.zeros(64, dtype=torch.uint8)
+    _write_bf16_le(host, byte_offset, values)
+    src = host.npu()
+    offset = torch.tensor([byte_offset], dtype=torch.int64).npu()
+    out = torch.empty((len(values), ), device="npu", dtype=torch.bfloat16)
+
+    compiled = _runtime_scalar_bf16_load.warmup(src, offset, out, N=len(values), BLOCK=8, grid=(1, ))
+    _require_no_runtime_check(compiled)
+    _runtime_scalar_bf16_load[(1, )](src, offset, out, N=len(values), BLOCK=8)
+    _sync_npu()
+
+    expected = torch.tensor(values, dtype=torch.float32).to(torch.bfloat16)
+    torch.testing.assert_close(out.cpu(), expected, rtol=0, atol=0)
+
+
+def test_runtime_tensor_offsets_u32_load_preserves_address():
+    byte_offsets = [4, 20, 36, 52]
+    values = [0x01020304, 0x11121314, 0x21222324, 0x31323334]
+    host = torch.zeros(80, dtype=torch.uint8)
+    _write_u32_le(host, byte_offsets, values)
+    src = host.npu()
+    offsets = torch.tensor(byte_offsets, dtype=torch.int64).npu()
+    out = torch.empty((len(values), ), device="npu", dtype=torch.int32)
+
+    compiled = _runtime_tensor_u32_load.warmup(src, offsets, out, N=len(values), BLOCK=4, grid=(1, ))
+    _require_no_runtime_check(compiled)
+    _runtime_tensor_u32_load[(1, )](src, offsets, out, N=len(values), BLOCK=4)
+    _sync_npu()
+
+    torch.testing.assert_close(out.cpu(), torch.tensor(values, dtype=torch.int32), rtol=0, atol=0)
+
+
+def test_runtime_tensor_offsets_u32_store_preserves_address():
+    byte_offsets = [8, 24, 40, 56]
+    values = [101, 202, 303, 404]
+    src = torch.tensor(values, dtype=torch.int32).npu()
+    dst = torch.zeros(80, device="npu", dtype=torch.uint8)
+    offsets = torch.tensor(byte_offsets, dtype=torch.int64).npu()
+
+    compiled = _runtime_tensor_u32_store.warmup(src, dst, offsets, N=len(values), BLOCK=4, grid=(1, ))
+    _require_no_runtime_check(compiled)
+    _runtime_tensor_u32_store[(1, )](src, dst, offsets, N=len(values), BLOCK=4)
+    _sync_npu()
+
+    expected = torch.zeros(80, dtype=torch.uint8)
+    _write_u32_le(expected, byte_offsets, values)
+    torch.testing.assert_close(dst.cpu(), expected, rtol=0, atol=0)
+
+
+def test_runtime_2d_tensor_offsets_u32_load_preserves_address():
+    block_m = 2
+    block_n = 4
+    byte_offsets = [0, 12, 24, 36, 48, 60, 72, 84]
+    values = [11, 22, 33, 44, 55, 66, 77, 88]
+    host = torch.zeros(96, dtype=torch.uint8)
+    _write_u32_le(host, byte_offsets, values)
+    src = host.npu()
+    offsets = torch.tensor(byte_offsets, dtype=torch.int64).npu()
+    out = torch.empty((block_m, block_n), device="npu", dtype=torch.int32)
+
+    compiled = _runtime_2d_tensor_u32_load.warmup(src, offsets, out, BLOCK_M=block_m, BLOCK_N=block_n, grid=(1, ))
+    _require_no_runtime_check(compiled)
+    _runtime_2d_tensor_u32_load[(1, )](src, offsets, out, BLOCK_M=block_m, BLOCK_N=block_n)
+    _sync_npu()
+
+    expected = torch.tensor(values, dtype=torch.int32).reshape(block_m, block_n)
+    torch.testing.assert_close(out.cpu(), expected, rtol=0, atol=0)
+
+
+def test_runtime_2d_tensor_offsets_u32_store_preserves_address():
+    block_m = 2
+    block_n = 4
+    byte_offsets = [4, 16, 28, 40, 52, 64, 76, 88]
+    values = [111, 222, 333, 444, 555, 666, 777, 888]
+    src = torch.tensor(values, dtype=torch.int32).reshape(block_m, block_n).npu()
+    dst = torch.zeros(96, device="npu", dtype=torch.uint8)
+    offsets = torch.tensor(byte_offsets, dtype=torch.int64).npu()
+
+    compiled = _runtime_2d_tensor_u32_store.warmup(src, dst, offsets, BLOCK_M=block_m, BLOCK_N=block_n, grid=(1, ))
+    _require_no_runtime_check(compiled)
+    _runtime_2d_tensor_u32_store[(1, )](src, dst, offsets, BLOCK_M=block_m, BLOCK_N=block_n)
+    _sync_npu()
+
+    expected = torch.zeros(96, dtype=torch.uint8)
+    _write_u32_le(expected, byte_offsets, values)
+    torch.testing.assert_close(dst.cpu(), expected, rtol=0, atol=0)
+
+
+def test_runtime_2d_block_ptr_bf16_load_preserves_address():
+    block_m = 4
+    block_n = 8
+    row_offset = 1
+    col_offset = 2
+    rows = block_m + row_offset
+    cols = block_n + col_offset
+    row_stride = 12
+    byte_offset = 8
+    storage_bytes = 144
+    values = [float(idx + 1) for idx in range(block_m * block_n)]
+    host = torch.zeros(storage_bytes, dtype=torch.uint8)
+    for row in range(block_m):
+        start = row * block_n
+        _write_bf16_le(
+            host,
+            byte_offset + ((row + row_offset) * row_stride + col_offset) * 2,
+            values[start:start + block_n],
+        )
+    src = host.npu()
+    offset = torch.tensor([byte_offset], dtype=torch.int64).npu()
+    out = torch.empty((block_m, block_n), device="npu", dtype=torch.bfloat16)
+    meta = {
+        "ROWS": rows,
+        "COLS": cols,
+        "ROW_STRIDE": row_stride,
+        "BLOCK_M": block_m,
+        "BLOCK_N": block_n,
+    }
+
+    compiled = _runtime_2d_block_ptr_bf16_load.warmup(src, offset, out, **meta, grid=(1, ))
+    _require_no_runtime_check(compiled)
+    _runtime_2d_block_ptr_bf16_load[(1, )](src, offset, out, **meta)
+    _sync_npu()
+
+    expected = torch.tensor(values, dtype=torch.float32).to(torch.bfloat16).reshape(block_m, block_n)
+    torch.testing.assert_close(out.cpu(), expected, rtol=0, atol=0)
+
+
+def test_runtime_2d_block_ptr_bf16_store_preserves_address():
+    block_m = 4
+    block_n = 8
+    row_offset = 1
+    col_offset = 2
+    rows = block_m + row_offset
+    cols = block_n + col_offset
+    row_stride = 12
+    byte_offset = 8
+    storage_bytes = 144
+    values = [float(idx + 1) for idx in range(block_m * block_n)]
+    src = torch.tensor(values, dtype=torch.float32).to(torch.bfloat16).reshape(block_m, block_n).npu()
+    dst = torch.zeros(storage_bytes, device="npu", dtype=torch.uint8)
+    offset = torch.tensor([byte_offset], dtype=torch.int64).npu()
+    meta = {
+        "ROWS": rows,
+        "COLS": cols,
+        "BLOCK_M": block_m,
+        "BLOCK_N": block_n,
+    }
+
+    compiled = _runtime_2d_block_ptr_bf16_store.warmup(src, dst, offset, row_stride, **meta, grid=(1, ))
+    _require_no_runtime_check(compiled)
+    _runtime_2d_block_ptr_bf16_store[(1, )](src, dst, offset, row_stride, **meta)
+    _sync_npu()
+
+    expected = torch.zeros(storage_bytes, dtype=torch.uint8)
+    for row in range(block_m):
+        start = row * block_n
+        _write_bf16_le(
+            expected,
+            byte_offset + ((row + row_offset) * row_stride + col_offset) * 2,
+            values[start:start + block_n],
+        )
+    torch.testing.assert_close(dst.cpu(), expected, rtol=0, atol=0)
+
+
+def test_runtime_pointer_bitcast_followed_by_value_bitcast():
+    byte_offsets = [4, 12, 20, 28]
+    values = [1.0, -2.0, 0.5, 8.0]
+    bit_patterns = [struct.unpack("<I", struct.pack("<f", value))[0] for value in values]
+    host = torch.zeros(40, dtype=torch.uint8)
+    _write_u32_le(host, byte_offsets, bit_patterns)
+    src = host.npu()
+    offsets = torch.tensor(byte_offsets, dtype=torch.int64).npu()
+    out = torch.empty((len(values), ), device="npu", dtype=torch.float32)
+
+    compiled = _runtime_pointer_then_value_bitcast.warmup(src, offsets, out, N=len(values), BLOCK=4, grid=(1, ))
+    _require_no_runtime_check(compiled)
+    _runtime_pointer_then_value_bitcast[(1, )](src, offsets, out, N=len(values), BLOCK=4)
+    _sync_npu()
+
+    torch.testing.assert_close(out.cpu(), torch.tensor(values, dtype=torch.float32), rtol=0, atol=0)
+
+
+def test_loaded_tensor_offset_division_without_pointer_bitcast_is_unchanged():
+    loaded_offsets = [1, 2, 3, 4]
+    source = torch.arange(16, dtype=torch.int32).npu()
+    offsets = torch.tensor(loaded_offsets, dtype=torch.int64).npu()
+    out = torch.empty((len(loaded_offsets), ), device="npu", dtype=torch.int32)
+
+    compiled = _loaded_offset_division_without_pointer_bitcast.warmup(source, offsets, out, N=len(loaded_offsets),
+                                                                      DIVISOR=2, BLOCK=4, grid=(1, ))
+    _require_no_pointer_bitcast_assert(compiled)
+    _loaded_offset_division_without_pointer_bitcast[(1, )](source, offsets, out, N=len(loaded_offsets), DIVISOR=2,
+                                                           BLOCK=4)
+    _sync_npu()
+
+    expected = torch.tensor([0, 1, 1, 2], dtype=torch.int32)
+    torch.testing.assert_close(out.cpu(), expected, rtol=0, atol=0)
+
+
+def test_runtime_scalar_bf16_store_preserves_address():
+    byte_offset = 22
+    values = [3.0, 6.0, 9.0, 12.0]
+    src = torch.tensor(values, dtype=torch.float32).to(torch.bfloat16).npu()
+    dst = torch.zeros(64, device="npu", dtype=torch.uint8)
+    offset = torch.tensor([byte_offset], dtype=torch.int64).npu()
+
+    compiled = _runtime_scalar_bf16_store.warmup(src, dst, offset, N=len(values), BLOCK=8, grid=(1, ))
+    _require_no_runtime_check(compiled)
+    _runtime_scalar_bf16_store[(1, )](src, dst, offset, N=len(values), BLOCK=8)
+    _sync_npu()
+
+    expected = torch.zeros(64, dtype=torch.uint8)
+    _write_bf16_le(expected, byte_offset, values)
+    torch.testing.assert_close(dst.cpu(), expected, rtol=0, atol=0)
+
+
+def test_static_byte_offsets_preserve_address_without_runtime_check():
+    block = 4
+    values = [11, 22, 33, 44]
+    host = torch.zeros(block * 4, dtype=torch.uint8)
+    _write_u32_le(host, [idx * 4 for idx in range(block)], values)
+    src = host.npu()
+    out = torch.empty((block, ), device="npu", dtype=torch.int32)
+
+    compiled = _static_byte_offset_u32_load.warmup(src, out, N=block, BLOCK=block, grid=(1, ))
+    _require_no_runtime_check(compiled)
+    _static_byte_offset_u32_load[(1, )](src, out, N=block, BLOCK=block)
+    _sync_npu()
+
+    torch.testing.assert_close(out.cpu(), torch.tensor(values, dtype=torch.int32), rtol=0, atol=0)
+
+
+def test_runtime_multi_addptr_bf16_load_preserves_address():
+    params_host = [1, 1, 64, 16, 8]
+    byte_offset = 64 + 16 + 8
+    values = [2.0, 4.0, 6.0, 8.0]
+    host = torch.zeros(128, dtype=torch.uint8)
+    _write_bf16_le(host, byte_offset, values)
+    src = host.npu()
+    params = torch.tensor(params_host, dtype=torch.int64).npu()
+    out = torch.empty((len(values), ), device="npu", dtype=torch.bfloat16)
+
+    compiled = _runtime_multi_addptr_bf16_load.warmup(src, params, out, N=len(values), BLOCK=8, grid=(1, ))
+    _require_no_runtime_check(compiled)
+    _runtime_multi_addptr_bf16_load[(1, )](src, params, out, N=len(values), BLOCK=8)
+    _sync_npu()
+
+    expected = torch.tensor(values, dtype=torch.float32).to(torch.bfloat16)
+    torch.testing.assert_close(out.cpu(), expected, rtol=0, atol=0)
+
+
+def test_runtime_negative_scalar_offset_u32_load_preserves_address():
+    host = torch.zeros(64, dtype=torch.uint8)
+    value = 0x10203040
+    _write_u32_le(host, [12], [value])
+    storage = host.npu()
+    src = storage[16:]
+    offset = torch.tensor([-4], dtype=torch.int64).npu()
+    out = torch.empty((), device="npu", dtype=torch.int32)
+
+    compiled = _runtime_scalar_u32_load.warmup(src, offset, out, grid=(1, ))
+    _require_no_runtime_check(compiled)
+    _runtime_scalar_u32_load[(1, )](src, offset, out)
+    _sync_npu()
+
+    assert int(out.cpu()) == value
+
+
+def test_tensor_offsets_before_and_after_bitcast_preserve_address():
+    block = 4
+    post_offsets = [0, 1, 0, 1]
+    byte_offsets = [lane * 8 + post_offsets[lane] * 4 for lane in range(block)]
+    values = [101, 202, 303, 404]
+    host = torch.zeros(40, dtype=torch.uint8)
+    _write_u32_le(host, byte_offsets, values)
+    src = host.npu()
+    offsets = torch.tensor(post_offsets, dtype=torch.int64).npu()
+    out = torch.empty((block, ), device="npu", dtype=torch.int32)
+
+    compiled = _runtime_tensor_pre_post_u32_load.warmup(src, offsets, out, BLOCK=block, grid=(1, ))
+    _require_no_runtime_check(compiled)
+    _runtime_tensor_pre_post_u32_load[(1, )](src, offsets, out, BLOCK=block)
+    _sync_npu()
+
+    torch.testing.assert_close(out.cpu(), torch.tensor(values, dtype=torch.int32), rtol=0, atol=0)
+
+
+def test_scalar_offsets_before_and_after_bitcast_preserve_address():
+    pre_bytes = 4
+    post_elements = 3
+    expected_byte_address = pre_bytes + post_elements * 4
+    value = 0x10203040
+    host = torch.zeros(40, dtype=torch.uint8)
+    _write_u32_le(host, [expected_byte_address], [value])
+    src = host.npu()
+    offsets = torch.tensor([pre_bytes, post_elements], dtype=torch.int64).npu()
+    out = torch.empty((), device="npu", dtype=torch.int32)
+
+    compiled = _runtime_scalar_pre_post_u32_load.warmup(src, offsets, out, grid=(1, ))
+    _require_no_runtime_check(compiled)
+    _runtime_scalar_pre_post_u32_load[(1, )](src, offsets, out)
+    _sync_npu()
+
+    assert int(out.cpu()) == value
+
+
+def test_multiple_bitcast_boundaries_preserve_address():
+    offsets_host = [3, 2, 1, 2]
+    expected_byte_address = 3 + 2 * 2 + 1 + 2 * 4
+    value = 0x11223344
+    host = torch.zeros(40, dtype=torch.uint8)
+    _write_u32_le(host, [expected_byte_address], [value])
+    src = host.npu()
+    offsets = torch.tensor(offsets_host, dtype=torch.int64).npu()
+    out = torch.empty((), device="npu", dtype=torch.int32)
+
+    compiled = _runtime_multiple_bitcast_boundaries_load.warmup(src, offsets, out, grid=(1, ))
+    _require_no_runtime_check(compiled)
+    _runtime_multiple_bitcast_boundaries_load[(1, )](src, offsets, out)
+    _sync_npu()
+
+    assert int(out.cpu()) == value
+
+
+def test_negative_post_bitcast_offset_preserves_address():
+    value = 0x21324354
+    host = torch.zeros(32, dtype=torch.uint8)
+    _write_u32_le(host, [12], [value])
+    storage = host.npu()
+    src = storage[16:]
+    offset = torch.tensor([-1], dtype=torch.int64).npu()
+    out = torch.empty((), device="npu", dtype=torch.int32)
+
+    compiled = _runtime_negative_post_bitcast_u32_load.warmup(src, offset, out, grid=(1, ))
+    _require_no_runtime_check(compiled)
+    _runtime_negative_post_bitcast_u32_load[(1, )](src, offset, out)
+    _sync_npu()
+
+    assert int(out.cpu()) == value
+
+
+def test_tensor_store_offsets_after_bitcast_preserve_address():
+    block = 4
+    post_offsets = [1, 0, 1, 0]
+    byte_offsets = [lane * 8 + post_offsets[lane] * 4 for lane in range(block)]
+    values_host = [11, 22, 33, 44]
+    values = torch.tensor(values_host, dtype=torch.int32).npu()
+    dst = torch.zeros(40, device="npu", dtype=torch.uint8)
+    offsets = torch.tensor(post_offsets, dtype=torch.int64).npu()
+
+    compiled = _runtime_tensor_pre_post_u32_store.warmup(values, dst, offsets, BLOCK=block, grid=(1, ))
+    _require_no_runtime_check(compiled)
+    _runtime_tensor_pre_post_u32_store[(1, )](values, dst, offsets, BLOCK=block)
+    _sync_npu()
+
+    expected = torch.zeros(40, dtype=torch.uint8)
+    _write_u32_le(expected, byte_offsets, values_host)
+    torch.testing.assert_close(dst.cpu(), expected, rtol=0, atol=0)
+
+
+def test_tensor_atomic_offsets_after_bitcast_preserve_address():
+    block = 4
+    post_offsets = [0, 1, 0, 1]
+    element_indices = [lane * 2 + post_offsets[lane] for lane in range(block)]
+    initial = torch.arange(12, dtype=torch.int32)
+    increments_host = [10, 20, 30, 40]
+    increments = torch.tensor(increments_host, dtype=torch.int32).npu()
+    dst = initial.clone().npu()
+    dst_bytes = dst.view(torch.uint8)
+    offsets = torch.tensor(post_offsets, dtype=torch.int64).npu()
+
+    compiled = _runtime_tensor_pre_post_atomic_add.warmup(increments, dst_bytes, offsets, BLOCK=block, grid=(1, ))
+    _require_no_runtime_check(compiled)
+    _runtime_tensor_pre_post_atomic_add[(1, )](increments, dst_bytes, offsets, BLOCK=block)
+    _sync_npu()
+
+    expected = initial.clone()
+    for index, increment in zip(element_indices, increments_host):
+        expected[index] += increment
+    torch.testing.assert_close(dst.cpu(), expected, rtol=0, atol=0)

--- a/third_party/ascend/unittest/pytest_ut/test_pointer_bitcast_matrix.py
+++ b/third_party/ascend/unittest/pytest_ut/test_pointer_bitcast_matrix.py
@@ -1,0 +1,379 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import struct
+
+import pytest
+import torch
+import torch_npu
+import triton
+import triton.language as tl
+
+
+def _sync_npu():
+    if hasattr(torch, "npu"):
+        torch.npu.synchronize()
+
+
+def _pack_i16(value):
+    return struct.pack("<h", int(value))
+
+
+def _pack_i32(value):
+    return struct.pack("<i", int(value))
+
+
+def _pack_f32(value):
+    return struct.pack("<f", float(value))
+
+
+def _float_to_bf16_bits(value):
+    f32_bits = struct.unpack("<I", struct.pack("<f", float(value)))[0]
+    return f32_bits >> 16
+
+
+def _pack_bf16(value):
+    bits = _float_to_bf16_bits(value)
+    return bytes((bits & 0xFF, (bits >> 8) & 0xFF))
+
+
+def _write_packed_values(buf, byte_offsets, values, pack_fn):
+    for byte_offset, value in zip(byte_offsets, values):
+        payload = pack_fn(value)
+        start = int(byte_offset)
+        for byte_idx, byte_value in enumerate(payload):
+            buf[start + byte_idx] = byte_value
+
+
+def _expected_bytes(values, pack_fn):
+    out = []
+    for value in values:
+        out.extend(pack_fn(value))
+    return torch.tensor(out, dtype=torch.uint8)
+
+
+def _float_bits_to_i32(value):
+    return struct.unpack("<i", struct.pack("<f", float(value)))[0]
+
+
+@triton.jit
+def _load_widen_from_u8(src, out, n_elements, BASE: tl.constexpr, BYTE_WIDTH: tl.constexpr, TARGET_DTYPE: tl.constexpr,
+                        BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    mask = lanes < n_elements
+    byte_offsets = BASE + lanes * BYTE_WIDTH
+    target_ptrs = (src + byte_offsets).to(tl.pointer_type(TARGET_DTYPE, 1), bitcast=True)
+    values = tl.load(target_ptrs, mask=mask, other=0)
+    tl.store(out + lanes, values)
+
+
+@triton.jit
+def _store_widen_to_u8(src, dst, n_elements, BASE: tl.constexpr, BYTE_WIDTH: tl.constexpr, TARGET_DTYPE: tl.constexpr,
+                       BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    mask = lanes < n_elements
+    values = tl.load(src + lanes, mask=mask, other=0)
+    byte_offsets = BASE + lanes * BYTE_WIDTH
+    target_ptrs = (dst + byte_offsets).to(tl.pointer_type(TARGET_DTYPE, 1), bitcast=True)
+    tl.store(target_ptrs, values, mask=mask)
+
+
+@triton.jit
+def _atomic_add_widen_to_u8(updates_ptr, dst, n_elements, BASE: tl.constexpr, BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    mask = lanes < n_elements
+    updates = tl.load(updates_ptr + lanes, mask=mask, other=0)
+    byte_offsets = BASE + lanes * 4
+    target_ptrs = (dst + byte_offsets).to(tl.pointer_type(tl.int32, 1), bitcast=True)
+    tl.atomic_add(target_ptrs, updates, mask=mask)
+
+
+@triton.jit
+def _atomic_cas_widen_to_u8(compare_ptr, updates_ptr, dst, old_ptr, BASE: tl.constexpr, BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    compare = tl.load(compare_ptr + lanes)
+    updates = tl.load(updates_ptr + lanes)
+    byte_offsets = BASE + lanes * 4
+    target_ptrs = (dst + byte_offsets).to(tl.pointer_type(tl.int32, 1), bitcast=True)
+    old = tl.atomic_cas(target_ptrs, compare, updates)
+    tl.store(old_ptr + lanes, old)
+
+
+@triton.jit
+def _same_width_i32_pointer_bitcast(src, out, word_base: tl.constexpr, n_elements: tl.constexpr, BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    src_words = src + word_base
+    f32_ptr = src_words.to(tl.pointer_type(tl.float32), bitcast=True)
+    values = tl.load(f32_ptr + lanes, mask=lanes < n_elements, other=0.0)
+    tl.store(out + lanes, values)
+
+
+@triton.jit
+def _value_bitcast_i32_to_f32(src, out, n_elements: tl.constexpr, BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    raw = tl.load(src + lanes, mask=lanes < n_elements, other=0)
+    values = raw.to(tl.float32, bitcast=True)
+    tl.store(out + lanes, values)
+
+
+@triton.jit
+def _narrow_i32_to_u8_load(src, out, word_base: tl.constexpr, n_bytes: tl.constexpr, BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    src_words = src + word_base
+    byte_ptr = src_words.to(tl.pointer_type(tl.uint8), bitcast=True)
+    values = tl.load(byte_ptr + lanes, mask=lanes < n_bytes, other=0)
+    tl.store(out + lanes, values)
+
+
+@triton.jit
+def _narrow_i32_tensor_ptrs_to_u8_load(src, word_offsets_ptr, out, N: tl.constexpr, BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    mask = lanes < N
+    word_offsets = tl.load(word_offsets_ptr + lanes, mask=mask, other=0)
+    word_ptrs = src + word_offsets
+    byte_ptrs = word_ptrs.to(tl.pointer_type(tl.uint8), bitcast=True)
+    values = tl.load(byte_ptrs, mask=mask, other=0)
+    tl.store(out + lanes, values, mask=mask)
+
+
+@triton.jit
+def _legacy_i1_pointer_to_u8_load(src, out, N: tl.constexpr, BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    mask = lanes < N
+    byte_ptr = src.to(tl.pointer_type(tl.uint8), bitcast=True)
+    values = tl.load(byte_ptr + lanes, mask=mask, other=0)
+    tl.store(out + lanes, values, mask=mask)
+
+
+@triton.jit
+def _plain_u8_copy(src, out, n_elements: tl.constexpr, BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    values = tl.load(src + lanes, mask=lanes < n_elements, other=0)
+    tl.store(out + lanes, values)
+
+
+@triton.jit
+def _static_pre_and_post_bitcast_i32_load(src, out):
+    ptr = (src + 4).to(tl.pointer_type(tl.int32, 1), bitcast=True)
+    value = tl.load(ptr + 2)
+    tl.store(out, value)
+
+
+@pytest.mark.parametrize(
+    "name,byte_width,target_dtype,torch_dtype,values,pack_fn",
+    [
+        ("i16", 2, tl.int16, torch.int16, [11, 22, 33, 44, 55], _pack_i16),
+        ("i32", 4, tl.int32, torch.int32, [0x01020304, 0x05060708, 0x11121314, 0x21222324], _pack_i32),
+        ("f32", 4, tl.float32, torch.float32, [1.0, 2.0, 4.0, 8.0, 16.0], _pack_f32),
+        ("bf16", 2, tl.bfloat16, torch.bfloat16, [1.0, 2.0, 3.0, 4.0, 5.0], _pack_bf16),
+    ],
+)
+def test_widen_load_from_uint8_dtype_matrix(name, byte_width, target_dtype, torch_dtype, values, pack_fn):
+    block = 8
+    base = 32
+    host = torch.zeros(base + block * byte_width, dtype=torch.uint8)
+    byte_offsets = [base + idx * byte_width for idx in range(len(values))]
+    _write_packed_values(host, byte_offsets, values, pack_fn)
+
+    src = host.npu()
+    out = torch.empty((block, ), device="npu", dtype=torch_dtype)
+
+    _load_widen_from_u8[(1, )](src, out, len(values), BASE=base, BYTE_WIDTH=byte_width, TARGET_DTYPE=target_dtype,
+                               BLOCK=block)
+    _sync_npu()
+
+    expected = torch.zeros((block, ), dtype=torch_dtype)
+    expected[:len(values)] = torch.tensor(values, dtype=torch_dtype)
+    torch.testing.assert_close(out.cpu(), expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "name,byte_width,target_dtype,torch_dtype,values,pack_fn",
+    [
+        ("i16", 2, tl.int16, torch.int16, [101, 202, 303, 404], _pack_i16),
+        ("i32", 4, tl.int32, torch.int32, [0x01010101, 0x02020202, 0x03030303], _pack_i32),
+        ("f32", 4, tl.float32, torch.float32, [1.0, 2.0, 4.0], _pack_f32),
+        ("bf16", 2, tl.bfloat16, torch.bfloat16, [1.0, 2.0, 3.0, 4.0], _pack_bf16),
+    ],
+)
+def test_widen_store_to_uint8_dtype_matrix(name, byte_width, target_dtype, torch_dtype, values, pack_fn):
+    block = 8
+    base = 16
+    src = torch.tensor(values, dtype=torch_dtype).npu()
+    dst = torch.zeros(base + block * byte_width, device="npu", dtype=torch.uint8)
+
+    _store_widen_to_u8[(1, )](src, dst, len(values), BASE=base, BYTE_WIDTH=byte_width, TARGET_DTYPE=target_dtype,
+                              BLOCK=block)
+    _sync_npu()
+
+    actual = dst.cpu()[base:base + len(values) * byte_width]
+    expected = _expected_bytes(values, pack_fn)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_widen_atomic_add_scalarizes_value_and_mask():
+    block = 8
+    base = 32
+    updates_host = torch.tensor([3, 7, 11, 13, 17], dtype=torch.int32)
+    initial = torch.full((base + block * 4 + 8, ), 0xA5, dtype=torch.uint8)
+    byte_offsets = [base + lane * 4 for lane in range(block)]
+    _write_packed_values(initial, byte_offsets, [0] * block, _pack_i32)
+
+    updates = updates_host.npu()
+    dst = initial.npu()
+    _atomic_add_widen_to_u8[(1, )](updates, dst, updates_host.numel(), BASE=base, BLOCK=block)
+    _sync_npu()
+
+    expected = initial.clone()
+    _write_packed_values(expected, byte_offsets[:updates_host.numel()], updates_host, _pack_i32)
+    torch.testing.assert_close(dst.cpu(), expected, rtol=0, atol=0)
+
+
+def test_widen_atomic_cas_scalarizes_compare_value_and_result():
+    block = 4
+    base = 32
+    initial_values = [10, 20, 30, 40]
+    compare_values = [10, 99, 30, 77]
+    update_values = [101, 202, 303, 404]
+    expected_values = [101, 20, 303, 40]
+    byte_offsets = [base + lane * 4 for lane in range(block)]
+    initial = torch.full((base + block * 4 + 8, ), 0x5A, dtype=torch.uint8)
+    _write_packed_values(initial, byte_offsets, initial_values, _pack_i32)
+
+    compare = torch.tensor(compare_values, dtype=torch.int32).npu()
+    updates = torch.tensor(update_values, dtype=torch.int32).npu()
+    dst = initial.npu()
+    old = torch.empty((block, ), dtype=torch.int32, device="npu")
+    _atomic_cas_widen_to_u8[(1, )](compare, updates, dst, old, BASE=base, BLOCK=block)
+    _sync_npu()
+
+    expected = initial.clone()
+    _write_packed_values(expected, byte_offsets, expected_values, _pack_i32)
+    torch.testing.assert_close(dst.cpu(), expected, rtol=0, atol=0)
+    torch.testing.assert_close(old.cpu(), torch.tensor(initial_values, dtype=torch.int32), rtol=0, atol=0)
+
+
+def test_same_width_pointer_bitcast_i32_to_f32_is_unchanged():
+    block = 8
+    word_base = 1
+    values = [1.0, 2.0, 4.0, 8.0]
+    raw = [0] + [_float_bits_to_i32(value) for value in values] + [0] * 4
+    src = torch.tensor(raw, dtype=torch.int32).npu()
+    out = torch.empty((block, ), device="npu", dtype=torch.float32)
+
+    _same_width_i32_pointer_bitcast[(1, )](src, out, word_base=word_base, n_elements=len(values), BLOCK=block)
+    _sync_npu()
+
+    expected = torch.zeros((block, ), dtype=torch.float32)
+    expected[:len(values)] = torch.tensor(values, dtype=torch.float32)
+    torch.testing.assert_close(out.cpu(), expected, rtol=0, atol=0)
+
+
+def test_value_bitcast_i32_to_f32_is_unchanged():
+    block = 8
+    values = [1.0, 2.0, 4.0, 8.0]
+    raw = [_float_bits_to_i32(value) for value in values] + [0] * 4
+    src = torch.tensor(raw, dtype=torch.int32).npu()
+    out = torch.empty((block, ), device="npu", dtype=torch.float32)
+
+    _value_bitcast_i32_to_f32[(1, )](src, out, n_elements=len(values), BLOCK=block)
+    _sync_npu()
+
+    expected = torch.zeros((block, ), dtype=torch.float32)
+    expected[:len(values)] = torch.tensor(values, dtype=torch.float32)
+    torch.testing.assert_close(out.cpu(), expected, rtol=0, atol=0)
+
+
+def test_narrow_i32_to_uint8_load():
+    block = 16
+    word_base = 1
+    words = [0, 0x01020304, 0x11121314, 0x21222324, 0x31323334]
+    src = torch.tensor(words, dtype=torch.int32).npu()
+    out = torch.empty((block, ), device="npu", dtype=torch.uint8)
+
+    _narrow_i32_to_u8_load[(1, )](src, out, word_base=word_base, n_bytes=12, BLOCK=block)
+    _sync_npu()
+
+    expected = _expected_bytes(words[1:4], _pack_i32)
+    padded = torch.zeros((block, ), dtype=torch.uint8)
+    padded[:expected.numel()] = expected
+    torch.testing.assert_close(out.cpu(), padded, rtol=0, atol=0)
+
+
+def test_narrow_i32_tensor_pointers_to_uint8_load():
+    words = [
+        0,
+        0x01020304,
+        0,
+        0x11121314,
+        0x21222324,
+        0,
+        0x31323334,
+    ]
+    word_offsets = [1, 3, 4, 6]
+    src = torch.tensor(words, dtype=torch.int32).npu()
+    offsets = torch.tensor(word_offsets, dtype=torch.int64).npu()
+    out = torch.empty((len(word_offsets), ), device="npu", dtype=torch.uint8)
+
+    _narrow_i32_tensor_ptrs_to_u8_load[(1, )](src, offsets, out, N=len(word_offsets), BLOCK=4)
+    _sync_npu()
+
+    expected = torch.tensor([0x04, 0x14, 0x24, 0x34], dtype=torch.uint8)
+    torch.testing.assert_close(out.cpu(), expected, rtol=0, atol=0)
+
+
+def test_legacy_i1_pointer_to_uint8_load_is_unchanged():
+    values = [False, True, True, False, True, False, False, True]
+    src = torch.tensor(values, dtype=torch.bool).npu()
+    out = torch.empty((len(values), ), device="npu", dtype=torch.uint8)
+
+    _legacy_i1_pointer_to_u8_load[(1, )](src, out, N=len(values), BLOCK=8)
+    _sync_npu()
+
+    expected = torch.tensor(values, dtype=torch.uint8)
+    torch.testing.assert_close(out.cpu(), expected, rtol=0, atol=0)
+
+
+def test_plain_uint8_load_store_is_unchanged():
+    block = 32
+    n_elements = 19
+    src_host = torch.arange(block, dtype=torch.uint8)
+    src = src_host.npu()
+    out = torch.empty((block, ), device="npu", dtype=torch.uint8)
+
+    _plain_u8_copy[(1, )](src, out, n_elements=n_elements, BLOCK=block)
+    _sync_npu()
+
+    expected = torch.zeros((block, ), dtype=torch.uint8)
+    expected[:n_elements] = src_host[:n_elements]
+    torch.testing.assert_close(out.cpu(), expected, rtol=0, atol=0)
+
+
+def test_static_offsets_before_and_after_bitcast_preserve_address():
+    value = 0x10203040
+    host = torch.zeros((32, ), dtype=torch.uint8)
+    _write_packed_values(host, [12], [value], _pack_i32)
+    src = host.npu()
+    out = torch.empty((), device="npu", dtype=torch.int32)
+
+    _static_pre_and_post_bitcast_i32_load[(1, )](src, out)
+    _sync_npu()
+
+    assert int(out.cpu()) == value

--- a/third_party/ascend/unittest/pytest_ut/test_pointer_bitcast_mlir.py
+++ b/third_party/ascend/unittest/pytest_ut/test_pointer_bitcast_mlir.py
@@ -1,0 +1,1242 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import os
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from triton.backends.ascend.utils import _get_triton_opt_path
+
+
+def _find_triton_opt():
+    configured = os.environ.get("TRITON_OPT")
+    if configured:
+        path = Path(configured)
+        if path.is_file():
+            return str(path)
+        pytest.fail(f"TRITON_OPT does not point to a file: {configured}")
+    return _get_triton_opt_path()
+
+
+def _run_ttolinalg(tmp_path, name, module):
+    source = tmp_path / f"{name}.mlir"
+    source.write_text(textwrap.dedent(module), encoding="utf-8")
+    return subprocess.run(
+        [_find_triton_opt(), "--triton-to-linalg=named-ops=True",
+         str(source)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+
+def _run_unstructure(tmp_path, name, module):
+    source = tmp_path / f"{name}.mlir"
+    source.write_text(textwrap.dedent(module), encoding="utf-8")
+    return subprocess.run(
+        [
+            _find_triton_opt(),
+            "--triton-to-unstructure",
+            str(source),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+
+def _run_discrete_mask_conversion(tmp_path, name, module):
+    source = tmp_path / f"{name}.mlir"
+    source.write_text(textwrap.dedent(module), encoding="utf-8")
+    return subprocess.run(
+        [
+            _find_triton_opt(),
+            "--discrete-mask-access-conversion",
+            str(source),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+
+def _run_pipeline(tmp_path, name, module):
+    source = tmp_path / f"{name}.mlir"
+    source.write_text(textwrap.dedent(module), encoding="utf-8")
+    return subprocess.run(
+        [
+            _find_triton_opt(),
+            "--triton-to-unstructure",
+            "--triton-to-linalg=named-ops=True",
+            str(source),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+
+def _assert_clean_failure(result, expected):
+    diagnostics = result.stdout + result.stderr
+    assert result.returncode > 0, diagnostics
+    assert expected in diagnostics
+    assert "Assertion" not in diagnostics
+    assert "PLEASE submit a bug report" not in diagnostics
+    assert "Stack dump" not in diagnostics
+    return diagnostics
+
+
+def _require_same_atomic_lane(output, minimum_uses):
+    lane_indices = re.findall(r"tensor\.extract [^\n]*\[(%[^\]\s]+)\]", output)
+    assert any(lane_indices.count(iv) >= minimum_uses for iv in set(lane_indices)), output
+
+
+def test_dynamic_scalar_offset_materializes_exact_byte_address(tmp_path):
+    result = _run_ttolinalg(
+        tmp_path, "dynamic_ratio4", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @dynamic_ratio4(
+              %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+              %byte_offset: i32) attributes {noinline = false} {
+            %byte_ptr = tt.addptr %src, %byte_offset : !tt.ptr<i8>, i32
+            %wide_ptr = tt.bitcast %byte_ptr : !tt.ptr<i8> -> !tt.ptr<i32>
+            %value = tt.load %wide_ptr : !tt.ptr<i32>
+            tt.store %dst, %value : !tt.ptr<i32>
+            tt.return
+          }
+        }
+    """)
+    assert result.returncode == 0, result.stderr
+    output = result.stdout
+    assert "arith.remsi" not in output, output
+    assert "triton_assert" not in output, output
+    assert "arith.divsi" not in output, output
+    assert "arith.muli" in output, output
+    assert "arith.addi" in output, output
+    assert "hivm.hir.pointer_cast" in output, output
+
+
+def test_tensor_byte_offsets_materialize_without_runtime_check(tmp_path):
+    result = _run_pipeline(
+        tmp_path, "tensor_byte_offsets", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @tensor_byte_offsets(
+              %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %range = tt.make_range {start = 0 : i32, end = 4 : i32}
+                : tensor<4xi32>
+            %four = arith.constant dense<4> : tensor<4xi32>
+            %offsets = arith.muli %range, %four : tensor<4xi32>
+            %srcs = tt.splat %src
+                : !tt.ptr<i8> -> tensor<4x!tt.ptr<i8>>
+            %byte_ptrs = tt.addptr %srcs, %offsets
+                : tensor<4x!tt.ptr<i8>>, tensor<4xi32>
+            %wide_ptrs = tt.bitcast %byte_ptrs
+                : tensor<4x!tt.ptr<i8>> -> tensor<4x!tt.ptr<i32>>
+            %values = tt.load %wide_ptrs : tensor<4x!tt.ptr<i32>>
+            %dsts = tt.splat %dst
+                : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+            %dst_ptrs = tt.addptr %dsts, %range
+                : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+            tt.store %dst_ptrs, %values : tensor<4x!tt.ptr<i32>>
+            tt.return
+          }
+        }
+    """)
+    assert result.returncode == 0, result.stderr
+    assert "arith.remsi" not in result.stdout, result.stdout
+    assert "triton_assert" not in result.stdout, result.stdout
+
+    assert "builtin.unrealized_conversion_cast" not in result.stdout
+    assert "hivm.hir.pointer_cast" in result.stdout
+
+
+def test_byte_addressed_discrete_mask_load_keeps_scalar_mask_and_other(tmp_path):
+    result = _run_unstructure(
+        tmp_path, "byte_addressed_discrete_mask_load", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @byte_addressed_discrete_mask_load(
+              %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %range = tt.make_range {start = 0 : i32, end = 4 : i32}
+                : tensor<4xi32>
+            %four = arith.constant dense<4> : tensor<4xi32>
+            %byte_offsets = arith.muli %range, %four : tensor<4xi32>
+            %bytes = tt.splat %src
+                : !tt.ptr<i8> -> tensor<4x!tt.ptr<i8>>
+            %byte_ptrs = tt.addptr %bytes, %byte_offsets
+                : tensor<4x!tt.ptr<i8>>, tensor<4xi32>
+            %wide_ptrs = tt.bitcast %byte_ptrs
+                : tensor<4x!tt.ptr<i8>> -> tensor<4x!tt.ptr<i32>>
+            %two = arith.constant dense<2> : tensor<4xi32>
+            %zero = arith.constant dense<0> : tensor<4xi32>
+            %remainder = arith.remsi %range, %two : tensor<4xi32>
+            %mask = arith.cmpi eq, %remainder, %zero : tensor<4xi32>
+            %other = arith.constant dense<-7> : tensor<4xi32>
+            %values = tt.load %wide_ptrs, %mask, %other
+                : tensor<4x!tt.ptr<i32>>
+            %dsts = tt.splat %dst
+                : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+            %dst_ptrs = tt.addptr %dsts, %range
+                : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+            tt.store %dst_ptrs, %values : tensor<4x!tt.ptr<i32>>
+            tt.return
+          }
+        }
+    """)
+    assert result.returncode == 0, result.stderr
+    output = result.stdout
+    scalar_loads = [line for line in output.splitlines() if "tt.load" in line and ": !tt.ptr<i32>" in line]
+    assert scalar_loads, output
+    assert all(line.count(",") >= 2 for line in scalar_loads), output
+    assert "tt.pointer_bitcast_pointer_cast" in output, output
+    # The constant other may fold directly to a scalar constant in each lane.
+    assert re.search(r"tensor\.extract .*tensor<4xi1>", output), output
+
+
+def test_byte_addressed_discrete_mask_load_without_other_keeps_scalar_mask(tmp_path):
+    result = _run_unstructure(
+        tmp_path, "byte_addressed_mask_load_without_other", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @byte_addressed_mask_load_without_other(
+              %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %range = tt.make_range {start = 0 : i32, end = 4 : i32}
+                : tensor<4xi32>
+            %four = arith.constant dense<4> : tensor<4xi32>
+            %byte_offsets = arith.muli %range, %four : tensor<4xi32>
+            %bytes = tt.splat %src
+                : !tt.ptr<i8> -> tensor<4x!tt.ptr<i8>>
+            %byte_ptrs = tt.addptr %bytes, %byte_offsets
+                : tensor<4x!tt.ptr<i8>>, tensor<4xi32>
+            %wide_ptrs = tt.bitcast %byte_ptrs
+                : tensor<4x!tt.ptr<i8>> -> tensor<4x!tt.ptr<i32>>
+            %two = arith.constant dense<2> : tensor<4xi32>
+            %zero = arith.constant dense<0> : tensor<4xi32>
+            %remainder = arith.remsi %range, %two : tensor<4xi32>
+            %mask = arith.cmpi eq, %remainder, %zero : tensor<4xi32>
+            %values = tt.load %wide_ptrs, %mask
+                : tensor<4x!tt.ptr<i32>>
+            %dsts = tt.splat %dst
+                : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+            %dst_ptrs = tt.addptr %dsts, %range
+                : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+            tt.store %dst_ptrs, %values : tensor<4x!tt.ptr<i32>>
+            tt.return
+          }
+        }
+    """)
+    assert result.returncode == 0, result.stderr
+    output = result.stdout
+    scalar_loads = [line for line in output.splitlines() if "tt.load" in line and ": !tt.ptr<i32>" in line]
+    assert scalar_loads, output
+    assert all(line.count(",") >= 1 for line in scalar_loads), output
+    assert re.search(r"tensor\.extract .*tensor<4xi1>", output), output
+
+
+def test_different_width_pointer_bitcast_discrete_mask_load_is_rejected(tmp_path):
+    result = _run_discrete_mask_conversion(
+        tmp_path, "pointer_bitcast_discrete_mask_load", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @pointer_bitcast_discrete_mask_load(
+              %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %range = tt.make_range {start = 0 : i32, end = 4 : i32}
+                : tensor<4xi32>
+            %four = arith.constant dense<4> : tensor<4xi32>
+            %byte_offsets = arith.muli %range, %four : tensor<4xi32>
+            %bytes = tt.splat %src
+                : !tt.ptr<i8> -> tensor<4x!tt.ptr<i8>>
+            %byte_ptrs = tt.addptr %bytes, %byte_offsets
+                : tensor<4x!tt.ptr<i8>>, tensor<4xi32>
+            %wide_ptrs = tt.bitcast %byte_ptrs
+                : tensor<4x!tt.ptr<i8>> -> tensor<4x!tt.ptr<i32>>
+            %two = arith.constant dense<2> : tensor<4xi32>
+            %zero = arith.constant dense<0> : tensor<4xi32>
+            %remainder = arith.remsi %range, %two : tensor<4xi32>
+            %mask = arith.cmpi eq, %remainder, %zero : tensor<4xi32>
+            %other = arith.constant dense<-7> : tensor<4xi32>
+            %values = tt.load %wide_ptrs, %mask, %other
+                : tensor<4x!tt.ptr<i32>>
+            %dsts = tt.splat %dst
+                : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+            %dst_ptrs = tt.addptr %dsts, %range
+                : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+            tt.store %dst_ptrs, %values : tensor<4x!tt.ptr<i32>>
+            tt.return
+          }
+        }
+    """)
+    _assert_clean_failure(
+        result,
+        "different-width pointer bitcast does not support discrete masked "
+        "memory access",
+    )
+
+
+def test_control_flow_pointer_bitcast_discrete_mask_load_is_rejected(tmp_path):
+    result = _run_discrete_mask_conversion(
+        tmp_path, "control_flow_pointer_bitcast_discrete_mask_load", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @control_flow_pointer_bitcast_discrete_mask_load(
+              %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+              %cond: i1) attributes {noinline = false} {
+            %range = tt.make_range {start = 0 : i32, end = 4 : i32}
+                : tensor<4xi32>
+            %four = arith.constant dense<4> : tensor<4xi32>
+            %byte_offsets = arith.muli %range, %four : tensor<4xi32>
+            %bytes = tt.splat %src
+                : !tt.ptr<i8> -> tensor<4x!tt.ptr<i8>>
+            %byte_ptrs = tt.addptr %bytes, %byte_offsets
+                : tensor<4x!tt.ptr<i8>>, tensor<4xi32>
+            %wide_ptrs = tt.bitcast %byte_ptrs
+                : tensor<4x!tt.ptr<i8>> -> tensor<4x!tt.ptr<i32>>
+            %selected = scf.if %cond -> (tensor<4x!tt.ptr<i32>>) {
+              scf.yield %wide_ptrs : tensor<4x!tt.ptr<i32>>
+            } else {
+              %else_ptrs = tt.addptr %wide_ptrs, %range
+                  : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+              scf.yield %else_ptrs : tensor<4x!tt.ptr<i32>>
+            }
+            %two = arith.constant dense<2> : tensor<4xi32>
+            %zero = arith.constant dense<0> : tensor<4xi32>
+            %remainder = arith.remsi %range, %two : tensor<4xi32>
+            %mask = arith.cmpi eq, %remainder, %zero : tensor<4xi32>
+            %other = arith.constant dense<-7> : tensor<4xi32>
+            %values = tt.load %selected, %mask, %other
+                : tensor<4x!tt.ptr<i32>>
+            %dsts = tt.splat %dst
+                : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+            %dst_ptrs = tt.addptr %dsts, %range
+                : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+            tt.store %dst_ptrs, %values : tensor<4x!tt.ptr<i32>>
+            tt.return
+          }
+        }
+    """)
+    _assert_clean_failure(
+        result,
+        "different-width pointer bitcast does not support discrete masked "
+        "memory access",
+    )
+
+
+def test_different_width_pointer_bitcast_discrete_mask_store_is_rejected(tmp_path):
+    result = _run_discrete_mask_conversion(
+        tmp_path, "pointer_bitcast_discrete_mask_store", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @pointer_bitcast_discrete_mask_store(
+              %dst: !tt.ptr<i8> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %range = tt.make_range {start = 0 : i32, end = 4 : i32}
+                : tensor<4xi32>
+            %four = arith.constant dense<4> : tensor<4xi32>
+            %byte_offsets = arith.muli %range, %four : tensor<4xi32>
+            %bytes = tt.splat %dst
+                : !tt.ptr<i8> -> tensor<4x!tt.ptr<i8>>
+            %byte_ptrs = tt.addptr %bytes, %byte_offsets
+                : tensor<4x!tt.ptr<i8>>, tensor<4xi32>
+            %wide_ptrs = tt.bitcast %byte_ptrs
+                : tensor<4x!tt.ptr<i8>> -> tensor<4x!tt.ptr<i32>>
+            %two = arith.constant dense<2> : tensor<4xi32>
+            %zero = arith.constant dense<0> : tensor<4xi32>
+            %remainder = arith.remsi %range, %two : tensor<4xi32>
+            %mask = arith.cmpi eq, %remainder, %zero : tensor<4xi32>
+            %values = arith.constant dense<[3, 5, 7, 11]>
+                : tensor<4xi32>
+            tt.store %wide_ptrs, %values, %mask
+                : tensor<4x!tt.ptr<i32>>
+            tt.return
+          }
+        }
+    """)
+    _assert_clean_failure(
+        result,
+        "different-width pointer bitcast does not support discrete masked "
+        "memory access",
+    )
+
+
+def test_different_width_pointer_bitcast_discrete_mask_atomic_is_rejected(tmp_path):
+    result = _run_discrete_mask_conversion(
+        tmp_path, "pointer_bitcast_discrete_mask_atomic", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @pointer_bitcast_discrete_mask_atomic(
+              %dst: !tt.ptr<i8> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %range = tt.make_range {start = 0 : i32, end = 4 : i32}
+                : tensor<4xi32>
+            %four = arith.constant dense<4> : tensor<4xi32>
+            %byte_offsets = arith.muli %range, %four : tensor<4xi32>
+            %bytes = tt.splat %dst
+                : !tt.ptr<i8> -> tensor<4x!tt.ptr<i8>>
+            %byte_ptrs = tt.addptr %bytes, %byte_offsets
+                : tensor<4x!tt.ptr<i8>>, tensor<4xi32>
+            %wide_ptrs = tt.bitcast %byte_ptrs
+                : tensor<4x!tt.ptr<i8>> -> tensor<4x!tt.ptr<i32>>
+            %two = arith.constant dense<2> : tensor<4xi32>
+            %zero = arith.constant dense<0> : tensor<4xi32>
+            %remainder = arith.remsi %range, %two : tensor<4xi32>
+            %mask = arith.cmpi eq, %remainder, %zero : tensor<4xi32>
+            %values = arith.constant dense<[3, 5, 7, 11]>
+                : tensor<4xi32>
+            %old = tt.atomic_rmw add, acq_rel, gpu, %wide_ptrs, %values, %mask
+                : (tensor<4x!tt.ptr<i32>>, tensor<4xi32>, tensor<4xi1>)
+                    -> tensor<4xi32>
+            tt.return
+          }
+        }
+    """)
+    _assert_clean_failure(
+        result,
+        "different-width pointer bitcast does not support discrete masked "
+        "memory access",
+    )
+
+
+def test_different_width_pointer_bitcast_contiguous_mask_is_supported(tmp_path):
+    result = _run_discrete_mask_conversion(
+        tmp_path, "pointer_bitcast_contiguous_mask_load", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @pointer_bitcast_contiguous_mask_load(
+              %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %range = tt.make_range {start = 0 : i32, end = 4 : i32}
+                : tensor<4xi32>
+            %four = arith.constant dense<4> : tensor<4xi32>
+            %byte_offsets = arith.muli %range, %four : tensor<4xi32>
+            %bytes = tt.splat %src
+                : !tt.ptr<i8> -> tensor<4x!tt.ptr<i8>>
+            %byte_ptrs = tt.addptr %bytes, %byte_offsets
+                : tensor<4x!tt.ptr<i8>>, tensor<4xi32>
+            %wide_ptrs = tt.bitcast %byte_ptrs
+                : tensor<4x!tt.ptr<i8>> -> tensor<4x!tt.ptr<i32>>
+            %three = arith.constant dense<3> : tensor<4xi32>
+            %mask = arith.cmpi slt, %range, %three : tensor<4xi32>
+            %other = arith.constant dense<-7> : tensor<4xi32>
+            %values = tt.load %wide_ptrs, %mask, %other
+                : tensor<4x!tt.ptr<i32>>
+            %dsts = tt.splat %dst
+                : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+            %dst_ptrs = tt.addptr %dsts, %range
+                : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+            tt.store %dst_ptrs, %values : tensor<4x!tt.ptr<i32>>
+            tt.return
+          }
+        }
+    """)
+    assert result.returncode == 0, result.stderr
+    output = result.stdout
+    assert "tt.bitcast" in output, output
+    assert "tt.load" in output, output
+    assert "arith.select" not in output, output
+
+
+def test_non_bitcast_discrete_mask_load_keeps_legacy_conversion(tmp_path):
+    result = _run_discrete_mask_conversion(
+        tmp_path, "legacy_discrete_mask_load", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @legacy_discrete_mask_load(
+              %src: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+              %cond: i1)
+              attributes {noinline = false} {
+            %range = tt.make_range {start = 0 : i32, end = 4 : i32}
+                : tensor<4xi32>
+            %srcs = tt.splat %src
+                : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+            %src_ptrs = tt.addptr %srcs, %range
+                : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+            %selected = scf.if %cond -> (tensor<4x!tt.ptr<i32>>) {
+              scf.yield %srcs : tensor<4x!tt.ptr<i32>>
+            } else {
+              scf.yield %src_ptrs : tensor<4x!tt.ptr<i32>>
+            }
+            %two = arith.constant dense<2> : tensor<4xi32>
+            %zero = arith.constant dense<0> : tensor<4xi32>
+            %remainder = arith.remsi %range, %two : tensor<4xi32>
+            %mask = arith.cmpi eq, %remainder, %zero : tensor<4xi32>
+            %other = arith.constant dense<-7> : tensor<4xi32>
+            %values = tt.load %selected, %mask, %other
+                : tensor<4x!tt.ptr<i32>>
+            %dsts = tt.splat %dst
+                : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+            %dst_ptrs = tt.addptr %dsts, %range
+                : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+            tt.store %dst_ptrs, %values : tensor<4x!tt.ptr<i32>>
+            tt.return
+          }
+        }
+    """)
+    assert result.returncode == 0, result.stderr
+    output = result.stdout
+    assert "arith.select" in output, output
+    assert "tt.load" in output, output
+    assert "tt.bitcast" not in output, output
+    assert "tt.pointer_bitcast_pointer_cast" not in output, output
+
+
+def test_pointer_bitcast_mask_guards_the_physical_scalar_load(tmp_path):
+    result = _run_pipeline(
+        tmp_path, "pointer_bitcast_guarded_scalar_load", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @pointer_bitcast_guarded_scalar_load(
+              %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+              %mask: i1, %fallback: i32) attributes {noinline = false} {
+            %wide_ptr = tt.bitcast %src : !tt.ptr<i8> -> !tt.ptr<i32>
+            %one = arith.constant 1 : i32
+            %other = arith.addi %fallback, %one : i32
+            %value = tt.load %wide_ptr, %mask, %other : !tt.ptr<i32>
+            tt.store %dst, %value : !tt.ptr<i32>
+            tt.return
+          }
+        }
+    """)
+    assert result.returncode == 0, result.stderr
+    output = result.stdout
+    assert "scf.if" in output, output
+    assert "memref.load" in output, output
+    assert output.index("scf.if") < output.index("memref.load"), output
+
+
+def test_byte_addressed_widening_store_scalarizes_value_and_mask(tmp_path):
+    result = _run_pipeline(
+        tmp_path, "byte_addressed_widening_store", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @byte_addressed_widening_store(
+              %src: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i8> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %range = tt.make_range {start = 0 : i32, end = 4 : i32}
+                : tensor<4xi32>
+            %srcs = tt.splat %src
+                : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+            %src_ptrs = tt.addptr %srcs, %range
+                : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+            %values = tt.load %src_ptrs : tensor<4x!tt.ptr<i32>>
+            %four = arith.constant dense<4> : tensor<4xi32>
+            %byte_offsets = arith.muli %range, %four : tensor<4xi32>
+            %bytes = tt.splat %dst
+                : !tt.ptr<i8> -> tensor<4x!tt.ptr<i8>>
+            %byte_ptrs = tt.addptr %bytes, %byte_offsets
+                : tensor<4x!tt.ptr<i8>>, tensor<4xi32>
+            %wide_ptrs = tt.bitcast %byte_ptrs
+                : tensor<4x!tt.ptr<i8>> -> tensor<4x!tt.ptr<i32>>
+            %three = arith.constant dense<3> : tensor<4xi32>
+            %mask = arith.cmpi slt, %range, %three
+                : tensor<4xi32>
+            tt.store %wide_ptrs, %values, %mask
+                : tensor<4x!tt.ptr<i32>>
+            tt.return
+          }
+        }
+    """)
+    assert result.returncode == 0, result.stderr
+    output = result.stdout
+    assert "scf.for" in output, output
+    assert "arith.addi" in output, output
+    assert "hivm.hir.pointer_cast" in output, output
+    assert "scf.if" in output, output
+    assert ("memref.store" in output or "bufferization.materialize_in_destination" in output), output
+    assert "tensor.extract_slice" not in output, output
+    assert "builtin.unrealized_conversion_cast" not in output, output
+    assert re.search(r"tensor\.extract .*tensor<4xi64>", output), output
+    assert re.search(r"tensor\.extract .*tensor<4xi32>", output), output
+    assert re.search(r"tensor\.extract .*tensor<4xi1>", output), output
+    lane_indices = re.findall(r"tensor\.extract [^\n]*\[(%[^\]\s]+)\]", output)
+    assert any(lane_indices.count(iv) >= 3 for iv in set(lane_indices)), output
+
+
+def test_widening_atomic_rmw_scalarizes_value_and_mask(tmp_path):
+    result = _run_unstructure(
+        tmp_path, "widening_atomic_rmw", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @widening_atomic_rmw(
+              %dst: !tt.ptr<i8> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %offsets = arith.constant dense<[0, 4, 8, 12]>
+                : tensor<4xi32>
+            %values = arith.constant dense<[3, 7, 11, 13]>
+                : tensor<4xi32>
+            %range = tt.make_range {start = 0 : i32, end = 4 : i32}
+                : tensor<4xi32>
+            %three = arith.constant dense<3> : tensor<4xi32>
+            %mask = arith.cmpi slt, %range, %three : tensor<4xi32>
+            %bytes = tt.splat %dst
+                : !tt.ptr<i8> -> tensor<4x!tt.ptr<i8>>
+            %byte_ptrs = tt.addptr %bytes, %offsets
+                : tensor<4x!tt.ptr<i8>>, tensor<4xi32>
+            %wide_ptrs = tt.bitcast %byte_ptrs
+                : tensor<4x!tt.ptr<i8>> -> tensor<4x!tt.ptr<i32>>
+            %old = tt.atomic_rmw add, acq_rel, gpu, %wide_ptrs, %values, %mask
+                : (tensor<4x!tt.ptr<i32>>, tensor<4xi32>, tensor<4xi1>)
+                    -> tensor<4xi32>
+            tt.return
+          }
+        }
+    """)
+    assert result.returncode == 0, result.stderr
+    output = result.stdout
+    assert "__builtin_indirect_atomic" not in output, output
+    assert "tt.atomic_rmw add" in output, output
+    assert re.search(r"tensor\.extract .*tensor<4xi1>", output), output
+    _require_same_atomic_lane(output, 3)
+
+
+def test_widening_atomic_cas_scalarizes_compare_value_and_result(tmp_path):
+    result = _run_unstructure(
+        tmp_path, "widening_atomic_cas", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @widening_atomic_cas(
+              %dst: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %old_dst: !tt.ptr<i32> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %offsets = arith.constant dense<[0, 4, 8, 12]>
+                : tensor<4xi32>
+            %compare = arith.constant dense<[10, 99, 30, 77]>
+                : tensor<4xi32>
+            %values = arith.constant dense<[101, 202, 303, 404]>
+                : tensor<4xi32>
+            %range = tt.make_range {start = 0 : i32, end = 4 : i32}
+                : tensor<4xi32>
+            %bytes = tt.splat %dst
+                : !tt.ptr<i8> -> tensor<4x!tt.ptr<i8>>
+            %byte_ptrs = tt.addptr %bytes, %offsets
+                : tensor<4x!tt.ptr<i8>>, tensor<4xi32>
+            %wide_ptrs = tt.bitcast %byte_ptrs
+                : tensor<4x!tt.ptr<i8>> -> tensor<4x!tt.ptr<i32>>
+            %old = tt.atomic_cas acq_rel, gpu, %wide_ptrs, %compare, %values
+                : (tensor<4x!tt.ptr<i32>>, tensor<4xi32>, tensor<4xi32>)
+                    -> tensor<4xi32>
+            %old_dsts = tt.splat %old_dst
+                : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+            %old_ptrs = tt.addptr %old_dsts, %range
+                : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+            tt.store %old_ptrs, %old : tensor<4x!tt.ptr<i32>>
+            tt.return
+          }
+        }
+    """)
+    assert result.returncode == 0, result.stderr
+    output = result.stdout
+    assert "__builtin_indirect_atomic" not in output, output
+    assert "tt.atomic_cas" in output, output
+    _require_same_atomic_lane(output, 3)
+
+
+def test_static_pre_and_post_bitcast_offsets_keep_their_units(tmp_path):
+    result = _run_pipeline(
+        tmp_path, "static_pre_post_offsets", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @static_pre_post_offsets(
+              %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %four_bytes = arith.constant 4 : i32
+            %two_elements = arith.constant 2 : i32
+            %byte_ptr = tt.addptr %src, %four_bytes : !tt.ptr<i8>, i32
+            %wide_ptr = tt.bitcast %byte_ptr
+                : !tt.ptr<i8> -> !tt.ptr<i32>
+            %final_ptr = tt.addptr %wide_ptr, %two_elements
+                : !tt.ptr<i32>, i32
+            %value = tt.load %final_ptr : !tt.ptr<i32>
+            tt.store %dst, %value : !tt.ptr<i32>
+            tt.return
+          }
+        }
+    """)
+    assert result.returncode == 0, result.stderr
+    output = result.stdout
+    assert "arith.remsi" not in output, output
+    assert "triton_assert" not in output, output
+    assert "arith.divsi" not in output, output
+    assert "hivm.hir.pointer_cast" in output, output
+
+
+def test_same_width_pointer_bitcast_preserves_existing_path(tmp_path):
+    result = _run_pipeline(
+        tmp_path, "same_width", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @same_width(
+              %src: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+              %offset_src: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<f32> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %one = arith.constant 1 : i32
+            %source_ptr = tt.addptr %src, %one : !tt.ptr<i32>, i32
+            %float_ptr = tt.bitcast %source_ptr
+                : !tt.ptr<i32> -> !tt.ptr<f32>
+            %range = tt.make_range {start = 0 : i32, end = 4 : i32}
+                : tensor<4xi32>
+            %offset_bases = tt.splat %offset_src
+                : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+            %offset_ptrs = tt.addptr %offset_bases, %range
+                : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+            %offsets = tt.load %offset_ptrs : tensor<4x!tt.ptr<i32>>
+            %float_bases = tt.splat %float_ptr
+                : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+            %float_ptrs = tt.addptr %float_bases, %offsets
+                : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+            %values = tt.load %float_ptrs : tensor<4x!tt.ptr<f32>>
+            %dst_bases = tt.splat %dst
+                : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+            %dst_ptrs = tt.addptr %dst_bases, %range
+                : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+            tt.store %dst_ptrs, %values : tensor<4x!tt.ptr<f32>>
+            tt.return
+          }
+        }
+    """)
+    assert result.returncode == 0, result.stderr
+    assert "arith.remsi" not in result.stdout, result.stdout
+    assert "triton_assert" not in result.stdout, result.stdout
+    assert "arith.divsi" not in result.stdout, result.stdout
+    assert "builtin.unrealized_conversion_cast" not in result.stdout
+
+
+def test_same_width_bitcast_keeps_dynamic_make_block_ptr_shape(tmp_path):
+    result = _run_pipeline(
+        tmp_path, "same_width_dynamic_block_shape", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @same_width_dynamic_block_shape(
+              %src: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+              %rows: i64, %cols: i64, %row_stride: i64)
+              attributes {noinline = false} {
+            %c0_i32 = arith.constant 0 : i32
+            %c1_i64 = arith.constant 1 : i64
+            %float_src = tt.bitcast %src : !tt.ptr<i32> -> !tt.ptr<f32>
+            %block_ptr = tt.make_tensor_ptr %float_src, [%rows, %cols],
+                [%row_stride, %c1_i64], [%c0_i32, %c0_i32]
+                {order = array<i32: 1, 0>} : <tensor<4x8xf32>>
+            %values = tt.load %block_ptr : !tt.ptr<tensor<4x8xf32>>
+            tt.return
+          }
+        }
+    """)
+    assert result.returncode == 0, result.stderr
+    assert "PointerCastOp requires statically known access sizes" not in (result.stdout + result.stderr)
+
+
+def test_user_int_to_ptr_does_not_gain_pointer_bitcast_provenance(tmp_path):
+    module = r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @user_int_to_ptr(
+              %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+              %value: i32,
+              %cond: i1) attributes {noinline = false} {
+            %address = tt.ptr_to_int %dst : !tt.ptr<i32> -> i64
+            %restored = tt.int_to_ptr %address : i64 -> !tt.ptr<i32>
+            tt.store %restored, %value, %cond : !tt.ptr<i32>
+            tt.return
+          }
+        }
+    """
+    unstructure_result = _run_unstructure(tmp_path, "user_int_to_ptr", module)
+    assert unstructure_result.returncode == 0, unstructure_result.stderr
+    assert "tt.int_to_ptr" in unstructure_result.stdout
+    assert "tt.pointer_bitcast_pointer_cast" not in unstructure_result.stdout
+
+    result = _run_ttolinalg(tmp_path, "user_int_to_ptr_ttolinalg", module)
+    assert result.returncode == 0, result.stderr
+    assert "tt.pointer_bitcast_pointer_cast" not in result.stdout
+
+
+def test_non_byte_addressable_pointee_is_rejected(tmp_path):
+    result = _run_ttolinalg(
+        tmp_path, "non_byte_addressable", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @non_byte_addressable(
+              %src: !tt.ptr<i4> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i16> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %wide_ptr = tt.bitcast %src : !tt.ptr<i4> -> !tt.ptr<i16>
+            %value = tt.load %wide_ptr : !tt.ptr<i16>
+            tt.store %dst, %value : !tt.ptr<i16>
+            tt.return
+          }
+        }
+    """)
+    _assert_clean_failure(result, "byte-addressable")
+
+
+def test_direct_function_argument_different_width_bitcast(tmp_path):
+    result = _run_ttolinalg(
+        tmp_path, "direct_function_argument", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @direct_function_argument(
+              %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %wide_ptr = tt.bitcast %src : !tt.ptr<i8> -> !tt.ptr<i32>
+            %value = tt.load %wide_ptr : !tt.ptr<i32>
+            tt.store %dst, %value : !tt.ptr<i32>
+            tt.return
+          }
+        }
+    """)
+    assert result.returncode == 0, result.stderr
+    assert "arith.remsi" not in result.stdout, result.stdout
+    assert "triton_assert" not in result.stdout, result.stdout
+    assert "arith.divsi" not in result.stdout, result.stdout
+
+
+def test_splat_tensor_pointer_bitcast_is_canonicalized(tmp_path):
+    result = _run_pipeline(
+        tmp_path, "splat_tensor_pointer", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @splat_tensor_pointer(
+              %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %srcs = tt.splat %src
+                : !tt.ptr<i8> -> tensor<4x!tt.ptr<i8>>
+            %wide_ptrs = tt.bitcast %srcs
+                : tensor<4x!tt.ptr<i8>> -> tensor<4x!tt.ptr<i32>>
+            %load_offsets = tt.make_range {start = 0 : i32, end = 4 : i32}
+                : tensor<4xi32>
+            %zero = arith.constant dense<0> : tensor<4xi32>
+            %load_ptrs = tt.addptr %wide_ptrs, %load_offsets
+                : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+            %values = tt.load %load_ptrs : tensor<4x!tt.ptr<i32>>
+            %dsts = tt.splat %dst
+                : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+            %store_ptrs = tt.addptr %dsts, %zero
+                : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+            tt.store %store_ptrs, %values : tensor<4x!tt.ptr<i32>>
+            tt.return
+          }
+        }
+    """)
+    assert result.returncode == 0, result.stderr
+    assert "arith.remsi" not in result.stdout, result.stdout
+    assert "triton_assert" not in result.stdout, result.stdout
+
+
+def test_nested_pointer_bitcasts_are_fused(tmp_path):
+    result = _run_ttolinalg(
+        tmp_path, "nested_pointer_bitcasts", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @nested_pointer_bitcasts(
+              %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %half_ptr = tt.bitcast %src : !tt.ptr<i8> -> !tt.ptr<i16>
+            %word_ptr = tt.bitcast %half_ptr : !tt.ptr<i16> -> !tt.ptr<i32>
+            %value = tt.load %word_ptr : !tt.ptr<i32>
+            tt.store %dst, %value : !tt.ptr<i32>
+            tt.return
+          }
+        }
+    """)
+    assert result.returncode == 0, result.stderr
+    assert "arith.remsi" not in result.stdout, result.stdout
+    assert "triton_assert" not in result.stdout, result.stdout
+
+
+def test_legacy_i1_to_i8_pointer_bitcast_is_unchanged(tmp_path):
+    result = _run_pipeline(
+        tmp_path, "legacy_i1_to_i8", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @legacy_i1_to_i8(
+              %src: !tt.ptr<i1> {tt.divisibility = 16 : i32},
+              %offset_src: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i8> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %byte_ptr = tt.bitcast %src : !tt.ptr<i1> -> !tt.ptr<i8>
+            %range = tt.make_range {start = 0 : i32, end = 4 : i32}
+                : tensor<4xi32>
+            %offset_bases = tt.splat %offset_src
+                : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+            %offset_ptrs = tt.addptr %offset_bases, %range
+                : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+            %offsets = tt.load %offset_ptrs : tensor<4x!tt.ptr<i32>>
+            %byte_bases = tt.splat %byte_ptr
+                : !tt.ptr<i8> -> tensor<4x!tt.ptr<i8>>
+            %byte_ptrs = tt.addptr %byte_bases, %offsets
+                : tensor<4x!tt.ptr<i8>>, tensor<4xi32>
+            %values = tt.load %byte_ptrs : tensor<4x!tt.ptr<i8>>
+            %dst_bases = tt.splat %dst
+                : !tt.ptr<i8> -> tensor<4x!tt.ptr<i8>>
+            %dst_ptrs = tt.addptr %dst_bases, %range
+                : tensor<4x!tt.ptr<i8>>, tensor<4xi32>
+            tt.store %dst_ptrs, %values : tensor<4x!tt.ptr<i8>>
+            tt.return
+          }
+        }
+    """)
+    assert result.returncode == 0, result.stderr
+    assert "arith.remsi" not in result.stdout, result.stdout
+    assert "triton_assert" not in result.stdout, result.stdout
+    assert "arith.divsi" not in result.stdout, result.stdout
+    assert "builtin.unrealized_conversion_cast" not in result.stdout
+
+
+def test_pointer_bitcast_from_i8_to_i1_is_cleanly_rejected(tmp_path):
+    result = _run_ttolinalg(
+        tmp_path, "i8_to_i1", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @i8_to_i1(
+              %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i1> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %bool_ptr = tt.bitcast %src : !tt.ptr<i8> -> !tt.ptr<i1>
+            %value = tt.load %bool_ptr : !tt.ptr<i1>
+            tt.store %dst, %value : !tt.ptr<i1>
+            tt.return
+          }
+        }
+    """)
+    _assert_clean_failure(
+        result,
+        "pointer bitcast to i1 from a different pointee type is unsupported",
+    )
+
+
+def test_tensor_pointer_bitcast_from_i8_to_i1_is_cleanly_rejected(tmp_path):
+    result = _run_unstructure(
+        tmp_path, "tensor_i8_to_i1", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @tensor_i8_to_i1(
+              %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i8> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %range = tt.make_range {start = 0 : i32, end = 4 : i32}
+                : tensor<4xi32>
+            %srcs = tt.splat %src
+                : !tt.ptr<i8> -> tensor<4x!tt.ptr<i8>>
+            %byte_ptrs = tt.addptr %srcs, %range
+                : tensor<4x!tt.ptr<i8>>, tensor<4xi32>
+            %bool_ptrs = tt.bitcast %byte_ptrs
+                : tensor<4x!tt.ptr<i8>> -> tensor<4x!tt.ptr<i1>>
+            %values = tt.load %bool_ptrs : tensor<4x!tt.ptr<i1>>
+            %byte_values = arith.extui %values
+                : tensor<4xi1> to tensor<4xi8>
+            %dsts = tt.splat %dst
+                : !tt.ptr<i8> -> tensor<4x!tt.ptr<i8>>
+            %dst_ptrs = tt.addptr %dsts, %range
+                : tensor<4x!tt.ptr<i8>>, tensor<4xi32>
+            tt.store %dst_ptrs, %byte_values : tensor<4x!tt.ptr<i8>>
+            tt.return
+          }
+        }
+    """)
+    _assert_clean_failure(
+        result,
+        "pointer bitcast to i1 from a different pointee type is unsupported",
+    )
+
+
+def test_address_space_mismatch_is_rejected(tmp_path):
+    result = _run_ttolinalg(
+        tmp_path, "address_space_mismatch", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @address_space_mismatch(
+              %src: !tt.ptr<i8, 0> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i32, 1> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %wide_ptr = tt.bitcast %src : !tt.ptr<i8, 0> -> !tt.ptr<i32, 1>
+            %value = tt.load %wide_ptr : !tt.ptr<i32, 1>
+            tt.store %dst, %value : !tt.ptr<i32, 1>
+            tt.return
+          }
+        }
+    """)
+    _assert_clean_failure(result, "different address spaces")
+
+
+def test_tensor_pointer_argument_without_scalar_root_is_rejected(tmp_path):
+    result = _run_unstructure(
+        tmp_path, "tensor_argument_without_root", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @tensor_argument_without_root(
+              %srcs: tensor<4x!tt.ptr<i8>>,
+              %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %wide_ptrs = tt.bitcast %srcs
+                : tensor<4x!tt.ptr<i8>> -> tensor<4x!tt.ptr<i32>>
+            %zero = arith.constant dense<0> : tensor<4xi32>
+            %load_ptrs = tt.addptr %wide_ptrs, %zero
+                : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+            %values = tt.load %load_ptrs : tensor<4x!tt.ptr<i32>>
+            %dsts = tt.splat %dst
+                : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+            %store_ptrs = tt.addptr %dsts, %zero
+                : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+            tt.store %store_ptrs, %values : tensor<4x!tt.ptr<i32>>
+            tt.return
+          }
+        }
+    """)
+    _assert_clean_failure(result, "requires a scalar root pointer")
+
+
+def test_byte_addressed_pointer_captured_inside_if_is_supported(tmp_path):
+    result = _run_pipeline(
+        tmp_path, "byte_addressed_pointer_if_capture", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @byte_addressed_pointer_if_capture(
+              %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+              %cond: i1) attributes {noinline = false} {
+            %wide_ptr = tt.bitcast %src : !tt.ptr<i8> -> !tt.ptr<i32>
+            %value = scf.if %cond -> (i32) {
+              %then_value = tt.load %wide_ptr : !tt.ptr<i32>
+              scf.yield %then_value : i32
+            } else {
+              %one = arith.constant 1 : i32
+              %else_ptr = tt.addptr %wide_ptr, %one : !tt.ptr<i32>, i32
+              %else_value = tt.load %else_ptr : !tt.ptr<i32>
+              scf.yield %else_value : i32
+            }
+            tt.store %dst, %value : !tt.ptr<i32>
+            tt.return
+          }
+        }
+    """)
+    assert result.returncode == 0, result.stderr
+    assert "scf.if" in result.stdout, result.stdout
+
+
+def test_legacy_pointer_control_flow_without_bitcast_is_unchanged(tmp_path):
+    result = _run_unstructure(
+        tmp_path, "legacy_pointer_control_flow", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @legacy_pointer_control_flow(
+              %src: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+              %upper: i32)
+              attributes {noinline = false} {
+            %c0 = arith.constant 0 : i32
+            %c1 = arith.constant 1 : i32
+            %range = tt.make_range {start = 0 : i32, end = 4 : i32}
+                : tensor<4xi32>
+            %base = tt.splat %src
+                : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+            %initial = tt.addptr %base, %range
+                : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+            %result = scf.for %iv = %c0 to %upper step %c1
+                iter_args(%current = %initial)
+                -> (tensor<4x!tt.ptr<i32>>) : i32 {
+              %next = tt.addptr %current, %range
+                  : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+              scf.yield %next : tensor<4x!tt.ptr<i32>>
+            }
+            %values = tt.load %result : tensor<4x!tt.ptr<i32>>
+            %dsts = tt.splat %dst
+                : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+            %dst_ptrs = tt.addptr %dsts, %range
+                : tensor<4x!tt.ptr<i32>>, tensor<4xi32>
+            tt.store %dst_ptrs, %values : tensor<4x!tt.ptr<i32>>
+            tt.return
+          }
+        }
+    """)
+    assert result.returncode == 0, result.stderr
+    assert "scf.for" in result.stdout, result.stdout
+    assert "tt.pointer_bitcast_pointer_cast" not in result.stdout
+
+
+def test_different_width_pointer_from_control_flow_is_rejected(tmp_path):
+    result = _run_ttolinalg(
+        tmp_path, "control_flow_pointer_source", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @control_flow_pointer_source(
+              %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+              %cond: i1) attributes {noinline = false} {
+            %four = arith.constant 4 : i32
+            %eight = arith.constant 8 : i32
+            %selected = scf.if %cond -> (!tt.ptr<i8>) {
+              %then_ptr = tt.addptr %src, %four : !tt.ptr<i8>, i32
+              scf.yield %then_ptr : !tt.ptr<i8>
+            } else {
+              %else_ptr = tt.addptr %src, %eight : !tt.ptr<i8>, i32
+              scf.yield %else_ptr : !tt.ptr<i8>
+            }
+            %wide_ptr = tt.bitcast %selected
+                : !tt.ptr<i8> -> !tt.ptr<i32>
+            %value = tt.load %wide_ptr : !tt.ptr<i32>
+            tt.store %dst, %value : !tt.ptr<i32>
+            tt.return
+          }
+        }
+    """)
+    _assert_clean_failure(
+        result,
+        "cannot preserve the exact address from unsupported producer 'scf.if'",
+    )
+
+
+def test_different_width_pointer_from_private_helper_argument_is_rejected(tmp_path):
+    result = _run_ttolinalg(
+        tmp_path, "private_helper_pointer_source", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func private @private_helper_pointer_source(
+              %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32}) {
+            %wide_ptr = tt.bitcast %src : !tt.ptr<i8> -> !tt.ptr<i32>
+            %value = tt.load %wide_ptr : !tt.ptr<i32>
+            tt.store %dst, %value : !tt.ptr<i32>
+            tt.return
+          }
+        }
+    """)
+    _assert_clean_failure(
+        result,
+        "requires a public kernel argument",
+    )
+
+
+def test_pointer_if_with_different_roots_is_rejected(tmp_path):
+    result = _run_unstructure(
+        tmp_path, "pointer_if_different_roots", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @pointer_if_different_roots(
+              %left: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %right: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %cond: i1) attributes {noinline = false} {
+            %left_wide = tt.bitcast %left : !tt.ptr<i8> -> !tt.ptr<i32>
+            %right_wide = tt.bitcast %right : !tt.ptr<i8> -> !tt.ptr<i32>
+            %left_ptrs = tt.splat %left_wide
+                : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+            %right_ptrs = tt.splat %right_wide
+                : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+            %selected = scf.if %cond -> (tensor<4x!tt.ptr<i32>>) {
+              scf.yield %left_ptrs : tensor<4x!tt.ptr<i32>>
+            } else {
+              scf.yield %right_ptrs : tensor<4x!tt.ptr<i32>>
+            }
+            %values = tt.load %selected : tensor<4x!tt.ptr<i32>>
+            tt.return
+          }
+        }
+    """)
+    _assert_clean_failure(
+        result,
+        "byte-addressed pointer cannot cross structured control flow",
+    )
+
+
+def test_pointer_if_with_different_address_units_is_rejected(tmp_path):
+    result = _run_unstructure(
+        tmp_path, "pointer_if_different_units", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @pointer_if_different_units(
+              %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %cond: i1) attributes {noinline = false} {
+            %element_ptrs = tt.splat %src
+                : !tt.ptr<i8> -> tensor<4x!tt.ptr<i8>>
+            %wide_ptrs = tt.bitcast %element_ptrs
+                : tensor<4x!tt.ptr<i8>> -> tensor<4x!tt.ptr<i32>>
+            %byte_ptrs = tt.bitcast %wide_ptrs
+                : tensor<4x!tt.ptr<i32>> -> tensor<4x!tt.ptr<i8>>
+            %selected = scf.if %cond -> (tensor<4x!tt.ptr<i8>>) {
+              scf.yield %byte_ptrs : tensor<4x!tt.ptr<i8>>
+            } else {
+              scf.yield %element_ptrs : tensor<4x!tt.ptr<i8>>
+            }
+            %values = tt.load %selected : tensor<4x!tt.ptr<i8>>
+            tt.return
+          }
+        }
+    """)
+    _assert_clean_failure(
+        result,
+        "byte-addressed pointer cannot cross structured control flow",
+    )
+
+
+def test_for_carried_pointer_with_different_roots_is_rejected(tmp_path):
+    result = _run_unstructure(
+        tmp_path, "for_pointer_different_roots", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @for_pointer_different_roots(
+              %left: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %right: !tt.ptr<i8> {tt.divisibility = 16 : i32})
+              attributes {noinline = false} {
+            %c0 = arith.constant 0 : i32
+            %c1 = arith.constant 1 : i32
+            %left_wide = tt.bitcast %left : !tt.ptr<i8> -> !tt.ptr<i32>
+            %right_wide = tt.bitcast %right : !tt.ptr<i8> -> !tt.ptr<i32>
+            %left_ptrs = tt.splat %left_wide
+                : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+            %right_ptrs = tt.splat %right_wide
+                : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
+            %result = scf.for %iv = %c0 to %c1 step %c1
+                iter_args(%current = %left_ptrs)
+                -> (tensor<4x!tt.ptr<i32>>) : i32 {
+              scf.yield %right_ptrs : tensor<4x!tt.ptr<i32>>
+            }
+            %values = tt.load %result : tensor<4x!tt.ptr<i32>>
+            tt.return
+          }
+        }
+    """)
+    _assert_clean_failure(
+        result,
+        "byte-addressed pointer cannot cross structured control flow",
+    )
+
+
+def test_while_carried_pointer_with_different_address_units_is_rejected(tmp_path):
+    result = _run_unstructure(
+        tmp_path, "while_pointer_different_units", r"""
+        module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+          tt.func public @while_pointer_different_units(
+              %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+              %cond: i1) attributes {noinline = false} {
+            %element_ptrs = tt.splat %src
+                : !tt.ptr<i8> -> tensor<4x!tt.ptr<i8>>
+            %wide_ptr = tt.bitcast %src : !tt.ptr<i8> -> !tt.ptr<i32>
+            %byte_ptr = tt.bitcast %wide_ptr : !tt.ptr<i32> -> !tt.ptr<i8>
+            %byte_ptrs = tt.splat %byte_ptr
+                : !tt.ptr<i8> -> tensor<4x!tt.ptr<i8>>
+            %result = scf.while (%current = %element_ptrs)
+                : (tensor<4x!tt.ptr<i8>>) -> (tensor<4x!tt.ptr<i8>>) {
+              scf.condition(%cond) %current : tensor<4x!tt.ptr<i8>>
+            } do {
+            ^bb0(%current_after: tensor<4x!tt.ptr<i8>>):
+              scf.yield %byte_ptrs : tensor<4x!tt.ptr<i8>>
+            }
+            %values = tt.load %result : tensor<4x!tt.ptr<i8>>
+            tt.return
+          }
+        }
+    """)
+    _assert_clean_failure(
+        result,
+        "byte-addressed pointer cannot cross structured control flow",
+    )

--- a/third_party/ascend/unittest/pytest_ut/test_pointer_bitcast_real_world.py
+++ b/third_party/ascend/unittest/pytest_ut/test_pointer_bitcast_real_world.py
@@ -1,0 +1,170 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import struct
+
+import torch
+import torch_npu
+import triton
+import triton.language as tl
+
+
+def _sync_npu():
+    if hasattr(torch, "npu"):
+        torch.npu.synchronize()
+
+
+def _write_u32_le(buf, byte_offsets, values):
+    for byte_offset, value in zip(byte_offsets, values):
+        value = int(value)
+        for byte_idx in range(4):
+            buf[int(byte_offset) + byte_idx] = (value >> (8 * byte_idx)) & 0xFF
+
+
+def _float_to_bf16_bits(value):
+    f32_bits = struct.unpack("<I", struct.pack("<f", float(value)))[0]
+    return f32_bits >> 16
+
+
+def _write_bf16_le(buf, byte_offset, values):
+    for idx, value in enumerate(values):
+        bits = _float_to_bf16_bits(value)
+        buf[int(byte_offset) + idx * 2] = bits & 0xFF
+        buf[int(byte_offset) + idx * 2 + 1] = (bits >> 8) & 0xFF
+
+
+@triton.jit
+def _load_u32_from_u8_tensor_offsets(src, out, n_elements, BASE: tl.constexpr, BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    mask = lanes < n_elements
+    byte_offsets = BASE + lanes * 4
+    u32_ptrs = (src + byte_offsets).to(tl.pointer_type(tl.uint32, 1), bitcast=True)
+    values = tl.load(u32_ptrs, mask=mask, other=0).to(tl.int32)
+    tl.store(out + lanes, values)
+
+
+@triton.jit
+def _load_bf16_from_u8_multi_addptr(src, out, block_idx, token_pos, block_stride, N: tl.constexpr,
+                                    TOKEN_BYTES: tl.constexpr, BF16_OFFSET: tl.constexpr, BLOCK: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    hinted_stride = tl.multiple_of(block_stride, 16)
+    block_base = src + block_idx * hinted_stride
+    token_fp8_ptr = block_base + token_pos * TOKEN_BYTES
+    bf16_ptr = (token_fp8_ptr + BF16_OFFSET).to(tl.pointer_type(tl.bfloat16))
+    values = tl.load(bf16_ptr + lanes, mask=lanes < N, other=0.0)
+    tl.store(out + lanes, values, mask=lanes < N)
+
+
+@triton.jit
+def _load_bf16_from_u8_inside_loop(src, out, count, NOPE_DIM: tl.constexpr, TOKEN_BYTES: tl.constexpr,
+                                   ROPE_DIM: tl.constexpr, BLOCK: tl.constexpr, NUM_WORKERS: tl.constexpr):
+    worker = tl.program_id(0)
+    lanes = tl.arange(0, BLOCK)
+    mask = lanes < ROPE_DIM
+    for token_idx in range(worker, count, NUM_WORKERS):
+        token_data = src + token_idx * TOKEN_BYTES
+        bf16_ptr = (token_data + NOPE_DIM).to(tl.pointer_type(tl.bfloat16))
+        values = tl.load(bf16_ptr + lanes, mask=mask, other=0.0)
+        tl.store(out + token_idx * ROPE_DIM + lanes, values, mask=mask)
+
+
+def test_load_uint32_scale_words_from_uint8_tensor_offsets():
+    block = 32
+    n_words = 17
+    base = 16
+    values = [0x01020304 + idx * 0x00010101 for idx in range(n_words)]
+    host = torch.zeros(base + block * 4, dtype=torch.uint8, device="cpu")
+    _write_u32_le(host, [base + idx * 4 for idx in range(n_words)], values)
+
+    src = host.npu()
+    out = torch.empty((block, ), device="npu", dtype=torch.int32)
+
+    _load_u32_from_u8_tensor_offsets[(1, )](src, out, n_words, BASE=base, BLOCK=block)
+    _sync_npu()
+
+    expected = torch.zeros((block, ), dtype=torch.int32, device="cpu")
+    expected[:n_words] = torch.tensor(values, dtype=torch.int32, device="cpu")
+    torch.testing.assert_close(out.cpu(), expected, rtol=0, atol=0)
+
+
+def test_load_bf16_rope_region_from_uint8_multi_addptr():
+    block_idx = 1
+    token_pos = 2
+    block_stride = 2048
+    token_bytes = 576
+    bf16_offset = 448
+    n_values = 16
+    base = block_idx * block_stride + token_pos * token_bytes + bf16_offset
+    values = [float(idx + 1) for idx in range(n_values)]
+
+    host = torch.zeros(base + n_values * 2 + 64, dtype=torch.uint8, device="cpu")
+    _write_bf16_le(host, base, values)
+
+    src = host.npu()
+    out = torch.empty((n_values, ), device="npu", dtype=torch.bfloat16)
+
+    _load_bf16_from_u8_multi_addptr[(1, )](
+        src,
+        out,
+        block_idx,
+        token_pos,
+        block_stride,
+        N=n_values,
+        TOKEN_BYTES=token_bytes,
+        BF16_OFFSET=bf16_offset,
+        BLOCK=32,
+    )
+    _sync_npu()
+
+    expected = torch.tensor(values, dtype=torch.float32, device="cpu").to(torch.bfloat16)
+    torch.testing.assert_close(out.cpu(), expected, rtol=0, atol=0)
+
+
+def test_load_bf16_rope_region_from_uint8_inside_dynamic_loop():
+    token_count = 5
+    nope_dim = 448
+    rope_dim = 8
+    token_bytes = 576
+    num_workers = 2
+    host = torch.zeros(token_count * token_bytes, dtype=torch.uint8, device="cpu")
+    expected_values = []
+
+    for token_idx in range(token_count):
+        values = [float(token_idx * rope_dim + idx + 1) for idx in range(rope_dim)]
+        expected_values.extend(values)
+        _write_bf16_le(host, token_idx * token_bytes + nope_dim, values)
+
+    src = host.npu()
+    out = torch.empty((token_count * rope_dim, ), device="npu", dtype=torch.bfloat16)
+
+    _load_bf16_from_u8_inside_loop[(num_workers, )](
+        src,
+        out,
+        token_count,
+        NOPE_DIM=nope_dim,
+        TOKEN_BYTES=token_bytes,
+        ROPE_DIM=rope_dim,
+        BLOCK=16,
+        NUM_WORKERS=num_workers,
+    )
+    _sync_npu()
+
+    expected = torch.tensor(expected_values, dtype=torch.float32, device="cpu").to(torch.bfloat16)
+    torch.testing.assert_close(out.cpu(), expected, rtol=0, atol=0)


### PR DESCRIPTION
## Summary

- Preserve exact byte addresses when pointer bitcasts change the pointee width.
- Keep offsets before and after the bitcast in their respective pointee units, without inserting divisibility or alignment checks.
- Cover scalar and tensor pointer load/store/atomic paths with Lit and pytest tests.

## IR example

Before:

```mlir
%byte_ptr = tt.addptr %src, %pre_bytes : !tt.ptr<i8>, i32
%wide_ptr = tt.bitcast %byte_ptr : !tt.ptr<i8> -> !tt.ptr<i32>
%final_ptr = tt.addptr %wide_ptr, %post_elements : !tt.ptr<i32>, i32
```

After lowering (simplified):

```mlir
%byte_addr = arith.addi %base_addr, %pre_bytes_i64 : i64
%post_bytes = arith.muli %post_elements_i64, %c4_i64 : i64
%final_addr = arith.addi %byte_addr, %post_bytes : i64
%typed_ptr = hivm.hir.pointer_cast %final_addr ... : memref<?xi32>
```

This preserves `base + pre_bytes + post_elements * 4` exactly and does not generate `arith.divsi`, `arith.remsi`, or a runtime alignment assertion.
