### PR TITLE
[ssbuffer](feat) Analyze the update procees of WhileOp ConditionArgs

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h
@@ -110,6 +110,27 @@ public:
   }
 };
 
+// Pass for analyzing whether an scf.while condition depends on non-scalar
+// (tensor) data through its loop-carried arg update chain
+class AnalyzeWhileConditionArgsPass
+    : public PassWrapper<AnalyzeWhileConditionArgsPass,
+                         OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(AnalyzeWhileConditionArgsPass)
+
+  AnalyzeWhileConditionArgsPass() = default;
+
+  void runOnOperation() override;
+
+  llvm::StringRef getArgument() const override {
+    return "analyze-while-condition-args";
+  }
+  llvm::StringRef getDescription() const override {
+    return "Analyze whether scf.while condition args are updated with "
+           "non-scalar data";
+  }
+};
+
 // Pass for analyzing cube control flow input chain
 class AnalyzeCubeControlFlowInputChainPass
     : public PassWrapper<AnalyzeCubeControlFlowInputChainPass,
@@ -137,6 +158,7 @@ std::unique_ptr<OperationPass<ModuleOp>>
 createAnalyzeCubeContolFLowInputChainPass();
 std::unique_ptr<OperationPass<ModuleOp>> createAnalyzeDataFlowPass();
 std::unique_ptr<OperationPass<ModuleOp>> createAnalyzeScopePass();
+std::unique_ptr<OperationPass<ModuleOp>> createAnalyzeWhileConditionArgsPass();
 
 void registerAnalyzeDataFlowPasses();
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow.cpp
@@ -53,6 +53,8 @@ void AnalyzeDataFlowPass::runOnOperation() {
 
   pm.addPass(createAnalyzeCubeContolFLowInputChainPass());
 
+  pm.addPass(createAnalyzeWhileConditionArgsPass());
+
   if (failed(runPipeline(pm, module))) {
     if (!CVPipeline::hasFallbackAttr(module)) {
       LDBG("Pass failed; fallback to compilation without dynamic CV pipeline.");
@@ -76,6 +78,7 @@ void registerAnalyzeDataFlowPasses() {
   registerPass(createAnalyzeFlagPass);
   registerPass(createAnalyzeScopePass);
   registerPass(createAnalyzeDataFlowPass);
+  registerPass(createAnalyzeWhileConditionArgsPass);
   registerPass(createAnalyzeCubeContolFLowInputChainPass);
 }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeWhileConditionArgs.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeWhileConditionArgs.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+static constexpr const char *DEBUG_TYPE = "analyze-while-condition-args";
+#define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
+#define LDBG(...)                                                              \
+  LLVM_DEBUG({                                                                 \
+    DBGS();                                                                    \
+    llvm::dbgs() << __VA_ARGS__;                                               \
+    llvm::dbgs() << "\n";                                                      \
+  })
+
+using namespace llvm;
+using namespace mlir;
+using namespace triton;
+using namespace CVPipeline;
+
+// Expand a block argument reached by the backward trace into the values that
+// update it per iteration:
+//   - a before-region arg is updated by the after-region scf.yield operand of
+//     the same index (the init value enters once from outside and is not
+//     traced);
+//   - an after-region arg is the value forwarded by scf.condition at the same
+//     index.
+// Args of enclosing ops (outer loops, function) are outside the while's
+// update process and are not expanded.
+static void expandBlockArgument(scf::WhileOp whileOp, BlockArgument blockArg,
+                                SmallVectorImpl<Value> &worklist) {
+  Block *owner = blockArg.getOwner();
+  unsigned argIdx = blockArg.getArgNumber();
+
+  if (owner == whileOp.getBeforeBody()) {
+    worklist.push_back(whileOp.getYieldOp()->getOperand(argIdx));
+    return;
+  }
+
+  if (owner == whileOp.getAfterBody()) {
+    worklist.push_back(whileOp.getConditionOp().getArgs()[argIdx]);
+    return;
+  }
+}
+
+// Expand an op result reached by the backward trace into the op's operands.
+// Computation outside the while op is not traced through. For region-holding
+// ops (scf.if/for/while nested in the loop), the results are produced by the
+// region terminators, so their operands are conservatively traced too.
+static void expandOpResult(scf::WhileOp whileOp, OpResult result,
+                           SmallVectorImpl<Value> &worklist) {
+  Operation *op = result.getOwner();
+
+  if (!whileOp->isProperAncestor(op)) {
+    return;
+  }
+
+  worklist.append(op->operand_begin(), op->operand_end());
+
+  for (Region &region : op->getRegions()) {
+    for (Block &block : region) {
+      if (Operation *terminator = block.getTerminator()) {
+        worklist.append(terminator->operand_begin(), terminator->operand_end());
+      }
+    }
+  }
+}
+
+// Returns true when `value` is a non-scalar (tensor) value produced inside
+// `whileOp`, either by an op nested in one of its regions or as a loop-carried
+// arg of the while itself or of a nested loop.
+//
+// A tensor defined outside the loop is not a problem: its computation stays
+// out of the scope that has to be cloned, and only the scalar extracted from
+// it takes part in the condition update chain.
+static bool isNonScalarProducedInside(scf::WhileOp whileOp, Value value) {
+  if (!isa<TensorType>(value.getType())) {
+    return false;
+  }
+
+  if (auto blockArg = dyn_cast<BlockArgument>(value)) {
+    Operation *parentOp = blockArg.getOwner()->getParentOp();
+    return parentOp && (parentOp == whileOp.getOperation() ||
+                        whileOp->isProperAncestor(parentOp));
+  }
+
+  return whileOp->isProperAncestor(value.getDefiningOp());
+}
+
+// Returns true when the condition of `whileOp` transitively depends on a
+// non-scalar (tensor) value produced inside the loop.
+//
+// The trace starts from the condition operand of scf.condition and walks the
+// use-def chain backwards, following loop-carried args across both regions.
+static bool conditionDependsOnTensor(scf::WhileOp whileOp) {
+  SmallVector<Value> worklist{whileOp.getConditionOp().getCondition()};
+  llvm::DenseSet<Value> visited;
+
+  while (!worklist.empty()) {
+    Value value = worklist.pop_back_val();
+    if (!visited.insert(value).second) {
+      continue;
+    }
+
+    if (isNonScalarProducedInside(whileOp, value)) {
+      LDBG("condition of " << *whileOp
+                           << " depends on tensor value: " << value);
+      return true;
+    }
+
+    if (auto blockArg = dyn_cast<BlockArgument>(value)) {
+      expandBlockArgument(whileOp, blockArg, worklist);
+    } else {
+      expandOpResult(whileOp, cast<OpResult>(value), worklist);
+    }
+  }
+  return false;
+}
+
+void AnalyzeWhileConditionArgsPass::runOnOperation() {
+  ModuleOp module = getOperation();
+
+  if (CVPipeline::hasFallbackAttr(module)) {
+    return;
+  }
+
+  WalkResult walkResult = module.walk([&](scf::WhileOp whileOp) -> WalkResult {
+    if (CVPipeline::isMainLoopOp(whileOp) &&
+        conditionDependsOnTensor(whileOp)) {
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+
+  if (walkResult.wasInterrupted()) {
+    LDBG("scf.while condition depends on non-scalar data, the "
+         "DynamicCVPipeline pass will be interrupted.");
+    CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_IGNORED);
+  }
+}
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<OperationPass<ModuleOp>> createAnalyzeWhileConditionArgsPass() {
+  return std::make_unique<AnalyzeWhileConditionArgsPass>();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-while-cond-not-main-loop.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-while-cond-not-main-loop.mlir
@@ -1,0 +1,35 @@
+// RUN: triton-opt --analyze-while-condition-args %s | FileCheck %s
+
+// Same tensor-driven condition update as check-while-cond-tensor-update.mlir,
+// but the scf.while is not tagged as the main loop. Only the main loop drives
+// the cube/vector split, so this one is none of the pass' business and the
+// fallback attr must NOT be set.
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @while_cond_tensor_update_not_main_loop(%arg0: memref<?xf32>, %arg1: i64) {
+    %c0_i64 = arith.constant 0 : i64
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = tensor.empty() : tensor<64xf32>
+    %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<64xf32>) -> tensor<64xf32>
+    %2:2 = scf.while (%arg2 = %c0_i64, %arg3 = %c0_i64) : (i64, i64) -> (i64, i64) {
+      %3 = arith.cmpi slt, %arg3, %arg1 : i64
+      scf.condition(%3) %arg2, %arg3 : i64, i64
+    } do {
+    ^bb0(%arg2: i64, %arg3: i64):
+      %3 = tensor.empty() : tensor<f32>
+      %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<f32>) -> tensor<f32>
+      %reduced = linalg.reduce ins(%1 : tensor<64xf32>) outs(%4 : tensor<f32>) dimensions = [0]
+        (%in: f32, %init: f32) {
+          %7 = arith.addf %in, %init : f32
+          linalg.yield %7 : f32
+        }
+      %5 = tensor.extract %reduced[] : tensor<f32>
+      %6 = arith.fptosi %5 : f32 to i64
+      %7 = arith.addi %arg3, %6 : i64
+      scf.yield %arg2, %7 : i64, i64
+    }
+    return
+  }
+}
+
+// CHECK-NOT: triton_ascend.dynamic_cv_pipeline.rc
+// CHECK: return

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-while-cond-outside-tensor-update.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-while-cond-outside-tensor-update.mlir
@@ -1,0 +1,35 @@
+// RUN: triton-opt --analyze-while-condition-args %s | FileCheck %s
+
+// The tensor reduction feeding the loop-carried arg %arg3 is computed outside
+// the scf.while; the do-region only extracts a scalar out of it. The non-scalar
+// computation is not part of the scope that has to be cloned, so the fallback
+// attr must NOT be set.
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @while_cond_updated_by_outside_tensor(%arg0: memref<?xf32>, %arg1: i64) {
+    %c0_i64 = arith.constant 0 : i64
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = tensor.empty() : tensor<64xf32>
+    %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<64xf32>) -> tensor<64xf32>
+    %2 = tensor.empty() : tensor<f32>
+    %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<f32>) -> tensor<f32>
+    %reduced = linalg.reduce ins(%1 : tensor<64xf32>) outs(%3 : tensor<f32>) dimensions = [0]
+      (%in: f32, %init: f32) {
+        %4 = arith.addf %in, %init : f32
+        linalg.yield %4 : f32
+      }
+    %5:2 = scf.while (%arg2 = %c0_i64, %arg3 = %c0_i64) : (i64, i64) -> (i64, i64) {
+      %6 = arith.cmpi slt, %arg3, %arg1 : i64
+      scf.condition(%6) %arg2, %arg3 : i64, i64
+    } do {
+    ^bb0(%arg2: i64, %arg3: i64):
+      %6 = tensor.extract %reduced[] : tensor<f32>
+      %7 = arith.fptosi %6 : f32 to i64
+      %8 = arith.addi %arg3, %7 : i64
+      scf.yield %arg2, %8 : i64, i64
+    } attributes {ssbuffer.main_loop = 1 : i64}
+    return
+  }
+}
+
+// CHECK-NOT: triton_ascend.dynamic_cv_pipeline.rc
+// CHECK: return

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-while-cond-scalar-update.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-while-cond-scalar-update.mlir
@@ -1,0 +1,29 @@
+// RUN: triton-opt --analyze-while-condition-args %s | FileCheck %s
+
+// The loop-carried args feeding the scf.condition are updated purely with
+// scalars (memref.load of a scalar + arith). This is the supported pattern,
+// so the fallback attr must NOT be set.
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @while_cond_updated_by_scalar_load(%arg0: memref<?xi64>, %arg1: i64) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %0:2 = scf.while (%arg2 = %c0_i64, %arg3 = %c0_i64) : (i64, i64) -> (i64, i64) {
+      %1 = arith.addi %arg2, %arg3 : i64
+      %2 = arith.cmpi sge, %arg1, %1 : i64
+      scf.condition(%2) %arg2, %arg3 : i64, i64
+    } do {
+    ^bb0(%arg2: i64, %arg3: i64):
+      %1 = arith.addi %arg2, %c1_i64 : i64
+      %2 = arith.index_cast %1 : i64 to index
+      %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [%2], sizes: [1], strides: [1] : memref<?xi64> to memref<1xi64, strided<[1], offset: ?>>
+      %3 = memref.load %reinterpret_cast[%c0] : memref<1xi64, strided<[1], offset: ?>>
+      scf.yield %1, %3 : i64, i64
+    } attributes {ssbuffer.main_loop = 1 : i64}
+    return
+  }
+}
+
+// CHECK-NOT: triton_ascend.dynamic_cv_pipeline.rc
+// CHECK: return

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-while-cond-tensor-update.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AnalyzeDataFlow/check-while-cond-tensor-update.mlir
@@ -1,0 +1,33 @@
+// RUN: triton-opt --analyze-while-condition-args %s | FileCheck %s
+
+// The loop-carried arg %arg3 feeds the scf.condition and is updated in the
+// do-region by a scalar produced from a tensor reduction (tl.sum style).
+// The dynamic CV pipeline cannot handle this, so the fallback attr must be set.
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @while_cond_updated_by_tensor_sum(%arg0: memref<?xf32>, %arg1: i64) {
+    %c0_i64 = arith.constant 0 : i64
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = tensor.empty() : tensor<64xf32>
+    %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<64xf32>) -> tensor<64xf32>
+    %2:2 = scf.while (%arg2 = %c0_i64, %arg3 = %c0_i64) : (i64, i64) -> (i64, i64) {
+      %3 = arith.cmpi slt, %arg3, %arg1 : i64
+      scf.condition(%3) %arg2, %arg3 : i64, i64
+    } do {
+    ^bb0(%arg2: i64, %arg3: i64):
+      %3 = tensor.empty() : tensor<f32>
+      %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<f32>) -> tensor<f32>
+      %reduced = linalg.reduce ins(%1 : tensor<64xf32>) outs(%4 : tensor<f32>) dimensions = [0]
+        (%in: f32, %init: f32) {
+          %7 = arith.addf %in, %init : f32
+          linalg.yield %7 : f32
+        }
+      %5 = tensor.extract %reduced[] : tensor<f32>
+      %6 = arith.fptosi %5 : f32 to i64
+      %7 = arith.addi %arg3, %6 : i64
+      scf.yield %arg2, %7 : i64, i64
+    } attributes {ssbuffer.main_loop = 1 : i64}
+    return
+  }
+}
+
+// CHECK: triton_ascend.dynamic_cv_pipeline.rc


### PR DESCRIPTION
Analyze the update procees of WhileOp ConditionArgs:
For scf.while with the ssbuffer.main_loop tag, the use-def chain is traversed in reverse order starting from the condition value of scf.condition:
The updates of each round of parameters carried in the loop are traced across the before and after regions. (The before parameter is traced to the operand with the same subscript as the scf.yield in the after region. The after parameter is traced to the argument with the same subscript as the scf.condition forwarding.)
When an op (scf.if or scf.for) in a nested region is encountered, the result is generated by the region terminator, and the operand of the terminator needs to be traced together.
The hit condition is that a tensor value of the tensor type appears in the chain and is generated inside the while loop. Generation inside the loop means that the value is generated by an op in a region of the while loop or is a parameter carried in the while loop or nested loop.
A tensor defined outside the while loop is not a problem. Its non-scalar computation is not within the scope of what needs to be cloned. Only a scalar is extracted from it in the loop.
If the hit condition is met, the fallback attribute is added to the module, and the error code is ERRCODE_IGNORED (indicating that the function is not supported).

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
