### PR TITLE
[AtomicOp](fix) Extend atomic min/max canonicalization

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
@@ -1138,14 +1138,32 @@ AtomicMaxMinCanonicalizer::matchAndRewrite(triton::AtomicRMWOp op,
                                            PatternRewriter &rewriter) const {
   // Revert the op to its original form
   auto ptrBitcastOp = op.getPtr().getDefiningOp<triton::BitcastOp>();
+  triton::SplatOp ptrSplatOp;
+  if (!ptrBitcastOp) {
+    // For tensor atomics on a scalar base pointer, semantic.py emits
+    //   splat(bitcast(ptr<f32> -> ptr<i32>))
+    // instead of
+    //   bitcast(tensor<ptr<f32>> -> tensor<ptr<i32>>).
+    // Accept both forms so the expanded integer atomics can be fused before
+    // discrete-mask conversion.
+    ptrSplatOp = op.getPtr().getDefiningOp<triton::SplatOp>();
+    if (ptrSplatOp)
+      ptrBitcastOp = ptrSplatOp.getSrc().getDefiningOp<triton::BitcastOp>();
+  }
   auto valueBitcastOp = op.getVal().getDefiningOp<triton::BitcastOp>();
   if (!ptrBitcastOp || !valueBitcastOp) {
     return failure();
   }
 
+  auto eraseDeadPointerCasts = [&]() {
+    if (ptrSplatOp && ptrSplatOp->use_empty())
+      rewriter.eraseOp(ptrSplatOp);
+    if (ptrBitcastOp->use_empty())
+      rewriter.eraseOp(ptrBitcastOp);
+  };
+
   // We only need to handle the op when the element type is float
-  auto elementType =
-      dyn_cast<TensorType>(valueBitcastOp.getSrc().getType()).getElementType();
+  auto elementType = getElementTypeOrSelf(valueBitcastOp.getSrc().getType());
   if (!isa<FloatType>(elementType)) {
     return failure();
   }
@@ -1158,8 +1176,7 @@ AtomicMaxMinCanonicalizer::matchAndRewrite(triton::AtomicRMWOp op,
     // if the return value of op is used, we can't simply erase it
     if (op.getResult().use_empty()) {
       rewriter.eraseOp(op);
-      if (ptrBitcastOp->use_empty())
-        rewriter.eraseOp(ptrBitcastOp);
+      eraseDeadPointerCasts();
       return success();
     }
     return failure();
@@ -1178,6 +1195,19 @@ AtomicMaxMinCanonicalizer::matchAndRewrite(triton::AtomicRMWOp op,
   //
   // Here wanna extract original mask
   Value originalMask = op.getMask();
+  auto createAllTrueMask = [&]() -> Value {
+    Type maskType = op.getMask().getType();
+    if (auto shapedMaskType = dyn_cast<ShapedType>(maskType)) {
+      return rewriter.create<arith::ConstantOp>(
+          op->getLoc(), DenseElementsAttr::get(shapedMaskType, true));
+    }
+    if (maskType.isInteger(1)) {
+      return rewriter.create<arith::ConstantOp>(op->getLoc(),
+                                                rewriter.getBoolAttr(true));
+    }
+    return {};
+  };
+
   if (auto andOp = originalMask.getDefiningOp<arith::AndIOp>())
     // LHS is convention in semantic interpreter
     originalMask = andOp.getLhs();
@@ -1200,9 +1230,23 @@ AtomicMaxMinCanonicalizer::matchAndRewrite(triton::AtomicRMWOp op,
       return op->emitError("Illegal mask for atomicrmwOp of float type");
 
     // Restore the implicit all-true mask.
-    originalMask = rewriter.create<arith::ConstantOp>(
-        op->getLoc(),
-        DenseElementsAttr::get(cast<ShapedType>(op.getMask().getType()), true));
+    originalMask = createAllTrueMask();
+    if (!originalMask)
+      return failure();
+  } else if (auto cmpOp = originalMask.getDefiningOp<arith::CmpIOp>()) {
+    // Scalar floating-point atomic max/min represents !signbit as:
+    //   shrui(value_bits, 31/63) -> cmpi eq 0.
+    if (cmpOp.getPredicate() != arith::CmpIPredicate::eq ||
+        !matchPattern(cmpOp.getRhs(), m_Zero()))
+      return failure();
+
+    auto shiftOp = cmpOp.getLhs().getDefiningOp<arith::ShRUIOp>();
+    if (!shiftOp || shiftOp.getLhs() != valueBitcastOp.getResult())
+      return failure();
+
+    originalMask = createAllTrueMask();
+    if (!originalMask)
+      return failure();
   } else if (auto cmpOp = originalMask.getDefiningOp<arith::CmpFOp>()) {
     if (cmpOp.getPredicate() != mlir::arith::CmpFPredicate::OGE ||
         !matchPattern(cmpOp.getRhs(),
@@ -1210,16 +1254,27 @@ AtomicMaxMinCanonicalizer::matchAndRewrite(triton::AtomicRMWOp op,
       // Here recheck frontend interpreter generation in no manual mask state
       return op->emitError("Illegal mask for atomicrmwOp of float type");
     // Restore original true mask
-    originalMask = rewriter.create<arith::ConstantOp>(
-        op->getLoc(),
-        /*typed attr*/ DenseElementsAttr::get(
-            cast<ShapedType>(originalMask.getType()), true));
+    originalMask = createAllTrueMask();
+    if (!originalMask)
+      return failure();
   } else
     return op->emitError("Illegal mask for atomicrmwOp of float type");
 
+  Value originalPtr = ptrBitcastOp.getSrc();
+  if (ptrSplatOp) {
+    auto ptrTensorType = dyn_cast<RankedTensorType>(op.getPtr().getType());
+    if (!ptrTensorType)
+      return failure();
+    auto originalPtrType = RankedTensorType::get(
+        ptrTensorType.getShape(), ptrBitcastOp.getSrc().getType(),
+        ptrTensorType.getEncoding());
+    originalPtr = rewriter.create<triton::SplatOp>(op.getLoc(), originalPtrType,
+                                                   ptrBitcastOp.getSrc());
+  }
+
   auto originAtomicOp = rewriter.create<triton::AtomicRMWOp>(
       op.getLoc(), valueBitcastOp.getSrc().getType(), op.getAtomicRmwOp(),
-      ptrBitcastOp.getSrc(), valueBitcastOp.getSrc(), originalMask, op.getSem(),
+      originalPtr, valueBitcastOp.getSrc(), originalMask, op.getSem(),
       op.getScope());
 
   // if the return value of op is used
@@ -1259,10 +1314,9 @@ AtomicMaxMinCanonicalizer::matchAndRewrite(triton::AtomicRMWOp op,
     rewriter.eraseOp(op);
   }
 
-  // The restored atomic uses ptrBitcastOp.getSrc(), i.e. the original GM
-  // pointer. Remove the pointer bitcast once the paired integer atomic is gone.
-  if (ptrBitcastOp->use_empty())
-    rewriter.eraseOp(ptrBitcastOp);
+  // The restored atomic uses the original floating-point GM pointer. Remove
+  // the expanded pointer splat/bitcast once the paired integer atomic is gone.
+  eraseDeadPointerCasts();
 
   return success();
 }

--- a/third_party/ascend/unittest/Conversion/General/DiscreteMaskAccess/atomic.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DiscreteMaskAccess/atomic.mlir
@@ -232,3 +232,51 @@ tt.func @atomic_add_cont_disc_i32(%arg0: !tt.ptr<i32>, %arg1: i32) {
   %16 = tt.atomic_rmw add, acq_rel, gpu, %15, %cst_3, %9 : (tensor<8x8x!tt.ptr<i32>>, tensor<8x8xi32>, tensor<8x8xi1>) -> tensor<8x8xi32>
   tt.return
 }
+
+// -----
+
+// CHECK-LABEL: tt.func @atomic_min_f32_splat_bitcast
+// CHECK: %[[VALUE_PTR:.*]] = tt.addptr %arg0, %{{.*}} : !tt.ptr<f32>, i32
+// CHECK: %[[VALUE_PTRS:.*]] = tt.splat %[[VALUE_PTR]] : !tt.ptr<f32> -> tensor<1x1x1x1x!tt.ptr<f32>>
+// CHECK: %[[VALUE:.*]] = tt.load %[[VALUE_PTRS]] : tensor<1x1x1x1x!tt.ptr<f32>>
+// CHECK: %[[OUTPUT_PTR:.*]] = tt.addptr %arg1, %{{.*}} : !tt.ptr<f32>, i32
+// CHECK: %[[OUTPUT_PTRS:.*]] = tt.splat %[[OUTPUT_PTR]] : !tt.ptr<f32> -> tensor<1x1x1x1x!tt.ptr<f32>>
+// CHECK: tt.atomic_rmw min, acq_rel, gpu, %[[OUTPUT_PTRS]], %[[VALUE]], %{{.*}} : (tensor<1x1x1x1x!tt.ptr<f32>>, tensor<1x1x1x1xf32>, tensor<1x1x1x1xi1>) -> tensor<1x1x1x1xf32>
+// CHECK-NOT: tt.atomic_rmw umax
+tt.func @atomic_min_f32_splat_bitcast(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>) {
+  %c0_i32 = arith.constant 0 : i32
+  %cst = arith.constant dense<0> : tensor<1x1x1x1xi32>
+  %cst_0 = arith.constant dense<31> : tensor<1x1x1x1xi32>
+  %cst_1 = arith.constant dense<true> : tensor<1x1x1x1xi1>
+  %0 = tt.addptr %arg0, %c0_i32 : !tt.ptr<f32>, i32
+  %1 = tt.splat %0 : !tt.ptr<f32> -> tensor<1x1x1x1x!tt.ptr<f32>>
+  %2 = tt.load %1 : tensor<1x1x1x1x!tt.ptr<f32>>
+  %3 = tt.addptr %arg1, %c0_i32 : !tt.ptr<f32>, i32
+  %4 = tt.bitcast %2 : tensor<1x1x1x1xf32> -> tensor<1x1x1x1xi32>
+  %5 = tt.bitcast %3 : !tt.ptr<f32> -> !tt.ptr<i32>
+  %6 = tt.splat %5 : !tt.ptr<i32> -> tensor<1x1x1x1x!tt.ptr<i32>>
+  %7 = arith.shrui %4, %cst_0 : tensor<1x1x1x1xi32>
+  %8 = arith.cmpi ne, %7, %cst : tensor<1x1x1x1xi32>
+  %9 = arith.xori %8, %cst_1 : tensor<1x1x1x1xi1>
+  %10 = tt.atomic_rmw min, acq_rel, gpu, %6, %4, %9 : (tensor<1x1x1x1x!tt.ptr<i32>>, tensor<1x1x1x1xi32>, tensor<1x1x1x1xi1>) -> tensor<1x1x1x1xi32>
+  %11 = tt.atomic_rmw umax, acq_rel, gpu, %6, %4, %8 : (tensor<1x1x1x1x!tt.ptr<i32>>, tensor<1x1x1x1xi32>, tensor<1x1x1x1xi1>) -> tensor<1x1x1x1xi32>
+  tt.return
+}
+
+// -----
+
+// CHECK-LABEL: tt.func @atomic_max_f32_scalar
+// CHECK: tt.atomic_rmw max, acq_rel, gpu, %arg1, %arg0, %{{.*}} : (!tt.ptr<f32>, f32, i1) -> f32
+// CHECK-NOT: tt.atomic_rmw umin
+tt.func @atomic_max_f32_scalar(%arg0: f32, %arg1: !tt.ptr<f32>) {
+  %c31_i32 = arith.constant 31 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %0 = tt.bitcast %arg0 : f32 -> i32
+  %1 = tt.bitcast %arg1 : !tt.ptr<f32> -> !tt.ptr<i32>
+  %2 = arith.shrui %0, %c31_i32 : i32
+  %3 = arith.cmpi eq, %2, %c0_i32 : i32
+  %4 = arith.cmpi ne, %2, %c0_i32 : i32
+  %5 = tt.atomic_rmw max, acq_rel, gpu, %1, %0, %3 : (!tt.ptr<i32>, i32, i1) -> i32
+  %6 = tt.atomic_rmw umin, acq_rel, gpu, %1, %0, %4 : (!tt.ptr<i32>, i32, i1) -> i32
+  tt.return
+}

--- a/third_party/ascend/unittest/pytest_ut/test_atomic_max.py
+++ b/third_party/ascend/unittest/pytest_ut/test_atomic_max.py
@@ -52,6 +52,20 @@ def triton_test_fn_atomic_max_dma_supply(in_ptr0, out_ptr0, n_elements: tl.const
     tmp1 = tl.atomic_max(out_ptr0 + (x1), tmp0, xmask)
 
 
+@triton.jit
+def float_scalar_atomic_max_kernel(
+    value_ptr,
+    output_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    values = tl.load(value_ptr + offsets, mask=mask, other=-1.0e9)
+    block_max = tl.max(values, axis=0)
+    tl.atomic_max(output_ptr, block_max)
+
+
 # torch.max do not support int
 @pytest.mark.parametrize('param_list', [
     ['int32', (32, 32), 2],
@@ -98,6 +112,25 @@ def test_atomic_max_2d_supply(dtype, shape):
     n_elements = shape[0] * shape[1]
     triton_test_fn_atomic_max_dma_supply[shape[0], 1, 1](x0, x1, n_elements, BLOCK_SIZE=shape[1])
     test_common.validate_cmp(dtype, x1, x1_ref)
+
+
+def test_float_scalar_atomic_max():
+    n_elements = 257
+    block_size = 1024
+
+    values_cpu = torch.linspace(-4.0, 4.0, n_elements, dtype=torch.float32, device="cpu")
+    values = values_cpu.npu()
+    output = torch.full((1, ), float("-inf"), dtype=torch.float32, device="npu")
+
+    float_scalar_atomic_max_kernel[(1, )](
+        values,
+        output,
+        n_elements,
+        BLOCK_SIZE=block_size,
+    )
+
+    expected = values_cpu.max().reshape(1)
+    torch.testing.assert_close(output.cpu(), expected, rtol=0, atol=0)
 
 
 # if __name__ == "__main__":


### PR DESCRIPTION
## Background

PR [[#1460](https://github.com/triton-lang/triton-ascend/pull/1460)](https://github.com/triton-lang/triton-ascend/pull/1460) introduced `AtomicMaxMinCanonicalizer` to fuse the integer atomic operations expanded from floating-point `atomic_min`/`atomic_max` back into a single floating-point atomic operation before discrete-mask conversion.

However, the canonicalizer did not cover the following two IR forms.

## Changes

1. **Support scalar floating-point atomic min/max**

   Floating-point atomics whose value is produced by a scalar reduction use scalar types instead of `TensorType`. Their positive sign mask is also represented as:

   ```mlir
   %sign = arith.shrui %value_bits, %c31_i32 : i32
   %positive = arith.cmpi eq, %sign, %c0_i32 : i32
   ```

   Extend the canonicalizer to:

   * Obtain the element type from both scalar and tensor values.
   * Recognize the scalar `cmpi eq 0` sign-mask form.
   * Create an all-true mask for both scalar and shaped atomic operations.

2. **Support pointers represented as `splat(bitcast(ptr))`**

   For tensor atomics constructed from a scalar base pointer, the pointer conversion may be represented as:

   ```mlir
   %int_ptr = tt.bitcast %float_ptr : !tt.ptr<f32> -> !tt.ptr<i32>
   %int_ptrs = tt.splat %int_ptr : !tt.ptr<i32> -> tensor<...x!tt.ptr<i32>>
   ```

   PR #1460 only recognized atomics whose pointer was directly defined by `tt.bitcast`.

   Extend the canonicalizer to recognize both direct `bitcast` and `splat(bitcast(ptr))` forms, rebuild the corresponding floating-point pointer tensor, and remove dead pointer splat/bitcast operations after fusion.

## Test

* Add regression coverage for scalar floating-point `atomic_max`.
* Add regression coverage for 4D floating-point `atomic_min` using a splatted scalar base pointer.