### PR TITLE
[test](chore) annotate abs reference helper

### DIFF
--- a/third_party/ascend/unittest/pytest_ut/test_abs.py
+++ b/third_party/ascend/unittest/pytest_ut/test_abs.py
@@ -27,6 +27,7 @@ import test_common
 
 
 def torch_pointwise(x0):
+    # Absolute value is an identity for unsigned tensor elements.
     if x0.dtype in [torch.uint8, torch.uint16, torch.uint32, torch.uint64]:
         return x0
     res = torch.abs(x0)


### PR DESCRIPTION
## Summary

- Add a non-functional comment to the Ascend absolute-value test reference helper.
- Keep the test and runtime behavior unchanged.
- Open this draft solely to exercise the `main`-branch PR gates; it is not intended for merge.

## Validation

- Targeted pre-commit hooks: trailing-whitespace, end-of-file-fixer, check-merge-conflict, check-ast, detect-private-key, and yapf.
- `git diff --check`
