### PR TITLE
[Backends](feat) add triton.backends.ascend.__version__

### DIFF
--- a/third_party/ascend/backend/__init__.py
+++ b/third_party/ascend/backend/__init__.py
@@ -17,6 +17,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+__version__ = '3.2.2'
 
 import logging
 from triton._C.libtriton.ascend import ir as ascend_ir

--- a/third_party/ascend/unittest/pytest_ut/test_ascend_version.py
+++ b/third_party/ascend/unittest/pytest_ut/test_ascend_version.py
@@ -1,0 +1,30 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import re
+
+import triton
+import triton.backends.ascend as ascend
+
+
+def test_triton_and_ascend_version_api():
+    assert hasattr(ascend, "__version__")
+    triton_ascend_version = ascend.__version__
+    print("triton-ascend:", triton_ascend_version)

--- a/third_party/ascend/unittest/pytest_ut/test_ascend_version.py
+++ b/third_party/ascend/unittest/pytest_ut/test_ascend_version.py
@@ -18,13 +18,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import re
-
-import triton
 import triton.backends.ascend as ascend
 
 
 def test_triton_and_ascend_version_api():
     assert hasattr(ascend, "__version__")
     triton_ascend_version = ascend.__version__
-    print("triton-ascend:", triton_ascend_version)
+    assert isinstance(triton_ascend_version, str)
+    assert triton_ascend_version


### PR DESCRIPTION

## Summary
Expose a dedicated Triton-Ascend package version via `triton.backends.ascend.__version__`, so users can query the Ascend release version at runtime without overwriting community `triton.__version__`.

## Background
`triton.__version__` is the **community Triton** version baked into `python/triton/__init__.py`. Triton-Ascend packaging versions can diverge from that community base, for example:

| Package / API | Example versions |
| --- | --- |
| Community `triton.__version__` | `3.2.0` |
| Triton-Ascend release (pip / `version.txt`) | `3.2.2`, … |

Related issue: [#750](https://github.com/triton-lang/triton-ascend/issues/750) — users who installed `triton-ascend==3.2.1` still saw `triton.__version__ == 3.2.0` and expected the Ascend package version.

**Why not change `triton.__version__`?**

- It is community API semantics (language / IR lineage).
- It is used by kernel cache keys and compiler metadata (`triton.compiler` / `triton.runtime.cache`).
- Overwriting it would confuse “which Triton IR dialect line” vs “which Ascend package release”.

So this PR **does not** modify community `triton.__version__`. Instead it adds an Ascend-backend attribute for the Triton-Ascend release version.

## Usage

```python
import triton
import triton.backends.ascend as ascend

print("triton:", triton.__version__)           # community, e.g. 3.2.0
print("triton-ascend:", ascend.__version__)    # Ascend package, e.g. 3.2.2
```

Or:

```python
from triton.backends.ascend import __version__ as triton_ascend_version
print(triton_ascend_version)
```

## What changed

| File | Change |
| --- | --- |
| `third_party/ascend/backend/__init__.py` | Add hardcoded `__version__` (same style as community `triton.__version__`) |
| `third_party/ascend/unittest/pytest_ut/test_ascend_version.py` | Assert `hasattr(ascend, "__version__")` so the API stays available |

## Test plan
- [x] `pytest -s third_party/ascend/unittest/pytest_ut/test_ascend_version.py`
- [ ] Manual smoke:

```bash
python -c "import triton; import triton.backends.ascend as a; print(triton.__version__, a.__version__)"
```

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
  - [ ] This PR does not need a test because …
  - [x] I have added tests.
- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices).
