### PR TITLE
[CI](fix) DCO check Set to fail without blocking

### DIFF
--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -18,6 +18,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: KineticCafe/actions-dco@v3.2.0
+        continue-on-error: true
         with:
           config: |
             comment = true


### PR DESCRIPTION
### Summary
DCO inspection should be treated as an auxiliary task. Here, it is modified to only alert the commitor when the task fails, without blocking the task from running.