### PR TITLE
[simd_simt](fix) remove compilation options passed incorrectly

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -866,12 +866,6 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
             if (_needs_lib_call_no_inline(metadata)
                     and _npu_compiler_supports_option(npu_compiler_path, "--enable-lib-call-no-inline")):
                 _compile_option_list += ["--enable-lib-call-no-inline=false"]
-            if metadata.get("parallel_mode") == "mix_simd_simt":
-                _compile_option_list += ["--enable-simd-simt-mix-compile"]
-                num_warps = metadata.get("num_warps") or opt.num_warps
-                _compile_option_list += [f"--num-warps={num_warps}"]
-                warp_size = metadata.get("warp_size") or opt.warp_size
-                _compile_option_list += [f"--threads-per-warp={warp_size}"]
 
             partition_mode = _validate_partition_and_bind_sub_block(
                 metadata.get(


### PR DESCRIPTION
The --enable-simd-simt-mix-compile option should not be passed in simt_template mode. 
The related code is deleted.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
