### PR TITLE
[ssbuffer](feat) revert 1D dependency narrowing: accept any 1D tensor

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -164,11 +164,7 @@ bool DataDependencyAnalysisPass::isValid1DValueForDependency(
     mlir::Value value) {
   auto tensorTy = dyn_cast<TensorType>(value.getType());
   if (tensorTy && tensorTy.getRank() == SHAPE_1D_LENGTH) {
-    // Only 1-D tensors consumed by linalg.broadcast count; extract-consumed
-    // ones go through the scalar SSBuffer channel instead.
-    return llvm::all_of(value.getUsers(), [](mlir::Operation *u) {
-      return isa<linalg::BroadcastOp>(u);
-    });
+    return true;
   }
   return false;
 }


### PR DESCRIPTION
main-dev #1538 merged the scalar feature with the all_of(linalg.broadcast) predicate, which dropped the V->C copy for 1-D bias tensors consumed by arith.extf (read before first write in hivm-plan-memory-regbase).

Return to the pre-narrowing behavior: any 1-D tensor counts for the tensor channel. Verified end-to-end; the extract-consumed scalar path is unaffected because extract stays on the VECTOR side and the 1-D source is not a CUBE external input.