### PR TITLE
[CI](fix) Fixed the issue of failed checks when pushing

### DIFF
--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -2,11 +2,6 @@ name: DCO Check
 
 on:
   pull_request_target:
-  merge_group:
-    branches: [main, 'release/**', '**-dev']
-    types: [checks_requested]
-  push:
-    branches: [main, 'release/**', '**-dev']
 
 concurrency:
   group: dco-check-${{ github.event.pull_request.number || github.sha }}
@@ -22,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: KineticCafe/actions-dco@v3.1.0
+      - uses: KineticCafe/actions-dco@v3.2.0
         with:
           config: |
             comment = true


### PR DESCRIPTION
### Summary
Since the action(KineticCafe/actions-dco) only supports `pull_request/pull_request_target` events and does not support other events, it leads to task failure issues during merging. Here, they are removed。

The version of the upgrade check action is upgraded to avoid check problems. https://github.com/KineticCafe/actions-dco/issues/216