### PR TITLE
[ChunkCoalescing](fix) coalesce under sanitize_overflow

### DIFF
--- a/third_party/ascend/lib/TritonToGraph/LegacyMemoryAccess/ChunkCoalescing.cpp
+++ b/third_party/ascend/lib/TritonToGraph/LegacyMemoryAccess/ChunkCoalescing.cpp
@@ -78,6 +78,8 @@ static bool getConstInt(Value v, int64_t &out) {
   return false;
 }
 
+// tt.assert is liftable: a group covers exactly H tiles of the original grid,
+// so a widened condition traps on the same inputs, only grouped differently.
 static bool isLiftable(Operation *op) {
   if (auto *d = op->getDialect()) {
     StringRef ns = d->getNamespace();
@@ -87,7 +89,32 @@ static bool isLiftable(Operation *op) {
   }
   return isa<triton::SplatOp, triton::AddPtrOp, triton::BroadcastOp,
              triton::ExpandDimsOp, triton::LoadOp, triton::StoreOp,
-             triton::ScanOp, triton::ReduceOp>(op);
+             triton::ScanOp, triton::ReduceOp, triton::AssertOp>(op);
+}
+
+// A pid-dependent predicate that can only trap does not constrain the rewrite:
+// tt.assert has no results, so nothing reaches an offset, a mask or a select.
+// The permitted sink is whitelisted rather than the forbidden ones blacklisted,
+// because the rewrite deletes the seed mask outright and so must fail closed.
+// sanitize_overflow is what makes this matter: it is on by default and
+// instruments nearly every pid-derived index.
+static bool onlyFeedsDeviceAssert(Value predicate) {
+  SmallVector<Value> wl{predicate};
+  DenseSet<Value> visited{predicate};
+  while (!wl.empty()) {
+    Value cur = wl.pop_back_val();
+    for (Operation *u : cur.getUsers()) {
+      if (isa<triton::AssertOp>(u))
+        continue;
+      // Only the instrumentation's own boolean combines may extend the chain.
+      if (!isa<arith::AndIOp, arith::OrIOp, arith::XOrIOp>(u))
+        return false;
+      for (Value r : u->getResults())
+        if (visited.insert(r).second)
+          wl.push_back(r);
+    }
+  }
+  return true;
 }
 
 static std::optional<TileSeed> findSeed(ModuleOp moduleOp) {
@@ -161,6 +188,8 @@ static std::optional<TileSeed> findSeed(ModuleOp moduleOp) {
                   mask = cmp.getResult();
                   continue;
                 }
+                if (onlyFeedsDeviceAssert(cmp.getResult()))
+                  continue;
                 unsafe = true;
                 break;
               }
@@ -317,11 +346,6 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
 
   int64_t numTiles = (seed->bound + seed->tileLen - 1) / seed->tileLen;
   int64_t H = chooseH(numTiles, seed->tileLen, elemBytes, maxH);
-  llvm::errs() << "ChunkCoalescing: tileLen=" << seed->tileLen
-               << " bound=" << seed->bound << " numTiles=" << numTiles
-               << " elemBytes=" << elemBytes
-               << " footprintUnit=" << footprintUnit << " maxH=" << maxH
-               << " H=" << H << "\n";
   if (H <= 1)
     return;
 

--- a/third_party/ascend/unittest/pytest_ut/test_layout_memory_91095_native_e2e.py
+++ b/third_party/ascend/unittest/pytest_ut/test_layout_memory_91095_native_e2e.py
@@ -154,6 +154,21 @@ def _chunk_axis1_copy(src, dst, N: tl.constexpr, BLOCK: tl.constexpr):
 
 
 @triton.jit
+def _chunk_axis1_extra_data_predicate(src, dst, N: tl.constexpr, BLOCK: tl.constexpr):
+    batch = tl.program_id(0)
+    tile = tl.program_id(1)
+    offsets = tile * BLOCK + tl.arange(0, BLOCK)
+    mask = offsets < N
+    base = batch * N
+    value = tl.load(src + base + offsets, mask=mask, other=0.0)
+    # A second pid-dependent compare that selects data instead of only feeding
+    # an assert.  N - 1 is not a whole number of tiles, so it also cannot be
+    # mistaken for the seed mask.
+    value = tl.where(offsets < N - 1, value, 0.0)
+    tl.store(dst + base + offsets, value, mask=mask)
+
+
+@triton.jit
 def _chunk_axis2_copy(src, dst, N: tl.constexpr, BLOCK: tl.constexpr):
     # Chunk chooses its seed from the greatest program-id axis.  Keeping axes
     # 0 and 1 at one makes this a real grid-Z case, rather than merely testing
@@ -228,10 +243,8 @@ def test_chunk_91095_native_metadata_launcher_and_ir(monkeypatch):
         # not set compile_on_910_95; _assert_real_91095_gate below proves the
         # device-derived gate remained true for the actual compiled kernel.
         force_simt_template=True,
-        # Keep the existing positive Chunk input form.  The historical matcher
-        # treats sanitizer-inserted non-mask compares on the pid dataflow as
-        # unsafe and conservatively bails; that rejection has its own test
-        # below, rather than relaxing the matcher or changing the default.
+        # Keep covering the uninstrumented form; the default instrumented one
+        # is covered by test_chunk_coalesces_through_overflow_sanitizer_91095.
         sanitize_overflow=False,
     )
 
@@ -289,8 +302,8 @@ def test_chunk_axis2_91095_native_metadata_launcher_and_ir(monkeypatch):
     assert launcher.count("ChunkCoalescing: grid[2] not divisible by coalesce_factor 16") == 2
 
 
-def test_chunk_sanitizer_preserves_original_bailout_91095(monkeypatch):
-    """The default overflow instrumentation must retain Chunk's no-op guard."""
+def test_chunk_coalesces_through_overflow_sanitizer_91095(monkeypatch):
+    """The default overflow instrumentation no longer suppresses Chunk."""
     batch, block, num_tiles = 2, 16, 32
     n = block * num_tiles
     src = torch.arange(batch * n, dtype=torch.float32).reshape(batch, n).npu()
@@ -305,19 +318,54 @@ def test_chunk_sanitizer_preserves_original_bailout_91095(monkeypatch):
         N=n,
         BLOCK=block,
         force_simt_template=True,
-        # Do not pass sanitize_overflow: the historical JIT default materializes
-        # extra overflow checks on the pid path, which the unchanged Chunk
-        # safety analysis must reject instead of attempting an unsafe coalesce.
+        # Do not pass sanitize_overflow: the JIT default instruments every
+        # pid-derived index with compares that can only trap.
     )
 
     assert torch.equal(dst.cpu(), src.cpu())
+    _assert_real_91095_gate(compiled, pure_simt=False)
+    assert compiled.metadata.sanitize_overflow is True
+    assert compiled.metadata.coalesce_factor == 16
+    assert compiled.metadata.coalesce_axis == 1
+    assert compiled.metadata.coalesce_grid_ceil_div is False
+    assert compiled.metadata.row_coalescing_applied is True
+
+    chunk_ir = observer.exported_ir_with("hacc.coalesce_factor = 16 : i32")
+    assert "hacc.coalesce_axis = 1 : i32" in chunk_ir
+    assert "hacc.coalesce_grid_ceil_div" not in chunk_ir
+
+    launcher = observer.launcher_with("gridY = gridY / 16;")
+    assert launcher.count("gridY = gridY / 16;") == 2
+    assert launcher.count("ChunkCoalescing: grid[1] not divisible by coalesce_factor 16") == 2
+
+
+def test_chunk_rejects_data_reaching_pid_predicate_91095(monkeypatch):
+    """Only trap-only compares are waived; one that selects data must bail."""
+    batch, block, num_tiles = 2, 16, 32
+    n = block * num_tiles
+    src = torch.arange(batch * n, dtype=torch.float32).reshape(batch, n).npu()
+    dst = torch.empty_like(src)
+
+    compiled, observer = _launch_with_observer(
+        monkeypatch,
+        _chunk_axis1_extra_data_predicate,
+        (batch, num_tiles),
+        src,
+        dst,
+        N=n,
+        BLOCK=block,
+        force_simt_template=True,
+    )
+
+    expected = src.clone()
+    expected[:, n - 1] = 0.0
+    assert torch.equal(dst.cpu(), expected.cpu())
     _assert_real_91095_gate(compiled, pure_simt=False)
     assert compiled.metadata.sanitize_overflow is True
     assert compiled.metadata.coalesce_factor == 1
     assert compiled.metadata.coalesce_axis == -1
     assert compiled.metadata.coalesce_grid_ceil_div is False
     assert compiled.metadata.row_coalescing_applied is False
-    assert compiled.metadata.parallel_mode == "simd"
     assert all("hacc.coalesce_factor" not in ir_text for ir_text in observer.pre_export_ir)
     assert all("gridY = gridY / 16;" not in launcher for launcher in observer.launcher_sources)
 


### PR DESCRIPTION
The safety walk in findSeed rejected every arith.cmpi on a pid-tainted value apart from the seed mask. sanitize_overflow is on by default and hangs an extsi/muli/cmpi/andi cone plus a tt.assert off nearly every pid-derived index, so the pass bailed on virtually all real kernels.

Waive a pid-dependent predicate when its result only reaches tt.assert, optionally through and/or/xor. tt.assert has no results, so nothing can flow on to an addptr offset, a load/store mask or a select. The permitted sink is whitelisted rather than the forbidden ones blacklisted, because the rewrite deletes the seed mask outright and so must fail closed.

Make tt.assert liftable as well, so collectRegion accepts the instrumentation instead of rejecting it. A group covers exactly H tiles of the original grid, so the widened assert checks the same (tile, condition) pairs and traps on the same inputs.

Drop the seed/H trace that went straight to llvm::errs() and so printed on every compile of every kernel. No test reads it, and DEBUG_TYPE is already declared here should it need to come back behind LLVM_DEBUG.

test_chunk_sanitizer_preserves_original_bailout_91095 asserted the old bailout and becomes a positive case. A new negative case covers a pid-dependent compare that selects data rather than only trapping.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
