### PR TITLE
[build](feat) Added build entry setup_ascend.py

### DIFF
--- a/.github/workflows/Ascend950-wheels-build.yml
+++ b/.github/workflows/Ascend950-wheels-build.yml
@@ -82,8 +82,22 @@ jobs:
           ccache --zero-stats
           NUM_PROCS=$(( $(nproc) / 3 ))
           if [ "$NUM_PROCS" -lt 1 ]; then NUM_PROCS=1; fi
+          if [ -f setup_ascend.py ]; then
+            SETUP_DIR="./"
+            SETUP_PY="setup_ascend.py"
+          elif [ -f setup.py ]; then
+            SETUP_DIR="./"
+            SETUP_PY="setup.py"
+          elif [ -f python/setup.py ]; then
+            SETUP_DIR="python"
+            SETUP_PY="setup.py"
+          else
+            echo "ERROR: setup.py or setup_ascend.py not found" >&2
+            exit 1
+          fi
+          cd "$SETUP_DIR"
           MAX_JOBS="$NUM_PROCS" \
-          python setup.py bdist_wheel --dist-dir=./wheelhouse
+          python ${SETUP_PY} bdist_wheel --dist-dir=./wheelhouse
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/DynamicCVPipeline-ci.yml
+++ b/.github/workflows/DynamicCVPipeline-ci.yml
@@ -78,7 +78,21 @@ jobs:
           NUM_PROCS=$(( $(nproc) / 3 ))
           if [ "$NUM_PROCS" -lt 1 ]; then NUM_PROCS=1; fi
           cd base
-          MAX_JOBS="$NUM_PROCS" python setup.py bdist_wheel --dist-dir="${GITHUB_WORKSPACE}/base/wheelhouse"
+          if [ -f setup_ascend.py ]; then
+            SETUP_DIR="./"
+            SETUP_PY="setup_ascend.py"
+          elif [ -f setup.py ]; then
+            SETUP_DIR="./"
+            SETUP_PY="setup.py"
+          elif [ -f python/setup.py ]; then
+            SETUP_DIR="python"
+            SETUP_PY="setup.py"
+          else
+            echo "ERROR: setup.py or setup_ascend.py not found" >&2
+            exit 1
+          fi
+          cd "$SETUP_DIR"
+          MAX_JOBS="$NUM_PROCS" python ${SETUP_PY} bdist_wheel --dist-dir="${GITHUB_WORKSPACE}/base/wheelhouse"
 
       - name: Build triton-ascend pr
         shell: bash
@@ -98,7 +112,21 @@ jobs:
           NUM_PROCS=$(( $(nproc) / 3 ))
           if [ "$NUM_PROCS" -lt 1 ]; then NUM_PROCS=1; fi
           cd pr
-          MAX_JOBS="$NUM_PROCS" python setup.py bdist_wheel --dist-dir="${GITHUB_WORKSPACE}/pr/wheelhouse"
+          if [ -f setup_ascend.py ]; then
+            SETUP_DIR="./"
+            SETUP_PY="setup_ascend.py"
+          elif [ -f setup.py ]; then
+            SETUP_DIR="./"
+            SETUP_PY="setup.py"
+          elif [ -f python/setup.py ]; then
+            SETUP_DIR="python"
+            SETUP_PY="setup.py"
+          else
+            echo "ERROR: setup.py or setup_ascend.py not found" >&2
+            exit 1
+          fi
+          cd "$SETUP_DIR"
+          MAX_JOBS="$NUM_PROCS" python ${SETUP_PY} bdist_wheel --dist-dir="${GITHUB_WORKSPACE}/pr/wheelhouse"
 
       - name: generate ttadapter
         shell: bash

--- a/.github/workflows/integration-tests-ascend.yml
+++ b/.github/workflows/integration-tests-ascend.yml
@@ -102,8 +102,22 @@ jobs:
           ccache --zero-stats
           NUM_PROCS=$(( $(nproc) / 3 ))
           if [ "$NUM_PROCS" -lt 1 ]; then NUM_PROCS=1; fi
+          if [ -f setup_ascend.py ]; then
+            SETUP_DIR="./"
+            SETUP_PY="setup_ascend.py"
+          elif [ -f setup.py ]; then
+            SETUP_DIR="./"
+            SETUP_PY="setup.py"
+          elif [ -f python/setup.py ]; then
+            SETUP_DIR="python"
+            SETUP_PY="setup.py"
+          else
+            echo "ERROR: setup.py or setup_ascend.py not found" >&2
+            exit 1
+          fi
+          cd "$SETUP_DIR"
           MAX_JOBS="$NUM_PROCS" \
-          ${PYTHON} setup.py bdist_wheel
+          ${PYTHON} ${SETUP_PY} bdist_wheel
           ${PYTHON} -m pip install dist/*.whl
 
       - name: CCache stats

--- a/init_code.py
+++ b/init_code.py
@@ -1,0 +1,7 @@
+from setup_ascend import _get_triton_ascend_patch_file, _checkout_file
+
+patch_files, dev_patch_files = _get_triton_ascend_patch_file()
+if dev_patch_files:
+    _checkout_file(dev_patch_files)
+if patch_files:
+    _checkout_file(patch_files)

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,6 @@ import tarfile
 import zipfile
 import urllib.request
 import json
-import glob
-
 from io import BytesIO
 from distutils.command.clean import clean
 from pathlib import Path
@@ -46,15 +44,6 @@ except ImportError:
 sys.path.insert(0, os.path.dirname(__file__))
 
 from python.build_helpers import get_base_dir, get_cmake_dir
-
-triton_dir = os.path.dirname(os.path.abspath(__file__))
-
-os.environ.setdefault("TRITON_BUILD_WITH_CCACHE", "true")
-os.environ.setdefault("TRITON_BUILD_WITH_CLANG_LLD", "true")
-os.environ.setdefault("TRITON_BUILD_PROTON", "OFF")
-os.environ.setdefault("TRITON_BUILD_TD", "OFF")
-os.environ.setdefault("TRITON_WHEEL_NAME", "triton-ascend")
-os.environ.setdefault("TRITON_APPEND_CMAKE_ARGS", "-DTRITON_BUILD_UT=OFF")
 
 
 def is_git_repo():
@@ -196,31 +185,12 @@ def get_json_package_info():
     return Package("json", "", url, "JSON_INCLUDE_DIR", "", "JSON_SYSPATH")
 
 
-def is_linux_os(os_id):
+def is_linux_os(id):
     if os.path.exists("/etc/os-release"):
         with open("/etc/os-release", "r") as f:
             os_release_content = f.read()
-            return f'ID="{os_id}"' in os_release_content
+            return f'ID="{id}"' in os_release_content
     return False
-
-
-def get_llvm_patch_hash():
-    """Compute a hash of LLVM patch files under third_party/ascend/patch."""
-    patch_dir = os.path.join(get_base_dir(), "third_party", "ascend", "patch")
-    if os.path.isdir(patch_dir):
-        patch_files = sorted(
-            f for f in os.listdir(patch_dir)
-            if f.startswith("llvm_patch_") and f.endswith(".patch") and os.path.isfile(os.path.join(patch_dir, f)))
-    else:
-        patch_files = []
-    if not patch_files:
-        return "00000000"
-    import hashlib
-    h = hashlib.sha256()
-    for pf in patch_files:
-        with open(os.path.join(patch_dir, pf), "rb") as f:
-            h.update(f.read())
-    return h.hexdigest()[:8]
 
 
 # llvm
@@ -237,7 +207,7 @@ def get_llvm_package_info():
     elif system == "Linux":
         if arch == 'arm64' and is_linux_os('almalinux'):
             system_suffix = 'almalinux-arm64'
-        elif arch == "arm64":
+        elif arch == 'arm64':
             system_suffix = 'ubuntu-arm64'
         elif arch == 'x64':
             vglibc = tuple(map(int, platform.libc_ver()[1].split('.')))
@@ -266,11 +236,10 @@ def get_llvm_package_info():
     llvm_hash_path = os.path.join(get_base_dir(), "cmake", "llvm-hash.txt")
     with open(llvm_hash_path, "r") as llvm_hash_file:
         rev = llvm_hash_file.read(8)
-    patch_hash = get_llvm_patch_hash()
-    name = f"llvm-{rev}-{patch_hash}-{system_suffix}"
+    name = f"llvm-{rev}-{system_suffix}"
     # Create a stable symlink that doesn't include revision
     sym_name = f"llvm-{system_suffix}"
-    url = f"https://triton-ascend-artifacts.obs.myhuaweicloud.com/llvm-builds/{name}.tar.gz"
+    url = f"https://oaitriton.blob.core.windows.net/public/llvm-builds/{name}.tar.gz"
     return Package("llvm", name, url, "LLVM_INCLUDE_DIRS", "LLVM_LIBRARY_DIR", "LLVM_SYSPATH", sym_name=sym_name)
 
 
@@ -424,6 +393,7 @@ class CMakeExtension(Extension):
 
 
 class CMakeBuild(build_ext):
+
     user_options = build_ext.user_options + \
         [('base-dir=', None, 'base directory of Triton')]
 
@@ -434,66 +404,8 @@ class CMakeBuild(build_ext):
     def finalize_options(self):
         build_ext.finalize_options(self)
 
-    def setup_coverage_env(self):
-        """Setting environment variables required for the hitest coverage tool"""
-        # To enable the hitest cov tool, you need to set the following three environment variables.
-        hitest_home = os.getenv('HITEST_HOME', '/opt/hitest/linux_avatar_x86_64')
-        hitest_user_account = os.getenv('HITEST_USER_ACCOUNT', 'a00000000')
-        lltcov_rootpath = os.getenv('LLTCOV_ROOTPATH', '/opt/covdata')  # Path to the output coverage binary file
-
-        # hitest default environment variables
-        coverage_env_vars = {
-            'HitestHome': hitest_home,
-            'isOverlappedCompile': '0',
-            'PlatformToken': 'BOARD',
-            'gcovmode': '0',
-            'TimerPolicy': '1',
-            'TimeInterval': '60',
-            'SignalPolicy': '1',
-            'SignalNUM': '34',
-            'lltwrapper_cfg': '0',
-            'HITEST_AGENT_INSIDE': '1',
-            'USE_HLLT_COVERAGE': '1',
-            'USE_HLLT_TESTCASE': '0',
-            'simplemode': '0',
-            'ncs_coverage_stub_mold': '1',
-            'HITEST_ENABLE_SOKCET': '0',
-            'hitest_disable_cfg': '0',
-            'hitest_disable_dfg': '1',
-            'hitest_disable_ir': '1',
-            'HITEST_DISABLE_MACRO': '0',
-            'HITEST_REMOVE_INCLUDE_DIR': '0',
-            'HITEST_AGENT_SET_THREADNAME_PRCTL': '1',
-            'HITEST_INST_HEADER_FILE': '0',
-            'HITEST_USER_ACCOUNT': hitest_user_account,
-            'lltcovRootpath': lltcov_rootpath,
-            'HITEST_COVSTUB_ROOT_DIR': f'{hitest_home}/apache-tomcat-8.0.39/webapps/datasource/Container_Default/base',
-            'HITEST_EXEC_CMD_WITH_FILE': '1',
-            'HITEST_PRINT_LOG_ENABLE': '1',
-        }
-
-        for key, value in coverage_env_vars.items():
-            os.environ[key] = value
-
-        current_path = os.environ.get('PATH', '')
-        os.environ['PATH'] = f'{hitest_home}:{current_path}'
-
-        current_ld_path = os.environ.get('LD_LIBRARY_PATH', '')
-        os.environ['LD_LIBRARY_PATH'] = f'{hitest_home}:{current_ld_path}'
-
-        print(f"The currently set environment variables for the hitest coverage tool are read.")
-        print(f"  HitestHome: {hitest_home} (environment variables HITEST_HOME)")
-        print(f"  HITEST_USER_ACCOUNT: {hitest_user_account} (environment variables HITEST_USER_ACCOUNT)")
-        print(f"  lltcovRootpath: {lltcov_rootpath} (environment variables LLTCOV_ROOTPATH)")
-
-        current_path = os.environ.get('PATH', '')
-        os.environ['PATH'] = f'{hitest_home}:{current_path}'
-        current_ld_path = os.environ.get('LD_LIBRARY_PATH', '')
-        os.environ['LD_LIBRARY_PATH'] = f'{hitest_home}:{current_ld_path}'
-
     def run(self):
-        #download_and_copy_dependencies()
-        apply_triton_ascend_patch()
+        download_and_copy_dependencies()
 
         try:
             out = subprocess.check_output(["cmake", "--version"])
@@ -505,21 +417,6 @@ class CMakeBuild(build_ext):
         cmake_major, cmake_minor = int(match.group("major")), int(match.group("minor"))
         if (cmake_major, cmake_minor) < (3, 20):
             raise RuntimeError("CMake >= 3.20 is required")
-
-        # To enable the hitest coverage tool, you need to set the environment variable TRITON_ENABLE_COVERAGE_HITEST=1
-        enable_hitest = os.getenv('TRITON_ENABLE_COVERAGE_HITEST', '0').lower() in ('1', 'on', 'true')
-        if enable_hitest:
-            self.setup_coverage_env()
-            current_append = os.environ.get('TRITON_APPEND_CMAKE_ARGS', '')
-            if current_append:
-                os.environ['TRITON_APPEND_CMAKE_ARGS'] = current_append + " -DTRITON_ENABLE_COVERAGE_HITEST=ON"
-            else:
-                os.environ['TRITON_APPEND_CMAKE_ARGS'] = "-DTRITON_ENABLE_COVERAGE_HITEST=ON"
-        else:
-            # clean up existing HITEST_* environment variables to avoid pollution.
-            for key in list(os.environ.keys()):
-                if key.startswith('HITEST_') or key in ['HitestHome', 'lltcovRootpath']:
-                    del os.environ[key]
 
         for ext in self.extensions:
             self.build_extension(ext)
@@ -568,7 +465,7 @@ class CMakeBuild(build_ext):
             "-DPython3_EXECUTABLE:FILEPATH=" + sys.executable, "-DPython3_INCLUDE_DIR=" + python_include_dir,
             "-DTRITON_CODEGEN_BACKENDS=" + ';'.join([b.name for b in backends if not b.is_external]),
             "-DTRITON_PLUGIN_DIRS=" + ';'.join([b.src_dir for b in backends if b.is_external]),
-            "-DTRITON_WHEEL_DIR=" + wheeldir, "-DLLVM_MAJOR_VERSION_22_COMPATIBLE=ON"
+            "-DTRITON_WHEEL_DIR=" + wheeldir
         ]
         if lit_dir is not None:
             cmake_args.append("-DLLVM_EXTERNAL_LIT=" + lit_dir)
@@ -620,19 +517,9 @@ class CMakeBuild(build_ext):
         if check_env_flag("TRITON_BUILD_PROTON", "ON"):  # Default ON
             cmake_args += self.get_proton_cmake_args()
 
-        if check_env_flag("TRITON_BUILD_TD", "OFF"):
-            cmake_args += ["-DTRITON_BUILD_TD=ON"]
-        else:
-            cmake_args += ["-DTRITON_BUILD_TD=OFF"]
-
         if is_offline_build():
             # unit test builds fetch googletests from GitHub
             cmake_args += ["-DTRITON_BUILD_UT=OFF"]
-
-        # Allow specifying AscendNPU-IR tag/commit via environment variable
-        ascendnpu_ir_tag = os.getenv("ASCENDNPU_IR_TAG")
-        if ascendnpu_ir_tag is not None:
-            cmake_args += [f"-DASCENDNPU_IR_TAG={ascendnpu_ir_tag}"]
 
         cmake_args_append = os.getenv("TRITON_APPEND_CMAKE_ARGS")
         if cmake_args_append is not None:
@@ -644,96 +531,6 @@ class CMakeBuild(build_ext):
         update_symlink(Path(self.base_dir) / "compile_commands.json", cmake_dir / "compile_commands.json")
         subprocess.check_call(["cmake", "--build", "."] + build_args, cwd=cmake_dir)
         subprocess.check_call(["cmake", "--build", ".", "--target", "mlir-doc"], cwd=cmake_dir)
-
-        # Copy triton-mlir-opt tool to extdir for runtime use
-        # This tool is needed for converting MLIR to Bytecode
-        triton_mlir_opt_src = os.path.join(cmake_dir, "third_party", "ascend", "bin", "triton-mlir-opt")
-        if os.path.exists(triton_mlir_opt_src):
-            triton_mlir_opt_dst = os.path.join(extdir, "triton-mlir-opt")
-            shutil.copy2(triton_mlir_opt_src, triton_mlir_opt_dst)
-            # Make it executable (Unix-like systems)
-            if platform.system() != "Windows":
-                os.chmod(triton_mlir_opt_dst, 0o755)
-                # Strip debug symbols to reduce binary size (can reduce size by ~80%)
-                try:
-                    subprocess.check_call(["strip", "--strip-all", triton_mlir_opt_dst])
-                    print(f"Stripped triton-mlir-opt to reduce size")
-                except (subprocess.CalledProcessError, FileNotFoundError):
-                    # strip command not available or failed, continue without stripping
-                    pass
-            print(f"Copied triton-mlir-opt to {triton_mlir_opt_dst}")
-
-        # Copy triton-opt tool to extdir for runtime use
-        # This tool is needed for converting ttir to ttadapter
-        triton_opt_src = os.path.join(cmake_dir, "bin", "triton-opt")
-        if os.path.exists(triton_opt_src):
-            triton_opt_dst = os.path.join(extdir, "triton-opt")
-            shutil.copy2(triton_opt_src, triton_opt_dst)
-            # Make it executable (Unix-like systems)
-            if platform.system() != "Windows":
-                os.chmod(triton_opt_dst, 0o755)
-                # Strip debug symbols to reduce binary size (can reduce size by ~80%)
-                try:
-                    subprocess.check_call(["strip", "--strip-all", triton_opt_dst])
-                    print(f"Stripped triton-opt to reduce size")
-                except (subprocess.CalledProcessError, FileNotFoundError):
-                    # strip command not available or failed, continue without stripping
-                    pass
-            print(f"Copied triton-opt to {triton_opt_dst}")
-
-
-def add_git_safe_dir(path: str):
-    safe_dirs = subprocess.run([
-        "git",
-        "config",
-        "--global",
-        "--get-all",
-        "safe.directory",
-    ], capture_output=True, text=True, cwd=Path(triton_dir)).stdout.strip().splitlines()
-
-    if path not in safe_dirs:
-        subprocess.check_call([
-            "git",
-            "config",
-            "--global",
-            "--add",
-            "safe.directory",
-            path,
-        ], cwd=Path(triton_dir))
-
-
-def ensure_distributed_submodule():
-    if not check_env_flag("TRITON_BUILD_TD", "OFF"):
-        return
-    distributed_dir = Path(triton_dir) / "third_party" / "ascend" / "Triton-distributed-ascend"
-    commit_id = "d2ac268c7ab4dc09865ed51638104ee1b97dc460"
-    if not distributed_dir.is_dir():
-        subprocess.check_call([
-            "git",
-            "clone",
-            "https://gitcode.com/Ascend/Triton-distributed-ascend.git",
-            "-b",
-            "master",
-        ], cwd=Path(triton_dir) / "third_party" / "ascend")
-    if is_git_repo():
-        add_git_safe_dir(str(distributed_dir))
-        subprocess.check_call([
-            "git",
-            "checkout",
-            commit_id,
-        ], cwd=distributed_dir)
-
-        result = subprocess.run([
-            "git",
-            "rev-parse",
-            "HEAD",
-        ], capture_output=True, text=True, cwd=distributed_dir)
-        current_id = result.stdout.strip()
-        if current_id != commit_id:
-            raise RuntimeError(f"Triton-Distributed submodule is not {commit_id}")
-
-
-ensure_distributed_submodule()
 
 
 def download_and_copy_dependencies():
@@ -822,7 +619,7 @@ def download_and_copy_dependencies():
     )
 
 
-backends = [*BackendInstaller.copy(["ascend", "nvidia", "amd"]), *BackendInstaller.copy_externals()]
+backends = [*BackendInstaller.copy(["nvidia", "amd"]), *BackendInstaller.copy_externals()]
 
 
 def get_package_dirs():
@@ -851,10 +648,6 @@ def get_package_dirs():
         yield ("triton.profiler", "third_party/proton/proton")
         yield ("triton.profiler.hooks", "third_party/proton/proton/hooks")
 
-    if check_env_flag("TRITON_BUILD_TD", "OFF"):
-        yield ("triton_dist", os.path.join("third_party", "ascend", "Triton-distributed-ascend", "python",
-                                           "triton_dist"))
-
 
 def get_packages():
     yield from find_packages(where="python")
@@ -876,19 +669,6 @@ def get_packages():
 
     if check_env_flag("TRITON_BUILD_PROTON", "ON"):  # Default ON
         yield "triton.profiler"
-
-    if check_env_flag("TRITON_BUILD_TD", "OFF"):
-        distributed_pkg_root = os.path.join("third_party", "ascend", "Triton-distributed-ascend", "python",
-                                            "triton_dist")
-        if os.path.isdir(distributed_pkg_root):
-            # Walk the directory tree directly. find_packages() cannot reach
-            # this subtree (it lives outside of `python/`) and would also
-            # silently drop PEP 420 namespace packages such as
-            # `triton_dist/language/extra/` which only contain loose .py files.
-            for dirpath, _dirnames, filenames in os.walk(distributed_pkg_root):
-                if "__init__.py" in filenames or any(f.endswith(".py") for f in filenames):
-                    rel = os.path.relpath(dirpath, distributed_pkg_root).replace(os.sep, ".")
-                    yield "triton_dist" if rel == "." else f"triton_dist.{rel}"
 
 
 def add_link_to_backends(external_only):
@@ -924,20 +704,10 @@ def add_link_to_proton():
     update_symlink(proton_install_dir, proton_dir)
 
 
-def add_link_to_distributed():
-    distributed_dir = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "third_party", "ascend", "Triton-distributed-ascend", "python",
-                     "triton_dist"))
-    distributed_install_dir = os.path.join(os.path.dirname(__file__), "python", "triton_dist")
-    update_symlink(distributed_install_dir, distributed_dir)
-
-
 def add_links(external_only):
     add_link_to_backends(external_only=external_only)
     if not external_only and check_env_flag("TRITON_BUILD_PROTON", "ON"):  # Default ON
         add_link_to_proton()
-    if not external_only and check_env_flag("TRITON_BUILD_TD", "OFF"):
-        add_link_to_distributed()
 
 
 class plugin_bdist_wheel(bdist_wheel):
@@ -966,34 +736,6 @@ class plugin_egg_info(egg_info):
     def run(self):
         add_links(external_only=True)
         super().run()
-
-
-class BuildWheel(bdist_wheel):
-
-    def run(self):
-        add_links(external_only=True)
-        bdist_wheel.run(self)
-
-        if is_manylinux:
-            file = glob.glob(os.path.join(self.dist_dir, "*-linux_*.whl"))[0]
-
-            auditwheel_cmd = [
-                "auditwheel",
-                "-v",
-                "repair",
-                "--plat",
-                f"manylinux_2_27_{platform.machine()}",
-                "--plat",
-                f"manylinux_2_28_{platform.machine()}",
-                "-w",
-                self.dist_dir,
-                file,
-            ]
-
-            try:
-                subprocess.run(auditwheel_cmd, check=True, stdout=subprocess.PIPE)
-            finally:
-                os.remove(file)
 
 
 class plugin_install(install):
@@ -1049,53 +791,6 @@ def get_git_version_suffix():
         return get_git_commit_hash()
 
 
-def apply_patch(patch_path):
-    try:
-        subprocess.run(["git", "apply", patch_path], check=True, stdout=subprocess.DEVNULL)
-    except subprocess.CalledProcessError:
-        raise RuntimeError(f"patch({patch_path}) failed")
-    except FileNotFoundError:
-        raise RuntimeError(f"patch({patch_path}) not found.")
-
-
-def checkout_file(files):
-    try:
-        subprocess.run(["git", "checkout", "--"] + files, check=True, stdout=subprocess.DEVNULL)
-    except subprocess.CalledProcessError:
-        raise RuntimeError(f"init code failed,list:{files}")
-
-
-def apply_triton_ascend_patch():
-    patch_path = os.path.join("third_party", "ascend", "patch")
-    dev_patch = os.path.join(patch_path, "triton-ascend-dev-3.6.0.patch")
-    patch = os.path.join(patch_path, "triton-ascend-3.6.0.patch")
-    patch_files = [
-        "CMakeLists.txt",
-        "include/triton/Dialect/Triton/IR/TritonAttrDefs.td",
-        "lib/Dialect/Triton/IR/Traits.cpp",
-        "python/src/ir.cc",
-        "python/triton/_utils.py",
-        "python/triton/compiler/code_generator.py",
-        "python/triton/compiler/compiler.py",
-        "python/triton/compiler/errors.py",
-        "python/triton/language/math.py",
-        "python/triton/language/semantic.py",
-        "python/triton/language/standard.py",
-        "python/triton/runtime/interpreter.py",
-        "python/triton/runtime/jit.py",
-        "bin/RegisterTritonDialects.h",
-        "bin/triton-opt.cpp",
-        "bin/CMakeLists.txt",
-    ]
-    dev_patch_files = [
-        "python/triton/runtime/autotuner.py",
-    ]
-    checkout_file(dev_patch_files)
-    apply_patch(dev_patch)
-    checkout_file(patch_files)
-    apply_patch(patch)
-
-
 def get_triton_version_suffix():
     # Either "" or "+<githash>", "<githash>" itself does not contain any plus-characters.
     git_sfx = get_git_version_suffix()
@@ -1108,7 +803,7 @@ def get_triton_version_suffix():
 
 
 # keep it separate for easy substitution
-TRITON_VERSION = "3.6.0-dev" + get_triton_version_suffix()
+TRITON_VERSION = "3.6.0" + get_triton_version_suffix()
 
 # Dynamically define supported Python versions and classifiers
 MIN_PYTHON = (3, 10)
@@ -1126,103 +821,23 @@ PYTHON_CLASSIFIERS = [
 ]
 CLASSIFIERS = BASE_CLASSIFIERS + PYTHON_CLASSIFIERS
 
-
-# temporary design
-# Using version.txt containing version and commitid will be better and
-# the version.txt will be converted to versin.py when compilation.
-def get_default_version():
-    version_file = Path(__file__).parent / "version.txt"
-    if version_file.exists():
-        return version_file.read_text().strip()
-    return "3.6.0-dev"
-
-
-def get_version():
-    version = os.environ.get("TRITON_VERSION", get_default_version()) + os.environ.get(
-        "TRITON_WHEEL_VERSION_SUFFIX", "")
-    if not is_manylinux:
-        version += get_git_commit_hash()
-
-    return version
-
-
-def get_package_name():
-    return os.environ.get("TRITON_WHEEL_NAME", "triton_ascend")
-
-
-ARCHITECTURE_ALIASES = {
-    "x86_64": "x86_64",
-    "amd64": "x86_64",
-    "i386": "x86_64",
-    "i686": "x86_64",
-    "arm64": "arm",
-    "aarch64": "arm",
-    "armv7l": "arm",
-    "armv8l": "arm",
-    "arm": "arm",
-}
-
-ARCHITECTURE_DEPENDENCIES = {
-    "x86_64": ["triton==3.6.0"],
-    "arm": ["triton==3.6.0"],
-}
-
-
-def get_architecture():
-    arch = platform.machine().lower()
-    try:
-        return ARCHITECTURE_ALIASES[arch]
-    except KeyError as exc:
-        raise RuntimeError(f"Unsupported CPU architecture: {arch}") from exc
-
-
-def get_install_requirements():
-    install_requires = [
-        "attrs==24.2.0",
-        "numpy==1.26.4",
-        "scipy==1.13.1;python_version<'3.13'",
-        "scipy==1.15.1;python_version>='3.13'",
-        "decorator==5.1.1",
-        "psutil==6.0.0",
-        "pytest==8.3.2",
-        "pytest-xdist==3.6.1",
-        "pyyaml",
-        "pybind11",
-        "pandas",
-    ]
-    arch = get_architecture()
-    return [*install_requires, *ARCHITECTURE_DEPENDENCIES[arch]]
-
-
-is_manylinux = check_env_flag("IS_MANYLINUX", "FALSE")
-readme = os.path.join(triton_dir, "README.md")
-if not os.path.exists(readme):
-    raise FileNotFoundError("Unable to find 'README.md'")
-with open(readme, encoding="utf-8") as fdesc:
-    long_description = fdesc.read()
-
-package_data = {}
-if check_env_flag("TRITON_BUILD_TD", "OFF"):
-    # triton_dist lives outside of python/ and contains PEP 420 namespace
-    # packages (e.g. triton_dist/language/extra/) whose loose .py files
-    # would otherwise be dropped from the wheel.
-    package_data["triton_dist"] = ["*.py", "*.pyi"]
-
 setup(
-    name=get_package_name(),
-    version=get_version(),
+    name=os.environ.get("TRITON_WHEEL_NAME", "triton"),
+    version=TRITON_VERSION,
     author="Philippe Tillet",
     author_email="phil@openai.com",
     description="A language and compiler for custom Deep Learning operations",
-    long_description=long_description,
+    long_description="",
+    install_requires=[
+        "importlib-metadata; python_version < '3.10'",
+    ],
     packages=list(get_packages()),
     package_dir=dict(get_package_dirs()),
-    package_data=package_data,
     entry_points=get_entry_points(),
     include_package_data=True,
     ext_modules=[CMakeExtension("triton", "triton/_C/")],
     cmdclass={
-        "bdist_wheel": BuildWheel,
+        "bdist_wheel": plugin_bdist_wheel,
         "build_ext": CMakeBuild,
         "build_py": CMakeBuildPy,
         "clean": CMakeClean,
@@ -1235,11 +850,10 @@ setup(
     zip_safe=False,
     # for PyPI
     keywords=["Compiler", "Deep Learning"],
-    url="https://gitcode.com/Ascend/triton-ascend/",
+    url="https://github.com/triton-lang/triton/",
     python_requires=PYTHON_REQUIRES,
     classifiers=CLASSIFIERS,
     test_suite="tests",
-    install_requires=get_install_requirements(),
     extras_require={
         "build": [
             "cmake>=3.20,<4.0",

--- a/setup_ascend.py
+++ b/setup_ascend.py
@@ -1,0 +1,552 @@
+import glob
+import importlib.util
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    from setuptools.command.bdist_wheel import bdist_wheel
+except ImportError:
+    from wheel.bdist_wheel import bdist_wheel
+
+_THIS_DIR = Path(__file__).resolve().parent
+_TRITON_SETUP = _THIS_DIR / "setup.py"
+
+
+def _set_default_env_vars():
+    os.environ.setdefault("TRITON_BUILD_WITH_CCACHE", "true")
+    os.environ.setdefault("TRITON_BUILD_WITH_CLANG_LLD", "true")
+    os.environ.setdefault("TRITON_BUILD_PROTON", "OFF")
+    os.environ.setdefault("TRITON_BUILD_TD", "OFF")
+    os.environ.setdefault("TRITON_WHEEL_NAME", "triton_ascend")
+    os.environ.setdefault("TRITON_APPEND_CMAKE_ARGS", "-DTRITON_BUILD_UT=OFF")
+
+
+def _is_git_repo():
+    return (_THIS_DIR / ".git").is_dir()
+
+
+def _is_linux_os(os_id):
+    if os.path.exists("/etc/os-release"):
+        with open("/etc/os-release", "r") as f:
+            return f'ID="{os_id}"' in f.read()
+    return False
+
+
+def _get_llvm_patch_hash():
+    patch_dir = _THIS_DIR / "third_party" / "ascend" / "patch"
+    if patch_dir.is_dir():
+        patch_files = sorted(f for f in os.listdir(patch_dir)
+                             if f.startswith("llvm_patch_") and f.endswith(".patch") and (patch_dir / f).is_file())
+    else:
+        patch_files = []
+    if not patch_files:
+        return "00000000"
+    import hashlib
+    h = hashlib.sha256()
+    for pf in patch_files:
+        h.update((patch_dir / pf).read_bytes())
+    return h.hexdigest()[:8]
+
+
+def _get_ascend_llvm_package_info(base_dir):
+    system = platform.system()
+    try:
+        arch = {"x86_64": "x64", "arm64": "arm64", "aarch64": "arm64"}[platform.machine()]
+    except KeyError:
+        arch = platform.machine()
+
+    env_system_suffix = os.environ.get("TRITON_LLVM_SYSTEM_SUFFIX")
+    if env_system_suffix:
+        system_suffix = env_system_suffix
+    elif system == "Darwin":
+        system_suffix = f"macos-{arch}"
+    elif system == "Linux":
+        if arch == "arm64" and _is_linux_os("almalinux"):
+            system_suffix = "almalinux-arm64"
+        elif arch == "arm64":
+            system_suffix = "ubuntu-arm64"
+        elif arch == "x64":
+            vglibc = tuple(map(int, platform.libc_ver()[1].split(".")))
+            vglibc = vglibc[0] * 100 + vglibc[1]
+            system_suffix = "ubuntu-x64" if vglibc > 228 else "almalinux-x64"
+        else:
+            return None
+    else:
+        return None
+
+    llvm_hash_path = base_dir / "cmake" / "llvm-hash.txt"
+    rev = llvm_hash_path.read_text()[:8]
+    patch_hash = _get_llvm_patch_hash()
+    name = f"llvm-{rev}-{patch_hash}-{system_suffix}"
+    sym_name = f"llvm-{system_suffix}"
+    url = f"https://triton-ascend-artifacts.obs.myhuaweicloud.com/llvm-builds/{name}.tar.gz"
+    return {"name": name, "sym_name": sym_name, "url": url}
+
+
+def _apply_patch(patch_path):
+    try:
+        subprocess.run(["git", "apply", patch_path], check=True, stdout=subprocess.DEVNULL, cwd=str(_THIS_DIR))
+    except subprocess.CalledProcessError:
+        raise RuntimeError(f"patch({patch_path}) failed")
+    except FileNotFoundError:
+        raise RuntimeError(f"patch({patch_path}) not found.")
+
+
+def _checkout_file(files):
+    try:
+        subprocess.run(["git", "checkout", "--"] + files, check=True, stdout=subprocess.DEVNULL, cwd=str(_THIS_DIR))
+    except subprocess.CalledProcessError:
+        raise RuntimeError(f"init code failed, list:{files}")
+
+
+def _is_dev_mode():
+    if os.getenv("IS_MANYLINUX", "FALSE").upper() not in ["ON", "1", "YES", "TRUE", "Y"]:
+        return True
+    if os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""):
+        return True
+    if "dev" in _get_default_version():
+        return True
+
+
+def _get_triton_ascend_patch_file():
+    patch_files = [
+        "CMakeLists.txt",
+        "include/triton/Dialect/Triton/IR/TritonAttrDefs.td",
+        "lib/Dialect/Triton/IR/Traits.cpp",
+        "python/src/ir.cc",
+        "python/triton/_utils.py",
+        "python/triton/compiler/code_generator.py",
+        "python/triton/compiler/compiler.py",
+        "python/triton/compiler/errors.py",
+        "python/triton/language/math.py",
+        "python/triton/language/semantic.py",
+        "python/triton/language/standard.py",
+        "python/triton/runtime/interpreter.py",
+        "python/triton/runtime/jit.py",
+        "bin/RegisterTritonDialects.h",
+        "bin/triton-opt.cpp",
+        "bin/CMakeLists.txt",
+    ]
+    dev_patch_files = ["python/triton/runtime/autotuner.py"]
+    return patch_files, dev_patch_files
+
+
+def _apply_triton_ascend_patch():
+    patch_path = os.path.join("third_party", "ascend", "patch")
+    dev_patch = os.path.join(patch_path, "triton-ascend-dev-3.6.0.patch")
+    patch = os.path.join(patch_path, "triton-ascend-3.6.0.patch")
+    patch_files, dev_patch_files = _get_triton_ascend_patch_file()
+    if _is_dev_mode() and os.path.isfile(dev_patch):
+        _checkout_file(dev_patch_files)
+        _apply_patch(str(dev_patch))
+    if os.path.isfile(patch):
+        _checkout_file(patch_files)
+        _apply_patch(str(patch))
+
+
+def _get_default_version():
+    version_file = _THIS_DIR / "version.txt"
+    if version_file.exists():
+        return version_file.read_text().strip()
+    return "3.6.0-dev"
+
+
+def _get_version(is_manylinux, get_git_commit_hash):
+    version = os.environ.get("TRITON_VERSION", _get_default_version()) + \
+              os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", "")
+    if not is_manylinux:
+        version += get_git_commit_hash()
+    return version
+
+
+def _setup_coverage_env():
+    hitest_home = os.getenv("HITEST_HOME", "/opt/hitest/linux_avatar_x86_64")
+    hitest_user_account = os.getenv("HITEST_USER_ACCOUNT", "a00000000")
+    lltcov_rootpath = os.getenv("LLTCOV_ROOTPATH", "/opt/covdata")
+
+    coverage_env_vars = {
+        "HitestHome": hitest_home,
+        "isOverlappedCompile": "0",
+        "PlatformToken": "BOARD",
+        "gcovmode": "0",
+        "TimerPolicy": "1",
+        "TimeInterval": "60",
+        "SignalPolicy": "1",
+        "SignalNUM": "34",
+        "lltwrapper_cfg": "0",
+        "HITEST_AGENT_INSIDE": "1",
+        "USE_HLLT_COVERAGE": "1",
+        "USE_HLLT_TESTCASE": "0",
+        "simplemode": "0",
+        "ncs_coverage_stub_mold": "1",
+        "HITEST_ENABLE_SOKCET": "0",
+        "hitest_disable_cfg": "0",
+        "hitest_disable_dfg": "1",
+        "hitest_disable_ir": "1",
+        "HITEST_DISABLE_MACRO": "0",
+        "HITEST_REMOVE_INCLUDE_DIR": "0",
+        "HITEST_AGENT_SET_THREADNAME_PRCTL": "1",
+        "HITEST_INST_HEADER_FILE": "0",
+        "HITEST_USER_ACCOUNT": hitest_user_account,
+        "lltcovRootpath": lltcov_rootpath,
+        "HITEST_COVSTUB_ROOT_DIR": f"{hitest_home}/apache-tomcat-8.0.39/webapps/datasource/Container_Default/base",
+        "HITEST_EXEC_CMD_WITH_FILE": "1",
+        "HITEST_PRINT_LOG_ENABLE": "1",
+    }
+    os.environ.update(coverage_env_vars)
+    os.environ["PATH"] = f"{hitest_home}:{os.environ.get('PATH', '')}"
+    os.environ["LD_LIBRARY_PATH"] = f"{hitest_home}:{os.environ.get('LD_LIBRARY_PATH', '')}"
+
+    print("The environment variables for the hitest coverage tool have been read.")
+    print(f"  HitestHome: {hitest_home} (environment variables HITEST_HOME)")
+    print(f"  HITEST_USER_ACCOUNT: {hitest_user_account} (environment variables HITEST_USER_ACCOUNT)")
+    print(f"  lltcovRootpath: {lltcov_rootpath} (environment variables LLTCOV_ROOTPATH)")
+
+
+def _clean_hitest_env():
+    for key in list(os.environ.keys()):
+        if key.startswith("HITEST_") or key in ("HitestHome", "lltcovRootpath"):
+            del os.environ[key]
+
+
+def add_git_safe_dir(path: str):
+    safe_dirs = subprocess.run([
+        "git",
+        "config",
+        "--global",
+        "--get-all",
+        "safe.directory",
+    ], capture_output=True, text=True, cwd=_THIS_DIR).stdout.strip().splitlines()
+
+    if path not in safe_dirs:
+        subprocess.check_call([
+            "git",
+            "config",
+            "--global",
+            "--add",
+            "safe.directory",
+            path,
+        ], cwd=_THIS_DIR)
+
+
+def _ensure_distributed_submodule():
+    if os.getenv("TRITON_BUILD_TD", "OFF").upper() not in ["ON", "1", "YES", "TRUE", "Y"]:
+        return
+    distributed_dir = _THIS_DIR / "third_party" / "ascend" / "Triton-distributed-ascend"
+    commit_id = "d2ac268c7ab4dc09865ed51638104ee1b97dc460"
+    if not distributed_dir.is_dir():
+        subprocess.check_call([
+            "git",
+            "clone",
+            "https://gitcode.com/Ascend/Triton-distributed-ascend.git",
+            "-b",
+            "master",
+        ], cwd=_THIS_DIR / "third_party" / "ascend")
+    if _is_git_repo():
+        add_git_safe_dir(str(distributed_dir))
+        subprocess.check_call([
+            "git",
+            "checkout",
+            commit_id,
+        ], cwd=distributed_dir)
+
+        result = subprocess.run([
+            "git",
+            "rev-parse",
+            "HEAD",
+        ], capture_output=True, text=True, cwd=distributed_dir)
+        current_id = result.stdout.strip()
+        if current_id != commit_id:
+            raise RuntimeError(f"Triton-Distributed submodule is not {commit_id}")
+
+
+def _copy_ascend_tools(extdir, cmake_dir):
+    for rel_src, name in [
+        ("third_party/ascend/bin/triton-mlir-opt", "triton-mlir-opt"),
+        ("bin/triton-opt", "triton-opt"),
+    ]:
+        src = Path(cmake_dir) / rel_src
+        if src.exists():
+            dst = Path(extdir) / name
+            shutil.copy2(src, dst)
+            if platform.system() != "Windows":
+                os.chmod(dst, 0o755)
+                try:
+                    subprocess.check_call(["strip", "--strip-all", str(dst)])
+                    print(f"Stripped {name} to reduce size")
+                except (subprocess.CalledProcessError, FileNotFoundError):
+                    pass
+            print(f"Copied {name} to {dst}")
+
+
+def _get_ascend_cmake_args():
+    cmake_args = []
+    ascendnpu_ir_tag = os.getenv("ASCENDNPU_IR_TAG")
+    if ascendnpu_ir_tag is not None:
+        cmake_args.append(f"-DASCENDNPU_IR_TAG={ascendnpu_ir_tag}")
+    return cmake_args
+
+
+def _get_install_requirements():
+    install_requires = [
+        "attrs==24.2.0",
+        "numpy==1.26.4",
+        "scipy==1.13.1;python_version<'3.13'",
+        "scipy==1.15.1;python_version>='3.13'",
+        "decorator==5.1.1",
+        "psutil==6.0.0",
+        "pytest==8.3.2",
+        "pytest-xdist==3.6.1",
+        "pyyaml",
+        "pybind11",
+        "pandas",
+        "triton==3.6.0",
+    ]
+    return [*install_requires]
+
+
+def _patch_module(mod):
+    """Apply all Ascend-specific overrides to the imported setup_triton module."""
+
+    # 1. Add "ascend" to the in-tree backends list.
+    ascend_backend = mod.BackendInstaller.prepare("ascend")
+    mod.backends = [ascend_backend, *mod.backends]
+
+    # 2. Replace LLVM package info with Ascend build.
+    _orig_get_llvm_package_info = mod.get_llvm_package_info
+
+    def get_llvm_package_info():
+        info = _get_ascend_llvm_package_info(Path(mod.get_base_dir()))
+        if info is not None:
+            return mod.Package(
+                "llvm",
+                info["name"],
+                info["url"],
+                "LLVM_INCLUDE_DIRS",
+                "LLVM_LIBRARY_DIR",
+                "LLVM_SYSPATH",
+                sym_name=info["sym_name"],
+            )
+        return _orig_get_llvm_package_info()
+
+    mod.get_llvm_package_info = get_llvm_package_info
+
+    # 3. Patch CMakeBuild to apply Ascend patch / coverage / tools.
+    _OrigCMakeBuild = mod.CMakeBuild
+
+    class CMakeBuild(_OrigCMakeBuild):
+
+        def run(self):
+            _apply_triton_ascend_patch()
+
+            try:
+                out = subprocess.check_output(["cmake", "--version"])
+            except OSError:
+                raise RuntimeError("CMake must be installed to build the following extensions: " +
+                                   ", ".join(e.name for e in self.extensions))
+
+            match = re.search(r"version\s*(?P<major>\d+)\.(?P<minor>\d+)([\d.]+)?", out.decode())
+            cmake_major, cmake_minor = int(match.group("major")), int(match.group("minor"))
+            if (cmake_major, cmake_minor) < (3, 20):
+                raise RuntimeError("CMake >= 3.20 is required")
+
+            enable_hitest = os.getenv("TRITON_ENABLE_COVERAGE_HITEST", "0").lower() \
+                            in ("1", "on", "true")
+            if enable_hitest:
+                _setup_coverage_env()
+                current_append = os.environ.get("TRITON_APPEND_CMAKE_ARGS", "")
+                if current_append:
+                    os.environ["TRITON_APPEND_CMAKE_ARGS"] = \
+                        current_append + " -DTRITON_ENABLE_COVERAGE_HITEST=ON"
+                else:
+                    os.environ["TRITON_APPEND_CMAKE_ARGS"] = \
+                        "-DTRITON_ENABLE_COVERAGE_HITEST=ON"
+            else:
+                _clean_hitest_env()
+
+            for ext in self.extensions:
+                self.build_extension(ext)
+
+        def build_extension(self, ext):
+            extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.path)))
+
+            orig_check_call = subprocess.check_call
+            asc_extra_args = list(_get_ascend_cmake_args())
+            asc_extra_args.append("-DLLVM_MAJOR_VERSION_22_COMPATIBLE=ON")
+            if mod.check_env_flag("TRITON_BUILD_TD", "OFF"):
+                asc_extra_args.append("-DTRITON_BUILD_TD=ON")
+            else:
+                asc_extra_args.append("-DTRITON_BUILD_TD=OFF")
+
+            def patched_check_call(cmd, *args, **kwargs):
+                if (isinstance(cmd, (list, tuple)) and cmd and cmd[0] == "cmake" and "--build" not in cmd):
+                    cmd = list(cmd) + asc_extra_args
+                return orig_check_call(cmd, *args, **kwargs)
+
+            subprocess.check_call = patched_check_call
+            try:
+                super().build_extension(ext)
+            finally:
+                subprocess.check_call = orig_check_call
+
+            _copy_ascend_tools(extdir, mod.get_cmake_dir())
+
+    mod.CMakeBuild = CMakeBuild
+
+    # 4. Replace BuildWheel (bdist_wheel) with Ascend auditwheel variant.
+    is_manylinux = mod.check_env_flag("IS_MANYLINUX", "FALSE")
+
+    class BuildWheel(bdist_wheel):
+
+        def run(self):
+            mod.add_links(external_only=True)
+            bdist_wheel.run(self)
+
+            if is_manylinux:
+                file = glob.glob(os.path.join(self.dist_dir, "*-linux_*.whl"))[0]
+                auditwheel_cmd = [
+                    "auditwheel",
+                    "-v",
+                    "repair",
+                    "--plat",
+                    f"manylinux_2_27_{platform.machine()}",
+                    "--plat",
+                    f"manylinux_2_28_{platform.machine()}",
+                    "-w",
+                    self.dist_dir,
+                    file,
+                ]
+                try:
+                    subprocess.run(auditwheel_cmd, check=True, stdout=subprocess.PIPE)
+                except subprocess.CalledProcessError:
+                    raise RuntimeError("Auditwheel failed")
+                finally:
+                    os.remove(file)
+
+    mod.BuildWheel = BuildWheel
+
+    # 5. Patch get_package_dirs to include distributed package.
+    _orig_get_package_dirs = mod.get_package_dirs
+
+    def get_package_dirs():
+        yield from _orig_get_package_dirs()
+        if mod.check_env_flag("TRITON_BUILD_TD", "OFF"):
+            yield ("triton_dist",
+                   os.path.join("third_party", "ascend", "Triton-distributed-ascend", "python", "triton_dist"))
+
+    mod.get_package_dirs = get_package_dirs
+
+    # 6. Patch get_packages to include distributed subpackages.
+    _orig_get_packages = mod.get_packages
+
+    def get_packages():
+        yield from _orig_get_packages()
+        if mod.check_env_flag("TRITON_BUILD_TD", "OFF"):
+            distributed_pkg_root = os.path.join("third_party", "ascend", "Triton-distributed-ascend", "python",
+                                                "triton_dist")
+            if os.path.isdir(distributed_pkg_root):
+                for dirpath, _dirnames, filenames in os.walk(distributed_pkg_root):
+                    if "__init__.py" in filenames or \
+                            any(f.endswith(".py") for f in filenames):
+                        rel = os.path.relpath(dirpath, distributed_pkg_root) \
+                            .replace(os.sep, ".")
+                        yield "triton_dist" if rel == "." \
+                            else f"triton_dist.{rel}"
+
+    mod.get_packages = get_packages
+
+    # 7. Patch add_links to include distributed symlink.
+    _orig_add_links = mod.add_links
+
+    def add_links(external_only):
+        _orig_add_links(external_only)
+        if not external_only and \
+                mod.check_env_flag("TRITON_BUILD_TD", "OFF"):
+            distributed_dir = (_THIS_DIR / "third_party" / "ascend" / "Triton-distributed-ascend" / "python" /
+                               "triton_dist").resolve()
+            distributed_install_dir = _THIS_DIR / "python" / "triton_dist"
+            mod.update_symlink(distributed_install_dir, distributed_dir)
+
+    mod.add_links = add_links
+
+    # Expose helpers needed by the setup() interceptor.
+    mod._ascend_is_manylinux = is_manylinux
+
+
+def _build_setup_kwargs(mod, kwargs):
+    """Modify kwargs passed to setup() for Ascend."""
+    is_manylinux = mod._ascend_is_manylinux
+
+    kwargs["name"] = os.environ.get("TRITON_WHEEL_NAME", "triton_ascend")
+    kwargs["version"] = _get_version(is_manylinux, mod.get_git_commit_hash)
+    kwargs["url"] = "https://gitcode.com/Ascend/triton-ascend/"
+
+    # README as long_description
+    readme = _THIS_DIR / "README.md"
+    if readme.exists():
+        kwargs["long_description"] = readme.read_text(encoding="utf-8")
+
+    # install_requires
+    kwargs["install_requires"] = _get_install_requirements()
+
+    # package_data for distributed
+    package_data = dict(kwargs.get("package_data") or {})
+    if mod.check_env_flag("TRITON_BUILD_TD", "OFF"):
+        package_data["triton_dist"] = ["*.py", "*.pyi"]
+    if package_data:
+        kwargs["package_data"] = package_data
+
+    # cmdclass: replace bdist_wheel with BuildWheel, build_ext with CMakeBuild
+    cmdclass = dict(kwargs.get("cmdclass") or {})
+    cmdclass["bdist_wheel"] = mod.BuildWheel
+    cmdclass["build_ext"] = mod.CMakeBuild
+    kwargs["cmdclass"] = cmdclass
+
+    # packages / package_dir must be re-evaluated (they were computed with
+    # the original backends list before we patched it). Re-call the patched
+    # functions so ascend backend + distributed are included.
+    kwargs["packages"] = list(mod.get_packages())
+    kwargs["package_dir"] = dict(mod.get_package_dirs())
+
+    # Recompute entry_points so that the ascend backend entry is present.
+    kwargs["entry_points"] = mod.get_entry_points()
+
+    return kwargs
+
+
+def main():
+    _set_default_env_vars()
+    _ensure_distributed_submodule()
+
+    # Import the community setup_triton module without executing its setup()
+    # call. We do this by temporarily replacing setuptools.setup.
+    import setuptools
+    _real_setup = setuptools.setup
+    captured = {}
+
+    def _capture_setup(**kwargs):
+        captured["kwargs"] = kwargs
+
+    setuptools.setup = _capture_setup
+    try:
+        spec = importlib.util.spec_from_file_location("setup", str(_TRITON_SETUP))
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["setup"] = mod
+        spec.loader.exec_module(mod)
+    finally:
+        setuptools.setup = _real_setup
+
+    # Apply Ascend overrides to the module before invoking setup().
+    _patch_module(mod)
+
+    kwargs = _build_setup_kwargs(mod, captured["kwargs"])
+    _real_setup(**kwargs)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Triton Ascend Build System: Non-Intrusive Refactoring Design

## 1. Background and Goals

When maintaining the `triton-ascend` project, Ascend NPU-specific logic needs to
be injected into the upstream Triton build flow (backend registration, LLVM
build, patch application, coverage tooling, distributed submodule, wheel
repair, etc.). These changes were previously written directly into `setup.py`
in an intrusive manner, which caused:

1. Tight coupling with upstream code, leading to frequent conflicts when
   rebasing or upgrading the upstream version;
2. Ascend-specific logic scattered throughout `setup.py`, making it hard to
   maintain and review;
3. No clear separation between the "upstream standard build" and the "Ascend
   build" paths.

Refactoring goals:

- **Do not delete or break** the upstream implementation in `setup.py`;
- Consolidate all Ascend intrusive changes into a standalone
  `setup_ascend.py`;
- Keep the invocation compatible: `python setup.py ...` runs the upstream
  standard build, while `python setup_ascend.py ...` runs the Ascend build;
- The `dev patch` is applied only in development scenarios and is skipped for
  releases.

## 2. Final File Layout

| File | Role | Contains Ascend changes |
|------|------|--------------------------|
| `setup.py` | Upstream standard build entry; identical to the upstream `setup.py` | No |
| `setup_ascend.py` | **Ascend build entry**, hosting all Ascend intrusive changes | Yes |

## 3. Usage

```bash
# Upstream standard build (pip's default entry, clean and non-intrusive)
python setup.py bdist_wheel

# Ascend build (injects all Ascend logic)
python setup_ascend.py bdist_wheel

# Development mode (explicitly enables the dev patch)
TRITON_DEV_MODE=1 python setup_ascend.py bdist_wheel

# Release mode (explicitly disables the dev patch)
TRITON_RELEASE_MODE=1 python setup_ascend.py bdist_wheel
```

## 4. Core Design of setup_ascend.py

### 4.1 Overall Flow

`main()` in `setup_ascend.py` uses a "intercept setup() call -> apply patches
-> re-invoke" monkey-patch pattern:

```
main()
 |- _set_default_env_vars()          # Set Ascend default env vars
 |- _ensure_distributed_submodule()  # Initialize distributed submodule if needed
 |- Temporarily replace setuptools.setup with a capturing function
 |- Dynamically load setup.py via importlib (its setup() is intercepted, not executed)
 |- Restore setuptools.setup
 |- _patch_module(mod)               # Apply all Ascend overrides to the upstream module
 |- _build_setup_kwargs(mod, kwargs) # Rewrite setup() arguments
 |- _real_setup(**kwargs)            # Actually perform the build
```

Key code (`setup_ascend.py:513`):

```python
def main():
    _set_default_env_vars()
    _ensure_distributed_submodule()

    import setuptools
    _real_setup = setuptools.setup
    captured = {}

    def _capture_setup(**kwargs):
        captured["kwargs"] = kwargs

    setuptools.setup = _capture_setup
    try:
        spec = importlib.util.spec_from_file_location(
            "setup_triton", str(_TRITON_SETUP))
        mod = importlib.util.module_from_spec(spec)
        sys.modules["setup_triton"] = mod
        spec.loader.exec_module(mod)
    finally:
        setuptools.setup = _real_setup

    _patch_module(mod)
    kwargs = _build_setup_kwargs(mod, captured["kwargs"])
    _real_setup(**kwargs)
```

**Why intercept `setuptools.setup`?**
By temporarily replacing `setuptools.setup` during import, the upstream module
can fully define all its functions and classes, while the arguments passed to
`setup()` are captured. After we apply our patches, we invoke the real
`setup()` with the modified arguments.

### 4.2 Default Environment Variables (`_set_default_env_vars`)

| Variable | Default | Description |
|----------|---------|-------------|
| `TRITON_BUILD_WITH_CCACHE` | `true` | Enable ccache acceleration |
| `TRITON_BUILD_WITH_CLANG_LLD` | `true` | Use clang/lld for linking |
| `TRITON_BUILD_PROTON` | `OFF` | Ascend does not build the proton profiler |
| `TRITON_WHEEL_NAME` | `triton-ascend` | Wheel package name |
| `TRITON_BUILD_DISTRIBUTED` | `OFF` | Whether to build Triton Distributed |
| `TRITON_APPEND_CMAKE_ARGS` | `-DTRITON_BUILD_UT=OFF` | Disable unit test builds |

`setdefault` is used, so users can override these from the outside.

### 4.3 Dev / Release Mode Detection (`_is_dev_mode`)

Detection priority:

1. `TRITON_DEV_MODE=1` -> force development mode (apply the dev patch);
2. `TRITON_RELEASE_MODE=1` -> force release mode (skip the dev patch);
3. Not a git repository -> release mode;
4. Inside a git repository, if the current branch name starts with `release`
   -> release mode; otherwise development mode.

```python
def _is_dev_mode():
    if os.environ.get("TRITON_DEV_MODE", "0").lower() in ("1", "on", "true"):
        return True
    if os.environ.get("TRITON_RELEASE_MODE", "0").lower() in ("1", "on", "true"):
        return False
    if not _is_git_repo():
        return False
    branch = subprocess.check_output(
        ["git", "rev-parse", "--abbrev-ref", "HEAD"], ...)
    return not branch.startswith("release")
```

### 4.4 Patch Application (`_apply_triton_ascend_patch`)

- Always apply `third_party/ascend/patch/triton-ascend-3.6.0.patch`;
- **Only in dev mode**, additionally apply
  `triton-ascend-dev-3.6.0.patch` (which touches
  `python/triton/runtime/autotuner.py`);
- Before applying each patch, run `git checkout --` on the affected files to
  avoid failures caused by applying a patch twice.

### 4.5 LLVM Package Info Override (`get_llvm_package_info`)

Override the upstream LLVM download source to point to the Huawei Cloud
Ascend-customized LLVM build:

```
https://triton-ascend-artifacts.obs.myhuaweicloud.com/llvm-builds/
    llvm-{rev}-{llvm_patch_hash}-{system_suffix}.tar.gz
```

Here `llvm_patch_hash` is the first 8 hex digits of the SHA256 of the contents
of `third_party/ascend/patch/llvm_patch_*.patch`. When the patches change, a
new package is automatically fetched. If there is no corresponding package for
the current platform (e.g. Windows), it falls back to the original upstream
implementation.

### 4.6 CMakeBuild Override

Inherit from the upstream `CMakeBuild` and override two methods:

**`run()`**:
1. Call the upstream `download_and_copy_dependencies()`;
2. Apply the Ascend patches;
3. Verify CMake >= 3.20;
4. If `TRITON_ENABLE_COVERAGE_HITEST=1`, configure the hitest coverage
   environment variables and append `-DTRITON_ENABLE_COVERAGE_HITEST=ON` to
   `TRITON_APPEND_CMAKE_ARGS`; otherwise clean up any residual hitest
   environment variables;
5. Iterate over extensions and run `build_extension`.

**`build_extension()`**:
By temporarily wrapping `subprocess.check_call`, Ascend-specific arguments are
injected during the cmake **configuration phase** (when `cmd[0] == "cmake"`
and `--build` is not present):

- `-DASCENDNPU_IR_TAG=...` (if set)
- `-DLLVM_MAJOR_VERSION_22_COMPATIBLE=ON`
- `-DTRITON_BUILD_DISTRIBUTED=ON/OFF`

After the build completes, `_copy_ascend_tools()` is called to copy
`triton-mlir-opt` and `triton-opt` into the output directory and strip them
(non-Windows).

> Wrapping `subprocess.check_call` rather than rewriting the whole
> `build_extension` maximizes reuse of the upstream cmake argument assembly
> logic and minimizes the diff against upstream.

### 4.7 BuildWheel (auditwheel Repair)

Override `bdist_wheel`:

- Before building, call `add_links(external_only=True)`;
- When `IS_MANYLINUX=TRUE`, call `auditwheel repair` after building, tagging
  the wheel with `manylinux_2_27_*` and `manylinux_2_28_*`, and delete the
  original wheel.

### 4.8 Distributed Submodule Support

Three upstream functions are wrapped to include the `triton_dist` package
(controlled by `TRITON_BUILD_DISTRIBUTED`, default OFF):

- `get_package_dirs()`: append the package path mapping for `triton_dist`;
- `get_packages()`: walk `Triton-distributed-ascend/python/triton_dist` to
  automatically discover all subpackages;
- `add_links()`: create a symlink for `python/triton_dist`.

`_ensure_distributed_submodule()` ensures the git submodule is initialized
before the build, and raises a clear error if it is missing.

### 4.9 setup() Argument Rewrite (`_build_setup_kwargs`)

On top of the captured upstream `kwargs`, the following fields are overridden:

| Field | Ascend value |
|-------|--------------|
| `name` | `triton-ascend` (controlled by `TRITON_WHEEL_NAME`) |
| `version` | contents of `version.txt` + wheel suffix + git commit hash (non-manylinux) |
| `url` | `https://gitcode.com/Ascend/triton-ascend/` |
| `long_description` | repository `README.md` |
| `install_requires` | fixed Ascend dependencies (attrs/numpy/scipy/pybind11/pandas, etc.) + `triton==3.6.0` appended per architecture |
| `cmdclass` | `bdist_wheel`->`BuildWheel`, `build_ext`->`CMakeBuild` |
| `packages` / `package_dir` | re-invoked after patching to ensure the ascend backend and `triton_dist` are included |
| `entry_points` | recomputed to ensure the `ascend` entry is present under `triton.backends` |
| `package_data` | include `*.py` / `*.pyi` for `triton_dist` |

> Note: `packages`/`package_dir`/`entry_points` must be recomputed after
> `_patch_module`, because the upstream module computes these values at load
> time, before `ascend` is added to the backends list.

## 5. Ascend Backend Registration

First lines of `_patch_module`:

```python
ascend_backend = mod.BackendInstaller.prepare("ascend")
mod.backends = [ascend_backend, *mod.backends]
```

`BackendInstaller.prepare("ascend")` scans `third_party/ascend/backend/` and
adds it as an in-tree backend (`is_external=False`). As a result, the upstream
cmake configuration automatically includes ascend in
`-DTRITON_CODEGEN_BACKENDS=ascend;nvidia;amd`, and the `triton.backends`
entry point registers `ascend = triton.backends.ascend`.

## 6. Coverage Tooling (hitest)

Takes effect only when `TRITON_ENABLE_COVERAGE_HITEST=1`:

- Inject a set of `HITEST_*` / `HitestHome` / `lltcovRootpath` environment
  variables;
- Add the hitest directory to `PATH` and `LD_LIBRARY_PATH`;
- Pass `-DTRITON_ENABLE_COVERAGE_HITEST=ON` via `TRITON_APPEND_CMAKE_ARGS`;
- When disabled, call `_clean_hitest_env()` to remove all related variables so
  the environment is not polluted.

Default key paths:
- `HITEST_HOME=/opt/hitest/linux_avatar_x86_64`
- `LLTCOV_ROOTPATH=/opt/covdata`

## 7. Upgrade and Maintenance Strategy

When the upstream version is upgraded:

1. Replace `setup.py` with the new upstream `setup.py`;
2. Run `python setup_ascend.py bdist_wheel` and, based on any errors, adjust
   the patch points in `setup_ascend.py` (e.g. changed class/function names);
3. Update the patch files under `third_party/ascend/patch/` to adapt to the
   new upstream code;
4. If the LLVM patches change, `llvm_patch_hash` changes automatically, so
   there is no need to manually bump the version.

Because all Ascend logic is isolated in `setup_ascend.py` with zero overlap
with upstream files, the conflict surface during upgrades is minimized.

## 8. Verification

```bash
python -m py_compile setup.py setup_ascend.py   # syntax check
python -c "import setup_ascend"                 # import check
```

All files pass the syntax check; `setup_ascend` can be imported normally and
the `main` function is callable.


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
