### PR TITLE
[TritonToLinalg](fix) skip select canonicalization inside SIMT scope

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -59,6 +59,7 @@
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
 #include "bishengir/Dialect/HFusion/IR/HFusion.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "bishengir/Dialect/Scope/IR/Scope.h"
 
 namespace TTOpConverters {
 using namespace mlir;
@@ -197,9 +198,38 @@ LogicalResult PreciseDivConverter::matchAndRewrite(
   return success();
 }
 
+// Return true if 'op' is enclosed by an explicit SIMT scope
+// (scope::ScopeOp with vector_mode = "simt").
+//
+// The whole ancestor chain is walked, so the scope does NOT need to be the
+// direct parent: 'op' may be nested under intermediate ops (e.g. scf.if /
+// scf.for) inside the scope. Every enclosing scope is inspected too, so a
+// select inside an inner scope that is itself nested in an outer SIMT scope
+// is also rejected.
+static bool isInsideSimtScope(Operation *op) {
+  for (Operation *curr = op->getParentOp(); curr; curr = curr->getParentOp()) {
+    auto scopeOp = dyn_cast<scope::ScopeOp>(curr);
+    if (!scopeOp) {
+      continue;
+    }
+    if (auto vecMode = scopeOp->getAttrOfType<StringAttr>("vector_mode");
+        vecMode && vecMode.getValue() == "simt")
+      return true;
+  }
+  return false;
+}
+
 LogicalResult
 SelectCanonicalizer::matchAndRewrite(arith::SelectOp op,
                                      PatternRewriter &rewriter) const {
+  // Do not rewrite masked selects inside an explicit SIMT scope: the SIMT
+  // lowering path must see the original select, and the extract/insert slice
+  // materialization is a SIMD-side optimization.
+  if (isInsideSimtScope(op)) {
+    return rewriter.notifyMatchFailure(
+        op, "Select inside an explicit SIMT scope is not canonicalized");
+  }
+
   auto loc = op.getLoc();
 
   // 0. Shortcut for scalars and bool type

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/select_in_simt_scope.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/select_in_simt_scope.mlir
@@ -1,0 +1,78 @@
+// RUN: triton-opt --triton-to-linalg="named-ops=True" --split-input-file %s | FileCheck %s
+
+// A masked select inside an explicit SIMT scope must NOT be canonicalized into
+// tensor.extract_slice/tensor.insert_slice: the SIMT lowering path needs the
+// original arith.select.
+//
+// Every select result is consumed by a tt.store: the canonicalizer treats an
+// unused tensor select as dead code and DCEs it (together with its operands),
+// which would empty the function body before the CHECKs run.
+// CHECK-LABEL: func.func @select_in_simt_scope
+// CHECK-SAME: parallel_mode = "mix_simd_simt"
+// CHECK: arith.select
+// CHECK-NOT: tensor.extract_slice
+// CHECK-NOT: tensor.insert_slice
+tt.func public @select_in_simt_scope(%out: !tt.ptr<f32>) {
+  %cst = arith.constant dense<1.000000e+00> : tensor<16xf32>
+  %cst_0 = arith.constant dense<0.000000e+00> : tensor<16xf32>
+  %cst_1 = arith.constant dense<8> : tensor<16xi32>
+  %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %1 = arith.cmpi slt, %0, %cst_1 : tensor<16xi32>
+  %ptrs = tt.splat %out : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+  scope.scope : () -> () {
+    %2 = arith.select %1, %cst, %cst_0 : tensor<16xi1>, tensor<16xf32>
+    tt.store %ptrs, %2 : tensor<16x!tt.ptr<f32>>
+    scope.return
+  } {vector_mode = "simt"}
+  tt.return
+}
+
+// Control: the same select OUTSIDE any SIMT scope is still canonicalized to
+// extract_slice + insert_slice. The extract_slice of a splat operand folds to
+// a linalg.fill, so only the insert_slice materialization is asserted.
+// CHECK-LABEL: func.func @select_outside_scope
+// CHECK-NOT: arith.select
+// CHECK: tensor.insert_slice
+tt.func public @select_outside_scope(%out: !tt.ptr<f32>) {
+  %cst = arith.constant dense<1.000000e+00> : tensor<16xf32>
+  %cst_0 = arith.constant dense<0.000000e+00> : tensor<16xf32>
+  %cst_1 = arith.constant dense<8> : tensor<16xi32>
+  %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %1 = arith.cmpi slt, %0, %cst_1 : tensor<16xi32>
+  %ptrs = tt.splat %out : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+  %2 = arith.select %1, %cst, %cst_0 : tensor<16xi1>, tensor<16xf32>
+  tt.store %ptrs, %2 : tensor<16x!tt.ptr<f32>>
+  tt.return
+}
+
+// Nested case: the select's DIRECT parent is scf.if, not the scope — the scope
+// is an ancestor further up. isInsideSimtScope must still find the SIMT scope
+// through the nesting and leave the select untouched.
+// The scf.if condition is a runtime value (get_program_id) so canonicalization
+// cannot fold the branch away (a constant-true condition would be folded and
+// the CHECK below could never match).
+// CHECK-LABEL: func.func @select_nested_in_simt_scope
+// CHECK-SAME: parallel_mode = "mix_simd_simt"
+// CHECK: scf.if
+// CHECK: arith.select
+// CHECK-NOT: tensor.extract_slice
+tt.func public @select_nested_in_simt_scope(%out: !tt.ptr<f32>) {
+  %cst = arith.constant dense<1.000000e+00> : tensor<16xf32>
+  %cst_0 = arith.constant dense<0.000000e+00> : tensor<16xf32>
+  %cst_1 = arith.constant dense<8> : tensor<16xi32>
+  %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %1 = arith.cmpi slt, %0, %cst_1 : tensor<16xi32>
+  %pid = tt.get_program_id x : i32
+  %c0_i32 = arith.constant 0 : i32
+  %cond = arith.cmpi eq, %pid, %c0_i32 : i32
+  %ptrs = tt.splat %out : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+  scope.scope : () -> () {
+    scf.if %cond {
+      %2 = arith.select %1, %cst, %cst_0 : tensor<16xi1>, tensor<16xf32>
+      tt.store %ptrs, %2 : tensor<16x!tt.ptr<f32>>
+      scf.yield
+    }
+    scope.return
+  } {vector_mode = "simt"}
+  tt.return
+}


### PR DESCRIPTION
The SelectCanonicalizer rewrites masked selects into extract_slice/insert_slice materialization, which is a SIMD-side optimization. Inside an explicit SIMT scope (scope::ScopeOp with vector_mode="simt") the SIMT lowering path must see the original arith.select, so the rewrite is skipped. The ancestor chain is walked, so selects nested under intermediate ops (e.g. scf.if) inside the scope are covered too. Add a lit test with direct, nested, and out-of-scope controls.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
