### PR TITLE
[TritonControlFlowOpt](fix) Preserve dense splat tensor offsets

### DIFF
--- a/third_party/ascend/include/TritonControlFlowOpt/ControlFlowRewrite.h
+++ b/third_party/ascend/include/TritonControlFlowOpt/ControlFlowRewrite.h
@@ -157,17 +157,21 @@ public:
 /// Signature expansion, region cloning, terminator rewriting, nested recursion
 /// and result replacement are driven solely by operation-level decisions in
 /// `plan`.
-LogicalResult
-applyControlFlowRewritePlan(ModuleOp module,
-                            const ControlFlowRewritePolicy &policy,
-                            const ControlFlowRewritePlan &plan);
+/// Set `emitDiagnostics` to false for a speculative rewrite on a detached
+/// clone whose failure is intentionally treated as an unsupported case.
+LogicalResult applyControlFlowRewritePlan(
+    ModuleOp module, const ControlFlowRewritePolicy &policy,
+    const ControlFlowRewritePlan &plan, bool emitDiagnostics = true);
 
 /// Analyzes the complete decomposition stage before mutating the IR, then
 /// applies the frozen plan from outermost to innermost. Pointer semantics
 /// remain selected by `policy` so different decompositions share the same SCF
 /// plumbing.
+/// When `allowUnsupportedFallback` is true, a failed complete rewrite is
+/// treated as an unsupported optimization and leaves the input module intact.
 LogicalResult rewriteControlFlow(ModuleOp module,
-                                 const ControlFlowRewritePolicy &policy);
+                                 const ControlFlowRewritePolicy &policy,
+                                 bool allowUnsupportedFallback = false);
 
 } // namespace mlir::triton::controlflow
 

--- a/third_party/ascend/include/TritonToLinalg/BlockPtrAnalysis.h
+++ b/third_party/ascend/include/TritonToLinalg/BlockPtrAnalysis.h
@@ -127,8 +127,8 @@ public:
   void removeSource();
 
   int64_t getRank() const;
-  MemRefType getResultMemrefType(int64_t offset,
-                                 ArrayRef<int64_t> resultShape) const;
+  FailureOr<MemRefType>
+  getResultMemrefType(int64_t offset, ArrayRef<int64_t> resultShape) const;
 
   void addBlock(BlockData &lBlock, BlockData &rBlock, Location loc,
                 ConversionPatternRewriter &rewriter);
@@ -139,9 +139,9 @@ public:
   void divBlock(BlockData &lBlock, BlockData &rBlock, Location loc,
                 ConversionPatternRewriter &rewriter);
 
-  memref::ReinterpretCastOp createCastOp(ArrayRef<int64_t> resultShape,
-                                         const Location &loc,
-                                         OpBuilder &builder) const;
+  FailureOr<memref::ReinterpretCastOp>
+  createCastOp(ArrayRef<int64_t> resultShape, const Location &loc,
+               OpBuilder &builder) const;
 
   void setResElemTy(const Type &);
   void setSource(const Value &);
@@ -359,10 +359,9 @@ public:
   rewriteLoopOp(LoopLikeOpInterface op, ConversionPatternRewriter &rewriter,
                 llvm::SmallDenseMap<Value, BlockData> &known);
 
-  static void rewriteAddPtrToUnstrucMemAcc(triton::AddPtrOp op,
-                                           triton::AddPtrOp::Adaptor &adaptor,
-                                           ConversionPatternRewriter &rewriter,
-                                           BlockData &data);
+  static LogicalResult rewriteAddPtrToUnstrucMemAcc(
+      triton::AddPtrOp op, triton::AddPtrOp::Adaptor &adaptor,
+      ConversionPatternRewriter &rewriter, BlockData &data);
 };
 
 template <typename OpTy>

--- a/third_party/ascend/include/TritonToUnstructure/OffsetAnalysis.h
+++ b/third_party/ascend/include/TritonToUnstructure/OffsetAnalysis.h
@@ -34,9 +34,17 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace mlir {
 namespace triton {
+
+/// Temporary T2U handoff marker for loop slots rewritten from a scalar
+/// pointer to a relative integer offset.  OffsetAnalysis uses this marker to
+/// keep the region argument's dynamic backedge value instead of replaying the
+/// original pointer-init provenance on every iteration.
+inline constexpr llvm::StringLiteral kScalarPointerOffsetBoundaryAttr =
+    "ScalarPointerOffsetBoundary";
 
 struct PtrOffsetInfo {
   /**

--- a/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowRewrite.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowRewrite.cpp
@@ -26,6 +26,7 @@
 #include "bishengir/Dialect/Scope/IR/Scope.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
@@ -1356,10 +1357,9 @@ tryDecoupleControlFlowOp(Operation *op, IRRewriter &rewriter,
 
 namespace mlir::triton::controlflow {
 
-LogicalResult
-applyControlFlowRewritePlan(ModuleOp module,
-                            const ControlFlowRewritePolicy &policy,
-                            const ControlFlowRewritePlan &plan) {
+LogicalResult applyControlFlowRewritePlan(
+    ModuleOp module, const ControlFlowRewritePolicy &policy,
+    const ControlFlowRewritePlan &plan, bool emitDiagnostics) {
   IRRewriter rewriter(module.getContext());
   // Analysis and application are consecutive and no IR mutation occurs in
   // between, so rediscover the roots from the module instead of duplicating
@@ -1367,13 +1367,15 @@ applyControlFlowRewritePlan(ModuleOp module,
   for (Operation *root : collectOutermostControlFlowOps(module)) {
     const ControlFlowOpAnalysis *rootAnalysis = plan.lookup(root);
     if (!rootAnalysis) {
-      root->emitError("missing frozen control-flow rewrite decision");
+      if (emitDiagnostics)
+        root->emitError("missing frozen control-flow rewrite decision");
       return failure();
     }
     if (!rootAnalysis->needsRewrite())
       continue;
     if (failed(tryDecoupleControlFlowOp(root, rewriter, policy, plan))) {
-      root->emitError("failed to apply analyzed pointer decomposition");
+      if (emitDiagnostics)
+        root->emitError("failed to apply analyzed pointer decomposition");
       return failure();
     }
   }
@@ -1381,7 +1383,32 @@ applyControlFlowRewritePlan(ModuleOp module,
 }
 
 LogicalResult rewriteControlFlow(ModuleOp module,
-                                 const ControlFlowRewritePolicy &policy) {
+                                 const ControlFlowRewritePolicy &policy,
+                                 bool allowUnsupportedFallback) {
+  // Tensor-pointer decomposition is an optimization, not the only legal
+  // representation of a TensorPtr. Probe the complete rewrite on a detached
+  // clone before mutating the real module. If analysis or application rejects
+  // any root, discard the clone and keep the original TensorPtr graph intact;
+  // this prevents a partially materialized descriptor from reaching T2L.
+  if (allowUnsupportedFallback) {
+    Operation *probeOperation = module->clone();
+    auto probeModule = cast<ModuleOp>(probeOperation);
+    bool probeSucceeded = false;
+    {
+      ScopedDiagnosticHandler suppressDiagnostics(
+          module.getContext(), [](Diagnostic &) { return success(); });
+      FailureOr<ControlFlowRewritePlan> probePlan =
+          analyzeControlFlow(probeModule, policy);
+      probeSucceeded =
+          succeeded(probePlan) &&
+          succeeded(applyControlFlowRewritePlan(probeModule, policy, *probePlan,
+                                                /*emitDiagnostics=*/false));
+    }
+    probeModule->erase();
+    if (!probeSucceeded)
+      return success();
+  }
+
   FailureOr<ControlFlowRewritePlan> plan = analyzeControlFlow(module, policy);
   if (failed(plan))
     return failure();

--- a/third_party/ascend/lib/TritonControlFlowOpt/TensorPtrDecompose.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/TensorPtrDecompose.cpp
@@ -282,6 +282,29 @@ static FailureOr<RankedTensorType> getRank1IntegerTensorType(Value value,
   return tensorType;
 }
 
+struct DenseIntegerSplat {
+  APInt value;
+};
+
+/// Returns the exact scalar bit pattern represented by an integer dense splat.
+/// Lane-varying dense constants deliberately fail this check and remain opaque.
+static FailureOr<DenseIntegerSplat> getDenseIntegerSplat(Value value) {
+  auto tensorType = dyn_cast<RankedTensorType>(value.getType());
+  auto constant = value.getDefiningOp<arith::ConstantOp>();
+  if (!tensorType || tensorType.getRank() == 0 ||
+      !tensorType.hasStaticShape() ||
+      !isa<IntegerType>(tensorType.getElementType()) || !constant)
+    return failure();
+  auto dense = dyn_cast<DenseIntElementsAttr>(constant.getValue());
+  if (!dense || !dense.isSplat() || dense.getType() != tensorType)
+    return failure();
+  APInt splatValue = dense.getSplatValue<APInt>();
+  if (splatValue.getBitWidth() !=
+      cast<IntegerType>(tensorType.getElementType()).getWidth())
+    return failure();
+  return DenseIntegerSplat{std::move(splatValue)};
+}
+
 static Rank1AnalyzedOffset getFallbackAnalyzedOffset(Value value, Type) {
   auto tensorType = cast<RankedTensorType>(value.getType());
   Type scalarType = tensorType.getElementType();
@@ -301,7 +324,8 @@ static FailureOr<Value> getSplatScalar(Value value) {
 static bool isSafeIntegerExtensionLeaf(Value value) {
   if (value.getDefiningOp<triton::MakeRangeOp>())
     return true;
-  return succeeded(getSplatScalar(value));
+  return succeeded(getSplatScalar(value)) ||
+         succeeded(getDenseIntegerSplat(value));
 }
 
 static FailureOr<Rank1AnalyzedOffset> analyzeRank1Offset(Value value,
@@ -333,6 +357,18 @@ static FailureOr<Rank1AnalyzedOffset> analyzeRank1Offset(Value value,
         getScalarConstant(splat.getSrc()) == std::optional<int64_t>(0)
             ? ComponentIdentity::zero(kOffsetComponent)
             : ComponentIdentity::fromValue(splat.getSrc(), kOffsetComponent);
+    return Rank1AnalyzedOffset{
+        {scalarType, ComponentIdentity::zero(kStrideComponent)},
+        {scalarType, offsetIdentity},
+        {*tensorType, ComponentIdentity::zero(kResidualComponent)}};
+  }
+
+  if (FailureOr<DenseIntegerSplat> dense = getDenseIntegerSplat(value);
+      succeeded(dense)) {
+    ComponentIdentity offsetIdentity =
+        dense->value.isZero()
+            ? ComponentIdentity::zero(kOffsetComponent)
+            : ComponentIdentity::fromValue(value, kOffsetComponent);
     return Rank1AnalyzedOffset{
         {scalarType, ComponentIdentity::zero(kStrideComponent)},
         {scalarType, offsetIdentity},
@@ -452,6 +488,15 @@ static Value createScalarConstant(OpBuilder &builder, Location loc, Type type,
     return nullptr;
   return builder.create<arith::ConstantOp>(
       loc, builder.getIntegerAttr(intType, value));
+}
+
+static Value createScalarConstant(OpBuilder &builder, Location loc, Type type,
+                                  const APInt &value) {
+  auto intType = dyn_cast<IntegerType>(type);
+  if (!intType || intType.getWidth() != value.getBitWidth())
+    return nullptr;
+  return builder.create<arith::ConstantOp>(loc,
+                                           IntegerAttr::get(intType, value));
 }
 
 static Value createZeroOffsets(OpBuilder &builder, Location loc,
@@ -582,6 +627,16 @@ static FailureOr<Rank1OffsetValues> materializeRank1Offset(Value value,
     if (failed(offset) || !stride || !residual)
       return failure();
     return Rank1OffsetValues{stride, *offset, residual};
+  }
+
+  if (FailureOr<DenseIntegerSplat> dense = getDenseIntegerSplat(value);
+      succeeded(dense)) {
+    Value stride = createScalarConstant(builder, loc, scalarType, 0);
+    Value offset = createScalarConstant(builder, loc, scalarType, dense->value);
+    Value residual = createZeroOffsets(builder, loc, *tensorType);
+    if (!stride || !offset || !residual)
+      return failure();
+    return Rank1OffsetValues{stride, offset, residual};
   }
 
   if (auto extension = value.getDefiningOp<arith::ExtSIOp>()) {
@@ -822,6 +877,15 @@ static FailureOr<AnalyzedTensorOffset> analyzeTensorOffset(Value value) {
     if (getScalarConstant(splat.getSrc()) != std::optional<int64_t>(0))
       result.uniformOffset.identity = ComponentIdentity::fromValue(
           splat.getSrc(), getUniformOffsetComponent(rank));
+    return result;
+  }
+
+  if (FailureOr<DenseIntegerSplat> dense = getDenseIntegerSplat(value);
+      succeeded(dense)) {
+    AnalyzedTensorOffset result = makeStructuredZero();
+    if (!dense->value.isZero())
+      result.uniformOffset.identity =
+          ComponentIdentity::fromValue(value, getUniformOffsetComponent(rank));
     return result;
   }
 
@@ -1084,6 +1148,21 @@ materializeTensorOffsetFields(Value value, OpBuilder &builder, Location loc) {
     if (failed(uniform))
       return failure();
     result->uniformOffset = *uniform;
+    return result;
+  }
+
+  if (FailureOr<DenseIntegerSplat> dense = getDenseIntegerSplat(value);
+      succeeded(dense)) {
+    OpBuilder::InsertionGuard insertionGuard(builder);
+    builder.setInsertionPointAfter(value.getDefiningOp());
+    FailureOr<TensorOffsetValues> result = makeZero(AxisKind::Structured);
+    if (failed(result))
+      return failure();
+    Value uniform =
+        createScalarConstant(builder, loc, scalarType, dense->value);
+    if (!uniform)
+      return failure();
+    result->uniformOffset = uniform;
     return result;
   }
 
@@ -1949,7 +2028,7 @@ namespace mlir::triton::controlflow {
 
 LogicalResult runTensorPtrDecompose(ModuleOp module) {
   TensorPtrDecomposePolicy policy;
-  return rewriteControlFlow(module, policy);
+  return rewriteControlFlow(module, policy, /*allowUnsupportedFallback=*/true);
 }
 
 } // namespace mlir::triton::controlflow

--- a/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
@@ -96,6 +96,28 @@ static bool isScalarPointerCarrierSource(Value source) {
   return pointerCast && pointerCast->hasAttr(kScalarPointerCarrierAttr);
 }
 
+// Dialect conversion may temporarily materialize a scalar Triton pointer from
+// a memref carrier so that an operation which has not been rewritten yet can
+// keep its original type.  Scalar pointer transport must consume the carrier
+// directly; otherwise the conversion driver is forced to leave a live
+// memref-to-!tt.ptr cast next to tt.load/tt.store.  Only peel the narrow,
+// one-to-one UCC form whose input is already a BaseMemRefType.  Unknown casts,
+// multi-value casts, and non-memref inputs remain unsupported and therefore
+// continue through the existing diagnostics.
+static Value unwrapScalarPointerMemRefCarrier(Value value) {
+  while (auto castOp = value.getDefiningOp<UnrealizedConversionCastOp>()) {
+    if (castOp.getInputs().size() != 1 || castOp.getOutputs().size() != 1)
+      break;
+    Value input = castOp.getInputs().front();
+    Value output = castOp.getOutputs().front();
+    if (!isa<BaseMemRefType>(input.getType()) ||
+        !isa<triton::PointerType, BaseMemRefType>(output.getType()))
+      break;
+    value = input;
+  }
+  return value;
+}
+
 // MemAccType selectMaxMemAccTy(const MemAccType &v1, const MemAccType &v2) {
 //   return (v1 > v2) ? v1 : v2;
 // }
@@ -191,15 +213,18 @@ OpFoldResult BlockData::inferBlockOffset(const Location &loc,
   return retOffset;
 }
 
-MemRefType BlockData::getResultMemrefType(int64_t offset,
-                                          ArrayRef<int64_t> resultShape) const {
+FailureOr<MemRefType>
+BlockData::getResultMemrefType(int64_t offset,
+                               ArrayRef<int64_t> resultShape) const {
   SmallVector<int64_t> staticStrides;
   SmallVector<Value> dynamicStrides;
   dispatchIndexOpFoldResults(strides, dynamicStrides, staticStrides);
 
+  if (!this->source)
+    return failure();
   auto baseMemrefType = dyn_cast<BaseMemRefType>(this->source.getType());
-  assert(baseMemrefType &&
-         "Invalid element type. It should be a base memref type.");
+  if (!baseMemrefType)
+    return failure();
   auto elementType = baseMemrefType.getElementType();
   auto layout =
       StridedLayoutAttr::get(this->source.getContext(), offset, staticStrides);
@@ -370,14 +395,21 @@ void BlockData::divBlock(BlockData &lBlock, BlockData &rBlock, Location loc,
   // rBlock.getMemAccType()));
 }
 
-memref::ReinterpretCastOp BlockData::createCastOp(ArrayRef<int64_t> resultShape,
-                                                  const Location &loc,
-                                                  OpBuilder &builder) const {
+FailureOr<memref::ReinterpretCastOp>
+BlockData::createCastOp(ArrayRef<int64_t> resultShape, const Location &loc,
+                        OpBuilder &builder) const {
   OpFoldResult resOffset = this->inferBlockOffset(loc, builder);
-  auto resultType = this->getResultMemrefType(
-      isa<Attribute>(resOffset) ? getConstantIntValue(resOffset).value()
-                                : ShapedType::kDynamic,
-      resultShape);
+  int64_t staticOffset = ShapedType::kDynamic;
+  if (isa<Attribute>(resOffset)) {
+    auto constantOffset = getConstantIntValue(resOffset);
+    if (!constantOffset)
+      return failure();
+    staticOffset = *constantOffset;
+  }
+  FailureOr<MemRefType> resultType =
+      this->getResultMemrefType(staticOffset, resultShape);
+  if (failed(resultType))
+    return failure();
 
   SmallVector<OpFoldResult> strides(this->strides);
   for (size_t i = 0; i < strides.size(); i++) {
@@ -392,7 +424,7 @@ memref::ReinterpretCastOp BlockData::createCastOp(ArrayRef<int64_t> resultShape,
   }
 
   return builder.create<memref::ReinterpretCastOp>(
-      loc, resultType, this->source, resOffset, this->sizes, strides);
+      loc, *resultType, this->source, resOffset, this->sizes, strides);
 }
 
 void BlockData::dump() const {
@@ -428,10 +460,59 @@ BlockDataParser::getScalarMemRef(Value ptr, Value memref, const Location &loc,
   if (!pointerType || isa<ShapedType>(pointerType.getPointeeType()))
     return failure();
 
+  memref = unwrapScalarPointerMemRefCarrier(memref);
+
+  // A complete scalar address reconstructed after an SCF boundary is exposed
+  // as tt.int_to_ptr in the Triton IR.  Its converted operand is already the
+  // canonical ScalarPointerCarrier memref; handle it before the legacy
+  // block-argument path so a direct load/store does not request a reverse
+  // memref-to-pointer materialization.
+  if (ptr.getDefiningOp<triton::IntToPtrOp>()) {
+    if (!isa<BaseMemRefType>(memref.getType()))
+      return failure();
+    if (auto memrefType = dyn_cast<MemRefType>(memref.getType());
+        memrefType && memrefType.getRank() == 1)
+      return memref;
+    BlockData data;
+    data.setSource(memref);
+    data.getOffsetsRef().push_back(rewriter.getIndexAttr(0));
+    data.getSizesRef().push_back(rewriter.getIndexAttr(1));
+    data.getStridesRef().push_back(rewriter.getIndexAttr(1));
+    auto castOp = data.createCastOp(SmallVector<int64_t>(1, 1), loc, rewriter);
+    if (failed(castOp))
+      return failure();
+    return (*castOp).getResult();
+  }
+
   if (ptr.getDefiningOp<triton::AddPtrOp>()) {
     if (auto castOp = memref.getDefiningOp<memref::ReinterpretCastOp>())
       return castOp.getResult();
+    if (auto pointerCast = memref.getDefiningOp<hivm::PointerCastOp>();
+        pointerCast && pointerCast->hasAttr(kScalarPointerCarrierAttr))
+      return memref;
     return failure();
+  }
+
+  // A scalar pointer produced by structured control flow or select is already
+  // represented by a converted memref. Give it the same one-element view used
+  // for a scalar block argument so direct tt.load/tt.store users can consume
+  // the transport result without attempting memref-to-pointer materialization.
+  if (auto definingOp = ptr.getDefiningOp();
+      definingOp && isScalarPointerTransport(definingOp)) {
+    if (!isa<BaseMemRefType>(memref.getType()))
+      return failure();
+    if (auto memrefType = dyn_cast<MemRefType>(memref.getType());
+        memrefType && memrefType.getRank() == 1)
+      return memref;
+    BlockData data;
+    data.setSource(memref);
+    data.getOffsetsRef().push_back(rewriter.getIndexAttr(0));
+    data.getSizesRef().push_back(rewriter.getIndexAttr(1));
+    data.getStridesRef().push_back(rewriter.getIndexAttr(1));
+    auto castOp = data.createCastOp(SmallVector<int64_t>(1, 1), loc, rewriter);
+    if (failed(castOp))
+      return failure();
+    return (*castOp).getResult();
   }
 
   if (!isa<BlockArgument>(ptr) || !isa<BaseMemRefType>(memref.getType()))
@@ -443,7 +524,9 @@ BlockDataParser::getScalarMemRef(Value ptr, Value memref, const Location &loc,
   data.getSizesRef().push_back(rewriter.getIndexAttr(1));
   data.getStridesRef().push_back(rewriter.getIndexAttr(1));
   auto castOp = data.createCastOp(SmallVector<int64_t>(1, 1), loc, rewriter);
-  return castOp.getResult();
+  if (failed(castOp))
+    return failure();
+  return (*castOp).getResult();
 }
 
 LogicalResult
@@ -471,6 +554,10 @@ BlockDataParser::parse(Value operand, BlockData &data, const Location &loc,
                      << operand;
       return failure();
     }
+    // A not-yet-rewritten pointer user may be represented by a one-to-one
+    // UCC from a converted memref.  Consume that memref as the transport
+    // source instead of asking the driver to materialize the pointer back.
+    remappedPtr = unwrapScalarPointerMemRefCarrier(remappedPtr);
     if (auto op = operand.getDefiningOp()) {
       if (auto addPtrOp = dyn_cast<triton::AddPtrOp>(op)) {
         return parseAddPtr(addPtrOp, data, loc, rewriter, known);
@@ -484,7 +571,19 @@ BlockDataParser::parse(Value operand, BlockData &data, const Location &loc,
         // ptr_1 = tl.advance(ptr_0)
         return parseTensorPtr(advanceOp, data, loc, rewriter, known);
       } else if (auto intToPtrOp = dyn_cast<triton::IntToPtrOp>(op)) {
+        if (!isa<BaseMemRefType>(remappedPtr.getType())) {
+          return op->emitError(
+              "int_to_ptr did not convert to a memref carrier");
+        }
         data.setSource(remappedPtr);
+        // An address reconstructed from an i64 is a complete scalar pointer,
+        // but AddPtr still needs the ordinary one-element BlockData schema to
+        // form a memref.reinterpret_cast for a later load/store.  Without
+        // this identity view the generic path sees an empty rank and may
+        // attempt to materialize a pointer from a non-memref source.
+        data.getOffsetsRef().push_back(rewriter.getIndexAttr(0));
+        data.getSizesRef().push_back(rewriter.getIndexAttr(1));
+        data.getStridesRef().push_back(rewriter.getIndexAttr(1));
       } else if (isDistributedTypeCustomOp(op)) {
         data.setSource(remappedPtr);
       } else if (isScalarPointerTransport(op)) {
@@ -493,6 +592,13 @@ BlockDataParser::parse(Value operand, BlockData &data, const Location &loc,
               "scalar pointer transport did not convert to a memref");
         }
         data.setSource(remappedPtr);
+        // Transport producers carry a complete scalar address but do not
+        // expose BlockData dimensions. Model the address as a one-element
+        // identity view so a following addptr can add a scalar offset without
+        // falling into the rank-mismatch/materialization failure path.
+        data.getOffsetsRef().push_back(rewriter.getIndexAttr(0));
+        data.getSizesRef().push_back(rewriter.getIndexAttr(1));
+        data.getStridesRef().push_back(rewriter.getIndexAttr(1));
       } else {
         return op->emitError()
                << "unsupported scalar pointer producer '" << op->getName()
@@ -893,6 +999,25 @@ LogicalResult BlockDataParser::parseSplat(
   if (failed(parse(src, data, loc, rewriter, known)))
     return failure();
 
+  // A ScalarPointerCarrier stores the complete integer address passed to
+  // tt.int_to_ptr, so an addptr displacement exists only in BlockData and must
+  // survive the following splat. Ordinary scalar pointers already carry their
+  // displacement in the converted memref descriptor; retain the established
+  // behavior of resetting those offsets while constructing the tensor layout.
+  OpFoldResult splatOffset;
+  if (isa<triton::PointerType>(src.getType()) &&
+      isScalarPointerCarrierSource(data.getSource())) {
+    SmallVector<OpFoldResult> pointerOffsets = data.getOffsets();
+    if (pointerOffsets.size() > 1)
+      return op.emitOpError(
+          "scalar pointer carrier splat requires at most one BlockData offset");
+    splatOffset = pointerOffsets.empty()
+                      ? OpFoldResult(rewriter.getIndexAttr(0))
+                      : pointerOffsets.front();
+  } else if (data.isScalar()) {
+    splatOffset = data.getScalarRef();
+  }
+
   if (isa<IntegerType>(src.getType()) ||
       isa<triton::PointerType>(src.getType())) {
     if (!data.isEmpty()) {
@@ -908,9 +1033,8 @@ LogicalResult BlockDataParser::parseSplat(
   } else {
     return op.emitOpError("BlockDataParser does not support this splat source");
   }
-  if (data.isScalar()) {
-    data.getOffsetsRef()[0] = data.getScalarRef();
-  }
+  if (!splatOffset.isNull())
+    data.getOffsetsRef()[0] = splatOffset;
   return success();
 }
 
@@ -1416,7 +1540,8 @@ BlockDataParser::rewriteAddPtr(triton::AddPtrOp op,
   if (data.getMemAccTypeRef().isUnstructured() &&
       !isScalarPointerCarrierSource(data.getSource())) {
     // TODO: Based on more info, try to create a performant IR
-    rewriteAddPtrToUnstrucMemAcc(op, adaptor, rewriter, data);
+    if (failed(rewriteAddPtrToUnstrucMemAcc(op, adaptor, rewriter, data)))
+      return failure();
     LLVM_DEBUG({ llvm::dbgs() << *getModuleOpFromOperation(op) << "\n"; });
     return success();
   }
@@ -1496,13 +1621,16 @@ BlockDataParser::rewriteAddPtr(triton::AddPtrOp op,
 
   // ToDo: need to handle module scenario
 
-  memref::ReinterpretCastOp castOp =
+  FailureOr<memref::ReinterpretCastOp> castOp =
       data.createCastOp(resultShape, op.getLoc(), rewriter);
-  Value src = castOp.getResult();
+  if (failed(castOp))
+    return op.emitOpError(
+        "could not materialize a memref from the source type");
+  Value src = (*castOp).getResult();
   LLVM_DEBUG({
     llvm::dbgs() << "cast MemRefType:\n";
-    castOp.getOperation()->print(llvm::dbgs(),
-                                 OpPrintingFlags().printGenericOpForm());
+    (*castOp).getOperation()->print(llvm::dbgs(),
+                                    OpPrintingFlags().printGenericOpForm());
     llvm::dbgs() << "\n";
   });
 
@@ -1603,7 +1731,11 @@ FailureOr<Value> BlockDataParser::materializePointer(
     }
   }
 
-  return data.createCastOp(resultShape, ptr.getLoc(), rewriter).getResult();
+  FailureOr<memref::ReinterpretCastOp> castOp =
+      data.createCastOp(resultShape, ptr.getLoc(), rewriter);
+  if (failed(castOp))
+    return failure();
+  return (*castOp).getResult();
 }
 
 static FailureOr<OpFoldResult>
@@ -1668,13 +1800,21 @@ LogicalResult BlockDataParser::rewriteCustomOp(
       if (failed(parse(in, blockData, loc, rewriter, known)))
         return failure();
       convertIntToPtr(blockData);
-      curInput = blockData.createCastOp({ShapedType::kDynamic}, loc, rewriter);
+      FailureOr<memref::ReinterpretCastOp> castOp =
+          blockData.createCastOp({ShapedType::kDynamic}, loc, rewriter);
+      if (failed(castOp))
+        return failure();
+      curInput = (*castOp).getResult();
     } else if (auto tensor = llvm::dyn_cast<RankedTensorType>(in.getType())) {
       if (llvm::isa<triton::PointerType>(tensor.getElementType())) {
         if (failed(parse(in, blockData, loc, rewriter, known)))
           return failure();
         convertIntToPtr(blockData);
-        curInput = blockData.createCastOp(tensor.getShape(), loc, rewriter);
+        FailureOr<memref::ReinterpretCastOp> castOp =
+            blockData.createCastOp(tensor.getShape(), loc, rewriter);
+        if (failed(castOp))
+          return failure();
+        curInput = (*castOp).getResult();
       }
     }
     newInputs.emplace_back(curInput);
@@ -1716,10 +1856,9 @@ LogicalResult BlockDataParser::rewriteCustomOp(
 }
 
 // Design for load/store boundary_check.
-memref::ReinterpretCastOp createRedundantOp(triton::MakeTensorPtrOp op,
-                                            OpFoldResult sourceBaseOffset,
-                                            ConversionPatternRewriter &rewriter,
-                                            BlockData &data) {
+FailureOr<memref::ReinterpretCastOp>
+createRedundantOp(triton::MakeTensorPtrOp op, OpFoldResult sourceBaseOffset,
+                  ConversionPatternRewriter &rewriter, BlockData &data) {
   auto loc = op.getLoc();
   // to do boundary_check in tt.load, we need to keep the parent tensor's
   // shape info in the IR.
@@ -1915,17 +2054,23 @@ LogicalResult BlockDataParser::rewriteMakeTensorPtrOp(
 
   // special handling for davinci
   // create redundant reinterpret_cast op for record shape info
-  auto redundantOp = createRedundantOp(op, *sourceBaseOffset, rewriter, data);
-  redundantOp->setAttr("tensor_ptr_full_shape", rewriter.getUnitAttr());
+  FailureOr<memref::ReinterpretCastOp> redundantOp =
+      createRedundantOp(op, *sourceBaseOffset, rewriter, data);
+  if (failed(redundantOp))
+    return op.emitOpError("could not materialize the full tensor pointer");
+  (*redundantOp)->setAttr("tensor_ptr_full_shape", rewriter.getUnitAttr());
 
   // create reinterpret_cast op for the target block
-  data.setSource(redundantOp.getResult());
+  data.setSource((*redundantOp).getResult());
   known[op.getResult()] = data;
-  auto castOp = data.createCastOp(resultShape, loc, rewriter);
-  rewriter.replaceOp(op, castOp.getResult());
+  FailureOr<memref::ReinterpretCastOp> castOp =
+      data.createCastOp(resultShape, loc, rewriter);
+  if (failed(castOp))
+    return op.emitOpError("could not materialize the block pointer");
+  rewriter.replaceOp(op, (*castOp).getResult());
 
   if (nd2nzFlag) {
-    auto basePtr = castOp.getResult();
+    auto basePtr = (*castOp).getResult();
     int original_rank = op.getShape().size() + 1;
     std::string shapeStr;
 
@@ -2069,10 +2214,13 @@ LogicalResult BlockDataParser::rewriteAdvanceOp(
     assert(blockData.getRank() == 1);
   }
 
-  auto newOp = blockData.createCastOp(resultShape, loc, rewriter);
-  rewriter.replaceOp(op, newOp.getResult());
+  FailureOr<memref::ReinterpretCastOp> newOp =
+      blockData.createCastOp(resultShape, loc, rewriter);
+  if (failed(newOp))
+    return op.emitOpError("could not materialize the advanced pointer");
+  rewriter.replaceOp(op, (*newOp).getResult());
 
-  known[newOp.getResult()] = blockData;
+  known[(*newOp).getResult()] = blockData;
   return success();
 }
 
@@ -2360,6 +2508,34 @@ bool needsLegacyBlockDataLoopRewrite(LoopLikeOpInterface loopOp) {
       return containsLegacyTritonPointer(value.getType());
     });
   };
+
+  auto isScalarPointerValue = [](Value value) {
+    auto pointerType = dyn_cast<triton::PointerType>(value.getType());
+    return pointerType && !isa<ShapedType>(pointerType.getPointeeType());
+  };
+  auto isTensorPointerValue = [](Value value) {
+    auto pointerType = dyn_cast<triton::PointerType>(value.getType());
+    return pointerType && isa<ShapedType>(pointerType.getPointeeType());
+  };
+
+  SmallVector<Value> boundaryValues;
+  boundaryValues.append(loopOp.getInits().begin(), loopOp.getInits().end());
+  boundaryValues.append(loopOp.getRegionIterArgs().begin(),
+                        loopOp.getRegionIterArgs().end());
+  boundaryValues.append(loopOp->getResults().begin(),
+                        loopOp->getResults().end());
+  if (auto whileOp = dyn_cast<scf::WhileOp>(loopOp.getOperation()))
+    boundaryValues.append(whileOp.getAfterArguments().begin(),
+                          whileOp.getAfterArguments().end());
+
+  bool hasScalarPointer = llvm::any_of(boundaryValues, isScalarPointerValue);
+  bool hasTensorPointer = llvm::any_of(boundaryValues, isTensorPointerValue);
+  // An opaque scalar-pointer loop has no legacy BlockData schema.  Leave it
+  // untouched so the conversion driver reports an ordinary unsupported
+  // boundary instead of entering the descriptor parser with a non-memref
+  // source. Tensor-pointer loops continue through their established path.
+  if (hasScalarPointer && !hasTensorPointer)
+    return false;
 
   // Inspect the original SCF boundary, before the dialect converter remaps a
   // Triton pointer to a reinterpret-cast memref. Such loops still belong to the
@@ -2657,26 +2833,30 @@ BlockDataParser::rewriteLoopOp(LoopLikeOpInterface op,
 
       // In current block data layout info, strides and offsets must be dynamic
       // value
-      auto castOp = data.createCastOp(resultShape, op.getLoc(), rewriter);
+      FailureOr<memref::ReinterpretCastOp> castOp =
+          data.createCastOp(resultShape, op.getLoc(), rewriter);
+      if (failed(castOp))
+        return op.emitOpError(
+            "could not materialize a loop-carried memref from the source type");
       if (resultShape.size() > 1) {
         auto originalOffset = dyn_cast<Value>(data.getOffsetsRef()[0]);
         for (auto &offsets : newInitArgs) {
           if (offsets == originalOffset) {
-            offsets = castOp.getOffsets()[0];
+            offsets = (*castOp).getOffsets()[0];
             break;
           }
         }
-        data.getOffsetsRef()[0] = castOp.getOffsets()[0];
+        data.getOffsetsRef()[0] = (*castOp).getOffsets()[0];
       }
 
       LLVM_DEBUG({
         llvm::dbgs() << "new reinterpret_cast with dynamic sizes "
                         "and offsets:";
-        castOp->print(llvm::dbgs(), OpPrintingFlags().printGenericOpForm());
+        (*castOp).print(llvm::dbgs(), OpPrintingFlags().printGenericOpForm());
         llvm::dbgs() << "\n";
       });
 
-      newInitArgs[i] = castOp.getResult();
+      newInitArgs[i] = (*castOp).getResult();
     }
   }
 
@@ -2967,7 +3147,7 @@ BlockDataParser::rewriteLoopOp(LoopLikeOpInterface op,
 /// @param adaptor The adaptor of the triton::AddPtrOp, used to get operands.
 /// @param rewriter The pattern rewriter used to modify the IR.
 /// @param data The BlockData containing information about the memory access.
-void BlockDataParser::rewriteAddPtrToUnstrucMemAcc(
+LogicalResult BlockDataParser::rewriteAddPtrToUnstrucMemAcc(
     triton::AddPtrOp op, triton::AddPtrOp::Adaptor &adaptor,
     ConversionPatternRewriter &rewriter, BlockData &data) {
   auto loc = op.getLoc();
@@ -3006,6 +3186,7 @@ void BlockDataParser::rewriteAddPtrToUnstrucMemAcc(
     forSteps.push_back(oneIdx);
   }
   SmallVector<Value> ivs;
+  bool castFailed = false;
   OpBuilder builder(op);
   auto loop = createNestedLoops(
       builder, loc, 0, blockSizes.size(), forLBs, forUBs, forSteps, ivs,
@@ -3034,13 +3215,21 @@ void BlockDataParser::rewriteAddPtrToUnstrucMemAcc(
         data.getSizesRef().push_back(bB.getIndexAttr(1));
         data.getStridesRef().clear();
         data.getStridesRef().push_back(bB.getIndexAttr(1));
-        memref::ReinterpretCastOp castOp = data.createCastOp({1}, bLoc, bB);
-        rewriter.replaceOp(op, castOp);
+        FailureOr<memref::ReinterpretCastOp> castOp =
+            data.createCastOp({1}, bLoc, bB);
+        if (failed(castOp)) {
+          castFailed = true;
+          return;
+        }
+        rewriter.replaceOp(op, (*castOp).getResult());
         // Move tt.load using this tt.addptr into this block
-        loadOp->moveAfter(castOp);
+        loadOp->moveAfter((*castOp).getOperation());
         loadOp->setAttr("IndirectLoad", UnitAttr::get(op.getContext()));
         bB.create<scf::YieldOp>(bLoc, iterArgs);
       });
+  if (castFailed)
+    return op.emitOpError("could not materialize the indirect pointer source");
+  return success();
 }
 
 } // namespace triton

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -320,6 +320,9 @@ IfConverter::matchAndRewrite(scf::IfOp op, OpAdaptor adaptor,
     return rewriter.notifyMatchFailure(op, "requires a type converter");
   if (!hasScalarPointerResult(op))
     return failure();
+  if (!op->hasAttr(kScalarPointerCarrierBoundaryAttr))
+    return rewriter.notifyMatchFailure(
+        op, "scalar-pointer if is missing its carrier boundary marker");
 
   SmallVector<Type> convertedResultTypes;
   convertedResultTypes.reserve(op.getNumResults());

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -1041,8 +1041,8 @@ void TritonToLinalgPass::addDynamicLegal(
     Operation *parent = op->getParentOp();
     if (parent &&
         parent->hasAttr(TTOpConverters::kScalarPointerCarrierBoundaryAttr)) {
-      auto parentIf = cast<scf::IfOp>(parent);
-      return llvm::equal(op->getOperandTypes(), parentIf.getResultTypes());
+      if (auto parentIf = dyn_cast<scf::IfOp>(parent))
+        return llvm::equal(op->getOperandTypes(), parentIf.getResultTypes());
     }
 
     if (parent && parent->hasAttr(controlflow::kPointerDescriptorBoundaryAttr))
@@ -1669,8 +1669,8 @@ void TritonToLinalgPass::runOnOperation() {
     op->removeAttr(controlflow::kPointerDescriptorOffsetFormAttr);
     op->removeAttr(controlflow::kPointerDescriptorStructuredAxesAttr);
   });
-  moduleOp.walk([](scf::IfOp ifOp) {
-    ifOp->removeAttr(TTOpConverters::kScalarPointerCarrierBoundaryAttr);
+  moduleOp.walk([](Operation *op) {
+    op->removeAttr(TTOpConverters::kScalarPointerCarrierBoundaryAttr);
   });
 
   // 7.1 Workaround: fold duplicated one-hot reconstruction emitted after

--- a/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
@@ -268,6 +268,33 @@ bool isPointerDescriptorBoundarySlot(Operation *loop, unsigned slot) {
   return llvm::is_contained(slots.asArrayRef(), static_cast<int32_t>(slot));
 }
 
+bool isScalarPointerOffsetBoundarySlot(Operation *loop, unsigned slot) {
+  auto slots = dyn_cast_or_null<DenseI32ArrayAttr>(
+      loop->getAttr(kScalarPointerOffsetBoundaryAttr));
+  return slots &&
+         llvm::is_contained(slots.asArrayRef(), static_cast<int32_t>(slot));
+}
+
+bool isScalarPointerOffsetBoundaryRegionArgument(LoopLikeOpInterface loopOp,
+                                                 BlockArgument regionIterArg) {
+  if (auto whileOp = dyn_cast<scf::WhileOp>(loopOp.getOperation())) {
+    if (regionIterArg.getOwner() != whileOp.getBeforeBody() &&
+        regionIterArg.getOwner() != whileOp.getAfterBody())
+      return false;
+    return isScalarPointerOffsetBoundarySlot(loopOp.getOperation(),
+                                             regionIterArg.getArgNumber());
+  }
+
+  if (auto forOp = dyn_cast<scf::ForOp>(loopOp.getOperation())) {
+    if (regionIterArg.getOwner() != forOp.getBody() ||
+        regionIterArg.getArgNumber() == 0)
+      return false;
+    return isScalarPointerOffsetBoundarySlot(loopOp.getOperation(),
+                                             regionIterArg.getArgNumber() - 1);
+  }
+  return false;
+}
+
 bool isPointerDescriptorBoundaryRegionArgument(LoopLikeOpInterface loopOp,
                                                BlockArgument regionIterArg) {
   if (auto whileOp = dyn_cast<scf::WhileOp>(loopOp.getOperation())) {
@@ -390,6 +417,16 @@ void parseLoopRegionIterArg(LoopLikeOpInterface loopOp, const Location &loc,
                             RewriterBase &rewriter,
                             llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap,
                             BlockArgument regionIterArg) {
+  // This argument is a dynamic relative offset created by T2U.  Do not copy
+  // the loop init provenance here: doing so makes every backedge restart from
+  // the initial offset and drops the accumulated delta.  A scalar-like empty
+  // record lets parseAddPtr combine the live argument with the next delta.
+  if (isScalarPointerOffsetBoundaryRegionArgument(loopOp, regionIterArg)) {
+    offsetMap[regionIterArg] = PtrOffsetInfo();
+    offsetMap[regionIterArg].setScalarLike(true);
+    return;
+  }
+
   if (isScalarPointer(regionIterArg) &&
       isPointerDescriptorBoundaryRegionArgument(loopOp, regionIterArg)) {
     recordOpaqueScalarPointer(regionIterArg, offsetMap);

--- a/third_party/ascend/lib/TritonToUnstructure/ReplaceArguments.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/ReplaceArguments.cpp
@@ -33,6 +33,9 @@ using namespace triton;
 
 namespace {
 
+inline constexpr llvm::StringLiteral kScalarPointerCarrierBoundaryAttr =
+    "ScalarPointerCarrierBoundary";
+
 static bool isScalarPointerType(Type type) {
   auto pointerType = dyn_cast<triton::PointerType>(type);
   return pointerType && !isa<ShapedType>(pointerType.getPointeeType());
@@ -54,7 +57,44 @@ static bool useCompleteScalarAddress(Operation *loop, unsigned slot,
                                      Type type) {
   return loop && isa<scf::ForOp, scf::WhileOp>(loop) &&
          isScalarPointerType(type) &&
-         isPointerDescriptorBoundarySlot(loop, slot);
+         (isPointerDescriptorBoundarySlot(loop, slot) ||
+          loop->hasAttr(kScalarPointerCarrierBoundaryAttr));
+}
+
+// Record the exact loop slot whose block argument is changed from a scalar
+// pointer to an i64 relative offset.  The marker is deliberately attached to
+// the cloned SCF op rather than inferred later from type alone: ordinary i64
+// loop-carried values must retain their established analysis.
+static void markScalarPointerOffsetSlot(Value value) {
+  auto blockArg = dyn_cast<BlockArgument>(value);
+  if (!blockArg)
+    return;
+  Operation *owner = blockArg.getOwner()->getParentOp();
+  if (!owner)
+    return;
+
+  unsigned slot = 0;
+  if (auto forOp = dyn_cast<scf::ForOp>(owner)) {
+    if (blockArg.getOwner() != forOp.getBody() || blockArg.getArgNumber() == 0)
+      return;
+    slot = blockArg.getArgNumber() - 1;
+  } else if (auto whileOp = dyn_cast<scf::WhileOp>(owner)) {
+    if (blockArg.getOwner() != whileOp.getBeforeBody() &&
+        blockArg.getOwner() != whileOp.getAfterBody())
+      return;
+    slot = blockArg.getArgNumber();
+  } else {
+    return;
+  }
+
+  SmallVector<int32_t> slots;
+  if (auto existing = dyn_cast_or_null<DenseI32ArrayAttr>(
+          owner->getAttr(kScalarPointerOffsetBoundaryAttr)))
+    slots.append(existing.asArrayRef().begin(), existing.asArrayRef().end());
+  if (!llvm::is_contained(slots, static_cast<int32_t>(slot)))
+    slots.push_back(static_cast<int32_t>(slot));
+  owner->setAttr(kScalarPointerOffsetBoundaryAttr,
+                 DenseI32ArrayAttr::get(owner->getContext(), slots));
 }
 
 // A scalar-pointer SCF slot is represented by one complete i64 address on all
@@ -74,10 +114,153 @@ static bool hasScalarPointerBase(const PtrOffsetInfo &info) {
   return info.getPtr() && isScalarPointerType(info.getPtr().getType());
 }
 
+// A scalar pointer can use the established T2U offset representation only if
+// analysis found both a source pointer and a displacement.  An entry whose
+// source is the value itself is an opaque complete address (for example a
+// control-flow phi or a function argument), so choosing an offset for only
+// one edge would change the meaning of the other edges.
+static bool
+canRewriteScalarPointer(Value value, RewriterBase &rewriter,
+                        llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+  if (!isScalarPointerType(value.getType()))
+    return true;
+
+  parse(value, value.getLoc(), rewriter, offsetMap);
+  auto it = offsetMap.find(value);
+  if (it == offsetMap.end())
+    return false;
+  const PtrOffsetInfo &info = it->second;
+  return info.getPtr() && info.getOffset() && info.getPtr() != value;
+}
+
+// Decide the representation once for the complete SCF boundary.  The caller
+// passes this same decision to every init, region argument, yield, condition
+// operand, and result rewrite.  Thus a failed proof falls back atomically to
+// the pointer representation instead of producing a mixed-type boundary.
+static bool
+shouldPreserveScalarPointers(Operation *op, RewriterBase &rewriter,
+                             llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+  SmallVector<Value> boundaryValues;
+  if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+    boundaryValues.append(whileOp.getInits().begin(), whileOp.getInits().end());
+    boundaryValues.append(whileOp.getBeforeArguments().begin(),
+                          whileOp.getBeforeArguments().end());
+    boundaryValues.append(whileOp.getAfterArguments().begin(),
+                          whileOp.getAfterArguments().end());
+    boundaryValues.append(whileOp->getResults().begin(),
+                          whileOp->getResults().end());
+    boundaryValues.append(whileOp.getConditionOp().getArgs().begin(),
+                          whileOp.getConditionOp().getArgs().end());
+    boundaryValues.append(whileOp.getYieldOp()->getOperands().begin(),
+                          whileOp.getYieldOp()->getOperands().end());
+  } else if (auto loopOp = dyn_cast<LoopLikeOpInterface>(op)) {
+    boundaryValues.append(loopOp.getInits().begin(), loopOp.getInits().end());
+    boundaryValues.append(loopOp.getRegionIterArgs().begin(),
+                          loopOp.getRegionIterArgs().end());
+    boundaryValues.append(loopOp->getResults().begin(),
+                          loopOp->getResults().end());
+    boundaryValues.append(loopOp.getYieldedValues().begin(),
+                          loopOp.getYieldedValues().end());
+  } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+    boundaryValues.append(ifOp->getResults().begin(), ifOp->getResults().end());
+    boundaryValues.append(ifOp.thenYield().getResults().begin(),
+                          ifOp.thenYield().getResults().end());
+    if (ifOp.elseBlock())
+      boundaryValues.append(ifOp.elseYield().getResults().begin(),
+                            ifOp.elseYield().getResults().end());
+  } else {
+    return false;
+  }
+
+  for (Value value : boundaryValues) {
+    if (!isScalarPointerType(value.getType()))
+      continue;
+    if (!canRewriteScalarPointer(value, rewriter, offsetMap))
+      return true;
+  }
+  return false;
+}
+
+static bool hasScalarPointerResult(scf::IfOp op) {
+  return llvm::any_of(op->getResultTypes(),
+                      [](Type type) { return isScalarPointerType(type); });
+}
+
+static bool hasScalarPointerBoundary(Operation *op) {
+  SmallVector<Value> values;
+  if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+    values.append(whileOp.getInits().begin(), whileOp.getInits().end());
+    values.append(whileOp.getBeforeArguments().begin(),
+                  whileOp.getBeforeArguments().end());
+    values.append(whileOp.getAfterArguments().begin(),
+                  whileOp.getAfterArguments().end());
+    values.append(whileOp->getResults().begin(), whileOp->getResults().end());
+    values.append(whileOp.getConditionOp().getArgs().begin(),
+                  whileOp.getConditionOp().getArgs().end());
+    values.append(whileOp.getYieldOp()->getOperands().begin(),
+                  whileOp.getYieldOp()->getOperands().end());
+  } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+    values.append(forOp.getInitArgs().begin(), forOp.getInitArgs().end());
+    values.append(forOp.getRegionIterArgs().begin(),
+                  forOp.getRegionIterArgs().end());
+    values.append(forOp->getResults().begin(), forOp->getResults().end());
+    values.append(forOp.getYieldedValues().begin(),
+                  forOp.getYieldedValues().end());
+  } else {
+    return false;
+  }
+  return llvm::any_of(
+      values, [](Value value) { return isScalarPointerType(value.getType()); });
+}
+
+static void markOpaqueScalarPointerBoundary(Operation *op) {
+  if (hasScalarPointerBoundary(op))
+    op->setAttr(kScalarPointerCarrierBoundaryAttr,
+                UnitAttr::get(op->getContext()));
+}
+
+// `shouldPreserveScalarPointers` analyzes every value on the SCF boundary to
+// choose one representation.  When the choice is relative offsets, those
+// cached entries describe the old pointer-typed boundary and must be removed
+// before replaceArgs/replaceOperands rebuild the boundary.  Keeping even one
+// stale yield or result entry is enough to bypass the live backedge analysis.
+static void invalidateScalarPointerBoundaryAnalysis(
+    Operation *op, llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+  auto eraseScalarPointers = [&](ValueRange values) {
+    for (Value value : values)
+      if (isScalarPointerType(value.getType()))
+        offsetMap.erase(value);
+  };
+
+  if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+    eraseScalarPointers(whileOp.getInits());
+    eraseScalarPointers(whileOp.getBeforeArguments());
+    eraseScalarPointers(whileOp.getAfterArguments());
+    eraseScalarPointers(whileOp->getResults());
+    eraseScalarPointers(whileOp.getConditionOp().getArgs());
+    eraseScalarPointers(whileOp.getYieldOp()->getOperands());
+    return;
+  }
+  if (auto loopOp = dyn_cast<LoopLikeOpInterface>(op)) {
+    eraseScalarPointers(loopOp.getInits());
+    eraseScalarPointers(loopOp.getRegionIterArgs());
+    eraseScalarPointers(loopOp->getResults());
+    eraseScalarPointers(loopOp.getYieldedValues());
+    return;
+  }
+  if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+    eraseScalarPointers(ifOp->getResults());
+    eraseScalarPointers(ifOp.thenYield().getResults());
+    if (ifOp.elseBlock())
+      eraseScalarPointers(ifOp.elseYield().getResults());
+  }
+}
+
 } // namespace
 
 void replaceOperands(MutableArrayRef<OpOperand> oprs, RewriterBase &rewriter,
-                     llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+                     llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap,
+                     bool preserveScalarPointers) {
   for (auto it = oprs.begin(); it != oprs.end(); ++it) {
     auto &opr = *it;
     auto operand = opr.get();
@@ -92,6 +275,11 @@ void replaceOperands(MutableArrayRef<OpOperand> oprs, RewriterBase &rewriter,
         opr.set(info.getOffset());
     } else if (auto ptrType =
                    dyn_cast<triton::PointerType>(operand.getType())) {
+      // An unmarked scalar pointer has no complete structural carrier schema.
+      // Keep it as a pointer on every SCF edge instead of changing only this
+      // operand to a relative offset and invalidating the parent operation.
+      if (preserveScalarPointers && isScalarPointerType(operand.getType()))
+        continue;
       parse(operand, operand.getLoc(), rewriter, offsetMap);
       if (auto tensorType =
               dyn_cast<RankedTensorType>(ptrType.getPointeeType())) {
@@ -113,7 +301,8 @@ void replaceOperands(MutableArrayRef<OpOperand> oprs, RewriterBase &rewriter,
 }
 
 void replaceArgs(ValueRange args, RewriterBase &rewriter,
-                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap,
+                 bool preserveScalarPointers) {
   for (auto it = args.begin(); it != args.end(); ++it) {
     auto arg = *it;
     if (auto tensorType = dyn_cast<RankedTensorType>(arg.getType());
@@ -145,6 +334,10 @@ void replaceArgs(ValueRange args, RewriterBase &rewriter,
       rewriter.replaceOpWithNewOp<triton::AddPtrOp>(
           tempVar.getDefiningOp(), tempVar.getType(), src, arg);
     } else if (auto ptrType = dyn_cast<triton::PointerType>(arg.getType())) {
+      // Region arguments and results must use the same representation as the
+      // corresponding init/condition/yield operands.
+      if (preserveScalarPointers && isScalarPointerType(arg.getType()))
+        continue;
       parse(arg, arg.getLoc(), rewriter, offsetMap);
       if (!isa<RankedTensorType>(ptrType.getPointeeType()) &&
           offsetMap.at(arg).getPtr() == arg)
@@ -177,6 +370,7 @@ void replaceArgs(ValueRange args, RewriterBase &rewriter,
             srcOp.getShape(), srcOp.getStrides(), newOffsets, srcOp.getOrder());
       } else {
         auto src = offsetMap.at(arg).getPtr();
+        offsetMap.erase(arg);
         arg.setType(rewriter.getIntegerType(64));
         rewriter.replaceOpWithNewOp<triton::AddPtrOp>(
             tempVar.getDefiningOp(), tempVar.getType(), src, arg);
@@ -191,21 +385,56 @@ void convertTensorPtrPre(Operation *op, RewriterBase &rewriter,
     auto &os = llvm::dbgs();
     os << "[convertTensorPtr]: Preorder start\n" << *op << "\n";
   });
+  bool preserveScalarPointers =
+      shouldPreserveScalarPointers(op, rewriter, offsetMap);
+  if (!preserveScalarPointers)
+    invalidateScalarPointerBoundaryAnalysis(op, offsetMap);
+  SmallVector<Value> scalarPointerOffsetArgs;
   if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
-    replaceArgs(whileOp.getBeforeArguments(), rewriter, offsetMap);
-    replaceOperands(whileOp.getInitsMutable(), rewriter, offsetMap);
-    replaceArgs(whileOp.getAfterArguments(), rewriter, offsetMap);
-    replaceArgs(whileOp->getResults(), rewriter, offsetMap);
+    if (!preserveScalarPointers)
+      llvm::copy_if(whileOp.getBeforeArguments(),
+                    std::back_inserter(scalarPointerOffsetArgs), [](Value arg) {
+                      return isScalarPointerType(arg.getType());
+                    });
+    replaceArgs(whileOp.getBeforeArguments(), rewriter, offsetMap,
+                preserveScalarPointers);
+    replaceOperands(whileOp.getInitsMutable(), rewriter, offsetMap,
+                    preserveScalarPointers);
+    replaceArgs(whileOp.getAfterArguments(), rewriter, offsetMap,
+                preserveScalarPointers);
+    replaceArgs(whileOp->getResults(), rewriter, offsetMap,
+                preserveScalarPointers);
     replaceOperands(whileOp.getConditionOp().getArgsMutable(), rewriter,
-                    offsetMap);
+                    offsetMap, preserveScalarPointers);
   } else if (auto loopOp = dyn_cast<LoopLikeOpInterface>(op)) {
-    replaceArgs(loopOp.getRegionIterArgs(), rewriter, offsetMap);
-    replaceOperands(loopOp.getInitsMutable(), rewriter, offsetMap);
+    if (!preserveScalarPointers)
+      llvm::copy_if(loopOp.getRegionIterArgs(),
+                    std::back_inserter(scalarPointerOffsetArgs), [](Value arg) {
+                      return isScalarPointerType(arg.getType());
+                    });
+    replaceArgs(loopOp.getRegionIterArgs(), rewriter, offsetMap,
+                preserveScalarPointers);
+    replaceOperands(loopOp.getInitsMutable(), rewriter, offsetMap,
+                    preserveScalarPointers);
   } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
-    replaceArgs(ifOp->getResults(), rewriter, offsetMap);
-    replaceOperands(ifOp.thenYield().getResultsMutable(), rewriter, offsetMap);
-    replaceOperands(ifOp.elseYield().getResultsMutable(), rewriter, offsetMap);
+    if (preserveScalarPointers && hasScalarPointerResult(ifOp))
+      ifOp->setAttr(kScalarPointerCarrierBoundaryAttr,
+                    UnitAttr::get(ifOp.getContext()));
+    replaceArgs(ifOp->getResults(), rewriter, offsetMap,
+                preserveScalarPointers);
+    replaceOperands(ifOp.thenYield().getResultsMutable(), rewriter, offsetMap,
+                    preserveScalarPointers);
+    replaceOperands(ifOp.elseYield().getResultsMutable(), rewriter, offsetMap,
+                    preserveScalarPointers);
   }
+  // Publish the offset-carrier schema only after every structural edge has
+  // been rewritten. In particular, a While before argument and its paired
+  // after argument must both retain their original base provenance while they
+  // are converted. Publishing after the first region would make parsing the
+  // second region treat its still-pointer-typed argument as a base-less i64
+  // offset and attempt to rebuild tt.addptr from a null source.
+  for (Value arg : scalarPointerOffsetArgs)
+    markScalarPointerOffsetSlot(arg);
   LLVM_DEBUG({
     auto &os = llvm::dbgs();
     os << "[convertTensorPtr]: Preorder end\n" << *op << "\n";
@@ -218,11 +447,16 @@ void convertTensorPtrPost(Operation *op, RewriterBase &rewriter,
     auto &os = llvm::dbgs();
     os << "[convertTensorPtr]: Postorder start\n" << *op << "\n";
   });
+  bool preserveScalarPointers =
+      shouldPreserveScalarPointers(op, rewriter, offsetMap);
   if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
-    replaceOperands(whileOp.getYieldOp()->getOpOperands(), rewriter, offsetMap);
+    replaceOperands(whileOp.getYieldOp()->getOpOperands(), rewriter, offsetMap,
+                    preserveScalarPointers);
   } else if (auto loopOp = dyn_cast<LoopLikeOpInterface>(op)) {
-    replaceArgs(loopOp->getResults(), rewriter, offsetMap);
-    replaceOperands(*loopOp.getYieldedValuesMutable(), rewriter, offsetMap);
+    replaceArgs(loopOp->getResults(), rewriter, offsetMap,
+                preserveScalarPointers);
+    replaceOperands(*loopOp.getYieldedValuesMutable(), rewriter, offsetMap,
+                    preserveScalarPointers);
   }
   LLVM_DEBUG({
     auto &os = llvm::dbgs();
@@ -290,6 +524,15 @@ void replacePtrArguments(triton::FuncOp funcOp,
     // replacement immediately before the old op and erase the old op last.
     rewriter.setInsertionPoint(op);
     if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+      // An opaque scalar-pointer boundary cannot be represented by the
+      // relative-offset protocol: one edge may come from an if/select and
+      // therefore has no single static base.  Convert every scalar pointer
+      // slot to a complete i64 address before constructing the replacement
+      // loop, so the loop signature is pointer-free and T2L never has to
+      // materialize a pointer from an unresolved SCF value.
+      if (shouldPreserveScalarPointers(forOp.getOperation(), rewriter,
+                                       offsetMap))
+        markOpaqueScalarPointerBoundary(forOp.getOperation());
       SmallVector<Value> newInitArgs = constructOperands(
           forOp.getInitArgs(), tempVar, mapping, rewriter, forOp);
       newOp = rewriter.create<scf::ForOp>(
@@ -318,12 +561,20 @@ void replacePtrArguments(triton::FuncOp funcOp,
                                                      forOp));
           });
     } else if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+      // Keep ordinary While on the established relative-offset path.  Its
+      // before/after regions are analyzed again by convertTensorPtrPre after
+      // the clone, where the full boundary cache invalidation can observe the
+      // live backedge.  Complete i64 carriers are still selected for For and
+      // explicitly marked descriptor slots; applying the opaque fallback to
+      // every While here changes the two-region T2U contract before that
+      // reanalysis can run.
       SmallVector<Value> newInits = constructOperands(
           whileOp.getInits(), tempVar, mapping, rewriter, whileOp);
       newOp = rewriter.create<scf::WhileOp>(
           whileOp.getLoc(), constructTypes(whileOp->getResultTypes(), whileOp),
           newInits,
           [&](OpBuilder &b, Location loc, ValueRange args) {
+            IRMapping beforeMapping;
             auto newArgIter = args.begin();
             for (auto [slot, oldArg] :
                  llvm::enumerate(whileOp.getBeforeArguments())) {
@@ -331,21 +582,22 @@ void replacePtrArguments(triton::FuncOp funcOp,
               if (useCompleteScalarAddress(whileOp, slot, oldArg.getType()))
                 mappedArg =
                     rebuildScalarPointer(mappedArg, oldArg.getType(), b, loc);
-              mapping.map(oldArg, mappedArg);
+              beforeMapping.map(oldArg, mappedArg);
               std::advance(newArgIter,
                            std::max(getPtrTensorRank(oldArg.getType()), 1));
             }
             for (auto &bodyOp : whileOp.getBeforeBody()->without_terminator()) {
-              b.clone(bodyOp, mapping);
+              b.clone(bodyOp, beforeMapping);
             }
             auto conditionOp = whileOp.getConditionOp();
             b.create<scf::ConditionOp>(
                 conditionOp.getLoc(),
-                mapping.lookup(conditionOp.getCondition()),
-                constructOperands(conditionOp.getArgs(), tempVar, mapping, b,
-                                  whileOp));
+                beforeMapping.lookup(conditionOp.getCondition()),
+                constructOperands(conditionOp.getArgs(), tempVar, beforeMapping,
+                                  b, whileOp));
           },
           [&](OpBuilder &b, Location loc, ValueRange args) {
+            IRMapping afterMapping;
             auto newArgIter = args.begin();
             for (auto [slot, oldArg] :
                  llvm::enumerate(whileOp.getAfterArguments())) {
@@ -353,17 +605,17 @@ void replacePtrArguments(triton::FuncOp funcOp,
               if (useCompleteScalarAddress(whileOp, slot, oldArg.getType()))
                 mappedArg =
                     rebuildScalarPointer(mappedArg, oldArg.getType(), b, loc);
-              mapping.map(oldArg, mappedArg);
+              afterMapping.map(oldArg, mappedArg);
               std::advance(newArgIter,
                            std::max(getPtrTensorRank(oldArg.getType()), 1));
             }
             for (auto &bodyOp : whileOp.getAfterBody()->without_terminator()) {
-              b.clone(bodyOp, mapping);
+              b.clone(bodyOp, afterMapping);
             }
             auto yieldOp = whileOp.getYieldOp();
             b.create<scf::YieldOp>(yieldOp.getLoc(),
                                    constructOperands(yieldOp.getOperands(),
-                                                     tempVar, mapping, b,
+                                                     tempVar, afterMapping, b,
                                                      whileOp));
           });
     } else if (auto ifOp = dyn_cast<scf::IfOp>(op);

--- a/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
@@ -1215,6 +1215,11 @@ void TritonToUnstructurePass::runOnOperation() {
     signalPassFailure();
   }
 
+  // The offset-boundary marker is only an intra-pass analysis handoff.  Do
+  // not expose it to T2L or let it inhibit later canonicalization.
+  moduleOp->walk(
+      [](Operation *op) { op->removeAttr(kScalarPointerOffsetBoundaryAttr); });
+
   PassManager pm(&getContext(), moduleOp.getOperationName());
   pm.addPass(createCSEPass());
   pm.addPass(createCanonicalizerPass());

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scope_pointer_unsupported.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scope_pointer_unsupported.mlir
@@ -1,4 +1,4 @@
-// RUN: not triton-opt --triton-control-flow-opt %s -verify-each 2>&1 | FileCheck %s --check-prefix=ERR
+// RUN: triton-opt --triton-control-flow-opt %s -verify-each | FileCheck %s --check-prefix=FALLBACK
 
 module {
   tt.func public @scope_internal_opaque_tensor_pointer(%lhs_base: !tt.ptr<f32>, %rhs_base: !tt.ptr<f32>, %cond: i1) -> tensor<4x!tt.ptr<f32>> {
@@ -13,7 +13,8 @@ module {
   }
 }
 
-// ERR: failed to analyze pointer components across control flow
-// ERR-NOT: Assertion
-// ERR-NOT: LLVM ERROR
-// ERR-NOT: Segmentation fault
+// FALLBACK-LABEL: tt.func public @scope_internal_opaque_tensor_pointer
+// FALLBACK:       scope.scope
+// FALLBACK-SAME:  tensor<4x!tt.ptr<f32>>
+// FALLBACK:       arith.select
+// FALLBACK:       tt.return

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/tensor_pointer_descriptor_loop.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/tensor_pointer_descriptor_loop.mlir
@@ -1,4 +1,5 @@
-// RUN: triton-opt --triton-control-flow-opt --triton-to-unstructure --triton-to-linalg %s -verify-each | FileCheck %s
+// RUN: triton-opt --triton-control-flow-opt %s -verify-each | FileCheck %s --check-prefix=CFO
+// RUN: triton-opt --triton-control-flow-opt --triton-to-unstructure --triton-to-linalg %s -verify-each | FileCheck %s --check-prefix=LINALG
 
 module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
   tt.func public @tensor_pointer_descriptor_loop(
@@ -21,8 +22,14 @@ module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
   }
 }
 
-// CHECK-LABEL: func.func @tensor_pointer_descriptor_loop
-// CHECK:       scf.for
-// CHECK-SAME:  tensor<4xi32>
-// CHECK-NOT:   tensor<4x!tt.ptr
-// CHECK-NOT:   unrealized_conversion_cast
+// CFO-LABEL: tt.func public @tensor_pointer_descriptor_loop
+// CFO:       scf.for
+// CFO-SAME:  i32
+// CFO:       tt.addptr {{.*}}PointerDescriptorOffsetForm = "strided_1d"
+// CFO-SAME:  PointerDescriptorStructuredAxes = array<i32: 1>
+
+// LINALG-LABEL: func.func @tensor_pointer_descriptor_loop
+// LINALG:       scf.for
+// LINALG-SAME:  i32
+// LINALG-NOT:   tensor<4x!tt.ptr
+// LINALG-NOT:   unrealized_conversion_cast

--- a/third_party/ascend/unittest/pytest_ut/test_control_flow_pointer_boundary.py
+++ b/third_party/ascend/unittest/pytest_ut/test_control_flow_pointer_boundary.py
@@ -140,6 +140,20 @@ def scalar_base_tensor_ptr_loop_kernel(x, out, steps_ptr, n: tl.constexpr, BLOCK
 
 
 @triton.jit
+def dense_splat_tensor_ptr_loop_kernel(x, out, steps_ptr, n: tl.constexpr, BLOCK: tl.constexpr):
+    steps = tl.load(steps_ptr)
+    lane = tl.arange(0, BLOCK)
+    # Keep the loop delta tensor-valued so TTIR materializes a dense splat.
+    delta = tl.full((BLOCK, ), BLOCK, tl.int32)
+    pointers = x + lane
+    for _ in tl.range(0, steps):
+        pointers = pointers + delta
+    index = lane + BLOCK * steps
+    value = tl.load(pointers, mask=index < n, other=0.0)
+    tl.store(out + lane, value)
+
+
+@triton.jit
 def opaque_tensor_ptr_loop_kernel(a, b, out, steps_ptr, n: tl.constexpr, BLOCK: tl.constexpr):
     steps = tl.load(steps_ptr)
     lane = tl.arange(0, BLOCK)
@@ -262,6 +276,16 @@ def test_scalar_base_tensor_pointer_loop(steps):
     scalar_base_tensor_ptr_loop_kernel[(1, )](a, out, _device_i32(steps), n=N, BLOCK=BLOCK)
 
     _assert_output(out, _slice(a_cpu, 0, N, 1, 3 + 2 * steps))
+
+
+@pytest.mark.parametrize("steps", [0, 1, 3])
+def test_dense_splat_tensor_pointer_loop(steps):
+    a_cpu, _, a, _ = _inputs()
+    out = torch.empty(BLOCK, dtype=torch.float32, device="npu")
+
+    dense_splat_tensor_ptr_loop_kernel[(1, )](a, out, _device_i32(steps), n=N, BLOCK=BLOCK)
+
+    _assert_output(out, _slice(a_cpu, 0, N, 1, BLOCK * steps))
 
 
 @pytest.mark.parametrize("steps", [0, 2, 4])

--- a/third_party/ascend/unittest/pytest_ut/test_scalar_pointer_control_flow.py
+++ b/third_party/ascend/unittest/pytest_ut/test_scalar_pointer_control_flow.py
@@ -1,0 +1,208 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+import triton
+import triton.language as tl
+
+BLOCK = 16
+INPUT_SIZE = 256
+
+
+@triton.jit
+def scalar_pointer_if_kernel(x, out, predicate_ptr):
+    predicate = tl.load(predicate_ptr)
+    if predicate != 0:
+        pointer = x + 3
+    else:
+        pointer = x + 11
+    tl.store(out, tl.load(pointer))
+
+
+@triton.jit
+def scalar_pointer_for_kernel(x, out, steps_ptr):
+    steps = tl.load(steps_ptr)
+    pointer = x + 2
+    for _ in tl.range(0, steps):
+        pointer = pointer + 3
+    tl.store(out, tl.load(pointer))
+
+
+@triton.jit
+def scalar_pointer_while_kernel(x, out, steps_ptr):
+    steps = tl.load(steps_ptr)
+    pointer = x + 1
+    iteration = 0
+    while iteration < steps:
+        pointer = pointer + 2
+        iteration += 1
+    tl.store(out, tl.load(pointer))
+
+
+@triton.jit
+def scalar_pointer_nested_if_for_kernel(x, out, predicate_ptr, steps_ptr):
+    predicate = tl.load(predicate_ptr)
+    steps = tl.load(steps_ptr)
+    pointer = x
+    for iteration in tl.range(0, steps):
+        if (iteration & 1) == predicate:
+            pointer = pointer + 2
+        else:
+            pointer = pointer + 1
+    tl.store(out, tl.load(pointer))
+
+
+@triton.jit
+def scalar_pointer_select_loop_kernel(x0, x1, out, predicate_ptr, steps_ptr):
+    predicate = tl.load(predicate_ptr)
+    steps = tl.load(steps_ptr)
+    pointer = tl.where(predicate != 0, x0 + 4, x1 + 7)
+    for _ in tl.range(0, steps):
+        pointer = pointer + 2
+    tl.store(out, tl.load(pointer))
+
+
+@triton.jit
+def descriptor_boundary_scalar_kernel(x0, x1, out, steps_ptr, switch_at_ptr, N: tl.constexpr, BLOCK: tl.constexpr):
+    steps = tl.load(steps_ptr)
+    switch_at = tl.load(switch_at_ptr)
+    pointer = tl.make_block_ptr(
+        base=x0,
+        shape=(N, ),
+        strides=(1, ),
+        offsets=(0, ),
+        block_shape=(BLOCK, ),
+        order=(0, ),
+    )
+    for iteration in tl.range(0, steps):
+        if iteration == switch_at:
+            pointer = tl.make_block_ptr(
+                base=x1,
+                shape=(N, ),
+                strides=(1, ),
+                offsets=(4, ),
+                block_shape=(BLOCK, ),
+                order=(0, ),
+            )
+        else:
+            pointer = tl.advance(pointer, (1, ))
+    value = tl.load(pointer, boundary_check=(0, ), padding_option="zero")
+    tl.store(out + tl.arange(0, BLOCK), value)
+
+
+def _inputs():
+    x0_cpu = torch.arange(INPUT_SIZE, dtype=torch.float32)
+    x1_cpu = 1000.0 + 2.0 * torch.arange(INPUT_SIZE, dtype=torch.float32)
+    return x0_cpu, x1_cpu, x0_cpu.npu(), x1_cpu.npu()
+
+
+def _device_i32(value):
+    return torch.tensor([value], dtype=torch.int32, device="npu")
+
+
+def _assert_output(actual, expected):
+    torch.npu.synchronize()
+    torch.testing.assert_close(actual.cpu(), expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("predicate", [0, 1])
+def test_scalar_pointer_if_yield(predicate):
+    x0_cpu, _, x0, _ = _inputs()
+    out = torch.empty(1, dtype=torch.float32, device="npu")
+
+    scalar_pointer_if_kernel[(1, )](x0, out, _device_i32(predicate))
+
+    expected_index = 3 if predicate else 11
+    _assert_output(out, x0_cpu[expected_index:expected_index + 1])
+
+
+@pytest.mark.parametrize("steps", [0, 1, 4])
+def test_scalar_pointer_for_carried(steps):
+    x0_cpu, _, x0, _ = _inputs()
+    out = torch.empty(1, dtype=torch.float32, device="npu")
+
+    scalar_pointer_for_kernel[(1, )](x0, out, _device_i32(steps))
+
+    expected_index = 2 + 3 * steps
+    _assert_output(out, x0_cpu[expected_index:expected_index + 1])
+
+
+@pytest.mark.parametrize("steps", [0, 1, 5])
+def test_scalar_pointer_while_carried(steps):
+    x0_cpu, _, x0, _ = _inputs()
+    out = torch.empty(1, dtype=torch.float32, device="npu")
+
+    scalar_pointer_while_kernel[(1, )](x0, out, _device_i32(steps))
+
+    expected_index = 1 + 2 * steps
+    _assert_output(out, x0_cpu[expected_index:expected_index + 1])
+
+
+@pytest.mark.parametrize("predicate", [0, 1])
+@pytest.mark.parametrize("steps", [0, 1, 4])
+def test_scalar_pointer_nested_if_for(predicate, steps):
+    x0_cpu, _, x0, _ = _inputs()
+    out = torch.empty(1, dtype=torch.float32, device="npu")
+
+    scalar_pointer_nested_if_for_kernel[(1, )](x0, out, _device_i32(predicate), _device_i32(steps))
+
+    expected_index = sum(2 if (iteration & 1) == predicate else 1 for iteration in range(steps))
+    _assert_output(out, x0_cpu[expected_index:expected_index + 1])
+
+
+@pytest.mark.parametrize("predicate", [0, 1])
+@pytest.mark.parametrize("steps", [0, 3])
+def test_scalar_pointer_select_into_loop(predicate, steps):
+    x0_cpu, x1_cpu, x0, x1 = _inputs()
+    out = torch.empty(1, dtype=torch.float32, device="npu")
+
+    scalar_pointer_select_loop_kernel[(1, )](x0, x1, out, _device_i32(predicate), _device_i32(steps))
+
+    source = x0_cpu if predicate else x1_cpu
+    expected_index = (4 if predicate else 7) + 2 * steps
+    _assert_output(out, source[expected_index:expected_index + 1])
+
+
+@pytest.mark.parametrize("steps,switch_at", [(0, -1), (3, -1), (3, 1)])
+def test_descriptor_boundary_scalar_regression(steps, switch_at):
+    x0_cpu, x1_cpu, x0, x1 = _inputs()
+    out = torch.empty(BLOCK, dtype=torch.float32, device="npu")
+
+    descriptor_boundary_scalar_kernel[(1, )](
+        x0,
+        x1,
+        out,
+        _device_i32(steps),
+        _device_i32(switch_at),
+        N=INPUT_SIZE,
+        BLOCK=BLOCK,
+    )
+
+    source = x0_cpu
+    offset = 0
+    for iteration in range(steps):
+        if iteration == switch_at:
+            source = x1_cpu
+            offset = 4
+        else:
+            offset += 1
+    _assert_output(out, source[offset:offset + BLOCK])


### PR DESCRIPTION
## Summary

Integer dense splat offsets were treated as opaque tensor contributions by `TensorPtrDecompose`, even though every lane carries the same displacement. This forced tensor pointer loops to carry complete offset tensors and prevented the structured downstream path from being selected.

This change:

- recognizes static ranked integer `DenseIntElementsAttr` splats in rank-1 and rank-N tensor pointer analysis;
- materializes an exact same-width scalar constant from the original `APInt`, without truncating wide or negative values;
- keeps non-splat dense constants on the existing opaque fallback path;
- updates the descriptor-loop contract to require a scalar carrier and structured descriptor metadata; and
- adds a Triton DSL end-to-end test covering zero, single, and multiple loop iterations.

## Local checks

- `git diff --check`
- Python syntax compilation for `test_control_flow_pointer_boundary.py`

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] I have added tests.
- [x] I have not added any new `lit` test files.
