### PR TITLE
[TritonToLinalg](fix) bugfix for dyn_cast when the args is nullptr

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/MaskAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/MaskAnalysis.cpp
@@ -477,9 +477,9 @@ LogicalResult MaskState::parseSel(arith::SelectOp selOp, const Location &loc,
   }
 
   auto trueScalar =
-      dyn_cast<IntegerAttr>(dyn_cast<Attribute>(trueState.scalar));
+      dyn_cast_if_present<IntegerAttr>(dyn_cast<Attribute>(trueState.scalar));
   auto falseScalar =
-      dyn_cast<IntegerAttr>(dyn_cast<Attribute>(falseState.scalar));
+      dyn_cast_if_present<IntegerAttr>(dyn_cast<Attribute>(falseState.scalar));
 
   if (trueScalar && falseScalar) {
     if (trueScalar.getInt() == 1 && falseScalar.getInt() == 0) {


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
