### PR TITLE
[OpClassifier](fix) share cube upstream skip rules across both BFS paths

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h
+++ b/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h
@@ -113,6 +113,11 @@ private:
   // Propagate CUBE upstream for a specific operation
   void propagateCubeUpstreamForOp(Operation *startOp);
 
+  // Shared skip predicates for both CUBE upstream BFS paths so the rules stay
+  // consistent: arith ops with tensor results, ExtractedLoadStore-related ops,
+  // and ops inside a nested linalg region.
+  bool shouldSkipCubeUpstream(Operation *op);
+
   // Helper: Handle fill op in scf.if - if all ops in scf.if are CUBE, mark
   // scf.if and propagate upstream
   void handleFillInScfIf(Operation *fillOp);

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -756,34 +756,10 @@ int OpClassifierPass::propagateCubeUpstream() {
       if (!def || cubeVisited.count(def) || isa<linalg::MatmulOp>(def))
         continue;
 
-      // Skip arith dialect ops with tensor results (they should be VECTOR, not
-      // CUBE)
-      if (isa<arith::ArithDialect>(def->getDialect())) {
-        bool hasTensorResult = false;
-        for (Value result : def->getResults()) {
-          if (isa<RankedTensorType>(result.getType())) {
-            hasTensorResult = true;
-            break;
-          }
-        }
-        if (hasTensorResult) {
-          LLVM_DEBUG(DBGS() << "skip " << def->getName().getStringRef()
-                            << ": arith tensor op\n");
-          continue;
-        }
-      }
-
-      // Skip ExtractedLoadOrStore related op
-      if (isExtractedLoadStoreRelated(def))
+      // Skip rules are shared with propagateCubeUpstreamForOp; see
+      // shouldSkipCubeUpstream for details.
+      if (shouldSkipCubeUpstream(def))
         continue;
-
-      // Skip operations inside linalg block (internal values)
-      // But don't skip the linalg op itself
-      if (isInsideNestedLinalgRegion(def)) {
-        LLVM_DEBUG(DBGS() << "skip " << def->getName().getStringRef()
-                          << ": inside linalg block\n");
-        continue;
-      }
 
       cubeVisited.insert(def);
 
@@ -938,6 +914,43 @@ void OpClassifierPass::handleFillInScfIf(Operation *fillOp) {
   }
 }
 
+// Helper: shared skip predicates for CUBE upstream BFS.
+//
+// Mirrors the three skip rules that lived inline inside propagateCubeUpstream
+// so propagateCubeUpstreamForOp (triggered by handleFillInScfIf) stays
+// consistent with the main BFS. Without this, fill-in-scf.if propagation
+// would over-color ExtractedLoadStore-related ops and ops inside a nested
+// linalg region.
+//
+// Returns true (and emits the matching debug log) if `op` should NOT be
+// coloured CUBE during upstream propagation.
+bool OpClassifierPass::shouldSkipCubeUpstream(Operation *op) {
+  // arith dialect ops with tensor results are vector compute, not CUBE.
+  if (isa<arith::ArithDialect>(op->getDialect())) {
+    for (Value result : op->getResults()) {
+      if (isa<RankedTensorType>(result.getType())) {
+        LLVM_DEBUG(DBGS() << "skip " << op->getName().getStringRef()
+                          << ": arith tensor op\n");
+        return true;
+      }
+    }
+  }
+
+  // ExtractedLoadOrStore related ops must stay where their original
+  // placement says.
+  if (isExtractedLoadStoreRelated(op))
+    return true;
+
+  // Internal block values inside a nested linalg region.
+  if (isInsideNestedLinalgRegion(op)) {
+    LLVM_DEBUG(DBGS() << "skip " << op->getName().getStringRef()
+                      << ": inside linalg block\n");
+    return true;
+  }
+
+  return false;
+}
+
 // Helper: Propagate CUBE core type upstream for a given operation
 void OpClassifierPass::propagateCubeUpstreamForOp(Operation *startOp) {
   std::queue<Operation *> cubeQueue;
@@ -957,6 +970,11 @@ void OpClassifierPass::propagateCubeUpstreamForOp(Operation *startOp) {
       if (!upstreamOp || cubeVisited.count(upstreamOp))
         continue;
       if (isa<linalg::MatmulOp>(upstreamOp))
+        continue;
+      // Reuse the same skip rules as the main CUBE BFS so the two paths
+      // never disagree on arith-on-tensor / ExtractedLoadStore /
+      // inside-linalg.
+      if (shouldSkipCubeUpstream(upstreamOp))
         continue;
 
       cubeVisited.insert(upstreamOp);


### PR DESCRIPTION
propagateCubeUpstreamForOp (triggered by handleFillInScfIf) re-coloured ExtractedLoadStore-related ops and ops inside a nested linalg region as CUBE because the three skip predicates (arith on tensors, isExtractedLoadStoreRelated, inside nested linalg region) only lived inline inside propagateCubeUpstream.

Extract the predicates into OpClassifierPass::shouldSkipCubeUpstream and call it from both BFS paths so they stay consistent.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
