### PR TITLE
[ssbuffer](fix) delete splitIf in unifyAllocBlock

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UnifyAllocBlockPass.cpp
@@ -172,21 +172,18 @@ static FillInfo findFillOpInSCFIf(Value allocResult) {
 }
 
 /**
- * @brief Check if scf.if needs to be split
+ * @brief Check if the scf.if containing linalg.fill has other operations
  *
- * Determines whether the scf.if operation containing linalg.fill needs to be
- * split. Split is needed when the if branch contains multiple operations (not
- * just linalg.fill).
+ * Determines whether the then region of the scf.if that contains linalg.fill
+ * also contains other operations besides linalg.fill. If it does, unification
+ * must be aborted, because the linalg.fill is mixed with unrelated operations
+ * and unifying the whole scf.if block_id would be incorrect.
  *
  * @param info FillInfo structure containing fillOp and parentIf
- * @return bool Returns true if split is needed, false otherwise
- *
- * @note Split logic:
- *       - If branch only has linalg.fill (+ scf.yield terminator), no split
- * needed
- *       - If branch has other operations besides linalg.fill, split needed
+ * @return bool Returns true if there are other ops besides linalg.fill in the
+ *         then region, false otherwise
  */
-static bool needsSplitIf(const FillInfo &info) {
+static bool hasOtherOpsInIf(const FillInfo &info) {
   if (!info.fillOp || !info.parentIf) {
     return false;
   }
@@ -198,72 +195,6 @@ static bool needsSplitIf(const FillInfo &info) {
     opCount++;
   }
   return opCount > 1;
-}
-
-/**
- * @brief Split scf.if into two separate scf.if blocks
- *
- * When an scf.if branch contains multiple operations (linalg.fill + other ops),
- * this function splits it into two scf.if blocks:
- * - One containing only linalg.fill (will be unified)
- * - One containing other operations (keeps original block_id)
- *
- * @param info FillInfo structure containing fillOp and parentIf
- * @return FillInfo Updated FillInfo pointing to the new fill-only scf.if
- *
- * @note Split pattern:
- *       Before:
- *         scf.if %cond {
- *           linalg.fill {block_id=8} ins(%v) outs(%alloc)  // keep
- *           arith.addf {block_id=12} %x, %y               // move to new scf.if
- *         } {hivm.unlikely_condition}
- *
- *       After:
- *         scf.if %cond {
- *           linalg.fill {block_id=8} ins(%v) outs(%alloc)  // keep
- *         } {hivm.unlikely_condition}
- *
- *         scf.if %cond {
- *           arith.addf {block_id=12} %x, %y               // new scf.if
- *         } {hivm.unlikely_condition}
- */
-static FillInfo splitSCFIfIfNeeded(FillInfo &info) {
-  Block *originalBlock = info.fillOp->getBlock();
-  Operation *fillOp = info.fillOp.getOperation();
-  scf::IfOp originalIf = info.parentIf;
-  Value cond = originalIf.getCondition();
-  Location loc = originalIf.getLoc();
-
-  SmallVector<Operation *> otherOps;
-  for (auto &op : originalBlock->without_terminator()) {
-    if (&op != fillOp) {
-      otherOps.push_back(&op);
-    }
-  }
-
-  if (otherOps.empty()) {
-    return info;
-  }
-
-  DictionaryAttr originalAttrs = originalIf->getAttrDictionary();
-
-  OpBuilder builder(originalIf);
-
-  fillOp->moveBefore(originalIf.getOperation()->getNextNode());
-  builder.setInsertionPointAfter(fillOp);
-
-  auto newFillIf =
-      builder.create<scf::IfOp>(loc, cond, /*withElseRegion=*/false);
-  if (originalAttrs) {
-    for (auto attr : originalAttrs) {
-      newFillIf->setAttr(attr.getName(), attr.getValue());
-    }
-  }
-
-  fillOp->moveBefore(newFillIf.getThenRegion().front().getTerminator());
-
-  info.parentIf = newFillIf;
-  return info;
 }
 
 /**
@@ -302,10 +233,10 @@ tryUnifyForAlloc(memref::AllocOp allocOp,
   }
   LOG_DEBUG("[getSameBlockId] GetSameBlockId: " << targetBlockId);
 
-  // Step4: Split if scf.if contains multiple operations
-  if (needsSplitIf(fillInfo)) {
-    LOG_DEBUG("[needsSplitIf] SCF.IF need split ");
-    fillInfo = splitSCFIfIfNeeded(fillInfo);
+  // Step4: If the scf.if has other operations besides linalg.fill, abort
+  if (hasOtherOpsInIf(fillInfo)) {
+    LOG_DEBUG("[warning] SCF.IF has other ops, failed to unify");
+    return success();
   }
 
   // Step5: Cycle detection and block_id assignment


### PR DESCRIPTION
### Title
Fix illegal IR generation in UnifyAllocBlockPass when scf.if contains other operations

### Background
UnifyAllocBlockPass unifies the block_id of memref.alloc , its linalg.fill , the enclosing scf.if , and the consumer operations. In the original implementation, when the then region of the scf.if contained operations other than the linalg.fill , splitSCFIfIfNeeded moved the linalg.fill out of the original scf.if into a newly created sibling scf.if , then unified the block_id of the new scf.if .

### Problem
When the memref.alloc is defined inside the then region of the scf.if , this splitting moves the linalg.fill (which references the alloc) outside the scf.if . This creates an out-of-scope use of a value defined in a nested region, violating SSA dominance and producing invalid IR. A typical trigger is a single scf.if containing multiple alloc + fill pairs mixed with many other operations.

### Changes
- Removed the splitSCFIfIfNeeded splitting logic; the fill is no longer moved out of the scf.if .
- Renamed needsSplitIf to haveOtherOpsInIf , whose semantics now check whether the then region of the scf.if contains operations other than the linalg.fill . If so, unification for this alloc is aborted ( return success() to skip), preventing invalid IR.

### 标题
修复 UnifyAllocBlockPass 在 scf.if 内存在其他操作时生成非法 IR 的问题

### 背景
UnifyAllocBlockPass 用于统一 memref.alloc 、 linalg.fill 及其 scf.if 与消费方的 block_id。原实现中，当 scf.if 的 then 分支内除 linalg.fill 外还混有其他操作时，会通过 splitSCFIfIfNeeded 把 linalg.fill 移出原 scf.if 并放入新建的兄弟 scf.if 中，再对新 scf.if 统一 block_id 。

### 问题
当 memref.alloc 定义在 scf.if 的 then region 内部时，上述拆分会把引用该 alloc 的 linalg.fill 移到 if 外部，导致对「嵌套 region 内部值」的越界使用，违反 SSA 支配关系，生成非法 IR。典型场景是一个 scf.if 内同时存在多个 alloc + fill 并混有大量其他操作。

### 修改
- 删除 splitSCFIfIfNeeded 拆分逻辑，不再把 fill 移出 if。
- 将 needsSplitIf 重命名为 haveOtherOpsInIf ，语义改为：判断 scf.if 的 then 分支内是否除 linalg.fill 外还有其他操作；若有，则直接中止对该 alloc 的统一（ return success() 跳过），避免生成非法 IR。
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
