### PR TITLE
[build](fix) delete submodule Triton-distributed-ascend

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,3 @@
 	path = third_party/ascend/AscendNPU-IR
 	url = https://gitcode.com/Ascend/AscendNPU-IR.git
     depth = 1
-[submodule "third_party/ascend/Triton-distributed-ascend"]
-	path = third_party/ascend/Triton-distributed-ascend
-	url = https://gitcode.com/Ascend/Triton-distributed-ascend.git

--- a/python/setup.py
+++ b/python/setup.py
@@ -566,7 +566,7 @@ class CMakeBuild(build_ext):
         else:
             cmake_args += ["-DTRITON_BUILD_PROTON=OFF"]
 
-        if check_env_flag("TRITON_BUILD_DISTRIBUTED", "ON"):
+        if check_env_flag("TRITON_BUILD_DISTRIBUTED", "OFF"):
             cmake_args += ["-DTRITON_BUILD_DISTRIBUTED=ON"]
         else:
             cmake_args += ["-DTRITON_BUILD_DISTRIBUTED=OFF"]
@@ -609,14 +609,28 @@ def is_git_repo():
 
 
 def ensure_distributed_submodule():
-    if not check_env_flag("TRITON_BUILD_DISTRIBUTED", "ON"):
+    if not check_env_flag("TRITON_BUILD_DISTRIBUTED", "OFF"):
         return
     distributed_dir = Path(triton_dir) / "third_party" / "ascend" / "Triton-distributed-ascend"
-    if not (distributed_dir / "CMakeLists.txt").is_file() and is_git_repo():
+    if not distributed_dir.is_dir():
         subprocess.check_call([
-            "git", "submodule", "update", "--init", "--",
-            "third_party/ascend/Triton-distributed-ascend"
-        ], cwd=triton_dir)
+            "git",
+            "clone",
+            "https://gitcode.com/Ascend/Triton-distributed-ascend.git",
+            "-b",
+            "release/3.2.2",
+        ], cwd=Path(triton_dir) / "third_party" / "ascend")
+    if is_git_repo():
+        subprocess.check_call([
+            "git",
+            "checkout",
+            "release/3.2.2",
+        ], cwd=distributed_dir)
+        subprocess.check_call([
+            "git",
+            "pull",
+            "origin",
+        ], cwd=distributed_dir)
     if not (distributed_dir / "CMakeLists.txt").is_file():
         raise RuntimeError(f"Triton-Distributed submodule is not initialized: {distributed_dir}")
 
@@ -735,7 +749,7 @@ def add_links():
     add_link_to_backends()
     if check_env_flag("TRITON_BUILD_PROTON", "ON"):  # Default ON
         add_link_to_proton()
-    if check_env_flag("TRITON_BUILD_DISTRIBUTED", "ON"):
+    if check_env_flag("TRITON_BUILD_DISTRIBUTED", "OFF"):
         add_link_to_distributed()
 
 
@@ -841,7 +855,7 @@ def get_packages():
     packages += get_language_extra_packages()
     if check_env_flag("TRITON_BUILD_PROTON", "ON"):  # Default ON
         packages += ["triton/profiler"]
-    if check_env_flag("TRITON_BUILD_DISTRIBUTED", "ON"):
+    if check_env_flag("TRITON_BUILD_DISTRIBUTED", "OFF"):
         distributed_root = os.path.join(os.pardir, "third_party", "ascend", "Triton-distributed-ascend", "python")
         distributed_pkg_root = os.path.join(distributed_root, "triton_dist")
         if os.path.isdir(distributed_pkg_root):


### PR DESCRIPTION
Fixing the cyclic reference issue
Symptom:
The submodule of td contains triton-ascend, and the submodule of triton-ascend contains td. As a result, a cyclic reference occurs when td pulls code.

<img width="160" height="164" alt="image" src="https://github.com/user-attachments/assets/5a94b2e3-b197-45a0-951a-3d7182f3583c" />


Solution:
The td submodule is removed from triton-ascend. The td code is pulled only when necessary using git clone, avoiding cyclic reference.
<img width="153" height="166" alt="image" src="https://github.com/user-attachments/assets/0988a1c5-2bef-49ef-abe3-d99a2067bf2a" />

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)