### PR TITLE
[TritonToLinalg](fix) support make_block_ptr base from tt.int_to_ptr

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
@@ -1256,6 +1256,90 @@ void BlockDataParser::parseSelect(
   }
 }
 
+// Convert tt.int_to_ptr into hivm.pointer_cast and set data.source.
+// Returns true if data.source was updated.
+//
+// Example 1 (int_to_ptr):
+//   %addr = ... : i64
+//   %p = tt.int_to_ptr %addr : i64 -> !tt.ptr<f32>
+//   %blk = tt.make_tensor_ptr %p, [%n], [%c1_i64], [%off]
+//       {order = array<i32: 0>} : <tensor<256xf32>>
+//
+// will be converted to:
+//   %m = hivm.pointer_cast %addr : memref<?xf32>
+//   %full = memref.reinterpret_cast %m to offset: [%c0], sizes: [%n],
+//       strides: [%c1] : memref<?xf32> to memref<?xf32, strided<[?], offset: ?>>
+//   %view = memref.reinterpret_cast %full to offset: [%off], sizes: [256],
+//       strides: [%c1] : ... to memref<256xf32, strided<[?], offset: ?>>
+//   (replace %blk with %view)
+//
+// Example 2 (int_to_ptr + bitcast, possibly multi-layer):
+//   %addr = ... : i64
+//   %p0 = tt.int_to_ptr %addr : i64 -> !tt.ptr<i32>
+//   %p1 = tt.bitcast %p0 : !tt.ptr<i32> -> !tt.ptr<f32>
+//   %blk = tt.make_tensor_ptr %p1, [%n], [%c1_i64], [%off]
+//       {order = array<i32: 0>} : <tensor<256xf32>>
+//
+// will be converted to:
+//   %m = hivm.pointer_cast %addr : memref<?xf32>
+//   %full / %view = memref.reinterpret_cast ... (same pattern as example 1)
+//
+// Example 3 (bitcast only, no int_to_ptr — this helper returns false):
+//   %arg0: !tt.ptr<i32>         // after type convert: memref<?xi32>
+//   %p1 = tt.bitcast %arg0 : !tt.ptr<i32> -> !tt.ptr<f32>
+//   %blk = tt.make_tensor_ptr %p1, [%n], [%c1_i64], [%off]
+//       {order = array<i32: 0>} : <tensor<256xf32>>
+//
+// will be converted to (in rewriteMakeTensorPtrOp, not here):
+//   %m_f32 = builtin.unrealized_conversion_cast %arg0_memref
+//       : memref<?xi32> to memref<?xf32>
+//   %full / %view = memref.reinterpret_cast ...
+static bool materializeIntToPtrAsMemref(Value tritonPtr, BlockData &data,
+                                        ConversionPatternRewriter &rewriter) {
+  Value cur = tritonPtr;
+  while (auto bitcastOp = cur.getDefiningOp<triton::BitcastOp>())
+    cur = bitcastOp.getSrc();
+
+  auto intToPtrOp = cur.getDefiningOp<triton::IntToPtrOp>();
+  // Fallback: parse() may have put a remapped value into data.source, e.g.
+  //   %p = tt.int_to_ptr %addr : i64 -> !tt.ptr<f32>
+  //   %tmp = builtin.unrealized_conversion_cast %p : !tt.ptr<f32> to memref<?xf32>
+  //   data.source = %tmp
+  // or with bitcast:
+  //   %p0 = tt.int_to_ptr %addr : i64 -> !tt.ptr<i32>
+  //   %p1 = tt.bitcast %p0 : !tt.ptr<i32> -> !tt.ptr<f32>
+  //   %tmp = builtin.unrealized_conversion_cast %p1 : !tt.ptr<f32> to memref<?xf32>
+  //   data.source = %tmp
+  // Peel unrealized_conversion_cast (then bitcast) to recover the underlying int_to_ptr.
+  if (!intToPtrOp && data.hasSource()) {
+    Value src = data.getSourceRef();
+    while (auto uc = src.getDefiningOp<UnrealizedConversionCastOp>()) {
+      if (uc.getInputs().size() != 1)
+        break;
+      src = uc.getInputs()[0];
+    }
+    while (auto bitcastOp = src.getDefiningOp<triton::BitcastOp>())
+      src = bitcastOp.getSrc();
+    intToPtrOp = src.getDefiningOp<triton::IntToPtrOp>();
+  }
+  if (!intToPtrOp)
+    return false;
+
+  // Prefer bitcast's final pointee (data.resElemTy from parseBitcast) so the
+  // resulting PointerCast feeds ReinterpretCast directly.
+  Type elemTy;
+  if (data.hasResElemTy())
+    elemTy = data.getResElemTyRef();
+  else
+    elemTy = cast<triton::PointerType>(intToPtrOp.getResult().getType())
+                 .getPointeeType();
+  auto memrefType = MemRefType::get({ShapedType::kDynamic}, elemTy);
+  auto hivmPointCastOp = rewriter.create<hivm::PointerCastOp>(
+      intToPtrOp.getLoc(), memrefType, ValueRange{intToPtrOp.getSrc()});
+  data.setSource(hivmPointCastOp.getResult());
+  return true;
+}
+
 void BlockDataParser::rewriteAddPtr(
     triton::AddPtrOp op, triton::AddPtrOp::Adaptor &adaptor,
     ConversionPatternRewriter &rewriter,
@@ -1326,18 +1410,11 @@ void BlockDataParser::rewriteAddPtr(
     }
   }
 
-  if (auto intToPtrOp =
-          dyn_cast<triton::IntToPtrOp>(data.getSourceRef().getDefiningOp())) {
-    auto rtype = cast<triton::PointerType>(intToPtrOp.getResult().getType());
-    auto memrefType =
-        MemRefType::get({ShapedType::kDynamic}, rtype.getPointeeType());
-    auto hivmPointCastOp = rewriter.create<hivm::PointerCastOp>(
-        intToPtrOp.getLoc(), memrefType, ValueRange{intToPtrOp.getSrc()});
-    data.setSource(hivmPointCastOp.getResult());
-  }
+  bool fromIntToPtr =
+      materializeIntToPtrAsMemref(op.getPtr(), data, rewriter);
 
-  if (data.hasResElemTy()) {
-    // Handle bitcast scenario
+  // Arg ptr + bitcast only: int_to_ptr(+bitcast) already has final elem type.
+  if (!fromIntToPtr && data.hasResElemTy()) {
     auto memrefType = dyn_cast<BaseMemRefType>(data.getSourceRef().getType())
                           .cloneWith(std::nullopt, data.getResElemTyRef());
     UnrealizedConversionCastOp castOp =
@@ -1432,17 +1509,17 @@ void BlockDataParser::rewriteMakeTensorPtrOp(
 
   auto orderSize = op.getOrder().size();
 
-  // Handle base is defined by tt.bitcast
+  // Handle base is defined by tt.bitcast / tt.int_to_ptr
   BlockDataParser::parse(op.getBase(), data, loc, rewriter, known);
-  if (data.hasResElemTy()) {
+  bool fromIntToPtr =
+      materializeIntToPtrAsMemref(op.getBase(), data, rewriter);
+  if (!fromIntToPtr && data.hasResElemTy()) {
     auto memrefType = dyn_cast<BaseMemRefType>(data.getSourceRef().getType())
                           .cloneWith(std::nullopt, data.getResElemTyRef());
     UnrealizedConversionCastOp castOp =
         rewriter.create<mlir::UnrealizedConversionCastOp>(loc, memrefType,
                                                           data.getSourceRef());
     data.setSource(castOp.getOutputs()[0]);
-  } else {
-    data.setSource(rewriter.getRemappedValue(op.getBase()));
   }
 
   data.getOffsetsRef() =

--- a/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
@@ -1330,6 +1330,8 @@ static bool materializeIntToPtrAsMemref(Value tritonPtr, BlockData &data,
   Type elemTy;
   if (data.hasResElemTy())
     elemTy = data.getResElemTyRef();
+  else if (auto ptrTy = dyn_cast<triton::PointerType>(tritonPtr.getType()))
+    elemTy = ptrTy.getPointeeType();
   else
     elemTy = cast<triton::PointerType>(intToPtrOp.getResult().getType())
                  .getPointeeType();

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_addptr.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_addptr.mlir
@@ -1,0 +1,135 @@
+// RUN: triton-opt --triton-to-linalg --split-input-file %s | FileCheck %s
+//
+// tt.addptr base variants (rewriteAddPtr + materializeIntToPtrAsMemref):
+//   1) int_to_ptr
+//   2) int_to_ptr + bitcast
+//   3) int_to_ptr + 2*bitcast
+//   4) bitcast(arg)
+//   5) 2*bitcast(arg)
+//
+// Note: tt.bitcast requires equal bitwidth (i32 <-> f32).
+
+// CHECK-LABEL: func.func @addptr_int_to_ptr
+// CHECK: %[[PC:.*]] = hivm.hir.pointer_cast
+// CHECK: memref.reinterpret_cast %[[PC]]
+// CHECK: memref.copy
+// CHECK: return
+module {
+  tt.func public @addptr_int_to_ptr(
+      %arg0: i64 {tt.divisibility = 16 : i32},
+      %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}
+  ) attributes {noinline = false} {
+    %0 = tt.int_to_ptr %arg0 : i64 -> !tt.ptr<f32>
+    %1 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %2 = tt.splat %0 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+    %3 = tt.addptr %2, %1 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+    %4 = tt.load %3 : tensor<256x!tt.ptr<f32>>
+    %5 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+    %6 = tt.addptr %5, %1 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+    tt.store %6, %4 : tensor<256x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @addptr_int_to_ptr_bitcast
+// CHECK: %[[PC:.*]] = hivm.hir.pointer_cast
+// CHECK-SAME: memref<?xf32>
+// CHECK: memref.reinterpret_cast %[[PC]]
+// CHECK: memref.copy
+// CHECK: return
+module {
+  tt.func public @addptr_int_to_ptr_bitcast(
+      %arg0: i64 {tt.divisibility = 16 : i32},
+      %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}
+  ) attributes {noinline = false} {
+    %0 = tt.int_to_ptr %arg0 : i64 -> !tt.ptr<i32>
+    %1 = tt.bitcast %0 : !tt.ptr<i32> -> !tt.ptr<f32>
+    %2 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %3 = tt.splat %1 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+    %4 = tt.addptr %3, %2 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+    %5 = tt.load %4 : tensor<256x!tt.ptr<f32>>
+    %6 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+    %7 = tt.addptr %6, %2 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+    tt.store %7, %5 : tensor<256x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @addptr_int_to_ptr_bitcast2
+// CHECK: %[[PC:.*]] = hivm.hir.pointer_cast
+// CHECK-SAME: memref<?xf32>
+// CHECK: memref.reinterpret_cast %[[PC]]
+// CHECK: memref.copy
+// CHECK: return
+module {
+  tt.func public @addptr_int_to_ptr_bitcast2(
+      %arg0: i64 {tt.divisibility = 16 : i32},
+      %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}
+  ) attributes {noinline = false} {
+    %0 = tt.int_to_ptr %arg0 : i64 -> !tt.ptr<f32>
+    %1 = tt.bitcast %0 : !tt.ptr<f32> -> !tt.ptr<i32>
+    %2 = tt.bitcast %1 : !tt.ptr<i32> -> !tt.ptr<f32>
+    %3 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %4 = tt.splat %2 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+    %5 = tt.addptr %4, %3 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+    %6 = tt.load %5 : tensor<256x!tt.ptr<f32>>
+    %7 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+    %8 = tt.addptr %7, %3 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+    tt.store %8, %6 : tensor<256x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @addptr_bitcast
+// CHECK-NOT: hivm.hir.pointer_cast
+// CHECK: unrealized_conversion_cast
+// CHECK: memref.reinterpret_cast
+// CHECK: memref.copy
+// CHECK: return
+module {
+  tt.func public @addptr_bitcast(
+      %arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+      %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}
+  ) attributes {noinline = false} {
+    %0 = tt.bitcast %arg0 : !tt.ptr<i32> -> !tt.ptr<f32>
+    %1 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %2 = tt.splat %0 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+    %3 = tt.addptr %2, %1 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+    %4 = tt.load %3 : tensor<256x!tt.ptr<f32>>
+    %5 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+    %6 = tt.addptr %5, %1 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+    tt.store %6, %4 : tensor<256x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @addptr_bitcast2
+// CHECK-NOT: hivm.hir.pointer_cast
+// CHECK: memref.reinterpret_cast
+// CHECK: memref.copy
+// CHECK: return
+module {
+  tt.func public @addptr_bitcast2(
+      %arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+      %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}
+  ) attributes {noinline = false} {
+    %0 = tt.bitcast %arg0 : !tt.ptr<f32> -> !tt.ptr<i32>
+    %1 = tt.bitcast %0 : !tt.ptr<i32> -> !tt.ptr<f32>
+    %2 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %3 = tt.splat %1 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+    %4 = tt.addptr %3, %2 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+    %5 = tt.load %4 : tensor<256x!tt.ptr<f32>>
+    %6 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+    %7 = tt.addptr %6, %2 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+    tt.store %7, %5 : tensor<256x!tt.ptr<f32>>
+    tt.return
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_block_ptr.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_block_ptr.mlir
@@ -1,0 +1,152 @@
+// RUN: triton-opt --triton-to-linalg --split-input-file %s | FileCheck %s
+//
+// make_tensor_ptr base variants:
+//   1) int_to_ptr
+//   2) int_to_ptr + bitcast
+//   3) int_to_ptr + 2*bitcast
+//   4) bitcast(arg)
+//   5) 2*bitcast(arg)
+
+// CHECK-LABEL: func.func @kernel_int_to_ptr
+// CHECK: %[[PC:.*]] = hivm.hir.pointer_cast
+// CHECK: memref.reinterpret_cast %[[PC]]
+// CHECK: memref.copy
+// CHECK: return
+module {
+  tt.func public @kernel_int_to_ptr(
+      %arg0: i64 {tt.divisibility = 16 : i32},
+      %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}
+  ) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c256_i64 = arith.constant 256 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %0 = tt.int_to_ptr %arg0 : i64 -> !tt.ptr<f32>
+    %1 = tt.make_tensor_ptr %0,
+         [%c256_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>}
+         : <tensor<256xf32>>
+    %2 = tt.load %1 : !tt.ptr<tensor<256xf32>>
+    %3 = tt.make_tensor_ptr %arg1,
+         [%c256_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>}
+         : <tensor<256xf32>>
+    tt.store %3, %2 : !tt.ptr<tensor<256xf32>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @kernel_int_to_ptr_bitcast
+// CHECK: %[[PC:.*]] = hivm.hir.pointer_cast
+// CHECK-SAME: memref<?xf32>
+// CHECK: memref.reinterpret_cast %[[PC]]
+// CHECK: memref.copy
+// CHECK: return
+module {
+  tt.func public @kernel_int_to_ptr_bitcast(
+      %arg0: i64 {tt.divisibility = 16 : i32},
+      %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}
+  ) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c256_i64 = arith.constant 256 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %0 = tt.int_to_ptr %arg0 : i64 -> !tt.ptr<i32>
+    %1 = tt.bitcast %0 : !tt.ptr<i32> -> !tt.ptr<f32>
+    %2 = tt.make_tensor_ptr %1,
+         [%c256_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>}
+         : <tensor<256xf32>>
+    %3 = tt.load %2 : !tt.ptr<tensor<256xf32>>
+    %4 = tt.make_tensor_ptr %arg1,
+         [%c256_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>}
+         : <tensor<256xf32>>
+    tt.store %4, %3 : !tt.ptr<tensor<256xf32>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @kernel_int_to_ptr_bitcast2
+// CHECK: %[[PC:.*]] = hivm.hir.pointer_cast
+// CHECK-SAME: memref<?xf32>
+// CHECK: memref.reinterpret_cast %[[PC]]
+// CHECK: memref.copy
+// CHECK: return
+module {
+  tt.func public @kernel_int_to_ptr_bitcast2(
+      %arg0: i64 {tt.divisibility = 16 : i32},
+      %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}
+  ) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c256_i64 = arith.constant 256 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %0 = tt.int_to_ptr %arg0 : i64 -> !tt.ptr<f32>
+    %1 = tt.bitcast %0 : !tt.ptr<f32> -> !tt.ptr<i32>
+    %2 = tt.bitcast %1 : !tt.ptr<i32> -> !tt.ptr<f32>
+    %3 = tt.make_tensor_ptr %2,
+         [%c256_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>}
+         : <tensor<256xf32>>
+    %4 = tt.load %3 : !tt.ptr<tensor<256xf32>>
+    %5 = tt.make_tensor_ptr %arg1,
+         [%c256_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>}
+         : <tensor<256xf32>>
+    tt.store %5, %4 : !tt.ptr<tensor<256xf32>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @kernel_bitcast
+// CHECK-NOT: hivm.hir.pointer_cast
+// CHECK: memref.reinterpret_cast
+// CHECK: memref.copy
+// CHECK: return
+module {
+  tt.func public @kernel_bitcast(
+      %arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+      %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}
+  ) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c256_i64 = arith.constant 256 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %0 = tt.bitcast %arg0 : !tt.ptr<i32> -> !tt.ptr<f32>
+    %1 = tt.make_tensor_ptr %0,
+         [%c256_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>}
+         : <tensor<256xf32>>
+    %2 = tt.load %1 : !tt.ptr<tensor<256xf32>>
+    %3 = tt.make_tensor_ptr %arg1,
+         [%c256_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>}
+         : <tensor<256xf32>>
+    tt.store %3, %2 : !tt.ptr<tensor<256xf32>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @kernel_bitcast2
+// CHECK-NOT: hivm.hir.pointer_cast
+// CHECK: memref.reinterpret_cast
+// CHECK: memref.copy
+// CHECK: return
+module {
+  tt.func public @kernel_bitcast2(
+      %arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+      %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}
+  ) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c256_i64 = arith.constant 256 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %0 = tt.bitcast %arg0 : !tt.ptr<f32> -> !tt.ptr<i32>
+    %1 = tt.bitcast %0 : !tt.ptr<i32> -> !tt.ptr<f32>
+    %2 = tt.make_tensor_ptr %1,
+         [%c256_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>}
+         : <tensor<256xf32>>
+    %3 = tt.load %2 : !tt.ptr<tensor<256xf32>>
+    %4 = tt.make_tensor_ptr %arg1,
+         [%c256_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>}
+         : <tensor<256xf32>>
+    tt.store %4, %3 : !tt.ptr<tensor<256xf32>>
+    tt.return
+  }
+}

--- a/third_party/ascend/unittest/pytest_ut/test_block_ptr.py
+++ b/third_party/ascend/unittest/pytest_ut/test_block_ptr.py
@@ -188,3 +188,100 @@ def test_func(param_list):
     ref_output = ref_func(inputs, scale, cu_lens)
     tt_output = tt_func(inputs, scale, cu_lens)
     torch.testing.assert_close(ref_output, tt_output)
+
+
+@triton.jit
+def triton_block_ptr_with_int_to_ptr(
+    src_ptr,  # i64 from host data_ptr()
+    dst_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """make_block_ptr base = tt.int_to_ptr (i64 -> !tt.ptr)."""
+    src = src_ptr.to(tl.pointer_type(tl.float32))
+    dst = dst_ptr.to(tl.pointer_type(tl.float32))
+    pid = tl.program_id(0)
+    offsets = (pid * BLOCK_SIZE,)
+    src_block = tl.make_block_ptr(
+        base=src,
+        shape=(n_elements,),
+        strides=(1,),
+        offsets=offsets,
+        block_shape=(BLOCK_SIZE,),
+        order=(0,),
+    )
+    dst_block = tl.make_block_ptr(
+        base=dst,
+        shape=(n_elements,),
+        strides=(1,),
+        offsets=offsets,
+        block_shape=(BLOCK_SIZE,),
+        order=(0,),
+    )
+    tl.store(dst_block, tl.load(src_block, boundary_check=(0,)), boundary_check=(0,))
+
+
+@pytest.mark.parametrize("n,block_size", [
+    (256, 64),
+    (1000, 256),  # not divisible: exercises boundary_check
+])
+def test_triton_block_ptr_with_int_to_ptr(n, block_size):
+    src = torch.randn(n, device="npu", dtype=torch.float32)
+    dst = torch.empty_like(src)
+    grid = (triton.cdiv(n, block_size),)
+    triton_block_ptr_with_int_to_ptr[grid](
+        src.data_ptr(),
+        dst.data_ptr(),
+        n,
+        BLOCK_SIZE=block_size,
+    )
+    torch.testing.assert_close(dst, src)
+
+
+@triton.jit
+def triton_block_ptr_with_int_to_ptr_bitcast(
+    src_ptr,  # i64 from host data_ptr()
+    dst_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """make_block_ptr base = tt.int_to_ptr + tt.bitcast (same bitwidth)."""
+    # i64 -> !tt.ptr<i32> (int_to_ptr), then !tt.ptr<i32> -> !tt.ptr<f32> (bitcast)
+    src = src_ptr.to(tl.pointer_type(tl.int32)).to(tl.pointer_type(tl.float32))
+    dst = dst_ptr.to(tl.pointer_type(tl.int32)).to(tl.pointer_type(tl.float32))
+    pid = tl.program_id(0)
+    offsets = (pid * BLOCK_SIZE,)
+    src_block = tl.make_block_ptr(
+        base=src,
+        shape=(n_elements,),
+        strides=(1,),
+        offsets=offsets,
+        block_shape=(BLOCK_SIZE,),
+        order=(0,),
+    )
+    dst_block = tl.make_block_ptr(
+        base=dst,
+        shape=(n_elements,),
+        strides=(1,),
+        offsets=offsets,
+        block_shape=(BLOCK_SIZE,),
+        order=(0,),
+    )
+    tl.store(dst_block, tl.load(src_block, boundary_check=(0,)), boundary_check=(0,))
+
+
+@pytest.mark.parametrize("n,block_size", [
+    (256, 64),
+    (512, 128),
+])
+def test_triton_block_ptr_with_int_to_ptr_bitcast(n, block_size):
+    src = torch.randn(n, device="npu", dtype=torch.float32)
+    dst = torch.empty_like(src)
+    grid = (triton.cdiv(n, block_size),)
+    triton_block_ptr_with_int_to_ptr_bitcast[grid](
+        src.data_ptr(),
+        dst.data_ptr(),
+        n,
+        BLOCK_SIZE=block_size,
+    )
+    torch.testing.assert_close(dst, src)


### PR DESCRIPTION
## Summary
Enable lowering for block‑pointer bases originating from raw `data_ptr()` addresses lowered via `tt.int_to_ptr` (optionally wrapped under `tt.bitcast`)..

## Background

Raw integer device addresses are passed into Triton kernels, cast to Triton pointers inside the kernel, and then used to construct block‑pointer and point‑pointer loads:
**Python example:**
```python
kernel[grid](x.data_ptr(), ..., BLOCK_SIZE=...)
# kernel:
ptr = x_ptr.to(tl.pointer_type(tl.float32))   # → tt.int_to_ptr
block = tl.make_block_ptr(base=ptr, ...)      # → tt.make_tensor_ptr
```
**Corresponding TTIR:**
```mlir
%0 = tt.int_to_ptr %arg0 : i64 -> !tt.ptr<f32>
%1 = tt.make_tensor_ptr %0, [%n], [%c1], [%off] {order = array<i32: 0>}
     : <tensor<256xf32>>
```

`make_tensor_ptr` would lower  to `memref.reinterpret_cast`, which needs `BlockData::source` to already be a **memref**.

### Pre‑PR failure path in `rewriteMakeTensorPtrOp`

```text
parse(base)                 // for int_to_ptr: source ← remapped !tt.ptr (NOT memref)
  └─ if hasResElemTy: insert UnrealizedConversionCast   // Only handles function‑arg + bitcast; int_to_ptr path leaves source unchanged
fill offsets / strides / sizes
createCastOp                // ★ FAIL HERE → getResultMemrefType(source)
replace original make_tensor_ptr
```

After `parse(%0)` on the TTIR above, `BlockData::source` is  still holds the `tt.int_to_ptr` result of type `!tt.ptr<f32>`, **not a memref**:

```mlir
// TTIR / mid-conversion (source SSA)
%arg0 = ... : i64
%0 = tt.int_to_ptr %arg0 : i64 -> !tt.ptr<f32>
// data.source == %0   (type !tt.ptr<f32>)   ← wrong: need memref<?xf32>

// createCastOp attempts to feed this Triton pointer into memref.reinterpret_cast:
%view = memref.reinterpret_cast %0
    to offset: [...], sizes: [256], strides: [1]
    : /* expects memref */ !tt.ptr<f32> -> memref<256xf32, ...>
```

**Crash in `getResultMemrefType`:**

```cpp
auto baseMemrefType = dyn_cast<BaseMemRefType>(this->source.getType());
// baseMemrefType = nullptr, since !tt.ptr is not a memref type
auto elementType = baseMemrefType.getElementType();  // aborts
```
> Assertion `detail::isPresent(Val) && "dyn_cast on a non-existent value"' failed.

Same for `int_to_ptr+bitcast`: `parse` may point `source` at the bitcast / remapped ptr; still not a memref.

| Base | `source` before this PR |
| --- | --- |
| Func arg `!tt.ptr` | `memref<?xelem>` (OK) |
| Arg + `bitcast` | remapped memref + UCC (OK) |
| `int_to_ptr` (with optional `bitcast*`) | `!tt.ptr<...>` / non-memref (**broken**) |

## Fix

1. Add **`materializeIntToPtrAsMemref`**: peel `bitcast*`, emit `hivm.pointer_cast` with **final** elem type (so `PointerCast → ReinterpretCast` directly; avoids UCC bridge that breaks post-pass size-refinement).
2. Wire into **`rewriteMakeTensorPtrOp` / `rewriteAddPtr`**: if materialized, skip arg-style UCC; arg+bitcast UCC unchanged.

```text
parse(base)
  └─ materializeIntToPtrAsMemref     // int_to_ptr(+bitcast*) → PointerCast
  └─ if !fromIntToPtr && hasResElemTy: UCC
createCastOp → reinterpret_cast
```
**IR transformation flows:**

* tt.int_to_ptr(+tt.bitcast*) → hivm.pointer_cast → memref.reinterpret_cast
* Function argument + tt.bitcast → UnrealizedConversionCast(memref) → memref.reinterpret_cast

**Post‑PR generated IR example:**

```mlir
%0 = tt.int_to_ptr %arg0 : i64 -> !tt.ptr<f32>
%1 = tt.make_tensor_ptr %0,
         [%c256_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>}
         : <tensor<256xf32>>
-->
%pc = hivm.hir.pointer_cast(%arg0) [%c256] : memref<?xf32>
%view = memref.reinterpret_cast %pc
    to offset: [0], sizes: [256], strides: [1]
    : memref<?xf32> to memref<256xf32, strided<[1], offset: ?>>
```

## What changed

| File | Change |
| --- | --- |
| `BlockPtrAnalysis.cpp` | `materializeIntToPtrAsMemref`; MakeTensorPtr / AddPtr |
| `test_block_ptr.mlir` / `test_addptr.mlir` | lit coverage |
| `test_block_ptr.py` | E2E `triton_block_ptr_with_int_to_ptr{,_bitcast}` |


## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
  - [ ] This PR does not need a test because …
  - [x] I have added tests.
- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices).
