### PR TITLE
[compiler](fix) remove bisheng_options with warning compatibility

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -710,9 +710,6 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
                 "--enable-hfusion-compile=true",
                 "--enable-triton-kernel-compile=true",
             ]
-        bisheng_options = metadata["bisheng_options"]
-        if bisheng_options is not None:
-            _compile_option_list += [f"--append-bisheng-options={bisheng_options}"]
         _compile_option_list += ["--mlir-print-ir-after-failure"]
         _compile_option_list += ["--mlir-print-stacktrace-on-diagnostic"]
         if opt.debug:
@@ -1043,7 +1040,6 @@ class NPUOptions:
     allowed_dot_input_precisions: Tuple[str] = ("ieee", "hf32")
     max_num_imprecise_acc_default: int = 0
     extern_libs: dict = None
-    bisheng_options: str = "-cce-link-aicore-ll-module " + get_libdevice()
     multibuffer: bool = True
     vf_fusion_mode: str = None
     enable_ubuf_saving: bool = None
@@ -1228,10 +1224,6 @@ def ttir_to_npubin(mod, metadata, opt):
                 _compile_option_list += ["--enable-simt-reorder-instruction=true"]
             if opt.disable_fma:
                 _compile_option_list += [f"--disable-fma"]
-
-            bisheng_options = metadata["bisheng_options"]
-            if bisheng_options is not None:
-                _compile_option_list += [f"--append-bisheng-options={bisheng_options}"]
 
             # Enable SIMT auto-blockify under the fixed automatic block-mapping
             # policy, mirroring the SIMD compile paths. driver.py's runtime

--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -44,6 +44,7 @@ _DEPRECATED_NPU_OPTIONS = frozenset({
     "arch",
     "auto_blockify_size",
     "auto_tile_and_bind_subblock",
+    "bisheng_options",
     "code_motion",
     "compile_on_910_95",
     "disable_size_align_for_cast",

--- a/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
+++ b/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
@@ -82,3 +82,17 @@ def test_graph_ub_budget_resolves_from_explicit_arch(arch, raw_ub_kib, graph_bud
 
     assert utils.ub_size_in_kbytes_for_arch(arch) == raw_ub_kib
     assert utils.graph_ub_budget_bytes_for_arch(arch) == graph_budget_bytes
+
+
+def test_removed_bisheng_options_warns_and_is_ignored_in_place():
+    utils = _load_utils_module()
+    options = {
+        "bisheng_options": "-mllvm --cce-enable-dynamic-micsched=true",
+        "debug": True,
+    }
+
+    with pytest.warns(FutureWarning, match=r"bisheng_options.*deprecated and ignored"):
+        normalized = utils._remove_deprecated_npu_options(options, in_place=True)
+
+    assert normalized is options
+    assert options == {"debug": True}

--- a/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
+++ b/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
@@ -100,6 +100,12 @@ def compiler_module():
     def remove_deprecated_npu_options(options, *, in_place=False):
         normalized = options if in_place else dict(options)
         normalized.pop("compile_on_910_95", None)
+        if "bisheng_options" in normalized:
+            warnings.warn(
+                "Ascend compile option 'bisheng_options' is deprecated and ignored.",
+                FutureWarning,
+            )
+            normalized.pop("bisheng_options")
         return normalized
 
     utils_stub = types.ModuleType(utils_name)
@@ -198,6 +204,21 @@ def compiler_module():
 def _parse_options(compiler, arch, opts=None):
     backend = compiler.AscendBackend(SimpleNamespace(backend="npu", arch=arch))
     return backend.parse_options({} if opts is None else opts)
+
+
+def test_parse_options_ignores_removed_bisheng_options(compiler_module):
+    opts = {
+        "bisheng_options": "-mllvm --cce-enable-dynamic-micsched=true",
+        "debug": True,
+    }
+
+    with pytest.warns(FutureWarning, match=r"bisheng_options.*deprecated and ignored"):
+        options = _parse_options(compiler_module, "Ascend910B1", opts)
+
+    assert opts == {"debug": True}
+    assert options.debug is True
+    assert "bisheng_options" not in compiler_module.NPUOptions.__dataclass_fields__
+    assert "bisheng_options" not in options.__dict__
 
 
 @pytest.mark.skip(reason="The case is not supported on A5, skipping for now. Will be fixed in future.")
@@ -376,7 +397,7 @@ def _run_ttir_to_npubin(
 
     result = compiler.ttir_to_npubin(
         module,
-        {"bisheng_options": None},
+        {},
         _make_opt(
             is_pure_simt=is_pure_simt,
             superblock_factor=superblock_factor,


### PR DESCRIPTION
## Summary

- remove `bisheng_options` from `NPUOptions`, compiler metadata, and `--append-bisheng-options` vendor argv construction
- accept the legacy public keyword at the existing deprecated-option boundary, emit a deduplicated `FutureWarning`, and remove it in place before JIT keyword validation
- keep the existing Linalg-derived `bitcodes -> --link-aicore-bitcode` backend path unchanged

## Root cause

Removing the real option without reserving it in `_DEPRECATED_NPU_OPTIONS` lets `JITFunction._pack_args()` see the legacy keyword after backend option parsing and raise `KeyError`. This change makes the removed keyword warning-only while ensuring it is no longer serialized or forwarded to BishengIR.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py` (`12 passed, 28 skipped`)
- targeted pre-commit hooks on all four changed files, run twice (`check-ast`, YAPF, mypy, whitespace and safety hooks passed)
- `git diff --check`

No NPU runtime validation was required for this Python/JIT compatibility boundary.