### PR TITLE
[TritonToLinalg](fix) support byte-buffer pointer bitcasts

### DIFF
--- a/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
@@ -39,6 +39,8 @@
 
 #include "llvm/ADT/STLExtras.h"
 
+#include <optional>
+
 #define DEBUG_TYPE "triton-unstructure-converter"
 
 using namespace mlir;
@@ -54,6 +56,226 @@ constexpr int64_t kBitsPerByte = 8;
 
 static constexpr const char *kRouteDiscreteMaskToSimtAttrName =
     "route_discrete_mask_to_simt";
+
+static triton::PointerType getScalarPointerType(Type type) {
+  if (auto tensorType = dyn_cast<RankedTensorType>(type))
+    type = tensorType.getElementType();
+  return dyn_cast<triton::PointerType>(type);
+}
+
+// Keep this deliberately narrow. These are the byte-buffer views used by the
+// paged-attention and KV-cache kernels covered by this canonicalization.
+static std::optional<int64_t>
+getSupportedPointerBitcastScale(triton::BitcastOp op) {
+  auto srcType = getScalarPointerType(op.getSrc().getType());
+  auto dstType = getScalarPointerType(op.getType());
+  if (!srcType || !dstType ||
+      srcType.getAddressSpace() != dstType.getAddressSpace() ||
+      !srcType.getPointeeType().isInteger(8))
+    return std::nullopt;
+
+  Type dstPointeeType = dstType.getPointeeType();
+  if (dstPointeeType.isF16() || dstPointeeType.isBF16())
+    return 2;
+  if (dstPointeeType.isF32() || dstPointeeType.isInteger(32))
+    return 4;
+  return std::nullopt;
+}
+
+static FailureOr<Value> scaleTensorPointerOffset(Value offset, int64_t divisor,
+                                                 IRRewriter &rewriter) {
+  auto offsetType = dyn_cast<RankedTensorType>(offset.getType());
+  if (!offsetType || !offsetType.hasStaticShape())
+    return failure();
+  auto elementType = dyn_cast<IntegerType>(offsetType.getElementType());
+  if (!elementType ||
+      (elementType.getWidth() != 32 && elementType.getWidth() != 64))
+    return failure();
+  auto divisorAttr = rewriter.getIntegerAttr(elementType, divisor);
+  Value divisorValue = rewriter.create<arith::ConstantOp>(
+      offset.getLoc(), DenseElementsAttr::get(offsetType, divisorAttr));
+  return rewriter.create<arith::DivSIOp>(offset.getLoc(), offset, divisorValue)
+      .getResult();
+}
+
+static bool isPublicKernelArgument(Value value) {
+  auto blockArgument = dyn_cast<BlockArgument>(value);
+  if (!blockArgument)
+    return false;
+  auto funcOp =
+      dyn_cast<triton::FuncOp>(blockArgument.getOwner()->getParentOp());
+  return funcOp && funcOp.getVisibility() == SymbolTable::Visibility::Public;
+}
+
+static FailureOr<Value> materializeScalarByteAddress(Value pointer,
+                                                     Location loc,
+                                                     IRRewriter &rewriter) {
+  SmallVector<Value> byteOffsets;
+  Value root = pointer;
+  while (auto addPtrOp = root.getDefiningOp<triton::AddPtrOp>()) {
+    auto offsetType = dyn_cast<IntegerType>(addPtrOp.getOffset().getType());
+    if (isa<RankedTensorType>(addPtrOp.getType()) || !offsetType ||
+        (offsetType.getWidth() != 32 && offsetType.getWidth() != 64))
+      return failure();
+    byteOffsets.push_back(addPtrOp.getOffset());
+    root = addPtrOp.getPtr();
+  }
+  if (!isPublicKernelArgument(root))
+    return failure();
+
+  Value address =
+      rewriter.create<triton::PtrToIntOp>(loc, rewriter.getI64Type(), root);
+  for (Value offset : llvm::reverse(byteOffsets)) {
+    auto offsetType = cast<IntegerType>(offset.getType());
+    if (offsetType.getWidth() < 64)
+      offset =
+          rewriter.create<arith::ExtSIOp>(loc, rewriter.getI64Type(), offset);
+    address = rewriter.create<arith::AddIOp>(loc, address, offset);
+  }
+  return address;
+}
+
+static bool hasOnlySupportedPointerUses(Value pointer) {
+  if (pointer.use_empty())
+    return false;
+  for (Operation *user : pointer.getUsers()) {
+    if (auto addPtrOp = dyn_cast<triton::AddPtrOp>(user)) {
+      if (addPtrOp.getPtr() != pointer ||
+          !hasOnlySupportedPointerUses(addPtrOp.getResult()))
+        return false;
+      continue;
+    }
+    if (auto splatOp = dyn_cast<triton::SplatOp>(user)) {
+      if (splatOp.getSrc() != pointer ||
+          !hasOnlySupportedPointerUses(splatOp.getResult()))
+        return false;
+      continue;
+    }
+    if (auto loadOp = dyn_cast<triton::LoadOp>(user)) {
+      if (loadOp.getPtr() != pointer)
+        return false;
+      continue;
+    }
+    if (auto storeOp = dyn_cast<triton::StoreOp>(user)) {
+      if (storeOp.getPtr() != pointer)
+        return false;
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+static bool canRewriteSupportedPointerBitcast(triton::BitcastOp op) {
+  if (!getSupportedPointerBitcastScale(op) ||
+      !hasOnlySupportedPointerUses(op.getResult()))
+    return false;
+
+  Value current = op.getSrc();
+  bool seenTensorAddPtr = false;
+  while (Operation *producer = current.getDefiningOp()) {
+    if (auto addPtrOp = dyn_cast<triton::AddPtrOp>(producer)) {
+      Type offsetType = addPtrOp.getOffset().getType();
+      if (isa<RankedTensorType>(current.getType())) {
+        if (seenTensorAddPtr)
+          return false;
+        seenTensorAddPtr = true;
+        auto tensorType = dyn_cast<RankedTensorType>(offsetType);
+        if (!tensorType || !tensorType.hasStaticShape())
+          return false;
+        auto elementType = dyn_cast<IntegerType>(tensorType.getElementType());
+        if (!elementType ||
+            (elementType.getWidth() != 32 && elementType.getWidth() != 64))
+          return false;
+      } else if (auto intType = dyn_cast<IntegerType>(offsetType);
+                 !intType ||
+                 (intType.getWidth() != 32 && intType.getWidth() != 64)) {
+        return false;
+      }
+      current = addPtrOp.getPtr();
+      continue;
+    }
+    if (auto splatOp = dyn_cast<triton::SplatOp>(producer)) {
+      if (isa<RankedTensorType>(splatOp.getSrc().getType()))
+        return false;
+      current = splatOp.getSrc();
+      continue;
+    }
+    return false;
+  }
+  return !isa<RankedTensorType>(current.getType()) &&
+         isPublicKernelArgument(current);
+}
+
+// Rewrite only the supported byte-buffer views into ordinary target-element
+// addptr operations. All later pointer and control-flow handling remains on the
+// existing main-dev paths.
+static LogicalResult
+rewriteSupportedPointerBitcast(triton::BitcastOp op, IRRewriter &rewriter,
+                               triton::BitcastOp &nextBitcast) {
+  auto divisor = getSupportedPointerBitcastScale(op);
+  if (!divisor)
+    return failure();
+
+  Value src = op.getSrc();
+  rewriter.setInsertionPoint(op);
+  if (!isa<RankedTensorType>(src.getType())) {
+    auto address = materializeScalarByteAddress(src, op.getLoc(), rewriter);
+    if (failed(address))
+      return failure();
+    auto targetPtr = rewriter.create<triton::IntToPtrOp>(
+        op.getLoc(), op.getType(), *address);
+    rewriter.replaceOp(op, targetPtr.getResult());
+    nextBitcast = nullptr;
+    return success();
+  }
+
+  if (auto addPtrOp = src.getDefiningOp<triton::AddPtrOp>()) {
+    auto scaledOffset =
+        scaleTensorPointerOffset(addPtrOp.getOffset(), *divisor, rewriter);
+    if (failed(scaledOffset))
+      return failure();
+    nextBitcast = rewriter.create<triton::BitcastOp>(op.getLoc(), op.getType(),
+                                                     addPtrOp.getPtr());
+    auto newAddPtr = rewriter.create<triton::AddPtrOp>(
+        op.getLoc(), op.getType(), nextBitcast, *scaledOffset);
+    rewriter.replaceOp(op, newAddPtr.getResult());
+    return success();
+  }
+
+  if (auto splatOp = src.getDefiningOp<triton::SplatOp>()) {
+    auto resultType = dyn_cast<RankedTensorType>(op.getType());
+    if (!resultType)
+      return failure();
+    nextBitcast = rewriter.create<triton::BitcastOp>(
+        op.getLoc(), resultType.getElementType(), splatOp.getSrc());
+    auto newSplat = rewriter.create<triton::SplatOp>(op.getLoc(), resultType,
+                                                     nextBitcast.getResult());
+    rewriter.replaceOp(op, newSplat.getResult());
+    return success();
+  }
+
+  return failure();
+}
+
+static void canonicalizeSupportedPointerBitcasts(ModuleOp moduleOp) {
+  SmallVector<triton::BitcastOp> bitcasts;
+  moduleOp.walk([&](triton::BitcastOp op) {
+    if (canRewriteSupportedPointerBitcast(op))
+      bitcasts.push_back(op);
+  });
+
+  IRRewriter rewriter(moduleOp.getContext());
+  for (triton::BitcastOp bitcast : bitcasts) {
+    triton::BitcastOp current = bitcast;
+    while (current) {
+      triton::BitcastOp next;
+      if (failed(rewriteSupportedPointerBitcast(current, rewriter, next)))
+        break;
+      current = next;
+    }
+  }
+}
 
 static RankedTensorType resolvePtrTensorType(Value ptr) {
   auto ptrType = dyn_cast<RankedTensorType>(ptr.getType());
@@ -872,6 +1094,8 @@ void TritonToUnstructurePass::runOnOperation() {
 
   ModuleOp moduleOp = getOperation();
   MLIRContext *ctx = &getContext();
+
+  canonicalizeSupportedPointerBitcasts(moduleOp);
 
   moduleOp->walk([this](triton::FuncOp funcOp) {
     replacePtrArguments(funcOp, offsetMapForLoopArgs);

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/pointer_bitcast_byte_buffer.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/pointer_bitcast_byte_buffer.mlir
@@ -1,0 +1,116 @@
+// RUN: triton-opt --triton-to-unstructure --triton-to-linalg="named-ops=True" --split-input-file %s | FileCheck %s
+// RUN: triton-opt --triton-to-unstructure --split-input-file %s | FileCheck %s --check-prefix=UNSTRUCTURE
+// RUN: triton-opt '--triton-to-unstructure=compile-on-910-95=True force-simt-template=True' --split-input-file %s | FileCheck %s --check-prefix=SIMT
+// RUN: triton-opt '--triton-to-unstructure=compile-on-910-95=True force-simt-template=True' '--triton-to-linalg=compile-on-910-95=True' --split-input-file %s | FileCheck %s --check-prefix=SIMT-LINALG
+
+// CHECK-LABEL: func.func @widen_tensor_offset
+// CHECK: scf.for
+// CHECK: hivm.hir.pointer_cast{{.*}} : memref<?xi32>
+// CHECK: return
+// UNSTRUCTURE-LABEL: tt.func public @widen_tensor_offset
+// UNSTRUCTURE: arith.divsi
+// UNSTRUCTURE: tt.ptr_to_int
+// UNSTRUCTURE: tt.int_to_ptr
+// UNSTRUCTURE-NOT: tt.bitcast
+// SIMT-LABEL: tt.func public @widen_tensor_offset
+// SIMT: ascend.indirect_load
+// SIMT-NOT: tt.bitcast
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @widen_tensor_offset(
+      %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<i32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %range = tt.make_range {start = 0 : i32, end = 8 : i32} : tensor<8xi32>
+    %four = arith.constant dense<4> : tensor<8xi32>
+    %offsets = arith.muli %range, %four : tensor<8xi32>
+    %srcs = tt.splat %src : !tt.ptr<i8> -> tensor<8x!tt.ptr<i8>>
+    %byte_ptrs = tt.addptr %srcs, %offsets : tensor<8x!tt.ptr<i8>>, tensor<8xi32>
+    %i32_ptrs = tt.bitcast %byte_ptrs : tensor<8x!tt.ptr<i8>> -> tensor<8x!tt.ptr<i32>>
+    %values = tt.load %i32_ptrs : tensor<8x!tt.ptr<i32>>
+    %dsts = tt.splat %dst : !tt.ptr<i32> -> tensor<8x!tt.ptr<i32>>
+    %dst_ptrs = tt.addptr %dsts, %range : tensor<8x!tt.ptr<i32>>, tensor<8xi32>
+    tt.store %dst_ptrs, %values : tensor<8x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @widen_scalar_multi_addptr
+// CHECK: arith.addi
+// CHECK: hivm.hir.pointer_cast{{.*}} : memref<?xbf16>
+// CHECK: return
+// UNSTRUCTURE-LABEL: tt.func public @widen_scalar_multi_addptr
+// UNSTRUCTURE: tt.ptr_to_int
+// UNSTRUCTURE: arith.addi
+// UNSTRUCTURE: tt.int_to_ptr
+// UNSTRUCTURE-NOT: tt.bitcast
+// SIMT-LINALG-LABEL: func.func @widen_scalar_multi_addptr
+// SIMT-LINALG-NOT: tt.int_to_ptr
+// SIMT-LINALG: memref.extract_aligned_pointer_as_index
+// SIMT-LINALG: memref.reinterpret_cast
+// SIMT-LINALG: bufferization.materialize_in_destination
+// SIMT-LINALG-NOT: tt.int_to_ptr
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @widen_scalar_multi_addptr(
+      %values: !tt.ptr<bf16> {tt.divisibility = 16 : i32},
+      %cache: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+      %block: i64,
+      %position: i64,
+      %block_stride: i64 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %range = tt.make_range {start = 0 : i32, end = 8 : i32} : tensor<8xi32>
+    %c576_i64 = arith.constant 576 : i64
+    %c448_i64 = arith.constant 448 : i64
+    %block_offset = arith.muli %block, %block_stride : i64
+    %block_base = tt.addptr %cache, %block_offset : !tt.ptr<i8>, i64
+    %token_offset = arith.muli %position, %c576_i64 : i64
+    %token_base = tt.addptr %block_base, %token_offset : !tt.ptr<i8>, i64
+    %rope_bytes = tt.addptr %token_base, %c448_i64 : !tt.ptr<i8>, i64
+    %rope_bf16 = tt.bitcast %rope_bytes : !tt.ptr<i8> -> !tt.ptr<bf16>
+    %rope_bases = tt.splat %rope_bf16 : !tt.ptr<bf16> -> tensor<8x!tt.ptr<bf16>>
+    %rope_ptrs = tt.addptr %rope_bases, %range : tensor<8x!tt.ptr<bf16>>, tensor<8xi32>
+    %value_bases = tt.splat %values : !tt.ptr<bf16> -> tensor<8x!tt.ptr<bf16>>
+    %value_ptrs = tt.addptr %value_bases, %range : tensor<8x!tt.ptr<bf16>>, tensor<8xi32>
+    %loaded = tt.load %value_ptrs : tensor<8x!tt.ptr<bf16>>
+    tt.store %rope_ptrs, %loaded : tensor<8x!tt.ptr<bf16>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @widen_pointer_inside_loop
+// CHECK: scf.for
+// CHECK: hivm.hir.pointer_cast{{.*}} : memref<?xbf16>
+// CHECK: return
+// UNSTRUCTURE-LABEL: tt.func public @widen_pointer_inside_loop
+// UNSTRUCTURE: scf.for
+// UNSTRUCTURE: tt.ptr_to_int
+// UNSTRUCTURE: tt.int_to_ptr
+// UNSTRUCTURE: tt.splat
+// UNSTRUCTURE: tt.addptr
+// UNSTRUCTURE-NOT: tt.bitcast
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @widen_pointer_inside_loop(
+      %src: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<bf16> {tt.divisibility = 16 : i32},
+      %count: i64) attributes {noinline = false} {
+    %range = tt.make_range {start = 0 : i32, end = 8 : i32} : tensor<8xi32>
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c576_i64 = arith.constant 576 : i64
+    %c448_i64 = arith.constant 448 : i64
+    scf.for %position = %c0_i64 to %count step %c1_i64 : i64 {
+      %token_offset = arith.muli %position, %c576_i64 : i64
+      %token_base = tt.addptr %src, %token_offset : !tt.ptr<i8>, i64
+      %rope_bytes = tt.addptr %token_base, %c448_i64 : !tt.ptr<i8>, i64
+      %rope_bf16 = tt.bitcast %rope_bytes : !tt.ptr<i8> -> !tt.ptr<bf16>
+      %rope_bases = tt.splat %rope_bf16 : !tt.ptr<bf16> -> tensor<8x!tt.ptr<bf16>>
+      %rope_ptrs = tt.addptr %rope_bases, %range : tensor<8x!tt.ptr<bf16>>, tensor<8xi32>
+      %values = tt.load %rope_ptrs : tensor<8x!tt.ptr<bf16>>
+      %dsts = tt.splat %dst : !tt.ptr<bf16> -> tensor<8x!tt.ptr<bf16>>
+      %dst_ptrs = tt.addptr %dsts, %range : tensor<8x!tt.ptr<bf16>>, tensor<8xi32>
+      tt.store %dst_ptrs, %values : tensor<8x!tt.ptr<bf16>>
+    }
+    tt.return
+  }
+}

--- a/third_party/ascend/unittest/pytest_ut/test_pointer_bitcast_byte_buffer.py
+++ b/third_party/ascend/unittest/pytest_ut/test_pointer_bitcast_byte_buffer.py
@@ -1,0 +1,203 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import struct
+
+import torch
+import torch_npu
+import triton
+import triton.language as tl
+
+
+def _write_u32_le(buffer, byte_offsets, values):
+    for byte_offset, value in zip(byte_offsets, values):
+        for byte_index, byte_value in enumerate(struct.pack("<I", value)):
+            buffer[byte_offset + byte_index] = byte_value
+
+
+def _write_bf16_le(buffer, byte_offset, values):
+    for index, value in enumerate(values):
+        fp32_bits = struct.unpack("<I", struct.pack("<f", value))[0]
+        bf16_bits = fp32_bits >> 16
+        buffer[byte_offset + index * 2] = bf16_bits & 0xFF
+        buffer[byte_offset + index * 2 + 1] = bf16_bits >> 8
+
+
+@triton.jit
+def _paged_scale_load(
+    kv_ptr,
+    block_tables_ptr,
+    out_ptr,
+    n_positions,
+    stride_kvblk,
+    stride_kvpos,
+    stride_kvbyte,
+    DIM: tl.constexpr,
+    CACHE_BLOCK_SIZE: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    positions = tl.arange(0, BLOCK)
+    mask = positions < n_positions
+    logical_block = positions // CACHE_BLOCK_SIZE
+    intra_block_pos = positions % CACHE_BLOCK_SIZE
+    physical_block = tl.load(block_tables_ptr + logical_block, mask=mask, other=0)
+    kv_base = (physical_block * stride_kvblk + intra_block_pos * stride_kvpos)
+    scale_addr = kv_base + DIM * stride_kvbyte
+    scale_ptr = (kv_ptr + scale_addr).to(tl.pointer_type(tl.uint32, 1), bitcast=True)
+    scale_u32 = tl.load(scale_ptr, mask=mask, other=0)
+    tl.store(out_ptr + positions, scale_u32.to(tl.int32), mask=mask)
+
+
+@triton.jit
+def _multi_addptr_bf16_store(
+    values_ptr,
+    cache_ptr,
+    block_idx,
+    token_pos,
+    block_stride,
+    N: tl.constexpr,
+    TOKEN_BYTES: tl.constexpr,
+    BF16_OFFSET: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    lanes = tl.arange(0, BLOCK)
+    block_base = cache_ptr + block_idx * tl.multiple_of(block_stride, 16)
+    token_base = block_base + token_pos * TOKEN_BYTES
+    bf16_ptr = (token_base + BF16_OFFSET).to(tl.pointer_type(tl.bfloat16))
+    mask = lanes < N
+    values = tl.load(values_ptr + lanes, mask=mask, other=0.0)
+    tl.store(bf16_ptr + lanes, values, mask=mask)
+
+
+@triton.jit
+def _loop_bf16_load(
+    src,
+    out,
+    count,
+    NOPE_DIM: tl.constexpr,
+    TOKEN_BYTES: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+    BLOCK: tl.constexpr,
+    NUM_WORKERS: tl.constexpr,
+):
+    worker = tl.program_id(0)
+    lanes = tl.arange(0, BLOCK)
+    mask = lanes < ROPE_DIM
+    for token_idx in range(worker, count, NUM_WORKERS):
+        token_data = src + token_idx * TOKEN_BYTES
+        bf16_ptr = (token_data + NOPE_DIM).to(tl.pointer_type(tl.bfloat16))
+        values = tl.load(bf16_ptr + lanes, mask=mask, other=0.0)
+        tl.store(out + token_idx * ROPE_DIM + lanes, values, mask=mask)
+
+
+def test_pointer_bitcast_paged_scale_tensor_offset():
+    cache_block_size = 4
+    dim = 8
+    record_bytes = dim + 4
+    stride_kvpos = record_bytes
+    stride_kvblk = cache_block_size * record_bytes
+    n_positions = 8
+    block_table = [2, 0]
+    values = [100 + index for index in range(n_positions)]
+
+    host = torch.zeros(3 * stride_kvblk, dtype=torch.uint8)
+    byte_offsets = []
+    for position in range(n_positions):
+        logical_block = position // cache_block_size
+        intra_block_pos = position % cache_block_size
+        physical_block = block_table[logical_block]
+        byte_offsets.append(physical_block * stride_kvblk + intra_block_pos * stride_kvpos + dim)
+    _write_u32_le(host, byte_offsets, values)
+
+    src = host.npu()
+    block_tables = torch.tensor(block_table, dtype=torch.int32).npu()
+    out = torch.empty((n_positions, ), dtype=torch.int32, device="npu")
+    _paged_scale_load[(1, )](
+        src,
+        block_tables,
+        out,
+        n_positions,
+        stride_kvblk,
+        stride_kvpos,
+        1,
+        DIM=dim,
+        CACHE_BLOCK_SIZE=cache_block_size,
+        BLOCK=n_positions,
+    )
+
+    torch.testing.assert_close(out.cpu(), torch.tensor(values, dtype=torch.int32), rtol=0, atol=0)
+
+
+def test_pointer_bitcast_scalar_multi_addptr_store():
+    block_idx = 1
+    token_pos = 2
+    block_stride = 2048
+    token_bytes = 576
+    bf16_offset = 448
+    values = [float(index + 1) for index in range(16)]
+    byte_offset = (block_idx * block_stride + token_pos * token_bytes + bf16_offset)
+
+    expected = torch.zeros(byte_offset + len(values) * 2 + 64, dtype=torch.uint8)
+    _write_bf16_le(expected, byte_offset, values)
+    cache = torch.zeros_like(expected).npu()
+    source = torch.tensor(values, dtype=torch.float32).to(torch.bfloat16).npu()
+    _multi_addptr_bf16_store[(1, )](
+        source,
+        cache,
+        block_idx,
+        token_pos,
+        block_stride,
+        N=len(values),
+        TOKEN_BYTES=token_bytes,
+        BF16_OFFSET=bf16_offset,
+        BLOCK=32,
+    )
+
+    torch.testing.assert_close(cache.cpu(), expected, rtol=0, atol=0)
+
+
+def test_pointer_bitcast_inside_dynamic_loop():
+    token_count = 5
+    nope_dim = 448
+    rope_dim = 8
+    token_bytes = 576
+    num_workers = 2
+    host = torch.zeros(token_count * token_bytes, dtype=torch.uint8)
+    expected_values = []
+    for token_idx in range(token_count):
+        values = [float(token_idx * rope_dim + index + 1) for index in range(rope_dim)]
+        expected_values.extend(values)
+        _write_bf16_le(host, token_idx * token_bytes + nope_dim, values)
+
+    src = host.npu()
+    out = torch.empty((token_count * rope_dim, ), dtype=torch.bfloat16, device="npu")
+    _loop_bf16_load[(num_workers, )](
+        src,
+        out,
+        token_count,
+        NOPE_DIM=nope_dim,
+        TOKEN_BYTES=token_bytes,
+        ROPE_DIM=rope_dim,
+        BLOCK=16,
+        NUM_WORKERS=num_workers,
+    )
+
+    expected = torch.tensor(expected_values, dtype=torch.float32).to(torch.bfloat16)
+    torch.testing.assert_close(out.cpu(), expected, rtol=0, atol=0)


### PR DESCRIPTION
## Summary
- canonicalize only the i8-to-bf16 and i8-to-i32 byte-buffer pointer views required by paged-attention and KV-cache kernels
- preserve scalar multi-addptr byte addresses and rescale one tensor byte-offset layer before existing lowering
- keep unsupported pointer casts and consumers on the existing main-dev path

## Tests
- add three NPU pytest cases for paged scale loads, scalar multi-addptr, and dynamic loops
- add TritonToUnstructure/TritonToLinalg MLIR coverage
- CI pending