### PR TITLE
[ssbuffer](fix) Simple L0C->L0C support

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
@@ -57,7 +57,7 @@ using namespace mlir;
 using namespace triton;
 using namespace CVPipeline;
 
-static constexpr const char *DEBUG_TYPE = "PlanCubeBlock";
+static constexpr const char *DEBUG_TYPE = "plan-cube-block";
 #define LOG_DEBUG(...)                                                         \
   LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__)
 
@@ -400,10 +400,21 @@ static bool checkValidInputSeed(Operation *op) {
              tensor::EmptyOp, linalg::BroadcastOp, tensor::ExpandShapeOp,
              arith::ExtFOp>(op);
 }
-static bool checkValidUserSeed(Operation *op) {
+static bool checkValidUserSeed(Operation *op, linalg::MatmulOp &preDot) {
   // keep unify to OpClassifer
-  return isa<hivm::StoreOp, bufferization::MaterializeInDestinationOp,
-             ViewLikeOpInterface, tensor::ExtractSliceOp>(op);
+  if (isa<hivm::StoreOp, bufferization::MaterializeInDestinationOp,
+          ViewLikeOpInterface, tensor::ExtractSliceOp>(op)) {
+    return true;
+  }
+  // add matmul link by L0C
+  if (auto nextDot = dyn_cast<linalg::MatmulOp>(op)) {
+    if (nextDot.getDpsInits()[0] == *preDot->getResults().begin()) {
+      preDot = nextDot;
+      return true;
+    }
+    return false;
+  }
+  return false;
 }
 
 static SmallVector<Operation *>
@@ -425,13 +436,14 @@ matchSeed(Operation *dotOp, ComputeBlockIdManager &bm,
   }
   // match outputs
   Operation *nowOp = dotOp;
+  linalg::MatmulOp linkMatmul = llvm::dyn_cast<linalg::MatmulOp>(dotOp);
   while (nowOp->hasOneUse()) {
     auto user = *nowOp->getUsers().begin();
     if (user->getBlock() != dotOp->getBlock() || !isCubeSimpleOpOrCf(user) ||
         bm.getBlockIdByOp(user) != -1) {
       break;
     }
-    if (checkValidUserSeed(user)) {
+    if (checkValidUserSeed(user, linkMatmul)) {
       nowOp = user;
       ret.push_back(user);
     } else {

--- a/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/StandardizeOp/SplitMatmulPattern.cpp
@@ -492,12 +492,12 @@ static bool shouldSplitByInput(linalg::MatmulOp matmulOp, Value &outerOutValue,
   }
 
   auto broadcastOp = dyn_cast<linalg::BroadcastOp>(outerInOp);
-  if (!broadcastOp)
-    return true;
-  if (auto btUsage = CVPipeline::getBTSizeFromValidBroadcastOp(broadcastOp)) {
-    if (btUsage != -1 && btUsage <= CVPipeline::CACHE_TABLE_BUFFER_SIZE) {
-      LOG_DEBUG("Not split because broadcast bias is small. " << matmulOp);
-      return false;
+  if (broadcastOp) {
+    if (auto btUsage = CVPipeline::getBTSizeFromValidBroadcastOp(broadcastOp)) {
+      if (btUsage != -1 && btUsage <= CVPipeline::CACHE_TABLE_BUFFER_SIZE) {
+        LOG_DEBUG("Not split because broadcast bias is small. " << matmulOp);
+        return false;
+      }
     }
   }
 
@@ -507,7 +507,6 @@ static bool shouldSplitByInput(linalg::MatmulOp matmulOp, Value &outerOutValue,
     LOG_DEBUG("Not split because L0C remain. " << matmulOp);
     return false;
   }
-  // from broadcast [N]->[M, N] // S11 S12 S19 S20
   return true;
 }
 


### PR DESCRIPTION

Simple L0C->L0C remain is interupted by broadcast, this PR fix this.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
