### PR TITLE
[Docs](feat) Add pytest UT running guide to installation docs

### DIFF
--- a/.github/docs-ci/codespell.whitelist.json
+++ b/.github/docs-ci/codespell.whitelist.json
@@ -323,5 +323,6 @@
   "rtol",
   "atol",
   "ffts",
-  "ctypes"
+  "ctypes",
+  "xdist"
 ]

--- a/docs/en/installation_guide.md
+++ b/docs/en/installation_guide.md
@@ -228,6 +228,50 @@ tensor([0.8329, 1.0024, 1.3639,  ..., 1.0796, 1.0406, 1.5811], device='npu:0')
 The maximum difference between torch and triton is 0.0
 ```
 
+## Running Pytest UT
+
+The source repository provides single-op test cases in the `third_party/ascend/unittest/pytest_ut` directory. Before running the tests, complete the Triton-Ascend installation and set the CANN environment variables.
+
+```bash
+# Set CANN environment variables (using the default installation path `/usr/local/Ascend` as an example)
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+# Install pytest
+pip install pytest pytest-xdist
+```
+
+**Run a Single Test Case**
+
+```bash
+# Taking the vector addition test case as an example
+python -m pytest third_party/ascend/unittest/pytest_ut/test_add.py
+```
+
+**Run All Test Cases**
+
+```bash
+# Run all test cases serially
+python -m pytest third_party/ascend/unittest/pytest_ut
+```
+
+To speed up the tests, specify the number of parallel workers with `-n` (parallel execution requires installing pytest-xdist):
+
+```bash
+python -m pytest -n 8 third_party/ascend/unittest/pytest_ut
+```
+
+To print detailed test progress, add the `-sv` option:
+
+```bash
+python -m pytest -sv -n 8 third_party/ascend/unittest/pytest_ut
+```
+
+The output after execution is similar to the following:
+
+```text
+collected 6 items
+third_party/ascend/unittest/pytest_ut/test_add.py ......
+```
+
 ## Installation FAQ
 
 **Question 1: An error "ERROR: No matching distribution found for torch==2.7.1+cpu" is reported when installing TorchNPU**

--- a/docs/zh/installation_guide.md
+++ b/docs/zh/installation_guide.md
@@ -229,6 +229,50 @@ tensor([0.8329, 1.0024, 1.3639,  ..., 1.0796, 1.0406, 1.5811], device='npu:0')
 The maximum difference between torch and triton is 0.0
 ```
 
+## 运行Pytest UT
+
+源码仓中提供了单op测试用例，位于`third_party/ascend/unittest/pytest_ut`目录下。执行前需完成Triton-Ascend安装，并设置CANN环境变量。
+
+```bash
+# 设置CANN环境变量（默认安装路径`/usr/local/Ascend`为例）
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+# 安装pytest
+pip install pytest pytest-xdist
+```
+
+**运行单个测试用例**
+
+```bash
+# 以向量加法测试用例为例
+python -m pytest third_party/ascend/unittest/pytest_ut/test_add.py
+```
+
+**运行全部测试用例**
+
+```bash
+# 串行执行全部用例
+python -m pytest third_party/ascend/unittest/pytest_ut
+```
+
+如需加速测试，可通过`-n`指定并行worker数（并行执行需安装pytest-xdist）：
+
+```bash
+python -m pytest -n 8 third_party/ascend/unittest/pytest_ut
+```
+
+如需要打印测试过程详细信息，添加`-sv`参数：
+
+```bash
+python -m pytest -sv -n 8 third_party/ascend/unittest/pytest_ut
+```
+
+执行完成后输出示例如下：
+
+```text
+collected 6 items
+third_party/ascend/unittest/pytest_ut/test_add.py ......
+```
+
 ## 安装常见问题
 
 **问题一：安装TorchNPU时出现报错“ERROR: No matching distribution found for torch==2.7.1+cpu”**


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
### Summary
The installation guides previously had no instructions for running the pytest-based unit tests, so users installing Triton-Ascend from source or from a development image cannot easily figure out how to run the UT.

This PR adds a "运行Pytest UT / Running Pytest UT" section to both `docs/zh/installation_guide.md` and `docs/en/installation_guide.md`.

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
