### PR TITLE
[test](style) Format specialization cache tests with YAPF

### DIFF
--- a/third_party/ascend/unittest/pytest_ut/test_specialization_cache_npu.py
+++ b/third_party/ascend/unittest/pytest_ut/test_specialization_cache_npu.py
@@ -40,14 +40,14 @@ def _clear_kernel_cache(kernel=_add_value):
 
 
 def _run_case(n, src, dst, mode):
-    _add_value[(1,)](src, dst, n, 3, BLOCK=32, compile_mode=mode)
+    _add_value[(1, )](src, dst, n, 3, BLOCK=32, compile_mode=mode)
     torch.npu.synchronize()
     expected = src[:n] + 3
     torch.testing.assert_close(dst[:n], expected)
 
 
 def _run_annotated_case(n, value, src, dst, mode):
-    _add_annotated_value[(1,)](src, dst, n, value, BLOCK=32, compile_mode=mode)
+    _add_annotated_value[(1, )](src, dst, n, value, BLOCK=32, compile_mode=mode)
     torch.npu.synchronize()
     expected = src[:n] + value
     torch.testing.assert_close(dst[:n], expected)

--- a/third_party/ascend/unittest/pytest_ut/test_specialization_cache_unit.py
+++ b/third_party/ascend/unittest/pytest_ut/test_specialization_cache_unit.py
@@ -13,7 +13,6 @@ from triton.backends.ascend.compiler import AscendBackend
 from triton.backends.compiler import GPUTarget
 from triton.runtime.jit import KernelParam, compute_cache_key, create_function_from_signature
 
-
 pytestmark = pytest.mark.backend("native")
 
 
@@ -160,8 +159,8 @@ def test_annotated_integer_one_keeps_constexpr_specialization(options):
 
     assert one_specialization == [("constexpr", 1)]
     assert two_specialization == [(annotation, "")]
-    assert compute_cache_key(cache, one_specialization, one_options) != compute_cache_key(
-        cache, two_specialization, two_options)
+    assert compute_cache_key(cache, one_specialization,
+                             one_options) != compute_cache_key(cache, two_specialization, two_options)
 
 
 @pytest.mark.parametrize("options", [SIMD_OPTIONS[0], *SIMT_OPTIONS])


### PR DESCRIPTION
## Summary

- Format the Ascend specialization cache tests added in #1480 with the repository-pinned YAPF version.
- Keep the change formatting-only; the Python AST and runtime behavior are unchanged.

## Testing

- Relevant pre-commit hooks for both modified files: passed
- CPU/native specialization tests: `159 passed`
- `git diff --check`