### PR TITLE
[TritonToUnstructure](fix) wrap int_to_ptr with addptr indirect_store

### DIFF
--- a/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
@@ -407,6 +407,24 @@ static bool canUseIndirectFastPath(Value srcPtr, Value ptrOffset) {
   return isa<RankedTensorType>(ptrOffset.getType());
 }
 
+// Wrap an int_to_ptr result with addptr(src, 0) so that the later
+// AddPtrConverter can lower it to a hivm::PointerCastOp (memref type), which
+// the IndirectLoad/StoreConverter needs to emit func.call @triton_indirect_*.
+// Returns the wrapped pointer, or the original srcPtr when it is not an
+// int_to_ptr result.
+static Value wrapIntToPtrWithAddPtr(Value srcPtr, Location loc,
+                                    PatternRewriter &rewriter) {
+  if (auto *defOp = srcPtr.getDefiningOp()) {
+    if (auto intToPtrOp = dyn_cast<triton::IntToPtrOp>(defOp)) {
+      auto zeroOffset = rewriter.create<arith::ConstantOp>(
+          loc, rewriter.getZeroAttr(intToPtrOp.getSrc().getType()));
+      return rewriter.create<triton::AddPtrOp>(loc, srcPtr.getType(), srcPtr,
+                                               zeroOffset);
+    }
+  }
+  return srcPtr;
+}
+
 template <typename MemAccOpTy>
 LogicalResult tryRewriteIndirectFastPath(MemAccOpTy op, Location loc,
                                          Value srcPtr, Value ptrOffset,
@@ -433,15 +451,7 @@ LogicalResult tryRewriteIndirectFastPath(MemAccOpTy op, Location loc,
     Value mask = op.getMask();
     Value other = op.getOther();
     auto resultType = op.getType();
-    auto newPtr = srcPtr;
-    if (auto *defOp = srcPtr.getDefiningOp()) {
-      if (auto intToPtrOp = dyn_cast<triton::IntToPtrOp>(defOp)) {
-        auto zeroOffset = rewriter.create<arith::ConstantOp>(
-            loc, rewriter.getZeroAttr(intToPtrOp.getSrc().getType()));
-        newPtr = rewriter.create<triton::AddPtrOp>(loc, srcPtr.getType(),
-                                                   srcPtr, zeroOffset);
-      }
-    }
+    auto newPtr = wrapIntToPtrWithAddPtr(srcPtr, loc, rewriter);
     auto indirect = rewriter.create<triton::ascend::IndirectLoadOp>(
         loc, resultType, newPtr, ptrOffset, mask, other,
         ConverterUtils::requiresVolatileIndirectLoad(op.getPtr(), op));
@@ -461,6 +471,11 @@ LogicalResult tryRewriteIndirectFastPath(MemAccOpTy op, Location loc,
            "src must be ptr type");
     Value value = op.getValue();
     Value mask = op.getMask();
+
+    // Wrap int_to_ptr with addptr so that AddPtrConverter can later produce
+    // a hivm::PointerCastOp (memref type) from it, which is required by
+    // IndirectStoreConverter to emit func.call @triton_indirect_store.
+    srcPtr = wrapIntToPtrWithAddPtr(srcPtr, loc, rewriter);
 
     // For bool store, unwrap ptr<i1> -> ptr<i8> bitcast before creating
     // indirect_store. Keep ptr<i1> so TypeConverter can map it to memref<?xi8>.

--- a/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/indirect_store.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/indirect_store.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt --triton-to-structured '--discrete-mask-access-conversion=compile-on-910-95=True force-simt-template=True' '--triton-to-unstructure=compile-on-910-95=True force-simt-template=True' %s --split-input-file | FileCheck %s
+// RUN: triton-opt '--triton-to-unstructure=compile-on-910-95=True force-simt-template=True' '--triton-to-linalg=compile-on-910-95=True' --split-input-file %s | FileCheck %s --check-prefix=LINALG
 
 // tt.store -> ascend.indirect_store
 tt.func public @triton_indirect_store_kernel(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<i64>, %arg2: !tt.ptr<f32>, %arg3: i32) attributes {noinline = false} {
@@ -40,3 +41,36 @@ tt.func public @triton_indirect_store_kernel(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr
 // CHECK:           ascend.indirect_store {{.*}} : <f32>, {{.*}} : tensor<8x32xi64>, {{.*}} : tensor<8x32xf32>
 // CHECK:           tt.return
 // CHECK:         }
+
+// tt.int_to_ptr + tt.store -> wrap with addptr(src, 0), then
+// ascend.indirect_store. The addptr wrap is required so that the later
+// TritonToLinalg AddPtrConverter can lower it to a hivm::PointerCastOp
+// (memref type), which IndirectStoreConverter needs to emit
+// func.call @triton_indirect_store.
+// CHECK-LABEL:     tt.func public @triton_indirect_store_int_to_ptr_kernel(
+// CHECK:           %[[ZERO:.*]] = arith.constant 0 : i64
+// CHECK:           %[[BASE:.*]] = tt.int_to_ptr {{.*}} : i64 -> !tt.ptr<f32>
+// CHECK:           %[[WRAPPED:.*]] = tt.addptr %[[BASE]], %[[ZERO]] : !tt.ptr<f32>, i64
+// CHECK:           ascend.indirect_store %[[WRAPPED]] : <f32>, {{.*}} : tensor<8xi64>, {{.*}} : tensor<8xf32>
+// CHECK:           tt.return
+// CHECK:         }
+
+// The same kernel lowered through TritonToLinalg must produce a
+// hivm::PointerCastOp (memref) from the wrapped addptr and finally a
+// func.call @triton_indirect_store.
+// LINALG-LABEL: func.func @triton_indirect_store_int_to_ptr_kernel
+// LINALG: hivm.hir.pointer_cast(%{{.*}}) [%{{.*}}] : memref<?xf32>
+// LINALG: call @triton_indirect_store{{.*}}(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<{{.*}}xf32, strided<[1]>>, tensor<8xi64>, tensor<8xf32>) -> ()
+tt.func public @triton_indirect_store_int_to_ptr_kernel(%arg0: !tt.ptr<i64>, %arg1: !tt.ptr<f32>) {
+  %base_i64 = arith.constant 1024 : i64
+  %base = tt.int_to_ptr %base_i64 : i64 -> !tt.ptr<f32>
+  %cst = arith.constant dense<32> : tensor<8xi32>
+  %range = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+  %idx = arith.addi %range, %cst : tensor<8xi32>
+  %base_splat = tt.splat %base : !tt.ptr<f32> -> tensor<8x!tt.ptr<f32>>
+  %ptr = tt.addptr %base_splat, %idx : tensor<8x!tt.ptr<f32>>, tensor<8xi32>
+  %val = tt.load %arg1 : !tt.ptr<f32>
+  %val_splat = tt.splat %val : f32 -> tensor<8xf32>
+  tt.store %ptr, %val_splat {route_discrete_mask_to_simt} : tensor<8x!tt.ptr<f32>>
+  tt.return
+}

--- a/third_party/ascend/unittest/pytest_ut/test_specialization_cache_npu.py
+++ b/third_party/ascend/unittest/pytest_ut/test_specialization_cache_npu.py
@@ -40,14 +40,14 @@ def _clear_kernel_cache(kernel=_add_value):
 
 
 def _run_case(n, src, dst, mode):
-    _add_value[(1,)](src, dst, n, 3, BLOCK=32, compile_mode=mode)
+    _add_value[(1, )](src, dst, n, 3, BLOCK=32, compile_mode=mode)
     torch.npu.synchronize()
     expected = src[:n] + 3
     torch.testing.assert_close(dst[:n], expected)
 
 
 def _run_annotated_case(n, value, src, dst, mode):
-    _add_annotated_value[(1,)](src, dst, n, value, BLOCK=32, compile_mode=mode)
+    _add_annotated_value[(1, )](src, dst, n, value, BLOCK=32, compile_mode=mode)
     torch.npu.synchronize()
     expected = src[:n] + value
     torch.testing.assert_close(dst[:n], expected)

--- a/third_party/ascend/unittest/pytest_ut/test_specialization_cache_unit.py
+++ b/third_party/ascend/unittest/pytest_ut/test_specialization_cache_unit.py
@@ -13,7 +13,6 @@ from triton.backends.ascend.compiler import AscendBackend
 from triton.backends.compiler import GPUTarget
 from triton.runtime.jit import KernelParam, compute_cache_key, create_function_from_signature
 
-
 pytestmark = pytest.mark.backend("native")
 
 
@@ -160,8 +159,8 @@ def test_annotated_integer_one_keeps_constexpr_specialization(options):
 
     assert one_specialization == [("constexpr", 1)]
     assert two_specialization == [(annotation, "")]
-    assert compute_cache_key(cache, one_specialization, one_options) != compute_cache_key(
-        cache, two_specialization, two_options)
+    assert compute_cache_key(cache, one_specialization,
+                             one_options) != compute_cache_key(cache, two_specialization, two_options)
 
 
 @pytest.mark.parametrize("options", [SIMD_OPTIONS[0], *SIMT_OPTIONS])


### PR DESCRIPTION
[✓] I am not making a trivial change, such as fixing a typo in a comment.
[✓] I have written a PR description following these rules https://cbea.ms/git-commit/#why-not-how.
[✓] I have run pre-commit run --from-ref origin/main --to-ref HEAD.
- Select one of the following.
    [✓] I have added tests.
      • /test for lit tests
      • /unittest for C++ tests
      • /python/test for end-to-end tests
    [ ] This PR does not need a test because FILL THIS IN.
- Select one of the following.
    [ ] I have not added any lit tests.
    [✓] The lit tests I have added follow these best practices https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices, including the "tests should be minimal" section. (Usually running Python code and using the instructions it generates is not minimal.)

 # Summary

修复 950 系列 SIMT 间接存储路径：当 tt.store 的基址由 tt.int_to_ptr 直接产生时，为其包装 tt.addptr(ptr, 0)，使后续 TritonToLinalg 的 AddPtrConverter 能将其降为 hivm::PointerCastOp（memref 类型），从而让 IndirectStoreConverter 正常发射 func.call @triton_indirect_store。

# Changes

- [Fix] 在 TritonToUnstructure::tryRewriteIndirectFastPath 的 Store 分支中，若 srcPtr 的 defining op 是 tt.int_to_ptr，插入零偏移
  tt.addptr 包装（third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp）
- [Test] 在 indirect_store.mlir 新增 @triton_indirect_store_int_to_ptr_kernel lit 用例，覆盖：
    - Unstructure 阶段：tt.int_to_ptr → tt.addptr(ptr, 0) 包装 → ascend.indirect_store
    - 完整链路（新增 LINALG RUN 行）：hivm.hir.pointer_cast（memref）→ call @triton_indirect_store

# Motivation

在 SIMT 间接存储 fast-path 下，当存储目标指针直接由 tt.int_to_ptr 定义时，ascend.indirect_store 的 src 直接指向 int_to_ptr 的结果（标量 ptr）。由于 IndirectStoreConverter（TritonToLinalg）要求 src 必须是 MemRefType 才能发射 func.call @triton_indirect_store，而裸 tt.int_to_ptr 不经过 BlockDataParser::rewriteAddPtr 的 int_to_ptr 分支生成 hivm::PointerCastOp (memref<?xT>)，导致降级失败、间接存储无法正确发射 func.call。

通过给 int_to_ptr 结果包一层 tt.addptr(src, 0)，触发 AddPtrConverter 的既有处理路径生成 hivm::PointerCastOp，使 src 稳定成为 memref 类型，最终正确发射 func.call @triton_indirect_store。
