### PR TITLE
[ssbuffer](fix) alloc ops should exec after unknown ops.

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -3277,6 +3277,9 @@ class range(base_value):
     :param disable_licm: Tells the compiler it shouldn't hoist loop invariant
         code outside the loop. This is often useful to avoid creating long liveranges
         within a loop.
+    :param compile_hint: Optional backend compile hint attached to this loop.
+        Ascend accepts ``"main_loop"`` to explicitly select the loop used by
+        the dynamic CV pipeline.
 
         Note that warp specialization is only supported on Blackwell GPUs and
         only works on simple matmul loops. Support for arbitrary loops will be
@@ -3284,7 +3287,8 @@ class range(base_value):
     """
 
     def __init__(self, arg1, arg2=None, step=None, num_stages=None, loop_unroll_factor=None,
-                 disallow_acc_multi_buffer=False, flatten=False, warp_specialize=False, disable_licm=False):
+                 disallow_acc_multi_buffer=False, flatten=False, warp_specialize=False, disable_licm=False,
+                 compile_hint=None):
         if step is None:
             self.step = constexpr(1)
         else:
@@ -3301,6 +3305,7 @@ class range(base_value):
         self.flatten = flatten
         self.warp_specialize = warp_specialize
         self.disable_licm = disable_licm
+        self.compile_hint = compile_hint
 
     def __iter__(self):
         raise RuntimeError("tl.range can only be used in @triton.jit'd functions")

--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -46,6 +46,8 @@ inline constexpr llvm::StringLiteral kCubeFirst = "ssbuffer.cube_first";
 inline constexpr llvm::StringLiteral kVectorFirst = "ssbuffer.vector_first";
 inline constexpr llvm::StringLiteral kAddFromMatmul =
     "ssbuffer.add_from_matmul";
+inline constexpr llvm::StringLiteral kLoopCompileHint = "tt.compile_hint";
+inline constexpr llvm::StringLiteral kMainLoopHint = "main_loop";
 inline constexpr llvm::StringLiteral kMainLoop = "ssbuffer.main_loop";
 inline constexpr llvm::StringLiteral kTcoreType = "hivm.tcore_type";
 inline constexpr llvm::StringLiteral kIf = "ssbuffer.if";

--- a/third_party/ascend/language/cann/extension/aux_ops.py
+++ b/third_party/ascend/language/cann/extension/aux_ops.py
@@ -93,11 +93,15 @@ class parallel(range):
         This is used in the mixed cube-vector kernel on 910B. The number of vector cores is determined by the
         number of iterations in this loop. Currently on 910B, at most 2 vector cores can be used.
     :type bind_sub_block: bool
+    :param compile_hint: Optional backend compile hint attached to this loop.
+        Use ``"main_loop"`` to explicitly select the dynamic CV pipeline's
+        main loop.
+    :type compile_hint: str | None
     """
 
     def __init__(self, arg1, arg2=None, step=None, num_stages=None, loop_unroll_factor=None,
-                 bind_sub_block: bool = False):
-        super().__init__(arg1, arg2, step, num_stages, loop_unroll_factor)
+                 bind_sub_block: bool = False, compile_hint=None):
+        super().__init__(arg1, arg2, step, num_stages, loop_unroll_factor, compile_hint=compile_hint)
         self.bind_sub_block = bind_sub_block
 
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/MarkMainLoop.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/MarkMainLoop.cpp
@@ -46,6 +46,27 @@ void MarkMainLoopPass::runOnOperation() {
   int mainLoopIdCounter = 0;
   SmallVector<Operation *> mainLoops;
 
+  // An explicit frontend hint takes precedence over the Fixpipe/Copy based
+  // heuristic below. This lets users select an outer loop even when a nested
+  // loop also contains a candidate operation.
+  module.walk([&](scf::ForOp forOp) {
+    auto hint = forOp->getAttrOfType<StringAttr>(CVPipeline::kLoopCompileHint);
+    if (hint && hint.getValue() == CVPipeline::kMainLoopHint)
+      mainLoops.push_back(forOp);
+  });
+
+  if (!mainLoops.empty()) {
+    for (Operation *loopOp : mainLoops) {
+      loopOp->removeAttr(CVPipeline::kLoopCompileHint);
+      loopOp->setAttr(
+          CVPipeline::kMainLoop,
+          Builder(module.getContext()).getI32IntegerAttr(mainLoopIdCounter++));
+    }
+    LOG_DEBUG("selected " << mainLoops.size()
+                          << " explicitly hinted main loop(s)\n");
+    return;
+  }
+
   // Find all candidate main loops (ForOp + WhileOp)
   auto isL1Fixpipe = [](Operation *op) -> bool {
     auto fixpipeOp = dyn_cast<hivm::FixpipeOp>(op);

--- a/third_party/ascend/lib/TritonToGraph/Rules/LoadStoreTransposeRule.cpp
+++ b/third_party/ascend/lib/TritonToGraph/Rules/LoadStoreTransposeRule.cpp
@@ -1927,6 +1927,7 @@ LogicalResult applyCandidate(IRRewriter &rewriter,
   auto newFor = rewriter.create<scf::ForOp>(
       oldFor.getLoc(), oldFor.getLowerBound(), oldFor.getUpperBound(),
       oldFor.getStep(), newInitArgs);
+  newFor->setAttrs(oldFor->getAttrs());
   created.push_back(newFor.getOperation());
   Block *newBody = newFor.getBody();
   // The generated SCF builder may leave a newly created body empty.  Do not

--- a/third_party/ascend/lib/TritonToStructured/CannonicalizerConverter.cpp
+++ b/third_party/ascend/lib/TritonToStructured/CannonicalizerConverter.cpp
@@ -819,9 +819,11 @@ PromotePointerIterArgsPattern::createNewIterArgsForAdvancePtr(
 scf::ForOp PromotePointerIterArgsPattern::createNewForLoop(
     scf::ForOp forOp, ArrayRef<Value> newInitArgs,
     ArrayRef<Type> newIterArgTypes, PatternRewriter &rewriter) const {
-  return rewriter.create<scf::ForOp>(forOp.getLoc(), forOp.getLowerBound(),
-                                     forOp.getUpperBound(), forOp.getStep(),
-                                     newInitArgs);
+  auto newFor = rewriter.create<scf::ForOp>(
+      forOp.getLoc(), forOp.getLowerBound(), forOp.getUpperBound(),
+      forOp.getStep(), newInitArgs);
+  newFor->setAttrs(forOp->getAttrs());
+  return newFor;
 }
 
 LogicalResult PromotePointerIterArgsPattern::rewriteLoopBody(
@@ -1957,6 +1959,7 @@ SimplifyTensorIterArgsPattern::rewriteForWithLocalCandidates(
   auto newFor = rewriter.create<scf::ForOp>(
       forOp.getLoc(), forOp.getLowerBound(), forOp.getUpperBound(),
       forOp.getStep(), newInitArgs);
+  newFor->setAttrs(forOp->getAttrs());
   newFor->setAttr(kIncompleteAttr, rewriter.getUnitAttr());
 
   auto failAfterCreate = [&]() -> LogicalResult {
@@ -2274,6 +2277,7 @@ SimplifyTensorIterArgsPattern::rewriteOuterForWithRelayCandidates(
   auto newOuterFor = rewriter.create<scf::ForOp>(
       outerFor.getLoc(), outerFor.getLowerBound(), outerFor.getUpperBound(),
       outerFor.getStep(), newOuterInitArgs);
+  newOuterFor->setAttrs(outerFor->getAttrs());
   newOuterFor->setAttr(kIncompleteAttr, rewriter.getUnitAttr());
 
   auto failAfterCreate = [&]() -> FailureOr<scf::ForOp> {

--- a/third_party/ascend/patch/triton-ascend-3.6.0.patch
+++ b/third_party/ascend/patch/triton-ascend-3.6.0.patch
@@ -449,7 +449,7 @@ index a3cf0ff0c..28ba11c92 100644
  
      if numel > TRITON_MAX_TENSOR_NUMEL:
 diff --git a/python/triton/compiler/code_generator.py b/python/triton/compiler/code_generator.py
-index c572f81e3..6e06b8477 100644
+index c572f81e3..90287eca8 100644
 --- a/python/triton/compiler/code_generator.py
 +++ b/python/triton/compiler/code_generator.py
 @@ -10,8 +10,16 @@ from dataclasses import dataclass
@@ -568,27 +568,41 @@ index c572f81e3..6e06b8477 100644
          # Lower `with` statements by constructing context managers and calling their enter/exit hooks
          # Instantiate each context manager with builder injection
          cm_list = []
-@@ -1147,7 +1199,7 @@ class CodeGenerator(ast.NodeVisitor):
+@@ -1147,7 +1199,8 @@ class CodeGenerator(ast.NodeVisitor):
          flatten = False
          warp_specialize = False
          disable_licm = False
++        compile_hint = None
 -        if IteratorClass is language.range:
 +        if IteratorClass in [language.range, extension.parallel]:
              iterator = IteratorClass(*iter_args, **iter_kwargs)
              # visit iterator arguments
              # note: only `range` iterator is supported now
-@@ -1224,7 +1276,9 @@ class CodeGenerator(ast.NodeVisitor):
+@@ -1161,6 +1214,7 @@ class CodeGenerator(ast.NodeVisitor):
+             flatten = iterator.flatten
+             warp_specialize = iterator.warp_specialize
+             disable_licm = iterator.disable_licm
++            compile_hint = iterator.compile_hint
+         elif IteratorClass is range:
+             # visit iterator arguments
+             # note: only `range` iterator is supported now
+@@ -1224,7 +1278,14 @@ class CodeGenerator(ast.NodeVisitor):
              if warp_specialize:
                  for_op.set_attr("tt.warp_specialize", self.builder.get_unit_attr())
              if disable_licm:
 -                for_op.set_attr("llvm.loop_annotation", self.builder.get_disable_loop_licm_attr())
 +                for_op.set_attr("tt.disable_licm", self.builder.get_unit_attr())
++            compile_hint = _unwrap_if_constexpr(compile_hint)
++            if compile_hint is not None:
++                if not isinstance(compile_hint, str):
++                    raise TypeError(f"For loop compile_hint must be a string, got {type(compile_hint).__name__}")
++                for_op.set_attr("tt.compile_hint", self.builder.get_string_attr(compile_hint))
 +            if (IteratorClass is extension.parallel):
 +                for_op.set_attr("hivm.parallel_loop", self.builder.get_unit_attr())
  
              self.scf_stack.append(node)
              for_op_body = for_op.get_body(0)
-@@ -1286,7 +1340,7 @@ class CodeGenerator(ast.NodeVisitor):
+@@ -1286,7 +1347,7 @@ class CodeGenerator(ast.NodeVisitor):
          args = inspect.getcallargs(fn.fn, *args, **kwargs)
          args = [args[name] for name in fn.arg_names]
          for i, arg in enumerate(args):
@@ -597,7 +611,7 @@ index c572f81e3..6e06b8477 100644
                  args[i] = language.core.constexpr(arg)
          args_cst = find_paths_if(args, lambda _, x: _is_constexpr(x))
          args_cst = {path: get_iterable_path(args, path) for path in args_cst}
-@@ -1340,6 +1394,11 @@ class CodeGenerator(ast.NodeVisitor):
+@@ -1340,6 +1401,11 @@ class CodeGenerator(ast.NodeVisitor):
              return self.call_JitFunction(fn, args, kws)
          if (hasattr(fn, '__self__') and _is_triton_value(fn.__self__)) or language.core.is_builtin(fn) or isinstance(
                  fn, ConstexprFunction):
@@ -609,7 +623,7 @@ index c572f81e3..6e06b8477 100644
              extra_kwargs = dict()
  
              if isinstance(fn, ConstexprFunction):
-@@ -1355,6 +1414,9 @@ class CodeGenerator(ast.NodeVisitor):
+@@ -1355,6 +1421,9 @@ class CodeGenerator(ast.NodeVisitor):
                  # builtin functions return plain tuples for readability
                  if isinstance(ret, tuple):
                      ret = language.tuple(ret)
@@ -619,7 +633,7 @@ index c572f81e3..6e06b8477 100644
                  return ret
              except Exception as e:
                  if knobs.compilation.front_end_debugging:
-@@ -1594,6 +1656,7 @@ class CodeGenerator(ast.NodeVisitor):
+@@ -1594,6 +1663,7 @@ class CodeGenerator(ast.NodeVisitor):
          ttgl.static_print: static_executor(print),
          int: static_executor(int),
          len: static_executor(len),

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_mark_main_loop_hint.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_mark_main_loop_hint.mlir
@@ -1,0 +1,20 @@
+// RUN: triton-opt --mark-main-loop %s | FileCheck %s --implicit-check-not="tt.compile_hint"
+
+// An explicit frontend hint must select the outer loop even though the
+// Fixpipe/Copy heuristic would otherwise select the inner loop.
+// CHECK-LABEL: func.func @explicit_outer_main_loop
+// CHECK: scf.for
+// CHECK:   scf.for
+// CHECK:   } {test.loop = "candidate"}
+// CHECK: } {ssbuffer.main_loop = 0 : i32, test.loop = "selected"}
+// CHECK-NOT: ssbuffer.main_loop
+func.func @explicit_outer_main_loop(%src: tensor<4xf32>, %dst: memref<4xf32>,
+                                    %lb: index, %ub: index, %step: index) {
+  scf.for %outer = %lb to %ub step %step {
+    scf.for %inner = %lb to %ub step %step {
+      hivm.hir.copy ins(%src : tensor<4xf32>) outs(%dst : memref<4xf32>)
+    } {test.loop = "candidate"}
+  } {test.loop = "selected", tt.compile_hint = "main_loop"}
+  return
+}
+

--- a/third_party/ascend/unittest/pytest_ut/test_main_loop_hint.py
+++ b/third_party/ascend/unittest/pytest_ut/test_main_loop_hint.py
@@ -1,0 +1,76 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import triton
+import triton.language as tl
+from triton._C.libtriton import ir
+from triton._C.libtriton.ascend import ir as ascend_ir
+from triton.backends.ascend import _apply_ascend_patch
+from triton.backends.ascend.compiler import NPUOptions, make_ttir, min_dot_size, ttir_to_linalg
+from triton.compiler.code_generator import ast_to_ttir
+from triton.compiler.compiler import ASTSource
+
+
+_apply_ascend_patch()
+
+
+class Options:
+    num_warps = 4
+    num_stages = 1
+    num_ctas = 1
+    cluster_dims = (1, 1, 1)
+    enable_fp_fusion = True
+    debug = False
+    sanitize_overflow = True
+
+
+@triton.jit
+def loop_hint_kernel(out, n):
+    for i in tl.range(0, n, compile_hint="main_loop"):
+        tl.store(out + i, i)
+
+
+def test_range_compile_hint_is_emitted():
+    src = ASTSource(loop_hint_kernel, {"out": "*i32", "n": "i32"}, {})
+    context = ir.context()
+    ir.load_dialects(context)
+    ascend_ir.load_dialects(context)
+    module = ast_to_ttir(loop_hint_kernel, src, context, Options(), {}, {})
+
+    ttir = str(module)
+    assert ttir.count('tt.compile_hint = "main_loop"') == 1
+
+
+def test_range_compile_hint_survives_ttadapter_lowering():
+    src = ASTSource(loop_hint_kernel, {"out": "*i32", "n": "i32"}, {})
+    context = ir.context()
+    ir.load_dialects(context)
+    ascend_ir.load_dialects(context)
+    options = NPUOptions(
+        arch="Ascend910_9589",
+        enable_dynamic_cv_pipeline=False,
+        enable_graph_optimize=False,
+    )
+    module = ast_to_ttir(loop_hint_kernel, src, context, options, {"min_dot_size": min_dot_size(None)}, {})
+    metadata = {**options.__dict__}
+    module = make_ttir(module, metadata, options)
+    ttadapter = ttir_to_linalg(module, metadata, options)
+
+    assert ttadapter.count('tt.compile_hint = "main_loop"') == 1


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
