### PR TITLE
[Launcher](fix) defer NPU utils initialization before fork

### DIFF
--- a/third_party/ascend/backend/backend_register.py
+++ b/third_party/ascend/backend/backend_register.py
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+import importlib.util
 import os
 from typing import Callable, Dict
 
@@ -195,12 +196,21 @@ def get_cc_cmd():
     ]
 
 
+def _get_package_dir(package_name):
+    spec = importlib.util.find_spec(package_name)
+    if spec is None:
+        raise ModuleNotFoundError(f"No module named '{package_name}'")
+    if spec.submodule_search_locations:
+        return os.path.realpath(next(iter(spec.submodule_search_locations)))
+    if spec.origin is None:
+        raise ModuleNotFoundError(f"Cannot locate module '{package_name}'")
+    return os.path.dirname(os.path.realpath(spec.origin))
+
+
 @backend_strategy_registry.register("torch_npu", "get_cc_cmd_npu_utils")
 def get_cc_cmd_npu_utils():
-    import torch
-    import torch_npu
-    torch_path = os.path.dirname(os.path.realpath(torch.__file__))
-    torch_npu_path = os.path.dirname(os.path.realpath(torch_npu.__file__))
+    torch_path = _get_package_dir("torch")
+    torch_npu_path = _get_package_dir("torch_npu")
     cc_cmd = [
         f"-I{os.path.join(torch_path, 'include')}",
         f"-I{os.path.join(torch_npu_path, 'include')}",

--- a/third_party/ascend/backend/backend_register.py
+++ b/third_party/ascend/backend/backend_register.py
@@ -76,19 +76,6 @@ class _LazyBackendStrategyRegister:
 backend_strategy_registry = _LazyBackendStrategyRegister()
 
 
-@backend_strategy_registry.register("mindspore", "version_hash")
-def version_hash():
-    import mindspore
-    return [str(mindspore.version)]
-
-
-@backend_strategy_registry.register("torch_npu", "version_hash")
-def version_hash():
-    import torch
-    import torch_npu
-    return [torch.version.git_version, torch_npu.version.git_version]
-
-
 @backend_strategy_registry.register("mindspore", "cxx_abi")
 def get_mindspore_cxx_abi():
     return 0

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -241,6 +241,7 @@ class NPULauncher(object):
         spec = importlib.util.spec_from_file_location("__triton_launcher", self.so_launcher_path)
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
+        mod.set_npu_utils_path(NPUUtils().get_so_path())
         cst_key = lambda i: self.src.fn.arg_names.index(i) if isinstance(i, str) else i
         signature = {cst_key(key): value for key, value in self.src.signature.items()}
         self.launch = wrap_handle_tensordesc(getattr(mod, "launch"), signature)
@@ -993,6 +994,8 @@ static triton_allocate_workspace_t g_allocate_workspace = nullptr;
 static triton_allocate_sync_block_lock_t g_allocate_sync_block_lock = nullptr;
 static triton_async_launch_t g_async_launch = nullptr;
 static triton_release_retained_tensor_t g_release_retained_tensor = nullptr;
+static std::string g_npu_utils_path;
+static std::string g_npu_utils_error;
 
 static bool npu_utils_ready() {{
     return g_allocate_workspace &&
@@ -1001,31 +1004,57 @@ static bool npu_utils_ready() {{
            g_release_retained_tensor;
 }}
 
-static void init_npu_utils() {{
-    if (npu_utils_ready()) return;
-    const char* cache_root = std::getenv("TRITON_CACHE_DIR");
-    std::string npu_utils_path;
-    if (cache_root && cache_root[0] != '\\0') {{
-        npu_utils_path = std::string(cache_root) + "/{npu_utils_cache_relative}";
-    }} else {{
-        const char* triton_home = std::getenv("TRITON_HOME");
-        const char* home = std::getenv("HOME");
-        const char* base = triton_home && triton_home[0] != '\\0' ? triton_home : home;
-        if (!base || base[0] == '\\0') {{
-            fprintf(stderr, "Error: neither TRITON_CACHE_DIR nor TRITON_HOME/HOME is set\\n");
-            return;
+static bool init_npu_utils() {{
+    if (npu_utils_ready()) return true;
+    std::string npu_utils_path = g_npu_utils_path;
+    if (npu_utils_path.empty()) {{
+        // Compatibility fallback for callers of the exported C launcher API,
+        // which cannot inject the cache-manager-resolved path through Python.
+        const char* cache_root = std::getenv("TRITON_CACHE_DIR");
+        if (cache_root && cache_root[0] != '\\0') {{
+            npu_utils_path = std::string(cache_root) + "/{npu_utils_cache_relative}";
+        }} else {{
+            const char* triton_home = std::getenv("TRITON_HOME");
+            const char* home = std::getenv("HOME");
+            const char* base = triton_home && triton_home[0] != '\\0' ? triton_home : home;
+            if (!base || base[0] == '\\0') {{
+                g_npu_utils_error = "neither TRITON_CACHE_DIR nor TRITON_HOME/HOME is set";
+                fprintf(stderr, "Error: %s\\n", g_npu_utils_error.c_str());
+                return false;
+            }}
+            npu_utils_path = std::string(base) + "/.triton/cache/{npu_utils_cache_relative}";
         }}
-        npu_utils_path = std::string(base) + "/.triton/cache/{npu_utils_cache_relative}";
     }}
     void* handle = dlopen(npu_utils_path.c_str(), RTLD_LAZY);
     if (!handle) {{
-        fprintf(stderr, "Error: dlopen %s failed: %s\\n", npu_utils_path.c_str(), dlerror());
-        return;
+        const char* error = dlerror();
+        g_npu_utils_error = error ? error : "unknown dlopen error";
+        fprintf(stderr, "Error: dlopen %s failed: %s\\n", npu_utils_path.c_str(), g_npu_utils_error.c_str());
+        return false;
     }}
     g_allocate_workspace = (triton_allocate_workspace_t)dlsym(handle, "triton_allocate_workspace");
     g_allocate_sync_block_lock = (triton_allocate_sync_block_lock_t)dlsym(handle, "triton_allocate_sync_block_lock");
     g_async_launch = (triton_async_launch_t)dlsym(handle, "triton_async_launch");
     g_release_retained_tensor = (triton_release_retained_tensor_t)dlsym(handle, "triton_release_retained_tensor");
+    if (!npu_utils_ready()) {{
+        g_npu_utils_error = "required NPU utility symbols are unavailable";
+        fprintf(stderr, "Error: %s in %s\\n", g_npu_utils_error.c_str(), npu_utils_path.c_str());
+        return false;
+    }}
+    g_npu_utils_error.clear();
+    return true;
+}}
+
+static PyObject* set_npu_utils_path(PyObject* self, PyObject* path_obj) {{
+    const char* path = PyUnicode_AsUTF8(path_obj);
+    if (!path) return nullptr;
+    g_npu_utils_path = path;
+    if (!init_npu_utils()) {{
+        PyErr_Format(PyExc_RuntimeError, "Failed to load NPU utilities from %s: %s", path,
+                     g_npu_utils_error.c_str());
+        return nullptr;
+    }}
+    Py_RETURN_NONE;
 }}
 
 static void release_npu_tensor_handle(void* handle) {{
@@ -1471,6 +1500,8 @@ static PyObject* launch(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 }}
 
 static PyMethodDef ModuleMethods[] = {{
+  {{"set_npu_utils_path", (PyCFunction)set_npu_utils_path, METH_O,
+    "Initialize NPU utilities from the cache-manager-resolved shared-object path"}},
   {{"launch", (PyCFunction)launch, METH_FASTCALL, "Entry point for all kernels with this signature"}},
   {{nullptr, nullptr, 0, nullptr}} // sentinel
 }};
@@ -1490,9 +1521,6 @@ PyMODINIT_FUNC PyInit___triton_launcher(void) {{
   }}
   PyModule_AddFunctions(m, ModuleMethods);
   {cpp_msprof_callback}
-  // One-time initialization of NPU utils (dlsym lookup for g_async_launch etc.)
-  // Moved here from the per-call async_launch path to avoid repeated dlsym work.
-  init_npu_utils();
   return m;
 }}
 """

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -19,6 +19,8 @@
 # THE SOFTWARE.
 
 from pathlib import Path
+import contextlib
+import fcntl
 import tempfile
 import os
 import os.path
@@ -39,6 +41,30 @@ from triton.backends.ascend.utils import (_build_npu_ext, _check_cxx11_abi, conv
 import triton.backends.ascend.utils as _ascend_utils
 
 
+def _get_cache_lock_path(cache):
+    lock_path = getattr(cache, "lock_path", None)
+    if lock_path is not None:
+        return lock_path
+    file_cache_manager = getattr(cache, "_file_cache_manager", None)
+    return getattr(file_cache_manager, "lock_path", None)
+
+
+@contextlib.contextmanager
+def _cache_build_lock(cache):
+    lock_path = _get_cache_lock_path(cache)
+    if lock_path is None:
+        yield
+        return
+
+    os.makedirs(os.path.dirname(lock_path), exist_ok=True)
+    with open(lock_path, "a") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+
 class NPUUtils(object):
 
     def __new__(cls):
@@ -47,17 +73,42 @@ class NPUUtils(object):
         return cls.instance
 
     def __init__(self):
+        if getattr(self, "_initialized", False):
+            return
+        self._initialized = True
+        self._cache_path = None
+        self.npu_utils_mod = None
+
+    def get_so_path(self):
+        if self._cache_path is None:
+            self._cache_path = self._build_or_get_cached_so()
+        return self._cache_path
+
+    def _build_or_get_cached_so(self):
         dirname = os.path.dirname(os.path.realpath(__file__))
         src_path = os.path.join(dirname, "npu_utils.cpp")
         src = Path(src_path).read_text()
-        version_info = get_backend_func("version_hash")
         cann_version = get_cann_version()
         cann_version_str = ".".join(map(str, cann_version)) if cann_version else ""
-        key = hashlib.md5((src + "_".join(version_info) + "_" + cann_version_str).encode("utf-8")).hexdigest()
+        key_parts = [
+            "npu_utils",
+            "torch_npu_wrapper_abi=triton_async_launch_v1",
+            "USE_TORCH_NPU",
+            f"cann_version={cann_version_str}",
+            src,
+        ]
+        key = hashlib.md5("\0".join(key_parts).encode("utf-8")).hexdigest()
         cache = get_cache_manager(key)
         fname = "npu_utils.so"
         cache_path = cache.get_file(fname)
-        if cache_path is None or not os.path.exists(cache_path):
+        if cache_path is not None and os.path.exists(cache_path):
+            return cache_path
+
+        with _cache_build_lock(cache):
+            cache_path = cache.get_file(fname)
+            if cache_path is not None and os.path.exists(cache_path):
+                return cache_path
+
             with tempfile.TemporaryDirectory() as tmpdir:
                 tmp_src_path = os.path.join(tmpdir, "npu_utils.cpp")
                 with open(tmp_src_path, "w") as f:
@@ -65,14 +116,23 @@ class NPUUtils(object):
                 so = _build_npu_ext("npu_utils", tmp_src_path)
                 with open(so, "rb") as f:
                     cache_path = cache.put(f.read(), fname, binary=True)
+        return cache_path
+
+    def _load_mod(self):
+        if self.npu_utils_mod is not None:
+            return self.npu_utils_mod
+
         import importlib.util
-        spec = importlib.util.spec_from_file_location("npu_utils", cache_path)
+        spec = importlib.util.spec_from_file_location("npu_utils", self.get_so_path())
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
         self.npu_utils_mod = mod
+        return self.npu_utils_mod
 
-    def load_binary(self, name, kernel, shared, device, mix_mode):
-        return self.npu_utils_mod.load_kernel_binary(name, kernel, shared, device, mix_mode)
+    def load_binary(self, name, kernel, shared, device, mix_mode=None):
+        if mix_mode is None:
+            name, mix_mode = name.rsplit("_", 1)
+        return self._load_mod().load_kernel_binary(name, kernel, shared, device, mix_mode)
 
     def _get_npu_device_limit_form_env(self) -> tuple[int, int]:
         """Read and validate the NPU_DEVICE_LIMIT env var, return the capped AICore and AIVector counts.
@@ -156,7 +216,7 @@ class NPUUtils(object):
 
     def get_arch(self):
         # temporarily return empty arch descriptor
-        return self.npu_utils_mod.get_arch()
+        return self._load_mod().get_arch()
 
     def get_aicore_num(self):
         # temporarily return empty arch descriptor
@@ -915,8 +975,7 @@ def make_launcher(constants, signature, metadata):
     alloc_success_code = 'return 1;'
     sync_lock_fail_code = 'fprintf(stderr, "Error: syncBlockLock allocation failed\\n"); return;'
     workspace_fail_code = 'fprintf(stderr, "Error: workspace allocation failed\\n"); return;'
-    npu_utils_mod = getattr(npu_utils, "npu_utils_mod", None)
-    npu_utils_so_path = getattr(npu_utils_mod, "__file__", "")
+    npu_utils_so_path = NPUUtils().get_so_path()
     # The generated launcher source is part of its cache key. Preserve only the
     # deterministic cache-key directory so the launcher can be reused after the
     # cache root changes.

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -90,13 +90,7 @@ class NPUUtils(object):
         src = Path(src_path).read_text()
         cann_version = get_cann_version()
         cann_version_str = ".".join(map(str, cann_version)) if cann_version else ""
-        key_parts = [
-            "npu_utils",
-            "torch_npu_wrapper_abi=triton_async_launch_v1",
-            "USE_TORCH_NPU",
-            f"cann_version={cann_version_str}",
-            src,
-        ]
+        key_parts = [cann_version_str, src]
         key = hashlib.md5("\0".join(key_parts).encode("utf-8")).hexdigest()
         cache = get_cache_manager(key)
         fname = "npu_utils.so"

--- a/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
+++ b/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
@@ -1,5 +1,7 @@
+import builtins
 import importlib.util
 import os
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -8,6 +10,8 @@ import pytest
 pytestmark = pytest.mark.backend("none")
 
 DEFAULT_UTILS_PATH = (Path(__file__).resolve().parents[2] / "backend" / "utils.py")
+DEFAULT_REGISTER_PATH = (Path(__file__).resolve().parents[2] / "backend" / "backend_register.py")
+DEFAULT_DRIVER_PATH = (Path(__file__).resolve().parents[2] / "backend" / "driver.py")
 
 
 def _get_utils_path():
@@ -23,6 +27,32 @@ def _load_utils_module():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def _load_register_module():
+    spec = importlib.util.spec_from_file_location("repo_backend_register", DEFAULT_REGISTER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_driver_module():
+    spec = importlib.util.spec_from_file_location("repo_backend_driver", DEFAULT_DRIVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _guard_torch_npu_import(monkeypatch):
+    monkeypatch.delitem(sys.modules, "torch_npu", raising=False)
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "torch_npu" or name.startswith("torch_npu."):
+            raise AssertionError(f"unexpected import of {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
 
 
 def _assert_npu_utils_uses_special_flags(utils, monkeypatch, tmp_path):
@@ -63,6 +93,108 @@ def _assert_npu_utils_uses_special_flags(utils, monkeypatch, tmp_path):
 def test_npu_utils_build_uses_special_flags(monkeypatch, tmp_path):
     utils = _load_utils_module()
     _assert_npu_utils_uses_special_flags(utils, monkeypatch, tmp_path)
+
+
+def test_get_backend_func_uses_torch_npu_without_import(monkeypatch):
+    utils = _load_utils_module()
+    monkeypatch.delenv("TRITON_BACKEND", raising=False)
+    monkeypatch.setattr(utils, "backend_policy", None)
+    _guard_torch_npu_import(monkeypatch)
+
+    calls = []
+
+    def fake_execute_func(category, method, *args, **kwargs):
+        calls.append((category, method, args, kwargs))
+        return "ok"
+
+    monkeypatch.setattr(
+        utils.backend_strategy_registry,
+        "execute_func",
+        fake_execute_func,
+    )
+
+    assert utils.get_backend_func("get_cc_cmd_npu_utils") == "ok"
+    assert calls == [("torch_npu", "get_cc_cmd_npu_utils", (), {})]
+    assert "torch_npu" not in sys.modules
+
+
+def test_get_cc_cmd_npu_utils_resolves_torch_npu_path_without_import(monkeypatch, tmp_path):
+    register = _load_register_module()
+    _guard_torch_npu_import(monkeypatch)
+    monkeypatch.setattr(register, "get_torch_cxx_abi", lambda: 1)
+
+    torch_path = tmp_path / "torch_pkg"
+    torch_npu_path = tmp_path / "torch_npu_pkg"
+
+    def fake_find_spec(name):
+        if name == "torch":
+            return SimpleNamespace(
+                origin=str(torch_path / "__init__.py"),
+                submodule_search_locations=[str(torch_path)],
+            )
+        if name == "torch_npu":
+            return SimpleNamespace(
+                origin=str(torch_npu_path / "__init__.py"),
+                submodule_search_locations=[str(torch_npu_path)],
+            )
+        return None
+
+    monkeypatch.setattr(register.importlib.util, "find_spec", fake_find_spec)
+
+    cc_cmd = register.get_cc_cmd_npu_utils()
+
+    assert f"-I{torch_path / 'include'}" in cc_cmd
+    assert f"-I{torch_npu_path / 'include'}" in cc_cmd
+    assert f"-L{torch_npu_path / 'lib'}" in cc_cmd
+    assert "torch_npu" not in sys.modules
+
+
+def test_npu_utils_initialization_is_lazy(monkeypatch):
+    driver = _load_driver_module()
+    monkeypatch.setattr(
+        driver,
+        "_build_npu_ext",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected npu_utils build")),
+    )
+
+    npu_utils = driver.NPUUtils()
+
+    assert npu_utils._cache_path is None
+    assert npu_utils.npu_utils_mod is None
+
+
+def test_npu_utils_build_rechecks_cache_after_lock(monkeypatch, tmp_path):
+    driver = _load_driver_module()
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    cached_so = cache_dir / "npu_utils.so"
+    cached_so.write_bytes(b"cached")
+
+    class FakeCache:
+        lock_path = str(cache_dir / "lock")
+
+        def __init__(self):
+            self.get_file_calls = 0
+
+        def get_file(self, filename):
+            self.get_file_calls += 1
+            if self.get_file_calls == 1:
+                return None
+            return str(cached_so)
+
+        def put(self, data, filename, binary=True):
+            raise AssertionError("unexpected cache put")
+
+    fake_cache = FakeCache()
+    monkeypatch.setattr(driver, "get_cache_manager", lambda key: fake_cache)
+    monkeypatch.setattr(
+        driver,
+        "_build_npu_ext",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected npu_utils build")),
+    )
+
+    assert driver.NPUUtils()._build_or_get_cached_so() == str(cached_so)
+    assert fake_cache.get_file_calls == 2
 
 
 @pytest.mark.parametrize(

--- a/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
+++ b/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
@@ -1,4 +1,5 @@
 import builtins
+import hashlib
 import importlib.util
 import os
 import sys
@@ -195,6 +196,29 @@ def test_npu_utils_build_rechecks_cache_after_lock(monkeypatch, tmp_path):
 
     assert driver.NPUUtils()._build_or_get_cached_so() == str(cached_so)
     assert fake_cache.get_file_calls == 2
+
+
+def test_npu_utils_cache_key_uses_only_cann_version_and_source(monkeypatch, tmp_path):
+    driver = _load_driver_module()
+    cached_so = tmp_path / "npu_utils.so"
+    cached_so.write_bytes(b"cached")
+    captured_keys = []
+
+    class FakeCache:
+
+        def get_file(self, filename):
+            assert filename == "npu_utils.so"
+            return str(cached_so)
+
+    monkeypatch.setattr(driver, "get_cann_version", lambda: (9, 0, 0))
+    monkeypatch.setattr(driver, "get_cache_manager", lambda key: captured_keys.append(key) or FakeCache())
+
+    npu_utils = driver.NPUUtils()
+    source = (DEFAULT_DRIVER_PATH.parent / "npu_utils.cpp").read_text()
+    expected_key = hashlib.md5("\0".join(["9.0.0", source]).encode("utf-8")).hexdigest()
+
+    assert npu_utils.get_so_path() == str(cached_so)
+    assert captured_keys == [expected_key]
 
 
 @pytest.mark.parametrize(

--- a/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
+++ b/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
@@ -3,7 +3,7 @@ import sys
 from itertools import product
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "python"))
 
@@ -126,6 +126,11 @@ def test_make_launcher_resolves_npu_utils_from_active_cache_root(
     assert f'npu_utils_path = std::string(cache_root) + "/{cache_key}/npu_utils.so";' in producer_src
     assert 'const char* triton_home = std::getenv("TRITON_HOME");' in producer_src
     assert f'npu_utils_path = std::string(base) + "/.triton/cache/{cache_key}/npu_utils.so";' in producer_src
+    assert "std::string npu_utils_path = g_npu_utils_path;" in producer_src
+    assert '"set_npu_utils_path", (PyCFunction)set_npu_utils_path, METH_O' in producer_src
+    assert "if (!init_npu_utils())" in producer_src
+    module_init = producer_src.split("PyMODINIT_FUNC PyInit___triton_launcher", maxsplit=1)[1]
+    assert "init_npu_utils();" not in module_init
 
 
 @patch.object(driver, "NPUUtils")
@@ -476,14 +481,19 @@ def test_argument_packing_differs_between_launch_paths(
 @patch.object(driver, "make_npu_launcher_stub", return_value="/tmp/fake_launcher.so")
 @patch.object(driver, "make_launcher", return_value="// wrapper src")
 @patch.object(driver, "generate_npu_header_src", return_value="// header src")
+@patch.object(driver, "NPUUtils")
 def test_npu_launcher_exposes_launcher_so_path(
+    mock_npu_utils,
     mock_header_src,
     mock_wrapper_src,
     mock_launcher_stub,
     mock_spec_from_file_location,
     mock_module_from_spec,
 ):
-    fake_module = SimpleNamespace(launch=object())
+    npu_utils_so_path = "/custom/cache-manager/path/npu_utils.so"
+    mock_npu_utils.return_value.get_so_path.return_value = npu_utils_so_path
+    set_npu_utils_path = Mock()
+    fake_module = SimpleNamespace(launch=object(), set_npu_utils_path=set_npu_utils_path)
     fake_spec = SimpleNamespace(loader=SimpleNamespace(exec_module=lambda module: None))
     mock_module_from_spec.return_value = fake_module
     mock_spec_from_file_location.return_value = fake_spec
@@ -502,6 +512,7 @@ def test_npu_launcher_exposes_launcher_so_path(
     assert mock_header_src.call_count == 1
     assert mock_wrapper_src.call_count == 1
     assert mock_launcher_stub.call_count == 1
+    set_npu_utils_path.assert_called_once_with(npu_utils_so_path)
     mock_wrapper_src.assert_called_with(
         {0: 1},
         {0: "*fp32", 1: "i32"},

--- a/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
+++ b/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
@@ -98,12 +98,14 @@ def test_make_launcher_resolves_npu_utils_from_active_cache_root(
         return SimpleNamespace(
             get_aivector_core_num=lambda: 40,
             get_aicore_num=lambda: 20,
-            npu_utils_mod=SimpleNamespace(__file__=f"{cache_root}/{cache_key}/npu_utils.so"),
+            get_so_path=lambda: f"{cache_root}/{cache_key}/npu_utils.so",
         )
 
     producer_utils = make_utils("/producer/cache")
     consumer_utils = make_utils("/consumer/cache")
-    mock_npu_utils.side_effect = [producer_utils, consumer_utils]
+    # make_launcher currently reads NPUUtils once for core counts and once for
+    # the shared-object path.
+    mock_npu_utils.side_effect = [producer_utils, producer_utils, consumer_utils, consumer_utils]
 
     producer_src = driver.make_launcher(
         constants={},


### PR DESCRIPTION
## Summary

- Port the fork-safety fix from #974/#982 to the current `main-dev`.
- Defer `npu_utils.so` compilation and loading until an actual NPU utility consumer needs it.
- Avoid importing `torch_npu` while selecting the backend or resolving build include/library paths.
- Serialize concurrent `npu_utils.so` cache builds.
- Load `npu_utils.so` from the exact path resolved by Triton's cache manager while preserving relocatable launcher behavior.

## Background

#974 fixed the issue on `release/3.2.2-dev`, and #982 applied the same fix to `release/3.2.2`. The equivalent change was not present in `main-dev`.

Before this change, constructing the Ascend driver also constructed `NPUUtils`, which could:

1. import `torch_npu` while selecting the backend or calculating build parameters;
2. compile `npu_utils.so`;
3. load the extension into the current Python process.

Importing TorchNPU or loading the extension may initialize TorchNPU/CANN runtime state. If the process forks afterwards, the child can inherit runtime threads, locks, and device state that are not safe to reuse after `fork()`, potentially causing the child process to hang.

This change removes driver construction and build-path discovery as eager TorchNPU/CANN initialization points.

## Changes

### Lazy NPU utility initialization

`NPUUtils.__init__()` now initializes Python-side fields only.

- `get_so_path()` builds or retrieves `npu_utils.so` on demand.
- `_load_mod()` loads the Python extension only when a Python-side NPU utility operation needs it.
- Repeated construction of the singleton no longer rebuilds or reloads the extension.

### Avoid eager `torch_npu` imports

Torch and TorchNPU package directories are resolved with
`importlib.util.find_spec()` instead of importing the packages.

This allows backend selection and compiler flag construction to complete without triggering TorchNPU runtime initialization.

### Serialize cache construction

Concurrent processes may request the same `npu_utils.so` cache entry.

The build path now:

1. checks the cache;
2. acquires the cache build lock;
3. checks the cache again;
4. builds and publishes the shared object only if it is still missing.

This avoids concurrent writes and redundant builds.

### Use the cache-manager-resolved shared-object path

The generated launcher exposes `set_npu_utils_path()`.

After importing the launcher extension, `NPULauncher` passes the exact result of:

```python
NPUUtils().get_so_path()