### PR TITLE
[compiler](fix) restore legacy compile option behavior

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -60,6 +60,7 @@ from triton.backends.ascend.utils import (
     _get_auto_blockify_blacklist_reasons,
     _warn_auto_blockify_disabled,
     _remove_deprecated_npu_options,
+    _warn_deprecated_npu_option,
     _warn_deprecated_ascend_env_vars,
     downgrade_llir,
     force_disable_ffts,
@@ -1018,8 +1019,9 @@ class NPUOptions:
     warp_size: int = field(default=32, init=False)
     ir_override: Optional[str] = None  # filename of a user-defined IR (*.{ttir|ttadapter|mlirbc|bcmlir|npubin})
 
-    # Internal lowering selector derived from the explicit GPUTarget.arch.
-    compile_on_910_95: bool = field(init=False, repr=False)
+    # Deprecated constructor-only compatibility input.  The supplied value is
+    # ignored and replaced with the lowering selector derived from GPUTarget.arch.
+    compile_on_910_95: Optional[bool] = field(default=None, repr=False, kw_only=True)
     enable_warp_specialization: bool = False
     enable_persistent: bool = False
     optimize_epilogue: bool = False
@@ -1099,6 +1101,8 @@ class NPUOptions:
 
         _apply_ascend_patch()
         object.__setattr__(self, "target_arch", arch)
+        if self.compile_on_910_95 is not None:
+            _warn_deprecated_npu_option("compile_on_910_95")
         object.__setattr__(
             self,
             "compile_on_910_95",
@@ -1298,7 +1302,7 @@ class AscendBackend(BaseBackend):
             option_names = {
                 name
                 for name, option_field in NPUOptions.__dataclass_fields__.items()
-                if option_field.init and name != "arch"
+                if option_field.init and name not in {"arch", "compile_on_910_95"}
             }
             # Serialized NPUOptions include backend-only derived fields.  Use
             # those provenance markers instead of depending on every public

--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -722,6 +722,12 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
         if vf_merge_level is not None:
             _compile_option_list += [f"--enable-vf-merge-level={vf_merge_level}"]
 
+        hfusion_enable_multiple_consumer_fusion = metadata["hfusion_enable_multiple_consumer_fusion"]
+        if hfusion_enable_multiple_consumer_fusion:
+            _compile_option_list += [
+                f"--hfusion-enable-multiple-consumer-fusion={hfusion_enable_multiple_consumer_fusion}"
+            ]
+
         plan_memory_strategy = metadata["plan_memory_strategy"]
         if plan_memory_strategy is not None:
             _compile_option_list += [f"--plan-memory-strategy={plan_memory_strategy}"]
@@ -1063,6 +1069,7 @@ class NPUOptions:
     enable_mixed_cv: bool = None
     enable_dynamic_cv_pipeline: bool = None
     enable_cube_block_merge: bool = False
+    hfusion_enable_multiple_consumer_fusion: bool = False
     buf_slot_num_of_veccore: int = None
     buf_slot_num_of_crosscore: int = None
     buf_slot_num_of_gm: int = None

--- a/third_party/ascend/backend/runtime/ubtuner.py
+++ b/third_party/ascend/backend/runtime/ubtuner.py
@@ -568,7 +568,7 @@ class UBTuner(KernelInterface):
             npu_option_keys = {
                 field.name
                 for field in NPUOptions.__dataclass_fields__.values()
-                if field.init and field.name != "arch"
+                if field.init and field.name not in {"arch", "compile_on_910_95"}
             }
             opts_dict = {k: v for k, v in metadata.items() if k in npu_option_keys}
             target_arch = metadata.get("target_arch", metadata.get("arch", ""))

--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -92,12 +92,20 @@ _DEPRECATED_NPU_OPTIONS = frozenset({
 _RESERVED_NPU_OPTION_NAMES = _DEPRECATED_NPU_OPTIONS
 _WARNED_DEPRECATED_NPU_OPTIONS = set()
 
-# Boolean compatibility switches route only their enabled state.  False keeps
-# the canonical compile_mode supplied by the user or its backend default.
+# Boolean compatibility switches route only their enabled state.  An enabled
+# legacy force switch overrides compile_mode to preserve its historical force
+# semantics; False keeps the canonical mode or backend default unchanged.
 _DEPRECATED_NPU_OPTION_ROUTES = {
     "force_simt_only": ("compile_mode", "simt_only"),
     "force_simt_template": ("compile_mode", "simd_simt_template"),
 }
+
+# Apply weaker selectors first so pure SIMT wins if both legacy force switches
+# are enabled together.
+_DEPRECATED_NPU_OPTION_ROUTE_PRECEDENCE = (
+    "force_simt_template",
+    "force_simt_only",
+)
 
 # Renamed value options preserve the complete user value.  A simultaneously
 # supplied canonical option wins via setdefault below.
@@ -230,16 +238,19 @@ def _remove_deprecated_npu_options(options, *, in_place=False):
     """Normalize reserved legacy NPU options, copying by default."""
     normalized = options if in_place else dict(options)
     deprecated = _get_deprecated_npu_options(normalized)
+    active_routes = [
+        _DEPRECATED_NPU_OPTION_ROUTES[name]
+        for name in _DEPRECATED_NPU_OPTION_ROUTE_PRECEDENCE
+        if name in deprecated and normalized[name]
+    ]
     for name in sorted(deprecated):
         _warn_deprecated_npu_option(name)
-        route = _DEPRECATED_NPU_OPTION_ROUTES.get(name)
-        if route is not None and normalized[name]:
-            replacement_name, replacement_value = route
-            normalized.setdefault(replacement_name, replacement_value)
         alias = _DEPRECATED_NPU_OPTION_ALIASES.get(name)
         if alias is not None:
             normalized.setdefault(alias, normalized[name])
         normalized.pop(name)
+    for replacement_name, replacement_value in active_routes:
+        normalized[replacement_name] = replacement_value
     return normalized
 
 

--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -69,7 +69,6 @@ _DEPRECATED_NPU_OPTIONS = frozenset({
     "graph_optimize_ub_capacity_bytes",
     "grid_num_tiles",
     "has_auto_blockify_blacklist_op",
-    "hfusion_enable_multiple_consumer_fusion",
     "inter_cache_num",
     "intra_cache_num",
     "kernel_name",
@@ -148,7 +147,6 @@ _DEPRECATED_NPU_OPTION_DETAILS = {
     "graph_optimize_ub_capacity_bytes":
     "it is ignored; the backend derives the UB budget from the target (A2: 96 KiB, A5: 128 KiB).",
     "has_auto_blockify_blacklist_op": "it is ignored; the safety flag is derived by scanning TTIR.",
-    "hfusion_enable_multiple_consumer_fusion": "it is ignored; the removed vendor compiler control has no replacement.",
     "kernel_name": "it is ignored; the kernel name is derived from TTIR.",
     "llvm_version": "it is ignored; this option has no replacement because it had no effective consumer.",
     "mix_mode": "it is ignored; mix mode is derived from Linalg IR as internal metadata.",

--- a/third_party/ascend/unittest/costmodel_ut/test_compiler_costmodel_contract.py
+++ b/third_party/ascend/unittest/costmodel_ut/test_compiler_costmodel_contract.py
@@ -64,6 +64,7 @@ class CompilerCostmodelContractTest(unittest.TestCase):
         utils_mod._is_auto_map_parallel_blocks_enabled = lambda *args, **kwargs: False
         utils_mod._warn_auto_blockify_disabled = lambda *args, **kwargs: None
         utils_mod._remove_deprecated_npu_options = lambda options, **kwargs: options
+        utils_mod._warn_deprecated_npu_option = lambda *_args, **_kwargs: None
         utils_mod._warn_deprecated_ascend_env_vars = lambda: None
         utils_mod.get_cann_version_file_hash = lambda *args, **kwargs: ""
         utils_mod.graph_ub_budget_bytes_for_arch = lambda *args, **kwargs: 0

--- a/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
+++ b/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
@@ -128,6 +128,8 @@ def compiler_module():
     utils_stub._get_auto_blockify_blacklist_reasons = lambda *_args, **_kwargs: []
     utils_stub._warn_auto_blockify_disabled = lambda *_args, **_kwargs: None
     utils_stub._remove_deprecated_npu_options = remove_deprecated_npu_options
+    utils_stub._warn_deprecated_npu_option = lambda name: warnings.warn(
+        f"Ascend compile option '{name}' is deprecated and ignored.", FutureWarning)
     utils_stub._warn_deprecated_ascend_env_vars = lambda: None
     utils_stub.downgrade_llir = lambda llir: llir
     utils_stub.get_cann_version_file_hash = lambda: ""
@@ -655,6 +657,13 @@ def test_default_compile_mode_keeps_the_91095_layout_memory_gate_prepared(compil
     assert a5_default.compile_on_910_95 is True
     assert a5_default.compile_mode == "simd_simt_template"
     assert a5_default.is_pure_simt is False
+
+    with pytest.warns(FutureWarning, match="compile_on_910_95"):
+        ignored_legacy_value = compiler_module.NPUOptions(
+            arch="Ascend910_9589",
+            compile_on_910_95=False,
+        )
+    assert ignored_legacy_value.compile_on_910_95 is True
 
     canonical = compiler_module.NPUOptions(
         arch="Ascend910_9589",

--- a/third_party/ascend/unittest/pytest_ut/test_runtime_utils.py
+++ b/third_party/ascend/unittest/pytest_ut/test_runtime_utils.py
@@ -77,14 +77,30 @@ def test_deprecated_simt_option_routes_to_compile_mode(legacy_option, compile_mo
     assert options == {legacy_option: True}
 
 
-def test_explicit_compile_mode_takes_precedence_over_deprecated_simt_option():
-    options = {"compile_mode": "simd", "force_simt_only": True}
+@pytest.mark.parametrize(
+    ("options", "expected_compile_mode"),
+    [
+        pytest.param({"compile_mode": "simd", "force_simt_only": True}, "simt_only", id="simt-only"),
+        pytest.param(
+            {"compile_mode": "simt_only", "force_simt_template": True},
+            "simd_simt_template",
+            id="simt-template",
+        ),
+        pytest.param(
+            {"compile_mode": "simd", "force_simt_only": True, "force_simt_template": True},
+            "simt_only",
+            id="simt-only-over-template",
+        ),
+    ],
+)
+def test_deprecated_simt_force_option_takes_precedence_over_compile_mode(options, expected_compile_mode):
+    original = dict(options)
 
-    with pytest.warns(FutureWarning, match=r"force_simt_only.*compile_mode='simt_only'"):
+    with pytest.warns(FutureWarning):
         normalized = utils._remove_deprecated_npu_options(options)
 
-    assert normalized == {"compile_mode": "simd"}
-    assert options == {"compile_mode": "simd", "force_simt_only": True}
+    assert normalized == {"compile_mode": expected_compile_mode}
+    assert options == original
 
 
 def test_deprecated_simt_option_is_routed_once_during_in_place_normalization():

--- a/third_party/ascend/unittest/pytest_ut/test_specialization_cache_unit.py
+++ b/third_party/ascend/unittest/pytest_ut/test_specialization_cache_unit.py
@@ -62,13 +62,13 @@ SIMD_OPTIONS = [
     pytest.param({"compile_mode": "simd"}, id="simd"),
     pytest.param({"compile_mode": "unstructured_in_simt"}, id="unstructured-in-simt"),
     pytest.param({"force_simt_template": True}, id="force-simt-template"),
-    pytest.param({"compile_mode": "simd", "force_simt_only": True}, id="compile-mode-overrides-force-simt"),
     pytest.param({}, id="default-simd-simt-template"),
 ]
 
 SIMT_OPTIONS = [
     pytest.param({"compile_mode": "simt_only"}, id="simt-only"),
     pytest.param({"force_simt_only": True}, id="force-simt-only"),
+    pytest.param({"compile_mode": "simd", "force_simt_only": True}, id="force-simt-overrides-mode"),
 ]
 
 


### PR DESCRIPTION
This PR fixes compatibility regressions introduced by the Ascend compile-option cleanup. It preserves direct `NPUOptions` construction with the deprecated `compile_on_910_95` argument while continuing to derive the effective value from `GPUTarget.arch`, restores the historical precedence of enabled `force_simt_only` and `force_simt_template` options over `compile_mode`, and keeps pure SIMT dominant when both legacy force options are enabled. It also restores `hfusion_enable_multiple_consumer_fusion` as an effective option with a default value of `False` and forwards it to the A5 BishengIR compiler when explicitly enabled, avoiding observed performance regressions.
