### PR TITLE
[GraphOptimize](feat) add graph optimization diagnostics

### DIFF
--- a/third_party/ascend/include/TritonToGraph/GraphOptimizationRule.h
+++ b/third_party/ascend/include/TritonToGraph/GraphOptimizationRule.h
@@ -29,6 +29,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <memory>
 
@@ -47,6 +48,11 @@ public:
   virtual unsigned getBenefit() const = 0;
   virtual Operation *getAnchor() const = 0;
   virtual unsigned getCreationEpoch() const = 0;
+
+  // Diagnostic-enabled plans override this to append a deterministic,
+  // single-line summary. The default keeps unrelated rules out of the
+  // GraphOptimize diagnostic surface.
+  virtual void printDebug(llvm::raw_ostream &) const {}
 
   // Failure means this plan is no longer applicable to the current epoch.
   virtual LogicalResult revalidate(GraphOptimizationContext &context) const = 0;

--- a/third_party/ascend/lib/TritonToGraph/GraphOptimizationPass.cpp
+++ b/third_party/ascend/lib/TritonToGraph/GraphOptimizationPass.cpp
@@ -28,6 +28,8 @@
 #include "mlir/IR/PatternMatch.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <algorithm>
 #include <array>
@@ -86,6 +88,56 @@ unsigned getProgramOrder(const RewritePlan &plan,
 
 bool isRuleEnabled(uint16_t ruleMask, GraphOptimizationRuleId ruleId) {
   return (ruleMask & getGraphOptimizationRuleMask(ruleId)) != 0;
+}
+
+bool isGraphDiagnosticsRule(GraphOptimizationRuleId ruleId) {
+  switch (ruleId) {
+  case GraphOptimizationRuleId::LoadStoreTranspose:
+  case GraphOptimizationRuleId::TransposePointwiseReorder:
+  case GraphOptimizationRuleId::StoreCoalescing:
+  case GraphOptimizationRuleId::RowCoalescing:
+    return true;
+  default:
+    return false;
+  }
+}
+
+llvm::StringRef getGraphRuleName(GraphOptimizationRuleId ruleId) {
+  switch (ruleId) {
+  case GraphOptimizationRuleId::LoadStoreTranspose:
+    return "LoadStoreTranspose";
+  case GraphOptimizationRuleId::TransposePointwiseReorder:
+    return "TransposePointwiseReorder";
+  case GraphOptimizationRuleId::StoreCoalescing:
+    return "StoreCoalescing";
+  case GraphOptimizationRuleId::RowCoalescing:
+    return "RowCoalescing";
+  default:
+    return "Unknown";
+  }
+}
+
+void writeGraphLogPrefix() { llvm::errs() << "[GRAPH] "; }
+
+void logCandidateSummary(GraphOptimizationRuleId ruleId, size_t count,
+                         unsigned epoch) {
+  writeGraphLogPrefix();
+  llvm::errs() << "event=candidates rule=" << getGraphRuleName(ruleId)
+               << " count=" << count << " epoch=" << epoch << '\n';
+}
+
+void logPlanEvent(llvm::StringRef event, const RewritePlan &plan,
+                  unsigned ordinal, unsigned epoch,
+                  llvm::StringRef suffix = "") {
+  writeGraphLogPrefix();
+  llvm::errs() << "event=" << event
+               << " rule=" << getGraphRuleName(plan.getRuleId())
+               << " benefit=" << plan.getBenefit() << " ordinal=" << ordinal
+               << " epoch=" << epoch;
+  plan.printDebug(llvm::errs());
+  if (!suffix.empty())
+    llvm::errs() << ' ' << suffix;
+  llvm::errs() << '\n';
 }
 
 class GraphOptimizePass final
@@ -167,11 +219,46 @@ void GraphOptimizePass::runOnOperation() {
   for (triton::FuncOp function : module.getOps<triton::FuncOp>()) {
     GraphOptimizationContext context(function);
     unsigned rewriteCount = 0;
+    unsigned rowRewriteCount = 0;
+    unsigned staleSkipped = 0;
+    unsigned revalidationSkipped = 0;
+    bool budgetExhausted = false;
+    std::array<unsigned, 4> successfulRewrites = {};
+
+    auto recordSuccessfulRewrite = [&](GraphOptimizationRuleId ruleId) {
+      switch (ruleId) {
+      case GraphOptimizationRuleId::LoadStoreTranspose:
+        ++successfulRewrites[0];
+        break;
+      case GraphOptimizationRuleId::TransposePointwiseReorder:
+        ++successfulRewrites[1];
+        break;
+      case GraphOptimizationRuleId::StoreCoalescing:
+        ++successfulRewrites[2];
+        break;
+      case GraphOptimizationRuleId::RowCoalescing:
+        ++successfulRewrites[3];
+        break;
+      default:
+        break;
+      }
+    };
+
+    writeGraphLogPrefix();
+    llvm::errs() << "event=pass-start function=" << function.getName()
+                 << " rule-mask="
+                 << static_cast<unsigned>(options.enabledRuleMask)
+                 << " max-rewrites=" << options.maxRewritesPerFunction
+                 << " ub-capacity-bytes=" << options.ubCapacityBytes
+                 << " force-simt-only="
+                 << (options.forceSimtOnly ? "true" : "false") << '\n';
 
     for (GraphOptimizationRuleId phase : kRulePhases) {
       if (!isRuleEnabled(options.enabledRuleMask, phase))
         continue;
 
+      const bool logPhase = isGraphDiagnosticsRule(phase);
+      bool loggedCandidateSummary = false;
       while (rewriteCount < options.maxRewritesPerFunction) {
         ProgramOrderMap programOrder = buildProgramOrderMap(function);
         SmallVector<std::unique_ptr<RewritePlan>> plans;
@@ -200,6 +287,10 @@ void GraphOptimizePass::runOnOperation() {
                              return !plan || plan->getRuleId() != phase;
                            }),
             plans.end());
+        if (logPhase && !loggedCandidateSummary) {
+          logCandidateSummary(phase, plans.size(), context.getEpoch());
+          loggedCandidateSummary = true;
+        }
         if (plans.empty())
           break;
 
@@ -220,13 +311,21 @@ void GraphOptimizePass::runOnOperation() {
             });
 
         std::unique_ptr<RewritePlan> selectedPlan;
+        unsigned selectedOrdinal = 0;
+        unsigned ordinal = 0;
         for (std::unique_ptr<RewritePlan> &plan : plans) {
-          if (plan->getCreationEpoch() != context.getEpoch())
+          ++ordinal;
+          if (plan->getCreationEpoch() != context.getEpoch()) {
+            ++staleSkipped;
             continue;
-          if (failed(plan->revalidate(context)))
+          }
+          if (failed(plan->revalidate(context))) {
+            ++revalidationSkipped;
             continue;
+          }
 
           selectedPlan = std::move(plan);
+          selectedOrdinal = ordinal;
           break;
         }
 
@@ -236,6 +335,9 @@ void GraphOptimizePass::runOnOperation() {
         }
 
         const GraphOptimizationRuleId appliedRuleId = selectedPlan->getRuleId();
+        if (logPhase)
+          logPlanEvent("plan-selected", *selectedPlan, selectedOrdinal,
+                       context.getEpoch());
         IRRewriter rewriter(&getContext());
         if (failed(selectedPlan->apply(rewriter))) {
           selectedPlan.reset();
@@ -244,6 +346,9 @@ void GraphOptimizePass::runOnOperation() {
           signalPassFailure();
           return;
         }
+        if (logPhase)
+          logPlanEvent("apply-ok", *selectedPlan, selectedOrdinal,
+                       context.getEpoch());
 
         if (options.emitRemarks)
           function.emitRemark() << "applied graph optimization rule "
@@ -255,10 +360,29 @@ void GraphOptimizePass::runOnOperation() {
         plans.clear();
         context.invalidate();
         ++rewriteCount;
+        if (logPhase)
+          recordSuccessfulRewrite(appliedRuleId);
       }
 
-      if (rewriteCount == options.maxRewritesPerFunction)
+      if (logPhase && !loggedCandidateSummary) {
+        writeGraphLogPrefix();
+        llvm::errs() << "event=candidates rule=" << getGraphRuleName(phase)
+                     << " status=not-scanned reason=rewrite-budget-exhausted"
+                     << " epoch=" << context.getEpoch() << '\n';
+      }
+
+      if (rewriteCount == options.maxRewritesPerFunction) {
+        budgetExhausted = true;
         break;
+      }
+    }
+
+    if (budgetExhausted) {
+      writeGraphLogPrefix();
+      llvm::errs() << "event=budget-exhausted function=" << function.getName()
+                   << " rewrites=" << rewriteCount
+                   << " max-rewrites=" << options.maxRewritesPerFunction
+                   << '\n';
     }
 
     // RowCoalescing has the same function-local candidate/rewrite interface
@@ -267,90 +391,132 @@ void GraphOptimizePass::runOnOperation() {
     // budget, so run it once after LoadStoreTranspose,
     // TransposePointwiseReorder, and StoreCoalescing even when that budget
     // has already been exhausted.
-    if (!isRuleEnabled(options.enabledRuleMask,
-                       GraphOptimizationRuleId::RowCoalescing))
-      continue;
+    if (isRuleEnabled(options.enabledRuleMask,
+                      GraphOptimizationRuleId::RowCoalescing)) {
+      if (!options.forceSimtOnly) {
+        writeGraphLogPrefix();
+        llvm::errs() << "event=rule-skip rule=RowCoalescing"
+                     << " reason=force-simt-only-false\n";
+      } else {
+        GraphOptimizationRule *rowRule = nullptr;
+        for (GraphOptimizationRule *rule : enabledRules) {
+          if (rule->getId() == GraphOptimizationRuleId::RowCoalescing) {
+            rowRule = rule;
+            break;
+          }
+        }
+        if (!rowRule) {
+          writeGraphLogPrefix();
+          llvm::errs() << "event=rule-skip rule=RowCoalescing"
+                       << " reason=not-registered\n";
+        } else {
+          if (failed(context.ensure(rowRule->getAnalysisRequirements()))) {
+            function.emitError()
+                << "graph-optimize failed to build Row analyses";
+            signalPassFailure();
+            return;
+          }
 
-    GraphOptimizationRule *rowRule = nullptr;
-    for (GraphOptimizationRule *rule : enabledRules) {
-      if (rule->getId() == GraphOptimizationRuleId::RowCoalescing) {
-        rowRule = rule;
-        break;
+          SmallVector<std::unique_ptr<RewritePlan>> rowPlans;
+          if (failed(rowRule->findCandidates(context, rowPlans))) {
+            function.emitError()
+                << "graph-optimize failed to discover Row candidate";
+            signalPassFailure();
+            return;
+          }
+          rowPlans.erase(
+              std::remove_if(
+                  rowPlans.begin(), rowPlans.end(),
+                  [](const std::unique_ptr<RewritePlan> &plan) {
+                    return !plan || plan->getRuleId() !=
+                                        GraphOptimizationRuleId::RowCoalescing;
+                  }),
+              rowPlans.end());
+          logCandidateSummary(GraphOptimizationRuleId::RowCoalescing,
+                              rowPlans.size(), context.getEpoch());
+
+          if (!rowPlans.empty()) {
+            ProgramOrderMap programOrder = buildProgramOrderMap(function);
+            std::stable_sort(
+                rowPlans.begin(), rowPlans.end(),
+                [&programOrder](const std::unique_ptr<RewritePlan> &lhs,
+                                const std::unique_ptr<RewritePlan> &rhs) {
+                  if (lhs->getBenefit() != rhs->getBenefit())
+                    return lhs->getBenefit() > rhs->getBenefit();
+
+                  const unsigned lhsOrder = getProgramOrder(*lhs, programOrder);
+                  const unsigned rhsOrder = getProgramOrder(*rhs, programOrder);
+                  if (lhsOrder != rhsOrder)
+                    return lhsOrder < rhsOrder;
+
+                  return static_cast<unsigned>(lhs->getRuleId()) <
+                         static_cast<unsigned>(rhs->getRuleId());
+                });
+
+            std::unique_ptr<RewritePlan> selectedRowPlan;
+            unsigned selectedRowOrdinal = 0;
+            unsigned ordinal = 0;
+            for (std::unique_ptr<RewritePlan> &plan : rowPlans) {
+              ++ordinal;
+              if (plan->getCreationEpoch() != context.getEpoch()) {
+                ++staleSkipped;
+                continue;
+              }
+              if (failed(plan->revalidate(context))) {
+                ++revalidationSkipped;
+                continue;
+              }
+              selectedRowPlan = std::move(plan);
+              selectedRowOrdinal = ordinal;
+              break;
+            }
+
+            if (selectedRowPlan) {
+              logPlanEvent("plan-selected", *selectedRowPlan,
+                           selectedRowOrdinal, context.getEpoch(),
+                           "sandbox=not-run");
+              IRRewriter rewriter(&getContext());
+              if (failed(selectedRowPlan->apply(rewriter))) {
+                selectedRowPlan.reset();
+                rowPlans.clear();
+                function.emitError()
+                    << "graph-optimize failed to apply Row rewrite";
+                signalPassFailure();
+                return;
+              }
+              logPlanEvent("apply-ok", *selectedRowPlan, selectedRowOrdinal,
+                           context.getEpoch(), "sandbox=verified");
+
+              if (options.emitRemarks)
+                function.emitRemark()
+                    << "applied graph optimization rule "
+                    << static_cast<unsigned>(
+                           GraphOptimizationRuleId::RowCoalescing);
+
+              selectedRowPlan.reset();
+              rowPlans.clear();
+              context.invalidate();
+              ++rowRewriteCount;
+              recordSuccessfulRewrite(GraphOptimizationRuleId::RowCoalescing);
+            }
+          }
+        }
       }
     }
-    if (!rowRule)
-      continue;
 
-    if (failed(context.ensure(rowRule->getAnalysisRequirements()))) {
-      function.emitError() << "graph-optimize failed to build Row analyses";
-      signalPassFailure();
-      return;
-    }
-
-    SmallVector<std::unique_ptr<RewritePlan>> rowPlans;
-    if (failed(rowRule->findCandidates(context, rowPlans))) {
-      function.emitError() << "graph-optimize failed to discover Row candidate";
-      signalPassFailure();
-      return;
-    }
-    rowPlans.erase(
-        std::remove_if(rowPlans.begin(), rowPlans.end(),
-                       [](const std::unique_ptr<RewritePlan> &plan) {
-                         return !plan ||
-                                plan->getRuleId() !=
-                                    GraphOptimizationRuleId::RowCoalescing;
-                       }),
-        rowPlans.end());
-    if (rowPlans.empty())
-      continue;
-
-    ProgramOrderMap programOrder = buildProgramOrderMap(function);
-    std::stable_sort(rowPlans.begin(), rowPlans.end(),
-                     [&programOrder](const std::unique_ptr<RewritePlan> &lhs,
-                                     const std::unique_ptr<RewritePlan> &rhs) {
-                       if (lhs->getBenefit() != rhs->getBenefit())
-                         return lhs->getBenefit() > rhs->getBenefit();
-
-                       const unsigned lhsOrder =
-                           getProgramOrder(*lhs, programOrder);
-                       const unsigned rhsOrder =
-                           getProgramOrder(*rhs, programOrder);
-                       if (lhsOrder != rhsOrder)
-                         return lhsOrder < rhsOrder;
-
-                       return static_cast<unsigned>(lhs->getRuleId()) <
-                              static_cast<unsigned>(rhs->getRuleId());
-                     });
-
-    std::unique_ptr<RewritePlan> selectedRowPlan;
-    for (std::unique_ptr<RewritePlan> &plan : rowPlans) {
-      if (plan->getCreationEpoch() != context.getEpoch())
-        continue;
-      if (failed(plan->revalidate(context)))
-        continue;
-      selectedRowPlan = std::move(plan);
-      break;
-    }
-    if (!selectedRowPlan)
-      continue;
-
-    IRRewriter rewriter(&getContext());
-    if (failed(selectedRowPlan->apply(rewriter))) {
-      selectedRowPlan.reset();
-      rowPlans.clear();
-      function.emitError() << "graph-optimize failed to apply Row rewrite";
-      signalPassFailure();
-      return;
-    }
-
-    if (options.emitRemarks)
-      function.emitRemark()
-          << "applied graph optimization rule "
-          << static_cast<unsigned>(GraphOptimizationRuleId::RowCoalescing);
-
-    selectedRowPlan.reset();
-    rowPlans.clear();
-    context.invalidate();
+    writeGraphLogPrefix();
+    llvm::errs() << "event=pass-end function=" << function.getName()
+                 << " rewrites-general=" << rewriteCount
+                 << " rewrites-row=" << rowRewriteCount
+                 << " rewrites-total=" << rewriteCount + rowRewriteCount
+                 << " success-load-store=" << successfulRewrites[0]
+                 << " success-transpose-pointwise=" << successfulRewrites[1]
+                 << " success-store-coalescing=" << successfulRewrites[2]
+                 << " success-row-coalescing=" << successfulRewrites[3]
+                 << " stale-skipped=" << staleSkipped
+                 << " revalidation-skipped=" << revalidationSkipped
+                 << " budget-exhausted=" << (budgetExhausted ? "true" : "false")
+                 << '\n';
   }
 }
 

--- a/third_party/ascend/lib/TritonToGraph/LegacyMemoryAccess/StridedAxisCoalescing.cpp
+++ b/third_party/ascend/lib/TritonToGraph/LegacyMemoryAccess/StridedAxisCoalescing.cpp
@@ -28,6 +28,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Matchers.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <functional>
 
@@ -576,6 +577,10 @@ void rewriteStridedAxisCoalesce(ModuleOp moduleOp) {
   auto i32t = IntegerType::get(moduleOp.getContext(), 32);
   moduleOp->setAttr("hacc.coalesce_factor", IntegerAttr::get(i32t, S));
   moduleOp->setAttr("hacc.coalesce_axis", IntegerAttr::get(i32t, coalesceAxis));
+  llvm::errs() << "[GRAPH] event=apply-ok rule=StridedAxisCoalescing"
+               << " block-rows=" << BT << " factor=" << S
+               << " axis=" << coalesceAxis << " seed-loads=" << seeds.size()
+               << " stores=" << sinks.size() << '\n';
 }
 
 } // namespace StridedAxisCoalescing

--- a/third_party/ascend/lib/TritonToGraph/Rules/LoadStoreTransposeRule.cpp
+++ b/third_party/ascend/lib/TritonToGraph/Rules/LoadStoreTransposeRule.cpp
@@ -2103,7 +2103,14 @@ class LayoutPermutationPlan final : public RewritePlan {
 public:
   LayoutPermutationPlan(LayoutPermutationCandidate candidate, unsigned epoch)
       : loop(candidate.loop), block(candidate.block), anchor(candidate.anchor),
-        permutation(std::move(candidate.permutation)), epoch(epoch) {}
+        permutation(std::move(candidate.permutation)),
+        externalTensorCount(candidate.externalTensorValues.size()),
+        reductionPortCount(candidate.reductionPorts.size()),
+        transformedResultCount(candidate.transformedResultIndices.size()),
+        blockOperationCount(candidate.blockOperations.size()),
+        externalAssertCount(candidate.externalAssertPorts.size()),
+        retireOperationCount(candidate.retireOperations.size()),
+        endpointCount(candidate.endpointCount), epoch(epoch) {}
 
   GraphOptimizationRuleId getRuleId() const override {
     return GraphOptimizationRuleId::LoadStoreTranspose;
@@ -2114,6 +2121,23 @@ public:
   Operation *getAnchor() const override { return anchor; }
 
   unsigned getCreationEpoch() const override { return epoch; }
+
+  void printDebug(llvm::raw_ostream &os) const override {
+    os << " scope=" << (loop ? "loop" : "block")
+       << " rank=" << permutation.size() << " permutation=[";
+    for (size_t index = 0; index < permutation.size(); ++index) {
+      if (index != 0)
+        os << ',';
+      os << permutation[index];
+    }
+    os << "] endpoints=" << endpointCount
+       << " external-tensors=" << externalTensorCount
+       << " reductions=" << reductionPortCount
+       << " transformed-results=" << transformedResultCount
+       << " closure-ops=" << blockOperationCount
+       << " external-asserts=" << externalAssertCount
+       << " retire-ops=" << retireOperationCount;
+  }
 
   LogicalResult revalidate(GraphOptimizationContext &context) const override {
     if (context.getEpoch() != epoch || !anchor || (!loop && !block) ||
@@ -2145,6 +2169,13 @@ private:
   Block *block;
   Operation *anchor;
   SmallVector<int32_t, 4> permutation;
+  size_t externalTensorCount;
+  size_t reductionPortCount;
+  size_t transformedResultCount;
+  size_t blockOperationCount;
+  size_t externalAssertCount;
+  size_t retireOperationCount;
+  unsigned endpointCount;
   unsigned epoch;
 };
 

--- a/third_party/ascend/lib/TritonToGraph/Rules/RowCoalescingRule.cpp
+++ b/third_party/ascend/lib/TritonToGraph/Rules/RowCoalescingRule.cpp
@@ -322,6 +322,13 @@ public:
   Operation *getAnchor() const override { return candidate.anchor; }
   unsigned getCreationEpoch() const override { return epoch; }
 
+  void printDebug(llvm::raw_ostream &os) const override {
+    os << " axis=" << candidate.axis
+       << " rows-per-program=" << candidate.rowsPerProgram
+       << " entry-contract=public-unique-pid"
+       << " factor=" << candidate.rowsPerProgram << " ceil-div=1";
+  }
+
   LogicalResult revalidate(GraphOptimizationContext &context) const override {
     if (context.getFunction() != candidate.function)
       return failure();

--- a/third_party/ascend/lib/TritonToGraph/Rules/StoreCoalescingRule.cpp
+++ b/third_party/ascend/lib/TritonToGraph/Rules/StoreCoalescingRule.cpp
@@ -666,7 +666,19 @@ public:
                       const EntryArgPointerAliasAnalysis *entryAliases,
                       unsigned ubCapacityBytes, unsigned epoch)
       : function(function), anchor(run.anchor), entryAliases(entryAliases),
-        ubCapacityBytes(ubCapacityBytes), epoch(epoch) {
+        ubCapacityBytes(ubCapacityBytes),
+        runStoreCount(run.addressOrderStores.size()),
+        programStoreCount(run.programOrderStores.size()),
+        firstOffset(run.firstOffset), endExclusive(run.endExclusive),
+        totalElements(run.totalElements), totalBytes(run.totalBytes),
+        elementBytes(run.addressOrderStores.empty()
+                         ? 0
+                         : run.addressOrderStores.front().elementBytes),
+        hasDynamicOrigin(
+            !run.addressOrderStores.empty() &&
+            static_cast<bool>(
+                run.addressOrderStores.front().access.dynamicOrigin)),
+        epoch(epoch) {
     for (const StoreCandidate &candidate : run.addressOrderStores)
       addressOrderStores.push_back(candidate.operation);
   }
@@ -684,6 +696,17 @@ public:
   Operation *getAnchor() const override { return anchor; }
 
   unsigned getCreationEpoch() const override { return epoch; }
+
+  void printDebug(llvm::raw_ostream &os) const override {
+    os << " ub-capacity-bytes=" << ubCapacityBytes
+       << " stores=" << runStoreCount << " program-stores=" << programStoreCount
+       << " elements=" << totalElements << " bytes=" << totalBytes
+       << " element-bytes=" << elementBytes
+       << " dynamic-origin=" << (hasDynamicOrigin ? "true" : "false")
+       << " address-order=ascending program-order=preserved offsets=["
+       << firstOffset << ',' << endExclusive << ")"
+       << " erased=" << programStoreCount;
+  }
 
   LogicalResult revalidate(GraphOptimizationContext &context) const override {
     if (context.getEpoch() != epoch || !function || !anchor || !entryAliases ||
@@ -714,6 +737,14 @@ private:
   SmallVector<Operation *, 4> addressOrderStores;
   const EntryArgPointerAliasAnalysis *entryAliases;
   unsigned ubCapacityBytes;
+  size_t runStoreCount;
+  size_t programStoreCount;
+  int64_t firstOffset;
+  int64_t endExclusive;
+  int64_t totalElements;
+  uint64_t totalBytes;
+  uint64_t elementBytes;
+  bool hasDynamicOrigin;
   unsigned epoch;
 };
 

--- a/third_party/ascend/lib/TritonToGraph/Rules/TransposePointwiseReorderRule.cpp
+++ b/third_party/ascend/lib/TritonToGraph/Rules/TransposePointwiseReorderRule.cpp
@@ -35,6 +35,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 #include <utility>
 
 using namespace mlir;
@@ -246,7 +247,13 @@ public:
       : dot(chain.dot), dotOperation(chain.dot.getOperation()),
         operandIndex(chain.operandIndex), trans(chain.trans),
         transOperation(chain.trans.getOperation()),
-        unaryOps(std::move(chain.unaryOps)), epoch(epoch) {}
+        unaryOps(std::move(chain.unaryOps)),
+        sourceType(trans.getSrc().getType()),
+        resultType(trans.getResult().getType()), epoch(epoch) {
+    order.append(trans.getOrder().begin(), trans.getOrder().end());
+    for (Operation *unary : unaryOps)
+      unaryOpNames.push_back(unary->getName().getStringRef().str());
+  }
 
   GraphOptimizationRuleId getRuleId() const override {
     return GraphOptimizationRuleId::TransposePointwiseReorder;
@@ -259,6 +266,27 @@ public:
   Operation *getAnchor() const override { return dotOperation; }
 
   unsigned getCreationEpoch() const override { return epoch; }
+
+  void printDebug(llvm::raw_ostream &os) const override {
+    os << " operand=" << (operandIndex == 0 ? "A" : "B") << " order=[";
+    for (size_t index = 0; index < order.size(); ++index) {
+      if (index != 0)
+        os << ',';
+      os << order[index];
+    }
+    os << "] unary-count=" << unaryOpNames.size() << " unary-ops=[";
+    for (size_t index = 0; index < unaryOpNames.size(); ++index) {
+      if (index != 0)
+        os << ',';
+      os << unaryOpNames[index];
+    }
+    os << "] source-type=";
+    sourceType.print(os);
+    os << " result-type=";
+    resultType.print(os);
+    os << " created=" << unaryOps.size() + 1
+       << " erased=" << unaryOps.size() + 1;
+  }
 
   LogicalResult revalidate(GraphOptimizationContext &context) const override {
     if (context.getEpoch() != epoch || !dot)
@@ -366,6 +394,10 @@ private:
   triton::TransOp trans;
   Operation *transOperation;
   SmallVector<Operation *> unaryOps;
+  SmallVector<int32_t, 4> order;
+  SmallVector<std::string, 4> unaryOpNames;
+  Type sourceType;
+  Type resultType;
   unsigned epoch;
 };
 

--- a/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/strided_axis_coalescing.mlir
+++ b/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/strided_axis_coalescing.mlir
@@ -1,11 +1,13 @@
 // RUN: triton-opt %s --triton-to-unstructure='compile-on-910-95=true force-simt-template=true' \
-// RUN:                --triton-to-linalg='compile-on-910-95=true' --split-input-file \
+// RUN:                --triton-to-linalg='compile-on-910-95=true' --split-input-file 2> %t.stderr \
 // RUN: | FileCheck %s
+// RUN: FileCheck %s --check-prefix=LOG < %t.stderr
 
 // -----
 // The `pid % S` strided block-pointer shape is owned by StridedAxisCoalescing,
 // before Chunk and StridedLoadStoreRewrite.  It folds the S heads into the
 // inner tensor dimension and records the launch-axis shrink metadata.
+// LOG: [GRAPH] event=apply-ok rule=StridedAxisCoalescing block-rows=16 factor=4 axis=0 seed-loads=1 stores=1
 // CHECK-LABEL: module attributes {
 // CHECK: hacc.coalesce_axis = 0 : i32
 // CHECK: hacc.coalesce_factor = 4 : i32


### PR DESCRIPTION
## Summary
- Ports the low-noise `[GRAPH]` event stream to the current `GraphOptimizePass` flow.
- Records pass configuration, first-scan candidate counts, selected plans, successful commits, rewrite-budget termination, Row gating, and per-rule success totals.
- Adds stable plan summaries for `LoadStoreTranspose`, `TransposePointwiseReorder`, `StoreCoalescing`, and `RowCoalescing`.
- Adds an applied-only `StridedAxisCoalescing` event with block rows, fold factor, grid axis, seed-load count, and store count.

## Scope
- `DiagonalMaskRemoval` and `ConvertModuloToMask` retain their existing optimization behavior and intentionally emit no rule-level diagnostic events.
- A default no-op `RewritePlan::printDebug` keeps unrelated and future plans outside this diagnostic surface.

## Validation
- Compile-only validation of the canonical `stride_axis_coalescing.py` case exports `coalesce_factor=4`, `coalesce_axis=0`, `coalesce_grid_ceil_div=false`, and a folded `[16, 4]` Linalg access.
- The updated `StridedAxisCoalescing.cpp` target compiles in an isolated LLVM 22/CANN build, and the resulting object contains the exact `[GRAPH]` event prefix.
- The MLIR regression captures stderr separately and checks the success event, so unrelated diagnostics cannot corrupt its IR assertions.
- `python -m pre_commit run --files` passes for all changed files.
- Full local Ascend wheel link remains blocked by pre-existing `AscendNPU-IR` HIVM generated-code compatibility failures and a separate `LibEntry` pybind11 include issue; neither failure is in this change set.