### PR TITLE
[launch](feat) adapter cann version(8.5.0 - 9.1.0)

### DIFF
--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -41,7 +41,8 @@ from triton.backends.ascend.utils import (
     get_ascend_arch_from_env,
     is_ffts_supported,
     force_disable_ffts,
-    get_backend_func
+    get_backend_func,
+    get_cann_version
 )
 # Bind the already-imported utils module once so the launch hot path can write
 # TRITON_PROFILER_REGISTERED without a per-launch `import triton` + attribute walk.
@@ -94,11 +95,14 @@ class NPUUtils(object):
         dirname = os.path.dirname(os.path.realpath(__file__))
         src_path = os.path.join(dirname, "npu_utils.cpp")
         src = Path(src_path).read_text()
+        cann_version = get_cann_version()
+        cann_version_str = ".".join(map(str, cann_version)) if cann_version else ""
         key_parts = [
             "npu_utils",
             "torch_npu_wrapper_abi=triton_async_launch_v1",
             "USE_TORCH_NPU",
             src,
+            cann_version_str,
         ]
         key = hashlib.md5("\0".join(key_parts).encode("utf-8")).hexdigest()
         cache = get_cache_manager(key)
@@ -138,12 +142,19 @@ class NPUUtils(object):
         return self._load_mod().load_kernel_binary(name, kernel, shared, device, mix_mode)
 
     @functools.lru_cache()
+    def get_device_core(self):
+        import torch
+        device = torch.npu.current_device()
+        prop = torch.npu.get_device_properties(device)
+        cube_core_num, vector_core_num = prop.cube_core_num, prop.vector_core_num
+        return cube_core_num, vector_core_num
+    
+    @functools.lru_cache()
     def get_device_properties(self, device):
         # temperoarily added "max_shared_mem" properties to avoid triton-compiler complain
         # fetch available memory at runtime
-        num_aic = self.get_aicore_num()
-        num_aiv = num_aic * 2
-        return {"max_shared_mem": 1, "num_aicore": num_aic, "num_vectorcore": num_aiv}
+        cube_core_num, vector_core_num = self.get_device_core()
+        return {"max_shared_mem": 1, "num_aicore": cube_core_num, "num_vectorcore": vector_core_num}
 
     @functools.lru_cache()
     def get_arch(self):
@@ -153,7 +164,7 @@ class NPUUtils(object):
     @functools.lru_cache()
     def get_aicore_num(self):
         # temporarily return empty arch descriptor
-        return self._load_mod().get_aicore_num()
+        return self.get_device_properties("npu")["num_aicore"]
 
     @functools.lru_cache()
     def get_aivector_core_num(self):
@@ -254,7 +265,7 @@ class NPUDriver(DriverBase):
         """
         Get stream for current device
         """
-        # According to torch_npu, the content of a torch.npu.Stream is essentilly an rtStream_t
+        # According to torch_npu, the content of a torch.npu.Stream is essentilly an cann_stream
         # TODO: use CANN API instead of torchnpu
         return get_backend_func("get_current_stream", device)
 
@@ -383,13 +394,79 @@ def generate_npu_header_src():
 #define TRITON_NPU_HEADERS
 #include <assert.h>
 #include <stdbool.h>
+#include <cstdlib>
+#include <cstring>
 #include <string>
 #include <memory>
 #include <sys/syscall.h>
 #include <vector>
 #include <Python.h>
 #include "runtime/runtime/rt.h"
+#ifdef TRITON_CANN_910
 #include <acl/acl.h>
+#endif
+
+// Compatibility shim for CANN runtime API transition (rt -> aclrt in 9.0.0).
+#ifdef TRITON_CANN_910
+using cann_error = aclError;
+using cann_stream = aclrtStream;
+using cann_func_handle = aclrtFuncHandle;
+using cann_memcpy_kind = aclrtMemcpyKind;
+static constexpr cann_error CANN_SUCCESS = ACL_SUCCESS;
+static constexpr cann_memcpy_kind CANN_MEMCPY_HOST_TO_DEVICE = ACL_MEMCPY_HOST_TO_DEVICE;
+static inline cann_error cann_malloc_host(void **ptr, size_t size) {{ return aclrtMallocHost(ptr, size); }}
+static inline cann_error cann_free_host(void *ptr) {{ return aclrtFreeHost(ptr); }}
+static inline cann_error cann_memcpy(void *dst, size_t destMax, const void *src, size_t count, cann_memcpy_kind kind) {{ return aclrtMemcpy(dst, destMax, src, count, kind); }}
+static inline cann_error cann_memset_async(void *dst, size_t destMax, int32_t value, size_t count, cann_stream stream) {{ return aclrtMemsetAsync(dst, destMax, value, count, stream); }}
+static inline cann_error cann_synchronize_stream(cann_stream stream) {{ return aclrtSynchronizeStream(stream); }}
+static inline cann_error cann_get_hardware_sync_addr(void **addr) {{ return aclrtGetHardwareSyncAddr(addr); }}
+static inline cann_error cann_launch_kernel(cann_func_handle func, uint32_t block_dim, cann_stream stream, void *cfg, void *args, size_t arg_size) {{
+  return aclrtLaunchKernelWithHostArgs(func, block_dim, stream, static_cast<aclrtLaunchKernelCfg *>(cfg), args, arg_size, nullptr, 0);
+}}
+static inline void* cann_get_launch_kernel_cfg(uint32_t shared_mem_dynamic_size) {{
+  // thread_local storage: launch is synchronous on the launcher thread, so the
+  // returned pointer remains valid until cann_launch_kernel returns.
+  static thread_local aclrtLaunchKernelAttr attrInfo;
+  static thread_local aclrtLaunchKernelCfg cfgCfgInfo;
+  attrInfo.id = ACL_RT_LAUNCH_KERNEL_ATTR_DYN_UBUF_SIZE;
+  attrInfo.value.localMemorySize = shared_mem_dynamic_size;
+  cfgCfgInfo.attrs = &attrInfo;
+  cfgCfgInfo.numAttrs = 1;
+  return &cfgCfgInfo;
+}}
+#else
+using cann_error = rtError_t;
+using cann_stream = rtStream_t;
+using cann_func_handle = const void*;
+using cann_memcpy_kind = rtMemcpyKind_t;
+static constexpr cann_error CANN_SUCCESS = RT_ERROR_NONE;
+static constexpr cann_memcpy_kind CANN_MEMCPY_HOST_TO_DEVICE = RT_MEMCPY_HOST_TO_DEVICE;
+static inline cann_error cann_malloc_host(void **ptr, size_t size) {{ return rtMallocHost(ptr, size, RT_MEMORY_HOST); }}
+static inline cann_error cann_free_host(void *ptr) {{ return rtFreeHost(ptr); }}
+static inline cann_error cann_memcpy(void *dst, size_t destMax, const void *src, size_t count, cann_memcpy_kind kind) {{ return rtMemcpy(dst, destMax, src, count, kind); }}
+static inline cann_error cann_memset_async(void *dst, size_t destMax, int32_t value, size_t count, cann_stream stream) {{ return rtMemsetAsync(dst, destMax, value, count, stream); }}
+static inline cann_error cann_synchronize_stream(cann_stream stream) {{ return rtStreamSynchronize(stream); }}
+static inline cann_error cann_get_hardware_sync_addr(void **addr) {{ uint32_t len = 0; return rtGetC2cCtrlAddr(reinterpret_cast<uint64_t *>(addr), &len); }}
+static inline cann_error cann_launch_kernel(cann_func_handle func, uint32_t block_dim, cann_stream stream, void *cfg, void *args, size_t arg_size) {{
+  if (cfg != nullptr) {{
+    rtArgsEx_t argsInfo = {{}};
+    argsInfo.args = args;
+    argsInfo.argsSize = arg_size;
+    return rtKernelLaunchWithFlagV2(func, block_dim, &argsInfo, NULL, stream, 0, static_cast<rtTaskCfgInfo_t *>(cfg));
+  }}
+  return rtKernelLaunch(func, block_dim, args, arg_size, NULL, stream);
+}}
+static inline void* cann_get_launch_kernel_cfg(uint32_t shared_mem_dynamic_size) {{
+  // thread_local storage: launch is synchronous on the launcher thread, so the
+  // returned pointer remains valid until cann_launch_kernel returns.
+  static thread_local rtTaskCfgInfo_t cfgInfo;
+  cfgInfo.localMemorySize = shared_mem_dynamic_size;
+  return &cfgInfo;
+}}
+
+
+#endif
+
 {get_backend_func("header_file", enable_taskqueue)}
 #endif
 """
@@ -493,9 +570,10 @@ def generate_npu_wrapper_src(constants, signature, metadata):
     """
     args:
         int gridX, gridY, gridZ;
-        rtStream_t stream;
-        const void *functon;
-        PyObject* packed_metadata,       
+        cann_stream stream;
+        cann_func_handle functon;
+        PyObject* packed_metadata, *launch_metadata;
+        PyObject* launch_enter_hook, *launch_exit_hook;
         *args_expand
     """
 
@@ -634,27 +712,6 @@ static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {
     ptr_info.dev_ptr = reinterpret_cast<void *>(PyLong_AsUnsignedLongLong(ret));
     if(!ptr_info.dev_ptr)
       return ptr_info;
-        aclrtPtrAttributes attributes;
-        aclError status = aclrtPointerGetAttributes(ptr_info.dev_ptr, &attributes);
-
-        if (status == ACL_SUCCESS) {
-          if (attributes.location.type != ACL_MEM_LOCATION_TYPE_DEVICE && attributes.location.type != 4) {
-            Py_DECREF(ret);
-            PyErr_Format(PyExc_ValueError,
-                         "Pointer argument (at %d) cannot be accessed from Triton (cpu tensor?)", idx);
-            ptr_info.valid = false;
-            return ptr_info;
-          }
-        } else {
-          Py_DECREF(ret);
-          PyErr_Format(PyExc_RuntimeError,
-                       "Failed to query pointer attributes at argument %d. "
-                       "Error code: %d. This may indicate invalid memory address "
-                       "or NPU device error.",
-                       idx, status);
-          ptr_info.valid = false;
-          return ptr_info;
-        }
     Py_DECREF(ret);
     return ptr_info;
   }
@@ -809,28 +866,20 @@ extern "C" {
 """
 
     cpp_kernel_launch = f"""
-    ret = rtKernelLaunch(func, blockNum, static_cast<void*>(launch_args.data()), launch_args.size(), NULL, stream);
+    ret = cann_launch_kernel(func, blockNum, stream, NULL, static_cast<void*>(launch_args.data()), launch_args.size());
 """
     if compile_on_910_95 and enable_simt:
         cpp_kernel_launch = f"""
-    rtArgsEx_t argsInfo = {{}};
-    argsInfo.args = static_cast<void*>(launch_args.data());
-    argsInfo.argsSize = launch_args.size();
-    rtTaskCfgInfo_t cfgInfo = {{}};
-    cfgInfo.localMemorySize = {metadata.shared_mem_dynamic_size};
-    ret = rtKernelLaunchWithFlagV2(func, blockNum, &argsInfo, NULL, stream, 0, &cfgInfo);
+    void *kernel_cfg = cann_get_launch_kernel_cfg({metadata.shared_mem_dynamic_size});
+    ret = cann_launch_kernel(func, blockNum, stream, kernel_cfg, static_cast<void*>(launch_args.data()), launch_args.size());
 """
     cpp_kernel_launch_local = f"""
-    ret = rtKernelLaunch(func, blockNum, static_cast<void*>(&args), sizeof(args), NULL, stream);
+    ret = cann_launch_kernel(func, blockNum, stream, NULL, static_cast<void*>(&args), sizeof(args));
 """
     if compile_on_910_95 and enable_simt:
         cpp_kernel_launch_local = f"""
-    rtArgsEx_t argsInfo = {{}};
-    argsInfo.args = static_cast<void*>(&args);
-    argsInfo.argsSize = sizeof(args);
-    rtTaskCfgInfo_t cfgInfo = {{}};
-    cfgInfo.localMemorySize = {metadata.shared_mem_dynamic_size};
-    ret = rtKernelLaunchWithFlagV2(func, blockNum, &argsInfo, NULL, stream, 0, &cfgInfo);
+    void *kernel_cfg = cann_get_launch_kernel_cfg({metadata.shared_mem_dynamic_size});
+    ret = cann_launch_kernel(func, blockNum, stream, kernel_cfg, static_cast<void*>(&args), sizeof(args));
 """
 
     npu_headers = generate_npu_header_src()
@@ -857,7 +906,7 @@ static inline size_t _align_launch_offset(size_t offset, size_t alignment) {{
 
 extern "C" {{
 void triton_launch_kernel(
-    const char* kernelName, const void* func, rtStream_t stream,
+    const char* kernelName, cann_func_handle func, cann_stream stream,
     int gridX, int gridY, int gridZ,
     const int64_t* shapes_data, const int* shape_dims, int num_tensors,
     const int* tensor_kinds,
@@ -906,7 +955,7 @@ void triton_launch_kernel(
     {workspace_fail_code}
   }}
   ''' if workspace_size > 0 else ''}
-  {'std::function<rtError_t()> launch_call = [=]() -> rtError_t' if enable_taskqueue else ''} {{
+  {'std::function<cann_error()> launch_call = [=]() -> cann_error' if enable_taskqueue else ''} {{
     {get_backend_func("pre_launch", False)}
     uint32_t blockNum = gridX * gridY * gridZ;
 
@@ -923,9 +972,9 @@ void triton_launch_kernel(
     uint32_t nodeBasicBlockDim = (mixBlockNumRation << 16) + blockNum;
 
     {'cce::internal::DebugTunnelData *DTData = cce::internal::DebugTunnel::Open(blockNum);' if enable_device_print else ''}
-    rtError_t ret = RT_ERROR_NONE;
-    {'void *ffts_addr = NULL; uint32_t ffts_len; ret = rtGetC2cCtrlAddr((uint64_t*)&ffts_addr, &ffts_len);' if target_support_ffts else ''}
-    {'if (ret != RT_ERROR_NONE) return ret;' if (target_support_ffts and enable_taskqueue) else 'if (ret != RT_ERROR_NONE) return;' if (target_support_ffts and (not enable_taskqueue)) else ''}
+    cann_error ret = CANN_SUCCESS;
+    {'void *ffts_addr = NULL; ret = cann_get_hardware_sync_addr(&ffts_addr);' if target_support_ffts else ''}
+    {'if (ret != CANN_SUCCESS) return ret;' if (target_support_ffts and enable_taskqueue) else 'if (ret != CANN_SUCCESS) return;' if (target_support_ffts and (not enable_taskqueue)) else ''}
     // stub argument for workspace
     void *syncBlockLock_ptr = NULL;
     void *syncBlockLock_handle = NULL;
@@ -938,16 +987,16 @@ void triton_launch_kernel(
       {alloc_success_code if enable_taskqueue else sync_lock_fail_code}
     }}
     std::vector<int64_t> lockInitData({lock_num}, {lock_init_value});
-    ret = rtMemcpy(
+    ret = cann_memcpy(
         syncBlockLock_ptr, syncBlockLockSize,
         reinterpret_cast<void *>(lockInitData.data()), syncBlockLockSize,
-        RT_MEMCPY_HOST_TO_DEVICE
+        CANN_MEMCPY_HOST_TO_DEVICE
     );
-    if (ret != RT_ERROR_NONE) {{
+    if (ret != CANN_SUCCESS) {{
       return {'ret' if enable_taskqueue else ''};
     }}
     ''' if lock_num > 0 else ''}
-    {'if (ret != RT_ERROR_NONE) return ret;' if (workspace_size > 0 and enable_taskqueue) else 'if (ret != RT_ERROR_NONE) return;' if (workspace_size > 0 and not enable_taskqueue) else ''}
+    {'if (ret != CANN_SUCCESS) return ret;' if (workspace_size > 0 and enable_taskqueue) else 'if (ret != CANN_SUCCESS) return;' if (workspace_size > 0 and not enable_taskqueue) else ''}
 
     size_t args_offset = 0;
     auto reserve_slot = [&](size_t size, size_t alignment) -> size_t {{
@@ -992,14 +1041,14 @@ void triton_launch_kernel(
     {'void *&stream_ref = const_cast<void*&>(stream);' if enable_device_print else ''}
     {'cce::internal::DebugTunnel::Close(DTData, stream_ref);' if enable_device_print else ''}
     {cpp_msprof_call_after_launch}
-    {'return ret;' if enable_taskqueue else 'ret = rtStreamSynchronize(stream);'}
+    {'return ret;' if enable_taskqueue else 'ret = cann_synchronize_stream(stream);'}
    }};
    {f'''{get_backend_func("async_launch", "launch_call") if enable_taskqueue else ''}'''}
   return;
 }}
 }} // extern "C"
 
-static void _launch(const char* kernelName, const void* func, rtStream_t stream, int gridX, int gridY, int gridZ, std::vector<std::vector<int64_t>> &tensorShapes, std::vector<int> &tensorKinds{', ' + arg_decls if len(signature) > 0 else ''}) {{
+static void _launch(const char* kernelName, cann_func_handle func, cann_stream stream, int gridX, int gridY, int gridZ, std::vector<std::vector<int64_t>> &tensorShapes, std::vector<int> &tensorKinds{', ' + arg_decls if len(signature) > 0 else ''}) {{
   // Keep Python launcher on the stable local packing path.
   std::string name = "";
   name.append(kernelName);
@@ -1014,7 +1063,7 @@ static void _launch(const char* kernelName, const void* func, rtStream_t stream,
     {workspace_fail_code}
   }}
   ''' if workspace_size > 0 else ''}
-  {'std::function<rtError_t()> launch_call = [=]() -> rtError_t' if enable_taskqueue else ''} {{
+  {'std::function<cann_error()> launch_call = [=]() -> cann_error' if enable_taskqueue else ''} {{
     {get_backend_func("pre_launch", False)}
     uint32_t blockNum = gridX * gridY * gridZ;
 
@@ -1030,9 +1079,9 @@ static void _launch(const char* kernelName, const void* func, rtStream_t stream,
     uint32_t nodeBasicBlockDim = (mixBlockNumRation << 16) + blockNum;
 
     {'cce::internal::DebugTunnelData *DTData = cce::internal::DebugTunnel::Open(blockNum);' if enable_device_print else ''}
-    rtError_t ret = RT_ERROR_NONE;
-    {'void *ffts_addr = NULL; uint32_t ffts_len; ret = rtGetC2cCtrlAddr((uint64_t*)&ffts_addr, &ffts_len);' if target_support_ffts else ''}
-    {'if (ret != RT_ERROR_NONE) return ret;' if (target_support_ffts and enable_taskqueue) else 'if (ret != RT_ERROR_NONE) return;' if (target_support_ffts and (not enable_taskqueue)) else ''}
+    cann_error ret = CANN_SUCCESS;
+    {'void *ffts_addr = NULL; ret = cann_get_hardware_sync_addr(&ffts_addr);' if target_support_ffts else ''}
+    {'if (ret != CANN_SUCCESS) return ret;' if (target_support_ffts and enable_taskqueue) else 'if (ret != CANN_SUCCESS) return;' if (target_support_ffts and (not enable_taskqueue)) else ''}
     void *syncBlockLock_ptr = NULL;
     void *syncBlockLock_handle = NULL;
     uint16_t ModuleId = 0;
@@ -1047,13 +1096,13 @@ static void _launch(const char* kernelName, const void* func, rtStream_t stream,
     ret = rtMemcpy(
         syncBlockLock_ptr, syncBlockLockSize,
         reinterpret_cast<void *>(lockInitData.data()), syncBlockLockSize,
-        RT_MEMCPY_HOST_TO_DEVICE
+        CANN_MEMCPY_HOST_TO_DEVICE
     );
-    if (ret != RT_ERROR_NONE) {{
+    if (ret != CANN_SUCCESS) {{
       return {'ret' if enable_taskqueue else ''};
     }}
     ''' if lock_num > 0 else ''}
-    {'if (ret != RT_ERROR_NONE) return ret;' if (workspace_size > 0 and enable_taskqueue) else 'if (ret != RT_ERROR_NONE) return;' if (workspace_size > 0 and not enable_taskqueue) else ''}
+    {'if (ret != CANN_SUCCESS) return ret;' if (workspace_size > 0 and enable_taskqueue) else 'if (ret != CANN_SUCCESS) return;' if (workspace_size > 0 and not enable_taskqueue) else ''}
     struct __attribute__((packed)) {{
       {'void* ffts_addr __attribute__((aligned(8)));' if target_support_ffts else ''}
       {'void* syncBlockLock __attribute__((aligned(8)));' if not metadata.force_simt_only else ''}
@@ -1115,7 +1164,7 @@ static std::vector<int64_t> _get_tensor_shape(PyObject *tensor) {{
 
 static PyObject* launch(PyObject* self, PyObject* args) {{
   int gridX, gridY, gridZ;
-  rtStream_t stream;
+  cann_stream stream;
   const void *function;
   PyObject *packedMetadata = NULL;
   PyObject *launch_metadata = NULL;

--- a/third_party/ascend/backend/npu_utils.cpp
+++ b/third_party/ascend/backend/npu_utils.cpp
@@ -42,13 +42,110 @@
 #include <functional>
 #endif
 
+// Compatibility shim for CANN runtime API transition (rt -> aclrt in 9.1.0).
+#ifdef TRITON_CANN_910
+using cann_error = aclError;
+using cann_stream = aclrtStream;
+static constexpr int CANN_MEMCPY_HOST_TO_DEVICE = ACL_MEMCPY_HOST_TO_DEVICE;
+static constexpr int CANN_MEMCPY_DEVICE_TO_HOST = ACL_MEMCPY_DEVICE_TO_HOST;
+static constexpr cann_error CANN_SUCCESS = ACL_SUCCESS;
+
+static inline cann_error cann_set_device(int32_t device) {
+  return aclrtSetDevice(device);
+}
+static inline cann_error cann_create_stream(cann_stream *stream) {
+  return aclrtCreateStream(stream);
+}
+static inline cann_error cann_destroy_stream(cann_stream stream) {
+  return aclrtDestroyStream(stream);
+}
+static inline cann_error cann_malloc_host(void **ptr, size_t size) {
+  return aclrtMallocHost(ptr, size);
+}
+static inline cann_error cann_free_host(void *ptr) {
+  return aclrtFreeHost(ptr);
+}
+static inline cann_error cann_malloc(void **ptr, size_t size) {
+  aclrtMemMallocPolicy policy = static_cast<aclrtMemMallocPolicy>(
+      ACL_MEM_MALLOC_HUGE_FIRST | ACL_MEM_TYPE_HIGH_BAND_WIDTH);
+  return aclrtMalloc(ptr, size, policy);
+}
+static inline cann_error cann_free(void *ptr) { return aclrtFree(ptr); }
+static inline cann_error cann_memcpy(void *dst, size_t destMax, const void *src,
+                                     size_t count, int kind) {
+  return aclrtMemcpy(dst, destMax, src, count,
+                     static_cast<aclrtMemcpyKind>(kind));
+}
+static inline const char *cann_get_soc_name() { return aclrtGetSocName(); }
+static inline std::tuple<void *, void *>
+cann_register_kernel(const char *name, const void *data, size_t data_size,
+                     const char *kernel_mode_str) {
+  uint32_t magic;
+  const std::string kernel_mode{kernel_mode_str};
+  if (kernel_mode == "aiv")
+    magic = ACL_RT_BINARY_MAGIC_ELF_VECTOR_CORE;
+  else
+    magic = ACL_RT_BINARY_MAGIC_ELF_AICORE;
+
+  aclrtBinaryLoadOption optArr[] = {
+      {.type = ACL_RT_BINARY_LOAD_OPT_LAZY_LOAD, .value = {.isLazyLoad = 0}},
+      {.type = ACL_RT_BINARY_LOAD_OPT_MAGIC, .value = {.magic = magic}}};
+  aclrtBinaryLoadOptions loadOptions = {.options = optArr, .numOpt = 2};
+  aclrtBinHandle binHandle = nullptr;
+  aclError aclRet =
+      aclrtBinaryLoadFromData(data, data_size, &loadOptions, &binHandle);
+  if (aclRet != ACL_SUCCESS) {
+    printf("aclrtBinaryLoadFromData failed, 0x%x\n", aclRet);
+    return {nullptr, nullptr};
+  }
+  aclrtFuncHandle funcHandle = nullptr;
+  aclRet = aclrtBinaryGetFunction(binHandle, name, &funcHandle);
+  if (aclRet != ACL_SUCCESS) {
+    printf("aclrtBinaryGetFunction failed(name = %s), 0x%x\n", name, aclRet);
+    return {nullptr, nullptr};
+  }
+  return std::make_tuple(binHandle, funcHandle);
+}
+#else
+using cann_error = rtError_t;
+using cann_stream = rtStream_t;
+static constexpr int CANN_MEMCPY_HOST_TO_DEVICE = RT_MEMCPY_HOST_TO_DEVICE;
+static constexpr int CANN_MEMCPY_DEVICE_TO_HOST = RT_MEMCPY_DEVICE_TO_HOST;
+static constexpr cann_error CANN_SUCCESS = RT_ERROR_NONE;
+
+static inline cann_error cann_set_device(int32_t device) {
+  return rtSetDevice(device);
+}
+static inline cann_error cann_create_stream(cann_stream *stream) {
+  return rtStreamCreate(stream, 0);
+}
+static inline cann_error cann_destroy_stream(cann_stream stream) {
+  return rtStreamDestroy(stream);
+}
+static inline cann_error cann_malloc_host(void **ptr, size_t size) {
+  return rtMallocHost(ptr, size, RT_MEMORY_HOST);
+}
+static inline cann_error cann_free_host(void *ptr) { return rtFreeHost(ptr); }
+static inline cann_error cann_malloc(void **ptr, size_t size) {
+  return rtMalloc(ptr, size, RT_MEMORY_HBM, 0);
+}
+static inline cann_error cann_free(void *ptr) { return rtFree(ptr); }
+static inline cann_error cann_memcpy(void *dst, size_t destMax, const void *src,
+                                     size_t count, int kind) {
+  return rtMemcpy(dst, destMax, src, count, static_cast<rtMemcpyKind_t>(kind));
+}
+static inline const char *cann_get_soc_name() {
+  static thread_local char name[64] = {};
+  if (rtGetSocVersion(name, sizeof(name)) != RT_ERROR_NONE)
+    return nullptr;
+  return name;
+}
 // Use map to differentiate same name functions from different binary
 static std::unordered_map<std::string, size_t> registered_names;
 static std::unordered_map<std::string, std::unique_ptr<size_t>> func_stubs;
-
-static std::tuple<void *, void *>
-registerKernel(const char *name, const void *data, size_t data_size,
-               int device, const char *kernel_mode_str) {
+static inline std::tuple<void *, void *>
+cann_register_kernel(const char *name, const void *data, size_t data_size,
+                     const char *kernel_mode_str) {
   rtError_t rtRet;
 
   rtDevBinary_t devbin;
@@ -60,12 +157,6 @@ registerKernel(const char *name, const void *data, size_t data_size,
   else
     devbin.magic = RT_DEV_BINARY_MAGIC_ELF;
   devbin.version = 0;
-
-  rtRet = rtSetDevice(device);
-  if (rtRet != RT_ERROR_NONE) {
-    printf("rtSetDevice failed, 0x%x\n", rtRet);
-    return {nullptr, nullptr};
-  }
 
   void *devbinHandle = nullptr;
   rtRet = rtDevBinaryRegister(&devbin, &devbinHandle);
@@ -89,6 +180,19 @@ registerKernel(const char *name, const void *data, size_t data_size,
 
   return std::make_tuple(devbinHandle, func_stub_handle);
 }
+#endif
+
+static std::tuple<void *, void *> registerKernel(const char *name,
+                                                 const void *data,
+                                                 size_t data_size, int device,
+                                                 const char *kernel_mode_str) {
+  cann_error rtRet = cann_set_device(device);
+  if (rtRet != CANN_SUCCESS) {
+    printf("cann_set_device failed, 0x%x\n", rtRet);
+    return {nullptr, nullptr};
+  }
+  return cann_register_kernel(name, data, data_size, kernel_mode_str);
+}
 
 static PyObject *loadKernelBinary(PyObject *self, PyObject *args) {
   const char *name;        // kernel name
@@ -102,10 +206,8 @@ static PyObject *loadKernelBinary(PyObject *self, PyObject *args) {
                         &device, &kernel_mode)) {
     return nullptr;
   }
-
   auto [module_handle, func_handle] =
       registerKernel(name, data, data_size, device, kernel_mode);
-
   uint64_t mod = reinterpret_cast<uint64_t>(module_handle);
   uint64_t func = reinterpret_cast<uint64_t>(func_handle);
   if (PyErr_Occurred()) {
@@ -116,55 +218,36 @@ static PyObject *loadKernelBinary(PyObject *self, PyObject *args) {
 }
 
 static PyObject *getArch(PyObject *self, PyObject *args) {
-  char name[64] = {'\0'};
+  const char *socName = cann_get_soc_name();
 
-  rtError_t rtRet = rtGetSocVersion(name, 64);
-
-  if (rtRet != RT_ERROR_NONE) {
-    printf("rtGetSocVersion failed, 0x%x", rtRet);
+  if (socName == nullptr) {
+    printf("cann_get_soc_name failed.");
     return nullptr;
   }
   if (PyErr_Occurred()) {
     return nullptr;
   }
-  return Py_BuildValue("s", name);
-}
-
-static PyObject *getAiCoreNum(PyObject *self, PyObject *args) {
-  uint32_t aiCoreCnt;
-
-  rtError_t rtRet = rtGetAiCoreCount(&aiCoreCnt);
-
-  if (rtRet != RT_ERROR_NONE) {
-    printf("rtGetAiCoreCount failed, 0x%x", rtRet);
-    return nullptr;
-  }
-  if (PyErr_Occurred()) {
-    return nullptr;
-  }
-  return Py_BuildValue("I", aiCoreCnt);
+  return Py_BuildValue("s", socName);
 }
 
 static PyObject *createStream(PyObject *self, PyObject *args) {
-	rtStream_t stream;
+  cann_stream stream;
+  cann_error rtRet = cann_create_stream(&stream);
+  if (rtRet != CANN_SUCCESS) {
+    printf("cann_create_stream failed, 0x%x", rtRet);
+    return nullptr;
+  }
+  if (PyErr_Occurred()) {
+    return nullptr;
+  }
+  uint64_t stream_uint64 = reinterpret_cast<uint64_t>(stream);
+  PyObject *result = Py_BuildValue("K", stream_uint64);
 
-	rtError_t rtRet = rtStreamCreate(&stream, 0);
+  if (result == nullptr) {
+    cann_destroy_stream(stream);
+  }
 
-	if (rtRet != RT_ERROR_NONE) {
-		printf("rtStreamCreate failed, 0x%x", rtRet);
-		return nullptr;
-	}
-	if (PyErr_Occurred()) {
-		return nullptr;
-	}
-	uint64_t stream_uint64 = reinterpret_cast<uint64_t>(stream);
-    PyObject* result = Py_BuildValue("K", stream_uint64);
-
-    if (result == nullptr) {
-        rtStreamDestroy(stream);
-    }
-
-    return result;
+  return result;
 }
 
 /**
@@ -258,18 +341,16 @@ static PyObject* allocateHostMemory(PyObject* self, PyObject* args) {
 	}
 
 	void* host_ptr = nullptr;
-	rtError_t error = rtMallocHost(&host_ptr, num_bytes, RT_MEMORY_HOST);
-	if (error != RT_ERROR_NONE) {
-		PyErr_Format(PyExc_RuntimeError, "rtMallocHost failed with error code: 0x%x", error);
+	cann_error error = cann_malloc_host(&host_ptr, num_bytes);
+	if (error != CANN_SUCCESS) {
+		PyErr_Format(PyExc_RuntimeError, "cann_malloc_host failed with error code: 0x%x", error);
 		return nullptr;
 	}
 
     PyObject* result = Py_BuildValue("K", (uint64_t)host_ptr);
-
     if (result == nullptr) {
-        rtFreeHost(host_ptr);
+        cann_free_host(host_ptr);
     }
-
     return result;
 }
 
@@ -280,16 +361,16 @@ static PyObject* allocateDeviceMemory(PyObject* self, PyObject* args) {
 	}
 
 	void* device_ptr = nullptr;
-	rtError_t error = rtMalloc(&device_ptr, num_bytes, RT_MEMORY_HBM, 0);
-	if (error != RT_ERROR_NONE) {
-		PyErr_Format(PyExc_RuntimeError, "rtMalloc failed with error code: 0x%x", error);
+	cann_error error = cann_malloc(&device_ptr, num_bytes);
+	if (error != CANN_SUCCESS) {
+		PyErr_Format(PyExc_RuntimeError, "cann_malloc failed with error code: 0x%x", error);
 		return nullptr;
 	}
 
     PyObject* result = Py_BuildValue("K", (uint64_t)device_ptr);
 
     if (result == nullptr) {
-        rtFree(device_ptr);
+        cann_free(device_ptr);
     }
 
     return result;
@@ -300,16 +381,16 @@ static PyObject* copyMemory(PyObject* self, PyObject* args) {
 	uint64_t src_ptr;
 	size_t count;
 	const char* direction_str;
-	rtMemcpyKind_t copy_direction;
+	int copy_direction;
 
 	if (!PyArg_ParseTuple(args, "KKns", &dst_ptr, &src_ptr, &count, &direction_str)) {
 		return nullptr;
 	}
 
 	if (strcmp(direction_str, "H2D") == 0) {
-		copy_direction = RT_MEMCPY_HOST_TO_DEVICE;
+		copy_direction = CANN_MEMCPY_HOST_TO_DEVICE;
 	} else if (strcmp(direction_str, "D2H") == 0) {
-		copy_direction = RT_MEMCPY_DEVICE_TO_HOST;
+		copy_direction = CANN_MEMCPY_DEVICE_TO_HOST;
 	} else {
 		PyErr_SetString(PyExc_ValueError, "Invalid copy direction. Must be 'H2D' or 'D2H'.");
 		return nullptr;
@@ -318,9 +399,9 @@ static PyObject* copyMemory(PyObject* self, PyObject* args) {
 	void *dst = (void*)dst_ptr;
 	void *src = (void*)src_ptr;
 
-	rtError_t error = rtMemcpy(dst, count, src, count, copy_direction);
-	if (error != RT_ERROR_NONE) {
-		PyErr_Format(PyExc_RuntimeError, "rtMemcpy failed with error code: 0x%x", error);
+	cann_error error = cann_memcpy(dst, count, src, count, copy_direction);
+	if (error != CANN_SUCCESS) {
+		PyErr_Format(PyExc_RuntimeError, "CANN_SUCCESS failed with error code: 0x%x", error);
 		return nullptr;
 	}
 
@@ -383,8 +464,6 @@ static PyMethodDef NpuUtilsMethods[] = {
     {"load_kernel_binary", loadKernelBinary, METH_VARARGS,
      "Load NPU kernel binary into NPU driver"},
     {"get_arch", getArch, METH_VARARGS, "Get soc version of NPU"},
-    // sentinel
-    {"get_aicore_num", getAiCoreNum, METH_VARARGS, "Get the number of AI core"},
 	{"create_stream", createStream, METH_VARARGS, "Create a stream"},
 	{"read_data_from_file", readDataFromBinaryFileWrapper, METH_VARARGS, "Read binary file into the array already allocated"},
 	{"write_data_to_file", writeDataToBinaryFileWrapper, METH_VARARGS, "Write an array to a binary file"},

--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -35,6 +35,7 @@ from triton.backends.ascend.backend_register import backend_strategy_registry
 
 import pybind11
 
+
 AUTO_BLOCKIFY_BLACKLIST_RULES = (
     (re.compile(r"\btt\.atomic_(?:rmw|cas)\b"), "atomic operations"),
     (re.compile(r"\btt\.elementwise_inline_asm\b"), "inline elementwise assembly"),
@@ -514,16 +515,69 @@ def triton_enable_libdevice_simt():
     return enable_libdevice_simt and is_compile_on_910_95
 
 
-def get_cann_version_file_hash():
-    ascend_path = _get_ascend_path()
+def _parse_cann_version(line: str):
+    m = re.search(r'(\d+)\.(\d+)(?:\.(\d+))?', line)
+    if m:
+        major = int(m.group(1))
+        minor = int(m.group(2))
+        patch = int(m.group(3)) if m.group(3) is not None else 0
+        return (major, minor, patch)
+    return None
+
+
+def _find_cann_version_file():
+    ascend_path = str(_get_ascend_path())
     arch = get_machine_arch()
-    cann_version_file_path = os.path.join(ascend_path, arch + "-linux", "ascend_toolkit_install.info")
-    if not os.path.exists(cann_version_file_path):
-        cann_version_file_path = os.path.join(ascend_path, arch + "-linux", "ascend_all_cann_install.info")
+    candidates = [
+        os.path.join(ascend_path, arch + "-linux", "ascend_toolkit_install.info"),
+        os.path.join(ascend_path, arch + "-linux", "ascend_all_cann_install.info"),
+    ]
+    for p in candidates:
+        if os.path.exists(p):
+            return p
+    return None
+
+
+def get_cann_version():
+    _cann_version = None
+    try:
+        version_file = _find_cann_version_file()
+        if version_file is None:
+            _cann_version = None
+            return None
+        with open(version_file, "r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                line = line.strip()
+                if "version" in line.lower():
+                    parsed = _parse_cann_version(line)
+                    if parsed is not None:
+                        _cann_version = parsed
+                        return _cann_version
+        _cann_version = None
+    except Exception:
+        raise EnvironmentError("Could not parse CANN version file")
+
+
+def is_cann_version_at_least(major: int, minor: int = 0, patch: int = 0) -> bool:
+    v = get_cann_version()
+    if v is None:
+        return False
+    return v >= (major, minor, patch)
+
+
+def cann_version_compile_args():
+    if is_cann_version_at_least(9, 1, 0):
+        return ["-DTRITON_CANN_910"]
+    return []
+
+def get_cann_version_file_hash():
+    cann_version_file_path = _find_cann_version_file()
     return get_file_hash256(cann_version_file_path)
 
 
 def get_file_hash256(file_path):
+    if file_path is None:
+        raise ValueError("file_path is None")
     sha256 = hashlib.sha256()
     try:
         with open(file_path, "rb") as f:


### PR DESCRIPTION
# Design of CANN Core Boot Configuration (cfg) Compatibility Layer #

## 1. Background and motivation ##

The launcher C++ code generated by the Triton Ascend backend requires the kernel to be started on different CANN versions. CANN provides two incompatible runtime startup interfaces before and after version 9.1 .0:

| CANN version | runtime library              | Kernel Boot Interface                       | Startup Configuration Structure                 | Parameter packaging structure             |
| ------------ | ---------------------------- | ------------------------------------------- | ----------------------------------------------- | ----------------------------------------- |
| ≥ 9.1. 0     | `aclrt`(`acl/acl.h`)         | `aclrtLaunchKernelWithHostArgs`             | `aclrtLaunchKernelCfg`\+`aclrtLaunchKernelAttr` | Direct transmission`void* args`\+`size_t` |
| < 9.1. 0     | `rt`(`runtime/runtime/rt.h`) | `rtKernelLaunch`/`rtKernelLaunchWithFlagV2` | `rtTaskCfgInfo_t`                               | `rtArgsEx_t`(only with cfg)               |

For SIMT-enabled kernels on 910 _ 95, the compiler passes in the metadata`shared_mem_dynamic_size`(Dynamic UBUF/local memory size. For the default value, see.)`compiler.py`\:`force_simt_only`is 122880; otherwise, is 221184). The launcher must write the value to the corresponding startup configuration structure when starting the kernel. Otherwise, the kernel cannot obtain the expected shared memory.

Before the current submission, the cfg construction code is scattered in the launcher generation logic in inline mode and directly invokes the underlying layer.`rt*`/`aclrt*`The interface has the following problems:

1.  **Lack of RT path function: compatible with the**`cann_launch_kernel`Used in the RT branch`(void)cfg;`Ignore the cfg parameter and change to`rtKernelLaunch`This causes the dynamic UBUF configuration to be completely invalid on CANN < 9.1.0.
2.  **Hanging Pointer: ACL branched**`cann_get_launch_kernel_cfg`Returns the address of a local variable on the stack. After the function is returned, the memory becomes invalid.
3.  **Undefined variable: RT branch's**`cann_get_launch_kernel_cfg`incorrectly referenced non-existent in a formal parameter`args`To be associated with the`cfgCfgInfo`, cannot be compiled by.
4.  **Missing semicolon in build code: missing at end of cfg fetch statement**`;`.

## 2. Design Objectives ##

 *  In the`generate_npu_header_src`Provides a unified`cann_*`This version is compatible with the shim. The differences between the ACL and RT interfaces are shielded from the upper-layer launcher.
 *  The dynamic UBUF configuration takes effect on both the ACL and RT paths.
 *  The life cycle of the cfg structure must be overwritten.`cann_launch_kernel`Call, must not return a dangling pointer.
 *  Keep the launcher generation logic simple: two startup paths are only responsible for calling.`cann_get_launch_kernel_cfg`To be associated with the`cann_launch_kernel`, does not directly reference the bottom layer`rt*`/`aclrt*`Symbol.
 *  Only the logic related to the cfg is modified, and other startup processes are not touched. (Parameter packing, workspace, FFTS, and profiling).

## 3. Overall design ##

### 3.1 Selecting the Version During Compilation ###

`utils.cann_version_compile_args()`Inject the macro (`utils.py:568-571`):

```
def cann_version_compile_args():
    if is_cann_version_at_least(9, 1, 0):
        return ["-DTRITON_CANN_910"]
    return []
```

 *  Defined`TRITON_CANN_910`\: ACL (`aclrt`) branch,`#include <acl/acl.h>`.
 *  Undefined: Use RT (`rt`) branch, using`#include "runtime/runtime/rt.h"`(Default header file).

All in shim`cann_*`Type aliases and inline functions are`#ifdef TRITON_CANN_910... #else... #endif`(`driver.py:410-468`Implemented separately in the section.

### 3.2 External Interfaces ###

The shim exposes two cfg-related entries:

```
//Construct a kernel startup configuration and return the pointer (the lifecycle covers subsequent cann_launch_kernel calls).
static inline void* cann_get_launch_kernel_cfg(uint32_t shared_mem_dynamic_size);

//Starts the kernel. If cfg == nullptr is used, the common startup mode is used. Otherwise, the configuration is carried.
static inline cann_error cann_launch_kernel(
    cann_func_handle func, uint32_t block_dim, cann_stream stream,
    void *cfg, void *args, size_t arg_size);
```

shim is also the other runtime capability (malloc/free host, memcpy, memset async, stream synchronize, hardware sync addr) A unified alias is provided so that the main code of the launcher is unaware of the underlying layer.`rt*`/`aclrt*`Difference.

### 3.3 Memory Life Cycle ###

`cann_get_launch_kernel_cfg`The pointer to the returned configuration structure must be in the`cann_launch_kernel`Remains valid until returned. Because launcher is a synchronous call on the kernel startup thread, use the function inside`static thread_local`Variables guarantee:

 *  Sequential calls on the same thread do not overwrite each other.
 *  Different threads have independent instances, which is a thread security problem.
 *  Variables are not released within the program life cycle, and no dangling pointer exists.

### 3.4 Two Boot Paths ###

`driver.py`When the launcher is generated, construct two pieces of kernel startup code (`driver.py:868-883`):

1.  **`cpp_kernel_launch`**\: for`triton_launch_kernel`Stable ABI path with parameters in`launch_args`In vector (`static_cast<void*>(launch_args.data())`).
2.  **`cpp_kernel_launch_local`**\: for`_launch`Local C++ packing path. Parameters are on the stack.`struct args`(`static_cast<void*>(&args), sizeof(args)`).

And when the`compile_on_910_95 and enable_simt`When true, both pieces of code are calling`cann_launch_kernel`Invoke before`cann_get_launch_kernel_cfg(shared_mem_dynamic_size)`Obtain the cfg file. Otherwise, the parameter is transferred.`NULL`.

```
make_launcher
  ├── cpp_kernel_launch        (triton_launch_kernel, 稳定 ABI)
  │     void *kernel_cfg = cann_get_launch_kernel_cfg(<size>);  //conditions
  │     ret = cann_launch_kernel(func, blockNum, stream,
  │                              kernel_cfg, launch_args.data(), launch_args.size());
  └── cpp_kernel_launch_local  (_launch, 本地 packing)
        void *kernel_cfg = cann_get_launch_kernel_cfg(<size>);  //conditions
        ret = cann_launch_kernel(func, blockNum, stream,
                                 kernel_cfg, &args, sizeof(args));
```

## 4. Key implementation ##

### 4.1 ACL branch (CANN ≥ 9.1.0,`driver.py:423-436`) ###

```
static inline cann_error cann_launch_kernel(
    cann_func_handle func, uint32_t block_dim, cann_stream stream,
    void *cfg, void *args, size_t arg_size) {
  return aclrtLaunchKernelWithHostArgs(
      func, block_dim, stream,
      static_cast<aclrtLaunchKernelCfg *>(cfg),
      args, arg_size, nullptr, 0);
}

static inline void* cann_get_launch_kernel_cfg(uint32_t shared_mem_dynamic_size) {
  //thread_local storage: launch is synchronous on the launcher thread, so the
  //returned pointer remains valid until cann_launch_kernel returns.
  static thread_local aclrtLaunchKernelAttr attrInfo;
  static thread_local aclrtLaunchKernelCfg cfgCfgInfo;
  attrInfo.id = ACL_RT_LAUNCH_KERNEL_ATTR_DYN_UBUF_SIZE;
  attrInfo.value.localMemorySize = shared_mem_dynamic_size;
  cfgCfgInfo.attrs = &attrInfo;
  cfgCfgInfo.numAttrs = 1;
  return &cfgCfgInfo;
}
```

Key points:

 *  `attrInfo`To be associated with the`cfgCfgInfo`Both are`thread_local`,`cfgCfgInfo.attrs`Pointing to the same thread`attrInfo`to avoid floating the internal pointer.
 *  Through the`ACL_RT_LAUNCH_KERNEL_ATTR_DYN_UBUF_SIZE`Property passes the dynamic UBUF size.
 *  cfg is`nullptr`When,`aclrtLaunchKernelWithHostArgs`Receive empty configuration, which is equivalent to common startup.

### 4.2 RT branch (CANN < 9.1.0,`driver.py:450-465`) ###

```
static inline cann_error cann_launch_kernel(
    cann_func_handle func, uint32_t block_dim, cann_stream stream,
    void *cfg, void *args, size_t arg_size) {
  if (cfg != nullptr) {
    rtArgsEx_t argsInfo = {};
    argsInfo.args = args;
    argsInfo.argsSize = arg_size;
    return rtKernelLaunchWithFlagV2(
        func, block_dim, &argsInfo, NULL, stream, 0,
        static_cast<rtTaskCfgInfo_t *>(cfg));
  }
  return rtKernelLaunch(func, block_dim, args, arg_size, NULL, stream);
}

static inline void* cann_get_launch_kernel_cfg(uint32_t shared_mem_dynamic_size) {
  //thread_local storage: launch is synchronous on the launcher thread, so the
  //returned pointer remains valid until cann_launch_kernel returns.
  static thread_local rtTaskCfgInfo_t cfgInfo;
  cfgInfo.localMemorySize = shared_mem_dynamic_size;
  return &cfgInfo;
}
```

Key points:

 *  **If the cfg is not empty, use the**`rtArgsEx_t`Packaged`args`/`arg_size`, invoke the`rtKernelLaunchWithFlagV2`And pass in`rtTaskCfgInfo_t*`The dynamic UBUF takes effect.
 *  **If cfg is empty, the value is changed to common.**`rtKernelLaunch`. The behavior is the same as that before the modification.
 *  `cann_get_launch_kernel_cfg`Only constructs cfg, not incorrectly constructs.`rtArgsEx_t`(args information is displayed in the`cann_launch_kernel`This parameter is constructed based on the actual input parameter.

### 4.3 Launcher Generation End (`driver.py:868-883`) ###

```
cpp_kernel_launch = f"""
    ret = cann_launch_kernel(func, blockNum, stream, NULL,
                             static_cast<void*>(launch_args.data()),
                             launch_args.size());
"""
if compile_on_910_95 and enable_simt:
    cpp_kernel_launch = f"""
    void *kernel_cfg = cann_get_launch_kernel_cfg({metadata.shared_mem_dynamic_size});
    ret = cann_launch_kernel(func, blockNum, stream, kernel_cfg,
                             static_cast<void*>(launch_args.data()),
                             launch_args.size());
"""

cpp_kernel_launch_local = f"""
    ret = cann_launch_kernel(func, blockNum, stream, NULL,
                             static_cast<void*>(&args), sizeof(args));
"""
if compile_on_910_95 and enable_simt:
    cpp_kernel_launch_local = f"""
    void *kernel_cfg = cann_get_launch_kernel_cfg({metadata.shared_mem_dynamic_size});
    ret = cann_launch_kernel(func, blockNum, stream, kernel_cfg,
                             static_cast<void*>(&args), sizeof(args));
"""
```

The two paths use the same conditions to generate cfg fetch statements, ensuring that the dynamic UBUF requirements of the SIMT kernel are met on both paths.

## 5. Data flow ##

```
AscendCompileOptions.shared_mem_dynamic_size (compiler.py)
        │  默认值: force_simt_only -> 122880, 否则 -> 221184
        ▼
metadata.shared_mem_dynamic_size
        │
        ▼
cann_get_launch_kernel_cfg(size)  ──►  thread_local cfg 结构体
        │                                   │
        ▼                                   ▼
cann_launch_kernel(func, blockDim, stream, kernel_cfg, args, arg_size)
        │
        ├── TRITON_CANN_910 定义: aclrtLaunchKernelWithHostArgs(..., aclrtLaunchKernelCfg*, ...)
        └── 未定义:
              ├── cfg != nullptr: rtKernelLaunchWithFlagV2(..., rtArgsEx_t*, ..., rtTaskCfgInfo_t*)
              └── cfg == nullptr: rtKernelLaunch(..., args, arg_size, ...)
```

## 6. Scope of impact ##

 *  **Modify the file:**`third_party/ascend/backend/driver.py`
    
     *  `generate_npu_header_src`(Line 410-468): Repair the ACL/RT branch`cann_launch_kernel`To be associated with the`cann_get_launch_kernel_cfg`Implement, introduce`thread_local`Storage, supplementing the RT branch`rtKernelLaunchWithFlagV2`Invoke.
     *  Launcher generation logic (lines 868 to 883): The two startup paths are invoked in a unified manner in the SIMT scenario.`cann_get_launch_kernel_cfg`Modified the semicolon in the cfg obtaining statement in.
 *  **Do not modify:**`compiler.py`Medium`shared_mem_dynamic_size`Default values and other startup processes such as compilation option transfer, parameter packaging, workspace allocation, FFTS, profiling, and grid calculation.
 *  **Runtime Impact:**
    
     *  CANN ≥ 9.1.0: Fixed the problem of the floating pointer of the cfg structure, and the dynamic UBUF configuration is correctly transferred.
     *  CANN < 9.1.0 + SIMT: Fixed dynamic UBUF configuration being`(void)cfg`bug that silently drops, now through the`rtKernelLaunchWithFlagV2`Correctly effective.
     *  CANN < 9.1.0 + non-SIMT: still going`rtKernelLaunch`The behavior remains the same.

