### PR TITLE
[Ascend](fix) preserve hidden launch argument slots

### DIFF
--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -1286,7 +1286,9 @@ void triton_launch_kernel(const char* kernelName, cann_func_handle func, cann_st
     size_t grid_offset = reserve_slot(sizeof(int32_t), 4);
     reserve_slot(sizeof(int32_t), 4);
     reserve_slot(sizeof(int32_t), 4);
-    {'size_t dtdata_offset = reserve_slot(sizeof(void*), 8);' if enable_device_print else ''}
+    {'reserve_slot(sizeof(void*), 8);' if metadata.is_pure_simt else ''}
+    {'reserve_slot(sizeof(void*), 8);' if metadata.is_pure_simt else ''}
+    {'size_t dtdata_offset = reserve_slot(sizeof(void*), 8);' if enable_device_print else 'reserve_slot(sizeof(void*), 8);'}
     size_t total_size = args_offset;
 
     std::vector<char> launch_args(total_size, 0);
@@ -1324,7 +1326,9 @@ static void _launch(const char* kernelName, cann_func_handle func, cann_stream s
       {'void* workspace_addr __attribute__((aligned(8)));' if not metadata.is_pure_simt else ''}
       {' '.join(f'{ty_to_cpp(ty)} arg{i} __attribute__((aligned({4 if ty[0] != "*" and ty[-2:] != "64" else 8})));' for i, ty in signature.items() if ty != "constexpr")}
       {' '.join(f'{ty_to_cpp(ty)} grid{mark} __attribute__((aligned(4)));' for mark, ty in grid_info.items())}
-      {'void* DTData __attribute__((aligned(8)));' if enable_device_print else ''}
+      {'void* global_scratch __attribute__((aligned(8)));' if metadata.is_pure_simt else ''}
+      {'void* profile_scratch __attribute__((aligned(8)));' if metadata.is_pure_simt else ''}
+      {'void* DTData __attribute__((aligned(8)));'}
     }} args = {{
       {'static_cast<void*>(ffts_addr),' if target_support_ffts else ''}
       {('static_cast<void*>(syncBlockLock_ptr),' if has_sync_block_lock else 'nullptr,') if not metadata.is_pure_simt else ''}
@@ -1333,7 +1337,9 @@ static void _launch(const char* kernelName, cann_func_handle func, cann_stream s
         [f'static_cast<{ty_to_cpp(ty)}>(arg{i})' for i, ty in signature.items() if ty != "constexpr"]
       )}
       {', '.join(f'static_cast<{ty_to_cpp(ty)}>(grid{mark})' for mark, ty in grid_info.items())}
-      {', static_cast<void*>(DTData)' if enable_device_print else ''}
+      {', static_cast<void*>(nullptr)' if metadata.is_pure_simt else ''}
+      {', static_cast<void*>(nullptr)' if metadata.is_pure_simt else ''}
+      {', static_cast<void*>(DTData)' if enable_device_print else ', static_cast<void*>(nullptr)'}
     }};
 {_launch_lambda_post.replace('__KERNEL_LAUNCH_CALL__', cpp_kernel_launch_local)}
 


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref github-upstream/main-dev --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
  - [x] This PR does not need a test because it restores fixed hidden ABI slots in generated launch argument packing; device behavior requires external Ascend validation.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow the MLIR testing best practices.

## Why

The Ascend kernel launch ABI includes a trailing `DTData` pointer even when device printing is disabled. Pure-SIMT kernels additionally reserve two pointer-width slots for global scratch and profile scratch between the three grid arguments and `DTData`.

Global scratch staging is not ready yet, so both scratch slots must remain null. Omitting them shifts `DTData` to the wrong offset, while omitting `DTData` when device printing is disabled shortens the packed launch buffer and also violates the kernel ABI.

## What changed

- Keep the pure-SIMT global-scratch and profile-scratch fields explicit and initialize both with `nullptr` in the Python launch path.
- Always append the `DTData` field in the Python launch path, passing the real pointer when device printing is enabled and `nullptr` otherwise.
- Always reserve the matching `DTData` slot in the exported `triton_launch_kernel` path. Its zero-initialized launch buffer leaves the slot null when device printing is disabled.

No allocator, compiler, or metadata behavior is changed.

## Validation

- `git diff --check`
- No tests were added or run for the latest amendment.
- Device validation was not run because this development machine has no CANN toolkit or Ascend NPU.
