### PR TITLE
[issue](fix) pytest>=8.3.2,<9.0.0

### DIFF
--- a/setup_ascend.py
+++ b/setup_ascend.py
@@ -305,7 +305,7 @@ def _get_install_requirements():
         "scipy==1.15.1;python_version>='3.13'",
         "decorator==5.1.1",
         "psutil==6.0.0",
-        "pytest==8.3.2",
+        "pytest>=8.3.2,<9.0.0",
         "pytest-xdist==3.6.1",
         "pyyaml",
         "pybind11",


### PR DESCRIPTION
https://github.com/triton-lang/triton-ascend/issues/215
用户期望pytest版本不要写死，根据实际情况，
基于pytest-xdist==3.6.1, 将调整为pytest>=8.3.2,<9.0.0 
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
