### PR TITLE
[ssbuffer](feat) add MergeSameSourceAxisPass

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
@@ -30,6 +30,8 @@ namespace mlir {
 namespace triton {
 
 std::unique_ptr<OperationPass<ModuleOp>> createUBUsageOptPass();
+std::unique_ptr<OperationPass<ModuleOp>> createMergeSameSourceAxisPass();
+void registerMergeSameSourceAxisPass();
 std::unique_ptr<OperationPass<ModuleOp>> createUnifyAllocBlockPass();
 void registerUnifyAllocBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createMergeVectorIfBlockPass();

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeSameSourceAxisPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeSameSourceAxisPass.cpp
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+
+#include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+static constexpr const char *DEBUG_TYPE = "merge-same-source-axis";
+#define LOG_DEBUG(...)                                                         \
+  LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
+
+using namespace mlir;
+
+namespace mlir {
+namespace triton {
+
+namespace {
+
+static bool findNearestConvergence(ArrayRef<Operation *> consumers,
+                                   SmallVectorImpl<Operation *> &chainOps) {
+  if (consumers.size() < 2) {
+    return false;
+  }
+
+  llvm::DenseMap<Operation *, int> firstIdx;
+  llvm::DenseMap<Operation *, Operation *> parent;
+  SmallVector<std::pair<Operation *, int>> bfsQueue;
+
+  for (size_t consumerIndex = 0; consumerIndex < consumers.size();
+       ++consumerIndex) {
+    Operation *consumer = consumers[consumerIndex];
+    auto ins = firstIdx.insert({consumer, (int)consumerIndex});
+    if (ins.second) {
+      parent[consumer] = nullptr;
+      bfsQueue.push_back({consumer, (int)consumerIndex});
+    }
+  }
+
+  for (size_t queueIndex = 0; queueIndex < bfsQueue.size(); ++queueIndex) {
+    Operation *cur = bfsQueue[queueIndex].first;
+    int myIdx = bfsQueue[queueIndex].second;
+    for (Operation *user : cur->getUsers()) {
+      if (CVPipeline::getOpCoreType(user) !=
+          CVPipeline::CoreType::VECTOR_ONLY) {
+        continue;
+      }
+      auto it = firstIdx.find(user);
+      if (it == firstIdx.end()) {
+        firstIdx[user] = myIdx;
+        parent[user] = cur;
+        bfsQueue.push_back({user, myIdx});
+      } else if (it->second != myIdx) {
+        Operation *cons1 = consumers[it->second];
+        Operation *cons2 = consumers[myIdx];
+        Operation *convergenceOp = user;
+
+        SmallVector<Operation *> p1;
+        for (Operation *pathOp = convergenceOp; pathOp;
+             pathOp = parent[pathOp]) {
+          p1.push_back(pathOp);
+          if (pathOp == cons1) {
+            break;
+          }
+        }
+        std::reverse(p1.begin(), p1.end());
+
+        SmallVector<Operation *> p2;
+        for (Operation *pathOp = cur; pathOp; pathOp = parent[pathOp]) {
+          p2.push_back(pathOp);
+          if (pathOp == cons2) {
+            break;
+          }
+        }
+        std::reverse(p2.begin(), p2.end());
+        p2.push_back(convergenceOp);
+
+        chainOps.clear();
+        llvm::DenseSet<Operation *> inChain;
+        for (Operation *op : p1) {
+          if (op != convergenceOp && inChain.insert(op).second) {
+            chainOps.push_back(op);
+          }
+        }
+        for (Operation *op : p2) {
+          if (op != convergenceOp && inChain.insert(op).second) {
+            chainOps.push_back(op);
+          }
+        }
+        chainOps.push_back(convergenceOp);
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+static void tryMergeSource(Operation *source,
+                           const CVPipeline::MemoryDependenceGraph &memGraph,
+                           CVPipeline::ComputeBlockIdManager &bm) {
+  auto srcBlockIdOpt = CVPipeline::getOpBlockId(source);
+  if (!srcBlockIdOpt || *srcBlockIdOpt < 0) {
+    return;
+  }
+  int srcBlockId = *srcBlockIdOpt;
+
+  SmallVector<Operation *> consumers;
+  for (Operation *user : source->getUsers()) {
+    if (CVPipeline::getOpCoreType(user) != CVPipeline::CoreType::VECTOR_ONLY) {
+      continue;
+    }
+    auto bidOpt = CVPipeline::getOpBlockId(user);
+    if (!bidOpt || *bidOpt == srcBlockId) {
+      continue;
+    }
+    consumers.push_back(user);
+  }
+  if (consumers.size() < 2) {
+    return;
+  }
+
+  SmallVector<Operation *> chainOps;
+  if (!findNearestConvergence(consumers, chainOps)) {
+    return;
+  }
+  LOG_DEBUG("[tryMergeSource] candidate source=" << *source << " chainSize="
+                                                 << chainOps.size());
+
+  if (CVPipeline::willCreateCycle(chainOps, memGraph, srcBlockId, bm)) {
+    LOG_DEBUG("[tryMergeSource] willCreateCycle, skip");
+    return;
+  }
+
+  for (Operation *op : chainOps) {
+    bm.updateBlockId(op, srcBlockId);
+  }
+  LOG_DEBUG("[tryMergeSource] merged " << chainOps.size()
+                                       << " ops into block_id=" << srcBlockId);
+}
+
+} // anonymous namespace
+
+class MergeSameSourceAxisPass
+    : public PassWrapper<MergeSameSourceAxisPass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MergeSameSourceAxisPass)
+
+  MergeSameSourceAxisPass() = default;
+
+  StringRef getArgument() const override { return "merge-same-source-axis"; }
+
+  StringRef getDescription() const override {
+    return "Rewrite ssbuffer.block_id so that >=2 vector consumers of a "
+           "source op whose downstream converges at a common op end up in "
+           "the same block as the source. Only VECTOR core ops are considered.";
+  }
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+
+    if (CVPipeline::hasFallbackAttr(module)) {
+      return;
+    }
+
+    LOG_DEBUG("Before: " << *module);
+    auto &aa = getAnalysis<AliasAnalysis>();
+    CVPipeline::MemoryDependenceGraph memGraph(module, aa);
+    auto bm = CVPipeline::ComputeBlockIdManager(module);
+
+    SmallVector<Operation *> candidates;
+    module.walk([&](Operation *op) {
+      if (CVPipeline::getOpCoreType(op) != CVPipeline::CoreType::VECTOR_ONLY) {
+        return;
+      }
+      if (!CVPipeline::getOpBlockId(op)) {
+        return;
+      }
+      if (op->getUsers().empty()) {
+        return;
+      }
+      candidates.push_back(op);
+    });
+
+    for (Operation *source : candidates) {
+      tryMergeSource(source, memGraph, bm);
+    }
+
+    LOG_DEBUG("After: " << *module);
+  }
+};
+
+std::unique_ptr<OperationPass<ModuleOp>> createMergeSameSourceAxisPass() {
+  return std::make_unique<MergeSameSourceAxisPass>();
+}
+
+void registerMergeSameSourceAxisPass() {
+  PassRegistration<MergeSameSourceAxisPass> reg;
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeSameSourceAxisPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeSameSourceAxisPass.cpp
@@ -26,11 +26,13 @@
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
 
 #include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
 
@@ -45,7 +47,17 @@ namespace triton {
 
 namespace {
 
-static bool findNearestConvergence(ArrayRef<Operation *> consumers,
+// True iff `op` lives in the same MLIR Region as `source`. Used to reject
+// merges whose BFS would cross a region-bearing op boundary (scf.for /
+// scf.while / scf.if / func.func / etc.) — every such op exposes its body
+// as a distinct Region, so plain pointer equality on getParentRegion()
+// catches all of them.
+static bool isInSameRegion(Operation *op, Operation *source) {
+  return op->getParentRegion() == source->getParentRegion();
+}
+
+static bool findNearestConvergence(Operation *source,
+                                   ArrayRef<Operation *> consumers,
                                    SmallVectorImpl<Operation *> &chainOps) {
   if (consumers.size() < 2) {
     return false;
@@ -73,12 +85,23 @@ static bool findNearestConvergence(ArrayRef<Operation *> consumers,
           CVPipeline::CoreType::VECTOR_ONLY) {
         continue;
       }
+      // Prune any traversal that crosses a region-bearing op boundary
+      // (scf.for / scf.while / scf.if / etc.). The merge is only valid
+      // when source and the entire reachable chain live in the same region.
+      if (!isInSameRegion(user, source)) {
+        continue;
+      }
       auto it = firstIdx.find(user);
       if (it == firstIdx.end()) {
         firstIdx[user] = myIdx;
         parent[user] = cur;
         bfsQueue.push_back({user, myIdx});
       } else if (it->second != myIdx) {
+        // Reject 1-step false convergence when `user` is itself a starting
+        // consumer — adjacent siblings are not a real two-branch merge.
+        if (llvm::is_contained(consumers, user)) {
+          continue;
+        }
         Operation *cons1 = consumers[it->second];
         Operation *cons2 = consumers[myIdx];
         Operation *convergenceOp = user;
@@ -116,6 +139,29 @@ static bool findNearestConvergence(ArrayRef<Operation *> consumers,
           }
         }
         chainOps.push_back(convergenceOp);
+
+        // Pull the convergence op's same-block VECTOR_ONLY direct users
+        // along so the moved convergence op doesn't leave its tail behind.
+        auto convBlockIdOpt = CVPipeline::getOpBlockId(convergenceOp);
+        if (convBlockIdOpt && *convBlockIdOpt >= 0) {
+          int convBlockId = *convBlockIdOpt;
+          for (Operation *user : convergenceOp->getUsers()) {
+            if (CVPipeline::getOpCoreType(user) !=
+                CVPipeline::CoreType::VECTOR_ONLY) {
+              continue;
+            }
+            if (!isInSameRegion(user, source)) {
+              continue;
+            }
+            auto userBidOpt = CVPipeline::getOpBlockId(user);
+            if (!userBidOpt || *userBidOpt != convBlockId) {
+              continue;
+            }
+            if (inChain.insert(user).second) {
+              chainOps.push_back(user);
+            }
+          }
+        }
         return true;
       }
     }
@@ -132,9 +178,21 @@ static void tryMergeSource(Operation *source,
   }
   int srcBlockId = *srcBlockIdOpt;
 
+  // Skip constants as merge sources: they have no axis semantics and their
+  // many users routinely trigger trivial 1-step BFS convergence.
+  if (mlir::isa<mlir::arith::ConstantOp>(source)) {
+    return;
+  }
+
   SmallVector<Operation *> consumers;
   for (Operation *user : source->getUsers()) {
     if (CVPipeline::getOpCoreType(user) != CVPipeline::CoreType::VECTOR_ONLY) {
+      continue;
+    }
+    // Mirror the BFS guard: only consider consumers that share the same
+    // region as the source. Cross-region consumers can't reach a valid
+    // convergence without leaving the scope.
+    if (!isInSameRegion(user, source)) {
       continue;
     }
     auto bidOpt = CVPipeline::getOpBlockId(user);
@@ -148,7 +206,7 @@ static void tryMergeSource(Operation *source,
   }
 
   SmallVector<Operation *> chainOps;
-  if (!findNearestConvergence(consumers, chainOps)) {
+  if (!findNearestConvergence(source, consumers, chainOps)) {
     return;
   }
   LOG_DEBUG("[tryMergeSource] candidate source=" << *source << " chainSize="

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeSameSourceAxisPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeSameSourceAxisPass.cpp
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
 #include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
@@ -47,13 +46,52 @@ namespace triton {
 
 namespace {
 
-// True iff `op` lives in the same MLIR Region as `source`. Used to reject
-// merges whose BFS would cross a region-bearing op boundary (scf.for /
-// scf.while / scf.if / func.func / etc.) — every such op exposes its body
-// as a distinct Region, so plain pointer equality on getParentRegion()
-// catches all of them.
 static bool isInSameRegion(Operation *op, Operation *source) {
   return op->getParentRegion() == source->getParentRegion();
+}
+
+// Walk parent chain from start to target (inclusive), deduped via inChain.
+// Caller ensures target is on start's parent chain.
+static void appendPath(Operation *start, Operation *target,
+                       const llvm::DenseMap<Operation *, Operation *> &parent,
+                       llvm::DenseSet<Operation *> &inChain,
+                       SmallVectorImpl<Operation *> &chainOps) {
+  for (Operation *pathOp = start; pathOp; pathOp = parent.lookup(pathOp)) {
+    if (inChain.insert(pathOp).second) {
+      chainOps.push_back(pathOp);
+    }
+    if (pathOp == target) {
+      break;
+    }
+  }
+}
+
+// Append convergenceOp's same-block VECTOR_ONLY direct downstream so the moved
+// op doesn't leave its tail behind.
+static void
+extendChainWithConvergenceTail(Operation *convergenceOp, Operation *source,
+                               llvm::DenseSet<Operation *> &inChain,
+                               SmallVectorImpl<Operation *> &chainOps) {
+  auto convBlockIdOpt = CVPipeline::getOpBlockId(convergenceOp);
+  if (!convBlockIdOpt || *convBlockIdOpt < 0) {
+    return;
+  }
+  int convBlockId = *convBlockIdOpt;
+  for (Operation *user : convergenceOp->getUsers()) {
+    if (CVPipeline::getOpCoreType(user) != CVPipeline::CoreType::VECTOR_ONLY) {
+      continue;
+    }
+    if (!isInSameRegion(user, source)) {
+      continue;
+    }
+    auto userBidOpt = CVPipeline::getOpBlockId(user);
+    if (!userBidOpt || *userBidOpt != convBlockId) {
+      continue;
+    }
+    if (inChain.insert(user).second) {
+      chainOps.push_back(user);
+    }
+  }
 }
 
 static bool findNearestConvergence(Operation *source,
@@ -85,9 +123,6 @@ static bool findNearestConvergence(Operation *source,
           CVPipeline::CoreType::VECTOR_ONLY) {
         continue;
       }
-      // Prune any traversal that crosses a region-bearing op boundary
-      // (scf.for / scf.while / scf.if / etc.). The merge is only valid
-      // when source and the entire reachable chain live in the same region.
       if (!isInSameRegion(user, source)) {
         continue;
       }
@@ -97,8 +132,6 @@ static bool findNearestConvergence(Operation *source,
         parent[user] = cur;
         bfsQueue.push_back({user, myIdx});
       } else if (it->second != myIdx) {
-        // Reject 1-step false convergence when `user` is itself a starting
-        // consumer — adjacent siblings are not a real two-branch merge.
         if (llvm::is_contained(consumers, user)) {
           continue;
         }
@@ -106,62 +139,13 @@ static bool findNearestConvergence(Operation *source,
         Operation *cons2 = consumers[myIdx];
         Operation *convergenceOp = user;
 
-        SmallVector<Operation *> p1;
-        for (Operation *pathOp = convergenceOp; pathOp;
-             pathOp = parent[pathOp]) {
-          p1.push_back(pathOp);
-          if (pathOp == cons1) {
-            break;
-          }
-        }
-        std::reverse(p1.begin(), p1.end());
-
-        SmallVector<Operation *> p2;
-        for (Operation *pathOp = cur; pathOp; pathOp = parent[pathOp]) {
-          p2.push_back(pathOp);
-          if (pathOp == cons2) {
-            break;
-          }
-        }
-        std::reverse(p2.begin(), p2.end());
-        p2.push_back(convergenceOp);
-
         chainOps.clear();
         llvm::DenseSet<Operation *> inChain;
-        for (Operation *op : p1) {
-          if (op != convergenceOp && inChain.insert(op).second) {
-            chainOps.push_back(op);
-          }
-        }
-        for (Operation *op : p2) {
-          if (op != convergenceOp && inChain.insert(op).second) {
-            chainOps.push_back(op);
-          }
-        }
-        chainOps.push_back(convergenceOp);
-
-        // Pull the convergence op's same-block VECTOR_ONLY direct users
-        // along so the moved convergence op doesn't leave its tail behind.
-        auto convBlockIdOpt = CVPipeline::getOpBlockId(convergenceOp);
-        if (convBlockIdOpt && *convBlockIdOpt >= 0) {
-          int convBlockId = *convBlockIdOpt;
-          for (Operation *user : convergenceOp->getUsers()) {
-            if (CVPipeline::getOpCoreType(user) !=
-                CVPipeline::CoreType::VECTOR_ONLY) {
-              continue;
-            }
-            if (!isInSameRegion(user, source)) {
-              continue;
-            }
-            auto userBidOpt = CVPipeline::getOpBlockId(user);
-            if (!userBidOpt || *userBidOpt != convBlockId) {
-              continue;
-            }
-            if (inChain.insert(user).second) {
-              chainOps.push_back(user);
-            }
-          }
-        }
+        inChain.clear();
+        appendPath(convergenceOp, cons1, parent, inChain, chainOps);
+        appendPath(cur, cons2, parent, inChain, chainOps);
+        extendChainWithConvergenceTail(convergenceOp, source, inChain,
+                                       chainOps);
         return true;
       }
     }
@@ -178,9 +162,13 @@ static void tryMergeSource(Operation *source,
   }
   int srcBlockId = *srcBlockIdOpt;
 
-  // Skip constants as merge sources: they have no axis semantics and their
-  // many users routinely trigger trivial 1-step BFS convergence.
   if (mlir::isa<mlir::arith::ConstantOp>(source)) {
+    return;
+  }
+
+  // Source must be tensor-shaped; scalars have no axis semantics.
+  if (source->getNumResults() != 1 ||
+      !mlir::isa<mlir::TensorType>(source->getResult(0).getType())) {
     return;
   }
 
@@ -189,9 +177,6 @@ static void tryMergeSource(Operation *source,
     if (CVPipeline::getOpCoreType(user) != CVPipeline::CoreType::VECTOR_ONLY) {
       continue;
     }
-    // Mirror the BFS guard: only consider consumers that share the same
-    // region as the source. Cross-region consumers can't reach a valid
-    // convergence without leaving the scope.
     if (!isInSameRegion(user, source)) {
       continue;
     }
@@ -255,13 +240,12 @@ public:
 
     SmallVector<Operation *> candidates;
     module.walk([&](Operation *op) {
-      if (CVPipeline::getOpCoreType(op) != CVPipeline::CoreType::VECTOR_ONLY) {
+      if (CVPipeline::getOpCoreType(op) != CVPipeline::CoreType::VECTOR_ONLY ||
+          !CVPipeline::getOpBlockId(op) || op->getUsers().empty()) {
         return;
       }
-      if (!CVPipeline::getOpBlockId(op)) {
-        return;
-      }
-      if (op->getUsers().empty()) {
+      if (op->getNumResults() != 1 ||
+          !mlir::isa<mlir::TensorType>(op->getResult(0).getType())) {
         return;
       }
       candidates.push_back(op);

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeSameSourceAxisPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeSameSourceAxisPass.cpp
@@ -194,6 +194,34 @@ static void tryMergeSource(Operation *source,
   if (!findNearestConvergence(source, consumers, chainOps)) {
     return;
   }
+
+  // Guard: convergenceOp's upstream operands must all live in blocks that this
+  // merge will cover
+  Operation *convergenceOp = chainOps.front();
+  for (Value operand : convergenceOp->getOperands()) {
+    Operation *defOp = operand.getDefiningOp();
+    if (!defOp) {
+      continue;
+    }
+    if (!isInSameRegion(defOp, source)) {
+      continue;
+    }
+    if (defOp == source) {
+      continue;
+    }
+    if (llvm::is_contained(chainOps, defOp)) {
+      continue;
+    }
+    auto defBidOpt = CVPipeline::getOpBlockId(defOp);
+    if (defBidOpt && *defBidOpt == srcBlockId) {
+      continue;
+    }
+    LOG_DEBUG("[tryMergeSource] convergenceOp="
+              << *convergenceOp << " has unaligned upstream defOp=" << *defOp
+              << ", skip");
+    return;
+  }
+
   LOG_DEBUG("[tryMergeSource] candidate source=" << *source << " chainSize="
                                                  << chainOps.size());
 

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
@@ -58,6 +58,7 @@ void ComputeBlockOptPass::runOnOperation() {
   pm.addPass(createReorderOpsByBlockIdPass());
 
   pm.addPass(createUBUsageOptPass());
+  pm.addPass(createMergeSameSourceAxisPass());
   pm.addPass(createReorderOpsByBlockIdPass());
 
   pm.addPass(createFixpipeOptPass());
@@ -83,6 +84,7 @@ void registerComputeBlockOptPasses() {
     return createComputeBlockOptPass();
   });
   registerPass(createUBUsageOptPass);
+  registerPass(createMergeSameSourceAxisPass);
   registerPass(createUnifyAllocBlockPass);
   registerPass(createMergeVectorIfBlockPass);
   registerPass(createMergeCubeForBlockPass);

--- a/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
@@ -43,24 +43,17 @@ static constexpr const char *DEBUG_TYPE = "RemoveAttributes";
 
 // if extra attr is needed, add to ut @
 // third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/test-remove-attrs.mlir
-static constexpr llvm::StringLiteral kAttrsToRemove[]{kBlockId,
-                                                      kCoreType,
-                                                      kTransferId,
-                                                      kMainLoop,
-                                                      kCubeFirst,
-                                                      kVectorFirst,
-                                                      kAddFromMatmul,
-                                                      kIntraBuffer,
-                                                      kAnalyzeFlagId,
-                                                      kLoopCarriedL0C,
-                                                      kCrossCoreDeps,
-                                                      kMemCrossDeps,
-                                                      kClone,
-                                                      kIntraBufCount,
-                                                      kInterCoreBufCount,
-                                                      kLoadStoreBufCount,
-                                                      kInsertionOptimization,
-                                                      kEnableUbRefineOpt};
+static constexpr llvm::StringLiteral kAttrsToRemove[]{
+    kBlockId,           kCoreType,
+    kTransferId,        kMainLoop,
+    kCubeFirst,         kVectorFirst,
+    kAddFromMatmul,     kIntraDeps,
+    kIntraBuffer,       kAnalyzeFlagId,
+    kLoopCarriedL0C,    kCrossCoreDeps,
+    kMemCrossDeps,      kClone,
+    kIntraBufCount,     kInterCoreBufCount,
+    kLoadStoreBufCount, kInsertionOptimization,
+    kEnableUbRefineOpt};
 
 void RemoveSsbufAttrPass::runOnOperation() {
   auto module = getOperation();

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_same_source_axis.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_same_source_axis.mlir
@@ -9,28 +9,25 @@
 // be touched.
 module {
   // CHECK-LABEL: func.func @same_source_diff_axis
-  func.func @same_source_diff_axis(%arg0: f32, %arg1: f32) {
-    %cst_a = arith.constant {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} 2.000000e+00 : f32
-    %cst_b = arith.constant {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} 3.000000e+00 : f32
-
+  func.func @same_source_diff_axis(%arg0: tensor<8xf32>, %arg1: tensor<8xf32>) {
     // Source in block 28.
-    %src = arith.addf %arg0, %arg1 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    %src = arith.addf %arg0, %arg1 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
 
     // Convergent chain in block 29 — all three should move to block 28.
     // CHECK: arith.mulf %{{.*}}, %{{.*}} {{{.*}}ssbuffer.block_id = 28
-    %b1 = arith.mulf %src, %cst_a {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    %b1 = arith.mulf %src, %arg0 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
     // CHECK: arith.mulf %{{.*}}, %{{.*}} {{{.*}}ssbuffer.block_id = 28
-    %b2 = arith.mulf %src, %cst_b {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    %b2 = arith.mulf %src, %arg1 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
     // CHECK: arith.subf %{{.*}}, %{{.*}} {{{.*}}ssbuffer.block_id = 28
-    %sub = arith.subf %b1, %b2 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    %sub = arith.subf %b1, %b2 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
 
     // Unrelated single consumer in block 30 — must stay.
     // CHECK: arith.addf %{{.*}}, %{{.*}} {{{.*}}ssbuffer.block_id = 30
-    %u1 = arith.addf %src, %cst_a {ssbuffer.block_id = 30 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    %u1 = arith.addf %src, %arg0 {ssbuffer.block_id = 30 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
 
     // Unrelated single consumer in block 31 — must stay.
     // CHECK: arith.mulf %{{.*}}, %{{.*}} {{{.*}}ssbuffer.block_id = 31
-    %u2 = arith.mulf %src, %cst_b {ssbuffer.block_id = 31 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    %u2 = arith.mulf %src, %arg1 {ssbuffer.block_id = 31 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
 
     return
   }
@@ -40,21 +37,18 @@ module {
 // Consumers u1 (block 29) and u2 (block 30) live in DIFFERENT blocks, but
 // converge at %sub (block 30). All three should still move to source's
 // block_id (50).
-func.func @same_source_diff_axis_cross_block(%arg0: f32, %arg1: f32) {
-  %cst_a = arith.constant {ssbuffer.block_id = 50 : i32, ssbuffer.core_type = "VECTOR"} 2.000000e+00 : f32
-  %cst_b = arith.constant {ssbuffer.block_id = 50 : i32, ssbuffer.core_type = "VECTOR"} 3.000000e+00 : f32
-
+func.func @same_source_diff_axis_cross_block(%arg0: tensor<8xf32>, %arg1: tensor<8xf32>) {
   // Source in block 50.
   // CHECK: arith.addf %{{.*}}, %{{.*}} {{{.*}}ssbuffer.block_id = 50
-  %src = arith.addf %arg0, %arg1 {ssbuffer.block_id = 50 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %src = arith.addf %arg0, %arg1 {ssbuffer.block_id = 50 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
 
   // u1 in block 29, u2 in block 30 — different blocks, but the chain still
   // converges at %sub.
   // CHECK: arith.mulf %{{.*}}, %{{.*}} {{{.*}}ssbuffer.block_id = 50
-  %u1 = arith.mulf %src, %cst_a {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %u1 = arith.mulf %src, %arg0 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
   // CHECK: arith.mulf %{{.*}}, %{{.*}} {{{.*}}ssbuffer.block_id = 50
-  %u2 = arith.mulf %src, %cst_b {ssbuffer.block_id = 30 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %u2 = arith.mulf %src, %arg1 {ssbuffer.block_id = 30 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
   // CHECK: arith.subf %{{.*}}, %{{.*}} {{{.*}}ssbuffer.block_id = 50
-  %sub = arith.subf %u1, %u2 {ssbuffer.block_id = 30 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %sub = arith.subf %u1, %u2 {ssbuffer.block_id = 30 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
   return
 }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_same_source_axis.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_same_source_axis.mlir
@@ -1,0 +1,60 @@
+// RUN: triton-opt --merge-same-source-axis %s | FileCheck %s
+
+// Source %src is in block_id 28. Two consumers in block_id 29 do different
+// "axis" processing of %src (here: mulf by different scalars) and converge
+// at %sub = arith.subf %b1, %b2 (also block_id 29). All three should be
+// moved to block_id 28.
+//
+// %src also has unrelated consumers in block 30 and block 31 that must NOT
+// be touched.
+module {
+  // CHECK-LABEL: func.func @same_source_diff_axis
+  func.func @same_source_diff_axis(%arg0: f32, %arg1: f32) {
+    %cst_a = arith.constant {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} 2.000000e+00 : f32
+    %cst_b = arith.constant {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} 3.000000e+00 : f32
+
+    // Source in block 28.
+    %src = arith.addf %arg0, %arg1 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : f32
+
+    // Convergent chain in block 29 — all three should move to block 28.
+    // CHECK: arith.mulf %{{.*}}, %{{.*}} {{{.*}}ssbuffer.block_id = 28
+    %b1 = arith.mulf %src, %cst_a {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    // CHECK: arith.mulf %{{.*}}, %{{.*}} {{{.*}}ssbuffer.block_id = 28
+    %b2 = arith.mulf %src, %cst_b {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    // CHECK: arith.subf %{{.*}}, %{{.*}} {{{.*}}ssbuffer.block_id = 28
+    %sub = arith.subf %b1, %b2 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+
+    // Unrelated single consumer in block 30 — must stay.
+    // CHECK: arith.addf %{{.*}}, %{{.*}} {{{.*}}ssbuffer.block_id = 30
+    %u1 = arith.addf %src, %cst_a {ssbuffer.block_id = 30 : i32, ssbuffer.core_type = "VECTOR"} : f32
+
+    // Unrelated single consumer in block 31 — must stay.
+    // CHECK: arith.mulf %{{.*}}, %{{.*}} {{{.*}}ssbuffer.block_id = 31
+    %u2 = arith.mulf %src, %cst_b {ssbuffer.block_id = 31 : i32, ssbuffer.core_type = "VECTOR"} : f32
+
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @same_source_diff_axis_cross_block
+// Consumers u1 (block 29) and u2 (block 30) live in DIFFERENT blocks, but
+// converge at %sub (block 30). All three should still move to source's
+// block_id (50).
+func.func @same_source_diff_axis_cross_block(%arg0: f32, %arg1: f32) {
+  %cst_a = arith.constant {ssbuffer.block_id = 50 : i32, ssbuffer.core_type = "VECTOR"} 2.000000e+00 : f32
+  %cst_b = arith.constant {ssbuffer.block_id = 50 : i32, ssbuffer.core_type = "VECTOR"} 3.000000e+00 : f32
+
+  // Source in block 50.
+  // CHECK: arith.addf %{{.*}}, %{{.*}} {{{.*}}ssbuffer.block_id = 50
+  %src = arith.addf %arg0, %arg1 {ssbuffer.block_id = 50 : i32, ssbuffer.core_type = "VECTOR"} : f32
+
+  // u1 in block 29, u2 in block 30 — different blocks, but the chain still
+  // converges at %sub.
+  // CHECK: arith.mulf %{{.*}}, %{{.*}} {{{.*}}ssbuffer.block_id = 50
+  %u1 = arith.mulf %src, %cst_a {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  // CHECK: arith.mulf %{{.*}}, %{{.*}} {{{.*}}ssbuffer.block_id = 50
+  %u2 = arith.mulf %src, %cst_b {ssbuffer.block_id = 30 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  // CHECK: arith.subf %{{.*}}, %{{.*}} {{{.*}}ssbuffer.block_id = 50
+  %sub = arith.subf %u1, %u2 {ssbuffer.block_id = 30 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  return
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_same_source_axis_cross_block_dep.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_same_source_axis_cross_block_dep.mlir
@@ -1,0 +1,77 @@
+// RUN: triton-opt --merge-same-source-axis %s | FileCheck %s
+
+// Guards: if the convergence op has an upstream operand whose defOp lives
+// in a block that this merge will NOT cover (neither source's block, nor
+// any block of an op in chainOps), the merge must be skipped. Otherwise
+// moving K to srcBlockId would leave a cross-block dependency between the
+// moved K and the unaligned defOp.
+
+// CHECK-LABEL: func.func @convergence_with_external_dep
+func.func @convergence_with_external_dep(%arg0: tensor<8xf32>, %arg1: tensor<8xf32>) {
+  // External tensor at block 50 — will NOT be moved by this merge.
+  // CHECK: arith.addf {{.*}}ssbuffer.block_id = 50
+  %ext = arith.addf %arg0, %arg1 {ssbuffer.block_id = 50 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
+
+  // Source at block 28.
+  // CHECK: arith.addf {{.*}}ssbuffer.block_id = 28
+  %src = arith.addf %arg0, %arg1 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
+
+  // Two consumers at block 29 — convergent chain.
+  // CHECK: arith.mulf {{.*}}ssbuffer.block_id = 29
+  %a = arith.mulf %src, %arg0 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
+  // CHECK: arith.addf {{.*}}ssbuffer.block_id = 29
+  %b = arith.addf %src, %arg1 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
+
+  // Convergence uses both consumers AND %ext. The guard must skip the
+  // merge — moving %k to block 28 while %ext stays at block 50 would
+  // create a cross-block dependency that ReorderOpsByBlockId cannot
+  // safely resolve.
+  // CHECK: arith.subf {{.*}}ssbuffer.block_id = 29
+  %k = arith.subf %a, %ext {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
+
+  return
+}
+
+// Even when the upstream defOp IS already in srcBlockId (28), the merge
+// is still rejected. reason: willCreateCycle's DFS treats `%ext(28) →
+// %k(29→28)` as an internal cycle within the target block, so the merge
+// is skipped. This is the correct conservative behavior — making the
+// chain self-referential at the target block (an upstream op at the
+// target block feeding a chain op that just arrived at the target block)
+// is exactly what the cycle detector is meant to prevent.
+func.func @external_dep_in_src_block_ok(%arg0: tensor<8xf32>, %arg1: tensor<8xf32>) {
+  // Upstream tensor already at srcBlockId.
+  // CHECK: arith.addf {{.*}}ssbuffer.block_id = 28
+  %ext = arith.addf %arg0, %arg1 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
+
+  // CHECK: arith.addf {{.*}}ssbuffer.block_id = 28
+  %src = arith.addf %arg0, %arg1 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
+
+  // Chain stays at block 29 — willCreateCycle rejects the merge.
+  // CHECK: arith.mulf {{.*}}ssbuffer.block_id = 29
+  %a = arith.mulf %src, %arg0 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
+  // CHECK: arith.addf {{.*}}ssbuffer.block_id = 29
+  %b = arith.addf %src, %arg1 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
+  // CHECK: arith.subf {{.*}}ssbuffer.block_id = 29
+  %k = arith.subf %a, %ext {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
+
+  return
+}
+
+// Upstream defOp that is itself part of chainOps is fine too: it will be
+// moved along with K, so no cross-block dep survives the merge.
+func.func @upstream_defop_already_in_chain(%arg0: tensor<8xf32>, %arg1: tensor<8xf32>) {
+  // CHECK: arith.addf {{.*}}ssbuffer.block_id = 28
+  %src = arith.addf %arg0, %arg1 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
+
+  // %a and %b both consume %src. Their convergent chain ends at %k,
+  // but %b is also an operand of %k — i.e. %b's defOp is in chainOps.
+  // CHECK: arith.mulf {{.*}}ssbuffer.block_id = 28
+  %a = arith.mulf %src, %arg0 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
+  // CHECK: arith.mulf {{.*}}ssbuffer.block_id = 28
+  %b = arith.mulf %src, %arg1 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
+  // CHECK: arith.subf {{.*}}ssbuffer.block_id = 28
+  %k = arith.subf %a, %b {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
+
+  return
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_same_source_axis_downstream.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_same_source_axis_downstream.mlir
@@ -1,0 +1,48 @@
+// RUN: triton-opt --merge-same-source-axis %s | FileCheck %s
+
+// Guards: convergence op's same-block VECTOR_ONLY direct downstream must
+// be pulled along with the merge chain, otherwise the moved convergence
+// op would leave its tail in the old block and create a cross-block
+// dependency inconsistency.
+
+// CHECK-LABEL: func.func @downstream_follows_convergence
+func.func @downstream_follows_convergence(%arg0: f32, %arg1: f32) {
+  // Source at block 28.
+  // CHECK: arith.addf {{.*}}ssbuffer.block_id = 28
+  %src = arith.addf %arg0, %arg1 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : f32
+
+  // Two consumers in block 29 doing different "axis" processing.
+  // CHECK: arith.mulf {{.*}}ssbuffer.block_id = 28
+  %a = arith.mulf %src, %arg1 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  // CHECK: arith.addf {{.*}}ssbuffer.block_id = 28
+  %b = arith.addf %src, %arg1 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+
+  // Convergence op at block 29 — moves to 28.
+  // CHECK: arith.subf {{.*}}ssbuffer.block_id = 28
+  %k = arith.subf %a, %b {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+
+  // Direct downstream VECTOR_ONLY user at the same block_id (29) as %k.
+  // It must follow %k to block 28 — otherwise %k ends up in 28 while
+  // %down stays in 29, splitting the chain.
+  // CHECK: arith.mulf {{.*}}ssbuffer.block_id = 28
+  %down = arith.mulf %k, %arg0 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+
+  return
+}
+
+// Downstream that is at a DIFFERENT block_id from the convergence op is
+// not touched — its placement is independent and may have been decided by
+// other passes.
+func.func @downstream_at_different_block_left_alone(%arg0: f32, %arg1: f32) {
+  %src = arith.addf %arg0, %arg1 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %a = arith.mulf %src, %arg1 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %b = arith.addf %src, %arg1 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  // CHECK: arith.subf {{.*}}ssbuffer.block_id = 28
+  %k = arith.subf %a, %b {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+
+  // Downstream at a different block (50) — must stay put.
+  // CHECK: arith.mulf {{.*}}ssbuffer.block_id = 50
+  %down = arith.mulf %k, %arg0 {ssbuffer.block_id = 50 : i32, ssbuffer.core_type = "VECTOR"} : f32
+
+  return
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_same_source_axis_downstream.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_same_source_axis_downstream.mlir
@@ -6,26 +6,26 @@
 // dependency inconsistency.
 
 // CHECK-LABEL: func.func @downstream_follows_convergence
-func.func @downstream_follows_convergence(%arg0: f32, %arg1: f32) {
+func.func @downstream_follows_convergence(%arg0: tensor<8xf32>, %arg1: tensor<8xf32>) {
   // Source at block 28.
   // CHECK: arith.addf {{.*}}ssbuffer.block_id = 28
-  %src = arith.addf %arg0, %arg1 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %src = arith.addf %arg0, %arg1 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
 
   // Two consumers in block 29 doing different "axis" processing.
   // CHECK: arith.mulf {{.*}}ssbuffer.block_id = 28
-  %a = arith.mulf %src, %arg1 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %a = arith.mulf %src, %arg1 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
   // CHECK: arith.addf {{.*}}ssbuffer.block_id = 28
-  %b = arith.addf %src, %arg1 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %b = arith.addf %src, %arg1 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
 
   // Convergence op at block 29 — moves to 28.
   // CHECK: arith.subf {{.*}}ssbuffer.block_id = 28
-  %k = arith.subf %a, %b {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %k = arith.subf %a, %b {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
 
   // Direct downstream VECTOR_ONLY user at the same block_id (29) as %k.
   // It must follow %k to block 28 — otherwise %k ends up in 28 while
   // %down stays in 29, splitting the chain.
   // CHECK: arith.mulf {{.*}}ssbuffer.block_id = 28
-  %down = arith.mulf %k, %arg0 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %down = arith.mulf %k, %arg0 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
 
   return
 }
@@ -33,16 +33,16 @@ func.func @downstream_follows_convergence(%arg0: f32, %arg1: f32) {
 // Downstream that is at a DIFFERENT block_id from the convergence op is
 // not touched — its placement is independent and may have been decided by
 // other passes.
-func.func @downstream_at_different_block_left_alone(%arg0: f32, %arg1: f32) {
-  %src = arith.addf %arg0, %arg1 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : f32
-  %a = arith.mulf %src, %arg1 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
-  %b = arith.addf %src, %arg1 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+func.func @downstream_at_different_block_left_alone(%arg0: tensor<8xf32>, %arg1: tensor<8xf32>) {
+  %src = arith.addf %arg0, %arg1 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
+  %a = arith.mulf %src, %arg1 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
+  %b = arith.addf %src, %arg1 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
   // CHECK: arith.subf {{.*}}ssbuffer.block_id = 28
-  %k = arith.subf %a, %b {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %k = arith.subf %a, %b {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
 
   // Downstream at a different block (50) — must stay put.
   // CHECK: arith.mulf {{.*}}ssbuffer.block_id = 50
-  %down = arith.mulf %k, %arg0 {ssbuffer.block_id = 50 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %down = arith.mulf %k, %arg0 {ssbuffer.block_id = 50 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
 
   return
 }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_same_source_axis_no_trivial_convergence.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_same_source_axis_no_trivial_convergence.mlir
@@ -1,0 +1,48 @@
+// RUN: triton-opt --merge-same-source-axis %s | FileCheck %s
+
+// Guards: 1-step "false convergence" must be rejected.
+//
+// Two VECTOR_ONLY consumers of a tensor source are in a direct
+// producer-consumer relationship (%A -> %B). Without the trivial-
+// convergence guard, the BFS would step once from %A and encounter %B,
+// declare %B the convergence op, and reblock the chain — even though
+// there is no real two-branch merge.
+//
+// With the guard, hitting another starting consumer is treated as a
+// non-event and the BFS keeps exploring. No downstream op is reached by
+// two independent paths, so findNearestConvergence returns false.
+
+// CHECK-LABEL: func.func @no_false_convergence_via_producer_consumer
+func.func @no_false_convergence_via_producer_consumer(%arg0: f32, %arg1: f32) {
+  // Tensor source at block 28 (will be tried as a merge root).
+  %src = arith.addf %arg0, %arg1 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : f32
+
+  // %a is a direct consumer of %src (block 27). It has only one
+  // downstream user %b, which is also a consumer of %src (block 27).
+  // The BFS would naively see %a -> %b as a "convergence at %b" but %b
+  // is itself a starting consumer — must be rejected.
+  // CHECK: arith.addf {{.*}}ssbuffer.block_id = 27
+  %a = arith.addf %src, %arg1 {ssbuffer.block_id = 27 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  // CHECK: arith.mulf {{.*}}ssbuffer.block_id = 27
+  %b = arith.mulf %a, %arg1 {ssbuffer.block_id = 27 : i32, ssbuffer.core_type = "VECTOR"} : f32
+
+  return
+}
+
+// Same pattern but the "trivial convergence" candidate is a deeper
+// consumer that the BFS would also reach in one step. Still rejected.
+func.func @no_false_convergence_via_chained_consumer(%arg0: f32, %arg1: f32) {
+  %src = arith.addf %arg0, %arg1 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : f32
+
+  // CHECK: arith.addf {{.*}}ssbuffer.block_id = 30
+  %x = arith.addf %src, %arg1 {ssbuffer.block_id = 30 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  // CHECK: arith.mulf {{.*}}ssbuffer.block_id = 30
+  %y = arith.mulf %x, %arg1 {ssbuffer.block_id = 30 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  // %z is downstream of both %x and %y paths only via %y; not a real
+  // two-branch merge. BFS from %x reaches %y in one step, but %y is a
+  // starting consumer — must be rejected.
+  // CHECK: arith.addf {{.*}}ssbuffer.block_id = 31
+  %z = arith.addf %y, %arg0 {ssbuffer.block_id = 31 : i32, ssbuffer.core_type = "VECTOR"} : f32
+
+  return
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_same_source_axis_no_trivial_convergence.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_same_source_axis_no_trivial_convergence.mlir
@@ -13,36 +13,36 @@
 // two independent paths, so findNearestConvergence returns false.
 
 // CHECK-LABEL: func.func @no_false_convergence_via_producer_consumer
-func.func @no_false_convergence_via_producer_consumer(%arg0: f32, %arg1: f32) {
+func.func @no_false_convergence_via_producer_consumer(%arg0: tensor<8xf32>, %arg1: tensor<8xf32>) {
   // Tensor source at block 28 (will be tried as a merge root).
-  %src = arith.addf %arg0, %arg1 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %src = arith.addf %arg0, %arg1 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
 
   // %a is a direct consumer of %src (block 27). It has only one
   // downstream user %b, which is also a consumer of %src (block 27).
   // The BFS would naively see %a -> %b as a "convergence at %b" but %b
   // is itself a starting consumer — must be rejected.
   // CHECK: arith.addf {{.*}}ssbuffer.block_id = 27
-  %a = arith.addf %src, %arg1 {ssbuffer.block_id = 27 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %a = arith.addf %src, %arg1 {ssbuffer.block_id = 27 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
   // CHECK: arith.mulf {{.*}}ssbuffer.block_id = 27
-  %b = arith.mulf %a, %arg1 {ssbuffer.block_id = 27 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %b = arith.mulf %a, %arg1 {ssbuffer.block_id = 27 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
 
   return
 }
 
 // Same pattern but the "trivial convergence" candidate is a deeper
 // consumer that the BFS would also reach in one step. Still rejected.
-func.func @no_false_convergence_via_chained_consumer(%arg0: f32, %arg1: f32) {
-  %src = arith.addf %arg0, %arg1 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : f32
+func.func @no_false_convergence_via_chained_consumer(%arg0: tensor<8xf32>, %arg1: tensor<8xf32>) {
+  %src = arith.addf %arg0, %arg1 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
 
   // CHECK: arith.addf {{.*}}ssbuffer.block_id = 30
-  %x = arith.addf %src, %arg1 {ssbuffer.block_id = 30 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %x = arith.addf %src, %arg1 {ssbuffer.block_id = 30 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
   // CHECK: arith.mulf {{.*}}ssbuffer.block_id = 30
-  %y = arith.mulf %x, %arg1 {ssbuffer.block_id = 30 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %y = arith.mulf %x, %arg1 {ssbuffer.block_id = 30 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
   // %z is downstream of both %x and %y paths only via %y; not a real
   // two-branch merge. BFS from %x reaches %y in one step, but %y is a
   // starting consumer — must be rejected.
   // CHECK: arith.addf {{.*}}ssbuffer.block_id = 31
-  %z = arith.addf %y, %arg0 {ssbuffer.block_id = 31 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %z = arith.addf %y, %arg0 {ssbuffer.block_id = 31 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
 
   return
 }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_same_source_axis_skip_constant.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_same_source_axis_skip_constant.mlir
@@ -1,0 +1,48 @@
+// RUN: triton-opt --merge-same-source-axis %s | FileCheck %s
+
+// Guards: arith.constant must NOT act as a merge source.
+//
+// %c0_i32 (block 31) is consumed by %79 and %80 (both block 27). %80 is
+// also a direct user of %79. Without the constant-source guard the BFS
+// would trigger a trivial 1-step convergence at %80 and reblock both ops
+// to block 31 — which is exactly the leak pattern that motivated this
+// guard. With the guard, the constant is skipped and nothing moves.
+
+// CHECK-LABEL: func.func @constant_source_skipped
+func.func @constant_source_skipped(%arg0: i32, %arg1: i32) {
+  // CHECK: arith.constant {{.*}}ssbuffer.block_id = 31
+  %c0_i32 = arith.constant {MixUse, ssbuffer.block_id = 31 : i32, ssbuffer.core_type = "VECTOR"} 0 : i32
+  // CHECK: arith.constant {{.*}}ssbuffer.block_id = 31
+  %c1_i32 = arith.constant {MixUse, ssbuffer.block_id = 31 : i32, ssbuffer.core_type = "VECTOR"} 1 : i32
+
+  // These two must stay at block 27 — constant is not a real axis source.
+  // CHECK: arith.subi {{.*}}ssbuffer.block_id = 27
+  %79 = arith.subi %c0_i32, %arg0 {ssbuffer.block_id = 27 : i32, ssbuffer.core_type = "VECTOR"} : i32
+  // CHECK: arith.maxsi {{.*}}ssbuffer.block_id = 27
+  %80 = arith.maxsi %79, %c0_i32 {ssbuffer.block_id = 27 : i32, ssbuffer.core_type = "VECTOR"} : i32
+  // CHECK: arith.index_cast {{.*}}ssbuffer.block_id = 27
+  %81 = arith.index_cast %80 {ssbuffer.block_id = 27 : i32, ssbuffer.core_type = "VECTOR"} : i32 to index
+
+  return
+}
+
+// Constants used purely as scalar operands to a tensor-typed merge chain
+// must also not perturb the chain. Here %src is a real tensor source at
+// block 28; the chain below is a legitimate same-source-different-axes
+// pattern and must still merge.
+func.func @constant_consumer_does_not_break_legit_chain(%arg0: tensor<32xf32>, %arg1: f32) {
+  %c0_i32 = arith.constant {ssbuffer.block_id = 31 : i32, ssbuffer.core_type = "VECTOR"} 0 : i32
+
+  // Source %src at block 28.
+  %src = arith.addf %arg1, %arg1 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : f32
+
+  // Two consumers with a shared constant operand — they must still merge.
+  // CHECK: arith.mulf {{.*}}ssbuffer.block_id = 28
+  %a = arith.mulf %src, %arg1 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  // CHECK: arith.addf {{.*}}ssbuffer.block_id = 28
+  %b = arith.addf %src, %arg1 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  // CHECK: arith.subf {{.*}}ssbuffer.block_id = 28
+  %k = arith.subf %a, %b {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+
+  return
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_same_source_axis_skip_constant.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_same_source_axis_skip_constant.mlir
@@ -30,19 +30,19 @@ func.func @constant_source_skipped(%arg0: i32, %arg1: i32) {
 // must also not perturb the chain. Here %src is a real tensor source at
 // block 28; the chain below is a legitimate same-source-different-axes
 // pattern and must still merge.
-func.func @constant_consumer_does_not_break_legit_chain(%arg0: tensor<32xf32>, %arg1: f32) {
+func.func @constant_consumer_does_not_break_legit_chain(%arg0: tensor<8xf32>, %arg1: f32) {
   %c0_i32 = arith.constant {ssbuffer.block_id = 31 : i32, ssbuffer.core_type = "VECTOR"} 0 : i32
 
-  // Source %src at block 28.
-  %src = arith.addf %arg1, %arg1 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  // Source %src at block 28 — tensor so the pass treats it as a candidate.
+  %src = arith.addf %arg0, %arg0 {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
 
   // Two consumers with a shared constant operand — they must still merge.
   // CHECK: arith.mulf {{.*}}ssbuffer.block_id = 28
-  %a = arith.mulf %src, %arg1 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %a = arith.mulf %src, %arg0 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
   // CHECK: arith.addf {{.*}}ssbuffer.block_id = 28
-  %b = arith.addf %src, %arg1 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %b = arith.addf %src, %arg0 {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
   // CHECK: arith.subf {{.*}}ssbuffer.block_id = 28
-  %k = arith.subf %a, %b {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : f32
+  %k = arith.subf %a, %b {ssbuffer.block_id = 29 : i32, ssbuffer.core_type = "VECTOR"} : tensor<8xf32>
 
   return
 }


### PR DESCRIPTION
This pull request is to add a pass which combined all ops from same source with different axis to avoid Tile-And-Bind Pass failed in NPUIR phase.