### PR TITLE
[Docs](feat) update maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,6 +2,14 @@
 
 | Name | ID | Join Date |
 |---|---|---|
+| Kaixin Yang | kaixin1976 | 2025-09-27 |
+| Ziqi Hong | hongziqi | 2026-03-26 |
+| Tianyao Wu | WuTYSFG | 2026-05-11 |
+| Yihan Zhou | KanuaK | 2026-05-11 |
+| Zhijie Zhao | insanecoder-zzj | 2025-09-27 |
+| Chunli Zhang | HEX1A0A | 2025-09-27 |
+| Ce Zhu | Cadenza4287 | 2025-12-23 |
+| Xuan Peng | HinPeng | 2025-12-23 |
 | Chen Cheng | ccdedreams | 2025-09-27 |
 | Lijuan Hai | hailijuan | 2025-09-27 |
 | Tao Wang | winter77-x | 2025-09-27 |
@@ -9,13 +17,5 @@
 | Jingchang Shi | jingchangshi | 2025-09-27 |
 | Hao Zhou | HaoVincentZhou | 2025-09-27 |
 | Kaipeng Xing | kpxing | 2025-09-27 |
-| Zhijie Zhao | zhaozhijie | 2025-09-27 |
-| Kaixin Yang | kaixin1976 | 2025-09-27 |
-| Chunli Zhang | HEX1A0A | 2025-09-27 |
-| Ce Zhu | Cadenza4287 | 2025-12-23 |
-| Xuan Peng | HinPeng | 2025-12-23 |
-| Ziqi Hong | hongziqi | 2026-03-26 |
 | Peiji Chen | zackc6 | 2026-05-07 |
 | Ingu Kung | kig9981 | 2026-05-08 |
-| Tianyao Wu | WuTYSFG | 2026-05-11 |
-| Yihan Zhou | KanuaK | 2026-05-11 |


### PR DESCRIPTION
## Summary
Reorder the maintainer list in `MAINTAINERS.md` by recent community activity, moving currently more active members to the top. Also update Zhijie Zhao's GitHub ID from `zhaozhijie` to `insanecoder-zzj`. No members are added or removed.

## What Is Included
- `MAINTAINERS.md`
  - Reorder by activity: Kaixin Yang, Ziqi Hong, Tianyao Wu, Yihan Zhou, and others moved up
  - Zhijie Zhao: `zhaozhijie` → `insanecoder-zzj`

## User Impact
No code behavior change. Documentation / governance list update only.

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
  - [x] This PR does not need a test because it only updates `MAINTAINERS.md`.
  - [ ] I have added tests.
- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices).
