### PR TITLE
[ssbuffer](fix) fix alloc tensor mistransfer by cloning

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
@@ -504,6 +504,11 @@ static bool isEmptyFillPattern(Value depVal) {
   return true;
 }
 
+// Check if depVal is the result of a bufferization.alloc_tensor
+static bool isAllocTensorPattern(Value depVal) {
+  return isa_and_nonnull<bufferization::AllocTensorOp>(depVal.getDefiningOp());
+}
+
 SmallVector<Value>
 collectBufferValues(DenseMap<Value, SmallVector<Value>> &depValueMap) {
   SmallVector<Value> valueList;
@@ -528,6 +533,10 @@ collectBufferValues(DenseMap<Value, SmallVector<Value>> &depValueMap) {
       // Skip tensor::EmptyOp + linalg::FillOp pattern - it gets cloned
       // to the consumer's position instead of being multi-buffered
       if (isEmptyFillPattern(depVal))
+        continue;
+
+      // Skip bufferization.alloc_tensor
+      if (isa<bufferization::AllocTensorOp>(op))
         continue;
 
       valueList.push_back(depVal);
@@ -1562,117 +1571,17 @@ static int processDepVal(Value depVal, mlir::scf::ForOp mainLoopForOp,
   return 0;
 }
 
-// Special handling for the tensor::EmptyOp + linalg::FillOp pattern:
-// Clone the empty+fill pair into each consumer block (different from
-// producerId), and replace depVal usage in those consumers with the new
-// linalg::FillOp result. Skips the normal multi-buffer (alloc + hivm.copy +
-// scf.if + to_tensor) path because cloning is cheaper for this pattern.
-//
-// When linalg.fill's `ins` operand's defining op lives in the same parentOp as
-// the tensor::EmptyOp (i.e. it is producer-side and not yet across blocks),
-// clone that defining op together so the cloned fill's `ins` references the
-// clone instead of leaving a cross-block reference.
-static int
-cloneEmptyFillToConsumers(Value depVal, int producerId,
-                          DenseMap<Value, SmallVector<Operation *>> &depUserMap,
-                          OpBuilder &builder) {
-  auto fillOp = cast<linalg::FillOp>(depVal.getDefiningOp());
-  auto origEmpty =
-      cast<tensor::EmptyOp>(fillOp.getOutputs()[0].getDefiningOp());
-
-  // Collect the `ins` operands whose defining op shares the parentOp with the
-  // tensor::EmptyOp. These will be cloned together with empty+fill so the
-  // cloned fill's `ins` becomes a local reference instead of a cross-block one.
-  SmallVector<Value> insToClone;
-  Operation *emptyParent = origEmpty->getParentOp();
-  for (Value insVal : fillOp.getInputs()) {
-    Operation *insDef = insVal.getDefiningOp();
-    if (!insDef)
-      continue;
-    if (insDef->getParentOp() != emptyParent)
-      continue;
-    insToClone.push_back(insVal);
-  }
-
-  auto userIt = depUserMap.find(depVal);
-  if (userIt == depUserMap.end())
-    return 0;
-
-  // Group users by their consumer block_id (skip users in the producer's own
-  // block)
-  DenseMap<int, SmallVector<Operation *>> opsByBlockId;
-  for (Operation *user : userIt->second) {
-    auto userBlockId = getOpBlockId(user);
-    if (!userBlockId.has_value() || *userBlockId == producerId)
-      continue;
-    // Only keep users that still use depVal (not already replaced)
-    bool stillUses = false;
-    for (OpOperand &opnd : user->getOpOperands()) {
-      if (opnd.get() == depVal) {
-        stillUses = true;
-        break;
-      }
-    }
-    if (!stillUses)
-      continue;
-    opsByBlockId[*userBlockId].push_back(user);
-  }
-
-  for (auto &p : opsByBlockId) {
-    int userBlockId = p.first;
-    auto &users = p.second;
-    if (users.empty())
-      continue;
-
-    Operation *firstUser = users.front();
-    builder.setInsertionPoint(firstUser);
-
-    // Clone tensor::EmptyOp and tag with consumer's block_id
-    IRMapping mapper;
-    Operation *newEmpty = builder.clone(*origEmpty, mapper);
-    newEmpty->setAttr(kBlockId, builder.getI32IntegerAttr(userBlockId));
-
-    // Map origEmpty's result to the new empty so the cloned fill's outs
-    // operand is rewired to point at the cloned empty.
-    mapper.map(origEmpty->getResult(0), newEmpty->getResult(0));
-
-    // Clone the `ins` defining ops that share the empty's parentOp, and
-    // pre-register their value mapping so the cloned fill uses the cloned
-    // scalar instead of leaving a cross-block reference.
-    for (Value insVal : insToClone) {
-      Operation *insDef = insVal.getDefiningOp();
-      Operation *newIns = builder.clone(*insDef, mapper);
-      newIns->setAttr(kBlockId, builder.getI32IntegerAttr(userBlockId));
-      mapper.map(insVal, newIns->getResult(0));
-    }
-
-    // Clone linalg::FillOp and tag with consumer's block_id
-    Operation *newFill = builder.clone(*fillOp, mapper);
-    newFill->setAttr(kBlockId, builder.getI32IntegerAttr(userBlockId));
-
-    // Replace depVal with the new fill's result for all users in this block
-    Value newResult = newFill->getResult(0);
-    for (Operation *user : users) {
-      user->replaceUsesOfWith(depVal, newResult);
-    }
-  }
-
-  return 0;
-}
-
-// First pass: clone tensor::EmptyOp + linalg::FillOp patterns to each
-// consumer block. Runs BEFORE the rest of dep collection because cloning
-// the fill can introduce fresh cross-block references (e.g. the cloned
-// fill's `ins` chain may now reach a producer-side tensor that needs
-// multi-buffering), and the second pass needs to see them.
-//
-// Returns 0 on success, -1 on failure.
-static int
-cloneEmptyFillsInBlocks(scf::ForOp mainLoopForOp,
-                        DenseMap<Value, InnerBlockInfo> &blocks,
-                        DenseMap<Value, SmallVector<Value>> &depValueMap,
-                        DenseMap<Value, SmallVector<Operation *>> &depUserMap,
-                        OpBuilder &globalBuilder) {
+// For each depVal matching `patternCheck`, groups cross-block users by
+// userBlockId and calls `cloneFn` at the first user of each group to clone
+// ops (with kBlockId = userBlockId) and return the replacement Value.
+static int cloneDepsToConsumers(
+    scf::ForOp mainLoopForOp, DenseMap<Value, InnerBlockInfo> &blocks,
+    DenseMap<Value, SmallVector<Value>> &depValueMap,
+    DenseMap<Value, SmallVector<Operation *>> &depUserMap, OpBuilder &builder,
+    llvm::function_ref<bool(Value)> patternCheck,
+    llvm::function_ref<Value(IRMapping &, OpBuilder &, Value depVal,
+                             int userBlockId, ArrayRef<Operation *> users)>
+        cloneFn) {
   SmallVector<Operation *> seenOps;
 
   for (auto &blockPair : blocks) {
@@ -1680,34 +1589,128 @@ cloneEmptyFillsInBlocks(scf::ForOp mainLoopForOp,
     if (depIt == depValueMap.end())
       continue;
 
-    // Walk the dep list carefully: cloneEmptyFillToConsumers mutates
-    // depUserMap (via replaceUsesOfWith) but does not invalidate the
-    // depValueMap iterator (no insert/erase of depValueMap). We just
-    // dedupe by defining op to avoid re-processing the same fill.
     for (Value depVal : depIt->second) {
       Operation *defOp = depVal.getDefiningOp();
       if (!defOp || llvm::is_contained(seenOps, defOp))
         continue;
-
-      if (!isEmptyFillPattern(depVal))
+      if (!patternCheck(depVal))
         continue;
-
-      // Skip if parentOp is not the main_loop forOp (clone logic
-      // currently expects the empty/fill to be inside main_loop).
       if (defOp->getParentOp() != mainLoopForOp.getOperation())
         continue;
 
       auto producerId = getOpBlockId(defOp);
       if (!producerId.has_value())
         continue;
-
       seenOps.push_back(defOp);
-      if (cloneEmptyFillToConsumers(depVal, *producerId, depUserMap,
-                                    globalBuilder) != 0)
-        return -1;
+
+      auto userIt = depUserMap.find(depVal);
+      if (userIt == depUserMap.end())
+        continue;
+
+      // Group users by their consumer block_id, skipping users in the
+      // producer's own block and users that no longer reference depVal.
+      DenseMap<int, SmallVector<Operation *>> opsByBlockId;
+      for (Operation *user : userIt->second) {
+        auto userBlockId = getOpBlockId(user);
+        if (!userBlockId.has_value() || *userBlockId == producerId)
+          continue;
+        bool stillUses = false;
+        for (OpOperand &opnd : user->getOpOperands()) {
+          if (opnd.get() == depVal) {
+            stillUses = true;
+            break;
+          }
+        }
+        if (!stillUses)
+          continue;
+        opsByBlockId[*userBlockId].push_back(user);
+      }
+
+      for (auto &p : opsByBlockId) {
+        int userBlockId = p.first;
+        auto &users = p.second;
+        if (users.empty())
+          continue;
+
+        Operation *firstUser = users.front();
+        builder.setInsertionPoint(firstUser);
+        IRMapping mapper;
+        Value newVal = cloneFn(mapper, builder, depVal, userBlockId, users);
+        if (!newVal)
+          continue;
+        for (Operation *user : users) {
+          user->replaceUsesOfWith(depVal, newVal);
+        }
+      }
     }
   }
   return 0;
+}
+
+// Phase 1: clone empty+fill (and any `ins` defining ops sharing the empty's
+// parentOp) to consumer blocks; runs before dep collection because the cloned
+// fill's `ins` chain may reach a producer-side tensor that Phase 2 must see.
+static int
+cloneEmptyFillsInBlocks(scf::ForOp mainLoopForOp,
+                        DenseMap<Value, InnerBlockInfo> &blocks,
+                        DenseMap<Value, SmallVector<Value>> &depValueMap,
+                        DenseMap<Value, SmallVector<Operation *>> &depUserMap,
+                        OpBuilder &globalBuilder) {
+  return cloneDepsToConsumers(
+      mainLoopForOp, blocks, depValueMap, depUserMap, globalBuilder,
+      isEmptyFillPattern,
+      [](IRMapping &mapper, OpBuilder &builder, Value depVal, int userBlockId,
+         ArrayRef<Operation *> users) -> Value {
+        auto fillOp = cast<linalg::FillOp>(depVal.getDefiningOp());
+        auto origEmpty =
+            cast<tensor::EmptyOp>(fillOp.getOutputs()[0].getDefiningOp());
+
+        // Collect the `ins` operands whose defining op shares the parentOp with
+        // the tensor::EmptyOp.
+        SmallVector<Value> insToClone;
+        Operation *emptyParent = origEmpty->getParentOp();
+        for (Value insVal : fillOp.getInputs()) {
+          Operation *insDef = insVal.getDefiningOp();
+          if (!insDef || insDef->getParentOp() != emptyParent)
+            continue;
+          insToClone.push_back(insVal);
+        }
+
+        Operation *newEmpty = builder.clone(*origEmpty, mapper);
+        newEmpty->setAttr(kBlockId, builder.getI32IntegerAttr(userBlockId));
+        mapper.map(origEmpty->getResult(0), newEmpty->getResult(0));
+
+        for (Value insVal : insToClone) {
+          Operation *insDef = insVal.getDefiningOp();
+          Operation *newIns = builder.clone(*insDef, mapper);
+          newIns->setAttr(kBlockId, builder.getI32IntegerAttr(userBlockId));
+          mapper.map(insVal, newIns->getResult(0));
+        }
+
+        Operation *newFill = builder.clone(*fillOp, mapper);
+        newFill->setAttr(kBlockId, builder.getI32IntegerAttr(userBlockId));
+        return newFill->getResult(0);
+      });
+}
+
+// Clone bufferization.alloc_tensor to each consumer block
+static int
+cloneAllocTensorsInBlocks(scf::ForOp mainLoopForOp,
+                          DenseMap<Value, InnerBlockInfo> &blocks,
+                          DenseMap<Value, SmallVector<Value>> &depValueMap,
+                          DenseMap<Value, SmallVector<Operation *>> &depUserMap,
+                          OpBuilder &globalBuilder) {
+  return cloneDepsToConsumers(
+      mainLoopForOp, blocks, depValueMap, depUserMap, globalBuilder,
+      isAllocTensorPattern,
+      [](IRMapping &mapper, OpBuilder &builder, Value depVal, int userBlockId,
+         ArrayRef<Operation *> users) -> Value {
+        auto origAlloc =
+            cast<bufferization::AllocTensorOp>(depVal.getDefiningOp());
+        Operation *newAlloc = builder.clone(*origAlloc, mapper);
+        newAlloc->setAttr(kBlockId, builder.getI32IntegerAttr(userBlockId));
+        return newAlloc->getResult(0);
+      });
 }
 
 // Process cross-block tensor dependencies for double buffering
@@ -1741,6 +1744,10 @@ static int processTensorDependencies(
       // Skip tensor::EmptyOp - it should only get dep_mark, not buffer
       // allocation
       if (isa<tensor::EmptyOp>(depVal.getDefiningOp()))
+        continue;
+
+      // Skip bufferization.alloc_tensor
+      if (isa<bufferization::AllocTensorOp>(depVal.getDefiningOp()))
         continue;
 
       // Check if definingOp's parentOp is the main_loop forOp
@@ -1913,6 +1920,11 @@ static int addInnerMultiBuffer(mlir::scf::ForOp mainLoopForOp,
 
   auto depUserMap = buildDepUserMap(blocks, allOps, depValueMap);
 
+  // Clone bufferization.alloc_tensor deps to each consumer's block.
+  if (cloneAllocTensorsInBlocks(mainLoopForOp, blocks, depValueMap, depUserMap,
+                                globalBuilder) != 0)
+    return -1;
+
   auto valueList = collectBufferValues(depValueMap);
   auto bufferMap =
       insertBuffersBeforeFor(mainLoopForOp, valueList, builder, groupId);
@@ -1988,10 +2000,7 @@ void AddMultiBufferInnerScopePass::runOnOperation() {
       int ret =
           addInnerMultiBuffer(mainLoopForOp, builder, scope, groupId, i1Found);
       if (i1Found) {
-        // i1 tensor deps are not safe to multi-buffer; mark the module
-        // with ERRCODE_IGNORED and bail out so downstream passes see the
-        // fallback attribute. Mirrors the AnalyzeName pass pattern:
-        // setFallbackAttr(module) + signalPassFailure() + return.
+        // i1 tensor deps are not safe to multi-buffer;
         LDBG("i1 tensor dep found, setting fallback attribute");
         CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_IGNORED);
         return WalkResult::interrupt();

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/Inner-scope-alloc-tensor-clone.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/Inner-scope-alloc-tensor-clone.mlir
@@ -1,0 +1,85 @@
+// RUN: triton-opt --add_multi_buffer_inner_scope %s | FileCheck %s
+
+// T-alloc-tensor-clone: bufferization.alloc_tensor() (no payload) is cloned
+// into each cross-block consumer's block instead of being multi-buffered.
+//
+// Case A (test_alloc_tensor_single_consumer):
+//   %alloc in block_id = 9 (producer block), consumed by linalg.fill in
+//   block_id = 10. After the pass:
+//     - Original %alloc stays at block_id = 9 (orphaned, DCE will clean it).
+//     - A cloned alloc_tensor appears at block_id = 10 (the consumer block).
+//     - linalg.fill's outs is rewired to the clone, NOT the original.
+//     - NO multi-buffer machinery (memref.alloc + hivm.copy + scf.if +
+//       to_tensor) is generated for this dep.
+//
+// Case B (test_alloc_tensor_multi_consumer):
+//   %alloc in block_id = 9, consumed by two ops in two different consumer
+//   blocks (block_id = 10 and block_id = 11). After the pass, the alloc is
+//   cloned ONCE PER consumer block — each consumer gets a fresh local alloc
+//   with the corresponding block_id tag.
+
+// CHECK-LABEL: func.func @test_alloc_tensor_single_consumer
+// Original alloc stays in producer block (orphaned, will be DCE'd).
+// CHECK: %[[ORIG:.*]] = bufferization.alloc_tensor() {ssbuffer.block_id = 9 : i32} : tensor<f32>
+// Cloned alloc appears in consumer block, tagged with consumer's block_id.
+// CHECK: %[[CLONE:.*]] = bufferization.alloc_tensor() {ssbuffer.block_id = 10 : i32} : tensor<f32>
+// linalg.fill's outs is rewired to the clone, NOT the original.
+// CHECK: linalg.fill {ssbuffer.block_id = 10 : i32} ins(%{{.+}} : f32) outs(%[[CLONE]] : tensor<f32>) -> tensor<f32>
+// alloc_tensor must NOT go through the multi-buffer path: no UB memref.alloc
+// or hivm.hir.copy chain for tensor<f32> in this scope.
+// CHECK-NOT: memref.alloc() : memref<f32, #hivm.address_space<ub>>
+// CHECK-NOT: hivm.hir.copy{{.*}}: tensor<f32>
+
+// CHECK-LABEL: func.func @test_alloc_tensor_multi_consumer
+// Original alloc stays in producer block (orphaned).
+// CHECK: %[[B_ORIG:.*]] = bufferization.alloc_tensor() {ssbuffer.block_id = 9 : i32} : tensor<f32>
+// Clone for block_id = 10 consumer.
+// CHECK: %[[B_CLONE_10:.*]] = bufferization.alloc_tensor() {ssbuffer.block_id = 10 : i32} : tensor<f32>
+// block_id = 10 fill uses the block 10 clone, NOT the original.
+// CHECK: linalg.fill {ssbuffer.block_id = 10 : i32} ins(%{{.+}} : f32) outs(%[[B_CLONE_10]] : tensor<f32>) -> tensor<f32>
+// Clone for block_id = 11 consumer.
+// CHECK: %[[B_CLONE_11:.*]] = bufferization.alloc_tensor() {ssbuffer.block_id = 11 : i32} : tensor<f32>
+// block_id = 11 fill uses the block 11 clone, NOT the original or the block 10
+// clone.
+// CHECK: linalg.fill {ssbuffer.block_id = 11 : i32} ins(%{{.+}} : f32) outs(%[[B_CLONE_11]] : tensor<f32>) -> tensor<f32>
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  // Case A: single cross-block consumer
+  func.func @test_alloc_tensor_single_consumer() {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c100_i32 = arith.constant 100 : i32
+    %cst = arith.constant 1.0 : f32
+    scope.scope : () -> () {
+      scf.for %i = %c0_i32 to %c100_i32 step %c1_i32  : i32 {
+        // alloc_tensor in producer block (block_id = 9).
+        %alloc = bufferization.alloc_tensor() {ssbuffer.block_id = 9 : i32} : tensor<f32>
+        // Single cross-block consumer (block_id = 10). Uses %alloc as outs.
+        %fill = linalg.fill {ssbuffer.block_id = 10 : i32} ins(%cst : f32) outs(%alloc : tensor<f32>) -> tensor<f32>
+        %used = arith.addf %fill, %fill {ssbuffer.block_id = 10 : i32} : tensor<f32>
+      } {ssbuffer.main_loop = 1 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return
+  }
+
+  // Case B: two cross-block consumers in different blocks
+  func.func @test_alloc_tensor_multi_consumer() {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c100_i32 = arith.constant 100 : i32
+    %cst = arith.constant 1.0 : f32
+    scope.scope : () -> () {
+      scf.for %i = %c0_i32 to %c100_i32 step %c1_i32  : i32 {
+        %alloc = bufferization.alloc_tensor() {ssbuffer.block_id = 9 : i32} : tensor<f32>
+        // Two cross-block consumers, different block_ids: 10 and 11.
+        %fill_a = linalg.fill {ssbuffer.block_id = 10 : i32} ins(%cst : f32) outs(%alloc : tensor<f32>) -> tensor<f32>
+        %fill_b = linalg.fill {ssbuffer.block_id = 11 : i32} ins(%cst : f32) outs(%alloc : tensor<f32>) -> tensor<f32>
+        %used_a = arith.addf %fill_a, %fill_a {ssbuffer.block_id = 10 : i32} : tensor<f32>
+        %used_b = arith.addf %fill_b, %fill_b {ssbuffer.block_id = 11 : i32} : tensor<f32>
+      } {ssbuffer.main_loop = 1 : i64}
+      scope.return
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    return
+  }
+}


### PR DESCRIPTION
This pull request is desigined to fix alloc tensor mistransfer by cloning to avoid compile error "read before first write" in NPUIR phase.