### PR TITLE
[ssbuffer](feat) add option enable_merge_compute_block

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -231,6 +231,7 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
             metadata["disable_auto_inject_block_sync"] = True
             ascend.passes.ttir.set_enable_cube_block_merge(metadata["enable_cube_block_merge"])
             ascend.passes.ttir.set_enable_ub_refine_opt(mod, metadata["enable_ub_refine_opt"])
+            ascend.passes.ttir.set_enable_merge_compute_block(mod, metadata["enable_merge_compute_block"])
 
             # Must run before add_dynamic_cv_pipeline because the driven
             # AddMultiBufferInnerScope pass reads the module-level
@@ -999,6 +1000,7 @@ class NPUOptions:
     # matmul's loader for-loop into the matmul's cube compute block.
     enable_cube_block_merge: bool = False
     enable_ub_refine_opt: bool = False
+    enable_merge_compute_block: bool = False
     # Multi-cache insertion optimization: avoid redundant tensor compute in the middle of an `if`.
     enable_buffer_insert_optimization: bool = False
     hfusion_enable_multiple_consumer_fusion: bool = False

--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -57,6 +57,7 @@ inline constexpr llvm::StringLiteral kMemCrossDeps = "ssbuffer.memCrossDeps";
 inline constexpr llvm::StringLiteral kMayNotExec = "ssbuffer.may_not_exec";
 inline constexpr llvm::StringLiteral kClone = "ssbuffer.clone";
 inline constexpr llvm::StringLiteral kEnableUbRefineOpt = "ssbuffer.enable_ub_refine_opt";
+inline constexpr llvm::StringLiteral kEnableMergeComputeBlock = "ssbuffer.enable_merge_compute_block";
 inline constexpr llvm::StringLiteral kInsertionOptimization = "ssbuffer.insertionOptimization";
 static constexpr llvm::StringLiteral kInlinableQuantScaleAttr = "enable_fast_tf32_mul";
 inline constexpr llvm::StringLiteral kHIVMMatmulLimitedInCubeAttr = "hivm.matmul_limited_in_cube";
@@ -89,6 +90,9 @@ bool isCubeBlockMergeEnabled();
 
 void setEnableUBRefineOpt(bool enable);
 bool isUBRefineOptEnabled();
+
+void setEnableMergeComputeBlock(ModuleOp &module, bool enable);
+bool isMergeComputeBlockEnabled(ModuleOp module);
 
 // Functions for managing core types
 CoreType getOpCoreType(Operation *op);

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
@@ -37,6 +37,7 @@ void registerMergeVectorIfBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createMergeCubeForBlockPass();
 void registerMergeCubeForBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createFixpipeOptPass();
+std::unique_ptr<OperationPass<ModuleOp>> createMergeComputeBlockPass();
 
 } // namespace triton
 } // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -37,6 +37,19 @@ bool isCubeBlockMergeEnabled()
     return g_enableCubeBlockMerge;
 }
 
+void setEnableMergeComputeBlock(ModuleOp &module, bool enable)
+{
+    OpBuilder builder(module.getContext());
+    if (enable) {
+        module->setAttr(kEnableMergeComputeBlock, builder.getUnitAttr());
+    }
+}
+
+bool isMergeComputeBlockEnabled(ModuleOp module)
+{
+    return module->getAttr(kEnableMergeComputeBlock) != nullptr;
+}
+
 CoreType getOpCoreType(Operation *op)
 {
     if (!op) {

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeComputeBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeComputeBlockPass.cpp
@@ -1,0 +1,554 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+
+#include "DynamicCVPipeline/Common/Utils.h"
+
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+static constexpr const char *DEBUG_TYPE = "merge-compute-block";
+#define LOG_DEBUG(...)                                                         \
+  LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
+
+using namespace mlir;
+using namespace triton;
+
+// ============================================================================
+// Data Structures
+// ============================================================================
+
+/// Represents a ComputeBlock: a group of ops sharing the same block_id
+struct ComputeBlock {
+  int id;                        // block_id value
+  CVPipeline::CoreType coreType; // CUBE_ONLY / VECTOR_ONLY
+  SmallVector<Operation *> ops;  // all ops in the group (in IR order)
+};
+
+// ============================================================================
+// Sub-function Implementations
+// ============================================================================
+
+/// Collect the body Blocks of the innermost scf::ForOp that contain
+/// linalg::MatmulOp in ModuleOp (deduplicated).
+static void collectInnermostMatmulLoopBlocks(ModuleOp module,
+                                             SmallVectorImpl<Block *> &blocks) {
+  DenseSet<Block *> seen;
+  module->walk([&](linalg::MatmulOp matmul) {
+    Operation *parent = matmul->getParentOp();
+    while (parent) {
+      if (auto forOp = dyn_cast<scf::ForOp>(parent)) {
+        Block *body = forOp.getBody();
+        if (seen.insert(body).second) {
+          blocks.push_back(body);
+        }
+        break;
+      }
+      parent = parent->getParentOp();
+    }
+  });
+}
+
+/// Check whether a ComputeBlock has any tensor-typed result.
+static bool hasTensorResult(const ComputeBlock &blk) {
+  for (Operation *op : blk.ops) {
+    for (Value result : op->getResults()) {
+      if (isa<TensorType>(result.getType())) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/// Step 1: Group ops and build block-level SSA dependency graph (enhanced).
+/// computeBlocks: output, block_id → ComputeBlock
+/// succs/preds: output, block_id → successor/predecessor block_id list
+/// blockEdges: output, srcId → dstId → operands (cross-block SSA edges)
+static void groupAndBuildGraph(
+    Block *block, DenseMap<int, ComputeBlock> &computeBlocks,
+    DenseMap<int, SmallVector<int>> &succs,
+    DenseMap<int, SmallVector<int>> &preds,
+    DenseMap<int, DenseMap<int, SmallVector<Value>>> &blockEdges) {
+  // Walk all ops in the body block and its nested regions, group by
+  // block_id
+  block->walk([&](Operation *op) {
+    if (op->hasTrait<OpTrait::IsTerminator>()) {
+      return;
+    }
+    auto optId = CVPipeline::getOpBlockId(op);
+    if (!optId.has_value()) {
+      return;
+    }
+    int bid = *optId;
+    if (!computeBlocks.contains(bid)) {
+        // find new block_id, create new ComputeBlock
+      computeBlocks[bid] = {bid, CVPipeline::getOpCoreType(op), {}};
+    }
+    computeBlocks[bid].ops.push_back(op);
+  });
+
+  if (computeBlocks.empty()) {
+    return;
+  }
+
+  // Build SSA dependency graph between ComputeBlocks, recording
+  // inter-block operand edges
+  DenseSet<std::pair<int, int>> seenEdges;
+  for (auto &kv : computeBlocks) {
+    int curId = kv.first;
+    for (Operation *op : kv.second.ops) {
+      for (Value operand : op->getOperands()) {
+        Operation *defOp = operand.getDefiningOp();
+        if (!defOp) {
+          continue; // block argument
+        }
+        Operation *ancestor = CVPipeline::getAncestorInBlock(defOp, block);
+        if (!ancestor) {
+          continue; // not in this block
+        }
+        auto ancIdOpt = CVPipeline::getOpBlockId(ancestor);
+        if (!ancIdOpt.has_value()) {
+          continue;
+        }
+        int ancId = *ancIdOpt;
+        if (ancId == curId) {
+          continue; // same ComputeBlock internal edge
+        }
+
+        // Record the operand that triggers this cross-block edge
+        blockEdges[ancId][curId].push_back(operand);
+
+        if (!seenEdges.insert({ancId, curId}).second) {
+          continue;
+        }
+        succs[ancId].push_back(curId);
+        preds[curId].push_back(ancId);
+      }
+    }
+  }
+}
+
+/// Find the first CUBE predecessor of a given block.
+/// Returns -1 if not found.
+static int findCubePred(int blockId,
+                        const DenseMap<int, ComputeBlock> &computeBlocks,
+                        const DenseMap<int, SmallVector<int>> &preds) {
+  auto it = preds.find(blockId);
+  if (it == preds.end()) {
+    return -1;
+  }
+  for (int p : it->second) {
+    if (computeBlocks.lookup(p).coreType == CVPipeline::CoreType::CUBE_ONLY) {
+      return p;
+    }
+  }
+  return -1;
+}
+
+
+/// Helper to add scalar/index-typed SSA defining ops of \p op to the worklist
+/// (recursively processes new additions in the same call).
+static void collectScalarDeps(Operation *op,
+                               SmallPtrSet<Operation *, 16> &collected,
+                               SmallVectorImpl<Operation *> &worklist) {
+  for (Value operand : op->getOperands()) {
+    Operation *defOp = operand.getDefiningOp();
+    if (!defOp) {
+      continue;
+    }
+    if (collected.insert(defOp).second) {
+      worklist.push_back(defOp);
+      collectScalarDeps(defOp, collected, worklist);
+    }
+  }
+}
+
+/// Recursively collect all execution predecessors of an op using
+/// MemoryDependenceGraph::getExecBefore, and also collect scalar/index-typed
+/// SSA dependencies for each collected op. Collects the transitive closure of
+/// both memory execution predecessors and scalar data dependencies.
+static void collectExecPreds(Operation *op,
+                             const CVPipeline::MemoryDependenceGraph &memGraph,
+                             SmallPtrSet<Operation *, 16> &collected) {
+  SmallVector<Operation *, 16> worklist;
+
+  for (Operation *pred : memGraph.getExecBefore(op)) {
+    if (collected.insert(pred).second) {
+      worklist.push_back(pred);
+      collectScalarDeps(pred, collected, worklist);
+    }
+  }
+  while (!worklist.empty()) {
+    Operation *cur = worklist.pop_back_val();
+    for (Operation *pred : memGraph.getExecBefore(cur)) {
+      if (collected.insert(pred).second) {
+        worklist.push_back(pred);
+        collectScalarDeps(pred, collected, worklist);
+      }
+    }
+    // Trace operand dependencies for ops nested inside cur's regions
+    // (e.g., linalg.fill inside scf.if), so that their operand-defining
+    // ops are also collected and cloned.
+    for (auto &region : cur->getRegions()) {
+      for (auto &blk : region) {
+        for (auto &innerOp : blk) {
+          collectScalarDeps(&innerOp, collected, worklist);
+        }
+      }
+    }
+  }
+}
+
+/// Check if Cube depends on CubePre via bufferization::ToTensorOp defined in
+/// CubePre. If so, returns the to_tensor ops in CubePre that Cube depends on.
+static SmallVector<Operation *>
+findToTensorDeps(int cubePreId, int cubeId,
+                 const DenseMap<int, ComputeBlock> &computeBlocks,
+                 const DenseMap<int, DenseMap<int, SmallVector<Value>>>
+                     &blockEdges) {
+  SmallVector<Operation *> result;
+  auto cubePreIt = computeBlocks.find(cubePreId);
+  if (cubePreIt == computeBlocks.end()) {
+    return result;
+  }
+  DenseSet<Operation *> cubePreOpsSet(cubePreIt->second.ops.begin(),
+                                       cubePreIt->second.ops.end());
+
+  auto edgeIt = blockEdges.find(cubePreId);
+  if (edgeIt == blockEdges.end()) {
+    return result;
+  }
+  auto dstIt = edgeIt->second.find(cubeId);
+  if (dstIt == edgeIt->second.end()) {
+    return result;
+  }
+
+  for (Value operand : dstIt->second) {
+    Operation *defOp = operand.getDefiningOp();
+    if (!defOp) {
+      continue;
+    }
+    if (isa<bufferization::ToTensorOp>(defOp) && cubePreOpsSet.contains(defOp)) {
+      result.push_back(defOp);
+    }
+  }
+  return result;
+}
+
+/// Clone ops from CubePre into Cube at the front of Cube's ops.
+/// Selected ops must be in CubePre and are in `toClone`.
+static void cloneOpCrossCubeDep(int cubePreId, int cubeId,
+                             const SmallPtrSet<Operation *, 16> &toClone,
+                             const DenseMap<int, ComputeBlock> &computeBlocks,
+                             CVPipeline::ComputeBlockIdManager &bm) {
+  const auto &cubePreBlock = computeBlocks.at(cubePreId);
+  const auto &cubeBlock = computeBlocks.at(cubeId);
+
+  if (cubeBlock.ops.empty()) {
+    return;
+  }
+
+  Operation *insertBefore = cubeBlock.ops.front();
+  OpBuilder builder(insertBefore);
+  IRMapping mapper;
+  for (Operation *op : cubePreBlock.ops) {
+    if (!toClone.contains(op)) {
+      continue;
+    }
+    Operation *cloned = builder.clone(*op, mapper);
+    bm.updateBlockId(cloned, cubeId);
+    // Update block_id for all ops nested inside regions (e.g. scf.if body)
+    for (auto &region : cloned->getRegions()) {
+      for (auto &block : region) {
+        block.walk([&](Operation *innerOp) {
+          bm.updateBlockId(innerOp, cubeId);
+        });
+      }
+    }
+  }
+
+  // Remap Cube's original ops' operands: replace references to old CubePre
+  // values with the corresponding cloned values now in Cube.
+  for (Operation *op : cubeBlock.ops) {
+    if (toClone.contains(op)) {
+      continue;
+    }
+    for (auto &operand : op->getOpOperands()) {
+      if (Value mapped = mapper.lookupOrNull(operand.get())) {
+        operand.set(mapped);
+      }
+    }
+  }
+}
+
+/// Step 2: Collect VECTOR_ONLY candidates that have tensor results.
+static void collectVectorCandidates(
+    const DenseMap<int, ComputeBlock> &computeBlocks,
+    DenseSet<int> &vecCandidateSet) {
+  for (auto &kv : computeBlocks) {
+    if (kv.second.coreType != CVPipeline::CoreType::VECTOR_ONLY)
+      continue;
+    if (!hasTensorResult(kv.second))
+      continue;
+    vecCandidateSet.insert(kv.first);
+  }
+}
+
+/// Step 3: Find a pair of adjacent VECTOR blocks (predV → succV).
+/// Returns true if a pair is found.
+static bool findAdjacentVectorPair(
+    const DenseSet<int> &vecCandidateSet,
+    const DenseMap<int, SmallVector<int>> &succs, int &predVId, int &succVId) {
+  for (int candId : vecCandidateSet) {
+    auto it = succs.find(candId);
+    if (it == succs.end())
+      continue;
+    for (int succId : it->second) {
+      if (vecCandidateSet.contains(succId)) {
+        predVId = candId;
+        succVId = succId;
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/// Step 4: Try to directly merge succV into predV.
+/// Returns true if merge succeeded.
+static bool tryDirectMerge(ArrayRef<Operation *> opsToMerge,
+                           const CVPipeline::MemoryDependenceGraph &memGraph,
+                           int predVId, int succVId,
+                           CVPipeline::ComputeBlockIdManager &bm) {
+  if (willCreateCycle(opsToMerge, memGraph, predVId, bm))
+    return false;
+  LOG_DEBUG("Successfully direct merge: " << succVId << " -> " << predVId);
+
+  for (Operation *op : opsToMerge) 
+    bm.updateBlockId(op, predVId);
+  return true;
+}
+
+/// Step 5e: Collect ops in CubePre that need to be cloned to Cube to break
+/// the cycle. Returns the set of ops to clone (empty if none).
+static SmallPtrSet<Operation *, 16> collectOpsToBreakCycle(
+    int cubePreId, const DenseMap<int, ComputeBlock> &computeBlocks,
+    const SmallPtrSet<Operation *, 16> &allPredecessors) {
+  auto cbIt = computeBlocks.find(cubePreId);
+
+  SmallPtrSet<Operation *, 16> opsToClone;
+  for (Operation *op : allPredecessors) {
+    if (llvm::is_contained(cbIt->second.ops, op))
+      opsToClone.insert(op);
+  }
+  return opsToClone;
+}
+
+/// Step 5: Try cross-Cube clone to break the cycle, then merge.
+/// Returns true if merge succeeded after clone.
+static bool tryCrossCubeCloneMerge(
+    Block *block, const DenseMap<int, ComputeBlock> &computeBlocks,
+    const DenseMap<int, SmallVector<int>> &preds,
+    const DenseMap<int, DenseMap<int, SmallVector<Value>>> &blockEdges,
+    int predVId, int succVId, ArrayRef<Operation *> opsToMerge,
+    const CVPipeline::MemoryDependenceGraph &memGraph,
+    CVPipeline::ComputeBlockIdManager &bm) {
+  // 5a. Find succV's CUBE predecessor (Cube)
+  int cubeId = findCubePred(succVId, computeBlocks, preds);
+  if (cubeId == -1) {
+    LOG_DEBUG("MergeComputeBlock: succV " << succVId
+              << " has no CUBE predecessor, skipping cross-Cube clone");
+    return false;
+  }
+
+  // 5b. Find Cube's CUBE predecessor (CubePre)
+  int cubePreId = findCubePred(cubeId, computeBlocks, preds);
+  if (cubePreId == -1) {
+    LOG_DEBUG("MergeComputeBlock: Cube " << cubeId
+              << " has no CUBE predecessor, skipping cross-Cube clone");
+    return false;
+  }
+
+  // 5c. Check if Cube depends on CubePre via to_tensor
+  SmallVector<Operation *> toTensorOps =
+      findToTensorDeps(cubePreId, cubeId, computeBlocks, blockEdges);
+  if (toTensorOps.empty()) {
+    LOG_DEBUG("MergeComputeBlock: Cube(" << cubeId
+              << ") depends on CubePre(" << cubePreId
+              << ") but not via to_tensor, skipping");
+    return false;
+  }
+
+  // 5d. Trace back all transitive execution predecessors
+  SmallPtrSet<Operation *, 16> allPredecessors;
+  for (Operation *toTensor : toTensorOps) {
+    allPredecessors.insert(toTensor);
+    collectExecPreds(toTensor, memGraph, allPredecessors);
+  }
+
+  // 5e. Filter to ops in CubePre and clone to Cube
+  SmallPtrSet<Operation *, 16> opsToClone = 
+      collectOpsToBreakCycle(cubePreId, computeBlocks, allPredecessors);
+
+  for (auto op : opsToClone)
+    LOG_DEBUG("Cloning op: " << *op);
+  cloneOpCrossCubeDep(cubePreId, cubeId, opsToClone, computeBlocks, bm);
+
+  // 5f. Re-check cycle after cloning
+  if (willCreateCycle(opsToMerge, memGraph, predVId, bm)) {
+    LOG_DEBUG("MergeComputeBlock: still creates cycle after cross-Cube clone for VECTOR "
+             << predVId << " -> " << succVId);
+    return false;
+  }
+
+  LOG_DEBUG("MergeComputeBlock: Successfully merge after cross-Cube clone: "
+            << succVId << " -> " << predVId);
+  for (Operation *op : opsToMerge) 
+    bm.updateBlockId(op, predVId);
+  return true;
+}
+
+/// Core merge logic for one scf::ForOp body Block.
+static void tryMergeInBlock(Block *block, CVPipeline::ComputeBlockIdManager &bm,
+                            const CVPipeline::MemoryDependenceGraph &memGraph) {
+  while (true) {
+    // Step 1: Group and build enhanced dependency graph
+    /// computeBlocks: block_id → ComputeBlock
+    DenseMap<int, ComputeBlock> computeBlocks;
+    /// succs/preds: block_id → successor/predecessor block_id list
+    DenseMap<int, SmallVector<int>> succs;
+    DenseMap<int, SmallVector<int>> preds;
+    /// blockEdges: srcId → dstId → operands (cross-block SSA edges)
+    DenseMap<int, DenseMap<int, SmallVector<Value>>> blockEdges;
+    groupAndBuildGraph(block, computeBlocks, succs, preds, blockEdges);
+    if (computeBlocks.empty())
+      return;
+
+    // Step 2: Collect VECTOR candidates
+    DenseSet<int> vecCandidateSet;
+    collectVectorCandidates(computeBlocks, vecCandidateSet);
+    if (vecCandidateSet.size() < 2) {
+      LOG_DEBUG("MergeComputeBlock: vecCandidates.size() < 2, skipping");
+      return;
+    }
+
+    // Step 3: Find a pair of adjacent VECTOR blocks
+    int predVId = -1, succVId = -1;
+    if (!findAdjacentVectorPair(vecCandidateSet, succs, predVId, succVId)) {
+      LOG_DEBUG("MergeComputeBlock: No adjacent VECTOR pair found, skipping");
+      return;
+    }
+
+    LOG_DEBUG("Found VECTOR pair: predV=" << predVId << ", succV=" << succVId);
+
+    auto succIt = computeBlocks.find(succVId);
+    if (succIt == computeBlocks.end())
+      return;
+    SmallVector<Operation *> opsToMerge = succIt->second.ops;
+
+    // Step 4: Try direct merge
+    if (tryDirectMerge(opsToMerge, memGraph, predVId, succVId, bm))
+      continue;
+
+    // Step 5: Try cross-Cube clone merge
+    if (!tryCrossCubeCloneMerge(block, computeBlocks, preds, blockEdges,
+                                predVId, succVId, opsToMerge, memGraph, bm))
+      return;
+    // continue to try next pair
+  }
+}
+
+// ============================================================================
+// Pass Definition
+// ============================================================================
+
+namespace {
+
+class MergeComputeBlockPass
+    : public PassWrapper<MergeComputeBlockPass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MergeComputeBlockPass)
+
+  MergeComputeBlockPass() = default;
+
+  StringRef getArgument() const override { return "merge-compute-block"; }
+
+  StringRef getDescription() const override {
+    return "Merge adjacent vector compute blocks between/around CUBE blocks";
+  }
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    
+    LOG_DEBUG("Before: " << *module);
+
+    SmallVector<Block *> blocksToProcess;
+    collectInnermostMatmulLoopBlocks(module, blocksToProcess);
+
+    auto &aa = getAnalysis<AliasAnalysis>();
+    CVPipeline::MemoryDependenceGraph memGraph(module, aa);
+    CVPipeline::ComputeBlockIdManager bm(module);
+    for (Block *block : blocksToProcess) {
+      tryMergeInBlock(block, bm, memGraph);
+    }
+
+    LOG_DEBUG("After: " << *module);
+  }
+};
+
+} // namespace
+
+// ============================================================================
+// Pass Registration
+// ============================================================================
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<OperationPass<ModuleOp>> createMergeComputeBlockPass() {
+  return std::make_unique<MergeComputeBlockPass>();
+}
+
+void registerMergeComputeBlockPass() {
+  PassRegistration<MergeComputeBlockPass> reg;
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
@@ -57,6 +57,11 @@ void ComputeBlockOptPass::runOnOperation()
     pm.addPass(createFixpipeOptPass());
     pm.addPass(createReorderOpsByBlockIdPass());
 
+    if (CVPipeline::isMergeComputeBlockEnabled(module)) {
+        pm.addPass(createMergeComputeBlockPass());
+        pm.addPass(createReorderOpsByBlockIdPass());
+    }
+
     if (failed(runPipeline(pm, module))) {
         signalPassFailure();
         return;
@@ -78,6 +83,7 @@ void registerComputeBlockOptPasses()
     registerPass(createUnifyAllocBlockPass);
     registerPass(createMergeVectorIfBlockPass);
     registerPass(createMergeCubeForBlockPass);
+    registerPass(createMergeComputeBlockPass);
     registerPass(createFixpipeOptPass);
 }
 

--- a/third_party/ascend/triton_ascend.cc
+++ b/third_party/ascend/triton_ascend.cc
@@ -404,6 +404,9 @@ void init_triton_ascend_passes_ttir(py::module &&m) {
       moduleop->setAttr(CVPipeline::kInsertionOptimization, builder.getUnitAttr());
     }
   });
+  m.def("set_enable_merge_compute_block", [](mlir::ModuleOp &moduleop, bool enable) {
+    mlir::CVPipeline::setEnableMergeComputeBlock(moduleop, enable);
+  });
 
 }
 

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_compute_block.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_compute_block.mlir
@@ -1,0 +1,140 @@
+// RUN: triton-opt --allow-unregistered-dialect --merge-compute-block %s | FileCheck %s
+
+// Test merge-compute-block pass: merges adjacent VECTOR blocks between CUBE blocks,
+// cloning CUBE ops that downstream blocks depend on.
+//
+// Pattern: C1(6,CUBE) → V1(32,VECTOR) → C2(8,CUBE) → V2(33,VECTOR) → C3(10,CUBE) → C4(12,CUBE)
+// After pass:
+//   - V2(33) merged into V1(32): all block_id 33 → 32
+//   - C3(10) gets cloned alloc/copy/to_tensor chain from C2(8)
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @merge_compute_blocks(
+    %arg0: memref<?xbf16> {tt.tensor_kind = 0 : i32},
+    %arg1: memref<?xbf16> {tt.tensor_kind = 0 : i32},
+    %arg2: i32 {tt.divisibility = 16 : i32}
+  ) attributes {global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %cst_bf16 = arith.constant 0.000000e+00 : bf16
+    %cst_f32 = arith.constant 0.000000e+00 : f32
+    %cst_scale = arith.constant 0.0883883461 : f32
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %c64_i32 = arith.constant 64 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+
+    %empty_2d_bf16 = tensor.empty() : tensor<64x64xbf16>
+
+    // VECTOR block constants
+    %cst_v = arith.constant {ssbuffer.block_id = 49 : i32, ssbuffer.core_type = "VECTOR"} 0.000000e+00 : f32
+    %empty_v = tensor.empty() {ssbuffer.block_id = 49 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+    %scale = linalg.fill {ssbuffer.block_id = 49 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_scale : f32) outs(%empty_v : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+    // CUBE block constants
+    %cst_bf16_cube = arith.constant {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : bf16
+    %cst_f32_cube = arith.constant {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
+    %empty_cube_f32 = tensor.empty() {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "CUBE"} : tensor<64x64xf32>
+    %cube_init = linalg.fill {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_f32_cube : f32) outs(%empty_cube_f32 : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+    scf.for %iv = %c0_i32 to %c64_i32 step %c1_i32  : i32 {
+      // Shared index computations used by C1 and C4
+      %iv_idx = arith.index_cast %iv {ssbuffer.block_id = 26 : i32, ssbuffer.core_type = "CUBE"} : i32 to index
+      %offset64 = arith.muli %iv_idx, %c64 {ssbuffer.block_id = 26 : i32, ssbuffer.core_type = "CUBE"} : index
+      %stride_idx = arith.index_cast %arg2 {ssbuffer.block_id = 26 : i32, ssbuffer.core_type = "CUBE"} : i32 to index
+      %cond_c2 = arith.cmpi slt, %iv_idx, %c64 {ssbuffer.block_id = 26 : i32, ssbuffer.core_type = "CUBE"} : index
+
+      // ==========================================
+      // C1: Block 6 (CUBE) — produces %tensor_c1 used by V1(32) and C4(12)
+      // ==========================================
+      // CHECK: memref.alloc() {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"}
+      %alloc_c1 = memref.alloc() {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16>
+      %cond_c1 = arith.cmpi slt, %iv_idx, %c64 {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : index
+      scf.if %cond_c1 {
+        linalg.fill {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_bf16 : bf16) outs(%alloc_c1 : memref<64x64xbf16>)
+      } {hivm.unlikely_condition, ssbuffer.block_id = 6 : i32}
+      %reint_c1 = memref.reinterpret_cast %arg0 to offset: [%offset64], sizes: [64, 64], strides: [%stride_idx, 1] {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<?xbf16> to memref<64x64xbf16, strided<[?, 1], offset: ?>>
+      %subv_c1_src = memref.subview %reint_c1[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16, strided<[?, 1], offset: ?>> to memref<64x64xbf16, strided<[?, 1], offset: ?>>
+      %subv_c1_dst = memref.subview %alloc_c1[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16> to memref<64x64xbf16, strided<[64, 1]>>
+      memref.copy %subv_c1_src, %subv_c1_dst {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16, strided<[?, 1], offset: ?>> to memref<64x64xbf16, strided<[64, 1]>>
+      %tensor_c1 = bufferization.to_tensor %alloc_c1 restrict writable {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16>
+      %matmul_c1 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE", ssbuffer.loop_carried_l0c} ins(%tensor_c1, %tensor_c1 : tensor<64x64xbf16>, tensor<64x64xbf16>) outs(%cube_init : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+      // ==========================================
+      // V1: Block 32 (VECTOR) — CUBE pred=6, CUBE succ=8, edge 32→33 via %v1_exp
+      // ==========================================
+      // CHECK: arith.mulf {{%.*}}, {{%.*}} {ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"}
+      %v1_mul = arith.mulf %matmul_c1, %scale {ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+      // CHECK: math.exp {{%.*}} {ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"}
+      %v1_exp = math.exp %v1_mul {ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+      // CHECK: arith.truncf {{%.*}} {ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"}
+      %v1_trunc = arith.truncf %v1_exp {ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xbf16>
+
+      // ==========================================
+      // C2: Block 8 (CUBE) — has copy chain with dedicated arith ops that C3(10) depends on
+      // ==========================================
+      // CHECK: memref.alloc() {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"}
+      %alloc_c2 = memref.alloc() {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16>
+      scf.if %cond_c2 {
+        linalg.fill {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_bf16 : bf16) outs(%alloc_c2 : memref<64x64xbf16>)
+      } {hivm.unlikely_condition, ssbuffer.block_id = 8 : i32}
+      // Dedicated arith ops in C2 for the reinterpret_cast offset computation
+      %c2_stride = arith.index_cast %arg2 {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : i32 to index
+      %c2_mul = arith.muli %iv_idx, %c2_stride {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : index
+      %c2_offset = arith.addi %offset64, %c2_mul {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : index
+      %reint_c2 = memref.reinterpret_cast %arg1 to offset: [%c2_offset], sizes: [64, 64], strides: [%c2_stride, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : memref<?xbf16> to memref<64x64xbf16, strided<[?, 1], offset: ?>>
+      %subv_c2_src = memref.subview %reint_c2[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16, strided<[?, 1], offset: ?>> to memref<64x64xbf16, strided<[?, 1], offset: ?>>
+      %subv_c2_dst = memref.subview %alloc_c2[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16> to memref<64x64xbf16, strided<[64, 1]>>
+      // CHECK: memref.copy {{%.*}}, {{%.*}} {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"}
+      memref.copy %subv_c2_src, %subv_c2_dst {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16, strided<[?, 1], offset: ?>> to memref<64x64xbf16, strided<[64, 1]>>
+      // CHECK: bufferization.to_tensor {{%.*}} {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"}
+      %tensor_c2 = bufferization.to_tensor %alloc_c2 restrict writable {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16>
+      %transposed_v1 = linalg.transpose ins(%v1_trunc : tensor<64x64xbf16>) outs(%empty_2d_bf16 : tensor<64x64xbf16>) permutation = [1, 0]  {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"}
+      %matmul_c2 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE", ssbuffer.loop_carried_l0c} ins(%transposed_v1, %tensor_c2 : tensor<64x64xbf16>, tensor<64x64xbf16>) outs(%cube_init : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+      // ==========================================
+      // C3: Block 10 (CUBE) — uses %tensor_c2 from C2, triggers clone from C2
+      // After pass: cloned alloc/index_cast/muli/addi/reinterpret_cast/subview×2/copy/to_tensor from C2
+      // ==========================================
+      // CHECK: memref.alloc() {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: scf.if {{%.*}} {
+      // CHECK:   linalg.fill {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: } {hivm.unlikely_condition, ssbuffer.block_id = 10 : i32}
+      // CHECK: arith.index_cast {{%.*}} {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: arith.muli {{%.*}}, {{%.*}} {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: arith.addi {{%.*}}, {{%.*}} {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: memref.reinterpret_cast {{%.*}} to offset: [{{%.*}}], sizes: [64, 64], strides: [{{%.*}}, 1] {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: memref.subview {{%.*}}[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: memref.subview {{%.*}}[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: memref.copy {{%.*}}, {{%.*}} {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: bufferization.to_tensor {{%.*}} {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: linalg.matmul {{.*}}ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"
+      %matmul_c3 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE", ssbuffer.loop_carried_l0c} ins(%tensor_c2, %tensor_c2 : tensor<64x64xbf16>, tensor<64x64xbf16>) outs(%cube_init : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+      // ==========================================
+      // V2: Block 33 (VECTOR) — uses %v1_exp (edge 32→33), %matmul_c3 (edge 10→33)
+      // After pass: merged into V1(32), all block_id 33 → 32
+      // ==========================================
+      // CHECK: arith.subf {{%.*}}, {{%.*}} {{{.*}}ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"}
+      %v2_sub = arith.subf %matmul_c3, %v1_exp {ssbuffer.block_id = 33 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+      // CHECK: arith.mulf {{%.*}}, {{%.*}} {{{.*}}ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"}
+      %v2_mul = arith.mulf %v1_exp, %v2_sub {ssbuffer.block_id = 33 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+      // CHECK: arith.mulf {{%.*}}, {{%.*}} {{{.*}}ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"}
+      %v2_mul2 = arith.mulf %v2_mul, %scale {ssbuffer.block_id = 33 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+      // CHECK: arith.truncf {{%.*}} {{{.*}}ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"}
+      %v2_trunc = arith.truncf %v2_mul2 {ssbuffer.block_id = 33 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xbf16>
+
+      // ==========================================
+      // C4: Block 12 (CUBE) — uses %v2_trunc (edge 33→12) and %tensor_c1 (edge 6→12)
+      // ==========================================
+      %transposed_v2 = linalg.transpose ins(%v2_trunc : tensor<64x64xbf16>) outs(%empty_2d_bf16 : tensor<64x64xbf16>) permutation = [1, 0]  {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: linalg.matmul {{.*}}ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "CUBE"
+      %matmul_c4 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "CUBE", ssbuffer.loop_carried_l0c} ins(%transposed_v2, %tensor_c1 : tensor<64x64xbf16>, tensor<64x64xbf16>) outs(%cube_init : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+      // Store output to prevent DCE
+      %reint_out = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [64, 64], strides: [%stride_idx, 1] {ssbuffer.block_id = 14 : i32, ssbuffer.core_type = "CUBE"} : memref<?xbf16> to memref<64x64xbf16, strided<[?, 1], offset: ?>>
+      %trunc_c4 = arith.truncf %matmul_c4 {ssbuffer.block_id = 14 : i32, ssbuffer.core_type = "CUBE"} : tensor<64x64xf32> to tensor<64x64xbf16>
+      bufferization.materialize_in_destination %trunc_c4 in writable %reint_out {ssbuffer.block_id = 14 : i32, ssbuffer.core_type = "CUBE"} : (tensor<64x64xbf16>, memref<64x64xbf16, strided<[?, 1], offset: ?>>) -> ()
+    }
+    return
+  }
+}


### PR DESCRIPTION
### 背景

在 DynamicCVPipeline 中，算子按 `block_id` 分组为 ComputeBlock，分为 `CUBE_ONLY`和 `VECTOR_ONLY`两类。CUBE 块之间的 VECTOR 块数量过多会增加 UB 开销。相邻 VECTOR 块之间不存在数据依赖冲突时，可以合并以减少块数量。



### 代码流程

1. **定位处理范围**：遍历 `ModuleOp`，找到包含 `linalg::MatmulOp` 的最内层 `scf::ForOp` 的 body block。

2. **构建依赖图** (`groupAndBuildGraph`)：按 `block_id` 将算子分组，建立块间 SSA 依赖图（successors / predecessors / blockEdges）。

3. **收集候选** (`collectVectorCandidates`)：筛选出有 tensor 类型结果的 `VECTOR_ONLY` 块。

4. **寻找相邻对** (`findAdjacentVectorPair`)：在候选集中找到相邻的 VECTOR 块对 (predV → succV)。

5. **直接合并** (`tryDirectMerge`)：若无环依赖，直接将 succV 的算子 `block_id` 改为 predV 的。

6. **跨 Cube 克隆合并** (`tryCrossCubeCloneMerge`)：若直接合并会形成环：
   - 找到 succV 的 CUBE 前驱 (Cube) 及 Cube 的 CUBE 前驱 (CubePre)
   - 确认 Cube 通过 `bufferization::ToTensorOp` 依赖 CubePre
   - 利用 `MemoryDependenceGraph` 追溯所有传递执行前驱
   - 将 CubePre 中的相关算子克隆到 Cube 中，打破循环依赖
   - 再次尝试合并

7. **循环迭代**：合并成功后继续在当前 block 中寻找下一对相邻 VECTOR 块，直到无法合并为止。

---

### Background

In DynamicCVPipeline, operations are grouped into ComputeBlocks by `block_id`, categorized as `CUBE_ONLY` (matmul) or `VECTOR_ONLY`. Excessive VECTOR blocks between CUBE blocks cause fUB overhead. Adjacent VECTOR blocks without data dependency conflicts can be merged to reduce block count.

### Code Flow

1. **Scope identification**: Walk the `ModuleOp` to find body blocks of the innermost `scf::ForOp` that contain `linalg::MatmulOp`.

2. **Dependency graph construction** (`groupAndBuildGraph`): Group ops by `block_id` and build inter-block SSA dependency edges (successors / predecessors / blockEdges).

3. **Candidate collection** (`collectVectorCandidates`): Filter `VECTOR_ONLY` blocks that have tensor-typed results.

4. **Adjacent pair discovery** (`findAdjacentVectorPair`): Find a pair of adjacent VECTOR blocks (predV → succV) from the candidate set.

5. **Direct merge** (`tryDirectMerge`): If no cycle would be created, reassign succV's ops to predV's `block_id`.

6. **Cross-Cube clone merge** (`tryCrossCubeCloneMerge`): When direct merge would create a cycle:
   - Identify succV's CUBE predecessor (Cube) and Cube's CUBE predecessor (CubePre)
   - Verify Cube depends on CubePre via `bufferization::ToTensorOp`
   - Trace all transitive execution predecessors using `MemoryDependenceGraph`
   - Clone relevant ops from CubePre into Cube to break the cycle
   - Retry the merge

7. **Iterative merging**: After a successful merge, continue searching for the next adjacent VECTOR pair in the same block until no more merges are possible.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
