### PR TITLE
[TritonToLinalg](feat) Stamp hacc.arg_type on launch-grid args

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/CMakeLists.txt
+++ b/third_party/ascend/lib/TritonToLinalg/CMakeLists.txt
@@ -28,6 +28,7 @@ add_triton_library(TritonToLinalg
   MLIRTensorDialect
   MLIRTransforms
   MLIRSupport
+  BiShengIRHACCDialect
   BiShengIRHIVMDialect
   TritonIR
   TritonTransforms

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -56,6 +56,7 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
+#include "bishengir/Dialect/HACC/IR/HACC.h"
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -245,6 +246,21 @@ void TritonToLinalgPass::addProgramInfo(triton::FuncOp func,
   // Append the arguments to the entry block.
   for (unsigned i = 0; i < TRITON_PROGRAM_INFO_ARG_COUNT; i++) {
     func.getBody().front().addArgument(b.getI32Type(), func.getLoc());
+  }
+
+  // Stamp the TA<->NPUIR launch-grid contract onto the new args:
+  // 1. program_num x/y/z
+  // 2. program_id x/y/z
+  static constexpr hacc::KernelArgType
+      kGridArgTypes[TRITON_PROGRAM_INFO_ARG_COUNT] = {
+          hacc::KernelArgType::kProgramNumX, hacc::KernelArgType::kProgramNumY,
+          hacc::KernelArgType::kProgramNumZ, hacc::KernelArgType::kProgramIdX,
+          hacc::KernelArgType::kProgramIdY, hacc::KernelArgType::kProgramIdZ};
+  const unsigned gridArgBase = origInputTypes.size();
+  for (unsigned i = 0; i < TRITON_PROGRAM_INFO_ARG_COUNT; i++) {
+    func.setArgAttr(gridArgBase + i, hacc::KernelArgTypeAttr::name,
+                    hacc::KernelArgTypeAttr::get(func.getContext(),
+                                                 kGridArgTypes[i]));
   }
 
   if (globalKernel) {
@@ -756,7 +772,8 @@ void TritonToLinalgPass::getDependentDialects(DialectRegistry &registry) const {
                   linalg::LinalgDialect, affine::AffineDialect, scf::SCFDialect,
                   tensor::TensorDialect, bufferization::BufferizationDialect,
                   memref::MemRefDialect, hfusion::HFusionDialect,
-                  hivm::HIVMDialect, annotation::AnnotationDialect>();
+                  hivm::HIVMDialect, hacc::HACCDialect,
+                  annotation::AnnotationDialect>();
 }
 
 LogicalResult

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/program_info_arg_attrs.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/program_info_arg_attrs.mlir
@@ -1,0 +1,16 @@
+// RUN: triton-opt --triton-to-linalg="named-ops=True" %s | FileCheck %s
+
+// The six launch-grid args appended by addProgramInfo carry the TA<->NPUIR
+// contract as hacc.arg_type annotations: program_num x/y/z, then
+// program_id x/y/z.
+// CHECK-LABEL: func.func @kernel_grid_arg_attrs(
+// CHECK-SAME: %{{.*}}: i32 {hacc.arg_type = #hacc.arg_type<program_num_x>}
+// CHECK-SAME: %{{.*}}: i32 {hacc.arg_type = #hacc.arg_type<program_num_y>}
+// CHECK-SAME: %{{.*}}: i32 {hacc.arg_type = #hacc.arg_type<program_num_z>}
+// CHECK-SAME: %{{.*}}: i32 {hacc.arg_type = #hacc.arg_type<program_id_x>}
+// CHECK-SAME: %{{.*}}: i32 {hacc.arg_type = #hacc.arg_type<program_id_y>}
+// CHECK-SAME: %{{.*}}: i32 {hacc.arg_type = #hacc.arg_type<program_id_z>}
+
+tt.func public @kernel_grid_arg_attrs(%arg0: !tt.ptr<f32>) attributes {noinline = false} {
+  tt.return
+}


### PR DESCRIPTION
`addProgramInfo` appends six `i32` grid args (three program_num `x/y/z`, then three program_id `x/y/z`) with no annotation; NPUIR decodes them by hardcoded position. Stamp each with `hacc.arg_type` (`program_num_*` / `program_id_*`) so the TA<->NPUIR contract is explicit in the IR.

Requires AscendNPU-IR with the new KernelArgType cases.