### PR TITLE
[compiler](revert) restore pre-0bd2 enable_vf_fusion state

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -673,6 +673,11 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
             _compile_option_list += \
                 [f"--enable-mixed-cv={enable_mixed_cv}"]
 
+        enable_vf_fusion = metadata["enable_vf_fusion"]
+        if enable_vf_fusion is not None:
+            _compile_option_list += \
+                [f"--enable-vf-fusion={enable_vf_fusion}"]
+
         enable_flatten = metadata["enable_flatten"]
         if enable_flatten is not None:
             _compile_option_list += \
@@ -1067,6 +1072,7 @@ class NPUOptions:
     tile_mix_cube_loop: int = None
     disable_auto_inject_block_sync: bool = None
     enable_mixed_cv: bool = None
+    enable_vf_fusion: bool = None
     enable_dynamic_cv_pipeline: bool = None
     enable_cube_block_merge: bool = False
     hfusion_enable_multiple_consumer_fusion: bool = False


### PR DESCRIPTION
## Summary

- Restore the enable_vf_fusion NPUOptions field from the state before 0bd2ad8ab35a5546f1bb2d93e83116b18db80a4e.
- Restore BishengIR compiler argument emission as --enable-vf-fusion=<value>.
- Change no other compile option.

## Scope note

The deprecated-option warning and cleanup remain unchanged because they were already present before 0bd2ad8a. This PR restores only the enable_vf_fusion backend field and compiler emission removed later.

## Validation

- git diff --check
- Repository pre-commit hooks on compiler.py, run twice
- Python AST and static enable_vf_fusion contract checks

NPU runtime validation is not included in this isolation PR.