### PR TITLE
[simt-template](fix) trace shape-only pointer wrappers in indirect-load

### DIFF
--- a/third_party/ascend/lib/Utils/Utils.cpp
+++ b/third_party/ascend/lib/Utils/Utils.cpp
@@ -487,6 +487,10 @@ static std::optional<Value> getRootPointer(Value ptr) {
                 [](auto op) -> std::optional<Value> { return op.getPtr(); })
             .Case<triton::SplatOp>(
                 [](auto op) -> std::optional<Value> { return op.getSrc(); })
+            .Case<triton::BroadcastOp>(
+                [](auto op) -> std::optional<Value> { return op.getSrc(); })
+            .Case<triton::ExpandDimsOp>(
+                [](auto op) -> std::optional<Value> { return op.getSrc(); })
             .Case<triton::MakeTensorPtrOp>(
                 [](auto op) -> std::optional<Value> { return op.getBase(); })
             .Case<triton::AdvanceOp>(

--- a/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/indirect_load_rewrite.mlir
+++ b/third_party/ascend/unittest/Conversion/950PR/TritonToLinalg/indirect_load_rewrite.mlir
@@ -947,6 +947,48 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
 }
 
 // -----
+// CHECK-LABEL: func.func @indirect_load_broadcast_loop_carried_different_root
+// CHECK: call @triton_indirect_load{{.*}}(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {isVolatile = false} : (memref<?xf32>, tensor<4x8xi64>, tensor<4x8xi1>, tensor<4x8xf32>) -> tensor<4x8xf32>
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  tt.func public @indirect_load_broadcast_loop_carried_different_root(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                                                      %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                                                      %trip: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %row_stride = arith.constant dense<8> : tensor<4x1xi32>
+    %advance = arith.constant dense<32> : tensor<4x8xi32>
+    %zero = arith.constant dense<0.000000e+00> : tensor<4x8xf32>
+    %mask = arith.constant dense<true> : tensor<4x8xi1>
+    %rows = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %rows_2d = tt.expand_dims %rows {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
+    %row_offsets = arith.muli %rows_2d, %row_stride : tensor<4x1xi32>
+    %cols = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+    %cols_2d = tt.expand_dims %cols {axis = 0 : i32} : tensor<8xi32> -> tensor<1x8xi32>
+    %col_offsets = tt.broadcast %cols_2d : tensor<1x8xi32> -> tensor<4x8xi32>
+    %src_base_1d = tt.splat %arg0 : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %src_base = tt.expand_dims %src_base_1d {axis = 1 : i32} : tensor<4x!tt.ptr<f32>> -> tensor<4x1x!tt.ptr<f32>>
+    %src_rows = tt.addptr %src_base, %row_offsets : tensor<4x1x!tt.ptr<f32>>, tensor<4x1xi32>
+    %src_broadcast = tt.broadcast %src_rows : tensor<4x1x!tt.ptr<f32>> -> tensor<4x8x!tt.ptr<f32>>
+    %src_ptr = tt.addptr %src_broadcast, %col_offsets : tensor<4x8x!tt.ptr<f32>>, tensor<4x8xi32>
+    %dst_base_1d = tt.splat %arg1 : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %dst_base = tt.expand_dims %dst_base_1d {axis = 1 : i32} : tensor<4x!tt.ptr<f32>> -> tensor<4x1x!tt.ptr<f32>>
+    %dst_rows = tt.addptr %dst_base, %row_offsets : tensor<4x1x!tt.ptr<f32>>, tensor<4x1xi32>
+    %dst_broadcast = tt.broadcast %dst_rows : tensor<4x1x!tt.ptr<f32>> -> tensor<4x8x!tt.ptr<f32>>
+    %dst_ptr = tt.addptr %dst_broadcast, %col_offsets : tensor<4x8x!tt.ptr<f32>>, tensor<4x8xi32>
+    %result:2 = scf.for %i = %c0_i32 to %trip step %c1_i32
+        iter_args(%src_iter = %src_ptr, %dst_iter = %dst_ptr)
+        -> (tensor<4x8x!tt.ptr<f32>>, tensor<4x8x!tt.ptr<f32>>) : i32 {
+      %value = tt.load %src_iter, %mask, %zero {MixCompileDiscreteMask} : tensor<4x8x!tt.ptr<f32>>
+      tt.store %dst_iter, %value, %mask : tensor<4x8x!tt.ptr<f32>>
+      %src_next = tt.addptr %src_iter, %advance : tensor<4x8x!tt.ptr<f32>>, tensor<4x8xi32>
+      %dst_next = tt.addptr %dst_iter, %advance : tensor<4x8x!tt.ptr<f32>>, tensor<4x8xi32>
+      scf.yield %src_next, %dst_next : tensor<4x8x!tt.ptr<f32>>, tensor<4x8x!tt.ptr<f32>>
+    }
+    tt.return
+  }
+}
+
+// -----
 // V1 guard (make_tensor_ptr Load): only one tt.advance layer is supported.
 // A nested advance must stay on the legacy block-pointer lowering path.
 // CHECK-LABEL: func.func @mtpt_nested_advance_bails


### PR DESCRIPTION
## Summary

Fix indirect-load volatility analysis for pointer chains containing `tt.broadcast` or `tt.expand_dims`.

This MR:

- Extends root-pointer tracing through these shape-only operations.
- Adds a regression test covering broadcast pointers carried through an `scf.for`.
- Verifies that a store to a different GM root does not make the indirect load volatile.

## Background

The volatility analysis previously failed to recover the root pointer when a pointer tensor passed through `tt.broadcast`.

For affected kernels, the analysis conservatively produced `isVolatile = true` even when the indirect-load source had no possible writes. This prevented the SIMT indirect load from using the nonvolatile/cache-load path and caused a performance regression.

## Fix

`getRootPointer()` now unwraps:

- `triton::BroadcastOp`
- `triton::ExpandDimsOp`

Both operations only change the shape of a pointer tensor and preserve its underlying pointer root.

This allows the analysis to correctly distinguish the indirect-load source root from unrelated output roots, including when both pointers are carried through loop iter arguments.

The analysis remains conservative for unsupported pointer transformations, unknown write targets, and writes to the same root.

## Test case

- Added an MLIR regression case expecting `isVolatile = false` for a broadcast, loop-carried source pointer with a store to a different GM root.