### PR TITLE
[ssbuffer](feat) scalar v2c dep opclassifier merge

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/SSBufferManager.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/SSBufferManager.h
@@ -107,9 +107,8 @@ getSsbufConstAndPointerCast(OpBuilder &builder, Location loc, uint64_t addr,
       builder.getAttr<hivm::AddressSpaceAttr>(hivm::AddressSpace::SSBUF);
   auto memrefType = MemRefType::get({}, elemType, nullptr, addressSpaceAttr);
 
-  return {addrConst,
-          builder.create<hivm::PointerCastOp>(loc, memrefType,
-                                              addrConst.getResult())};
+  return {addrConst, builder.create<hivm::PointerCastOp>(
+                         loc, memrefType, addrConst.getResult())};
 }
 
 inline hivm::PointerCastOp createPointerCastOp(OpBuilder &builder, Location loc,

--- a/third_party/ascend/include/DynamicCVPipeline/Common/SSBufferManager.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/SSBufferManager.h
@@ -98,19 +98,25 @@ inline MemRefType getSsbufMemrefType(Builder &builder) {
 }
 
 inline std::pair<arith::ConstantOp, hivm::PointerCastOp>
-getSsbufConstAndPointerCast(OpBuilder &builder, Location loc, uint64_t addr) {
+getSsbufConstAndPointerCast(OpBuilder &builder, Location loc, uint64_t addr,
+                            Type elemType) {
   auto i64Type = builder.getIntegerType(ADDR_INT_TYPE);
   auto addrAttr = builder.getIntegerAttr(i64Type, addr);
   auto addrConst = builder.create<arith::ConstantOp>(loc, i64Type, addrAttr);
+  auto addressSpaceAttr =
+      builder.getAttr<hivm::AddressSpaceAttr>(hivm::AddressSpace::SSBUF);
+  auto memrefType = MemRefType::get({}, elemType, nullptr, addressSpaceAttr);
 
   return {addrConst,
-          builder.create<hivm::PointerCastOp>(loc, getSsbufMemrefType(builder),
+          builder.create<hivm::PointerCastOp>(loc, memrefType,
                                               addrConst.getResult())};
 }
 
 inline hivm::PointerCastOp createPointerCastOp(OpBuilder &builder, Location loc,
                                                uint64_t addr) {
-  return getSsbufConstAndPointerCast(builder, loc, addr).second;
+  return getSsbufConstAndPointerCast(builder, loc, addr,
+                                     builder.getIntegerType(CONST_INT_TYPE))
+      .second;
 }
 
 } // namespace triton

--- a/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h
+++ b/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h
@@ -77,6 +77,10 @@ private:
   // Map from operation to its core type
   llvm::DenseMap<Operation *, OpCoreType> opCoreTypes;
 
+  // Cache: value -> whether its defining chain reaches a VECTOR-only op.
+  // Memoizes hasVectorOnlyProducer during CUBE upstream propagation.
+  llvm::DenseMap<mlir::Value, bool> vectorOnlyProducerCache;
+
   // All operations in the module
   llvm::SmallVector<Operation *> allOps;
 
@@ -112,6 +116,9 @@ private:
 
   // Propagate CUBE upstream for a specific operation
   void propagateCubeUpstreamForOp(Operation *startOp);
+
+  // Shared skip predicates for both CUBE upstream BFS paths.
+  bool shouldSkipCubeUpstream(Operation *op);
 
   // Helper: Handle fill op in scf.if - if all ops in scf.if are CUBE, mark
   // scf.if and propagate upstream

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/SSBufferManager.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/SSBufferManager.cpp
@@ -104,7 +104,7 @@ SSBufferManager::writeToSSBuffer(Value value, OpBuilder &builder,
   int64_t addrValue = addrResult.value();
   Location loc = builder.getUnknownLoc();
   auto [constOp, pointerCastOp] =
-      getSsbufConstAndPointerCast(builder, loc, addrValue);
+      getSsbufConstAndPointerCast(builder, loc, addrValue, value.getType());
   createdOps.push_back(constOp);
   createdOps.push_back(pointerCastOp);
 
@@ -128,9 +128,11 @@ SSBufferManager::readFromSSBuffer(int64_t addr, OpBuilder &builder,
     return std::nullopt;
   }
 
+  // Load the value back with the original scalar type, not a hardcoded i32.
+  Type dataType = findResult.value().second;
   Location loc = builder.getUnknownLoc();
   auto [constOp, pointerCastOp] =
-      getSsbufConstAndPointerCast(builder, loc, addr);
+      getSsbufConstAndPointerCast(builder, loc, addr, dataType);
   createdOps.push_back(constOp);
   createdOps.push_back(pointerCastOp);
 

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -108,7 +108,7 @@ bool isVectorOnlyOp(Operation *op) {
 
   return llvm::TypeSwitch<Operation *, bool>(op)
       .Case([](linalg::ReduceOp) { return true; })
-      .Case<arith::SelectOp, math::FloorOp>([](Operation *op) {
+      .Case<arith::SelectOp, math::FloorOp, math::CeilOp>([](Operation *op) {
         return isa<RankedTensorType>(op->getResult(0).getType());
       })
       .Default([](auto) { return false; });

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -128,6 +128,9 @@ void OpClassifierPass::initializePass(ModuleOp module) {
   opCoreTypes.clear();
   allOps.clear();
   cubeSeeds.clear();
+  vectorOnlyProducerCache.clear();
+  inBroadcastChain.clear();
+  CloneOpMap.clear();
 
   // Collect all operations
   module.walk([&](Operation *op) {
@@ -703,6 +706,74 @@ void OpClassifierPass::getUpstreamOpsWithMemoryDeps(
   }
 }
 
+// arith/math op with a tensor result is VECTOR-only (not CUBE).
+static bool isTensorArithOrMathOp(Operation *op) {
+  if (!isa<arith::ArithDialect, math::MathDialect>(op->getDialect())) {
+    return false;
+  }
+  for (Value result : op->getResults()) {
+    if (isa<RankedTensorType>(result.getType())) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// True if ANY op in the defining chain is VECTOR-only.  Conservative by
+// design: once a chain contains a VECTOR-only op the value (and any extract of
+// it) cannot be recomputed on CUBE, so mixed VECTOR-only + CUBE producers still
+// classify as VECTOR.  Memoized in `cache` so a tensor extracted from multiple
+// times is not re-walked.
+static bool hasVectorOnlyProducer(Value value,
+                                  llvm::DenseMap<Value, bool> &cache) {
+  auto it = cache.find(value);
+  if (it != cache.end()) {
+    return it->second;
+  }
+
+  llvm::SmallVector<Value> worklist{value};
+  llvm::DenseSet<Operation *> visited;
+  bool result = false;
+  while (!worklist.empty()) {
+    Value cur = worklist.pop_back_val();
+    Operation *defOp = cur.getDefiningOp();
+    if (!defOp || !visited.insert(defOp).second) {
+      continue;
+    }
+    if (CVPipeline::isVectorOnlyOp(defOp)) {
+      result = true;
+      break;
+    }
+    for (Value operand : defOp->getOperands()) {
+      worklist.push_back(operand);
+    }
+  }
+  cache[value] = result;
+  return result;
+}
+
+// Shared skip predicates for both CUBE upstream BFS paths.
+bool OpClassifierPass::shouldSkipCubeUpstream(Operation *op) {
+  if (isTensorArithOrMathOp(op)) {
+    LLVM_DEBUG(DBGS() << "skip " << op->getName().getStringRef()
+                      << ": arith/math tensor op\n");
+    return true;
+  }
+  if (auto extOp = dyn_cast<tensor::ExtractOp>(op)) {
+    if (hasVectorOnlyProducer(extOp.getTensor(), vectorOnlyProducerCache)) {
+      LLVM_DEBUG(DBGS() << "skip " << op->getName().getStringRef()
+                        << ": extract of vector-only producer\n");
+      return true;
+    }
+  }
+  if (isInsideNestedLinalgRegion(op)) {
+    LLVM_DEBUG(DBGS() << "skip " << op->getName().getStringRef()
+                      << ": inside linalg block\n");
+    return true;
+  }
+  return false;
+}
+
 // Propagate CUBE core type upstream
 int OpClassifierPass::propagateCubeUpstream() {
   LLVM_DEBUG(DBGS() << "--- Step 2: CUBE upstream BFS --->\n");
@@ -729,30 +800,9 @@ int OpClassifierPass::propagateCubeUpstream() {
       if (!def || cubeVisited.count(def) || isa<linalg::MatmulOp>(def))
         continue;
 
-      // Skip arith dialect ops with tensor results (they should be VECTOR, not
-      // CUBE)
-      if (isa<arith::ArithDialect>(def->getDialect())) {
-        bool hasTensorResult = false;
-        for (Value result : def->getResults()) {
-          if (isa<RankedTensorType>(result.getType())) {
-            hasTensorResult = true;
-            break;
-          }
-        }
-        if (hasTensorResult) {
-          LLVM_DEBUG(DBGS() << "skip " << def->getName().getStringRef()
-                            << ": arith tensor op\n");
-          continue;
-        }
-      }
-
-      // Skip operations inside linalg block (internal values)
-      // But don't skip the linalg op itself
-      if (isInsideNestedLinalgRegion(def)) {
-        LLVM_DEBUG(DBGS() << "skip " << def->getName().getStringRef()
-                          << ": inside linalg block\n");
+      // Shared skip rules (see shouldSkipCubeUpstream).
+      if (shouldSkipCubeUpstream(def))
         continue;
-      }
 
       cubeVisited.insert(def);
 
@@ -926,6 +976,9 @@ void OpClassifierPass::propagateCubeUpstreamForOp(Operation *startOp) {
       if (!upstreamOp || cubeVisited.count(upstreamOp))
         continue;
       if (isa<linalg::MatmulOp>(upstreamOp))
+        continue;
+      // Same skip rules as the main CUBE BFS.
+      if (shouldSkipCubeUpstream(upstreamOp))
         continue;
 
       cubeVisited.insert(upstreamOp);

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -163,7 +163,11 @@ bool DataDependencyAnalysisPass::isValid1DValueForDependency(
     mlir::Value value) {
   auto tensorTy = dyn_cast<TensorType>(value.getType());
   if (tensorTy && tensorTy.getRank() == SHAPE_1D_LENGTH) {
-    return true;
+    // Only 1-D tensors consumed by linalg.broadcast count; extract-consumed
+    // ones go through the scalar SSBuffer channel instead.
+    return llvm::all_of(value.getUsers(), [](mlir::Operation *u) {
+      return isa<linalg::BroadcastOp>(u);
+    });
   }
   return false;
 }
@@ -1050,7 +1054,8 @@ void DataDependencyAnalysisPass::runOnOperation() {
   processIterArgDependencies();
   createBlockInfoMap(info);
 
-  // Step 3: Analyze dependencies (populate v2c, c2v lists)
+  // Step 3: Analyze dependencies (v2c/c2v).  Scalar V->C deps come from
+  // analyzeExternalInputs (VECTOR scalars crossing into CUBE).
   analyzeExternalInputs(info);
 
   analyzeExternalOutputs(info);

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -789,10 +789,11 @@ InterCoreTransferAndSyncPass::getTransferPipeConfig(Operation *transferOp,
     config.srcCoreType = "VECTOR";
     config.dstCoreType = "CUBE";
   } else if (isa<memref::StoreOp>(transferOp)) {
-    config.forReadTPipe = pipeVAttr;
-    config.forReadPipe = pipeFixAttr;
-    config.forWriteTPipe = pipeFixAttr;
-    config.forWritePipe = pipeVAttr;
+    // Scalar sync uses PIPE_S to stay isolated from tensor flag space.
+    config.forReadTPipe = pipeSAttr;
+    config.forReadPipe = pipeSAttr;
+    config.forWriteTPipe = pipeSAttr;
+    config.forWritePipe = pipeSAttr;
     config.srcCoreAttr = vecCoreAttr;
     config.dstCoreAttr = cubeCoreAttr;
     config.srcCoreType = "VECTOR";

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
@@ -28,13 +28,14 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
 
+#include "ascend/include/DynamicCVPipeline/Common/SSBufferManager.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/SeparateCVScope.h"
+#include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
 #include "bishengir/Dialect/Scope/IR/Scope.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"
@@ -995,7 +996,7 @@ static void replaceRedundantVectorStoreLoad(scope::ScopeOp scopeOp) {
 
   // Pass 1: collect the value each ssbuffer.transfer_id stores.
   llvm::DenseMap<int64_t, mlir::Value> storedValues;
-  scopeOp.walk([&](LLVM::StoreOp storeOp) {
+  scopeOp.walk([&](memref::StoreOp storeOp) {
     auto transferIdAttr =
         storeOp->getAttrOfType<mlir::IntegerAttr>(CVPipeline::kTransferId);
     if (!transferIdAttr) {
@@ -1010,8 +1011,8 @@ static void replaceRedundantVectorStoreLoad(scope::ScopeOp scopeOp) {
   }
 
   // Pass 2: replace loads of the same transfer_id with the stored value.
-  llvm::SmallVector<LLVM::LoadOp> deadLoads;
-  scopeOp.walk([&](LLVM::LoadOp loadOp) {
+  llvm::SmallVector<memref::LoadOp> deadLoads;
+  scopeOp.walk([&](memref::LoadOp loadOp) {
     auto transferIdAttr =
         loadOp->getAttrOfType<mlir::IntegerAttr>(CVPipeline::kTransferId);
     if (!transferIdAttr) {
@@ -1026,10 +1027,18 @@ static void replaceRedundantVectorStoreLoad(scope::ScopeOp scopeOp) {
     if (storeVal == loadOp.getResult()) {
       return;
     }
+    // Drop the volatile annotation the scalar read attached to this load;
+    // it only makes sense while the load survives in the CUBE scope.
+    for (Operation *user :
+         llvm::make_early_inc_range(loadOp.getResult().getUsers())) {
+      if (isa<annotation::MarkOp>(user) && user->hasAttr(kMemrefExtVolatile)) {
+        user->erase();
+      }
+    }
     loadOp.replaceAllUsesWith(storeVal);
     deadLoads.push_back(loadOp);
   });
-  for (LLVM::LoadOp loadOp : deadLoads) {
+  for (memref::LoadOp loadOp : deadLoads) {
     loadOp->erase();
   }
 }
@@ -1037,7 +1046,8 @@ static void replaceRedundantVectorStoreLoad(scope::ScopeOp scopeOp) {
 // Declare dependent dialects
 void mlir::triton::SeparateCVScopePass::getDependentDialects(
     DialectRegistry &registry) const {
-  registry.insert<arith::ArithDialect, hivm::HIVMDialect, memref::MemRefDialect,
+  registry.insert<annotation::AnnotationDialect, arith::ArithDialect,
+                  hivm::HIVMDialect, memref::MemRefDialect,
                   scope::ScopeDialect>();
 }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
@@ -22,15 +22,19 @@
 
 #include <optional>
 
+#include <map>
+
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
 
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/SplitDataflow/SeparateCVScope.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
 #include "bishengir/Dialect/Scope/IR/Scope.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"
@@ -38,12 +42,7 @@
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Pass/Pass.h"
-
-#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
-#include "ascend/include/DynamicCVPipeline/SplitDataflow/SeparateCVScope.h"
-
-#include "bishengir/Dialect/HIVM/IR/HIVM.h"
-#include "bishengir/Dialect/Scope/IR/Scope.h"
+#include "mlir/Transforms/RegionUtils.h"
 
 using namespace mlir;
 
@@ -1013,6 +1012,54 @@ void mlir::triton::SeparateCVScopePass::runOnOperation() {
   module.walk([](scope::ScopeOp scopeOp) {
     scopeOp->setAttr(CVPipeline::kHIVMMatmulLimitedInCubeAttr,
                      UnitAttr::get(scopeOp->getContext()));
+  });
+
+  // VECTOR scopes: replace the redundant store→load with the stored value.
+  module.walk([](scope::ScopeOp scopeOp) {
+    auto coreTypeAttr =
+        scopeOp->getAttrOfType<hivm::TCoreTypeAttr>(hivm::TCoreTypeAttr::name);
+    if (!coreTypeAttr ||
+        coreTypeAttr.getTcoretype() != hivm::TCoreType::VECTOR) {
+      return;
+    }
+
+    llvm::DenseMap<int64_t, mlir::Value> storedValues;
+    scopeOp.walk([&](LLVM::StoreOp storeOp) {
+      auto transferIdAttr =
+          storeOp->getAttrOfType<mlir::IntegerAttr>(CVPipeline::kTransferId);
+      if (!transferIdAttr) {
+        return;
+      }
+      int64_t tid = transferIdAttr.getInt();
+      storedValues[tid] = storeOp.getValue();
+    });
+
+    if (storedValues.empty()) {
+      return;
+    }
+
+    llvm::SmallVector<LLVM::LoadOp> deadLoads;
+    scopeOp.walk([&](LLVM::LoadOp loadOp) {
+      auto transferIdAttr =
+          loadOp->getAttrOfType<mlir::IntegerAttr>(CVPipeline::kTransferId);
+      if (!transferIdAttr) {
+        return;
+      }
+      int64_t tid = transferIdAttr.getInt();
+      auto it = storedValues.find(tid);
+      if (it == storedValues.end()) {
+        return;
+      }
+      mlir::Value storeVal = it->second;
+      if (storeVal == loadOp.getResult()) {
+        return;
+      }
+      loadOp.replaceAllUsesWith(storeVal);
+      deadLoads.push_back(loadOp);
+    });
+    for (LLVM::LoadOp loadOp : deadLoads) {
+      loadOp->erase();
+    }
   });
 
   debugDumpOperation("after SeparateCVScopePass", module.getOperation());

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
@@ -979,6 +979,61 @@ static LogicalResult separateScopes(func::FuncOp funcOp) {
   return success();
 }
 
+// Mechanism A: in VECTOR scopes, replace each redundant store→load pair that
+// shares an ssbuffer.transfer_id with the stored value, then erase the load.
+//
+// The scope-clone step duplicates the CUBE-side scalar load into the VECTOR
+// scope too; there it reads back a value this scope itself just stored, so the
+// load is pure redundancy (not dead code — it has users), and DCE will not
+// remove it.
+static void replaceRedundantVectorStoreLoad(scope::ScopeOp scopeOp) {
+  auto coreTypeAttr =
+      scopeOp->getAttrOfType<hivm::TCoreTypeAttr>(hivm::TCoreTypeAttr::name);
+  if (!coreTypeAttr || coreTypeAttr.getTcoretype() != hivm::TCoreType::VECTOR) {
+    return;
+  }
+
+  // Pass 1: collect the value each ssbuffer.transfer_id stores.
+  llvm::DenseMap<int64_t, mlir::Value> storedValues;
+  scopeOp.walk([&](LLVM::StoreOp storeOp) {
+    auto transferIdAttr =
+        storeOp->getAttrOfType<mlir::IntegerAttr>(CVPipeline::kTransferId);
+    if (!transferIdAttr) {
+      return;
+    }
+    int64_t tid = transferIdAttr.getInt();
+    storedValues[tid] = storeOp.getValue();
+  });
+
+  if (storedValues.empty()) {
+    return;
+  }
+
+  // Pass 2: replace loads of the same transfer_id with the stored value.
+  llvm::SmallVector<LLVM::LoadOp> deadLoads;
+  scopeOp.walk([&](LLVM::LoadOp loadOp) {
+    auto transferIdAttr =
+        loadOp->getAttrOfType<mlir::IntegerAttr>(CVPipeline::kTransferId);
+    if (!transferIdAttr) {
+      return;
+    }
+    int64_t tid = transferIdAttr.getInt();
+    auto it = storedValues.find(tid);
+    if (it == storedValues.end()) {
+      return;
+    }
+    mlir::Value storeVal = it->second;
+    if (storeVal == loadOp.getResult()) {
+      return;
+    }
+    loadOp.replaceAllUsesWith(storeVal);
+    deadLoads.push_back(loadOp);
+  });
+  for (LLVM::LoadOp loadOp : deadLoads) {
+    loadOp->erase();
+  }
+}
+
 // Declare dependent dialects
 void mlir::triton::SeparateCVScopePass::getDependentDialects(
     DialectRegistry &registry) const {
@@ -1014,53 +1069,9 @@ void mlir::triton::SeparateCVScopePass::runOnOperation() {
                      UnitAttr::get(scopeOp->getContext()));
   });
 
-  // VECTOR scopes: replace the redundant store→load with the stored value.
-  module.walk([](scope::ScopeOp scopeOp) {
-    auto coreTypeAttr =
-        scopeOp->getAttrOfType<hivm::TCoreTypeAttr>(hivm::TCoreTypeAttr::name);
-    if (!coreTypeAttr ||
-        coreTypeAttr.getTcoretype() != hivm::TCoreType::VECTOR) {
-      return;
-    }
-
-    llvm::DenseMap<int64_t, mlir::Value> storedValues;
-    scopeOp.walk([&](LLVM::StoreOp storeOp) {
-      auto transferIdAttr =
-          storeOp->getAttrOfType<mlir::IntegerAttr>(CVPipeline::kTransferId);
-      if (!transferIdAttr) {
-        return;
-      }
-      int64_t tid = transferIdAttr.getInt();
-      storedValues[tid] = storeOp.getValue();
-    });
-
-    if (storedValues.empty()) {
-      return;
-    }
-
-    llvm::SmallVector<LLVM::LoadOp> deadLoads;
-    scopeOp.walk([&](LLVM::LoadOp loadOp) {
-      auto transferIdAttr =
-          loadOp->getAttrOfType<mlir::IntegerAttr>(CVPipeline::kTransferId);
-      if (!transferIdAttr) {
-        return;
-      }
-      int64_t tid = transferIdAttr.getInt();
-      auto it = storedValues.find(tid);
-      if (it == storedValues.end()) {
-        return;
-      }
-      mlir::Value storeVal = it->second;
-      if (storeVal == loadOp.getResult()) {
-        return;
-      }
-      loadOp.replaceAllUsesWith(storeVal);
-      deadLoads.push_back(loadOp);
-    });
-    for (LLVM::LoadOp loadOp : deadLoads) {
-      loadOp->erase();
-    }
-  });
+  // Mechanism A: clean up redundant VECTOR-side store→load pairs.
+  module.walk(
+      [](scope::ScopeOp scopeOp) { replaceRedundantVectorStoreLoad(scopeOp); });
 
   debugDumpOperation("after SeparateCVScopePass", module.getOperation());
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/SeparateCVScope.cpp
@@ -1046,9 +1046,9 @@ static void replaceRedundantVectorStoreLoad(scope::ScopeOp scopeOp) {
 // Declare dependent dialects
 void mlir::triton::SeparateCVScopePass::getDependentDialects(
     DialectRegistry &registry) const {
-  registry.insert<annotation::AnnotationDialect, arith::ArithDialect,
-                  hivm::HIVMDialect, memref::MemRefDialect,
-                  scope::ScopeDialect>();
+  registry
+      .insert<annotation::AnnotationDialect, arith::ArithDialect,
+              hivm::HIVMDialect, memref::MemRefDialect, scope::ScopeDialect>();
 }
 
 void mlir::triton::SeparateCVScopePass::runOnOperation() {

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_scalar_v2c_external_input.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_scalar_v2c_external_input.mlir
@@ -3,39 +3,46 @@
 // Scalar V->C dependency via external-input.
 //
 // A VECTOR block produces a 1D tensor (math.floor is a VECTOR-only op), then
-// `tensor.extract`s a scalar from it. A CUBE block consumes that scalar
-// (arith.addf). analyzeExternalInputs sees the scalar as a CUBE-block external
-// input defined by a VECTOR op and records a V->C dependency.
+// `tensor.extract`s an i32 scalar from it (memref-era scalar channel only
+// carries i32 through the memref<i32, ssbuf> SSBuffer slot). A CUBE block
+// consumes that scalar (arith.addi). analyzeExternalInputs sees the scalar as
+// a CUBE-block external input defined by a VECTOR op and records a V->C
+// dependency.
 //
 // inter-core-transfer-and-sync then routes the scalar through the SSBuffer
 // scalar channel:
-//   VECTOR side: llvm.store %extracted + sync_block_set[<VECTOR>, <PIPE_S>, <PIPE_S>]
-//   CUBE side:   sync_block_wait[<CUBE>, <PIPE_S>, <PIPE_S>] + llvm.load
+//   VECTOR side: hivm.hir.pointer_cast + memref.store %extracted
+//                + sync_block_set[<VECTOR>, <PIPE_S>, <PIPE_S>]
+//   CUBE side:   sync_block_wait[<CUBE>, <PIPE_S>, <PIPE_S>] + memref.load
+//                + annotation.mark {memref_ext.volatile}
 // The scalar PIPE_S sync stays isolated from the tensor flag space.
 // CHECK-LABEL: func.func @scalar_v2c
 // CHECK: %{{.*}} = tensor.extract
-// CHECK: llvm.store volatile {{.*}} {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.crossCoreDeps = [0 : i32, 1 : i32], ssbuffer.transfer_id = 0 : i32} : f32, !llvm.ptr<11>
+// CHECK: hivm.hir.pointer_cast({{.*}})
+// CHECK: memref.store %{{.*}}, %{{.*}}[] {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.crossCoreDeps = [0 : i32, 1 : i32], ssbuffer.transfer_id = 0 : i32} : memref<i32, #hivm.address_space<ssbuf>>
 // CHECK: hivm.hir.sync_block_set {{.*}}[<VECTOR>, <PIPE_S>, <PIPE_S>] flag = 1
 // CHECK: hivm.hir.sync_block_wait {{.*}}[<CUBE>, <PIPE_S>, <PIPE_S>] flag = 1
-// CHECK: llvm.load volatile {{.*}} {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE", ssbuffer.crossCoreDeps = [0 : i32, 0 : i32], ssbuffer.transfer_id = 0 : i32} : !llvm.ptr<11> -> f32
+// CHECK: memref.load %{{.*}}[] {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE", ssbuffer.crossCoreDeps = [0 : i32, 0 : i32], ssbuffer.transfer_id = 0 : i32} : memref<i32, #hivm.address_space<ssbuf>>
+// CHECK: annotation.mark {{.*}} {memref_ext.volatile, {{.*}}} : i32
 // The CUBE op must consume the loaded scalar, not the raw extract.
-// CHECK: arith.addf
+// CHECK: arith.addi
 module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
-  func.func @scalar_v2c(%arg0: memref<?xf32> {tt.tensor_kind = 0 : i32}) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+  func.func @scalar_v2c(%arg0: memref<?xi32> {tt.tensor_kind = 0 : i32}) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
     %cst = arith.constant {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} 1.000000e+00 : f32
     %c0 = arith.constant {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
     %t = tensor.empty() {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64xf32>
     %filled = linalg.fill {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : f32) outs(%t : tensor<64xf32>) -> tensor<64xf32>
     %floor = math.floor %filled {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64xf32>
-    %scalar = tensor.extract %floor[%c0] {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64xf32>
-    %cst_c = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} 2.000000e+00 : f32
-    %used = arith.addf %scalar, %cst_c {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : f32
-    %dst = memref.reinterpret_cast %arg0 to offset: [0], sizes: [1], strides: [1] : memref<?xf32> to memref<1xf32, strided<[1]>>
-    %subview = memref.subview %dst[0] [1] [1] {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<1xf32, strided<[1]>> to memref<1xf32, strided<[1]>>
-    %tt = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : tensor<1xf32>
-    %filled_c = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%used : f32) outs(%tt : tensor<1xf32>) -> tensor<1xf32>
-    %extracted_slice = tensor.extract_slice %filled_c[0] [1] [1] {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : tensor<1xf32> to tensor<1xf32>
-    bufferization.materialize_in_destination %extracted_slice in writable %subview {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : (tensor<1xf32>, memref<1xf32, strided<[1]>>) -> ()
+    %cast = arith.fptosi %floor {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64xf32> to tensor<64xi32>
+    %scalar = tensor.extract %cast[%c0] {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64xi32>
+    %cst_c = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} 2 : i32
+    %used = arith.addi %scalar, %cst_c {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : i32
+    %dst = memref.reinterpret_cast %arg0 to offset: [0], sizes: [1], strides: [1] : memref<?xi32> to memref<1xi32, strided<[1]>>
+    %subview = memref.subview %dst[0] [1] [1] {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<1xi32, strided<[1]>> to memref<1xi32, strided<[1]>>
+    %tt = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : tensor<1xi32>
+    %filled_c = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%used : i32) outs(%tt : tensor<1xi32>) -> tensor<1xi32>
+    %extracted_slice = tensor.extract_slice %filled_c[0] [1] [1] {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : tensor<1xi32> to tensor<1xi32>
+    bufferization.materialize_in_destination %extracted_slice in writable %subview {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : (tensor<1xi32>, memref<1xi32, strided<[1]>>) -> ()
     return
   }
 }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_scalar_v2c_external_input.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_scalar_v2c_external_input.mlir
@@ -1,0 +1,41 @@
+// RUN: triton-opt --add-block-id-for-control-ops --data-dependency-analysis --inter-core-transfer-and-sync %s | FileCheck %s
+
+// Scalar V->C dependency via external-input.
+//
+// A VECTOR block produces a 1D tensor (math.floor is a VECTOR-only op), then
+// `tensor.extract`s a scalar from it. A CUBE block consumes that scalar
+// (arith.addf). analyzeExternalInputs sees the scalar as a CUBE-block external
+// input defined by a VECTOR op and records a V->C dependency.
+//
+// inter-core-transfer-and-sync then routes the scalar through the SSBuffer
+// scalar channel:
+//   VECTOR side: llvm.store %extracted + sync_block_set[<VECTOR>, <PIPE_S>, <PIPE_S>]
+//   CUBE side:   sync_block_wait[<CUBE>, <PIPE_S>, <PIPE_S>] + llvm.load
+// The scalar PIPE_S sync stays isolated from the tensor flag space.
+// CHECK-LABEL: func.func @scalar_v2c
+// CHECK: %{{.*}} = tensor.extract
+// CHECK: llvm.store volatile {{.*}} {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.crossCoreDeps = [0 : i32, 1 : i32], ssbuffer.transfer_id = 0 : i32} : f32, !llvm.ptr<11>
+// CHECK: hivm.hir.sync_block_set {{.*}}[<VECTOR>, <PIPE_S>, <PIPE_S>] flag = 1
+// CHECK: hivm.hir.sync_block_wait {{.*}}[<CUBE>, <PIPE_S>, <PIPE_S>] flag = 1
+// CHECK: llvm.load volatile {{.*}} {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE", ssbuffer.crossCoreDeps = [0 : i32, 0 : i32], ssbuffer.transfer_id = 0 : i32} : !llvm.ptr<11> -> f32
+// The CUBE op must consume the loaded scalar, not the raw extract.
+// CHECK: arith.addf
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @scalar_v2c(%arg0: memref<?xf32> {tt.tensor_kind = 0 : i32}) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %cst = arith.constant {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} 1.000000e+00 : f32
+    %c0 = arith.constant {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} 0 : index
+    %t = tensor.empty() {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64xf32>
+    %filled = linalg.fill {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : f32) outs(%t : tensor<64xf32>) -> tensor<64xf32>
+    %floor = math.floor %filled {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64xf32>
+    %scalar = tensor.extract %floor[%c0] {ssbuffer.block_id = 0 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64xf32>
+    %cst_c = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} 2.000000e+00 : f32
+    %used = arith.addf %scalar, %cst_c {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : f32
+    %dst = memref.reinterpret_cast %arg0 to offset: [0], sizes: [1], strides: [1] : memref<?xf32> to memref<1xf32, strided<[1]>>
+    %subview = memref.subview %dst[0] [1] [1] {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : memref<1xf32, strided<[1]>> to memref<1xf32, strided<[1]>>
+    %tt = tensor.empty() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : tensor<1xf32>
+    %filled_c = linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} ins(%used : f32) outs(%tt : tensor<1xf32>) -> tensor<1xf32>
+    %extracted_slice = tensor.extract_slice %filled_c[0] [1] [1] {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : tensor<1xf32> to tensor<1xf32>
+    bufferization.materialize_in_destination %extracted_slice in writable %subview {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "CUBE"} : (tensor<1xf32>, memref<1xf32, strided<[1]>>) -> ()
+    return
+  }
+}


### PR DESCRIPTION
Support scalar V→C dependencies in the Dynamic CV pipeline so that scalar values (e.g. loop bounds and extracted elements) produced by VECTOR blocks and consumed by CUBE blocks are transferred through the SSBuffer scalar channel.

  Previously these scalars were classified as CUBE (or missed entirely), which either left VECTOR math chains behind in CUBE scopes or required the whole kernel to fall back. The new classification makes every scalar that CUBE cannot produce itself an external input of the CUBE block, and the existing `analyzeExternalInputs` path turns it into a proper V→C dependency.

  ## Changes

  - **OpClassifier**: `tensor.extract` of a tensor with a VECTOR-only producer (`math.floor`/`math.ceil`, `linalg.reduce`, `arith.select` on tensors) is now classified as VECTOR through the shared `shouldSkipCubeUpstream` predicate used by both CUBE-upstream BFS paths, so the extract stays in the VECTOR block and is directly referenced by the CUBE block.
  - **SplitDataflow / analyzeExternalInputs**: the cross-block scalar is detected as a CUBE-block external input defined by a VECTOR op and recorded as a V→C dependency — no custom scalar detection pass needed.
  - **InterCoreTransferAndSync**: scalar transfers now use a PIPE_S set/wait pair, isolated from the tensor flag space to avoid deadlocks.
  - **SeparateCVScope**: mechanism A replaces the redundant store→load that the scope clone leaves in VECTOR scopes with the stored value directly (and drops the now-redundant `memref_ext.volatile` annotation).
  - **SSBufferManager**: the memref scalar channel now carries the scalar's own element type through the SSBuffer slot (`memref<T, ssbuf>`), instead of a hardcoded `memref<i32, ssbuf>`. This restores support for f32/f16/i64 scalars that the LLVM→memref migration had dropped (f32 stores used to fail `memref.store` verification).
  - **UT**: `test_scalar_v2c_external_input.mlir` covering the scalar store/load, PIPE_S sync and the typed SSBuffer slot.
