### PR TITLE
[TritonToLinalg](fix) Lower static all-zero-stride MTP loads

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
@@ -76,6 +76,59 @@ using namespace triton;
 const std::string MayImplicitTransposeWithLastAxisTAG =
     "MayImplicitTransposeWithLastAxis";
 
+namespace {
+
+Value getRemappedOrOriginal(Value value, ConversionPatternRewriter &rewriter) {
+  if (Value remapped = rewriter.getRemappedValue(value))
+    return remapped;
+  return value;
+}
+
+bool hasStaticAllZeroStrides(triton::MakeTensorPtrOp makeTensorPtrOp) {
+  auto strides = makeTensorPtrOp.getStrides();
+  return !strides.empty() && llvm::all_of(strides, [](Value stride) {
+    auto constantStride = getConstantIntValue(stride);
+    return constantStride && constantStride.value() == 0;
+  });
+}
+
+SmallVector<OpFoldResult> getBoundarySizesFromAllZeroStrideMTP(
+    triton::MakeTensorPtrOp makeTensorPtrOp,
+    llvm::ArrayRef<int32_t> boundaryCheck, llvm::ArrayRef<int64_t> tileShape,
+    const Location &loc, ConversionPatternRewriter &rewriter) {
+  assert(makeTensorPtrOp.getShape().size() == tileShape.size());
+  assert(makeTensorPtrOp.getOffsets().size() == tileShape.size());
+
+  SmallVector<OpFoldResult> boundarySizes =
+      getAsIndexOpFoldResult(rewriter.getContext(), tileShape);
+  const OpFoldResult zero = rewriter.getIndexAttr(0);
+
+  for (size_t i = 0; i < tileShape.size(); ++i) {
+    if (llvm::find(boundaryCheck, i) == boundaryCheck.end())
+      continue;
+
+    OpFoldResult shape = getOpFoldResultOfLayoutInfo(
+        getRemappedOrOriginal(makeTensorPtrOp.getShape()[i], rewriter),
+        rewriter);
+    OpFoldResult offset = getOpFoldResultOfLayoutInfo(
+        getRemappedOrOriginal(makeTensorPtrOp.getOffsets()[i], rewriter),
+        rewriter);
+    // This is the exclusive end of the logical valid interval expressed in
+    // tile coordinates.  The caller removes the negative-offset prefix when
+    // it computes the destination subview.  Using shape - offset (rather
+    // than shape - max(offset, 0)) is necessary for cases such as
+    // shape=1, offset=-2, tile=4: lane 2 is valid and must not be dropped.
+    OpFoldResult remaining = maxOpFoldResult(
+        subOpFoldResult(shape, offset, loc, rewriter), zero, loc, rewriter);
+    boundarySizes[i] =
+        minOpFoldResult(boundarySizes[i], remaining, loc, rewriter);
+  }
+
+  return boundarySizes;
+}
+
+} // namespace
+
 LogicalResult
 AddPtrConverter::matchAndRewrite(triton::AddPtrOp op, OpAdaptor adaptor,
                                  ConversionPatternRewriter &rewriter) const {
@@ -365,6 +418,105 @@ LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
   // Check if tt.load is modified by AddPtrConverter to a specified state.
   if (checkModifiedByAddPtrConverter(op).succeeded()) {
     return continueModifyFromAddPtrConverter(op, adaptor, rewriter);
+  }
+
+  auto makeTensorPtrOp = op.getPtr().getDefiningOp<triton::MakeTensorPtrOp>();
+  auto allZeroStrideBoundaryCheck = op.getBoundaryCheck();
+  const bool isStaticAllZeroStrideMTP =
+      makeTensorPtrOp && makeTensorPtrOp.getResult().hasOneUse() &&
+      !allZeroStrideBoundaryCheck.empty() && !op.getMask() && !op.getOther() &&
+      op.getPadding().has_value() && hasStaticAllZeroStrides(makeTensorPtrOp);
+  if (isStaticAllZeroStrideMTP) {
+    auto tensorType = dyn_cast<RankedTensorType>(op.getResult().getType());
+    if (!tensorType) {
+      return rewriter.notifyMatchFailure(
+          op,
+          "all-zero-stride tensor pointer load must return a ranked tensor");
+    }
+
+    Value base = getRemappedOrOriginal(makeTensorPtrOp.getBase(), rewriter);
+    auto baseMemRefType = dyn_cast<MemRefType>(base.getType());
+    if (!baseMemRefType || baseMemRefType.getRank() != 1 ||
+        baseMemRefType.getElementType() != tensorType.getElementType()) {
+      return rewriter.notifyMatchFailure(
+          op, "all-zero-stride tensor pointer load requires a rank-1 remapped "
+              "base with the result element type");
+    }
+
+    auto loc = op.getLoc();
+    auto memRefElementType = tensorType.getElementType();
+    Value allocOp = rewriter.create<memref::AllocOp>(
+        loc, MemRefType::get(tensorType.getShape(), memRefElementType));
+    auto boundarySizes = getBoundarySizesFromAllZeroStrideMTP(
+        makeTensorPtrOp, allZeroStrideBoundaryCheck, tensorType.getShape(), loc,
+        rewriter);
+
+    SmallVector<OpFoldResult> dstOffsets;
+    dstOffsets.reserve(boundarySizes.size());
+    const OpFoldResult zero = rewriter.getIndexAttr(0);
+    for (auto [idx, offset] : llvm::enumerate(makeTensorPtrOp.getOffsets())) {
+      if (llvm::find(allZeroStrideBoundaryCheck, idx) ==
+          allZeroStrideBoundaryCheck.end()) {
+        dstOffsets.push_back(zero);
+        continue;
+      }
+
+      OpFoldResult logicalOffset = getOpFoldResultOfLayoutInfo(
+          getRemappedOrOriginal(offset, rewriter), rewriter);
+      OpFoldResult leftPadding =
+          maxOpFoldResult(subOpFoldResult(zero, logicalOffset, loc, rewriter),
+                          zero, loc, rewriter);
+      OpFoldResult dstOffset =
+          minOpFoldResult(leftPadding, boundarySizes[idx], loc, rewriter);
+      boundarySizes[idx] =
+          subOpFoldResult(boundarySizes[idx], dstOffset, loc, rewriter);
+      dstOffsets.push_back(dstOffset);
+    }
+
+    auto dstSubview = mlir::ConverterUtils::makeSubViewOp(
+        allocOp, dstOffsets, boundarySizes, loc, rewriter);
+
+    auto padding = op.getPadding();
+    TypedAttr padAttr = rewriter.getZeroAttr(memRefElementType);
+    if (padding.value() == triton::PaddingOption::PAD_NAN) {
+      assert(!memRefElementType.isIntOrIndex());
+      auto apNaN = llvm::APFloat::getNaN(
+          cast<FloatAttr>(padAttr).getValue().getSemantics());
+      padAttr = rewriter.getFloatAttr(memRefElementType, apNaN);
+    }
+    auto padVal = rewriter.create<arith::ConstantOp>(loc, padAttr);
+    // boundarySizes now contains the actual valid extent after removal of a
+    // negative logical-offset prefix.  Fill against this final extent so the
+    // prefix is padded even when the right edge of the tile remains in range.
+    fillTensorWithOtherForMaskScenario(padVal, allocOp, boundarySizes,
+                                       rewriter);
+
+    Value zeroIndex = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value hasValidRegion =
+        rewriter.create<arith::ConstantOp>(loc, rewriter.getBoolAttr(true));
+    for (const OpFoldResult &boundarySize : boundarySizes) {
+      Value boundarySizeValue =
+          getValueOrCreateConstantIndexOp(rewriter, loc, boundarySize);
+      Value hasValidDimension = rewriter.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::sgt, boundarySizeValue, zeroIndex);
+      hasValidRegion = rewriter.create<arith::AndIOp>(loc, hasValidRegion,
+                                                      hasValidDimension);
+    }
+
+    auto ifOp = rewriter.create<scf::IfOp>(loc, hasValidRegion);
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
+      auto scalar =
+          rewriter.create<memref::LoadOp>(loc, base, ValueRange{zeroIndex});
+      auto fillOp = rewriter.create<linalg::FillOp>(loc, ValueRange{scalar},
+                                                    ValueRange{dstSubview});
+      propagateWasBoolToInt8Attr(op.getOperation(), fillOp.getOperation(),
+                                 rewriter);
+    }
+    return this->toTensorAndReplace(op, tensorType, allocOp,
+                                    /*mayImplicitTransposeWithLastAxis=*/false,
+                                    loc, rewriter);
   }
 
   auto ptr = adaptor.getPtr();

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/zero_stride_block_ptr_scalar_fill.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/zero_stride_block_ptr_scalar_fill.mlir
@@ -1,0 +1,139 @@
+// RUN: triton-opt "--triton-to-linalg=global-kernel=false named-ops=True" --split-input-file %s | FileCheck %s
+
+// A direct all-zero-stride MTP load is a scalar broadcast. Boundary sizes must
+// be calculated from the original logical shape/offset, then the valid region
+// is filled from base[0]. Do not materialize a zero-stride memref layout.
+// CHECK-LABEL: func.func @all_zero_stride_dynamic
+// CHECK-NOT: strided<[0
+// CHECK: memref.alloc() : memref<4x4xf32>
+// CHECK: arith.subi
+// CHECK: arith.maxsi
+// CHECK: arith.minsi
+// CHECK: memref.subview
+// CHECK: arith.cmpi sgt
+// CHECK: scf.if
+// CHECK: memref.load
+// CHECK: linalg.fill
+// CHECK: bufferization.to_tensor
+// CHECK-NOT: strided<[0
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @all_zero_stride_dynamic(
+      %src: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+      %shape_m: i32, %shape_n: i32, %offset_m: i32, %offset_n: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %shape_m_i64 = arith.extsi %shape_m : i32 to i64
+    %shape_n_i64 = arith.extsi %shape_n : i32 to i64
+    %src_block = tt.make_tensor_ptr %src, [%shape_m_i64, %shape_n_i64],
+        [%c0_i64, %c0_i64], [%offset_m, %offset_n]
+        {order = array<i32: 1, 0>} : <tensor<4x4xf32>>
+    %value = tt.load %src_block {boundaryCheck = array<i32: 0, 1>, padding = 1 : i32}
+        : !tt.ptr<tensor<4x4xf32>>
+    %dst_block = tt.make_tensor_ptr %dst, [%c4_i64, %c4_i64],
+        [%c4_i64, %c1_i64], [%c0_i32, %c0_i32]
+        {order = array<i32: 1, 0>} : <tensor<4x4xf32>>
+    tt.store %dst_block, %value : !tt.ptr<tensor<4x4xf32>>
+    tt.return
+  }
+}
+
+// -----
+
+// Negative logical offsets leave a padded prefix. The scalar source access
+// remains guarded by a non-empty valid region.
+// CHECK-LABEL: func.func @all_zero_stride_negative_offset
+// CHECK-NOT: strided<[0
+// CHECK: memref.subview
+// CHECK: memref.load
+// CHECK: linalg.fill
+// CHECK-NOT: strided<[0
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @all_zero_stride_negative_offset(
+      %src: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+    %cneg2_i32 = arith.constant -2 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %c5_i64 = arith.constant 5 : i64
+    %c6_i64 = arith.constant 6 : i64
+    %src_block = tt.make_tensor_ptr %src, [%c6_i64, %c5_i64],
+        [%c0_i64, %c0_i64], [%cneg2_i32, %c0_i32]
+        {order = array<i32: 1, 0>} : <tensor<4x4xf32>>
+    %value = tt.load %src_block {boundaryCheck = array<i32: 0, 1>, padding = 1 : i32}
+        : !tt.ptr<tensor<4x4xf32>>
+    %dst_block = tt.make_tensor_ptr %dst, [%c4_i64, %c4_i64],
+        [%c4_i64, %c1_i64], [%c0_i32, %c0_i32]
+        {order = array<i32: 1, 0>} : <tensor<4x4xf32>>
+    tt.store %dst_block, %value : !tt.ptr<tensor<4x4xf32>>
+    tt.return
+  }
+}
+
+// -----
+
+// A short logical shape with a negative offset has a valid suffix that starts
+// inside the tile. The final valid subview must keep that suffix rather than
+// subtracting the left padding from an already-clipped right extent.
+// CHECK-LABEL: func.func @all_zero_stride_negative_offset_short_shape
+// CHECK: memref.subview %alloc[2, 0] [1, 1] [1, 1]
+// CHECK: linalg.fill ins(%cst : f32) outs(%alloc : memref<4x4xf32>)
+// CHECK: memref.load
+// CHECK: linalg.fill
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @all_zero_stride_negative_offset_short_shape(
+      %src: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+    %cneg2_i32 = arith.constant -2 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %src_block = tt.make_tensor_ptr %src, [%c1_i64, %c1_i64],
+        [%c0_i64, %c0_i64], [%cneg2_i32, %c0_i32]
+        {order = array<i32: 1, 0>} : <tensor<4x4xf32>>
+    %value = tt.load %src_block {boundaryCheck = array<i32: 0, 1>, padding = 1 : i32}
+        : !tt.ptr<tensor<4x4xf32>>
+    %dst_block = tt.make_tensor_ptr %dst, [%c4_i64, %c4_i64],
+        [%c4_i64, %c1_i64], [%c0_i32, %c0_i32]
+        {order = array<i32: 1, 0>} : <tensor<4x4xf32>>
+    tt.store %dst_block, %value : !tt.ptr<tensor<4x4xf32>>
+    tt.return
+  }
+}
+
+// -----
+
+// All-nonzero MTP loads must retain the existing physical-offset
+// reconstruction and copy lowering.
+// CHECK-LABEL: func.func @nonzero_stride_dynamic
+// CHECK: arith.divsi
+// CHECK: arith.remsi
+// CHECK: memref.copy
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @nonzero_stride_dynamic(
+      %src: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+      %dst: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+      %shape_m: i32, %shape_n: i32, %offset_m: i32, %offset_n: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %c8_i64 = arith.constant 8 : i64
+    %shape_m_i64 = arith.extsi %shape_m : i32 to i64
+    %shape_n_i64 = arith.extsi %shape_n : i32 to i64
+    %src_block = tt.make_tensor_ptr %src, [%shape_m_i64, %shape_n_i64],
+        [%c8_i64, %c1_i64], [%offset_m, %offset_n]
+        {order = array<i32: 1, 0>} : <tensor<4x4xf32>>
+    %value = tt.load %src_block {boundaryCheck = array<i32: 0, 1>, padding = 1 : i32}
+        : !tt.ptr<tensor<4x4xf32>>
+    %dst_block = tt.make_tensor_ptr %dst, [%c4_i64, %c4_i64],
+        [%c4_i64, %c1_i64], [%c0_i32, %c0_i32]
+        {order = array<i32: 1, 0>} : <tensor<4x4xf32>>
+    tt.store %dst_block, %value : !tt.ptr<tensor<4x4xf32>>
+    tt.return
+  }
+}


### PR DESCRIPTION
## Summary

Fix `tt.load` lowering for a direct, single-use `tt.make_tensor_ptr` whose strides are all compile-time zero and which uses `boundaryCheck` plus padding.

The generic block-pointer path reconstructs logical coordinates from physical offsets. That is invalid when every physical stride is zero and can reach a zero-divisor / zero-stride memref layout. The new narrow fast path recognizes the scalar-broadcast case, computes the valid logical subview from the original shape and offsets, fills padding, then loads `base[0]` and fills the valid region.

The match is intentionally limited to all-zero static strides, no explicit mask/other, a single-use MTP, and a compatible rank-1 remapped base. Nonzero, mixed/dynamic stride and other load paths keep their existing lowering.

The regression file covers dynamic all-zero strides, negative logical offsets (including `shape=1, offset=-2, tile=4`), and a nonzero-stride control case.

## Validation

- `clang-format --dry-run --Werror third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp`
- `triton-opt --triton-to-linalg ... zero_stride_block_ptr_scalar_fill.mlir | FileCheck ...`
- Baseline vs. fixed `ttir -> ttadapter` diff for the static nonzero-stride control: identical output
- FlagGems on Ascend910B4:
  ```bash
  PYTHONPATH=src python -m pytest -q \
    'tests/test_pointwise_dynamic.py::test_dynamic_function_with_predefined_out[True]' \
    'tests/test_pointwise_dynamic.py::test_dynamic_function_with_some_predefined_out1[True]' \
    'tests/test_pointwise_dynamic.py::test_dynamic_function_with_some_predefined_out2[True]'
  ```
  Result: `3 passed`.
- Strict no-launch A5 compile using explicit `GPUTarget("npu", "Ascend910_9589", 0)`: `1 passed`; generated `ttir`, `ttadapter`, `mlirbc`, `bcmlir`, and `npubin`.
