### PR TITLE
[TritonToStructure](fix) Lower zero-stride make_tensor_ptr to scalar-…

### DIFF
--- a/third_party/ascend/include/TritonToStructured/CannonicalizerConverter.h
+++ b/third_party/ascend/include/TritonToStructured/CannonicalizerConverter.h
@@ -78,6 +78,22 @@ public:
                                 PatternRewriter &rewriter) const override;
 };
 
+// Rewrites `tt.load %bptr` whose `%bptr = tt.make_tensor_ptr ...` has all
+// statically zero strides. The zero strides are the IR-level signature of a
+// broadcasted tensor: every element of the loaded block refers to the same
+// memory location `base`. Lower the load into a single scalar `tt.load %base`
+// followed by `tt.broadcast` back to the original block shape, so downstream
+// passes see only standard ops.
+class ZeroStrideMakeTensorPtrConverter
+    : public OpRewritePattern<triton::MakeTensorPtrOp> {
+public:
+  explicit ZeroStrideMakeTensorPtrConverter(MLIRContext *context)
+      : OpRewritePattern<triton::MakeTensorPtrOp>(context) {}
+
+  LogicalResult matchAndRewrite(triton::MakeTensorPtrOp op,
+                                PatternRewriter &rewriter) const override;
+};
+
 class IfYieldAddHoistConverter : public OpRewritePattern<scf::IfOp> {
 public:
   explicit IfYieldAddHoistConverter(MLIRContext *context)

--- a/third_party/ascend/lib/TritonToStructured/CannonicalizerConverter.cpp
+++ b/third_party/ascend/lib/TritonToStructured/CannonicalizerConverter.cpp
@@ -33,6 +33,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Passes.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/Attributes.h"
@@ -346,6 +347,72 @@ LoadBroadcastConverter::matchAndRewrite(triton::LoadOp loadOp,
                                                           newLoad.getResult());
 
   rewriter.replaceOp(loadOp, broadcasted.getResult());
+  return success();
+}
+
+LogicalResult ZeroStrideMakeTensorPtrConverter::matchAndRewrite(
+    triton::MakeTensorPtrOp op, PatternRewriter &rewriter) const {
+  // Only rewrite when every stride is statically 0; any non-zero stride
+  // would mean the dimension actually varies in memory and the broadcast
+  // pattern doesn't apply.
+  if (!llvm::all_of(op.getStrides(), [](Value stride) {
+        Attribute attr;
+        if (!matchPattern(stride, m_Constant(&attr)))
+          return false;
+        if (auto intAttr = dyn_cast<IntegerAttr>(attr))
+          return intAttr.getValue() == 0;
+        return false;
+      })) {
+    return failure();
+  }
+
+  auto isAllowedUser = [](Operation *user) {
+    // FIXME: temporary solution
+    // return isa<triton::LoadOp, triton::StoreOp, triton::AdvanceOp>(user);
+    return isa<triton::LoadOp>(user);
+  };
+  if (!llvm::all_of(op->getUsers(), isAllowedUser))
+    return failure();
+
+  Location loc = op.getLoc();
+  Value base = op.getBase();
+
+  auto ptrType = cast<triton::PointerType>(op.getResult().getType());
+  auto pointeeTensorTy = cast<RankedTensorType>(ptrType.getPointeeType());
+
+  SmallVector<triton::LoadOp> loadUsers;
+  SmallVector<triton::StoreOp> storeUsers;
+  SmallVector<triton::AdvanceOp> advanceUsers;
+  for (Operation *user : op->getUsers()) {
+    if (auto loadOp = dyn_cast<triton::LoadOp>(user))
+      loadUsers.push_back(loadOp);
+    else if (auto storeOp = dyn_cast<triton::StoreOp>(user))
+      storeUsers.push_back(storeOp);
+    else if (auto advanceOp = dyn_cast<triton::AdvanceOp>(user))
+      advanceUsers.push_back(advanceOp);
+  }
+
+  // Rewrite loads: load a scalar from `base` directly (tt.load accepts a
+  // pointer-to-scalar type) and splat it to the block shape. The
+  // "splat" Triton op is the intended way to broadcast a scalar value into
+  // a tensor of arbitrary shape — equivalent in semantics to what
+  // `tt.broadcast(0-D-tensor -> shape)` does, but without the intermediate
+  // 0-D tensorization step.
+  auto rewriteLoad = [&](triton::LoadOp loadOp) {
+    rewriter.setInsertionPoint(loadOp);
+    auto scalarLoad = rewriter.create<triton::LoadOp>(
+        loc, base, /*mask=*/Value(), /*other=*/Value(), loadOp.getCache(),
+        loadOp.getEvict(), loadOp.getIsVolatile());
+
+    auto broadcasted = rewriter.create<triton::SplatOp>(loc, pointeeTensorTy,
+                                                        scalarLoad.getResult());
+    rewriter.replaceOp(loadOp, broadcasted.getResult());
+  };
+
+  for (triton::LoadOp loadOp : loadUsers)
+    rewriteLoad(loadOp);
+
+  rewriter.eraseOp(op);
   return success();
 }
 

--- a/third_party/ascend/lib/TritonToStructured/TritonToStructuredPass.cpp
+++ b/third_party/ascend/lib/TritonToStructured/TritonToStructuredPass.cpp
@@ -95,6 +95,9 @@ void TritonToStructuredPass::populateTritonToStructuredCanonicalizationPatterns(
   // Move loads before broadcasts when safe
   patterns.add<CannonicalizerConverter::LoadBroadcastConverter>(
       patterns.getContext());
+  // Lower `make_tensor_ptr` with all-zero strides to scalar load + broadcast.
+  patterns.add<CannonicalizerConverter::ZeroStrideMakeTensorPtrConverter>(
+      patterns.getContext());
 }
 
 void TritonToStructuredPass::populateTritonToStructuredPatterns(

--- a/third_party/ascend/unittest/pytest_ut/test_make_tensor_ptr_zero_stride.py
+++ b/third_party/ascend/unittest/pytest_ut/test_make_tensor_ptr_zero_stride.py
@@ -1,0 +1,186 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import torch
+import torch_npu
+
+import triton
+import triton.language as tl
+import pytest
+
+
+@triton.jit
+def broadcast_load_ref_kernel(in_ptr, out_ptr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr):
+    """Reference: load a (BLOCK_M, BLOCK_N, BLOCK_K) block where every element
+    is ``in_ptr[0]`` (broadcast of a single scalar to the block shape)."""
+    off_m = tl.arange(0, BLOCK_M)[:, None, None]
+    off_n = tl.arange(0, BLOCK_N)[None, :, None]
+    off_k = tl.arange(0, BLOCK_K)[None, None, :]
+    val = tl.load(in_ptr + off_m * 0 + off_n * 0 + off_k * 0)
+    tl.store(out_ptr + off_m * (BLOCK_N * BLOCK_K) + off_n * BLOCK_K + off_k, val)
+
+
+@triton.jit
+def broadcast_store_ref_kernel(in_ptr, out_ptr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr):
+    """Reference: store ``in_ptr[0] + 1`` into every position of a
+    (BLOCK_M, BLOCK_N, BLOCK_K) block. Under broadcast-zero-stride semantics
+    every store site receives the same scalar; the last writer wins on the
+    single shared address."""
+    off_m = tl.arange(0, BLOCK_M)[:, None, None]
+    off_n = tl.arange(0, BLOCK_N)[None, :, None]
+    off_k = tl.arange(0, BLOCK_K)[None, None, :]
+    val = tl.load(in_ptr) + 1.0
+    tl.store(out_ptr + off_m * (BLOCK_N * BLOCK_K) + off_n * BLOCK_K + off_k, val)
+
+
+@triton.jit
+def broadcast_advance_ref_kernel(in_ptr, out_ptr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr):
+    """Reference: advance with strides (0, 0, 0) keeps the address at
+    ``base``, so the loaded block is still ``in_ptr[0]`` broadcast."""
+    off_m = tl.arange(0, BLOCK_M)[:, None, None]
+    off_n = tl.arange(0, BLOCK_N)[None, :, None]
+    off_k = tl.arange(0, BLOCK_K)[None, None, :]
+    val = tl.load(in_ptr)
+    tl.store(out_ptr + off_m * (BLOCK_N * BLOCK_K) + off_n * BLOCK_K + off_k, val)
+
+
+@triton.jit
+def broadcast_load_kernel(in_ptr, out_ptr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr):
+    """Use ``make_block_ptr`` with all-zero strides for the load."""
+    bptr = tl.make_block_ptr(
+        base=in_ptr,
+        shape=(BLOCK_M, BLOCK_N, BLOCK_K),
+        strides=(0, 0, 0),
+        offsets=(0, 0, 0),
+        block_shape=(BLOCK_M, BLOCK_N, BLOCK_K),
+        order=(0, 1, 2),
+    )
+    val = tl.load(bptr, boundary_check=(0, 1, 2))
+
+    out = tl.make_block_ptr(
+        base=out_ptr,
+        shape=(BLOCK_M, BLOCK_N, BLOCK_K),
+        strides=(BLOCK_N * BLOCK_K, BLOCK_K, 1),
+        offsets=(0, 0, 0),
+        block_shape=(BLOCK_M, BLOCK_N, BLOCK_K),
+        order=(0, 1, 2),
+    )
+    tl.store(out, val, boundary_check=(0, 1, 2))
+
+
+@triton.jit
+def broadcast_store_kernel(in_ptr, out_ptr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr):
+    """Use ``make_block_ptr`` with all-zero strides for the store."""
+    scalar = tl.load(in_ptr)
+
+    bptr = tl.make_block_ptr(
+        base=out_ptr,
+        shape=(BLOCK_M, BLOCK_N, BLOCK_K),
+        strides=(0, 0, 0),
+        offsets=(0, 0, 0),
+        block_shape=(BLOCK_M, BLOCK_N, BLOCK_K),
+        order=(0, 1, 2),
+    )
+    tl.store(bptr, scalar + 1.0, boundary_check=(0, 1, 2))
+
+
+@triton.jit
+def broadcast_advance_kernel(in_ptr, out_ptr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr):
+    """Use ``make_block_ptr`` with all-zero strides followed by ``tl.advance``
+    with non-zero offsets — the advanced pointer must still alias base."""
+    bptr = tl.make_block_ptr(
+        base=in_ptr,
+        shape=(BLOCK_M, BLOCK_N, BLOCK_K),
+        strides=(0, 0, 0),
+        offsets=(0, 0, 0),
+        block_shape=(BLOCK_M, BLOCK_N, BLOCK_K),
+        order=(0, 1, 2),
+    )
+    advanced = tl.advance(bptr, [2, 3, 4])
+    val = tl.load(advanced, boundary_check=(0, 1, 2))
+
+    out = tl.make_block_ptr(
+        base=out_ptr,
+        shape=(BLOCK_M, BLOCK_N, BLOCK_K),
+        strides=(BLOCK_N * BLOCK_K, BLOCK_K, 1),
+        offsets=(0, 0, 0),
+        block_shape=(BLOCK_M, BLOCK_N, BLOCK_K),
+        order=(0, 1, 2),
+    )
+    tl.store(out, val, boundary_check=(0, 1, 2))
+
+
+def _check_close(actual: torch.Tensor, expected: torch.Tensor, tag: str):
+    torch.testing.assert_close(
+        actual,
+        expected,
+        rtol=0,
+        atol=0,
+        msg=(f"{tag}: broadcast-zero-stride kernel diverged from the "
+             "reference implementation"),
+    )
+
+
+def test_zero_stride_make_block_ptr_load():
+    BLOCK_M, BLOCK_N, BLOCK_K = 4, 16, 16
+
+    scalar = torch.tensor([3.14], dtype=torch.float32, device="npu")
+
+    out_kernel = torch.zeros((BLOCK_M, BLOCK_N, BLOCK_K), dtype=torch.float32, device="npu")
+    out_ref = torch.zeros_like(out_kernel)
+
+    broadcast_load_kernel[(1, )](scalar, out_kernel, BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K)
+    broadcast_load_ref_kernel[(1, )](scalar, out_ref, BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K)
+    torch.npu.synchronize()
+
+    _check_close(out_kernel, out_ref, "load")
+
+
+@pytest.mark.skip(reason="waiting for fix")
+def test_zero_stride_make_block_ptr_store():
+
+    BLOCK_M, BLOCK_N, BLOCK_K = 4, 16, 16
+
+    scalar = torch.tensor([2.0], dtype=torch.float32, device="npu")
+    sink = torch.tensor([0.0], dtype=torch.float32, device="npu")
+    sink_ref = torch.tensor([0.0], dtype=torch.float32, device="npu")
+
+    broadcast_store_kernel[(1, )](scalar, sink, BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K)
+    broadcast_store_ref_kernel[(1, )](scalar, sink_ref, BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K)
+    torch.npu.synchronize()
+
+    _check_close(sink, sink_ref, "store")
+
+
+@pytest.mark.skip(reason="waiting for fix")
+def test_zero_stride_make_block_ptr_advance():
+
+    BLOCK_M, BLOCK_N, BLOCK_K = 4, 16, 16
+
+    scalar = torch.tensor([1.5], dtype=torch.float32, device="npu")
+
+    out_kernel = torch.zeros((BLOCK_M, BLOCK_N, BLOCK_K), dtype=torch.float32, device="npu")
+    out_ref = torch.zeros_like(out_kernel)
+
+    broadcast_advance_kernel[(1, )](scalar, out_kernel, BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K)
+    broadcast_advance_ref_kernel[(1, )](scalar, out_ref, BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K)
+    torch.npu.synchronize()
+
+    _check_close(out_kernel, out_ref, "advance")


### PR DESCRIPTION
…load and splat

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
## Summary

Fix `cannot div 0!` crash in triton-opt when `tt.make_tensor_ptr` is emitted with statically zero strides.

## Background

When the Python frontend produces a block pointer with all strides statically zero, e.g.

```mlir
%in1_bptr = tt.make_tensor_ptr %in1_ptr,
    [%s0, %s1, %s2], // shape
    [%c0_i64, %c0_i64, %c0_i64], // strides    [%off0, %off1, %off2],      // offsets
    {order = array<i32: 0, 1, 2>} : <tensor<4x16x16xf32>>
%in1 = tt.load %in1_bptr {boundaryCheck = array<i32: 0, 1, 2>, padding = 1 : i32}
    : !tt.ptr<tensor<4x16x16xf32>>
```

`Utils::getBoundarySizes` (called by `LoadConverter`) feeds the zero strides into `divOpFoldResult` / `subOpFoldResult`. `divOpFoldResult` emits the diagnostic `cannot div 0!` and returns a default-constructed null `OpFoldResult`, which is then propagated to`materializeIndexOperand`, where `dyn_cast<Value>(operand)` trips LLVM's `isPresent` assertion and aborts triton-opt:

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
