### PR TITLE
[Ascend](fix) complete global scratch runtime setup

### DIFF
--- a/third_party/ascend/backend/backend_register.py
+++ b/third_party/ascend/backend/backend_register.py
@@ -75,6 +75,20 @@ class _LazyBackendStrategyRegister:
 backend_strategy_registry = _LazyBackendStrategyRegister()
 
 
+class _ScratchBuffer:
+
+    def __init__(self, tensor, alignment):
+        self.tensor = tensor
+        get_data_ptr = getattr(tensor, "data_ptr", None)
+        if get_data_ptr is None:
+            get_data_ptr = tensor._data_ptr
+        address = get_data_ptr()
+        self._aligned_data_ptr = ((address + alignment - 1) // alignment) * alignment
+
+    def data_ptr(self):
+        return self._aligned_data_ptr
+
+
 @backend_strategy_registry.register("mindspore", "version_hash")
 def version_hash():
     import mindspore
@@ -161,6 +175,22 @@ def get_empty_tensor(size):
 def get_empty_tensor(size):
     import torch
     return torch.empty(size, dtype=torch.int32, device='npu')
+
+
+@backend_strategy_registry.register("mindspore", "allocate_global_scratch")
+def allocate_mindspore_global_scratch(size, alignment, stream):
+    import mindspore
+    alignment = max(int(alignment), 1)
+    tensor = mindspore.mint.empty(size + alignment - 1, dtype=mindspore.uint8)
+    return _ScratchBuffer(tensor, alignment)
+
+
+@backend_strategy_registry.register("torch_npu", "allocate_global_scratch")
+def allocate_torch_global_scratch(size, alignment, stream):
+    import torch
+    alignment = max(int(alignment), 1)
+    tensor = torch.empty(size + alignment - 1, dtype=torch.uint8, device='npu')
+    return _ScratchBuffer(tensor, alignment)
 
 
 @backend_strategy_registry.register("mindspore", "get_cc_cmd")

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -148,10 +148,12 @@ class NPUUtils(object):
             return False
 
     def get_device_properties(self, device):
-        # temperoarily added "max_shared_mem" properties to avoid triton-compiler complain
-        # fetch available memory at runtime
+        arch = self.get_arch()
+        # A5 exposes 248 KiB usable UB (256 KiB physical, 8 KiB reserved);
+        # A2/A3 expose 192 KiB.
+        max_shared_mem = (248 if arch.startswith(("Ascend910_95", "Ascend950")) else 192) * 1024
         num_aic, num_aiv = self._get_npu_device_limit_form_env()
-        return {"max_shared_mem": 1, "num_aicore": num_aic, "num_vectorcore": num_aiv}
+        return {"max_shared_mem": max_shared_mem, "num_aicore": num_aic, "num_vectorcore": num_aiv}
 
     def get_arch(self):
         # temporarily return empty arch descriptor
@@ -210,7 +212,11 @@ class NPULauncher(object):
             grid_size = gridX * gridY * gridZ
             alloc_size = grid_size * self.global_scratch_size
             alloc_fn = _allocation._allocator.get()
-            global_scratch = alloc_fn(alloc_size, self.global_scratch_align, stream)
+            if isinstance(alloc_fn, _allocation.NullAllocator):
+                global_scratch = get_backend_func("allocate_global_scratch", alloc_size, self.global_scratch_align,
+                                                  stream)
+            else:
+                global_scratch = alloc_fn(alloc_size, self.global_scratch_align, stream)
 
         profiler_registered = self.launch(gridX, gridY, gridZ, stream, function, global_scratch, None, packed_metadata,
                                           launch_metadata, launch_enter_hook, launch_exit_hook, *kernel_args, **kwargs)
@@ -523,6 +529,18 @@ static inline DevicePtrInfo getPointer(PyObject* obj, int idx) {
   PyErr_SetString(PyExc_TypeError, "Pointer argument must be either uint64 or have data_ptr method");
   ptr_info.valid = false;
   return ptr_info;
+}
+
+static std::shared_ptr<PyObject> retain_python_object(PyObject* obj) {
+  if (!obj || obj == Py_None) {
+    return {};
+  }
+  Py_INCREF(obj);
+  return std::shared_ptr<PyObject>(obj, [](PyObject* value) {
+    PyGILState_STATE state = PyGILState_Ensure();
+    Py_DECREF(value);
+    PyGILState_Release(state);
+  });
 }
 """
 
@@ -1263,14 +1281,20 @@ void triton_launch_kernel(const char* kernelName, aclrtFuncHandle func, aclrtStr
 static void _launch(const char* kernelName, aclrtFuncHandle func, aclrtStream stream,
     int gridX, int gridY, int gridZ,
     std::vector<std::vector<int64_t>> &tensorShapes, std::vector<int> &tensorKinds,
-    void *global_scratch, void *profile_scratch{(', ' + arg_decls) if len(arg_decls) > 0 else ''}) {{
+    void *global_scratch, void *profile_scratch,
+    PyObject *global_scratch_owner, PyObject *profile_scratch_owner
+    {(', ' + arg_decls) if len(arg_decls) > 0 else ''}) {{
   // Keep Python launcher on the stable local packing path.
   if (gridX <=0 || gridY <=0 || gridZ <=0) {{
     printf("WARNING: Skipping launch for kernel '%s' due to empty grid (gridX=%d, gridY=%d, gridZ=%d).\\n", kernelName, gridX, gridY, gridZ);
     return;
   }}
+  auto global_scratch_owner_guard = retain_python_object(global_scratch_owner);
+  auto profile_scratch_owner_guard = retain_python_object(profile_scratch_owner);
 {_launch_preamble}
 {_launch_lambda_pre}
+    (void)global_scratch_owner_guard;
+    (void)profile_scratch_owner_guard;
     struct __attribute__((packed)) {{
       {'void* ffts_addr __attribute__((aligned(8)));' if target_support_ffts else ''}
       {'void* syncBlockLock __attribute__((aligned(8)));' if not metadata.is_pure_simt else ''}
@@ -1392,7 +1416,8 @@ static PyObject* launch(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
   _launch(kernelName, function, stream,
           gridX, gridY, gridZ,
           tensorShapes, tensorKinds,
-          global_scratch, profile_scratch
+          global_scratch, profile_scratch,
+          global_scratch_obj, profile_scratch_obj
           {', ' + ', '.join(internal_args_list) if len(internal_args_list) > 0 else ''});
   if (PyErr_Occurred()) {{
     return nullptr;

--- a/third_party/ascend/unittest/pytest_ut/test_driver.py
+++ b/third_party/ascend/unittest/pytest_ut/test_driver.py
@@ -23,6 +23,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+pytestmark = pytest.mark.backend("none")
+
 _MOCK_AICORE_NUM = 24
 _MOCK_AIVECTOR_NUM = _MOCK_AICORE_NUM * 2
 
@@ -42,6 +44,7 @@ def _make_mock_npu_utils():
     # _get_npu_device_limit_form_env calls self.get_device_aicore(); configure it
     # to return a fixed int instead of binding the real lru_cached method.
     mock.get_device_core.return_value = _MOCK_AICORE_NUM, _MOCK_AIVECTOR_NUM
+    mock.get_arch.return_value = "Ascend910_9392"
     # Bind real methods (not lru_cached) so the actual parsing/property logic runs.
     mock._get_npu_device_limit_form_env = types.MethodType(NPUUtils._get_npu_device_limit_form_env, mock)
     mock.get_device_properties = types.MethodType(NPUUtils.get_device_properties, mock)
@@ -118,7 +121,24 @@ def test_npu_device_limit_get_device_properties(monkeypatch):
     props = NPUUtils.get_device_properties(mock_utils, "npu")
     assert props["num_aicore"] == 8
     assert props["num_vectorcore"] == 16
-    assert props["max_shared_mem"] == 1
+
+
+@pytest.mark.parametrize(
+    "arch,expected_max_shared_mem",
+    [
+        ("Ascend910_9392", 192 * 1024),
+        ("Ascend910_9589", 248 * 1024),
+        ("Ascend950A3", 248 * 1024),
+    ],
+)
+def test_get_device_properties_reports_usable_shared_memory(monkeypatch, arch, expected_max_shared_mem):
+    mock_utils, NPUUtils = _make_mock_npu_utils()
+    mock_utils.get_arch.return_value = arch
+    monkeypatch.delenv("NPU_DEVICE_LIMIT", raising=False)
+
+    props = NPUUtils.get_device_properties(mock_utils, "npu")
+
+    assert props["max_shared_mem"] == expected_max_shared_mem
 
 
 def test_npu_device_limit_default_when_unset(monkeypatch):

--- a/third_party/ascend/unittest/pytest_ut/test_npu_launcher.py
+++ b/third_party/ascend/unittest/pytest_ut/test_npu_launcher.py
@@ -19,21 +19,25 @@
 # THE SOFTWARE.
 
 import importlib.util
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+import triton
 
-def _load_driver_module():
-    driver_path = Path(__file__).resolve().parents[2] / "backend" / "driver.py"
-    spec = importlib.util.spec_from_file_location("ascend_driver_under_test", driver_path)
+
+def _load_backend_module(name):
+    module_path = Path(__file__).resolve().parents[2] / "backend" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"ascend_{name}_under_test", module_path)
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)
     return module
 
 
-driver = _load_driver_module()
+backend_register = _load_backend_module("backend_register")
+driver = _load_backend_module("driver")
 
 
 def _make_launcher(monkeypatch, global_scratch_size, global_scratch_align, launch):
@@ -99,33 +103,65 @@ def _assert_order(text, *items):
     assert offsets == sorted(offsets)
 
 
-def test_npu_launcher_allocates_global_scratch(monkeypatch):
+def _assert_scratch_forwarded(launch, expected):
+    launch.assert_called_once()
+    _, _, _, _, _, global_scratch, profile_scratch, *_ = launch.call_args.args
+    assert global_scratch is expected
+    assert profile_scratch is None
+
+
+def test_npu_launcher_uses_framework_allocator_when_unset(monkeypatch):
     buffer = object()
-    allocate = Mock(return_value=buffer)
-    allocator = Mock()
-    allocator.get.return_value = allocate
-    monkeypatch.setattr(driver._allocation, "_allocator", allocator)
+    allocation_requests = []
+
+    def allocate_from_framework(name, *args):
+        allocation_requests.append((name, *args))
+        return buffer
+
+    monkeypatch.setattr(driver, "get_backend_func", allocate_from_framework)
+    token = driver._allocation._allocator.set(driver._allocation.NullAllocator())
     launch = Mock(return_value=0)
-    launcher = _make_launcher(monkeypatch, global_scratch_size=64, global_scratch_align=16, launch=launch)
     packed_metadata = {"hash": "h"}
 
-    launcher(2, 3, 4, 99, 123, packed_metadata, None, None, None, "kernel-arg")
+    try:
+        launcher = _make_launcher(monkeypatch, global_scratch_size=64, global_scratch_align=16, launch=launch)
+        launcher(2, 3, 4, 99, 123, packed_metadata, None, None, None, "kernel-arg")
+    finally:
+        driver._allocation._allocator.reset(token)
+
+    assert allocation_requests == [("allocate_global_scratch", 1536, 16, 99)]
+    _assert_scratch_forwarded(launch, buffer)
+
+
+def test_npu_launcher_prefers_explicit_allocator(monkeypatch):
+    buffer = object()
+    allocate = Mock(return_value=buffer)
+    monkeypatch.setattr(driver, "get_backend_func", Mock(side_effect=AssertionError("framework fallback used")))
+    previous_allocator = driver._allocation._allocator.get()
+    triton.set_allocator(allocate)
+    launch = Mock(return_value=0)
+    packed_metadata = {"hash": "h"}
+
+    try:
+        launcher = _make_launcher(monkeypatch, global_scratch_size=64, global_scratch_align=16, launch=launch)
+        launcher(2, 3, 4, 99, 123, packed_metadata, None, None, None, "kernel-arg")
+    finally:
+        triton.set_allocator(previous_allocator)
 
     allocate.assert_called_once_with(1536, 16, 99)
-    launch.assert_called_once_with(
-        2,
-        3,
-        4,
-        99,
-        123,
-        buffer,
-        None,
-        packed_metadata,
-        None,
-        None,
-        None,
-        "kernel-arg",
-    )
+    _assert_scratch_forwarded(launch, buffer)
+
+
+def test_mindspore_framework_allocator_returns_launcher_buffer(monkeypatch):
+    tensor = SimpleNamespace(_data_ptr=Mock(return_value=123))
+    empty = Mock(return_value=tensor)
+    uint8 = object()
+    monkeypatch.setitem(sys.modules, "mindspore", SimpleNamespace(mint=SimpleNamespace(empty=empty), uint8=uint8))
+
+    buffer = backend_register.backend_strategy_registry.execute_func("mindspore", "allocate_global_scratch", 64, 16, 99)
+
+    empty.assert_called_once_with(79, dtype=uint8)
+    assert buffer.data_ptr() == 128
 
 
 def test_npu_launcher_skips_zero_sized_global_scratch(monkeypatch):
@@ -194,6 +230,21 @@ def test_make_launcher_threads_scratch_through_pure_simt_abi(monkeypatch):
 
     exported = _exported_launcher_source(src)
     _assert_order(exported, "global_scratch_offset", "profile_scratch_offset", "dtdata_offset")
+
+
+def test_make_launcher_retains_scratch_while_async_launch_is_queued(monkeypatch):
+    monkeypatch.setenv("TRITON_ENABLE_TASKQUEUE", "true")
+    src = _make_launcher_source(monkeypatch, is_pure_simt=True)
+
+    assert "static std::shared_ptr<PyObject> retain_python_object" in src
+    internal = src[src.index("static void _launch("):]
+    assert "global_scratch_owner_guard = retain_python_object(global_scratch_owner)" in internal
+    callback = internal[internal.index("std::function<aclError()> launch_call"):]
+    _assert_order(callback, "(void)global_scratch_owner_guard;", "struct __attribute__((packed))")
+
+    call_start = src.index("_launch(kernelName")
+    call = src[call_start:src.index(");", call_start)]
+    _assert_order(call, "global_scratch", "profile_scratch", "global_scratch_obj", "profile_scratch_obj")
 
 
 def test_make_launcher_omits_scratch_from_non_simt_device_layout(monkeypatch):


### PR DESCRIPTION
## Why

PR #1645 added compiler-emitted global scratch metadata and launch support. Once a kernel requests nonzero scratch, an ordinary Ascend launch still fails with "kernel requires a runtime memory allocation, but no allocator was set" unless the application explicitly configures Triton's generic allocator. The driver also reports a placeholder max_shared_mem value of one byte, so resource validation can reject kernels that use on-chip UB.

The integration suite also leaks its NPU default device from the unified-attention test into later files on the same pytest-xdist worker. Depending on worker scheduling, the pointer-bitcast CPU references are then created on NPU and fail with a CPU/NPU device mismatch.

## What

- Report 248 KiB of usable UB for Ascend910_95 and Ascend950 targets, and 192 KiB for other supported Ascend targets.
- When Triton's allocator is unset, allocate global scratch through the active Torch-NPU or MindSpore backend; an explicit triton.set_allocator callback still takes precedence.
- Allocate scratch as bytes, overallocate as needed, and expose a compiler-aligned pointer. Adapt MindSpore's _data_ptr interface to Triton's Buffer protocol.
- Retain the scratch owner through deferred task-queue callbacks so its device pointer remains valid until the ACL launch is enqueued.
- Keep NPU_DEVICE_LIMIT core-count handling unchanged.
- Scope the unified-attention test's NPU default device to each test case so the xdist worker state is restored afterward.
- Add host coverage for architecture limits, fallback allocation, explicit allocator precedence, alignment/MindSpore adaptation, and queued-launch ownership.

## Tests

- Launcher/driver host regression: 52 passed.
- Compiler layout/memory contract: 3 passed, 30 environment-specific skips.
- pre-commit on all changed files: passed.
- The default-device leak was reproduced in PR #1701 and independently in PRs #1689 and #1700 plus a main-dev push; all showed the same four pointer-bitcast device-mismatch failures.
- No global-scratch NPU device test was run on this machine; task-queue enabled/disabled device validation is handed off separately.

## Checklist

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following the project rules.
- [x] I have run pre-commit over the PR range.
- [x] I have added tests.
- [x] I have not added any lit tests.
