### PR TITLE
[OP](feat) commit dotScaled fp4 test case

### DIFF
--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/dotScaled_fp4.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/dotScaled_fp4.mlir
@@ -1,0 +1,60 @@
+// RUN: triton-opt --pass-pipeline="builtin.module(triton-to-unstructure{compile-on-910-95=true force-simt-template=false},triton-to-linalg{compile-on-910-95=true enable-nd2nz-on-vector=false global-kernel=false named-ops=true})" --split-input-file %s | FileCheck %s
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @_dot_scaled_test_fp4(%a_ptr: !tt.ptr<i8>, %a_scale_ptr: !tt.ptr<i8>, %b_ptr: !tt.ptr<i8>, %b_scale_ptr: !tt.ptr<i8>, %c_ptr: !tt.ptr<f32>) attributes {noinline = false} {
+    %cst = arith.constant dense<16> : tensor<16x1xi32>
+    %acc = arith.constant dense<0.000000e+00> : tensor<16x16xf32>
+    %b = arith.constant dense<16> : tensor<32x1xi32>
+    %cst_0 = arith.constant dense<2> : tensor<16x1xi32>
+    %a = arith.constant dense<32> : tensor<16x1xi32>
+    %m_offs = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %k_packed_offs = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %scale_offs = tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32>
+    %a_1 = tt.expand_dims %m_offs {axis = 1 : i32} : tensor<16xi32> -> tensor<16x1xi32>
+    %a_2 = arith.muli %a_1, %a : tensor<16x1xi32>
+    %a_3 = tt.splat %a_ptr : !tt.ptr<i8> -> tensor<16x1x!tt.ptr<i8>>
+    %a_4 = tt.addptr %a_3, %a_2 : tensor<16x1x!tt.ptr<i8>>, tensor<16x1xi32>
+    %a_5 = tt.expand_dims %k_packed_offs {axis = 0 : i32} : tensor<32xi32> -> tensor<1x32xi32>
+    %a_6 = tt.broadcast %a_4 : tensor<16x1x!tt.ptr<i8>> -> tensor<16x32x!tt.ptr<i8>>
+    %a_7 = tt.broadcast %a_5 : tensor<1x32xi32> -> tensor<16x32xi32>
+    %a_8 = tt.addptr %a_6, %a_7 : tensor<16x32x!tt.ptr<i8>>, tensor<16x32xi32>
+    %a_9 = tt.load %a_8 : tensor<16x32x!tt.ptr<i8>>
+    %a_scale = arith.muli %a_1, %cst_0 : tensor<16x1xi32>
+    %a_scale_10 = tt.splat %a_scale_ptr : !tt.ptr<i8> -> tensor<16x1x!tt.ptr<i8>>
+    %a_scale_11 = tt.addptr %a_scale_10, %a_scale : tensor<16x1x!tt.ptr<i8>>, tensor<16x1xi32>
+    %a_scale_12 = tt.expand_dims %scale_offs {axis = 0 : i32} : tensor<2xi32> -> tensor<1x2xi32>
+    %a_scale_13 = tt.broadcast %a_scale_11 : tensor<16x1x!tt.ptr<i8>> -> tensor<16x2x!tt.ptr<i8>>
+    %a_scale_14 = tt.broadcast %a_scale_12 : tensor<1x2xi32> -> tensor<16x2xi32>
+    %a_scale_15 = tt.addptr %a_scale_13, %a_scale_14 : tensor<16x2x!tt.ptr<i8>>, tensor<16x2xi32>
+    %a_scale_16 = tt.load %a_scale_15 : tensor<16x2x!tt.ptr<i8>>
+    %b_17 = tt.expand_dims %k_packed_offs {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+    %b_18 = arith.muli %b_17, %b : tensor<32x1xi32>
+    %b_19 = tt.splat %b_ptr : !tt.ptr<i8> -> tensor<32x1x!tt.ptr<i8>>
+    %b_20 = tt.addptr %b_19, %b_18 : tensor<32x1x!tt.ptr<i8>>, tensor<32x1xi32>
+    %b_21 = tt.expand_dims %m_offs {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+    %b_22 = tt.broadcast %b_20 : tensor<32x1x!tt.ptr<i8>> -> tensor<32x16x!tt.ptr<i8>>
+    %b_23 = tt.broadcast %b_21 : tensor<1x16xi32> -> tensor<32x16xi32>
+    %b_24 = tt.addptr %b_22, %b_23 : tensor<32x16x!tt.ptr<i8>>, tensor<32x16xi32>
+    %b_25 = tt.load %b_24 : tensor<32x16x!tt.ptr<i8>>
+    %b_scale = tt.splat %b_scale_ptr : !tt.ptr<i8> -> tensor<16x1x!tt.ptr<i8>>
+    %b_scale_26 = tt.addptr %b_scale, %a_scale : tensor<16x1x!tt.ptr<i8>>, tensor<16x1xi32>
+    %b_scale_27 = tt.broadcast %b_scale_26 : tensor<16x1x!tt.ptr<i8>> -> tensor<16x2x!tt.ptr<i8>>
+    %b_scale_28 = tt.addptr %b_scale_27, %a_scale_14 : tensor<16x2x!tt.ptr<i8>>, tensor<16x2xi32>
+    %b_scale_29 = tt.load %b_scale_28 : tensor<16x2x!tt.ptr<i8>>
+    %acc_30 = tt.dot_scaled %a_9 scale %a_scale_16, %b_25 scale %b_scale_29, %acc lhs = e2m1 rhs = e2m1 {fastMath = false} : tensor<16x32xi8>, tensor<16x2xi8> * tensor<32x16xi8>, tensor<16x2xi8> -> tensor<16x16xf32>
+    %0 = arith.muli %a_1, %cst : tensor<16x1xi32>
+    %1 = tt.splat %c_ptr : !tt.ptr<f32> -> tensor<16x1x!tt.ptr<f32>>
+    %2 = tt.addptr %1, %0 : tensor<16x1x!tt.ptr<f32>>, tensor<16x1xi32>
+    %3 = tt.broadcast %2 : tensor<16x1x!tt.ptr<f32>> -> tensor<16x16x!tt.ptr<f32>>
+    %4 = tt.broadcast %b_21 : tensor<1x16xi32> -> tensor<16x16xi32>
+    %5 = tt.addptr %3, %4 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+    tt.store %5, %acc_30 : tensor<16x16x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+
+// CHECK-LABEL: func.func @_dot_scaled_test_fp4
+// CHECK: hfusion.matmul_mx
+// CHECK: outs([[OUT:.*]] : tensor<16x16xf32>) -> tensor<16x16xf32>
+// CHECK: bufferization.materialize_in_destination

--- a/third_party/ascend/unittest/pytest_ut/test_common.py
+++ b/third_party/ascend/unittest/pytest_ut/test_common.py
@@ -67,7 +67,7 @@ def generate_tensor(shape, dtype):
         raise ValueError('Invalid parameter \"dtype\" is found : {}'.format(dtype))
 
 
-def generate_tensor_fp4_fp8(
+def generate_tensor_fp8(
         shape, dtype, seed=None, data_range=None,
         special_ratio=0.05,  # Ratio of inf/-inf/nan values (only takes effect when dtype is float type)
         precision_ratio=0.35,  # Ratio of precision small floats (only takes effect when dtype is float type)
@@ -79,28 +79,24 @@ def generate_tensor_fp4_fp8(
         'fp8e4m3': [-50, 50],
         'fp8e5m2': [-500, 500],
         'fp8e5b16': [-500, 500],
-        'fp4': [-6, 6],
     }
 
     float_precision_dict = {
         'fp8e4m3': [-1, 1],
         'fp8e5m2': [-1, 1],
         'fp8e5b16': [-1, 1],
-        'fp4': [-2, 2],
     }
 
     extreme_range_dict = {
         'fp8e4m3': [-448, 448],
         'fp8e5m2': [-57344, 57344],
         'fp8e5b16': [-57344, 57344],
-        'fp4': [-6, 6],
     }
 
     ddtype_dict = {
         'fp8e4m3': torch.float8_e4m3fn,
         'fp8e5m2': torch.float8_e5m2,
         'fp8e5b16': None,
-        'fp4': None,
     }
 
     if seed is not None:
@@ -113,12 +109,8 @@ def generate_tensor_fp4_fp8(
     min_val, max_val = extreme_range_dict[dtype]
     total = np.prod(shape)
 
-    if dtype == 'fp4':
-        left_range = (min_val, min_val + 1)
-        right_range = (max_val - 1, max_val)
-    else:
-        left_range = (min_val, min_val + 10)
-        right_range = (max_val - 10, max_val)
+    left_range = (min_val, min_val + 10)
+    right_range = (max_val - 10, max_val)
 
     if data_range == None:
         mid_range = middle_range_dict[dtype]

--- a/third_party/ascend/unittest/pytest_ut/test_dot_scaled_fp4_fp8.py
+++ b/third_party/ascend/unittest/pytest_ut/test_dot_scaled_fp4_fp8.py
@@ -93,15 +93,15 @@ testlist = [
 @pytest.mark.skipif(not is_compile_on_910_95(), reason="only support in A5")
 @pytest.mark.parametrize("dtype", ["fp8e4m3", "fp8e5m2"])
 @pytest.mark.parametrize("M, N, K", testlist)
-def test_2D_scaled_dot_chain(M, N, K, dtype):
+def test_scaled_dot_fp8(M, N, K, dtype):
     if not ub_overflow_check(M, N, K):
         pytest.skip("UB overflow")
 
     lhs_format = dtype[3:]
     rhs_format = lhs_format
 
-    lhs = test_common.generate_tensor_fp4_fp8(shape=(M, K), dtype=dtype).npu()
-    rhs = test_common.generate_tensor_fp4_fp8(shape=(K, N), dtype=dtype).npu()
+    lhs = test_common.generate_tensor_fp8(shape=(M, K), dtype=dtype).npu()
+    rhs = test_common.generate_tensor_fp8(shape=(K, N), dtype=dtype).npu()
     lhs_scale = torch.randint(low=110, high=128, size=(M, K // 32), dtype=torch.int8).npu()
     rhs_scale = torch.randint(low=110, high=128, size=(N, K // 32), dtype=torch.int8).npu()
 
@@ -120,3 +120,85 @@ def test_2D_scaled_dot_chain(M, N, K, dtype):
         torch.testing.assert_close(triton_res.cpu(), torch_ref.cpu(), rtol=125e-03, atol=125e-03, equal_nan=True)
     elif dtype == "fp8e5m2":
         torch.testing.assert_close(triton_res.cpu(), torch_ref.cpu(), rtol=75e-02, atol=75e-02, equal_nan=True)
+
+
+@triton.jit
+def _dot_scaled_test_fp4(
+    a_ptr,
+    a_scale_ptr,
+    b_ptr,
+    b_scale_ptr,
+    c_ptr,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    K_PACKED: tl.constexpr,
+    K_SCALE: tl.constexpr,
+):
+    # A: [M, K_PACKED] uint8 (packed e2m1), scale [M, K_SCALE] uint8 e8m0
+    # B: [K_PACKED, N] uint8 (packed e2m1), scale [N, K_SCALE] uint8 e8m0
+    # note: rhs is [K, N] not [N, K] for dot_scaled
+    m_offs = tl.arange(0, M)
+    n_offs = tl.arange(0, N)
+    k_packed_offs = tl.arange(0, K_PACKED)
+    scale_offs = tl.arange(0, K_SCALE)
+
+    a = tl.load(a_ptr + m_offs[:, None] * K_PACKED + k_packed_offs[None, :])
+    a_scale = tl.load(a_scale_ptr + m_offs[:, None] * K_SCALE + scale_offs[None, :])
+
+    b = tl.load(b_ptr + k_packed_offs[:, None] * N + n_offs[None, :])
+    b_scale = tl.load(b_scale_ptr + n_offs[:, None] * K_SCALE + scale_offs[None, :])
+
+    acc = tl.dot_scaled(a, a_scale, "e2m1", b, b_scale, "e2m1")
+
+    tl.store(c_ptr + m_offs[:, None] * N + n_offs[None, :], acc)
+
+
+def dequant_e2m1(packed_uint8, scale_uint8, rows, K):
+    """Reference dequant for verification."""
+    vals = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
+                        device=packed_uint8.device, dtype=torch.float32)
+    low = vals[(packed_uint8 & 0x0F).long()]
+    high = vals[((packed_uint8 >> 4) & 0x0F).long()]
+    out = torch.zeros(rows, K, device=packed_uint8.device, dtype=torch.float32)
+    out[:, 0::2] = low
+    out[:, 1::2] = high
+    scale_f = torch.pow(2.0, scale_uint8.float() - 127.0)
+    scale_expanded = scale_f.repeat_interleave(32, dim=1)[:, :K]
+    return out * scale_expanded
+
+
+@pytest.mark.skip(reason="to be supported in A5")
+def test_dot_scaled_fp4():
+    M, N, K = 16, 16, 64
+    K_PACKED = K // 2
+    K_SCALE = K // 32
+
+    a_packed = torch.randint(0, 256, (M, K_PACKED), device='npu', dtype=torch.uint8)
+    a_scale = torch.full((M, K_SCALE), 127, device='npu', dtype=torch.uint8)
+
+    # B for dot_scaled: [K_PACKED, N] (K-major)
+    b_packed_nk = torch.randint(0, 256, (N, K_PACKED), device='npu', dtype=torch.uint8)
+    b_packed_kn = b_packed_nk.t().contiguous()  # [K_PACKED, N]
+    b_scale = torch.full((N, K_SCALE), 127, device='npu', dtype=torch.uint8)
+
+    c = torch.empty(M, N, device='npu', dtype=torch.float32)
+
+    _dot_scaled_test_fp4[(1, )](
+        a_packed,
+        a_scale,
+        b_packed_kn,
+        b_scale,
+        c,
+        M,
+        N,
+        K,
+        K_PACKED,
+        K_SCALE,
+    )
+
+    # Reference
+    a_deq = dequant_e2m1(a_packed, a_scale, M, K)
+    b_deq = dequant_e2m1(b_packed_nk, b_scale, N, K)
+    ref = a_deq @ b_deq.t()
+    torch.testing.assert_close(c, ref)


### PR DESCRIPTION
This pr commit fp4 case which has been run successfully on GPU, and skip due to not support on npuir now, in order to verify this func on Triton-Ascend, we add a mlir case.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
