### PR TITLE
[ssbuffer](fix) revert Replace LLVM dialect with MLIR (#1038)

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.h
@@ -23,22 +23,18 @@
 #ifndef TRITON_ADAPTER_UPDATE_CONDITION_INFO_H
 #define TRITON_ADAPTER_UPDATE_CONDITION_INFO_H
 
-#include <optional>
-
-#include "llvm/ADT/DenseSet.h"
-#include "llvm/ADT/SmallPtrSet.h"
-#include "llvm/ADT/SmallVector.h"
-
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/TransformOps/DialectExtension.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/Pass/Pass.h"
-
 #include "third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include <optional>
 
 namespace mlir {
 namespace triton {
@@ -193,16 +189,16 @@ private:
   void updateDAGAfterIfOpReplacement(scf::IfOp oldIfOp, scf::IfOp newIfOp);
 
   // Helper function to get pointer based on core type
-  Value getSSBufferMemref(bool isAIC, int groupIdx, int ptrSetIdx,
-                          DenseMap<int, Value> &precomputedPtrs,
-                          ArrayRef<SmallVector<Value>> ssbufferPtrs);
+  Value getSSBufferPtr(bool isAIC, int groupIdx, int ptrSetIdx,
+                       DenseMap<int, Value> &precomputedPtrs,
+                       SmallVector<SmallVector<Value>> ssbufferPtrs);
 
   // Compute pointers for VECTOR core SSBuffer
   std::optional<DenseMap<int, Value>>
-  computeVectorSSBufferMemrefs(OpBuilder &builder, Location loc,
-                               Operation *scopeOp,
-                               SmallVector<int> crossCoreInputValues,
-                               SmallVector<int> crossCoreOutputValues);
+  computeVectorSSBufferPtrs(OpBuilder &builder, Location loc,
+                            Operation *scopeOp,
+                            SmallVector<int> crossCoreInputValues,
+                            SmallVector<int> crossCoreOutputValues);
 
   // Part 2: Add cross-core conditions
   Value addCrossCoreConditions(
@@ -228,13 +224,6 @@ private:
   // Record each ifOp as the variables that need to be controlled when it acts
   // as a consumer or a producer
   llvm::DenseMap<scf::IfOp, TensorIterArgIfOpVars> tensorIterArgIfOpVars;
-
-  template <typename FuncTy>
-  auto createSsbufLoads(OpBuilder &builder, Location loc, bool isAIC,
-                        int groupIdx,
-                        DenseMap<int, Value> &vectorSSBufferMemrefs,
-                        llvm::ArrayRef<SmallVector<Value>> ssbufferMemrefs,
-                        FuncTy &&pred);
 };
 
 std::unique_ptr<OperationPass<ModuleOp>> createUpdateConditionInfoPass();

--- a/third_party/ascend/include/DynamicCVPipeline/Common/SSBufferManager.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/SSBufferManager.h
@@ -23,10 +23,7 @@
 #ifndef TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_COMMON_SSBUFFER_MANAGER_H
 #define TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_COMMON_SSBUFFER_MANAGER_H
 
-#include "bishengir/Dialect/HIVM/IR/HIVM.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/Builders.h"
-#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Types.h"
 #include "mlir/IR/Value.h"
 #include "llvm/ADT/DenseMap.h"
@@ -35,8 +32,6 @@
 namespace mlir {
 namespace triton {
 
-static constexpr llvm::StringRef kMemrefExtVolatile = "memref_ext.volatile";
-
 // SSBuffer Manager for managing SSBuffer address allocation and type tracking
 // Purpose: Globally manage SSBuffer addresses across the entire pass pipeline
 // This class maintains a single mapping table: Value -> address (int64_t)
@@ -44,6 +39,7 @@ static constexpr llvm::StringRef kMemrefExtVolatile = "memref_ext.volatile";
 class SSBufferManager {
 public:
   // SSBuffer address space and constants
+  static constexpr int SSBUF_ADDR_SPACE = 11;
   static constexpr int ADDR_INT_TYPE = 64;
   static constexpr int SSBUF_BASE_ADDR = 2048; // Base address for SSBuffer
   static constexpr int SSBUF_ADDR_OFFSET =
@@ -86,32 +82,6 @@ private:
   // This avoids O(n) traversal in findValueByAddr
   llvm::DenseMap<int64_t, Value> addrToValueMap;
 };
-
-static constexpr int ADDR_INT_TYPE = 64;
-static constexpr int CONST_INT_TYPE = 32;
-
-inline MemRefType getSsbufMemrefType(Builder &builder) {
-  auto i32Type = builder.getIntegerType(CONST_INT_TYPE);
-  auto addressSpaceAttr =
-      builder.getAttr<hivm::AddressSpaceAttr>(hivm::AddressSpace::SSBUF);
-  return MemRefType::get({}, i32Type, nullptr, addressSpaceAttr);
-}
-
-inline std::pair<arith::ConstantOp, hivm::PointerCastOp>
-getSsbufConstAndPointerCast(OpBuilder &builder, Location loc, uint64_t addr) {
-  auto i64Type = builder.getIntegerType(ADDR_INT_TYPE);
-  auto addrAttr = builder.getIntegerAttr(i64Type, addr);
-  auto addrConst = builder.create<arith::ConstantOp>(loc, i64Type, addrAttr);
-
-  return {addrConst,
-          builder.create<hivm::PointerCastOp>(loc, getSsbufMemrefType(builder),
-                                              addrConst.getResult())};
-}
-
-inline hivm::PointerCastOp createPointerCastOp(OpBuilder &builder, Location loc,
-                                               uint64_t addr) {
-  return getSsbufConstAndPointerCast(builder, loc, addr).second;
-}
 
 } // namespace triton
 } // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
@@ -19,40 +19,32 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
-#include <functional>
-#include <string>
-#include <type_traits>
-
+#include "third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.h"
+#include "ascend/include/DynamicCVPipeline/AddControlFlowCondition.h"
+#include "ascend/include/DynamicCVPipeline/Common/BufferCountManager.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "bishengir/Dialect/HIVM/IR/HIVMImpl.h"
+#include "bishengir/Dialect/HIVM/IR/HIVMInterfaces.h"
+#include "bishengir/Dialect/HIVM/Transforms/Passes.h"
+#include "bishengir/Dialect/HIVM/Utils/Utils.h"
+#include "bishengir/Dialect/Scope/IR/Scope.h"
 #include "llvm/ADT/APFloat.h"
-#include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/IR/Builders.h"
-#include "mlir/IR/Location.h"
-#include "mlir/IR/ValueRange.h"
-
-#include "ascend/include/DynamicCVPipeline/AddControlFlowCondition.h"
-#include "ascend/include/DynamicCVPipeline/Common/SSBufferManager.h"
-#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
-
-#include "bishengir/Dialect/Annotation/IR/Annotation.h"
-#include "bishengir/Dialect/HIVM/IR/HIVM.h"
-#include "bishengir/Dialect/HIVM/IR/HIVMInterfaces.h"
-#include "bishengir/Dialect/Scope/IR/Scope.h"
-#include "third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.h"
+#include <string>
 
 static constexpr const char *DEBUG_TYPE = "UpdateConditionInfoPass";
+static constexpr const char *SSBUFFER_Main_LOOP = "ssbuffer.main_loop";
+static constexpr const char *SSBUFFER_IF = "ssbuffer.if";
+static constexpr int SSBUF_ADDR_SPACE = 11;
+static constexpr int ADDR_INT_TYPE = 64;
+static constexpr int CONST_INT_TYPE = 32;
 static constexpr int VECTOR_SSBUF_OFFSET = 1024;
 static constexpr int VALUE_SSBUF_OFFSET = 4;
 static constexpr int UPDATE_CONDITION_INFO_SUCCESS = 0;
 static constexpr int UPDATE_CONDITION_INFO_FAILED = -1;
-static constexpr size_t kVectorCount = 2;
 
 #define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
 #define LDBG(...)                                                              \
@@ -63,7 +55,6 @@ static constexpr size_t kVectorCount = 2;
 using namespace mlir;
 using namespace triton;
 using namespace hivm;
-using namespace CVPipeline;
 
 static void logConditionGroupIndices(llvm::StringRef label,
                                      llvm::ArrayRef<int> groupIndices) {
@@ -95,47 +86,59 @@ UpdateConditionInfoPass::allocSSBuffer(ModuleOp module) {
   OpBuilder builder(module.getContext());
   auto i64Type = builder.getIntegerType(ADDR_INT_TYPE);
   auto i32Type = builder.getIntegerType(CONST_INT_TYPE);
-  auto memrefType = getSsbufMemrefType(builder);
+  auto ptrType =
+      mlir::LLVM::LLVMPointerType::get(builder.getContext(), SSBUF_ADDR_SPACE);
 
   // alloc 2 group of ssbuffer pointers:
   // Core Vector 0: allocate ssbuffer address: 0, 4, 8, ...
   // Core Vector 1: allocate ssbuffer address: 1024, 1028, 1032, ...
-  SmallVector<SmallVector<Value>> ssbufferMemrefs;
-  SmallVector<Value> ssbufferVec0Memrefs;
-  SmallVector<Value> ssbufferVec1Memrefs;
+  SmallVector<SmallVector<Value>> ssbufferPtrs;
+  SmallVector<Value> ssbufferVec0Ptrs;
+  SmallVector<Value> ssbufferVec1Ptrs;
   int numBuffers = info->crossCoreDependentMap.size();
   if (numBuffers == 0) {
     LDBG("crossCoreDependentMap is empty!" << "\n");
-    return ssbufferMemrefs;
+    return ssbufferPtrs;
   }
 
   module->walk([&](Operation *op) {
     if (auto scopeOp = dyn_cast<scope::ScopeOp>(op)) {
       builder.setInsertionPoint(scopeOp);
-      auto loc = scopeOp.getLoc();
-      auto zeroConst = builder.create<arith::ConstantOp>(
+      auto zeroConst = builder.create<mlir::LLVM::ConstantOp>(
           scopeOp->getLoc(), i32Type, builder.getIntegerAttr(i32Type, 0));
 
       for (int i = 0; i < numBuffers; i++) {
-        auto memref0 =
-            createPointerCastOp(builder, loc, i * VALUE_SSBUF_OFFSET);
-        auto memref1 = createPointerCastOp(
-            builder, loc, VECTOR_SSBUF_OFFSET + i * VALUE_SSBUF_OFFSET);
+        auto addr0Attr =
+            builder.getIntegerAttr(i64Type, i * VALUE_SSBUF_OFFSET);
+        auto addr1Attr = builder.getIntegerAttr(
+            i64Type, VECTOR_SSBUF_OFFSET + i * VALUE_SSBUF_OFFSET);
 
-        builder.create<memref::StoreOp>(scopeOp->getLoc(), zeroConst, memref0);
-        builder.create<memref::StoreOp>(scopeOp->getLoc(), zeroConst, memref1);
+        auto addr0Const = builder.create<mlir::LLVM::ConstantOp>(
+            scopeOp->getLoc(), i64Type, addr0Attr);
+        auto addr1Const = builder.create<mlir::LLVM::ConstantOp>(
+            scopeOp->getLoc(), i64Type, addr1Attr);
 
-        ssbufferVec0Memrefs.push_back(memref0.getResult());
-        ssbufferVec1Memrefs.push_back(memref1.getResult());
+        auto ptr0 = builder.create<mlir::LLVM::IntToPtrOp>(
+            scopeOp->getLoc(), ptrType, addr0Const.getResult());
+        auto ptr1 = builder.create<mlir::LLVM::IntToPtrOp>(
+            scopeOp->getLoc(), ptrType, addr1Const.getResult());
+
+        builder.create<LLVM::StoreOp>(scopeOp->getLoc(), zeroConst, ptr0, 0,
+                                      /*volatile=*/true);
+        builder.create<LLVM::StoreOp>(scopeOp->getLoc(), zeroConst, ptr1, 0,
+                                      /*volatile=*/true);
+
+        ssbufferVec0Ptrs.push_back(ptr0.getResult());
+        ssbufferVec1Ptrs.push_back(ptr1.getResult());
       }
       return mlir::WalkResult::interrupt();
     }
     return mlir::WalkResult::advance();
   });
 
-  ssbufferMemrefs.push_back(ssbufferVec0Memrefs);
-  ssbufferMemrefs.push_back(ssbufferVec1Memrefs);
-  return ssbufferMemrefs;
+  ssbufferPtrs.push_back(ssbufferVec0Ptrs);
+  ssbufferPtrs.push_back(ssbufferVec1Ptrs);
+  return ssbufferPtrs;
 }
 
 // Collect dependency buffer
@@ -436,10 +439,10 @@ int UpdateConditionInfoPass::buildOutputGroups(
 
 // Select corresponding SSBuffer ptr based on ifblock running on vector/cube
 // core
-Value UpdateConditionInfoPass::getSSBufferMemref(
+Value UpdateConditionInfoPass::getSSBufferPtr(
     bool isAIC, int groupIdx, int ptrSetIdx,
     DenseMap<int, Value> &VectorSSBufferPtrs,
-    ArrayRef<SmallVector<Value>> ssbufferPtrs) {
+    SmallVector<SmallVector<Value>> ssbufferPtrs) {
   if (isAIC) {
     return ssbufferPtrs[ptrSetIdx][groupIdx];
   } else {
@@ -449,7 +452,7 @@ Value UpdateConditionInfoPass::getSSBufferMemref(
 
 // Compute pointers for VECTOR core SSBuffer
 std::optional<DenseMap<int, Value>>
-UpdateConditionInfoPass::computeVectorSSBufferMemrefs(
+UpdateConditionInfoPass::computeVectorSSBufferPtrs(
     OpBuilder &builder, Location loc, Operation *scopeOp,
     SmallVector<int> crossCoreInputValues,
     SmallVector<int> crossCoreOutputValues) {
@@ -472,7 +475,7 @@ UpdateConditionInfoPass::computeVectorSSBufferMemrefs(
     }
   }
 
-  DenseMap<int, Value> vectorSSBufferMemrefs;
+  DenseMap<int, Value> vectorSSBufferPtrs;
 
   builder.setInsertionPointToStart(&scopeOp->getRegion(0).front());
   int vec1Offset = 1024;
@@ -488,33 +491,13 @@ UpdateConditionInfoPass::computeVectorSSBufferMemrefs(
         loc, groupIdx * VALUE_SSBUF_OFFSET, ADDR_INT_TYPE);
     auto ssbAddr =
         builder.create<arith::AddIOp>(loc, ssbBaseAddr, ssbAddrOffset);
-    Value memref = builder.create<PointerCastOp>(
-        loc, getSsbufMemrefType(builder), ssbAddr.getResult());
-    vectorSSBufferMemrefs[groupIdx] = memref;
+    Value ptr = builder.create<LLVM::IntToPtrOp>(
+        loc, LLVM::LLVMPointerType::get(builder.getContext(), SSBUF_ADDR_SPACE),
+        ssbAddr.getResult());
+    vectorSSBufferPtrs[groupIdx] = ptr;
   }
 
-  return vectorSSBufferMemrefs;
-}
-
-template <typename FuncTy>
-auto UpdateConditionInfoPass::createSsbufLoads(
-    OpBuilder &builder, Location loc, bool isAIC, int groupIdx,
-    DenseMap<int, Value> &vectorSSBufferMemrefs,
-    llvm::ArrayRef<SmallVector<Value>> ssbufferMemrefs, FuncTy &&pred) {
-  using ResTy = std::invoke_result_t<FuncTy, memref::LoadOp, int>;
-  SmallVector<ResTy, kVectorCount> res;
-  size_t resNum = isAIC ? kVectorCount : 1;
-  for (int ptrSetIdx : llvm::seq(resNum)) {
-    auto loadOp = builder.create<memref::LoadOp>(
-        loc,
-        getSSBufferMemref(isAIC, groupIdx, ptrSetIdx, vectorSSBufferMemrefs,
-                          ssbufferMemrefs),
-        ValueRange{});
-    auto markOp = builder.create<annotation::MarkOp>(loc, loadOp);
-    markOp->setAttr(kMemrefExtVolatile, builder.getUnitAttr());
-    res.push_back(std::invoke(pred, loadOp, ptrSetIdx));
-  }
-  return res;
+  return vectorSSBufferPtrs;
 }
 
 // Part 2: Add cross-core conditions
@@ -536,15 +519,31 @@ Value UpdateConditionInfoPass::addCrossCoreConditions(
   };
 
   for (int inputGroupIdx : crossCoreInputValues) {
-    auto conds = createSsbufLoads(
-        builder, loc, isAIC, inputGroupIdx, VectorSSBufferPtrs, ssbufferPtrs,
-        [&](memref::LoadOp loadOp, auto) {
-          return builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sgt,
-                                               loadOp, zeroConst);
-        });
-    Value cond = conds[0];
+    Value cond = nullptr;
     if (isAIC) {
-      cond = builder.create<arith::AndIOp>(loc, conds[0], conds[1]);
+      Value vec0Value = builder.create<LLVM::LoadOp>(
+          loc, builder.getI32Type(),
+          getSSBufferPtr(isAIC, inputGroupIdx, 0, VectorSSBufferPtrs,
+                         ssbufferPtrs),
+          0, /*volatile=*/true);
+      Value vec1Value = builder.create<LLVM::LoadOp>(
+          loc, builder.getI32Type(),
+          getSSBufferPtr(isAIC, inputGroupIdx, 1, VectorSSBufferPtrs,
+                         ssbufferPtrs),
+          0, /*volatile=*/true);
+      Value vec0Cond = builder.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::sgt, vec0Value, zeroConst);
+      Value vec1Cond = builder.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::sgt, vec1Value, zeroConst);
+      cond = builder.create<arith::AndIOp>(loc, vec0Cond, vec1Cond);
+    } else {
+      Value value = builder.create<LLVM::LoadOp>(
+          loc, builder.getI32Type(),
+          getSSBufferPtr(isAIC, inputGroupIdx, 0, VectorSSBufferPtrs,
+                         ssbufferPtrs),
+          0, /*volatile=*/true);
+      cond = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sgt,
+                                           value, zeroConst);
     }
     combineCondition(cond);
   }
@@ -562,15 +561,31 @@ Value UpdateConditionInfoPass::addCrossCoreConditions(
     }
     Value bufferNum =
         builder.create<arith::ConstantIntOp>(loc, outputCount, CONST_INT_TYPE);
-    auto conds = createSsbufLoads(
-        builder, loc, isAIC, outputGroupIdx, VectorSSBufferPtrs, ssbufferPtrs,
-        [&](Value cond, auto) {
-          return builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt,
-                                               cond, bufferNum);
-        });
-    Value cond = conds[0];
+    Value cond = nullptr;
     if (isAIC) {
-      cond = builder.create<arith::AndIOp>(loc, conds[0], conds[1]);
+      Value vec0Value = builder.create<LLVM::LoadOp>(
+          loc, builder.getI32Type(),
+          getSSBufferPtr(isAIC, outputGroupIdx, 0, VectorSSBufferPtrs,
+                         ssbufferPtrs),
+          0, /*volatile=*/true);
+      Value vec1Value = builder.create<LLVM::LoadOp>(
+          loc, builder.getI32Type(),
+          getSSBufferPtr(isAIC, outputGroupIdx, 1, VectorSSBufferPtrs,
+                         ssbufferPtrs),
+          0, /*volatile=*/true);
+      Value vec0Cond = builder.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::slt, vec0Value, bufferNum);
+      Value vec1Cond = builder.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::slt, vec1Value, bufferNum);
+      cond = builder.create<arith::AndIOp>(loc, vec0Cond, vec1Cond);
+    } else {
+      Value value = builder.create<LLVM::LoadOp>(
+          loc, builder.getI32Type(),
+          getSSBufferPtr(isAIC, outputGroupIdx, 0, VectorSSBufferPtrs,
+                         ssbufferPtrs),
+          0, /*volatile=*/true);
+      cond = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt,
+                                           value, bufferNum);
     }
     combineCondition(cond);
   }
@@ -590,29 +605,85 @@ void UpdateConditionInfoPass::updateCrossCoreControlVars(
   builder.setInsertionPoint(yieldOp);
 
   for (int inputGroupIdx : crossCoreInputValues) {
-    createSsbufLoads(builder, loc, isAIC, inputGroupIdx, VectorSSBufferPtrs,
-                     ssbufferPtrs, [&](Value loadRes, int ptrSetIdx) {
-                       Value newValue = builder.create<arith::SubIOp>(
-                           loc, loadRes, oneConst);
-                       return builder.create<memref::StoreOp>(
-                           loc, newValue,
-                           getSSBufferMemref(isAIC, inputGroupIdx, ptrSetIdx,
-                                             VectorSSBufferPtrs, ssbufferPtrs),
-                           ValueRange{});
-                     });
+    if (isAIC) {
+      Value vec0Value = builder.create<LLVM::LoadOp>(
+          loc, builder.getI32Type(),
+          getSSBufferPtr(isAIC, inputGroupIdx, 0, VectorSSBufferPtrs,
+                         ssbufferPtrs),
+          0, /*volatile=*/true);
+      Value vec1Value = builder.create<LLVM::LoadOp>(
+          loc, builder.getI32Type(),
+          getSSBufferPtr(isAIC, inputGroupIdx, 1, VectorSSBufferPtrs,
+                         ssbufferPtrs),
+          0, /*volatile=*/true);
+      Value vec0NewValue =
+          builder.create<arith::SubIOp>(loc, vec0Value, oneConst);
+      Value vec1NewValue =
+          builder.create<arith::SubIOp>(loc, vec1Value, oneConst);
+      builder.create<LLVM::StoreOp>(loc, vec0NewValue,
+                                    getSSBufferPtr(isAIC, inputGroupIdx, 0,
+                                                   VectorSSBufferPtrs,
+                                                   ssbufferPtrs),
+                                    0, /*volatile=*/true);
+      builder.create<LLVM::StoreOp>(loc, vec1NewValue,
+                                    getSSBufferPtr(isAIC, inputGroupIdx, 1,
+                                                   VectorSSBufferPtrs,
+                                                   ssbufferPtrs),
+                                    0, /*volatile=*/true);
+    } else {
+      Value value = builder.create<LLVM::LoadOp>(
+          loc, builder.getI32Type(),
+          getSSBufferPtr(isAIC, inputGroupIdx, 0, VectorSSBufferPtrs,
+                         ssbufferPtrs),
+          0, /*volatile=*/true);
+      Value newValue = builder.create<arith::SubIOp>(loc, value, oneConst);
+      builder.create<LLVM::StoreOp>(loc, newValue,
+                                    getSSBufferPtr(isAIC, inputGroupIdx, 0,
+                                                   VectorSSBufferPtrs,
+                                                   ssbufferPtrs),
+                                    0, /*volatile=*/true);
+    }
   }
 
   for (int outputGroupIdx : crossCoreOutputValues) {
-    createSsbufLoads(builder, loc, isAIC, outputGroupIdx, VectorSSBufferPtrs,
-                     ssbufferPtrs, [&](Value loadRes, int ptrSetIdx) {
-                       Value newValue = builder.create<arith::AddIOp>(
-                           loc, loadRes, oneConst);
-                       return builder.create<memref::StoreOp>(
-                           loc, newValue,
-                           getSSBufferMemref(isAIC, outputGroupIdx, ptrSetIdx,
-                                             VectorSSBufferPtrs, ssbufferPtrs),
-                           ValueRange{});
-                     });
+    if (isAIC) {
+      Value vec0Value = builder.create<LLVM::LoadOp>(
+          loc, builder.getI32Type(),
+          getSSBufferPtr(isAIC, outputGroupIdx, 0, VectorSSBufferPtrs,
+                         ssbufferPtrs),
+          0, /*volatile=*/true);
+      Value vec1Value = builder.create<LLVM::LoadOp>(
+          loc, builder.getI32Type(),
+          getSSBufferPtr(isAIC, outputGroupIdx, 1, VectorSSBufferPtrs,
+                         ssbufferPtrs),
+          0, /*volatile=*/true);
+      Value vec0NewValue =
+          builder.create<arith::AddIOp>(loc, vec0Value, oneConst);
+      Value vec1NewValue =
+          builder.create<arith::AddIOp>(loc, vec1Value, oneConst);
+      builder.create<LLVM::StoreOp>(loc, vec0NewValue,
+                                    getSSBufferPtr(isAIC, outputGroupIdx, 0,
+                                                   VectorSSBufferPtrs,
+                                                   ssbufferPtrs),
+                                    0, /*volatile=*/true);
+      builder.create<LLVM::StoreOp>(loc, vec1NewValue,
+                                    getSSBufferPtr(isAIC, outputGroupIdx, 1,
+                                                   VectorSSBufferPtrs,
+                                                   ssbufferPtrs),
+                                    0, /*volatile=*/true);
+    } else {
+      Value value = builder.create<LLVM::LoadOp>(
+          loc, builder.getI32Type(),
+          getSSBufferPtr(isAIC, outputGroupIdx, 0, VectorSSBufferPtrs,
+                         ssbufferPtrs),
+          0, /*volatile=*/true);
+      Value newValue = builder.create<arith::AddIOp>(loc, value, oneConst);
+      builder.create<LLVM::StoreOp>(loc, newValue,
+                                    getSSBufferPtr(isAIC, outputGroupIdx, 0,
+                                                   VectorSSBufferPtrs,
+                                                   ssbufferPtrs),
+                                    0, /*volatile=*/true);
+    }
   }
 }
 
@@ -667,7 +738,7 @@ int UpdateConditionInfoPass::setCrossCoreCondition(
   // side
   DenseMap<int, Value> VectorSSBufferPtrs;
   if (!isAIC) {
-    auto result = computeVectorSSBufferMemrefs(
+    auto result = computeVectorSSBufferPtrs(
         builder, loc, scopeOp, crossCoreInputValues, crossCoreOutputValues);
     if (!result) {
       LDBG("computeVectorSSBufferPtrs failed!");
@@ -1472,7 +1543,7 @@ int UpdateConditionInfoPass::updateIfConds(
   // Walk the forOp in the module to update the conditions of ifOp
   SmallVector<scf::ForOp> mainLoopForOps;
   WalkResult walkResult = module.walk([&](Operation *op) -> WalkResult {
-    if (!op->hasAttr(kMainLoop)) {
+    if (!op->hasAttr(SSBUFFER_Main_LOOP)) {
       return WalkResult::advance();
     }
 
@@ -1526,7 +1597,7 @@ int UpdateConditionInfoPass::updateIfConds(
     size_t usedCounterNum = 0;
     SmallVector<scf::IfOp> ifOps;
     WalkResult ifWalkResult = forOp.walk([&](Operation *op) -> WalkResult {
-      if (!op->hasAttr(kIf)) {
+      if (!op->hasAttr(SSBUFFER_IF)) {
         return WalkResult::advance();
       }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/SSBufferManager.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/SSBufferManager.cpp
@@ -21,7 +21,7 @@
  */
 
 #include "ascend/include/DynamicCVPipeline/Common/SSBufferManager.h"
-#include "bishengir/Dialect/Annotation/IR/Annotation.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/BuiltinTypes.h"
 
 using namespace mlir;
@@ -103,14 +103,23 @@ SSBufferManager::writeToSSBuffer(Value value, OpBuilder &builder,
 
   int64_t addrValue = addrResult.value();
   Location loc = builder.getUnknownLoc();
-  auto [constOp, pointerCastOp] =
-      getSsbufConstAndPointerCast(builder, loc, addrValue);
-  createdOps.push_back(constOp);
-  createdOps.push_back(pointerCastOp);
+  auto i64Type = builder.getIntegerType(ADDR_INT_TYPE);
+  auto ptrType =
+      LLVM::LLVMPointerType::get(builder.getContext(), SSBUF_ADDR_SPACE);
+
+  // Create address constant
+  auto addrAttr = builder.getIntegerAttr(i64Type, addrValue);
+  auto addrConst = builder.create<LLVM::ConstantOp>(loc, i64Type, addrAttr);
+  createdOps.push_back(addrConst); // Record the created operation
+
+  // Convert integer address to pointer
+  auto ptr =
+      builder.create<LLVM::IntToPtrOp>(loc, ptrType, addrConst.getResult());
+  createdOps.push_back(ptr); // Record the created operation
 
   // Store the value to SSBuffer
-  auto storeOp =
-      builder.create<memref::StoreOp>(loc, value, pointerCastOp.getResult());
+  auto storeOp = builder.create<LLVM::StoreOp>(loc, value, ptr.getResult(), 0,
+                                               /*volatile=*/true);
   createdOps.push_back(storeOp); // Record the created operation
 
   // Return the address value (int64_t), not the pointer
@@ -128,20 +137,28 @@ SSBufferManager::readFromSSBuffer(int64_t addr, OpBuilder &builder,
     return std::nullopt;
   }
 
+  Value foundValue = findResult.value().first;
+  Type dataType = findResult.value().second;
+
   Location loc = builder.getUnknownLoc();
-  auto [constOp, pointerCastOp] =
-      getSsbufConstAndPointerCast(builder, loc, addr);
-  createdOps.push_back(constOp);
-  createdOps.push_back(pointerCastOp);
+  auto i64Type = builder.getIntegerType(ADDR_INT_TYPE);
+  auto ptrType =
+      LLVM::LLVMPointerType::get(builder.getContext(), SSBUF_ADDR_SPACE);
+
+  // Create address constant
+  auto addrAttr = builder.getIntegerAttr(i64Type, addr);
+  auto addrConst = builder.create<LLVM::ConstantOp>(loc, i64Type, addrAttr);
+  createdOps.push_back(addrConst); // Record the created operation
+
+  // Convert integer address to pointer
+  auto ptr =
+      builder.create<LLVM::IntToPtrOp>(loc, ptrType, addrConst.getResult());
+  createdOps.push_back(ptr); // Record the created operation
 
   // Load the value from SSBuffer address with the retrieved data type
-  auto loadOp = builder.create<memref::LoadOp>(loc, pointerCastOp.getResult(),
-                                               ValueRange{});
+  auto loadOp = builder.create<LLVM::LoadOp>(loc, dataType, ptr.getResult(), 0,
+                                             /*volatile=*/true);
   createdOps.push_back(loadOp); // Record the created operation
-
-  auto markOp = builder.create<annotation::MarkOp>(loc, loadOp.getResult());
-  markOp->setAttr(kMemrefExtVolatile, builder.getUnitAttr());
-  createdOps.push_back(markOp);
 
   return loadOp.getResult();
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -35,10 +35,12 @@
 #include "Utils/Utils.h"
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "bishengir/Dialect/HIVM/IR/HIVMImpl.h"
 #include "bishengir/Dialect/HIVM/IR/HIVMInterfaces.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/Block.h"
@@ -358,7 +360,6 @@ void InterCoreTransferAndSyncPass::Nd2NzNormalize(OpBuilder &builder,
     newValue = alignShapeByInsertSlice(builder, dep, loc, origValue,
                                        expectedShape, originBlockId);
   }
-
   // Step 3: insert nd2nz
   auto srcTensorType = cast<RankedTensorType>(newValue.getType());
   int64_t M = srcTensorType.getDimSize(0);
@@ -522,7 +523,7 @@ InterCoreTransferAndSyncPass::getConsumerWaitPoint(int transferIndex) {
       return;
     }
     if (!isa<hivm::ConvertLayoutOp>(op) &&
-        !isa<memref::MemorySpaceCastOp>(op) && !isa<memref::LoadOp>(op)) {
+        !isa<memref::MemorySpaceCastOp>(op) && !isa<LLVM::LoadOp>(op)) {
       return;
     }
     auto transferIdAttr =
@@ -560,7 +561,7 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(
     Operation *storeOp = nullptr;
     for (Operation *op : writeOps) {
       attachTransferTags(op, vecBlockId, "VECTOR", transferIndex);
-      if (isa<memref::StoreOp>(op)) {
+      if (isa<LLVM::StoreOp>(op)) {
         storeOp = op;
       }
     }
@@ -581,7 +582,7 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(
     Operation *loadOp = nullptr;
     for (Operation *op : readOps) {
       attachTransferTags(op, cubeBlockId, "CUBE", transferIndex);
-      if (isa<memref::LoadOp>(op)) {
+      if (isa<LLVM::LoadOp>(op)) {
         loadOp = op;
       }
     }
@@ -788,7 +789,7 @@ InterCoreTransferAndSyncPass::getTransferPipeConfig(Operation *transferOp,
     config.dstCoreAttr = cubeCoreAttr;
     config.srcCoreType = "VECTOR";
     config.dstCoreType = "CUBE";
-  } else if (isa<memref::StoreOp>(transferOp)) {
+  } else if (isa<LLVM::StoreOp>(transferOp)) {
     config.forReadTPipe = pipeVAttr;
     config.forReadPipe = pipeFixAttr;
     config.forWriteTPipe = pipeFixAttr;
@@ -1715,7 +1716,8 @@ void InterCoreTransferAndSyncPass::getDependentDialects(
   registry.insert<func::FuncDialect, arith::ArithDialect, linalg::LinalgDialect,
                   scf::SCFDialect, tensor::TensorDialect,
                   bufferization::BufferizationDialect, memref::MemRefDialect,
-                  hivm::HIVMDialect, annotation::AnnotationDialect>();
+                  hivm::HIVMDialect, LLVM::LLVMDialect,
+                  annotation::AnnotationDialect>();
 }
 
 // Pass Entry Point


### PR DESCRIPTION
This reverts commit daceb99ff50003dc4dfe48d7b0cf1f154a3b6b68.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
