### PR TITLE
[MaskAnalysis](fix) add atomic op in parseSplat

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/MaskAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/MaskAnalysis.cpp
@@ -695,6 +695,9 @@ LogicalResult MaskState::parseSplat(triton::SplatOp splatOp,
             [&](triton::LoadOp loadOp) { return loadOp.getMask() == dst; })
         .Case<triton::StoreOp>(
             [&](triton::StoreOp storeOp) { return storeOp.getMask() == dst; })
+        .Case<triton::AtomicRMWOp>([&](triton::AtomicRMWOp atomicOp) {
+          return atomicOp.getMask() == dst;
+        })
         .Default([&](Operation *op) { return false; });
   };
 

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/atomic_rmw_block.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/atomic_rmw_block.mlir
@@ -41,8 +41,9 @@ module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
 
 // CHECK-LABEL: func.func @moe_align_block_size_stage4
 
-// CHECK:  %[[CAST1:.*]] = memref.reinterpret_cast %[[ARG1:.*]] to offset: [%{{.*}}], sizes: [1], strides: [1] : memref<?xi32> to memref<1xi32, strided<[1], offset: ?>>
-// CHECK:  %[[CAST2:.*]] = memref.reinterpret_cast %[[ARG2:.*]] to offset: [%{{.*}}], sizes: [1], strides: [1] : memref<?xi32> to memref<1xi32, strided<[1], offset: ?>>
-// CHECK:  %[[CAST3:.*]] = memref.reinterpret_cast %[[ARG3:.*]] to offset: [%{{.*}}], sizes: [1], strides: [1] : memref<?xi32> to memref<1xi32, strided<[1], offset: ?>>
-// CHECK:  %[[ALLOC:.*]] = memref.alloc() : memref<1xi32>
-// CHECK-NEXT:  memref.copy %[[CAST3:.*]], %[[ALLOC:.*]] : memref<1xi32, strided<[1], offset: ?>> to memref<1xi32>
+// CHECK: %[[MASK:.*]] = arith.cmpi slt
+// CHECK: %[[MASK_SIZE:.*]] = arith.index_castui %[[MASK]] : i1 to index
+// CHECK: %[[ATOMIC_PTR:.*]] = memref.reinterpret_cast %{{.*}} to offset: [%{{.*}}], sizes: [1], strides: [1] : memref<?xi32> to memref<1xi32, strided<[1], offset: ?>>
+// CHECK: %[[ATOMIC_VIEW:.*]] = memref.subview %[[ATOMIC_PTR]][0] [%[[MASK_SIZE]]] [1] : memref<1xi32, strided<[1], offset: ?>> to memref<?xi32, strided<[1], offset: ?>>
+// CHECK: %[[ATOMIC_VALUE:.*]] = tensor.extract_slice %{{.*}}[0] [%[[MASK_SIZE]]] [1] : tensor<1xi32> to tensor<?xi32>
+// CHECK: hivm.hir.store ins(%[[ATOMIC_VALUE]] : tensor<?xi32>) outs(%[[ATOMIC_VIEW]] : memref<?xi32, strided<[1], offset: ?>>) atomic = <add>

--- a/third_party/ascend/unittest/pytest_ut/test_indirect_atomic_add.py
+++ b/third_party/ascend/unittest/pytest_ut/test_indirect_atomic_add.py
@@ -29,6 +29,7 @@
 #  | partial structured: high-dim disc + low-dim cont|  -   | (B2) | (B3) | (B4) | (B5) |
 #  | fully unstructured indirect offsets             | (C1) | (C2) | (C3) | (C4) | (C5) |
 #  | loaded mask + masked-off out-of-bounds offsets   | (D1) |  -   |  -   |  -   |  -   |
+#  | scalar-splat mask shared by load and atomic      | (E1) |  -   |  -   |  -   |  -   |
 #
 # Notes:
 # 1. Case A exercises the structured-pointer discrete-mask atomic_add path.
@@ -36,7 +37,9 @@
 #    remaining lower dimensions kept contiguous.
 # 3. Case C exercises fully unstructured indirect offsets.
 # 4. Case D verifies that a loaded discrete mask guards loaded invalid offsets.
-# 5. All cases validate both the final destination tensor and the atomic_add
+# 5. Case E verifies that a scalar-splat mask shared by an indirect load and
+#    atomic_add still guards inactive programs.
+# 6. Cases A-D validate both the final destination tensor and the atomic_add
 #    return value, which must be the old value observed at each access.
 # =============================================================================
 
@@ -110,6 +113,20 @@ def loaded_mask_oob_offset_atomic_add_1d(
     value = tl.load(val_ptr + linear)
     old = tl.atomic_add(out_ptr + offset, value, mask=mask)
     tl.store(old_ptr + linear, old, mask=mask)
+
+
+@triton.jit(do_not_specialize=["numel"])
+def scalar_splat_mask_atomic_add_1d(
+    topk_ids_ptr,
+    tokens_cnts_ptr,
+    numel,
+    TOKENS_PER_THREAD: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * TOKENS_PER_THREAD + tl.arange(0, TOKENS_PER_THREAD)
+    mask = offsets < numel
+    expert_id = tl.load(topk_ids_ptr + offsets, mask=mask, other=0)
+    tl.atomic_add(tokens_cnts_ptr + expert_id, 1, mask=mask)
 
 
 @triton.jit
@@ -589,3 +606,29 @@ def test_atomic_add_loaded_mask_skips_oob_offsets():
     )
     _assert_equal(output, expected_output, "int32", 1, "loaded-mask-oob-offset/output")
     _assert_equal(old, expected_old, "int32", 1, "loaded-mask-oob-offset/old")
+
+
+def test_atomic_add_scalar_splat_mask_skips_inactive_programs():
+    numel = 3
+    grid_size = 8
+    tokens_per_thread = 1
+    sentinel_expert = 3
+
+    # The inactive programs point to a valid sentinel bucket so the regression
+    # is detected deterministically without deliberately triggering an MTE OOB.
+    topk_ids = torch.tensor(
+        [0, 1, 2] + [sentinel_expert] * (grid_size - numel),
+        dtype=torch.int64,
+    ).npu()
+    tokens_cnts = torch.zeros(sentinel_expert + 1, dtype=torch.int32).npu()
+
+    scalar_splat_mask_atomic_add_1d[(grid_size, )](
+        topk_ids,
+        tokens_cnts,
+        numel,
+        TOKENS_PER_THREAD=tokens_per_thread,
+    )
+    torch.npu.synchronize()
+
+    expected = torch.tensor([1, 1, 1, 0], dtype=torch.int32)
+    assert torch.equal(tokens_cnts.cpu(), expected)


### PR DESCRIPTION
## Summary

Fix scalar-splat masks being dropped when the same mask is shared by an indirect load and an atomic RMW operation.

`MaskState::parseSplat` recognizes a splatted `i1` value as a mask only when all of its users consume it as a mask. `LoadOp` and `StoreOp` were handled, but `AtomicRMWOp` was not. Therefore, an atomic user caused the analysis to reject the entire mask, potentially lowering both the load and atomic operation as unconditional single-element accesses.

## Changes

- Recognize `AtomicRMWOp` as a valid mask consumer in `MaskState::parseSplat` to preserve the scalar mask as a dynamic zero-or-one-sized access for both the indirect load and atomic operation.
- Add an end-to-end indirect `atomic_add` test verifying that inactive programs do not update a sentinel expert bucket.
