### PR TITLE
[ConvertModuloToMask](fix) track the wrapped dimension per load

### DIFF
--- a/third_party/ascend/lib/TritonToGraph/Rules/ConvertModuloToMaskRule.cpp
+++ b/third_party/ascend/lib/TritonToGraph/Rules/ConvertModuloToMaskRule.cpp
@@ -30,6 +30,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Verifier.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
@@ -48,6 +49,16 @@ using namespace cfg;
 
 namespace {
 
+// A load the modulo result addresses, together with the dimension of that load
+// along which the wrapped coordinate varies.  Recording the dimension per load
+// instead of once per candidate is what lets one index address differently
+// shaped loads: in a block-quantised matmul the same column index addresses a
+// rank-two weight tile and the rank-one scale vector that scales it.
+struct AddressedLoad {
+  triton::LoadOp load;
+  int64_t dim = 0;
+};
+
 // A modulo whose result is only ever used to compute load addresses, and whose
 // wrapped lanes are already discarded by a store mask.  Such a modulo can be
 // dropped so the addresses become linear again, provided the loads that consume
@@ -63,11 +74,8 @@ struct ModuloCandidate {
   Value result;
   // anchor plus, for the expanded form, the muli and divsi that die with it.
   SmallVector<Operation *, 3> patternOps;
-  SmallVector<triton::LoadOp, 4> loads;
+  SmallVector<AddressedLoad, 4> loads;
   int64_t tileSize = 0;
-  // The axis that expand_dims inserted on the modulo result.  The mask has to
-  // be expanded on the same axis to vary along the same dimension of the load.
-  int64_t axis = 0;
 };
 
 Value getSplatScalar(Value value) {
@@ -96,45 +104,113 @@ bool isCompileTimeConstant(Value value) {
   return matchPattern(value, m_ConstantInt(&constant));
 }
 
-// Reports whether `mask` reaches the mask operand of a tt.store.  Shape ops and
-// arith.andi are transparent because a store mask is normally the conjunction
-// of one comparison per output axis, each broadcast to the output shape.
-bool feedsStoreMask(Value mask, SmallPtrSetImpl<Operation *> &visited) {
+// Reports whether every lane of `value` holds the same number.  An elementwise
+// op with such an operand leaves each result lane a function of that same lane
+// of the tracked index, so one boundary comparison still describes exactly the
+// lanes the wrap used to fold back.
+bool isUniformOperand(Value value) {
+  if (getSplatScalar(value))
+    return true;
+  DenseElementsAttr constant;
+  return matchPattern(value, m_Constant(&constant)) && constant.isSplat();
+}
+
+// Where the tracked dimension ends up after tt.expand_dims inserted a unit
+// dimension.  Ranks above two are rejected: the boundary mask this rule builds
+// is one comparison expanded once, which only covers a rank-two consumer.
+std::optional<int64_t> mapDimThroughExpand(int64_t dim,
+                                           triton::ExpandDimsOp expand) {
+  auto type = dyn_cast<RankedTensorType>(expand.getResult().getType());
+  if (!type || type.getRank() > 2)
+    return std::nullopt;
+  int64_t axis = expand.getAxis();
+  int64_t mapped = dim >= axis ? dim + 1 : dim;
+  if (mapped >= type.getRank())
+    return std::nullopt;
+  return mapped;
+}
+
+// Where the tracked dimension ends up after tt.trans permuted the dimensions.
+// Result dimension i holds source dimension order[i].
+std::optional<int64_t> mapDimThroughTrans(int64_t dim,
+                                          triton::TransOp transpose) {
+  for (auto [position, source] : llvm::enumerate(transpose.getOrder())) {
+    if (static_cast<int64_t>(source) == dim)
+      return static_cast<int64_t>(position);
+  }
+  return std::nullopt;
+}
+
+// tt.broadcast only stretches dimensions of extent one, so it moves no lane.
+// Stretching the tracked dimension itself would leave the boundary mask
+// describing fewer lanes than the result has, so that case is rejected.
+bool broadcastKeepsDim(triton::BroadcastOp broadcast, int64_t dim) {
+  auto source = dyn_cast<RankedTensorType>(broadcast.getSrc().getType());
+  auto result = dyn_cast<RankedTensorType>(broadcast.getResult().getType());
+  return source && result && dim < source.getRank() && dim < result.getRank() &&
+         source.getShape()[dim] == result.getShape()[dim];
+}
+
+// The dimensions a store's mask discards the wrapped lanes along, as a bit per
+// dimension.  A store may be guarded on more than one of them, and a tile
+// wrapped along any one of those is safe to rewrite.
+using GuardedStores = DenseMap<Operation *, unsigned>;
+
+// Collects the tt.store ops that `mask` guards, tracking which dimension of the
+// stored shape the comparison varies along.  Shape ops and arith.andi are
+// transparent because a store mask is normally the conjunction of one
+// comparison per output axis, each broadcast to the output shape.
+void collectMaskedStores(Value mask, int64_t dim, GuardedStores &stores,
+                         DenseMap<Value, unsigned> &visited) {
+  unsigned bit = 1u << dim;
+  unsigned &seen = visited[mask];
+  if (seen & bit)
+    return;
+  seen |= bit;
+
   for (OpOperand &use : mask.getUses()) {
     Operation *user = use.getOwner();
     if (auto store = dyn_cast<triton::StoreOp>(user)) {
       if (store.getMask() == mask)
-        return true;
+        stores[store.getOperation()] |= bit;
       continue;
     }
-    if (!isa<triton::BroadcastOp, triton::ExpandDimsOp, arith::AndIOp>(user))
+    if (auto expand = dyn_cast<triton::ExpandDimsOp>(user)) {
+      if (std::optional<int64_t> next = mapDimThroughExpand(dim, expand))
+        collectMaskedStores(expand.getResult(), *next, stores, visited);
       continue;
-    if (!visited.insert(user).second)
+    }
+    if (auto broadcast = dyn_cast<triton::BroadcastOp>(user)) {
+      if (broadcastKeepsDim(broadcast, dim))
+        collectMaskedStores(broadcast.getResult(), dim, stores, visited);
       continue;
-    if (feedsStoreMask(user->getResult(0), visited))
-      return true;
+    }
+    // A conjunction only ever drops more lanes, so the dimension this operand
+    // discards is still discarded by the result.
+    if (isa<arith::AndIOp>(user))
+      collectMaskedStores(user->getResult(0), dim, stores, visited);
   }
-  return false;
 }
 
-// Reports whether some `cmpi slt` of the un-wrapped tile offset against the
-// same bound guards a store.  This is the proof that the kernel itself treats
-// offsets at or beyond the bound as absent, so the values the wrap used to
-// fetch for those lanes never reach memory.
-//
-// It also pins the modulo to an axis of the output.  A modulo on a reduction
-// axis could not be rewritten this way, because zeros injected there would
-// change every output element rather than only the discarded lanes, and such a
-// modulo has no store-mask guard precisely because the axis has no output
-// coordinate.
-bool hasStoreMaskGuard(Value offset, Value boundScalar) {
-  SmallVector<Value, 2> forms = {offset};
+// Collects the stores guarded by a `cmpi slt` of the un-wrapped tile offset
+// against the same bound, which is where the kernel itself discards the wrapped
+// lanes.  Which stores they are matters, and along which dimension: without the
+// dimension a square tile whose store mask drops rows would look like a proof
+// about the columns the injected mask zeros.
+bool collectStoreMaskGuard(Value offset, Value boundScalar,
+                           GuardedStores &stores) {
+  // The comparison is written either on the bare tile offset or on an already
+  // expanded form of it, so both shapes have to be considered.
+  SmallVector<std::pair<Value, int64_t>, 4> forms = {{offset, 0}};
   for (OpOperand &use : offset.getUses()) {
-    if (isa<triton::ExpandDimsOp>(use.getOwner()))
-      forms.push_back(use.getOwner()->getResult(0));
+    auto expand = dyn_cast<triton::ExpandDimsOp>(use.getOwner());
+    if (!expand)
+      continue;
+    if (std::optional<int64_t> dim = mapDimThroughExpand(0, expand))
+      forms.emplace_back(expand.getResult(), *dim);
   }
 
-  for (Value form : forms) {
+  for (auto [form, dim] : forms) {
     for (OpOperand &use : form.getUses()) {
       auto compare = dyn_cast<arith::CmpIOp>(use.getOwner());
       if (!compare || compare.getPredicate() != arith::CmpIPredicate::slt ||
@@ -143,12 +219,11 @@ bool hasStoreMaskGuard(Value offset, Value boundScalar) {
       Value bound = getSplatScalar(compare.getRhs());
       if (bound != boundScalar)
         continue;
-      SmallPtrSet<Operation *, 16> visited;
-      if (feedsStoreMask(compare.getResult(), visited))
-        return true;
+      DenseMap<Value, unsigned> visited;
+      collectMaskedStores(compare.getResult(), dim, stores, visited);
     }
   }
-  return false;
+  return !stores.empty();
 }
 
 // Returns true when two distinct loop-carried paths cross nested scf.for ops.
@@ -167,18 +242,58 @@ bool crossesNestedCarriedFor(ArrayRef<Operation *> carriedForChain,
   });
 }
 
-// Walks forward from the modulo result and collects the loads it addresses.
-// Returns false as soon as the value reaches anything else, which is what makes
-// dropping the wrap unobservable: no other consumer can see the widened index.
-//
-// The allowlist is restricted to ops that preserve dimension positions, so the
-// axis recorded for the modulo result stays the axis it varies along in every
-// load that it reaches.  tt.trans and tt.reshape are therefore rejected.
-bool collectAddressedLoads(Value value, SmallPtrSetImpl<Value> &visited,
-                           SmallVectorImpl<triton::LoadOp> &loads,
-                           ArrayRef<Operation *> carriedForChain) {
-  if (!visited.insert(value).second)
+// Reports whether `assertOp` is one the overflow sanitizer inserted.  A user
+// device_assert may carry the same message, so only the marker proves it.
+bool isAutomaticOverflowAssert(triton::AssertOp assertOp) {
+  if (!assertOp->hasAttr("tt.auto_overflow_assert"))
+    return false;
+  auto message = dyn_cast<StringAttr>(assertOp.getMessageAttr());
+  return message &&
+         message.getValue().contains("overflow detected for operation");
+}
+
+// Reports whether `op` can only make the kernel trap: every path forward ends
+// in an overflow assert, so nothing it computes is observed.  In debug builds
+// the sanitizer hangs such a cone off every tile offset, which would otherwise
+// count as a consumer of the un-wrapped index.  The rewrite keeps the check
+// honest because the emitted arithmetic really does become un-wrapped, and that
+// argument is why the sanitizer's provenance is required here.
+bool onlyFeedsOverflowAssert(Operation *op,
+                             SmallPtrSetImpl<Operation *> &visited) {
+  if (auto assertOp = dyn_cast<triton::AssertOp>(op))
+    return isAutomaticOverflowAssert(assertOp);
+  if (!visited.insert(op).second)
     return true;
+  // Anything else without results ends the walk before reaching an assert.
+  if (op->getNumResults() == 0)
+    return false;
+  if (!isa<arith::ExtSIOp, arith::MulIOp, arith::AddIOp, arith::SubIOp,
+           arith::CmpIOp, arith::AndIOp, arith::OrIOp, arith::XOrIOp,
+           triton::SplatOp, triton::ExpandDimsOp, triton::BroadcastOp>(op))
+    return false;
+  for (Value result : op->getResults()) {
+    for (OpOperand &use : result.getUses()) {
+      if (!onlyFeedsOverflowAssert(use.getOwner(), visited))
+        return false;
+    }
+  }
+  return true;
+}
+
+// Walks forward from the modulo result and collects the loads it addresses,
+// carrying the dimension the tile coordinate varies along.  Returns false as
+// soon as the value reaches anything else, which is what makes dropping the
+// wrap unobservable: no other consumer can see the widened index.
+bool collectAddressedLoads(Value value, int64_t dim,
+                           DenseMap<Value, int64_t> &visited,
+                           SmallVectorImpl<AddressedLoad> &loads,
+                           ArrayRef<Operation *> carriedForChain) {
+  auto known = visited.find(value);
+  if (known != visited.end())
+    // Two paths reached the same value on different dimensions, so the index
+    // addresses both and no single mask orientation describes it.
+    return known->second == dim;
+  visited[value] = dim;
 
   for (OpOperand &use : value.getUses()) {
     Operation *user = use.getOwner();
@@ -188,15 +303,44 @@ bool collectAddressedLoads(Value value, SmallPtrSetImpl<Value> &visited,
       // rewriting it would change the loaded data itself.
       if (load.getPtr() != value)
         return false;
-      loads.push_back(load);
+      loads.push_back({load, dim});
       continue;
     }
-    if (isa<triton::ExpandDimsOp, triton::BroadcastOp, triton::AddPtrOp,
-            arith::MulIOp, arith::AddIOp>(user)) {
+    if (auto expand = dyn_cast<triton::ExpandDimsOp>(user)) {
+      std::optional<int64_t> next = mapDimThroughExpand(dim, expand);
+      if (!next || !collectAddressedLoads(expand.getResult(), *next, visited,
+                                          loads, carriedForChain))
+        return false;
+      continue;
+    }
+    if (auto broadcast = dyn_cast<triton::BroadcastOp>(user)) {
+      if (!broadcastKeepsDim(broadcast, dim) ||
+          !collectAddressedLoads(broadcast.getResult(), dim, visited, loads,
+                                 carriedForChain))
+        return false;
+      continue;
+    }
+    // These keep operand and result shapes identical, so they move no lane.
+    if (isa<triton::AddPtrOp, arith::MulIOp, arith::AddIOp>(user)) {
       for (Value result : user->getResults()) {
-        if (!collectAddressedLoads(result, visited, loads, carriedForChain))
+        if (!collectAddressedLoads(result, dim, visited, loads,
+                                   carriedForChain))
           return false;
       }
+      continue;
+    }
+    // A uniform divisor leaves each lane of the derived index a function of
+    // that same lane of the tracked one, so the boundary mask still zeros
+    // exactly the lanes the wrap used to fold back.  The derived index itself
+    // may leave the array it indexes, but only on lanes the mask removes, so
+    // the load never reads them.
+    if (isa<arith::DivSIOp, arith::RemSIOp>(user)) {
+      if (user->getOperand(0) != value ||
+          !isUniformOperand(user->getOperand(1)))
+        return false;
+      if (!collectAddressedLoads(user->getResult(0), dim, visited, loads,
+                                 carriedForChain))
+        return false;
       continue;
     }
     if (auto forOp = dyn_cast<scf::ForOp>(user)) {
@@ -209,7 +353,7 @@ bool collectAddressedLoads(Value value, SmallPtrSetImpl<Value> &visited,
           return false;
         SmallVector<Operation *, 2> nextChain(carriedForChain);
         nextChain.push_back(forOp.getOperation());
-        if (!collectAddressedLoads(forOp.getRegionIterArg(index), visited,
+        if (!collectAddressedLoads(forOp.getRegionIterArg(index), dim, visited,
                                    loads, nextChain))
           return false;
       }
@@ -226,46 +370,34 @@ bool collectAddressedLoads(Value value, SmallPtrSetImpl<Value> &visited,
         return false;
       SmallVector<Operation *, 2> nextChain(carriedForChain);
       nextChain.push_back(forOp.getOperation());
-      if (!collectAddressedLoads(forOp.getResult(index), visited, loads,
+      if (!collectAddressedLoads(forOp.getResult(index), dim, visited, loads,
                                  nextChain))
         return false;
       continue;
     }
+
+    // A consumer that can only trap never observes the index in a value.
+    SmallPtrSet<Operation *, 16> assertCone;
+    if (onlyFeedsOverflowAssert(user, assertCone))
+      continue;
 
     return false;
   }
   return true;
 }
 
-// Reports the single axis that expand_dims inserted on the modulo result.
-// Distinct axes mean the one index addresses two different dimensions, and no
-// single mask orientation would be correct for both, so such a result is
-// rejected rather than rewritten on a guessed axis.
-std::optional<int64_t> getUniqueExpandDimsAxis(Value value) {
-  std::optional<int64_t> axis;
-  for (OpOperand &use : value.getUses()) {
-    auto expand = dyn_cast<triton::ExpandDimsOp>(use.getOwner());
-    if (!expand)
-      continue;
-    int64_t current = expand.getAxis();
-    if (axis && *axis != current)
-      return std::nullopt;
-    axis = current;
-  }
-  return axis;
-}
-
-// Reports whether a boundary mask of `tileSize` lanes, expanded on `axis`, can
-// be broadcast to every loaded shape.  Checking it up front means the mask ops
-// this rule creates are valid by construction.
-bool areLoadsMaskable(ArrayRef<triton::LoadOp> loads, int64_t axis,
-                      int64_t tileSize) {
-  if (loads.empty() || axis < 0 || axis > 1)
+// Reports whether a boundary mask of `tileSize` lanes can be shaped to fit
+// every load, on the dimension that load's address varies along.  Checking it
+// up front means the mask ops this rule creates are valid by construction.
+bool areLoadsMaskable(ArrayRef<AddressedLoad> loads, int64_t tileSize) {
+  if (loads.empty())
     return false;
-  for (triton::LoadOp load : loads) {
+  for (const AddressedLoad &addressed : loads) {
+    triton::LoadOp load = addressed.load;
     auto type = dyn_cast<RankedTensorType>(load.getResult().getType());
-    if (!type || !type.hasStaticShape() || type.getRank() != 2 ||
-        type.getShape()[1 - axis] != tileSize)
+    if (!type || !type.hasStaticShape() || type.getRank() < 1 ||
+        type.getRank() > 2 || addressed.dim >= type.getRank() ||
+        type.getShape()[addressed.dim] != tileSize)
       return false;
     // A load carrying `other` without a mask reads it nowhere, so injecting a
     // mask would suddenly make that operand observable.
@@ -273,6 +405,116 @@ bool areLoadsMaskable(ArrayRef<triton::LoadOp> loads, int64_t axis,
       return false;
     if (!load.getBoundaryCheck().empty() || load.getIsVolatile())
       return false;
+  }
+  return true;
+}
+
+// Reports whether `value` still carries the wrapped coordinate on dimension
+// `dim`, with the extent the injected mask has.
+bool keepsWrappedDim(Value value, int64_t dim, int64_t tileSize) {
+  auto type = dyn_cast<RankedTensorType>(value.getType());
+  return type && type.hasStaticShape() && type.getRank() >= 1 &&
+         type.getRank() <= 2 && dim < type.getRank() &&
+         type.getShape()[dim] == tileSize;
+}
+
+// Reports whether the tile a load produced reaches memory only through stores
+// that discard the wrapped lanes, on the dimension those lanes ended up on.
+// The guard alone proves some store drops them, not that the store writing this
+// tile does; without that, a kernel whose guard belongs to an unrelated store
+// gets a deliberate circular index rewritten and the injected zeros written
+// out.  Requiring the dimension to agree is what makes the proof hold for a
+// square tile, where a mask on rows and a mask on columns have the same shape.
+bool tileReachesOnlyGuardedStores(Value value, int64_t dim, int64_t tileSize,
+                                  const GuardedStores &guarded,
+                                  DenseMap<Value, int64_t> &visited) {
+  auto known = visited.find(value);
+  if (known != visited.end())
+    return known->second == dim;
+  visited[value] = dim;
+
+  if (!keepsWrappedDim(value, dim, tileSize))
+    return false;
+
+  auto reaches = [&](Value next, int64_t nextDim) {
+    return tileReachesOnlyGuardedStores(next, nextDim, tileSize, guarded,
+                                        visited);
+  };
+
+  for (OpOperand &use : value.getUses()) {
+    Operation *user = use.getOwner();
+
+    if (auto store = dyn_cast<triton::StoreOp>(user)) {
+      // As an address or a mask the tile is no longer the data reasoned about.
+      if (store.getValue() != value)
+        return false;
+      auto guard = guarded.find(store.getOperation());
+      if (guard == guarded.end() || !(guard->second & (1u << dim)))
+        return false;
+      continue;
+    }
+    if (auto expand = dyn_cast<triton::ExpandDimsOp>(user)) {
+      std::optional<int64_t> next = mapDimThroughExpand(dim, expand);
+      if (!next || !reaches(expand.getResult(), *next))
+        return false;
+      continue;
+    }
+    if (auto transpose = dyn_cast<triton::TransOp>(user)) {
+      std::optional<int64_t> next = mapDimThroughTrans(dim, transpose);
+      if (!next || !reaches(transpose.getResult(), *next))
+        return false;
+      continue;
+    }
+    if (auto broadcast = dyn_cast<triton::BroadcastOp>(user)) {
+      if (!broadcastKeepsDim(broadcast, dim) ||
+          !reaches(broadcast.getResult(), dim))
+        return false;
+      continue;
+    }
+    if (auto dot = dyn_cast<triton::DotOp>(user)) {
+      // Zeros on a contracted axis would spread into every output element, so
+      // an operand has to carry the wrapped coordinate on the axis the result
+      // keeps: rows for A, columns for B.
+      if (dot.getA() == value && dim != 0)
+        return false;
+      if (dot.getB() == value && dim != 1)
+        return false;
+      if (!reaches(dot.getResult(), dim))
+        return false;
+      continue;
+    }
+    // Arith ops on tensors are elementwise, so they move no lane.
+    Dialect *dialect = user->getDialect();
+    if (dialect &&
+        dialect->getNamespace() == arith::ArithDialect::getDialectNamespace()) {
+      for (Value result : user->getResults())
+        if (!reaches(result, dim))
+          return false;
+      continue;
+    }
+    if (auto forOp = dyn_cast<scf::ForOp>(user)) {
+      for (auto [index, initArg] : llvm::enumerate(forOp.getInitArgs())) {
+        if (initArg != value)
+          continue;
+        if (!reaches(forOp.getRegionIterArg(index), dim) ||
+            !reaches(forOp.getResult(index), dim))
+          return false;
+      }
+      continue;
+    }
+    if (auto yield = dyn_cast<scf::YieldOp>(user)) {
+      auto forOp = dyn_cast<scf::ForOp>(yield->getParentOp());
+      if (!forOp)
+        return false;
+      unsigned index = use.getOperandNumber();
+      if (index >= forOp.getNumResults())
+        return false;
+      if (!reaches(forOp.getResult(index), dim))
+        return false;
+      continue;
+    }
+
+    return false;
   }
   return true;
 }
@@ -347,40 +589,50 @@ std::optional<ModuloCandidate> analyzeModulo(Operation *op) {
   if (isCompileTimeConstant(candidate.boundScalar))
     return std::nullopt;
 
-  if (!hasStoreMaskGuard(candidate.dividend, candidate.boundScalar))
+  GuardedStores guardedStores;
+  if (!collectStoreMaskGuard(candidate.dividend, candidate.boundScalar,
+                             guardedStores))
     return std::nullopt;
 
-  std::optional<int64_t> axis = getUniqueExpandDimsAxis(candidate.result);
-  if (!axis)
-    return std::nullopt;
-  candidate.axis = *axis;
-
-  SmallPtrSet<Value, 32> visited;
+  DenseMap<Value, int64_t> visited;
   SmallVector<Operation *, 2> carriedForChain;
-  if (!collectAddressedLoads(candidate.result, visited, candidate.loads,
-                             carriedForChain))
+  if (!collectAddressedLoads(candidate.result, /*dim=*/0, visited,
+                             candidate.loads, carriedForChain))
     return std::nullopt;
-  if (!areLoadsMaskable(candidate.loads, candidate.axis, candidate.tileSize))
+  if (!areLoadsMaskable(candidate.loads, candidate.tileSize))
     return std::nullopt;
+
+  for (const AddressedLoad &addressed : candidate.loads) {
+    triton::LoadOp load = addressed.load;
+    DenseMap<Value, int64_t> tileVisited;
+    if (!tileReachesOnlyGuardedStores(load.getResult(), addressed.dim,
+                                      candidate.tileSize, guardedStores,
+                                      tileVisited))
+      return std::nullopt;
+  }
 
   return candidate;
 }
 
 bool matchesCandidate(const ModuloCandidate &candidate,
                       const ModuloCandidate &current) {
-  return candidate.anchor == current.anchor &&
-         candidate.dividend == current.dividend &&
-         candidate.divisor == current.divisor &&
-         candidate.boundScalar == current.boundScalar &&
-         candidate.result == current.result &&
-         candidate.tileSize == current.tileSize &&
-         candidate.axis == current.axis &&
-         candidate.patternOps.size() == current.patternOps.size() &&
-         std::equal(candidate.patternOps.begin(), candidate.patternOps.end(),
-                    current.patternOps.begin()) &&
-         candidate.loads.size() == current.loads.size() &&
-         std::equal(candidate.loads.begin(), candidate.loads.end(),
-                    current.loads.begin());
+  if (candidate.anchor != current.anchor ||
+      candidate.dividend != current.dividend ||
+      candidate.divisor != current.divisor ||
+      candidate.boundScalar != current.boundScalar ||
+      candidate.result != current.result ||
+      candidate.tileSize != current.tileSize ||
+      candidate.patternOps.size() != current.patternOps.size() ||
+      !std::equal(candidate.patternOps.begin(), candidate.patternOps.end(),
+                  current.patternOps.begin()) ||
+      candidate.loads.size() != current.loads.size())
+    return false;
+  for (auto [planned, found] :
+       llvm::zip_equal(candidate.loads, current.loads)) {
+    if (planned.load != found.load || planned.dim != found.dim)
+      return false;
+  }
+  return true;
 }
 
 void eraseCreatedOperations(IRRewriter &rewriter,
@@ -422,29 +674,40 @@ LogicalResult applyCandidate(IRRewriter &rewriter,
     return fail();
 
   SmallVector<LoadMask, 4> loadMasks;
-  for (triton::LoadOp load : candidate.loads) {
+  for (const AddressedLoad &addressed : candidate.loads) {
+    triton::LoadOp load = addressed.load;
     auto loadType = dyn_cast<RankedTensorType>(load.getResult().getType());
     if (!loadType)
       return fail();
 
     rewriter.setInsertionPoint(load);
     Location loadLoc = load.getLoc();
-    auto expanded = rewriter.create<triton::ExpandDimsOp>(
-        loadLoc, boundary.getResult(), static_cast<int32_t>(candidate.axis));
-    if (!recordVerifiedOperation(expanded.getOperation(), created))
-      return fail();
 
-    auto maskType =
-        RankedTensorType::get(loadType.getShape(), rewriter.getI1Type());
-    auto broadcast = rewriter.create<triton::BroadcastOp>(loadLoc, maskType,
-                                                          expanded.getResult());
-    if (!recordVerifiedOperation(broadcast.getOperation(), created))
-      return fail();
+    // The comparison already has one lane per tile element.  Putting the unit
+    // dimension where the load does not vary leaves it varying along the same
+    // dimension as the address it masks.
+    Value mask = boundary.getResult();
+    if (loadType.getRank() == 2) {
+      auto expanded = rewriter.create<triton::ExpandDimsOp>(
+          loadLoc, mask, static_cast<int32_t>(1 - addressed.dim));
+      if (!recordVerifiedOperation(expanded.getOperation(), created))
+        return fail();
+      mask = expanded.getResult();
+    }
+    if (cast<RankedTensorType>(mask.getType()).getShape() !=
+        loadType.getShape()) {
+      auto maskType =
+          RankedTensorType::get(loadType.getShape(), rewriter.getI1Type());
+      auto broadcast =
+          rewriter.create<triton::BroadcastOp>(loadLoc, maskType, mask);
+      if (!recordVerifiedOperation(broadcast.getOperation(), created))
+        return fail();
+      mask = broadcast.getResult();
+    }
 
-    LoadMask loadMask{load, broadcast.getResult(), nullptr};
+    LoadMask loadMask{load, mask, nullptr};
     if (Value existing = load.getMask()) {
-      auto combined = rewriter.create<arith::AndIOp>(loadLoc, existing,
-                                                     broadcast.getResult());
+      auto combined = rewriter.create<arith::AndIOp>(loadLoc, existing, mask);
       if (!recordVerifiedOperation(combined.getOperation(), created))
         return fail();
       loadMask.mask = combined.getResult();

--- a/third_party/ascend/unittest/Conversion/General/TritonToGraph/convert_modulo_to_mask.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToGraph/convert_modulo_to_mask.mlir
@@ -369,6 +369,263 @@ tt.func public @modulo_load_inside_nested_loop(%base: !tt.ptr<f16> {tt.divisibil
 }
 
 // -----
+// In a debug build every tile offset carries an overflow-check cone.  It ends in
+// tt.assert, which has no results, so it never observes the un-wrapped index and
+// must not block the rewrite.
+// CHECK-LABEL: tt.func public @modulo_with_overflow_sanitizer_cone
+// CHECK-NOT: arith.remsi
+// CHECK: %[[BOUND:.*]] = arith.cmpi slt
+// CHECK: tt.assert
+// CHECK: %[[EXPAND:.*]] = tt.expand_dims %[[BOUND]] {axis = 0 : i32}
+// CHECK: %[[MASK:.*]] = tt.broadcast %[[EXPAND]]
+// CHECK: tt.load %{{.*}}, %[[MASK]], %{{.*}} : tensor<32x16x!tt.ptr<f16>>
+// CHECK-NOT: arith.remsi
+// DISABLED-LABEL: tt.func public @modulo_with_overflow_sanitizer_cone
+// DISABLED: arith.remsi
+tt.func public @modulo_with_overflow_sanitizer_cone(%base: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                                                   %dst: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                                                   %n: i32) {
+  %c16 = arith.constant 16 : i32
+  %pid = tt.get_program_id x : i32
+  %blk = arith.muli %pid, %c16 : i32
+  %blk_splat = tt.splat %blk : i32 -> tensor<16xi32>
+  %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %offs = arith.addi %blk_splat, %range : tensor<16xi32>
+  %n_splat = tt.splat %n : i32 -> tensor<16xi32>
+  %rem = arith.remsi %offs, %n_splat : tensor<16xi32>
+
+  %rem_expd = tt.expand_dims %rem {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+
+  // The sanitizer cone is a side use of the very value that addresses the load.
+  %wide = arith.extsi %rem_expd : tensor<1x16xi32> to tensor<1x16xi64>
+  %stride_wide = arith.constant dense<4> : tensor<1x16xi64>
+  %prod_wide = arith.muli %wide, %stride_wide : tensor<1x16xi64>
+  %i32_max = arith.constant dense<2147483647> : tensor<1x16xi64>
+  %i32_min = arith.constant dense<-2147483648> : tensor<1x16xi64>
+  %le = arith.cmpi sle, %prod_wide, %i32_max : tensor<1x16xi64>
+  %ge = arith.cmpi sge, %prod_wide, %i32_min : tensor<1x16xi64>
+  %ok = arith.andi %le, %ge : tensor<1x16xi1>
+  tt.assert %ok, "int32 overflow detected for operation mul" {tt.auto_overflow_assert} : tensor<1x16xi1>
+
+  %rem_bc = tt.broadcast %rem_expd : tensor<1x16xi32> -> tensor<32x16xi32>
+  %row = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+  %row_expd = tt.expand_dims %row {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+  %row_stride = arith.constant dense<16> : tensor<32x1xi32>
+  %row_scaled = arith.muli %row_expd, %row_stride : tensor<32x1xi32>
+  %row_bc = tt.broadcast %row_scaled : tensor<32x1xi32> -> tensor<32x16xi32>
+  %addr = arith.addi %row_bc, %rem_bc : tensor<32x16xi32>
+  %base_splat = tt.splat %base : !tt.ptr<f16> -> tensor<32x16x!tt.ptr<f16>>
+  %ptrs = tt.addptr %base_splat, %addr : tensor<32x16x!tt.ptr<f16>>, tensor<32x16xi32>
+  %val = tt.load %ptrs : tensor<32x16x!tt.ptr<f16>>
+
+  %guard = arith.cmpi slt, %offs, %n_splat : tensor<16xi32>
+  %guard_expd = tt.expand_dims %guard {axis = 0 : i32} : tensor<16xi1> -> tensor<1x16xi1>
+  %guard_bc = tt.broadcast %guard_expd : tensor<1x16xi1> -> tensor<32x16xi1>
+  %col_expd = tt.expand_dims %offs {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+  %col_bc = tt.broadcast %col_expd : tensor<1x16xi32> -> tensor<32x16xi32>
+  %out_addr = arith.addi %row_bc, %col_bc : tensor<32x16xi32>
+  %dst_splat = tt.splat %dst : !tt.ptr<f16> -> tensor<32x16x!tt.ptr<f16>>
+  %out_ptrs = tt.addptr %dst_splat, %out_addr : tensor<32x16x!tt.ptr<f16>>, tensor<32x16xi32>
+  tt.store %out_ptrs, %val, %guard_bc : tensor<32x16x!tt.ptr<f16>>
+  tt.return
+}
+
+// -----
+// Negative: the same cone without the frontend marker may be a user
+// device_assert, which would start checking a condition the kernel never wrote.
+// CHECK-LABEL: tt.func public @modulo_skip_unmarked_assert_cone
+// CHECK: arith.remsi
+tt.func public @modulo_skip_unmarked_assert_cone(%base: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                                                %dst: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                                                %n: i32) {
+  %c16 = arith.constant 16 : i32
+  %pid = tt.get_program_id x : i32
+  %blk = arith.muli %pid, %c16 : i32
+  %blk_splat = tt.splat %blk : i32 -> tensor<16xi32>
+  %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %offs = arith.addi %blk_splat, %range : tensor<16xi32>
+  %n_splat = tt.splat %n : i32 -> tensor<16xi32>
+  %rem = arith.remsi %offs, %n_splat : tensor<16xi32>
+
+  %rem_expd = tt.expand_dims %rem {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+  %wide = arith.extsi %rem_expd : tensor<1x16xi32> to tensor<1x16xi64>
+  %i32_max = arith.constant dense<2147483647> : tensor<1x16xi64>
+  %le = arith.cmpi sle, %wide, %i32_max : tensor<1x16xi64>
+  tt.assert %le, "int32 overflow detected for operation mul" : tensor<1x16xi1>
+
+  %rem_bc = tt.broadcast %rem_expd : tensor<1x16xi32> -> tensor<32x16xi32>
+  %row = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+  %row_expd = tt.expand_dims %row {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+  %row_stride = arith.constant dense<16> : tensor<32x1xi32>
+  %row_scaled = arith.muli %row_expd, %row_stride : tensor<32x1xi32>
+  %row_bc = tt.broadcast %row_scaled : tensor<32x1xi32> -> tensor<32x16xi32>
+  %addr = arith.addi %row_bc, %rem_bc : tensor<32x16xi32>
+  %base_splat = tt.splat %base : !tt.ptr<f16> -> tensor<32x16x!tt.ptr<f16>>
+  %ptrs = tt.addptr %base_splat, %addr : tensor<32x16x!tt.ptr<f16>>, tensor<32x16xi32>
+  %val = tt.load %ptrs : tensor<32x16x!tt.ptr<f16>>
+
+  %guard = arith.cmpi slt, %offs, %n_splat : tensor<16xi32>
+  %guard_expd = tt.expand_dims %guard {axis = 0 : i32} : tensor<16xi1> -> tensor<1x16xi1>
+  %guard_bc = tt.broadcast %guard_expd : tensor<1x16xi1> -> tensor<32x16xi1>
+  %col_expd = tt.expand_dims %offs {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+  %col_bc = tt.broadcast %col_expd : tensor<1x16xi32> -> tensor<32x16xi32>
+  %out_addr = arith.addi %row_bc, %col_bc : tensor<32x16xi32>
+  %dst_splat = tt.splat %dst : !tt.ptr<f16> -> tensor<32x16x!tt.ptr<f16>>
+  %out_ptrs = tt.addptr %dst_splat, %out_addr : tensor<32x16x!tt.ptr<f16>>, tensor<32x16xi32>
+  tt.store %out_ptrs, %val, %guard_bc : tensor<32x16x!tt.ptr<f16>>
+  tt.return
+}
+
+// -----
+// Negative: the widened index goes on to address a second load instead of
+// stopping at an assert, so it reaches memory and the wrap has to stay.
+// CHECK-LABEL: tt.func public @modulo_skip_widened_index_reaches_load
+// CHECK: arith.remsi
+tt.func public @modulo_skip_widened_index_reaches_load(%base: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                                                      %dst: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                                                      %n: i32) {
+  %c16 = arith.constant 16 : i32
+  %pid = tt.get_program_id x : i32
+  %blk = arith.muli %pid, %c16 : i32
+  %blk_splat = tt.splat %blk : i32 -> tensor<16xi32>
+  %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %offs = arith.addi %blk_splat, %range : tensor<16xi32>
+  %n_splat = tt.splat %n : i32 -> tensor<16xi32>
+  %rem = arith.remsi %offs, %n_splat : tensor<16xi32>
+
+  %rem_expd = tt.expand_dims %rem {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+  %rem_bc = tt.broadcast %rem_expd : tensor<1x16xi32> -> tensor<32x16xi32>
+  %row = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+  %row_expd = tt.expand_dims %row {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+  %row_stride = arith.constant dense<16> : tensor<32x1xi32>
+  %row_scaled = arith.muli %row_expd, %row_stride : tensor<32x1xi32>
+  %row_bc = tt.broadcast %row_scaled : tensor<32x1xi32> -> tensor<32x16xi32>
+  %addr = arith.addi %row_bc, %rem_bc : tensor<32x16xi32>
+  %base_splat = tt.splat %base : !tt.ptr<f16> -> tensor<32x16x!tt.ptr<f16>>
+  %ptrs = tt.addptr %base_splat, %addr : tensor<32x16x!tt.ptr<f16>>, tensor<32x16xi32>
+  %val = tt.load %ptrs : tensor<32x16x!tt.ptr<f16>>
+
+  // The widened index addresses memory instead of only feeding a check.
+  %wide = arith.extsi %rem_expd : tensor<1x16xi32> to tensor<1x16xi64>
+  %wide_bc = tt.broadcast %wide : tensor<1x16xi64> -> tensor<32x16xi64>
+  %wide_ptrs = tt.addptr %base_splat, %wide_bc : tensor<32x16x!tt.ptr<f16>>, tensor<32x16xi64>
+  %wide_val = tt.load %wide_ptrs : tensor<32x16x!tt.ptr<f16>>
+  %sum = arith.addf %val, %wide_val : tensor<32x16xf16>
+
+  %guard = arith.cmpi slt, %offs, %n_splat : tensor<16xi32>
+  %guard_expd = tt.expand_dims %guard {axis = 0 : i32} : tensor<16xi1> -> tensor<1x16xi1>
+  %guard_bc = tt.broadcast %guard_expd : tensor<1x16xi1> -> tensor<32x16xi1>
+  %col_expd = tt.expand_dims %offs {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+  %col_bc = tt.broadcast %col_expd : tensor<1x16xi32> -> tensor<32x16xi32>
+  %out_addr = arith.addi %row_bc, %col_bc : tensor<32x16xi32>
+  %dst_splat = tt.splat %dst : !tt.ptr<f16> -> tensor<32x16x!tt.ptr<f16>>
+  %out_ptrs = tt.addptr %dst_splat, %out_addr : tensor<32x16x!tt.ptr<f16>>, tensor<32x16xi32>
+  tt.store %out_ptrs, %sum, %guard_bc : tensor<32x16x!tt.ptr<f16>>
+  tt.return
+}
+
+// -----
+// Negative: the guard belongs to an unrelated store while the wrapped tile
+// leaves through an unmasked one, so the injected zeros would be written out
+// over what a deliberate circular index was meant to fetch.
+// CHECK-LABEL: tt.func public @modulo_skip_guard_from_unrelated_store
+// CHECK: arith.remsi
+tt.func public @modulo_skip_guard_from_unrelated_store(%base: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                                                      %dst: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                                                      %side: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                                                      %n: i32) {
+  %c16 = arith.constant 16 : i32
+  %pid = tt.get_program_id x : i32
+  %blk = arith.muli %pid, %c16 : i32
+  %blk_splat = tt.splat %blk : i32 -> tensor<16xi32>
+  %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %offs = arith.addi %blk_splat, %range : tensor<16xi32>
+  %n_splat = tt.splat %n : i32 -> tensor<16xi32>
+  %rem = arith.remsi %offs, %n_splat : tensor<16xi32>
+
+  %rem_expd = tt.expand_dims %rem {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+  %rem_bc = tt.broadcast %rem_expd : tensor<1x16xi32> -> tensor<32x16xi32>
+  %row = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+  %row_expd = tt.expand_dims %row {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+  %row_stride = arith.constant dense<16> : tensor<32x1xi32>
+  %row_scaled = arith.muli %row_expd, %row_stride : tensor<32x1xi32>
+  %row_bc = tt.broadcast %row_scaled : tensor<32x1xi32> -> tensor<32x16xi32>
+  %addr = arith.addi %row_bc, %rem_bc : tensor<32x16xi32>
+  %base_splat = tt.splat %base : !tt.ptr<f16> -> tensor<32x16x!tt.ptr<f16>>
+  %ptrs = tt.addptr %base_splat, %addr : tensor<32x16x!tt.ptr<f16>>, tensor<32x16xi32>
+  %val = tt.load %ptrs : tensor<32x16x!tt.ptr<f16>>
+
+  // This guarded store supplies the proof, but it writes an unrelated value.
+  %guard = arith.cmpi slt, %offs, %n_splat : tensor<16xi32>
+  %guard_expd = tt.expand_dims %guard {axis = 0 : i32} : tensor<16xi1> -> tensor<1x16xi1>
+  %guard_bc = tt.broadcast %guard_expd : tensor<1x16xi1> -> tensor<32x16xi1>
+  %col_expd = tt.expand_dims %offs {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+  %col_bc = tt.broadcast %col_expd : tensor<1x16xi32> -> tensor<32x16xi32>
+  %side_addr = arith.addi %row_bc, %col_bc : tensor<32x16xi32>
+  %side_splat = tt.splat %side : !tt.ptr<f16> -> tensor<32x16x!tt.ptr<f16>>
+  %side_ptrs = tt.addptr %side_splat, %side_addr : tensor<32x16x!tt.ptr<f16>>, tensor<32x16xi32>
+  %ones = arith.constant dense<1.000000e+00> : tensor<32x16xf16>
+  tt.store %side_ptrs, %ones, %guard_bc : tensor<32x16x!tt.ptr<f16>>
+
+  // The wrapped tile itself leaves through a store that keeps every lane.
+  %dst_splat = tt.splat %dst : !tt.ptr<f16> -> tensor<32x16x!tt.ptr<f16>>
+  %out_ptrs = tt.addptr %dst_splat, %row_bc : tensor<32x16x!tt.ptr<f16>>, tensor<32x16xi32>
+  tt.store %out_ptrs, %val : tensor<32x16x!tt.ptr<f16>>
+  tt.return
+}
+
+// -----
+// A transpose moves the wrapped lanes from the columns of the tile to the rows
+// of the stored value, and the store mask discards exactly those rows.  The
+// permutation is tracked, so the injected mask still zeros the lanes the store
+// drops and the wrap can go.
+// CHECK-LABEL: tt.func public @modulo_tile_transposed_before_store
+// CHECK-NOT: arith.remsi
+// CHECK: %[[BOUND:.*]] = arith.cmpi slt
+// CHECK: %[[EXPAND:.*]] = tt.expand_dims %[[BOUND]] {axis = 0 : i32}
+// CHECK: %[[MASK:.*]] = tt.broadcast %[[EXPAND]]
+// CHECK: tt.load %{{.*}}, %[[MASK]], %{{.*}} : tensor<32x16x!tt.ptr<f16>>
+// CHECK: tt.trans
+// CHECK-NOT: arith.remsi
+tt.func public @modulo_tile_transposed_before_store(%base: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                                                   %dst: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                                                   %n: i32) {
+  %c16 = arith.constant 16 : i32
+  %pid = tt.get_program_id x : i32
+  %blk = arith.muli %pid, %c16 : i32
+  %blk_splat = tt.splat %blk : i32 -> tensor<16xi32>
+  %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %offs = arith.addi %blk_splat, %range : tensor<16xi32>
+  %n_splat = tt.splat %n : i32 -> tensor<16xi32>
+  %rem = arith.remsi %offs, %n_splat : tensor<16xi32>
+
+  %rem_expd = tt.expand_dims %rem {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+  %rem_bc = tt.broadcast %rem_expd : tensor<1x16xi32> -> tensor<32x16xi32>
+  %row = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+  %row_expd = tt.expand_dims %row {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+  %row_stride = arith.constant dense<16> : tensor<32x1xi32>
+  %row_scaled = arith.muli %row_expd, %row_stride : tensor<32x1xi32>
+  %row_bc = tt.broadcast %row_scaled : tensor<32x1xi32> -> tensor<32x16xi32>
+  %addr = arith.addi %row_bc, %rem_bc : tensor<32x16xi32>
+  %base_splat = tt.splat %base : !tt.ptr<f16> -> tensor<32x16x!tt.ptr<f16>>
+  %ptrs = tt.addptr %base_splat, %addr : tensor<32x16x!tt.ptr<f16>>, tensor<32x16xi32>
+  %val = tt.load %ptrs : tensor<32x16x!tt.ptr<f16>>
+  %flipped = tt.trans %val {order = array<i32: 1, 0>} : tensor<32x16xf16> -> tensor<16x32xf16>
+
+  %guard = arith.cmpi slt, %offs, %n_splat : tensor<16xi32>
+  %guard_expd = tt.expand_dims %guard {axis = 1 : i32} : tensor<16xi1> -> tensor<16x1xi1>
+  %guard_bc = tt.broadcast %guard_expd : tensor<16x1xi1> -> tensor<16x32xi1>
+  %out_row = tt.expand_dims %offs {axis = 1 : i32} : tensor<16xi32> -> tensor<16x1xi32>
+  %out_stride = arith.constant dense<32> : tensor<16x1xi32>
+  %out_scaled = arith.muli %out_row, %out_stride : tensor<16x1xi32>
+  %out_bc = tt.broadcast %out_scaled : tensor<16x1xi32> -> tensor<16x32xi32>
+  %dst_splat = tt.splat %dst : !tt.ptr<f16> -> tensor<16x32x!tt.ptr<f16>>
+  %out_ptrs = tt.addptr %dst_splat, %out_bc : tensor<16x32x!tt.ptr<f16>>, tensor<16x32xi32>
+  tt.store %out_ptrs, %flipped, %guard_bc : tensor<16x32x!tt.ptr<f16>>
+  tt.return
+}
+
+// -----
 // Negative: a compile-time constant divisor belongs to TritonToStructured,
 // whose visitOperandRem keeps the wrap and re-expresses it as a strided access.
 // That is exactly equivalent, so it is always preferable to discarding the wrap.
@@ -734,13 +991,180 @@ tt.func public @modulo_skip_transposed_address(%base: !tt.ptr<f16> {tt.divisibil
 }
 
 // -----
-// Negative: a rank-one load has no second dimension for the boundary mask to
-// leave alone, and it is already a contiguous transfer.
-// CHECK-LABEL: tt.func public @modulo_skip_rank_one_load
+// A rank-one load needs no expand_dims: the comparison already has one lane per
+// tile element, so it is the mask.  Such a load is how a block-quantised matmul
+// reads its scale vector, and rejecting it used to veto the whole candidate
+// including the weight tile beside it.
+// CHECK-LABEL: tt.func public @modulo_rank_one_load
+// CHECK-NOT: arith.remsi
+// CHECK: %[[BOUND:.*]] = arith.cmpi slt
+// CHECK: %[[FILL:.*]] = arith.constant dense<0.000000e+00> : tensor<16xf32>
+// CHECK: tt.load %{{.*}}, %[[BOUND]], %[[FILL]] : tensor<16x!tt.ptr<f32>>
+// CHECK-NOT: arith.remsi
+tt.func public @modulo_rank_one_load(%base: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                     %dst: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                     %n: i32) {
+  %c16 = arith.constant 16 : i32
+  %pid = tt.get_program_id x : i32
+  %blk = arith.muli %pid, %c16 : i32
+  %blk_splat = tt.splat %blk : i32 -> tensor<16xi32>
+  %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %offs = arith.addi %blk_splat, %range : tensor<16xi32>
+  %n_splat = tt.splat %n : i32 -> tensor<16xi32>
+  %rem = arith.remsi %offs, %n_splat : tensor<16xi32>
+
+  %base_splat = tt.splat %base : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+  %ptrs = tt.addptr %base_splat, %rem : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+  %val = tt.load %ptrs : tensor<16x!tt.ptr<f32>>
+
+  %guard = arith.cmpi slt, %offs, %n_splat : tensor<16xi32>
+  %dst_splat = tt.splat %dst : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+  %out_ptrs = tt.addptr %dst_splat, %offs : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+  tt.store %out_ptrs, %val, %guard : tensor<16x!tt.ptr<f32>>
+  tt.return
+}
+
+// -----
+// The wrapped column index also addresses a scale vector through a division by
+// the group size.  A uniform divisor leaves each lane of the derived index a
+// function of the same lane of the tracked one, so the one boundary mask fits
+// both loads.  The derived index may now run past the scale array, but only on
+// lanes the mask removes, so those lanes are never read.  This is the shape a
+// block-quantised fused-MoE weight tile has, and the scale load used to veto it.
+// CHECK-LABEL: tt.func public @modulo_derived_index_addresses_scale_vector
+// CHECK-NOT: arith.remsi
+// CHECK: %[[BOUND:.*]] = arith.cmpi slt
+// CHECK: %[[EXPAND:.*]] = tt.expand_dims %[[BOUND]] {axis = 0 : i32}
+// CHECK: %[[MASK:.*]] = tt.broadcast %[[EXPAND]]
+// CHECK: tt.load %{{.*}}, %[[MASK]], %{{.*}} : tensor<32x16x!tt.ptr<f32>>
+// CHECK: arith.divsi
+// CHECK: tt.load %{{.*}}, %[[BOUND]], %{{.*}} : tensor<16x!tt.ptr<f32>>
+// CHECK-NOT: arith.remsi
+// DISABLED-LABEL: tt.func public @modulo_derived_index_addresses_scale_vector
+// DISABLED: arith.remsi
+tt.func public @modulo_derived_index_addresses_scale_vector(%base: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                                           %scale: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                                           %dst: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                                           %n: i32) {
+  %c16 = arith.constant 16 : i32
+  %pid = tt.get_program_id x : i32
+  %blk = arith.muli %pid, %c16 : i32
+  %blk_splat = tt.splat %blk : i32 -> tensor<16xi32>
+  %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %offs = arith.addi %blk_splat, %range : tensor<16xi32>
+  %n_splat = tt.splat %n : i32 -> tensor<16xi32>
+  %rem = arith.remsi %offs, %n_splat : tensor<16xi32>
+
+  // The weight tile, addressed by the wrapped index on its column axis.
+  %rem_expd = tt.expand_dims %rem {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+  %rem_bc = tt.broadcast %rem_expd : tensor<1x16xi32> -> tensor<32x16xi32>
+  %row = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+  %row_expd = tt.expand_dims %row {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+  %row_stride = arith.constant dense<16> : tensor<32x1xi32>
+  %row_scaled = arith.muli %row_expd, %row_stride : tensor<32x1xi32>
+  %row_bc = tt.broadcast %row_scaled : tensor<32x1xi32> -> tensor<32x16xi32>
+  %addr = arith.addi %row_bc, %rem_bc : tensor<32x16xi32>
+  %base_splat = tt.splat %base : !tt.ptr<f32> -> tensor<32x16x!tt.ptr<f32>>
+  %ptrs = tt.addptr %base_splat, %addr : tensor<32x16x!tt.ptr<f32>>, tensor<32x16xi32>
+  %tile = tt.load %ptrs : tensor<32x16x!tt.ptr<f32>>
+
+  // The per-group scale vector, addressed by the same index over the group size.
+  %group = arith.constant dense<8> : tensor<16xi32>
+  %group_index = arith.divsi %rem, %group : tensor<16xi32>
+  %scale_splat = tt.splat %scale : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+  %scale_ptrs = tt.addptr %scale_splat, %group_index : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+  %scales = tt.load %scale_ptrs : tensor<16x!tt.ptr<f32>>
+
+  %scales_expd = tt.expand_dims %scales {axis = 0 : i32} : tensor<16xf32> -> tensor<1x16xf32>
+  %scales_bc = tt.broadcast %scales_expd : tensor<1x16xf32> -> tensor<32x16xf32>
+  %scaled = arith.mulf %tile, %scales_bc : tensor<32x16xf32>
+
+  %guard = arith.cmpi slt, %offs, %n_splat : tensor<16xi32>
+  %guard_expd = tt.expand_dims %guard {axis = 0 : i32} : tensor<16xi1> -> tensor<1x16xi1>
+  %guard_bc = tt.broadcast %guard_expd : tensor<1x16xi1> -> tensor<32x16xi1>
+  %col_expd = tt.expand_dims %offs {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+  %col_bc = tt.broadcast %col_expd : tensor<1x16xi32> -> tensor<32x16xi32>
+  %out_addr = arith.addi %row_bc, %col_bc : tensor<32x16xi32>
+  %dst_splat = tt.splat %dst : !tt.ptr<f32> -> tensor<32x16x!tt.ptr<f32>>
+  %out_ptrs = tt.addptr %dst_splat, %out_addr : tensor<32x16x!tt.ptr<f32>>, tensor<32x16xi32>
+  tt.store %out_ptrs, %scaled, %guard_bc : tensor<32x16x!tt.ptr<f32>>
+  tt.return
+}
+
+// -----
+// Swapping the operands of the dot transposes the wrapped tile in and the
+// result back out.  Every step is a permutation of known dimensions, so the
+// wrapped lanes are still the ones the store mask discards even though both
+// intermediate shapes are square.
+// CHECK-LABEL: tt.func public @modulo_tile_transposed_through_dot
+// CHECK-NOT: arith.remsi
+// CHECK: %[[BOUND:.*]] = arith.cmpi slt
+// CHECK: %[[EXPAND:.*]] = tt.expand_dims %[[BOUND]] {axis = 0 : i32}
+// CHECK: %[[MASK:.*]] = tt.broadcast %[[EXPAND]]
+// CHECK: tt.load %{{.*}}, %[[MASK]], %{{.*}} : tensor<8x16x!tt.ptr<f32>>
+// CHECK: tt.dot
+// CHECK-NOT: arith.remsi
+tt.func public @modulo_tile_transposed_through_dot(%base: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                                   %other: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                                   %dst: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                                   %n: i32) {
+  %c16 = arith.constant 16 : i32
+  %pid = tt.get_program_id x : i32
+  %blk = arith.muli %pid, %c16 : i32
+  %blk_splat = tt.splat %blk : i32 -> tensor<16xi32>
+  %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %offs = arith.addi %blk_splat, %range : tensor<16xi32>
+  %n_splat = tt.splat %n : i32 -> tensor<16xi32>
+  %rem = arith.remsi %offs, %n_splat : tensor<16xi32>
+
+  // The wrapped index addresses the columns of an 8x16 tile.
+  %rem_expd = tt.expand_dims %rem {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+  %rem_bc = tt.broadcast %rem_expd : tensor<1x16xi32> -> tensor<8x16xi32>
+  %row = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+  %row_expd = tt.expand_dims %row {axis = 1 : i32} : tensor<8xi32> -> tensor<8x1xi32>
+  %row_stride = arith.constant dense<16> : tensor<8x1xi32>
+  %row_scaled = arith.muli %row_expd, %row_stride : tensor<8x1xi32>
+  %row_bc = tt.broadcast %row_scaled : tensor<8x1xi32> -> tensor<8x16xi32>
+  %addr = arith.addi %row_bc, %rem_bc : tensor<8x16xi32>
+  %base_splat = tt.splat %base : !tt.ptr<f32> -> tensor<8x16x!tt.ptr<f32>>
+  %ptrs = tt.addptr %base_splat, %addr : tensor<8x16x!tt.ptr<f32>>, tensor<8x16xi32>
+  %tile = tt.load %ptrs : tensor<8x16x!tt.ptr<f32>>
+
+  // Transposed it becomes the left operand, so the wrapped lanes are its rows.
+  %flipped = tt.trans %tile {order = array<i32: 1, 0>} : tensor<8x16xf32> -> tensor<16x8xf32>
+  // The right operand carries no wrapped lane, so it is addressed linearly.
+  %other_splat = tt.splat %other : !tt.ptr<f32> -> tensor<8x16x!tt.ptr<f32>>
+  %other_ptrs = tt.addptr %other_splat, %row_bc : tensor<8x16x!tt.ptr<f32>>, tensor<8x16xi32>
+  %rhs = tt.load %other_ptrs : tensor<8x16x!tt.ptr<f32>>
+  %acc = arith.constant dense<0.000000e+00> : tensor<16x16xf32>
+  %product = tt.dot %flipped, %rhs, %acc : tensor<16x8xf32> * tensor<8x16xf32> -> tensor<16x16xf32>
+
+  // Transposing the result back puts the wrapped lanes on the stored columns.
+  %result = tt.trans %product {order = array<i32: 1, 0>} : tensor<16x16xf32> -> tensor<16x16xf32>
+
+  %guard = arith.cmpi slt, %offs, %n_splat : tensor<16xi32>
+  %guard_expd = tt.expand_dims %guard {axis = 0 : i32} : tensor<16xi1> -> tensor<1x16xi1>
+  %guard_bc = tt.broadcast %guard_expd : tensor<1x16xi1> -> tensor<16x16xi1>
+  %out_row = tt.expand_dims %range {axis = 1 : i32} : tensor<16xi32> -> tensor<16x1xi32>
+  %out_stride = arith.constant dense<16> : tensor<16x1xi32>
+  %out_scaled = arith.muli %out_row, %out_stride : tensor<16x1xi32>
+  %out_bc = tt.broadcast %out_scaled : tensor<16x1xi32> -> tensor<16x16xi32>
+  %dst_splat = tt.splat %dst : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+  %out_ptrs = tt.addptr %dst_splat, %out_bc : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+  tt.store %out_ptrs, %result, %guard_bc : tensor<16x16x!tt.ptr<f32>>
+  tt.return
+}
+
+// -----
+// Negative: the tile and the store mask are both square, but the mask discards
+// rows while the wrapped index varies along the columns.  Only tracking which
+// dimension the guard belongs to separates this from the transposing cases
+// above; a shape comparison alone cannot.
+// CHECK-LABEL: tt.func public @modulo_skip_guard_on_other_square_dim
 // CHECK: arith.remsi
-tt.func public @modulo_skip_rank_one_load(%base: !tt.ptr<f32> {tt.divisibility = 16 : i32},
-                                         %dst: !tt.ptr<f32> {tt.divisibility = 16 : i32},
-                                         %n: i32) {
+tt.func public @modulo_skip_guard_on_other_square_dim(%base: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                                                     %dst: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                                                     %n: i32) {
   %c16 = arith.constant 16 : i32
   %pid = tt.get_program_id x : i32
   %blk = arith.muli %pid, %c16 : i32
@@ -751,8 +1175,80 @@ tt.func public @modulo_skip_rank_one_load(%base: !tt.ptr<f32> {tt.divisibility =
   %rem = arith.remsi %offs, %n_splat : tensor<16xi32>
 
   %rem_expd = tt.expand_dims %rem {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+  %rem_bc = tt.broadcast %rem_expd : tensor<1x16xi32> -> tensor<16x16xi32>
+  %row_expd = tt.expand_dims %range {axis = 1 : i32} : tensor<16xi32> -> tensor<16x1xi32>
+  %row_stride = arith.constant dense<16> : tensor<16x1xi32>
+  %row_scaled = arith.muli %row_expd, %row_stride : tensor<16x1xi32>
+  %row_bc = tt.broadcast %row_scaled : tensor<16x1xi32> -> tensor<16x16xi32>
+  %addr = arith.addi %row_bc, %rem_bc : tensor<16x16xi32>
+  %base_splat = tt.splat %base : !tt.ptr<f16> -> tensor<16x16x!tt.ptr<f16>>
+  %ptrs = tt.addptr %base_splat, %addr : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi32>
+  %val = tt.load %ptrs : tensor<16x16x!tt.ptr<f16>>
+
+  // The guard is expanded on the row axis, so it drops rows, not the columns
+  // the injected mask would zero.
+  %guard = arith.cmpi slt, %offs, %n_splat : tensor<16xi32>
+  %guard_expd = tt.expand_dims %guard {axis = 1 : i32} : tensor<16xi1> -> tensor<16x1xi1>
+  %guard_bc = tt.broadcast %guard_expd : tensor<16x1xi1> -> tensor<16x16xi1>
+  %dst_splat = tt.splat %dst : !tt.ptr<f16> -> tensor<16x16x!tt.ptr<f16>>
+  %out_ptrs = tt.addptr %dst_splat, %row_bc : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi32>
+  tt.store %out_ptrs, %val, %guard_bc : tensor<16x16x!tt.ptr<f16>>
+  tt.return
+}
+
+// -----
+// Negative: the wrapped index is the divisor rather than the dividend, so
+// dropping the wrap changes the divisor every lane is divided by instead of
+// only widening an index.
+// CHECK-LABEL: tt.func public @modulo_skip_derived_index_from_divisor
+// CHECK: arith.remsi
+tt.func public @modulo_skip_derived_index_from_divisor(%base: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                                      %dst: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                                      %n: i32) {
+  %c16 = arith.constant 16 : i32
+  %pid = tt.get_program_id x : i32
+  %blk = arith.muli %pid, %c16 : i32
+  %blk_splat = tt.splat %blk : i32 -> tensor<16xi32>
+  %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %offs = arith.addi %blk_splat, %range : tensor<16xi32>
+  %n_splat = tt.splat %n : i32 -> tensor<16xi32>
+  %rem = arith.remsi %offs, %n_splat : tensor<16xi32>
+
+  %group = arith.constant dense<8> : tensor<16xi32>
+  %derived = arith.divsi %group, %rem : tensor<16xi32>
   %base_splat = tt.splat %base : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
-  %ptrs = tt.addptr %base_splat, %rem : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+  %ptrs = tt.addptr %base_splat, %derived : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+  %val = tt.load %ptrs : tensor<16x!tt.ptr<f32>>
+
+  %guard = arith.cmpi slt, %offs, %n_splat : tensor<16xi32>
+  %dst_splat = tt.splat %dst : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+  %out_ptrs = tt.addptr %dst_splat, %offs : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+  tt.store %out_ptrs, %val, %guard : tensor<16x!tt.ptr<f32>>
+  tt.return
+}
+
+// -----
+// Negative: the divisor of the derived index varies per lane, so which lanes it
+// sends out of bounds no longer follows from the one boundary comparison.
+// CHECK-LABEL: tt.func public @modulo_skip_derived_index_lane_varying_divisor
+// CHECK: arith.remsi
+tt.func public @modulo_skip_derived_index_lane_varying_divisor(%base: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                                              %dst: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                                              %n: i32) {
+  %c16 = arith.constant 16 : i32
+  %pid = tt.get_program_id x : i32
+  %blk = arith.muli %pid, %c16 : i32
+  %blk_splat = tt.splat %blk : i32 -> tensor<16xi32>
+  %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %offs = arith.addi %blk_splat, %range : tensor<16xi32>
+  %n_splat = tt.splat %n : i32 -> tensor<16xi32>
+  %rem = arith.remsi %offs, %n_splat : tensor<16xi32>
+
+  %ones = arith.constant dense<1> : tensor<16xi32>
+  %varying = arith.addi %range, %ones : tensor<16xi32>
+  %derived = arith.divsi %rem, %varying : tensor<16xi32>
+  %base_splat = tt.splat %base : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+  %ptrs = tt.addptr %base_splat, %derived : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
   %val = tt.load %ptrs : tensor<16x!tt.ptr<f32>>
 
   %guard = arith.cmpi slt, %offs, %n_splat : tensor<16xi32>

--- a/third_party/ascend/unittest/pytest_ut/test_graph_optimize.py
+++ b/third_party/ascend/unittest/pytest_ut/test_graph_optimize.py
@@ -116,6 +116,26 @@ def constexpr_wrapped_tile_copy_kernel(src_ptr, dst_ptr, N: tl.constexpr, BLOCK_
 
 
 @triton.jit
+def block_quant_wrapped_tile_kernel(src_ptr, scale_ptr, dst_ptr, n, BLOCK_K: tl.constexpr, BLOCK_N: tl.constexpr,
+                                    GROUP_N: tl.constexpr):
+    # The block-quantised fused-MoE shape: the wrapped column index addresses
+    # the weight tile and, divided by the group size, the rank-one scale vector.
+    # A uniform divisor keeps each lane of that derived index a function of the
+    # same lane, so the one boundary mask covers both loads.
+    pid = tl.program_id(0)
+    offs_n = pid * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+    wrapped = offs_n % n
+    tile = tl.load(src_ptr + (offs_k[:, None] * n + wrapped[None, :]))
+    scales = tl.load(scale_ptr + wrapped // GROUP_N)
+    tl.store(
+        dst_ptr + (offs_k[:, None] * n + offs_n[None, :]),
+        tile * scales[None, :],
+        mask=offs_n[None, :] < n,
+    )
+
+
+@triton.jit
 def overflow_assert_provenance_kernel(output_ptr, n, BLOCK: tl.constexpr):
     offsets = tl.arange(0, BLOCK)
     checked_offset = offsets * n
@@ -918,6 +938,99 @@ def test_convert_modulo_to_mask_numerical_equivalence(monkeypatch, tmp_path):
             compiled.asm["ttir"],
             tmp_path,
             f"wrapped-tile-{rule_mask}",
+        )
+        outputs[rule_mask] = output.cpu()
+
+    assert "arith.remsi" not in compiled.asm["ttir"]
+    torch.testing.assert_close(outputs[255], expected, rtol=0, atol=0)
+    torch.testing.assert_close(outputs[511], outputs[255], rtol=0, atol=0)
+
+
+def make_block_quant_ttir(options, block_k=8, block_n=16, group_n=8):
+    signature = {"src_ptr": "*fp32", "scale_ptr": "*fp32", "dst_ptr": "*fp32", "n": "i32"}
+    constants = {"BLOCK_K": block_k, "BLOCK_N": block_n, "GROUP_N": group_n}
+
+    source = ASTSource(block_quant_wrapped_tile_kernel, signature, constants)
+    context = ir.context()
+    ir.load_dialects(context)
+    ascend_ir.load_dialects(context)
+    module = ast_to_ttir(block_quant_wrapped_tile_kernel, source, context, options, {}, {})
+    return str(make_ttir(module, {}, options))
+
+
+def test_convert_modulo_to_mask_masks_derived_scale_index():
+    """A derived index no longer vetoes the candidate it shares with the tile.
+
+    The scale vector is rank one and is addressed by the wrapped index over the
+    group size.  Both loads take the same boundary mask, so both gain a zero
+    fill; the rank-one one is the evidence that the derived path was walked.
+    """
+    options = NPUOptions(arch="Ascend910B1", enable_graph_optimize=True)
+
+    ttir = make_block_quant_ttir(options)
+
+    assert "arith.remsi" not in ttir
+    assert "arith.cmpi slt" in ttir
+    assert "arith.constant dense<0.000000e+00> : tensor<8x16xf32>" in ttir
+    assert "arith.constant dense<0.000000e+00> : tensor<16xf32>" in ttir
+
+
+def test_convert_modulo_to_mask_derived_index_is_gated_by_its_rule_bit():
+    """Mask 255 is every other identity, so the wrap must survive intact."""
+    options = NPUOptions(
+        arch="Ascend910B1",
+        enable_graph_optimize=True,
+        graph_optimize_rule_mask=255,
+    )
+
+    ttir = make_block_quant_ttir(options)
+
+    assert "arith.remsi" in ttir
+
+
+def test_convert_modulo_to_mask_derived_index_numerical_equivalence(monkeypatch, tmp_path):
+    """The lanes the store keeps must read exactly what the wrap gave them.
+
+    Both loads are rewritten here, so a wrong mask orientation on either would
+    scale the surviving columns by zero rather than by their own group.
+    """
+    torch = _require_npu()
+    monkeypatch.setenv("TRITON_ALWAYS_COMPILE", "1")
+    block_k = 8
+    block_n = 16
+    group_n = 8
+    # A bound that is not a multiple of the tile makes the last program a
+    # boundary tile, which is the only place the wrap ever mattered.
+    bound = 20
+    # The widened lanes address past the end of both arrays instead of folding
+    # back into them, so each allocation carries one tile of slack.  Whether the
+    # lowered transfer really stops at the mask is a TritonToStructured
+    # property, asserted structurally by the tests above.
+    source = torch.rand(block_k * bound + block_n, dtype=torch.float32, device="npu")
+    scales = torch.rand((bound + block_n) // group_n + 1, dtype=torch.float32, device="npu")
+    columns = torch.arange(bound, device="npu")
+    expected = (source[:block_k * bound].view(block_k, bound) * scales[columns // group_n][None, :]).reshape(-1).cpu()
+
+    outputs = {}
+    for rule_mask in (255, 511):
+        block_quant_wrapped_tile_kernel.device_caches.clear()
+        output = torch.zeros(block_k * bound, dtype=torch.float32, device="npu")
+        grid = ((bound + block_n - 1) // block_n, )
+        compiled = block_quant_wrapped_tile_kernel[grid](
+            source,
+            scales,
+            output,
+            bound,
+            BLOCK_K=block_k,
+            BLOCK_N=block_n,
+            GROUP_N=group_n,
+            graph_optimize_rule_mask=rule_mask,
+        )
+        torch.npu.synchronize()
+        assert_ttir_text_reparseable(
+            compiled.asm["ttir"],
+            tmp_path,
+            f"block-quant-{rule_mask}",
         )
         outputs[rule_mask] = output.cpu()
 


### PR DESCRIPTION
The rule proved its rewrite safe with a single axis recorded on the modulo result plus a shape invariant on the data path.  That approximation rejected the shapes a block-quantised fused-MoE weight tile actually has, so the wrap survived and the tile stayed a per-element gather instead of a contiguous transfer.

Track instead, per load, the dimension the wrapped coordinate varies along, and map it through expand_dims, broadcast, trans and dot.  That admits three shapes the rule had to reject before:

  - A derived index, offs_bn // group_n, addressing the scale vector.  A uniform divisor leaves each lane a function of the same lane of the tracked index, so the one boundary mask still zeros exactly the lanes the wrap folded back.  The derived index may run past the array it indexes, but only on lanes the mask removes, so those are never read.
  - A rank-one load.  The comparison already has one lane per tile element, so it is the mask.  Rejecting it used to veto the whole candidate, including the rank-two tile beside it.
  - A transpose on the data path, which is what swapping the dot operands emits.

Admitting the transpose needs the guard to be precise about orientation, so collectStoreMaskGuard now records which dimension each store discards rather than only that some store discards something.  Without that, a square tile whose store mask drops rows would read as a proof about the columns the injected mask zeros, which is a miscompile the old shape comparison could not see.

Two lit cases that were negative only because of the old approximation are now positive, with the reasoning that makes them safe stated in place.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
