### PR TITLE
[drive](fix) Fix incorrect Tensor dataType reporting to Msprof

### DIFF
--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -900,9 +900,11 @@ extern "C" {
       int dataTypes[MSPROF_GE_TENSOR_DATA_NUM];
       if (tensorShapes.size() > 0) {{
         {LINE_CHANGE_CHAR.join(
-          f'dataTypes[{i}] = {convert_sigtype_to_int(ty[1:])};'
-          for i, ty in signature.items()
-          if ty.startswith("*") and i < 5
+          f'dataTypes[{idx}] = {convert_sigtype_to_int(ty[1:])};'
+          for idx, (_, ty) in enumerate(
+            (k, v) for k, v in signature.items() if v.startswith("*")
+          )
+          if idx < 5
         )}
       }}
       for (int i = 0; i < tensorShapes.size() && tensorCount < MSPROF_GE_TENSOR_DATA_NUM; i++) {{


### PR DESCRIPTION
### Problem
When profiling kernels via Msprof, the reported `dataType` for tensors was incorrect (showing garbage values like random large negative integers). This mismatched the actual tensor data types (e.g., FP32), making profiling data unreliable.

### Root Cause
There was an index alignment issue between `dataTypes` arguments and `tensorShapes`:

1.  **Assignment**: The old code used the dictionary Key `i` (parameter index) as the array index for `dataTypes[i]`.
2.  **Issue**: If the first few kernel arguments were scalars (non-pointers), these indices (0, 1, etc.) were skipped in the `dataTypes` array, leaving them uninitialized (garbage values).
3.  **Usage**: The runtime loop iterates over `tensorShapes` (which only contains valid tensors) and attempts to read `dataTypes[i]`.
4.  **Result**: This caused a mismatch: The 1st valid tensor (at index 0) read from `dataTypes[0]` (which was garbage because it corresponded to a skipped scalar argument), while the actual data was stored at higher indices.

### Solution
Refactored the `dataTypes` assignment logic to be **dense** and **ordered**:
- Instead of using the sparse `signature` Key, we now use a continuous counter `idx` (0, 1, 2...).
- We filter for `*` (pointers) first, then sequentially assign them to `dataTypes[0]` through `dataTypes[4]`.
- This ensures `dataTypes[i]` strictly corresponds to the i-th valid tensor in `tensorShapes`.

### Changes
- Modified the Python code generation logic for `cpp_msprof_call_after_launch`.
- Replaced the direct index assignment with a filtered list comprehension to ensure `dataTypes` is densely packed.

### Testing
- Verified that Msprof reports now show correct data types (e.g., `3` for FP32) matching the kernel signature.
- Confirmed that scalar arguments no longer cause misalignment in tensor type reporting.



<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
