### PR TITLE
[TritonToGraph](feat) log graph optimization rule matches

### DIFF
--- a/third_party/ascend/lib/TritonToGraph/GraphOptimizationPass.cpp
+++ b/third_party/ascend/lib/TritonToGraph/GraphOptimizationPass.cpp
@@ -231,8 +231,14 @@ void GraphOptimizePass::runOnOperation() {
         for (std::unique_ptr<RewritePlan> &plan : plans) {
           if (plan->getCreationEpoch() != context.getEpoch())
             continue;
-          if (failed(plan->revalidate(context)))
+          if (failed(plan->revalidate(context))) {
+            LLVM_DEBUG(
+                llvm::dbgs()
+                << "[" DEBUG_TYPE "] dropped stale graph optimization rule "
+                << static_cast<unsigned>(plan->getRuleId()) << " ("
+                << getGraphOptimizationRuleName(plan->getRuleId()) << ")\n");
             continue;
+          }
 
           selectedPlan = std::move(plan);
           break;

--- a/third_party/ascend/lib/TritonToGraph/LegacyMemoryAccess/ChunkCoalescing.cpp
+++ b/third_party/ascend/lib/TritonToGraph/LegacyMemoryAccess/ChunkCoalescing.cpp
@@ -22,6 +22,7 @@
 
 #include "TritonToGraph/LegacyMemoryAccess/ChunkCoalescing.h"
 
+#include "TritonToGraph/GraphOptimization.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -34,7 +35,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
 
-#define DEBUG_TYPE "chunk-coalescing"
+#define DEBUG_TYPE "graph-optimize"
 
 #include <algorithm>
 #include <functional>
@@ -394,6 +395,17 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
     }
     return RankedTensorType::get({H}, t);
   };
+
+  LLVM_DEBUG(llvm::dbgs() << "[" DEBUG_TYPE "] matched graph optimization rule "
+                          << static_cast<unsigned>(
+                                 cfg::GraphOptimizationRuleId::ChunkCoalescing)
+                          << " ("
+                          << cfg::getGraphOptimizationRuleName(
+                                 cfg::GraphOptimizationRuleId::ChunkCoalescing)
+                          << ") at " << ploc << ": tileLen=" << seed->tileLen
+                          << " bound=" << seed->bound
+                          << " numTiles=" << numTiles << " maxH=" << maxH
+                          << " H=" << H << "\n");
 
   rw.setInsertionPointAfter(seed->pid);
   Value cH = rw.create<arith::ConstantIntOp>(ploc, H, 32);

--- a/third_party/ascend/lib/TritonToGraph/LegacyMemoryAccess/RowCoalescing.cpp
+++ b/third_party/ascend/lib/TritonToGraph/LegacyMemoryAccess/RowCoalescing.cpp
@@ -22,6 +22,7 @@
 
 #include "TritonToGraph/LegacyMemoryAccess/RowCoalescing.h"
 
+#include "TritonToGraph/GraphOptimization.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Math/IR/Math.h"
@@ -34,10 +35,13 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
 
 #include <algorithm>
 #include <functional>
 #include <optional>
+
+#define DEBUG_TYPE "graph-optimize"
 
 namespace RowCoalescing {
 
@@ -620,6 +624,16 @@ static void rewriteModule(ModuleOp moduleOp, IRRewriter &rw) {
 
   if (!rewriteMatchedRow(moduleOp, *seed, ordered, rw, rowsPerProgram))
     return;
+
+  LLVM_DEBUG(llvm::dbgs() << "[" DEBUG_TYPE "] matched graph optimization rule "
+                          << static_cast<unsigned>(
+                                 cfg::GraphOptimizationRuleId::RowCoalescing)
+                          << " ("
+                          << cfg::getGraphOptimizationRuleName(
+                                 cfg::GraphOptimizationRuleId::RowCoalescing)
+                          << ") at " << seed->pid.getLoc()
+                          << ": axis=" << seed->axis
+                          << " rowsPerProgram=" << rowsPerProgram << "\n");
 
   auto i32Ty = IntegerType::get(moduleOp.getContext(), 32);
   moduleOp->setAttr(kCoalesceFactorAttr,

--- a/third_party/ascend/lib/TritonToGraph/LegacyMemoryAccess/StridedAxisCoalescing.cpp
+++ b/third_party/ascend/lib/TritonToGraph/LegacyMemoryAccess/StridedAxisCoalescing.cpp
@@ -22,14 +22,18 @@
 
 #include "TritonToGraph/LegacyMemoryAccess/StridedAxisCoalescing.h"
 
+#include "TritonToGraph/GraphOptimization.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Matchers.h"
+#include "llvm/Support/Debug.h"
 
 #include <functional>
+
+#define DEBUG_TYPE "graph-optimize"
 
 namespace StridedAxisCoalescing {
 
@@ -564,6 +568,17 @@ void rewriteStridedAxisCoalesce(ModuleOp moduleOp) {
       }
     }
   }
+
+  LLVM_DEBUG(
+      llvm::dbgs() << "[" DEBUG_TYPE "] matched graph optimization rule "
+                   << static_cast<unsigned>(
+                          cfg::GraphOptimizationRuleId::StridedAxisCoalescing)
+                   << " ("
+                   << cfg::getGraphOptimizationRuleName(
+                          cfg::GraphOptimizationRuleId::StridedAxisCoalescing)
+                   << ") at " << seeds.front().getLoc() << ": stride=" << S
+                   << " tileLen=" << BT << " axis=" << coalesceAxis << " loads="
+                   << seeds.size() << " stores=" << sinks.size() << "\n");
 
   // Erase the original chain (sinks, then region in reverse order, then seeds).
   for (auto st : sinks)

--- a/third_party/ascend/lib/TritonToGraph/LegacyMemoryAccess/StridedLoadStoreRewrite.cpp
+++ b/third_party/ascend/lib/TritonToGraph/LegacyMemoryAccess/StridedLoadStoreRewrite.cpp
@@ -27,6 +27,7 @@
 #include "Utils/Utils.h"
 
 #include "Dialect/TritonAscend/IR/TritonAscendDialect.h"
+#include "TritonToGraph/GraphOptimization.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
@@ -35,8 +36,10 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Matchers.h"
 
+#include "llvm/ADT/Twine.h"
 #include "llvm/Support/Debug.h"
 
+#include <cstdint>
 #include <cstdlib>
 #include <functional>
 
@@ -52,6 +55,21 @@ namespace {
 // V1 fast-path supports up to 5D tensors, mirroring
 // UnstructureConversionPass::tryRewriteIndirectFastPath.
 constexpr size_t kFastPathRankLimit = 5;
+
+// Funnel for the eight rewrite variants, which differ only in how the pointer
+// was formed and which op they produce.
+static void logMatch(Location loc, const llvm::Twine &pointerKind,
+                     const llvm::Twine &rewrite, int64_t lastStride) {
+  LLVM_DEBUG(
+      llvm::dbgs() << "[" DEBUG_TYPE "] matched graph optimization rule "
+                   << static_cast<unsigned>(
+                          cfg::GraphOptimizationRuleId::StridedLoadStoreRewrite)
+                   << " ("
+                   << cfg::getGraphOptimizationRuleName(
+                          cfg::GraphOptimizationRuleId::StridedLoadStoreRewrite)
+                   << ") at " << loc << ": [" << pointerKind << "] " << rewrite
+                   << " lastStride=" << lastStride << "\n");
+}
 
 // Returns true iff `v` is a static integer constant with |v| > 1.
 static bool isStaticConstAbsGtOne(Value v) {
@@ -755,14 +773,7 @@ static LogicalResult tryRewriteAddPtrLoad(triton::LoadOp op,
       if (!strideLoadResult)
         return markInspectedAndReturn();
 
-      LLVM_DEBUG({
-        llvm::dbgs() << "----------------------------------------------\n";
-        llvm::dbgs() << "StridedLoadStoreRewrite [AddPtr]: tt.load -> "
-                        "ttasc.stride_load\n";
-        llvm::dbgs() << "  last_stride = " << lastStride << "\n";
-        llvm::dbgs() << strideLoadResult.getDefiningOp() << "\n";
-        llvm::dbgs() << "----------------------------------------------\n";
-      });
+      logMatch(loc, "AddPtr", "tt.load -> ttasc.stride_load", lastStride);
       rewriter.replaceOp(op, strideLoadResult);
       return success();
     }
@@ -790,14 +801,7 @@ static LogicalResult tryRewriteAddPtrLoad(triton::LoadOp op,
   indirectLoad->setAttr(RewrittenByStridedLoadStoreRewriteTAG,
                         UnitAttr::get(rewriter.getContext()));
 
-  LLVM_DEBUG({
-    llvm::dbgs() << "----------------------------------------------\n";
-    llvm::dbgs() << "StridedLoadStoreRewrite [AddPtr]: tt.load -> "
-                    "tt.indirect_load\n";
-    llvm::dbgs() << "  last_stride = " << lastStride << "\n";
-    llvm::dbgs() << indirectLoad << "\n";
-    llvm::dbgs() << "----------------------------------------------\n";
-  });
+  logMatch(loc, "AddPtr", "tt.load -> tt.indirect_load", lastStride);
   rewriter.replaceOp(op, indirectLoad.getResult());
   return success();
 }
@@ -930,15 +934,8 @@ static LogicalResult tryRewriteBlockPtrLoad(triton::LoadOp op,
       if (!strideLoadResult)
         return failure();
 
-      LLVM_DEBUG({
-        llvm::dbgs() << "----------------------------------------------\n";
-        llvm::dbgs() << "StridedLoadStoreRewrite [BlockPtr"
-                     << (advance ? "+Advance" : "")
-                     << "]: tt.load -> ttasc.stride_load\n";
-        llvm::dbgs() << "  last_stride = " << lastStride << "\n";
-        llvm::dbgs() << strideLoadResult.getDefiningOp() << "\n";
-        llvm::dbgs() << "----------------------------------------------\n";
-      });
+      logMatch(loc, llvm::Twine("BlockPtr") + (advance ? "+Advance" : ""),
+               "tt.load -> ttasc.stride_load", lastStride);
       rewriter.replaceOp(op, strideLoadResult);
       return success();
     }
@@ -1003,16 +1000,10 @@ static LogicalResult tryRewriteBlockPtrLoad(triton::LoadOp op,
   indirectLoad->setAttr(RewrittenByStridedLoadStoreRewriteTAG,
                         UnitAttr::get(rewriter.getContext()));
 
-  LLVM_DEBUG({
-    llvm::dbgs() << "----------------------------------------------\n";
-    llvm::dbgs() << "StridedLoadStoreRewrite [BlockPtr"
-                 << (advance ? "+Advance" : "")
-                 << (boundaryCheck.empty() ? "" : "+Boundary")
-                 << "]: tt.load -> tt.indirect_load\n";
-    llvm::dbgs() << "  last_stride = " << lastStride << "\n";
-    llvm::dbgs() << indirectLoad << "\n";
-    llvm::dbgs() << "----------------------------------------------\n";
-  });
+  logMatch(loc,
+           llvm::Twine("BlockPtr") + (advance ? "+Advance" : "") +
+               (boundaryCheck.empty() ? "" : "+Boundary"),
+           "tt.load -> tt.indirect_load", lastStride);
   rewriter.replaceOp(op, indirectLoad.getResult());
   return success();
 }
@@ -1103,14 +1094,7 @@ static LogicalResult tryRewriteAddPtrStore(triton::StoreOp op,
       if (!strideStore)
         return markInspectedAndReturn();
 
-      LLVM_DEBUG({
-        llvm::dbgs() << "----------------------------------------------\n";
-        llvm::dbgs() << "StridedLoadStoreRewrite [AddPtr/Store]: "
-                        "tt.store -> ttasc.stride_store\n";
-        llvm::dbgs() << "  last_stride = " << lastStride << "\n";
-        llvm::dbgs() << *strideStore << "\n";
-        llvm::dbgs() << "----------------------------------------------\n";
-      });
+      logMatch(loc, "AddPtr", "tt.store -> ttasc.stride_store", lastStride);
       rewriter.eraseOp(op);
       return success();
     }
@@ -1137,14 +1121,7 @@ static LogicalResult tryRewriteAddPtrStore(triton::StoreOp op,
   indirectStore->setAttr(RewrittenByStridedLoadStoreRewriteTAG,
                          UnitAttr::get(rewriter.getContext()));
 
-  LLVM_DEBUG({
-    llvm::dbgs() << "----------------------------------------------\n";
-    llvm::dbgs() << "StridedLoadStoreRewrite [AddPtr/Store]: tt.store -> "
-                    "tt.indirect_store\n";
-    llvm::dbgs() << "  last_stride = " << lastStride << "\n";
-    llvm::dbgs() << indirectStore << "\n";
-    llvm::dbgs() << "----------------------------------------------\n";
-  });
+  logMatch(loc, "AddPtr", "tt.store -> tt.indirect_store", lastStride);
   rewriter.eraseOp(op);
   return success();
 }
@@ -1246,16 +1223,10 @@ static LogicalResult tryRewriteBlockPtrStore(triton::StoreOp op,
           createStrideStoreOp(loc, valueType, src, op.getValue(), scalarBase,
                               strideOperands, *numels, rewriter);
       if (strideStore) {
-        LLVM_DEBUG({
-          llvm::dbgs() << "----------------------------------------------\n";
-          llvm::dbgs() << "StridedLoadStoreRewrite [BlockPtr"
-                       << (advance ? "+Advance" : "")
-                       << (boundaryCheck.empty() ? "" : "+Boundary")
-                       << "/Store]: tt.store -> ttasc.stride_store\n";
-          llvm::dbgs() << "  last_stride = " << lastStride << "\n";
-          llvm::dbgs() << *strideStore << "\n";
-          llvm::dbgs() << "----------------------------------------------\n";
-        });
+        logMatch(loc,
+                 llvm::Twine("BlockPtr") + (advance ? "+Advance" : "") +
+                     (boundaryCheck.empty() ? "" : "+Boundary"),
+                 "tt.store -> ttasc.stride_store", lastStride);
         rewriter.eraseOp(op);
         return success();
       }
@@ -1308,16 +1279,10 @@ static LogicalResult tryRewriteBlockPtrStore(triton::StoreOp op,
   indirectStore->setAttr(RewrittenByStridedLoadStoreRewriteTAG,
                          UnitAttr::get(rewriter.getContext()));
 
-  LLVM_DEBUG({
-    llvm::dbgs() << "----------------------------------------------\n";
-    llvm::dbgs() << "StridedLoadStoreRewrite [BlockPtr"
-                 << (advance ? "+Advance" : "")
-                 << (boundaryCheck.empty() ? "" : "+Boundary")
-                 << "/Store]: tt.store -> tt.indirect_store\n";
-    llvm::dbgs() << "  last_stride = " << lastStride << "\n";
-    llvm::dbgs() << indirectStore << "\n";
-    llvm::dbgs() << "----------------------------------------------\n";
-  });
+  logMatch(loc,
+           llvm::Twine("BlockPtr") + (advance ? "+Advance" : "") +
+               (boundaryCheck.empty() ? "" : "+Boundary"),
+           "tt.store -> tt.indirect_store", lastStride);
   rewriter.eraseOp(op);
   return success();
 }

--- a/third_party/ascend/lib/TritonToGraph/MergeConcatLoadBuffer.cpp
+++ b/third_party/ascend/lib/TritonToGraph/MergeConcatLoadBuffer.cpp
@@ -531,8 +531,9 @@ public:
       }
     }
 
-    LLVM_DEBUG(llvm::dbgs() << "Merging concat load buffers:\n  "
-                            << infoA->alloc << "\n  " << infoB->alloc << "\n");
+    LLVM_DEBUG(llvm::dbgs() << "[" DEBUG_TYPE "] matched at "
+                            << insertOp.getLoc() << ": fillDead=" << fillDead
+                            << " keepSingleFill=" << keepSingleFill << "\n");
 
     if (fillDead) {
       eraseFill(rewriter, infoA->fill);

--- a/third_party/ascend/lib/TritonToGraph/Rules/ConvertModuloToMaskRule.cpp
+++ b/third_party/ascend/lib/TritonToGraph/Rules/ConvertModuloToMaskRule.cpp
@@ -34,6 +34,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
 
 #include <algorithm>
 #include <cstddef>
@@ -42,6 +43,8 @@
 #include <memory>
 #include <optional>
 #include <utility>
+
+#define DEBUG_TYPE "graph-optimize"
 
 using namespace mlir;
 using namespace triton;
@@ -803,9 +806,17 @@ public:
     context.getFunction().walk([&](Operation *op) {
       if (!isa<arith::RemSIOp, arith::SubIOp>(op))
         return;
-      if (std::optional<ModuloCandidate> candidate = analyzeModulo(op))
+      if (std::optional<ModuloCandidate> candidate = analyzeModulo(op)) {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "[" DEBUG_TYPE "] matched graph optimization rule "
+                   << static_cast<unsigned>(getId()) << " ("
+                   << getGraphOptimizationRuleName(getId()) << ") at "
+                   << op->getLoc() << ": " << op->getName()
+                   << " tileSize=" << candidate->tileSize
+                   << " maskedLoads=" << candidate->loads.size() << "\n");
         plans.push_back(std::make_unique<ConvertModuloToMaskPlan>(
             std::move(*candidate), context.getEpoch()));
+      }
     });
     return success();
   }

--- a/third_party/ascend/lib/TritonToGraph/Rules/DiagonalMaskRemovalRule.cpp
+++ b/third_party/ascend/lib/TritonToGraph/Rules/DiagonalMaskRemovalRule.cpp
@@ -57,6 +57,7 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -64,6 +65,8 @@
 #include <limits>
 #include <memory>
 #include <optional>
+
+#define DEBUG_TYPE "graph-optimize"
 
 using namespace mlir;
 using namespace triton;
@@ -516,9 +519,16 @@ public:
       GraphOptimizationContext &context,
       SmallVectorImpl<std::unique_ptr<RewritePlan>> &plans) override {
     context.getFunction().walk([&](triton::ReduceOp reduce) {
-      if (std::optional<DiagonalCandidate> candidate = analyzeDiagonal(reduce))
+      if (std::optional<DiagonalCandidate> candidate =
+              analyzeDiagonal(reduce)) {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "[" DEBUG_TYPE "] matched graph optimization rule "
+                   << static_cast<unsigned>(getId()) << " ("
+                   << getGraphOptimizationRuleName(getId()) << ") at "
+                   << reduce.getLoc() << "\n");
         plans.push_back(std::make_unique<DiagonalMaskRemovalPlan>(
             *candidate, context.getEpoch()));
+      }
     });
     return success();
   }

--- a/third_party/ascend/lib/TritonToGraph/Rules/LoadStoreTransposeRule.cpp
+++ b/third_party/ascend/lib/TritonToGraph/Rules/LoadStoreTransposeRule.cpp
@@ -36,6 +36,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -43,6 +44,8 @@
 #include <memory>
 #include <optional>
 #include <utility>
+
+#define DEBUG_TYPE "graph-optimize"
 
 using namespace mlir;
 using namespace triton;
@@ -2165,6 +2168,14 @@ public:
       std::optional<LayoutPermutationCandidate> candidate =
           matchLoopCandidate(loop);
       if (candidate) {
+        LLVM_DEBUG({
+          llvm::dbgs() << "[" DEBUG_TYPE "] matched graph optimization rule "
+                       << static_cast<unsigned>(getId()) << " ("
+                       << getGraphOptimizationRuleName(getId()) << ") at loop "
+                       << candidate->anchor->getLoc() << ": perm=[";
+          llvm::interleaveComma(candidate->permutation, llvm::dbgs());
+          llvm::dbgs() << "] endpoints=" << candidate->endpointCount << "\n";
+        });
         plans.push_back(std::make_unique<LayoutPermutationPlan>(
             std::move(*candidate), context.getEpoch()));
       }
@@ -2184,6 +2195,14 @@ public:
       std::optional<LayoutPermutationCandidate> candidate =
           matchBlockCandidate(block);
       if (candidate) {
+        LLVM_DEBUG({
+          llvm::dbgs() << "[" DEBUG_TYPE "] matched graph optimization rule "
+                       << static_cast<unsigned>(getId()) << " ("
+                       << getGraphOptimizationRuleName(getId()) << ") at block "
+                       << candidate->anchor->getLoc() << ": perm=[";
+          llvm::interleaveComma(candidate->permutation, llvm::dbgs());
+          llvm::dbgs() << "] endpoints=" << candidate->endpointCount << "\n";
+        });
         plans.push_back(std::make_unique<LayoutPermutationPlan>(
             std::move(*candidate), context.getEpoch()));
       }

--- a/third_party/ascend/lib/TritonToGraph/Rules/RowCoalescingRule.cpp
+++ b/third_party/ascend/lib/TritonToGraph/Rules/RowCoalescingRule.cpp
@@ -35,10 +35,13 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
 
 #include <algorithm>
 #include <memory>
 #include <optional>
+
+#define DEBUG_TYPE "graph-optimize"
 
 using namespace mlir;
 using namespace triton;
@@ -392,9 +395,17 @@ public:
       GraphOptimizationContext &context,
       SmallVectorImpl<std::unique_ptr<RewritePlan>> &plans) override {
     if (std::optional<RowCandidate> candidate =
-            analyzeRow(context.getFunction()))
+            analyzeRow(context.getFunction())) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "[" DEBUG_TYPE "] matched graph optimization rule "
+                 << static_cast<unsigned>(getId()) << " ("
+                 << getGraphOptimizationRuleName(getId()) << ") in @"
+                 << candidate->function.getName()
+                 << ": axis=" << candidate->axis
+                 << " rowsPerProgram=" << candidate->rowsPerProgram << "\n");
       plans.push_back(
           std::make_unique<RowCoalescingPlan>(*candidate, context.getEpoch()));
+    }
     return success();
   }
 };

--- a/third_party/ascend/lib/TritonToGraph/Rules/StoreCoalescingRule.cpp
+++ b/third_party/ascend/lib/TritonToGraph/Rules/StoreCoalescingRule.cpp
@@ -33,6 +33,7 @@
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -40,6 +41,8 @@
 #include <memory>
 #include <optional>
 #include <utility>
+
+#define DEBUG_TYPE "graph-optimize"
 
 using namespace mlir;
 using namespace triton;
@@ -741,6 +744,13 @@ public:
         &context.getEntryArgPointerAliasAnalysis();
     for (const StoreCoalescingRun &run :
          findRuns(context.getFunction(), ubCapacityBytes, entryAliases)) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "[" DEBUG_TYPE "] matched graph optimization rule "
+                 << static_cast<unsigned>(getId()) << " ("
+                 << getGraphOptimizationRuleName(getId()) << ") at "
+                 << run.anchor->getLoc()
+                 << ": stores=" << run.programOrderStores.size() << " elements="
+                 << run.totalElements << " bytes=" << run.totalBytes << "\n");
       plans.push_back(std::make_unique<StoreCoalescingPlan>(
           run, context.getFunction(), entryAliases, ubCapacityBytes,
           context.getEpoch()));

--- a/third_party/ascend/lib/TritonToGraph/Rules/TransposePointwiseReorderRule.cpp
+++ b/third_party/ascend/lib/TritonToGraph/Rules/TransposePointwiseReorderRule.cpp
@@ -32,10 +32,13 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
 
 #include <memory>
 #include <optional>
 #include <utility>
+
+#define DEBUG_TYPE "graph-optimize"
 
 using namespace mlir;
 using namespace triton;
@@ -386,6 +389,12 @@ public:
       for (unsigned operandIndex : {0u, 1u}) {
         std::optional<MatchedChain> chain = matchCandidate(dot, operandIndex);
         if (chain) {
+          LLVM_DEBUG(llvm::dbgs()
+                     << "[" DEBUG_TYPE "] matched graph optimization rule "
+                     << static_cast<unsigned>(getId()) << " ("
+                     << getGraphOptimizationRuleName(getId()) << ") at "
+                     << dot.getLoc() << ": operand=" << operandIndex
+                     << " pointwiseOps=" << chain->unaryOps.size() << "\n");
           plans.push_back(std::make_unique<TransposePointwiseReorderPlan>(
               std::move(*chain), context.getEpoch()));
         }


### PR DESCRIPTION
Graph optimization only logs the rule the scheduler applied, so a rule that analysed the IR and produced no candidate reads exactly like one whose candidate lost to a higher-benefit plan or went stale before it was revalidated.

Every rule now logs its own match under the graph-optimize debug type, reusing the sentence the driver already prints and appending the parameters that decided the match:

  [graph-optimize] matched graph optimization rule 256 (ConvertModuloToMask) at loc("k.py":12:8): arith.remsi tileSize=64 maskedLoads=2

The scheduler also reports the candidates it drops on revalidation, covering the remaining case where a match never reaches an applied line.

StridedLoadStoreRewrite routes its eight rewrite variants through one helper. The per-variant banners and op dumps it used predate the shared format and buried the surrounding output.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
