### PR TITLE
[ssbuffer](feat) support fixpipe to L1

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -34,6 +34,7 @@
 #include <string_view>
 
 #include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
 
 namespace mlir {
 namespace CVPipeline {
@@ -310,6 +311,14 @@ inline bool isTensorComputeOp(Operation *op) {
 
   return false;
 }
+
+// Determine FixpipePreQuantMode from a trunc op.
+// Returns std::nullopt for scalars (non-shaped types) or unrecognized patterns.
+// Supported patterns:
+// - arith.truncf: f32 -> bf16, f32 -> f16
+// - arith.trunci: i32 -> i8
+std::optional<hivm::FixpipePreQuantMode>
+getFixpipePreQuantMode(Operation *truncOp);
 
 } // namespace CVPipeline
 } // namespace mlir

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h
@@ -37,7 +37,7 @@
 
 namespace mlir {
 namespace triton {
-enum class DependencyType { VectorToCube, CubeToVector };
+enum class DependencyType { VectorToCube, CubeToVector, CubeToCube };
 
 struct BlockInfo {
   int blockId;
@@ -85,6 +85,9 @@ public:
   }
   llvm::SmallVector<DependencyInfo> &getC2VDependencies() {
     return c2vDependencies;
+  }
+  llvm::SmallVector<DependencyInfo> &getC2CDependencies() {
+    return c2cDependencies;
   }
   llvm::SmallVector<DependencyInfo> &getMemoryDependencies() {
     return memoryDependencies;

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
@@ -117,6 +117,8 @@ private:
   handleCubeToVector(mlir::OpBuilder &builder, DependencyInfo &dep,
                      FlagIdManager &flagManager,
                      FlagIdReuseManager &flagIdReuseManager);
+  mlir::LogicalResult handleCubeToCube(mlir::OpBuilder &builder,
+                                       DependencyInfo &dep);
   mlir::LogicalResult handleMemoryDependency(
       mlir::OpBuilder &builder, DependencyInfo &dep, size_t depIndex,
       llvm::SmallVector<DependencyInfo> memDependencies,
@@ -144,6 +146,12 @@ private:
                                                 mlir::Location loc);
   mlir::Operation *findMainLoopforTransfer(mlir::Operation *endOp,
                                            mlir::Operation *startOp);
+  mlir::Operation *createC2CSharedL1Buffer(mlir::OpBuilder &builder,
+                                           mlir::Location loc,
+                                           llvm::ArrayRef<int64_t> shape,
+                                           mlir::Type elemType, int prodBlockId,
+                                           mlir::Operation *prodEnd,
+                                           mlir::Operation *consStart);
   std::pair<mlir::Operation *, mlir::Operation *>
   createTransferAllocs(mlir::OpBuilder &builder, mlir::Location loc,
                        llvm::ArrayRef<int64_t> shape, mlir::Type elemType,

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -452,5 +452,27 @@ int getLoopCarriedArgIndex(Value operand, Block *block) {
   return argIdx;
 }
 
+std::optional<hivm::FixpipePreQuantMode> getFixpipePreQuantMode(Operation *op) {
+  if (!isa<arith::TruncFOp, arith::TruncIOp>(op))
+    return std::nullopt;
+
+  // Exclude scalars: only shaped types are valid for fixpipe pre_quant.
+  auto resultType = dyn_cast<ShapedType>(op->getResult(0).getType());
+  if (!resultType)
+    return std::nullopt;
+
+  Type inElemType =
+      cast<ShapedType>(op->getOperand(0).getType()).getElementType();
+  Type outElemType = resultType.getElementType();
+
+  if (isa<Float32Type>(inElemType) && isa<BFloat16Type>(outElemType))
+    return hivm::FixpipePreQuantMode::F322BF16;
+  if (isa<Float32Type>(inElemType) && isa<Float16Type>(outElemType))
+    return hivm::FixpipePreQuantMode::F322F16;
+  if (inElemType.isInteger(32) && outElemType.isInteger(8))
+    return hivm::FixpipePreQuantMode::S322I8;
+  return std::nullopt;
+}
+
 } // namespace CVPipeline
 } // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/FixpipeOptPass.cpp
@@ -93,36 +93,9 @@ private:
                        CVPipeline::ComputeBlockIdManager &bm);
   bool isSubviewFromGlobalMemory(ViewLikeOpInterface viewOp,
                                  SetVector<Operation *> &matchedOps);
-  bool isValidTrunc(Operation *op);
   bool isValidMul(Operation *op, Value matmulValues,
                   SetVector<Operation *> &matchedOps);
 };
-
-bool FixpipeOptPass::isValidTrunc(Operation *op) {
-  // Just filter: arith.truncf(f32->bf16, f32->f16, i32->i8)
-  if (auto truncFOp = dyn_cast<arith::TruncFOp>(op)) {
-    Type inType = truncFOp.getIn().getType();
-    Type outType = truncFOp.getResult().getType();
-    if (auto shapedType = dyn_cast<ShapedType>(inType))
-      inType = shapedType.getElementType();
-    if (auto shapedType = dyn_cast<ShapedType>(outType))
-      outType = shapedType.getElementType();
-
-    return isa<Float32Type>(inType) &&
-           (isa<BFloat16Type>(outType) || isa<Float16Type>(outType));
-  }
-  if (auto truncIOp = dyn_cast<arith::TruncIOp>(op)) {
-    Type inType = truncIOp.getIn().getType();
-    Type outType = truncIOp.getResult().getType();
-    if (auto shapedType = dyn_cast<ShapedType>(inType))
-      inType = shapedType.getElementType();
-    if (auto shapedType = dyn_cast<ShapedType>(outType))
-      outType = shapedType.getElementType();
-
-    return inType.isInteger(32) && outType.isInteger(8);
-  }
-  return false;
-}
 
 void transSource(Value value, SetVector<Operation *> &matchedOps,
                  Block *block) {
@@ -246,8 +219,18 @@ bool FixpipeOptPass::isFixpipeCastPattern(Operation *truncOp,
   tensor::ExtractSliceOp extractSliceOp = nullptr;
   if (auto extract = dyn_cast<tensor::ExtractSliceOp>(maybeExtract)) {
     extractSliceOp = extract;
+  } else if (auto consumerMatmul = dyn_cast<linalg::MatmulOp>(maybeExtract)) {
+    // matmul -> trunc -> matmul pattern
+    for (Value input : consumerMatmul.getDpsInputs()) {
+      if (input == truncResult) {
+        matchedOps.insert(truncOp);
+        return true;
+      }
+    }
+    LOG_DEBUG("Trunc result is not a DPS input of consumer matmul, NOT match.");
+    return false;
   } else {
-    LOG_DEBUG("Cannot find extract slice op, NOT match");
+    LOG_DEBUG("Cannot find extract slice op or matmul, NOT match");
     return false;
   }
 
@@ -353,7 +336,7 @@ bool FixpipeOptPass::matchFixpipePattern(linalg::MatmulOp matmulOp,
 
   auto matmulUser = *matmulResult.getUsers().begin();
 
-  if (isValidTrunc(matmulUser)) {
+  if (CVPipeline::getFixpipePreQuantMode(matmulUser).has_value()) {
     if (isFixpipeCastPattern(matmulUser, matchedOps)) {
       return true;
     }

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.cpp
@@ -696,7 +696,7 @@ void DataDependencyAnalysisPass::processIterArgDependencies() {
   }
 }
 
-// Analyze V->C
+// Analyze V->C and C->C
 void DataDependencyAnalysisPass::analyzeExternalInputs(
     DataDependencyInfo &info) {
   auto &blockInfoMap = info.getBlockInfoMap();
@@ -729,8 +729,22 @@ void DataDependencyAnalysisPass::analyzeExternalInputs(
         continue;
       }
 
-      // Case 1: Cube -> C->C special case
+      // Case 1: Cube -> C->C dependency
       if (coreType == ssbufferCoreTypeCubeAttr) {
+        LOG_DEBUG("Found external input with CUBE core type: " << input
+                                                               << "\n");
+        auto producerIdOpt = CVPipeline::getOpBlockId(input.getDefiningOp());
+        if (!producerIdOpt) {
+          LOG_DEBUG("Warning: [c->c] Producer block ID not found for input "
+                    "value.\n");
+          continue;
+        }
+        int producerId = *producerIdOpt;
+        if (!collectDepInfo(input, DependencyType::CubeToCube,
+                            info.getC2CDependencies(), producerId,
+                            blockInfo.blockId, info)) {
+          continue;
+        }
         continue;
       }
       // Case 2: Vector -> V->C dependency
@@ -1072,7 +1086,7 @@ void DataDependencyAnalysisPass::runOnOperation() {
   }
   createBlockInfoMap(info);
 
-  // Step 3: Analyze dependencies (v2c/c2v).  Scalar V->C deps come from
+  // Step 3: Analyze dependencies (v2c/c2v/c2c).  Scalar V->C deps come from
   // analyzeExternalInputs (VECTOR scalars crossing into CUBE).
   analyzeExternalInputs(info);
 
@@ -1085,6 +1099,7 @@ void DataDependencyAnalysisPass::runOnOperation() {
   // iniConsumerBlockId, iniProducerBlockId)
   deduplicateDependencies(info.getV2CDependencies());
   deduplicateDependencies(info.getC2VDependencies());
+  deduplicateDependencies(info.getC2CDependencies());
   deduplicateDependencies(info.getMemoryDependencies());
 
   info.setValid(true);
@@ -1093,6 +1108,8 @@ void DataDependencyAnalysisPass::runOnOperation() {
   LOG_DEBUG("  V->C dependencies: " << info.getV2CDependencies().size()
                                     << "\n");
   LOG_DEBUG("  C->V dependencies: " << info.getC2VDependencies().size()
+                                    << "\n");
+  LOG_DEBUG("  C->C dependencies: " << info.getC2CDependencies().size()
                                     << "\n");
   LOG_DEBUG("  Memory dependencies: " << info.getMemoryDependencies().size()
                                       << "\n");

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -29,6 +29,7 @@
 
 #include "ascend/include/DynamicCVPipeline/Common/FlagIdManager.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/DataDependencyAnalysis.h"
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/FlagIdReuse.h"
 
@@ -36,6 +37,7 @@
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
 #include "bishengir/Dialect/HIVM/IR/HIVMInterfaces.h"
+#include "bishengir/Dialect/Utils/Util.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -128,6 +130,55 @@ static void attachCrossCoreDeps(Operation *op, int tid, int seqId,
 static void attachAnalyzeFlagIdTag(Operation *op) {
   MLIRContext *ctx = op->getContext();
   op->setAttr(CVPipeline::kAnalyzeFlagId, UnitAttr::get(ctx));
+}
+
+static bool isChannelSplitNeeded(RankedTensorType tensorType) {
+  static constexpr int32_t alignM = 16;
+  return mlir::utils::getNumPerBlock(tensorType) == alignM / 2;
+}
+
+// Check whether a value is a valid C->C transfer candidate: at least one user
+// whose block_id matches \p consumerBlockId must be a matmul op consuming the
+// value as an A/B input. The value may also be used as init (outs) by other
+// users (or the same matmul) — the replacement logic in handleCubeToCube
+// ensures only the input operands are replaced.
+static bool hasAnyMatmulABInputUser(Value value, int consumerBlockId) {
+  for (Operation *user : value.getUsers()) {
+    if (CVPipeline::getOpBlockId(user).value_or(-1) != consumerBlockId) {
+      continue;
+    }
+    auto matmulUser = dyn_cast<linalg::MatmulOp>(user);
+    if (!matmulUser) {
+      continue;
+    }
+    for (Value input : matmulUser.getDpsInputs()) {
+      if (input == value) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/// Check if \p op is a valid intermediate op that can appear between two
+/// matmuls in a C2C chain. Extend this list to support new intermediate types.
+static bool isValidC2CIntermediateOp(Operation *op) {
+  return CVPipeline::getFixpipePreQuantMode(op).has_value();
+}
+
+/// Check if \p value is a valid C2C matmul dependency.
+/// Valid chains: matmul -> (intermediate_op)* -> matmul.
+static bool isValidC2CMatmulDependency(Value value, int consumerBlockId) {
+  // Walk back through valid intermediate ops to find the source matmul.
+  Operation *defOp = value.getDefiningOp();
+  while (defOp && isValidC2CIntermediateOp(defOp)) {
+    defOp = defOp->getOperand(0).getDefiningOp();
+  }
+
+  if (!isa_and_nonnull<linalg::MatmulOp>(defOp))
+    return false;
+
+  return hasAnyMatmulABInputUser(value, consumerBlockId);
 }
 
 // Block Start/End Operation Retrieval
@@ -353,10 +404,11 @@ mlir::Value InterCoreTransferAndSyncPass::alignShapeByInsertSlice(
       loc, origValue, linalgFillOp->getResult(0), offsets, insertsizes,
       strides);
 
-  attachCommonTags(zeroConstOp, originBlockId, "VECTOR");
-  attachCommonTags(tensorEmptyOp, originBlockId, "VECTOR");
-  attachCommonTags(linalgFillOp, originBlockId, "VECTOR");
-  attachCommonTags(tensorInsertSliceOp, originBlockId, "VECTOR");
+  attachCommonTags(zeroConstOp, originBlockId, CVPipeline::kCoreTypeVector);
+  attachCommonTags(tensorEmptyOp, originBlockId, CVPipeline::kCoreTypeVector);
+  attachCommonTags(linalgFillOp, originBlockId, CVPipeline::kCoreTypeVector);
+  attachCommonTags(tensorInsertSliceOp, originBlockId,
+                   CVPipeline::kCoreTypeVector);
 
   return tensorInsertSliceOp.getResult();
 }
@@ -428,12 +480,12 @@ void InterCoreTransferAndSyncPass::Nd2NzNormalize(OpBuilder &builder,
   auto reshape4DOp = builder.create<tensor::ReshapeOp>(
       loc, typeFinal, transposeOp->getResult(0), reshape4Dcst);
 
-  attachCommonTags(reshape3Dcst, originBlockId, "VECTOR");
-  attachCommonTags(reshape3DOp, originBlockId, "VECTOR");
-  attachCommonTags(emptyTrans, originBlockId, "VECTOR");
-  attachCommonTags(transposeOp, originBlockId, "VECTOR");
-  attachCommonTags(reshape4Dcst, originBlockId, "VECTOR");
-  attachCommonTags(reshape4DOp, originBlockId, "VECTOR");
+  attachCommonTags(reshape3Dcst, originBlockId, CVPipeline::kCoreTypeVector);
+  attachCommonTags(reshape3DOp, originBlockId, CVPipeline::kCoreTypeVector);
+  attachCommonTags(emptyTrans, originBlockId, CVPipeline::kCoreTypeVector);
+  attachCommonTags(transposeOp, originBlockId, CVPipeline::kCoreTypeVector);
+  attachCommonTags(reshape4Dcst, originBlockId, CVPipeline::kCoreTypeVector);
+  attachCommonTags(reshape4DOp, originBlockId, CVPipeline::kCoreTypeVector);
   LOG_DEBUG("[reshape3DOp]: " << *reshape3DOp << "\n");
   LOG_DEBUG("[transposeOp]: " << *transposeOp << "\n");
   LOG_DEBUG("[reshape4DOp]: " << *reshape4DOp << "\n");
@@ -590,7 +642,8 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(
     LOG_DEBUG("after writeToSSBuffer\n");
     Operation *storeOp = nullptr;
     for (Operation *op : writeOps) {
-      attachTransferTags(op, vecBlockId, "VECTOR", transferIndex);
+      attachTransferTags(op, vecBlockId, CVPipeline::kCoreTypeVector,
+                         transferIndex);
       if (isa<memref::StoreOp>(op)) {
         storeOp = op;
       }
@@ -611,7 +664,8 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(
     LOG_DEBUG("after readFromSSBuffer\n");
     Operation *loadOp = nullptr;
     for (Operation *op : readOps) {
-      attachTransferTags(op, cubeBlockId, "CUBE", transferIndex);
+      attachTransferTags(op, cubeBlockId, CVPipeline::kCoreTypeCube,
+                         transferIndex);
       if (isa<memref::LoadOp>(op)) {
         loadOp = op;
       }
@@ -629,12 +683,14 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(
     auto [vecAllocOp, cubeAllocOp] = createTransferAllocs(
         builder, loc, normalizedTensorType.getShape(), elemType,
         hivm::AddressSpace::L1, vectorEndOp, cubeStartOp, vecBlockId,
-        cubeBlockId, "VECTOR", "CUBE", transferIndex);
+        cubeBlockId, CVPipeline::kCoreTypeVector, CVPipeline::kCoreTypeCube,
+        transferIndex);
 
     auto copyOp = builder.create<hivm::CopyOp>(
         loc, mlir::TypeRange{}, normalizedValue, vecAllocOp->getResult(0));
 
-    attachTransferTags(copyOp, vecBlockId, "VECTOR", transferIndex);
+    attachTransferTags(copyOp, vecBlockId, CVPipeline::kCoreTypeVector,
+                       transferIndex);
     attachCrossCoreDeps(copyOp, transferIndex, CVPipeline::crossCoreProducerId,
                         builder);
     LOG_DEBUG("[copyOp]: " << *copyOp << "\n");
@@ -657,7 +713,8 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(
                                                 ndLayout  // dstLayout
           );
       memValue = convertLayoutOp.getResult();
-      attachTransferTags(convertLayoutOp, cubeBlockId, "CUBE", transferIndex);
+      attachTransferTags(convertLayoutOp, cubeBlockId,
+                         CVPipeline::kCoreTypeCube, transferIndex);
       attachCrossCoreDeps(convertLayoutOp, transferIndex,
                           CVPipeline::crossCoreConsumerId, builder);
     }
@@ -667,12 +724,14 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(
     auto toTensorOp = builder.create<bufferization::ToTensorOp>(
         loc, srcTensorType, memspaceCastOp.getResult(), true, true);
 
-    attachTransferTags(memspaceCastOp, cubeBlockId, "CUBE", transferIndex);
+    attachTransferTags(memspaceCastOp, cubeBlockId, CVPipeline::kCoreTypeCube,
+                       transferIndex);
     if (is1DTensor) {
       attachCrossCoreDeps(memspaceCastOp, transferIndex,
                           CVPipeline::crossCoreConsumerId, builder);
     }
-    attachTransferTags(toTensorOp, cubeBlockId, "CUBE", transferIndex);
+    attachTransferTags(toTensorOp, cubeBlockId, CVPipeline::kCoreTypeCube,
+                       transferIndex);
     LOG_DEBUG("[toTensorOp]: " << *toTensorOp << "\n");
     sendOp = copyOp;
     receiveOp = toTensorOp;
@@ -717,7 +776,8 @@ Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(
   auto targetTensorType = RankedTensorType::get(targetShape, elemType);
   auto [cubeAllocOp, vecAllocOp] = createTransferAllocs(
       builder, loc, targetShape, elemType, hivm::AddressSpace::UB, cubeEndOp,
-      vectorStartOp, cubeBlockId, vecBlockId, "CUBE", "VECTOR", transferIndex);
+      vectorStartOp, cubeBlockId, vecBlockId, CVPipeline::kCoreTypeCube,
+      CVPipeline::kCoreTypeVector, transferIndex);
   auto dmaModeAttr = FixpipeDMAModeAttr::get(
       builder.getContext(),
       dep.isAllTranspoesd ? FixpipeDMAMode::NZ2DN : FixpipeDMAMode::NZ2ND);
@@ -728,7 +788,8 @@ Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(
       cubeAllocOp->getResult(0), // dst
       mlir::ValueRange{}, dmaModeAttr, nullptr, nullptr, nullptr, nullptr,
       nullptr, nullptr, nullptr, mlir::ArrayAttr{}, nullptr);
-  attachTransferTags(fixpipeOp, cubeBlockId, "CUBE", transferIndex);
+  attachTransferTags(fixpipeOp, cubeBlockId, CVPipeline::kCoreTypeCube,
+                     transferIndex);
   attachCrossCoreDeps(fixpipeOp, transferIndex, CVPipeline::crossCoreProducerId,
                       builder);
   LOG_DEBUG("[fixpipeOp]: " << *fixpipeOp << "\n");
@@ -743,10 +804,12 @@ Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(
   auto toTensorOp = builder.create<bufferization::ToTensorOp>(
       loc, targetTensorType, memspaceCastOp.getResult(), true, true);
 
-  attachTransferTags(memspaceCastOp, vecBlockId, "VECTOR", transferIndex);
+  attachTransferTags(memspaceCastOp, vecBlockId, CVPipeline::kCoreTypeVector,
+                     transferIndex);
   attachCrossCoreDeps(memspaceCastOp, transferIndex,
                       CVPipeline::crossCoreConsumerId, builder);
-  attachTransferTags(toTensorOp, vecBlockId, "VECTOR", transferIndex);
+  attachTransferTags(toTensorOp, vecBlockId, CVPipeline::kCoreTypeVector,
+                     transferIndex);
   LOG_DEBUG("[toTensorOp]: " << *toTensorOp << "\n");
 
   if (dep.isAllTranspoesd) {
@@ -798,8 +861,8 @@ InterCoreTransferAndSyncPass::getTransferPipeConfig(Operation *transferOp,
       config.forWritePipe = pipeFixAttr;
       config.srcCoreAttr = cubeCoreAttr;
       config.dstCoreAttr = vecCoreAttr;
-      config.srcCoreType = "CUBE";
-      config.dstCoreType = "VECTOR";
+      config.srcCoreType = CVPipeline::kCoreTypeCube;
+      config.dstCoreType = CVPipeline::kCoreTypeVector;
     } else {
       config.forReadTPipe = pipeFixAttr;
       config.forReadPipe = pipeVAttr;
@@ -807,8 +870,8 @@ InterCoreTransferAndSyncPass::getTransferPipeConfig(Operation *transferOp,
       config.forWritePipe = pipeFixAttr;
       config.srcCoreAttr = cubeCoreAttr;
       config.dstCoreAttr = vecCoreAttr;
-      config.srcCoreType = "CUBE";
-      config.dstCoreType = "VECTOR";
+      config.srcCoreType = CVPipeline::kCoreTypeCube;
+      config.dstCoreType = CVPipeline::kCoreTypeVector;
     }
   } else if (isa<hivm::CopyOp>(transferOp)) {
     config.forReadTPipe = pipeMte3Attr;
@@ -817,8 +880,8 @@ InterCoreTransferAndSyncPass::getTransferPipeConfig(Operation *transferOp,
     config.forWritePipe = pipeMte3Attr;
     config.srcCoreAttr = vecCoreAttr;
     config.dstCoreAttr = cubeCoreAttr;
-    config.srcCoreType = "VECTOR";
-    config.dstCoreType = "CUBE";
+    config.srcCoreType = CVPipeline::kCoreTypeVector;
+    config.dstCoreType = CVPipeline::kCoreTypeCube;
   } else if (isa<memref::StoreOp>(transferOp)) {
     // Scalar sync uses PIPE_S to stay isolated from tensor flag space.
     config.forReadTPipe = pipeSAttr;
@@ -827,8 +890,8 @@ InterCoreTransferAndSyncPass::getTransferPipeConfig(Operation *transferOp,
     config.forWritePipe = pipeSAttr;
     config.srcCoreAttr = vecCoreAttr;
     config.dstCoreAttr = cubeCoreAttr;
-    config.srcCoreType = "VECTOR";
-    config.dstCoreType = "CUBE";
+    config.srcCoreType = CVPipeline::kCoreTypeVector;
+    config.dstCoreType = CVPipeline::kCoreTypeCube;
   }
   return config;
 }
@@ -997,11 +1060,13 @@ void InterCoreTransferAndSyncPass::insertMemDepSync(
   auto prodBlockIdOpt = CVPipeline::getOpBlockId(producerOp);
   auto consBlockIdOpt = CVPipeline::getOpBlockId(consumerOp);
   if (prodBlockIdOpt) {
-    StringRef prodCoreType = isCubeToVector ? "CUBE" : "VECTOR";
+    StringRef prodCoreType = isCubeToVector ? CVPipeline::kCoreTypeCube
+                                            : CVPipeline::kCoreTypeVector;
     attachCommonTags(setOp, *prodBlockIdOpt, prodCoreType);
   }
   if (consBlockIdOpt) {
-    StringRef consCoreType = isCubeToVector ? "VECTOR" : "CUBE";
+    StringRef consCoreType = isCubeToVector ? CVPipeline::kCoreTypeVector
+                                            : CVPipeline::kCoreTypeCube;
     attachCommonTags(waitOp, *consBlockIdOpt, consCoreType);
   }
   attachAnalyzeFlagIdTag(setOp);
@@ -1029,7 +1094,7 @@ std::optional<VectorToTensorInfo> findVectorToTensorInScfOp(Operation *scfOp) {
       }
       auto coreAttr =
           toTensor->getAttrOfType<StringAttr>(CVPipeline::kCoreType);
-      if (!coreAttr || coreAttr.getValue() != "VECTOR") {
+      if (!coreAttr || coreAttr.getValue() != CVPipeline::kCoreTypeVector) {
         continue;
       }
       Value memref = CVPipeline::traceBackToMemrefAlloc(toTensor.getBuffer());
@@ -1129,7 +1194,7 @@ void InterCoreTransferAndSyncPass::removeVectorPseudoOps() {
       return;
     }
     auto coreAttr = op->getAttrOfType<StringAttr>(CVPipeline::kCoreType);
-    if (!coreAttr || coreAttr.getValue() != "VECTOR") {
+    if (!coreAttr || coreAttr.getValue() != CVPipeline::kCoreTypeVector) {
       return;
     }
     if (op->getNumOperands() != 2) {
@@ -1241,10 +1306,10 @@ static std::optional<hivm::TCoreType> getAnalyzeCoreType(Operation *op) {
     return std::nullopt;
   }
   StringRef coreType = coreStringAttr.getValue();
-  if (coreType == "CUBE") {
+  if (coreType == CVPipeline::kCoreTypeCube) {
     return hivm::TCoreType::CUBE;
   }
-  if (coreType == "VECTOR") {
+  if (coreType == CVPipeline::kCoreTypeVector) {
     return hivm::TCoreType::VECTOR;
   }
   return std::nullopt;
@@ -1395,6 +1460,144 @@ LogicalResult InterCoreTransferAndSyncPass::handleCubeToVector(
 
   transferIndex++;
   LOG_DEBUG("Inserted C->V transfer and sync: block "
+            << dep.producerBlockId << " -> block " << dep.consumerBlockId
+            << "\n");
+  return success();
+}
+
+// C->C Shared L1 buffer allocation.
+// Allocates before the main loop if one encloses both producer and consumer,
+// otherwise after the producer block end.
+Operation *InterCoreTransferAndSyncPass::createC2CSharedL1Buffer(
+    OpBuilder &builder, Location loc, ArrayRef<int64_t> shape, Type elemType,
+    int prodBlockId, Operation *prodEnd, Operation *consStart) {
+  auto addressSpaceAttr =
+      builder.getAttr<hivm::AddressSpaceAttr>(hivm::AddressSpace::L1);
+  auto allocType = MemRefType::get(shape, elemType, nullptr, addressSpaceAttr);
+
+  Operation *allocOp = nullptr;
+  Operation *mainLoopOp = findMainLoopforTransfer(prodEnd, consStart);
+  if (mainLoopOp) {
+    builder.setInsertionPoint(mainLoopOp);
+    allocOp = builder.create<memref::AllocOp>(loc, allocType);
+    int loopBlockId = CVPipeline::getOpBlockId(mainLoopOp).value_or(-1);
+    attachCommonTags(allocOp, loopBlockId, CVPipeline::kCoreTypeCube);
+    builder.setInsertionPointAfter(prodEnd);
+  } else {
+    builder.setInsertionPointAfter(prodEnd);
+    allocOp = builder.create<memref::AllocOp>(loc, allocType);
+    attachCommonTags(allocOp, prodBlockId, CVPipeline::kCoreTypeCube);
+  }
+  return allocOp;
+}
+
+// C->C Transfer Logic
+LogicalResult
+InterCoreTransferAndSyncPass::handleCubeToCube(OpBuilder &builder,
+                                               DependencyInfo &dep) {
+  mlir::Value transferValue = dep.value;
+  Location loc = transferValue.getLoc();
+
+  // Check if this is a matmul -> trunc -> matmul pattern.
+  // If so, use the matmul result (pre-trunc) as the fixpipe source and
+  // fold the type conversion into the fixpipe as pre_quant.
+  Operation *truncOp = transferValue.getDefiningOp();
+  mlir::Value fixpipeSrcValue = transferValue;
+  std::optional<FixpipePreQuantMode> quantMode =
+      CVPipeline::getFixpipePreQuantMode(truncOp);
+  if (quantMode) {
+    fixpipeSrcValue = transferValue.getDefiningOp()->getOperand(0);
+  }
+
+  auto [prodStart, prodEnd] =
+      getBlockStartEnd(dep.producerBlockId, module); // C Block
+  auto [consStart, consEnd] =
+      getBlockStartEnd(dep.consumerBlockId, module); // C Block
+
+  // Adjust consStart to the first operation that actually reads transferValue
+  // within the consumer block, matching the logic in handleVectorToCube.
+  if (dep.consumerBlockId == dep.iniConsumerBlockId) {
+    auto consumerPoint =
+        analyzeConsumerReadInsertPoint(transferValue, dep.iniConsumerBlockId);
+    if (consumerPoint) {
+      consStart = consumerPoint;
+    }
+  }
+
+  auto transferTensorType = cast<RankedTensorType>(transferValue.getType());
+  int64_t M = transferTensorType.getDimSize(0);
+  int64_t N = transferTensorType.getDimSize(1);
+  Type elemType = transferTensorType.getElementType();
+  auto shape = std::vector<int64_t>{M, N};
+
+  int prodBlockId =
+      CVPipeline::getOpBlockId(fixpipeSrcValue.getDefiningOp()).value_or(-1);
+  int consBlockId = CVPipeline::getOpBlockId(consStart).value_or(-1);
+
+  // Allocate a single shared L1 buffer for producer and consumer.
+  auto *allocOp = createC2CSharedL1Buffer(builder, loc, shape, elemType,
+                                          prodBlockId, prodEnd, consStart);
+
+  // Producer side: insert fixpipe to write matmul L0C output to L1 buffer
+  auto dmaModeAttr =
+      FixpipeDMAModeAttr::get(builder.getContext(), FixpipeDMAMode::NZ2NZ);
+  bool channelSplit = isChannelSplitNeeded(transferTensorType);
+
+  // Build quantModeAttr when a trunc is being folded in as pre_quant.
+  FixpipePreQuantModeAttr quantModeAttr = nullptr;
+  if (quantMode.has_value()) {
+    quantModeAttr =
+        FixpipePreQuantModeAttr::get(builder.getContext(), quantMode.value());
+  }
+
+  auto fixpipeOp = builder.create<hivm::FixpipeOp>(
+      loc, mlir::TypeRange{}, fixpipeSrcValue, allocOp->getResult(0),
+      mlir::ValueRange{}, dmaModeAttr, nullptr, nullptr, quantModeAttr, nullptr,
+      builder.getBoolAttr(channelSplit), nullptr, nullptr, mlir::ArrayAttr{},
+      nullptr);
+  attachCommonTags(fixpipeOp, prodBlockId, CVPipeline::kCoreTypeCube);
+  LOG_DEBUG("[fixpipeOp C->C]: " << *fixpipeOp << "\n");
+
+  // Consumer side: read L1 buffer via MemorySpaceCast + ToTensor
+  builder.setInsertionPoint(consStart);
+  auto plainMemrefType = MemRefType::get(shape, elemType);
+  auto memspaceCastOp = builder.create<memref::MemorySpaceCastOp>(
+      loc, plainMemrefType, allocOp->getResult(0));
+  auto targetTensorType = RankedTensorType::get(shape, elemType);
+  auto toTensorOp = builder.create<bufferization::ToTensorOp>(
+      loc, targetTensorType, memspaceCastOp.getResult(), true, true);
+  attachCommonTags(memspaceCastOp, consBlockId, CVPipeline::kCoreTypeCube);
+  attachCommonTags(toTensorOp, consBlockId, CVPipeline::kCoreTypeCube);
+
+  // Replace uses of transferValue within the consumer block.
+  // For matmul ops, only replace input (A/B) operands so that the init (outs)
+  // still directly uses the producer matmul result when the same value is
+  // used as both input and init.
+  llvm::SmallVector<Operation *> users(transferValue.getUsers().begin(),
+                                       transferValue.getUsers().end());
+  for (Operation *user : users) {
+    auto userBlockIdOpt = CVPipeline::getOpBlockId(user);
+    if (userBlockIdOpt && *userBlockIdOpt == dep.iniConsumerBlockId) {
+      if (auto matmulUser = dyn_cast<linalg::MatmulOp>(user)) {
+        for (int64_t i = 0; i < matmulUser.getNumDpsInputs(); ++i) {
+          if (matmulUser->getOpOperand(i).get() == transferValue) {
+            matmulUser->setOperand(i, toTensorOp.getResult());
+          }
+        }
+      } else {
+        LOG_DEBUG(
+            "warning: c2c transferValue is used by non-matmul op: " << *user);
+        user->replaceUsesOfWith(transferValue, toTensorOp.getResult());
+      }
+    }
+  }
+
+  // Erase the trunc op after all uses are replaced (dead code elimination).
+  if (truncOp && CVPipeline::getFixpipePreQuantMode(truncOp).has_value()) {
+    truncOp->erase();
+  }
+
+  LOG_DEBUG("Inserted C->C fixpipe transfer: block "
             << dep.producerBlockId << " -> block " << dep.consumerBlockId
             << "\n");
   return success();
@@ -1705,6 +1908,29 @@ LogicalResult InterCoreTransferAndSyncPass::processDependencies(
     }
   }
   LOG_DEBUG("Completed C->V transfers and syncs.\n");
+
+  // Step 3: Handle C->C dependencies (fixpipe L0C to L1)
+  llvm::SmallVector<DependencyInfo> &C2CDependencies =
+      info.getC2CDependencies();
+  sortDependencies(C2CDependencies, module);
+  LOG_DEBUG("[DEBUG] C2CDependencies size: " << C2CDependencies.size() << "\n");
+  for (auto &dep : C2CDependencies) {
+    LOG_DEBUG("[C->C] producerBlockId = " << dep.producerBlockId
+                                          << ", consumerBlockId = "
+                                          << dep.consumerBlockId << "\n");
+    // Only handle C->C transfer when both the defining op and the consuming
+    // users of dep.value are matmul ops.
+    if (!isValidC2CMatmulDependency(dep.value, dep.consumerBlockId)) {
+      continue;
+    }
+    if (failed(handleCubeToCube(builder, dep))) {
+      LOG_DEBUG("[ERROR] C->C failed! producerBlockId = "
+                << dep.producerBlockId
+                << ", consumerBlockId = " << dep.consumerBlockId << "\n");
+      return failure();
+    }
+  }
+  LOG_DEBUG("Completed C->C transfers and syncs.\n");
 
   llvm::SmallVector<DependencyInfo> &memDependencies =
       info.getMemoryDependencies();

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/MarkMainLoop.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/MarkMainLoop.cpp
@@ -47,15 +47,30 @@ void MarkMainLoopPass::runOnOperation() {
   SmallVector<Operation *> mainLoops;
 
   // Find all candidate main loops (ForOp + WhileOp)
+  auto isL1Fixpipe = [](Operation *op) -> bool {
+    auto fixpipeOp = dyn_cast<hivm::FixpipeOp>(op);
+    if (!fixpipeOp)
+      return false;
+    auto dstType = dyn_cast<MemRefType>(fixpipeOp.getDst().getType());
+    if (!dstType)
+      return false;
+    auto addrSpaceAttr =
+        dyn_cast_or_null<hivm::AddressSpaceAttr>(dstType.getMemorySpace());
+    return addrSpaceAttr &&
+           addrSpaceAttr.getAddressSpace() == hivm::AddressSpace::L1;
+  };
+
   module.walk([&](Operation *op) {
-    if (isa<hivm::FixpipeOp, hivm::CopyOp>(op)) {
-      if (auto forOp = op->getParentOfType<scf::ForOp>()) {
-        mainLoops.push_back(forOp);
-      }
-      if (auto whileOp = op->getParentOfType<scf::WhileOp>()) {
-        mainLoops.push_back(whileOp);
-      }
-    }
+    if (!isa<hivm::FixpipeOp, hivm::CopyOp>(op))
+      return;
+
+    if (isL1Fixpipe(op))
+      return;
+
+    if (auto forOp = op->getParentOfType<scf::ForOp>())
+      mainLoops.push_back(forOp);
+    if (auto whileOp = op->getParentOfType<scf::WhileOp>())
+      mainLoops.push_back(whileOp);
   });
 
   for (Operation *loopOp : mainLoops) {

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
@@ -438,7 +438,8 @@ static bool shouldSplitByOutput(linalg::MatmulOp matmulOp, Value &outerOutValue,
   };
   auto usedByL1 =
       traceChainUser(outerOutValue, false, matchMatmulAB, skipCubeop);
-  if (usedByL1.has_value()) {
+  if (usedByL1.has_value() &&
+      usedByL1.value()->getBlock() != outerOutValue.getParentBlock()) {
     LOG_DEBUG("Split avoid L0C -> L1. " << matmulOp); // S01-S08
     return true;
   }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_fixpipe_nz2nz.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/SplitDataflow/test_fixpipe_nz2nz.mlir
@@ -1,0 +1,142 @@
+// RUN: triton-opt --data-dependency-analysis --inter-core-transfer-and-sync --mark-main-loop --split-input-file %s | FileCheck %s
+
+// Test fixpipe nz2nz f32: channel_split = true
+// Producer matmul at block_id=3 -> Consumer matmul at block_id=5
+
+// CHECK-LABEL: func.func @test_c2c_fixpipe_nz2nz_f32
+
+// CHECK: memref.alloc() {{.*}} : memref<32x32xf32, #hivm.address_space<cbuf>>
+
+// CHECK: hivm.hir.fixpipe {channel_split = true, ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} ins({{%.*}} : tensor<32x32xf32>) outs({{%.*}} : memref<32x32xf32, #hivm.address_space<cbuf>>)
+
+// CHECK: memref.memory_space_cast {{%.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf32, #hivm.address_space<cbuf>> to memref<32x32xf32>
+// CHECK: bufferization.to_tensor {{%.*}} restrict writable {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf32> to tensor<32x32xf32>
+
+// CHECK-NOT: ssbuffer.main_loop
+// CHECK: return
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_c2c_fixpipe_nz2nz_f32(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %a: tensor<32x1xf32>, %b: tensor<1x32xf32>, %c: tensor<32x1xf32>, %arg5: i32 {tt.divisibility = 16 : i32}) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %c0_i32 = arith.constant {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "VECTOR"} 0 : i32
+    %c1_i32 = arith.constant {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "VECTOR"} 1 : i32
+    %cst = arith.constant {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
+    %init32x32 = tensor.empty() {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %fill32x32 = linalg.fill {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : f32) outs(%init32x32 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %init32x1 = tensor.empty() {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x1xf32>
+    %fill32x1 = linalg.fill {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : f32) outs(%init32x1 : tensor<32x1xf32>) -> tensor<32x1xf32>
+    scf.for %arg6 = %c0_i32 to %arg5 step %c1_i32  : i32 {
+      %mm1 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.loop_carried_l0c} ins(%a, %b : tensor<32x1xf32>, tensor<1x32xf32>) outs(%fill32x32 : tensor<32x32xf32>) -> tensor<32x32xf32>
+      %mm2 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE", ssbuffer.loop_carried_l0c} ins(%mm1, %c : tensor<32x32xf32>, tensor<32x1xf32>) outs(%fill32x1 : tensor<32x1xf32>) -> tensor<32x1xf32>
+    }
+    return
+  }
+}
+
+// -----
+
+// Test fixpipe nz2nz f32->f16 via trunc: pre_quant = F322F16
+// Producer matmul (f32) -> trunc f32->f16 -> Consumer matmul (f16)
+// The trunc is folded into the fixpipe as pre_quant.
+
+// CHECK-LABEL: func.func @test_c2c_fixpipe_nz2nz_trunc_f32_f16
+
+// CHECK: memref.alloc() {{.*}} : memref<32x32xf16, #hivm.address_space<cbuf>>
+
+// CHECK: hivm.hir.fixpipe {pre_quant = #hivm.fixpipe_pre_quant_mode<F322F16>, ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} ins({{%.*}} : tensor<32x32xf32>) outs({{%.*}} : memref<32x32xf16, #hivm.address_space<cbuf>>)
+
+// CHECK: memref.memory_space_cast {{%.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16, #hivm.address_space<cbuf>> to memref<32x32xf16>
+// CHECK: bufferization.to_tensor {{%.*}} restrict writable {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16> to tensor<32x32xf16>
+
+// CHECK-NOT: ssbuffer.main_loop
+// CHECK-NOT: arith.truncf
+// CHECK: return
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_c2c_fixpipe_nz2nz_trunc_f32_f16(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %a: tensor<32x1xf32>, %b: tensor<1x32xf32>, %c: tensor<32x1xf16>, %arg5: i32 {tt.divisibility = 16 : i32}) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %c0_i32 = arith.constant {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "VECTOR"} 0 : i32
+    %c1_i32 = arith.constant {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "VECTOR"} 1 : i32
+    %cst_f32 = arith.constant {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
+    %cst_f16 = arith.constant {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f16
+    %init32x32 = tensor.empty() {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %fill32x32 = linalg.fill {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_f32 : f32) outs(%init32x32 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %init32x1 = tensor.empty() {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x1xf16>
+    %fill32x1 = linalg.fill {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_f16 : f16) outs(%init32x1 : tensor<32x1xf16>) -> tensor<32x1xf16>
+    scf.for %arg6 = %c0_i32 to %arg5 step %c1_i32  : i32 {
+      %mm1 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.loop_carried_l0c} ins(%a, %b : tensor<32x1xf32>, tensor<1x32xf32>) outs(%fill32x32 : tensor<32x32xf32>) -> tensor<32x32xf32>
+      %trunc = arith.truncf %mm1 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32> to tensor<32x32xf16>
+      %mm2 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE", ssbuffer.loop_carried_l0c} ins(%trunc, %c : tensor<32x32xf16>, tensor<32x1xf16>) outs(%fill32x1 : tensor<32x1xf16>) -> tensor<32x1xf16>
+    }
+    return
+  }
+}
+
+// -----
+
+// Test fixpipe nz2nz f16: channel_split = false
+// f16: numElemPerBlock = 256/16 = 16, channelSplit = (16 == 8) = false
+
+// CHECK-LABEL: func.func @test_c2c_fixpipe_nz2nz_f16
+
+// CHECK: memref.alloc() {{.*}} : memref<32x32xf16, #hivm.address_space<cbuf>>
+
+// CHECK: hivm.hir.fixpipe {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} ins({{%.*}} : tensor<32x32xf16>) outs({{%.*}} : memref<32x32xf16, #hivm.address_space<cbuf>>)
+// CHECK-NOT: channel_split
+
+// CHECK: memref.memory_space_cast {{%.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16, #hivm.address_space<cbuf>> to memref<32x32xf16>
+// CHECK: bufferization.to_tensor {{%.*}} restrict writable {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf16> to tensor<32x32xf16>
+
+// CHECK: return
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_c2c_fixpipe_nz2nz_f16(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %a: tensor<32x1xf16>, %b: tensor<1x32xf16>, %c: tensor<32x1xf16>, %arg5: i32 {tt.divisibility = 16 : i32}) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %c0_i32 = arith.constant {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "VECTOR"} 0 : i32
+    %c1_i32 = arith.constant {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "VECTOR"} 1 : i32
+    %cst = arith.constant {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f16
+    %init32x32 = tensor.empty() {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf16>
+    %fill32x32 = linalg.fill {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : f16) outs(%init32x32 : tensor<32x32xf16>) -> tensor<32x32xf16>
+    %init32x1 = tensor.empty() {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x1xf16>
+    %fill32x1 = linalg.fill {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : f16) outs(%init32x1 : tensor<32x1xf16>) -> tensor<32x1xf16>
+    scf.for %arg6 = %c0_i32 to %arg5 step %c1_i32  : i32 {
+      %mm1 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.loop_carried_l0c} ins(%a, %b : tensor<32x1xf16>, tensor<1x32xf16>) outs(%fill32x32 : tensor<32x32xf16>) -> tensor<32x32xf16>
+      %mm2 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE", ssbuffer.loop_carried_l0c} ins(%mm1, %c : tensor<32x32xf16>, tensor<32x1xf16>) outs(%fill32x1 : tensor<32x1xf16>) -> tensor<32x1xf16>
+    }
+    return
+  }
+}
+
+// -----
+
+// Test fixpipe nz2nz f32: matmul result used as both input and init of another matmul
+// Producer matmul at block_id=3 -> Consumer matmul at block_id=5
+// The bufferization.to_tensor result should only be used for the input,
+// while the init should still directly use the producer matmul result.
+
+// CHECK-LABEL: func.func @test_c2c_fixpipe_nz2nz_input_and_init
+
+// CHECK: memref.alloc() {{.*}} : memref<32x32xf32, #hivm.address_space<cbuf>>
+
+// CHECK: hivm.hir.fixpipe {channel_split = true, ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} ins([[MM1:%.*]] : tensor<32x32xf32>) outs({{%.*}} : memref<32x32xf32, #hivm.address_space<cbuf>>)
+
+// CHECK: memref.memory_space_cast {{%.*}} {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf32, #hivm.address_space<cbuf>> to memref<32x32xf32>
+// CHECK: [[TO_TENSOR:%.*]] = bufferization.to_tensor {{%.*}} restrict writable {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE"} : memref<32x32xf32> to tensor<32x32xf32>
+
+// Verify: the consumer matmul uses [[TO_TENSOR]] as input and [[MM1]] as init
+// CHECK: linalg.matmul {{.*}} ins([[TO_TENSOR]], {{%.*}} : tensor<32x32xf32>, tensor<32x32xf32>) outs([[MM1]] : tensor<32x32xf32>)
+
+// CHECK-NOT: ssbuffer.main_loop
+// CHECK: return
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  func.func @test_c2c_fixpipe_nz2nz_input_and_init(%arg0: memref<?xi8>, %arg1: memref<?xi8>, %a: tensor<32x1xf32>, %b: tensor<1x32xf32>, %c: tensor<32x32xf32>, %arg5: i32 {tt.divisibility = 16 : i32}) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %c0_i32 = arith.constant {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "VECTOR"} 0 : i32
+    %c1_i32 = arith.constant {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "VECTOR"} 1 : i32
+    %cst = arith.constant {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
+    %init32x32 = tensor.empty() {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"} : tensor<32x32xf32>
+    %fill32x32 = linalg.fill {ssbuffer.block_id = 11 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : f32) outs(%init32x32 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    scf.for %arg6 = %c0_i32 to %arg5 step %c1_i32  : i32 {
+      %mm1 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE", ssbuffer.loop_carried_l0c} ins(%a, %b : tensor<32x1xf32>, tensor<1x32xf32>) outs(%fill32x32 : tensor<32x32xf32>) -> tensor<32x32xf32>
+      %mm2 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "CUBE", ssbuffer.loop_carried_l0c} ins(%mm1, %c : tensor<32x32xf32>, tensor<32x32xf32>) outs(%mm1 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    }
+    return
+  }
+}


### PR DESCRIPTION
[ssbuffer] fixpipe nz2nz: L0C→L1 数据传输与 pre_quant 支持
1. 插入 fixpipe L0C→L1 数据传输
   - 在 DataDependencyAnalysis 中识别需要 L0C→L1 传输的 fixpipe 模式
   - 在 InterCoreTransferAndSync 中插入相应的数据传输指令
   - MarkMainLoop 适配 L0C→L1 场景的 block 标记
   
2. fixpipe nz2nz 支持 pre_quant
   - 新增 MergeFixpipeInlineChainPass ，将内联的 fixpipe 链（matmul->trunc->matmul)合并为单条 fixpipe
   - 在 InterCoreTransferAndSync 中支持 pre_quant 属性处理（F32→F16 截断等）
   - 工具函数： isChannelSplitNeeded 提取为独立函数， Utils 新增辅助方法
   - 新增 merge_fixpipe_inline_chain.mlir 和 test_fixpipe_nz2nz.mlir 测试用例

[ssbuffer] fixpipe nz2nz: L0C→L1 data transfer and pre_quant support
1. Insert fixpipe L0C→L1 data transfer
   - Identify fixpipe patterns requiring L0C→L1 transfer in DataDependencyAnalysis
   - Insert corresponding data transfer ops in InterCoreTransferAndSync
   - Adapt MarkMainLoop block marking for L0C→L1 scenarios
 
2. fixpipe nz2nz pre_quant support
   - Add MergeFixpipeInlineChainPass to merge inline fixpipe chains into a single fixpipe
   - Support pre_quant attribute handling in InterCoreTransferAndSync (F32→F16 truncation, etc.)
   - Extract isChannelSplitNeeded as a standalone utility function; add helpers in Utils
   - Add test cases: merge_fixpipe_inline_chain.mlir and test_fixpipe_nz2nz.mlir
   - 
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
