### PR TITLE
[TritonControlFlowOpt](fix) support structured pointer broadcast

### DIFF
--- a/third_party/ascend/lib/TritonControlFlowOpt/TensorPtrDecompose.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/TensorPtrDecompose.cpp
@@ -102,6 +102,24 @@ static bool isTensorPointerType(Type type) {
   return tensorType && isa<triton::PointerType>(tensorType.getElementType());
 }
 
+static bool isCompatiblePointerBroadcast(Type sourceType, Type resultType) {
+  auto sourceTensor = dyn_cast<RankedTensorType>(sourceType);
+  auto resultTensor = dyn_cast<RankedTensorType>(resultType);
+  if (!sourceTensor || !resultTensor || !isTensorPointerType(sourceType) ||
+      !isTensorPointerType(resultType) ||
+      sourceTensor.getRank() != resultTensor.getRank() ||
+      sourceTensor.getElementType() != resultTensor.getElementType() ||
+      sourceTensor.getEncoding() != resultTensor.getEncoding())
+    return false;
+
+  for (auto [sourceExtent, resultExtent] :
+       llvm::zip(sourceTensor.getShape(), resultTensor.getShape())) {
+    if (sourceExtent != resultExtent && sourceExtent != 1)
+      return false;
+  }
+  return true;
+}
+
 static bool isRankOneTensorPointer(Type type) {
   auto tensorType = dyn_cast<RankedTensorType>(type);
   return tensorType && tensorType.getRank() == 1 &&
@@ -1647,6 +1665,49 @@ public:
       return *known;
     }
 
+    // Broadcasting an already-structured pointer tensor only changes the
+    // descriptor shape. An expanded unit dimension repeats the same pointer,
+    // so that dimension has stride zero in the result descriptor. Restrict the
+    // propagation to scalar-base descriptors with no opaque contribution;
+    // unknown or partially opaque pointer tensors retain the established
+    // complete-pointer fallback below.
+    if (auto broadcast = value.getDefiningOp<triton::BroadcastOp>()) {
+      FailureOr<AnalyzedValue> result =
+          context.analyzeValue(broadcast.getSrc());
+      if (succeeded(result) && hasValidLayout(*result) &&
+          hasScalarBase(*result) &&
+          isCompatiblePointerBroadcast(broadcast.getSrc().getType(),
+                                       value.getType())) {
+        FailureOr<SmallVector<AxisKind>> kinds = getAxisKinds(*result);
+        auto sourceType = cast<RankedTensorType>(broadcast.getSrc().getType());
+        auto resultType = cast<RankedTensorType>(value.getType());
+        unsigned rank = resultType.getRank();
+        if (succeeded(kinds) && !llvm::is_contained(*kinds, AxisKind::Opaque) &&
+            isZeroIdentity(
+                result->components[getOpaqueContributionComponent(rank)]
+                    .identity)) {
+          for (unsigned axis = 0; axis < rank; ++axis) {
+            if (sourceType.getShape()[axis] == 1 &&
+                resultType.getShape()[axis] != 1) {
+              result->components[getStrideComponent(axis)].identity =
+                  ComponentIdentity::zero(getStrideComponent(axis));
+            }
+          }
+          Type scalarType =
+              result->components[getUniformOffsetComponent(rank)].type;
+          auto resultOffsetsType = RankedTensorType::get(
+              resultType.getShape(), scalarType, resultType.getEncoding());
+          result->components[getOpaqueContributionComponent(rank)] = {
+              resultOffsetsType,
+              ComponentIdentity::zero(getOpaqueContributionComponent(rank))};
+          result->originalType = value.getType();
+          result->attributes[kAxisKindsAttribute] =
+              getAxisKindsAttr(value.getContext(), *kinds);
+          return *result;
+        }
+      }
+    }
+
     if (auto addPtr = value.getDefiningOp<triton::AddPtrOp>()) {
       FailureOr<AnalyzedValue> result = context.analyzeValue(addPtr.getPtr());
       FailureOr<AnalyzedTensorOffset> delta =
@@ -1907,6 +1968,52 @@ public:
     }
 
     value = context.remap(value);
+    if (auto broadcast = value.getDefiningOp<triton::BroadcastOp>()) {
+      FailureOr<DecomposedValue> result =
+          decompose(broadcast.getSrc(), context, builder, loc);
+      if (succeeded(result) && hasValidLayout(*result) &&
+          hasScalarBase(*result) &&
+          isCompatiblePointerBroadcast(broadcast.getSrc().getType(),
+                                       value.getType())) {
+        FailureOr<SmallVector<AxisKind>> kinds = getAxisKinds(*result);
+        auto sourceType = cast<RankedTensorType>(broadcast.getSrc().getType());
+        auto resultType = cast<RankedTensorType>(value.getType());
+        unsigned rank = resultType.getRank();
+        if (succeeded(kinds) && !llvm::is_contained(*kinds, AxisKind::Opaque) &&
+            isConstantZero(
+                result->components[getOpaqueContributionComponent(rank)])) {
+          OpBuilder::InsertionGuard guard(builder);
+          builder.setInsertionPoint(broadcast);
+          for (unsigned axis = 0; axis < rank; ++axis) {
+            if (sourceType.getShape()[axis] == 1 &&
+                resultType.getShape()[axis] != 1) {
+              Type strideType =
+                  result->components[getStrideComponent(axis)].getType();
+              result->components[getStrideComponent(axis)] =
+                  createScalarConstant(builder, broadcast.getLoc(), strideType,
+                                       0);
+              if (!result->components[getStrideComponent(axis)])
+                return failure();
+            }
+          }
+          Type scalarType =
+              result->components[getUniformOffsetComponent(rank)].getType();
+          auto resultOffsetsType = RankedTensorType::get(
+              resultType.getShape(), scalarType, resultType.getEncoding());
+          Value zeroOffsets =
+              createZeroOffsets(builder, broadcast.getLoc(), resultOffsetsType);
+          if (!zeroOffsets)
+            return failure();
+          result->components[getOpaqueContributionComponent(rank)] =
+              zeroOffsets;
+          result->originalType = value.getType();
+          result->attributes[kAxisKindsAttribute] =
+              getAxisKindsAttr(value.getContext(), *kinds);
+          return *result;
+        }
+      }
+    }
+
     if (auto addPtr = value.getDefiningOp<triton::AddPtrOp>()) {
       FailureOr<DecomposedValue> result =
           decompose(addPtr.getPtr(), context, builder, loc);

--- a/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
@@ -470,9 +470,9 @@ BlockDataParser::getScalarMemRef(Value ptr, Value memref, const Location &loc,
   if (ptr.getDefiningOp<triton::IntToPtrOp>()) {
     if (!isa<BaseMemRefType>(memref.getType()))
       return failure();
-    if (auto memrefType = dyn_cast<MemRefType>(memref.getType());
-        memrefType && memrefType.getRank() == 1)
-      return memref;
+    // IntToPtrConverter's rank-1 carrier is still a dynamic base memref, not
+    // the canonical scalar view consumed by indirect loads.  Normalize every
+    // int_to_ptr carrier to the one-element identity view below.
     BlockData data;
     data.setSource(memref);
     data.getOffsetsRef().push_back(rewriter.getIndexAttr(0));

--- a/third_party/ascend/unittest/pytest_ut/test_control_flow_pointer_boundary.py
+++ b/third_party/ascend/unittest/pytest_ut/test_control_flow_pointer_boundary.py
@@ -18,6 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+import re
+
 import pytest
 import torch
 import torch_npu  # noqa: F401
@@ -178,6 +180,22 @@ def dense_splat_affine_rank2_loop_kernel(x, out, steps_ptr, n: tl.constexpr, BM:
     for _ in tl.range(0, steps):
         pointers += 1
     value = tl.load(pointers, mask=offsets + steps < n, other=0.0)
+    tl.store(out + row * BN + col, value)
+
+
+@triton.jit
+def broadcasted_pointer_rank2_loop_kernel(x, out, steps_ptr, BM: tl.constexpr, BN: tl.constexpr,
+                                          ROW_STRIDE: tl.constexpr):
+    steps = tl.load(steps_ptr)
+    row = tl.arange(0, BM)[:, None]
+    col = tl.arange(0, BN)[None, :]
+    # Match grouped matmul's construction order: first create a lower-rank
+    # pointer tensor, then broadcast it while adding the second axis.
+    row_pointers = x + row * ROW_STRIDE
+    pointers = row_pointers + col
+    for _ in tl.range(0, steps):
+        pointers += 1
+    value = tl.load(pointers)
     tl.store(out + row * BN + col, value)
 
 
@@ -344,6 +362,35 @@ def test_dense_splat_affine_rank2_loop(steps):
     cols = torch.arange(bn)[None, :]
     expected = source_cpu[rows * row_stride + cols + steps]
     _assert_output(out, expected)
+
+
+@pytest.mark.parametrize("steps", [0, 2])
+def test_broadcasted_pointer_rank2_loop(steps):
+    bm, bn, row_stride = 8, 16, 64
+    n = 1024
+    source_cpu = torch.arange(n, dtype=torch.float32)
+    source = source_cpu.npu()
+    out = torch.empty((bm, bn), dtype=torch.float32, device="npu")
+
+    compiled = broadcasted_pointer_rank2_loop_kernel[(1, )](
+        source,
+        out,
+        _device_i32(steps),
+        BM=bm,
+        BN=bn,
+        ROW_STRIDE=row_stride,
+    )
+
+    rows = torch.arange(bm)[:, None]
+    cols = torch.arange(bn)[None, :]
+    expected = source_cpu[rows * row_stride + cols + steps]
+    _assert_output(out, expected)
+
+    # Before descriptor propagation, the pointer broadcast becomes an opaque
+    # tensor<8x16xi32> loop carrier even though both axes are affine.
+    adapter = compiled.asm["ttadapter"]
+    assert not re.search(r"scf\.for[^\n]*-> \(tensor<8x16xi32>\)", adapter)
+    assert re.search(r"scf\.for[^\n]*-> \(i32\)", adapter)
 
 
 @pytest.mark.parametrize("steps", [0, 2, 4])

--- a/third_party/ascend/unittest/pytest_ut/test_inttoptr_offset_reset.py
+++ b/third_party/ascend/unittest/pytest_ut/test_inttoptr_offset_reset.py
@@ -1,8 +1,15 @@
+import re
+
 import torch
 import torch_npu  # noqa: F401
 
 import triton
 import triton.language as tl
+from triton.compiler.code_generator import ast_to_ttir
+from triton.compiler.compiler import ASTSource
+from triton._C.libtriton import ir
+from triton._C.libtriton.ascend import ir as ascend_ir
+from triton.backends.ascend.compiler import NPUOptions, ttir_to_linalg
 
 
 @triton.jit
@@ -47,6 +54,31 @@ def _inttoptr_dyn_offset_kernel(
     tl.store(out + offsets, slot_ids)
 
 
+@triton.jit
+def _inttoptr_indirect_load_kernel(
+    block_table_ptrs,
+    offsets_ptr,
+    out,
+    BLOCK: tl.constexpr,
+):
+    offsets = tl.arange(0, BLOCK)
+    offsets = tl.load(offsets_ptr + offsets)
+    raw_ptr = tl.load(block_table_ptrs).to(tl.pointer_type(tl.int32))
+    raw_ptrs = tl.broadcast_to(raw_ptr, (BLOCK, ))
+    values = tl.load(raw_ptrs + offsets)
+    tl.store(out + offsets, values)
+
+
+def _compile_to_adapter(kernel, signature, constants):
+    src = ASTSource(kernel, signature, constants)
+    context = ir.context()
+    ir.load_dialects(context)
+    ascend_ir.load_dialects(context)
+    options = NPUOptions()
+    ttir = ast_to_ttir(kernel, src, context, options, {}, {})
+    return str(ttir_to_linalg(ttir, {**options.__dict__}, options, named_ops=True))
+
+
 def test_inttoptr_static_offset_reset():
     """Static offset (constant 1) baked into base address."""
     block = 8
@@ -68,6 +100,19 @@ def test_inttoptr_static_offset_reset():
     # offset 1 => skip block_table[0]
     expected = block_table_cpu[1:1 + block].to(torch.int64)
     torch.testing.assert_close(out.cpu(), expected.cpu())
+
+
+def test_inttoptr_indirect_load_uses_scalar_view():
+    """An opaque int_to_ptr tensor load keeps the one-element carrier view."""
+    adapter = _compile_to_adapter(
+        _inttoptr_indirect_load_kernel,
+        {"block_table_ptrs": "*i64", "offsets_ptr": "*i32", "out": "*i32"},
+        {"BLOCK": 8},
+    )
+    assert "hivm.hir.pointer_cast" in adapter
+    assert "annotation.mark" in adapter
+    assert "memref.reinterpret_cast" in adapter
+    assert re.search(r"memref<1xi32, strided<\[1\]>>", adapter)
 
 
 def test_inttoptr_dyn_offset_reset():


### PR DESCRIPTION
## Summary

- propagate structured tensor-pointer descriptors through compatible broadcasts
- assign zero strides to dimensions expanded from a unit extent
- materialize zero residual offsets for the broadcast result
- add an end-to-end control-flow regression for broadcasted rank-2 pointers

## Validation

- `pre-commit run --all-files` passed; `expand-yaml-anchors` skipped by the existing local environment configuration
- rebased onto `main-dev@8516a565e`, which includes PR #1748 and PR #1741