### PR TITLE
Revert "[build](fix) delete submodule Triton-distributed-ascend (#1530)"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = third_party/ascend/AscendNPU-IR
 	url = https://gitcode.com/Ascend/AscendNPU-IR.git
     depth = 1
+[submodule "third_party/ascend/Triton-distributed-ascend"]
+	path = third_party/ascend/Triton-distributed-ascend
+	url = https://gitcode.com/Ascend/Triton-distributed-ascend.git

--- a/python/setup.py
+++ b/python/setup.py
@@ -566,7 +566,7 @@ class CMakeBuild(build_ext):
         else:
             cmake_args += ["-DTRITON_BUILD_PROTON=OFF"]
 
-        if check_env_flag("TRITON_BUILD_DISTRIBUTED", "OFF"):
+        if check_env_flag("TRITON_BUILD_DISTRIBUTED", "ON"):
             cmake_args += ["-DTRITON_BUILD_DISTRIBUTED=ON"]
         else:
             cmake_args += ["-DTRITON_BUILD_DISTRIBUTED=OFF"]
@@ -609,28 +609,14 @@ def is_git_repo():
 
 
 def ensure_distributed_submodule():
-    if not check_env_flag("TRITON_BUILD_DISTRIBUTED", "OFF"):
+    if not check_env_flag("TRITON_BUILD_DISTRIBUTED", "ON"):
         return
     distributed_dir = Path(triton_dir) / "third_party" / "ascend" / "Triton-distributed-ascend"
-    if not distributed_dir.is_dir():
+    if not (distributed_dir / "CMakeLists.txt").is_file() and is_git_repo():
         subprocess.check_call([
-            "git",
-            "clone",
-            "https://gitcode.com/Ascend/Triton-distributed-ascend.git",
-            "-b",
-            "release/3.2.2",
-        ], cwd=Path(triton_dir) / "third_party" / "ascend")
-    if is_git_repo():
-        subprocess.check_call([
-            "git",
-            "checkout",
-            "release/3.2.2",
-        ], cwd=distributed_dir)
-        subprocess.check_call([
-            "git",
-            "pull",
-            "origin",
-        ], cwd=distributed_dir)
+            "git", "submodule", "update", "--init", "--",
+            "third_party/ascend/Triton-distributed-ascend"
+        ], cwd=triton_dir)
     if not (distributed_dir / "CMakeLists.txt").is_file():
         raise RuntimeError(f"Triton-Distributed submodule is not initialized: {distributed_dir}")
 
@@ -749,7 +735,7 @@ def add_links():
     add_link_to_backends()
     if check_env_flag("TRITON_BUILD_PROTON", "ON"):  # Default ON
         add_link_to_proton()
-    if check_env_flag("TRITON_BUILD_DISTRIBUTED", "OFF"):
+    if check_env_flag("TRITON_BUILD_DISTRIBUTED", "ON"):
         add_link_to_distributed()
 
 
@@ -855,7 +841,7 @@ def get_packages():
     packages += get_language_extra_packages()
     if check_env_flag("TRITON_BUILD_PROTON", "ON"):  # Default ON
         packages += ["triton/profiler"]
-    if check_env_flag("TRITON_BUILD_DISTRIBUTED", "OFF"):
+    if check_env_flag("TRITON_BUILD_DISTRIBUTED", "ON"):
         distributed_root = os.path.join(os.pardir, "third_party", "ascend", "Triton-distributed-ascend", "python")
         distributed_pkg_root = os.path.join(distributed_root, "triton_dist")
         if os.path.isdir(distributed_pkg_root):


### PR DESCRIPTION
## Summary

Revert commit `ca921c898705f06e6826348c25f13d67570c7357` (`#1530`).

This restores:
- the `Triton-distributed-ascend` submodule declaration and pinned gitlink
- distributed build/package support as enabled by default
- submodule initialization through `git submodule update --init`

## Verification

- `git diff --check HEAD^ HEAD`
- `python3 -m py_compile python/setup.py`