### PR TITLE
[TritonToLinalg](feat) wrap associative_scan with scope

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/CMakeLists.txt
+++ b/third_party/ascend/lib/TritonToLinalg/CMakeLists.txt
@@ -25,6 +25,7 @@ add_triton_library(TritonToLinalg
   MLIRTransforms
   MLIRSupport
   BiShengIRHIVMDialect
+  BiShengIRScopeDialect
   TritonIR
   TritonTransforms
   TritonAnalysis

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -59,6 +59,7 @@
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "bishengir/Dialect/HFusion/IR/HFusion.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "bishengir/Dialect/Scope/IR/Scope.h"
 
 namespace TTOpConverters {
 using namespace mlir;
@@ -1447,7 +1448,18 @@ ScanConverter::convertToTargetOp(triton::ScanOp op,
     auto memrefType = MemRefType::get(shape, elementType);
     Value inputMemRef =
         rewriter.create<bufferization::ToBufferOp>(loc, memrefType, scanInput);
-    Value outputMemRef = rewriter.create<memref::AllocOp>(loc, memrefType);
+
+    // Wrap scan logic in a scope with UB address space for the output buffer.
+    auto tensorResultType = RankedTensorType::get(shape, elementType);
+    auto scopeOp =
+        rewriter.create<scope::ScopeOp>(loc, TypeRange{tensorResultType});
+    scopeOp.getBodyRegion().emplaceBlock();
+    rewriter.setInsertionPointToEnd(&scopeOp.getBodyRegion().front());
+
+    auto ubMemRefType = MemRefType::get(
+        shape, elementType, nullptr,
+        rewriter.getAttr<hivm::AddressSpaceAttr>(hivm::AddressSpace::UB));
+    Value outputMemRef = rewriter.create<memref::AllocOp>(loc, ubMemRefType);
 
     auto processDimension = [&](ArrayRef<Value> baseIdxsArray) {
       auto startInd = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
@@ -1544,13 +1556,17 @@ ScanConverter::convertToTargetOp(triton::ScanOp op,
     createSimpleNestedLoops(rewriter, loc, outputMemRef, nonScanDims,
                             processDimension);
 
-    rewriter.setInsertionPointAfter(op);
-
     mlir::Type resultType = mlir::memref::getTensorTypeFromMemRefType(
         dyn_cast<mlir::MemRefType>(outputMemRef.getType()));
     Value outputTensor = rewriter.create<bufferization::ToTensorOp>(
         loc, resultType, outputMemRef, true);
-    rewriter.replaceOp(op, outputTensor);
+    rewriter.create<scope::ReturnOp>(loc, ValueRange{outputTensor});
+
+    scopeOp->setAttr(hivm::TCoreTypeAttr::name,
+                     hivm::TCoreTypeAttr::get(rewriter.getContext(),
+                                              hivm::TCoreType::VECTOR));
+
+    rewriter.replaceOp(op, scopeOp.getResult(0));
     return success();
   }
 }

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -55,6 +55,7 @@
 
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "bishengir/Dialect/Scope/IR/Scope.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
@@ -508,13 +509,13 @@ void TritonToLinalgPass::convertTTFunc(triton::FuncOp func, const bool existDot,
 
 void TritonToLinalgPass::addDynamicLegal(
     ConversionTarget &target, TritonTypeConverter &tritonTypeConverter) {
-  target.addLegalDialect<func::FuncDialect, arith::ArithDialect,
-                         math::MathDialect, linalg::LinalgDialect,
-                         affine::AffineDialect, scf::SCFDialect,
-                         cf::ControlFlowDialect, tensor::TensorDialect,
-                         LLVM::LLVMDialect, bufferization::BufferizationDialect,
-                         memref::MemRefDialect, annotation::AnnotationDialect,
-                         hivm::HIVMDialect, hfusion::HFusionDialect>();
+  target.addLegalDialect<
+      func::FuncDialect, arith::ArithDialect, math::MathDialect,
+      linalg::LinalgDialect, affine::AffineDialect, scf::SCFDialect,
+      cf::ControlFlowDialect, tensor::TensorDialect, LLVM::LLVMDialect,
+      bufferization::BufferizationDialect, memref::MemRefDialect,
+      annotation::AnnotationDialect, hivm::HIVMDialect, hfusion::HFusionDialect,
+      scope::ScopeDialect>();
 
   // add legal dialect on condition
   target.addLegalOp<ModuleOp>();
@@ -750,11 +751,12 @@ void TritonToLinalgPass::populateTritonToLinalgConversionPatterns(
 }
 
 void TritonToLinalgPass::getDependentDialects(DialectRegistry &registry) const {
-  registry.insert<func::FuncDialect, arith::ArithDialect, math::MathDialect,
-                  linalg::LinalgDialect, affine::AffineDialect, scf::SCFDialect,
-                  tensor::TensorDialect, bufferization::BufferizationDialect,
-                  memref::MemRefDialect, hfusion::HFusionDialect,
-                  hivm::HIVMDialect, annotation::AnnotationDialect>();
+  registry
+      .insert<func::FuncDialect, arith::ArithDialect, math::MathDialect,
+              linalg::LinalgDialect, affine::AffineDialect, scf::SCFDialect,
+              tensor::TensorDialect, bufferization::BufferizationDialect,
+              memref::MemRefDialect, hfusion::HFusionDialect, hivm::HIVMDialect,
+              annotation::AnnotationDialect, scope::ScopeDialect>();
 }
 
 LogicalResult

--- a/third_party/ascend/unittest/pytest_ut/test_load_strided.py
+++ b/third_party/ascend/unittest/pytest_ut/test_load_strided.py
@@ -185,26 +185,26 @@ def _ref_multi_d(src_flat_cpu: torch.Tensor, blocks, strides) -> torch.Tensor:
 
 
 @pytest.mark.parametrize("dtype,blocks,strides", [
-    # ---- V1 命中: 非 permuted, 尾轴 stride 静态 > 1, 所有 block 是 2 的幂 ----
+    # ---- V1 hit: non-permuted, last-axis stride statically > 1, all blocks power-of-2 ----
     # 2D
     ("float32", (4, 8), (8, 4)),  # stride 4
-    ("float32", (4, 8), (24, 3)),  # stride 3 (奇)
+    ("float32", (4, 8), (24, 3)),  # stride 3 (odd)
     # 3D
     ("float16", (2, 4, 8), (32, 8, 4)),  # stride 4
-    ("float32", (4, 4, 8), (96, 24, 3)),  # stride 3 (奇)
+    ("float32", (4, 4, 8), (96, 24, 3)),  # stride 3 (odd)
     # 4D
     ("float16", (2, 4, 4, 8), (128, 32, 8, 3)),  # stride 3
     # 5D
-    ("float32", (2, 2, 2, 4, 8), (256, 128, 64, 16, 5)),  # stride 5 (奇)
+    ("float32", (2, 2, 2, 4, 8), (256, 128, 64, 16, 5)),  # stride 5 (odd)
 
-    # ---- Deinterleave 接管 (stride==2 + 偶数 last block) ----
+    # ---- Deinterleave handles (stride==2 + even last block) ----
     ("float16", (4, 4, 8), (32, 8, 2)),
 
-    # ---- Permuted: ImplicitPermute 处理, V1 必须放过 ----
-    ("float32", (4, 8), (1, 4)),  # strides 升序
-    ("float32", (4, 4, 8), (1, 4, 16)),  # 严格升序
+    # ---- Permuted: ImplicitPermute handles, V1 must skip ----
+    ("float32", (4, 8), (1, 4)),  # strides ascending
+    ("float32", (4, 4, 8), (1, 4, 16)),  # strictly ascending
 
-    # ---- Normal contiguous (stride==1): 不应改写 ----
+    # ---- Normal contiguous (stride==1): no rewrite ----
     ("float32", (4, 8), (8, 1)),
     ("float32", (4, 4, 8), (32, 8, 1)),
 ])
@@ -556,15 +556,15 @@ def _ref_boundary_load(src_cpu_flat, parent_m, parent_n, stride_m, stride_n, blo
 
 
 @pytest.mark.parametrize("dtype,parent_m,parent_n,stride_m,stride_n,block_m,block_n,pad_nan", [
-    # V1.5 命中: PAD_ZERO, stride_n=4, block 超出 parent
+    # V1.5 hit: PAD_ZERO, stride_n=4, block exceeds parent
     pytest.param("float32", 5, 3, 12, 4, 8, 8, False, marks=a3_known_boundary_load_issue),
-    # V1.5 命中: PAD_ZERO, stride_n=3, block 部分越界
+    # V1.5 hit: PAD_ZERO, stride_n=3, block partially out-of-bounds
     pytest.param("float32", 7, 5, 15, 3, 8, 8, False, marks=a3_known_boundary_load_issue),
-    # V1.5 命中: PAD_NAN (float)
+    # V1.5 hit: PAD_NAN (float)
     pytest.param("float32", 5, 3, 12, 4, 8, 8, True, marks=a3_known_boundary_load_issue),
-    # V1.5 命中: float16
+    # V1.5 hit: float16
     pytest.param("float16", 5, 5, 20, 4, 8, 8, False, marks=a3_known_boundary_load_issue),
-    # 越界都在尾轴: block 完全装得下 axis 0
+    # OOB only on last axis: block fully fits axis 0
     pytest.param("float32", 8, 3, 12, 4, 8, 8, False, marks=a3_known_boundary_load_issue),
 ])
 def test_block_ptr_boundary_load(dtype, parent_m, parent_n, stride_m, stride_n, block_m, block_n, pad_nan):

--- a/third_party/ascend/unittest/pytest_ut/test_specialization_cache_unit.py
+++ b/third_party/ascend/unittest/pytest_ut/test_specialization_cache_unit.py
@@ -8,7 +8,6 @@ import inspect
 
 import pytest
 import torch
-
 from triton.backends.ascend.compiler import AscendBackend
 from triton.backends.compiler import GPUTarget
 from triton.runtime.jit import KernelParam, compute_cache_key, create_function_from_signature
@@ -17,7 +16,6 @@ pytestmark = pytest.mark.backend("native")
 
 
 class PointerArg:
-
     dtype = torch.float32
 
     def __init__(self, address):


### PR DESCRIPTION
Wrap the converted scan op with scope::ScopeOp and scope::ReturnOp, and annotate the output memref with #hivm.address_space<ub> plus the {hivm.tcore_type = #hivm.tcore_type<VECTOR>} attribute on the scope.

- TritonOpConverter.cpp: create scope::ScopeOp around the scan loop, use UB address space for the output memref, return via scope::ReturnOp and set tcore_type=VECTOR on the scope.
- TritonToLinalgPass.cpp: register scope::ScopeDialect in getDependentDialects and mark it legal in addDynamicLegal so the converted IR can be legalized.
- CMakeLists.txt: link BiShengIRScopeDialect.
