### PR TITLE
[docs](fix) Fix the document search function

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,3 +9,4 @@ pytest
 sphinx-gallery
 sphinx-multiversion
 llnl-hatchet
+jieba

--- a/docs/zh/_templates/search.html
+++ b/docs/zh/_templates/search.html
@@ -1,0 +1,35 @@
+{#-
+  Custom search page for the Chinese docs.
+
+  Sphinx 9.1.0 generates `window.Stemmer = ChineseStemmer;` in
+  language_data.js for zh builds, but the inlined stemmer rawcode is
+  english-stemmer.js (which defines EnglishStemmer), so `ChineseStemmer`
+  is never defined and the search page crashes with
+  "ReferenceError: ChineseStemmer is not defined", leaving it stuck on
+  "正在搜索中." forever.
+
+  The zh search language stems Latin words with the English snowball
+  stemmer at build time (e.g. "install" is indexed as "instal"), so the
+  query side must apply the same stemming or Latin queries stop
+  matching. Delegate to EnglishStemmer, which language_data.js defines
+  on the line just before the crashing assignment; fall back to a
+  passthrough if it is missing (Chinese words need no stemming either
+  way).
+
+  Safe to keep after the upstream fix lands (fixed language_data.js
+  assigns window.Stemmer = EnglishStemmer directly and no longer
+  references ChineseStemmer); see sphinx-doc/sphinx get_js_stemmer_code.
+-#}
+{%- extends "!furo/search.html" -%}
+
+{% block extrahead %}
+{{ super() }}
+<script>
+  var ChineseStemmer = function () {
+    if (typeof EnglishStemmer === "function") {
+      return new EnglishStemmer();
+    }
+    this.stemWord = function (word) { return word; };
+  };
+</script>
+{% endblock %}

--- a/docs/zh/requirement.txt
+++ b/docs/zh/requirement.txt
@@ -2,3 +2,4 @@ sphinx
 sphinx_rtd_theme
 myst_parser
 furo
+jieba

--- a/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/MarkGMLoadPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/MarkGMLoadPass.cpp
@@ -306,7 +306,8 @@ void MarkGMLoadPass::runOnOperation() {
   // Skip marking for the sdpa infer kernel.
   bool isSdpaInferKernel = false;
   module.walk([&](func::FuncOp funcOp) -> WalkResult {
-    if (funcOp.getSymName() == "_sdpa_infer_kernel" || funcOp.getSymName() == "kernel_sdpa_fwd") {
+    if (funcOp.getSymName() == "_sdpa_infer_kernel" ||
+        funcOp.getSymName() == "kernel_sdpa_fwd") {
       isSdpaInferKernel = true;
       return WalkResult::interrupt();
     }


### PR DESCRIPTION
## Problem

The search feature in the Chinese docs (https://triton-ascend.readthedocs.io/zh-cn/latest/)
is unusable: the search page stays at "正在搜索中." (Searching...) forever and returns
nothing for any query — including Latin terms such as `install`, which work fine in the
English docs. Two independent root causes:

1. **Sphinx 9.1.0 bug — the search page JS crashes.**
   For `language = 'zh_CN'` builds, Sphinx generates the line
   `window.Stemmer = ChineseStemmer;` in `language_data.js`, but the inlined stemmer
   rawcode is `english-stemmer.js` (which defines `EnglishStemmer`). `ChineseStemmer`
   is never defined, so the page throws `ReferenceError: ChineseStemmer is not defined`
   during search initialization and hangs. Fixed upstream in
   sphinx-doc/sphinx#14416 (derive the JS class name from the stemmer filename), but that
   fix is not released yet (latest PyPI version is 9.1.0).

2. **Missing `jieba` — the Chinese search index contains zero Chinese terms.**
   Sphinx's Chinese search language segments text with `jieba` at build time; without it
   installed, the fallback produces no terms at all. The deployed `searchindex.js`
   contained 3483 terms, none of which were Chinese.

## Changes

- Add `docs/zh/_templates/search.html` which pre-defines a `ChineseStemmer` constructor
  in `extrahead` (before `language_data.js` runs) that **delegates to `EnglishStemmer`**,
  which `language_data.js` defines on the line just before the crashing assignment.
  Delegation (rather than a no-op) is required: the zh search language stems Latin words
  with the English snowball stemmer at build time (`install` is indexed as `instal`),
  so the query side must stem identically or Latin queries return nothing. Chinese words
  pass through unchanged either way. The shim becomes unnecessary once the upstream fix
  ships and is harmless to keep (the template comment documents this).

- Add `jieba` to `docs/zh/requirement.txt` (installed by the RTD zh project) and
  `docs/requirements.txt` (local builds), restoring real Chinese word segmentation in the
  search index.

## Verification

Built the zh docs locally with Sphinx 9.1.0 + furo 2025.12.19 + jieba and tested the
search page in a real browser (headless Chrome):

| Query | Before | After |
|---|---|---|
| `安装依赖` | stuck on "Searching..." | 1 result |
| `安装` | stuck | 13 results |
| `install` | stuck | 4 results |
| `pip install` | stuck | 3 results |
| non-matching term | stuck | clean "no results", no JS errors |

- The rebuilt index contains 2766 Chinese terms (0 before).
- The English docs are unaffected (no template/requirement change on the `en` side).

## Notes

- Known limitation (Sphinx-native search): query splitting is whitespace/letter-run based,
  so unspaced multi-word Chinese queries mainly match via title substring; the RTD
  server-side search modal has no such limitation.
- Optional follow-up: report the `ChineseStemmer` issue upstream for visibility, pointing
  to sphinx-doc/sphinx#14416.
