### PR TITLE
[TritonControlFlowOpt](feat) decouple pointers across SCF boundaries

### DIFF
--- a/third_party/ascend/include/TritonControlFlowOpt/ControlFlowAnalysis.h
+++ b/third_party/ascend/include/TritonControlFlowOpt/ControlFlowAnalysis.h
@@ -75,7 +75,6 @@ struct AnalyzedComponent {
 struct AnalyzedValue {
   Type originalType;
   SmallVector<AnalyzedComponent> components;
-  SmallVector<Value> invariants;
   SmallVector<Attribute> attributes;
 };
 

--- a/third_party/ascend/include/TritonControlFlowOpt/ControlFlowRewrite.h
+++ b/third_party/ascend/include/TritonControlFlowOpt/ControlFlowRewrite.h
@@ -32,19 +32,27 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace mlir::triton::controlflow {
 
+/// Handoff marker for SCF loops whose pointer slots have already been expanded
+/// into policy-owned descriptor components. Its DenseI32ArrayAttr value lists
+/// the loop-carried init/result slots occupied by pointer descriptor state.
+/// TritonToLinalg uses those slots to preserve only the required producer
+/// chains and removes the marker after conversion.
+inline constexpr llvm::StringLiteral kPointerDescriptorBoundaryAttr =
+    "PointerDescriptorBoundary";
+
 /// Policy-owned description of one value crossing a control-flow boundary.
 ///
-/// `components` are runtime values that a policy may place in an expanded SCF
-/// signature. `invariants` and `attributes` are public storage whose layout is
-/// interpreted only by the policy that creates them. The shared rewrite treats
-/// those fields as opaque and only accesses `components` directly.
+/// `components` contain every runtime value needed to rebuild the original
+/// value. A policy may place a selected subset in an expanded SCF signature.
+/// `attributes` retain non-SSA metadata. Both layouts are private to the
+/// policy; the shared rewrite never interprets pointer-specific fields.
 struct DecomposedValue {
   Type originalType;
   SmallVector<Value> components;
-  SmallVector<Value> invariants;
   SmallVector<Attribute> attributes;
 };
 
@@ -71,8 +79,9 @@ private:
 ///
 /// The policy decides how its value is decomposed and rebuilt, which components
 /// cross loop/if boundaries, and whether two decompositions share a compatible
-/// invariant schema. It is not an IR marker and carries no state between
-/// policy invocations.
+/// non-carried schema. It carries no mutable state between policy invocations;
+/// a capability hook tells the shared rewrite whether expanded loop slots must
+/// be recorded for downstream conversion.
 class ControlFlowRewritePolicy : public ControlFlowAnalysisPolicy {
 public:
   virtual ~ControlFlowRewritePolicy() = default;
@@ -80,6 +89,11 @@ public:
   /// Whether results of this ordinary operation need immediate decomposition
   /// after cloning so later operations can reuse their exact component state.
   virtual bool shouldDecomposeOperation(Operation *op) const = 0;
+
+  /// Whether rewritten loops owned by this policy must expose their descriptor
+  /// slots to downstream conversion. The shared rewrite owns the positional
+  /// marker because it alone knows both the previous and expanded signatures.
+  virtual bool requiresPointerDescriptorBoundaryMarker() const { return false; }
 
   virtual FailureOr<DecomposedValue>
   decompose(Value value, const ControlFlowRewriteContext &context,

--- a/third_party/ascend/include/TritonToLinalg/BlockPtrAnalysis.h
+++ b/third_party/ascend/include/TritonToLinalg/BlockPtrAnalysis.h
@@ -45,6 +45,16 @@ namespace triton {
 
 enum class MemAccVal { Undefined = 0, StrucMemAcc = 1, UnstrucMemAcc = 2 };
 
+/// Creates a verifier-valid HIVM pointer cast for a scalar Triton pointer
+/// represented by an integer address. Triton scalar pointers do not carry an
+/// extent, while their downstream carrier is normally `memref<?xT>` and every
+/// dynamic memref dimension requires a size operand. Use one element as the
+/// conservative carrier extent; reinterpret-cast lowering replaces it with a
+/// precise access range when a larger descriptor is materialized.
+hivm::PointerCastOp createScalarPointerCast(OpBuilder &builder, Location loc,
+                                            MemRefType resultType,
+                                            Value address);
+
 struct MemAccType {
 
   MemAccVal value;
@@ -288,8 +298,8 @@ public:
                             ConversionPatternRewriter &rewriter,
                             llvm::SmallDenseMap<Value, BlockData> &known);
 
-  static void
-  rewriteMakeTensorPtrOp(triton::MakeTensorPtrOp op, Value base,
+  static LogicalResult
+  rewriteMakeTensorPtrOp(triton::MakeTensorPtrOp op, Value convertedBase,
                          ConversionPatternRewriter &rewriter,
                          llvm::SmallDenseMap<Value, BlockData> &known);
 
@@ -312,9 +322,9 @@ public:
 
   /// @param known is mainly designed for `rewriteLoop`, and is just non-const
   /// in `rewriteLoop`, `rewriteAddPtr` and `rewriteAdvance`
-  static void rewriteLoopOp(LoopLikeOpInterface op,
-                            ConversionPatternRewriter &rewriter,
-                            llvm::SmallDenseMap<Value, BlockData> &known);
+  static LogicalResult
+  rewriteLoopOp(LoopLikeOpInterface op, ConversionPatternRewriter &rewriter,
+                llvm::SmallDenseMap<Value, BlockData> &known);
 
   static void rewriteAddPtrToUnstrucMemAcc(triton::AddPtrOp op,
                                            triton::AddPtrOp::Adaptor &adaptor,

--- a/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
@@ -37,6 +37,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 
@@ -576,6 +577,66 @@ public:
                   ConversionPatternRewriter &rewriter) const override;
 };
 
+// These predicates select only scalar !tt.ptr<T> transports. A
+// tensor<...x!tt.ptr<T>> follows the separate tensor-pointer lowering.
+bool hasScalarPointerResult(scf::IfOp op);
+bool isScalarPointerSelect(arith::SelectOp op);
+
+// Marks an scf.if temporarily rebuilt by IfConverter. Its scalar-pointer
+// results are represented as complete i64 addresses, so only its own yields
+// require the matching pointer-to-address conversion.
+inline constexpr llvm::StringLiteral kScalarPointerCarrierBoundaryAttr =
+    "ScalarPointerCarrierBoundary";
+
+// Rebuild an scf.if with scalar-pointer results so the boundary carries
+// complete i64 addresses and reconstructs memrefs only after the join.
+// The original branch regions are moved into the new operation, preserving
+// side effects and allowing the conversion driver to rewrite each scf.yield
+// operand in place.
+//
+// Example:
+//   %base = scf.if %cond -> !tt.ptr<f32> {
+//     scf.yield %lhs : !tt.ptr<f32>
+//   } else {
+//     scf.yield %rhs : !tt.ptr<f32>
+//   }
+//   %ptr = tt.make_tensor_ptr %base, ...
+// becomes an scf.if returning i64 plus one hivm.pointer_cast after the if.
+class IfConverter : public OpConversionPattern<scf::IfOp> {
+public:
+  using OpConversionPattern<scf::IfOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(scf::IfOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override;
+};
+
+// Convert a scalar-pointer select into a select over complete integer addresses
+// and reconstruct one memref after the selection. This handles both BlockPtr
+// bases and ordinary scalar pointers without asking the backend to merge two
+// memory objects.
+//
+// Example:
+//   %base = arith.select %cond, %lhs, %rhs : !tt.ptr<f32>
+//   %ptr = tt.make_tensor_ptr %base, ...
+// becomes:
+//   %lhs_addr = memref.extract_aligned_pointer_as_index %lhs
+//   %rhs_addr = memref.extract_aligned_pointer_as_index %rhs
+//   %selected_addr = arith.select %cond, %lhs_addr, %rhs_addr : i64
+//   %base = hivm.pointer_cast %selected_addr : i64 to memref<?xf32>
+class PointerSelectConverter : public OpConversionPattern<arith::SelectOp> {
+public:
+  using OpConversionPattern<arith::SelectOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(arith::SelectOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override;
+};
+
+// Convert the yields of an IfConverter-created scf.if to its carrier result
+// types. In particular, a yielded scalar pointer becomes its complete i64
+// address. Yields belonging to ordinary ifs or loops are intentionally left to
+// their owning conversions.
 class YieldConverter : public OpConversionPattern<scf::YieldOp> {
 public:
   using OpConversionPattern<scf::YieldOp>::OpConversionPattern;
@@ -596,11 +657,15 @@ public:
   matchAndRewrite(LoopOpTy op,
                   typename OpConversionPattern<LoopOpTy>::OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    // CFO-expanded descriptor loops already carry pointer-free policy values
+    // and remain structurally unchanged. This legacy BlockData rewrite is only
+    // valid for explicitly marked loops.
+    if (!op->hasAttr("UnhandledLoopOp"))
+      return failure();
     llvm::SmallDenseMap<Value, BlockData> known;
 
-    op->removeAttr("UnhandledLoopOp");
-    BlockDataParser::rewriteLoopOp(op, rewriter, known);
-    return success();
+    rewriter.modifyOpInPlace(op, [&]() { op->removeAttr("UnhandledLoopOp"); });
+    return BlockDataParser::rewriteLoopOp(op, rewriter, known);
   }
 };
 
@@ -733,6 +798,14 @@ public:
   using OpConversionPattern<triton::PtrToIntOp>::OpConversionPattern;
   LogicalResult
   matchAndRewrite(triton::PtrToIntOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override;
+};
+
+class IntToPtrConverter : public OpConversionPattern<triton::IntToPtrOp> {
+public:
+  using OpConversionPattern<triton::IntToPtrOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(triton::IntToPtrOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override;
 };
 

--- a/third_party/ascend/include/TritonToUnstructure/BubbleUpOperation.h
+++ b/third_party/ascend/include/TritonToUnstructure/BubbleUpOperation.h
@@ -72,6 +72,11 @@ private:
                          PatternRewriter &rewriter) const;
   void bubbleUpOperation(ExtractOpTy op, arith::CmpIOp parentOp, Location loc,
                          PatternRewriter &rewriter) const;
+  // Pushes extract(select(condition, lhs, rhs)) through the select. A shaped
+  // condition is extracted at the same position while a scalar condition is
+  // reused directly.
+  void bubbleUpOperation(ExtractOpTy op, arith::SelectOp parentOp, Location loc,
+                         PatternRewriter &rewriter) const;
   void bubbleUpOperation(ExtractOpTy op, arith::TruncFOp parentOp, Location loc,
                          PatternRewriter &rewriter) const;
   void bubbleUpOperation(ExtractOpTy op, arith::ExtFOp parentOp, Location loc,

--- a/third_party/ascend/lib/TritonControlFlowOpt/BlockPtrDecompose.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/BlockPtrDecompose.cpp
@@ -35,15 +35,26 @@ using namespace mlir::triton::controlflow;
 
 namespace {
 
+static constexpr unsigned kBaseComponent = 0;
+static constexpr unsigned getShapeStart() { return kBaseComponent + 1; }
+static constexpr unsigned getStrideStart(unsigned rank) {
+  return getShapeStart() + rank;
+}
+static constexpr unsigned getOffsetStart(unsigned rank) {
+  return getStrideStart(rank) + rank;
+}
+
 /// Block-pointer component layout used only by this policy:
 ///
-///   components = [shape..., strides..., offsets...]
-///   invariants = [base]
+///   components = [base_address, shape..., strides..., offsets...]
 ///   attributes = [order]
 ///
-/// Loops currently carry only `offsets`; shape and strides must remain
-/// invariant across a backedge. An scf.if may select any component whose SSA
-/// value differs between its branches.
+/// Every supported SCF boundary carries all components in this exact order.
+/// The base is represented as an i64 address rather than a pointer/memref so a
+/// control-flow merge remains an SSA value selection and cannot be lowered as
+/// a memory-object copy by the backend.
+/// `order` remains policy-owned static metadata and must agree on every
+/// incoming path.
 ///
 /// Keep rank/layout checks local to this file: the generic control-flow
 /// machinery intentionally does not know the descriptor format of a policy.
@@ -59,13 +70,39 @@ static FailureOr<unsigned> getRank(Type originalType) {
   return tensorType.getRank();
 }
 
+// Recovers the scalar pointer type accepted by tt.make_tensor_ptr from the
+// BlockPtr result type. The address space is preserved across the temporary
+// integer carrier.
+static FailureOr<triton::PointerType> getBasePointerType(Type originalType) {
+  auto pointerType = dyn_cast<triton::PointerType>(originalType);
+  if (!pointerType)
+    return failure();
+  auto tensorType = dyn_cast<RankedTensorType>(pointerType.getPointeeType());
+  if (!tensorType)
+    return failure();
+  return triton::PointerType::get(tensorType.getElementType(),
+                                  pointerType.getAddressSpace());
+}
+
 // Validates the common block-pointer schema for either state representation.
 // Their component element types differ, but this check only needs field sizes.
 template <typename StateT> static bool hasValidLayout(const StateT &state) {
   FailureOr<unsigned> rank = getRank(state.originalType);
-  return succeeded(rank) && state.components.size() == 3 * *rank &&
-         state.invariants.size() == 1 && state.attributes.size() == 1 &&
+  return succeeded(rank) && state.components.size() == 1 + 3 * *rank &&
+         state.attributes.size() == 1 &&
          isa<DenseI32ArrayAttr>(state.attributes.front());
+}
+
+/// Returns the complete, ordered descriptor range used to expand one
+/// block-pointer control-flow slot. Keeping this policy-local prevents the
+/// generic SCF rewrite from depending on the BlockPtr field layout.
+static SmallVector<unsigned>
+getAllComponentIndices(const AnalyzedValue &value) {
+  SmallVector<unsigned> indices;
+  indices.reserve(value.components.size());
+  for (unsigned index = 0; index < value.components.size(); ++index)
+    indices.push_back(index);
+  return indices;
 }
 
 class BlockPtrPolicy final : public ControlFlowRewritePolicy {
@@ -93,7 +130,11 @@ public:
       // types and symbolic identities here; this phase must not create IR.
       AnalyzedValue result;
       result.originalType = value.getType();
-      unsigned componentIndex = 0;
+      Value base = makePtr.getBase();
+      result.components.push_back(
+          {IntegerType::get(value.getContext(), 64),
+           ComponentIdentity::fromValue(base, kBaseComponent)});
+      unsigned componentIndex = getShapeStart();
       auto appendComponents = [&](ValueRange values) {
         for (Value component : values) {
           result.components.push_back(
@@ -104,7 +145,6 @@ public:
       appendComponents(makePtr.getShape());
       appendComponents(makePtr.getStrides());
       appendComponents(makePtr.getOffsets());
-      result.invariants.push_back(makePtr.getBase());
       result.attributes.push_back(makePtr.getOrderAttr());
       if (!hasValidLayout(result))
         return failure();
@@ -124,7 +164,7 @@ public:
     if (advance.getOffsets().size() != rank)
       return failure();
     for (unsigned dimension = 0; dimension < rank; ++dimension) {
-      unsigned componentIndex = 2 * rank + dimension;
+      unsigned componentIndex = getOffsetStart(rank) + dimension;
       result->components[componentIndex].identity =
           ComponentIdentity::fromValue(value, componentIndex);
     }
@@ -136,13 +176,9 @@ public:
   getLoopCandidateComponents(const AnalyzedValue &value) const override {
     if (!hasValidLayout(value))
       return failure();
-    unsigned rank = *getRank(value.originalType);
-    SmallVector<unsigned> indices;
-    // Only the final rank entries (offsets) are legal loop-carried state in the
-    // current block-pointer model.
-    for (unsigned dimension = 0; dimension < rank; ++dimension)
-      indices.push_back(2 * rank + dimension);
-    return indices;
+    // A BlockPtr never crosses a supported loop boundary directly. Its entire
+    // descriptor becomes ordinary loop-carried SSA state.
+    return getAllComponentIndices(value);
   }
 
   FailureOr<SmallVector<unsigned>>
@@ -153,35 +189,25 @@ public:
         !hasValidLayout(next) ||
         initial.originalType != regionArgument.originalType ||
         initial.originalType != next.originalType ||
-        initial.invariants != regionArgument.invariants ||
-        initial.invariants != next.invariants ||
         initial.attributes != regionArgument.attributes ||
         initial.attributes != next.attributes)
       return failure();
 
-    unsigned rank = *getRank(initial.originalType);
-    // The current implementation does not expand shape or stride iter_args.
-    // Reject a loop that changes either instead of silently reconstructing a
-    // descriptor with stale values.
-    for (unsigned index = 0; index < 2 * rank; ++index) {
-      if (initial.components[index].type != next.components[index].type ||
-          initial.components[index].identity != next.components[index].identity)
-        return failure();
-    }
-
-    SmallVector<unsigned> transferred;
-    // An offset is carried only if the backedge state depends on the region
-    // argument. Constant/invariant offsets remain outside the loop signature.
-    for (unsigned dimension = 0; dimension < rank; ++dimension) {
-      unsigned index = 2 * rank + dimension;
+    // Full descriptor transfer permits every field to change, but each
+    // position must retain the strict type required by tt.make_tensor_ptr.
+    // In particular, tt.advance preserving its base does not make the base a
+    // loop invariant: a nested if may rebuild the descriptor from a different
+    // root base, and that if result becomes the next backedge value. A generic
+    // SCF canonicalization may remove exactly forwarded components from an
+    // advance-only loop later; this policy must retain changing-base semantics.
+    for (unsigned index = 0; index < initial.components.size(); ++index) {
       if (failed(joinComponentTypes(initial.components[index].type,
+                                    regionArgument.components[index].type)) ||
+          failed(joinComponentTypes(initial.components[index].type,
                                     next.components[index].type)))
         return failure();
-      if (regionArgument.components[index].identity !=
-          next.components[index].identity)
-        transferred.push_back(index);
     }
-    return transferred;
+    return getAllComponentIndices(initial);
   }
 
   FailureOr<SmallVector<unsigned>>
@@ -189,24 +215,18 @@ public:
                              const AnalyzedValue &elseValue) const override {
     if (!hasValidLayout(thenValue) || !hasValidLayout(elseValue) ||
         thenValue.originalType != elseValue.originalType ||
-        thenValue.invariants != elseValue.invariants ||
-        thenValue.attributes != elseValue.attributes ||
-        thenValue.components.size() != elseValue.components.size())
+        thenValue.attributes != elseValue.attributes)
       return failure();
 
-    // Unlike loops, an if can select shape, stride, or offset components. Base
-    // and order remain invariants because AdapterIR cannot represent a runtime
-    // selection between heterogeneous pointer descriptors.
-    SmallVector<unsigned> transferred;
+    // Both branches yield a complete descriptor even when a field has the same
+    // symbolic identity. This gives every rewritten BlockPtr boundary one
+    // stable positional schema.
     for (unsigned index = 0; index < thenValue.components.size(); ++index) {
       if (failed(joinComponentTypes(thenValue.components[index].type,
                                     elseValue.components[index].type)))
         return failure();
-      if (thenValue.components[index].identity !=
-          elseValue.components[index].identity)
-        transferred.push_back(index);
     }
-    return transferred;
+    return getAllComponentIndices(thenValue);
   }
 
   FailureOr<Type> joinComponentTypes(Type lhs, Type rhs) const override {
@@ -223,6 +243,8 @@ public:
     // flattened descriptor rather than walking through the rebuilt pointer.
     return isa<triton::AdvanceOp>(op);
   }
+
+  bool requiresPointerDescriptorBoundaryMarker() const override { return true; }
 
   FailureOr<DecomposedValue> decompose(Value value,
                                        const ControlFlowRewriteContext &context,
@@ -241,13 +263,17 @@ public:
       // Materialize the concrete counterpart of analyzeValue's descriptor.
       DecomposedValue result;
       result.originalType = value.getType();
+      OpBuilder::InsertionGuard guard(builder);
+      builder.setInsertionPoint(makePtr);
+      Value baseAddress = builder.create<triton::PtrToIntOp>(
+          makePtr.getLoc(), builder.getI64Type(), makePtr.getBase());
+      result.components.push_back(baseAddress);
       result.components.append(makePtr.getShape().begin(),
                                makePtr.getShape().end());
       result.components.append(makePtr.getStrides().begin(),
                                makePtr.getStrides().end());
       result.components.append(makePtr.getOffsets().begin(),
                                makePtr.getOffsets().end());
-      result.invariants.push_back(makePtr.getBase());
       result.attributes.push_back(makePtr.getOrderAttr());
       if (!hasValidLayout(result))
         return failure();
@@ -271,7 +297,7 @@ public:
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPoint(advance);
     for (auto [dim, delta] : llvm::enumerate(advance.getOffsets())) {
-      unsigned component = 2 * *rank + dim;
+      unsigned component = getOffsetStart(*rank) + dim;
       Value currentOffset = result->components[component];
       Value remappedDelta = context.remap(delta);
       if (!remappedDelta)
@@ -295,11 +321,18 @@ public:
       return nullptr;
     unsigned rank = *getRank(value.originalType);
     auto order = cast<DenseI32ArrayAttr>(value.attributes.front());
+    FailureOr<triton::PointerType> basePointerType =
+        getBasePointerType(value.originalType);
+    if (failed(basePointerType) ||
+        value.components[kBaseComponent].getType() != builder.getI64Type())
+      return nullptr;
+    Value base = builder.create<triton::IntToPtrOp>(
+        loc, *basePointerType, value.components[kBaseComponent]);
     return builder.create<triton::MakeTensorPtrOp>(
-        loc, value.originalType, value.invariants.front(),
-        ValueRange(value.components).take_front(rank),
-        ValueRange(value.components).slice(rank, rank),
-        ValueRange(value.components).take_back(rank), order);
+        loc, value.originalType, base,
+        ValueRange(value.components).slice(getShapeStart(), rank),
+        ValueRange(value.components).slice(getStrideStart(rank), rank),
+        ValueRange(value.components).slice(getOffsetStart(rank), rank), order);
   }
 };
 
@@ -308,8 +341,8 @@ public:
 namespace mlir::triton::controlflow {
 
 LogicalResult runBlockPtrDecompose(ModuleOp module) {
-  // Make the explicit descriptor carried by a block pointer cross each
-  // supported SCF boundary as ordinary SSA components.
+  // Expand every BlockPtr that crosses a supported SCF boundary into its full
+  // ordered descriptor, then rebuild the pointer at each use site.
   BlockPtrPolicy policy;
   return rewriteControlFlow(module, policy);
 }

--- a/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowAnalysis.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowAnalysis.cpp
@@ -44,7 +44,7 @@ static bool isSupportedControlFlow(Operation *op) {
 static void setResultIdentity(AnalyzedValue &value, Value result,
                               ArrayRef<unsigned> componentIndices) {
   // A transferred component is represented by the SCF result outside the op;
-  // invariant components retain their incoming symbolic identities.
+  // non-transferred components retain their incoming symbolic identities.
   for (unsigned index : componentIndices)
     value.components[index].identity =
         ComponentIdentity::fromValue(result, index);
@@ -120,8 +120,8 @@ void ControlFlowAnalysisContext::bindRegionArgument(
     Value argument, const AnalyzedValue &initial,
     ArrayRef<unsigned> componentIndices) {
   // Only candidate loop components acquire a new identity at region entry.
-  // Policy-owned invariants and non-carried components remain traceable to the
-  // initial descriptor and can therefore be checked at the backedge.
+  // Policy-owned non-carried components remain traceable to the initial
+  // descriptor and can therefore be checked at the backedge.
   AnalyzedValue argumentState = initial;
   for (unsigned index : componentIndices)
     argumentState.components[index].identity =

--- a/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowRewrite.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowRewrite.cpp
@@ -34,6 +34,8 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 
+#include <cstdint>
+#include <limits>
 #include <optional>
 
 using namespace mlir;
@@ -43,6 +45,7 @@ using mlir::triton::controlflow::ControlFlowRewritePlan;
 using mlir::triton::controlflow::ControlFlowRewritePolicy;
 using mlir::triton::controlflow::ControlFlowSlotAnalysis;
 using mlir::triton::controlflow::DecomposedValue;
+using mlir::triton::controlflow::kPointerDescriptorBoundaryAttr;
 
 namespace mlir::triton::controlflow {
 
@@ -65,7 +68,7 @@ namespace {
 // handlers are mutually recursive through rewriteBodyOps(), share one
 // short-lived RewriteEnv, and must agree on signature expansion, nested-op
 // ordering and failure cleanup. Splitting them by op kind would expose those
-// private invariants through additional internal headers without creating an
+// private constraints through additional internal headers without creating an
 // independently reusable component.
 //
 //===----------------------------------------------------------------------===//
@@ -84,8 +87,8 @@ namespace {
 /// offsets, a region-local environment can contain:
 /// valueMapping:      %old_ptr_arg -> %rebuilt_ptr
 /// decomposedValues:  %old_ptr_arg -> {
-///   components = [%shape0, %stride0, %new_offset0],
-///   invariants = [%base], attributes = [order]
+///   components = [%base, %shape0, %stride0, %new_offset0],
+///   attributes = [order]
 /// }
 /// Operations cloned into that region use the mapping, while pointer
 /// decomposition uses the stored components.
@@ -152,9 +155,9 @@ struct RewriteEnv {
   /// %next = tt.advance %ptr, [%delta0, %delta1]
   ///
   /// decomposeValue(%next) -> DecomposedValue {
-  ///   components = [%shape0, %shape1, %stride0, %stride1,
+  ///   components = [%base, %shape0, %shape1, %stride0, %stride1,
   ///                 %offset0 + %delta0, %offset1 + %delta1],
-  ///   invariants = [%base], attributes = [order]
+  ///   attributes = [order]
   /// }
   /// The caller can put selected components into a new control-flow signature
   /// or pass the whole descriptor to policy.recompose(). Unsupported values
@@ -219,6 +222,60 @@ struct IfPointerInfo {
   std::optional<DecomposedValue> thenInfo;
 };
 
+// Updates the downstream descriptor marker after a loop signature expansion.
+// Existing slots may have been recorded by an earlier pointer policy, so they
+// are remapped through oldToNewStart before the current policy's expanded
+// component slots are merged. The resulting DenseI32ArrayAttr is expressed in
+// the replacement loop's iter-argument/result coordinate space.
+//
+// Example:
+//   old slots = [0], oldToNewStart = [0, 1], new component slots = [1, 2]
+//   result = [0, 1, 2]
+static LogicalResult updatePointerDescriptorBoundaryMarker(
+    Operation *loop, ArrayRef<LoopPointerInfo> pointerInfos,
+    ArrayRef<unsigned> oldToNewStart, const ControlFlowRewritePolicy &policy) {
+  SmallVector<int32_t> descriptorSlots;
+  llvm::SmallDenseSet<unsigned> seenSlots;
+  auto appendSlot = [&](unsigned slot) -> LogicalResult {
+    if (slot > static_cast<unsigned>(std::numeric_limits<int32_t>::max()))
+      return failure();
+    if (!seenSlots.insert(slot).second)
+      return success();
+    descriptorSlots.push_back(static_cast<int32_t>(slot));
+    return success();
+  };
+
+  if (Attribute oldMarker = loop->getAttr(kPointerDescriptorBoundaryAttr)) {
+    auto oldSlots = dyn_cast<DenseI32ArrayAttr>(oldMarker);
+    if (!oldSlots)
+      return failure();
+    for (int32_t oldSlot : oldSlots.asArrayRef()) {
+      if (oldSlot < 0 ||
+          static_cast<unsigned>(oldSlot) >= oldToNewStart.size() ||
+          failed(appendSlot(oldToNewStart[oldSlot])))
+        return failure();
+    }
+  }
+
+  if (policy.requiresPointerDescriptorBoundaryMarker()) {
+    for (const LoopPointerInfo &pointerInfo : pointerInfos) {
+      for (unsigned newSlot : pointerInfo.newIndices) {
+        if (failed(appendSlot(newSlot)))
+          return failure();
+      }
+    }
+  }
+
+  if (descriptorSlots.empty()) {
+    loop->removeAttr(kPointerDescriptorBoundaryAttr);
+    return success();
+  }
+  llvm::sort(descriptorSlots);
+  loop->setAttr(kPointerDescriptorBoundaryAttr,
+                DenseI32ArrayAttr::get(loop->getContext(), descriptorSlots));
+  return success();
+}
+
 // Copies the values selected by indices into a new owning vector while
 // preserving their input order. Indices must be unique and in bounds; this
 // function reports failure instead of deduplicating or accessing invalid input.
@@ -245,9 +302,9 @@ static FailureOr<SmallVector<Value>> gatherValues(ValueRange sourceValues,
 // replacement changes the component type; the input object remains unchanged.
 //
 // Example:
-//   decomposition.components = [shape, stride, originalOffset]
-//   componentIndices = [2], replacements = [nextOffset]
-//   result.components = [shape, stride, nextOffset]
+//   decomposition.components = [base, shape, stride, originalOffset]
+//   componentIndices = [3], replacements = [nextOffset]
+//   result.components = [base, shape, stride, nextOffset]
 static FailureOr<DecomposedValue>
 withReplacedComponents(DecomposedValue decomposition,
                        ArrayRef<unsigned> componentIndices,
@@ -306,10 +363,12 @@ static auto findPointerInfoByOldIndex(InfoRange &pointerInfos,
   return nullptr;
 }
 
-// A replacement loop carries selected scalar or tensor descriptor components
-// instead of the original pointer iter-argument. Operations cloned from the
-// original body still expect one pointer-typed block argument, so this function
-// reconstructs that pointer at the replacement region entry.
+// A replacement loop carries policy-selected scalar or tensor descriptor
+// components instead of the original pointer iter-argument. BlockPtr selects
+// its complete descriptor; TensorPtr currently selects complete offsets only.
+// Operations cloned from the original body still expect one pointer-typed
+// block argument, so this function reconstructs that pointer at the replacement
+// region entry.
 // `pointerInfo.newIndices` selects the current component values from
 // `newRegionArguments`, while
 // `pointerInfo.componentIndices` identifies the descriptor fields that those
@@ -323,17 +382,17 @@ static auto findPointerInfoByOldIndex(InfoRange &pointerInfos,
 //
 // Example:
 //   oldRegionArgument = %old_ptr
-//   newRegionArguments = [%ordinary, %current_offset0, %current_offset1]
-//   pointerInfo.newIndices = [1, 2]
-//   pointerInfo.componentIndices = [4, 5]
+//   newRegionArguments = [%ordinary, %base, %shape, %stride, %offset]
+//   pointerInfo.newIndices = [1, 2, 3, 4]
+//   pointerInfo.componentIndices = [0, 1, 2, 3]
 //   pointerInfo.initInfo.components =
-//       [shape0, shape1, stride0, stride1, initial_offset0, initial_offset1]
+//       [initial_base, initial_shape, initial_stride, initial_offset]
 //
-// The rebuilt descriptor keeps shape and stride, replaces the final two
-// components with the current offsets, and records `%old_ptr -> %rebuilt_ptr`
-// in `regionEnv`. Invalid indices, incompatible component types, or a policy
-// that cannot recompose the descriptor return failure without recording a
-// partial binding; the enclosing loop rewrite owns cleanup of inserted IR.
+// The rebuilt BlockPtr descriptor replaces all four fields with the current
+// loop values and records `%old_ptr -> %rebuilt_ptr` in `regionEnv`. Invalid
+// indices, incompatible component types, or a policy that cannot recompose the
+// descriptor return failure without recording a partial binding; the enclosing
+// loop rewrite owns cleanup of inserted IR.
 static LogicalResult bindLoopCarriedPointer(Value oldRegionArgument,
                                             const LoopPointerInfo &pointerInfo,
                                             ValueRange newRegionArguments,
@@ -416,16 +475,19 @@ static LogicalResult bindLoopRegionArguments(
 // Example:
 //   oldOperands = [%next_ptr, %sum]
 //   pointerInfo = {
-//     oldIndex = 0, componentIndices = [4, 5], newIndices = [0, 1]
+//     oldIndex = 0, componentIndices = [0, 1, 2, 3],
+//     newIndices = [0, 1, 2, 3]
 //   }
-//   currentRegionArguments = [%current_offset0, %current_offset1, %sum_arg]
+//   currentRegionArguments =
+//       [%current_base, %current_shape, %current_stride, %current_offset,
+//        %sum_arg]
 //
 // A valid `%next_ptr` decomposition produces
-// `[%next_offset0, %next_offset1, %mapped_sum]`. If pointer decomposition or
-// component normalization fails, the output instead uses
-// `[%current_offset0, %current_offset1, %mapped_sum]`. The fallback keeps the
-// temporary scf.yield/scf.condition structurally complete until the enclosing
-// failed loop rewrite erases it.
+// `[%next_base, %next_shape, %next_stride, %next_offset, %mapped_sum]`. If
+// pointer decomposition or component normalization fails, the output instead
+// uses the four current descriptor arguments followed by `%mapped_sum`. The
+// fallback keeps the temporary scf.yield/scf.condition structurally complete
+// until the enclosing failed loop rewrite erases it.
 //
 // The output vector is separate from the LogicalResult intentionally. The
 // function visits every old operand and fills all available fallback positions
@@ -484,15 +546,17 @@ static LogicalResult rewriteLoopTerminatorOperands(
 //
 // Example:
 //   oldResults = [%old_sum, %old_ptr, %old_flag]
-//   newResults = [%new_sum, %offset0, %offset1, %new_flag]
+//   newResults =
+//       [%new_sum, %base, %shape, %stride, %offset, %new_flag]
 //   pointerInfo = {
-//     oldIndex = 1, componentIndices = [4, 5], newIndices = [1, 2]
+//     oldIndex = 1, componentIndices = [0, 1, 2, 3],
+//     newIndices = [1, 2, 3, 4]
 //   }
-//   oldToNewStart = [0, 1, 3]
+//   oldToNewStart = [0, 1, 5]
 //
 // The function maps `%old_sum -> %new_sum` and `%old_flag -> %new_flag`. It
-// inserts `%offset0` and `%offset1` into the pointer descriptor, rebuilds
-// `%old_ptr`, and records `%old_ptr -> %rebuilt_ptr` plus that decomposition.
+// inserts all four results into the pointer descriptor, rebuilds `%old_ptr`,
+// and records `%old_ptr -> %rebuilt_ptr` plus that decomposition.
 //
 // The caller must set the builder insertion point after the replacement loop,
 // so any rebuilt pointer dominates later operations. On failure this function
@@ -675,6 +739,12 @@ static LogicalResult rewriteForOp(scf::ForOp forOp, OpBuilder &builder,
         bodyBuilder.create<scf::YieldOp>(yieldOp.getLoc(), newYieldOperands);
       });
   newForOp->setAttrs(forOp->getAttrs());
+  if (analysis->rewritesOwnSignature() &&
+      failed(updatePointerDescriptorBoundaryMarker(
+          newForOp, pointerInfos, oldToNewStart, env.policy))) {
+    newForOp.erase();
+    return failure();
+  }
 
   if (!bodyOk) {
     newForOp.erase();
@@ -797,6 +867,12 @@ static LogicalResult rewriteWhileOp(scf::WhileOp whileOp, OpBuilder &builder,
         bodyBuilder.create<scf::YieldOp>(yieldOp.getLoc(), newYieldOperands);
       });
   newWhileOp->setAttrs(whileOp->getAttrs());
+  if (analysis->rewritesOwnSignature() &&
+      failed(updatePointerDescriptorBoundaryMarker(
+          newWhileOp, pointerInfos, oldToNewStart, env.policy))) {
+    newWhileOp.erase();
+    return failure();
+  }
 
   if (!bodyOk) {
     newWhileOp.erase();

--- a/third_party/ascend/lib/TritonControlFlowOpt/TensorPtrDecompose.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/TensorPtrDecompose.cpp
@@ -34,8 +34,8 @@ using namespace mlir::triton::controlflow;
 
 namespace {
 
-static constexpr unsigned kOffsetsComponent = 0;
-static constexpr unsigned kBaseInvariant = 0;
+static constexpr unsigned kBaseComponent = 0;
+static constexpr unsigned kCompleteOffsetsComponent = 1;
 static constexpr unsigned kBaseIsScalarAttribute = 0;
 
 /// Identifies tensor-of-pointers handled by this stage:
@@ -48,14 +48,13 @@ static bool isTensorPointerType(Type type) {
 
 /// Tensor-pointer state used only by this policy:
 ///
-///   control-flow components = [complete_offsets]
-///   rewrite-only invariants = [common_base]
+///   components = [common_base, complete_offsets]
 ///   attributes = [base_is_scalar]
 ///
-/// Only `components` expand an SCF signature. The common base is deliberately
-/// kept out of iter-args and results; it must be identical at every incoming
-/// edge and is used to rebuild the tensor-of-pointers inside and after the
-/// rewritten control-flow operation.
+/// The complete offsets are the only transfer candidate in this NFC stage.
+/// The common base is now an ordinary component, but it must remain identical
+/// at every incoming edge and therefore stays outside expanded SCF signatures.
+///
 static RankedTensorType getDefaultOffsetsType(Type pointerType) {
   auto pointerTensor = cast<RankedTensorType>(pointerType);
   return RankedTensorType::get(pointerTensor.getShape(),
@@ -64,14 +63,12 @@ static RankedTensorType getDefaultOffsetsType(Type pointerType) {
 }
 
 /// Validates the policy-owned component layout, including the offsets shape
-/// and the representation selected for the invariant base.
-static bool hasValidSchema(Type originalType, Type offsetsType,
-                           ArrayRef<Value> invariants,
+/// and the scalar-or-tensor representation selected for the base component.
+static bool hasValidSchema(Type originalType, Type baseType, Type offsetsType,
                            ArrayRef<Attribute> attributes) {
   auto pointerTensor = dyn_cast<RankedTensorType>(originalType);
   auto offsetsTensor = dyn_cast<RankedTensorType>(offsetsType);
-  if (!pointerTensor || !offsetsTensor || invariants.size() != 1 ||
-      attributes.size() != 1 ||
+  if (!pointerTensor || !offsetsTensor || attributes.size() != 1 ||
       !isa<triton::PointerType>(pointerTensor.getElementType()) ||
       !isa<IntegerType>(offsetsTensor.getElementType()) ||
       pointerTensor.getShape() != offsetsTensor.getShape() ||
@@ -83,33 +80,39 @@ static bool hasValidSchema(Type originalType, Type offsetsType,
     return false;
   Type expectedBaseType =
       baseIsScalar.getValue() ? pointerTensor.getElementType() : originalType;
-  return invariants[kBaseInvariant].getType() == expectedBaseType;
+  return baseType == expectedBaseType;
 }
 
 /// Validates the concrete Value-based state created while rewriting IR.
 static bool hasValidLayout(const DecomposedValue &value) {
-  return value.components.size() == 1 &&
+  return value.components.size() == 2 &&
          hasValidSchema(value.originalType,
-                        value.components[kOffsetsComponent].getType(),
-                        value.invariants, value.attributes);
+                        value.components[kBaseComponent].getType(),
+                        value.components[kCompleteOffsetsComponent].getType(),
+                        value.attributes);
 }
 
 /// Validates the read-only counterpart without materializing component Values.
 static bool hasValidLayout(const AnalyzedValue &value) {
-  return value.components.size() == 1 &&
+  return value.components.size() == 2 &&
          hasValidSchema(value.originalType,
-                        value.components[kOffsetsComponent].type,
-                        value.invariants, value.attributes);
+                        value.components[kBaseComponent].type,
+                        value.components[kCompleteOffsetsComponent].type,
+                        value.attributes);
 }
 
-template <typename StateT>
-static bool haveSameTensorPtrBaseSchema(const StateT &lhs, const StateT &rhs) {
+static bool haveSameTensorPtrBaseSchema(const AnalyzedValue &lhs,
+                                        const AnalyzedValue &rhs) {
   return hasValidLayout(lhs) && hasValidLayout(rhs) &&
          lhs.originalType == rhs.originalType &&
-         lhs.invariants == rhs.invariants && lhs.attributes == rhs.attributes;
+         lhs.components[kBaseComponent].type ==
+             rhs.components[kBaseComponent].type &&
+         lhs.components[kBaseComponent].identity ==
+             rhs.components[kBaseComponent].identity &&
+         lhs.attributes == rhs.attributes;
 }
 
-/// Whether the invariant base must be broadcast before rebuilding addptr.
+/// Whether the scalar base component must be broadcast before rebuilding.
 static bool hasScalarBase(const DecomposedValue &value) {
   return cast<BoolAttr>(value.attributes[kBaseIsScalarAttribute]).getValue();
 }
@@ -206,14 +209,15 @@ public:
       FailureOr<AnalyzedValue> result = context.analyzeValue(addPtr.getPtr());
       if (failed(result) || !hasValidLayout(*result))
         return failure();
-      FailureOr<Type> offsetsType =
-          getWiderOffsetsType(result->components[kOffsetsComponent].type,
-                              addPtr.getOffset().getType());
+      FailureOr<Type> offsetsType = getWiderOffsetsType(
+          result->components[kCompleteOffsetsComponent].type,
+          addPtr.getOffset().getType());
       if (failed(offsetsType))
         return failure();
       result->originalType = value.getType();
-      result->components[kOffsetsComponent] = {
-          *offsetsType, ComponentIdentity::fromValue(value, kOffsetsComponent)};
+      result->components[kCompleteOffsetsComponent] = {
+          *offsetsType,
+          ComponentIdentity::fromValue(value, kCompleteOffsetsComponent)};
       return *result;
     }
 
@@ -223,10 +227,12 @@ public:
       if (!isa<triton::PointerType>(splat.getSrc().getType()))
         return failure();
       Type offsetsType = getDefaultOffsetsType(value.getType());
-      return AnalyzedValue{value.getType(),
-                           {{offsetsType, ComponentIdentity::zero()}},
-                           {splat.getSrc()},
-                           {BoolAttr::get(value.getContext(), true)}};
+      return AnalyzedValue{
+          value.getType(),
+          {{splat.getSrc().getType(),
+            ComponentIdentity::fromValue(splat.getSrc(), kBaseComponent)},
+           {offsetsType, ComponentIdentity::zero(kCompleteOffsetsComponent)}},
+          {BoolAttr::get(value.getContext(), true)}};
     }
 
     // An otherwise opaque tensor-of-pointers is treated as an already-vector
@@ -235,38 +241,40 @@ public:
     if (!matches(value.getType()))
       return failure();
     Type offsetsType = getDefaultOffsetsType(value.getType());
-    return AnalyzedValue{value.getType(),
-                         {{offsetsType, ComponentIdentity::zero()}},
-                         {value},
-                         {BoolAttr::get(value.getContext(), false)}};
+    return AnalyzedValue{
+        value.getType(),
+        {{value.getType(), ComponentIdentity::fromValue(value, kBaseComponent)},
+         {offsetsType, ComponentIdentity::zero(kCompleteOffsetsComponent)}},
+        {BoolAttr::get(value.getContext(), false)}};
   }
 
   /// Tensor pointers have exactly one loop-transfer candidate: the complete
-  /// per-lane offsets tensor at component index 0.
+  /// per-lane offsets tensor at component index 1.
   FailureOr<SmallVector<unsigned>>
   getLoopCandidateComponents(const AnalyzedValue &value) const override {
     if (!hasValidLayout(value))
       return failure();
-    return SmallVector<unsigned>{kOffsetsComponent};
+    return SmallVector<unsigned>{kCompleteOffsetsComponent};
   }
 
   /// Classifies the loop offsets as transferred only when the backedge changes
   /// their symbolic identity. The original pointer type, common base, and base
-  /// representation must remain invariant for reconstruction to be valid.
+  /// representation must remain unchanged for reconstruction to be valid.
   FailureOr<SmallVector<unsigned>>
   getLoopTransferredComponents(const AnalyzedValue &initial,
                                const AnalyzedValue &regionArgument,
                                const AnalyzedValue &next) const override {
     if (!haveSameTensorPtrBaseSchema(initial, regionArgument) ||
         !haveSameTensorPtrBaseSchema(initial, next) ||
-        failed(joinComponentTypes(initial.components[kOffsetsComponent].type,
-                                  next.components[kOffsetsComponent].type)))
+        failed(joinComponentTypes(
+            initial.components[kCompleteOffsetsComponent].type,
+            next.components[kCompleteOffsetsComponent].type)))
       return failure();
     // Yielding the region argument unchanged requires no new SCF iter-arg.
-    if (regionArgument.components[kOffsetsComponent].identity ==
-        next.components[kOffsetsComponent].identity)
+    if (regionArgument.components[kCompleteOffsetsComponent].identity ==
+        next.components[kCompleteOffsetsComponent].identity)
       return SmallVector<unsigned>{};
-    return SmallVector<unsigned>{kOffsetsComponent};
+    return SmallVector<unsigned>{kCompleteOffsetsComponent};
   }
 
   /// Merges the two `scf.if` pointer states. Different complete-offset
@@ -276,15 +284,15 @@ public:
   getIfTransferredComponents(const AnalyzedValue &thenValue,
                              const AnalyzedValue &elseValue) const override {
     if (!haveSameTensorPtrBaseSchema(thenValue, elseValue) ||
-        failed(
-            joinComponentTypes(thenValue.components[kOffsetsComponent].type,
-                               elseValue.components[kOffsetsComponent].type)))
+        failed(joinComponentTypes(
+            thenValue.components[kCompleteOffsetsComponent].type,
+            elseValue.components[kCompleteOffsetsComponent].type)))
       return failure();
-    // Identical symbolic offsets are available outside the if as an invariant.
-    if (thenValue.components[kOffsetsComponent].identity ==
-        elseValue.components[kOffsetsComponent].identity)
+    // Identical symbolic offsets remain available outside the if.
+    if (thenValue.components[kCompleteOffsetsComponent].identity ==
+        elseValue.components[kCompleteOffsetsComponent].identity)
       return SmallVector<unsigned>{};
-    return SmallVector<unsigned>{kOffsetsComponent};
+    return SmallVector<unsigned>{kCompleteOffsetsComponent};
   }
 
   /// Chooses the offsets type carried by the replacement control-flow op.
@@ -301,6 +309,8 @@ public:
   bool shouldDecomposeOperation(Operation *op) const override {
     return isa<triton::AddPtrOp>(op);
   }
+
+  bool requiresPointerDescriptorBoundaryMarker() const override { return true; }
 
   /// Materializes the same decomposition described by analyzeValue. This may
   /// create zero constants and integer additions, so it is called only after
@@ -331,18 +341,19 @@ public:
       // ControlFlowRewrite will use this Value in the expanded SCF signature.
       OpBuilder::InsertionGuard guard(builder);
       builder.setInsertionPoint(addPtr);
-      Value offsets = createOffsetsAdd(builder, addPtr.getLoc(),
-                                       result->components[kOffsetsComponent],
-                                       context.remap(addPtr.getOffset()));
+      Value offsets =
+          createOffsetsAdd(builder, addPtr.getLoc(),
+                           result->components[kCompleteOffsetsComponent],
+                           context.remap(addPtr.getOffset()));
       if (!offsets)
         return failure();
       result->originalType = value.getType();
-      result->components[kOffsetsComponent] = offsets;
+      result->components[kCompleteOffsetsComponent] = offsets;
       return *result;
     }
 
-    // A scalar pointer splat materializes zero offsets while retaining the
-    // scalar source as the common-base invariant.
+    // A scalar pointer splat materializes zero offsets and records the
+    // scalar source as component 0.
     if (auto splat = value.getDefiningOp<triton::SplatOp>()) {
       if (!isa<triton::PointerType>(splat.getSrc().getType()))
         return failure();
@@ -353,13 +364,12 @@ public:
       if (!offsets)
         return failure();
       return DecomposedValue{value.getType(),
-                             {offsets},
-                             {splat.getSrc()},
+                             {splat.getSrc(), offsets},
                              {builder.getBoolAttr(true)}};
     }
 
-    // Fallback for an opaque tensor base: use the entire tensor-of-pointers as
-    // the invariant base and represent only subsequent displacement in offsets.
+    // Fallback for an opaque tensor base: keep the entire tensor-of-pointers
+    // as component 0 and represent subsequent displacement in component 1.
     if (!matches(value.getType()))
       return failure();
 
@@ -373,22 +383,23 @@ public:
     if (!offsets)
       return failure();
     return DecomposedValue{
-        value.getType(), {offsets}, {value}, {builder.getBoolAttr(false)}};
+        value.getType(), {value, offsets}, {builder.getBoolAttr(false)}};
   }
 
-  /// Rebuilds the original tensor-of-pointers from the invariant base and the
+  /// Rebuilds the original tensor-of-pointers from the base component and
   /// complete offsets selected/carried by the rewritten control flow.
   Value recompose(const DecomposedValue &value, OpBuilder &builder,
                   Location loc) const override {
     if (!hasValidLayout(value))
       return nullptr;
-    Value base = value.invariants[kBaseInvariant];
+    Value base = value.components[kBaseComponent];
     // addptr requires matching tensor lanes; broadcast a scalar common base
     // only when the decomposition recorded `base_is_scalar = true`.
     if (hasScalarBase(value))
       base = builder.create<triton::SplatOp>(loc, value.originalType, base);
     return builder.create<triton::AddPtrOp>(
-        loc, value.originalType, base, value.components[kOffsetsComponent]);
+        loc, value.originalType, base,
+        value.components[kCompleteOffsetsComponent]);
   }
 };
 
@@ -400,10 +411,9 @@ namespace mlir::triton::controlflow {
 /// handling. The shared driver analyzes each outermost SCF root, then rewrites
 /// only the complete-offset components selected by this policy.
 LogicalResult runTensorPtrDecompose(ModuleOp module) {
-  // Carry only complete per-lane offsets through SCF. The common scalar base
-  // remains a rewrite invariant and is used to rebuild tensor-of-pointers at
-  // each region boundary. This decomposition is independent of
-  // BlockPtrDecompose.
+  // Carry only complete per-lane offsets through SCF. The base is a
+  // non-carried component used to rebuild tensor-of-pointers at each region
+  // boundary. This decomposition is independent of BlockPtrDecompose.
   // TODO: Replace this local extraction with TritonToUnstructure's common-base
   // analysis. Different or lane-wise bases must become explicit diagnostics
   // instead of pattern misses.

--- a/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
@@ -59,6 +59,25 @@
 namespace mlir {
 namespace triton {
 
+hivm::PointerCastOp createScalarPointerCast(OpBuilder &builder, Location loc,
+                                            MemRefType resultType,
+                                            Value address) {
+  SmallVector<Value> dynamicSizes;
+  if (resultType.getNumDynamicDims() != 0) {
+    Value defaultSize = builder.create<arith::ConstantIndexOp>(loc, 1);
+    dynamicSizes.assign(resultType.getNumDynamicDims(), defaultSize);
+  }
+  return builder.create<hivm::PointerCastOp>(
+      loc, resultType, ValueRange{address}, ValueRange{dynamicSizes});
+}
+
+// Recognize original scalar-pointer producers whose converted result may act
+// as a memref carrier. The parse site still requires BaseMemRefType, so merely
+// appearing in this list never makes an unconverted pointer an opaque source.
+static bool isScalarPointerTransport(Operation *op) {
+  return op && isa<scf::IfOp, scf::ForOp, scf::WhileOp, arith::SelectOp>(op);
+}
+
 // MemAccType selectMaxMemAccTy(const MemAccType &v1, const MemAccType &v2) {
 //   return (v1 > v2) ? v1 : v2;
 // }
@@ -421,8 +440,12 @@ void BlockDataParser::parse(
   //
   if (isa<triton::PointerType>(operand.getType())) {
     // Just consider two state: ptr<scalar> and ptr<tensor<scalar>>
-    auto remappedPtr = rewriter.getRemappedValue(operand);
-    assert(remappedPtr);
+    Value remappedPtr = rewriter.getRemappedValue(operand);
+    if (!remappedPtr) {
+      if (Operation *definingOp = operand.getDefiningOp())
+        definingOp->emitError("scalar pointer has no converted value");
+      return;
+    }
     if (auto op = operand.getDefiningOp()) {
       if (auto addPtrOp = dyn_cast<triton::AddPtrOp>(op)) {
         parseAddPtr(addPtrOp, data, loc, rewriter, known);
@@ -439,11 +462,18 @@ void BlockDataParser::parse(
         data.setSource(remappedPtr);
       } else if (isDistributedTypeCustomOp(op)) {
         data.setSource(remappedPtr);
+      } else if (isScalarPointerTransport(op)) {
+        if (!isa<BaseMemRefType>(remappedPtr.getType())) {
+          op->emitError("scalar pointer transport did not convert to a memref");
+          return;
+        }
+        data.setSource(remappedPtr);
       } else {
-        LLVM_DEBUG({ llvm::dbgs() << operand << "\n"; });
-        llvm_unreachable("Unexpected operand defining operation, a scalar "
-                         "pointer can only be produced by AddPtrOp or direct "
-                         "block ptr or hivm CustomOp");
+        op->emitError() << "unsupported scalar pointer producer '"
+                        << op->getName() << "' with original type "
+                        << operand.getType() << " and converted type "
+                        << remappedPtr.getType();
+        return;
       }
     } else {
       data.setSource(remappedPtr);
@@ -1358,8 +1388,8 @@ void BlockDataParser::rewriteAddPtr(
     auto rtype = cast<triton::PointerType>(intToPtrOp.getResult().getType());
     auto memrefType =
         MemRefType::get({ShapedType::kDynamic}, rtype.getPointeeType());
-    auto hivmPointCastOp = rewriter.create<hivm::PointerCastOp>(
-        intToPtrOp.getLoc(), memrefType, ValueRange{intToPtrOp.getSrc()});
+    auto hivmPointCastOp = createScalarPointerCast(
+        rewriter, intToPtrOp.getLoc(), memrefType, intToPtrOp.getSrc());
     data.setSource(hivmPointCastOp.getResult());
   }
 
@@ -1389,19 +1419,28 @@ void BlockDataParser::rewriteAddPtr(
   rewriter.restoreInsertionPoint(insertPoint);
 }
 
-OpFoldResult
-accumulatePotentialOffsetOnBase(triton::MakeTensorPtrOp op, Value base,
-                                OpFoldResult offset,
-                                ConversionPatternRewriter &rewriter) {
-  if (auto baseRecast = base.getDefiningOp<memref::ReinterpretCastOp>()) {
-    assert(isa<triton::AddPtrOp>(op.getBase().getDefiningOp()) &&
-           "base of MakeTensorPtrOp only comes from native ptr or AddPtrOp");
+static FailureOr<OpFoldResult>
+getBaseMemRefOffset(Value convertedBase, ConversionPatternRewriter &rewriter) {
+  auto memrefType = dyn_cast<MemRefType>(convertedBase.getType());
+  if (!memrefType)
+    return failure();
 
-    return addOpFoldResult(offset, baseRecast.getConstifiedMixedOffset(),
-                           op.getLoc(), rewriter, rewriter.getIndexType());
-  }
+  // Preserve the existing foldable path for a directly converted tt.addptr.
+  // Reinterpret-casting a reinterpret cast does not compose offsets, so the
+  // first cast's absolute offset must be carried into the new descriptor.
+  if (auto baseRecast =
+          convertedBase.getDefiningOp<memref::ReinterpretCastOp>())
+    return baseRecast.getConstifiedMixedOffset();
 
-  return offset;
+  auto stridedLayout = memrefType.getStridesAndOffset();
+  int64_t staticOffset = stridedLayout.second;
+  if (!ShapedType::isDynamic(staticOffset))
+    return OpFoldResult(rewriter.getIndexAttr(staticOffset));
+
+  // A control-flow-carried BlockPtr base uses the canonical identity-layout
+  // memref and therefore has static offset zero. Dynamic hidden offsets are not
+  // valid BlockPtr bases; their displacement belongs in descriptor offsets.
+  return failure();
 }
 
 void BlockDataParser::rewriteCustomOp(
@@ -1419,8 +1458,8 @@ void BlockDataParser::rewriteCustomOp(
       auto rtype = cast<triton::PointerType>(intToPtrOp.getResult().getType());
       auto memrefType =
           MemRefType::get({ShapedType::kDynamic}, rtype.getPointeeType());
-      auto hivmPointCastOp = rewriter.create<hivm::PointerCastOp>(
-          intToPtrOp.getLoc(), memrefType, ValueRange{intToPtrOp.getSrc()});
+      auto hivmPointCastOp = createScalarPointerCast(
+          rewriter, intToPtrOp.getLoc(), memrefType, intToPtrOp.getSrc());
       if (data.getSizesRef().size() == 0) {
         data.getSizesRef().push_back(rewriter.getIndexAttr(1));
         if (data.getScalarRef().isNull()) {
@@ -1488,6 +1527,7 @@ void BlockDataParser::rewriteCustomOp(
 
 // Design for load/store boundary_check.
 memref::ReinterpretCastOp createRedundantOp(triton::MakeTensorPtrOp op,
+                                            OpFoldResult sourceBaseOffset,
                                             ConversionPatternRewriter &rewriter,
                                             BlockData &data) {
   auto loc = op.getLoc();
@@ -1507,10 +1547,10 @@ memref::ReinterpretCastOp createRedundantOp(triton::MakeTensorPtrOp op,
   // dim offset from base is initialized as zero.
   SmallVector<OpFoldResult> curOffsets(op.getOffsets().size(),
                                        rewriter.getIndexAttr(0));
-  // Just accumulate base potential offset
-  curOffsets.front() = accumulatePotentialOffsetOnBase(
-      op, rewriter.getRemappedValue(op.getBase()), curOffsets.front(),
-      rewriter);
+  // Both the full-shape descriptor and the final block descriptor use the
+  // same absolute source offset. Reusing this value avoids both dropping it
+  // across SCF and accidentally composing it twice.
+  curOffsets.front() = sourceBaseOffset;
 
   for (auto offset : curOffsets) {
     data.getOffsetsRef().push_back(offset);
@@ -1532,25 +1572,39 @@ memref::ReinterpretCastOp createRedundantOp(triton::MakeTensorPtrOp op,
   return castOp;
 }
 
-void BlockDataParser::rewriteMakeTensorPtrOp(
-    triton::MakeTensorPtrOp op, Value base, ConversionPatternRewriter &rewriter,
+LogicalResult BlockDataParser::rewriteMakeTensorPtrOp(
+    triton::MakeTensorPtrOp op, Value convertedBase,
+    ConversionPatternRewriter &rewriter,
     llvm::SmallDenseMap<Value, BlockData> &known) {
+  if (!convertedBase || !isa<BaseMemRefType>(convertedBase.getType())) {
+    op.emitOpError("expected the converted base to be a memref descriptor");
+    return failure();
+  }
   Location loc = op.getLoc();
   BlockData data;
 
-  auto orderSize = op.getOrder().size();
-
-  // Handle base is defined by tt.bitcast
+  // Parse the original producer only for semantic information such as a
+  // bitcast element type. The runtime source always comes from the conversion
+  // adaptor so SCF-selected memref descriptors are not bypassed.
   BlockDataParser::parse(op.getBase(), data, loc, rewriter, known);
+  if (!data.hasSource()) {
+    op.emitOpError("failed to resolve the converted scalar base");
+    return failure();
+  }
   if (data.hasResElemTy()) {
-    auto memrefType = dyn_cast<BaseMemRefType>(data.getSourceRef().getType())
-                          .cloneWith(std::nullopt, data.getResElemTyRef());
+    auto sourceType = dyn_cast<BaseMemRefType>(data.getSourceRef().getType());
+    if (!sourceType) {
+      op.emitOpError("bitcast base did not resolve to a memref descriptor");
+      return failure();
+    }
+    auto memrefType =
+        sourceType.cloneWith(std::nullopt, data.getResElemTyRef());
     UnrealizedConversionCastOp castOp =
         rewriter.create<mlir::UnrealizedConversionCastOp>(loc, memrefType,
                                                           data.getSourceRef());
     data.setSource(castOp.getOutputs()[0]);
   } else {
-    data.setSource(rewriter.getRemappedValue(op.getBase()));
+    data.setSource(convertedBase);
   }
 
   data.getOffsetsRef() =
@@ -1571,20 +1625,19 @@ void BlockDataParser::rewriteMakeTensorPtrOp(
     newOffsets.push_back(mulOpFoldResult(offset, stride, loc, rewriter,
                                          rewriter.getIndexType()));
 
-  // 1. Consider that current base ptr may comes from `triton::AddPtrOp`,
-  // which have been converted to `memref::ReinterpretCastOp` with 1D
-  // shape([1,]) by `AddPtrConverter`.
-  // 2. While here would also convert `triton::MakeTensorPtrOp` to
-  // `memref::ReinterpretCastOp`, it will create use-def on double recast
-  // which means offset&size&stride info of first one will be dropped in terms
-  // of memref recast op fold specification.
-  //
-  // Conclusion with above two:
-  // Base of MakeTensorPtrOp has been seen as origin base, so it should
-  // reserve offset of first recast if it exists.
-  // Here extract the offset of first recast and add it to highest dimension
-  newOffsets.front() =
-      accumulatePotentialOffsetOnBase(op, base, newOffsets.front(), rewriter);
+  if (newOffsets.empty()) {
+    op.emitOpError("expected at least one block pointer dimension");
+    return failure();
+  }
+
+  FailureOr<OpFoldResult> sourceBaseOffset =
+      getBaseMemRefOffset(convertedBase, rewriter);
+  if (failed(sourceBaseOffset)) {
+    op.emitOpError("could not extract the converted base offset");
+    return failure();
+  }
+  newOffsets.front() = addOpFoldResult(newOffsets.front(), *sourceBaseOffset,
+                                       loc, rewriter, rewriter.getIndexType());
 
   data.getOffsetsRef().clear();
 
@@ -1610,7 +1663,7 @@ void BlockDataParser::rewriteMakeTensorPtrOp(
 
   // special handling for davinci
   // create redundant reinterpret_cast op for record shape info
-  auto redundantOp = createRedundantOp(op, rewriter, data);
+  auto redundantOp = createRedundantOp(op, *sourceBaseOffset, rewriter, data);
   redundantOp->setAttr("tensor_ptr_full_shape", rewriter.getUnitAttr());
 
   // create reinterpret_cast op for the target block
@@ -1700,6 +1753,8 @@ void BlockDataParser::rewriteMakeTensorPtrOp(
     }
     rewriter.create<func::CallOp>(loc, funcName, dstElemTy, args);
   }
+
+  return success();
 }
 
 void BlockDataParser::rewriteAdvanceOp(
@@ -1967,6 +2022,26 @@ bool isUsedWithCondition(Value v, std::function<bool(OpOperand *)> cond,
   return false;
 }
 
+// A loop-carried value may be consumed through a region argument, through a
+// while after-argument, or only after the loop result. Check every semantic
+// view of the same carried slot so an identity tensor.cast after the loop
+// cannot hide an AddPtr/load/store use from the decomposition decision.
+bool isLoopCarriedValueUsedWithCondition(
+    LoopLikeOpInterface loopOp, unsigned index,
+    const std::function<bool(OpOperand *)> &condition) {
+  if (index >= loopOp.getRegionIterArgs().size() ||
+      index >= loopOp->getNumResults())
+    return false;
+  if (isUsedWithCondition(loopOp.getRegionIterArgs()[index], condition))
+    return true;
+  if (auto whileOp = dyn_cast<scf::WhileOp>(loopOp.getOperation())) {
+    if (index < whileOp.getAfterArguments().size() &&
+        isUsedWithCondition(whileOp.getAfterArguments()[index], condition))
+      return true;
+  }
+  return isUsedWithCondition(loopOp->getResult(index), condition);
+}
+
 // This function is util function for rewriteLoopOp that create value from data.
 // Assume data is structured, and from regionIterArg from LoopLikeOpInterface.
 //
@@ -2030,9 +2105,10 @@ Value createFromData(RankedTensorType resType, const BlockData &data,
   return newRes;
 }
 
-void BlockDataParser::rewriteLoopOp(
-    LoopLikeOpInterface op, ConversionPatternRewriter &rewriter,
-    llvm::SmallDenseMap<Value, BlockData> &known) {
+LogicalResult
+BlockDataParser::rewriteLoopOp(LoopLikeOpInterface op,
+                               ConversionPatternRewriter &rewriter,
+                               llvm::SmallDenseMap<Value, BlockData> &known) {
   SmallVector<Value> newInitArgs;
   SmallVector<int64_t> iterArgIdxMap;
   SmallVector<bool> maskIterArgs;
@@ -2080,7 +2156,7 @@ void BlockDataParser::rewriteLoopOp(
         isa<IntegerType>(cast<TensorType>(arg.getType()).getElementType()) &&
         cast<IntegerType>(cast<TensorType>(arg.getType()).getElementType())
                 .getWidth() != 1 &&
-        isUsedWithCondition(op.getRegionIterArgs()[i], [](OpOperand *use) {
+        isLoopCarriedValueUsedWithCondition(op, i, [](OpOperand *use) {
           auto *user = use->getOwner();
           return isa<triton::AddPtrOp>(user) ||
                  (isa<triton::LoadOp>(user) && use->getOperandNumber() == 1) ||
@@ -2102,7 +2178,7 @@ void BlockDataParser::rewriteLoopOp(
 
     maskIterArgs[i] =
         indexTensor &&
-        isUsedWithCondition(op.getRegionIterArgs()[i], [](OpOperand *use) {
+        isLoopCarriedValueUsedWithCondition(op, i, [](OpOperand *use) {
           auto *user = use->getOwner();
           return (isa<triton::LoadOp>(user) && use->getOperandNumber() == 1) ||
                  (isa<triton::StoreOp>(user) && use->getOperandNumber() == 2);
@@ -2363,21 +2439,19 @@ void BlockDataParser::rewriteLoopOp(
       auto indexTensor =
           isa<RankedTensorType>(resType) &&
           isa<IntegerType>(cast<RankedTensorType>(resType).getElementType()) &&
-          isUsedWithCondition(whileOp.getAfterArguments()[i],
-                              [](OpOperand *use) {
-                                auto *user = use->getOwner();
-                                return isa<triton::AddPtrOp>(user) ||
-                                       (isa<triton::LoadOp>(user) &&
-                                        use->getOperandNumber() == 1) ||
-                                       (isa<triton::StoreOp>(user) &&
-                                        use->getOperandNumber() == 2);
-                              });
+          isLoopCarriedValueUsedWithCondition(whileOp, i, [](OpOperand *use) {
+            auto *user = use->getOwner();
+            return isa<triton::AddPtrOp>(user) ||
+                   (isa<triton::LoadOp>(user) &&
+                    use->getOperandNumber() == 1) ||
+                   (isa<triton::StoreOp>(user) && use->getOperandNumber() == 2);
+          });
       if (indexTensor) {
         indexCnt += 2 * cast<RankedTensorType>(resType).getRank();
         usedForAfterRegionArgs.push_back(false);
         iterArgIdxMapForAfter.push_back(-1);
-        maskIterArgsForAfter[i] = isUsedWithCondition(
-            whileOp.getAfterArguments()[i], [](OpOperand *use) {
+        maskIterArgsForAfter[i] =
+            isLoopCarriedValueUsedWithCondition(whileOp, i, [](OpOperand *use) {
               auto *user = use->getOwner();
               return (isa<triton::LoadOp>(user) &&
                       use->getOperandNumber() == 1) ||
@@ -2435,6 +2509,10 @@ void BlockDataParser::rewriteLoopOp(
                       iterArgIdxMapForAfter, known);
   }
 
+  if (!newOp || newResults.size() != op->getNumResults())
+    return op->emitError(
+        "loop rewrite produced a result list with incompatible arity");
+
   // Copy all attributes from op to newOp
   newOp->setAttrs(op->getAttrs());
   rewriter.replaceOp(op, newResults);
@@ -2456,17 +2534,20 @@ void BlockDataParser::rewriteLoopOp(
                      dyn_cast<triton::MakeTensorPtrOp>(bodyOp)) {
         ConversionPatternRewriter::InsertionGuard guard(rewriter);
         rewriter.setInsertionPoint(makeTensorPtrOp);
-        rewriteMakeTensorPtrOp(
-            makeTensorPtrOp,
-            rewriter.getRemappedValue(makeTensorPtrOp.getBase()), rewriter,
-            known);
+        if (failed(rewriteMakeTensorPtrOp(
+                makeTensorPtrOp,
+                rewriter.getRemappedValue(makeTensorPtrOp.getBase()), rewriter,
+                known)))
+          return failure();
       } else if (auto loopOp = dyn_cast<LoopLikeOpInterface>(bodyOp);
                  loopOp && !loopOp->hasAttr("ExtractedLoadOrStore")) {
         ConversionPatternRewriter::InsertionGuard guard(rewriter);
         rewriter.setInsertionPoint(loopOp);
         // Remove UnhandledLoopOp attr before process
-        loopOp->removeAttr("UnhandledLoopOp");
-        rewriteLoopOp(loopOp, rewriter, known);
+        rewriter.modifyOpInPlace(
+            loopOp, [&]() { loopOp->removeAttr("UnhandledLoopOp"); });
+        if (failed(rewriteLoopOp(loopOp, rewriter, known)))
+          return failure();
       }
     }
   }
@@ -2483,6 +2564,7 @@ void BlockDataParser::rewriteLoopOp(
                                 OpPrintingFlags().printGenericOpForm());
     llvm::dbgs() << "\n";
   });
+  return success();
 }
 
 /// @brief Rewrite the triton::AddPtrOp to handle unstructured memory access.

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -154,10 +154,294 @@ TransposeConverter::matchAndRewrite(triton::TransOp op, OpAdaptor adaptor,
   return success();
 }
 
+bool hasScalarPointerResult(scf::IfOp op) {
+  bool hasPointerResult = false;
+  for (Type resultType : op.getResultTypes()) {
+    auto pointerType = dyn_cast<triton::PointerType>(resultType);
+    if (!pointerType)
+      continue;
+    if (isa<ShapedType>(pointerType.getPointeeType()))
+      return false;
+    hasPointerResult = true;
+  }
+  return hasPointerResult;
+}
+
+bool isScalarPointerSelect(arith::SelectOp op) {
+  auto pointerType = dyn_cast<triton::PointerType>(op.getType());
+  return pointerType && !isa<ShapedType>(pointerType.getPointeeType());
+}
+
+// Convert a scalar Triton pointer type to the canonical memref descriptor used
+// by TritonTypeConverter. It is reconstructed only after a complete byte
+// address has crossed control flow, so it needs no dynamic layout.
+static FailureOr<MemRefType>
+getScalarPointerCarrierType(Type originalType,
+                            const TypeConverter &typeConverter) {
+  auto pointerType = dyn_cast<triton::PointerType>(originalType);
+  if (!pointerType || isa<ShapedType>(pointerType.getPointeeType()))
+    return failure();
+
+  Type convertedType = typeConverter.convertType(originalType);
+  if (!convertedType)
+    return failure();
+  auto memrefType = dyn_cast<MemRefType>(convertedType);
+  if (!memrefType)
+    return failure();
+
+  return memrefType;
+}
+
+static FailureOr<Type>
+getIfResultCarrierType(Type originalType, const TypeConverter &typeConverter) {
+  if (isa<triton::PointerType>(originalType))
+    return IntegerType::get(originalType.getContext(), 64);
+
+  Type convertedType = typeConverter.convertType(originalType);
+  if (!convertedType)
+    return failure();
+  return convertedType;
+}
+
+// Materialize a no-op-compatible memref cast to the common carrier. Returning
+// failure for non-memref or incompatible values prevents the pointer transport
+// pattern from silently changing element, shape, rank, or memory-space types.
+static FailureOr<Value>
+castToMemRefCarrier(Value value, MemRefType carrierType, Location loc,
+                    ConversionPatternRewriter &rewriter) {
+  if (value.getType() == carrierType)
+    return value;
+
+  auto sourceType = dyn_cast<MemRefType>(value.getType());
+  if (!sourceType ||
+      !memref::CastOp::areCastCompatible(sourceType, carrierType))
+    return failure();
+
+  return rewriter.create<memref::CastOp>(loc, carrierType, value).getResult();
+}
+
+// Dialect conversion may adapt a lane-local pointer descriptor such as
+// `memref<1xT, strided<[1], offset: ?>>` to the canonical scalar-pointer
+// carrier `memref<?xT>`. Address materialization must inspect the original
+// descriptor: its dynamic layout offset is part of the represented address and
+// cannot be recovered from the shape-only carrier type.
+//
+// Only unwrap a one-to-one memref materialization that preserves rank, element
+// type, and memory space. Other unrealized casts may represent a real element
+// or address-space conversion and must remain visible to their converters.
+static Value unwrapPointerDescriptorMaterialization(Value value) {
+  auto materialization = value.getDefiningOp<UnrealizedConversionCastOp>();
+  if (!materialization || materialization.getInputs().size() != 1 ||
+      materialization.getOutputs().size() != 1)
+    return value;
+
+  Value source = materialization.getInputs().front();
+  auto sourceType = dyn_cast<MemRefType>(source.getType());
+  auto targetType = dyn_cast<MemRefType>(value.getType());
+  if (!sourceType || !targetType ||
+      sourceType.getRank() != targetType.getRank() ||
+      sourceType.getElementType() != targetType.getElementType() ||
+      sourceType.getMemorySpace() != targetType.getMemorySpace())
+    return value;
+
+  return source;
+}
+
+// Converts a memref descriptor into the complete byte address represented by
+// that descriptor. extract_aligned_pointer_as_index yields the aligned buffer
+// pointer; the descriptor's element offset must therefore be converted to
+// bytes and added explicitly before the address crosses control flow.
+static FailureOr<Value>
+materializePointerAddress(Value value, Location loc,
+                          ConversionPatternRewriter &rewriter) {
+  value = unwrapPointerDescriptorMaterialization(value);
+  auto memrefType = dyn_cast<MemRefType>(value.getType());
+  if (!memrefType)
+    return failure();
+  Type elementType = memrefType.getElementType();
+  if (!elementType.isIntOrFloat())
+    return failure();
+
+  // A canonical scalar PointerCast already stores the complete byte address
+  // that IntToPtr received. Extracting its aligned pointer immediately and
+  // casting it back to i64 is an identity round trip. In current failing
+  // kernels this chain also survives into InjectSync, so folding it keeps a
+  // redundant region-local form out of the backend. Only fold the canonical
+  // one-dimensional carrier; descriptors with a non-zero offset or a non-unit
+  // stride still require the general address materialization below.
+  if (auto pointerCast = value.getDefiningOp<hivm::PointerCastOp>()) {
+    auto [strides, offset] = memrefType.getStridesAndOffset();
+    if (pointerCast.getAddrs().size() == 1 && memrefType.getRank() == 1 &&
+        offset == 0 && strides.size() == 1 && strides.front() == 1) {
+      Value address = pointerCast.getAddrs().front();
+      if (address.getType().isInteger(64))
+        return address;
+      if (address.getType().isIndex())
+        return rewriter
+            .create<arith::IndexCastOp>(loc, rewriter.getI64Type(), address)
+            .getResult();
+    }
+  }
+
+  Value address =
+      rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(loc, value);
+  int64_t staticOffset = memrefType.getStridesAndOffset().second;
+  if (staticOffset != 0) {
+    Value elementOffset;
+    if (ShapedType::isDynamic(staticOffset)) {
+      elementOffset =
+          rewriter.create<memref::ExtractStridedMetadataOp>(loc, value)
+              .getOffset();
+    } else {
+      elementOffset =
+          rewriter.create<arith::ConstantIndexOp>(loc, staticOffset);
+    }
+
+    int64_t elementBytes = (elementType.getIntOrFloatBitWidth() + 7) / 8;
+    if (elementBytes != 1) {
+      Value scale = rewriter.create<arith::ConstantIndexOp>(loc, elementBytes);
+      elementOffset = rewriter.create<arith::MulIOp>(loc, elementOffset, scale);
+    }
+    address = rewriter.create<arith::AddIOp>(loc, address, elementOffset);
+  }
+  return rewriter
+      .create<arith::IndexCastOp>(loc, rewriter.getI64Type(), address)
+      .getResult();
+}
+
+LogicalResult
+IfConverter::matchAndRewrite(scf::IfOp op, OpAdaptor adaptor,
+                             ConversionPatternRewriter &rewriter) const {
+  const TypeConverter *typeConverter = getTypeConverter();
+  if (!typeConverter)
+    return rewriter.notifyMatchFailure(op, "requires a type converter");
+  if (!hasScalarPointerResult(op))
+    return failure();
+
+  SmallVector<Type> convertedResultTypes;
+  convertedResultTypes.reserve(op.getNumResults());
+  for (Type resultType : op.getResultTypes()) {
+    FailureOr<Type> convertedType =
+        getIfResultCarrierType(resultType, *typeConverter);
+    if (failed(convertedType))
+      return rewriter.notifyMatchFailure(op,
+                                         "could not convert an if result type");
+    convertedResultTypes.push_back(*convertedType);
+  }
+
+  auto newIfOp = rewriter.create<scf::IfOp>(op.getLoc(), convertedResultTypes,
+                                            adaptor.getCondition(),
+                                            /*withElseRegion=*/true);
+  newIfOp->setAttrs(op->getAttrs());
+  newIfOp->setAttr(kScalarPointerCarrierBoundaryAttr,
+                   UnitAttr::get(rewriter.getContext()));
+
+  // Move the original regions instead of cloning them. Besides preserving
+  // side effects, this keeps nested operations in the conversion driver's
+  // worklist so their operands are remapped normally.
+  rewriter.eraseBlock(newIfOp.thenBlock());
+  rewriter.eraseBlock(newIfOp.elseBlock());
+  rewriter.inlineRegionBefore(op.getThenRegion(), newIfOp.getThenRegion(),
+                              newIfOp.getThenRegion().end());
+  rewriter.inlineRegionBefore(op.getElseRegion(), newIfOp.getElseRegion(),
+                              newIfOp.getElseRegion().end());
+
+  SmallVector<Value> replacementResults;
+  replacementResults.reserve(op.getNumResults());
+  rewriter.setInsertionPointAfter(newIfOp);
+  for (auto [originalResultType, newResult] :
+       llvm::zip(op.getResultTypes(), newIfOp.getResults())) {
+    if (!isa<triton::PointerType>(originalResultType)) {
+      replacementResults.push_back(newResult);
+      continue;
+    }
+    FailureOr<MemRefType> resultType =
+        getScalarPointerCarrierType(originalResultType, *typeConverter);
+    if (failed(resultType))
+      return rewriter.notifyMatchFailure(
+          op, "could not reconstruct a scalar pointer result");
+    replacementResults.push_back(
+        createScalarPointerCast(rewriter, op.getLoc(), *resultType, newResult)
+            .getResult());
+  }
+  rewriter.replaceOp(op, replacementResults);
+  return success();
+}
+
+LogicalResult PointerSelectConverter::matchAndRewrite(
+    arith::SelectOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+  if (!isScalarPointerSelect(op))
+    return failure();
+
+  const TypeConverter *typeConverter = getTypeConverter();
+  if (!typeConverter)
+    return rewriter.notifyMatchFailure(op, "requires a type converter");
+
+  FailureOr<MemRefType> resultType =
+      getScalarPointerCarrierType(op.getType(), *typeConverter);
+  if (failed(resultType))
+    return rewriter.notifyMatchFailure(
+        op, "could not build a scalar pointer memref carrier");
+
+  FailureOr<Value> trueAddress =
+      materializePointerAddress(adaptor.getTrueValue(), op.getLoc(), rewriter);
+  FailureOr<Value> falseAddress =
+      materializePointerAddress(adaptor.getFalseValue(), op.getLoc(), rewriter);
+  if (failed(trueAddress) || failed(falseAddress))
+    return rewriter.notifyMatchFailure(
+        op, "selected pointer values have no complete integer address");
+
+  auto selectedAddress = rewriter.create<arith::SelectOp>(
+      op.getLoc(), rewriter.getI64Type(), adaptor.getCondition(), *trueAddress,
+      *falseAddress);
+  selectedAddress->setAttrs(op->getAttrs());
+  auto pointerCast = createScalarPointerCast(rewriter, op.getLoc(), *resultType,
+                                             selectedAddress.getResult());
+  rewriter.replaceOp(op, pointerCast.getResult());
+  return success();
+}
+
 LogicalResult
 YieldConverter::matchAndRewrite(scf::YieldOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const {
-  rewriter.replaceOpWithNewOp<scf::YieldOp>(op, adaptor.getOperands());
+  auto parentIf = dyn_cast<scf::IfOp>(op->getParentOp());
+  if (!parentIf || !parentIf->hasAttr(kScalarPointerCarrierBoundaryAttr))
+    return failure();
+
+  SmallVector<Value> convertedOperands(adaptor.getOperands());
+
+  if (parentIf.getNumResults() != convertedOperands.size())
+    return rewriter.notifyMatchFailure(op, "yield/result arity does not match");
+
+  for (auto [index, targetType] : llvm::enumerate(parentIf.getResultTypes())) {
+    Value &operand = convertedOperands[index];
+    if (operand.getType() == targetType)
+      continue;
+
+    if (targetType.isInteger(64) && isa<MemRefType>(operand.getType())) {
+      FailureOr<Value> address =
+          materializePointerAddress(operand, op.getLoc(), rewriter);
+      if (failed(address))
+        return rewriter.notifyMatchFailure(
+            op, "could not materialize a yielded pointer address");
+      operand = *address;
+      continue;
+    }
+    auto targetMemrefType = dyn_cast<MemRefType>(targetType);
+    if (!targetMemrefType)
+      return rewriter.notifyMatchFailure(
+          op, "converted yield operand is incompatible with if result");
+
+    FailureOr<Value> casted =
+        castToMemRefCarrier(operand, targetMemrefType, op.getLoc(), rewriter);
+    if (failed(casted))
+      return rewriter.notifyMatchFailure(
+          op, "converted yield operand is incompatible with if result");
+    operand = *casted;
+  }
+
+  rewriter.replaceOpWithNewOp<scf::YieldOp>(op, convertedOperands);
   return success();
 }
 
@@ -178,9 +462,8 @@ LogicalResult MakeTensorPtrConverter::matchAndRewrite(
     triton::MakeTensorPtrOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
   llvm::SmallDenseMap<Value, BlockData> known;
-  BlockDataParser::rewriteMakeTensorPtrOp(op, adaptor.getBase(), rewriter,
-                                          known);
-  return success();
+  return BlockDataParser::rewriteMakeTensorPtrOp(op, adaptor.getBase(),
+                                                 rewriter, known);
 }
 
 LogicalResult PreciseDivConverter::matchAndRewrite(
@@ -3102,26 +3385,41 @@ DotScaledConverter::matchAndRewrite(triton::DotScaledOp op, OpAdaptor adaptor,
 }
 
 LogicalResult
+IntToPtrConverter::matchAndRewrite(triton::IntToPtrOp op, OpAdaptor adaptor,
+                                   ConversionPatternRewriter &rewriter) const {
+  auto pointerType = dyn_cast<triton::PointerType>(op.getType());
+  if (!pointerType || isa<ShapedType>(pointerType.getPointeeType()))
+    return rewriter.notifyMatchFailure(
+        op, "only scalar pointer reconstruction is supported");
+
+  const TypeConverter *typeConverter = getTypeConverter();
+  if (!typeConverter)
+    return rewriter.notifyMatchFailure(op, "requires a type converter");
+  auto resultType =
+      dyn_cast<MemRefType>(typeConverter->convertType(op.getType()));
+  if (!resultType)
+    return rewriter.notifyMatchFailure(
+        op, "pointer result did not convert to a memref type");
+
+  // Rebuild the memref only after the integer address has crossed control
+  // flow. Selecting an i64 address is a pure SSA operation and avoids the
+  // backend interpreting a memref-valued merge as a GM-to-UB copy.
+  auto pointerCast = createScalarPointerCast(rewriter, op.getLoc(), resultType,
+                                             adaptor.getSrc());
+  rewriter.replaceOp(op, pointerCast.getResult());
+  return success();
+}
+
+LogicalResult
 PtrToIntConverter::matchAndRewrite(triton::PtrToIntOp op, OpAdaptor adaptor,
                                    ConversionPatternRewriter &rewriter) const {
-  auto loc = op.getLoc();
-  Value ptr = adaptor.getSrc();
-
-  if (!mlir::isa<MemRefType>(ptr.getType())) {
+  FailureOr<Value> address =
+      materializePointerAddress(adaptor.getSrc(), op.getLoc(), rewriter);
+  if (failed(address)) {
     return rewriter.notifyMatchFailure(op, "input is not a memref type");
   }
 
-  auto resultType = op.getType();
-
-  // memref.extract_aligned_pointer_as_index is used to obtain the integer
-  // representation of the base address.
-  auto ptrToIndexOp =
-      rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(loc, ptr);
-
-  Value intResult =
-      rewriter.create<arith::IndexCastOp>(loc, resultType, ptrToIndexOp);
-
-  rewriter.replaceOp(op, intResult);
+  rewriter.replaceOp(op, *address);
   return success();
 }
 

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -23,6 +23,7 @@
 
 #include <cstdlib>
 
+#include "TritonControlFlowOpt/ControlFlowRewrite.h"
 #include "TritonToLinalg/BlockPtrAnalysis.h"
 #include "ascend/include/Dialect/TritonAscend/IR/TritonAscendDialect.h"
 #include "ascend/include/TritonToLinalg/ArgMinMaxConverter.h"
@@ -74,7 +75,9 @@
 #include "mlir/Transforms/Passes.h"
 
 #include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/ADT/Twine.h"
@@ -85,6 +88,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <limits>
 #include <optional>
 
 #define DEBUG_TYPE "triton-to-linalg"
@@ -95,6 +99,258 @@ using namespace triton;
 int nd2nzFlag = 0;
 bool compileOn91095Flag = false;
 bool existDotFlag = false;
+
+static bool containsTritonPointer(Type type) {
+  if (isa<triton::PointerType>(type))
+    return true;
+  auto shapedType = dyn_cast<ShapedType>(type);
+  return shapedType && isa<triton::PointerType>(shapedType.getElementType());
+}
+
+static bool hasPointerFreeBoundary(Operation *op) {
+  return llvm::none_of(op->getOperandTypes(), containsTritonPointer) &&
+         llvm::none_of(op->getResultTypes(), containsTritonPointer);
+}
+
+// Adds only the values that can produce one SSA result. Structured control
+// flow is followed by result index so preserving one pointer descriptor does
+// not retain unrelated values yielded by the same operation.
+static LogicalResult
+appendProducerOperands(Value value, SmallVectorImpl<Value> &producerWorklist) {
+  if (auto argument = dyn_cast<BlockArgument>(value)) {
+    Operation *parent = argument.getOwner()->getParentOp();
+    unsigned argumentIndex = argument.getArgNumber();
+    if (auto forOp = dyn_cast_or_null<scf::ForOp>(parent)) {
+      if (argumentIndex == 0)
+        return success();
+      unsigned iterIndex = argumentIndex - 1;
+      if (iterIndex >= forOp.getInitArgs().size())
+        return failure();
+      producerWorklist.push_back(forOp.getInitArgs()[iterIndex]);
+      producerWorklist.push_back(forOp.getYieldedValues()[iterIndex]);
+      return success();
+    }
+    if (auto whileOp = dyn_cast_or_null<scf::WhileOp>(parent)) {
+      if (argumentIndex >= whileOp.getInits().size())
+        return failure();
+      if (argument.getOwner() == whileOp.getBeforeBody()) {
+        producerWorklist.push_back(whileOp.getInits()[argumentIndex]);
+        producerWorklist.push_back(
+            whileOp.getYieldOp().getOperand(argumentIndex));
+        return success();
+      }
+      if (argument.getOwner() == whileOp.getAfterBody()) {
+        producerWorklist.push_back(
+            whileOp.getConditionOp().getArgs()[argumentIndex]);
+        return success();
+      }
+    }
+    return success();
+  }
+
+  Operation *producer = value.getDefiningOp();
+  if (!producer)
+    return success();
+
+  auto result = dyn_cast<OpResult>(value);
+  if (auto forOp = dyn_cast<scf::ForOp>(producer)) {
+    if (!result || result.getResultNumber() >= forOp.getNumResults())
+      return failure();
+    unsigned index = result.getResultNumber();
+    producerWorklist.push_back(forOp.getInitArgs()[index]);
+    producerWorklist.push_back(forOp.getYieldedValues()[index]);
+    return success();
+  }
+  if (auto whileOp = dyn_cast<scf::WhileOp>(producer)) {
+    if (!result || result.getResultNumber() >= whileOp.getNumResults())
+      return failure();
+    unsigned index = result.getResultNumber();
+    producerWorklist.push_back(whileOp.getInits()[index]);
+    producerWorklist.push_back(whileOp.getConditionOp().getArgs()[index]);
+    producerWorklist.push_back(whileOp.getYieldOp().getOperand(index));
+    return success();
+  }
+  if (auto ifOp = dyn_cast<scf::IfOp>(producer)) {
+    if (!result || result.getResultNumber() >= ifOp.getNumResults() ||
+        !ifOp.elseBlock())
+      return failure();
+    unsigned index = result.getResultNumber();
+    producerWorklist.push_back(ifOp.thenYield().getOperand(index));
+    producerWorklist.push_back(ifOp.elseYield().getOperand(index));
+    return success();
+  }
+
+  producerWorklist.append(producer->operand_begin(), producer->operand_end());
+  return success();
+}
+
+// PointerDescriptorBoundary records exactly which loop-carried slots rebuild
+// Triton pointers. Preserve only those init/condition/yield producer chains so
+// MetaUseEraser cannot leave dangling descriptor operands without retaining
+// unrelated accumulators, masks, bounds, or ordinary tensor computations.
+static LogicalResult preservePointerDescriptorComputations(ModuleOp moduleOp) {
+  bool valid = true;
+  moduleOp.walk([&](LoopLikeOpInterface loopOp) {
+    Operation *loop = loopOp.getOperation();
+    auto descriptorSlots = loop->getAttrOfType<DenseI32ArrayAttr>(
+        controlflow::kPointerDescriptorBoundaryAttr);
+    if (!loop->hasAttr(controlflow::kPointerDescriptorBoundaryAttr))
+      return;
+    if (!descriptorSlots) {
+      valid = false;
+      return;
+    }
+
+    loop->removeAttr("MetaUse");
+
+    SmallVector<Value> producerWorklist;
+    auto appendSlotValues = [&](ValueRange values, int32_t slot) {
+      if (slot < 0 || static_cast<unsigned>(slot) >= values.size()) {
+        valid = false;
+        return;
+      }
+      producerWorklist.push_back(values[slot]);
+    };
+
+    auto appendLoopSlotValues = [&](int32_t slot) {
+      if (auto forOp = dyn_cast<scf::ForOp>(loop)) {
+        appendSlotValues(forOp.getInitArgs(), slot);
+        appendSlotValues(forOp.getYieldedValues(), slot);
+        return;
+      }
+      if (auto whileOp = dyn_cast<scf::WhileOp>(loop)) {
+        appendSlotValues(whileOp.getInits(), slot);
+        appendSlotValues(whileOp.getConditionOp().getArgs(), slot);
+        appendSlotValues(whileOp.getYieldOp().getOperands(), slot);
+        return;
+      }
+      valid = false;
+    };
+
+    llvm::SmallDenseSet<int32_t> seenSlots;
+    for (int32_t slot : descriptorSlots.asArrayRef()) {
+      if (!seenSlots.insert(slot).second) {
+        valid = false;
+        continue;
+      }
+      appendLoopSlotValues(slot);
+    }
+
+    // A mixed loop can contain both CFO-expanded descriptor slots and a
+    // pointer slot that was invariant for a later policy. The latter still
+    // belongs to the legacy loop conversion and its producer must survive
+    // MetaUse erasure. Preserve exactly those residual pointer slots, without
+    // adding unrelated tensor/scalar loop state to the descriptor marker.
+    for (auto [slot, type] : llvm::enumerate(loop->getResultTypes())) {
+      if (!containsTritonPointer(type))
+        continue;
+      if (slot > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
+        valid = false;
+        continue;
+      }
+      appendLoopSlotValues(static_cast<int32_t>(slot));
+    }
+
+    llvm::DenseSet<Value> visitedValues;
+
+    while (!producerWorklist.empty()) {
+      Value value = producerWorklist.pop_back_val();
+      if (!value || !visitedValues.insert(value).second)
+        continue;
+      Operation *producer = value.getDefiningOp();
+      if (producer)
+        producer->removeAttr("MetaUse");
+      if (failed(appendProducerOperands(value, producerWorklist)))
+        valid = false;
+    }
+  });
+  return success(valid);
+}
+
+// Recomputes the result layouts of subviews whose source descriptor has been
+// rebased. A memref.subview result layout is derived from both its mixed
+// offsets/strides and its source layout. For example, changing the source from
+// `memref<32xf32, strided<[1], offset: ?>>` to the equivalent rebased
+// `memref<32xf32, strided<[1]>>` changes a zero-offset subview result from a
+// dynamic offset to offset zero. Merely changing the source SSA value leaves
+// the old result type behind and makes SubViewOp verification fail.
+//
+// Subviews may be chained, so every updated result becomes a new worklist
+// source. Rank-reduced subviews retain their existing result shape while their
+// layout is inferred again from the rebased source.
+static LogicalResult propagateRebasedSubviewTypes(Value rebasedSource,
+                                                  IRRewriter &rewriter) {
+  SmallVector<Value> sources{rebasedSource};
+  llvm::SmallPtrSet<Operation *, 8> visited;
+
+  while (!sources.empty()) {
+    Value source = sources.pop_back_val();
+    for (Operation *user : source.getUsers()) {
+      auto subview = dyn_cast<memref::SubViewOp>(user);
+      if (!subview || !visited.insert(user).second)
+        continue;
+
+      auto sourceType = dyn_cast<MemRefType>(subview.getSource().getType());
+      auto oldResultType = dyn_cast<MemRefType>(subview.getResult().getType());
+      if (!sourceType || !oldResultType)
+        return failure();
+
+      Type inferredType;
+      if (sourceType.getRank() == oldResultType.getRank()) {
+        inferredType = memref::SubViewOp::inferResultType(
+            sourceType, subview.getMixedOffsets(), subview.getMixedSizes(),
+            subview.getMixedStrides());
+      } else {
+        inferredType = memref::SubViewOp::inferRankReducedResultType(
+            oldResultType.getShape(), sourceType, subview.getMixedOffsets(),
+            subview.getMixedSizes(), subview.getMixedStrides());
+      }
+
+      auto inferredMemRefType = dyn_cast<MemRefType>(inferredType);
+      if (!inferredMemRefType)
+        return failure();
+      if (inferredMemRefType != oldResultType) {
+        rewriter.modifyOpInPlace(
+            subview, [&] { subview.getResult().setType(inferredMemRefType); });
+      }
+      sources.push_back(subview.getResult());
+    }
+  }
+  return success();
+}
+
+// Returns true when rebasing a descriptor would reach a user whose type
+// contract is owned elsewhere. Only a subview chain ending in direct
+// memref.load/store operations is proven local here. Every other user,
+// including SCF/CFG terminators, function calls/returns and dialect-specific
+// fixed-type operations, conservatively keeps the original descriptor layout.
+static bool reachesLayoutSensitiveBoundary(Value root) {
+  SmallVector<Value> worklist{root};
+  llvm::DenseSet<Value> visited;
+  while (!worklist.empty()) {
+    Value value = worklist.pop_back_val();
+    if (!visited.insert(value).second)
+      continue;
+    for (Operation *user : value.getUsers()) {
+      if (auto subview = dyn_cast<memref::SubViewOp>(user)) {
+        if (subview.getSource() == value) {
+          worklist.push_back(subview.getResult());
+          continue;
+        }
+      }
+      if (auto load = dyn_cast<memref::LoadOp>(user)) {
+        if (load.getMemRef() == value)
+          continue;
+      }
+      if (auto store = dyn_cast<memref::StoreOp>(user)) {
+        if (store.getMemRef() == value)
+          continue;
+      }
+      return true;
+    }
+  }
+  return false;
+}
 
 // Convert structured custom ops after operand type converted,
 // for example tt.ptr converted to memref.
@@ -563,35 +819,58 @@ void TritonToLinalgPass::addDynamicLegal(
     return true;
   });
 
-  target.addDynamicallyLegalOp<scf::ForOp, scf::YieldOp>([](Operation *op) {
+  target.addDynamicallyLegalOp<scf::IfOp>(
+      [](scf::IfOp op) { return !TTOpConverters::hasScalarPointerResult(op); });
+
+  auto controlFlowTerminatorLegal = [](Operation *op) {
+    Operation *parent = op->getParentOp();
+    if (parent &&
+        parent->hasAttr(TTOpConverters::kScalarPointerCarrierBoundaryAttr)) {
+      auto parentIf = cast<scf::IfOp>(parent);
+      return llvm::equal(op->getOperandTypes(), parentIf.getResultTypes());
+    }
+
+    if (parent && parent->hasAttr(controlflow::kPointerDescriptorBoundaryAttr))
+      return hasPointerFreeBoundary(op);
+
     return llvm::all_of(op->getOperandTypes(), [](Type t) {
-      if (isa<triton::PointerType>(t)) {
+      if (isa<triton::PointerType>(t))
         return false;
-      }
-      if (auto shapedType = dyn_cast<ShapedType>(t)) {
+      if (auto shapedType = dyn_cast<ShapedType>(t))
         return shapedType.getElementType().isIntOrFloat();
-      }
       assert(t.isIntOrIndexOrFloat());
       return true;
     });
-  });
+  };
+
+  target.addDynamicallyLegalOp<scf::YieldOp, scf::ConditionOp>(
+      controlFlowTerminatorLegal);
+
+  auto isArithOrMathOpLegal = [this](Operation *op) {
+    if (op->hasAttr("MetaUse"))
+      return false;
+
+    if (isa<arith::ConstantOp>(op))
+      return true;
+
+    bool operateOnTensors = llvm::all_of(op->getOperandTypes(), [](Type type) {
+      return isa<RankedTensorType>(type);
+    });
+
+    return this->namedOps || !operateOnTensors;
+  };
+
+  // Numeric selects retain the existing Arith legality. Every scalar-pointer
+  // select uses the integer-address converter so no memref object crosses it.
+  target.addDynamicallyLegalOp<arith::SelectOp>(
+      [isArithOrMathOpLegal](arith::SelectOp op) {
+        if (TTOpConverters::isScalarPointerSelect(op))
+          return false;
+        return isArithOrMathOpLegal(op);
+      });
 
   target.addDynamicallyLegalDialect<arith::ArithDialect, math::MathDialect>(
-      [this](Operation *op) {
-        if (op->hasAttr("MetaUse")) {
-          return false;
-        }
-
-        if (isa<arith::ConstantOp>(op)) {
-          return true;
-        }
-
-        bool operateOnTensors =
-            llvm::all_of(op->getOperandTypes(),
-                         [](Type type) { return isa<RankedTensorType>(type); });
-
-        return this->namedOps || !operateOnTensors;
-      });
+      isArithOrMathOpLegal);
 }
 
 void TritonToLinalgPass::populateTritonToLinalgCanonicalizationPatterns(
@@ -710,11 +989,16 @@ void TritonToLinalgPass::populateTritonToLinalgConversionPatterns(
   patterns.add<TTOpConverters::JoinConverter>(patterns.getContext());
   patterns.add<TTOpConverters::CatConverter>(patterns.getContext());
   patterns.add<TTOpConverters::BitcastConverter>(patterns.getContext());
-  patterns.add<TTOpConverters::LoopConverter<scf::ForOp>>(
-      patterns.getContext());
+  patterns.add<TTOpConverters::LoopConverter<scf::ForOp>>(patterns.getContext(),
+                                                          PatternBenefit(2));
   patterns.add<TTOpConverters::LoopConverter<scf::WhileOp>>(
-      patterns.getContext());
-  patterns.add<TTOpConverters::YieldConverter>(patterns.getContext());
+      patterns.getContext(), PatternBenefit(2));
+  patterns.add<TTOpConverters::YieldConverter>(patterns.getContext(),
+                                               PatternBenefit(2));
+  patterns.add<TTOpConverters::IfConverter>(
+      typeConverter, patterns.getContext(), PatternBenefit(2));
+  patterns.add<TTOpConverters::PointerSelectConverter>(typeConverter,
+                                                       patterns.getContext());
 
   patterns.add<TTOpConverters::DeviceAssertConverter>(patterns.getContext());
   patterns.add<TTOpConverters::DevicePrintConverter>(patterns.getContext());
@@ -722,6 +1006,8 @@ void TritonToLinalgPass::populateTritonToLinalgConversionPatterns(
   patterns.add<TTOpConverters::DotConverter>(patterns.getContext());
   patterns.add<TTOpConverters::DotScaledConverter>(patterns.getContext());
   patterns.add<TTOpConverters::PtrToIntConverter>(patterns.getContext());
+  patterns.add<TTOpConverters::IntToPtrConverter>(typeConverter,
+                                                  patterns.getContext());
 
   patterns.add<TTOpConverters::IndirectLoadConverter>(patterns.getContext());
   patterns.add<TTOpConverters::StrideLoadConverter>(patterns.getContext());
@@ -1043,6 +1329,12 @@ void TritonToLinalgPass::runOnOperation() {
     }
   });
 
+  if (failed(preservePointerDescriptorComputations(moduleOp))) {
+    moduleOp->emitError("invalid PointerDescriptorBoundary slot metadata");
+    signalPassFailure();
+    return;
+  }
+
   RewritePatternSet patterns(&getContext());
   ConversionTarget target(getContext());
   TritonTypeConverter tritonTypeConverter{};
@@ -1051,8 +1343,11 @@ void TritonToLinalgPass::runOnOperation() {
   this->addDynamicLegal(target, tritonTypeConverter);
 
   // 4. Mark ops that must be converted explicitly (e.g. tt.scan).
-  auto loopOpLegalFn = [](LoopLikeOpInterface op) {
-    return !op.getOperation()->hasAttr("UnhandledLoopOp");
+  auto loopOpLegalFn = [](LoopLikeOpInterface loopOp) {
+    Operation *op = loopOp.getOperation();
+    if (op->hasAttr(controlflow::kPointerDescriptorBoundaryAttr))
+      return hasPointerFreeBoundary(op);
+    return !op->hasAttr("UnhandledLoopOp");
   };
 
   target.addIllegalOp<triton::ScanOp>();
@@ -1076,8 +1371,20 @@ void TritonToLinalgPass::runOnOperation() {
 
   moduleOp.walk([this](LoopLikeOpInterface loopOp) {
     auto *op = loopOp.getOperation();
-    if (!op->hasAttr("ExtractedLoadOrStore"))
+    // A marker identifies the slots already expanded by CFO. Skip the legacy
+    // loop rewrite only when that expansion made the complete boundary
+    // pointer-free. A mixed loop may still contain an invariant pointer slot;
+    // the legacy converter must process that remaining slot without losing the
+    // marker's precise producer-preservation roots.
+    bool hasPointerDescriptorSlots =
+        op->hasAttr(mlir::triton::controlflow::kPointerDescriptorBoundaryAttr);
+    bool hasCompletePointerFreeBoundary =
+        hasPointerDescriptorSlots && hasPointerFreeBoundary(op);
+    if (!op->hasAttr("ExtractedLoadOrStore") && !hasCompletePointerFreeBoundary)
       op->setAttr("UnhandledLoopOp", UnitAttr::get(op->getContext()));
+
+    if (hasCompletePointerFreeBoundary)
+      return;
 
     for (auto res : loopOp->getResults()) {
       if (auto tensorType = dyn_cast<RankedTensorType>(res.getType());
@@ -1093,7 +1400,18 @@ void TritonToLinalgPass::runOnOperation() {
   });
 
   // 7. Convert ops.
-  if (failed(applyPartialConversion(moduleOp, target, std::move(patterns)))) {
+  LogicalResult conversionResult =
+      applyPartialConversion(moduleOp, target, std::move(patterns));
+
+  // The marker is a contract between CFO and this conversion pass; no
+  // downstream dialect should observe this implementation detail.
+  moduleOp.walk([](LoopLikeOpInterface loopOp) {
+    loopOp->removeAttr(controlflow::kPointerDescriptorBoundaryAttr);
+  });
+  moduleOp.walk([](scf::IfOp ifOp) {
+    ifOp->removeAttr(TTOpConverters::kScalarPointerCarrierBoundaryAttr);
+  });
+  if (failed(conversionResult)) {
     moduleOp->emitError("failed to apply Conversion Patterns");
     signalPassFailure();
   }
@@ -1141,34 +1459,31 @@ void TritonToLinalgPass::runOnOperation() {
   moduleOp.walk([&](hivm::PointerCastOp op) { castOps.push_back(op); });
 
   for (auto op : castOps) {
-    SmallVector<Operation *> userOps(op->getUsers().begin(),
-                                     op->getUsers().end());
+    SmallVector<memref::ReinterpretCastOp> reinterpretCastOps;
+    for (Operation *user : op->getUsers()) {
+      if (auto reinterpretCast = dyn_cast<memref::ReinterpretCastOp>(user))
+        reinterpretCastOps.push_back(reinterpretCast);
+    }
+    if (reinterpretCastOps.empty())
+      continue;
+
     IRRewriter rewriter(&getContext());
     rewriter.setInsertionPointAfter(op);
     Value addr = op.getAddrs()[0];
     auto elementType =
         cast<MemRefType>(op.getResult().getType()).getElementType();
-    Value elementTypeSize;
-    if (auto intType = dyn_cast<IntegerType>(elementType)) {
-      elementTypeSize = rewriter.create<arith::ConstantOp>(
-          op.getLoc(),
-          rewriter.getIntegerAttr(addr.getType(), intType.getWidth() / 8));
-    } else if (auto floatType = dyn_cast<FloatType>(elementType)) {
-      elementTypeSize = rewriter.create<arith::ConstantOp>(
-          op.getLoc(),
-          rewriter.getIntegerAttr(addr.getType(), floatType.getWidth() / 8));
-    } else {
-      llvm_unreachable("Cannot get memory size");
-    }
 
-    for (auto userOp : userOps) {
-      auto reinterpretCastOp = cast<memref::ReinterpretCastOp>(userOp);
+    for (memref::ReinterpretCastOp reinterpretCastOp : reinterpretCastOps) {
       auto sizes = reinterpretCastOp.getStaticSizes();
       auto staticStrides = reinterpretCastOp.getStaticStrides();
       auto strides = reinterpretCastOp.getStrides();
-      if (reinterpretCastOp.getStaticOffsets().size() != 1)
-        userOp->emitError("IntToPtrOp must converted to PointerCastOp of "
-                          "memref<?xdtype> type");
+      if (reinterpretCastOp.getStaticOffsets().size() != 1) {
+        reinterpretCastOp->emitError(
+            "IntToPtrOp must converted to PointerCastOp of "
+            "memref<?xdtype> type");
+        signalPassFailure();
+        return;
+      }
       int64_t castOpSize = 0;
       SmallVector<int64_t> dynamicSizes;
       for (const auto &[size, stride] : llvm::zip_equal(sizes, staticStrides)) {
@@ -1190,53 +1505,108 @@ void TritonToLinalgPass::runOnOperation() {
         dynamicSize =
             rewriter.create<arith::AddIOp>(op.getLoc(), dynamicSize, axisSize);
       }
-      Value offsetValue;
+      Value offsetElements;
       auto staticOffset = reinterpretCastOp.getStaticOffsets()[0];
       if (ShapedType::isDynamic(staticOffset)) {
-        offsetValue = reinterpretCastOp.getOffsets()[0];
-        if (offsetValue.getType() != addr.getType())
-          offsetValue = rewriter.create<arith::IndexCastOp>(
-              op.getLoc(), addr.getType(), offsetValue);
+        offsetElements = reinterpretCastOp.getOffsets()[0];
       } else {
-        offsetValue = rewriter.create<arith::ConstantOp>(
-            op.getLoc(), rewriter.getIntegerAttr(addr.getType(), staticOffset));
+        offsetElements =
+            rewriter.create<arith::ConstantIndexOp>(op.getLoc(), staticOffset);
+      }
+
+      auto memrefType = MemRefType::get({ShapedType::kDynamic}, elementType);
+      auto createPointerCast = [&](Value address, Value capacity) {
+        auto cast = rewriter.create<hivm::PointerCastOp>(
+            op.getLoc(), memrefType, address, capacity);
+        auto mark =
+            rewriter.create<annotation::MarkOp>(op.getLoc(), cast.getResult());
+        mark->setAttr(hivm::AddressSpaceAttr::getMnemonic(),
+                      {hivm::AddressSpaceAttr::get(rewriter.getContext(),
+                                                   hivm::AddressSpace::GM)});
+        return cast;
+      };
+
+      if (reachesLayoutSensitiveBoundary(reinterpretCastOp.getResult())) {
+        // Keep the original descriptor type and offset at externally typed
+        // boundaries. Because the PointerCast still starts at the old base,
+        // its element capacity must cover both the leading offset and view.
+        Value pointerCapacity = dynamicSize;
+        if (offsetElements.getType() != pointerCapacity.getType())
+          offsetElements = rewriter.create<arith::IndexCastOp>(
+              op.getLoc(), pointerCapacity.getType(), offsetElements);
+        Value leadingExtent = offsetElements;
+        if (ShapedType::isDynamic(staticOffset)) {
+          Value zero = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
+          leadingExtent = rewriter.create<arith::MaxSIOp>(op.getLoc(),
+                                                          offsetElements, zero);
+        }
+        if (ShapedType::isDynamic(staticOffset) || staticOffset > 0)
+          pointerCapacity = rewriter.create<arith::AddIOp>(
+              op.getLoc(), pointerCapacity, leadingExtent);
+        auto newCastOp = createPointerCast(addr, pointerCapacity);
+        rewriter.modifyOpInPlace(reinterpretCastOp, [&] {
+          reinterpretCastOp.getSourceMutable().assign(newCastOp.getResult());
+        });
+        continue;
+      }
+
+      Value offsetValue = offsetElements;
+      if (offsetValue.getType() != addr.getType())
+        offsetValue = rewriter.create<arith::IndexCastOp>(
+            op.getLoc(), addr.getType(), offsetValue);
+      Value elementTypeSize;
+      if (auto intType = dyn_cast<IntegerType>(elementType)) {
+        elementTypeSize = rewriter.create<arith::ConstantOp>(
+            op.getLoc(),
+            rewriter.getIntegerAttr(addr.getType(), intType.getWidth() / 8));
+      } else if (auto floatType = dyn_cast<FloatType>(elementType)) {
+        elementTypeSize = rewriter.create<arith::ConstantOp>(
+            op.getLoc(),
+            rewriter.getIntegerAttr(addr.getType(), floatType.getWidth() / 8));
+      } else {
+        llvm_unreachable("Cannot get memory size");
       }
       offsetValue = rewriter.create<arith::MulIOp>(op.getLoc(), offsetValue,
                                                    elementTypeSize);
       Value realAddr =
           rewriter.create<arith::AddIOp>(op.getLoc(), addr, offsetValue);
-      auto memrefType = MemRefType::get({ShapedType::kDynamic}, elementType);
-      auto newCastOp = rewriter.create<hivm::PointerCastOp>(
-          op.getLoc(), memrefType, realAddr, dynamicSize);
-      auto markOp = rewriter.create<annotation::MarkOp>(op.getLoc(),
-                                                        newCastOp.getResult());
-      markOp->setAttr(hivm::AddressSpaceAttr::getMnemonic(),
-                      {hivm::AddressSpaceAttr::get(rewriter.getContext(),
-                                                   hivm::AddressSpace::GM)});
-
-      // update result offset
-      auto origResultType =
+      auto newCastOp = createPointerCast(realAddr, dynamicSize);
+      // realAddr already includes the old reinterpret-cast offset in bytes.
+      // The replacement view therefore starts at offset zero, and its result
+      // type must describe the same rebased layout. Reusing the old type here
+      // would combine static_offsets=[0] with (for example) a type-level
+      // offset of 1, which is rejected by the ReinterpretCast verifier.
+      auto oldResultType =
           cast<MemRefType>(reinterpretCastOp.getResult().getType());
-      MemRefType newResultType = origResultType;
-      if (auto stridedLayout =
-              dyn_cast<StridedLayoutAttr>(origResultType.getLayout())) {
-        int64_t offset = stridedLayout.getOffset();
-        if (!ShapedType::isDynamic(offset)) {
-          auto newLayout = StridedLayoutAttr::get(rewriter.getContext(), 0,
-                                                  stridedLayout.getStrides());
-          newResultType = MemRefType::get(
-              origResultType.getShape(), origResultType.getElementType(),
-              newLayout, origResultType.getMemorySpace());
-        }
-      }
+      SmallVector<int64_t> rebasedStrides(
+          oldResultType.getStridesAndOffset().first);
+      auto rebasedResultType = MemRefType::get(
+          oldResultType.getShape(), oldResultType.getElementType(),
+          StridedLayoutAttr::get(oldResultType.getContext(), /*offset=*/0,
+                                 rebasedStrides),
+          oldResultType.getMemorySpace());
 
-      rewriter.replaceOpWithNewOp<memref::ReinterpretCastOp>(
-          reinterpretCastOp, newResultType, newCastOp, ValueRange({}),
-          reinterpretCastOp.getSizes(), reinterpretCastOp.getStrides(),
-          SmallVector<int64_t>({0}), reinterpretCastOp.getStaticSizes(),
-          reinterpretCastOp.getStaticStrides());
+      // Keep the old result and replacement types equal while RAUW updates all
+      // users to the rebased descriptor type.
+      rewriter.modifyOpInPlace(reinterpretCastOp, [&] {
+        reinterpretCastOp.getResult().setType(rebasedResultType);
+      });
+      auto rebasedReinterpretCast =
+          rewriter.replaceOpWithNewOp<memref::ReinterpretCastOp>(
+              reinterpretCastOp, rebasedResultType, newCastOp, ValueRange({}),
+              reinterpretCastOp.getSizes(), reinterpretCastOp.getStrides(),
+              SmallVector<int64_t>({0}), reinterpretCastOp.getStaticSizes(),
+              reinterpretCastOp.getStaticStrides());
+      if (failed(propagateRebasedSubviewTypes(
+              rebasedReinterpretCast.getResult(), rewriter))) {
+        rebasedReinterpretCast.emitError(
+            "failed to propagate rebased layout through subview users");
+        signalPassFailure();
+        return;
+      }
     }
-    rewriter.eraseOp(op);
+    if (op->use_empty())
+      rewriter.eraseOp(op);
   }
 
   // Try interleave optimization

--- a/third_party/ascend/lib/TritonToUnstructure/BubbleUpOperation.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/BubbleUpOperation.cpp
@@ -87,6 +87,8 @@ BubbleUpExtract<ExtractOpTy>::matchAndRewrite(ExtractOpTy op,
     bubbleUpIntBinaryOp(op, orIOp, loc, rewriter);
   } else if (auto cmpIOp = dyn_cast<arith::CmpIOp>(parentOp)) {
     bubbleUpOperation(op, cmpIOp, loc, rewriter);
+  } else if (auto selectOp = dyn_cast<arith::SelectOp>(parentOp)) {
+    bubbleUpOperation(op, selectOp, loc, rewriter);
   } else if (auto truncFOp = dyn_cast<arith::TruncFOp>(parentOp)) {
     bubbleUpOperation(op, truncFOp, loc, rewriter);
   } else if (auto extFOp = dyn_cast<arith::ExtFOp>(parentOp)) {
@@ -217,6 +219,20 @@ void BubbleUpExtract<ExtractOpTy>::bubbleUpOperation(
   auto rhs = createExtractOp(op, parentOp.getRhs(), loc, rewriter);
   rewriter.replaceOpWithNewOp<arith::CmpIOp>(op, parentOp.getPredicateAttr(),
                                              lhs, rhs);
+}
+
+template <typename ExtractOpTy>
+void BubbleUpExtract<ExtractOpTy>::bubbleUpOperation(
+    ExtractOpTy op, arith::SelectOp parentOp, Location loc,
+    PatternRewriter &rewriter) const {
+  Value condition = parentOp.getCondition();
+  if (isa<ShapedType>(condition.getType()))
+    condition = createExtractOp(op, condition, loc, rewriter);
+  Value trueValue = createExtractOp(op, parentOp.getTrueValue(), loc, rewriter);
+  Value falseValue =
+      createExtractOp(op, parentOp.getFalseValue(), loc, rewriter);
+  rewriter.replaceOpWithNewOp<arith::SelectOp>(op, condition, trueValue,
+                                               falseValue);
 }
 
 template <>

--- a/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
@@ -207,6 +207,46 @@ PtrOffsetInfo combineInfo(const PtrOffsetInfo &lhs, const PtrOffsetInfo &rhs) {
   return info;
 }
 
+namespace {
+
+bool isScalarPointer(Value value) {
+  auto pointerType = dyn_cast<triton::PointerType>(value.getType());
+  return pointerType && !isa<ShapedType>(pointerType.getPointeeType());
+}
+
+bool isTensorPointer(Value value) {
+  auto tensorType = dyn_cast<RankedTensorType>(value.getType());
+  return tensorType && isa<triton::PointerType>(tensorType.getElementType());
+}
+
+// A scalar pointer selected or carried by structured control flow is already a
+// complete runtime address. Recording the SSA value itself as the source avoids
+// choosing one incoming source and losing the other branch or loop iteration.
+// Later addptr users can still accumulate a separate offset from this address.
+void recordOpaqueScalarPointer(
+    Value pointer, llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+  offsetMap[pointer] = PtrOffsetInfo();
+  offsetMap[pointer].setPtr(pointer);
+  offsetMap[pointer].setZeroOffset();
+  offsetMap[pointer].setScalarLike(true);
+}
+
+// A per-lane tensor-pointer select may choose a different source for every
+// element, so it cannot be represented by one incoming base plus a structured
+// offset. Preserve the selected pointer tensor itself as the complete opaque
+// base and attach a zero displacement. Later addptr parsing can accumulate an
+// additional offset without discarding the select's lane-wise source choice.
+void recordOpaqueTensorPointer(
+    Value pointerTensor, llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+  auto tensorType = cast<RankedTensorType>(pointerTensor.getType());
+  offsetMap[pointerTensor] = PtrOffsetInfo();
+  offsetMap[pointerTensor].setPtr(pointerTensor);
+  offsetMap[pointerTensor].setZeroOffset();
+  offsetMap[pointerTensor].setUnstructured(tensorType.getRank());
+}
+
+} // namespace
+
 void parse(Value operand, const Location &loc, RewriterBase &rewriter,
            llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
   if (offsetMap.contains(operand)) {
@@ -296,6 +336,11 @@ void parseLoopRegionIterArg(LoopLikeOpInterface loopOp, const Location &loc,
                             RewriterBase &rewriter,
                             llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap,
                             BlockArgument regionIterArg) {
+  if (isScalarPointer(regionIterArg)) {
+    recordOpaqueScalarPointer(regionIterArg, offsetMap);
+    return;
+  }
+
   if (auto whileOp = dyn_cast<scf::WhileOp>(loopOp.getOperation());
       whileOp && whileOp.getAfterBody() == regionIterArg.getOwner()) {
     auto argNum = regionIterArg.getArgNumber();
@@ -787,6 +832,16 @@ void parseClampF(triton::ClampFOp op, const Location &loc,
 void parseSelect(arith::SelectOp op, const Location &loc,
                  RewriterBase &rewriter,
                  llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+  if (isScalarPointer(op.getResult())) {
+    recordOpaqueScalarPointer(op.getResult(), offsetMap);
+    return;
+  }
+
+  if (isTensorPointer(op.getResult())) {
+    recordOpaqueTensorPointer(op.getResult(), offsetMap);
+    return;
+  }
+
   // Get select condition
   auto condition = op.getCondition();
   parse(condition, op.getLoc(), rewriter, offsetMap);
@@ -967,6 +1022,11 @@ void parseReduceReturn(triton::ReduceReturnOp op, const Location &loc,
 
 void parseIf(scf::IfOp op, const Location &loc, RewriterBase &rewriter,
              llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap, Value dst) {
+  if (isScalarPointer(dst)) {
+    recordOpaqueScalarPointer(dst, offsetMap);
+    return;
+  }
+
   const unsigned int index = cast<OpResult>(dst).getResultNumber();
   // Get if then region
   Block &thenBlock = op.getThenRegion().front();
@@ -1022,6 +1082,11 @@ void parseYield(scf::YieldOp op, const Location &loc, RewriterBase &rewriter,
 void parseLoopOp(LoopLikeOpInterface op, const Location &loc,
                  RewriterBase &rewriter,
                  llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap, Value dst) {
+  if (isScalarPointer(dst)) {
+    recordOpaqueScalarPointer(dst, offsetMap);
+    return;
+  }
+
   auto resNum = cast<OpResult>(dst).getResultNumber();
   Value yieldedValue = nullptr;
   if (auto whileOp = dyn_cast<scf::WhileOp>(op.getOperation())) {

--- a/third_party/ascend/lib/TritonToUnstructure/ReplaceArguments.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/ReplaceArguments.cpp
@@ -50,6 +50,11 @@ void replaceOperands(MutableArrayRef<OpOperand> oprs, RewriterBase &rewriter,
         }
         --it;
       } else {
+        // source == operand marks a complete scalar address whose source may be
+        // selected or loop-carried at runtime. Keep it as a pointer instead of
+        // replacing it with an offset relative to one statically chosen base.
+        if (offsetMap.at(operand).getPtr() == operand)
+          continue;
         opr.set(offsetMap.at(operand).getOffset());
       }
     }
@@ -82,6 +87,11 @@ void replaceArgs(ValueRange args, RewriterBase &rewriter,
       rewriter.replaceOpWithNewOp<triton::AddPtrOp>(
           tempVar.getDefiningOp(), tempVar.getType(), src, arg);
     } else if (auto ptrType = dyn_cast<triton::PointerType>(arg.getType())) {
+      parse(arg, arg.getLoc(), rewriter, offsetMap);
+      if (!isa<RankedTensorType>(ptrType.getPointeeType()) &&
+          offsetMap.at(arg).getPtr() == arg)
+        continue;
+
       RewriterBase::InsertionGuard guard(rewriter);
       if (auto blockArg = dyn_cast<BlockArgument>(arg)) {
         rewriter.setInsertionPointToStart(blockArg.getOwner());
@@ -92,7 +102,6 @@ void replaceArgs(ValueRange args, RewriterBase &rewriter,
                          .create<UnrealizedConversionCastOp>(
                              arg.getLoc(), arg.getType(), ValueRange({}))
                          ->getResult(0);
-      parse(arg, arg.getLoc(), rewriter, offsetMap);
       rewriter.replaceAllUsesWith(arg, tempVar);
       if (auto tensorType =
               dyn_cast<RankedTensorType>(ptrType.getPointeeType())) {

--- a/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
@@ -52,6 +52,11 @@ bool forceSimtTemplateFlag = false;
 
 namespace {
 
+static bool isTensorOfPointers(Type type) {
+  auto tensorType = dyn_cast<RankedTensorType>(type);
+  return tensorType && isa<triton::PointerType>(tensorType.getElementType());
+}
+
 constexpr int64_t kBitsPerByte = 8;
 
 static constexpr const char *kRouteDiscreteMaskToSimtAttrName =
@@ -412,6 +417,12 @@ LogicalResult tryRewriteIndirectFastPath(MemAccOpTy op, Location loc,
                                          Value srcPtr, Value ptrOffset,
                                          ArrayRef<int64_t> resultShape,
                                          PatternRewriter &rewriter) {
+  // Indirect backend operations accept one scalar base plus lane offsets. An
+  // opaque tensor base can contain a different pointer in every lane, so it
+  // must be handled by the scalar-loop fallback below.
+  if (!isa<triton::PointerType>(srcPtr.getType()))
+    return failure();
+
   bool rankWithinIndirectLoadStoreFastPathLimit = resultShape.size() <= 5;
 
   if (!canUseIndirectFastPath(srcPtr, ptrOffset)) {
@@ -767,6 +778,10 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
 
   auto srcPtr = ptrOffsetInfo.getPtr();
   auto ptrOffset = ptrOffsetInfo.getOffset();
+  if (!isa<triton::PointerType>(srcPtr.getType()) &&
+      !isTensorOfPointers(srcPtr.getType()))
+    return rewriter.notifyMatchFailure(
+        op, "expected a scalar pointer or a tensor of scalar pointers");
 
   // LoadLike is operation with result
   bool isLoadLike = !op->use_empty();
@@ -943,8 +958,20 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
     os << extractedOffset << "\n";
   });
 
-  assert(isa<triton::PointerType>(srcPtr.getType()) && "src must be ptr type");
-  if (!fullyUnstructured) {
+  // A tensor-of-pointers base is opaque: each lane may select a different
+  // allocation. Extract the base with the same scalar or slice coordinates as
+  // the offset, then form the access pointer lane by lane.
+  if (isTensorOfPointers(srcPtr.getType())) {
+    if (fullyUnstructured)
+      srcPtr = createExtractOp(loc, srcPtr, rewriter, offsets);
+    else
+      srcPtr = createExtractOp(loc, srcPtr, rewriter, offsets, sizes, strides);
+  }
+
+  assert((isa<triton::PointerType>(srcPtr.getType()) ||
+          isTensorOfPointers(srcPtr.getType())) &&
+         "src must be a scalar pointer or tensor of pointers");
+  if (!fullyUnstructured && isa<triton::PointerType>(srcPtr.getType())) {
     srcPtr = rewriter.create<triton::SplatOp>(
         loc, RankedTensorType::get(extractedShape, srcPtr.getType()), srcPtr);
   }

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/block_ptr_addptr_base.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/block_ptr_addptr_base.mlir
@@ -1,0 +1,95 @@
+// RUN: triton-opt --triton-control-flow-opt --split-input-file %s | FileCheck %s
+// RUN: triton-opt --triton-control-flow-opt --triton-to-linalg --split-input-file %s -verify-each | FileCheck %s --check-prefix=LINALG
+
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @local_addptr_base(%base: !tt.ptr<f32>) -> tensor<16xf32> {
+    %c0_i32 = arith.constant 0 : i32
+    %c3_i32 = arith.constant 3 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %shifted = tt.addptr %base, %c3_i32 : !tt.ptr<f32>, i32
+    %ptr = tt.make_tensor_ptr %shifted, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf32>>
+    %value = tt.load %ptr : !tt.ptr<tensor<16xf32>>
+    tt.return %value : tensor<16xf32>
+  }
+}
+
+// CHECK-LABEL: tt.func public @local_addptr_base
+// CHECK:       %[[SHIFTED:.*]] = tt.addptr
+// CHECK:       tt.make_tensor_ptr %[[SHIFTED]],
+// CHECK-NOT:   tt.ptr_to_int
+
+// LINALG-LABEL: func.func @local_addptr_base
+// LINALG:       return
+
+// -----
+
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @region_local_addptr_base(%base: !tt.ptr<f32>, %cond: i1) -> tensor<16xf32> {
+    %result = scf.if %cond -> (tensor<16xf32>) {
+      %c0_i32 = arith.constant 0 : i32
+      %c3_i32 = arith.constant 3 : i32
+      %c1_i64 = arith.constant 1 : i64
+      %c16_i64 = arith.constant 16 : i64
+      %shifted = tt.addptr %base, %c3_i32 : !tt.ptr<f32>, i32
+      %ptr = tt.make_tensor_ptr %shifted, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf32>>
+      %loaded = tt.load %ptr : !tt.ptr<tensor<16xf32>>
+      scf.yield %loaded : tensor<16xf32>
+    } else {
+      %zero = arith.constant dense<0.000000e+00> : tensor<16xf32>
+      scf.yield %zero : tensor<16xf32>
+    }
+    tt.return %result : tensor<16xf32>
+  }
+}
+
+// CHECK-LABEL: tt.func public @region_local_addptr_base
+// CHECK:       scf.if
+// CHECK:         %[[SHIFTED:.*]] = tt.addptr
+// CHECK:         tt.make_tensor_ptr %[[SHIFTED]],
+// CHECK-NOT:   tt.ptr_to_int
+
+// LINALG-LABEL: func.func @region_local_addptr_base
+// LINALG:       return
+
+// -----
+
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @loop_carried_addptr_base(%base: !tt.ptr<f32>, %output: !tt.ptr<f32>) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c3_i32 = arith.constant 3 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %c0 = arith.constant 0 : index
+    %c2 = arith.constant 2 : index
+    %c1 = arith.constant 1 : index
+    %shifted = tt.addptr %base, %c3_i32 : !tt.ptr<f32>, i32
+    %initial = tt.make_tensor_ptr %shifted, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf32>>
+    %final = scf.for %iv = %c0 to %c2 step %c1 iter_args(%ptr = %initial) -> (!tt.ptr<tensor<16xf32>>) {
+      %next = tt.advance %ptr, [%c1_i32] : !tt.ptr<tensor<16xf32>>
+      scf.yield %next : !tt.ptr<tensor<16xf32>>
+    }
+    %value = tt.load %final : !tt.ptr<tensor<16xf32>>
+    %output_ptr = tt.make_tensor_ptr %output, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf32>>
+    tt.store %output_ptr, %value : !tt.ptr<tensor<16xf32>>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: tt.func public @loop_carried_addptr_base
+// CHECK:       %[[SHIFTED:.*]] = tt.addptr
+// CHECK:       %[[ADDRESS:.*]] = tt.ptr_to_int %[[SHIFTED]]
+// CHECK:       %[[FOR:.*]]:4 = scf.for
+// CHECK-SAME:      iter_args(%{{.*}} = %[[ADDRESS]], %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}})
+// CHECK-SAME:      -> (i64, i64, i64, i32)
+// CHECK:       %[[BASE:.*]] = tt.int_to_ptr %[[FOR]]#0
+// CHECK:       tt.make_tensor_ptr %[[BASE]], [%[[FOR]]#1], [%[[FOR]]#2], [%[[FOR]]#3]
+
+// LINALG-LABEL: func.func @loop_carried_addptr_base
+// LINALG:       scf.for
+// LINALG-NOT:   tt.addptr
+// LINALG-NOT:   tt.make_tensor_ptr
+// LINALG-NOT:   tt.ptr_to_int
+// LINALG-NOT:   tt.int_to_ptr
+// LINALG:       return

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/block_ptr_different_base.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/block_ptr_different_base.mlir
@@ -1,4 +1,4 @@
-// RUN: not triton-opt --triton-control-flow-opt %s 2>&1 | FileCheck %s
+// RUN: triton-opt --triton-control-flow-opt %s | FileCheck %s
 
 module {
   tt.func public @if_block_ptr_different_base(%base0: !tt.ptr<f32>, %base1: !tt.ptr<f32>, %cond: i1) -> !tt.ptr<tensor<16xf32>> {
@@ -20,4 +20,16 @@ module {
   }
 }
 
-// CHECK: error: failed to analyze pointer components across control flow
+// CHECK-LABEL: tt.func public @if_block_ptr_different_base(
+// CHECK-SAME:  %[[BASE0:[^ ,]+]]: !tt.ptr<f32>, %[[BASE1:[^ ,]+]]: !tt.ptr<f32>
+// CHECK:       %[[BASE0_ADDR:.*]] = tt.ptr_to_int %[[BASE0]]
+// CHECK:       %[[BASE1_ADDR:.*]] = tt.ptr_to_int %[[BASE1]]
+// CHECK:       %[[SELECTED:[^ :]+]]:4 = scf.if %{{[^ ]+}} -> (i64, i64, i64, i32) {
+// CHECK:         scf.yield %[[BASE0_ADDR]], %{{[^ ,]+}}, %{{[^ ,]+}}, %{{[^ ,]+}} : i64, i64, i64, i32
+// CHECK:       } else {
+// CHECK:         scf.yield %[[BASE1_ADDR]], %{{[^ ,]+}}, %{{[^ ,]+}}, %{{[^ ,]+}} : i64, i64, i64, i32
+// CHECK:       }
+// CHECK:       %[[SELECTED_BASE:.*]] = tt.int_to_ptr %[[SELECTED]]#0
+// CHECK:       %[[REBUILT:.*]] = tt.make_tensor_ptr %[[SELECTED_BASE]],
+// CHECK-SAME:      [%[[SELECTED]]#1], [%[[SELECTED]]#2], [%[[SELECTED]]#3]
+// CHECK:       tt.return %[[REBUILT]] : !tt.ptr<tensor<16xf32>>

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/pointer_descriptor_boundary_marker.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/pointer_descriptor_boundary_marker.mlir
@@ -1,0 +1,74 @@
+// RUN: triton-opt --triton-control-flow-opt --split-input-file %s | FileCheck %s
+
+module {
+  tt.func public @block_ptr_loop_marker(%base: !tt.ptr<f32>, %upper: index) -> !tt.ptr<tensor<16xf32>> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %initial = tt.make_tensor_ptr %base, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf32>>
+    %final = scf.for %iv = %c0 to %upper step %c1 iter_args(%ptr = %initial) -> (!tt.ptr<tensor<16xf32>>) {
+      %next = tt.advance %ptr, [%c1_i32] : !tt.ptr<tensor<16xf32>>
+      scf.yield %next : !tt.ptr<tensor<16xf32>>
+    }
+    tt.return %final : !tt.ptr<tensor<16xf32>>
+  }
+}
+
+// CHECK-LABEL: tt.func public @block_ptr_loop_marker
+// CHECK:       scf.for
+// CHECK:       PointerDescriptorBoundary = array<i32: 0, 1, 2, 3>
+
+// -----
+
+module {
+  tt.func public @tensor_ptr_loop_marker(%base: !tt.ptr<f32>, %upper: index) -> tensor<4x!tt.ptr<f32>> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %zero = tt.splat %c0_i32 : i32 -> tensor<4xi32>
+    %delta = tt.splat %c1_i32 : i32 -> tensor<4xi32>
+    %base_tensor = tt.splat %base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %initial = tt.addptr %base_tensor, %zero : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    %final = scf.for %iv = %c0 to %upper step %c1 iter_args(%ptr = %initial) -> (tensor<4x!tt.ptr<f32>>) {
+      %next = tt.addptr %ptr, %delta : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scf.yield %next : tensor<4x!tt.ptr<f32>>
+    }
+    tt.return %final : tensor<4x!tt.ptr<f32>>
+  }
+}
+
+// CHECK-LABEL: tt.func public @tensor_ptr_loop_marker
+// CHECK:       scf.for
+// CHECK:       PointerDescriptorBoundary = array<i32: 0>
+
+// -----
+
+module {
+  tt.func public @mixed_pointer_loop_marker(%block_base: !tt.ptr<f16>, %tensor_base: !tt.ptr<f32>, %upper: index) -> tensor<4x!tt.ptr<f32>> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %zero = tt.splat %c0_i32 : i32 -> tensor<4xi32>
+    %delta = tt.splat %c1_i32 : i32 -> tensor<4xi32>
+    %block = tt.make_tensor_ptr %block_base, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf16>>
+    %tensor_base_splat = tt.splat %tensor_base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %tensor = tt.addptr %tensor_base_splat, %zero : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    %results:4 = scf.for %iv = %c0 to %upper step %c1 iter_args(%acc = %c0_i32, %block_arg = %block, %ordinary = %c1_i32, %tensor_arg = %tensor) -> (i32, !tt.ptr<tensor<16xf16>>, i32, tensor<4x!tt.ptr<f32>>) {
+      %next_block = tt.advance %block_arg, [%c1_i32] : !tt.ptr<tensor<16xf16>>
+      %next_tensor = tt.addptr %tensor_arg, %delta : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scf.yield %acc, %next_block, %ordinary, %next_tensor : i32, !tt.ptr<tensor<16xf16>>, i32, tensor<4x!tt.ptr<f32>>
+    }
+    tt.return %results#3 : tensor<4x!tt.ptr<f32>>
+  }
+}
+
+// CHECK-LABEL: tt.func public @mixed_pointer_loop_marker
+// CHECK:       scf.for
+// CHECK:       PointerDescriptorBoundary = array<i32: 1, 2, 3, 4, 6>

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/pointer_descriptor_boundary_mixed_downstream.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/pointer_descriptor_boundary_mixed_downstream.mlir
@@ -1,0 +1,38 @@
+// RUN: triton-opt --triton-control-flow-opt %s | FileCheck %s --check-prefix=CFO
+// RUN: triton-opt --triton-control-flow-opt --triton-to-linalg %s -verify-each | FileCheck %s --check-prefix=LINALG --implicit-check-not='!tt.ptr' --implicit-check-not=unrealized_conversion_cast --implicit-check-not=PointerDescriptorBoundary
+
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @expanded_block_ptr_with_invariant_tensor_ptr(
+      %block_base: !tt.ptr<f32>, %tensor_base: !tt.ptr<f32>,
+      %output: !tt.ptr<f32>, %upper: index) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %range = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %block = tt.make_tensor_ptr %block_base, [%c4_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<4xf32>>
+    %tensor_base_splat = tt.splat %tensor_base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %tensor = tt.addptr %tensor_base_splat, %range : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    %results:2 = scf.for %iv = %c0 to %upper step %c1 iter_args(%block_arg = %block, %tensor_arg = %tensor) -> (!tt.ptr<tensor<4xf32>>, tensor<4x!tt.ptr<f32>>) {
+      %next_block = tt.advance %block_arg, [%c1_i32] : !tt.ptr<tensor<4xf32>>
+      scf.yield %next_block, %tensor_arg : !tt.ptr<tensor<4xf32>>, tensor<4x!tt.ptr<f32>>
+    }
+    %value = tt.load %results#1 : tensor<4x!tt.ptr<f32>>
+    %output_splat = tt.splat %output : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %output_ptrs = tt.addptr %output_splat, %range : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    tt.store %output_ptrs, %value : tensor<4x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// CFO-LABEL: tt.func public @expanded_block_ptr_with_invariant_tensor_ptr
+// CFO:       %[[LOOP:.*]]:5 = scf.for
+// CFO-SAME:  -> (i64, i64, i64, i32, tensor<4x!tt.ptr<f32>>) {
+// CFO:       } {PointerDescriptorBoundary = array<i32: 0, 1, 2, 3>}
+// CFO:       tt.load %[[LOOP]]#4 : tensor<4x!tt.ptr<f32>>
+
+// LINALG-LABEL: func.func @expanded_block_ptr_with_invariant_tensor_ptr
+// LINALG:       scf.for
+// LINALG:       return

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scf_pointer_decouple.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scf_pointer_decouple.mlir
@@ -22,13 +22,13 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @for_block_ptr_dynamic_step
-// CHECK:       %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[OFF:.*]] = %{{.*}}) -> (i32) {
+// CHECK:       %[[FOR:.*]]:4 = scf.for {{.*}} iter_args(%[[BASE:.*]] = %{{.*}}, %[[SHAPE:.*]] = %{{.*}}, %[[STRIDE:.*]] = %{{.*}}, %[[OFF:.*]] = %{{.*}}) -> (i64, i64, i64, i32) {
 // CHECK-NOT:     arith.muli
-// CHECK:         tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[OFF]]] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:         tt.make_tensor_ptr %{{.*}}, [%[[SHAPE]]], [%[[STRIDE]]], [%[[OFF]]] {order = array<i32: 0>} : <tensor<32xf16>>
 // CHECK:         %[[NEXT:.*]] = arith.addi %[[OFF]], %{{.*}} : i32
-// CHECK:         scf.yield %[[NEXT]] : i32
+// CHECK:         scf.yield %[[BASE]], %[[SHAPE]], %[[STRIDE]], %[[NEXT]] : i64, i64, i64, i32
 // CHECK:       }
-// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[FOR]]] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%[[FOR]]#1], [%[[FOR]]#2], [%[[FOR]]#3] {order = array<i32: 0>} : <tensor<32xf16>>
 
 // -----
 
@@ -52,16 +52,16 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @for_block_ptr_invariant_delta_carried
-// CHECK:       %[[FOR:[^:]+]]:2 = scf.for
-// CHECK-SAME:  {{.*}} iter_args(%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) -> (i32, tensor<32xf16>) {
+// CHECK:       %[[FOR:[^:]+]]:5 = scf.for
+// CHECK-SAME:  {{.*}} -> (i64, i64, i64, i32, tensor<32xf16>) {
 // CHECK-NOT:     arith.index_cast
 // CHECK-NOT:     arith.muli
 // CHECK:         %[[NEXT:.*]] = arith.addi %{{.*}}, %{{.*}} : i32
 // CHECK:         %[[LOAD_PTR:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[NEXT]]] {order = array<i32: 0>} : <tensor<32xf16>>
 // CHECK:         %[[LOADED:.*]] = tt.load %[[LOAD_PTR]] : !tt.ptr<tensor<32xf16>>
-// CHECK:         scf.yield %[[NEXT]], %[[LOADED]] : i32, tensor<32xf16>
+// CHECK:         scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %[[NEXT]], %[[LOADED]] : i64, i64, i64, i32, tensor<32xf16>
 // CHECK:       }
-// CHECK:       tt.return %[[FOR]]#1 : tensor<32xf16>
+// CHECK:       tt.return %[[FOR]]#4 : tensor<32xf16>
 
 // -----
 
@@ -80,12 +80,12 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @for_block_ptr_dynamic_bounds_and_step
-// CHECK:       %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[OFF:.*]] = %{{.*}}) -> (i32) {
+// CHECK:       %[[FOR:.*]]:4 = scf.for {{.*}} iter_args(%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %[[OFF:.*]] = %{{.*}}) -> (i64, i64, i64, i32) {
 // CHECK-NOT:     arith.muli
 // CHECK:         %[[NEXT:.*]] = arith.addi %[[OFF]], %{{.*}} : i32
-// CHECK:         scf.yield %[[NEXT]] : i32
+// CHECK:         scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %[[NEXT]] : i64, i64, i64, i32
 // CHECK:       }
-// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[FOR]]] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%[[FOR]]#1], [%[[FOR]]#2], [%[[FOR]]#3] {order = array<i32: 0>} : <tensor<32xf16>>
 
 // -----
 
@@ -108,12 +108,12 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @for_block_ptr_iter_arg_delta
-// CHECK:       %[[FOR:.*]]:2 = scf.for {{.*}} iter_args(%[[OFF:.*]] = %{{.*}}, %[[DELTA:.*]] = %{{.*}}) -> (i32, i32) {
+// CHECK:       %[[FOR:.*]]:5 = scf.for {{.*}} iter_args(%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %[[OFF:.*]] = %{{.*}}, %[[DELTA:.*]] = %{{.*}}) -> (i64, i64, i64, i32, i32) {
 // CHECK:         %[[NEXT_PTR:.*]] = arith.addi %[[OFF]], %[[DELTA]] : i32
 // CHECK:         %[[NEXT_DELTA:.*]] = arith.addi %[[DELTA]], %{{.*}} : i32
-// CHECK:         scf.yield %[[NEXT_PTR]], %[[NEXT_DELTA]] : i32, i32
+// CHECK:         scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %[[NEXT_PTR]], %[[NEXT_DELTA]] : i64, i64, i64, i32, i32
 // CHECK:       }
-// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[FOR]]#0] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%[[FOR]]#1], [%[[FOR]]#2], [%[[FOR]]#3] {order = array<i32: 0>} : <tensor<32xf16>>
 
 // -----
 
@@ -139,12 +139,13 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @for_block_ptr_multidim_delta
-// CHECK:       %[[FOR:.*]]:2 = scf.for {{.*}} iter_args(%[[OFF0:.*]] = %{{.*}}, %[[OFF1:.*]] = %{{.*}}) -> (i32, i32) {
+// CHECK:       %[[FOR:.*]]:7 = scf.for {{.*}} iter_args(%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %[[OFF0:.*]] = %{{.*}}, %[[OFF1:.*]] = %{{.*}})
+// CHECK-SAME:  -> (i64, i64, i64, i64, i64, i32, i32) {
 // CHECK:         %[[NEXT0:.*]] = arith.addi %[[OFF0]], %{{.*}} : i32
 // CHECK:         %[[NEXT1:.*]] = arith.addi %[[OFF1]], %{{.*}} : i32
-// CHECK:         scf.yield %[[NEXT0]], %[[NEXT1]] : i32, i32
+// CHECK:         scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[NEXT0]], %[[NEXT1]] : i64, i64, i64, i64, i64, i32, i32
 // CHECK:       }
-// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}], [%[[FOR]]#0, %[[FOR]]#1] {order = array<i32: 1, 0>} : <tensor<16x32xf16>>
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%[[FOR]]#1, %[[FOR]]#2], [%[[FOR]]#3, %[[FOR]]#4], [%[[FOR]]#5, %[[FOR]]#6] {order = array<i32: 1, 0>} : <tensor<16x32xf16>>
 
 // -----
 
@@ -167,11 +168,11 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @for_block_ptr_zero_trip
-// CHECK:       %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[OFF:.*]] = %{{.*}}) -> (i32) {
+// CHECK:       %[[FOR:.*]]:4 = scf.for {{.*}} iter_args(%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %[[OFF:.*]] = %{{.*}}) -> (i64, i64, i64, i32) {
 // CHECK:         %[[NEXT:.*]] = arith.addi %[[OFF]], %{{.*}} : i32
-// CHECK:         scf.yield %[[NEXT]] : i32
+// CHECK:         scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %[[NEXT]] : i64, i64, i64, i32
 // CHECK:       }
-// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[FOR]]] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%[[FOR]]#1], [%[[FOR]]#2], [%[[FOR]]#3] {order = array<i32: 0>} : <tensor<32xf16>>
 
 // -----
 
@@ -196,13 +197,14 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @while_block_ptr_basic
-// CHECK:       %[[WHILE:.*]]:2 = scf.while (%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) : (i32, i32) -> (i32, i32) {
-// CHECK:       scf.condition(%{{.*}}) %{{.*}}, %{{.*}} : i32, i32
+// CHECK:       %[[WHILE:.*]]:5 = scf.while
+// CHECK-SAME:  : (i32, i64, i64, i64, i32) -> (i32, i64, i64, i64, i32) {
+// CHECK:       scf.condition(%{{.*}}) %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i32, i64, i64, i64, i32
 // CHECK:       } do {
 // CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%{{.*}}] {order = array<i32: 0>} : <tensor<32xf16>>
-// CHECK:       scf.yield %{{.*}}, %{{.*}} : i32, i32
+// CHECK:       scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i32, i64, i64, i64, i32
 // CHECK:       }
-// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[WHILE]]#1] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%[[WHILE]]#2], [%[[WHILE]]#3], [%[[WHILE]]#4] {order = array<i32: 0>} : <tensor<32xf16>>
 
 // -----
 
@@ -226,12 +228,12 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @if_block_ptr_same_base_offsets
-// CHECK:       %[[OFF:.*]] = scf.if %{{.*}} -> (i32) {
-// CHECK:         scf.yield %{{.*}} : i32
+// CHECK:       %[[DESC:.*]]:4 = scf.if %{{.*}} -> (i64, i64, i64, i32) {
+// CHECK:         scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i64, i64, i32
 // CHECK:       } else {
-// CHECK:         scf.yield %{{.*}} : i32
+// CHECK:         scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i64, i64, i32
 // CHECK:       }
-// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[OFF]]] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%[[DESC]]#1], [%[[DESC]]#2], [%[[DESC]]#3] {order = array<i32: 0>} : <tensor<32xf16>>
 
 // -----
 
@@ -288,9 +290,11 @@ module {
 
 // CHECK-LABEL: tt.func public @while_block_ptr_large_step
 // CHECK-DAG:   %[[C37:.*]] = arith.constant 37 : i32
+// CHECK:       %[[WHILE:.*]]:5 = scf.while
+// CHECK-SAME:  : (i32, i64, i64, i64, i32) -> (i32, i64, i64, i64, i32)
 // CHECK:       } do {
 // CHECK:         %[[NEXT_OFF:.*]] = arith.addi %{{.*}}, %[[C37]] : i32
-// CHECK:         scf.yield %{{.*}}, %[[NEXT_OFF]] : i32, i32
+// CHECK:         scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[NEXT_OFF]] : i32, i64, i64, i64, i32
 
 // -----
 
@@ -382,18 +386,18 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @for_if_block_ptr_same_base_post_advance
-// CHECK:       %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[OFF:.*]] = %{{.*}}) -> (i32) {
-// CHECK:         %[[SELECTED:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:       %[[FOR:.*]]:4 = scf.for {{.*}} iter_args(%[[BASE:.*]] = %{{.*}}, %[[SHAPE:.*]] = %{{.*}}, %[[STRIDE:.*]] = %{{.*}}, %[[OFF:.*]] = %{{.*}}) -> (i64, i64, i64, i32) {
+// CHECK:         %[[SELECTED:.*]]:4 = scf.if %{{.*}} -> (i64, i64, i64, i32) {
 // CHECK:           arith.addi %[[OFF]], %{{.*}} : i32
-// CHECK:           scf.yield %{{.*}} : i32
+// CHECK:           scf.yield %[[BASE]], %[[SHAPE]], %[[STRIDE]], %{{.*}} : i64, i64, i64, i32
 // CHECK:         } else {
 // CHECK:           arith.addi %[[OFF]], %{{.*}} : i32
-// CHECK:           scf.yield %{{.*}} : i32
+// CHECK:           scf.yield %[[BASE]], %[[SHAPE]], %[[STRIDE]], %{{.*}} : i64, i64, i64, i32
 // CHECK:         }
-// CHECK:         %[[NEXT:.*]] = arith.addi %[[SELECTED]], %{{.*}} : i32
-// CHECK:         scf.yield %[[NEXT]] : i32
+// CHECK:         %[[NEXT:.*]] = arith.addi %[[SELECTED]]#3, %{{.*}} : i32
+// CHECK:         scf.yield %[[SELECTED]]#0, %[[SELECTED]]#1, %[[SELECTED]]#2, %[[NEXT]] : i64, i64, i64, i32
 // CHECK:       }
-// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[FOR]]] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%[[FOR]]#1], [%[[FOR]]#2], [%[[FOR]]#3] {order = array<i32: 0>} : <tensor<32xf16>>
 
 // -----
 
@@ -428,18 +432,18 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @while_if_block_ptr_same_base_post_advance
-// CHECK:       %[[WHILE:.*]]:2 = scf.while
-// CHECK-SAME:  (i32, i32) -> (i32, i32)
+// CHECK:       %[[WHILE:.*]]:5 = scf.while
+// CHECK-SAME:  (i32, i64, i64, i64, i32) -> (i32, i64, i64, i64, i32)
 // CHECK:       } do {
-// CHECK:         %[[SELECTED:.*]] = scf.if %{{.*}} -> (i32) {
-// CHECK:           scf.yield %{{.*}} : i32
+// CHECK:         %[[SELECTED:.*]]:4 = scf.if %{{.*}} -> (i64, i64, i64, i32) {
+// CHECK:           scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i64, i64, i32
 // CHECK:         } else {
-// CHECK:           scf.yield %{{.*}} : i32
+// CHECK:           scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i64, i64, i32
 // CHECK:         }
-// CHECK:         %[[NEXT:.*]] = arith.addi %[[SELECTED]], %{{.*}} : i32
-// CHECK:         scf.yield %{{.*}}, %[[NEXT]] : i32, i32
+// CHECK:         %[[NEXT:.*]] = arith.addi %[[SELECTED]]#3, %{{.*}} : i32
+// CHECK:         scf.yield %{{.*}}, %[[SELECTED]]#0, %[[SELECTED]]#1, %[[SELECTED]]#2, %[[NEXT]] : i32, i64, i64, i64, i32
 // CHECK:       }
-// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[WHILE]]#1] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%[[WHILE]]#2], [%[[WHILE]]#3], [%[[WHILE]]#4] {order = array<i32: 0>} : <tensor<32xf16>>
 
 // -----
 
@@ -518,20 +522,21 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @for_if_block_ptr_load_after_post_advance
-// CHECK:       %[[FOR:.*]]:2 = scf.for {{.*}} iter_args(%[[OFF:.*]] = %{{.*}}, %{{.*}} = %{{.*}}) -> (i32, tensor<32xf16>) {
-// CHECK:         %[[SELECTED:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:       %[[FOR:.*]]:5 = scf.for {{.*}} iter_args(%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %[[OFF:.*]] = %{{.*}}, %{{.*}} = %{{.*}})
+// CHECK-SAME:  -> (i64, i64, i64, i32, tensor<32xf16>) {
+// CHECK:         %[[SELECTED:.*]]:4 = scf.if %{{.*}} -> (i64, i64, i64, i32) {
 // CHECK:           arith.addi %[[OFF]], %{{.*}} : i32
-// CHECK:           scf.yield %{{.*}} : i32
+// CHECK:           scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i64, i64, i32
 // CHECK:         } else {
 // CHECK:           arith.addi %[[OFF]], %{{.*}} : i32
-// CHECK:           scf.yield %{{.*}} : i32
+// CHECK:           scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i64, i64, i32
 // CHECK:         }
-// CHECK:         %[[NEXT:.*]] = arith.addi %[[SELECTED]], %{{.*}} : i32
+// CHECK:         %[[NEXT:.*]] = arith.addi %[[SELECTED]]#3, %{{.*}} : i32
 // CHECK:         %[[LOAD_PTR:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[NEXT]]] {order = array<i32: 0>} : <tensor<32xf16>>
 // CHECK:         %[[LOADED:.*]] = tt.load %[[LOAD_PTR]] : !tt.ptr<tensor<32xf16>>
-// CHECK:         scf.yield %[[NEXT]], %[[LOADED]] : i32, tensor<32xf16>
+// CHECK:         scf.yield %[[SELECTED]]#0, %[[SELECTED]]#1, %[[SELECTED]]#2, %[[NEXT]], %[[LOADED]] : i64, i64, i64, i32, tensor<32xf16>
 // CHECK:       }
-// CHECK:       tt.return %[[FOR]]#1 : tensor<32xf16>
+// CHECK:       tt.return %[[FOR]]#4 : tensor<32xf16>
 
 // -----
 
@@ -581,28 +586,29 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @for_nested_if_block_ptr_load_after_post_advance
-// CHECK:       %[[FOR:.*]]:2 = scf.for {{.*}} iter_args(%[[OFF:.*]] = %{{.*}}, %{{.*}} = %{{.*}}) -> (i32, tensor<16xf32>) {
-// CHECK:         %[[SELECTED:.*]] = scf.if %{{.*}} -> (i32) {
-// CHECK:           %[[THEN_INNER:.*]] = scf.if %{{.*}} -> (i32) {
-// CHECK:             scf.yield %{{.*}} : i32
+// CHECK:       %[[FOR:.*]]:5 = scf.for {{.*}} iter_args(%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %[[OFF:.*]] = %{{.*}}, %{{.*}} = %{{.*}})
+// CHECK-SAME:  -> (i64, i64, i64, i32, tensor<16xf32>) {
+// CHECK:         %[[SELECTED:.*]]:4 = scf.if %{{.*}} -> (i64, i64, i64, i32) {
+// CHECK:           %[[THEN_INNER:.*]]:4 = scf.if %{{.*}} -> (i64, i64, i64, i32) {
+// CHECK:             scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i64, i64, i32
 // CHECK:           } else {
-// CHECK:             scf.yield %{{.*}} : i32
+// CHECK:             scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i64, i64, i32
 // CHECK:           }
-// CHECK:           scf.yield %[[THEN_INNER]] : i32
+// CHECK:           scf.yield %[[THEN_INNER]]#0, %[[THEN_INNER]]#1, %[[THEN_INNER]]#2, %[[THEN_INNER]]#3 : i64, i64, i64, i32
 // CHECK:         } else {
-// CHECK:           %[[ELSE_INNER:.*]] = scf.if %{{.*}} -> (i32) {
-// CHECK:             scf.yield %{{.*}} : i32
+// CHECK:           %[[ELSE_INNER:.*]]:4 = scf.if %{{.*}} -> (i64, i64, i64, i32) {
+// CHECK:             scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i64, i64, i32
 // CHECK:           } else {
-// CHECK:             scf.yield %{{.*}} : i32
+// CHECK:             scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i64, i64, i32
 // CHECK:           }
-// CHECK:           scf.yield %[[ELSE_INNER]] : i32
+// CHECK:           scf.yield %[[ELSE_INNER]]#0, %[[ELSE_INNER]]#1, %[[ELSE_INNER]]#2, %[[ELSE_INNER]]#3 : i64, i64, i64, i32
 // CHECK:         }
-// CHECK:         %[[NEXT:.*]] = arith.addi %[[SELECTED]], %{{.*}} : i32
+// CHECK:         %[[NEXT:.*]] = arith.addi %[[SELECTED]]#3, %{{.*}} : i32
 // CHECK:         %[[LOAD_PTR:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[NEXT]]] {order = array<i32: 0>} : <tensor<16xf32>>
 // CHECK:         %[[LOADED:.*]] = tt.load %[[LOAD_PTR]] : !tt.ptr<tensor<16xf32>>
-// CHECK:         scf.yield %[[NEXT]], %[[LOADED]] : i32, tensor<16xf32>
+// CHECK:         scf.yield %[[SELECTED]]#0, %[[SELECTED]]#1, %[[SELECTED]]#2, %[[NEXT]], %[[LOADED]] : i64, i64, i64, i32, tensor<16xf32>
 // CHECK:       }
-// CHECK:       tt.return %[[FOR]]#1 : tensor<16xf32>
+// CHECK:       tt.return %[[FOR]]#4 : tensor<16xf32>
 
 // -----
 
@@ -698,15 +704,15 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @if_block_ptr_same_base_dynamic_shape
-// CHECK:       %[[SHAPE:.*]] = scf.if %{{.*}} -> (i64) {
-// CHECK:         scf.yield %{{.*}} : i64
+// CHECK:       %[[DESC:.*]]:4 = scf.if %{{.*}} -> (i64, i64, i64, i32) {
+// CHECK:         scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i64, i64, i32
 // CHECK:       } else {
-// CHECK:         scf.yield %{{.*}} : i64
+// CHECK:         scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i64, i64, i32
 // CHECK:       }
-// CHECK:       tt.make_tensor_ptr %{{.*}}, [%[[SHAPE]]], [%{{.*}}], [%{{.*}}] {order = array<i32: 0>} : <tensor<16xf32>>
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%[[DESC]]#1], [%[[DESC]]#2], [%[[DESC]]#3] {order = array<i32: 0>} : <tensor<16xf32>>
 
 module {
-  tt.func public @if_same_nested_result_not_decoupled(%base: !tt.ptr<f32>, %cond0: i1, %cond1: i1) -> !tt.ptr<tensor<16xf32>> {
+  tt.func public @if_same_nested_result_fully_decoupled(%base: !tt.ptr<f32>, %cond0: i1, %cond1: i1) -> !tt.ptr<tensor<16xf32>> {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
     %c2_i32 = arith.constant 2 : i32
@@ -729,19 +735,20 @@ module {
   }
 }
 
-// CHECK-LABEL: tt.func public @if_same_nested_result_not_decoupled
-// CHECK:       %[[INNER_OFF:.*]] = scf.if %{{.*}} -> (i32) {
-// CHECK:         scf.yield %{{.*}} : i32
+// CHECK-LABEL: tt.func public @if_same_nested_result_fully_decoupled
+// CHECK:       %[[INNER_DESC:.*]]:4 = scf.if %{{.*}} -> (i64, i64, i64, i32) {
+// CHECK:         scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i64, i64, i32
 // CHECK:       } else {
-// CHECK:         scf.yield %{{.*}} : i32
+// CHECK:         scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i64, i64, i32
 // CHECK:       }
-// CHECK:       %[[INNER_PTR:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[INNER_OFF]]] {order = array<i32: 0>} : <tensor<16xf32>>
-// CHECK:       %[[OUTER:.*]] = scf.if %{{.*}} -> (!tt.ptr<tensor<16xf32>>) {
-// CHECK:         scf.yield %[[INNER_PTR]] : !tt.ptr<tensor<16xf32>>
+// CHECK:       %[[OUTER:.*]]:4 = scf.if %{{.*}} -> (i64, i64, i64, i32) {
+// CHECK:         scf.yield %[[INNER_DESC]]#0, %[[INNER_DESC]]#1, %[[INNER_DESC]]#2, %[[INNER_DESC]]#3 : i64, i64, i64, i32
 // CHECK:       } else {
-// CHECK:         scf.yield %[[INNER_PTR]] : !tt.ptr<tensor<16xf32>>
+// CHECK:         scf.yield %[[INNER_DESC]]#0, %[[INNER_DESC]]#1, %[[INNER_DESC]]#2, %[[INNER_DESC]]#3 : i64, i64, i64, i32
 // CHECK:       }
-// CHECK:       tt.return %[[OUTER]] : !tt.ptr<tensor<16xf32>>
+// CHECK:       %[[OUTER_BASE:.*]] = tt.int_to_ptr %[[OUTER]]#0
+// CHECK:       %[[OUTER_PTR:.*]] = tt.make_tensor_ptr %[[OUTER_BASE]], [%[[OUTER]]#1], [%[[OUTER]]#2], [%[[OUTER]]#3]
+// CHECK:       tt.return %[[OUTER_PTR]] : !tt.ptr<tensor<16xf32>>
 
 // -----
 
@@ -770,13 +777,13 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @if_mixed_block_and_tensor_ptr
-// CHECK:       %[[RESULT:.*]]:2 = scf.if %{{.*}} -> (i32, tensor<4xi32>) {
-// CHECK:         scf.yield %{{.*}}, %{{.*}} : i32, tensor<4xi32>
+// CHECK:       %[[RESULT:.*]]:5 = scf.if %{{.*}} -> (i64, i64, i64, i32, tensor<4xi32>) {
+// CHECK:         scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i64, i64, i32, tensor<4xi32>
 // CHECK:       } else {
-// CHECK:         scf.yield %{{.*}}, %{{.*}} : i32, tensor<4xi32>
+// CHECK:         scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i64, i64, i32, tensor<4xi32>
 // CHECK:       }
-// CHECK-DAG:   %[[BLOCK:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[RESULT]]#0] {order = array<i32: 0>} : <tensor<16xf16>>
-// CHECK-DAG:   %[[TENSOR:.*]] = tt.addptr %{{.*}}, %[[RESULT]]#1 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+// CHECK-DAG:   %[[BLOCK:.*]] = tt.make_tensor_ptr %{{.*}}, [%[[RESULT]]#1], [%[[RESULT]]#2], [%[[RESULT]]#3] {order = array<i32: 0>} : <tensor<16xf16>>
+// CHECK-DAG:   %[[TENSOR:.*]] = tt.addptr %{{.*}}, %[[RESULT]]#4 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
 // CHECK:       tt.return %[[BLOCK]], %[[TENSOR]] : !tt.ptr<tensor<16xf16>>, tensor<4x!tt.ptr<f32>>
 
 // -----
@@ -805,11 +812,11 @@ module {
 
 // CHECK-LABEL: tt.func public @if_without_else_rewrites_nested_block_ptr
 // CHECK:       scf.if %{{.*}} {
-// CHECK:         %[[FOR:.*]] = scf.for
-// CHECK-SAME:    -> (i32) {
-// CHECK:           scf.yield %{{.*}} : i32
+// CHECK:         %[[FOR:.*]]:4 = scf.for
+// CHECK-SAME:    -> (i64, i64, i64, i32) {
+// CHECK:           scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i64, i64, i32
 // CHECK:         }
-// CHECK:         %[[PTR:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[FOR]]] {order = array<i32: 0>} : <tensor<16xf16>>
+// CHECK:         %[[PTR:.*]] = tt.make_tensor_ptr %{{.*}}, [%[[FOR]]#1], [%[[FOR]]#2], [%[[FOR]]#3] {order = array<i32: 0>} : <tensor<16xf16>>
 // CHECK:         tt.load %[[PTR]] : !tt.ptr<tensor<16xf16>>
 // CHECK:       }
 

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/scalar_pointer_select.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/scalar_pointer_select.mlir
@@ -1,0 +1,207 @@
+// RUN: triton-opt --triton-to-linalg %s -verify-each | FileCheck %s
+
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  func.func private @consume_offset_view(memref<1xf32, strided<[1], offset: 1>>)
+  func.func private @next_offset_view(memref<1xf32, strided<[1], offset: 1>>) -> memref<1xf32, strided<[1], offset: 1>>
+
+  tt.func public @scalar_pointer_select(%lhs: !tt.ptr<f32>, %rhs: !tt.ptr<f32>, %condition: i1) -> i64 {
+    %selected = arith.select %condition, %lhs, %rhs : !tt.ptr<f32>
+    %address = tt.ptr_to_int %selected : !tt.ptr<f32> -> i64
+    tt.return %address : i64
+  }
+
+  tt.func public @scalar_pointer_roundtrip(%address: i64) -> i64 {
+    %pointer = tt.int_to_ptr %address : i64 -> !tt.ptr<f32>
+    %roundtrip = tt.ptr_to_int %pointer : !tt.ptr<f32> -> i64
+    tt.return %roundtrip : i64
+  }
+
+  func.func @pointer_cast_static_offset(%address: i64) -> f32 {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %pointer = hivm.hir.pointer_cast(%address) [%c1] : memref<?xf32>
+    %view = memref.reinterpret_cast %pointer to offset: [1], sizes: [1], strides: [1]
+        : memref<?xf32> to memref<1xf32, strided<[1], offset: 1>>
+    %value = memref.load %view[%c0] : memref<1xf32, strided<[1], offset: 1>>
+    return %value : f32
+  }
+
+  func.func @pointer_cast_dynamic_offset_subviews(%address: i64, %offset: index, %size: index) -> f32 {
+    %c0 = arith.constant 0 : index
+    %c8 = arith.constant 8 : index
+    %pointer = hivm.hir.pointer_cast(%address) [%c8] : memref<?xf32>
+    %view = memref.reinterpret_cast %pointer to offset: [%offset], sizes: [1, 8], strides: [8, 1]
+        : memref<?xf32> to memref<1x8xf32, strided<[8, 1], offset: ?>>
+    %rank_reduced = memref.subview %view[0, 0] [1, %size] [1, 1]
+        : memref<1x8xf32, strided<[8, 1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+    %subview = memref.subview %rank_reduced[0] [%size] [1]
+        : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+    %value = memref.load %subview[%c0] : memref<?xf32, strided<[1], offset: ?>>
+    return %value : f32
+  }
+
+  func.func @pointer_cast_offset_return(%address: i64) -> memref<1xf32, strided<[1], offset: 1>> {
+    %c1 = arith.constant 1 : index
+    %pointer = hivm.hir.pointer_cast(%address) [%c1] : memref<?xf32>
+    %view = memref.reinterpret_cast %pointer to offset: [1], sizes: [1], strides: [1]
+        : memref<?xf32> to memref<1xf32, strided<[1], offset: 1>>
+    return %view : memref<1xf32, strided<[1], offset: 1>>
+  }
+
+  func.func @pointer_cast_dynamic_offset_return(%address: i64, %offset: index) -> memref<1xf32, strided<[1], offset: ?>> {
+    %c1 = arith.constant 1 : index
+    %pointer = hivm.hir.pointer_cast(%address) [%c1] : memref<?xf32>
+    %view = memref.reinterpret_cast %pointer to offset: [%offset], sizes: [1], strides: [1]
+        : memref<?xf32> to memref<1xf32, strided<[1], offset: ?>>
+    return %view : memref<1xf32, strided<[1], offset: ?>>
+  }
+
+  func.func @pointer_cast_offset_call(%address: i64) {
+    %c1 = arith.constant 1 : index
+    %pointer = hivm.hir.pointer_cast(%address) [%c1] : memref<?xf32>
+    %view = memref.reinterpret_cast %pointer to offset: [1], sizes: [1], strides: [1]
+        : memref<?xf32> to memref<1xf32, strided<[1], offset: 1>>
+    call @consume_offset_view(%view) : (memref<1xf32, strided<[1], offset: 1>>) -> ()
+    return
+  }
+
+  func.func @pointer_cast_offset_if(%address: i64, %condition: i1, %alternate: memref<1xf32, strided<[1], offset: 1>>) -> memref<1xf32, strided<[1], offset: 1>> {
+    %c1 = arith.constant 1 : index
+    %pointer = hivm.hir.pointer_cast(%address) [%c1] : memref<?xf32>
+    %view = memref.reinterpret_cast %pointer to offset: [1], sizes: [1], strides: [1]
+        : memref<?xf32> to memref<1xf32, strided<[1], offset: 1>>
+    %result = scf.if %condition -> (memref<1xf32, strided<[1], offset: 1>>) {
+      %then = call @next_offset_view(%view) : (memref<1xf32, strided<[1], offset: 1>>) -> memref<1xf32, strided<[1], offset: 1>>
+      scf.yield %then : memref<1xf32, strided<[1], offset: 1>>
+    } else {
+      %else = call @next_offset_view(%alternate) : (memref<1xf32, strided<[1], offset: 1>>) -> memref<1xf32, strided<[1], offset: 1>>
+      scf.yield %else : memref<1xf32, strided<[1], offset: 1>>
+    }
+    return %result : memref<1xf32, strided<[1], offset: 1>>
+  }
+
+  func.func @pointer_cast_offset_loop(%address: i64, %upper: index) -> memref<1xf32, strided<[1], offset: 1>> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %pointer = hivm.hir.pointer_cast(%address) [%c1] : memref<?xf32>
+    %view = memref.reinterpret_cast %pointer to offset: [1], sizes: [1], strides: [1]
+        : memref<?xf32> to memref<1xf32, strided<[1], offset: 1>>
+    %result = scf.for %iv = %c0 to %upper step %c1 iter_args(%current = %view) -> (memref<1xf32, strided<[1], offset: 1>>) {
+      %next = call @next_offset_view(%current) : (memref<1xf32, strided<[1], offset: 1>>) -> memref<1xf32, strided<[1], offset: 1>>
+      scf.yield %next : memref<1xf32, strided<[1], offset: 1>>
+    }
+    return %result : memref<1xf32, strided<[1], offset: 1>>
+  }
+
+  func.func @pointer_cast_offset_while(%address: i64, %condition: i1) -> memref<1xf32, strided<[1], offset: 1>> {
+    %c1 = arith.constant 1 : index
+    %pointer = hivm.hir.pointer_cast(%address) [%c1] : memref<?xf32>
+    %view = memref.reinterpret_cast %pointer to offset: [1], sizes: [1], strides: [1]
+        : memref<?xf32> to memref<1xf32, strided<[1], offset: 1>>
+    %result = scf.while (%current = %view) : (memref<1xf32, strided<[1], offset: 1>>) -> (memref<1xf32, strided<[1], offset: 1>>) {
+      scf.condition(%condition) %current : memref<1xf32, strided<[1], offset: 1>>
+    } do {
+    ^bb0(%current: memref<1xf32, strided<[1], offset: 1>>):
+      %next = call @next_offset_view(%current) : (memref<1xf32, strided<[1], offset: 1>>) -> memref<1xf32, strided<[1], offset: 1>>
+      scf.yield %next : memref<1xf32, strided<[1], offset: 1>>
+    }
+    return %result : memref<1xf32, strided<[1], offset: 1>>
+  }
+}
+
+// CHECK-LABEL: func.func @scalar_pointer_select(
+// CHECK-SAME:  %[[LHS:[^ ,]+]]: memref<?xf32>, %[[RHS:[^ ,]+]]: memref<?xf32>
+// CHECK:       %[[LHS_INDEX:.*]] = memref.extract_aligned_pointer_as_index %[[LHS]]
+// CHECK:       %[[LHS_ADDRESS:.*]] = arith.index_cast %[[LHS_INDEX]] : index to i64
+// CHECK:       %[[RHS_INDEX:.*]] = memref.extract_aligned_pointer_as_index %[[RHS]]
+// CHECK:       %[[RHS_ADDRESS:.*]] = arith.index_cast %[[RHS_INDEX]] : index to i64
+// CHECK:       %[[SELECTED:.*]] = arith.select %{{.*}}, %[[LHS_ADDRESS]], %[[RHS_ADDRESS]] : i64
+// CHECK-NOT:   arith.select {{.*}} : memref
+// CHECK-NOT:   hivm.hir.pointer_cast
+// CHECK-NOT:   memref.extract_aligned_pointer_as_index
+// CHECK:       return %[[SELECTED]] : i64
+
+// CHECK-LABEL: func.func @scalar_pointer_roundtrip(
+// CHECK-SAME:  %[[ADDRESS:[^ ,]+]]: i64
+// CHECK-NOT:   hivm.hir.pointer_cast
+// CHECK-NOT:   memref.extract_aligned_pointer_as_index
+// CHECK:       return %[[ADDRESS]] : i64
+
+// CHECK-LABEL: func.func @pointer_cast_static_offset(
+// CHECK-SAME:  %[[ADDRESS:[^ ,]+]]: i64
+// CHECK:       %[[OFFSET_I64:.*]] = arith.index_cast %[[OFFSET:.*]] : index to i64
+// CHECK:       %[[BYTE_WIDTH:.*]] = arith.constant 4 : i64
+// CHECK:       %[[BYTE_OFFSET:.*]] = arith.muli %[[OFFSET_I64]], %[[BYTE_WIDTH]] : i64
+// CHECK:       %[[REAL_ADDRESS:.*]] = arith.addi %[[ADDRESS]], %[[BYTE_OFFSET]] : i64
+// CHECK:       %[[REBASED_POINTER:.*]] = hivm.hir.pointer_cast(%[[REAL_ADDRESS]]) [%[[SIZE:.*]]] : memref<?xf32>
+// CHECK:       %[[VIEW:.*]] = memref.reinterpret_cast %[[REBASED_POINTER]] to offset: [0], sizes: [1], strides: [1]
+// CHECK-SAME:  to memref<1xf32, strided<[1]>>
+// CHECK:       memref.load %[[VIEW]][%{{.*}}] : memref<1xf32, strided<[1]>>
+
+// CHECK-LABEL: func.func @pointer_cast_dynamic_offset_subviews(
+// CHECK-SAME:  %[[ADDRESS:[^ ,]+]]: i64, %[[OFFSET:[^ ,]+]]: index, %[[DYNAMIC_SIZE:[^ ,]+]]: index
+// CHECK:       %[[OFFSET_I64:.*]] = arith.index_cast %[[OFFSET]] : index to i64
+// CHECK:       %[[BYTE_WIDTH:.*]] = arith.constant 4 : i64
+// CHECK:       %[[BYTE_OFFSET:.*]] = arith.muli %[[OFFSET_I64]], %[[BYTE_WIDTH]] : i64
+// CHECK:       %[[REAL_ADDRESS:.*]] = arith.addi %[[ADDRESS]], %[[BYTE_OFFSET]] : i64
+// CHECK:       %[[REBASED_POINTER:.*]] = hivm.hir.pointer_cast(%[[REAL_ADDRESS]]) [%[[SIZE:.*]]] : memref<?xf32>
+// CHECK:       %[[VIEW:.*]] = memref.reinterpret_cast %[[REBASED_POINTER]] to offset: [0], sizes: [1, 8], strides: [8, 1]
+// CHECK-SAME:  to memref<1x8xf32, strided<[8, 1]>>
+// CHECK:       %[[RANK_REDUCED:.*]] = memref.subview %[[VIEW]][0, 0] [1, %[[DYNAMIC_SIZE]]] [1, 1]
+// CHECK-SAME:  to memref<?xf32, strided<[1]>>
+// CHECK:       %[[SUBVIEW:.*]] = memref.subview %[[RANK_REDUCED]][0] [%[[DYNAMIC_SIZE]]] [1]
+// CHECK-SAME:  to memref<?xf32, strided<[1]>>
+// CHECK:       memref.load %[[SUBVIEW]][%{{.*}}] : memref<?xf32, strided<[1]>>
+
+// CHECK-LABEL: func.func @pointer_cast_offset_return(
+// CHECK-SAME:  %[[ADDRESS:[^ ,]+]]: i64
+// CHECK:       %[[CAPACITY:.*]] = arith.addi %[[VIEW_SIZE:.*]], %[[VIEW_OFFSET:.*]] : index
+// CHECK:       %[[POINTER:.*]] = hivm.hir.pointer_cast(%[[ADDRESS]]) [%[[CAPACITY]]] : memref<?xf32>
+// CHECK:       %[[VIEW:.*]] = memref.reinterpret_cast %[[POINTER]] to offset: [1], sizes: [1], strides: [1]
+// CHECK-SAME:  to memref<1xf32, strided<[1], offset: 1>>
+// CHECK:       return %[[VIEW]] : memref<1xf32, strided<[1], offset: 1>>
+
+// CHECK-LABEL: func.func @pointer_cast_dynamic_offset_return(
+// CHECK-SAME:  %[[ADDRESS:[^ ,]+]]: i64, %[[OFFSET:[^ ,]+]]: index
+// CHECK:       %[[ZERO:.*]] = arith.constant 0 : index
+// CHECK:       %[[LEADING_EXTENT:.*]] = arith.maxsi %[[OFFSET]], %[[ZERO]] : index
+// CHECK:       %[[CAPACITY:.*]] = arith.addi %[[VIEW_SIZE:.*]], %[[LEADING_EXTENT]] : index
+// CHECK:       %[[POINTER:.*]] = hivm.hir.pointer_cast(%[[ADDRESS]]) [%[[CAPACITY]]] : memref<?xf32>
+// CHECK:       %[[VIEW:.*]] = memref.reinterpret_cast %[[POINTER]] to offset: [%[[OFFSET]]], sizes: [1], strides: [1]
+// CHECK-SAME:  to memref<1xf32, strided<[1], offset: ?>>
+// CHECK:       return %[[VIEW]] : memref<1xf32, strided<[1], offset: ?>>
+
+// CHECK-LABEL: func.func @pointer_cast_offset_call(
+// CHECK-SAME:  %[[ADDRESS:[^ ,]+]]: i64
+// CHECK:       %[[POINTER:.*]] = hivm.hir.pointer_cast(%[[ADDRESS]])
+// CHECK:       %[[VIEW:.*]] = memref.reinterpret_cast %[[POINTER]] to offset: [1], sizes: [1], strides: [1]
+// CHECK-SAME:  to memref<1xf32, strided<[1], offset: 1>>
+// CHECK:       call @consume_offset_view(%[[VIEW]])
+
+// CHECK-LABEL: func.func @pointer_cast_offset_if(
+// CHECK-SAME:  %[[ADDRESS:[^ ,]+]]: i64
+// CHECK:       %[[POINTER:.*]] = hivm.hir.pointer_cast(%[[ADDRESS]])
+// CHECK:       %[[VIEW:.*]] = memref.reinterpret_cast %[[POINTER]] to offset: [1], sizes: [1], strides: [1]
+// CHECK-SAME:  to memref<1xf32, strided<[1], offset: 1>>
+// CHECK:       scf.if
+// CHECK-SAME:  -> (memref<1xf32, strided<[1], offset: 1>>)
+// CHECK:       call @next_offset_view(%[[VIEW]])
+// CHECK:       scf.yield {{.*}} : memref<1xf32, strided<[1], offset: 1>>
+
+// CHECK-LABEL: func.func @pointer_cast_offset_loop(
+// CHECK-SAME:  %[[ADDRESS:[^ ,]+]]: i64
+// CHECK:       %[[POINTER:.*]] = hivm.hir.pointer_cast(%[[ADDRESS]])
+// CHECK:       %[[VIEW:.*]] = memref.reinterpret_cast %[[POINTER]] to offset: [1], sizes: [1], strides: [1]
+// CHECK-SAME:  to memref<1xf32, strided<[1], offset: 1>>
+// CHECK:       scf.for
+// CHECK-SAME:  memref<1xf32, strided<[1], offset: 1>>
+
+// CHECK-LABEL: func.func @pointer_cast_offset_while(
+// CHECK-SAME:  %[[ADDRESS:[^ ,]+]]: i64
+// CHECK:       %[[POINTER:.*]] = hivm.hir.pointer_cast(%[[ADDRESS]])
+// CHECK:       %[[VIEW:.*]] = memref.reinterpret_cast %[[POINTER]] to offset: [1], sizes: [1], strides: [1]
+// CHECK-SAME:  to memref<1xf32, strided<[1], offset: 1>>
+// CHECK:       scf.while
+// CHECK-SAME:  memref<1xf32, strided<[1], offset: 1>>
+// CHECK:       scf.condition
+// CHECK-SAME:  memref<1xf32, strided<[1], offset: 1>>

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/tensor_pointer_descriptor_loop.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/tensor_pointer_descriptor_loop.mlir
@@ -1,0 +1,28 @@
+// RUN: triton-opt --triton-control-flow-opt --triton-to-linalg %s -verify-each | FileCheck %s
+
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @tensor_pointer_descriptor_loop(
+      %base: !tt.ptr<f32>, %output: !tt.ptr<f32>, %upper: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %delta = arith.constant dense<1> : tensor<4xi32>
+    %range = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %base_tensor = tt.splat %base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %initial = tt.addptr %base_tensor, %range : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    %final = scf.for %iv = %c0 to %upper step %c1 iter_args(%ptr = %initial) -> (tensor<4x!tt.ptr<f32>>) {
+      %next = tt.addptr %ptr, %delta : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scf.yield %next : tensor<4x!tt.ptr<f32>>
+    }
+    %value = tt.load %final : tensor<4x!tt.ptr<f32>>
+    %output_tensor = tt.splat %output : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %output_ptr = tt.addptr %output_tensor, %range : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    tt.store %output_ptr, %value : tensor<4x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: func.func @tensor_pointer_descriptor_loop
+// CHECK:       scf.for
+// CHECK-SAME:  tensor<4xi32>
+// CHECK-NOT:   tensor<4x!tt.ptr
+// CHECK-NOT:   unrealized_conversion_cast

--- a/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/bubbleupoperation.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/bubbleupoperation.mlir
@@ -69,6 +69,18 @@ tt.func @test_addptr_extract_bubbleup(%a: tensor<128x!tt.ptr<f32>>, %b: tensor<1
     tt.return %1 : !tt.ptr<f32>
 }
 
+// CHECK-LABEL: tt.func @test_select_pointer_extract_bubbleup
+// CHECK: %[[CONDITION:.*]] = tensor.extract %{{.*}}[%{{.*}}] {DiscreteMemAccess} : tensor<4xi1>
+// CHECK: %[[TRUE_VALUE:.*]] = tensor.extract %{{.*}}[%{{.*}}] {DiscreteMemAccess} : tensor<4x!tt.ptr<f32>>
+// CHECK: %[[FALSE_VALUE:.*]] = tensor.extract %{{.*}}[%{{.*}}] {DiscreteMemAccess} : tensor<4x!tt.ptr<f32>>
+// CHECK: arith.select %[[CONDITION]], %[[TRUE_VALUE]], %[[FALSE_VALUE]] : !tt.ptr<f32>
+tt.func @test_select_pointer_extract_bubbleup(
+    %condition: tensor<4xi1>, %true_value: tensor<4x!tt.ptr<f32>>,
+    %false_value: tensor<4x!tt.ptr<f32>>, %i: index) -> !tt.ptr<f32> {
+    %selected = arith.select %condition, %true_value, %false_value : tensor<4xi1>, tensor<4x!tt.ptr<f32>>
+    %pointer = tensor.extract %selected[%i] : tensor<4x!tt.ptr<f32>>
+    tt.return %pointer : !tt.ptr<f32>
+}
 
 // CHECK-LABEL: tt.func @test_ceil_extract_bubbleup
 tt.func @test_ceil_extract_bubbleup(%a: tensor<128xf32>, %i: index, %c: f32) -> f32 {

--- a/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/tensor_pointer_select.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/tensor_pointer_select.mlir
@@ -1,0 +1,27 @@
+// RUN: triton-opt %s --triton-to-unstructure | FileCheck %s
+
+tt.func public @opaque_tensor_pointer_select(
+    %lhs: !tt.ptr<f32>, %rhs: !tt.ptr<f32>) -> tensor<4xf32> {
+  %zero = arith.constant dense<0> : tensor<4xi32>
+  %one = arith.constant dense<1> : tensor<4xi32>
+  %range = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+  %lhs_tensor = tt.splat %lhs : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+  %rhs_tensor = tt.splat %rhs : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+  %lhs_ptrs = tt.addptr %lhs_tensor, %range : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+  %rhs_ptrs = tt.addptr %rhs_tensor, %range : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+  %bits = arith.andi %range, %one : tensor<4xi32>
+  %condition = arith.cmpi eq, %bits, %zero : tensor<4xi32>
+  %selected = arith.select %condition, %lhs_ptrs, %rhs_ptrs : tensor<4xi1>, tensor<4x!tt.ptr<f32>>
+  %advanced = tt.addptr %selected, %one : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+  %loaded = tt.load %advanced : tensor<4x!tt.ptr<f32>>
+  tt.return %loaded : tensor<4xf32>
+}
+
+// CHECK-LABEL: tt.func public @opaque_tensor_pointer_select
+// CHECK:       %[[SELECTED:.*]] = arith.select {{.*}} : tensor<4xi1>, tensor<4x!tt.ptr<f32>>
+// CHECK:       scf.for
+// CHECK:       %[[LANE_PTR:.*]] = tensor.extract %[[SELECTED]]{{\[}}%{{.*}}] {DiscreteMemAccess} : tensor<4x!tt.ptr<f32>>
+// CHECK:       %[[ACCESS_PTR:.*]] = tt.addptr %[[LANE_PTR]],
+// CHECK-SAME:  : !tt.ptr<f32>, i64
+// CHECK:       tt.load %[[ACCESS_PTR]] {DiscreteMemAccess} : !tt.ptr<f32>
+// CHECK:       tt.return

--- a/third_party/ascend/unittest/pytest_ut/test_control_flow_pointer_boundary.py
+++ b/third_party/ascend/unittest/pytest_ut/test_control_flow_pointer_boundary.py
@@ -1,0 +1,247 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+import triton
+import triton.language as tl
+
+BLOCK = 32
+N = 128
+
+
+@triton.jit
+def block_ptr_if_descriptor_kernel(a, b, out, choose_ptr, descriptor_ptr, BLOCK: tl.constexpr):
+    choose = tl.load(choose_ptr)
+    size_a = tl.load(descriptor_ptr)
+    size_b = tl.load(descriptor_ptr + 1)
+    stride_a = tl.load(descriptor_ptr + 2)
+    stride_b = tl.load(descriptor_ptr + 3)
+    offset_a = tl.load(descriptor_ptr + 4)
+    offset_b = tl.load(descriptor_ptr + 5)
+    if choose != 0:
+        pointer = tl.make_block_ptr(
+            base=a + 3,
+            shape=(size_a, ),
+            strides=(stride_a, ),
+            offsets=(offset_a, ),
+            block_shape=(BLOCK, ),
+            order=(0, ),
+        )
+    else:
+        pointer = tl.make_block_ptr(
+            base=b + 11,
+            shape=(size_b, ),
+            strides=(stride_b, ),
+            offsets=(offset_b, ),
+            block_shape=(BLOCK, ),
+            order=(0, ),
+        )
+    value = tl.load(pointer, boundary_check=(0, ), padding_option="zero")
+    tl.store(out + tl.arange(0, BLOCK), value)
+
+
+@triton.jit
+def block_ptr_for_descriptor_kernel(a, b, out, scalar_out, steps_ptr, descriptor_ptr, BLOCK: tl.constexpr):
+    steps = tl.load(steps_ptr)
+    size_a = tl.load(descriptor_ptr)
+    size_b = tl.load(descriptor_ptr + 1)
+    stride_a = tl.load(descriptor_ptr + 2)
+    stride_b = tl.load(descriptor_ptr + 3)
+    pointer = tl.make_block_ptr(
+        base=a,
+        shape=(size_a, ),
+        strides=(stride_a, ),
+        offsets=(1, ),
+        block_shape=(BLOCK, ),
+        order=(0, ),
+    )
+    ordinary_result = 17
+    for i in tl.range(0, steps):
+        if (i & 1) == 0:
+            pointer = tl.advance(pointer, (2, ))
+        else:
+            pointer = tl.make_block_ptr(
+                base=b,
+                shape=(size_b, ),
+                strides=(stride_b, ),
+                offsets=(i + 3, ),
+                block_shape=(BLOCK, ),
+                order=(0, ),
+            )
+        ordinary_result = ordinary_result + i + 1
+    value = tl.load(pointer, boundary_check=(0, ), padding_option="zero")
+    tl.store(out + tl.arange(0, BLOCK), value)
+    tl.store(scalar_out, ordinary_result)
+
+
+@triton.jit
+def block_ptr_while_descriptor_kernel(a, b, out, steps_ptr, switch_at_ptr, n: tl.constexpr, BLOCK: tl.constexpr):
+    steps = tl.load(steps_ptr)
+    switch_at = tl.load(switch_at_ptr)
+    pointer = tl.make_block_ptr(
+        base=a,
+        shape=(n, ),
+        strides=(1, ),
+        offsets=(0, ),
+        block_shape=(BLOCK, ),
+        order=(0, ),
+    )
+    i = 0
+    while i < steps:
+        if i == switch_at:
+            pointer = tl.make_block_ptr(
+                base=b,
+                shape=(n - 3, ),
+                strides=(1, ),
+                offsets=(1, ),
+                block_shape=(BLOCK, ),
+                order=(0, ),
+            )
+        else:
+            pointer = tl.advance(pointer, (2, ))
+        i += 1
+    value = tl.load(pointer, boundary_check=(0, ), padding_option="zero")
+    tl.store(out + tl.arange(0, BLOCK), value)
+
+
+@triton.jit
+def scalar_base_tensor_ptr_loop_kernel(x, out, steps_ptr, n: tl.constexpr, BLOCK: tl.constexpr):
+    steps = tl.load(steps_ptr)
+    lane = tl.arange(0, BLOCK)
+    pointers = x + 3 + lane
+    for _ in tl.range(0, steps):
+        pointers = pointers + 2
+    index = 3 + lane + 2 * steps
+    value = tl.load(pointers, mask=index < n, other=0.0)
+    tl.store(out + lane, value)
+
+
+@triton.jit
+def opaque_tensor_ptr_loop_kernel(a, b, out, steps_ptr, n: tl.constexpr, BLOCK: tl.constexpr):
+    steps = tl.load(steps_ptr)
+    lane = tl.arange(0, BLOCK)
+    pointers = tl.where((lane & 1) == 0, a + lane, b + lane)
+    for _ in tl.range(0, steps):
+        pointers = pointers + 1
+    index = lane + steps
+    value = tl.load(pointers, mask=index < n, other=0.0)
+    tl.store(out + lane, value)
+
+
+def _inputs():
+    a_cpu = torch.arange(2048, dtype=torch.float32)
+    b_cpu = 100000.0 + torch.arange(2048, dtype=torch.float32) * 3.0
+    return a_cpu, b_cpu, a_cpu.npu(), b_cpu.npu()
+
+
+def _device_i32(value):
+    return torch.tensor([value], dtype=torch.int32, device="npu")
+
+
+def _slice(source, base_offset, logical_size, stride, offset):
+    expected = torch.zeros(BLOCK, dtype=source.dtype)
+    for lane in range(BLOCK):
+        logical_index = offset + lane
+        if 0 <= logical_index < logical_size:
+            expected[lane] = source[base_offset + logical_index * stride]
+    return expected
+
+
+def _assert_output(actual, expected):
+    torch.npu.synchronize()
+    torch.testing.assert_close(actual.cpu(), expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("choose", [0, 1])
+def test_block_ptr_if_carries_complete_dynamic_descriptor(choose):
+    a_cpu, b_cpu, a, b = _inputs()
+    descriptor = torch.tensor([40, 29, 2, 3, 3, 5], dtype=torch.int64, device="npu")
+    choose_ptr = _device_i32(choose)
+    out = torch.empty(BLOCK, dtype=torch.float32, device="npu")
+
+    block_ptr_if_descriptor_kernel[(1, )](a, b, out, choose_ptr, descriptor, BLOCK=BLOCK)
+
+    if choose:
+        expected = _slice(a_cpu, 3, 40, 2, 3)
+    else:
+        expected = _slice(b_cpu, 11, 29, 3, 5)
+    _assert_output(out, expected)
+
+
+@pytest.mark.parametrize("steps", [0, 2, 5])
+def test_block_ptr_for_carries_changing_descriptor_and_ordinary_result(steps):
+    a_cpu, b_cpu, a, b = _inputs()
+    descriptor = torch.tensor([60, 55, 2, 3], dtype=torch.int64, device="npu")
+    out = torch.empty(BLOCK, dtype=torch.float32, device="npu")
+    scalar_out = torch.empty(1, dtype=torch.int32, device="npu")
+
+    block_ptr_for_descriptor_kernel[(1, )](a, b, out, scalar_out, _device_i32(steps), descriptor, BLOCK=BLOCK)
+
+    source, logical_size, stride, offset = a_cpu, 60, 2, 1
+    for i in range(steps):
+        if (i & 1) == 0:
+            offset += 2
+        else:
+            source, logical_size, stride, offset = b_cpu, 55, 3, i + 3
+    _assert_output(out, _slice(source, 0, logical_size, stride, offset))
+    assert scalar_out.cpu().item() == 17 + steps * (steps + 1) // 2
+
+
+@pytest.mark.parametrize("steps,switch_at", [(0, -1), (4, -1), (4, 2)])
+def test_block_ptr_while_carries_descriptor(steps, switch_at):
+    a_cpu, b_cpu, a, b = _inputs()
+    out = torch.empty(BLOCK, dtype=torch.float32, device="npu")
+
+    block_ptr_while_descriptor_kernel[(1, )](a, b, out, _device_i32(steps), _device_i32(switch_at), n=N, BLOCK=BLOCK)
+
+    source, logical_size, offset = a_cpu, N, 0
+    for i in range(steps):
+        if i == switch_at:
+            source, logical_size, offset = b_cpu, N - 3, 1
+        else:
+            offset += 2
+    _assert_output(out, _slice(source, 0, logical_size, 1, offset))
+
+
+@pytest.mark.parametrize("steps", [0, 2, 4])
+def test_scalar_base_tensor_pointer_loop(steps):
+    a_cpu, _, a, _ = _inputs()
+    out = torch.empty(BLOCK, dtype=torch.float32, device="npu")
+
+    scalar_base_tensor_ptr_loop_kernel[(1, )](a, out, _device_i32(steps), n=N, BLOCK=BLOCK)
+
+    _assert_output(out, _slice(a_cpu, 0, N, 1, 3 + 2 * steps))
+
+
+@pytest.mark.parametrize("steps", [0, 2, 4])
+def test_opaque_tensor_pointer_loop(steps):
+    a_cpu, b_cpu, a, b = _inputs()
+    out = torch.empty(BLOCK, dtype=torch.float32, device="npu")
+
+    opaque_tensor_ptr_loop_kernel[(1, )](a, b, out, _device_i32(steps), n=N, BLOCK=BLOCK)
+
+    expected = torch.zeros(BLOCK, dtype=torch.float32)
+    for lane in range(BLOCK):
+        index = lane + steps
+        if index < N:
+            expected[lane] = a_cpu[index] if (lane & 1) == 0 else b_cpu[index]
+    _assert_output(out, expected)


### PR DESCRIPTION
## Motivation

Triton block pointers and tensors of pointers could cross `scf.for`,
`scf.while`, and `scf.if` boundaries as Triton pointer-typed SSA values. This
made the downstream conversion depend on pointer values embedded in SCF
signatures and prevented control-flow lowering from using ordinary scalar or
tensor state consistently.

This change establishes a pointer-free boundary representation for supported
pointer states. `TritonControlFlowOpt` analyzes an entire control-flow subtree,
expands the selected pointer results into descriptor components, and rebuilds
the original Triton pointer only at use sites. The downstream passes consume
the descriptor contract without changing unrelated pointer code.

## Changes

### 1. Carry complete block-pointer descriptors across SCF

A block pointer is represented as:

```mlir
[base_address, shape..., strides..., offsets...]
```

`base_address` is an `i64`; shape, stride, and offset components retain their
original integer types. The `order` attribute remains compile-time metadata.
All descriptor components are carried for a rewritten block-pointer boundary,
which gives `for`, `while`, and `if` one stable positional schema.

```mlir
// Before
%final = scf.for ... iter_args(%ptr = %initial)
    -> (!tt.ptr<tensor<16xf32>>) {
  %next = tt.advance %ptr, [%delta]
  scf.yield %next : !tt.ptr<tensor<16xf32>>
}

// After
%desc:4 = scf.for ...
    iter_args(%base = %base_addr, %shape = %s, %stride = %st, %off = %o)
    -> (i64, i64, i64, i32) {
  %next_off = arith.addi %off, %delta : i32
  scf.yield %base, %shape, %stride, %next_off
      : i64, i64, i64, i32
}
%base = tt.int_to_ptr %desc#0 : i64 -> !tt.ptr<f32>
%ptr = tt.make_tensor_ptr %base, [%desc#1], [%desc#2], [%desc#3]
    {order = array<i32: 0>} : !tt.ptr<tensor<16xf32>>
```

### 2. Separate read-only control-flow analysis from IR rewriting

The pass first computes a schema for every supported SCF result and backedge.
No operations are created during this phase. Rewriting starts only after the
whole control-flow subtree has a compatible plan, so nested control flow uses
the same component order at every edge.

```mlir
// One schema is planned for the nested result before either op is rewritten.
%selected = scf.if %outer_cond -> (!tt.ptr<tensor<16xf32>>) {
  %inner = scf.if %inner_cond -> (!tt.ptr<tensor<16xf32>>) {
    scf.yield %ptr0 : !tt.ptr<tensor<16xf32>>
  } else {
    scf.yield %ptr1 : !tt.ptr<tensor<16xf32>>
  }
  scf.yield %inner : !tt.ptr<tensor<16xf32>>
} else {
  scf.yield %ptr2 : !tt.ptr<tensor<16xf32>>
}

// Both nested joins use the same descriptor result schema.
%inner_desc:4 = scf.if ... -> (i64, i64, i64, i32)
%outer_desc:4 = scf.if ... -> (i64, i64, i64, i32)
```

### 3. Keep complete descriptors correct for dynamic loop behavior

Loop bounds, steps, and pointer deltas may be dynamic. Pointer advancement is
lowered to loop-carried offset arithmetic instead of an induction-variable
closed form, so zero-trip loops and deltas defined in the loop body preserve
the original SCF semantics.

```mlir
// Dynamic delta computed in the body.
%delta = arith.addi %iter_delta, %one : i32
%next = tt.advance %ptr, [%delta]

// Rewritten backedge.
%next_offset = arith.addi %offset, %delta : i32
scf.yield %base_addr, %shape, %stride, %next_offset, %delta
    : i64, i64, i64, i32, i32
```

### 4. Support branch-selected and addptr-derived block-pointer bases

Different `scf.if` branches may select different block-pointer bases. Each
branch yields the corresponding integer address and the pointer is rebuilt
after the join. A `tt.make_tensor_ptr` whose base is produced by `tt.addptr` is
accepted when it actually crosses a supported SCF boundary. Local block
pointers are not globally rejected or rewritten.

```mlir
%ptr0 = tt.make_tensor_ptr %base0, ...
%ptr1 = tt.make_tensor_ptr %base1, ...
%selected = scf.if %cond -> (!tt.ptr<tensor<16xf32>>) {
  scf.yield %ptr0 : !tt.ptr<tensor<16xf32>>
} else {
  scf.yield %ptr1 : !tt.ptr<tensor<16xf32>>
}

// Rewritten join.
%addr0 = tt.ptr_to_int %base0 : !tt.ptr<f32> -> i64
%addr1 = tt.ptr_to_int %base1 : !tt.ptr<f32> -> i64
%desc:4 = scf.if %cond -> (i64, i64, i64, i32) {
  scf.yield %addr0, %shape0, %stride0, %offset0
} else {
  scf.yield %addr1, %shape1, %stride1, %offset1
}
```

An unrelated local descriptor remains local:

```mlir
%shifted = tt.addptr %base, %offset : !tt.ptr<f32>, i32
%local = tt.make_tensor_ptr %shifted, ...
%value = tt.load %local : !tt.ptr<tensor<16xf32>>
```

### 5. Represent tensor-of-pointers as common base plus complete offsets

For `tensor<...x!tt.ptr<T>>`, the policy records:

```mlir
[common_base, complete_offsets]
```

A scalar pointer introduced by `tt.splat` is retained outside a loop while the
complete per-lane offsets tensor is carried only when it changes. Chained
`tt.addptr` operations are flattened into the complete offsets. The component
model keeps an explicit base slot so a future analysis can support richer
tensor-base decomposition without changing the shared control-flow rewrite.

```mlir
%base_tensor = tt.splat %base
%initial = tt.addptr %base_tensor, %range
%final = scf.for ... iter_args(%ptr = %initial)
    -> (tensor<4x!tt.ptr<f32>>) {
  %next = tt.addptr %ptr, %delta
  scf.yield %next : tensor<4x!tt.ptr<f32>>
}

// The invariant scalar base stays outside; only offsets cross the loop.
%final_offsets = scf.for ... iter_args(%offsets = %range)
    -> (tensor<4xi32>) {
  %next_offsets = arith.addi %offsets, %delta : tensor<4xi32>
  scf.yield %next_offsets : tensor<4xi32>
}
%base_tensor = tt.splat %base
%final_ptrs = tt.addptr %base_tensor, %final_offsets
```

### 6. Mark the exact descriptor slots consumed downstream

Rewritten loops receive `PointerDescriptorBoundary`, a dense array containing
only the loop slots that belong to pointer descriptors. When multiple pointer
policies rewrite the same loop, existing slots are remapped into the new
signature and merged with the newly expanded slots.

```mlir
%results = scf.for ...
    iter_args(%acc = %zero, %base = %addr, %shape = %s,
              %stride = %st, %offset = %o, %ordinary = %value)
    -> (i32, i64, i64, i64, i32, tensor<16xf32>) {
  ...
} {PointerDescriptorBoundary = array<i32: 1, 2, 3, 4>}
```

`TritonToLinalg` uses those exact slots as producer-preservation roots. It does
not retain unrelated accumulators, masks, bounds, or ordinary tensor state.
Malformed or duplicate slot metadata is rejected.

### 7. Preserve mixed boundaries and legacy pointer conversion

A loop can contain both CFO-expanded descriptor slots and a residual pointer
slot that a later policy proved invariant. Such a loop is not treated as fully
pointer-free. The descriptor roots are preserved, while the existing legacy
loop conversion remains responsible for the residual pointer.

```mlir
// BlockPtr expands, while an invariant tensor-of-pointers remains in slot 4.
%loop:5 = scf.for ...
    -> (i64, i64, i64, i32, tensor<4x!tt.ptr<f32>>) {
  ...
} {PointerDescriptorBoundary = array<i32: 0, 1, 2, 3>}
```

After `TritonToLinalg`, both paths converge on a legal pointer-free boundary
instead of skipping conversion merely because the marker exists.

### 8. Lower scalar pointer joins through integer address carriers

Scalar pointer `arith.select`, pointer `scf.if` joins, `tt.ptr_to_int`, and
`tt.int_to_ptr` round trips are lowered through integer addresses. This avoids
requiring `arith.select` or SCF to choose between memrefs whose layouts may
differ.

```mlir
// Triton input.
%selected = arith.select %cond, %lhs, %rhs : !tt.ptr<f32>
%address = tt.ptr_to_int %selected : !tt.ptr<f32> -> i64

// Lowered address selection.
%lhs_index = memref.extract_aligned_pointer_as_index %lhs
%lhs_address = arith.index_cast %lhs_index : index to i64
%rhs_index = memref.extract_aligned_pointer_as_index %rhs
%rhs_address = arith.index_cast %rhs_index : index to i64
%address = arith.select %cond, %lhs_address, %rhs_address : i64
```

Pointer-valued `scf.if` uses the same carrier rule:

```mlir
%address = scf.if %cond -> (i64) {
  scf.yield %lhs_address : i64
} else {
  scf.yield %rhs_address : i64
}
```

### 9. Rebase memref layouts without breaking typed boundaries

When a pointer address absorbs a descriptor offset, the corresponding
`memref.reinterpret_cast` is rebased to offset zero. Result layouts are
propagated through chained and rank-reduced `memref.subview` operations.
Layout-sensitive consumers such as `scf.yield`, `scf.condition`, `func.return`,
and `func.call` retain their declared memref type instead of receiving an
incompatible rewritten layout.

```mlir
// Before rebasing.
%view = memref.reinterpret_cast %ptr to offset: [%offset],
    sizes: [1, 8], strides: [8, 1]
    : memref<?xf32> to memref<1x8xf32, strided<[8, 1], offset: ?>>

// Address absorbs offset * sizeof(f32); the internal view starts at zero.
%byte_offset = arith.muli %offset_i64, %c4_i64 : i64
%real_address = arith.addi %address, %byte_offset : i64
%rebased = hivm.hir.pointer_cast(%real_address) [%capacity] : memref<?xf32>
%view = memref.reinterpret_cast %rebased to offset: [0],
    sizes: [1, 8], strides: [8, 1]
    : memref<?xf32> to memref<1x8xf32, strided<[8, 1]>>
```

At a fixed function or SCF boundary, the declared layout remains unchanged:

```mlir
func.return %view : memref<1xf32, strided<[1], offset: 1>>
```

### 10. Lower opaque tensor-pointer operations lane by lane

`TritonToUnstructure` can now bubble `tensor.extract` through pointer
`arith.select` and preserve opaque tensor-pointer expressions until the lane is
known. Offset analysis and argument replacement then lower each selected lane
to scalar pointer arithmetic and memory access.

```mlir
%selected = arith.select %condition, %lhs_ptrs, %rhs_ptrs
    : tensor<4xi1>, tensor<4x!tt.ptr<f32>>
%advanced = tt.addptr %selected, %delta
%loaded = tt.load %advanced : tensor<4x!tt.ptr<f32>>

// Representative unstructured lane.
%lane_cond = tensor.extract %condition[%i] : tensor<4xi1>
%lhs = tensor.extract %lhs_ptrs[%i] : tensor<4x!tt.ptr<f32>>
%rhs = tensor.extract %rhs_ptrs[%i] : tensor<4x!tt.ptr<f32>>
%lane_base = arith.select %lane_cond, %lhs, %rhs : !tt.ptr<f32>
%lane_ptr = tt.addptr %lane_base, %lane_delta : !tt.ptr<f32>, i64
%value = tt.load %lane_ptr {DiscreteMemAccess} : !tt.ptr<f32>
```

## Regression coverage

The change adds or updates focused MLIR coverage for:

- full block-pointer descriptors across `scf.for`, `scf.while`, `scf.if`,
  nested control flow, dynamic deltas, and zero-trip loops;
- different and `tt.addptr`-derived block-pointer bases;
- exact descriptor-marker slot remapping and mixed pointer boundaries;
- scalar pointer selects, integer round trips, memref rebasing, subviews, and
  fixed `return`/`call`/`if`/`for`/`while` layout boundaries;
- tensor-pointer descriptor loops and opaque lane-wise pointer selection;
- an end-to-end pytest covering dynamic block-pointer and tensor-pointer
  control-flow cases.
