### PR TITLE
[test](feat) migrate community runtime tests to Ascend

### DIFF
--- a/third_party/ascend/unittest/pytest_ut/test_bindings.py
+++ b/third_party/ascend/unittest/pytest_ut/test_bindings.py
@@ -1,0 +1,114 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# Copyright 2018-2020 Philippe Tillet
+# Copyright 2020-2022 OpenAI
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import math
+
+import torch
+import torch_npu  # noqa: F401  # Registers the "npu" device with PyTorch.
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def add_helper(x, y):
+    return x + y
+
+
+@triton.jit
+def add_kernel(in_ptr0, in_ptr1, n_elements, out_ptr, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(in_ptr0 + offsets, mask=mask)
+    y = tl.load(in_ptr1 + offsets, mask=mask)
+    output = add_helper(x, y)
+    tl.store(out_ptr + offsets, output, mask=mask)
+
+
+def test_module_walk():
+    """Test the MLIR bindings exposed for the out-of-tree walk."""
+
+    def walk_fn(op):
+        name = op.get_name()
+        for i in range(op.get_num_results()):
+            op.get_result(i).id()
+        for i in range(op.get_num_operands()):
+            op.get_operand(i).id()
+        for i in range(op.get_num_regions()):
+            op.get_region(i).id()
+        block = op.get_block()
+        if block is not None:
+            block.id()
+            for i in range(block.get_num_arguments()):
+                block.get_argument(i)
+        if name == "tt.func":
+            op.get_str_attr("sym_name")
+        if name == "tt.call":
+            op.get_flat_symbol_ref_attr("callee")
+
+    args = [
+        torch.empty((32, 32), device="npu"),
+        torch.empty((32, 32), device="npu"),
+        1024,
+        torch.empty((32, 32), device="npu"),
+        16,
+    ]
+    target = triton.runtime.driver.active.get_current_target()
+    backend = triton.compiler.compiler.make_backend(target)
+    src = triton.compiler.compiler.ASTSource(
+        fn=add_kernel,
+        signature={add_kernel.arg_names[i]: triton.runtime.jit.mangle_type(arg)
+                   for i, arg in enumerate(args)},
+        constexprs={add_kernel.arg_names[i]: arg
+                    for i, arg in enumerate(args)
+                    if not isinstance(arg, torch.Tensor)},
+    )
+
+    context = triton._C.libtriton.ir.context()
+    options = backend.parse_options(dict())
+    codegen_fns = dict()
+    module_map = backend.get_module_map()
+    triton._C.libtriton.ir.load_dialects(context)
+    backend.load_dialects(context)
+
+    ttir_module = src.make_ir(target, options, codegen_fns, module_map, context)
+    ttir_module.walk(walk_fn)
+
+
+def test_python_func_in_visit_call():
+
+    @triton.jit
+    def test_py_call_const_kernel(in_ptr0, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+        log2e: tl.constexpr = math.log2(math.e)
+        pid = tl.program_id(axis=0)
+        block_start = pid * BLOCK_SIZE
+        offsets = block_start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        x = tl.load(in_ptr0 + offsets, mask=mask)
+        output = x * log2e
+        tl.store(out_ptr + offsets, output, mask=mask)
+
+    x = torch.randn(4, device="npu")
+    out = torch.zeros_like(x)
+    test_py_call_const_kernel[(4, )](x, out, 4, 4)

--- a/third_party/ascend/unittest/pytest_ut/test_cache.py
+++ b/third_party/ascend/unittest/pytest_ut/test_cache.py
@@ -1,0 +1,433 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# Copyright 2018-2020 Philippe Tillet
+# Copyright 2020-2022 OpenAI
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import importlib.util
+import itertools
+import pathlib
+
+import pytest
+import torch
+import torch_npu  # noqa: F401  # Registers the "npu" device with PyTorch.
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def function_0(i):
+    return i + 1
+
+
+@triton.jit
+def function_1(i):
+    i = i + 1
+    cond: tl.constexpr = True
+    if cond:
+        FN: tl.constexpr = function_2
+    else:
+        FN: tl.constexpr = function_0
+    return FN(i)
+
+
+@triton.jit
+def function_2(i):
+    i = i + 1
+    return i
+
+
+@triton.jit
+def combine_fn(a, b):
+    return COMBINE_OP  # noqa: F821
+
+
+@triton.jit
+def kernel(X, i, BLOCK: tl.constexpr):
+    i = i + 1
+    i = function_1(i)
+    tl.store(X, i)
+
+
+@triton.jit
+def kernel_with_combine_fn(X, BLOCK: tl.constexpr):
+    i = tl.arange(0, BLOCK)
+    i = REDUCE_OR_SCAN(i, 0, combine_fn)  # noqa: F821
+    tl.store(X, i)
+
+
+def apply_src_change(target, old, new, to_modify):
+    orig_src = to_modify.src
+    kernel.hash = None
+    function_0.hash = None
+    function_1.hash = None
+    function_2.hash = None
+    try:
+        to_modify._unsafe_update_src(orig_src.replace(old, new))
+        return target.cache_key
+    finally:
+        to_modify._unsafe_update_src(orig_src)
+        kernel.hash = None
+        function_0.hash = None
+        function_1.hash = None
+        function_2.hash = None
+
+
+def test_nochange():
+    baseline = kernel.cache_key
+    updated = apply_src_change(kernel, 'i + 1', 'i + 1', function_1)
+    assert baseline == updated
+
+
+def test_toplevel_change():
+    baseline = kernel.cache_key
+    updated = apply_src_change(kernel, 'i + 1', 'i + 2', function_1)
+    assert baseline != updated
+
+
+def test_nested1_change():
+    baseline = kernel.cache_key
+    updated = apply_src_change(kernel, 'i + 1', 'i + 2', function_2)
+    assert baseline != updated
+
+
+def test_nested2_change():
+    baseline = kernel.cache_key
+    updated = apply_src_change(kernel, 'i + 1', 'i + 2', function_0)
+    assert baseline != updated
+
+
+def test_combine_fn_change():
+    # Test that tl.reduce and associative_scan calls include the combine_fn in
+    # the hash.
+    orig_combine_fn_src = combine_fn.src
+    orig_kernel_src = kernel_with_combine_fn.src
+    seen_keys = set()
+
+    for reduce_or_scan, combine_op in itertools.product(
+        ["tl.reduce", "tl.associative_scan"],
+        ["a + b", "a * b"],
+    ):
+        combine_fn._unsafe_update_src(orig_combine_fn_src.replace("COMBINE_OP", combine_op))
+        kernel_with_combine_fn._unsafe_update_src(orig_kernel_src.replace("REDUCE_OR_SCAN", reduce_or_scan))
+        try:
+            key = kernel_with_combine_fn.cache_key
+        finally:
+            combine_fn._unsafe_update_src(orig_combine_fn_src)
+            kernel_with_combine_fn._unsafe_update_src(orig_kernel_src)
+
+        assert key not in seen_keys
+        seen_keys.add(key)
+
+
+@triton.constexpr_function
+def constexpr_flag_fn():
+    return False
+
+
+@triton.jit
+def constexpr_fn_user(out):
+    a: tl.constexpr = constexpr_flag_fn()
+    tl.store(out, a)
+
+
+def test_constexpr_fn_change():
+    baseline = constexpr_fn_user.cache_key
+
+    orig_src = constexpr_flag_fn.src
+    new_src = orig_src.replace("False", "True")
+    constexpr_flag_fn._unsafe_update_src(new_src)
+    constexpr_fn_user.hash = None
+    updated = constexpr_fn_user.cache_key
+    assert baseline != updated
+
+    constexpr_flag_fn._unsafe_update_src(orig_src)
+    constexpr_fn_user.hash = None
+    assert constexpr_fn_user.cache_key == baseline
+
+
+def write_and_load_module(temp_file: pathlib.Path, code, num_extra_lines):
+    temp_file.write_text(('# extra line\n' * num_extra_lines) + code)
+    spec = importlib.util.spec_from_file_location("module.name", str(temp_file))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_changed_line_numbers_invalidate_cache(tmp_path: pathlib.Path):
+    from textwrap import dedent
+    code = dedent("""
+        import triton
+        @triton.jit
+        def test_kernel(i):
+            i = i + 1
+    """)
+    temp_file0 = tmp_path / "test_changed_line_numbers_invalidate_cache0.py"
+    orig_mod = write_and_load_module(temp_file0, code, 0)
+    orig_cache_key = orig_mod.test_kernel.cache_key
+
+    temp_file1 = tmp_path / "test_changed_line_numbers_invalidate_cache1.py"
+    updated_mod = write_and_load_module(temp_file1, code, 1)
+    updated_cache_key = updated_mod.test_kernel.cache_key
+    assert orig_cache_key != updated_cache_key
+
+
+def test_use_builtin():
+
+    @triton.jit
+    def builtin_kernel():
+        a = float(0)  # noqa: F841
+
+    # No error about the value of `float` changing.
+    builtin_kernel[(1, )]()
+    builtin_kernel[(1, )]()
+
+
+def test_no_cache_module_as_global():
+
+    @triton.jit
+    def module_kernel():
+        tl.arange(0, 16)
+
+    module_kernel[(1, )]()
+    # `tl` should not be entered into used_global_vals.
+    assert not module_kernel.used_global_vals
+
+
+@triton.jit
+def no_cache_callable_inner():
+    pass
+
+
+def test_no_cache_callable():
+
+    @triton.jit
+    def callable_kernel():
+        no_cache_callable_inner()
+
+    callable_kernel[(1, )]()
+    # `no_cache_callable_inner` should not be entered into used_global_vals.
+    assert not callable_kernel.used_global_vals
+
+
+device = "npu"
+GLOBAL_DEFAULT_ARG = 1
+GLOBAL_VAR = tl.constexpr(1)
+GLOBAL = 42  # noqa: N816
+CONSTEXPR_GLOBAL = tl.constexpr(42)
+BUILTIN_AS_GLOBAL = tl.int32
+
+
+def test_kernel_global_var_change():
+    global GLOBAL_VAR
+
+    previous_global = GLOBAL_VAR
+    GLOBAL_VAR = tl.constexpr(1)
+    try:
+
+        @triton.jit
+        def global_var_kernel(X):
+            tl.store(X, GLOBAL_VAR)
+
+        x = torch.empty(1, dtype=torch.int32, device=device)
+        global_var_kernel[(1, )](x)
+        assert x == torch.ones_like(x)
+
+        GLOBAL_VAR = 2
+        with pytest.raises(RuntimeError) as error:
+            global_var_kernel[(1, )](x)
+
+        assert "global variable" in str(error.value).lower()
+    finally:
+        GLOBAL_VAR = previous_global
+
+
+def test_local_shadows_global():
+    global GLOBAL
+
+    previous_global = GLOBAL
+    GLOBAL = 42
+    try:
+
+        @triton.jit
+        def local_shadow_kernel():
+            _, GLOBAL = 0, 0  # noqa: N806
+            a = GLOBAL  # noqa: F841
+
+        # No error because the local `GLOBAL` is distinct from the module-level
+        # value changed between launches.
+        local_shadow_kernel[(1, )]()
+        GLOBAL = 43
+        local_shadow_kernel[(1, )]()
+    finally:
+        GLOBAL = previous_global
+
+
+def test_local_does_not_shadow_global():
+    global CONSTEXPR_GLOBAL
+
+    previous_global = CONSTEXPR_GLOBAL
+    CONSTEXPR_GLOBAL = tl.constexpr(42)
+    try:
+
+        @triton.jit
+        def local_constexpr_kernel():
+            a = CONSTEXPR_GLOBAL  # noqa: F823, F841
+            _, CONSTEXPR_GLOBAL = 0, 0  # noqa: F841, N806
+
+        local_constexpr_kernel[(1, )]()
+        CONSTEXPR_GLOBAL = tl.constexpr(43)
+
+        # The first read uses the module global even though the kernel later
+        # assigns a local with the same name, so changing the global is an
+        # error on the next launch.
+        with pytest.raises(RuntimeError):
+            local_constexpr_kernel[(1, )]()
+    finally:
+        CONSTEXPR_GLOBAL = previous_global
+
+
+def test_cache_builtin_as_global():
+    global BUILTIN_AS_GLOBAL
+
+    previous_global = BUILTIN_AS_GLOBAL
+    BUILTIN_AS_GLOBAL = tl.int32
+    try:
+
+        @triton.jit
+        def builtin_global_kernel():
+            x = BUILTIN_AS_GLOBAL  # noqa: F841
+
+        builtin_global_kernel[(1, )]()
+
+        BUILTIN_AS_GLOBAL = tl.int64
+        with pytest.raises(RuntimeError) as error:
+            builtin_global_kernel[(1, )]()
+
+        assert "global variable" in str(error.value).lower()
+    finally:
+        BUILTIN_AS_GLOBAL = previous_global
+
+
+def test_cache_closure():
+
+    def make_closure(cst):
+
+        @triton.jit
+        def closure():
+            tl.full((16, ), cst, dtype=tl.int32)
+
+        return closure
+
+    cst = tl.constexpr(42)
+    closure = make_closure(cst)
+
+    closure[(1, )]()
+    cst.value = 43
+    with pytest.raises(RuntimeError) as error:
+        closure[(1, )]()
+
+    assert "cst has changed since we compiled this kernel, from constexpr[42] to constexpr[43]" in str(error.value)
+
+
+def test_kernel_default_arg():
+    global GLOBAL_DEFAULT_ARG
+
+    previous_default = GLOBAL_DEFAULT_ARG
+    GLOBAL_DEFAULT_ARG = 1
+    try:
+
+        @triton.jit
+        def kernel(X, i: tl.constexpr = GLOBAL_DEFAULT_ARG):
+            tl.store(X, i)
+
+        x = torch.empty(1, dtype=torch.int32, device=device)
+        kernel[(1, )](x)
+        assert x == torch.ones_like(x)
+
+        # Changing the global variable must not change the default value that
+        # was captured when kernel was defined.
+        GLOBAL_DEFAULT_ARG = 2
+        kernel[(1, )](x)
+        assert x == torch.ones_like(x)
+
+        device_id = torch.npu.current_device()
+        assert len(kernel.device_caches[device_id][0]) == 1
+    finally:
+        GLOBAL_DEFAULT_ARG = previous_default
+
+
+def test_constexpr_cache_invalidation_recreated():
+
+    def test_run(val):
+        VAL = tl.constexpr(val)
+
+        @triton.jit
+        def kernel(out):
+            tl.store(out, VAL)
+
+        out = torch.zeros(1, device=device)
+        kernel[(1, )](out)
+        return out.item()
+
+    assert test_run(123) == 123
+    assert test_run(123) == 123
+    assert test_run(1234) == 1234
+    assert test_run(1234) == 1234
+
+
+def test_jit_warmup_cache():
+
+    @triton.jit
+    def kernel_add(a, b, o, N: tl.constexpr):
+        idx = tl.arange(0, N)
+        tl.store(o + idx, tl.load(a + idx) + tl.load(b + idx))
+
+    args = [
+        torch.randn(32, dtype=torch.float32, device=device),
+        torch.randn(32, dtype=torch.float32, device=device),
+        torch.randn(32, dtype=torch.float32, device=device),
+        32,
+    ]
+    device_id = torch.npu.current_device()
+    assert len(kernel_add.device_caches[device_id][0]) == 0
+    kernel_add.warmup(torch.float32, torch.float32, torch.float32, 32, grid=(1, ))
+    assert len(kernel_add.device_caches[device_id][0]) == 1
+    kernel_add.warmup(*args, grid=(1, ))
+    assert len(kernel_add.device_caches[device_id][0]) == 1
+    kernel_add.warmup(*args, grid=(1, ))
+    assert len(kernel_add.device_caches[device_id][0]) == 1
+
+
+def test_jit_debug():
+
+    @triton.jit
+    def debug_kernel(tmp):
+        tl.device_assert(tl.load(tmp) == 1, "tmp == 1")
+
+    device_id = torch.npu.current_device()
+    tmp = torch.tensor([1], dtype=torch.int32, device=device)
+    assert len(debug_kernel.device_caches[device_id][0]) == 0
+    debug_kernel[(1, )](tmp, debug=False)
+    assert len(debug_kernel.device_caches[device_id][0]) == 1
+    debug_kernel[(1, )](tmp, debug=True)
+    assert len(debug_kernel.device_caches[device_id][0]) == 2
+    bins = list(debug_kernel.device_caches[device_id][0].values())
+    assert bins[0].asm['ttir'] != bins[1].asm['ttir']

--- a/third_party/ascend/unittest/pytest_ut/test_compile_errors.py
+++ b/third_party/ascend/unittest/pytest_ut/test_compile_errors.py
@@ -1,0 +1,381 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# Copyright 2018-2020 Philippe Tillet
+# Copyright 2020-2022 OpenAI
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import os
+import traceback
+
+import pytest
+import torch_npu  # noqa: F401  # Registers the "npu" device with PyTorch.
+
+import triton
+import triton.language as tl
+from triton.compiler.errors import CompilationError, CompileTimeAssertionFailure
+
+
+def format_exception(type, value, tb):
+    list_msg = traceback.format_exception(type, value, tb, chain=False)
+    return "\n".join(list_msg)
+
+
+def test_err_undefined_variable():
+
+    @triton.jit
+    def kernel():
+        a += 1  # noqa
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constexprs={}))
+
+    try:
+        err_msg = format_exception(e.type, value=e.value, tb=e.tb)
+        assert "is not defined" in err_msg, "error should mention the undefined variable"
+        assert "code_generator.py" not in err_msg
+    except AssertionError as assertion_err:
+        raise assertion_err from e.value
+
+
+def test_err_in_binary_operator():
+
+    @triton.jit
+    def kernel():
+        0 + "a"
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constexprs={}))
+
+    try:
+        err_msg = format_exception(e.type, value=e.value, tb=e.tb)
+        assert "at 2:4:" in err_msg, "error should point to the 0"
+        assert "code_generator.py" not in err_msg
+    except AssertionError as assertion_err:
+        raise assertion_err from e.value
+
+
+def test_err_static_assert():
+
+    @triton.jit
+    def kernel():
+        tl.static_assert(isinstance(0, tl.tensor))
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constexprs={}))
+
+    try:
+        assert isinstance(e.value, CompileTimeAssertionFailure)
+        assert e.value.__cause__ is None
+        err_msg = format_exception(e.type, value=e.value, tb=e.tb)
+        print(err_msg)
+        assert "at 2:4:" in err_msg, "error should point to the static_assert call"
+        assert "<source unavailable>" not in err_msg
+        assert "code_generator.py" not in err_msg
+    except AssertionError as assertion_err:
+        raise assertion_err from e.value
+
+
+def test_err_in_unary_op():
+    # Currently Triton can't evaluate `not` of a tuple at compile time. That's
+    # acceptable, but the error message needs to point to the correct spot.
+    @triton.jit
+    def kernel():
+        not (0, 0)
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constexprs={}))
+
+    try:
+        assert e.value.__cause__ is None
+        err_msg = format_exception(e.type, value=e.value, tb=e.tb)
+        assert "at 2:4:" in err_msg, "error should point to the `not`"
+        assert "<source unavailable>" not in err_msg
+        assert "code_generator.py" not in err_msg
+    except AssertionError as assertion_err:
+        raise assertion_err from e.value
+
+
+def test_err_in_binary_op():
+
+    @triton.jit
+    def kernel():
+        1.0 << 1
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constexprs={}))
+
+    try:
+        err_msg = format_exception(e.type, value=e.value, tb=e.tb)
+        assert "at 2:4:" in err_msg, "error should point to the 1.0"
+        assert "<source unavailable>" not in err_msg
+        assert "code_generator.py" not in err_msg
+    except AssertionError as assertion_err:
+        raise assertion_err from e.value
+
+
+# This has to be defined as a top-level function; jit'ed functions can't call
+# nested functions.
+@triton.jit
+def nested_call():
+    xyz  # noqa
+
+
+def test_err_in_nested_call():
+
+    @triton.jit
+    def kernel():
+        # this is a comment to push nested_call() onto the next line
+        nested_call()
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constexprs={}))
+
+    try:
+        inner_exc = e.value.__cause__
+        inner = format_exception(inner_exc.__class__, inner_exc, inner_exc.__traceback__)
+        assert "at 2:4:" in inner, "error should point to xyz"
+        assert "<source unavailable>" not in inner
+        assert "code_generator.py" not in inner
+
+        outer = format_exception(e.type, value=e.value, tb=e.tb)
+        assert "at 3:4" in outer, "error should point to the nested_call"
+        assert "<source unavailable>" not in outer
+        assert "code_generator.py" not in outer
+    except AssertionError as assertion_err:
+        raise assertion_err from e.value
+
+
+def test_err_in_builtin():
+
+    # The root error here comes from core.py. Make sure the stacktrace reflects
+    # this.
+    @triton.jit
+    def kernel():
+        tl.expand_dims(None, -1)
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constexprs={}))
+
+    try:
+        inner_exc = e.value.__cause__
+        inner = format_exception(inner_exc.__class__, inner_exc, inner_exc.__traceback__)
+        assert f"{os.sep}core.py" in inner, "error should point inside core.py"
+        assert "code_generator.py" not in inner
+
+        outer = format_exception(e.type, value=e.value, tb=e.tb)
+        assert "at 2:4:" in outer, "error should point to expand_dims call"
+        assert "<source unavailable>" not in outer
+        assert "code_generator.py" not in outer
+    except AssertionError as assertion_err:
+        raise assertion_err from e.value
+
+
+@triton.jit
+def two_returns():
+    return tl.arange(0, 4)
+    return tl.arange(0, 8)
+
+
+def test_two_returns_no_err():
+    # This program is valid; `a` has shape (4,).
+    @triton.jit
+    def kernel():
+        a = two_returns()
+        a + tl.arange(0, 4)  # only works if we took the first return
+
+    triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constexprs={}))
+
+
+def test_not_const_annotate_no_err():
+
+    @triton.jit
+    def kernel(N: int = 1):
+        pass
+
+    triton.compile(triton.compiler.ASTSource(fn=kernel, signature={'N': 'i32'}, constexprs={}))
+
+
+@triton.jit
+def returns_branched_on_constexpr(N: tl.constexpr):
+    if N == 0:
+        return tl.arange(0, 4)
+    # Ideally this would work even without the `else`, but we're not that smart
+    # yet.
+    else:
+        return tl.arange(0, 8)
+
+
+def test_returns_branched_on_constexpr():
+
+    @triton.jit
+    def kernel1(N: tl.constexpr):
+        a = returns_branched_on_constexpr(N)
+        a + tl.arange(0, 4)
+
+    triton.compile(triton.compiler.ASTSource(fn=kernel1, signature={"N": "constexpr"}, constexprs={"N": 0}))
+
+    @triton.jit
+    def kernel2(N: tl.constexpr):
+        a = returns_branched_on_constexpr(N)
+        a + tl.arange(0, 8)
+
+    triton.compile(triton.compiler.ASTSource(fn=kernel2, signature={"N": "constexpr"}, constexprs={"N": 1}))
+
+
+@triton.jit
+def returns_branched_on_non_constexpr(N: int):
+    if N == 0:
+        return tl.arange(0, 4)
+    else:
+        return tl.arange(0, 8)
+
+
+def test_returns_branched_on_non_constexpr():
+
+    @triton.jit
+    def kernel(N: int):
+        returns_branched_on_non_constexpr(N)
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={'N': 'i32'}, constexprs={}))
+
+    try:
+        assert "at 2:4:" in str(e.value), "error should point to the function call"
+        assert "at 5:8:" in str(e.value.__cause__), "error should point to the second `return`"
+    except AssertionError as assertion_err:
+        raise assertion_err from e.value
+
+
+GLOBAL = 42
+
+
+def test_global_var_access():
+
+    @triton.jit
+    def kernel():
+        a = GLOBAL  # noqa: F841
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constexprs={}))
+    assert "global variable" in str(e.value)
+
+
+CONSTEXPR_ANNOTATED_GLOBAL: tl.constexpr = 42
+
+
+def test_constexpr_annotated_global_var_access():
+
+    @triton.jit
+    def kernel():
+        a = CONSTEXPR_ANNOTATED_GLOBAL  # noqa: F841
+
+    # A Python annotation alone does not make this global accessible from JIT
+    # code.
+    try:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constexprs={}))
+        assert False, "Using a constexpr annotated global variable should not be allowed"
+    except CompilationError as e:
+        assert "Cannot access global variable" in str(e)
+
+
+CONSTEXPR_GLOBAL = tl.constexpr(42)
+
+
+def test_constexpr_global_var_access():
+
+    @triton.jit
+    def kernel():
+        a = CONSTEXPR_GLOBAL  # noqa: F841
+
+    triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constexprs={}))
+
+
+TYPE_ALIAS = tl.pointer_type(tl.int32)
+
+
+def test_global_type_alias_access():
+
+    @triton.jit
+    def kernel():
+        a = TYPE_ALIAS  # noqa: F841
+
+    triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constexprs={}))
+
+
+def test_global_access_in_fn_default_arg():
+
+    @triton.jit
+    def kernel(a=GLOBAL):
+        pass
+
+    triton.compile(triton.compiler.ASTSource(fn=kernel, signature={'a': "i32"}, constexprs={}))
+
+
+def test_defaults_assign_no_err():
+
+    @triton.jit
+    def kernel(a=1, B: tl.constexpr = ""):
+        pass
+
+    triton.compile(triton.compiler.ASTSource(fn=kernel, signature={'a': 'i32', 'B': 'constexpr'}, constexprs={'B': ""}))
+
+
+extra_words = "These are extra words in the error message."
+
+
+@triton.must_use_result(extra_words)
+@triton.jit
+def cube(x):
+    return x * x * x
+
+
+def test_unused_result():
+
+    @triton.jit
+    def evil_cube_kernel():
+        a = tl.full((64, 64), 0.0, tl.float32)
+        cube(a)
+
+    @triton.jit
+    def good_cube_kernel():
+        a = tl.full((64, 64), 0.0, tl.float32)
+        a = cube(a)
+
+    triton.compile(triton.compiler.ASTSource(fn=good_cube_kernel, signature={}, constexprs={}))
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=evil_cube_kernel, signature={}, constexprs={}))
+
+    expected_err_msg = "The result of cube is not being used. " + extra_words
+    obtained_err_msg = str(e.value).split('\n')[-1]
+
+    assert expected_err_msg == obtained_err_msg
+
+
+def test_err_constexpr_and_do_not_specialize():
+
+    @triton.jit(do_not_specialize=["N"])
+    def kernel(N: tl.constexpr):
+        pass
+
+    with pytest.raises(CompilationError, match="N marked as constexpr and listed in do_not_specialize"):
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constexprs={"N": 5}))
+
+    with pytest.raises(CompilationError, match="N marked as constexpr and listed in do_not_specialize"):
+        kernel[(1, )](5)

--- a/third_party/ascend/unittest/pytest_ut/test_compile_only.py
+++ b/third_party/ascend/unittest/pytest_ut/test_compile_only.py
@@ -1,0 +1,47 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# Copyright 2018-2020 Philippe Tillet
+# Copyright 2020-2022 OpenAI
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import torch_npu  # noqa: F401  # Registers the "npu" device with PyTorch.
+
+import triton
+import triton.language as tl
+from triton.compiler import ASTSource
+
+
+def test_signature_ordering():
+    """
+    Checks that ASTSource always uses the argument order from
+    fn.arg_names and not the signature.
+    """
+
+    @triton.jit
+    def kernel(a, o, N: tl.constexpr):
+        tl.store(o + N, tl.load(a + N))
+
+    # Add the arguments so the order always differs from fn.arg_names.
+    signature = {}
+    signature["N"] = "constexpr"
+    signature["a"] = "*fp32"
+    signature["o"] = "*fp32"
+    src = ASTSource(fn=kernel, constexprs={"N": 32}, signature=signature)
+    target = triton.runtime.driver.active.get_current_target()
+    triton.compile(src=src, target=target)

--- a/third_party/ascend/unittest/pytest_ut/test_core.py
+++ b/third_party/ascend/unittest/pytest_ut/test_core.py
@@ -1,0 +1,131 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# Copyright 2018-2020 Philippe Tillet
+# Copyright 2020-2022 OpenAI
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import torch
+import torch_npu  # noqa: F401  # Registers the "npu" device with PyTorch.
+
+import triton
+import triton.language as tl
+
+device = "npu"
+
+
+def test_constexpr_shape():
+
+    @triton.jit
+    def kernel(X):
+        off = tl.arange(0, 128 + 128)
+        tl.store(X + off, off)
+
+    x = torch.empty((256, ), dtype=torch.int32, device=device)
+    kernel[(1, )](x)
+    torch.testing.assert_close(x, torch.arange(0, 256, dtype=torch.int32, device=device))
+
+
+def test_constexpr_scalar_shape():
+
+    @triton.jit
+    def kernel(X, s):
+        off = tl.arange(0, 256)
+        val = off % (256 // s)
+        tl.store(X + off, val)
+
+    x = torch.empty((256, ), dtype=torch.int32, device=device)
+    kernel[(1, )](x, 32)
+    expected = torch.arange(0, 256, dtype=torch.int32, device=device) % 8
+    torch.testing.assert_close(x, expected)
+
+
+def test_dtype():
+
+    @triton.jit
+    def kernel(X):
+        dtype_x: tl.constexpr = X.dtype.element_ty
+        tl.static_assert(dtype_x == tl.int32)
+        tl.static_assert(dtype_x == tl.constexpr(tl.int32))
+        tl.static_assert(dtype_x == tl.int8 or (dtype_x == tl.int16 or dtype_x == tl.int32))
+
+    X = torch.empty(1, dtype=torch.int32, device=device)
+    kernel[(1, )](X)
+
+
+def test_aliasing():
+
+    @triton.jit
+    def aliasing_kernel(buffer, buffer2):
+        triton.language.store(buffer, 1)
+
+    buffer = torch.zeros(1, device=device)
+    aliasing_kernel[(1, )](buffer, buffer)
+    assert buffer[0] == 1
+
+
+def test_temp_var_in_loop():
+
+    @triton.jit
+    def temp_in_loop(Z, N: tl.constexpr, BLOCK: tl.constexpr):
+        acc = tl.full((BLOCK, ), 0, dtype=tl.int32)
+        for i in range(N):
+            if i == 0:
+                temp = tl.full((BLOCK, ), 2, dtype=tl.int32)
+                acc = temp
+            else:
+                acc += tl.full((BLOCK, ), 1, dtype=tl.int32)
+            # Reuse the temporary and verify that it does not create invalid IR.
+            temp = tl.full((BLOCK, ), 1, dtype=tl.int32)
+            acc += temp
+        z = Z + tl.arange(0, BLOCK)
+        tl.store(z, acc)
+
+    N = 10
+    BLOCK = 32
+    out = torch.empty((BLOCK, ), dtype=torch.int32, device=device)
+    temp_in_loop[(1, )](out, N, BLOCK)
+    acc = torch.full((BLOCK, ), 0, dtype=torch.int32, device=device)
+    for i in range(N):
+        if i == 0:
+            temp = torch.full((BLOCK, ), 2, dtype=torch.int32, device=device)
+            acc = temp
+        else:
+            acc += torch.full((BLOCK, ), 1, dtype=torch.int32, device=device)
+        temp = torch.full((BLOCK, ), 1, dtype=torch.int32, device=device)
+        acc += temp
+    assert (acc == out).all()
+
+
+def test_static_range():
+
+    @triton.jit
+    def loop_kernel(Z, N: tl.constexpr, step: tl.constexpr):
+        acc = 0
+        for i in tl.static_range(0, N, step=step):
+            acc += i
+        tl.store(Z, acc)
+
+    N = 100
+    step = 7
+    Out = torch.empty(1, dtype=torch.int32, device=device)
+    loop_kernel[(1, )](Out, N, step)
+    Acc = torch.tensor([0], dtype=torch.int32, device=device)
+    for i in range(0, N, step):
+        Acc += i
+    assert (Out == Acc).all(), (Out, Acc)

--- a/third_party/ascend/unittest/pytest_ut/test_decorator.py
+++ b/third_party/ascend/unittest/pytest_ut/test_decorator.py
@@ -1,0 +1,73 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# Copyright 2018-2020 Philippe Tillet
+# Copyright 2020-2022 OpenAI
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import pytest
+import torch
+import torch_npu  # noqa: F401  # Registers the "npu" device with PyTorch.
+
+import triton
+import triton.language as tl
+
+
+def test_decorator_with_def():
+
+    def triton_heuristics_pointwise(**kwargs):
+
+        def decorator(func):
+            return func
+
+        return decorator
+
+    # "def" might appear in a decorator call, e.g. a hash string argument.
+    # This test makes sure the compiler can find the right position of function
+    # definition.
+    @triton_heuristics_pointwise(inductor_meta={"backend_hash": "def0aeffabe53b3f8"})
+    @triton.jit
+    def kernel():
+        pass
+
+    try:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constexprs={}))
+    except Exception as exc:
+        pytest.fail(f"triton compile failed with error: {exc}")
+
+
+def test_triton_heuristic():
+    N = 1023
+    src = torch.empty(N, device="npu")
+    dst = torch.zeros(N, device="npu")
+
+    do_bench = lambda kernel, quantiles: triton.testing.do_bench(kernel, quantiles=quantiles, warmup=1, rep=1)
+
+    @triton.autotune(configs=[triton.Config(kwargs={"BLOCK_SIZE": 32})], key=["N"], do_bench=do_bench)
+    @triton.heuristics({"EVEN_N": lambda nargs: nargs["N"] % 2 == 0})  # Test kwargs.
+    @triton.heuristics({"EVEN_src": lambda nargs: nargs["src"].data_ptr() % 2 == 0})  # Test args.
+    @triton.jit
+    def _kernel(dst, src, N, BLOCK_SIZE: tl.constexpr, EVEN_N: tl.constexpr, EVEN_src: tl.constexpr):
+        tl.store(dst, EVEN_N)
+        tl.store(dst + 1, EVEN_src)
+
+    grid = lambda meta: (triton.cdiv(N, meta["BLOCK_SIZE"]), )
+    _kernel[grid](dst, src, N=N)
+    assert dst[0].item() == 0.0
+    assert dst[1].item() == 1.0
+    assert _kernel.base_fn.__name__ == "_kernel"

--- a/third_party/ascend/unittest/pytest_ut/test_jit.py
+++ b/third_party/ascend/unittest/pytest_ut/test_jit.py
@@ -1,0 +1,82 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# Copyright 2018-2020 Philippe Tillet
+# Copyright 2020-2022 OpenAI
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import torch
+import torch_npu  # noqa: F401  # Registers the "npu" device with PyTorch.
+
+import triton
+import triton.language as tl
+
+device = "npu"
+
+
+@triton.jit
+def _impl(value=10):
+    return value
+
+
+def test_default():
+    value = 5
+    ret0 = torch.zeros(1, dtype=torch.int32, device=device)
+    ret1 = torch.zeros(1, dtype=torch.int32, device=device)
+
+    @triton.jit
+    def _kernel(ret0, ret1, value=3):
+        tl.store(ret0, _impl())
+        tl.store(ret1, _impl(value))
+
+    _kernel[(1, )](ret0, ret1, value)
+    assert ret0.item() == 10
+    assert ret1.item() == value
+
+    _kernel[(1, )](ret0, ret1)
+    assert ret0.item() == 10
+    assert ret1.item() == 3
+
+
+@triton.jit
+def mul_jit_function(x, y):
+    return x * y
+
+
+@triton.jit
+def apply_binary_op(x, combine_op):
+    return combine_op(x, x)
+
+
+def test_jit_function_arg():
+
+    @triton.jit
+    def square_kernel_jit_function(in_ptr, out_ptr, BLOCK_SIZE: tl.constexpr):
+        offsets = tl.arange(0, BLOCK_SIZE)
+        in_data = tl.load(in_ptr + offsets)
+        out_data = apply_binary_op(in_data, mul_jit_function)
+        tl.store(out_ptr + offsets, out_data)
+
+    BLOCK_SIZE = 16
+    x = torch.full((BLOCK_SIZE, ), 3.0, device=device)
+    out = torch.empty((BLOCK_SIZE, ), device=device)
+    expect = torch.full((BLOCK_SIZE, ), 9.0, dtype=x.dtype, device=device)
+
+    square_kernel_jit_function[(1, )](x, out, BLOCK_SIZE)
+
+    torch.testing.assert_close(out, expect)

--- a/third_party/ascend/unittest/pytest_ut/test_launch_hooks.py
+++ b/third_party/ascend/unittest/pytest_ut/test_launch_hooks.py
@@ -1,0 +1,127 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# Copyright 2018-2020 Philippe Tillet
+# Copyright 2020-2022 OpenAI
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import torch_npu  # noqa: F401  # Registers the "npu" device with PyTorch.
+
+import triton
+
+
+def test_metadata():
+    used_hook = False
+
+    def _launch_metadata(grid, kernel, args):
+        return {"grid": grid, "value": args["x"]}
+
+    def hook(launch_metadata):
+        nonlocal used_hook
+        metadata = launch_metadata.get()
+        assert metadata["grid"] == (1, 3, 2)
+        assert metadata["value"] == 6
+        used_hook = True
+
+    @triton.jit(launch_metadata=_launch_metadata)
+    def kernel(x):
+        pass
+
+    triton.knobs.runtime.launch_enter_hook.add(hook)
+    try:
+        kernel[(1, 3, 2)](6)
+        assert used_hook
+    finally:
+        triton.knobs.runtime.launch_enter_hook.remove(hook)
+
+
+def test_load_hook():
+    used_start_hook = False
+    start_hash = None
+
+    def hook_start(module, function, name, metadata_group, hash):
+        nonlocal used_start_hook, start_hash
+        start_hash = hash
+        used_start_hook = True
+
+    used_end_hook = False
+    end_hash = None
+
+    def hook_end(module, function, name, metadata_group, hash):
+        nonlocal used_end_hook, end_hash
+        end_hash = hash
+        used_end_hook = True
+
+    @triton.jit
+    def kernel(x):
+        pass
+
+    triton.knobs.runtime.kernel_load_start_hook.add(hook_start)
+    triton.knobs.runtime.kernel_load_end_hook.add(hook_end)
+    try:
+        kernel[(1, 3, 2)](6)
+        assert used_start_hook
+        assert used_end_hook
+        assert start_hash == end_hash
+    finally:
+        triton.knobs.runtime.kernel_load_start_hook.remove(hook_start)
+        triton.knobs.runtime.kernel_load_end_hook.remove(hook_end)
+
+
+def test_multiple_hooks():
+    start0 = False
+    end0 = False
+    start1 = False
+    end1 = False
+
+    def hook_start0(module, function, name, metadata_group, hash):
+        nonlocal start0
+        start0 = True
+
+    def hook_end0(module, function, name, metadata_group, hash):
+        nonlocal end0
+        end0 = True
+
+    def hook_start1(module, function, name, metadata_group, hash):
+        nonlocal start1
+        start1 = True
+
+    def hook_end1(module, function, name, metadata_group, hash):
+        nonlocal end1
+        end1 = True
+
+    triton.knobs.runtime.kernel_load_start_hook.add(hook_start0)
+    triton.knobs.runtime.kernel_load_end_hook.add(hook_end0)
+    triton.knobs.runtime.kernel_load_start_hook.add(hook_start1)
+    triton.knobs.runtime.kernel_load_end_hook.add(hook_end1)
+
+    @triton.jit
+    def kernel(x):
+        pass
+
+    try:
+        kernel[(1, )](6)
+        assert start0
+        assert end0
+        assert start1
+        assert end1
+    finally:
+        triton.knobs.runtime.kernel_load_start_hook.remove(hook_start0)
+        triton.knobs.runtime.kernel_load_end_hook.remove(hook_end0)
+        triton.knobs.runtime.kernel_load_start_hook.remove(hook_start1)
+        triton.knobs.runtime.kernel_load_end_hook.remove(hook_end1)

--- a/third_party/ascend/unittest/pytest_ut/test_pre_run_hooks.py
+++ b/third_party/ascend/unittest/pytest_ut/test_pre_run_hooks.py
@@ -1,0 +1,53 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# Copyright 2018-2020 Philippe Tillet
+# Copyright 2020-2022 OpenAI
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import torch
+import torch_npu  # noqa: F401  # Registers the "npu" device with PyTorch.
+
+import triton
+import triton.language as tl
+
+device = "npu"
+
+
+def test_pre_run_hooks():
+
+    @triton.jit
+    def add_kernel(a_ptr, n_elements: tl.constexpr):
+        offsets = tl.arange(0, n_elements)
+        a = tl.load(a_ptr + offsets)
+        a += 2
+        tl.store(a_ptr + offsets, a)
+
+    def my_hook(*args, **kwargs):
+        args[0].zero_()
+
+    add_kernel.add_pre_run_hook(my_hook)
+
+    n_elements = 4
+    a = torch.ones(n_elements, device=device, dtype=torch.int32)
+    add_kernel[(1, )](a, n_elements)
+    assert torch.all(a == 2)
+
+    a = torch.ones(n_elements, device=device, dtype=torch.int32)
+    add_kernel.run(a, n_elements, grid=(1, ), warmup=False)
+    assert torch.all(a == 2)

--- a/third_party/ascend/unittest/pytest_ut/test_tuple.py
+++ b/third_party/ascend/unittest/pytest_ut/test_tuple.py
@@ -1,0 +1,112 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# Copyright 2018-2020 Philippe Tillet
+# Copyright 2020-2022 OpenAI
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import pytest
+import torch
+import torch_npu  # noqa: F401  # Registers the "npu" device with PyTorch.
+
+import triton
+import triton.language as tl
+
+device = "npu"
+
+
+@triton.jit
+def _tuple_ret(a, b):
+    return a + b, a - b, a * b
+
+
+def test_assign_return():
+
+    @triton.jit
+    def with_fn(X, Y, A, B, C):
+        x = tl.load(X)
+        y = tl.load(Y)
+        a, b, c = _tuple_ret(x, y)
+        tl.store(A, a)
+        tl.store(B, b)
+        tl.store(C, c)
+
+    @triton.jit
+    def without_fn(X, Y, A, B, C):
+        x = tl.load(X)
+        y = tl.load(Y)
+        a, b, c = x + y, x - y, x * y
+        tl.store(A, a)
+        tl.store(B, b)
+        tl.store(C, c)
+
+    x = torch.tensor([1.3], device=device, dtype=torch.float32)
+    y = torch.tensor([1.9], device=device, dtype=torch.float32)
+    a_tri = torch.tensor([0], device=device, dtype=torch.float32)
+    b_tri = torch.tensor([0], device=device, dtype=torch.float32)
+    c_tri = torch.tensor([0], device=device, dtype=torch.float32)
+    for kernel in [with_fn, without_fn]:
+        kernel[(1, )](x, y, a_tri, b_tri, c_tri, num_warps=1)
+        a_ref, b_ref, c_ref = x + y, x - y, x * y
+        assert a_tri == a_ref
+        assert b_tri == b_ref
+        assert c_tri == c_ref
+
+
+def test_eq():
+
+    @triton.jit
+    def fn(ret_ptrs):
+        tl.store(ret_ptrs + 0, (1, 2) == (1, 2))
+        tl.store(ret_ptrs + 1, (1, 2) == (1, 1))
+        tl.store(ret_ptrs + 2, tl.tuple((1, 2)) == (1, 2))
+        tl.store(ret_ptrs + 3, tl.tuple((1, 2)) == (1, 3))
+
+    rets = torch.zeros((4, ), dtype=torch.int32, device=device)
+    fn[(1, )](rets)
+    assert rets[0].item() == 1
+    assert rets[1].item() == 0
+    assert rets[2].item() == 1
+    assert rets[3].item() == 0
+
+
+def test_add():
+
+    @triton.jit
+    def fn(ret_ptrs):
+        tuple0 = ((0, 1)) + (2, 3)
+        for i in tl.static_range(4):
+            tl.store(ret_ptrs + i, tuple0[i])
+        tuple1 = tl.tuple((4, 5)) + (6, 7)
+        for i in tl.static_range(4):
+            tl.store(ret_ptrs + 4 + i, tuple1[i])
+
+    rets = torch.zeros((8, ), dtype=torch.int32, device=device)
+    fn[(1, )](rets)
+    torch.testing.assert_close(rets.cpu(), torch.arange(8, dtype=torch.int32))
+
+
+def test_modifying_tuples():
+
+    @triton.jit
+    def set_tuple_value_at_idx():
+        t = tl.tuple([5, 6, 7])
+        t[0] = 0
+
+    with pytest.raises(triton.CompilationError):
+        set_tuple_value_at_idx[(1, )]()


### PR DESCRIPTION
## Summary

- Migrate 59 existing Triton community tests from python/test/unit into the Ascend pytest suite.
- Cover bindings, cache invalidation and specialization, compilation diagnostics, compile-only paths, language core behavior, decorators, JIT function arguments, launch and pre-run hooks, and tuples.
- Preserve the original test intent and assertions. Of the 59 test functions, 28 keep the community test AST unchanged and 31 contain Ascend device adaptation, test-state isolation, or non-semantic cleanup.

## Source audit

- Every migrated test maps to one unique community source test; no duplicate or self-invented cases were added.
- No skip, skipif, or xfail marker was introduced.
- No assertion was removed or relaxed.
- No CUDA, NVIDIA, AMD, HIP, ROCm, PTX, or GPU hard-coding remains in these files.

## Validation

- The 59 migrated nodes passed on a physical Ascend NPU with a cold cache: 59 passed.
- That runtime evidence used wheel 3.6.0.dev0+gitc9a8d5e4.
- This branch is based on current main-dev commit 41509cb78, but the wheel has not yet been rebuilt from that commit; CI or a fresh wheel still needs to validate the latest backend binary.
- Targeted Ruff and YAPF checks passed, and git diff --check is clean.
- Full pre-commit was not run locally.

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following the linked why-not-how guidance.
- [ ] I have run pre-commit run from the target base to HEAD.
- [x] I have added Python end-to-end tests under third_party/ascend/unittest/pytest_ut.
- [x] I have not added any lit tests.