### PR TITLE
[launch](feat) optimize the launch to reduce the exection time

### DIFF
--- a/third_party/ascend/backend/backend_register.py
+++ b/third_party/ascend/backend/backend_register.py
@@ -355,4 +355,4 @@ def async_launch(func):
      fprintf(stderr, "Error: triton_async_launch is unavailable\\n");
      return;
    }}
-   g_async_launch(static_cast<void*>(&{func}), name.c_str());'''
+   g_async_launch(static_cast<void*>(&{func}), kernelName);'''

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -672,17 +672,17 @@ def make_launcher(constants, signature, metadata):
          lockOffset += syncBlockLockStrideI64) {{
       lockInitData[lockOffset] = syncBlockLockParticipantNum;
     }}
-    ret = rtMemcpy(syncBlockLock_ptr, syncBlockLockSize,
+    ret = aclrtMemcpy(syncBlockLock_ptr, syncBlockLockSize,
                    reinterpret_cast<void *>(lockInitData.data()),
-                   syncBlockLockSize, RT_MEMCPY_HOST_TO_DEVICE);"""
+                   syncBlockLockSize, ACL_MEMCPY_HOST_TO_DEVICE);"""
     elif lock_init_value == 0:
-        lock_init_stmt = ("ret = rtMemsetAsync(syncBlockLock_ptr, syncBlockLockSize, 0, "
+        lock_init_stmt = ("ret = aclrtMemsetAsync(syncBlockLock_ptr, syncBlockLockSize, 0, "
                           "syncBlockLockSize, stream);")
     else:
         lock_init_stmt = (f"std::vector<int64_t> lockInitData({lock_num}, {lock_init_value});\n"
-                          "    ret = rtMemcpy(syncBlockLock_ptr, syncBlockLockSize, "
+                          "    ret = aclrtMemcpy(syncBlockLock_ptr, syncBlockLockSize, "
                           "reinterpret_cast<void *>(lockInitData.data()), syncBlockLockSize, "
-                          "RT_MEMCPY_HOST_TO_DEVICE);")
+                          "ACL_MEMCPY_HOST_TO_DEVICE);")
     bs_task_type = metadata.bs_task_type if hasattr(metadata, 'bs_task_type') else 0
     mix_mode = metadata.mix_mode
     compile_on_910_95 = metadata.compile_on_910_95
@@ -1212,13 +1212,14 @@ void triton_launch_kernel(const char* kernelName, aclrtFuncHandle func, aclrtStr
     return;
   }}
   std::vector<size_t> launch_arg_sizes;
-  launch_arg_sizes.assign(arg_sizes, arg_sizes + num_args);
-  // NOTE: We deliberately do not copy kernel_args into a separate buffer here.
-  // triton_async_launch() invokes the launch_call synchronously on the caller
-  // thread (see npu_utils.cpp triton_async_launch -> OpCommand::Run), so the
-  // caller-provided kernel_args/arg_sizes memory remains valid for the entire
-  // lifetime of launch_call. Avoiding the per-arg vector<vector<char>> copy
-  // removes num_args heap allocations per launch.
+  launch_arg_sizes.reserve(num_args);
+  std::vector<std::vector<char>> copied_kernel_args;
+  copied_kernel_args.reserve(num_args);
+  for (int arg_idx = 0; arg_idx < num_args; ++arg_idx) {{
+    launch_arg_sizes.push_back(arg_sizes[arg_idx]);
+    copied_kernel_args.emplace_back(arg_sizes[arg_idx]);
+    memcpy(copied_kernel_args.back().data(), kernel_args[arg_idx], arg_sizes[arg_idx]);
+  }}
 
   // Only 1D parallelization is supported for NPU.
   // Pointer type becomes flattened 1-D Memref tuple: base_ptr, data_ptr,
@@ -1252,8 +1253,7 @@ void triton_launch_kernel(const char* kernelName, aclrtFuncHandle func, aclrtStr
     {'size_t dtdata_offset = reserve_slot(sizeof(void*), 8);' if enable_device_print else ''}
     size_t total_size = args_offset;
 
-    static thread_local std::vector<char> launch_args;
-    launch_args.assign(total_size, 0);
+    std::vector<char> launch_args(total_size, 0);
     {'memcpy(launch_args.data() + ffts_offset, &ffts_addr, sizeof(void*));' if target_support_ffts else ''}
     {f'memcpy(launch_args.data() + sync_block_lock_offset, &syncBlockLock_ptr, sizeof(void*));' if not metadata.force_simt_only else ''}
     {f'memcpy(launch_args.data() + workspace_offset, &workspace_addr_ptr, sizeof(void*));' if not metadata.force_simt_only else ''}
@@ -1261,7 +1261,7 @@ void triton_launch_kernel(const char* kernelName, aclrtFuncHandle func, aclrtStr
     for (int arg_idx = 0; arg_idx < num_args; ++arg_idx) {{
       size_t alignment = launch_arg_sizes[arg_idx] >= 8 ? 8 : (launch_arg_sizes[arg_idx] >= 4 ? 4 : 1);
       kernel_arg_offset = _align_launch_offset(kernel_arg_offset, alignment);
-      memcpy(launch_args.data() + kernel_arg_offset, kernel_args[arg_idx], launch_arg_sizes[arg_idx]);
+      memcpy(launch_args.data() + kernel_arg_offset, copied_kernel_args[arg_idx].data(), launch_arg_sizes[arg_idx]);
       kernel_arg_offset += launch_arg_sizes[arg_idx];
     }}
     memcpy(launch_args.data() + grid_offset, &gridX, sizeof(int32_t));

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -426,6 +426,7 @@ def generate_npu_header_src():
 #include <assert.h>
 #include <stdbool.h>
 #include <cstdlib>
+#include <cstring>
 #include <string>
 #include <memory>
 #include <sys/syscall.h>
@@ -493,6 +494,159 @@ def wrap_handle_tensordesc(launcher, signature):
         return launcher(*final_args)
 
     return inner
+
+
+_CPP_DEVICE_POINTER = r"""
+typedef struct _DevicePtrInfo {
+  void* dev_ptr;
+  bool valid;
+} DevicePtrInfo;
+
+static inline DevicePtrInfo getPointer(PyObject* obj, int idx) {
+  DevicePtrInfo ptr_info;
+  ptr_info.dev_ptr = nullptr;
+  ptr_info.valid = true;
+  if (PyLong_Check(obj)) {
+    ptr_info.dev_ptr = reinterpret_cast<void*>(PyLong_AsUnsignedLongLong(obj));
+    return ptr_info;
+  }
+  if (obj == Py_None) {
+    return ptr_info;
+  }
+  // Cache the interned "data_ptr" key once instead of rebuilding a temporary
+  // PyUnicode on every call. Function-local static init is thread-safe in C++11
+  // and the GIL is held here, so the one-time init is safe.
+  static PyObject* data_ptr_str = PyUnicode_InternFromString("data_ptr");
+  // PyObject_CallMethodNoArgs avoids creating a temporary tuple and a temporary
+  // method-name PyUnicode on every call (Python 3.9+).
+  PyObject* ret = PyObject_CallMethodNoArgs(obj, data_ptr_str);
+  if (ret) {
+    if (!PyLong_Check(ret)) {
+      PyErr_SetString(PyExc_TypeError, "data_ptr method of Pointer object must return 64-bit int");
+      ptr_info.valid = false;
+      Py_DECREF(ret);
+      return ptr_info;
+    }
+    ptr_info.dev_ptr = reinterpret_cast<void*>(PyLong_AsUnsignedLongLong(ret));
+    Py_DECREF(ret);
+    if (!ptr_info.dev_ptr) {
+      return ptr_info;
+    }
+    return ptr_info;
+  }
+  PyErr_SetString(PyExc_TypeError, "Pointer argument must be either uint64 or have data_ptr method");
+  ptr_info.valid = false;
+  return ptr_info;
+}
+"""
+
+_CPP_MSPROF_EXTERN = r"""
+extern "C" {
+typedef int (*callback)(unsigned int type, void* data, unsigned int len);
+extern int MsprofReportApi(unsigned int agingFlag, const MsprofApi* api);
+extern unsigned long int MsprofSysCycleTime();
+extern int MsprofRegisterCallback(unsigned int moduleId, callback handle);
+static unsigned int __MsprofFlagL0 = 0;
+static unsigned int __MsprofFlagL1 = 0;
+static std::vector<int> tensorKinds;
+
+int ProfCtrlHandle(unsigned int CtrlType, void* CtrlData, unsigned int DataLen) {
+  if ((CtrlData == nullptr) || (DataLen == 0U)) {
+    return 1;
+  }
+  if (CtrlType == 1) {
+    MsprofCommandHandle* handle = (MsprofCommandHandle*)(CtrlData);
+    if (handle->type >= 6) {
+      return 1;
+    }
+    if (handle->type == 1) {
+      __MsprofFlagL0 = ((0x00000800ULL & handle->profSwitch) == 0x00000800ULL) ? 1 : 0;
+      __MsprofFlagL1 = ((0x00000002ULL & handle->profSwitch) == 0x00000002ULL) ? 1 : 0;
+    }
+  }
+  return 0;
+}
+}
+"""
+
+_CPP_MSPROF_CALLBACK = r"""
+    MsprofRegisterCallback(8, ProfCtrlHandle);
+"""
+
+_CPP_MSPROF_BEFORE_LAUNCH = r"""
+    unsigned long int beginTime = 0;
+    unsigned long int endTime = 0;
+    unsigned long int opNameHashID = 0;
+    unsigned int threadId = 0;
+    char* _kernelName = const_cast<char*>(kernelName);
+    size_t length = kernelName ? strlen(kernelName) : 0;
+    if (__MsprofFlagL0 || __MsprofFlagL1) {
+      beginTime = MsprofSysCycleTime();
+    }
+"""
+
+_CPP_ALIGN_LAUNCH_OFFSET = r"""
+static inline size_t _align_launch_offset(size_t offset, size_t alignment) {
+  return (offset + alignment - 1) & ~(alignment - 1);
+}
+
+// aclrtGetHardwareSyncAddr returns a per-process per-stream constant address;
+// re-querying it on every kernel launch is pure overhead. Cache the most
+// recently observed (stream, ffts_addr) pair on the calling thread.
+// Thread-safety: launch_call is invoked synchronously from the launcher thread
+// by triton_async_launch (see npu_utils.cpp), so thread_local is safe.
+static thread_local aclrtStream g_last_ffts_stream = nullptr;
+static thread_local void* g_last_ffts_addr = nullptr;
+static inline aclError get_ffts_addr(aclrtStream stream, void** out_addr) {
+  if (stream == g_last_ffts_stream && g_last_ffts_addr) {
+    *out_addr = g_last_ffts_addr;
+    return ACL_SUCCESS;
+  }
+  void* ffts_addr = nullptr;
+  uint32_t ffts_len = 0;
+  aclError ret = aclrtGetHardwareSyncAddr(&ffts_addr);
+  if (ret == ACL_SUCCESS) {
+    g_last_ffts_stream = stream;
+    g_last_ffts_addr = ffts_addr;
+    *out_addr = ffts_addr;
+  }
+  return ret;
+}
+"""
+
+_CPP_GET_TENSOR_SHAPE = r"""
+static std::vector<int64_t> _get_tensor_shape(PyObject* tensor) {
+  std::vector<int64_t> shape;
+  if (!tensor || tensor == Py_None) {
+    return shape;
+  }
+  // Cache the interned "size" key once; avoid temporary PyUnicode/tuple per call.
+  static PyObject* size_str = PyUnicode_InternFromString("size");
+  // PyObject_CallMethodNoArgs avoids building "size" PyUnicode and an empty
+  // tuple on every launch (Python 3.9+).
+  PyObject* size_result = PyObject_CallMethodNoArgs(tensor, size_str);
+  if (!size_result) {
+    // Defensive: profiling-only path; swallow attribute errors so subsequent
+    // PyErr_Occurred() checks in launch() are not poisoned.
+    PyErr_Clear();
+    return shape;
+  }
+  PyObject* seq = PySequence_Fast(size_result, "Expected a sequence from tensor.size()");
+  if (seq) {
+    Py_ssize_t len = PySequence_Fast_GET_SIZE(seq);
+    PyObject** items = PySequence_Fast_ITEMS(seq);
+    for (Py_ssize_t i = 0; i < len; ++i) {
+      PyObject* dim = items[i];
+      if (PyLong_Check(dim)) {
+        shape.push_back(PyLong_AsLong(dim));
+      }
+    }
+  }
+  Py_DECREF(seq);
+  Py_DECREF(size_result);
+  return shape;
+}
+"""
 
 
 # the template is from triton-adapter HEAD. Wrapping the generated kernel binary into a python module
@@ -611,6 +765,36 @@ def make_launcher(constants, signature, metadata):
             "uint64_t": "K",
         }[ty_to_cpp(ty)]
 
+    def _format_to_fastcall_stmt(ty, var, idx):
+        """Generate C statement to parse argument at index idx from METH_FASTCALL args array."""
+        fmt = format_of(ty)
+        if fmt == "O":
+            return f"{var} = args[{idx}];"
+        elif fmt == "i":
+            return f"{var} = (int)PyLong_AsLong(args[{idx}]);"
+        elif fmt == "L":
+            return f"{var} = (int64_t)PyLong_AsLongLong(args[{idx}]);"
+        elif fmt == "K":
+            return f"{var} = (uint64_t)PyLong_AsUnsignedLongLong(args[{idx}]);"
+        elif fmt == "I":
+            return f"{var} = (uint32_t)PyLong_AsUnsignedLong(args[{idx}]);"
+        elif fmt == "H":
+            return f"{var} = (uint16_t)PyLong_AsUnsignedLong(args[{idx}]);"
+        elif fmt == "B":
+            return f"{var} = (uint8_t)PyLong_AsUnsignedLong(args[{idx}]);"
+        elif fmt == "h":
+            return f"{var} = (int16_t)PyLong_AsLong(args[{idx}]);"
+        elif fmt == "b":
+            return f"{var} = (int8_t)PyLong_AsLong(args[{idx}]);"
+        elif fmt == "l":
+            return f"{var} = (long)PyLong_AsLong(args[{idx}]);"
+        elif fmt == "f":
+            return f"{var} = (float)PyFloat_AsDouble(args[{idx}]);"
+        elif fmt == "d":
+            return f"{var} = PyFloat_AsDouble(args[{idx}]);"
+        else:
+            raise ValueError(f"Unsupported format: {fmt} for type {ty}")
+
     def _format_of_msprof_task_type_ratio(bs_task_type, mix_mode):
         # Default fallback based on mix_mode
         default_task_type = "MSPROF_GE_TASK_TYPE_AIV" if mix_mode == "aiv" else "MSPROF_GE_TASK_TYPE_AI_CORE"
@@ -651,6 +835,12 @@ def make_launcher(constants, signature, metadata):
         _flatten_signature(sig, flat_signature)
     signature = {i: s for i, s in enumerate(flat_signature)}
     args_list = ', ' + ', '.join(f"&_arg{i}" for i, ty in signature.items()) if len(signature) > 0 else ''
+    # Total expected argument count for METH_FASTCALL arity check.
+    total_nargs = _BASE_ARGS_FORMAT_LEN + len(signature)
+    # Generate manual parsing statements for signature args (indices 9..) used by
+    # the METH_FASTCALL fast path in launch().
+    fastcall_sig_parse_stmts = '\n  '.join(
+        _format_to_fastcall_stmt(ty, f"_arg{i}", _BASE_ARGS_FORMAT_LEN + i) for i, ty in signature.items())
     # Record the end of regular arguments;
     # subsequent arguments are architecture-specific descriptors.
     arg_decls = ', '.join(f"{ty_to_cpp(ty)} arg{i}" for i, ty in signature.items() if ty != "constexpr")
@@ -664,7 +854,7 @@ def make_launcher(constants, signature, metadata):
     # generate glue code
     newline = '\n  '
     ptr_decls = [
-        f"DevicePtrInfo ptr_info{i} = getPointer(_arg{i}, {i}); if (!ptr_info{i}.valid) return NULL;"
+        f"DevicePtrInfo ptr_info{i} = getPointer(_arg{i}, {i}); if (!ptr_info{i}.valid) return nullptr;"
         for i, ty in signature.items()
         if ty[0] == "*"
     ]
@@ -686,7 +876,7 @@ def make_launcher(constants, signature, metadata):
     num_physical_blocks = npu_utils.get_aivector_core_num() if mix_mode == "aiv" else npu_utils.get_aicore_num()
     task_type, mix_block_dim_ratio = _format_of_msprof_task_type_ratio(bs_task_type, mix_mode)
     is_mix_task_type = "true" if ("MIX" in task_type) else "false"
-    LINE_CHANGE_CHAR = chr(10)  # it is \n
+    LINE_CHANGE_CHAR = '\n'
     alloc_success_code = 'return 1;'
     sync_lock_fail_code = 'fprintf(stderr, "Error: syncBlockLock allocation failed\\n"); return;'
     workspace_fail_code = 'fprintf(stderr, "Error: workspace allocation failed\\n"); return;'
@@ -695,13 +885,7 @@ def make_launcher(constants, signature, metadata):
         exported_scratch_guard = (
             'fprintf(stderr, "Error: triton_launch_kernel does not support nonzero global scratch\\n");\n'
             '  return;')
-    launch_signature_items = [(i, ty) for i, ty in signature.items() if ty != "constexpr"]
-    launch_arg_count = len(launch_signature_items)
-    launch_arg_ptrs = ', '.join(f'static_cast<const void*>(&arg{i})' for i, ty in launch_signature_items)
-    launch_arg_sizes = ', '.join(f'sizeof({ty_to_cpp(ty)})' for i, ty in launch_signature_items)
-
-    npu_utils_inst = NPUUtils()
-    npu_utils_mod = getattr(npu_utils_inst, "npu_utils_mod", None)
+    npu_utils_mod = getattr(npu_utils, "npu_utils_mod", None)
     npu_utils_so_path = getattr(npu_utils_mod, "__file__", "")
     # The generated launcher source is part of its cache key. Preserve only the
     # deterministic cache-key directory so the launcher can be reused after the
@@ -787,96 +971,10 @@ static void release_npu_tensor_handle(void* handle) {{
     else:
         coalesce_grid_div = ""
 
-    cpp_device_pointer = """
-typedef struct _DevicePtrInfo {
-  void *dev_ptr;
-  bool valid;
-} DevicePtrInfo;
-
-static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {
-  DevicePtrInfo ptr_info;
-  ptr_info.dev_ptr = 0;
-  ptr_info.valid = true;
-  if (PyLong_Check(obj)) {
-    ptr_info.dev_ptr = reinterpret_cast<void *>(PyLong_AsUnsignedLongLong(obj));
-    return ptr_info;
-  }
-  if (obj == Py_None) {
-    // valid nullptr
-    return ptr_info;
-  }
-  // Cache the interned "data_ptr" key once instead of rebuilding a temporary
-  // PyUnicode on every call. Function-local static init is thread-safe in C++11
-  // and the GIL is held here, so the one-time init is safe.
-  static PyObject *data_ptr_str = PyUnicode_InternFromString("data_ptr");
-  PyObject *ptr = PyObject_GetAttr(obj, data_ptr_str);
-  if(ptr){
-    PyObject *empty_tuple = PyTuple_New(0);
-    PyObject *ret = PyObject_Call(ptr, empty_tuple, NULL);
-    Py_DECREF(empty_tuple);
-    Py_DECREF(ptr);
-    if (!PyLong_Check(ret)) {
-      PyErr_SetString(PyExc_TypeError, "data_ptr method of Pointer object must return 64-bit int");
-      ptr_info.valid = false;
-      return ptr_info;
-    }
-    ptr_info.dev_ptr = reinterpret_cast<void *>(PyLong_AsUnsignedLongLong(ret));
-    if(!ptr_info.dev_ptr)
-      return ptr_info;
-    Py_DECREF(ret);
-    return ptr_info;
-  }
-  PyErr_SetString(PyExc_TypeError, "Pointer argument must be either uint64 or have data_ptr method");
-  ptr_info.valid = false;
-  return ptr_info;
-}
-"""
-
-    cpp_msprof_extern = """
-extern "C" {
-  typedef int (* callback)(unsigned int type, void* data, unsigned int len);
-  extern int MsprofReportApi(unsigned int  agingFlag, const MsprofApi *api);
-  extern unsigned long int  MsprofSysCycleTime();
-  extern int MsprofRegisterCallback(unsigned int moduleId, callback handle);
-  static unsigned int __MsprofFlagL0  = 0;
-  static unsigned int __MsprofFlagL1  = 0;
-  static std::vector<int> tensorKinds;
-
-  int ProfCtrlHandle(unsigned int CtrlType, void* CtrlData, unsigned int DataLen) {
-    if ((CtrlData == nullptr) || (DataLen == 0U)) {
-      return 1;
-    }
-
-    if (CtrlType == 1) {
-      MsprofCommandHandle* handle = (MsprofCommandHandle *)(CtrlData);
-      if (handle->type >= 6)  // 6 is not used here
-        return 1;
-      if (handle->type == 1) {  // init - 0  , start - 1
-        __MsprofFlagL0 = ((0x00000800ULL & handle->profSwitch) == 0x00000800ULL) ? 1 : 0;
-        __MsprofFlagL1 = ((0x00000002ULL & handle->profSwitch) == 0x00000002ULL) ? 1 : 0;
-      }
-    }
-    return 0;
-  }
-}
-"""
-
-    cpp_msprof_callback = """
-    MsprofRegisterCallback(8, ProfCtrlHandle);      // 8 - CCE defined in msprof headerfile slog.h
-"""
-
-    cpp_msprof_call_before_launch = """
-    unsigned long int beginTime = 0;
-    unsigned long int endTime = 0;
-    unsigned long int opNameHashID = 0;
-    unsigned int threadId = 0;
-    char* _kernelName = const_cast<char*>(name.c_str());
-    size_t length = name.length();
-    if (__MsprofFlagL0 || __MsprofFlagL1)
-    {
-      beginTime = MsprofSysCycleTime();
-    }
-"""
+    cpp_device_pointer = _CPP_DEVICE_POINTER
+    cpp_msprof_extern = _CPP_MSPROF_EXTERN
+    cpp_msprof_callback = _CPP_MSPROF_CALLBACK
+    cpp_msprof_call_before_launch = _CPP_MSPROF_BEFORE_LAUNCH
 
     cpp_msprof_call_after_launch = f"""
     if (__MsprofFlagL0 || __MsprofFlagL1)
@@ -979,33 +1077,91 @@ extern "C" {
     }}
 """
 
-    cpp_kernel_launch = f"""
-    ret = aclrtLaunchKernelWithHostArgs(func, blockNum, stream, nullptr, static_cast<void*>(launch_args.data()), launch_args.size(), nullptr, 0);
+    def _make_kernel_launch(args_ptr, args_size, indent="    "):
+        cfg = "&cfgCfgInfo" if (compile_on_910_95 and enable_simt) else "nullptr"
+        cfg_setup = ""
+        if compile_on_910_95 and enable_simt:
+            cfg_setup = f"""{indent}aclrtLaunchKernelAttr attrInfo = {{}};
+{indent}attrInfo.id = ACL_RT_LAUNCH_KERNEL_ATTR_DYN_UBUF_SIZE;
+{indent}aclrtLaunchKernelAttrValue value = {{}};
+{indent}value.localMemorySize = {metadata.shared_mem_dynamic_size};
+{indent}attrInfo.value = value;
+{indent}aclrtLaunchKernelCfg cfgCfgInfo = {{}};
+{indent}cfgCfgInfo.attrs = &attrInfo;
+{indent}cfgCfgInfo.numAttrs = 1;
 """
-    cpp_kernel_launch_local = f"""
-        ret = aclrtLaunchKernelWithHostArgs(func, blockNum, stream, nullptr, &args, sizeof(args), nullptr, 0);
-    """
-    if compile_on_910_95 and enable_simt:
-        cpp_kernel_args = f"""
-        aclrtLaunchKernelAttr attrInfo = {{}};
-        attrInfo.id = ACL_RT_LAUNCH_KERNEL_ATTR_DYN_UBUF_SIZE;
-        aclrtLaunchKernelAttrValue value = {{}};
-        value.localMemorySize = {metadata.shared_mem_dynamic_size};
-        attrInfo.value = value;
-        aclrtLaunchKernelCfg cfgCfgInfo = {{}};
-        cfgCfgInfo.attrs = &attrInfo;
-        cfgCfgInfo.numAttrs = 1;
-    """
-        cpp_kernel_launch = f"""
-        {cpp_kernel_args}
-        ret = aclrtLaunchKernelWithHostArgs(func, blockNum, stream, &cfgCfgInfo,  static_cast<void*>(launch_args.data()), launch_args.size() , nullptr, 0);
-"""
-        cpp_kernel_launch_local = f"""
-        {cpp_kernel_args}
-        ret = aclrtLaunchKernelWithHostArgs(func, blockNum, stream, &cfgCfgInfo,  &args, sizeof(args) , nullptr, 0);
+        return f"""{cfg_setup}{indent}ret = aclrtLaunchKernelWithHostArgs(func, blockNum, stream, {cfg}, {args_ptr}, {args_size}, nullptr, 0);
 """
 
+    cpp_kernel_launch = _make_kernel_launch("static_cast<void*>(launch_args.data())", "launch_args.size()")
+    cpp_kernel_launch_local = _make_kernel_launch("&args", "sizeof(args)", indent="        ")
+
     npu_headers = generate_npu_header_src()
+
+    _launch_preamble = f"""
+  void* workspace_addr_ptr = nullptr;
+  void* workspace_handle = nullptr;
+  {coalesce_grid_div}
+  uint32_t blockNum4Workspace = gridX * gridY * gridZ;
+  {get_backend_func("pre_launch", True)}
+  {f'''
+  uint64_t totalWorkSpaceSize = {workspace_size} * blockNum4Workspace;
+  {get_backend_func("allocate_memory", "totalWorkSpaceSize", "stream")}
+  std::shared_ptr<void> workspace_handle_guard(workspace_handle, release_npu_tensor_handle);
+  if (!workspace_addr_ptr) {{
+    {workspace_fail_code}
+  }}
+  ''' if workspace_size > 0 else ''}"""
+
+    _launch_lambda_pre = f"""  {'std::function<aclError()> launch_call = [=]() -> aclError' if enable_taskqueue else ''} {{
+    {get_backend_func("pre_launch", False)}
+    uint32_t blockNum = gridX * gridY * gridZ;
+
+    #ifdef ENABLE_GRID_WARN_PRINT
+      static bool warned = false;
+      if (!warned && blockNum > (uint32_t){num_physical_blocks}) {{
+        printf("WARNING: Grid %u > physical limit {num_physical_blocks}, performance maybe reduced.\\n",blockNum);
+        warned = true;
+    }}
+    #endif
+    {'blockNum = std::min(blockNum, (uint32_t)' + str(num_physical_blocks) + ');' if enable_auto_map_parallel_blocks else ''}
+    // set mixBlockNumRation for nodeBasicBlockDim for msprof report
+    uint32_t mixBlockNumRation = {mix_block_dim_ratio};
+    uint32_t nodeBasicBlockDim = (mixBlockNumRation << 16) + blockNum;
+
+    {'cce::internal::DebugTunnelData *DTData = cce::internal::DebugTunnel::Open(blockNum);' if enable_device_print else ''}
+    aclError ret = ACL_SUCCESS;
+    {'void *ffts_addr = nullptr; ret = get_ffts_addr(stream, &ffts_addr);' if target_support_ffts else ''}
+    {'if (ret != ACL_SUCCESS) return ret;' if (target_support_ffts and enable_taskqueue) else 'if (ret != ACL_SUCCESS) return;' if (target_support_ffts and (not enable_taskqueue)) else ''}
+    // stub argument for workspace
+    void *syncBlockLock_ptr = nullptr;
+    void *syncBlockLock_handle = nullptr;
+    uint16_t ModuleId = 0;
+    {f'''
+    uint64_t syncBlockLockSize = {lock_num} * sizeof(int64_t);
+    {get_backend_func("allocate_sync_block_lock", "syncBlockLockSize", "stream")}
+    std::shared_ptr<void> syncBlockLock_handle_guard(syncBlockLock_handle, release_npu_tensor_handle);
+    if (!syncBlockLock_ptr) {{
+      {alloc_success_code if enable_taskqueue else sync_lock_fail_code}
+    }}
+    {lock_init_stmt}
+    if (ret != ACL_SUCCESS) {{
+      return {'ret' if enable_taskqueue else ''};
+    }}
+    ''' if lock_num > 0 else ''}
+    {'if (ret != ACL_SUCCESS) {{ return ret; }}' if (workspace_size > 0 and enable_taskqueue) else 'if (ret != ACL_SUCCESS) {{ return; }}' if (workspace_size > 0 and not enable_taskqueue) else ''}"""
+
+    _launch_lambda_post = f"""
+    {cpp_msprof_call_before_launch}
+    __KERNEL_LAUNCH_CALL__
+    {'void*& stream_ref = const_cast<void*&>(stream);' if enable_device_print else ''}
+    {'cce::internal::DebugTunnel::Close(DTData, stream_ref);' if enable_device_print else ''}
+    {cpp_msprof_call_after_launch}
+    {'return ret;' if enable_taskqueue else 'ret = aclrtSynchronizeStream(stream);'}
+  }};
+  {f'''{get_backend_func("async_launch", "launch_call") if enable_taskqueue else ''}'''}
+  return;
+}}"""
 
     return f"""
 {npu_headers}
@@ -1023,17 +1179,17 @@ extern "C" {
 
 {cpp_device_pointer}
 
-static inline size_t _align_launch_offset(size_t offset, size_t alignment) {{
-  return (offset + alignment - 1) & ~(alignment - 1);
-}}
+{_CPP_ALIGN_LAUNCH_OFFSET}
 
 extern "C" {{
-void triton_launch_kernel(const char* kernelName, aclrtFuncHandle func, aclrtStream stream, int gridX, int gridY, int gridZ,
+void triton_launch_kernel(const char* kernelName, aclrtFuncHandle func, aclrtStream stream,
+    int gridX, int gridY, int gridZ,
     const int64_t* shapes_data, const int* shape_dims, int num_tensors,
     const int* tensor_kinds,
     const void* const* kernel_args, const size_t* arg_sizes, int num_args) {{
-  if (gridX <=0 || gridY <=0 || gridZ <=0) {{
-    printf("WARNING: Skipping launch for kernel '%s' due to empty grid (gridX=%d, gridY=%d, gridZ=%d).\\n", kernelName, gridX, gridY, gridZ);
+  if (gridX <= 0 || gridY <= 0 || gridZ <= 0) {{
+    printf("WARNING: Skipping launch for kernel '%s' due to empty grid (gridX=%d, gridY=%d, gridZ=%d).\\n",
+           kernelName, gridX, gridY, gridZ);
     return;
   }}
   {exported_scratch_guard}
@@ -1056,70 +1212,21 @@ void triton_launch_kernel(const char* kernelName, aclrtFuncHandle func, aclrtStr
     return;
   }}
   std::vector<size_t> launch_arg_sizes;
-  launch_arg_sizes.reserve(num_args);
-  std::vector<std::vector<char>> copied_kernel_args;
-  copied_kernel_args.reserve(num_args);
-  for (int arg_idx = 0; arg_idx < num_args; ++arg_idx) {{
-    launch_arg_sizes.push_back(arg_sizes[arg_idx]);
-    copied_kernel_args.emplace_back(arg_sizes[arg_idx]);
-    memcpy(copied_kernel_args.back().data(), kernel_args[arg_idx], arg_sizes[arg_idx]);
-  }}
+  launch_arg_sizes.assign(arg_sizes, arg_sizes + num_args);
+  // NOTE: We deliberately do not copy kernel_args into a separate buffer here.
+  // triton_async_launch() invokes the launch_call synchronously on the caller
+  // thread (see npu_utils.cpp triton_async_launch -> OpCommand::Run), so the
+  // caller-provided kernel_args/arg_sizes memory remains valid for the entire
+  // lifetime of launch_call. Avoiding the per-arg vector<vector<char>> copy
+  // removes num_args heap allocations per launch.
 
-  // only 1D parallelization is supported for NPU
-  // Pointer type becomes flattend 1-D Memref tuple: base_ptr, data_ptr, offset, shape, stride
-  // base_ptr offset shape and stride are not used, arbitrarily set for now
-  std::string name(kernelName);
-  void *workspace_addr_ptr = NULL;
-  void *workspace_handle = NULL;
-  {'void *global_scratch = nullptr; void *profile_scratch = nullptr;' if metadata.force_simt_only else ''}
-  {coalesce_grid_div}
-  uint32_t blockNum4Workspace = gridX * gridY * gridZ;
-  {get_backend_func("pre_launch", True)}
-  {f'''
-  uint64_t totalWorkSpaceSize = {workspace_size} * blockNum4Workspace;
-  {get_backend_func("allocate_memory", "totalWorkSpaceSize", "stream")}
-  std::shared_ptr<void> workspace_handle_guard(workspace_handle, release_npu_tensor_handle);
-  if (!workspace_addr_ptr) {{
-    {workspace_fail_code}
-  }}
-  ''' if workspace_size > 0 else ''}
-  {'std::function<aclError()> launch_call = [=]() -> aclError' if enable_taskqueue else ''} {{
-    {get_backend_func("pre_launch", False)}
-    uint32_t blockNum = gridX * gridY * gridZ;
-
-    #ifdef ENABLE_GRID_WARN_PRINT
-      static bool warned = false;
-      if (!warned && blockNum > (uint32_t){num_physical_blocks}) {{
-        printf("WARNING: Grid %u > physical limit {num_physical_blocks}, performance maybe reduced.\\n",blockNum);
-        warned = true;
-    }}
-    #endif
-    {'blockNum = std::min(blockNum, (uint32_t)' + str(num_physical_blocks) + ');' if enable_auto_map_parallel_blocks else ''}
-    // set mixBlockNumRation for nodeBasicBlockDim for msprof report
-    uint32_t mixBlockNumRation = {mix_block_dim_ratio};
-    uint32_t nodeBasicBlockDim = (mixBlockNumRation << 16) + blockNum;
-
-    {'cce::internal::DebugTunnelData *DTData = cce::internal::DebugTunnel::Open(blockNum);' if enable_device_print else ''}
-    aclError ret = ACL_SUCCESS;
-    {'void *ffts_addr = NULL; uint32_t ffts_len; ret = aclrtGetHardwareSyncAddr(&ffts_addr);' if target_support_ffts else ''}
-    {'if (ret != ACL_SUCCESS) return ret;' if (target_support_ffts and enable_taskqueue) else 'if (ret != ACL_SUCCESS) return;' if (target_support_ffts and (not enable_taskqueue)) else ''}
-    // stub argument for workspace
-    void *syncBlockLock_ptr = NULL;
-    void *syncBlockLock_handle = NULL;
-    uint16_t ModuleId = 0;
-    {f'''
-    uint64_t syncBlockLockSize = {lock_num} * sizeof(int64_t);
-    {get_backend_func("allocate_sync_block_lock", "syncBlockLockSize", "stream")}
-    std::shared_ptr<void> syncBlockLock_handle_guard(syncBlockLock_handle, release_npu_tensor_handle);
-    if (!syncBlockLock_ptr) {{
-      {alloc_success_code if enable_taskqueue else sync_lock_fail_code}
-    }}
-    {lock_init_stmt}
-    if (ret != ACL_SUCCESS) {{
-      return {'ret' if enable_taskqueue else ''};
-    }}
-    ''' if lock_num > 0 else ''}
-    {'if (ret != ACL_SUCCESS) return ret;' if (workspace_size > 0 and enable_taskqueue) else 'if (ret != ACL_SUCCESS) return;' if (workspace_size > 0 and not enable_taskqueue) else ''}
+  // Only 1D parallelization is supported for NPU.
+  // Pointer type becomes flattened 1-D Memref tuple: base_ptr, data_ptr,
+  // offset, shape, stride. base_ptr offset shape and stride are not used,
+  // arbitrarily set for now.
+{'void *global_scratch = nullptr; void *profile_scratch = nullptr;' if metadata.force_simt_only else ''}
+{_launch_preamble}
+{_launch_lambda_pre}
 
     size_t args_offset = 0;
     auto reserve_slot = [&](size_t size, size_t alignment) -> size_t {{
@@ -1145,7 +1252,8 @@ void triton_launch_kernel(const char* kernelName, aclrtFuncHandle func, aclrtStr
     {'size_t dtdata_offset = reserve_slot(sizeof(void*), 8);' if enable_device_print else ''}
     size_t total_size = args_offset;
 
-    std::vector<char> launch_args(total_size, 0);
+    static thread_local std::vector<char> launch_args;
+    launch_args.assign(total_size, 0);
     {'memcpy(launch_args.data() + ffts_offset, &ffts_addr, sizeof(void*));' if target_support_ffts else ''}
     {f'memcpy(launch_args.data() + sync_block_lock_offset, &syncBlockLock_ptr, sizeof(void*));' if not metadata.force_simt_only else ''}
     {f'memcpy(launch_args.data() + workspace_offset, &workspace_addr_ptr, sizeof(void*));' if not metadata.force_simt_only else ''}
@@ -1153,7 +1261,7 @@ void triton_launch_kernel(const char* kernelName, aclrtFuncHandle func, aclrtStr
     for (int arg_idx = 0; arg_idx < num_args; ++arg_idx) {{
       size_t alignment = launch_arg_sizes[arg_idx] >= 8 ? 8 : (launch_arg_sizes[arg_idx] >= 4 ? 4 : 1);
       kernel_arg_offset = _align_launch_offset(kernel_arg_offset, alignment);
-      memcpy(launch_args.data() + kernel_arg_offset, copied_kernel_args[arg_idx].data(), launch_arg_sizes[arg_idx]);
+      memcpy(launch_args.data() + kernel_arg_offset, kernel_args[arg_idx], launch_arg_sizes[arg_idx]);
       kernel_arg_offset += launch_arg_sizes[arg_idx];
     }}
     memcpy(launch_args.data() + grid_offset, &gridX, sizeof(int32_t));
@@ -1163,78 +1271,20 @@ void triton_launch_kernel(const char* kernelName, aclrtFuncHandle func, aclrtStr
     {'memcpy(launch_args.data() + profile_scratch_offset, &profile_scratch, sizeof(void*));' if metadata.force_simt_only else ''}
     {'memcpy(launch_args.data() + dtdata_offset, &DTData, sizeof(void*));' if enable_device_print else ''}
 
-    {cpp_msprof_call_before_launch}
-    {cpp_kernel_launch}
-    {'void *&stream_ref = const_cast<void*&>(stream);' if enable_device_print else ''}
-    {'cce::internal::DebugTunnel::Close(DTData, stream_ref);' if enable_device_print else ''}
-    {cpp_msprof_call_after_launch}
-    {'return ret;' if enable_taskqueue else 'ret = aclrtSynchronizeStream(stream);'}
-   }};
-   {f'''{get_backend_func("async_launch", "launch_call") if enable_taskqueue else ''}'''}
-  return;
-}}
+{_launch_lambda_post.replace('__KERNEL_LAUNCH_CALL__', cpp_kernel_launch)}
 }} // extern "C"
 
-static void _launch(
-    const char* kernelName, aclrtFuncHandle func, aclrtStream stream,
+static void _launch(const char* kernelName, aclrtFuncHandle func, aclrtStream stream,
     int gridX, int gridY, int gridZ,
     std::vector<std::vector<int64_t>> &tensorShapes, std::vector<int> &tensorKinds,
-    void *global_scratch, void *profile_scratch
-    {(', ' + arg_decls) if len(arg_decls) > 0 else ''}) {{
+    void *global_scratch, void *profile_scratch{(', ' + arg_decls) if len(arg_decls) > 0 else ''}) {{
   // Keep Python launcher on the stable local packing path.
   if (gridX <=0 || gridY <=0 || gridZ <=0) {{
     printf("WARNING: Skipping launch for kernel '%s' due to empty grid (gridX=%d, gridY=%d, gridZ=%d).\\n", kernelName, gridX, gridY, gridZ);
     return;
   }}
-  std::string name(kernelName);
-  void *workspace_addr_ptr = NULL;
-  void *workspace_handle = NULL;
-  {coalesce_grid_div}
-  uint32_t blockNum4Workspace = gridX * gridY * gridZ;
-  {get_backend_func("pre_launch", True)}
-  {f'''
-  uint64_t totalWorkSpaceSize = {workspace_size} * blockNum4Workspace;
-  {get_backend_func("allocate_memory", "totalWorkSpaceSize", "stream")}
-  std::shared_ptr<void> workspace_handle_guard(workspace_handle, release_npu_tensor_handle);
-  if (!workspace_addr_ptr) {{
-    {workspace_fail_code}
-  }}
-  ''' if workspace_size > 0 else ''}
-  {'std::function<aclError()> launch_call = [=]() -> aclError' if enable_taskqueue else ''} {{
-    {get_backend_func("pre_launch", False)}
-    uint32_t blockNum = gridX * gridY * gridZ;
-
-    #ifdef ENABLE_GRID_WARN_PRINT
-      static bool warned = false;
-      if (!warned && blockNum > (uint32_t){num_physical_blocks}) {{
-        printf("WARNING: Grid %u > physical limit {num_physical_blocks}, performance maybe reduced.\\n",blockNum);
-        warned = true;
-    }}
-    #endif
-    {'blockNum = std::min(blockNum, (uint32_t)' + str(num_physical_blocks) + ');' if enable_auto_map_parallel_blocks else ''}
-    uint32_t mixBlockNumRation = {mix_block_dim_ratio};
-    uint32_t nodeBasicBlockDim = (mixBlockNumRation << 16) + blockNum;
-
-    {'cce::internal::DebugTunnelData *DTData = cce::internal::DebugTunnel::Open(blockNum);' if enable_device_print else ''}
-    aclError ret = ACL_SUCCESS;
-    {'void *ffts_addr = NULL; uint32_t ffts_len; ret = aclrtGetHardwareSyncAddr(&ffts_addr);' if target_support_ffts else ''}
-    {'if (ret != ACL_SUCCESS) return ret;' if (target_support_ffts and enable_taskqueue) else 'if (ret != ACL_SUCCESS) return;' if (target_support_ffts and (not enable_taskqueue)) else ''}
-    void *syncBlockLock_ptr = NULL;
-    void *syncBlockLock_handle = NULL;
-    uint16_t ModuleId = 0;
-    {f'''
-    uint64_t syncBlockLockSize = {lock_num} * sizeof(int64_t);
-    {get_backend_func("allocate_sync_block_lock", "syncBlockLockSize", "stream")}
-    std::shared_ptr<void> syncBlockLock_handle_guard(syncBlockLock_handle, release_npu_tensor_handle);
-    if (!syncBlockLock_ptr) {{
-      {alloc_success_code if enable_taskqueue else sync_lock_fail_code}
-    }}
-    {lock_init_stmt}
-    if (ret != ACL_SUCCESS) {{
-      return {'ret' if enable_taskqueue else ''};
-    }}
-    ''' if lock_num > 0 else ''}
-    {'if (ret != ACL_SUCCESS) return ret;' if (workspace_size > 0 and enable_taskqueue) else 'if (ret != ACL_SUCCESS) return;' if (workspace_size > 0 and not enable_taskqueue) else ''}
+{_launch_preamble}
+{_launch_lambda_pre}
     struct __attribute__((packed)) {{
       {'void* ffts_addr __attribute__((aligned(8)));' if target_support_ffts else ''}
       {'void* syncBlockLock __attribute__((aligned(8)));' if not metadata.force_simt_only else ''}
@@ -1256,71 +1306,46 @@ static void _launch(
       {', static_cast<void*>(profile_scratch)' if metadata.force_simt_only else ''}
       {', static_cast<void*>(DTData)' if enable_device_print else ''}
     }};
-    {cpp_msprof_call_before_launch}
-    {cpp_kernel_launch_local}
-    {'void *&stream_ref = const_cast<void*&>(stream);' if enable_device_print else ''}
-    {'cce::internal::DebugTunnel::Close(DTData, stream_ref);' if enable_device_print else ''}
-    {cpp_msprof_call_after_launch}
-    {'return ret;' if enable_taskqueue else 'ret = aclrtSynchronizeStream(stream);'}
-   }};
-   {f'''{get_backend_func("async_launch", "launch_call") if enable_taskqueue else ''}'''}
-  return;
-}}
+{_launch_lambda_post.replace('__KERNEL_LAUNCH_CALL__', cpp_kernel_launch_local)}
 
-// Extract tensor shape from PyObject
-static std::vector<int64_t> _get_tensor_shape(PyObject *tensor) {{
-  std::vector<int64_t> shape;
+{_CPP_GET_TENSOR_SHAPE}
 
-  // Early return if tensor is None or null
-  if (!tensor || tensor == Py_None) {{
-    return shape;
-  }}
-
-  // Calling tensor.size()
-  PyObject* size_result = PyObject_CallMethod(tensor, "size", NULL);
-  if (!size_result) {{
-    return shape;
-  }}
-  // Using PySequence_Fast to improve access efficiency
-  PyObject* seq = PySequence_Fast(size_result, "Expected a sequence from tensor.size()");
-  if (seq) {{
-    Py_ssize_t len = PySequence_Fast_GET_SIZE(seq);
-    PyObject** items = PySequence_Fast_ITEMS(seq);
-    for (Py_ssize_t i = 0; i < len; ++i) {{
-      PyObject* dim = items[i];
-      if (PyLong_Check(dim)) {{
-        shape.push_back(PyLong_AsLong(dim));
-      }}
-    }}
-  }}
-  Py_DECREF(seq);
-  Py_DECREF(size_result);
-  return shape;
-}}
-
-static PyObject* launch(PyObject* self, PyObject* args) {{
+static PyObject* launch(PyObject* self, PyObject* const* args, Py_ssize_t nargs) {{
   int gridX, gridY, gridZ;
   aclrtStream stream;
   aclrtFuncHandle function;
-  PyObject *packedMetadata = NULL;
-  PyObject *launch_metadata = NULL;
-  PyObject *launch_enter_hook = NULL;
-  PyObject *launch_exit_hook = NULL;
-  PyObject *global_scratch_obj = NULL;
-  PyObject *profile_scratch_obj = NULL;
+  PyObject *packedMetadata = nullptr;
+  PyObject *launch_metadata = nullptr;
+  PyObject *launch_enter_hook = nullptr;
+  PyObject *launch_exit_hook = nullptr;
+  PyObject *global_scratch_obj = nullptr;
+  PyObject *profile_scratch_obj = nullptr;
   std::vector<std::vector<int64_t>> tensorShapes;
 
   {newline.join([f"{_extracted_type(ty)} _arg{i};" for i, ty in signature.items()])}
-  if(!PyArg_ParseTuple(
-      args, \"{format}\",
-      &gridX, &gridY, &gridZ, &stream, &function,
-      &global_scratch_obj, &profile_scratch_obj,
-      &packedMetadata, &launch_metadata,
-      &launch_enter_hook, &launch_exit_hook{args_list})) {{
-    return NULL;
+  // METH_FASTCALL fast path: avoid per-call tuple allocation (METH_VARARGS) and
+  // skip PyArg_ParseTuple's format-string interpreter by parsing manually.
+  // Borrowed-reference semantics match PyArg_ParseTuple("O").
+  if (nargs != {total_nargs}) {{
+    PyErr_Format(PyExc_TypeError, "launch expects %d arguments, got %zd", {total_nargs}, nargs);
+    return nullptr;
   }}
-  if (__MsprofFlagL1)
-  {{
+  gridX = (int)PyLong_AsLong(args[0]);
+  gridY = (int)PyLong_AsLong(args[1]);
+  gridZ = (int)PyLong_AsLong(args[2]);
+  stream = reinterpret_cast<aclrtStream>(PyLong_AsUnsignedLongLong(args[3]));
+  function = reinterpret_cast<aclrtFuncHandle>(PyLong_AsUnsignedLongLong(args[4]));
+  global_scratch_obj = args[5];
+  profile_scratch_obj = args[6];
+  packedMetadata = args[7];
+  launch_metadata = args[8];
+  launch_enter_hook = args[9];
+  launch_exit_hook = args[10];
+  {fastcall_sig_parse_stmts}
+  if (PyErr_Occurred()) {{
+    return nullptr;
+  }}
+  if (__MsprofFlagL1) {{
     {
       LINE_CHANGE_CHAR.join(
         f"{{ auto tmp = _get_tensor_shape(_arg{i}); if (!tmp.empty()) tensorShapes.push_back(tmp); }}"
@@ -1330,18 +1355,18 @@ static PyObject* launch(PyObject* self, PyObject* args) {{
   }}
 
   if (launch_enter_hook != Py_None){{
-    PyObject* args = Py_BuildValue("(O)", launch_metadata);
-    PyObject* ret = PyObject_CallObject(launch_enter_hook, args);
-    Py_DECREF(args);
-    if (!ret)
-      return NULL;
+    PyObject* hook_args = Py_BuildValue("(O)", launch_metadata);
+    PyObject* hook_ret = PyObject_CallObject(launch_enter_hook, hook_args);
+    Py_DECREF(hook_args);
+    if (!hook_ret)
+      return nullptr;
   }}
 
   void *global_scratch = 0;
   if (global_scratch_obj != Py_None) {{
     DevicePtrInfo global_scratch_info = getPointer(global_scratch_obj, -1);
     if (!global_scratch_info.valid) {{
-      return NULL;
+      return nullptr;
     }}
     global_scratch = global_scratch_info.dev_ptr;
   }}
@@ -1354,23 +1379,27 @@ static PyObject* launch(PyObject* self, PyObject* args) {{
     }}
     profile_scratch = profile_scratch_info.dev_ptr;
   }}
-
-
-  // get kernel_name
-  PyObject *kernelNameObj = PyDict_GetItemString(packedMetadata, "kernel_name");
-  const char* kernelName = PyUnicode_AsUTF8(kernelNameObj);
-  // get tensor_kinds
-  if( tensorKinds.empty() ) {{
-     PyObject *tensorKindList = PyDict_GetItemString(packedMetadata, "tensor_kinds");
-     if (tensorKindList) {{
-       int size = PyObject_Size(tensorKindList);
-       for (int i = 0; i < size; i++) {{
-         PyObject *kind = PySequence_GetItem(tensorKindList, i);
-         tensorKinds.push_back(PyLong_AsLong(kind));
-       }}
-     }}
+  // get kernel_name (use interned key to avoid temporary PyUnicode per call)
+  static PyObject* key_kernel_name = PyUnicode_InternFromString("kernel_name");
+  PyObject* kernelNameObj = PyDict_GetItemWithError(packedMetadata, key_kernel_name);
+  if (!kernelNameObj) {{
+    PyErr_SetString(PyExc_KeyError, "packedMetadata missing 'kernel_name'");
+    return nullptr;
   }}
-
+  const char* kernelName = PyUnicode_AsUTF8(kernelNameObj);
+  // get tensor_kinds (use interned key, cache result in tensorKinds)
+  if (tensorKinds.empty()) {{
+    static PyObject* key_tensor_kinds = PyUnicode_InternFromString("tensor_kinds");
+    PyObject* tensorKindList = PyDict_GetItemWithError(packedMetadata, key_tensor_kinds);
+    if (tensorKindList) {{
+      Py_ssize_t size = PySequence_Size(tensorKindList);
+      for (Py_ssize_t i = 0; i < size; ++i) {{
+        PyObject* kind = PySequence_GetItem(tensorKindList, i);
+        tensorKinds.push_back(PyLong_AsLong(kind));
+        Py_DECREF(kind);
+      }}
+    }}
+  }}
 
   // raise exception asap
   {newline.join(ptr_decls)}
@@ -1380,38 +1409,41 @@ static PyObject* launch(PyObject* self, PyObject* args) {{
           global_scratch, profile_scratch
           {', ' + ', '.join(internal_args_list) if len(internal_args_list) > 0 else ''});
   if (PyErr_Occurred()) {{
-    return NULL;
+    return nullptr;
   }}
   if(launch_exit_hook != Py_None){{
-    PyObject* args = Py_BuildValue("(O)", launch_metadata);
-    PyObject* ret = PyObject_CallObject(launch_exit_hook, args);
-    Py_DECREF(args);
-    if (!ret)
-      return NULL;
+    PyObject* hook_args = Py_BuildValue("(O)", launch_metadata);
+    PyObject* hook_ret = PyObject_CallObject(launch_exit_hook, hook_args);
+    Py_DECREF(hook_args);
+    if (!hook_ret)
+      return nullptr;
   }}
   Py_RETURN_NONE;
 }}
 
 static PyMethodDef ModuleMethods[] = {{
-  {{"launch", launch, METH_VARARGS, "Entry point for all kernels with this signature"}},
-  {{NULL, NULL, 0, NULL}} // sentinel
+  {{"launch", (PyCFunction)launch, METH_FASTCALL, "Entry point for all kernels with this signature"}},
+  {{nullptr, nullptr, 0, nullptr}} // sentinel
 }};
 
 static struct PyModuleDef ModuleDef = {{
   PyModuleDef_HEAD_INIT,
   \"__triton_launcher\",
-  NULL, //documentation
+  nullptr, //documentation
   -1, //size
   ModuleMethods
 }};
 
 PyMODINIT_FUNC PyInit___triton_launcher(void) {{
   PyObject *m = PyModule_Create(&ModuleDef);
-  if(m == NULL) {{
-    return NULL;
+  if(m == nullptr) {{
+    return nullptr;
   }}
   PyModule_AddFunctions(m, ModuleMethods);
   {cpp_msprof_callback}
+  // One-time initialization of NPU utils (dlsym lookup for g_async_launch etc.)
+  // Moved here from the per-call async_launch path to avoid repeated dlsym work.
+  init_npu_utils();
   return m;
 }}
 """

--- a/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
+++ b/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
@@ -75,10 +75,9 @@ def test_make_launcher_exposes_triton_launch_kernel(
 
     assert 'void triton_launch_kernel(' in src
     assert 'const void* const* kernel_args, const size_t* arg_sizes, int num_args' in src
-    assert 'std::vector<std::vector<char>> copied_kernel_args;' not in src
-    assert 'static thread_local std::vector<char> launch_args;' in src
+    assert 'std::vector<std::vector<char>> copied_kernel_args;' in src
     assert 'std::vector<size_t> launch_arg_sizes;' in src
-    assert 'launch_args.assign(total_size, 0);' in src
+    assert 'std::vector<char> launch_args(total_size, 0);' in src
     assert 'memcpy(launch_args.data() + grid_offset, &gridX, sizeof(int32_t));' in src
 
 
@@ -486,8 +485,7 @@ def test_argument_packing_differs_between_launch_paths(
 
     c_abi_launch, cpp_launch = _split_launch_functions(src)
 
-    assert "static thread_local std::vector<char> launch_args;" in c_abi_launch
-    assert "launch_args.assign(total_size, 0);" in c_abi_launch
+    assert "std::vector<char> launch_args(total_size, 0);" in c_abi_launch
     assert "reserve_slot" in c_abi_launch
 
     assert "struct __attribute__((packed))" in cpp_launch

--- a/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
+++ b/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
@@ -1,8 +1,11 @@
 import importlib.util
+import sys
 from itertools import product
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "python"))
 
 
 def _load_driver_module():
@@ -42,6 +45,11 @@ def _make_metadata():
     )
 
 
+def _split_launch_functions(src):
+    c_abi_part, cpp_part = src.split("static void _launch(", maxsplit=1)
+    return c_abi_part, "static void _launch(" + cpp_part
+
+
 @patch.object(driver, "NPUUtils")
 @patch.object(driver, "_is_auto_map_parallel_blocks_enabled", return_value=False)
 @patch.object(driver, "force_disable_ffts", return_value=False)
@@ -67,9 +75,10 @@ def test_make_launcher_exposes_triton_launch_kernel(
 
     assert 'void triton_launch_kernel(' in src
     assert 'const void* const* kernel_args, const size_t* arg_sizes, int num_args' in src
-    assert 'std::vector<std::vector<char>> copied_kernel_args;' in src
+    assert 'std::vector<std::vector<char>> copied_kernel_args;' not in src
+    assert 'static thread_local std::vector<char> launch_args;' in src
     assert 'std::vector<size_t> launch_arg_sizes;' in src
-    assert 'std::vector<char> launch_args(total_size, 0);' in src
+    assert 'launch_args.assign(total_size, 0);' in src
     assert 'memcpy(launch_args.data() + grid_offset, &gridX, sizeof(int32_t));' in src
 
 
@@ -98,9 +107,7 @@ def test_make_launcher_resolves_npu_utils_from_active_cache_root(
 
     producer_utils = make_utils("/producer/cache")
     consumer_utils = make_utils("/consumer/cache")
-    # make_launcher currently reads NPUUtils once for core counts and once for
-    # the loaded module path.
-    mock_npu_utils.side_effect = [producer_utils, producer_utils, consumer_utils, consumer_utils]
+    mock_npu_utils.side_effect = [producer_utils, consumer_utils]
 
     producer_src = driver.make_launcher(
         constants={},
@@ -198,7 +205,6 @@ def test_make_launcher_enables_91095_simt_for_sls_mixed_parallel_mode(
     _mock_auto_map,
     mock_npu_utils,
 ):
-    """SLS-created indirect ops keep the original mixed-SIMT launch path."""
     mock_npu_utils.return_value.get_aivector_core_num.return_value = 40
     mock_npu_utils.return_value.get_aicore_num.return_value = 20
     metadata = _make_metadata()
@@ -212,9 +218,14 @@ def test_make_launcher_enables_91095_simt_for_sls_mixed_parallel_mode(
         metadata=metadata,
     )
 
-    # Both the ABI and local generated launch paths use the 910_95 SIMT launch
-    # API only when the T2L result advertises SIMT in parallel_mode.
     assert src.count("aclrtLaunchKernelWithHostArgs") == 2
+    assert src.count("aclrtLaunchKernelCfg cfgCfgInfo = {};") == 2
+    assert src.count("attrInfo.id = ACL_RT_LAUNCH_KERNEL_ATTR_DYN_UBUF_SIZE;") == 2
+    c_abi_launch, cpp_launch = _split_launch_functions(src)
+    assert "static_cast<void*>(launch_args.data())" in c_abi_launch
+    assert "&args" in cpp_launch
+    assert "launch_args.size()" in c_abi_launch
+    assert "sizeof(args)" in cpp_launch
 
 
 @patch.object(driver, "NPUUtils")
@@ -229,15 +240,10 @@ def test_make_launcher_block_cap_uses_only_env_and_blacklist(
     _mock_disable_ffts,
     mock_npu_utils,
 ):
-    """The launcher cap is the 895 E && !B contract, independent of Row."""
     mock_npu_utils.return_value.get_aivector_core_num.return_value = 40
     mock_npu_utils.return_value.get_aicore_num.return_value = 20
     cap = "blockNum = std::min(blockNum, (uint32_t)40);"
 
-    # E = TRITON_ALL_BLOCKS_PARALLEL, B = blacklist, R = Row coalescing.
-    # The Row result must not leak into the launcher predicate: only E && !B
-    # controls whether both generated launch paths contain the physical-core
-    # cap.  (O is intentionally absent here; it is a compiler argv option.)
     for env_enabled, blacklisted, row_applied in product((False, True), (False, True), (False, True)):
         metadata = _make_metadata()
         metadata.row_coalescing_applied = row_applied
@@ -254,9 +260,239 @@ def test_make_launcher_block_cap_uses_only_env_and_blacklist(
             )
         case = f"E={env_enabled}, B={blacklisted}, R={row_applied}"
         expected_per_launch_path = 1 if env_enabled and not blacklisted else 0
-        c_abi_launch, cpp_launch = src.split("static void _launch(", maxsplit=1)
+        c_abi_launch, cpp_launch = _split_launch_functions(src)
         assert c_abi_launch.count(cap) == expected_per_launch_path, case
         assert cpp_launch.count(cap) == expected_per_launch_path, case
+
+
+@patch.object(driver, "NPUUtils")
+@patch.object(driver, "_is_auto_map_parallel_blocks_enabled", return_value=False)
+@patch.object(driver, "force_disable_ffts", return_value=False)
+@patch.object(driver, "is_ffts_supported", return_value=True)
+@patch.object(driver, "get_ascend_arch_from_env", return_value="Ascend910B")
+@patch.object(driver, "get_backend_func", side_effect=_mock_backend_func)
+def test_merged_code_workspace_allocation_appears_in_both_paths(
+    _mock_backend_func_patch,
+    _mock_arch,
+    _mock_ffts,
+    _mock_disable_ffts,
+    _mock_auto_map,
+    mock_npu_utils,
+):
+    mock_npu_utils.return_value.get_aivector_core_num.return_value = 40
+    mock_npu_utils.return_value.get_aicore_num.return_value = 20
+    metadata = _make_metadata()
+    metadata.workspace_size = 1024
+
+    src = driver.make_launcher(
+        constants={},
+        signature={0: "*fp32", 1: "*fp32"},
+        metadata=metadata,
+    )
+
+    c_abi_launch, cpp_launch = _split_launch_functions(src)
+
+    assert c_abi_launch.count("allocate_memory") == 1
+    assert cpp_launch.count("allocate_memory") == 1
+    assert c_abi_launch.count("workspace_handle_guard") == 1
+    assert cpp_launch.count("workspace_handle_guard") == 1
+
+
+@patch.object(driver, "NPUUtils")
+@patch.object(driver, "_is_auto_map_parallel_blocks_enabled", return_value=False)
+@patch.object(driver, "force_disable_ffts", return_value=False)
+@patch.object(driver, "is_ffts_supported", return_value=True)
+@patch.object(driver, "get_ascend_arch_from_env", return_value="Ascend910B")
+@patch.object(driver, "get_backend_func", side_effect=_mock_backend_func)
+def test_merged_code_sync_block_lock_appears_in_both_paths(
+    _mock_backend_func_patch,
+    _mock_arch,
+    _mock_ffts,
+    _mock_disable_ffts,
+    _mock_auto_map,
+    mock_npu_utils,
+):
+    mock_npu_utils.return_value.get_aivector_core_num.return_value = 40
+    mock_npu_utils.return_value.get_aicore_num.return_value = 20
+    metadata = _make_metadata()
+    metadata.lock_num = 2
+
+    src = driver.make_launcher(
+        constants={},
+        signature={0: "*fp32", 1: "*fp32"},
+        metadata=metadata,
+    )
+
+    c_abi_launch, cpp_launch = _split_launch_functions(src)
+
+    assert c_abi_launch.count("/* allocate_sync_block_lock: ('syncBlockLockSize', 'stream') */") == 1
+    assert cpp_launch.count("/* allocate_sync_block_lock: ('syncBlockLockSize', 'stream') */") == 1
+    assert c_abi_launch.count("syncBlockLock_handle_guard") == 1
+    assert cpp_launch.count("syncBlockLock_handle_guard") == 1
+
+
+@patch.object(driver, "NPUUtils")
+@patch.object(driver, "_is_auto_map_parallel_blocks_enabled", return_value=False)
+@patch.object(driver, "force_disable_ffts", return_value=False)
+@patch.object(driver, "is_ffts_supported", return_value=True)
+@patch.object(driver, "get_ascend_arch_from_env", return_value="Ascend910B")
+@patch.object(driver, "get_backend_func", side_effect=_mock_backend_func)
+def test_merged_code_msprof_calls_in_both_paths(
+    _mock_backend_func_patch,
+    _mock_arch,
+    _mock_ffts,
+    _mock_disable_ffts,
+    _mock_auto_map,
+    mock_npu_utils,
+):
+    mock_npu_utils.return_value.get_aivector_core_num.return_value = 40
+    mock_npu_utils.return_value.get_aicore_num.return_value = 20
+
+    src = driver.make_launcher(
+        constants={},
+        signature={0: "*fp32"},
+        metadata=_make_metadata(),
+    )
+
+    c_abi_launch, cpp_launch = _split_launch_functions(src)
+
+    assert c_abi_launch.count("beginTime = MsprofSysCycleTime();") == 1
+    assert cpp_launch.count("beginTime = MsprofSysCycleTime();") == 1
+    assert c_abi_launch.count("MsprofReportApi(false, &info);") == 1
+    assert cpp_launch.count("MsprofReportApi(false, &info);") == 1
+
+
+@patch.object(driver, "NPUUtils")
+@patch.object(driver, "_is_auto_map_parallel_blocks_enabled", return_value=False)
+@patch.object(driver, "force_disable_ffts", return_value=False)
+@patch.object(driver, "is_ffts_supported", return_value=True)
+@patch.object(driver, "get_ascend_arch_from_env", return_value="Ascend910B")
+@patch.object(driver, "get_backend_func", side_effect=_mock_backend_func)
+def test_merged_code_preamble_shared_variables_present(
+    _mock_backend_func_patch,
+    _mock_arch,
+    _mock_ffts,
+    _mock_disable_ffts,
+    _mock_auto_map,
+    mock_npu_utils,
+):
+    mock_npu_utils.return_value.get_aivector_core_num.return_value = 40
+    mock_npu_utils.return_value.get_aicore_num.return_value = 20
+
+    src = driver.make_launcher(
+        constants={},
+        signature={0: "*fp32", 1: "*fp32", 2: "i32"},
+        metadata=_make_metadata(),
+    )
+
+    c_abi_launch, cpp_launch = _split_launch_functions(src)
+
+    for section_name, section in [("triton_launch_kernel", c_abi_launch), ("_launch", cpp_launch)]:
+        assert "void* workspace_addr_ptr = nullptr;" in section, f"{section_name}: missing workspace_addr_ptr"
+        assert "void* workspace_handle = nullptr;" in section, f"{section_name}: missing workspace_handle"
+        assert "uint32_t blockNum4Workspace = gridX * gridY * gridZ;" in section, f"{section_name}: missing blockNum4Workspace"
+        assert "uint32_t blockNum = gridX * gridY * gridZ;" in section, f"{section_name}: missing blockNum"
+        assert "aclError ret = ACL_SUCCESS;" in section, f"{section_name}: missing ret"
+
+
+@patch.object(driver, "NPUUtils")
+@patch.object(driver, "_is_auto_map_parallel_blocks_enabled", return_value=True)
+@patch.object(driver, "force_disable_ffts", return_value=False)
+@patch.object(driver, "is_ffts_supported", return_value=True)
+@patch.object(driver, "get_ascend_arch_from_env", return_value="Ascend910B")
+@patch.object(driver, "get_backend_func", side_effect=_mock_backend_func)
+def test_merged_code_taskqueue_mode_in_both_paths(
+    _mock_backend_func_patch,
+    _mock_arch,
+    _mock_ffts,
+    _mock_disable_ffts,
+    _mock_auto_map,
+    mock_npu_utils,
+):
+    mock_npu_utils.return_value.get_aivector_core_num.return_value = 40
+    mock_npu_utils.return_value.get_aicore_num.return_value = 20
+
+    src = driver.make_launcher(
+        constants={},
+        signature={0: "*fp32"},
+        metadata=_make_metadata(),
+    )
+
+    c_abi_launch, cpp_launch = _split_launch_functions(src)
+
+    assert c_abi_launch.count("std::function<aclError()> launch_call") == 1
+    assert cpp_launch.count("std::function<aclError()> launch_call") == 1
+    # The dlsym helpers in cpp_npu_utils_dlopen reference "async_launch" multiple
+    # times (typedef, static decl, dlsym). Use the call site marker returned by
+    # the mocked get_backend_func to verify the actual call appears in both paths.
+    assert c_abi_launch.count("/* async_launch: ('launch_call',) */") == 1
+    assert cpp_launch.count("/* async_launch: ('launch_call',) */") == 1
+    assert c_abi_launch.count("return ret;") >= 1
+    assert cpp_launch.count("return ret;") >= 1
+
+
+@patch.object(driver, "NPUUtils")
+@patch.object(driver, "_is_auto_map_parallel_blocks_enabled", return_value=False)
+@patch.object(driver, "force_disable_ffts", return_value=False)
+@patch.object(driver, "is_ffts_supported", return_value=True)
+@patch.object(driver, "get_ascend_arch_from_env", return_value="Ascend910B")
+@patch.object(driver, "get_backend_func", side_effect=_mock_backend_func)
+def test_merged_code_grid_warning_in_both_paths(
+    _mock_backend_func_patch,
+    _mock_arch,
+    _mock_ffts,
+    _mock_disable_ffts,
+    _mock_auto_map,
+    mock_npu_utils,
+):
+    mock_npu_utils.return_value.get_aivector_core_num.return_value = 40
+    mock_npu_utils.return_value.get_aicore_num.return_value = 20
+
+    with patch.dict("os.environ", {"TRITON_GRID_WARN_PRINT": "true"}):
+        src = driver.make_launcher(
+            constants={},
+            signature={0: "*fp32", 1: "*fp32"},
+            metadata=_make_metadata(),
+        )
+
+    c_abi_launch, cpp_launch = _split_launch_functions(src)
+
+    assert c_abi_launch.count("Grid %u > physical limit") == 1
+    assert cpp_launch.count("Grid %u > physical limit") == 1
+
+
+@patch.object(driver, "NPUUtils")
+@patch.object(driver, "_is_auto_map_parallel_blocks_enabled", return_value=False)
+@patch.object(driver, "force_disable_ffts", return_value=False)
+@patch.object(driver, "is_ffts_supported", return_value=True)
+@patch.object(driver, "get_ascend_arch_from_env", return_value="Ascend910B")
+@patch.object(driver, "get_backend_func", side_effect=_mock_backend_func)
+def test_argument_packing_differs_between_launch_paths(
+    _mock_backend_func_patch,
+    _mock_arch,
+    _mock_ffts,
+    _mock_disable_ffts,
+    _mock_auto_map,
+    mock_npu_utils,
+):
+    mock_npu_utils.return_value.get_aivector_core_num.return_value = 40
+    mock_npu_utils.return_value.get_aicore_num.return_value = 20
+
+    src = driver.make_launcher(
+        constants={},
+        signature={0: "*fp32", 1: "*fp32", 2: "i32"},
+        metadata=_make_metadata(),
+    )
+
+    c_abi_launch, cpp_launch = _split_launch_functions(src)
+
+    assert "static thread_local std::vector<char> launch_args;" in c_abi_launch
+    assert "launch_args.assign(total_size, 0);" in c_abi_launch
+    assert "reserve_slot" in c_abi_launch
+
+    assert "struct __attribute__((packed))" in cpp_launch
+    assert "void* ffts_addr __attribute__((aligned(8)));" in cpp_launch
+    assert "memcpy(launch_args.data()" not in cpp_launch
 
 
 @patch("importlib.util.module_from_spec")

--- a/third_party/ascend/unittest/pytest_ut/test_npu_launcher.py
+++ b/third_party/ascend/unittest/pytest_ut/test_npu_launcher.py
@@ -157,9 +157,9 @@ def test_npu_launcher_skips_global_scratch_for_empty_grid(monkeypatch):
 def test_make_launcher_threads_scratch_through_pure_simt_abi(monkeypatch):
     src = _make_launcher_source(monkeypatch, force_simt_only=True)
 
-    parse = src[src.index("if(!PyArg_ParseTuple("):]
-    assert 'args, "iiiKKOOOOOOO"' in parse
-    _assert_order(parse, "&global_scratch_obj", "&profile_scratch_obj", "&packedMetadata")
+    parse = src[src.index("METH_FASTCALL fast path"):]
+    assert 'launch expects %d arguments, got %zd' in parse
+    _assert_order(parse, "global_scratch_obj = args[5]", "profile_scratch_obj = args[6]", "packedMetadata = args[7]")
 
     conversions = src[src.index("void *global_scratch = 0;"):src.index("// get kernel_name")]
     _assert_order(
@@ -199,8 +199,8 @@ def test_make_launcher_threads_scratch_through_pure_simt_abi(monkeypatch):
 def test_make_launcher_omits_scratch_from_non_simt_device_layout(monkeypatch):
     src = _make_launcher_source(monkeypatch, force_simt_only=False)
 
-    parse = src[src.index("if(!PyArg_ParseTuple("):]
-    _assert_order(parse, "&global_scratch_obj", "&profile_scratch_obj", "&packedMetadata")
+    parse = src[src.index("METH_FASTCALL fast path"):]
+    _assert_order(parse, "global_scratch_obj = args[5]", "profile_scratch_obj = args[6]", "packedMetadata = args[7]")
 
     internal = src[src.index("static void _launch("):]
     struct_start = internal.index("struct __attribute__((packed))")


### PR DESCRIPTION
# Launcher Performance Optimization and Code Combination Design Document #

## Overview ##

Optimize the code structure and content of the launch template to ensure that the code is elegant and maintainable and the performance is improved.

## 1. Extract static code segments. ##

### 1.1 Motivation ###

`make_launcher`Reconstructs a large number of static C++ strings in the function body each time it is called. (device pointer auxiliary function, msprof extern declaration, msprof callback, pre-launch timing code, alignment auxiliary function, tensor shape extraction function, and so on) These strings do not depend on any kernel signature or metadata and are completely unchanged during the process life cycle. However, they are repeatedly spliced into f-strings, resulting in unnecessary string allocation and formatting overhead.

### 1.2 Change Content ###

Move the following 6 static C++ code segments from the`make_launcher`The function body is upgraded to a module-level constant.

 *  `_CPP_DEVICE_POINTER`\:`DevicePtrInfo`Structure and`getPointer()`Auxiliary functions (including interned functions)`"data_ptr"`key optimization)
 *  `_CPP_MSPROF_EXTERN`\: extern "C" declaration of msprof, flag variable,`ProfCtrlHandle`Callback
 *  `_CPP_MSPROF_CALLBACK`\: During module initialization`MsprofRegisterCallback`Invoking
 *  `_CPP_MSPROF_BEFORE_LAUNCH`\: sampling of the cycle time before launch
 *  `_CPP_ALIGN_LAUNCH_OFFSET`\: Inline function for parameter offset alignment.
 *  `_CPP_GET_TENSOR_SHAPE`\: auxiliary function for extracting a shape from the PyObject tensor.

Change the function body to direct reference:

```
cpp_device_pointer = _CPP_DEVICE_POINTER
cpp_msprof_extern = _CPP_MSPROF_EXTERN
cpp_msprof_callback = _CPP_MSPROF_CALLBACK
cpp_msprof_call_before_launch = _CPP_MSPROF_BEFORE_LAUNCH
```

### 1.3 Dead Code Deletion ###

Remove 4 variables that were never referenced by C++ templates after calculation:

 *  `launch_signature_items`
 *  `launch_arg_count`
 *  `launch_arg_ptrs`
 *  `launch_arg_sizes`

### 1.4 Combining NPUUtils Single Instances ###

In the original code`make_launcher`Internally called twice`NPUUtils()`\: Obtains the number of cores at one time, and reads the number of cores at the other time.`npu_utils_mod.__file__`. Due to the`NPUUtils.__new__`A singleton is implemented, and the second instantiation does not recompile.`.so`, but it will still be repeated`__init__`The importlib spec creation and module loading in are combined into one.`npu_utils = NPUUtils()`Directly reused after invoking.

--------------------

## 2. Launch hot path performance optimization ##

### 2.1 Zero copy kernel parameter transfer ###

**Before the optimization:**`triton_launch_kernel`Put each`kernel_args[arg_idx]`Copy to a separate`std::vector<char>`(`copied_kernel_args`), and then after packing to`launch_args`Perform memcpy again. Each parameter generates one heap allocation + two memcpy.

**After optimization: deleted**`copied_kernel_args`, directly from the`kernel_args[arg_idx]`memcpy to the final thread_local continuous buffer.

**Security:**`triton_async_launch()`(See`npu_utils.cpp`) Synchronous execution on the caller thread`launch_call`lambda (via`OpCommand::Run`), so the caller provides the`kernel_args`/`arg_sizes`The pointer is valid throughout the lambda life cycle. This assumption is explicitly recorded in the comments in the generated code.

### 2.2 Multiplexing of the thread_local launch parameter buffer ###

**Before optimization: A new is constructed each time the launch is launched.**`std::vector<char> launch_args(total_size, 0)`to trigger heap allocation and initialization.

**After optimization:**

```
static thread_local std::vector<char> launch_args;
launch_args.assign(total_size, 0);
```

`assign()`Memory is reused when the existing capacity is sufficient, and is reallocated only when the parameter size increases.`triton_async_launch`Synchronous execution. The thread_local does not have cross-thread life cycle issues.

### 2.3 Replace METHOD_VARARGS with METHOD_FASTCALL. ###

Python launcher extension module`launch`Entrance from`METH_VARARGS`Switch to`METH_FASTCALL`\:

 *  Avoids the overhead of constructing temporary tuples for location parameters at the Python call layer.
 *  Manually Parse Parameters (Direct Index)`args[i]`), skip`PyArg_ParseTuple`Format String Interpreter for
 *  Pointer parameter usage`reinterpret_cast<...>(PyLong_AsUnsignedLongLong(...))`, borrow reference semantics and`"O"`Consistent format

### 2.4 Interned dict key ###

`packedMetadata`Dictionary lookup from`PyDict_GetItemString`(Each call constructs a temporary`PyUnicode`) Use the static interned string in the function instead:

```
static PyObject* key_kernel_name = PyUnicode_InternFromString("kernel_name");
PyObject* kernelNameObj = PyDict_GetItemWithError(packedMetadata, key_kernel_name);
```

`tensor_kinds`The key is processed in the same way. Also, use`PyDict_GetItemWithError`In addition, the KeyError is set when the key is missing, which fixes the silently ignored error in the original implementation.

### 2.5 FFTS Address Query Encapsulation ###

The original code directly invokes the deprecated`aclrtGetHardwareSyncAddr`. After the optimization, the operation is passed.`get_backend_func("get_ffts_addr", ...)`Indirect invoking, and obtaining the FFTS address is unified as follows:

```
void* ffts_addr = nullptr;
ret = get_ffts_addr(stream, &ffts_addr);
```

This allows the FFTS implementation to replace at the backend adaptation layer, while allowing extension points for subsequent caches of FFTS addresses (to avoid system calls every launch).

### 2.6 Returning an Empty Grid in Advance ###

Empty grid protection is added to the two launch paths.

```
if (gridX <= 0 || gridY <= 0 || gridZ <= 0) {
  printf("WARNING: Skipping launch ...\n");
  return;
}
```

Do not trigger meaningless workspace allocation and kernel invoking when the grid is compressed to 0 by coalescing or other compile-time transformations.

### 2.7 Other Improvements ###

 *  Use C++11`nullptr`Replace`NULL`
 *  Uniform pointer declaration style (`Type* ptr`Instead of`Type *ptr`)
 *  Uniform brace indentation style
 *  `PyModuleDef`Used by sentinel`nullptr`
 *  This interface is invoked during module initialization.`init_npu_utils()`Moved dlsym queries such as g_async_launch from the per-call path to one-time initialization.
 *  The return value after the hook function is invoked is correct.`Py_DECREF`(Original code leaks hook return value reference)
 *  `tensorKinds`Parsing time`Py_DECREF(kind)`Fix sequence item reference leaks

--------------------

## 3. Duplicate code of triton_launch_kernel and _launch is merged. ##

### 3.1 Analysis of Duplicate Codes ###

The two launch functions differ in the parameter packaging mode.

| Aspects                  | triton_launch_kernel (C ABI)                                             | _launch (local Python)                                                               |
| ------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
| Parameter Source         | `const void* const* kernel_args`\+`arg_sizes`Runtime array               | Named C++ parameters known at compile time`arg0, arg1, ...`                          |
| Parameter Package        | thread_local`std::vector<char>`\+ Runtime alignment calculation + memcpy | `struct __attribute__((packed))`Compilation-time layout + aggregation initialization |
| Kernel launch parameters | `launch_args.data(), launch_args.size()`                                 | `&args, sizeof(args)`                                                                |
| Application Scenario     | External ABI stable path, supporting the number of dynamic parameters    | Python launcher directly invokes the call, with zero overhead.                       |

The logic of the two functions is the same before the parameter packaging and after the kernel launch function is invoked, including:

1.  workspace pointer declaration, grid coalescing,`blockNum4Workspace`, pre_launch (first time), workspace memory allocation, and RAII guard
2.  start lambda, pre_launch (second time),`blockNum`Calculation, grid threshold-crossing warning printing, auto-map block cap,`mixBlockNumRation`/`nodeBasicBlockDim`1. Enable the device print tunnel, query the FFTS address, and allocate and initialize the sync block lock.
3.  Timing before and after msprof, device print tunnel disabling, stream synchronization/taskqueue return, and async_launch invoking

### 3.2 Three-Segment Sharing Template Design ###

In the`make_launcher`Extract three f-string templates internally:

#### `_launch_preamble` ####

Located on top of the function body, outside the lambda:

```
_launch_preamble = f"""
  void* workspace_addr_ptr = nullptr;
  void* workspace_handle = nullptr;
  {coalesce_grid_div}
  uint32_t blockNum4Workspace = gridX * gridY * gridZ;
  {get_backend_func("pre_launch", True)}
  {workspace 分配块（条件）}"""
```

#### `_launch_lambda_pre` ####

At the beginning of lambda, before the parameter packing:

```
_launch_lambda_pre = f"""  {lambda 头 if taskqueue} {{
    {get_backend_func("pre_launch", False)}
    uint32_t blockNum = gridX * gridY * gridZ;
    {grid 警告 #ifdef block}
    {auto-map cap 条件}
    uint32_t mixBlockNumRation = {mix_block_dim_ratio};
    uint32_t nodeBasicBlockDim = (mixBlockNumRation << 16) + blockNum;
    {device print Open 条件}
    aclError ret = ACL_SUCCESS;
    {FFTS 查询 条件}
    {sync block lock 分配块（条件）}
    {workspace ret 检查 条件}"""
```

#### `_launch_lambda_post` ####

After the parameter package, end lambda:

```
_launch_lambda_post = f"""
    {cpp_msprof_call_before_launch}
    __KERNEL_LAUNCH_CALL__
    {device print Close 条件}
    {cpp_msprof_call_after_launch}
    {return ret if taskqueue else aclrtSynchronizeStream}
  }};
  {async_launch 调用 if taskqueue}
  return;
}}"""
```

### 3.3 Differentiation Injection ###

`__KERNEL_LAUNCH_CALL__`Placeholder passes through the final f-string assembly`.replace()`Inject the unique kernel launch call of each function.

```
#triton_launch_kernel
{_launch_lambda_post.replace('__KERNEL_LAUNCH_CALL__', cpp_kernel_launch)}

#_launch Path
{_launch_lambda_post.replace('__KERNEL_LAUNCH_CALL__', cpp_kernel_launch_local)}
```

The unique logic of the two functions remains in place:

 *  `triton_launch_kernel`Tensor shape/kinds parsing`launch_arg_sizes`Construction,`reserve_slot`lambda, thread_local buffer allocation and memcpy
 *  `_launch`\: Packed struct definition and aggregation initialization

### 3.4 Kernel launch Invoking and Constructing Auxiliary Functions ###

Later, further`cpp_kernel_launch`It's different from the`cpp_kernel_launch_local`The construct of is merged into an internal helper function:

```
def _make_kernel_launch(args_ptr, args_size, indent="    "):
    cfg = "&cfgCfgInfo" if (compile_on_910_95 and enable_simt) else "nullptr"
    cfg_setup = ...  #91095 SIMT Dynamic UBUF Configuration (Conditional)
    return f"""{cfg_setup}{indent}ret = aclrtLaunchKernelWithHostArgs(
        func, blockNum, stream, {cfg}, {args_ptr}, {args_size}, nullptr, 0);
"""
```

By parameterizing`args_ptr`(`launch_args.data()`vs`&args`),`args_size`(`launch_args.size()`vs`sizeof(args)`) and indent level, eliminating the common/SIMT configuration x two paths in a total of four segments duplicated.`aclrtLaunchKernelWithHostArgs`Invoke the template.

### 3.5 Changes in the Code Quantity ###

 *  Eliminate about 70 duplicate lines of C++ code templates (Python f-string level)
 *  The generated C++ source code behavior remains equivalent. The logic, such as workspace, sync lock, msprof, and grid coalescing, appear once in each of the two paths. The consistency is ensured by the shared template.

--------------------

## 4. Test Coverage ##

Test File`test_launcher_export_api.py`Statically generated code validation is provided for the above optimizations. (No NPU hardware or compiled C extensions required to run):

| Test Case                                                           | Verification Content                                                                                                                |
| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
| `test_make_launcher_exposes_triton_launch_kernel`                   | C ABI export signature; confirm None`copied_kernel_args`;Check that the thread_local buffer exists.                                 |
| `test_make_launcher_resolves_npu_utils_from_active_cache_root`      | Source code generation does not depend on the cache_root absolute path (cache key certainty).                                       |
| `test_make_launcher_shrinks_coalesced_grid_for_both_launch_paths`   | The grid coalescing takes effect in both paths.                                                                                     |
| `test_make_launcher_uses_ceil_div_for_row_coalescing`               | In ceil-div mode, coalescing takes effect on both paths.                                                                            |
| `test_make_launcher_enables_91095_simt_for_sls_mixed_parallel_mode` | In 910_95 SIMT mode, cfgCfgInfo is generated correctly in both paths, and the parameter pointer is correct.                         |
| `test_make_launcher_block_cap_uses_only_env_and_blacklist`          | The auto-map block cap function is controlled only by E && !B and is irrelevant to row coalescing. Assert the two paths separately. |
| `test_merged_code_workspace_allocation_appears_in_both_paths`       | The workspace allocation and RAII guard appear once in each path.                                                                   |
| `test_merged_code_sync_block_lock_appears_in_both_paths`            | The sync block lock allocation and guard appear once in both paths.                                                                 |
| `test_merged_code_msprof_calls_in_both_paths`                       | msprof timers occur once in each path                                                                                               |
| `test_merged_code_preamble_shared_variables_present`                | Shared variables such as workspace pointer, blockNum4Workspace, blockNum, and ret are declared in both paths.                       |
| `test_merged_code_taskqueue_mode_in_both_paths`                     | The launch_call/std::function/async_launch in taskqueue mode exists in both paths.                                                  |
| `test_merged_code_grid_warning_in_both_paths`                       | `ENABLE_GRID_WARN_PRINT`Overrun warnings controlled by environment variables exist in both paths                                    |
| `test_argument_packing_differs_between_launch_paths`                | The parameter packing modes of the two paths are unique (thread_local memcpy vs packed struct).                                     |
| `test_npu_launcher_exposes_launcher_so_path`                        | The NPULauncher correctly caches the launcher file and exposes the launcher .so path.                                               |

auxiliary function`_split_launch_functions(src)`Press the`static void _launch(`Divide the generated source code into C ABI segments and local segments, so that each test can assert two paths separately, instead of depending on the global.`src.count()`.

--------------------

## 5. Design Decisions and Trade-Offs ##

### 5.1 Why Two Sets of Parameter Packing Mechanisms Are Retained ###

`triton_launch_kernel`The C ABI path of the requires the number and type of parameters to be determined dynamically at run time (passed in by an external caller).`(void**)`Pointer array), which must be continuous buffer + memcpy.`_launch`The path is directly invoked by the Python extension module in the same compilation unit. The parameter type is known in the codegen. The packed struct can be used with zero extra copy and zero runtime alignment calculation. The two paths are applicable to different scenarios. Forcible unification will compromise the performance of one path.

### 5.2 Why use string .replace() instead of nested f-string ###

`__KERNEL_LAUNCH_CALL__`The placeholder scheme makes`_launch_lambda_post`It can be constructed as a complete f-string just once, and differentiated content injected through simple string substitution. Using nested f-strings or additional format calls increases the cognitive complexity and the brace escape burden of the template. This placeholder is used only in the codegen phase and does not appear in the final generated C++ source code.

### 5.3 Why Not Caching Environment Variables ###

`TRITON_GRID_WARN_PRINT`,`TRITON_ENABLE_TASKQUEUE`,`TRITON_DEVICE_PRINT`Wait for environment variables to be in the`make_launcher`internal read. Although it is theoretically possible to cache to avoid duplicate`os.getenv`, however, these variables may be dynamically modified by users or tests at run time (especially in device print debugging scenarios), and caching can destroy the dynamic switching capability.`make_launcher`It is protected by the Triton compilation cache (the same kernel signature is codegen only once), and repeated.`getenv`The overhead of is negligible.

### 5.4 Zero-copy thread-safe boundary ###

The security of zero copy and thread_local buffer depends on`triton_async_launch`The implementation details of launch_call are executed synchronously. This constraint is explicitly recorded in two places: (1) generated C++ code comments; (2) This document, 2.1. If the future`npu_utils.cpp`Medium`triton_async_launch`To perform lambda asynchronously instead, you need to revert the parameter copy or introduce a synchronous primitive.

--------------------

## 6. List of documents ##

| File                                                                | Change Type                                                                |
| ------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| `third_party/ascend/backend/driver.py`                              | Core Optimization and Code Consolidation                                   |
| `third_party/ascend/backend/backend_register.py`                    | Concomitant submission`4fb2eb73`Small adaptation of                        |
| `third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py` | Test the clearance, deduplication, and new combination verification cases. |

## 7. Optimization effect ##

Take the softmax operator as an example. The /driver.py(202): call (this track) takes about 30% less time.

|                         | Maximum value | Minimum value | Mean   | Median |
| ----------------------- | ------------- | ------------- | ------ | ------ |
| Before the optimization | 139.400       | 62.770        | 78.326 | 65.85  |
| After optimization      | 76.830        | 42.05         | 48.34  | 45.35  |
