### PR TITLE
[simd_simt](fix) use getRealReductionOps in ScanConverter

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -1264,7 +1264,7 @@ LogicalResult
 ScanConverter::convertToTargetOp(triton::ScanOp op,
                                  typename triton::ScanOp::Adaptor adaptor,
                                  ConversionPatternRewriter &rewriter) const {
-  auto reductionOps = this->getReductionOps(op);
+  auto reductionOps = this->getRealReductionOps(op);
   if (reductionOps.empty()) {
     return rewriter.notifyMatchFailure(op,
                                        "No reduction op found in scan body");

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/scan_debug_assert.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/scan_debug_assert.mlir
@@ -1,0 +1,62 @@
+// RUN: triton-opt --triton-to-linalg="named-ops=True" --split-input-file %s | FileCheck %s
+
+// TRITON_DEBUG=1 makes the frontend insert an integer-overflow-check
+// prologue (widen to i64, compare against i32 bounds, tt.assert) ahead of
+// the real arith.addi inside a tt.scan combine body. ScanConverter must
+// still recognize arith.addi as the sole real reduction op and lower to the
+// triton_cumsum library call, instead of mis-selecting one of the prologue
+// ops (e.g. arith.extsi, which is the first op in program order) and
+// falling back to the slow generic associative-scan expansion.
+// CHECK-LABEL: func.func @cumsum_with_debug_assert
+// CHECK: call @triton_cumsum
+// CHECK-NOT: memref.alloc
+// CHECK-NOT: bufferization.to_buffer
+tt.func public @cumsum_with_debug_assert(%in: !tt.ptr<i32>, %out: !tt.ptr<i32>) {
+  %off = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  %in_splat = tt.splat %in : !tt.ptr<i32> -> tensor<128x!tt.ptr<i32>>
+  %in_ptrs = tt.addptr %in_splat, %off : tensor<128x!tt.ptr<i32>>, tensor<128xi32>
+  %x = tt.load %in_ptrs : tensor<128x!tt.ptr<i32>>
+  %0 = "tt.scan"(%x) <{axis = 0 : i32, reverse = false}> ({
+  ^bb0(%arg0: i32, %arg1: i32):
+    %lhs64 = arith.extsi %arg0 : i32 to i64
+    %rhs64 = arith.extsi %arg1 : i32 to i64
+    %sum64 = arith.addi %lhs64, %rhs64 : i64
+    %max = arith.constant 2147483647 : i64
+    %min = arith.constant -2147483648 : i64
+    %le = arith.cmpi sle, %sum64, %max : i64
+    %ge = arith.cmpi sge, %sum64, %min : i64
+    %cond = arith.andi %le, %ge : i1
+    tt.assert %cond, "int32 overflow detected for operation add" : i1
+    %res = arith.addi %arg0, %arg1 : i32
+    tt.scan.return %res : i32
+  }) : (tensor<128xi32>) -> tensor<128xi32>
+  %out_splat = tt.splat %out : !tt.ptr<i32> -> tensor<128x!tt.ptr<i32>>
+  %out_ptrs = tt.addptr %out_splat, %off : tensor<128x!tt.ptr<i32>>, tensor<128xi32>
+  tt.store %out_ptrs, %0 : tensor<128x!tt.ptr<i32>>
+  tt.return
+}
+
+// -----
+
+// Control: the same cumsum WITHOUT the debug-assert prologue must still
+// take the triton_cumsum fast path. Guards against a fix that only works
+// when the assert prologue is present.
+// CHECK-LABEL: func.func @cumsum_without_debug_assert
+// CHECK: call @triton_cumsum
+// CHECK-NOT: memref.alloc
+// CHECK-NOT: bufferization.to_buffer
+tt.func public @cumsum_without_debug_assert(%in: !tt.ptr<i32>, %out: !tt.ptr<i32>) {
+  %off = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  %in_splat = tt.splat %in : !tt.ptr<i32> -> tensor<128x!tt.ptr<i32>>
+  %in_ptrs = tt.addptr %in_splat, %off : tensor<128x!tt.ptr<i32>>, tensor<128xi32>
+  %x = tt.load %in_ptrs : tensor<128x!tt.ptr<i32>>
+  %0 = "tt.scan"(%x) <{axis = 0 : i32, reverse = false}> ({
+  ^bb0(%arg0: i32, %arg1: i32):
+    %res = arith.addi %arg0, %arg1 : i32
+    tt.scan.return %res : i32
+  }) : (tensor<128xi32>) -> tensor<128xi32>
+  %out_splat = tt.splat %out : !tt.ptr<i32> -> tensor<128x!tt.ptr<i32>>
+  %out_ptrs = tt.addptr %out_splat, %off : tensor<128x!tt.ptr<i32>>, tensor<128xi32>
+  tt.store %out_ptrs, %0 : tensor<128x!tt.ptr<i32>>
+  tt.return
+}


### PR DESCRIPTION
## Why

`ScanConverter::convertToTargetOp` used `getReductionOps`, which returns every op in the scan body (except the terminator).

When `TRITON_DEBUG=1`, the frontend inserts overflow-check assert semantics (`tt.assert` plus its condition-computing ops) directly into the combine body alongside the real reduction op. With the naive `getReductionOps`, `reductionOps.front()` could end up being one of these inserted assert-related ops instead of the actual add/mul/max/min op, which breaks `isReductionOpSupported` whenever `TRITON_DEBUG=1` is set on a `tl.cumsum`/`cumprod`/`cummax`/`cummin`.

## What

Switch `getReductionOps` to `getRealReductionOps`, which computes a backward slice from the body's yielded value so only ops that actually feed the scan result are kept (it also already filters `arith.extf`/`arith.truncf`/`arith.bitcast` precision casts).

## Testing

- `TRITON_DEBUG=1` + `tl.cumsum` now correctly dispatch to the right cumsum library function.

---
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
