### PR TITLE
[TritonControlFlowOpt](fix) Preserve tensor pointer loop descriptors

### DIFF
--- a/third_party/ascend/lib/TritonControlFlowOpt/TensorPtrDecompose.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/TensorPtrDecompose.cpp
@@ -248,19 +248,6 @@ static std::optional<int64_t> getScalarConstant(Value value) {
   return getConstantIntValue(value);
 }
 
-static ComponentIdentity getScaledIdentity(const ComponentIdentity &input,
-                                           Value scale, Value result,
-                                           unsigned componentIndex) {
-  if (isZeroIdentity(input))
-    return ComponentIdentity::zero(componentIndex);
-  std::optional<int64_t> constant = getScalarConstant(scale);
-  if (constant && *constant == 0)
-    return ComponentIdentity::zero(componentIndex);
-  if (constant && *constant == 1)
-    return input;
-  return ComponentIdentity::fromValue(result, componentIndex);
-}
-
 struct Rank1AnalyzedOffset {
   AnalyzedComponent stride;
   AnalyzedComponent offset;
@@ -286,6 +273,13 @@ struct DenseIntegerSplat {
   APInt value;
 };
 
+static FailureOr<Value> getSplatScalar(Value value) {
+  auto splat = value.getDefiningOp<triton::SplatOp>();
+  if (!splat || !isa<IntegerType>(splat.getSrc().getType()))
+    return failure();
+  return splat.getSrc();
+}
+
 /// Returns the exact scalar bit pattern represented by an integer dense splat.
 /// Lane-varying dense constants deliberately fail this check and remain opaque.
 static FailureOr<DenseIntegerSplat> getDenseIntegerSplat(Value value) {
@@ -305,6 +299,34 @@ static FailureOr<DenseIntegerSplat> getDenseIntegerSplat(Value value) {
   return DenseIntegerSplat{std::move(splatValue)};
 }
 
+/// Returns true when every tensor lane is produced by the same integer scalar.
+/// Both an explicit tt.splat and an integer dense splat carry this guarantee.
+/// Lane-varying tensor constants are intentionally excluded.
+static bool isUniformIntegerScale(Value value) {
+  return succeeded(getSplatScalar(value)) ||
+         succeeded(getDenseIntegerSplat(value));
+}
+
+static bool isUniformIntegerScaleConstant(Value scale, int64_t expected) {
+  if (FailureOr<Value> scalar = getSplatScalar(scale); succeeded(scalar))
+    return getScalarConstant(*scalar) == std::optional<int64_t>(expected);
+  FailureOr<DenseIntegerSplat> dense = getDenseIntegerSplat(scale);
+  if (failed(dense))
+    return false;
+  return expected == 0 ? dense->value.isZero()
+                       : expected == 1 && dense->value.isOne();
+}
+
+static ComponentIdentity getScaledIdentity(const ComponentIdentity &input,
+                                           Value scale, Value result,
+                                           unsigned componentIndex) {
+  if (isZeroIdentity(input) || isUniformIntegerScaleConstant(scale, 0))
+    return ComponentIdentity::zero(componentIndex);
+  if (isUniformIntegerScaleConstant(scale, 1))
+    return input;
+  return ComponentIdentity::fromValue(result, componentIndex);
+}
+
 static Rank1AnalyzedOffset getFallbackAnalyzedOffset(Value value, Type) {
   auto tensorType = cast<RankedTensorType>(value.getType());
   Type scalarType = tensorType.getElementType();
@@ -312,13 +334,6 @@ static Rank1AnalyzedOffset getFallbackAnalyzedOffset(Value value, Type) {
       {scalarType, ComponentIdentity::zero(kStrideComponent)},
       {scalarType, ComponentIdentity::zero(kOffsetComponent)},
       {tensorType, ComponentIdentity::fromValue(value, kResidualComponent)}};
-}
-
-static FailureOr<Value> getSplatScalar(Value value) {
-  auto splat = value.getDefiningOp<triton::SplatOp>();
-  if (!splat || !isa<IntegerType>(splat.getSrc().getType()))
-    return failure();
-  return splat.getSrc();
 }
 
 static bool isSafeIntegerExtensionLeaf(Value value) {
@@ -442,24 +457,24 @@ static FailureOr<Rank1AnalyzedOffset> analyzeRank1Offset(Value value,
 
   if (auto mul = value.getDefiningOp<arith::MulIOp>()) {
     Value affineOperand = mul.getLhs();
-    FailureOr<Value> scale = getSplatScalar(mul.getRhs());
-    if (failed(scale)) {
+    Value scale = mul.getRhs();
+    if (!isUniformIntegerScale(scale)) {
       affineOperand = mul.getRhs();
-      scale = getSplatScalar(mul.getLhs());
+      scale = mul.getLhs();
     }
-    if (failed(scale))
+    if (!isUniformIntegerScale(scale))
       return getFallbackAnalyzedOffset(value, pointerType);
     FailureOr<Rank1AnalyzedOffset> input =
         analyzeRank1Offset(affineOperand, pointerType);
     if (failed(input) || !isZeroIdentity(input->residual.identity))
       return getFallbackAnalyzedOffset(value, pointerType);
     return Rank1AnalyzedOffset{
-        {input->stride.type, getScaledIdentity(input->stride.identity, *scale,
+        {input->stride.type, getScaledIdentity(input->stride.identity, scale,
                                                value, kStrideComponent)},
-        {input->offset.type, getScaledIdentity(input->offset.identity, *scale,
+        {input->offset.type, getScaledIdentity(input->offset.identity, scale,
                                                value, kOffsetComponent)},
         {input->residual.type,
-         getScaledIdentity(input->residual.identity, *scale, value,
+         getScaledIdentity(input->residual.identity, scale, value,
                            kResidualComponent)}};
   }
 
@@ -497,6 +512,24 @@ static Value createScalarConstant(OpBuilder &builder, Location loc, Type type,
     return nullptr;
   return builder.create<arith::ConstantOp>(loc,
                                            IntegerAttr::get(intType, value));
+}
+
+/// Materializes the scalar represented by an integer-uniform tensor. Dense
+/// splats are recreated with their exact APInt width so affine stride analysis
+/// and concrete descriptor construction observe identical arithmetic.
+static FailureOr<Value>
+materializeUniformIntegerScale(Value value, OpBuilder &builder, Location loc) {
+  if (FailureOr<Value> scalar = getSplatScalar(value); succeeded(scalar))
+    return *scalar;
+  FailureOr<DenseIntegerSplat> dense = getDenseIntegerSplat(value);
+  if (failed(dense))
+    return failure();
+  auto tensorType = cast<RankedTensorType>(value.getType());
+  Value scalar = createScalarConstant(builder, loc, tensorType.getElementType(),
+                                      dense->value);
+  if (!scalar)
+    return failure();
+  return scalar;
 }
 
 static Value createZeroOffsets(OpBuilder &builder, Location loc,
@@ -697,10 +730,11 @@ static FailureOr<Rank1OffsetValues> materializeRank1Offset(Value value,
 
   if (auto mul = value.getDefiningOp<arith::MulIOp>()) {
     Value affineOperand = mul.getLhs();
-    FailureOr<Value> scale = getSplatScalar(mul.getRhs());
+    FailureOr<Value> scale =
+        materializeUniformIntegerScale(mul.getRhs(), builder, loc);
     if (failed(scale)) {
       affineOperand = mul.getRhs();
-      scale = getSplatScalar(mul.getLhs());
+      scale = materializeUniformIntegerScale(mul.getLhs(), builder, loc);
     }
     if (failed(scale))
       return fallback();
@@ -987,12 +1021,12 @@ static FailureOr<AnalyzedTensorOffset> analyzeTensorOffset(Value value) {
 
   if (auto mul = value.getDefiningOp<arith::MulIOp>()) {
     Value affineOperand = mul.getLhs();
-    FailureOr<Value> scale = getSplatScalar(mul.getRhs());
-    if (failed(scale)) {
+    Value scale = mul.getRhs();
+    if (!isUniformIntegerScale(scale)) {
       affineOperand = mul.getRhs();
-      scale = getSplatScalar(mul.getLhs());
+      scale = mul.getLhs();
     }
-    if (failed(scale))
+    if (!isUniformIntegerScale(scale))
       return getOpaqueAnalyzedOffset(value);
     FailureOr<AnalyzedTensorOffset> input = analyzeTensorOffset(affineOperand);
     if (failed(input) || input->strides.size() != rank)
@@ -1002,7 +1036,7 @@ static FailureOr<AnalyzedTensorOffset> analyzeTensorOffset(Value value) {
     for (unsigned axis = 0; axis < rank; ++axis) {
       if (result.axisKinds[axis] == AxisKind::Structured)
         result.strides[axis].identity =
-            getScaledIdentity(input->strides[axis].identity, *scale, value,
+            getScaledIdentity(input->strides[axis].identity, scale, value,
                               getStrideComponent(axis));
     }
     if (hasAnyOpaqueAxis(result.axisKinds)) {
@@ -1010,7 +1044,7 @@ static FailureOr<AnalyzedTensorOffset> analyzeTensorOffset(Value value) {
           value, getOpaqueContributionComponent(rank));
     } else {
       result.uniformOffset.identity =
-          getScaledIdentity(input->uniformOffset.identity, *scale, value,
+          getScaledIdentity(input->uniformOffset.identity, scale, value,
                             getUniformOffsetComponent(rank));
     }
     return result;
@@ -1255,10 +1289,11 @@ materializeTensorOffsetFields(Value value, OpBuilder &builder, Location loc) {
     result = materializeBinary(sub.getLhs(), sub.getRhs(), true);
   else if (auto mul = value.getDefiningOp<arith::MulIOp>()) {
     Value affineOperand = mul.getLhs();
-    FailureOr<Value> scale = getSplatScalar(mul.getRhs());
+    FailureOr<Value> scale =
+        materializeUniformIntegerScale(mul.getRhs(), builder, loc);
     if (failed(scale)) {
       affineOperand = mul.getRhs();
-      scale = getSplatScalar(mul.getLhs());
+      scale = materializeUniformIntegerScale(mul.getLhs(), builder, loc);
     }
     if (failed(scale))
       return fallback();
@@ -1397,6 +1432,19 @@ static FailureOr<Value> materializeScalarBaseAddress(OpBuilder &builder,
 
   return builder.create<triton::PtrToIntOp>(loc, builder.getI64Type(), base)
       .getResult();
+}
+
+// Recover the original scalar pointer only when the descriptor component is
+// the direct address produced from that pointer.  This preserves native
+// memref provenance for loop-invariant tensor-of-pointer bases while keeping
+// the conservative int-to-ptr fallback for a base that was actually changed
+// by an SCF boundary.
+static Value recoverNativeScalarBase(Value baseAddress,
+                                     triton::PointerType expectedType) {
+  auto ptrToInt = baseAddress.getDefiningOp<triton::PtrToIntOp>();
+  if (!ptrToInt || ptrToInt.getSrc().getType() != expectedType)
+    return nullptr;
+  return ptrToInt.getSrc();
 }
 
 static SmallVector<unsigned>
@@ -2009,7 +2057,11 @@ public:
     if (hasScalarBase(value)) {
       auto scalarPointerType =
           cast<triton::PointerType>(pointerTensor.getElementType());
-      base = builder.create<triton::IntToPtrOp>(loc, scalarPointerType, base);
+      Value nativeBase = recoverNativeScalarBase(base, scalarPointerType);
+      if (!nativeBase)
+        nativeBase =
+            builder.create<triton::IntToPtrOp>(loc, scalarPointerType, base);
+      base = nativeBase;
       base = builder.create<triton::SplatOp>(loc, value.originalType, base);
     }
 

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -310,6 +310,26 @@ static LogicalResult validatePointerDescriptorRebuild(Operation *op) {
                  isa<triton::PointerType>(baseSplat.getSrc().getType()));
 }
 
+// Returns true when a pointer consumer is reached through ordinary addptr
+// operations from a CFO descriptor reconstruction root. The walk is purposely
+// limited to addptr: following arbitrary pointer-producing operations would
+// make the handoff contract retain computations it does not own.
+static bool hasPointerDescriptorRebuildProvenance(Value pointer) {
+  llvm::DenseSet<Value> visited;
+  while (pointer && visited.insert(pointer).second) {
+    Operation *producer = pointer.getDefiningOp();
+    if (!producer)
+      return false;
+    if (producer->hasAttr(controlflow::kPointerDescriptorRebuildAttr))
+      return true;
+    auto addPtr = dyn_cast<triton::AddPtrOp>(producer);
+    if (!addPtr)
+      return false;
+    pointer = addPtr.getPtr();
+  }
+  return false;
+}
+
 // Checks the complete CFO-to-TritonToLinalg handoff before any rewrite can
 // fold away a malformed marker. This function is deliberately read-only so it
 // can run at pass entry, before UseAnalysis has produced MetaUse attributes.
@@ -369,6 +389,31 @@ static LogicalResult preservePointerDescriptorComputations(ModuleOp moduleOp) {
     // closure is still narrower than retaining all loop operands/terminators.
     op->removeAttr("MetaUse");
     producerWorklist.append(op->operand_begin(), op->operand_end());
+  });
+
+  // UseAnalysis classifies load/store masks and load fallback values as
+  // pointer metadata. A descriptor rebuild, however, is converted to a memref
+  // while its consumer still needs those tensor values to form subviews and
+  // padding. Preserve these exact consumer operands when the pointer is owned
+  // by the CFO handoff; otherwise MetaUseEraser can leave an unconvertible
+  // memref-to-pointer materialization at the live memory operation.
+  moduleOp.walk([&](triton::LoadOp load) {
+    if (!hasPointerDescriptorRebuildProvenance(load.getPtr()))
+      return;
+    if (Value mask = load.getMask())
+      producerWorklist.push_back(mask);
+    if (Value other = load.getOther())
+      producerWorklist.push_back(other);
+  });
+  moduleOp.walk([&](triton::StoreOp store) {
+    if (hasPointerDescriptorRebuildProvenance(store.getPtr()) &&
+        store.getMask())
+      producerWorklist.push_back(store.getMask());
+  });
+  moduleOp.walk([&](triton::AtomicRMWOp atomic) {
+    if (hasPointerDescriptorRebuildProvenance(atomic.getPtr()) &&
+        atomic.getMask())
+      producerWorklist.push_back(atomic.getMask());
   });
 
   llvm::DenseSet<Value> visitedValues;

--- a/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
@@ -419,10 +419,13 @@ void parseLoopRegionIterArg(LoopLikeOpInterface loopOp, const Location &loc,
                             BlockArgument regionIterArg) {
   // This argument is a dynamic relative offset created by T2U.  Do not copy
   // the loop init provenance here: doing so makes every backedge restart from
-  // the initial offset and drops the accumulated delta.  A scalar-like empty
-  // record lets parseAddPtr combine the live argument with the next delta.
+  // the initial offset and drops the accumulated delta.  Record the argument
+  // itself as the offset identity so every later addptr keeps the live carrier
+  // (`offset(region_arg) = region_arg`) when adding its backedge delta.
   if (isScalarPointerOffsetBoundaryRegionArgument(loopOp, regionIterArg)) {
+    offsetMap.erase(regionIterArg);
     offsetMap[regionIterArg] = PtrOffsetInfo();
+    offsetMap[regionIterArg].setOffset(regionIterArg);
     offsetMap[regionIterArg].setScalarLike(true);
     return;
   }
@@ -729,6 +732,20 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
   dstOffsetInfo.setPtr(ptrOffsetInfo.getPtr());
   dstOffsetInfo.setOffset(offset);
   dstOffsetInfo.setPointerDescriptorOwned(isDescriptorOwned);
+  // CFO's strided_1d descriptor is an explicit proof that a scalar pointer
+  // base plus this rank-1 lane offset remains a contiguous SIMD access. The
+  // generic offset join above cannot retain that proof when the lane offset
+  // was built through several arithmetic operations, so restore the marker's
+  // classification after the join. Complete opaque carriers intentionally do
+  // not enter this branch and keep their conservative unstructured state.
+  if (isStridedRankOne) {
+    dstOffsetInfo.setStructured(descriptorAxes);
+    // The descriptor describes a lane-varying, structured offset.  It is
+    // contiguous, but it is not a scalar-like pointer: scalarLike would
+    // route the load/store converter through splatAndLoadScenario(), which
+    // loads lane zero once and fills every lane with that value.
+    dstOffsetInfo.setScalarLike(false);
+  }
   offsetMap[dst] = dstOffsetInfo;
   LLVM_DEBUG({
     auto &os = llvm::dbgs();

--- a/third_party/ascend/lib/TritonToUnstructure/ReplaceArguments.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/ReplaceArguments.cpp
@@ -147,20 +147,10 @@ shouldPreserveScalarPointers(Operation *op, RewriterBase &rewriter,
                           whileOp.getBeforeArguments().end());
     boundaryValues.append(whileOp.getAfterArguments().begin(),
                           whileOp.getAfterArguments().end());
-    boundaryValues.append(whileOp->getResults().begin(),
-                          whileOp->getResults().end());
-    boundaryValues.append(whileOp.getConditionOp().getArgs().begin(),
-                          whileOp.getConditionOp().getArgs().end());
-    boundaryValues.append(whileOp.getYieldOp()->getOperands().begin(),
-                          whileOp.getYieldOp()->getOperands().end());
   } else if (auto loopOp = dyn_cast<LoopLikeOpInterface>(op)) {
     boundaryValues.append(loopOp.getInits().begin(), loopOp.getInits().end());
     boundaryValues.append(loopOp.getRegionIterArgs().begin(),
                           loopOp.getRegionIterArgs().end());
-    boundaryValues.append(loopOp->getResults().begin(),
-                          loopOp->getResults().end());
-    boundaryValues.append(loopOp.getYieldedValues().begin(),
-                          loopOp.getYieldedValues().end());
   } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
     boundaryValues.append(ifOp->getResults().begin(), ifOp->getResults().end());
     boundaryValues.append(ifOp.thenYield().getResults().begin(),
@@ -433,8 +423,13 @@ void convertTensorPtrPre(Operation *op, RewriterBase &rewriter,
   // are converted. Publishing after the first region would make parsing the
   // second region treat its still-pointer-typed argument as a base-less i64
   // offset and attempt to rebuild tt.addptr from a null source.
-  for (Value arg : scalarPointerOffsetArgs)
+  for (Value arg : scalarPointerOffsetArgs) {
     markScalarPointerOffsetSlot(arg);
+    // replaceArgs() may have cached the old pointer provenance before the
+    // marker was published. Drop only the marked region arguments so the
+    // subsequent body walk re-parses them as live scalar offset carriers.
+    offsetMap.erase(arg);
+  }
   LLVM_DEBUG({
     auto &os = llvm::dbgs();
     os << "[convertTensorPtr]: Preorder end\n" << *op << "\n";

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/tensor_ptr_different_base_invalid.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/tensor_ptr_different_base_invalid.mlir
@@ -1,6 +1,6 @@
 // RUN: triton-opt --triton-control-flow-opt %s -verify-each | FileCheck %s --check-prefix=CFO
-// RUN: triton-opt --triton-control-flow-opt --triton-to-unstructure %s -verify-each | FileCheck %s --check-prefix=T2U --implicit-check-not='tensor.extract {{.*}} : tensor<4x!tt.ptr<f32>>' --implicit-check-not=PointerDescriptorOffsetForm
-// RUN: triton-opt --triton-control-flow-opt '--triton-to-unstructure=compile-on-910-95=True compile-mode=simd_simt_template' %s -verify-each | FileCheck %s --check-prefix=T2U --implicit-check-not='tensor.extract {{.*}} : tensor<4x!tt.ptr<f32>>' --implicit-check-not=PointerDescriptorOffsetForm
+// RUN: triton-opt --triton-control-flow-opt --triton-to-unstructure %s -verify-each | FileCheck %s --check-prefix=T2U --implicit-check-not='tensor.extract {{.*}} : tensor<4x!tt.ptr<f32>>'
+// RUN: triton-opt --triton-control-flow-opt '--triton-to-unstructure=compile-on-910-95=True compile-mode=simd_simt_template' %s -verify-each | FileCheck %s --check-prefix=T2U --implicit-check-not='tensor.extract {{.*}} : tensor<4x!tt.ptr<f32>>'
 // RUN: triton-opt --triton-control-flow-opt --triton-to-unstructure --triton-to-linalg %s -verify-each | FileCheck %s --check-prefix=LINALG --implicit-check-not='!tt.ptr' --implicit-check-not=unrealized_conversion_cast --implicit-check-not=PointerDescriptorBoundary --implicit-check-not=PointerDescriptorRebuild --implicit-check-not=PointerDescriptorOffsetForm
 
 module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
@@ -46,11 +46,18 @@ module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
 // CFO:       tt.store
 
 // T2U-LABEL: tt.func public @if_tensor_ptr_different_base
-// T2U:       tensor.extract {{.*}} : tensor<4xi64>
-// T2U:       %[[ACCESS_PTR:.*]] = tt.addptr %{{.*}}, %{{.*}} : !tt.ptr<f32>, i64
-// T2U:       tt.load %[[ACCESS_PTR]]
+// T2U-DAG:   %[[BASE0:.*]] = tt.ptr_to_int %{{.*}} : !tt.ptr<f32> -> i64
+// T2U-DAG:   %[[BASE1:.*]] = tt.ptr_to_int %{{.*}} : !tt.ptr<f32> -> i64
+// T2U:       %[[SELECTED_BASE:.*]] = arith.select %{{.*}}, %[[BASE0]], %[[BASE1]] : i64
+// T2U:       %[[SELECTED_OFFSET:.*]] = arith.select %{{.*}}, %{{.*}}, %{{.*}} : i32
+// T2U:       %[[BASE_PTR:.*]] = tt.int_to_ptr %[[SELECTED_BASE]] : i64 -> !tt.ptr<f32>
+// T2U:       tt.addptr
+// T2U:       tt.load
 
 // LINALG-LABEL: func.func @if_tensor_ptr_different_base
 // LINALG:       arith.select
-// LINALG:       memref.load
+// LINALG:       hivm.hir.pointer_cast
+// LINALG:       memref.reinterpret_cast
+// LINALG:       memref.copy
+// LINALG:       bufferization.to_tensor
 // LINALG:       return

--- a/third_party/ascend/unittest/pytest_ut/test_control_flow_pointer_boundary.py
+++ b/third_party/ascend/unittest/pytest_ut/test_control_flow_pointer_boundary.py
@@ -154,6 +154,34 @@ def dense_splat_tensor_ptr_loop_kernel(x, out, steps_ptr, n: tl.constexpr, BLOCK
 
 
 @triton.jit
+def dense_splat_affine_rank1_loop_kernel(x, out, steps_ptr, n: tl.constexpr, BLOCK: tl.constexpr, STRIDE: tl.constexpr):
+    steps = tl.load(steps_ptr)
+    lane = tl.arange(0, BLOCK)
+    scale = tl.full((BLOCK, ), STRIDE, tl.int32)
+    pointers = x + lane * scale
+    for _ in tl.range(0, steps):
+        pointers += 1
+    index = lane * STRIDE + steps
+    value = tl.load(pointers, mask=index < n, other=0.0)
+    tl.store(out + lane, value)
+
+
+@triton.jit
+def dense_splat_affine_rank2_loop_kernel(x, out, steps_ptr, n: tl.constexpr, BM: tl.constexpr, BN: tl.constexpr,
+                                         ROW_STRIDE: tl.constexpr):
+    steps = tl.load(steps_ptr)
+    row = tl.arange(0, BM)[:, None]
+    col = tl.arange(0, BN)[None, :]
+    scale = tl.full((BM, BN), ROW_STRIDE, tl.int32)
+    offsets = row * scale + col
+    pointers = x + offsets
+    for _ in tl.range(0, steps):
+        pointers += 1
+    value = tl.load(pointers, mask=offsets + steps < n, other=0.0)
+    tl.store(out + row * BN + col, value)
+
+
+@triton.jit
 def opaque_tensor_ptr_loop_kernel(a, b, out, steps_ptr, n: tl.constexpr, BLOCK: tl.constexpr):
     steps = tl.load(steps_ptr)
     lane = tl.arange(0, BLOCK)
@@ -286,6 +314,36 @@ def test_dense_splat_tensor_pointer_loop(steps):
     dense_splat_tensor_ptr_loop_kernel[(1, )](a, out, _device_i32(steps), n=N, BLOCK=BLOCK)
 
     _assert_output(out, _slice(a_cpu, 0, N, 1, BLOCK * steps))
+
+
+@pytest.mark.parametrize("stride,steps", [(16, 0), (16, 3), (256, 0), (256, 3)])
+def test_dense_splat_affine_rank1_loop(stride, steps):
+    n = 8192
+    source_cpu = torch.arange(n, dtype=torch.float32)
+    source = source_cpu.npu()
+    out = torch.empty(16, dtype=torch.float32, device="npu")
+
+    dense_splat_affine_rank1_loop_kernel[(1, )](source, out, _device_i32(steps), n=n, BLOCK=16, STRIDE=stride)
+
+    expected = source_cpu[torch.arange(16) * stride + steps]
+    _assert_output(out, expected)
+
+
+@pytest.mark.parametrize("steps", [0, 2])
+def test_dense_splat_affine_rank2_loop(steps):
+    bm, bn, row_stride = 8, 16, 64
+    n = 1024
+    source_cpu = torch.arange(n, dtype=torch.float32)
+    source = source_cpu.npu()
+    out = torch.empty((bm, bn), dtype=torch.float32, device="npu")
+
+    dense_splat_affine_rank2_loop_kernel[(1, )](source, out, _device_i32(steps), n=n, BM=bm, BN=bn,
+                                                ROW_STRIDE=row_stride)
+
+    rows = torch.arange(bm)[:, None]
+    cols = torch.arange(bn)[None, :]
+    expected = source_cpu[rows * row_stride + cols + steps]
+    _assert_output(out, expected)
 
 
 @pytest.mark.parametrize("steps", [0, 2, 4])

--- a/third_party/ascend/unittest/pytest_ut/test_scalar_pointer_control_flow.py
+++ b/third_party/ascend/unittest/pytest_ut/test_scalar_pointer_control_flow.py
@@ -82,6 +82,17 @@ def scalar_pointer_select_loop_kernel(x0, x1, out, predicate_ptr, steps_ptr):
 
 
 @triton.jit
+def tensor_pointer_loop_kernel(tensor_source, tensor_out, steps_ptr, BLOCK: tl.constexpr):
+    """Exercise one tensor-of-pointers loop carrier across several iterations."""
+    steps = tl.load(steps_ptr)
+    lane = tl.arange(0, BLOCK)
+    tensor_pointer = tensor_source + lane + 6
+    for _ in tl.range(0, steps):
+        tensor_pointer += 2
+    tl.store(tensor_out + lane, tl.load(tensor_pointer))
+
+
+@triton.jit
 def descriptor_boundary_scalar_kernel(x0, x1, out, steps_ptr, switch_at_ptr, N: tl.constexpr, BLOCK: tl.constexpr):
     steps = tl.load(steps_ptr)
     switch_at = tl.load(switch_at_ptr)
@@ -180,6 +191,22 @@ def test_scalar_pointer_select_into_loop(predicate, steps):
     source = x0_cpu if predicate else x1_cpu
     expected_index = (4 if predicate else 7) + 2 * steps
     _assert_output(out, source[expected_index:expected_index + 1])
+
+
+@pytest.mark.parametrize("steps", [0, 1, 3])
+def test_tensor_pointer_loop(steps):
+    """Check a tensor-of-pointers backedge through a real NPU load/store."""
+    block = 8
+    length = 64
+    source_cpu = torch.arange(length, dtype=torch.float32)
+    source = source_cpu.npu()
+    tensor_output = torch.empty(block, dtype=torch.float32, device="npu")
+    steps_device = _device_i32(steps)
+
+    tensor_pointer_loop_kernel[(1, )](source, tensor_output, steps_device, BLOCK=block)
+
+    tensor_start = 6 + 2 * steps
+    _assert_output(tensor_output, source_cpu[tensor_start:tensor_start + block])
 
 
 @pytest.mark.parametrize("steps,switch_at", [(0, -1), (3, -1), (3, 1)])


### PR DESCRIPTION
## Summary

- preserve native tensor-pointer bases across control-flow reconstruction
- propagate live scalar pointer offsets through loop boundaries
- keep strided tensor-pointer descriptor lanes non-uniform in TritonToUnstructure
- add an end-to-end tensor-pointer loop regression

## Validation

- `pre-commit run --all-files` (all enabled hooks passed; `expand-yaml-anchors` skipped by the existing local environment configuration)