### PR TITLE
[runtime](fix) evaluate alignment specialization once per launch

### DIFF
--- a/third_party/ascend/patch/triton-ascend-3.6.0.patch
+++ b/third_party/ascend/patch/triton-ascend-3.6.0.patch
@@ -1118,13 +1118,15 @@ index cd871cb2e..82eb6960d 100644
                  if triton.knobs.compilation.front_end_debugging:
                      raise
 diff --git a/python/triton/runtime/jit.py b/python/triton/runtime/jit.py
-index 0f506818f..b2992457f 100644
+index 0f506818f..43742c328 100644
 --- a/python/triton/runtime/jit.py
 +++ b/python/triton/runtime/jit.py
-@@ -398,14 +398,16 @@ def create_function_from_signature(sig, kparams, backend):
+@@ -398,14 +398,19 @@ def create_function_from_signature(sig, kparams, backend):
      assert len(sig.parameters) == len(kparams)
      # Create the function argument list and the dict entries for the return statement
      specialization = []
++    uses_alignment_specialization = False
++    alignment_specialization_name = "__triton_alignment_specialization"
 +    integer_annotation_types = {"i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64"}
      # signature
      for name, kp in zip(sig.parameters.keys(), kparams):
@@ -1134,19 +1136,21 @@ index 0f506818f..b2992457f 100644
 -            is_const = 'True' if kp.is_const else 'False'
 -            specialize = 'False' if kp.do_not_specialize else 'True'
 -            align = 'False' if kp.do_not_specialize_on_alignment else 'True'
+-            ret = f"specialize_impl(backend, {name}, {is_const}, {specialize}, {align})"
 +            is_const = kp.is_const
 +            specialize = not kp.do_not_specialize
 +            align = not kp.do_not_specialize_on_alignment
--            ret = f"specialize_impl(backend, {name}, {is_const}, {specialize}, {align})"
++            effective_align = alignment_specialization_name if align and specialize else "False"
 +            ret = (f"specialize_impl(backend, {name}, {is_const}, {specialize}, "
-+                   f"{align} and backend.use_alignment_specialization(options))")
++                   f"{effective_align})")
              if kp.annotation_type:
                  if isinstance(kp.annotation_type, str):
-@@ -413,7 +415,13 @@ def create_function_from_signature(sig, kparams, backend):
+@@ -413,7 +418,14 @@ def create_function_from_signature(sig, kparams, backend):
                          # we do not specialize non-constexpr floats and bools:
                          specialize = False
                  if specialize:
 -                    specialization.append(f'("{kp.annotation_type}",) + {ret}[1:]')
++                    uses_alignment_specialization = uses_alignment_specialization or align
 +                    if kp.annotation_type in integer_annotation_types:
 +                        # An integer annotation constrains the type of runtime values, but must not discard a
 +                        # constexpr classification already produced by the value specializer (for example, 1).
@@ -1157,3 +1161,20 @@ index 0f506818f..b2992457f 100644
                  else:
                      # skip runtime specialization:
                      specialization.append(f'("{kp.annotation_type}", None)')
+@@ -420,2 +432,3 @@ def create_function_from_signature(sig, kparams, backend):
+             else:
++                uses_alignment_specialization = uses_alignment_specialization or (align and specialize)
+                 specialization.append(f"{ret}")
+@@ -423,8 +436,11 @@ def create_function_from_signature(sig, kparams, backend):
+     # compute argument string for a given parameter
+     arg = lambda x: x[0] if x[1].default is inspect.Parameter.empty else f"{x[0]}=default_{x[0]}"
++    alignment_specialization_init = (f"    {alignment_specialization_name} = "
++                                     "backend.use_alignment_specialization(options)\n"
++                                     if uses_alignment_specialization else "")
+     func_body = f"""
+ def dynamic_func({", ".join(list(map(arg, sig.parameters.items())) + ["**options"])}):
+-    params = {{{', '.join([f"'{name}': {name}" for name in sig.parameters.keys()])}}}
++{alignment_specialization_init}    params = {{{', '.join([f"'{name}': {name}" for name in sig.parameters.keys()])}}}
+     specialization = [{','.join(specialization)}]
+     return params, specialization, options
+ """

--- a/third_party/ascend/unittest/pytest_ut/test_specialization_cache_unit.py
+++ b/third_party/ascend/unittest/pytest_ut/test_specialization_cache_unit.py
@@ -25,13 +25,27 @@ class PointerArg:
         return self.address
 
 
-def make_binder(backend=None):
+class CountingAscendBackend(AscendBackend):
+
+    def __init__(self):
+        super().__init__(GPUTarget("npu", "Ascend910B", 32))
+        self.alignment_specialization_calls = 0
+
+    def use_alignment_specialization(self, options):
+        self.alignment_specialization_calls += 1
+        return super().use_alignment_specialization(options)
+
+
+def make_binder(backend=None, do_not_specialize_on_alignment=False):
 
     def kernel(value, pointer):
         pass
 
     signature = inspect.signature(kernel)
-    params = [KernelParam(i, param, False, False) for i, param in enumerate(signature.parameters.values())]
+    params = [
+        KernelParam(i, param, False, do_not_specialize_on_alignment)
+        for i, param in enumerate(signature.parameters.values())
+    ]
     if backend is None:
         backend = AscendBackend(GPUTarget("npu", "Ascend910B", 32))
     return create_function_from_signature(signature, params, backend)
@@ -54,6 +68,59 @@ SIMT_OPTIONS = [
     pytest.param({"force_simt_only": True}, id="legacy-force-simt-only"),
     pytest.param({"compile_mode": "simd", "force_simt_only": True}, id="legacy-force-simt-overrides-mode"),
 ]
+
+
+def test_alignment_policy_is_evaluated_once_per_binder_call():
+    backend = CountingAscendBackend()
+    binder = make_binder(backend)
+
+    binder(16, PointerArg(0x1000), compile_mode="simd")
+    assert backend.alignment_specialization_calls == 1
+
+    binder(17, PointerArg(0x1004), compile_mode="simt_only")
+    assert backend.alignment_specialization_calls == 2
+
+
+def test_alignment_policy_is_not_evaluated_when_unused():
+    backend = CountingAscendBackend()
+    binder = make_binder(backend, do_not_specialize_on_alignment=True)
+
+    binder(16, PointerArg(0x1000), compile_mode="simd")
+
+    assert backend.alignment_specialization_calls == 0
+
+
+def test_alignment_policy_is_not_evaluated_for_non_specialized_annotation():
+
+    def kernel(value):
+        pass
+
+    kernel.__annotations__["value"] = "fp32"
+    signature = inspect.signature(kernel)
+    params = [KernelParam(0, next(iter(signature.parameters.values())), False, False)]
+    backend = CountingAscendBackend()
+    binder = create_function_from_signature(signature, params, backend)
+
+    _, specialization, _ = binder(1.25, compile_mode="simd")
+
+    assert specialization == [("fp32", None)]
+    assert backend.alignment_specialization_calls == 0
+
+
+def test_alignment_policy_is_not_evaluated_when_value_specialization_is_disabled():
+
+    def kernel(value):
+        pass
+
+    signature = inspect.signature(kernel)
+    params = [KernelParam(0, next(iter(signature.parameters.values())), True, False)]
+    backend = CountingAscendBackend()
+    binder = create_function_from_signature(signature, params, backend)
+
+    _, specialization, _ = binder(16, compile_mode="simd")
+
+    assert specialization == [("i32", None)]
+    assert backend.alignment_specialization_calls == 0
 
 
 @pytest.mark.parametrize("options", SIMD_OPTIONS)


### PR DESCRIPTION
## Summary

- Evaluate the Ascend alignment-specialization policy once per generated binder invocation instead of once per eligible runtime argument.
- Keep the policy evaluation lazy, so binders with no applicable alignment specialization do not pay an extra call.
- Add device-independent regression tests for the one-call and zero-call paths.

## Motivation

This is a performance follow-up to #1480.

The generated binder currently embeds `backend.use_alignment_specialization(options)` in every eligible argument expression. All arguments in one binder invocation share the same backend and raw options, so these calls return the same value. A kernel with `N` eligible runtime arguments therefore performs the same Python method call `N` times on every launch.

The supplied softmax reproducer has four eligible runtime arguments and showed an approximately 1 microsecond host-launch regression per kernel. The optimization computes the policy once in the generated function and reuses that invocation-local value. It is recomputed for every launch, so switching compile options on the same binder remains correct.

This does not change specialization keys, compilation behavior, generated kernels, or the number of kernel launches.

## Performance

Measured on Ascend 910B4 with the supplied softmax kernel, using the same compiled kernel and cache for both binder implementations:

| Metric | Current | Optimized |
|---|---:|---:|
| Alignment-policy calls per launch | 4 | 1 |
| Median host enqueue time | 60.430 us/kernel | 59.286 us/kernel |

- Median paired improvement: `0.842 us/kernel`.
- Bootstrap 95% confidence interval: `[0.530, 1.412] us/kernel`.
- Samples: 201 paired samples, 5 launches per sample.
- Compilation events during measurement: 0.
- Numerical correctness: PASS.
- The five requested kernel launches remain five kernel launches.

An independent cross-process binder benchmark measured `4.236 us` before and `3.301 us` after, an improvement of approximately `0.935 us/kernel`.

## Testing

- Wheel build: PASS.
- CPU/native specialization regression: `163 passed`.
- Ascend 910B4 specialization integration with a fresh Triton cache: `24 passed`.
- Ascend 910B4 repository softmax smoke: `2 passed`; maximum difference from PyTorch was `3.0517578125e-05`.
- Release patch replay: `git apply --check` PASS.
- `git diff --check`: PASS.
- Applicable pre-commit checks, including YAPF, Ruff, AST, mypy, whitespace, EOF, merge-conflict, and private-key checks: PASS.

After rebasing onto the latest `main`, the CPU/native regression was rerun: `163 passed in 0.71s`.
