### PR TITLE
[DiscreteMask](fix) revert SIMT path with mask for atomic_rmw

### DIFF
--- a/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
+++ b/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include "TritonToUnstructure/IndirectAtomicUtils.h"
 #include "Utils/Utils.h"
 #include "ascend/include/DiscreteMaskAccessConversion/Passes.h"
 
@@ -434,6 +433,16 @@ struct DiscreteMaskAtomicConversion
       return failure();
     }
 
+    auto [contMask, discMask] = decomposeAndMask(op, mask, loc, rewriter);
+    if (!contMask && discMask && compileOn91095Flag && forceSimtTemplateFlag) {
+      // A pure discrete mask cannot safely be removed because masked-off
+      // elements may carry out-of-bounds pointers. Keep the original mask so
+      // Unstructure can use either the masked indirect atomic template or its
+      // masked fallback.
+      op->setAttr(routeDiscreteMaskToSimtAttrName, rewriter.getUnitAttr());
+      return failure();
+    }
+
     FailureOr<mlir::Value> fill = specializeTypelessValueToConstant(
         typelessVal, src.getType(), loc, rewriter);
     if (failed(fill)) {
@@ -445,9 +454,21 @@ struct DiscreteMaskAtomicConversion
       return failure();
     }
 
-    auto maskedValue = rewriter.create<arith::SelectOp>(loc, mask, src, *fill);
+    // For mask = contMask & discMask, retain contMask as the memory-access
+    // guard and replace only the discrete part with the RMW identity value.
+    // The continuous mask can then be lowered to a bounded subview without
+    // accessing the masked-off tail.
+    Value valueMask = mask;
+    Value accessMask = nullptr;
+    if (contMask && discMask) {
+      valueMask = discMask;
+      accessMask = contMask;
+    }
+
+    auto maskedValue =
+        rewriter.create<arith::SelectOp>(loc, valueMask, src, *fill);
     auto newAtomicOp = rewriter.create<mlir::triton::AtomicRMWOp>(
-        loc, src.getType(), rmwOp, ptr, maskedValue, mlir::Value(), op.getSem(),
+        loc, src.getType(), rmwOp, ptr, maskedValue, accessMask, op.getSem(),
         op.getScope());
     rewriter.replaceOp(op, newAtomicOp);
     return success();

--- a/third_party/ascend/unittest/Conversion/General/DiscreteMaskAccess/atomic.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DiscreteMaskAccess/atomic.mlir
@@ -199,3 +199,36 @@ tt.func @atomic_max_f16(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>) {
   %9 = tt.atomic_rmw max, acq_rel, gpu, %5, %8, %3 : (tensor<1024x!tt.ptr<f16>>, tensor<1024xf16>, tensor<1024xi1>) -> tensor<1024xf16>
   tt.return
 }
+
+// -----
+
+// CHECK-LABEL: tt.func @atomic_add_cont_disc_i32
+// CHECK: %[[DEFAULT:.*]] = arith.constant dense<0> : tensor<8x8xi32>
+// CHECK: %[[CONT_MASK:.*]] = tt.broadcast {{.*}} : tensor<8x1xi1> -> tensor<8x8xi1>
+// CHECK: %[[DISC_MASK:.*]] = tt.broadcast {{.*}} : tensor<1x8xi1> -> tensor<8x8xi1>
+// CHECK: %[[VALUE:.*]] = arith.select %[[DISC_MASK]], %{{.*}}, %[[DEFAULT]] : tensor<8x8xi1>, tensor<8x8xi32>
+// CHECK: tt.atomic_rmw add, acq_rel, gpu, %{{.*}}, %[[VALUE]], %[[CONT_MASK]] : (tensor<8x8x!tt.ptr<i32>>, tensor<8x8xi32>, tensor<8x8xi1>) -> tensor<8x8xi32>
+tt.func @atomic_add_cont_disc_i32(%arg0: !tt.ptr<i32>, %arg1: i32) {
+  %cst_0 = arith.constant dense<8> : tensor<8x1xi32>
+  %cst_1 = arith.constant dense<2> : tensor<1x8xi32>
+  %cst_2 = arith.constant dense<8> : tensor<1x8xi32>
+  %cst_3 = arith.constant dense<1> : tensor<8x8xi32>
+  %0 = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+  %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<8xi32> -> tensor<8x1xi32>
+  %2 = tt.expand_dims %0 {axis = 0 : i32} : tensor<8xi32> -> tensor<1x8xi32>
+  %3 = tt.splat %arg1 : i32 -> tensor<8x1xi32>
+  %4 = arith.cmpi slt, %1, %3 : tensor<8x1xi32>
+  %5 = tt.broadcast %4 : tensor<8x1xi1> -> tensor<8x8xi1>
+  %6 = arith.muli %2, %cst_1 : tensor<1x8xi32>
+  %7 = arith.cmpi slt, %6, %cst_2 : tensor<1x8xi32>
+  %8 = tt.broadcast %7 : tensor<1x8xi1> -> tensor<8x8xi1>
+  %9 = arith.andi %5, %8 : tensor<8x8xi1>
+  %10 = arith.muli %1, %cst_0 : tensor<8x1xi32>
+  %11 = tt.broadcast %10 : tensor<8x1xi32> -> tensor<8x8xi32>
+  %12 = tt.broadcast %2 : tensor<1x8xi32> -> tensor<8x8xi32>
+  %13 = arith.addi %11, %12 : tensor<8x8xi32>
+  %14 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<8x8x!tt.ptr<i32>>
+  %15 = tt.addptr %14, %13 : tensor<8x8x!tt.ptr<i32>>, tensor<8x8xi32>
+  %16 = tt.atomic_rmw add, acq_rel, gpu, %15, %cst_3, %9 : (tensor<8x8x!tt.ptr<i32>>, tensor<8x8xi32>, tensor<8x8xi1>) -> tensor<8x8xi32>
+  tt.return
+}

--- a/third_party/ascend/unittest/Conversion/General/DiscreteMaskAccess/indirect_atomic.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DiscreteMaskAccess/indirect_atomic.mlir
@@ -1,8 +1,8 @@
 // RUN: triton-opt '--discrete-mask-access-conversion=compile-on-910-95=True force-simt-template=True' --split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: tt.func @structured_disc_mask_atomic_add_2d
-// CHECK: arith.select {{.*}} : tensor<4x4xi1>, tensor<4x4xi32>
-// CHECK: tt.atomic_rmw add, acq_rel, gpu, {{.*}} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>) -> tensor<4x4xi32>
+// CHECK-NOT: arith.select {{.*}} : tensor<4x4xi1>, tensor<4x4xi32>
+// CHECK: tt.atomic_rmw add, acq_rel, gpu, {{.*}} {route_discrete_mask_to_simt} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
 // CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<4x4x!tt.ptr<i32>>
 tt.func @structured_disc_mask_atomic_add_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>, %arg2: !tt.ptr<i32>) {
 	%cst = arith.constant dense<16> : tensor<4x4xi32>
@@ -32,8 +32,8 @@ tt.func @structured_disc_mask_atomic_add_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<
 // -----
 
 // CHECK-LABEL: tt.func @structured_disc_mask_atomic_and_2d
-// CHECK: arith.select {{.*}} : tensor<4x4xi1>, tensor<4x4xi32>
-// CHECK: tt.atomic_rmw and, acq_rel, gpu, {{.*}} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>) -> tensor<4x4xi32>
+// CHECK-NOT: arith.select {{.*}} : tensor<4x4xi1>, tensor<4x4xi32>
+// CHECK: tt.atomic_rmw and, acq_rel, gpu, {{.*}} {route_discrete_mask_to_simt} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
 // CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<4x4x!tt.ptr<i32>>
 tt.func @structured_disc_mask_atomic_and_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>, %arg2: !tt.ptr<i32>) {
 	%cst = arith.constant dense<16> : tensor<4x4xi32>
@@ -63,8 +63,8 @@ tt.func @structured_disc_mask_atomic_and_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<
 // -----
 
 // CHECK-LABEL: tt.func @structured_disc_mask_atomic_or_2d
-// CHECK: arith.select {{.*}} : tensor<4x4xi1>, tensor<4x4xi32>
-// CHECK: tt.atomic_rmw or, acq_rel, gpu, {{.*}} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>) -> tensor<4x4xi32>
+// CHECK-NOT: arith.select {{.*}} : tensor<4x4xi1>, tensor<4x4xi32>
+// CHECK: tt.atomic_rmw or, acq_rel, gpu, {{.*}} {route_discrete_mask_to_simt} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
 // CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<4x4x!tt.ptr<i32>>
 tt.func @structured_disc_mask_atomic_or_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>, %arg2: !tt.ptr<i32>) {
 	%cst = arith.constant dense<16> : tensor<4x4xi32>
@@ -94,8 +94,8 @@ tt.func @structured_disc_mask_atomic_or_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i
 // -----
 
 // CHECK-LABEL: tt.func @structured_disc_mask_atomic_xor_2d
-// CHECK: arith.select {{.*}} : tensor<4x4xi1>, tensor<4x4xi32>
-// CHECK: tt.atomic_rmw xor, acq_rel, gpu, {{.*}} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>) -> tensor<4x4xi32>
+// CHECK-NOT: arith.select {{.*}} : tensor<4x4xi1>, tensor<4x4xi32>
+// CHECK: tt.atomic_rmw xor, acq_rel, gpu, {{.*}} {route_discrete_mask_to_simt} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
 // CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<4x4x!tt.ptr<i32>>
 tt.func @structured_disc_mask_atomic_xor_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>, %arg2: !tt.ptr<i32>) {
 	%cst = arith.constant dense<16> : tensor<4x4xi32>
@@ -155,8 +155,8 @@ tt.func @structured_disc_mask_atomic_xchg_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr
 // -----
 
 // CHECK-LABEL: tt.func @structured_disc_mask_atomic_max_2d
-// CHECK: arith.select {{.*}} : tensor<4x4xi1>, tensor<4x4xi32>
-// CHECK: tt.atomic_rmw max, acq_rel, gpu, {{.*}} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>) -> tensor<4x4xi32>
+// CHECK-NOT: arith.select {{.*}} : tensor<4x4xi1>, tensor<4x4xi32>
+// CHECK: tt.atomic_rmw max, acq_rel, gpu, {{.*}} {route_discrete_mask_to_simt} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
 // CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<4x4x!tt.ptr<i32>>
 tt.func @structured_disc_mask_atomic_max_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>, %arg2: !tt.ptr<i32>) {
 	%cst = arith.constant dense<16> : tensor<4x4xi32>
@@ -186,8 +186,8 @@ tt.func @structured_disc_mask_atomic_max_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<
 // -----
 
 // CHECK-LABEL: tt.func @structured_disc_mask_atomic_min_2d
-// CHECK: arith.select {{.*}} : tensor<4x4xi1>, tensor<4x4xi32>
-// CHECK: tt.atomic_rmw min, acq_rel, gpu, {{.*}} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>) -> tensor<4x4xi32>
+// CHECK-NOT: arith.select {{.*}} : tensor<4x4xi1>, tensor<4x4xi32>
+// CHECK: tt.atomic_rmw min, acq_rel, gpu, {{.*}} {route_discrete_mask_to_simt} : (tensor<4x4x!tt.ptr<i32>>, tensor<4x4xi32>, tensor<4x4xi1>) -> tensor<4x4xi32>
 // CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<4x4x!tt.ptr<i32>>
 tt.func @structured_disc_mask_atomic_min_2d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>, %arg2: !tt.ptr<i32>) {
 	%cst = arith.constant dense<16> : tensor<4x4xi32>

--- a/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/indirect_atomic.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/indirect_atomic.mlir
@@ -1,5 +1,48 @@
 // RUN: triton-opt '--discrete-mask-access-conversion=compile-on-910-95=True force-simt-template=True' '--triton-to-unstructure=compile-on-910-95=True force-simt-template=True' --split-input-file %s | FileCheck %s
 
+// CHECK-LABEL: tt.func public @structured_discrete_mask_atomic_add_1d
+// CHECK-NOT: arith.select {{.*}} : tensor<8xi1>, tensor<8xi32>
+// CHECK: %[[MASK_I8:.*]] = arith.extui {{.*}} : tensor<8xi1> to tensor<8xi8>
+// CHECK: hivm.hir.custom {extra_attr = "operate=add"{{.*}}} "__builtin_indirect_atomic" ins(%arg1, {{.*}}, {{.*}}, %[[MASK_I8]]
+tt.func public @structured_discrete_mask_atomic_add_1d(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
+	%cst = arith.constant dense<2> : tensor<8xi32>
+	%cst_0 = arith.constant dense<8> : tensor<8xi32>
+	%0 = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+	%1 = arith.muli %0, %cst : tensor<8xi32>
+	%2 = arith.cmpi slt, %1, %cst_0 : tensor<8xi32>
+	%3 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<8x!tt.ptr<i32>>
+	%4 = tt.addptr %3, %0 : tensor<8x!tt.ptr<i32>>, tensor<8xi32>
+	%5 = tt.load %4 : tensor<8x!tt.ptr<i32>>
+	%6 = tt.splat %arg1 : !tt.ptr<i32> -> tensor<8x!tt.ptr<i32>>
+	%7 = tt.addptr %6, %0 : tensor<8x!tt.ptr<i32>>, tensor<8xi32>
+	%8 = tt.atomic_rmw add, acq_rel, gpu, %7, %5, %2 : (tensor<8x!tt.ptr<i32>>, tensor<8xi32>, tensor<8xi1>) -> tensor<8xi32>
+	tt.return
+}
+
+// -----
+
+// CHECK-LABEL: tt.func public @structured_discrete_mask_atomic_add_i16_fallback
+// CHECK-NOT: arith.select {{.*}} : tensor<8xi1>, tensor<8xi16>
+// CHECK: scf.for
+// CHECK: scf.if
+// CHECK: tt.atomic_rmw add, acq_rel, gpu, {{.*}} {DiscreteMemAccess}
+tt.func public @structured_discrete_mask_atomic_add_i16_fallback(%arg0: !tt.ptr<i16>, %arg1: !tt.ptr<i16>) {
+	%cst = arith.constant dense<2> : tensor<8xi32>
+	%cst_0 = arith.constant dense<8> : tensor<8xi32>
+	%0 = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+	%1 = arith.muli %0, %cst : tensor<8xi32>
+	%2 = arith.cmpi slt, %1, %cst_0 : tensor<8xi32>
+	%3 = tt.splat %arg0 : !tt.ptr<i16> -> tensor<8x!tt.ptr<i16>>
+	%4 = tt.addptr %3, %0 : tensor<8x!tt.ptr<i16>>, tensor<8xi32>
+	%5 = tt.load %4 : tensor<8x!tt.ptr<i16>>
+	%6 = tt.splat %arg1 : !tt.ptr<i16> -> tensor<8x!tt.ptr<i16>>
+	%7 = tt.addptr %6, %0 : tensor<8x!tt.ptr<i16>>, tensor<8xi32>
+	%8 = tt.atomic_rmw add, acq_rel, gpu, %7, %5, %2 : (tensor<8x!tt.ptr<i16>>, tensor<8xi16>, tensor<8xi1>) -> tensor<8xi16>
+	tt.return
+}
+
+// -----
+
 // CHECK-LABEL: tt.func public @fully_unstructured_atomic_add_2d
 // CHECK: %[[MASK_TRUE:.*]] = arith.constant dense<1> : tensor<16xi8>
 // CHECK: %[[OFFSET_FLAT:.*]] = tt.reshape {{.*}} : tensor<4x4xi64> -> tensor<16xi64>

--- a/third_party/ascend/unittest/pytest_ut/test_indirect_atomic_add.py
+++ b/third_party/ascend/unittest/pytest_ut/test_indirect_atomic_add.py
@@ -28,13 +28,15 @@
 #  | structured pointer + discrete mask              | (A1) | (A2) | (A3) | (A4) | (A5) |
 #  | partial structured: high-dim disc + low-dim cont|  -   | (B2) | (B3) | (B4) | (B5) |
 #  | fully unstructured indirect offsets             | (C1) | (C2) | (C3) | (C4) | (C5) |
+#  | loaded mask + masked-off out-of-bounds offsets   | (D1) |  -   |  -   |  -   |  -   |
 #
 # Notes:
 # 1. Case A exercises the structured-pointer discrete-mask atomic_add path.
 # 2. Case B exercises a single high-dimension discrete remap with the
 #    remaining lower dimensions kept contiguous.
 # 3. Case C exercises fully unstructured indirect offsets.
-# 4. All cases validate both the final destination tensor and the atomic_add
+# 4. Case D verifies that a loaded discrete mask guards loaded invalid offsets.
+# 5. All cases validate both the final destination tensor and the atomic_add
 #    return value, which must be the old value observed at each access.
 # =============================================================================
 
@@ -90,6 +92,23 @@ def structured_disc_mask_atomic_add_1d(
     mask = (linear * 2) < D0
     value = tl.load(val_ptr + linear)
     old = tl.atomic_add(out_ptr + linear, value, mask=mask)
+    tl.store(old_ptr + linear, old, mask=mask)
+
+
+@triton.jit
+def loaded_mask_oob_offset_atomic_add_1d(
+    idx_ptr,
+    mask_ptr,
+    val_ptr,
+    out_ptr,
+    old_ptr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    linear = tl.arange(0, BLOCK_SIZE)
+    offset = tl.load(idx_ptr + linear)
+    mask = tl.load(mask_ptr + linear) != 0
+    value = tl.load(val_ptr + linear)
+    old = tl.atomic_add(out_ptr + offset, value, mask=mask)
     tl.store(old_ptr + linear, old, mask=mask)
 
 
@@ -534,3 +553,39 @@ def test_atomic_add_fully_unstructured_indirect_offsets(dtype_name, torch_dtype,
     )
     _assert_equal(output, expected_output, dtype_name, rank, "fully-unstructured-indirect/output")
     _assert_equal(old, expected_old, dtype_name, rank, "fully-unstructured-indirect/old")
+
+
+def test_atomic_add_loaded_mask_skips_oob_offsets():
+    if not is_compile_on_910_95():
+        pytest.skip("masked indirect atomic template is only enabled on 910_95/950")
+
+    block_size = 8
+    invalid_offset = 1 << 30
+    offsets = torch.tensor(
+        [0, invalid_offset, 1, invalid_offset, 2, invalid_offset, 3, invalid_offset],
+        dtype=torch.int64,
+    )
+    mask = torch.tensor([1, 0, 1, 0, 1, 0, 1, 0], dtype=torch.int32)
+    values = torch.ones(block_size, dtype=torch.int32)
+    baseline = torch.tensor([10, 20, 30, 40], dtype=torch.int32)
+    old_sentinel = -777
+
+    output = baseline.clone().npu()
+    old = torch.full((block_size, ), old_sentinel, dtype=torch.int32).npu()
+    loaded_mask_oob_offset_atomic_add_1d[(1, )](
+        offsets.npu(),
+        mask.npu(),
+        values.npu(),
+        output,
+        old,
+        BLOCK_SIZE=block_size,
+    )
+    torch.npu.synchronize()
+
+    expected_output = baseline + 1
+    expected_old = torch.tensor(
+        [10, old_sentinel, 20, old_sentinel, 30, old_sentinel, 40, old_sentinel],
+        dtype=torch.int32,
+    )
+    _assert_equal(output, expected_output, "int32", 1, "loaded-mask-oob-offset/output")
+    _assert_equal(old, expected_old, "int32", 1, "loaded-mask-oob-offset/old")


### PR DESCRIPTION
`DiscreteMaskAtomicConversion` previously lowered a masked `atomic_rmw` by selecting the RMW identity value for masked-off lanes and then removing the mask.

Although this preserves numerical results when all pointers are valid, the resulting unmasked atomic still accesses every pointer. For indirect offsets loaded at runtime, masked-off lanes may contain out-of-bounds addresses and cause runtime failures.

## Changes

- Preserve pure discrete masks for atomic RMW operations supported by the 910_95/950 SIMT indirect-atomic fast path, and route them to the masked `__builtin_indirect_atomic` lowering.
- For `mask = contMask & discMask`:
  - use `discMask` to select the RMW identity value;
  - retain `contMask` as the atomic access mask.
  
  This keeps the continuous-mask optimization while preventing accesses to the masked-off tail.
