### PR TITLE
[simt_costmodel](feat) compile route auto selection and auto scope

### DIFF
--- a/third_party/ascend/CMakeLists.txt
+++ b/third_party/ascend/CMakeLists.txt
@@ -30,6 +30,10 @@ set_property(DIRECTORY PROPERTY RULE_LAUNCH_LINK ${_saved_launch_link})
 
 include_directories(${ASCENDNPU_IR_SRC_DIR}/bishengir/include)
 include_directories(${ASCENDNPU_IR_BINARY_DIR}/bishengir/include) # Tablegen'd files
+# RouteModel exposes a small header-only execution-selection contract used by
+# backend lowerings. Make CostModel public headers visible before those targets
+# are created by add_subdirectory(lib).
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/costmodel/include)
 
 add_subdirectory(bin)
 add_subdirectory(include)
@@ -103,6 +107,20 @@ if(TRITON_ASCEND_ENABLE_COSTMODEL_INPROC)
     include_directories("${CMAKE_BINARY_DIR}/third_party/ascend/costmodel_build/include_AscendModel")
     include_directories("${TRITON_ASCEND_COSTMODEL_SOURCE_DIR}/include")
 
+    # The vendored cost model is built inside Triton-Ascend, where BiShengIR
+    # has already been added above. Enable native HIVM parsing explicitly;
+    # otherwise HIVMAnalyzer is compiled in generic/unregistered-dialect mode.
+    set(TRITONSIM_HAS_BISHENGIR_HIVM ON)
+    set(TRITONSIM_BISHENGIR_INCLUDE_DIRS
+      "${ASCENDNPU_IR_SRC_DIR}/bishengir/include"
+      "${ASCENDNPU_IR_BINARY_DIR}/bishengir/include"
+    )
+    set(TRITONSIM_BISHENGIR_HIVM_LIBS
+      BiShengIRAnnotationDialect
+      BiShengIRHACCDialect
+      BiShengIRHIVMDialect
+    )
+
     add_subdirectory(${_costmodel_include_dir} ${CMAKE_BINARY_DIR}/third_party/ascend/costmodel_build/include_AscendModel)
     add_subdirectory(${_costmodel_lib_dir} ${CMAKE_BINARY_DIR}/third_party/ascend/costmodel_build/lib_AscendModel)
     set(TRITON_ASCEND_HAS_INPROC_COSTMODEL 1)
@@ -122,6 +140,27 @@ add_triton_plugin(TritonAscend
   BiShengIRScopeDialect
   BiShengIRHIVMDialect
 )
+
+# Keep canonical Cost Model profiles under costmodel/profiles.  Python's
+# community-owned setup.py builds the native extension before build_py, so an
+# Ascend-owned CMake target can place the runtime copy next to that extension
+# without teaching setup.py about backend-specific resources.
+if(TRITON_BUILD_PYTHON_MODULE AND CMAKE_LIBRARY_OUTPUT_DIRECTORY)
+  set(_ascend_costmodel_profile_source
+      "${CMAKE_CURRENT_SOURCE_DIR}/costmodel/profiles")
+  set(_ascend_costmodel_profile_package
+      "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/ascend/costmodel_profiles")
+  add_custom_target(TritonAscendCostModelProfiles ALL
+    COMMAND ${CMAKE_COMMAND} -E make_directory
+            "${_ascend_costmodel_profile_package}"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${_ascend_costmodel_profile_source}"
+            "${_ascend_costmodel_profile_package}"
+    COMMENT "Copying Ascend Cost Model profiles beside the native extension"
+    VERBATIM
+  )
+  add_dependencies(TritonAscend TritonAscendCostModelProfiles)
+endif()
 
 option(TRITON_ENABLE_COVERAGE_LLVM_COV "Enable code llvm-cov coverage tool for Ascend plugin " OFF)
 if(TRITON_ENABLE_COVERAGE_LLVM_COV)

--- a/third_party/ascend/ascend_ir.cc
+++ b/third_party/ascend/ascend_ir.cc
@@ -29,6 +29,7 @@
 
 #include "triton/Dialect/Triton/IR/Dialect.h"
 
+#include "AscendModel/RouteModel/SimtSelection.h"
 #include "ascend/include/Dialect/TritonAscend/IR/TritonAscendDialect.h"
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
@@ -613,8 +614,40 @@ void init_ascend_ir(py::module &&m) {
     }
     return py::cast(ret.getInt());
   });
+  m.def("get_string_attr",
+        [](OpState &op, const std::string &name) -> py::object {
+          auto ret = op->getAttrOfType<StringAttr>(name);
+          if (!ret) {
+            return py::none();
+          }
+          return py::cast(ret.getValue().str());
+        });
   m.def("remove_attr",
         [](OpState &op, std::string &name) -> void { op->removeAttr(name); });
+
+  m.def("clear_simd_simt_costmodel_attrs", [](OpState &op) {
+    for (llvm::StringRef name : {
+             "ascend.simt_costmodel.effective",
+             "ascend.simt_costmodel.recommended",
+             "ascend.simt_costmodel.selection_source",
+             "ascend.simt_costmodel.ranking_confidence",
+             "ascend.simt_costmodel.all_simd_score",
+             "ascend.simt_costmodel.all_simt_score",
+             "ascend.simt_costmodel.mixed_score",
+             "ascend.simt_costmodel.report_json",
+         }) {
+      op->removeAttr(name);
+    }
+  });
+  m.def("is_whole_body_void_simt_scope", [](OpState &op) {
+    return ascend::simt_selection::findWholeBodyVoidSimtScope(
+               op.getOperation()) != nullptr;
+  });
+  m.def("inline_void_simt_scopes_for_pure_simt", [](OpState &op) {
+    return ascend::simt_selection::inlineVoidSimtScopesForPureSimt(
+        op.getOperation());
+  });
+
   py::class_<StringAttr, Attribute>(m, "str_attr", py::module_local());
   py::class_<ArrayAttr, Attribute>(m, "array_attr", py::module_local());
 

--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -245,7 +245,7 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
         # Once the C++ Route Model has made an explicit decision, lowering
         # must implement that decision rather than also applying the legacy
         # global SIMT-template switch. A mixed decision is represented solely
-        # by the materialized scope.scope<vec_mode=simt>; an all-SIMD
+        # by the materialized scope.scope<vector_mode=simt>; an all-SIMD
         # decision contains no such scope.  Keep the old global behavior only
         # for backend_default/report/off compatibility paths.
         model_owns_local_routing = cpp_decision in {
@@ -291,6 +291,8 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
         ascend.passes.ttir.add_triton_to_structure(pm, enable_mask_fallback_conversion, optimize_dynamic_offset)
         ascend.passes.ttir.add_triton_to_linalg(pm, False, named_ops, enable_nd2nz_on_vector, enable_select_analysis,
                                                 compile_on_910_95, compile_mode)
+        ascend.passes.ttir.set_enable_buffer_insert_optimization(
+            mod, metadata.get("enable_buffer_insert_optimization", True))
         if metadata["enable_dynamic_cv_pipeline"]:
             metadata["set_workspace_multibuffer"] = 0
             metadata["enable_mixed_cv"] = True
@@ -298,10 +300,6 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
             ascend.passes.ttir.set_enable_cube_block_merge(metadata["enable_cube_block_merge"])
             ascend.passes.ttir.set_enable_ub_refine_opt(mod, metadata["enable_ub_refine_opt"])
 
-            # Must run before add_dynamic_cv_pipeline because the driven
-            # AddMultiBufferInnerScope pass reads the module-level
-            # `ssbuffer.insertionOptimization` attribute (set here) at run time.
-            ascend.passes.ttir.set_enable_buffer_insert_optimization(mod, metadata["enable_buffer_insert_optimization"])
             ascend.passes.ttir.add_dynamic_cv_pipeline(pm, compile_on_910_95)
 
         _intra_val = metadata.get("intra_cache_num")
@@ -609,6 +607,17 @@ def _needs_lib_call_no_inline(metadata):
     return arch.startswith("Ascend950")
 
 
+@functools.lru_cache()
+def _npu_compiler_supports_option(compiler_path: str, option: str) -> bool:
+    """Check an optional BiShengIR flag instead of assuming toolchain parity."""
+    try:
+        result = subprocess.run([compiler_path, "--help"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+                                timeout=10, check=False)
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return option in result.stdout
+
+
 def get_auto_bind_sub_block_option(metadata):
     # auto_tile_and_bind_subblock is read from the module.
     # enable_auto_bind_sub_block is set by the user and has a higher priority.
@@ -854,7 +863,8 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
                 "--enable-hfusion-compile=true",
                 "--enable-triton-kernel-compile=true",
             ]
-            if _needs_lib_call_no_inline(metadata):
+            if (_needs_lib_call_no_inline(metadata)
+                    and _npu_compiler_supports_option(npu_compiler_path, "--enable-lib-call-no-inline")):
                 _compile_option_list += ["--enable-lib-call-no-inline=false"]
             if metadata.get("parallel_mode") == "mix_simd_simt":
                 _compile_option_list += ["--enable-simd-simt-mix-compile"]
@@ -1122,11 +1132,9 @@ def linalg_to_bin_enable_npu_compile_A2_A3(linalg: str, metadata, opt):
                 bishengir_hivm_opt,
                 "--enable-triton-kernel-compile=true",
             ]
-            # CANN 9.1's hivmc-a5 cannot translate hacc.noinline yet. A2/A3
-            # BiShengIR versions may not recognize this command-line option.
-            if _needs_lib_call_no_inline(metadata):
+            if (_needs_lib_call_no_inline(metadata)
+                    and _npu_compiler_supports_option(npu_compiler_path, "--enable-lib-call-no-inline")):
                 _compile_option_list += ["--enable-lib-call-no-inline=false"]
-
         _compile_option_list += ["--mlir-print-ir-after-failure"]
         _compile_option_list += ["--mlir-print-stacktrace-on-diagnostic"]
         if opt.debug:

--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -22,6 +22,7 @@ import ctypes
 import functools
 import hashlib
 import glob
+import json
 import os
 import re
 import shlex
@@ -31,7 +32,7 @@ import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple
 
 from triton._C.libtriton import ir, passes, ascend, buffer_ir
 from triton._C.libtriton.ascend import ir as ascend_ir
@@ -41,7 +42,6 @@ except ImportError:
     distributed = None
 from triton.backends.ascend.utils import (
     _check_bishengir_api_change,
-    _check_bishengir_able_save_ir,
     _check_bishengir_is_regbased,
     _enable_print_ub_bits,
     _enable_dump_memory_info,
@@ -59,7 +59,6 @@ from triton.backends.ascend.utils import (
     _is_auto_map_parallel_blocks_enabled,
     _get_auto_blockify_blacklist_reasons,
     _warn_auto_blockify_disabled,
-    downgrade_llir,
     force_disable_ffts,
     get_cann_version_file_hash,
     is_compile_on_910_95,
@@ -150,9 +149,75 @@ def make_ttir(mod, metadata, opt):
     return mod
 
 
+def _costmodel_profiles_dir() -> Path:
+    """Locate runtime assets without requiring backend-specific setup.py code."""
+    compiler = Path(__file__)
+
+    # Ascend CMake copies canonical profiles beside the native extension.
+    native_packaged = (compiler.resolve().parents[2] / "_C" / "ascend" / "costmodel_profiles")
+    if native_packaged.is_dir():
+        return native_packaged
+
+    # Compatibility with packages produced before the Cost Model ownership
+    # cleanup.  Check this only after the canonical native package location so
+    # incremental build directories cannot shadow freshly packaged profiles.
+    legacy_packaged = compiler.with_name("costmodel_profiles")
+    if legacy_packaged.is_dir():
+        return legacy_packaged
+
+    # Editable/source-tree builds resolve compiler.py back into
+    # third_party/ascend/backend.
+    source = Path(__file__).resolve().parent.parent / "costmodel" / "profiles"
+    return source if source.is_dir() else native_packaged
+
+
+def _run_cpp_simd_simt_costmodel(mod, metadata, opt) -> str:
+    """Run native selection/materialization; Python only schedules the passes."""
+    mode = opt.auto_simt_scope_mode
+    if mode == "off" or metadata.get("compile_mode") != "simd_simt":
+        return "backend_default"
+
+    profile = opt.auto_simt_model_profile or str(
+        _costmodel_profiles_dir() / "simd_simt" / "david_v100_simd_simt_v1.json")
+    pm = ir.pass_manager(mod.context)
+    pm.enable_debug()
+    ascend.passes.ttir.add_select_simd_simt_costmodel(
+        pm,
+        mode,
+        profile,
+        str(opt.arch),
+        int(opt.num_warps),
+        float(opt.auto_simt_scope_margin),
+        bool(opt.compile_on_910_95),
+        str(opt.auto_simt_scope_dump),
+    )
+    ascend.passes.ttir.add_materialize_simt_scopes(pm)
+    pm.run(mod, "select_simd_simt_costmodel")
+
+    report = ascend.ir.get_string_attr(mod, "ascend.simt_costmodel.report_json")
+    effective = ascend.ir.get_string_attr(mod, "ascend.simt_costmodel.effective")
+    if not report or effective not in {"all_simd", "all_simt_only", "mixed_simd_simt", "backend_default"}:
+        raise RuntimeError("invalid native SIMD/SIMT costmodel result")
+    metadata["auto_simt_scope_report"] = report
+    if effective == "mixed_simd_simt":
+        metadata["auto_simt_requested_kind"] = effective
+    return effective
+
+
 def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
     # use triton_adapter to lower Triton-MLIR to linalg
-    # Get Triton-MLIR as string
+    cpp_decision = _run_cpp_simd_simt_costmodel(mod, metadata, opt)
+    cpp_all_simt = cpp_decision == "all_simt_only"
+    if metadata.get("compile_mode") == "simd_simt" and (cpp_all_simt or ascend.ir.is_whole_body_void_simt_scope(mod)):
+        metadata["scope_pure_simt_auto"] = True
+        metadata["force_simt_only"] = True
+        metadata["parallel_mode"] = "simt"
+        metadata["shared_mem_dynamic_size"] = 122880
+        ascend.ir.inline_void_simt_scopes_for_pure_simt(mod)
+        ascend.ir.clear_simd_simt_costmodel_attrs(mod)
+        return str(mod)
+
+    # Get TTIR after C++ has materialized any selected mixed-mode scopes.
     ttir_code = str(mod)
     auto_map_parallel_blocks_enabled = _is_auto_map_parallel_blocks_enabled()
     blacklist_reasons = []
@@ -175,8 +240,19 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
         enable_nd2nz_on_vector = metadata["enable_nd2nz_on_vector"]
         enable_select_analysis = metadata["enable_select_analysis"]
         compile_on_910_95 = metadata["compile_on_910_95"]
-        force_simt_template = metadata["force_simt_template"]
+        requested_force_simt_template = metadata["force_simt_template"]
         compile_mode = _validate_compile_mode(metadata.get("compile_mode", "simd"))
+        # Once the C++ Route Model has made an explicit decision, lowering
+        # must implement that decision rather than also applying the legacy
+        # global SIMT-template switch. A mixed decision is represented solely
+        # by the materialized scope.scope<vec_mode=simt>; an all-SIMD
+        # decision contains no such scope.  Keep the old global behavior only
+        # for backend_default/report/off compatibility paths.
+        model_owns_local_routing = cpp_decision in {
+            "all_simd",
+            "mixed_simd_simt",
+        }
+        force_simt_template = (requested_force_simt_template and not model_owns_local_routing)
         if force_simt_template:
             compile_mode = "simd_simt_template"
         enable_sync_block_lock = metadata["enable_sync_block_lock"]
@@ -230,15 +306,15 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
 
         _intra_val = metadata.get("intra_cache_num")
         if _intra_val is not None:
-            ascend.passes.ttir.set_buffer_count(mod, "INTRA", _intra_val)
+            ascend.passes.ttir.set_buffer_count("INTRA", _intra_val)
 
         _inter_val = metadata.get("inter_cache_num")
         if _inter_val is not None:
-            ascend.passes.ttir.set_buffer_count(mod, "INTER", _inter_val)
+            ascend.passes.ttir.set_buffer_count("INTER", _inter_val)
 
         _load_val = metadata.get("load_cache_num")
         if _load_val is not None:
-            ascend.passes.ttir.set_buffer_count(mod, "LOAD", _load_val)
+            ascend.passes.ttir.set_buffer_count("LOAD", _load_val)
 
         if opt.debug:
             # Print the equivalent triton-opt command line so the pass
@@ -400,6 +476,13 @@ def _parse_linalg_metadata(linalg: str, metadata: dict):
     # the mix mode is also encoded into metadata['name'] for runtime to distinguish
     metadata["mix_mode"] = re.search(MIX_MODE_REGEX, linalg).group(1)
     metadata["parallel_mode"] = re.search(PARALLEL_MODE_REGEX, linalg).group(1)
+    if metadata.get("auto_simt_requested_kind") == "mixed_simd_simt":
+        applied = metadata["parallel_mode"] == "mix_simd_simt"
+        metadata["auto_simt_scope_applied"] = applied
+        if not applied and os.environ.get("TRITON_ASCEND_AUTO_SIMT_STRICT_VERIFY",
+                                          "").strip().lower() in {"1", "true", "yes", "on"}:
+            raise RuntimeError("C++ costmodel selected mixed SIMD/SIMT, but lowering "
+                               f"reported {metadata['parallel_mode']!r}")
     metadata["kernel_name"] = re.search(KERNEL_NAME_REGEX, linalg).group(1)
     # Check the function load_binary in npu_driver.py.
     metadata["name"] = metadata["kernel_name"]
@@ -447,10 +530,83 @@ def _parse_ttir_metadata(ttir: str, metadata: dict):
     return metadata
 
 
+def _normalize_auto_simt_scope_mode(mode: Optional[str]) -> str:
+    if mode is None:
+        return "off"
+    mode = str(mode).strip().lower()
+    if mode in ("1", "true", "on", "yes", "auto"):
+        return "auto"
+    if mode in ("report", "dry_run", "dry-run", "dump"):
+        return "report"
+    return "off"
+
+
+VALID_PARTITION_AND_BIND_SUB_BLOCK = (
+    "off",
+    "default-pin",
+    "load-balanced",
+)
+
+
+def _validate_partition_and_bind_sub_block(partition_mode: str) -> str:
+    if partition_mode not in VALID_PARTITION_AND_BIND_SUB_BLOCK:
+        valid_values = ", ".join(VALID_PARTITION_AND_BIND_SUB_BLOCK)
+        raise ValueError("Invalid enable_partition_and_bind_sub_block="
+                         f"{partition_mode!r}. Expected one of: {valid_values}.")
+    return partition_mode
+
+
+def _parse_float_env(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    if value is None or value == "":
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
+def _auto_simt_asset_hash(path: str, default_name: str) -> str:
+    asset = Path(path) if path else _costmodel_profiles_dir() / default_name
+    try:
+        selection_bytes = asset.read_bytes()
+    except OSError:
+        return f"missing:{asset}"
+
+    digest = hashlib.sha256()
+    digest.update(b"selection-profile\0")
+    digest.update(selection_bytes)
+    try:
+        profile = json.loads(selection_bytes)
+        shared_ref = (profile.get("microbenchmark_profile") if isinstance(profile, dict) else None)
+    except (TypeError, ValueError, UnicodeError):
+        shared_ref = None
+    if shared_ref is not None and not isinstance(shared_ref, str):
+        digest.update(b"\0invalid-shared-microbenchmark-reference\0")
+        digest.update(repr(shared_ref).encode())
+        return digest.hexdigest()
+    if shared_ref:
+        shared_asset = Path(shared_ref)
+        if not shared_asset.is_absolute():
+            shared_asset = asset.parent / shared_asset
+        digest.update(b"\0shared-microbenchmark\0")
+        try:
+            digest.update(shared_asset.read_bytes())
+        except OSError:
+            digest.update(f"missing:{shared_asset}".encode())
+    return digest.hexdigest()
+
+
 def get_common_bishengir_compile_options(metadata):
     bishengir_target = metadata['target'].arch
     bishengir_target_opt = f"--target={bishengir_target}"
     return [bishengir_target_opt]
+
+
+def _needs_lib_call_no_inline(metadata):
+    """Return whether the target needs the CANN 9.1 hacc.noinline workaround."""
+    arch = metadata['target'].arch
+    return arch.startswith("Ascend950")
 
 
 def get_auto_bind_sub_block_option(metadata):
@@ -698,6 +854,24 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
                 "--enable-hfusion-compile=true",
                 "--enable-triton-kernel-compile=true",
             ]
+            if _needs_lib_call_no_inline(metadata):
+                _compile_option_list += ["--enable-lib-call-no-inline=false"]
+            if metadata.get("parallel_mode") == "mix_simd_simt":
+                _compile_option_list += ["--enable-simd-simt-mix-compile"]
+                num_warps = metadata.get("num_warps") or opt.num_warps
+                _compile_option_list += [f"--num-warps={num_warps}"]
+                warp_size = metadata.get("warp_size") or opt.warp_size
+                _compile_option_list += [f"--threads-per-warp={warp_size}"]
+
+            partition_mode = _validate_partition_and_bind_sub_block(
+                metadata.get(
+                    "enable_partition_and_bind_sub_block",
+                    opt.enable_partition_and_bind_sub_block,
+                ) or "off")
+            if partition_mode != "off":
+                _compile_option_list += [f"--partition-and-bind-sub-block={partition_mode}"]
+            if metadata.get("auto_simt_requested_kind") == "mixed_simd_simt":
+                _compile_option_list += ["--enable-hivm-delayed-cross-core-gss=false"]
         bisheng_options = metadata["bisheng_options"]
         if bisheng_options is not None:
             _compile_option_list += [f"--append-bisheng-options={bisheng_options}"]
@@ -948,6 +1122,10 @@ def linalg_to_bin_enable_npu_compile_A2_A3(linalg: str, metadata, opt):
                 bishengir_hivm_opt,
                 "--enable-triton-kernel-compile=true",
             ]
+            # CANN 9.1's hivmc-a5 cannot translate hacc.noinline yet. A2/A3
+            # BiShengIR versions may not recognize this command-line option.
+            if _needs_lib_call_no_inline(metadata):
+                _compile_option_list += ["--enable-lib-call-no-inline=false"]
 
         _compile_option_list += ["--mlir-print-ir-after-failure"]
         _compile_option_list += ["--mlir-print-stacktrace-on-diagnostic"]
@@ -1063,6 +1241,9 @@ class NPUOptions:
     enable_ubuf_saving: bool = None
     enable_preload: bool = None
     enable_auto_bind_sub_block: bool = None
+    # Experimental BiShengIR policy for assigning work to the two AIV
+    # sub-blocks. Off preserves the existing backend behavior.
+    enable_partition_and_bind_sub_block: str = "off"
     disable_tightly_coupled_buffer_reuse: bool = False
     enable_select_analysis: bool = True
     enable_hivm_auto_cv_balance: bool = None
@@ -1136,6 +1317,14 @@ class NPUOptions:
     # take effect on the reorder instruction pattern for SIMT. The pattern is disabled by default.
     enable_simt_reorder_instruction: bool = False
     enable_costmodel_backend: bool = False
+    # Native AscendModel selection: Python only schedules the C++ passes.
+    auto_simt_scope_mode: str = ""
+    auto_simt_scope_dump: str = ""
+    auto_simt_scope_margin: Optional[float] = None
+    auto_simt_model_profile: str = ""
+    # Content digest is populated in __post_init__ so profile edits invalidate
+    # the Triton compile cache even when the path itself is unchanged.
+    auto_simt_model_assets_hash: str = ""
     # disable simt fma optimization to get high precision
     disable_fma: bool = False
 
@@ -1144,6 +1333,42 @@ class NPUOptions:
 
     def __post_init__(self):
         from triton.backends.ascend import _apply_ascend_patch
+
+        mode = self.auto_simt_scope_mode or os.environ.get("TRITON_ASCEND_AUTO_SIMT_SCOPE", "")
+        object.__setattr__(self, "auto_simt_scope_mode", _normalize_auto_simt_scope_mode(mode))
+        dump = self.auto_simt_scope_dump or os.environ.get("TRITON_ASCEND_AUTO_SIMT_SCOPE_DUMP", "")
+        margin = self.auto_simt_scope_margin
+        if margin is None:
+            margin = _parse_float_env("TRITON_ASCEND_AUTO_SIMT_SCOPE_MARGIN", 0.10)
+        try:
+            margin = float(margin)
+            margin = (min(1.0, max(0.0, margin)) if float("-inf") < margin < float("inf") else 0.10)
+        except (TypeError, ValueError):
+            margin = 0.10
+        profile = self.auto_simt_model_profile or os.environ.get("TRITON_ASCEND_AUTO_SIMT_PROFILE", "")
+        if self.auto_simt_scope_mode == "off":
+            dump, margin, profile, asset_hash = "", 0.10, "", "disabled"
+        else:
+            asset_hash = _auto_simt_asset_hash(profile, "simd_simt/david_v100_simd_simt_v1.json")
+        object.__setattr__(self, "auto_simt_scope_dump", dump)
+        object.__setattr__(self, "auto_simt_scope_margin", margin)
+        object.__setattr__(self, "auto_simt_model_profile", profile)
+        object.__setattr__(self, "auto_simt_model_assets_hash", asset_hash)
+
+        forced_compile_mode = os.environ.get("TRITON_ASCEND_COMPILE_MODE")
+        if forced_compile_mode:
+            object.__setattr__(self, "compile_mode", forced_compile_mode)
+
+        _validate_partition_and_bind_sub_block(self.enable_partition_and_bind_sub_block)
+
+        # Backward compatibility: legacy force options override compile_mode.
+        if self.force_simt_template:
+            warnings.warn(
+                "force_simt_template is deprecated, use compile_mode='simd_simt_template' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            object.__setattr__(self, "compile_mode", "simd_simt_template")
 
         _apply_ascend_patch()
 
@@ -1154,8 +1379,13 @@ class NPUOptions:
 
 
 def ttir_to_npubin(mod, metadata, opt):
-    # Get Triton-MLIR as string
-    ttir_code = str(mod)
+    if opt.force_simt_only:
+        metadata["force_simt_only"] = True
+        metadata["parallel_mode"] = "simt"
+        metadata["shared_mem_dynamic_size"] = opt.shared_mem_dynamic_size
+        if not isinstance(mod, str):
+            ascend.ir.inline_void_simt_scopes_for_pure_simt(mod)
+    ttir_code = mod if isinstance(mod, str) else str(mod)
     metadata = _parse_ttir_metadata(ttir_code, metadata)
     with tempfile.TemporaryDirectory() as tmpdir:
         # prepare input
@@ -1203,7 +1433,7 @@ def ttir_to_npubin(mod, metadata, opt):
             # Enable SIMT auto-blockify when TRITON_ALL_BLOCKS_PARALLEL is set,
             # mirroring the SIMD compile paths. driver.py's runtime block-count
             # cap keys off the same env switch, so the two stay in sync.
-            if _is_auto_map_parallel_blocks_enabled():
+            if (_is_auto_map_parallel_blocks_enabled() and not metadata.get("has_auto_blockify_blacklist_op", False)):
                 _compile_option_list += ["--enable-auto-blockify-loop"]
                 if opt.superblock_factor > 0:
                     _compile_option_list += [f"--super-block-factor={opt.superblock_factor}"]

--- a/third_party/ascend/costmodel/README.md
+++ b/third_party/ascend/costmodel/README.md
@@ -1,0 +1,47 @@
+# Ascend Cost Model architecture
+
+This directory contains two cost models and one shared evidence layer.
+
+```text
+profiles/microbench
+        |
+        v
+AscendModelProfile
+   |             |
+   v             v
+AscendModelAnalysis      AscendModelRouteModel
+(absolute/HIVM)          (SIMD/SIMT routing)
+          \               /
+           v             v
+           AscendModelTransforms / backend integration
+```
+
+The two models share measurements, not objectives or scoring formulas:
+
+- `configs/`, `include/AscendModel/Analysis`, `lib/AscendModel/Analysis`,
+  `IR`, and the original transforms implement the absolute/autotune and HIVM
+  model.
+- `profiles/microbench`, `include/AscendModel/Profile`, and
+  `lib/AscendModel/Profile` own model-neutral measurements plus their loader,
+  units, clock domains, target checks, and provenance.
+- `profiles/simd_simt`, `include/AscendModel/RouteModel`, and
+  `lib/AscendModel/RouteModel` own SIMD/SIMT feature extraction, Coverage,
+  conditional candidate scoring, post-score checks, selection reporting, and
+  scope materialization.
+
+`third_party/ascend/backend/compiler.py` is an integration layer: it schedules
+the native passes and locates installed assets. `python/setup.py` copies
+`profiles/` to `triton/backends/ascend/costmodel_profiles/` while building a
+Python package. That installed directory is generated runtime data, not a
+source-of-truth Cost Model directory.
+
+## Coverage boundary
+
+Coverage is checked before candidate scoring.  An unknown `scf.for` trip count
+is rejected by default; the only bounded exception is a recognized
+`triangular_solve_loop` anchor group.  That exception still requires the
+small-tensor limit, one to four materializable anchors, and the mask/reduction
+limits from the SIMD/SIMT profile.  Removing the triangular mechanism evidence
+therefore returns `unknown_loop_trip_count` rather than silently admitting a
+generic dynamic loop.  The regression tests for both paths are in
+`unittest/costmodel_ut/SimdSimtCostModelTest.cpp`.

--- a/third_party/ascend/costmodel/configs/ascend_davidv100.json
+++ b/third_party/ascend/costmodel/configs/ascend_davidv100.json
@@ -3,10 +3,26 @@
   "name": "Ascend davidV100",
   "vendor": "Huawei",
   "version": "1.0",
+  "description": "Hardware topology, theoretical limits, and absolute-cost-model priors for Ascend950PR/dav-c310. Values are not all board measurements; consult field_metadata and calibration.description.",
+  "target": "Ascend950PR/dav-c310",
+  "microbenchmark_profile": "../profiles/microbench/ascend_davidv100_v1.json",
 
   "clock": {
+    "description": "Device-compute clock domain used by the absolute cost model. SYS_CNT uses a different frequency stored in the shared microbenchmark profile.",
     "frequency_ghz": 1.65,
-    "cycles_per_us": 1650
+    "cycles_per_us": 1650,
+    "field_metadata": {
+      "frequency_ghz": {
+        "description": "Device-compute clock in GHz.",
+        "source": "tilesim davidV100 arc_config",
+        "confidence": "high"
+      },
+      "cycles_per_us": {
+        "description": "Human-readable frequency_ghz * 1000. The current C++ loader derives timing from frequency_ghz and does not read this scalar.",
+        "source": "Derived from frequency_ghz",
+        "confidence": "high"
+      }
+    }
   },
 
   "memory_spaces": {
@@ -14,13 +30,32 @@
       "type": "off_chip",
       "size_gb": 32,
       "bandwidth_tbps": 1.6,
-      "latency_cycles": 200
+      "latency_cycles": 200,
+      "description": "Device-level off-chip HBM model. These three values are inherited 910B baseline priors, not isolated Ascend950PR measurements.",
+      "field_metadata": {
+        "size_gb": {
+          "description": "Configured HBM capacity; HardwareConfig converts this value with 1024^3 bytes per unit.",
+          "source": "Inherited Ascend 910B baseline from cost-model PR #237; not verified on triton_a5",
+          "confidence": "low"
+        },
+        "bandwidth_tbps": {
+          "description": "Whole-device theoretical bandwidth seed in 10^12 byte/s; it is not the measured single-AIV GM bandwidth.",
+          "source": "Inherited Ascend 910B baseline from cost-model PR #237",
+          "confidence": "low"
+        },
+        "latency_cycles": {
+          "description": "Fixed HBM access-latency prior in device-compute cycles, used by latency-inclusive fallback estimates.",
+          "source": "Inherited model prior; no isolated Ascend950PR latency measurement is recorded",
+          "confidence": "low"
+        }
+      }
     },
     "l2": {
       "type": "on_chip_shared",
       "size_mb": 192,
       "bandwidth_gbps": 3200,
-      "latency_cycles": 50
+      "latency_cycles": 50,
+      "description": "Shared on-chip L2 model; the numeric values remain inherited baseline priors pending target-specific calibration."
     },
     "l1": {
       "type": "on_chip_local",
@@ -56,6 +91,7 @@
   "compute_units": {
     "cube": {
       "type": "matrix_engine",
+      "description": "Cube matrix engine topology, theoretical arithmetic rates, supported fractal shapes, and memory-space contract.",
       "tflops_fp16": 448,
       "tflops_fp32": 224,
       "tflops_int8": 896,
@@ -98,6 +134,7 @@
     },
     "vector": {
       "type": "simd_engine",
+      "description": "AIV SIMD engine topology and declared operation/data-type support; measured instruction rates live in the shared microbenchmark profile.",
       "width_elements": 128,
       "width_bytes": 256,
       "tflops_fp32": 14,
@@ -245,15 +282,19 @@
   },
 
   "performance_model": {
+    "description": "Documentary analytical formulas from the original model. The current HardwareConfig loader does not parse this block.",
     "cube_cycles_per_tile": {
+      "description": "Nominal Cube tile-count formula; not currently consumed by HardwareConfig::loadFromJSON.",
       "formula": "ceil(M/16) * ceil(N/16) * ceil(K/16)",
       "base_cycles": 1
     },
     "vector_cycles_per_op": {
+      "description": "Nominal SIMD instruction-count formula; not currently consumed by HardwareConfig::loadFromJSON.",
       "formula": "ceil(elements / 128)",
       "base_cycles": 1
     },
     "memory_cycles": {
+      "description": "Nominal bandwidth-plus-latency formula; not currently consumed from this block.",
       "formula": "bytes / bandwidth_per_cycle",
       "include_latency": true
     }
@@ -263,6 +304,7 @@
     "description": "davidV100 profile adapted from tilesim arc_config (clock=1650MHz, UB=512KB, core_config: cube=28, vector=56). Remaining model parameters follow Ascend 910B baseline and should be re-calibrated with davidV100 profiling data.",
 
     "startup_latencies": {
+      "description": "Absolute-model startup priors. The current JSON loader does not read this object; corresponding getters still use C++ defaults.",
       "vector_startup_cycles": 35,
       "mte2_startup_cycles": 50,
       "mte3_startup_cycles": 40,
@@ -271,6 +313,7 @@
     },
 
     "vector_op_cycles_per_vec_instruction": {
+      "description": "Legacy per-vector-instruction cycle priors. This is the only calibration sub-object currently consumed by HardwareConfig::loadFromJSON.",
       "exp": 4,
       "log": 3,
       "tanh": 3,
@@ -282,6 +325,7 @@
     },
 
     "scalar_overhead": {
+      "description": "Observed scalar/compute ratios retained as calibration evidence; the current JSON loader does not consume these fields.",
       "aiv_scalar_to_vec_ratio_steady_state": 1.27,
       "aic_scalar_to_mac_ratio_steady_state": 8.4,
       "aiv_vec_ratio_observed": 0.211,
@@ -295,6 +339,7 @@
     },
 
     "pipe_barrier": {
+      "description": "Legacy barrier-overhead prior; the current JSON loader does not consume this object.",
       "cycles_per_inner_iteration": 7500
     },
 

--- a/third_party/ascend/costmodel/configs/hardware_schema.json
+++ b/third_party/ascend/costmodel/configs/hardware_schema.json
@@ -3,6 +3,7 @@
   "$id": "hardware_schema.json",
   "title": "TritonSim Hardware Configuration",
   "description": "Schema for defining NPU/accelerator hardware parameters",
+  "$comment": "Standard JSON has no // comments. Property descriptions in this schema are the canonical field comments for hardware configuration files.",
   "type": "object",
   "required": [
     "name",
@@ -13,19 +14,39 @@
   ],
 
   "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Relative path to this JSON Schema; used by editors and offline validators, not by the runtime cost formulas."
+    },
     "name": {
       "type": "string",
       "description": "Hardware name (e.g., Ascend 910B)"
     },
     "vendor": {
-      "type": "string"
+      "type": "string",
+      "description": "Hardware or accelerator vendor."
     },
     "version": {
-      "type": "string"
+      "type": "string",
+      "description": "Version of this configuration data, not the silicon generation."
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable scope, evidence boundary, and usage warning for this concrete target configuration."
+    },
+    "target": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Canonical compiler target used to validate referenced measurement assets"
+    },
+    "microbenchmark_profile": {
+      "type": "string",
+      "description": "Path, relative to this hardware config, to the shared model-neutral measurement catalog"
     },
 
     "clock": {
       "type": "object",
+      "description": "Device-compute clock configuration. SYS_CNT is a separate clock domain stored in the shared microbenchmark profile.",
       "required": [
         "frequency_ghz"
       ],
@@ -37,15 +58,24 @@
         },
         "cycles_per_us": {
           "type": "integer",
-          "description": "Derived: cycles per microsecond"
+          "description": "Human-readable frequency_ghz × 1000. The current C++ loader derives timing from frequency_ghz and does not consume this scalar."
+        },
+        "description": {
+          "type": "string",
+          "description": "Meaning and clock-domain boundary of this object."
+        },
+        "field_metadata": {
+          "$ref": "#/definitions/field_metadata"
         }
       }
     },
 
     "memory_spaces": {
       "type": "object",
+      "description": "Named addressable memory hierarchy. Names are referenced by compute units and data movers.",
       "additionalProperties": {
         "type": "object",
+        "description": "One named memory space and its capacity, bandwidth, latency, purpose, and optional per-field provenance.",
         "required": [
           "type"
         ],
@@ -57,28 +87,43 @@
               "on_chip_shared",
               "on_chip_local",
               "register_file"
-            ]
+            ],
+            "description": "Memory category: off-chip, shared on-chip, local on-chip, or register-file-like storage."
           },
           "size_gb": {
-            "type": "number"
+            "type": "number",
+            "description": "Capacity label in GB; the current loader multiplies by 1024^3 bytes, so its effective interpretation is GiB-like."
           },
           "size_mb": {
-            "type": "number"
+            "type": "number",
+            "description": "Capacity label in MB; the current loader multiplies by 1024^2 bytes."
           },
           "size_kb": {
-            "type": "number"
+            "type": "number",
+            "description": "Capacity label in KB; the current loader multiplies by 1024 bytes."
           },
           "bandwidth_tbps": {
-            "type": "number"
+            "type": "number",
+            "description": "Theoretical or model bandwidth in decimal 10^12 byte/s; converted to byte/device-compute-cycle."
           },
           "bandwidth_gbps": {
-            "type": "number"
+            "type": "number",
+            "description": "Theoretical or model bandwidth in decimal 10^9 byte/s; converted to byte/device-compute-cycle."
           },
           "latency_cycles": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Fixed access-latency prior in device-compute cycles."
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Purpose, source boundary, and calibration status of this memory space."
+          },
+          "field_metadata": {
+            "$ref": "#/definitions/field_metadata"
+          },
+          "source": {
+            "type": "string",
+            "description": "Optional source shared by the complete memory-space record."
           }
         }
       }
@@ -86,8 +131,10 @@
 
     "compute_units": {
       "type": "object",
+      "description": "Named compute engines and their declared topology, peak rates, legal types, and memory-space contract.",
       "additionalProperties": {
         "type": "object",
+        "description": "One named compute engine and its physical width, peak rates, supported operations, and memory-space contract.",
         "required": [
           "type"
         ],
@@ -98,55 +145,87 @@
               "matrix_engine",
               "simd_engine",
               "scalar_engine"
-            ]
+            ],
+            "description": "Compute-engine category."
+          },
+          "description": {
+            "type": "string",
+            "description": "Purpose and evidence boundary of this compute unit."
           },
           "tflops_fp16": {
-            "type": "number"
+            "type": "number",
+            "description": "Declared FP16 peak arithmetic rate in TFLOP/s."
           },
           "tflops_fp32": {
-            "type": "number"
+            "type": "number",
+            "description": "Declared FP32 peak arithmetic rate in TFLOP/s."
           },
           "tflops_int8": {
-            "type": "number"
+            "type": "number",
+            "description": "Declared INT8 peak operation rate; the legacy field name says TFLOPS although TOPS is the more precise unit."
+          },
+          "fractal_sizes": {
+            "type": "object",
+            "description": "Dtype-specific Cube atomic matrix shapes.",
+            "additionalProperties": {
+              "$ref": "#/definitions/fractal_size"
+            }
           },
           "tile_m": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Fallback Cube tile M when no dtype-specific fractal shape is found."
           },
           "tile_n": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Fallback Cube tile N when no dtype-specific fractal shape is found."
           },
           "tile_k": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Fallback Cube reduction dimension K when no dtype-specific fractal shape is found."
           },
           "width_elements": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Nominal SIMD element count, traditionally expressed for the reference dtype; do not use as a dtype-independent lane count."
           },
           "width_bytes": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Physical SIMD vector width in bytes; lane count equals width_bytes × 8 / element_bits."
           },
           "input_spaces": {
             "type": "array",
+            "description": "Names of memory spaces read by this compute engine.",
             "items": {
               "type": "string"
             }
           },
           "output_space": {
-            "type": "string"
+            "type": "string",
+            "description": "Name of the memory space written by this compute engine."
           },
           "compute_space": {
-            "type": "string"
+            "type": "string",
+            "description": "Local memory space in which this engine executes its arithmetic."
           },
           "supported_ops": {
             "type": "array",
+            "description": "Operation categories declared as supported by this engine.",
             "items": {
               "type": "string"
             }
           },
           "supported_dtypes": {
             "type": "array",
+            "description": "Data types declared as supported by this engine.",
             "items": {
               "type": "string"
             }
+          },
+          "field_metadata": {
+            "$ref": "#/definitions/field_metadata"
+          },
+          "source": {
+            "type": "string",
+            "description": "Optional source shared by the complete compute-unit record."
           }
         }
       }
@@ -154,41 +233,55 @@
 
     "data_movers": {
       "type": "object",
+      "description": "Named hardware transfer paths between memory spaces.",
       "additionalProperties": {
         "type": "object",
+        "description": "One named data-mover path, including its endpoints, modeled bandwidth, burst constraints, and fused capabilities.",
         "required": [
           "src_space"
         ],
         "properties": {
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable role and transfer direction."
           },
           "src_space": {
-            "type": "string"
+            "type": "string",
+            "description": "Source memory-space name."
           },
           "dst_space": {
-            "type": "string"
+            "type": "string",
+            "description": "Single destination memory-space name."
           },
           "dst_spaces": {
             "type": "array",
+            "description": "Multiple destination memory-space names; when present, the loader replaces dst_space with this list.",
             "items": {
               "type": "string"
             }
           },
           "bandwidth_gbps": {
-            "type": "number"
+            "type": "number",
+            "description": "Modeled transfer bandwidth in decimal GB/s."
           },
           "max_burst_bytes": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Maximum bytes in one modeled burst."
           },
           "alignment_bytes": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Required or efficient byte alignment for this transfer path."
           },
           "supports_accumulate": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether accumulation may be fused into this transfer."
           },
           "supports_cast": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether type conversion may be fused into this transfer."
+          },
+          "field_metadata": {
+            "$ref": "#/definitions/field_metadata"
           }
         }
       }
@@ -196,25 +289,364 @@
 
     "pipeline": {
       "type": "object",
-      "additionalProperties": {
-        "type": "object",
-        "properties": {
-          "stages": {
-            "type": "array",
-            "items": {
-              "type": "string"
+      "description": "Pipeline path declarations and intended overlap relationships.",
+      "properties": {
+        "cube_path": {
+          "$ref": "#/definitions/pipeline_path"
+        },
+        "vector_path": {
+          "$ref": "#/definitions/pipeline_path"
+        },
+        "hardware_units": {
+          "type": "object",
+          "description": "Map from hardware-unit name to its pipeline path and overlap capability. The current C++ loader does not consume this nested map.",
+          "additionalProperties": {
+            "$ref": "#/definitions/pipeline_hardware_unit"
+          }
+        },
+        "parallelism": {
+          "type": "object",
+          "description": "Intended inter-path and intra-path overlap relationships. The current nested representation is not consumed by the C++ loader.",
+          "properties": {
+            "inter_path": {
+              "$ref": "#/definitions/pipeline_overlap_group"
+            },
+            "intra_path": {
+              "$ref": "#/definitions/pipeline_overlap_group"
             }
-          },
-          "description": {
-            "type": "string"
           }
         }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/pipeline_path"
       }
     },
 
     "performance_model": {
       "type": "object",
-      "description": "Custom performance estimation formulas"
+      "description": "Documentary analytical formulas. The current C++ loader does not interpret or execute this block.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Consumption-status warning for this block."
+        },
+        "cube_cycles_per_tile": {
+          "$ref": "#/definitions/formula_entry"
+        },
+        "vector_cycles_per_op": {
+          "$ref": "#/definitions/formula_entry"
+        },
+        "memory_cycles": {
+          "type": "object",
+          "description": "Documentary memory transfer formula.",
+          "properties": {
+            "description": {
+              "type": "string",
+              "description": "Human-readable status and intended meaning of this formula."
+            },
+            "formula": {
+              "type": "string",
+              "description": "Human-readable expression; it is not evaluated by the loader."
+            },
+            "include_latency": {
+              "type": "boolean",
+              "description": "Documents whether the conceptual formula includes fixed latency; not consumed from this block."
+            }
+          }
+        }
+      }
+    },
+
+    "calibration": {
+      "type": "object",
+      "description": "Absolute-model priors, evidence notes, and target-specific calibration parameters.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Origin, inheritance, and recalibration requirements for this target profile."
+        },
+        "startup_latencies": {
+          "type": "object",
+          "description": "Startup-cycle priors. The current JSON loader does not consume this object; getters use C++ defaults.",
+          "properties": {
+            "description": {
+              "type": "string",
+              "description": "Consumption status or provenance shared by the startup-latency fields."
+            },
+            "vector_startup_cycles": {
+              "type": "integer",
+              "description": "Vector pipeline startup prior in device-compute cycles."
+            },
+            "mte2_startup_cycles": {
+              "type": "integer",
+              "description": "MTE2 startup prior in device-compute cycles."
+            },
+            "mte3_startup_cycles": {
+              "type": "integer",
+              "description": "MTE3 startup prior in device-compute cycles."
+            },
+            "cube_startup_cycles": {
+              "type": "integer",
+              "description": "Cube engine startup prior in device-compute cycles."
+            },
+            "fixpipe_startup_cycles": {
+              "type": "integer",
+              "description": "FixPipe startup prior in device-compute cycles."
+            },
+            "notes": {
+              "type": "string",
+              "description": "Free-form calibration rationale retained for human review; not consumed by the loader."
+            }
+          }
+        },
+        "vector_op_cycles_per_vec_instruction": {
+          "type": "object",
+          "description": "Legacy cycles-per-vector-instruction priors. This is the only calibration sub-object currently parsed from JSON.",
+          "properties": {
+            "description": {
+              "type": "string",
+              "description": "Consumption status or provenance shared by these operation-cycle priors."
+            },
+            "exp": {
+              "type": "integer",
+              "description": "Vector exponential cycles per instruction."
+            },
+            "log": {
+              "type": "integer",
+              "description": "Vector logarithm cycles per instruction."
+            },
+            "tanh": {
+              "type": "integer",
+              "description": "Vector tanh cycles per instruction."
+            },
+            "sigmoid": {
+              "type": "integer",
+              "description": "Vector sigmoid cycles per instruction."
+            },
+            "sqrt": {
+              "type": "integer",
+              "description": "Vector square-root cycles per instruction."
+            },
+            "rsqrt": {
+              "type": "integer",
+              "description": "Vector reciprocal-square-root cycles per instruction."
+            },
+            "div": {
+              "type": "integer",
+              "description": "Vector division cycles per instruction."
+            },
+            "simple_ops_add_sub_mul_etc": {
+              "type": "integer",
+              "description": "Shared legacy cycle prior for simple vector add, sub, mul, and cast instructions."
+            },
+            "notes": {
+              "type": "string",
+              "description": "Free-form calibration rationale retained for human review; not consumed as an operation cost."
+            }
+          }
+        },
+        "scalar_overhead": {
+          "type": "object",
+          "description": "Observed scalar/compute ratios retained as evidence; the current JSON loader does not consume them.",
+          "properties": {
+            "description": {
+              "type": "string",
+              "description": "Source and interpretation shared by the scalar-overhead fields."
+            },
+            "aiv_scalar_to_vec_ratio_steady_state": {
+              "type": "number",
+              "description": "Steady-state AIV scalar cost relative to vector cost."
+            },
+            "aic_scalar_to_mac_ratio_steady_state": {
+              "type": "number",
+              "description": "Steady-state AIC scalar cost relative to Cube MAC cost."
+            },
+            "aiv_vec_ratio_observed": {
+              "type": "number",
+              "description": "Observed fraction of AIV time attributed to vector work."
+            },
+            "aiv_scalar_overhead_factor": {
+              "type": "number",
+              "description": "Non-vector overhead factor in total ≈ vector × (1 + factor)."
+            }
+          }
+        },
+        "parallelism": {
+          "type": "object",
+          "description": "Declared physical core counts. The current JSON loader does not consume them; current getters still use C++ defaults.",
+          "properties": {
+            "num_aic_cores": {
+              "type": "integer",
+              "description": "Declared AIC/Cube core count."
+            },
+            "num_aiv_cores": {
+              "type": "integer",
+              "description": "Declared AIV/Vector core count."
+            },
+            "description": {
+              "type": "string",
+              "description": "Source of the declared core counts."
+            }
+          }
+        },
+        "pipe_barrier": {
+          "type": "object",
+          "description": "Barrier-overhead prior. The current JSON loader does not consume this object.",
+          "properties": {
+            "description": {
+              "type": "string",
+              "description": "Calibration source and interpretation of the barrier prior."
+            },
+            "cycles_per_inner_iteration": {
+              "type": "integer",
+              "description": "Modeled AIC/AIV pipe-barrier cost per inner iteration."
+            }
+          }
+        },
+        "wave_overhead": {
+          "type": "object",
+          "description": "Multi-wave overhead evidence and recalibration warning; not parsed by the current loader.",
+          "properties": {
+            "description": {
+              "type": "string",
+              "description": "Source and validity boundary of the wave-overhead model."
+            }
+          }
+        }
+      }
+    }
+  },
+
+  "definitions": {
+    "pipeline_path": {
+      "type": "object",
+      "description": "One ordered hardware data/compute pipeline.",
+      "properties": {
+        "stages": {
+          "type": "array",
+          "description": "Ordered data-mover and compute-unit names in this path.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable role of this pipeline path."
+        },
+        "fully_pipelined": {
+          "type": "boolean",
+          "description": "Declares steady-state stage overlap. The current C++ JSON loader does not consume this field."
+        }
+      }
+    },
+    "pipeline_hardware_unit": {
+      "type": "object",
+      "description": "Pipeline membership and overlap declaration for one named hardware unit.",
+      "properties": {
+        "path": {
+          "type": "string",
+          "enum": [
+            "cube",
+            "vector"
+          ],
+          "description": "Execution path to which this unit belongs."
+        },
+        "can_overlap": {
+          "type": "boolean",
+          "description": "Whether this unit is declared able to overlap with independent hardware units."
+        }
+      }
+    },
+    "pipeline_overlap_group": {
+      "type": "object",
+      "description": "Named overlap relationships within or between pipeline paths.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human-readable interpretation of this group of overlap flags."
+        }
+      },
+      "additionalProperties": {
+        "type": "boolean",
+        "description": "Whether the hardware paths or stages named by this key may execute concurrently."
+      }
+    },
+    "field_metadata": {
+      "type": "object",
+      "description": "Per-field provenance and confidence without changing the scalar field shape expected by the runtime loader.",
+      "additionalProperties": {
+        "$ref": "#/definitions/field_metadata_entry"
+      }
+    },
+    "field_metadata_entry": {
+      "type": "object",
+      "description": "Meaning, provenance, and confidence attached to one scalar field while preserving that field's loader-compatible numeric type.",
+      "required": [
+        "description",
+        "source",
+        "confidence"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Meaning and scope of the concrete field value."
+        },
+        "source": {
+          "type": "string",
+          "description": "Specification, configuration, baseline, or measurement from which the value came."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "high",
+            "medium",
+            "low"
+          ],
+          "description": "Evidence confidence for this concrete value."
+        }
+      },
+      "additionalProperties": false
+    },
+    "fractal_size": {
+      "type": "object",
+      "required": [
+        "m",
+        "n",
+        "k"
+      ],
+      "description": "Dtype-specific Cube atomic matrix dimensions.",
+      "properties": {
+        "m": {
+          "type": "integer",
+          "description": "Output-row dimension M."
+        },
+        "n": {
+          "type": "integer",
+          "description": "Output-column dimension N."
+        },
+        "k": {
+          "type": "integer",
+          "description": "Reduction dimension K."
+        }
+      }
+    },
+    "formula_entry": {
+      "type": "object",
+      "description": "Documentary formula entry; current C++ code does not evaluate this expression.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human-readable status and intended meaning of this formula."
+        },
+        "formula": {
+          "type": "string",
+          "description": "Human-readable expression."
+        },
+        "base_cycles": {
+          "type": "integer",
+          "description": "Nominal cycles per atomic unit in the documented formula."
+        }
+      }
     }
   }
 }

--- a/third_party/ascend/costmodel/include/AscendModel/Analysis/HIVMAnalysis.h
+++ b/third_party/ascend/costmodel/include/AscendModel/Analysis/HIVMAnalysis.h
@@ -90,6 +90,8 @@ struct HIVMAnalysisReport {
   void emitPerfettoTrace(llvm::raw_ostream &os,
                          const HardwareConfig &config) const;
   void emitDESGraph(llvm::raw_ostream &os, const HardwareConfig &config) const;
+  void emitFeedbackJSON(llvm::raw_ostream &os,
+                        const HardwareConfig &config) const;
 };
 
 class HIVMAnalyzer {

--- a/third_party/ascend/costmodel/include/AscendModel/Analysis/HardwareConfig.h
+++ b/third_party/ascend/costmodel/include/AscendModel/Analysis/HardwareConfig.h
@@ -20,6 +20,8 @@
 namespace mlir {
 namespace ascend {
 
+class MicrobenchmarkProfile;
+
 //===----------------------------------------------------------------------===//
 // Memory Space
 //===----------------------------------------------------------------------===//
@@ -182,7 +184,6 @@ struct BandwidthEntry {
 class HardwareConfig {
 public:
   HardwareConfig();
-  ~HardwareConfig();
 
   // Factory methods
   static std::unique_ptr<HardwareConfig> loadFromFile(llvm::StringRef path);
@@ -197,6 +198,17 @@ public:
   // Basic info
   llvm::StringRef getName() const { return name; }
   llvm::StringRef getVendor() const { return vendor; }
+  llvm::StringRef getTarget() const { return target; }
+
+  // Shared, model-neutral microbenchmark evidence.  The absolute cost model
+  // and route-selection model may consume different subsets of this catalog.
+  const MicrobenchmarkProfile *getMicrobenchmarkProfile() const {
+    return microbenchmarkProfile.get();
+  }
+  llvm::StringRef getMicrobenchmarkProfileReference() const {
+    return microbenchmarkProfileReference;
+  }
+  double getMicrobenchmarkRatePerDeviceCycle(llvm::StringRef key) const;
 
   // Clock
   double getClockFrequencyGHz() const { return clockFreqGHz; }
@@ -335,6 +347,8 @@ public:
 
 private:
   bool parseJSON(const llvm::json::Value &json, std::string &error);
+  bool loadReferencedMicrobenchmarkProfile(llvm::StringRef configPath,
+                                           std::string &error);
 
   /// Populate the tilesim-migrated tables with 910B1 measured values
   /// (hardcoded-fallback path; JSON is authoritative in production).
@@ -343,6 +357,7 @@ private:
   std::string name;
   std::string vendor;
   std::string version;
+  std::string target;
 
   double clockFreqGHz;
 
@@ -351,6 +366,8 @@ private:
   llvm::StringMap<DataMover> dataMovers;
   llvm::StringMap<PipelinePath> pipelinePaths;
   llvm::StringMap<int> vectorOpCyclesPerInstruction;
+  std::string microbenchmarkProfileReference;
+  std::shared_ptr<const MicrobenchmarkProfile> microbenchmarkProfile;
 
   // Parallelism info
   llvm::StringMap<bool> parallelismFlags;

--- a/third_party/ascend/costmodel/include/AscendModel/Profile/MicrobenchmarkProfile.h
+++ b/third_party/ascend/costmodel/include/AscendModel/Profile/MicrobenchmarkProfile.h
@@ -1,0 +1,78 @@
+//===- MicrobenchmarkProfile.h - Shared cost-model evidence -----*- C++ -*-===//
+//
+// This file defines the versioned, model-neutral measurement catalog shared
+// by the absolute autotune cost model and the SIMD/SIMT route selector.
+//
+// Measurements describe observed hardware behaviour.  Model-specific
+// calibration (for example structural penalties, coverage gates, or pipeline
+// overlap) deliberately does not belong in this profile.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ASCENDMODEL_PROFILE_MICROBENCHMARKPROFILE_H
+#define ASCENDMODEL_PROFILE_MICROBENCHMARKPROFILE_H
+
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/JSON.h"
+
+#include <optional>
+#include <string>
+
+namespace mlir {
+namespace ascend {
+
+struct MicrobenchmarkMeasurement {
+  double value = 0.0;
+  std::string unit;
+  std::string cycleDomain;
+  std::string scope;
+  std::string sourceKind;
+  std::string source;
+  std::string confidence;
+};
+
+/// A model-neutral catalog of target facts and microbenchmark measurements.
+///
+/// Every scalar carries its physical unit, cycle domain, measurement scope,
+/// provenance, and confidence.  Consumers may use different subsets and
+/// different formulas, but must not reinterpret a value in another unit or
+/// scope silently.
+class MicrobenchmarkProfile {
+public:
+  static llvm::Expected<MicrobenchmarkProfile>
+  loadFromFile(llvm::StringRef path);
+
+  static llvm::Expected<MicrobenchmarkProfile>
+  loadFromJSON(const llvm::json::Value &json,
+               llvm::StringRef contentForHash = {});
+
+  llvm::StringRef getProfileVersion() const { return profileVersion; }
+  llvm::StringRef getTarget() const { return target; }
+  llvm::StringRef getContentSha256() const { return contentSha256; }
+
+  const MicrobenchmarkMeasurement *getMeasurement(llvm::StringRef key) const;
+
+  llvm::Expected<double> requireValue(
+      llvm::StringRef key,
+      std::optional<llvm::StringRef> expectedUnit = std::nullopt,
+      std::optional<llvm::StringRef> expectedCycleDomain = std::nullopt) const;
+
+  /// Convert a rate expressed per source-domain cycle into a rate expressed
+  /// per destination-domain cycle.
+  llvm::Expected<double>
+  convertRatePerCycle(double rate, llvm::StringRef sourceFrequencyKey,
+                      llvm::StringRef destinationFrequencyKey) const;
+
+private:
+  std::string profileVersion;
+  std::string target;
+  std::string contentSha256;
+  llvm::StringMap<MicrobenchmarkMeasurement> measurements;
+};
+
+} // namespace ascend
+} // namespace mlir
+
+#endif // ASCENDMODEL_PROFILE_MICROBENCHMARKPROFILE_H

--- a/third_party/ascend/costmodel/include/AscendModel/RouteModel/SimdSimtCostModel.h
+++ b/third_party/ascend/costmodel/include/AscendModel/RouteModel/SimdSimtCostModel.h
@@ -1,0 +1,401 @@
+//===- SimdSimtCostModel.h - Ascend SIMD/SIMT candidate model -*- C++ -*-===//
+//
+// This file exposes the target-profile-backed candidate cost model used to
+// compare all-SIMD, all-SIMT, and mixed SIMD/SIMT execution for generic TTIR.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ASCENDMODEL_ROUTEMODEL_SIMDSIMTCOSTMODEL_H
+#define ASCENDMODEL_ROUTEMODEL_SIMDSIMTCOSTMODEL_H
+
+#include "AscendModel/RouteModel/SimtAnchorAnalysis.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace mlir {
+namespace ascend {
+
+enum class SimdSimtCandidateKind {
+  AllSIMD,
+  AllSIMTOnly,
+  MixedSIMDSIMT,
+};
+
+llvm::StringRef stringifySimdSimtCandidate(SimdSimtCandidateKind candidate);
+
+/// Resource summary for the exact non-overlapping TTIR operations that the
+/// current materializer can wrap in local SIMT scopes.  It intentionally
+/// contains no Operation pointers, so reports remain stable and serializable.
+struct SimtAnchorFeatureSummary {
+  /// All mechanism anchors recognized before target/lowering checks.
+  int64_t recognizedCount = 0;
+  /// Materializable anchors used by the mixed candidate.  `count` is retained
+  /// as the serialized compatibility name for this value.
+  int64_t count = 0;
+  int64_t coveredOperationCount = 0;
+  int64_t loadOps = 0;
+  int64_t storeOps = 0;
+  int64_t reduceOps = 0;
+  int64_t scanOps = 0;
+  int64_t gatherOps = 0;
+  int64_t dotOps = 0;
+  int64_t atomicOps = 0;
+  int64_t histogramOps = 0;
+
+  int64_t maxTensorNumel = 1;
+  int64_t maxElementBits = 0;
+  int64_t maskRankSum = 0;
+  int64_t uniqueMaskValues = 0;
+  int64_t uniqueMaskRankSum = 0;
+  int64_t predicateElements = 0;
+  /// Loop-weighted mask lanes on predicate-producing/consuming IR edges.
+  int64_t predicateLaneEvaluations = 0;
+  int64_t pointerTensorOps = 0;
+  int64_t loadedIndexDependentMemoryOps = 0;
+  int64_t laneDependentPointerOps = 0;
+  int64_t maxReduceAxisExtent = 1;
+  int64_t weightedReduceAxisElements = 0;
+  /// Loop-weighted input lanes times log2(reduction/scan axis extent).
+  int64_t shuffleLaneSteps = 0;
+  int64_t staticLoopCount = 0;
+  int64_t staticLoopTripCountSum = 0;
+  int64_t modeledDynamicLoopCount = 0;
+  int64_t modeledDynamicLoopTripCountSum = 0;
+  bool hasControlFlow = false;
+
+  llvm::StringMap<int64_t> weightedOps;
+  llvm::StringMap<int64_t> opElements;
+  double loadBytes = 0.0;
+  double storeBytes = 0.0;
+  int64_t loadWarpInstructions = 0;
+  int64_t storeWarpInstructions = 0;
+  int64_t dotFlops = 0;
+
+  int64_t capturedTensorCount = 0;
+  int64_t escapingTensorCount = 0;
+  double capturedTensorBytes = 0.0;
+  double escapingTensorBytes = 0.0;
+
+  std::vector<std::string> mechanismKinds;
+  std::vector<TensorAtomicFacts> tensorAtomics;
+  std::vector<HistogramFacts> histograms;
+  std::vector<PlainCumsumFacts> plainCumsums;
+  CandidateLowerability kernelLowerability;
+
+  llvm::json::Object toJSON() const;
+};
+
+/// Static, workload-name-independent properties extracted directly from a
+/// generic TTIR ModuleOp.  Weighted fields include statically known scf.for
+/// trip counts.
+struct SimdSimtFeatureSummary {
+  int64_t loadOps = 0;
+  int64_t storeOps = 0;
+  int64_t reduceOps = 0;
+  int64_t scanOps = 0;
+  int64_t gatherOps = 0;
+  int64_t dotOps = 0;
+  int64_t atomicOps = 0;
+  int64_t histogramOps = 0;
+  int64_t broadcastOps = 0;
+  int64_t expandDimsOps = 0;
+  int64_t splatOps = 0;
+  int64_t addPtrOps = 0;
+
+  int64_t arithOps = 0;
+  int64_t mathOps = 0;
+  int64_t addOps = 0;
+  int64_t subOps = 0;
+  int64_t mulOps = 0;
+  int64_t divOps = 0;
+  int64_t maxOps = 0;
+  int64_t absOps = 0;
+  int64_t expOps = 0;
+  int64_t logOps = 0;
+  int64_t cmpOps = 0;
+  int64_t selectOps = 0;
+  int64_t castOps = 0;
+  int64_t clampOps = 0;
+  int64_t scalarOps = 0;
+
+  int64_t maxTensorRank = 0;
+  int64_t maxTensorNumel = 1;
+  int64_t maxElementBits = 0;
+  int64_t maskTensorOps = 0;
+  int64_t maskRankSum = 0;
+  int64_t uniqueMaskValues = 0;
+  int64_t uniqueMaskRankSum = 0;
+  int64_t predicateElements = 0;
+  /// Loop-weighted mask lanes on predicate-producing/consuming IR edges.
+  int64_t predicateLaneEvaluations = 0;
+  int64_t maskBroadcastOps = 0;
+  int64_t pointerTensorOps = 0;
+  int64_t pointerUnstructuredDims = 0;
+  /// Real SSA provenance count.  Unlike laneDependentPointerOps, this field
+  /// requires the address backward slice to reach a loaded/gathered index.
+  int64_t loadedIndexDependentMemoryOps = 0;
+  /// Legacy rank-based proxy retained for report compatibility.
+  int64_t laneDependentPointerOps = 0;
+  int64_t rowLocalReduceOps = 0;
+  int64_t maxReduceAxisExtent = 1;
+  int64_t weightedReduceAxisElements = 0;
+  /// Loop-weighted input lanes times log2(reduction/scan axis extent).
+  int64_t shuffleLaneSteps = 0;
+  int64_t scalarLoadOps = 0;
+  int64_t scalarStoreOps = 0;
+  int64_t vectorPtrSplatOps = 0;
+  int64_t vectorReduceToScalarOps = 0;
+  bool rank1IndirectVectorReduce = false;
+
+  llvm::StringMap<int64_t> weightedOps;
+  llvm::StringMap<int64_t> opElements;
+  double loadBytes = 0.0;
+  double storeBytes = 0.0;
+  int64_t loadWarpInstructions = 0;
+  int64_t storeWarpInstructions = 0;
+  int64_t dotFlops = 0;
+  int64_t dotOutputElements = 0;
+  std::vector<std::array<int64_t, 3>> dotMNK;
+  int64_t staticLoopCount = 0;
+  int64_t staticLoopTripCountSum = 0;
+  int64_t staticLoopTripCountMax = 1;
+  int64_t modeledDynamicLoopCount = 0;
+  int64_t modeledDynamicLoopTripCountSum = 0;
+
+  bool hasDot = false;
+  bool hasGather = false;
+  bool hasAtomic = false;
+  bool hasHistogram = false;
+  bool hasScan = false;
+  bool hasExplicitScope = false;
+  bool hasControlFlow = false;
+  bool hasDynamicShape = false;
+  bool hasUnknownTripCount = false;
+
+  /// Pattern observations are diagnostic inputs to the model.  They do not
+  /// create a mandatory online route: all three candidates stay selectable.
+  std::vector<std::string> observedMixedKinds;
+
+  SimtAnchorFeatureSummary simtAnchors;
+
+  llvm::json::Object toJSON() const;
+};
+
+/// Applicability is a hardware/lowering statement, not a calibration-domain
+/// statement.  It says whether TTIR contains a recognized SIMT mechanism and
+/// whether the current target can materialize at least one corresponding
+/// anchor.  Calibration coverage is reported separately.
+struct SimtApplicabilityResult {
+  bool mechanismDetected = false;
+  bool targetSupported = false;
+  bool materializable = false;
+  int64_t recognizedAnchorCount = 0;
+  int64_t materializableAnchorCount = 0;
+  std::vector<std::string> mechanisms;
+  std::vector<std::string> reasons;
+
+  llvm::json::Object toJSON() const;
+};
+
+struct SimdSimtCandidateScores {
+  double allSimd = 0.0;
+  double allSimtOnly = 0.0;
+  double mixedSimdSimt = 0.0;
+
+  double get(SimdSimtCandidateKind candidate) const;
+  llvm::json::Object toJSON() const;
+};
+
+/// Detailed values retained so the JSON report can explain every major term
+/// in the versioned analytical and structural formulas.
+struct SimdSimtCostBreakdown {
+  llvm::StringMap<double> simdOpSystemCycles;
+  llvm::StringMap<double> simtOpSystemCycles;
+  llvm::StringMap<double> structuralComponents;
+
+  double simdComputeCycles = 0.0;
+  double simtComputeCycles = 0.0;
+  double simdDotCycles = 0.0;
+  double simtDotCycles = 0.0;
+  double simdLoadCycles = 0.0;
+  double simdStoreCycles = 0.0;
+  double simdMemoryCycles = 0.0;
+  double simtLoadCycles = 0.0;
+  double simtStoreCycles = 0.0;
+  double simtMemoryCycles = 0.0;
+  double simtShuffleInstructions = 0.0;
+  double simtShuffleCycles = 0.0;
+  double simtPredicateInstructions = 0.0;
+  double simtPredicateCycles = 0.0;
+  double simdSetupCycles = 0.0;
+  double simtSetupCycles = 0.0;
+  double simdIssuePayloadCycles = 0.0;
+  double simtIssuePayloadCycles = 0.0;
+  double simdAnalyticalCycles = 0.0;
+  double simtAnalyticalCycles = 0.0;
+  double programIssueScale = 1.0;
+
+  double mixedSimdRegularComputeCycles = 0.0;
+  double mixedSimdRegularDotCycles = 0.0;
+  double mixedSimdRegularMemoryCycles = 0.0;
+  double mixedSimdRegularPayloadCycles = 0.0;
+  double mixedSimtAnchorComputeCycles = 0.0;
+  double mixedSimtAnchorDotCycles = 0.0;
+  double mixedSimtAnchorMemoryCycles = 0.0;
+  double mixedSimtAnchorShuffleCycles = 0.0;
+  double mixedSimtAnchorPredicateCycles = 0.0;
+  double mixedSimtAnchorPayloadCycles = 0.0;
+  double mixedBoundaryCycles = 0.0;
+  double mixedRemainingStructuralPenaltyRatio = 0.0;
+
+  double irregularDensity = 0.0;
+  double tinyDotUnderfill = 0.0;
+  double structuralPenaltyRatio = 0.0;
+  /// SIMD-only residual cost for structures omitted by its compute/memory
+  /// roofline. It must not depend on the cost of another route candidate.
+  double simdStructuralPenaltyCycles = 0.0;
+
+  double mixedSimdFraction = 0.0;
+  /// Conservative low-confidence setup fallback for a mixed plan.  The
+  /// current source is a standalone empty-VF harness, not a measured
+  /// directional SIMD/SIMT transition.
+  double mixedSetupFallbackCycles = 0.0;
+  double standaloneSimtSetupCycles = 0.0;
+  double setupProxyDeltaCycles = 0.0;
+  int64_t mixedSetupFallbackNumWarps = 0;
+  std::string mixedCostSource;
+
+  llvm::json::Object toJSON(const SimdSimtFeatureSummary &features) const;
+};
+
+struct SimdSimtCostModelOptions {
+  /// Empty selects TRITON_ASCEND_SIMD_SIMT_PROFILE, then the source-tree
+  /// profile compiled into AscendModelRouteModel.
+  std::string profilePath;
+  std::string actualTarget;
+  unsigned numWarps = 32;
+  /// Minimum relative advantage over the established all-SIMD baseline.
+  /// The absolute floor is fixed at 64 selection-score cycles.
+  double marginRatio = 0.10;
+  bool includeFeaturesInJSON = true;
+  /// Keep scoring outside the calibrated feature domain for offline/report
+  /// diagnostics.  Production auto selection disables this so that coverage
+  /// rejection happens before candidate-cost evaluation.
+  bool scoreOutsideCalibrationCoverage = true;
+  /// True only when the target backend can materialize the shared TTIR anchor
+  /// plan.  Candidate costs remain reportable when false, but mixed is not
+  /// eligible for selection.
+  bool compileOn91095 = false;
+};
+
+struct SimdSimtCostReport {
+  int64_t schemaVersion = 10;
+  std::string model = "ascend_candidate_cost_v2_cpp";
+  std::string profileVersion;
+  std::string profileTarget;
+  std::string actualTarget;
+  std::string profileContentSha256;
+  std::string selectionProfileContentSha256;
+  std::string microbenchmarkProfileVersion;
+  std::string microbenchmarkProfileTarget;
+  std::string microbenchmarkProfileContentSha256;
+  std::string scoreUnit;
+  std::string scoreScope = "per_program_ranking_proxy";
+
+  /// False means coverage rejected the kernel before any candidate cost was
+  /// evaluated.  In that state the numeric score members are placeholders and
+  /// are serialized as null rather than as meaningful zeros.
+  bool candidateCostsEvaluated = false;
+  /// Resource/structural scores before the bounded Event calibration for the
+  /// recognized feature domain is applied.
+  SimdSimtCandidateScores uncalibratedCandidateCosts;
+  SimdSimtCandidateScores candidateCosts;
+  SimdSimtCandidateScores candidateRatiosToBest;
+  SimdSimtCandidateScores eventRouteScoreMultipliers{1.0, 1.0, 1.0};
+  bool eventRouteCalibrationApplied = false;
+  bool eventAllSimtOnlyValidated = false;
+  bool eventMixedSimdSimtValidated = false;
+  std::string eventRouteCalibrationSource;
+  std::string eventRouteCalibrationConfidence = "none";
+  bool allSimdCandidateLegal = true;
+  bool allSimtOnlyCandidateLegal = true;
+  bool mixedCandidateLegal = false;
+  SimdSimtCandidateKind decision = SimdSimtCandidateKind::AllSIMD;
+  SimdSimtCandidateKind runnerUp = SimdSimtCandidateKind::AllSIMTOnly;
+  double bestScore = 0.0;
+  double runnerUpScore = 0.0;
+  /// Alias of decisionAdvantage kept as the compact gate-facing gain field.
+  double gainScore = 0.0;
+  /// For non-SIMD decisions this is all_simd - best.  For an all-SIMD
+  /// decision this is runner_up - best, so the baseline can win its own gate.
+  double decisionAdvantage = 0.0;
+  double requiredGainScore = 0.0;
+  double marginRatio = 0.10;
+
+  bool targetCompatible = true;
+  bool selectionScoreValid = false;
+  bool absoluteCostValid = false;
+  std::string rankingConfidence = "none";
+  std::string minimumConfidenceForDecision = "medium";
+  std::string absoluteConfidence = "none";
+  bool gatePassed = false;
+  std::vector<std::string> gateReasons;
+  std::vector<std::string> unsupported;
+  bool calibrationCovered = false;
+  std::string calibrationDomain = "out_of_calibration_domain";
+  SimtApplicabilityResult applicability;
+
+  SimdSimtFeatureSummary features;
+  SimdSimtCostBreakdown breakdown;
+  bool includeFeaturesInJSON = true;
+
+  llvm::json::Object toJSON() const;
+  void printJSON(llvm::raw_ostream &os, bool pretty = true) const;
+};
+
+/// Return the configured profile path.  The value is resolved in this
+/// order: TRITON_ASCEND_SIMD_SIMT_PROFILE, compiled source-tree path.
+std::string getDefaultSimdSimtProfilePath();
+
+/// Analyze generic TTIR without depending on Triton C++ op classes.
+llvm::Expected<SimdSimtFeatureSummary>
+analyzeSimdSimtFeatures(mlir::ModuleOp module, bool compileOn91095 = true);
+
+/// Analyze using a caller-owned immutable plan.  Selector uses this overload
+/// so the exact operations charged by the mixed score are the operations later
+/// marked for materialization.
+llvm::Expected<SimdSimtFeatureSummary>
+analyzeSimdSimtFeatures(mlir::ModuleOp module,
+                        const SimtAnchorPlan &anchorPlan);
+
+/// Run the versioned profile formula on an already materialized feature
+/// summary.  By default this preserves full out-of-coverage scoring for
+/// offline diagnostics; production callers can disable it in the options.
+/// This overload is useful for golden feature tests and offline tools.
+llvm::Expected<SimdSimtCostReport>
+estimateSimdSimtCandidates(const SimdSimtFeatureSummary &features,
+                           const SimdSimtCostModelOptions &options = {});
+
+/// Analyze a ModuleOp and, when admitted for scoring, score all three
+/// candidates in one call.
+llvm::Expected<SimdSimtCostReport>
+analyzeSimdSimtCandidates(mlir::ModuleOp module,
+                          const SimdSimtCostModelOptions &options = {});
+
+llvm::Expected<SimdSimtCostReport>
+analyzeSimdSimtCandidates(mlir::ModuleOp module,
+                          const SimtAnchorPlan &anchorPlan,
+                          const SimdSimtCostModelOptions &options = {});
+
+} // namespace ascend
+} // namespace mlir
+
+#endif // ASCENDMODEL_ROUTEMODEL_SIMDSIMTCOSTMODEL_H

--- a/third_party/ascend/costmodel/include/AscendModel/RouteModel/SimtAnchorAnalysis.h
+++ b/third_party/ascend/costmodel/include/AscendModel/RouteModel/SimtAnchorAnalysis.h
@@ -1,0 +1,154 @@
+//===- SimtAnchorAnalysis.h - Materializable SIMT anchors -------*- C++ -*-===//
+//
+// Shared TTIR pattern matching for the Route Model and scope materializer.
+// Keeping this contract in one place guarantees that mixed-candidate costs
+// describe the same operations that the selector can actually mark for SIMT.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ASCENDMODEL_ROUTEMODEL_SIMTANCHORANALYSIS_H
+#define ASCENDMODEL_ROUTEMODEL_SIMTANCHORANALYSIS_H
+
+#include "mlir/IR/BuiltinOps.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace mlir {
+namespace ascend {
+
+/// Hardware/lowering mechanism represented by one local SIMT anchor.  These
+/// names describe what the backend will do; they are intentionally independent
+/// of calibration workload names such as "tiny_irregular_dot".
+enum class SimtAnchorKind {
+  DirectGather,
+  LoadedIndexDependentMemory,
+  Histogram,
+  PlainOneDimensionalCumsum,
+  TensorAtomic,
+  TriangularSolveLoop,
+};
+
+llvm::StringRef stringifySimtAnchorKind(SimtAnchorKind kind);
+
+/// Whether one physical route is available for an anchor.  BackendConditional
+/// may be reported and scored offline, but it is not production-selectable.
+enum class CandidateLoweringStatus {
+  Unsupported,
+  Native,
+  BackendConditional,
+  AliasesMixed,
+};
+
+llvm::StringRef
+stringifyCandidateLoweringStatus(CandidateLoweringStatus status);
+
+struct CandidateLowerability {
+  CandidateLoweringStatus allSimd = CandidateLoweringStatus::Native;
+  CandidateLoweringStatus allSimtOnly = CandidateLoweringStatus::Native;
+  CandidateLoweringStatus mixed = CandidateLoweringStatus::Native;
+  std::vector<std::string> allSimdReasons;
+  std::vector<std::string> allSimtOnlyReasons;
+  std::vector<std::string> mixedReasons;
+};
+
+struct TensorAtomicFacts {
+  int64_t updateElements = 0;
+  int64_t addressRank = 0;
+  std::string valueType = "unknown";
+  std::string offsetType = "unknown";
+  std::string operation = "unknown";
+  bool hasMask = false;
+  std::optional<double> staticMaskActiveFraction;
+  bool resultUsed = false;
+  bool addressIsLaneVarying = false;
+  bool addressDependsOnLoadedIndex = false;
+  std::string contention = "unknown";
+};
+
+struct HistogramFacts {
+  int64_t inputElements = 0;
+  int64_t numBins = 0;
+  std::string inputType = "unknown";
+  std::string resultType = "unknown";
+};
+
+struct PlainCumsumFacts {
+  int64_t axisExtent = 0;
+  std::string elementType = "unknown";
+  bool reverse = false;
+};
+
+using SimtAnchorFacts = std::variant<std::monostate, TensorAtomicFacts,
+                                     HistogramFacts, PlainCumsumFacts>;
+
+struct SimtAnchorDescriptor {
+  Operation *operation = nullptr;
+  /// Exact top-level TTIR operations that will be moved into one local SIMT
+  /// scope. A simple anchor contains only `operation`; compound mechanisms
+  /// such as solve_tril may contain movable mask setup followed by the
+  /// recurrence/final-update range. Feature extraction and materialization
+  /// must consume this same set so the scored work is the work that the
+  /// backend actually lowers.
+  llvm::SmallVector<Operation *, 0> scopeOperations;
+  /// Where to insert the scope before moving `scopeOperations`. This differs
+  /// from scopeOperations.front() when pure mask setup is moved across the
+  /// initial SIMD loads to reproduce the hand-written solve_tril scope.
+  Operation *scopeInsertionPoint = nullptr;
+  SimtAnchorKind kind = SimtAnchorKind::LoadedIndexDependentMemory;
+  SimtAnchorFacts facts;
+  CandidateLowerability lowerability;
+  /// True only when the current target/materializer contract can turn this
+  /// descriptor into a local SIMT scope.
+  bool materializable = false;
+};
+
+/// One immutable analysis result shared by feature extraction, scoring, and
+/// selector application.  Keeping Operation pointers here prevents those
+/// stages from independently rediscovering different anchor sets.
+struct SimtAnchorPlan {
+  llvm::SmallVector<SimtAnchorDescriptor, 0> anchors;
+  CandidateLowerability kernelLowerability;
+
+  llvm::SmallVector<Operation *> materializableRoots() const;
+  int64_t materializableCount() const;
+};
+
+/// Materialize exactly the local SIMT regions described by `plan`.
+///
+/// This is deliberately a transform over the immutable analysis result: it
+/// does not rediscover anchors, recompute features, or read per-operation
+/// selection attributes.  The caller owns the final effective route decision.
+LogicalResult materializeSimtAnchorPlan(ModuleOp module,
+                                        const SimtAnchorPlan &plan);
+
+/// Classify a TTIR operation by SIMT mechanism, independently of whether the
+/// selected target can currently materialize it.
+std::optional<SimtAnchorKind> classifyMixedSimtAnchor(Operation *op);
+
+/// True when a load/store pointer has an SSA backward slice that reaches a
+/// loaded/gathered index.  This is a real data-dependence test and must not be
+/// confused with the legacy rank-based laneDependentPointerOps proxy.
+bool isLoadedIndexDependentMemoryOp(Operation *op);
+
+/// Build the non-overlapping shared plan in pre-order.
+SimtAnchorPlan buildMixedSimtAnchorPlan(ModuleOp module, bool compileOn91095);
+
+/// Return true when `op` is a TTIR operation that the current local-scope
+/// materializer can move into a SIMT scope on 910_95-class targets.
+bool isMixedSimtAnchor(Operation *op, bool compileOn91095);
+
+/// Collect non-overlapping anchors in pre-order.  Nested operations are not
+/// returned when an enclosing operation already forms one materialized scope.
+llvm::SmallVector<Operation *> collectMixedSimtAnchors(ModuleOp module,
+                                                       bool compileOn91095);
+
+} // namespace ascend
+} // namespace mlir
+
+#endif // ASCENDMODEL_ROUTEMODEL_SIMTANCHORANALYSIS_H

--- a/third_party/ascend/costmodel/include/AscendModel/RouteModel/SimtSelection.h
+++ b/third_party/ascend/costmodel/include/AscendModel/RouteModel/SimtSelection.h
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef ASCENDMODEL_ROUTEMODEL_SIMTSELECTION_H
+#define ASCENDMODEL_ROUTEMODEL_SIMTSELECTION_H
+
+#include "mlir/IR/Block.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Region.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace mlir::ascend::simt_selection {
+
+inline constexpr llvm::StringLiteral kEffectiveExecutionAttr =
+    "ascend.simt_costmodel.effective";
+// The kanuak mixed SIMD/SIMT pipeline consumes `vec_mode`. Keep
+// `vector_type` readable for compatibility, but materialize `vec_mode` in new
+// IR so the existing lowering recognizes the selected scope.
+inline constexpr llvm::StringLiteral kVectorModeAttr = "vec_mode";
+inline constexpr llvm::StringLiteral kLegacyVectorModeAttr = "vector_type";
+
+inline constexpr llvm::StringLiteral kAllSimd = "all_simd";
+inline constexpr llvm::StringLiteral kAllSimtOnly = "all_simt_only";
+inline constexpr llvm::StringLiteral kMixedSimdSimt = "mixed_simd_simt";
+inline constexpr llvm::StringLiteral kBackendDefault = "backend_default";
+
+/// Find the nearest function/module execution decision visible to `op`.
+///
+/// The cost model may attach the decision either to the kernel function or to
+/// its containing module.  Looking from the operation outwards also lets a
+/// function-level decision override a module-level default.
+inline StringAttr getEffectiveExecution(Operation *op) {
+  for (Operation *current = op; current; current = current->getParentOp()) {
+    if (auto attr =
+            current->getAttrOfType<StringAttr>(kEffectiveExecutionAttr)) {
+      return attr;
+    }
+  }
+  return {};
+}
+
+inline bool isKnownExecutionKind(llvm::StringRef kind) {
+  return kind == kAllSimd || kind == kAllSimtOnly || kind == kMixedSimdSimt ||
+         kind == kBackendDefault;
+}
+
+/// A backend_default or absent decision keeps the legacy backend routing.
+/// Only an admitted concrete model decision suppresses global legacy force
+/// flags and makes the local scope authoritative.
+inline bool isModelControlled(Operation *op) {
+  auto effective = getEffectiveExecution(op);
+  return effective && isKnownExecutionKind(effective.getValue()) &&
+         effective.getValue() != kBackendDefault;
+}
+
+inline bool isMixedModelDecision(Operation *op) {
+  auto effective = getEffectiveExecution(op);
+  return effective && effective.getValue() == kMixedSimdSimt;
+}
+
+inline StringAttr getVectorMode(Operation *op) {
+  if (auto attr = op->getAttrOfType<StringAttr>(kVectorModeAttr))
+    return attr;
+  return op->getAttrOfType<StringAttr>(kLegacyVectorModeAttr);
+}
+
+/// Return the nearest enclosing vector-mode annotation.  Nearest scope wins
+/// for nested explicit scopes.
+inline StringAttr getEnclosingVectorMode(Operation *op) {
+  for (Operation *parent = op->getParentOp(); parent;
+       parent = parent->getParentOp()) {
+    if (auto attr = getVectorMode(parent))
+      return attr;
+  }
+  return {};
+}
+
+inline bool hasEnclosingVectorMode(Operation *op, llvm::StringRef mode) {
+  auto attr = getEnclosingVectorMode(op);
+  return attr && attr.getValue() == mode;
+}
+
+/// Resolve whether an individual operation may take a SIMT lowering.
+///
+/// In a model-controlled compilation, the legacy global force flag is ignored:
+/// only an explicit local SIMT scope may enable SIMT.  In
+/// backend_default/legacy compilation the historical global behavior remains
+/// unchanged.  An explicit nearest SIMD scope always wins.
+inline bool shouldUseSimtTemplate(Operation *op, bool legacyForceSimt) {
+  if (hasEnclosingVectorMode(op, "simd"))
+    return false;
+
+  const bool locallySelected = hasEnclosingVectorMode(op, "simt");
+  if (isModelControlled(op))
+    return locallySelected;
+  return legacyForceSimt || locallySelected;
+}
+
+inline bool isVoidSimtScope(Operation *op) {
+  if (op->getName().getStringRef() != "scope.scope" ||
+      op->getNumResults() != 0 || op->getNumRegions() != 1)
+    return false;
+  auto mode = getVectorMode(op);
+  if (!mode || mode.getValue() != "simt")
+    return false;
+
+  Region &region = op->getRegion(0);
+  if (!region.hasOneBlock() || region.front().empty() ||
+      region.front().getNumArguments() != 0)
+    return false;
+  Operation &terminator = region.front().back();
+  return terminator.getName().getStringRef() == "scope.return" &&
+         terminator.getNumOperands() == 0;
+}
+
+/// Return the sole void SIMT scope that owns a kernel's whole executable body.
+///
+/// Constants and the function return may stay outside the scope.  Inspecting
+/// structured IR here replaces the former Python TTIR text heuristic.
+inline Operation *findWholeBodyVoidSimtScope(Operation *root) {
+  Operation *kernel = nullptr;
+  for (Region &region : root->getRegions()) {
+    for (Block &block : region) {
+      for (Operation &nested : block) {
+        llvm::StringRef name = nested.getName().getStringRef();
+        if (name != "tt.func" && name != "func.func")
+          continue;
+        auto visibility = nested.getAttrOfType<StringAttr>("sym_visibility");
+        if (visibility && visibility.getValue() != "public")
+          continue;
+        if (kernel)
+          return nullptr;
+        kernel = &nested;
+      }
+    }
+  }
+  if (!kernel || kernel->getNumRegions() != 1 ||
+      !kernel->getRegion(0).hasOneBlock())
+    return nullptr;
+
+  Block &body = kernel->getRegion(0).front();
+  if (body.empty())
+    return nullptr;
+  Operation *terminator = body.getTerminator();
+  llvm::StringRef terminatorName = terminator->getName().getStringRef();
+  if ((terminatorName != "tt.return" && terminatorName != "func.return") ||
+      terminator->getNumOperands() != 0)
+    return nullptr;
+
+  Operation *simtScope = nullptr;
+  for (Operation &nested : body.without_terminator()) {
+    llvm::StringRef name = nested.getName().getStringRef();
+    if (name == "arith.constant")
+      continue;
+    if (isVoidSimtScope(&nested) && !simtScope) {
+      simtScope = &nested;
+      continue;
+    }
+    return nullptr;
+  }
+  return simtScope;
+}
+
+/// Inline result-free SIMT scopes before the pure-SIMT TTIR compiler.
+///
+/// Result-bearing scopes are intentionally left untouched because they need
+/// SSA result remapping and belong to the mixed lowering path.
+inline int64_t inlineVoidSimtScopesForPureSimt(Operation *root) {
+  llvm::SmallVector<Operation *> scopes;
+  root->walk<WalkOrder::PostOrder>([&](Operation *nested) {
+    if (isVoidSimtScope(nested))
+      scopes.push_back(nested);
+  });
+
+  int64_t inlined = 0;
+  for (Operation *scope : scopes) {
+    Block &body = scope->getRegion(0).front();
+    Operation *terminator = &body.back();
+    while (&body.front() != terminator)
+      body.front().moveBefore(scope);
+    terminator->erase();
+    scope->erase();
+    ++inlined;
+  }
+  return inlined;
+}
+
+} // namespace mlir::ascend::simt_selection
+
+#endif // ASCENDMODEL_ROUTEMODEL_SIMTSELECTION_H

--- a/third_party/ascend/costmodel/include/AscendModel/RouteModel/SimtSelection.h
+++ b/third_party/ascend/costmodel/include/AscendModel/RouteModel/SimtSelection.h
@@ -34,10 +34,8 @@ namespace mlir::ascend::simt_selection {
 
 inline constexpr llvm::StringLiteral kEffectiveExecutionAttr =
     "ascend.simt_costmodel.effective";
-// The kanuak mixed SIMD/SIMT pipeline consumes `vec_mode`. Keep
-// `vector_type` readable for compatibility, but materialize `vec_mode` in new
-// IR so the existing lowering recognizes the selected scope.
-inline constexpr llvm::StringLiteral kVectorModeAttr = "vec_mode";
+// Use one spelling from the Python API through TTIR and Route Model lowering.
+inline constexpr llvm::StringLiteral kVectorModeAttr = "vector_mode";
 inline constexpr llvm::StringLiteral kLegacyVectorModeAttr = "vector_type";
 
 inline constexpr llvm::StringLiteral kAllSimd = "all_simd";

--- a/third_party/ascend/costmodel/include/AscendModel/Transforms/Passes.td
+++ b/third_party/ascend/costmodel/include/AscendModel/Transforms/Passes.td
@@ -183,5 +183,71 @@ def PerfReportPass : Pass<"perf-report", "ModuleOp"> {
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// SelectSimdSimtCostModel
+//===----------------------------------------------------------------------===//
+
+def SelectSimdSimtCostModelPass
+    : Pass<"select-simd-simt-costmodel", "ModuleOp"> {
+  let summary = "Select SIMD, SIMT-only, or mixed execution with the C++ cost model";
+  let description = [{
+    This pass runs the AscendModel C++ SIMD/SIMT candidate model directly on
+    Triton IR.  Report mode always records the complete three-candidate
+    diagnostic report.  Auto mode first checks calibration coverage and skips
+    candidate scoring for out-of-domain kernels; an admitted in-domain decision
+    becomes the authoritative execution intent.  A mixed decision passes the
+    same immutable anchor plan used for scoring directly to the C++
+    materializer, which creates local scope.scope regions without persisting
+    per-operation selection attributes.
+
+    Mandatory mixed is intentionally not part of this pass.  Singleton
+    legality fast paths can be added in front of the model after the calibrated
+    three-candidate path is complete.
+  }];
+
+  let options = [
+    Option<"mode", "mode", "std::string",
+           /*default=*/"\"report\"",
+           "Application mode: report or auto">,
+    Option<"profilePath", "profile-path", "std::string",
+           /*default=*/"\"\"",
+           "Versioned SIMD/SIMT calibration profile JSON">,
+    Option<"actualTarget", "actual-target", "std::string",
+           /*default=*/"\"\"",
+           "Backend target used for profile compatibility checks">,
+    Option<"numWarps", "num-warps", "int64_t",
+           /*default=*/"32",
+           "Number of logical warps in the candidate execution plan">,
+    Option<"marginRatio", "margin-ratio", "double",
+           /*default=*/"0.10",
+           "Minimum relative score advantage required for an online action">,
+    Option<"compileOn91095", "compile-on-910-95", "bool",
+           /*default=*/"false",
+           "Whether the target exposes the 910/95 SIMT lowering templates">,
+    Option<"reportFile", "report-file", "std::string",
+           /*default=*/"\"\"",
+           "Optional JSONL path for the C++ selection report">
+  ];
+}
+
+//===----------------------------------------------------------------------===//
+// MaterializeSimtScopes
+//===----------------------------------------------------------------------===//
+
+def MaterializeSimtScopesPass
+    : Pass<"materialize-simt-scopes", "ModuleOp"> {
+  let summary = "Validate the scope-only contract for an admitted mixed route";
+  let description = [{
+    Production materialization is performed from the immutable anchor plan in
+    the selector pass.  This compatibility pass verifies that:
+
+      ascend.simt_costmodel.effective = "mixed_simd_simt"
+      scope.scope {vec_mode = "simt"}
+
+    coexist in the IR.  It does not rediscover anchors or read/write a
+    per-operation selected marker.
+  }];
+}
+
 
 #endif // ASCEND_MODEL_TRANSFORMS_PASSES_TD

--- a/third_party/ascend/costmodel/include/AscendModel/Transforms/Passes.td
+++ b/third_party/ascend/costmodel/include/AscendModel/Transforms/Passes.td
@@ -242,7 +242,7 @@ def MaterializeSimtScopesPass
     the selector pass.  This compatibility pass verifies that:
 
       ascend.simt_costmodel.effective = "mixed_simd_simt"
-      scope.scope {vec_mode = "simt"}
+      scope.scope {vector_mode = "simt"}
 
     coexist in the IR.  It does not rediscover anchors or read/write a
     per-operation selected marker.

--- a/third_party/ascend/costmodel/lib/AscendModel/Analysis/CMakeLists.txt
+++ b/third_party/ascend/costmodel/lib/AscendModel/Analysis/CMakeLists.txt
@@ -1,3 +1,17 @@
+if(TRITONSIM_HAS_BISHENGIR_HIVM)
+  add_compile_definitions(TRITONSIM_HAS_BISHENGIR_HIVM=1)
+  include_directories(SYSTEM ${TRITONSIM_BISHENGIR_INCLUDE_DIRS})
+endif()
+
+set(ASCEND_MODEL_ANALYSIS_DEPENDS
+  AscendModelOpsIncGen
+)
+if(TRITONSIM_HAS_BISHENGIR_HIVM)
+  list(APPEND ASCEND_MODEL_ANALYSIS_DEPENDS
+    ${TRITONSIM_BISHENGIR_HIVM_LIBS}
+  )
+endif()
+
 add_mlir_library(AscendModelAnalysis
   PARTIAL_SOURCES_INTENDED
   HardwareConfig.cpp
@@ -5,12 +19,13 @@ add_mlir_library(AscendModelAnalysis
   PipelineAnalysis.cpp
 
   ADDITIONAL_HEADER_DIRS
-  ${PROJECT_SOURCE_DIR}/include/AscendModel/Analysis
+  ${TRITON_ASCEND_COSTMODEL_SOURCE_DIR}/include/AscendModel/Analysis
 
   DEPENDS
-  AscendModelOpsIncGen
+  ${ASCEND_MODEL_ANALYSIS_DEPENDS}
 
   LINK_LIBS PUBLIC
+  AscendModelProfile
   AscendModelIR
   MLIRArithDialect
   MLIRFuncDialect

--- a/third_party/ascend/costmodel/lib/AscendModel/Analysis/HIVMAnalysis.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Analysis/HIVMAnalysis.cpp
@@ -33,6 +33,8 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/JSON.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 
@@ -505,6 +507,19 @@ static void eraseAttributeAssignment(std::string &line, llvm::StringRef name) {
   }
 }
 
+static void eraseAngleBracketClause(std::string &line, llvm::StringRef name) {
+  std::string needle = (name + " = <").str();
+  for (;;) {
+    size_t pos = line.find(needle);
+    if (pos == std::string::npos)
+      return;
+    size_t valueEnd = line.find('>', pos + needle.size());
+    if (valueEnd == std::string::npos)
+      return;
+    line.erase(pos, valueEnd - pos + 1);
+  }
+}
+
 static std::string sanitizeMlirBuffer(llvm::StringRef buffer) {
   // Pre-process to remove custom dialect attributes/types that require
   // registered dialects.  When built without BiShengIR, the parser cannot
@@ -517,12 +532,14 @@ static std::string sanitizeMlirBuffer(llvm::StringRef buffer) {
     for (llvm::StringRef line : lines) {
       llvm::StringRef trimmed = line.trim();
       if (trimmed.starts_with("warning: ") ||
+          trimmed.starts_with("bisheng: warning:") ||
           trimmed.ends_with("warning generated."))
         break;
       if (trimmed.starts_with("ld.lld:") || trimmed.starts_with("[ERROR]") ||
           trimmed.starts_with("[WARNING]") || trimmed.starts_with("[INFO]"))
         continue;
       std::string l = line.str();
+#ifndef TRITONSIM_HAS_BISHENGIR_HIVM
       // Replace #hivm.address_space<xxx> with integer memory space
       while (auto pos = l.find("#hivm.address_space<")) {
         auto end = l.find('>', pos);
@@ -551,6 +568,10 @@ static std::string sanitizeMlirBuffer(llvm::StringRef buffer) {
       eraseAttributeAssignment(l, "hacc.arg_type");
       eraseAttributeAssignment(l, "hivm.func_core_type");
       eraseAttributeAssignment(l, "hacc.function_kind");
+#endif
+      // Newer HIVM printers emit this optional policy clause, but older
+      // BiShengIR parsers do not accept it. It does not affect this model.
+      eraseAngleBracketClause(l, "eviction_policy");
       os << l << "\n";
     }
     os.flush();
@@ -612,6 +633,32 @@ static std::string canonicalizeStaticEventToken(llvm::StringRef token) {
   if (token.consume_front("EVENT_ID"))
     return token.str();
   return token.str();
+}
+
+static std::string stringifyTypedValue(mlir::Value value) {
+  if (!value)
+    return "";
+  std::string text;
+  llvm::raw_string_ostream os(text);
+  value.printAsOperand(os, mlir::OpPrintingFlags());
+  return os.str();
+}
+
+static std::string
+stringifyTypedEvent(std::optional<mlir::hivm::EventAttr> staticEvent,
+                    mlir::Value dynamicEvent) {
+  if (staticEvent)
+    return canonicalizeStaticEventToken(
+        mlir::hivm::stringifyEVENT(staticEvent->getEvent()));
+  return stringifyTypedValue(dynamicEvent);
+}
+
+static std::string
+stringifyTypedFlag(std::optional<mlir::IntegerAttr> staticFlag,
+                   mlir::Value dynamicFlag) {
+  if (staticFlag)
+    return std::to_string(staticFlag->getInt());
+  return stringifyTypedValue(dynamicFlag);
 }
 
 static bool populateTypedHivmOp(mlir::Operation *op, ParsedOp &parsed) {
@@ -2835,6 +2882,58 @@ void HIVMAnalysisReport::print(llvm::raw_ostream &os,
       os << ", " << op->elements << " elems";
     os << "\n";
   }
+}
+
+void HIVMAnalysisReport::emitFeedbackJSON(llvm::raw_ostream &os,
+                                          const HardwareConfig &config) const {
+  const double fallbackRatio =
+      opCount > 0 ? static_cast<double>(unknownOpCount) / opCount : 1.0;
+  const bool scheduleComplete =
+      opCount > 0 && operations.size() == opCount && unknownOpCount == 0;
+
+  llvm::json::Object pipes;
+  for (const auto &entry : pipeBusyCycles)
+    pipes[HIVMAnalyzer::stringifyPipe(entry.first).str()] = entry.second;
+
+  llvm::json::Object weightedPipes;
+  for (const auto &entry : weightedPipeCycles)
+    weightedPipes[HIVMAnalyzer::stringifyPipe(entry.first).str()] =
+        entry.second;
+
+  llvm::json::Object quality;
+  quality["parsed_operation_count"] = static_cast<int64_t>(operations.size());
+  quality["scheduled_operation_count"] = static_cast<int64_t>(opCount);
+  quality["fallback_operation_count"] = static_cast<int64_t>(unknownOpCount);
+  quality["fallback_ratio"] = fallbackRatio;
+  quality["schedule_complete"] = scheduleComplete;
+
+  llvm::json::Object summary;
+  summary["critical_path_cycles"] = oneIterationCycles;
+  summary["critical_path_us"] = config.cyclesToMicroseconds(oneIterationCycles);
+  summary["weighted_cycles"] = weightedCycles;
+  summary["sync_cycles"] = syncCycles;
+  summary["barrier_cycles"] = barrierCycles;
+  summary["operation_count"] = static_cast<int64_t>(opCount);
+  summary["sync_operation_count"] = static_cast<int64_t>(syncOpCount);
+  summary["barrier_count"] = static_cast<int64_t>(barrierCount);
+  summary["max_loop_multiplier"] = maxLoopMultiplier;
+
+  llvm::json::Object root;
+  root["schema_version"] = 1;
+  root["kind"] = "hivm_des_feedback_source";
+  root["source_mode"] = sourceMode;
+  root["source"] = sourcePath;
+  root["scheduler"] = HIVMAnalyzer::stringifySchedulerMode(schedulerMode).str();
+  root["target"] = config.getName();
+  root["scope"] = "single_program";
+  root["cycle_domain"] = "device_clock_cycles";
+  root["clock_frequency_ghz"] = config.getClockFrequencyGHz();
+  root["excludes"] = llvm::json::Array({"host_launch", "grid_wave_count"});
+  root["quality"] = std::move(quality);
+  root["summary"] = std::move(summary);
+  root["pipe_busy_cycles"] = std::move(pipes);
+  root["weighted_pipe_cycles"] = std::move(weightedPipes);
+  os << llvm::formatv("{0:2}", llvm::json::Value(std::move(root)));
 }
 
 void HIVMAnalysisReport::emitPerfettoTrace(llvm::raw_ostream &os,

--- a/third_party/ascend/costmodel/lib/AscendModel/Analysis/HardwareConfig.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Analysis/HardwareConfig.cpp
@@ -6,10 +6,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "AscendModel/HardwareConfig.h"
+#include "AscendModel/Profile/MicrobenchmarkProfile.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
+#include <algorithm>
 #include <cmath>
 #include <cstdlib>
 #include <mutex>
@@ -86,8 +89,6 @@ mlir::ascend::loadHardwareConfigForAnalysis(llvm::StringRef path,
 
 HardwareConfig::HardwareConfig() : clockFreqGHz(1.0) {}
 
-HardwareConfig::~HardwareConfig() = default;
-
 std::unique_ptr<HardwareConfig>
 HardwareConfig::loadFromFile(llvm::StringRef path) {
   auto bufferOrErr = llvm::MemoryBuffer::getFile(path);
@@ -103,7 +104,18 @@ HardwareConfig::loadFromFile(llvm::StringRef path) {
     return nullptr;
   }
 
-  return loadFromJSON(*json);
+  auto config = std::make_unique<HardwareConfig>();
+  std::string error;
+  if (!config->parseJSON(*json, error)) {
+    llvm::errs() << "Error parsing hardware config: " << error << "\n";
+    return nullptr;
+  }
+  if (!config->loadReferencedMicrobenchmarkProfile(path, error)) {
+    llvm::errs() << "Error loading shared microbenchmark profile: " << error
+                 << "\n";
+    return nullptr;
+  }
+  return config;
 }
 
 std::unique_ptr<HardwareConfig>
@@ -113,6 +125,22 @@ HardwareConfig::loadFromJSON(const llvm::json::Value &json) {
   if (!config->parseJSON(json, error)) {
     llvm::errs() << "Error parsing hardware config: " << error << "\n";
     return nullptr;
+  }
+  if (!config->microbenchmarkProfileReference.empty()) {
+    llvm::StringRef reference(config->microbenchmarkProfileReference);
+    if (!llvm::sys::path::is_absolute(reference)) {
+      llvm::errs()
+          << "Error parsing hardware config: relative microbenchmark_profile "
+             "requires HardwareConfig::loadFromFile so it can be resolved "
+             "against the owner JSON path\n";
+      return nullptr;
+    }
+    if (!config->loadReferencedMicrobenchmarkProfile(/*configPath=*/"",
+                                                     error)) {
+      llvm::errs() << "Error loading shared microbenchmark profile: " << error
+                   << "\n";
+      return nullptr;
+    }
   }
   return config;
 }
@@ -587,6 +615,23 @@ bool HardwareConfig::parseJSON(const llvm::json::Value &json,
     vendor = v->str();
   if (auto ver = root->getString("version"))
     version = ver->str();
+  if (const llvm::json::Value *rawTarget = root->get("target")) {
+    auto targetName = rawTarget->getAsString();
+    if (!targetName || targetName->empty()) {
+      error = "target must be a non-empty string";
+      return false;
+    }
+    target = targetName->str();
+  }
+  if (const llvm::json::Value *rawProfile =
+          root->get("microbenchmark_profile")) {
+    auto profile = rawProfile->getAsString();
+    if (!profile || profile->empty()) {
+      error = "microbenchmark_profile must be a non-empty string";
+      return false;
+    }
+    microbenchmarkProfileReference = profile->str();
+  }
 
   // Clock
   if (const auto *clock = root->getObject("clock")) {
@@ -954,6 +999,84 @@ bool HardwareConfig::parseJSON(const llvm::json::Value &json,
   return true;
 }
 
+bool HardwareConfig::loadReferencedMicrobenchmarkProfile(
+    llvm::StringRef configPath, std::string &error) {
+  if (microbenchmarkProfileReference.empty())
+    return true;
+
+  llvm::SmallString<256> resolved;
+  llvm::StringRef reference(microbenchmarkProfileReference);
+  if (llvm::sys::path::is_absolute(reference)) {
+    resolved = reference;
+  } else {
+    resolved = configPath;
+    llvm::sys::path::remove_filename(resolved);
+    llvm::sys::path::append(resolved, reference);
+    llvm::sys::path::remove_dots(resolved, true);
+  }
+
+  auto profile = MicrobenchmarkProfile::loadFromFile(resolved);
+  if (!profile) {
+    error = llvm::toString(profile.takeError());
+    return false;
+  }
+
+  auto measuredDeviceMHz = profile->requireValue(
+      "clock.device_compute.frequency_mhz", "MHz", "wall_clock");
+  if (!measuredDeviceMHz) {
+    error = llvm::toString(measuredDeviceMHz.takeError());
+    return false;
+  }
+
+  if (!target.empty() && llvm::StringRef(target) != profile->getTarget()) {
+    error = "shared microbenchmark target '" + profile->getTarget().str() +
+            "' does not match hardware config target '" + target + "'";
+    return false;
+  }
+
+  const double configuredDeviceMHz = clockFreqGHz * 1000.0;
+  const double clockToleranceMHz = std::max(1.0, configuredDeviceMHz * 1.0e-3);
+  if (configuredDeviceMHz <= 0.0 ||
+      std::abs(*measuredDeviceMHz - configuredDeviceMHz) > clockToleranceMHz) {
+    error = "shared microbenchmark device clock " +
+            std::to_string(*measuredDeviceMHz) +
+            " MHz does not match hardware config clock " +
+            std::to_string(configuredDeviceMHz) + " MHz";
+    return false;
+  }
+
+  auto measuredVectorWidth =
+      profile->requireValue("simd.vector_width_bits", "bit", "none");
+  if (!measuredVectorWidth) {
+    error = llvm::toString(measuredVectorWidth.takeError());
+    return false;
+  }
+  const int configuredVectorWidthBits = getVectorWidthBytes() * 8;
+  if (configuredVectorWidthBits <= 0 ||
+      std::llround(*measuredVectorWidth) != configuredVectorWidthBits) {
+    error = "shared microbenchmark SIMD vector width " +
+            std::to_string(*measuredVectorWidth) +
+            " bits does not match hardware config width " +
+            std::to_string(configuredVectorWidthBits) + " bits";
+    return false;
+  }
+
+  auto f32AddThroughput = profile->requireValue(
+      "simd.f32.add.throughput", "vector_instruction/system_cycle", "SYS_CNT");
+  if (!f32AddThroughput) {
+    error = llvm::toString(f32AddThroughput.takeError());
+    return false;
+  }
+  if (*f32AddThroughput <= 0.0) {
+    error = "shared microbenchmark SIMD f32.add throughput must be positive";
+    return false;
+  }
+
+  microbenchmarkProfile =
+      std::make_shared<MicrobenchmarkProfile>(std::move(*profile));
+  return true;
+}
+
 //===----------------------------------------------------------------------===//
 // Query Methods
 //===----------------------------------------------------------------------===//
@@ -1101,6 +1224,26 @@ int HardwareConfig::getVectorOpCyclesPerInstruction(
   if (opName == "vreduce")
     return 2;
   return 1;
+}
+
+double
+HardwareConfig::getMicrobenchmarkRatePerDeviceCycle(llvm::StringRef key) const {
+  if (!microbenchmarkProfile || clockFreqGHz <= 0.0)
+    return 0.0;
+  const MicrobenchmarkMeasurement *measurement =
+      microbenchmarkProfile->getMeasurement(key);
+  if (!measurement || measurement->value <= 0.0 ||
+      !llvm::StringRef(measurement->unit).ends_with("/system_cycle") ||
+      measurement->cycleDomain != "SYS_CNT")
+    return 0.0;
+
+  auto systemMHz = microbenchmarkProfile->requireValue(
+      "clock.sys_cnt.frequency_mhz", "MHz", "wall_clock");
+  if (!systemMHz) {
+    llvm::consumeError(systemMHz.takeError());
+    return 0.0;
+  }
+  return measurement->value * *systemMHz / (clockFreqGHz * 1000.0);
 }
 
 double HardwareConfig::getHBMBandwidthGBs() const {

--- a/third_party/ascend/costmodel/lib/AscendModel/CMakeLists.txt
+++ b/third_party/ascend/costmodel/lib/AscendModel/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_subdirectory(IR)
+add_subdirectory(Profile)
 add_subdirectory(Analysis)
+add_subdirectory(RouteModel)
 add_subdirectory(Transforms)

--- a/third_party/ascend/costmodel/lib/AscendModel/IR/AscendModelOps.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/IR/AscendModelOps.cpp
@@ -15,6 +15,9 @@
 #include "mlir/IR/TypeUtilities.h"
 #include "llvm/ADT/STLExtras.h"
 
+#include <algorithm>
+#include <cmath>
+
 using namespace mlir;
 using namespace mlir::ascend;
 
@@ -59,29 +62,32 @@ static int getElementBitsFromType(Type type) {
 }
 
 /// Estimate vector operation cycles.
-/// Vector unit is 2048 bits wide = 128 FP16 = 64 FP32 elements per cycle.
-static int64_t estimateVectorCycles(int64_t numElements, int cyclesPerVectorOp,
-                                    int elementBits, int startupLatency) {
+///
+/// The vector width is a hardware fact.  A model-neutral measured throughput
+/// may override the absolute model's legacy cycles-per-instruction fallback,
+/// while startup and other calibration remain absolute-model policy.
+static int64_t
+estimateVectorCycles(int64_t numElements, int cyclesPerVectorOp,
+                     int elementBits, int startupLatency,
+                     const HardwareConfig &config,
+                     llvm::StringRef throughputMeasurement = {}) {
   // Vector width based on element type
-  int64_t vectorWidth = 2048 / elementBits;
+  int64_t vectorWidth =
+      std::max<int64_t>(1, config.getVectorWidthBytes() * 8 / elementBits);
 
   // Number of vector operations
   int64_t numVectorOps = (numElements + vectorWidth - 1) / vectorWidth;
 
-  // Total cycles
+  if (!throughputMeasurement.empty()) {
+    double instructionsPerDeviceCycle =
+        config.getMicrobenchmarkRatePerDeviceCycle(throughputMeasurement);
+    if (instructionsPerDeviceCycle > 0.0)
+      return static_cast<int64_t>(
+                 std::ceil(numVectorOps / instructionsPerDeviceCycle)) +
+             startupLatency;
+  }
+
   return numVectorOps * cyclesPerVectorOp + startupLatency;
-}
-
-/// Estimate memory transfer cycles.
-static int64_t estimateMemoryCycles(int64_t bytes, const HardwareConfig &config,
-                                    int startupLatency) {
-  double bandwidth_gbs = config.getHBMBandwidthGBs();
-  if (bandwidth_gbs <= 0)
-    bandwidth_gbs = 1600.0;
-
-  double time_seconds = static_cast<double>(bytes) / (bandwidth_gbs * 1e9);
-  double cycles = time_seconds * config.getClockFrequencyGHz() * 1e9;
-  return static_cast<int64_t>(cycles) + startupLatency;
 }
 
 /// tilesim-migrated vector estimate (root cause 1, vector side):
@@ -389,7 +395,7 @@ IMPL_VEC_UNARY_TABLE(SqrtOp, "VSQRT")
     int64_t n = getNumElementsFromType(getInput().getType());                  \
     int bits = getElementBitsFromType(getInput().getType());                   \
     return estimateVectorCycles(n, CyclesPerOp, bits,                          \
-                                config.getVectorStartupLatency());             \
+                                config.getVectorStartupLatency(), config);     \
   }                                                                            \
   HWUnit OpClass::getHWUnit() { return HWUnit::Vector; }                       \
   int64_t OpClass::getFlops() {                                                \
@@ -425,7 +431,8 @@ int SigmoidOp::getCyclesPerVectorOp() { return 15; }
   int64_t OpClass::estimateCycles(const HardwareConfig &config) {              \
     int64_t numElems = getNumElementsFromType(getInput().getType());           \
     int bits = getElementBitsFromType(getInput().getType());                   \
-    int64_t vectorWidth = 2048 / bits;                                         \
+    int64_t vectorWidth =                                                      \
+        std::max<int64_t>(1, config.getVectorWidthBytes() * 8 / bits);         \
     int64_t numVectors = (numElems + vectorWidth - 1) / vectorWidth;           \
     int vectorReduceCycles = 0;                                                \
     int64_t w = vectorWidth;                                                   \
@@ -471,7 +478,8 @@ HWUnit BroadcastOp::getHWUnit() { return HWUnit::Vector; }
 int64_t SelectOp::estimateCycles(const HardwareConfig &config) {
   int64_t n = getNumElementsFromType(getResult().getType());
   int bits = getElementBitsFromType(getResult().getType());
-  return estimateVectorCycles(n, 1, bits, config.getVectorStartupLatency());
+  return estimateVectorCycles(n, 1, bits, config.getVectorStartupLatency(),
+                              config);
 }
 HWUnit SelectOp::getHWUnit() { return HWUnit::Vector; }
 int64_t SelectOp::getFlops() {

--- a/third_party/ascend/costmodel/lib/AscendModel/Profile/CMakeLists.txt
+++ b/third_party/ascend/costmodel/lib/AscendModel/Profile/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_mlir_library(AscendModelProfile
+  MicrobenchmarkProfile.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${TRITON_ASCEND_COSTMODEL_SOURCE_DIR}/include/AscendModel/Profile
+
+  LINK_LIBS PUBLIC
+  MLIRSupport
+  LLVMSupport
+)

--- a/third_party/ascend/costmodel/lib/AscendModel/Profile/MicrobenchmarkProfile.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Profile/MicrobenchmarkProfile.cpp
@@ -1,0 +1,184 @@
+//===- MicrobenchmarkProfile.cpp - Shared cost-model evidence -------------===//
+
+#include "AscendModel/Profile/MicrobenchmarkProfile.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/SHA256.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cmath>
+#include <system_error>
+#include <utility>
+
+using namespace mlir;
+using namespace mlir::ascend;
+
+namespace {
+
+static std::string sha256(llvm::StringRef content) {
+  llvm::ArrayRef<uint8_t> bytes(
+      reinterpret_cast<const uint8_t *>(content.data()), content.size());
+  auto digest = llvm::SHA256::hash(bytes);
+  return llvm::toHex(llvm::ArrayRef<uint8_t>(digest), true);
+}
+
+static llvm::Error invalidProfile(llvm::Twine message) {
+  return llvm::createStringError(std::errc::invalid_argument,
+                                 "invalid microbenchmark profile: %s",
+                                 message.str().c_str());
+}
+
+} // namespace
+
+llvm::Expected<MicrobenchmarkProfile>
+MicrobenchmarkProfile::loadFromFile(llvm::StringRef path) {
+  auto buffer = llvm::MemoryBuffer::getFile(path);
+  if (!buffer)
+    return llvm::createStringError(buffer.getError(),
+                                   "failed to read microbenchmark profile '%s'",
+                                   path.str().c_str());
+
+  llvm::StringRef content = buffer.get()->getBuffer();
+  auto parsed = llvm::json::parse(content);
+  if (!parsed)
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "failed to parse microbenchmark profile '%s': %s", path.str().c_str(),
+        llvm::toString(parsed.takeError()).c_str());
+  return loadFromJSON(*parsed, content);
+}
+
+llvm::Expected<MicrobenchmarkProfile>
+MicrobenchmarkProfile::loadFromJSON(const llvm::json::Value &json,
+                                    llvm::StringRef contentForHash) {
+  const auto *root = json.getAsObject();
+  if (!root)
+    return invalidProfile("root must be an object");
+
+  auto schemaVersion = root->getInteger("schema_version");
+  if (!schemaVersion || *schemaVersion != 1)
+    return invalidProfile("schema_version must be 1");
+
+  auto version = root->getString("profile_version");
+  auto targetName = root->getString("target");
+  const auto *rawMeasurements = root->getObject("measurements");
+  if (!version || version->empty())
+    return invalidProfile("profile_version must be a non-empty string");
+  if (!targetName || targetName->empty())
+    return invalidProfile("target must be a non-empty string");
+  if (!rawMeasurements || rawMeasurements->empty())
+    return invalidProfile("measurements must be a non-empty object");
+
+  MicrobenchmarkProfile result;
+  result.profileVersion = version->str();
+  result.target = targetName->str();
+
+  for (const auto &entry : *rawMeasurements) {
+    llvm::StringRef key = entry.first;
+    const auto *object = entry.second.getAsObject();
+    if (!object)
+      return invalidProfile("measurement '" + key + "' must be an object");
+
+    auto value = object->getNumber("value");
+    auto unit = object->getString("unit");
+    auto cycleDomain = object->getString("cycle_domain");
+    auto scope = object->getString("scope");
+    auto sourceKind = object->getString("source_kind");
+    auto source = object->getString("source");
+    auto confidence = object->getString("confidence");
+    if (!value || !std::isfinite(*value))
+      return invalidProfile("measurement '" + key +
+                            "' must have a finite numeric value");
+    if (!unit || unit->empty())
+      return invalidProfile("measurement '" + key + "' must have a unit");
+    if (!cycleDomain || cycleDomain->empty())
+      return invalidProfile("measurement '" + key +
+                            "' must have a cycle_domain");
+    if (!scope || scope->empty())
+      return invalidProfile("measurement '" + key + "' must have a scope");
+    if (!sourceKind || sourceKind->empty())
+      return invalidProfile("measurement '" + key +
+                            "' must have a source_kind");
+    if (!source || source->empty())
+      return invalidProfile("measurement '" + key + "' must have a source");
+    if (!confidence || confidence->empty())
+      return invalidProfile("measurement '" + key + "' must have a confidence");
+    if (*confidence != "high" && *confidence != "medium" &&
+        *confidence != "low")
+      return invalidProfile("measurement '" + key +
+                            "' confidence must be high, medium, or low");
+    if (*cycleDomain != "none" && *cycleDomain != "wall_clock" &&
+        *cycleDomain != "SYS_CNT" && *cycleDomain != "device_compute")
+      return invalidProfile("measurement '" + key +
+                            "' has an unsupported cycle_domain");
+
+    MicrobenchmarkMeasurement measurement;
+    measurement.value = *value;
+    measurement.unit = unit->str();
+    measurement.cycleDomain = cycleDomain->str();
+    measurement.scope = scope->str();
+    measurement.sourceKind = sourceKind->str();
+    measurement.source = source->str();
+    measurement.confidence = confidence->str();
+    result.measurements[key] = std::move(measurement);
+  }
+
+  if (!contentForHash.empty()) {
+    result.contentSha256 = sha256(contentForHash);
+  } else {
+    std::string serialized;
+    llvm::raw_string_ostream stream(serialized);
+    stream << json;
+    stream.flush();
+    result.contentSha256 = sha256(serialized);
+  }
+  return result;
+}
+
+const MicrobenchmarkMeasurement *
+MicrobenchmarkProfile::getMeasurement(llvm::StringRef key) const {
+  auto iterator = measurements.find(key);
+  return iterator == measurements.end() ? nullptr : &iterator->second;
+}
+
+llvm::Expected<double> MicrobenchmarkProfile::requireValue(
+    llvm::StringRef key, std::optional<llvm::StringRef> expectedUnit,
+    std::optional<llvm::StringRef> expectedCycleDomain) const {
+  const MicrobenchmarkMeasurement *measurement = getMeasurement(key);
+  if (!measurement)
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "microbenchmark profile is missing measurement '%s'",
+        key.str().c_str());
+  if (expectedUnit && measurement->unit != *expectedUnit)
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "microbenchmark measurement '%s' has unit '%s', expected '%s'",
+        key.str().c_str(), measurement->unit.c_str(),
+        expectedUnit->str().c_str());
+  if (expectedCycleDomain && measurement->cycleDomain != *expectedCycleDomain)
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "microbenchmark measurement '%s' has cycle_domain '%s', expected '%s'",
+        key.str().c_str(), measurement->cycleDomain.c_str(),
+        expectedCycleDomain->str().c_str());
+  return measurement->value;
+}
+
+llvm::Expected<double> MicrobenchmarkProfile::convertRatePerCycle(
+    double rate, llvm::StringRef sourceFrequencyKey,
+    llvm::StringRef destinationFrequencyKey) const {
+  auto sourceMHz = requireValue(sourceFrequencyKey, "MHz", "wall_clock");
+  if (!sourceMHz)
+    return sourceMHz.takeError();
+  auto destinationMHz =
+      requireValue(destinationFrequencyKey, "MHz", "wall_clock");
+  if (!destinationMHz)
+    return destinationMHz.takeError();
+  if (*sourceMHz <= 0.0 || *destinationMHz <= 0.0)
+    return invalidProfile("cycle-domain frequencies must be positive");
+  return rate * *sourceMHz / *destinationMHz;
+}

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/CMakeLists.txt
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/CMakeLists.txt
@@ -1,0 +1,27 @@
+# The source-tree profile is a fallback for native tests and standalone C++
+# users. Python production wiring passes the packaged profile path explicitly.
+add_compile_definitions(
+  TRITON_ASCEND_SIMD_SIMT_PROFILE_PATH="${CMAKE_CURRENT_SOURCE_DIR}/../../../profiles/simd_simt/david_v100_simd_simt_v1.json"
+)
+
+add_mlir_library(AscendModelRouteModel
+  SimtAnchorAnalysis.cpp
+  SimdSimtCostModel.cpp
+  Transforms/SelectSimdSimtCostModel.cpp
+  Transforms/MaterializeSimtScopes.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${TRITON_ASCEND_COSTMODEL_SOURCE_DIR}/include/AscendModel/RouteModel
+
+  DEPENDS
+  AscendModelOpsIncGen
+  AscendModelTransformsPassIncGen
+
+  LINK_LIBS PUBLIC
+  AscendModelProfile
+  MLIRIR
+  MLIRPass
+  MLIRSupport
+  MLIRTransformUtils
+  LLVMSupport
+)

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/SimdSimtCostModel.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/SimdSimtCostModel.cpp
@@ -1,0 +1,2887 @@
+//===- SimdSimtCostModel.cpp - Ascend SIMD/SIMT candidate model ----------===//
+//
+// The numerical model in this file is the versioned C++ candidate model.  It
+// intentionally produces a relative per-program selection score, not an
+// end-to-end kernel-time prediction.
+//
+//===----------------------------------------------------------------------===//
+
+#include "AscendModel/RouteModel/SimdSimtCostModel.h"
+#include "AscendModel/Profile/MicrobenchmarkProfile.h"
+#include "AscendModel/RouteModel/SimtAnchorAnalysis.h"
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/SHA256.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <limits>
+#include <optional>
+#include <set>
+#include <system_error>
+#include <tuple>
+#include <utility>
+
+using namespace mlir;
+using namespace mlir::ascend;
+
+namespace {
+
+constexpr llvm::StringLiteral kAllSimd = "all_simd";
+constexpr llvm::StringLiteral kAllSimtOnly = "all_simt_only";
+constexpr llvm::StringLiteral kMixedSimdSimt = "mixed_simd_simt";
+
+struct OpProfile {
+  double throughput = 0.0;
+  double factor = 1.0;
+  std::string confidence = "none";
+};
+
+struct CoverageProfile {
+  double minimumIrregularDensity = 0.0;
+  int64_t tinyDotFlopsMax = 0;
+  int64_t tinyDotMaxTensorNumel = 0;
+  int64_t rowwiseLoopTripSumMax = 0;
+  int64_t rowwiseMaskRankSumMax = 0;
+  int64_t rowwiseWeightedReductionsMax = 0;
+  int64_t rowwiseMaxTensorNumel = 0;
+  int64_t rank1WeightedReductionsMax = 0;
+  int64_t rank1MaxTensorNumel = 0;
+  int64_t triangularLoopCountMax = 0;
+  int64_t triangularLoopTripSumMax = 0;
+  int64_t triangularMaskRankSumMax = 0;
+  int64_t triangularWeightedReductionsMax = 0;
+  int64_t triangularMaxTensorNumel = 0;
+};
+
+struct StructuralProfile {
+  double irregularPerDensity = 0.0;
+  double irregularCap = 0.0;
+  double tinyDotIrregularPerDensity = 0.0;
+  double tinyDotIrregularCap = 0.0;
+  double perMaskRank = 0.0;
+  double maskCap = 0.0;
+  double perWeightedReduction = 0.0;
+  double reductionCap = 0.0;
+  double perStaticLoopTrip = 0.0;
+  double loopCap = 0.0;
+  double controlFlow = 0.0;
+  double rank1IndirectVectorReduction = 0.0;
+  double tinyDot = 0.0;
+  int64_t tinyDotFlopsMax = 0;
+};
+
+struct MixedSetupFallbackProfile {
+  int64_t numWarps = 0;
+  double emptySimtSetupCycles = 0.0;
+};
+
+struct EventRouteCalibrationProfile {
+  double allSimdMultiplier = 1.0;
+  double allSimtOnlyMultiplier = 1.0;
+  double mixedSimdSimtMultiplier = 1.0;
+  bool allSimtOnlyValidated = false;
+  bool mixedSimdSimtValidated = false;
+  std::string source;
+  std::string confidence = "none";
+};
+
+struct CandidateProfile {
+  std::string profileVersion;
+  std::string target;
+  std::vector<std::string> compatibleTargets;
+  std::string scoreUnit;
+  std::string minimumConfidence = "medium";
+  std::string contentSha256;
+  std::string selectionContentSha256;
+  std::string microbenchmarkProfileVersion;
+  std::string microbenchmarkProfileTarget;
+  std::string microbenchmarkContentSha256;
+
+  double programIssueScale = 1.0;
+  std::string rankingConfidence = "low";
+  std::string calibrationSource;
+  CoverageProfile coverage;
+  StructuralProfile structural;
+  llvm::StringMap<EventRouteCalibrationProfile> eventRouteCalibration;
+
+  int64_t simdVectorWidthBits = 2048;
+  double simdSetupCycles = 0.0;
+  llvm::StringMap<OpProfile> simdOps;
+  double simdMte2BytesPerCycle = 0.0;
+  double simdMte3BytesPerCycle = 0.0;
+  std::string simdMemoryConfidence = "none";
+  double simdDotSetupCycles = 0.0;
+  double simdDotFlopsPerCycle = 0.0;
+  std::string simdDotConfidence = "none";
+
+  int64_t simtWarpSize = 32;
+  double simtSetupCycles = 0.0;
+  std::string simtSetupConfidence = "none";
+  llvm::StringMap<OpProfile> simtOps;
+  double simtDotSetupCycles = 0.0;
+  double simtDotFlopsPerCycle = 0.0;
+  std::string simtDotConfidence = "none";
+  double simtPredicateRate = 0.0;
+  double simtShuffleRate = 0.0;
+  std::string simtShuffleConfidence = "none";
+  double simtLoadWarpRate = 0.0;
+  double simtStoreWarpRate = 0.0;
+  std::string simtMemoryConfidence = "none";
+  std::vector<MixedSetupFallbackProfile> mixedSetupFallbacks;
+  std::string mixedSetupFallbackConfidence = "none";
+};
+
+/// Small fail-fast facade around llvm::json.  It permits a readable profile
+/// parser while retaining a single actionable error message.
+class ProfileJSONReader {
+public:
+  const llvm::json::Object *object(const llvm::json::Object &parent,
+                                   llvm::StringRef key,
+                                   llvm::StringRef context) {
+    if (failed())
+      return nullptr;
+    if (const auto *value = parent.getObject(key))
+      return value;
+    setError(context + "." + key + " must be an object");
+    return nullptr;
+  }
+
+  const llvm::json::Array *array(const llvm::json::Object &parent,
+                                 llvm::StringRef key, llvm::StringRef context) {
+    if (failed())
+      return nullptr;
+    if (const auto *value = parent.getArray(key))
+      return value;
+    setError(context + "." + key + " must be an array");
+    return nullptr;
+  }
+
+  double number(const llvm::json::Object &parent, llvm::StringRef key,
+                llvm::StringRef context) {
+    if (failed())
+      return 0.0;
+    if (auto value = parent.getNumber(key))
+      return *value;
+    setError(context + "." + key + " must be a number");
+    return 0.0;
+  }
+
+  int64_t integer(const llvm::json::Object &parent, llvm::StringRef key,
+                  llvm::StringRef context) {
+    if (failed())
+      return 0;
+    if (auto value = parent.getInteger(key))
+      return *value;
+    setError(context + "." + key + " must be an integer");
+    return 0;
+  }
+
+  std::string string(const llvm::json::Object &parent, llvm::StringRef key,
+                     llvm::StringRef context) {
+    if (failed())
+      return {};
+    if (auto value = parent.getString(key))
+      return value->str();
+    setError(context + "." + key + " must be a string");
+    return {};
+  }
+
+  std::string optionalString(const llvm::json::Object &parent,
+                             llvm::StringRef key,
+                             llvm::StringRef defaultValue = {}) {
+    if (auto value = parent.getString(key))
+      return value->str();
+    return defaultValue.str();
+  }
+
+  double optionalNumber(const llvm::json::Object &parent, llvm::StringRef key,
+                        double defaultValue) {
+    if (auto value = parent.getNumber(key))
+      return *value;
+    return defaultValue;
+  }
+
+  int64_t optionalInteger(const llvm::json::Object &parent, llvm::StringRef key,
+                          int64_t defaultValue) {
+    if (auto value = parent.getInteger(key))
+      return *value;
+    return defaultValue;
+  }
+
+  bool failed() const { return !error.empty(); }
+  llvm::StringRef getError() const { return error; }
+
+  void setError(const llvm::Twine &message) {
+    if (error.empty())
+      error = message.str();
+  }
+
+private:
+  std::string error;
+};
+
+static llvm::json::Object toJSON(const llvm::StringMap<int64_t> &values) {
+  llvm::json::Object result;
+  for (const auto &entry : values)
+    result[entry.first()] = entry.second;
+  return result;
+}
+
+static llvm::json::Object toJSON(const llvm::StringMap<double> &values) {
+  llvm::json::Object result;
+  for (const auto &entry : values)
+    result[entry.first()] = entry.second;
+  return result;
+}
+
+template <typename SummaryT>
+static void initializeWorkMaps(SummaryT &features) {
+  for (llvm::StringRef key :
+       {"load", "store", "reduce", "scan", "gather", "histogram", "atomic",
+        "add", "sub", "mul", "div", "max", "abs", "exp", "log", "cmp", "select",
+        "cast", "clamp"}) {
+    features.weightedOps[key] = 0;
+    features.opElements[key] = 0;
+  }
+}
+
+static std::string typeToString(Type type) {
+  std::string text;
+  llvm::raw_string_ostream os(text);
+  os << type;
+  os.flush();
+  return text;
+}
+
+static bool isPointerType(Type type) {
+  if (auto tensor = dyn_cast<RankedTensorType>(type))
+    type = tensor.getElementType();
+  return llvm::StringRef(typeToString(type)).contains("!tt.ptr");
+}
+
+static Type getElementType(Type type) {
+  if (auto tensor = dyn_cast<RankedTensorType>(type))
+    return tensor.getElementType();
+  return type;
+}
+
+static int64_t parseTypeBitWidth(llvm::StringRef text) {
+  for (size_t index = 0; index + 1 < text.size(); ++index) {
+    if (text[index] != 'f' && text[index] != 'i')
+      continue;
+    size_t end = index + 1;
+    while (end < text.size() && llvm::isDigit(text[end]))
+      ++end;
+    if (end == index + 1)
+      continue;
+    int64_t width = 0;
+    if (!text.slice(index + 1, end).getAsInteger(10, width) && width > 0)
+      return width;
+  }
+  return 0;
+}
+
+static int64_t getTypeBitWidth(Type type, int64_t defaultWidth = 32) {
+  type = getElementType(type);
+  if (auto integer = dyn_cast<IntegerType>(type))
+    return integer.getWidth();
+  if (auto floating = dyn_cast<FloatType>(type))
+    return floating.getWidth();
+  int64_t parsed = parseTypeBitWidth(typeToString(type));
+  return parsed > 0 ? parsed : defaultWidth;
+}
+
+static bool isMaskTensorType(Type type) {
+  auto tensor = dyn_cast<RankedTensorType>(type);
+  if (!tensor)
+    return false;
+  auto integer = dyn_cast<IntegerType>(tensor.getElementType());
+  return integer && integer.getWidth() == 1;
+}
+
+static int64_t getStaticNumElements(Type type) {
+  auto tensor = dyn_cast<RankedTensorType>(type);
+  if (!tensor)
+    return 1;
+  int64_t count = 1;
+  for (int64_t dim : tensor.getShape()) {
+    if (ShapedType::isDynamic(dim) || dim <= 0)
+      return 1;
+    if (count > std::numeric_limits<int64_t>::max() / dim)
+      return std::numeric_limits<int64_t>::max();
+    count *= dim;
+  }
+  return std::max<int64_t>(1, count);
+}
+
+static double getStaticTensorBytes(Type type) {
+  auto tensor = dyn_cast<RankedTensorType>(type);
+  if (!tensor || !tensor.hasStaticShape())
+    return 0.0;
+  return static_cast<double>(getStaticNumElements(type)) *
+         getTypeBitWidth(tensor.getElementType()) / 8.0;
+}
+
+static int64_t getOperationElements(Operation *op) {
+  int64_t elements = 1;
+  for (Type type : op->getOperandTypes())
+    elements = std::max(elements, getStaticNumElements(type));
+  for (Type type : op->getResultTypes())
+    elements = std::max(elements, getStaticNumElements(type));
+  return elements;
+}
+
+static std::optional<int64_t> getConstantInteger(Value value) {
+  Operation *definingOp = value.getDefiningOp();
+  if (!definingOp || definingOp->getName().getStringRef() != "arith.constant")
+    return std::nullopt;
+  if (auto integer = definingOp->getAttrOfType<IntegerAttr>("value"))
+    return integer.getInt();
+  return std::nullopt;
+}
+
+static std::optional<int64_t> getKnownStaticLoopTripCount(Operation *op) {
+  if (!op || op->getName().getStringRef() != "scf.for" ||
+      op->getNumOperands() < 3)
+    return std::nullopt;
+  auto lower = getConstantInteger(op->getOperand(0));
+  auto upper = getConstantInteger(op->getOperand(1));
+  auto step = getConstantInteger(op->getOperand(2));
+  if (!lower || !upper || !step || *step == 0)
+    return std::nullopt;
+  int64_t span = *upper - *lower;
+  if (span > 0 && *step > 0)
+    return std::max<int64_t>(1, (span + *step - 1) / *step);
+  if (span < 0 && *step < 0) {
+    int64_t positiveSpan = -span;
+    int64_t positiveStep = -*step;
+    return std::max<int64_t>(1,
+                             (positiveSpan + positiveStep - 1) / positiveStep);
+  }
+  return std::nullopt;
+}
+
+static int64_t getModeledLoopTripCount(
+    Operation *op,
+    const llvm::DenseMap<Operation *, int64_t> &structuralTripEstimates) {
+  if (auto knownTripCount = getKnownStaticLoopTripCount(op))
+    return *knownTripCount;
+  if (auto iterator = structuralTripEstimates.find(op);
+      iterator != structuralTripEstimates.end())
+    return iterator->second;
+  return 1;
+}
+
+static int64_t getLoopMultiplier(
+    Operation *op,
+    const llvm::DenseMap<Operation *, int64_t> &structuralTripEstimates) {
+  int64_t multiplier = 1;
+  for (Operation *parent = op->getParentOp(); parent;
+       parent = parent->getParentOp()) {
+    if (parent->getName().getStringRef() != "scf.for")
+      continue;
+    int64_t tripCount =
+        getModeledLoopTripCount(parent, structuralTripEstimates);
+    if (tripCount > 0 &&
+        multiplier <= std::numeric_limits<int64_t>::max() / tripCount)
+      multiplier *= tripCount;
+  }
+  return multiplier;
+}
+
+static bool isCastOp(llvm::StringRef name) {
+  return name.starts_with("arith.ext") || name.starts_with("arith.trunc") ||
+         name == "arith.sitofp" || name == "arith.uitofp" ||
+         name == "arith.fptosi" || name == "arith.fptoui" ||
+         name.starts_with("arith.index_cast");
+}
+
+static llvm::StringRef classifyWeightedOp(llvm::StringRef name) {
+  if (name == "tt.load")
+    return "load";
+  if (name == "tt.store")
+    return "store";
+  if (name == "tt.reduce")
+    return "reduce";
+  if (name == "tt.scan" || name == "tt.associative_scan")
+    return "scan";
+  if (name == "tt.gather")
+    return "gather";
+  if (name == "tt.histogram")
+    return "histogram";
+  if (name.starts_with("tt.atomic"))
+    return "atomic";
+  if (name == "arith.addf" || name == "arith.addi")
+    return "add";
+  if (name == "arith.subf" || name == "arith.subi")
+    return "sub";
+  if (name == "arith.mulf" || name == "arith.muli")
+    return "mul";
+  if (name == "arith.divf" || name == "arith.divsi" || name == "arith.divui")
+    return "div";
+  if (name == "arith.maxnumf" || name == "arith.maxf" ||
+      name == "arith.maxsi" || name == "arith.maxui")
+    return "max";
+  if (name == "math.absf" || name == "math.absi")
+    return "abs";
+  if (name == "math.exp")
+    return "exp";
+  if (name == "math.log")
+    return "log";
+  if (name == "arith.cmpf" || name == "arith.cmpi")
+    return "cmp";
+  if (name == "arith.select")
+    return "select";
+  if (isCastOp(name))
+    return "cast";
+  if (name.starts_with("tt.clamp"))
+    return "clamp";
+  return {};
+}
+
+static void appendUnique(std::vector<std::string> &values,
+                         llvm::StringRef value) {
+  if (llvm::find(values, value.str()) == values.end())
+    values.push_back(value.str());
+}
+
+static int confidenceRank(llvm::StringRef confidence) {
+  if (confidence == "high")
+    return 3;
+  if (confidence == "medium")
+    return 2;
+  if (confidence == "low")
+    return 1;
+  return 0;
+}
+
+static std::string minimumConfidence(llvm::ArrayRef<std::string> values) {
+  if (values.empty())
+    return "none";
+  return *std::min_element(values.begin(), values.end(),
+                           [](const std::string &lhs, const std::string &rhs) {
+                             return confidenceRank(lhs) < confidenceRank(rhs);
+                           });
+}
+
+static bool wildcardMatch(llvm::StringRef pattern, llvm::StringRef value) {
+  size_t patternIndex = 0;
+  size_t valueIndex = 0;
+  size_t starIndex = llvm::StringRef::npos;
+  size_t retryValueIndex = 0;
+  while (valueIndex < value.size()) {
+    if (patternIndex < pattern.size() &&
+        (pattern[patternIndex] == '?' ||
+         pattern[patternIndex] == value[valueIndex])) {
+      ++patternIndex;
+      ++valueIndex;
+      continue;
+    }
+    if (patternIndex < pattern.size() && pattern[patternIndex] == '*') {
+      starIndex = patternIndex++;
+      retryValueIndex = valueIndex;
+      continue;
+    }
+    if (starIndex != llvm::StringRef::npos) {
+      patternIndex = starIndex + 1;
+      valueIndex = ++retryValueIndex;
+      continue;
+    }
+    return false;
+  }
+  while (patternIndex < pattern.size() && pattern[patternIndex] == '*')
+    ++patternIndex;
+  return patternIndex == pattern.size();
+}
+
+static bool targetMatches(const CandidateProfile &profile,
+                          llvm::StringRef actualTarget) {
+  if (actualTarget.trim().empty())
+    return true;
+  std::string actual = actualTarget.trim().lower();
+  std::vector<std::string> patterns = profile.compatibleTargets;
+  patterns.push_back(profile.target);
+  for (std::string pattern : patterns) {
+    std::replace(pattern.begin(), pattern.end(), ':', '/');
+    llvm::SmallVector<llvm::StringRef> aliases;
+    llvm::StringRef(pattern).split(aliases, '/', -1, false);
+    for (llvm::StringRef alias : aliases) {
+      std::string lower = alias.trim().lower();
+      if (!lower.empty() && wildcardMatch(lower, actual))
+        return true;
+    }
+  }
+  return false;
+}
+
+static double resolveNumberOrMeasurement(
+    const llvm::json::Object &object, llvm::StringRef numberKey,
+    llvm::StringRef measurementKey, llvm::StringRef expectedUnit,
+    const MicrobenchmarkProfile *microbench, ProfileJSONReader &reader,
+    llvm::StringRef context, std::string *measurementConfidence = nullptr) {
+  if (auto reference = object.getString(measurementKey)) {
+    if (!microbench) {
+      reader.setError(context + "." + measurementKey +
+                      " requires microbenchmark_profile");
+      return 0.0;
+    }
+    llvm::StringRef expectedCycleDomain = "none";
+    if (expectedUnit == "system_cycle" ||
+        expectedUnit.ends_with("/system_cycle"))
+      expectedCycleDomain = "SYS_CNT";
+    auto value =
+        microbench->requireValue(*reference, expectedUnit, expectedCycleDomain);
+    if (!value) {
+      reader.setError(llvm::toString(value.takeError()));
+      return 0.0;
+    }
+    if (measurementConfidence) {
+      const MicrobenchmarkMeasurement *measurement =
+          microbench->getMeasurement(*reference);
+      *measurementConfidence = measurement ? measurement->confidence : "none";
+    }
+    return *value;
+  }
+  return reader.number(object, numberKey, context);
+}
+
+static OpProfile resolveOpProfile(const llvm::json::Object &ops,
+                                  llvm::StringRef opName,
+                                  llvm::StringRef throughputKey,
+                                  llvm::StringRef expectedUnit,
+                                  const MicrobenchmarkProfile *microbench,
+                                  ProfileJSONReader &reader) {
+  OpProfile result;
+  const llvm::json::Value *raw = ops.get(opName);
+  if (!raw) {
+    reader.setError("missing operation profile " + opName);
+    return result;
+  }
+  const auto *op = raw->getAsObject();
+  if (!op) {
+    reader.setError("operation profile " + opName + " must be an object");
+    return result;
+  }
+  if (auto relative = op->getString("relative_to")) {
+    OpProfile base = resolveOpProfile(ops, *relative, throughputKey,
+                                      expectedUnit, microbench, reader);
+    result.throughput = base.throughput;
+    result.factor = reader.optionalNumber(*op, "factor", 1.0);
+    result.confidence = reader.optionalString(*op, "confidence", "low");
+    return result;
+  }
+  std::string measuredConfidence = "none";
+  result.throughput = resolveNumberOrMeasurement(
+      *op, throughputKey, "throughput_measurement", expectedUnit, microbench,
+      reader, opName, &measuredConfidence);
+  result.factor = reader.optionalNumber(*op, "factor", 1.0);
+  result.confidence =
+      reader.optionalString(*op, "confidence", measuredConfidence);
+  return result;
+}
+
+/// Match Python's json.dumps(value, sort_keys=True) representation.  Keeping
+/// this stable makes profile_content_sha256 identical across the temporary
+/// Python model and this C++ implementation.
+static void emitPythonCanonicalJSON(const llvm::json::Value &value,
+                                    llvm::raw_ostream &os) {
+  if (const auto *object = value.getAsObject()) {
+    std::vector<llvm::StringRef> keys;
+    keys.reserve(object->size());
+    for (const auto &entry : *object)
+      keys.push_back(entry.first);
+    llvm::sort(keys);
+    os << '{';
+    bool first = true;
+    for (llvm::StringRef key : keys) {
+      if (!first)
+        os << ", ";
+      first = false;
+      os << llvm::json::Value(key.str()) << ": ";
+      emitPythonCanonicalJSON(*object->get(key), os);
+    }
+    os << '}';
+    return;
+  }
+  if (const auto *array = value.getAsArray()) {
+    os << '[';
+    bool first = true;
+    for (const llvm::json::Value &element : *array) {
+      if (!first)
+        os << ", ";
+      first = false;
+      emitPythonCanonicalJSON(element, os);
+    }
+    os << ']';
+    return;
+  }
+  os << value;
+}
+
+static std::string resolveProfileReference(llvm::StringRef ownerPath,
+                                           llvm::StringRef reference) {
+  if (llvm::sys::path::is_absolute(reference))
+    return reference.str();
+  llvm::SmallString<256> resolved(ownerPath);
+  llvm::sys::path::remove_filename(resolved);
+  llvm::sys::path::append(resolved, reference);
+  llvm::sys::path::remove_dots(resolved, true);
+  return resolved.str().str();
+}
+
+static llvm::Expected<CandidateProfile>
+loadCandidateProfile(llvm::StringRef requestedPath) {
+  std::string path = requestedPath.empty() ? getDefaultSimdSimtProfilePath()
+                                           : requestedPath.str();
+  if (path.empty())
+    return llvm::createStringError(std::errc::no_such_file_or_directory,
+                                   "SIMD/SIMT profile path is empty; set "
+                                   "TRITON_ASCEND_SIMD_SIMT_PROFILE");
+
+  auto buffer = llvm::MemoryBuffer::getFile(path);
+  if (!buffer)
+    return llvm::createStringError(buffer.getError(),
+                                   "failed to read SIMD/SIMT profile '%s'",
+                                   path.c_str());
+  auto parsed = llvm::json::parse(buffer.get()->getBuffer());
+  if (!parsed)
+    return llvm::createStringError(std::errc::invalid_argument,
+                                   "failed to parse SIMD/SIMT profile '%s': %s",
+                                   path.c_str(),
+                                   llvm::toString(parsed.takeError()).c_str());
+  const auto *root = parsed->getAsObject();
+  if (!root)
+    return llvm::createStringError(std::errc::invalid_argument,
+                                   "SIMD/SIMT profile root must be an object");
+  auto selectionSchemaVersion = root->getInteger("schema_version");
+  if (!selectionSchemaVersion ||
+      (*selectionSchemaVersion != 1 && *selectionSchemaVersion != 2 &&
+       *selectionSchemaVersion != 3 && *selectionSchemaVersion != 4))
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "SIMD/SIMT profile schema_version must be 1, 2, 3, or 4");
+
+  CandidateProfile profile;
+  ProfileJSONReader reader;
+  std::optional<MicrobenchmarkProfile> microbenchmarkProfile;
+  if (auto reference = root->getString("microbenchmark_profile")) {
+    std::string resolved = resolveProfileReference(path, *reference);
+    auto loaded = MicrobenchmarkProfile::loadFromFile(resolved);
+    if (!loaded)
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "failed to load shared microbenchmark profile referenced by '%s': %s",
+          path.c_str(), llvm::toString(loaded.takeError()).c_str());
+    microbenchmarkProfile.emplace(std::move(*loaded));
+    profile.microbenchmarkProfileVersion =
+        microbenchmarkProfile->getProfileVersion().str();
+    profile.microbenchmarkProfileTarget =
+        microbenchmarkProfile->getTarget().str();
+    profile.microbenchmarkContentSha256 =
+        microbenchmarkProfile->getContentSha256().str();
+  }
+  const MicrobenchmarkProfile *microbench =
+      microbenchmarkProfile ? &*microbenchmarkProfile : nullptr;
+
+  profile.profileVersion = reader.string(*root, "profile_version", "profile");
+  const bool usesAnchorPartitionProfile =
+      profile.profileVersion == "david-v100-simd-simt-20260730-v7" ||
+      profile.profileVersion == "david-v100-simd-simt-20260803-v8" ||
+      profile.profileVersion == "david-v100-simd-simt-20260804-v9" ||
+      profile.profileVersion == "david-v100-simd-simt-20260804-v10" ||
+      profile.profileVersion == "david-v100-simd-simt-20260806-v11";
+  profile.target = reader.string(*root, "target", "profile");
+  if (microbench && llvm::StringRef(profile.target) != microbench->getTarget())
+    reader.setError("selection profile target '" + profile.target +
+                    "' does not match shared microbenchmark target '" +
+                    microbench->getTarget().str() + "'");
+  profile.scoreUnit = reader.string(*root, "score_unit", "profile");
+  if (const auto *targets =
+          reader.array(*root, "compatible_targets", "profile")) {
+    for (const llvm::json::Value &target : *targets) {
+      if (auto text = target.getAsString())
+        profile.compatibleTargets.push_back(text->str());
+      else
+        reader.setError("profile.compatible_targets entries must be strings");
+    }
+  }
+  if (const auto *policy = reader.object(*root, "policy", "profile"))
+    profile.minimumConfidence = reader.optionalString(
+        *policy, "minimum_confidence_for_decision", "medium");
+
+  const auto *calibration =
+      reader.object(*root, "selection_calibration", "profile");
+  if (calibration) {
+    profile.programIssueScale = reader.number(
+        *calibration, "program_issue_scale", "profile.selection_calibration");
+    profile.rankingConfidence =
+        reader.optionalString(*calibration, "ranking_confidence", "low");
+    profile.calibrationSource =
+        reader.optionalString(*calibration, "source", "");
+
+    if (const auto *coverage = reader.object(*calibration, "coverage",
+                                             "profile.selection_calibration")) {
+      profile.coverage.minimumIrregularDensity =
+          reader.number(*coverage, "minimum_irregular_density", "coverage");
+      profile.coverage.tinyDotFlopsMax =
+          reader.integer(*coverage, "tiny_dot_flops_max", "coverage");
+      profile.coverage.tinyDotMaxTensorNumel =
+          reader.integer(*coverage, "tiny_dot_max_tensor_numel", "coverage");
+      profile.coverage.rowwiseLoopTripSumMax =
+          reader.integer(*coverage, "rowwise_loop_trip_sum_max", "coverage");
+      profile.coverage.rowwiseMaskRankSumMax =
+          reader.integer(*coverage, "rowwise_mask_rank_sum_max", "coverage");
+      profile.coverage.rowwiseWeightedReductionsMax = reader.integer(
+          *coverage, "rowwise_weighted_reductions_max", "coverage");
+      profile.coverage.rowwiseMaxTensorNumel =
+          reader.integer(*coverage, "rowwise_max_tensor_numel", "coverage");
+      profile.coverage.rank1WeightedReductionsMax = reader.integer(
+          *coverage, "rank1_weighted_reductions_max", "coverage");
+      profile.coverage.rank1MaxTensorNumel =
+          reader.integer(*coverage, "rank1_max_tensor_numel", "coverage");
+      // These fields were introduced by v11. Keep bounded defaults only for
+      // reading older diagnostic profiles; the v11 JSON schema requires all
+      // five values explicitly.
+      profile.coverage.triangularLoopCountMax =
+          reader.optionalInteger(*coverage, "triangular_loop_count_max", 4);
+      profile.coverage.triangularLoopTripSumMax =
+          reader.optionalInteger(*coverage, "triangular_loop_trip_sum_max", 56);
+      profile.coverage.triangularMaskRankSumMax =
+          reader.optionalInteger(*coverage, "triangular_mask_rank_sum_max", 64);
+      profile.coverage.triangularWeightedReductionsMax = reader.optionalInteger(
+          *coverage, "triangular_weighted_reductions_max", 56);
+      profile.coverage.triangularMaxTensorNumel =
+          reader.optionalInteger(*coverage, "triangular_max_tensor_numel", 256);
+    }
+
+    if (const auto *structural =
+            reader.object(*calibration, "simd_structural_penalty_ratio",
+                          "profile.selection_calibration")) {
+      profile.structural.irregularPerDensity =
+          reader.number(*structural, "irregular_per_density", "structural");
+      profile.structural.irregularCap =
+          reader.number(*structural, "irregular_cap", "structural");
+      profile.structural.tinyDotIrregularPerDensity = reader.number(
+          *structural, "tiny_dot_irregular_per_density", "structural");
+      profile.structural.tinyDotIrregularCap =
+          reader.number(*structural, "tiny_dot_irregular_cap", "structural");
+      profile.structural.perMaskRank =
+          reader.number(*structural, "per_mask_rank", "structural");
+      profile.structural.maskCap =
+          reader.number(*structural, "mask_cap", "structural");
+      profile.structural.perWeightedReduction =
+          reader.number(*structural, "per_weighted_reduction", "structural");
+      profile.structural.reductionCap =
+          reader.number(*structural, "reduction_cap", "structural");
+      profile.structural.perStaticLoopTrip =
+          reader.number(*structural, "per_static_loop_trip", "structural");
+      profile.structural.loopCap =
+          reader.number(*structural, "loop_cap", "structural");
+      profile.structural.controlFlow =
+          reader.number(*structural, "control_flow", "structural");
+      profile.structural.rank1IndirectVectorReduction = reader.number(
+          *structural, "rank1_indirect_vector_reduction", "structural");
+      profile.structural.tinyDot =
+          reader.number(*structural, "tiny_dot", "structural");
+      profile.structural.tinyDotFlopsMax =
+          reader.integer(*structural, "tiny_dot_flops_max", "structural");
+    }
+
+    if (calibration->get("event_route_score_multiplier")) {
+      const auto *eventCalibration =
+          reader.object(*calibration, "event_route_score_multiplier",
+                        "profile.selection_calibration");
+      if (!eventCalibration)
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "invalid event_route_score_multiplier object");
+      if (const auto *domains = reader.object(*eventCalibration, "domains",
+                                              "event_route_score_multiplier")) {
+        for (const auto &entry : *domains) {
+          const auto *domain = entry.second.getAsObject();
+          if (!domain) {
+            reader.setError("event_route_score_multiplier.domains." +
+                            entry.first.str() + " must be an object");
+            continue;
+          }
+          EventRouteCalibrationProfile route;
+          const std::string context =
+              "event_route_score_multiplier.domains." + entry.first.str();
+          route.allSimdMultiplier = reader.number(*domain, "all_simd", context);
+          route.allSimtOnlyMultiplier =
+              reader.number(*domain, "all_simt_only", context);
+          route.mixedSimdSimtMultiplier =
+              reader.number(*domain, "mixed_simd_simt", context);
+          auto allSimtValidated = domain->getBoolean("all_simt_only_validated");
+          if (!allSimtValidated) {
+            reader.setError(context +
+                            ".all_simt_only_validated must be a boolean");
+          } else {
+            route.allSimtOnlyValidated = *allSimtValidated;
+          }
+          auto mixedValidated = domain->getBoolean("mixed_simd_simt_validated");
+          if (!mixedValidated) {
+            reader.setError(context +
+                            ".mixed_simd_simt_validated must be a boolean");
+          } else {
+            route.mixedSimdSimtValidated = *mixedValidated;
+          }
+          route.source = reader.string(*domain, "source", context);
+          route.confidence = reader.string(*domain, "confidence", context);
+          profile.eventRouteCalibration[entry.first.str()] = std::move(route);
+        }
+      }
+    }
+  }
+
+  const auto *simd = reader.object(*root, "simd", "profile");
+  if (simd) {
+    if (simd->getString("vector_width_measurement")) {
+      profile.simdVectorWidthBits =
+          static_cast<int64_t>(std::llround(resolveNumberOrMeasurement(
+              *simd, "vector_width_bits", "vector_width_measurement", "bit",
+              microbench, reader, "simd")));
+    } else {
+      profile.simdVectorWidthBits =
+          reader.integer(*simd, "vector_width_bits", "simd");
+    }
+    if (const auto *startup =
+            reader.object(*simd, "startup_system_cycles", "simd"))
+      profile.simdSetupCycles =
+          reader.number(*startup, "vector", "simd.startup_system_cycles");
+    if (const auto *ops = reader.object(*simd, "ops", "simd")) {
+      for (llvm::StringRef op :
+           {"f32.add", "f32.sub", "f32.mul", "f32.div", "f32.max", "f32.abs",
+            "f32.exp", "f32.log", "predicate.cmp", "predicate.select",
+            "convert.cast", "f32.clamp"})
+        profile.simdOps[op] = resolveOpProfile(
+            *ops, op, "throughput_vector_instructions_per_system_cycle",
+            "vector_instruction/system_cycle", microbench, reader);
+    }
+    if (const auto *memory = reader.object(*simd, "memory", "simd")) {
+      profile.simdMte2BytesPerCycle = reader.number(
+          *memory, "vector_mte2_bytes_per_system_cycle", "simd.memory");
+      profile.simdMte3BytesPerCycle =
+          reader.number(*memory, "mte3_bytes_per_system_cycle", "simd.memory");
+      profile.simdMemoryConfidence =
+          reader.optionalString(*memory, "confidence", "none");
+    }
+    if (const auto *dot = reader.object(*simd, "dot", "simd")) {
+      profile.simdDotSetupCycles =
+          reader.number(*dot, "startup_system_cycles", "simd.dot");
+      profile.simdDotFlopsPerCycle =
+          reader.number(*dot, "flops_per_system_cycle", "simd.dot");
+      profile.simdDotConfidence =
+          reader.optionalString(*dot, "confidence", "none");
+    }
+  }
+
+  const auto *simt = reader.object(*root, "simt", "profile");
+  if (simt) {
+    if (simt->getString("warp_size_measurement")) {
+      profile.simtWarpSize =
+          static_cast<int64_t>(std::llround(resolveNumberOrMeasurement(
+              *simt, "warp_size", "warp_size_measurement", "lane", microbench,
+              reader, "simt")));
+    } else {
+      profile.simtWarpSize = reader.integer(*simt, "warp_size", "simt");
+    }
+    if (const auto *setup =
+            reader.object(*simt, "setup_system_cycles", "simt")) {
+      profile.simtSetupCycles = resolveNumberOrMeasurement(
+          *setup, "empty_launch", "empty_launch_measurement", "system_cycle",
+          microbench, reader, "simt.setup_system_cycles",
+          &profile.simtSetupConfidence);
+    }
+    if (const auto *ops = reader.object(*simt, "ops", "simt")) {
+      for (llvm::StringRef op :
+           {"f32.add", "f32.sub", "f32.mul", "f32.div", "f32.max", "f32.abs",
+            "f32.exp", "f32.log", "predicate.cmp", "predicate.select",
+            "convert.cast", "f32.clamp"})
+        profile.simtOps[op] =
+            resolveOpProfile(*ops, op, "throughput_scalar_ops_per_system_cycle",
+                             "scalar_op/system_cycle", microbench, reader);
+    }
+    if (const auto *dot = reader.object(*simt, "dot", "simt")) {
+      profile.simtDotSetupCycles =
+          reader.number(*dot, "startup_system_cycles", "simt.dot");
+      profile.simtDotFlopsPerCycle =
+          reader.number(*dot, "flops_per_system_cycle", "simt.dot");
+      profile.simtDotConfidence =
+          reader.optionalString(*dot, "confidence", "none");
+    }
+    if (const auto *camodel =
+            reader.object(*simt, "camodel_effective", "simt")) {
+      if (const auto *rates =
+              reader.object(*camodel, "warp_instructions_per_system_cycle",
+                            "simt.camodel_effective"))
+        profile.simtPredicateRate =
+            reader.number(*rates, "predicate", "simt.camodel_effective.rates");
+    }
+    if (const auto *shuffle = reader.object(*simt, "shuffle", "simt")) {
+      std::string measuredConfidence;
+      profile.simtShuffleRate = resolveNumberOrMeasurement(
+          *shuffle, "warp_instructions_per_system_cycle",
+          "throughput_measurement", "warp_instruction/system_cycle", microbench,
+          reader, "simt.shuffle", &measuredConfidence);
+      profile.simtShuffleConfidence =
+          reader.optionalString(*shuffle, "confidence", measuredConfidence);
+    }
+    if (const auto *memory = reader.object(*simt, "memory", "simt")) {
+      std::string loadConfidence;
+      std::string storeConfidence;
+      profile.simtLoadWarpRate = resolveNumberOrMeasurement(
+          *memory, "load_warp_instructions_per_system_cycle",
+          "load_throughput_measurement", "warp_instruction/system_cycle",
+          microbench, reader, "simt.memory", &loadConfidence);
+      profile.simtStoreWarpRate = resolveNumberOrMeasurement(
+          *memory, "store_warp_instructions_per_system_cycle",
+          "store_throughput_measurement", "warp_instruction/system_cycle",
+          microbench, reader, "simt.memory", &storeConfidence);
+      profile.simtMemoryConfidence = reader.optionalString(
+          *memory, "confidence",
+          minimumConfidence({loadConfidence, storeConfidence}));
+    }
+    const llvm::json::Object *mixedSetupFallback = nullptr;
+    if (usesAnchorPartitionProfile)
+      mixedSetupFallback = reader.object(*simt, "mixed_setup_fallback", "simt");
+    else
+      mixedSetupFallback = reader.object(*simt, "transition", "simt");
+    if (mixedSetupFallback) {
+      for (int64_t numWarps : {1, 2, 4, 8, 16, 32}) {
+        std::string key = std::to_string(numWarps);
+        const auto *entry = mixedSetupFallback->getObject(key);
+        if (!entry)
+          continue;
+        std::string measuredConfidence;
+        profile.mixedSetupFallbacks.push_back(
+            {numWarps,
+             resolveNumberOrMeasurement(
+                 *entry, "empty_simt_setup_system_cycles", "measurement",
+                 "system_cycle", microbench, reader,
+                 "simt.mixed_setup_fallback." + key, &measuredConfidence)});
+        if (profile.mixedSetupFallbackConfidence == "none")
+          profile.mixedSetupFallbackConfidence = measuredConfidence;
+      }
+      profile.mixedSetupFallbackConfidence =
+          reader.optionalString(*mixedSetupFallback, "confidence",
+                                profile.mixedSetupFallbackConfidence);
+    }
+  }
+
+  if (reader.failed())
+    return llvm::createStringError(
+        std::errc::invalid_argument, "invalid SIMD/SIMT profile '%s': %s",
+        path.c_str(), reader.getError().str().c_str());
+  if (profile.profileVersion != "david-v100-simd-simt-20260727-v3" &&
+      profile.profileVersion != "david-v100-simd-simt-20260727-v4" &&
+      profile.profileVersion != "david-v100-simd-simt-20260728-v5" &&
+      profile.profileVersion != "david-v100-simd-simt-20260730-v6" &&
+      profile.profileVersion != "david-v100-simd-simt-20260730-v7" &&
+      profile.profileVersion != "david-v100-simd-simt-20260803-v8" &&
+      profile.profileVersion != "david-v100-simd-simt-20260804-v9" &&
+      profile.profileVersion != "david-v100-simd-simt-20260804-v10" &&
+      profile.profileVersion != "david-v100-simd-simt-20260806-v11")
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "unsupported SIMD/SIMT profile version '%s' "
+        "(expected v3, v4, v5, v6, v7, v8, v9, v10, or v11)",
+        profile.profileVersion.c_str());
+  const bool usesSharedMicrobench =
+      profile.profileVersion == "david-v100-simd-simt-20260728-v5" ||
+      profile.profileVersion == "david-v100-simd-simt-20260730-v6" ||
+      profile.profileVersion == "david-v100-simd-simt-20260730-v7" ||
+      profile.profileVersion == "david-v100-simd-simt-20260803-v8" ||
+      profile.profileVersion == "david-v100-simd-simt-20260804-v9" ||
+      profile.profileVersion == "david-v100-simd-simt-20260804-v10" ||
+      profile.profileVersion == "david-v100-simd-simt-20260806-v11";
+  if (usesSharedMicrobench && !microbench)
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "SIMD/SIMT v5/v6/v7/v8/v9/v10/v11 profile must reference "
+        "microbenchmark_profile");
+  const bool usesEventCalibrationSchema =
+      profile.profileVersion == "david-v100-simd-simt-20260804-v9" ||
+      profile.profileVersion == "david-v100-simd-simt-20260804-v10" ||
+      profile.profileVersion == "david-v100-simd-simt-20260806-v11";
+  if (usesSharedMicrobench &&
+      ((!usesAnchorPartitionProfile && *selectionSchemaVersion != 2) ||
+       (!usesEventCalibrationSchema && usesAnchorPartitionProfile &&
+        *selectionSchemaVersion != 3) ||
+       (usesEventCalibrationSchema && *selectionSchemaVersion != 4)))
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "SIMD/SIMT v5/v6 requires schema_version 2 and v7 requires "
+        "schema_version 3; v9/v10/v11 require schema_version 4");
+  if (profile.simdVectorWidthBits <= 0 || profile.simtWarpSize <= 0 ||
+      profile.simdMte2BytesPerCycle <= 0.0 ||
+      profile.simdMte3BytesPerCycle <= 0.0 || profile.simtLoadWarpRate <= 0.0 ||
+      profile.simtStoreWarpRate <= 0.0 || profile.simtShuffleRate <= 0.0 ||
+      profile.simtPredicateRate <= 0.0 || profile.mixedSetupFallbacks.empty())
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "SIMD/SIMT profile contains non-positive rates or no mixed setup "
+        "fallbacks");
+  if (profile.coverage.triangularLoopCountMax <= 0 ||
+      profile.coverage.triangularLoopTripSumMax <= 0 ||
+      profile.coverage.triangularMaskRankSumMax <= 0 ||
+      profile.coverage.triangularWeightedReductionsMax <= 0 ||
+      profile.coverage.triangularMaxTensorNumel <= 0)
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "SIMD/SIMT profile contains non-positive triangular-solve "
+        "coverage bounds");
+  if (usesEventCalibrationSchema && profile.eventRouteCalibration.empty())
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "SIMD/SIMT v9/v10/v11 profile requires event route calibration "
+        "domains");
+  for (const auto &entry : profile.eventRouteCalibration) {
+    const EventRouteCalibrationProfile &route = entry.second;
+    if (!std::isfinite(route.allSimdMultiplier) ||
+        !std::isfinite(route.allSimtOnlyMultiplier) ||
+        !std::isfinite(route.mixedSimdSimtMultiplier) ||
+        route.allSimdMultiplier <= 0.0 || route.allSimtOnlyMultiplier <= 0.0 ||
+        route.mixedSimdSimtMultiplier <= 0.0)
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "event route calibration domain '%s' has a non-positive or "
+          "non-finite multiplier",
+          entry.first().str().c_str());
+  }
+
+  std::string canonicalProfile;
+  llvm::raw_string_ostream canonicalStream(canonicalProfile);
+  emitPythonCanonicalJSON(*parsed, canonicalStream);
+  canonicalStream.flush();
+  llvm::ArrayRef<uint8_t> byteArray(
+      reinterpret_cast<const uint8_t *>(canonicalProfile.data()),
+      canonicalProfile.size());
+  auto hash = llvm::SHA256::hash(byteArray);
+  profile.selectionContentSha256 =
+      llvm::toHex(llvm::ArrayRef<uint8_t>(hash), true);
+
+  profile.contentSha256 = profile.selectionContentSha256;
+  if (!profile.microbenchmarkContentSha256.empty()) {
+    std::string combinedAssets =
+        canonicalProfile +
+        "\nshared_microbenchmark_sha256=" + profile.microbenchmarkContentSha256;
+    llvm::ArrayRef<uint8_t> combinedBytes(
+        reinterpret_cast<const uint8_t *>(combinedAssets.data()),
+        combinedAssets.size());
+    auto combinedHash = llvm::SHA256::hash(combinedBytes);
+    profile.contentSha256 =
+        llvm::toHex(llvm::ArrayRef<uint8_t>(combinedHash), true);
+  }
+  return profile;
+}
+
+static int64_t mapValue(const llvm::StringMap<int64_t> &values,
+                        llvm::StringRef key, int64_t fallback = 0) {
+  auto iterator = values.find(key);
+  return iterator == values.end() ? fallback : iterator->second;
+}
+
+static std::vector<std::pair<llvm::StringRef, int64_t>>
+getProfileOpElements(const SimdSimtFeatureSummary &features) {
+  const int64_t maxNumel = std::max<int64_t>(1, features.maxTensorNumel);
+  auto work = [&](llvm::StringRef elementName, int64_t rawCount) {
+    auto iterator = features.opElements.find(elementName);
+    if (iterator != features.opElements.end())
+      return std::max<int64_t>(0, iterator->second);
+    return std::max<int64_t>(0, rawCount) * maxNumel;
+  };
+  return {
+      {"f32.add", work("add", features.addOps)},
+      {"f32.sub", work("sub", features.subOps)},
+      {"f32.mul", work("mul", features.mulOps)},
+      {"f32.div", work("div", features.divOps)},
+      {"f32.max", work("max", features.maxOps)},
+      {"f32.abs", work("abs", features.absOps)},
+      {"f32.exp", work("exp", features.expOps)},
+      {"f32.log", work("log", features.logOps)},
+      {"predicate.cmp", work("cmp", features.cmpOps)},
+      {"predicate.select", work("select", features.selectOps)},
+      {"convert.cast", work("cast", features.castOps)},
+      {"f32.clamp", work("clamp", features.clampOps)},
+  };
+}
+
+static std::vector<std::pair<llvm::StringRef, int64_t>>
+getProfileOpElements(const SimtAnchorFeatureSummary &features) {
+  auto work = [&](llvm::StringRef elementName) {
+    auto iterator = features.opElements.find(elementName);
+    return iterator == features.opElements.end()
+               ? int64_t{0}
+               : std::max<int64_t>(0, iterator->second);
+  };
+  return {
+      {"f32.add", work("add")},       {"f32.sub", work("sub")},
+      {"f32.mul", work("mul")},       {"f32.div", work("div")},
+      {"f32.max", work("max")},       {"f32.abs", work("abs")},
+      {"f32.exp", work("exp")},       {"f32.log", work("log")},
+      {"predicate.cmp", work("cmp")}, {"predicate.select", work("select")},
+      {"convert.cast", work("cast")}, {"f32.clamp", work("clamp")},
+  };
+}
+
+static std::pair<bool, std::string>
+rankingCalibrationCoverage(const SimdSimtFeatureSummary &features,
+                           int64_t weightedReductions, int64_t dotFlops,
+                           const CandidateProfile &profile,
+                           double irregularDensity) {
+  if (features.hasDynamicShape)
+    return {false, "dynamic_shape"};
+  const CoverageProfile &coverage = profile.coverage;
+  const int64_t maxNumel = features.maxTensorNumel;
+  const int64_t staticLoopTrips = features.staticLoopTripCountSum;
+  const int64_t maskRankSum = features.maskRankSum;
+  const bool hasTriangularSolve = llvm::is_contained(
+      features.simtAnchors.mechanismKinds, "triangular_solve_loop");
+  // The triangular solve has intentionally dynamic loop bounds (min(T, 16),
+  // min(T, 32), ...), so the generic unknown-trip-count rejection is too
+  // coarse. Admit only the independently bounded BT64 anchor shape. Do not
+  // borrow masked-rowwise limits: a full tile has four loops and 56 weighted
+  // reductions after structural trip modeling.
+  if (hasTriangularSolve && features.simtAnchors.count == 1 &&
+      features.simtAnchors.staticLoopCount > 0 &&
+      features.simtAnchors.staticLoopCount <= coverage.triangularLoopCountMax &&
+      features.simtAnchors.staticLoopTripCountSum <=
+          coverage.triangularLoopTripSumMax &&
+      maxNumel <= coverage.triangularMaxTensorNumel &&
+      maskRankSum <= coverage.triangularMaskRankSumMax &&
+      weightedReductions <= coverage.triangularWeightedReductionsMax)
+    return {true, "triangular_solve_loop"};
+  if (features.hasUnknownTripCount)
+    return {false, "unknown_loop_trip_count"};
+  if (dotFlops > 0 && dotFlops <= coverage.tinyDotFlopsMax &&
+      staticLoopTrips == 0 && maxNumel <= coverage.tinyDotMaxTensorNumel &&
+      irregularDensity >= coverage.minimumIrregularDensity)
+    return {true, "tiny_irregular_dot"};
+  if (dotFlops == 0 && features.rank1IndirectVectorReduce &&
+      weightedReductions > 0 &&
+      weightedReductions <= coverage.rank1WeightedReductionsMax &&
+      maxNumel <= coverage.rank1MaxTensorNumel &&
+      staticLoopTrips <= coverage.rowwiseLoopTripSumMax)
+    return {true, "rank1_indirect_vector_reduction"};
+  if (dotFlops == 0 && staticLoopTrips > 0 &&
+      staticLoopTrips <= coverage.rowwiseLoopTripSumMax && maskRankSum > 0 &&
+      maskRankSum <= coverage.rowwiseMaskRankSumMax && weightedReductions > 0 &&
+      weightedReductions <= coverage.rowwiseWeightedReductionsMax &&
+      maxNumel <= coverage.rowwiseMaxTensorNumel &&
+      irregularDensity >= coverage.minimumIrregularDensity)
+    return {true, "masked_rowwise_reduction"};
+  return {false, "out_of_calibration_domain"};
+}
+
+static SimtApplicabilityResult
+evaluateSimtApplicability(const SimdSimtFeatureSummary &features,
+                          bool targetSupported) {
+  SimtApplicabilityResult result;
+  result.targetSupported = targetSupported;
+  result.recognizedAnchorCount = features.simtAnchors.recognizedCount;
+  result.materializableAnchorCount = features.simtAnchors.count;
+  result.mechanisms = features.simtAnchors.mechanismKinds;
+  for (const std::string &kind : features.observedMixedKinds)
+    appendUnique(result.mechanisms, kind);
+  llvm::sort(result.mechanisms);
+  result.mechanismDetected =
+      result.recognizedAnchorCount > 0 || !result.mechanisms.empty();
+  result.materializable =
+      targetSupported && result.materializableAnchorCount > 0;
+  if (!result.mechanismDetected)
+    result.reasons.push_back("no_recognized_simt_mechanism");
+  else if (!targetSupported)
+    result.reasons.push_back("target_does_not_support_simt_materialization");
+  else if (result.materializableAnchorCount == 0)
+    result.reasons.push_back("no_materializable_simt_anchor");
+  return result;
+}
+
+static llvm::SmallVector<std::pair<double, SimdSimtCandidateKind>>
+legalCandidates(const SimdSimtCandidateScores &scores, bool allSimdLegal,
+                bool allSimtLegal, bool mixedLegal) {
+  llvm::SmallVector<std::pair<double, SimdSimtCandidateKind>> candidates;
+  if (allSimdLegal)
+    candidates.push_back({scores.allSimd, SimdSimtCandidateKind::AllSIMD});
+  if (allSimtLegal)
+    candidates.push_back(
+        {scores.allSimtOnly, SimdSimtCandidateKind::AllSIMTOnly});
+  if (mixedLegal)
+    candidates.push_back(
+        {scores.mixedSimdSimt, SimdSimtCandidateKind::MixedSIMDSIMT});
+  llvm::stable_sort(candidates, [](const auto &lhs, const auto &rhs) {
+    return lhs.first < rhs.first;
+  });
+  return candidates;
+}
+
+static SimdSimtCandidateKind chooseBest(const SimdSimtCandidateScores &scores,
+                                        bool allSimdLegal, bool allSimtLegal,
+                                        bool mixedLegal) {
+  return legalCandidates(scores, allSimdLegal, allSimtLegal, mixedLegal)
+      .front()
+      .second;
+}
+
+static SimdSimtCandidateKind
+chooseRunnerUp(const SimdSimtCandidateScores &scores, bool allSimdLegal,
+               bool allSimtLegal, bool mixedLegal, SimdSimtCandidateKind best) {
+  auto candidates =
+      legalCandidates(scores, allSimdLegal, allSimtLegal, mixedLegal);
+  return candidates.size() > 1 ? candidates[1].second : best;
+}
+
+static void sortAndUnique(std::vector<std::string> &values) {
+  llvm::sort(values);
+  values.erase(std::unique(values.begin(), values.end()), values.end());
+}
+
+} // namespace
+
+llvm::StringRef
+mlir::ascend::stringifySimdSimtCandidate(SimdSimtCandidateKind candidate) {
+  switch (candidate) {
+  case SimdSimtCandidateKind::AllSIMD:
+    return kAllSimd;
+  case SimdSimtCandidateKind::AllSIMTOnly:
+    return kAllSimtOnly;
+  case SimdSimtCandidateKind::MixedSIMDSIMT:
+    return kMixedSimdSimt;
+  }
+  llvm_unreachable("unknown SIMD/SIMT candidate");
+}
+
+double SimdSimtCandidateScores::get(SimdSimtCandidateKind candidate) const {
+  switch (candidate) {
+  case SimdSimtCandidateKind::AllSIMD:
+    return allSimd;
+  case SimdSimtCandidateKind::AllSIMTOnly:
+    return allSimtOnly;
+  case SimdSimtCandidateKind::MixedSIMDSIMT:
+    return mixedSimdSimt;
+  }
+  llvm_unreachable("unknown SIMD/SIMT candidate");
+}
+
+llvm::json::Object SimdSimtCandidateScores::toJSON() const {
+  llvm::json::Object result;
+  result[kAllSimd] = allSimd;
+  result[kAllSimtOnly] = allSimtOnly;
+  result[kMixedSimdSimt] = mixedSimdSimt;
+  return result;
+}
+
+static llvm::json::Array toReasonJSON(const std::vector<std::string> &reasons) {
+  llvm::json::Array result;
+  for (const std::string &reason : reasons)
+    result.push_back(reason);
+  return result;
+}
+
+static llvm::json::Object
+toLowerabilityJSON(const CandidateLowerability &lowerability) {
+  llvm::json::Object result;
+  auto route = [](CandidateLoweringStatus status,
+                  const std::vector<std::string> &reasons) {
+    llvm::json::Object entry;
+    entry["status"] = stringifyCandidateLoweringStatus(status).str();
+    entry["reasons"] = toReasonJSON(reasons);
+    return entry;
+  };
+  result[kAllSimd] = route(lowerability.allSimd, lowerability.allSimdReasons);
+  result[kAllSimtOnly] =
+      route(lowerability.allSimtOnly, lowerability.allSimtOnlyReasons);
+  result[kMixedSimdSimt] = route(lowerability.mixed, lowerability.mixedReasons);
+  return result;
+}
+
+static llvm::json::Object toAtomicFactsJSON(const TensorAtomicFacts &facts) {
+  llvm::json::Object result;
+  result["update_elements"] = facts.updateElements;
+  result["address_rank"] = facts.addressRank;
+  result["value_type"] = facts.valueType;
+  result["offset_type"] = facts.offsetType;
+  result["operation"] = facts.operation;
+  result["has_mask"] = facts.hasMask;
+  if (facts.staticMaskActiveFraction)
+    result["static_mask_active_fraction"] = *facts.staticMaskActiveFraction;
+  else
+    result["static_mask_active_fraction"] = nullptr;
+  result["result_used"] = facts.resultUsed;
+  result["address_is_lane_varying"] = facts.addressIsLaneVarying;
+  result["address_depends_on_loaded_index"] = facts.addressDependsOnLoadedIndex;
+  result["contention"] = facts.contention;
+  return result;
+}
+
+static llvm::json::Object toHistogramFactsJSON(const HistogramFacts &facts) {
+  llvm::json::Object result;
+  result["input_elements"] = facts.inputElements;
+  result["num_bins"] = facts.numBins;
+  result["input_type"] = facts.inputType;
+  result["result_type"] = facts.resultType;
+  return result;
+}
+
+static llvm::json::Object
+toPlainCumsumFactsJSON(const PlainCumsumFacts &facts) {
+  llvm::json::Object result;
+  result["axis_extent"] = facts.axisExtent;
+  result["element_type"] = facts.elementType;
+  result["reverse"] = facts.reverse;
+  return result;
+}
+
+llvm::json::Object SimtAnchorFeatureSummary::toJSON() const {
+  llvm::json::Object result;
+  result["recognized_count"] = recognizedCount;
+  result["count"] = count;
+  result["materializable_count"] = count;
+  result["covered_operation_count"] = coveredOperationCount;
+  result["load_ops"] = loadOps;
+  result["store_ops"] = storeOps;
+  result["reduce_ops"] = reduceOps;
+  result["scan_ops"] = scanOps;
+  result["gather_ops"] = gatherOps;
+  result["dot_ops"] = dotOps;
+  result["atomic_ops"] = atomicOps;
+  result["histogram_ops"] = histogramOps;
+  result["max_tensor_numel"] = maxTensorNumel;
+  result["max_element_bits"] = maxElementBits;
+  result["mask_rank_sum"] = maskRankSum;
+  result["unique_mask_values"] = uniqueMaskValues;
+  result["unique_mask_rank_sum"] = uniqueMaskRankSum;
+  result["predicate_elements"] = predicateElements;
+  result["predicate_lane_evaluations"] = predicateLaneEvaluations;
+  result["pointer_tensor_ops"] = pointerTensorOps;
+  result["loaded_index_dependent_memory_ops"] = loadedIndexDependentMemoryOps;
+  result["lane_dependent_pointer_ops"] = laneDependentPointerOps;
+  result["max_reduce_axis_extent"] = maxReduceAxisExtent;
+  result["weighted_reduce_axis_elements"] = weightedReduceAxisElements;
+  result["shuffle_lane_steps"] = shuffleLaneSteps;
+  result["static_loop_count"] = staticLoopCount;
+  result["static_loop_trip_count_sum"] = staticLoopTripCountSum;
+  result["modeled_dynamic_loop_count"] = modeledDynamicLoopCount;
+  result["modeled_dynamic_loop_trip_count_sum"] =
+      modeledDynamicLoopTripCountSum;
+  result["has_control_flow"] = hasControlFlow;
+  result["weighted_ops"] = ::toJSON(weightedOps);
+  result["op_elements"] = ::toJSON(opElements);
+  result["load_bytes"] = loadBytes;
+  result["store_bytes"] = storeBytes;
+  result["load_warp_instructions"] = loadWarpInstructions;
+  result["store_warp_instructions"] = storeWarpInstructions;
+  result["dot_flops"] = dotFlops;
+  result["captured_tensor_count"] = capturedTensorCount;
+  result["escaping_tensor_count"] = escapingTensorCount;
+  result["captured_tensor_bytes"] = capturedTensorBytes;
+  result["escaping_tensor_bytes"] = escapingTensorBytes;
+  llvm::json::Array mechanisms;
+  for (const std::string &kind : mechanismKinds)
+    mechanisms.push_back(kind);
+  result["mechanism_kinds"] = std::move(mechanisms);
+  llvm::json::Array atomicFacts;
+  for (const TensorAtomicFacts &facts : tensorAtomics)
+    atomicFacts.push_back(toAtomicFactsJSON(facts));
+  result["tensor_atomics"] = std::move(atomicFacts);
+  llvm::json::Array histogramFacts;
+  for (const HistogramFacts &facts : histograms)
+    histogramFacts.push_back(toHistogramFactsJSON(facts));
+  result["histograms"] = std::move(histogramFacts);
+  llvm::json::Array cumsumFacts;
+  for (const PlainCumsumFacts &facts : plainCumsums)
+    cumsumFacts.push_back(toPlainCumsumFactsJSON(facts));
+  result["plain_cumsums"] = std::move(cumsumFacts);
+  result["kernel_lowerability"] = toLowerabilityJSON(kernelLowerability);
+  return result;
+}
+
+llvm::json::Object SimdSimtFeatureSummary::toJSON() const {
+  llvm::json::Object result;
+  result["load_ops"] = loadOps;
+  result["store_ops"] = storeOps;
+  result["reduce_ops"] = reduceOps;
+  result["scan_ops"] = scanOps;
+  result["gather_ops"] = gatherOps;
+  result["dot_ops"] = dotOps;
+  result["atomic_ops"] = atomicOps;
+  result["histogram_ops"] = histogramOps;
+  result["broadcast_ops"] = broadcastOps;
+  result["expand_dims_ops"] = expandDimsOps;
+  result["splat_ops"] = splatOps;
+  result["addptr_ops"] = addPtrOps;
+  result["arith_ops"] = arithOps;
+  result["math_ops"] = mathOps;
+  result["add_ops"] = addOps;
+  result["sub_ops"] = subOps;
+  result["mul_ops"] = mulOps;
+  result["div_ops"] = divOps;
+  result["max_ops"] = maxOps;
+  result["abs_ops"] = absOps;
+  result["exp_ops"] = expOps;
+  result["log_ops"] = logOps;
+  result["cmp_ops"] = cmpOps;
+  result["select_ops"] = selectOps;
+  result["cast_ops"] = castOps;
+  result["clamp_ops"] = clampOps;
+  result["scalar_ops"] = scalarOps;
+  result["max_tensor_rank"] = maxTensorRank;
+  result["max_tensor_numel"] = maxTensorNumel;
+  result["max_element_bits"] = maxElementBits;
+  result["mask_tensor_ops"] = maskTensorOps;
+  result["mask_rank_sum"] = maskRankSum;
+  result["unique_mask_values"] = uniqueMaskValues;
+  result["unique_mask_rank_sum"] = uniqueMaskRankSum;
+  result["predicate_elements"] = predicateElements;
+  result["predicate_lane_evaluations"] = predicateLaneEvaluations;
+  result["mask_broadcast_ops"] = maskBroadcastOps;
+  result["pointer_tensor_ops"] = pointerTensorOps;
+  result["pointer_unstructured_dims"] = pointerUnstructuredDims;
+  result["loaded_index_dependent_memory_ops"] = loadedIndexDependentMemoryOps;
+  result["lane_dependent_pointer_ops"] = laneDependentPointerOps;
+  result["row_local_reduce_ops"] = rowLocalReduceOps;
+  result["max_reduce_axis_extent"] = maxReduceAxisExtent;
+  result["weighted_reduce_axis_elements"] = weightedReduceAxisElements;
+  result["shuffle_lane_steps"] = shuffleLaneSteps;
+  result["scalar_load_ops"] = scalarLoadOps;
+  result["scalar_store_ops"] = scalarStoreOps;
+  result["vector_ptr_splat_ops"] = vectorPtrSplatOps;
+  result["vector_reduce_to_scalar_ops"] = vectorReduceToScalarOps;
+  result["rank1_indirect_vector_reduce"] = rank1IndirectVectorReduce;
+  result["weighted_ops"] = ::toJSON(weightedOps);
+  result["op_elements"] = ::toJSON(opElements);
+  result["load_bytes"] = loadBytes;
+  result["store_bytes"] = storeBytes;
+  result["load_warp_instructions"] = loadWarpInstructions;
+  result["store_warp_instructions"] = storeWarpInstructions;
+  result["dot_flops"] = dotFlops;
+  result["dot_output_elements"] = dotOutputElements;
+  llvm::json::Array dotShapes;
+  for (const auto &shape : dotMNK)
+    dotShapes.push_back(llvm::json::Array({shape[0], shape[1], shape[2]}));
+  result["dot_mnk"] = std::move(dotShapes);
+  result["static_loop_count"] = staticLoopCount;
+  result["static_loop_trip_count_sum"] = staticLoopTripCountSum;
+  result["static_loop_trip_count_max"] = staticLoopTripCountMax;
+  result["modeled_dynamic_loop_count"] = modeledDynamicLoopCount;
+  result["modeled_dynamic_loop_trip_count_sum"] =
+      modeledDynamicLoopTripCountSum;
+  result["has_dot"] = hasDot;
+  result["has_gather"] = hasGather;
+  result["has_atomic"] = hasAtomic;
+  result["has_histogram"] = hasHistogram;
+  result["has_scan"] = hasScan;
+  result["has_explicit_scope"] = hasExplicitScope;
+  result["has_control_flow"] = hasControlFlow;
+  result["has_dynamic_shape"] = hasDynamicShape;
+  result["has_unknown_trip_count"] = hasUnknownTripCount;
+  result["simt_anchors"] = simtAnchors.toJSON();
+  llvm::json::Array mixedKinds;
+  for (const std::string &kind : observedMixedKinds)
+    mixedKinds.push_back(kind);
+  result["observed_mixed_kinds"] = std::move(mixedKinds);
+  result["mixed_required"] = !observedMixedKinds.empty();
+  result["mandatory_mixed_enabled"] = false;
+  return result;
+}
+
+llvm::json::Object SimtApplicabilityResult::toJSON() const {
+  llvm::json::Object result;
+  result["mechanism_detected"] = mechanismDetected;
+  result["target_supported"] = targetSupported;
+  result["materializable"] = materializable;
+  result["recognized_anchor_count"] = recognizedAnchorCount;
+  result["materializable_anchor_count"] = materializableAnchorCount;
+  llvm::json::Array mechanismValues;
+  for (const std::string &mechanism : mechanisms)
+    mechanismValues.push_back(mechanism);
+  result["mechanisms"] = std::move(mechanismValues);
+  llvm::json::Array reasonValues;
+  for (const std::string &reason : reasons)
+    reasonValues.push_back(reason);
+  result["reasons"] = std::move(reasonValues);
+  return result;
+}
+
+llvm::json::Object
+SimdSimtCostBreakdown::toJSON(const SimdSimtFeatureSummary &features) const {
+  llvm::json::Object result;
+  llvm::json::Object compute;
+  compute["simd"] = simdComputeCycles;
+  compute["simt"] = simtComputeCycles;
+  compute["simd_dot"] = simdDotCycles;
+  compute["simt_dot"] = simtDotCycles;
+  result["compute_only"] = std::move(compute);
+
+  llvm::json::Object memory;
+  memory["load_bytes"] = features.loadBytes;
+  memory["store_bytes"] = features.storeBytes;
+  memory["simd_load_system_cycles"] = simdLoadCycles;
+  memory["simd_store_system_cycles"] = simdStoreCycles;
+  memory["simd_roofline_system_cycles"] = simdMemoryCycles;
+  memory["simt_load_warp_instructions"] = features.loadWarpInstructions;
+  memory["simt_store_warp_instructions"] = features.storeWarpInstructions;
+  memory["simt_load_system_cycles"] = simtLoadCycles;
+  memory["simt_store_system_cycles"] = simtStoreCycles;
+  memory["simt_serial_memory_system_cycles"] = simtMemoryCycles;
+  // Compatibility field retained for existing report consumers. SIMT memory
+  // is not roofline-overlapped with SIMT compute by the route model.
+  memory["simt_roofline_system_cycles"] = simtMemoryCycles;
+  result["memory"] = std::move(memory);
+
+  llvm::json::Object structure;
+  structure["irregular_density"] = irregularDensity;
+  structure["tiny_dot_underfill"] = tinyDotUnderfill;
+  structure["components"] = ::toJSON(structuralComponents);
+  structure["penalty_ratio"] = structuralPenaltyRatio;
+  structure["simd_structural_penalty_system_cycles"] =
+      simdStructuralPenaltyCycles;
+  result["structure"] = std::move(structure);
+
+  llvm::json::Object mixed;
+  mixed["derived_simd_fraction"] = mixedSimdFraction;
+  mixed["cost_source"] = mixedCostSource;
+  mixed["setup_fallback_num_warps"] = mixedSetupFallbackNumWarps;
+  mixed["mixed_setup_fallback_system_cycles"] = mixedSetupFallbackCycles;
+  mixed["standalone_serialized_setup_system_cycles"] =
+      standaloneSimtSetupCycles;
+  mixed["setup_proxy_delta_system_cycles"] = setupProxyDeltaCycles;
+  mixed["directional_transition_system_cycles"] = nullptr;
+  mixed["directional_transition_measurement_status"] = "unmeasured";
+  llvm::json::Object partition;
+  partition["simd_regular_compute_system_cycles"] =
+      mixedSimdRegularComputeCycles;
+  partition["simd_regular_dot_system_cycles"] = mixedSimdRegularDotCycles;
+  partition["simd_regular_memory_system_cycles"] = mixedSimdRegularMemoryCycles;
+  partition["simd_regular_payload_system_cycles"] =
+      mixedSimdRegularPayloadCycles;
+  partition["simt_anchor_compute_system_cycles"] = mixedSimtAnchorComputeCycles;
+  partition["simt_anchor_dot_system_cycles"] = mixedSimtAnchorDotCycles;
+  partition["simt_anchor_memory_system_cycles"] = mixedSimtAnchorMemoryCycles;
+  partition["simt_anchor_shuffle_system_cycles"] = mixedSimtAnchorShuffleCycles;
+  partition["simt_anchor_predicate_system_cycles"] =
+      mixedSimtAnchorPredicateCycles;
+  partition["simt_anchor_payload_system_cycles"] = mixedSimtAnchorPayloadCycles;
+  partition["measured_boundary_system_cycles"] = nullptr;
+  partition["applied_boundary_fallback_system_cycles"] = mixedBoundaryCycles;
+  partition["remaining_simd_structural_penalty_ratio"] =
+      mixedRemainingStructuralPenaltyRatio;
+  mixed["partition"] = std::move(partition);
+  result["mixed"] = std::move(mixed);
+
+  llvm::json::Object execution;
+  execution["shuffle_warp_instructions"] = simtShuffleInstructions;
+  execution["shuffle_system_cycles"] = simtShuffleCycles;
+  execution["predicate_warp_instructions"] = simtPredicateInstructions;
+  execution["predicate_system_cycles"] = simtPredicateCycles;
+  execution["program_issue_scale"] = programIssueScale;
+  execution["simd_setup_system_cycles"] = simdSetupCycles;
+  execution["simt_setup_system_cycles"] = simtSetupCycles;
+  execution["simd_issue_payload_system_cycles"] = simdIssuePayloadCycles;
+  execution["simt_issue_payload_system_cycles"] = simtIssuePayloadCycles;
+  execution["simt_issue_aggregation"] = "serial_sum";
+  result["simt_execution"] = std::move(execution);
+
+  llvm::json::Object opBreakdown;
+  opBreakdown["simd_ops_system_cycles"] = ::toJSON(simdOpSystemCycles);
+  opBreakdown["simt_ops_system_cycles"] = ::toJSON(simtOpSystemCycles);
+  result["op_breakdown"] = std::move(opBreakdown);
+  return result;
+}
+
+llvm::json::Object SimdSimtCostReport::toJSON() const {
+  llvm::json::Object result;
+  result["schema_version"] = schemaVersion;
+  result["model"] = model;
+  result["profile_version"] = profileVersion;
+  result["profile_target"] = profileTarget;
+  result["actual_target"] = actualTarget;
+  result["target_compatible"] = targetCompatible;
+  result["profile_content_sha256"] = profileContentSha256;
+  result["selection_profile_content_sha256"] = selectionProfileContentSha256;
+  llvm::json::Object sharedEvidence;
+  sharedEvidence["profile_version"] = microbenchmarkProfileVersion;
+  sharedEvidence["target"] = microbenchmarkProfileTarget;
+  sharedEvidence["content_sha256"] = microbenchmarkProfileContentSha256;
+  result["shared_microbenchmark_profile"] = std::move(sharedEvidence);
+  result["unit"] = scoreUnit;
+  result["score_scope"] = scoreScope;
+  result["selection_score_valid"] = selectionScoreValid;
+  result["absolute_cost_valid"] = absoluteCostValid;
+  result["excludes"] = llvm::json::Array({"host_launch", "grid_wave_count"});
+  result["candidate_costs_evaluated"] = candidateCostsEvaluated;
+  if (candidateCostsEvaluated) {
+    result["candidate_costs"] = candidateCosts.toJSON();
+    result["candidate_ratios_to_best"] = candidateRatiosToBest.toJSON();
+    result["decision_kind"] = stringifySimdSimtCandidate(decision);
+    result["runner_up_kind"] = stringifySimdSimtCandidate(runnerUp);
+    result["best_score"] = bestScore;
+    result["runner_up_score"] = runnerUpScore;
+    result["gain_score"] = gainScore;
+    result["decision_advantage"] = decisionAdvantage;
+    result["required_gain_score"] = requiredGainScore;
+  } else {
+    result["candidate_costs"] = nullptr;
+    result["candidate_ratios_to_best"] = nullptr;
+    result["decision_kind"] = nullptr;
+    result["runner_up_kind"] = nullptr;
+    result["best_score"] = nullptr;
+    result["runner_up_score"] = nullptr;
+    result["gain_score"] = nullptr;
+    result["decision_advantage"] = nullptr;
+    result["required_gain_score"] = nullptr;
+  }
+  llvm::json::Object eventCalibration;
+  eventCalibration["applied"] = eventRouteCalibrationApplied;
+  eventCalibration["domain"] = eventRouteCalibrationApplied
+                                   ? llvm::json::Value(calibrationDomain)
+                                   : llvm::json::Value(nullptr);
+  eventCalibration["all_simt_only_validated"] = eventAllSimtOnlyValidated;
+  eventCalibration["mixed_simd_simt_validated"] = eventMixedSimdSimtValidated;
+  eventCalibration["source"] = eventRouteCalibrationSource;
+  eventCalibration["confidence"] = eventRouteCalibrationConfidence;
+  if (candidateCostsEvaluated) {
+    eventCalibration["raw_candidate_costs"] =
+        uncalibratedCandidateCosts.toJSON();
+    eventCalibration["score_multipliers"] = eventRouteScoreMultipliers.toJSON();
+  } else {
+    eventCalibration["raw_candidate_costs"] = nullptr;
+    eventCalibration["score_multipliers"] = nullptr;
+  }
+  result["event_route_calibration"] = std::move(eventCalibration);
+  llvm::json::Array selectableCandidates;
+  if (allSimdCandidateLegal)
+    selectableCandidates.push_back(kAllSimd);
+  if (allSimtOnlyCandidateLegal)
+    selectableCandidates.push_back(kAllSimtOnly);
+  if (mixedCandidateLegal)
+    selectableCandidates.push_back(kMixedSimdSimt);
+  result["selectable_candidates"] = std::move(selectableCandidates);
+  result["margin_ratio"] = marginRatio;
+  result["ranking_confidence"] = rankingConfidence;
+  result["minimum_confidence_for_decision"] = minimumConfidenceForDecision;
+  result["absolute_confidence"] = absoluteConfidence;
+  result["confidence"] = rankingConfidence;
+  result["gate_passed"] = gatePassed;
+
+  llvm::json::Array reasons;
+  for (const std::string &reason : gateReasons)
+    reasons.push_back(reason);
+  result["gate_reasons"] = std::move(reasons);
+  llvm::json::Array unsupportedValues;
+  for (const std::string &value : unsupported)
+    unsupportedValues.push_back(value);
+  result["unsupported"] = std::move(unsupportedValues);
+
+  llvm::json::Object structure;
+  structure["calibration_covered"] = calibrationCovered;
+  structure["calibration_domain"] = calibrationDomain;
+  structure["calibration_sample_domain"] = calibrationDomain;
+  result["calibration"] = std::move(structure);
+  result["applicability"] = applicability.toJSON();
+
+  llvm::json::Object contract;
+  contract["version"] = 2;
+  contract["enabled"] = false;
+  contract["requested"] = !features.observedMixedKinds.empty();
+  contract["mandatory_override_suppressed"] =
+      !features.observedMixedKinds.empty();
+  contract["mandatory"] = false;
+  contract["required"] = false;
+  contract["target_kind"] = nullptr;
+  llvm::json::Array routeKinds;
+  for (const std::string &kind : features.observedMixedKinds)
+    routeKinds.push_back(kind);
+  contract["route_kinds"] = std::move(routeKinds);
+  contract["all_simt_only_reference_only"] = false;
+  result["mixed_execution_contract"] = std::move(contract);
+
+  llvm::json::Object roles;
+  roles[kAllSimd] =
+      allSimdCandidateLegal ? "selectable_candidate" : "inapplicable";
+  roles[kAllSimtOnly] =
+      allSimtOnlyCandidateLegal ? "selectable_candidate" : "inapplicable";
+  roles[kMixedSimdSimt] =
+      mixedCandidateLegal ? "selectable_candidate" : "inapplicable";
+  result["candidate_roles"] = std::move(roles);
+
+  if (candidateCostsEvaluated) {
+    llvm::json::Object analytical;
+    analytical[kAllSimd] = breakdown.simdAnalyticalCycles;
+    analytical[kAllSimtOnly] = breakdown.simtAnalyticalCycles;
+    result["analytical_candidate_costs"] = std::move(analytical);
+
+    llvm::json::Object detail = breakdown.toJSON(features);
+    for (auto &entry : detail)
+      result[entry.first] = std::move(entry.second);
+    if (auto *structureObject = result.getObject("structure")) {
+      (*structureObject)["calibration_covered"] = calibrationCovered;
+      (*structureObject)["calibration_domain"] = calibrationDomain;
+      (*structureObject)["calibration_sample_domain"] = calibrationDomain;
+    }
+  } else {
+    result["analytical_candidate_costs"] = nullptr;
+    llvm::json::Object structure;
+    structure["irregular_density"] = breakdown.irregularDensity;
+    structure["calibration_covered"] = calibrationCovered;
+    structure["calibration_domain"] = calibrationDomain;
+    structure["calibration_sample_domain"] = calibrationDomain;
+    result["structure"] = std::move(structure);
+  }
+  if (includeFeaturesInJSON)
+    result["features"] = features.toJSON();
+  result["des_feedback_applied"] = llvm::json::Array();
+  result["des_feedback_validation_errors"] = llvm::json::Array();
+  return result;
+}
+
+void SimdSimtCostReport::printJSON(llvm::raw_ostream &os, bool pretty) const {
+  llvm::json::Object object = toJSON();
+  if (pretty)
+    os << llvm::formatv("{0:2}", llvm::json::Value(std::move(object)));
+  else
+    os << llvm::json::Value(std::move(object));
+}
+
+std::string mlir::ascend::getDefaultSimdSimtProfilePath() {
+  if (const char *environment = std::getenv("TRITON_ASCEND_SIMD_SIMT_PROFILE"))
+    if (*environment)
+      return environment;
+#ifdef TRITON_ASCEND_SIMD_SIMT_PROFILE_PATH
+  return TRITON_ASCEND_SIMD_SIMT_PROFILE_PATH;
+#else
+  return {};
+#endif
+}
+
+llvm::Expected<SimdSimtFeatureSummary>
+mlir::ascend::analyzeSimdSimtFeatures(ModuleOp module, bool compileOn91095) {
+  if (!module)
+    return llvm::createStringError(std::errc::invalid_argument,
+                                   "cannot analyze a null ModuleOp");
+  SimtAnchorPlan anchorPlan = buildMixedSimtAnchorPlan(module, compileOn91095);
+  return analyzeSimdSimtFeatures(module, anchorPlan);
+}
+
+llvm::Expected<SimdSimtFeatureSummary>
+mlir::ascend::analyzeSimdSimtFeatures(ModuleOp module,
+                                      const SimtAnchorPlan &anchorPlan) {
+  if (!module)
+    return llvm::createStringError(std::errc::invalid_argument,
+                                   "cannot analyze a null ModuleOp");
+
+  SimdSimtFeatureSummary features;
+  initializeWorkMaps(features);
+  initializeWorkMaps(features.simtAnchors);
+  llvm::DenseSet<Operation *> anchorSet;
+  llvm::DenseMap<Operation *, int64_t> structuralTripEstimates;
+  for (const SimtAnchorDescriptor &anchor : anchorPlan.anchors) {
+    if (!anchor.materializable)
+      continue;
+    if (anchor.scopeOperations.empty()) {
+      if (anchor.operation)
+        anchorSet.insert(anchor.operation);
+    } else {
+      for (Operation *scopeOperation : anchor.scopeOperations)
+        if (scopeOperation)
+          anchorSet.insert(scopeOperation);
+    }
+    if (anchor.kind == SimtAnchorKind::TriangularSolveLoop) {
+      // A recognized solve_tril block has a fixed 16x16 state and starts its
+      // recurrence at row 2: a full block performs 16 - 2 = 14 iterations.
+      // The TTIR upper bound is min(runtime_remaining, block_end), so it is
+      // not a compile-time constant even though the full-tile estimate is
+      // structurally known.  Do not apply this fallback to generic loops.
+      for (Operation *scopeOperation : anchor.scopeOperations)
+        if (scopeOperation &&
+            scopeOperation->getName().getStringRef() == "scf.for")
+          structuralTripEstimates[scopeOperation] = 14;
+    }
+  }
+  features.simtAnchors.recognizedCount = anchorPlan.anchors.size();
+  features.simtAnchors.count = anchorPlan.materializableCount();
+  features.simtAnchors.kernelLowerability = anchorPlan.kernelLowerability;
+  for (const SimtAnchorDescriptor &anchor : anchorPlan.anchors) {
+    std::string kind = stringifySimtAnchorKind(anchor.kind).str();
+    appendUnique(features.simtAnchors.mechanismKinds, kind);
+    appendUnique(features.observedMixedKinds, kind);
+    if (const auto *facts = std::get_if<TensorAtomicFacts>(&anchor.facts))
+      features.simtAnchors.tensorAtomics.push_back(*facts);
+    else if (const auto *facts = std::get_if<HistogramFacts>(&anchor.facts))
+      features.simtAnchors.histograms.push_back(*facts);
+    else if (const auto *facts = std::get_if<PlainCumsumFacts>(&anchor.facts))
+      features.simtAnchors.plainCumsums.push_back(*facts);
+  }
+
+  auto isInAnchor = [&](Operation *op) {
+    for (Operation *current = op; current; current = current->getParentOp())
+      if (anchorSet.contains(current))
+        return true;
+    return false;
+  };
+
+  llvm::DenseSet<Value> capturedTensors;
+  llvm::DenseSet<Value> escapingTensors;
+  llvm::DenseSet<Value> uniqueMasks;
+  llvm::DenseSet<Value> anchorUniqueMasks;
+  auto isValueDefinedInAnchor = [&](Value value) {
+    if (Operation *definingOp = value.getDefiningOp())
+      return isInAnchor(definingOp);
+    auto argument = dyn_cast<BlockArgument>(value);
+    Operation *parent = argument ? argument.getOwner()->getParentOp() : nullptr;
+    return parent && isInAnchor(parent);
+  };
+  module.walk([&](Operation *op) {
+    if (!isInAnchor(op))
+      return;
+    for (Value operand : op->getOperands()) {
+      if (!isa<RankedTensorType>(operand.getType()) ||
+          isValueDefinedInAnchor(operand) ||
+          !capturedTensors.insert(operand).second)
+        continue;
+      ++features.simtAnchors.capturedTensorCount;
+      features.simtAnchors.capturedTensorBytes +=
+          getStaticTensorBytes(operand.getType());
+    }
+    for (Value result : op->getResults()) {
+      if (!isa<RankedTensorType>(result.getType()) || result.use_empty())
+        continue;
+      bool escapes = llvm::any_of(result.getUses(), [&](OpOperand &use) {
+        return !isInAnchor(use.getOwner());
+      });
+      if (!escapes || !escapingTensors.insert(result).second)
+        continue;
+      ++features.simtAnchors.escapingTensorCount;
+      features.simtAnchors.escapingTensorBytes +=
+          getStaticTensorBytes(result.getType());
+    }
+  });
+  auto updateTypeStats = [&](Type type, bool inAnchor) {
+    if (auto tensor = dyn_cast<RankedTensorType>(type)) {
+      if (!tensor.hasStaticShape())
+        features.hasDynamicShape = true;
+      features.maxElementBits =
+          std::max(features.maxElementBits, getTypeBitWidth(type));
+      features.maxTensorRank =
+          std::max<int64_t>(features.maxTensorRank, tensor.getRank());
+      features.maxTensorNumel =
+          std::max(features.maxTensorNumel, getStaticNumElements(type));
+      if (inAnchor) {
+        features.simtAnchors.maxElementBits = std::max(
+            features.simtAnchors.maxElementBits, getTypeBitWidth(type));
+        features.simtAnchors.maxTensorNumel = std::max(
+            features.simtAnchors.maxTensorNumel, getStaticNumElements(type));
+      }
+    }
+  };
+
+  module.walk([&](Operation *op) {
+    llvm::StringRef name = op->getName().getStringRef();
+    const int64_t elements = getOperationElements(op);
+    const int64_t loopMultiplier =
+        getLoopMultiplier(op, structuralTripEstimates);
+    const bool inAnchor = isInAnchor(op);
+    if (inAnchor)
+      ++features.simtAnchors.coveredOperationCount;
+
+    for (Type type : op->getOperandTypes())
+      updateTypeStats(type, inAnchor);
+    for (Type type : op->getResultTypes())
+      updateTypeStats(type, inAnchor);
+    for (Region &region : op->getRegions())
+      for (Block &block : region)
+        for (BlockArgument argument : block.getArguments())
+          updateTypeStats(argument.getType(), inAnchor);
+
+    if (name.starts_with("arith."))
+      ++features.arithOps;
+    if (name.starts_with("math."))
+      ++features.mathOps;
+    if (name.starts_with("scf.") || name.starts_with("cf.")) {
+      features.hasControlFlow = true;
+      if (inAnchor)
+        features.simtAnchors.hasControlFlow = true;
+    }
+    if (name == "scope.scope")
+      features.hasExplicitScope = true;
+
+    auto incrementRaw = [&](int64_t &counter, int64_t &anchorCounter) {
+      ++counter;
+      if (inAnchor)
+        ++anchorCounter;
+    };
+    if (name == "tt.load")
+      incrementRaw(features.loadOps, features.simtAnchors.loadOps);
+    else if (name == "tt.store")
+      incrementRaw(features.storeOps, features.simtAnchors.storeOps);
+    else if (name == "tt.reduce")
+      incrementRaw(features.reduceOps, features.simtAnchors.reduceOps);
+    else if (name == "tt.scan" || name == "tt.associative_scan")
+      incrementRaw(features.scanOps, features.simtAnchors.scanOps);
+    else if (name == "tt.gather")
+      incrementRaw(features.gatherOps, features.simtAnchors.gatherOps);
+    else if (name == "tt.dot")
+      incrementRaw(features.dotOps, features.simtAnchors.dotOps);
+    else if (name.starts_with("tt.atomic"))
+      incrementRaw(features.atomicOps, features.simtAnchors.atomicOps);
+    else if (name == "tt.histogram")
+      incrementRaw(features.histogramOps, features.simtAnchors.histogramOps);
+    else if (name == "tt.broadcast")
+      ++features.broadcastOps;
+    else if (name == "tt.expand_dims")
+      ++features.expandDimsOps;
+    else if (name == "tt.splat")
+      ++features.splatOps;
+    else if (name == "tt.addptr")
+      ++features.addPtrOps;
+
+    if (name == "arith.addf" || name == "arith.addi")
+      ++features.addOps;
+    else if (name == "arith.subf" || name == "arith.subi")
+      ++features.subOps;
+    else if (name == "arith.mulf" || name == "arith.muli")
+      ++features.mulOps;
+    else if (name == "arith.divf" || name == "arith.divsi" ||
+             name == "arith.divui")
+      ++features.divOps;
+    else if (name == "arith.maxnumf" || name == "arith.maxf" ||
+             name == "arith.maxsi" || name == "arith.maxui")
+      ++features.maxOps;
+    else if (name == "math.absf" || name == "math.absi")
+      ++features.absOps;
+    else if (name == "math.exp")
+      ++features.expOps;
+    else if (name == "math.log")
+      ++features.logOps;
+    else if (name == "arith.cmpf" || name == "arith.cmpi")
+      ++features.cmpOps;
+    else if (name == "arith.select")
+      ++features.selectOps;
+    else if (isCastOp(name))
+      ++features.castOps;
+    else if (name.starts_with("tt.clamp"))
+      ++features.clampOps;
+
+    llvm::StringRef weightedKind = classifyWeightedOp(name);
+    if (!weightedKind.empty()) {
+      int64_t weightedElements = elements;
+      if (name == "tt.histogram" && op->getNumOperands() > 0)
+        if (auto input =
+                dyn_cast<RankedTensorType>(op->getOperand(0).getType()))
+          if (input.hasStaticShape())
+            weightedElements = getStaticNumElements(input);
+      features.weightedOps[weightedKind] += loopMultiplier;
+      features.opElements[weightedKind] += weightedElements * loopMultiplier;
+      if (inAnchor) {
+        features.simtAnchors.weightedOps[weightedKind] += loopMultiplier;
+        features.simtAnchors.opElements[weightedKind] +=
+            weightedElements * loopMultiplier;
+      }
+    }
+
+    if (name == "scf.for") {
+      auto knownTripCount = getKnownStaticLoopTripCount(op);
+      if (!knownTripCount)
+        features.hasUnknownTripCount = true;
+      int64_t tripCount = getModeledLoopTripCount(op, structuralTripEstimates);
+      const bool usedStructuralEstimate =
+          !knownTripCount && structuralTripEstimates.contains(op);
+      ++features.staticLoopCount;
+      features.staticLoopTripCountSum += tripCount;
+      features.staticLoopTripCountMax =
+          std::max(features.staticLoopTripCountMax, tripCount);
+      if (usedStructuralEstimate) {
+        ++features.modeledDynamicLoopCount;
+        features.modeledDynamicLoopTripCountSum += tripCount;
+      }
+      if (inAnchor) {
+        ++features.simtAnchors.staticLoopCount;
+        features.simtAnchors.staticLoopTripCountSum += tripCount;
+        if (usedStructuralEstimate) {
+          ++features.simtAnchors.modeledDynamicLoopCount;
+          features.simtAnchors.modeledDynamicLoopTripCountSum += tripCount;
+        }
+      }
+    }
+
+    auto dataTypeAndElements = [&](bool load) -> std::pair<Type, int64_t> {
+      if (load && op->getNumResults() > 0)
+        return {op->getResult(0).getType(),
+                getStaticNumElements(op->getResult(0).getType())};
+      if (!load && op->getNumOperands() > 1)
+        return {op->getOperand(1).getType(),
+                getStaticNumElements(op->getOperand(1).getType())};
+      if (op->getNumOperands() > 0)
+        return {op->getOperand(0).getType(), elements};
+      return {Type(), elements};
+    };
+    if (name == "tt.load" || name == "tt.store") {
+      bool load = name == "tt.load";
+      auto [dataType, dataElements] = dataTypeAndElements(load);
+      int64_t bitWidth = dataType ? getTypeBitWidth(dataType) : 32;
+      double bytes =
+          static_cast<double>(dataElements) * loopMultiplier * bitWidth / 8.0;
+      int64_t warpInstructions =
+          static_cast<int64_t>(std::ceil(dataElements / 32.0)) * loopMultiplier;
+      if (load) {
+        features.loadBytes += bytes;
+        features.loadWarpInstructions += warpInstructions;
+        if (inAnchor) {
+          features.simtAnchors.loadBytes += bytes;
+          features.simtAnchors.loadWarpInstructions += warpInstructions;
+        }
+      } else {
+        features.storeBytes += bytes;
+        features.storeWarpInstructions += warpInstructions;
+        if (inAnchor) {
+          features.simtAnchors.storeBytes += bytes;
+          features.simtAnchors.storeWarpInstructions += warpInstructions;
+        }
+      }
+    }
+
+    if (name == "tt.dot" && op->getNumOperands() >= 2) {
+      auto lhs = dyn_cast<RankedTensorType>(op->getOperand(0).getType());
+      auto rhs = dyn_cast<RankedTensorType>(op->getOperand(1).getType());
+      if (lhs && rhs && lhs.getRank() >= 2 && rhs.getRank() >= 2) {
+        int64_t m = lhs.getShape()[lhs.getRank() - 2];
+        int64_t k = lhs.getShape()[lhs.getRank() - 1];
+        int64_t n = rhs.getShape()[rhs.getRank() - 1];
+        if (m > 0 && n > 0 && k > 0) {
+          features.dotFlops += 2 * m * n * k * loopMultiplier;
+          features.dotOutputElements += m * n * loopMultiplier;
+          features.dotMNK.push_back({m, n, k});
+          if (inAnchor)
+            features.simtAnchors.dotFlops += 2 * m * n * k * loopMultiplier;
+        }
+      }
+    }
+
+    std::vector<int64_t> rankedResultAndOperandRanks;
+    bool hasRankedInput = false;
+    bool hasRankedResult = false;
+    for (Type type : op->getOperandTypes())
+      if (auto tensor = dyn_cast<RankedTensorType>(type)) {
+        rankedResultAndOperandRanks.push_back(tensor.getRank());
+        hasRankedInput = true;
+      }
+    for (Type type : op->getResultTypes())
+      if (auto tensor = dyn_cast<RankedTensorType>(type)) {
+        rankedResultAndOperandRanks.push_back(tensor.getRank());
+        hasRankedResult = true;
+      }
+    if (name == "tt.reduce") {
+      if (rankedResultAndOperandRanks.size() > 1) {
+        auto [minimum, maximum] =
+            std::minmax_element(rankedResultAndOperandRanks.begin(),
+                                rankedResultAndOperandRanks.end());
+        if (*maximum > *minimum)
+          ++features.rowLocalReduceOps;
+      }
+      if (hasRankedInput && !hasRankedResult)
+        ++features.vectorReduceToScalarOps;
+      if (op->getNumOperands() > 0) {
+        auto source = dyn_cast<RankedTensorType>(op->getOperand(0).getType());
+        auto axis = op->getAttrOfType<IntegerAttr>("axis");
+        if (source && source.hasStaticShape() && axis) {
+          int64_t axisValue = axis.getInt();
+          if (axisValue < 0)
+            axisValue += source.getRank();
+          if (axisValue >= 0 && axisValue < source.getRank()) {
+            int64_t extent = source.getShape()[axisValue];
+            if (extent > 0) {
+              features.maxReduceAxisExtent =
+                  std::max(features.maxReduceAxisExtent, extent);
+              features.weightedReduceAxisElements += extent * loopMultiplier;
+              const int64_t shuffleLevels = static_cast<int64_t>(
+                  std::ceil(std::log2(static_cast<double>(extent))));
+              const int64_t inputElements = getStaticNumElements(source);
+              const int64_t shuffleLaneSteps =
+                  inputElements * shuffleLevels * loopMultiplier;
+              features.shuffleLaneSteps += shuffleLaneSteps;
+              if (inAnchor) {
+                features.simtAnchors.maxReduceAxisExtent =
+                    std::max(features.simtAnchors.maxReduceAxisExtent, extent);
+                features.simtAnchors.weightedReduceAxisElements +=
+                    extent * loopMultiplier;
+                features.simtAnchors.shuffleLaneSteps += shuffleLaneSteps;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    if ((name == "tt.scan" || name == "tt.associative_scan") &&
+        op->getNumOperands() > 0) {
+      auto source = dyn_cast<RankedTensorType>(op->getOperand(0).getType());
+      auto axis = op->getAttrOfType<IntegerAttr>("axis");
+      if (source && source.hasStaticShape() && axis) {
+        int64_t axisValue = axis.getInt();
+        if (axisValue < 0)
+          axisValue += source.getRank();
+        if (axisValue >= 0 && axisValue < source.getRank()) {
+          int64_t extent = source.getShape()[axisValue];
+          if (extent > 0) {
+            const int64_t shuffleLevels = static_cast<int64_t>(
+                std::ceil(std::log2(static_cast<double>(extent))));
+            const int64_t laneSteps =
+                getStaticNumElements(source) * shuffleLevels * loopMultiplier;
+            features.shuffleLaneSteps += laneSteps;
+            if (inAnchor)
+              features.simtAnchors.shuffleLaneSteps += laneSteps;
+          }
+        }
+      }
+    }
+
+    std::vector<int64_t> maskRanks;
+    for (Type type : op->getOperandTypes())
+      if (isMaskTensorType(type))
+        maskRanks.push_back(cast<RankedTensorType>(type).getRank());
+    for (Type type : op->getResultTypes())
+      if (isMaskTensorType(type))
+        maskRanks.push_back(cast<RankedTensorType>(type).getRank());
+    if (!maskRanks.empty()) {
+      ++features.maskTensorOps;
+      for (int64_t rank : maskRanks) {
+        features.maskRankSum += rank;
+        if (inAnchor)
+          features.simtAnchors.maskRankSum += rank;
+      }
+      auto addPredicateLaneEvaluations = [&](Type type) {
+        if (!isMaskTensorType(type))
+          return;
+        const int64_t laneEvaluations =
+            getStaticNumElements(type) * loopMultiplier;
+        features.predicateLaneEvaluations += laneEvaluations;
+        if (inAnchor)
+          features.simtAnchors.predicateLaneEvaluations += laneEvaluations;
+      };
+      for (Type type : op->getOperandTypes())
+        addPredicateLaneEvaluations(type);
+      for (Type type : op->getResultTypes())
+        addPredicateLaneEvaluations(type);
+      if (name == "tt.broadcast" || name == "tt.expand_dims")
+        ++features.maskBroadcastOps;
+    }
+
+    auto recordUniqueMask = [&](Value value) {
+      auto type = dyn_cast<RankedTensorType>(value.getType());
+      if (!type || !type.getElementType().isInteger(1))
+        return;
+      if (uniqueMasks.insert(value).second) {
+        ++features.uniqueMaskValues;
+        features.uniqueMaskRankSum += type.getRank();
+        const int64_t elements = getStaticNumElements(type);
+        features.predicateElements += elements;
+      }
+      if (inAnchor && anchorUniqueMasks.insert(value).second) {
+        ++features.simtAnchors.uniqueMaskValues;
+        features.simtAnchors.uniqueMaskRankSum += type.getRank();
+        const int64_t elements = getStaticNumElements(type);
+        features.simtAnchors.predicateElements += elements;
+      }
+    };
+    for (Value operand : op->getOperands())
+      recordUniqueMask(operand);
+    for (Value result : op->getResults())
+      recordUniqueMask(result);
+
+    bool isPointerOperation =
+        name == "tt.addptr" || name == "tt.load" || name == "tt.store";
+    if (isLoadedIndexDependentMemoryOp(op)) {
+      ++features.loadedIndexDependentMemoryOps;
+      if (inAnchor)
+        ++features.simtAnchors.loadedIndexDependentMemoryOps;
+    }
+    if (isPointerOperation) {
+      std::set<std::string> uniqueShapes;
+      auto collectShape = [&](Type type) {
+        auto tensor = dyn_cast<RankedTensorType>(type);
+        if (!tensor)
+          return;
+        std::string key;
+        llvm::raw_string_ostream os(key);
+        os << tensor.getRank();
+        for (int64_t dim : tensor.getShape())
+          os << 'x' << dim;
+        os.flush();
+        uniqueShapes.insert(std::move(key));
+      };
+      for (Type type : op->getOperandTypes())
+        collectShape(type);
+      for (Type type : op->getResultTypes())
+        collectShape(type);
+      int64_t maxPointerRank = 0;
+      for (const std::string &shape : uniqueShapes) {
+        llvm::StringRef shapeRef(shape);
+        int64_t rank = 0;
+        (void)shapeRef.take_front(shapeRef.find('x')).getAsInteger(10, rank);
+        ++features.pointerTensorOps;
+        if (inAnchor)
+          ++features.simtAnchors.pointerTensorOps;
+        maxPointerRank = std::max(maxPointerRank, rank);
+        if (rank > 1)
+          features.pointerUnstructuredDims += rank;
+      }
+      if (maxPointerRank > 1) {
+        ++features.laneDependentPointerOps;
+        if (inAnchor)
+          ++features.simtAnchors.laneDependentPointerOps;
+      }
+    }
+
+    bool anyRankedType = llvm::any_of(op->getOperandTypes(), [](Type type) {
+      return isa<RankedTensorType>(type);
+    });
+    anyRankedType |= llvm::any_of(op->getResultTypes(), [](Type type) {
+      return isa<RankedTensorType>(type);
+    });
+    if (name == "tt.load" && !anyRankedType && op->getNumOperands() > 0 &&
+        isPointerType(op->getOperand(0).getType()))
+      ++features.scalarLoadOps;
+    if (name == "tt.store" && !anyRankedType && op->getNumOperands() > 0 &&
+        isPointerType(op->getOperand(0).getType()))
+      ++features.scalarStoreOps;
+    if (name == "tt.splat" && op->getNumOperands() > 0 &&
+        op->getNumResults() > 0 && isPointerType(op->getOperand(0).getType()) &&
+        isa<RankedTensorType>(op->getResult(0).getType()))
+      ++features.vectorPtrSplatOps;
+  });
+
+  features.scalarOps = features.addOps + features.subOps + features.mulOps +
+                       features.divOps + features.maxOps + features.absOps +
+                       features.expOps + features.logOps + features.cmpOps +
+                       features.selectOps + features.castOps +
+                       features.clampOps;
+  features.hasDot = features.dotOps > 0;
+  features.hasGather = features.gatherOps > 0;
+  features.hasAtomic = features.atomicOps > 0;
+  features.hasHistogram = features.histogramOps > 0;
+  features.hasScan = features.scanOps > 0;
+  features.rank1IndirectVectorReduce =
+      features.maxTensorRank == 1 && features.reduceOps > 0 &&
+      features.vectorReduceToScalarOps > 0 && features.vectorPtrSplatOps > 0 &&
+      features.scalarLoadOps >= 2;
+
+  return features;
+}
+
+llvm::Expected<SimdSimtCostReport> mlir::ascend::estimateSimdSimtCandidates(
+    const SimdSimtFeatureSummary &features,
+    const SimdSimtCostModelOptions &options) {
+  if (!std::isfinite(options.marginRatio) || options.marginRatio < 0.0)
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "SIMD/SIMT marginRatio must be finite and non-negative");
+  auto profileOrError = loadCandidateProfile(options.profilePath);
+  if (!profileOrError)
+    return profileOrError.takeError();
+  CandidateProfile profile = std::move(*profileOrError);
+
+  SimdSimtCostReport report;
+  report.profileVersion = profile.profileVersion;
+  report.profileTarget = profile.target;
+  report.actualTarget = options.actualTarget;
+  report.profileContentSha256 = profile.contentSha256;
+  report.selectionProfileContentSha256 = profile.selectionContentSha256;
+  report.microbenchmarkProfileVersion = profile.microbenchmarkProfileVersion;
+  report.microbenchmarkProfileTarget = profile.microbenchmarkProfileTarget;
+  report.microbenchmarkProfileContentSha256 =
+      profile.microbenchmarkContentSha256;
+  report.scoreUnit = profile.scoreUnit;
+  report.minimumConfidenceForDecision = profile.minimumConfidence;
+  report.targetCompatible = targetMatches(profile, options.actualTarget);
+  report.features = features;
+  report.applicability =
+      evaluateSimtApplicability(features, options.compileOn91095);
+  report.allSimdCandidateLegal =
+      features.simtAnchors.kernelLowerability.allSimd ==
+      CandidateLoweringStatus::Native;
+  report.allSimtOnlyCandidateLegal =
+      options.compileOn91095 && !features.hasExplicitScope &&
+      features.simtAnchors.kernelLowerability.allSimtOnly ==
+          CandidateLoweringStatus::Native;
+  report.mixedCandidateLegal = !features.hasExplicitScope &&
+                               report.applicability.materializable &&
+                               features.simtAnchors.kernelLowerability.mixed ==
+                                   CandidateLoweringStatus::Native;
+  report.includeFeaturesInJSON = options.includeFeaturesInJSON;
+  report.marginRatio = options.marginRatio;
+
+  // Coverage is a validity check over extracted features, not a cost term.
+  // Evaluate it before all resource, structural, and transition scoring so
+  // production auto selection can reject out-of-domain kernels cheaply.
+  const int64_t weightedReductions =
+      mapValue(features.weightedOps, "reduce", features.reduceOps);
+  const int64_t dotFlops = features.dotFlops;
+  const int64_t pointerOps = std::max<int64_t>(1, features.pointerTensorOps);
+  report.breakdown.irregularDensity = std::min(
+      1.0, static_cast<double>(features.laneDependentPointerOps) / pointerOps);
+  auto [covered, domain] =
+      rankingCalibrationCoverage(features, weightedReductions, dotFlops,
+                                 profile, report.breakdown.irregularDensity);
+  report.calibrationCovered = covered;
+  report.calibrationDomain = std::move(domain);
+  report.selectionScoreValid = covered;
+
+  const EventRouteCalibrationProfile *eventRouteCalibration = nullptr;
+  if (report.calibrationCovered) {
+    auto calibration =
+        profile.eventRouteCalibration.find(report.calibrationDomain);
+    if (calibration != profile.eventRouteCalibration.end()) {
+      eventRouteCalibration = &calibration->second;
+      report.eventRouteCalibrationApplied = true;
+      report.eventAllSimtOnlyValidated =
+          eventRouteCalibration->allSimtOnlyValidated;
+      report.eventMixedSimdSimtValidated =
+          eventRouteCalibration->mixedSimdSimtValidated;
+      report.eventRouteCalibrationSource = eventRouteCalibration->source;
+      report.eventRouteCalibrationConfidence =
+          eventRouteCalibration->confidence;
+      report.eventRouteScoreMultipliers = {
+          eventRouteCalibration->allSimdMultiplier,
+          eventRouteCalibration->allSimtOnlyMultiplier,
+          eventRouteCalibration->mixedSimdSimtMultiplier};
+
+      // BackendConditional is deliberately not globally selectable.  A
+      // bounded Event domain may promote it only after the whole-kernel pure
+      // SIMT path passed correctness on the target represented by this
+      // versioned profile.  Unsupported/AliasesMixed statuses never promote.
+      if (options.compileOn91095 && !features.hasExplicitScope &&
+          eventRouteCalibration->allSimtOnlyValidated &&
+          features.simtAnchors.kernelLowerability.allSimtOnly ==
+              CandidateLoweringStatus::BackendConditional)
+        report.allSimtOnlyCandidateLegal = true;
+      if (!eventRouteCalibration->mixedSimdSimtValidated)
+        report.mixedCandidateLegal = false;
+    }
+  }
+
+  if (!report.calibrationCovered && !options.scoreOutsideCalibrationCoverage) {
+    if (!report.targetCompatible)
+      report.gateReasons.push_back("target_incompatible");
+    report.gateReasons.push_back("selection_score_invalid");
+    report.gatePassed = false;
+    return report;
+  }
+
+  const int64_t numWarps =
+      std::max<int64_t>(1, static_cast<int64_t>(options.numWarps));
+  const int64_t maxNumel = std::max<int64_t>(1, features.maxTensorNumel);
+  const int64_t elementBits =
+      features.maxElementBits > 0
+          ? std::max<int64_t>(8, features.maxElementBits)
+          : 32;
+  const int64_t vectorWidth =
+      std::max<int64_t>(1, profile.simdVectorWidthBits / elementBits);
+  std::vector<std::string> resourceConfidence;
+  if (report.allSimtOnlyCandidateLegal)
+    resourceConfidence.push_back(profile.simtSetupConfidence);
+  if (report.mixedCandidateLegal)
+    resourceConfidence.push_back(profile.mixedSetupFallbackConfidence);
+  if (eventRouteCalibration)
+    resourceConfidence.push_back(eventRouteCalibration->confidence);
+
+  llvm::StringMap<int64_t> rawCountByKind;
+  rawCountByKind["gather"] = features.gatherOps;
+  rawCountByKind["histogram"] = features.histogramOps;
+  rawCountByKind["atomic"] = features.atomicOps;
+  for (llvm::StringRef kind : {"gather", "histogram", "atomic"}) {
+    int64_t coreWork = mapValue(features.opElements, kind,
+                                mapValue(rawCountByKind, kind) * maxNumel);
+    if (coreWork > 0)
+      report.unsupported.push_back((kind + "_core_cost_uncalibrated").str());
+  }
+
+  int64_t classifiedScalarOps =
+      features.addOps + features.subOps + features.mulOps + features.divOps +
+      features.maxOps + features.absOps + features.expOps + features.logOps +
+      features.cmpOps + features.selectOps + features.castOps +
+      features.clampOps;
+  int64_t unclassifiedScalarOps =
+      std::max<int64_t>(0, features.scalarOps - classifiedScalarOps);
+  if (unclassifiedScalarOps)
+    report.unsupported.push_back(std::to_string(unclassifiedScalarOps) +
+                                 " unclassified arithmetic ops");
+
+  for (const auto &[opName, elements] : getProfileOpElements(features)) {
+    if (elements <= 0)
+      continue;
+    auto simdIterator = profile.simdOps.find(opName);
+    auto simtIterator = profile.simtOps.find(opName);
+    if (simdIterator == profile.simdOps.end() ||
+        simtIterator == profile.simtOps.end()) {
+      report.unsupported.push_back(opName.str());
+      continue;
+    }
+    const OpProfile &simd = simdIterator->second;
+    const OpProfile &simt = simtIterator->second;
+    if (simd.throughput <= 0.0 || simt.throughput <= 0.0) {
+      report.unsupported.push_back(opName.str());
+      continue;
+    }
+    double simdCycles = std::ceil(static_cast<double>(elements) / vectorWidth) /
+                        simd.throughput * simd.factor;
+    double simtCycles =
+        static_cast<double>(elements) / simt.throughput * simt.factor;
+    report.breakdown.simdOpSystemCycles[opName] = simdCycles;
+    report.breakdown.simtOpSystemCycles[opName] = simtCycles;
+    report.breakdown.simdComputeCycles += simdCycles;
+    report.breakdown.simtComputeCycles += simtCycles;
+    resourceConfidence.push_back(simd.confidence);
+    resourceConfidence.push_back(simt.confidence);
+  }
+
+  for (const auto &[opName, elements] :
+       getProfileOpElements(features.simtAnchors)) {
+    if (elements <= 0)
+      continue;
+    auto simdIterator = profile.simdOps.find(opName);
+    auto simtIterator = profile.simtOps.find(opName);
+    if (simdIterator == profile.simdOps.end() ||
+        simtIterator == profile.simtOps.end())
+      continue;
+    const OpProfile &simd = simdIterator->second;
+    const OpProfile &simt = simtIterator->second;
+    if (simd.throughput <= 0.0 || simt.throughput <= 0.0)
+      continue;
+    report.breakdown.mixedSimdRegularComputeCycles -=
+        std::ceil(static_cast<double>(elements) / vectorWidth) /
+        simd.throughput * simd.factor;
+    report.breakdown.mixedSimtAnchorComputeCycles +=
+        static_cast<double>(elements) / simt.throughput * simt.factor;
+  }
+  report.breakdown.mixedSimdRegularComputeCycles +=
+      report.breakdown.simdComputeCycles;
+  report.breakdown.mixedSimdRegularComputeCycles =
+      std::max(0.0, report.breakdown.mixedSimdRegularComputeCycles);
+
+  report.breakdown.simdLoadCycles =
+      features.loadBytes / profile.simdMte2BytesPerCycle;
+  report.breakdown.simdStoreCycles =
+      features.storeBytes / profile.simdMte3BytesPerCycle;
+  report.breakdown.simdMemoryCycles = std::max(
+      report.breakdown.simdLoadCycles, report.breakdown.simdStoreCycles);
+  const double mixedSimdRegularLoadCycles =
+      std::max(0.0, features.loadBytes - features.simtAnchors.loadBytes) /
+      profile.simdMte2BytesPerCycle;
+  const double mixedSimdRegularStoreCycles =
+      std::max(0.0, features.storeBytes - features.simtAnchors.storeBytes) /
+      profile.simdMte3BytesPerCycle;
+  report.breakdown.mixedSimdRegularMemoryCycles =
+      std::max(mixedSimdRegularLoadCycles, mixedSimdRegularStoreCycles);
+  if (features.loadBytes != 0.0 || features.storeBytes != 0.0)
+    resourceConfidence.push_back(profile.simdMemoryConfidence);
+
+  const int64_t loadWarpInstructions =
+      features.loadWarpInstructions != 0
+          ? features.loadWarpInstructions
+          : features.loadOps *
+                static_cast<int64_t>(std::ceil(static_cast<double>(maxNumel) /
+                                               profile.simtWarpSize));
+  const int64_t storeWarpInstructions =
+      features.storeWarpInstructions != 0
+          ? features.storeWarpInstructions
+          : features.storeOps *
+                static_cast<int64_t>(std::ceil(static_cast<double>(maxNumel) /
+                                               profile.simtWarpSize));
+  report.features.loadWarpInstructions = loadWarpInstructions;
+  report.features.storeWarpInstructions = storeWarpInstructions;
+  report.breakdown.simtLoadCycles =
+      loadWarpInstructions / profile.simtLoadWarpRate;
+  report.breakdown.simtStoreCycles =
+      storeWarpInstructions / profile.simtStoreWarpRate;
+  report.breakdown.simtMemoryCycles =
+      report.breakdown.simtLoadCycles + report.breakdown.simtStoreCycles;
+  report.breakdown.mixedSimtAnchorMemoryCycles =
+      features.simtAnchors.loadWarpInstructions / profile.simtLoadWarpRate +
+      features.simtAnchors.storeWarpInstructions / profile.simtStoreWarpRate;
+  if (loadWarpInstructions != 0 || storeWarpInstructions != 0)
+    resourceConfidence.push_back(profile.simtMemoryConfidence);
+
+  const int64_t weightedScans =
+      mapValue(features.weightedOps, "scan", features.scanOps);
+  if (weightedScans)
+    report.unsupported.push_back("scan_template_ranking_uncalibrated");
+  const int64_t shuffleLevels = static_cast<int64_t>(
+      std::ceil(std::log2(static_cast<double>(profile.simtWarpSize))));
+  report.breakdown.simtShuffleInstructions =
+      features.shuffleLaneSteps > 0
+          ? std::ceil(static_cast<double>(features.shuffleLaneSteps) /
+                      profile.simtWarpSize)
+          : static_cast<double>(weightedReductions + weightedScans) *
+                std::ceil(static_cast<double>(maxNumel) /
+                          profile.simtWarpSize) *
+                shuffleLevels;
+  report.breakdown.simtShuffleCycles =
+      report.breakdown.simtShuffleInstructions / profile.simtShuffleRate;
+  const int64_t anchorWeightedReductions =
+      mapValue(features.simtAnchors.weightedOps, "reduce",
+               features.simtAnchors.reduceOps);
+  const int64_t anchorWeightedScans = mapValue(
+      features.simtAnchors.weightedOps, "scan", features.simtAnchors.scanOps);
+  const int64_t anchorMaxNumel =
+      std::max<int64_t>(1, features.simtAnchors.maxTensorNumel);
+  const double anchorShuffleInstructions =
+      features.simtAnchors.shuffleLaneSteps > 0
+          ? std::ceil(
+                static_cast<double>(features.simtAnchors.shuffleLaneSteps) /
+                profile.simtWarpSize)
+          : static_cast<double>(anchorWeightedReductions +
+                                anchorWeightedScans) *
+                std::ceil(static_cast<double>(anchorMaxNumel) /
+                          profile.simtWarpSize) *
+                shuffleLevels;
+  report.breakdown.mixedSimtAnchorShuffleCycles =
+      anchorShuffleInstructions / profile.simtShuffleRate;
+  if (report.breakdown.simtShuffleInstructions != 0.0)
+    resourceConfidence.push_back(profile.simtShuffleConfidence);
+
+  report.breakdown.simtPredicateInstructions =
+      features.predicateLaneEvaluations > 0
+          ? std::ceil(static_cast<double>(features.predicateLaneEvaluations) /
+                      profile.simtWarpSize)
+          : static_cast<double>(features.maskRankSum) *
+                std::ceil(static_cast<double>(maxNumel) / profile.simtWarpSize);
+  report.breakdown.simtPredicateCycles =
+      report.breakdown.simtPredicateInstructions / profile.simtPredicateRate;
+  const double anchorPredicateInstructions =
+      features.simtAnchors.predicateLaneEvaluations > 0
+          ? std::ceil(static_cast<double>(
+                          features.simtAnchors.predicateLaneEvaluations) /
+                      profile.simtWarpSize)
+          : static_cast<double>(features.simtAnchors.maskRankSum) *
+                std::ceil(static_cast<double>(anchorMaxNumel) /
+                          profile.simtWarpSize);
+  report.breakdown.mixedSimtAnchorPredicateCycles =
+      anchorPredicateInstructions / profile.simtPredicateRate;
+
+  if (dotFlops) {
+    report.breakdown.simdDotCycles =
+        profile.simdDotSetupCycles +
+        static_cast<double>(dotFlops) / profile.simdDotFlopsPerCycle;
+    report.breakdown.simtDotCycles =
+        profile.simtDotSetupCycles +
+        static_cast<double>(dotFlops) / profile.simtDotFlopsPerCycle;
+    resourceConfidence.push_back(profile.simdDotConfidence);
+    resourceConfidence.push_back(profile.simtDotConfidence);
+  }
+  const int64_t regularDotFlops =
+      std::max<int64_t>(0, dotFlops - features.simtAnchors.dotFlops);
+  if (regularDotFlops)
+    report.breakdown.mixedSimdRegularDotCycles =
+        profile.simdDotSetupCycles +
+        static_cast<double>(regularDotFlops) / profile.simdDotFlopsPerCycle;
+  if (features.simtAnchors.dotFlops)
+    report.breakdown.mixedSimtAnchorDotCycles =
+        profile.simtDotSetupCycles +
+        static_cast<double>(features.simtAnchors.dotFlops) /
+            profile.simtDotFlopsPerCycle;
+
+  report.breakdown.simdSetupCycles = profile.simdSetupCycles;
+  report.breakdown.simtSetupCycles = profile.simtSetupCycles;
+  report.breakdown.simdIssuePayloadCycles = std::max(
+      report.breakdown.simdComputeCycles + report.breakdown.simdDotCycles,
+      report.breakdown.simdMemoryCycles);
+  // The current SIMT lowering emits a dependency-ordered warp instruction
+  // stream. Loads feed compute, compute feeds shuffle/reduction, and stores
+  // consume the result. There is no measured overlap contract that would
+  // justify a roofline max(compute, memory), so charge the serial path.
+  report.breakdown.simtIssuePayloadCycles =
+      report.breakdown.simtComputeCycles + report.breakdown.simtShuffleCycles +
+      report.breakdown.simtDotCycles + report.breakdown.simtMemoryCycles +
+      report.breakdown.simtPredicateCycles;
+  report.breakdown.programIssueScale = profile.programIssueScale;
+  report.breakdown.simdAnalyticalCycles =
+      profile.simdSetupCycles +
+      report.breakdown.simdIssuePayloadCycles * profile.programIssueScale;
+  report.breakdown.simtAnalyticalCycles =
+      profile.simtSetupCycles +
+      report.breakdown.simtIssuePayloadCycles * profile.programIssueScale;
+
+  const bool tinyDot =
+      dotFlops > 0 && dotFlops <= profile.structural.tinyDotFlopsMax;
+  report.breakdown.tinyDotUnderfill =
+      tinyDot ? std::max(0.0, 1.0 - static_cast<double>(dotFlops) /
+                                        profile.structural.tinyDotFlopsMax)
+              : 0.0;
+  const double irregularPerDensity =
+      tinyDot ? profile.structural.tinyDotIrregularPerDensity
+              : profile.structural.irregularPerDensity;
+  const double irregularCap = tinyDot ? profile.structural.tinyDotIrregularCap
+                                      : profile.structural.irregularCap;
+  report.breakdown.structuralComponents["irregular_addressing"] = std::min(
+      irregularCap, report.breakdown.irregularDensity * irregularPerDensity);
+  report.breakdown.structuralComponents["mask_materialization"] =
+      std::min(profile.structural.maskCap,
+               features.maskRankSum * profile.structural.perMaskRank);
+  report.breakdown.structuralComponents["reduction_lowering"] =
+      std::min(profile.structural.reductionCap,
+               weightedReductions * profile.structural.perWeightedReduction);
+  report.breakdown.structuralComponents["static_loop_control"] = std::min(
+      profile.structural.loopCap,
+      features.staticLoopTripCountSum * profile.structural.perStaticLoopTrip);
+  report.breakdown.structuralComponents["control_flow"] =
+      features.hasControlFlow ? profile.structural.controlFlow : 0.0;
+  report.breakdown.structuralComponents["tiny_dot_startup"] =
+      tinyDot ? profile.structural.tinyDot * report.breakdown.tinyDotUnderfill
+              : 0.0;
+  report.breakdown.structuralComponents["rank1_indirect_vector_reduction"] =
+      features.rank1IndirectVectorReduce
+          ? profile.structural.rank1IndirectVectorReduction
+          : 0.0;
+  for (const auto &component : report.breakdown.structuralComponents)
+    report.breakdown.structuralPenaltyRatio += component.second;
+  // Candidate costs must remain independent. Structural terms describe work
+  // omitted by the SIMD roofline, so charge them against A_SIMD itself;
+  // changing SIMT throughput/setup must never change the all-SIMD score.
+  report.breakdown.simdStructuralPenaltyCycles =
+      report.breakdown.simdAnalyticalCycles *
+      report.breakdown.structuralPenaltyRatio;
+  report.candidateCosts.allSimd = report.breakdown.simdAnalyticalCycles +
+                                  report.breakdown.simdStructuralPenaltyCycles;
+  report.candidateCosts.allSimtOnly = report.breakdown.simtAnalyticalCycles;
+
+  const MixedSetupFallbackProfile *nearestSetupFallback = nullptr;
+  for (const MixedSetupFallbackProfile &fallback : profile.mixedSetupFallbacks)
+    if (!nearestSetupFallback ||
+        std::abs(fallback.numWarps - numWarps) <
+            std::abs(nearestSetupFallback->numWarps - numWarps))
+      nearestSetupFallback = &fallback;
+  if (!nearestSetupFallback)
+    return llvm::createStringError(std::errc::invalid_argument,
+                                   "SIMD/SIMT profile has no mixed setup "
+                                   "fallback");
+  report.breakdown.mixedSetupFallbackNumWarps = nearestSetupFallback->numWarps;
+  report.breakdown.standaloneSimtSetupCycles = profile.simtSetupCycles;
+  report.breakdown.mixedSetupFallbackCycles =
+      nearestSetupFallback->emptySimtSetupCycles;
+  report.breakdown.setupProxyDeltaCycles =
+      std::max(0.0, report.breakdown.mixedSetupFallbackCycles -
+                        report.breakdown.standaloneSimtSetupCycles);
+
+  // A mixed route is not a convex blend of two whole-kernel costs. Charge
+  // exact materializable anchors at SIMT rates and remaining operations at
+  // SIMD rates. The regular SIMD phase keeps its measured roofline model;
+  // the SIMT anchor is a serial load/compute/shuffle/store instruction path.
+  report.breakdown.mixedSimdRegularPayloadCycles =
+      std::max(report.breakdown.mixedSimdRegularComputeCycles +
+                   report.breakdown.mixedSimdRegularDotCycles,
+               report.breakdown.mixedSimdRegularMemoryCycles);
+  report.breakdown.mixedSimtAnchorPayloadCycles =
+      report.breakdown.mixedSimtAnchorComputeCycles +
+      report.breakdown.mixedSimtAnchorDotCycles +
+      report.breakdown.mixedSimtAnchorShuffleCycles +
+      report.breakdown.mixedSimtAnchorMemoryCycles +
+      report.breakdown.mixedSimtAnchorPredicateCycles;
+
+  const int64_t remainingPointerOps = std::max<int64_t>(
+      0, features.pointerTensorOps - features.simtAnchors.pointerTensorOps);
+  const int64_t remainingLaneDependentPointerOps =
+      std::max<int64_t>(0, features.laneDependentPointerOps -
+                               features.simtAnchors.laneDependentPointerOps);
+  const double remainingIrregularDensity =
+      remainingPointerOps > 0
+          ? std::min(1.0,
+                     static_cast<double>(remainingLaneDependentPointerOps) /
+                         remainingPointerOps)
+          : 0.0;
+  const int64_t remainingMaskRank = std::max<int64_t>(
+      0, features.maskRankSum - features.simtAnchors.maskRankSum);
+  const int64_t remainingWeightedReductions =
+      std::max<int64_t>(0, weightedReductions - anchorWeightedReductions);
+  const int64_t remainingLoopTrips =
+      std::max<int64_t>(0, features.staticLoopTripCountSum -
+                               features.simtAnchors.staticLoopTripCountSum);
+  const bool remainingControlFlow =
+      features.hasControlFlow && !features.simtAnchors.hasControlFlow;
+  const bool remainingRank1Reduction =
+      features.rank1IndirectVectorReduce && remainingWeightedReductions > 0;
+  const bool remainingTinyDot = regularDotFlops > 0 && tinyDot;
+
+  double remainingStructuralPenalty = 0.0;
+  remainingStructuralPenalty +=
+      std::min(irregularCap, remainingIrregularDensity * irregularPerDensity);
+  remainingStructuralPenalty +=
+      std::min(profile.structural.maskCap,
+               remainingMaskRank * profile.structural.perMaskRank);
+  remainingStructuralPenalty += std::min(
+      profile.structural.reductionCap,
+      remainingWeightedReductions * profile.structural.perWeightedReduction);
+  remainingStructuralPenalty +=
+      std::min(profile.structural.loopCap,
+               remainingLoopTrips * profile.structural.perStaticLoopTrip);
+  if (remainingControlFlow)
+    remainingStructuralPenalty += profile.structural.controlFlow;
+  if (remainingRank1Reduction)
+    remainingStructuralPenalty +=
+        profile.structural.rank1IndirectVectorReduction;
+  if (remainingTinyDot)
+    remainingStructuralPenalty +=
+        profile.structural.tinyDot * report.breakdown.tinyDotUnderfill;
+  report.breakdown.mixedRemainingStructuralPenaltyRatio =
+      remainingStructuralPenalty;
+
+  double totalPartitionWork = features.loadBytes + features.storeBytes +
+                              static_cast<double>(features.dotFlops);
+  for (const auto &entry : features.opElements)
+    totalPartitionWork += std::max<int64_t>(0, entry.second);
+  double anchorPartitionWork =
+      features.simtAnchors.loadBytes + features.simtAnchors.storeBytes +
+      static_cast<double>(features.simtAnchors.dotFlops);
+  for (const auto &entry : features.simtAnchors.opElements)
+    anchorPartitionWork += std::max<int64_t>(0, entry.second);
+  report.breakdown.mixedSimdFraction =
+      totalPartitionWork > 0.0
+          ? std::clamp(1.0 - anchorPartitionWork / totalPartitionWork, 0.0, 1.0)
+          : 0.0;
+
+  if (features.simtAnchors.count > 0) {
+    const double regularPayloadWithResidual =
+        report.breakdown.mixedSimdRegularPayloadCycles *
+        (1.0 + remainingStructuralPenalty);
+    report.candidateCosts.mixedSimdSimt =
+        report.breakdown.mixedSetupFallbackCycles +
+        profile.programIssueScale *
+            (regularPayloadWithResidual +
+             report.breakdown.mixedSimtAnchorPayloadCycles) +
+        report.breakdown.mixedBoundaryCycles;
+    report.breakdown.mixedCostSource =
+        "materializable_anchor_resource_partition";
+  } else {
+    report.candidateCosts.mixedSimdSimt =
+        std::max(report.candidateCosts.allSimd,
+                 report.candidateCosts.allSimtOnly) +
+        report.breakdown.mixedSetupFallbackCycles;
+    report.breakdown.mixedCostSource =
+        "inapplicable_without_materializable_anchor";
+  }
+
+  report.uncalibratedCandidateCosts = report.candidateCosts;
+  if (eventRouteCalibration) {
+    // The analytical/structural formula supplies the feature-sensitive base.
+    // A bounded, versioned Event multiplier corrects its route-relative
+    // residual for the admitted domain.  Keeping the raw score in the report
+    // makes the empirical correction explicit instead of hiding it in a
+    // structural penalty or a Python heuristic.
+    report.candidateCosts.allSimd *= eventRouteCalibration->allSimdMultiplier;
+    report.candidateCosts.allSimtOnly *=
+        eventRouteCalibration->allSimtOnlyMultiplier;
+    report.candidateCosts.mixedSimdSimt *=
+        eventRouteCalibration->mixedSimdSimtMultiplier;
+  }
+
+  report.candidateCostsEvaluated = true;
+  sortAndUnique(report.unsupported);
+  const unsigned legalCandidateCount =
+      static_cast<unsigned>(report.allSimdCandidateLegal) +
+      static_cast<unsigned>(report.allSimtOnlyCandidateLegal) +
+      static_cast<unsigned>(report.mixedCandidateLegal);
+  if (legalCandidateCount == 0)
+    return llvm::createStringError(
+        std::errc::not_supported,
+        "SIMD/SIMT route model found no independently lowerable candidate");
+  report.decision =
+      chooseBest(report.candidateCosts, report.allSimdCandidateLegal,
+                 report.allSimtOnlyCandidateLegal, report.mixedCandidateLegal);
+  report.runnerUp =
+      chooseRunnerUp(report.candidateCosts, report.allSimdCandidateLegal,
+                     report.allSimtOnlyCandidateLegal,
+                     report.mixedCandidateLegal, report.decision);
+  report.bestScore = report.candidateCosts.get(report.decision);
+  report.runnerUpScore = report.candidateCosts.get(report.runnerUp);
+  if (legalCandidateCount <= 1) {
+    report.decisionAdvantage = 0.0;
+  } else if (report.allSimdCandidateLegal) {
+    report.decisionAdvantage =
+        report.decision == SimdSimtCandidateKind::AllSIMD
+            ? report.runnerUpScore - report.bestScore
+            : report.candidateCosts.allSimd - report.bestScore;
+  } else {
+    report.decisionAdvantage = report.runnerUpScore - report.bestScore;
+  }
+  report.gainScore = report.decisionAdvantage;
+  const double gainBaseline = report.allSimdCandidateLegal
+                                  ? report.candidateCosts.allSimd
+                                  : report.runnerUpScore;
+  report.requiredGainScore =
+      legalCandidateCount > 1
+          ? std::max(64.0, gainBaseline * options.marginRatio)
+          : 0.0;
+  double ratioDenominator =
+      std::max(1.0e-9, std::min({report.candidateCosts.allSimd,
+                                 report.candidateCosts.allSimtOnly,
+                                 report.candidateCosts.mixedSimdSimt}));
+  report.candidateRatiosToBest = {
+      report.candidateCosts.allSimd / ratioDenominator,
+      report.candidateCosts.allSimtOnly / ratioDenominator,
+      report.candidateCosts.mixedSimdSimt / ratioDenominator};
+
+  report.absoluteConfidence = minimumConfidence(resourceConfidence);
+  if (!report.unsupported.empty()) {
+    report.rankingConfidence = "none";
+  } else if (report.breakdown.structuralPenaltyRatio > 0.0 && covered) {
+    report.rankingConfidence = minimumConfidence(
+        {report.absoluteConfidence, profile.rankingConfidence});
+  } else {
+    report.rankingConfidence = report.absoluteConfidence;
+  }
+  if (!report.targetCompatible)
+    report.rankingConfidence = "none";
+
+  if (!report.targetCompatible)
+    report.gateReasons.push_back("target_incompatible");
+  if (!report.selectionScoreValid)
+    report.gateReasons.push_back("selection_score_invalid");
+  if (!report.unsupported.empty())
+    report.gateReasons.push_back("unsupported_cost_terms");
+  if (confidenceRank(report.rankingConfidence) <
+      confidenceRank(report.minimumConfidenceForDecision))
+    report.gateReasons.push_back("ranking_confidence_" +
+                                 report.rankingConfidence + "_below_" +
+                                 report.minimumConfidenceForDecision);
+  if (legalCandidateCount > 1 &&
+      report.decision != SimdSimtCandidateKind::AllSIMD &&
+      !(report.decisionAdvantage > report.requiredGainScore))
+    report.gateReasons.push_back("decision_advantage_not_above_required_gain");
+  report.gatePassed = report.gateReasons.empty();
+  return report;
+}
+
+llvm::Expected<SimdSimtCostReport> mlir::ascend::analyzeSimdSimtCandidates(
+    ModuleOp module, const SimdSimtCostModelOptions &options) {
+  if (!module)
+    return llvm::createStringError(std::errc::invalid_argument,
+                                   "cannot analyze a null ModuleOp");
+  SimtAnchorPlan anchorPlan =
+      buildMixedSimtAnchorPlan(module, options.compileOn91095);
+  return analyzeSimdSimtCandidates(module, anchorPlan, options);
+}
+
+llvm::Expected<SimdSimtCostReport> mlir::ascend::analyzeSimdSimtCandidates(
+    ModuleOp module, const SimtAnchorPlan &anchorPlan,
+    const SimdSimtCostModelOptions &options) {
+  auto features = analyzeSimdSimtFeatures(module, anchorPlan);
+  if (!features)
+    return features.takeError();
+  return estimateSimdSimtCandidates(*features, options);
+}

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/SimtAnchorAnalysis.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/SimtAnchorAnalysis.cpp
@@ -1,0 +1,734 @@
+//===- SimtAnchorAnalysis.cpp - Materializable SIMT anchors --------------===//
+
+#include "AscendModel/RouteModel/SimtAnchorAnalysis.h"
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <functional>
+#include <numeric>
+
+using namespace mlir;
+using namespace mlir::ascend;
+
+namespace {
+
+static int64_t getStaticNumElements(RankedTensorType type) {
+  if (!type || !type.hasStaticShape())
+    return 0;
+  return std::accumulate(type.getShape().begin(), type.getShape().end(),
+                         int64_t{1}, std::multiplies<int64_t>());
+}
+
+static std::string getScalarTypeName(Type type) {
+  if (auto tensor = dyn_cast<RankedTensorType>(type))
+    type = tensor.getElementType();
+  if (type.isF16())
+    return "f16";
+  if (type.isBF16())
+    return "bf16";
+  if (type.isF32())
+    return "f32";
+  if (auto integer = dyn_cast<IntegerType>(type))
+    return ("i" + std::to_string(integer.getWidth()));
+  if (type.isIndex())
+    return "index";
+  return "unknown";
+}
+
+static std::optional<PlainCumsumFacts>
+analyzePlainOneDimensionalCumsum(Operation *op) {
+  if (!op || op->getName().getStringRef() != "tt.scan" ||
+      op->getNumOperands() != 1 || op->getNumResults() != 1)
+    return std::nullopt;
+
+  auto axis = op->getAttrOfType<IntegerAttr>("axis");
+  auto sourceType = dyn_cast<RankedTensorType>(op->getOperand(0).getType());
+  if (!axis || !sourceType || !sourceType.hasStaticShape())
+    return std::nullopt;
+
+  int64_t axisValue = axis.getInt();
+  if (axisValue < 0 || axisValue >= sourceType.getRank())
+    return std::nullopt;
+  for (auto [index, extent] : llvm::enumerate(sourceType.getShape()))
+    if (static_cast<int64_t>(index) != axisValue && extent != 1)
+      return std::nullopt;
+
+  int64_t realCombineOps = 0;
+  bool isAdd = false;
+  if (op->getNumRegions() != 1 || op->getRegion(0).empty())
+    return std::nullopt;
+  Block &body = op->getRegion(0).front();
+  Operation *terminator = body.empty() ? nullptr : &body.back();
+  for (Operation &nested : body) {
+    if (&nested == terminator)
+      continue;
+    llvm::StringRef name = nested.getName().getStringRef();
+    if (name == "arith.extf" || name == "arith.truncf" ||
+        name == "arith.bitcast")
+      continue;
+    ++realCombineOps;
+    isAdd = name == "arith.addf" || name == "arith.addi";
+  }
+  if (realCombineOps != 1 || !isAdd || !terminator ||
+      terminator->getName().getStringRef() != "tt.scan.return")
+    return std::nullopt;
+
+  PlainCumsumFacts facts;
+  facts.axisExtent = sourceType.getShape()[axisValue];
+  facts.elementType = getScalarTypeName(sourceType.getElementType());
+  if (auto reverse = op->getAttrOfType<BoolAttr>("reverse"))
+    facts.reverse = reverse.getValue();
+  return facts;
+}
+
+static bool hasTensorPointerOperand(Operation *op) {
+  if (!op || op->getNumOperands() == 0)
+    return false;
+  auto type = dyn_cast<RankedTensorType>(op->getOperand(0).getType());
+  return type && type.hasStaticShape() && type.getRank() <= 5;
+}
+
+static bool pointerDependsOnLoadedIndex(Operation *memoryOp) {
+  if (!memoryOp || memoryOp->getNumOperands() == 0)
+    return false;
+  llvm::SmallVector<Value> worklist{memoryOp->getOperand(0)};
+  llvm::DenseSet<Value> visited;
+
+  while (!worklist.empty()) {
+    Value value = worklist.pop_back_val();
+    if (!visited.insert(value).second)
+      continue;
+
+    if (auto argument = dyn_cast<BlockArgument>(value)) {
+      Operation *parent = argument.getOwner()->getParentOp();
+      unsigned number = argument.getArgNumber();
+      if (parent && parent->getName().getStringRef() == "scf.for" &&
+          number > 0 && number + 2 < parent->getNumOperands()) {
+        worklist.push_back(parent->getOperand(number + 2));
+        Operation *yield = argument.getOwner()->getTerminator();
+        if (yield && number - 1 < yield->getNumOperands())
+          worklist.push_back(yield->getOperand(number - 1));
+      }
+      continue;
+    }
+
+    Operation *producer = value.getDefiningOp();
+    if (!producer)
+      continue;
+    llvm::StringRef name = producer->getName().getStringRef();
+    if (name == "tt.load" || name == "tt.gather")
+      return true;
+    llvm::append_range(worklist, producer->getOperands());
+  }
+  return false;
+}
+
+static Value findPointerOffset(Value pointer) {
+  llvm::SmallVector<Value> worklist{pointer};
+  llvm::DenseSet<Value> visited;
+  while (!worklist.empty()) {
+    Value value = worklist.pop_back_val();
+    if (!visited.insert(value).second)
+      continue;
+    Operation *producer = value.getDefiningOp();
+    if (!producer)
+      continue;
+    if (producer->getName().getStringRef() == "tt.addptr" &&
+        producer->getNumOperands() > 1)
+      return producer->getOperand(1);
+    llvm::append_range(worklist, producer->getOperands());
+  }
+  return {};
+}
+
+static std::optional<double> getStaticMaskActiveFraction(Value mask) {
+  if (!mask)
+    return std::nullopt;
+  Operation *producer = mask.getDefiningOp();
+  if (!producer)
+    return std::nullopt;
+  if (producer->getName().getStringRef() == "arith.constant") {
+    Attribute value = producer->getAttr("value");
+    if (auto dense = dyn_cast_or_null<DenseElementsAttr>(value)) {
+      if (!dense.getElementType().isInteger(1) || dense.getNumElements() == 0)
+        return std::nullopt;
+      int64_t active = 0;
+      for (bool item : dense.getValues<bool>())
+        active += item;
+      return static_cast<double>(active) / dense.getNumElements();
+    }
+    if (auto integer = dyn_cast_or_null<IntegerAttr>(value))
+      return integer.getValue().isZero() ? 0.0 : 1.0;
+  }
+  if (producer->getName().getStringRef() == "tt.splat" &&
+      producer->getNumOperands() == 1)
+    return getStaticMaskActiveFraction(producer->getOperand(0));
+  return std::nullopt;
+}
+
+static std::string getAtomicOperation(Operation *op) {
+  if (op->getName().getStringRef() == "tt.atomic_cas")
+    return "cas";
+  Attribute attribute = op->getAttr("atomic_rmw_op");
+  if (!attribute)
+    return "unknown";
+  if (auto integer = dyn_cast<IntegerAttr>(attribute)) {
+    switch (integer.getInt()) {
+    case 1:
+      return "and";
+    case 2:
+      return "or";
+    case 3:
+      return "xor";
+    case 4:
+      return "add";
+    case 5:
+      return "fadd";
+    case 6:
+      return "max";
+    case 7:
+      return "min";
+    case 8:
+      return "umax";
+    case 9:
+      return "umin";
+    case 10:
+      return "xchg";
+    default:
+      return "unknown";
+    }
+  }
+  std::string text;
+  llvm::raw_string_ostream os(text);
+  attribute.print(os);
+  os.flush();
+  for (char &character : text)
+    character = llvm::toLower(character);
+  for (llvm::StringRef name : {"fadd", "umax", "umin", "xchg", "exch", "and",
+                               "xor", "add", "max", "min", "or"})
+    if (llvm::StringRef(text).contains(name))
+      return name == "exch" ? "xchg" : name.str();
+  return "unknown";
+}
+
+static bool isSupportedCumsumType(llvm::StringRef type) {
+  return type == "i8" || type == "i16" || type == "i32" || type == "f16" ||
+         type == "bf16" || type == "f32";
+}
+
+static bool isSupportedAtomicType(llvm::StringRef type,
+                                  llvm::StringRef operation) {
+  if (operation == "and" || operation == "or" || operation == "xor")
+    return type == "i32" || type == "i64";
+  if (operation == "xchg" || operation == "cas")
+    return type == "i32" || type == "i64" || type == "f32";
+  if (operation == "add" || operation == "fadd" || operation == "max" ||
+      operation == "min" || operation == "umax" || operation == "umin")
+    return type == "i32" || type == "i64" || type == "f16" || type == "bf16" ||
+           type == "f32";
+  return false;
+}
+
+static bool isTriangularSolveLoop(Operation *op) {
+  if (!op || op->getName().getStringRef() != "scf.for" ||
+      op->getNumRegions() != 1 || op->getRegion(0).empty())
+    return false;
+
+  bool hasVectorLoad = false;
+  bool hasAxisZeroReduce = false;
+  bool hasMaskedUpdate = false;
+  Block &body = op->getRegion(0).front();
+  body.walk([&](Operation *nested) {
+    llvm::StringRef name = nested->getName().getStringRef();
+    if (name == "tt.load" && nested->getNumResults() == 1) {
+      if (auto type =
+              dyn_cast<RankedTensorType>(nested->getResult(0).getType()))
+        hasVectorLoad |= type.hasStaticShape() && type.getRank() == 1 &&
+                         type.getShape()[0] == 16;
+    } else if (name == "tt.reduce") {
+      auto axis = nested->getAttrOfType<IntegerAttr>("axis");
+      hasAxisZeroReduce |= axis && axis.getInt() == 0;
+    } else if (name == "arith.select") {
+      hasMaskedUpdate = true;
+    }
+  });
+  if (!hasVectorLoad || !hasAxisZeroReduce || !hasMaskedUpdate)
+    return false;
+
+  // The production solve_tril kernel has one block-update loop.  Its
+  // iter_args carry the 16x16 triangular state; requiring that fixed state
+  // shape keeps this single-loop form distinct from a generic vector reduce.
+  bool hasTriangularState = false;
+  for (BlockArgument argument : body.getArguments()) {
+    if (auto type = dyn_cast<RankedTensorType>(argument.getType()))
+      hasTriangularState |= type.hasStaticShape() && type.getRank() == 2 &&
+                            type.getShape()[0] == 16 &&
+                            type.getShape()[1] == 16;
+  }
+
+  // Multi-loop lowering variants use two or more sibling block-update loops;
+  // retain that form for kernels whose state shape is not explicit in the
+  // loop arguments.
+  Block *parentBlock = op->getBlock();
+  if (!parentBlock)
+    return false;
+  unsigned siblingMatches = 0;
+  for (Operation &sibling : *parentBlock) {
+    if (&sibling == op || sibling.getName().getStringRef() != "scf.for")
+      continue;
+    bool siblingLoad = false;
+    bool siblingReduce = false;
+    bool siblingSelect = false;
+    sibling.walk([&](Operation *nested) {
+      llvm::StringRef name = nested->getName().getStringRef();
+      if (name == "tt.load" && nested->getNumResults() == 1)
+        if (auto type =
+                dyn_cast<RankedTensorType>(nested->getResult(0).getType()))
+          siblingLoad |= type.hasStaticShape() && type.getRank() == 1 &&
+                         type.getShape()[0] == 16;
+      siblingReduce |= name == "tt.reduce";
+      siblingSelect |= name == "arith.select";
+    });
+    siblingMatches += siblingLoad && siblingReduce && siblingSelect;
+  }
+  return hasTriangularState || siblingMatches >= 1;
+}
+
+static bool isMovableTriangularTensorSetup(Operation *op) {
+  if (!op || op->getNumResults() == 0 || op->getNumRegions() != 0)
+    return false;
+  if (!llvm::all_of(op->getResultTypes(),
+                    [](Type type) { return isa<RankedTensorType>(type); }))
+    return false;
+  llvm::StringRef name = op->getName().getStringRef();
+  // Triton hoists both integer offset splats and floating-point zero splats
+  // out of a hand-written scope. Keep all arith.constant ops as captures so
+  // the automatically materialized scope has the same boundary contract.
+  return name == "tt.make_range" || name == "tt.expand_dims" ||
+         name == "tt.broadcast" || name == "tt.splat" || name == "arith.cmpi" ||
+         name == "arith.cmpf" || name == "arith.andi" || name == "arith.ori" ||
+         name == "arith.xori" || name == "arith.addi" || name == "arith.subi" ||
+         name == "arith.muli" || name == "arith.index_cast";
+}
+
+static Operation *getTopLevelOwnerInBlock(Operation *op, Block *block) {
+  while (op && op->getBlock() != block)
+    op = op->getParentOp();
+  return op;
+}
+
+/// Return the exact TTIR operations represented by the hand-written
+/// triangular-solve scope. The four 16x16 input loads stay outside. Pure
+/// ranked-tensor mask setup is moved after those loads, then the sibling
+/// recurrences and final diagonal updates execute inside the scope. The dense
+/// tt.dot tail remains outside. Keeping this in analysis makes the plan
+/// authoritative; the materializer must not rediscover a different set.
+static llvm::SmallVector<Operation *, 0>
+collectTriangularSolveScopeOperations(Operation *anchor,
+                                      Operation *&insertionPoint) {
+  llvm::SmallVector<Operation *, 0> result;
+  insertionPoint = nullptr;
+  if (!isTriangularSolveLoop(anchor) || !anchor->getBlock())
+    return result;
+
+  Block *block = anchor->getBlock();
+  Operation *firstLoop = nullptr;
+  Operation *lastLoop = nullptr;
+  for (Operation &nested : *block) {
+    if (!isTriangularSolveLoop(&nested))
+      continue;
+    if (!firstLoop)
+      firstLoop = &nested;
+    lastLoop = &nested;
+  }
+  if (!firstLoop || !lastLoop)
+    return result;
+
+  Operation *lastInputLoad = nullptr;
+  Operation *cursor = firstLoop->getPrevNode();
+  while (cursor && cursor->getName().getStringRef() != "tt.load")
+    cursor = cursor->getPrevNode();
+  if (cursor)
+    lastInputLoad = cursor;
+  Operation *start = lastInputLoad ? lastInputLoad->getNextNode() : firstLoop;
+  insertionPoint = start;
+
+  Operation *end = lastLoop;
+  cursor = lastLoop->getNextNode();
+  while (cursor) {
+    llvm::StringRef name = cursor->getName().getStringRef();
+    if (name != "arith.uitofp" && name != "arith.addf" &&
+        name != "arith.select")
+      break;
+    end = cursor;
+    cursor = cursor->getNextNode();
+  }
+
+  llvm::SmallVector<Operation *, 0> recurrenceRange;
+  llvm::DenseSet<Operation *> selected;
+  for (Operation *op = start; op; op = op->getNextNode()) {
+    recurrenceRange.push_back(op);
+    selected.insert(op);
+    if (op == end)
+      break;
+  }
+  if (recurrenceRange.empty() || recurrenceRange.back() != end)
+    return {};
+
+  // In the unscope source, o_i/m_A/m_I are constructed before the initial
+  // block loads. The hand-written scope constructs them after the loads.
+  // Pull in only a side-effect-free ranked-tensor backward slice whose uses
+  // are entirely inside the selected scope; scalar/pointer setup and all
+  // memory operations remain captures outside.
+  llvm::DenseSet<Operation *> setupCandidates;
+  llvm::SmallVector<Value, 16> worklist;
+  for (Operation *op : recurrenceRange) {
+    llvm::append_range(worklist, op->getOperands());
+    op->walk([&](Operation *nested) {
+      if (nested != op)
+        llvm::append_range(worklist, nested->getOperands());
+    });
+  }
+  while (!worklist.empty()) {
+    Value value = worklist.pop_back_val();
+    Operation *definingOp = value.getDefiningOp();
+    if (!definingOp || definingOp->getBlock() != block ||
+        definingOp == insertionPoint || !lastInputLoad ||
+        !definingOp->isBeforeInBlock(lastInputLoad) ||
+        !isMovableTriangularTensorSetup(definingOp) ||
+        !setupCandidates.insert(definingOp).second)
+      continue;
+    llvm::append_range(worklist, definingOp->getOperands());
+  }
+
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (Operation *candidate : llvm::make_early_inc_range(setupCandidates)) {
+      bool hasOutsideUse =
+          llvm::any_of(candidate->getResults(), [&](Value resultValue) {
+            return llvm::any_of(resultValue.getUses(), [&](OpOperand &use) {
+              Operation *owner = getTopLevelOwnerInBlock(use.getOwner(), block);
+              return !selected.contains(owner) &&
+                     !setupCandidates.contains(owner);
+            });
+          });
+      if (!hasOutsideUse)
+        continue;
+      setupCandidates.erase(candidate);
+      changed = true;
+    }
+  }
+
+  for (Operation &op : *block)
+    if (setupCandidates.contains(&op))
+      result.push_back(&op);
+  llvm::append_range(result, recurrenceRange);
+  return result;
+}
+
+static CandidateLowerability
+simpleMixedLowerability(llvm::StringRef allSimtReason) {
+  CandidateLowerability result;
+  result.allSimtOnly = CandidateLoweringStatus::BackendConditional;
+  result.allSimtOnlyReasons.push_back(allSimtReason.str());
+  return result;
+}
+
+static std::optional<SimtAnchorDescriptor> analyzeAnchor(Operation *op,
+                                                         bool compileOn91095) {
+  if (!op)
+    return std::nullopt;
+  SimtAnchorDescriptor descriptor;
+  descriptor.operation = op;
+  llvm::StringRef name = op->getName().getStringRef();
+
+  if (name == "tt.gather") {
+    descriptor.kind = SimtAnchorKind::DirectGather;
+    descriptor.lowerability = simpleMixedLowerability(
+        "whole_module_pure_simt_requires_backend_check");
+  } else if (name == "tt.histogram") {
+    descriptor.kind = SimtAnchorKind::Histogram;
+    HistogramFacts facts;
+    auto input = op->getNumOperands() > 0
+                     ? dyn_cast<RankedTensorType>(op->getOperand(0).getType())
+                     : RankedTensorType();
+    auto result = op->getNumResults() > 0
+                      ? dyn_cast<RankedTensorType>(op->getResult(0).getType())
+                      : RankedTensorType();
+    facts.inputElements = getStaticNumElements(input);
+    facts.numBins = result && result.hasStaticShape() && result.getRank() == 1
+                        ? result.getShape()[0]
+                        : 0;
+    facts.inputType = input ? getScalarTypeName(input) : "unknown";
+    facts.resultType = result ? getScalarTypeName(result) : "unknown";
+    descriptor.facts = facts;
+    descriptor.lowerability.allSimd = CandidateLoweringStatus::Unsupported;
+    descriptor.lowerability.allSimdReasons.push_back(
+        "ascend950_plain_histogram_aliases_backend_mixed_template");
+    descriptor.lowerability.allSimtOnly = CandidateLoweringStatus::Unsupported;
+    descriptor.lowerability.allSimtOnlyReasons.push_back(
+        "tt.histogram_not_legalized_by_pure_simt_pipeline");
+    bool supported = input && result && input.hasStaticShape() &&
+                     result.hasStaticShape() && input.getRank() == 1 &&
+                     result.getRank() == 1 &&
+                     (facts.inputType == "i8" || facts.inputType == "i16" ||
+                      facts.inputType == "i32" || facts.inputType == "i64") &&
+                     facts.resultType == "i32" && facts.inputElements > 0 &&
+                     facts.numBins > 0;
+    if (!supported) {
+      descriptor.lowerability.mixed = CandidateLoweringStatus::Unsupported;
+      descriptor.lowerability.mixedReasons.push_back(
+          "histogram_requires_static_rank1_integer_input_and_rank1_i32_bins");
+    }
+  } else if (name == "tt.scan") {
+    auto facts = analyzePlainOneDimensionalCumsum(op);
+    if (!facts)
+      return std::nullopt;
+    descriptor.kind = SimtAnchorKind::PlainOneDimensionalCumsum;
+    descriptor.facts = *facts;
+    descriptor.lowerability.allSimd = CandidateLoweringStatus::AliasesMixed;
+    descriptor.lowerability.allSimdReasons.push_back(
+        "ascend950_plain_1d_cumsum_symbol_is_simt_template");
+    descriptor.lowerability.allSimtOnly =
+        CandidateLoweringStatus::BackendConditional;
+    descriptor.lowerability.allSimtOnlyReasons.push_back(
+        "pure_simt_cumsum_requires_whole_module_backend_check");
+    if (facts->axisExtent <= 0 || !isSupportedCumsumType(facts->elementType)) {
+      descriptor.lowerability.mixed = CandidateLoweringStatus::Unsupported;
+      descriptor.lowerability.mixedReasons.push_back(
+          "plain_1d_cumsum_dtype_or_axis_extent_not_supported");
+    } else if (facts->axisExtent <= 64) {
+      descriptor.lowerability.mixedReasons.push_back(
+          "template_uses_small_register_path_without_simt_async_invoke");
+    }
+  } else if (name == "tt.atomic_rmw" || name == "tt.atomic_cas") {
+    descriptor.kind = SimtAnchorKind::TensorAtomic;
+    TensorAtomicFacts facts;
+    auto result = op->getNumResults() > 0
+                      ? dyn_cast<RankedTensorType>(op->getResult(0).getType())
+                      : RankedTensorType();
+    facts.updateElements = getStaticNumElements(result);
+    facts.valueType = result ? getScalarTypeName(result) : "unknown";
+    facts.operation = getAtomicOperation(op);
+    if (op->getNumOperands() > 0) {
+      if (auto pointer =
+              dyn_cast<RankedTensorType>(op->getOperand(0).getType())) {
+        facts.addressRank = pointer.getRank();
+        facts.addressIsLaneVarying = getStaticNumElements(pointer) > 1;
+      }
+      Value offset = findPointerOffset(op->getOperand(0));
+      if (offset) {
+        facts.offsetType = getScalarTypeName(offset.getType());
+        if (auto offsetTensor = dyn_cast<RankedTensorType>(offset.getType()))
+          facts.addressIsLaneVarying |= getStaticNumElements(offsetTensor) > 1;
+      }
+      facts.addressDependsOnLoadedIndex = pointerDependsOnLoadedIndex(op);
+    }
+    facts.hasMask = name == "tt.atomic_rmw" && op->getNumOperands() >= 3;
+    if (facts.hasMask)
+      facts.staticMaskActiveFraction =
+          getStaticMaskActiveFraction(op->getOperand(2));
+    facts.resultUsed = op->getNumResults() > 0 && !op->getResult(0).use_empty();
+    facts.contention = "unknown";
+    descriptor.facts = facts;
+    descriptor.lowerability =
+        simpleMixedLowerability("pure_simt_atomic_requires_backend_check");
+
+    bool supported = result && result.hasStaticShape() &&
+                     facts.updateElements > 0 &&
+                     isSupportedAtomicType(facts.valueType, facts.operation) &&
+                     (facts.offsetType == "i32" || facts.offsetType == "i64");
+    if (facts.resultUsed &&
+        (facts.valueType == "f16" || facts.valueType == "bf16")) {
+      supported = false;
+      descriptor.lowerability.mixedReasons.push_back(
+          "f16_bf16_atomic_old_value_semantics_require_validation");
+    }
+    if (!supported) {
+      descriptor.lowerability.mixed = CandidateLoweringStatus::Unsupported;
+      descriptor.lowerability.mixedReasons.push_back(
+          "atomic_shape_dtype_operation_or_offset_not_supported");
+    }
+  } else if (isTriangularSolveLoop(op)) {
+    descriptor.kind = SimtAnchorKind::TriangularSolveLoop;
+    descriptor.lowerability = simpleMixedLowerability(
+        "pure_simt_triangular_solve_requires_cube_tail_partition");
+    descriptor.lowerability.mixedReasons.push_back(
+        "manual_scope_shape_vector16_masked_reduce_loop");
+  } else if (isLoadedIndexDependentMemoryOp(op)) {
+    descriptor.kind = SimtAnchorKind::LoadedIndexDependentMemory;
+    descriptor.lowerability = simpleMixedLowerability(
+        "whole_module_pure_simt_requires_backend_check");
+  } else {
+    return std::nullopt;
+  }
+
+  descriptor.materializable =
+      compileOn91095 &&
+      descriptor.lowerability.mixed == CandidateLoweringStatus::Native;
+  return descriptor;
+}
+
+static CandidateLoweringStatus
+combineWholeKernelStatus(CandidateLoweringStatus lhs,
+                         CandidateLoweringStatus rhs) {
+  auto rank = [](CandidateLoweringStatus status) {
+    switch (status) {
+    case CandidateLoweringStatus::Native:
+      return 0;
+    case CandidateLoweringStatus::BackendConditional:
+      return 1;
+    case CandidateLoweringStatus::AliasesMixed:
+      return 2;
+    case CandidateLoweringStatus::Unsupported:
+      return 3;
+    }
+    llvm_unreachable("unknown lowering status");
+  };
+  return rank(lhs) >= rank(rhs) ? lhs : rhs;
+}
+
+} // namespace
+
+llvm::StringRef mlir::ascend::stringifySimtAnchorKind(SimtAnchorKind kind) {
+  switch (kind) {
+  case SimtAnchorKind::DirectGather:
+    return "direct_gather";
+  case SimtAnchorKind::LoadedIndexDependentMemory:
+    return "loaded_index_dependent_memory";
+  case SimtAnchorKind::Histogram:
+    return "histogram";
+  case SimtAnchorKind::PlainOneDimensionalCumsum:
+    return "plain_1d_cumsum";
+  case SimtAnchorKind::TensorAtomic:
+    return "tensor_atomic";
+  case SimtAnchorKind::TriangularSolveLoop:
+    return "triangular_solve_loop";
+  }
+  llvm_unreachable("unknown SIMT anchor kind");
+}
+
+llvm::StringRef
+mlir::ascend::stringifyCandidateLoweringStatus(CandidateLoweringStatus status) {
+  switch (status) {
+  case CandidateLoweringStatus::Unsupported:
+    return "unsupported";
+  case CandidateLoweringStatus::Native:
+    return "native";
+  case CandidateLoweringStatus::BackendConditional:
+    return "backend_conditional";
+  case CandidateLoweringStatus::AliasesMixed:
+    return "aliases_mixed";
+  }
+  llvm_unreachable("unknown candidate lowering status");
+}
+
+llvm::SmallVector<Operation *> SimtAnchorPlan::materializableRoots() const {
+  llvm::SmallVector<Operation *> result;
+  result.reserve(anchors.size());
+  for (const SimtAnchorDescriptor &anchor : anchors)
+    if (anchor.materializable)
+      result.push_back(anchor.operation);
+  return result;
+}
+
+int64_t SimtAnchorPlan::materializableCount() const {
+  return llvm::count_if(anchors, [](const SimtAnchorDescriptor &anchor) {
+    return anchor.materializable;
+  });
+}
+
+bool mlir::ascend::isLoadedIndexDependentMemoryOp(Operation *op) {
+  if (!op)
+    return false;
+  llvm::StringRef name = op->getName().getStringRef();
+  return (name == "tt.load" || name == "tt.store") &&
+         hasTensorPointerOperand(op) && pointerDependsOnLoadedIndex(op);
+}
+
+std::optional<SimtAnchorKind>
+mlir::ascend::classifyMixedSimtAnchor(Operation *op) {
+  auto descriptor = analyzeAnchor(op, /*compileOn91095=*/true);
+  return descriptor ? std::optional<SimtAnchorKind>(descriptor->kind)
+                    : std::nullopt;
+}
+
+SimtAnchorPlan mlir::ascend::buildMixedSimtAnchorPlan(ModuleOp module,
+                                                      bool compileOn91095) {
+  SimtAnchorPlan plan;
+  llvm::DenseSet<Operation *> operationsInPlannedScope;
+  module.walk<WalkOrder::PreOrder>([&](Operation *op) {
+    if (operationsInPlannedScope.contains(op))
+      return WalkResult::skip();
+    std::optional<SimtAnchorDescriptor> descriptor =
+        analyzeAnchor(op, compileOn91095);
+    if (!descriptor)
+      return WalkResult::advance();
+
+    if (descriptor->kind == SimtAnchorKind::TriangularSolveLoop) {
+      descriptor->scopeOperations = collectTriangularSolveScopeOperations(
+          op, descriptor->scopeInsertionPoint);
+      if (descriptor->scopeOperations.empty()) {
+        descriptor->materializable = false;
+        descriptor->lowerability.mixed = CandidateLoweringStatus::Unsupported;
+        descriptor->lowerability.mixedReasons.push_back(
+            "triangular_solve_has_no_materializable_scope_operations");
+      }
+    } else {
+      descriptor->scopeOperations.push_back(op);
+      descriptor->scopeInsertionPoint = op;
+    }
+    for (Operation *scopeOperation : descriptor->scopeOperations)
+      operationsInPlannedScope.insert(scopeOperation);
+    plan.anchors.push_back(std::move(*descriptor));
+    return WalkResult::skip();
+  });
+
+  bool anyMixedNative = false;
+  bool mixedBlocked = false;
+  for (const SimtAnchorDescriptor &anchor : plan.anchors) {
+    plan.kernelLowerability.allSimd = combineWholeKernelStatus(
+        plan.kernelLowerability.allSimd, anchor.lowerability.allSimd);
+    plan.kernelLowerability.allSimtOnly = combineWholeKernelStatus(
+        plan.kernelLowerability.allSimtOnly, anchor.lowerability.allSimtOnly);
+    llvm::append_range(plan.kernelLowerability.allSimdReasons,
+                       anchor.lowerability.allSimdReasons);
+    llvm::append_range(plan.kernelLowerability.allSimtOnlyReasons,
+                       anchor.lowerability.allSimtOnlyReasons);
+    if (anchor.lowerability.mixed == CandidateLoweringStatus::Native)
+      anyMixedNative = true;
+    else if (anchor.lowerability.allSimd != CandidateLoweringStatus::Native)
+      mixedBlocked = true;
+    llvm::append_range(plan.kernelLowerability.mixedReasons,
+                       anchor.lowerability.mixedReasons);
+  }
+  if (plan.anchors.empty()) {
+    plan.kernelLowerability.mixed = CandidateLoweringStatus::Unsupported;
+    plan.kernelLowerability.mixedReasons.push_back("no_recognized_simt_anchor");
+  } else if (anyMixedNative && !mixedBlocked) {
+    plan.kernelLowerability.mixed = CandidateLoweringStatus::Native;
+  } else {
+    plan.kernelLowerability.mixed =
+        mixedBlocked ? CandidateLoweringStatus::Unsupported
+                     : CandidateLoweringStatus::BackendConditional;
+  }
+  return plan;
+}
+
+bool mlir::ascend::isMixedSimtAnchor(Operation *op, bool compileOn91095) {
+  auto descriptor = analyzeAnchor(op, compileOn91095);
+  return descriptor && descriptor->materializable;
+}
+
+llvm::SmallVector<Operation *>
+mlir::ascend::collectMixedSimtAnchors(ModuleOp module, bool compileOn91095) {
+  return buildMixedSimtAnchorPlan(module, compileOn91095).materializableRoots();
+}

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/Transforms/MaterializeSimtScopes.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/Transforms/MaterializeSimtScopes.cpp
@@ -1,0 +1,236 @@
+//===- MaterializeSimtScopes.cpp - Materialize local SIMT scopes --------===//
+//
+// Materialization consumes the immutable SimtAnchorPlan produced by the Route
+// Model and creates SSA-safe scope.scope regions.  No per-operation selection
+// marker is written or read.  The compatibility pass below only validates that
+// an admitted mixed decision already carries its local scope contract.
+//
+//===----------------------------------------------------------------------===//
+
+#include "AscendModel/RouteModel/SimtAnchorAnalysis.h"
+#include "AscendModel/RouteModel/SimtSelection.h"
+#include "AscendModel/Transforms/Passes.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <utility>
+
+namespace mlir {
+namespace ascend {
+
+#define GEN_PASS_DEF_MATERIALIZESIMTSCOPESPASS
+#include "AscendModel/Transforms/Passes.h.inc"
+
+namespace {
+
+using namespace simt_selection;
+
+static bool isMaterializable(Operation *op) {
+  return op->getBlock() && !isa<ModuleOp>(op) &&
+         !op->hasTrait<OpTrait::IsIsolatedFromAbove>() &&
+         !op->hasTrait<OpTrait::IsTerminator>() &&
+         op->getName().getStringRef() != "scope.scope" &&
+         op->getName().getStringRef() != "scope.return";
+}
+
+/// Wrap one anchor operation and thread all of its SSA results through
+/// scope.return.
+///
+/// Scope regions are not isolated from above, so operands remain legal
+/// captures.  Moving only the planned operation keeps SIMD producers and
+/// consumers outside the SIMT region.
+static LogicalResult wrapAnchorOperation(Operation *op) {
+  OpBuilder builder(op);
+  OperationState scopeState(op->getLoc(), "scope.scope");
+  scopeState.addTypes(op->getResultTypes());
+  scopeState.addAttribute(kVectorModeAttr, builder.getStringAttr("simt"));
+  scopeState.addRegion();
+  Operation *scopeOp = builder.create(scopeState);
+
+  Region &scopeRegion = scopeOp->getRegion(0);
+  auto *scopeBody = new Block();
+  scopeRegion.push_back(scopeBody);
+
+  SmallVector<Value> originalResults(op->getResults());
+  op->moveBefore(scopeBody, scopeBody->end());
+
+  OpBuilder bodyBuilder = OpBuilder::atBlockEnd(scopeBody);
+  OperationState returnState(op->getLoc(), "scope.return");
+  returnState.addOperands(originalResults);
+  Operation *returnOp = bodyBuilder.create(returnState);
+
+  if (scopeOp->getNumResults() != originalResults.size())
+    return op->emitError("SIMT scope result count does not match anchor op");
+
+  for (auto [original, replacement] :
+       llvm::zip_equal(originalResults, scopeOp->getResults())) {
+    original.replaceAllUsesExcept(replacement, returnOp);
+  }
+  return success();
+}
+
+/// Wrap an exact planned operation set and thread only values that escape it.
+/// `insertionPoint` lets solve_tril move pure mask setup across the initial
+/// loads while keeping those loads outside, matching the hand-written scope.
+static LogicalResult wrapAnchorRange(ArrayRef<Operation *> ops,
+                                     Operation *insertionPoint) {
+  if (ops.empty())
+    return success();
+  Block *parent = insertionPoint ? insertionPoint->getBlock() : nullptr;
+  if (!parent)
+    return failure();
+
+  DenseSet<Operation *> planned;
+  for (Operation *op : ops) {
+    if (!op || op->getBlock() != parent || !isMaterializable(op))
+      return failure();
+    planned.insert(op);
+  }
+
+  auto isInsideRange = [&](Operation *user) {
+    for (Operation *owner = user; owner; owner = owner->getParentOp())
+      if (planned.contains(owner))
+        return true;
+    return false;
+  };
+
+  SmallVector<Value> escaping;
+  DenseSet<Value> seen;
+  for (Operation *op : ops)
+    for (Value result : op->getResults())
+      for (OpOperand &use : result.getUses())
+        if (!isInsideRange(use.getOwner()) && seen.insert(result).second) {
+          escaping.push_back(result);
+          break;
+        }
+
+  OpBuilder builder(insertionPoint);
+  OperationState scopeState(insertionPoint->getLoc(), "scope.scope");
+  SmallVector<Type> escapingTypes;
+  escapingTypes.reserve(escaping.size());
+  for (Value value : escaping)
+    escapingTypes.push_back(value.getType());
+  scopeState.addTypes(escapingTypes);
+  scopeState.addAttribute(kVectorModeAttr, builder.getStringAttr("simt"));
+  scopeState.addRegion();
+  Operation *scopeOp = builder.create(scopeState);
+
+  Region &scopeRegion = scopeOp->getRegion(0);
+  auto *scopeBody = new Block();
+  scopeRegion.push_back(scopeBody);
+  for (Operation *op : ops)
+    op->moveBefore(scopeBody, scopeBody->end());
+
+  OpBuilder bodyBuilder = OpBuilder::atBlockEnd(scopeBody);
+  OperationState returnState(insertionPoint->getLoc(), "scope.return");
+  returnState.addOperands(escaping);
+  Operation *returnOp = bodyBuilder.create(returnState);
+
+  if (scopeOp->getNumResults() != escaping.size())
+    return failure();
+  for (auto [original, replacement] :
+       llvm::zip_equal(escaping, scopeOp->getResults())) {
+    for (OpOperand &use : llvm::make_early_inc_range(original.getUses()))
+      if (use.getOwner() != returnOp && !isInsideRange(use.getOwner()))
+        use.set(replacement);
+  }
+  return success();
+}
+
+} // namespace
+
+LogicalResult materializeSimtAnchorPlan(ModuleOp module,
+                                        const SimtAnchorPlan &plan) {
+  struct PlannedRange {
+    SmallVector<Operation *> operations;
+    Operation *insertionPoint = nullptr;
+  };
+  SmallVector<Operation *> anchorOps;
+  SmallVector<PlannedRange> anchorRanges;
+  DenseSet<Operation *> coveredByRange;
+
+  for (const SimtAnchorDescriptor &anchor : plan.anchors) {
+    Operation *op = anchor.operation;
+    if (!anchor.materializable || !op || coveredByRange.contains(op))
+      continue;
+    if (hasEnclosingVectorMode(op, "simt"))
+      continue;
+
+    if (anchor.scopeOperations.size() > 1) {
+      for (Operation *rangeOp : anchor.scopeOperations)
+        coveredByRange.insert(rangeOp);
+      PlannedRange range;
+      llvm::append_range(range.operations, anchor.scopeOperations);
+      range.insertionPoint = anchor.scopeInsertionPoint;
+      anchorRanges.push_back(std::move(range));
+      continue;
+    }
+
+    if (!isMaterializable(op))
+      return op->emitError(
+          "SIMT anchor is not materializable as a local scope");
+    anchorOps.push_back(op);
+  }
+
+  int64_t materialized = 0;
+  for (const PlannedRange &range : anchorRanges) {
+    if (failed(wrapAnchorRange(range.operations, range.insertionPoint)))
+      return failure();
+    ++materialized;
+  }
+  for (Operation *op : anchorOps) {
+    if (failed(wrapAnchorOperation(op)))
+      return failure();
+    ++materialized;
+  }
+
+  if (materialized == 0)
+    return module.emitError(
+        "mixed_simd_simt has no materializable local SIMT scope");
+  return success();
+}
+
+namespace {
+
+static bool containsLocalSimtScope(ModuleOp module) {
+  bool found = false;
+  module.walk([&](Operation *op) {
+    if (op->getName().getStringRef() != "scope.scope")
+      return WalkResult::advance();
+    auto mode = getVectorMode(op);
+    if (!mode || mode.getValue() != "simt")
+      return WalkResult::advance();
+    found = true;
+    return WalkResult::interrupt();
+  });
+  return found;
+}
+
+struct MaterializeSimtScopesPass
+    : public impl::MaterializeSimtScopesPassBase<MaterializeSimtScopesPass> {
+  using MaterializeSimtScopesPassBase::MaterializeSimtScopesPassBase;
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    if (!isMixedModelDecision(module))
+      return;
+    if (containsLocalSimtScope(module))
+      return;
+    module.emitError(
+        "mixed_simd_simt requires a materialized scope.scope<simt> contract");
+    signalPassFailure();
+  }
+};
+
+} // namespace
+} // namespace ascend
+} // namespace mlir

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/Transforms/SelectSimdSimtCostModel.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/Transforms/SelectSimdSimtCostModel.cpp
@@ -1,0 +1,225 @@
+//===- SelectSimdSimtCostModel.cpp - C++ SIMD/SIMT selection ------------===//
+//
+// This pass is the online owner of SIMD/SIMT candidate selection.  Python
+// only schedules the pass and reacts to its machine-readable execution intent.
+// Feature extraction, calibrated scoring, confidence/target/margin gates, and
+// mixed-operation planning stay in C++.
+//
+//===----------------------------------------------------------------------===//
+
+#include "AscendModel/RouteModel/SimdSimtCostModel.h"
+#include "AscendModel/RouteModel/SimtAnchorAnalysis.h"
+#include "AscendModel/RouteModel/SimtSelection.h"
+#include "AscendModel/Transforms/Passes.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <system_error>
+
+namespace mlir {
+namespace ascend {
+
+#define GEN_PASS_DEF_SELECTSIMDSIMTCOSTMODELPASS
+#include "AscendModel/Transforms/Passes.h.inc"
+
+namespace {
+
+using namespace simt_selection;
+
+inline constexpr llvm::StringLiteral kRecommendedExecutionAttr =
+    "ascend.simt_costmodel.recommended";
+inline constexpr llvm::StringLiteral kSelectionSourceAttr =
+    "ascend.simt_costmodel.selection_source";
+inline constexpr llvm::StringLiteral kRankingConfidenceAttr =
+    "ascend.simt_costmodel.ranking_confidence";
+inline constexpr llvm::StringLiteral kAllSimdScoreAttr =
+    "ascend.simt_costmodel.all_simd_score";
+inline constexpr llvm::StringLiteral kAllSimtScoreAttr =
+    "ascend.simt_costmodel.all_simt_score";
+inline constexpr llvm::StringLiteral kMixedScoreAttr =
+    "ascend.simt_costmodel.mixed_score";
+inline constexpr llvm::StringLiteral kReportJSONAttr =
+    "ascend.simt_costmodel.report_json";
+
+static bool containsExplicitVectorScope(ModuleOp module) {
+  bool found = false;
+  module.walk([&](Operation *op) {
+    if (op->getName().getStringRef() == "scope.scope") {
+      found = true;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return found;
+}
+
+static void clearPreviousSelection(ModuleOp module) {
+  module->removeAttr(kEffectiveExecutionAttr);
+  module->removeAttr(kRecommendedExecutionAttr);
+  module->removeAttr(kSelectionSourceAttr);
+  module->removeAttr(kRankingConfidenceAttr);
+  module->removeAttr(kAllSimdScoreAttr);
+  module->removeAttr(kAllSimtScoreAttr);
+  module->removeAttr(kMixedScoreAttr);
+  module->removeAttr(kReportJSONAttr);
+}
+
+static LogicalResult appendJSONLine(llvm::StringRef path,
+                                    llvm::StringRef json) {
+  if (path.empty())
+    return success();
+  std::error_code error;
+  llvm::raw_fd_ostream os(path, error, llvm::sys::fs::OF_Append);
+  if (error)
+    return failure();
+  os << json << '\n';
+  return success();
+}
+
+struct SelectSimdSimtCostModelPass
+    : public impl::SelectSimdSimtCostModelPassBase<
+          SelectSimdSimtCostModelPass> {
+  using SelectSimdSimtCostModelPassBase::SelectSimdSimtCostModelPassBase;
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    clearPreviousSelection(module);
+    bool autoMode = mode.getValue() == "auto";
+
+    SimdSimtCostModelOptions options;
+    options.profilePath = profilePath.getValue();
+    options.actualTarget = actualTarget.getValue();
+    options.numWarps =
+        static_cast<unsigned>(std::max<int64_t>(1, numWarps.getValue()));
+    options.marginRatio = std::max(0.0, std::min(1.0, marginRatio.getValue()));
+    options.includeFeaturesInJSON = true;
+    options.scoreOutsideCalibrationCoverage = !autoMode;
+    options.compileOn91095 = compileOn91095.getValue();
+
+    SimtAnchorPlan anchorPlan =
+        buildMixedSimtAnchorPlan(module, options.compileOn91095);
+    auto reportOr = analyzeSimdSimtCandidates(module, anchorPlan, options);
+    if (!reportOr) {
+      module.emitError("C++ SIMD/SIMT cost model failed: ")
+          << llvm::toString(reportOr.takeError());
+      signalPassFailure();
+      return;
+    }
+    SimdSimtCostReport report = std::move(*reportOr);
+
+    std::string recommended =
+        report.candidateCostsEvaluated
+            ? stringifySimdSimtCandidate(report.decision).str()
+            : kBackendDefault.str();
+    std::string effective = kBackendDefault.str();
+    std::string selectionSource = "backend_default";
+    std::string applicationReason;
+    SmallVector<Operation *> mixedAnchors;
+
+    bool actionSupported = true;
+    bool hasExplicitScope = containsExplicitVectorScope(module);
+    if (recommended == kMixedSimdSimt) {
+      if (hasExplicitScope) {
+        actionSupported = false;
+        applicationReason = "explicit_scope_present";
+      } else {
+        mixedAnchors = anchorPlan.materializableRoots();
+        if (mixedAnchors.empty()) {
+          actionSupported = false;
+          applicationReason = "no_materializable_mixed_anchor";
+        }
+      }
+    } else if (recommended == kAllSimtOnly && hasExplicitScope) {
+      // Preserve explicit local SIMD/SIMT/cube scope semantics instead of
+      // replacing the whole kernel with a pure-SIMT route.
+      actionSupported = false;
+      applicationReason = "explicit_scope_present";
+    }
+
+    const bool onlyInsufficientGain =
+        report.gateReasons.size() == 1 &&
+        report.gateReasons.front() ==
+            "decision_advantage_not_above_required_gain";
+    if (autoMode && report.gatePassed && actionSupported) {
+      effective = recommended;
+      selectionSource = "cpp_cost_model";
+      applicationReason = "cpp_cost_model_admitted";
+    } else if (autoMode && onlyInsufficientGain &&
+               report.allSimdCandidateLegal) {
+      // A failed switch-margin check means "do not leave the established
+      // baseline", not "hand control back to legacy backend heuristics".
+      // Keeping all-SIMD here avoids accidentally taking the historical
+      // compile_mode=simd_simt force path after the model rejected a marginal
+      // SIMT/mixed recommendation.
+      effective = kAllSimd.str();
+      selectionSource = "cpp_cost_model_safe_baseline";
+      applicationReason = "decision_gain_below_margin_keep_all_simd";
+    } else if (!autoMode) {
+      applicationReason = "report_mode";
+    } else if (!report.gatePassed) {
+      applicationReason = report.gateReasons.empty()
+                              ? "model_gate_rejected"
+                              : report.gateReasons.front();
+    }
+
+    Builder builder(module.getContext());
+    module->setAttr(kRecommendedExecutionAttr,
+                    builder.getStringAttr(recommended));
+    module->setAttr(kEffectiveExecutionAttr, builder.getStringAttr(effective));
+    module->setAttr(kSelectionSourceAttr,
+                    builder.getStringAttr(selectionSource));
+    module->setAttr(kRankingConfidenceAttr,
+                    builder.getStringAttr(report.rankingConfidence));
+    if (report.candidateCostsEvaluated) {
+      module->setAttr(kAllSimdScoreAttr,
+                      builder.getF64FloatAttr(report.candidateCosts.allSimd));
+      module->setAttr(
+          kAllSimtScoreAttr,
+          builder.getF64FloatAttr(report.candidateCosts.allSimtOnly));
+      module->setAttr(
+          kMixedScoreAttr,
+          builder.getF64FloatAttr(report.candidateCosts.mixedSimdSimt));
+    }
+
+    // Selector and Materializer consume the same immutable anchor plan in one
+    // pass invocation.  No per-operation marker is persisted in TTIR.
+    if (effective == kMixedSimdSimt &&
+        failed(materializeSimtAnchorPlan(module, anchorPlan))) {
+      signalPassFailure();
+      return;
+    }
+
+    llvm::json::Object reportJSON = report.toJSON();
+    reportJSON["mode"] = mode.getValue();
+    reportJSON["recommended_decision_kind"] = recommended;
+    reportJSON["effective_decision_kind"] = effective;
+    reportJSON["selection_source"] = selectionSource;
+    reportJSON["application_reason"] = applicationReason;
+    reportJSON["action_supported"] = actionSupported;
+    reportJSON["materialized_simt_anchor_count"] =
+        static_cast<int64_t>(mixedAnchors.size());
+    std::string json =
+        llvm::formatv("{0}", llvm::json::Value(std::move(reportJSON))).str();
+    module->setAttr(kReportJSONAttr, builder.getStringAttr(json));
+
+    if (failed(appendJSONLine(reportFile.getValue(), json)))
+      module.emitWarning("failed to append C++ SIMD/SIMT report to ")
+          << reportFile.getValue();
+  }
+};
+
+} // namespace
+} // namespace ascend
+} // namespace mlir

--- a/third_party/ascend/costmodel/lib/AscendModel/Transforms/CMakeLists.txt
+++ b/third_party/ascend/costmodel/lib/AscendModel/Transforms/CMakeLists.txt
@@ -15,7 +15,9 @@ add_mlir_library(AscendModelTransforms
   LINK_LIBS PUBLIC
   AscendModelIR
   AscendModelAnalysis
+  AscendModelRouteModel
   MLIRIR
+  MLIRFunctionInterfaces
   MLIRPass
   MLIRSupport
   MLIRTransformUtils
@@ -23,6 +25,7 @@ add_mlir_library(AscendModelTransforms
   MLIRArithDialect
   MLIRMathDialect
   MLIRTensorDialect
+  LLVMSupport
 )
 
 # Conditionally link Triton dialect library and add dependency

--- a/third_party/ascend/costmodel/profiles/README.md
+++ b/third_party/ascend/costmodel/profiles/README.md
@@ -1,0 +1,12 @@
+# Ascend Cost Model profiles
+
+This directory is the canonical source for target-specific Cost Model data.
+
+- `microbench/` contains model-neutral hardware measurements shared by the
+  absolute/autotune model and the SIMD/SIMT Route Model.
+- `simd_simt/` contains Route Model policy, calibration, schema, and DES
+  feedback data.
+
+Python packaging copies these files to
+`triton/backends/ascend/costmodel_profiles/`. That installed directory is a
+generated runtime asset location; it is not the source owner of the profiles.

--- a/third_party/ascend/costmodel/profiles/microbench/ascend_davidv100_v1.json
+++ b/third_party/ascend/costmodel/profiles/microbench/ascend_davidv100_v1.json
@@ -1,0 +1,259 @@
+{
+  "$schema": "./microbenchmark_profile_schema.json",
+  "schema_version": 1,
+  "profile_version": "david-v100-shared-microbench-20260730-v2",
+  "target": "Ascend950PR/dav-c310",
+  "description": "Model-neutral target facts and microbenchmark evidence. Model-specific scale, penalties, coverage, gates, and fallback priors are intentionally excluded.",
+  "measurements": {
+    "clock.sys_cnt.frequency_mhz": {
+      "description": "SYS_CNT counter frequency used to convert SYS_CNT cycles to wall-clock time and device-compute cycles.",
+      "value": 988.9,
+      "unit": "MHz",
+      "cycle_domain": "wall_clock",
+      "scope": "device",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/tput.cce; data_provider/build_commands.md",
+      "confidence": "high"
+    },
+    "clock.device_compute.frequency_mhz": {
+      "description": "Device compute clock from the local hardware/simulator configuration. It is not runtime telemetry from the measured A5 board and is used only for conditional clock-domain conversion.",
+      "value": 1650.0,
+      "unit": "MHz",
+      "cycle_domain": "wall_clock",
+      "scope": "device",
+      "source_kind": "device_configuration",
+      "source": "ascend_davidv100.json clock.frequency_ghz",
+      "confidence": "medium"
+    },
+    "simd.vector_width_bits": {
+      "description": "Physical SIMD vector width of one AIV, expressed in bits; FP32 lane count is width_bits / 32.",
+      "value": 2048,
+      "unit": "bit",
+      "cycle_domain": "none",
+      "scope": "single_aiv",
+      "source_kind": "architecture_fact",
+      "source": "Ascend vector ISA width",
+      "confidence": "high"
+    },
+    "simt.warp_size": {
+      "description": "Number of scalar SIMT lanes that execute as one warp.",
+      "value": 32,
+      "unit": "lane",
+      "cycle_domain": "none",
+      "scope": "single_warp",
+      "source_kind": "architecture_fact",
+      "source": "Ascend SIMT execution contract",
+      "confidence": "high"
+    },
+    "simd.f32.add.throughput": {
+      "description": "Effective source-level FP32 SIMD add throughput on one AIV for the tput.cce runtime-loop code shape. The numerator counts source vadd operations; loop/control/codegen overhead remains in elapsed cycles, so this is not a proven bare-ALU issue rate.",
+      "value": 3.30,
+      "unit": "vector_instruction/system_cycle",
+      "cycle_domain": "SYS_CNT",
+      "scope": "single_aiv_runtime_loop_ilp4_or_more_effective_source_vadd",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/tput.cce; data_provider/concur2.cce; data_provider/build_commands.md",
+      "confidence": "high"
+    },
+    "simd.f32.add.dependent_latency": {
+      "description": "Latency of one FP32 SIMD add in a dependent instruction chain on one AIV.",
+      "value": 1.818,
+      "unit": "system_cycle",
+      "cycle_domain": "SYS_CNT",
+      "scope": "single_aiv_dependent_chain",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/tput.cce; data_provider/concur2.cce; data_provider/build_commands.md",
+      "confidence": "high"
+    },
+    "simt.f32.add.throughput": {
+      "description": "Effective source-level FP32 SIMT scalar-add throughput on one AIV for the tput.cce runtime-loop code shape. The numerator counts only source fadd operations while loop increment/compare/branch and codegen overhead remain in elapsed cycles; this is not a proven bare-ALU peak.",
+      "value": 141.0,
+      "unit": "scalar_op/system_cycle",
+      "cycle_domain": "SYS_CNT",
+      "scope": "single_aiv_runtime_loop_ilp8_32_launched_warps_effective_source_fadd",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/tput.cce; data_provider/build_commands.md",
+      "confidence": "high"
+    },
+    "simt.setup.empty": {
+      "description": "Back-to-back async_invoke enqueue/launch-issue slope without a per-iteration barrier. The end counter is read before the final completion barrier, so this is not a completed empty-VF latency.",
+      "value": 115.0,
+      "unit": "system_cycle",
+      "cycle_domain": "SYS_CNT",
+      "scope": "single_aiv_empty_vf_enqueue_slope_no_per_iteration_barrier",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/meas.cce; data_provider/build_commands.md",
+      "confidence": "medium"
+    },
+    "simt.setup.empty_with_barrier": {
+      "description": "Serialized empty-VF completion proxy with a per-iteration PIPE_ALL barrier. It includes async_invoke, one thread(0,0) UB write, barrier, and runtime-loop control; it is not a pure barrier or SIMD/SIMT transition latency.",
+      "value": 141.0,
+      "unit": "system_cycle",
+      "cycle_domain": "SYS_CNT",
+      "scope": "single_aiv_serialized_empty_vf_with_per_iteration_barrier",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/meas.cce; data_provider/build_commands.md",
+      "confidence": "medium"
+    },
+    "simt.shuffle.throughput": {
+      "description": "Effective source-level FP32 shfl-up rate for the stated 32-warp ILP4 runtime-loop workload. Loop/control and sink overhead remain in elapsed cycles; this is not an intrinsic shuffle-pipeline peak.",
+      "value": 0.817124,
+      "unit": "warp_instruction/system_cycle",
+      "cycle_domain": "SYS_CNT",
+      "scope": "single_aiv_fp32_shfl_up_32_warps_ilp4_four_independent_chains",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/simt_shuffle.cce; data_provider/simt_shuffle_host.cpp; triton_cases/SIMT_Test/simt_shuffle_david_v100_20260725.csv; data_provider/build_commands.md",
+      "confidence": "medium"
+    },
+    "simt.shuffle.dependent_latency": {
+      "description": "Effective FP32 dependent shfl-up chain iteration cost for the stated one-warp runtime-loop workload. It includes loop/control overhead and is not an isolated intrinsic latency.",
+      "value": 27.284375,
+      "unit": "system_cycle",
+      "cycle_domain": "SYS_CNT",
+      "scope": "single_aiv_fp32_shfl_up_1_warp_dependent_chain",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/simt_shuffle.cce; data_provider/simt_shuffle_host.cpp; triton_cases/SIMT_Test/simt_shuffle_david_v100_20260725.csv; data_provider/build_commands.md",
+      "confidence": "medium"
+    },
+    "simt.gm.load.throughput": {
+      "description": "Effective source GM-load rate for the stated 32-warp sequential rotating runtime-loop workload. Address generation, loop/control and the source sink remain in elapsed cycles; this is not an intrinsic LSU issue peak.",
+      "value": 0.1761917890625,
+      "unit": "warp_instruction/system_cycle",
+      "cycle_domain": "SYS_CNT",
+      "scope": "single_aiv_32_warps_sequential_128mib_rotating_8_independent_ops_per_thread",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/simt_gm_memory.cce; data_provider/simt_gm_memory_host.cpp; triton_cases/SIMT_Test/simt_gm_memory_david_v100_20260725.csv; data_provider/build_commands.md",
+      "confidence": "medium"
+    },
+    "simt.gm.store.throughput": {
+      "description": "Effective source GM-store rate for the stated 32-warp sequential rotating runtime-loop workload. Address generation, value construction and loop/control remain in elapsed cycles; this is not an intrinsic LSU issue peak.",
+      "value": 0.12914221875,
+      "unit": "warp_instruction/system_cycle",
+      "cycle_domain": "SYS_CNT",
+      "scope": "single_aiv_32_warps_sequential_128mib_rotating_8_independent_ops_per_thread",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/simt_gm_memory.cce; data_provider/simt_gm_memory_host.cpp; triton_cases/SIMT_Test/simt_gm_memory_david_v100_20260725.csv; data_provider/build_commands.md",
+      "confidence": "medium"
+    },
+    "simt.gm.load.bandwidth": {
+      "description": "Effective single-AIV GM-load byte bandwidth for the stated workload; this is not whole-device theoretical HBM peak bandwidth.",
+      "value": 22.552549,
+      "unit": "byte/system_cycle",
+      "cycle_domain": "SYS_CNT",
+      "scope": "single_aiv_32_warps_sequential_128mib_rotating_8_independent_ops_per_thread",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/simt_gm_memory.cce; data_provider/simt_gm_memory_host.cpp; triton_cases/SIMT_Test/simt_gm_memory_david_v100_20260725.csv; data_provider/build_commands.md",
+      "confidence": "medium"
+    },
+    "simt.gm.store.bandwidth": {
+      "description": "Effective single-AIV GM-store byte bandwidth for the stated workload; this is not whole-device theoretical HBM peak bandwidth.",
+      "value": 16.530204,
+      "unit": "byte/system_cycle",
+      "cycle_domain": "SYS_CNT",
+      "scope": "single_aiv_32_warps_sequential_128mib_rotating_8_independent_ops_per_thread",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/simt_gm_memory.cce; data_provider/simt_gm_memory_host.cpp; triton_cases/SIMT_Test/simt_gm_memory_david_v100_20260725.csv; data_provider/build_commands.md",
+      "confidence": "medium"
+    },
+    "simt.ub.load.throughput": {
+      "description": "Effective source UB-load rate for the stated 32-warp rotating-set runtime-loop workload. Address, ALU and loop/control overhead remain in elapsed cycles.",
+      "value": 0.5073532265625,
+      "unit": "warp_instruction/system_cycle",
+      "cycle_domain": "SYS_CNT",
+      "scope": "single_aiv_32_warps_128kib_4_rotating_sets_8_independent_ops_per_thread",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/simt_memory.cce; data_provider/simt_memory_host.cpp; triton_cases/SIMT_Test/simt_memory_david_v100_20260725.csv; data_provider/build_commands.md",
+      "confidence": "medium"
+    },
+    "simt.ub.store.throughput": {
+      "description": "Effective source UB-store rate for the stated 32-warp rotating-set runtime-loop workload. Address, ALU and loop/control overhead remain in elapsed cycles.",
+      "value": 0.5301766328125,
+      "unit": "warp_instruction/system_cycle",
+      "cycle_domain": "SYS_CNT",
+      "scope": "single_aiv_32_warps_128kib_4_rotating_sets_8_independent_ops_per_thread",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/simt_memory.cce; data_provider/simt_memory_host.cpp; triton_cases/SIMT_Test/simt_memory_david_v100_20260725.csv; data_provider/build_commands.md",
+      "confidence": "medium"
+    },
+    "simt.ub.load.bandwidth": {
+      "description": "Effective single-AIV UB-load byte bandwidth for the stated workload.",
+      "value": 64.941213,
+      "unit": "byte/system_cycle",
+      "cycle_domain": "SYS_CNT",
+      "scope": "single_aiv_32_warps_128kib_4_rotating_sets_8_independent_ops_per_thread",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/simt_memory.cce; data_provider/simt_memory_host.cpp; triton_cases/SIMT_Test/simt_memory_david_v100_20260725.csv; data_provider/build_commands.md",
+      "confidence": "medium"
+    },
+    "simt.ub.store.bandwidth": {
+      "description": "Effective single-AIV UB-store byte bandwidth for the stated workload.",
+      "value": 67.862609,
+      "unit": "byte/system_cycle",
+      "cycle_domain": "SYS_CNT",
+      "scope": "single_aiv_32_warps_128kib_4_rotating_sets_8_independent_ops_per_thread",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/simt_memory.cce; data_provider/simt_memory_host.cpp; triton_cases/SIMT_Test/simt_memory_david_v100_20260725.csv; data_provider/build_commands.md",
+      "confidence": "medium"
+    },
+    "simt.setup.transition_harness_net.warps_1": {
+      "description": "Standalone serialized empty-VF net setup proxy from the branch-heavy transition harness for one launched warp. It is mode1 minus barrier-only mode6 and does not contain a SIMD phase, so it is neither a mixed transition nor a dependent handoff latency.",
+      "value": 182.0,
+      "unit": "system_cycle",
+      "cycle_domain": "SYS_CNT",
+      "scope": "single_aiv_transition_harness_standalone_empty_vf_net_1_warp",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/transition.cce; data_provider/transition_host.cpp; triton_cases/SIMT_Test/run_transition.remote.sh; data_provider/build_commands.md",
+      "confidence": "low"
+    },
+    "simt.setup.transition_harness_net.warps_2": {
+      "description": "Standalone serialized empty-VF net setup proxy from the branch-heavy transition harness for two launched warps. It is mode1 minus barrier-only mode6 and does not contain a SIMD phase, so it is neither a mixed transition nor a dependent handoff latency.",
+      "value": 182.0,
+      "unit": "system_cycle",
+      "cycle_domain": "SYS_CNT",
+      "scope": "single_aiv_transition_harness_standalone_empty_vf_net_2_warps",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/transition.cce; data_provider/transition_host.cpp; triton_cases/SIMT_Test/run_transition.remote.sh; data_provider/build_commands.md",
+      "confidence": "low"
+    },
+    "simt.setup.transition_harness_net.warps_4": {
+      "description": "Standalone serialized empty-VF net setup proxy from the branch-heavy transition harness for four launched warps. It is mode1 minus barrier-only mode6 and does not contain a SIMD phase, so it is neither a mixed transition nor a dependent handoff latency.",
+      "value": 182.0,
+      "unit": "system_cycle",
+      "cycle_domain": "SYS_CNT",
+      "scope": "single_aiv_transition_harness_standalone_empty_vf_net_4_warps",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/transition.cce; data_provider/transition_host.cpp; triton_cases/SIMT_Test/run_transition.remote.sh; data_provider/build_commands.md",
+      "confidence": "low"
+    },
+    "simt.setup.transition_harness_net.warps_8": {
+      "description": "Standalone serialized empty-VF net setup proxy from the branch-heavy transition harness for eight launched warps. It is mode1 minus barrier-only mode6 and does not contain a SIMD phase, so it is neither a mixed transition nor a dependent handoff latency.",
+      "value": 182.0,
+      "unit": "system_cycle",
+      "cycle_domain": "SYS_CNT",
+      "scope": "single_aiv_transition_harness_standalone_empty_vf_net_8_warps",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/transition.cce; data_provider/transition_host.cpp; triton_cases/SIMT_Test/run_transition.remote.sh; data_provider/build_commands.md",
+      "confidence": "low"
+    },
+    "simt.setup.transition_harness_net.warps_16": {
+      "description": "Standalone serialized empty-VF net setup proxy from the branch-heavy transition harness for sixteen launched warps. It is mode1 minus barrier-only mode6 and does not contain a SIMD phase, so it is neither a mixed transition nor a dependent handoff latency.",
+      "value": 182.0,
+      "unit": "system_cycle",
+      "cycle_domain": "SYS_CNT",
+      "scope": "single_aiv_transition_harness_standalone_empty_vf_net_16_warps",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/transition.cce; data_provider/transition_host.cpp; triton_cases/SIMT_Test/run_transition.remote.sh; data_provider/build_commands.md",
+      "confidence": "low"
+    },
+    "simt.setup.transition_harness_net.warps_32": {
+      "description": "Standalone serialized empty-VF net setup proxy from the branch-heavy transition harness for thirty-two launched warps. It is mode1 minus barrier-only mode6 and does not contain a SIMD phase, so it is neither a mixed transition nor a dependent handoff latency.",
+      "value": 223.0,
+      "unit": "system_cycle",
+      "cycle_domain": "SYS_CNT",
+      "scope": "single_aiv_transition_harness_standalone_empty_vf_net_32_warps",
+      "source_kind": "isolated_microbenchmark",
+      "source": "data_provider/transition.cce; data_provider/transition_host.cpp; triton_cases/SIMT_Test/run_transition.remote.sh; data_provider/build_commands.md",
+      "confidence": "low"
+    }
+  }
+}

--- a/third_party/ascend/costmodel/profiles/microbench/data_provider/build_and_run.sh
+++ b/third_party/ascend/costmodel/profiles/microbench/data_provider/build_and_run.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Build + run the Ascend SIMT probes ON THE BOARD (dav-c310):
+#   meas  -> SIMT launch overhead (empty-launch / SIMT-scan / SIMD-scan)
+#   busy  -> warp/lane parallelism (is Ascend SIMT real or fake?)
+#   tput  -> saturated peak throughput SIMD vs SIMT + #independent warps
+#   decomp-> WHY simt_cumsum_core is ~17x slower, component by component
+# Run this in a LOGIN shell on triton_a5 from the directory holding the sources:
+#     bash -lc './build_and_run.sh'          # build + run both
+#     bash -lc './build_and_run.sh meas'     # just the launch-overhead probe
+#     bash -lc './build_and_run.sh busy'     # just the warp/lane probe
+# (a login shell is required so conda + CANN env are set up; do NOT hack LD_LIBRARY_PATH).
+set -e
+
+# --- environment (kaixin conda for toolchain, CANN env for ccec + runtime) ---
+conda activate kaixin 2>/dev/null || true
+if [[ -f /data/kaixin/set_env.sh ]]; then
+  source /data/kaixin/set_env.sh >/dev/null 2>&1
+else
+  source /home/kaixin/set_env.sh >/dev/null 2>&1
+fi
+
+# Template headers (RegBase/VecUtils.h, RegBase/Cumulative/SIMTCumsumCore.h, ...).
+# Override by exporting INC=... if your catfood checkout lives elsewhere.
+INC="${INC:-/data/kaixin/AscendNPU-IR-Dev/bishengir/lib/Template/include}"
+TK="${ASCEND_TOOLKIT_HOME:?ASCEND_TOOLKIT_HOME unset - did set_env.sh run?}"
+
+echo "INC = $INC"
+echo "TK  = $TK"
+[ -f "$INC/RegBase/VecUtils.h" ] || { echo "!! RegBase/VecUtils.h not found under INC"; exit 1; }
+
+# build one probe: <name>.cce -> <name>.o (device) and <name>_host.cpp -> <name>_host (host)
+build_probe() {
+  local name="$1"
+  echo "--- building $name.o (device) ---"
+  ccec -c -std=c++17 -O2 --cce-aicore-only --cce-aicore-arch=dav-c310 \
+       -I"$INC" "$name.cce" -o "$name.o"
+  echo "--- building ${name}_host (host) ---"
+  g++ -O2 "${name}_host.cpp" -o "${name}_host" \
+      -I"$TK/x86_64-linux/pkg_inc" -I"$TK/include" \
+      -L"$TK/lib64" -lruntime -lascendcl
+}
+
+run_probe() {
+  local name="$1"
+  echo "=== running $name ==="
+  "./${name}_host"
+  echo
+}
+
+targets="${*:-meas busy tput decomp}"
+for t in $targets; do
+  build_probe "$t"
+done
+for t in $targets; do
+  run_probe "$t"
+done

--- a/third_party/ascend/costmodel/profiles/microbench/data_provider/build_commands.md
+++ b/third_party/ascend/costmodel/profiles/microbench/data_provider/build_commands.md
@@ -1,0 +1,92 @@
+# Microbenchmark data provider
+
+This directory contains the source CCE probes and host launchers used as
+evidence for `../ascend_davidv100_v1.json`.
+
+Run on the Ascend board, from this directory:
+
+```bash
+cd /data/kaixin/triton-ascend/third_party/ascend/costmodel/profiles/microbench/data_provider
+bash -lc './build_and_run.sh tput concur2 meas simt_memory simt_gm_memory simt_shuffle'
+```
+
+If the template headers are not under the default path, override `INC`:
+
+```bash
+INC=/data/kaixin/AscendNPU-IR/bishengir/lib/Template/include \
+bash -lc './build_and_run.sh tput concur2 meas simt_memory simt_gm_memory simt_shuffle'
+```
+
+The device build command used by `build_and_run.sh` is:
+
+```bash
+ccec -c -std=c++17 -O2 --cce-aicore-only --cce-aicore-arch=dav-c310 \
+  -I"$INC" "$name.cce" -o "$name.o"
+```
+
+The host build command used by `build_and_run.sh` is:
+
+```bash
+g++ -O2 "${name}_host.cpp" -o "${name}_host" \
+  -I"$ASCEND_TOOLKIT_HOME/x86_64-linux/pkg_inc" \
+  -I"$ASCEND_TOOLKIT_HOME/include" \
+  -L"$ASCEND_TOOLKIT_HOME/lib64" \
+  -lruntime -lascendcl
+```
+
+## Source mapping
+
+| JSON evidence source | Local files | Related measurements |
+|---|---|---|
+| `triton_cases/SIMT_Test/tput.cce` | `tput.cce`, `tput_host.cpp` | `simt.f32.add.throughput` |
+| `triton_cases/SIMT_Test/tput.cce; concur2.cce` | `tput.cce`, `tput_host.cpp`, `concur2.cce`, `concur2_host.cpp` | `simd.f32.add.throughput`, `simd.f32.add.dependent_latency` |
+| `triton_cases/SIMT_Test/meas.cce` | `meas.cce`, `meas_host.cpp` | `simt.setup.empty`, `simt.setup.empty_with_barrier` |
+| `triton_cases/SIMT_Test/simt_memory_david_v100_20260725.csv` | `simt_memory.cce`, `simt_memory_host.cpp` | SIMT UB load/store throughput and bandwidth |
+| `triton_cases/SIMT_Test/simt_gm_memory_david_v100_20260725.csv` | `simt_gm_memory.cce`, `simt_gm_memory_host.cpp` | SIMT GM load/store throughput and bandwidth |
+| `triton_cases/SIMT_Test/simt_shuffle_david_v100_20260725.csv` | `simt_shuffle.cce`, `simt_shuffle_host.cpp` | SIMT shuffle throughput and dependent latency |
+| `simt_transition_microbench_tail16_barrier_20260713.txt` | `transition.cce`, `transition_host.cpp`, `run_transition.remote.sh` | SIMT transition harness setup proxies |
+
+`build_and_run.sh` sources `/data/kaixin/set_env.sh` or `/home/kaixin/set_env.sh`,
+then builds `<name>.cce -> <name>.o` and `<name>_host.cpp -> <name>_host`.
+
+## CAModel / msopprof simulator
+
+The full workflow for generating CAModel data and promoting it into
+`../ascend_davidv100_v1.json` as a data source is documented in
+`camodel/README.md`.
+
+The simulator command follows the Ascend devkit documentation pattern:
+
+```bash
+msopprof simulator --soc-version=Ascend950PR ./${name}_host
+```
+
+If the local CANN package uses the davinci-style SOC name, use the matching
+target name instead, for example:
+
+```bash
+msopprof simulator --soc-version=dav-c310 ./${name}_host
+```
+
+The output directory is usually named `OPPROF_*`.  Per-instruction/per-unit
+simulator data is under:
+
+```text
+OPPROF_*/device0/
+```
+
+The current parser for converted CAModel counts is:
+
+```bash
+python3 camodel/extract_camodel_system_cycle_profile.py parsed_camodel_counts.json \
+  --simulator-clock-mhz 1650.0 \
+  --sys-cnt-mhz 988.9 \
+  --scope <experiment-name>
+```
+
+Files:
+
+| Purpose | File |
+|---|---|
+| CAModel experiment plan | `camodel/camodel_experiment_matrix.json` |
+| CAModel count-to-SYS_CNT parser | `camodel/extract_camodel_system_cycle_profile.py` |

--- a/third_party/ascend/costmodel/profiles/microbench/data_provider/camodel/README.md
+++ b/third_party/ascend/costmodel/profiles/microbench/data_provider/camodel/README.md
@@ -1,0 +1,153 @@
+# CAModel data source workflow
+
+This directory documents how to generate CAModel simulator data and how to
+promote the parsed result into the microbenchmark profile data source used by
+`../../ascend_davidv100_v1.json`.
+
+## Directory layout
+
+```text
+data_provider/
+  *.cce / *_host.cpp                 # runnable microbenchmark sources
+  build_and_run.sh                   # build + on-board run helper
+  build_commands.md                  # normal build/run commands
+  camodel/
+    README.md                        # this workflow
+    camodel_experiment_matrix.json   # planned CAModel experiment coverage
+    extract_camodel_system_cycle_profile.py
+```
+
+## 1. Build the probe
+
+Run on the Ascend board from `data_provider/`:
+
+```bash
+cd /data/kaixin/triton-ascend/third_party/ascend/costmodel/profiles/microbench/data_provider
+bash -lc './build_and_run.sh simt_memory'
+```
+
+`build_and_run.sh` expands to:
+
+```bash
+ccec -c -std=c++17 -O2 --cce-aicore-only --cce-aicore-arch=dav-c310 \
+  -I"$INC" "$name.cce" -o "$name.o"
+
+g++ -O2 "${name}_host.cpp" -o "${name}_host" \
+  -I"$ASCEND_TOOLKIT_HOME/x86_64-linux/pkg_inc" \
+  -I"$ASCEND_TOOLKIT_HOME/include" \
+  -L"$ASCEND_TOOLKIT_HOME/lib64" \
+  -lruntime -lascendcl
+```
+
+If the template headers are not in the default path:
+
+```bash
+INC=/data/kaixin/AscendNPU-IR/bishengir/lib/Template/include \
+bash -lc './build_and_run.sh simt_memory'
+```
+
+## 2. Generate CAModel simulator output
+
+After the host binary is built, run CAModel through `msopprof simulator`:
+
+```bash
+msopprof simulator --soc-version=Ascend950PR ./simt_memory_host
+```
+
+If the local CANN package uses davinci naming, use:
+
+```bash
+msopprof simulator --soc-version=dav-c310 ./simt_memory_host
+```
+
+The simulator creates an output directory similar to:
+
+```text
+OPPROF_YYYYMMDDHHMMSS_xxx/
+  device0/
+    ...
+```
+
+Keep the raw `OPPROF_*` directory as the primary evidence artifact.  The
+profile JSON should not point only to an opaque number; it should point to the
+source probe, host launcher, raw CAModel output, parser, and derived result.
+
+## 3. Parse CAModel counts into SYS_CNT-domain rates
+
+The parser expects a normalized JSON count file with this shape:
+
+```json
+{
+  "per_unit": {
+    "aiv0": {
+      "span": {"delta": 1000},
+      "group_counts": {
+        "memory": 100,
+        "float_alu": 200,
+        "shuffle": 0,
+        "predicate": 10,
+        "control": 20,
+        "int_alu": 30
+      }
+    }
+  }
+}
+```
+
+Then run:
+
+```bash
+python3 camodel/extract_camodel_system_cycle_profile.py parsed_camodel_counts.json \
+  --simulator-clock-mhz 1650.0 \
+  --sys-cnt-mhz 988.9 \
+  --scope simt_memory
+```
+
+The parser emits JSON like:
+
+```json
+{
+  "unit": "system_cycles",
+  "scope": "simt_memory",
+  "rates": {
+    "memory": {
+      "warp_instructions_per_system_cycle": 0.5
+    }
+  },
+  "confidence": "low"
+}
+```
+
+Important: these are workload-effective CAModel rates.  They are useful as
+calibration evidence, but they are not bare hardware peak throughput or
+isolated instruction latency.
+
+## 4. Promote the result into the microbenchmark profile
+
+When a CAModel-derived number is used by `ascend_davidv100_v1.json`, record the
+complete provenance in the measurement `source` field.
+
+Recommended source format:
+
+```json
+"source": "data_provider/simt_memory.cce; data_provider/simt_memory_host.cpp; data_provider/camodel/OPPROF_xxx; data_provider/camodel/parsed_simt_memory.json; data_provider/camodel/extract_camodel_system_cycle_profile.py; data_provider/build_commands.md"
+```
+
+The measurement should also state:
+
+- `source_kind`: `camodel_simulator` or `isolated_microbenchmark_with_camodel`
+- `cycle_domain`: normally `SYS_CNT` after parser conversion
+- `confidence`: usually `low` or `medium`, unless independently validated
+- `description`: whether the value is workload-effective or isolated
+
+## 5. Validation checklist
+
+Before treating a CAModel result as a data source:
+
+1. Source `.cce` and `_host.cpp` are checked into `data_provider/`.
+2. Exact build command is covered by `build_commands.md`.
+3. Raw CAModel `OPPROF_*` artifact or a documented extracted subset is saved.
+4. Parser command and output JSON are saved under `data_provider/camodel/`.
+5. `ascend_davidv100_v1.json` `source` points to all relevant artifacts.
+6. The profile description does not claim hardware peak if the measurement is
+   only workload-effective.

--- a/third_party/ascend/costmodel/profiles/microbench/data_provider/camodel/camodel_experiment_matrix.json
+++ b/third_party/ascend/costmodel/profiles/microbench/data_provider/camodel/camodel_experiment_matrix.json
@@ -1,0 +1,224 @@
+{
+  "schema_version": 1,
+  "unit": "system_cycles",
+  "target": "Ascend950PR/dav-c310",
+  "sweeps": {
+    "repetitions": [
+      64,
+      128,
+      256,
+      512
+    ],
+    "ilp": [
+      1,
+      2,
+      4,
+      8
+    ],
+    "num_warps": [
+      1,
+      2,
+      4,
+      8,
+      16,
+      32
+    ],
+    "active_lanes": [
+      1,
+      8,
+      16,
+      32
+    ]
+  },
+  "experiments": [
+    {
+      "family": "simd_compute",
+      "ops": [
+        "f32.add",
+        "f32.mul",
+        "f32.div",
+        "f32.exp",
+        "f32.min",
+        "f32.max"
+      ],
+      "variants": [
+        "dependent_chain",
+        "independent_ilp"
+      ],
+      "outputs": [
+        "startup",
+        "dependent_latency",
+        "peak_throughput"
+      ]
+    },
+    {
+      "family": "simt_compute",
+      "ops": [
+        "f32.add",
+        "f32.mul",
+        "f32.div",
+        "f32.min",
+        "f32.max",
+        "i32.add",
+        "i32.mul"
+      ],
+      "variants": [
+        "dependent_chain",
+        "independent_ilp"
+      ],
+      "sweep": [
+        "repetitions",
+        "ilp",
+        "num_warps",
+        "active_lanes"
+      ],
+      "outputs": [
+        "startup",
+        "dependent_latency",
+        "issue_rate_curve"
+      ]
+    },
+    {
+      "family": "simt_shuffle",
+      "ops": [
+        "shuffle_xor",
+        "shuffle_up",
+        "reduce_sum",
+        "reduce_min",
+        "reduce_max"
+      ],
+      "variants": [
+        "dependent_chain",
+        "independent_ilp"
+      ],
+      "sweep": [
+        "repetitions",
+        "num_warps",
+        "active_lanes"
+      ],
+      "outputs": [
+        "dependent_latency",
+        "issue_rate_curve"
+      ]
+    },
+    {
+      "family": "memory",
+      "spaces": [
+        "gm",
+        "ub_shared"
+      ],
+      "patterns": [
+        "sequential",
+        "stride",
+        "gather_random"
+      ],
+      "variants": [
+        "load_to_use_chain",
+        "independent_loads",
+        "stores"
+      ],
+      "sweep": [
+        "repetitions",
+        "ilp",
+        "num_warps",
+        "active_lanes"
+      ],
+      "outputs": [
+        "latency",
+        "bytes_per_system_cycle",
+        "transactions_per_system_cycle"
+      ]
+    },
+    {
+      "family": "predicate_control",
+      "ops": [
+        "predicate",
+        "uniform_branch",
+        "divergent_branch"
+      ],
+      "sweep": [
+        "repetitions",
+        "num_warps",
+        "active_lanes"
+      ],
+      "outputs": [
+        "issue_rate",
+        "divergence_penalty"
+      ]
+    },
+    {
+      "family": "atomic",
+      "ops": [
+        "atomic_add"
+      ],
+      "conflict_ratio": [
+        0.0,
+        0.25,
+        0.5,
+        1.0
+      ],
+      "sweep": [
+        "repetitions",
+        "num_warps",
+        "active_lanes"
+      ],
+      "outputs": [
+        "throughput",
+        "serialization_penalty"
+      ]
+    },
+    {
+      "family": "resource_pair",
+      "pairs": [
+        [
+          "simd_mte2",
+          "simd_vector"
+        ],
+        [
+          "simd_vector",
+          "simd_mte3"
+        ],
+        [
+          "cube",
+          "vector"
+        ],
+        [
+          "scalar_agu",
+          "vector"
+        ],
+        [
+          "simt_lsu",
+          "simt_alu"
+        ],
+        [
+          "simt_shuffle",
+          "simt_alu"
+        ]
+      ],
+      "variants": [
+        "a_only",
+        "b_only",
+        "a_plus_b"
+      ],
+      "outputs": [
+        "overlap_coefficient",
+        "shared_resource"
+      ]
+    }
+  ],
+  "required_metadata": [
+    "git_revision",
+    "compiler_revision",
+    "cann_version",
+    "camodel_version",
+    "target",
+    "kernel",
+    "shape",
+    "dtype",
+    "num_warps",
+    "active_lanes",
+    "ilp",
+    "repetitions",
+    "raw_opprof_path"
+  ]
+}

--- a/third_party/ascend/costmodel/profiles/microbench/data_provider/camodel/extract_camodel_system_cycle_profile.py
+++ b/third_party/ascend/costmodel/profiles/microbench/data_provider/camodel/extract_camodel_system_cycle_profile.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Convert parsed SIMT CAMODEL counts into SYS_CNT-cycle effective rates.
+
+This does not claim isolated instruction latency.  It reports workload-level
+issue rates from active veccores and keeps the source workload in the output.
+"""
+
+import argparse
+import json
+import statistics
+from pathlib import Path
+
+GROUPS = ("memory", "float_alu", "shuffle", "predicate", "control", "int_alu")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input", type=Path)
+    parser.add_argument("--simulator-clock-mhz", type=float, default=1650.0)
+    parser.add_argument("--sys-cnt-mhz", type=float, default=988.9)
+    parser.add_argument("--scope", default="unknown")
+    args = parser.parse_args()
+
+    data = json.loads(args.input.read_text(encoding="utf-8"))
+    active = []
+    for name, unit in data.get("per_unit", {}).items():
+        span = unit.get("span")
+        if not span or span.get("delta", 0) <= 0:
+            continue
+        active.append((name, float(span["delta"]), unit.get("group_counts", {})))
+    if not active:
+        raise RuntimeError("no active CAMODEL units with a positive timestamp span")
+
+    wall_simulator_cycles = max(row[1] for row in active)
+    clock_ratio = args.simulator_clock_mhz / args.sys_cnt_mhz
+    rates = {}
+    for group in GROUPS:
+        total = sum(float(row[2].get(group, 0)) for row in active)
+        aggregate_per_simulator_cycle = total / wall_simulator_cycles
+        per_unit_rates = [float(row[2].get(group, 0)) / row[1] for row in active]
+        rates[group] = {
+            "ops": total,
+            "aggregate_ops_per_simulator_cycle": aggregate_per_simulator_cycle,
+            "warp_instructions_per_system_cycle": aggregate_per_simulator_cycle * clock_ratio,
+            "median_per_unit_ops_per_simulator_cycle": statistics.median(per_unit_rates),
+        }
+
+    print(
+        json.dumps(
+            {
+                "unit": "system_cycles",
+                "scope": args.scope,
+                "source": str(args.input),
+                "active_units": len(active),
+                "wall_simulator_cycles": wall_simulator_cycles,
+                "simulator_clock_mhz": args.simulator_clock_mhz,
+                "sys_cnt_mhz": args.sys_cnt_mhz,
+                "rates": rates,
+                "confidence": "low",
+                "note": "Workload-effective CAMODEL issue rates; not isolated peak throughput or latency.",
+            }, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/third_party/ascend/costmodel/profiles/microbench/data_provider/camodel/simt_costmodel_calibration_notes.md
+++ b/third_party/ascend/costmodel/profiles/microbench/data_provider/camodel/simt_costmodel_calibration_notes.md
@@ -1,0 +1,214 @@
+# SIMT Cost Model Calibration Notes
+
+Date: 2026-07-13
+
+## Files
+
+- Parser: `extract_simt_camodel_calibration.py`
+- SIMT scope camodel JSON: `D:\backup\codex\simt_camodel_calibration_scope_b8.json`
+- SIMD baseline instr summary JSON: `D:\backup\codex\simd_camodel_instr_summary_b8.json`
+
+Remote source data:
+
+- SIMT scope: `/data/kaixin/triton_cases/fbgemm/sim_scope_camodel_scope_b8/OPPROF_20260712042738_MECSEVSNUOCUDPXV`
+- SIMD baseline: `/data/kaixin/triton_cases/fbgemm/sim_scope_camodel_simd_b8/OPPROF_20260712043444_JIMGWGXCYTWWPYJT`
+
+## Parser Policy
+
+For SIMT op counts, only primary issue/receive-level dumps are counted:
+
+- `rvec.simt.exu0..3.dump`
+- `rvec.simt.lsu.dump`
+- `rvec.simt.dvg0..3.dump`
+
+Register read/write logs are intentionally excluded because they duplicate a single instruction across register events and hazards.
+
+## FBGEMM Scope SIMT Summary
+
+Aggregate primary SIMT counts:
+
+```text
+memory      14196
+float_alu    4264
+shuffle      2496
+control      1612
+int_alu      1542
+predicate     252
+other         732
+```
+
+Top ops:
+
+```text
+SIMT_LDG       5928
+SIMT_LDS       2964
+SIMT_FMNMX_I   2548
+SIMT_SHFL      2496
+SIMT_FMNMX     1664
+SIMT_BRANCH    1560
+SIMT_STG       2652
+SIMT_STS       2652
+```
+
+Important interpretation:
+
+- Aggregate counts are across multiple active core/veccore units, while the timestamp span is wall-clock-like. Aggregate `cycles/op` is therefore a throughput seed, not a single-unit latency.
+- Per-unit entries, for example `core0.veccore0`, are better for local cost weights.
+- For `core0.veccore0`, primary span is about `10789` cycles, with `1092` memory ops, `328` float ALU ops, and `192` shuffle ops.
+
+## SIMD Baseline Summary
+
+SIMD `instr_exe` pipe cycles:
+
+```text
+SCALAR 335330
+RVECEX  49144
+MTE3    18823
+PUSHQ   19992
+RVECLD  16618
+RVECST   9910
+MTE2     3179
+```
+
+The SIMD baseline is dominated by `SCALAR`, which supports the cost model split:
+
+```text
+simd_total = max(vector_roofline, scalar_path)
+```
+
+For this FBGEMM case, scalar address/mask/scalarization risk should dominate the SIMD estimate.
+
+## Cost Model Use
+
+Initial practical mapping:
+
+- `SIMT_LDG/STG/LDS/STS` -> SIMT memory bucket
+- `SIMT_SHFL` -> shuffle/reduce bucket
+- `SIMT_ISETP/PLOP3` -> predicate bucket
+- `SIMT_FADD/FMUL/FMNMX` -> float ALU bucket
+- `SIMT_BRANCH/END` -> control/divergence bucket
+
+Do not treat the generated naive cycles/op as exact latency. They are calibration seeds to rank SIMD vs SIMT regions.
+
+## SIMD/SIMT Transition Microbench
+
+Source files:
+
+- `D:\projects\triton_cases\SIMT_Test\transition.cce`
+- `D:\projects\triton_cases\SIMT_Test\transition_host.cpp`
+- `D:\projects\triton_cases\SIMT_Test\run_transition.remote.sh`
+
+Saved result:
+
+- `D:\backup\codex\simt_transition_microbench_tail16_barrier_20260713.txt`
+
+Method:
+
+- Use in-kernel `get_sys_cnt()` slope over `K=100 -> 500`.
+- Measure `barrier_only`, SIMD tail only, empty SIMT `async_invoke` only, no-mid-barrier mixed orders, and mid-barrier mixed orders.
+- SIMD tail is a dependent UB read/add/write chain with `tail_reps=16`.
+
+Measured SYS_CNT frequency was about `989 MHz`, so one cycle is close to one nanosecond.
+
+Key results:
+
+```text
+nwarp  barrier  simt_with_barrier  simt_minus_barrier
+1        8.5          190.3              181.8
+2        8.5          190.4              181.9
+4        8.5          190.4              182.0
+8        8.5          190.3              181.8
+16       8.5          190.4              181.9
+32       8.5          231.7              223.3
+```
+
+The mixed-order deltas did not show a positive `SIMT -> SIMD` increment. Even with an explicit mid `pipe_barrier`, `SIMT + barrier + SIMD` was smaller than the sum of standalone SIMT and standalone SIMD baselines. Therefore the current cost model treats `SIMT -> SIMD` extra as `0` unless a future benchmark finds a positive increment.
+
+The transition table currently uses:
+
+```text
+num_warps  simd_to_simt  simd_to_simt_with_barrier  simt_to_simd
+1..16          182              190                      0
+32             223              232                      0
+```
+
+The `simd_to_simt` column is a complete mixed-kernel empty-SIMT setup proxy,
+not an increment to add after the standalone 115-cycle empty launch.  The
+shadow scorer therefore computes:
+
+```text
+mixed = (simt_total - standalone_empty_launch) + mixed_setup
+```
+
+This avoids counting SIMT launch/setup twice.  The earlier implementation used
+`simt_total + mixed_setup` and overestimated the mixed candidate by 115 system
+cycles.
+
+## Isolated SIMT UB Memory Microbenchmark
+
+Source files:
+
+- `D:\projects\triton_cases\SIMT_Test\simt_memory.cce`
+- `D:\projects\triton_cases\SIMT_Test\simt_memory_host.cpp`
+- `D:\projects\triton_cases\SIMT_Test\simt_memory_david_v100_20260725.csv`
+
+Method:
+
+- Eight independent UB loads or stores per active SIMT thread and iteration.
+- Four rotating contiguous working sets prevent loop-invariant load hoisting.
+- Maximum 32-warp working set is 128 KiB.
+- Use the slope over `iters=128 -> 512` with `K=20` to remove launch and timer
+  overhead.
+
+Measured saturation:
+
+```text
+operation   16 warps          32 warps
+UB load     65.54 B/cycle     64.93 B/cycle
+UB store    67.91 B/cycle     67.85 B/cycle
+```
+
+The isolated profile therefore uses 64.9347 B/system-cycle for UB loads and
+67.8525 B/system-cycle for UB stores with medium confidence.  These values do
+not replace the still-unmeasured GM LDG/STG rates.
+
+## Isolated SIMT GM Memory Microbenchmark
+
+Source files:
+
+- `D:\projects\triton_cases\SIMT_Test\simt_gm_memory.cce`
+- `D:\projects\triton_cases\SIMT_Test\simt_gm_memory_host.cpp`
+- `D:\projects\triton_cases\SIMT_Test\simt_gm_memory_david_v100_20260725.csv`
+
+The 32-warp run rotates over a 128 MiB sequential working set and performs
+eight independent operations per thread.  The measured single-AIV saturation
+rates are:
+
+```text
+GM load     22.1516 B/system-cycle
+GM store    16.5114 B/system-cycle
+```
+
+These replace the workload-aggregate CaModel memory fallback.  Because SIMT
+LDG and STG share the LSU, the scorer adds their separately calibrated cycle
+costs.  The profile confidence is raised from low to medium for sequential GM
+traffic; stride/gather latency remains future work.
+
+## Isolated SIMT Shuffle Microbenchmark
+
+Source files:
+
+- `D:\projects\triton_cases\SIMT_Test\simt_shuffle.cce`
+- `D:\projects\triton_cases\SIMT_Test\simt_shuffle_host.cpp`
+- `D:\projects\triton_cases\SIMT_Test\simt_shuffle_david_v100_20260725.csv`
+
+The dependent test executes one `__shfl_up` chain.  The throughput test uses
+four independent chains and sweeps 1–32 warps.
+
+```text
+one-warp dependent latency       27.2706 system cycles
+32-warp ILP4 throughput           0.8172 warp shuffles/system-cycle
+```
+
+This replaces the FBGEMM aggregate CaModel shuffle fallback of 0.3763 warp
+instructions/system-cycle and raises shuffle confidence from low to medium.

--- a/third_party/ascend/costmodel/profiles/microbench/data_provider/concur2.cce
+++ b/third_party/ascend/costmodel/profiles/microbench/data_provider/concur2.cce
@@ -1,0 +1,63 @@
+// Decompose the per-element cost of a SIMD cumsum into load / add / store, to
+// see whether the 4-wide vadd issue helps OneWay at all, or whether OneWay is
+// issue-bound across load+add+store (so vadd ILP is irrelevant).
+// All modes use 4 independent accumulators (ILP4, which already saturates the
+// vadd issue at ~3.3/cyc per the tput probe). Per "pass" = 4 ops of the kind.
+//   mode 0 : add-only        (acc_i += k)                   -> pure vadd issue rate
+//   mode 1 : load + add      (vlds x_i; acc_i += x_i)       -> + load cost
+//   mode 2 : load + add + st (vlds; acc_i += x_i; vsts)     -> + store cost  (= cumsum element)
+#include "RegBase/VecUtils.h"
+#include "Vector/VecUtils.h"
+#include "Utils.h"
+#include "RegBase/Cumulative/SIMTCumsumCore.h"
+
+using DT = float;
+constexpr int W = 64;
+
+extern "C" __global__ [aicore] void measure(__gm__ long long *out, int K, int a, int b, int iters, int mode) {
+  auto ob = reinterpret_cast<__ubuf__ DT *>(0);
+  auto kb = reinterpret_cast<__ubuf__ DT *>(32768);
+  uint32_t cnt = (uint32_t)W;
+
+  pipe_barrier(PIPE_ALL);
+  long long t0 = get_sys_cnt();
+  for (int k = 0; k < K; k++) {
+    __VEC_SCOPE__ {
+      vector_bool m;
+      CREATE_MASK_BY_SIZE(m, DT, cnt);
+      VectorReg<DT> kk; vlds(kk, kb, 0, NORM);
+      VectorReg<DT> a0, a1, a2, a3, x0, x1, x2, x3;
+      vlds(a0, ob+0*W,0,NORM); vlds(a1, ob+1*W,0,NORM); vlds(a2, ob+2*W,0,NORM); vlds(a3, ob+3*W,0,NORM);
+      if (mode == 0) {
+        for (uint16_t it = 0; it < (uint16_t)iters; it++) {
+          vadd(a0,a0,kk,m); vadd(a1,a1,kk,m); vadd(a2,a2,kk,m); vadd(a3,a3,kk,m);
+        }
+      } else if (mode == 1) {
+        for (uint16_t it = 0; it < (uint16_t)iters; it++) {
+          vlds(x0, ob+4*W,0,NORM); vlds(x1, ob+5*W,0,NORM); vlds(x2, ob+6*W,0,NORM); vlds(x3, ob+7*W,0,NORM);
+          vadd(a0,a0,x0,m); vadd(a1,a1,x1,m); vadd(a2,a2,x2,m); vadd(a3,a3,x3,m);
+        }
+      } else if (mode == 2) {
+        // INDEPENDENT load+add+store (Sklansky-inner shape: 4 parallel acc) -> issue-bound
+        for (uint16_t it = 0; it < (uint16_t)iters; it++) {
+          vlds(x0, ob+4*W,0,NORM); vlds(x1, ob+5*W,0,NORM); vlds(x2, ob+6*W,0,NORM); vlds(x3, ob+7*W,0,NORM);
+          vadd(a0,a0,x0,m); vadd(a1,a1,x1,m); vadd(a2,a2,x2,m); vadd(a3,a3,x3,m);
+          vsts(a0, ob+8*W,0,NORM_B32,m); vsts(a1, ob+9*W,0,NORM_B32,m); vsts(a2, ob+10*W,0,NORM_B32,m); vsts(a3, ob+11*W,0,NORM_B32,m);
+        }
+      } else {
+        // DEPENDENT load+add+store (plain_seq shape: ONE acc chain) -> latency-bound?
+        for (uint16_t it = 0; it < (uint16_t)iters; it++) {
+          vlds(x0, ob+4*W,0,NORM); vadd(a0,a0,x0,m); vsts(a0, ob+8*W,0,NORM_B32,m);
+          vlds(x1, ob+5*W,0,NORM); vadd(a0,a0,x1,m); vsts(a0, ob+9*W,0,NORM_B32,m);
+          vlds(x2, ob+6*W,0,NORM); vadd(a0,a0,x2,m); vsts(a0, ob+10*W,0,NORM_B32,m);
+          vlds(x3, ob+7*W,0,NORM); vadd(a0,a0,x3,m); vsts(a0, ob+11*W,0,NORM_B32,m);
+        }
+      }
+      vsts(a0, ob+0*W,0,NORM_B32,m); vsts(a1, ob+1*W,0,NORM_B32,m); vsts(a2, ob+2*W,0,NORM_B32,m); vsts(a3, ob+3*W,0,NORM_B32,m);
+    }
+    pipe_barrier(PIPE_ALL);
+  }
+  long long t1 = get_sys_cnt();
+  pipe_barrier(PIPE_ALL);
+  out[0] = t1 - t0;
+}

--- a/third_party/ascend/costmodel/profiles/microbench/data_provider/concur2_host.cpp
+++ b/third_party/ascend/costmodel/profiles/microbench/data_provider/concur2_host.cpp
@@ -1,0 +1,122 @@
+#include "runtime/runtime/rt.h"
+#include <acl/acl.h>
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <sys/time.h>
+using namespace std;
+static unsigned long us() {
+  timeval t;
+  gettimeofday(&t, 0);
+  return t.tv_sec * 1000000UL + t.tv_usec;
+}
+static char *readBin(const char *f, uint32_t *sz) {
+  ifstream s(f, ios::binary);
+  s.seekg(0, ios::end);
+  size_t n = s.tellg();
+  s.seekg(0);
+  char *b = new char[n];
+  s.read(b, n);
+  *sz = n;
+  return b;
+}
+static void *reg(const char *bin, char **buf) {
+  uint32_t sz;
+  *buf = readBin(bin, &sz);
+  rtDevBinary_t b;
+  b.data = *buf;
+  b.length = sz;
+  b.magic = RT_DEV_BINARY_MAGIC_ELF_AIVEC;
+  b.version = 0;
+  void *h = 0;
+  rtDevBinaryRegister(&b, &h);
+  return h;
+}
+struct Args {
+  void *out;
+  int K;
+  int a;
+  int b;
+  int iters;
+  int mode;
+};
+static long long runK(const char *fn, rtStream_t s, void *dout, int K,
+                      int iters, int mode) {
+  Args a{dout, K, 0, 0, iters, mode};
+  rtArgsEx_t ai = {};
+  ai.args = &a;
+  ai.argsSize = sizeof(a);
+  rtTaskCfgInfo_t c = {};
+  c.localMemorySize = 192 * 1024;
+  rtKernelLaunchWithFlagV2((void *)fn, 1, &ai, 0, s, 0, &c);
+  rtStreamSynchronize(s);
+  long long cyc = 0;
+  rtMemcpy(&cyc, 8, dout, 8, RT_MEMCPY_DEVICE_TO_HOST);
+  return cyc;
+}
+static long long mn(const char *fn, rtStream_t s, void *dout, int K, int it,
+                    int md, int rep) {
+  long long m = (long long)1e18;
+  for (int i = 0; i < rep; i++) {
+    long long c = runK(fn, s, dout, K, it, md);
+    if (c < m)
+      m = c;
+  }
+  return m;
+}
+static double FREQ;
+// cyc per inner op (each iter has 4 load-add-store units)
+static double cycPerOp(const char *fn, rtStream_t s, void *dout, int md) {
+  const int K = 20, I1 = 200, I2 = 600;
+  long long c1 = mn(fn, s, dout, K, I1, md, 7),
+            c2 = mn(fn, s, dout, K, I2, md, 7);
+  return (double)(c2 - c1) / ((double)(I2 - I1) * K * 4.0); // /4 ops per iter
+}
+int main() {
+  aclInit(0);
+  rtSetDevice(0);
+  char *buf;
+  void *h = reg("concur2.o", &buf);
+  const char *fn = "measure";
+  rtFunctionRegister(h, fn, fn, (void *)fn, 0);
+  rtStream_t s;
+  rtStreamCreate(&s, 0);
+  void *dout;
+  rtMalloc(&dout, 8, RT_MEMORY_HBM, 0);
+  runK(fn, s, dout, 10, 100, 0);
+  int CK = 6000;
+  long long cmin = (long long)1e18;
+  unsigned long hmin = -1UL;
+  for (int i = 0; i < 7; i++) {
+    unsigned long t0 = us();
+    long long c = runK(fn, s, dout, CK, 100, 2);
+    unsigned long dt = us() - t0;
+    if (dt < hmin) {
+      hmin = dt;
+      cmin = c;
+    }
+  }
+  FREQ = (double)cmin / (double)hmin;
+  printf("CALIB: %.1f MHz\n\n", FREQ);
+  double a = cycPerOp(fn, s, dout, 0);
+  double b = cycPerOp(fn, s, dout, 1);
+  double c = cycPerOp(fn, s, dout, 2);
+  double d = cycPerOp(fn, s, dout, 3);
+  printf("mode0 add-only (ILP4)            : %5.3f cyc/op\n", a);
+  printf("mode1 load+add (ILP4)            : %5.3f cyc/op\n", b);
+  printf("mode2 load+add+store INDEP (Sklansky-inner): %5.3f cyc/op\n", c);
+  printf("mode3 load+add+store DEP   (plain_seq)     : %5.3f cyc/op\n", d);
+  printf("\n>> dep/indep per-op ratio = %.2f  (break-even for Sklansky = "
+         "addcount_ratio)\n",
+         d / c);
+  printf(
+      "   For R=32: Sklansky/plain_seq addcount = (R/2)logR / (R-1) = %.2f\n",
+      (32.0 / 2 * 5) / (31.0));
+  printf("   Sklansky wins iff dep/indep > addcount_ratio  -> %s\n",
+         (d / c) > ((32.0 / 2 * 5) / 31.0) ? "YES (room!)" : "NO (no room)");
+  rtFree(dout);
+  rtStreamDestroy(s);
+  rtDeviceReset(0);
+  aclFinalize();
+  return 0;
+}

--- a/third_party/ascend/costmodel/profiles/microbench/data_provider/meas.cce
+++ b/third_party/ascend/costmodel/profiles/microbench/data_provider/meas.cce
@@ -1,0 +1,70 @@
+// SIMT launch-overhead probe for Ascend (dav-c310).
+// Measures the cost of one cce::async_invoke (SIMT VF launch) and compares three
+// ways of doing the SAME [R=32, N=32] cumsum:
+//   mode 0  empty-launch : async_invoke of a VF that writes 1 element -> isolates
+//                          the PURE launch cost (no real compute).
+//   mode 1  SIMT-scan    : async_invoke of the warp-shuffle Kogge-Stone scan
+//                          (launch + the actual SIMT compute).
+//   mode 2  SIMD-scan    : the same scan done inline as register-resident vector
+//                          adds (no SIMT, no launch at all).
+// `barrier` toggles a pipe_barrier(PIPE_ALL) after each op (serialized vs
+// back-to-back). Host sweeps K and takes the slope to get per-op cycles, so:
+//   launch       = mode0
+//   SIMT compute = mode1 - mode0
+//   SIMD compute = mode2
+// Result (2026-06-07): launch ~115 ns; SIMT scan ~1391 ns; SIMD scan ~73 ns.
+#include "RegBase/VecUtils.h"
+#include "Vector/VecUtils.h"
+#include "Utils.h"
+#include "RegBase/Cumulative/SIMTCumsumCore.h"
+
+using DT = float;
+constexpr int R = 32, N = 32;
+
+// Minimal SIMT VF: writes one element so the launch can't be optimized away,
+// but does no real work -> its cost is essentially the async_invoke launch.
+template <typename T>
+__simt_vf__ LAUNCH_BOUND(1024) __aiv__ __attribute__((always_inline)) static void
+empty_vf(__ubuf__ T *p) {
+  int l = blockIdx.x * blockDim.y + threadIdx.y;
+  if (l == 0 && threadIdx.x == 0)
+    p[0] = (T)1;
+}
+
+extern "C" __global__ [aicore] void measure(__gm__ long long *out, int K, int mode, int barrier) {
+  auto ub = reinterpret_cast<__ubuf__ DT *>(0);
+  auto ub2 = reinterpret_cast<__ubuf__ DT *>(8192);
+  uint32_t cnt = (uint32_t)N;
+  uint16_t rL = (uint16_t)R;
+
+  pipe_barrier(PIPE_ALL);
+  long long t0 = _sys_cnt();
+  for (int i = 0; i < K; i++) {
+    if (mode == 0) {
+      // pure launch
+      cce::async_invoke<empty_vf<DT>>(cce::dim3{32, 32, 1}, ub);
+    } else if (mode == 1) {
+      // launch + SIMT warp-shuffle scan
+      cce::async_invoke<simt_cumsum_core<DT>>(cce::dim3{32, 32, 1}, ub, ub2, 1, R, N, 0, N, 0);
+    } else {
+      // inline SIMD scan (register-resident sequential cumsum over R rows)
+      __VEC_SCOPE__ {
+        VectorReg<DT> acc, x2;
+        vector_bool m;
+        CREATE_MASK_BY_SIZE(m, DT, cnt);
+        vlds(acc, ub, 0, NORM);
+        vsts(acc, ub2, 0, NORM_B32, m);
+        for (uint16_t r = 1; r < rL; r++) {
+          vlds(x2, ub + (int)r * N, 0, NORM);
+          vadd(acc, acc, x2, m);
+          vsts(acc, ub2 + (int)r * N, 0, NORM_B32, m);
+        }
+      }
+    }
+    if (barrier)
+      pipe_barrier(PIPE_ALL);
+  }
+  long long t1 = _sys_cnt();
+  pipe_barrier(PIPE_ALL);
+  out[0] = t1 - t0;
+}

--- a/third_party/ascend/costmodel/profiles/microbench/data_provider/meas_host.cpp
+++ b/third_party/ascend/costmodel/profiles/microbench/data_provider/meas_host.cpp
@@ -1,0 +1,153 @@
+// Host driver for meas.cce — measures SIMT launch overhead and compares
+// empty-launch / SIMT-scan / SIMD-scan per-op cost.
+#include "runtime/runtime/rt.h"
+#include <acl/acl.h>
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <sys/time.h>
+
+using namespace std;
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+static unsigned long us() {
+  timeval t;
+  gettimeofday(&t, 0);
+  return t.tv_sec * 1000000UL + t.tv_usec;
+}
+
+static char *readBin(const char *f, uint32_t *sz) {
+  ifstream s(f, ios::binary);
+  s.seekg(0, ios::end);
+  size_t n = s.tellg();
+  s.seekg(0);
+  char *b = new char[n];
+  s.read(b, n);
+  *sz = n;
+  return b;
+}
+
+// Register the device .o as an AIVEC binary and return its handle.
+static void *reg(const char *bin, char **buf) {
+  uint32_t sz;
+  *buf = readBin(bin, &sz);
+
+  rtDevBinary_t b;
+  b.data = *buf;
+  b.length = sz;
+  b.magic = RT_DEV_BINARY_MAGIC_ELF_AIVEC;
+  b.version = 0;
+
+  void *h = 0;
+  rtDevBinaryRegister(&b, &h);
+  return h;
+}
+
+// ---------------------------------------------------------------------------
+// kernel launch + timing
+// ---------------------------------------------------------------------------
+
+// Argument block laid out exactly like `measure(...)` in meas.cce.
+struct Args {
+  void *out;
+  int K;
+  int mode;    // 0 empty-launch, 1 SIMT-scan, 2 SIMD-scan
+  int barrier; // pipe_barrier after each op?
+};
+
+// Launch `measure` once (it internally does K ops) and return the SYS_CNT cycle
+// count it wrote to dout.
+static long long runK(const char *fn, rtStream_t s, void *dout, int K, int mode,
+                      int bar) {
+  Args a{dout, K, mode, bar};
+
+  rtArgsEx_t ai = {};
+  ai.args = &a;
+  ai.argsSize = sizeof(a);
+
+  rtTaskCfgInfo_t c = {};
+  c.localMemorySize = 192 * 1024;
+
+  rtKernelLaunchWithFlagV2((void *)fn, 1, &ai, 0, s, 0, &c);
+  rtStreamSynchronize(s);
+
+  long long cyc = 0;
+  rtMemcpy(&cyc, 8, dout, 8, RT_MEMCPY_DEVICE_TO_HOST);
+  return cyc;
+}
+
+// Min over `rep` repetitions of the raw K-loop cycle count.
+static long long avg(const char *fn, rtStream_t s, void *dout, int K, int mode,
+                     int bar, int rep) {
+  long long m = (long long)1e18;
+  for (int i = 0; i < rep; i++) {
+    long long c = runK(fn, s, dout, K, mode, bar);
+    if (c < m)
+      m = c;
+  }
+  return m;
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+int main() {
+  aclInit(0);
+  rtSetDevice(0);
+
+  char *buf;
+  void *h = reg("meas.o", &buf);
+  const char *fn = "measure";
+  rtFunctionRegister(h, fn, fn, (void *)fn, 0);
+
+  rtStream_t s;
+  rtStreamCreate(&s, 0);
+
+  void *dout;
+  rtMalloc(&dout, 8, RT_MEMORY_HBM, 0);
+
+  runK(fn, s, dout, 10, 0, 1); // warmup
+
+  // Calibrate the SYS_CNT frequency by host-timing a long SIMD-scan run.
+  const int CK = 8000;
+  long long cmin = (long long)1e18;
+  unsigned long hmin = -1UL;
+  for (int i = 0; i < 7; i++) {
+    unsigned long t0 = us();
+    long long c = runK(fn, s, dout, CK, 2, 1);
+    unsigned long dt = us() - t0;
+    if (dt < hmin) {
+      hmin = dt;
+      cmin = c;
+    }
+  }
+  double freq_mhz = (double)cmin / (double)hmin; // cycles/us = MHz
+  printf("CALIB: %lld cyc over %lu us host -> %.1f MHz (cycle=%.3f ns)\n", cmin,
+         hmin, freq_mhz, 1000.0 / freq_mhz);
+
+  // For each mode x barrier: per-op cycles via the slope over K
+  // (empty-launch = pure launch cost; SIMT-scan - empty-launch = SIMT compute).
+  const char *mn[3] = {"empty-launch", "SIMT-scan", "SIMD-scan"};
+  for (int mode = 0; mode < 3; mode++) {
+    for (int bar = 0; bar < 2; bar++) {
+      long long c0 = avg(fn, s, dout, 0, mode, bar, 7);
+      long long c200 = avg(fn, s, dout, 200, mode, bar, 7);
+      long long c400 = avg(fn, s, dout, 400, mode, bar, 7);
+      double per = (double)(c400 - c0) / 400.0;
+      double ns = per / freq_mhz * 1000.0;
+      printf("%-13s barrier=%d: per-op = %.1f cyc = %.1f ns  (c0=%lld "
+             "c200=%lld c400=%lld)\n",
+             mn[mode], bar, per, ns, c0, c200, c400);
+    }
+  }
+
+  rtFree(dout);
+  rtStreamDestroy(s);
+  rtDeviceReset(0);
+  aclFinalize();
+  return 0;
+}

--- a/third_party/ascend/costmodel/profiles/microbench/data_provider/simt_gm_memory.cce
+++ b/third_party/ascend/costmodel/profiles/microbench/data_provider/simt_gm_memory.cce
@@ -1,0 +1,68 @@
+// SIMT global-memory throughput probe for dav-c310.
+//
+// mode 0: eight independent GM loads + one UB sink store.
+// mode 1: eight independent GM stores.
+//
+// At 32 warps the rotating working set is 128 MiB, intentionally larger than
+// cache.  The host measures the slope over iterations.
+#include "RegBase/VecUtils.h"
+#include "Vector/VecUtils.h"
+#include "Utils.h"
+
+using DT = float;
+
+template <typename T>
+__simt_vf__ LAUNCH_BOUND(1024) __aiv__ __attribute__((always_inline)) static void
+simt_gm_memory_core(__gm__ T *gm, __ubuf__ T *sink, int nlane, int nwarp,
+                    int iters, int mode) {
+  int lane = threadIdx.x;
+  int warp = threadIdx.y;
+  if (lane >= nlane || warp >= nwarp)
+    return;
+
+  int tid = warp * 32 + lane;
+  int threads = nwarp * 32;
+  T acc = (T)(tid + 1);
+  for (int i = 0; i < iters; ++i) {
+    int base = (i & 4095) * threads * 8 + tid;
+    if (mode == 0) {
+      T x0 = gm[base + threads * 0];
+      T x1 = gm[base + threads * 1];
+      T x2 = gm[base + threads * 2];
+      T x3 = gm[base + threads * 3];
+      T x4 = gm[base + threads * 4];
+      T x5 = gm[base + threads * 5];
+      T x6 = gm[base + threads * 6];
+      T x7 = gm[base + threads * 7];
+      acc += x0 + x1 + x2 + x3 + x4 + x5 + x6 + x7;
+    } else {
+      gm[base + threads * 0] = acc;
+      gm[base + threads * 1] = acc + (T)1;
+      gm[base + threads * 2] = acc + (T)2;
+      gm[base + threads * 3] = acc + (T)3;
+      gm[base + threads * 4] = acc + (T)4;
+      gm[base + threads * 5] = acc + (T)5;
+      gm[base + threads * 6] = acc + (T)6;
+      gm[base + threads * 7] = acc + (T)7;
+      acc += (T)1;
+    }
+  }
+  sink[tid] = acc;
+}
+
+extern "C" __global__ [aicore] void measure(__gm__ long long *out,
+                                             __gm__ DT *gm, int K, int nlane,
+                                             int nwarp, int iters, int mode) {
+  auto sink = reinterpret_cast<__ubuf__ DT *>(0);
+  pipe_barrier(PIPE_ALL);
+  long long t0 = get_sys_cnt();
+  for (int i = 0; i < K; ++i) {
+    cce::async_invoke<simt_gm_memory_core<DT>>(
+        cce::dim3{32, (unsigned)nwarp, 1}, gm, sink, nlane, nwarp, iters,
+        mode);
+    pipe_barrier(PIPE_ALL);
+  }
+  long long t1 = get_sys_cnt();
+  pipe_barrier(PIPE_ALL);
+  out[0] = t1 - t0;
+}

--- a/third_party/ascend/costmodel/profiles/microbench/data_provider/simt_gm_memory_host.cpp
+++ b/third_party/ascend/costmodel/profiles/microbench/data_provider/simt_gm_memory_host.cpp
@@ -1,0 +1,116 @@
+// Host driver for simt_gm_memory.cce.
+#include "runtime/runtime/rt.h"
+#include <acl/acl.h>
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+
+using namespace std;
+constexpr size_t GM_BYTES = 128ULL * 1024 * 1024;
+
+static char *readBin(const char *f, uint32_t *sz) {
+  ifstream s(f, ios::binary);
+  s.seekg(0, ios::end);
+  size_t n = s.tellg();
+  s.seekg(0);
+  char *b = new char[n];
+  s.read(b, n);
+  *sz = n;
+  return b;
+}
+
+static void *reg(const char *bin, char **buf) {
+  uint32_t sz;
+  *buf = readBin(bin, &sz);
+  rtDevBinary_t b;
+  b.data = *buf;
+  b.length = sz;
+  b.magic = RT_DEV_BINARY_MAGIC_ELF_AIVEC;
+  b.version = 0;
+  void *h = nullptr;
+  rtDevBinaryRegister(&b, &h);
+  return h;
+}
+
+struct Args {
+  void *out;
+  void *gm;
+  int K;
+  int nlane;
+  int nwarp;
+  int iters;
+  int mode;
+};
+
+static long long runK(const char *fn, rtStream_t stream, void *dout, void *gm,
+                      int K, int nwarp, int iters, int mode) {
+  Args args{dout, gm, K, 32, nwarp, iters, mode};
+  rtArgsEx_t ai = {};
+  ai.args = &args;
+  ai.argsSize = sizeof(args);
+  rtTaskCfgInfo_t cfg = {};
+  cfg.localMemorySize = 192 * 1024;
+  rtKernelLaunchWithFlagV2((void *)fn, 1, &ai, 0, stream, 0, &cfg);
+  rtStreamSynchronize(stream);
+  long long cycles = 0;
+  rtMemcpy(&cycles, sizeof(cycles), dout, sizeof(cycles),
+           RT_MEMCPY_DEVICE_TO_HOST);
+  return cycles;
+}
+
+static long long minimum(const char *fn, rtStream_t stream, void *dout,
+                         void *gm, int K, int nwarp, int iters, int mode) {
+  long long result = (long long)1e18;
+  for (int rep = 0; rep < 5; ++rep) {
+    long long value = runK(fn, stream, dout, gm, K, nwarp, iters, mode);
+    if (value < result)
+      result = value;
+  }
+  return result;
+}
+
+static double cyclesPerIter(const char *fn, rtStream_t stream, void *dout,
+                            void *gm, int nwarp, int mode) {
+  const int K = 4;
+  const int I1 = 1024;
+  const int I2 = 4096;
+  long long c1 = minimum(fn, stream, dout, gm, K, nwarp, I1, mode);
+  long long c2 = minimum(fn, stream, dout, gm, K, nwarp, I2, mode);
+  return (double)(c2 - c1) / ((double)(I2 - I1) * K);
+}
+
+int main() {
+  aclInit(nullptr);
+  rtSetDevice(0);
+  char *binary = nullptr;
+  void *handle = reg("simt_gm_memory.o", &binary);
+  const char *fn = "measure";
+  rtFunctionRegister(handle, fn, fn, (void *)fn, 0);
+  rtStream_t stream;
+  rtStreamCreate(&stream, 0);
+  void *dout = nullptr;
+  void *gm = nullptr;
+  rtMalloc(&dout, sizeof(long long), RT_MEMORY_HBM, 0);
+  rtMalloc(&gm, GM_BYTES, RT_MEMORY_HBM, 0);
+  rtMemset(gm, GM_BYTES, 0, GM_BYTES);
+
+  runK(fn, stream, dout, gm, 1, 4, 16, 0);
+  printf("SIMT GM memory, 128 MiB maximum working set\n");
+  printf("warps,load_cycles,load_bytes_per_cycle,store_cycles,"
+         "store_bytes_per_cycle\n");
+  for (int warps : {1, 2, 4, 8, 16, 32}) {
+    double loadCycles = cyclesPerIter(fn, stream, dout, gm, warps, 0);
+    double storeCycles = cyclesPerIter(fn, stream, dout, gm, warps, 1);
+    double bytes = (double)warps * 32.0 * 8.0 * sizeof(float);
+    printf("%d,%.6f,%.6f,%.6f,%.6f\n", warps, loadCycles, bytes / loadCycles,
+           storeCycles, bytes / storeCycles);
+  }
+
+  rtFree(gm);
+  rtFree(dout);
+  rtStreamDestroy(stream);
+  rtDeviceReset(0);
+  aclFinalize();
+  delete[] binary;
+  return 0;
+}

--- a/third_party/ascend/costmodel/profiles/microbench/data_provider/simt_memory.cce
+++ b/third_party/ascend/costmodel/profiles/microbench/data_provider/simt_memory.cce
@@ -1,0 +1,69 @@
+// SIMT UB-memory throughput probe for dav-c310.
+//
+// mode 0: eight independent UB loads + one sink store per thread/iteration.
+// mode 1: eight independent UB stores per thread/iteration.
+//
+// The host takes a slope over `iters`, removing async_invoke and SYS_CNT
+// overhead.  The address rotates over 32 cache lines so loads cannot be hoisted
+// into registers across iterations.
+#include "RegBase/VecUtils.h"
+#include "Vector/VecUtils.h"
+#include "Utils.h"
+
+using DT = float;
+
+template <typename T>
+__simt_vf__ LAUNCH_BOUND(1024) __aiv__ __attribute__((always_inline)) static void
+simt_memory_core(__ubuf__ T *buf, int nlane, int nwarp, int iters, int mode) {
+  int lane = threadIdx.x;
+  int warp = threadIdx.y;
+  if (lane >= nlane || warp >= nwarp)
+    return;
+
+  int tid = warp * 32 + lane;
+  int threads = nwarp * 32;
+  T acc = (T)(tid + 1);
+  for (int i = 0; i < iters; ++i) {
+    // Four rotating working sets keep the maximum 32-warp footprint at
+    // 128 KiB, within the 192 KiB local-memory allocation.
+    int base = (i & 3) * threads * 8 + tid;
+    if (mode == 0) {
+      T x0 = buf[base + threads * 0];
+      T x1 = buf[base + threads * 1];
+      T x2 = buf[base + threads * 2];
+      T x3 = buf[base + threads * 3];
+      T x4 = buf[base + threads * 4];
+      T x5 = buf[base + threads * 5];
+      T x6 = buf[base + threads * 6];
+      T x7 = buf[base + threads * 7];
+      acc += x0 + x1 + x2 + x3 + x4 + x5 + x6 + x7;
+    } else {
+      buf[base + threads * 0] = acc;
+      buf[base + threads * 1] = acc + (T)1;
+      buf[base + threads * 2] = acc + (T)2;
+      buf[base + threads * 3] = acc + (T)3;
+      buf[base + threads * 4] = acc + (T)4;
+      buf[base + threads * 5] = acc + (T)5;
+      buf[base + threads * 6] = acc + (T)6;
+      buf[base + threads * 7] = acc + (T)7;
+      acc += (T)1;
+    }
+  }
+  buf[tid] = acc;
+}
+
+extern "C" __global__ [aicore] void measure(__gm__ long long *out, int K,
+                                             int nlane, int nwarp, int iters,
+                                             int mode) {
+  auto buf = reinterpret_cast<__ubuf__ DT *>(0);
+  pipe_barrier(PIPE_ALL);
+  long long t0 = get_sys_cnt();
+  for (int i = 0; i < K; ++i) {
+    cce::async_invoke<simt_memory_core<DT>>(
+        cce::dim3{32, (unsigned)nwarp, 1}, buf, nlane, nwarp, iters, mode);
+    pipe_barrier(PIPE_ALL);
+  }
+  long long t1 = get_sys_cnt();
+  pipe_barrier(PIPE_ALL);
+  out[0] = t1 - t0;
+}

--- a/third_party/ascend/costmodel/profiles/microbench/data_provider/simt_memory_host.cpp
+++ b/third_party/ascend/costmodel/profiles/microbench/data_provider/simt_memory_host.cpp
@@ -1,0 +1,110 @@
+// Host driver for simt_memory.cce.
+#include "runtime/runtime/rt.h"
+#include <acl/acl.h>
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+
+using namespace std;
+
+static char *readBin(const char *f, uint32_t *sz) {
+  ifstream s(f, ios::binary);
+  s.seekg(0, ios::end);
+  size_t n = s.tellg();
+  s.seekg(0);
+  char *b = new char[n];
+  s.read(b, n);
+  *sz = n;
+  return b;
+}
+
+static void *reg(const char *bin, char **buf) {
+  uint32_t sz;
+  *buf = readBin(bin, &sz);
+  rtDevBinary_t b;
+  b.data = *buf;
+  b.length = sz;
+  b.magic = RT_DEV_BINARY_MAGIC_ELF_AIVEC;
+  b.version = 0;
+  void *h = nullptr;
+  rtDevBinaryRegister(&b, &h);
+  return h;
+}
+
+struct Args {
+  void *out;
+  int K;
+  int nlane;
+  int nwarp;
+  int iters;
+  int mode;
+};
+
+static long long runK(const char *fn, rtStream_t stream, void *dout, int K,
+                      int nlane, int nwarp, int iters, int mode) {
+  Args args{dout, K, nlane, nwarp, iters, mode};
+  rtArgsEx_t ai = {};
+  ai.args = &args;
+  ai.argsSize = sizeof(args);
+  rtTaskCfgInfo_t cfg = {};
+  cfg.localMemorySize = 192 * 1024;
+  rtKernelLaunchWithFlagV2((void *)fn, 1, &ai, 0, stream, 0, &cfg);
+  rtStreamSynchronize(stream);
+  long long cycles = 0;
+  rtMemcpy(&cycles, sizeof(cycles), dout, sizeof(cycles),
+           RT_MEMCPY_DEVICE_TO_HOST);
+  return cycles;
+}
+
+static long long minimum(const char *fn, rtStream_t stream, void *dout, int K,
+                         int nlane, int nwarp, int iters, int mode) {
+  long long result = (long long)1e18;
+  for (int rep = 0; rep < 7; ++rep) {
+    long long value = runK(fn, stream, dout, K, nlane, nwarp, iters, mode);
+    if (value < result)
+      result = value;
+  }
+  return result;
+}
+
+static double cyclesPerIter(const char *fn, rtStream_t stream, void *dout,
+                            int nwarp, int mode) {
+  const int K = 20;
+  const int I1 = 128;
+  const int I2 = 512;
+  long long c1 = minimum(fn, stream, dout, K, 32, nwarp, I1, mode);
+  long long c2 = minimum(fn, stream, dout, K, 32, nwarp, I2, mode);
+  return (double)(c2 - c1) / ((double)(I2 - I1) * K);
+}
+
+int main() {
+  aclInit(nullptr);
+  rtSetDevice(0);
+  char *binary = nullptr;
+  void *handle = reg("simt_memory.o", &binary);
+  const char *fn = "measure";
+  rtFunctionRegister(handle, fn, fn, (void *)fn, 0);
+  rtStream_t stream;
+  rtStreamCreate(&stream, 0);
+  void *dout = nullptr;
+  rtMalloc(&dout, sizeof(long long), RT_MEMORY_HBM, 0);
+
+  runK(fn, stream, dout, 2, 32, 4, 16, 0);
+  printf("SIMT UB memory, eight operations/thread/iteration\n");
+  printf("warps,load_cycles,load_bytes_per_cycle,store_cycles,"
+         "store_bytes_per_cycle\n");
+  for (int warps : {1, 2, 4, 8, 16, 32}) {
+    double loadCycles = cyclesPerIter(fn, stream, dout, warps, 0);
+    double storeCycles = cyclesPerIter(fn, stream, dout, warps, 1);
+    double bytes = (double)warps * 32.0 * 8.0 * sizeof(float);
+    printf("%d,%.6f,%.6f,%.6f,%.6f\n", warps, loadCycles, bytes / loadCycles,
+           storeCycles, bytes / storeCycles);
+  }
+
+  rtFree(dout);
+  rtStreamDestroy(stream);
+  rtDeviceReset(0);
+  aclFinalize();
+  delete[] binary;
+  return 0;
+}

--- a/third_party/ascend/costmodel/profiles/microbench/data_provider/simt_shuffle.cce
+++ b/third_party/ascend/costmodel/profiles/microbench/data_provider/simt_shuffle.cce
@@ -1,0 +1,50 @@
+// SIMT shuffle dependent-latency and throughput probe for dav-c310.
+#include "RegBase/VecUtils.h"
+#include "Vector/VecUtils.h"
+#include "Utils.h"
+
+using DT = float;
+
+template <typename T>
+__simt_vf__ LAUNCH_BOUND(1024) __aiv__ __attribute__((always_inline)) static void
+simt_shuffle_core(__ubuf__ T *sink, int nlane, int nwarp, int iters,
+                  int mode) {
+  int lane = threadIdx.x;
+  int warp = threadIdx.y;
+  if (lane >= nlane || warp >= nwarp)
+    return;
+
+  T x0 = (T)(lane + warp + 1);
+  T x1 = x0 + (T)1;
+  T x2 = x0 + (T)2;
+  T x3 = x0 + (T)3;
+  for (int i = 0; i < iters; ++i) {
+    if (mode == 0) {
+      // One dependent chain: latency-oriented.
+      x0 = __shfl_up(x0, 1, 32);
+    } else {
+      // Four independent chains: throughput-oriented.
+      x0 = __shfl_up(x0, 1, 32);
+      x1 = __shfl_up(x1, 2, 32);
+      x2 = __shfl_up(x2, 4, 32);
+      x3 = __shfl_up(x3, 8, 32);
+    }
+  }
+  sink[warp * 32 + lane] = x0 + x1 + x2 + x3;
+}
+
+extern "C" __global__ [aicore] void measure(__gm__ long long *out, int K,
+                                             int nlane, int nwarp, int iters,
+                                             int mode) {
+  auto sink = reinterpret_cast<__ubuf__ DT *>(0);
+  pipe_barrier(PIPE_ALL);
+  long long t0 = get_sys_cnt();
+  for (int i = 0; i < K; ++i) {
+    cce::async_invoke<simt_shuffle_core<DT>>(
+        cce::dim3{32, (unsigned)nwarp, 1}, sink, nlane, nwarp, iters, mode);
+    pipe_barrier(PIPE_ALL);
+  }
+  long long t1 = get_sys_cnt();
+  pipe_barrier(PIPE_ALL);
+  out[0] = t1 - t0;
+}

--- a/third_party/ascend/costmodel/profiles/microbench/data_provider/simt_shuffle_host.cpp
+++ b/third_party/ascend/costmodel/profiles/microbench/data_provider/simt_shuffle_host.cpp
@@ -1,0 +1,110 @@
+// Host driver for simt_shuffle.cce.
+#include "runtime/runtime/rt.h"
+#include <acl/acl.h>
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+
+using namespace std;
+
+static char *readBin(const char *f, uint32_t *sz) {
+  ifstream s(f, ios::binary);
+  s.seekg(0, ios::end);
+  size_t n = s.tellg();
+  s.seekg(0);
+  char *b = new char[n];
+  s.read(b, n);
+  *sz = n;
+  return b;
+}
+
+static void *reg(const char *bin, char **buf) {
+  uint32_t sz;
+  *buf = readBin(bin, &sz);
+  rtDevBinary_t b;
+  b.data = *buf;
+  b.length = sz;
+  b.magic = RT_DEV_BINARY_MAGIC_ELF_AIVEC;
+  b.version = 0;
+  void *h = nullptr;
+  rtDevBinaryRegister(&b, &h);
+  return h;
+}
+
+struct Args {
+  void *out;
+  int K;
+  int nlane;
+  int nwarp;
+  int iters;
+  int mode;
+};
+
+static long long runK(const char *fn, rtStream_t stream, void *dout, int K,
+                      int nwarp, int iters, int mode) {
+  Args args{dout, K, 32, nwarp, iters, mode};
+  rtArgsEx_t ai = {};
+  ai.args = &args;
+  ai.argsSize = sizeof(args);
+  rtTaskCfgInfo_t cfg = {};
+  cfg.localMemorySize = 192 * 1024;
+  rtKernelLaunchWithFlagV2((void *)fn, 1, &ai, 0, stream, 0, &cfg);
+  rtStreamSynchronize(stream);
+  long long cycles = 0;
+  rtMemcpy(&cycles, sizeof(cycles), dout, sizeof(cycles),
+           RT_MEMCPY_DEVICE_TO_HOST);
+  return cycles;
+}
+
+static long long minimum(const char *fn, rtStream_t stream, void *dout, int K,
+                         int nwarp, int iters, int mode) {
+  long long result = (long long)1e18;
+  for (int rep = 0; rep < 7; ++rep) {
+    long long value = runK(fn, stream, dout, K, nwarp, iters, mode);
+    if (value < result)
+      result = value;
+  }
+  return result;
+}
+
+static double cyclesPerIter(const char *fn, rtStream_t stream, void *dout,
+                            int nwarp, int mode) {
+  const int K = 20;
+  const int I1 = 256;
+  const int I2 = 1024;
+  long long c1 = minimum(fn, stream, dout, K, nwarp, I1, mode);
+  long long c2 = minimum(fn, stream, dout, K, nwarp, I2, mode);
+  return (double)(c2 - c1) / ((double)(I2 - I1) * K);
+}
+
+int main() {
+  aclInit(nullptr);
+  rtSetDevice(0);
+  char *binary = nullptr;
+  void *handle = reg("simt_shuffle.o", &binary);
+  const char *fn = "measure";
+  rtFunctionRegister(handle, fn, fn, (void *)fn, 0);
+  rtStream_t stream;
+  rtStreamCreate(&stream, 0);
+  void *dout = nullptr;
+  rtMalloc(&dout, sizeof(long long), RT_MEMORY_HBM, 0);
+
+  runK(fn, stream, dout, 2, 4, 16, 0);
+  printf("SIMT __shfl_up dependent and ILP4 throughput\n");
+  printf("warps,dependent_cycles,dependent_warp_shuffles_per_cycle,"
+         "ilp4_cycles,ilp4_warp_shuffles_per_cycle\n");
+  for (int warps : {1, 2, 4, 8, 16, 32}) {
+    double depCycles = cyclesPerIter(fn, stream, dout, warps, 0);
+    double ilpCycles = cyclesPerIter(fn, stream, dout, warps, 1);
+    printf("%d,%.6f,%.6f,%.6f,%.6f\n", warps, depCycles,
+           (double)warps / depCycles, ilpCycles,
+           (double)warps * 4.0 / ilpCycles);
+  }
+
+  rtFree(dout);
+  rtStreamDestroy(stream);
+  rtDeviceReset(0);
+  aclFinalize();
+  delete[] binary;
+  return 0;
+}

--- a/third_party/ascend/costmodel/profiles/microbench/data_provider/tput.cce
+++ b/third_party/ascend/costmodel/profiles/microbench/data_provider/tput.cce
@@ -1,0 +1,93 @@
+// Saturated-throughput comparison: SIMD vs SIMT on the SAME AIV vector unit,
+// PLUS a SIMD ILP sweep to pin the vector issue width (full-width vadd/cycle).
+// Both grind independent ADD chains with the vector unit kept BUSY, so we
+// compare peak arithmetic throughput (scalar adds / cycle), not a specific algo.
+//   mode 0 : SIMT  — async_invoke, each of nlane*nwarp threads does 8 indep adds/iter
+//   mode 1 : SIMD  — inline __VEC_SCOPE__, `nwarp` independent full-width VectorRegs
+//                    (ILP = nwarp, 1..8); sweeping it shows where throughput saturates.
+// fp32 vector width W = sizeof(vector_f32)/4 = 64 lanes per vector op (dav-c310).
+#include "RegBase/VecUtils.h"
+#include "Vector/VecUtils.h"
+#include "Utils.h"
+
+using DT = float;
+constexpr int W = 64; // fp32 lanes per VectorReg (sizeof(vector_f32)==256B)
+
+#if defined(__DAV_C310__)
+// SIMT: each active thread runs 8 independent ADD chains (ILP8).
+template <typename T>
+__simt_vf__ LAUNCH_BOUND(1024) __aiv__ __attribute__((always_inline)) static void
+simt_add(__ubuf__ T *out, int nlane, int nwarp, int iters, T k) {
+  int lane = threadIdx.x;
+  int warp = threadIdx.y;
+  if (lane >= nlane || warp >= nwarp) return;
+  T b = (T)(lane + warp + 1);
+  T a0=b, a1=b+1, a2=b+2, a3=b+3, a4=b+4, a5=b+5, a6=b+6, a7=b+7;
+  for (int i = 0; i < iters; i++) {
+    a0+=k; a1+=k; a2+=k; a3+=k; a4+=k; a5+=k; a6+=k; a7+=k;
+  }
+  out[warp * 32 + lane] = a0+a1+a2+a3+a4+a5+a6+a7;
+}
+#endif
+
+// one full-width vadd chain of length `iters` starting from ub slot j
+#define VLD(reg, j) VectorReg<DT> reg; vlds(reg, ob + (j) * W, 0, NORM)
+#define VST(reg, j) vsts(reg, ob + (j) * W, 0, NORM_B32, m)
+
+extern "C" __global__ [aicore] void measure(__gm__ long long *out, int K, int nlane, int nwarp, int iters, int mode) {
+  auto ob = reinterpret_cast<__ubuf__ DT *>(0);
+  auto kb = reinterpret_cast<__ubuf__ DT *>(8192);
+  uint32_t cnt = (uint32_t)W;
+  int ilp = nwarp; // for SIMD (mode 1), nwarp carries the ILP count
+
+  pipe_barrier(PIPE_ALL);
+  long long t0 = get_sys_cnt();
+  for (int i = 0; i < K; i++) {
+    if (mode == 0) {
+      cce::async_invoke<simt_add<DT>>(cce::dim3{32, 32, 1}, ob, nlane, nwarp, iters, (DT)1.0000001f);
+    } else {
+      __VEC_SCOPE__ {
+        vector_bool m;
+        CREATE_MASK_BY_SIZE(m, DT, cnt);
+        VectorReg<DT> kk;
+        vlds(kk, kb, 0, NORM);
+        // `ilp` independent full-width vadd chains -> sweep to find the issue width
+        if (ilp <= 1) {
+          VLD(a0, 0);
+          for (uint16_t r = 0; r < (uint16_t)iters; r++) { vadd(a0,a0,kk,m); }
+          VST(a0, 0);
+        } else if (ilp == 2) {
+          VLD(a0,0); VLD(a1,1);
+          for (uint16_t r = 0; r < (uint16_t)iters; r++) { vadd(a0,a0,kk,m); vadd(a1,a1,kk,m); }
+          VST(a0,0); VST(a1,1);
+        } else if (ilp == 3) {
+          VLD(a0,0); VLD(a1,1); VLD(a2,2);
+          for (uint16_t r = 0; r < (uint16_t)iters; r++) { vadd(a0,a0,kk,m); vadd(a1,a1,kk,m); vadd(a2,a2,kk,m); }
+          VST(a0,0); VST(a1,1); VST(a2,2);
+        } else if (ilp == 4) {
+          VLD(a0,0); VLD(a1,1); VLD(a2,2); VLD(a3,3);
+          for (uint16_t r = 0; r < (uint16_t)iters; r++) { vadd(a0,a0,kk,m); vadd(a1,a1,kk,m); vadd(a2,a2,kk,m); vadd(a3,a3,kk,m); }
+          VST(a0,0); VST(a1,1); VST(a2,2); VST(a3,3);
+        } else if (ilp == 6) {
+          VLD(a0,0); VLD(a1,1); VLD(a2,2); VLD(a3,3); VLD(a4,4); VLD(a5,5);
+          for (uint16_t r = 0; r < (uint16_t)iters; r++) {
+            vadd(a0,a0,kk,m); vadd(a1,a1,kk,m); vadd(a2,a2,kk,m);
+            vadd(a3,a3,kk,m); vadd(a4,a4,kk,m); vadd(a5,a5,kk,m);
+          }
+          VST(a0,0); VST(a1,1); VST(a2,2); VST(a3,3); VST(a4,4); VST(a5,5);
+        } else { // ilp >= 8
+          VLD(a0,0); VLD(a1,1); VLD(a2,2); VLD(a3,3); VLD(a4,4); VLD(a5,5); VLD(a6,6); VLD(a7,7);
+          for (uint16_t r = 0; r < (uint16_t)iters; r++) {
+            vadd(a0,a0,kk,m); vadd(a1,a1,kk,m); vadd(a2,a2,kk,m); vadd(a3,a3,kk,m);
+            vadd(a4,a4,kk,m); vadd(a5,a5,kk,m); vadd(a6,a6,kk,m); vadd(a7,a7,kk,m);
+          }
+          VST(a0,0); VST(a1,1); VST(a2,2); VST(a3,3); VST(a4,4); VST(a5,5); VST(a6,6); VST(a7,7);
+        }
+      }
+    }
+    pipe_barrier(PIPE_ALL);
+  }
+  long long t1 = get_sys_cnt();
+  pipe_barrier(PIPE_ALL);
+  out[0] = t1 - t0;
+}

--- a/third_party/ascend/costmodel/profiles/microbench/data_provider/tput_host.cpp
+++ b/third_party/ascend/costmodel/profiles/microbench/data_provider/tput_host.cpp
@@ -1,0 +1,168 @@
+// Host driver for tput.cce — measures saturated arithmetic throughput
+// (scalar adds / cycle) for SIMD vs SIMT, and a fine SIMT warp sweep to count
+// how many warps actually run independently.
+#include "runtime/runtime/rt.h"
+#include <acl/acl.h>
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <sys/time.h>
+
+using namespace std;
+
+static unsigned long us() {
+  timeval t;
+  gettimeofday(&t, 0);
+  return t.tv_sec * 1000000UL + t.tv_usec;
+}
+
+static char *readBin(const char *f, uint32_t *sz) {
+  ifstream s(f, ios::binary);
+  s.seekg(0, ios::end);
+  size_t n = s.tellg();
+  s.seekg(0);
+  char *b = new char[n];
+  s.read(b, n);
+  *sz = n;
+  return b;
+}
+
+static void *reg(const char *bin, char **buf) {
+  uint32_t sz;
+  *buf = readBin(bin, &sz);
+  rtDevBinary_t b;
+  b.data = *buf;
+  b.length = sz;
+  b.magic = RT_DEV_BINARY_MAGIC_ELF_AIVEC;
+  b.version = 0;
+  void *h = 0;
+  rtDevBinaryRegister(&b, &h);
+  return h;
+}
+
+struct Args {
+  void *out;
+  int K;
+  int nlane;
+  int nwarp;
+  int iters;
+  int mode;
+};
+
+static long long runK(const char *fn, rtStream_t s, void *dout, int K,
+                      int nlane, int nwarp, int iters, int mode) {
+  Args a{dout, K, nlane, nwarp, iters, mode};
+  rtArgsEx_t ai = {};
+  ai.args = &a;
+  ai.argsSize = sizeof(a);
+  rtTaskCfgInfo_t c = {};
+  c.localMemorySize = 192 * 1024;
+  rtKernelLaunchWithFlagV2((void *)fn, 1, &ai, 0, s, 0, &c);
+  rtStreamSynchronize(s);
+  long long cyc = 0;
+  rtMemcpy(&cyc, 8, dout, 8, RT_MEMCPY_DEVICE_TO_HOST);
+  return cyc;
+}
+
+static long long mn(const char *fn, rtStream_t s, void *dout, int K, int nl,
+                    int nw, int it, int md, int rep) {
+  long long m = (long long)1e18;
+  for (int i = 0; i < rep; i++) {
+    long long c = runK(fn, s, dout, K, nl, nw, it, md);
+    if (c < m)
+      m = c;
+  }
+  return m;
+}
+
+static double FREQ; // MHz
+
+// cyc per iter-of-one-launch via the slope over iters (removes launch + timer).
+static double cycPerIter(const char *fn, rtStream_t s, void *dout, int nl,
+                         int nw, int md) {
+  const int K = 20, I1 = 400, I2 = 1200;
+  long long c1 = mn(fn, s, dout, K, nl, nw, I1, md, 7);
+  long long c2 = mn(fn, s, dout, K, nl, nw, I2, md, 7);
+  return (double)(c2 - c1) / ((double)(I2 - I1) * K);
+}
+
+int main() {
+  aclInit(0);
+  rtSetDevice(0);
+  char *buf;
+  void *h = reg("tput.o", &buf);
+  const char *fn = "measure";
+  rtFunctionRegister(h, fn, fn, (void *)fn, 0);
+  rtStream_t s;
+  rtStreamCreate(&s, 0);
+  void *dout;
+  rtMalloc(&dout, 8, RT_MEMORY_HBM, 0);
+
+  runK(fn, s, dout, 10, 32, 32, 100, 0); // warmup
+
+  // calibrate SYS_CNT MHz (host wall-clock vs device cycles on a long run)
+  const int CK = 4000;
+  long long cmin = (long long)1e18;
+  unsigned long hmin = -1UL;
+  for (int i = 0; i < 7; i++) {
+    unsigned long t0 = us();
+    long long c = runK(fn, s, dout, CK, 32, 32, 100, 0);
+    unsigned long dt = us() - t0;
+    if (dt < hmin) {
+      hmin = dt;
+      cmin = c;
+    }
+  }
+  FREQ = (double)cmin / (double)hmin;
+  printf("CALIB: %lld cyc / %lu us = %.1f MHz (1 cyc = %.3f ns)\n", cmin, hmin,
+         FREQ, 1000.0 / FREQ);
+  printf("fp32 vector width W = 64 lanes/op\n\n");
+
+  // --- SIMD ILP sweep: throughput vs #independent vadd chains -> issue width
+  // --- mode 1, nwarp carries ILP. adds/iter = ILP*64. vadd/cyc = adds/cyc
+  // / 64. Where adds/cyc stops growing = peak full-width vadd issue/cycle.
+  printf("== SIMD ILP sweep (independent full-width vadd chains) -> issue "
+         "width ==\n");
+  double simdSat = 0;
+  for (int ilp : {1, 2, 3, 4, 6, 8}) {
+    double cpi = cycPerIter(fn, s, dout, 0, ilp, 1);
+    double tput = (double)ilp * 64.0 / cpi; // scalar adds/cyc
+    double vaddPerCyc = tput / 64.0;        // full-width vadds/cyc
+    printf("ILP=%d : %6.2f cyc/iter -> %6.1f adds/cyc = %.2f full-width "
+           "vadd/cyc\n",
+           ilp, cpi, tput, vaddPerCyc);
+    if (tput > simdSat)
+      simdSat = tput;
+  }
+
+  // --- SIMT peak (1024 threads) + ratio ---
+  double cpiSimt = cycPerIter(fn, s, dout, 32, 32, 0);
+  double simtSat = 32.0 * 32 * 8 / cpiSimt;
+  printf("\nSIMT 1024-thread peak : %6.1f adds/cyc = %.2f full-width "
+         "vadd-equiv/cyc\n",
+         simtSat, simtSat / 64.0);
+  printf(">> SIMD peak / SIMT peak = %.2fx  (SIMT ~ 1/%.2f of SIMD)\n\n",
+         simdSat / simtSat, simdSat / simtSat);
+
+  // --- Fine warp sweep: how many warps run independently? (per-launch cyc,
+  // fixed iters) ---
+  printf("== Fine SIMT warp sweep (nlane=32, iters=400, ILP8) -> knee = "
+         "#independent warps ==\n");
+  for (int nw : {1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 24, 32}) {
+    const int K = 20;
+    long long c1 = mn(fn, s, dout, K, 32, nw, 400, 0, 7);
+    long long c2 = mn(fn, s, dout, K, 32, nw, 1200, 0, 7);
+    double perLaunchIterCyc =
+        (double)(c2 - c1) /
+        ((double)(1200 - 400) * K); // cyc/iter for this width
+    double adds = 32.0 * nw * 8;
+    printf("nwarp=%2d (%4d thr) : %7.2f cyc/iter  ->  %7.1f adds/cyc\n", nw,
+           nw * 32, perLaunchIterCyc, adds / perLaunchIterCyc);
+  }
+
+  rtFree(dout);
+  rtStreamDestroy(s);
+  rtDeviceReset(0);
+  aclFinalize();
+  return 0;
+}

--- a/third_party/ascend/costmodel/profiles/microbench/data_provider/transition.cce
+++ b/third_party/ascend/costmodel/profiles/microbench/data_provider/transition.cce
@@ -1,0 +1,95 @@
+// Measure SIMD/SIMT boundary costs with in-kernel SYS_CNT slope.
+//
+// Modes:
+//   0: SIMD tail only
+//   1: empty SIMT async_invoke only
+//   2: empty SIMT async_invoke followed by SIMD tail, no mid barrier
+//   3: SIMD tail followed by empty SIMT async_invoke, no mid barrier
+//   4: empty SIMT async_invoke, mid barrier, then SIMD tail
+//   5: SIMD tail, mid barrier, then empty SIMT async_invoke
+//   6: barrier only
+//
+// Each mode is repeated K times inside one AICore kernel. The host measures the
+// slope over K to remove SYS_CNT read and host launch overhead.
+#include "RegBase/VecUtils.h"
+#include "Vector/VecUtils.h"
+#include "Utils.h"
+
+using __cce_simd::NORM;
+using __cce_simd::NORM_B32;
+using __cce_simd::POST_UPDATE;
+
+using DT = float;
+
+template <typename T>
+__simt_vf__ LAUNCH_BOUND(1024) __aiv__ __attribute__((always_inline)) static void
+empty_vf(__ubuf__ T *p) {
+  if (threadIdx.x == 0 && threadIdx.y == 0) {
+    p[0] = (T)1;
+  }
+}
+
+__aiv__ __attribute__((always_inline)) static void simd_tail(__ubuf__ DT *src, __ubuf__ DT *dst, uint32_t cnt) {
+  __VEC_SCOPE__ {
+    VectorReg<DT> x, y;
+    vector_bool m;
+    CREATE_MASK_BY_SIZE(m, DT, cnt);
+    vlds(x, dst, 0, NORM);
+    vadd(y, x, x, m);
+    vsts(y, dst, 0, NORM_B32, m);
+  }
+}
+
+extern "C" __global__ [aicore] void measure(__gm__ long long *out, int K, int nwarp, int cnt, int tail_reps, int mode) {
+  auto src = reinterpret_cast<__ubuf__ DT *>(0);
+  auto dst = reinterpret_cast<__ubuf__ DT *>(32768);
+  uint32_t active = (uint32_t)(cnt <= 0 ? 64 : cnt);
+  int warps = nwarp;
+  if (warps < 1) {
+    warps = 1;
+  }
+  if (warps > 32) {
+    warps = 32;
+  }
+  int reps = tail_reps <= 0 ? 1 : tail_reps;
+
+  pipe_barrier(PIPE_ALL);
+  long long t0 = get_sys_cnt();
+  for (int i = 0; i < K; i++) {
+    if (mode == 6) {
+      // The loop epilogue pipe_barrier below is the measured operation.
+    } else if (mode == 0) {
+      for (int r = 0; r < reps; r++) {
+        simd_tail(src, dst, active);
+      }
+    } else if (mode == 1) {
+      cce::async_invoke<empty_vf<DT>>(cce::dim3{32, (unsigned)warps, 1}, src);
+    } else if (mode == 2) {
+      cce::async_invoke<empty_vf<DT>>(cce::dim3{32, (unsigned)warps, 1}, src);
+      for (int r = 0; r < reps; r++) {
+        simd_tail(src, dst, active);
+      }
+    } else if (mode == 3) {
+      for (int r = 0; r < reps; r++) {
+        simd_tail(src, dst, active);
+      }
+      cce::async_invoke<empty_vf<DT>>(cce::dim3{32, (unsigned)warps, 1}, src);
+    } else if (mode == 4) {
+      cce::async_invoke<empty_vf<DT>>(cce::dim3{32, (unsigned)warps, 1}, src);
+      pipe_barrier(PIPE_ALL);
+      for (int r = 0; r < reps; r++) {
+        simd_tail(src, dst, active);
+      }
+    } else {
+      for (int r = 0; r < reps; r++) {
+        simd_tail(src, dst, active);
+      }
+      pipe_barrier(PIPE_ALL);
+      cce::async_invoke<empty_vf<DT>>(cce::dim3{32, (unsigned)warps, 1}, src);
+    }
+    pipe_barrier(PIPE_ALL);
+  }
+  long long t1 = get_sys_cnt();
+  pipe_barrier(PIPE_ALL);
+  out[0] = t1 - t0;
+}

--- a/third_party/ascend/costmodel/profiles/microbench/data_provider/transition_host.cpp
+++ b/third_party/ascend/costmodel/profiles/microbench/data_provider/transition_host.cpp
@@ -1,0 +1,172 @@
+// Host driver for transition.cce. It reports per-iteration costs and derives:
+//   no-barrier extras:
+//     mode2 - mode1 - mode0, mode3 - mode0 - mode1
+//   mid-barrier extras:
+//     mode4 - mode1 - mode0, mode5 - mode0 - mode1
+#include "runtime/runtime/rt.h"
+#include <acl/acl.h>
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <sys/time.h>
+
+using namespace std;
+
+static unsigned long us() {
+  timeval t;
+  gettimeofday(&t, 0);
+  return t.tv_sec * 1000000UL + t.tv_usec;
+}
+
+static char *readBin(const char *f, uint32_t *sz) {
+  ifstream s(f, ios::binary);
+  s.seekg(0, ios::end);
+  size_t n = s.tellg();
+  s.seekg(0);
+  char *b = new char[n];
+  s.read(b, n);
+  *sz = n;
+  return b;
+}
+
+static void *reg(const char *bin, char **buf) {
+  uint32_t sz;
+  *buf = readBin(bin, &sz);
+
+  rtDevBinary_t b;
+  b.data = *buf;
+  b.length = sz;
+  b.magic = RT_DEV_BINARY_MAGIC_ELF_AIVEC;
+  b.version = 0;
+
+  void *h = 0;
+  rtDevBinaryRegister(&b, &h);
+  return h;
+}
+
+struct Args {
+  void *out;
+  int K;
+  int nwarp;
+  int cnt;
+  int tail_reps;
+  int mode;
+};
+
+static long long runK(const char *fn, rtStream_t s, void *dout, int K,
+                      int nwarp, int cnt, int tail_reps, int mode) {
+  Args a{dout, K, nwarp, cnt, tail_reps, mode};
+
+  rtArgsEx_t ai = {};
+  ai.args = &a;
+  ai.argsSize = sizeof(a);
+
+  rtTaskCfgInfo_t c = {};
+  c.localMemorySize = 192 * 1024;
+
+  rtKernelLaunchWithFlagV2((void *)fn, 1, &ai, 0, s, 0, &c);
+  rtStreamSynchronize(s);
+
+  long long cyc = 0;
+  rtMemcpy(&cyc, 8, dout, 8, RT_MEMCPY_DEVICE_TO_HOST);
+  return cyc;
+}
+
+static long long mn(const char *fn, rtStream_t s, void *dout, int K, int nwarp,
+                    int cnt, int tail_reps, int mode, int rep) {
+  long long m = (long long)1e18;
+  for (int i = 0; i < rep; i++) {
+    long long c = runK(fn, s, dout, K, nwarp, cnt, tail_reps, mode);
+    if (c < m) {
+      m = c;
+    }
+  }
+  return m;
+}
+
+static double FREQ;
+
+static double perIter(const char *fn, rtStream_t s, void *dout, int nwarp,
+                      int cnt, int tail_reps, int mode) {
+  const int K1 = 100;
+  const int K2 = 500;
+  long long c1 = mn(fn, s, dout, K1, nwarp, cnt, tail_reps, mode, 9);
+  long long c2 = mn(fn, s, dout, K2, nwarp, cnt, tail_reps, mode, 9);
+  return (double)(c2 - c1) / (double)(K2 - K1);
+}
+
+static void print_row(int nw, double barrier, double simd, double simt,
+                      double nb_sts, double nb_st, double mb_sts,
+                      double mb_st) {
+  double nb_simt_to_simd = nb_sts - simt - simd;
+  double nb_simd_to_simt = nb_st - simd - simt;
+  double mb_simt_to_simd = mb_sts - simt - simd;
+  double mb_simd_to_simt = mb_st - simd - simt;
+  printf("nwarp=%2d  barrier=%7.1f  simd=%7.1f  simt=%7.1f  "
+         "raw_nb(sts/st)=%7.1f/%7.1f  raw_mb(sts/st)=%7.1f/%7.1f\n",
+         nw, barrier, simd, simt, nb_sts, nb_st, mb_sts, mb_st);
+  printf("          approx net cyc: simd-barrier=%7.1f simt-barrier=%7.1f\n",
+         simd - barrier, simt - barrier);
+  printf("          extra cyc: no_barrier simt->simd=%7.1f simd->simt=%7.1f | "
+         "mid_barrier simt->simd=%7.1f simd->simt=%7.1f\n",
+         nb_simt_to_simd, nb_simd_to_simt, mb_simt_to_simd, mb_simd_to_simt);
+  printf("          extra ns : no_barrier simt->simd=%7.1f simd->simt=%7.1f | "
+         "mid_barrier simt->simd=%7.1f simd->simt=%7.1f\n",
+         nb_simt_to_simd / FREQ * 1000.0, nb_simd_to_simt / FREQ * 1000.0,
+         mb_simt_to_simd / FREQ * 1000.0, mb_simd_to_simt / FREQ * 1000.0);
+}
+
+int main() {
+  aclInit(0);
+  rtSetDevice(0);
+
+  char *buf;
+  void *h = reg("transition.o", &buf);
+  const char *fn = "measure";
+  rtFunctionRegister(h, fn, fn, (void *)fn, 0);
+
+  rtStream_t s;
+  rtStreamCreate(&s, 0);
+
+  void *dout;
+  rtMalloc(&dout, 8, RT_MEMORY_HBM, 0);
+
+  const int tail_reps = 16;
+  runK(fn, s, dout, 20, 32, 64, tail_reps, 1);
+
+  const int CK = 8000;
+  long long cmin = (long long)1e18;
+  unsigned long hmin = -1UL;
+  for (int i = 0; i < 7; i++) {
+    unsigned long t0 = us();
+    long long c = runK(fn, s, dout, CK, 32, 64, tail_reps, 1);
+    unsigned long dt = us() - t0;
+    if (dt < hmin) {
+      hmin = dt;
+      cmin = c;
+    }
+  }
+  FREQ = (double)cmin / (double)hmin;
+  printf("CALIB: %lld cyc / %lu us = %.1f MHz (1 cyc = %.3f ns)\n\n", cmin,
+         hmin, FREQ, 1000.0 / FREQ);
+
+  printf("== SIMD/SIMT transition sweep (cnt=64, tail_reps=%d, K slope "
+         "100->500) ==\n",
+         tail_reps);
+  for (int nw : {1, 2, 4, 8, 16, 32}) {
+    double barrier = perIter(fn, s, dout, nw, 64, tail_reps, 6);
+    double simd = perIter(fn, s, dout, nw, 64, tail_reps, 0);
+    double simt = perIter(fn, s, dout, nw, 64, tail_reps, 1);
+    double nb_sts = perIter(fn, s, dout, nw, 64, tail_reps, 2);
+    double nb_st = perIter(fn, s, dout, nw, 64, tail_reps, 3);
+    double mb_sts = perIter(fn, s, dout, nw, 64, tail_reps, 4);
+    double mb_st = perIter(fn, s, dout, nw, 64, tail_reps, 5);
+    print_row(nw, barrier, simd, simt, nb_sts, nb_st, mb_sts, mb_st);
+  }
+
+  rtFree(dout);
+  rtStreamDestroy(s);
+  rtDeviceReset(0);
+  aclFinalize();
+  return 0;
+}

--- a/third_party/ascend/costmodel/profiles/microbench/microbenchmark_profile_schema.json
+++ b/third_party/ascend/costmodel/profiles/microbench/microbenchmark_profile_schema.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "microbenchmark_profile_schema.json",
+  "title": "Ascend shared microbenchmark evidence profile",
+  "description": "Model-neutral hardware facts and isolated measurements shared by the absolute and SIMD/SIMT route cost models.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "profile_version",
+    "target",
+    "description",
+    "measurements"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Relative path to this JSON Schema; used by editors and validators, not by the cost formula."
+    },
+    "schema_version": {
+      "const": 1,
+      "description": "Machine-readable layout version expected by MicrobenchmarkProfile::loadFromJSON."
+    },
+    "profile_version": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable version of this concrete target evidence set."
+    },
+    "target": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Canonical compiler target for which every measurement in this file is valid."
+    },
+    "description": {
+      "type": "string",
+      "description": "Purpose and ownership boundary of the complete shared evidence profile."
+    },
+    "measurements": {
+      "type": "object",
+      "minProperties": 1,
+      "description": "Map from stable semantic measurement keys to typed values and their provenance.",
+      "additionalProperties": {
+        "$ref": "#/definitions/measurement"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "measurement": {
+      "type": "object",
+      "description": "One model-neutral hardware fact or isolated measurement with units, scope, provenance, and evidence confidence.",
+      "required": [
+        "description",
+        "value",
+        "unit",
+        "cycle_domain",
+        "scope",
+        "source_kind",
+        "source",
+        "confidence"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable meaning of this measurement and the distinction from similarly named rates."
+        },
+        "value": {
+          "type": "number",
+          "description": "Measured or declared numeric value before any cost-model-specific scaling."
+        },
+        "unit": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Physical unit of value; loaders validate the expected unit at each use site."
+        },
+        "cycle_domain": {
+          "type": "string",
+          "enum": [
+            "none",
+            "wall_clock",
+            "SYS_CNT",
+            "device_compute"
+          ],
+          "description": "Clock domain for cycle-based values; required for correct rate conversion."
+        },
+        "scope": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Exact execution scope and workload shape, such as one AIV, warp count, dependency pattern, and working set."
+        },
+        "source_kind": {
+          "type": "string",
+          "enum": [
+            "isolated_microbenchmark",
+            "device_configuration",
+            "architecture_fact"
+          ],
+          "description": "Evidence category: measured result, device configuration, or architecture contract."
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Reproducible file, command, configuration, or artifact from which value was obtained."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "high",
+            "medium",
+            "low"
+          ],
+          "description": "Evidence confidence. This is consumed by Route Model admission and is not a documentation-only comment."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/third_party/ascend/costmodel/profiles/simd_simt/david_v100_des_feedback_v1.json
+++ b/third_party/ascend/costmodel/profiles/simd_simt/david_v100_des_feedback_v1.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "kind": "simd_simt_calibration_feedback",
+  "profile_version": "david-v100-des-feedback-20260727-v1",
+  "feedback_version": "david-v100-des-feedback-20260727-v1",
+  "target": "Ascend950PR/dav-c310",
+  "base_profile_version": "david-v100-simd-simt-20260727-v3",
+  "rules": [],
+  "validation": {
+    "event_validated": false,
+    "maximum_fallback_ratio": 0.1
+  },
+  "provenance": {
+    "producer": "HIVMAnalysisReport JSON",
+    "policy": "Only enable a rule after op coverage and source mapping pass their gates",
+    "current_status": "Interface enabled; no correction is applied because the current gather-dot DES run has 1672/1727 scalar-or-unknown fallback operations and FBGEMM three-candidate coverage is incomplete"
+  }
+}

--- a/third_party/ascend/costmodel/profiles/simd_simt/david_v100_simd_simt_v1.json
+++ b/third_party/ascend/costmodel/profiles/simd_simt/david_v100_simd_simt_v1.json
@@ -1,0 +1,337 @@
+{
+  "$schema": "./simd_simt_profile_schema.json",
+  "schema_version": 4,
+  "profile_version": "david-v100-simd-simt-20260806-v11",
+  "target": "Ascend950PR/dav-c310",
+  "description": "Route Model policy and target-specific calibration used to rank all-SIMD, all-SIMT, and mixed SIMD/SIMT candidates. Model-neutral hardware measurements are referenced from microbenchmark_profile instead of duplicated here.",
+  "microbenchmark_profile": "../microbench/ascend_davidv100_v1.json",
+  "compatible_targets": [
+    "Ascend950*",
+    "Ascend910_95*",
+    "dav-c310"
+  ],
+  "score_unit": "system_cycle_selection_score",
+  "policy": {
+    "description": "Admission policy for turning a ranking into an actionable route decision. Only minimum_confidence_for_decision is currently consumed by the C++ loader.",
+    "minimum_confidence_for_decision": "low",
+    "unknown_op": "mark_low_confidence",
+    "notes": "Analytical payloads use SYS_CNT cycles, but Event-calibrated structural residuals make final values selection scores rather than literal measured cycles. Low-confidence rankings may act only inside the bounded calibration domain and must still pass target, unsupported-term, legality, and gain gates."
+  },
+  "selection_calibration": {
+    "description": "Route-specific calibration that converts analytical resource costs into relative selection scores and bounds where those scores may make decisions. Mixed cost is partitioned from the materializable anchor plan; the removed legacy mixed_simd_fraction blend no longer participates.",
+    "program_issue_scale": 8.0,
+    "ranking_confidence": "low",
+    "source": "v11 keeps the measured masked-rowwise and tiny-gather-dot calibration, but invalidates the previous label-only triangular mixed result. Mixed scoring now uses the exact materialized scope operation set and insertion point, including safely movable mask setup but excluding the initial SIMD loads and dense dot tail; recognized 16x16 triangular recurrences use the structurally derived 14-trip full-block estimate; and SIMT predicate/shuffle work uses loop-weighted lane counts. Triangular route multipliers remain identity and non-SIMD production selection remains disabled until a real hivm.vf_mode<SIMT> A5 run is measured. No directional SIMD/SIMT boundary latency has been measured.",
+    "coverage": {
+      "description": "Feature-domain limits within which Event-calibrated structural ranking is admitted; these are model validity bounds rather than hardware limits. Masked-rowwise, rank-1 and triangular-solve use independent thresholds. The triangular bounds describe one BT64 scope containing four 16x16 recurrences and 56 structurally modeled loop trips/reductions; they do not reuse the rowwise ceiling of 16.",
+      "minimum_irregular_density": 0.25,
+      "tiny_dot_flops_max": 16384,
+      "tiny_dot_max_tensor_numel": 256,
+      "rowwise_loop_trip_sum_max": 32,
+      "rowwise_mask_rank_sum_max": 48,
+      "rowwise_weighted_reductions_max": 16,
+      "rowwise_max_tensor_numel": 128,
+      "rank1_weighted_reductions_max": 8,
+      "rank1_max_tensor_numel": 2048,
+      "triangular_loop_count_max": 4,
+      "triangular_loop_trip_sum_max": 56,
+      "triangular_mask_rank_sum_max": 64,
+      "triangular_weighted_reductions_max": 56,
+      "triangular_max_tensor_numel": 256
+    },
+    "simd_structural_penalty_ratio": {
+      "description": "Additive SIMD-only residual ratios for irregular addressing, mask materialization, reductions, loops, control flow, tiny dot, and rank-1 indirect reduction patterns. Their sum multiplies A_SIMD; A_SIMT never participates in the all-SIMD cost.",
+      "irregular_per_density": 0.8,
+      "irregular_cap": 0.5,
+      "tiny_dot_irregular_per_density": 0.24,
+      "tiny_dot_irregular_cap": 0.12,
+      "per_mask_rank": 0.022,
+      "mask_cap": 0.35,
+      "per_weighted_reduction": 0.02,
+      "reduction_cap": 0.15,
+      "per_static_loop_trip": 0.008,
+      "loop_cap": 0.15,
+      "control_flow": 0.03,
+      "rank1_indirect_vector_reduction": 0.75,
+      "tiny_dot": 0.06,
+      "tiny_dot_flops_max": 16384
+    },
+    "event_route_score_multiplier": {
+      "description": "Low-confidence route-relative residual calibration. For each bounded feature domain, calibrated_score = raw_analytical_structural_score * route_multiplier. Masked-rowwise and tiny-irregular-dot retain their measured A5 multipliers; triangular-solve uses identity placeholders after its former label-only mixed evidence was invalidated. Raw scores and multipliers are both emitted in the report. A validated flag may promote a non-default route only after correctness and real lowering were independently verified.",
+      "domains": {
+        "masked_rowwise_reduction": {
+          "all_simd": 67.628046,
+          "all_simt_only": 0.807671,
+          "mixed_simd_simt": 3.537276,
+          "all_simt_only_validated": true,
+          "mixed_simd_simt_validated": true,
+          "source": "A5 card 0, FBGEMM T128/D128/H8/num_warps4, 30 warmup + 100 NPU Event samples: median all-SIMD 68.9340 us, all-SIMT 26.7795 us, Auto mixed 36.0365 us; all routes correctness PASS.",
+          "confidence": "low"
+        },
+        "tiny_irregular_dot": {
+          "all_simd": 1.321185,
+          "all_simt_only": 1.0,
+          "mixed_simd_simt": 0.666478,
+          "all_simt_only_validated": false,
+          "mixed_simd_simt_validated": true,
+          "source": "A5 card 0, gather-dot-min M16/N16/K16/num_warps4, one process with routes interleaved after 50 warmup, 200 NPU Event samples each: median all-SIMD 29.2525 us and correctness PASS; all-SIMT 25.1570 us but mismatched 256/256 elements; C++-materialized 2-scope mixed 25.3980 us and correctness PASS after lowering buffer-semantics identity vtranspose to copy and using cross-core GSS instead of the delayed variant whose split-side anchor interval is reversed. Mixed is 13.18% faster than all-SIMD.",
+          "confidence": "low"
+        },
+        "triangular_solve_loop": {
+          "all_simd": 1.0,
+          "all_simt_only": 1.0,
+          "mixed_simd_simt": 1.0,
+          "all_simt_only_validated": false,
+          "mixed_simd_simt_validated": false,
+          "source": "Identity placeholders after invalidating the previous solve-tril calibration. The old feature extractor treated each dynamic 16x16 recurrence as one iteration instead of the structurally known 14 and the earlier 22.3130 us mixed label did not pass --enable-simd-simt-mix-compile. Both non-SIMD production routes stay disabled until the canonical vec_mode scope is observed as hivm.vf_mode<SIMT>, the corrected raw scores are emitted, and all routes are remeasured on A5 card 0.",
+          "confidence": "low"
+        }
+      }
+    }
+  },
+  "simd": {
+    "description": "Inputs used to estimate the all-SIMD candidate: SIMD width, setup, operation, memory, and dot costs.",
+    "vector_width_measurement": "simd.vector_width_bits",
+    "startup_system_cycles": {
+      "description": "Legacy SIMD pipeline startup priors in SYS_CNT cycles. Only vector is currently consumed by Route Model scoring.",
+      "vector": 21.212121,
+      "mte2": 30.303030,
+      "mte3": 24.242424,
+      "source": "Legacy selection-model seed inherited from device-cycle startup values",
+      "confidence": "low",
+      "note": "Not isolated davidV100 microbenchmark evidence; kept outside the shared catalog"
+    },
+    "ops": {
+      "f32.add": {
+        "description": "Measured FP32 SIMD add base throughput resolved from the shared microbenchmark profile.",
+        "throughput_measurement": "simd.f32.add.throughput"
+      },
+      "f32.sub": {
+        "description": "Estimated FP32 SIMD subtract cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 1.0,
+        "confidence": "medium"
+      },
+      "f32.mul": {
+        "description": "Estimated FP32 SIMD multiply cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 1.0,
+        "confidence": "medium"
+      },
+      "f32.div": {
+        "description": "Estimated FP32 SIMD divide cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 12.0,
+        "confidence": "low"
+      },
+      "f32.max": {
+        "description": "Estimated FP32 SIMD maximum cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 1.2,
+        "confidence": "medium"
+      },
+      "f32.abs": {
+        "description": "Estimated FP32 SIMD absolute-value cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 1.0,
+        "confidence": "medium"
+      },
+      "f32.exp": {
+        "description": "Estimated FP32 SIMD exponential cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 9.0,
+        "confidence": "low"
+      },
+      "f32.log": {
+        "description": "Estimated FP32 SIMD logarithm cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 12.0,
+        "confidence": "low"
+      },
+      "predicate.cmp": {
+        "description": "Estimated SIMD predicate-comparison cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 1.0,
+        "confidence": "medium"
+      },
+      "predicate.select": {
+        "description": "Estimated SIMD predicate-select cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 1.0,
+        "confidence": "low"
+      },
+      "convert.cast": {
+        "description": "Estimated SIMD conversion cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 1.5,
+        "confidence": "low"
+      },
+      "f32.clamp": {
+        "description": "Estimated FP32 SIMD clamp cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 2.0,
+        "confidence": "low"
+      }
+    },
+    "memory": {
+      "description": "Model-specific all-SIMD memory fallback rates. vector_mte2 and mte3 plus confidence are consumed; hbm is retained only as documentary legacy context.",
+      "hbm_bytes_per_system_cycle": 1617.96,
+      "vector_mte2_bytes_per_system_cycle": 202.25,
+      "mte3_bytes_per_system_cycle": 202.25,
+      "source": "Selection-model seed retained for v4 score continuity; 202.25 B/SYS_CNT-cycle corresponds to 200 GB/s and must not be presented as the davidV100 75/71 GB/s data-mover specification",
+      "confidence": "low",
+      "note": "Model-specific fallback, not shared microbenchmark evidence"
+    },
+    "dot": {
+      "description": "All-SIMD dot setup and throughput seed used for every dot operation; current calibrated admission is narrower and covers only tiny irregular dot.",
+      "startup_system_cycles": 128.0,
+      "flops_per_system_cycle": 4096.0,
+      "source": "AscendModel cube startup/throughput seed; DES feedback is expected to refine scheduled lowering",
+      "confidence": "low"
+    }
+  },
+  "simt": {
+    "description": "Inputs used to estimate the all-SIMT candidate and the SIMT portion of a mixed candidate.",
+    "warp_size_measurement": "simt.warp_size",
+    "setup_system_cycles": {
+      "description": "Conservative standalone SIMT setup proxy resolved from the serialized empty-VF shared measurement; it is completion-inclusive but still contains a UB write, barrier, and runtime-loop control.",
+      "empty_launch_measurement": "simt.setup.empty_with_barrier"
+    },
+    "ops": {
+      "f32.add": {
+        "description": "Measured FP32 SIMT scalar-add base throughput resolved from the shared microbenchmark profile.",
+        "throughput_measurement": "simt.f32.add.throughput"
+      },
+      "f32.sub": {
+        "description": "Estimated FP32 SIMT subtract cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 1.0,
+        "confidence": "medium"
+      },
+      "f32.mul": {
+        "description": "Estimated FP32 SIMT multiply cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 1.0,
+        "confidence": "medium"
+      },
+      "f32.div": {
+        "description": "Estimated FP32 SIMT divide cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 12.0,
+        "confidence": "low"
+      },
+      "f32.max": {
+        "description": "Estimated FP32 SIMT maximum cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 1.2,
+        "confidence": "medium"
+      },
+      "f32.abs": {
+        "description": "Estimated FP32 SIMT absolute-value cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 1.0,
+        "confidence": "medium"
+      },
+      "f32.exp": {
+        "description": "Estimated FP32 SIMT exponential cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 9.0,
+        "confidence": "low"
+      },
+      "f32.log": {
+        "description": "Estimated FP32 SIMT logarithm cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 12.0,
+        "confidence": "low"
+      },
+      "predicate.cmp": {
+        "description": "Estimated SIMT predicate-comparison cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 1.0,
+        "confidence": "medium"
+      },
+      "predicate.select": {
+        "description": "Estimated SIMT predicate-select cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 1.0,
+        "confidence": "low"
+      },
+      "convert.cast": {
+        "description": "Estimated SIMT conversion cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 1.5,
+        "confidence": "low"
+      },
+      "f32.clamp": {
+        "description": "Estimated FP32 SIMT clamp cost relative to f32.add; factor multiplies the base cycle estimate.",
+        "relative_to": "f32.add",
+        "factor": 2.0,
+        "confidence": "low"
+      }
+    },
+    "dot": {
+      "description": "All-SIMT dot setup and scalar-FMA throughput seed used for every dot operation; current calibrated admission is narrower and covers only tiny irregular dot.",
+      "startup_system_cycles": 64.0,
+      "flops_per_system_cycle": 141.0,
+      "source": "SIMT scalar FMA issue seed plus fixed tiny-dot setup; calibrated by gather-dot ranking",
+      "confidence": "low"
+    },
+    "camodel_effective": {
+      "description": "Workload-effective CaModel issue rates retained as fallback calibration context. The current Route Model consumes only the predicate rate from the nested rate map.",
+      "scope": "FBGEMM scope_b8; 13 active veccores",
+      "simulator_clock_mhz": 1650.0,
+      "conversion": "ops_per_system_cycle = aggregate_ops_per_simulator_cycle * simulator_clock_mhz / SYS_CNT_mhz",
+      "warp_instructions_per_system_cycle": {
+        "memory": 2.1411,
+        "float_alu": 0.6429,
+        "shuffle": 0.3763,
+        "predicate": 0.0380,
+        "control": 0.2431,
+        "int_alu": 0.2325
+      },
+      "warp_size": 32,
+      "source": "simt_camodel_calibration_scope_b8.json; remote OPPROF_20260712042738_MECSEVSNUOCUDPXV",
+      "confidence": "low",
+      "note": "These are effective issue rates for one FBGEMM workload, including its dependencies and stalls. They are fallback calibration seeds, not isolated instruction peak throughput or latency."
+    },
+    "shuffle": {
+      "description": "SIMT workload-effective shuffle rate resolved from the shared runtime-loop microbenchmark. Route-level generalization confidence is intentionally lower than measurement repeatability.",
+      "throughput_measurement": "simt.shuffle.throughput",
+      "confidence": "low"
+    },
+    "memory": {
+      "description": "SIMT workload-effective GM load/store rates resolved from sequential rotating runtime-loop measurements. Indirect/random/coalescing behavior is not calibrated by these rates.",
+      "load_throughput_measurement": "simt.gm.load.throughput",
+      "store_throughput_measurement": "simt.gm.store.throughput",
+      "confidence": "low"
+    },
+    "mixed_setup_fallback": {
+      "1": {
+        "description": "Low-confidence mixed setup fallback for one warp, sourced from a standalone empty-VF net probe rather than a mixed transition.",
+        "measurement": "simt.setup.transition_harness_net.warps_1"
+      },
+      "2": {
+        "description": "Low-confidence mixed setup fallback for two warps, sourced from a standalone empty-VF net probe rather than a mixed transition.",
+        "measurement": "simt.setup.transition_harness_net.warps_2"
+      },
+      "4": {
+        "description": "Low-confidence mixed setup fallback for four warps, sourced from a standalone empty-VF net probe rather than a mixed transition.",
+        "measurement": "simt.setup.transition_harness_net.warps_4"
+      },
+      "8": {
+        "description": "Low-confidence mixed setup fallback for eight warps, sourced from a standalone empty-VF net probe rather than a mixed transition.",
+        "measurement": "simt.setup.transition_harness_net.warps_8"
+      },
+      "16": {
+        "description": "Low-confidence mixed setup fallback for sixteen warps, sourced from a standalone empty-VF net probe rather than a mixed transition.",
+        "measurement": "simt.setup.transition_harness_net.warps_16"
+      },
+      "32": {
+        "description": "Low-confidence mixed setup fallback for thirty-two warps, sourced from a standalone empty-VF net probe rather than a mixed transition.",
+        "measurement": "simt.setup.transition_harness_net.warps_32"
+      },
+      "confidence": "low",
+      "note": "These values are mode1(empty SIMT plus tail barrier) minus mode6(barrier only) in a branch-heavy harness. They contain no SIMD phase and are used only as conservative setup fallbacks. Directional SIMD-to-SIMT, SIMT-to-SIMD, and dependent UB hand-off costs remain unmeasured."
+    }
+  }
+}

--- a/third_party/ascend/costmodel/profiles/simd_simt/david_v100_simd_simt_v1.json
+++ b/third_party/ascend/costmodel/profiles/simd_simt/david_v100_simd_simt_v1.json
@@ -83,7 +83,7 @@
           "mixed_simd_simt": 1.0,
           "all_simt_only_validated": false,
           "mixed_simd_simt_validated": false,
-          "source": "Identity placeholders after invalidating the previous solve-tril calibration. The old feature extractor treated each dynamic 16x16 recurrence as one iteration instead of the structurally known 14 and the earlier 22.3130 us mixed label did not pass --enable-simd-simt-mix-compile. Both non-SIMD production routes stay disabled until the canonical vec_mode scope is observed as hivm.vf_mode<SIMT>, the corrected raw scores are emitted, and all routes are remeasured on A5 card 0.",
+          "source": "Identity placeholders after invalidating the previous solve-tril calibration. The old feature extractor treated each dynamic 16x16 recurrence as one iteration instead of the structurally known 14 and the earlier 22.3130 us mixed label did not pass --enable-simd-simt-mix-compile. Both non-SIMD production routes stay disabled until the canonical TTIR vector_mode scope is observed as hivm.vf_mode<SIMT>, the corrected raw scores are emitted, and all routes are remeasured on A5 card 0.",
           "confidence": "low"
         }
       }

--- a/third_party/ascend/costmodel/profiles/simd_simt/simd_simt_profile_schema.json
+++ b/third_party/ascend/costmodel/profiles/simd_simt/simd_simt_profile_schema.json
@@ -1,0 +1,1021 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "simd_simt_profile_schema.json",
+  "title": "Ascend SIMD/SIMT Route Model profile",
+  "description": "Target-specific policy, calibration, priors, and measurement references used to rank all-SIMD, all-SIMT, and mixed SIMD/SIMT candidates.",
+  "$comment": "Standard JSON has no // comments. Property descriptions in this schema are the canonical field comments for Route Model profiles.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "profile_version",
+    "target",
+    "description",
+    "microbenchmark_profile",
+    "compatible_targets",
+    "score_unit",
+    "policy",
+    "selection_calibration",
+    "simd",
+    "simt"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Relative path to this JSON Schema; used by editors and offline validators, not by Route Model scoring."
+    },
+    "schema_version": {
+      "const": 4,
+      "description": "Machine-readable Route Model layout version. The current v11 profile requires schema version 4."
+    },
+    "profile_version": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Version identifier accepted by the C++ Route Model loader and emitted in decision reports."
+    },
+    "target": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Canonical target for this calibration; it must equal the target of the referenced shared microbenchmark profile."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable ownership boundary and purpose of this Route Model profile."
+    },
+    "microbenchmark_profile": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Path, relative to this file, to the model-neutral hardware measurement profile."
+    },
+    "compatible_targets": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Additional wildcard target aliases accepted by the target-compatibility gate.",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "One case-insensitive wildcard target pattern; '*' and '?' are supported."
+      }
+    },
+    "score_unit": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unit label for candidate scores. Values retain SYS_CNT-cycle structure but are selection scores after empirical residual calibration."
+    },
+    "policy": {
+      "$ref": "#/definitions/policy"
+    },
+    "selection_calibration": {
+      "$ref": "#/definitions/selection_calibration"
+    },
+    "simd": {
+      "$ref": "#/definitions/simd_model"
+    },
+    "simt": {
+      "$ref": "#/definitions/simt_model"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "confidence": {
+      "type": "string",
+      "enum": [
+        "none",
+        "low",
+        "medium",
+        "high"
+      ],
+      "description": "Evidence confidence ordered as none < low < medium < high."
+    },
+    "policy": {
+      "type": "object",
+      "description": "Decision-admission policy applied after candidate scoring.",
+      "required": [
+        "description",
+        "minimum_confidence_for_decision",
+        "unknown_op",
+        "notes"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human-readable scope and current loader-consumption status of this policy object."
+        },
+        "minimum_confidence_for_decision": {
+          "type": "string",
+          "enum": [
+            "none",
+            "low",
+            "medium",
+            "high"
+          ],
+          "description": "Minimum final ranking-confidence level required by the confidence gate."
+        },
+        "unknown_op": {
+          "type": "string",
+          "description": "Documented handling intent for unknown operations. The current C++ loader does not consume this field; unsupported terms are collected directly during analysis."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Free-form explanation of score semantics and the gates that remain mandatory; not parsed as policy logic."
+        }
+      },
+      "additionalProperties": false
+    },
+    "selection_calibration": {
+      "type": "object",
+      "description": "Model-specific scale, confidence, domain bounds, and residual terms used for route ranking.",
+      "required": [
+        "description",
+        "program_issue_scale",
+        "ranking_confidence",
+        "source",
+        "coverage",
+        "simd_structural_penalty_ratio",
+        "event_route_score_multiplier"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human-readable role and evidence boundary of the complete calibration object."
+        },
+        "program_issue_scale": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Multiplier applied after route-specific payload aggregation; SIMD uses its compute-versus-memory roofline maximum, while SIMT serially sums compute, dot, shuffle, memory, and predicate cycles. Setup cost is not multiplied."
+        },
+        "ranking_confidence": {
+          "type": "string",
+          "enum": [
+            "none",
+            "low",
+            "medium",
+            "high"
+          ],
+          "description": "Confidence assigned to Event-calibrated structural residuals; inside a covered structural domain it is combined with resource and mixed-setup-fallback confidence by taking the lowest level."
+        },
+        "source": {
+          "type": "string",
+          "description": "Workloads, measurements, and rollout boundary from which the route-specific calibration was derived. It is loaded into profile metadata but currently does not affect scoring or reports."
+        },
+        "coverage": {
+          "$ref": "#/definitions/coverage"
+        },
+        "simd_structural_penalty_ratio": {
+          "$ref": "#/definitions/simd_structural_penalty"
+        },
+        "event_route_score_multiplier": {
+          "$ref": "#/definitions/event_route_score_multiplier"
+        }
+      },
+      "additionalProperties": false
+    },
+    "event_route_score_multiplier": {
+      "type": "object",
+      "description": "Versioned Event residuals applied after analytical/structural scoring and before legal-candidate ranking.",
+      "required": [
+        "description",
+        "domains"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Formula, evidence boundary, and report visibility of the route multipliers."
+        },
+        "domains": {
+          "type": "object",
+          "minProperties": 1,
+          "description": "Map from calibration-domain name to independently measured route corrections.",
+          "additionalProperties": {
+            "$ref": "#/definitions/event_route_domain"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "event_route_domain": {
+      "type": "object",
+      "description": "One bounded workload-structure domain. Multipliers preserve feature-sensitive raw scores while correcting route-relative residual error.",
+      "required": [
+        "all_simd",
+        "all_simt_only",
+        "mixed_simd_simt",
+        "all_simt_only_validated",
+        "mixed_simd_simt_validated",
+        "source",
+        "confidence"
+      ],
+      "properties": {
+        "all_simd": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Multiplier for the raw all-SIMD score."
+        },
+        "all_simt_only": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Multiplier for the raw all-SIMT score."
+        },
+        "mixed_simd_simt": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Multiplier for the raw mixed score."
+        },
+        "all_simt_only_validated": {
+          "type": "boolean",
+          "description": "True only when the BackendConditional whole-kernel pure-SIMT route passed correctness in this bounded domain. It cannot promote an Unsupported or AliasesMixed route."
+        },
+        "mixed_simd_simt_validated": {
+          "type": "boolean",
+          "description": "True only when C++ anchor materialization, BiShengIR compilation, and correctness passed for the local-scope mixed route in this bounded domain. False demotes the otherwise structurally Native mixed candidate."
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Exact shape/config, timing protocol, medians, and correctness result used to fit the multipliers."
+        },
+        "confidence": {
+          "$ref": "#/definitions/confidence"
+        }
+      },
+      "additionalProperties": false
+    },
+    "coverage": {
+      "type": "object",
+      "description": "Feature-domain admission bounds for trusting Event-calibrated ranking residuals.",
+      "required": [
+        "description",
+        "minimum_irregular_density",
+        "tiny_dot_flops_max",
+        "tiny_dot_max_tensor_numel",
+        "rowwise_loop_trip_sum_max",
+        "rowwise_mask_rank_sum_max",
+        "rowwise_weighted_reductions_max",
+        "rowwise_max_tensor_numel",
+        "rank1_weighted_reductions_max",
+        "rank1_max_tensor_numel",
+        "triangular_loop_count_max",
+        "triangular_loop_trip_sum_max",
+        "triangular_mask_rank_sum_max",
+        "triangular_weighted_reductions_max",
+        "triangular_max_tensor_numel"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Meaning of these thresholds and warning that they are model-validity limits, not hardware limits."
+        },
+        "minimum_irregular_density": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Minimum value of the current rank-based pointer irregularity proxy required by calibrated irregular domains. The proxy is rank>1 pointer-operation count divided by unique ranked tensor-shape count across tt.addptr/tt.load/tt.store; it does not inspect actual address strides or lane dependence."
+        },
+        "tiny_dot_flops_max": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum dot FLOP count admitted to the tiny-gather-dot calibration domain."
+        },
+        "tiny_dot_max_tensor_numel": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum tensor element count admitted to the tiny-gather-dot calibration domain."
+        },
+        "rowwise_loop_trip_sum_max": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum sum of statically known loop trip counts admitted to rowwise and rank-1 calibrated domains."
+        },
+        "rowwise_mask_rank_sum_max": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum sum of ranks of mask-producing tensor expressions admitted to the masked-rowwise calibration domain."
+        },
+        "rowwise_weighted_reductions_max": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum loop-execution-weighted tt.reduce count admitted to the masked-rowwise calibration domain. Each reduce contributes the product of its enclosing static scf.for trip counts."
+        },
+        "rowwise_max_tensor_numel": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum tensor element count admitted to the masked-rowwise calibration domain. This is bounded by the largest calibrated per-program tensor and must not be widened merely to make a new workload pass admission."
+        },
+        "rank1_weighted_reductions_max": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum loop-execution-weighted tt.reduce count admitted to the rank-1 indirect vector-reduction domain. Each reduce contributes the product of its enclosing static scf.for trip counts."
+        },
+        "rank1_max_tensor_numel": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum tensor element count admitted to the rank-1 indirect vector-reduction domain."
+        },
+        "triangular_loop_count_max": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum number of sibling 16x16 recurrence loops inside the one materializable triangular-solve scope. BT64 has four."
+        },
+        "triangular_loop_trip_sum_max": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum structurally modeled recurrence trip sum in the triangular-solve domain. A full BT64 tile is 4 * (16 - 2) = 56."
+        },
+        "triangular_mask_rank_sum_max": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum unweighted mask-rank sum admitted to the triangular-solve calibration domain."
+        },
+        "triangular_weighted_reductions_max": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum loop-execution-weighted tt.reduce count for one BT64 triangular-solve scope."
+        },
+        "triangular_max_tensor_numel": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum tensor element count admitted to the 16x16 triangular recurrence calibration domain."
+        }
+      },
+      "additionalProperties": false
+    },
+    "simd_structural_penalty": {
+      "type": "object",
+      "description": "Parameters for the additive SIMD-only structural residual ratio. The summed ratio multiplies A_SIMD and is added to A_SIMD; it never references A_SIMT.",
+      "required": [
+        "description",
+        "irregular_per_density",
+        "irregular_cap",
+        "tiny_dot_irregular_per_density",
+        "tiny_dot_irregular_cap",
+        "per_mask_rank",
+        "mask_cap",
+        "per_weighted_reduction",
+        "reduction_cap",
+        "per_static_loop_trip",
+        "loop_cap",
+        "control_flow",
+        "rank1_indirect_vector_reduction",
+        "tiny_dot",
+        "tiny_dot_flops_max"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human-readable meaning of the all-SIMD structural residual model."
+        },
+        "irregular_per_density": {
+          "type": "number",
+          "minimum": 0,
+          "description": "All-SIMD penalty ratio per unit of the current rank-based pointer irregularity proxy outside the tiny-dot special case."
+        },
+        "irregular_cap": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Maximum penalty ratio contributed by the rank-based pointer irregularity proxy outside the tiny-dot special case."
+        },
+        "tiny_dot_irregular_per_density": {
+          "type": "number",
+          "minimum": 0,
+          "description": "All-SIMD penalty ratio per unit of the rank-based pointer irregularity proxy for tiny-dot workloads."
+        },
+        "tiny_dot_irregular_cap": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Maximum penalty ratio contributed by the rank-based pointer irregularity proxy for tiny-dot workloads."
+        },
+        "per_mask_rank": {
+          "type": "number",
+          "minimum": 0,
+          "description": "All-SIMD mask-materialization penalty ratio added per unit of mask_rank_sum."
+        },
+        "mask_cap": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Maximum accumulated mask-materialization penalty ratio."
+        },
+        "per_weighted_reduction": {
+          "type": "number",
+          "minimum": 0,
+          "description": "All-SIMD reduction-lowering penalty ratio per loop-execution-weighted tt.reduce."
+        },
+        "reduction_cap": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Maximum accumulated reduction-lowering penalty ratio."
+        },
+        "per_static_loop_trip": {
+          "type": "number",
+          "minimum": 0,
+          "description": "All-SIMD loop-control penalty ratio per statically known loop trip."
+        },
+        "loop_cap": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Maximum accumulated static-loop-control penalty ratio."
+        },
+        "control_flow": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Fixed all-SIMD structural penalty ratio when control flow is present."
+        },
+        "rank1_indirect_vector_reduction": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Fixed all-SIMD penalty ratio for the rank-1 indirect vector-reduction pattern."
+        },
+        "tiny_dot": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Maximum tiny-dot startup penalty ratio, multiplied by the computed underfill fraction."
+        },
+        "tiny_dot_flops_max": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "FLOP count at which tiny-dot underfill and its startup penalty reach zero."
+        }
+      },
+      "additionalProperties": false
+    },
+    "op_profiles": {
+      "type": "object",
+      "minProperties": 1,
+      "description": "Map from semantic operation name to either a shared throughput measurement or a cycle multiplier relative to another operation.",
+      "additionalProperties": {
+        "$ref": "#/definitions/op_profile"
+      }
+    },
+    "op_profile": {
+      "type": "object",
+      "description": "One SIMD or SIMT operation-cost rule.",
+      "required": [
+        "description"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Operation-specific provenance and interpretation of this rule."
+        },
+        "throughput_measurement": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Key of a throughput measurement in microbenchmark_profile."
+        },
+        "throughput_vector_instructions_per_system_cycle": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Inline SIMD vector-instruction throughput fallback in vector instructions per SYS_CNT cycle."
+        },
+        "throughput_scalar_ops_per_system_cycle": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Inline SIMT scalar-operation throughput fallback in scalar lane operations per SYS_CNT cycle."
+        },
+        "relative_to": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Operation name whose resolved throughput supplies the base cycle estimate."
+        },
+        "factor": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Multiplier applied to the resolved base cycle estimate; values above one make this operation slower."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "none",
+            "low",
+            "medium",
+            "high"
+          ],
+          "description": "Confidence of this measured or relative operation rule; when the operation occurs, it contributes to the resource-confidence minimum used by the gate."
+        }
+      },
+      "additionalProperties": false
+    },
+    "simd_model": {
+      "type": "object",
+      "description": "All-SIMD resource and operation model.",
+      "required": [
+        "description",
+        "vector_width_measurement",
+        "startup_system_cycles",
+        "ops",
+        "memory",
+        "dot"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human-readable role of the all-SIMD model."
+        },
+        "vector_width_measurement": {
+          "type": "string",
+          "description": "Shared measurement key for physical SIMD vector width in bits."
+        },
+        "vector_width_bits": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Inline SIMD vector-width fallback supported by the loader when no measurement key is provided."
+        },
+        "startup_system_cycles": {
+          "$ref": "#/definitions/simd_startup"
+        },
+        "ops": {
+          "$ref": "#/definitions/op_profiles"
+        },
+        "memory": {
+          "$ref": "#/definitions/simd_memory"
+        },
+        "dot": {
+          "$ref": "#/definitions/dot_model"
+        }
+      },
+      "additionalProperties": false
+    },
+    "simd_startup": {
+      "type": "object",
+      "description": "Legacy all-SIMD startup priors in SYS_CNT cycles.",
+      "required": [
+        "description",
+        "vector",
+        "mte2",
+        "mte3",
+        "source",
+        "confidence",
+        "note"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human-readable status and current consumption boundary of these startup priors."
+        },
+        "vector": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Fixed all-SIMD vector setup cost in SYS_CNT cycles; this is the only startup value currently consumed."
+        },
+        "mte2": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Legacy MTE2 startup prior in SYS_CNT cycles; currently not consumed by Route Model scoring."
+        },
+        "mte3": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Legacy MTE3 startup prior in SYS_CNT cycles; currently not consumed by Route Model scoring."
+        },
+        "source": {
+          "type": "string",
+          "description": "Origin of the startup priors."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "none",
+            "low",
+            "medium",
+            "high"
+          ],
+          "description": "Documentary confidence of the legacy startup priors; the current Route Model loader does not consume it."
+        },
+        "note": {
+          "type": "string",
+          "description": "Evidence caveat retained for human review; not consumed by scoring."
+        }
+      },
+      "additionalProperties": false
+    },
+    "simd_memory": {
+      "type": "object",
+      "description": "All-SIMD memory rates and their model-specific provenance.",
+      "required": [
+        "description",
+        "hbm_bytes_per_system_cycle",
+        "vector_mte2_bytes_per_system_cycle",
+        "mte3_bytes_per_system_cycle",
+        "source",
+        "confidence",
+        "note"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human-readable role and consumption boundary of these rates."
+        },
+        "hbm_bytes_per_system_cycle": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Legacy whole-device HBM-rate seed in byte/SYS_CNT-cycle; currently not consumed by Route Model scoring."
+        },
+        "vector_mte2_bytes_per_system_cycle": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "All-SIMD load-path rate in byte/SYS_CNT-cycle; load cycles equal load bytes divided by this value."
+        },
+        "mte3_bytes_per_system_cycle": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "All-SIMD store-path rate in byte/SYS_CNT-cycle; store cycles equal store bytes divided by this value."
+        },
+        "source": {
+          "type": "string",
+          "description": "Origin and validity caveat of these model-specific rates."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "none",
+            "low",
+            "medium",
+            "high"
+          ],
+          "description": "Confidence of the all-SIMD memory rates; when load or store work exists, it contributes to the resource-confidence minimum used by the gate."
+        },
+        "note": {
+          "type": "string",
+          "description": "Warning that these are fallback Route Model inputs rather than shared isolated measurements."
+        }
+      },
+      "additionalProperties": false
+    },
+    "dot_model": {
+      "type": "object",
+      "description": "Fixed setup plus throughput model for dot work.",
+      "required": [
+        "description",
+        "startup_system_cycles",
+        "flops_per_system_cycle",
+        "source",
+        "confidence"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human-readable role and execution mode of this dot model."
+        },
+        "startup_system_cycles": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Fixed dot setup cost in SYS_CNT cycles."
+        },
+        "flops_per_system_cycle": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Modeled dot arithmetic rate in FLOP per SYS_CNT cycle."
+        },
+        "source": {
+          "type": "string",
+          "description": "Origin and intended refinement path for the dot prior."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "none",
+            "low",
+            "medium",
+            "high"
+          ],
+          "description": "Confidence of this dot prior; when dot work exists, it contributes to the resource-confidence minimum used by the gate."
+        }
+      },
+      "additionalProperties": false
+    },
+    "simt_model": {
+      "type": "object",
+      "description": "All-SIMT resources plus mixed-mode setup evidence.",
+      "required": [
+        "description",
+        "warp_size_measurement",
+        "setup_system_cycles",
+        "ops",
+        "dot",
+        "camodel_effective",
+        "shuffle",
+        "memory",
+        "mixed_setup_fallback"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human-readable role of the all-SIMT and mixed-mode inputs."
+        },
+        "warp_size_measurement": {
+          "type": "string",
+          "description": "Shared measurement key for the number of scalar lanes in one SIMT warp."
+        },
+        "warp_size": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Inline warp-size fallback supported by the loader when no measurement key is provided."
+        },
+        "setup_system_cycles": {
+          "$ref": "#/definitions/simt_setup"
+        },
+        "ops": {
+          "$ref": "#/definitions/op_profiles"
+        },
+        "dot": {
+          "$ref": "#/definitions/dot_model"
+        },
+        "camodel_effective": {
+          "$ref": "#/definitions/camodel_effective"
+        },
+        "shuffle": {
+          "$ref": "#/definitions/simt_shuffle"
+        },
+        "memory": {
+          "$ref": "#/definitions/simt_memory"
+        },
+        "mixed_setup_fallback": {
+          "$ref": "#/definitions/mixed_setup_fallbacks"
+        }
+      },
+      "additionalProperties": false
+    },
+    "simt_setup": {
+      "type": "object",
+      "description": "Standalone SIMT setup cost.",
+      "required": [
+        "description",
+        "empty_launch_measurement"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human-readable meaning and source boundary of the setup cost."
+        },
+        "empty_launch_measurement": {
+          "type": "string",
+          "description": "Shared measurement key for standalone empty-SIMT setup in SYS_CNT cycles."
+        },
+        "empty_launch": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Inline empty-SIMT setup fallback in SYS_CNT cycles."
+        }
+      },
+      "additionalProperties": false
+    },
+    "camodel_effective": {
+      "type": "object",
+      "description": "Workload-effective CaModel rates retained as fallback calibration context.",
+      "required": [
+        "description",
+        "scope",
+        "simulator_clock_mhz",
+        "conversion",
+        "warp_instructions_per_system_cycle",
+        "warp_size",
+        "source",
+        "confidence",
+        "note"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human-readable warning that only part of this block is currently consumed."
+        },
+        "scope": {
+          "type": "string",
+          "description": "Workload and active-vector-core scope from which these effective rates were derived."
+        },
+        "simulator_clock_mhz": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Clock used by the simulator-cycle measurements before conversion to SYS_CNT cycles."
+        },
+        "conversion": {
+          "type": "string",
+          "description": "Documentary formula used to convert aggregate simulator-cycle rates into SYS_CNT-cycle rates; not evaluated by the loader."
+        },
+        "warp_instructions_per_system_cycle": {
+          "$ref": "#/definitions/camodel_rates"
+        },
+        "warp_size": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Warp size assumed by the CaModel workload. The current loader uses simt.warp_size_measurement instead."
+        },
+        "source": {
+          "type": "string",
+          "description": "CaModel artifact and profiling run that produced these workload-effective rates."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "none",
+            "low",
+            "medium",
+            "high"
+          ],
+          "description": "Documentary confidence of the complete CaModel workload-effective block; the current loader does not propagate it to predicate-cost confidence or the gate."
+        },
+        "note": {
+          "type": "string",
+          "description": "Warning that these values include workload dependencies and stalls and are not isolated peak rates."
+        }
+      },
+      "additionalProperties": false
+    },
+    "camodel_rates": {
+      "type": "object",
+      "description": "Workload-effective aggregate warp-instruction issue rates in warp instructions per SYS_CNT cycle. The current loader consumes only predicate.",
+      "required": [
+        "memory",
+        "float_alu",
+        "shuffle",
+        "predicate",
+        "control",
+        "int_alu"
+      ],
+      "properties": {
+        "memory": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Effective memory warp-instruction rate; retained as context and not currently consumed."
+        },
+        "float_alu": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Effective floating-point ALU warp-instruction rate; retained as context and not currently consumed."
+        },
+        "shuffle": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Effective shuffle warp-instruction rate; isolated shared measurement is used instead."
+        },
+        "predicate": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Effective predicate warp-instruction rate consumed to estimate mask predicate cycles."
+        },
+        "control": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Effective control warp-instruction rate; retained as context and not currently consumed."
+        },
+        "int_alu": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Effective integer-ALU warp-instruction rate; retained as context and not currently consumed."
+        }
+      },
+      "additionalProperties": false
+    },
+    "simt_shuffle": {
+      "type": "object",
+      "description": "SIMT shuffle issue-rate input.",
+      "required": [
+        "description",
+        "throughput_measurement"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human-readable meaning and source boundary of the shuffle rate."
+        },
+        "throughput_measurement": {
+          "type": "string",
+          "description": "Shared measurement key for shuffle throughput in warp instructions per SYS_CNT cycle."
+        },
+        "warp_instructions_per_system_cycle": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Inline shuffle-throughput fallback supported by the loader."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "none",
+            "low",
+            "medium",
+            "high"
+          ],
+          "description": "Optional explicit shuffle confidence; otherwise confidence is inherited from the referenced shared measurement and contributes to the gate when shuffle work exists."
+        }
+      },
+      "additionalProperties": false
+    },
+    "simt_memory": {
+      "type": "object",
+      "description": "SIMT GM load/store warp-instruction issue-rate inputs.",
+      "required": [
+        "description",
+        "load_throughput_measurement",
+        "store_throughput_measurement"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human-readable meaning and source boundary of the SIMT memory rates."
+        },
+        "load_throughput_measurement": {
+          "type": "string",
+          "description": "Shared measurement key for GM-load throughput in warp instructions per SYS_CNT cycle."
+        },
+        "store_throughput_measurement": {
+          "type": "string",
+          "description": "Shared measurement key for GM-store throughput in warp instructions per SYS_CNT cycle."
+        },
+        "load_warp_instructions_per_system_cycle": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Inline GM-load throughput fallback supported by the loader."
+        },
+        "store_warp_instructions_per_system_cycle": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Inline GM-store throughput fallback supported by the loader."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "none",
+            "low",
+            "medium",
+            "high"
+          ],
+          "description": "Optional explicit SIMT-memory confidence; otherwise the lower confidence of the referenced load/store measurements is used when memory work exists."
+        }
+      },
+      "additionalProperties": false
+    },
+    "mixed_setup_fallbacks": {
+      "type": "object",
+      "description": "Map from warp count to low-confidence mixed setup fallback. The referenced probes contain no SIMD phase and are not directional transition measurements.",
+      "required": [
+        "1",
+        "2",
+        "4",
+        "8",
+        "16",
+        "32",
+        "confidence",
+        "note"
+      ],
+      "properties": {
+        "1": {
+          "$ref": "#/definitions/mixed_setup_fallback_entry"
+        },
+        "2": {
+          "$ref": "#/definitions/mixed_setup_fallback_entry"
+        },
+        "4": {
+          "$ref": "#/definitions/mixed_setup_fallback_entry"
+        },
+        "8": {
+          "$ref": "#/definitions/mixed_setup_fallback_entry"
+        },
+        "16": {
+          "$ref": "#/definitions/mixed_setup_fallback_entry"
+        },
+        "32": {
+          "$ref": "#/definitions/mixed_setup_fallback_entry"
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "none",
+            "low",
+            "medium",
+            "high"
+          ],
+          "description": "Required Route Model confidence for using these standalone empty-VF probes as mixed setup fallbacks."
+        },
+        "note": {
+          "type": "string",
+          "description": "Required warning that true directional switching and dependent hand-off costs remain unmeasured."
+        }
+      },
+      "additionalProperties": false
+    },
+    "mixed_setup_fallback_entry": {
+      "type": "object",
+      "description": "One low-confidence mixed setup fallback for a measured warp count.",
+      "required": [
+        "description",
+        "measurement"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human-readable warp-count scope and evidence limitation of this fallback entry."
+        },
+        "measurement": {
+          "type": "string",
+          "description": "Shared measurement key for the standalone empty-VF harness proxy in SYS_CNT cycles."
+        },
+        "empty_simt_setup_system_cycles": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Inline mixed setup fallback supported by the loader."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/third_party/ascend/include/TritonToLinalg/StridedLoadStoreRewrite.h
+++ b/third_party/ascend/include/TritonToLinalg/StridedLoadStoreRewrite.h
@@ -52,7 +52,11 @@ inline constexpr const char *InspectedByStridedLoadStoreRewriteTAG =
 //   the stride==2 even-size case handled by DeinterleaveStatusOptimization).
 //
 //   Runs as a sub-step of TritonToLinalgPass, after processImplicitPermute,
-//   and is gated on 910_95 with compile-mode=simd_simt_template.
+//   and is gated on 910_95 with compile-mode=simd_simt_template. Cost-model
+//   controlled routing can also enable it for selected operations in local
+//   SIMT scopes while leaving unselected operations on the SIMD path.
+//   model-controlled routing additionally filters every rewrite to operations
+//   enclosed by the local SIMT route scope.
 class LoadConverter : public OpRewritePattern<triton::LoadOp> {
 public:
   explicit LoadConverter(MLIRContext *context)

--- a/third_party/ascend/include/Utils/Utils.h
+++ b/third_party/ascend/include/Utils/Utils.h
@@ -77,7 +77,7 @@ inline bool isMixCompileMode(CompileMode mode) {
 inline bool hasScopeVecMode(Operation *op, llvm::StringRef mode) {
   for (Operation *parent = op->getParentOp(); parent;
        parent = parent->getParentOp()) {
-    if (auto vecModeAttr = parent->getAttrOfType<StringAttr>("vec_mode")) {
+    if (auto vecModeAttr = parent->getAttrOfType<StringAttr>("vector_mode")) {
       if (vecModeAttr.getValue() == mode)
         return true;
     }

--- a/third_party/ascend/language/cann/extension/code_generator.py
+++ b/third_party/ascend/language/cann/extension/code_generator.py
@@ -64,7 +64,8 @@ def _extract_scope_attributes(context_expr):
     scope_attrs = {}
     for keyword in context_expr.keywords:
         if isinstance(keyword.value, ast.Constant):
-            scope_attrs[keyword.arg] = keyword.value.value
+            attr_name = "vec_mode" if keyword.arg == "vector_mode" else keyword.arg
+            scope_attrs[attr_name] = keyword.value.value
     return scope_attrs
 
 

--- a/third_party/ascend/language/cann/extension/code_generator.py
+++ b/third_party/ascend/language/cann/extension/code_generator.py
@@ -64,8 +64,7 @@ def _extract_scope_attributes(context_expr):
     scope_attrs = {}
     for keyword in context_expr.keywords:
         if isinstance(keyword.value, ast.Constant):
-            attr_name = "vec_mode" if keyword.arg == "vector_mode" else keyword.arg
-            scope_attrs[attr_name] = keyword.value.value
+            scope_attrs[keyword.arg] = keyword.value.value
     return scope_attrs
 
 
@@ -105,9 +104,9 @@ def _build_mlir_attrs_from_scope_attrs(builder, scope_attrs):
     for k, v in scope_attrs.items():
         if k == "core_mode":
             mlir_attrs.update(_handle_core_mode_attr(builder, v))
-        elif k == "vec_mode":
+        elif k == "vector_mode":
             if v is not None:
-                mlir_attrs["vec_mode"] = builder.get_string_attr(v)
+                mlir_attrs["vector_mode"] = builder.get_string_attr(v)
         elif k == "noinline":
             if not v:
                 mlir_attrs.pop("noinline")

--- a/third_party/ascend/language/cann/extension/scope.py
+++ b/third_party/ascend/language/cann/extension/scope.py
@@ -47,33 +47,33 @@ class scope:
 
     Reserved keywords:
         - `core_mode`: Selects cube or vector core operations.
-        - `vec_mode`: Selects the SIMD or SIMT vector path inside a mixed
+        - `vector_mode`: Selects the SIMD or SIMT vector path inside a mixed
             compile mode (`compile_mode="simd_simt"` or
             `"simd_simt_template"`).
     """
 
-    def __init__(self, core_mode: str = None, _builder=None, _semantic=None, vec_mode: str = None, **kwargs):
+    def __init__(self, core_mode: str = None, _builder=None, _semantic=None, vector_mode: str = None, **kwargs):
         """
         :param core_mode: Either "cube" or "vector" to specify the core type (optional)
-        :param vec_mode: Either "simd" or "simt" to select the vector path (optional)
+        :param vector_mode: Either "simd" or "simt" to select the vector path (optional)
         :param _builder: Internal builder object (set by code_generator)
         :param _semantic: Internal semantic object (set by code_generator)
         :param kwargs: Additional internal parameters
         """
         # Convert constexpr to value if not being called from code generator
         self.core_mode = _unwrap_if_constexpr(core_mode) if _builder is None else core_mode
-        self.vec_mode = _unwrap_if_constexpr(vec_mode) if _builder is None else vec_mode
+        self.vector_mode = _unwrap_if_constexpr(vector_mode) if _builder is None else vector_mode
         self._builder = _builder
         self._semantic = _semantic
 
         # Validate core_mode
         if self.core_mode is not None and self.core_mode not in _VALID_CORE_MODES:
             raise ValueError(f'core_mode must be one of {_VALID_CORE_MODES}, got {self.core_mode!r}')
-        if self.vec_mode is not None and self.vec_mode not in _VALID_VEC_MODES:
-            raise ValueError(f'vec_mode must be one of {_VALID_VEC_MODES}, got {self.vec_mode!r}')
-        if self.core_mode == "cube" and self.vec_mode is not None:
-            raise ValueError('vec_mode cannot be set when core_mode="cube"')
-        if self.core_mode is None and self.vec_mode is None and not kwargs:
+        if self.vector_mode is not None and self.vector_mode not in _VALID_VEC_MODES:
+            raise ValueError(f'vector_mode must be one of {_VALID_VEC_MODES}, got {self.vector_mode!r}')
+        if self.core_mode == "cube" and self.vector_mode is not None:
+            raise ValueError('vector_mode cannot be set when core_mode="cube"')
+        if self.core_mode is None and self.vector_mode is None and not kwargs:
             raise ValueError("scope requires at least one annotation")
 
     def __enter__(self):

--- a/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
+++ b/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
@@ -20,6 +20,7 @@
  * THE SOFTWARE.
  */
 
+#include "AscendModel/RouteModel/SimtSelection.h"
 #include "TritonToUnstructure/IndirectAtomicUtils.h"
 #include "Utils/Utils.h"
 #include "ascend/include/DiscreteMaskAccessConversion/Passes.h"
@@ -56,6 +57,8 @@ static bool compileOn91095Flag = false;
 static mlir::triton::ascend::CompileMode compileModeFlag =
     mlir::triton::ascend::CompileMode::Simd;
 static bool enableSyncBlockLockFlag = true;
+static constexpr const char *routeDiscreteMaskToSimtAttrName =
+    "route_discrete_mask_to_simt";
 
 static bool traceUserToTargetOp(Value val) {
   llvm::SmallVector<Value, 32> worklist;
@@ -280,22 +283,19 @@ struct DiscreteMaskStoreConversion : OpRewritePattern<triton::StoreOp> {
 
     auto ptr = op.getPtr();
     auto ptrType = dyn_cast<RankedTensorType>(ptr.getType());
+    op->setAttr(routeDiscreteMaskToSimtAttrName, rewriter.getUnitAttr());
     bool rankWithinIndirectFastPathLimit =
         ptrType && ptrType.getShape().size() <= 5;
-    if (compileOn91095Flag &&
-        compileModeFlag == triton::ascend::CompileMode::SimdSimt) {
-      rewriter.modifyOpInPlace(op, [&]() {
-        op->setAttr(ConverterUtils::mixCompileDiscreteMaskAttrName,
-                    rewriter.getUnitAttr());
-      });
-      return success();
-    }
-
-    if (compileOn91095Flag &&
-        compileModeFlag == triton::ascend::CompileMode::SimdSimtTemplate &&
-        rankWithinIndirectFastPathLimit) {
-      op->setAttr(ConverterUtils::mixCompileDiscreteMaskAttrName,
-                  rewriter.getUnitAttr());
+    const bool legacyMixedRoute =
+        compileModeFlag == triton::ascend::CompileMode::SimdSimt ||
+        compileModeFlag == triton::ascend::CompileMode::SimdSimtTemplate;
+    const bool simtRouteRequested =
+        mlir::ascend::simt_selection::shouldUseSimtTemplate(op.getOperation(),
+                                                            legacyMixedRoute);
+    const bool routeSupportsRank =
+        compileModeFlag == triton::ascend::CompileMode::SimdSimt ||
+        rankWithinIndirectFastPathLimit;
+    if (compileOn91095Flag && simtRouteRequested && routeSupportsRank) {
       return failure();
     }
 
@@ -364,22 +364,19 @@ struct DiscreteMaskLoadConversion : OpRewritePattern<triton::LoadOp> {
       return failure();
 
     auto ptrType = dyn_cast<RankedTensorType>(ptr.getType());
+    op->setAttr(routeDiscreteMaskToSimtAttrName, rewriter.getUnitAttr());
     bool rankWithinIndirectFastPathLimit =
         ptrType && ptrType.getShape().size() <= 5;
-    if (compileOn91095Flag &&
-        compileModeFlag == triton::ascend::CompileMode::SimdSimt) {
-      rewriter.modifyOpInPlace(op, [&]() {
-        op->setAttr(ConverterUtils::mixCompileDiscreteMaskAttrName,
-                    rewriter.getUnitAttr());
-      });
-      return success();
-    }
-
-    if (compileOn91095Flag &&
-        compileModeFlag == triton::ascend::CompileMode::SimdSimtTemplate &&
-        rankWithinIndirectFastPathLimit) {
-      op->setAttr(ConverterUtils::mixCompileDiscreteMaskAttrName,
-                  rewriter.getUnitAttr());
+    const bool legacyMixedRoute =
+        compileModeFlag == triton::ascend::CompileMode::SimdSimt ||
+        compileModeFlag == triton::ascend::CompileMode::SimdSimtTemplate;
+    const bool simtRouteRequested =
+        mlir::ascend::simt_selection::shouldUseSimtTemplate(op.getOperation(),
+                                                            legacyMixedRoute);
+    const bool routeSupportsRank =
+        compileModeFlag == triton::ascend::CompileMode::SimdSimt ||
+        rankWithinIndirectFastPathLimit;
+    if (compileOn91095Flag && simtRouteRequested && routeSupportsRank) {
       return failure();
     }
 

--- a/third_party/ascend/lib/TritonToLinalg/CMakeLists.txt
+++ b/third_party/ascend/lib/TritonToLinalg/CMakeLists.txt
@@ -29,6 +29,7 @@ add_triton_library(TritonToLinalg
   MLIRTransforms
   MLIRSupport
   BiShengIRHIVMDialect
+  BiShengIRScopeDialect
   TritonIR
   TritonTransforms
   TritonAnalysis

--- a/third_party/ascend/lib/TritonToLinalg/StridedLoadStoreRewrite.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/StridedLoadStoreRewrite.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "TritonToLinalg/StridedLoadStoreRewrite.h"
+#include "AscendModel/RouteModel/SimtSelection.h"
 #include "TritonToLinalg/ImplicitPermute.h"
 #include "TritonToLinalg/MaskAnalysis.h"
 #include "TritonToStructured/PtrAnalysis.h"
@@ -1348,6 +1349,13 @@ LogicalResult LoadConverter::matchAndRewrite(triton::LoadOp op,
   auto loc = op.getLoc();
   (void)loc;
 
+  // In model-controlled compilation, only operations inside the selected
+  // local SIMT scope may use this fast path.
+  if (mlir::ascend::simt_selection::isModelControlled(op) &&
+      !mlir::ascend::simt_selection::shouldUseSimtTemplate(
+          op, /*legacyForceSimt=*/false))
+    return failure();
+
   // ---- Re-entry / cross-step guards ----
   if (op->hasAttr(InspectedByStridedLoadStoreRewriteTAG))
     return failure();
@@ -1393,6 +1401,11 @@ LogicalResult LoadConverter::matchAndRewrite(triton::LoadOp op,
 
 LogicalResult StoreConverter::matchAndRewrite(triton::StoreOp op,
                                               PatternRewriter &rewriter) const {
+  if (mlir::ascend::simt_selection::isModelControlled(op) &&
+      !mlir::ascend::simt_selection::shouldUseSimtTemplate(
+          op, /*legacyForceSimt=*/false))
+    return failure();
+
   // ---- Re-entry / cross-step guards (same convention as LoadConverter) ----
   if (op->hasAttr(InspectedByStridedLoadStoreRewriteTAG))
     return failure();

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "ascend/include/TritonToLinalg/TritonOpConverter.h"
+#include "AscendModel/RouteModel/SimtSelection.h"
 #include "ascend/include/TritonToLinalg/BlockPtrAnalysis.h"
 #include "ascend/include/TritonToLinalg/MaskAnalysis.h"
 #include "ascend/include/TritonToLinalg/TritonToLinalgPass.h"
@@ -3600,6 +3601,17 @@ LogicalResult IndexSelectSimdConverter::matchAndRewrite(
 LogicalResult
 HistogramConverter::matchAndRewrite(triton::HistogramOp op, OpAdaptor adaptor,
                                     ConversionPatternRewriter &rewriter) const {
+  // The 910/95 histogram converter below is intrinsically SIMT.  Never
+  // silently emit it for an admitted all-SIMD/model-unselected operation;
+  // legality analysis must keep mixed as the only selectable route until a
+  // real SIMD histogram lowering exists.
+  if (mlir::ascend::simt_selection::isModelControlled(op) &&
+      !mlir::ascend::simt_selection::shouldUseSimtTemplate(
+          op, /*legacyForceSimt=*/false)) {
+    return rewriter.notifyMatchFailure(
+        op, "SIMT histogram was not selected by the cost model");
+  }
+
   auto loc = op.getLoc();
   Value input = adaptor.getSrc();
   auto resultType = dyn_cast<RankedTensorType>(op.getResult().getType());

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -23,6 +23,7 @@
 
 #include <cstdlib>
 
+#include "AscendModel/RouteModel/SimtSelection.h"
 #include "TritonToLinalg/BlockPtrAnalysis.h"
 #include "ascend/include/Dialect/TritonAscend/IR/TritonAscendDialect.h"
 #include "ascend/include/TritonToLinalg/ArgMinMaxConverter.h"
@@ -42,8 +43,10 @@
 #include "ascend/include/TritonToStructured/CannonicalizerConverter.h"
 #include "ascend/include/TritonToUnstructure/UnstructureConversionPass.h"
 #include "ascend/include/Utils/InterleaveOptimization.h"
+#include "ascend/include/Utils/Utils.h"
 
 #include "bishengir/Dialect/HFusion/IR/HFusion.h"
+#include "bishengir/Dialect/Scope/IR/Scope.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -161,24 +164,44 @@ static bool isCustomOpOperandTypesLegal(TypeRange types) {
 }
 
 static bool isSIMTOp(Operation *op) {
+  // scope.scope is the canonical route contract.  It is also a native
+  // BiShengIR construct, so it survives this pass and lets the backend retain
+  // the selected region as SIMT even when no individual Triton op lowers to an
+  // intrinsically SIMT custom op (for example a triangular solve loop).
+  if (op->getName().getStringRef() == "scope.scope") {
+    auto mode = mlir::ascend::simt_selection::getVectorMode(op);
+    if (mode && mode.getValue() == "simt")
+      return true;
+  }
+
   if (auto custom_op = dyn_cast<hivm::CustomOp>(op)) {
     return custom_op.getCoreType() == hivm::TCoreType::VECTOR &&
            custom_op.getVFMode() == hivm::VFMode::SIMT;
   }
 
+  // backend_default retains the historical target-specific routing.  Once a
+  // concrete cost-model decision is present, direct SIMT templates must be
+  // backed by the enclosing local SIMT scope.  The scope remains live through
+  // this pass and is carried into TTAdapter/BiShengIR as the execution-region
+  // contract.
+  const bool directSimtEnabled =
+      !mlir::ascend::simt_selection::isModelControlled(op) ||
+      mlir::ascend::simt_selection::shouldUseSimtTemplate(
+          op, /*legacyForceSimt=*/false);
+
   if (isa<triton::GatherOp>(op) && compileOn91095Flag) {
-    return true;
+    return directSimtEnabled;
   }
 
   if (isa<triton::HistogramOp>(op) && compileOn91095Flag) {
-    return true;
+    return directSimtEnabled;
   }
 
   // tt.scan: only a 1-D cumsum is treated as a SIMT op (drives the kernel
   // parallel_mode -> mix_simd_simt -> enable_simt). Everything else stays SIMD.
   if (compileOn91095Flag) {
     if (auto scan = dyn_cast<triton::ScanOp>(op)) {
-      return isSimt1DCumsum(scan);
+      return directSimtEnabled && isSimt1DCumsum(scan);
     }
   }
   return isa<triton::ascend::IndexPutOp, triton::ascend::GatherOutToUbOp,
@@ -870,8 +893,39 @@ LogicalResult TritonToLinalgPass::processStridedLoadStoreRewriteOperations(
     ModuleOp moduleOp) {
   // The strided-axis rewrites below only apply in 950 SIMT mode. On other
   // targets we leave strided loads to the legacy strided DMA lowering.
+  bool hasModelControlledFunction =
+      mlir::ascend::simt_selection::isModelControlled(moduleOp);
+  if (!hasModelControlledFunction) {
+    moduleOp.walk([&](triton::FuncOp funcOp) {
+      if (mlir::ascend::simt_selection::isModelControlled(funcOp))
+        hasModelControlledFunction = true;
+    });
+  }
+
+  bool hasModelSelectedMemoryOp = false;
+  if (hasModelControlledFunction) {
+    moduleOp.walk([&](Operation *op) {
+      if (!isa<triton::LoadOp, triton::StoreOp>(op))
+        return WalkResult::advance();
+      if (mlir::ascend::simt_selection::isModelControlled(op) &&
+          mlir::ascend::simt_selection::shouldUseSimtTemplate(
+              op, /*legacyForceSimt=*/false)) {
+        hasModelSelectedMemoryOp = true;
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+  }
+
+  // A concrete model decision owns routing for this compilation.  In
+  // particular, compile_mode=simd_simt still sets the historical global force
+  // flag, but all-SIMD and mixed-without-memory selections must not activate
+  // the module-wide strided/coalescing rewrites.
+  const bool useLegacyGlobalForce =
+      compileModeFlag == triton::ascend::CompileMode::SimdSimtTemplate &&
+      !hasModelControlledFunction;
   if (!(compileOn91095Flag &&
-        compileModeFlag == triton::ascend::CompileMode::SimdSimtTemplate)) {
+        (useLegacyGlobalForce || hasModelSelectedMemoryOp))) {
     return success();
   }
 
@@ -959,16 +1013,19 @@ void TritonToLinalgPass::runOnOperation() {
   });
   existDotFlag = existDot;
 
-  // NOTE: existSIMTOp is intentionally computed AFTER
-  // processStridedLoadStoreRewriteOperations below, because that step
-  // materializes triton::ascend::UnstructuredLoadOp/UnstructuredStoreOp
-  // (which isSIMTOp() counts). Walking here (before the rewrite) would miss
-  // them and mislabel the kernel parallel_mode as "simd" instead of
-  // "mix_simd_simt";
-  // then enable_simt would be false and the launch would not reserve
-  // localMemorySize for the SIMT templates -> VEC UB out-of-bounds (error 341)
-  // at runtime on mix-CV kernels.
+  // Preserve an explicit SIMT scope before earlier conversions can fold an
+  // empty scope. The post-rewrite scan below ORs in SIMT custom ops created by
+  // strided/unstructured rewrites.
   bool existSIMTOp = false;
+  moduleOp.walk([&](Operation *op) {
+    if (op->getName().getStringRef() != "scope.scope")
+      return WalkResult::advance();
+    auto mode = mlir::ascend::simt_selection::getVectorMode(op);
+    if (!mode || mode.getValue() != "simt")
+      return WalkResult::advance();
+    existSIMTOp = true;
+    return WalkResult::interrupt();
+  });
 
   // Execute tensor descriptor operations conversion
   if (failed(processDescriptorOperations(moduleOp))) {
@@ -1346,6 +1403,22 @@ void TritonToLinalgPass::runOnOperation() {
     }
     return WalkResult::advance();
   });
+
+  // Model report attributes are compile-time control state, not device IR.
+  // Python has already copied the report into compiler metadata.  Preserve
+  // scope.scope itself: it is the native BiShengIR execution-region contract,
+  // not a private cost-model marker.
+  for (llvm::StringRef name : {
+           "ascend.simt_costmodel.effective",
+           "ascend.simt_costmodel.recommended",
+           "ascend.simt_costmodel.selection_source",
+           "ascend.simt_costmodel.ranking_confidence",
+           "ascend.simt_costmodel.all_simd_score",
+           "ascend.simt_costmodel.all_simt_score",
+           "ascend.simt_costmodel.mixed_score",
+           "ascend.simt_costmodel.report_json",
+       })
+    moduleOp->removeAttr(name);
 }
 
 std::unique_ptr<OperationPass<ModuleOp>>

--- a/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "TritonToUnstructure/UnstructureConversionPass.h"
+#include "AscendModel/RouteModel/SimtSelection.h"
 #include "TritonToLinalg/MaskAnalysis.h"
 #include "TritonToStructured/CannonicalizerConverter.h"
 #include "TritonToUnstructure/IndirectAtomicUtils.h"
@@ -53,6 +54,9 @@ static triton::ascend::CompileMode unstructureCompileModeFlag =
 namespace {
 
 constexpr int64_t kBitsPerByte = 8;
+
+static constexpr const char *kRouteDiscreteMaskToSimtAttrName =
+    "route_discrete_mask_to_simt";
 
 static RankedTensorType resolvePtrTensorType(Value ptr) {
   auto ptrType = dyn_cast<RankedTensorType>(ptr.getType());
@@ -113,8 +117,10 @@ void normalizeDiscreteMaskAccessForFallback(MemAccOpTy &op,
 // ======================== 950 SIMT Template Fast-Path Lowering
 // ========================
 // 1. SIMT Fast-Path Gate
-//    The SIMT template lowering path is enabled only when:
-//      - compileOn91095Flag && forceSimtTemplateFlag
+//    The SIMT indirect lowering path is enabled only when:
+//      - compileOn91095Flag
+//      - and either a legacy mixed compile mode is active, or the C++ cost
+//        model selected this operation through a local SIMT scope.
 //      - and the access is either:
 //          * unstructured, or has tag with 'MixCompileDiscreteMask'
 //
@@ -456,6 +462,12 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
   auto ptrType = resolvePtrTensorType(ptr);
   auto mixCompileDiscreteMask =
       op->hasAttr(ConverterUtils::mixCompileDiscreteMaskAttrName);
+  auto routeDiscreteMaskToSimt = op->hasAttr(kRouteDiscreteMaskToSimtAttrName);
+  bool scopeForcesSimt =
+      mlir::ascend::simt_selection::hasEnclosingVectorMode(op, "simt");
+  bool scopeForcesSimd =
+      mlir::ascend::simt_selection::hasEnclosingVectorMode(op, "simd");
+  bool modelControlled = mlir::ascend::simt_selection::isModelControlled(op);
 
   if (!ptrType || op->hasAttr(ConverterUtils::discreteAttrName))
     return failure();
@@ -468,6 +480,7 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
     ptrOffsetInfo.setUnstructured(ptrOffsetInfo.getRank());
 
   if (ptrOffsetInfo.isStructured() && !mixCompileDiscreteMask &&
+      !routeDiscreteMaskToSimt &&
       (!ptrOffsetInfo.isScalarLike() ||
        llvm::all_of(ptrType.getShape(), [](int64_t dim) { return dim == 1; })))
     return failure();
@@ -531,14 +544,29 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
     os << "compileOn91095Flag: " << compileOn91095Flag << "\n";
     os << "compileModeFlag: " << static_cast<int>(unstructureCompileModeFlag)
        << "\n";
+    os << "forceSimtTemplateFlag: " << forceSimtTemplateFlag << "\n";
+    os << "modelControlled: " << modelControlled << "\n";
+    os << "scopeForcesSimt: " << scopeForcesSimt << "\n";
+    os << "scopeForcesSimd: " << scopeForcesSimd << "\n";
   });
 
-  // Preserve the existing template eligibility limits while using one
-  // canonical unstructured load/store op in both mixed compilation modes.
-  bool simtFastPathEnabled =
-      compileOn91095Flag && forceSimtTemplateFlag &&
+  const bool legacyMixedRoute =
+      unstructureCompileModeFlag == triton::ascend::CompileMode::SimdSimt ||
+      unstructureCompileModeFlag ==
+          triton::ascend::CompileMode::SimdSimtTemplate;
+  bool simtRouteRequested =
+      mlir::ascend::simt_selection::shouldUseSimtTemplate(op, legacyMixedRoute);
+
+  // Preserve the template eligibility limits while using one canonical
+  // unstructured load/store op in both mixed compilation modes.
+  bool simtTemplateLoadStoreFastPathEnabled =
+      compileOn91095Flag && forceSimtTemplateFlag && simtRouteRequested &&
       ((!ptrOffsetInfo.isStructured() && sizeInByte < 64) ||
-       mixCompileDiscreteMask);
+       mixCompileDiscreteMask || routeDiscreteMaskToSimt);
+  bool simtTemplateAtomicFastPathEnabled =
+      compileOn91095Flag && forceSimtTemplateFlag && simtRouteRequested &&
+      ((!ptrOffsetInfo.isStructured() && sizeInByte < 64) ||
+       mixCompileDiscreteMask || routeDiscreteMaskToSimt);
   bool rankWithinSimtTemplateLimit = resultShape.size() <= 5;
 
   if constexpr (std::is_same_v<MemAccOpTy, triton::LoadOp> ||
@@ -546,10 +574,12 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
     bool useUnstructuredOp =
         compileOn91095Flag &&
         ((unstructureCompileModeFlag == triton::ascend::CompileMode::SimdSimt &&
-          (ptrOffsetInfo.hasUnstructuredDim() || mixCompileDiscreteMask)) ||
+          simtRouteRequested &&
+          (ptrOffsetInfo.hasUnstructuredDim() || mixCompileDiscreteMask ||
+           routeDiscreteMaskToSimt)) ||
          (unstructureCompileModeFlag ==
               triton::ascend::CompileMode::SimdSimtTemplate &&
-          simtFastPathEnabled && rankWithinSimtTemplateLimit));
+          simtTemplateLoadStoreFastPathEnabled && rankWithinSimtTemplateLimit));
     if (useUnstructuredOp) {
       auto unstructuredDims = ptrOffsetInfo.getUnstructuredDims();
       if (succeeded(tryRewriteUnstructuredLoadStoreFastPath(
@@ -560,8 +590,9 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
 
   if constexpr (std::is_same_v<MemAccOpTy, triton::AtomicRMWOp> ||
                 std::is_same_v<MemAccOpTy, triton::AtomicCASOp>) {
-    if (simtFastPathEnabled && succeeded(tryRewriteIndirectAtomicFastPath(
-                                   op, srcPtr, ptrOffset, rewriter))) {
+    if (simtTemplateAtomicFastPathEnabled &&
+        succeeded(tryRewriteIndirectAtomicFastPath(op, srcPtr, ptrOffset,
+                                                   rewriter))) {
       return success();
     }
   }
@@ -574,7 +605,8 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
     }
     if constexpr (std::is_same_v<MemAccOpTy, triton::LoadOp> ||
                   std::is_same_v<MemAccOpTy, triton::StoreOp>) {
-      if (simtFastPathEnabled && !rankWithinSimtTemplateLimit) {
+      if (simtTemplateLoadStoreFastPathEnabled &&
+          !rankWithinSimtTemplateLimit) {
         auto &os = llvm::dbgs();
         os << "Skip ascend.unstructured_load/store fast path because rank is "
            << resultShape.size() << " (>5), falling back to scalar loop path\n";
@@ -922,6 +954,11 @@ void TritonToUnstructurePass::runOnOperation() {
     moduleOp->emitError("failed to apply Patterns");
     signalPassFailure();
   }
+
+  // Keep the local SIMT scope alive.  This pass is only the first consumer;
+  // Reduce/Scan and other route-sensitive conversions run later in
+  // TritonToLinalg, and scope.scope is also the native region contract carried
+  // into the external BiShengIR lowering.
 
   PassManager pm(&getContext(), moduleOp.getOperationName());
   pm.addPass(createCSEPass());

--- a/third_party/ascend/triton_ascend.cc
+++ b/third_party/ascend/triton_ascend.cc
@@ -33,6 +33,8 @@
 #include <pybind11/stl.h>
 
 #if TRITON_ASCEND_HAS_INPROC_COSTMODEL
+#include "AscendModel/Analysis/HIVMAnalysis.h"
+#include "AscendModel/Analysis/HardwareConfig.h"
 #include "AscendModel/IR/AscendModelDialect.h"
 #include "AscendModel/Transforms/Passes.h"
 
@@ -47,6 +49,10 @@
 #include <sstream>
 #include <stdexcept>
 #include <vector>
+
+#include "llvm/ADT/SmallString.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/raw_ostream.h"
 #endif
 
 namespace py = pybind11;
@@ -58,6 +64,32 @@ void init_triton_ascend_passes_ttir(py::module &&m) {
     opts.autoBlockifySize = autoBlockifySize;
     pm.addPass(mlir::triton::createAutoBlockifyPass(opts));
   });
+
+#if TRITON_ASCEND_HAS_INPROC_COSTMODEL
+  m.def(
+      "add_select_simd_simt_costmodel",
+      [](mlir::PassManager &pm, const std::string &mode,
+         const std::string &profilePath, const std::string &actualTarget,
+         int64_t numWarps, double marginRatio, bool compileOn91095,
+         const std::string &reportFile) {
+        mlir::ascend::SelectSimdSimtCostModelPassOptions opts;
+        opts.mode = mode;
+        opts.profilePath = profilePath;
+        opts.actualTarget = actualTarget;
+        opts.numWarps = numWarps;
+        opts.marginRatio = marginRatio;
+        opts.compileOn91095 = compileOn91095;
+        opts.reportFile = reportFile;
+        pm.addPass(mlir::ascend::createSelectSimdSimtCostModelPass(opts));
+      },
+      py::arg("pm"), py::arg("mode"), py::arg("profile_path"),
+      py::arg("actual_target"), py::arg("num_warps"), py::arg("margin_ratio"),
+      py::arg("compile_on_910_95"), py::arg("report_file") = "");
+
+  m.def("add_materialize_simt_scopes", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::ascend::createMaterializeSimtScopesPass());
+  });
+#endif
 
   m.def("add_triton_to_structure",
         [](mlir::PassManager &pm, bool enableMaskFallbackConversion,
@@ -386,6 +418,58 @@ runAscendCostModelInProcess(const std::string &mlirText,
   os << "Estimated Time: " << timeUs << " us\n";
   return os.str();
 }
+
+static std::string runHIVMCostModelInProcess(
+    const std::string &mlirText, const std::string &hardwareConfigPath,
+    const std::string &scheduler, const std::string &argBindings = "",
+    bool feedbackJSON = false) {
+  std::string loadError;
+  auto config = mlir::ascend::loadHardwareConfigForAnalysis(hardwareConfigPath,
+                                                            loadError);
+  if (!config)
+    throw std::runtime_error("failed to load HIVM hardware config: " +
+                             loadError);
+
+  mlir::ascend::HIVMSchedulerMode mode;
+  if (scheduler.empty() || scheduler == "static")
+    mode = mlir::ascend::HIVMSchedulerMode::Static;
+  else if (scheduler == "des")
+    mode = mlir::ascend::HIVMSchedulerMode::DES;
+  else
+    throw std::runtime_error(
+        "invalid HIVM scheduler; expected 'static' or 'des'");
+  if (feedbackJSON && mode != mlir::ascend::HIVMSchedulerMode::DES)
+    throw std::runtime_error("HIVM feedback JSON requires the 'des' scheduler");
+
+  int fd = -1;
+  llvm::SmallString<128> path;
+  if (auto ec = llvm::sys::fs::createTemporaryFile("triton-hivm-costmodel",
+                                                   "mlir", fd, path))
+    throw std::runtime_error("failed to create temporary HIVM IR file: " +
+                             ec.message());
+  {
+    llvm::raw_fd_ostream os(fd, true);
+    os << mlirText;
+  }
+
+  mlir::ascend::HIVMAnalyzer analyzer(*config, argBindings, mode);
+  mlir::ascend::HIVMAnalysisReport report;
+  std::string error;
+  bool ok = analyzer.analyzeFile(path, report, error);
+  llvm::sys::fs::remove(path);
+  if (!ok)
+    throw std::runtime_error("in-process HIVM analysis failed: " + error);
+  if (feedbackJSON)
+    report.sourcePath = "<in-memory-module>";
+
+  std::string result;
+  llvm::raw_string_ostream os(result);
+  if (feedbackJSON)
+    report.emitFeedbackJSON(os, *config);
+  else
+    report.print(os, *config);
+  return os.str();
+}
 #endif
 
 // Forward declaration for ascend_ir bindings (defined in ascend_ir.cc)
@@ -416,6 +500,26 @@ void init_triton_ascend(py::module &&m) {
         return runAscendCostModelInProcess(mlirText, extraArgs);
       },
       py::arg("mlir_text"), py::arg("extra_args") = std::vector<std::string>{});
+  m.def(
+      "run_hivm_costmodel_inproc",
+      [](const std::string &mlirText, const std::string &hardwareConfigPath,
+         const std::string &scheduler) {
+        py::gil_scoped_release release;
+        return runHIVMCostModelInProcess(mlirText, hardwareConfigPath,
+                                         scheduler);
+      },
+      py::arg("mlir_text"), py::arg("hardware_config"),
+      py::arg("scheduler") = "des");
+  m.def(
+      "run_hivm_costmodel_feedback_inproc",
+      [](const std::string &mlirText, const std::string &hardwareConfigPath,
+         const std::string &scheduler, const std::string &argBindings) {
+        py::gil_scoped_release release;
+        return runHIVMCostModelInProcess(mlirText, hardwareConfigPath,
+                                         scheduler, argBindings, true);
+      },
+      py::arg("mlir_text"), py::arg("hardware_config"),
+      py::arg("scheduler") = "des", py::arg("arg_bindings") = "");
 #else
   m.def(
       "run_costmodel_inproc",
@@ -425,6 +529,25 @@ void init_triton_ascend(py::module &&m) {
         return std::string();
       },
       py::arg("mlir_text"), py::arg("extra_args") = std::vector<std::string>{});
+  m.def(
+      "run_hivm_costmodel_inproc",
+      [](const std::string &, const std::string &, const std::string &) {
+        throw std::runtime_error(
+            "in-process costmodel bridge is not enabled in this build");
+        return std::string();
+      },
+      py::arg("mlir_text"), py::arg("hardware_config"),
+      py::arg("scheduler") = "des");
+  m.def(
+      "run_hivm_costmodel_feedback_inproc",
+      [](const std::string &, const std::string &, const std::string &,
+         const std::string &) {
+        throw std::runtime_error(
+            "in-process costmodel bridge is not enabled in this build");
+        return std::string();
+      },
+      py::arg("mlir_text"), py::arg("hardware_config"),
+      py::arg("scheduler") = "des", py::arg("arg_bindings") = "");
 #endif
 
   // Initialize ascend IR bindings (ascendnpu_ir_builder, scope/hivm dialects)

--- a/third_party/ascend/unittest/Conversion/950PR/DiscreteMaskAccess/indirect_loadstore.mlir
+++ b/third_party/ascend/unittest/Conversion/950PR/DiscreteMaskAccess/indirect_loadstore.mlir
@@ -1,7 +1,7 @@
 // RUN: triton-opt '--discrete-mask-access-conversion=compile-on-910-95=True force-simt-template=True' --split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: tt.func @discrete_load
-// CHECK: tt.load {{.*}} {MixCompileDiscreteMask} : tensor<1024x!tt.ptr<i32>>
+// CHECK: tt.load {{.*}} {route_discrete_mask_to_simt} : tensor<1024x!tt.ptr<i32>>
 tt.func @discrete_load(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
   %cst = arith.constant dense<0> : tensor<1024xi32>
   %cst_0 = arith.constant dense<200> : tensor<1024xi32>
@@ -20,7 +20,7 @@ tt.func @discrete_load(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
 }
 
 // CHECK-LABEL: tt.func @discrete_store
-// CHECK: tt.store {{.*}} {MixCompileDiscreteMask} : tensor<1024x!tt.ptr<i32>>
+// CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<1024x!tt.ptr<i32>>
 tt.func @discrete_store(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
   %cst = arith.constant dense<0> : tensor<1024xi32>
   %cst_0 = arith.constant dense<200> : tensor<1024xi32>

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/simt_scope.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/simt_scope.mlir
@@ -7,6 +7,6 @@
 tt.func public @simt_scope(%arg0: !tt.ptr<f32>) {
   scope.scope : () -> () {
     scope.return
-  } {vec_mode = "simt"}
+  } {vector_mode = "simt"}
   tt.return
 }

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/simt_scope.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/simt_scope.mlir
@@ -1,0 +1,12 @@
+// RUN: triton-opt --triton-to-linalg="named-ops=True" --split-input-file %s | FileCheck %s
+
+// A canonical SIMT scope must select both the mixed BiShengIR pipeline and
+// the SIMT-aware runtime launch path.
+// CHECK-LABEL: func.func @simt_scope
+// CHECK-SAME: parallel_mode = "mix_simd_simt"
+tt.func public @simt_scope(%arg0: !tt.ptr<f32>) {
+  scope.scope : () -> () {
+    scope.return
+  } {vec_mode = "simt"}
+  tt.return
+}

--- a/third_party/ascend/unittest/costmodel_ut/CMakeLists.txt
+++ b/third_party/ascend/unittest/costmodel_ut/CMakeLists.txt
@@ -18,10 +18,14 @@ add_triton_ut(
 add_triton_ut(
   NAME CostModelPasses
   SRCS PassesTest.cpp
+  DEFS
+    TRITON_ASCEND_DAVID_TEST_CONFIG_PATH="${CMAKE_CURRENT_SOURCE_DIR}/../../costmodel/configs/ascend_davidv100.json"
+    TRITON_ASCEND_SIMD_SIMT_TEST_PROFILE_PATH="${CMAKE_CURRENT_SOURCE_DIR}/../../costmodel/profiles/simd_simt/david_v100_simd_simt_v1.json"
   LIBS
     AscendModelTransforms
     AscendModelAnalysis
     AscendModelIR
+    BiShengIRScopeDialect
     MLIRArithDialect
     MLIRFuncDialect
     MLIRIR
@@ -29,4 +33,13 @@ add_triton_ut(
     MLIRPass
     MLIRSCFDialect
     MLIRSupport
+)
+
+add_triton_ut(
+  NAME SimdSimtCostModel
+  SRCS SimdSimtCostModelTest.cpp
+  DEFS
+    TRITON_ASCEND_SIMD_SIMT_TEST_PROFILE_PATH="${CMAKE_CURRENT_SOURCE_DIR}/../../costmodel/profiles/simd_simt/david_v100_simd_simt_v1.json"
+  LIBS
+    AscendModelRouteModel
 )

--- a/third_party/ascend/unittest/costmodel_ut/HardwareConfigTest.cpp
+++ b/third_party/ascend/unittest/costmodel_ut/HardwareConfigTest.cpp
@@ -1,4 +1,5 @@
 #include "AscendModel/HardwareConfig.h"
+#include "AscendModel/Profile/MicrobenchmarkProfile.h"
 
 #include <gtest/gtest.h>
 
@@ -12,6 +13,21 @@ std::string get910BConfigPath() {
   fs::path src = fs::path(__FILE__).parent_path().parent_path().parent_path();
   fs::path cfg = src / "costmodel" / "configs" / "ascend_910b.json";
   return cfg.string();
+}
+
+std::string getDavidConfigPath() {
+  namespace fs = std::filesystem;
+  fs::path src = fs::path(__FILE__).parent_path().parent_path().parent_path();
+  fs::path cfg = src / "costmodel" / "configs" / "ascend_davidv100.json";
+  return cfg.string();
+}
+
+std::string getDavidMicrobenchmarkProfilePath() {
+  namespace fs = std::filesystem;
+  fs::path src = fs::path(__FILE__).parent_path().parent_path().parent_path();
+  fs::path profile = src / "costmodel" / "profiles" / "microbench" /
+                     "ascend_davidv100_v1.json";
+  return profile.string();
 }
 
 std::unique_ptr<mlir::ascend::HardwareConfig>
@@ -65,6 +81,75 @@ TEST(CostModelHardwareConfigTest, LoadGlobalConfigFromFile) {
   mlir::ascend::HardwareConfig &global = mlir::ascend::getHardwareConfig();
   EXPECT_GT(global.getClockFrequencyGHz(), 0.0);
   EXPECT_GT(global.getHBMBandwidthGBs(), 0.0);
+}
+
+TEST(CostModelHardwareConfigTest,
+     SharedMicrobenchmarkProfilePreservesMetadataAndUnits) {
+  auto profile = mlir::ascend::MicrobenchmarkProfile::loadFromFile(
+      getDavidMicrobenchmarkProfilePath());
+  if (!profile)
+    FAIL() << llvm::toString(profile.takeError());
+
+  EXPECT_EQ(profile->getProfileVersion(),
+            "david-v100-shared-microbench-20260730-v2");
+  EXPECT_EQ(profile->getTarget(), "Ascend950PR/dav-c310");
+  EXPECT_FALSE(profile->getContentSha256().empty());
+
+  const auto *measurement = profile->getMeasurement("simd.f32.add.throughput");
+  ASSERT_NE(measurement, nullptr);
+  EXPECT_DOUBLE_EQ(measurement->value, 3.30);
+  EXPECT_EQ(measurement->unit, "vector_instruction/system_cycle");
+  EXPECT_EQ(measurement->cycleDomain, "SYS_CNT");
+  EXPECT_EQ(measurement->scope,
+            "single_aiv_runtime_loop_ilp4_or_more_effective_source_vadd");
+  EXPECT_EQ(measurement->sourceKind, "isolated_microbenchmark");
+  EXPECT_EQ(measurement->confidence, "high");
+
+  const auto *serializedSetup =
+      profile->getMeasurement("simt.setup.empty_with_barrier");
+  ASSERT_NE(serializedSetup, nullptr);
+  EXPECT_DOUBLE_EQ(serializedSetup->value, 141.0);
+  EXPECT_EQ(serializedSetup->confidence, "medium");
+
+  const auto *gmLoad = profile->getMeasurement("simt.gm.load.throughput");
+  ASSERT_NE(gmLoad, nullptr);
+  EXPECT_DOUBLE_EQ(gmLoad->value, 0.1761917890625);
+  const auto *gmStore = profile->getMeasurement("simt.gm.store.throughput");
+  ASSERT_NE(gmStore, nullptr);
+  EXPECT_DOUBLE_EQ(gmStore->value, 0.12914221875);
+
+  auto converted = profile->convertRatePerCycle(
+      measurement->value, "clock.sys_cnt.frequency_mhz",
+      "clock.device_compute.frequency_mhz");
+  if (!converted)
+    FAIL() << llvm::toString(converted.takeError());
+  EXPECT_NEAR(*converted, 3.30 * 988.9 / 1650.0, 1.0e-12);
+
+  auto wrongUnit =
+      profile->requireValue("simd.f32.add.throughput", "byte/system_cycle");
+  EXPECT_FALSE(static_cast<bool>(wrongUnit));
+  if (!wrongUnit)
+    llvm::consumeError(wrongUnit.takeError());
+
+  auto wrongDomain = profile->requireValue("simd.f32.add.throughput",
+                                           "vector_instruction/system_cycle",
+                                           "device_compute");
+  EXPECT_FALSE(static_cast<bool>(wrongDomain));
+  if (!wrongDomain)
+    llvm::consumeError(wrongDomain.takeError());
+}
+
+TEST(CostModelHardwareConfigTest,
+     DavidConfigLoadsAndConsumesReferencedSharedProfile) {
+  auto cfg = mlir::ascend::HardwareConfig::loadFromFile(getDavidConfigPath());
+  ASSERT_NE(cfg, nullptr);
+  ASSERT_NE(cfg->getMicrobenchmarkProfile(), nullptr);
+  EXPECT_EQ(cfg->getTarget(), "Ascend950PR/dav-c310");
+  EXPECT_EQ(cfg->getMicrobenchmarkProfile()->getProfileVersion(),
+            "david-v100-shared-microbench-20260730-v2");
+  EXPECT_NEAR(
+      cfg->getMicrobenchmarkRatePerDeviceCycle("simd.f32.add.throughput"),
+      3.30 * 988.9 / 1650.0, 1.0e-12);
 }
 
 TEST(CostModelHardwareConfigTest, EstimationAPIsReturnNonNegative) {
@@ -197,4 +282,15 @@ TEST(CostModelHardwareConfigTest, RejectsInvalidConfigReferences) {
   EXPECT_FALSE(cfg->validate(error));
   EXPECT_NE(error.find("bad_mover"), std::string::npos);
   EXPECT_NE(error.find("missing_space"), std::string::npos);
+}
+
+TEST(CostModelHardwareConfigTest,
+     RejectsNonStringMicrobenchmarkProfileReference) {
+  auto cfg = loadConfigFromText(R"json(
+{
+  "microbenchmark_profile": 17,
+  "clock": {"frequency_ghz": 1.0}
+}
+)json");
+  EXPECT_EQ(cfg, nullptr);
 }

--- a/third_party/ascend/unittest/costmodel_ut/PassesTest.cpp
+++ b/third_party/ascend/unittest/costmodel_ut/PassesTest.cpp
@@ -1,13 +1,21 @@
 #include "AscendModel/Transforms/Passes.h"
 #include "AscendModel/IR/AscendModelDialect.h"
+#include "AscendModel/RouteModel/SimdSimtCostModel.h"
+#include "AscendModel/RouteModel/SimtAnchorAnalysis.h"
+#include "AscendModel/RouteModel/SimtSelection.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Verifier.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Pass/PassManager.h"
+
+#include "bishengir/Dialect/Scope/IR/Scope.h"
+#include "llvm/Support/JSON.h"
 
 #include <gtest/gtest.h>
 
@@ -20,11 +28,16 @@ using mlir::OwningOpRef;
 using mlir::Pass;
 using mlir::PassManager;
 using mlir::StringAttr;
+using mlir::ascend::analyzeSimdSimtFeatures;
+using mlir::ascend::buildMixedSimtAnchorPlan;
 using mlir::ascend::createAssignOpIDsPass;
 using mlir::ascend::createEstimateCyclesPass;
 using mlir::ascend::createPerfReportPass;
 using mlir::ascend::createPipelineAnalysisPass;
+using mlir::ascend::createSelectSimdSimtCostModelPass;
 using mlir::ascend::EstimateCyclesPassOptions;
+using mlir::ascend::materializeSimtAnchorPlan;
+using mlir::ascend::SelectSimdSimtCostModelPassOptions;
 
 namespace {
 
@@ -39,11 +52,21 @@ module {
 }
 )mlir";
 
+constexpr const char *kOutOfSimdSimtCoverageModule = R"mlir(
+module {
+  func.func @main(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+    %0 = arith.addf %arg0, %arg1 : tensor<4xf32>
+    return %0 : tensor<4xf32>
+  }
+}
+)mlir";
+
 void registerDialects(mlir::MLIRContext &context) {
   context.getOrLoadDialect<mlir::arith::ArithDialect>();
   context.getOrLoadDialect<mlir::ascend::AscendModelDialect>();
   context.getOrLoadDialect<mlir::func::FuncDialect>();
   context.getOrLoadDialect<mlir::scf::SCFDialect>();
+  context.getOrLoadDialect<mlir::scope::ScopeDialect>();
 }
 
 OwningOpRef<ModuleOp> parseModule(mlir::MLIRContext &context,
@@ -129,6 +152,358 @@ TEST(CostModelPassesTest, EstimateCyclesAnnotatesComputeAndTransferOps) {
   EXPECT_TRUE(storeOp->getAttrOfType<StringAttr>("hw_unit"));
 }
 
+TEST(CostModelPassesTest, DavidF32AddConsumesSharedThroughputInAbsoluteModel) {
+  mlir::MLIRContext context;
+  auto module = parseModule(context, R"mlir(
+module {
+  func.func @main(%arg0: tensor<1024xf32>) -> tensor<1024xf32> {
+    %0 = ascend.add %arg0, %arg0
+      : (tensor<1024xf32>, tensor<1024xf32>) -> tensor<1024xf32>
+    return %0 : tensor<1024xf32>
+  }
+}
+)mlir");
+  ASSERT_TRUE(module);
+
+  EstimateCyclesPassOptions options;
+  options.hardwareConfigPath = TRITON_ASCEND_DAVID_TEST_CONFIG_PATH;
+  ASSERT_TRUE(runPasses(*module, createEstimateCyclesPass(options)));
+
+  Operation *addOp = findFirstOp(*module, "ascend.add");
+  ASSERT_NE(addOp, nullptr);
+  // The absolute model uses the TileSim VADD table: 1024 f32 values / 64
+  // lanes = 16 repeats, plus 35 startup cycles.
+  EXPECT_EQ(getI64Attr(addOp, "estimated_cycles"), 51);
+}
+
+TEST(CostModelPassesTest,
+     SimtFeatureExtractionUsesSSAProvenanceAndUniqueMasks) {
+  mlir::MLIRContext context;
+  context.allowUnregisteredDialects();
+  auto module = parseModule(context, R"mlir(
+module {
+  func.func @main(
+      %index_ptr: tensor<4x16xi64>,
+      %data_ptr: tensor<4x16xi64>) -> tensor<4x16xf32> {
+    %idx = "tt.load"(%index_ptr)
+      : (tensor<4x16xi64>) -> tensor<4x16xi64>
+    %addr = arith.addi %data_ptr, %idx : tensor<4x16xi64>
+    %zero = arith.constant dense<0> : tensor<4x16xi64>
+    %mask = arith.cmpi sge, %idx, %zero : tensor<4x16xi64>
+    %data = "tt.load"(%addr, %mask)
+      : (tensor<4x16xi64>, tensor<4x16xi1>) -> tensor<4x16xf32>
+    %reduced = "tt.reduce"(%data) ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %sum = arith.addf %lhs, %rhs : f32
+      "tt.reduce.return"(%sum) : (f32) -> ()
+    }) {axis = 1 : i32}
+      : (tensor<4x16xf32>) -> tensor<4xf32>
+    return %data : tensor<4x16xf32>
+  }
+}
+)mlir");
+  ASSERT_TRUE(module);
+
+  auto plan = buildMixedSimtAnchorPlan(*module, /*compileOn91095=*/true);
+  ASSERT_EQ(plan.anchors.size(), 1u);
+  EXPECT_EQ(plan.materializableCount(), 1);
+  EXPECT_EQ(mlir::ascend::stringifySimtAnchorKind(plan.anchors[0].kind),
+            "loaded_index_dependent_memory");
+
+  auto features = analyzeSimdSimtFeatures(*module, plan);
+  if (!features)
+    FAIL() << llvm::toString(features.takeError());
+
+  EXPECT_EQ(features->loadedIndexDependentMemoryOps, 1);
+  EXPECT_EQ(features->simtAnchors.loadedIndexDependentMemoryOps, 1);
+  EXPECT_EQ(features->simtAnchors.recognizedCount, 1);
+  EXPECT_EQ(features->simtAnchors.count, 1);
+  ASSERT_EQ(features->simtAnchors.mechanismKinds.size(), 1u);
+  EXPECT_EQ(features->simtAnchors.mechanismKinds.front(),
+            "loaded_index_dependent_memory");
+
+  // The same predicate is produced once and consumed by tt.load.  The legacy
+  // rank sum sees both uses, while the hardware-facing fields count one SSA
+  // value and its 64 predicate elements exactly once.
+  EXPECT_GT(features->maskRankSum, features->uniqueMaskRankSum);
+  EXPECT_EQ(features->uniqueMaskValues, 1);
+  EXPECT_EQ(features->uniqueMaskRankSum, 2);
+  EXPECT_EQ(features->predicateElements, 64);
+  EXPECT_EQ(features->simtAnchors.uniqueMaskValues, 1);
+  EXPECT_EQ(features->simtAnchors.predicateElements, 64);
+
+  EXPECT_EQ(features->rowLocalReduceOps, 1);
+  EXPECT_EQ(features->maxReduceAxisExtent, 16);
+  EXPECT_EQ(features->weightedReduceAxisElements, 16);
+}
+
+TEST(CostModelPassesTest,
+     SimtAnchorAnalysisExtractsHistogramFactsAndLowerability) {
+  mlir::MLIRContext context;
+  context.allowUnregisteredDialects();
+  auto module = parseModule(context, R"mlir(
+module {
+  func.func @main(%input: tensor<64xi32>) -> tensor<256xi32> {
+    %histogram = "tt.histogram"(%input)
+      : (tensor<64xi32>) -> tensor<256xi32>
+    return %histogram : tensor<256xi32>
+  }
+}
+)mlir");
+  ASSERT_TRUE(module);
+
+  auto plan = buildMixedSimtAnchorPlan(*module, /*compileOn91095=*/true);
+  ASSERT_EQ(plan.anchors.size(), 1u);
+  const auto &anchor = plan.anchors.front();
+  EXPECT_EQ(anchor.kind, mlir::ascend::SimtAnchorKind::Histogram);
+  const auto *facts = std::get_if<mlir::ascend::HistogramFacts>(&anchor.facts);
+  ASSERT_NE(facts, nullptr);
+  EXPECT_EQ(facts->inputElements, 64);
+  EXPECT_EQ(facts->numBins, 256);
+  EXPECT_EQ(facts->inputType, "i32");
+  EXPECT_EQ(facts->resultType, "i32");
+
+  EXPECT_EQ(anchor.lowerability.allSimd,
+            mlir::ascend::CandidateLoweringStatus::Unsupported);
+  EXPECT_EQ(anchor.lowerability.allSimtOnly,
+            mlir::ascend::CandidateLoweringStatus::Unsupported);
+  EXPECT_EQ(anchor.lowerability.mixed,
+            mlir::ascend::CandidateLoweringStatus::Native);
+  EXPECT_TRUE(anchor.materializable);
+  EXPECT_EQ(plan.kernelLowerability.allSimd,
+            mlir::ascend::CandidateLoweringStatus::Unsupported);
+  EXPECT_EQ(plan.kernelLowerability.allSimtOnly,
+            mlir::ascend::CandidateLoweringStatus::Unsupported);
+  EXPECT_EQ(plan.kernelLowerability.mixed,
+            mlir::ascend::CandidateLoweringStatus::Native);
+}
+
+TEST(CostModelPassesTest,
+     SimtAnchorAnalysisExtractsPlainCumsumFactsAndLowerability) {
+  mlir::MLIRContext context;
+  context.allowUnregisteredDialects();
+  auto module = parseModule(context, R"mlir(
+module {
+  func.func @main(%input: tensor<1x128x1xf32>)
+      -> tensor<1x128x1xf32> {
+    %cumsum = "tt.scan"(%input) ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %sum = arith.addf %lhs, %rhs : f32
+      "tt.scan.return"(%sum) : (f32) -> ()
+    }) {axis = 1 : i32, reverse = true}
+      : (tensor<1x128x1xf32>) -> tensor<1x128x1xf32>
+    return %cumsum : tensor<1x128x1xf32>
+  }
+}
+)mlir");
+  ASSERT_TRUE(module);
+
+  auto plan = buildMixedSimtAnchorPlan(*module, /*compileOn91095=*/true);
+  ASSERT_EQ(plan.anchors.size(), 1u);
+  const auto &anchor = plan.anchors.front();
+  EXPECT_EQ(anchor.kind,
+            mlir::ascend::SimtAnchorKind::PlainOneDimensionalCumsum);
+  const auto *facts =
+      std::get_if<mlir::ascend::PlainCumsumFacts>(&anchor.facts);
+  ASSERT_NE(facts, nullptr);
+  EXPECT_EQ(facts->axisExtent, 128);
+  EXPECT_EQ(facts->elementType, "f32");
+  EXPECT_TRUE(facts->reverse);
+
+  EXPECT_EQ(anchor.lowerability.allSimd,
+            mlir::ascend::CandidateLoweringStatus::AliasesMixed);
+  EXPECT_EQ(anchor.lowerability.allSimtOnly,
+            mlir::ascend::CandidateLoweringStatus::BackendConditional);
+  EXPECT_EQ(anchor.lowerability.mixed,
+            mlir::ascend::CandidateLoweringStatus::Native);
+  EXPECT_TRUE(anchor.materializable);
+  EXPECT_EQ(plan.kernelLowerability.allSimd,
+            mlir::ascend::CandidateLoweringStatus::AliasesMixed);
+  EXPECT_EQ(plan.kernelLowerability.allSimtOnly,
+            mlir::ascend::CandidateLoweringStatus::BackendConditional);
+  EXPECT_EQ(plan.kernelLowerability.mixed,
+            mlir::ascend::CandidateLoweringStatus::Native);
+}
+
+TEST(CostModelPassesTest,
+     SimtAnchorAnalysisExtractsTensorAtomicFactsAndLowerability) {
+  mlir::MLIRContext context;
+  context.allowUnregisteredDialects();
+  auto module = parseModule(context, R"mlir(
+module {
+  func.func @main(
+      %index_pointer: tensor<64xi64>,
+      %base_pointer: tensor<64xi64>,
+      %value: tensor<64xf32>) -> tensor<64xf32> {
+    %index = "tt.load"(%index_pointer)
+      : (tensor<64xi64>) -> tensor<64xi64>
+    %address = "tt.addptr"(%base_pointer, %index)
+      : (tensor<64xi64>, tensor<64xi64>) -> tensor<64xi64>
+    %mask = arith.constant dense<true> : tensor<64xi1>
+    %old = "tt.atomic_rmw"(%address, %value, %mask)
+      {atomic_rmw_op = 5 : i32}
+      : (tensor<64xi64>, tensor<64xf32>, tensor<64xi1>)
+        -> tensor<64xf32>
+    return %old : tensor<64xf32>
+  }
+}
+)mlir");
+  ASSERT_TRUE(module);
+
+  auto plan = buildMixedSimtAnchorPlan(*module, /*compileOn91095=*/true);
+  ASSERT_EQ(plan.anchors.size(), 1u);
+  const auto &anchor = plan.anchors.front();
+  EXPECT_EQ(anchor.kind, mlir::ascend::SimtAnchorKind::TensorAtomic);
+  const auto *facts =
+      std::get_if<mlir::ascend::TensorAtomicFacts>(&anchor.facts);
+  ASSERT_NE(facts, nullptr);
+  EXPECT_EQ(facts->updateElements, 64);
+  EXPECT_EQ(facts->addressRank, 1);
+  EXPECT_EQ(facts->valueType, "f32");
+  EXPECT_EQ(facts->offsetType, "i64");
+  EXPECT_EQ(facts->operation, "fadd");
+  EXPECT_TRUE(facts->hasMask);
+  ASSERT_TRUE(facts->staticMaskActiveFraction.has_value());
+  EXPECT_DOUBLE_EQ(*facts->staticMaskActiveFraction, 1.0);
+  EXPECT_TRUE(facts->resultUsed);
+  EXPECT_TRUE(facts->addressIsLaneVarying);
+  EXPECT_TRUE(facts->addressDependsOnLoadedIndex);
+
+  EXPECT_EQ(anchor.lowerability.allSimd,
+            mlir::ascend::CandidateLoweringStatus::Native);
+  EXPECT_EQ(anchor.lowerability.allSimtOnly,
+            mlir::ascend::CandidateLoweringStatus::BackendConditional);
+  EXPECT_EQ(anchor.lowerability.mixed,
+            mlir::ascend::CandidateLoweringStatus::Native);
+  EXPECT_TRUE(anchor.materializable);
+  EXPECT_EQ(plan.kernelLowerability.allSimd,
+            mlir::ascend::CandidateLoweringStatus::Native);
+  EXPECT_EQ(plan.kernelLowerability.allSimtOnly,
+            mlir::ascend::CandidateLoweringStatus::BackendConditional);
+  EXPECT_EQ(plan.kernelLowerability.mixed,
+            mlir::ascend::CandidateLoweringStatus::Native);
+}
+
+TEST(CostModelPassesTest,
+     SimtAnchorAnalysisRecognizesTriangularSolveLoopGroup) {
+  mlir::MLIRContext context;
+  context.allowUnregisteredDialects();
+  auto module = parseModule(context, R"mlir(
+module {
+  func.func @main(%input: tensor<16xi32>, %state: tensor<16x16xf32>,
+                  %limit: index)
+      -> tensor<16x16xf32> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %range = "tt.make_range"() {end = 16 : i32, start = 0 : i32}
+      : () -> tensor<16xi32>
+    %row = "tt.expand_dims"(%range) {axis = 1 : i32}
+      : (tensor<16xi32>) -> tensor<16x1xi32>
+    %column = "tt.expand_dims"(%range) {axis = 0 : i32}
+      : (tensor<16xi32>) -> tensor<1x16xi32>
+    %rows = "tt.broadcast"(%row)
+      : (tensor<16x1xi32>) -> tensor<16x16xi32>
+    %columns = "tt.broadcast"(%column)
+      : (tensor<1x16xi32>) -> tensor<16x16xi32>
+    %mask = arith.cmpi sgt, %rows, %columns : tensor<16x16xi32>
+    %zero = arith.constant dense<0.0> : tensor<16x16xf32>
+    %initial = "tt.load"(%state)
+      : (tensor<16x16xf32>) -> tensor<16x16xf32>
+    %a = scf.for %i = %c0 to %limit step %c1 iter_args(%acc = %state)
+        -> (tensor<16x16xf32>) {
+      %load = "tt.load"(%input) : (tensor<16xi32>) -> tensor<16xf32>
+      %red = "tt.reduce"(%acc) ({
+      ^bb0(%lhs: f32, %rhs: f32):
+        %sum = arith.addf %lhs, %rhs : f32
+        "tt.reduce.return"(%sum) : (f32) -> ()
+      }) {axis = 0 : i32} : (tensor<16x16xf32>) -> tensor<16xf32>
+      %sel = arith.select %mask, %acc, %zero : tensor<16x16xi1>, tensor<16x16xf32>
+      scf.yield %sel : tensor<16x16xf32>
+    }
+    %b = scf.for %i = %c0 to %limit step %c1 iter_args(%acc = %a)
+        -> (tensor<16x16xf32>) {
+      %load = "tt.load"(%input) : (tensor<16xi32>) -> tensor<16xf32>
+      %red = "tt.reduce"(%acc) ({
+      ^bb0(%lhs: f32, %rhs: f32):
+        %sum = arith.addf %lhs, %rhs : f32
+        "tt.reduce.return"(%sum) : (f32) -> ()
+      }) {axis = 0 : i32} : (tensor<16x16xf32>) -> tensor<16xf32>
+      %sel = arith.select %mask, %acc, %zero : tensor<16x16xi1>, tensor<16x16xf32>
+      scf.yield %sel : tensor<16x16xf32>
+    }
+    return %b : tensor<16x16xf32>
+  }
+}
+)mlir");
+  ASSERT_TRUE(module);
+
+  auto plan = buildMixedSimtAnchorPlan(*module, /*compileOn91095=*/true);
+  ASSERT_EQ(plan.anchors.size(), 1u);
+  EXPECT_EQ(plan.materializableCount(), 1);
+  for (const auto &anchor : plan.anchors) {
+    EXPECT_EQ(anchor.kind, mlir::ascend::SimtAnchorKind::TriangularSolveLoop);
+    EXPECT_EQ(anchor.lowerability.mixed,
+              mlir::ascend::CandidateLoweringStatus::Native);
+    EXPECT_TRUE(anchor.materializable);
+    // Both recurrence loops are one physical SIMT scope and therefore one
+    // scored/materialized anchor, not two independent route decisions.
+    EXPECT_GE(anchor.scopeOperations.size(), 2u);
+    EXPECT_EQ(anchor.scopeInsertionPoint, anchor.operation);
+    EXPECT_EQ(anchor.scopeOperations.front()->getName().getStringRef(),
+              "tt.make_range");
+  }
+  EXPECT_EQ(plan.kernelLowerability.mixed,
+            mlir::ascend::CandidateLoweringStatus::Native);
+
+  auto features = analyzeSimdSimtFeatures(*module, plan);
+  if (!features)
+    FAIL() << llvm::toString(features.takeError());
+  EXPECT_EQ(features->simtAnchors.count, 1);
+  EXPECT_EQ(features->simtAnchors.staticLoopCount, 2);
+  EXPECT_EQ(features->simtAnchors.staticLoopTripCountSum, 28);
+  EXPECT_EQ(features->simtAnchors.modeledDynamicLoopCount, 2);
+  EXPECT_EQ(features->simtAnchors.modeledDynamicLoopTripCountSum, 28);
+  EXPECT_EQ(features->simtAnchors.reduceOps, 2);
+  EXPECT_EQ(features->simtAnchors.weightedOps.lookup("reduce"), 28);
+  EXPECT_EQ(features->simtAnchors.shuffleLaneSteps, 28672);
+  // 2 loop-weighted mask uses: 2 * 256 * 14, plus the 256-lane mask setup
+  // that is moved into the same scope.
+  EXPECT_EQ(features->simtAnchors.predicateLaneEvaluations, 7424);
+  EXPECT_TRUE(features->hasUnknownTripCount);
+
+  ASSERT_TRUE(mlir::succeeded(materializeSimtAnchorPlan(*module, plan)));
+  Operation *scope = findFirstOp(*module, "scope.scope");
+  ASSERT_NE(scope, nullptr);
+  EXPECT_EQ(scope->getAttrOfType<mlir::StringAttr>("vec_mode").getValue(),
+            "simt");
+  Operation *initialLoad = findFirstOp(*module, "tt.load");
+  ASSERT_NE(initialLoad, nullptr);
+  EXPECT_NE(initialLoad->getParentOp(), scope);
+  bool tensorMaskSetupMovedIntoScope = false;
+  Operation *floatingZero = nullptr;
+  module->walk([&](Operation *op) {
+    if (op->getName().getStringRef() != "arith.constant" ||
+        op->getNumResults() != 1)
+      return;
+    auto type =
+        llvm::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (type && type.getElementType().isF32())
+      floatingZero = op;
+  });
+  scope->walk([&](Operation *op) {
+    if (op->getName().getStringRef() != "arith.cmpi" ||
+        op->getNumResults() != 1)
+      return;
+    auto type =
+        llvm::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (type && type.getElementType().isInteger(1))
+      tensorMaskSetupMovedIntoScope = true;
+  });
+  EXPECT_TRUE(tensorMaskSetupMovedIntoScope);
+  ASSERT_NE(floatingZero, nullptr);
+  EXPECT_NE(floatingZero->getParentOp(), scope);
+}
+
 TEST(CostModelPassesTest, EstimateCyclesReportsInvalidArgBindings) {
   mlir::MLIRContext context;
   auto module = parseModule(context, kVectorModule);
@@ -171,4 +546,234 @@ TEST(CostModelPassesTest, PerfReportPassAcceptsEstimatedPipeline) {
   EXPECT_TRUE(runPasses(*module, createAssignOpIDsPass(),
                         createEstimateCyclesPass(),
                         createPipelineAnalysisPass(), createPerfReportPass()));
+}
+
+TEST(CostModelPassesTest, SimdSimtCoverageShortCircuitIsAutoOnly) {
+  auto configureOptions = [](SelectSimdSimtCostModelPassOptions &options,
+                             llvm::StringRef mode) {
+    options.mode = mode.str();
+    options.profilePath = TRITON_ASCEND_SIMD_SIMT_TEST_PROFILE_PATH;
+    options.actualTarget = "Ascend950PR_9579";
+    options.numWarps = 4;
+    options.marginRatio = 0.10;
+    options.compileOn91095 = true;
+  };
+
+  mlir::MLIRContext autoContext;
+  auto autoModule = parseModule(autoContext, kOutOfSimdSimtCoverageModule);
+  ASSERT_TRUE(autoModule);
+  SelectSimdSimtCostModelPassOptions autoOptions;
+  configureOptions(autoOptions, "auto");
+  ASSERT_TRUE(
+      runPasses(*autoModule, createSelectSimdSimtCostModelPass(autoOptions)));
+
+  auto autoEffective =
+      (*autoModule)
+          ->getAttrOfType<StringAttr>("ascend.simt_costmodel.effective");
+  auto autoRecommended =
+      (*autoModule)
+          ->getAttrOfType<StringAttr>("ascend.simt_costmodel.recommended");
+  auto autoReport =
+      (*autoModule)
+          ->getAttrOfType<StringAttr>("ascend.simt_costmodel.report_json");
+  ASSERT_TRUE(autoEffective);
+  ASSERT_TRUE(autoRecommended);
+  ASSERT_TRUE(autoReport);
+  EXPECT_EQ(autoEffective.getValue(), "backend_default");
+  EXPECT_EQ(autoRecommended.getValue(), "backend_default");
+  EXPECT_FALSE((*autoModule)->hasAttr("ascend.simt_costmodel.all_simd_score"));
+  auto autoJSON = llvm::json::parse(autoReport.getValue());
+  ASSERT_TRUE(static_cast<bool>(autoJSON));
+  auto *autoObject = autoJSON->getAsObject();
+  ASSERT_NE(autoObject, nullptr);
+  auto autoEvaluated = autoObject->getBoolean("candidate_costs_evaluated");
+  ASSERT_TRUE(autoEvaluated);
+  EXPECT_FALSE(*autoEvaluated);
+  auto *autoCandidateCosts = autoObject->get("candidate_costs");
+  auto *autoDecision = autoObject->get("decision_kind");
+  ASSERT_NE(autoCandidateCosts, nullptr);
+  ASSERT_NE(autoDecision, nullptr);
+  EXPECT_TRUE(autoCandidateCosts->getAsNull().has_value());
+  EXPECT_TRUE(autoDecision->getAsNull().has_value());
+  auto autoReason = autoObject->getString("application_reason");
+  ASSERT_TRUE(autoReason);
+  EXPECT_EQ(*autoReason, "selection_score_invalid");
+
+  mlir::MLIRContext reportContext;
+  auto reportModule = parseModule(reportContext, kOutOfSimdSimtCoverageModule);
+  ASSERT_TRUE(reportModule);
+  SelectSimdSimtCostModelPassOptions reportOptions;
+  configureOptions(reportOptions, "report");
+  ASSERT_TRUE(runPasses(*reportModule,
+                        createSelectSimdSimtCostModelPass(reportOptions)));
+
+  auto reportEffective =
+      (*reportModule)
+          ->getAttrOfType<StringAttr>("ascend.simt_costmodel.effective");
+  auto reportJSONAttr =
+      (*reportModule)
+          ->getAttrOfType<StringAttr>("ascend.simt_costmodel.report_json");
+  ASSERT_TRUE(reportEffective);
+  ASSERT_TRUE(reportJSONAttr);
+  EXPECT_EQ(reportEffective.getValue(), "backend_default");
+  EXPECT_TRUE((*reportModule)->hasAttr("ascend.simt_costmodel.all_simd_score"));
+  auto reportJSON = llvm::json::parse(reportJSONAttr.getValue());
+  ASSERT_TRUE(static_cast<bool>(reportJSON));
+  auto *reportObject = reportJSON->getAsObject();
+  ASSERT_NE(reportObject, nullptr);
+  auto reportEvaluated = reportObject->getBoolean("candidate_costs_evaluated");
+  ASSERT_TRUE(reportEvaluated);
+  EXPECT_TRUE(*reportEvaluated);
+  auto reportReason = reportObject->getString("application_reason");
+  ASSERT_TRUE(reportReason);
+  EXPECT_EQ(*reportReason, "report_mode");
+}
+
+TEST(CostModelPassesTest, MaterializeSimtScopePreservesEscapingSSAResult) {
+  mlir::MLIRContext context;
+  auto module = parseModule(context, R"mlir(
+module attributes {
+  ascend.simt_costmodel.effective = "mixed_simd_simt"
+} {
+  func.func @main(%arg0: i32, %arg1: i32) -> i32 {
+    %0 = arith.addi %arg0, %arg1 : i32
+    %1 = arith.muli %0, %arg1 : i32
+    return %1 : i32
+  }
+}
+)mlir");
+  ASSERT_TRUE(module);
+
+  Operation *addBeforeMaterialization = findFirstOp(*module, "arith.addi");
+  ASSERT_NE(addBeforeMaterialization, nullptr);
+  mlir::ascend::SimtAnchorPlan plan;
+  mlir::ascend::SimtAnchorDescriptor anchor;
+  anchor.operation = addBeforeMaterialization;
+  anchor.kind = mlir::ascend::SimtAnchorKind::DirectGather;
+  anchor.materializable = true;
+  plan.anchors.push_back(anchor);
+  ASSERT_TRUE(mlir::succeeded(materializeSimtAnchorPlan(*module, plan)));
+
+  Operation *scopeOp = findFirstOp(*module, "scope.scope");
+  ASSERT_NE(scopeOp, nullptr);
+  ASSERT_EQ(scopeOp->getNumRegions(), 1u);
+  ASSERT_EQ(scopeOp->getNumResults(), 1u);
+  ASSERT_TRUE(scopeOp->getAttrOfType<StringAttr>("vec_mode"));
+  EXPECT_EQ(scopeOp->getAttrOfType<StringAttr>("vec_mode").getValue(), "simt");
+
+  auto &scopeBody = scopeOp->getRegion(0).front();
+  Operation *scopedAdd = nullptr;
+  Operation *scopeReturn = nullptr;
+  for (Operation &nested : scopeBody) {
+    if (nested.getName().getStringRef() == "arith.addi")
+      scopedAdd = &nested;
+    if (nested.getName().getStringRef() == "scope.return")
+      scopeReturn = &nested;
+  }
+  ASSERT_NE(scopedAdd, nullptr);
+  ASSERT_NE(scopeReturn, nullptr);
+  ASSERT_EQ(scopeReturn->getNumOperands(), 1u);
+  EXPECT_EQ(scopeReturn->getOperand(0), scopedAdd->getResult(0));
+
+  Operation *mulOp = findFirstOp(*module, "arith.muli");
+  ASSERT_NE(mulOp, nullptr);
+  ASSERT_EQ(mulOp->getNumOperands(), 2u);
+  EXPECT_EQ(mulOp->getOperand(0), scopeOp->getResult(0));
+  EXPECT_NE(mulOp->getParentOp(), scopeOp);
+
+  EXPECT_FALSE(module->getOperation()->hasAttr(
+      "ascend.simt_costmodel.scope_materialized"));
+}
+
+TEST(CostModelPassesTest, NativeWholeBodySimtScopeDetectionAndInlining) {
+  mlir::MLIRContext context;
+  auto module = parseModule(context, R"mlir(
+module {
+  func.func public @main(%arg0: i32) {
+    %c1 = arith.constant 1 : i32
+    "scope.scope"() ({
+      "scope.scope"() ({
+        %0 = arith.addi %arg0, %c1 : i32
+        "scope.return"() : () -> ()
+      }) {vec_mode = "simt"} : () -> ()
+      "scope.return"() : () -> ()
+    }) {vec_mode = "simt"} : () -> ()
+    return
+  }
+}
+)mlir");
+  ASSERT_TRUE(module);
+
+  Operation *scope = mlir::ascend::simt_selection::findWholeBodyVoidSimtScope(
+      module->getOperation());
+  ASSERT_NE(scope, nullptr);
+  EXPECT_EQ(mlir::ascend::simt_selection::inlineVoidSimtScopesForPureSimt(
+                module->getOperation()),
+            2);
+  EXPECT_EQ(findFirstOp(*module, "scope.scope"), nullptr);
+  EXPECT_NE(findFirstOp(*module, "arith.addi"), nullptr);
+  EXPECT_EQ(mlir::ascend::simt_selection::findWholeBodyVoidSimtScope(
+                module->getOperation()),
+            nullptr);
+  EXPECT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+  auto resultBearing = parseModule(context, R"mlir(
+module {
+  func.func public @main(%arg0: i32) -> i32 {
+    %0 = "scope.scope"() ({
+      "scope.return"(%arg0) : (i32) -> ()
+    }) {vec_mode = "simt"} : () -> i32
+    return %0 : i32
+  }
+}
+)mlir");
+  ASSERT_TRUE(resultBearing);
+  EXPECT_EQ(mlir::ascend::simt_selection::findWholeBodyVoidSimtScope(
+                resultBearing->getOperation()),
+            nullptr);
+  EXPECT_EQ(mlir::ascend::simt_selection::inlineVoidSimtScopesForPureSimt(
+                resultBearing->getOperation()),
+            0);
+  EXPECT_NE(findFirstOp(*resultBearing, "scope.scope"), nullptr);
+}
+
+TEST(CostModelPassesTest, ModelControlledRoutingIgnoresLegacyGlobalForce) {
+  mlir::MLIRContext context;
+  auto module = parseModule(context, R"mlir(
+module attributes {
+  ascend.simt_costmodel.effective = "all_simd"
+} {
+  func.func @main(%arg0: i32, %arg1: i32) -> i32 {
+    %0 = arith.addi %arg0, %arg1 : i32
+    return %0 : i32
+  }
+}
+)mlir");
+  ASSERT_TRUE(module);
+
+  Operation *addOp = findFirstOp(*module, "arith.addi");
+  ASSERT_NE(addOp, nullptr);
+  EXPECT_TRUE(mlir::ascend::simt_selection::isModelControlled(addOp));
+  EXPECT_FALSE(mlir::ascend::simt_selection::shouldUseSimtTemplate(
+      addOp, /*legacyForceSimt=*/true));
+
+  (*module)->setAttr(mlir::ascend::simt_selection::kEffectiveExecutionAttr,
+                     mlir::StringAttr::get(&context, "mixed_simd_simt"));
+  mlir::ascend::SimtAnchorPlan plan;
+  mlir::ascend::SimtAnchorDescriptor anchor;
+  anchor.operation = addOp;
+  anchor.kind = mlir::ascend::SimtAnchorKind::DirectGather;
+  anchor.materializable = true;
+  plan.anchors.push_back(anchor);
+  ASSERT_TRUE(mlir::succeeded(materializeSimtAnchorPlan(*module, plan)));
+  addOp = findFirstOp(*module, "arith.addi");
+  ASSERT_NE(addOp, nullptr);
+  EXPECT_TRUE(mlir::ascend::simt_selection::shouldUseSimtTemplate(
+      addOp, /*legacyForceSimt=*/false));
+
+  (*module)->setAttr(mlir::ascend::simt_selection::kEffectiveExecutionAttr,
+                     mlir::StringAttr::get(&context, "backend_default"));
+  EXPECT_FALSE(mlir::ascend::simt_selection::isModelControlled(addOp));
+  EXPECT_TRUE(mlir::ascend::simt_selection::shouldUseSimtTemplate(
+      addOp, /*legacyForceSimt=*/true));
 }

--- a/third_party/ascend/unittest/costmodel_ut/PassesTest.cpp
+++ b/third_party/ascend/unittest/costmodel_ut/PassesTest.cpp
@@ -474,7 +474,7 @@ module {
   ASSERT_TRUE(mlir::succeeded(materializeSimtAnchorPlan(*module, plan)));
   Operation *scope = findFirstOp(*module, "scope.scope");
   ASSERT_NE(scope, nullptr);
-  EXPECT_EQ(scope->getAttrOfType<mlir::StringAttr>("vec_mode").getValue(),
+  EXPECT_EQ(scope->getAttrOfType<mlir::StringAttr>("vector_mode").getValue(),
             "simt");
   Operation *initialLoad = findFirstOp(*module, "tt.load");
   ASSERT_NE(initialLoad, nullptr);
@@ -658,8 +658,9 @@ module attributes {
   ASSERT_NE(scopeOp, nullptr);
   ASSERT_EQ(scopeOp->getNumRegions(), 1u);
   ASSERT_EQ(scopeOp->getNumResults(), 1u);
-  ASSERT_TRUE(scopeOp->getAttrOfType<StringAttr>("vec_mode"));
-  EXPECT_EQ(scopeOp->getAttrOfType<StringAttr>("vec_mode").getValue(), "simt");
+  ASSERT_TRUE(scopeOp->getAttrOfType<StringAttr>("vector_mode"));
+  EXPECT_EQ(scopeOp->getAttrOfType<StringAttr>("vector_mode").getValue(),
+            "simt");
 
   auto &scopeBody = scopeOp->getRegion(0).front();
   Operation *scopedAdd = nullptr;
@@ -695,9 +696,9 @@ module {
       "scope.scope"() ({
         %0 = arith.addi %arg0, %c1 : i32
         "scope.return"() : () -> ()
-      }) {vec_mode = "simt"} : () -> ()
+      }) {vector_mode = "simt"} : () -> ()
       "scope.return"() : () -> ()
-    }) {vec_mode = "simt"} : () -> ()
+    }) {vector_mode = "simt"} : () -> ()
     return
   }
 }
@@ -722,7 +723,7 @@ module {
   func.func public @main(%arg0: i32) -> i32 {
     %0 = "scope.scope"() ({
       "scope.return"(%arg0) : (i32) -> ()
-    }) {vec_mode = "simt"} : () -> i32
+    }) {vector_mode = "simt"} : () -> i32
     return %0 : i32
   }
 }

--- a/third_party/ascend/unittest/costmodel_ut/SimdSimtCostModelTest.cpp
+++ b/third_party/ascend/unittest/costmodel_ut/SimdSimtCostModelTest.cpp
@@ -1,0 +1,439 @@
+#include "AscendModel/RouteModel/SimdSimtCostModel.h"
+
+#include <gtest/gtest.h>
+
+using mlir::ascend::estimateSimdSimtCandidates;
+using mlir::ascend::SimdSimtCandidateKind;
+using mlir::ascend::SimdSimtCostModelOptions;
+using mlir::ascend::SimdSimtFeatureSummary;
+
+namespace {
+
+SimdSimtCostModelOptions options(unsigned numWarps) {
+  SimdSimtCostModelOptions result;
+  result.profilePath = TRITON_ASCEND_SIMD_SIMT_TEST_PROFILE_PATH;
+  result.actualTarget = "Ascend950PR_9579";
+  result.numWarps = numWarps;
+  result.compileOn91095 = true;
+  return result;
+}
+
+SimdSimtFeatureSummary gatherDotFeatures() {
+  SimdSimtFeatureSummary f;
+  f.loadOps = 3;
+  f.storeOps = 1;
+  f.dotOps = 1;
+  f.broadcastOps = 5;
+  f.expandDimsOps = 4;
+  f.splatOps = 9;
+  f.addPtrOps = 7;
+  f.arithOps = 9;
+  f.addOps = 2;
+  f.mulOps = 5;
+  f.scalarOps = 7;
+  f.maxTensorRank = 2;
+  f.maxTensorNumel = 256;
+  f.maxElementBits = 32;
+  f.pointerTensorOps = 11;
+  f.pointerUnstructuredDims = 18;
+  f.laneDependentPointerOps = 9;
+  f.vectorPtrSplatOps = 4;
+  f.loadBytes = 1088;
+  f.storeBytes = 1024;
+  f.loadWarpInstructions = 17;
+  f.storeWarpInstructions = 8;
+  f.dotFlops = 8192;
+  f.dotOutputElements = 256;
+  f.dotMNK.push_back({16, 16, 16});
+  f.hasDot = true;
+  f.observedMixedKinds.push_back("conditional_indirect_memory");
+
+  f.weightedOps["add"] = 2;
+  f.weightedOps["mul"] = 5;
+  f.weightedOps["load"] = 3;
+  f.weightedOps["store"] = 1;
+  f.opElements["add"] = 32;
+  f.opElements["mul"] = 50;
+  f.opElements["load"] = 528;
+  f.opElements["store"] = 256;
+  return f;
+}
+
+SimdSimtFeatureSummary fbgemmFeatures() {
+  SimdSimtFeatureSummary f;
+  f.loadOps = 7;
+  f.storeOps = 2;
+  f.reduceOps = 1;
+  f.broadcastOps = 6;
+  f.expandDimsOps = 6;
+  f.splatOps = 10;
+  f.addPtrOps = 12;
+  f.arithOps = 29;
+  f.mathOps = 2;
+  f.addOps = 1;
+  f.mulOps = 7;
+  f.divOps = 2;
+  f.maxOps = 2;
+  f.absOps = 2;
+  f.cmpOps = 1;
+  f.castOps = 2;
+  f.clampOps = 2;
+  f.scalarOps = 19;
+  f.maxTensorRank = 2;
+  f.maxTensorNumel = 64;
+  f.maxElementBits = 64;
+  f.maskTensorOps = 12;
+  f.maskRankSum = 25;
+  f.maskBroadcastOps = 4;
+  f.pointerTensorOps = 19;
+  f.pointerUnstructuredDims = 20;
+  f.laneDependentPointerOps = 10;
+  f.rowLocalReduceOps = 1;
+  f.scalarLoadOps = 2;
+  f.vectorPtrSplatOps = 6;
+  f.loadBytes = 4152;
+  f.storeBytes = 2064;
+  f.loadWarpInstructions = 37;
+  f.storeWarpInstructions = 17;
+  f.staticLoopCount = 2;
+  f.staticLoopTripCountSum = 16;
+  f.staticLoopTripCountMax = 8;
+  f.hasControlFlow = true;
+  f.observedMixedKinds.push_back("conditional_indirect_memory");
+
+  f.weightedOps["abs"] = 9;
+  f.weightedOps["add"] = 1;
+  f.weightedOps["cast"] = 2;
+  f.weightedOps["clamp"] = 9;
+  f.weightedOps["cmp"] = 1;
+  f.weightedOps["div"] = 2;
+  f.weightedOps["load"] = 21;
+  f.weightedOps["max"] = 16;
+  f.weightedOps["mul"] = 14;
+  f.weightedOps["reduce"] = 8;
+  f.weightedOps["store"] = 9;
+  f.opElements["abs"] = 516;
+  f.opElements["add"] = 4;
+  f.opElements["cast"] = 8;
+  f.opElements["clamp"] = 516;
+  f.opElements["cmp"] = 4;
+  f.opElements["div"] = 8;
+  f.opElements["load"] = 1038;
+  f.opElements["max"] = 40;
+  f.opElements["mul"] = 533;
+  f.opElements["reduce"] = 512;
+  f.opElements["store"] = 516;
+  return f;
+}
+
+SimdSimtFeatureSummary outOfCoverageFeatures() {
+  SimdSimtFeatureSummary f = gatherDotFeatures();
+  // One FLOP above the profile's tiny-dot coverage ceiling.  Since dotFlops is
+  // non-zero, neither reduction-only coverage domain can admit this feature.
+  f.dotFlops = 16385;
+  return f;
+}
+
+SimdSimtFeatureSummary rank1IndirectVectorReductionFeatures() {
+  SimdSimtFeatureSummary f;
+  f.reduceOps = 1;
+  f.maxTensorRank = 1;
+  f.maxTensorNumel = 256;
+  f.maxElementBits = 32;
+  f.rank1IndirectVectorReduce = true;
+  f.weightedOps["reduce"] = 8;
+  return f;
+}
+
+SimdSimtFeatureSummary solveTrilBt16Features() {
+  SimdSimtFeatureSummary f;
+  f.reduceOps = 1;
+  f.maxTensorRank = 2;
+  f.maxTensorNumel = 256;
+  f.maxElementBits = 64;
+  f.maskRankSum = 20;
+  f.pointerTensorOps = 5;
+  f.laneDependentPointerOps = 2;
+  f.staticLoopCount = 1;
+  f.staticLoopTripCountSum = 1;
+  f.staticLoopTripCountMax = 1;
+  f.hasControlFlow = true;
+  f.weightedOps["reduce"] = 1;
+  return f;
+}
+
+SimdSimtFeatureSummary triangularUnknownLoopFeatures() {
+  SimdSimtFeatureSummary f = solveTrilBt16Features();
+  // BT64 has four sibling 16x16 recurrences. Their TTIR upper bounds remain
+  // dynamic, but the full-tile structural estimate is 14 trips per loop.
+  f.staticLoopCount = 4;
+  f.staticLoopTripCountSum = 56;
+  f.staticLoopTripCountMax = 14;
+  f.modeledDynamicLoopCount = 4;
+  f.modeledDynamicLoopTripCountSum = 56;
+  f.hasUnknownTripCount = true;
+  f.maskRankSum = 62;
+  f.weightedOps["reduce"] = 56;
+  f.shuffleLaneSteps = 57344;
+  f.predicateLaneEvaluations = 35840;
+  f.simtAnchors.count = 1;
+  f.simtAnchors.recognizedCount = 1;
+  f.simtAnchors.reduceOps = 4;
+  f.simtAnchors.maxTensorNumel = 256;
+  f.simtAnchors.maskRankSum = 62;
+  f.simtAnchors.staticLoopCount = 4;
+  f.simtAnchors.staticLoopTripCountSum = 56;
+  f.simtAnchors.modeledDynamicLoopCount = 4;
+  f.simtAnchors.modeledDynamicLoopTripCountSum = 56;
+  f.simtAnchors.weightedOps["reduce"] = 56;
+  f.simtAnchors.shuffleLaneSteps = 57344;
+  f.simtAnchors.predicateLaneEvaluations = 35840;
+  f.simtAnchors.mechanismKinds.push_back("triangular_solve_loop");
+  return f;
+}
+
+} // namespace
+
+TEST(SimdSimtCostModelTest,
+     GatherDotGoldenScoresRequireMaterializableMixedPlan) {
+  auto modelOptions = options(32);
+  modelOptions.scoreOutsideCalibrationCoverage = false;
+  auto report = estimateSimdSimtCandidates(gatherDotFeatures(), modelOptions);
+  if (!report)
+    FAIL() << llvm::toString(report.takeError());
+
+  EXPECT_TRUE(report->candidateCostsEvaluated);
+  EXPECT_NEAR(report->breakdown.simdStructuralPenaltyCycles,
+              report->breakdown.simdAnalyticalCycles *
+                  report->breakdown.structuralPenaltyRatio,
+              1.0e-6);
+  EXPECT_NEAR(report->uncalibratedCandidateCosts.allSimd,
+              report->breakdown.simdAnalyticalCycles +
+                  report->breakdown.simdStructuralPenaltyCycles,
+              1.0e-6);
+  EXPECT_NE(report->uncalibratedCandidateCosts.allSimd,
+            report->breakdown.simtAnalyticalCycles *
+                (1.0 + report->breakdown.structuralPenaltyRatio));
+  EXPECT_NEAR(report->candidateCosts.allSimtOnly, 2389.91061977427, 1.0e-6);
+  EXPECT_DOUBLE_EQ(report->uncalibratedCandidateCosts.mixedSimdSimt,
+                   std::max(report->uncalibratedCandidateCosts.allSimd,
+                            report->uncalibratedCandidateCosts.allSimtOnly) +
+                       223.0);
+  EXPECT_NEAR(report->candidateCosts.mixedSimdSimt,
+              report->uncalibratedCandidateCosts.mixedSimdSimt * 0.666478,
+              1.0e-6);
+  EXPECT_TRUE(report->eventRouteCalibrationApplied);
+  EXPECT_FALSE(report->eventAllSimtOnlyValidated);
+  EXPECT_TRUE(report->eventMixedSimdSimtValidated);
+  EXPECT_DOUBLE_EQ(report->eventRouteScoreMultipliers.mixedSimdSimt, 0.666478);
+  EXPECT_FALSE(report->mixedCandidateLegal);
+  EXPECT_TRUE(report->applicability.mechanismDetected);
+  EXPECT_FALSE(report->applicability.materializable);
+  EXPECT_DOUBLE_EQ(report->breakdown.standaloneSimtSetupCycles, 141.0);
+  EXPECT_DOUBLE_EQ(report->breakdown.mixedSetupFallbackCycles, 223.0);
+  EXPECT_DOUBLE_EQ(report->breakdown.setupProxyDeltaCycles, 82.0);
+  EXPECT_EQ(report->decision, SimdSimtCandidateKind::AllSIMD);
+  EXPECT_TRUE(report->selectionScoreValid);
+  EXPECT_EQ(report->calibrationDomain, "tiny_irregular_dot");
+  EXPECT_EQ(report->rankingConfidence, "low");
+  EXPECT_TRUE(report->gatePassed);
+  EXPECT_TRUE(report->gateReasons.empty());
+  EXPECT_EQ(report->schemaVersion, 10);
+  EXPECT_EQ(report->profileVersion, "david-v100-simd-simt-20260806-v11");
+  EXPECT_FALSE(report->selectionProfileContentSha256.empty());
+  EXPECT_EQ(report->microbenchmarkProfileVersion,
+            "david-v100-shared-microbench-20260730-v2");
+  EXPECT_EQ(report->microbenchmarkProfileTarget, "Ascend950PR/dav-c310");
+  EXPECT_FALSE(report->microbenchmarkProfileContentSha256.empty());
+  EXPECT_NE(report->profileContentSha256,
+            report->selectionProfileContentSha256);
+}
+
+TEST(SimdSimtCostModelTest, FbgemmGoldenScoresRequireMaterializableMixedPlan) {
+  auto modelOptions = options(4);
+  modelOptions.scoreOutsideCalibrationCoverage = false;
+  auto report = estimateSimdSimtCandidates(fbgemmFeatures(), modelOptions);
+  if (!report)
+    FAIL() << llvm::toString(report.takeError());
+
+  EXPECT_TRUE(report->candidateCostsEvaluated);
+  EXPECT_NEAR(report->uncalibratedCandidateCosts.allSimd,
+              report->breakdown.simdAnalyticalCycles *
+                  (1.0 + report->breakdown.structuralPenaltyRatio),
+              1.0e-6);
+  EXPECT_NEAR(report->uncalibratedCandidateCosts.allSimtOnly,
+              14311.016566489482, 1.0e-6);
+  EXPECT_DOUBLE_EQ(report->uncalibratedCandidateCosts.mixedSimdSimt,
+                   std::max(report->uncalibratedCandidateCosts.allSimd,
+                            report->uncalibratedCandidateCosts.allSimtOnly) +
+                       182.0);
+  EXPECT_NEAR(report->candidateCosts.allSimd,
+              report->uncalibratedCandidateCosts.allSimd *
+                  report->eventRouteScoreMultipliers.allSimd,
+              1.0e-6);
+  EXPECT_NEAR(report->candidateCosts.allSimtOnly,
+              report->uncalibratedCandidateCosts.allSimtOnly * 0.807671,
+              1.0e-6);
+  EXPECT_NEAR(report->candidateCosts.mixedSimdSimt,
+              report->uncalibratedCandidateCosts.mixedSimdSimt * 3.537276,
+              1.0e-6);
+  EXPECT_TRUE(report->eventRouteCalibrationApplied);
+  EXPECT_TRUE(report->eventAllSimtOnlyValidated);
+  EXPECT_TRUE(report->eventMixedSimdSimtValidated);
+  EXPECT_FALSE(report->mixedCandidateLegal);
+  EXPECT_TRUE(report->applicability.mechanismDetected);
+  EXPECT_FALSE(report->applicability.materializable);
+  EXPECT_DOUBLE_EQ(report->breakdown.standaloneSimtSetupCycles, 141.0);
+  EXPECT_DOUBLE_EQ(report->breakdown.mixedSetupFallbackCycles, 182.0);
+  EXPECT_DOUBLE_EQ(report->breakdown.setupProxyDeltaCycles, 41.0);
+  EXPECT_EQ(report->decision, SimdSimtCandidateKind::AllSIMTOnly);
+  EXPECT_TRUE(report->selectionScoreValid);
+  EXPECT_EQ(report->calibrationDomain, "masked_rowwise_reduction");
+  EXPECT_EQ(report->rankingConfidence, "low");
+  EXPECT_TRUE(report->gatePassed);
+  EXPECT_TRUE(report->gateReasons.empty());
+}
+
+TEST(SimdSimtCostModelTest, Rank1IndirectVectorReductionIsCovered) {
+  auto modelOptions = options(4);
+  modelOptions.scoreOutsideCalibrationCoverage = false;
+  auto report = estimateSimdSimtCandidates(
+      rank1IndirectVectorReductionFeatures(), modelOptions);
+  if (!report)
+    FAIL() << llvm::toString(report.takeError());
+
+  EXPECT_TRUE(report->calibrationCovered);
+  EXPECT_EQ(report->calibrationDomain, "rank1_indirect_vector_reduction");
+  EXPECT_TRUE(report->selectionScoreValid);
+  EXPECT_TRUE(report->candidateCostsEvaluated);
+}
+
+TEST(SimdSimtCostModelTest, SolveTrilBt16StaysOutsideMaskedRowwiseCalibration) {
+  auto modelOptions = options(32);
+  modelOptions.scoreOutsideCalibrationCoverage = false;
+  auto report =
+      estimateSimdSimtCandidates(solveTrilBt16Features(), modelOptions);
+  if (!report)
+    FAIL() << llvm::toString(report.takeError());
+
+  EXPECT_FALSE(report->calibrationCovered);
+  EXPECT_EQ(report->calibrationDomain, "out_of_calibration_domain");
+  EXPECT_FALSE(report->selectionScoreValid);
+  EXPECT_FALSE(report->candidateCostsEvaluated);
+  EXPECT_FALSE(report->gatePassed);
+  ASSERT_EQ(report->gateReasons.size(), 1u);
+  EXPECT_EQ(report->gateReasons.front(), "selection_score_invalid");
+}
+
+TEST(SimdSimtCostModelTest,
+     TriangularUnknownLoopUsesBoundedCalibrationException) {
+  auto modelOptions = options(32);
+  modelOptions.scoreOutsideCalibrationCoverage = false;
+  auto report =
+      estimateSimdSimtCandidates(triangularUnknownLoopFeatures(), modelOptions);
+  if (!report)
+    FAIL() << llvm::toString(report.takeError());
+
+  EXPECT_TRUE(report->calibrationCovered);
+  EXPECT_EQ(report->calibrationDomain, "triangular_solve_loop");
+  EXPECT_TRUE(report->selectionScoreValid);
+  EXPECT_TRUE(report->candidateCostsEvaluated);
+  EXPECT_NEAR(report->breakdown.simtIssuePayloadCycles,
+              report->breakdown.simtComputeCycles +
+                  report->breakdown.simtShuffleCycles +
+                  report->breakdown.simtDotCycles +
+                  report->breakdown.simtMemoryCycles +
+                  report->breakdown.simtPredicateCycles,
+              1.0e-6);
+  EXPECT_NEAR(report->breakdown.mixedSimtAnchorPayloadCycles,
+              report->breakdown.mixedSimtAnchorComputeCycles +
+                  report->breakdown.mixedSimtAnchorDotCycles +
+                  report->breakdown.mixedSimtAnchorShuffleCycles +
+                  report->breakdown.mixedSimtAnchorMemoryCycles +
+                  report->breakdown.mixedSimtAnchorPredicateCycles,
+              1.0e-6);
+  EXPECT_GT(report->breakdown.mixedSimtAnchorShuffleCycles, 0.0);
+  EXPECT_GT(report->breakdown.mixedSimtAnchorPredicateCycles, 0.0);
+}
+
+TEST(SimdSimtCostModelTest,
+     UnknownLoopWithoutTriangularEvidenceRemainsRejected) {
+  auto features = triangularUnknownLoopFeatures();
+  features.simtAnchors.mechanismKinds.clear();
+  auto modelOptions = options(32);
+  modelOptions.scoreOutsideCalibrationCoverage = false;
+  auto report = estimateSimdSimtCandidates(features, modelOptions);
+  if (!report)
+    FAIL() << llvm::toString(report.takeError());
+
+  EXPECT_FALSE(report->calibrationCovered);
+  EXPECT_EQ(report->calibrationDomain, "unknown_loop_trip_count");
+  EXPECT_FALSE(report->selectionScoreValid);
+  EXPECT_FALSE(report->candidateCostsEvaluated);
+}
+
+TEST(SimdSimtCostModelTest,
+     TriangularUnknownLoopStillHonorsAnchorLoopAndShapeBounds) {
+  auto modelOptions = options(32);
+  modelOptions.scoreOutsideCalibrationCoverage = false;
+
+  auto tooFewAnchors = triangularUnknownLoopFeatures();
+  tooFewAnchors.simtAnchors.count = 0;
+  auto fewAnchorReport =
+      estimateSimdSimtCandidates(tooFewAnchors, modelOptions);
+  if (!fewAnchorReport)
+    FAIL() << llvm::toString(fewAnchorReport.takeError());
+  EXPECT_FALSE(fewAnchorReport->calibrationCovered);
+  EXPECT_EQ(fewAnchorReport->calibrationDomain, "unknown_loop_trip_count");
+
+  auto tooManyLoops = triangularUnknownLoopFeatures();
+  tooManyLoops.simtAnchors.staticLoopCount = 5;
+  auto loopReport = estimateSimdSimtCandidates(tooManyLoops, modelOptions);
+  if (!loopReport)
+    FAIL() << llvm::toString(loopReport.takeError());
+  EXPECT_FALSE(loopReport->calibrationCovered);
+  EXPECT_EQ(loopReport->calibrationDomain, "unknown_loop_trip_count");
+
+  auto oversized = triangularUnknownLoopFeatures();
+  oversized.maxTensorNumel = 257;
+  auto oversizedReport = estimateSimdSimtCandidates(oversized, modelOptions);
+  if (!oversizedReport)
+    FAIL() << llvm::toString(oversizedReport.takeError());
+  EXPECT_FALSE(oversizedReport->calibrationCovered);
+  EXPECT_EQ(oversizedReport->calibrationDomain, "unknown_loop_trip_count");
+}
+
+TEST(SimdSimtCostModelTest, OutOfCoverageAutoSkipsButDiagnosticsStillScore) {
+  auto autoOptions = options(32);
+  autoOptions.scoreOutsideCalibrationCoverage = false;
+  auto skipped =
+      estimateSimdSimtCandidates(outOfCoverageFeatures(), autoOptions);
+  if (!skipped)
+    FAIL() << llvm::toString(skipped.takeError());
+
+  EXPECT_FALSE(skipped->calibrationCovered);
+  EXPECT_EQ(skipped->calibrationDomain, "out_of_calibration_domain");
+  EXPECT_FALSE(skipped->selectionScoreValid);
+  EXPECT_FALSE(skipped->candidateCostsEvaluated);
+  EXPECT_FALSE(skipped->gatePassed);
+  ASSERT_EQ(skipped->gateReasons.size(), 1u);
+  EXPECT_EQ(skipped->gateReasons.front(), "selection_score_invalid");
+  EXPECT_DOUBLE_EQ(skipped->candidateCosts.allSimd, 0.0);
+  EXPECT_DOUBLE_EQ(skipped->candidateCosts.allSimtOnly, 0.0);
+  EXPECT_DOUBLE_EQ(skipped->candidateCosts.mixedSimdSimt, 0.0);
+
+  auto diagnosticOptions = options(32);
+  diagnosticOptions.scoreOutsideCalibrationCoverage = true;
+  auto diagnostic =
+      estimateSimdSimtCandidates(outOfCoverageFeatures(), diagnosticOptions);
+  if (!diagnostic)
+    FAIL() << llvm::toString(diagnostic.takeError());
+
+  EXPECT_FALSE(diagnostic->calibrationCovered);
+  EXPECT_FALSE(diagnostic->selectionScoreValid);
+  EXPECT_TRUE(diagnostic->candidateCostsEvaluated);
+  EXPECT_GT(diagnostic->candidateCosts.allSimd, 0.0);
+  EXPECT_GT(diagnostic->candidateCosts.allSimtOnly, 0.0);
+  EXPECT_GT(diagnostic->candidateCosts.mixedSimdSimt, 0.0);
+  EXPECT_FALSE(diagnostic->gatePassed);
+}

--- a/third_party/ascend/unittest/costmodel_ut/test_compiler_costmodel_contract.py
+++ b/third_party/ascend/unittest/costmodel_ut/test_compiler_costmodel_contract.py
@@ -1,5 +1,6 @@
 import importlib.util
 import sys
+import tempfile
 import types
 import unittest
 from pathlib import Path
@@ -132,6 +133,37 @@ class CompilerCostmodelContractTest(unittest.TestCase):
         opt_costmodel = backend.parse_options({"enable_costmodel_backend": True})
         self.assertTrue(opt_costmodel.enable_costmodel_backend)
         self.assertFalse(opt_costmodel.use_bytecode)
+
+    def test_costmodel_profiles_use_canonical_source_in_checkout(self):
+        cmplr, _dump_mgr, _GPUTarget = self._load_compiler_module()
+
+        expected = Path(__file__).resolve().parents[2] / "costmodel" / "profiles"
+        self.assertEqual(cmplr._costmodel_profiles_dir(), expected)
+
+    def test_costmodel_profiles_find_native_package_assets(self):
+        cmplr, _dump_mgr, _GPUTarget = self._load_compiler_module()
+
+        with tempfile.TemporaryDirectory() as temporary:
+            package = Path(temporary) / "triton"
+            compiler = package / "backends" / "ascend" / "compiler.py"
+            profiles = package / "_C" / "ascend" / "costmodel_profiles"
+            legacy_profiles = compiler.parent / "costmodel_profiles"
+            compiler.parent.mkdir(parents=True)
+            profiles.mkdir(parents=True)
+            legacy_profiles.mkdir()
+            cmplr.__file__ = str(compiler)
+
+            self.assertEqual(cmplr._costmodel_profiles_dir(), profiles)
+
+    def test_lib_call_no_inline_is_only_enabled_for_ascend950(self):
+        cmplr, _dump_mgr, GPUTarget = self._load_compiler_module()
+
+        for arch in ("Ascend910B3", "Ascend910_95"):
+            metadata = {"target": GPUTarget(backend="npu", arch=arch)}
+            self.assertFalse(cmplr._needs_lib_call_no_inline(metadata))
+
+        metadata = {"target": GPUTarget(backend="npu", arch="Ascend950PR_9579")}
+        self.assertTrue(cmplr._needs_lib_call_no_inline(metadata))
 
 
 if __name__ == "__main__":

--- a/third_party/ascend/unittest/pytest_ut/test_cdiv.py
+++ b/third_party/ascend/unittest/pytest_ut/test_cdiv.py
@@ -84,7 +84,7 @@ def test_cdiv(param_list):
     dtype, shape, ncore, xblock, xblock_sub = param_list
     torch_dtype = eval('torch.' + dtype)
     x0 = test_common.generate_tensor(shape, dtype).npu()
-    x1 = test_common.generate_tensor(shape, dtype).npu()
+    x1 = test_common.generate_tensor(shape, dtype).clamp_min(1).npu()
     # torch结果
     torch_res = torch_cdiv(x0, x1, dtype)
     # triton结果

--- a/third_party/ascend/unittest/pytest_ut/test_scope.py
+++ b/third_party/ascend/unittest/pytest_ut/test_scope.py
@@ -96,19 +96,8 @@ def kernel_scope_disable_auto_sync(x_ptr, y_ptr, out_ptr, n, BLOCK: tl.constexpr
 
 
 @triton.jit
-def kernel_scope_vector_mode_simt(x_ptr, y_ptr, out_ptr, n, BLOCK: tl.constexpr):
-    """Test vector_mode SIMT annotation."""
-    i = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
-    with al.scope(vector_mode="simt"):
-        x = tl.load(x_ptr + i, mask=i < n)
-        y = tl.load(y_ptr + i, mask=i < n)
-        result = x + y
-        tl.store(out_ptr + i, result, mask=i < n)
-
-
-@triton.jit
 def kernel_whole_body_simt(out_ptr):
-    with al.scope(vec_mode="simt"):
+    with al.scope(vector_mode="simt"):
         tl.store(out_ptr, 1.0)
 
 
@@ -160,25 +149,15 @@ def test_scope_disable_auto_sync():
     assert "hivm.disable_auto_sync" in mlir
 
 
-def test_scope_vector_mode_simt():
-    """Test the legacy API alias generates canonical BiShengIR IR."""
-    mlir = compile_kernel(
-        kernel_scope_vector_mode_simt,
-        {"x_ptr": "*fp32", "y_ptr": "*fp32", "out_ptr": "*fp32", "n": "i32"},
-        {"BLOCK": 256},
-    )
-    assert "scope.scope" in mlir
-    assert 'vec_mode = "simt"' in mlir
-    assert "vector_mode =" not in mlir
-    assert "simt" in mlir
-
-
 def test_native_whole_body_simt_scope():
     module = compile_kernel_module(
         kernel_whole_body_simt,
         {"out_ptr": "*fp32"},
         {},
     )
+    module_text = str(module)
+    assert 'vector_mode = "simt"' in module_text
+    assert "vec_mode" not in module_text
     assert ascend_ir.is_whole_body_void_simt_scope(module)
     assert ascend_ir.inline_void_simt_scopes_for_pure_simt(module) == 1
     assert module.verify()

--- a/third_party/ascend/unittest/pytest_ut/test_scope.py
+++ b/third_party/ascend/unittest/pytest_ut/test_scope.py
@@ -3,7 +3,6 @@ import os
 
 os.environ["TORCH_DEVICE_BACKEND_AUTOLOAD"] = "0"
 
-import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.extension as al
@@ -23,14 +22,17 @@ class Options:
     sanitize_overflow = True
 
 
-def compile_kernel(kernel, signature, constants):
-    """Helper to compile a kernel to MLIR."""
+def compile_kernel_module(kernel, signature, constants):
     src = ASTSource(kernel, signature, constants)
     context = ir.context()
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
-    module = ast_to_ttir(kernel, src, context, Options(), {}, {})
-    return str(module)
+    return ast_to_ttir(kernel, src, context, Options(), {}, {})
+
+
+def compile_kernel(kernel, signature, constants):
+    """Helper to compile a kernel to MLIR."""
+    return str(compile_kernel_module(kernel, signature, constants))
 
 
 # ============== Kernel definitions ==============
@@ -93,6 +95,23 @@ def kernel_scope_disable_auto_sync(x_ptr, y_ptr, out_ptr, n, BLOCK: tl.constexpr
         tl.store(out_ptr + i, result, mask=i < n)
 
 
+@triton.jit
+def kernel_scope_vector_mode_simt(x_ptr, y_ptr, out_ptr, n, BLOCK: tl.constexpr):
+    """Test vector_mode SIMT annotation."""
+    i = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    with al.scope(vector_mode="simt"):
+        x = tl.load(x_ptr + i, mask=i < n)
+        y = tl.load(y_ptr + i, mask=i < n)
+        result = x + y
+        tl.store(out_ptr + i, result, mask=i < n)
+
+
+@triton.jit
+def kernel_whole_body_simt(out_ptr):
+    with al.scope(vec_mode="simt"):
+        tl.store(out_ptr, 1.0)
+
+
 # ============== Pytest tests ==============
 
 
@@ -141,20 +160,26 @@ def test_scope_disable_auto_sync():
     assert "hivm.disable_auto_sync" in mlir
 
 
-# ============== Main for manual testing ==============
+def test_scope_vector_mode_simt():
+    """Test the legacy API alias generates canonical BiShengIR IR."""
+    mlir = compile_kernel(
+        kernel_scope_vector_mode_simt,
+        {"x_ptr": "*fp32", "y_ptr": "*fp32", "out_ptr": "*fp32", "n": "i32"},
+        {"BLOCK": 256},
+    )
+    assert "scope.scope" in mlir
+    assert 'vec_mode = "simt"' in mlir
+    assert "vector_mode =" not in mlir
+    assert "simt" in mlir
 
-if __name__ == "__main__":
-    print("=" * 60)
-    print("Test 1: Nested Scopes")
-    print("=" * 60)
-    mlir = compile_kernel(kernel_nested_scope, {"x_ptr": "*fp32", "y_ptr": "*fp32", "out_ptr": "*fp32", "n": "i32"},
-                          {"BLOCK": 256})
-    print(f"✅ Generated MLIR ({len(mlir)} chars):\n")
-    print(mlir)
 
-    print("\n" + "=" * 60)
-    print("Test 2: Scope Escape")
-    print("=" * 60)
-    mlir = compile_kernel(kernel_scope_escape, {"x_ptr": "*fp32", "out_ptr": "*fp32", "n": "i32"}, {"BLOCK": 256})
-    print(f"✅ Generated MLIR ({len(mlir)} chars):\n")
-    print(mlir)
+def test_native_whole_body_simt_scope():
+    module = compile_kernel_module(
+        kernel_whole_body_simt,
+        {"out_ptr": "*fp32"},
+        {},
+    )
+    assert ascend_ir.is_whole_body_void_simt_scope(module)
+    assert ascend_ir.inline_void_simt_scopes_for_pure_simt(module) == 1
+    assert module.verify()
+    assert "scope.scope" not in str(module)


### PR DESCRIPTION

##  1.  initiative 

Ascend hardware starts to  support SIMT since 950 generation,  for a given triton kernel,  triton-ascend need to decide which compile/execution route is the best it should go, SIMD, SIMT or SIMD_SIMT mixed .   To make the best decision, we introduced SIMTCostModel to help TritonAscend firstly to decide which route should go, secondly to outline SIMT scope in TT IR if simd_simt mode is selected .


## 2. 方案和架构

<img width="1194" height="610" alt="image" src="https://github.com/user-attachments/assets/d2e0a696-db61-45a9-b332-44bfb817b724" />


| 一级组件 | 输入 | 输出 | 二级组件 | 明确边界 |
|---|---|---|---|---|
| Profile / Analysis | HardwareConfig、TTIR/NPUIR、microbenchmark | versioned Profile、operation/pipeline cost | Profile Loader、Op Analysis、Pipeline Analysis | 不选择 SIMD/SIMT route |
| Route Model | TTIR features、共享 Profile、target/options | candidate scores、`recommended`、post-check result、anchor plan | Feature、Coverage、Calibration Check、Scorer、Post Check | 不改写 TTIR |
| Route Transforms | route report、anchor plan | kernel 级 `effective`、局部 `scope.scope` | Selector、Materializer | 不重新提取 feature，不重新评分 |
| Backend Integration | `effective`、scope、compile options | lowered IR、binary、metadata | Python Bridge、Pass Pipeline、Lowering | 不维护第二套 route policy |
| DES Feedback | HIVM/NPUIR、DES report、NPU Event | 误差项、校准提案、验证后的新版 Profile | DES Analyzer、Event Validator、Profile Publisher | 不在线覆盖 `effective` |

```text
TTIR
  -> Route Model
  -> Route Transforms: Selector + Materializer
  -> effective + scope.scope<simt>
  -> Backend Integration
  -> NPU binary
```

## 3. 三个候选的 Cost 公式

公共符号：

```text
S*       = candidate setup
scale    = program_issue_scale，当前为 8
Ccomp    = arithmetic payload
Cdot     = dot payload
Cmem     = memory payload
Cshuffle = SIMT shuffle payload
Cpred    = SIMT predicate payload
Pstruct  = SIMD structural penalty ratio
```

### 3.1 all-SIMD

```text
A_SIMD = S_SIMD + scale * max(Ccomp_SIMD + Cdot_SIMD,
                              Cmem_SIMD)

Pstruct = irregular + mask + reduction + loop
          + control + tiny-dot + rank1

Cstruct_SIMD = A_SIMD * Pstruct

all-SIMD = A_SIMD + Cstruct_SIMD
         = A_SIMD * (1 + Pstruct)
```

`all-SIMD` 的 raw cost 只使用 SIMD 自己的 setup、compute、memory、dot
与 structural residual。`A_SIMT` 只用于计算 all-SIMT，不能作为 SIMD
的下限或参考成本。这样修改 SIMT throughput/setup 时，不会无故改变
all-SIMD 分数。当前 `Pstruct` 仍是低置信度的 SIMD residual ratio；后续应
逐项替换为 irregular、mask、reduction、control 等 SIMD 专属 microbenchmark
得到的绝对成本。

### 3.2 all-SIMT

```text
A_SIMT = S_SIMT + scale * (
           Cmem_SIMT
         + Ccomp_SIMT
         + Cshuffle
         + Cdot_SIMT
         + Cpred)

all-SIMT = A_SIMT
```

### 3.3 mixed

当前实现不是对两个整 kernel cost 做固定比例插值，而是按 materializable anchor 分区：

```text
C_regular = max(Ccomp_SIMD_regular + Cdot_SIMD_regular,
                Cmem_SIMD_regular)

C_anchor  = Cmem_SIMT_anchor
          + Ccomp_SIMT_anchor
          + Cshuffle_anchor
          + Cpred_anchor

mixed = S_mixed
        + scale * (C_regular * (1 + P_remaining) + C_anchor)
        + C_boundary
```

当前 Auto Materializer 不把 `tt.dot` 选作 SIMT anchor，dense/tiny dot 留在
scope 外，因此自动 mixed 路径中 `Cdot_SIMT_anchor = 0`。若用户显式 scope
包含 dot，模型仍支持互斥分区：`Cdot_total = Cdot_regular + Cdot_anchor`，同一个
dot 不会在 scope 内外重复计费。
在线链路是：



Profile / Analysis 为在线链路提供事实；DES Feedback 在离线闭环中修正下一版事实。


# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)


# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
