### PR TITLE
[Autotune](fix) extract packed_metadata from tuple when using @libentry

### DIFF
--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -2265,6 +2265,8 @@ class AutoTilingTuner(Autotuner):
                     *args,
                     **current,
                 )
+                if isinstance(res, tuple):
+                    res = res[0]
                 packed_metadata = getattr(res, "packed_metadata", None)
                 if isinstance(packed_metadata, dict):
                     kernel_call.target_kernel_name = packed_metadata.get("kernel_name")

--- a/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
+++ b/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
@@ -1637,3 +1637,52 @@ def test_inject_grid_num_tiles_uses_only_static_grid_and_preserves_explicit_valu
     explicit_hint = {"grid": (2, 16), "grid_num_tiles": 99}
     inject_grid_num_tiles(explicit_hint)
     assert explicit_hint["grid_num_tiles"] == 99
+
+
+def test_make_kernel_call_extracts_name_from_jit_run():
+    namespace = _load_autotuner_methods("_make_kernel_call")
+    _make_kernel_call = _normalize_loaded_method(namespace["_make_kernel_call"])
+
+    @triton.jit
+    def test_kernel_jit(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+        pid = tl.program_id(0)
+        offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        x = tl.load(x_ptr + offsets, mask=mask)
+        tl.store(x_ptr + offsets, x, mask=mask)
+
+    fake_self = SimpleNamespace(fn=test_kernel_jit, pre_hook=lambda full_nargs: None,
+                                post_hook=lambda full_nargs, exception=None: None, nargs={})
+    fake_config = SimpleNamespace(kwargs={"BLOCK_SIZE": 32}, all_kwargs=lambda: {"BLOCK_SIZE": 32}, pre_hook=None)
+
+    x = torch.zeros(128, dtype=torch.float32, device="npu")
+    kernel_call_closure = _make_kernel_call(fake_self, x, x.numel(), config=fake_config, grid=(1, ))
+    kernel_call_closure(warmup=False)
+
+    assert kernel_call_closure.target_kernel_name == "test_kernel_jit"
+
+
+def test_make_kernel_call_extracts_name_from_libentry_tuple():
+    namespace = _load_autotuner_methods("_make_kernel_call")
+    _make_kernel_call = _normalize_loaded_method(namespace["_make_kernel_call"])
+
+    from triton.runtime.libentry import libentry
+
+    @libentry()
+    @triton.jit
+    def test_kernel_libentry(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+        pid = tl.program_id(0)
+        offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        x = tl.load(x_ptr + offsets, mask=mask)
+        tl.store(x_ptr + offsets, x, mask=mask)
+
+    fake_self = SimpleNamespace(fn=test_kernel_libentry, pre_hook=lambda full_nargs: None,
+                                post_hook=lambda full_nargs, exception=None: None, nargs={})
+    fake_config = SimpleNamespace(kwargs={"BLOCK_SIZE": 32}, all_kwargs=lambda: {"BLOCK_SIZE": 32}, pre_hook=None)
+
+    x = torch.zeros(128, dtype=torch.float32, device="npu")
+    kernel_call_closure = _make_kernel_call(fake_self, x, x.numel(), config=fake_config, grid=(1, ))
+    kernel_call_closure(warmup=False)
+
+    assert kernel_call_closure.target_kernel_name == "test_kernel_libentry"


### PR DESCRIPTION
Background:
Autotuner._make_kernel_call attempts to extract packed_metadata from the return value of self.fn.run() to get the kernel_name.

Root Cause:
When a kernel is decorated with @libentry(), the call chain becomes Autotuner -> LibEntry -> JITFunction. To pass additional info like constexprs, the LibEntry.run() method wraps its return value into a tuple: (CompiledKernel, constexprs).
The old code directly called getattr(res, "packed_metadata", None) on this tuple. Since tuples do not have this attribute, it returned None, causing the Autotuner to fail to capture the target kernel name.

Solution:
Add a type check before accessing the attribute. If res is a tuple, extract the first element (the CompiledKernel object) before fetching packed_metadata. This approach safely handles all return types: tuples from @libentry, raw CompiledKernel objects, and FutureKernel during async compilation.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
