### PR TITLE
[Autotune](fix) Resolve conflict between ubtuner and autotune cache

### DIFF
--- a/third_party/ascend/backend/runtime/__init__.py
+++ b/third_party/ascend/backend/runtime/__init__.py
@@ -18,6 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+import os
+
 from .autotuner import get_max_configs, max_autotune
 
 
@@ -32,4 +34,50 @@ def _patch_autotune():
     triton.autotune = autotune
 
 
+def _patch_config_init():
+    """Allow Config to round-trip the ubtune_cfg attribute through the disk cache.
+
+    UB-tuner dynamically injects ubtune_cfg onto Config objects via setattr to
+    fix UB-overflow compile failures. The disk cache serializes config.__dict__
+    to JSON, and on cache hit rebuilds configs with Config(**config_dict).
+    The upstream Config.__init__ does not accept ubtune_cfg, so the attribute
+    would be lost (or crash) on a disk-cache round-trip. This patch restores it.
+    """
+    from triton.runtime.autotuner import Config
+
+    _original_config_init = Config.__init__
+
+    def _patched_config_init(self, kwargs, num_warps=4, num_stages=3, num_ctas=1, maxnreg=None, pre_hook=None,
+                             ir_override=None, **extra):
+        _original_config_init(self, kwargs, num_warps, num_stages, num_ctas, maxnreg, pre_hook, ir_override)
+        if "ubtune_cfg" in extra:
+            setattr(self, "ubtune_cfg", extra["ubtune_cfg"])
+
+    Config.__init__ = _patched_config_init
+
+
+def _patch_cache_invalidating_env_vars():
+    """Include TRITON_ENABLE_UBTUNER in the autotune disk cache key.
+
+    UB-tuner may rescue configs that would otherwise fail to compile, changing
+    the benchmark outcome. Toggling it must therefore invalidate cached
+    autotune results; otherwise a cache hit from a run without UB-tuner would
+    silently skip configs that UB-tuner could have rescued.
+    """
+    import triton.runtime.autotuner as _autotuner_module
+
+    _original_get_env_vars = _autotuner_module.get_cache_invalidating_env_vars
+
+    def _patched_get_env_vars():
+        env_vars = _original_get_env_vars()
+        ubtuner_mode = os.environ.get("TRITON_ENABLE_UBTUNER", "")
+        if ubtuner_mode:
+            env_vars["TRITON_ENABLE_UBTUNER"] = ubtuner_mode
+        return env_vars
+
+    _autotuner_module.get_cache_invalidating_env_vars = _patched_get_env_vars
+
+
 _patch_autotune()
+_patch_config_init()
+_patch_cache_invalidating_env_vars()

--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -2067,18 +2067,7 @@ class AutoTilingTuner(Autotuner):
                     self.configs_timings = timings
 
                 if self.cache_results:
-                    if self.enable_ubtuner:
-                        warnings.warn(
-                            "Autotune disk cache is disabled because UB-tuner is enabled "
-                            "(TRITON_ENABLE_UBTUNER is set). UB-tuner may dynamically add "
-                            "compile-time fixes to configs that cannot be safely cached to disk. "
-                            "To enable disk caching, unset TRITON_ENABLE_UBTUNER.",
-                            RuntimeWarning,
-                            stacklevel=2,
-                        )
-                        benchmark()
-                    else:
-                        disk_cache_hit = self.check_disk_cache(key, pruned_configs, benchmark)
+                    disk_cache_hit = self.check_disk_cache(key, pruned_configs, benchmark)
                 else:
                     benchmark()
 


### PR DESCRIPTION
## Background

Prerequisite PR [#1442](https://github.com/triton-lang/triton-ascend/pull/1442) introduced autotune disk caching, but with a usage restriction: **disk caching is automatically disabled when UB-tuner is enabled** (a RuntimeWarning is emitted). At the time, UB-tuner and disk caching had two conflict points, and the restriction was a conservative workaround to avoid cache corruption.

This PR resolves both conflicts with two runtime patches and **removes the UB-tuner restriction** — UB-tuner and disk caching can now be enabled simultaneously. Rescued configs and their fix parameters are fully written to the disk cache and restored on subsequent runs.

## Supporting UB-tuner and disk caching together

### Why patches are necessary

The root cause is a runtime behavior of UB-tuner: when a candidate config fails to compile due to UB overflow, UB-tuner searches for a set of compile options and **dynamically injects** them onto the Config object via `setattr`:

```python
# autotuner.py: _try_ubtuner
setattr(config, 'ubtune_cfg', ub_cfg)   # {"storage_align": True, "multibuffer": False, ...}
```

The disk cache's serialization/deserialization path (upstream `check_disk_cache`):

- **Write side**: `json.dumps(config.__dict__)` — `ubtune_cfg` is a dynamic attribute serialized along with `__dict__` (its values are bool/str, so JSON serialization succeeds)
- **Read side**: `Config(**config_dict)` — the upstream `Config.__init__` signature has **no** `ubtune_cfg` field, so deserialization on a cache hit raises `TypeError: unexpected keyword argument 'ubtune_cfg'`

The `Config` class lives in upstream code `python/triton/runtime/autotuner.py`, which the Ascend side cannot modify directly. However, monkey-patching has always been the Ascend backend's extension pattern (`_patch_autotune` replacing `triton.autotune` being one example), so patching `Config.__init__` is the natural approach.

### `_patch_config_init`

Patch `Config.__init__` to restore the `ubtune_cfg` field via a whitelist:

```python
def _patch_config_init():
    from triton.runtime.autotuner import Config

    _original_config_init = Config.__init__

    def _patched_config_init(self, kwargs, num_warps=4, num_stages=3, num_ctas=1,
                             maxnreg=None, pre_hook=None, ir_override=None, **extra):
        _original_config_init(self, kwargs, num_warps, num_stages, num_ctas,
                              maxnreg, pre_hook, ir_override)
        if "ubtune_cfg" in extra:
            setattr(self, "ubtune_cfg", extra["ubtune_cfg"])

    Config.__init__ = _patched_config_init
```

Effect: on a disk cache hit, the config rebuilt from JSON carries its fix parameters, and `final_kwargs.update(ub_cfg)` injects them as usual at kernel execution — the rescued config compiles successfully without UB-tuner re-intervention. For ordinary configs without `ubtune_cfg`, `extra` is empty and behavior is identical to the original.

## `_patch_cache_invalidating_env_vars`

### Scenario: stale cache hit when toggling the switch

Once the serialization issue is resolved, there remains a cache-key-level scenario:

```mermaid
flowchart LR
    subgraph Run1[Run 1: UB-tuner off]
        A1[config X fails to compile<br/>ub overflow] --> A2[Skipped,<br/>not in timings]
        A2 --> A3[Benchmark completes<br/>cache written without X]
    end
    subgraph Run2[Run 2: UB-tuner on]
        B1[UB-tuner switch does not affect cache key] --> B2[Hit Run 1 cache<br/>benchmark skipped]
        B2 --> B3[X is never compiled<br/>UB-tuner never gets a chance to rescue X]
        B3 --> B4[Inaccurate selection result]
    end
    A3 -.|stale cache|.-> B2
    style B4 fill:#FF9800,stroke:#E65100,color:#fff
```

Why does the cache key not change? The config's representation in the disk cache key is `str(config)`, while `ubtune_cfg` is a dynamic attribute attached **after** benchmarking (the key is computed before benchmarking, when the field does not yet exist). Toggling UB-tuner therefore has no effect on the key.

### Call chain

When `check_disk_cache` builds the disk cache key, it collects "compilation-affecting environment variables" into the key:

```python
# python/triton/runtime/autotuner.py: check_disk_cache
env_vars = get_cache_invalidating_env_vars()          # ① module-level name
cache_key = [
    triton_key(),
    make_backend(driver.active.get_current_target()).hash(),
    fn.cache_key,
    str(sorted(env_vars.items())),                    # ② env_vars in cache key
    str(tuning_key),
] + [str(c) for c in configs]
```

This module-level name is bound to a C++ function at import time:

```python
# python/triton/runtime/autotuner.py, at the top
from triton._C.libtriton import get_cache_invalidating_env_vars
```

The C++ function iterates a fixed list `CACHE_INVALIDATING_ENV_VARS` and returns only variables that are **in the list and currently set**:

```
check_disk_cache()
  └─ triton.runtime.autotuner.get_cache_invalidating_env_vars   ← module-level binding
       └─ triton._C.libtriton.get_cache_invalidating_env_vars   ← C++ function
            └─ iterate CACHE_INVALIDATING_ENV_VARS list
                 └─ return {name: value} → into the disk cache key
```

`TRITON_ENABLE_UBTUNER` is an Ascend-specific environment variable not in this upstream list — so the returned dict lacks it, and the switch state never reaches the cache key.

### Why replacing the module-level binding solves it

The call in `check_disk_cache` resolves through the **module-level name**, not a fresh import from libtriton on each call. Replacing the `triton.runtime.autotuner.get_cache_invalidating_env_vars` binding therefore routes `check_disk_cache` to our wrapper, which appends the switch state to the C++ result:

```python
def _patched_get_env_vars():
    env_vars = _original_get_env_vars()                    # original C++ result
    ubtuner_mode = os.environ.get("TRITON_ENABLE_UBTUNER", "")
    if ubtuner_mode:
        env_vars["TRITON_ENABLE_UBTUNER"] = ubtuner_mode   # append switch state
    return env_vars                                        # into the disk cache key
```

Switch on → the key contains `TRITON_ENABLE_UBTUNER=compile`; switch off → the key does not. Toggling the switch → different key → re-benchmark, and the stale-cache-hit problem is resolved.

### Why not modify the C++ header

The C++ change itself is simple — just add one line to `CACHE_INVALIDATING_ENV_VARS`:

```diff
--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -40,6 +40,7 @@ inline const std::set<std::string> CACHE_INVALIDATING_ENV_VARS = {
     "TRITON_LLVM_DEBUG_ONLY",
     "TRITON_ENABLE_ASAN",
+    "TRITON_ENABLE_UBTUNER",
     "TRITON_OVERRIDE_ARCH",
     "USE_IR_LOC",
```

However, this list is also used by `jit.py` for the compile cache key — the C++ change would affect both keys, require modifying an upstream file, and need a rebuild. The Python patch replaces only the binding inside the `triton.runtime.autotuner` module; `jit.py` has its own independent import and is unaffected, so the patch **precisely affects only the autotune disk cache key**.

Full patch implementation:

```python
def _patch_cache_invalidating_env_vars():
    import triton.runtime.autotuner as _autotuner_module

    _original_get_env_vars = _autotuner_module.get_cache_invalidating_env_vars

    def _patched_get_env_vars():
        env_vars = _original_get_env_vars()
        ubtuner_mode = os.environ.get("TRITON_ENABLE_UBTUNER", "")
        if ubtuner_mode:
            env_vars["TRITON_ENABLE_UBTUNER"] = ubtuner_mode
        return env_vars

    _autotuner_module.get_cache_invalidating_env_vars = _patched_get_env_vars
```

## Testing

Test script: `docs/zhudada/test_ubtuner_disk_cache.py`

The UB-overflow recipe comes from the existing test case `third_party/ascend/unittest/ubtuner_ut/test_ubtuner.py`: `BLOCK_SIZE=20480` + `ITERATIONS=8` + `multibuffer=True` reliably exceeds the UB limit. The test kernel has two configs — one normal (4096) and one overflowing (20480).

```python
#!/usr/bin/env python3
"""
UB-tuner + autotune disk cache test

UB overflow recipe from ubtuner_ut/test_ubtuner.py:
  BLOCK_SIZE=20480 + ITERATIONS=8 + multibuffer=True → "ub overflow"

Three-run verification flow (same script, no arguments):

  Run 1 (clear cache, TRITON_ENABLE_UBTUNER=compile):
    - the overflowing config fails with ub overflow → UB-tuner rescues it → ubtune_cfg injected
    - after benchmarking, configs_timings (including ubtune_cfg) is written to the disk cache
    - verify: log shows "ub_cfg {...}"; the cache JSON entry for 20480 contains ubtune_cfg

  Run 2 (keep cache, same env):
    - hits the disk cache (~0.4s), skips benchmarking
    - verify: elapsed time drops sharply and it PASSES. During deserialization
      Config(**dict) handles the ubtune_cfg field; a missing _patch_config_init
      would crash with TypeError

  Run 3 (keep cache, UB-tuner off):
    - the cache key includes TRITON_ENABLE_UBTUNER (via _patch_cache_invalidating_env_vars),
      the key changes → miss → re-benchmark, the overflowing config fails and is skipped
    - verify: a second .autotune.json appears under ~/.triton/cache (2 in total)

Usage:
  python test_ubtuner_disk_cache.py
"""
import time

import torch
import torch_npu
import triton
import triton.language as tl
import triton.backends.ascend.runtime  # noqa: F401

SIZE = 20480
ITERATIONS = 8
BLOCK_OVERFLOW = 20480

CONFIGS = [
    triton.Config(kwargs={"BLOCK_SIZE": 4096}, num_warps=4),
    # overflow recipe: exceeds the UB limit with ITERATIONS=8 + multibuffer=True
    triton.Config(kwargs={"BLOCK_SIZE": BLOCK_OVERFLOW}, num_warps=4),
]


@triton.autotune(configs=CONFIGS, key=["n_elements"])
@triton.jit
def add_kernel(x_ptr, y_ptr, output_ptr, n_elements,
               BLOCK_SIZE: tl.constexpr, ITERATIONS: tl.constexpr):
    pid = tl.program_id(0)
    combined_block_start = pid * BLOCK_SIZE * ITERATIONS

    for i in range(0, ITERATIONS):
        curr_block_start = combined_block_start + i * BLOCK_SIZE
        offsets = curr_block_start + tl.arange(0, BLOCK_SIZE)
        mask = offsets < n_elements
        x = tl.load(x_ptr + offsets, mask=mask)
        y = tl.load(y_ptr + offsets, mask=mask)
        output = x + y
        tl.store(output_ptr + offsets, output, mask=mask)


def main():
    x = torch.rand(SIZE, dtype=torch.float32, device="npu")
    y = torch.rand(SIZE, dtype=torch.float32, device="npu")
    output = torch.empty(SIZE, dtype=torch.float32, device="npu")
    n_elements = output.numel()

    t0 = time.time()
    add_kernel[(1,)](x, y, output, n_elements, ITERATIONS=ITERATIONS, multibuffer=True)
    elapsed = time.time() - t0

    expected = x + y
    torch.testing.assert_close(output, expected, rtol=1e-5, atol=1e-5)
    print("Vector Add {} PASSED! (elapsed: {:.2f}s)".format(SIZE, elapsed))


if __name__ == "__main__":
    main()
```

### Measured results (Atlas 800I A2, CANN 9.0)

| Run | Elapsed | Key evidence |
|-----|---------|--------------|
| 1 | 19.91s | Log shows `ub_cfg {'storage_align': True, 'multibuffer': False, 'vf_fusion_mode': 'max-parallel'}`; the 20480 config in the cache JSON carries `ubtune_cfg` |
| 2 | 0.41s | Disk cache hit (including `ubtune_cfg` deserialization; a missing patch would TypeError) |
| 3 | 1.55s | Cache key changed → miss → re-benchmark, overflowing config skipped |

Cache file count verifies Run 3's invalidation:

```
autotune.json count: 2
  DZDZ44JL6H6Z → configs: [(4096, None)]                                    ← written by Run 3
  OX5BC6NECZIR → configs: [(4096, None), (20480, {'storage_align': True, ...})]  ← written by Run 1
```
