### PR TITLE
[TritonToLinalg](fix) reset ReinterpretCastOp result type offset to 0

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -1206,12 +1206,27 @@ void TritonToLinalgPass::runOnOperation() {
       markOp->setAttr(hivm::AddressSpaceAttr::getMnemonic(),
                       {hivm::AddressSpaceAttr::get(rewriter.getContext(),
                                                    hivm::AddressSpace::GM)});
+
+      // update result offset
+      auto origResultType =
+          cast<MemRefType>(reinterpretCastOp.getResult().getType());
+      MemRefType newResultType = origResultType;
+      if (auto stridedLayout =
+              dyn_cast<StridedLayoutAttr>(origResultType.getLayout())) {
+        int64_t offset = stridedLayout.getOffset();
+        if (!ShapedType::isDynamic(offset)) {
+          auto newLayout = StridedLayoutAttr::get(rewriter.getContext(), 0,
+                                                  stridedLayout.getStrides());
+          newResultType = MemRefType::get(
+              origResultType.getShape(), origResultType.getElementType(),
+              newLayout, origResultType.getMemorySpace());
+        }
+      }
+
       rewriter.replaceOpWithNewOp<memref::ReinterpretCastOp>(
-          reinterpretCastOp,
-          cast<MemRefType>(reinterpretCastOp.getResult().getType()), newCastOp,
-          ValueRange({}), reinterpretCastOp.getSizes(),
-          reinterpretCastOp.getStrides(), SmallVector<int64_t>({0}),
-          reinterpretCastOp.getStaticSizes(),
+          reinterpretCastOp, newResultType, newCastOp, ValueRange({}),
+          reinterpretCastOp.getSizes(), reinterpretCastOp.getStrides(),
+          SmallVector<int64_t>({0}), reinterpretCastOp.getStaticSizes(),
           reinterpretCastOp.getStaticStrides());
     }
     rewriter.eraseOp(op);

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_inttoptr_offset_reset.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_inttoptr_offset_reset.mlir
@@ -1,0 +1,68 @@
+// RUN: triton-opt "--triton-to-linalg=global-kernel=false named-ops=True" --split-input-file %s | FileCheck %s
+
+// Test that ReinterpretCastOp's result type has offset: 0 after the
+// "Calculate size of PointerCastOp precisely" optimization.
+//
+// When a scalar tt.addptr adds a constant offset to a tt.int_to_ptr result,
+// the conversion creates a hivm.pointer_cast + memref.reinterpret_cast with
+// the original offset in the result type. The optimization then bakes the
+// offset into the base address (realAddr = addr + offset * elemSize) and
+// creates a new ReinterpretCastOp with offset 0. The result type's strided
+// layout must also have offset 0, otherwise the op offset and type offset
+// are inconsistent.
+
+// CHECK-LABEL: func.func @test_inttoptr_offset_reset
+// The optimized ReinterpretCastOp must have offset 0 in the result type.
+// CHECK: memref.reinterpret_cast {{.*}} strided<[1]>
+// CHECK-NOT: memref.reinterpret_cast {{.*}} strided<[1], offset: 4>
+
+module attributes {hacc.target = #hacc.target<"Ascend910B4">} {
+  tt.func public @test_inttoptr_offset_reset(%addr_ptr: !tt.ptr<i64> {tt.divisibility = 16 : i32}, %out_ptr: !tt.ptr<i32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c4_i32 = arith.constant 4 : i32
+    // Load a raw i64 address from memory, then convert to pointer.
+    // This creates a hivm.pointer_cast during conversion.
+    %raw_addr = tt.load %addr_ptr : !tt.ptr<i64>
+    %ptr = tt.int_to_ptr %raw_addr : i64 -> !tt.ptr<i32>
+    // Scalar addptr with a constant offset — the offset ends up in the
+    // ReinterpretCastOp result type's strided layout.
+    %offset_ptr = tt.addptr %ptr, %c4_i32 : !tt.ptr<i32>, i32
+    // Splat to tensor and load via indirect addressing.
+    %ptrs = tt.splat %offset_ptr : !tt.ptr<i32> -> tensor<8x!tt.ptr<i32>>
+    %offsets = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+    %load_ptrs = tt.addptr %ptrs, %offsets : tensor<8x!tt.ptr<i32>>, tensor<8xi32>
+    %data = tt.load %load_ptrs : tensor<8x!tt.ptr<i32>>
+    // Store result.
+    %out_ptrs = tt.splat %out_ptr : !tt.ptr<i32> -> tensor<8x!tt.ptr<i32>>
+    %out_addptr = tt.addptr %out_ptrs, %offsets : tensor<8x!tt.ptr<i32>>, tensor<8xi32>
+    tt.store %out_addptr, %data : tensor<8x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// -----
+
+// Dynamic offset variant: the scalar tt.addptr uses a runtime value as
+// offset, so the original ReinterpretCastOp has a dynamic offset (?)
+// in its result type. After the optimization bakes the offset into the
+// base address, the new ReinterpretCastOp still have a dynamic offset
+// in the result type.
+
+// CHECK-LABEL: func.func @test_inttoptr_dyn_offset_reset
+// CHECK: memref.reinterpret_cast {{.*}} strided<[1], offset: ?>
+
+module attributes {hacc.target = #hacc.target<"Ascend910B4">} {
+  tt.func public @test_inttoptr_dyn_offset_reset(%addr_ptr: !tt.ptr<i64> {tt.divisibility = 16 : i32}, %out_ptr: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %dyn_offset: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %raw_addr = tt.load %addr_ptr : !tt.ptr<i64>
+    %ptr = tt.int_to_ptr %raw_addr : i64 -> !tt.ptr<i32>
+    // Scalar addptr with a dynamic (runtime) offset.
+    %offset_ptr = tt.addptr %ptr, %dyn_offset : !tt.ptr<i32>, i32
+    %ptrs = tt.splat %offset_ptr : !tt.ptr<i32> -> tensor<8x!tt.ptr<i32>>
+    %offsets = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+    %load_ptrs = tt.addptr %ptrs, %offsets : tensor<8x!tt.ptr<i32>>, tensor<8xi32>
+    %data = tt.load %load_ptrs : tensor<8x!tt.ptr<i32>>
+    %out_ptrs = tt.splat %out_ptr : !tt.ptr<i32> -> tensor<8x!tt.ptr<i32>>
+    %out_addptr = tt.addptr %out_ptrs, %offsets : tensor<8x!tt.ptr<i32>>, tensor<8xi32>
+    tt.store %out_addptr, %data : tensor<8x!tt.ptr<i32>>
+    tt.return
+  }
+}

--- a/third_party/ascend/unittest/pytest_ut/test_inttoptr_offset_reset.py
+++ b/third_party/ascend/unittest/pytest_ut/test_inttoptr_offset_reset.py
@@ -1,0 +1,95 @@
+import torch
+import torch_npu  # noqa: F401
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _inttoptr_static_offset_kernel(
+    block_table_ptrs,
+    out,
+    BLOCK_SIZE: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    offsets = tl.arange(0, BLOCK)
+
+    # Load a raw i64 address and cast to pointer — creates tt.int_to_ptr.
+    block_table_ptr = tl.load(block_table_ptrs).to(tl.pointer_type(tl.int32))
+
+    # Scalar addptr with a constant offset — creates a ReinterpretCastOp
+    # whose result type has a non-zero static offset in the strided layout.
+    block_table_ptr = block_table_ptr + 1
+
+    block_numbers = tl.load(block_table_ptr + offsets)
+    slot_ids = block_numbers.to(tl.int64)
+    tl.store(out + offsets, slot_ids)
+
+
+@triton.jit
+def _inttoptr_dyn_offset_kernel(
+    block_table_ptrs,
+    dyn_offset,
+    out,
+    BLOCK_SIZE: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    offsets = tl.arange(0, BLOCK)
+
+    block_table_ptr = tl.load(block_table_ptrs).to(tl.pointer_type(tl.int32))
+
+    # Scalar addptr with a runtime offset — creates a ReinterpretCastOp
+    # whose result type has a dynamic offset (?) in the strided layout.
+    block_table_ptr = block_table_ptr + tl.load(dyn_offset)
+
+    block_numbers = tl.load(block_table_ptr + offsets)
+    slot_ids = block_numbers.to(tl.int64)
+    tl.store(out + offsets, slot_ids)
+
+
+def test_inttoptr_static_offset_reset():
+    """Static offset (constant 1) baked into base address."""
+    block = 8
+
+    block_table_cpu = torch.arange(16, dtype=torch.int32)
+    block_table = block_table_cpu.npu()
+    out = torch.empty((block, ), dtype=torch.int64, device="npu")
+
+    block_table_ptrs = torch.tensor([block_table.data_ptr()], dtype=torch.int64).npu()
+
+    _inttoptr_static_offset_kernel[(1, )](
+        block_table_ptrs,
+        out,
+        BLOCK_SIZE=4,
+        BLOCK=block,
+    )
+    torch.npu.synchronize()
+
+    # offset 1 => skip block_table[0]
+    expected = block_table_cpu[1:1 + block].to(torch.int64)
+    torch.testing.assert_close(out.cpu(), expected.cpu())
+
+
+def test_inttoptr_dyn_offset_reset():
+    """Dynamic offset (runtime value) baked into base address."""
+    block = 8
+
+    block_table_cpu = torch.arange(16, dtype=torch.int32)
+    block_table = block_table_cpu.npu()
+    out = torch.empty((block, ), dtype=torch.int64, device="npu")
+
+    block_table_ptrs = torch.tensor([block_table.data_ptr()], dtype=torch.int64).npu()
+    dyn_offset = torch.tensor([2], dtype=torch.int32).npu()
+
+    _inttoptr_dyn_offset_kernel[(1, )](
+        block_table_ptrs,
+        dyn_offset,
+        out,
+        BLOCK_SIZE=4,
+        BLOCK=block,
+    )
+    torch.npu.synchronize()
+
+    # dynamic offset 2 => skip block_table[0:2]
+    expected = block_table_cpu[2:2 + block].to(torch.int64)
+    torch.testing.assert_close(out.cpu(), expected.cpu())


### PR DESCRIPTION
## Description
When baking the pointer offset into the base address during the "Calculate size of PointerCastOp precisely" optimization, the new ReinterpretCastOp sets offset to 0 in its static_offsets parameter, but the result MemRefType's StridedLayoutAttr still carries the original non-zero offset. This inconsistency between the op offset (0) and the type offset (non-zero) is fixed by reconstructing the MemRefType with offset 0 in the strided layout.

## Reproduce
```python
import torch
import torch_npu  # noqa: F401

import triton
import triton.language as tl


@triton.jit
def _inttoptr_static_offset_kernel(
    block_table_ptrs,
    out,
    BLOCK_SIZE: tl.constexpr,
    BLOCK: tl.constexpr,
):
    offsets = tl.arange(0, BLOCK)

    # Load a raw i64 address and cast to pointer — creates tt.int_to_ptr.
    block_table_ptr = tl.load(block_table_ptrs).to(tl.pointer_type(tl.int32))

    # Scalar addptr with a constant offset — creates a ReinterpretCastOp
    # whose result type has a non-zero static offset in the strided layout.
    block_table_ptr = block_table_ptr + 1

    block_numbers = tl.load(block_table_ptr + offsets)
    slot_ids = block_numbers.to(tl.int64)
    tl.store(out + offsets, slot_ids)


if __name__ == '__main__':
    """Static offset (constant 1) baked into base address."""
    block = 8

    block_table_cpu = torch.arange(16, dtype=torch.int32)
    block_table = block_table_cpu.npu()
    out = torch.empty((block,), dtype=torch.int64, device="npu")

    block_table_ptrs = torch.tensor(
        [block_table.data_ptr()], dtype=torch.int64
    ).npu()

    _inttoptr_static_offset_kernel[(1,)](
        block_table_ptrs,
        out,
        BLOCK_SIZE=4,
        BLOCK=block,
    )
    torch.npu.synchronize()

    # offset 1 => skip block_table[0]
    expected = block_table_cpu[1 : 1 + block].to(torch.int64)
    assert torch.equal(out.cpu(), expected.cpu())

```
Output:
```bash
test.py:24:46: error: expected result type with offset = 0 instead of 1
    block_numbers = tl.load(block_table_ptr + offsets)
                                             ^
```

## Fix
Before constructing the new ReinterpretCastOp , extract the original MemRefType , check if its layout is a StridedLayoutAttr , and if so, rebuild the layout with offset 0 (preserving the original strides). The new MemRefType with the corrected layout is then passed to the builder.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
