### PR TITLE
[simd_simt](feat) add shared-mem-dynamic-size to compile_option_list …

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -901,6 +901,8 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
             _compile_option_list += [f"--num-warps={num_warps}"]
             warp_size = metadata.get("warp_size", opt.warp_size)
             _compile_option_list += [f"--threads-per-warp={warp_size}"]
+            if opt.shared_mem_dynamic_size is not None:
+                _compile_option_list += [f"--shared-mem-dynamic-size={opt.shared_mem_dynamic_size}"]
 
         cmd_list = ([npu_compiler_path, ttadapter_path] + _compile_option_list + ["-o", bin_file])
         vf_merge_level = metadata["vf_merge_level"]


### PR DESCRIPTION
## PR Description


### Description

In the `simd_simt` mixed compile mode, `shared_mem_dynamic_size` (default 221184) was only passed to the CANN runtime at launch time via `cfgInfo.localMemorySize`, but was **not** passed to bishengir-compile at compile time via the `--shared-mem-dynamic-size` flag. This caused bishengir-compile to be unaware of the actual local memory size allocated at runtime, potentially leading to a mismatch between compile-time memory planning and runtime allocation.


### Changes

Add the `--shared-mem-dynamic-size` option to  `simd_simt` branch, aligning with the `simt_only` path

### Impact

- **Functionality**: bishengir-compile can now correctly account for the runtime-allocated local memory size (221184 / 216 KB) in mixed compile mode, ensuring compile-time memory planning aligns with runtime allocation.
- **Compatibility**: Fully backward compatible. No impact on `simd` or `simt_only` paths. User-specified `shared_mem_dynamic_size` values are also correctly forwarded.
- **Risk**: Low — appends an existing, recognized flag to the compile option list with no behavioral change for other compile modes.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)