### PR TITLE
[launch](fix) make NPU utils launcher relocatable

### DIFF
--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -416,6 +416,7 @@ def generate_npu_header_src():
 #define TRITON_NPU_HEADERS
 #include <assert.h>
 #include <stdbool.h>
+#include <cstdlib>
 #include <string>
 #include <memory>
 #include <sys/syscall.h>
@@ -686,6 +687,13 @@ def make_launcher(constants, signature, metadata):
     npu_utils_inst = NPUUtils()
     npu_utils_mod = getattr(npu_utils_inst, "npu_utils_mod", None)
     npu_utils_so_path = getattr(npu_utils_mod, "__file__", "")
+    # The generated launcher source is part of its cache key. Preserve only the
+    # deterministic cache-key directory so the launcher can be reused after the
+    # cache root changes.
+    npu_utils_cache_relative = os.path.join(
+        os.path.basename(os.path.dirname(npu_utils_so_path)),
+        os.path.basename(npu_utils_so_path),
+    )
     cpp_npu_utils_dlopen = f"""
 typedef void* (*triton_allocate_workspace_t)(uint64_t, void**);
 typedef void* (*triton_allocate_sync_block_lock_t)(uint64_t, void*, void**);
@@ -706,10 +714,23 @@ static bool npu_utils_ready() {{
 
 static void init_npu_utils() {{
     if (npu_utils_ready()) return;
-    const char* so_path = "{npu_utils_so_path}";
-    void* handle = dlopen(so_path, RTLD_LAZY);
+    const char* cache_root = std::getenv("TRITON_CACHE_DIR");
+    std::string npu_utils_path;
+    if (cache_root && cache_root[0] != '\\0') {{
+        npu_utils_path = std::string(cache_root) + "/{npu_utils_cache_relative}";
+    }} else {{
+        const char* triton_home = std::getenv("TRITON_HOME");
+        const char* home = std::getenv("HOME");
+        const char* base = triton_home && triton_home[0] != '\\0' ? triton_home : home;
+        if (!base || base[0] == '\\0') {{
+            fprintf(stderr, "Error: neither TRITON_CACHE_DIR nor TRITON_HOME/HOME is set\\n");
+            return;
+        }}
+        npu_utils_path = std::string(base) + "/.triton/cache/{npu_utils_cache_relative}";
+    }}
+    void* handle = dlopen(npu_utils_path.c_str(), RTLD_LAZY);
     if (!handle) {{
-        fprintf(stderr, "Error: dlopen %s failed: %s\\n", so_path, dlerror());
+        fprintf(stderr, "Error: dlopen %s failed: %s\\n", npu_utils_path.c_str(), dlerror());
         return;
     }}
     g_allocate_workspace = (triton_allocate_workspace_t)dlsym(handle, "triton_allocate_workspace");

--- a/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
+++ b/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
@@ -79,6 +79,56 @@ def test_make_launcher_exposes_triton_launch_kernel(
 @patch.object(driver, "is_ffts_supported", return_value=True)
 @patch.object(driver, "get_ascend_arch_from_env", return_value="Ascend910B")
 @patch.object(driver, "get_backend_func", side_effect=_mock_backend_func)
+def test_make_launcher_resolves_npu_utils_from_active_cache_root(
+    _mock_backend_func_patch,
+    _mock_arch,
+    _mock_ffts,
+    _mock_disable_ffts,
+    _mock_auto_map,
+    mock_npu_utils,
+):
+    cache_key = "NPU_UTILS_CACHE_KEY"
+
+    def make_utils(cache_root):
+        return SimpleNamespace(
+            get_aivector_core_num=lambda: 40,
+            get_aicore_num=lambda: 20,
+            npu_utils_mod=SimpleNamespace(__file__=f"{cache_root}/{cache_key}/npu_utils.so"),
+        )
+
+    producer_utils = make_utils("/producer/cache")
+    consumer_utils = make_utils("/consumer/cache")
+    # make_launcher currently reads NPUUtils once for core counts and once for
+    # the loaded module path.
+    mock_npu_utils.side_effect = [producer_utils, producer_utils, consumer_utils, consumer_utils]
+
+    producer_src = driver.make_launcher(
+        constants={},
+        signature={0: "*fp32", 1: "*fp32"},
+        metadata=_make_metadata(),
+    )
+    consumer_src = driver.make_launcher(
+        constants={},
+        signature={0: "*fp32", 1: "*fp32"},
+        metadata=_make_metadata(),
+    )
+
+    assert producer_src == consumer_src
+    assert "/producer/cache" not in producer_src
+    assert "/consumer/cache" not in consumer_src
+    assert '#include <cstdlib>' in producer_src
+    assert 'const char* cache_root = std::getenv("TRITON_CACHE_DIR");' in producer_src
+    assert f'npu_utils_path = std::string(cache_root) + "/{cache_key}/npu_utils.so";' in producer_src
+    assert 'const char* triton_home = std::getenv("TRITON_HOME");' in producer_src
+    assert f'npu_utils_path = std::string(base) + "/.triton/cache/{cache_key}/npu_utils.so";' in producer_src
+
+
+@patch.object(driver, "NPUUtils")
+@patch.object(driver, "_is_auto_map_parallel_blocks_enabled", return_value=False)
+@patch.object(driver, "force_disable_ffts", return_value=False)
+@patch.object(driver, "is_ffts_supported", return_value=True)
+@patch.object(driver, "get_ascend_arch_from_env", return_value="Ascend910B")
+@patch.object(driver, "get_backend_func", side_effect=_mock_backend_func)
 def test_make_launcher_shrinks_coalesced_grid_for_both_launch_paths(
     _mock_backend_func_patch,
     _mock_arch,


### PR DESCRIPTION
## Summary

- Resolve `npu_utils.so` from the active Triton cache root at launcher runtime.
- Keep generated launcher source independent of the cache root so restored caches reuse the launcher artifact.
- Add a launcher-source regression for producer and consumer cache roots.

## Problem before this change

The issue was not that `npu_utils.so` could not be built. The issue was that the generated NPU launcher embedded the **absolute path** of that library in generated C++ source.

During launcher generation, `NPUUtils` exposes the path of the already loaded module through `npu_utils_mod.__file__`. Before this change, that value was inserted directly into the generated launcher:

```cpp
const char* so_path =
    "/mnt/ci/triton-cache/NPU_UTILS_KEY/npu_utils.so";
void* handle = dlopen(so_path, RTLD_LAZY);
```

The launcher stub cache key is computed from the generated header and wrapper source:

```text
sha256(header_src + "\\0" + wrapper_src)
```

Therefore, the absolute cache root was part of `wrapper_src` and, in turn, part of the launcher cache key. Moving the same cache contents to a different root changed the generated source even when the kernel, compiler options, and `npu_utils.so` cache-key directory were otherwise identical.

## Concrete cache-relocation example

### 1. Build machine

Assume a build machine uses:

```text
TRITON_CACHE_DIR=/mnt/ci/triton-cache
```

For a given NPU Utils cache key, the library is materialized as:

```text
/mnt/ci/triton-cache/NPU_UTILS_KEY/npu_utils.so
```

Before this change, the generated launcher source contains that exact `/mnt/ci/...` path. Let the resulting launcher cache key be `LA`.

### 2. Restore the cache on a runtime machine

The cache is copied or restored under a different root:

```text
TRITON_CACHE_DIR=/data/runtime/triton-cache
```

The same library is now located at:

```text
/data/runtime/triton-cache/NPU_UTILS_KEY/npu_utils.so
```

### 3. What happened before this change

There were two problematic outcomes:

1. **Normal launcher generation:** `npu_utils_mod.__file__` now points to `/data/runtime/...`. The newly generated wrapper source embeds that new absolute path, so its launcher cache key becomes `LB`, where `LB != LA` solely because the cache root changed. The restored launcher artifact under `LA` is not reused and the launcher must be rebuilt.
2. **Direct reuse of an existing launcher artifact:** the old launcher still calls `dlopen("/mnt/ci/triton-cache/.../npu_utils.so")`. If the build-machine path does not exist on the runtime machine, dynamic loading fails even though the same library is present under `/data/runtime/...`.

This is a launcher-stub cache reuse and dynamic-library lookup problem. It does not by itself mean that TTIR, TTAdapter, or NPUbin artifacts are invalid.

## Behavior after this change

The generated source now preserves only the stable relative suffix:

```text
NPU_UTILS_KEY/npu_utils.so
```

At runtime, the launcher constructs the full path as follows:

1. Use `TRITON_CACHE_DIR` when it is set and non-empty.
2. Otherwise, use `TRITON_HOME`; if it is unset, use `HOME`.
3. For the fallback case, resolve the default Triton cache layout as `<base>/.triton/cache/NPU_UTILS_KEY/npu_utils.so`.

Consequently, the launcher source generated on the build machine and the runtime machine is identical with respect to the cache root. The launcher cache key can be reused after cache relocation, while `dlopen` still targets the active machine's actual cache location.

The NPU Utils cache-key directory is intentionally retained. It distinguishes the library built for the current NPU Utils source and backend version; relocation should not make a launcher load a library from a different key.

## Validation scope

The new unit test generates launcher source twice using different producer and consumer cache roots. It verifies that:

- both generated sources are identical;
- neither absolute cache root appears in the generated source;
- the generated C++ contains the `TRITON_CACHE_DIR` branch and the `TRITON_HOME`/`HOME` fallback.

The test validates source generation and launcher-cache-key stability. It does not compile the generated launcher, execute `dlopen`, or run an NPU kernel; those remain runtime/integration validation boundaries.

## Testing

- `python3 -m pytest -q --confcutdir=third_party/ascend/unittest/pytest_ut third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py` (7 passed)
- Targeted pre-commit hooks: `check-ast`, `trailing-whitespace`, `end-of-file-fixer`, `check-merge-conflict`, `yapf`
