### PR TITLE
[simd_simt](feat) default compile_mode to simd_simt_template

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -1522,14 +1522,14 @@ class NPUOptions:
     # enable_bishengir_simt_optimization is passed as
     # -enable-bishengir-simt-optimization flag to bishengir-compile.
     enable_bishengir_simt_optimization: int = 000
-    # compile_mode: "simd" (default), "simd_simt", "simd_simt_template", "simt_only"
-    #   - "simd":          pure SIMD path (default)
+    # compile_mode: "simd", "simd_simt", "simd_simt_template", "simt_only"
+    #   - "simd":          pure SIMD path
     #   - "simd_simt":     unstructured access -> hfusion.gather_load/scatter_store
-    #   - "simd_simt_template": unstructured access -> SIMT template call
+    #   - "simd_simt_template(default)": unstructured access -> SIMT template call
     #   - "simt_only":     pure SIMT path
     # "simt_template" and "unstructured_in_simt" are deprecated aliases for
     # "simd_simt_template".
-    compile_mode: str = "simd"
+    compile_mode: str = "simd_simt_template"
     mix_mode: str = ""
     simt_stack_limit: int = None
     # use_bytecode:
@@ -1733,9 +1733,6 @@ class AscendBackend(BaseBackend):
                     stacklevel=2,
                 )
                 object.__setattr__(options, "compile_mode", "simd_simt_template")
-            if not options.compile_on_910_95:
-                raise ValueError(f"compile_mode='{options.compile_mode}' is only supported on 910_95. "
-                                 "A2/A3 targets do not support SIMT mix compile.")
             if options.shared_mem_dynamic_size is None:
                 object.__setattr__(options, "shared_mem_dynamic_size", 221184)
         elif options.compile_mode == "simt_only":

--- a/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
+++ b/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
@@ -286,6 +286,24 @@ struct DiscreteMaskStoreConversion : OpRewritePattern<triton::StoreOp> {
     op->setAttr(routeDiscreteMaskToSimtAttrName, rewriter.getUnitAttr());
     bool rankWithinIndirectFastPathLimit =
         ptrType && ptrType.getShape().size() <= 5;
+
+    if (compileOn91095Flag &&
+        compileModeFlag == triton::ascend::CompileMode::SimdSimt) {
+      rewriter.modifyOpInPlace(op, [&]() {
+        op->setAttr(ConverterUtils::mixCompileDiscreteMaskAttrName,
+                    rewriter.getUnitAttr());
+      });
+      return success();
+    }
+
+    if (compileOn91095Flag &&
+        compileModeFlag == triton::ascend::CompileMode::SimdSimtTemplate &&
+        rankWithinIndirectFastPathLimit) {
+      op->setAttr(ConverterUtils::mixCompileDiscreteMaskAttrName,
+                  rewriter.getUnitAttr());
+      return failure();
+    }
+
     const bool legacyMixedRoute =
         compileModeFlag == triton::ascend::CompileMode::SimdSimt ||
         compileModeFlag == triton::ascend::CompileMode::SimdSimtTemplate;
@@ -367,6 +385,24 @@ struct DiscreteMaskLoadConversion : OpRewritePattern<triton::LoadOp> {
     op->setAttr(routeDiscreteMaskToSimtAttrName, rewriter.getUnitAttr());
     bool rankWithinIndirectFastPathLimit =
         ptrType && ptrType.getShape().size() <= 5;
+
+    if (compileOn91095Flag &&
+        compileModeFlag == triton::ascend::CompileMode::SimdSimt) {
+      rewriter.modifyOpInPlace(op, [&]() {
+        op->setAttr(ConverterUtils::mixCompileDiscreteMaskAttrName,
+                    rewriter.getUnitAttr());
+      });
+      return success();
+    }
+
+    if (compileOn91095Flag &&
+        compileModeFlag == triton::ascend::CompileMode::SimdSimtTemplate &&
+        rankWithinIndirectFastPathLimit) {
+      op->setAttr(ConverterUtils::mixCompileDiscreteMaskAttrName,
+                  rewriter.getUnitAttr());
+      return failure();
+    }
+
     const bool legacyMixedRoute =
         compileModeFlag == triton::ascend::CompileMode::SimdSimt ||
         compileModeFlag == triton::ascend::CompileMode::SimdSimtTemplate;

--- a/third_party/ascend/unittest/Conversion/950PR/DiscreteMaskAccess/indirect_loadstore.mlir
+++ b/third_party/ascend/unittest/Conversion/950PR/DiscreteMaskAccess/indirect_loadstore.mlir
@@ -1,7 +1,7 @@
 // RUN: triton-opt '--discrete-mask-access-conversion=compile-on-910-95=True force-simt-template=True' --split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: tt.func @discrete_load
-// CHECK: tt.load {{.*}} {route_discrete_mask_to_simt} : tensor<1024x!tt.ptr<i32>>
+// CHECK: tt.load {{.*}} {MixCompileDiscreteMask, route_discrete_mask_to_simt} : tensor<1024x!tt.ptr<i32>>
 tt.func @discrete_load(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
   %cst = arith.constant dense<0> : tensor<1024xi32>
   %cst_0 = arith.constant dense<200> : tensor<1024xi32>
@@ -20,7 +20,7 @@ tt.func @discrete_load(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
 }
 
 // CHECK-LABEL: tt.func @discrete_store
-// CHECK: tt.store {{.*}} {route_discrete_mask_to_simt} : tensor<1024x!tt.ptr<i32>>
+// CHECK: tt.store {{.*}} {MixCompileDiscreteMask, route_discrete_mask_to_simt} : tensor<1024x!tt.ptr<i32>>
 tt.func @discrete_store(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
   %cst = arith.constant dense<0> : tensor<1024xi32>
   %cst_0 = arith.constant dense<200> : tensor<1024xi32>


### PR DESCRIPTION
- Default compile_mode to simd_simt_template and drop the 910_95-only  restriction (allow A2/A3 targets to use SIMT mix compile).
- DiscreteMaskAccessConversionPass: restore the discrete-mask routing branches in DiscreteMaskLoadConversion and DiscreteMaskStoreConversion that were accidentally dropped by https://github.com/triton-lang/triton-ascend/commit/210bb41f4755169113b48a4acec8e8244539dcf8 (simt_costmodel auto selection): on 910_95, mark discrete-mask loads/stores with mix_compile_discrete_mask and route them per compile_mode --
 simd_simt converts in-place (gather/scatter path); simd_simt_template  keeps the SIMT template path when the indirect rank is within the fast-path limit (<=5). The costmodel selection logic introduced by  https://github.com/triton-lang/triton-ascend/commit/210bb41f4755169113b48a4acec8e8244539dcf8 is kept after the restored branches.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
