### PR TITLE
[UBOverflowChecker](fix) Refine UB estimation

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/SeparateMemoryFromCompute/UBOverflowChecker.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SeparateMemoryFromCompute/UBOverflowChecker.h
@@ -26,6 +26,7 @@
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Pass/Pass.h"
@@ -51,8 +52,16 @@ struct BufferInfo {
   int64_t originalSize = 0;
   int64_t reducedSize = 0;
   int64_t alignedSize = 0;
+  int64_t multiBufferCount = 1;
   scf::ForOp forOp = nullptr;
   bool fromHint = false;
+};
+
+struct TensorInfo {
+  tensor::EmptyOp emptyOp = nullptr;
+  int64_t originalSize = 0;
+  int64_t reducedSize = 0;
+  int64_t alignedSize = 0;
 };
 
 struct UBEstimateResult {
@@ -79,9 +88,14 @@ int getAlignUnit(Type elementType);
 
 SmallVector<BufferInfo> collectBuffers(ModuleOp module);
 
+SmallVector<TensorInfo> collectTensorEmpties(ModuleOp module);
+
 void computeBufferSize(BufferInfo &buf);
 
-UBEstimateResult checkUBOverflow(ModuleOp module);
+void computeTensorSize(TensorInfo &tensor);
+
+UBEstimateResult checkUBOverflow(ArrayRef<BufferInfo> buffers,
+                                 ArrayRef<TensorInfo> tensors);
 
 LogicalResult pruneMultiBufferMarks(ModuleOp module);
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/MarkGMLoadPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/MarkGMLoadPass.cpp
@@ -303,21 +303,6 @@ void MarkGMLoadPass::runOnOperation() {
     return;
   }
 
-  // Skip marking for the sdpa infer kernel.
-  bool isSdpaInferKernel = false;
-  module.walk([&](func::FuncOp funcOp) -> WalkResult {
-    if (funcOp.getSymName() == "_sdpa_infer_kernel" ||
-        funcOp.getSymName() == "kernel_sdpa_fwd") {
-      isSdpaInferKernel = true;
-      return WalkResult::interrupt();
-    }
-    return WalkResult::advance();
-  });
-  if (isSdpaInferKernel) {
-    LOG_DEBUG("kernel _sdpa_infer_kernel: skip GM load marking");
-    return;
-  }
-
   LOG_DEBUG("Enter MarkGMLoad pass");
 
   // Phase 1: collect candidates (read-only).

--- a/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/UBOverflowChecker.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SeparateMemoryFromCompute/UBOverflowChecker.cpp
@@ -30,11 +30,11 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinTypes.h"
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/MathExtras.h"
 
 #include <algorithm>
-#include <limits>
 
 using namespace mlir;
 using namespace triton;
@@ -76,17 +76,15 @@ SmallVector<BufferInfo> triton::collectBuffers(ModuleOp module) {
 
       annotation::MarkOp markOp = findMarkOp(allocOp);
       if (markOp) {
-        if (markOp->hasAttr(hivm::MultiBufferAttr::name)) {
+        if (auto attr = markOp->getAttrOfType<IntegerAttr>(
+                hivm::MultiBufferAttr::name)) {
           buf.kind = BufferInfo::Kind::Annot;
           buf.markOp = markOp;
+          buf.multiBufferCount = std::max<int64_t>(attr.getInt(), 1);
           buf.fromHint = markOp->hasAttr(CVPipeline::kGMLoadHintAttr);
           if (buf.fromHint)
             markOp->removeAttr(CVPipeline::kGMLoadHintAttr);
-        } else {
-          buf.kind = BufferInfo::Kind::Unannot;
         }
-      } else {
-        buf.kind = BufferInfo::Kind::Unannot;
       }
 
       buffers.push_back(buf);
@@ -99,131 +97,167 @@ SmallVector<BufferInfo> triton::collectBuffers(ModuleOp module) {
   return buffers;
 }
 
-void triton::computeBufferSize(BufferInfo &buf) {
-  auto memrefType = mlir::cast<MemRefType>(buf.allocOp.getResult().getType());
-  ArrayRef<int64_t> shape = memrefType.getShape();
-  Type elementType = memrefType.getElementType();
+SmallVector<TensorInfo> triton::collectTensorEmpties(ModuleOp module) {
+  SmallVector<TensorInfo> tensors;
+
+  module.walk([&](scope::ScopeOp scopeOp) {
+    bool isCube = false;
+    bool isVector = false;
+    if (failed(getScopeType(scopeOp, isCube, isVector)) || !isVector)
+      return WalkResult::advance();
+
+    scopeOp.walk([&](tensor::EmptyOp emptyOp) {
+      if (emptyOp->getParentOfType<scope::ScopeOp>() != scopeOp)
+        return;
+
+      auto tensorType = emptyOp.getType();
+      if (!tensorType.hasStaticShape() || tensorType.getRank() == 0 ||
+          llvm::any_of(tensorType.getShape(),
+                       [](int64_t dim) { return dim == 0; })) {
+        LOG_DEBUG("unsupported tensor.empty shape, skipping " << emptyOp);
+        return;
+      }
+
+      TensorInfo tensor;
+      tensor.emptyOp = emptyOp;
+      LOG_DEBUG("tensor.empty: " << emptyOp);
+      tensors.push_back(tensor);
+    });
+
+    return WalkResult::advance();
+  });
+
+  LOG_DEBUG("collected " << tensors.size() << " tensor.empty ops");
+  return tensors;
+}
+
+static void computeShapedSize(ShapedType shapedType, int64_t &originalSize,
+                              int64_t &reducedSize, int64_t &alignedSize) {
+  ArrayRef<int64_t> shape = shapedType.getShape();
+  Type elementType = shapedType.getElementType();
   unsigned bitWidth = elementType.getIntOrFloatBitWidth();
 
-  for (auto dim : shape) {
-    if (ShapedType::isDynamic(dim)) {
-      LOG_DEBUG("dynamic dim encountered, skipping size computation for "
-                << buf.allocOp);
-      return;
-    }
-  }
-
-  if (shape.empty() || shape[0] == 0) {
-    LOG_DEBUG("zero-sized or rank-0 buffer, skipping size computation");
+  if (!shapedType.hasStaticShape() || shape.empty() || bitWidth == 0 ||
+      llvm::any_of(shape, [](int64_t dim) { return dim == 0; })) {
+    LOG_DEBUG("unsupported shape, skipping size computation");
     return;
   }
 
   int64_t numElements = 1;
   for (auto dim : shape) {
-    if (numElements > std::numeric_limits<int64_t>::max() / dim) {
-      LOG_DEBUG("overflow in element count computation, clamping");
-      numElements = std::numeric_limits<int64_t>::max();
-      break;
-    }
     numElements *= dim;
   }
-  buf.originalSize = numElements * bitWidth;
+  originalSize = numElements * bitWidth;
 
-  // TileAndBindSubBlock: dim0 = ceil(dim0 / K_SUB_BLOCK_DIM)
+  // TileAndBindSubBlock splits dim0 across two sub-blocks (one-to-two):
+  // reducedDim0 = ceil(dim0 / K_SUB_BLOCK_DIM), where K_SUB_BLOCK_DIM = 2.
   int64_t reducedDim0 = (shape[0] + UBConstants::K_SUB_BLOCK_DIM - 1) /
                         UBConstants::K_SUB_BLOCK_DIM;
-  int64_t reducedElements = numElements * reducedDim0 / shape[0];
-  buf.reducedSize = reducedElements * bitWidth;
+  int64_t reducedElements = numElements / shape[0] * reducedDim0;
+  reducedSize = reducedElements * bitWidth;
 
-  // EnableStrideAlign: align last dim to 32B
-  int64_t lastDim = (shape.size() == 1) ? reducedDim0 : shape.back();
-  int alignUnit = getAlignUnit(elementType);
-
-  if (lastDim % alignUnit != 0) {
-    int64_t alignedLastDim = (lastDim + alignUnit - 1) / alignUnit * alignUnit;
-    buf.alignedSize =
-        (buf.reducedSize * alignedLastDim + lastDim - 1) / lastDim;
-    buf.alignedSize =
-        llvm::alignTo(buf.alignedSize, UBConstants::ALIGN_UNIT_BITS);
-  } else {
-    buf.alignedSize = buf.reducedSize;
+  int64_t lastDim = shape.size() == 1 ? reducedDim0 : shape.back();
+  int64_t alignUnit = getAlignUnit(elementType);
+  if (lastDim % alignUnit == 0) {
+    alignedSize = reducedSize;
+    return;
   }
+
+  int64_t alignedLastDim = (lastDim + alignUnit - 1) / alignUnit * alignUnit;
+  alignedSize = (reducedSize * alignedLastDim + lastDim - 1) / lastDim;
+  alignedSize = llvm::alignTo(alignedSize, UBConstants::ALIGN_UNIT_BITS);
 }
 
-UBEstimateResult triton::checkUBOverflow(ModuleOp module) {
-  auto buffers = collectBuffers(module);
-  for (auto &buf : buffers)
-    computeBufferSize(buf);
+void triton::computeBufferSize(BufferInfo &buf) {
+  auto memrefType = mlir::cast<MemRefType>(buf.allocOp.getResult().getType());
+  computeShapedSize(memrefType, buf.originalSize, buf.reducedSize,
+                    buf.alignedSize);
+}
 
+void triton::computeTensorSize(TensorInfo &tensor) {
+  computeShapedSize(tensor.emptyOp.getType(), tensor.originalSize,
+                    tensor.reducedSize, tensor.alignedSize);
+}
+
+UBEstimateResult triton::checkUBOverflow(ArrayRef<BufferInfo> buffers,
+                                         ArrayRef<TensorInfo> tensors) {
   UBEstimateResult result;
-  int64_t total = 0;
-  for (auto &buf : buffers) {
-    if (buf.alignedSize <= 0)
-      continue;
-    int64_t n = 1;
-    if (buf.kind == BufferInfo::Kind::Annot && buf.markOp)
-      if (auto attr = buf.markOp->getAttrOfType<IntegerAttr>(
-              hivm::MultiBufferAttr::name))
-        n = attr.getInt();
-    // Conservative: assume full expansion (alignedSize × N). Will be
-    // refined with PlanMemory-based for-loop tree model later.
-    total += buf.alignedSize * n;
+  for (const auto &buf : buffers) {
+    if (buf.alignedSize > 0)
+      result.totalBits += buf.alignedSize * buf.multiBufferCount;
   }
-
-  result.totalBits = total;
+  for (const auto &tensor : tensors) {
+    if (tensor.alignedSize > 0)
+      result.totalBits += tensor.alignedSize;
+  }
 
   LOG_DEBUG("UB = " << result.totalBits << " bits");
   return result;
 }
 
+static SmallVector<size_t>
+collectPruneCandidates(ArrayRef<BufferInfo> buffers) {
+  SmallVector<size_t> candidates;
+  for (size_t index = 0; index < buffers.size(); ++index) {
+    const auto &buf = buffers[index];
+    if (buf.kind == BufferInfo::Kind::Annot && buf.markOp &&
+        buf.alignedSize > 0 && !buf.fromHint)
+      candidates.push_back(index);
+  }
+  return candidates;
+}
+
+static bool shouldPrune(const UBEstimateResult &result,
+                        ArrayRef<size_t> candidates) {
+  LOG_DEBUG("initial UB = " << result.totalBits << " bits, max = "
+                            << UBConstants::UB_SPACE_SIZE_BITS << " bits");
+
+  if (result.totalBits <= UBConstants::UB_SPACE_SIZE_BITS) {
+    LOG_DEBUG("safe, no pruning needed");
+    return false;
+  }
+
+  if (candidates.empty()) {
+    LOG_DEBUG("no computable multi_buffer marks to prune");
+    return false;
+  }
+
+  LOG_DEBUG("collected " << candidates.size() << " annot marks");
+  return true;
+}
+
 LogicalResult triton::pruneMultiBufferMarks(ModuleOp module) {
+  // Step 1: collect buffers and tensors once, then compute their static sizes.
   auto buffers = collectBuffers(module);
   for (auto &buf : buffers)
     computeBufferSize(buf);
 
-  int64_t total = 0;
-  SmallVector<std::pair<annotation::MarkOp, int64_t>> annotMarks;
-  for (auto &buf : buffers) {
-    if (buf.alignedSize <= 0)
-      continue;
-    int64_t n = 1;
-    if (buf.kind == BufferInfo::Kind::Annot && buf.markOp)
-      if (auto attr = buf.markOp->getAttrOfType<IntegerAttr>(
-              hivm::MultiBufferAttr::name))
-        n = attr.getInt();
-    total += buf.alignedSize * n;
+  auto tensors = collectTensorEmpties(module);
+  for (auto &tensor : tensors)
+    computeTensorSize(tensor);
 
-    if (buf.kind == BufferInfo::Kind::Annot && buf.markOp &&
-        buf.alignedSize > 0 && !buf.fromHint) {
-      annotMarks.push_back({buf.markOp, buf.alignedSize});
-    }
-  }
-
-  LOG_DEBUG("initial UB = " << total << " bits, max = "
-                            << UBConstants::UB_SPACE_SIZE_BITS << " bits");
-
-  if (total <= UBConstants::UB_SPACE_SIZE_BITS) {
-    LOG_DEBUG("safe, no pruning needed");
+  // Step 2: compute the initial UB usage and collect pruning candidates.
+  auto result = checkUBOverflow(buffers, tensors);
+  auto candidates = collectPruneCandidates(buffers);
+  if (!shouldPrune(result, candidates))
     return success();
-  }
 
-  if (annotMarks.empty()) {
-    LOG_DEBUG("no computable multi_buffer marks to prune");
-    return success();
-  }
+  // Step 3: sort eligible non-hint marks by buffer size, largest first.
+  llvm::sort(candidates, [&](size_t lhs, size_t rhs) {
+    return buffers[lhs].alignedSize > buffers[rhs].alignedSize;
+  });
 
-  llvm::sort(annotMarks,
-             [](const auto &a, const auto &b) { return a.second > b.second; });
-
-  LOG_DEBUG("collected " << annotMarks.size() << " annot marks");
-
+  // Step 4: remove marks one by one, update BufferInfo, and fully re-estimate.
   int deleted = 0;
-  for (auto &[markOp, size] : annotMarks) {
-    markOp->removeAttr(hivm::MultiBufferAttr::name);
+  for (size_t index : candidates) {
+    auto &buf = buffers[index];
+    buf.markOp->removeAttr(hivm::MultiBufferAttr::name);
+    buf.kind = BufferInfo::Kind::Unannot;
+    buf.multiBufferCount = 1;
     ++deleted;
 
-    auto result = checkUBOverflow(module);
-    LOG_DEBUG("after deleting mark #" << deleted << " (size " << size
+    result = checkUBOverflow(buffers, tensors);
+    LOG_DEBUG("after deleting mark #" << deleted << " (size " << buf.alignedSize
                                       << " bits): UB = " << result.totalBits
                                       << " bits");
 

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/ub_overflow_check.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/ub_overflow_check.mlir
@@ -134,3 +134,84 @@ func.func @hint_protected_kept() {
   } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
   return
 }
+
+
+// -----
+
+// ============================================================================
+// Test 5: Hint protection survives multiple pruning rounds.
+//   Hint: 256x144xf32, alignedSize=589824, expanded=1179648.
+//   Auto: two 256x96xf32, alignedSize=393216, expanded=786432 each.
+//   Initial=2752512; after one prune=2359296; after two=1966080.
+// ============================================================================
+
+func.func @multi_round_hint_protection() {
+  // CHECK-LABEL: func.func @multi_round_hint_protection
+  // CHECK-NOT: gm_load_hint
+
+  scope.scope : () -> () {
+    // CHECK: memref.alloc() : memref<256x144xf32>
+    // CHECK-NEXT: annotation.mark %{{.*}} {hivm.multi_buffer = 2 : i32} : memref<256x144xf32>
+    %hint = memref.alloc() : memref<256x144xf32>
+    annotation.mark %hint {gm_load_hint, hivm.multi_buffer = 2 : i32} : memref<256x144xf32>
+
+    // CHECK: memref.alloc() : memref<256x96xf32>
+    // CHECK-NEXT: annotation.mark %{{.*}} : memref<256x96xf32>
+    %auto1 = memref.alloc() : memref<256x96xf32>
+    annotation.mark %auto1 {hivm.multi_buffer = 2 : i32} : memref<256x96xf32>
+
+    // CHECK: memref.alloc() : memref<256x96xf32>
+    // CHECK-NEXT: annotation.mark %{{.*}} : memref<256x96xf32>
+    %auto2 = memref.alloc() : memref<256x96xf32>
+    annotation.mark %auto2 {hivm.multi_buffer = 2 : i32} : memref<256x96xf32>
+    scope.return
+  } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+  return
+}
+
+// -----
+
+// ============================================================================
+// Test 6: A blind tensor.empty contributes to UB and triggers pruning.
+//   Alloc expanded=1572864; tensor=524288; total=2097152 > 2031616.
+// ============================================================================
+
+func.func @blind_tensor_triggers_pruning() {
+  // CHECK-LABEL: func.func @blind_tensor_triggers_pruning
+
+  scope.scope : () -> () {
+    // CHECK: memref.alloc() : memref<256x192xf32>
+    // CHECK-NEXT: annotation.mark %{{.*}} : memref<256x192xf32>
+    %alloc = memref.alloc() : memref<256x192xf32>
+    annotation.mark %alloc {hivm.multi_buffer = 2 : i32} : memref<256x192xf32>
+
+    // CHECK: tensor.empty() : tensor<256x128xf32>
+    %empty = tensor.empty() : tensor<256x128xf32>
+    scope.return
+  } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+  return
+}
+
+// -----
+
+// ============================================================================
+// Test 7: A same-shape tensor.empty is still counted independently.
+//   Alloc expanded=1572864; tensor=786432; total=2359296 > 2031616.
+//   Removing the mark leaves 1572864 bits, which is safe.
+// ============================================================================
+
+func.func @same_shape_tensor_counted() {
+  // CHECK-LABEL: func.func @same_shape_tensor_counted
+
+  scope.scope : () -> () {
+    // CHECK: memref.alloc() : memref<256x192xf32>
+    // CHECK-NEXT: annotation.mark %{{.*}} : memref<256x192xf32>
+    %alloc = memref.alloc() : memref<256x192xf32>
+    annotation.mark %alloc {hivm.multi_buffer = 2 : i32} : memref<256x192xf32>
+
+    // CHECK: tensor.empty() : tensor<256x192xf32>
+    %empty = tensor.empty() : tensor<256x192xf32>
+    scope.return
+  } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+  return
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/ub_overflow_sdpa.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SeparateMemoryFromCompute/ub_overflow_sdpa.mlir
@@ -1,0 +1,60 @@
+// RUN: triton-opt -split-input-file --ub-overflow-check %s | FileCheck %s
+// RUN: triton-opt -split-input-file --ub-overflow-check --debug-only=UBOverflow %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=DEBUG
+
+// The allocs below match the SDPA dump. With the mask double-buffered,
+// alloc-only UB is 1318912 bits (161 KiB), so the mark is safe.
+
+// CHECK-LABEL: func.func @alloc_only_keeps_mark
+func.func @alloc_only_keeps_mark() {
+  scope.scope : () -> () {
+    %cbuf = memref.alloc() : memref<16x8x16x16xf16, #hivm.address_space<cbuf>>
+    %a0 = memref.alloc() : memref<128x256xf32, #hivm.address_space<ub>>
+    %a1 = memref.alloc() : memref<128x128xf32, #hivm.address_space<ub>>
+    %a2 = memref.alloc() : memref<128xf32, #hivm.address_space<ub>>
+    %a3 = memref.alloc() : memref<128xf32, #hivm.address_space<ub>>
+    %a4 = memref.alloc() : memref<128xf32, #hivm.address_space<ub>>
+    %a5 = memref.alloc() : memref<128xf32, #hivm.address_space<ub>>
+    // CHECK: %[[SAFE_MASK:.*]] = memref.alloc() : memref<128x256xi8>
+    // CHECK-NEXT: annotation.mark %[[SAFE_MASK]] {hivm.multi_buffer = 2 : i32} : memref<128x256xi8>
+    %mask = memref.alloc() : memref<128x256xi8>
+    annotation.mark %mask {hivm.multi_buffer = 2 : i32} : memref<128x256xi8>
+    scope.return
+  } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+  return
+}
+
+// DEBUG: initial UB = 1318912 bits, max = 2031616 bits
+// DEBUG: safe, no pruning needed
+
+// -----
+
+// The five tensor.empty ops add 1181696 bits (144.25 KiB).
+// Total UB becomes 2500608 bits (305.25 KiB), so the mark must be pruned.
+
+// CHECK-LABEL: func.func @tensor_sizes_prune_mark
+func.func @tensor_sizes_prune_mark() {
+  scope.scope : () -> () {
+    %cbuf = memref.alloc() : memref<16x8x16x16xf16, #hivm.address_space<cbuf>>
+    %a0 = memref.alloc() : memref<128x256xf32, #hivm.address_space<ub>>
+    %a1 = memref.alloc() : memref<128x128xf32, #hivm.address_space<ub>>
+    %a2 = memref.alloc() : memref<128xf32, #hivm.address_space<ub>>
+    %a3 = memref.alloc() : memref<128xf32, #hivm.address_space<ub>>
+    %a4 = memref.alloc() : memref<128xf32, #hivm.address_space<ub>>
+    %a5 = memref.alloc() : memref<128xf32, #hivm.address_space<ub>>
+    // CHECK: %[[PRUNED_MASK:.*]] = memref.alloc() : memref<128x256xi8>
+    // CHECK-NEXT: annotation.mark %[[PRUNED_MASK]] : memref<128x256xi8>
+    %mask = memref.alloc() : memref<128x256xi8>
+    annotation.mark %mask {hivm.multi_buffer = 2 : i32} : memref<128x256xi8>
+
+    %t0 = tensor.empty() : tensor<128x128xf32>
+    %t1 = tensor.empty() : tensor<128xf32>
+    %t2 = tensor.empty() : tensor<128x256xf32>
+    %t3 = tensor.empty() : tensor<128x256xi8>
+    %t4 = tensor.empty() : tensor<16x128x16xf16>
+    scope.return
+  } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+  return
+}
+
+// DEBUG: initial UB = 2500608 bits, max = 2031616 bits
+// DEBUG: after deleting mark #1 (size 131072 bits): UB = 2369536 bits


### PR DESCRIPTION
… duplicate logic in pruneMultiBufferMarks

- UBEstimateResult now carries annotMarks, sorted by size descending
- checkUBOverflow collects and sorts marks in single traversal
- pruneMultiBufferMarks delegates to checkUBOverflow, drops 22 duplicate lines
- extract shouldPrune helper for early-return checks

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
