### PR TITLE
[compiler](fix) restore deprecated compile option compatibility

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -179,7 +179,7 @@ def make_ttir(mod, metadata, opt):
         ascend.passes.ttir.add_graph_optimize(
             pm,
             ub_capacity_bytes=graph_ub_budget_bytes_for_arch(opt.target_arch),
-            compile_mode=opt.effective_compile_mode,
+            compile_mode=opt.compile_mode,
         )
     pm.run(mod, 'make_ttir')
     if opt.debug:
@@ -213,14 +213,7 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
         # Select analysis is a fixed lowering policy, not a user compile option.
         enable_select_analysis = True
         compile_on_910_95 = metadata["compile_on_910_95"]
-        # Use one effective lowering mode. It preserves an explicitly passed
-        # compile_mode; otherwise the direct force selectors choose their
-        # historical route.
-        compile_mode = getattr(
-            opt,
-            "effective_compile_mode",
-            getattr(opt, "compile_mode", "simd_simt_template"),
-        )
+        compile_mode = opt.compile_mode
         metadata["compile_mode"] = compile_mode
         enable_mixed_cv = metadata.get("enable_mixed_cv")
         disable_auto_inject_block_sync = metadata.get("disable_auto_inject_block_sync")
@@ -265,14 +258,12 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
             metadata["set_workspace_multibuffer"] = 0
             metadata["enable_mixed_cv"] = True
             metadata["disable_auto_inject_block_sync"] = True
-            # Cube block merge remains a backend-managed lowering policy.
-            ascend.passes.ttir.set_enable_cube_block_merge(False)
+            ascend.passes.ttir.set_enable_cube_block_merge(metadata["enable_cube_block_merge"])
 
             # Must run before add_dynamic_cv_pipeline because the driven
             # AddMultiBufferInnerScope pass reads the module-level
             # `ssbuffer.insertionOptimization` attribute (set here) at run time.
-            # Keep the existing default-on lowering behavior after removing
-            # the public compile option.
+            # Keep the existing default-on buffer insertion behavior.
             ascend.passes.ttir.set_enable_buffer_insert_optimization(mod)
             ascend.passes.ttir.add_dynamic_cv_pipeline(pm, compile_on_910_95)
 
@@ -718,6 +709,9 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
                 "--enable-hfusion-compile=true",
                 "--enable-triton-kernel-compile=true",
             ]
+        bisheng_options = metadata["bisheng_options"]
+        if bisheng_options is not None:
+            _compile_option_list += [f"--append-bisheng-options={bisheng_options}"]
         _compile_option_list += ["--mlir-print-ir-after-failure"]
         _compile_option_list += ["--mlir-print-stacktrace-on-diagnostic"]
         if opt.debug:
@@ -905,6 +899,10 @@ def linalg_to_bin_enable_npu_compile_A2_A3(linalg: str, metadata, opt):
                 _compile_option_list += \
                     [f"--link-aicore-bitcode={bitcode}"]
 
+        enable_libdevice = os.getenv("TRITON_ENABLE_LIBDEVICE", False)
+        if enable_libdevice:
+            _compile_option_list += [f"--link-aicore-bitcode={get_libdevice()}"]
+
         if _is_auto_map_parallel_blocks_enabled() and not metadata.get("has_auto_blockify_blacklist_op", False):
             _compile_option_list += ["--enable-auto-blockify-loop"]
         npu_compiler_path, env = _get_npucompiler_path()
@@ -967,17 +965,17 @@ def _is_a5_target_arch(arch: str) -> bool:
     return isinstance(arch, str) and arch.startswith(("Ascend910_95", "Ascend950"))
 
 
+def _get_libdevice_compile_state(arch: str) -> tuple[bool, bool]:
+    return (
+        bool(os.getenv("TRITON_ENABLE_LIBDEVICE", False)),
+        bool(os.getenv("TRITON_ENABLE_LIBDEVICE_SIMT", False)) and _is_a5_target_arch(arch),
+    )
+
+
 _CANONICAL_COMPILE_MODES = ("simd", "simd_simt_template", "simt_only")
 _COMPILE_MODE_ALIASES = {
     "unstructured_in_simt": "simd_simt_template",
 }
-
-
-class _DefaultCompileMode(str):
-    """Distinguish an omitted compile_mode from an explicit default value."""
-
-
-_DEFAULT_COMPILE_MODE = _DefaultCompileMode("simd_simt_template")
 
 
 def _normalize_compile_mode(compile_mode, arch: str) -> str:
@@ -1037,6 +1035,7 @@ class NPUOptions:
     allowed_dot_input_precisions: Tuple[str] = ("ieee", "hf32")
     max_num_imprecise_acc_default: int = 0
     extern_libs: dict = None
+    bisheng_options: str = "-cce-link-aicore-ll-module " + get_libdevice()
     multibuffer: bool = True
     vf_fusion_mode: str = None
     enable_ubuf_saving: bool = None
@@ -1061,6 +1060,7 @@ class NPUOptions:
     disable_auto_inject_block_sync: bool = None
     enable_mixed_cv: bool = None
     enable_dynamic_cv_pipeline: bool = None
+    enable_cube_block_merge: bool = False
     buf_slot_num_of_veccore: int = None
     buf_slot_num_of_crosscore: int = None
     buf_slot_num_of_gm: int = None
@@ -1072,10 +1072,6 @@ class NPUOptions:
     parallel_mode: str = field(default="simd", init=False)
     # Internal pure-SIMT state, derived from the effective lowering mode.
     is_pure_simt: bool = field(default=False, init=False)
-    # Retained public selectors. They apply only when compile_mode was not
-    # explicitly supplied by the caller.
-    force_simt_only: bool = False
-    force_simt_template: bool = False
     # Only takes effect on the pure-SIMT path.
     shared_mem_dynamic_size: int = None
     # A5 pure-SIMT-only option passed as -enable-bishengir-simt-optimization
@@ -1083,14 +1079,10 @@ class NPUOptions:
     enable_bishengir_simt_optimization: int = 000
     # Canonical modes: SIMD (D), SIMD with template-SIMT (P), and pure-SIMT
     # (T). ``unstructured_in_simt`` is an equivalent P spelling.
-    compile_mode: str = _DEFAULT_COMPILE_MODE
-    # Internal round-trip marker. The core compiler reconstructs NPUOptions
-    # from serialized metadata, so this preserves whether simd was explicit.
-    compile_mode_is_explicit: Optional[bool] = field(default=None, repr=False)
+    compile_mode: str = "simd_simt_template"
     simt_stack_limit: int = None
     # take effect on the reorder instruction pattern for SIMT. The pattern is disabled by default.
     enable_simt_reorder_instruction: bool = False
-    enable_costmodel_backend: bool = False
     # disable simt fma optimization to get high precision
     disable_fma: bool = False
 
@@ -1121,17 +1113,10 @@ class NPUOptions:
         if self.simt_stack_limit is not None:
             _validate_simt_stack_limit(self.simt_stack_limit)
 
-        compile_mode_is_explicit = self.compile_mode_is_explicit
-        if compile_mode_is_explicit is None:
-            compile_mode_is_explicit = self.compile_mode is not _DEFAULT_COMPILE_MODE
-        else:
-            compile_mode_is_explicit = bool(compile_mode_is_explicit)
-
         compile_mode = str(_normalize_compile_mode(self.compile_mode, arch))
         object.__setattr__(self, "compile_mode", compile_mode)
-        object.__setattr__(self, "compile_mode_is_explicit", compile_mode_is_explicit)
 
-        if self.effective_compile_mode == "simt_only":
+        if compile_mode == "simt_only":
             object.__setattr__(self, "is_pure_simt", True)
             object.__setattr__(self, "parallel_mode", "simt")
         else:
@@ -1142,17 +1127,6 @@ class NPUOptions:
                 object.__setattr__(self, "shared_mem_dynamic_size", 122880)
         else:
             object.__setattr__(self, "shared_mem_dynamic_size", 221184)
-
-    @property
-    def effective_compile_mode(self) -> str:
-        """Return the one lowering selector consumed after option parsing."""
-        if self.compile_mode_is_explicit:
-            return self.compile_mode
-        if self.force_simt_only:
-            return "simt_only"
-        if self.force_simt_template:
-            return "simd_simt_template"
-        return self.compile_mode
 
     def hash(self):
         key = "_".join([f"{name}-{val}" for name, val in self.__dict__.items()])
@@ -1172,6 +1146,19 @@ def _get_npu_options_arch(options: NPUOptions) -> str:
 
 
 NPUOptions.arch = property(_get_npu_options_arch)
+
+_INTERNAL_NPU_OPTION_MARKERS = frozenset({
+    "target_arch",
+    "compile_on_910_95",
+    "parallel_mode",
+    "is_pure_simt",
+})
+
+
+def _is_internal_npu_options(options, target_arch: str) -> bool:
+    """Recognize an NPUOptions metadata round trip by backend-only fields."""
+    return (_INTERNAL_NPU_OPTION_MARKERS <= options.keys() and options.get("target_arch") == target_arch
+            and options.get("compile_on_910_95") == _is_a5_target_arch(target_arch))
 
 
 def _normalize_bishengir_simt_optimization_for_context(options: NPUOptions, raw_options) -> None:
@@ -1231,6 +1218,10 @@ def ttir_to_npubin(mod, metadata, opt):
             if opt.disable_fma:
                 _compile_option_list += [f"--disable-fma"]
 
+            bisheng_options = metadata["bisheng_options"]
+            if bisheng_options is not None:
+                _compile_option_list += [f"--append-bisheng-options={bisheng_options}"]
+
             # Enable SIMT auto-blockify under the fixed automatic block-mapping
             # policy, mirroring the SIMD compile paths. driver.py's runtime
             # block-count cap keys off the same policy, so the two stay in sync.
@@ -1288,10 +1279,10 @@ class AscendBackend(BaseBackend):
 
     @staticmethod
     def use_alignment_specialization(options: dict) -> bool:
-        compile_mode_is_explicit = options.get("compile_mode_is_explicit", "compile_mode" in options)
-        if compile_mode_is_explicit:
-            return options["compile_mode"] == "simt_only"
-        return bool(options.get("force_simt_only", False))
+        # The binder runs before parse_options. Normalize its option copy so
+        # legacy selectors affect alignment specialization and the cache key.
+        normalized = _remove_deprecated_npu_options(options, in_place=True)
+        return normalized.get("compile_mode") == "simt_only"
 
     def __init__(self, target: GPUTarget) -> None:
         super().__init__(target)
@@ -1307,25 +1298,24 @@ class AscendBackend(BaseBackend):
             option_names = {
                 name
                 for name, option_field in NPUOptions.__dataclass_fields__.items()
-                if option_field.init and name not in {"arch", "compile_mode_is_explicit"}
+                if option_field.init and name != "arch"
             }
-            # JIT and AOT hand the complete, already-normalized dataclass back to
-            # parse_options before compilation.  Those values are internal state,
-            # not a second batch of user overrides.
-            internal_options = option_names <= opts.keys()
+            # Serialized NPUOptions include backend-only derived fields.  Use
+            # those provenance markers instead of depending on every public
+            # field being present, which changes whenever the dataclass evolves.
+            internal_options = _is_internal_npu_options(opts, self.target.arch)
             # JIT validates the same dictionary after this call.  Remove public
             # compatibility keys in place so Ascend can accept them without
             # requiring any change to the community JIT implementation.
             normalized_opts = opts if internal_options else _remove_deprecated_npu_options(opts, in_place=True)
             args = {k: normalized_opts[k] for k in option_names if k in normalized_opts}
-            if internal_options and "compile_mode_is_explicit" in normalized_opts:
-                args["compile_mode_is_explicit"] = normalized_opts["compile_mode_is_explicit"]
             options = NPUOptions(arch=self.target.arch, **args)
             # Lazy init enable_dynamic_cv_pipeline if not provided.
             # compile_on_910_95 is already resolved from the requested target.
             if options.enable_dynamic_cv_pipeline is None:
                 object.__setattr__(options, "enable_dynamic_cv_pipeline", options.compile_on_910_95)
-            _normalize_bishengir_simt_optimization_for_context(options, opts)
+            if not internal_options:
+                _normalize_bishengir_simt_optimization_for_context(options, opts)
         else:
             raise NotImplementedError(f"Backend '{self.target.backend}' is not supported. "
                                       "Please ensure the target backend is set to 'npu'.")
@@ -1390,7 +1380,7 @@ class AscendBackend(BaseBackend):
     @functools.lru_cache()
     def hash(self):
         # TODO fetch compiler version
-        version_key = self.target
+        version_key = (self.target, _get_libdevice_compile_state(self.target.arch))
         return str(version_key)
 
     def get_module_map(self) -> Dict[str, ModuleType]:

--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -42,7 +42,8 @@ from torch import Tensor
 
 import triton
 from triton.runtime.autotuner import Autotuner, Config
-from triton.backends.ascend.utils import (_InternalNPUOptionInt, _remove_deprecated_npu_options, is_compile_on_910_95)
+from triton.backends.ascend.utils import (_InternalNPUOptionInt, _remove_deprecated_npu_options,
+                                          _RESERVED_NPU_OPTION_NAMES, is_compile_on_910_95)
 
 from .autoparser import (LowDimsAxesParser, PtrNumsParser, ReductionAxesParser, SplitAxesParser, TilingAxesParser)
 from .dsl_analysis.cv_param_parser import parse_cv_params
@@ -71,6 +72,12 @@ _RESERVED_HINT_KEYS = {
     "vv_parser_v2_mode",
 }
 _DEFAULT_HINT_NUM_STAGES = [1, 2]
+_DEFAULT_COMPILE_MODE = "simd_simt_template"
+
+
+def _inject_default_simt_stack_limit(options: Dict[str, object], stack_limit: int) -> None:
+    if options.get("compile_mode") == "simt_only" and options.get("simt_stack_limit") is None:
+        options["simt_stack_limit"] = stack_limit
 
 
 def _get_constexpr_candidates_from_fn(fn) -> List[str]:
@@ -123,12 +130,12 @@ def _clone_config_with_kwargs(
     )
 
 
-def _normalize_user_configs(configs, *, protected=()):
+def _normalize_user_configs(configs):
     if not configs:
         return configs
     normalized_configs = []
     for config in configs:
-        normalized_kwargs = _remove_deprecated_npu_options(config.kwargs, protected=protected)
+        normalized_kwargs = _remove_deprecated_npu_options(config.kwargs)
         if normalized_kwargs == config.kwargs:
             normalized_configs.append(config)
             continue
@@ -136,6 +143,13 @@ def _normalize_user_configs(configs, *, protected=()):
         normalized_config.kwargs = normalized_kwargs
         normalized_configs.append(normalized_config)
     return normalized_configs
+
+
+def _validate_reserved_npu_option_names(arg_names) -> None:
+    conflicts = sorted(set(arg_names) & _RESERVED_NPU_OPTION_NAMES)
+    if conflicts:
+        raise ValueError("Kernel parameters cannot use reserved Ascend compile-option names: {}.".format(
+            ", ".join(conflicts)))
 
 
 def _split_hints(hints: Optional[Dict[str, object]]):
@@ -258,9 +272,9 @@ class AutoTilingTuner(Autotuner):
             and trigger re-evaluation of candidate configs.
         :type key: List[str]
         """
-        constexpr_names = _get_constexpr_candidates_from_fn(fn)
-        hints = _remove_deprecated_npu_options(hints or {}, protected=constexpr_names)
-        configs = _normalize_user_configs(configs, protected=constexpr_names)
+        _validate_reserved_npu_option_names(arg_names)
+        hints = _remove_deprecated_npu_options(hints or {})
+        configs = _normalize_user_configs(configs)
         _validate_user_hints(fn, hints)
         reserved_hints, config_hints = _split_hints(hints)
         config_hints = _normalize_config_hints(
@@ -1994,11 +2008,8 @@ class AutoTilingTuner(Autotuner):
 
     def generate_key_and_configs(self, *args, **kwargs):
         self.nargs = dict(zip(self.arg_names, args))
-        compile_mode_is_explicit = kwargs.get("compile_mode_is_explicit", "compile_mode" in kwargs)
-        if compile_mode_is_explicit:
-            self.is_simt_mode = kwargs.get("compile_mode") == "simt_only"
-        else:
-            self.is_simt_mode = bool(kwargs.get("force_simt_only", False))
+        compile_mode = kwargs.get("compile_mode", _DEFAULT_COMPILE_MODE)
+        self.is_simt_mode = compile_mode == "simt_only"
         if 'num_warps' in kwargs and kwargs['num_warps'] is not None:
             self.user_specified_warps = kwargs['num_warps']
         else:
@@ -2025,6 +2036,7 @@ class AutoTilingTuner(Autotuner):
                 dtype = (arg.dtype if get_byte_per_numel(arg.dtype) >= get_byte_per_numel(dtype) else dtype)
         if dtype is None:
             raise NotImplementedError("Not support for non-Tensor inputs")
+        key.append(("compile_mode", compile_mode))
 
         key = tuple(key)
         if key not in self.cache:
@@ -2077,12 +2089,11 @@ class AutoTilingTuner(Autotuner):
             kwargs["grid_num_tiles"] = _InternalNPUOptionInt(outermost)
 
     def run(self, *args, **kwargs):
-        kwargs = _remove_deprecated_npu_options(kwargs, protected=self.arg_names)
+        kwargs = _remove_deprecated_npu_options(kwargs)
         self._inject_grid_num_tiles(kwargs)
         key = self.generate_key_and_configs(*args, **kwargs)
         cache_miss = key not in self.cache
-        if self.is_simt_mode and kwargs.get('simt_stack_limit', None) is None:
-            kwargs['simt_stack_limit'] = self.simt_stack_limit
+        _inject_default_simt_stack_limit(kwargs, self.simt_stack_limit)
         did_benchmark = False
         disk_cache_hit = False
         if cache_miss:
@@ -2133,12 +2144,11 @@ class AutoTilingTuner(Autotuner):
         if did_benchmark and self.auto_profile_dir is not None:
             self._profile(*args, config=self.best_config, **kwargs)
         ub_cfg = dict(getattr(config, "ubtune_cfg", {}))
-        if config.pre_hook is not None:
-            full_nargs = {**self.nargs, **kwargs, **config.all_kwargs()}
-            full_nargs.update(ub_cfg)
-            config.pre_hook(full_nargs)
         final_kwargs = dict(config.all_kwargs(), **kwargs)
         final_kwargs.update(ub_cfg)
+        _inject_default_simt_stack_limit(final_kwargs, self.simt_stack_limit)
+        if config.pre_hook is not None:
+            config.pre_hook({**self.nargs, **final_kwargs})
         try:
             ret = self.fn.run(
                 *args,
@@ -2289,6 +2299,7 @@ class AutoTilingTuner(Autotuner):
         ub_cfg = dict(getattr(config, "ubtune_cfg", {}))
         if ub_cfg:
             current.update(ub_cfg)
+        _inject_default_simt_stack_limit(current, self.simt_stack_limit)
         full_nargs = {**self.nargs, **current}
 
         def kernel_call(warmup):
@@ -2321,11 +2332,17 @@ class AutoTilingTuner(Autotuner):
         return kernel_call
 
     def warmup(self, *args, **kwargs):
-        kwargs = _remove_deprecated_npu_options(kwargs, protected=self.arg_names)
+        kwargs = _remove_deprecated_npu_options(kwargs)
         self._inject_grid_num_tiles(kwargs)
         _ = self.generate_key_and_configs(*args, **kwargs)
         pruned_configs = self.prune_configs(kwargs)
         ret = []
+
+        def warmup_config(config):
+            compile_options = dict(config.all_kwargs(), **kwargs)
+            _inject_default_simt_stack_limit(compile_options, self.simt_stack_limit)
+            return self.fn.warmup(*args, **compile_options)
+
         if self.compile_parallel:
             import psutil
 
@@ -2335,10 +2352,10 @@ class AutoTilingTuner(Autotuner):
                     triton.AsyncCompileMode(executor),
             ):
                 for config in pruned_configs:
-                    ret.append(self.fn.warmup(*args, **kwargs, **config.all_kwargs()))
+                    ret.append(warmup_config(config))
         else:
             for config in pruned_configs:
-                ret.append(self.fn.warmup(*args, **kwargs, **config.all_kwargs()))
+                ret.append(warmup_config(config))
         self.nargs = None
         return ret
 

--- a/third_party/ascend/backend/runtime/ubtuner.py
+++ b/third_party/ascend/backend/runtime/ubtuner.py
@@ -565,9 +565,14 @@ class UBTuner(KernelInterface):
         """Create NPUOptions from metadata."""
         from triton.backends.ascend.compiler import NPUOptions
         try:
-            npu_option_keys = {f.name for f in NPUOptions.__dataclass_fields__.values()}
+            npu_option_keys = {
+                field.name
+                for field in NPUOptions.__dataclass_fields__.values()
+                if field.init and field.name != "arch"
+            }
             opts_dict = {k: v for k, v in metadata.items() if k in npu_option_keys}
-            return NPUOptions(**opts_dict)
+            target_arch = metadata.get("target_arch", metadata.get("arch", ""))
+            return NPUOptions(arch=target_arch, **opts_dict)
         except Exception as e:
             _log_debug(f"Failed to create NPUOptions: {e}")
             return None

--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -33,9 +33,11 @@ from triton.backends.ascend.backend_register import backend_strategy_registry
 
 import pybind11
 
-# Phase-one compatibility boundary for compile-option cleanup.  Keep the
-# existing NPUOptions fields and their internal consumers intact while public
-# dictionaries route supported aliases and drop backend-managed fields.
+_is_compile_on_910_95 = None
+
+# Compatibility boundary for compile-option cleanup.  Public dictionaries
+# route renamed options and discard backend-managed options before community
+# JIT validates the remaining keys.
 _DEPRECATED_NPU_OPTIONS = frozenset({
     "add_auto_scheduling",
     "allow_fp8e4nv",
@@ -50,6 +52,7 @@ _DEPRECATED_NPU_OPTIONS = frozenset({
     "enable_cce_vf_auto_sync",
     "enable_cce_vf_remove_membar",
     "enable_cross_if_fusion",
+    "enable_costmodel_backend",
     "enable_drop_unit_dims",
     "enable_linearize",
     "enable_mask_fallback_conversion",
@@ -58,13 +61,19 @@ _DEPRECATED_NPU_OPTIONS = frozenset({
     "enable_sync_block_lock",
     "enable_ub_refine_opt",
     "enable_vf_fusion",
+    "force_simt_only",
+    "force_simt_template",
     "graph_optimize_emit_remarks",
     "graph_optimize_max_rewrites_per_function",
     "graph_optimize_rule_mask",
     "graph_optimize_ub_capacity_bytes",
+    "grid_num_tiles",
     "has_auto_blockify_blacklist_op",
     "hfusion_enable_multiple_consumer_fusion",
+    "inter_cache_num",
+    "intra_cache_num",
     "kernel_name",
+    "load_cache_num",
     "llvm_version",
     "mix_mode",
     "ops_reorder",
@@ -76,6 +85,27 @@ _DEPRECATED_NPU_OPTIONS = frozenset({
     "vf_merge_level",
     "warp_size",
 })
+
+# These names remain reserved while the compatibility layer accepts them as
+# deprecated compile options.  Kernel parameters, including tl.constexpr
+# parameters supplied through autotune configs, must not reuse them.
+_RESERVED_NPU_OPTION_NAMES = _DEPRECATED_NPU_OPTIONS
+_WARNED_DEPRECATED_NPU_OPTIONS = set()
+
+# Boolean compatibility switches route only their enabled state.  False keeps
+# the canonical compile_mode supplied by the user or its backend default.
+_DEPRECATED_NPU_OPTION_ROUTES = {
+    "force_simt_only": ("compile_mode", "simt_only"),
+    "force_simt_template": ("compile_mode", "simd_simt_template"),
+}
+
+# Renamed value options preserve the complete user value.  A simultaneously
+# supplied canonical option wins via setdefault below.
+_DEPRECATED_NPU_OPTION_ALIASES = {
+    "intra_cache_num": "buf_slot_num_of_veccore",
+    "inter_cache_num": "buf_slot_num_of_crosscore",
+    "load_cache_num": "buf_slot_num_of_gm",
+}
 
 _DEPRECATED_ASCEND_ENV_VARS = frozenset({
     "LLVM_ROOT",
@@ -107,8 +137,20 @@ def _get_deprecated_npu_options(options) -> set[str]:
 
 
 def _warn_deprecated_npu_option(name: str) -> None:
-    message = (f"Ascend compile option '{name}' is deprecated and ignored; "
-               "the backend-managed/default behavior is used instead.")
+    if name in _WARNED_DEPRECATED_NPU_OPTIONS:
+        return
+    _WARNED_DEPRECATED_NPU_OPTIONS.add(name)
+    route = _DEPRECATED_NPU_OPTION_ROUTES.get(name)
+    alias = _DEPRECATED_NPU_OPTION_ALIASES.get(name)
+    if route is not None:
+        replacement_name, replacement_value = route
+        message = (f"Ascend compile option '{name}' is deprecated; "
+                   f"use {replacement_name}={replacement_value!r} instead.")
+    elif alias is not None:
+        message = f"Ascend compile option '{name}' is deprecated; use '{alias}' instead."
+    else:
+        message = (f"Ascend compile option '{name}' is deprecated and ignored; "
+                   "the backend-managed/default behavior is used instead.")
     warnings.warn(
         message,
         FutureWarning,
@@ -116,12 +158,19 @@ def _warn_deprecated_npu_option(name: str) -> None:
     )
 
 
-def _remove_deprecated_npu_options(options, *, protected=(), in_place=False):
-    """Normalize and remove deprecated public NPU options, copying by default."""
+def _remove_deprecated_npu_options(options, *, in_place=False):
+    """Normalize reserved legacy NPU options, copying by default."""
     normalized = options if in_place else dict(options)
-    deprecated = _get_deprecated_npu_options(normalized) - set(protected)
+    deprecated = _get_deprecated_npu_options(normalized)
     for name in sorted(deprecated):
         _warn_deprecated_npu_option(name)
+        route = _DEPRECATED_NPU_OPTION_ROUTES.get(name)
+        if route is not None and normalized[name]:
+            replacement_name, replacement_value = route
+            normalized.setdefault(replacement_name, replacement_value)
+        alias = _DEPRECATED_NPU_OPTION_ALIASES.get(name)
+        if alias is not None:
+            normalized.setdefault(alias, normalized[name])
         normalized.pop(name)
     return normalized
 
@@ -144,9 +193,21 @@ def _warn_deprecated_ascend_env_vars() -> None:
         _warn_deprecated_ascend_env_var(name)
 
 
-def is_compile_on_910_95(arch: str) -> bool:
-    """Return whether the explicit compilation target belongs to the A5 generation."""
-    return isinstance(arch, str) and arch.startswith(("Ascend910_95", "Ascend950"))
+def is_compile_on_910_95(arch: str = None) -> bool:
+    """Return whether the compilation target belongs to the A5 generation."""
+    if arch is not None:
+        return isinstance(arch, str) and arch.startswith(("Ascend910_95", "Ascend950"))
+
+    global _is_compile_on_910_95
+    if _is_compile_on_910_95 is None:
+        try:
+            import acl
+            name_lower = acl.get_soc_name().lower()
+            _is_compile_on_910_95 = ("ascend910_95" in name_lower or "ascend950" in name_lower
+                                     or "910_958b" in name_lower)
+        except (ImportError, AttributeError):
+            _is_compile_on_910_95 = False
+    return _is_compile_on_910_95
 
 
 AUTO_BLOCKIFY_BLACKLIST_RULES = (
@@ -666,6 +727,11 @@ def is_ffts_supported(arch: str):
 def force_disable_ffts(arch: str) -> bool:
     """Return whether the selected target requires FFTS to be disabled."""
     return is_compile_on_910_95(arch)
+
+
+def triton_enable_libdevice_simt(arch: str = None) -> bool:
+    """Return whether the environment switch selects SIMT libdevice."""
+    return bool(os.getenv("TRITON_ENABLE_LIBDEVICE_SIMT", False)) and is_compile_on_910_95(arch)
 
 
 def get_cann_version_file_hash():

--- a/third_party/ascend/language/cann/libdevice.py
+++ b/third_party/ascend/language/cann/libdevice.py
@@ -22,21 +22,15 @@ from math import pi as math_pi
 from triton.language import core, math, semantic, standard
 from triton._C.libtriton import ir
 from triton.runtime.jit import jit
-from triton.backends.ascend.utils import is_compile_on_910_95
+from triton.backends.ascend.utils import is_compile_on_910_95, triton_enable_libdevice_simt
 
 
 def _is_libdevice_simt_enabled(_semantic) -> bool:
-    """Enable the SIMT libdevice implementation for A5 pure-SIMT compilation.
+    return triton_enable_libdevice_simt(_semantic.builder.options.arch)
 
-    ``AscendBackend.parse_options`` injects ``GPUTarget.arch`` into
-    ``NPUOptions``.  The builder's established ``options.arch`` view exposes
-    that internal target without serializing a second architecture field.
-    Template-SIMT lowering keeps the language builder in SIMD mode, so only
-    an effective pure-SIMT selection may select SIMT libdevice symbols.
-    """
-    options = _semantic.builder.options
-    return is_compile_on_910_95(options.arch) and (getattr(options, "is_pure_simt", False)
-                                                   or getattr(options, "compile_mode", "simd") == "simt_only")
+
+def _is_a5_target(_semantic) -> bool:
+    return is_compile_on_910_95(_semantic.builder.options.arch)
 
 
 class _FlipStaticRange:
@@ -375,7 +369,7 @@ def pow(arg0, arg1, _semantic=None):
     if arg1.dtype == core.dtype("int32"):
         arg1 = _semantic.cast(arg1, arg0.dtype)
 
-    if arg0.dtype == core.dtype("fp32") and _is_libdevice_simt_enabled(_semantic):
+    if arg0.dtype == core.dtype("fp32") and _is_a5_target(_semantic):
         return core.extern_elementwise("", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_pow_fp32", core.dtype("fp32")),
         }, is_pure=True, _semantic=_semantic)
@@ -517,7 +511,7 @@ def sad(arg0, arg1, arg2, _semantic=None):
 def ffs(arg0, _semantic=None):
     arg0 = _semantic.to_tensor(arg0)
     dtype = arg0.dtype
-    if _is_libdevice_simt_enabled(_semantic):
+    if _is_a5_target(_semantic):
         return core.extern_elementwise(
             "", "", [arg0], {
                 (core.dtype("int32"), ): ("__hmf_ffs_i32", core.dtype("int32")),
@@ -1505,7 +1499,7 @@ def acos(arg0: core.tensor, _semantic=None):
     :param arg0: The input tensor. Supported dtypes: fp32, fp16, bf16.
     :type arg0: tl.tensor
     """
-    if arg0.dtype == core.dtype("fp32") and _is_libdevice_simt_enabled(_semantic):
+    if arg0.dtype == core.dtype("fp32") and _is_a5_target(_semantic):
         return core.extern_elementwise("", "", [arg0], {
             (core.dtype("fp32"), ): ("__hmf_acos_fp32", core.dtype("fp32")),
         }, is_pure=True, _semantic=_semantic)
@@ -1733,7 +1727,7 @@ def nextafter(arg0: core.tensor, arg1: core.tensor, _semantic=None):
     :param arg1: The direction value tensor. Supported dtypes: fp32, fp16, bf16.
     :type arg1: tl.tensor
     """
-    if arg0.dtype == core.dtype("fp32") and _is_libdevice_simt_enabled(_semantic):
+    if arg0.dtype == core.dtype("fp32") and _is_a5_target(_semantic):
         return core.extern_elementwise("", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_nextafter_fp32", core.dtype("fp32")),
         }, is_pure=True, _semantic=_semantic)
@@ -2583,7 +2577,7 @@ def rint(arg0: core.tensor, _semantic=None):
     :type arg0: tl.tensor
     """
     arg0 = _semantic.to_tensor(arg0)
-    if _is_libdevice_simt_enabled(_semantic):
+    if _is_a5_target(_semantic):
         if arg0.dtype != core.dtype("fp32"):
             arg0 = _semantic.cast(arg0, core.dtype("fp32"))
         return core.extern_elementwise("", "", [
@@ -2923,7 +2917,7 @@ def rsqrt(arg0, _semantic=None):
 @math._add_math_1arg_docstr("sine")
 def sin(arg0, _semantic=None):
     arg0 = _semantic.to_tensor(arg0)
-    if arg0.dtype == core.dtype("fp32") and _is_libdevice_simt_enabled(_semantic):
+    if arg0.dtype == core.dtype("fp32") and _is_a5_target(_semantic):
         return core.extern_elementwise("", "", [arg0], {
             (core.dtype("fp32"), ): ("__hmf_sin_fp32", core.dtype("fp32")),
         }, is_pure=True, _semantic=_semantic)

--- a/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
+++ b/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
@@ -68,6 +68,8 @@ def _load_autotuner_methods(*method_names):
         "valid_axis_names": VALID_AXIS_NAMES,
         "VectorAxes": _load_vector_axes_module().VectorAxes,
         "_InternalNPUOptionInt": ascend_autotuner._InternalNPUOptionInt,
+        "_DEFAULT_COMPILE_MODE": ascend_autotuner._DEFAULT_COMPILE_MODE,
+        "_inject_default_simt_stack_limit": ascend_autotuner._inject_default_simt_stack_limit,
     }
     exec(compile(extracted_module, str(AUTOTUNER_PATH), "exec"), namespace)
     return namespace
@@ -607,7 +609,14 @@ def test_generate_key_and_configs_uses_axis_arg_names_for_kv_dict():
         17,
     )
 
-    assert key == (17, "float16")
+    assert key == (17, "float16", ("compile_mode", "simd_simt_template"))
+    simt_key = _normalize_loaded_method(namespace["generate_key_and_configs"])(
+        tuner,
+        FakeArg(),
+        17,
+        compile_mode="simt_only",
+    )
+    assert simt_key == (17, "float16", ("compile_mode", "simt_only"))
     assert captured["kv_dict"] == {"x": 17}
 
 
@@ -1617,7 +1626,7 @@ def test_autoparse_reduction_axes_rejects_prefixed_parser_output():
     assert refresh_calls == []
 
 
-def test_inject_grid_num_tiles_uses_only_static_grid_and_preserves_explicit_value():
+def test_inject_grid_num_tiles_uses_only_static_grid_and_preserves_internal_value():
     namespace = _load_autotuner_methods("_inject_grid_num_tiles")
     inject_grid_num_tiles = _normalize_loaded_method(namespace["_inject_grid_num_tiles"])
 
@@ -1636,9 +1645,12 @@ def test_inject_grid_num_tiles_uses_only_static_grid_and_preserves_explicit_valu
     inject_grid_num_tiles(callable_grid)
     assert "grid_num_tiles" not in callable_grid
 
-    explicit_hint = {"grid": (2, 16), "grid_num_tiles": 99}
-    inject_grid_num_tiles(explicit_hint)
-    assert explicit_hint["grid_num_tiles"] == 99
+    internal_hint = {
+        "grid": (2, 16),
+        "grid_num_tiles": ascend_autotuner._InternalNPUOptionInt(99),
+    }
+    inject_grid_num_tiles(internal_hint)
+    assert internal_hint["grid_num_tiles"] == 99
 
 
 def test_make_kernel_call_extracts_name_from_jit_run():
@@ -1654,7 +1666,7 @@ def test_make_kernel_call_extracts_name_from_jit_run():
         tl.store(x_ptr + offsets, x, mask=mask)
 
     fake_self = SimpleNamespace(fn=test_kernel_jit, pre_hook=lambda full_nargs: None,
-                                post_hook=lambda full_nargs, exception=None: None, nargs={})
+                                post_hook=lambda full_nargs, exception=None: None, nargs={}, simt_stack_limit=8192)
     fake_config = SimpleNamespace(kwargs={"BLOCK_SIZE": 32}, all_kwargs=lambda: {"BLOCK_SIZE": 32}, pre_hook=None)
 
     x = torch.zeros(128, dtype=torch.float32, device="npu")
@@ -1680,7 +1692,7 @@ def test_make_kernel_call_extracts_name_from_libentry_tuple():
         tl.store(x_ptr + offsets, x, mask=mask)
 
     fake_self = SimpleNamespace(fn=test_kernel_libentry, pre_hook=lambda full_nargs: None,
-                                post_hook=lambda full_nargs, exception=None: None, nargs={})
+                                post_hook=lambda full_nargs, exception=None: None, nargs={}, simt_stack_limit=8192)
     fake_config = SimpleNamespace(kwargs={"BLOCK_SIZE": 32}, all_kwargs=lambda: {"BLOCK_SIZE": 32}, pre_hook=None)
 
     x = torch.zeros(128, dtype=torch.float32, device="npu")

--- a/third_party/ascend/unittest/autotune_ut/test_do_bench_compat.py
+++ b/third_party/ascend/unittest/autotune_ut/test_do_bench_compat.py
@@ -59,7 +59,8 @@ def _make_run_tuner(configs):
     tuner.auto_profile_dir = None
     tuner.nargs = {}
     tuner.pre_hook = lambda kwargs, reset_only=False: None
-    tuner.fn = SimpleNamespace(run=lambda *args, **kwargs: "kernel-result")
+    tuner.run_kwargs = []
+    tuner.fn = SimpleNamespace(run=lambda *args, **kwargs: tuner.run_kwargs.append(kwargs) or "kernel-result")
     return tuner, key
 
 
@@ -246,7 +247,7 @@ def test_run_keeps_gc_on_autotune_disk_cache_miss(monkeypatch):
 
 
 def test_run_keeps_gc_on_single_config_cache_miss(monkeypatch):
-    tuner, _ = _make_run_tuner([Config({"BLOCK_SIZE": 16})])
+    tuner, _ = _make_run_tuner([Config({"BLOCK_SIZE": 16, "compile_mode": "simt_only"})])
     gc_calls = []
     profile_calls = []
 
@@ -259,5 +260,6 @@ def test_run_keeps_gc_on_single_config_cache_miss(monkeypatch):
     monkeypatch.setattr(ascend_autotuner.gc, "collect", lambda: gc_calls.append(True))
 
     assert tuner.run() == "kernel-result"
+    assert tuner.run_kwargs[-1]["simt_stack_limit"] == 8192
     assert gc_calls == [True]
     assert profile_calls == []

--- a/third_party/ascend/unittest/costmodel_ut/test_compiler_costmodel_contract.py
+++ b/third_party/ascend/unittest/costmodel_ut/test_compiler_costmodel_contract.py
@@ -29,9 +29,11 @@ class CompilerCostmodelContractTest(unittest.TestCase):
         debug_line_rewriter_mod = types.ModuleType("triton.backends.ascend.debug_line_rewriter")
         debug_line_rewriter_mod.rewrite_debug_line = lambda fn: fn
         libtriton_mod = types.ModuleType("triton._C.libtriton")
+        libtriton_ascend_mod = types.ModuleType("triton._C.libtriton.ascend")
+        libtriton_ascend_mod.ir = Dummy()
         libtriton_mod.ir = Dummy()
         libtriton_mod.passes = Dummy()
-        libtriton_mod.ascend = Dummy()
+        libtriton_mod.ascend = libtriton_ascend_mod
         libtriton_mod.buffer_ir = Dummy()
 
         utils_mod = types.ModuleType("triton.backends.ascend.utils")
@@ -111,6 +113,7 @@ class CompilerCostmodelContractTest(unittest.TestCase):
             "triton": triton_mod,
             "triton._C": triton_c_mod,
             "triton._C.libtriton": libtriton_mod,
+            "triton._C.libtriton.ascend": libtriton_ascend_mod,
             "triton.backends.ascend": ascend_backend_mod,
             "triton.backends.ascend.debug_line_rewriter": debug_line_rewriter_mod,
             "triton.backends.ascend.utils": utils_mod,
@@ -129,17 +132,17 @@ class CompilerCostmodelContractTest(unittest.TestCase):
         spec.loader.exec_module(module)
         return module, dump_mgr, GPUTarget
 
-    def test_parse_options_costmodel_forces_no_bytecode(self):
+    def test_obsolete_costmodel_and_bytecode_switches_are_not_npu_options(self):
         cmplr, _dump_mgr, GPUTarget = self._load_compiler_module()
 
         backend = cmplr.AscendBackend(GPUTarget(backend="npu", arch="910B"))
+        options = backend.parse_options({
+            "enable_costmodel_backend": True,
+            "use_bytecode": True,
+        })
 
-        opt_plain = backend.parse_options({})
-        self.assertFalse(hasattr(opt_plain, "use_bytecode"))
-
-        opt_costmodel = backend.parse_options({"enable_costmodel_backend": True})
-        self.assertTrue(opt_costmodel.enable_costmodel_backend)
-        self.assertFalse(hasattr(opt_costmodel, "use_bytecode"))
+        self.assertFalse(hasattr(options, "enable_costmodel_backend"))
+        self.assertFalse(hasattr(options, "use_bytecode"))
 
 
 if __name__ == "__main__":

--- a/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
+++ b/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
@@ -97,10 +97,9 @@ def compiler_module():
     def return_false(*_args, **_kwargs):
         return False
 
-    def remove_deprecated_npu_options(options, *, protected=(), in_place=False):
+    def remove_deprecated_npu_options(options, *, in_place=False):
         normalized = options if in_place else dict(options)
-        if "compile_on_910_95" not in protected:
-            normalized.pop("compile_on_910_95", None)
+        normalized.pop("compile_on_910_95", None)
         return normalized
 
     utils_stub = types.ModuleType(utils_name)
@@ -375,7 +374,7 @@ def _run_ttir_to_npubin(
 
     result = compiler.ttir_to_npubin(
         module,
-        {},
+        {"bisheng_options": None},
         _make_opt(
             is_pure_simt=is_pure_simt,
             superblock_factor=superblock_factor,
@@ -546,12 +545,11 @@ def _run_make_ttir_with_recorded_graph_options(compiler, monkeypatch, options):
     return events, graph_calls
 
 
-def test_make_ttir_passes_force_simt_only_to_graph_optimize(compiler_module, monkeypatch):
+def test_make_ttir_passes_canonical_compile_mode_to_graph_optimize(compiler_module, monkeypatch):
     options = SimpleNamespace(
         enable_graph_optimize=True,
         target_arch="Ascend910B1",
         compile_mode="simt_only",
-        effective_compile_mode="simt_only",
         debug=False,
     )
 
@@ -651,13 +649,11 @@ def test_default_compile_mode_keeps_the_91095_layout_memory_gate_prepared(compil
     a2_default = compiler_module.NPUOptions(arch="Ascend910B1")
     assert a2_default.compile_on_910_95 is False
     assert a2_default.compile_mode == "simd_simt_template"
-    assert a2_default.effective_compile_mode == "simd_simt_template"
     assert a2_default.is_pure_simt is False
 
     a5_default = compiler_module.NPUOptions(arch="Ascend910_9589")
     assert a5_default.compile_on_910_95 is True
     assert a5_default.compile_mode == "simd_simt_template"
-    assert a5_default.effective_compile_mode == "simd_simt_template"
     assert a5_default.is_pure_simt is False
 
     canonical = compiler_module.NPUOptions(
@@ -672,49 +668,25 @@ def test_default_compile_mode_keeps_the_91095_layout_memory_gate_prepared(compil
         )
     assert not caught
     assert alias.compile_mode == canonical.compile_mode == "simd_simt_template"
-    assert alias.effective_compile_mode == canonical.effective_compile_mode
     assert alias.hash() == canonical.hash()
 
     with pytest.raises(ValueError, match=r"invalid compile_mode='simt_template'"):
         compiler_module.NPUOptions(arch="Ascend910_9589", compile_mode="simt_template")
 
-    explicit_simd = compiler_module.NPUOptions(
-        arch="Ascend910_9589",
-        compile_mode="simd",
-        force_simt_only=True,
-        force_simt_template=True,
-    )
-    assert explicit_simd.effective_compile_mode == "simd"
+    explicit_simd = compiler_module.NPUOptions(arch="Ascend910_9589", compile_mode="simd")
+    assert explicit_simd.compile_mode == "simd"
     assert explicit_simd.is_pure_simt is False
 
     explicit_template = compiler_module.NPUOptions(
         arch="Ascend910_9589",
         compile_mode="simd_simt_template",
-        force_simt_only=True,
     )
-    assert explicit_template.effective_compile_mode == "simd_simt_template"
+    assert explicit_template.compile_mode == "simd_simt_template"
     assert explicit_template.is_pure_simt is False
 
-    explicit_only = compiler_module.NPUOptions(
-        arch="Ascend910_9589",
-        compile_mode="simt_only",
-        force_simt_template=True,
-    )
-    assert explicit_only.effective_compile_mode == "simt_only"
+    explicit_only = compiler_module.NPUOptions(arch="Ascend910_9589", compile_mode="simt_only")
+    assert explicit_only.compile_mode == "simt_only"
     assert explicit_only.is_pure_simt is True
 
-    force_template = compiler_module.NPUOptions(arch="Ascend910_9589", force_simt_template=True)
-    assert force_template.effective_compile_mode == "simd_simt_template"
-    assert force_template.is_pure_simt is False
-
-    force_only = compiler_module.NPUOptions(arch="Ascend910_9589", force_simt_only=True)
-    assert force_only.effective_compile_mode == "simt_only"
-    assert force_only.is_pure_simt is True
-
-    both_forces = compiler_module.NPUOptions(
-        arch="Ascend910_9589",
-        force_simt_only=True,
-        force_simt_template=True,
-    )
-    assert both_forces.effective_compile_mode == "simt_only"
-    assert both_forces.is_pure_simt is True
+    assert "force_simt_only" not in compiler_module.NPUOptions.__dataclass_fields__
+    assert "force_simt_template" not in compiler_module.NPUOptions.__dataclass_fields__

--- a/third_party/ascend/unittest/pytest_ut/test_layout_memory_895_closure_differential.py
+++ b/third_party/ascend/unittest/pytest_ut/test_layout_memory_895_closure_differential.py
@@ -233,9 +233,8 @@ def _run_ttir_to_npubin(
             # pass result from the mock module attrs, just like production.
             "row_coalescing_applied": False,
         })
-        # The 895 baseline still reads this retired metadata key.  Supply a
-        # null legacy value only so its historical closure can be compared to
-        # the current source, which no longer consumes it.
+        # Both the 895 baseline and the compatibility-restored target read
+        # this option. Keep it neutral for the argv differential below.
         if "bisheng_options" in closure["ttir_to_npubin"].__code__.co_consts:
             parsed["bisheng_options"] = None
         metadata_after_parse.append(parsed)
@@ -337,8 +336,8 @@ def test_895_pure_simt_bisheng_argv_matrix_after_row_make_ttir_migration(source_
         )
         case = f"E={env_enabled}, B={blacklisted}, R={row_applied}, superblock={superblock}"
 
-        # The target contract is explicit: after deleting bisheng_options,
-        # retain the full pure-SIMT envelope and its automatic block policy.
+        # Keep bisheng_options neutral in this matrix so it verifies only the
+        # pure-SIMT envelope and automatic block policy.
         expected_options = list(common_prefix)
         auto_blockify = env_enabled and not blacklisted and not row_applied
         if auto_blockify:

--- a/third_party/ascend/unittest/pytest_ut/test_runtime_utils.py
+++ b/third_party/ascend/unittest/pytest_ut/test_runtime_utils.py
@@ -27,6 +27,11 @@ from triton.backends.ascend import utils
 from triton.backends.ascend.runtime import utils as runtime_utils
 
 
+@pytest.fixture(autouse=True)
+def _reset_deprecated_npu_option_warnings(monkeypatch):
+    monkeypatch.setattr(utils, "_WARNED_DEPRECATED_NPU_OPTIONS", set())
+
+
 def test_get_logger():
     logger = utils.get_logger("test_utils", "INFO")
     assert logger.level == logging.INFO
@@ -56,35 +61,33 @@ def test_deprecated_ascend_env_var_warns_only_once_per_process(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "simt_option",
+    ("legacy_option", "compile_mode"),
     [
-        pytest.param("force_simt_only", id="simt-only"),
-        pytest.param("force_simt_template", id="simt-template"),
+        pytest.param("force_simt_only", "simt_only", id="simt-only"),
+        pytest.param("force_simt_template", "simd_simt_template", id="simt-template"),
     ],
 )
-def test_retained_simt_option_is_not_removed(simt_option):
-    options = {simt_option: True}
+def test_deprecated_simt_option_routes_to_compile_mode(legacy_option, compile_mode):
+    options = {legacy_option: True}
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
+    with pytest.warns(FutureWarning, match=rf"{legacy_option}.*compile_mode={compile_mode!r}"):
         normalized = utils._remove_deprecated_npu_options(options)
 
-    assert not caught
-    assert normalized == options == {simt_option: True}
+    assert normalized == {"compile_mode": compile_mode}
+    assert options == {legacy_option: True}
 
 
-def test_explicit_compile_mode_preserves_retained_simt_option():
+def test_explicit_compile_mode_takes_precedence_over_deprecated_simt_option():
     options = {"compile_mode": "simd", "force_simt_only": True}
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
+    with pytest.warns(FutureWarning, match=r"force_simt_only.*compile_mode='simt_only'"):
         normalized = utils._remove_deprecated_npu_options(options)
 
-    assert not caught
-    assert normalized == options
+    assert normalized == {"compile_mode": "simd"}
+    assert options == {"compile_mode": "simd", "force_simt_only": True}
 
 
-def test_retained_simt_option_is_preserved_after_in_place_normalization():
+def test_deprecated_simt_option_is_routed_once_during_in_place_normalization():
     options = {"force_simt_only": True}
 
     with warnings.catch_warnings(record=True) as caught:
@@ -92,9 +95,9 @@ def test_retained_simt_option_is_preserved_after_in_place_normalization():
         first = utils._remove_deprecated_npu_options(options, in_place=True)
         second = utils._remove_deprecated_npu_options(options, in_place=True)
 
-    assert not caught
+    assert len(caught) == 1
     assert first is second is options
-    assert options == {"force_simt_only": True}
+    assert options == {"compile_mode": "simt_only"}
 
 
 def test_get_byte_per_numel_supports_unsigned_integer_dtypes():


### PR DESCRIPTION
This PR restores the compatibility boundary for deprecated Ascend compile options. Removed and backend-managed options are accepted as no-ops with deduplicated `FutureWarning` messages, while renamed options are routed to their canonical replacements. Legacy `force_simt_only` and `force_simt_template` values are routed to `compile_mode`, and the legacy cache-count options are routed to the corresponding `buf_slot_num_*` options.

Internally, compilation now consumes the canonical `compile_mode` directly, uses backend-only fields to identify serialized `NPUOptions`, and preserves backend-injected `grid_num_tiles` values without exposing the option to users. Deprecated option names are reserved in autotune to avoid ambiguity with kernel parameters.

The temporarily retained `bisheng_options` and `enable_cube_block_merge` options are restored together with their compiler forwarding paths. The `TRITON_ENABLE_LIBDEVICE` and `TRITON_ENABLE_LIBDEVICE_SIMT` environment-variable behavior is also restored, so libdevice selection is no longer derived automatically from `compile_mode`.
