### PR TITLE
[TritonToGraph](feat) Add merge-concat-load-buffer pass

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -213,6 +213,13 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
         ascend.passes.ttir.add_triton_to_structure(pm, enable_mask_fallback_conversion, optimize_dynamic_offset)
         ascend.passes.ttir.add_triton_to_linalg(pm, False, named_ops, enable_nd2nz_on_vector, enable_select_analysis,
                                                 compile_on_910_95)
+        # Restricted to 910_95/950. The merged buffer is written by two disjoint
+        # memref.copy ops, and on 910_9362 the generated code only makes the
+        # copy next to the surviving to_tensor visible, so the other half of the
+        # tile reads back the padding value. The IR is unchanged through
+        # bishengir-opt, so the loss happens in code generation.
+        if compile_on_910_95:
+            ascend.passes.ttir.add_merge_concat_load_buffer(pm)
         if metadata["enable_dynamic_cv_pipeline"]:
             metadata["set_workspace_multibuffer"] = 0
             metadata["enable_mixed_cv"] = True

--- a/third_party/ascend/include/TritonToGraph/Passes.h
+++ b/third_party/ascend/include/TritonToGraph/Passes.h
@@ -33,6 +33,10 @@ namespace cfg {
 // 创建 BuildCFG pass 的工厂函数
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createBuildCFGPass();
 
+// Merge disjoint masked-load UB buffers concatenated by insert_slice.
+std::unique_ptr<OperationPass<mlir::ModuleOp>>
+createMergeConcatLoadBufferPass();
+
 // 注册所有 CFG 相关的 passes
 #define GEN_PASS_REGISTRATION
 #include "ascend/include/TritonToGraph/Passes.h.inc"

--- a/third_party/ascend/include/TritonToGraph/Passes.td
+++ b/third_party/ascend/include/TritonToGraph/Passes.td
@@ -42,4 +42,31 @@ def BuildCFG : Pass<"build-cfg", "mlir::ModuleOp"> {
   ];
 }
 
+def MergeConcatLoadBuffer : Pass<"merge-concat-load-buffer", "mlir::ModuleOp"> {
+  let summary = "Merge disjoint masked-load UB buffers concatenated by insert_slice";
+  let description = [{
+    After triton-to-linalg, each masked tt.load allocates a full-tile UB buffer,
+    fills it with the padding value, and copies only the masked subview. A
+    subsequent cat/join is lowered to extract_slice + insert_slice, so two
+    allocs that write disjoint regions of the same static shape can be merged
+    into one memref.alloc.
+
+    If the union of copy destinations is proven to cover every later read of
+    the concatenated tensor, both linalg.fill ops are deleted. Otherwise a
+    single fill is kept (when both fills are bare and use the same value), or
+    the rewrite is abandoned.
+
+    A fill only counts as padding when it runs before the copies that overwrite
+    it, so a fill placed after them is what the concatenated value observes and
+    the rewrite is abandoned. The fill that survives a merge must additionally
+    precede the copies of both buffers, since it initialises the shared one.
+
+    The merged buffer ends up written by two disjoint memref.copy ops. On
+    910_9362 the generated code only makes the copy next to the surviving
+    to_tensor visible and the rest of the tile reads back the padding value, so
+    the pipeline only enables this pass on 910_95/950.
+  }];
+  let constructor = "mlir::triton::cfg::createMergeConcatLoadBufferPass()";
+}
+
 #endif // TRITON_TO_CFG_PASSES

--- a/third_party/ascend/lib/TritonToGraph/CMakeLists.txt
+++ b/third_party/ascend/lib/TritonToGraph/CMakeLists.txt
@@ -4,6 +4,7 @@ add_triton_library(TritonToGraph
   ControlFlowGraphBuilder.cpp
   DataflowGraph.cpp
   MemorySsaBuilder.cpp
+  MergeConcatLoadBuffer.cpp
   Passes.cpp
 
   DEPENDS
@@ -11,13 +12,17 @@ add_triton_library(TritonToGraph
 
   LINK_LIBS PUBLIC
   MLIRArithDialect
+  MLIRBufferizationDialect
   MLIRControlFlowDialect
   MLIRDialectUtils
   MLIRIR
   MLIRFuncDialect
+  MLIRLinalgDialect
+  MLIRMemRefDialect
   MLIRPass
   MLIRSCFDialect
   MLIRSupport
+  MLIRTensorDialect
   MLIRTransforms
   TritonIR
   TritonTransforms

--- a/third_party/ascend/lib/TritonToGraph/MergeConcatLoadBuffer.cpp
+++ b/third_party/ascend/lib/TritonToGraph/MergeConcatLoadBuffer.cpp
@@ -1,0 +1,576 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "TritonToGraph/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Debug.h"
+
+#include <limits>
+
+#define DEBUG_TYPE "merge-concat-load-buffer"
+
+namespace mlir {
+namespace triton {
+namespace cfg {
+#define GEN_PASS_DEF_MERGECONCATLOADBUFFER
+#include "ascend/include/TritonToGraph/Passes.h.inc"
+} // namespace cfg
+} // namespace triton
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::triton::cfg;
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// OpFoldResult / box geometry
+//===----------------------------------------------------------------------===//
+
+static bool isSameOFR(OpFoldResult a, OpFoldResult b) {
+  if (a == b)
+    return true;
+  std::optional<int64_t> ca = getConstantIntValue(a);
+  std::optional<int64_t> cb = getConstantIntValue(b);
+  return ca && cb && *ca == *cb;
+}
+
+static bool allUnitStrides(ArrayRef<OpFoldResult> strides) {
+  return llvm::all_of(strides,
+                      [](OpFoldResult s) { return isConstantIntValue(s, 1); });
+}
+
+static std::optional<int64_t> addConst(OpFoldResult offset, OpFoldResult size) {
+  std::optional<int64_t> off = getConstantIntValue(offset);
+  std::optional<int64_t> sz = getConstantIntValue(size);
+  if (!off || !sz)
+    return std::nullopt;
+  // No real tile comes anywhere near overflowing here, but a box that does is
+  // reported as unknown rather than wrapping around into a bogus bound.
+  if (*off < 0 || *sz < 0 || *off > std::numeric_limits<int64_t>::max() - *sz)
+    return std::nullopt;
+  return *off + *sz;
+}
+
+struct Box {
+  SmallVector<OpFoldResult> offsets;
+  SmallVector<OpFoldResult> sizes;
+
+  unsigned rank() const { return offsets.size(); }
+};
+
+static Box makeFullBox(ArrayRef<int64_t> shape, MLIRContext *ctx) {
+  Builder b(ctx);
+  Box box;
+  box.offsets.resize(shape.size(), b.getIndexAttr(0));
+  for (int64_t dim : shape)
+    box.sizes.push_back(b.getIndexAttr(dim));
+  return box;
+}
+
+// Prove [wOff, wOff+wSz) ⊆ [iOff, iOff+iSz). Dynamic write sizes are assumed
+// to be in-bounds for a well-formed subview of a static alloc when the insert
+// region covers that entire dimension.
+static bool intervalContained(OpFoldResult wOff, OpFoldResult wSz,
+                              OpFoldResult iOff, OpFoldResult iSz,
+                              int64_t allocDim) {
+  if (isSameOFR(wOff, iOff) && isSameOFR(wSz, iSz))
+    return true;
+
+  std::optional<int64_t> wOffC = getConstantIntValue(wOff);
+  std::optional<int64_t> wSzC = getConstantIntValue(wSz);
+  std::optional<int64_t> iOffC = getConstantIntValue(iOff);
+  std::optional<int64_t> iSzC = getConstantIntValue(iSz);
+  if (wOffC && wSzC && iOffC && iSzC)
+    return *wOffC >= *iOffC && (*wOffC + *wSzC) <= (*iOffC + *iSzC);
+
+  if (isSameOFR(wOff, iOff) && isConstantIntValue(wOff, 0) && iSzC &&
+      *iSzC == allocDim)
+    return true;
+  return false;
+}
+
+static bool boxContainedIn(const Box &inner, const Box &outer,
+                           ArrayRef<int64_t> allocShape) {
+  if (inner.rank() != outer.rank() || inner.rank() != allocShape.size())
+    return false;
+  for (unsigned d = 0; d < inner.rank(); ++d) {
+    if (!intervalContained(inner.offsets[d], inner.sizes[d], outer.offsets[d],
+                           outer.sizes[d], allocShape[d]))
+      return false;
+  }
+  return true;
+}
+
+static bool intervalsDisjoint(OpFoldResult aOff, OpFoldResult aSz,
+                              OpFoldResult bOff, OpFoldResult bSz) {
+  std::optional<int64_t> aEnd = addConst(aOff, aSz);
+  std::optional<int64_t> bEnd = addConst(bOff, bSz);
+  std::optional<int64_t> aOffC = getConstantIntValue(aOff);
+  std::optional<int64_t> bOffC = getConstantIntValue(bOff);
+  if (aEnd && bOffC && *aEnd <= *bOffC)
+    return true;
+  if (bEnd && aOffC && *bEnd <= *aOffC)
+    return true;
+  return false;
+}
+
+static bool boxesDisjoint(const Box &a, const Box &b) {
+  if (a.rank() != b.rank())
+    return false;
+  for (unsigned d = 0; d < a.rank(); ++d) {
+    if (intervalsDisjoint(a.offsets[d], a.sizes[d], b.offsets[d], b.sizes[d]))
+      return true;
+  }
+  return false;
+}
+
+// Union boxes that differ on exactly one dimension and abut on that dimension.
+static std::optional<Box> unionBoxesAlongOneDim(ArrayRef<Box> boxes,
+                                                MLIRContext *ctx) {
+  if (boxes.empty())
+    return std::nullopt;
+  if (boxes.size() == 1)
+    return Box(boxes.front());
+
+  unsigned rank = boxes.front().rank();
+  for (const Box &box : boxes) {
+    if (box.rank() != rank)
+      return std::nullopt;
+  }
+
+  SmallVector<unsigned> diffDims;
+  for (unsigned d = 0; d < rank; ++d) {
+    bool same = llvm::all_of(boxes, [&](const Box &box) {
+      return isSameOFR(box.offsets[d], boxes.front().offsets[d]) &&
+             isSameOFR(box.sizes[d], boxes.front().sizes[d]);
+    });
+    if (!same)
+      diffDims.push_back(d);
+  }
+  if (diffDims.size() != 1)
+    return std::nullopt;
+
+  unsigned dim = diffDims.front();
+  struct Interval {
+    int64_t start;
+    int64_t end;
+  };
+  SmallVector<Interval> intervals;
+  intervals.reserve(boxes.size());
+  for (const Box &box : boxes) {
+    std::optional<int64_t> start = getConstantIntValue(box.offsets[dim]);
+    std::optional<int64_t> end = addConst(box.offsets[dim], box.sizes[dim]);
+    if (!start || !end || *end < *start)
+      return std::nullopt;
+    intervals.push_back({*start, *end});
+  }
+  llvm::sort(intervals,
+             [](Interval lhs, Interval rhs) { return lhs.start < rhs.start; });
+  for (size_t i = 1; i < intervals.size(); ++i) {
+    if (intervals[i].start != intervals[i - 1].end)
+      return std::nullopt;
+  }
+
+  Builder b(ctx);
+  Box result = boxes.front();
+  result.offsets[dim] = b.getIndexAttr(intervals.front().start);
+  result.sizes[dim] =
+      b.getIndexAttr(intervals.back().end - intervals.front().start);
+  return result;
+}
+
+//===----------------------------------------------------------------------===//
+// Alloc user collection
+//===----------------------------------------------------------------------===//
+
+struct FillInfo {
+  linalg::FillOp fill;
+  scf::IfOp wrappingIf;
+  Value fillValue;
+  bool isBare = false;
+};
+
+struct AllocInfo {
+  memref::AllocOp alloc;
+  bufferization::ToTensorOp toTensor;
+  SmallVector<Box> writeBoxes;
+  SmallVector<memref::CopyOp> copies;
+  FillInfo fill;
+};
+
+static bool sameFillValue(Value a, Value b) {
+  if (a == b)
+    return true;
+  auto ca = a.getDefiningOp<arith::ConstantOp>();
+  auto cb = b.getDefiningOp<arith::ConstantOp>();
+  return ca && cb && ca.getValue() == cb.getValue();
+}
+
+static scf::IfOp wrappingTrivialFillIf(linalg::FillOp fill) {
+  auto ifOp = dyn_cast<scf::IfOp>(fill->getParentOp());
+  if (!ifOp || ifOp.getNumResults() != 0)
+    return nullptr;
+
+  unsigned thenCount = 0;
+  for (Operation &op : ifOp.getThenRegion().front()) {
+    if (isa<scf::YieldOp>(op))
+      continue;
+    if (&op != fill.getOperation())
+      return nullptr;
+    ++thenCount;
+  }
+  if (thenCount != 1)
+    return nullptr;
+
+  if (!ifOp.getElseRegion().empty()) {
+    for (Operation &op : ifOp.getElseRegion().front()) {
+      if (!isa<scf::YieldOp>(op))
+        return nullptr;
+    }
+  }
+  return ifOp;
+}
+
+// Recursively find the unique memref.copy that writes `v` (looking through
+// memref.cast). Returns null if `v` has any other user or is used as a copy
+// source.
+static memref::CopyOp getUniqueCopyWriting(Value v) {
+  memref::CopyOp found;
+  for (Operation *user : v.getUsers()) {
+    if (auto copy = dyn_cast<memref::CopyOp>(user)) {
+      if (copy.getTarget() != v || found)
+        return nullptr;
+      found = copy;
+      continue;
+    }
+    if (auto cast = dyn_cast<memref::CastOp>(user)) {
+      memref::CopyOp inner = getUniqueCopyWriting(cast.getResult());
+      if (!inner || found)
+        return nullptr;
+      found = inner;
+      continue;
+    }
+    return nullptr;
+  }
+  return found;
+}
+
+// A whole-buffer fill only acts as padding if it runs before the copies that
+// overwrite parts of it. A fill placed after them is what the concatenated
+// value actually observes, so it is neither dead nor safe to reorder.
+static bool fillPrecedesCopies(const FillInfo &fill,
+                               ArrayRef<memref::CopyOp> copies) {
+  if (!fill.fill)
+    return true;
+  scf::IfOp wrappingIf = fill.wrappingIf;
+  linalg::FillOp fillOp = fill.fill;
+  Operation *fillPoint =
+      wrappingIf ? wrappingIf.getOperation() : fillOp.getOperation();
+  for (memref::CopyOp copy : copies) {
+    Operation *copyPoint = copy.getOperation();
+    if (fillPoint->getBlock() != copyPoint->getBlock() ||
+        !fillPoint->isBeforeInBlock(copyPoint))
+      return false;
+  }
+  return true;
+}
+
+static std::optional<AllocInfo> collectAllocInfo(Value mem) {
+  auto alloc = mem.getDefiningOp<memref::AllocOp>();
+  if (!alloc || !alloc.getDynamicSizes().empty())
+    return std::nullopt;
+
+  auto memType = dyn_cast<MemRefType>(alloc.getType());
+  if (!memType || !memType.hasStaticShape())
+    return std::nullopt;
+
+  AllocInfo info;
+  info.alloc = alloc;
+
+  for (Operation *user : alloc.getResult().getUsers()) {
+    if (auto fill = dyn_cast<linalg::FillOp>(user)) {
+      if (info.fill.fill)
+        return std::nullopt;
+      if (fill.getDpsInits().empty() || fill.getDpsInputs().empty() ||
+          fill.getDpsInits().front() != alloc.getResult())
+        return std::nullopt;
+      info.fill.fill = fill;
+      info.fill.fillValue = fill.getDpsInputs().front();
+      info.fill.wrappingIf = wrappingTrivialFillIf(fill);
+      info.fill.isBare = fill->getBlock() == alloc->getBlock();
+      continue;
+    }
+
+    if (auto toTensor = dyn_cast<bufferization::ToTensorOp>(user)) {
+      if (info.toTensor)
+        return std::nullopt;
+      if (!toTensor.getRestrict() || !toTensor.getWritable())
+        return std::nullopt;
+      if (toTensor.getBuffer() != alloc.getResult())
+        return std::nullopt;
+      info.toTensor = toTensor;
+      continue;
+    }
+
+    if (auto subview = dyn_cast<memref::SubViewOp>(user)) {
+      if (!allUnitStrides(subview.getMixedStrides()))
+        return std::nullopt;
+      memref::CopyOp copy = getUniqueCopyWriting(subview.getResult());
+      if (!copy)
+        return std::nullopt;
+      info.copies.push_back(copy);
+      info.writeBoxes.push_back(
+          Box{subview.getMixedOffsets(), subview.getMixedSizes()});
+      continue;
+    }
+
+    return std::nullopt;
+  }
+
+  if (!info.toTensor || info.writeBoxes.empty())
+    return std::nullopt;
+  if (!fillPrecedesCopies(info.fill, info.copies))
+    return std::nullopt;
+  return info;
+}
+
+static void eraseFill(PatternRewriter &rewriter, const FillInfo &fill) {
+  if (!fill.fill)
+    return;
+  if (fill.wrappingIf)
+    rewriter.eraseOp(fill.wrappingIf);
+  else
+    rewriter.eraseOp(fill.fill);
+}
+
+//===----------------------------------------------------------------------===//
+// Rewrite pattern
+//===----------------------------------------------------------------------===//
+
+class MergeConcatLoadBufferPattern
+    : public OpRewritePattern<tensor::InsertSliceOp> {
+public:
+  using OpRewritePattern<tensor::InsertSliceOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::InsertSliceOp insertOp,
+                                PatternRewriter &rewriter) const override {
+    if (!allUnitStrides(insertOp.getMixedStrides()))
+      return rewriter.notifyMatchFailure(insertOp, "non-unit insert strides");
+
+    auto extractOp =
+        insertOp.getSource().getDefiningOp<tensor::ExtractSliceOp>();
+    if (!extractOp || !extractOp->hasOneUse())
+      return rewriter.notifyMatchFailure(insertOp,
+                                         "source is not a single-use extract");
+    if (!allUnitStrides(extractOp.getMixedStrides()))
+      return rewriter.notifyMatchFailure(insertOp, "non-unit extract strides");
+
+    // Identity move: extract and insert must use the same offsets/sizes so
+    // the source buffer can be RAUW'd onto the dest buffer without shifting.
+    if (extractOp.getMixedOffsets().size() !=
+            insertOp.getMixedOffsets().size() ||
+        extractOp.getMixedSizes().size() != insertOp.getMixedSizes().size())
+      return failure();
+    for (auto [eOff, iOff] :
+         llvm::zip(extractOp.getMixedOffsets(), insertOp.getMixedOffsets())) {
+      if (!isSameOFR(eOff, iOff))
+        return rewriter.notifyMatchFailure(insertOp,
+                                           "extract/insert offsets differ");
+    }
+    for (auto [eSz, iSz] :
+         llvm::zip(extractOp.getMixedSizes(), insertOp.getMixedSizes())) {
+      if (!isSameOFR(eSz, iSz))
+        return rewriter.notifyMatchFailure(insertOp,
+                                           "extract/insert sizes differ");
+    }
+
+    auto toTensorA =
+        extractOp.getSource().getDefiningOp<bufferization::ToTensorOp>();
+    auto toTensorB =
+        insertOp.getDest().getDefiningOp<bufferization::ToTensorOp>();
+    if (!toTensorA || !toTensorB || toTensorA == toTensorB)
+      return failure();
+    if (!toTensorA->hasOneUse() || !toTensorB->hasOneUse())
+      return rewriter.notifyMatchFailure(
+          insertOp, "to_tensor must be used only by this concat");
+
+    std::optional<AllocInfo> infoA = collectAllocInfo(toTensorA.getBuffer());
+    std::optional<AllocInfo> infoB = collectAllocInfo(toTensorB.getBuffer());
+    if (!infoA || !infoB)
+      return rewriter.notifyMatchFailure(insertOp,
+                                         "alloc users are not a load buffer");
+    if (infoA->toTensor != toTensorA || infoB->toTensor != toTensorB)
+      return failure();
+
+    auto typeA = dyn_cast<MemRefType>(infoA->alloc.getType());
+    auto typeB = dyn_cast<MemRefType>(infoB->alloc.getType());
+    if (!typeA || !typeB || typeA != typeB)
+      return rewriter.notifyMatchFailure(insertOp, "alloc types differ");
+
+    if (infoA->alloc->getBlock() != infoB->alloc->getBlock() ||
+        insertOp->getBlock() != infoA->alloc->getBlock() ||
+        extractOp->getBlock() != insertOp->getBlock() ||
+        toTensorA->getBlock() != insertOp->getBlock() ||
+        toTensorB->getBlock() != insertOp->getBlock())
+      return rewriter.notifyMatchFailure(insertOp, "ops not in the same block");
+
+    Box insertBox{insertOp.getMixedOffsets(), insertOp.getMixedSizes()};
+    ArrayRef<int64_t> shape = typeA.getShape();
+    for (const Box &write : infoA->writeBoxes) {
+      if (!boxContainedIn(write, insertBox, shape))
+        return rewriter.notifyMatchFailure(
+            insertOp, "source write is not inside the insert region");
+    }
+    for (const Box &write : infoB->writeBoxes) {
+      if (!boxesDisjoint(write, insertBox))
+        return rewriter.notifyMatchFailure(
+            insertOp, "dest write overlaps the insert region");
+    }
+
+    SmallVector<memref::CopyOp> allCopies;
+    allCopies.append(infoA->copies.begin(), infoA->copies.end());
+    allCopies.append(infoB->copies.begin(), infoB->copies.end());
+    for (memref::CopyOp copy : allCopies) {
+      if (copy->getBlock() != toTensorB->getBlock() ||
+          !copy->isBeforeInBlock(toTensorB))
+        return rewriter.notifyMatchFailure(
+            insertOp, "to_tensor B does not dominate all copies");
+    }
+
+    // Read region of the concatenated value: extract_slice users contribute
+    // their boxes; any other user conservatively reads the whole buffer.
+    // to_tensor B is required to have a single use (the insert), so only
+    // insert result users matter.
+    SmallVector<Box> readBoxes;
+    bool readsFull = false;
+    for (Operation *user : insertOp.getResult().getUsers()) {
+      if (auto readExtract = dyn_cast<tensor::ExtractSliceOp>(user)) {
+        if (!allUnitStrides(readExtract.getMixedStrides())) {
+          readsFull = true;
+          break;
+        }
+        readBoxes.push_back(
+            Box{readExtract.getMixedOffsets(), readExtract.getMixedSizes()});
+        continue;
+      }
+      readsFull = true;
+      break;
+    }
+    if (readsFull) {
+      readBoxes.clear();
+      readBoxes.push_back(makeFullBox(shape, insertOp.getContext()));
+    }
+
+    SmallVector<Box> writeUnionInput;
+    writeUnionInput.append(infoA->writeBoxes.begin(), infoA->writeBoxes.end());
+    writeUnionInput.append(infoB->writeBoxes.begin(), infoB->writeBoxes.end());
+    std::optional<Box> writeUnion =
+        unionBoxesAlongOneDim(writeUnionInput, insertOp.getContext());
+
+    bool fillDead = false;
+    if (writeUnion) {
+      fillDead = llvm::all_of(readBoxes, [&](const Box &read) {
+        return boxContainedIn(read, *writeUnion, shape);
+      });
+    }
+
+    // Keep the earlier alloc so RAUW cannot create uses-before-def.
+    bool aIsEarlier = infoA->alloc->isBeforeInBlock(infoB->alloc);
+    memref::AllocOp survivor = aIsEarlier ? infoA->alloc : infoB->alloc;
+    memref::AllocOp dropped = aIsEarlier ? infoB->alloc : infoA->alloc;
+    const FillInfo &survivorFill = aIsEarlier ? infoA->fill : infoB->fill;
+    const FillInfo &droppedFill = aIsEarlier ? infoB->fill : infoA->fill;
+
+    bool keepSingleFill = false;
+    if (!fillDead) {
+      // Once merged, the surviving fill initialises the shared buffer, so it
+      // must run before every copy and not just before the ones that used to
+      // target its own buffer.
+      if (infoA->fill.isBare && infoB->fill.isBare && infoA->fill.fill &&
+          infoB->fill.fill &&
+          sameFillValue(infoA->fill.fillValue, infoB->fill.fillValue) &&
+          fillPrecedesCopies(survivorFill, allCopies)) {
+        keepSingleFill = true;
+      } else if (infoA->fill.fill || infoB->fill.fill) {
+        return rewriter.notifyMatchFailure(
+            insertOp, "cannot prove fill dead and cannot merge fills");
+      }
+    }
+
+    LLVM_DEBUG(llvm::dbgs() << "Merging concat load buffers:\n  "
+                            << infoA->alloc << "\n  " << infoB->alloc << "\n");
+
+    if (fillDead) {
+      eraseFill(rewriter, infoA->fill);
+      eraseFill(rewriter, infoB->fill);
+    } else if (keepSingleFill) {
+      eraseFill(rewriter, droppedFill);
+    }
+
+    rewriter.replaceOp(insertOp, toTensorB.getResult());
+    rewriter.eraseOp(extractOp);
+    rewriter.eraseOp(toTensorA);
+    rewriter.replaceAllUsesWith(dropped.getResult(), survivor.getResult());
+    rewriter.eraseOp(dropped);
+    return success();
+  }
+};
+
+struct MergeConcatLoadBufferPass
+    : public mlir::triton::cfg::impl::MergeConcatLoadBufferBase<
+          MergeConcatLoadBufferPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry
+        .insert<arith::ArithDialect, bufferization::BufferizationDialect,
+                func::FuncDialect, linalg::LinalgDialect, memref::MemRefDialect,
+                scf::SCFDialect, tensor::TensorDialect>();
+  }
+
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<MergeConcatLoadBufferPattern>(&getContext());
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::triton::cfg::createMergeConcatLoadBufferPass() {
+  return std::make_unique<MergeConcatLoadBufferPass>();
+}

--- a/third_party/ascend/triton_ascend.cc
+++ b/third_party/ascend/triton_ascend.cc
@@ -14,6 +14,7 @@
 #include "ascend/include/DiscreteMaskAccessConversion/Passes.h"
 #include "ascend/include/TritonControlFlowOpt/Passes.h"
 #include "ascend/include/TritonToAnnotation/Passes.h"
+#include "ascend/include/TritonToGraph/Passes.h"
 #include "ascend/include/TritonToHFusion/Passes.h"
 #include "ascend/include/TritonToHIVM/Passes.h"
 #include "ascend/include/TritonToLLVM/Passes.h"
@@ -82,6 +83,10 @@ void init_triton_ascend_passes_ttir(py::module &&m) {
               globalKernel, namedOps, enableNd2nzOnVector, enableSelectAnalysis,
               compileOn91095));
         });
+
+  m.def("add_merge_concat_load_buffer", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::cfg::createMergeConcatLoadBufferPass());
+  });
 
   m.def("add_triton_to_unstructure",
         [](mlir::PassManager &pm, bool compileOn91095, bool forceSimtTemplate) {

--- a/third_party/ascend/unittest/Conversion/General/TritonToGraph/merge_concat_load_buffer.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToGraph/merge_concat_load_buffer.mlir
@@ -1,0 +1,619 @@
+// RUN: triton-opt --merge-concat-load-buffer --split-input-file %s | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Positive: the canonical tl.cat pattern.
+//
+// Two masked loads write disjoint column ranges of identically shaped UB
+// buffers and are concatenated by extract_slice + insert_slice. The store
+// reads [0, %n) x [0, 512), which the union of the two copies covers exactly,
+// so the allocs merge into one and both fills die.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @merge_and_drop_fill
+// CHECK-NOT:     linalg.fill
+// CHECK:         %[[ALLOC:.*]] = memref.alloc() : memref<32x512xf32>
+// CHECK-NOT:     memref.alloc()
+// CHECK-NOT:     linalg.fill
+// CHECK:         memref.subview %[[ALLOC]][0, 0]
+// CHECK:         memref.copy
+// CHECK-NOT:     memref.alloc()
+// CHECK-NOT:     linalg.fill
+// CHECK:         memref.subview %[[ALLOC]][0, 256]
+// CHECK:         memref.copy
+// CHECK-NOT:     memref.alloc()
+// CHECK-NOT:     linalg.fill
+// CHECK-NOT:     tensor.insert_slice
+// CHECK:         %[[T:.*]] = bufferization.to_tensor %[[ALLOC]] restrict writable
+// CHECK:         tensor.extract_slice %[[T]][0, 0] [%{{.*}}, 512] [1, 1]
+// CHECK-NOT:     memref.alloc()
+// CHECK-NOT:     linalg.fill
+// CHECK-NOT:     tensor.insert_slice
+func.func @merge_and_drop_fill(%arg0: memref<32x512xf32>, %arg1: memref<32x512xf32>, %n: index) -> tensor<?x512xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+
+  %alloc0 = memref.alloc() : memref<32x512xf32>
+  linalg.fill ins(%cst : f32) outs(%alloc0 : memref<32x512xf32>)
+  %ss0 = memref.subview %arg0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  %sd0 = memref.subview %alloc0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  memref.copy %ss0, %sd0 : memref<?x256xf32, strided<[512, 1]>> to memref<?x256xf32, strided<[512, 1]>>
+  %t0 = bufferization.to_tensor %alloc0 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %alloc1 = memref.alloc() : memref<32x512xf32>
+  linalg.fill ins(%cst : f32) outs(%alloc1 : memref<32x512xf32>)
+  %ss1 = memref.subview %arg1[0, 256] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  %sd1 = memref.subview %alloc1[0, 256] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  memref.copy %ss1, %sd1 : memref<?x256xf32, strided<[512, 1], offset: 256>> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  %t1 = bufferization.to_tensor %alloc1 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %ex = tensor.extract_slice %t0[0, 0] [32, 256] [1, 1] : tensor<32x512xf32> to tensor<32x256xf32>
+  %ins = tensor.insert_slice %ex into %t1[0, 0] [32, 256] [1, 1] : tensor<32x256xf32> into tensor<32x512xf32>
+  %out = tensor.extract_slice %ins[0, 0] [%n, 512] [1, 1] : tensor<32x512xf32> to tensor<?x512xf32>
+  return %out : tensor<?x512xf32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Positive: the shape actually emitted by triton-to-linalg for a cat kernel,
+// i.e. inside scf.for with memref.reinterpret_cast sources and a
+// materialize_in_destination store.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @merge_inside_scf_for
+// CHECK:       scf.for
+// CHECK:         %[[ALLOC:.*]] = memref.alloc() : memref<32x512xf32>
+// CHECK-NOT:     memref.alloc()
+// CHECK-NOT:     linalg.fill
+// CHECK:         memref.subview %[[ALLOC]][0, 0]
+// CHECK:         memref.copy
+// CHECK:         memref.subview %[[ALLOC]][0, 256]
+// CHECK:         memref.copy
+// CHECK-NOT:     tensor.insert_slice
+// CHECK:         %[[T:.*]] = bufferization.to_tensor %[[ALLOC]] restrict writable
+// CHECK:         tensor.extract_slice %[[T]]
+// CHECK:         bufferization.materialize_in_destination
+// CHECK-NOT:     linalg.fill
+// CHECK-NOT:     tensor.insert_slice
+func.func @merge_inside_scf_for(%in0: memref<?xf32>, %in1: memref<?xf32>, %out: memref<?xf32>, %ub: i32, %bound: i32) {
+  %cst = arith.constant 0.000000e+00 : f32
+  %cn256 = arith.constant -256 : index
+  %c0 = arith.constant 0 : index
+  %c32 = arith.constant 32 : index
+  %c256 = arith.constant 256 : index
+  %c512 = arith.constant 512 : index
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c32_i32 = arith.constant 32 : i32
+
+  scf.for %i = %c0_i32 to %ub step %c1_i32 : i32 {
+    %row = arith.muli %i, %c32_i32 : i32
+    %row_idx = arith.index_cast %row : i32 to index
+    %off0 = arith.muli %row_idx, %c256 : index
+    %rc0 = memref.reinterpret_cast %in0 to offset: [%off0], sizes: [32, 512], strides: [256, 1] : memref<?xf32> to memref<32x512xf32, strided<[256, 1], offset: ?>>
+
+    %alloc0 = memref.alloc() : memref<32x512xf32>
+    %hi = arith.addi %row_idx, %c32 : index
+    %bnd = arith.index_cast %bound : i32 to index
+    %lo = arith.maxsi %row_idx, %bnd : index
+    %clamped = arith.minsi %hi, %lo : index
+    %len = arith.subi %clamped, %row_idx : index
+    %len32 = arith.minsi %len, %c32 : index
+    %rows = arith.maxsi %len32, %c0 : index
+    linalg.fill ins(%cst : f32) outs(%alloc0 : memref<32x512xf32>)
+    %ss0 = memref.subview %rc0[0, 0] [%rows, 256] [1, 1] : memref<32x512xf32, strided<[256, 1], offset: ?>> to memref<?x256xf32, strided<[256, 1], offset: ?>>
+    %sd0 = memref.subview %alloc0[0, 0] [%rows, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+    memref.copy %ss0, %sd0 : memref<?x256xf32, strided<[256, 1], offset: ?>> to memref<?x256xf32, strided<[512, 1]>>
+    %t0 = bufferization.to_tensor %alloc0 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+    %off1 = arith.addi %off0, %cn256 : index
+    %rc1 = memref.reinterpret_cast %in1 to offset: [%off1], sizes: [32, 512], strides: [256, 1] : memref<?xf32> to memref<32x512xf32, strided<[256, 1], offset: ?>>
+    %alloc1 = memref.alloc() : memref<32x512xf32>
+    linalg.fill ins(%cst : f32) outs(%alloc1 : memref<32x512xf32>)
+    %ss1 = memref.subview %rc1[0, 256] [%rows, 256] [1, 1] : memref<32x512xf32, strided<[256, 1], offset: ?>> to memref<?x256xf32, strided<[256, 1], offset: ?>>
+    %sd1 = memref.subview %alloc1[0, 256] [%rows, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+    memref.copy %ss1, %sd1 : memref<?x256xf32, strided<[256, 1], offset: ?>> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+    %t1 = bufferization.to_tensor %alloc1 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+    %ex = tensor.extract_slice %t0[0, 0] [32, 256] [1, 1] : tensor<32x512xf32> to tensor<32x256xf32>
+    %ins = tensor.insert_slice %ex into %t1[0, 0] [32, 256] [1, 1] : tensor<32x256xf32> into tensor<32x512xf32>
+
+    %off_out = arith.muli %row_idx, %c512 : index
+    %rc_out = memref.reinterpret_cast %out to offset: [%off_out], sizes: [32, 512], strides: [512, 1] : memref<?xf32> to memref<32x512xf32, strided<[512, 1], offset: ?>>
+    %store_src = tensor.extract_slice %ins[0, 0] [%rows, 512] [1, 1] : tensor<32x512xf32> to tensor<?x512xf32>
+    %store_dst = memref.subview %rc_out[0, 0] [%rows, 512] [1, 1] : memref<32x512xf32, strided<[512, 1], offset: ?>> to memref<?x512xf32, strided<[512, 1], offset: ?>>
+    bufferization.materialize_in_destination %store_src in writable %store_dst : (tensor<?x512xf32>, memref<?x512xf32, strided<[512, 1], offset: ?>>) -> ()
+  }
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Positive: LoadConverter inserts a memref.cast between the destination
+// subview and the copy. The pass must look through it.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @merge_through_memref_cast
+// CHECK:         %[[ALLOC:.*]] = memref.alloc() : memref<32x512xf32>
+// CHECK-NOT:     memref.alloc()
+// CHECK-NOT:     linalg.fill
+// CHECK:         memref.subview %[[ALLOC]][0, 0]
+// CHECK:         memref.copy
+// CHECK:         memref.subview %[[ALLOC]][0, 256]
+// CHECK:         memref.copy
+// CHECK:         bufferization.to_tensor %[[ALLOC]] restrict writable
+// CHECK-NOT:     linalg.fill
+// CHECK-NOT:     tensor.insert_slice
+func.func @merge_through_memref_cast(%arg0: memref<32x512xf32>, %arg1: memref<32x512xf32>, %n: index) -> tensor<?x512xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+
+  %alloc0 = memref.alloc() : memref<32x512xf32>
+  linalg.fill ins(%cst : f32) outs(%alloc0 : memref<32x512xf32>)
+  %ss0 = memref.subview %arg0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  %sd0 = memref.subview %alloc0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  %cast0 = memref.cast %sd0 : memref<?x256xf32, strided<[512, 1]>> to memref<?x256xf32, strided<[?, ?], offset: ?>>
+  memref.copy %ss0, %cast0 : memref<?x256xf32, strided<[512, 1]>> to memref<?x256xf32, strided<[?, ?], offset: ?>>
+  %t0 = bufferization.to_tensor %alloc0 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %alloc1 = memref.alloc() : memref<32x512xf32>
+  linalg.fill ins(%cst : f32) outs(%alloc1 : memref<32x512xf32>)
+  %ss1 = memref.subview %arg1[0, 256] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  %sd1 = memref.subview %alloc1[0, 256] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  %cast1 = memref.cast %sd1 : memref<?x256xf32, strided<[512, 1], offset: 256>> to memref<?x256xf32, strided<[?, ?], offset: ?>>
+  memref.copy %ss1, %cast1 : memref<?x256xf32, strided<[512, 1], offset: 256>> to memref<?x256xf32, strided<[?, ?], offset: ?>>
+  %t1 = bufferization.to_tensor %alloc1 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %ex = tensor.extract_slice %t0[0, 0] [32, 256] [1, 1] : tensor<32x512xf32> to tensor<32x256xf32>
+  %ins = tensor.insert_slice %ex into %t1[0, 0] [32, 256] [1, 1] : tensor<32x256xf32> into tensor<32x512xf32>
+  %out = tensor.extract_slice %ins[0, 0] [%n, 512] [1, 1] : tensor<32x512xf32> to tensor<?x512xf32>
+  return %out : tensor<?x512xf32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Positive: the padding fill is still wrapped in the scf.if that
+// fillTensorWithOtherForMaskScenario emits (not yet folded by the
+// canonicalizer). A dead fill must take its guarding scf.if with it.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @merge_drop_guarded_fill
+// CHECK:         %[[ALLOC:.*]] = memref.alloc() : memref<32x512xf32>
+// CHECK-NOT:     memref.alloc()
+// CHECK-NOT:     linalg.fill
+// CHECK-NOT:     scf.if
+// CHECK:         memref.subview %[[ALLOC]][0, 0]
+// CHECK:         memref.copy
+// CHECK:         memref.subview %[[ALLOC]][0, 256]
+// CHECK:         memref.copy
+// CHECK:         bufferization.to_tensor %[[ALLOC]] restrict writable
+// CHECK-NOT:     linalg.fill
+// CHECK-NOT:     scf.if
+// CHECK-NOT:     tensor.insert_slice
+func.func @merge_drop_guarded_fill(%arg0: memref<32x512xf32>, %arg1: memref<32x512xf32>, %n: index) -> tensor<?x512xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c32 = arith.constant 32 : index
+  %partial = arith.cmpi slt, %n, %c32 : index
+
+  %alloc0 = memref.alloc() : memref<32x512xf32>
+  scf.if %partial {
+    linalg.fill ins(%cst : f32) outs(%alloc0 : memref<32x512xf32>)
+  } {hivm.unlikely_condition}
+  %ss0 = memref.subview %arg0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  %sd0 = memref.subview %alloc0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  memref.copy %ss0, %sd0 : memref<?x256xf32, strided<[512, 1]>> to memref<?x256xf32, strided<[512, 1]>>
+  %t0 = bufferization.to_tensor %alloc0 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %alloc1 = memref.alloc() : memref<32x512xf32>
+  scf.if %partial {
+    linalg.fill ins(%cst : f32) outs(%alloc1 : memref<32x512xf32>)
+  } {hivm.unlikely_condition}
+  %ss1 = memref.subview %arg1[0, 256] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  %sd1 = memref.subview %alloc1[0, 256] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  memref.copy %ss1, %sd1 : memref<?x256xf32, strided<[512, 1], offset: 256>> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  %t1 = bufferization.to_tensor %alloc1 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %ex = tensor.extract_slice %t0[0, 0] [32, 256] [1, 1] : tensor<32x512xf32> to tensor<32x256xf32>
+  %ins = tensor.insert_slice %ex into %t1[0, 0] [32, 256] [1, 1] : tensor<32x256xf32> into tensor<32x512xf32>
+  %out = tensor.extract_slice %ins[0, 0] [%n, 512] [1, 1] : tensor<32x512xf32> to tensor<?x512xf32>
+  return %out : tensor<?x512xf32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Positive: 1-D cat. The concatenated tensor is consumed whole, but the two
+// static copies together cover the entire buffer, so the fills are still dead.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @merge_1d_full_cover
+// CHECK:         %[[ALLOC:.*]] = memref.alloc() : memref<512xf32>
+// CHECK-NOT:     memref.alloc()
+// CHECK-NOT:     linalg.fill
+// CHECK:         memref.subview %[[ALLOC]][0]
+// CHECK:         memref.copy
+// CHECK:         memref.subview %[[ALLOC]][256]
+// CHECK:         memref.copy
+// CHECK-NOT:     tensor.insert_slice
+// CHECK:         bufferization.to_tensor %[[ALLOC]] restrict writable
+// CHECK-NOT:     linalg.fill
+// CHECK-NOT:     tensor.insert_slice
+func.func @merge_1d_full_cover(%arg0: memref<512xf32>, %arg1: memref<512xf32>) -> tensor<512xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+
+  %alloc0 = memref.alloc() : memref<512xf32>
+  linalg.fill ins(%cst : f32) outs(%alloc0 : memref<512xf32>)
+  %ss0 = memref.subview %arg0[0] [256] [1] : memref<512xf32> to memref<256xf32, strided<[1]>>
+  %sd0 = memref.subview %alloc0[0] [256] [1] : memref<512xf32> to memref<256xf32, strided<[1]>>
+  memref.copy %ss0, %sd0 : memref<256xf32, strided<[1]>> to memref<256xf32, strided<[1]>>
+  %t0 = bufferization.to_tensor %alloc0 restrict writable : memref<512xf32> to tensor<512xf32>
+
+  %alloc1 = memref.alloc() : memref<512xf32>
+  linalg.fill ins(%cst : f32) outs(%alloc1 : memref<512xf32>)
+  %ss1 = memref.subview %arg1[256] [256] [1] : memref<512xf32> to memref<256xf32, strided<[1], offset: 256>>
+  %sd1 = memref.subview %alloc1[256] [256] [1] : memref<512xf32> to memref<256xf32, strided<[1], offset: 256>>
+  memref.copy %ss1, %sd1 : memref<256xf32, strided<[1], offset: 256>> to memref<256xf32, strided<[1], offset: 256>>
+  %t1 = bufferization.to_tensor %alloc1 restrict writable : memref<512xf32> to tensor<512xf32>
+
+  %ex = tensor.extract_slice %t0[0] [256] [1] : tensor<512xf32> to tensor<256xf32>
+  %ins = tensor.insert_slice %ex into %t1[0] [256] [1] : tensor<256xf32> into tensor<512xf32>
+  return %ins : tensor<512xf32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Fallback: the concatenated tensor is consumed whole while the copies only
+// cover [0, %n) rows, so the padding is observable. The allocs still merge but
+// exactly one fill survives, placed before both copies.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @merge_keep_single_fill
+// CHECK:         %[[ALLOC:.*]] = memref.alloc() : memref<32x512xf32>
+// CHECK:         linalg.fill ins(%{{.*}} : f32) outs(%[[ALLOC]] : memref<32x512xf32>)
+// CHECK-NOT:     memref.alloc()
+// CHECK-NOT:     linalg.fill
+// CHECK:         memref.subview %[[ALLOC]][0, 0]
+// CHECK:         memref.copy
+// CHECK:         memref.subview %[[ALLOC]][0, 256]
+// CHECK:         memref.copy
+// CHECK-NOT:     tensor.insert_slice
+// CHECK:         bufferization.to_tensor %[[ALLOC]] restrict writable
+// CHECK-NOT:     memref.alloc()
+// CHECK-NOT:     linalg.fill
+// CHECK-NOT:     tensor.insert_slice
+func.func @merge_keep_single_fill(%arg0: memref<32x512xf32>, %arg1: memref<32x512xf32>, %n: index) -> tensor<32x512xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+
+  %alloc0 = memref.alloc() : memref<32x512xf32>
+  linalg.fill ins(%cst : f32) outs(%alloc0 : memref<32x512xf32>)
+  %ss0 = memref.subview %arg0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  %sd0 = memref.subview %alloc0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  memref.copy %ss0, %sd0 : memref<?x256xf32, strided<[512, 1]>> to memref<?x256xf32, strided<[512, 1]>>
+  %t0 = bufferization.to_tensor %alloc0 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %alloc1 = memref.alloc() : memref<32x512xf32>
+  linalg.fill ins(%cst : f32) outs(%alloc1 : memref<32x512xf32>)
+  %ss1 = memref.subview %arg1[0, 256] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  %sd1 = memref.subview %alloc1[0, 256] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  memref.copy %ss1, %sd1 : memref<?x256xf32, strided<[512, 1], offset: 256>> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  %t1 = bufferization.to_tensor %alloc1 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %ex = tensor.extract_slice %t0[0, 0] [32, 256] [1, 1] : tensor<32x512xf32> to tensor<32x256xf32>
+  %ins = tensor.insert_slice %ex into %t1[0, 0] [32, 256] [1, 1] : tensor<32x256xf32> into tensor<32x512xf32>
+  return %ins : tensor<32x512xf32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Negative: both copies target the same column range, so the dest write is not
+// disjoint from the insert region. Merging would clobber data.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @no_merge_overlapping_writes
+// CHECK:         memref.alloc() : memref<32x512xf32>
+// CHECK:         memref.alloc() : memref<32x512xf32>
+// CHECK:         tensor.insert_slice
+func.func @no_merge_overlapping_writes(%arg0: memref<32x512xf32>, %arg1: memref<32x512xf32>, %n: index) -> tensor<?x512xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+
+  %alloc0 = memref.alloc() : memref<32x512xf32>
+  linalg.fill ins(%cst : f32) outs(%alloc0 : memref<32x512xf32>)
+  %ss0 = memref.subview %arg0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  %sd0 = memref.subview %alloc0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  memref.copy %ss0, %sd0 : memref<?x256xf32, strided<[512, 1]>> to memref<?x256xf32, strided<[512, 1]>>
+  %t0 = bufferization.to_tensor %alloc0 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %alloc1 = memref.alloc() : memref<32x512xf32>
+  linalg.fill ins(%cst : f32) outs(%alloc1 : memref<32x512xf32>)
+  %ss1 = memref.subview %arg1[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  %sd1 = memref.subview %alloc1[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  memref.copy %ss1, %sd1 : memref<?x256xf32, strided<[512, 1]>> to memref<?x256xf32, strided<[512, 1]>>
+  %t1 = bufferization.to_tensor %alloc1 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %ex = tensor.extract_slice %t0[0, 0] [32, 256] [1, 1] : tensor<32x512xf32> to tensor<32x256xf32>
+  %ins = tensor.insert_slice %ex into %t1[0, 0] [32, 256] [1, 1] : tensor<32x256xf32> into tensor<32x512xf32>
+  %out = tensor.extract_slice %ins[0, 0] [%n, 512] [1, 1] : tensor<32x512xf32> to tensor<?x512xf32>
+  return %out : tensor<?x512xf32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Negative: the extract offset differs from the insert offset, so the source
+// data is shifted on its way into the dest. A plain RAUW would be wrong.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @no_merge_shifted_placement
+// CHECK:         memref.alloc() : memref<32x512xf32>
+// CHECK:         memref.alloc() : memref<32x512xf32>
+// CHECK:         tensor.insert_slice
+func.func @no_merge_shifted_placement(%arg0: memref<32x512xf32>, %arg1: memref<32x512xf32>, %n: index) -> tensor<?x512xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+
+  %alloc0 = memref.alloc() : memref<32x512xf32>
+  linalg.fill ins(%cst : f32) outs(%alloc0 : memref<32x512xf32>)
+  %ss0 = memref.subview %arg0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  %sd0 = memref.subview %alloc0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  memref.copy %ss0, %sd0 : memref<?x256xf32, strided<[512, 1]>> to memref<?x256xf32, strided<[512, 1]>>
+  %t0 = bufferization.to_tensor %alloc0 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %alloc1 = memref.alloc() : memref<32x512xf32>
+  linalg.fill ins(%cst : f32) outs(%alloc1 : memref<32x512xf32>)
+  %ss1 = memref.subview %arg1[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  %sd1 = memref.subview %alloc1[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  memref.copy %ss1, %sd1 : memref<?x256xf32, strided<[512, 1]>> to memref<?x256xf32, strided<[512, 1]>>
+  %t1 = bufferization.to_tensor %alloc1 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %ex = tensor.extract_slice %t0[0, 0] [32, 256] [1, 1] : tensor<32x512xf32> to tensor<32x256xf32>
+  %ins = tensor.insert_slice %ex into %t1[0, 256] [32, 256] [1, 1] : tensor<32x256xf32> into tensor<32x512xf32>
+  %out = tensor.extract_slice %ins[0, 0] [%n, 512] [1, 1] : tensor<32x512xf32> to tensor<?x512xf32>
+  return %out : tensor<?x512xf32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Negative: the two buffers have different shapes, so they cannot share one
+// allocation.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @no_merge_shape_mismatch
+// CHECK:         memref.alloc() : memref<32x512xf32>
+// CHECK:         memref.alloc() : memref<64x512xf32>
+// CHECK:         tensor.insert_slice
+func.func @no_merge_shape_mismatch(%arg0: memref<32x512xf32>, %arg1: memref<64x512xf32>, %n: index) -> tensor<64x512xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+
+  %alloc0 = memref.alloc() : memref<32x512xf32>
+  linalg.fill ins(%cst : f32) outs(%alloc0 : memref<32x512xf32>)
+  %ss0 = memref.subview %arg0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  %sd0 = memref.subview %alloc0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  memref.copy %ss0, %sd0 : memref<?x256xf32, strided<[512, 1]>> to memref<?x256xf32, strided<[512, 1]>>
+  %t0 = bufferization.to_tensor %alloc0 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %alloc1 = memref.alloc() : memref<64x512xf32>
+  linalg.fill ins(%cst : f32) outs(%alloc1 : memref<64x512xf32>)
+  %ss1 = memref.subview %arg1[0, 256] [%n, 256] [1, 1] : memref<64x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  %sd1 = memref.subview %alloc1[0, 256] [%n, 256] [1, 1] : memref<64x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  memref.copy %ss1, %sd1 : memref<?x256xf32, strided<[512, 1], offset: 256>> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  %t1 = bufferization.to_tensor %alloc1 restrict writable : memref<64x512xf32> to tensor<64x512xf32>
+
+  %ex = tensor.extract_slice %t0[0, 0] [32, 256] [1, 1] : tensor<32x512xf32> to tensor<32x256xf32>
+  %ins = tensor.insert_slice %ex into %t1[0, 0] [32, 256] [1, 1] : tensor<32x256xf32> into tensor<64x512xf32>
+  return %ins : tensor<64x512xf32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Negative: the source buffer has a user the pass does not model (a dealloc),
+// so its lifetime cannot be folded into the dest buffer.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @no_merge_unmodeled_alloc_user
+// CHECK:         memref.alloc() : memref<32x512xf32>
+// CHECK:         memref.alloc() : memref<32x512xf32>
+// CHECK:         tensor.insert_slice
+// CHECK:         memref.dealloc
+func.func @no_merge_unmodeled_alloc_user(%arg0: memref<32x512xf32>, %arg1: memref<32x512xf32>, %n: index) -> tensor<?x512xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+
+  %alloc0 = memref.alloc() : memref<32x512xf32>
+  linalg.fill ins(%cst : f32) outs(%alloc0 : memref<32x512xf32>)
+  %ss0 = memref.subview %arg0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  %sd0 = memref.subview %alloc0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  memref.copy %ss0, %sd0 : memref<?x256xf32, strided<[512, 1]>> to memref<?x256xf32, strided<[512, 1]>>
+  %t0 = bufferization.to_tensor %alloc0 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %alloc1 = memref.alloc() : memref<32x512xf32>
+  linalg.fill ins(%cst : f32) outs(%alloc1 : memref<32x512xf32>)
+  %ss1 = memref.subview %arg1[0, 256] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  %sd1 = memref.subview %alloc1[0, 256] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  memref.copy %ss1, %sd1 : memref<?x256xf32, strided<[512, 1], offset: 256>> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  %t1 = bufferization.to_tensor %alloc1 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %ex = tensor.extract_slice %t0[0, 0] [32, 256] [1, 1] : tensor<32x512xf32> to tensor<32x256xf32>
+  %ins = tensor.insert_slice %ex into %t1[0, 0] [32, 256] [1, 1] : tensor<32x256xf32> into tensor<32x512xf32>
+  %out = tensor.extract_slice %ins[0, 0] [%n, 512] [1, 1] : tensor<32x512xf32> to tensor<?x512xf32>
+  memref.dealloc %alloc0 : memref<32x512xf32>
+  return %out : tensor<?x512xf32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Negative: the source tensor is read a second time, so the buffer it comes
+// from is still live after the concat.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @no_merge_source_tensor_reused
+// CHECK:         memref.alloc() : memref<32x512xf32>
+// CHECK:         memref.alloc() : memref<32x512xf32>
+// CHECK:         tensor.insert_slice
+func.func @no_merge_source_tensor_reused(%arg0: memref<32x512xf32>, %arg1: memref<32x512xf32>, %n: index) -> (tensor<32x512xf32>, tensor<32x512xf32>) {
+  %cst = arith.constant 0.000000e+00 : f32
+
+  %alloc0 = memref.alloc() : memref<32x512xf32>
+  linalg.fill ins(%cst : f32) outs(%alloc0 : memref<32x512xf32>)
+  %ss0 = memref.subview %arg0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  %sd0 = memref.subview %alloc0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  memref.copy %ss0, %sd0 : memref<?x256xf32, strided<[512, 1]>> to memref<?x256xf32, strided<[512, 1]>>
+  %t0 = bufferization.to_tensor %alloc0 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %alloc1 = memref.alloc() : memref<32x512xf32>
+  linalg.fill ins(%cst : f32) outs(%alloc1 : memref<32x512xf32>)
+  %ss1 = memref.subview %arg1[0, 256] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  %sd1 = memref.subview %alloc1[0, 256] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  memref.copy %ss1, %sd1 : memref<?x256xf32, strided<[512, 1], offset: 256>> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  %t1 = bufferization.to_tensor %alloc1 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %ex = tensor.extract_slice %t0[0, 0] [32, 256] [1, 1] : tensor<32x512xf32> to tensor<32x256xf32>
+  %ins = tensor.insert_slice %ex into %t1[0, 0] [32, 256] [1, 1] : tensor<32x256xf32> into tensor<32x512xf32>
+  return %ins, %t0 : tensor<32x512xf32>, tensor<32x512xf32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Negative: the padding is observable and the two fills use different values,
+// so neither dropping nor merging the fills is legal.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @no_merge_conflicting_fill_values
+// CHECK:         memref.alloc() : memref<32x512xf32>
+// CHECK:         linalg.fill
+// CHECK:         memref.alloc() : memref<32x512xf32>
+// CHECK:         linalg.fill
+// CHECK:         tensor.insert_slice
+func.func @no_merge_conflicting_fill_values(%arg0: memref<32x512xf32>, %arg1: memref<32x512xf32>, %n: index) -> tensor<32x512xf32> {
+  %zero = arith.constant 0.000000e+00 : f32
+  %one = arith.constant 1.000000e+00 : f32
+
+  %alloc0 = memref.alloc() : memref<32x512xf32>
+  linalg.fill ins(%zero : f32) outs(%alloc0 : memref<32x512xf32>)
+  %ss0 = memref.subview %arg0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  %sd0 = memref.subview %alloc0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  memref.copy %ss0, %sd0 : memref<?x256xf32, strided<[512, 1]>> to memref<?x256xf32, strided<[512, 1]>>
+  %t0 = bufferization.to_tensor %alloc0 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %alloc1 = memref.alloc() : memref<32x512xf32>
+  linalg.fill ins(%one : f32) outs(%alloc1 : memref<32x512xf32>)
+  %ss1 = memref.subview %arg1[0, 256] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  %sd1 = memref.subview %alloc1[0, 256] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  memref.copy %ss1, %sd1 : memref<?x256xf32, strided<[512, 1], offset: 256>> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  %t1 = bufferization.to_tensor %alloc1 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %ex = tensor.extract_slice %t0[0, 0] [32, 256] [1, 1] : tensor<32x512xf32> to tensor<32x256xf32>
+  %ins = tensor.insert_slice %ex into %t1[0, 0] [32, 256] [1, 1] : tensor<32x256xf32> into tensor<32x512xf32>
+  return %ins : tensor<32x512xf32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Negative: a strided insert_slice does not describe a contiguous region, so
+// the box arithmetic the pass relies on does not apply.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @no_merge_strided_insert
+// CHECK:         memref.alloc() : memref<32x512xf32>
+// CHECK:         memref.alloc() : memref<32x512xf32>
+// CHECK:         tensor.insert_slice
+func.func @no_merge_strided_insert(%arg0: memref<32x512xf32>, %arg1: memref<32x512xf32>, %n: index) -> tensor<32x512xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+
+  %alloc0 = memref.alloc() : memref<32x512xf32>
+  linalg.fill ins(%cst : f32) outs(%alloc0 : memref<32x512xf32>)
+  %ss0 = memref.subview %arg0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  %sd0 = memref.subview %alloc0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  memref.copy %ss0, %sd0 : memref<?x256xf32, strided<[512, 1]>> to memref<?x256xf32, strided<[512, 1]>>
+  %t0 = bufferization.to_tensor %alloc0 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %alloc1 = memref.alloc() : memref<32x512xf32>
+  linalg.fill ins(%cst : f32) outs(%alloc1 : memref<32x512xf32>)
+  %ss1 = memref.subview %arg1[0, 256] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  %sd1 = memref.subview %alloc1[0, 256] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  memref.copy %ss1, %sd1 : memref<?x256xf32, strided<[512, 1], offset: 256>> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  %t1 = bufferization.to_tensor %alloc1 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %ex = tensor.extract_slice %t0[0, 0] [32, 256] [1, 1] : tensor<32x512xf32> to tensor<32x256xf32>
+  %ins = tensor.insert_slice %ex into %t1[0, 0] [32, 256] [1, 2] : tensor<32x256xf32> into tensor<32x512xf32>
+  return %ins : tensor<32x512xf32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Negative: the fill of the source buffer runs *after* the copy it would
+// initialise, so the padding is what the concat observes rather than the copied
+// data. The read region is fully covered, so without an ordering check the
+// rewrite would wrongly delete both fills.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @no_merge_late_fill
+// CHECK:         memref.alloc() : memref<32x512xf32>
+// CHECK:         memref.copy
+// CHECK:         linalg.fill
+// CHECK:         memref.alloc() : memref<32x512xf32>
+// CHECK:         tensor.insert_slice
+func.func @no_merge_late_fill(%arg0: memref<32x512xf32>, %arg1: memref<32x512xf32>, %n: index) -> tensor<?x512xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+
+  %alloc0 = memref.alloc() : memref<32x512xf32>
+  %ss0 = memref.subview %arg0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  %sd0 = memref.subview %alloc0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  memref.copy %ss0, %sd0 : memref<?x256xf32, strided<[512, 1]>> to memref<?x256xf32, strided<[512, 1]>>
+  linalg.fill ins(%cst : f32) outs(%alloc0 : memref<32x512xf32>)
+  %t0 = bufferization.to_tensor %alloc0 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %alloc1 = memref.alloc() : memref<32x512xf32>
+  linalg.fill ins(%cst : f32) outs(%alloc1 : memref<32x512xf32>)
+  %ss1 = memref.subview %arg1[0, 256] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  %sd1 = memref.subview %alloc1[0, 256] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  memref.copy %ss1, %sd1 : memref<?x256xf32, strided<[512, 1], offset: 256>> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  %t1 = bufferization.to_tensor %alloc1 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %ex = tensor.extract_slice %t0[0, 0] [32, 256] [1, 1] : tensor<32x512xf32> to tensor<32x256xf32>
+  %ins = tensor.insert_slice %ex into %t1[0, 0] [32, 256] [1, 1] : tensor<32x256xf32> into tensor<32x512xf32>
+  %out = tensor.extract_slice %ins[0, 0] [%n, 512] [1, 1] : tensor<32x512xf32> to tensor<?x512xf32>
+  return %out : tensor<?x512xf32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Negative: each fill precedes the copies into its own buffer, but the fill of
+// the surviving (earlier) alloc sits after the copy into the other one. Merging
+// would let that fill clobber data the other copy had already written, so the
+// keep-one-fill fallback must be refused too.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @no_merge_fill_after_other_copy
+// CHECK:         memref.alloc() : memref<32x512xf32>
+// CHECK:         memref.alloc() : memref<32x512xf32>
+// CHECK:         tensor.insert_slice
+func.func @no_merge_fill_after_other_copy(%arg0: memref<32x512xf32>, %arg1: memref<32x512xf32>, %n: index) -> tensor<32x512xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+
+  %alloc0 = memref.alloc() : memref<32x512xf32>
+  %alloc1 = memref.alloc() : memref<32x512xf32>
+
+  linalg.fill ins(%cst : f32) outs(%alloc1 : memref<32x512xf32>)
+  %ss1 = memref.subview %arg1[0, 256] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  %sd1 = memref.subview %alloc1[0, 256] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+  memref.copy %ss1, %sd1 : memref<?x256xf32, strided<[512, 1], offset: 256>> to memref<?x256xf32, strided<[512, 1], offset: 256>>
+
+  linalg.fill ins(%cst : f32) outs(%alloc0 : memref<32x512xf32>)
+  %ss0 = memref.subview %arg0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  %sd0 = memref.subview %alloc0[0, 0] [%n, 256] [1, 1] : memref<32x512xf32> to memref<?x256xf32, strided<[512, 1]>>
+  memref.copy %ss0, %sd0 : memref<?x256xf32, strided<[512, 1]>> to memref<?x256xf32, strided<[512, 1]>>
+
+  %t0 = bufferization.to_tensor %alloc0 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+  %t1 = bufferization.to_tensor %alloc1 restrict writable : memref<32x512xf32> to tensor<32x512xf32>
+
+  %ex = tensor.extract_slice %t0[0, 0] [32, 256] [1, 1] : tensor<32x512xf32> to tensor<32x256xf32>
+  %ins = tensor.insert_slice %ex into %t1[0, 0] [32, 256] [1, 1] : tensor<32x256xf32> into tensor<32x512xf32>
+  return %ins : tensor<32x512xf32>
+}

--- a/third_party/ascend/unittest/pytest_ut/test_merge_concat_load_buffer.py
+++ b/third_party/ascend/unittest/pytest_ut/test_merge_concat_load_buffer.py
@@ -1,0 +1,176 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""End-to-end coverage for the merge-concat-load-buffer pass.
+
+Two masked tl.load results that are concatenated lower to two full-tile UB
+allocs, two linalg.fill ops and an extract_slice/insert_slice pair. The pass
+folds the two allocs into one and drops the fills when it can prove the copies
+cover every later read.
+
+The kernels below reproduce that shape so the optimised code is exercised on
+device. Padding correctness is the interesting part: if the pass ever dropped a
+fill it could not prove dead, the `other` value would be replaced by whatever
+was left in UB, so `test_cat_masked_load_padding_visible` stores the whole tile
+instead of masking the tail away.
+
+The pipeline only enables the pass on 910_95/950, so on other targets these
+tests cover the unoptimised lowering of the same kernels rather than the pass.
+"""
+
+import pytest
+import torch
+import torch_npu
+
+import triton
+import triton.language as tl
+
+import test_common
+
+
+@triton.jit
+def fused_cat_masked_load_kernel(in_ptr0, in_ptr1, out_ptr, y_numel, HALF: tl.constexpr, YBLOCK: tl.constexpr,
+                                 OTHER: tl.constexpr, MASK_STORE: tl.constexpr):
+    """Concatenate two row-masked loads along the column axis.
+
+    This mirrors what torch-inductor emits for a `cat` of two tensors: one
+    full-width tile whose left half is loaded from `in_ptr0` and whose right
+    half is loaded from `in_ptr1` at a negative bias.
+    """
+    yoffset = tl.program_id(0) * YBLOCK
+    row = (yoffset + tl.arange(0, YBLOCK))[:, None]
+    col = tl.arange(0, 2 * HALF)[None, :]
+
+    row_mask = row < y_numel
+    from_left = col < HALF
+
+    left = tl.load(in_ptr0 + row * HALF + col, mask=row_mask & from_left, other=OTHER)
+    right = tl.load(in_ptr1 + row * HALF + (col - HALF), mask=row_mask & (col >= HALF), other=OTHER)
+    result = tl.where(from_left, left, right)
+
+    if MASK_STORE:
+        tl.store(out_ptr + row * (2 * HALF) + col, result, mask=row_mask)
+    else:
+        tl.store(out_ptr + row * (2 * HALF) + col, result)
+
+
+@triton.jit
+def cat_masked_load_1d_kernel(x_ptr, y_ptr, out_ptr, n_valid, BLOCK: tl.constexpr, OTHER: tl.constexpr):
+    idx = tl.arange(0, BLOCK)
+    mask = idx < n_valid
+
+    x = tl.load(x_ptr + idx, mask=mask, other=OTHER)
+    y = tl.load(y_ptr + idx, mask=mask, other=OTHER)
+    result = tl.cat(x, y, can_reorder=True)
+
+    tl.store(out_ptr + tl.arange(0, 2 * BLOCK), result)
+
+
+def _reference(x0, x1, rows, half, y_valid, tail):
+    """Expected output tile: valid rows carry the concat, the rest carry `tail`."""
+    ref = torch.full((rows, 2 * half), tail, dtype=x0.dtype)
+    ref[:y_valid, :half] = x0[:y_valid]
+    ref[:y_valid, half:] = x1[:y_valid]
+    return ref
+
+
+# y_numel is deliberately not a multiple of YBLOCK in most cases so the tail
+# tile is partially masked and the padding path is actually taken.
+@pytest.mark.parametrize('dtype', ['float32', 'float16', 'int32'])
+@pytest.mark.parametrize('y_numel, yblock, half', [
+    (32, 32, 256),
+    (30, 32, 256),
+    (70, 32, 128),
+    (1, 32, 64),
+    (100, 16, 32),
+])
+def test_cat_masked_load_masked_store(dtype, y_numel, yblock, half):
+    """Concat of two masked loads, tail rows masked away on store."""
+    torch_dtype = eval('torch.' + dtype)
+    n_prog = triton.cdiv(y_numel, yblock)
+    rows = n_prog * yblock
+    sentinel = -1
+
+    x0 = test_common.generate_tensor((rows, half), dtype)
+    x1 = test_common.generate_tensor((rows, half), dtype)
+    out = torch.full((rows, 2 * half), sentinel, dtype=torch_dtype)
+
+    # Tail rows are never stored, so they keep the sentinel the buffer held.
+    ref = _reference(x0, x1, rows, half, y_valid=y_numel, tail=sentinel)
+
+    out_npu = out.npu()
+    fused_cat_masked_load_kernel[n_prog, 1, 1](x0.npu(), x1.npu(), out_npu, y_numel, HALF=half, YBLOCK=yblock, OTHER=0,
+                                               MASK_STORE=True)
+
+    test_common.validate_cmp(dtype, out_npu, ref)
+
+
+@pytest.mark.parametrize('dtype', ['float32', 'float16'])
+@pytest.mark.parametrize('y_numel, yblock, half', [
+    (30, 32, 256),
+    (70, 32, 128),
+    (1, 32, 64),
+])
+def test_cat_masked_load_padding_visible(dtype, y_numel, yblock, half):
+    """Same concat, but the whole tile is stored so `other` padding is observed.
+
+    This is the case where the pass must not drop the fill it cannot prove
+    dead: rows in [y_numel, rows) are never written by a copy, so their value
+    comes purely from the padding.
+    """
+    torch_dtype = eval('torch.' + dtype)
+    n_prog = triton.cdiv(y_numel, yblock)
+    rows = n_prog * yblock
+    other = -7.5
+
+    x0 = test_common.generate_tensor((rows, half), dtype)
+    x1 = test_common.generate_tensor((rows, half), dtype)
+    out = torch.zeros((rows, 2 * half), dtype=torch_dtype)
+
+    ref = _reference(x0, x1, rows, half, y_valid=y_numel, tail=other)
+
+    out_npu = out.npu()
+    fused_cat_masked_load_kernel[n_prog, 1, 1](x0.npu(), x1.npu(), out_npu, y_numel, HALF=half, YBLOCK=yblock,
+                                               OTHER=other, MASK_STORE=False)
+
+    test_common.validate_cmp(dtype, out_npu, ref)
+
+
+@pytest.mark.parametrize('dtype', ['float32', 'float16'])
+@pytest.mark.parametrize('block, n_valid', [
+    (64, 64),
+    (64, 40),
+    (128, 1),
+])
+def test_cat_masked_load_1d(dtype, block, n_valid):
+    """1-D tl.cat of two masked loads; the padding is always observable."""
+    torch_dtype = eval('torch.' + dtype)
+    other = -3.25
+
+    x = test_common.generate_tensor((block, ), dtype)
+    y = test_common.generate_tensor((block, ), dtype)
+
+    keep = torch.arange(block) < n_valid
+    pad = torch.full((block, ), other, dtype=torch_dtype)
+    ref = torch.cat((torch.where(keep, x, pad), torch.where(keep, y, pad)))
+
+    out_npu = torch.zeros((2 * block, ), dtype=torch_dtype).npu()
+    cat_masked_load_1d_kernel[1, 1, 1](x.npu(), y.npu(), out_npu, n_valid, BLOCK=block, OTHER=other)
+
+    test_common.validate_cmp(dtype, out_npu, ref)


### PR DESCRIPTION
https://github.com/triton-lang/triton-ascend/issues/1086
A masked tt.load lowers to a full-tile UB alloc, a linalg.fill with the padding value, and a memref.copy of only the in-bounds subview. When two such loads are concatenated by tl.cat, triton-to-linalg emits an extract_slice + insert_slice pair over two separate allocs of the same static shape, so the kernel pays for twice the UB it needs plus two whole-tile fills.

This pass recognises that shape and folds the two allocs into one. The rewrite only fires when the source copies land inside the insert region and the dest copies stay clear of it, which makes the merge a pure renaming of the second buffer onto the first.

The fills are dropped only when the union of the copy destinations provably covers every later read of the concatenated tensor. When the padding is still observable the allocs are merged but one fill is kept, and when the two fills disagree on the padding value the rewrite is abandoned entirely.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
