### PR TITLE
[compiler](feat) isolate deprecated Ascend compile options

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -62,6 +62,9 @@ from triton.backends.ascend.utils import (
     _is_auto_map_parallel_blocks_enabled,
     _get_auto_blockify_blacklist_reasons,
     _warn_auto_blockify_disabled,
+    _remove_deprecated_npu_options,
+    _warn_deprecated_ascend_env_var,
+    _warn_deprecated_ascend_env_vars,
     downgrade_llir,
     force_disable_ffts,
     graph_ub_budget_bytes_for_arch,
@@ -998,7 +1001,8 @@ def linalg_to_bin_enable_npu_compile_A2_A3(linalg: str, metadata, opt):
                 _compile_option_list += \
                     [f"--link-aicore-bitcode={bitcode}"]
 
-        enable_libdevice = os.getenv("TRITON_ENABLE_LIBDEVICE", False)
+        _warn_deprecated_ascend_env_var("TRITON_ENABLE_LIBDEVICE")
+        enable_libdevice = True
         if enable_libdevice:
             _compile_option_list += [f"--link-aicore-bitcode={get_libdevice()}"]
 
@@ -1354,7 +1358,17 @@ class AscendBackend(BaseBackend):
     def parse_options(self, opts) -> Any:
         # TODO: get available targets when building options?
         if self.target.backend == "npu":
-            args = {k: opts[k] for k in NPUOptions.__dataclass_fields__.keys() if k in opts}
+            _warn_deprecated_ascend_env_vars()
+            option_names = NPUOptions.__dataclass_fields__.keys()
+            # JIT and AOT hand the complete, already-normalized dataclass back to
+            # parse_options before compilation.  Those values are internal state,
+            # not a second batch of user overrides.
+            internal_options = option_names <= opts.keys()
+            # JIT validates the same dictionary after this call.  Remove public
+            # compatibility keys in place so Ascend can accept them without
+            # requiring any change to the community JIT implementation.
+            normalized_opts = opts if internal_options else _remove_deprecated_npu_options(opts, in_place=True)
+            args = {k: normalized_opts[k] for k in option_names if k in normalized_opts}
             args.setdefault("arch", self.target.arch)
             options = NPUOptions(**args)
             # Lazy init compile_on_910_95 if not provided

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -34,7 +34,8 @@ from triton.backends.driver import DriverBase
 from triton.backends.compiler import GPUTarget
 from triton.backends.ascend.utils import (_build_npu_ext, _check_cxx11_abi, convert_sigtype_to_int,
                                           _is_auto_map_parallel_blocks_enabled, get_ascend_arch_from_env,
-                                          is_ffts_supported, force_disable_ffts, get_backend_func)
+                                          is_ffts_supported, force_disable_ffts, get_backend_func,
+                                          _warn_deprecated_ascend_env_var)
 # Bind the already-imported utils module once so the launch hot path can write
 # TRITON_PROFILER_REGISTERED without a per-launch `import triton` + attribute walk.
 import triton.backends.ascend.utils as _ascend_utils
@@ -171,8 +172,8 @@ class NPULauncher(object):
 
     def __init__(self, src, metadata):
         self.compile_only = os.getenv("TRITON_COMPILE_ONLY", 'false').lower() in ('true', '1')
-        self.enable_msprof_register_tensor = os.getenv("TRITON_REGISTER_TENSOR_MSPROF",
-                                                       'false').lower() in ('true', '1')
+        _warn_deprecated_ascend_env_var("TRITON_REGISTER_TENSOR_MSPROF")
+        self.enable_msprof_register_tensor = False
         self.src = src
         self.metadata = metadata
         self.so_launcher_path = self._make_launcher_stub_path()
@@ -671,7 +672,7 @@ def make_launcher(constants, signature, metadata):
     grid_info = {'X': 'i32', 'Y': 'i32', 'Z': 'i32'}
     # TODO: automatically check if gather load ops are used.
 
-    arch = get_ascend_arch_from_env()
+    arch = metadata.target.arch
     target_support_ffts = is_ffts_supported(arch) and (not force_disable_ffts())
     enable_device_print = os.getenv("TRITON_DEVICE_PRINT", 'false').lower() in ('true', '1')
     enable_taskqueue = os.getenv("TRITON_ENABLE_TASKQUEUE", 'true').lower() in ('true', '1')

--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -42,7 +42,7 @@ from torch import Tensor
 
 import triton
 from triton.runtime.autotuner import Autotuner, Config
-from triton.backends.ascend.utils import is_compile_on_910_95
+from triton.backends.ascend.utils import (_InternalNPUOptionInt, _remove_deprecated_npu_options, is_compile_on_910_95)
 
 from .autoparser import (LowDimsAxesParser, PtrNumsParser, ReductionAxesParser, SplitAxesParser, TilingAxesParser)
 from .dsl_analysis.cv_param_parser import parse_cv_params
@@ -109,6 +109,21 @@ def _clone_config_with_kwargs(
         pre_hook=config.pre_hook,
         ir_override=config.ir_override,
     )
+
+
+def _normalize_user_configs(configs, *, protected=()):
+    if not configs:
+        return configs
+    normalized_configs = []
+    for config in configs:
+        normalized_kwargs = _remove_deprecated_npu_options(config.kwargs, protected=protected)
+        if normalized_kwargs == config.kwargs:
+            normalized_configs.append(config)
+            continue
+        normalized_config = copy.copy(config)
+        normalized_config.kwargs = normalized_kwargs
+        normalized_configs.append(normalized_config)
+    return normalized_configs
 
 
 def _split_hints(hints: Optional[Dict[str, object]]):
@@ -231,6 +246,9 @@ class AutoTilingTuner(Autotuner):
             and trigger re-evaluation of candidate configs.
         :type key: List[str]
         """
+        constexpr_names = _get_constexpr_candidates_from_fn(fn)
+        hints = _remove_deprecated_npu_options(hints or {}, protected=constexpr_names)
+        configs = _normalize_user_configs(configs, protected=constexpr_names)
         _validate_user_hints(fn, hints)
         reserved_hints, config_hints = _split_hints(hints)
         config_hints = _normalize_config_hints(
@@ -2039,9 +2057,10 @@ class AutoTilingTuner(Autotuner):
             return
         outermost = grid[glen - 1]
         if isinstance(outermost, int) and outermost > 1:
-            kwargs["grid_num_tiles"] = outermost
+            kwargs["grid_num_tiles"] = _InternalNPUOptionInt(outermost)
 
     def run(self, *args, **kwargs):
+        kwargs = _remove_deprecated_npu_options(kwargs, protected=self.arg_names)
         self._inject_grid_num_tiles(kwargs)
         key = self.generate_key_and_configs(*args, **kwargs)
         cache_miss = key not in self.cache
@@ -2285,6 +2304,8 @@ class AutoTilingTuner(Autotuner):
         return kernel_call
 
     def warmup(self, *args, **kwargs):
+        kwargs = _remove_deprecated_npu_options(kwargs, protected=self.arg_names)
+        self._inject_grid_num_tiles(kwargs)
         _ = self.generate_key_and_configs(*args, **kwargs)
         pruned_configs = self.prune_configs(kwargs)
         ret = []
@@ -2817,6 +2838,8 @@ def get_max_configs(config, kernel_type="mixcv", **kwargs):
                    or from the defaults.
     :return: List of expanded Config objects.
     """
+    kwargs = _remove_deprecated_npu_options(kwargs)
+
     # Determine the set of parameters supported by the current kernel_type
     if kernel_type == "cube":
         supported = _CUBE_PARAMS
@@ -2913,6 +2936,8 @@ def max_autotune(configs, key, kernel_type="mixcv", prune_configs_by=None, reset
                           Each value must be a list; the Cartesian product of these lists
                           will be combined with each base config.
     """
+
+    tuning_params = _remove_deprecated_npu_options(tuning_params)
 
     def decorator(fn):
         if not configs or len(configs) == 0:

--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -25,6 +25,7 @@ import re
 import shutil
 import subprocess
 import sysconfig
+import warnings
 from pathlib import Path
 import logging
 import platform
@@ -34,6 +35,139 @@ import pybind11
 
 # Lazy init for is_compile_on_910_95
 _is_compile_on_910_95 = None
+
+# Phase-one compatibility boundary for compile-option cleanup.  Keep the
+# existing NPUOptions fields and their internal consumers intact while public
+# dictionaries route supported aliases and drop backend-managed fields.
+_DEPRECATED_NPU_OPTIONS = frozenset({
+    "add_auto_scheduling",
+    "allow_fp8e4nv",
+    "arch",
+    "auto_blockify_size",
+    "auto_tile_and_bind_subblock",
+    "bisheng_options",
+    "code_motion",
+    "compile_on_910_95",
+    "disable_auto_inject_block_sync",
+    "disable_size_align_for_cast",
+    "enable_auto_blockify",
+    "enable_buffer_insert_optimization",
+    "enable_cce_vf_auto_sync",
+    "enable_cce_vf_remove_membar",
+    "enable_cross_if_fusion",
+    "enable_cube_block_merge",
+    "enable_drop_unit_dims",
+    "enable_linearize",
+    "enable_mask_fallback_conversion",
+    "enable_nd2nz_on_vector",
+    "enable_select_analysis",
+    "enable_sync_block_lock",
+    "enable_ub_refine_opt",
+    "enable_vf_fusion",
+    "force_simt_only",
+    "force_simt_template",
+    "graph_optimize_emit_remarks",
+    "graph_optimize_max_rewrites_per_function",
+    "graph_optimize_rule_mask",
+    "graph_optimize_ub_capacity_bytes",
+    "grid_num_tiles",
+    "has_auto_blockify_blacklist_op",
+    "hfusion_enable_multiple_consumer_fusion",
+    "kernel_name",
+    "llvm_version",
+    "mix_mode",
+    "ops_reorder",
+    "optimize_dynamic_offset",
+    "parallel_mode",
+    "storage_align",
+    "stream",
+    "use_bytecode",
+    "vf_merge_level",
+    "warp_size",
+})
+
+_DEPRECATED_NPU_OPTION_ROUTES = {
+    "force_simt_only": ("compile_mode", "simt_only"),
+    "force_simt_template": ("compile_mode", "unstructured_in_simt"),
+}
+
+_DEPRECATED_ASCEND_ENV_VARS = frozenset({
+    "LLVM_ROOT",
+    "MLIR_ROOT",
+    "TRITON_ALL_BLOCKS_PARALLEL",
+    "TRITON_ASCEND_ARCH",
+    "TRITON_ASCEND_COMPILE_SPEED_OPT",
+    "TRITON_BACKEND",
+    "TRITON_DISABLE_FFTS",
+    "TRITON_ENABLE_LIBDEVICE",
+    "TRITON_ENABLE_LIBDEVICE_SIMT",
+    "TRITON_REGISTER_TENSOR_MSPROF",
+})
+_WARNED_DEPRECATED_ASCEND_ENV_VARS = set()
+
+
+class _InternalNPUOptionInt(int):
+    """Marks an integer option value produced by the Ascend backend itself."""
+
+
+def _is_internal_npu_option_value(value) -> bool:
+    return isinstance(value, _InternalNPUOptionInt)
+
+
+def _get_deprecated_npu_options(options) -> set[str]:
+    return {
+        name
+        for name in options.keys() & _DEPRECATED_NPU_OPTIONS
+        if not _is_internal_npu_option_value(options[name])
+    }
+
+
+def _warn_deprecated_npu_option(name: str) -> None:
+    route = _DEPRECATED_NPU_OPTION_ROUTES.get(name)
+    if route is not None:
+        replacement_name, replacement_value = route
+        message = (f"Ascend compile option '{name}' is deprecated; "
+                   f"use {replacement_name}={replacement_value!r} instead.")
+    else:
+        message = (f"Ascend compile option '{name}' is deprecated and ignored; "
+                   "the backend-managed/default behavior is used instead.")
+    warnings.warn(
+        message,
+        FutureWarning,
+        stacklevel=3,
+    )
+
+
+def _remove_deprecated_npu_options(options, *, protected=(), in_place=False):
+    """Normalize and remove deprecated public NPU options, copying by default."""
+    normalized = options if in_place else dict(options)
+    deprecated = _get_deprecated_npu_options(normalized) - set(protected)
+    for name in sorted(deprecated):
+        _warn_deprecated_npu_option(name)
+        route = _DEPRECATED_NPU_OPTION_ROUTES.get(name)
+        if route is not None and normalized[name]:
+            replacement_name, replacement_value = route
+            normalized.setdefault(replacement_name, replacement_value)
+        normalized.pop(name)
+    return normalized
+
+
+def _warn_deprecated_ascend_env_var(name: str) -> None:
+    if (name not in _DEPRECATED_ASCEND_ENV_VARS or name not in os.environ
+            or name in _WARNED_DEPRECATED_ASCEND_ENV_VARS):
+        return
+    _WARNED_DEPRECATED_ASCEND_ENV_VARS.add(name)
+    warnings.warn(
+        f"Ascend environment variable '{name}' is deprecated and ignored; "
+        "the default behavior is used instead.",
+        FutureWarning,
+        stacklevel=3,
+    )
+
+
+def _warn_deprecated_ascend_env_vars() -> None:
+    for name in sorted(_DEPRECATED_ASCEND_ENV_VARS & os.environ.keys()):
+        _warn_deprecated_ascend_env_var(name)
 
 
 def is_compile_on_910_95():
@@ -69,7 +203,8 @@ backend_policy = None
 def get_backend_func(name, *args, **kwargs):
     global backend_policy
     if backend_policy is None:
-        backend_policy_env = os.getenv("TRITON_BACKEND", "default").lower()
+        _warn_deprecated_ascend_env_var("TRITON_BACKEND")
+        backend_policy_env = None
         if backend_policy_env == "torch_npu" or backend_policy_env == "mindspore":
             backend_policy = backend_policy_env
         if backend_policy is None:
@@ -166,18 +301,26 @@ def _get_triton_adapter_opt_path() -> str:
     return path
 
 
+def _get_default_tool_path(path: str, *paths) -> str:
+    relative_path = os.path.join(path, *paths)
+    try:
+        import triton._C.libtriton as libtriton
+        tool_path = os.path.join(os.path.dirname(libtriton.__file__), relative_path)
+        if os.path.exists(tool_path) and os.access(tool_path, os.X_OK):
+            return tool_path
+    except (ImportError, AttributeError):
+        pass
+    return _get_tool_path(os.path.basename(relative_path))
+
+
 def _get_mlir_path(path: str, *paths) -> str:
-    root_path = os.getenv("MLIR_ROOT", "")
-    if root_path == "":
-        raise EnvironmentError("MLIR_ROOT is not set.")
-    return os.path.join(root_path, path, *paths)
+    _warn_deprecated_ascend_env_var("MLIR_ROOT")
+    return _get_default_tool_path(path, *paths)
 
 
 def _get_llvm_path(path: str, *paths) -> str:
-    root_path = os.getenv("LLVM_ROOT", "")
-    if root_path == "":
-        raise EnvironmentError("LLVM_ROOT is not set.")
-    return os.path.join(root_path, path, *paths)
+    _warn_deprecated_ascend_env_var("LLVM_ROOT")
+    return _get_default_tool_path(path, *paths)
 
 
 def _get_tool_path(tool_name: str) -> str:
@@ -347,7 +490,8 @@ def _is_debug_line_info_disabled() -> bool:
 
 
 def _is_auto_map_parallel_blocks_enabled() -> bool:
-    return os.getenv("TRITON_ALL_BLOCKS_PARALLEL", "true").lower() in ("true", "1")
+    _warn_deprecated_ascend_env_var("TRITON_ALL_BLOCKS_PARALLEL")
+    return True
 
 
 def _get_auto_blockify_blacklist_reasons(ir_text: str):
@@ -524,38 +668,8 @@ def _check_bishengir_able_save_ir() -> bool:
 
 
 def get_ascend_arch_from_env():
-    arch = os.getenv("TRITON_ASCEND_ARCH", "")
-    if arch == "":
-        # User does not set arch by ENV. Thus directly return.
-        return arch
-    # User sets arch by ENV. Thus we need to check if it is supported.
-    valid_arch_list = [
-        "Ascend910B1",
-        "Ascend910B2",
-        "Ascend910B3",
-        "Ascend910B4",
-        "Ascend910_9362",
-        "Ascend910_9363",
-        "Ascend910_9372",
-        "Ascend910_9381",
-        "Ascend910_9382",
-        "Ascend910_9391",
-        "Ascend910_9392",
-        "Ascend310B1",
-        "Ascend310B2",
-        "Ascend310B3",
-        "Ascend310B4",
-        "Ascend910_9579",
-        "Ascend910_9581",
-        "Ascend910_9589",
-        "Ascend910_9599",
-    ]
-    is_valid = arch in valid_arch_list
-    if not is_valid:
-        valid_arch_str = ", ".join(valid_arch_list)
-        raise ValueError(f"TRITON_ASCEND_ARCH = {arch} is invalid!"
-                         f"Candidates are [{valid_arch_str}]")
-    return arch
+    _warn_deprecated_ascend_env_var("TRITON_ASCEND_ARCH")
+    return ""
 
 
 def ub_size_in_kbytes_for_arch(arch: str) -> int:
@@ -603,8 +717,8 @@ def force_disable_ffts():
     '''
     if is_compile_on_910_95():
         return True
-    disable_ffts = os.getenv("TRITON_DISABLE_FFTS", "false").lower() in ("true", "1")
-    return disable_ffts
+    _warn_deprecated_ascend_env_var("TRITON_DISABLE_FFTS")
+    return False
 
 
 def triton_support_ffts():
@@ -613,8 +727,8 @@ def triton_support_ffts():
 
 
 def triton_enable_libdevice_simt():
-    enable_libdevice_simt = os.getenv("TRITON_ENABLE_LIBDEVICE_SIMT", False)
-    return enable_libdevice_simt and is_compile_on_910_95()
+    _warn_deprecated_ascend_env_var("TRITON_ENABLE_LIBDEVICE_SIMT")
+    return is_compile_on_910_95()
 
 
 def get_cann_version_file_hash():

--- a/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
+++ b/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
@@ -23,6 +23,7 @@ def _mock_backend_func(name, *args):
 
 def _make_metadata():
     return SimpleNamespace(
+        target=driver.GPUTarget("npu", "Ascend910B3", 0),
         workspace_size=0,
         lock_init_value=0,
         lock_num=0,
@@ -71,6 +72,7 @@ def test_make_launcher_exposes_triton_launch_kernel(
     assert 'std::vector<size_t> launch_arg_sizes;' in src
     assert 'std::vector<char> launch_args(total_size, 0);' in src
     assert 'memcpy(launch_args.data() + grid_offset, &gridX, sizeof(int32_t));' in src
+    _mock_ffts.assert_called_once_with("Ascend910B3")
 
 
 @patch.object(driver, "NPUUtils")

--- a/third_party/ascend/unittest/pytest_ut/test_layout_memory_895_closure_differential.py
+++ b/third_party/ascend/unittest/pytest_ut/test_layout_memory_895_closure_differential.py
@@ -478,6 +478,7 @@ def _load_make_launcher(source):
 
 def _make_metadata(*, factor, axis, ceil_div, blacklisted, row_applied):
     return SimpleNamespace(
+        target=SimpleNamespace(arch="Ascend910B"),
         workspace_size=0,
         lock_init_value=0,
         lock_num=0,

--- a/third_party/ascend/unittest/pytest_ut/test_runtime_utils.py
+++ b/third_party/ascend/unittest/pytest_ut/test_runtime_utils.py
@@ -18,10 +18,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 import logging
-import os
+import warnings
+
+import pytest
+import torch
+
 from triton.backends.ascend import utils
 from triton.backends.ascend.runtime import utils as runtime_utils
-import torch
 
 
 def test_get_logger():
@@ -29,10 +32,65 @@ def test_get_logger():
     assert logger.level == logging.INFO
 
 
-def test_get_ascend_arch_from_env():
-    os.environ["TRITON_ASCEND_ARCH"] = "Ascend910_9599"
-    result = utils.get_ascend_arch_from_env()
-    assert result == "Ascend910_9599"
+def test_get_ascend_arch_from_env_is_deprecated(monkeypatch):
+    monkeypatch.setattr(utils, "_WARNED_DEPRECATED_ASCEND_ENV_VARS", set(), raising=False)
+    monkeypatch.setenv("TRITON_ASCEND_ARCH", "Ascend910_9599")
+    with pytest.warns(FutureWarning, match=r"TRITON_ASCEND_ARCH.*deprecated and ignored"):
+        result = utils.get_ascend_arch_from_env()
+    assert result == ""
+
+
+def test_deprecated_ascend_env_var_warns_only_once_per_process(monkeypatch):
+    name = "TRITON_ENABLE_LIBDEVICE"
+    monkeypatch.setattr(utils, "_WARNED_DEPRECATED_ASCEND_ENV_VARS", set(), raising=False)
+    monkeypatch.delenv(name, raising=False)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        utils._warn_deprecated_ascend_env_var(name)
+        monkeypatch.setenv(name, "1")
+        utils._warn_deprecated_ascend_env_var(name)
+        utils._warn_deprecated_ascend_env_var(name)
+
+    assert len(caught) == 1
+
+
+@pytest.mark.parametrize(
+    "legacy_option, compile_mode",
+    [
+        pytest.param("force_simt_only", "simt_only", id="simt-only"),
+        pytest.param("force_simt_template", "unstructured_in_simt", id="unstructured-in-simt"),
+    ],
+)
+def test_deprecated_simt_option_routes_to_compile_mode(legacy_option, compile_mode):
+    options = {legacy_option: True}
+
+    with pytest.warns(FutureWarning, match=rf"{legacy_option}.*use compile_mode='{compile_mode}' instead"):
+        normalized = utils._remove_deprecated_npu_options(options)
+
+    assert normalized == {"compile_mode": compile_mode}
+    assert options == {legacy_option: True}
+
+
+def test_explicit_compile_mode_takes_precedence_over_deprecated_simt_option():
+    options = {"compile_mode": "simd", "force_simt_only": True}
+
+    with pytest.warns(FutureWarning, match=r"force_simt_only.*use compile_mode='simt_only' instead"):
+        normalized = utils._remove_deprecated_npu_options(options)
+
+    assert normalized == {"compile_mode": "simd"}
+
+
+def test_deprecated_simt_option_warns_only_once_after_in_place_normalization():
+    options = {"force_simt_only": True}
+
+    with pytest.warns(FutureWarning) as warnings:
+        first = utils._remove_deprecated_npu_options(options, in_place=True)
+        second = utils._remove_deprecated_npu_options(options, in_place=True)
+
+    assert len(warnings) == 1
+    assert first is second is options
+    assert options == {"compile_mode": "simt_only"}
 
 
 def test_get_byte_per_numel_supports_unsigned_integer_dtypes():


### PR DESCRIPTION
Triton-Ascend exposes a number of compile options and environment variables that are obsolete, ineffective, or should be managed internally by the backend.

Removing them immediately would cause existing user code to fail option validation. This PR introduces the first-stage compatibility boundary: deprecated options are still accepted, explicit usage emits a `FutureWarning`, user-provided values are ignored, and compilation continues with backend-managed or default behavior.

The internal `NPUOptions` fields and consumers are intentionally retained in this stage to reduce regression risk. Their structural removal can be handled in a follow-up after the compatibility behavior has been observed.

## Compatibility

Existing calls that pass deprecated options continue to compile, but the provided values no longer affect compilation and produce a `FutureWarning`.

No community Triton source files are modified by this PR.

This PR does not yet remove the corresponding internal fields, consumers, cache dimensions, or documentation. Those changes are deferred to the next cleanup stage.
