### PR TITLE
Revert "[build](fix) delete submodule Triton-distributed-ascend (#1513)"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = third_party/ascend/AscendNPU-IR
 	url = https://gitcode.com/Ascend/AscendNPU-IR.git
     depth = 1
+[submodule "third_party/ascend/Triton-distributed-ascend"]
+	path = third_party/ascend/Triton-distributed-ascend
+	url = https://gitcode.com/Ascend/Triton-distributed-ascend.git
+    depth = 1

--- a/setup.py
+++ b/setup.py
@@ -686,21 +686,10 @@ def ensure_distributed_submodule():
     if not check_env_flag("TRITON_BUILD_DISTRIBUTED", "ON"):
         return
     distributed_dir = Path(triton_dir) / "third_party" / "ascend" / "Triton-distributed-ascend"
-    commit_id = "d2ac268c7ab4dc09865ed51638104ee1b97dc460"
-    if not distributed_dir.is_dir():
-        subprocess.check_call([
-            "git",
-            "clone",
-            "https://gitcode.com/Ascend/Triton-distributed-ascend.git",
-            "-b",
-            "master",
-        ], cwd=Path(triton_dir) / "third_party" / "ascend")
     if not (distributed_dir / "CMakeLists.txt").is_file() and is_git_repo():
-        subprocess.check_call([
-            "git",
-            "checkout",
-            commit_id,
-        ], cwd=distributed_dir)
+        subprocess.check_call(
+            ["git", "submodule", "update", "--init", "--", "third_party/ascend/Triton-distributed-ascend"],
+            cwd=triton_dir)
     if not (distributed_dir / "CMakeLists.txt").is_file():
         raise RuntimeError(f"Triton-Distributed submodule is not initialized: {distributed_dir}")
 


### PR DESCRIPTION
## Summary

Revert commit `5c48952c8c1790493db8bbbf82f2dec9c97b65e8` (`#1513`).

This restores the `Triton-distributed-ascend` submodule declaration and pinned gitlink, and restores submodule initialization during setup.

## Verification

- `git diff --check HEAD^ HEAD`
- `python3 -m py_compile setup.py