### PR TITLE
[ssbuffer](feat) merge compute blocks in computeBlockOptPass

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -84,6 +84,7 @@ inline constexpr llvm::StringLiteral kTightlyCoupledBufferAttr =
 inline constexpr llvm::StringLiteral kCoreTypeCube = "CUBE";
 inline constexpr llvm::StringLiteral kCoreTypeVector = "VECTOR";
 inline constexpr llvm::StringLiteral kFromMakeRange = "tt.from_make_range";
+inline constexpr llvm::StringLiteral kSubBlock = "ssbuffer.subBlock";
 
 inline constexpr const char *ERRCODE_ATTR =
     "triton_ascend.dynamic_cv_pipeline.rc";

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
@@ -48,6 +48,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createBroadcastUBOptPass();
 std::unique_ptr<OperationPass<ModuleOp>> createMoveLoadIntoUserPass();
 std::unique_ptr<OperationPass<ModuleOp>> createPosMaskPatternPass();
 std::unique_ptr<OperationPass<ModuleOp>> createRelocateMemrefDeclPass();
+std::unique_ptr<OperationPass<ModuleOp>> createMergeComputeBlockPass();
 
 std::unique_ptr<OperationPass<ModuleOp>> createSplitIfByBlockIdPass();
 std::unique_ptr<OperationPass<ModuleOp>> createExpSubfPatternPass();

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
@@ -127,6 +127,7 @@ private:
 
   std::pair<mlir::Operation *, mlir::Operation *>
   getBlockStartEnd(int blockId, mlir::ModuleOp module);
+  mlir::Operation *getSubBlockEnd(mlir::Operation *defOp);
   bool
   isOuterLayerDependency(size_t depIndex, mlir::Operation *currProdEnd,
                          mlir::Operation *currConsStart,

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeComputeBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeComputeBlockPass.cpp
@@ -1,0 +1,563 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ComputeBlockOpt/SplitIfByBlockId/Common.h"
+#include "ascend/include/DynamicCVPipeline/Common/DependencyHelper.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Common.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+
+#include "DynamicCVPipeline/Common/Utils.h"
+
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+#include <optional>
+
+static constexpr const char *DEBUG_TYPE = "merge-compute-block";
+#define LOG_DEBUG(...)                                                         \
+  LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
+
+static constexpr llvm::StringLiteral kEnableMergeComputeBlockKernels[] = {
+    "flex_attention_backward_dkdv_kernel",
+    "flex_attention_backward_dkdv_kernel_tasklist", "_swa_bwd_dkdv_kernel",
+    "kernel_sdpa_bwd_kv"};
+
+using namespace mlir;
+using namespace triton;
+
+/// Represents a ComputeBlock: a group of ops sharing the same block_id
+struct ComputeBlock {
+  int id;                        // block_id value
+  CVPipeline::CoreType coreType; // CUBE_ONLY / VECTOR_ONLY
+  SmallVector<Operation *> ops;  // all ops in the group (in IR order)
+};
+
+static bool hasTensorResult(const ComputeBlock &blk) {
+  for (Operation *op : blk.ops) {
+    for (Value result : op->getResults()) {
+      if (isa<TensorType>(result.getType())) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/// Step 1: Group ops and build block-level dependency graph (enhanced).
+/// computeBlocks: output, block_id → ComputeBlock
+/// succs/preds: output, block_id → successor/predecessor block_id list
+/// blockEdges: output, srcId → dstId → source ops (cross-block SSA/memory
+/// dependency sources)
+static void groupAndBuildGraph(
+    Block *block, const CVPipeline::MemoryDependenceGraph &memGraph,
+    DenseMap<int, ComputeBlock> &computeBlocks,
+    DenseMap<int, SmallVector<int>> &succs,
+    DenseMap<int, SmallVector<int>> &preds,
+    DenseMap<int, DenseMap<int, SmallVector<Operation *>>> &blockEdges) {
+  // Walk all ops in the body block and its nested regions, group by
+  // block_id
+  block->walk([&](Operation *op) {
+    if (op->hasTrait<OpTrait::IsTerminator>()) {
+      return;
+    }
+    auto optId = CVPipeline::getOpBlockId(op);
+    if (!optId.has_value()) {
+      return;
+    }
+    int bid = *optId;
+    if (!computeBlocks.contains(bid)) {
+      // find new block_id, create new ComputeBlock
+      computeBlocks[bid] = {bid, CVPipeline::getOpCoreType(op), {}};
+    }
+    computeBlocks[bid].ops.push_back(op);
+  });
+
+  if (computeBlocks.empty()) {
+    return;
+  }
+
+  // Build dependency graph between ComputeBlocks via DependencyHelper,
+  // covering both SSA operands and memory execution dependencies.
+  CVPipeline::DependencyHelper helper(memGraph);
+  DenseSet<std::pair<int, int>> seenEdges;
+  DenseSet<std::tuple<int, int, Operation *>> seenDeps;
+  for (auto &kv : computeBlocks) {
+    int curId = kv.first;
+    for (Operation *op : kv.second.ops) {
+      helper.forEachSource(op, [&](Operation *src) {
+        Operation *ancestor = CVPipeline::getAncestorInBlock(src, block);
+        if (!ancestor) {
+          return WalkResult::advance(); // not in this block
+        }
+        auto ancIdOpt = CVPipeline::getOpBlockId(ancestor);
+        if (!ancIdOpt.has_value()) {
+          return WalkResult::advance();
+        }
+        int ancId = *ancIdOpt;
+        if (ancId == curId) {
+          return WalkResult::advance(); // same ComputeBlock internal edge
+        }
+
+        // Record the source op that triggers this cross-block edge
+        // (dedup: outer op and its nested subOps report the same source)
+        if (seenDeps.insert({ancId, curId, src}).second) {
+          blockEdges[ancId][curId].push_back(src);
+        }
+
+        if (!seenEdges.insert({ancId, curId}).second) {
+          return WalkResult::advance();
+        }
+        succs[ancId].push_back(curId);
+        preds[curId].push_back(ancId);
+        return WalkResult::advance();
+      });
+    }
+  }
+}
+
+/// Find the first CUBE predecessor of a given block.
+static std::optional<int>
+findCubePred(int blockId, const DenseMap<int, ComputeBlock> &computeBlocks,
+             const DenseMap<int, SmallVector<int>> &preds) {
+  auto it = preds.find(blockId);
+  if (it == preds.end()) {
+    return std::nullopt;
+  }
+  for (int p : it->second) {
+    if (computeBlocks.lookup(p).coreType == CVPipeline::CoreType::CUBE_ONLY) {
+      return p;
+    }
+  }
+  return std::nullopt;
+}
+
+/// Collect all transitive dependencies of \p startOp via SSA use-def chains,
+/// memory execution predecessors, and ops nested in regions. Results are
+/// accumulated into \p collected (including \p startOp itself).
+static void collectAllDeps(Operation *startOp,
+                           const CVPipeline::MemoryDependenceGraph &memGraph,
+                           SmallPtrSetImpl<Operation *> &collected) {
+  collected.insert(startOp);
+  CVPipeline::DependencyHelper helper(memGraph);
+  SmallVector<Operation *> worklist = {startOp};
+  while (!worklist.empty()) {
+    Operation *cur = worklist.pop_back_val();
+    helper.forEachSource(cur, [&](Operation *src) {
+      if (collected.insert(src).second)
+        worklist.push_back(src);
+      return WalkResult::advance();
+    });
+  }
+}
+
+/// Check if Cube depends on CubePre via bufferization::ToTensorOp defined in
+/// CubePre. \p edgeSrcOps are the dependency source ops on the CubePre → Cube
+/// edges. Returns the to_tensor ops in CubePre that Cube depends on.
+static SmallVector<Operation *>
+findToTensorDeps(const ComputeBlock *cubePre,
+                 ArrayRef<Operation *> edgeSrcOps) {
+  SmallVector<Operation *> result;
+  if (!cubePre) {
+    return result;
+  }
+  DenseSet<Operation *> cubePreOpsSet(cubePre->ops.begin(), cubePre->ops.end());
+
+  for (Operation *srcOp : edgeSrcOps) {
+    if (isa<bufferization::ToTensorOp>(srcOp) &&
+        cubePreOpsSet.contains(srcOp)) {
+      result.push_back(srcOp);
+    }
+  }
+  return result;
+}
+
+/// Clone ops from CubePre into Cube at the front of Cube's ops.
+/// Selected ops must be in CubePre and are in `toClone`.
+static void
+cloneOpCrossCubeDep(int cubePreId, int cubeId,
+                    const SmallPtrSet<Operation *, 16> &toClone,
+                    const DenseMap<int, ComputeBlock> &computeBlocks,
+                    CVPipeline::ComputeBlockIdManager &bm) {
+  const auto &cubePreBlock = computeBlocks.at(cubePreId);
+  const auto &cubeBlock = computeBlocks.at(cubeId);
+
+  if (cubeBlock.ops.empty()) {
+    return;
+  }
+
+  Operation *insertBefore = cubeBlock.ops.front();
+  OpBuilder builder(insertBefore);
+  IRMapping mapper;
+  for (Operation *op : cubePreBlock.ops) {
+    if (!toClone.contains(op)) {
+      continue;
+    }
+    Operation *cloned = builder.clone(*op, mapper);
+    cloned->walk(
+        [&](Operation *innerOp) { bm.updateBlockId(innerOp, cubeId); });
+  }
+
+  // Remap Cube's original ops' operands: replace references to old CubePre
+  // values with the corresponding cloned values now in Cube.
+  for (Operation *op : cubeBlock.ops) {
+    if (toClone.contains(op)) {
+      continue;
+    }
+    for (auto &operand : op->getOpOperands()) {
+      if (Value mapped = mapper.lookupOrNull(operand.get())) {
+        operand.set(mapped);
+      }
+    }
+  }
+}
+
+/// Step 2: Collect VECTOR_ONLY candidates that have tensor results
+/// and have at least one edge (incoming or outgoing) to a CUBE block.
+static SmallVector<int>
+collectVectorCandidates(const DenseMap<int, ComputeBlock> &computeBlocks,
+                        const DenseMap<int, SmallVector<int>> &succs,
+                        const DenseMap<int, SmallVector<int>> &preds) {
+  auto hasCubeNeighbor = [&](const DenseMap<int, SmallVector<int>> &neighbors,
+                             int blockId) {
+    auto it = neighbors.find(blockId);
+    return it != neighbors.end() && llvm::any_of(it->second, [&](int id) {
+             return computeBlocks.lookup(id).coreType ==
+                    CVPipeline::CoreType::CUBE_ONLY;
+           });
+  };
+
+  SmallVector<int> vecCandidates;
+  for (auto &kv : computeBlocks) {
+    if (kv.second.coreType != CVPipeline::CoreType::VECTOR_ONLY)
+      continue;
+    if (!hasTensorResult(kv.second))
+      continue;
+
+    // Must have a successor or predecessor that is CUBE
+    bool hasCubeEdge =
+        hasCubeNeighbor(succs, kv.first) || hasCubeNeighbor(preds, kv.first);
+    if (!hasCubeEdge)
+      continue;
+
+    if (!llvm::is_contained(vecCandidates, kv.first))
+      vecCandidates.push_back(kv.first);
+  }
+  return vecCandidates;
+}
+
+/// Step 3: Find a pair of adjacent VECTOR blocks (predV → succV).
+/// Returns {predVId, succVId} if a pair is found, otherwise nullopt.
+static std::optional<std::pair<int, int>>
+findAdjacentVectorPair(ArrayRef<int> vecCandidates,
+                       const DenseMap<int, SmallVector<int>> &succs) {
+  for (int candId : vecCandidates) {
+    auto it = succs.find(candId);
+    if (it == succs.end())
+      continue;
+    for (int succId : it->second) {
+      if (llvm::is_contained(vecCandidates, succId)) {
+        return std::make_pair(candId, succId);
+      }
+    }
+  }
+  return std::nullopt;
+}
+
+static void markSubBlock(const DenseMap<int, ComputeBlock> &computeBlocks,
+                         int predVId, int succVId) {
+  for (int id : {predVId, succVId}) {
+    auto it = computeBlocks.find(id);
+    if (it == computeBlocks.end())
+      continue;
+    for (Operation *op : it->second.ops) {
+      int curId = CVPipeline::getOpBlockId(op).value_or(id);
+      op->setAttr(
+          CVPipeline::kSubBlock,
+          IntegerAttr::get(IntegerType::get(op->getContext(), 32), curId));
+    }
+  }
+}
+
+/// Step 4: Try to directly merge succV into predV.
+/// Returns true if merge succeeded.
+static bool tryDirectMerge(ArrayRef<Operation *> opsToMerge,
+                           const CVPipeline::MemoryDependenceGraph &memGraph,
+                           int predVId, int succVId,
+                           const DenseMap<int, ComputeBlock> &computeBlocks,
+                           CVPipeline::ComputeBlockIdManager &bm) {
+  if (willCreateCycle(opsToMerge, memGraph, predVId, bm))
+    return false;
+  LOG_DEBUG("Successfully direct merge: " << succVId << " -> " << predVId);
+
+  markSubBlock(computeBlocks, predVId, succVId);
+  for (Operation *op : opsToMerge)
+    bm.updateBlockId(op, predVId);
+  return true;
+}
+
+/// Step 5e: Collect ops in CubePre that need to be cloned to Cube to break
+/// the cycle. Returns the set of ops to clone (empty if none).
+static SmallPtrSet<Operation *, 16>
+collectOpsToBreakCycle(int cubePreId,
+                       const DenseMap<int, ComputeBlock> &computeBlocks,
+                       const SmallPtrSet<Operation *, 16> &allPredecessors) {
+  auto cbIt = computeBlocks.find(cubePreId);
+
+  SmallPtrSet<Operation *, 16> opsToClone;
+  for (Operation *op : allPredecessors) {
+    if (llvm::is_contained(cbIt->second.ops, op))
+      opsToClone.insert(op);
+  }
+  return opsToClone;
+}
+
+/// Step 5: Try cross-Cube clone to break the cycle, then merge.
+/// Returns true if merge succeeded after clone.
+static bool tryCrossCubeCloneMerge(
+    Block *block, const DenseMap<int, ComputeBlock> &computeBlocks,
+    const DenseMap<int, SmallVector<int>> &preds,
+    const DenseMap<int, DenseMap<int, SmallVector<Operation *>>> &blockEdges,
+    int predVId, int succVId, ArrayRef<Operation *> opsToMerge,
+    const CVPipeline::MemoryDependenceGraph &memGraph,
+    CVPipeline::ComputeBlockIdManager &bm) {
+  // 5a. Find succV's CUBE predecessor (Cube)
+  std::optional<int> cubeId = findCubePred(succVId, computeBlocks, preds);
+  if (!cubeId) {
+    LOG_DEBUG("MergeComputeBlock: succV "
+              << succVId
+              << " has no CUBE predecessor, skipping cross-Cube clone");
+    return false;
+  }
+
+  // 5b. Find Cube's CUBE predecessor (CubePre)
+  std::optional<int> cubePreId = findCubePred(*cubeId, computeBlocks, preds);
+  if (!cubePreId) {
+    LOG_DEBUG("MergeComputeBlock: Cube "
+              << *cubeId
+              << " has no CUBE predecessor, skipping cross-Cube clone");
+    return false;
+  }
+
+  // 5c. Check if Cube depends on CubePre via to_tensor
+  SmallVector<Operation *> toTensorOps;
+  auto edgeIt = blockEdges.find(*cubePreId);
+  if (edgeIt != blockEdges.end()) {
+    auto dstIt = edgeIt->second.find(*cubeId);
+    if (dstIt != edgeIt->second.end()) {
+      toTensorOps =
+          findToTensorDeps(&computeBlocks.at(*cubePreId), dstIt->second);
+    }
+  }
+  if (toTensorOps.empty()) {
+    LOG_DEBUG("MergeComputeBlock: Cube("
+              << *cubeId << ") depends on CubePre(" << *cubePreId
+              << ") but not via to_tensor, skipping");
+    return false;
+  }
+
+  // 5d. Trace back all transitive dependencies
+  SmallPtrSet<Operation *, 16> allPredecessors;
+  for (Operation *toTensor : toTensorOps) {
+    collectAllDeps(toTensor, memGraph, allPredecessors);
+  }
+
+  // 5e. Filter to ops in CubePre and clone to Cube
+  SmallPtrSet<Operation *, 16> opsToClone =
+      collectOpsToBreakCycle(*cubePreId, computeBlocks, allPredecessors);
+
+  for (auto op : opsToClone)
+    LOG_DEBUG("Cloning op: " << *op);
+  cloneOpCrossCubeDep(*cubePreId, *cubeId, opsToClone, computeBlocks, bm);
+
+  // 5f. Re-check cycle after cloning
+  if (willCreateCycle(opsToMerge, memGraph, predVId, bm)) {
+    LOG_DEBUG("MergeComputeBlock: still creates cycle after cross-Cube clone "
+              "for VECTOR "
+              << predVId << " -> " << succVId);
+    return false;
+  }
+
+  LOG_DEBUG("MergeComputeBlock: Successfully merge after cross-Cube clone: "
+            << succVId << " -> " << predVId);
+  markSubBlock(computeBlocks, predVId, succVId);
+  for (Operation *op : opsToMerge)
+    bm.updateBlockId(op, predVId);
+  return true;
+}
+
+/// Core merge logic for one scf::ForOp body Block.
+static void tryMergeInBlock(Block *block, CVPipeline::ComputeBlockIdManager &bm,
+                            const CVPipeline::MemoryDependenceGraph &memGraph) {
+  while (true) {
+    // Step 1: Group and build enhanced dependency graph
+    /// computeBlocks: block_id → ComputeBlock
+    DenseMap<int, ComputeBlock> computeBlocks;
+    /// succs/preds: block_id → successor/predecessor block‘s blockid list
+    DenseMap<int, SmallVector<int>> succs;
+    DenseMap<int, SmallVector<int>> preds;
+    /// blockEdges: srcId → dstId → source ops (cross-block SSA/memory deps)
+    DenseMap<int, DenseMap<int, SmallVector<Operation *>>> blockEdges;
+    groupAndBuildGraph(block, memGraph, computeBlocks, succs, preds,
+                       blockEdges);
+    if (computeBlocks.empty())
+      return;
+
+    // Step 2: Collect VECTOR candidates
+    SmallVector<int> vecCandidates =
+        collectVectorCandidates(computeBlocks, succs, preds);
+    if (vecCandidates.size() < 2) {
+      LOG_DEBUG("MergeComputeBlock: vecCandidates.size() < 2, skipping");
+      return;
+    }
+
+    // Step 3: Find a pair of adjacent VECTOR blocks
+    auto pairOpt = findAdjacentVectorPair(vecCandidates, succs);
+    if (!pairOpt) {
+      LOG_DEBUG("MergeComputeBlock: No adjacent VECTOR pair found, skipping");
+      return;
+    }
+    int predVId = pairOpt->first;
+    int succVId = pairOpt->second;
+
+    LOG_DEBUG("Found VECTOR pair: predV=" << predVId << ", succV=" << succVId);
+
+    SmallVector<Operation *> opsToMerge = computeBlocks.at(succVId).ops;
+
+    // Step 4: Try direct merge
+    if (tryDirectMerge(opsToMerge, memGraph, predVId, succVId, computeBlocks,
+                       bm))
+      continue;
+
+    // Step 5: Try cross-Cube clone merge
+    if (!tryCrossCubeCloneMerge(block, computeBlocks, preds, blockEdges,
+                                predVId, succVId, opsToMerge, memGraph, bm))
+      return;
+    // continue to try next pair
+  }
+}
+
+namespace {
+
+class MergeComputeBlockPass
+    : public PassWrapper<MergeComputeBlockPass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MergeComputeBlockPass)
+
+  MergeComputeBlockPass() = default;
+
+  StringRef getArgument() const override { return "merge-compute-block"; }
+
+  StringRef getDescription() const override {
+    return "Merge adjacent vector compute blocks between/around CUBE blocks";
+  }
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+
+    if (CVPipeline::hasFallbackAttr(module)) {
+      return;
+    }
+
+    bool shouldRun = false;
+    for (auto funcOp : module.getOps<func::FuncOp>()) {
+      if (llvm::is_contained(kEnableMergeComputeBlockKernels,
+                             funcOp.getSymName())) {
+        LOG_DEBUG(
+            "Enable MergeComputeBlock for kernel: " << funcOp.getSymName());
+        shouldRun = true;
+        break;
+      }
+    }
+    if (!shouldRun) {
+      return;
+    }
+
+    auto intraBufCount =
+        module->getAttrOfType<IntegerAttr>(CVPipeline::kIntraBufCount);
+    auto interCoreBufCount =
+        module->getAttrOfType<IntegerAttr>(CVPipeline::kInterCoreBufCount);
+    if (!intraBufCount || !interCoreBufCount || intraBufCount.getInt() < 3 ||
+        interCoreBufCount.getInt() < 2) {
+      LOG_DEBUG("MergeComputeBlock disabled: intraBufCount < 3 or "
+                "interCoreBufCount < 2");
+      return;
+    }
+
+    LOG_DEBUG("Before MergeComputeBlockPass: " << *module);
+
+    SmallVector<Block *> blocksToProcess;
+    llvm::LogicalResult walkResult =
+        CVPipeline::SplitIf::walkMainLoop(module, [&](Operation *loop) {
+          blocksToProcess.push_back(&loop->getRegion(0).front());
+          return success();
+        });
+    if (failed(walkResult)) {
+      return;
+    }
+
+    auto &aa = getAnalysis<AliasAnalysis>();
+    CVPipeline::MemoryDependenceGraph memGraph(module, aa);
+    CVPipeline::ComputeBlockIdManager bm(module);
+    for (Block *block : blocksToProcess) {
+      LOG_DEBUG("try merge in LoopBlock");
+      tryMergeInBlock(block, bm, memGraph);
+    }
+
+    LOG_DEBUG("After MergeComputeBlockPass: " << *module);
+  }
+};
+
+} // namespace
+
+// ============================================================================
+// Pass Registration
+// ============================================================================
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<OperationPass<ModuleOp>> createMergeComputeBlockPass() {
+  return std::make_unique<MergeComputeBlockPass>();
+}
+
+void registerMergeComputeBlockPass() {
+  PassRegistration<MergeComputeBlockPass> reg;
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
@@ -77,6 +77,7 @@ void ComputeBlockOptPass::runOnOperation() {
   pm.addPass(createMergeSmallBlockPass());
   pm.addPass(createReorderOpsByBlockIdPass());
 
+  pm.addPass(createMergeComputeBlockPass());
   pm.addPass(createMergeCubeBlockPass());
   pm.addPass(createReorderOpsByBlockIdPass());
 
@@ -115,6 +116,7 @@ void registerComputeBlockOptPasses() {
   registerPass(createPosMaskPatternPass);
   registerPass(createMergeSmallBlockPass);
   registerPass(createSplitIfByBlockIdPass);
+  registerPass(createMergeComputeBlockPass);
   registerPass(createMergeCubeBlockPass);
   registerPass(createRelocateMemrefDeclPass);
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
@@ -53,7 +53,8 @@ static constexpr llvm::StringLiteral kAttrsToRemove[]{
     kMemCrossDeps,      kClone,
     kIntraBufCount,     kInterCoreBufCount,
     kLoadStoreBufCount, kInsertionOptimization,
-    kDepMark,           kIntraDeps};
+    kDepMark,           kIntraDeps,
+    kSubBlock};
 
 void RemoveSsbufAttrPass::runOnOperation() {
   auto module = getOperation();

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -133,6 +133,25 @@ static void attachAnalyzeFlagIdTag(Operation *op) {
   op->setAttr(CVPipeline::kAnalyzeFlagId, UnitAttr::get(ctx));
 }
 
+/// Get the sub-block id of \p op, or std::nullopt if \p op is null or does
+/// not carry the sub-block tag.
+static std::optional<int> getSubBlockId(Operation *op) {
+  if (!op) {
+    return std::nullopt;
+  }
+  auto attr = op->getAttrOfType<IntegerAttr>(CVPipeline::kSubBlock);
+  if (!attr)
+    return std::nullopt;
+  return attr.getInt();
+}
+
+/// Set the sub-block tag of \p op to \p subBlockId.
+static void setSubBlockId(Operation *op, int subBlockId) {
+  MLIRContext *ctx = op->getContext();
+  op->setAttr(CVPipeline::kSubBlock,
+              IntegerAttr::get(IntegerType::get(ctx, 32), subBlockId));
+}
+
 static bool isChannelSplitNeeded(RankedTensorType tensorType) {
   static constexpr int32_t alignM = 16;
   return mlir::utils::getNumPerBlock(tensorType) == alignM / 2;
@@ -228,6 +247,33 @@ InterCoreTransferAndSyncPass::getBlockStartEnd(int targetId,
     }
   }
   return {start, end};
+}
+
+mlir::Operation *
+InterCoreTransferAndSyncPass::getSubBlockEnd(mlir::Operation *defOp) {
+  if (!defOp) {
+    return nullptr;
+  }
+  auto subBlockId = getSubBlockId(defOp);
+  if (!subBlockId) {
+    return nullptr;
+  }
+  if (!defOp->getBlock()) {
+    return nullptr;
+  }
+  mlir::Operation *subBlockEnd = nullptr;
+  for (Operation &op : *defOp->getBlock()) {
+    auto opSubBlockId = getSubBlockId(&op);
+    if (!opSubBlockId) {
+      continue;
+    }
+    if (*opSubBlockId == *subBlockId) {
+      subBlockEnd = &op;
+    } else if (subBlockEnd) {
+      break;
+    }
+  }
+  return subBlockEnd;
 }
 
 bool InterCoreTransferAndSyncPass::isOuterLayerDependency(
@@ -463,6 +509,11 @@ void InterCoreTransferAndSyncPass::Nd2NzNormalize(OpBuilder &builder,
         getCopyPointBeforeStore(newValue, newProdEnd, dep.iniProducerBlockId);
     if (producerPoint) {
       newProdEnd = producerPoint;
+    }
+    if (Operation *origDefOp = origValue.getDefiningOp()) {
+      if (getSubBlockId(origDefOp)) {
+        newProdEnd = origDefOp;
+      }
     }
   }
   builder.setInsertionPointAfter(newProdEnd);
@@ -705,6 +756,12 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(
                        transferIndex);
     attachCrossCoreDeps(copyOp, transferIndex, CVPipeline::crossCoreProducerId,
                         builder);
+    // Propagate the sub-block tag from the src defining op to the copy op.
+    if (Operation *srcDefOp = srcValue.getDefiningOp()) {
+      if (auto subBlockId = getSubBlockId(srcDefOp)) {
+        setSubBlockId(copyOp, *subBlockId);
+      }
+    }
     LOG_DEBUG("[copyOp]: " << *copyOp << "\n");
 
     builder.setInsertionPoint(cubeStartOp);
@@ -969,6 +1026,11 @@ void InterCoreTransferAndSyncPass::insertInterCoreSync(
       loc, config.srcCoreAttr, config.forReadTPipe, config.forReadPipe, flagId);
   attachTransferTags(setOpForRead, producerBlockId, config.srcCoreType,
                      transferIndex);
+  // Propagate the sub-block tag from transferOp to the sync ops.
+  if (auto subBlockId = getSubBlockId(transferOp)) {
+    setSubBlockId(setOpForRead, *subBlockId);
+  }
+
   builder.setInsertionPoint(consumerStartOp);
   auto waitOpForRead = builder.create<SyncBlockWaitOp>(
       loc, config.dstCoreAttr, config.forReadTPipe, config.forReadPipe, flagId);
@@ -1004,6 +1066,10 @@ void InterCoreTransferAndSyncPass::insertInterCoreSync(
                        transferIndex);
     attachTransferTags(waitOpForEnd, startEndBlockId, config.srcCoreType,
                        transferIndex);
+
+    if (auto subBlockId = getSubBlockId(transferOp)) {
+      setSubBlockId(waitOpForWrite, *subBlockId);
+    }
 
     attachAnalyzeFlagIdTag(setOpForRead);
     attachAnalyzeFlagIdTag(waitOpForRead);
@@ -1462,6 +1528,11 @@ LogicalResult InterCoreTransferAndSyncPass::handleVectorToCube(
     if (producerPoint) {
       prodEnd = producerPoint;
     }
+    if (Operation *srcDefOp = srcValue.getDefiningOp()) {
+      if (getSubBlockId(srcDefOp)) {
+        prodEnd = normalizedVal.getDefiningOp();
+      }
+    }
   }
   LOG_DEBUG("after analyzeConsumerReadInsertPoint\n");
   Operation *transferOp = insertVectorToCubeTransfer(
@@ -1513,6 +1584,18 @@ LogicalResult InterCoreTransferAndSyncPass::handleCubeToVector(
       prodEnd = producerPoint;
     }
   }
+
+  // uses of srcValue. Only applied when the source op belongs to a
+  // sub-block.
+  Operation *consumerPoint = nullptr;
+  if (dep.consumerBlockId == dep.iniConsumerBlockId) {
+    consumerPoint =
+        analyzeConsumerReadInsertPoint(srcValue, dep.iniConsumerBlockId);
+    if (consumerPoint && getSubBlockId(consumerPoint)) {
+      consStart = consumerPoint;
+    }
+  }
+
   Operation *consumedDataOp = nullptr;
   Operation *transferOp =
       insertCubeToVectorTransfer(builder, srcValue, prodEnd, consStart, loc,
@@ -1522,10 +1605,21 @@ LogicalResult InterCoreTransferAndSyncPass::handleCubeToVector(
       getBlockStartEnd(dep.producerBlockId, module); // C Block
   auto [newConsStart, newConsEnd] =
       getBlockStartEnd(dep.consumerBlockId, module); // V Block
+  if (Operation *subBlockEnd = getSubBlockEnd(consumerPoint)) {
+    newConsEnd = subBlockEnd;
+  }
   int flagId = flagManager.acquireId();
 
   bool isStoreDirectly =
       isStoreDirectlyInUserChain(consumedDataOp->getResult(0));
+
+  if (dep.consumerBlockId == dep.iniConsumerBlockId) {
+    auto newconsumerPoint = getConsumerWaitPoint(transferIndex);
+    if (newconsumerPoint && getSubBlockId(consumerPoint)) {
+      newConsStart = newconsumerPoint;
+    }
+  }
+
   insertInterCoreSync(builder, transferOp, newConsStart, newConsEnd, flagId,
                       loc, transferIndex, flagIdReuseManager, consumedDataOp,
                       isStoreDirectly);

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_compute_block.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_compute_block.mlir
@@ -1,0 +1,140 @@
+// RUN: triton-opt --allow-unregistered-dialect --merge-compute-block %s | FileCheck %s
+
+// Test merge-compute-block pass: merges adjacent VECTOR blocks between CUBE blocks,
+// cloning CUBE ops that downstream blocks depend on.
+//
+// Pattern: C1(6,CUBE) → V1(32,VECTOR) → C2(8,CUBE) → V2(33,VECTOR) → C3(10,CUBE) → C4(12,CUBE)
+// After pass:
+//   - V2(33) merged into V1(32): all block_id 33 → 32
+//   - C3(10) gets cloned alloc/copy/to_tensor chain from C2(8)
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">, ssbuffer.intra_buf_count = 3 : i32, ssbuffer.inter_core_buf_count = 2 : i32} {
+  func.func @_swa_bwd_dkdv_kernel(
+    %arg0: memref<?xbf16> {tt.tensor_kind = 0 : i32},
+    %arg1: memref<?xbf16> {tt.tensor_kind = 0 : i32},
+    %arg2: i32 {tt.divisibility = 16 : i32}
+  ) attributes {global_kernel = "local", mix_mode = "mix", parallel_mode = "simd"} {
+    %cst_bf16 = arith.constant 0.000000e+00 : bf16
+    %cst_f32 = arith.constant 0.000000e+00 : f32
+    %cst_scale = arith.constant 0.0883883461 : f32
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %c64_i32 = arith.constant 64 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+
+    %empty_2d_bf16 = tensor.empty() : tensor<64x64xbf16>
+
+    // VECTOR block constants
+    %cst_v = arith.constant {ssbuffer.block_id = 49 : i32, ssbuffer.core_type = "VECTOR"} 0.000000e+00 : f32
+    %empty_v = tensor.empty() {ssbuffer.block_id = 49 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+    %scale = linalg.fill {ssbuffer.block_id = 49 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_scale : f32) outs(%empty_v : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+    // CUBE block constants
+    %cst_bf16_cube = arith.constant {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : bf16
+    %cst_f32_cube = arith.constant {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "CUBE"} 0.000000e+00 : f32
+    %empty_cube_f32 = tensor.empty() {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "CUBE"} : tensor<64x64xf32>
+    %cube_init = linalg.fill {ssbuffer.block_id = 28 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_f32_cube : f32) outs(%empty_cube_f32 : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+    scf.for %iv = %c0_i32 to %c64_i32 step %c1_i32  : i32 {
+      // Shared index computations used by C1 and C4
+      %iv_idx = arith.index_cast %iv {ssbuffer.block_id = 26 : i32, ssbuffer.core_type = "CUBE"} : i32 to index
+      %offset64 = arith.muli %iv_idx, %c64 {ssbuffer.block_id = 26 : i32, ssbuffer.core_type = "CUBE"} : index
+      %stride_idx = arith.index_cast %arg2 {ssbuffer.block_id = 26 : i32, ssbuffer.core_type = "CUBE"} : i32 to index
+      %cond_c2 = arith.cmpi slt, %iv_idx, %c64 {ssbuffer.block_id = 26 : i32, ssbuffer.core_type = "CUBE"} : index
+
+      // ==========================================
+      // C1: Block 6 (CUBE) — produces %tensor_c1 used by V1(32) and C4(12)
+      // ==========================================
+      // CHECK: memref.alloc() {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"}
+      %alloc_c1 = memref.alloc() {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16>
+      %cond_c1 = arith.cmpi slt, %iv_idx, %c64 {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : index
+      scf.if %cond_c1 {
+        linalg.fill {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_bf16 : bf16) outs(%alloc_c1 : memref<64x64xbf16>)
+      } {hivm.unlikely_condition, ssbuffer.block_id = 6 : i32}
+      %reint_c1 = memref.reinterpret_cast %arg0 to offset: [%offset64], sizes: [64, 64], strides: [%stride_idx, 1] {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<?xbf16> to memref<64x64xbf16, strided<[?, 1], offset: ?>>
+      %subv_c1_src = memref.subview %reint_c1[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16, strided<[?, 1], offset: ?>> to memref<64x64xbf16, strided<[?, 1], offset: ?>>
+      %subv_c1_dst = memref.subview %alloc_c1[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16> to memref<64x64xbf16, strided<[64, 1]>>
+      memref.copy %subv_c1_src, %subv_c1_dst {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16, strided<[?, 1], offset: ?>> to memref<64x64xbf16, strided<[64, 1]>>
+      %tensor_c1 = bufferization.to_tensor %alloc_c1 restrict writable {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16> to tensor<64x64xbf16>
+      %matmul_c1 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE", ssbuffer.loop_carried_l0c} ins(%tensor_c1, %tensor_c1 : tensor<64x64xbf16>, tensor<64x64xbf16>) outs(%cube_init : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+      // ==========================================
+      // V1: Block 32 (VECTOR) — CUBE pred=6, CUBE succ=8, edge 32→33 via %v1_exp
+      // ==========================================
+      // CHECK: arith.mulf {{%.*}}, {{%.*}} {ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.subBlock = 32 : i32}
+      %v1_mul = arith.mulf %matmul_c1, %scale {ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+      // CHECK: math.exp {{%.*}} {ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.subBlock = 32 : i32}
+      %v1_exp = math.exp %v1_mul {ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+      // CHECK: arith.truncf {{%.*}} {ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.subBlock = 32 : i32}
+      %v1_trunc = arith.truncf %v1_exp {ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xbf16>
+
+      // ==========================================
+      // C2: Block 8 (CUBE) — has copy chain with dedicated arith ops that C3(10) depends on
+      // ==========================================
+      // CHECK: memref.alloc() {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"}
+      %alloc_c2 = memref.alloc() {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16>
+      scf.if %cond_c2 {
+        linalg.fill {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} ins(%cst_bf16 : bf16) outs(%alloc_c2 : memref<64x64xbf16>)
+      } {hivm.unlikely_condition, ssbuffer.block_id = 8 : i32}
+      // Dedicated arith ops in C2 for the reinterpret_cast offset computation
+      %c2_stride = arith.index_cast %arg2 {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : i32 to index
+      %c2_mul = arith.muli %iv_idx, %c2_stride {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : index
+      %c2_offset = arith.addi %offset64, %c2_mul {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : index
+      %reint_c2 = memref.reinterpret_cast %arg1 to offset: [%c2_offset], sizes: [64, 64], strides: [%c2_stride, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : memref<?xbf16> to memref<64x64xbf16, strided<[?, 1], offset: ?>>
+      %subv_c2_src = memref.subview %reint_c2[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16, strided<[?, 1], offset: ?>> to memref<64x64xbf16, strided<[?, 1], offset: ?>>
+      %subv_c2_dst = memref.subview %alloc_c2[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16> to memref<64x64xbf16, strided<[64, 1]>>
+      // CHECK: memref.copy {{%.*}}, {{%.*}} {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"}
+      memref.copy %subv_c2_src, %subv_c2_dst {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16, strided<[?, 1], offset: ?>> to memref<64x64xbf16, strided<[64, 1]>>
+      // CHECK: bufferization.to_tensor {{%.*}} {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"}
+      %tensor_c2 = bufferization.to_tensor %alloc_c2 restrict writable {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"} : memref<64x64xbf16> to tensor<64x64xbf16>
+      %transposed_v1 = linalg.transpose ins(%v1_trunc : tensor<64x64xbf16>) outs(%empty_2d_bf16 : tensor<64x64xbf16>) permutation = [1, 0]  {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE"}
+      %matmul_c2 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "CUBE", ssbuffer.loop_carried_l0c} ins(%transposed_v1, %tensor_c2 : tensor<64x64xbf16>, tensor<64x64xbf16>) outs(%cube_init : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+      // ==========================================
+      // C3: Block 10 (CUBE) — uses %tensor_c2 from C2, triggers clone from C2
+      // After pass: cloned alloc/index_cast/muli/addi/reinterpret_cast/subview×2/copy/to_tensor from C2
+      // ==========================================
+      // CHECK: memref.alloc() {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: scf.if {{%.*}} {
+      // CHECK:   linalg.fill {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: } {hivm.unlikely_condition, ssbuffer.block_id = 10 : i32}
+      // CHECK: arith.index_cast {{%.*}} {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: arith.muli {{%.*}}, {{%.*}} {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: arith.addi {{%.*}}, {{%.*}} {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: memref.reinterpret_cast {{%.*}} to offset: [{{%.*}}], sizes: [64, 64], strides: [{{%.*}}, 1] {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: memref.subview {{%.*}}[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: memref.subview {{%.*}}[0, 0] [64, 64] [1, 1] {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: memref.copy {{%.*}}, {{%.*}} {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: bufferization.to_tensor {{%.*}} {ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: linalg.matmul {{.*}}ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE"
+      %matmul_c3 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 10 : i32, ssbuffer.core_type = "CUBE", ssbuffer.loop_carried_l0c} ins(%tensor_c2, %tensor_c2 : tensor<64x64xbf16>, tensor<64x64xbf16>) outs(%cube_init : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+      // ==========================================
+      // V2: Block 33 (VECTOR) — uses %v1_exp (edge 32→33), %matmul_c3 (edge 10→33)
+      // After pass: merged into V1(32), all block_id 33 → 32
+      // ==========================================
+      // CHECK: arith.subf {{%.*}}, {{%.*}} {{{.*}}ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.subBlock = 33 : i32}
+      %v2_sub = arith.subf %matmul_c3, %v1_exp {ssbuffer.block_id = 33 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+      // CHECK: arith.mulf {{%.*}}, {{%.*}} {{{.*}}ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.subBlock = 33 : i32}
+      %v2_mul = arith.mulf %v1_exp, %v2_sub {ssbuffer.block_id = 33 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+      // CHECK: arith.mulf {{%.*}}, {{%.*}} {{{.*}}ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.subBlock = 33 : i32}
+      %v2_mul2 = arith.mulf %v2_mul, %scale {ssbuffer.block_id = 33 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32>
+      // CHECK: arith.truncf {{%.*}} {{{.*}}ssbuffer.block_id = 32 : i32, ssbuffer.core_type = "VECTOR", ssbuffer.subBlock = 33 : i32}
+      %v2_trunc = arith.truncf %v2_mul2 {ssbuffer.block_id = 33 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64x64xf32> to tensor<64x64xbf16>
+
+      // ==========================================
+      // C4: Block 12 (CUBE) — uses %v2_trunc (edge 33→12) and %tensor_c1 (edge 6→12)
+      // ==========================================
+      %transposed_v2 = linalg.transpose ins(%v2_trunc : tensor<64x64xbf16>) outs(%empty_2d_bf16 : tensor<64x64xbf16>) permutation = [1, 0]  {ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "CUBE"}
+      // CHECK: linalg.matmul {{.*}}ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "CUBE"
+      %matmul_c4 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 12 : i32, ssbuffer.core_type = "CUBE", ssbuffer.loop_carried_l0c} ins(%transposed_v2, %tensor_c1 : tensor<64x64xbf16>, tensor<64x64xbf16>) outs(%cube_init : tensor<64x64xf32>) -> tensor<64x64xf32>
+
+      // Store output to prevent DCE
+      %reint_out = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [64, 64], strides: [%stride_idx, 1] {ssbuffer.block_id = 14 : i32, ssbuffer.core_type = "CUBE"} : memref<?xbf16> to memref<64x64xbf16, strided<[?, 1], offset: ?>>
+      %trunc_c4 = arith.truncf %matmul_c4 {ssbuffer.block_id = 14 : i32, ssbuffer.core_type = "CUBE"} : tensor<64x64xf32> to tensor<64x64xbf16>
+      bufferization.materialize_in_destination %trunc_c4 in writable %reint_out {ssbuffer.block_id = 14 : i32, ssbuffer.core_type = "CUBE"} : (tensor<64x64xbf16>, memref<64x64xbf16, strided<[?, 1], offset: ?>>) -> ()
+    }
+    return
+  }
+}


### PR DESCRIPTION
### 背景

在 DynamicCVPipeline 中，算子按 `block_id` 分组为 ComputeBlock，分为 `CUBE_ONLY`和 `VECTOR_ONLY`两类。CUBE 块之间的 VECTOR 块数量过多会增加 UB 开销。相邻 VECTOR 块之间不存在数据依赖冲突时，可以合并以减少块数量。



### 代码流程

1. **定位处理范围**：遍历 `ModuleOp`，找到包含 `linalg::MatmulOp` 的最内层 `scf::ForOp` 的 body block。

2. **构建依赖图** (`groupAndBuildGraph`)：按 `block_id` 将算子分组，建立块间 SSA 依赖图（successors / predecessors / blockEdges）。

3. **收集候选** (`collectVectorCandidates`)：筛选出有 tensor 类型结果的 `VECTOR_ONLY` 块。

4. **寻找相邻对** (`findAdjacentVectorPair`)：在候选集中找到相邻的 VECTOR 块对 (predV → succV)。

5. **直接合并** (`tryDirectMerge`)：若无环依赖，直接将 succV 的算子 `block_id` 改为 predV 的。

6. **跨 Cube 克隆合并** (`tryCrossCubeCloneMerge`)：若直接合并会形成环：
   - 找到 succV 的 CUBE 前驱 (Cube) 及 Cube 的 CUBE 前驱 (CubePre)
   - 确认 Cube 通过 `bufferization::ToTensorOp` 依赖 CubePre
   - 利用 `MemoryDependenceGraph` 追溯所有传递执行前驱
   - 将 CubePre 中的相关算子克隆到 Cube 中，打破循环依赖
   - 再次尝试合并

7. **循环迭代**：合并成功后继续在当前 block 中寻找下一对相邻 VECTOR 块，直到无法合并为止。

---

### Background

In DynamicCVPipeline, operations are grouped into ComputeBlocks by `block_id`, categorized as `CUBE_ONLY` (matmul) or `VECTOR_ONLY`. Excessive VECTOR blocks between CUBE blocks cause fUB overhead. Adjacent VECTOR blocks without data dependency conflicts can be merged to reduce block count.

### Code Flow

1. **Scope identification**: Walk the `ModuleOp` to find body blocks of the innermost `scf::ForOp` that contain `linalg::MatmulOp`.

2. **Dependency graph construction** (`groupAndBuildGraph`): Group ops by `block_id` and build inter-block SSA dependency edges (successors / predecessors / blockEdges).

3. **Candidate collection** (`collectVectorCandidates`): Filter `VECTOR_ONLY` blocks that have tensor-typed results.

4. **Adjacent pair discovery** (`findAdjacentVectorPair`): Find a pair of adjacent VECTOR blocks (predV → succV) from the candidate set.

5. **Direct merge** (`tryDirectMerge`): If no cycle would be created, reassign succV's ops to predV's `block_id`.

6. **Cross-Cube clone merge** (`tryCrossCubeCloneMerge`): When direct merge would create a cycle:
   - Identify succV's CUBE predecessor (Cube) and Cube's CUBE predecessor (CubePre)
   - Verify Cube depends on CubePre via `bufferization::ToTensorOp`
   - Trace all transitive execution predecessors using `MemoryDependenceGraph`
   - Clone relevant ops from CubePre into Cube to break the cycle
   - Retry the merge

7. **Iterative merging**: After a successful merge, continue searching for the next adjacent VECTOR pair in the same block until no more merges are possible.
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
