### PR TITLE
[TritonToLinalg](fix) Restore addptr foading

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -202,7 +202,7 @@ def TT_AddPtrOp : TT_Op<"addptr",
     let results = (outs TT_PtrLike:$result);
 
     let assemblyFormat = "$ptr `,` $offset attr-dict `:` type($result) `,` type($offset)";
-    // let hasFolder = 1;
+    let hasFolder = 1;
 }
 
 def TT_AdvanceOp : TT_Op<"advance",

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -1033,13 +1033,13 @@ void MakeTensorPtrOp::build(OpBuilder &builder, OperationState &state,
 }
 
 //-- AddPtrOp --
-// OpFoldResult AddPtrOp::fold(FoldAdaptor adaptor) {
-//   // addptr(ptr, 0) -> ptr
-//   if (matchPattern(adaptor.getOffset(), m_Zero())) {
-//     return getPtr();
-//   }
-//   return {};
-// }
+OpFoldResult AddPtrOp::fold(FoldAdaptor adaptor) {
+  // addptr(ptr, 0) -> ptr
+  if (matchPattern(adaptor.getOffset(), m_Zero())) {
+    return getPtr();
+  }
+  return {};
+}
 
 //-- AdvanceOp --
 OpFoldResult AdvanceOp::fold(FoldAdaptor adaptor) {

--- a/third_party/ascend/include/TritonToLinalg/BlockPtrAnalysis.h
+++ b/third_party/ascend/include/TritonToLinalg/BlockPtrAnalysis.h
@@ -288,6 +288,10 @@ public:
                             ConversionPatternRewriter &rewriter,
                             llvm::SmallDenseMap<Value, BlockData> &known);
 
+  static FailureOr<Value>
+  materializePointer(Value ptr, ConversionPatternRewriter &rewriter,
+                     llvm::SmallDenseMap<Value, BlockData> &known);
+
   static void
   rewriteMakeTensorPtrOp(triton::MakeTensorPtrOp op, Value base,
                          ConversionPatternRewriter &rewriter,

--- a/third_party/ascend/include/TritonToLinalg/LoadStoreConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/LoadStoreConverter.h
@@ -34,8 +34,9 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 
 #include "mlir/Dialect/Arith/Utils/Utils.h"
-
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+
+#include "ascend/include/TritonToLinalg/BlockPtrAnalysis.h"
 
 namespace LoadStoreConverter {
 
@@ -48,6 +49,35 @@ public:
   LogicalResult
   matchAndRewrite(triton::AddPtrOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override;
+};
+
+/// Materialize pointer tensor expressions directly instead of routing them
+/// through a synthetic AddPtrOp with a zero offset. A higher benefit than the
+/// generic value converters ensures pointer layout is handled by
+/// BlockDataParser.
+template <typename OpTy>
+class MemoryPointerConverter : public OpConversionPattern<OpTy> {
+public:
+  explicit MemoryPointerConverter(MLIRContext *context)
+      : OpConversionPattern<OpTy>(context, PatternBenefit(2)) {}
+
+  LogicalResult
+  matchAndRewrite(OpTy op, typename OpTy::Adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto resultTy = dyn_cast<RankedTensorType>(op->getResult(0).getType());
+    if (!resultTy || !isa<triton::PointerType>(resultTy.getElementType()))
+      return failure();
+
+    llvm::SmallDenseMap<Value, BlockData> known;
+    FailureOr<Value> memref =
+        BlockDataParser::materializePointer(op->getResult(0), rewriter, known);
+    if (failed(memref))
+      return rewriter.notifyMatchFailure(
+          op, "unsupported pointer expression for direct materialization");
+
+    rewriter.replaceOp(op, *memref);
+    return success();
+  }
 };
 
 class LoadConverter : public OpConversionPattern<triton::LoadOp> {
@@ -93,39 +123,36 @@ public:
   LogicalResult matchAndRewrite(OpTy op,
                                 PatternRewriter &rewriter) const override {
     Value ptrVal = op.getPtr();
-    Type ptrTy = ptrVal.getType();
-    auto ptrDefOp = ptrVal.getDefiningOp();
+    auto ptrTy = dyn_cast<RankedTensorType>(ptrVal.getType());
+    if (!ptrTy || !isa<triton::PointerType>(ptrTy.getElementType()))
+      return failure();
 
-    bool shouldAddZeros = false;
-    if (!isa<BlockArgument>(ptrVal))
-      shouldAddZeros = !isTensorPointerType(ptrTy) &&
-                       !isa_and_nonnull<triton::AddPtrOp>(ptrDefOp);
-    else if (auto ptrType = dyn_cast<triton::PointerType>(ptrTy))
-      shouldAddZeros = ptrType.getPointeeType().isIntOrIndexOrFloat();
+    // ReorderBroadcast may turn
+    //   addptr(splat(base), splat(offset))
+    // into
+    //   splat(addptr(base, offset)).
+    // Recover the former shape at the memory boundary so AddPtrConverter can
+    // keep using the real (non-synthetic) offset as its lowering anchor.
+    auto splatOp = ptrVal.getDefiningOp<triton::SplatOp>();
+    if (!splatOp)
+      return failure();
 
-    if (shouldAddZeros) {
-      if (isa_and_nonnull<triton::BitcastOp>(ptrDefOp)) {
-        auto castOp = cast<triton::BitcastOp>(ptrDefOp);
-        auto castSrc = castOp.getSrc();
-        if (!isa<BlockArgument>(castSrc)) {
-          auto castSrcDefOp = castSrc.getDefiningOp();
-          if (isa<triton::AddPtrOp>(castSrcDefOp)) {
-            return rewriter.notifyMatchFailure(
-                op, "BitcastCanonicalizer handles addptr->bitcast->load!");
-          }
-        }
-      }
+    auto scalarAddPtr = splatOp.getSrc().getDefiningOp<triton::AddPtrOp>();
+    if (!scalarAddPtr)
+      return failure();
 
-      Type zeroTy = getI32SameShape(ptrTy);
-      Value zeroVal =
-          createScalarOrSplatConstant(rewriter, op.getLoc(), zeroTy, 0);
-      Value addptrVal = rewriter.create<triton::AddPtrOp>(op.getLoc(), ptrTy,
-                                                          ptrVal, zeroVal);
-      rewriter.modifyOpInPlace(
-          op, [&]() { op->replaceUsesOfWith(ptrVal, addptrVal); });
-      return success();
-    }
-    return failure();
+    Value ptrSplat = rewriter.create<triton::SplatOp>(op.getLoc(), ptrTy,
+                                                      scalarAddPtr.getPtr());
+    auto offsetTy =
+        ptrTy.cloneWith(std::nullopt, scalarAddPtr.getOffset().getType());
+    Value offsetSplat = rewriter.create<triton::SplatOp>(
+        op.getLoc(), offsetTy, scalarAddPtr.getOffset());
+    Value addptr = rewriter.create<triton::AddPtrOp>(op.getLoc(), ptrTy,
+                                                     ptrSplat, offsetSplat);
+
+    rewriter.modifyOpInPlace(op,
+                             [&]() { op->replaceUsesOfWith(ptrVal, addptr); });
+    return success();
   }
 };
 

--- a/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
@@ -387,16 +387,11 @@ Value BlockDataParser::getScalarMemRef(Value ptr, Value memref,
                                        const Location &loc,
                                        ConversionPatternRewriter &rewriter) {
   assert(isa<triton::PointerType>(ptr.getType()) && "expect a scalar pointer");
-  if (ptr.getDefiningOp<triton::AddPtrOp>()) {
-    if (auto castOp = memref.getDefiningOp<memref::ReinterpretCastOp>()) {
-      return castOp.getResult();
-    } else {
-      llvm_unreachable("pointer value is defined by an unexpected op");
-    }
-  }
+  if (auto castOp = memref.getDefiningOp<memref::ReinterpretCastOp>())
+    return castOp.getResult();
 
-  assert(isa<BlockArgument>(ptr) &&
-         "pointer should be produced by addptr or block argument");
+  assert(isa<BaseMemRefType>(memref.getType()) &&
+         "converted scalar pointer should be a memref");
   BlockData data;
   data.setSource(memref);
   data.getOffsetsRef().push_back(rewriter.getIndexAttr(0));
@@ -1394,6 +1389,100 @@ void BlockDataParser::rewriteAddPtr(
 
   rewriter.replaceOp(op, src);
   rewriter.restoreInsertionPoint(insertPoint);
+}
+
+FailureOr<Value> BlockDataParser::materializePointer(
+    Value ptr, ConversionPatternRewriter &rewriter,
+    llvm::SmallDenseMap<Value, BlockData> &known) {
+  SmallVector<int64_t> resultShape;
+  if (auto resultTy = dyn_cast<RankedTensorType>(ptr.getType())) {
+    if (!isa<triton::PointerType>(resultTy.getElementType()))
+      return failure();
+    resultShape.append(resultTy.getShape().begin(), resultTy.getShape().end());
+  } else if (auto pointerTy = dyn_cast<triton::PointerType>(ptr.getType())) {
+    // A pointer to a shaped value is a block pointer, not a scalar element
+    // pointer. It is materialized by the make_tensor_ptr path instead.
+    if (isa<ShapedType>(pointerTy.getPointeeType()))
+      return failure();
+    resultShape.push_back(1);
+  } else {
+    return failure();
+  }
+
+  Operation *defOp = ptr.getDefiningOp();
+  if (!defOp)
+    return failure();
+
+  ConversionPatternRewriter::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(defOp);
+
+  BlockData data;
+  parse(ptr, data, ptr.getLoc(), rewriter, known);
+  if (!data.hasSource() || data.getMemAccType().isUnstructured())
+    return failure();
+
+  if (data.getSizesRef().empty()) {
+    data.getSizesRef().push_back(rewriter.getIndexAttr(1));
+    data.getStridesRef().push_back(rewriter.getIndexAttr(0));
+    data.getOffsetsRef().push_back(data.getScalarRef().isNull()
+                                       ? OpFoldResult(rewriter.getIndexAttr(0))
+                                       : data.getScalarRef());
+  }
+
+  if (data.getRank() != static_cast<int64_t>(resultShape.size()))
+    return failure();
+
+  known[ptr] = data;
+
+  // A unit dimension with zero stride is represented as a normal contiguous
+  // unit dimension. Non-unit zero strides are intentional (for example a
+  // splatted base pointer) and must be preserved.
+  int64_t inferredSize = 1;
+  for (int64_t i = data.getRank() - 1; i >= 0; --i) {
+    auto strideConst = getConstantIntValue(data.getStridesRef()[i]);
+    auto sizeConst = getConstantIntValue(data.getSizesRef()[i]);
+    if (!sizeConst)
+      return failure();
+    if (sizeConst.value() == 1 && strideConst && strideConst.value() == 0)
+      data.getStridesRef()[i] = rewriter.getIndexAttr(inferredSize);
+    inferredSize *= sizeConst.value();
+  }
+
+  // Keep negative static offsets as SSA values. This mirrors rewriteAddPtr and
+  // avoids unsigned attribute handling in later reinterpret_cast lowering.
+  auto &offsets = data.getOffsetsRef();
+  for (OpFoldResult &offset : offsets) {
+    if (auto constVal = getConstantIntValue(offset);
+        constVal && constVal.value() < 0) {
+      offset =
+          rewriter
+              .create<arith::ConstantIndexOp>(ptr.getLoc(), constVal.value())
+              .getResult();
+    }
+  }
+
+  if (auto intToPtrOp = dyn_cast_or_null<triton::IntToPtrOp>(
+          data.getSourceRef().getDefiningOp())) {
+    auto pointerTy =
+        cast<triton::PointerType>(intToPtrOp.getResult().getType());
+    auto memrefTy =
+        MemRefType::get({ShapedType::kDynamic}, pointerTy.getPointeeType());
+    auto pointerCast = rewriter.create<hivm::PointerCastOp>(
+        intToPtrOp.getLoc(), memrefTy, ValueRange{intToPtrOp.getSrc()});
+    data.setSource(pointerCast.getResult());
+  }
+
+  if (data.hasResElemTy()) {
+    auto sourceTy = dyn_cast<BaseMemRefType>(data.getSourceRef().getType());
+    if (!sourceTy)
+      return failure();
+    auto castTy = sourceTy.cloneWith(std::nullopt, data.getResElemTyRef());
+    auto cast = rewriter.create<UnrealizedConversionCastOp>(
+        ptr.getLoc(), castTy, data.getSourceRef());
+    data.setSource(cast.getResult(0));
+  }
+
+  return data.createCastOp(resultShape, ptr.getLoc(), rewriter).getResult();
 }
 
 OpFoldResult

--- a/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
@@ -77,6 +77,39 @@ using namespace triton;
 const std::string MayImplicitTransposeWithLastAxisTAG =
     "MayImplicitTransposeWithLastAxis";
 
+static bool shouldMaterializeCustomPointer(Value ptr) {
+  auto result = dyn_cast<OpResult>(ptr);
+  if (!result)
+    return false;
+
+  Operation *defOp = result.getOwner();
+  if (!defOp || !isDistributedTypeCustomOp(defOp))
+    return false;
+
+  auto srcIndices = defOp->getAttrOfType<DenseI32ArrayAttr>(
+      ConverterUtils::customSrcPtrIndexAttrName);
+  if (!srcIndices)
+    return false;
+
+  auto values = srcIndices.asArrayRef();
+  unsigned resultIdx = result.getResultNumber();
+  return resultIdx < values.size() && values[resultIdx] >= 0;
+}
+
+static FailureOr<Value>
+resolveMemoryPointer(Value originalPtr, Value convertedPtr,
+                     ConversionPatternRewriter &rewriter) {
+  llvm::SmallDenseMap<Value, BlockData> known;
+
+  if (shouldMaterializeCustomPointer(originalPtr))
+    return BlockDataParser::materializePointer(originalPtr, rewriter, known);
+
+  if (isa<MemRefType>(convertedPtr.getType()))
+    return convertedPtr;
+
+  return BlockDataParser::materializePointer(originalPtr, rewriter, known);
+}
+
 LogicalResult
 AddPtrConverter::matchAndRewrite(triton::AddPtrOp op, OpAdaptor adaptor,
                                  ConversionPatternRewriter &rewriter) const {
@@ -376,6 +409,12 @@ LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
   auto loc = op.getLoc();
   insertDebugNopForMask(mask, rewriter);
 
+  FailureOr<Value> resolvedPtr =
+      resolveMemoryPointer(op.getPtr(), ptr, rewriter);
+  if (failed(resolvedPtr))
+    return rewriter.notifyMatchFailure(
+        op, "unable to materialize the load pointer as a memref");
+  ptr = *resolvedPtr;
   // handling scalar
   if (!isa<ShapedType>(op.getResult().getType())) {
     auto scalarMemref =
@@ -732,9 +771,16 @@ AtomicRMWConverter::matchAndRewrite(triton::AtomicRMWOp op, OpAdaptor adaptor,
   auto mask = op.getMask();
   auto rmwOp = op.getAtomicRmwOp();
   auto resType = dyn_cast<TensorType>(op.getResult().getType());
-  auto ptrType = dyn_cast<MemRefType>(ptr.getType());
   insertDebugNop(loc, rewriter);
   insertDebugNopForMask(mask, rewriter);
+
+  FailureOr<Value> resolvedPtr =
+      resolveMemoryPointer(op.getPtr(), ptr, rewriter);
+  if (failed(resolvedPtr))
+    return rewriter.notifyMatchFailure(
+        op, "unable to materialize the atomic RMW pointer as a memref");
+  ptr = *resolvedPtr;
+  auto ptrType = dyn_cast<MemRefType>(ptr.getType());
   if (!resType)
     return rewriter.notifyMatchFailure(
         op, "atomicRMWConverter: scalar will be handled by "
@@ -896,6 +942,12 @@ AtomicCASConverter::matchAndRewrite(triton::AtomicCASOp op, OpAdaptor adaptor,
   auto val = op.getVal();
   auto loc = op.getLoc();
 
+  FailureOr<Value> resolvedPtr =
+      resolveMemoryPointer(op.getPtr(), ptr, rewriter);
+  if (failed(resolvedPtr))
+    return rewriter.notifyMatchFailure(
+        op, "unable to materialize the atomic CAS pointer as a memref");
+  ptr = *resolvedPtr;
   auto resType = dyn_cast<TensorType>(op.getResult().getType());
   if (!resType) {
     return rewriter.notifyMatchFailure(
@@ -1340,6 +1392,12 @@ StoreConverter::matchAndRewrite(triton::StoreOp op, OpAdaptor adaptor,
   auto ptr = adaptor.getPtr();
   auto val = adaptor.getValue();
 
+  FailureOr<Value> resolvedPtr =
+      resolveMemoryPointer(op.getPtr(), ptr, rewriter);
+  if (failed(resolvedPtr))
+    return rewriter.notifyMatchFailure(
+        op, "unable to materialize the store pointer as a memref");
+  ptr = *resolvedPtr;
   // 1. boundary size check
   auto boundaryCheck = op.getBoundaryCheck();
   if (!boundaryCheck.empty()) {

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -3303,6 +3303,15 @@ LogicalResult IndirectLoadConverter::matchAndRewrite(
   auto res = op.getResult();
   auto resTy = res.getType();
 
+  if (!isa<MemRefType>(src.getType())) {
+    llvm::SmallDenseMap<Value, BlockData> known;
+    FailureOr<Value> materialized =
+        BlockDataParser::materializePointer(op.getSrc(), rewriter, known);
+    if (failed(materialized))
+      return rewriter.notifyMatchFailure(
+          op, "unable to materialize indirect-load source as a memref");
+    src = *materialized;
+  }
   // convert !tt.ptr<f32> to memref<?xf32>
   auto srcTy = dyn_cast<MemRefType>(src.getType());
   if (!srcTy) {
@@ -3437,6 +3446,15 @@ LogicalResult IndirectStoreConverter::matchAndRewrite(
   auto value = op.getValue();
   auto mask = op.getMask();
 
+  if (!isa<MemRefType>(src.getType())) {
+    llvm::SmallDenseMap<Value, BlockData> known;
+    FailureOr<Value> materialized =
+        BlockDataParser::materializePointer(op.getSrc(), rewriter, known);
+    if (failed(materialized))
+      return rewriter.notifyMatchFailure(
+          op, "unable to materialize indirect-store source as a memref");
+    src = *materialized;
+  }
   // convert !tt.ptr<f32> to memref<?xf32>
   auto srcTy = dyn_cast<MemRefType>(src.getType());
   if (!srcTy) {

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -675,6 +675,12 @@ void TritonToLinalgPass::populateTritonToLinalgConversionPatterns(
   patterns.add<triton::MetaUseEraser>(patterns.getContext());
   patterns.add<LoadStoreConverter::StoreConverter>(patterns.getContext());
   patterns.add<LoadStoreConverter::AddPtrConverter>(patterns.getContext());
+  patterns
+      .add<LoadStoreConverter::MemoryPointerConverter<triton::SplatOp>,
+           LoadStoreConverter::MemoryPointerConverter<triton::BitcastOp>,
+           LoadStoreConverter::MemoryPointerConverter<triton::BroadcastOp>,
+           LoadStoreConverter::MemoryPointerConverter<triton::ExpandDimsOp>>(
+          patterns.getContext());
   patterns.add<FunctionConverter::GetProgramIDConverter>(patterns.getContext());
   patterns.add<FunctionConverter::GetNumProgramsConverter>(
       patterns.getContext());

--- a/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
@@ -407,24 +407,6 @@ static bool canUseIndirectFastPath(Value srcPtr, Value ptrOffset) {
   return isa<RankedTensorType>(ptrOffset.getType());
 }
 
-// Wrap an int_to_ptr result with addptr(src, 0) so that the later
-// AddPtrConverter can lower it to a hivm::PointerCastOp (memref type), which
-// the IndirectLoad/StoreConverter needs to emit func.call @triton_indirect_*.
-// Returns the wrapped pointer, or the original srcPtr when it is not an
-// int_to_ptr result.
-static Value wrapIntToPtrWithAddPtr(Value srcPtr, Location loc,
-                                    PatternRewriter &rewriter) {
-  if (auto *defOp = srcPtr.getDefiningOp()) {
-    if (auto intToPtrOp = dyn_cast<triton::IntToPtrOp>(defOp)) {
-      auto zeroOffset = rewriter.create<arith::ConstantOp>(
-          loc, rewriter.getZeroAttr(intToPtrOp.getSrc().getType()));
-      return rewriter.create<triton::AddPtrOp>(loc, srcPtr.getType(), srcPtr,
-                                               zeroOffset);
-    }
-  }
-  return srcPtr;
-}
-
 template <typename MemAccOpTy>
 LogicalResult tryRewriteIndirectFastPath(MemAccOpTy op, Location loc,
                                          Value srcPtr, Value ptrOffset,
@@ -451,9 +433,8 @@ LogicalResult tryRewriteIndirectFastPath(MemAccOpTy op, Location loc,
     Value mask = op.getMask();
     Value other = op.getOther();
     auto resultType = op.getType();
-    auto newPtr = wrapIntToPtrWithAddPtr(srcPtr, loc, rewriter);
     auto indirect = rewriter.create<triton::ascend::IndirectLoadOp>(
-        loc, resultType, newPtr, ptrOffset, mask, other,
+        loc, resultType, srcPtr, ptrOffset, mask, other,
         ConverterUtils::requiresVolatileIndirectLoad(op.getPtr(), op));
     rewriter.replaceOp(op, indirect.getResult());
     LLVM_DEBUG({
@@ -471,11 +452,6 @@ LogicalResult tryRewriteIndirectFastPath(MemAccOpTy op, Location loc,
            "src must be ptr type");
     Value value = op.getValue();
     Value mask = op.getMask();
-
-    // Wrap int_to_ptr with addptr so that AddPtrConverter can later produce
-    // a hivm::PointerCastOp (memref type) from it, which is required by
-    // IndirectStoreConverter to emit func.call @triton_indirect_store.
-    srcPtr = wrapIntToPtrWithAddPtr(srcPtr, loc, rewriter);
 
     // For bool store, unwrap ptr<i1> -> ptr<i8> bitcast before creating
     // indirect_store. Keep ptr<i1> so TypeConverter can map it to memref<?xi8>.

--- a/third_party/ascend/unittest/Conversion/General/DiscreteMaskAccess/atomic.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DiscreteMaskAccess/atomic.mlir
@@ -236,11 +236,11 @@ tt.func @atomic_add_cont_disc_i32(%arg0: !tt.ptr<i32>, %arg1: i32) {
 // -----
 
 // CHECK-LABEL: tt.func @atomic_min_f32_splat_bitcast
-// CHECK: %[[VALUE_PTR:.*]] = tt.addptr %arg0, %{{.*}} : !tt.ptr<f32>, i32
-// CHECK: %[[VALUE_PTRS:.*]] = tt.splat %[[VALUE_PTR]] : !tt.ptr<f32> -> tensor<1x1x1x1x!tt.ptr<f32>>
+// CHECK-NOT: tt.addptr %arg0
+// CHECK: %[[VALUE_PTRS:.*]] = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1x1x1x1x!tt.ptr<f32>>
 // CHECK: %[[VALUE:.*]] = tt.load %[[VALUE_PTRS]] : tensor<1x1x1x1x!tt.ptr<f32>>
-// CHECK: %[[OUTPUT_PTR:.*]] = tt.addptr %arg1, %{{.*}} : !tt.ptr<f32>, i32
-// CHECK: %[[OUTPUT_PTRS:.*]] = tt.splat %[[OUTPUT_PTR]] : !tt.ptr<f32> -> tensor<1x1x1x1x!tt.ptr<f32>>
+// CHECK-NOT: tt.addptr %arg1
+// CHECK: %[[OUTPUT_PTRS:.*]] = tt.splat %arg1 : !tt.ptr<f32> -> tensor<1x1x1x1x!tt.ptr<f32>>
 // CHECK: tt.atomic_rmw min, acq_rel, gpu, %[[OUTPUT_PTRS]], %[[VALUE]], %{{.*}} : (tensor<1x1x1x1x!tt.ptr<f32>>, tensor<1x1x1x1xf32>, tensor<1x1x1x1xi1>) -> tensor<1x1x1x1xf32>
 // CHECK-NOT: tt.atomic_rmw umax
 tt.func @atomic_min_f32_splat_bitcast(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>) {

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/parse_custom.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/parse_custom.mlir
@@ -30,14 +30,15 @@ module {
 
 // -----
 
-// CHECK-LABEL: func.func @parse_custom
-// CHECK: %4 = hivm.hir.custom {{.*}} "foo1" ins(%reinterpret_cast, %arg7, %c0_i64 : memref<1xi64, strided<[1]>>, i32, i64) -> i32
-// CHECK: %5 = hivm.hir.custom {{.*}} "foo2" ins(%arg2, %3 : memref<?xf16>, i32) -> memref<?xf16>
-// CHECK: %reinterpret_cast_0 = memref.reinterpret_cast %5 to offset: [0], sizes: [32], strides: [1] : memref<?xf16> to memref<32xf16, strided<[1]>>
-// CHECK: %6 = hivm.hir.custom {{.*}} "foo3" ins(%reinterpret_cast_0, %4 : memref<32xf16, strided<[1]>>, i32) -> memref<32xf16>
-// CHECK: %reinterpret_cast_1 = memref.reinterpret_cast %6 to offset: [0], sizes: [32], strides: [1] : memref<32xf16> to memref<32xf16, strided<[1]>>
-// CHECK: %alloc = memref.alloc() : memref<32xf16>
-// CHECK: memref.copy %reinterpret_cast_1, %alloc : memref<32xf16, strided<[1]>> to memref<32xf16>
+// CHECK-LABEL: func.func @parse_custom(
+// CHECK-SAME: %[[BASE_I64:arg[0-9]+]]: memref<?xi64>, %[[NUM_PROGRAMS_X:arg[0-9]+]]: i32
+// CHECK: %[[FOO1:.*]] = hivm.hir.custom {{.*}} "foo1" ins(%[[BASE_I64]], %[[NUM_PROGRAMS_X]], %c0_i64 : memref<?xi64>, i32, i64) -> i32
+// CHECK: %[[FOO2:.*]] = hivm.hir.custom {{.*}} "foo2" ins(%arg2, %3 : memref<?xf16>, i32) -> memref<?xf16>
+// CHECK: %[[FOO2_VIEW:.*]] = memref.reinterpret_cast %[[FOO2]] to offset: [0], sizes: [32], strides: [1] : memref<?xf16> to memref<32xf16, strided<[1]>>
+// CHECK: %[[FOO3:.*]] = hivm.hir.custom {{.*}} "foo3" ins(%[[FOO2_VIEW]], %[[FOO1]] : memref<32xf16, strided<[1]>>, i32) -> memref<32xf16>
+// CHECK: %[[FOO3_VIEW:.*]] = memref.reinterpret_cast %[[FOO3]] to offset: [0], sizes: [32], strides: [1] : memref<32xf16> to memref<32xf16, strided<[1]>>
+// CHECK: %[[ALLOC:.*]] = memref.alloc() : memref<32xf16>
+// CHECK: memref.copy %[[FOO3_VIEW]], %[[ALLOC]] : memref<32xf16, strided<[1]>> to memref<32xf16>
 module {
   tt.func public @parse_custom(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: i32, %arg3: i32, %arg4: !tt.ptr<i64>) {
     %c0_i64 = arith.constant 0 : i64

--- a/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/indirect_store.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/indirect_store.mlir
@@ -42,22 +42,18 @@ tt.func public @triton_indirect_store_kernel(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr
 // CHECK:           tt.return
 // CHECK:         }
 
-// tt.int_to_ptr + tt.store -> wrap with addptr(src, 0), then
-// ascend.indirect_store. The addptr wrap is required so that the later
-// TritonToLinalg AddPtrConverter can lower it to a hivm::PointerCastOp
-// (memref type), which IndirectStoreConverter needs to emit
-// func.call @triton_indirect_store.
+// tt.int_to_ptr + tt.store -> ascend.indirect_store with the original pointer.
+// TritonToLinalg materializes the pointer at the indirect-store consumer.
 // CHECK-LABEL:     tt.func public @triton_indirect_store_int_to_ptr_kernel(
-// CHECK:           %[[ZERO:.*]] = arith.constant 0 : i64
 // CHECK:           %[[BASE:.*]] = tt.int_to_ptr {{.*}} : i64 -> !tt.ptr<f32>
-// CHECK:           %[[WRAPPED:.*]] = tt.addptr %[[BASE]], %[[ZERO]] : !tt.ptr<f32>, i64
-// CHECK:           ascend.indirect_store %[[WRAPPED]] : <f32>, {{.*}} : tensor<8xi64>, {{.*}} : tensor<8xf32>
+// CHECK-NOT:       tt.addptr %[[BASE]]
+// CHECK:           ascend.indirect_store %[[BASE]] : <f32>, {{.*}} : tensor<8xi64>, {{.*}} : tensor<8xf32>
 // CHECK:           tt.return
 // CHECK:         }
 
 // The same kernel lowered through TritonToLinalg must produce a
-// hivm::PointerCastOp (memref) from the wrapped addptr and finally a
-// func.call @triton_indirect_store.
+// hivm::PointerCastOp (memref) directly from int_to_ptr and finally a func.call
+// @triton_indirect_store.
 // LINALG-LABEL: func.func @triton_indirect_store_int_to_ptr_kernel
 // LINALG: hivm.hir.pointer_cast(%{{.*}}) [%{{.*}}] : memref<?xf32>
 // LINALG: call @triton_indirect_store{{.*}}(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<{{.*}}xf32, strided<[1]>>, tensor<8xi64>, tensor<8xf32>) -> ()


### PR DESCRIPTION
## Background

Upstream Triton defines a standard folder for `tt.addptr`: `tt.addptr(ptr, 0)` is canonicalized to the original pointer.

```cpp
OpFoldResult AddPtrOp::fold(FoldAdaptor adaptor) {
  if (matchPattern(adaptor.getOffset(), m_Zero()))
    return getPtr();
  return {};
}
```

The Ascend backend previously used `tt.addptr` as the common entry point for pointer analysis and memory lowering. To prevent a synthetic zero-offset `tt.addptr` from being folded before reaching `AddPtrConverter`, the backend commented out both `TT_AddPtrOp::hasFolder` and `AddPtrOp::fold()` in the shared Triton dialect. This changed upstream canonicalization behavior and introduced an invasive community-code modification.

This PR restores the upstream implementation:

```tablegen
let hasFolder = 1;
```

and re-enables:

```cpp
OpFoldResult AddPtrOp::fold(FoldAdaptor adaptor) {
  if (matchPattern(adaptor.getOffset(), m_Zero())) {
    return getPtr();
  }
  return {};
}
```

Once the folder is restored, Ascend pointer lowering can no longer assume that every memory pointer is produced by `tt.addptr`. This PR therefore also removes the backend dependency on synthetic `AddPtr(ptr, 0)` anchors.

## Problem

The previous `LoadStoreCanonicalizer` inspected the pointer operands of Load, Store, AtomicRMW, and AtomicCAS operations. When a pointer was not produced by `tt.addptr`, the canonicalizer inserted a zero-offset `tt.addptr` to trigger the downstream `AddPtrConverter`.

Current TTIR:

```mlir
%ptrs = tt.splat %arg0 : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
%value = tt.load %ptrs : tensor<4x!tt.ptr<f32>>
```

The previous canonicalizer rewrote it as:

```mlir
%zero = arith.constant dense<0> : tensor<4xi32>
%addr = tt.addptr %ptrs, %zero : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
%value = tt.load %addr : tensor<4x!tt.ptr<f32>>
```

After restoring `AddPtrOp::fold()`, `%addr` is immediately folded back to `%ptrs`. Under `applyPatternsGreedily()`, this creates the following rewrite cycle:

```text
load(ptr) -> load(addptr(ptr, 0)) -> load(ptr) -> load(addptr(ptr, 0)) -> ...
```

The rewrite never reaches a fixed point, so `TritonToLinalg` compilation hangs.

The root cause is not the upstream `addptr(ptr, 0) -> ptr` fold. The actual issue is that the Ascend backend treated a semantically redundant `+0 AddPtr` as a mandatory pointer-lowering entry point.

## Solution

This PR separates pointer lowering into two paths:

1. A real `tt.addptr(base, offset)` exists: preserve the actual address calculation and continue using `AddPtrConverter`.
2. No real AddPtr exists: parse the pointer expression directly to obtain its source, offsets, sizes, and strides, then materialize a memref without creating `AddPtr(ptr, 0)`.

```text
Real pointer arithmetic -> AddPtrConverter
Pure pointer expression -> BlockDataParser::materializePointer()
```

Load, Store, Atomic, and indirect-memory consumers resolve their pointers at the consumption boundary. This also removes the dependency on the execution order of producer and consumer conversion patterns.

## Covered scenarios

### 1. Recover a real AddPtr hidden by Splat

Optimizations such as `ReorderBroadcast` may transform tensor pointer arithmetic into `splat(addptr(base, offset))`. The offset in this expression represents a real address calculation and must be preserved.

Current TTIR:

```mlir
%x = tt.addptr %x_ptr, %pid : !tt.ptr<f32>, i32
%x_3 = tt.splat %x : !tt.ptr<f32> -> tensor<1x!tt.ptr<f32>>
%x_4 = tt.load %x_3 : tensor<1x!tt.ptr<f32>>
```

It can be rewritten as:

```mlir
%x_ptrs = tt.splat %x_ptr : !tt.ptr<f32> -> tensor<1x!tt.ptr<f32>>
%pids = tt.splat %pid : i32 -> tensor<1xi32>
%x_3 = tt.addptr %x_ptrs, %pids : tensor<1x!tt.ptr<f32>>, tensor<1xi32>
%x_4 = tt.load %x_3 : tensor<1x!tt.ptr<f32>>
```

The updated `LoadStoreCanonicalizer` only recovers this kind of real AddPtr. It no longer inserts a zero offset for ordinary pointers.

### 2. Materialize a pointer Splat without a real AddPtr

A plain `splat(base)` does not contain pointer arithmetic, so a synthetic `+0` must not be introduced.

Current TTIR:

```mlir
%ptrs = tt.splat %arg0 : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
%value = tt.load %ptrs : tensor<4x!tt.ptr<f32>>
```

It is materialized directly as:

```mlir
%view = memref.reinterpret_cast %arg0 to offset: [0], sizes: [4], strides: [0] : memref<?xf32> to memref<4xf32, strided<[0]>>
```

The zero stride means that all four lanes access the same base address. `BlockDataParser` preserves this layout, and the Load, Store, and Atomic converters consume `%view` directly.

### 3. Materialize a pointer Bitcast directly

Current TTIR:

```mlir
%ptrs = tt.splat %arg0 : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>>
%cast = tt.bitcast %ptrs : tensor<4x!tt.ptr<i32>> -> tensor<4x!tt.ptr<f32>>
%value = tt.load %cast : tensor<4x!tt.ptr<f32>>
```

It is materialized directly as:

```mlir
%source = builtin.unrealized_conversion_cast %arg0 : memref<?xi32> to memref<?xf32>
%view = memref.reinterpret_cast %source to offset: [0], sizes: [4], strides: [0] : memref<?xf32> to memref<4xf32, strided<[0]>>
```

Only the memref element type changes; the original offsets, sizes, and strides are preserved. Pointer Broadcast and ExpandDims expressions are recursively handled through the same materialization entry point.

### 4. Resolve Load, Store, and Atomic pointers through one entry point

This PR adds a shared pointer-resolution helper:

```cpp
static FailureOr<Value>
resolveMemoryPointer(Value originalPtr, Value convertedPtr,
                     ConversionPatternRewriter &rewriter);
```

The helper uses the following order:

1. If the pointer is a Structured CustomOp result with `SrcPtrIndex`, rematerialize its inherited layout first.
2. If the adaptor pointer is already a memref, reuse it directly.
3. Otherwise, call `BlockDataParser::materializePointer()` on the original TTIR pointer expression.

The helper is used by:

- `LoadConverter`
- `StoreConverter`
- `AtomicRMWConverter`
- `AtomicCASConverter`


### 5. Support `int_to_ptr` indirect loads

The previous `TritonToUnstructure` path wrapped `tt.int_to_ptr` in a synthetic scalar zero AddPtr:

```mlir
%base = tt.int_to_ptr %address : i64 -> !tt.ptr<i32>
%zero = arith.constant 0 : i64
%anchor = tt.addptr %base, %zero : !tt.ptr<i32>, i64
%value = ttg.indirect_load %anchor, %offsets : !tt.ptr<i32>, tensor<128xi64>
```

Because `%anchor` necessarily disappears after the folder is restored, the updated implementation removes this wrapper and preserves the actual source directly:

```mlir
%base = tt.int_to_ptr %address : i64 -> !tt.ptr<i32>
%value = ttg.indirect_load %base, %offsets : !tt.ptr<i32>, tensor<128xi64>
```

In `TritonToLinalg`, `IndirectLoadConverter` materializes the pointer at the consumer boundary:

```mlir
%base_memref = hivm.hir.pointer_cast %address : i64 to memref<?xi32>
%view = memref.reinterpret_cast %base_memref to offset: [0], sizes: [1], strides: [1] : memref<?xi32> to memref<1xi32, strided<[1]>>
%result = call @triton_indirect_load(%view, %offsets, %mask, %other) {isVolatile = true} : (memref<1xi32, strided<[1]>>, tensor<128xi64>, tensor<128xi1>, tensor<128xi32>) -> tensor<128xi32>
```

`requiresVolatileIndirectLoad()` still examines the original load pointer, so volatile semantics for unknown integer addresses are preserved.

