### PR TITLE
[TritonToLinalg](fix) fix zero-stride load boundary

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
@@ -76,6 +76,56 @@ using namespace triton;
 const std::string MayImplicitTransposeWithLastAxisTAG =
     "MayImplicitTransposeWithLastAxis";
 
+namespace {
+
+Value getRemappedOrOriginal(Value value, ConversionPatternRewriter &rewriter) {
+  if (Value remapped = rewriter.getRemappedValue(value))
+    return remapped;
+  return value;
+}
+
+bool hasStaticZeroStride(triton::MakeTensorPtrOp makeTensorPtrOp) {
+  return llvm::any_of(makeTensorPtrOp.getStrides(), [](Value stride) {
+    auto constantStride = getConstantIntValue(stride);
+    return constantStride.has_value() && constantStride.value() == 0;
+  });
+}
+
+SmallVector<OpFoldResult> getBoundarySizesFromMakeTensorPtr(
+    triton::MakeTensorPtrOp makeTensorPtrOp,
+    llvm::ArrayRef<int32_t> boundaryCheck, llvm::ArrayRef<int64_t> tileShape,
+    const Location &loc, ConversionPatternRewriter &rewriter) {
+  assert(makeTensorPtrOp.getShape().size() == tileShape.size());
+  assert(makeTensorPtrOp.getOffsets().size() == tileShape.size());
+
+  SmallVector<OpFoldResult> boundarySizes =
+      getAsIndexOpFoldResult(rewriter.getContext(), tileShape);
+  const OpFoldResult zero = rewriter.getIndexAttr(0);
+
+  for (size_t i = 0; i < tileShape.size(); ++i) {
+    if (llvm::find(boundaryCheck, i) == boundaryCheck.end())
+      continue;
+
+    OpFoldResult shape = getOpFoldResultOfLayoutInfo(
+        getRemappedOrOriginal(makeTensorPtrOp.getShape()[i], rewriter),
+        rewriter);
+    OpFoldResult offset = getOpFoldResultOfLayoutInfo(
+        getRemappedOrOriginal(makeTensorPtrOp.getOffsets()[i], rewriter),
+        rewriter);
+    OpFoldResult nonNegativeOffset =
+        maxOpFoldResult(offset, zero, loc, rewriter);
+    OpFoldResult remaining = maxOpFoldResult(
+        subOpFoldResult(shape, nonNegativeOffset, loc, rewriter), zero, loc,
+        rewriter);
+    boundarySizes[i] =
+        minOpFoldResult(boundarySizes[i], remaining, loc, rewriter);
+  }
+
+  return boundarySizes;
+}
+
+} // namespace
+
 LogicalResult
 AddPtrConverter::matchAndRewrite(triton::AddPtrOp op, OpAdaptor adaptor,
                                  ConversionPatternRewriter &rewriter) const {
@@ -325,13 +375,19 @@ LogicalResult LoadConverter::replaceMaskedLoadWithTensorOther(
 LogicalResult
 LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
                                ConversionPatternRewriter &rewriter) const {
+  auto makeTensorPtrOp = op.getPtr().getDefiningOp<triton::MakeTensorPtrOp>();
+  const bool hasZeroStrideMTP =
+      makeTensorPtrOp && hasStaticZeroStride(makeTensorPtrOp);
 
   // Check if tt.load is modified by AddPtrConverter to a specified state.
-  if (checkModifiedByAddPtrConverter(op).succeeded()) {
+  if (!hasZeroStrideMTP && checkModifiedByAddPtrConverter(op).succeeded()) {
     return continueModifyFromAddPtrConverter(op, adaptor, rewriter);
   }
 
-  auto ptr = adaptor.getPtr();
+  Value ptr = hasZeroStrideMTP ? rewriter.getRemappedValue(op.getPtr())
+                               : adaptor.getPtr();
+  if (!ptr)
+    return rewriter.notifyMatchFailure(op, "missing remapped tensor pointer");
   auto mask = op.getMask();
   auto other = op.getOther();
   auto loc = op.getLoc();
@@ -367,7 +423,7 @@ LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
   }
 
   int64_t lastStride = -1;
-  if (isa<BlockArgument>(ptr)) {
+  if (!hasZeroStrideMTP && isa<BlockArgument>(ptr)) {
     auto u = ptr;
     while (auto blkArg = dyn_cast<BlockArgument>(u)) {
       if (auto forOp = dyn_cast<scf::ForOp>(blkArg.getOwner()->getParentOp())) {
@@ -392,14 +448,15 @@ LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
     return rewriter.notifyMatchFailure(
         op, "LoadOp expects a memref, not a memref of pointers");
   }
-  if (!op->hasAttr(ConverterUtils::GeneratedByMakeTensorPtrTAG)) {
+  if (!hasZeroStrideMTP &&
+      !op->hasAttr(ConverterUtils::GeneratedByMakeTensorPtrTAG)) {
     auto memrefOp = dyn_cast<memref::ReinterpretCastOp>(ptr.getDefiningOp());
     auto ret = mlir::ConverterUtils::getLastStrideOfReinterpretCastOp(memrefOp);
     if (ret.has_value())
       lastStride = *ret;
   }
   bool mayImplicitTransposeWithLastAxis =
-      (existDotFlag) &&
+      (!hasZeroStrideMTP) && (existDotFlag) &&
       (!op->hasAttr(ConverterUtils::GeneratedByMakeTensorPtrTAG)) &&
       (lastStride != 1 &&
        mlir::ConverterUtils::isaPermutedMemRefType(memRefType));
@@ -464,9 +521,12 @@ LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
   // boundary check
   auto boundaryCheck = op.getBoundaryCheck();
   if (!boundaryCheck.empty()) {
-    auto makeTensorPtrOp = op.getPtr().getDefiningOp<triton::MakeTensorPtrOp>();
-    auto boundarySizes = mlir::ConverterUtils::getBoundarySizes(
-        boundaryCheck, /*remapped*/ ptr, loc, rewriter);
+    auto boundarySizes =
+        hasZeroStrideMTP
+            ? getBoundarySizesFromMakeTensorPtr(makeTensorPtrOp, boundaryCheck,
+                                                memRefShape, loc, rewriter)
+            : mlir::ConverterUtils::getBoundarySizes(
+                  boundaryCheck, /*remapped*/ ptr, loc, rewriter);
     // handle the padding
     auto padding = op.getPadding();
     SmallVector<OpFoldResult> srcOffsets(boundarySizes.size(),

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/zero_stride_block_ptr_load.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/zero_stride_block_ptr_load.mlir
@@ -1,0 +1,128 @@
+// RUN: triton-opt "--triton-to-linalg=global-kernel=false named-ops=True" --split-input-file %s | FileCheck %s
+
+// A direct MTP load with zero strides must derive its boundary from the MTP
+// logical shape/offset. The converted physical offset is always zero and
+// cannot be divided by a zero physical stride to recover that information.
+// CHECK-LABEL: func.func @zero_stride_dynamic
+// CHECK: memref.reinterpret_cast {{.*}}strides: [0, 0]
+// CHECK: arith.subi
+// CHECK: arith.maxsi
+// CHECK: arith.minsi
+// CHECK: memref.copy
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @zero_stride_dynamic(
+      %src: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+      %shape_m: i32, %shape_n: i32, %offset_m: i32, %offset_n: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %shape_m_i64 = arith.extsi %shape_m : i32 to i64
+    %shape_n_i64 = arith.extsi %shape_n : i32 to i64
+    %src_block = tt.make_tensor_ptr %src, [%shape_m_i64, %shape_n_i64],
+        [%c0_i64, %c0_i64], [%offset_m, %offset_n]
+        {order = array<i32: 1, 0>} : <tensor<4x4xf32>>
+    %value = tt.load %src_block {boundaryCheck = array<i32: 0, 1>, padding = 1 : i32}
+        : !tt.ptr<tensor<4x4xf32>>
+    %dst_block = tt.make_tensor_ptr %dst, [%c4_i64, %c4_i64],
+        [%c4_i64, %c1_i64], [%c0_i32, %c0_i32]
+        {order = array<i32: 1, 0>} : <tensor<4x4xf32>>
+    tt.store %dst_block, %value : !tt.ptr<tensor<4x4xf32>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @mixed_zero_stride_dynamic
+// CHECK: memref.reinterpret_cast {{.*}}strides: [0, 1]
+// CHECK: arith.subi
+// CHECK: arith.maxsi
+// CHECK: arith.minsi
+// CHECK: memref.copy
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @mixed_zero_stride_dynamic(
+      %src: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+      %shape_m: i32, %shape_n: i32, %offset_m: i32, %offset_n: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %shape_m_i64 = arith.extsi %shape_m : i32 to i64
+    %shape_n_i64 = arith.extsi %shape_n : i32 to i64
+    %src_block = tt.make_tensor_ptr %src, [%shape_m_i64, %shape_n_i64],
+        [%c0_i64, %c1_i64], [%offset_m, %offset_n]
+        {order = array<i32: 1, 0>} : <tensor<4x4xf32>>
+    %value = tt.load %src_block {boundaryCheck = array<i32: 0, 1>, padding = 1 : i32}
+        : !tt.ptr<tensor<4x4xf32>>
+    %dst_block = tt.make_tensor_ptr %dst, [%c4_i64, %c4_i64],
+        [%c4_i64, %c1_i64], [%c0_i32, %c0_i32]
+        {order = array<i32: 1, 0>} : <tensor<4x4xf32>>
+    tt.store %dst_block, %value : !tt.ptr<tensor<4x4xf32>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @zero_stride_negative_offset
+// CHECK: memref.reinterpret_cast {{.*}}strides: [0, 0]
+// CHECK: memref.subview {{.*}}[2, 0]
+// CHECK: memref.copy
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @zero_stride_negative_offset(
+      %src: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+    %cneg2_i32 = arith.constant -2 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %c5_i64 = arith.constant 5 : i64
+    %c6_i64 = arith.constant 6 : i64
+    %src_block = tt.make_tensor_ptr %src, [%c6_i64, %c5_i64],
+        [%c0_i64, %c0_i64], [%cneg2_i32, %c0_i32]
+        {order = array<i32: 1, 0>} : <tensor<4x4xf32>>
+    %value = tt.load %src_block {boundaryCheck = array<i32: 0, 1>, padding = 1 : i32}
+        : !tt.ptr<tensor<4x4xf32>>
+    %dst_block = tt.make_tensor_ptr %dst, [%c4_i64, %c4_i64],
+        [%c4_i64, %c1_i64], [%c0_i32, %c0_i32]
+        {order = array<i32: 1, 0>} : <tensor<4x4xf32>>
+    tt.store %dst_block, %value : !tt.ptr<tensor<4x4xf32>>
+    tt.return
+  }
+}
+
+// -----
+
+// A direct MTP with statically nonzero strides must keep the legacy physical
+// offset reconstruction path.
+// CHECK-LABEL: func.func @nonzero_stride_dynamic
+// CHECK: arith.divsi
+// CHECK: arith.remsi
+// CHECK: memref.copy
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @nonzero_stride_dynamic(
+      %src: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+      %shape_m: i32, %shape_n: i32, %offset_m: i32, %offset_n: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %c8_i64 = arith.constant 8 : i64
+    %shape_m_i64 = arith.extsi %shape_m : i32 to i64
+    %shape_n_i64 = arith.extsi %shape_n : i32 to i64
+    %src_block = tt.make_tensor_ptr %src, [%shape_m_i64, %shape_n_i64],
+        [%c8_i64, %c1_i64], [%offset_m, %offset_n]
+        {order = array<i32: 1, 0>} : <tensor<4x4xf32>>
+    %value = tt.load %src_block {boundaryCheck = array<i32: 0, 1>, padding = 1 : i32}
+        : !tt.ptr<tensor<4x4xf32>>
+    %dst_block = tt.make_tensor_ptr %dst, [%c4_i64, %c4_i64],
+        [%c4_i64, %c1_i64], [%c0_i32, %c0_i32]
+        {order = array<i32: 1, 0>} : <tensor<4x4xf32>>
+    tt.store %dst_block, %value : !tt.ptr<tensor<4x4xf32>>
+    tt.return
+  }
+}


### PR DESCRIPTION
## Summary

- Compute a boundary-checked tile size from the original `tt.make_tensor_ptr`
  logical shape and offsets when any static stride is zero.
- Preserve the existing direct structured lowering (`strided<[0, ...]>` and
  `memref.copy`) for those loads; this PR does not add a fallback or change
  later TTAdapter/BishengIR stages.
- Add MLIR coverage for all-zero stride, mixed zero/non-zero stride, negative
  offsets, and the unchanged regular non-zero-stride path.

## Root cause

The generic boundary-size helper reconstructs logical coordinates from the
remapped physical pointer. A zero stride removes that physical-coordinate
information, so the reconstruction can reach a `0 / 0` expression and leave a
required `OpFoldResult` absent. Using the original tensor-pointer shape and
offsets retains the logical coordinates needed for the boundary calculation.

## Scope

This is the boundary-only alternative to #1508. It fixes the
`triton-to-linalg` conversion crash only; it intentionally leaves downstream
acceptance of the resulting zero-stride memref to the existing pipeline. Do
not merge both PRs.

## Validation

- `pre-commit run --files third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp third_party/ascend/unittest/Conversion/General/TritonToLinalg/zero_stride_block_ptr_load.mlir`
- `cmake --build <isolated-build> --target TritonToLinalg -- -j 16`
- Built a `triton-opt` driver from this source with the existing TA command-line
  pass registration enabled solely for this check, then ran the new regression:

  ```bash
  triton-opt -allow-unregistered-dialect \
    "--triton-to-linalg=global-kernel=false named-ops=True" \
    --split-input-file \
    third_party/ascend/unittest/Conversion/General/TritonToLinalg/zero_stride_block_ptr_load.mlir \
    | FileCheck \
    third_party/ascend/unittest/Conversion/General/TritonToLinalg/zero_stride_block_ptr_load.mlir
  ```
