### PR TITLE
[TritonToLinalg](fix) preserve masked atomic return values

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
@@ -894,19 +894,21 @@ AtomicRMWConverter::matchAndRewrite(triton::AtomicRMWOp op, OpAdaptor adaptor,
        elementType.isInteger(32));
 
   bool isDiscreteMask = false;
+  bool hasContinuousMaskSubview = false;
+  MaskState mstate;
   if (mask) {
     auto constantMask = mask.getDefiningOp<arith::ConstantOp>();
     if (constantMask && !isConstantMaskTrue(mask)) {
       rewriter.eraseOp(op);
       return success();
     }
-    MaskState mstate;
     isDiscreteMask = mstate.parse(mask, loc, rewriter).failed();
     if (!constantMask && !isDiscreteMask) {
       // For dstMemref (store output), use subview to maintain reference to
       // original memref. For inputVal (store input), use tensor.extract_slice
       // to keep tensor semantics.
       dstMemref = mstate.getSubview(ptr, loc, rewriter);
+      hasContinuousMaskSubview = true;
       if (isHardwareSupported) {
         auto inputTensorType = RankedTensorType::get(
             inputMemrefType.getShape(), inputMemrefType.getElementType());
@@ -925,7 +927,15 @@ AtomicRMWConverter::matchAndRewrite(triton::AtomicRMWOp op, OpAdaptor adaptor,
         RankedTensorType::get(ptrType.getShape(), ptrType.getElementType());
     auto alloc = rewriter.create<memref::AllocOp>(
         loc, MemRefType::get(ptrType.getShape(), ptrType.getElementType()));
-    rewriter.create<memref::CopyOp>(loc, ptr, alloc);
+    Value copySrc = ptr;
+    Value copyDst = alloc;
+    if (hasContinuousMaskSubview) {
+      // Masked-off atomic results are undefined. Copy only the active region
+      // so the old-value read and the atomic store use the same address view.
+      copySrc = dstMemref;
+      copyDst = mstate.getSubview(alloc, loc, rewriter);
+    }
+    rewriter.create<memref::CopyOp>(loc, copySrc, copyDst);
     Value tensorToReplace = rewriter.create<bufferization::ToTensorOp>(
         loc, tensorType, alloc, true /* restrict */, true /* writable */);
     rewriter.replaceOp(op, tensorToReplace);

--- a/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
@@ -76,6 +76,7 @@ using namespace triton;
 
 const std::string MayImplicitTransposeWithLastAxisTAG =
     "MayImplicitTransposeWithLastAxis";
+static constexpr llvm::StringLiteral kAlreadySyncAttr = "already_sync";
 
 // During dialect conversion the adaptor may expose the converted memref
 // directly, while a failed rewrite later leaves a one-input, one-output UCC in
@@ -895,6 +896,7 @@ AtomicRMWConverter::matchAndRewrite(triton::AtomicRMWOp op, OpAdaptor adaptor,
 
   bool isDiscreteMask = false;
   bool hasContinuousMaskSubview = false;
+  bool hasUsedReturn = !op.getResult().use_empty();
   MaskState mstate;
   if (mask) {
     auto constantMask = mask.getDefiningOp<arith::ConstantOp>();
@@ -922,7 +924,10 @@ AtomicRMWConverter::matchAndRewrite(triton::AtomicRMWOp op, OpAdaptor adaptor,
     }
   }
 
-  if (!op.getResult().use_empty()) {
+  bool needsReturnValueLock =
+      hasUsedReturn && hasContinuousMaskSubview && isHardwareSupported;
+  Value returnValueLock;
+  if (hasUsedReturn) {
     auto tensorType =
         RankedTensorType::get(ptrType.getShape(), ptrType.getElementType());
     auto alloc = rewriter.create<memref::AllocOp>(
@@ -934,6 +939,13 @@ AtomicRMWConverter::matchAndRewrite(triton::AtomicRMWOp op, OpAdaptor adaptor,
       // so the old-value read and the atomic store use the same address view.
       copySrc = dstMemref;
       copyDst = mstate.getSubview(alloc, loc, rewriter);
+    }
+    if (needsReturnValueLock) {
+      auto lockType = MemRefType::get({1}, rewriter.getI64Type());
+      auto lockVar =
+          rewriter.create<hivm::CreateSyncBlockLockOp>(loc, lockType, Value());
+      returnValueLock = lockVar.getResult();
+      rewriter.create<hivm::SyncBlockLockOp>(loc, returnValueLock);
     }
     rewriter.create<memref::CopyOp>(loc, copySrc, copyDst);
     Value tensorToReplace = rewriter.create<bufferization::ToTensorOp>(
@@ -957,10 +969,16 @@ AtomicRMWConverter::matchAndRewrite(triton::AtomicRMWOp op, OpAdaptor adaptor,
     rewriter.create<hfusion::AtomicXchgOp>(op.getLoc(), TypeRange(),
                                            inputMemref, dstMemref, memrefMask);
   } else {
-    if (isHardwareSupported)
-      rewriter.create<hivm::StoreOp>(op.getLoc(), TypeRange{}, inputVal,
-                                     dstMemref, atomicKind);
-    else if (rmwOp == RMWOp::XCHG)
+    if (isHardwareSupported) {
+      auto storeOp = rewriter.create<hivm::StoreOp>(
+          op.getLoc(), TypeRange{}, inputVal, dstMemref, atomicKind);
+      if (needsReturnValueLock) {
+        // The return-value copy and the atomic update must be one critical
+        // section. Mark the store so HIVM does not add another lock.
+        storeOp->setAttr(kAlreadySyncAttr, rewriter.getUnitAttr());
+        rewriter.create<hivm::SyncBlockUnlockOp>(loc, returnValueLock);
+      }
+    } else if (rmwOp == RMWOp::XCHG)
       rewriter.create<hfusion::AtomicXchgOp>(op.getLoc(), TypeRange(),
                                              inputMemref, dstMemref);
     else {

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/atomic_rmw_block.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/atomic_rmw_block.mlir
@@ -46,4 +46,6 @@ module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
 // CHECK: %[[ATOMIC_PTR:.*]] = memref.reinterpret_cast %{{.*}} to offset: [%{{.*}}], sizes: [1], strides: [1] : memref<?xi32> to memref<1xi32, strided<[1], offset: ?>>
 // CHECK: %[[ATOMIC_VIEW:.*]] = memref.subview %[[ATOMIC_PTR]][0] [%[[MASK_SIZE]]] [1] : memref<1xi32, strided<[1], offset: ?>> to memref<?xi32, strided<[1], offset: ?>>
 // CHECK: %[[ATOMIC_VALUE:.*]] = tensor.extract_slice %{{.*}}[0] [%[[MASK_SIZE]]] [1] : tensor<1xi32> to tensor<?xi32>
+// CHECK: %[[RESULT_VIEW:.*]] = memref.subview %{{.*}}[0] [%[[MASK_SIZE]]] [1] : memref<1xi32> to memref<?xi32, strided<[1]>>
+// CHECK: memref.copy %[[ATOMIC_VIEW]], %[[RESULT_VIEW]] :
 // CHECK: hivm.hir.store ins(%[[ATOMIC_VALUE]] : tensor<?xi32>) outs(%[[ATOMIC_VIEW]] : memref<?xi32, strided<[1], offset: ?>>) atomic = <add>

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/atomic_rmw_block.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/atomic_rmw_block.mlir
@@ -47,5 +47,8 @@ module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
 // CHECK: %[[ATOMIC_VIEW:.*]] = memref.subview %[[ATOMIC_PTR]][0] [%[[MASK_SIZE]]] [1] : memref<1xi32, strided<[1], offset: ?>> to memref<?xi32, strided<[1], offset: ?>>
 // CHECK: %[[ATOMIC_VALUE:.*]] = tensor.extract_slice %{{.*}}[0] [%[[MASK_SIZE]]] [1] : tensor<1xi32> to tensor<?xi32>
 // CHECK: %[[RESULT_VIEW:.*]] = memref.subview %{{.*}}[0] [%[[MASK_SIZE]]] [1] : memref<1xi32> to memref<?xi32, strided<[1]>>
+// CHECK: %[[LOCK:.*]] = hivm.hir.create_sync_block_lock : memref<1xi64>
+// CHECK: hivm.hir.sync_block_lock lock_var(%[[LOCK]] : memref<1xi64>)
 // CHECK: memref.copy %[[ATOMIC_VIEW]], %[[RESULT_VIEW]] :
-// CHECK: hivm.hir.store ins(%[[ATOMIC_VALUE]] : tensor<?xi32>) outs(%[[ATOMIC_VIEW]] : memref<?xi32, strided<[1], offset: ?>>) atomic = <add>
+// CHECK: hivm.hir.store ins(%[[ATOMIC_VALUE]] : tensor<?xi32>) outs(%[[ATOMIC_VIEW]] : memref<?xi32, strided<[1], offset: ?>>) {already_sync} atomic = <add>
+// CHECK: hivm.hir.sync_block_unlock lock_var(%[[LOCK]] : memref<1xi64>)

--- a/third_party/ascend/unittest/pytest_ut/test_indirect_atomic_add.py
+++ b/third_party/ascend/unittest/pytest_ut/test_indirect_atomic_add.py
@@ -30,6 +30,7 @@
 #  | fully unstructured indirect offsets             | (C1) | (C2) | (C3) | (C4) | (C5) |
 #  | loaded mask + masked-off out-of-bounds offsets   | (D1) |  -   |  -   |  -   |  -   |
 #  | scalar-splat mask shared by load and atomic      | (E1) |  -   |  -   |  -   |  -   |
+#  | scalar-splat mask + used atomic return value     | (F1) |  -   |  -   |  -   |  -   |
 #
 # Notes:
 # 1. Case A exercises the structured-pointer discrete-mask atomic_add path.
@@ -39,7 +40,9 @@
 # 4. Case D verifies that a loaded discrete mask guards loaded invalid offsets.
 # 5. Case E verifies that a scalar-splat mask shared by an indirect load and
 #    atomic_add still guards inactive programs.
-# 6. Cases A-D validate both the final destination tensor and the atomic_add
+# 6. Case F verifies that the old-value copy and atomic store use the same
+#    scalar-splat-masked address range, including inactive invalid offsets.
+# 7. Cases A-D and F validate both the final destination tensor and the atomic_add
 #    return value, which must be the old value observed at each access.
 # =============================================================================
 
@@ -129,6 +132,20 @@ def scalar_splat_mask_atomic_add_1d(
     mask = offsets < numel
     expert_id = tl.load(topk_ids_ptr + offsets, mask=mask, other=0)
     tl.atomic_add(tokens_cnts_ptr + expert_id, 1, mask=mask)
+
+
+@triton.jit(do_not_specialize=["numel"])
+def scalar_splat_mask_atomic_add_return_value_1d(
+    idx_ptr,
+    out_ptr,
+    old_ptr,
+    numel,
+):
+    pid = tl.program_id(0)
+    offset = tl.load(idx_ptr + pid)
+    mask = pid < numel
+    old = tl.atomic_add(out_ptr + offset, 1, mask=mask)
+    tl.store(old_ptr + pid, old, mask=mask)
 
 
 @triton.jit
@@ -634,3 +651,34 @@ def test_atomic_add_scalar_splat_mask_skips_inactive_programs():
 
     expected = torch.tensor([1, 1, 1, 0], dtype=torch.int32)
     assert torch.equal(tokens_cnts.cpu(), expected)
+
+
+def test_atomic_add_scalar_splat_mask_return_value_skips_oob_offsets():
+    numel = 3
+    grid_size = 8
+    invalid_offset = 1 << 30
+    old_sentinel = -777
+
+    offsets = torch.tensor(
+        [0, 1, 2] + [invalid_offset] * (grid_size - numel),
+        dtype=torch.int64,
+    ).npu()
+    baseline = torch.tensor([10, 20, 30], dtype=torch.int32)
+    output = baseline.clone().npu()
+    old = torch.full((grid_size, ), old_sentinel, dtype=torch.int32).npu()
+
+    scalar_splat_mask_atomic_add_return_value_1d[(grid_size, )](
+        offsets,
+        output,
+        old,
+        numel,
+    )
+    torch.npu.synchronize()
+
+    expected_output = baseline + 1
+    expected_old = torch.tensor(
+        [10, 20, 30] + [old_sentinel] * (grid_size - numel),
+        dtype=torch.int32,
+    )
+    _assert_equal(output, expected_output, "int32", 1, "scalar-splat-mask-return-value/output")
+    _assert_equal(old, expected_old, "int32", 1, "scalar-splat-mask-return-value/old")


### PR DESCRIPTION

Fix the lowering of masked `tt.atomic_rmw` operations whose return values are used.

For continuously masked atomics, TritonToLinalg now:

- Copies the old value only from the active GM subview.
- Uses a matching subview for the return-value buffer.
- Places the old-value copy and hardware atomic store in the same sync-block critical section.
- Marks the atomic store as `already_sync` to prevent duplicate synchronization in NPU-IR.

## Problem

The current vector atomic lowering cannot perform the old-value read and atomic update as a single RMW operation when the atomic return value is required. It is lowered into two operations:

```text
old = load/copy from GM
atomic update to GM
```

These operations must be serialized to preserve the `tt.atomic_rmw` contract that the result is the value observed before the update.

With a continuous mask, the atomic store uses a masked `memref.subview`. Previously, the return-value copy could use a different memref representation. Although the values referred to the same underlying buffers, NPU-IR could not reliably recover the relationship through combinations of `subview`, `reinterpret_cast`, and `bufferization.to_tensor`.

This could result in:

- Masked-off invalid addresses being accessed by the return-value copy.
- The old-value copy and atomic update not being synchronized, allowing concurrent blocks to observe incorrect old values.

## Implementation

TritonToLinalg directly determines whether synchronization is required using the original atomic semantics:

```text
atomic result is used
&& mask is lowered to a continuous subview
&& the operation uses the hardware atomic-store path
```

For this case, it emits:

```text
sync_block_lock
memref.copy old value from the active GM subview
hivm.hir.store {already_sync} atomic
sync_block_unlock
```

The analysis is performed in TA because the original `tt.atomic_rmw` result-use relationship is still explicit at this level. No NPU-IR source changes are required.

Atomics with unused return values, unmasked atomics, and compile-time constant masks are unaffected by this synchronization path.

## Performance impact

This is a correctness-first fallback for atomic implementations that cannot return the old value directly.

The generated ordered sync-block lock may be hoisted outside an enclosing loop, which can serialize participating blocks and cause a significant performance regression for atomics whose return values are used inside loops.

A follow-up optimization can route supported data types to an atomic-return SIMT implementation and retain the sync-block lock only as a fallback.

