### PR TITLE
[ssbuffer](fix) fix multi-yield op transfer

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferInnerScope.cpp
@@ -478,14 +478,15 @@ SmallVector<Value>
 collectBufferValues(DenseMap<Value, SmallVector<Value>> &depValueMap,
                     const DenseSet<Value> &clonedDepVals) {
   SmallVector<Value> valueList;
-  SmallVector<Operation *> seenOps;
+  llvm::DenseSet<Value> seenVals;
 
   for (auto &p : depValueMap) {
     for (Value depVal : p.second) {
       Operation *op = depVal.getDefiningOp();
-      if (!op || llvm::is_contained(seenOps, op))
+      if (!op)
         continue;
-      seenOps.push_back(op);
+      if (!seenVals.insert(depVal).second)
+        continue;
 
       auto shapedType = dyn_cast<ShapedType>(depVal.getType());
       if (!shapedType)
@@ -1550,7 +1551,7 @@ static int cloneDepsToConsumers(
                              int userBlockId, ArrayRef<Operation *> users)>
         cloneFn,
     DenseSet<Value> *clonedDepVals = nullptr) {
-  SmallVector<Operation *> seenOps;
+  llvm::DenseSet<Value> seenVals;
 
   for (auto &blockPair : blocks) {
     auto depIt = depValueMap.find(blockPair.first);
@@ -1559,7 +1560,9 @@ static int cloneDepsToConsumers(
 
     for (Value depVal : depIt->second) {
       Operation *defOp = depVal.getDefiningOp();
-      if (!defOp || llvm::is_contained(seenOps, defOp))
+      if (!defOp)
+        continue;
+      if (!seenVals.insert(depVal).second)
         continue;
       if (!patternCheck(depVal))
         continue;
@@ -1569,7 +1572,6 @@ static int cloneDepsToConsumers(
       auto producerId = getOpBlockId(defOp);
       if (!producerId.has_value())
         continue;
-      seenOps.push_back(defOp);
 
       auto userIt = depUserMap.find(depVal);
       if (userIt == depUserMap.end())
@@ -1692,7 +1694,8 @@ processTensorDependencies(const MainLoop &loop,
                           DenseMap<Value, SmallVector<Operation *>> &depUserMap,
                           BufferMap &bufferMap, OpBuilder &globalBuilder,
                           int &groupId, const DenseSet<Value> &clonedDepVals) {
-  SmallVector<Operation *> seenOps;
+  // Dedupe by depVal instead of op
+  llvm::DenseSet<Value> seenVals;
 
   for (auto &blockPair : blocks) {
     Value blockKey = blockPair.first;
@@ -1704,9 +1707,8 @@ processTensorDependencies(const MainLoop &loop,
 
     for (Value depVal : depValues) {
       // Skip if already processed
-      if (llvm::is_contained(seenOps, depVal.getDefiningOp()))
+      if (!seenVals.insert(depVal).second)
         continue;
-      seenOps.push_back(depVal.getDefiningOp());
 
       // Validate dependency value (skip BlockArgument, null definingOp,
       // non-ShapedType)


### PR DESCRIPTION
This pull request is to fix multi-yield op transfer by processing dependent value set instead of dependent ops.