### PR TITLE
[launch](feat) adapter cann version(8.5.0 - 9.2.0)

### DIFF
--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -33,7 +33,7 @@ from triton.backends.driver import DriverBase
 from triton.backends.compiler import GPUTarget
 from triton.backends.ascend.utils import (_build_npu_ext, _check_cxx11_abi, convert_sigtype_to_int,
                                           _is_auto_map_parallel_blocks_enabled, is_ffts_supported, force_disable_ffts,
-                                          get_backend_func)
+                                          get_backend_func, get_cann_version)
 # Bind the already-imported utils module once so the launch hot path can write
 # TRITON_PROFILER_REGISTERED without a per-launch `import triton` + attribute walk.
 import triton.backends.ascend.utils as _ascend_utils
@@ -51,7 +51,9 @@ class NPUUtils(object):
         src_path = os.path.join(dirname, "npu_utils.cpp")
         src = Path(src_path).read_text()
         version_info = get_backend_func("version_hash")
-        key = hashlib.md5((src + "_".join(version_info)).encode("utf-8")).hexdigest()
+        cann_version = get_cann_version()
+        cann_version_str = ".".join(map(str, cann_version)) if cann_version else ""
+        key = hashlib.md5((src + "_".join(version_info) + "_" + cann_version_str).encode("utf-8")).hexdigest()
         cache = get_cache_manager(key)
         fname = "npu_utils.so"
         cache_path = cache.get_file(fname)
@@ -411,6 +413,67 @@ def generate_npu_header_src():
 #include <acl/acl.h>
 {get_backend_func("header_file", enable_taskqueue)}
 #endif
+
+// Compatibility shim for CANN runtime API transition (rt -> aclrt in 9.0.0).
+#ifdef TRITON_CANN_910
+using cann_error = aclError;
+using cann_stream = aclrtStream;
+using cann_func_handle = aclrtFuncHandle;
+using cann_memcpy_kind = aclrtMemcpyKind;
+static constexpr cann_error CANN_SUCCESS = ACL_SUCCESS;
+static constexpr cann_memcpy_kind CANN_MEMCPY_HOST_TO_DEVICE = ACL_MEMCPY_HOST_TO_DEVICE;
+static inline cann_error cann_malloc_host(void **ptr, size_t size) {{ return aclrtMallocHost(ptr, size); }}
+static inline cann_error cann_free_host(void *ptr) {{ return aclrtFreeHost(ptr); }}
+static inline cann_error cann_memcpy(void *dst, size_t destMax, const void *src, size_t count, cann_memcpy_kind kind) {{ return aclrtMemcpy(dst, destMax, src, count, kind); }}
+static inline cann_error cann_memset_async(void *dst, size_t destMax, int32_t value, size_t count, cann_stream stream) {{ return aclrtMemsetAsync(dst, destMax, value, count, stream); }}
+static inline cann_error cann_synchronize_stream(cann_stream stream) {{ return aclrtSynchronizeStream(stream); }}
+static inline cann_error cann_get_hardware_sync_addr(void **addr) {{ return aclrtGetHardwareSyncAddr(addr); }}
+static inline cann_error cann_launch_kernel(cann_func_handle func, uint32_t block_dim, cann_stream stream, void *cfg, void *args, size_t arg_size) {{
+  return aclrtLaunchKernelWithHostArgs(func, block_dim, stream, static_cast<aclrtLaunchKernelCfg *>(cfg), args, arg_size, nullptr, 0);
+}}
+static inline void* cann_get_launch_kernel_cfg(uint32_t shared_mem_dynamic_size) {{
+  // thread_local storage: launch is synchronous on the launcher thread, so the
+  // returned pointer remains valid until cann_launch_kernel returns.
+  static thread_local aclrtLaunchKernelAttr attrInfo;
+  static thread_local aclrtLaunchKernelCfg cfgCfgInfo;
+  attrInfo.id = ACL_RT_LAUNCH_KERNEL_ATTR_DYN_UBUF_SIZE;
+  aclrtLaunchKernelAttrValue attrValue;
+  attrValue.localMemorySize = shared_mem_dynamic_size;
+  attrInfo.value = attrValue;
+  cfgCfgInfo.attrs = &attrInfo;
+  cfgCfgInfo.numAttrs = 1;
+  return &cfgCfgInfo;
+}}
+#else
+using cann_error = rtError_t;
+using cann_stream = rtStream_t;
+using cann_func_handle = const void*;
+using cann_memcpy_kind = rtMemcpyKind_t;
+static constexpr cann_error CANN_SUCCESS = RT_ERROR_NONE;
+static constexpr cann_memcpy_kind CANN_MEMCPY_HOST_TO_DEVICE = RT_MEMCPY_HOST_TO_DEVICE;
+static inline cann_error cann_malloc_host(void **ptr, size_t size) {{ return rtMallocHost(ptr, size, RT_MEMORY_HOST); }}
+static inline cann_error cann_free_host(void *ptr) {{ return rtFreeHost(ptr); }}
+static inline cann_error cann_memcpy(void *dst, size_t destMax, const void *src, size_t count, cann_memcpy_kind kind) {{ return rtMemcpy(dst, destMax, src, count, kind); }}
+static inline cann_error cann_memset_async(void *dst, size_t destMax, int32_t value, size_t count, cann_stream stream) {{ return rtMemsetAsync(dst, destMax, value, count, stream); }}
+static inline cann_error cann_synchronize_stream(cann_stream stream) {{ return rtStreamSynchronize(stream); }}
+static inline cann_error cann_get_hardware_sync_addr(void **addr) {{ uint32_t len = 0; return rtGetC2cCtrlAddr(reinterpret_cast<uint64_t *>(addr), &len); }}
+static inline cann_error cann_launch_kernel(cann_func_handle func, uint32_t block_dim, cann_stream stream, void *cfg, void *args, size_t arg_size) {{
+  if (cfg != nullptr) {{
+    rtArgsEx_t argsInfo = {{}};
+    argsInfo.args = args;
+    argsInfo.argsSize = arg_size;
+    return rtKernelLaunchWithFlagV2(func, block_dim, &argsInfo, NULL, stream, 0, static_cast<rtTaskCfgInfo_t *>(cfg));
+  }}
+  return rtKernelLaunch(func, block_dim, args, arg_size, NULL, stream);
+}}
+static inline void* cann_get_launch_kernel_cfg(uint32_t shared_mem_dynamic_size) {{
+  // thread_local storage: launch is synchronous on the launcher thread, so the
+  // returned pointer remains valid until cann_launch_kernel returns.
+  static thread_local rtTaskCfgInfo_t cfgInfo;
+  cfgInfo.localMemorySize = shared_mem_dynamic_size;
+  return &cfgInfo;
+}}
+#endif
 """
 
 
@@ -565,22 +628,21 @@ static inline size_t _align_launch_offset(size_t offset, size_t alignment) {
   return (offset + alignment - 1) & ~(alignment - 1);
 }
 
-// aclrtGetHardwareSyncAddr returns a per-process per-stream constant address;
+// cann_get_hardware_sync_addr returns a per-process per-stream constant address;
 // re-querying it on every kernel launch is pure overhead. Cache the most
 // recently observed (stream, ffts_addr) pair on the calling thread.
 // Thread-safety: launch_call is invoked synchronously from the launcher thread
-// by triton_async_launch (see npu_utils.cpp), so thread_local is safe.
-static thread_local aclrtStream g_last_ffts_stream = nullptr;
+// by cann_async_launch (see npu_utils.cpp), so thread_local is safe.
+static thread_local cann_stream g_last_ffts_stream = nullptr;
 static thread_local void* g_last_ffts_addr = nullptr;
-static inline aclError get_ffts_addr(aclrtStream stream, void** out_addr) {
+static inline cann_error get_ffts_addr(cann_stream stream, void** out_addr) {
   if (stream == g_last_ffts_stream && g_last_ffts_addr) {
     *out_addr = g_last_ffts_addr;
-    return ACL_SUCCESS;
+    return CANN_SUCCESS;
   }
   void* ffts_addr = nullptr;
-  uint32_t ffts_len = 0;
-  aclError ret = aclrtGetHardwareSyncAddr(&ffts_addr);
-  if (ret == ACL_SUCCESS) {
+  cann_error ret = cann_get_hardware_sync_addr(&ffts_addr);
+  if (ret == CANN_SUCCESS) {
     g_last_ffts_stream = stream;
     g_last_ffts_addr = ffts_addr;
     *out_addr = ffts_addr;
@@ -646,17 +708,17 @@ def make_launcher(constants, signature, metadata):
          lockOffset += syncBlockLockStrideI64) {{
       lockInitData[lockOffset] = syncBlockLockParticipantNum;
     }}
-    ret = aclrtMemcpy(syncBlockLock_ptr, syncBlockLockSize,
+    ret = cann_memcpy(syncBlockLock_ptr, syncBlockLockSize,
                    reinterpret_cast<void *>(lockInitData.data()),
-                   syncBlockLockSize, ACL_MEMCPY_HOST_TO_DEVICE);"""
+                   syncBlockLockSize, CANN_MEMCPY_HOST_TO_DEVICE);"""
     elif lock_init_value == 0:
-        lock_init_stmt = ("ret = aclrtMemsetAsync(syncBlockLock_ptr, syncBlockLockSize, 0, "
+        lock_init_stmt = ("ret = cann_memset_async(syncBlockLock_ptr, syncBlockLockSize, 0, "
                           "syncBlockLockSize, stream);")
     else:
         lock_init_stmt = (f"std::vector<int64_t> lockInitData({lock_num}, {lock_init_value});\n"
-                          "    ret = aclrtMemcpy(syncBlockLock_ptr, syncBlockLockSize, "
+                          "    ret = cann_memcpy(syncBlockLock_ptr, syncBlockLockSize, "
                           "reinterpret_cast<void *>(lockInitData.data()), syncBlockLockSize, "
-                          "ACL_MEMCPY_HOST_TO_DEVICE);")
+                          "CANN_MEMCPY_HOST_TO_DEVICE);")
     bs_task_type = metadata.bs_task_type if hasattr(metadata, 'bs_task_type') else 0
     mix_mode = metadata.mix_mode
     compile_on_910_95 = metadata.compile_on_910_95
@@ -1046,19 +1108,12 @@ static void release_npu_tensor_handle(void* handle) {{
 """
 
     def _make_kernel_launch(args_ptr, args_size, indent="    "):
-        cfg = "&cfgCfgInfo" if (compile_on_910_95 and enable_simt) else "nullptr"
         cfg_setup = ""
         if compile_on_910_95 and enable_simt:
-            cfg_setup = f"""{indent}aclrtLaunchKernelAttr attrInfo = {{}};
-{indent}attrInfo.id = ACL_RT_LAUNCH_KERNEL_ATTR_DYN_UBUF_SIZE;
-{indent}aclrtLaunchKernelAttrValue value = {{}};
-{indent}value.localMemorySize = {metadata.shared_mem_dynamic_size};
-{indent}attrInfo.value = value;
-{indent}aclrtLaunchKernelCfg cfgCfgInfo = {{}};
-{indent}cfgCfgInfo.attrs = &attrInfo;
-{indent}cfgCfgInfo.numAttrs = 1;
-"""
-        return f"""{cfg_setup}{indent}ret = aclrtLaunchKernelWithHostArgs(func, blockNum, stream, {cfg}, {args_ptr}, {args_size}, nullptr, 0);
+            cfg_setup = f"{indent}void *kernel_cfg = cann_get_launch_kernel_cfg({metadata.shared_mem_dynamic_size});\n"
+        else:
+            cfg_setup = f"{indent}void *kernel_cfg = nullptr;\n"
+        return f"""{cfg_setup}{indent}ret = cann_launch_kernel(func, blockNum, stream, kernel_cfg, {args_ptr}, {args_size});
 """
 
     cpp_kernel_launch = _make_kernel_launch("static_cast<void*>(launch_args.data())", "launch_args.size()")
@@ -1081,7 +1136,7 @@ static void release_npu_tensor_handle(void* handle) {{
   }}
   ''' if workspace_size > 0 else ''}"""
 
-    _launch_lambda_pre = f"""  {'std::function<aclError()> launch_call = [=]() -> aclError' if enable_taskqueue else ''} {{
+    _launch_lambda_pre = f"""  {'std::function<cann_error()> launch_call = [=]() -> cann_error' if enable_taskqueue else ''} {{
     {get_backend_func("pre_launch", False)}
     uint32_t blockNum = gridX * gridY * gridZ;
 
@@ -1098,9 +1153,9 @@ static void release_npu_tensor_handle(void* handle) {{
     uint32_t nodeBasicBlockDim = (mixBlockNumRation << 16) + blockNum;
 
     {'cce::internal::DebugTunnelData *DTData = cce::internal::DebugTunnel::Open(blockNum);' if enable_device_print else ''}
-    aclError ret = ACL_SUCCESS;
+    cann_error ret = CANN_SUCCESS;
     {'void *ffts_addr = nullptr; ret = get_ffts_addr(stream, &ffts_addr);' if target_support_ffts else ''}
-    {'if (ret != ACL_SUCCESS) return ret;' if (target_support_ffts and enable_taskqueue) else 'if (ret != ACL_SUCCESS) return;' if (target_support_ffts and (not enable_taskqueue)) else ''}
+    {'if (ret != CANN_SUCCESS) return ret;' if (target_support_ffts and enable_taskqueue) else 'if (ret != CANN_SUCCESS) return;' if (target_support_ffts and (not enable_taskqueue)) else ''}
     // stub argument for workspace
     void *syncBlockLock_ptr = nullptr;
     void *syncBlockLock_handle = nullptr;
@@ -1113,11 +1168,11 @@ static void release_npu_tensor_handle(void* handle) {{
       {alloc_success_code if enable_taskqueue else sync_lock_fail_code}
     }}
     {lock_init_stmt}
-    if (ret != ACL_SUCCESS) {{
+    if (ret != CANN_SUCCESS) {{
       return {'ret' if enable_taskqueue else ''};
     }}
     ''' if lock_num > 0 else ''}
-    {'if (ret != ACL_SUCCESS) {{ return ret; }}' if (workspace_size > 0 and enable_taskqueue) else 'if (ret != ACL_SUCCESS) {{ return; }}' if (workspace_size > 0 and not enable_taskqueue) else ''}"""
+    {'if (ret != CANN_SUCCESS) {{ return ret; }}' if (workspace_size > 0 and enable_taskqueue) else 'if (ret != CANN_SUCCESS) {{ return; }}' if (workspace_size > 0 and not enable_taskqueue) else ''}"""
 
     _launch_lambda_post = f"""
     {cpp_msprof_call_before_launch}
@@ -1125,7 +1180,7 @@ static void release_npu_tensor_handle(void* handle) {{
     {'void*& stream_ref = const_cast<void*&>(stream);' if enable_device_print else ''}
     {'cce::internal::DebugTunnel::Close(DTData, stream_ref);' if enable_device_print else ''}
     {cpp_msprof_call_after_launch}
-    {'return ret;' if enable_taskqueue else 'ret = aclrtSynchronizeStream(stream);'}
+    {'return ret;' if enable_taskqueue else 'ret = cann_synchronize_stream(stream);'}
   }};
   {f'''{get_backend_func("async_launch", "launch_call") if enable_taskqueue else ''}'''}
   return;
@@ -1150,7 +1205,7 @@ static void release_npu_tensor_handle(void* handle) {{
 {_CPP_ALIGN_LAUNCH_OFFSET}
 
 extern "C" {{
-void triton_launch_kernel(const char* kernelName, aclrtFuncHandle func, aclrtStream stream,
+void triton_launch_kernel(const char* kernelName, cann_func_handle func, cann_stream stream,
     int gridX, int gridY, int gridZ,
     const int64_t* shapes_data, const int* shape_dims, int num_tensors,
     const int* tensor_kinds,
@@ -1236,7 +1291,7 @@ void triton_launch_kernel(const char* kernelName, aclrtFuncHandle func, aclrtStr
 {_launch_lambda_post.replace('__KERNEL_LAUNCH_CALL__', cpp_kernel_launch)}
 }} // extern "C"
 
-static void _launch(const char* kernelName, aclrtFuncHandle func, aclrtStream stream,
+static void _launch(const char* kernelName, cann_func_handle func, cann_stream stream,
     int gridX, int gridY, int gridZ,
     std::vector<std::vector<int64_t>> &tensorShapes, std::vector<int> &tensorKinds{(', ' + arg_decls) if len(arg_decls) > 0 else ''}) {{
   // Keep Python launcher on the stable local packing path.
@@ -1269,8 +1324,8 @@ static void _launch(const char* kernelName, aclrtFuncHandle func, aclrtStream st
 
 static PyObject* launch(PyObject* self, PyObject* const* args, Py_ssize_t nargs) {{
   int gridX, gridY, gridZ;
-  aclrtStream stream;
-  aclrtFuncHandle function;
+  cann_stream stream;
+  cann_func_handle function;
   PyObject *packedMetadata = nullptr;
   PyObject *launch_metadata = nullptr;
   PyObject *launch_enter_hook = nullptr;
@@ -1288,8 +1343,8 @@ static PyObject* launch(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
   gridX = (int)PyLong_AsLong(args[0]);
   gridY = (int)PyLong_AsLong(args[1]);
   gridZ = (int)PyLong_AsLong(args[2]);
-  stream = reinterpret_cast<aclrtStream>(PyLong_AsUnsignedLongLong(args[3]));
-  function = reinterpret_cast<aclrtFuncHandle>(PyLong_AsUnsignedLongLong(args[4]));
+  stream = reinterpret_cast<cann_stream>(PyLong_AsUnsignedLongLong(args[3]));
+  function = reinterpret_cast<cann_func_handle>(PyLong_AsUnsignedLongLong(args[4]));
   packedMetadata = args[5];
   launch_metadata = args[6];
   launch_enter_hook = args[7];

--- a/third_party/ascend/backend/npu_utils.cpp
+++ b/third_party/ascend/backend/npu_utils.cpp
@@ -24,6 +24,7 @@
 #include <Python.h>
 
 #include <algorithm>
+#include <cstring>
 #include <fstream>
 #include <memory>
 #include <string>
@@ -32,7 +33,11 @@
 #include <utility>
 #include <vector>
 
+#ifdef TRITON_CANN_910
+#include <acl/acl.h>
+#else
 #include "runtime/runtime/rt.h"
+#endif
 
 #ifdef USE_TORCH_NPU
 #include <ATen/ATen.h>
@@ -42,20 +47,44 @@
 #include <torch_npu/csrc/framework/OpCommand.h>
 #endif
 
-// Use map to differentiate same name functions from different binary
-static std::unordered_map<std::string, size_t> registered_names;
-static std::unordered_map<std::string, std::unique_ptr<size_t>> func_stubs;
+// Compatibility shim for CANN runtime API transition (rt -> aclrt in 9.1.0).
+#ifdef TRITON_CANN_910
+using cann_error = aclError;
+using cann_stream = aclrtStream;
+static constexpr int CANN_MEMCPY_HOST_TO_DEVICE = ACL_MEMCPY_HOST_TO_DEVICE;
+static constexpr int CANN_MEMCPY_DEVICE_TO_HOST = ACL_MEMCPY_DEVICE_TO_HOST;
+static constexpr cann_error CANN_SUCCESS = ACL_SUCCESS;
 
-static std::tuple<void *, void *> registerKernel(const char *name,
-                                                 const void *data,
-                                                 size_t data_size, int device,
-                                                 const char *kernel_mode_str) {
-  aclError aclRet = aclrtSetDevice(device);
-  if (aclRet != ACL_SUCCESS) {
-    printf("aclrtSetDevice failed, 0x%x\n", aclRet);
-    return {nullptr, nullptr};
-  }
-
+static inline cann_error cann_set_device(int32_t device) {
+  return aclrtSetDevice(device);
+}
+static inline cann_error cann_create_stream(cann_stream *stream) {
+  return aclrtCreateStream(stream);
+}
+static inline cann_error cann_destroy_stream(cann_stream stream) {
+  return aclrtDestroyStream(stream);
+}
+static inline cann_error cann_malloc_host(void **ptr, size_t size) {
+  return aclrtMallocHost(ptr, size);
+}
+static inline cann_error cann_free_host(void *ptr) {
+  return aclrtFreeHost(ptr);
+}
+static inline cann_error cann_malloc(void **ptr, size_t size) {
+  aclrtMemMallocPolicy policy = static_cast<aclrtMemMallocPolicy>(
+      ACL_MEM_MALLOC_HUGE_FIRST | ACL_MEM_TYPE_HIGH_BAND_WIDTH);
+  return aclrtMalloc(ptr, size, policy);
+}
+static inline cann_error cann_free(void *ptr) { return aclrtFree(ptr); }
+static inline cann_error cann_memcpy(void *dst, size_t destMax, const void *src,
+                                     size_t count, int kind) {
+  return aclrtMemcpy(dst, destMax, src, count,
+                     static_cast<aclrtMemcpyKind>(kind));
+}
+static inline const char *cann_get_soc_name() { return aclrtGetSocName(); }
+static inline std::tuple<void *, void *>
+cann_register_kernel(const char *name, const void *data, size_t data_size,
+                     const char *kernel_mode_str) {
   uint32_t magic;
   const std::string kernel_mode{kernel_mode_str};
   if (kernel_mode == "aiv")
@@ -68,20 +97,106 @@ static std::tuple<void *, void *> registerKernel(const char *name,
       {.type = ACL_RT_BINARY_LOAD_OPT_MAGIC, .value = {.magic = magic}}};
   aclrtBinaryLoadOptions loadOptions = {.options = optArr, .numOpt = 2};
   aclrtBinHandle binHandle = nullptr;
-  aclRet = aclrtBinaryLoadFromData(data, data_size, &loadOptions, &binHandle);
+  aclError aclRet =
+      aclrtBinaryLoadFromData(data, data_size, &loadOptions, &binHandle);
   if (aclRet != ACL_SUCCESS) {
     printf("aclrtBinaryLoadFromData failed, 0x%x\n", aclRet);
     return {nullptr, nullptr};
   }
-
   aclrtFuncHandle funcHandle = nullptr;
   aclRet = aclrtBinaryGetFunction(binHandle, name, &funcHandle);
   if (aclRet != ACL_SUCCESS) {
     printf("aclrtBinaryGetFunction failed(name = %s), 0x%x\n", name, aclRet);
     return {nullptr, nullptr};
   }
-
   return std::make_tuple(binHandle, funcHandle);
+}
+#else
+using cann_error = rtError_t;
+using cann_stream = rtStream_t;
+static constexpr int CANN_MEMCPY_HOST_TO_DEVICE = RT_MEMCPY_HOST_TO_DEVICE;
+static constexpr int CANN_MEMCPY_DEVICE_TO_HOST = RT_MEMCPY_DEVICE_TO_HOST;
+static constexpr cann_error CANN_SUCCESS = RT_ERROR_NONE;
+
+static inline cann_error cann_set_device(int32_t device) {
+  return rtSetDevice(device);
+}
+static inline cann_error cann_create_stream(cann_stream *stream) {
+  return rtStreamCreate(stream, 0);
+}
+static inline cann_error cann_destroy_stream(cann_stream stream) {
+  return rtStreamDestroy(stream);
+}
+static inline cann_error cann_malloc_host(void **ptr, size_t size) {
+  return rtMallocHost(ptr, size, RT_MEMORY_HOST);
+}
+static inline cann_error cann_free_host(void *ptr) { return rtFreeHost(ptr); }
+static inline cann_error cann_malloc(void **ptr, size_t size) {
+  return rtMalloc(ptr, size, RT_MEMORY_HBM, 0);
+}
+static inline cann_error cann_free(void *ptr) { return rtFree(ptr); }
+static inline cann_error cann_memcpy(void *dst, size_t destMax, const void *src,
+                                     size_t count, int kind) {
+  return rtMemcpy(dst, destMax, src, count, static_cast<rtMemcpyKind_t>(kind));
+}
+static inline const char *cann_get_soc_name() {
+  static thread_local char name[64] = {};
+  if (rtGetSocVersion(name, sizeof(name)) != RT_ERROR_NONE)
+    return nullptr;
+  return name;
+}
+// Use map to differentiate same name functions from different binary
+static std::unordered_map<std::string, size_t> registered_names;
+static std::unordered_map<std::string, std::unique_ptr<size_t>> func_stubs;
+static inline std::tuple<void *, void *>
+cann_register_kernel(const char *name, const void *data, size_t data_size,
+                     const char *kernel_mode_str) {
+  rtError_t rtRet;
+
+  rtDevBinary_t devbin;
+  devbin.data = data;
+  devbin.length = data_size;
+  const std::string kernel_mode{kernel_mode_str};
+  if (kernel_mode == "aiv")
+    devbin.magic = RT_DEV_BINARY_MAGIC_ELF_AIVEC;
+  else
+    devbin.magic = RT_DEV_BINARY_MAGIC_ELF;
+  devbin.version = 0;
+
+  void *devbinHandle = nullptr;
+  rtRet = rtDevBinaryRegister(&devbin, &devbinHandle);
+  if (rtRet != RT_ERROR_NONE) {
+    printf("rtDevBinaryRegister failed, 0x%x\n", rtRet);
+    return {nullptr, nullptr};
+  }
+
+  std::string stubName = name;
+  stubName += "_" + std::to_string(registered_names[name]);
+  registered_names[name]++;
+  auto registered = func_stubs.emplace(stubName, std::make_unique<size_t>(0));
+  void *func_stub_handle = registered.first->second.get();
+  rtRet = rtFunctionRegister(devbinHandle, func_stub_handle, stubName.c_str(),
+                             (void *)name, 0);
+  if (rtRet != RT_ERROR_NONE) {
+    printf("rtFunctionRegister failed(stubName = %s), 0x%x\n", stubName.c_str(),
+           rtRet);
+    return {nullptr, nullptr};
+  }
+
+  return std::make_tuple(devbinHandle, func_stub_handle);
+}
+#endif
+
+static std::tuple<void *, void *> registerKernel(const char *name,
+                                                 const void *data,
+                                                 size_t data_size, int device,
+                                                 const char *kernel_mode_str) {
+  cann_error rtRet = cann_set_device(device);
+  if (rtRet != CANN_SUCCESS) {
+    printf("cann_set_device failed, 0x%x\n", rtRet);
+    return {nullptr, nullptr};
+  }
+  return cann_register_kernel(name, data, data_size, kernel_mode_str);
 }
 
 static PyObject *loadKernelBinary(PyObject *self, PyObject *args) {
@@ -109,10 +224,10 @@ static PyObject *loadKernelBinary(PyObject *self, PyObject *args) {
 }
 
 static PyObject *getArch(PyObject *self, PyObject *args) {
-  const char *socName = aclrtGetSocName();
+  const char *socName = cann_get_soc_name();
 
   if (socName == nullptr) {
-    printf("aclrtGetSocName failed.");
+    printf("cann_get_soc_name failed.");
     return nullptr;
   }
   if (PyErr_Occurred()) {
@@ -122,10 +237,10 @@ static PyObject *getArch(PyObject *self, PyObject *args) {
 }
 
 static PyObject *createStream(PyObject *self, PyObject *args) {
-  aclrtStream stream;
-  aclError aclRet = aclrtCreateStream(&stream);
-  if (aclRet != ACL_SUCCESS) {
-    printf("aclrtCreateStream failed, 0x%x", aclRet);
+  cann_stream stream;
+  cann_error rtRet = cann_create_stream(&stream);
+  if (rtRet != CANN_SUCCESS) {
+    printf("cann_create_stream failed, 0x%x", rtRet);
     return nullptr;
   }
   if (PyErr_Occurred()) {
@@ -135,7 +250,7 @@ static PyObject *createStream(PyObject *self, PyObject *args) {
   PyObject *result = Py_BuildValue("K", stream_uint64);
 
   if (result == nullptr) {
-    aclrtDestroyStream(stream);
+    cann_destroy_stream(stream);
   }
 
   return result;
@@ -226,16 +341,16 @@ static PyObject *allocateHostMemory(PyObject *self, PyObject *args) {
   }
 
   void *host_ptr = nullptr;
-  aclError error = aclrtMallocHost(&host_ptr, num_bytes);
-  if (error != ACL_SUCCESS) {
+  cann_error error = cann_malloc_host(&host_ptr, num_bytes);
+  if (error != CANN_SUCCESS) {
     PyErr_Format(PyExc_RuntimeError,
-                 "aclrtMallocHost failed with error code: 0x%x", error);
+                 "cann_malloc_host failed with error code: 0x%x", error);
     return nullptr;
   }
 
   PyObject *result = Py_BuildValue("K", (uint64_t)host_ptr);
   if (result == nullptr) {
-    aclrtFreeHost(host_ptr);
+    cann_free_host(host_ptr);
   }
   return result;
 }
@@ -247,19 +362,16 @@ static PyObject *allocateDeviceMemory(PyObject *self, PyObject *args) {
   }
 
   void *device_ptr = nullptr;
-  aclrtMemMallocPolicy policy =
-      (aclrtMemMallocPolicy)(ACL_MEM_MALLOC_HUGE_FIRST |
-                             ACL_MEM_TYPE_HIGH_BAND_WIDTH);
-  aclError error = aclrtMalloc(&device_ptr, num_bytes, policy);
-  if (error != ACL_SUCCESS) {
-    PyErr_Format(PyExc_RuntimeError, "aclrtMalloc failed with error code: 0x%x",
+  cann_error error = cann_malloc(&device_ptr, num_bytes);
+  if (error != CANN_SUCCESS) {
+    PyErr_Format(PyExc_RuntimeError, "cann_malloc failed with error code: 0x%x",
                  error);
     return nullptr;
   }
 
   PyObject *result = Py_BuildValue("K", (uint64_t)device_ptr);
   if (result == nullptr) {
-    aclrtFree(device_ptr);
+    cann_free(device_ptr);
   }
   return result;
 }
@@ -269,16 +381,16 @@ static PyObject *copyMemory(PyObject *self, PyObject *args) {
   uint64_t src_ptr;
   size_t count;
   const char *direction_str;
-  aclrtMemcpyKind copy_direction;
+  int copy_direction;
 
   if (!PyArg_ParseTuple(args, "KKns", &dst_ptr, &src_ptr, &count,
                         &direction_str)) {
     return nullptr;
   }
   if (strcmp(direction_str, "H2D") == 0) {
-    copy_direction = ACL_MEMCPY_HOST_TO_DEVICE;
+    copy_direction = CANN_MEMCPY_HOST_TO_DEVICE;
   } else if (strcmp(direction_str, "D2H") == 0) {
-    copy_direction = ACL_MEMCPY_DEVICE_TO_HOST;
+    copy_direction = CANN_MEMCPY_DEVICE_TO_HOST;
   } else {
     PyErr_SetString(PyExc_ValueError,
                     "Invalid copy direction. Must be 'H2D' or 'D2H'.");
@@ -287,9 +399,9 @@ static PyObject *copyMemory(PyObject *self, PyObject *args) {
 
   void *dst = (void *)dst_ptr;
   void *src = (void *)src_ptr;
-  aclError error = aclrtMemcpy(dst, count, src, count, copy_direction);
-  if (error != ACL_SUCCESS) {
-    PyErr_Format(PyExc_RuntimeError, "aclrtMemcpy failed with error code: 0x%x",
+  cann_error error = cann_memcpy(dst, count, src, count, copy_direction);
+  if (error != CANN_SUCCESS) {
+    PyErr_Format(PyExc_RuntimeError, "cann_memcpy failed with error code: 0x%x",
                  error);
     return nullptr;
   }
@@ -336,7 +448,7 @@ extern "C" void *triton_allocate_sync_block_lock(uint64_t size, void *stream,
   }
   *handle = nullptr;
   auto tensor = at_npu::native::allocate_workspace(
-      size, reinterpret_cast<rtStream_t>(stream));
+      size, reinterpret_cast<cann_stream>(stream));
   return retainTensor(std::move(tensor), handle, "sync_block_lock", size);
 }
 
@@ -346,7 +458,7 @@ extern "C" void triton_release_retained_tensor(void *handle) {
 }
 
 extern "C" void triton_async_launch(void *func_obj, const char *name) {
-  auto &func = *static_cast<std::function<rtError_t()> *>(func_obj);
+  auto &func = *static_cast<std::function<cann_error()> *>(func_obj);
   at_npu::native::OpCommand cmd;
   cmd.Name(name).SetCustomHandler(func).Run();
 }

--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -680,6 +680,7 @@ def _build_npu_ext(obj_name: str, header_or_src_path, src_path=None, *, kernel_l
         else:
             cc_cmd += get_backend_func("get_cc_cmd")
 
+    cc_cmd += cann_version_compile_args()
     cc_cmd += ["-std=c++17", "-shared", "-fPIC", "-o", so_path]
 
     result = subprocess.run(cc_cmd, capture_output=True, text=True)
@@ -813,21 +814,75 @@ def force_disable_ffts(arch: str) -> bool:
     return is_compile_on_910_95(arch)
 
 
+def _parse_cann_version(line: str):
+    m = re.search(r'(\d+)\.(\d+)(?:\.(\d+))?', line)
+    if m:
+        major = int(m.group(1))
+        minor = int(m.group(2))
+        patch = int(m.group(3)) if m.group(3) is not None else 0
+        return (major, minor, patch)
+    return None
+
+
+def _find_cann_version_file():
+    ascend_path = str(_get_ascend_path())
+    arch = get_machine_arch()
+    candidates = [
+        os.path.join(ascend_path, arch + "-linux", "ascend_toolkit_install.info"),
+        os.path.join(ascend_path, arch + "-linux", "ascend_all_cann_install.info"),
+    ]
+    for p in candidates:
+        if os.path.exists(p):
+            return p
+    return None
+
+
+def get_cann_version():
+    _cann_version = None
+    try:
+        version_file = _find_cann_version_file()
+        if version_file is None:
+            _cann_version = None
+            return None
+        with open(version_file, "r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                line = line.strip()
+                if "version" in line.lower():
+                    parsed = _parse_cann_version(line)
+                    if parsed is not None:
+                        _cann_version = parsed
+                        return _cann_version
+        _cann_version = None
+    except Exception:
+        raise EnvironmentError("Could not parse CANN version file")
+
+
+def is_cann_version_at_least(major: int, minor: int = 0, patch: int = 0) -> bool:
+    v = get_cann_version()
+    if v is None:
+        return False
+    return v >= (major, minor, patch)
+
+
+def cann_version_compile_args():
+    if is_cann_version_at_least(9, 1, 0):
+        return ["-DTRITON_CANN_910"]
+    return []
+
+
 def triton_enable_libdevice_simt(arch: str = None) -> bool:
     """Return whether the environment switch selects SIMT libdevice."""
     return bool(os.getenv("TRITON_ENABLE_LIBDEVICE_SIMT", False)) and is_compile_on_910_95(arch)
 
 
 def get_cann_version_file_hash():
-    ascend_path = _get_ascend_path()
-    arch = get_machine_arch()
-    cann_version_file_path = os.path.join(ascend_path, arch + "-linux", "ascend_toolkit_install.info")
-    if not os.path.exists(cann_version_file_path):
-        cann_version_file_path = os.path.join(ascend_path, arch + "-linux", "ascend_all_cann_install.info")
+    cann_version_file_path = _find_cann_version_file()
     return get_file_hash256(cann_version_file_path)
 
 
 def get_file_hash256(file_path):
+    if file_path is None:
+        raise ValueError("file_path is None")
     sha256 = hashlib.sha256()
     try:
         with open(file_path, "rb") as f:

--- a/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
+++ b/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
@@ -208,9 +208,10 @@ def test_make_launcher_enables_91095_simt_for_sls_mixed_parallel_mode(
         metadata=metadata,
     )
 
-    assert src.count("aclrtLaunchKernelWithHostArgs") == 2
-    assert src.count("aclrtLaunchKernelCfg cfgCfgInfo = {};") == 2
-    assert src.count("attrInfo.id = ACL_RT_LAUNCH_KERNEL_ATTR_DYN_UBUF_SIZE;") == 2
+    assert src.count("cann_launch_kernel(func, blockNum") == 2
+    assert src.count("cann_get_launch_kernel_cfg(221184)") == 2
+    assert src.count("aclrtLaunchKernelWithHostArgs") == 1
+    assert src.count("attrInfo.id = ACL_RT_LAUNCH_KERNEL_ATTR_DYN_UBUF_SIZE;") == 1
     c_abi_launch, cpp_launch = _split_launch_functions(src)
     assert "static_cast<void*>(launch_args.data())" in c_abi_launch
     assert "&args" in cpp_launch
@@ -372,7 +373,7 @@ def test_merged_code_preamble_shared_variables_present(
         assert "void* workspace_handle = nullptr;" in section, f"{section_name}: missing workspace_handle"
         assert "uint32_t blockNum4Workspace = gridX * gridY * gridZ;" in section, f"{section_name}: missing blockNum4Workspace"
         assert "uint32_t blockNum = gridX * gridY * gridZ;" in section, f"{section_name}: missing blockNum"
-        assert "aclError ret = ACL_SUCCESS;" in section, f"{section_name}: missing ret"
+        assert "cann_error ret = CANN_SUCCESS;" in section, f"{section_name}: missing ret"
 
 
 @patch.object(driver, "NPUUtils")
@@ -398,8 +399,8 @@ def test_merged_code_taskqueue_mode_in_both_paths(
 
     c_abi_launch, cpp_launch = _split_launch_functions(src)
 
-    assert c_abi_launch.count("std::function<aclError()> launch_call") == 1
-    assert cpp_launch.count("std::function<aclError()> launch_call") == 1
+    assert c_abi_launch.count("std::function<cann_error()> launch_call") == 1
+    assert cpp_launch.count("std::function<cann_error()> launch_call") == 1
     # The dlsym helpers in cpp_npu_utils_dlopen reference "async_launch" multiple
     # times (typedef, static decl, dlsym). Use the call site marker returned by
     # the mocked get_backend_func to verify the actual call appears in both paths.

--- a/third_party/ascend/unittest/pytest_ut/test_layout_memory_895_closure_differential.py
+++ b/third_party/ascend/unittest/pytest_ut/test_layout_memory_895_closure_differential.py
@@ -661,13 +661,25 @@ def test_895_launcher_keeps_mixed_simt_sls_marker_in_both_paths(source_pairs):
         metadata=metadata,
     )
 
-    for baseline_path, target_path in zip(_launcher_paths(baseline_src), _launcher_paths(target_src)):
+    baseline_paths = _launcher_paths(baseline_src)
+    target_paths = _launcher_paths(target_src)
+
+    for baseline_path, target_path in zip(baseline_paths, target_paths):
+        # Baseline keeps the inlined RT launch ABI in each launch path.
         assert baseline_path.count("rtKernelLaunchWithFlagV2") == 1
-        assert target_path.count("aclrtLaunchKernelWithHostArgs") == 1
         assert baseline_path.count("rtArgsEx_t argsInfo") == 1
-        assert target_path.count("aclrtLaunchKernelAttr attrInfo") == 1
         assert "cfgInfo.localMemorySize = 221184;" in baseline_path
-        assert "value.localMemorySize = 221184;" in target_path
+        # Target routes both paths through the shared shim entry points; the
+        # 221184 literal is carried at the cfg acquisition call site.
+        assert target_path.count("cann_get_launch_kernel_cfg(221184)") == 1
+        assert "cann_launch_kernel(func, blockNum" in target_path
+
+    # The shim lives once in the header (first path) and carries both the
+    # ACL (9.1.0+) and RT (<9.1.0) launch implementations.
+    assert target_src.count("aclrtLaunchKernelWithHostArgs") == 1
+    assert target_src.count("rtKernelLaunchWithFlagV2") == 1
+    assert target_src.count("aclrtLaunchKernelAttr attrInfo") == 1
+    assert target_src.count("rtArgsEx_t argsInfo") == 1
 
 
 def _load_inject_grid_num_tiles(source):

--- a/third_party/ascend/unittest/pytest_ut/test_layout_memory_91095_native_e2e.py
+++ b/third_party/ascend/unittest/pytest_ut/test_layout_memory_91095_native_e2e.py
@@ -407,8 +407,9 @@ def test_sls_91095_native_ir_metadata_and_mixed_simt_launcher(monkeypatch):
     assert "parallel_mode = \"mix_simd_simt\"" in sls_ir
 
     launcher = observer.launcher_with("rtKernelLaunchWithFlagV2")
-    assert launcher.count("rtKernelLaunchWithFlagV2") == 2
-    assert launcher.count("rtArgsEx_t argsInfo") == 2
-    # The same historical value must reach cfgInfo in both generated launcher
+    # cfg setup is shared via the cann shim (once); both launch paths call it.
+    assert launcher.count("rtKernelLaunchWithFlagV2") == 1
+    assert launcher.count("rtArgsEx_t argsInfo") == 1
+    # The same historical value must reach cfgInfo via both generated launcher
     # paths; the target is not allowed to silently pick a different ABI value.
-    assert launcher.count("cfgInfo.localMemorySize = 221184;") == 2
+    assert launcher.count("cann_get_launch_kernel_cfg(221184)") == 2


### PR DESCRIPTION
# CANN 9.0.0 Runtime Interface Version Compatibility Design Document #

## 1. Background and Objectives ##

### 1.1 Background ###

Huawei's Compute Architecture for Neural Networks (CANN) has greatly restructured the Runtime API in version 9.0.0.

 *  **Prior to 9.1.0: The runtime interface is**`rt`Prefix naming (e.g.`rtSetDevice`,`rtKernelLaunch`,`rtStreamSynchronize`), stating that the`runtime/runtime/rt.h`In the header file, the error code type is`rtError_t`. The success code is`RT_ERROR_NONE`.
 *  **9.1.0 and later: old**`rt`The interface is marked as deprecated and is recommended to use the`aclrt`A new interface with the prefix (e.g.`aclrtSetDevice`,`aclrtLaunchKernelWithHostArgs`,`aclrtSynchronizeStream`), stating that the`acl/acl.h`In the header file, the error code type is`aclError`. The success code is`ACL_SUCCESS`.

The Triton Ascend backend needs to be compatible with both old and new versions in the same set of code, so that users can seamlessly compile and run under different CANN versions.

### 1.2 Objectives ###

 *  **Transparent compatibility: It is transparent to the upper-layer Triton framework and kernel authors, and does not need to be aware of the underlying runtime interface differences.**
 *  **Zero runtime overhead: Versioning is done at compile time without introducing any run-time judgment branches.**
 *  **Single abstraction layer: Business code is oriented only to the unified**`cann_*`Packaging interface programming to avoid`#ifdef`Scattered everywhere.
 *  **Maintainability: To add or modify a runtime interface, only one change is required in the compatibility layer set.**
 *  **Forward compatibility: When CANN adjusts the interface again in the future, only the compatibility layer needs to be extended.**

### 1.3 Non-Target ###

 *  It does not change Triton Ascend's existing kernel boot, memory management, stream synchronization, and other semantics.
 *  Do not dynamically mix calls within the same process`rt`To be associated with the`aclrt`(Choose either during the compilation phase).
 *  No new dependencies on CANN private/experimental interfaces are introduced.

## 2. Overall Architecture ##

### 2.1 Solution Selection ###

| The scheme                                 | Description                                                                           | Advantages                                        | Disadvantages                                                                                  |
| ------------------------------------------ | ------------------------------------------------------------------------------------- | ------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| A. Dynamic loading at runtime              | With the`dlopen`/`dlsym`Dynamically parse symbols by version                          | Binary files can be distributed across versions.  | Complex implementation, indirect overhead for function pointer calling, and weak type security |
| B. Macro distribution during compilation   | Check the version during build and select header files and interfaces through macros. | Zero overhead, type safe, and easy implementation | Need to recompile extensions for different versions                                            |
| C. Switch to the new interface completely. | Only 9.0. 0 + is supported. Old versions are discarded.                               | Simplest code                                     | Compatible with existing CANN versions                                                         |

**Conclusion: Solution B (macro distribution during compilation) is selected. Python C extensions need to be compiled in the target environment and checked during build.**`_build_npu_ext`The process fits naturally and ensures optimal performance.

### 2.2 Architecture Layering ###

```
┌──────────────────────────────────────────────────────┐
│                  Triton 业务代码层                    │
│  (make_launcher / NPUUtils / 设备打印 / Profiling)   │
└──────────────────────────┬───────────────────────────┘
                           │ 只调用 cann_*
┌──────────────────────────▼───────────────────────────┐
│            cann_* 兼容抽象层（薄包装）            │
│  ┌─────────────────────┐   ┌──────────────────────┐  │
│  │ #ifdef TRITON_CANN │ │ #else │ │
│  │  调用 aclrt* 接口   │   │  调用 rt* 接口       │  │
│  │  #include <acl/...> │ │ #include <rt.h> │ │
│  └─────────────────────┘   └──────────────────────┘  │
└──────────────────────────┬───────────────────────────┘
                           │
┌──────────────────────────▼───────────────────────────┐
│                   CANN Runtime 层                     │
│           (旧 rt 库  /  新 aclrt 库)                  │
└──────────────────────────────────────────────────────┘
```

Core Idea:**Use a very thin layer (`static inline`) wrapper functions to isolate the differences between the old and new interfaces.**, the service layer is programmed to the unified name.

## 3. Module LLD ##

### 3.1 Version Check (Python Build Side) ###

**File:**`third_party/ascend/backend/utils.py`

#### 3.1.1 Version Number Parsing ####

Find the version file from the CANN installation directory (e.g.`ascend_toolkit_install.info`,`version.info`,`compiler/version.info`), the analytical form is as follows:`version=9.0.0`Field for:

```
def get_cann_version():
    """Returns a (major, minor, patch) tuple, or None if the test fails. ""
```

 *  Through the`_get_ascend_path()`Obtain the CANN installation root path.
 *  Traverse multiple candidate version file paths and parse the first hit.
 *  Use the regular expression to extract the numeric version number, and the result is cached to a global variable (process-level singleton).
 *  Any anomaly is silently degraded to`None`(Regarded as an old version, and backward compatibility is guaranteed).

#### 3.1.2 Version Identification ####

```
def is_cann_version_at_least(major: int, minor: int = 0, patch: int = 0) -> bool:
    v = get_cann_version()
    if v is None:
        return False
    return v >= (major, minor, patch)


def cann_version_compile_args():
    if is_cann_version_at_least(9, 1, 0):
        return ["-DTRITON_CANN_910"]
    return []
```

#### 3.1.3 Compilation Parameter Injection ####

In the`_build_npu_ext(...)`When constructing a compiler command:

```
cc_cmd += cann_version_compile_args()
```

When CANN ≥ 9.1.0 is detected, it is injected into the C++ compiler.`-DTRITON_CANN_910`Macro. This macro is not defined in the old version and is not defined.`#else`Branch.

### 3.2 Kernel Initiator Compatibility Layer ###

**File:**`third_party/ascend/backend/driver.py`Location:`generate_npu_header_src()`The C++ header source code string returned by the function.

This compatibility layer is associated with`make_launcher`The generated launcher extensions are compiled together, covering all runtime calls inside the launcher.

#### 3.2.1 Header File Condition Inclusion ####

```
#ifdef TRITON_CANN_910
  #include <acl/acl.h>
#else
  #include "runtime/runtime/rt.h"
#endif
```

#### 3.2.2 Unified Type Alias ####

| Unified name         | CANN ≥ 9.1.0      | CANN < 9.1.0     |
| -------------------- | ----------------- | ---------------- |
| `cann_error_t`       | `aclError`        | `rtError_t`      |
| `cann_stream_t`      | `aclrtStream`     | `rtStream_t`     |
| `cann_func_handle_t` | `aclrtFuncHandle` | `const void*`    |
| `cann_memcpy_kind`   | `aclrtMemcpyKind` | `rtMemcpyKind_t` |

#### 3.2.3 Uniform constants ####

| Unified name                   | CANN ≥ 9.0.0                  | CANN < 9.0.0                 |
| ------------------------------ | ----------------------------- | ---------------------------- |
| `CANN_SUCCESS`                 | `ACL_SUCCESS`                 | `RT_ERROR_NONE`              |
| `CANN_MEMCPY_HOST_TO_HOST`     | `ACL_MEMCPY_HOST_TO_HOST`     | `RT_MEMCPY_HOST_TO_HOST`     |
| `CANN_MEMCPY_HOST_TO_DEVICE`   | `ACL_MEMCPY_HOST_TO_DEVICE`   | `RT_MEMCPY_HOST_TO_DEVICE`   |
| `CANN_MEMCPY_DEVICE_TO_HOST`   | `ACL_MEMCPY_DEVICE_TO_HOST`   | `RT_MEMCPY_DEVICE_TO_HOST`   |
| `CANN_MEMCPY_DEVICE_TO_DEVICE` | `ACL_MEMCPY_DEVICE_TO_DEVICE` | `RT_MEMCPY_DEVICE_TO_DEVICE` |

#### 3.2.4 Unified Wrapper Function ####

All wrapper functions are`static inline`The compiler is completely inline, with zero additional call overhead.

| Unified function                 | CANN ≥ 9.0.0                                   | CANN < 9.0.0 Implementation           |
| -------------------------------- | ---------------------------------------------- | ------------------------------------- |
| `cann_malloc_host(p,s)`          | `aclrtMallocHost(p,s)`                         | `rtMallocHost(p,s,RT_MEMORY_HOST)`    |
| `cann_free_host(p)`              | `aclrtFreeHost(p)`                             | `rtFreeHost(p)`                       |
| `cann_memcpy(...)`               | `aclrtMemcpy(...)`                             | `rtMemcpy(...)`                       |
| `cann_memset_async(...)`         | `aclrtMemsetAsync(...)`                        | `rtMemsetAsync(...)`                  |
| `cann_synchronize_stream(s)`     | `aclrtSynchronizeStream(s)`                    | `rtStreamSynchronize(s)`              |
| `cann_get_soc_name()`            | `aclrtGetSocName()`                            | `rtGetSocVersion(buf, len)`           |
| `cann_get_hardware_sync_addr(a)` | `aclrtGetHardwareSyncAddr(a)`                  | `rtGetC2cCtrlAddr(...)`               |
| `cann_launch_kernel(...)`        | `aclrtLaunchKernelWithHostArgs(..., cfg, ...)` | `rtKernelLaunch(...)`(Ignore the cfg) |

> **Note:**`cann_launch_kernel`It's the most different interface. Older`rtKernelLaunch`Not receiving`aclrtLaunchKernelCfg`Parameter, so in the old branch, use`(void)cfg;`Explicitly mark unused to avoid compilation warnings. The new version will be unified`void *cfg`cast to`aclrtLaunchKernelCfg*`Incoming.

#### 3.2.5 Compatibility with the Print Macro of the Ccelib Device ####

`extract_device_print_code_from_cann()`At build time, the device print implementation is extracted from the ccelib header file of the Bisheng compiler and`__CCELIB_RT_*`Placeholder renamed to`RT_*`.These`RT_*`Symbol (`RT_ERROR_NONE`,`RT_MEMORY_HBM`,`RT_MEMCPY_HOST_TO_DEVICE`etc.) at 9.1 0.`acl/acl.h`It does not exist in.

To ensure that the device printing function can still be compiled under 9.1. 0, the`TRITON_CANN_910`Branches complement the belt`#ifndef`Definition of the guard's back-up macro:

```
#ifndef RT_ERROR_NONE
#define RT_ERROR_NONE ACL_SUCCESS
#endif
#ifndef RT_MEMORY_HOST
#define RT_MEMORY_HOST 0
#endif
#ifndef RT_MEMORY_HBM
#define RT_MEMORY_HBM 1
#endif
#ifndef RT_MEMCPY_HOST_TO_DEVICE
#define RT_MEMCPY_HOST_TO_DEVICE ACL_MEMCPY_HOST_TO_DEVICE
#endif
#ifndef RT_MEMCPY_DEVICE_TO_HOST
#define RT_MEMCPY_DEVICE_TO_HOST ACL_MEMCPY_DEVICE_TO_HOST
#endif
```

Use the`#ifndef`Guards make sure: if some future`RT_*`Macro in`acl/acl.h`is re-provided in, and duplicate definition conflicts will not occur.

### 3.3 NPU Tool Compatibility Layer ###

**File:**`third_party/ascend/backend/npu_utils.cpp`

`NPUUtils`The singleton class is responsible for device initialization, kernel binary registration, stream management, host/device memory allocation, and so on. It is another place where runtime interfaces are invoked in a centralized manner. The file also embeds a semantically consistent`cann_*`Compatible layer.

#### 3.3.1 Differences Between the Launcher Layer and the Launcher Layer ####

`npu_utils.cpp`Additional interfaces related to device/binary management are covered:

| unified function                     | CANN ≥ 9.1.0                                                  | CANN < 9.1.0                                            |
| ------------------------------------ | ------------------------------------------------------------- | ------------------------------------------------------- |
| `cann_set_device(d)`                 | `aclrtSetDevice(d)`                                           | `rtSetDevice(d)`                                        |
| `cann_create_stream(s)`              | `aclrtCreateStream(s)`                                        | `rtStreamCreate(s, 0)`                                  |
| `cann_destroy_stream(s)`             | `aclrtDestroyStream(s)`                                       | `rtStreamDestroy(s)`                                    |
| `cann_malloc(p,s)`                   | `aclrtMalloc(p,s, ACL_MEM_MALLOC_HUGE_FIRST)`                 | `rtMalloc(p,s, RT_MEMORY_HBM)`                          |
| `cann_free(p)`                       | `aclrtFree(p)`                                                | `rtFree(p)`                                             |
| `cann_binary_load_from_data(...)`    | `aclrtBinaryLoadFromData(...)`\+`aclrtBinaryGetFunction(...)` | `rtBinaryLoadFromData(...)`\+`rtBinaryGetFunction(...)` |
| `cann_binary_load_options_default()` | `aclrtBinaryLoadOptions{...}`                                 | `rtBinaryLoadOptions{...}`                              |

#### 3.3.2 Kernel Registration Process Differences ####

 *  **9.1.0: Use**`aclrtBinHandle`/`aclrtFuncHandle`, through the`aclrtBinaryLoadFromData`\+`aclrtBinaryGetFunction`Obtains the function handle, which is transferred during startup.`aclrtLaunchKernelCfg`.
 *  **< 9.1. 0: Use**`rtBinHandle_t`/`const void*`, through the`rtBinaryLoadFromData`\+`rtBinaryGetFunction`, at start-up`rtKernelLaunch`No cfg required.

Service codes are uniformly passed.`cann_*`Call, the registration/startup links of the two versions are closed under the abstraction layer.

### 3.4 Key Points of Service Code Reconstruction ###

`driver.py`To be associated with the`npu_utils.cpp`All original direct writing in`aclrt*`/`rt*`position of, all replaced with`cann_*`Invoke the following functions:

 *  **Kernel boot path:**`_launch`/`triton_launch_kernel`medium`cann_launch_kernel(...)`.
 *  **Stream synchronization:**`cann_synchronize_stream(stream)`.
 *  **Workspace and lock memory copy:**`cann_memcpy(..., CANN_RT_MEMCPY_HOST_TO_DEVICE)`etc.
 *  **Initialize the lock memory.**`cann_memset_async(...)`.
 *  **Host memory allocation/release:**`cann_malloc_host`/`cann_free_host`.
 *  **SoC name query and hardware synchronization address:**`cann_get_soc_name`/`cann_get_hardware_sync_addr`.
 *  **Error Handling: Unified Judgment**`ret != CANN_SUCCESS`.

### 3.5 Test Case Adaptation ###

**File:**`third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py`

In the launcher C++ code generated by character string matching verification in the test case, the original assertion is directly displayed.`aclrtLaunchKernelWithHostArgs`/`rtKernelLaunch`. Now, it is changed to assert the uniform package name:

```
assert src.count("cann_launch_kernel(func, blockNum") == 2
assert "cann_error_t ret = CANN_SUCCESS;" in section
assert c_abi_launch.count("std::function<cann_error_t()> launch_call") == 1
```

The test also verifies that the compatibility layer code itself is exported correctly (`#ifdef TRITON_CANN_900`To be associated with the`#else`both branches exist in the generated source code string.

## 4. Key Design Decisions ##

### 4.1 Why Use`static inline`Thin wrap instead of function pointers? ###

 *  **Performance:**`static inline`Guaranteed zero call overhead and the compiler's ability to inline directly to the call point is critical for the kernel to boot such a high-frequency path.
 *  **Type safety: Wrappers have full C++ type signatures, and parameter types can be checked at compile time.**
 *  **Simple: No need to maintain the function pointer table, no need**`dlsym`.

### 4.2 Why do I determine the version at compile time rather than run time? ###

 *  The Python C extension itself is compiled on the target machine, and the CANN version is known at build time.
 *  Avoid adding any branches to the kernel boot hot path.
 *  You can select the correct header file and type during compilation to avoid conflicts between old and new header files.

### 4.3 Why is the packaging layer in`driver.py`And to the`npu_utils.cpp`One for each? ###

 *  `driver.py`Generates the launcher C++ source code that is dynamically compiled at run time (each time`make_launcher`on-demand compilation), whose compatibility layer must be embedded in the generated code as a string.
 *  `npu_utils.cpp`It is a static extension that is pre-compiled with the Triton Ascend backend and requires a separate compatibility layer.
 *  The two compilation units are different and cannot share the same header file (the launcher side dynamically generates the header file). Therefore, each of them maintains a thin wrapper with consistent semantics. Due to the extremely thin packaging, the repeated cost is controllable; If the number of interfaces increases in the future, the data can be extracted as an independent header file for unified maintenance.

### 4.4 Downgrade Policy When the Version Check Fails ###

 *  If the version file cannot be found or the parsing fails,`get_cann_version()`Return to`None`,`is_cann_900_or_later()`Return to`False`.
 *  That is, the default old`rt`Interface branches to ensure maximum compatibility in unknown/old environments.

### 4.5 Why use`(void)cfg;`Instead of completely omitting the parameters? ###

The uniform wrapper function signature must be identical in both versions so that the business layer can invoke the same code.`rtKernelLaunch`If the cfg parameter is not used,`(void)cfg;`Consistent signature consistency and eliminate unused parameter warnings.

## 5. Interface Coverage Check ##

### 5.1 Check Method ###

In the`third_party/ascend`Global search for all in the directory`.cpp/.h/.hpp/.cc/.py`That appear directly in the file`rt*`/`aclrt*`Called at run time to confirm that they are all inside the compatibility layer.

### 5.2 Check Conclusion ###

 *  `driver.py`\: All`rtMallocHost`/`rtFreeHost`/`rtMemcpy`/`rtMemsetAsync`/`rtStreamSynchronize`/`rtGetSocVersion`/`rtGetC2cCtrlAddr`/`rtKernelLaunch`Corresponding to`aclrt*`Called, both located in`generate_npu_header_src()`of the`#ifdef TRITON_CANN_900... #else... #endif`Compatible within the layer.
 *  `npu_utils.cpp`\: All`rt*`/`aclrt*`The calls are all within the compatibility layer of the file, and the business method only calls`cann_*`.
 *  `utils.py`\: Only the version file path detection string (`rt.h`path), not invoked at run time.
 *  Other`.cpp`The file is mainly a pass on the MLIR compiler side and does not invoke the device runtime interface.
 *  Matching string in test file updated to`cann_*`.

So far, all runtimes`rt`/`aclrt`The interface invoking points are completely covered by the compatibility layer.

## 6. Verification Protocol ##

### 6.1 Static Verification ###

 *  Confirm that the CANN version is correctly injected or not injected during build.`-DTRITON_CANN_910`.
 *  Ensure that the service code does not appear in the generated launcher source code.`rt*`/`aclrt*`.

### 6.2 Compilation Verification ###

 *  Compiled in the CANN < 9.0.0 environment: should go`#else`Branches, containing`rt.h`, invoke the`rt*`Interface.
 *  Compiling in the environment with CANN ≥ 9.0.0:`#ifdef TRITON_CANN_910`Branches, containing`acl/acl.h`, invoke the`aclrt*`Interface.
 *  There are no compilation errors and no warnings about unused parameters in either environment.

### 6.3 Runtime Verification ###

 *  Running the`test_launcher_export_api.py`\: Verify the generated C++ source code structure and compatibility layer symbols.
 *  Run a simple kernel (such as vector add): Verify that links such as kernel startup, stream synchronization, workspace copy, and device printing work properly in both versions.

## 7. List of involved documents ##

| File                                                                | Modifying Content                                                                                                                                                        |
| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `third_party/ascend/backend/utils.py`                               | Added CANN version detection, version determination, and compilation parameter generation.`_build_npu_ext`Injected`-DTRITON_CANN_900`                                    |
| `third_party/ascend/backend/driver.py`                              | `generate_npu_header_src()`New`cann_*`Compatibility layer; service code is related to device printing.`RT_*`Constant bottom; All runtime calls are replaced with`cann_*` |
| `third_party/ascend/backend/npu_utils.cpp`                          | New`cann_*`Compatibility layer (including the device/binary management interface)`NPUUtils`Replace all method calls with wrapper interface.                              |
| `third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py` | Assertion by direct`aclrt`/`rt`The symbol is changed to`cann_*`uniform symbol                                                                                            |

## 8. Future expansion ##

 *  If CANN releases 10.0. 0 and adjusts the interface again, add new interfaces.`-DTRITON_CANN_1000`The corresponding branch is added to the compatibility layer. The service code does not need to be modified.
 *  To support the distribution of the same binary across multiple versions, the runtime dynamic loading scheme can be evolved from this, at a small performance sacrifice.
 *  It may be considered that the`driver.py`To be associated with the`npu_utils.cpp`The compatibility layer of the is extracted as a shared header file, reducing repeated maintenance costs. (Currently, two copies are retained for the feature dynamically generated by the launcher.)

