### PR TITLE
[Ascend](feat) support global scratch at launch

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -1252,12 +1252,15 @@ def ttir_to_npubin(mod, metadata, opt):
         # prepare output
         bin_file = os.path.join(tmpdir, "kernel")
         bin_path = os.path.join(tmpdir, "kernel.o")
+        metadata_path = os.path.join(tmpdir, "triton-metadata.json")
         # build compile options
         _compile_option_list = get_common_bishengir_compile_options(metadata)
         if opt.force_simt_only:
+            _compile_option_list += [f"--triton-metadata-output={metadata_path}"]
             _compile_option_list += ["--enable-hivm-compile=false"]
             _compile_option_list += ["--enable-triton-ir-compile"]
             _compile_option_list += ["--pure-simt"]
+            _compile_option_list += ["--enable-global-scratch-allocation"]
             _compile_option_list += [f"--num-warps={opt.num_warps}"]
             _compile_option_list += [f"--threads-per-warp={opt.warp_size}"]
             if opt.enable_bishengir_simt_optimization != 000:
@@ -1304,6 +1307,8 @@ def ttir_to_npubin(mod, metadata, opt):
             print(f"[DEBUG] {bin_path} is not found")
             print(f"[DEBUG] Stderr:\n{error_msg}")
             raise subprocess.CalledProcessError(ret.returncode, cmd_list, ret.stdout, ret.stderr)
+        if opt.force_simt_only:
+            metadata.update(json.loads(Path(metadata_path).read_text()))
         return Path(bin_path).read_bytes()
 
 

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -28,6 +28,7 @@ import sysconfig
 from typing import Optional
 import functools
 import hashlib
+from triton.runtime import _allocation
 from triton.runtime.cache import get_cache_manager, get_dump_manager
 from triton.backends.driver import DriverBase
 from triton.backends.compiler import GPUTarget
@@ -186,6 +187,8 @@ class NPULauncher(object):
         cst_key = lambda i: self.src.fn.arg_names.index(i) if isinstance(i, str) else i
         signature = {cst_key(key): value for key, value in self.src.signature.items()}
         self.launch = wrap_handle_tensordesc(getattr(mod, "launch"), signature)
+        self.global_scratch_size = getattr(metadata, "global_scratch_size", 0)
+        self.global_scratch_align = getattr(metadata, "global_scratch_align", 1)
 
     def _make_launcher_stub_path(self):
         header_src = generate_npu_header_src()
@@ -199,21 +202,27 @@ class NPULauncher(object):
     def get_launcher_so_path(self):
         return self.so_launcher_path
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, gridX, gridY, gridZ, stream, function, packed_metadata, launch_metadata, launch_enter_hook,
+                 launch_exit_hook, *kernel_args, **kwargs):
         if self.compile_only:
-            cache_manager = get_cache_manager(args[5]['hash'])
+            cache_manager = get_cache_manager(packed_metadata['hash'])
             print("[INFO]: skip running kernel")
             print(f"[INFO]: The compiled kernel cache is in {cache_manager.cache_dir}")
+            return
         if self.enable_msprof_register_tensor:
-            tensor_params_shape = get_backend_func("get_tensor_params_shape", *args)
-            # args[5] must be the packed metadata.
-            # Check the launch wrapper in which PyArg_ParseTuple specifies the ordering of args
-            args[5]['tensor_params_shape'] = tensor_params_shape
+            tensor_params_shape = get_backend_func("get_tensor_params_shape", *kernel_args)
+            packed_metadata['tensor_params_shape'] = tensor_params_shape
         else:
-            if self.compile_only:
-                return
+            global_scratch = None
+            if self.global_scratch_size > 0 and gridX > 0 and gridY > 0 and gridZ > 0:
+                grid_size = gridX * gridY * gridZ
+                alloc_size = grid_size * self.global_scratch_size
+                alloc_fn = _allocation._allocator.get()
+                global_scratch = alloc_fn(alloc_size, self.global_scratch_align, stream)
 
-            profiler_registered = self.launch(*args, **kwargs)
+            profiler_registered = self.launch(gridX, gridY, gridZ, stream, function, global_scratch, None,
+                                              packed_metadata, launch_metadata, launch_enter_hook, launch_exit_hook,
+                                              *kernel_args, **kwargs)
             _ascend_utils.TRITON_PROFILER_REGISTERED = (profiler_registered == 1)
 
 
@@ -458,7 +467,7 @@ def ty_to_cpp(ty):
     }[ty]
 
 
-_BASE_ARGS_FORMAT = "iiiKKOOOO"
+_BASE_ARGS_FORMAT = "iiiKKOOOOOO"
 _BASE_ARGS_FORMAT_LEN = len(_BASE_ARGS_FORMAT)
 
 
@@ -491,6 +500,7 @@ def make_launcher(constants, signature, metadata):
     import os
     workspace_size = int(metadata.workspace_size) \
                           if hasattr(metadata, 'workspace_size') else -1
+    global_scratch_size = int(getattr(metadata, "global_scratch_size", 0) or 0)
     lock_init_value = int(metadata.lock_init_value if hasattr(metadata, 'lock_init_value') else metadata.
                           lock_init_val if hasattr(metadata, 'lock_init_val') else 0)
     lock_num = int(metadata.lock_num) \
@@ -624,6 +634,7 @@ def make_launcher(constants, signature, metadata):
         int gridX, gridY, gridZ;
         aclrtStream stream;
         aclrtFuncHandle functon;
+        PyObject* global_scratch, *profile_scratch;
         PyObject* packed_metadata, *launch_metadata;
         PyObject* launch_enter_hook, *launch_exit_hook;
         *args_expand
@@ -679,6 +690,11 @@ def make_launcher(constants, signature, metadata):
     alloc_success_code = 'return 1;'
     sync_lock_fail_code = 'fprintf(stderr, "Error: syncBlockLock allocation failed\\n"); return;'
     workspace_fail_code = 'fprintf(stderr, "Error: workspace allocation failed\\n"); return;'
+    exported_scratch_guard = ""
+    if metadata.force_simt_only and global_scratch_size > 0:
+        exported_scratch_guard = (
+            'fprintf(stderr, "Error: triton_launch_kernel does not support nonzero global scratch\\n");\n'
+            '  return;')
     launch_signature_items = [(i, ty) for i, ty in signature.items() if ty != "constexpr"]
     launch_arg_count = len(launch_signature_items)
     launch_arg_ptrs = ', '.join(f'static_cast<const void*>(&arg{i})' for i, ty in launch_signature_items)
@@ -1020,6 +1036,7 @@ void triton_launch_kernel(const char* kernelName, aclrtFuncHandle func, aclrtStr
     printf("WARNING: Skipping launch for kernel '%s' due to empty grid (gridX=%d, gridY=%d, gridZ=%d).\\n", kernelName, gridX, gridY, gridZ);
     return;
   }}
+  {exported_scratch_guard}
   std::vector<std::vector<int64_t>> tensorShapes;
   if (shapes_data != nullptr && shape_dims != nullptr) {{
     int shapes_idx = 0;
@@ -1054,6 +1071,7 @@ void triton_launch_kernel(const char* kernelName, aclrtFuncHandle func, aclrtStr
   std::string name(kernelName);
   void *workspace_addr_ptr = NULL;
   void *workspace_handle = NULL;
+  {'void *global_scratch = nullptr; void *profile_scratch = nullptr;' if metadata.force_simt_only else ''}
   {coalesce_grid_div}
   uint32_t blockNum4Workspace = gridX * gridY * gridZ;
   {get_backend_func("pre_launch", True)}
@@ -1122,6 +1140,8 @@ void triton_launch_kernel(const char* kernelName, aclrtFuncHandle func, aclrtStr
     size_t grid_offset = reserve_slot(sizeof(int32_t), 4);
     reserve_slot(sizeof(int32_t), 4);
     reserve_slot(sizeof(int32_t), 4);
+    {'size_t global_scratch_offset = reserve_slot(sizeof(void*), 8);' if metadata.force_simt_only else ''}
+    {'size_t profile_scratch_offset = reserve_slot(sizeof(void*), 8);' if metadata.force_simt_only else ''}
     {'size_t dtdata_offset = reserve_slot(sizeof(void*), 8);' if enable_device_print else ''}
     size_t total_size = args_offset;
 
@@ -1139,6 +1159,8 @@ void triton_launch_kernel(const char* kernelName, aclrtFuncHandle func, aclrtStr
     memcpy(launch_args.data() + grid_offset, &gridX, sizeof(int32_t));
     memcpy(launch_args.data() + grid_offset + sizeof(int32_t), &gridY, sizeof(int32_t));
     memcpy(launch_args.data() + grid_offset + 2 * sizeof(int32_t), &gridZ, sizeof(int32_t));
+    {'memcpy(launch_args.data() + global_scratch_offset, &global_scratch, sizeof(void*));' if metadata.force_simt_only else ''}
+    {'memcpy(launch_args.data() + profile_scratch_offset, &profile_scratch, sizeof(void*));' if metadata.force_simt_only else ''}
     {'memcpy(launch_args.data() + dtdata_offset, &DTData, sizeof(void*));' if enable_device_print else ''}
 
     {cpp_msprof_call_before_launch}
@@ -1153,7 +1175,12 @@ void triton_launch_kernel(const char* kernelName, aclrtFuncHandle func, aclrtStr
 }}
 }} // extern "C"
 
-static void _launch(const char* kernelName, aclrtFuncHandle func, aclrtStream stream, int gridX, int gridY, int gridZ, std::vector<std::vector<int64_t>> &tensorShapes, std::vector<int> &tensorKinds{(', ' + arg_decls) if len(arg_decls) > 0 else ''}) {{
+static void _launch(
+    const char* kernelName, aclrtFuncHandle func, aclrtStream stream,
+    int gridX, int gridY, int gridZ,
+    std::vector<std::vector<int64_t>> &tensorShapes, std::vector<int> &tensorKinds,
+    void *global_scratch, void *profile_scratch
+    {(', ' + arg_decls) if len(arg_decls) > 0 else ''}) {{
   // Keep Python launcher on the stable local packing path.
   if (gridX <=0 || gridY <=0 || gridZ <=0) {{
     printf("WARNING: Skipping launch for kernel '%s' due to empty grid (gridX=%d, gridY=%d, gridZ=%d).\\n", kernelName, gridX, gridY, gridZ);
@@ -1214,6 +1241,8 @@ static void _launch(const char* kernelName, aclrtFuncHandle func, aclrtStream st
       {'void* workspace_addr __attribute__((aligned(8)));' if not metadata.force_simt_only else ''}
       {' '.join(f'{ty_to_cpp(ty)} arg{i} __attribute__((aligned({4 if ty[0] != "*" and ty[-2:] != "64" else 8})));' for i, ty in signature.items() if ty != "constexpr")}
       {' '.join(f'{ty_to_cpp(ty)} grid{mark} __attribute__((aligned(4)));' for mark, ty in grid_info.items())}
+      {'void* global_scratch __attribute__((aligned(8)));' if metadata.force_simt_only else ''}
+      {'void* profile_scratch __attribute__((aligned(8)));' if metadata.force_simt_only else ''}
       {'void* DTData __attribute__((aligned(8)));' if enable_device_print else ''}
     }} args = {{
       {'static_cast<void*>(ffts_addr),' if target_support_ffts else ''}
@@ -1223,6 +1252,8 @@ static void _launch(const char* kernelName, aclrtFuncHandle func, aclrtStream st
         [f'static_cast<{ty_to_cpp(ty)}>(arg{i})' for i, ty in signature.items() if ty != "constexpr"]
       )}
       {', '.join(f'static_cast<{ty_to_cpp(ty)}>(grid{mark})' for mark, ty in grid_info.items())}
+      {', static_cast<void*>(global_scratch)' if metadata.force_simt_only else ''}
+      {', static_cast<void*>(profile_scratch)' if metadata.force_simt_only else ''}
       {', static_cast<void*>(DTData)' if enable_device_print else ''}
     }};
     {cpp_msprof_call_before_launch}
@@ -1275,16 +1306,17 @@ static PyObject* launch(PyObject* self, PyObject* args) {{
   PyObject *launch_metadata = NULL;
   PyObject *launch_enter_hook = NULL;
   PyObject *launch_exit_hook = NULL;
+  PyObject *global_scratch_obj = NULL;
+  PyObject *profile_scratch_obj = NULL;
   std::vector<std::vector<int64_t>> tensorShapes;
 
   {newline.join([f"{_extracted_type(ty)} _arg{i};" for i, ty in signature.items()])}
   if(!PyArg_ParseTuple(
       args, \"{format}\",
       &gridX, &gridY, &gridZ, &stream, &function,
-      &packedMetadata, &launch_metadata, &launch_enter_hook, &launch_exit_hook
-      {', ' + ', '.join(f"&_arg{i}" for i, ty in signature.items()) if len(signature) > 0 else ''}
-      )
-    ) {{
+      &global_scratch_obj, &profile_scratch_obj,
+      &packedMetadata, &launch_metadata,
+      &launch_enter_hook, &launch_exit_hook{args_list})) {{
     return NULL;
   }}
   if (__MsprofFlagL1)
@@ -1303,6 +1335,24 @@ static PyObject* launch(PyObject* self, PyObject* args) {{
     Py_DECREF(args);
     if (!ret)
       return NULL;
+  }}
+
+  void *global_scratch = 0;
+  if (global_scratch_obj != Py_None) {{
+    DevicePtrInfo global_scratch_info = getPointer(global_scratch_obj, -1);
+    if (!global_scratch_info.valid) {{
+      return NULL;
+    }}
+    global_scratch = global_scratch_info.dev_ptr;
+  }}
+
+  void *profile_scratch = 0;
+  if (profile_scratch_obj != Py_None) {{
+    DevicePtrInfo profile_scratch_info = getPointer(profile_scratch_obj, -1);
+    if (!profile_scratch_info.valid) {{
+      return NULL;
+    }}
+    profile_scratch = profile_scratch_info.dev_ptr;
   }}
 
 
@@ -1324,7 +1374,11 @@ static PyObject* launch(PyObject* self, PyObject* args) {{
 
   // raise exception asap
   {newline.join(ptr_decls)}
-  _launch(kernelName, function, stream, gridX, gridY, gridZ, tensorShapes, tensorKinds{', ' + ', '.join(internal_args_list) if len(internal_args_list) > 0 else ''});
+  _launch(kernelName, function, stream,
+          gridX, gridY, gridZ,
+          tensorShapes, tensorKinds,
+          global_scratch, profile_scratch
+          {', ' + ', '.join(internal_args_list) if len(internal_args_list) > 0 else ''});
   if (PyErr_Occurred()) {{
     return NULL;
   }}

--- a/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
+++ b/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
@@ -92,6 +92,7 @@ def compiler_module():
     utils_name = "triton.backends.ascend.utils"
     driver_name = "triton.backends.ascend.driver"
     cache_name = "triton.runtime.cache"
+    debug_line_rewriter_name = "triton.backends.ascend.debug_line_rewriter"
 
     def return_false(*_args, **_kwargs):
         return False
@@ -139,12 +140,17 @@ def compiler_module():
     cache_stub.get_dump_manager = lambda *_args, **_kwargs: SimpleNamespace(cache_dir="", put=lambda *_args, **_kwargs:
                                                                             None)
 
+    debug_line_rewriter_stub = types.ModuleType(debug_line_rewriter_name)
+    debug_line_rewriter_stub.rewrite_debug_line = lambda artifact, metadata=None, options=None: artifact
+
     previous_utils = sys.modules.get(utils_name)
     previous_driver = sys.modules.get(driver_name)
     previous_cache = sys.modules.get(cache_name)
+    previous_debug_line_rewriter = sys.modules.get(debug_line_rewriter_name)
     sys.modules[utils_name] = utils_stub
     sys.modules[driver_name] = driver_stub
     sys.modules[cache_name] = cache_stub
+    sys.modules[debug_line_rewriter_name] = debug_line_rewriter_stub
     sys.modules.pop(module_name, None)
     try:
         spec = importlib.util.spec_from_file_location(module_name, compiler_path)
@@ -165,6 +171,10 @@ def compiler_module():
             sys.modules.pop(cache_name, None)
         else:
             sys.modules[cache_name] = previous_cache
+        if previous_debug_line_rewriter is None:
+            sys.modules.pop(debug_line_rewriter_name, None)
+        else:
+            sys.modules[debug_line_rewriter_name] = previous_debug_line_rewriter
     return module
 
 
@@ -320,6 +330,9 @@ def _run_ttir_to_npubin(
         commands.append(list(command))
         output = Path(command[command.index("-o") + 1] + ".o")
         output.write_bytes(b"npubin")
+        metadata_option = next((arg for arg in command if arg.startswith("--triton-metadata-output=")), None)
+        if metadata_option is not None:
+            Path(metadata_option.split("=", 1)[1]).write_text("{}")
         return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
 
     monkeypatch.setattr(
@@ -366,6 +379,16 @@ def _run_ttir_to_npubin(
     assert result == b"npubin"
     assert len(commands) == 1
     return events, commands[0]
+
+
+@pytest.mark.parametrize("force_simt_only", (False, True))
+def test_ttir_to_npubin_global_scratch_allocation_flag(compiler_module, monkeypatch, force_simt_only):
+    _events, command = _run_ttir_to_npubin(
+        compiler_module,
+        monkeypatch,
+        force_simt_only=force_simt_only,
+    )
+    assert ("--enable-global-scratch-allocation" in command) is force_simt_only
 
 
 @pytest.mark.skip(reason="The case is not supported on A5, skipping for now. Will be fixed in future.")
@@ -594,6 +617,7 @@ def test_ttir_to_npubin_auto_blockify_argv_matrix(compiler_module, monkeypatch):
         "--enable-hivm-compile=false",
         "--enable-triton-ir-compile",
         "--pure-simt",
+        "--enable-global-scratch-allocation",
         "--num-warps=4",
         "--threads-per-warp=32",
         "--enable-bishengir-simt-optimization=17",
@@ -644,7 +668,12 @@ def test_ttir_to_npubin_auto_blockify_argv_matrix(compiler_module, monkeypatch):
                 f"R={row_applied}, superblock={superblock}, "
                 f"bisheng_options={case_bisheng_options!r}")
 
-        expected_options = [*common_options, *pure_simt_prefix]
+        metadata_options = [arg for arg in command if arg.startswith("--triton-metadata-output=")]
+        assert len(metadata_options) == 1, case
+        metadata_option = metadata_options[0]
+        assert Path(metadata_option.split("=", 1)[1]).name == "triton-metadata.json", case
+
+        expected_options = [*common_options, metadata_option, *pure_simt_prefix]
         if first_injection:
             expected_options.append(auto_blockify_flag)
         if case_bisheng_options is not None:

--- a/third_party/ascend/unittest/pytest_ut/test_layout_memory_895_closure_differential.py
+++ b/third_party/ascend/unittest/pytest_ut/test_layout_memory_895_closure_differential.py
@@ -24,6 +24,7 @@ rather than a misleading green skip.
 import ast
 import copy
 import itertools
+import json
 import os
 from pathlib import Path
 import subprocess
@@ -34,6 +35,7 @@ import pytest
 
 _BASELINE_COMMIT = "895c5fbe2b0e69349b76388e65fd8c3e79703bb9"
 _REQUIRE_BASELINE_ENV = "TRITON_REQUIRE_895_DIFFERENTIAL"
+_TRITON_METADATA_OUTPUT_PREFIX = "--triton-metadata-output="
 _SOURCE_PATHS = {
     "compiler": "third_party/ascend/backend/compiler.py",
     "driver": "third_party/ascend/backend/driver.py",
@@ -121,6 +123,7 @@ def _load_compiler_closure(source):
     # the installed compiler package or an NPU toolchain.
     subprocess_proxy = SimpleNamespace(CalledProcessError=subprocess.CalledProcessError, )
     namespace = {
+        "json": json,
         "os": os,
         "tempfile": tempfile,
         "Path": Path,
@@ -239,6 +242,9 @@ def _run_ttir_to_npubin(
         commands.append(list(command))
         bin_file = Path(command[command.index("-o") + 1])
         bin_file.with_name(f"{bin_file.name}.o").write_bytes(b"npubin")
+        metadata_option = next((arg for arg in command if arg.startswith(_TRITON_METADATA_OUTPUT_PREFIX)), None)
+        if metadata_option is not None:
+            Path(metadata_option.removeprefix(_TRITON_METADATA_OUTPUT_PREFIX)).write_text("{}")
         return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
 
     closure["ir"] = SimpleNamespace(pass_manager=lambda _context: pass_manager)
@@ -274,7 +280,7 @@ def _normalise_command(command):
     return [
         command[0],
         Path(command[1]).name,
-        *command[2:-2],
+        *(arg for arg in command[2:-2] if not arg.startswith(_TRITON_METADATA_OUTPUT_PREFIX)),
         command[-2],
         Path(command[-1]).name,
     ]

--- a/third_party/ascend/unittest/pytest_ut/test_npu_launcher.py
+++ b/third_party/ascend/unittest/pytest_ut/test_npu_launcher.py
@@ -1,0 +1,236 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+
+def _load_driver_module():
+    driver_path = Path(__file__).resolve().parents[2] / "backend" / "driver.py"
+    spec = importlib.util.spec_from_file_location("ascend_driver_under_test", driver_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+driver = _load_driver_module()
+
+
+def _make_launcher(monkeypatch, global_scratch_size, global_scratch_align, launch):
+    monkeypatch.setenv("TRITON_COMPILE_ONLY", "false")
+    monkeypatch.setenv("TRITON_REGISTER_TENSOR_MSPROF", "false")
+    metadata = SimpleNamespace(
+        mix_mode="aiv",
+        shared=0,
+        global_scratch_size=global_scratch_size,
+        global_scratch_align=global_scratch_align,
+    )
+    fake_module = SimpleNamespace(launch=launch)
+    fake_spec = SimpleNamespace(loader=SimpleNamespace(exec_module=lambda module: None))
+    with patch.object(driver.NPULauncher, "_make_launcher_stub_path", return_value="/tmp/fake_launcher.so"), \
+            patch("importlib.util.spec_from_file_location", return_value=fake_spec), \
+            patch("importlib.util.module_from_spec", return_value=fake_module):
+        src = SimpleNamespace(fn=SimpleNamespace(arg_names=[]), signature={})
+        return driver.NPULauncher(src, metadata)
+
+
+def _mock_backend_func(name, *args):
+    return f"/* {name}: {args} */"
+
+
+def _make_launcher_source(monkeypatch, *, force_simt_only, global_scratch_size=0, workspace_size=0):
+    metadata = SimpleNamespace(
+        workspace_size=workspace_size,
+        lock_init_value=0,
+        lock_num=0,
+        bs_task_type=0,
+        mix_mode="aiv",
+        shared=0,
+        global_scratch_size=global_scratch_size,
+        global_scratch_align=1,
+        compile_on_910_95=False,
+        parallel_mode="simt" if force_simt_only else "",
+        force_simt_only=force_simt_only,
+        shared_mem_dynamic_size=122880,
+        debug=False,
+        coalesce_factor=1,
+        coalesce_axis=-1,
+    )
+    monkeypatch.setenv("TRITON_DEVICE_PRINT", "true")
+    monkeypatch.setattr(driver, "extract_device_print_code_from_cann", lambda: "/* print stub */")
+    with patch.object(driver, "NPUUtils") as mock_npu_utils, \
+            patch.object(driver, "get_backend_func", side_effect=_mock_backend_func), \
+            patch.object(driver, "get_ascend_arch_from_env", return_value="Ascend910B"), \
+            patch.object(driver, "is_ffts_supported", return_value=False), \
+            patch.object(driver, "force_disable_ffts", return_value=False), \
+            patch.object(driver, "_is_auto_map_parallel_blocks_enabled", return_value=False):
+        mock_npu_utils.return_value.get_aivector_core_num.return_value = 40
+        mock_npu_utils.return_value.get_aicore_num.return_value = 20
+        return driver.make_launcher({}, {0: "*fp32"}, metadata)
+
+
+def _exported_launcher_source(src):
+    start = src.index("void triton_launch_kernel(")
+    return src[start:src.index("static void _launch(", start)]
+
+
+def _assert_order(text, *items):
+    offsets = [text.index(item) for item in items]
+    assert offsets == sorted(offsets)
+
+
+def test_npu_launcher_allocates_global_scratch(monkeypatch):
+    buffer = object()
+    allocate = Mock(return_value=buffer)
+    allocator = Mock()
+    allocator.get.return_value = allocate
+    monkeypatch.setattr(driver._allocation, "_allocator", allocator)
+    launch = Mock(return_value=0)
+    launcher = _make_launcher(monkeypatch, global_scratch_size=64, global_scratch_align=16, launch=launch)
+    packed_metadata = {"hash": "h"}
+
+    launcher(2, 3, 4, 99, 123, packed_metadata, None, None, None, "kernel-arg")
+
+    allocate.assert_called_once_with(1536, 16, 99)
+    launch.assert_called_once_with(
+        2,
+        3,
+        4,
+        99,
+        123,
+        buffer,
+        None,
+        packed_metadata,
+        None,
+        None,
+        None,
+        "kernel-arg",
+    )
+
+
+def test_npu_launcher_skips_zero_sized_global_scratch(monkeypatch):
+    allocator = Mock()
+    monkeypatch.setattr(driver._allocation, "_allocator", allocator)
+    launch = Mock(return_value=0)
+    launcher = _make_launcher(monkeypatch, global_scratch_size=0, global_scratch_align=1, launch=launch)
+    packed_metadata = {"hash": "h"}
+
+    launcher(1, 1, 1, 99, 123, packed_metadata, None, None, None)
+
+    allocator.get.assert_not_called()
+    launch.assert_called_once_with(1, 1, 1, 99, 123, None, None, packed_metadata, None, None, None)
+
+
+def test_npu_launcher_skips_global_scratch_for_empty_grid(monkeypatch):
+    allocator = Mock()
+    monkeypatch.setattr(driver._allocation, "_allocator", allocator)
+    launch = Mock(return_value=0)
+    launcher = _make_launcher(monkeypatch, global_scratch_size=64, global_scratch_align=16, launch=launch)
+    packed_metadata = {"hash": "h"}
+
+    launcher(0, 3, 4, 99, 123, packed_metadata, None, None, None)
+
+    allocator.get.assert_not_called()
+    launch.assert_called_once_with(0, 3, 4, 99, 123, None, None, packed_metadata, None, None, None)
+
+
+def test_make_launcher_threads_scratch_through_pure_simt_abi(monkeypatch):
+    src = _make_launcher_source(monkeypatch, force_simt_only=True)
+
+    parse = src[src.index("if(!PyArg_ParseTuple("):]
+    assert 'args, "iiiKKOOOOOOO"' in parse
+    _assert_order(parse, "&global_scratch_obj", "&profile_scratch_obj", "&packedMetadata")
+
+    conversions = src[src.index("void *global_scratch = 0;"):src.index("// get kernel_name")]
+    _assert_order(
+        conversions,
+        "global_scratch_obj != Py_None",
+        "getPointer(global_scratch_obj, -1)",
+        "profile_scratch_obj != Py_None",
+        "getPointer(profile_scratch_obj, -1)",
+    )
+
+    internal = src[src.index("static void _launch("):]
+    signature = internal[:internal.index(") {")]
+    _assert_order(signature, "global_scratch", "profile_scratch", "arg0")
+
+    struct_start = internal.index("struct __attribute__((packed))")
+    initializer_start = internal.index("} args = {", struct_start)
+    declarations = internal[struct_start:initializer_start]
+    initializer = internal[initializer_start:internal.index("};", initializer_start)]
+    _assert_order(declarations, "arg0", "gridX", "gridY", "gridZ", "global_scratch", "profile_scratch", "DTData")
+    _assert_order(
+        initializer,
+        "static_cast<void*>(arg0)",
+        "static_cast<int32_t>(gridX)",
+        "static_cast<void*>(global_scratch)",
+        "static_cast<void*>(profile_scratch)",
+        "static_cast<void*>(DTData)",
+    )
+
+    call_start = src.index("_launch(kernelName")
+    call = src[call_start:src.index(");", call_start)]
+    _assert_order(call, "global_scratch", "profile_scratch", "ptr_info0.dev_ptr")
+
+    exported = _exported_launcher_source(src)
+    _assert_order(exported, "global_scratch_offset", "profile_scratch_offset", "dtdata_offset")
+
+
+def test_make_launcher_omits_scratch_from_non_simt_device_layout(monkeypatch):
+    src = _make_launcher_source(monkeypatch, force_simt_only=False)
+
+    parse = src[src.index("if(!PyArg_ParseTuple("):]
+    _assert_order(parse, "&global_scratch_obj", "&profile_scratch_obj", "&packedMetadata")
+
+    internal = src[src.index("static void _launch("):]
+    struct_start = internal.index("struct __attribute__((packed))")
+    initializer_start = internal.index("} args = {", struct_start)
+    declarations = internal[struct_start:initializer_start]
+    assert "DTData" in declarations
+    assert "global_scratch" not in declarations
+    assert "profile_scratch" not in declarations
+
+    exported = _exported_launcher_source(src)
+    assert "dtdata_offset" in exported
+    assert "global_scratch_offset" not in exported
+    assert "profile_scratch_offset" not in exported
+
+
+def test_exported_launcher_rejects_nonzero_global_scratch_before_setup(monkeypatch):
+    monkeypatch.setenv("TRITON_ENABLE_TASKQUEUE", "true")
+    src = _make_launcher_source(
+        monkeypatch,
+        force_simt_only=True,
+        global_scratch_size=64,
+        workspace_size=32,
+    )
+    exported = _exported_launcher_source(src)
+    header = exported.split("{", 1)[0]
+    assert "global_scratch" not in header
+
+    diagnostic = 'fprintf(stderr, "Error: triton_launch_kernel does not support nonzero global scratch\\n");'
+    diagnostic_offset = exported.index(diagnostic)
+    guard_return = exported.index("return;", diagnostic_offset)
+    assert diagnostic_offset < guard_return
+    for setup_marker in ("tensorShapes", "allocate_memory", "DebugTunnel::Open", "aclrtLaunchKernelWithHostArgs("):
+        assert guard_return < exported.index(setup_marker)


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref github-upstream/main-dev --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices), including the "tests should be minimal" section.

## Target

This is the `main-dev` companion to #1620, which targets `main`. The branches have diverged, so this PR carries the same production change as one clean commit based directly on current `main-dev`.

## Why

BiShengIR pure-SIMT lowering reserves global- and profile-scratch arguments in the kernel ABI, but the Ascend launcher did not consume compiler-emitted global-scratch metadata or provide the required device allocation.

[AscendNPU-IR PR 2333](https://gitcode.com/Ascend/AscendNPU-IR/pull/2333) adds optional global-scratch staging for TileDotLoads and layout conversions. Its option defaults to disabled, so Triton-Ascend must enable the lowering and honor the resulting scratch metadata at launch.

## What changed

- Enable NPUIR global-scratch allocation for pure-SIMT compilation with `--enable-global-scratch-allocation`.
- Request and ingest pure-SIMT scratch metadata from `bishengir-compile`.
- Allocate per-program global scratch through the Triton stream-aware allocator.
- Thread global and profile scratch pointer slots through the generated Python launcher and pure-SIMT packed ABI.
- Keep profile scratch null in this global-only prerequisite; the Proton integration owns its separate allocator.
- Reject nonzero global scratch in the exported C launcher until that API has an allocation contract.
- Add focused host-side launcher and compiler-contract coverage.
- Keep the compiler contract fixture runnable against `main-dev`'s debug-line post-processor import.

## Validation

- Focused host suite: **15 passed, 30 skipped** by upstream A5 skip markers.
- New pure-SIMT/SIMD flag contract: **2 passed**.
- Existing 96-case pure-SIMT argv matrix, run with its temporary upstream skip suppressed: **passed**.
- `pre-commit run --from-ref github-upstream/main-dev --to-ref HEAD`: **passed**.
- Device execution was not rerun locally because this development machine has no CANN toolkit or Ascend NPU. The companion launcher test previously passed **6 tests** on the device box.

The deployment compiler must include merged AscendNPU-IR PR 2333 to recognize the new option.
