### PR TITLE
feat(ci): add buildkit dockerfile test for docker/Dockerfile

### DIFF
--- a/.github/workflows/buildkit-dockerfile-test.yaml
+++ b/.github/workflows/buildkit-dockerfile-test.yaml
@@ -40,4 +40,5 @@ jobs:
             APTMIRROR=http://cache-service.nginx-pypi-cache.svc.cluster.local:8081
             PIP_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
             PIP_TRUSTED_HOST=cache-service.nginx-pypi-cache.svc.cluster.local
+            PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cpu
           provenance: false

--- a/.github/workflows/buildkit-dockerfile-test.yaml
+++ b/.github/workflows/buildkit-dockerfile-test.yaml
@@ -40,5 +40,4 @@ jobs:
             APTMIRROR=http://cache-service.nginx-pypi-cache.svc.cluster.local:8081
             PIP_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
             PIP_TRUSTED_HOST=cache-service.nginx-pypi-cache.svc.cluster.local
-            PYTORCH_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu
           provenance: false

--- a/.github/workflows/buildkit-dockerfile-test.yaml
+++ b/.github/workflows/buildkit-dockerfile-test.yaml
@@ -40,5 +40,5 @@ jobs:
             APTMIRROR=http://cache-service.nginx-pypi-cache.svc.cluster.local:8081
             PIP_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
             PIP_TRUSTED_HOST=cache-service.nginx-pypi-cache.svc.cluster.local
-            PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cpu
+            TORCH_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu
           provenance: false

--- a/.github/workflows/buildkit-dockerfile-test.yaml
+++ b/.github/workflows/buildkit-dockerfile-test.yaml
@@ -1,0 +1,44 @@
+name: buildkit-dockerfile-test
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/buildkit-dockerfile-test.yaml'
+      - 'docker/Dockerfile'
+  workflow_dispatch:
+
+jobs:
+  build-test:
+    name: "build docker/Dockerfile (${{ matrix.runner_info.arch }})"
+    runs-on: ${{ matrix.runner_info.runner }}
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.0.0-a3-ubuntu22.04-py3.12
+
+    strategy:
+      fail-fast: false
+      matrix:
+        runner_info:
+          - {runner: linux-aarch64-cpu-4-buildkit, arch: arm64}
+          - {runner: linux-amd64-cpu-4-buildkit, arch: amd64}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: swr.cn-southwest-2.myhuaweicloud.com/modelfoundry/test-buildkit:triton-${{ matrix.runner_info.arch }}-${{ github.sha }}
+          build-args: |
+            CANN_BASE_IMAGE=swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-a3-ubuntu22.04-py3.10
+            APTMIRROR=http://cache-service.nginx-pypi-cache.svc.cluster.local:8081
+            PIP_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+            PIP_TRUSTED_HOST=cache-service.nginx-pypi-cache.svc.cluster.local
+            PYTORCH_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu
+          provenance: false

--- a/.github/workflows/buildkit-dockerfile-test.yaml
+++ b/.github/workflows/buildkit-dockerfile-test.yaml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         runner_info:
-          - {runner: linux-aarch64-cpu-4-buildkit, arch: arm64}
-          - {runner: linux-amd64-cpu-4-buildkit, arch: amd64}
+          - {runner: linux-aarch64-cpu-4, arch: arm64}
+          - {runner: linux-amd64-cpu-4, arch: amd64}
 
     steps:
       - name: Checkout

--- a/.github/workflows/buildkit-dockerfile-test.yaml
+++ b/.github/workflows/buildkit-dockerfile-test.yaml
@@ -28,6 +28,13 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Login to SWR
+        uses: docker/login-action@v3
+        with:
+          registry: swr.cn-southwest-2.myhuaweicloud.com
+          username: ${{ secrets.SWR_USERNAME }}
+          password: ${{ secrets.SWR_PASSWORD }}
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,8 +52,7 @@ COPY requirements.txt requirements_dev.txt ./
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     python3 -m pip install torch==2.7.1+cpu \
-      --index-url ${TORCH_INDEX_URL} \
-      --trusted-host ${PIP_TRUSTED_HOST:-cache-service.nginx-pypi-cache.svc.cluster.local}
+      --find-links ${TORCH_INDEX_URL}/torch/
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     python3 -m pip install -r requirements_dev.txt && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,7 @@ ENV TZ="Asia/shanghai"
 
 ARG APTMIRROR
 ARG PIP_INDEX_URL="https://repo.huaweicloud.com/repository/pypi/simple"
+ARG PYTORCH_INDEX_URL="https://download.pytorch.org/whl/cpu"
 ARG PIP_TRUSTED_HOST=""
 
 RUN if [ -n "$APTMIRROR" ]; then \
@@ -44,7 +45,7 @@ RUN if [ -n "$APTMIRROR" ]; then \
     update-ca-certificates
 
 RUN mkdir -p /root/.config/pip && \
-    printf '[global]\nindex-url = %s\n' "$PIP_INDEX_URL" > /root/.config/pip/pip.conf && \
+    printf '[global]\nindex-url = %s\nextra-index-url = %s\n' "$PIP_INDEX_URL" "$PYTORCH_INDEX_URL" > /root/.config/pip/pip.conf && \
     if [ -n "$PIP_TRUSTED_HOST" ]; then printf 'trusted-host = %s\n' "$PIP_TRUSTED_HOST" >> /root/.config/pip/pip.conf; fi
 
 COPY requirements.txt requirements_dev.txt ./

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,14 +45,15 @@ RUN if [ -n "$APTMIRROR" ]; then \
     update-ca-certificates
 
 RUN mkdir -p /root/.config/pip && \
-    printf '[global]\nindex-url = %s\n' "$PIP_INDEX_URL" > /root/.config/pip/pip.conf && \
+    printf '[global]\nindex-url = %s\ntimeout = 600\n' "$PIP_INDEX_URL" > /root/.config/pip/pip.conf && \
     if [ -n "$PIP_TRUSTED_HOST" ]; then printf 'trusted-host = %s\n' "$PIP_TRUSTED_HOST" >> /root/.config/pip/pip.conf; fi
 
 COPY requirements.txt requirements_dev.txt ./
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     python3 -m pip install torch==2.7.1+cpu \
-      --find-links ${TORCH_INDEX_URL}/torch/
+      --find-links ${TORCH_INDEX_URL}/torch/ \
+      --timeout 600
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     python3 -m pip install -r requirements_dev.txt && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,6 @@ ENV TZ="Asia/shanghai"
 
 ARG APTMIRROR
 ARG PIP_INDEX_URL="https://repo.huaweicloud.com/repository/pypi/simple"
-ARG PYTORCH_INDEX_URL="https://download.pytorch.org/whl/cpu"
 ARG PIP_TRUSTED_HOST=""
 
 RUN if [ -n "$APTMIRROR" ]; then \
@@ -45,7 +44,7 @@ RUN if [ -n "$APTMIRROR" ]; then \
     update-ca-certificates
 
 RUN mkdir -p /root/.config/pip && \
-    printf '[global]\nindex-url = %s\nextra-index-url = %s\n' "$PIP_INDEX_URL" "$PYTORCH_INDEX_URL" > /root/.config/pip/pip.conf && \
+    printf '[global]\nindex-url = %s\n' "$PIP_INDEX_URL" > /root/.config/pip/pip.conf && \
     if [ -n "$PIP_TRUSTED_HOST" ]; then printf 'trusted-host = %s\n' "$PIP_TRUSTED_HOST" >> /root/.config/pip/pip.conf; fi
 
 COPY requirements.txt requirements_dev.txt ./

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,8 +5,17 @@ SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ="Asia/shanghai"
 
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.huaweicloud.com|g' /etc/apt/sources.list 2>/dev/null || true && \
-    sed -i 's|http://security.ubuntu.com|http://mirrors.huaweicloud.com|g' /etc/apt/sources.list 2>/dev/null || true && \
+ARG APTMIRROR
+ARG PIP_INDEX_URL="https://repo.huaweicloud.com/repository/pypi/simple"
+ARG PYTORCH_INDEX_URL="https://download.pytorch.org/whl/cpu"
+ARG PIP_TRUSTED_HOST=""
+
+RUN if [ -n "$APTMIRROR" ]; then \
+        sed -Ei "s@(ports|archive).ubuntu.com@${APTMIRROR#http://}@g" /etc/apt/sources.list; \
+    else \
+        sed -i 's|http://archive.ubuntu.com|http://mirrors.huaweicloud.com|g' /etc/apt/sources.list 2>/dev/null || true; \
+        sed -i 's|http://security.ubuntu.com|http://mirrors.huaweicloud.com|g' /etc/apt/sources.list 2>/dev/null || true; \
+    fi && \
     echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
     echo 'Acquire::http::Timeout "30";' >> /etc/apt/apt.conf.d/80-retries && \
     apt update && \
@@ -36,7 +45,8 @@ RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.huaweicloud.com|g' /etc/a
     update-ca-certificates
 
 RUN mkdir -p /root/.config/pip && \
-    echo -e "[global]\nindex-url = https://repo.huaweicloud.com/repository/pypi/simple\nextra-index-url = https://download.pytorch.org/whl/cpu" > /root/.config/pip/pip.conf
+    printf '[global]\nindex-url = %s\nextra-index-url = %s\n' "$PIP_INDEX_URL" "$PYTORCH_INDEX_URL" > /root/.config/pip/pip.conf && \
+    if [ -n "$PIP_TRUSTED_HOST" ]; then printf 'trusted-host = %s\n' "$PIP_TRUSTED_HOST" >> /root/.config/pip/pip.conf; fi
 
 COPY requirements.txt requirements_dev.txt ./
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ ENV TZ="Asia/shanghai"
 
 ARG APTMIRROR
 ARG PIP_INDEX_URL="https://repo.huaweicloud.com/repository/pypi/simple"
-ARG PYTORCH_INDEX_URL="https://download.pytorch.org/whl/cpu"
+ARG TORCH_INDEX_URL="http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
 ARG PIP_TRUSTED_HOST=""
 
 RUN if [ -n "$APTMIRROR" ]; then \
@@ -45,10 +45,15 @@ RUN if [ -n "$APTMIRROR" ]; then \
     update-ca-certificates
 
 RUN mkdir -p /root/.config/pip && \
-    printf '[global]\nindex-url = %s\nextra-index-url = %s\n' "$PIP_INDEX_URL" "$PYTORCH_INDEX_URL" > /root/.config/pip/pip.conf && \
+    printf '[global]\nindex-url = %s\n' "$PIP_INDEX_URL" > /root/.config/pip/pip.conf && \
     if [ -n "$PIP_TRUSTED_HOST" ]; then printf 'trusted-host = %s\n' "$PIP_TRUSTED_HOST" >> /root/.config/pip/pip.conf; fi
 
 COPY requirements.txt requirements_dev.txt ./
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python3 -m pip install torch==2.7.1+cpu \
+      --index-url ${TORCH_INDEX_URL} \
+      --trusted-host ${PIP_TRUSTED_HOST:-cache-service.nginx-pypi-cache.svc.cluster.local}
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     python3 -m pip install -r requirements_dev.txt && \


### PR DESCRIPTION
## Summary

Add a buildkit-dockerfile-test workflow that builds `docker/Dockerfile` on both **arm64** and **amd64** buildkit runners natively (no QEMU), using the internal cache service for faster and more reliable builds.

This is adapted from the same pattern used in vllm-ascend ([PR #13188](https://github.com/vllm-project/vllm-ascend/pull/13188)).

## Changes

### New workflow: `.github/workflows/buildkit-dockerfile-test.yaml`
- Triggered on PR to `docker/Dockerfile` and the workflow itself
- Matrix with both `linux-aarch64-cpu-4-buildkit` and `linux-amd64-cpu-4-buildkit` runners
- Builds `docker/Dockerfile` using `docker/build-push-action` with:
  - `APTMIRROR=http://cache-service.nginx-pypi-cache.svc.cluster.local:8081`
  - `PIP_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple`
  - `PYTORCH_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu`
  - `CANN_BASE_IMAGE=swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:...`

### Modified: `docker/Dockerfile`
- Added `ARG APTMIRROR`, `ARG PIP_INDEX_URL`, `ARG PYTORCH_INDEX_URL`, `ARG PIP_TRUSTED_HOST`
- APTMIRROR: when provided, rewrites apt sources.list to use the cache service; otherwise falls back to huaweicloud mirrors
- PIP_INDEX_URL/PYTORCH_INDEX_URL: configurable pip index and torch extra-index-url instead of hardcoded values
- PIP_TRUSTED_HOST: optional trusted-host for pip behind a proxy