### PR TITLE
[compiler](fix) deprecate disable_auto_inject_block_sync

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -136,7 +136,6 @@ def _adjust_metadata_by_module_result(mod, metadata, opt, **kwargs):
         # these options should also reverted.
         metadata["enable_dynamic_cv_pipeline"] = False
         metadata["enable_mixed_cv"] = kwargs["enable_mixed_cv"]
-        metadata["disable_auto_inject_block_sync"] = kwargs["disable_auto_inject_block_sync"]
         metadata["set_workspace_multibuffer"] = kwargs["set_workspace_multibuffer"]
         if opt.debug:
             print(f"SSBUFFER return code={rc}, will fallback to enable_dynamic_cv_pipeline=False")
@@ -217,7 +216,6 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
         compile_mode = opt.compile_mode
         metadata["compile_mode"] = compile_mode
         enable_mixed_cv = metadata.get("enable_mixed_cv")
-        disable_auto_inject_block_sync = metadata.get("disable_auto_inject_block_sync")
         set_workspace_multibuffer = metadata.get("set_workspace_multibuffer")
 
         # Inject grid tile-count hint for ChunkCoalescing. When the kernel
@@ -258,7 +256,6 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
         if metadata["enable_dynamic_cv_pipeline"]:
             metadata["set_workspace_multibuffer"] = 0
             metadata["enable_mixed_cv"] = True
-            metadata["disable_auto_inject_block_sync"] = True
             ascend.passes.ttir.set_enable_cube_block_merge(metadata["enable_cube_block_merge"])
 
             # Must run before add_dynamic_cv_pipeline because the driven
@@ -299,7 +296,6 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
 
         pm.run(mod, 'ttir_to_linalg')
         _adjust_metadata_by_module_result(mod, metadata, opt, enable_mixed_cv=enable_mixed_cv,
-                                          disable_auto_inject_block_sync=disable_auto_inject_block_sync,
                                           set_workspace_multibuffer=set_workspace_multibuffer)
         _export_coalesce_metadata(mod, metadata)
 
@@ -691,11 +687,6 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
             _compile_option_list += \
                 [f"--hfusion-max-fused-elementwise-ops={prevec_max_fused_ops_num}"]
 
-        disable_auto_inject_block_sync = metadata["disable_auto_inject_block_sync"]
-        if disable_auto_inject_block_sync is not None:
-            _compile_option_list += \
-                [f"--disable-auto-inject-block-sync={disable_auto_inject_block_sync}"]
-
         bitcodes = metadata["bitcodes"]
         if bitcodes is not None:
             for bitcode in bitcodes:
@@ -895,11 +886,6 @@ def linalg_to_bin_enable_npu_compile_A2_A3(linalg: str, metadata, opt):
             _compile_option_list += \
                 [f"--limit-auto-multi-buffer-of-local-buffer={auto_multi_buffer}"]
 
-        disable_auto_inject_block_sync = metadata["disable_auto_inject_block_sync"]
-        if disable_auto_inject_block_sync is not None:
-            _compile_option_list += \
-                [f"--disable-auto-inject-block-sync={disable_auto_inject_block_sync}"]
-
         bitcodes = metadata["bitcodes"]
         if bitcodes is not None:
             for bitcode in bitcodes:
@@ -1065,7 +1051,6 @@ class NPUOptions:
     set_workspace_multibuffer: int = None
     tile_mix_vector_loop: int = None
     tile_mix_cube_loop: int = None
-    disable_auto_inject_block_sync: bool = None
     enable_mixed_cv: bool = None
     enable_dynamic_cv_pipeline: bool = None
     enable_cube_block_merge: bool = False

--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -46,6 +46,7 @@ _DEPRECATED_NPU_OPTIONS = frozenset({
     "auto_tile_and_bind_subblock",
     "code_motion",
     "compile_on_910_95",
+    "disable_auto_inject_block_sync",
     "disable_size_align_for_cast",
     "enable_auto_blockify",
     "enable_buffer_insert_optimization",
@@ -125,6 +126,7 @@ _DEPRECATED_NPU_OPTION_DETAILS = {
     "auto_tile_and_bind_subblock":
     "it is ignored; tiling and subblock binding are derived from Linalg IR and lock semantics.",
     "code_motion": "it is ignored; the removed vendor compiler control has no replacement.",
+    "disable_auto_inject_block_sync": "it is ignored; automatic block synchronization injection is managed by NPU IR.",
     "disable_size_align_for_cast": "it is ignored; the removed vendor compiler control has no replacement.",
     "enable_auto_blockify": "it is ignored; automatic block mapping and its safety blacklist are backend-managed.",
     "enable_buffer_insert_optimization":

--- a/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
+++ b/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
@@ -699,3 +699,4 @@ def test_default_compile_mode_keeps_the_91095_layout_memory_gate_prepared(compil
 
     assert "force_simt_only" not in compiler_module.NPUOptions.__dataclass_fields__
     assert "force_simt_template" not in compiler_module.NPUOptions.__dataclass_fields__
+    assert "disable_auto_inject_block_sync" not in compiler_module.NPUOptions.__dataclass_fields__


### PR DESCRIPTION
This PR deprecates the Ascend compile option `disable_auto_inject_block_sync` now that automatic block synchronization injection is managed by NPU IR. Existing callers can continue to pass the option without compilation errors, but the supplied value is ignored and a `FutureWarning` is emitted. The backend no longer stores this option in `NPUOptions`, modifies it during DynamicCV processing, restores it during fallback, or forwards `--disable-auto-inject-block-sync` to the A2/A3 and A5 compilation pipelines.