### PR TITLE
[ControlFlowOpt](feat) Add scope.scope pointer decoupling

### DIFF
--- a/third_party/ascend/include/TritonControlFlowOpt/ControlFlowAnalysis.h
+++ b/third_party/ascend/include/TritonControlFlowOpt/ControlFlowAnalysis.h
@@ -139,6 +139,15 @@ public:
   virtual FailureOr<SmallVector<unsigned>>
   getLoopCandidateComponents(const AnalyzedValue &value) const = 0;
 
+  /// Components which may cross a scope.scope result boundary. Scope has no
+  /// region arguments or backedge, so the first implementation returns every
+  /// component that the policy already permits a loop to carry. A policy may
+  /// override this hook when its Scope schema differs from its loop schema.
+  virtual FailureOr<SmallVector<unsigned>>
+  getScopeCandidateComponents(const AnalyzedValue &value) const {
+    return getLoopCandidateComponents(value);
+  }
+
   virtual FailureOr<SmallVector<unsigned>>
   getLoopTransferredComponents(const AnalyzedValue &initial,
                                const AnalyzedValue &regionArgument,
@@ -183,6 +192,7 @@ private:
   FailureOr<ControlFlowOpAnalysis> analyzeFor(Operation *op);
   FailureOr<ControlFlowOpAnalysis> analyzeWhile(Operation *op);
   FailureOr<ControlFlowOpAnalysis> analyzeIf(Operation *op);
+  FailureOr<ControlFlowOpAnalysis> analyzeScope(Operation *op);
 
   void bindRegionArgument(Value argument, const AnalyzedValue &initial,
                           ArrayRef<unsigned> componentIndices);

--- a/third_party/ascend/lib/TritonControlFlowOpt/CMakeLists.txt
+++ b/third_party/ascend/lib/TritonControlFlowOpt/CMakeLists.txt
@@ -10,6 +10,7 @@ add_triton_library(TritonControlFlowOpt
   TritonControlFlowOptPassIncGen
 
   LINK_LIBS PUBLIC
+  BiShengIRScopeDialect
   MLIRArithDialect
   MLIRControlFlowDialect
   MLIRFuncDialect

--- a/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowAnalysis.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowAnalysis.cpp
@@ -22,6 +22,7 @@
 
 #include "TritonControlFlowOpt/ControlFlowAnalysis.h"
 
+#include "bishengir/Dialect/Scope/IR/Scope.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
 
@@ -38,7 +39,50 @@ namespace {
 /// Control-flow kinds whose operand/result correspondence is understood by
 /// both the analyzer and the mechanical rewrite.
 static bool isSupportedControlFlow(Operation *op) {
-  return isa<scf::ForOp, scf::WhileOp, scf::IfOp>(op);
+  return isa<scf::ForOp, scf::WhileOp, scf::IfOp, scope::ScopeOp>(op);
+}
+
+/// Scope rewriting deliberately supports only the frontend's single-block,
+/// operand-free form. Validating the complete shape here keeps the later
+/// rewrite mechanical and prevents partially rewriting an unfamiliar Scope
+/// region contract.
+static FailureOr<scope::ReturnOp>
+getSupportedScopeReturn(scope::ScopeOp scopeOp) {
+  if (scopeOp->getNumOperands() != 0 || scopeOp->getNumRegions() != 1)
+    return failure();
+
+  Region &region = scopeOp.getBodyRegion();
+  if (!llvm::hasSingleElement(region))
+    return failure();
+  Block &body = region.front();
+  if (body.getNumArguments() != 0)
+    return failure();
+
+  auto returnOp = dyn_cast<scope::ReturnOp>(body.getTerminator());
+  if (!returnOp || returnOp.getNumOperands() != scopeOp.getNumResults())
+    return failure();
+  for (auto [operand, result] :
+       llvm::zip(returnOp.getOperands(), scopeOp.getResults())) {
+    if (operand.getType() != result.getType())
+      return failure();
+  }
+  return returnOp;
+}
+
+/// Returns true when an identity can be reused while the defining Scope is
+/// replaced. Internal values disappear with the old region and therefore must
+/// be represented by an expanded result instead.
+static bool isDefinedOutsideScope(scope::ScopeOp scopeOp, Value value) {
+  if (!value)
+    return false;
+  if (Operation *definingOp = value.getDefiningOp())
+    return !scopeOp->isAncestor(definingOp);
+
+  auto blockArgument = dyn_cast<BlockArgument>(value);
+  if (!blockArgument)
+    return false;
+  Operation *owner = blockArgument.getOwner()->getParentOp();
+  return owner != scopeOp && (!owner || !scopeOp->isAncestor(owner));
 }
 
 static void setResultIdentity(AnalyzedValue &value, Value result,
@@ -458,6 +502,74 @@ ControlFlowAnalysisContext::analyzeIf(Operation *operation) {
 }
 
 //===----------------------------------------------------------------------===//
+// scope.scope schema analysis
+//===----------------------------------------------------------------------===//
+
+FailureOr<ControlFlowOpAnalysis>
+ControlFlowAnalysisContext::analyzeScope(Operation *operation) {
+  auto scopeOp = cast<scope::ScopeOp>(operation);
+  FailureOr<scope::ReturnOp> returnOp = getSupportedScopeReturn(scopeOp);
+  if (failed(returnOp))
+    return failure();
+
+  ControlFlowOpAnalysis result;
+  Block &body = scopeOp.getBodyRegion().front();
+  if (failed(analyzeNestedOperations(&body, result.hasNestedRewrite)))
+    return failure();
+
+  // Scope has no incoming region argument and no backedge. Each pointer result
+  // is therefore described by the value returned from the body. The policy
+  // chooses the components that become explicit Scope results; every omitted
+  // component must already name an SSA value defined outside this Scope.
+  for (auto [index, scopeResult] : llvm::enumerate(scopeOp.getResults())) {
+    if (!policy.isDecompositionTarget(scopeResult))
+      continue;
+
+    FailureOr<AnalyzedValue> returned =
+        analyzeValue(returnOp->getOperand(index));
+    if (failed(returned) || returned->originalType != scopeResult.getType())
+      return failure();
+    FailureOr<SmallVector<unsigned>> candidates =
+        policy.getScopeCandidateComponents(*returned);
+    if (failed(candidates))
+      return failure();
+
+    SmallVector<bool> isCandidate(returned->components.size(), false);
+    std::optional<unsigned> previousIndex;
+    for (unsigned componentIndex : *candidates) {
+      if (componentIndex >= returned->components.size() ||
+          (previousIndex && componentIndex <= *previousIndex))
+        return failure();
+      isCandidate[componentIndex] = true;
+      previousIndex = componentIndex;
+    }
+
+    for (auto [componentIndex, component] :
+         llvm::enumerate(returned->components)) {
+      if (isCandidate[componentIndex])
+        continue;
+      if (component.identity.kind != ComponentIdentity::Kind::Value ||
+          !isDefinedOutsideScope(scopeOp, component.identity.value))
+        return failure();
+    }
+
+    SmallVector<Type> componentTypes;
+    componentTypes.reserve(candidates->size());
+    for (unsigned componentIndex : *candidates)
+      componentTypes.push_back(returned->components[componentIndex].type);
+
+    AnalyzedValue resultState = *returned;
+    result.slots.push_back(
+        makeSlotAnalysis(index, resultState.components.size(), *candidates,
+                         std::move(componentTypes), resultState.attributes));
+    setResultIdentity(resultState, scopeResult, *candidates);
+    analyzedValues[scopeResult] = std::move(resultState);
+  }
+
+  return result;
+}
+
+//===----------------------------------------------------------------------===//
 // Stage-wide caching, plan freezing and entry-point discovery
 //===----------------------------------------------------------------------===//
 
@@ -477,6 +589,8 @@ ControlFlowAnalysisContext::analyzeControlFlowOp(Operation *op) {
     result = analyzeWhile(op);
   else if (isa<scf::IfOp>(op))
     result = analyzeIf(op);
+  else if (isa<scope::ScopeOp>(op))
+    result = analyzeScope(op);
 
   operationsBeingAnalyzed.erase(op);
   if (failed(result))

--- a/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowRewrite.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowRewrite.cpp
@@ -23,6 +23,7 @@
 #include "TritonControlFlowOpt/ControlFlowRewrite.h"
 #include "Utils/Utils.h"
 
+#include "bishengir/Dialect/Scope/IR/Scope.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/IRMapping.h"
@@ -64,8 +65,9 @@ const DecomposedValue *ControlFlowRewriteContext::lookup(Value value) const {
 
 namespace {
 
-// Keep the mechanical if/for/while rewrite in one translation unit. These
-// handlers are mutually recursive through rewriteBodyOps(), share one
+// Keep the mechanical structured-control-flow and Scope rewrite in one
+// translation unit. These handlers are mutually recursive through
+// rewriteBodyOps(), share one
 // short-lived RewriteEnv, and must agree on signature expansion, nested-op
 // ordering and failure cleanup. Splitting them by op kind would expose those
 // private constraints through additional internal headers without creating an
@@ -81,7 +83,7 @@ namespace {
 /// valueMapping answers which new SSA value replaces an old SSA value.
 /// decomposedValues remembers the policy-specific pieces of an old pointer.
 /// policy defines what those pieces mean and how to rebuild the pointer,
-/// while plan says which loop/if operands must be expanded into such pieces.
+/// while plan says which control-flow values must be expanded into such pieces.
 ///
 /// For example, after a block-pointer loop argument is expanded into scalar
 /// offsets, a region-local environment can contain:
@@ -144,8 +146,8 @@ struct RewriteEnv {
   Value remap(Value value) const { return getRewriteContext().remap(value); }
 
   /// Asks the active policy to express one high-level SSA value as the runtime
-  /// components that may cross an expanded scf.for, scf.while, or scf.if
-  /// boundary. value is the original pointer-like SSA value. The policy
+  /// components that may cross an expanded supported control-flow boundary.
+  /// value is the original pointer-like SSA value. The policy
   /// receives the current rewrite context so it can reuse a known decomposition
   /// and remap operands to the replacement IR. It may use builder and loc
   /// to insert scalar address arithmetic at the correct rewrite position.
@@ -224,6 +226,40 @@ struct IfPointerInfo {
   SmallVector<Attribute> resultAttributes;
   std::optional<DecomposedValue> thenInfo;
 };
+
+struct ScopePointerInfo {
+  unsigned oldIndex = 0;
+  SmallVector<unsigned> componentIndices;
+  SmallVector<Type> componentTypes;
+  SmallVector<Attribute> resultAttributes;
+  std::optional<DecomposedValue> returnedInfo;
+};
+
+/// Returns the terminator of the single-block Scope form supported by the
+/// dedicated rewrite. The analyzer already checked these conditions, but the
+/// frozen plan is consumed after analysis, so the rewrite validates them again
+/// before creating replacement IR.
+static FailureOr<scope::ReturnOp>
+getSupportedScopeReturn(scope::ScopeOp scopeOp) {
+  if (scopeOp->getNumOperands() != 0 || scopeOp->getNumRegions() != 1)
+    return failure();
+  Region &region = scopeOp.getBodyRegion();
+  if (!llvm::hasSingleElement(region))
+    return failure();
+  Block &body = region.front();
+  if (body.getNumArguments() != 0)
+    return failure();
+
+  auto returnOp = dyn_cast<scope::ReturnOp>(body.getTerminator());
+  if (!returnOp || returnOp.getNumOperands() != scopeOp.getNumResults())
+    return failure();
+  for (auto [operand, result] :
+       llvm::zip(returnOp.getOperands(), scopeOp.getResults())) {
+    if (operand.getType() != result.getType())
+      return failure();
+  }
+  return returnOp;
+}
 
 // Updates the downstream descriptor marker after a loop signature expansion.
 // Existing slots are remapped through oldToNewStart before slots introduced by
@@ -681,7 +717,7 @@ static LogicalResult rewriteBodyOps(Block *oldBlock, OpBuilder &builder,
   // recursively with the same policy; ordinary operations are cloned through
   // the current SSA mapping.
   for (Operation &originalOp : oldBlock->without_terminator()) {
-    if (isa<scf::ForOp, scf::WhileOp, scf::IfOp>(originalOp)) {
+    if (isa<scf::ForOp, scf::WhileOp, scf::IfOp, scope::ScopeOp>(originalOp)) {
       const ControlFlowOpAnalysis *analysis = env.plan.lookup(&originalOp);
       if (!analysis)
         return failure();
@@ -1090,6 +1126,178 @@ static LogicalResult rewriteIfOp(scf::IfOp ifOp, OpBuilder &builder,
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// scope.scope rewrite
+//===----------------------------------------------------------------------===//
+
+/// Erases the replacement Scope and any pointer reconstruction operations
+/// inserted between it and the original Scope. Body-local operations disappear
+/// with the replacement region; post-Scope operations are erased in reverse
+/// order so their SSA dependencies remain valid during cleanup.
+static void eraseScopeReplacement(scope::ScopeOp replacement,
+                                  scope::ScopeOp original) {
+  SmallVector<Operation *> followingOperations;
+  for (Operation *operation = replacement->getNextNode();
+       operation && operation != original.getOperation();
+       operation = operation->getNextNode())
+    followingOperations.push_back(operation);
+  for (Operation *operation : llvm::reverse(followingOperations))
+    operation->erase();
+  replacement.erase();
+}
+
+static LogicalResult rewriteScopeOp(scope::ScopeOp scopeOp, OpBuilder &builder,
+                                    RewriteEnv &env) {
+  const ControlFlowOpAnalysis *analysis = env.plan.lookup(scopeOp);
+  FailureOr<scope::ReturnOp> oldReturn = getSupportedScopeReturn(scopeOp);
+  if (!analysis || !analysis->needsRewrite() || failed(oldReturn))
+    return failure();
+
+  SmallVector<ScopePointerInfo, 0> pointerInfos;
+  llvm::SmallDenseSet<unsigned> claimedResultIndices;
+  pointerInfos.reserve(analysis->slots.size());
+  for (const ControlFlowSlotAnalysis &slot : analysis->slots) {
+    if (slot.oldIndex >= scopeOp.getNumResults() ||
+        slot.componentIndices.size() != slot.componentTypes.size() ||
+        !claimedResultIndices.insert(slot.oldIndex).second ||
+        !env.policy.isDecompositionTarget(scopeOp.getResult(slot.oldIndex)))
+      return failure();
+    pointerInfos.push_back(ScopePointerInfo{
+        slot.oldIndex, slot.componentIndices, slot.componentTypes,
+        slot.resultAttributes, std::nullopt});
+  }
+
+  SmallVector<Type> newResultTypes;
+  for (auto [oldIndex, oldResult] : llvm::enumerate(scopeOp.getResults())) {
+    if (const ScopePointerInfo *pointerInfo =
+            findPointerInfoByOldIndex(pointerInfos, oldIndex)) {
+      newResultTypes.append(pointerInfo->componentTypes.begin(),
+                            pointerInfo->componentTypes.end());
+      continue;
+    }
+    newResultTypes.push_back(oldResult.getType());
+  }
+
+  auto newScope =
+      builder.create<scope::ScopeOp>(scopeOp.getLoc(), newResultTypes);
+  newScope->setAttrs(scopeOp->getAttrs());
+  // PointerDescriptorBoundary describes loop-carried slot positions and has no
+  // meaning for an operand-free Scope result boundary.
+  newScope->removeAttr(kPointerDescriptorBoundaryAttr);
+  newScope.getBodyRegion().emplaceBlock();
+
+  bool bodyOk = true;
+  {
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToEnd(&newScope.getBodyRegion().front());
+    RewriteEnv scopeEnv = env;
+    if (failed(rewriteBodyOps(&scopeOp.getBodyRegion().front(), builder,
+                              scopeEnv))) {
+      bodyOk = false;
+    } else {
+      SmallVector<Value> newReturnOperands;
+      newReturnOperands.reserve(newResultTypes.size());
+      for (auto [oldIndex, oldOperand] :
+           llvm::enumerate(oldReturn->getOperands())) {
+        ScopePointerInfo *pointerInfo =
+            findPointerInfoByOldIndex(pointerInfos, oldIndex);
+        if (!pointerInfo) {
+          newReturnOperands.push_back(scopeEnv.remap(oldOperand));
+          continue;
+        }
+
+        FailureOr<DecomposedValue> returnedInfo =
+            scopeEnv.decomposeValue(oldOperand, builder, oldReturn->getLoc());
+        if (failed(returnedInfo) ||
+            failed(castPlannedComponents(
+                *returnedInfo, pointerInfo->componentIndices,
+                pointerInfo->componentTypes, builder, oldReturn->getLoc())) ||
+            failed(scopeEnv.policy.normalizeControlFlowValue(
+                *returnedInfo, pointerInfo->resultAttributes, builder,
+                oldReturn->getLoc()))) {
+          bodyOk = false;
+          break;
+        }
+
+        FailureOr<SmallVector<Value>> returnedComponents = gatherValues(
+            returnedInfo->components, pointerInfo->componentIndices);
+        if (failed(returnedComponents)) {
+          bodyOk = false;
+          break;
+        }
+        pointerInfo->returnedInfo = *returnedInfo;
+        newReturnOperands.append(returnedComponents->begin(),
+                                 returnedComponents->end());
+      }
+
+      if (bodyOk)
+        builder.create<scope::ReturnOp>(oldReturn->getLoc(), newReturnOperands);
+    }
+  }
+
+  if (!bodyOk) {
+    eraseScopeReplacement(newScope, scopeOp);
+    return failure();
+  }
+
+  // Pointer values are reconstructed immediately outside Scope. Scope itself
+  // returns only policy-selected components and deliberately does not receive
+  // PointerDescriptorBoundary; the reconstruction operation remains the
+  // precise downstream ownership marker.
+  builder.setInsertionPointAfter(newScope);
+  unsigned newResultIndex = 0;
+  for (auto [oldIndex, oldResult] : llvm::enumerate(scopeOp.getResults())) {
+    ScopePointerInfo *pointerInfo =
+        findPointerInfoByOldIndex(pointerInfos, oldIndex);
+    if (!pointerInfo) {
+      if (newResultIndex >= newScope.getNumResults()) {
+        eraseScopeReplacement(newScope, scopeOp);
+        return failure();
+      }
+      env.valueMapping.map(oldResult, newScope.getResult(newResultIndex++));
+      continue;
+    }
+
+    if (!pointerInfo->returnedInfo ||
+        newResultIndex + pointerInfo->componentIndices.size() >
+            newScope.getNumResults()) {
+      eraseScopeReplacement(newScope, scopeOp);
+      return failure();
+    }
+    SmallVector<Value> componentValues;
+    componentValues.reserve(pointerInfo->componentIndices.size());
+    for (unsigned componentIndex = 0;
+         componentIndex < pointerInfo->componentIndices.size();
+         ++componentIndex)
+      componentValues.push_back(newScope.getResult(newResultIndex++));
+
+    FailureOr<DecomposedValue> resultInfo =
+        withReplacedComponents(*pointerInfo->returnedInfo,
+                               pointerInfo->componentIndices, componentValues);
+    if (failed(resultInfo) || failed(env.policy.normalizeControlFlowValue(
+                                  *resultInfo, pointerInfo->resultAttributes,
+                                  builder, oldResult.getLoc()))) {
+      eraseScopeReplacement(newScope, scopeOp);
+      return failure();
+    }
+
+    Value rebuilt =
+        env.policy.recompose(*resultInfo, builder, oldResult.getLoc());
+    if (!rebuilt || failed(markPointerDescriptorRebuild(rebuilt, *resultInfo,
+                                                        env.policy))) {
+      eraseScopeReplacement(newScope, scopeOp);
+      return failure();
+    }
+    env.recordDecomposition(oldResult, *resultInfo, rebuilt);
+  }
+
+  if (newResultIndex != newScope.getNumResults()) {
+    eraseScopeReplacement(newScope, scopeOp);
+    return failure();
+  }
+  return success();
+}
+
 static LogicalResult rewriteControlFlowOp(Operation *op, OpBuilder &builder,
                                           RewriteEnv &env) {
   // Keep the operation dispatch next to the shared recursive implementation:
@@ -1101,8 +1309,8 @@ static LogicalResult rewriteControlFlowOp(Operation *op, OpBuilder &builder,
     return rewriteWhileOp(whileOp, builder, env);
   if (auto ifOp = dyn_cast<scf::IfOp>(op))
     return rewriteIfOp(ifOp, builder, env);
-  // TODO: Add the frontend-produced scope.scope operation here. Scope support
-  // belongs in this shared plumbing rather than in both decompositions.
+  if (auto scopeOp = dyn_cast<scope::ScopeOp>(op))
+    return rewriteScopeOp(scopeOp, builder, env);
   return failure();
 }
 

--- a/third_party/ascend/lib/TritonControlFlowOpt/TritonControlFlowOptPass.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/TritonControlFlowOptPass.cpp
@@ -26,6 +26,7 @@
 #include "TritonControlFlowOpt/CFGStructuring.h"
 #include "TritonControlFlowOpt/TensorPtrDecompose.h"
 
+#include "bishengir/Dialect/Scope/IR/Scope.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -39,8 +40,9 @@ void TritonControlFlowOptPass::getDependentDialects(
     DialectRegistry &registry) const {
   // CFG structuring creates SCF operations, while pointer decomposition
   // materializes arith and Triton pointer operations.
-  registry.insert<arith::ArithDialect, cf::ControlFlowDialect,
-                  func::FuncDialect, scf::SCFDialect, triton::TritonDialect>();
+  registry
+      .insert<arith::ArithDialect, cf::ControlFlowDialect, func::FuncDialect,
+              scf::SCFDialect, scope::ScopeDialect, triton::TritonDialect>();
 }
 
 void TritonControlFlowOptPass::runOnOperation() {
@@ -48,8 +50,8 @@ void TritonControlFlowOptPass::runOnOperation() {
 
   // Apply the control-flow preprocessing pipeline in dependency order:
   //   1. normalize supported cf graphs to scf;
-  //   2. decompose block-pointer descriptors across SCF boundaries;
-  //   3. replace common-base tensor pointers at SCF boundaries with offsets.
+  //   2. decompose block-pointer descriptors across supported boundaries;
+  //   3. replace common-base tensor pointers at those boundaries with offsets.
   // TODO: Extend stage 3 to carry both the base and complete offsets, then add
   // StructuredOffsetsDecompose to further split structured offsets into a
   // base offset and per-dimension strides.

--- a/third_party/ascend/lib/TritonToLinalg/UseAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/UseAnalysis.cpp
@@ -24,6 +24,7 @@
 #include "ascend/include/Utils/Utils.h"
 
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "bishengir/Dialect/Scope/IR/Scope.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 
 #include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
@@ -340,7 +341,7 @@ LogicalResult triton::runUseAnalysis(triton::FuncOp &funcOp) {
         }
       }
       if (!isa<mlir::scf::IfOp, mlir::scf::ForOp, mlir::scf::WhileOp,
-               triton::ReduceOp>(op)) {
+               scope::ScopeOp, triton::ReduceOp>(op)) {
         assert(op->getNumResults() == 1 &&
                "Ops used for meta computation are expected to have one result");
       }

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scope_pointer_decouple.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scope_pointer_decouple.mlir
@@ -1,0 +1,208 @@
+// RUN: triton-opt --triton-control-flow-opt --split-input-file %s -verify-each | FileCheck %s --check-prefix=CFO
+
+module {
+  tt.func public @scope_block_ptr_result(%base: !tt.ptr<f16>, %delta: i32) -> !tt.ptr<tensor<32xf16>> {
+    %c1_i64 = arith.constant 1 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %result = scope.scope : () -> (!tt.ptr<tensor<32xf16>>) {
+      %pointer = tt.make_tensor_ptr %base, [%c32_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<32xf16>>
+      %next = tt.advance %pointer, [%delta] : !tt.ptr<tensor<32xf16>>
+      scope.return %next : !tt.ptr<tensor<32xf16>>
+    } {hivm.disable_auto_sync = true, hivm.tcore_type = #hivm.tcore_type<VECTOR>, noinline, scope_test_attr = "kept"}
+    tt.return %result : !tt.ptr<tensor<32xf16>>
+  }
+}
+
+// CFO-LABEL: tt.func public @scope_block_ptr_result
+// CFO:       %[[SCOPE:.*]]:4 = scope.scope : () -> (i64, i64, i64, i32) {
+// CFO:         scope.return %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i64, i64, i32
+// CFO:       } {hivm.disable_auto_sync = true, hivm.tcore_type = #hivm.tcore_type<VECTOR>, noinline, scope_test_attr = "kept"}
+// CFO:       tt.make_tensor_ptr
+// CFO-SAME:  PointerDescriptorRebuild
+// CFO-NOT:   PointerDescriptorBoundary
+
+// -----
+
+module {
+  tt.func public @scope_block_ptr_mixed_results(%base: !tt.ptr<f16>) -> !tt.ptr<tensor<16xf16>> {
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %results:3 = scope.scope : () -> (i32, !tt.ptr<tensor<16xf16>>, tensor<4xi32>) {
+      %ordinary = arith.constant 7 : i32
+      %tensor = arith.constant dense<9> : tensor<4xi32>
+      %pointer = tt.make_tensor_ptr %base, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf16>>
+      scope.return %ordinary, %pointer, %tensor : i32, !tt.ptr<tensor<16xf16>>, tensor<4xi32>
+    }
+    tt.return %results#1 : !tt.ptr<tensor<16xf16>>
+  }
+}
+
+// CFO-LABEL: tt.func public @scope_block_ptr_mixed_results
+// CFO:       %[[SCOPE:.*]]:6 = scope.scope : () -> (i32, i64, i64, i64, i32, tensor<4xi32>) {
+// CFO:         scope.return %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i32, i64, i64, i64, i32, tensor<4xi32>
+// CFO:       }
+// CFO:       %[[POINTER:.*]] = tt.make_tensor_ptr
+// CFO-SAME:  PointerDescriptorRebuild
+// CFO:       tt.return %[[POINTER]] : !tt.ptr<tensor<16xf16>>
+
+// -----
+
+module {
+  tt.func public @scope_tensor_ptr_scalar_base(%base: !tt.ptr<f32>) -> tensor<4x!tt.ptr<f32>> {
+    %range = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %base_tensor = tt.splat %base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %result = scope.scope : () -> (tensor<4x!tt.ptr<f32>>) {
+      %pointer = tt.addptr %base_tensor, %range : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scope.return %pointer : tensor<4x!tt.ptr<f32>>
+    }
+    tt.return %result : tensor<4x!tt.ptr<f32>>
+  }
+}
+
+// CFO-LABEL: tt.func public @scope_tensor_ptr_scalar_base
+// CFO:       %[[SCOPE:.*]]:4 = scope.scope
+// CFO-SAME:  -> (i64, i32, i32, tensor<4xi32>)
+// CFO:         scope.return %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i32, i32, tensor<4xi32>
+// CFO:       }
+// CFO:       %[[POINTER:.*]] = tt.addptr
+// CFO-SAME:  PointerDescriptorOffsetForm = "strided_1d"
+// CFO-SAME:  PointerDescriptorRebuild
+// CFO-SAME:  PointerDescriptorStructuredAxes = array<i32: 1>
+// CFO:       tt.return %[[POINTER]] : tensor<4x!tt.ptr<f32>>
+
+// -----
+
+module {
+  tt.func public @scope_tensor_ptr_external_opaque_base(%lhs_base: !tt.ptr<f32>, %rhs_base: !tt.ptr<f32>, %cond: i1) -> tensor<4x!tt.ptr<f32>> {
+    %lhs = tt.splat %lhs_base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %rhs = tt.splat %rhs_base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %condition = tt.splat %cond : i1 -> tensor<4xi1>
+    %opaque = arith.select %condition, %lhs, %rhs : tensor<4xi1>, tensor<4x!tt.ptr<f32>>
+    %delta = arith.constant dense<3> : tensor<4xi32>
+    %result = scope.scope : () -> (tensor<4x!tt.ptr<f32>>) {
+      %pointer = tt.addptr %opaque, %delta : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scope.return %pointer : tensor<4x!tt.ptr<f32>>
+    }
+    tt.return %result : tensor<4x!tt.ptr<f32>>
+  }
+}
+
+// CFO-LABEL: tt.func public @scope_tensor_ptr_external_opaque_base
+// CFO:       %[[OPAQUE:.*]] = arith.select
+// CFO:       %[[SCOPE:.*]]:3 = scope.scope
+// CFO-SAME:  -> (i32, i32, tensor<4xi32>)
+// CFO:         scope.return
+// CFO:       }
+// CFO:       %[[REBUILT:.*]] = tt.addptr %[[OPAQUE]],
+// CFO-SAME:  PointerDescriptorRebuild
+// CFO-NOT:   PointerDescriptorOffsetForm
+// CFO:       tt.return %[[REBUILT]] : tensor<4x!tt.ptr<f32>>
+
+// -----
+
+module {
+  tt.func public @scope_contains_pointer_for(%base: !tt.ptr<f16>) -> !tt.ptr<tensor<16xf16>> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %result = scope.scope : () -> (!tt.ptr<tensor<16xf16>>) {
+      %initial = tt.make_tensor_ptr %base, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf16>>
+      %final = scf.for %iv = %c0 to %c2 step %c1 iter_args(%pointer = %initial) -> (!tt.ptr<tensor<16xf16>>) {
+        %next = tt.advance %pointer, [%c1_i32] : !tt.ptr<tensor<16xf16>>
+        scf.yield %next : !tt.ptr<tensor<16xf16>>
+      }
+      scope.return %final : !tt.ptr<tensor<16xf16>>
+    } {scope_test_attr = "outer"}
+    tt.return %result : !tt.ptr<tensor<16xf16>>
+  }
+}
+
+// CFO-LABEL: tt.func public @scope_contains_pointer_for
+// CFO:       scope.scope
+// CFO:         scf.for
+// CFO-SAME:    -> (i32)
+// CFO:         } {PointerDescriptorBoundary = array<i32: 0>}
+// CFO:       } {scope_test_attr = "outer"}
+
+// -----
+
+module {
+  tt.func public @nested_scope_pointer_result(%base: !tt.ptr<f16>) -> !tt.ptr<tensor<16xf16>> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %outer = scope.scope : () -> (!tt.ptr<tensor<16xf16>>) {
+      %inner = scope.scope : () -> (!tt.ptr<tensor<16xf16>>) {
+        %pointer = tt.make_tensor_ptr %base, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf16>>
+        scope.return %pointer : !tt.ptr<tensor<16xf16>>
+      } {scope_test_attr = "inner"}
+      %next = tt.advance %inner, [%c1_i32] : !tt.ptr<tensor<16xf16>>
+      scope.return %next : !tt.ptr<tensor<16xf16>>
+    } {scope_test_attr = "outer"}
+    tt.return %outer : !tt.ptr<tensor<16xf16>>
+  }
+}
+
+// CFO-LABEL: tt.func public @nested_scope_pointer_result
+// CFO:       scope.scope : () -> (i64, i64, i64, i32) {
+// CFO:         scope.scope : () -> (i64, i64, i64, i32) {
+// CFO:         } {scope_test_attr = "inner"}
+// CFO:       } {scope_test_attr = "outer"}
+
+// -----
+
+module {
+  tt.func public @resultless_scope_contains_pointer_if(%base: !tt.ptr<f16>, %cond: i1) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    scope.scope : () -> () {
+      %initial = tt.make_tensor_ptr %base, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf16>>
+      %selected = scf.if %cond -> (!tt.ptr<tensor<16xf16>>) {
+        %then = tt.advance %initial, [%c1_i32] : !tt.ptr<tensor<16xf16>>
+        scf.yield %then : !tt.ptr<tensor<16xf16>>
+      } else {
+        %else = tt.advance %initial, [%c2_i32] : !tt.ptr<tensor<16xf16>>
+        scf.yield %else : !tt.ptr<tensor<16xf16>>
+      }
+      %loaded = tt.load %selected : !tt.ptr<tensor<16xf16>>
+      scope.return
+    } {scope_test_attr = "resultless"}
+    tt.return
+  }
+}
+
+// CFO-LABEL: tt.func public @resultless_scope_contains_pointer_if
+// CFO:       scope.scope : () -> () {
+// CFO:         scf.if
+// CFO-SAME:    -> (i32)
+// CFO:         tt.load
+// CFO:       } {scope_test_attr = "resultless"}
+
+// -----
+
+module {
+  tt.func public @scope_attributes_preserved(%base: !tt.ptr<f16>) -> !tt.ptr<tensor<16xf16>> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %result = scope.scope : () -> (!tt.ptr<tensor<16xf16>>) {
+      %pointer = tt.make_tensor_ptr %base, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf16>>
+      scope.return %pointer : !tt.ptr<tensor<16xf16>>
+    } {hivm.disable_auto_sync = true, hivm.tcore_type = #hivm.tcore_type<VECTOR>, noinline, scope_test_attr = "all-preserved"}
+    tt.return %result : !tt.ptr<tensor<16xf16>>
+  }
+}
+
+// CFO-LABEL: tt.func public @scope_attributes_preserved
+// CFO:       scope.scope : () -> (i64, i64, i64, i32) {
+// CFO:       } {hivm.disable_auto_sync = true, hivm.tcore_type = #hivm.tcore_type<VECTOR>, noinline, scope_test_attr = "all-preserved"}

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scope_pointer_downstream.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scope_pointer_downstream.mlir
@@ -1,0 +1,51 @@
+// RUN: triton-opt --triton-control-flow-opt --triton-to-unstructure --triton-to-linalg --split-input-file %s -verify-each | FileCheck %s --check-prefix=E2E --implicit-check-not='!tt.ptr' --implicit-check-not=unrealized_conversion_cast --implicit-check-not=PointerDescriptorBoundary --implicit-check-not=PointerDescriptorRebuild --implicit-check-not=PointerDescriptorOffsetForm --implicit-check-not=PointerDescriptorStructuredAxes
+
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @scope_block_ptr_load_store(%base: !tt.ptr<f32>, %output: !tt.ptr<f32>) {
+    %c0_i32 = arith.constant 0 : i32
+    %c3_i32 = arith.constant 3 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %pointer = scope.scope : () -> (!tt.ptr<tensor<16xf32>>) {
+      %initial = tt.make_tensor_ptr %base, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf32>>
+      %next = tt.advance %initial, [%c3_i32] : !tt.ptr<tensor<16xf32>>
+      scope.return %next : !tt.ptr<tensor<16xf32>>
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    %value = tt.load %pointer : !tt.ptr<tensor<16xf32>>
+    %output_pointer = tt.make_tensor_ptr %output, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf32>>
+    tt.store %output_pointer, %value : !tt.ptr<tensor<16xf32>>
+    tt.return
+  }
+}
+
+// E2E-LABEL: func.func @scope_block_ptr_load_store
+// E2E:       scope.scope
+// E2E:       memref.copy
+// E2E:       bufferization.materialize_in_destination %{{.*}} in writable %{{.*}}
+// E2E:       return
+
+// -----
+
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @scope_tensor_ptr_masked_load_store(%base: !tt.ptr<f32>, %output: !tt.ptr<f32>) {
+    %range = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %base_tensor = tt.splat %base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %pointer = scope.scope : () -> (tensor<4x!tt.ptr<f32>>) {
+      %next = tt.addptr %base_tensor, %range : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scope.return %next : tensor<4x!tt.ptr<f32>>
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    %mask = arith.constant dense<true> : tensor<4xi1>
+    %other = arith.constant dense<0.000000e+00> : tensor<4xf32>
+    %value = tt.load %pointer, %mask, %other : tensor<4x!tt.ptr<f32>>
+    %output_tensor = tt.splat %output : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %output_pointer = tt.addptr %output_tensor, %range : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    tt.store %output_pointer, %value, %mask : tensor<4x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// E2E-LABEL: func.func @scope_tensor_ptr_masked_load_store
+// E2E:       scope.scope
+// E2E:       memref.copy
+// E2E:       bufferization.materialize_in_destination %{{.*}} in writable %{{.*}}
+// E2E:       return

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scope_pointer_unsupported.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scope_pointer_unsupported.mlir
@@ -1,0 +1,19 @@
+// RUN: not triton-opt --triton-control-flow-opt %s -verify-each 2>&1 | FileCheck %s --check-prefix=ERR
+
+module {
+  tt.func public @scope_internal_opaque_tensor_pointer(%lhs_base: !tt.ptr<f32>, %rhs_base: !tt.ptr<f32>, %cond: i1) -> tensor<4x!tt.ptr<f32>> {
+    %lhs = tt.splat %lhs_base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %rhs = tt.splat %rhs_base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %condition = tt.splat %cond : i1 -> tensor<4xi1>
+    %result = scope.scope : () -> (tensor<4x!tt.ptr<f32>>) {
+      %opaque = arith.select %condition, %lhs, %rhs : tensor<4xi1>, tensor<4x!tt.ptr<f32>>
+      scope.return %opaque : tensor<4x!tt.ptr<f32>>
+    }
+    tt.return %result : tensor<4x!tt.ptr<f32>>
+  }
+}
+
+// ERR: failed to analyze pointer components across control flow
+// ERR-NOT: Assertion
+// ERR-NOT: LLVM ERROR
+// ERR-NOT: Segmentation fault

--- a/third_party/ascend/unittest/pytest_ut/test_control_flow_pointer_boundary.py
+++ b/third_party/ascend/unittest/pytest_ut/test_control_flow_pointer_boundary.py
@@ -23,6 +23,7 @@ import torch
 import torch_npu  # noqa: F401
 import triton
 import triton.language as tl
+import triton.language.extra.cann.extension as al
 
 BLOCK = 32
 N = 128
@@ -150,6 +151,34 @@ def opaque_tensor_ptr_loop_kernel(a, b, out, steps_ptr, n: tl.constexpr, BLOCK: 
     tl.store(out + lane, value)
 
 
+@triton.jit
+def scope_block_ptr_kernel(x, out, delta_ptr, n: tl.constexpr, BLOCK: tl.constexpr):
+    delta = tl.load(delta_ptr).to(tl.int32)
+    pointer = tl.make_block_ptr(
+        base=x,
+        shape=(n, ),
+        strides=(1, ),
+        offsets=(1, ),
+        block_shape=(BLOCK, ),
+        order=(0, ),
+    )
+    with al.scope(core_mode="vector", disable_auto_sync=True):
+        pointer = tl.advance(pointer, (delta, ))
+    value = tl.load(pointer, boundary_check=(0, ), padding_option="zero")
+    tl.store(out + tl.arange(0, BLOCK), value)
+
+
+@triton.jit
+def scope_tensor_ptr_kernel(x, out, delta_ptr, n: tl.constexpr, BLOCK: tl.constexpr):
+    lane = tl.arange(0, BLOCK)
+    delta = tl.load(delta_ptr)
+    pointers = x + lane
+    with al.scope(core_mode="vector"):
+        pointers = pointers + delta
+    value = tl.load(pointers, mask=lane + delta < n, other=0.0)
+    tl.store(out + lane, value)
+
+
 def _inputs():
     a_cpu = torch.arange(2048, dtype=torch.float32)
     b_cpu = 100000.0 + torch.arange(2048, dtype=torch.float32) * 3.0
@@ -248,3 +277,23 @@ def test_opaque_tensor_pointer_loop(steps):
         if index < N:
             expected[lane] = a_cpu[index] if (lane & 1) == 0 else b_cpu[index]
     _assert_output(out, expected)
+
+
+@pytest.mark.parametrize("delta", [0, 3, 37])
+def test_scope_block_pointer_result(delta):
+    a_cpu, _, a, _ = _inputs()
+    out = torch.empty(BLOCK, dtype=torch.float32, device="npu")
+
+    scope_block_ptr_kernel[(1, )](a, out, _device_i32(delta), n=N, BLOCK=BLOCK)
+
+    _assert_output(out, _slice(a_cpu, 0, N, 1, 1 + delta))
+
+
+@pytest.mark.parametrize("delta", [0, 2, 5])
+def test_scope_tensor_pointer_result(delta):
+    a_cpu, _, a, _ = _inputs()
+    out = torch.empty(BLOCK, dtype=torch.float32, device="npu")
+
+    scope_tensor_ptr_kernel[(1, )](a, out, _device_i32(delta), n=N, BLOCK=BLOCK)
+
+    _assert_output(out, _slice(a_cpu, 0, N, 1, delta))


### PR DESCRIPTION
## Summary

- add dedicated read-only analysis and mechanical rewriting for the frontend's single-region `scope.scope` operation
- expand policy-selected BlockPtr and TensorPtr descriptor components through Scope results, then rebuild marked pointers outside Scope
- support BlockPtr, scalar-base TensorPtr, and external opaque-base TensorPtr while rejecting Scope-local opaque bases during analysis
- preserve Scope attributes and result ordering without attaching the loop-only `PointerDescriptorBoundary` marker
- register and link the Scope dialect without changing T2L, T2U, DynamicCV, pointer policy implementations, or AscendNPU-IR

## Examples

The following examples use simplified IR to illustrate the pointer boundary transformation. Exact auxiliary casts and canonicalized SSA values may differ.

### BlockPtr result

A BlockPtr cannot remain a direct Scope result. The pass expands it into its base address, shape, stride, and offset components, then reconstructs the
BlockPtr immediately after Scope.

Before:

```mlir
%result = scope.scope
    : () -> (!tt.ptr<tensor<16xf32>>) {
  %ptr = tt.make_tensor_ptr
      %base, [%c16], [%c1], [%offset]
      {order = array<i32: 0>}
      : !tt.ptr<tensor<16xf32>>

  scope.return %ptr
      : !tt.ptr<tensor<16xf32>>
}
```
After:
```
%base_address = tt.ptr_to_int %base
    : !tt.ptr<f32> -> i64

%components:4 = scope.scope
    : () -> (i64, i64, i64, i32) {
  scope.return
      %base_address, %c16, %c1, %offset
      : i64, i64, i64, i32
}

%native_base = tt.int_to_ptr %components#0
    : i64 -> !tt.ptr<f32>

%result = tt.make_tensor_ptr
    %native_base,
    [%components#1],
    [%components#2],
    [%components#3]
    {
      order = array<i32: 0>,
    }
    : !tt.ptr<tensor<16xf32>>
```
TensorPtr result
A scalar-base tensor<ptr> is represented by a scalar base address together with structured and opaque offset components. Scope returns those components, and the pointer tensor is rebuilt outside Scope as splat(base) + offsets.
Before:
```
%range = tt.make_range {start = 0 : i32, end = 4 : i32}
    : tensor<4xi32>

%base_tensor = tt.splat %base
    : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>

%result = scope.scope
    : () -> (tensor<4x!tt.ptr<f32>>) {
  %ptrs = tt.addptr %base_tensor, %range
      : tensor<4x!tt.ptr<f32>>, tensor<4xi32>

  scope.return %ptrs
      : tensor<4x!tt.ptr<f32>>
}
```
After:
```
%base_address = tt.ptr_to_int %base
    : !tt.ptr<f32> -> i64

%components:4 = scope.scope
    : () -> (i64, i32, i32, tensor<4xi32>) {
  scope.return
      %base_address,
      %stride,
      %uniform_offset,
      %opaque_offsets
      : i64, i32, i32, tensor<4xi32>
}

%native_base = tt.int_to_ptr %components#0
    : i64 -> !tt.ptr<f32>

%rebuilt_base = tt.splat %native_base
    : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>

// rebuilt_offsets = range * stride + uniform_offset + opaque_offsets

%result = tt.addptr %rebuilt_base, %rebuilt_offsets
    : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
```
Unsupported Scope-local opaque base
An opaque pointer-tensor base created inside Scope cannot be referenced after the original Scope region is replaced. The analysis therefore rejects this case instead of performing a partial or unsafe rewrite.
```
%result = scope.scope
    : () -> (tensor<4x!tt.ptr<f32>>) {
  %selected = arith.select %condition, %lhs, %rhs
      : tensor<4xi1>, tensor<4x!tt.ptr<f32>>

  scope.return %selected
      : tensor<4x!tt.ptr<f32>>
}
```
The same opaque base is supported when it is defined outside Scope, because the reconstruction can reuse the external SSA value and only carry the modified offset components through Scope.