### PR TITLE
[Autotune](fix) Backport skip GC on disk cache hit

### DIFF
--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -2045,20 +2045,41 @@ class AutoTilingTuner(Autotuner):
         cache_miss = key not in self.cache
         if self.is_simt_mode and kwargs.get('simt_stack_limit', None) is None:
             kwargs['simt_stack_limit'] = self.simt_stack_limit
-        used_cached_result = True
+        did_benchmark = False
+        disk_cache_hit = False
         if cache_miss:
             # prune configs
             pruned_configs = self.prune_configs(kwargs)
             if self.enable_ubtuner or len(pruned_configs) > 1:
-                used_cached_result = False
-                bench_start = time.time()
-                timings = self._batch_bench(*args, configs=pruned_configs, **kwargs)
-                bench_end = time.time()
-                self.bench_time = bench_end - bench_start
-                self.cache[key] = builtins.min(timings, key=timings.get)
-                full_nargs = {**self.nargs, **kwargs, **self.cache[key].all_kwargs()}
-                self.pre_hook(full_nargs, reset_only=True)
-                self.configs_timings = timings
+
+                def benchmark():
+                    nonlocal did_benchmark
+                    did_benchmark = True
+                    bench_start = time.time()
+                    timings = self._batch_bench(*args, configs=pruned_configs, **kwargs)
+                    bench_end = time.time()
+                    self.bench_time = bench_end - bench_start
+                    self.cache[key] = builtins.min(timings, key=timings.get)
+                    full_nargs = {**self.nargs, **kwargs, **self.cache[key].all_kwargs()}
+                    self.pre_hook(full_nargs, reset_only=True)
+                    self.configs_timings = timings
+
+                if self.cache_results:
+                    if self.enable_ubtuner:
+                        warnings.warn(
+                            "Autotune disk cache is disabled because UB-tuner is enabled "
+                            "(TRITON_ENABLE_UBTUNER is set). UB-tuner may dynamically add "
+                            "compile-time fixes to configs that cannot be safely cached to disk. "
+                            "To enable disk caching, unset TRITON_ENABLE_UBTUNER.",
+                            RuntimeWarning,
+                            stacklevel=2,
+                        )
+                        benchmark()
+                    else:
+                        disk_cache_hit = self.check_disk_cache(key, pruned_configs, benchmark)
+                else:
+                    benchmark()
+
                 config = self.cache[key]
             else:
                 config = pruned_configs[0]
@@ -2067,11 +2088,11 @@ class AutoTilingTuner(Autotuner):
 
         self.best_config = config
 
-        if self.print_autotuning and not used_cached_result:
+        if self.print_autotuning and did_benchmark:
             print(f"Triton autotuning for function {self.base_fn.__name__} finished after "
                   f"{self.bench_time:.2f}s; best config selected: {self.best_config};")
 
-        if not used_cached_result and self.auto_profile_dir is not None:
+        if did_benchmark and self.auto_profile_dir is not None:
             self._profile(*args, config=self.best_config, **kwargs)
         ub_cfg = dict(getattr(config, "ubtune_cfg", {}))
         if config.pre_hook is not None:
@@ -2088,7 +2109,7 @@ class AutoTilingTuner(Autotuner):
             return ret
         finally:
             self.nargs = None
-            if cache_miss:
+            if cache_miss and not disk_cache_hit:
                 # workaround for memory leak when some configs fail to compile
                 gc.collect()
 

--- a/third_party/ascend/unittest/autotune_ut/test_do_bench_compat.py
+++ b/third_party/ascend/unittest/autotune_ut/test_do_bench_compat.py
@@ -18,10 +18,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from types import MethodType
+from types import MethodType, SimpleNamespace
 
 import pytest
 import triton
+import triton.backends.ascend.runtime.autotuner as ascend_autotuner
 from triton.runtime.autotuner import Config
 from triton.backends.ascend.runtime.autotuner import AutoTilingTuner
 
@@ -41,6 +42,24 @@ def _make_tuner(do_bench):
 
     tuner._make_kernel_call = MethodType(_make_kernel_call, tuner)
     return tuner
+
+
+def _make_run_tuner(configs):
+    key = ("disk-cache-key", )
+    tuner = object.__new__(AutoTilingTuner)
+    tuner.cache = {}
+    tuner.is_simt_mode = False
+    tuner.simt_stack_limit = 8192
+    tuner.generate_key_and_configs = lambda *args, **kwargs: key
+    tuner.prune_configs = lambda kwargs: configs
+    tuner.enable_ubtuner = False
+    tuner.cache_results = True
+    tuner.print_autotuning = False
+    tuner.auto_profile_dir = None
+    tuner.nargs = {}
+    tuner.pre_hook = lambda kwargs, reset_only=False: None
+    tuner.fn = SimpleNamespace(run=lambda *args, **kwargs: "kernel-result")
+    return tuner, key
 
 
 def test_batch_bench_supports_do_bench_with_quantiles():
@@ -170,3 +189,74 @@ def test_ascend_autotune_decorator_forwards_do_bench(monkeypatch):
     ascend_autotuner.autotune(configs=[object()], key=[], do_bench=my_do_bench)(_dummy_kernel)
 
     assert captured["do_bench"] is my_do_bench
+
+
+def test_run_skips_gc_on_autotune_disk_cache_hit(monkeypatch):
+    configs = [Config({"BLOCK_SIZE": 16}), Config({"BLOCK_SIZE": 32})]
+    tuner, key = _make_run_tuner(configs)
+    gc_calls = []
+    profile_calls = []
+
+    def check_disk_cache(tuning_key, pruned_configs, benchmark):
+        assert tuning_key == key
+        tuner.cache[tuning_key] = pruned_configs[0]
+        return True
+
+    def unexpected_batch_bench(*args, **kwargs):
+        raise AssertionError("benchmark must not run on a disk-cache hit")
+
+    tuner.check_disk_cache = check_disk_cache
+    tuner._batch_bench = unexpected_batch_bench
+    tuner.auto_profile_dir = "profile-output"
+    tuner._profile = lambda *args, config, **kwargs: profile_calls.append(config)
+    monkeypatch.setattr(ascend_autotuner.gc, "collect", lambda: gc_calls.append(True))
+
+    assert tuner.run() == "kernel-result"
+    assert gc_calls == []
+    assert profile_calls == []
+
+
+def test_run_keeps_gc_on_autotune_disk_cache_miss(monkeypatch):
+    configs = [Config({"BLOCK_SIZE": 16}), Config({"BLOCK_SIZE": 32})]
+    tuner, key = _make_run_tuner(configs)
+    gc_calls = []
+    benchmark_calls = []
+    profile_calls = []
+
+    def check_disk_cache(tuning_key, pruned_configs, benchmark):
+        assert tuning_key == key
+        benchmark()
+        return False
+
+    def batch_bench(*args, configs, **kwargs):
+        benchmark_calls.append(configs)
+        return {configs[0]: 1.0, configs[1]: 2.0}
+
+    tuner.check_disk_cache = check_disk_cache
+    tuner._batch_bench = batch_bench
+    tuner.auto_profile_dir = "profile-output"
+    tuner._profile = lambda *args, config, **kwargs: profile_calls.append(config)
+    monkeypatch.setattr(ascend_autotuner.gc, "collect", lambda: gc_calls.append(True))
+
+    assert tuner.run() == "kernel-result"
+    assert benchmark_calls == [configs]
+    assert gc_calls == [True]
+    assert profile_calls == [configs[0]]
+
+
+def test_run_keeps_gc_on_single_config_cache_miss(monkeypatch):
+    tuner, _ = _make_run_tuner([Config({"BLOCK_SIZE": 16})])
+    gc_calls = []
+    profile_calls = []
+
+    def unexpected_disk_cache(*args, **kwargs):
+        raise AssertionError("single-config path must not probe disk cache")
+
+    tuner.check_disk_cache = unexpected_disk_cache
+    tuner.auto_profile_dir = "profile-output"
+    tuner._profile = lambda *args, config, **kwargs: profile_calls.append(config)
+    monkeypatch.setattr(ascend_autotuner.gc, "collect", lambda: gc_calls.append(True))
+
+    assert tuner.run() == "kernel-result"
+    assert gc_calls == [True]
+    assert profile_calls == []


### PR DESCRIPTION
## What changed

Backports #1605 to `main`.

- Track whether autotuning actually benchmarked and whether the result came from the disk cache.
- Skip `gc.collect()` when an in-memory cache miss is satisfied by the autotune disk cache.
- Add regression coverage for disk-cache hits, disk-cache misses, and single-config cache misses.

## Why

`AutoTilingTuner.run()` previously used the in-memory-cache miss as the cleanup condition. A disk-cache lookup starts as an in-memory miss, so a successful disk-cache hit still triggered a full GC even though no benchmark ran. The backport carries the disk-cache result separately and preserves GC for real benchmark/cache-miss paths.

## Impact

Disk-cache hits avoid unnecessary garbage collection and profiling/benchmark reporting. Cache misses and single-config cache misses retain the existing cleanup behavior.

## Validation

- Targeted pre-commit hooks passed: `check-ast`, `check-merge-conflict`, `trailing-whitespace`, `end-of-file-fixer`, `detect-private-key`, `debug-statements`, and `yapf`.
- An isolated method harness from the backported `run()` passed disk-cache-hit, disk-cache-miss, and single-config-cache-miss assertions.
- `git diff --check` passed.

## Validation boundary

The repository pytest node could not be collected in the available local environments because checkout Python sources require a newer `triton._C.libtriton` extension exposing `getenv`; the available extension does not provide that symbol. This is recorded as an environment/import-provenance limitation rather than a test pass.
