### PR TITLE
[ssbuffer](fix) splitIf precision & compilation errors

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
@@ -41,7 +41,7 @@ using namespace triton;
 namespace {
 
 static constexpr llvm::StringLiteral interceptrFunc[]{
-    "_parallel_hstu_attn_bwd"};
+    "_parallel_hstu_attn_bwd", "chunk_gsa_fwd_k_kernel_intra"};
 
 static LogicalResult verifyFuncNames(ModuleOp module) {
   bool intercepted = false;

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/SplitIfByBlockId/SplitIfByBlockId.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/SplitIfByBlockId/SplitIfByBlockId.cpp
@@ -20,6 +20,7 @@
  * THE SOFTWARE.
  */
 #include <cstdint>
+#include <optional>
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
@@ -27,14 +28,17 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Analysis/ScalarEvolution.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/LogicalResult.h"
 
+#include "bishengir/Dialect/HIVM/IR/HIVMImpl.h"
 #include "mlir/Analysis/AliasAnalysis.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -45,6 +49,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
@@ -786,15 +791,67 @@ static Value getRootTensor(Value v) {
   return v;
 }
 
+static llvm::FailureOr<Value>
+createMatmulPlaceHolderValue(OpBuilder &builder, scf::IfOp ifOp,
+                             linalg::MatmulOp matmulOp,
+                             RankedTensorType tensorType, Location loc) {
+  auto bias = matmulOp.getDpsInitOperand(0)->get();
+  auto block = ifOp->getBlock();
+  return llvm::TypeSwitch<Value, llvm::FailureOr<Value>>(bias)
+      .Case([&](BlockArgument barg) -> llvm::FailureOr<Value> {
+        if (barg.getParentBlock()->findAncestorOpInBlock(*ifOp))
+          return bias;
+        else
+          return llvm::failure();
+      })
+      .Case([&](OpResult res) -> llvm::FailureOr<Value> {
+        auto defOp = res.getDefiningOp();
+        auto fillOp = llvm::dyn_cast_if_present<linalg::FillOp>(defOp);
+        if (!fillOp) {
+          return llvm::failure();
+        }
+
+        auto sourceOp = fillOp.getDpsInitOperand(0)->get().getDefiningOp();
+        auto sourceEmpty = llvm::dyn_cast_if_present<tensor::EmptyOp>(sourceOp);
+        if (!sourceEmpty)
+          return llvm::failure();
+
+        if (ifOp->isAncestor(sourceEmpty) || ifOp->isAncestor(fillOp)) {
+          auto valueDefinedInsideIf = [ifOp](Value value) {
+            Operation *defOp =
+                llvm::TypeSwitch<Value, Operation *>(value)
+                    .Case([&](BlockArgument barg) -> Operation * {
+                      auto block = barg.getOwner();
+                      if (!block)
+                        return nullptr;
+                      auto parentOp = block->getParentOp();
+                      if (!parentOp)
+                        return nullptr;
+                      return parentOp;
+                    })
+                    .Case([&](OpResult res) { return res.getDefiningOp(); })
+                    .Default([&](auto) { return nullptr; });
+            return defOp && ifOp->isAncestor(defOp);
+          };
+          if (llvm::any_of(matmulOp.getDpsInputs(), valueDefinedInsideIf))
+            return llvm::failure();
+        }
+
+        auto emptyOp = builder.create<tensor::EmptyOp>(
+            loc, tensorType.getShape(), tensorType.getElementType());
+        return emptyOp.getResult();
+      })
+      .Default([](auto) { return llvm::failure(); });
+}
+
 /// Create a zero/default SSA value of the given type.
 /// Used for placeholder values in Case A else blocks when the original
 /// scf.if has no yield results to passthrough.
 /// When \p referenceValue traces to a function argument, the placeholder
 /// preserves that provenance instead of creating a fresh alloca.
-static llvm::FailureOr<Value> createPlaceholderValue(int blockId,
-                                                     OpBuilder &builder,
-                                                     Location loc, Type type,
-                                                     Value referenceValue) {
+static llvm::FailureOr<Value>
+createPlaceholderValue(int blockId, OpBuilder &builder, Location loc, Type type,
+                       Value referenceValue, scf::IfOp ifOp) {
   Value result;
   bool usedTrace = false;
   if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
@@ -806,18 +863,33 @@ static llvm::FailureOr<Value> createPlaceholderValue(int blockId,
     // the builder's region. Values defined inside inner regions
     // (e.g. scf.if then-blocks) or sibling regions are rejected.
     if (referenceValue) {
-      Value root = getRootTensor(referenceValue);
-      auto *rootRegion = root.getParentRegion();
-      auto *builderRegion = builder.getBlock()->getParent();
-      bool dominates = (rootRegion == builderRegion) ||
-                       rootRegion->isAncestor(builderRegion);
-      if (dominates) {
-        if (auto *rootOp = root.getDefiningOp()) {
-          auto existingId =
-              rootOp->getAttrOfType<IntegerAttr>(CVPipeline::kBlockId);
-          if (!existingId || existingId.getInt() != -1) {
-            result = root;
-            usedTrace = true;
+      auto matmulOpt = hivm::traceDefOp<linalg::MatmulOp>(referenceValue);
+      if (matmulOpt.has_value()) {
+        auto matmulOp = llvm::dyn_cast<linalg::MatmulOp>(matmulOpt.value());
+        if (matmulOp) {
+          auto resultRes = createMatmulPlaceHolderValue(builder, ifOp, matmulOp,
+                                                        tensorType, loc);
+          if (llvm::failed(resultRes)) {
+            return llvm::failure();
+          }
+          result = resultRes.value();
+          usedTrace = true;
+        }
+      }
+      if (!usedTrace) {
+        Value root = getRootTensor(referenceValue);
+        auto *rootRegion = root.getParentRegion();
+        auto *builderRegion = builder.getBlock()->getParent();
+        bool dominates = (rootRegion == builderRegion) ||
+                         rootRegion->isAncestor(builderRegion);
+        if (dominates) {
+          if (auto *rootOp = root.getDefiningOp()) {
+            auto existingId =
+                rootOp->getAttrOfType<IntegerAttr>(CVPipeline::kBlockId);
+            if (!existingId || existingId.getInt() != -1) {
+              result = root;
+              usedTrace = true;
+            }
           }
         }
       }
@@ -1100,6 +1172,9 @@ static bool valueDominates(Value val, Block *block) {
 static llvm::LogicalResult
 buildElseYieldForGroup(const int blockId, const GroupOutputInfo &output,
                        Block &elseBlock, Location loc, OpBuilder &builder) {
+  auto ifOp = llvm::dyn_cast<scf::IfOp>(elseBlock.getParentOp());
+  if (!ifOp)
+    return llvm::failure();
   builder.setInsertionPointToEnd(&elseBlock);
   SmallVector<Value> yieldVals;
 
@@ -1111,7 +1186,7 @@ buildElseYieldForGroup(const int blockId, const GroupOutputInfo &output,
     if (it != placeholderCache.end()) {
       return it->second;
     }
-    auto ph = createPlaceholderValue(blockId, builder, loc, type, ref);
+    auto ph = createPlaceholderValue(blockId, builder, loc, type, ref, ifOp);
     placeholderCache[type] = ph;
     return ph;
   };
@@ -1225,6 +1300,7 @@ static llvm::LogicalResult
 buildElseYieldForLastIf(int blockId, const OtherSideContext &otherCtx,
                         ArrayRef<Type> lastIfTypes, Block &elseBlock,
                         Location loc, OpBuilder &builder) {
+  auto ifOp = llvm::dyn_cast<scf::IfOp>(elseBlock.getParentOp());
   if (elseBlock.mightHaveTerminator()) {
     elseBlock.getTerminator()->erase();
   }
@@ -1249,7 +1325,7 @@ buildElseYieldForLastIf(int blockId, const OtherSideContext &otherCtx,
                                            elseBlock, builder));
     } else {
       auto phRes = createPlaceholderValue(blockId, builder, loc,
-                                          lastIfTypes[slot], Value());
+                                          lastIfTypes[slot], Value(), ifOp);
       if (llvm::failed(phRes)) {
         return failure();
       }
@@ -1606,6 +1682,17 @@ void SplitIfByBlockIdPass::runOnOperation() {
   if (hasFallbackAttr(module)) {
     return;
   }
+
+  constexpr llvm::StringLiteral noSplitFns{"parallel_deltaformer_fwd_kernel"};
+  auto walkRes = module.walk([&](func::FuncOp funcOp) {
+    if (!llvm::is_contained(noSplitFns, funcOp.getSymName())) {
+      return WalkResult::advance();
+    }
+    return WalkResult::interrupt();
+  });
+  if (walkRes.wasInterrupted())
+    return;
+
   LDBG("Before:\n" << module << "\n----------");
 
   CVPipeline::ComputeBlockIdManager bm(module);


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
