### PR TITLE
[ControlFlowOpt](feat) restore pointer control-flow decoupling

### DIFF
--- a/third_party/ascend/include/TritonControlFlowOpt/ControlFlowAnalysis.h
+++ b/third_party/ascend/include/TritonControlFlowOpt/ControlFlowAnalysis.h
@@ -75,21 +75,25 @@ struct AnalyzedComponent {
 struct AnalyzedValue {
   Type originalType;
   SmallVector<AnalyzedComponent> components;
-  SmallVector<Value> invariants;
   SmallVector<Attribute> attributes;
 };
 
-/// Signature decision for one original result/iter-argument position.
+/// Signature decision for one original result/iter-argument position. The slot
+/// itself means the original value is removed from the SCF signature;
+/// componentIndices may be empty when every component is invariant and no
+/// replacement operand/result is required.
 struct ControlFlowSlotAnalysis {
   unsigned oldIndex = 0;
   SmallVector<ComponentTransferKind> componentKinds;
   SmallVector<unsigned> componentIndices;
   SmallVector<Type> componentTypes;
+  /// Policy metadata after all incoming paths have been joined.
+  SmallVector<Attribute> resultAttributes;
 };
 
 /// Cached decision for one structured control-flow operation.
 struct ControlFlowOpAnalysis {
-  SmallVector<ControlFlowSlotAnalysis> slots;
+  SmallVector<ControlFlowSlotAnalysis, 0> slots;
   bool hasNestedRewrite = false;
 
   bool rewritesOwnSignature() const { return !slots.empty(); }
@@ -135,6 +139,15 @@ public:
   virtual FailureOr<SmallVector<unsigned>>
   getLoopCandidateComponents(const AnalyzedValue &value) const = 0;
 
+  /// Components which may cross a scope.scope result boundary. Scope has no
+  /// region arguments or backedge, so the first implementation returns every
+  /// component that the policy already permits a loop to carry. A policy may
+  /// override this hook when its Scope schema differs from its loop schema.
+  virtual FailureOr<SmallVector<unsigned>>
+  getScopeCandidateComponents(const AnalyzedValue &value) const {
+    return getLoopCandidateComponents(value);
+  }
+
   virtual FailureOr<SmallVector<unsigned>>
   getLoopTransferredComponents(const AnalyzedValue &initial,
                                const AnalyzedValue &regionArgument,
@@ -146,6 +159,16 @@ public:
 
   /// Selects the component type used in the replacement SCF signature.
   virtual FailureOr<Type> joinComponentTypes(Type lhs, Type rhs) const = 0;
+
+  /// Joins policy-owned metadata across one control-flow boundary. The
+  /// default requires exact equality, which preserves BlockPtr behavior.
+  virtual FailureOr<SmallVector<Attribute>>
+  mergeControlFlowAttributes(const AnalyzedValue &lhs,
+                             const AnalyzedValue &rhs) const {
+    if (lhs.attributes != rhs.attributes)
+      return failure();
+    return lhs.attributes;
+  }
 };
 
 /// Stage-scoped transient cache used while computing a rewrite plan. One
@@ -169,6 +192,7 @@ private:
   FailureOr<ControlFlowOpAnalysis> analyzeFor(Operation *op);
   FailureOr<ControlFlowOpAnalysis> analyzeWhile(Operation *op);
   FailureOr<ControlFlowOpAnalysis> analyzeIf(Operation *op);
+  FailureOr<ControlFlowOpAnalysis> analyzeScope(Operation *op);
 
   void bindRegionArgument(Value argument, const AnalyzedValue &initial,
                           ArrayRef<unsigned> componentIndices);

--- a/third_party/ascend/include/TritonControlFlowOpt/ControlFlowRewrite.h
+++ b/third_party/ascend/include/TritonControlFlowOpt/ControlFlowRewrite.h
@@ -32,26 +32,52 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace mlir::triton::controlflow {
 
+/// Handoff marker for SCF loops whose pointer slots have already been expanded
+/// into policy-owned descriptor components. TritonToLinalg consumes and
+/// removes it instead of applying its legacy pointer-loop decomposition a
+/// second time.
+inline constexpr llvm::StringLiteral kPointerDescriptorBoundaryAttr =
+    "PointerDescriptorBoundary";
+
+/// Handoff marker for a pointer rebuilt at a CFO control-flow boundary. The
+/// defining operation's operands are the complete descriptor roots, including
+/// invariant components omitted from the replacement SCF signature.
+inline constexpr llvm::StringLiteral kPointerDescriptorRebuildAttr =
+    "PointerDescriptorRebuild";
+
+/// Optional companion on a PointerDescriptorRebuild root. The `strided_1d`
+/// form means the tensor-pointer offset operand is a proven rank-1 affine
+/// expression rather than an opaque complete-offset carrier.
+inline constexpr llvm::StringLiteral kPointerDescriptorOffsetFormAttr =
+    "PointerDescriptorOffsetForm";
+inline constexpr llvm::StringLiteral kStrided1DOffsetForm = "strided_1d";
+
+/// Dense per-axis classification attached to a descriptor rebuild. A value
+/// of one means the complete contribution of that logical axis is represented
+/// by its scalar stride; zero means the axis is carried by the opaque complete
+/// contribution tensor.
+inline constexpr llvm::StringLiteral kPointerDescriptorStructuredAxesAttr =
+    "PointerDescriptorStructuredAxes";
+
 /// Policy-owned description of one value crossing a control-flow boundary.
 ///
-/// `components` are runtime values that a policy may place in an expanded SCF
-/// signature. `invariants` and `attributes` are public storage whose layout is
-/// interpreted only by the policy that creates them. The shared rewrite treats
-/// those fields as opaque and only accesses `components` directly.
+/// `components` contain every runtime value needed to rebuild the original
+/// value. A policy may place a selected subset in an expanded SCF signature.
+/// `attributes` retain non-SSA metadata. Both layouts are private to the
+/// policy; the shared rewrite never interprets pointer-specific fields.
 struct DecomposedValue {
   Type originalType;
   SmallVector<Value> components;
-  SmallVector<Value> invariants;
   SmallVector<Attribute> attributes;
 };
 
 /// Read-only view of the SSA mapping and decompositions visible at the current
 /// rewrite point. Policies use it while recursively analyzing pointer
-/// producers; the state exists only for one control-flow rewrite attempt. The
-/// referenced mappings are not owned and must outlive the context.
+/// producers; the state exists only for one control-flow rewrite attempt.
 class ControlFlowRewriteContext {
 public:
   ControlFlowRewriteContext(
@@ -71,8 +97,9 @@ private:
 ///
 /// The policy decides how its value is decomposed and rebuilt, which components
 /// cross loop/if boundaries, and whether two decompositions share a compatible
-/// invariant schema. It is not an IR marker and carries no state between
-/// policy invocations.
+/// non-carried schema. It carries no mutable state between policy invocations.
+/// A policy that expands pointer descriptors may request a downstream handoff
+/// marker; the shared rewrite owns the positional slot metadata.
 class ControlFlowRewritePolicy : public ControlFlowAnalysisPolicy {
 public:
   virtual ~ControlFlowRewritePolicy() = default;
@@ -80,6 +107,41 @@ public:
   /// Whether results of this ordinary operation need immediate decomposition
   /// after cloning so later operations can reuse their exact component state.
   virtual bool shouldDecomposeOperation(Operation *op) const = 0;
+
+  /// Whether rewritten loops owned by this policy must expose their descriptor
+  /// slots to downstream conversion. The shared rewrite records the exact
+  /// expanded result indices because only it knows both old and new signatures.
+  virtual bool requiresPointerDescriptorBoundaryMarker() const { return false; }
+
+  /// Whether recomposing a result of this ordinary cloned operation creates a
+  /// descriptor root that downstream conversion must recognize. This is more
+  /// selective than the boundary marker request above: most policies need
+  /// handoff markers only for SCF argument/result reconstructions, while a
+  /// policy may opt in for a specific pointer-preserving operation.
+  virtual bool shouldMarkOperationRecomposition(Operation *) const {
+    return false;
+  }
+
+  /// Adds policy-private metadata to a descriptor rebuild root.
+  /// This is called only after the generic rewrite has attached the ownership
+  /// marker, whether the root was created at an SCF boundary or by an ordinary
+  /// operation recomposition explicitly selected by the policy.
+  virtual LogicalResult
+  annotatePointerDescriptorRebuild(Operation *, const DecomposedValue &) const {
+    return success();
+  }
+
+  /// Normalizes a concrete descriptor to the schema selected by control-flow
+  /// analysis. The default only replaces policy metadata; tensor-pointer
+  /// policies override it to fold structured fields into an opaque carrier
+  /// when an incoming edge was downgraded.
+  virtual LogicalResult
+  normalizeControlFlowValue(DecomposedValue &value,
+                            ArrayRef<Attribute> targetAttributes, OpBuilder &,
+                            Location) const {
+    value.attributes.assign(targetAttributes.begin(), targetAttributes.end());
+    return success();
+  }
 
   virtual FailureOr<DecomposedValue>
   decompose(Value value, const ControlFlowRewriteContext &context,
@@ -95,17 +157,21 @@ public:
 /// Signature expansion, region cloning, terminator rewriting, nested recursion
 /// and result replacement are driven solely by operation-level decisions in
 /// `plan`.
-LogicalResult
-applyControlFlowRewritePlan(ModuleOp module,
-                            const ControlFlowRewritePolicy &policy,
-                            const ControlFlowRewritePlan &plan);
+/// Set `emitDiagnostics` to false for a speculative rewrite on a detached
+/// clone whose failure is intentionally treated as an unsupported case.
+LogicalResult applyControlFlowRewritePlan(
+    ModuleOp module, const ControlFlowRewritePolicy &policy,
+    const ControlFlowRewritePlan &plan, bool emitDiagnostics = true);
 
 /// Analyzes the complete decomposition stage before mutating the IR, then
 /// applies the frozen plan from outermost to innermost. Pointer semantics
 /// remain selected by `policy` so different decompositions share the same SCF
 /// plumbing.
+/// When `allowUnsupportedFallback` is true, a failed complete rewrite is
+/// treated as an unsupported optimization and leaves the input module intact.
 LogicalResult rewriteControlFlow(ModuleOp module,
-                                 const ControlFlowRewritePolicy &policy);
+                                 const ControlFlowRewritePolicy &policy,
+                                 bool allowUnsupportedFallback = false);
 
 } // namespace mlir::triton::controlflow
 

--- a/third_party/ascend/include/TritonToLinalg/BlockPtrAnalysis.h
+++ b/third_party/ascend/include/TritonToLinalg/BlockPtrAnalysis.h
@@ -35,6 +35,7 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 
 #include <set>
 namespace mlir {
@@ -43,7 +44,38 @@ class ConversionPatternRewriter;
 
 namespace triton {
 
+/// Temporary provenance for memref carriers materialized from complete scalar
+/// pointer addresses. Address round-trip folding is valid only for casts with
+/// this marker; ordinary HIVM PointerCast operations retain their baseline
+/// descriptor semantics. TritonToLinalg removes the marker after conversion.
+inline constexpr llvm::StringLiteral kScalarPointerCarrierAttr =
+    "ScalarPointerCarrier";
+
+/// Returns true when a loop still carries Triton pointer state, or when a
+/// loop-carried integer tensor participates in legacy address computation.
+/// Ordinary memrefs, including fixed-layout memrefs created by
+/// memref.reinterpret_cast, are complete SSA values and do not require the
+/// legacy BlockData loop expansion solely because of their producer.
+bool needsLegacyBlockDataLoopRewrite(LoopLikeOpInterface loopOp);
+
+/// Returns the non-descriptor loop slots that carry a make-range integer
+/// tensor through a CFO-owned SCF boundary. These slots are safe to lower with
+/// the legacy BlockData mask path; pointer descriptor slots and opaque tensor
+/// carriers are deliberately excluded.
+SmallVector<unsigned>
+getMarkedMakeRangeCarrierSlots(LoopLikeOpInterface loopOp);
+
 enum class MemAccVal { Undefined = 0, StrucMemAcc = 1, UnstrucMemAcc = 2 };
+
+/// Creates a verifier-valid HIVM pointer cast for a scalar Triton pointer
+/// represented by an integer address. Triton scalar pointers do not carry an
+/// extent, while their downstream carrier is normally `memref<?xT>` and every
+/// dynamic memref dimension requires a size operand. Use one element as the
+/// conservative carrier extent; reinterpret-cast lowering replaces it with a
+/// precise access range when a larger descriptor is materialized.
+hivm::PointerCastOp createScalarPointerCast(OpBuilder &builder, Location loc,
+                                            MemRefType resultType,
+                                            Value address);
 
 struct MemAccType {
 
@@ -102,8 +134,8 @@ public:
   void removeSource();
 
   int64_t getRank() const;
-  MemRefType getResultMemrefType(int64_t offset,
-                                 ArrayRef<int64_t> resultShape) const;
+  FailureOr<MemRefType>
+  getResultMemrefType(int64_t offset, ArrayRef<int64_t> resultShape) const;
 
   void addBlock(BlockData &lBlock, BlockData &rBlock, Location loc,
                 ConversionPatternRewriter &rewriter);
@@ -114,9 +146,9 @@ public:
   void divBlock(BlockData &lBlock, BlockData &rBlock, Location loc,
                 ConversionPatternRewriter &rewriter);
 
-  memref::ReinterpretCastOp createCastOp(ArrayRef<int64_t> resultShape,
-                                         const Location &loc,
-                                         OpBuilder &builder) const;
+  FailureOr<memref::ReinterpretCastOp>
+  createCastOp(ArrayRef<int64_t> resultShape, const Location &loc,
+               OpBuilder &builder) const;
 
   void setResElemTy(const Type &);
   void setSource(const Value &);
@@ -147,32 +179,43 @@ private:
 
 class BlockDataParser {
 public:
-  static Value getScalarMemRef(Value ptr, Value memref, const Location &loc,
-                               ConversionPatternRewriter &rewriter);
+  /// Materialize the rank-one memref used by a scalar load only when the
+  /// pointer producer has already been converted to a compatible memref.
+  /// Returning failure lets a consumer reject an unconverted producer without
+  /// asserting or creating partial IR.
+  static FailureOr<Value> getScalarMemRef(Value ptr, Value memref,
+                                          const Location &loc,
+                                          ConversionPatternRewriter &rewriter);
 
-  static void parse(Value operand, BlockData &data, const Location &loc,
-                    ConversionPatternRewriter &rewriter,
-                    const llvm::SmallDenseMap<Value, BlockData> &known);
+  static LogicalResult
+  parse(Value operand, BlockData &data, const Location &loc,
+        ConversionPatternRewriter &rewriter,
+        const llvm::SmallDenseMap<Value, BlockData> &known);
 
-  static void parseAdd(arith::AddIOp op, BlockData &data, const Location &loc,
-                       ConversionPatternRewriter &rewriter,
-                       const llvm::SmallDenseMap<Value, BlockData> &known);
+  static LogicalResult
+  parseAdd(arith::AddIOp op, BlockData &data, const Location &loc,
+           ConversionPatternRewriter &rewriter,
+           const llvm::SmallDenseMap<Value, BlockData> &known);
 
-  static void parseSub(arith::SubIOp op, BlockData &data, const Location &loc,
-                       ConversionPatternRewriter &rewriter,
-                       const llvm::SmallDenseMap<Value, BlockData> &known);
+  static LogicalResult
+  parseSub(arith::SubIOp op, BlockData &data, const Location &loc,
+           ConversionPatternRewriter &rewriter,
+           const llvm::SmallDenseMap<Value, BlockData> &known);
 
-  static void parseMul(arith::MulIOp op, BlockData &data, const Location &loc,
-                       ConversionPatternRewriter &rewriter,
-                       const llvm::SmallDenseMap<Value, BlockData> &known);
+  static LogicalResult
+  parseMul(arith::MulIOp op, BlockData &data, const Location &loc,
+           ConversionPatternRewriter &rewriter,
+           const llvm::SmallDenseMap<Value, BlockData> &known);
 
-  static void parseDiv(arith::DivSIOp op, BlockData &data, const Location &loc,
-                       ConversionPatternRewriter &rewriter,
-                       const llvm::SmallDenseMap<Value, BlockData> &known);
+  static LogicalResult
+  parseDiv(arith::DivSIOp op, BlockData &data, const Location &loc,
+           ConversionPatternRewriter &rewriter,
+           const llvm::SmallDenseMap<Value, BlockData> &known);
 
-  static void parseRem(arith::RemSIOp op, BlockData &data, const Location &loc,
-                       ConversionPatternRewriter &rewriter,
-                       const llvm::SmallDenseMap<Value, BlockData> &known);
+  static LogicalResult
+  parseRem(arith::RemSIOp op, BlockData &data, const Location &loc,
+           ConversionPatternRewriter &rewriter,
+           const llvm::SmallDenseMap<Value, BlockData> &known);
 
   static void
   parseUnrealizedCast(UnrealizedConversionCastOp op, BlockData &data,
@@ -189,30 +232,30 @@ public:
       ConversionPatternRewriter &rewriter,
       const llvm::SmallDenseMap<Value, BlockData> &known);
 
-  static void
+  static LogicalResult
   parseExpandDims(triton::ExpandDimsOp op, BlockData &data, const Location &loc,
                   ConversionPatternRewriter &rewriter,
                   const llvm::SmallDenseMap<Value, BlockData> &known);
 
-  static void parseBitcast(triton::BitcastOp op, BlockData &data,
-                           const Location &loc,
-                           ConversionPatternRewriter &rewriter,
-                           const llvm::SmallDenseMap<Value, BlockData> &known);
+  static LogicalResult
+  parseBitcast(triton::BitcastOp op, BlockData &data, const Location &loc,
+               ConversionPatternRewriter &rewriter,
+               const llvm::SmallDenseMap<Value, BlockData> &known);
 
-  static void parseExtSI(arith::ExtSIOp op, BlockData &data,
-                         const Location &loc,
-                         ConversionPatternRewriter &rewriter,
-                         const llvm::SmallDenseMap<Value, BlockData> &known);
+  static LogicalResult
+  parseExtSI(arith::ExtSIOp op, BlockData &data, const Location &loc,
+             ConversionPatternRewriter &rewriter,
+             const llvm::SmallDenseMap<Value, BlockData> &known);
 
-  static void
+  static LogicalResult
   parseBroadcast(triton::BroadcastOp op, BlockData &data, const Location &loc,
                  ConversionPatternRewriter &rewriter,
                  const llvm::SmallDenseMap<Value, BlockData> &known);
 
-  static void parseSplat(triton::SplatOp op, BlockData &data,
-                         const Location &loc,
-                         ConversionPatternRewriter &rewriter,
-                         const llvm::SmallDenseMap<Value, BlockData> &known);
+  static LogicalResult
+  parseSplat(triton::SplatOp op, BlockData &data, const Location &loc,
+             ConversionPatternRewriter &rewriter,
+             const llvm::SmallDenseMap<Value, BlockData> &known);
 
   static void
   parseConstSplat(arith::ConstantOp op, BlockData &data, const Location &loc,
@@ -221,17 +264,18 @@ public:
 
   template <typename T>
   static std::enable_if_t<std::is_same_v<T, triton::MakeTensorPtrOp> ||
-                          std::is_same_v<T, triton::AdvanceOp>>
+                              std::is_same_v<T, triton::AdvanceOp>,
+                          LogicalResult>
   parseTensorPtr(T op, BlockData &data, const Location &loc,
                  ConversionPatternRewriter &rewriter,
                  const llvm::SmallDenseMap<Value, BlockData> &known);
 
-  static void parseAddPtr(triton::AddPtrOp op, BlockData &data,
-                          const Location &loc,
-                          ConversionPatternRewriter &rewriter,
-                          const llvm::SmallDenseMap<Value, BlockData> &known);
+  static LogicalResult
+  parseAddPtr(triton::AddPtrOp op, BlockData &data, const Location &loc,
+              ConversionPatternRewriter &rewriter,
+              const llvm::SmallDenseMap<Value, BlockData> &known);
 
-  static void
+  static LogicalResult
   parseExtractSlice(tensor::ExtractSliceOp op, BlockData &data,
                     const Location &loc, ConversionPatternRewriter &rewriter,
                     const llvm::SmallDenseMap<Value, BlockData> &known);
@@ -241,24 +285,25 @@ public:
                        const Location &loc, ConversionPatternRewriter &rewriter,
                        const llvm::SmallDenseMap<Value, BlockData> &known);
 
-  static void parseReduce(triton::ReduceOp op, BlockData &data,
-                          const Location &loc,
-                          ConversionPatternRewriter &rewriter,
-                          const llvm::SmallDenseMap<Value, BlockData> &known);
+  static LogicalResult
+  parseReduce(triton::ReduceOp op, BlockData &data, const Location &loc,
+              ConversionPatternRewriter &rewriter,
+              const llvm::SmallDenseMap<Value, BlockData> &known);
 
   static void
   parseAtomicRmw(triton::AtomicRMWOp op, BlockData &data, const Location &loc,
                  ConversionPatternRewriter &rewriter,
                  const llvm::SmallDenseMap<Value, BlockData> &known);
 
-  static void parseFill(linalg::FillOp op, BlockData &data, const Location &loc,
-                        ConversionPatternRewriter &rewriter,
-                        const llvm::SmallDenseMap<Value, BlockData> &known);
+  static LogicalResult
+  parseFill(linalg::FillOp op, BlockData &data, const Location &loc,
+            ConversionPatternRewriter &rewriter,
+            const llvm::SmallDenseMap<Value, BlockData> &known);
 
-  static void parseSelect(arith::SelectOp op, BlockData &data,
-                          const Location &loc,
-                          ConversionPatternRewriter &rewriter,
-                          const llvm::SmallDenseMap<Value, BlockData> &known);
+  static LogicalResult
+  parseSelect(arith::SelectOp op, BlockData &data, const Location &loc,
+              ConversionPatternRewriter &rewriter,
+              const llvm::SmallDenseMap<Value, BlockData> &known);
 
   static void parseCustomOp(hivm::CustomOp op, BlockData &data,
                             const Location &loc,
@@ -266,7 +311,7 @@ public:
                             const llvm::SmallDenseMap<Value, BlockData> &known,
                             unsigned resultIdx);
 
-  static void
+  static LogicalResult
   parseStructuredCustomOp(Operation *op, BlockData &data, const Location &loc,
                           ConversionPatternRewriter &rewriter,
                           const llvm::SmallDenseMap<Value, BlockData> &known,
@@ -283,32 +328,33 @@ public:
   static void rewriteStructuredCustomOp(Operation *op,
                                         ConversionPatternRewriter &rewriter);
 
-  static void rewriteAddPtr(triton::AddPtrOp op,
-                            triton::AddPtrOp::Adaptor &adaptor,
-                            ConversionPatternRewriter &rewriter,
-                            llvm::SmallDenseMap<Value, BlockData> &known);
+  static LogicalResult
+  rewriteAddPtr(triton::AddPtrOp op, triton::AddPtrOp::Adaptor &adaptor,
+                ConversionPatternRewriter &rewriter,
+                llvm::SmallDenseMap<Value, BlockData> &known);
 
   static FailureOr<Value>
   materializePointer(Value ptr, ConversionPatternRewriter &rewriter,
                      llvm::SmallDenseMap<Value, BlockData> &known);
 
-  static void
-  rewriteMakeTensorPtrOp(triton::MakeTensorPtrOp op, Value base,
+  static LogicalResult
+  rewriteMakeTensorPtrOp(triton::MakeTensorPtrOp op, Value convertedBase,
                          ConversionPatternRewriter &rewriter,
                          llvm::SmallDenseMap<Value, BlockData> &known);
 
-  static void rewriteAdvanceOp(triton::AdvanceOp op,
-                               ConversionPatternRewriter &rewriter,
-                               llvm::SmallDenseMap<Value, BlockData> &known);
+  static LogicalResult
+  rewriteAdvanceOp(triton::AdvanceOp op, ConversionPatternRewriter &rewriter,
+                   llvm::SmallDenseMap<Value, BlockData> &known);
 
-  static void
+  static LogicalResult
   rewriteCustomOp(hivm::CustomOp op, hivm::CustomOp::Adaptor &adaptor,
                   ConversionPatternRewriter &rewriter,
                   const llvm::SmallDenseMap<Value, BlockData> &known);
 
   template <typename T>
   static std::enable_if_t<std::is_same_v<T, scf::YieldOp> ||
-                          std::is_same_v<T, scf::ConditionOp>>
+                              std::is_same_v<T, scf::ConditionOp>,
+                          LogicalResult>
   rewriteTerminator(T op, ConversionPatternRewriter &rewriter,
                     const llvm::SmallDenseSet<size_t> &blockArgIdxSet,
                     ArrayRef<int64_t> iterArgIdxMap,
@@ -316,14 +362,14 @@ public:
 
   /// @param known is mainly designed for `rewriteLoop`, and is just non-const
   /// in `rewriteLoop`, `rewriteAddPtr` and `rewriteAdvance`
-  static void rewriteLoopOp(LoopLikeOpInterface op,
-                            ConversionPatternRewriter &rewriter,
-                            llvm::SmallDenseMap<Value, BlockData> &known);
+  static LogicalResult
+  rewriteLoopOp(LoopLikeOpInterface op, ConversionPatternRewriter &rewriter,
+                llvm::SmallDenseMap<Value, BlockData> &known,
+                ArrayRef<unsigned> onlyIndexTensorSlots = {});
 
-  static void rewriteAddPtrToUnstrucMemAcc(triton::AddPtrOp op,
-                                           triton::AddPtrOp::Adaptor &adaptor,
-                                           ConversionPatternRewriter &rewriter,
-                                           BlockData &data);
+  static LogicalResult rewriteAddPtrToUnstrucMemAcc(
+      triton::AddPtrOp op, triton::AddPtrOp::Adaptor &adaptor,
+      ConversionPatternRewriter &rewriter, BlockData &data);
 };
 
 template <typename OpTy>

--- a/third_party/ascend/include/TritonToLinalg/LoadStoreConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/LoadStoreConverter.h
@@ -24,6 +24,7 @@
 #define TRITON_ADAPTER_LOADSTORECONVERTER_H
 
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/MLIRContext.h"
@@ -123,6 +124,25 @@ public:
   LogicalResult matchAndRewrite(OpTy op,
                                 PatternRewriter &rewriter) const override {
     Value ptrVal = op.getPtr();
+
+    // A uniform scalar pointer can be broadcast and immediately extracted at
+    // a memory boundary. Fold that round-trip here so scalar pointer
+    // conversion does not require a tensor-of-pointer materialization.
+    if (auto extractOp = ptrVal.getDefiningOp<tensor::ExtractOp>()) {
+      if (auto splatOp =
+              extractOp.getTensor().getDefiningOp<triton::SplatOp>()) {
+        Value scalarPointer = splatOp.getSrc();
+        auto pointerType =
+            dyn_cast<triton::PointerType>(scalarPointer.getType());
+        if (pointerType && !isa<ShapedType>(pointerType.getPointeeType()) &&
+            scalarPointer.getType() == ptrVal.getType()) {
+          rewriter.modifyOpInPlace(
+              op, [&]() { op->replaceUsesOfWith(ptrVal, scalarPointer); });
+          return success();
+        }
+      }
+    }
+
     auto ptrTy = dyn_cast<RankedTensorType>(ptrVal.getType());
     if (!ptrTy || !isa<triton::PointerType>(ptrTy.getElementType()))
       return failure();

--- a/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
@@ -37,6 +37,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 
@@ -576,6 +577,66 @@ public:
                   ConversionPatternRewriter &rewriter) const override;
 };
 
+// These predicates select only scalar !tt.ptr<T> transports. A
+// tensor<...x!tt.ptr<T>> follows the separate tensor-pointer lowering.
+bool hasScalarPointerResult(scf::IfOp op);
+bool isScalarPointerSelect(arith::SelectOp op);
+
+// Marks an scf.if temporarily rebuilt by IfConverter. Its scalar-pointer
+// results are represented as complete i64 addresses, so only its own yields
+// require the matching pointer-to-address conversion.
+inline constexpr llvm::StringLiteral kScalarPointerCarrierBoundaryAttr =
+    "ScalarPointerCarrierBoundary";
+
+// Rebuild an scf.if with scalar-pointer results so the boundary carries
+// complete i64 addresses and reconstructs memrefs only after the join.
+// The original branch regions are moved into the new operation, preserving
+// side effects and allowing the conversion driver to rewrite each scf.yield
+// operand in place.
+//
+// Example:
+//   %base = scf.if %cond -> !tt.ptr<f32> {
+//     scf.yield %lhs : !tt.ptr<f32>
+//   } else {
+//     scf.yield %rhs : !tt.ptr<f32>
+//   }
+//   %ptr = tt.make_tensor_ptr %base, ...
+// becomes an scf.if returning i64 plus one hivm.pointer_cast after the if.
+class IfConverter : public OpConversionPattern<scf::IfOp> {
+public:
+  using OpConversionPattern<scf::IfOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(scf::IfOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override;
+};
+
+// Convert a scalar-pointer select into a select over complete integer addresses
+// and reconstruct one memref after the selection. This handles both BlockPtr
+// bases and ordinary scalar pointers without asking the backend to merge two
+// memory objects.
+//
+// Example:
+//   %base = arith.select %cond, %lhs, %rhs : !tt.ptr<f32>
+//   %ptr = tt.make_tensor_ptr %base, ...
+// becomes:
+//   %lhs_addr = memref.extract_aligned_pointer_as_index %lhs
+//   %rhs_addr = memref.extract_aligned_pointer_as_index %rhs
+//   %selected_addr = arith.select %cond, %lhs_addr, %rhs_addr : i64
+//   %base = hivm.pointer_cast %selected_addr : i64 to memref<?xf32>
+class PointerSelectConverter : public OpConversionPattern<arith::SelectOp> {
+public:
+  using OpConversionPattern<arith::SelectOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(arith::SelectOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override;
+};
+
+// Convert the yields of an IfConverter-created scf.if to its carrier result
+// types. In particular, a yielded scalar pointer becomes its complete i64
+// address. Yields belonging to ordinary ifs or loops are intentionally left to
+// their owning conversions.
 class YieldConverter : public OpConversionPattern<scf::YieldOp> {
 public:
   using OpConversionPattern<scf::YieldOp>::OpConversionPattern;
@@ -596,11 +657,17 @@ public:
   matchAndRewrite(LoopOpTy op,
                   typename OpConversionPattern<LoopOpTy>::OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    // CFO-expanded descriptor loops already carry pointer-free policy values
+    // and remain structurally unchanged. This legacy BlockData rewrite is only
+    // valid for explicitly marked loops.
+    SmallVector<unsigned> markedRangeSlots = getMarkedMakeRangeCarrierSlots(op);
+    if (!op->hasAttr("UnhandledLoopOp") && markedRangeSlots.empty())
+      return failure();
     llvm::SmallDenseMap<Value, BlockData> known;
 
-    op->removeAttr("UnhandledLoopOp");
-    BlockDataParser::rewriteLoopOp(op, rewriter, known);
-    return success();
+    rewriter.modifyOpInPlace(op, [&]() { op->removeAttr("UnhandledLoopOp"); });
+    return BlockDataParser::rewriteLoopOp(op, rewriter, known,
+                                          markedRangeSlots);
   }
 };
 
@@ -733,6 +800,14 @@ public:
   using OpConversionPattern<triton::PtrToIntOp>::OpConversionPattern;
   LogicalResult
   matchAndRewrite(triton::PtrToIntOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override;
+};
+
+class IntToPtrConverter : public OpConversionPattern<triton::IntToPtrOp> {
+public:
+  using OpConversionPattern<triton::IntToPtrOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(triton::IntToPtrOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override;
 };
 

--- a/third_party/ascend/include/TritonToUnstructure/BubbleUpOperation.h
+++ b/third_party/ascend/include/TritonToUnstructure/BubbleUpOperation.h
@@ -72,6 +72,11 @@ private:
                          PatternRewriter &rewriter) const;
   void bubbleUpOperation(ExtractOpTy op, arith::CmpIOp parentOp, Location loc,
                          PatternRewriter &rewriter) const;
+  // Pushes extract(select(condition, lhs, rhs)) through the select. A shaped
+  // condition is extracted at the same position while a scalar condition is
+  // reused directly.
+  void bubbleUpOperation(ExtractOpTy op, arith::SelectOp parentOp, Location loc,
+                         PatternRewriter &rewriter) const;
   void bubbleUpOperation(ExtractOpTy op, arith::TruncFOp parentOp, Location loc,
                          PatternRewriter &rewriter) const;
   void bubbleUpOperation(ExtractOpTy op, arith::ExtFOp parentOp, Location loc,

--- a/third_party/ascend/include/TritonToUnstructure/OffsetAnalysis.h
+++ b/third_party/ascend/include/TritonToUnstructure/OffsetAnalysis.h
@@ -34,9 +34,17 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace mlir {
 namespace triton {
+
+/// Temporary T2U handoff marker for loop slots rewritten from a scalar
+/// pointer to a relative integer offset.  OffsetAnalysis uses this marker to
+/// keep the region argument's dynamic backedge value instead of replaying the
+/// original pointer-init provenance on every iteration.
+inline constexpr llvm::StringLiteral kScalarPointerOffsetBoundaryAttr =
+    "ScalarPointerOffsetBoundary";
 
 struct PtrOffsetInfo {
   /**
@@ -95,6 +103,7 @@ public:
   SmallVector<Value> getOffsets() const;
   SmallVector<Value> &getOffsetsRef();
   bool isScalarLike() const;
+  bool isPointerDescriptorOwned() const;
   SmallVector<AxisInfo> &getStructuredRef();
   const SmallVector<AxisInfo> &getStructured() const;
   int getRank() const;
@@ -105,11 +114,15 @@ public:
   void setStructured();
   void setStructured(int rank);
   void setStructured(int rank, AxisInfo info);
+  // These setters update only per-axis structure. They intentionally preserve
+  // the independent scalarLike property; callers that invalidate scalar
+  // equivalence must clear it explicitly.
   void setUnstructured();
   void setUnstructured(int rank);
   void setStructured(ArrayRef<AxisInfo> structured);
   void setStructured(const PtrOffsetInfo &other);
   void setScalarLike(bool scalarLike);
+  void setPointerDescriptorOwned(bool pointerDescriptorOwned);
 
   bool isStructured(int dim) const;
   bool isStructured() const;
@@ -124,6 +137,12 @@ private:
   SmallVector<Value> tptOffsets;
 
   bool scalarLike = false;
+
+  // True only when the pointer originates from a CFO descriptor rebuild and
+  // every pointer-preserving operation since that rebuild was modeled by this
+  // analysis. Consumers may then use the analyzed scalar base without relying
+  // on the load operand's direct producer.
+  bool pointerDescriptorOwned = false;
 
   SmallVector<AxisInfo> structured;
 };

--- a/third_party/ascend/include/TritonToUnstructure/UnstructureConversionPass.h
+++ b/third_party/ascend/include/TritonToUnstructure/UnstructureConversionPass.h
@@ -107,8 +107,9 @@ private:
                         ArrayRef<OpFoldResult> sizes,
                         ArrayRef<OpFoldResult> strides) const;
   template <typename U = MemAccOpTy>
-  typename std::enable_if<std::is_same_v<U, triton::LoadOp>, void>::type
-  splatAndLoadScenario(MemAccOpTy op, int rank,
+  typename std::enable_if<std::is_same_v<U, triton::LoadOp>,
+                          LogicalResult>::type
+  splatAndLoadScenario(MemAccOpTy op, const PtrOffsetInfo &ptrOffsetInfo,
                        PatternRewriter &rewriter) const;
 
   template <typename... Args>

--- a/third_party/ascend/lib/TritonControlFlowOpt/BlockPtrDecompose.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/BlockPtrDecompose.cpp
@@ -35,15 +35,27 @@ using namespace mlir::triton::controlflow;
 
 namespace {
 
+static constexpr unsigned kBaseComponent = 0;
+static constexpr unsigned getShapeStart() { return kBaseComponent + 1; }
+static constexpr unsigned getStrideStart(unsigned rank) {
+  return getShapeStart() + rank;
+}
+static constexpr unsigned getOffsetStart(unsigned rank) {
+  return getStrideStart(rank) + rank;
+}
+
 /// Block-pointer component layout used only by this policy:
 ///
-///   components = [shape..., strides..., offsets...]
-///   invariants = [base]
+///   components = [base_address, shape..., strides..., offsets...]
 ///   attributes = [order]
 ///
-/// Loops currently carry only `offsets`; shape and strides must remain
-/// invariant across a backedge. An scf.if may select any component whose SSA
-/// value differs between its branches.
+/// Analysis tracks all components in this exact order, while a rewritten SCF
+/// boundary carries only the components whose symbolic identities may change.
+/// The base is represented as an i64 address rather than a pointer/memref so a
+/// control-flow merge remains an SSA value selection and cannot be lowered as
+/// a memory-object copy by the backend.
+/// `order` remains policy-owned static metadata and must agree on every
+/// incoming path.
 ///
 /// Keep rank/layout checks local to this file: the generic control-flow
 /// machinery intentionally does not know the descriptor format of a policy.
@@ -59,13 +71,117 @@ static FailureOr<unsigned> getRank(Type originalType) {
   return tensorType.getRank();
 }
 
+// Recovers the scalar pointer type accepted by tt.make_tensor_ptr from the
+// BlockPtr result type. The address space is preserved across the temporary
+// integer carrier.
+static FailureOr<triton::PointerType> getBasePointerType(Type originalType) {
+  auto pointerType = dyn_cast<triton::PointerType>(originalType);
+  if (!pointerType)
+    return failure();
+  auto tensorType = dyn_cast<RankedTensorType>(pointerType.getPointeeType());
+  if (!tensorType)
+    return failure();
+  return triton::PointerType::get(tensorType.getElementType(),
+                                  pointerType.getAddressSpace());
+}
+
+// Materializes the integer form of a make_tensor_ptr base at a point dominated
+// by the base itself, rather than unconditionally inside the make_tensor_ptr's
+// block. This matters when two scf.if branches build equivalent descriptors
+// from one outer base: analysis classifies the base as invariant, so the
+// concrete address reused after the if must also dominate that use.
+//
+// Example:
+//   %base is a function argument
+//   scf.if ... {
+//     %a = tt.make_tensor_ptr %base, ...
+//   } else {
+//     %b = tt.make_tensor_ptr %base, ...
+//   }
+//
+// The shared tt.ptr_to_int is materialized among the leading conversions of a
+// block-argument owner, or immediately after the base's defining operation.
+// Both positions dominate later branches and the pointer rebuilt after them.
+// Keeping the explicit tt.ptr_to_int even for a base produced by tt.int_to_ptr
+// preserves the native pointer provenance used during invariant-base
+// recomposition.
+static FailureOr<Value> materializeBaseAddress(Value base, Location loc,
+                                               OpBuilder &builder) {
+  OpBuilder::InsertionGuard guard(builder);
+  if (auto blockArgument = dyn_cast<BlockArgument>(base)) {
+    Block *owner = blockArgument.getOwner();
+    Operation *lastLeadingAddress = nullptr;
+    for (Operation &operation : *owner) {
+      auto existing = dyn_cast<triton::PtrToIntOp>(&operation);
+      if (!existing)
+        break;
+      if (existing.getSrc() == base &&
+          existing.getResult().getType().isInteger(64))
+        return existing.getResult();
+      lastLeadingAddress = &operation;
+    }
+    if (lastLeadingAddress)
+      builder.setInsertionPointAfter(lastLeadingAddress);
+    else
+      builder.setInsertionPointToStart(owner);
+  } else if (Operation *definingOp = base.getDefiningOp()) {
+    if (Operation *next = definingOp->getNextNode()) {
+      if (auto existing = dyn_cast<triton::PtrToIntOp>(next);
+          existing && existing.getSrc() == base &&
+          existing.getResult().getType().isInteger(64))
+        return existing.getResult();
+    }
+    builder.setInsertionPointAfter(definingOp);
+  } else {
+    return failure();
+  }
+  return builder.create<triton::PtrToIntOp>(loc, builder.getI64Type(), base)
+      .getResult();
+}
+
+// Recovers the original pointer when a concrete descriptor still holds the
+// exact address produced for that pointer. An invariant base keeps the direct
+//
+//   %address = tt.ptr_to_int %base
+//
+// result as component zero while offsets cross an SCF boundary. A changing
+// base instead replaces component zero with an SCF result or region argument,
+// so this lookup intentionally fails and recomposition must use tt.int_to_ptr.
+static Value recoverNativeBase(Value baseAddress,
+                               triton::PointerType expectedType) {
+  auto ptrToInt = baseAddress.getDefiningOp<triton::PtrToIntOp>();
+  if (!ptrToInt || ptrToInt.getSrc().getType() != expectedType)
+    return nullptr;
+  return ptrToInt.getSrc();
+}
+
+// Analysis and rewrite must agree on which advance dimensions change the
+// descriptor. Only a literal integer zero is ignored; values that merely fold
+// to zero after another rewrite remain conservative transfer candidates.
+static bool isConstantZeroInteger(Value value) {
+  std::optional<int64_t> constant = getConstantIntValue(value);
+  return constant && *constant == 0;
+}
+
 // Validates the common block-pointer schema for either state representation.
 // Their component element types differ, but this check only needs field sizes.
 template <typename StateT> static bool hasValidLayout(const StateT &state) {
   FailureOr<unsigned> rank = getRank(state.originalType);
-  return succeeded(rank) && state.components.size() == 3 * *rank &&
-         state.invariants.size() == 1 && state.attributes.size() == 1 &&
+  return succeeded(rank) && state.components.size() == 1 + 3 * *rank &&
+         state.attributes.size() == 1 &&
          isa<DenseI32ArrayAttr>(state.attributes.front());
+}
+
+/// Returns the complete, ordered descriptor range used to expand one
+/// block-pointer control-flow slot. Keeping this policy-local prevents the
+/// generic SCF rewrite from depending on the BlockPtr field layout.
+static SmallVector<unsigned>
+getAllComponentIndices(const AnalyzedValue &value) {
+  SmallVector<unsigned> indices;
+  indices.reserve(value.components.size());
+  for (unsigned index = 0; index < value.components.size(); ++index)
+    indices.push_back(index);
+  return indices;
 }
 
 class BlockPtrPolicy final : public ControlFlowRewritePolicy {
@@ -93,7 +209,11 @@ public:
       // types and symbolic identities here; this phase must not create IR.
       AnalyzedValue result;
       result.originalType = value.getType();
-      unsigned componentIndex = 0;
+      Value base = makePtr.getBase();
+      result.components.push_back(
+          {IntegerType::get(value.getContext(), 64),
+           ComponentIdentity::fromValue(base, kBaseComponent)});
+      unsigned componentIndex = getShapeStart();
       auto appendComponents = [&](ValueRange values) {
         for (Value component : values) {
           result.components.push_back(
@@ -104,7 +224,6 @@ public:
       appendComponents(makePtr.getShape());
       appendComponents(makePtr.getStrides());
       appendComponents(makePtr.getOffsets());
-      result.invariants.push_back(makePtr.getBase());
       result.attributes.push_back(makePtr.getOrderAttr());
       if (!hasValidLayout(result))
         return failure();
@@ -124,7 +243,9 @@ public:
     if (advance.getOffsets().size() != rank)
       return failure();
     for (unsigned dimension = 0; dimension < rank; ++dimension) {
-      unsigned componentIndex = 2 * rank + dimension;
+      if (isConstantZeroInteger(advance.getOffsets()[dimension]))
+        continue;
+      unsigned componentIndex = getOffsetStart(rank) + dimension;
       result->components[componentIndex].identity =
           ComponentIdentity::fromValue(value, componentIndex);
     }
@@ -136,13 +257,10 @@ public:
   getLoopCandidateComponents(const AnalyzedValue &value) const override {
     if (!hasValidLayout(value))
       return failure();
-    unsigned rank = *getRank(value.originalType);
-    SmallVector<unsigned> indices;
-    // Only the final rank entries (offsets) are legal loop-carried state in the
-    // current block-pointer model.
-    for (unsigned dimension = 0; dimension < rank; ++dimension)
-      indices.push_back(2 * rank + dimension);
-    return indices;
+    // Analyze the complete descriptor so changes to base, shape, stride, or
+    // offset remain visible. The transfer hook below decides which candidates
+    // actually become ordinary loop-carried SSA state.
+    return getAllComponentIndices(value);
   }
 
   FailureOr<SmallVector<unsigned>>
@@ -153,32 +271,22 @@ public:
         !hasValidLayout(next) ||
         initial.originalType != regionArgument.originalType ||
         initial.originalType != next.originalType ||
-        initial.invariants != regionArgument.invariants ||
-        initial.invariants != next.invariants ||
         initial.attributes != regionArgument.attributes ||
         initial.attributes != next.attributes)
       return failure();
 
-    unsigned rank = *getRank(initial.originalType);
-    // The current implementation does not expand shape or stride iter_args.
-    // Reject a loop that changes either instead of silently reconstructing a
-    // descriptor with stale values.
-    for (unsigned index = 0; index < 2 * rank; ++index) {
-      if (initial.components[index].type != next.components[index].type ||
-          initial.components[index].identity != next.components[index].identity)
-        return failure();
-    }
-
     SmallVector<unsigned> transferred;
-    // An offset is carried only if the backedge state depends on the region
-    // argument. Constant/invariant offsets remain outside the loop signature.
-    for (unsigned dimension = 0; dimension < rank; ++dimension) {
-      unsigned index = 2 * rank + dimension;
+    for (unsigned index = 0; index < initial.components.size(); ++index) {
       if (failed(joinComponentTypes(initial.components[index].type,
+                                    regionArgument.components[index].type)) ||
+          failed(joinComponentTypes(initial.components[index].type,
                                     next.components[index].type)))
         return failure();
-      if (regionArgument.components[index].identity !=
-          next.components[index].identity)
+      const ComponentIdentity &nextIdentity = next.components[index].identity;
+      bool forwardsCurrent =
+          nextIdentity == regionArgument.components[index].identity;
+      bool restoresInitial = nextIdentity == initial.components[index].identity;
+      if (!forwardsCurrent && !restoresInitial)
         transferred.push_back(index);
     }
     return transferred;
@@ -189,14 +297,9 @@ public:
                              const AnalyzedValue &elseValue) const override {
     if (!hasValidLayout(thenValue) || !hasValidLayout(elseValue) ||
         thenValue.originalType != elseValue.originalType ||
-        thenValue.invariants != elseValue.invariants ||
-        thenValue.attributes != elseValue.attributes ||
-        thenValue.components.size() != elseValue.components.size())
+        thenValue.attributes != elseValue.attributes)
       return failure();
 
-    // Unlike loops, an if can select shape, stride, or offset components. Base
-    // and order remain invariants because AdapterIR cannot represent a runtime
-    // selection between heterogeneous pointer descriptors.
     SmallVector<unsigned> transferred;
     for (unsigned index = 0; index < thenValue.components.size(); ++index) {
       if (failed(joinComponentTypes(thenValue.components[index].type,
@@ -224,6 +327,8 @@ public:
     return isa<triton::AdvanceOp>(op);
   }
 
+  bool requiresPointerDescriptorBoundaryMarker() const override { return true; }
+
   FailureOr<DecomposedValue> decompose(Value value,
                                        const ControlFlowRewriteContext &context,
                                        OpBuilder &builder,
@@ -241,13 +346,17 @@ public:
       // Materialize the concrete counterpart of analyzeValue's descriptor.
       DecomposedValue result;
       result.originalType = value.getType();
+      FailureOr<Value> baseAddress =
+          materializeBaseAddress(makePtr.getBase(), makePtr.getLoc(), builder);
+      if (failed(baseAddress))
+        return failure();
+      result.components.push_back(*baseAddress);
       result.components.append(makePtr.getShape().begin(),
                                makePtr.getShape().end());
       result.components.append(makePtr.getStrides().begin(),
                                makePtr.getStrides().end());
       result.components.append(makePtr.getOffsets().begin(),
                                makePtr.getOffsets().end());
-      result.invariants.push_back(makePtr.getBase());
       result.attributes.push_back(makePtr.getOrderAttr());
       if (!hasValidLayout(result))
         return failure();
@@ -271,8 +380,10 @@ public:
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPoint(advance);
     for (auto [dim, delta] : llvm::enumerate(advance.getOffsets())) {
-      unsigned component = 2 * *rank + dim;
+      unsigned component = getOffsetStart(*rank) + dim;
       Value currentOffset = result->components[component];
+      if (isConstantZeroInteger(delta))
+        continue;
       Value remappedDelta = context.remap(delta);
       if (!remappedDelta)
         return failure();
@@ -295,11 +406,21 @@ public:
       return nullptr;
     unsigned rank = *getRank(value.originalType);
     auto order = cast<DenseI32ArrayAttr>(value.attributes.front());
+    FailureOr<triton::PointerType> basePointerType =
+        getBasePointerType(value.originalType);
+    if (failed(basePointerType) ||
+        value.components[kBaseComponent].getType() != builder.getI64Type())
+      return nullptr;
+    Value base =
+        recoverNativeBase(value.components[kBaseComponent], *basePointerType);
+    if (!base)
+      base = builder.create<triton::IntToPtrOp>(
+          loc, *basePointerType, value.components[kBaseComponent]);
     return builder.create<triton::MakeTensorPtrOp>(
-        loc, value.originalType, value.invariants.front(),
-        ValueRange(value.components).take_front(rank),
-        ValueRange(value.components).slice(rank, rank),
-        ValueRange(value.components).take_back(rank), order);
+        loc, value.originalType, base,
+        ValueRange(value.components).slice(getShapeStart(), rank),
+        ValueRange(value.components).slice(getStrideStart(rank), rank),
+        ValueRange(value.components).slice(getOffsetStart(rank), rank), order);
   }
 };
 
@@ -308,8 +429,9 @@ public:
 namespace mlir::triton::controlflow {
 
 LogicalResult runBlockPtrDecompose(ModuleOp module) {
-  // Make the explicit descriptor carried by a block pointer cross each
-  // supported SCF boundary as ordinary SSA components.
+  // Analyze the complete ordered descriptor for every BlockPtr that crosses a
+  // supported SCF boundary, carry only changing components, and rebuild the
+  // pointer at each use site.
   BlockPtrPolicy policy;
   return rewriteControlFlow(module, policy);
 }

--- a/third_party/ascend/lib/TritonControlFlowOpt/CMakeLists.txt
+++ b/third_party/ascend/lib/TritonControlFlowOpt/CMakeLists.txt
@@ -10,6 +10,7 @@ add_triton_library(TritonControlFlowOpt
   TritonControlFlowOptPassIncGen
 
   LINK_LIBS PUBLIC
+  BiShengIRScopeDialect
   MLIRArithDialect
   MLIRControlFlowDialect
   MLIRFuncDialect

--- a/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowAnalysis.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowAnalysis.cpp
@@ -22,6 +22,7 @@
 
 #include "TritonControlFlowOpt/ControlFlowAnalysis.h"
 
+#include "bishengir/Dialect/Scope/IR/Scope.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
 
@@ -38,13 +39,56 @@ namespace {
 /// Control-flow kinds whose operand/result correspondence is understood by
 /// both the analyzer and the mechanical rewrite.
 static bool isSupportedControlFlow(Operation *op) {
-  return isa<scf::ForOp, scf::WhileOp, scf::IfOp>(op);
+  return isa<scf::ForOp, scf::WhileOp, scf::IfOp, scope::ScopeOp>(op);
+}
+
+/// Scope rewriting deliberately supports only the frontend's single-block,
+/// operand-free form. Validating the complete shape here keeps the later
+/// rewrite mechanical and prevents partially rewriting an unfamiliar Scope
+/// region contract.
+static FailureOr<scope::ReturnOp>
+getSupportedScopeReturn(scope::ScopeOp scopeOp) {
+  if (scopeOp->getNumOperands() != 0 || scopeOp->getNumRegions() != 1)
+    return failure();
+
+  Region &region = scopeOp.getBodyRegion();
+  if (!llvm::hasSingleElement(region))
+    return failure();
+  Block &body = region.front();
+  if (body.getNumArguments() != 0)
+    return failure();
+
+  auto returnOp = dyn_cast<scope::ReturnOp>(body.getTerminator());
+  if (!returnOp || returnOp.getNumOperands() != scopeOp.getNumResults())
+    return failure();
+  for (auto [operand, result] :
+       llvm::zip(returnOp.getOperands(), scopeOp.getResults())) {
+    if (operand.getType() != result.getType())
+      return failure();
+  }
+  return returnOp;
+}
+
+/// Returns true when an identity can be reused while the defining Scope is
+/// replaced. Internal values disappear with the old region and therefore must
+/// be represented by an expanded result instead.
+static bool isDefinedOutsideScope(scope::ScopeOp scopeOp, Value value) {
+  if (!value)
+    return false;
+  if (Operation *definingOp = value.getDefiningOp())
+    return !scopeOp->isAncestor(definingOp);
+
+  auto blockArgument = dyn_cast<BlockArgument>(value);
+  if (!blockArgument)
+    return false;
+  Operation *owner = blockArgument.getOwner()->getParentOp();
+  return owner != scopeOp && (!owner || !scopeOp->isAncestor(owner));
 }
 
 static void setResultIdentity(AnalyzedValue &value, Value result,
                               ArrayRef<unsigned> componentIndices) {
   // A transferred component is represented by the SCF result outside the op;
-  // invariant components retain their incoming symbolic identities.
+  // non-transferred components retain their incoming symbolic identities.
   for (unsigned index : componentIndices)
     value.components[index].identity =
         ComponentIdentity::fromValue(result, index);
@@ -53,7 +97,8 @@ static void setResultIdentity(AnalyzedValue &value, Value result,
 static ControlFlowSlotAnalysis
 makeSlotAnalysis(unsigned oldIndex, unsigned componentCount,
                  ArrayRef<unsigned> componentIndices,
-                 SmallVector<Type> componentTypes) {
+                 SmallVector<Type> componentTypes,
+                 SmallVector<Attribute> resultAttributes) {
   // Preserve the full classification for future Recomputed support while also
   // storing a compact ordered list used by the current signature rewrite.
   ControlFlowSlotAnalysis slot;
@@ -64,6 +109,7 @@ makeSlotAnalysis(unsigned oldIndex, unsigned componentCount,
   slot.componentIndices.append(componentIndices.begin(),
                                componentIndices.end());
   slot.componentTypes = std::move(componentTypes);
+  slot.resultAttributes = std::move(resultAttributes);
   return slot;
 }
 
@@ -120,8 +166,8 @@ void ControlFlowAnalysisContext::bindRegionArgument(
     Value argument, const AnalyzedValue &initial,
     ArrayRef<unsigned> componentIndices) {
   // Only candidate loop components acquire a new identity at region entry.
-  // Policy-owned invariants and non-carried components remain traceable to the
-  // initial descriptor and can therefore be checked at the backedge.
+  // Policy-owned non-carried components remain traceable to the initial
+  // descriptor and can therefore be checked at the backedge.
   AnalyzedValue argumentState = initial;
   for (unsigned index : componentIndices)
     argumentState.components[index].identity =
@@ -231,20 +277,25 @@ ControlFlowAnalysisContext::analyzeFor(Operation *operation) {
       return failure();
 
     AnalyzedValue resultState = *initialStates[index];
-    if (!transferred->empty()) {
-      // The ordered component/type list is the complete contract consumed by
-      // rewriteForOp; rewrite does not rediscover its signature on the fly.
-      FailureOr<SmallVector<Type>> types =
-          getTransferredTypes(*initialStates[index], *next, *transferred);
-      if (failed(types))
-        return failure();
-      for (auto [component, type] : llvm::zip(*transferred, *types))
-        resultState.components[component].type = type;
-      result.slots.push_back(makeSlotAnalysis(index,
-                                              resultState.components.size(),
-                                              *transferred, std::move(*types)));
-      setResultIdentity(resultState, forOp.getResult(index), *transferred);
-    }
+    // A decomposition-target slot remains in the plan even when every
+    // component is invariant. An empty component list means remove the old
+    // pointer slot and rebuild it from the initial descriptor without adding
+    // replacement loop operands/results.
+    FailureOr<SmallVector<Type>> types =
+        getTransferredTypes(*initialStates[index], *next, *transferred);
+    if (failed(types))
+      return failure();
+    FailureOr<SmallVector<Attribute>> resultAttributes =
+        policy.mergeControlFlowAttributes(*initialStates[index], *next);
+    if (failed(resultAttributes))
+      return failure();
+    resultState.attributes = *resultAttributes;
+    for (auto [component, type] : llvm::zip(*transferred, *types))
+      resultState.components[component].type = type;
+    result.slots.push_back(
+        makeSlotAnalysis(index, resultState.components.size(), *transferred,
+                         std::move(*types), std::move(*resultAttributes)));
+    setResultIdentity(resultState, forOp.getResult(index), *transferred);
     analyzedValues[forOp.getResult(index)] = std::move(resultState);
   }
 
@@ -347,24 +398,37 @@ ControlFlowAnalysisContext::analyzeWhile(Operation *operation) {
     llvm::sort(transferred);
 
     AnalyzedValue resultState = *initialStates[index];
-    if (!transferred.empty()) {
-      FailureOr<SmallVector<Type>> types = getTransferredTypes(
-          *initialStates[index], *conditionStates[index], transferred);
-      if (failed(types))
+    FailureOr<SmallVector<Type>> types = getTransferredTypes(
+        *initialStates[index], *conditionStates[index], transferred);
+    if (failed(types))
+      return failure();
+    FailureOr<SmallVector<Attribute>> resultAttributes =
+        policy.mergeControlFlowAttributes(*initialStates[index],
+                                          *conditionStates[index]);
+    if (failed(resultAttributes))
+      return failure();
+    for (auto [component, type] : llvm::zip(transferred, *types)) {
+      FailureOr<Type> joined =
+          policy.joinComponentTypes(type, next->components[component].type);
+      if (failed(joined))
         return failure();
-      for (auto [component, type] : llvm::zip(transferred, *types)) {
-        FailureOr<Type> joined =
-            policy.joinComponentTypes(type, next->components[component].type);
-        if (failed(joined))
-          return failure();
-        type = *joined;
-        resultState.components[component].type = type;
-      }
-      result.slots.push_back(makeSlotAnalysis(index,
-                                              resultState.components.size(),
-                                              transferred, std::move(*types)));
-      setResultIdentity(resultState, whileOp.getResult(index), transferred);
+      type = *joined;
+      resultState.components[component].type = type;
     }
+    // The initial/condition schema is already the fixed point for the common
+    // analyzer. TensorPtr policy metadata is monotone and is joined again
+    // against the yielded state below.
+    AnalyzedValue conditionMergedState = resultState;
+    conditionMergedState.attributes = *resultAttributes;
+    FailureOr<SmallVector<Attribute>> finalAttributes =
+        policy.mergeControlFlowAttributes(conditionMergedState, *next);
+    if (failed(finalAttributes))
+      return failure();
+    resultState.attributes = *finalAttributes;
+    result.slots.push_back(
+        makeSlotAnalysis(index, resultState.components.size(), transferred,
+                         std::move(*types), std::move(*finalAttributes)));
+    setResultIdentity(resultState, whileOp.getResult(index), transferred);
     analyzedValues[whileOp.getResult(index)] = std::move(resultState);
   }
 
@@ -416,19 +480,90 @@ ControlFlowAnalysisContext::analyzeIf(Operation *operation) {
       return failure();
 
     AnalyzedValue resultState = *thenState;
-    if (!transferred->empty()) {
-      FailureOr<SmallVector<Type>> types =
-          getTransferredTypes(*thenState, *elseState, *transferred);
-      if (failed(types))
-        return failure();
-      for (auto [component, type] : llvm::zip(*transferred, *types))
-        resultState.components[component].type = type;
-      result.slots.push_back(makeSlotAnalysis(index,
-                                              resultState.components.size(),
-                                              *transferred, std::move(*types)));
-      setResultIdentity(resultState, opResult, *transferred);
-    }
+    FailureOr<SmallVector<Type>> types =
+        getTransferredTypes(*thenState, *elseState, *transferred);
+    if (failed(types))
+      return failure();
+    FailureOr<SmallVector<Attribute>> resultAttributes =
+        policy.mergeControlFlowAttributes(*thenState, *elseState);
+    if (failed(resultAttributes))
+      return failure();
+    resultState.attributes = *resultAttributes;
+    for (auto [component, type] : llvm::zip(*transferred, *types))
+      resultState.components[component].type = type;
+    result.slots.push_back(
+        makeSlotAnalysis(index, resultState.components.size(), *transferred,
+                         std::move(*types), std::move(*resultAttributes)));
+    setResultIdentity(resultState, opResult, *transferred);
     analyzedValues[opResult] = std::move(resultState);
+  }
+
+  return result;
+}
+
+//===----------------------------------------------------------------------===//
+// scope.scope schema analysis
+//===----------------------------------------------------------------------===//
+
+FailureOr<ControlFlowOpAnalysis>
+ControlFlowAnalysisContext::analyzeScope(Operation *operation) {
+  auto scopeOp = cast<scope::ScopeOp>(operation);
+  FailureOr<scope::ReturnOp> returnOp = getSupportedScopeReturn(scopeOp);
+  if (failed(returnOp))
+    return failure();
+
+  ControlFlowOpAnalysis result;
+  Block &body = scopeOp.getBodyRegion().front();
+  if (failed(analyzeNestedOperations(&body, result.hasNestedRewrite)))
+    return failure();
+
+  // Scope has no incoming region argument and no backedge. Each pointer result
+  // is therefore described by the value returned from the body. The policy
+  // chooses the components that become explicit Scope results; every omitted
+  // component must already name an SSA value defined outside this Scope.
+  for (auto [index, scopeResult] : llvm::enumerate(scopeOp.getResults())) {
+    if (!policy.isDecompositionTarget(scopeResult))
+      continue;
+
+    FailureOr<AnalyzedValue> returned =
+        analyzeValue(returnOp->getOperand(index));
+    if (failed(returned) || returned->originalType != scopeResult.getType())
+      return failure();
+    FailureOr<SmallVector<unsigned>> candidates =
+        policy.getScopeCandidateComponents(*returned);
+    if (failed(candidates))
+      return failure();
+
+    SmallVector<bool> isCandidate(returned->components.size(), false);
+    std::optional<unsigned> previousIndex;
+    for (unsigned componentIndex : *candidates) {
+      if (componentIndex >= returned->components.size() ||
+          (previousIndex && componentIndex <= *previousIndex))
+        return failure();
+      isCandidate[componentIndex] = true;
+      previousIndex = componentIndex;
+    }
+
+    for (auto [componentIndex, component] :
+         llvm::enumerate(returned->components)) {
+      if (isCandidate[componentIndex])
+        continue;
+      if (component.identity.kind != ComponentIdentity::Kind::Value ||
+          !isDefinedOutsideScope(scopeOp, component.identity.value))
+        return failure();
+    }
+
+    SmallVector<Type> componentTypes;
+    componentTypes.reserve(candidates->size());
+    for (unsigned componentIndex : *candidates)
+      componentTypes.push_back(returned->components[componentIndex].type);
+
+    AnalyzedValue resultState = *returned;
+    result.slots.push_back(
+        makeSlotAnalysis(index, resultState.components.size(), *candidates,
+                         std::move(componentTypes), resultState.attributes));
+    setResultIdentity(resultState, scopeResult, *candidates);
+    analyzedValues[scopeResult] = std::move(resultState);
   }
 
   return result;
@@ -454,6 +589,8 @@ ControlFlowAnalysisContext::analyzeControlFlowOp(Operation *op) {
     result = analyzeWhile(op);
   else if (isa<scf::IfOp>(op))
     result = analyzeIf(op);
+  else if (isa<scope::ScopeOp>(op))
+    result = analyzeScope(op);
 
   operationsBeingAnalyzed.erase(op);
   if (failed(result))

--- a/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowRewrite.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowRewrite.cpp
@@ -23,8 +23,10 @@
 #include "TritonControlFlowOpt/ControlFlowRewrite.h"
 #include "Utils/Utils.h"
 
+#include "bishengir/Dialect/Scope/IR/Scope.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
@@ -34,6 +36,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 
+#include <limits>
 #include <optional>
 
 using namespace mlir;
@@ -43,6 +46,8 @@ using mlir::triton::controlflow::ControlFlowRewritePlan;
 using mlir::triton::controlflow::ControlFlowRewritePolicy;
 using mlir::triton::controlflow::ControlFlowSlotAnalysis;
 using mlir::triton::controlflow::DecomposedValue;
+using mlir::triton::controlflow::kPointerDescriptorBoundaryAttr;
+using mlir::triton::controlflow::kPointerDescriptorRebuildAttr;
 
 namespace mlir::triton::controlflow {
 
@@ -61,11 +66,12 @@ const DecomposedValue *ControlFlowRewriteContext::lookup(Value value) const {
 
 namespace {
 
-// Keep the mechanical if/for/while rewrite in one translation unit. These
-// handlers are mutually recursive through rewriteBodyOps(), share one
+// Keep the mechanical structured-control-flow and Scope rewrite in one
+// translation unit. These handlers are mutually recursive through
+// rewriteBodyOps(), share one
 // short-lived RewriteEnv, and must agree on signature expansion, nested-op
 // ordering and failure cleanup. Splitting them by op kind would expose those
-// private invariants through additional internal headers without creating an
+// private constraints through additional internal headers without creating an
 // independently reusable component.
 //
 //===----------------------------------------------------------------------===//
@@ -78,14 +84,14 @@ namespace {
 /// valueMapping answers which new SSA value replaces an old SSA value.
 /// decomposedValues remembers the policy-specific pieces of an old pointer.
 /// policy defines what those pieces mean and how to rebuild the pointer,
-/// while plan says which loop/if operands must be expanded into such pieces.
+/// while plan says which control-flow values must be expanded into such pieces.
 ///
 /// For example, after a block-pointer loop argument is expanded into scalar
 /// offsets, a region-local environment can contain:
 /// valueMapping:      %old_ptr_arg -> %rebuilt_ptr
 /// decomposedValues:  %old_ptr_arg -> {
-///   components = [%shape0, %stride0, %new_offset0],
-///   invariants = [%base], attributes = [order]
+///   components = [%base, %shape0, %stride0, %new_offset0],
+///   attributes = [order]
 /// }
 /// Operations cloned into that region use the mapping, while pointer
 /// decomposition uses the stored components.
@@ -141,8 +147,8 @@ struct RewriteEnv {
   Value remap(Value value) const { return getRewriteContext().remap(value); }
 
   /// Asks the active policy to express one high-level SSA value as the runtime
-  /// components that may cross an expanded scf.for, scf.while, or scf.if
-  /// boundary. value is the original pointer-like SSA value. The policy
+  /// components that may cross an expanded supported control-flow boundary.
+  /// value is the original pointer-like SSA value. The policy
   /// receives the current rewrite context so it can reuse a known decomposition
   /// and remap operands to the replacement IR. It may use builder and loc
   /// to insert scalar address arithmetic at the correct rewrite position.
@@ -152,9 +158,9 @@ struct RewriteEnv {
   /// %next = tt.advance %ptr, [%delta0, %delta1]
   ///
   /// decomposeValue(%next) -> DecomposedValue {
-  ///   components = [%shape0, %shape1, %stride0, %stride1,
+  ///   components = [%base, %shape0, %shape1, %stride0, %stride1,
   ///                 %offset0 + %delta0, %offset1 + %delta1],
-  ///   invariants = [%base], attributes = [order]
+  ///   attributes = [order]
   /// }
   /// The caller can put selected components into a new control-flow signature
   /// or pass the whole descriptor to policy.recompose(). Unsupported values
@@ -208,6 +214,8 @@ struct LoopPointerInfo {
   // Ordered schema decided by ControlFlowSlotAnalysis.
   SmallVector<unsigned> componentIndices;
   SmallVector<Type> componentTypes;
+  // Policy metadata after all loop incoming paths have been normalized.
+  SmallVector<Attribute> resultAttributes;
   // Positions occupied by those components in the replacement operation.
   SmallVector<unsigned> newIndices;
 };
@@ -216,8 +224,117 @@ struct IfPointerInfo {
   unsigned oldIndex = 0;
   SmallVector<unsigned> componentIndices;
   SmallVector<Type> componentTypes;
+  SmallVector<Attribute> resultAttributes;
   std::optional<DecomposedValue> thenInfo;
 };
+
+struct ScopePointerInfo {
+  unsigned oldIndex = 0;
+  SmallVector<unsigned> componentIndices;
+  SmallVector<Type> componentTypes;
+  SmallVector<Attribute> resultAttributes;
+  std::optional<DecomposedValue> returnedInfo;
+};
+
+/// Returns the terminator of the single-block Scope form supported by the
+/// dedicated rewrite. The analyzer already checked these conditions, but the
+/// frozen plan is consumed after analysis, so the rewrite validates them again
+/// before creating replacement IR.
+static FailureOr<scope::ReturnOp>
+getSupportedScopeReturn(scope::ScopeOp scopeOp) {
+  if (scopeOp->getNumOperands() != 0 || scopeOp->getNumRegions() != 1)
+    return failure();
+  Region &region = scopeOp.getBodyRegion();
+  if (!llvm::hasSingleElement(region))
+    return failure();
+  Block &body = region.front();
+  if (body.getNumArguments() != 0)
+    return failure();
+
+  auto returnOp = dyn_cast<scope::ReturnOp>(body.getTerminator());
+  if (!returnOp || returnOp.getNumOperands() != scopeOp.getNumResults())
+    return failure();
+  for (auto [operand, result] :
+       llvm::zip(returnOp.getOperands(), scopeOp.getResults())) {
+    if (operand.getType() != result.getType())
+      return failure();
+  }
+  return returnOp;
+}
+
+// Updates the downstream descriptor marker after a loop signature expansion.
+// Existing slots are remapped through oldToNewStart before slots introduced by
+// the active policy are merged. The array is always expressed in the
+// replacement loop's iter-argument/result coordinate space.
+//
+// Example:
+//   old slots = [1], oldToNewStart = [0, 1, 3]
+//   the active policy expands old slot 2 into new slots [3, 4]
+//   result = [1, 3, 4]
+static LogicalResult updatePointerDescriptorBoundaryMarker(
+    Operation *loop, ArrayRef<LoopPointerInfo> pointerInfos,
+    ArrayRef<unsigned> oldToNewStart, const ControlFlowRewritePolicy &policy) {
+  SmallVector<int32_t> descriptorSlots;
+  bool ownsPointerBoundary = false;
+  llvm::SmallDenseSet<unsigned> seenSlots;
+  auto appendSlot = [&](unsigned slot) -> LogicalResult {
+    if (slot > static_cast<unsigned>(std::numeric_limits<int32_t>::max()))
+      return failure();
+    if (!seenSlots.insert(slot).second)
+      return failure();
+    descriptorSlots.push_back(static_cast<int32_t>(slot));
+    return success();
+  };
+
+  if (Attribute oldMarker = loop->getAttr(kPointerDescriptorBoundaryAttr)) {
+    ownsPointerBoundary = true;
+    auto oldSlots = dyn_cast<DenseI32ArrayAttr>(oldMarker);
+    if (!oldSlots)
+      return failure();
+    for (int32_t oldSlot : oldSlots.asArrayRef()) {
+      if (oldSlot < 0 ||
+          static_cast<unsigned>(oldSlot) >= oldToNewStart.size() ||
+          failed(appendSlot(oldToNewStart[oldSlot])))
+        return failure();
+    }
+  }
+
+  if (policy.requiresPointerDescriptorBoundaryMarker()) {
+    ownsPointerBoundary |= !pointerInfos.empty();
+    for (const LoopPointerInfo &pointerInfo : pointerInfos) {
+      for (unsigned newSlot : pointerInfo.newIndices) {
+        if (failed(appendSlot(newSlot)))
+          return failure();
+      }
+    }
+  }
+
+  if (!ownsPointerBoundary) {
+    loop->removeAttr(kPointerDescriptorBoundaryAttr);
+    return success();
+  }
+  llvm::sort(descriptorSlots);
+  loop->setAttr(kPointerDescriptorBoundaryAttr,
+                DenseI32ArrayAttr::get(loop->getContext(), descriptorSlots));
+  return success();
+}
+
+// Marks policy-created pointer descriptor reconstructions. Their defining
+// operation consumes the complete descriptor, including invariant components
+// omitted from a replacement SCF signature. TritonToLinalg uses these operands
+// as precise preservation roots and removes the marker after conversion.
+static LogicalResult
+markPointerDescriptorRebuild(Value rebuiltPointer, const DecomposedValue &value,
+                             const ControlFlowRewritePolicy &policy) {
+  if (!policy.requiresPointerDescriptorBoundaryMarker())
+    return success();
+  Operation *definingOp = rebuiltPointer.getDefiningOp();
+  if (!definingOp)
+    return failure();
+  definingOp->setAttr(kPointerDescriptorRebuildAttr,
+                      UnitAttr::get(definingOp->getContext()));
+  return policy.annotatePointerDescriptorRebuild(definingOp, value);
+}
 
 // Copies the values selected by indices into a new owning vector while
 // preserving their input order. Indices must be unique and in bounds; this
@@ -245,9 +362,9 @@ static FailureOr<SmallVector<Value>> gatherValues(ValueRange sourceValues,
 // replacement changes the component type; the input object remains unchanged.
 //
 // Example:
-//   decomposition.components = [shape, stride, originalOffset]
-//   componentIndices = [2], replacements = [nextOffset]
-//   result.components = [shape, stride, nextOffset]
+//   decomposition.components = [base, shape, stride, originalOffset]
+//   componentIndices = [3], replacements = [nextOffset]
+//   result.components = [base, shape, stride, nextOffset]
 static FailureOr<DecomposedValue>
 withReplacedComponents(DecomposedValue decomposition,
                        ArrayRef<unsigned> componentIndices,
@@ -306,10 +423,13 @@ static auto findPointerInfoByOldIndex(InfoRange &pointerInfos,
   return nullptr;
 }
 
-// A replacement loop carries selected scalar or tensor descriptor components
-// instead of the original pointer iter-argument. Operations cloned from the
-// original body still expect one pointer-typed block argument, so this function
-// reconstructs that pointer at the replacement region entry.
+// A replacement loop carries policy-selected scalar or tensor descriptor
+// components instead of the original pointer iter-argument. BlockPtr selects
+// every component that analysis found dynamic; TensorPtr selects only the
+// base/offset fields whose symbolic identities change at that boundary.
+// Operations cloned from the original body still expect one pointer-typed
+// block argument, so this function reconstructs that pointer at the replacement
+// region entry.
 // `pointerInfo.newIndices` selects the current component values from
 // `newRegionArguments`, while
 // `pointerInfo.componentIndices` identifies the descriptor fields that those
@@ -323,17 +443,17 @@ static auto findPointerInfoByOldIndex(InfoRange &pointerInfos,
 //
 // Example:
 //   oldRegionArgument = %old_ptr
-//   newRegionArguments = [%ordinary, %current_offset0, %current_offset1]
-//   pointerInfo.newIndices = [1, 2]
-//   pointerInfo.componentIndices = [4, 5]
+//   newRegionArguments = [%ordinary, %base, %shape, %stride, %offset]
+//   pointerInfo.newIndices = [1, 2, 3, 4]
+//   pointerInfo.componentIndices = [0, 1, 2, 3]
 //   pointerInfo.initInfo.components =
-//       [shape0, shape1, stride0, stride1, initial_offset0, initial_offset1]
+//       [initial_base, initial_shape, initial_stride, initial_offset]
 //
-// The rebuilt descriptor keeps shape and stride, replaces the final two
-// components with the current offsets, and records `%old_ptr -> %rebuilt_ptr`
-// in `regionEnv`. Invalid indices, incompatible component types, or a policy
-// that cannot recompose the descriptor return failure without recording a
-// partial binding; the enclosing loop rewrite owns cleanup of inserted IR.
+// The rebuilt BlockPtr descriptor replaces all four fields with the current
+// loop values and records `%old_ptr -> %rebuilt_ptr` in `regionEnv`. Invalid
+// indices, incompatible component types, or a policy that cannot recompose the
+// descriptor return failure without recording a partial binding; the enclosing
+// loop rewrite owns cleanup of inserted IR.
 static LogicalResult bindLoopCarriedPointer(Value oldRegionArgument,
                                             const LoopPointerInfo &pointerInfo,
                                             ValueRange newRegionArguments,
@@ -347,12 +467,15 @@ static LogicalResult bindLoopCarriedPointer(Value oldRegionArgument,
   FailureOr<DecomposedValue> argumentInfo =
       withReplacedComponents(pointerInfo.initInfo, pointerInfo.componentIndices,
                              *carriedComponentValues);
-  if (failed(argumentInfo))
+  if (failed(argumentInfo) ||
+      failed(regionEnv.policy.normalizeControlFlowValue(
+          *argumentInfo, pointerInfo.resultAttributes, builder, loc)))
     return failure();
 
   Value rebuiltPointer =
       regionEnv.policy.recompose(*argumentInfo, builder, loc);
-  if (!rebuiltPointer)
+  if (!rebuiltPointer || failed(markPointerDescriptorRebuild(
+                             rebuiltPointer, *argumentInfo, regionEnv.policy)))
     return failure();
 
   regionEnv.recordDecomposition(oldRegionArgument, *argumentInfo,
@@ -416,16 +539,19 @@ static LogicalResult bindLoopRegionArguments(
 // Example:
 //   oldOperands = [%next_ptr, %sum]
 //   pointerInfo = {
-//     oldIndex = 0, componentIndices = [4, 5], newIndices = [0, 1]
+//     oldIndex = 0, componentIndices = [0, 1, 2, 3],
+//     newIndices = [0, 1, 2, 3]
 //   }
-//   currentRegionArguments = [%current_offset0, %current_offset1, %sum_arg]
+//   currentRegionArguments =
+//       [%current_base, %current_shape, %current_stride, %current_offset,
+//        %sum_arg]
 //
 // A valid `%next_ptr` decomposition produces
-// `[%next_offset0, %next_offset1, %mapped_sum]`. If pointer decomposition or
-// component normalization fails, the output instead uses
-// `[%current_offset0, %current_offset1, %mapped_sum]`. The fallback keeps the
-// temporary scf.yield/scf.condition structurally complete until the enclosing
-// failed loop rewrite erases it.
+// `[%next_base, %next_shape, %next_stride, %next_offset, %mapped_sum]`. If
+// pointer decomposition or component normalization fails, the output instead
+// uses the four current descriptor arguments followed by `%mapped_sum`. The
+// fallback keeps the temporary scf.yield/scf.condition structurally complete
+// until the enclosing failed loop rewrite erases it.
 //
 // The output vector is separate from the LogicalResult intentionally. The
 // function visits every old operand and fills all available fallback positions
@@ -453,9 +579,12 @@ static LogicalResult rewriteLoopTerminatorOperands(
 
     FailureOr<DecomposedValue> nextInfo =
         regionEnv.decomposeValue(oldOperand, builder, loc);
-    if (failed(nextInfo) || failed(castPlannedComponents(
-                                *nextInfo, pointerInfo->componentIndices,
-                                pointerInfo->componentTypes, builder, loc))) {
+    if (failed(nextInfo) ||
+        failed(castPlannedComponents(*nextInfo, pointerInfo->componentIndices,
+                                     pointerInfo->componentTypes, builder,
+                                     loc)) ||
+        failed(regionEnv.policy.normalizeControlFlowValue(
+            *nextInfo, pointerInfo->resultAttributes, builder, loc))) {
       allOperandsValid = false;
       appendFallbackComponents(*pointerInfo);
       continue;
@@ -484,15 +613,17 @@ static LogicalResult rewriteLoopTerminatorOperands(
 //
 // Example:
 //   oldResults = [%old_sum, %old_ptr, %old_flag]
-//   newResults = [%new_sum, %offset0, %offset1, %new_flag]
+//   newResults =
+//       [%new_sum, %base, %shape, %stride, %offset, %new_flag]
 //   pointerInfo = {
-//     oldIndex = 1, componentIndices = [4, 5], newIndices = [1, 2]
+//     oldIndex = 1, componentIndices = [0, 1, 2, 3],
+//     newIndices = [1, 2, 3, 4]
 //   }
-//   oldToNewStart = [0, 1, 3]
+//   oldToNewStart = [0, 1, 5]
 //
 // The function maps `%old_sum -> %new_sum` and `%old_flag -> %new_flag`. It
-// inserts `%offset0` and `%offset1` into the pointer descriptor, rebuilds
-// `%old_ptr`, and records `%old_ptr -> %rebuilt_ptr` plus that decomposition.
+// inserts all four results into the pointer descriptor, rebuilds `%old_ptr`,
+// and records `%old_ptr -> %rebuilt_ptr` plus that decomposition.
 //
 // The caller must set the builder insertion point after the replacement loop,
 // so any rebuilt pointer dominates later operations. On failure this function
@@ -518,12 +649,15 @@ rebuildAndMapLoopResults(ValueRange oldResults, ValueRange newResults,
     FailureOr<DecomposedValue> resultInfo = withReplacedComponents(
         pointerInfo->initInfo, pointerInfo->componentIndices,
         *resultComponentValues);
-    if (failed(resultInfo))
+    if (failed(resultInfo) || failed(env.policy.normalizeControlFlowValue(
+                                  *resultInfo, pointerInfo->resultAttributes,
+                                  builder, oldResult.getLoc())))
       return failure();
 
     Value rebuiltPointer =
         env.policy.recompose(*resultInfo, builder, oldResult.getLoc());
-    if (!rebuiltPointer)
+    if (!rebuiltPointer || failed(markPointerDescriptorRebuild(
+                               rebuiltPointer, *resultInfo, env.policy)))
       return failure();
 
     env.recordDecomposition(oldResult, *resultInfo, rebuiltPointer);
@@ -563,6 +697,9 @@ static LogicalResult materializePointerResult(Operation &originalOp,
     Value rebuilt = env.policy.recompose(*info, builder, oldResult.getLoc());
     if (!rebuilt)
       return failure();
+    if (env.policy.shouldMarkOperationRecomposition(&originalOp) &&
+        failed(markPointerDescriptorRebuild(rebuilt, *info, env.policy)))
+      return failure();
     env.recordDecomposition(oldResult, *info, rebuilt);
   }
 
@@ -581,7 +718,7 @@ static LogicalResult rewriteBodyOps(Block *oldBlock, OpBuilder &builder,
   // recursively with the same policy; ordinary operations are cloned through
   // the current SSA mapping.
   for (Operation &originalOp : oldBlock->without_terminator()) {
-    if (isa<scf::ForOp, scf::WhileOp, scf::IfOp>(originalOp)) {
+    if (isa<scf::ForOp, scf::WhileOp, scf::IfOp, scope::ScopeOp>(originalOp)) {
       const ControlFlowOpAnalysis *analysis = env.plan.lookup(&originalOp);
       if (!analysis)
         return failure();
@@ -620,12 +757,19 @@ static LogicalResult rewriteForOp(scf::ForOp forOp, OpBuilder &builder,
 
     FailureOr<DecomposedValue> initInfo =
         env.decomposeValue(forOp.getInitArgs()[idx], builder, forOp.getLoc());
-    if (failed(initInfo) || failed(castPlannedComponents(
-                                *initInfo, slot.componentIndices,
-                                slot.componentTypes, builder, forOp.getLoc())))
+    if (failed(initInfo) ||
+        failed(env.policy.normalizeControlFlowValue(
+            *initInfo, slot.resultAttributes, builder, forOp.getLoc())) ||
+        failed(castPlannedComponents(*initInfo, slot.componentIndices,
+                                     slot.componentTypes, builder,
+                                     forOp.getLoc())))
       return failure();
-    pointerInfos.push_back(LoopPointerInfo{
-        idx, *initInfo, slot.componentIndices, slot.componentTypes, {}});
+    pointerInfos.push_back(LoopPointerInfo{idx,
+                                           *initInfo,
+                                           slot.componentIndices,
+                                           slot.componentTypes,
+                                           slot.resultAttributes,
+                                           {}});
   }
 
   SmallVector<Value> newInitArgs;
@@ -675,6 +819,12 @@ static LogicalResult rewriteForOp(scf::ForOp forOp, OpBuilder &builder,
         bodyBuilder.create<scf::YieldOp>(yieldOp.getLoc(), newYieldOperands);
       });
   newForOp->setAttrs(forOp->getAttrs());
+  if (analysis->rewritesOwnSignature() &&
+      failed(updatePointerDescriptorBoundaryMarker(
+          newForOp, pointerInfos, oldToNewStart, env.policy))) {
+    newForOp.erase();
+    return failure();
+  }
 
   if (!bodyOk) {
     newForOp.erase();
@@ -718,12 +868,18 @@ static LogicalResult rewriteWhileOp(scf::WhileOp whileOp, OpBuilder &builder,
     FailureOr<DecomposedValue> initInfo =
         env.decomposeValue(whileOp.getInits()[idx], builder, whileOp.getLoc());
     if (failed(initInfo) ||
+        failed(env.policy.normalizeControlFlowValue(
+            *initInfo, slot.resultAttributes, builder, whileOp.getLoc())) ||
         failed(castPlannedComponents(*initInfo, slot.componentIndices,
                                      slot.componentTypes, builder,
                                      whileOp.getLoc())))
       return failure();
-    pointerInfos.push_back(LoopPointerInfo{
-        idx, *initInfo, slot.componentIndices, slot.componentTypes, {}});
+    pointerInfos.push_back(LoopPointerInfo{idx,
+                                           *initInfo,
+                                           slot.componentIndices,
+                                           slot.componentTypes,
+                                           slot.resultAttributes,
+                                           {}});
   }
 
   // Expand inits and result types in lockstep. oldToNewStart keeps untouched
@@ -797,6 +953,12 @@ static LogicalResult rewriteWhileOp(scf::WhileOp whileOp, OpBuilder &builder,
         bodyBuilder.create<scf::YieldOp>(yieldOp.getLoc(), newYieldOperands);
       });
   newWhileOp->setAttrs(whileOp->getAttrs());
+  if (analysis->rewritesOwnSignature() &&
+      failed(updatePointerDescriptorBoundaryMarker(
+          newWhileOp, pointerInfos, oldToNewStart, env.policy))) {
+    newWhileOp.erase();
+    return failure();
+  }
 
   if (!bodyOk) {
     newWhileOp.erase();
@@ -836,7 +998,8 @@ static LogicalResult rewriteIfOp(scf::IfOp ifOp, OpBuilder &builder,
         slot.componentIndices.size() != slot.componentTypes.size())
       return failure();
     pointerInfos.push_back(IfPointerInfo{slot.oldIndex, slot.componentIndices,
-                                         slot.componentTypes, std::nullopt});
+                                         slot.componentTypes,
+                                         slot.resultAttributes, std::nullopt});
   }
 
   // Expand only result positions selected by analysis. An if with no pointer
@@ -871,7 +1034,10 @@ static LogicalResult rewriteIfOp(scf::IfOp ifOp, OpBuilder &builder,
         if (failed(branchInfo) ||
             failed(castPlannedComponents(*branchInfo, info->componentIndices,
                                          info->componentTypes, branchBuilder,
-                                         oldYield.getLoc())))
+                                         oldYield.getLoc())) ||
+            failed(branchEnv.policy.normalizeControlFlowValue(
+                *branchInfo, info->resultAttributes, branchBuilder,
+                oldYield.getLoc())))
           return failure();
         if (isThen)
           info->thenInfo = *branchInfo;
@@ -939,13 +1105,16 @@ static LogicalResult rewriteIfOp(scf::IfOp ifOp, OpBuilder &builder,
         componentValues.push_back(newIfOp.getResult(newResultIndex++));
       FailureOr<DecomposedValue> resultInfo = withReplacedComponents(
           *info->thenInfo, info->componentIndices, componentValues);
-      if (failed(resultInfo)) {
+      if (failed(resultInfo) || failed(env.policy.normalizeControlFlowValue(
+                                    *resultInfo, info->resultAttributes,
+                                    builder, oldResult.getLoc()))) {
         newIfOp.erase();
         return failure();
       }
       Value rebuilt =
           env.policy.recompose(*resultInfo, builder, oldResult.getLoc());
-      if (!rebuilt) {
+      if (!rebuilt || failed(markPointerDescriptorRebuild(rebuilt, *resultInfo,
+                                                          env.policy))) {
         newIfOp.erase();
         return failure();
       }
@@ -955,6 +1124,178 @@ static LogicalResult rewriteIfOp(scf::IfOp ifOp, OpBuilder &builder,
     env.valueMapping.map(oldResult, newIfOp.getResult(newResultIndex++));
   }
 
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// scope.scope rewrite
+//===----------------------------------------------------------------------===//
+
+/// Erases the replacement Scope and any pointer reconstruction operations
+/// inserted between it and the original Scope. Body-local operations disappear
+/// with the replacement region; post-Scope operations are erased in reverse
+/// order so their SSA dependencies remain valid during cleanup.
+static void eraseScopeReplacement(scope::ScopeOp replacement,
+                                  scope::ScopeOp original) {
+  SmallVector<Operation *> followingOperations;
+  for (Operation *operation = replacement->getNextNode();
+       operation && operation != original.getOperation();
+       operation = operation->getNextNode())
+    followingOperations.push_back(operation);
+  for (Operation *operation : llvm::reverse(followingOperations))
+    operation->erase();
+  replacement.erase();
+}
+
+static LogicalResult rewriteScopeOp(scope::ScopeOp scopeOp, OpBuilder &builder,
+                                    RewriteEnv &env) {
+  const ControlFlowOpAnalysis *analysis = env.plan.lookup(scopeOp);
+  FailureOr<scope::ReturnOp> oldReturn = getSupportedScopeReturn(scopeOp);
+  if (!analysis || !analysis->needsRewrite() || failed(oldReturn))
+    return failure();
+
+  SmallVector<ScopePointerInfo, 0> pointerInfos;
+  llvm::SmallDenseSet<unsigned> claimedResultIndices;
+  pointerInfos.reserve(analysis->slots.size());
+  for (const ControlFlowSlotAnalysis &slot : analysis->slots) {
+    if (slot.oldIndex >= scopeOp.getNumResults() ||
+        slot.componentIndices.size() != slot.componentTypes.size() ||
+        !claimedResultIndices.insert(slot.oldIndex).second ||
+        !env.policy.isDecompositionTarget(scopeOp.getResult(slot.oldIndex)))
+      return failure();
+    pointerInfos.push_back(ScopePointerInfo{
+        slot.oldIndex, slot.componentIndices, slot.componentTypes,
+        slot.resultAttributes, std::nullopt});
+  }
+
+  SmallVector<Type> newResultTypes;
+  for (auto [oldIndex, oldResult] : llvm::enumerate(scopeOp.getResults())) {
+    if (const ScopePointerInfo *pointerInfo =
+            findPointerInfoByOldIndex(pointerInfos, oldIndex)) {
+      newResultTypes.append(pointerInfo->componentTypes.begin(),
+                            pointerInfo->componentTypes.end());
+      continue;
+    }
+    newResultTypes.push_back(oldResult.getType());
+  }
+
+  auto newScope =
+      builder.create<scope::ScopeOp>(scopeOp.getLoc(), newResultTypes);
+  newScope->setAttrs(scopeOp->getAttrs());
+  // PointerDescriptorBoundary describes loop-carried slot positions and has no
+  // meaning for an operand-free Scope result boundary.
+  newScope->removeAttr(kPointerDescriptorBoundaryAttr);
+  newScope.getBodyRegion().emplaceBlock();
+
+  bool bodyOk = true;
+  {
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToEnd(&newScope.getBodyRegion().front());
+    RewriteEnv scopeEnv = env;
+    if (failed(rewriteBodyOps(&scopeOp.getBodyRegion().front(), builder,
+                              scopeEnv))) {
+      bodyOk = false;
+    } else {
+      SmallVector<Value> newReturnOperands;
+      newReturnOperands.reserve(newResultTypes.size());
+      for (auto [oldIndex, oldOperand] :
+           llvm::enumerate(oldReturn->getOperands())) {
+        ScopePointerInfo *pointerInfo =
+            findPointerInfoByOldIndex(pointerInfos, oldIndex);
+        if (!pointerInfo) {
+          newReturnOperands.push_back(scopeEnv.remap(oldOperand));
+          continue;
+        }
+
+        FailureOr<DecomposedValue> returnedInfo =
+            scopeEnv.decomposeValue(oldOperand, builder, oldReturn->getLoc());
+        if (failed(returnedInfo) ||
+            failed(castPlannedComponents(
+                *returnedInfo, pointerInfo->componentIndices,
+                pointerInfo->componentTypes, builder, oldReturn->getLoc())) ||
+            failed(scopeEnv.policy.normalizeControlFlowValue(
+                *returnedInfo, pointerInfo->resultAttributes, builder,
+                oldReturn->getLoc()))) {
+          bodyOk = false;
+          break;
+        }
+
+        FailureOr<SmallVector<Value>> returnedComponents = gatherValues(
+            returnedInfo->components, pointerInfo->componentIndices);
+        if (failed(returnedComponents)) {
+          bodyOk = false;
+          break;
+        }
+        pointerInfo->returnedInfo = *returnedInfo;
+        newReturnOperands.append(returnedComponents->begin(),
+                                 returnedComponents->end());
+      }
+
+      if (bodyOk)
+        builder.create<scope::ReturnOp>(oldReturn->getLoc(), newReturnOperands);
+    }
+  }
+
+  if (!bodyOk) {
+    eraseScopeReplacement(newScope, scopeOp);
+    return failure();
+  }
+
+  // Pointer values are reconstructed immediately outside Scope. Scope itself
+  // returns only policy-selected components and deliberately does not receive
+  // PointerDescriptorBoundary; the reconstruction operation remains the
+  // precise downstream ownership marker.
+  builder.setInsertionPointAfter(newScope);
+  unsigned newResultIndex = 0;
+  for (auto [oldIndex, oldResult] : llvm::enumerate(scopeOp.getResults())) {
+    ScopePointerInfo *pointerInfo =
+        findPointerInfoByOldIndex(pointerInfos, oldIndex);
+    if (!pointerInfo) {
+      if (newResultIndex >= newScope.getNumResults()) {
+        eraseScopeReplacement(newScope, scopeOp);
+        return failure();
+      }
+      env.valueMapping.map(oldResult, newScope.getResult(newResultIndex++));
+      continue;
+    }
+
+    if (!pointerInfo->returnedInfo ||
+        newResultIndex + pointerInfo->componentIndices.size() >
+            newScope.getNumResults()) {
+      eraseScopeReplacement(newScope, scopeOp);
+      return failure();
+    }
+    SmallVector<Value> componentValues;
+    componentValues.reserve(pointerInfo->componentIndices.size());
+    for (unsigned componentIndex = 0;
+         componentIndex < pointerInfo->componentIndices.size();
+         ++componentIndex)
+      componentValues.push_back(newScope.getResult(newResultIndex++));
+
+    FailureOr<DecomposedValue> resultInfo =
+        withReplacedComponents(*pointerInfo->returnedInfo,
+                               pointerInfo->componentIndices, componentValues);
+    if (failed(resultInfo) || failed(env.policy.normalizeControlFlowValue(
+                                  *resultInfo, pointerInfo->resultAttributes,
+                                  builder, oldResult.getLoc()))) {
+      eraseScopeReplacement(newScope, scopeOp);
+      return failure();
+    }
+
+    Value rebuilt =
+        env.policy.recompose(*resultInfo, builder, oldResult.getLoc());
+    if (!rebuilt || failed(markPointerDescriptorRebuild(rebuilt, *resultInfo,
+                                                        env.policy))) {
+      eraseScopeReplacement(newScope, scopeOp);
+      return failure();
+    }
+    env.recordDecomposition(oldResult, *resultInfo, rebuilt);
+  }
+
+  if (newResultIndex != newScope.getNumResults()) {
+    eraseScopeReplacement(newScope, scopeOp);
+    return failure();
+  }
   return success();
 }
 
@@ -969,8 +1310,8 @@ static LogicalResult rewriteControlFlowOp(Operation *op, OpBuilder &builder,
     return rewriteWhileOp(whileOp, builder, env);
   if (auto ifOp = dyn_cast<scf::IfOp>(op))
     return rewriteIfOp(ifOp, builder, env);
-  // TODO: Add the frontend-produced scope.scope operation here. Scope support
-  // belongs in this shared plumbing rather than in both decompositions.
+  if (auto scopeOp = dyn_cast<scope::ScopeOp>(op))
+    return rewriteScopeOp(scopeOp, builder, env);
   return failure();
 }
 
@@ -1016,10 +1357,9 @@ tryDecoupleControlFlowOp(Operation *op, IRRewriter &rewriter,
 
 namespace mlir::triton::controlflow {
 
-LogicalResult
-applyControlFlowRewritePlan(ModuleOp module,
-                            const ControlFlowRewritePolicy &policy,
-                            const ControlFlowRewritePlan &plan) {
+LogicalResult applyControlFlowRewritePlan(
+    ModuleOp module, const ControlFlowRewritePolicy &policy,
+    const ControlFlowRewritePlan &plan, bool emitDiagnostics) {
   IRRewriter rewriter(module.getContext());
   // Analysis and application are consecutive and no IR mutation occurs in
   // between, so rediscover the roots from the module instead of duplicating
@@ -1027,13 +1367,15 @@ applyControlFlowRewritePlan(ModuleOp module,
   for (Operation *root : collectOutermostControlFlowOps(module)) {
     const ControlFlowOpAnalysis *rootAnalysis = plan.lookup(root);
     if (!rootAnalysis) {
-      root->emitError("missing frozen control-flow rewrite decision");
+      if (emitDiagnostics)
+        root->emitError("missing frozen control-flow rewrite decision");
       return failure();
     }
     if (!rootAnalysis->needsRewrite())
       continue;
     if (failed(tryDecoupleControlFlowOp(root, rewriter, policy, plan))) {
-      root->emitError("failed to apply analyzed pointer decomposition");
+      if (emitDiagnostics)
+        root->emitError("failed to apply analyzed pointer decomposition");
       return failure();
     }
   }
@@ -1041,7 +1383,32 @@ applyControlFlowRewritePlan(ModuleOp module,
 }
 
 LogicalResult rewriteControlFlow(ModuleOp module,
-                                 const ControlFlowRewritePolicy &policy) {
+                                 const ControlFlowRewritePolicy &policy,
+                                 bool allowUnsupportedFallback) {
+  // Tensor-pointer decomposition is an optimization, not the only legal
+  // representation of a TensorPtr. Probe the complete rewrite on a detached
+  // clone before mutating the real module. If analysis or application rejects
+  // any root, discard the clone and keep the original TensorPtr graph intact;
+  // this prevents a partially materialized descriptor from reaching T2L.
+  if (allowUnsupportedFallback) {
+    Operation *probeOperation = module->clone();
+    auto probeModule = cast<ModuleOp>(probeOperation);
+    bool probeSucceeded = false;
+    {
+      ScopedDiagnosticHandler suppressDiagnostics(
+          module.getContext(), [](Diagnostic &) { return success(); });
+      FailureOr<ControlFlowRewritePlan> probePlan =
+          analyzeControlFlow(probeModule, policy);
+      probeSucceeded =
+          succeeded(probePlan) &&
+          succeeded(applyControlFlowRewritePlan(probeModule, policy, *probePlan,
+                                                /*emitDiagnostics=*/false));
+    }
+    probeModule->erase();
+    if (!probeSucceeded)
+      return success();
+  }
+
   FailureOr<ControlFlowRewritePlan> plan = analyzeControlFlow(module, policy);
   if (failed(plan))
     return failure();

--- a/third_party/ascend/lib/TritonControlFlowOpt/TensorPtrDecompose.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/TensorPtrDecompose.cpp
@@ -26,7 +26,15 @@
 #include "Utils/Utils.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Matchers.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/STLExtras.h"
+
+#include <limits>
+#include <optional>
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -34,28 +42,90 @@ using namespace mlir::triton::controlflow;
 
 namespace {
 
-static constexpr unsigned kOffsetsComponent = 0;
-static constexpr unsigned kBaseInvariant = 0;
+static constexpr unsigned kBaseComponent = 0;
+static constexpr unsigned kStrideComponent = 1;
+static constexpr unsigned kOffsetComponent = 2;
+static constexpr unsigned kResidualComponent = 3;
 static constexpr unsigned kBaseIsScalarAttribute = 0;
+static constexpr unsigned kAxisKindsAttribute = 1;
 
-/// Identifies tensor-of-pointers handled by this stage:
-/// `tensor<...x!tt.ptr<T>>`. A block pointer has the different scalar type
-/// `!tt.ptr<tensor<...xT>>` and is handled by BlockPtrDecompose.
+enum class AxisKind : int32_t { Opaque = 0, Structured = 1 };
+
+static constexpr unsigned getStrideComponent(unsigned axis) {
+  return kBaseComponent + 1 + axis;
+}
+
+static constexpr unsigned getUniformOffsetComponent(unsigned rank) {
+  return kBaseComponent + 1 + rank;
+}
+
+static constexpr unsigned getOpaqueContributionComponent(unsigned rank) {
+  return getUniformOffsetComponent(rank) + 1;
+}
+
+static SmallVector<AxisKind> getAxisKinds(unsigned rank, AxisKind kind) {
+  return SmallVector<AxisKind>(rank, kind);
+}
+
+static DenseI32ArrayAttr getAxisKindsAttr(MLIRContext *context,
+                                          ArrayRef<AxisKind> kinds) {
+  SmallVector<int32_t> values;
+  values.reserve(kinds.size());
+  for (AxisKind kind : kinds)
+    values.push_back(static_cast<int32_t>(kind));
+  return DenseI32ArrayAttr::get(context, values);
+}
+
+template <typename StateT>
+static FailureOr<SmallVector<AxisKind>> getAxisKinds(const StateT &value) {
+  auto pointerTensor = dyn_cast<RankedTensorType>(value.originalType);
+  if (!pointerTensor || value.attributes.size() != 2)
+    return failure();
+  auto attribute =
+      dyn_cast<DenseI32ArrayAttr>(value.attributes[kAxisKindsAttribute]);
+  if (!attribute || static_cast<int64_t>(attribute.asArrayRef().size()) !=
+                        pointerTensor.getRank())
+    return failure();
+  SmallVector<AxisKind> kinds;
+  kinds.reserve(attribute.asArrayRef().size());
+  for (int32_t rawKind : attribute.asArrayRef()) {
+    if (rawKind != static_cast<int32_t>(AxisKind::Opaque) &&
+        rawKind != static_cast<int32_t>(AxisKind::Structured))
+      return failure();
+    kinds.push_back(static_cast<AxisKind>(rawKind));
+  }
+  return kinds;
+}
+
 static bool isTensorPointerType(Type type) {
   auto tensorType = dyn_cast<RankedTensorType>(type);
   return tensorType && isa<triton::PointerType>(tensorType.getElementType());
 }
 
-/// Tensor-pointer state used only by this policy:
-///
-///   control-flow components = [complete_offsets]
-///   rewrite-only invariants = [common_base]
-///   attributes = [base_is_scalar]
-///
-/// Only `components` expand an SCF signature. The common base is deliberately
-/// kept out of iter-args and results; it must be identical at every incoming
-/// edge and is used to rebuild the tensor-of-pointers inside and after the
-/// rewritten control-flow operation.
+static bool isCompatiblePointerBroadcast(Type sourceType, Type resultType) {
+  auto sourceTensor = dyn_cast<RankedTensorType>(sourceType);
+  auto resultTensor = dyn_cast<RankedTensorType>(resultType);
+  if (!sourceTensor || !resultTensor || !isTensorPointerType(sourceType) ||
+      !isTensorPointerType(resultType) ||
+      sourceTensor.getRank() != resultTensor.getRank() ||
+      sourceTensor.getElementType() != resultTensor.getElementType() ||
+      sourceTensor.getEncoding() != resultTensor.getEncoding())
+    return false;
+
+  for (auto [sourceExtent, resultExtent] :
+       llvm::zip(sourceTensor.getShape(), resultTensor.getShape())) {
+    if (sourceExtent != resultExtent && sourceExtent != 1)
+      return false;
+  }
+  return true;
+}
+
+static bool isRankOneTensorPointer(Type type) {
+  auto tensorType = dyn_cast<RankedTensorType>(type);
+  return tensorType && tensorType.getRank() == 1 &&
+         isa<triton::PointerType>(tensorType.getElementType());
+}
+
 static RankedTensorType getDefaultOffsetsType(Type pointerType) {
   auto pointerTensor = cast<RankedTensorType>(pointerType);
   return RankedTensorType::get(pointerTensor.getShape(),
@@ -63,100 +133,443 @@ static RankedTensorType getDefaultOffsetsType(Type pointerType) {
                                pointerTensor.getEncoding());
 }
 
-/// Validates the policy-owned component layout, including the offsets shape
-/// and the representation selected for the invariant base.
-static bool hasValidSchema(Type originalType, Type offsetsType,
-                           ArrayRef<Value> invariants,
+static bool isCompatibleOffsetTensor(Type pointerType, Type offsetType) {
+  auto pointerTensor = dyn_cast<RankedTensorType>(pointerType);
+  auto offsetTensor = dyn_cast<RankedTensorType>(offsetType);
+  return pointerTensor && offsetTensor &&
+         pointerTensor.getShape() == offsetTensor.getShape() &&
+         pointerTensor.getEncoding() == offsetTensor.getEncoding() &&
+         isa<IntegerType>(offsetTensor.getElementType());
+}
+
+static bool hasValidSchema(Type originalType, TypeRange componentTypes,
                            ArrayRef<Attribute> attributes) {
   auto pointerTensor = dyn_cast<RankedTensorType>(originalType);
-  auto offsetsTensor = dyn_cast<RankedTensorType>(offsetsType);
-  if (!pointerTensor || !offsetsTensor || invariants.size() != 1 ||
-      attributes.size() != 1 ||
-      !isa<triton::PointerType>(pointerTensor.getElementType()) ||
-      !isa<IntegerType>(offsetsTensor.getElementType()) ||
-      pointerTensor.getShape() != offsetsTensor.getShape() ||
-      pointerTensor.getEncoding() != offsetsTensor.getEncoding())
+  if (!pointerTensor || !isTensorPointerType(originalType) ||
+      attributes.size() != 2)
     return false;
 
   auto baseIsScalar = dyn_cast<BoolAttr>(attributes[kBaseIsScalarAttribute]);
   if (!baseIsScalar)
     return false;
-  Type expectedBaseType =
-      baseIsScalar.getValue() ? pointerTensor.getElementType() : originalType;
-  return invariants[kBaseInvariant].getType() == expectedBaseType;
+  Type expectedBaseType = baseIsScalar.getValue()
+                              ? IntegerType::get(originalType.getContext(), 64)
+                              : originalType;
+  unsigned rank = pointerTensor.getRank();
+  if (rank == 0 || componentTypes.size() != rank + 3 ||
+      componentTypes[kBaseComponent] != expectedBaseType)
+    return false;
+
+  auto axisKinds = dyn_cast<DenseI32ArrayAttr>(attributes[kAxisKindsAttribute]);
+  if (!axisKinds || axisKinds.asArrayRef().size() != rank)
+    return false;
+  for (int32_t kind : axisKinds.asArrayRef()) {
+    if (kind != static_cast<int32_t>(AxisKind::Opaque) &&
+        kind != static_cast<int32_t>(AxisKind::Structured))
+      return false;
+  }
+
+  auto uniformType =
+      dyn_cast<IntegerType>(componentTypes[getUniformOffsetComponent(rank)]);
+  auto opaqueType = dyn_cast<RankedTensorType>(
+      componentTypes[getOpaqueContributionComponent(rank)]);
+  if (!uniformType || !opaqueType ||
+      opaqueType.getElementType() != uniformType ||
+      !isCompatibleOffsetTensor(originalType, opaqueType))
+    return false;
+  for (unsigned axis = 0; axis < rank; ++axis) {
+    if (componentTypes[getStrideComponent(axis)] != uniformType)
+      return false;
+  }
+  return true;
 }
 
-/// Validates the concrete Value-based state created while rewriting IR.
 static bool hasValidLayout(const DecomposedValue &value) {
-  return value.components.size() == 1 &&
-         hasValidSchema(value.originalType,
-                        value.components[kOffsetsComponent].getType(),
-                        value.invariants, value.attributes);
+  return hasValidSchema(value.originalType,
+                        TypeRange{ValueRange{value.components}},
+                        value.attributes);
 }
 
-/// Validates the read-only counterpart without materializing component Values.
 static bool hasValidLayout(const AnalyzedValue &value) {
-  return value.components.size() == 1 &&
-         hasValidSchema(value.originalType,
-                        value.components[kOffsetsComponent].type,
-                        value.invariants, value.attributes);
+  SmallVector<Type> componentTypes;
+  componentTypes.reserve(value.components.size());
+  for (const AnalyzedComponent &component : value.components)
+    componentTypes.push_back(component.type);
+  return hasValidSchema(value.originalType, componentTypes, value.attributes);
 }
 
-template <typename StateT>
-static bool haveSameTensorPtrBaseSchema(const StateT &lhs, const StateT &rhs) {
-  return hasValidLayout(lhs) && hasValidLayout(rhs) &&
-         lhs.originalType == rhs.originalType &&
-         lhs.invariants == rhs.invariants && lhs.attributes == rhs.attributes;
-}
-
-/// Whether the invariant base must be broadcast before rebuilding addptr.
-static bool hasScalarBase(const DecomposedValue &value) {
+template <typename StateT> static bool hasScalarBase(const StateT &value) {
   return cast<BoolAttr>(value.attributes[kBaseIsScalarAttribute]).getValue();
 }
 
-/// Creates the initial complete offsets for an opaque tensor-of-pointers.
-/// i32 is the current default. A later addptr or control-flow merge may promote
-/// it to i64 through getWiderOffsetsType.
-static Value createZeroOffsets(OpBuilder &builder, Location loc,
-                               Type pointerType) {
-  RankedTensorType offsetsType = getDefaultOffsetsType(pointerType);
-  auto elementType = cast<IntegerType>(offsetsType.getElementType());
-  auto zero = DenseElementsAttr::get(offsetsType,
-                                     builder.getIntegerAttr(elementType, 0));
-  return builder.create<arith::ConstantOp>(loc, zero);
+static bool hasSameRepresentation(const AnalyzedValue &lhs,
+                                  const AnalyzedValue &rhs) {
+  if (!hasValidLayout(lhs) || !hasValidLayout(rhs) ||
+      lhs.originalType != rhs.originalType ||
+      hasScalarBase(lhs) != hasScalarBase(rhs))
+    return false;
+  if (hasScalarBase(lhs))
+    return true;
+  return lhs.components[kBaseComponent].type ==
+             rhs.components[kBaseComponent].type &&
+         lhs.components[kBaseComponent].identity ==
+             rhs.components[kBaseComponent].identity;
 }
 
-/// Computes the common type used by an offset addition or SCF merge.
-///
-/// Complete offsets are always integer tensors with the pointer tensor's shape
-/// and encoding. When element widths differ, use the wider signed width.
-static FailureOr<Type> getWiderOffsetsType(Type lhs, Type rhs) {
+static FailureOr<Type> getWiderIntegerLikeType(Type lhs, Type rhs) {
+  if (lhs == rhs)
+    return lhs;
+
+  if (auto lhsInt = dyn_cast<IntegerType>(lhs)) {
+    auto rhsInt = dyn_cast<IntegerType>(rhs);
+    if (!rhsInt)
+      return failure();
+    return lhsInt.getWidth() >= rhsInt.getWidth() ? lhs : rhs;
+  }
+
   auto lhsTensor = dyn_cast<RankedTensorType>(lhs);
   auto rhsTensor = dyn_cast<RankedTensorType>(rhs);
   if (!lhsTensor || !rhsTensor ||
       lhsTensor.getShape() != rhsTensor.getShape() ||
       lhsTensor.getEncoding() != rhsTensor.getEncoding())
     return failure();
-  auto lhsElementInt = dyn_cast<IntegerType>(lhsTensor.getElementType());
-  auto rhsElementInt = dyn_cast<IntegerType>(rhsTensor.getElementType());
-  if (!lhsElementInt || !rhsElementInt)
+  auto lhsInt = dyn_cast<IntegerType>(lhsTensor.getElementType());
+  auto rhsInt = dyn_cast<IntegerType>(rhsTensor.getElementType());
+  if (!lhsInt || !rhsInt)
     return failure();
-  if (lhsElementInt.getWidth() == rhsElementInt.getWidth()) {
-    if (lhsElementInt != rhsElementInt)
-      return failure();
-    return lhs;
-  }
-  return lhsElementInt.getWidth() >= rhsElementInt.getWidth() ? lhs : rhs;
+  return lhsInt.getWidth() >= rhsInt.getWidth() ? lhs : rhs;
 }
 
-/// Adds two offset values after promoting both operands to their common type.
-/// This is the concrete IR counterpart of joinComponentTypes used in the
-/// read-only analysis.
-static Value createOffsetsAdd(OpBuilder &builder, Location loc, Value lhs,
-                              Value rhs) {
-  if (!lhs || !rhs)
+static bool isZeroIdentity(const ComponentIdentity &identity) {
+  return identity.kind == ComponentIdentity::Kind::Zero;
+}
+
+static ComponentIdentity getAddIdentity(const ComponentIdentity &lhs,
+                                        const ComponentIdentity &rhs,
+                                        Value result, unsigned componentIndex) {
+  if (isZeroIdentity(lhs))
+    return rhs;
+  if (isZeroIdentity(rhs))
+    return lhs;
+  return ComponentIdentity::fromValue(result, componentIndex);
+}
+
+static ComponentIdentity getSubIdentity(const ComponentIdentity &lhs,
+                                        const ComponentIdentity &rhs,
+                                        Value result, unsigned componentIndex) {
+  if (isZeroIdentity(rhs))
+    return lhs;
+  return ComponentIdentity::fromValue(result, componentIndex);
+}
+
+static std::optional<int64_t> getScalarConstant(Value value) {
+  return getConstantIntValue(value);
+}
+
+struct Rank1AnalyzedOffset {
+  AnalyzedComponent stride;
+  AnalyzedComponent offset;
+  AnalyzedComponent residual;
+};
+
+struct Rank1OffsetValues {
+  Value stride;
+  Value offset;
+  Value residual;
+};
+
+static FailureOr<RankedTensorType> getRank1IntegerTensorType(Value value,
+                                                             Type pointerType) {
+  auto tensorType = dyn_cast<RankedTensorType>(value.getType());
+  if (!tensorType || tensorType.getRank() != 1 ||
+      !isCompatibleOffsetTensor(pointerType, tensorType))
+    return failure();
+  return tensorType;
+}
+
+struct DenseIntegerSplat {
+  APInt value;
+};
+
+static FailureOr<Value> getSplatScalar(Value value) {
+  auto splat = value.getDefiningOp<triton::SplatOp>();
+  if (!splat || !isa<IntegerType>(splat.getSrc().getType()))
+    return failure();
+  return splat.getSrc();
+}
+
+/// Returns the exact scalar bit pattern represented by an integer dense splat.
+/// Lane-varying dense constants deliberately fail this check and remain opaque.
+static FailureOr<DenseIntegerSplat> getDenseIntegerSplat(Value value) {
+  auto tensorType = dyn_cast<RankedTensorType>(value.getType());
+  auto constant = value.getDefiningOp<arith::ConstantOp>();
+  if (!tensorType || tensorType.getRank() == 0 ||
+      !tensorType.hasStaticShape() ||
+      !isa<IntegerType>(tensorType.getElementType()) || !constant)
+    return failure();
+  auto dense = dyn_cast<DenseIntElementsAttr>(constant.getValue());
+  if (!dense || !dense.isSplat() || dense.getType() != tensorType)
+    return failure();
+  APInt splatValue = dense.getSplatValue<APInt>();
+  if (splatValue.getBitWidth() !=
+      cast<IntegerType>(tensorType.getElementType()).getWidth())
+    return failure();
+  return DenseIntegerSplat{std::move(splatValue)};
+}
+
+/// Returns true when every tensor lane is produced by the same integer scalar.
+/// Both an explicit tt.splat and an integer dense splat carry this guarantee.
+/// Lane-varying tensor constants are intentionally excluded.
+static bool isUniformIntegerScale(Value value) {
+  return succeeded(getSplatScalar(value)) ||
+         succeeded(getDenseIntegerSplat(value));
+}
+
+static bool isUniformIntegerScaleConstant(Value scale, int64_t expected) {
+  if (FailureOr<Value> scalar = getSplatScalar(scale); succeeded(scalar))
+    return getScalarConstant(*scalar) == std::optional<int64_t>(expected);
+  FailureOr<DenseIntegerSplat> dense = getDenseIntegerSplat(scale);
+  if (failed(dense))
+    return false;
+  return expected == 0 ? dense->value.isZero()
+                       : expected == 1 && dense->value.isOne();
+}
+
+static ComponentIdentity getScaledIdentity(const ComponentIdentity &input,
+                                           Value scale, Value result,
+                                           unsigned componentIndex) {
+  if (isZeroIdentity(input) || isUniformIntegerScaleConstant(scale, 0))
+    return ComponentIdentity::zero(componentIndex);
+  if (isUniformIntegerScaleConstant(scale, 1))
+    return input;
+  return ComponentIdentity::fromValue(result, componentIndex);
+}
+
+static Rank1AnalyzedOffset getFallbackAnalyzedOffset(Value value, Type) {
+  auto tensorType = cast<RankedTensorType>(value.getType());
+  Type scalarType = tensorType.getElementType();
+  return {
+      {scalarType, ComponentIdentity::zero(kStrideComponent)},
+      {scalarType, ComponentIdentity::zero(kOffsetComponent)},
+      {tensorType, ComponentIdentity::fromValue(value, kResidualComponent)}};
+}
+
+static bool isSafeIntegerExtensionLeaf(Value value) {
+  if (value.getDefiningOp<triton::MakeRangeOp>())
+    return true;
+  return succeeded(getSplatScalar(value)) ||
+         succeeded(getDenseIntegerSplat(value));
+}
+
+static FailureOr<Rank1AnalyzedOffset> analyzeRank1Offset(Value value,
+                                                         Type pointerType) {
+  FailureOr<RankedTensorType> tensorType =
+      getRank1IntegerTensorType(value, pointerType);
+  if (failed(tensorType))
+    return failure();
+  Type scalarType = (*tensorType).getElementType();
+
+  if (auto range = value.getDefiningOp<triton::MakeRangeOp>()) {
+    int64_t extent = (*tensorType).getShape()[0];
+    if (range.getEnd() - range.getStart() != extent)
+      return getFallbackAnalyzedOffset(value, pointerType);
+    ComponentIdentity offsetIdentity =
+        range.getStart() == 0
+            ? ComponentIdentity::zero(kOffsetComponent)
+            : ComponentIdentity::fromValue(value, kOffsetComponent);
+    return Rank1AnalyzedOffset{
+        {scalarType, ComponentIdentity::fromValue(value, kStrideComponent)},
+        {scalarType, offsetIdentity},
+        {*tensorType, ComponentIdentity::zero(kResidualComponent)}};
+  }
+
+  if (auto splat = value.getDefiningOp<triton::SplatOp>()) {
+    if (!isa<IntegerType>(splat.getSrc().getType()))
+      return getFallbackAnalyzedOffset(value, pointerType);
+    ComponentIdentity offsetIdentity =
+        getScalarConstant(splat.getSrc()) == std::optional<int64_t>(0)
+            ? ComponentIdentity::zero(kOffsetComponent)
+            : ComponentIdentity::fromValue(splat.getSrc(), kOffsetComponent);
+    return Rank1AnalyzedOffset{
+        {scalarType, ComponentIdentity::zero(kStrideComponent)},
+        {scalarType, offsetIdentity},
+        {*tensorType, ComponentIdentity::zero(kResidualComponent)}};
+  }
+
+  if (FailureOr<DenseIntegerSplat> dense = getDenseIntegerSplat(value);
+      succeeded(dense)) {
+    ComponentIdentity offsetIdentity =
+        dense->value.isZero()
+            ? ComponentIdentity::zero(kOffsetComponent)
+            : ComponentIdentity::fromValue(value, kOffsetComponent);
+    return Rank1AnalyzedOffset{
+        {scalarType, ComponentIdentity::zero(kStrideComponent)},
+        {scalarType, offsetIdentity},
+        {*tensorType, ComponentIdentity::zero(kResidualComponent)}};
+  }
+
+  if (auto extension = value.getDefiningOp<arith::ExtSIOp>()) {
+    Value source = extension.getIn();
+    if (!isSafeIntegerExtensionLeaf(source))
+      return getFallbackAnalyzedOffset(value, pointerType);
+    FailureOr<Rank1AnalyzedOffset> sourceInfo =
+        analyzeRank1Offset(source, pointerType);
+    if (failed(sourceInfo))
+      return failure();
+    auto extendedIdentity = [&](const AnalyzedComponent &component,
+                                unsigned componentIndex) {
+      return isZeroIdentity(component.identity)
+                 ? ComponentIdentity::zero(componentIndex)
+                 : ComponentIdentity::fromValue(value, componentIndex);
+    };
+    return Rank1AnalyzedOffset{
+        {scalarType, extendedIdentity(sourceInfo->stride, kStrideComponent)},
+        {scalarType, extendedIdentity(sourceInfo->offset, kOffsetComponent)},
+        {*tensorType,
+         extendedIdentity(sourceInfo->residual, kResidualComponent)}};
+  }
+
+  auto analyzeBinary = [&](Value lhs, Value rhs,
+                           bool subtract) -> FailureOr<Rank1AnalyzedOffset> {
+    FailureOr<Rank1AnalyzedOffset> lhsInfo =
+        analyzeRank1Offset(lhs, pointerType);
+    FailureOr<Rank1AnalyzedOffset> rhsInfo =
+        analyzeRank1Offset(rhs, pointerType);
+    if (failed(lhsInfo) || failed(rhsInfo) ||
+        lhsInfo->stride.type != rhsInfo->stride.type ||
+        lhsInfo->offset.type != rhsInfo->offset.type ||
+        lhsInfo->residual.type != rhsInfo->residual.type)
+      return getFallbackAnalyzedOffset(value, pointerType);
+
+    // One rank-1 axis is represented either entirely by scalar affine fields
+    // or entirely by the opaque carrier. Do not retain a partial affine term
+    // beside an existing residual.
+    if (!isZeroIdentity(lhsInfo->residual.identity) ||
+        !isZeroIdentity(rhsInfo->residual.identity))
+      return getFallbackAnalyzedOffset(value, pointerType);
+
+    auto combine = [&](const ComponentIdentity &lhsIdentity,
+                       const ComponentIdentity &rhsIdentity,
+                       unsigned componentIndex) {
+      return subtract ? getSubIdentity(lhsIdentity, rhsIdentity, value,
+                                       componentIndex)
+                      : getAddIdentity(lhsIdentity, rhsIdentity, value,
+                                       componentIndex);
+    };
+    return Rank1AnalyzedOffset{
+        {lhsInfo->stride.type,
+         combine(lhsInfo->stride.identity, rhsInfo->stride.identity,
+                 kStrideComponent)},
+        {lhsInfo->offset.type,
+         combine(lhsInfo->offset.identity, rhsInfo->offset.identity,
+                 kOffsetComponent)},
+        {lhsInfo->residual.type,
+         combine(lhsInfo->residual.identity, rhsInfo->residual.identity,
+                 kResidualComponent)}};
+  };
+
+  if (auto add = value.getDefiningOp<arith::AddIOp>())
+    return analyzeBinary(add.getLhs(), add.getRhs(), false);
+  if (auto sub = value.getDefiningOp<arith::SubIOp>())
+    return analyzeBinary(sub.getLhs(), sub.getRhs(), true);
+
+  if (auto mul = value.getDefiningOp<arith::MulIOp>()) {
+    Value affineOperand = mul.getLhs();
+    Value scale = mul.getRhs();
+    if (!isUniformIntegerScale(scale)) {
+      affineOperand = mul.getRhs();
+      scale = mul.getLhs();
+    }
+    if (!isUniformIntegerScale(scale))
+      return getFallbackAnalyzedOffset(value, pointerType);
+    FailureOr<Rank1AnalyzedOffset> input =
+        analyzeRank1Offset(affineOperand, pointerType);
+    if (failed(input) || !isZeroIdentity(input->residual.identity))
+      return getFallbackAnalyzedOffset(value, pointerType);
+    return Rank1AnalyzedOffset{
+        {input->stride.type, getScaledIdentity(input->stride.identity, scale,
+                                               value, kStrideComponent)},
+        {input->offset.type, getScaledIdentity(input->offset.identity, scale,
+                                               value, kOffsetComponent)},
+        {input->residual.type,
+         getScaledIdentity(input->residual.identity, scale, value,
+                           kResidualComponent)}};
+  }
+
+  // Pushing an extension through a previously computed tensor expression can
+  // change the source-width overflow semantics. Keep the already-evaluated
+  // tensor as residual until the schema records arithmetic width explicitly.
+  return getFallbackAnalyzedOffset(value, pointerType);
+}
+
+static bool isConstantZero(Value value) {
+  if (!value)
+    return false;
+  if (std::optional<int64_t> scalar = getConstantIntValue(value))
+    return *scalar == 0;
+  auto constant = value.getDefiningOp<arith::ConstantOp>();
+  if (!constant)
+    return false;
+  auto dense = dyn_cast<DenseIntElementsAttr>(constant.getValue());
+  return dense && dense.isSplat() && dense.getSplatValue<APInt>().isZero();
+}
+
+static Value createScalarConstant(OpBuilder &builder, Location loc, Type type,
+                                  int64_t value) {
+  auto intType = dyn_cast<IntegerType>(type);
+  if (!intType)
     return nullptr;
-  FailureOr<Type> type = getWiderOffsetsType(lhs.getType(), rhs.getType());
+  return builder.create<arith::ConstantOp>(
+      loc, builder.getIntegerAttr(intType, value));
+}
+
+static Value createScalarConstant(OpBuilder &builder, Location loc, Type type,
+                                  const APInt &value) {
+  auto intType = dyn_cast<IntegerType>(type);
+  if (!intType || intType.getWidth() != value.getBitWidth())
+    return nullptr;
+  return builder.create<arith::ConstantOp>(loc,
+                                           IntegerAttr::get(intType, value));
+}
+
+/// Materializes the scalar represented by an integer-uniform tensor. Dense
+/// splats are recreated with their exact APInt width so affine stride analysis
+/// and concrete descriptor construction observe identical arithmetic.
+static FailureOr<Value>
+materializeUniformIntegerScale(Value value, OpBuilder &builder, Location loc) {
+  if (FailureOr<Value> scalar = getSplatScalar(value); succeeded(scalar))
+    return *scalar;
+  FailureOr<DenseIntegerSplat> dense = getDenseIntegerSplat(value);
+  if (failed(dense))
+    return failure();
+  auto tensorType = cast<RankedTensorType>(value.getType());
+  Value scalar = createScalarConstant(builder, loc, tensorType.getElementType(),
+                                      dense->value);
+  if (!scalar)
+    return failure();
+  return scalar;
+}
+
+static Value createZeroOffsets(OpBuilder &builder, Location loc,
+                               RankedTensorType offsetsType) {
+  auto elementType = cast<IntegerType>(offsetsType.getElementType());
+  return builder.create<arith::ConstantOp>(
+      loc, DenseElementsAttr::get(offsetsType,
+                                  builder.getIntegerAttr(elementType, 0)));
+}
+
+static Value createZeroOffsets(OpBuilder &builder, Location loc,
+                               Type pointerType) {
+  return createZeroOffsets(builder, loc, getDefaultOffsetsType(pointerType));
+}
+
+static Value createIntegerAdd(OpBuilder &builder, Location loc, Value lhs,
+                              Value rhs) {
+  if (isConstantZero(lhs))
+    return rhs;
+  if (isConstantZero(rhs))
+    return lhs;
+  FailureOr<Type> type = getWiderIntegerLikeType(lhs.getType(), rhs.getType());
   if (failed(type))
     return nullptr;
   FailureOr<Value> convertedLhs = castIntegerLike(builder, loc, lhs, *type);
@@ -166,229 +579,1605 @@ static Value createOffsetsAdd(OpBuilder &builder, Location loc, Value lhs,
   return builder.create<arith::AddIOp>(loc, *convertedLhs, *convertedRhs);
 }
 
-/// Tensor-pointer semantics plugged into the shared control-flow machinery.
-///
-/// The analysis methods compute a symbolic schema without changing IR. The
-/// rewrite methods later materialize the exact Values for that already-chosen
-/// schema. Keeping both implementations here makes their layouts directly
-/// comparable and avoids hiding pointer semantics in ControlFlowRewrite.
-class TensorPtrDecomposePolicy final : public ControlFlowRewritePolicy {
-public:
-  /// Selects only tensor-of-pointers owned by this decomposition stage.
-  bool matches(Type type) const override {
-    // A tensor pointer here means tensor<...x!tt.ptr<...>>. Scalar block
-    // pointers have already been handled by BlockPtrDecompose.
-    return isTensorPointerType(type);
+static Value createIntegerSub(OpBuilder &builder, Location loc, Value lhs,
+                              Value rhs) {
+  if (isConstantZero(rhs))
+    return lhs;
+  FailureOr<Type> type = getWiderIntegerLikeType(lhs.getType(), rhs.getType());
+  if (failed(type))
+    return nullptr;
+  FailureOr<Value> convertedLhs = castIntegerLike(builder, loc, lhs, *type);
+  FailureOr<Value> convertedRhs = castIntegerLike(builder, loc, rhs, *type);
+  if (failed(convertedLhs) || failed(convertedRhs))
+    return nullptr;
+  return builder.create<arith::SubIOp>(loc, *convertedLhs, *convertedRhs);
+}
+
+static Value scaleIntegerValue(OpBuilder &builder, Location loc, Value value,
+                               Value scale) {
+  if (isConstantZero(value))
+    return value;
+  std::optional<int64_t> constant = getScalarConstant(scale);
+  if (constant && *constant == 0) {
+    if (auto tensorType = dyn_cast<RankedTensorType>(value.getType()))
+      return createZeroOffsets(builder, loc, tensorType);
+    return createScalarConstant(builder, loc, value.getType(), 0);
+  }
+  if (constant && *constant == 1)
+    return value;
+
+  if (auto tensorType = dyn_cast<RankedTensorType>(value.getType())) {
+    FailureOr<Value> convertedScale =
+        castIntegerLike(builder, loc, scale, tensorType.getElementType());
+    if (failed(convertedScale))
+      return nullptr;
+    Value scaleTensor =
+        builder.create<triton::SplatOp>(loc, tensorType, *convertedScale);
+    return builder.create<arith::MulIOp>(loc, value, scaleTensor);
   }
 
-  //===--------------------------------------------------------------------===//
-  // Read-only schema analysis
-  //===--------------------------------------------------------------------===//
+  FailureOr<Type> type =
+      getWiderIntegerLikeType(value.getType(), scale.getType());
+  if (failed(type))
+    return nullptr;
+  FailureOr<Value> convertedValue = castIntegerLike(builder, loc, value, *type);
+  FailureOr<Value> convertedScale = castIntegerLike(builder, loc, scale, *type);
+  if (failed(convertedValue) || failed(convertedScale))
+    return nullptr;
+  return builder.create<arith::MulIOp>(loc, *convertedValue, *convertedScale);
+}
 
-  /// Recovers `{common_base, complete_offsets, base_is_scalar}` without
-  /// creating constants, additions, or pointer operations.
+static FailureOr<Rank1OffsetValues> materializeRank1Offset(Value value,
+                                                           Type pointerType,
+                                                           OpBuilder &builder,
+                                                           Location loc) {
+  FailureOr<RankedTensorType> tensorType =
+      getRank1IntegerTensorType(value, pointerType);
+  if (failed(tensorType))
+    return failure();
+
+  // Component identities are keyed by the analyzed tensor expression. Create
+  // its concrete scalar fields next to that expression, where they dominate
+  // every reuse (including sibling scf.if arms). Materializing at each addptr
+  // user would make equal abstract identities refer to branch-local Values.
+  OpBuilder::InsertionGuard insertionGuard(builder);
+  if (Operation *definingOp = value.getDefiningOp())
+    builder.setInsertionPointAfter(definingOp);
+  else if (auto blockArgument = dyn_cast<BlockArgument>(value))
+    builder.setInsertionPointToStart(blockArgument.getOwner());
+
+  Type scalarType = (*tensorType).getElementType();
+
+  auto fallback = [&]() -> FailureOr<Rank1OffsetValues> {
+    Value stride = createScalarConstant(builder, loc, scalarType, 0);
+    Value offset = createScalarConstant(builder, loc, scalarType, 0);
+    if (!stride || !offset)
+      return failure();
+    return Rank1OffsetValues{stride, offset, value};
+  };
+
+  if (auto range = value.getDefiningOp<triton::MakeRangeOp>()) {
+    if (range.getEnd() - range.getStart() != (*tensorType).getShape()[0])
+      return fallback();
+    Value stride = createScalarConstant(builder, loc, scalarType, 1);
+    Value offset =
+        createScalarConstant(builder, loc, scalarType, range.getStart());
+    Value residual = createZeroOffsets(builder, loc, *tensorType);
+    if (!stride || !offset || !residual)
+      return failure();
+    return Rank1OffsetValues{stride, offset, residual};
+  }
+
+  if (auto splat = value.getDefiningOp<triton::SplatOp>()) {
+    if (!isa<IntegerType>(splat.getSrc().getType()))
+      return fallback();
+    FailureOr<Value> offset =
+        castIntegerLike(builder, loc, splat.getSrc(), scalarType);
+    Value stride = createScalarConstant(builder, loc, scalarType, 0);
+    Value residual = createZeroOffsets(builder, loc, *tensorType);
+    if (failed(offset) || !stride || !residual)
+      return failure();
+    return Rank1OffsetValues{stride, *offset, residual};
+  }
+
+  if (FailureOr<DenseIntegerSplat> dense = getDenseIntegerSplat(value);
+      succeeded(dense)) {
+    Value stride = createScalarConstant(builder, loc, scalarType, 0);
+    Value offset = createScalarConstant(builder, loc, scalarType, dense->value);
+    Value residual = createZeroOffsets(builder, loc, *tensorType);
+    if (!stride || !offset || !residual)
+      return failure();
+    return Rank1OffsetValues{stride, offset, residual};
+  }
+
+  if (auto extension = value.getDefiningOp<arith::ExtSIOp>()) {
+    Value source = extension.getIn();
+    if (!isSafeIntegerExtensionLeaf(source))
+      return fallback();
+    FailureOr<Rank1OffsetValues> sourceInfo =
+        materializeRank1Offset(source, pointerType, builder, loc);
+    if (failed(sourceInfo))
+      return failure();
+    auto extendComponent = [&](Value component,
+                               Type targetType) -> FailureOr<Value> {
+      if (!isConstantZero(component))
+        return castIntegerLike(builder, loc, component, targetType);
+      if (auto targetTensor = dyn_cast<RankedTensorType>(targetType))
+        return createZeroOffsets(builder, loc, targetTensor);
+      Value zero = createScalarConstant(builder, loc, targetType, 0);
+      if (!zero)
+        return failure();
+      return zero;
+    };
+    FailureOr<Value> stride = extendComponent(sourceInfo->stride, scalarType);
+    FailureOr<Value> offset = extendComponent(sourceInfo->offset, scalarType);
+    FailureOr<Value> residual =
+        extendComponent(sourceInfo->residual, *tensorType);
+    if (failed(stride) || failed(offset) || failed(residual))
+      return failure();
+    return Rank1OffsetValues{*stride, *offset, *residual};
+  }
+
+  auto materializeBinary = [&](Value lhs, Value rhs,
+                               bool subtract) -> FailureOr<Rank1OffsetValues> {
+    FailureOr<Rank1OffsetValues> lhsInfo =
+        materializeRank1Offset(lhs, pointerType, builder, loc);
+    FailureOr<Rank1OffsetValues> rhsInfo =
+        materializeRank1Offset(rhs, pointerType, builder, loc);
+    if (failed(lhsInfo) || failed(rhsInfo))
+      return failure();
+    if (!isConstantZero(lhsInfo->residual) ||
+        !isConstantZero(rhsInfo->residual))
+      return fallback();
+    auto combine = [&](Value lhsValue, Value rhsValue) {
+      return subtract ? createIntegerSub(builder, loc, lhsValue, rhsValue)
+                      : createIntegerAdd(builder, loc, lhsValue, rhsValue);
+    };
+    Value stride = combine(lhsInfo->stride, rhsInfo->stride);
+    Value offset = combine(lhsInfo->offset, rhsInfo->offset);
+    Value residual = combine(lhsInfo->residual, rhsInfo->residual);
+    if (!stride || !offset || !residual)
+      return failure();
+    return Rank1OffsetValues{stride, offset, residual};
+  };
+
+  if (auto add = value.getDefiningOp<arith::AddIOp>())
+    return materializeBinary(add.getLhs(), add.getRhs(), false);
+  if (auto sub = value.getDefiningOp<arith::SubIOp>())
+    return materializeBinary(sub.getLhs(), sub.getRhs(), true);
+
+  if (auto mul = value.getDefiningOp<arith::MulIOp>()) {
+    Value affineOperand = mul.getLhs();
+    FailureOr<Value> scale =
+        materializeUniformIntegerScale(mul.getRhs(), builder, loc);
+    if (failed(scale)) {
+      affineOperand = mul.getRhs();
+      scale = materializeUniformIntegerScale(mul.getLhs(), builder, loc);
+    }
+    if (failed(scale))
+      return fallback();
+    FailureOr<Rank1OffsetValues> input =
+        materializeRank1Offset(affineOperand, pointerType, builder, loc);
+    if (failed(input))
+      return failure();
+    if (!isConstantZero(input->residual))
+      return fallback();
+    Value stride = scaleIntegerValue(builder, loc, input->stride, *scale);
+    Value offset = scaleIntegerValue(builder, loc, input->offset, *scale);
+    Value residual = scaleIntegerValue(builder, loc, input->residual, *scale);
+    if (!stride || !offset || !residual)
+      return failure();
+    return Rank1OffsetValues{stride, offset, residual};
+  }
+
+  return fallback();
+}
+
+static Value materializeRank1CompleteOffsets(const DecomposedValue &value,
+                                             OpBuilder &builder, Location loc) {
+  if (!hasValidLayout(value) || !isRankOneTensorPointer(value.originalType))
+    return nullptr;
+  Value stride = value.components[kStrideComponent];
+  Value offset = value.components[kOffsetComponent];
+  Value residual = value.components[kResidualComponent];
+  auto residualType = cast<RankedTensorType>(residual.getType());
+  int64_t extent = residualType.getShape()[0];
+
+  // Zero is a policy-level identity, not an SSA owner. A concrete zero may
+  // have been created inside one arm of an scf.if and therefore cannot be used
+  // by the rebuild after the if. Rematerialize every proven zero at the current
+  // insertion point so empty/invariant slots remain dominance-correct.
+  if (isConstantZero(stride))
+    stride = createScalarConstant(builder, loc, stride.getType(), 0);
+  if (isConstantZero(offset))
+    offset = createScalarConstant(builder, loc, offset.getType(), 0);
+  if (isConstantZero(residual))
+    residual = createZeroOffsets(builder, loc, residualType);
+  if (!stride || !offset || !residual)
+    return nullptr;
+
+  if (isConstantZero(stride) && isConstantZero(offset))
+    return residual;
+  if (extent < 0 || extent > std::numeric_limits<int32_t>::max())
+    return nullptr;
+
+  auto rangeType =
+      RankedTensorType::get(residualType.getShape(), builder.getI32Type(),
+                            residualType.getEncoding());
+  Value range = builder.create<triton::MakeRangeOp>(
+      loc, rangeType, 0, static_cast<int32_t>(extent));
+  FailureOr<Value> convertedRange =
+      castIntegerLike(builder, loc, range, residualType);
+  FailureOr<Value> convertedStride =
+      castIntegerLike(builder, loc, stride, residualType.getElementType());
+  FailureOr<Value> convertedOffset =
+      castIntegerLike(builder, loc, offset, residualType.getElementType());
+  if (failed(convertedRange) || failed(convertedStride) ||
+      failed(convertedOffset))
+    return nullptr;
+
+  Value strideTensor =
+      builder.create<triton::SplatOp>(loc, residualType, *convertedStride);
+  Value offsetTensor =
+      builder.create<triton::SplatOp>(loc, residualType, *convertedOffset);
+  Value affine =
+      builder.create<arith::MulIOp>(loc, *convertedRange, strideTensor);
+  affine = createIntegerAdd(builder, loc, affine, offsetTensor);
+  if (!affine)
+    return nullptr;
+  if (isConstantZero(residual))
+    return affine;
+  return createIntegerAdd(builder, loc, affine, residual);
+}
+
+struct AnalyzedTensorOffset {
+  SmallVector<AnalyzedComponent> strides;
+  AnalyzedComponent uniformOffset;
+  AnalyzedComponent opaqueContribution;
+  SmallVector<AxisKind> axisKinds;
+};
+
+struct TensorOffsetValues {
+  SmallVector<Value> strides;
+  Value uniformOffset;
+  Value opaqueContribution;
+  SmallVector<AxisKind> axisKinds;
+};
+
+static FailureOr<RankedTensorType> getIntegerTensorType(Value value) {
+  auto type = dyn_cast<RankedTensorType>(value.getType());
+  if (!type || type.getRank() == 0 || !isa<IntegerType>(type.getElementType()))
+    return failure();
+  return type;
+}
+
+static bool hasAnyOpaqueAxis(ArrayRef<AxisKind> kinds) {
+  return llvm::is_contained(kinds, AxisKind::Opaque);
+}
+
+static AnalyzedTensorOffset getOpaqueAnalyzedOffset(Value value) {
+  auto tensorType = cast<RankedTensorType>(value.getType());
+  Type scalarType = tensorType.getElementType();
+  unsigned rank = tensorType.getRank();
+  AnalyzedTensorOffset result;
+  result.axisKinds = getAxisKinds(rank, AxisKind::Opaque);
+  for (unsigned axis = 0; axis < rank; ++axis) {
+    result.strides.push_back(
+        {scalarType, ComponentIdentity::zero(getStrideComponent(axis))});
+  }
+  result.uniformOffset = {
+      scalarType, ComponentIdentity::zero(getUniformOffsetComponent(rank))};
+  result.opaqueContribution = {
+      tensorType, ComponentIdentity::fromValue(
+                      value, getOpaqueContributionComponent(rank))};
+  return result;
+}
+
+static FailureOr<AnalyzedTensorOffset> analyzeTensorOffset(Value value) {
+  FailureOr<RankedTensorType> tensorType = getIntegerTensorType(value);
+  if (failed(tensorType))
+    return failure();
+  unsigned rank = (*tensorType).getRank();
+  Type scalarType = (*tensorType).getElementType();
+
+  if (rank == 1) {
+    FailureOr<Rank1AnalyzedOffset> rankOne =
+        analyzeRank1Offset(value, value.getType());
+    if (failed(rankOne))
+      return failure();
+    bool opaque = !isZeroIdentity(rankOne->residual.identity);
+    if (opaque)
+      return getOpaqueAnalyzedOffset(value);
+    return AnalyzedTensorOffset{{rankOne->stride},
+                                rankOne->offset,
+                                rankOne->residual,
+                                {AxisKind::Structured}};
+  }
+
+  auto makeStructuredZero = [&]() {
+    AnalyzedTensorOffset result;
+    result.axisKinds = getAxisKinds(rank, AxisKind::Structured);
+    for (unsigned axis = 0; axis < rank; ++axis) {
+      result.strides.push_back(
+          {scalarType, ComponentIdentity::zero(getStrideComponent(axis))});
+    }
+    result.uniformOffset = {
+        scalarType, ComponentIdentity::zero(getUniformOffsetComponent(rank))};
+    result.opaqueContribution = {
+        *tensorType,
+        ComponentIdentity::zero(getOpaqueContributionComponent(rank))};
+    return result;
+  };
+
+  if (auto range = value.getDefiningOp<triton::MakeRangeOp>()) {
+    if (rank != 1 ||
+        range.getEnd() - range.getStart() != (*tensorType).getShape()[0])
+      return getOpaqueAnalyzedOffset(value);
+    AnalyzedTensorOffset result = makeStructuredZero();
+    result.strides[0].identity =
+        ComponentIdentity::fromValue(value, getStrideComponent(0));
+    if (range.getStart() != 0)
+      result.uniformOffset.identity =
+          ComponentIdentity::fromValue(value, getUniformOffsetComponent(rank));
+    return result;
+  }
+
+  if (auto splat = value.getDefiningOp<triton::SplatOp>()) {
+    if (!isa<IntegerType>(splat.getSrc().getType()))
+      return getOpaqueAnalyzedOffset(value);
+    AnalyzedTensorOffset result = makeStructuredZero();
+    if (getScalarConstant(splat.getSrc()) != std::optional<int64_t>(0))
+      result.uniformOffset.identity = ComponentIdentity::fromValue(
+          splat.getSrc(), getUniformOffsetComponent(rank));
+    return result;
+  }
+
+  if (FailureOr<DenseIntegerSplat> dense = getDenseIntegerSplat(value);
+      succeeded(dense)) {
+    AnalyzedTensorOffset result = makeStructuredZero();
+    if (!dense->value.isZero())
+      result.uniformOffset.identity =
+          ComponentIdentity::fromValue(value, getUniformOffsetComponent(rank));
+    return result;
+  }
+
+  if (auto expand = value.getDefiningOp<triton::ExpandDimsOp>()) {
+    FailureOr<AnalyzedTensorOffset> source =
+        analyzeTensorOffset(expand.getSrc());
+    if (failed(source) || source->strides.size() + 1 != rank ||
+        expand.getAxis() >= rank)
+      return getOpaqueAnalyzedOffset(value);
+    AnalyzedTensorOffset result = makeStructuredZero();
+    unsigned sourceAxis = 0;
+    for (unsigned axis = 0; axis < rank; ++axis) {
+      if (axis == expand.getAxis())
+        continue;
+      result.axisKinds[axis] = source->axisKinds[sourceAxis];
+      if (!isZeroIdentity(source->strides[sourceAxis].identity))
+        result.strides[axis].identity =
+            ComponentIdentity::fromValue(value, getStrideComponent(axis));
+      ++sourceAxis;
+    }
+    if (!isZeroIdentity(source->uniformOffset.identity))
+      result.uniformOffset.identity =
+          ComponentIdentity::fromValue(value, getUniformOffsetComponent(rank));
+    if (!isZeroIdentity(source->opaqueContribution.identity))
+      result.opaqueContribution.identity = ComponentIdentity::fromValue(
+          value, getOpaqueContributionComponent(rank));
+    return result;
+  }
+
+  if (auto broadcast = value.getDefiningOp<triton::BroadcastOp>()) {
+    FailureOr<AnalyzedTensorOffset> source =
+        analyzeTensorOffset(broadcast.getSrc());
+    auto sourceType = dyn_cast<RankedTensorType>(broadcast.getSrc().getType());
+    if (failed(source) || !sourceType || sourceType.getRank() != rank)
+      return getOpaqueAnalyzedOffset(value);
+    AnalyzedTensorOffset result = makeStructuredZero();
+    for (unsigned axis = 0; axis < rank; ++axis) {
+      bool expandsScalarAxis = sourceType.getShape()[axis] == 1 &&
+                               (*tensorType).getShape()[axis] != 1;
+      if (expandsScalarAxis)
+        continue;
+      result.axisKinds[axis] = source->axisKinds[axis];
+      if (!isZeroIdentity(source->strides[axis].identity))
+        result.strides[axis].identity =
+            ComponentIdentity::fromValue(value, getStrideComponent(axis));
+    }
+    if (!isZeroIdentity(source->uniformOffset.identity))
+      result.uniformOffset.identity =
+          ComponentIdentity::fromValue(value, getUniformOffsetComponent(rank));
+    if (!isZeroIdentity(source->opaqueContribution.identity))
+      result.opaqueContribution.identity = ComponentIdentity::fromValue(
+          value, getOpaqueContributionComponent(rank));
+    return result;
+  }
+
+  auto analyzeBinary = [&](Value lhs, Value rhs,
+                           bool subtract) -> FailureOr<AnalyzedTensorOffset> {
+    FailureOr<AnalyzedTensorOffset> lhsInfo = analyzeTensorOffset(lhs);
+    FailureOr<AnalyzedTensorOffset> rhsInfo = analyzeTensorOffset(rhs);
+    if (failed(lhsInfo) || failed(rhsInfo) || lhsInfo->strides.size() != rank ||
+        rhsInfo->strides.size() != rank)
+      return getOpaqueAnalyzedOffset(value);
+    AnalyzedTensorOffset result = makeStructuredZero();
+    for (unsigned axis = 0; axis < rank; ++axis) {
+      result.axisKinds[axis] =
+          lhsInfo->axisKinds[axis] == AxisKind::Structured &&
+                  rhsInfo->axisKinds[axis] == AxisKind::Structured
+              ? AxisKind::Structured
+              : AxisKind::Opaque;
+      if (result.axisKinds[axis] == AxisKind::Structured) {
+        result.strides[axis].identity =
+            subtract ? getSubIdentity(lhsInfo->strides[axis].identity,
+                                      rhsInfo->strides[axis].identity, value,
+                                      getStrideComponent(axis))
+                     : getAddIdentity(lhsInfo->strides[axis].identity,
+                                      rhsInfo->strides[axis].identity, value,
+                                      getStrideComponent(axis));
+      }
+    }
+    if (hasAnyOpaqueAxis(result.axisKinds)) {
+      result.opaqueContribution.identity = ComponentIdentity::fromValue(
+          value, getOpaqueContributionComponent(rank));
+      return result;
+    }
+    result.uniformOffset.identity =
+        subtract ? getSubIdentity(lhsInfo->uniformOffset.identity,
+                                  rhsInfo->uniformOffset.identity, value,
+                                  getUniformOffsetComponent(rank))
+                 : getAddIdentity(lhsInfo->uniformOffset.identity,
+                                  rhsInfo->uniformOffset.identity, value,
+                                  getUniformOffsetComponent(rank));
+    return result;
+  };
+
+  if (auto add = value.getDefiningOp<arith::AddIOp>())
+    return analyzeBinary(add.getLhs(), add.getRhs(), false);
+  if (auto sub = value.getDefiningOp<arith::SubIOp>())
+    return analyzeBinary(sub.getLhs(), sub.getRhs(), true);
+
+  if (auto mul = value.getDefiningOp<arith::MulIOp>()) {
+    Value affineOperand = mul.getLhs();
+    Value scale = mul.getRhs();
+    if (!isUniformIntegerScale(scale)) {
+      affineOperand = mul.getRhs();
+      scale = mul.getLhs();
+    }
+    if (!isUniformIntegerScale(scale))
+      return getOpaqueAnalyzedOffset(value);
+    FailureOr<AnalyzedTensorOffset> input = analyzeTensorOffset(affineOperand);
+    if (failed(input) || input->strides.size() != rank)
+      return getOpaqueAnalyzedOffset(value);
+    AnalyzedTensorOffset result = makeStructuredZero();
+    result.axisKinds = input->axisKinds;
+    for (unsigned axis = 0; axis < rank; ++axis) {
+      if (result.axisKinds[axis] == AxisKind::Structured)
+        result.strides[axis].identity =
+            getScaledIdentity(input->strides[axis].identity, scale, value,
+                              getStrideComponent(axis));
+    }
+    if (hasAnyOpaqueAxis(result.axisKinds)) {
+      result.opaqueContribution.identity = ComponentIdentity::fromValue(
+          value, getOpaqueContributionComponent(rank));
+    } else {
+      result.uniformOffset.identity =
+          getScaledIdentity(input->uniformOffset.identity, scale, value,
+                            getUniformOffsetComponent(rank));
+    }
+    return result;
+  }
+
+  return getOpaqueAnalyzedOffset(value);
+}
+
+static FailureOr<Value> materializeAxisRange(OpBuilder &builder, Location loc,
+                                             RankedTensorType tensorType,
+                                             unsigned axis) {
+  if (axis >= static_cast<unsigned>(tensorType.getRank()))
+    return failure();
+  int64_t extent = tensorType.getShape()[axis];
+  if (extent < 0 || extent > std::numeric_limits<int32_t>::max())
+    return failure();
+  auto rangeType = RankedTensorType::get({extent}, builder.getI32Type());
+  Value range = builder.create<triton::MakeRangeOp>(
+      loc, rangeType, 0, static_cast<int32_t>(extent));
+  auto elementRangeType =
+      RankedTensorType::get({extent}, tensorType.getElementType());
+  FailureOr<Value> converted =
+      castIntegerLike(builder, loc, range, elementRangeType);
+  if (failed(converted))
+    return failure();
+  Value expanded = *converted;
+  for (unsigned dimension = 0;
+       dimension < static_cast<unsigned>(tensorType.getRank()); ++dimension) {
+    if (dimension == axis)
+      continue;
+    expanded = builder.create<triton::ExpandDimsOp>(loc, expanded, dimension);
+  }
+  if (expanded.getType() != tensorType)
+    expanded = builder.create<triton::BroadcastOp>(loc, tensorType, expanded);
+  return expanded;
+}
+
+static FailureOr<Value> materializeStructuredContribution(
+    ArrayRef<Value> strides, ArrayRef<AxisKind> axisKinds,
+    RankedTensorType tensorType, OpBuilder &builder, Location loc) {
+  if (strides.size() != axisKinds.size() ||
+      strides.size() != static_cast<size_t>(tensorType.getRank()))
+    return failure();
+  Value contribution = createZeroOffsets(builder, loc, tensorType);
+  for (unsigned axis = 0; axis < strides.size(); ++axis) {
+    if (axisKinds[axis] != AxisKind::Structured ||
+        isConstantZero(strides[axis]))
+      continue;
+    FailureOr<Value> range =
+        materializeAxisRange(builder, loc, tensorType, axis);
+    FailureOr<Value> stride = castIntegerLike(builder, loc, strides[axis],
+                                              tensorType.getElementType());
+    if (failed(range) || failed(stride))
+      return failure();
+    Value strideTensor =
+        builder.create<triton::SplatOp>(loc, tensorType, *stride);
+    Value axisContribution =
+        builder.create<arith::MulIOp>(loc, *range, strideTensor);
+    contribution =
+        createIntegerAdd(builder, loc, contribution, axisContribution);
+    if (!contribution)
+      return failure();
+  }
+  return contribution;
+}
+
+static FailureOr<TensorOffsetValues>
+materializeTensorOffsetFields(Value value, OpBuilder &builder, Location loc) {
+  FailureOr<RankedTensorType> tensorType = getIntegerTensorType(value);
+  if (failed(tensorType))
+    return failure();
+  unsigned rank = (*tensorType).getRank();
+  Type scalarType = (*tensorType).getElementType();
+
+  auto makeZero = [&](AxisKind kind) -> FailureOr<TensorOffsetValues> {
+    TensorOffsetValues result;
+    result.axisKinds = getAxisKinds(rank, kind);
+    for (unsigned axis = 0; axis < rank; ++axis) {
+      Value stride = createScalarConstant(builder, loc, scalarType, 0);
+      if (!stride)
+        return failure();
+      result.strides.push_back(stride);
+    }
+    result.uniformOffset = createScalarConstant(builder, loc, scalarType, 0);
+    result.opaqueContribution = createZeroOffsets(builder, loc, *tensorType);
+    if (!result.uniformOffset || !result.opaqueContribution)
+      return failure();
+    return result;
+  };
+
+  auto fallback = [&]() -> FailureOr<TensorOffsetValues> {
+    FailureOr<TensorOffsetValues> result = makeZero(AxisKind::Opaque);
+    if (failed(result))
+      return failure();
+    result->opaqueContribution = value;
+    return result;
+  };
+
+  if (rank == 1) {
+    FailureOr<Rank1OffsetValues> rankOne =
+        materializeRank1Offset(value, value.getType(), builder, loc);
+    if (failed(rankOne))
+      return failure();
+    if (!isConstantZero(rankOne->residual))
+      return fallback();
+    return TensorOffsetValues{{rankOne->stride},
+                              rankOne->offset,
+                              rankOne->residual,
+                              {AxisKind::Structured}};
+  }
+
+  if (auto range = value.getDefiningOp<triton::MakeRangeOp>()) {
+    if (rank != 1 ||
+        range.getEnd() - range.getStart() != (*tensorType).getShape()[0])
+      return fallback();
+    FailureOr<TensorOffsetValues> result = makeZero(AxisKind::Structured);
+    if (failed(result))
+      return failure();
+    result->strides[0] = createScalarConstant(builder, loc, scalarType, 1);
+    result->uniformOffset =
+        createScalarConstant(builder, loc, scalarType, range.getStart());
+    if (!result->strides[0] || !result->uniformOffset)
+      return failure();
+    return result;
+  }
+
+  if (auto splat = value.getDefiningOp<triton::SplatOp>()) {
+    if (!isa<IntegerType>(splat.getSrc().getType()))
+      return fallback();
+    FailureOr<TensorOffsetValues> result = makeZero(AxisKind::Structured);
+    if (failed(result))
+      return failure();
+    FailureOr<Value> uniform =
+        castIntegerLike(builder, loc, splat.getSrc(), scalarType);
+    if (failed(uniform))
+      return failure();
+    result->uniformOffset = *uniform;
+    return result;
+  }
+
+  if (FailureOr<DenseIntegerSplat> dense = getDenseIntegerSplat(value);
+      succeeded(dense)) {
+    OpBuilder::InsertionGuard insertionGuard(builder);
+    builder.setInsertionPointAfter(value.getDefiningOp());
+    FailureOr<TensorOffsetValues> result = makeZero(AxisKind::Structured);
+    if (failed(result))
+      return failure();
+    Value uniform =
+        createScalarConstant(builder, loc, scalarType, dense->value);
+    if (!uniform)
+      return failure();
+    result->uniformOffset = uniform;
+    return result;
+  }
+
+  if (auto expand = value.getDefiningOp<triton::ExpandDimsOp>()) {
+    FailureOr<TensorOffsetValues> source =
+        materializeTensorOffsetFields(expand.getSrc(), builder, loc);
+    if (failed(source) || source->strides.size() + 1 != rank ||
+        expand.getAxis() >= rank)
+      return fallback();
+    FailureOr<TensorOffsetValues> result = makeZero(AxisKind::Structured);
+    if (failed(result))
+      return failure();
+    unsigned sourceAxis = 0;
+    for (unsigned axis = 0; axis < rank; ++axis) {
+      if (axis == expand.getAxis())
+        continue;
+      result->strides[axis] = source->strides[sourceAxis];
+      result->axisKinds[axis] = source->axisKinds[sourceAxis];
+      ++sourceAxis;
+    }
+    result->uniformOffset = source->uniformOffset;
+    return result;
+  }
+
+  if (auto broadcast = value.getDefiningOp<triton::BroadcastOp>()) {
+    FailureOr<TensorOffsetValues> source =
+        materializeTensorOffsetFields(broadcast.getSrc(), builder, loc);
+    auto sourceType = dyn_cast<RankedTensorType>(broadcast.getSrc().getType());
+    if (failed(source) || !sourceType || sourceType.getRank() != rank)
+      return fallback();
+    FailureOr<TensorOffsetValues> result = makeZero(AxisKind::Structured);
+    if (failed(result))
+      return failure();
+    for (unsigned axis = 0; axis < rank; ++axis) {
+      bool expandsScalarAxis = sourceType.getShape()[axis] == 1 &&
+                               (*tensorType).getShape()[axis] != 1;
+      if (expandsScalarAxis)
+        continue;
+      result->strides[axis] = source->strides[axis];
+      result->axisKinds[axis] = source->axisKinds[axis];
+    }
+    result->uniformOffset = source->uniformOffset;
+    return result;
+  }
+
+  auto materializeBinary = [&](Value lhs, Value rhs,
+                               bool subtract) -> FailureOr<TensorOffsetValues> {
+    FailureOr<TensorOffsetValues> lhsInfo =
+        materializeTensorOffsetFields(lhs, builder, loc);
+    FailureOr<TensorOffsetValues> rhsInfo =
+        materializeTensorOffsetFields(rhs, builder, loc);
+    if (failed(lhsInfo) || failed(rhsInfo) || lhsInfo->strides.size() != rank ||
+        rhsInfo->strides.size() != rank)
+      return fallback();
+    FailureOr<TensorOffsetValues> result = makeZero(AxisKind::Structured);
+    if (failed(result))
+      return failure();
+    for (unsigned axis = 0; axis < rank; ++axis) {
+      result->axisKinds[axis] =
+          lhsInfo->axisKinds[axis] == AxisKind::Structured &&
+                  rhsInfo->axisKinds[axis] == AxisKind::Structured
+              ? AxisKind::Structured
+              : AxisKind::Opaque;
+      if (result->axisKinds[axis] == AxisKind::Structured) {
+        result->strides[axis] =
+            subtract ? createIntegerSub(builder, loc, lhsInfo->strides[axis],
+                                        rhsInfo->strides[axis])
+                     : createIntegerAdd(builder, loc, lhsInfo->strides[axis],
+                                        rhsInfo->strides[axis]);
+        if (!result->strides[axis])
+          return failure();
+      }
+    }
+    if (!hasAnyOpaqueAxis(result->axisKinds)) {
+      result->uniformOffset =
+          subtract ? createIntegerSub(builder, loc, lhsInfo->uniformOffset,
+                                      rhsInfo->uniformOffset)
+                   : createIntegerAdd(builder, loc, lhsInfo->uniformOffset,
+                                      rhsInfo->uniformOffset);
+      if (!result->uniformOffset)
+        return failure();
+    }
+    return result;
+  };
+
+  FailureOr<TensorOffsetValues> result = failure();
+  if (auto add = value.getDefiningOp<arith::AddIOp>())
+    result = materializeBinary(add.getLhs(), add.getRhs(), false);
+  else if (auto sub = value.getDefiningOp<arith::SubIOp>())
+    result = materializeBinary(sub.getLhs(), sub.getRhs(), true);
+  else if (auto mul = value.getDefiningOp<arith::MulIOp>()) {
+    Value affineOperand = mul.getLhs();
+    FailureOr<Value> scale =
+        materializeUniformIntegerScale(mul.getRhs(), builder, loc);
+    if (failed(scale)) {
+      affineOperand = mul.getRhs();
+      scale = materializeUniformIntegerScale(mul.getLhs(), builder, loc);
+    }
+    if (failed(scale))
+      return fallback();
+    result = materializeTensorOffsetFields(affineOperand, builder, loc);
+    if (succeeded(result)) {
+      for (unsigned axis = 0; axis < rank; ++axis) {
+        if (result->axisKinds[axis] == AxisKind::Structured)
+          result->strides[axis] =
+              scaleIntegerValue(builder, loc, result->strides[axis], *scale);
+        if (!result->strides[axis])
+          return failure();
+      }
+      if (!hasAnyOpaqueAxis(result->axisKinds)) {
+        result->uniformOffset =
+            scaleIntegerValue(builder, loc, result->uniformOffset, *scale);
+        if (!result->uniformOffset)
+          return failure();
+      }
+    }
+  } else {
+    return fallback();
+  }
+
+  if (failed(result))
+    return failure();
+  if (!hasAnyOpaqueAxis(result->axisKinds))
+    return result;
+
+  FailureOr<Value> structured = materializeStructuredContribution(
+      result->strides, result->axisKinds, *tensorType, builder, loc);
+  if (failed(structured))
+    return failure();
+  FailureOr<Value> complete =
+      castIntegerLike(builder, loc, value, (*tensorType));
+  if (failed(complete))
+    return failure();
+  Value opaque = createIntegerSub(builder, loc, *complete, *structured);
+  if (!opaque)
+    return failure();
+  result->uniformOffset = createScalarConstant(builder, loc, scalarType, 0);
+  result->opaqueContribution = opaque;
+  for (unsigned axis = 0; axis < rank; ++axis) {
+    if (result->axisKinds[axis] == AxisKind::Opaque)
+      result->strides[axis] = createScalarConstant(builder, loc, scalarType, 0);
+    if (!result->strides[axis])
+      return failure();
+  }
+  if (!result->uniformOffset)
+    return failure();
+  return result;
+}
+
+static Value materializeTensorCompleteOffsets(const DecomposedValue &value,
+                                              OpBuilder &builder,
+                                              Location loc) {
+  if (!hasValidLayout(value))
+    return nullptr;
+  auto pointerTensor = cast<RankedTensorType>(value.originalType);
+  unsigned rank = pointerTensor.getRank();
+  if (rank == 1)
+    return materializeRank1CompleteOffsets(value, builder, loc);
+
+  auto offsetsType = cast<RankedTensorType>(
+      value.components[getOpaqueContributionComponent(rank)].getType());
+  SmallVector<Value> strides;
+  strides.reserve(rank);
+  for (unsigned axis = 0; axis < rank; ++axis)
+    strides.push_back(value.components[getStrideComponent(axis)]);
+  SmallVector<AxisKind> allStructured =
+      getAxisKinds(rank, AxisKind::Structured);
+  FailureOr<Value> structured = materializeStructuredContribution(
+      strides, allStructured, offsetsType, builder, loc);
+  if (failed(structured))
+    return nullptr;
+
+  Value uniform = value.components[getUniformOffsetComponent(rank)];
+  if (!isConstantZero(uniform)) {
+    FailureOr<Value> converted =
+        castIntegerLike(builder, loc, uniform, offsetsType.getElementType());
+    if (failed(converted))
+      return nullptr;
+    Value uniformTensor =
+        builder.create<triton::SplatOp>(loc, offsetsType, *converted);
+    *structured = createIntegerAdd(builder, loc, *structured, uniformTensor);
+    if (!*structured)
+      return nullptr;
+  }
+
+  Value opaque = value.components[getOpaqueContributionComponent(rank)];
+  if (isConstantZero(opaque))
+    return *structured;
+  return createIntegerAdd(builder, loc, *structured, opaque);
+}
+
+static FailureOr<Value> materializeScalarBaseAddress(OpBuilder &builder,
+                                                     Location loc, Value base) {
+  if (!isa<triton::PointerType>(base.getType()))
+    return failure();
+
+  if (auto intToPtr = base.getDefiningOp<triton::IntToPtrOp>();
+      intToPtr && intToPtr.getSrc().getType().isInteger(64))
+    return intToPtr.getSrc();
+
+  // The symbolic base identity is the scalar pointer Value, so its concrete
+  // i64 address must dominate every splat of that Value. In particular, two
+  // sibling if arms may each build a tensor pointer from one function argument
+  // while the rebuilt result lives after the if.
+  OpBuilder::InsertionGuard insertionGuard(builder);
+  if (auto blockArgument = dyn_cast<BlockArgument>(base)) {
+    Block *owner = blockArgument.getOwner();
+    Operation *lastLeadingAddress = nullptr;
+    for (Operation &operation : *owner) {
+      auto existing = dyn_cast<triton::PtrToIntOp>(&operation);
+      if (!existing)
+        break;
+      if (existing.getSrc() == base &&
+          existing.getResult().getType().isInteger(64))
+        return existing.getResult();
+      lastLeadingAddress = &operation;
+    }
+    if (lastLeadingAddress)
+      builder.setInsertionPointAfter(lastLeadingAddress);
+    else
+      builder.setInsertionPointToStart(owner);
+  } else if (Operation *definingOp = base.getDefiningOp()) {
+    if (Operation *next = definingOp->getNextNode()) {
+      if (auto existing = dyn_cast<triton::PtrToIntOp>(next);
+          existing && existing.getSrc() == base &&
+          existing.getResult().getType().isInteger(64))
+        return existing.getResult();
+    }
+    builder.setInsertionPointAfter(definingOp);
+  } else {
+    return failure();
+  }
+
+  return builder.create<triton::PtrToIntOp>(loc, builder.getI64Type(), base)
+      .getResult();
+}
+
+// Recover the original scalar pointer only when the descriptor component is
+// the direct address produced from that pointer.  This preserves native
+// memref provenance for loop-invariant tensor-of-pointer bases while keeping
+// the conservative int-to-ptr fallback for a base that was actually changed
+// by an SCF boundary.
+static Value recoverNativeScalarBase(Value baseAddress,
+                                     triton::PointerType expectedType) {
+  auto ptrToInt = baseAddress.getDefiningOp<triton::PtrToIntOp>();
+  if (!ptrToInt || ptrToInt.getSrc().getType() != expectedType)
+    return nullptr;
+  return ptrToInt.getSrc();
+}
+
+static SmallVector<unsigned>
+getCandidateComponents(const AnalyzedValue &value) {
+  SmallVector<unsigned> indices;
+  unsigned first = hasScalarBase(value) ? kBaseComponent : kBaseComponent + 1;
+  for (unsigned index = first; index < value.components.size(); ++index)
+    indices.push_back(index);
+  return indices;
+}
+
+static SmallVector<unsigned> getOffsetComponentIndices(Type pointerType) {
+  unsigned rank = cast<RankedTensorType>(pointerType).getRank();
+  SmallVector<unsigned> indices;
+  for (unsigned axis = 0; axis < rank; ++axis)
+    indices.push_back(getStrideComponent(axis));
+  indices.push_back(getUniformOffsetComponent(rank));
+  indices.push_back(getOpaqueContributionComponent(rank));
+  return indices;
+}
+
+static bool offsetComponentTypesDiffer(const AnalyzedValue &lhs,
+                                       const AnalyzedValue &rhs) {
+  for (unsigned component : getOffsetComponentIndices(lhs.originalType)) {
+    if (lhs.components[component].type != rhs.components[component].type)
+      return true;
+  }
+  return false;
+}
+
+static bool canSafelyJoinOffsetTypes(const AnalyzedValue &lhs,
+                                     const AnalyzedValue &rhs) {
+  if (!offsetComponentTypesDiffer(lhs, rhs))
+    return true;
+  unsigned rank = cast<RankedTensorType>(lhs.originalType).getRank();
+  auto lhsType = dyn_cast<IntegerType>(
+      lhs.components[getUniformOffsetComponent(rank)].type);
+  auto rhsType = dyn_cast<IntegerType>(
+      rhs.components[getUniformOffsetComponent(rank)].type);
+  if (!lhsType || !rhsType || lhsType.getWidth() == rhsType.getWidth())
+    return false;
+  const AnalyzedValue &narrower =
+      lhsType.getWidth() < rhsType.getWidth() ? lhs : rhs;
+  for (unsigned axis = 0; axis < rank; ++axis) {
+    if (!isZeroIdentity(narrower.components[getStrideComponent(axis)].identity))
+      return false;
+  }
+  return isZeroIdentity(
+      narrower.components[getUniformOffsetComponent(rank)].identity);
+}
+
+static FailureOr<SmallVector<AxisKind>>
+joinAxisKinds(const AnalyzedValue &lhs, const AnalyzedValue &rhs) {
+  FailureOr<SmallVector<AxisKind>> lhsKinds = getAxisKinds(lhs);
+  FailureOr<SmallVector<AxisKind>> rhsKinds = getAxisKinds(rhs);
+  if (failed(lhsKinds) || failed(rhsKinds) ||
+      lhsKinds->size() != rhsKinds->size())
+    return failure();
+  SmallVector<AxisKind> result;
+  for (auto [lhsKind, rhsKind] : llvm::zip(*lhsKinds, *rhsKinds)) {
+    result.push_back(lhsKind == AxisKind::Structured &&
+                             rhsKind == AxisKind::Structured
+                         ? AxisKind::Structured
+                         : AxisKind::Opaque);
+  }
+  return result;
+}
+
+// Keep only identity-changing fields that survive normalization to the joined
+// axis schema. For example, joining a Structured axis with an Opaque axis
+// makes that axis stride and the shared uniform offset canonical zero values;
+// carrying either value through SCF would create dead positional slots. Any
+// change represented by those fields is transferred through the complete
+// opaque contribution instead.
+static FailureOr<SmallVector<unsigned>>
+filterTransferredComponentsForJoinedAxes(
+    const AnalyzedValue &value, ArrayRef<AxisKind> joinedKinds,
+    ArrayRef<unsigned> identityChangingComponents) {
+  if (!hasValidLayout(value))
+    return failure();
+  unsigned rank = cast<RankedTensorType>(value.originalType).getRank();
+  if (joinedKinds.size() != rank)
+    return failure();
+
+  bool hasOpaqueAxis = hasAnyOpaqueAxis(joinedKinds);
+  bool opaqueContributionChanges = false;
+  SmallVector<unsigned> transferred;
+  for (unsigned component : identityChangingComponents) {
+    if (component >= value.components.size())
+      return failure();
+    if (component == kBaseComponent) {
+      transferred.push_back(component);
+      continue;
+    }
+    if (component >= getStrideComponent(0) &&
+        component < getStrideComponent(rank)) {
+      unsigned axis = component - getStrideComponent(0);
+      if (joinedKinds[axis] == AxisKind::Structured)
+        transferred.push_back(component);
+      else
+        opaqueContributionChanges = true;
+      continue;
+    }
+    if (component == getUniformOffsetComponent(rank)) {
+      if (!hasOpaqueAxis)
+        transferred.push_back(component);
+      else
+        opaqueContributionChanges = true;
+      continue;
+    }
+    if (component == getOpaqueContributionComponent(rank)) {
+      if (hasOpaqueAxis)
+        opaqueContributionChanges = true;
+      continue;
+    }
+    return failure();
+  }
+  if (opaqueContributionChanges)
+    transferred.push_back(getOpaqueContributionComponent(rank));
+  llvm::sort(transferred);
+  return transferred;
+}
+
+static SmallVector<Attribute>
+getTensorPointerAttributes(MLIRContext *context, bool baseIsScalar,
+                           ArrayRef<AxisKind> axisKinds) {
+  return {BoolAttr::get(context, baseIsScalar),
+          getAxisKindsAttr(context, axisKinds)};
+}
+
+static LogicalResult normalizeOffsetComponents(DecomposedValue &value,
+                                               ArrayRef<AxisKind> targetKinds,
+                                               OpBuilder &builder,
+                                               Location loc) {
+  if (!hasValidLayout(value))
+    return failure();
+  unsigned rank = cast<RankedTensorType>(value.originalType).getRank();
+  FailureOr<SmallVector<AxisKind>> currentKinds = getAxisKinds(value);
+  if (failed(currentKinds) || targetKinds.size() != rank)
+    return failure();
+  for (unsigned axis = 0; axis < rank; ++axis) {
+    if ((*currentKinds)[axis] == AxisKind::Opaque &&
+        targetKinds[axis] == AxisKind::Structured)
+      return failure();
+  }
+
+  Value complete = materializeTensorCompleteOffsets(value, builder, loc);
+  if (!complete)
+    return failure();
+  auto completeType = cast<RankedTensorType>(complete.getType());
+  Type scalarType = completeType.getElementType();
+  SmallVector<Value> retainedStrides;
+  for (unsigned axis = 0; axis < rank; ++axis) {
+    FailureOr<Value> stride = castIntegerLike(
+        builder, loc, value.components[getStrideComponent(axis)], scalarType);
+    if (failed(stride))
+      return failure();
+    if (targetKinds[axis] == AxisKind::Opaque)
+      *stride = createScalarConstant(builder, loc, scalarType, 0);
+    if (!*stride)
+      return failure();
+    retainedStrides.push_back(*stride);
+    value.components[getStrideComponent(axis)] = *stride;
+  }
+
+  if (hasAnyOpaqueAxis(targetKinds)) {
+    FailureOr<Value> structured = materializeStructuredContribution(
+        retainedStrides, targetKinds, completeType, builder, loc);
+    if (failed(structured))
+      return failure();
+    Value opaque = createIntegerSub(builder, loc, complete, *structured);
+    Value zero = createScalarConstant(builder, loc, scalarType, 0);
+    if (!opaque || !zero)
+      return failure();
+    value.components[getUniformOffsetComponent(rank)] = zero;
+    value.components[getOpaqueContributionComponent(rank)] = opaque;
+  } else {
+    FailureOr<Value> uniform = castIntegerLike(
+        builder, loc, value.components[getUniformOffsetComponent(rank)],
+        scalarType);
+    if (failed(uniform))
+      return failure();
+    value.components[getUniformOffsetComponent(rank)] = *uniform;
+    value.components[getOpaqueContributionComponent(rank)] =
+        createZeroOffsets(builder, loc, completeType);
+  }
+  return success();
+}
+
+class TensorPtrDecomposePolicy final : public ControlFlowRewritePolicy {
+public:
+  bool matches(Type type) const override { return isTensorPointerType(type); }
+
   FailureOr<AnalyzedValue>
   analyzeValue(Value value,
                ControlFlowAnalysisContext &context) const override {
-    // Region arguments and previously merged control-flow results are already
-    // bound in the stage-scoped cache. Reusing them is what lets analysis cross
-    // sibling and nested SCF without inspecting rewritten IR.
     if (const AnalyzedValue *known = context.lookupValue(value)) {
       if (!matches(known->originalType))
         return failure();
       return *known;
     }
 
-    // addptr preserves the upstream common base and adds another contribution
-    // to complete_offsets. The result Value is used only as a symbolic identity
-    // showing that this component changed.
+    // Broadcasting an already-structured pointer tensor only changes the
+    // descriptor shape. An expanded unit dimension repeats the same pointer,
+    // so that dimension has stride zero in the result descriptor. Restrict the
+    // propagation to scalar-base descriptors with no opaque contribution;
+    // unknown or partially opaque pointer tensors retain the established
+    // complete-pointer fallback below.
+    if (auto broadcast = value.getDefiningOp<triton::BroadcastOp>()) {
+      FailureOr<AnalyzedValue> result =
+          context.analyzeValue(broadcast.getSrc());
+      if (succeeded(result) && hasValidLayout(*result) &&
+          hasScalarBase(*result) &&
+          isCompatiblePointerBroadcast(broadcast.getSrc().getType(),
+                                       value.getType())) {
+        FailureOr<SmallVector<AxisKind>> kinds = getAxisKinds(*result);
+        auto sourceType = cast<RankedTensorType>(broadcast.getSrc().getType());
+        auto resultType = cast<RankedTensorType>(value.getType());
+        unsigned rank = resultType.getRank();
+        if (succeeded(kinds) && !llvm::is_contained(*kinds, AxisKind::Opaque) &&
+            isZeroIdentity(
+                result->components[getOpaqueContributionComponent(rank)]
+                    .identity)) {
+          for (unsigned axis = 0; axis < rank; ++axis) {
+            if (sourceType.getShape()[axis] == 1 &&
+                resultType.getShape()[axis] != 1) {
+              result->components[getStrideComponent(axis)].identity =
+                  ComponentIdentity::zero(getStrideComponent(axis));
+            }
+          }
+          Type scalarType =
+              result->components[getUniformOffsetComponent(rank)].type;
+          auto resultOffsetsType = RankedTensorType::get(
+              resultType.getShape(), scalarType, resultType.getEncoding());
+          result->components[getOpaqueContributionComponent(rank)] = {
+              resultOffsetsType,
+              ComponentIdentity::zero(getOpaqueContributionComponent(rank))};
+          result->originalType = value.getType();
+          result->attributes[kAxisKindsAttribute] =
+              getAxisKindsAttr(value.getContext(), *kinds);
+          return *result;
+        }
+      }
+    }
+
     if (auto addPtr = value.getDefiningOp<triton::AddPtrOp>()) {
       FailureOr<AnalyzedValue> result = context.analyzeValue(addPtr.getPtr());
-      if (failed(result) || !hasValidLayout(*result))
+      FailureOr<AnalyzedTensorOffset> delta =
+          analyzeTensorOffset(addPtr.getOffset());
+      if (failed(result) || !hasValidLayout(*result) || failed(delta))
         return failure();
-      FailureOr<Type> offsetsType =
-          getWiderOffsetsType(result->components[kOffsetsComponent].type,
-                              addPtr.getOffset().getType());
-      if (failed(offsetsType))
+      FailureOr<SmallVector<AxisKind>> currentKinds = getAxisKinds(*result);
+      if (failed(currentKinds) || currentKinds->size() != delta->strides.size())
         return failure();
+      unsigned rank = currentKinds->size();
+      FailureOr<Type> joinedResidualType = getWiderIntegerLikeType(
+          result->components[getOpaqueContributionComponent(rank)].type,
+          delta->opaqueContribution.type);
+      if (failed(joinedResidualType))
+        return failure();
+      auto joinedTensorType = cast<RankedTensorType>(*joinedResidualType);
+      Type scalarType = joinedTensorType.getElementType();
+      SmallVector<AxisKind> resultKinds;
+      for (unsigned axis = 0; axis < rank; ++axis) {
+        AxisKind kind = hasScalarBase(*result) &&
+                                (*currentKinds)[axis] == AxisKind::Structured &&
+                                delta->axisKinds[axis] == AxisKind::Structured
+                            ? AxisKind::Structured
+                            : AxisKind::Opaque;
+        resultKinds.push_back(kind);
+        result->components[getStrideComponent(axis)] = {
+            scalarType,
+            kind == AxisKind::Structured
+                ? getAddIdentity(
+                      result->components[getStrideComponent(axis)].identity,
+                      delta->strides[axis].identity, value,
+                      getStrideComponent(axis))
+                : ComponentIdentity::zero(getStrideComponent(axis))};
+      }
+      if (hasAnyOpaqueAxis(resultKinds)) {
+        result->components[getUniformOffsetComponent(rank)] = {
+            scalarType,
+            ComponentIdentity::zero(getUniformOffsetComponent(rank))};
+        result->components[getOpaqueContributionComponent(rank)] = {
+            joinedTensorType, ComponentIdentity::fromValue(
+                                  value, getOpaqueContributionComponent(rank))};
+      } else {
+        result->components[getUniformOffsetComponent(rank)] = {
+            scalarType,
+            getAddIdentity(
+                result->components[getUniformOffsetComponent(rank)].identity,
+                delta->uniformOffset.identity, value,
+                getUniformOffsetComponent(rank))};
+        result->components[getOpaqueContributionComponent(rank)] = {
+            joinedTensorType,
+            ComponentIdentity::zero(getOpaqueContributionComponent(rank))};
+      }
       result->originalType = value.getType();
-      result->components[kOffsetsComponent] = {
-          *offsetsType, ComponentIdentity::fromValue(value, kOffsetsComponent)};
+      result->attributes[kAxisKindsAttribute] =
+          getAxisKindsAttr(value.getContext(), resultKinds);
       return *result;
     }
 
-    // Splatting one scalar pointer establishes the canonical common-base form:
-    // every lane starts at the scalar base and therefore has zero offset.
     if (auto splat = value.getDefiningOp<triton::SplatOp>()) {
       if (!isa<triton::PointerType>(splat.getSrc().getType()))
         return failure();
-      Type offsetsType = getDefaultOffsetsType(value.getType());
-      return AnalyzedValue{value.getType(),
-                           {{offsetsType, ComponentIdentity::zero()}},
-                           {splat.getSrc()},
-                           {BoolAttr::get(value.getContext(), true)}};
+      auto offsetsType = getDefaultOffsetsType(value.getType());
+      unsigned rank = cast<RankedTensorType>(value.getType()).getRank();
+      Type scalarType = offsetsType.getElementType();
+      SmallVector<AnalyzedComponent> components = {
+          {IntegerType::get(value.getContext(), 64),
+           ComponentIdentity::fromValue(splat.getSrc(), kBaseComponent)}};
+      for (unsigned axis = 0; axis < rank; ++axis)
+        components.push_back(
+            {scalarType, ComponentIdentity::zero(getStrideComponent(axis))});
+      components.push_back({scalarType, ComponentIdentity::zero(
+                                            getUniformOffsetComponent(rank))});
+      components.push_back(
+          {offsetsType,
+           ComponentIdentity::zero(getOpaqueContributionComponent(rank))});
+      return AnalyzedValue{
+          value.getType(), std::move(components),
+          getTensorPointerAttributes(value.getContext(), true,
+                                     getAxisKinds(rank, AxisKind::Structured))};
     }
 
-    // An otherwise opaque tensor-of-pointers is treated as an already-vector
-    // base with zero additional offsets. This preserves current behavior until
-    // common-base analysis is shared with TritonToUnstructure.
     if (!matches(value.getType()))
       return failure();
-    Type offsetsType = getDefaultOffsetsType(value.getType());
-    return AnalyzedValue{value.getType(),
-                         {{offsetsType, ComponentIdentity::zero()}},
-                         {value},
-                         {BoolAttr::get(value.getContext(), false)}};
+    auto offsetsType = getDefaultOffsetsType(value.getType());
+    unsigned rank = cast<RankedTensorType>(value.getType()).getRank();
+    Type scalarType = offsetsType.getElementType();
+    SmallVector<AnalyzedComponent> components = {
+        {value.getType(), ComponentIdentity::fromValue(value, kBaseComponent)}};
+    for (unsigned axis = 0; axis < rank; ++axis)
+      components.push_back(
+          {scalarType, ComponentIdentity::zero(getStrideComponent(axis))});
+    components.push_back(
+        {scalarType, ComponentIdentity::zero(getUniformOffsetComponent(rank))});
+    components.push_back(
+        {offsetsType,
+         ComponentIdentity::zero(getOpaqueContributionComponent(rank))});
+    return AnalyzedValue{
+        value.getType(), std::move(components),
+        getTensorPointerAttributes(value.getContext(), false,
+                                   getAxisKinds(rank, AxisKind::Opaque))};
   }
 
-  /// Tensor pointers have exactly one loop-transfer candidate: the complete
-  /// per-lane offsets tensor at component index 0.
   FailureOr<SmallVector<unsigned>>
   getLoopCandidateComponents(const AnalyzedValue &value) const override {
     if (!hasValidLayout(value))
       return failure();
-    return SmallVector<unsigned>{kOffsetsComponent};
+    return getCandidateComponents(value);
   }
 
-  /// Classifies the loop offsets as transferred only when the backedge changes
-  /// their symbolic identity. The original pointer type, common base, and base
-  /// representation must remain invariant for reconstruction to be valid.
   FailureOr<SmallVector<unsigned>>
   getLoopTransferredComponents(const AnalyzedValue &initial,
                                const AnalyzedValue &regionArgument,
                                const AnalyzedValue &next) const override {
-    if (!haveSameTensorPtrBaseSchema(initial, regionArgument) ||
-        !haveSameTensorPtrBaseSchema(initial, next) ||
-        failed(joinComponentTypes(initial.components[kOffsetsComponent].type,
-                                  next.components[kOffsetsComponent].type)))
+    if (!hasSameRepresentation(initial, regionArgument) ||
+        !hasSameRepresentation(initial, next) ||
+        !canSafelyJoinOffsetTypes(initial, next))
       return failure();
-    // Yielding the region argument unchanged requires no new SCF iter-arg.
-    if (regionArgument.components[kOffsetsComponent].identity ==
-        next.components[kOffsetsComponent].identity)
-      return SmallVector<unsigned>{};
-    return SmallVector<unsigned>{kOffsetsComponent};
+    FailureOr<SmallVector<AxisKind>> joinedKinds = joinAxisKinds(initial, next);
+    if (failed(joinedKinds))
+      return failure();
+
+    SmallVector<unsigned> identityChangingComponents;
+    for (unsigned component : getCandidateComponents(initial)) {
+      const ComponentIdentity &nextIdentity =
+          next.components[component].identity;
+      bool forwardsCurrent =
+          nextIdentity == regionArgument.components[component].identity;
+      bool restoresInitial =
+          nextIdentity == initial.components[component].identity;
+      if (!forwardsCurrent && !restoresInitial)
+        identityChangingComponents.push_back(component);
+    }
+    FailureOr<SmallVector<unsigned>> transferred =
+        filterTransferredComponentsForJoinedAxes(initial, *joinedKinds,
+                                                 identityChangingComponents);
+    if (failed(transferred))
+      return failure();
+    for (unsigned component : *transferred) {
+      if (failed(joinComponentTypes(initial.components[component].type,
+                                    next.components[component].type)))
+        return failure();
+    }
+    return *transferred;
   }
 
-  /// Merges the two `scf.if` pointer states. Different complete-offset
-  /// identities become an if result; the base and its scalar/tensor form must
-  /// agree so one pointer can be rebuilt after the if.
   FailureOr<SmallVector<unsigned>>
   getIfTransferredComponents(const AnalyzedValue &thenValue,
                              const AnalyzedValue &elseValue) const override {
-    if (!haveSameTensorPtrBaseSchema(thenValue, elseValue) ||
-        failed(
-            joinComponentTypes(thenValue.components[kOffsetsComponent].type,
-                               elseValue.components[kOffsetsComponent].type)))
+    if (!hasSameRepresentation(thenValue, elseValue) ||
+        !canSafelyJoinOffsetTypes(thenValue, elseValue))
       return failure();
-    // Identical symbolic offsets are available outside the if as an invariant.
-    if (thenValue.components[kOffsetsComponent].identity ==
-        elseValue.components[kOffsetsComponent].identity)
-      return SmallVector<unsigned>{};
-    return SmallVector<unsigned>{kOffsetsComponent};
+    FailureOr<SmallVector<AxisKind>> joinedKinds =
+        joinAxisKinds(thenValue, elseValue);
+    if (failed(joinedKinds))
+      return failure();
+    SmallVector<unsigned> identityChangingComponents;
+    for (unsigned component : getCandidateComponents(thenValue)) {
+      if (thenValue.components[component].identity !=
+          elseValue.components[component].identity)
+        identityChangingComponents.push_back(component);
+    }
+    FailureOr<SmallVector<unsigned>> transferred =
+        filterTransferredComponentsForJoinedAxes(thenValue, *joinedKinds,
+                                                 identityChangingComponents);
+    if (failed(transferred))
+      return failure();
+    for (unsigned component : *transferred) {
+      if (failed(joinComponentTypes(thenValue.components[component].type,
+                                    elseValue.components[component].type)))
+        return failure();
+    }
+    return *transferred;
   }
 
-  /// Chooses the offsets type carried by the replacement control-flow op.
+  FailureOr<SmallVector<Attribute>>
+  mergeControlFlowAttributes(const AnalyzedValue &lhs,
+                             const AnalyzedValue &rhs) const override {
+    if (!hasValidLayout(lhs) || !hasValidLayout(rhs) ||
+        lhs.originalType != rhs.originalType ||
+        hasScalarBase(lhs) != hasScalarBase(rhs))
+      return failure();
+    FailureOr<SmallVector<AxisKind>> kinds = joinAxisKinds(lhs, rhs);
+    if (failed(kinds))
+      return failure();
+    return getTensorPointerAttributes(lhs.originalType.getContext(),
+                                      hasScalarBase(lhs), *kinds);
+  }
+
   FailureOr<Type> joinComponentTypes(Type lhs, Type rhs) const override {
-    return getWiderOffsetsType(lhs, rhs);
+    return getWiderIntegerLikeType(lhs, rhs);
   }
 
-  //===--------------------------------------------------------------------===//
-  // Concrete rewrite materialization
-  //===--------------------------------------------------------------------===//
-
-  /// addptr results must be decomposed immediately after cloning so later users
-  /// can obtain their accumulated offsets from the rewrite context.
   bool shouldDecomposeOperation(Operation *op) const override {
     return isa<triton::AddPtrOp>(op);
   }
 
-  /// Materializes the same decomposition described by analyzeValue. This may
-  /// create zero constants and integer additions, so it is called only after
-  /// the complete control-flow subtree has passed read-only analysis.
+  bool requiresPointerDescriptorBoundaryMarker() const override { return true; }
+
+  bool shouldMarkOperationRecomposition(Operation *op) const override {
+    return isa<triton::AddPtrOp>(op);
+  }
+
+  LogicalResult normalizeControlFlowValue(DecomposedValue &value,
+                                          ArrayRef<Attribute> targetAttributes,
+                                          OpBuilder &builder,
+                                          Location loc) const override {
+    if (!hasValidLayout(value) || targetAttributes.size() != 2)
+      return failure();
+    auto targetBase =
+        dyn_cast<BoolAttr>(targetAttributes[kBaseIsScalarAttribute]);
+    auto targetKinds =
+        dyn_cast<DenseI32ArrayAttr>(targetAttributes[kAxisKindsAttribute]);
+    if (!targetBase || !targetKinds ||
+        targetBase.getValue() != hasScalarBase(value))
+      return failure();
+    SmallVector<AxisKind> kinds;
+    for (int32_t rawKind : targetKinds.asArrayRef()) {
+      if (rawKind != static_cast<int32_t>(AxisKind::Opaque) &&
+          rawKind != static_cast<int32_t>(AxisKind::Structured))
+        return failure();
+      kinds.push_back(static_cast<AxisKind>(rawKind));
+    }
+    if (failed(normalizeOffsetComponents(value, kinds, builder, loc)))
+      return failure();
+    value.attributes.assign(targetAttributes.begin(), targetAttributes.end());
+    return success();
+  }
+
+  LogicalResult annotatePointerDescriptorRebuild(
+      Operation *rebuildOp, const DecomposedValue &value) const override {
+    if (!hasValidLayout(value) || !isa<triton::AddPtrOp>(rebuildOp))
+      return failure();
+    FailureOr<SmallVector<AxisKind>> kinds = getAxisKinds(value);
+    if (failed(kinds))
+      return failure();
+    rebuildOp->setAttr(kPointerDescriptorStructuredAxesAttr,
+                       getAxisKindsAttr(rebuildOp->getContext(), *kinds));
+    if (kinds->size() == 1 && kinds->front() == AxisKind::Structured &&
+        hasScalarBase(value) &&
+        isConstantZero(value.components[kResidualComponent])) {
+      rebuildOp->setAttr(
+          kPointerDescriptorOffsetFormAttr,
+          StringAttr::get(rebuildOp->getContext(), kStrided1DOffsetForm));
+    } else {
+      rebuildOp->removeAttr(kPointerDescriptorOffsetFormAttr);
+    }
+    return success();
+  }
+
   FailureOr<DecomposedValue> decompose(Value value,
                                        const ControlFlowRewriteContext &context,
                                        OpBuilder &builder,
                                        Location loc) const override {
-    // Rewritten region arguments and nested results have exact component Values
-    // recorded by ControlFlowRewrite; never reconstruct them from old IR.
     if (const DecomposedValue *known = context.lookup(value)) {
       if (!matches(known->originalType))
         return failure();
       return *known;
     }
 
-    // Ordinary SSA inputs may already have been cloned into the replacement
-    // region, so pointer producer matching must use the remapped Value.
     value = context.remap(value);
-    // Recursively flatten an addptr chain into one complete offsets tensor.
+    if (auto broadcast = value.getDefiningOp<triton::BroadcastOp>()) {
+      FailureOr<DecomposedValue> result =
+          decompose(broadcast.getSrc(), context, builder, loc);
+      if (succeeded(result) && hasValidLayout(*result) &&
+          hasScalarBase(*result) &&
+          isCompatiblePointerBroadcast(broadcast.getSrc().getType(),
+                                       value.getType())) {
+        FailureOr<SmallVector<AxisKind>> kinds = getAxisKinds(*result);
+        auto sourceType = cast<RankedTensorType>(broadcast.getSrc().getType());
+        auto resultType = cast<RankedTensorType>(value.getType());
+        unsigned rank = resultType.getRank();
+        if (succeeded(kinds) && !llvm::is_contained(*kinds, AxisKind::Opaque) &&
+            isConstantZero(
+                result->components[getOpaqueContributionComponent(rank)])) {
+          OpBuilder::InsertionGuard guard(builder);
+          builder.setInsertionPoint(broadcast);
+          for (unsigned axis = 0; axis < rank; ++axis) {
+            if (sourceType.getShape()[axis] == 1 &&
+                resultType.getShape()[axis] != 1) {
+              Type strideType =
+                  result->components[getStrideComponent(axis)].getType();
+              result->components[getStrideComponent(axis)] =
+                  createScalarConstant(builder, broadcast.getLoc(), strideType,
+                                       0);
+              if (!result->components[getStrideComponent(axis)])
+                return failure();
+            }
+          }
+          Type scalarType =
+              result->components[getUniformOffsetComponent(rank)].getType();
+          auto resultOffsetsType = RankedTensorType::get(
+              resultType.getShape(), scalarType, resultType.getEncoding());
+          Value zeroOffsets =
+              createZeroOffsets(builder, broadcast.getLoc(), resultOffsetsType);
+          if (!zeroOffsets)
+            return failure();
+          result->components[getOpaqueContributionComponent(rank)] =
+              zeroOffsets;
+          result->originalType = value.getType();
+          result->attributes[kAxisKindsAttribute] =
+              getAxisKindsAttr(value.getContext(), *kinds);
+          return *result;
+        }
+      }
+    }
+
     if (auto addPtr = value.getDefiningOp<triton::AddPtrOp>()) {
       FailureOr<DecomposedValue> result =
           decompose(addPtr.getPtr(), context, builder, loc);
       if (failed(result) || !hasValidLayout(*result))
         return failure();
-
-      // Insert the accumulated addition beside the addptr being decomposed;
-      // ControlFlowRewrite will use this Value in the expanded SCF signature.
       OpBuilder::InsertionGuard guard(builder);
       builder.setInsertionPoint(addPtr);
-      Value offsets = createOffsetsAdd(builder, addPtr.getLoc(),
-                                       result->components[kOffsetsComponent],
-                                       context.remap(addPtr.getOffset()));
-      if (!offsets)
+      Value deltaValue = context.remap(addPtr.getOffset());
+      FailureOr<TensorOffsetValues> delta =
+          materializeTensorOffsetFields(deltaValue, builder, addPtr.getLoc());
+      FailureOr<SmallVector<AxisKind>> currentKinds = getAxisKinds(*result);
+      if (failed(delta) || failed(currentKinds) ||
+          delta->strides.size() != currentKinds->size())
         return failure();
+      unsigned rank = currentKinds->size();
+      SmallVector<AxisKind> resultKinds;
+      SmallVector<Value> resultStrides;
+      for (unsigned axis = 0; axis < rank; ++axis) {
+        AxisKind kind = hasScalarBase(*result) &&
+                                (*currentKinds)[axis] == AxisKind::Structured &&
+                                delta->axisKinds[axis] == AxisKind::Structured
+                            ? AxisKind::Structured
+                            : AxisKind::Opaque;
+        resultKinds.push_back(kind);
+        Value stride =
+            kind == AxisKind::Structured
+                ? createIntegerAdd(builder, addPtr.getLoc(),
+                                   result->components[getStrideComponent(axis)],
+                                   delta->strides[axis])
+                : createScalarConstant(builder, addPtr.getLoc(),
+                                       delta->strides[axis].getType(), 0);
+        if (!stride)
+          return failure();
+        resultStrides.push_back(stride);
+      }
+
+      Value currentComplete =
+          materializeTensorCompleteOffsets(*result, builder, addPtr.getLoc());
+      Value nextComplete = currentComplete
+                               ? createIntegerAdd(builder, addPtr.getLoc(),
+                                                  currentComplete, deltaValue)
+                               : nullptr;
+      if (!nextComplete)
+        return failure();
+      auto nextType = cast<RankedTensorType>(nextComplete.getType());
+      Type scalarType = nextType.getElementType();
+      for (unsigned axis = 0; axis < rank; ++axis) {
+        FailureOr<Value> converted = castIntegerLike(
+            builder, addPtr.getLoc(), resultStrides[axis], scalarType);
+        if (failed(converted))
+          return failure();
+        result->components[getStrideComponent(axis)] = *converted;
+      }
+      if (hasAnyOpaqueAxis(resultKinds)) {
+        SmallVector<Value> strides;
+        for (unsigned axis = 0; axis < rank; ++axis)
+          strides.push_back(result->components[getStrideComponent(axis)]);
+        FailureOr<Value> structured = materializeStructuredContribution(
+            strides, resultKinds, nextType, builder, addPtr.getLoc());
+        if (failed(structured))
+          return failure();
+        Value opaque = createIntegerSub(builder, addPtr.getLoc(), nextComplete,
+                                        *structured);
+        Value zero =
+            createScalarConstant(builder, addPtr.getLoc(), scalarType, 0);
+        if (!opaque || !zero)
+          return failure();
+        result->components[getUniformOffsetComponent(rank)] = zero;
+        result->components[getOpaqueContributionComponent(rank)] = opaque;
+      } else {
+        Value uniform = createIntegerAdd(
+            builder, addPtr.getLoc(),
+            result->components[getUniformOffsetComponent(rank)],
+            delta->uniformOffset);
+        if (!uniform)
+          return failure();
+        FailureOr<Value> converted =
+            castIntegerLike(builder, addPtr.getLoc(), uniform, scalarType);
+        if (failed(converted))
+          return failure();
+        result->components[getUniformOffsetComponent(rank)] = *converted;
+        result->components[getOpaqueContributionComponent(rank)] =
+            createZeroOffsets(builder, addPtr.getLoc(), nextType);
+      }
       result->originalType = value.getType();
-      result->components[kOffsetsComponent] = offsets;
+      result->attributes[kAxisKindsAttribute] =
+          getAxisKindsAttr(value.getContext(), resultKinds);
       return *result;
     }
 
-    // A scalar pointer splat materializes zero offsets while retaining the
-    // scalar source as the common-base invariant.
     if (auto splat = value.getDefiningOp<triton::SplatOp>()) {
       if (!isa<triton::PointerType>(splat.getSrc().getType()))
         return failure();
       OpBuilder::InsertionGuard guard(builder);
       builder.setInsertionPoint(splat);
-      Value offsets =
-          createZeroOffsets(builder, splat.getLoc(), value.getType());
-      if (!offsets)
+      FailureOr<Value> baseAddress =
+          materializeScalarBaseAddress(builder, splat.getLoc(), splat.getSrc());
+      if (failed(baseAddress))
         return failure();
-      return DecomposedValue{value.getType(),
-                             {offsets},
-                             {splat.getSrc()},
-                             {builder.getBoolAttr(true)}};
+      RankedTensorType offsetsType = getDefaultOffsetsType(value.getType());
+      unsigned rank = cast<RankedTensorType>(value.getType()).getRank();
+      Type scalarType = offsetsType.getElementType();
+      SmallVector<Value> components{*baseAddress};
+      for (unsigned axis = 0; axis < rank; ++axis)
+        components.push_back(
+            createScalarConstant(builder, splat.getLoc(), scalarType, 0));
+      components.push_back(
+          createScalarConstant(builder, splat.getLoc(), scalarType, 0));
+      components.push_back(
+          createZeroOffsets(builder, splat.getLoc(), offsetsType));
+      if (llvm::any_of(components, [](Value component) { return !component; }))
+        return failure();
+      return DecomposedValue{
+          value.getType(), std::move(components),
+          getTensorPointerAttributes(builder.getContext(), true,
+                                     getAxisKinds(rank, AxisKind::Structured))};
     }
 
-    // Fallback for an opaque tensor base: use the entire tensor-of-pointers as
-    // the invariant base and represent only subsequent displacement in offsets.
     if (!matches(value.getType()))
       return failure();
-
     OpBuilder::InsertionGuard guard(builder);
     if (Operation *definingOp = value.getDefiningOp())
       builder.setInsertionPointAfter(definingOp);
     else if (auto blockArg = dyn_cast<BlockArgument>(value))
       builder.setInsertionPointToStart(blockArg.getOwner());
-    // Place the zero where it dominates every later reconstruction using it.
-    Value offsets = createZeroOffsets(builder, loc, value.getType());
-    if (!offsets)
+    RankedTensorType offsetsType = getDefaultOffsetsType(value.getType());
+    unsigned rank = cast<RankedTensorType>(value.getType()).getRank();
+    Type scalarType = offsetsType.getElementType();
+    SmallVector<Value> components{value};
+    for (unsigned axis = 0; axis < rank; ++axis)
+      components.push_back(createScalarConstant(builder, loc, scalarType, 0));
+    components.push_back(createScalarConstant(builder, loc, scalarType, 0));
+    components.push_back(createZeroOffsets(builder, loc, offsetsType));
+    if (llvm::any_of(components, [](Value component) { return !component; }))
       return failure();
     return DecomposedValue{
-        value.getType(), {offsets}, {value}, {builder.getBoolAttr(false)}};
+        value.getType(), std::move(components),
+        getTensorPointerAttributes(builder.getContext(), false,
+                                   getAxisKinds(rank, AxisKind::Opaque))};
   }
 
-  /// Rebuilds the original tensor-of-pointers from the invariant base and the
-  /// complete offsets selected/carried by the rewritten control flow.
   Value recompose(const DecomposedValue &value, OpBuilder &builder,
                   Location loc) const override {
     if (!hasValidLayout(value))
       return nullptr;
-    Value base = value.invariants[kBaseInvariant];
-    // addptr requires matching tensor lanes; broadcast a scalar common base
-    // only when the decomposition recorded `base_is_scalar = true`.
-    if (hasScalarBase(value))
+    auto pointerTensor = cast<RankedTensorType>(value.originalType);
+    Value base = value.components[kBaseComponent];
+    if (hasScalarBase(value)) {
+      auto scalarPointerType =
+          cast<triton::PointerType>(pointerTensor.getElementType());
+      Value nativeBase = recoverNativeScalarBase(base, scalarPointerType);
+      if (!nativeBase)
+        nativeBase =
+            builder.create<triton::IntToPtrOp>(loc, scalarPointerType, base);
+      base = nativeBase;
       base = builder.create<triton::SplatOp>(loc, value.originalType, base);
-    return builder.create<triton::AddPtrOp>(
-        loc, value.originalType, base, value.components[kOffsetsComponent]);
+    }
+
+    Value completeOffsets =
+        materializeTensorCompleteOffsets(value, builder, loc);
+    if (!completeOffsets)
+      return nullptr;
+    return builder.create<triton::AddPtrOp>(loc, value.originalType, base,
+                                            completeOffsets);
   }
 };
 
@@ -396,19 +2185,9 @@ public:
 
 namespace mlir::triton::controlflow {
 
-/// Runs tensor-pointer decomposition after CFG structuring/block-pointer
-/// handling. The shared driver analyzes each outermost SCF root, then rewrites
-/// only the complete-offset components selected by this policy.
 LogicalResult runTensorPtrDecompose(ModuleOp module) {
-  // Carry only complete per-lane offsets through SCF. The common scalar base
-  // remains a rewrite invariant and is used to rebuild tensor-of-pointers at
-  // each region boundary. This decomposition is independent of
-  // BlockPtrDecompose.
-  // TODO: Replace this local extraction with TritonToUnstructure's common-base
-  // analysis. Different or lane-wise bases must become explicit diagnostics
-  // instead of pattern misses.
   TensorPtrDecomposePolicy policy;
-  return rewriteControlFlow(module, policy);
+  return rewriteControlFlow(module, policy, /*allowUnsupportedFallback=*/true);
 }
 
 } // namespace mlir::triton::controlflow

--- a/third_party/ascend/lib/TritonControlFlowOpt/TritonControlFlowOptPass.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/TritonControlFlowOptPass.cpp
@@ -26,6 +26,7 @@
 #include "TritonControlFlowOpt/CFGStructuring.h"
 #include "TritonControlFlowOpt/TensorPtrDecompose.h"
 
+#include "bishengir/Dialect/Scope/IR/Scope.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -39,8 +40,9 @@ void TritonControlFlowOptPass::getDependentDialects(
     DialectRegistry &registry) const {
   // CFG structuring creates SCF operations, while pointer decomposition
   // materializes arith and Triton pointer operations.
-  registry.insert<arith::ArithDialect, cf::ControlFlowDialect,
-                  func::FuncDialect, scf::SCFDialect, triton::TritonDialect>();
+  registry
+      .insert<arith::ArithDialect, cf::ControlFlowDialect, func::FuncDialect,
+              scf::SCFDialect, scope::ScopeDialect, triton::TritonDialect>();
 }
 
 void TritonControlFlowOptPass::runOnOperation() {
@@ -48,8 +50,8 @@ void TritonControlFlowOptPass::runOnOperation() {
 
   // Apply the control-flow preprocessing pipeline in dependency order:
   //   1. normalize supported cf graphs to scf;
-  //   2. decompose block-pointer descriptors across SCF boundaries;
-  //   3. replace common-base tensor pointers at SCF boundaries with offsets.
+  //   2. decompose block-pointer descriptors across supported boundaries;
+  //   3. replace common-base tensor pointers at those boundaries with offsets.
   // TODO: Extend stage 3 to carry both the base and complete offsets, then add
   // StructuredOffsetsDecompose to further split structured offsets into a
   // base offset and per-dimension strides.

--- a/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "ascend/include/TritonToLinalg/BlockPtrAnalysis.h"
+#include "ascend/include/TritonControlFlowOpt/ControlFlowRewrite.h"
 #include "ascend/include/TritonToLinalg/TritonToLinalgPass.h"
 #include "ascend/include/Utils/DebugUtils.h"
 #include "ascend/include/Utils/Utils.h"
@@ -54,11 +55,70 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FormatVariadic.h"
 #include <cassert>
+#include <limits>
 #include <set>
 
 #define DEBUG_TYPE "triton-block-ptr-analysis"
 namespace mlir {
 namespace triton {
+
+hivm::PointerCastOp createScalarPointerCast(OpBuilder &builder, Location loc,
+                                            MemRefType resultType,
+                                            Value address) {
+  SmallVector<Value> dynamicSizes;
+  if (resultType.getNumDynamicDims() != 0) {
+    Value defaultSize = builder.create<arith::ConstantIndexOp>(loc, 1);
+    dynamicSizes.assign(resultType.getNumDynamicDims(), defaultSize);
+  }
+  auto pointerCast = builder.create<hivm::PointerCastOp>(
+      loc, resultType, ValueRange{address}, ValueRange{dynamicSizes});
+  pointerCast->setAttr(kScalarPointerCarrierAttr,
+                       UnitAttr::get(builder.getContext()));
+  return pointerCast;
+}
+
+// Recognize original scalar-pointer producers whose converted result may act
+// as a memref carrier. The parse site still requires BaseMemRefType, so merely
+// appearing in this list never makes an unconverted pointer an opaque source.
+static bool isScalarPointerTransport(Operation *op) {
+  return op && isa<scf::IfOp, scf::ForOp, scf::WhileOp, arith::SelectOp>(op);
+}
+
+// Returns true only for sources known to carry a complete scalar integer
+// address. Before dialect conversion the source is tt.int_to_ptr; after
+// IntToPtrConverter it is a memref-producing HIVM PointerCast with explicit
+// ScalarPointerCarrier provenance. Ordinary PointerCast descriptors must keep
+// using the existing unstructured fallback.
+static bool isScalarPointerCarrierSource(Value source) {
+  if (!source)
+    return false;
+  if (source.getDefiningOp<triton::IntToPtrOp>())
+    return true;
+  auto pointerCast = source.getDefiningOp<hivm::PointerCastOp>();
+  return pointerCast && pointerCast->hasAttr(kScalarPointerCarrierAttr);
+}
+
+// Dialect conversion may temporarily materialize a scalar Triton pointer from
+// a memref carrier so that an operation which has not been rewritten yet can
+// keep its original type.  Scalar pointer transport must consume the carrier
+// directly; otherwise the conversion driver is forced to leave a live
+// memref-to-!tt.ptr cast next to tt.load/tt.store.  Only peel the narrow,
+// one-to-one UCC form whose input is already a BaseMemRefType.  Unknown casts,
+// multi-value casts, and non-memref inputs remain unsupported and therefore
+// continue through the existing diagnostics.
+static Value unwrapScalarPointerMemRefCarrier(Value value) {
+  while (auto castOp = value.getDefiningOp<UnrealizedConversionCastOp>()) {
+    if (castOp.getInputs().size() != 1 || castOp.getOutputs().size() != 1)
+      break;
+    Value input = castOp.getInputs().front();
+    Value output = castOp.getOutputs().front();
+    if (!isa<BaseMemRefType>(input.getType()) ||
+        !isa<triton::PointerType, BaseMemRefType>(output.getType()))
+      break;
+    value = input;
+  }
+  return value;
+}
 
 // MemAccType selectMaxMemAccTy(const MemAccType &v1, const MemAccType &v2) {
 //   return (v1 > v2) ? v1 : v2;
@@ -155,15 +215,18 @@ OpFoldResult BlockData::inferBlockOffset(const Location &loc,
   return retOffset;
 }
 
-MemRefType BlockData::getResultMemrefType(int64_t offset,
-                                          ArrayRef<int64_t> resultShape) const {
+FailureOr<MemRefType>
+BlockData::getResultMemrefType(int64_t offset,
+                               ArrayRef<int64_t> resultShape) const {
   SmallVector<int64_t> staticStrides;
   SmallVector<Value> dynamicStrides;
   dispatchIndexOpFoldResults(strides, dynamicStrides, staticStrides);
 
+  if (!this->source)
+    return failure();
   auto baseMemrefType = dyn_cast<BaseMemRefType>(this->source.getType());
-  assert(baseMemrefType &&
-         "Invalid element type. It should be a base memref type.");
+  if (!baseMemrefType)
+    return failure();
   auto elementType = baseMemrefType.getElementType();
   auto layout =
       StridedLayoutAttr::get(this->source.getContext(), offset, staticStrides);
@@ -334,14 +397,21 @@ void BlockData::divBlock(BlockData &lBlock, BlockData &rBlock, Location loc,
   // rBlock.getMemAccType()));
 }
 
-memref::ReinterpretCastOp BlockData::createCastOp(ArrayRef<int64_t> resultShape,
-                                                  const Location &loc,
-                                                  OpBuilder &builder) const {
+FailureOr<memref::ReinterpretCastOp>
+BlockData::createCastOp(ArrayRef<int64_t> resultShape, const Location &loc,
+                        OpBuilder &builder) const {
   OpFoldResult resOffset = this->inferBlockOffset(loc, builder);
-  auto resultType = this->getResultMemrefType(
-      isa<Attribute>(resOffset) ? getConstantIntValue(resOffset).value()
-                                : ShapedType::kDynamic,
-      resultShape);
+  int64_t staticOffset = ShapedType::kDynamic;
+  if (isa<Attribute>(resOffset)) {
+    auto constantOffset = getConstantIntValue(resOffset);
+    if (!constantOffset)
+      return failure();
+    staticOffset = *constantOffset;
+  }
+  FailureOr<MemRefType> resultType =
+      this->getResultMemrefType(staticOffset, resultShape);
+  if (failed(resultType))
+    return failure();
 
   SmallVector<OpFoldResult> strides(this->strides);
   for (size_t i = 0; i < strides.size(); i++) {
@@ -356,7 +426,7 @@ memref::ReinterpretCastOp BlockData::createCastOp(ArrayRef<int64_t> resultShape,
   }
 
   return builder.create<memref::ReinterpretCastOp>(
-      loc, resultType, this->source, resOffset, this->sizes, strides);
+      loc, *resultType, this->source, resOffset, this->sizes, strides);
 }
 
 void BlockData::dump() const {
@@ -383,138 +453,250 @@ void BlockData::dump() const {
   llvm::outs() << "[INFO][END] BlockData info\n";
 }
 
-Value BlockDataParser::getScalarMemRef(Value ptr, Value memref,
-                                       const Location &loc,
-                                       ConversionPatternRewriter &rewriter) {
-  assert(isa<triton::PointerType>(ptr.getType()) && "expect a scalar pointer");
-  if (auto castOp = memref.getDefiningOp<memref::ReinterpretCastOp>())
-    return castOp.getResult();
+FailureOr<Value>
+BlockDataParser::getScalarMemRef(Value ptr, Value memref, const Location &loc,
+                                 ConversionPatternRewriter &rewriter) {
+  if (!ptr || !memref)
+    return failure();
+  auto pointerType = dyn_cast<triton::PointerType>(ptr.getType());
+  if (!pointerType || isa<ShapedType>(pointerType.getPointeeType()))
+    return failure();
 
-  assert(isa<BaseMemRefType>(memref.getType()) &&
-         "converted scalar pointer should be a memref");
+  memref = unwrapScalarPointerMemRefCarrier(memref);
+
+  // A complete scalar address reconstructed after an SCF boundary is exposed
+  // as tt.int_to_ptr in the Triton IR.  Its converted operand is already the
+  // canonical ScalarPointerCarrier memref; handle it before the legacy
+  // block-argument path so a direct load/store does not request a reverse
+  // memref-to-pointer materialization.
+  if (ptr.getDefiningOp<triton::IntToPtrOp>()) {
+    if (!isa<BaseMemRefType>(memref.getType()))
+      return failure();
+    // IntToPtrConverter's rank-1 carrier is still a dynamic base memref, not
+    // the canonical scalar view consumed by indirect loads.  Normalize every
+    // int_to_ptr carrier to the one-element identity view below.
+    BlockData data;
+    data.setSource(memref);
+    data.getOffsetsRef().push_back(rewriter.getIndexAttr(0));
+    data.getSizesRef().push_back(rewriter.getIndexAttr(1));
+    data.getStridesRef().push_back(rewriter.getIndexAttr(1));
+    auto castOp = data.createCastOp(SmallVector<int64_t>(1, 1), loc, rewriter);
+    if (failed(castOp))
+      return failure();
+    return (*castOp).getResult();
+  }
+
+  if (ptr.getDefiningOp<triton::AddPtrOp>()) {
+    if (auto castOp = memref.getDefiningOp<memref::ReinterpretCastOp>())
+      return castOp.getResult();
+    if (auto pointerCast = memref.getDefiningOp<hivm::PointerCastOp>();
+        pointerCast && pointerCast->hasAttr(kScalarPointerCarrierAttr))
+      return memref;
+    return failure();
+  }
+
+  // A scalar pointer produced by structured control flow or select is already
+  // represented by a converted memref. Give it the same one-element view used
+  // for a scalar block argument so direct tt.load/tt.store users can consume
+  // the transport result without attempting memref-to-pointer materialization.
+  if (auto definingOp = ptr.getDefiningOp();
+      definingOp && isScalarPointerTransport(definingOp)) {
+    if (!isa<BaseMemRefType>(memref.getType()))
+      return failure();
+    if (auto memrefType = dyn_cast<MemRefType>(memref.getType());
+        memrefType && memrefType.getRank() == 1)
+      return memref;
+    BlockData data;
+    data.setSource(memref);
+    data.getOffsetsRef().push_back(rewriter.getIndexAttr(0));
+    data.getSizesRef().push_back(rewriter.getIndexAttr(1));
+    data.getStridesRef().push_back(rewriter.getIndexAttr(1));
+    auto castOp = data.createCastOp(SmallVector<int64_t>(1, 1), loc, rewriter);
+    if (failed(castOp))
+      return failure();
+    return (*castOp).getResult();
+  }
+
+  if (!isa<BlockArgument>(ptr) || !isa<BaseMemRefType>(memref.getType()))
+    return failure();
+
   BlockData data;
   data.setSource(memref);
   data.getOffsetsRef().push_back(rewriter.getIndexAttr(0));
   data.getSizesRef().push_back(rewriter.getIndexAttr(1));
   data.getStridesRef().push_back(rewriter.getIndexAttr(1));
   auto castOp = data.createCastOp(SmallVector<int64_t>(1, 1), loc, rewriter);
-  return castOp.getResult();
+  if (failed(castOp))
+    return failure();
+  return (*castOp).getResult();
 }
 
-void BlockDataParser::parse(
-    Value operand, BlockData &data, const Location &loc,
-    ConversionPatternRewriter &rewriter,
-    const llvm::SmallDenseMap<Value, BlockData> &known) {
+LogicalResult
+BlockDataParser::parse(Value operand, BlockData &data, const Location &loc,
+                       ConversionPatternRewriter &rewriter,
+                       const llvm::SmallDenseMap<Value, BlockData> &known) {
   if (known.find(operand) != known.end()) {
-    return data = known.lookup(operand), void();
+    data = known.lookup(operand);
+    return success();
   }
 
   if (isa<IntegerType>(operand.getType())) {
     data.setScalar(getOpFoldResultOfLayoutInfo(operand, rewriter));
-    return;
+    return success();
   }
 
   //
   if (isa<triton::PointerType>(operand.getType())) {
     // Just consider two state: ptr<scalar> and ptr<tensor<scalar>>
-    auto remappedPtr = rewriter.getRemappedValue(operand);
-    assert(remappedPtr);
+    Value remappedPtr = rewriter.getRemappedValue(operand);
+    if (!remappedPtr) {
+      if (Operation *definingOp = operand.getDefiningOp())
+        return definingOp->emitError("scalar pointer has no converted value");
+      emitError(loc) << "scalar pointer block argument has no converted value: "
+                     << operand;
+      return failure();
+    }
+    // A not-yet-rewritten pointer user may be represented by a one-to-one
+    // UCC from a converted memref.  Consume that memref as the transport
+    // source instead of asking the driver to materialize the pointer back.
+    remappedPtr = unwrapScalarPointerMemRefCarrier(remappedPtr);
     if (auto op = operand.getDefiningOp()) {
       if (auto addPtrOp = dyn_cast<triton::AddPtrOp>(op)) {
-        parseAddPtr(addPtrOp, data, loc, rewriter, known);
+        return parseAddPtr(addPtrOp, data, loc, rewriter, known);
       } else if (auto bitcastOp = dyn_cast<triton::BitcastOp>(op)) {
-        parseBitcast(bitcastOp, data, loc, rewriter, known);
+        return parseBitcast(bitcastOp, data, loc, rewriter, known);
       } else if (auto makeTensorPtrOp = dyn_cast<triton::MakeTensorPtrOp>(op)) {
-        parseTensorPtr(makeTensorPtrOp, data, loc, rewriter, known);
+        return parseTensorPtr(makeTensorPtrOp, data, loc, rewriter, known);
       } else if (auto advanceOp = dyn_cast<triton::AdvanceOp>(op)) {
         // To support
         // ptr_0 = tl.advance(ptr)
         // ptr_1 = tl.advance(ptr_0)
-        parseTensorPtr(advanceOp, data, loc, rewriter, known);
+        return parseTensorPtr(advanceOp, data, loc, rewriter, known);
       } else if (auto intToPtrOp = dyn_cast<triton::IntToPtrOp>(op)) {
+        if (!isa<BaseMemRefType>(remappedPtr.getType())) {
+          return op->emitError(
+              "int_to_ptr did not convert to a memref carrier");
+        }
         data.setSource(remappedPtr);
+        // An address reconstructed from an i64 is a complete scalar pointer,
+        // but AddPtr still needs the ordinary one-element BlockData schema to
+        // form a memref.reinterpret_cast for a later load/store.  Without
+        // this identity view the generic path sees an empty rank and may
+        // attempt to materialize a pointer from a non-memref source.
+        data.getOffsetsRef().push_back(rewriter.getIndexAttr(0));
+        data.getSizesRef().push_back(rewriter.getIndexAttr(1));
+        data.getStridesRef().push_back(rewriter.getIndexAttr(1));
       } else if (isDistributedTypeCustomOp(op)) {
         data.setSource(remappedPtr);
+      } else if (isScalarPointerTransport(op)) {
+        if (!isa<BaseMemRefType>(remappedPtr.getType())) {
+          return op->emitError(
+              "scalar pointer transport did not convert to a memref");
+        }
+        data.setSource(remappedPtr);
+        // Transport producers carry a complete scalar address but do not
+        // expose BlockData dimensions. Model the address as a one-element
+        // identity view so a following addptr can add a scalar offset without
+        // falling into the rank-mismatch/materialization failure path.
+        data.getOffsetsRef().push_back(rewriter.getIndexAttr(0));
+        data.getSizesRef().push_back(rewriter.getIndexAttr(1));
+        data.getStridesRef().push_back(rewriter.getIndexAttr(1));
       } else {
-        LLVM_DEBUG({ llvm::dbgs() << operand << "\n"; });
-        llvm_unreachable("Unexpected operand defining operation, a scalar "
-                         "pointer can only be produced by AddPtrOp or direct "
-                         "block ptr or hivm CustomOp");
+        return op->emitError()
+               << "unsupported scalar pointer producer '" << op->getName()
+               << "' with original type " << operand.getType()
+               << " and converted type " << remappedPtr.getType();
       }
     } else {
       data.setSource(remappedPtr);
     }
-    return;
+    return success();
   }
 
   // not a scalar pointer
   if (auto addOp = operand.getDefiningOp<arith::AddIOp>()) {
-    parseAdd(addOp, data, loc, rewriter, known);
+    return parseAdd(addOp, data, loc, rewriter, known);
   } else if (auto subOp = operand.getDefiningOp<arith::SubIOp>()) {
-    parseSub(subOp, data, loc, rewriter, known);
+    return parseSub(subOp, data, loc, rewriter, known);
   } else if (auto mulOp = operand.getDefiningOp<arith::MulIOp>()) {
-    parseMul(mulOp, data, loc, rewriter, known);
+    return parseMul(mulOp, data, loc, rewriter, known);
   } else if (auto addPtrOp = operand.getDefiningOp<triton::AddPtrOp>()) {
-    parseAddPtr(addPtrOp, data, loc, rewriter, known);
+    return parseAddPtr(addPtrOp, data, loc, rewriter, known);
   } else if (auto constOp = operand.getDefiningOp<arith::ConstantOp>()) {
     parseConstSplat(constOp, data, loc, rewriter, known);
+    return success();
   } else if (auto broadcastOp = operand.getDefiningOp<triton::BroadcastOp>()) {
-    parseBroadcast(broadcastOp, data, loc, rewriter, known);
+    return parseBroadcast(broadcastOp, data, loc, rewriter, known);
   } else if (auto splatOp = operand.getDefiningOp<triton::SplatOp>()) {
-    parseSplat(splatOp, data, loc, rewriter, known);
+    return parseSplat(splatOp, data, loc, rewriter, known);
   } else if (auto expandDimsOp =
                  operand.getDefiningOp<triton::ExpandDimsOp>()) {
-    parseExpandDims(expandDimsOp, data, loc, rewriter, known);
+    return parseExpandDims(expandDimsOp, data, loc, rewriter, known);
   } else if (auto remOp = operand.getDefiningOp<arith::RemSIOp>()) {
-    parseRem(remOp, data, loc, rewriter, known);
+    return parseRem(remOp, data, loc, rewriter, known);
   } else if (auto bitcastOp = operand.getDefiningOp<triton::BitcastOp>()) {
-    parseBitcast(bitcastOp, data, loc, rewriter, known);
+    return parseBitcast(bitcastOp, data, loc, rewriter, known);
   } else if (auto extsiOp = operand.getDefiningOp<arith::ExtSIOp>()) {
-    parseExtSI(extsiOp, data, loc, rewriter, known);
+    return parseExtSI(extsiOp, data, loc, rewriter, known);
   } else if (auto divOp = operand.getDefiningOp<arith::DivSIOp>()) {
-    parseDiv(divOp, data, loc, rewriter, known);
+    return parseDiv(divOp, data, loc, rewriter, known);
   } else if (auto makeRangeOp = operand.getDefiningOp<triton::MakeRangeOp>()) {
     parseMakeRange(makeRangeOp, data, loc, rewriter, known);
+    return success();
   } else if (auto reduceOp = operand.getDefiningOp<triton::ReduceOp>()) {
-    parseReduce(reduceOp, data, loc, rewriter, known);
+    return parseReduce(reduceOp, data, loc, rewriter, known);
   } else if (auto loadOp = operand.getDefiningOp<triton::LoadOp>()) {
     parseIndirectLoad<triton::LoadOp>(loadOp, data, loc, rewriter, known);
+    return success();
   } else if (auto castOp = operand.getDefiningOp<arith::FPToSIOp>()) {
     parseIndirectLoad<arith::FPToSIOp>(castOp, data, loc, rewriter, known);
+    return success();
   } else if (auto extractSliceOp =
                  operand.getDefiningOp<tensor::ExtractSliceOp>()) {
-    parseExtractSlice(extractSliceOp, data, loc, rewriter, known);
+    return parseExtractSlice(extractSliceOp, data, loc, rewriter, known);
   } else if (auto forOp = operand.getDefiningOp<scf::ForOp>()) {
     auto opResult = dyn_cast<OpResult>(operand);
-    assert(opResult && "expected OpResult for scf.for result");
+    if (!opResult)
+      return forOp.emitOpError("expected an OpResult while parsing its result");
     unsigned resultIdx = opResult.getResultNumber();
     parseIndirectLoad<scf::ForOp>(forOp, data, loc, rewriter, known, resultIdx);
+    return success();
   } else if (auto tensorCastOp = operand.getDefiningOp<tensor::CastOp>()) {
     // Used for identity operation.
-    parse(tensorCastOp.getSource(), data, loc, rewriter, known);
+    return parse(tensorCastOp.getSource(), data, loc, rewriter, known);
   } else if (auto fillOp = operand.getDefiningOp<linalg::FillOp>()) {
-    parseFill(fillOp, data, loc, rewriter, known);
+    return parseFill(fillOp, data, loc, rewriter, known);
   } else if (auto selectOp = operand.getDefiningOp<arith::SelectOp>()) {
-    parseSelect(selectOp, data, loc, rewriter, known);
+    if (auto resultType = dyn_cast<ShapedType>(selectOp.getType());
+        resultType && isa<triton::PointerType>(resultType.getElementType()))
+      return selectOp.emitOpError(
+          "tensor-of-pointers select must be lowered before BlockData parsing");
+    return parseSelect(selectOp, data, loc, rewriter, known);
   } else if (isDistributedTypeCustomOp(operand.getDefiningOp())) {
     auto opResult = dyn_cast<OpResult>(operand);
-    assert(opResult && "Expected operand to be an OpResult");
-    parseStructuredCustomOp(operand.getDefiningOp(), data, loc, rewriter, known,
-                            opResult.getResultNumber());
+    if (!opResult)
+      return emitError(loc, "expected a custom operation result");
+    return parseStructuredCustomOp(operand.getDefiningOp(), data, loc, rewriter,
+                                   known, opResult.getResultNumber());
   } else if (auto genericOp = operand.getDefiningOp<linalg::GenericOp>()) {
     if (genericOp->hasAttr("tt.from_make_range")) {
       parseLinalgGenericFromMakeRange(genericOp, data, loc, rewriter, known);
-    } else {
-      operand.dump();
-      llvm_unreachable(
-          "encountered AddPtrOp produced by unsupported operation");
+      return success();
     }
+    return genericOp.emitOpError(
+        "cannot parse a generic operation without tt.from_make_range");
   } else if (auto atomicRMWOp = operand.getDefiningOp<triton::AtomicRMWOp>()) {
     parseAtomicRmw(atomicRMWOp, data, loc, rewriter, known);
-  } else {
-    operand.dump();
-    llvm_unreachable("encountered AddPtrOp produced by unsupported operation");
+    return success();
   }
+
+  if (Operation *producer = operand.getDefiningOp())
+    return producer->emitError()
+           << "unsupported BlockData producer '" << producer->getName()
+           << "' with result type " << operand.getType();
+  emitError(loc) << "unsupported BlockData block argument of type "
+                 << operand.getType();
+  return failure();
 }
 
 void BlockDataParser::parseAtomicRmw(
@@ -554,54 +736,67 @@ void BlockDataParser::parseAtomicRmw(
   data.setSource(opRes);
 }
 
-void BlockDataParser::parseAdd(
-    arith::AddIOp op, BlockData &data, const Location &loc,
-    ConversionPatternRewriter &rewriter,
-    const llvm::SmallDenseMap<Value, BlockData> &known) {
+LogicalResult
+BlockDataParser::parseAdd(arith::AddIOp op, BlockData &data,
+                          const Location &loc,
+                          ConversionPatternRewriter &rewriter,
+                          const llvm::SmallDenseMap<Value, BlockData> &known) {
   BlockData lBlock, rBlock;
-  parse(op.getLhs(), lBlock, loc, rewriter, known);
-  parse(op.getRhs(), rBlock, loc, rewriter, known);
+  if (failed(parse(op.getLhs(), lBlock, loc, rewriter, known)) ||
+      failed(parse(op.getRhs(), rBlock, loc, rewriter, known)))
+    return failure();
   data.addBlock(lBlock, rBlock, loc, rewriter);
+  return success();
 }
 
-void BlockDataParser::parseSub(
-    arith::SubIOp op, BlockData &data, const Location &loc,
-    ConversionPatternRewriter &rewriter,
-    const llvm::SmallDenseMap<Value, BlockData> &known) {
+LogicalResult
+BlockDataParser::parseSub(arith::SubIOp op, BlockData &data,
+                          const Location &loc,
+                          ConversionPatternRewriter &rewriter,
+                          const llvm::SmallDenseMap<Value, BlockData> &known) {
   BlockData lBlock, rBlock;
-  parse(op.getLhs(), lBlock, loc, rewriter, known);
-  parse(op.getRhs(), rBlock, loc, rewriter, known);
+  if (failed(parse(op.getLhs(), lBlock, loc, rewriter, known)) ||
+      failed(parse(op.getRhs(), rBlock, loc, rewriter, known)))
+    return failure();
   data.subBlock(lBlock, rBlock, loc, rewriter);
+  return success();
 }
 
-void BlockDataParser::parseMul(
-    arith::MulIOp op, BlockData &data, const Location &loc,
-    ConversionPatternRewriter &rewriter,
-    const llvm::SmallDenseMap<Value, BlockData> &known) {
+LogicalResult
+BlockDataParser::parseMul(arith::MulIOp op, BlockData &data,
+                          const Location &loc,
+                          ConversionPatternRewriter &rewriter,
+                          const llvm::SmallDenseMap<Value, BlockData> &known) {
   BlockData lBlock, rBlock;
-  parse(op.getLhs(), lBlock, loc, rewriter, known);
-  parse(op.getRhs(), rBlock, loc, rewriter, known);
+  if (failed(parse(op.getLhs(), lBlock, loc, rewriter, known)) ||
+      failed(parse(op.getRhs(), rBlock, loc, rewriter, known)))
+    return failure();
 
   data.mulBlock(lBlock, rBlock, loc, rewriter);
+  return success();
 }
 
-void BlockDataParser::parseDiv(
-    arith::DivSIOp op, BlockData &data, const Location &loc,
-    ConversionPatternRewriter &rewriter,
-    const llvm::SmallDenseMap<Value, BlockData> &known) {
+LogicalResult
+BlockDataParser::parseDiv(arith::DivSIOp op, BlockData &data,
+                          const Location &loc,
+                          ConversionPatternRewriter &rewriter,
+                          const llvm::SmallDenseMap<Value, BlockData> &known) {
   BlockData lBlock, rBlock;
-  parse(op.getLhs(), lBlock, loc, rewriter, known);
-  parse(op.getRhs(), rBlock, loc, rewriter, known);
+  if (failed(parse(op.getLhs(), lBlock, loc, rewriter, known)) ||
+      failed(parse(op.getRhs(), rBlock, loc, rewriter, known)))
+    return failure();
   data.divBlock(lBlock, rBlock, loc, rewriter);
+  return success();
 }
 
 // TODO : support modulos
-void BlockDataParser::parseRem(
-    arith::RemSIOp op, BlockData &data, const Location &loc,
-    ConversionPatternRewriter &rewriter,
-    const llvm::SmallDenseMap<Value, BlockData> &known) {
-  assert(false && "Address expression with modulo is not supported yet, it "
-                  "shall be analysis at linearize.");
+LogicalResult
+BlockDataParser::parseRem(arith::RemSIOp op, BlockData &data,
+                          const Location &loc,
+                          ConversionPatternRewriter &rewriter,
+                          const llvm::SmallDenseMap<Value, BlockData> &known) {
+  return op.emitOpError(
+      "address expressions with modulo are not supported by BlockDataParser");
 }
 
 void BlockDataParser::parseMakeRange(
@@ -644,13 +839,14 @@ void BlockDataParser::parseLinalgGenericFromMakeRange(
   data.getStridesRef().push_back(rewriter.getIndexAttr(1));
 }
 
-void BlockDataParser::parseExpandDims(
+LogicalResult BlockDataParser::parseExpandDims(
     triton::ExpandDimsOp op, BlockData &data, const Location &loc,
     ConversionPatternRewriter &rewriter,
     const llvm::SmallDenseMap<Value, BlockData> &known) {
   assert(data.isEmpty());
 
-  parse(op.getSrcMutable().get(), data, loc, rewriter, known);
+  if (failed(parse(op.getSrcMutable().get(), data, loc, rewriter, known)))
+    return failure();
   auto resShape = dyn_cast<ShapedType>(op.getResult().getType()).getShape();
   auto axis = op.getAxis();
 
@@ -663,9 +859,10 @@ void BlockDataParser::parseExpandDims(
                             rewriter.getIndexAttr(1));
   data.getStridesRef().insert(data.getStridesRef().begin() + axis,
                               rewriter.getIndexAttr(0));
+  return success();
 }
 
-void BlockDataParser::parseExtractSlice(
+LogicalResult BlockDataParser::parseExtractSlice(
     tensor::ExtractSliceOp op, BlockData &data, const Location &loc,
     ConversionPatternRewriter &rewriter,
     const llvm::SmallDenseMap<Value, BlockData> &known) {
@@ -681,21 +878,19 @@ void BlockDataParser::parseExtractSlice(
 
   auto extract_src = op->getOperand(0);
   BlockData srcBlock;
-  parse(extract_src, srcBlock, loc, rewriter, known);
-  if (!srcBlock.hasSource()) {
-    llvm_unreachable(scenarioMessages.c_str());
-  }
+  if (failed(parse(extract_src, srcBlock, loc, rewriter, known)))
+    return failure();
+  if (!srcBlock.hasSource())
+    return op.emitOpError(scenarioMessages);
   // Use isa_and_nonnull for LLVM 21 compatibility
-  if (!isa_and_nonnull<triton::LoadOp>(srcBlock.getSource().getDefiningOp())) {
-    llvm_unreachable(scenarioMessages.c_str());
-  }
+  if (!isa_and_nonnull<triton::LoadOp>(srcBlock.getSource().getDefiningOp()))
+    return op.emitOpError(scenarioMessages);
 
   auto extract_result = op->getResult(0);
   auto shaped_ty = dyn_cast<RankedTensorType>(extract_result.getType());
   auto shape = shaped_ty.getShape();
-  if (shape.size() > 1 || shape[0] > 1) {
-    llvm_unreachable(scenarioMessages.c_str());
-  }
+  if (shape.size() > 1 || shape[0] > 1)
+    return op.emitOpError(scenarioMessages);
   auto castOp = rewriter.create<arith::IndexCastOp>(
       loc, RankedTensorType::get(shape, rewriter.getIndexType()),
       extract_result);
@@ -705,17 +900,19 @@ void BlockDataParser::parseExtractSlice(
     data.getSizesRef().push_back(rewriter.getIndexAttr(shape[0]));
     data.getStridesRef().push_back(rewriter.getIndexAttr(1));
   } else {
-    llvm_unreachable(
-        "parseExtractSlice with offset already setup not yet supported");
+    return op.emitOpError(
+        "extract_slice parsing with a pre-populated offset is unsupported");
   }
+  return success();
 }
 
-void BlockDataParser::parseBitcast(
+LogicalResult BlockDataParser::parseBitcast(
     triton::BitcastOp op, BlockData &data, const Location &loc,
     ConversionPatternRewriter &rewriter,
     const llvm::SmallDenseMap<Value, BlockData> &known) {
   assert(data.isEmpty());
-  parse(op.getSrc(), data, loc, rewriter, known);
+  if (failed(parse(op.getSrc(), data, loc, rewriter, known)))
+    return failure();
 
   auto resType = op.getResult().getType();
   Type resElemPointeeTy = nullptr;
@@ -738,6 +935,8 @@ void BlockDataParser::parseBitcast(
       resElemPointeeTy = resPointeeType;
     } else {
       auto remappedValue = rewriter.getRemappedValue(op);
+      if (!remappedValue)
+        return op.emitOpError("bitcast result has no converted value");
       data.setSource(remappedValue);
       LLVM_DEBUG({
         llvm::dbgs() << "Remapping bitcastOp:\n";
@@ -747,17 +946,18 @@ void BlockDataParser::parseBitcast(
     }
   }
   data.setResElemTy(resElemPointeeTy);
+  return success();
 }
 
-void BlockDataParser::parseExtSI(
+LogicalResult BlockDataParser::parseExtSI(
     arith::ExtSIOp op, BlockData &data, const Location &loc,
     ConversionPatternRewriter &rewriter,
     const llvm::SmallDenseMap<Value, BlockData> &known) {
   assert(data.isEmpty());
-  parse(op.getIn(), data, loc, rewriter, known);
+  return parse(op.getIn(), data, loc, rewriter, known);
 }
 
-void BlockDataParser::parseBroadcast(
+LogicalResult BlockDataParser::parseBroadcast(
     triton::BroadcastOp op, BlockData &data, const Location &loc,
     ConversionPatternRewriter &rewriter,
     const llvm::SmallDenseMap<Value, BlockData> &known) {
@@ -773,7 +973,8 @@ void BlockDataParser::parseBroadcast(
   assert(srcShape.size() == dstShape.size() &&
          "rank of source shoule be equal to destnation");
 
-  parse(src, data, loc, rewriter, known);
+  if (failed(parse(src, data, loc, rewriter, known)))
+    return failure();
 
   for (const auto &[idx, src_dst] :
        llvm::enumerate(llvm::zip(srcShape, dstShape))) {
@@ -785,9 +986,10 @@ void BlockDataParser::parseBroadcast(
            "srcShape of broadcastOp must be less than dstShape.");
     data.getSizesRef()[idx] = rewriter.getIndexAttr(dstAxis);
   }
+  return success();
 }
 
-void BlockDataParser::parseSplat(
+LogicalResult BlockDataParser::parseSplat(
     triton::SplatOp op, BlockData &data, const Location &loc,
     ConversionPatternRewriter &rewriter,
     const llvm::SmallDenseMap<Value, BlockData> &known) {
@@ -796,7 +998,27 @@ void BlockDataParser::parseSplat(
   auto dst = op.getResult();
   auto dstShape = dyn_cast<ShapedType>(dst.getType()).getShape();
 
-  parse(src, data, loc, rewriter, known);
+  if (failed(parse(src, data, loc, rewriter, known)))
+    return failure();
+
+  // A ScalarPointerCarrier stores the complete integer address passed to
+  // tt.int_to_ptr, so an addptr displacement exists only in BlockData and must
+  // survive the following splat. Ordinary scalar pointers already carry their
+  // displacement in the converted memref descriptor; retain the established
+  // behavior of resetting those offsets while constructing the tensor layout.
+  OpFoldResult splatOffset;
+  if (isa<triton::PointerType>(src.getType()) &&
+      isScalarPointerCarrierSource(data.getSource())) {
+    SmallVector<OpFoldResult> pointerOffsets = data.getOffsets();
+    if (pointerOffsets.size() > 1)
+      return op.emitOpError(
+          "scalar pointer carrier splat requires at most one BlockData offset");
+    splatOffset = pointerOffsets.empty()
+                      ? OpFoldResult(rewriter.getIndexAttr(0))
+                      : pointerOffsets.front();
+  } else if (data.isScalar()) {
+    splatOffset = data.getScalarRef();
+  }
 
   if (isa<IntegerType>(src.getType()) ||
       isa<triton::PointerType>(src.getType())) {
@@ -811,12 +1033,11 @@ void BlockDataParser::parseSplat(
       data.getStridesRef().push_back(rewriter.getIndexAttr(0));
     }
   } else {
-    op->emitError("Block data Analysis: unsupported splat pattern");
-    return;
+    return op.emitOpError("BlockDataParser does not support this splat source");
   }
-  if (data.isScalar()) {
-    data.getOffsetsRef()[0] = data.getScalarRef();
-  }
+  if (!splatOffset.isNull())
+    data.getOffsetsRef()[0] = splatOffset;
+  return success();
 }
 
 void BlockDataParser::parseConstSplat(
@@ -851,7 +1072,8 @@ void BlockDataParser::parseConstSplat(
 
 template <typename T>
 std::enable_if_t<std::is_same_v<T, triton::MakeTensorPtrOp> ||
-                 std::is_same_v<T, triton::AdvanceOp>>
+                     std::is_same_v<T, triton::AdvanceOp>,
+                 LogicalResult>
 BlockDataParser::parseTensorPtr(
     T op, BlockData &data, const Location &loc,
     ConversionPatternRewriter &rewriter,
@@ -859,25 +1081,30 @@ BlockDataParser::parseTensorPtr(
   assert(data.isEmpty());
 
   Value remappedValue = rewriter.getRemappedValue(op);
+  if (!remappedValue)
+    return op.emitOpError("tensor pointer has no converted value");
   if (auto castOp = remappedValue.getDefiningOp<memref::ReinterpretCastOp>()) {
     parseReinterpretCast(castOp, data, loc, rewriter, known);
-  } else {
-    llvm_unreachable("the value should be mapped to memref.reinterpret_cast");
+    return success();
   }
+  return op.emitOpError(
+      "expected the converted tensor pointer to be a memref.reinterpret_cast");
 }
 
-void BlockDataParser::parseAddPtr(
+LogicalResult BlockDataParser::parseAddPtr(
     triton::AddPtrOp op, BlockData &data, const Location &loc,
     ConversionPatternRewriter &rewriter,
     const llvm::SmallDenseMap<Value, BlockData> &known) {
   assert(data.isEmpty());
 
   BlockData ptrBlock, offsetBlock;
-  parse(op.getPtr(), ptrBlock, op.getLoc(), rewriter, known);
-  parse(op.getOffset(), offsetBlock, op.getLoc(), rewriter, known);
+  if (failed(parse(op.getPtr(), ptrBlock, op.getLoc(), rewriter, known)) ||
+      failed(parse(op.getOffset(), offsetBlock, op.getLoc(), rewriter, known)))
+    return failure();
 
-  assert(ptrBlock.hasSource() &&
-         "Ptr field should provide source/base pointer");
+  if (!ptrBlock.hasSource())
+    return op.emitOpError(
+        "could not resolve a source/base pointer for the addptr operand");
   // offset has source means offset is from tl.load and other ops(TODO)
   if (offsetBlock.hasSource()) {
     ptrBlock.setMemAccTy(offsetBlock.getMemAccType());
@@ -891,8 +1118,8 @@ void BlockDataParser::parseAddPtr(
     offsetBlock.getStridesRef().push_back(rewriter.getIndexAttr(0));
   }
 
-  assert(ptrBlock.getRank() == offsetBlock.getRank() &&
-         "ptr and offset should have same rank");
+  if (ptrBlock.getRank() != offsetBlock.getRank())
+    return op.emitOpError("pointer and offset BlockData ranks do not match");
   LLVM_DEBUG({
     auto &os = llvm::dbgs();
     os << "[parseAddPtr][BEG] =========================\n";
@@ -914,6 +1141,7 @@ void BlockDataParser::parseAddPtr(
     os << "[parseAddPtr][END] -------------------------\n";
   });
   data.addBlock(ptrBlock, offsetBlock, op.getLoc(), rewriter);
+  return success();
 }
 
 void BlockDataParser::parseReinterpretCast(
@@ -937,7 +1165,7 @@ void BlockDataParser::parseReinterpretCast(
   }
 }
 
-void BlockDataParser::parseReduce(
+LogicalResult BlockDataParser::parseReduce(
     triton::ReduceOp op, BlockData &data, const Location &loc,
     ConversionPatternRewriter &rewriter,
     const llvm::SmallDenseMap<Value, BlockData> &known) {
@@ -950,14 +1178,13 @@ void BlockDataParser::parseReduce(
 
   auto reduce_src = op->getOperand(0);
   BlockData srcBlock;
-  parse(reduce_src, srcBlock, loc, rewriter, known);
-  if (!srcBlock.hasSource()) {
-    llvm_unreachable(scenarioMessages.c_str());
-  }
+  if (failed(parse(reduce_src, srcBlock, loc, rewriter, known)))
+    return failure();
+  if (!srcBlock.hasSource())
+    return op.emitOpError(scenarioMessages);
   // Use isa_and_nonnull for LLVM 21 compatibility
-  if (!isa_and_nonnull<triton::LoadOp>(srcBlock.getSource().getDefiningOp())) {
-    llvm_unreachable(scenarioMessages.c_str());
-  }
+  if (!isa_and_nonnull<triton::LoadOp>(srcBlock.getSource().getDefiningOp()))
+    return op.emitOpError(scenarioMessages);
 
   auto reduce_result = op->getResult(0);
   auto shaped_ty = dyn_cast<RankedTensorType>(reduce_result.getType());
@@ -966,9 +1193,8 @@ void BlockDataParser::parseReduce(
                                  [](Operation &op) { return &op; });
   // Support only the case: scalar = tl.load(1D tensor)
   if (shape.size() != 1 || op.getAxis() != 0 || ops.size() != 1 ||
-      !isa<arith::MinSIOp>(ops.front())) {
-    llvm_unreachable(scenarioMessages.c_str());
-  }
+      !isa<arith::MinSIOp>(ops.front()))
+    return op.emitOpError(scenarioMessages);
 
   auto castOp = rewriter.create<arith::IndexCastOp>(
       loc, RankedTensorType::get(shape, rewriter.getIndexType()),
@@ -979,8 +1205,10 @@ void BlockDataParser::parseReduce(
     data.getSizesRef().push_back(rewriter.getIndexAttr(shape[0]));
     data.getStridesRef().push_back(rewriter.getIndexAttr(1));
   } else {
-    llvm_unreachable("parseReduce with offset already setup not yet supported");
+    return op.emitOpError(
+        "reduce parsing with a pre-populated offset is unsupported");
   }
+  return success();
 }
 
 template <typename OpTy>
@@ -1030,10 +1258,11 @@ void parseIndirectLoad(OpTy op, BlockData &data, const Location &loc,
 
 namespace {
 template <typename CustomOpT>
-void parseStructuredCustomOpImpl(
-    CustomOpT op, BlockData &data, const Location &loc,
-    ConversionPatternRewriter &rewriter,
-    const llvm::SmallDenseMap<Value, BlockData> &known, unsigned resultIdx) {
+LogicalResult
+parseStructuredCustomOpImpl(CustomOpT op, BlockData &data, const Location &loc,
+                            ConversionPatternRewriter &rewriter,
+                            const llvm::SmallDenseMap<Value, BlockData> &known,
+                            unsigned resultIdx) {
   auto srcValArrayAttr = op->template getAttrOfType<DenseI32ArrayAttr>(
       ConverterUtils::customSrcPtrIndexAttrName);
   assert(srcValArrayAttr &&
@@ -1041,9 +1270,14 @@ void parseStructuredCustomOpImpl(
   auto srcValArray = srcValArrayAttr.asArrayRef();
   assert(srcValArray[resultIdx] != -1 &&
          "tensor<tt.ptr> result should map to src tensor<tt.ptr>");
-  BlockDataParser::parse(op->getOperand(srcValArray[resultIdx]), data, loc,
-                         rewriter, known);
-  data.setSource(rewriter.getRemappedValue(op->getResult(resultIdx)));
+  if (failed(BlockDataParser::parse(op->getOperand(srcValArray[resultIdx]),
+                                    data, loc, rewriter, known)))
+    return failure();
+  Value remappedResult = rewriter.getRemappedValue(op->getResult(resultIdx));
+  if (!remappedResult)
+    return op.emitOpError("custom operation result has no converted value");
+  data.setSource(remappedResult);
+  return success();
 }
 
 template <typename CustomOpT>
@@ -1127,18 +1361,18 @@ void BlockDataParser::rewriteStructuredCustomOp(
   rewriteStructuredCustomOpImpl(op, adaptor, rewriter);
 }
 
-void BlockDataParser::parseStructuredCustomOp(
+LogicalResult BlockDataParser::parseStructuredCustomOp(
     Operation *op, BlockData &data, const Location &loc,
     ConversionPatternRewriter &rewriter,
     const llvm::SmallDenseMap<Value, BlockData> &known, unsigned resultIdx) {
   if (auto customOp = dyn_cast<hivm::CustomOp>(op)) {
-    parseStructuredCustomOpImpl(customOp, data, loc, rewriter, known,
-                                resultIdx);
+    return parseStructuredCustomOpImpl(customOp, data, loc, rewriter, known,
+                                       resultIdx);
   } else if (auto macroOp = dyn_cast<hivm::CustomMacroOp>(op)) {
-    parseStructuredCustomOpImpl(macroOp, data, loc, rewriter, known, resultIdx);
-  } else {
-    llvm_unreachable("expected hivm custom op");
+    return parseStructuredCustomOpImpl(macroOp, data, loc, rewriter, known,
+                                       resultIdx);
   }
+  return op->emitError("expected a structured hivm custom operation");
 }
 
 void BlockDataParser::rewriteStructuredCustomOp(
@@ -1154,15 +1388,17 @@ void BlockDataParser::rewriteStructuredCustomOp(
   }
 }
 
-void BlockDataParser::parseFill(
-    linalg::FillOp op, BlockData &data, const Location &loc,
-    ConversionPatternRewriter &rewriter,
-    const llvm::SmallDenseMap<Value, BlockData> &known) {
+LogicalResult
+BlockDataParser::parseFill(linalg::FillOp op, BlockData &data,
+                           const Location &loc,
+                           ConversionPatternRewriter &rewriter,
+                           const llvm::SmallDenseMap<Value, BlockData> &known) {
   auto src = op.getInputs()[0];
   auto dst = op.getResult(0);
   auto dstShape = dyn_cast<ShapedType>(dst.getType()).getShape();
 
-  parse(src, data, loc, rewriter, known);
+  if (failed(parse(src, data, loc, rewriter, known)))
+    return failure();
 
   if (isa<IntegerType>(src.getType())) {
     if (!data.isEmpty()) {
@@ -1176,25 +1412,28 @@ void BlockDataParser::parseFill(
       data.getStridesRef().push_back(rewriter.getIndexAttr(0));
     }
   } else {
-    op->emitError("Block data Analysis: unsupported fillOp pattern");
-    return;
+    return op.emitOpError("BlockDataParser does not support this fill pattern");
   }
   if (data.isScalar()) {
     data.getOffsetsRef()[0] = data.getScalarRef();
   }
+  return success();
 }
 
-void BlockDataParser::parseSelect(
+LogicalResult BlockDataParser::parseSelect(
     arith::SelectOp op, BlockData &data, const Location &loc,
     ConversionPatternRewriter &rewriter,
     const llvm::SmallDenseMap<Value, BlockData> &known) {
-  assert(data.isEmpty());
+  if (!data.isEmpty())
+    return op.emitOpError(
+        "select parsing requires an empty BlockData destination");
 
   auto res = op.getResult();
   auto resType = dyn_cast<ShapedType>(res.getType());
-  assert(resType && "arith.select result should be a ShapedType");
-  assert(isa<IntegerType>(resType.getElementType()) ||
-         isa<IndexType>(resType.getElementType()));
+  if (!resType || (!isa<IntegerType>(resType.getElementType()) &&
+                   !isa<IndexType>(resType.getElementType())))
+    return op.emitOpError(
+        "BlockData select requires a shaped integer or index result");
 
   OpFoldResult indexOfr;
   size_t loopLimit = resType.getShape().size();
@@ -1205,16 +1444,17 @@ void BlockDataParser::parseSelect(
                         !isa<ShapedType>(cond.getType());
 
   auto trueConst =
-      dyn_cast<arith::ConstantOp>(op.getTrueValue().getDefiningOp());
+      dyn_cast_or_null<arith::ConstantOp>(op.getTrueValue().getDefiningOp());
   auto falseConst =
-      dyn_cast<arith::ConstantOp>(op.getFalseValue().getDefiningOp());
+      dyn_cast_or_null<arith::ConstantOp>(op.getFalseValue().getDefiningOp());
   auto trueDense = trueConst ? dyn_cast<DenseElementsAttr>(trueConst.getValue())
                              : DenseElementsAttr();
   auto falseDense = falseConst
                         ? dyn_cast<DenseElementsAttr>(falseConst.getValue())
                         : DenseElementsAttr();
 
-  bool denseConstCase = condIsScalarI1 && trueDense && falseDense;
+  bool denseConstCase = condIsScalarI1 && trueDense && falseDense &&
+                        trueDense.isSplat() && falseDense.isSplat();
 
   if (denseConstCase) {
     // if cond is scalar i1 and both true and false value are splat dense const,
@@ -1228,27 +1468,30 @@ void BlockDataParser::parseSelect(
     if (auto tInt = dyn_cast<IntegerAttr>(trueFirst)) {
       trueScalar = rewriter.create<arith::ConstantOp>(loc, tInt).getResult();
     } else {
-      llvm_unreachable("unsupported true dense element attr in parseSelect");
+      return op.emitOpError(
+          "BlockData select requires integer dense true values");
     }
 
     if (auto fInt = dyn_cast<IntegerAttr>(falseFirst)) {
       falseScalar = rewriter.create<arith::ConstantOp>(loc, fInt).getResult();
     } else {
-      llvm_unreachable("unsupported false dense element attr in parseSelect");
+      return op.emitOpError(
+          "BlockData select requires integer dense false values");
     }
 
-    assert(trueScalar.getType() == falseScalar.getType() &&
-           "scalarized true/false type mismatch");
+    if (trueScalar.getType() != falseScalar.getType())
+      return op.emitOpError(
+          "scalarized BlockData select values must have the same type");
 
     auto scalarSelect = rewriter.create<arith::SelectOp>(
         loc, trueScalar.getType(), cond, trueScalar, falseScalar);
 
     indexOfr = getOpFoldResultOfLayoutInfo(scalarSelect.getResult(), rewriter);
   } else {
-    assert(llvm::all_of(resType.getShape(),
-                        [](int64_t dim) { return dim == 1; }) &&
-           "parseSelect currently supports all-ones shape unless cond=i1 with "
-           "dense constants");
+    if (!llvm::all_of(resType.getShape(), [](int64_t dim) { return dim == 1; }))
+      return op.emitOpError(
+          "BlockData select supports non-splat values only when every result "
+          "dimension is one");
 
     SmallVector<Value> indices;
     indices.reserve(loopLimit);
@@ -1276,13 +1519,15 @@ void BlockDataParser::parseSelect(
     data.getSizesRef().push_back(rewriter.getIndexAttr(resType.getShape()[i]));
     data.getStridesRef().push_back(rewriter.getIndexAttr(0));
   }
+  return success();
 }
 
-void BlockDataParser::rewriteAddPtr(
-    triton::AddPtrOp op, triton::AddPtrOp::Adaptor &adaptor,
-    ConversionPatternRewriter &rewriter,
-    llvm::SmallDenseMap<Value, BlockData> &known) {
-  auto insertPoint = rewriter.saveInsertionPoint();
+LogicalResult
+BlockDataParser::rewriteAddPtr(triton::AddPtrOp op,
+                               triton::AddPtrOp::Adaptor &adaptor,
+                               ConversionPatternRewriter &rewriter,
+                               llvm::SmallDenseMap<Value, BlockData> &known) {
+  ConversionPatternRewriter::InsertionGuard guard(rewriter);
   rewriter.setInsertionPoint(op);
 
   Location offLoc = op.getLoc();
@@ -1291,15 +1536,16 @@ void BlockDataParser::rewriteAddPtr(
       offLoc = defOp->getLoc();
   insertDebugNop(offLoc, rewriter);
   BlockData data;
-  parseAddPtr(op, data, op.getLoc(), rewriter, known);
+  if (failed(parseAddPtr(op, data, op.getLoc(), rewriter, known)))
+    return failure();
 
-  if (auto src = data.getSource();
-      data.getMemAccTypeRef().isUnstructured() &&
-      !(src && isa_and_nonnull<triton::IntToPtrOp>(src.getDefiningOp()))) {
+  if (data.getMemAccTypeRef().isUnstructured() &&
+      !isScalarPointerCarrierSource(data.getSource())) {
     // TODO: Based on more info, try to create a performant IR
-    rewriteAddPtrToUnstrucMemAcc(op, adaptor, rewriter, data);
+    if (failed(rewriteAddPtrToUnstrucMemAcc(op, adaptor, rewriter, data)))
+      return failure();
     LLVM_DEBUG({ llvm::dbgs() << *getModuleOpFromOperation(op) << "\n"; });
-    return;
+    return success();
   }
 
   if (data.getSizesRef().size() == 0) {
@@ -1360,8 +1606,8 @@ void BlockDataParser::rewriteAddPtr(
     auto rtype = cast<triton::PointerType>(intToPtrOp.getResult().getType());
     auto memrefType =
         MemRefType::get({ShapedType::kDynamic}, rtype.getPointeeType());
-    auto hivmPointCastOp = rewriter.create<hivm::PointerCastOp>(
-        intToPtrOp.getLoc(), memrefType, ValueRange{intToPtrOp.getSrc()});
+    auto hivmPointCastOp = createScalarPointerCast(
+        rewriter, intToPtrOp.getLoc(), memrefType, intToPtrOp.getSrc());
     data.setSource(hivmPointCastOp.getResult());
   }
 
@@ -1377,18 +1623,21 @@ void BlockDataParser::rewriteAddPtr(
 
   // ToDo: need to handle module scenario
 
-  memref::ReinterpretCastOp castOp =
+  FailureOr<memref::ReinterpretCastOp> castOp =
       data.createCastOp(resultShape, op.getLoc(), rewriter);
-  Value src = castOp.getResult();
+  if (failed(castOp))
+    return op.emitOpError(
+        "could not materialize a memref from the source type");
+  Value src = (*castOp).getResult();
   LLVM_DEBUG({
     llvm::dbgs() << "cast MemRefType:\n";
-    castOp.getOperation()->print(llvm::dbgs(),
-                                 OpPrintingFlags().printGenericOpForm());
+    (*castOp).getOperation()->print(llvm::dbgs(),
+                                    OpPrintingFlags().printGenericOpForm());
     llvm::dbgs() << "\n";
   });
 
   rewriter.replaceOp(op, src);
-  rewriter.restoreInsertionPoint(insertPoint);
+  return success();
 }
 
 FailureOr<Value> BlockDataParser::materializePointer(
@@ -1417,8 +1666,8 @@ FailureOr<Value> BlockDataParser::materializePointer(
   rewriter.setInsertionPoint(defOp);
 
   BlockData data;
-  parse(ptr, data, ptr.getLoc(), rewriter, known);
-  if (!data.hasSource() || data.getMemAccType().isUnstructured())
+  if (failed(parse(ptr, data, ptr.getLoc(), rewriter, known)) ||
+      !data.hasSource() || data.getMemAccType().isUnstructured())
     return failure();
 
   if (data.getSizesRef().empty()) {
@@ -1467,8 +1716,8 @@ FailureOr<Value> BlockDataParser::materializePointer(
         cast<triton::PointerType>(intToPtrOp.getResult().getType());
     auto memrefTy =
         MemRefType::get({ShapedType::kDynamic}, pointerTy.getPointeeType());
-    auto pointerCast = rewriter.create<hivm::PointerCastOp>(
-        intToPtrOp.getLoc(), memrefTy, ValueRange{intToPtrOp.getSrc()});
+    auto pointerCast = createScalarPointerCast(rewriter, intToPtrOp.getLoc(),
+                                               memrefTy, intToPtrOp.getSrc());
     data.setSource(pointerCast.getResult());
   }
 
@@ -1477,34 +1726,48 @@ FailureOr<Value> BlockDataParser::materializePointer(
     if (!sourceTy)
       return failure();
     auto castTy = sourceTy.cloneWith(std::nullopt, data.getResElemTyRef());
-    auto cast = rewriter.create<UnrealizedConversionCastOp>(
-        ptr.getLoc(), castTy, data.getSourceRef());
-    data.setSource(cast.getResult(0));
+    if (sourceTy != castTy) {
+      auto cast = rewriter.create<UnrealizedConversionCastOp>(
+          ptr.getLoc(), castTy, data.getSourceRef());
+      data.setSource(cast.getResult(0));
+    }
   }
 
-  return data.createCastOp(resultShape, ptr.getLoc(), rewriter).getResult();
+  FailureOr<memref::ReinterpretCastOp> castOp =
+      data.createCastOp(resultShape, ptr.getLoc(), rewriter);
+  if (failed(castOp))
+    return failure();
+  return (*castOp).getResult();
 }
 
-OpFoldResult
-accumulatePotentialOffsetOnBase(triton::MakeTensorPtrOp op, Value base,
-                                OpFoldResult offset,
-                                ConversionPatternRewriter &rewriter) {
-  if (auto baseRecast = base.getDefiningOp<memref::ReinterpretCastOp>()) {
-    assert(isa<triton::AddPtrOp>(op.getBase().getDefiningOp()) &&
-           "base of MakeTensorPtrOp only comes from native ptr or AddPtrOp");
+static FailureOr<OpFoldResult>
+getBaseMemRefOffset(Value convertedBase, ConversionPatternRewriter &rewriter) {
+  auto memrefType = dyn_cast<MemRefType>(convertedBase.getType());
+  if (!memrefType)
+    return failure();
+  // Preserve the existing foldable path for a directly converted tt.addptr.
+  // Reinterpret-casting a reinterpret cast does not compose offsets, so the
+  // first cast's absolute offset must be carried into the new descriptor.
+  if (auto baseRecast =
+          convertedBase.getDefiningOp<memref::ReinterpretCastOp>())
+    return baseRecast.getConstifiedMixedOffset();
 
-    return addOpFoldResult(offset, baseRecast.getConstifiedMixedOffset(),
-                           op.getLoc(), rewriter, rewriter.getIndexType());
-  }
+  auto stridedLayout = memrefType.getStridesAndOffset();
+  int64_t staticOffset = stridedLayout.second;
+  if (!ShapedType::isDynamic(staticOffset))
+    return OpFoldResult(rewriter.getIndexAttr(staticOffset));
 
-  return offset;
+  // A control-flow-carried BlockPtr base uses the canonical identity-layout
+  // memref and therefore has static offset zero. Dynamic hidden offsets are not
+  // valid BlockPtr bases; their displacement belongs in descriptor offsets.
+  return failure();
 }
 
-void BlockDataParser::rewriteCustomOp(
+LogicalResult BlockDataParser::rewriteCustomOp(
     hivm::CustomOp op, hivm::CustomOp::Adaptor &adaptor,
     ConversionPatternRewriter &rewriter,
     const llvm::SmallDenseMap<Value, BlockData> &known) {
-  auto ip = rewriter.saveInsertionPoint();
+  ConversionPatternRewriter::InsertionGuard guard(rewriter);
   rewriter.setInsertionPoint(op);
   auto loc = op.getLoc();
   llvm::SmallVector<Value> newInputs;
@@ -1515,8 +1778,8 @@ void BlockDataParser::rewriteCustomOp(
       auto rtype = cast<triton::PointerType>(intToPtrOp.getResult().getType());
       auto memrefType =
           MemRefType::get({ShapedType::kDynamic}, rtype.getPointeeType());
-      auto hivmPointCastOp = rewriter.create<hivm::PointerCastOp>(
-          intToPtrOp.getLoc(), memrefType, ValueRange{intToPtrOp.getSrc()});
+      auto hivmPointCastOp = createScalarPointerCast(
+          rewriter, intToPtrOp.getLoc(), memrefType, intToPtrOp.getSrc());
       if (data.getSizesRef().size() == 0) {
         data.getSizesRef().push_back(rewriter.getIndexAttr(1));
         if (data.getScalarRef().isNull()) {
@@ -1531,17 +1794,29 @@ void BlockDataParser::rewriteCustomOp(
   };
   for (auto in : op.getInputs()) {
     in = rewriter.getRemappedValue(in);
+    if (!in)
+      return op.emitOpError("custom operation input has no converted value");
     BlockData blockData;
     auto curInput = in;
     if (llvm::isa<triton::PointerType>(in.getType())) {
-      parse(in, blockData, loc, rewriter, known);
+      if (failed(parse(in, blockData, loc, rewriter, known)))
+        return failure();
       convertIntToPtr(blockData);
-      curInput = blockData.createCastOp({ShapedType::kDynamic}, loc, rewriter);
+      FailureOr<memref::ReinterpretCastOp> castOp =
+          blockData.createCastOp({ShapedType::kDynamic}, loc, rewriter);
+      if (failed(castOp))
+        return failure();
+      curInput = (*castOp).getResult();
     } else if (auto tensor = llvm::dyn_cast<RankedTensorType>(in.getType())) {
       if (llvm::isa<triton::PointerType>(tensor.getElementType())) {
-        parse(in, blockData, loc, rewriter, known);
+        if (failed(parse(in, blockData, loc, rewriter, known)))
+          return failure();
         convertIntToPtr(blockData);
-        curInput = blockData.createCastOp(tensor.getShape(), loc, rewriter);
+        FailureOr<memref::ReinterpretCastOp> castOp =
+            blockData.createCastOp(tensor.getShape(), loc, rewriter);
+        if (failed(castOp))
+          return failure();
+        curInput = (*castOp).getResult();
       }
     }
     newInputs.emplace_back(curInput);
@@ -1579,13 +1854,13 @@ void BlockDataParser::rewriteCustomOp(
   newCustomOp->setAttrs(op->getAttrs());
   newCustomOp->setAttr("operandSegmentSizes", operandSegmentSizesAttr);
   rewriter.replaceOp(op, newCustomOp.getResults());
-  rewriter.restoreInsertionPoint(ip);
+  return success();
 }
 
 // Design for load/store boundary_check.
-memref::ReinterpretCastOp createRedundantOp(triton::MakeTensorPtrOp op,
-                                            ConversionPatternRewriter &rewriter,
-                                            BlockData &data) {
+FailureOr<memref::ReinterpretCastOp>
+createRedundantOp(triton::MakeTensorPtrOp op, OpFoldResult sourceBaseOffset,
+                  ConversionPatternRewriter &rewriter, BlockData &data) {
   auto loc = op.getLoc();
   // to do boundary_check in tt.load, we need to keep the parent tensor's
   // shape info in the IR.
@@ -1603,10 +1878,10 @@ memref::ReinterpretCastOp createRedundantOp(triton::MakeTensorPtrOp op,
   // dim offset from base is initialized as zero.
   SmallVector<OpFoldResult> curOffsets(op.getOffsets().size(),
                                        rewriter.getIndexAttr(0));
-  // Just accumulate base potential offset
-  curOffsets.front() = accumulatePotentialOffsetOnBase(
-      op, rewriter.getRemappedValue(op.getBase()), curOffsets.front(),
-      rewriter);
+  // Both the full-shape descriptor and the final block descriptor use the
+  // same absolute source offset. Reusing this value avoids both dropping it
+  // across SCF and accidentally composing it twice.
+  curOffsets.front() = sourceBaseOffset;
 
   for (auto offset : curOffsets) {
     data.getOffsetsRef().push_back(offset);
@@ -1628,25 +1903,101 @@ memref::ReinterpretCastOp createRedundantOp(triton::MakeTensorPtrOp op,
   return castOp;
 }
 
-void BlockDataParser::rewriteMakeTensorPtrOp(
-    triton::MakeTensorPtrOp op, Value base, ConversionPatternRewriter &rewriter,
+// Carries the converted runtime descriptor and records whether the resolver
+// has already proven the complete ptr<i1>-to-ptr<i8> normalization contract.
+// That exact fallback can initialize BlockData without consulting conversion
+// state attached to the original bitcast result.
+struct ResolvedMakeTensorPtrBase {
+  Value value;
+  bool normalizedI1ToI8 = false;
+};
+
+static FailureOr<ResolvedMakeTensorPtrBase>
+resolveMakeTensorPtrBase(triton::MakeTensorPtrOp op, Value adaptorBase,
+                         ConversionPatternRewriter &rewriter) {
+  if (adaptorBase && isa<BaseMemRefType>(adaptorBase.getType()))
+    return ResolvedMakeTensorPtrBase{adaptorBase};
+
+  auto bitcast = op.getBase().getDefiningOp<triton::BitcastOp>();
+  if (!bitcast)
+    return failure();
+
+  auto sourceArgument = dyn_cast<BlockArgument>(bitcast.getSrc());
+  if (!sourceArgument)
+    return failure();
+
+  auto sourcePointer =
+      dyn_cast<triton::PointerType>(bitcast.getSrc().getType());
+  auto resultPointer =
+      dyn_cast<triton::PointerType>(bitcast.getResult().getType());
+  if (!sourcePointer || !resultPointer ||
+      !sourcePointer.getPointeeType().isInteger(1) ||
+      !resultPointer.getPointeeType().isInteger(8))
+    return failure();
+
+  Value convertedSource = rewriter.getRemappedValue(bitcast.getSrc());
+  if (!convertedSource)
+    return failure();
+  auto sourceMemRef = dyn_cast<MemRefType>(convertedSource.getType());
+  auto expectedType =
+      MemRefType::get({ShapedType::kDynamic}, rewriter.getIntegerType(8));
+  if (!sourceMemRef || sourceMemRef != expectedType)
+    return failure();
+
+  return ResolvedMakeTensorPtrBase{convertedSource,
+                                   /*normalizedI1ToI8=*/true};
+}
+
+LogicalResult BlockDataParser::rewriteMakeTensorPtrOp(
+    triton::MakeTensorPtrOp op, Value convertedBase,
+    ConversionPatternRewriter &rewriter,
     llvm::SmallDenseMap<Value, BlockData> &known) {
+  FailureOr<ResolvedMakeTensorPtrBase> resolvedBase =
+      resolveMakeTensorPtrBase(op, convertedBase, rewriter);
+  if (failed(resolvedBase)) {
+    op.emitOpError("expected the converted base to be a memref descriptor");
+    return failure();
+  }
+  convertedBase = resolvedBase->value;
   Location loc = op.getLoc();
   BlockData data;
 
-  auto orderSize = op.getOrder().size();
-
-  // Handle base is defined by tt.bitcast
-  BlockDataParser::parse(op.getBase(), data, loc, rewriter, known);
-  if (data.hasResElemTy()) {
-    auto memrefType = dyn_cast<BaseMemRefType>(data.getSourceRef().getType())
-                          .cloneWith(std::nullopt, data.getResElemTyRef());
-    UnrealizedConversionCastOp castOp =
-        rewriter.create<mlir::UnrealizedConversionCastOp>(loc, memrefType,
-                                                          data.getSourceRef());
-    data.setSource(castOp.getOutputs()[0]);
+  if (resolvedBase->normalizedI1ToI8) {
+    // The resolver has already established the complete normalized mask-base
+    // contract. Avoid querying the bitcast result mapping while dialect
+    // conversion may still be rewriting its owner block.
+    data.setSource(convertedBase);
+    data.setResElemTy(rewriter.getIntegerType(8));
   } else {
-    data.setSource(rewriter.getRemappedValue(op.getBase()));
+    // Parse the original producer only for semantic information such as a
+    // bitcast element type. The runtime source always comes from the resolved
+    // converted base so SCF-selected memref descriptors are not bypassed.
+    if (failed(
+            BlockDataParser::parse(op.getBase(), data, loc, rewriter, known)))
+      return failure();
+  }
+  if (!data.hasSource()) {
+    op.emitOpError("failed to resolve the converted scalar base");
+    return failure();
+  }
+  if (data.hasResElemTy()) {
+    auto sourceType = dyn_cast<BaseMemRefType>(convertedBase.getType());
+    if (!sourceType) {
+      op.emitOpError("bitcast base did not resolve to a memref descriptor");
+      return failure();
+    }
+    auto memrefType =
+        sourceType.cloneWith(std::nullopt, data.getResElemTyRef());
+    if (sourceType == memrefType) {
+      data.setSource(convertedBase);
+    } else {
+      UnrealizedConversionCastOp castOp =
+          rewriter.create<mlir::UnrealizedConversionCastOp>(loc, memrefType,
+                                                            convertedBase);
+      data.setSource(castOp.getOutputs()[0]);
+    }
+  } else {
+    data.setSource(convertedBase);
   }
 
   data.getOffsetsRef() =
@@ -1667,20 +2018,19 @@ void BlockDataParser::rewriteMakeTensorPtrOp(
     newOffsets.push_back(mulOpFoldResult(offset, stride, loc, rewriter,
                                          rewriter.getIndexType()));
 
-  // 1. Consider that current base ptr may comes from `triton::AddPtrOp`,
-  // which have been converted to `memref::ReinterpretCastOp` with 1D
-  // shape([1,]) by `AddPtrConverter`.
-  // 2. While here would also convert `triton::MakeTensorPtrOp` to
-  // `memref::ReinterpretCastOp`, it will create use-def on double recast
-  // which means offset&size&stride info of first one will be dropped in terms
-  // of memref recast op fold specification.
-  //
-  // Conclusion with above two:
-  // Base of MakeTensorPtrOp has been seen as origin base, so it should
-  // reserve offset of first recast if it exists.
-  // Here extract the offset of first recast and add it to highest dimension
-  newOffsets.front() =
-      accumulatePotentialOffsetOnBase(op, base, newOffsets.front(), rewriter);
+  if (newOffsets.empty()) {
+    op.emitOpError("expected at least one block pointer dimension");
+    return failure();
+  }
+
+  FailureOr<OpFoldResult> sourceBaseOffset =
+      getBaseMemRefOffset(convertedBase, rewriter);
+  if (failed(sourceBaseOffset)) {
+    op.emitOpError("could not extract the converted base offset");
+    return failure();
+  }
+  newOffsets.front() = addOpFoldResult(newOffsets.front(), *sourceBaseOffset,
+                                       loc, rewriter, rewriter.getIndexType());
 
   data.getOffsetsRef().clear();
 
@@ -1706,17 +2056,23 @@ void BlockDataParser::rewriteMakeTensorPtrOp(
 
   // special handling for davinci
   // create redundant reinterpret_cast op for record shape info
-  auto redundantOp = createRedundantOp(op, rewriter, data);
-  redundantOp->setAttr("tensor_ptr_full_shape", rewriter.getUnitAttr());
+  FailureOr<memref::ReinterpretCastOp> redundantOp =
+      createRedundantOp(op, *sourceBaseOffset, rewriter, data);
+  if (failed(redundantOp))
+    return op.emitOpError("could not materialize the full tensor pointer");
+  (*redundantOp)->setAttr("tensor_ptr_full_shape", rewriter.getUnitAttr());
 
   // create reinterpret_cast op for the target block
-  data.setSource(redundantOp.getResult());
+  data.setSource((*redundantOp).getResult());
   known[op.getResult()] = data;
-  auto castOp = data.createCastOp(resultShape, loc, rewriter);
-  rewriter.replaceOp(op, castOp.getResult());
+  FailureOr<memref::ReinterpretCastOp> castOp =
+      data.createCastOp(resultShape, loc, rewriter);
+  if (failed(castOp))
+    return op.emitOpError("could not materialize the block pointer");
+  rewriter.replaceOp(op, (*castOp).getResult());
 
   if (nd2nzFlag) {
-    auto basePtr = castOp.getResult();
+    auto basePtr = (*castOp).getResult();
     int original_rank = op.getShape().size() + 1;
     std::string shapeStr;
 
@@ -1796,9 +2152,11 @@ void BlockDataParser::rewriteMakeTensorPtrOp(
     }
     rewriter.create<func::CallOp>(loc, funcName, dstElemTy, args);
   }
+
+  return success();
 }
 
-void BlockDataParser::rewriteAdvanceOp(
+LogicalResult BlockDataParser::rewriteAdvanceOp(
     triton::AdvanceOp op, ConversionPatternRewriter &rewriter,
     llvm::SmallDenseMap<Value, BlockData> &known) {
   OpBuilder::InsertionGuard insertionGuard(rewriter);
@@ -1806,7 +2164,8 @@ void BlockDataParser::rewriteAdvanceOp(
   auto loc = op.getLoc();
 
   BlockData blockData;
-  parse(op.getOperand(0), blockData, loc, rewriter, known);
+  if (failed(parse(op.getOperand(0), blockData, loc, rewriter, known)))
+    return failure();
 
   // region [BUGFIX] Add the code block below following the same logic as
   // 'BlockDataParser::rewriteAddPtr' function.
@@ -1857,15 +2216,86 @@ void BlockDataParser::rewriteAdvanceOp(
     assert(blockData.getRank() == 1);
   }
 
-  auto newOp = blockData.createCastOp(resultShape, loc, rewriter);
-  rewriter.replaceOp(op, newOp.getResult());
+  FailureOr<memref::ReinterpretCastOp> newOp =
+      blockData.createCastOp(resultShape, loc, rewriter);
+  if (failed(newOp))
+    return op.emitOpError("could not materialize the advanced pointer");
+  rewriter.replaceOp(op, (*newOp).getResult());
 
-  known[newOp.getResult()] = blockData;
+  known[(*newOp).getResult()] = blockData;
+  return success();
+}
+
+static bool isIntegerTensorBlockDataValue(Value value) {
+  auto tensorType = dyn_cast<TensorType>(value.getType());
+  return tensorType && isa<IntegerType>(tensorType.getElementType());
+}
+
+static bool containsLegacyTritonPointer(Type type) {
+  if (isa<triton::PointerType>(type))
+    return true;
+  auto shapedType = dyn_cast<ShapedType>(type);
+  return shapedType && isa<triton::PointerType>(shapedType.getElementType());
+}
+
+// Before expanding a loop signature, reject backedges that are already known
+// to be opaque to BlockData. Triton pointer values may still receive a legal
+// converted mapping later, while complete memrefs require an explicit
+// reinterpret-cast producer. In particular, this deliberately rejects an
+// arbitrary fixed-layout memref returned by func.call.
+static bool canAnalyzeLegacyBlockDataBackedge(LoopLikeOpInterface loopOp,
+                                              unsigned slot, Value value) {
+  if (containsLegacyTritonPointer(value.getType()) ||
+      isIntegerTensorBlockDataValue(value) ||
+      value.getDefiningOp<memref::ReinterpretCastOp>())
+    return true;
+
+  // Forwarding the same loop-carried block argument preserves the descriptor
+  // state already parsed from the init. A captured function/block argument is
+  // not equivalent and remains opaque to this analysis.
+  if (slot < loopOp.getRegionIterArgs().size() &&
+      value == loopOp.getRegionIterArgs()[slot])
+    return true;
+  if (auto whileOp = dyn_cast<scf::WhileOp>(loopOp.getOperation())) {
+    return slot < whileOp.getAfterArguments().size() &&
+           value == whileOp.getAfterArguments()[slot];
+  }
+  return false;
+}
+
+// Resolve a selected legacy BlockData state after dialect-conversion remapping.
+// The legacy representation is intentionally limited to reinterpret-cast
+// descriptors and integer tensors. An opaque memref returned by func.call is a
+// complete value, not an analyzable descriptor producer, and must never be
+// guessed across the call boundary.
+static FailureOr<Value>
+resolveBlockDataStateValue(Value originalValue,
+                           ConversionPatternRewriter &rewriter) {
+  Value value = originalValue;
+  if (Value mappedValue = rewriter.getRemappedValue(originalValue)) {
+    if (originalValue.getDefiningOp<triton::AddPtrOp>() ||
+        originalValue.getDefiningOp<triton::AdvanceOp>() ||
+        originalValue.getDefiningOp<triton::MakeTensorPtrOp>()) {
+      if (!mappedValue.getDefiningOp<memref::ReinterpretCastOp>())
+        return failure();
+    } else if (auto tensorType = dyn_cast<TensorType>(mappedValue.getType());
+               tensorType &&
+               isa<triton::PointerType>(tensorType.getElementType())) {
+      return failure();
+    }
+    value = mappedValue;
+  }
+
+  if (value.getDefiningOp<memref::ReinterpretCastOp>() ||
+      isIntegerTensorBlockDataValue(value))
+    return value;
+  return failure();
 }
 
 template <typename T>
 std::enable_if_t<std::is_same_v<T, scf::YieldOp> ||
-                 std::is_same_v<T, scf::ConditionOp>>
+                     std::is_same_v<T, scf::ConditionOp>,
+                 LogicalResult>
 BlockDataParser::rewriteTerminator(
     T op, ConversionPatternRewriter &rewriter,
     const llvm::SmallDenseSet<size_t> &blockArgIdxSet,
@@ -1896,50 +2326,40 @@ BlockDataParser::rewriteTerminator(
   // For each of the init arg that we added additional Values in for loop, we
   // need to add corresponding Values as yield operands. The loop below gathers
   // BlockData for those values.
-  for (auto [i, v] : llvm::enumerate(args)) {
-    if (auto mappedV = rewriter.getRemappedValue(v)) {
-      // If this value is a tensor of pointers produced by AddPtrOp,
-      // we should have already converted to a ReinterpretCastOp without
-      // layout information for the normal cases
-      if (v.getDefiningOp<triton::AddPtrOp>() ||
-          v.getDefiningOp<triton::AdvanceOp>() ||
-          v.getDefiningOp<triton::MakeTensorPtrOp>()) {
-        if (auto castOp = mappedV.getDefiningOp<memref::ReinterpretCastOp>()) {
-          v = castOp;
-        } else {
-          llvm_unreachable("mapped value defined by an unexpected op");
-        }
-      } else {
-        // If this value is not a tensor of pointers, we will use the
-        // mapped value, and rely on the conversion will happen later
-        // automatically when we legalize loop body.
-
-        // TODO:
-        // The scenario where a value is a tensor of pointers but not
-        // produced by AddPtrOp is not supported
-        if (isa<TensorType>(mappedV.getType()) &&
-            isa<triton::PointerType>(
-                dyn_cast<TensorType>(mappedV.getType()).getElementType()))
-          llvm_unreachable("unsupported scenario where a value is a tensor of "
-                           "pointers but not produced by AddPtrOp");
-        v = mappedV;
-      }
-    }
-
+  for (auto [i, originalValue] : llvm::enumerate(args)) {
     if (blockArgIdxSet.find(i) == blockArgIdxSet.end())
       continue;
 
+    Value knownKey = rewriter.getRemappedValue(originalValue);
+    if (!knownKey)
+      knownKey = originalValue;
+    if (auto knownState = known.find(knownKey); knownState != known.end()) {
+      initArgState.push_back(knownState->second);
+      continue;
+    }
+
+    FailureOr<Value> stateValue =
+        resolveBlockDataStateValue(originalValue, rewriter);
+    if (failed(stateValue)) {
+      InFlightDiagnostic diagnostic = op.emitError(
+          "legacy BlockData loop rewrite cannot analyze carried slot ");
+      diagnostic << i << " produced by ";
+      if (Operation *producer = originalValue.getDefiningOp())
+        diagnostic << producer->getName();
+      else
+        diagnostic << "a block argument";
+      return failure();
+    }
+
+    Value v = *stateValue;
     auto reintCastOp = v.getDefiningOp<memref::ReinterpretCastOp>();
-    assert(
-        reintCastOp ||
-        (isa<TensorType>(v.getType()) &&
-         isa<IntegerType>(dyn_cast<TensorType>(v.getType()).getElementType())));
 
     BlockData state;
     if (reintCastOp) {
       parseReinterpretCast(reintCastOp, state, op.getLoc(), rewriter, known);
     } else {
-      parse(v, state, op.getLoc(), rewriter, known);
+      if (failed(parse(v, state, op.getLoc(), rewriter, known)))
+        return failure();
     }
     initArgState.push_back(state);
   }
@@ -2008,6 +2428,7 @@ BlockDataParser::rewriteTerminator(
     newOp->print(llvm::dbgs(), OpPrintingFlags().printGenericOpForm());
     llvm::dbgs() << "\n";
   });
+  return success();
 }
 
 // This function is util function for rewriteLoopOp that
@@ -2061,6 +2482,145 @@ bool isUsedWithCondition(Value v, std::function<bool(OpOperand *)> cond,
     }
   }
   return false;
+}
+
+// A loop-carried value may be consumed through a region argument, through a
+// while after-argument, or only after the loop result. Check every semantic
+// view of the same carried slot so an identity tensor.cast after the loop
+// cannot hide an AddPtr/load/store use from the decomposition decision.
+bool isLoopCarriedValueUsedWithCondition(
+    LoopLikeOpInterface loopOp, unsigned index,
+    const std::function<bool(OpOperand *)> &condition) {
+  if (index >= loopOp.getRegionIterArgs().size() ||
+      index >= loopOp->getNumResults())
+    return false;
+  if (isUsedWithCondition(loopOp.getRegionIterArgs()[index], condition))
+    return true;
+  if (auto whileOp = dyn_cast<scf::WhileOp>(loopOp.getOperation())) {
+    if (index < whileOp.getAfterArguments().size() &&
+        isUsedWithCondition(whileOp.getAfterArguments()[index], condition))
+      return true;
+  }
+  return isUsedWithCondition(loopOp->getResult(index), condition);
+}
+
+bool needsLegacyBlockDataLoopRewrite(LoopLikeOpInterface loopOp) {
+  auto hasPointerValue = [&](auto values) {
+    return llvm::any_of(values, [&](Value value) {
+      return containsLegacyTritonPointer(value.getType());
+    });
+  };
+
+  auto isScalarPointerValue = [](Value value) {
+    auto pointerType = dyn_cast<triton::PointerType>(value.getType());
+    return pointerType && !isa<ShapedType>(pointerType.getPointeeType());
+  };
+  auto isTensorPointerValue = [](Value value) {
+    auto pointerType = dyn_cast<triton::PointerType>(value.getType());
+    return pointerType && isa<ShapedType>(pointerType.getPointeeType());
+  };
+
+  SmallVector<Value> boundaryValues;
+  boundaryValues.append(loopOp.getInits().begin(), loopOp.getInits().end());
+  boundaryValues.append(loopOp.getRegionIterArgs().begin(),
+                        loopOp.getRegionIterArgs().end());
+  boundaryValues.append(loopOp->getResults().begin(),
+                        loopOp->getResults().end());
+  if (auto whileOp = dyn_cast<scf::WhileOp>(loopOp.getOperation()))
+    boundaryValues.append(whileOp.getAfterArguments().begin(),
+                          whileOp.getAfterArguments().end());
+
+  bool hasScalarPointer = llvm::any_of(boundaryValues, isScalarPointerValue);
+  bool hasTensorPointer = llvm::any_of(boundaryValues, isTensorPointerValue);
+  // An opaque scalar-pointer loop has no legacy BlockData schema.  Leave it
+  // untouched so the conversion driver reports an ordinary unsupported
+  // boundary instead of entering the descriptor parser with a non-memref
+  // source. Tensor-pointer loops continue through their established path.
+  if (hasScalarPointer && !hasTensorPointer)
+    return false;
+
+  // Inspect the original SCF boundary, before the dialect converter remaps a
+  // Triton pointer to a reinterpret-cast memref. Such loops still belong to the
+  // legacy pointer conversion even though their converted init may look like
+  // an ordinary memref later in rewriteLoopOp().
+  if (hasPointerValue(loopOp.getInits()) ||
+      hasPointerValue(loopOp.getRegionIterArgs()) ||
+      llvm::any_of(loopOp->getResultTypes(), containsLegacyTritonPointer))
+    return true;
+  if (auto whileOp = dyn_cast<scf::WhileOp>(loopOp.getOperation())) {
+    if (hasPointerValue(whileOp.getAfterArguments()))
+      return true;
+  }
+
+  // Preserve the pre-existing tensor-offset/mask path. These pointer-free
+  // integer tensors are nevertheless expanded by BlockData when they feed the
+  // address operands recognized by the legacy analysis.
+  for (auto [index, init] : llvm::enumerate(loopOp.getInits())) {
+    auto tensorType = dyn_cast<TensorType>(init.getType());
+    if (!tensorType)
+      continue;
+    auto integerType = dyn_cast<IntegerType>(tensorType.getElementType());
+    if (!integerType || integerType.getWidth() == 1)
+      continue;
+    if (isLoopCarriedValueUsedWithCondition(loopOp, index, [](OpOperand *use) {
+          Operation *user = use->getOwner();
+          return isa<triton::AddPtrOp>(user) ||
+                 (isa<triton::LoadOp>(user) && use->getOperandNumber() == 1) ||
+                 (isa<triton::StoreOp>(user) && use->getOperandNumber() == 2);
+        }))
+      return true;
+  }
+  return false;
+}
+
+static bool isMakeRangeCarrier(Value value) {
+  Operation *producer = value.getDefiningOp();
+  if (!producer)
+    return false;
+  if (isa<triton::MakeRangeOp>(producer))
+    return true;
+  if (auto cast = dyn_cast<tensor::CastOp>(producer))
+    return isMakeRangeCarrier(cast.getSource());
+  return false;
+}
+
+SmallVector<unsigned>
+getMarkedMakeRangeCarrierSlots(LoopLikeOpInterface loopOp) {
+  SmallVector<unsigned> slots;
+  if (!loopOp || !loopOp->hasAttr(controlflow::kPointerDescriptorBoundaryAttr))
+    return slots;
+
+  auto marker = dyn_cast<DenseI32ArrayAttr>(
+      loopOp->getAttr(controlflow::kPointerDescriptorBoundaryAttr));
+  if (!marker)
+    return slots;
+
+  llvm::SmallDenseSet<unsigned> descriptorSlots;
+  for (int32_t slot : marker.asArrayRef()) {
+    if (slot >= 0)
+      descriptorSlots.insert(static_cast<unsigned>(slot));
+  }
+
+  auto isMaskOrAddressUse = [](OpOperand *use) {
+    Operation *user = use->getOwner();
+    return isa<triton::AddPtrOp>(user) ||
+           (isa<triton::LoadOp>(user) && use->getOperandNumber() == 1) ||
+           (isa<triton::StoreOp>(user) && use->getOperandNumber() == 2);
+  };
+
+  for (auto [slot, init] : llvm::enumerate(loopOp.getInits())) {
+    if (descriptorSlots.contains(slot) || !isMakeRangeCarrier(init))
+      continue;
+    auto tensorType = dyn_cast<RankedTensorType>(init.getType());
+    if (!tensorType || !tensorType.hasStaticShape())
+      continue;
+    auto elementType = dyn_cast<IntegerType>(tensorType.getElementType());
+    if (!elementType || elementType.getWidth() == 1)
+      continue;
+    if (isLoopCarriedValueUsedWithCondition(loopOp, slot, isMaskOrAddressUse))
+      slots.push_back(slot);
+  }
+  return slots;
 }
 
 // This function is util function for rewriteLoopOp that create value from data.
@@ -2126,9 +2686,11 @@ Value createFromData(RankedTensorType resType, const BlockData &data,
   return newRes;
 }
 
-void BlockDataParser::rewriteLoopOp(
-    LoopLikeOpInterface op, ConversionPatternRewriter &rewriter,
-    llvm::SmallDenseMap<Value, BlockData> &known) {
+LogicalResult
+BlockDataParser::rewriteLoopOp(LoopLikeOpInterface op,
+                               ConversionPatternRewriter &rewriter,
+                               llvm::SmallDenseMap<Value, BlockData> &known,
+                               ArrayRef<unsigned> onlyIndexTensorSlots) {
   SmallVector<Value> newInitArgs;
   SmallVector<int64_t> iterArgIdxMap;
   SmallVector<bool> maskIterArgs;
@@ -2176,12 +2738,16 @@ void BlockDataParser::rewriteLoopOp(
         isa<IntegerType>(cast<TensorType>(arg.getType()).getElementType()) &&
         cast<IntegerType>(cast<TensorType>(arg.getType()).getElementType())
                 .getWidth() != 1 &&
-        isUsedWithCondition(op.getRegionIterArgs()[i], [](OpOperand *use) {
+        isLoopCarriedValueUsedWithCondition(op, i, [](OpOperand *use) {
           auto *user = use->getOwner();
           return isa<triton::AddPtrOp>(user) ||
                  (isa<triton::LoadOp>(user) && use->getOperandNumber() == 1) ||
                  (isa<triton::StoreOp>(user) && use->getOperandNumber() == 2);
         });
+
+    if (!onlyIndexTensorSlots.empty() &&
+        !llvm::is_contained(onlyIndexTensorSlots, static_cast<unsigned>(i)))
+      indexTensor = false;
 
     // Handle memref::ReinterpretCastOp and tensor<Integer> specially
     if (!reintCastOp && !indexTensor)
@@ -2192,13 +2758,14 @@ void BlockDataParser::rewriteLoopOp(
       parseReinterpretCast(reintCastOp, data, op.getLoc(), rewriter,
                            llvm::SmallDenseMap<Value, BlockData>(0));
     } else {
-      parse(arg, data, op.getLoc(), rewriter,
-            llvm::SmallDenseMap<Value, BlockData>(0));
+      if (failed(parse(arg, data, op.getLoc(), rewriter,
+                       llvm::SmallDenseMap<Value, BlockData>(0))))
+        return failure();
     }
 
     maskIterArgs[i] =
         indexTensor &&
-        isUsedWithCondition(op.getRegionIterArgs()[i], [](OpOperand *use) {
+        isLoopCarriedValueUsedWithCondition(op, i, [](OpOperand *use) {
           auto *user = use->getOwner();
           return (isa<triton::LoadOp>(user) && use->getOperandNumber() == 1) ||
                  (isa<triton::StoreOp>(user) && use->getOperandNumber() == 2);
@@ -2212,6 +2779,42 @@ void BlockDataParser::rewriteLoopOp(
 
     // Record the BlockData for later processing
     initArgIndexIfBlockData.push_back(std::make_pair(i, data));
+  }
+
+  // Validate every structural backedge before creating constants or a new
+  // loop. This prevents a partially expanded signature when an opaque memref
+  // source cannot provide offsets and strides.
+  auto preflightBackedge = [&](ValueRange values,
+                               StringRef edgeName) -> LogicalResult {
+    for (auto [index, data] : initArgIndexIfBlockData) {
+      (void)data;
+      if (index < 0 || static_cast<unsigned>(index) >= values.size()) {
+        op->emitError("legacy BlockData preflight found a missing ")
+            << edgeName << " value for carried slot " << index;
+        return failure();
+      }
+      Value value = values[index];
+      if (!canAnalyzeLegacyBlockDataBackedge(op, index, value)) {
+        InFlightDiagnostic diagnostic = op->emitError(
+            "legacy BlockData preflight cannot analyze carried slot ");
+        diagnostic << index << " on the " << edgeName << " edge produced by ";
+        if (Operation *producer = value.getDefiningOp())
+          diagnostic << producer->getName();
+        else
+          diagnostic << "an unknown source";
+        return failure();
+      }
+    }
+    return success();
+  };
+  if (auto forOp = dyn_cast<scf::ForOp>(op.getOperation())) {
+    if (failed(preflightBackedge(forOp.getYieldedValues(), "yield")))
+      return failure();
+  } else if (auto whileOp = dyn_cast<scf::WhileOp>(op.getOperation())) {
+    if (failed(preflightBackedge(whileOp.getConditionOp().getArgs(),
+                                 "condition")) ||
+        failed(preflightBackedge(whileOp.getYieldOp().getOperands(), "yield")))
+      return failure();
   }
 
   // Set insertion point to be before the for loop for new variables passed
@@ -2287,26 +2890,30 @@ void BlockDataParser::rewriteLoopOp(
 
       // In current block data layout info, strides and offsets must be dynamic
       // value
-      auto castOp = data.createCastOp(resultShape, op.getLoc(), rewriter);
+      FailureOr<memref::ReinterpretCastOp> castOp =
+          data.createCastOp(resultShape, op.getLoc(), rewriter);
+      if (failed(castOp))
+        return op.emitOpError(
+            "could not materialize a loop-carried memref from the source type");
       if (resultShape.size() > 1) {
         auto originalOffset = dyn_cast<Value>(data.getOffsetsRef()[0]);
         for (auto &offsets : newInitArgs) {
           if (offsets == originalOffset) {
-            offsets = castOp.getOffsets()[0];
+            offsets = (*castOp).getOffsets()[0];
             break;
           }
         }
-        data.getOffsetsRef()[0] = castOp.getOffsets()[0];
+        data.getOffsetsRef()[0] = (*castOp).getOffsets()[0];
       }
 
       LLVM_DEBUG({
         llvm::dbgs() << "new reinterpret_cast with dynamic sizes "
                         "and offsets:";
-        castOp->print(llvm::dbgs(), OpPrintingFlags().printGenericOpForm());
+        (*castOp).print(llvm::dbgs(), OpPrintingFlags().printGenericOpForm());
         llvm::dbgs() << "\n";
       });
 
-      newInitArgs[i] = castOp.getResult();
+      newInitArgs[i] = (*castOp).getResult();
     }
   }
 
@@ -2402,6 +3009,7 @@ void BlockDataParser::rewriteLoopOp(
     }
   }
   SmallVector<Value> newResults;
+  SmallVector<int64_t> markerSlotMap;
   if (auto forOp = dyn_cast<scf::ForOp>(op.getOperation())) {
     SmallVector<bool> usedForRegionArgs;
     for (auto newInitArg : newInitArgs) {
@@ -2441,6 +3049,7 @@ void BlockDataParser::rewriteLoopOp(
         newResults.push_back(newRes);
       }
     }
+    markerSlotMap = iterArgIdxMap;
   } else if (auto whileOp = dyn_cast<scf::WhileOp>(op.getOperation())) {
     SmallVector<Type> resultTypes;
     SmallVector<bool> usedForBeforeRegionArgs;
@@ -2459,21 +3068,19 @@ void BlockDataParser::rewriteLoopOp(
       auto indexTensor =
           isa<RankedTensorType>(resType) &&
           isa<IntegerType>(cast<RankedTensorType>(resType).getElementType()) &&
-          isUsedWithCondition(whileOp.getAfterArguments()[i],
-                              [](OpOperand *use) {
-                                auto *user = use->getOwner();
-                                return isa<triton::AddPtrOp>(user) ||
-                                       (isa<triton::LoadOp>(user) &&
-                                        use->getOperandNumber() == 1) ||
-                                       (isa<triton::StoreOp>(user) &&
-                                        use->getOperandNumber() == 2);
-                              });
+          isLoopCarriedValueUsedWithCondition(whileOp, i, [](OpOperand *use) {
+            auto *user = use->getOwner();
+            return isa<triton::AddPtrOp>(user) ||
+                   (isa<triton::LoadOp>(user) &&
+                    use->getOperandNumber() == 1) ||
+                   (isa<triton::StoreOp>(user) && use->getOperandNumber() == 2);
+          });
       if (indexTensor) {
         indexCnt += 2 * cast<RankedTensorType>(resType).getRank();
         usedForAfterRegionArgs.push_back(false);
         iterArgIdxMapForAfter.push_back(-1);
-        maskIterArgsForAfter[i] = isUsedWithCondition(
-            whileOp.getAfterArguments()[i], [](OpOperand *use) {
+        maskIterArgsForAfter[i] =
+            isLoopCarriedValueUsedWithCondition(whileOp, i, [](OpOperand *use) {
               auto *user = use->getOwner();
               return (isa<triton::LoadOp>(user) &&
                       use->getOperandNumber() == 1) ||
@@ -2527,12 +3134,43 @@ void BlockDataParser::rewriteLoopOp(
 
     auto conditionOp =
         cast<scf::WhileOp>(newOp.getOperation()).getConditionOp();
-    rewriteTerminator(conditionOp, rewriter, blockArgIdxSetForAfter,
-                      iterArgIdxMapForAfter, known);
+    if (failed(rewriteTerminator(conditionOp, rewriter, blockArgIdxSetForAfter,
+                                 iterArgIdxMapForAfter, known)))
+      return failure();
+    markerSlotMap = iterArgIdxMapForAfter;
   }
+
+  if (!newOp || newResults.size() != op->getNumResults())
+    return op->emitError(
+        "loop rewrite produced a result list with incompatible arity");
 
   // Copy all attributes from op to newOp
   newOp->setAttrs(op->getAttrs());
+  if (!onlyIndexTensorSlots.empty()) {
+    if (Attribute marker =
+            op->getAttr(controlflow::kPointerDescriptorBoundaryAttr)) {
+      auto descriptorSlots = dyn_cast<DenseI32ArrayAttr>(marker);
+      if (!descriptorSlots) {
+        rewriter.eraseOp(newOp.getOperation());
+        return op->emitError("invalid pointer descriptor boundary marker");
+      }
+
+      SmallVector<int32_t> remappedSlots;
+      remappedSlots.reserve(descriptorSlots.size());
+      for (int32_t slot : descriptorSlots.asArrayRef()) {
+        if (slot < 0 || static_cast<size_t>(slot) >= markerSlotMap.size() ||
+            markerSlotMap[slot] < 0 ||
+            markerSlotMap[slot] > std::numeric_limits<int32_t>::max()) {
+          rewriter.eraseOp(newOp.getOperation());
+          return op->emitError(
+              "pointer descriptor slot cannot be remapped after range rewrite");
+        }
+        remappedSlots.push_back(static_cast<int32_t>(markerSlotMap[slot]));
+      }
+      newOp->setAttr(controlflow::kPointerDescriptorBoundaryAttr,
+                     DenseI32ArrayAttr::get(op->getContext(), remappedSlots));
+    }
+  }
   rewriter.replaceOp(op, newResults);
 
   // Update the loop body. Manually invoke the rewrite logic on addptr and yield
@@ -2545,24 +3183,29 @@ void BlockDataParser::rewriteLoopOp(
         // FIXME: Constructed adaptor here does not hold the transformed op
         // info.
         auto adaptor = triton::AddPtrOp::Adaptor(addptrOp);
-        rewriteAddPtr(addptrOp, adaptor, rewriter, known);
+        if (failed(rewriteAddPtr(addptrOp, adaptor, rewriter, known)))
+          return failure();
       } else if (auto advanceOp = dyn_cast<triton::AdvanceOp>(bodyOp)) {
-        rewriteAdvanceOp(advanceOp, rewriter, known);
+        if (failed(rewriteAdvanceOp(advanceOp, rewriter, known)))
+          return failure();
       } else if (auto makeTensorPtrOp =
                      dyn_cast<triton::MakeTensorPtrOp>(bodyOp)) {
         ConversionPatternRewriter::InsertionGuard guard(rewriter);
         rewriter.setInsertionPoint(makeTensorPtrOp);
-        rewriteMakeTensorPtrOp(
-            makeTensorPtrOp,
-            rewriter.getRemappedValue(makeTensorPtrOp.getBase()), rewriter,
-            known);
+        if (failed(rewriteMakeTensorPtrOp(
+                makeTensorPtrOp,
+                rewriter.getRemappedValue(makeTensorPtrOp.getBase()), rewriter,
+                known)))
+          return failure();
       } else if (auto loopOp = dyn_cast<LoopLikeOpInterface>(bodyOp);
                  loopOp && !loopOp->hasAttr("ExtractedLoadOrStore")) {
         ConversionPatternRewriter::InsertionGuard guard(rewriter);
         rewriter.setInsertionPoint(loopOp);
         // Remove UnhandledLoopOp attr before process
-        loopOp->removeAttr("UnhandledLoopOp");
-        rewriteLoopOp(loopOp, rewriter, known);
+        rewriter.modifyOpInPlace(
+            loopOp, [&]() { loopOp->removeAttr("UnhandledLoopOp"); });
+        if (failed(rewriteLoopOp(loopOp, rewriter, known)))
+          return failure();
       }
     }
   }
@@ -2570,7 +3213,9 @@ void BlockDataParser::rewriteLoopOp(
   if (!op.getRegionIterArgs().empty()) {
     auto yieldOp = cast<scf::YieldOp>(
         newOp.getLoopRegions().back()->back().getTerminator());
-    rewriteTerminator(yieldOp, rewriter, blockArgIdxSet, iterArgIdxMap, known);
+    if (failed(rewriteTerminator(yieldOp, rewriter, blockArgIdxSet,
+                                 iterArgIdxMap, known)))
+      return failure();
   }
 
   LLVM_DEBUG({
@@ -2579,6 +3224,7 @@ void BlockDataParser::rewriteLoopOp(
                                 OpPrintingFlags().printGenericOpForm());
     llvm::dbgs() << "\n";
   });
+  return success();
 }
 
 /// @brief Rewrite the triton::AddPtrOp to handle unstructured memory access.
@@ -2586,7 +3232,7 @@ void BlockDataParser::rewriteLoopOp(
 /// @param adaptor The adaptor of the triton::AddPtrOp, used to get operands.
 /// @param rewriter The pattern rewriter used to modify the IR.
 /// @param data The BlockData containing information about the memory access.
-void BlockDataParser::rewriteAddPtrToUnstrucMemAcc(
+LogicalResult BlockDataParser::rewriteAddPtrToUnstrucMemAcc(
     triton::AddPtrOp op, triton::AddPtrOp::Adaptor &adaptor,
     ConversionPatternRewriter &rewriter, BlockData &data) {
   auto loc = op.getLoc();
@@ -2625,6 +3271,7 @@ void BlockDataParser::rewriteAddPtrToUnstrucMemAcc(
     forSteps.push_back(oneIdx);
   }
   SmallVector<Value> ivs;
+  bool castFailed = false;
   OpBuilder builder(op);
   auto loop = createNestedLoops(
       builder, loc, 0, blockSizes.size(), forLBs, forUBs, forSteps, ivs,
@@ -2653,13 +3300,21 @@ void BlockDataParser::rewriteAddPtrToUnstrucMemAcc(
         data.getSizesRef().push_back(bB.getIndexAttr(1));
         data.getStridesRef().clear();
         data.getStridesRef().push_back(bB.getIndexAttr(1));
-        memref::ReinterpretCastOp castOp = data.createCastOp({1}, bLoc, bB);
-        rewriter.replaceOp(op, castOp);
+        FailureOr<memref::ReinterpretCastOp> castOp =
+            data.createCastOp({1}, bLoc, bB);
+        if (failed(castOp)) {
+          castFailed = true;
+          return;
+        }
+        rewriter.replaceOp(op, (*castOp).getResult());
         // Move tt.load using this tt.addptr into this block
-        loadOp->moveAfter(castOp);
+        loadOp->moveAfter((*castOp).getOperation());
         loadOp->setAttr("IndirectLoad", UnitAttr::get(op.getContext()));
         bB.create<scf::YieldOp>(bLoc, iterArgs);
       });
+  if (castFailed)
+    return op.emitOpError("could not materialize the indirect pointer source");
+  return success();
 }
 
 } // namespace triton

--- a/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
@@ -77,6 +77,41 @@ using namespace triton;
 const std::string MayImplicitTransposeWithLastAxisTAG =
     "MayImplicitTransposeWithLastAxis";
 
+// During dialect conversion the adaptor may expose the converted memref
+// directly, while a failed rewrite later leaves a one-input, one-output UCC in
+// the diagnostic IR. Accept both representations, but only for the canonical
+// i1-to-i8 scalar pointer normalization.
+static Value
+unwrapCanonicalI8ScalarPointerMaterialization(Value originalPointer,
+                                              Value convertedPointer) {
+  auto bitcastOp = originalPointer.getDefiningOp<triton::BitcastOp>();
+  if (!bitcastOp)
+    return nullptr;
+
+  auto sourceType = dyn_cast<triton::PointerType>(bitcastOp.getSrc().getType());
+  auto resultType = dyn_cast<triton::PointerType>(originalPointer.getType());
+  if (!sourceType || !resultType || !sourceType.getPointeeType().isInteger(1) ||
+      !resultType.getPointeeType().isInteger(8))
+    return nullptr;
+
+  Value memref = convertedPointer;
+  if (auto castOp = memref.getDefiningOp<UnrealizedConversionCastOp>()) {
+    if (castOp.getInputs().size() != 1 || castOp.getOutputs().size() != 1 ||
+        castOp.getOutputs().front() != memref)
+      return nullptr;
+    memref = castOp.getInputs().front();
+  }
+
+  auto memrefType = dyn_cast<MemRefType>(memref.getType());
+  if (!memrefType || memrefType.getRank() != 1 ||
+      !memrefType.getElementType().isInteger(8) ||
+      !memrefType.getLayout().isIdentity() || memrefType.getMemorySpace() ||
+      memrefType.getDimSize(0) != ShapedType::kDynamic)
+    return nullptr;
+
+  return memref;
+}
+
 static bool shouldMaterializeCustomPointer(Value ptr) {
   auto result = dyn_cast<OpResult>(ptr);
   if (!result)
@@ -116,8 +151,7 @@ AddPtrConverter::matchAndRewrite(triton::AddPtrOp op, OpAdaptor adaptor,
   Location loc = op.getLoc();
   insertDebugNop(loc, rewriter);
   llvm::SmallDenseMap<Value, BlockData> known;
-  BlockDataParser::rewriteAddPtr(op, adaptor, rewriter, known);
-  return success();
+  return BlockDataParser::rewriteAddPtr(op, adaptor, rewriter, known);
 }
 
 LogicalResult LoadConverter::toTensorAndReplace(
@@ -409,16 +443,34 @@ LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
   auto loc = op.getLoc();
   insertDebugNopForMask(mask, rewriter);
 
-  FailureOr<Value> resolvedPtr =
-      resolveMemoryPointer(op.getPtr(), ptr, rewriter);
-  if (failed(resolvedPtr))
-    return rewriter.notifyMatchFailure(
-        op, "unable to materialize the load pointer as a memref");
-  ptr = *resolvedPtr;
+  bool isScalarLoad = !isa<ShapedType>(op.getResult().getType());
+  Value normalizedScalarMemref;
+  if (isScalarLoad && op.getResult().getType().isInteger(8))
+    normalizedScalarMemref =
+        unwrapCanonicalI8ScalarPointerMaterialization(op.getPtr(), ptr);
+
+  if (normalizedScalarMemref) {
+    ptr = normalizedScalarMemref;
+  } else {
+    FailureOr<Value> resolvedPtr =
+        resolveMemoryPointer(op.getPtr(), ptr, rewriter);
+    if (failed(resolvedPtr))
+      return rewriter.notifyMatchFailure(
+          op, "unable to materialize the load pointer as a memref");
+    ptr = *resolvedPtr;
+  }
   // handling scalar
-  if (!isa<ShapedType>(op.getResult().getType())) {
-    auto scalarMemref =
-        BlockDataParser::getScalarMemRef(op.getPtr(), ptr, loc, rewriter);
+  if (isScalarLoad) {
+    Value scalarMemref = normalizedScalarMemref;
+    if (!scalarMemref) {
+      FailureOr<Value> resolvedScalarMemref =
+          BlockDataParser::getScalarMemRef(op.getPtr(), ptr, loc, rewriter);
+      if (failed(resolvedScalarMemref))
+        return rewriter.notifyMatchFailure(
+            op, "scalar pointer operand has not been converted to a memref");
+      scalarMemref = *resolvedScalarMemref;
+    }
+
     auto resTy = op.getResult().getType();
     auto idxZero =
         rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));

--- a/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonOpConverter.cpp
@@ -33,6 +33,7 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -107,6 +108,65 @@ generateUniqueFuncName(ModuleOp moduleOp, llvm::StringRef funcNameBase) {
   return funcName;
 }
 
+// Indirect load/store conversion normally consumes the already-converted
+// memref adaptor directly. That is correct for ordinary pointer bases, but it
+// skips BlockDataParser::materializePointer for an int_to_ptr base and loses
+// the required one-element identity view. Only scalar pointer-preserving
+// producers are followed here; tensor-of-pointers and arbitrary pointer
+// arithmetic retain their established conversion path.
+static bool isIntToPtrBasedScalarPointer(Value value) {
+  auto pointerType = dyn_cast<triton::PointerType>(value.getType());
+  if (!pointerType || isa<ShapedType>(pointerType.getPointeeType()))
+    return false;
+
+  SmallPtrSet<Value, 8> visited;
+  while (value && visited.insert(value).second) {
+    if (value.getDefiningOp<triton::IntToPtrOp>())
+      return true;
+
+    Operation *producer = value.getDefiningOp();
+    if (!producer)
+      return false;
+    if (auto addPtr = dyn_cast<triton::AddPtrOp>(producer)) {
+      value = addPtr.getPtr();
+      continue;
+    }
+    if (auto bitcast = dyn_cast<triton::BitcastOp>(producer)) {
+      value = bitcast.getSrc();
+      continue;
+    }
+    return false;
+  }
+  return false;
+}
+
+// A volatile indirect load whose scalar source is obtained through a Triton
+// pointer bitcast needs the same one-element identity descriptor as the
+// scalar-pointer path. Restrict this provenance check to scalar pointers and
+// a pointer-preserving bitcast/addptr chain so ordinary dynamic memrefs and
+// tensor-of-pointers keep their established ABI.
+static bool isVolatileBitcastScalarPointer(Value value) {
+  auto pointerType = dyn_cast<triton::PointerType>(value.getType());
+  if (!pointerType || isa<ShapedType>(pointerType.getPointeeType()))
+    return false;
+
+  SmallPtrSet<Value, 8> visited;
+  bool sawBitcast = false;
+  while (value && visited.insert(value).second) {
+    if (auto bitcast = value.getDefiningOp<triton::BitcastOp>()) {
+      sawBitcast = true;
+      value = bitcast.getSrc();
+      continue;
+    }
+    if (auto addPtr = value.getDefiningOp<triton::AddPtrOp>()) {
+      value = addPtr.getPtr();
+      continue;
+    }
+    break;
+  }
+  return sawBitcast;
+}
+
 LogicalResult
 BitcastConverter::matchAndRewrite(triton::BitcastOp op, OpAdaptor adaptor,
                                   ConversionPatternRewriter &rewriter) const {
@@ -156,10 +216,298 @@ TransposeConverter::matchAndRewrite(triton::TransOp op, OpAdaptor adaptor,
   return success();
 }
 
+bool hasScalarPointerResult(scf::IfOp op) {
+  bool hasPointerResult = false;
+  for (Type resultType : op.getResultTypes()) {
+    auto pointerType = dyn_cast<triton::PointerType>(resultType);
+    if (!pointerType)
+      continue;
+    if (isa<ShapedType>(pointerType.getPointeeType()))
+      return false;
+    hasPointerResult = true;
+  }
+  return hasPointerResult;
+}
+
+bool isScalarPointerSelect(arith::SelectOp op) {
+  auto pointerType = dyn_cast<triton::PointerType>(op.getType());
+  return pointerType && !isa<ShapedType>(pointerType.getPointeeType());
+}
+
+// Convert a scalar Triton pointer type to the canonical memref descriptor used
+// by TritonTypeConverter. It is reconstructed only after a complete byte
+// address has crossed control flow, so it needs no dynamic layout.
+static FailureOr<MemRefType>
+getScalarPointerCarrierType(Type originalType,
+                            const TypeConverter &typeConverter) {
+  auto pointerType = dyn_cast<triton::PointerType>(originalType);
+  if (!pointerType || isa<ShapedType>(pointerType.getPointeeType()))
+    return failure();
+
+  Type convertedType = typeConverter.convertType(originalType);
+  if (!convertedType)
+    return failure();
+  auto memrefType = dyn_cast<MemRefType>(convertedType);
+  if (!memrefType)
+    return failure();
+
+  return memrefType;
+}
+
+static FailureOr<Type>
+getIfResultCarrierType(Type originalType, const TypeConverter &typeConverter) {
+  if (isa<triton::PointerType>(originalType))
+    return IntegerType::get(originalType.getContext(), 64);
+
+  Type convertedType = typeConverter.convertType(originalType);
+  if (!convertedType)
+    return failure();
+  return convertedType;
+}
+
+// Materialize a no-op-compatible memref cast to the common carrier. Returning
+// failure for non-memref or incompatible values prevents the pointer transport
+// pattern from silently changing element, shape, rank, or memory-space types.
+static FailureOr<Value>
+castToMemRefCarrier(Value value, MemRefType carrierType, Location loc,
+                    ConversionPatternRewriter &rewriter) {
+  if (value.getType() == carrierType)
+    return value;
+
+  auto sourceType = dyn_cast<MemRefType>(value.getType());
+  if (!sourceType ||
+      !memref::CastOp::areCastCompatible(sourceType, carrierType))
+    return failure();
+
+  return rewriter.create<memref::CastOp>(loc, carrierType, value).getResult();
+}
+
+// Dialect conversion may adapt a lane-local pointer descriptor such as
+// `memref<1xT, strided<[1], offset: ?>>` to the canonical scalar-pointer
+// carrier `memref<?xT>`. Address materialization must inspect the original
+// descriptor: its dynamic layout offset is part of the represented address and
+// cannot be recovered from the shape-only carrier type.
+//
+// Only unwrap a one-to-one memref materialization that preserves rank, element
+// type, and memory space. Other unrealized casts may represent a real element
+// or address-space conversion and must remain visible to their converters.
+static Value unwrapPointerDescriptorMaterialization(Value value) {
+  auto materialization = value.getDefiningOp<UnrealizedConversionCastOp>();
+  if (!materialization || materialization.getInputs().size() != 1 ||
+      materialization.getOutputs().size() != 1)
+    return value;
+
+  Value source = materialization.getInputs().front();
+  auto sourceType = dyn_cast<MemRefType>(source.getType());
+  auto targetType = dyn_cast<MemRefType>(value.getType());
+  if (!sourceType || !targetType ||
+      sourceType.getRank() != targetType.getRank() ||
+      sourceType.getElementType() != targetType.getElementType() ||
+      sourceType.getMemorySpace() != targetType.getMemorySpace())
+    return value;
+
+  return source;
+}
+
+// Converts a memref descriptor into the complete byte address represented by
+// that descriptor. extract_aligned_pointer_as_index yields the aligned buffer
+// pointer; the descriptor's element offset must therefore be converted to
+// bytes and added explicitly before the address crosses control flow.
+static FailureOr<Value>
+materializePointerAddress(Value value, Location loc,
+                          ConversionPatternRewriter &rewriter) {
+  value = unwrapPointerDescriptorMaterialization(value);
+  auto memrefType = dyn_cast<MemRefType>(value.getType());
+  if (!memrefType)
+    return failure();
+  Type elementType = memrefType.getElementType();
+  if (!elementType.isIntOrFloat())
+    return failure();
+
+  // A canonical scalar PointerCast already stores the complete byte address
+  // that IntToPtr received. Extracting its aligned pointer immediately and
+  // casting it back to i64 is an identity round trip. In current failing
+  // kernels this chain also survives into InjectSync, so folding it keeps a
+  // redundant region-local form out of the backend. Only fold the canonical
+  // one-dimensional carrier; descriptors with a non-zero offset or a non-unit
+  // stride still require the general address materialization below.
+  if (auto pointerCast = value.getDefiningOp<hivm::PointerCastOp>();
+      pointerCast && pointerCast->hasAttr(kScalarPointerCarrierAttr)) {
+    auto [strides, offset] = memrefType.getStridesAndOffset();
+    if (pointerCast.getAddrs().size() == 1 && memrefType.getRank() == 1 &&
+        offset == 0 && strides.size() == 1 && strides.front() == 1) {
+      Value address = pointerCast.getAddrs().front();
+      if (address.getType().isInteger(64))
+        return address;
+      if (address.getType().isIndex())
+        return rewriter
+            .create<arith::IndexCastOp>(loc, rewriter.getI64Type(), address)
+            .getResult();
+    }
+  }
+
+  Value address =
+      rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(loc, value);
+  int64_t staticOffset = memrefType.getStridesAndOffset().second;
+  if (staticOffset != 0) {
+    Value elementOffset;
+    if (ShapedType::isDynamic(staticOffset)) {
+      elementOffset =
+          rewriter.create<memref::ExtractStridedMetadataOp>(loc, value)
+              .getOffset();
+    } else {
+      elementOffset =
+          rewriter.create<arith::ConstantIndexOp>(loc, staticOffset);
+    }
+
+    int64_t elementBytes = (elementType.getIntOrFloatBitWidth() + 7) / 8;
+    if (elementBytes != 1) {
+      Value scale = rewriter.create<arith::ConstantIndexOp>(loc, elementBytes);
+      elementOffset = rewriter.create<arith::MulIOp>(loc, elementOffset, scale);
+    }
+    address = rewriter.create<arith::AddIOp>(loc, address, elementOffset);
+  }
+  return rewriter
+      .create<arith::IndexCastOp>(loc, rewriter.getI64Type(), address)
+      .getResult();
+}
+
+LogicalResult
+IfConverter::matchAndRewrite(scf::IfOp op, OpAdaptor adaptor,
+                             ConversionPatternRewriter &rewriter) const {
+  const TypeConverter *typeConverter = getTypeConverter();
+  if (!typeConverter)
+    return rewriter.notifyMatchFailure(op, "requires a type converter");
+  if (!hasScalarPointerResult(op))
+    return failure();
+  if (!op->hasAttr(kScalarPointerCarrierBoundaryAttr))
+    return rewriter.notifyMatchFailure(
+        op, "scalar-pointer if is missing its carrier boundary marker");
+
+  SmallVector<Type> convertedResultTypes;
+  convertedResultTypes.reserve(op.getNumResults());
+  for (Type resultType : op.getResultTypes()) {
+    FailureOr<Type> convertedType =
+        getIfResultCarrierType(resultType, *typeConverter);
+    if (failed(convertedType))
+      return rewriter.notifyMatchFailure(op,
+                                         "could not convert an if result type");
+    convertedResultTypes.push_back(*convertedType);
+  }
+
+  auto newIfOp = rewriter.create<scf::IfOp>(op.getLoc(), convertedResultTypes,
+                                            adaptor.getCondition(),
+                                            /*withElseRegion=*/true);
+  newIfOp->setAttrs(op->getAttrs());
+  newIfOp->setAttr(kScalarPointerCarrierBoundaryAttr,
+                   UnitAttr::get(rewriter.getContext()));
+
+  // Move the original regions instead of cloning them. Besides preserving
+  // side effects, this keeps nested operations in the conversion driver's
+  // worklist so their operands are remapped normally.
+  rewriter.eraseBlock(newIfOp.thenBlock());
+  rewriter.eraseBlock(newIfOp.elseBlock());
+  rewriter.inlineRegionBefore(op.getThenRegion(), newIfOp.getThenRegion(),
+                              newIfOp.getThenRegion().end());
+  rewriter.inlineRegionBefore(op.getElseRegion(), newIfOp.getElseRegion(),
+                              newIfOp.getElseRegion().end());
+
+  SmallVector<Value> replacementResults;
+  replacementResults.reserve(op.getNumResults());
+  rewriter.setInsertionPointAfter(newIfOp);
+  for (auto [originalResultType, newResult] :
+       llvm::zip(op.getResultTypes(), newIfOp.getResults())) {
+    if (!isa<triton::PointerType>(originalResultType)) {
+      replacementResults.push_back(newResult);
+      continue;
+    }
+    FailureOr<MemRefType> resultType =
+        getScalarPointerCarrierType(originalResultType, *typeConverter);
+    if (failed(resultType))
+      return rewriter.notifyMatchFailure(
+          op, "could not reconstruct a scalar pointer result");
+    replacementResults.push_back(
+        createScalarPointerCast(rewriter, op.getLoc(), *resultType, newResult)
+            .getResult());
+  }
+  rewriter.replaceOp(op, replacementResults);
+  return success();
+}
+
+LogicalResult PointerSelectConverter::matchAndRewrite(
+    arith::SelectOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+  if (!isScalarPointerSelect(op))
+    return failure();
+
+  const TypeConverter *typeConverter = getTypeConverter();
+  if (!typeConverter)
+    return rewriter.notifyMatchFailure(op, "requires a type converter");
+
+  FailureOr<MemRefType> resultType =
+      getScalarPointerCarrierType(op.getType(), *typeConverter);
+  if (failed(resultType))
+    return rewriter.notifyMatchFailure(
+        op, "could not build a scalar pointer memref carrier");
+
+  FailureOr<Value> trueAddress =
+      materializePointerAddress(adaptor.getTrueValue(), op.getLoc(), rewriter);
+  FailureOr<Value> falseAddress =
+      materializePointerAddress(adaptor.getFalseValue(), op.getLoc(), rewriter);
+  if (failed(trueAddress) || failed(falseAddress))
+    return rewriter.notifyMatchFailure(
+        op, "selected pointer values have no complete integer address");
+
+  auto selectedAddress = rewriter.create<arith::SelectOp>(
+      op.getLoc(), rewriter.getI64Type(), adaptor.getCondition(), *trueAddress,
+      *falseAddress);
+  selectedAddress->setAttrs(op->getAttrs());
+  auto pointerCast = createScalarPointerCast(rewriter, op.getLoc(), *resultType,
+                                             selectedAddress.getResult());
+  rewriter.replaceOp(op, pointerCast.getResult());
+  return success();
+}
+
 LogicalResult
 YieldConverter::matchAndRewrite(scf::YieldOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const {
-  rewriter.replaceOpWithNewOp<scf::YieldOp>(op, adaptor.getOperands());
+  auto parentIf = dyn_cast<scf::IfOp>(op->getParentOp());
+  if (!parentIf || !parentIf->hasAttr(kScalarPointerCarrierBoundaryAttr))
+    return failure();
+
+  SmallVector<Value> convertedOperands(adaptor.getOperands());
+
+  if (parentIf.getNumResults() != convertedOperands.size())
+    return rewriter.notifyMatchFailure(op, "yield/result arity does not match");
+
+  for (auto [index, targetType] : llvm::enumerate(parentIf.getResultTypes())) {
+    Value &operand = convertedOperands[index];
+    if (operand.getType() == targetType)
+      continue;
+
+    if (targetType.isInteger(64) && isa<MemRefType>(operand.getType())) {
+      FailureOr<Value> address =
+          materializePointerAddress(operand, op.getLoc(), rewriter);
+      if (failed(address))
+        return rewriter.notifyMatchFailure(
+            op, "could not materialize a yielded pointer address");
+      operand = *address;
+      continue;
+    }
+    auto targetMemrefType = dyn_cast<MemRefType>(targetType);
+    if (!targetMemrefType)
+      return rewriter.notifyMatchFailure(
+          op, "converted yield operand is incompatible with if result");
+
+    FailureOr<Value> casted =
+        castToMemRefCarrier(operand, targetMemrefType, op.getLoc(), rewriter);
+    if (failed(casted))
+      return rewriter.notifyMatchFailure(
+          op, "converted yield operand is incompatible with if result");
+    operand = *casted;
+  }
+
+  rewriter.replaceOpWithNewOp<scf::YieldOp>(op, convertedOperands);
   return success();
 }
 
@@ -167,8 +515,7 @@ LogicalResult
 AdvanceConverter::matchAndRewrite(triton::AdvanceOp op, OpAdaptor adaptor,
                                   ConversionPatternRewriter &rewriter) const {
   llvm::SmallDenseMap<Value, BlockData> known;
-  BlockDataParser::rewriteAdvanceOp(op, rewriter, known);
-  return success();
+  return BlockDataParser::rewriteAdvanceOp(op, rewriter, known);
 }
 
 // ToDo:
@@ -180,9 +527,8 @@ LogicalResult MakeTensorPtrConverter::matchAndRewrite(
     triton::MakeTensorPtrOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
   llvm::SmallDenseMap<Value, BlockData> known;
-  BlockDataParser::rewriteMakeTensorPtrOp(op, adaptor.getBase(), rewriter,
-                                          known);
-  return success();
+  return BlockDataParser::rewriteMakeTensorPtrOp(op, adaptor.getBase(),
+                                                 rewriter, known);
 }
 
 LogicalResult PreciseDivConverter::matchAndRewrite(
@@ -3112,26 +3458,41 @@ DotScaledConverter::matchAndRewrite(triton::DotScaledOp op, OpAdaptor adaptor,
 }
 
 LogicalResult
+IntToPtrConverter::matchAndRewrite(triton::IntToPtrOp op, OpAdaptor adaptor,
+                                   ConversionPatternRewriter &rewriter) const {
+  auto pointerType = dyn_cast<triton::PointerType>(op.getType());
+  if (!pointerType || isa<ShapedType>(pointerType.getPointeeType()))
+    return rewriter.notifyMatchFailure(
+        op, "only scalar pointer reconstruction is supported");
+
+  const TypeConverter *typeConverter = getTypeConverter();
+  if (!typeConverter)
+    return rewriter.notifyMatchFailure(op, "requires a type converter");
+  auto resultType =
+      dyn_cast<MemRefType>(typeConverter->convertType(op.getType()));
+  if (!resultType)
+    return rewriter.notifyMatchFailure(
+        op, "pointer result did not convert to a memref type");
+
+  // Rebuild the memref only after the integer address has crossed control
+  // flow. Selecting an i64 address is a pure SSA operation and avoids the
+  // backend interpreting a memref-valued merge as a GM-to-UB copy.
+  auto pointerCast = createScalarPointerCast(rewriter, op.getLoc(), resultType,
+                                             adaptor.getSrc());
+  rewriter.replaceOp(op, pointerCast.getResult());
+  return success();
+}
+
+LogicalResult
 PtrToIntConverter::matchAndRewrite(triton::PtrToIntOp op, OpAdaptor adaptor,
                                    ConversionPatternRewriter &rewriter) const {
-  auto loc = op.getLoc();
-  Value ptr = adaptor.getSrc();
-
-  if (!mlir::isa<MemRefType>(ptr.getType())) {
+  FailureOr<Value> address =
+      materializePointerAddress(adaptor.getSrc(), op.getLoc(), rewriter);
+  if (failed(address)) {
     return rewriter.notifyMatchFailure(op, "input is not a memref type");
   }
 
-  auto resultType = op.getType();
-
-  // memref.extract_aligned_pointer_as_index is used to obtain the integer
-  // representation of the base address.
-  auto ptrToIndexOp =
-      rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(loc, ptr);
-
-  Value intResult =
-      rewriter.create<arith::IndexCastOp>(loc, resultType, ptrToIndexOp);
-
-  rewriter.replaceOp(op, intResult);
+  rewriter.replaceOp(op, *address);
   return success();
 }
 
@@ -3303,7 +3664,20 @@ LogicalResult IndirectLoadConverter::matchAndRewrite(
   auto res = op.getResult();
   auto resTy = res.getType();
 
-  if (!isa<MemRefType>(src.getType())) {
+  // The adaptor may already expose the dynamic carrier created by
+  // IntToPtrConverter.  Re-materialize that narrow provenance before the
+  // MemRefType fast path, otherwise the indirect helper receives memref<?xT>
+  // instead of the required one-element identity descriptor.
+  if (isIntToPtrBasedScalarPointer(op.getSrc()) ||
+      (op.getIsVolatile() && isVolatileBitcastScalarPointer(op.getSrc()))) {
+    llvm::SmallDenseMap<Value, BlockData> known;
+    FailureOr<Value> materialized =
+        BlockDataParser::materializePointer(op.getSrc(), rewriter, known);
+    if (failed(materialized))
+      return rewriter.notifyMatchFailure(
+          op, "unable to materialize int_to_ptr indirect-load source");
+    src = *materialized;
+  } else if (!isa<MemRefType>(src.getType())) {
     llvm::SmallDenseMap<Value, BlockData> known;
     FailureOr<Value> materialized =
         BlockDataParser::materializePointer(op.getSrc(), rewriter, known);
@@ -3446,7 +3820,18 @@ LogicalResult IndirectStoreConverter::matchAndRewrite(
   auto value = op.getValue();
   auto mask = op.getMask();
 
-  if (!isa<MemRefType>(src.getType())) {
+  // Keep the indirect-store ABI consistent with indirect-load for a scalar
+  // address reconstructed by tt.int_to_ptr.  Ordinary dynamic memrefs retain
+  // the existing direct path.
+  if (isIntToPtrBasedScalarPointer(op.getSrc())) {
+    llvm::SmallDenseMap<Value, BlockData> known;
+    FailureOr<Value> materialized =
+        BlockDataParser::materializePointer(op.getSrc(), rewriter, known);
+    if (failed(materialized))
+      return rewriter.notifyMatchFailure(
+          op, "unable to materialize int_to_ptr indirect-store source");
+    src = *materialized;
+  } else if (!isa<MemRefType>(src.getType())) {
     llvm::SmallDenseMap<Value, BlockData> known;
     FailureOr<Value> materialized =
         BlockDataParser::materializePointer(op.getSrc(), rewriter, known);

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -23,6 +23,7 @@
 
 #include <cstdlib>
 
+#include "TritonControlFlowOpt/ControlFlowRewrite.h"
 #include "TritonToGraph/LayoutMemoryOptimization.h"
 #include "TritonToLinalg/BlockPtrAnalysis.h"
 #include "ascend/include/Dialect/TritonAscend/IR/TritonAscendDialect.h"
@@ -74,7 +75,9 @@
 #include "mlir/Transforms/Passes.h"
 
 #include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/ADT/Twine.h"
@@ -85,6 +88,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <limits>
 #include <optional>
 
 #define DEBUG_TYPE "triton-to-linalg"
@@ -96,6 +100,629 @@ int nd2nzFlag = 0;
 bool compileOn91095Flag = false;
 bool existDotFlag = false;
 triton::ascend::CompileMode compileModeFlag = triton::ascend::CompileMode::Simd;
+
+static bool containsTritonPointer(Type type) {
+  if (isa<triton::PointerType>(type))
+    return true;
+  auto shapedType = dyn_cast<ShapedType>(type);
+  return shapedType && isa<triton::PointerType>(shapedType.getElementType());
+}
+
+static bool hasPointerFreeTypes(TypeRange types) {
+  return llvm::none_of(types, containsTritonPointer);
+}
+
+template <typename RangeT> static bool hasPointerFreeValues(RangeT values) {
+  return llvm::none_of(values, [](auto value) {
+    return containsTritonPointer(value.getType());
+  });
+}
+
+// Checks every structural edge of a marker loop. Looking only at the loop
+// operation's operands/results misses region arguments and terminator operands,
+// which can otherwise leave a half-converted pointer boundary.
+static bool hasPointerFreeControlFlowBoundary(LoopLikeOpInterface loopOp) {
+  Operation *loop = loopOp.getOperation();
+  if (auto forOp = dyn_cast<scf::ForOp>(loop)) {
+    return hasPointerFreeValues(forOp.getInitArgs()) &&
+           hasPointerFreeValues(forOp.getRegionIterArgs()) &&
+           hasPointerFreeValues(forOp.getYieldedValues()) &&
+           hasPointerFreeTypes(forOp.getResultTypes());
+  }
+  if (auto whileOp = dyn_cast<scf::WhileOp>(loop)) {
+    return hasPointerFreeValues(whileOp.getInits()) &&
+           hasPointerFreeValues(whileOp.getBeforeArguments()) &&
+           hasPointerFreeValues(whileOp.getConditionOp().getArgs()) &&
+           hasPointerFreeValues(whileOp.getAfterArguments()) &&
+           hasPointerFreeTypes(whileOp.getYieldOp().getOperandTypes()) &&
+           hasPointerFreeTypes(whileOp.getResultTypes());
+  }
+  return false;
+}
+
+// Adds only the values that can produce one SSA result. Structured control
+// flow is followed by result index so preserving one descriptor slot does not
+// retain unrelated loop accumulators or sibling results.
+static LogicalResult
+appendProducerOperands(Value value, SmallVectorImpl<Value> &producerWorklist) {
+  if (auto argument = dyn_cast<BlockArgument>(value)) {
+    Operation *parent = argument.getOwner()->getParentOp();
+    unsigned argumentIndex = argument.getArgNumber();
+    if (auto forOp = dyn_cast_or_null<scf::ForOp>(parent)) {
+      if (argumentIndex == 0)
+        return success();
+      unsigned iterIndex = argumentIndex - 1;
+      if (iterIndex >= forOp.getInitArgs().size())
+        return failure();
+      producerWorklist.push_back(forOp.getInitArgs()[iterIndex]);
+      producerWorklist.push_back(forOp.getYieldedValues()[iterIndex]);
+      return success();
+    }
+    if (auto whileOp = dyn_cast_or_null<scf::WhileOp>(parent)) {
+      if (argumentIndex >= whileOp.getInits().size())
+        return failure();
+      if (argument.getOwner() == whileOp.getBeforeBody()) {
+        producerWorklist.push_back(whileOp.getInits()[argumentIndex]);
+        producerWorklist.push_back(
+            whileOp.getYieldOp().getOperand(argumentIndex));
+        return success();
+      }
+      if (argument.getOwner() == whileOp.getAfterBody()) {
+        producerWorklist.push_back(
+            whileOp.getConditionOp().getArgs()[argumentIndex]);
+        return success();
+      }
+    }
+    return success();
+  }
+
+  Operation *producer = value.getDefiningOp();
+  if (!producer)
+    return success();
+
+  auto result = dyn_cast<OpResult>(value);
+  if (auto forOp = dyn_cast<scf::ForOp>(producer)) {
+    if (!result || result.getResultNumber() >= forOp.getNumResults())
+      return failure();
+    unsigned index = result.getResultNumber();
+    producerWorklist.push_back(forOp.getInitArgs()[index]);
+    producerWorklist.push_back(forOp.getYieldedValues()[index]);
+    return success();
+  }
+  if (auto whileOp = dyn_cast<scf::WhileOp>(producer)) {
+    if (!result || result.getResultNumber() >= whileOp.getNumResults())
+      return failure();
+    unsigned index = result.getResultNumber();
+    producerWorklist.push_back(whileOp.getInits()[index]);
+    producerWorklist.push_back(whileOp.getConditionOp().getArgs()[index]);
+    producerWorklist.push_back(whileOp.getYieldOp().getOperand(index));
+    return success();
+  }
+  if (auto ifOp = dyn_cast<scf::IfOp>(producer)) {
+    if (!result || result.getResultNumber() >= ifOp.getNumResults() ||
+        !ifOp.elseBlock())
+      return failure();
+    unsigned index = result.getResultNumber();
+    producerWorklist.push_back(ifOp.thenYield().getOperand(index));
+    producerWorklist.push_back(ifOp.elseYield().getOperand(index));
+    return success();
+  }
+
+  producerWorklist.append(producer->operand_begin(), producer->operand_end());
+  return success();
+}
+
+// Visits every structural value represented by one dynamic descriptor slot.
+// The result type is the slot contract; init values, region arguments and
+// terminator operands must all agree with it exactly. Keeping this traversal
+// shared prevents entry validation and later MetaUse preservation from
+// interpreting PointerDescriptorBoundary differently.
+template <typename VisitorT>
+static LogicalResult
+visitPointerDescriptorBoundarySlotValues(Operation *loop, int32_t slot,
+                                         VisitorT &&visit) {
+  if (!isa<scf::ForOp, scf::WhileOp>(loop) || slot < 0 ||
+      static_cast<unsigned>(slot) >= loop->getNumResults())
+    return failure();
+
+  Type expectedType = loop->getResult(slot).getType();
+  if (containsTritonPointer(expectedType))
+    return failure();
+
+  auto visitSlot = [&](auto values) {
+    if (static_cast<unsigned>(slot) >= values.size() ||
+        values[slot].getType() != expectedType)
+      return failure();
+    visit(values[slot]);
+    return success();
+  };
+
+  visit(loop->getResult(slot));
+  if (auto forOp = dyn_cast<scf::ForOp>(loop)) {
+    return success(succeeded(visitSlot(forOp.getInitArgs())) &&
+                   succeeded(visitSlot(forOp.getRegionIterArgs())) &&
+                   succeeded(visitSlot(forOp.getYieldedValues())));
+  }
+
+  auto whileOp = cast<scf::WhileOp>(loop);
+  return success(succeeded(visitSlot(whileOp.getInits())) &&
+                 succeeded(visitSlot(whileOp.getBeforeArguments())) &&
+                 succeeded(visitSlot(whileOp.getConditionOp().getArgs())) &&
+                 succeeded(visitSlot(whileOp.getAfterArguments())) &&
+                 succeeded(visitSlot(whileOp.getYieldOp().getOperands())));
+}
+
+// Validates one CFO-owned loop boundary without changing the IR. An empty
+// DenseI32ArrayAttr is valid and means every descriptor component is invariant
+// and therefore absent from the loop signature.
+static LogicalResult validatePointerDescriptorBoundary(Operation *loop) {
+  if (!isa<scf::ForOp, scf::WhileOp>(loop))
+    return failure();
+
+  Attribute marker = loop->getAttr(controlflow::kPointerDescriptorBoundaryAttr);
+  if (!marker)
+    return failure();
+  auto descriptorSlots = dyn_cast<DenseI32ArrayAttr>(marker);
+  if (!descriptorSlots ||
+      !hasPointerFreeControlFlowBoundary(cast<LoopLikeOpInterface>(loop)))
+    return failure();
+
+  llvm::SmallDenseSet<int32_t> seenSlots;
+  for (int32_t slot : descriptorSlots.asArrayRef()) {
+    if (!seenSlots.insert(slot).second ||
+        failed(
+            visitPointerDescriptorBoundarySlotValues(loop, slot, [](Value) {})))
+      return failure();
+  }
+  return success();
+}
+
+// Validates a complete descriptor reconstruction root without changing the
+// IR. Rebuild roots need operands even when the corresponding loop marker is
+// empty because those operands preserve the invariant descriptor components.
+static LogicalResult validatePointerDescriptorRebuild(Operation *op) {
+  Attribute marker = op->getAttr(controlflow::kPointerDescriptorRebuildAttr);
+  if (!marker || !isa<UnitAttr>(marker) || op->getNumOperands() == 0 ||
+      !llvm::any_of(op->getResultTypes(), containsTritonPointer))
+    return failure();
+
+  Attribute offsetForm =
+      op->getAttr(controlflow::kPointerDescriptorOffsetFormAttr);
+  if (!offsetForm)
+    return success();
+  auto form = dyn_cast<StringAttr>(offsetForm);
+  auto addPtr = dyn_cast<triton::AddPtrOp>(op);
+  if (!form || form.getValue() != controlflow::kStrided1DOffsetForm || !addPtr)
+    return failure();
+
+  auto resultType = dyn_cast<RankedTensorType>(addPtr.getType());
+  auto offsetType = dyn_cast<RankedTensorType>(addPtr.getOffset().getType());
+  auto offsetElementType =
+      offsetType ? dyn_cast<IntegerType>(offsetType.getElementType())
+                 : IntegerType();
+  auto baseSplat = addPtr.getPtr().getDefiningOp<triton::SplatOp>();
+  return success(resultType && resultType.getRank() == 1 && offsetType &&
+                 isa<triton::PointerType>(resultType.getElementType()) &&
+                 offsetElementType && offsetElementType.getWidth() <= 64 &&
+                 resultType.getShape() == offsetType.getShape() &&
+                 resultType.getEncoding() == offsetType.getEncoding() &&
+                 baseSplat &&
+                 isa<triton::PointerType>(baseSplat.getSrc().getType()));
+}
+
+// Returns true when a pointer consumer is reached through ordinary addptr
+// operations from a CFO descriptor reconstruction root. The walk is purposely
+// limited to addptr: following arbitrary pointer-producing operations would
+// make the handoff contract retain computations it does not own.
+static bool hasPointerDescriptorRebuildProvenance(Value pointer) {
+  llvm::DenseSet<Value> visited;
+  while (pointer && visited.insert(pointer).second) {
+    Operation *producer = pointer.getDefiningOp();
+    if (!producer)
+      return false;
+    if (producer->hasAttr(controlflow::kPointerDescriptorRebuildAttr))
+      return true;
+    auto addPtr = dyn_cast<triton::AddPtrOp>(producer);
+    if (!addPtr)
+      return false;
+    pointer = addPtr.getPtr();
+  }
+  return false;
+}
+
+// Checks the complete CFO-to-TritonToLinalg handoff before any rewrite can
+// fold away a malformed marker. This function is deliberately read-only so it
+// can run at pass entry, before UseAnalysis has produced MetaUse attributes.
+static LogicalResult
+validatePointerDescriptorHandoffMetadata(ModuleOp moduleOp) {
+  bool valid = true;
+  moduleOp.walk([&](Operation *op) {
+    if (op->hasAttr(controlflow::kPointerDescriptorBoundaryAttr) &&
+        failed(validatePointerDescriptorBoundary(op)))
+      valid = false;
+    if (op->hasAttr(controlflow::kPointerDescriptorRebuildAttr) &&
+        failed(validatePointerDescriptorRebuild(op)))
+      valid = false;
+    if (op->hasAttr(controlflow::kPointerDescriptorOffsetFormAttr) &&
+        !op->hasAttr(controlflow::kPointerDescriptorRebuildAttr))
+      valid = false;
+  });
+  return success(valid);
+}
+
+// PointerDescriptorBoundary identifies the dynamic loop slots used to rebuild
+// pointers. PointerDescriptorRebuild operands are the complete descriptor
+// roots, including invariant components omitted from an empty or minimal slot
+// list. After UseAnalysis, preserve exactly those producer chains so
+// MetaUseEraser cannot discard values required by conversion.
+static LogicalResult preservePointerDescriptorComputations(ModuleOp moduleOp) {
+  if (failed(validatePointerDescriptorHandoffMetadata(moduleOp)))
+    return failure();
+
+  bool valid = true;
+  SmallVector<Value> producerWorklist;
+  moduleOp.walk([&](Operation *loop) {
+    Attribute marker =
+        loop->getAttr(controlflow::kPointerDescriptorBoundaryAttr);
+    if (!marker)
+      return;
+    auto descriptorSlots = cast<DenseI32ArrayAttr>(marker);
+
+    loop->removeAttr("MetaUse");
+    for (int32_t slot : descriptorSlots.asArrayRef()) {
+      if (failed(visitPointerDescriptorBoundarySlotValues(
+              loop, slot,
+              [&](Value value) { producerWorklist.push_back(value); })))
+        valid = false;
+    }
+  });
+
+  moduleOp.walk([&](Operation *op) {
+    if (!op->hasAttr(controlflow::kPointerDescriptorRebuildAttr))
+      return;
+
+    // The rebuild operation itself and each of its operands are exact live
+    // conversion roots. This includes an invariant opaque tensor base as well
+    // as a scalar address behind int_to_ptr+splat. UseAnalysis has already
+    // propagated MetaUse by this point; preserving only the offset would leave
+    // a live ptr operand's producer eligible for erasure. This operand-local
+    // closure is still narrower than retaining all loop operands/terminators.
+    op->removeAttr("MetaUse");
+    producerWorklist.append(op->operand_begin(), op->operand_end());
+  });
+
+  // UseAnalysis classifies load/store masks and load fallback values as
+  // pointer metadata. A descriptor rebuild, however, is converted to a memref
+  // while its consumer still needs those tensor values to form subviews and
+  // padding. Preserve these exact consumer operands when the pointer is owned
+  // by the CFO handoff; otherwise MetaUseEraser can leave an unconvertible
+  // memref-to-pointer materialization at the live memory operation.
+  moduleOp.walk([&](triton::LoadOp load) {
+    if (!hasPointerDescriptorRebuildProvenance(load.getPtr()))
+      return;
+    if (Value mask = load.getMask())
+      producerWorklist.push_back(mask);
+    if (Value other = load.getOther())
+      producerWorklist.push_back(other);
+  });
+  moduleOp.walk([&](triton::StoreOp store) {
+    if (hasPointerDescriptorRebuildProvenance(store.getPtr()) &&
+        store.getMask())
+      producerWorklist.push_back(store.getMask());
+  });
+  moduleOp.walk([&](triton::AtomicRMWOp atomic) {
+    if (hasPointerDescriptorRebuildProvenance(atomic.getPtr()) &&
+        atomic.getMask())
+      producerWorklist.push_back(atomic.getMask());
+  });
+
+  llvm::DenseSet<Value> visitedValues;
+  while (!producerWorklist.empty()) {
+    Value value = producerWorklist.pop_back_val();
+    if (!value || !visitedValues.insert(value).second)
+      continue;
+    if (Operation *producer = value.getDefiningOp())
+      producer->removeAttr("MetaUse");
+    if (failed(appendProducerOperands(value, producerWorklist)))
+      valid = false;
+  }
+  return success(valid);
+}
+
+// The generic canonicalizer may remove forwarded scf.for/scf.while iter-args,
+// which changes a marker loop's positional signature without updating its
+// external descriptor-slot metadata. Marker-bearing modules therefore use this
+// narrow pre-clean: CSE remains enabled, and only constant scf.if regions are
+// inlined so use analysis does not visit unreachable branches.
+class FoldConstantIfBeforeUseAnalysis final
+    : public OpRewritePattern<scf::IfOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(scf::IfOp ifOp,
+                                PatternRewriter &rewriter) const override {
+    auto condition = ifOp.getCondition().getDefiningOp<arith::ConstantOp>();
+    if (!condition)
+      return failure();
+    auto conditionValue = dyn_cast<IntegerAttr>(condition.getValue());
+    if (!conditionValue || !conditionValue.getType().isInteger(1))
+      return failure();
+
+    Block *selectedBlock =
+        conditionValue.getValue().isOne() ? ifOp.thenBlock() : ifOp.elseBlock();
+    if (!selectedBlock) {
+      if (ifOp.getNumResults() != 0)
+        return failure();
+      rewriter.eraseOp(ifOp);
+      return success();
+    }
+
+    auto yield = cast<scf::YieldOp>(selectedBlock->getTerminator());
+    SmallVector<Value> replacements(yield.getOperands());
+    rewriter.inlineBlockBefore(selectedBlock, ifOp->getBlock(),
+                               ifOp->getIterator());
+    rewriter.eraseOp(yield);
+    rewriter.replaceOp(ifOp, replacements);
+    return success();
+  }
+};
+
+// Inspect Operation directly so discovery cannot silently miss an SCF marker
+// or an if-only rebuild root. Any surviving handoff attribute disables generic
+// pre-clean canonicalization because its validated slot positions and rebuild
+// operands must remain stable until MetaUse preservation.
+static bool containsPointerDescriptorHandoff(ModuleOp moduleOp) {
+  bool found = false;
+  moduleOp.walk([&](Operation *op) {
+    if (op->hasAttr(controlflow::kPointerDescriptorBoundaryAttr) ||
+        op->hasAttr(controlflow::kPointerDescriptorRebuildAttr) ||
+        op->hasAttr(controlflow::kPointerDescriptorOffsetFormAttr))
+      found = true;
+  });
+  return found;
+}
+
+// A converted make_range may leave a tensor-valued SCF state behind even
+// though no loop result or loop-body operation observes it. Keep this cleanup
+// deliberately narrow: it recognizes only statically shaped integer tensors
+// whose entire loop-carried use chain consists of uniform integer updates.
+static bool isDeadRangeUpdate(Value value, scf::ForOp loop, unsigned slot,
+                              llvm::SmallPtrSetImpl<Value> &visited) {
+  if (!visited.insert(value).second)
+    return false;
+
+  auto yield = cast<scf::YieldOp>(loop.getBody()->getTerminator());
+  bool sawYield = false;
+  for (OpOperand &use : value.getUses()) {
+    Operation *user = use.getOwner();
+    if (user == yield) {
+      if (use.getOperandNumber() != slot)
+        return false;
+      sawYield = true;
+      continue;
+    }
+
+    Value updateResult;
+    Value lhs;
+    Value rhs;
+    if (auto add = dyn_cast<arith::AddIOp>(user)) {
+      updateResult = add.getResult();
+      lhs = add.getLhs();
+      rhs = add.getRhs();
+    } else if (auto sub = dyn_cast<arith::SubIOp>(user)) {
+      updateResult = sub.getResult();
+      lhs = sub.getLhs();
+      rhs = sub.getRhs();
+    } else {
+      return false;
+    }
+    if (updateResult.getType() != value.getType())
+      return false;
+
+    bool usesValueAsLhs = lhs == value;
+    bool usesValueAsRhs = rhs == value;
+    if (usesValueAsLhs == usesValueAsRhs)
+      return false;
+    Value delta = usesValueAsLhs ? rhs : lhs;
+    auto deltaType = dyn_cast<RankedTensorType>(delta.getType());
+    if (!deltaType || deltaType != value.getType())
+      return false;
+
+    Operation *deltaProducer = delta.getDefiningOp();
+    bool isUniformDelta = false;
+    if (auto constant = dyn_cast_or_null<arith::ConstantOp>(deltaProducer)) {
+      if (auto dense = dyn_cast<DenseIntElementsAttr>(constant.getValue()))
+        isUniformDelta = dense.isSplat();
+    }
+    if (auto fill = dyn_cast_or_null<linalg::FillOp>(deltaProducer))
+      isUniformDelta = fill.getInputs().size() == 1 &&
+                       fill.getOutputs().size() == 1 &&
+                       fill.getOutputs().front().getType() == value.getType();
+    if (!isUniformDelta)
+      return false;
+
+    if (!isDeadRangeUpdate(updateResult, loop, slot, visited))
+      return false;
+  }
+  return sawYield;
+}
+
+static bool isDeadRangeCarrier(scf::ForOp loop, unsigned slot) {
+  if (slot >= loop.getInitArgs().size() ||
+      slot >= loop.getRegionIterArgs().size() ||
+      slot >= loop.getResults().size() ||
+      slot >= loop.getYieldedValues().size() ||
+      !loop.getResult(slot).use_empty())
+    return false;
+
+  auto type = dyn_cast<RankedTensorType>(loop.getInitArgs()[slot].getType());
+  auto iterType =
+      dyn_cast<RankedTensorType>(loop.getRegionIterArgs()[slot].getType());
+  if (!type || !iterType || type != iterType || !type.hasStaticShape() ||
+      !isa<IntegerType>(type.getElementType()))
+    return false;
+
+  Operation *producer = loop.getInitArgs()[slot].getDefiningOp();
+  if (!producer ||
+      (!isa<linalg::GenericOp, linalg::FillOp, tensor::CastOp>(producer) &&
+       !producer->hasAttr("tt.from_make_range") &&
+       !producer->hasAttr("tt.make_range_offset") &&
+       !producer->hasAttr("tt.make_range_size")))
+    return false;
+
+  llvm::SmallPtrSet<Value, 8> visited;
+  return isDeadRangeUpdate(loop.getRegionIterArgs()[slot], loop, slot, visited);
+}
+
+// Remove only fully dead range-like SCF state. Body arguments and yield
+// operands are removed first, then the loop is rebuilt with surviving values.
+static void eraseDeadRangeCarriers(ModuleOp moduleOp) {
+  SmallVector<scf::ForOp> loops;
+  moduleOp.walk([&](scf::ForOp loop) { loops.push_back(loop); });
+
+  for (scf::ForOp loop : loops) {
+    if (!loop || loop->getParentOp() == nullptr)
+      continue;
+    llvm::BitVector dead(loop.getInitArgs().size());
+    for (unsigned i = 0; i < dead.size(); ++i) {
+      if (isDeadRangeCarrier(loop, i))
+        dead.set(i);
+    }
+    if (dead.none())
+      continue;
+
+    auto yield = cast<scf::YieldOp>(loop.getBody()->getTerminator());
+    yield->eraseOperands(dead);
+    loop.getBody()->eraseArguments([&](BlockArgument arg) {
+      unsigned argNumber = arg.getArgNumber();
+      return argNumber != 0 && dead.test(argNumber - 1);
+    });
+
+    llvm::BitVector operandIndices(loop->getNumOperands());
+    for (auto [i, init] : llvm::enumerate(loop.getInitArgsMutable())) {
+      if (dead.test(i))
+        operandIndices.set(init.getOperandNumber());
+    }
+    loop->eraseOperands(operandIndices);
+
+    OperationState state(loop.getLoc(), loop->getName(), loop->getOperands(),
+                         loop.getInitArgs().getTypes(), loop->getAttrs());
+    state.addRegion()->takeBody(loop.getBodyRegion());
+    OpBuilder builder(loop);
+    auto newLoop = cast<scf::ForOp>(builder.create(state));
+
+    unsigned newResultIndex = 0;
+    for (auto [i, result] : llvm::enumerate(loop.getResults())) {
+      if (dead.test(i)) {
+        assert(result.use_empty() && "dead range result still has uses");
+        continue;
+      }
+      result.replaceAllUsesWith(newLoop.getResult(newResultIndex++));
+    }
+    loop.erase();
+  }
+}
+
+static LogicalResult preCleanBeforeUseAnalysis(ModuleOp moduleOp) {
+  bool hasPointerDescriptorHandoff = containsPointerDescriptorHandoff(moduleOp);
+
+  PassManager csePipeline(moduleOp.getContext(), moduleOp.getOperationName());
+  csePipeline.addPass(createCSEPass());
+  if (!hasPointerDescriptorHandoff)
+    csePipeline.addPass(createCanonicalizerPass());
+  if (failed(csePipeline.run(moduleOp)))
+    return failure();
+
+  if (!hasPointerDescriptorHandoff)
+    return success();
+  RewritePatternSet patterns(moduleOp.getContext());
+  patterns.add<FoldConstantIfBeforeUseAnalysis>(moduleOp.getContext());
+  return applyPatternsGreedily(moduleOp, std::move(patterns));
+}
+
+// Recomputes the result layouts of subviews whose source descriptor has been
+// rebased. A memref.subview result layout is derived from both its mixed
+// offsets/strides and its source layout. For example, changing the source from
+// `memref<32xf32, strided<[1], offset: ?>>` to the equivalent rebased
+// `memref<32xf32, strided<[1]>>` changes a zero-offset subview result from a
+// dynamic offset to offset zero. Merely changing the source SSA value leaves
+// the old result type behind and makes SubViewOp verification fail.
+//
+// Subviews may be chained, so every updated result becomes a new worklist
+// source. Rank-reduced subviews retain their existing result shape while their
+// layout is inferred again from the rebased source.
+static LogicalResult propagateRebasedSubviewTypes(Value rebasedSource,
+                                                  IRRewriter &rewriter) {
+  SmallVector<Value> sources{rebasedSource};
+  llvm::SmallPtrSet<Operation *, 8> visited;
+
+  while (!sources.empty()) {
+    Value source = sources.pop_back_val();
+    for (Operation *user : source.getUsers()) {
+      auto subview = dyn_cast<memref::SubViewOp>(user);
+      if (!subview || !visited.insert(user).second)
+        continue;
+
+      auto sourceType = dyn_cast<MemRefType>(subview.getSource().getType());
+      auto oldResultType = dyn_cast<MemRefType>(subview.getResult().getType());
+      if (!sourceType || !oldResultType)
+        return failure();
+
+      Type inferredType;
+      if (sourceType.getRank() == oldResultType.getRank()) {
+        inferredType = memref::SubViewOp::inferResultType(
+            sourceType, subview.getMixedOffsets(), subview.getMixedSizes(),
+            subview.getMixedStrides());
+      } else {
+        inferredType = memref::SubViewOp::inferRankReducedResultType(
+            oldResultType.getShape(), sourceType, subview.getMixedOffsets(),
+            subview.getMixedSizes(), subview.getMixedStrides());
+      }
+
+      auto inferredMemRefType = dyn_cast<MemRefType>(inferredType);
+      if (!inferredMemRefType)
+        return failure();
+      if (inferredMemRefType != oldResultType) {
+        rewriter.modifyOpInPlace(
+            subview, [&] { subview.getResult().setType(inferredMemRefType); });
+      }
+      sources.push_back(subview.getResult());
+    }
+  }
+  return success();
+}
+
+// Returns true when rebasing a descriptor would change a type owned by a
+// different operation. A subview chain ending in direct memref loads/stores is
+// local to this rewrite. Calls, returns, SCF/CFG boundaries, and every other
+// user retain their existing descriptor layout and therefore stop rebasing.
+static bool reachesLayoutSensitiveBoundary(Value root) {
+  SmallVector<Value> worklist{root};
+  llvm::DenseSet<Value> visited;
+  while (!worklist.empty()) {
+    Value value = worklist.pop_back_val();
+    if (!visited.insert(value).second)
+      continue;
+    for (Operation *user : value.getUsers()) {
+      if (auto subview = dyn_cast<memref::SubViewOp>(user)) {
+        if (subview.getSource() == value) {
+          worklist.push_back(subview.getResult());
+          continue;
+        }
+      }
+      if (auto load = dyn_cast<memref::LoadOp>(user)) {
+        if (load.getMemRef() == value)
+          continue;
+      }
+      if (auto store = dyn_cast<memref::StoreOp>(user)) {
+        if (store.getMemRef() == value)
+          continue;
+      }
+      return true;
+    }
+  }
+  return false;
+}
 
 // Convert structured custom ops after operand type converted,
 // for example tt.ptr converted to memref.
@@ -218,6 +845,35 @@ TritonTypeConverter::TritonTypeConverter() {
       });
     }
     return MemRefType::get(tensorType.getShape(), elemType);
+  });
+
+  // A pointer-descriptor boundary can intentionally remain a legal SCF op
+  // carrying pointer-free tensor values while function signature conversion
+  // changes the corresponding argument to a memref. Materialize only the
+  // canonical numerical memref-to-ranked-tensor pair produced by the
+  // conversion above. The exact type check deliberately excludes pointer
+  // tensors, encoded tensors, i1-to-i8 normalization, non-identity layouts,
+  // and non-default memory spaces, so this does not become a general SCF
+  // type-conversion path.
+  addSourceMaterialization([](OpBuilder &builder, RankedTensorType resultType,
+                              ValueRange inputs, Location loc) -> Value {
+    if (inputs.size() != 1 || resultType.getEncoding() ||
+        isa<triton::PointerType>(resultType.getElementType()))
+      return nullptr;
+
+    auto inputType = dyn_cast<MemRefType>(inputs.front().getType());
+    if (!inputType || !inputType.getLayout().isIdentity() ||
+        inputType.getMemorySpace())
+      return nullptr;
+
+    auto expectedInputType =
+        MemRefType::get(resultType.getShape(), resultType.getElementType());
+    if (inputType != expectedInputType)
+      return nullptr;
+
+    return builder.create<bufferization::ToTensorOp>(
+        loc, resultType, inputs.front(), /*restrict=*/false,
+        /*writable=*/false);
   });
 }
 
@@ -564,35 +1220,59 @@ void TritonToLinalgPass::addDynamicLegal(
     return true;
   });
 
-  target.addDynamicallyLegalOp<scf::ForOp, scf::YieldOp>([](Operation *op) {
+  target.addDynamicallyLegalOp<scf::IfOp>(
+      [](scf::IfOp op) { return !TTOpConverters::hasScalarPointerResult(op); });
+
+  auto controlFlowTerminatorLegal = [](Operation *op) {
+    Operation *parent = op->getParentOp();
+    if (parent &&
+        parent->hasAttr(TTOpConverters::kScalarPointerCarrierBoundaryAttr)) {
+      if (auto parentIf = dyn_cast<scf::IfOp>(parent))
+        return llvm::equal(op->getOperandTypes(), parentIf.getResultTypes());
+    }
+
+    if (parent && parent->hasAttr(controlflow::kPointerDescriptorBoundaryAttr))
+      return hasPointerFreeControlFlowBoundary(
+          cast<LoopLikeOpInterface>(parent));
+
     return llvm::all_of(op->getOperandTypes(), [](Type t) {
-      if (isa<triton::PointerType>(t)) {
+      if (isa<triton::PointerType>(t))
         return false;
-      }
-      if (auto shapedType = dyn_cast<ShapedType>(t)) {
+      if (auto shapedType = dyn_cast<ShapedType>(t))
         return shapedType.getElementType().isIntOrFloat();
-      }
       assert(t.isIntOrIndexOrFloat());
       return true;
     });
-  });
+  };
+
+  target.addDynamicallyLegalOp<scf::YieldOp, scf::ConditionOp>(
+      controlFlowTerminatorLegal);
+
+  auto isArithOrMathOpLegal = [this](Operation *op) {
+    if (op->hasAttr("MetaUse"))
+      return false;
+
+    if (isa<arith::ConstantOp>(op))
+      return true;
+
+    bool operateOnTensors = llvm::all_of(op->getOperandTypes(), [](Type type) {
+      return isa<RankedTensorType>(type);
+    });
+
+    return this->namedOps || !operateOnTensors;
+  };
+
+  // Numeric selects retain the existing Arith legality. Every scalar-pointer
+  // select uses the integer-address converter so no memref object crosses it.
+  target.addDynamicallyLegalOp<arith::SelectOp>(
+      [isArithOrMathOpLegal](arith::SelectOp op) {
+        if (TTOpConverters::isScalarPointerSelect(op))
+          return false;
+        return isArithOrMathOpLegal(op);
+      });
 
   target.addDynamicallyLegalDialect<arith::ArithDialect, math::MathDialect>(
-      [this](Operation *op) {
-        if (op->hasAttr("MetaUse")) {
-          return false;
-        }
-
-        if (isa<arith::ConstantOp>(op)) {
-          return true;
-        }
-
-        bool operateOnTensors =
-            llvm::all_of(op->getOperandTypes(),
-                         [](Type type) { return isa<RankedTensorType>(type); });
-
-        return this->namedOps || !operateOnTensors;
-      });
+      isArithOrMathOpLegal);
 }
 
 void TritonToLinalgPass::populateTritonToLinalgCanonicalizationPatterns(
@@ -717,11 +1397,16 @@ void TritonToLinalgPass::populateTritonToLinalgConversionPatterns(
   patterns.add<TTOpConverters::JoinConverter>(patterns.getContext());
   patterns.add<TTOpConverters::CatConverter>(patterns.getContext());
   patterns.add<TTOpConverters::BitcastConverter>(patterns.getContext());
-  patterns.add<TTOpConverters::LoopConverter<scf::ForOp>>(
-      patterns.getContext());
+  patterns.add<TTOpConverters::LoopConverter<scf::ForOp>>(patterns.getContext(),
+                                                          PatternBenefit(2));
   patterns.add<TTOpConverters::LoopConverter<scf::WhileOp>>(
-      patterns.getContext());
-  patterns.add<TTOpConverters::YieldConverter>(patterns.getContext());
+      patterns.getContext(), PatternBenefit(2));
+  patterns.add<TTOpConverters::YieldConverter>(patterns.getContext(),
+                                               PatternBenefit(2));
+  patterns.add<TTOpConverters::IfConverter>(
+      typeConverter, patterns.getContext(), PatternBenefit(2));
+  patterns.add<TTOpConverters::PointerSelectConverter>(typeConverter,
+                                                       patterns.getContext());
 
   patterns.add<TTOpConverters::DeviceAssertConverter>(patterns.getContext());
   patterns.add<TTOpConverters::DevicePrintConverter>(patterns.getContext());
@@ -729,6 +1414,8 @@ void TritonToLinalgPass::populateTritonToLinalgConversionPatterns(
   patterns.add<TTOpConverters::DotConverter>(patterns.getContext());
   patterns.add<TTOpConverters::DotScaledConverter>(patterns.getContext());
   patterns.add<TTOpConverters::PtrToIntConverter>(patterns.getContext());
+  patterns.add<TTOpConverters::IntToPtrConverter>(typeConverter,
+                                                  patterns.getContext());
 
   patterns.add<TTOpConverters::IndirectLoadConverter>(patterns.getContext());
   patterns.add<TTOpConverters::StrideLoadConverter>(patterns.getContext());
@@ -943,6 +1630,14 @@ void TritonToLinalgPass::runOnOperation() {
 
   auto moduleOp = getOperation();
 
+  // Validate the CFO handoff before descriptor conversion, canonicalization,
+  // or any other IR mutation can erase malformed metadata with dead code.
+  if (failed(validatePointerDescriptorHandoffMetadata(moduleOp))) {
+    moduleOp->emitError("invalid pointer descriptor handoff metadata");
+    signalPassFailure();
+    return;
+  }
+
   // Check if the kernel contains tl.dot. Without tl.dot,
   // the kernel would be pure AIV kernel.
   bool existDot = false;
@@ -1030,26 +1725,36 @@ void TritonToLinalgPass::runOnOperation() {
 
   RewritePatternSet canonicalizerPatterns(&getContext());
   // 1. Canonicalize load/store related patterns.
+  // The currently registered patterns rewrite pointer consumers but do not
+  // replace tt.make_tensor_ptr/tt.addptr descriptor rebuild roots. A future
+  // pattern that rewrites those producers must atomically transfer
+  // PointerDescriptorRebuild to its replacement; entry validation alone
+  // cannot preserve metadata across a producer rewrite.
   this->populateTritonToLinalgCanonicalizationPatterns(canonicalizerPatterns);
   if (failed(
           applyPatternsGreedily(moduleOp, std::move(canonicalizerPatterns)))) {
     moduleOp->emitError("failed to apply Canonicalizer Patterns");
     signalPassFailure();
+    return;
   }
 
-  // 2.1 Pre-clean dead control-flow before use analysis.
-  // This helps remove unreachable branches such as `scf.if %true` else-region,
-  // so runUseAnalysis won't walk dead ops with missing lattice states.
-  {
-    PassManager pm(&getContext(), moduleOp.getOperationName());
-    pm.addPass(createCSEPass());
-    pm.addPass(createCanonicalizerPass());
-    if (failed(runPipeline(pm, moduleOp))) {
-      moduleOp->emitError(
-          "failed to pre-clean dead control-flow before use analysis");
-      signalPassFailure();
-      return;
-    }
+  // Stage-1 may legitimately delete an unused, already validated boundary.
+  // Revalidate every surviving handoff so later phases never consume a marker
+  // whose structural edges were changed without updating its slot contract.
+  if (failed(validatePointerDescriptorHandoffMetadata(moduleOp))) {
+    moduleOp->emitError("invalid pointer descriptor handoff metadata");
+    signalPassFailure();
+    return;
+  }
+
+  // 2.1 Pre-clean dead control flow before use analysis. Descriptor handoff
+  // attributes require stable loop positions and rebuild operands, so marked
+  // modules use a restricted cleanup that cannot rewrite either contract.
+  if (failed(preCleanBeforeUseAnalysis(moduleOp))) {
+    moduleOp->emitError(
+        "failed to pre-clean dead control-flow before use analysis");
+    signalPassFailure();
+    return;
   }
 
   // 2. Perform use analysis on FuncOp.
@@ -1059,6 +1764,12 @@ void TritonToLinalgPass::runOnOperation() {
     }
   });
 
+  if (failed(preservePointerDescriptorComputations(moduleOp))) {
+    moduleOp->emitError("invalid pointer descriptor handoff metadata");
+    signalPassFailure();
+    return;
+  }
+
   RewritePatternSet patterns(&getContext());
   ConversionTarget target(getContext());
   TritonTypeConverter tritonTypeConverter{};
@@ -1067,8 +1778,18 @@ void TritonToLinalgPass::runOnOperation() {
   this->addDynamicLegal(target, tritonTypeConverter);
 
   // 4. Mark ops that must be converted explicitly (e.g. tt.scan).
-  auto loopOpLegalFn = [](LoopLikeOpInterface op) {
-    return !op.getOperation()->hasAttr("UnhandledLoopOp");
+  auto loopOpLegalFn = [](LoopLikeOpInterface loopOp) {
+    Operation *op = loopOp.getOperation();
+    if (op->hasAttr(controlflow::kPointerDescriptorBoundaryAttr)) {
+      // CFO descriptor loops may still carry a non-descriptor make_range
+      // tensor used by a load/store mask. Route only those loops through the
+      // narrow legacy mask-carrier rewrite; descriptor and opaque slots remain
+      // on the normal pointer-free boundary path.
+      if (!getMarkedMakeRangeCarrierSlots(loopOp).empty())
+        return false;
+      return hasPointerFreeControlFlowBoundary(loopOp);
+    }
+    return !op->hasAttr("UnhandledLoopOp");
   };
 
   target.addIllegalOp<triton::ScanOp>();
@@ -1092,8 +1813,21 @@ void TritonToLinalgPass::runOnOperation() {
 
   moduleOp.walk([this](LoopLikeOpInterface loopOp) {
     auto *op = loopOp.getOperation();
-    if (!op->hasAttr("ExtractedLoadOrStore"))
+    // CFO-expanded pointer loops already carry policy-owned descriptor
+    // components. They require ordinary nested-op conversion, not the legacy
+    // pointer-loop decomposition a second time. Unmarked loops are delegated
+    // only when their original boundary still carries Triton pointer/address
+    // state. A fixed-layout memref is already a complete SCF value; the fact
+    // that its init is produced by reinterpret_cast does not make it BlockData.
+    bool hasExpandedPointerDescriptor =
+        op->hasAttr(mlir::triton::controlflow::kPointerDescriptorBoundaryAttr);
+    auto markedRangeSlots = getMarkedMakeRangeCarrierSlots(loopOp);
+    if (!op->hasAttr("ExtractedLoadOrStore") &&
+        (needsLegacyBlockDataLoopRewrite(loopOp) || !markedRangeSlots.empty()))
       op->setAttr("UnhandledLoopOp", UnitAttr::get(op->getContext()));
+
+    if (hasExpandedPointerDescriptor && markedRangeSlots.empty())
+      return;
 
     for (auto res : loopOp->getResults()) {
       if (auto tensorType = dyn_cast<RankedTensorType>(res.getType());
@@ -1109,10 +1843,34 @@ void TritonToLinalgPass::runOnOperation() {
   });
 
   // 7. Convert ops.
-  if (failed(applyPartialConversion(moduleOp, target, std::move(patterns)))) {
+  LogicalResult conversionResult =
+      applyPartialConversion(moduleOp, target, std::move(patterns));
+
+  if (failed(conversionResult)) {
     moduleOp->emitError("failed to apply Conversion Patterns");
     signalPassFailure();
+    return;
   }
+
+  // These markers are contracts with this conversion pass. Remove them only
+  // after successful conversion so failure reproducers retain ownership,
+  // exact dynamic descriptor slots, and complete rebuild roots.
+  moduleOp.walk([](LoopLikeOpInterface loopOp) {
+    loopOp->removeAttr(controlflow::kPointerDescriptorBoundaryAttr);
+  });
+  moduleOp.walk([](Operation *op) {
+    op->removeAttr(controlflow::kPointerDescriptorRebuildAttr);
+    op->removeAttr(controlflow::kPointerDescriptorOffsetFormAttr);
+    op->removeAttr(controlflow::kPointerDescriptorStructuredAxesAttr);
+  });
+  moduleOp.walk([](Operation *op) {
+    op->removeAttr(TTOpConverters::kScalarPointerCarrierBoundaryAttr);
+  });
+
+  // Conversion can expose a make_range carrier whose loop result is already
+  // dead. Remove only the proven dead range/update chain before generic
+  // canonicalization; live tensor carriers and scalar address state remain.
+  eraseDeadRangeCarriers(moduleOp);
 
   // 7.1 Workaround: fold duplicated one-hot reconstruction emitted after
   // ArgMax lowering. The issue is not in triton::ReduceOp semantics themselves;
@@ -1179,34 +1937,32 @@ void TritonToLinalgPass::runOnOperation() {
   moduleOp.walk([&](hivm::PointerCastOp op) { castOps.push_back(op); });
 
   for (auto op : castOps) {
-    SmallVector<Operation *> userOps(op->getUsers().begin(),
-                                     op->getUsers().end());
+    SmallVector<memref::ReinterpretCastOp> reinterpretCastOps;
+    for (Operation *user : op->getUsers()) {
+      if (auto reinterpretCast = dyn_cast<memref::ReinterpretCastOp>(user))
+        reinterpretCastOps.push_back(reinterpretCast);
+    }
+    if (reinterpretCastOps.empty())
+      continue;
+
+    bool isScalarPointerCarrier = op->hasAttr(kScalarPointerCarrierAttr);
     IRRewriter rewriter(&getContext());
     rewriter.setInsertionPointAfter(op);
     Value addr = op.getAddrs()[0];
     auto elementType =
         cast<MemRefType>(op.getResult().getType()).getElementType();
-    Value elementTypeSize;
-    if (auto intType = dyn_cast<IntegerType>(elementType)) {
-      elementTypeSize = rewriter.create<arith::ConstantOp>(
-          op.getLoc(),
-          rewriter.getIntegerAttr(addr.getType(), intType.getWidth() / 8));
-    } else if (auto floatType = dyn_cast<FloatType>(elementType)) {
-      elementTypeSize = rewriter.create<arith::ConstantOp>(
-          op.getLoc(),
-          rewriter.getIntegerAttr(addr.getType(), floatType.getWidth() / 8));
-    } else {
-      llvm_unreachable("Cannot get memory size");
-    }
 
-    for (auto userOp : userOps) {
-      auto reinterpretCastOp = cast<memref::ReinterpretCastOp>(userOp);
+    for (memref::ReinterpretCastOp reinterpretCastOp : reinterpretCastOps) {
       auto sizes = reinterpretCastOp.getStaticSizes();
       auto staticStrides = reinterpretCastOp.getStaticStrides();
       auto strides = reinterpretCastOp.getStrides();
-      if (reinterpretCastOp.getStaticOffsets().size() != 1)
-        userOp->emitError("IntToPtrOp must converted to PointerCastOp of "
-                          "memref<?xdtype> type");
+      if (reinterpretCastOp.getStaticOffsets().size() != 1) {
+        reinterpretCastOp->emitError(
+            "IntToPtrOp must converted to PointerCastOp of "
+            "memref<?xdtype> type");
+        signalPassFailure();
+        return;
+      }
       int64_t castOpSize = 0;
       SmallVector<int64_t> dynamicSizes;
       for (const auto &[size, stride] : llvm::zip_equal(sizes, staticStrides)) {
@@ -1228,54 +1984,163 @@ void TritonToLinalgPass::runOnOperation() {
         dynamicSize =
             rewriter.create<arith::AddIOp>(op.getLoc(), dynamicSize, axisSize);
       }
-      Value offsetValue;
       auto staticOffset = reinterpretCastOp.getStaticOffsets()[0];
-      if (ShapedType::isDynamic(staticOffset)) {
-        offsetValue = reinterpretCastOp.getOffsets()[0];
-        if (offsetValue.getType() != addr.getType())
-          offsetValue = rewriter.create<arith::IndexCastOp>(
-              op.getLoc(), addr.getType(), offsetValue);
+      auto materializeOffset = [&](Type targetType) -> Value {
+        if (ShapedType::isDynamic(staticOffset)) {
+          Value offset = reinterpretCastOp.getOffsets()[0];
+          if (offset.getType() != targetType)
+            offset = rewriter.create<arith::IndexCastOp>(op.getLoc(),
+                                                         targetType, offset);
+          return offset;
+        }
+        if (targetType.isIndex())
+          return rewriter.create<arith::ConstantIndexOp>(op.getLoc(),
+                                                         staticOffset);
+        return rewriter.create<arith::ConstantOp>(
+            op.getLoc(), rewriter.getIntegerAttr(targetType, staticOffset));
+      };
+
+      auto memrefType = MemRefType::get({ShapedType::kDynamic}, elementType);
+      auto createPointerCast = [&](Value address, Value capacity) {
+        auto cast = rewriter.create<hivm::PointerCastOp>(
+            op.getLoc(), memrefType, address, capacity);
+        auto mark =
+            rewriter.create<annotation::MarkOp>(op.getLoc(), cast.getResult());
+        mark->setAttr(hivm::AddressSpaceAttr::getMnemonic(),
+                      {hivm::AddressSpaceAttr::get(rewriter.getContext(),
+                                                   hivm::AddressSpace::GM)});
+        return cast;
+      };
+
+      if (!isScalarPointerCarrier) {
+        // Preserve main-dev behavior for ordinary PointerCast operations. The
+        // provenance-gated branches below exist specifically for scalar
+        // pointer carriers introduced by this conversion pipeline.
+        Value offsetValue = materializeOffset(addr.getType());
+        Value elementTypeSize;
+        if (auto intType = dyn_cast<IntegerType>(elementType)) {
+          elementTypeSize = rewriter.create<arith::ConstantOp>(
+              op.getLoc(),
+              rewriter.getIntegerAttr(addr.getType(), intType.getWidth() / 8));
+        } else if (auto floatType = dyn_cast<FloatType>(elementType)) {
+          elementTypeSize = rewriter.create<arith::ConstantOp>(
+              op.getLoc(), rewriter.getIntegerAttr(addr.getType(),
+                                                   floatType.getWidth() / 8));
+        } else {
+          llvm_unreachable("Cannot get memory size");
+        }
+        offsetValue = rewriter.create<arith::MulIOp>(op.getLoc(), offsetValue,
+                                                     elementTypeSize);
+        Value realAddr =
+            rewriter.create<arith::AddIOp>(op.getLoc(), addr, offsetValue);
+        auto newCastOp = createPointerCast(realAddr, dynamicSize);
+
+        auto oldResultType =
+            cast<MemRefType>(reinterpretCastOp.getResult().getType());
+        MemRefType newResultType = oldResultType;
+        if (auto stridedLayout =
+                dyn_cast<StridedLayoutAttr>(oldResultType.getLayout())) {
+          if (!ShapedType::isDynamic(stridedLayout.getOffset())) {
+            auto newLayout =
+                StridedLayoutAttr::get(rewriter.getContext(), /*offset=*/0,
+                                       stridedLayout.getStrides());
+            newResultType = MemRefType::get(
+                oldResultType.getShape(), oldResultType.getElementType(),
+                newLayout, oldResultType.getMemorySpace());
+          }
+        }
+        rewriter.replaceOpWithNewOp<memref::ReinterpretCastOp>(
+            reinterpretCastOp, newResultType, newCastOp, ValueRange({}),
+            reinterpretCastOp.getSizes(), reinterpretCastOp.getStrides(),
+            SmallVector<int64_t>({0}), reinterpretCastOp.getStaticSizes(),
+            reinterpretCastOp.getStaticStrides());
+        continue;
+      }
+
+      if (reachesLayoutSensitiveBoundary(reinterpretCastOp.getResult())) {
+        // Keep the original offset and result type at externally typed
+        // boundaries. The replacement PointerCast still starts at the old
+        // address, so its capacity must include the leading view displacement.
+        Value pointerCapacity = dynamicSize;
+        Value offsetElements = materializeOffset(pointerCapacity.getType());
+        Value leadingExtent = offsetElements;
+        if (ShapedType::isDynamic(staticOffset)) {
+          Value zero = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
+          leadingExtent = rewriter.create<arith::MaxSIOp>(op.getLoc(),
+                                                          offsetElements, zero);
+        }
+        if (ShapedType::isDynamic(staticOffset) || staticOffset > 0)
+          pointerCapacity = rewriter.create<arith::AddIOp>(
+              op.getLoc(), pointerCapacity, leadingExtent);
+        auto newCastOp = createPointerCast(addr, pointerCapacity);
+        rewriter.modifyOpInPlace(reinterpretCastOp, [&] {
+          reinterpretCastOp.getSourceMutable().assign(newCastOp.getResult());
+        });
+        continue;
+      }
+
+      Value offsetValue = materializeOffset(addr.getType());
+      Value elementTypeSize;
+      if (auto intType = dyn_cast<IntegerType>(elementType)) {
+        elementTypeSize = rewriter.create<arith::ConstantOp>(
+            op.getLoc(),
+            rewriter.getIntegerAttr(addr.getType(), intType.getWidth() / 8));
+      } else if (auto floatType = dyn_cast<FloatType>(elementType)) {
+        elementTypeSize = rewriter.create<arith::ConstantOp>(
+            op.getLoc(),
+            rewriter.getIntegerAttr(addr.getType(), floatType.getWidth() / 8));
       } else {
-        offsetValue = rewriter.create<arith::ConstantOp>(
-            op.getLoc(), rewriter.getIntegerAttr(addr.getType(), staticOffset));
+        llvm_unreachable("Cannot get memory size");
       }
       offsetValue = rewriter.create<arith::MulIOp>(op.getLoc(), offsetValue,
                                                    elementTypeSize);
       Value realAddr =
           rewriter.create<arith::AddIOp>(op.getLoc(), addr, offsetValue);
-      auto memrefType = MemRefType::get({ShapedType::kDynamic}, elementType);
-      auto newCastOp = rewriter.create<hivm::PointerCastOp>(
-          op.getLoc(), memrefType, realAddr, dynamicSize);
-      auto markOp = rewriter.create<annotation::MarkOp>(op.getLoc(),
-                                                        newCastOp.getResult());
-      markOp->setAttr(hivm::AddressSpaceAttr::getMnemonic(),
-                      {hivm::AddressSpaceAttr::get(rewriter.getContext(),
-                                                   hivm::AddressSpace::GM)});
-
-      // update result offset
-      auto origResultType =
+      auto newCastOp = createPointerCast(realAddr, dynamicSize);
+      // realAddr already includes the old reinterpret-cast offset in bytes.
+      // The replacement view therefore starts at offset zero, and its result
+      // type must describe the same rebased layout. Reusing the old type here
+      // would combine static_offsets=[0] with (for example) a type-level
+      // offset of 1, which is rejected by the ReinterpretCast verifier.
+      auto oldResultType =
           cast<MemRefType>(reinterpretCastOp.getResult().getType());
-      MemRefType newResultType = origResultType;
-      if (auto stridedLayout =
-              dyn_cast<StridedLayoutAttr>(origResultType.getLayout())) {
-        int64_t offset = stridedLayout.getOffset();
-        if (!ShapedType::isDynamic(offset)) {
-          auto newLayout = StridedLayoutAttr::get(rewriter.getContext(), 0,
-                                                  stridedLayout.getStrides());
-          newResultType = MemRefType::get(
-              origResultType.getShape(), origResultType.getElementType(),
-              newLayout, origResultType.getMemorySpace());
-        }
-      }
+      SmallVector<int64_t> rebasedStrides(
+          oldResultType.getStridesAndOffset().first);
+      auto rebasedResultType = MemRefType::get(
+          oldResultType.getShape(), oldResultType.getElementType(),
+          StridedLayoutAttr::get(oldResultType.getContext(), /*offset=*/0,
+                                 rebasedStrides),
+          oldResultType.getMemorySpace());
 
-      rewriter.replaceOpWithNewOp<memref::ReinterpretCastOp>(
-          reinterpretCastOp, newResultType, newCastOp, ValueRange({}),
-          reinterpretCastOp.getSizes(), reinterpretCastOp.getStrides(),
-          SmallVector<int64_t>({0}), reinterpretCastOp.getStaticSizes(),
-          reinterpretCastOp.getStaticStrides());
+      // Keep the old result and replacement types equal while RAUW updates all
+      // users to the rebased descriptor type.
+      rewriter.modifyOpInPlace(reinterpretCastOp, [&] {
+        reinterpretCastOp.getResult().setType(rebasedResultType);
+      });
+      auto rebasedReinterpretCast =
+          rewriter.replaceOpWithNewOp<memref::ReinterpretCastOp>(
+              reinterpretCastOp, rebasedResultType, newCastOp, ValueRange({}),
+              reinterpretCastOp.getSizes(), reinterpretCastOp.getStrides(),
+              SmallVector<int64_t>({0}), reinterpretCastOp.getStaticSizes(),
+              reinterpretCastOp.getStaticStrides());
+      if (failed(propagateRebasedSubviewTypes(
+              rebasedReinterpretCast.getResult(), rewriter))) {
+        rebasedReinterpretCast.emitError(
+            "failed to propagate rebased layout through subview users");
+        signalPassFailure();
+        return;
+      }
     }
-    rewriter.eraseOp(op);
+    if (op->use_empty())
+      rewriter.eraseOp(op);
   }
+
+  // ScalarPointerCarrier is a pass-local provenance marker. Keep it through
+  // PointerCast post-processing so only known scalar-address carriers use the
+  // new layout path, then remove it before downstream dialects observe the IR.
+  moduleOp.walk([](hivm::PointerCastOp pointerCast) {
+    pointerCast->removeAttr(kScalarPointerCarrierAttr);
+  });
 
   // Try interleave optimization
   llvm::DenseMap<BlockArgument, SmallVector<Operation *>> interleaveCandidate;

--- a/third_party/ascend/lib/TritonToLinalg/UseAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/UseAnalysis.cpp
@@ -24,6 +24,7 @@
 #include "ascend/include/Utils/Utils.h"
 
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "bishengir/Dialect/Scope/IR/Scope.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 
 #include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
@@ -340,7 +341,7 @@ LogicalResult triton::runUseAnalysis(triton::FuncOp &funcOp) {
         }
       }
       if (!isa<mlir::scf::IfOp, mlir::scf::ForOp, mlir::scf::WhileOp,
-               triton::ReduceOp>(op)) {
+               scope::ScopeOp, triton::ReduceOp>(op)) {
         assert(op->getNumResults() == 1 &&
                "Ops used for meta computation are expected to have one result");
       }
@@ -588,6 +589,20 @@ LogicalResult triton::runUseAnalysis(triton::FuncOp &funcOp) {
   return success();
 }
 
+static bool isScalarI1ToI8PointerBitcast(Operation *op) {
+  auto bitcast = dyn_cast<triton::BitcastOp>(op);
+  if (!bitcast)
+    return false;
+
+  auto sourceType = dyn_cast<triton::PointerType>(bitcast.getSrc().getType());
+  auto resultType = dyn_cast<triton::PointerType>(bitcast.getType());
+  if (!sourceType || !resultType)
+    return false;
+
+  return sourceType.getPointeeType().isInteger(1) &&
+         resultType.getPointeeType().isInteger(8);
+}
+
 MetaUseEraser::MetaUseEraser(MLIRContext *context)
     : RewritePattern(MatchAnyOpTypeTag(), /*benefit=*/10, context) {}
 
@@ -604,6 +619,9 @@ LogicalResult MetaUseEraser::matchAndRewrite(Operation *op,
     return rewriter.notifyMatchFailure(op,
                                        "AddPtrOp will be handled separately");
   }
+  if (isScalarI1ToI8PointerBitcast(op))
+    return rewriter.notifyMatchFailure(
+        op, "scalar i1-to-i8 pointer bitcast requires conversion");
   if (isMetaUse(op)) {
     rewriter.eraseOp(op);
     return success();

--- a/third_party/ascend/lib/TritonToStructured/CannonicalizerConverter.cpp
+++ b/third_party/ascend/lib/TritonToStructured/CannonicalizerConverter.cpp
@@ -473,10 +473,16 @@ LogicalResult PromotePointerIterArgsPattern::matchAndRewriteForAddPtr(
   // 4. Rewrite the loop body
   if (failed(rewriteLoopBody(forOp, newForOp, pointerArgsInfo, indexMap,
                              rewriter))) {
+    rewriter.eraseOp(newForOp);
     return failure();
   }
   // 5. Replace original loop results
-  return replaceResults(forOp, newForOp, pointerArgsInfo, indexMap, rewriter);
+  if (failed(replaceResults(forOp, newForOp, pointerArgsInfo, indexMap,
+                            rewriter))) {
+    rewriter.eraseOp(newForOp);
+    return failure();
+  }
+  return success();
 }
 
 // Transform a for loop that uses pointer iteration arguments into one that uses
@@ -530,6 +536,7 @@ LogicalResult PromotePointerIterArgsPattern::matchAndRewriteAdvancePtr(
   // 5. Rewrite the loop body
   if (failed(rewriteLoopBodyForAdvancePtr(forOp, newForOp, pointerArgsInfo,
                                           indexMap, rewriter))) {
+    rewriter.eraseOp(newForOp);
     return failure();
   }
   rewriter.replaceOp(forOp, newForOp);
@@ -1799,7 +1806,7 @@ LogicalResult SimplifyTensorIterArgsPattern::matchAndRewrite(
     scf::ForOp oldFor = forOp;
     if (failed(rewriteForWithRelayCandidates(newFor, oldFor, relayCandidates,
                                              rewriter))) {
-      newFor->setAttr(kFailedAttr, rewriter.getUnitAttr());
+      rewriter.eraseOp(newFor);
       return failure();
     }
     return success();
@@ -1953,7 +1960,7 @@ SimplifyTensorIterArgsPattern::rewriteForWithLocalCandidates(
   newFor->setAttr(kIncompleteAttr, rewriter.getUnitAttr());
 
   auto failAfterCreate = [&]() -> LogicalResult {
-    newFor->setAttr(kFailedAttr, rewriter.getUnitAttr());
+    rewriter.eraseOp(newFor);
     return failure();
   };
 
@@ -2240,9 +2247,6 @@ SimplifyTensorIterArgsPattern::rewriteOuterForWithRelayCandidates(
     return failure();
   }
 
-  constexpr llvm::StringLiteral kFailedAttr =
-      "tts.simplify_tensor_iter_args.failed";
-
   Block &oldOuterBody = *outerFor.getBody();
   if (!oldOuterBody.mightHaveTerminator()) {
     return failure();
@@ -2273,7 +2277,7 @@ SimplifyTensorIterArgsPattern::rewriteOuterForWithRelayCandidates(
   newOuterFor->setAttr(kIncompleteAttr, rewriter.getUnitAttr());
 
   auto failAfterCreate = [&]() -> FailureOr<scf::ForOp> {
-    newOuterFor->setAttr(kFailedAttr, rewriter.getUnitAttr());
+    rewriter.eraseOp(newOuterFor);
     return failure();
   };
 

--- a/third_party/ascend/lib/TritonToUnstructure/BubbleUpOperation.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/BubbleUpOperation.cpp
@@ -87,6 +87,8 @@ BubbleUpExtract<ExtractOpTy>::matchAndRewrite(ExtractOpTy op,
     bubbleUpIntBinaryOp(op, orIOp, loc, rewriter);
   } else if (auto cmpIOp = dyn_cast<arith::CmpIOp>(parentOp)) {
     bubbleUpOperation(op, cmpIOp, loc, rewriter);
+  } else if (auto selectOp = dyn_cast<arith::SelectOp>(parentOp)) {
+    bubbleUpOperation(op, selectOp, loc, rewriter);
   } else if (auto truncFOp = dyn_cast<arith::TruncFOp>(parentOp)) {
     bubbleUpOperation(op, truncFOp, loc, rewriter);
   } else if (auto extFOp = dyn_cast<arith::ExtFOp>(parentOp)) {
@@ -217,6 +219,20 @@ void BubbleUpExtract<ExtractOpTy>::bubbleUpOperation(
   auto rhs = createExtractOp(op, parentOp.getRhs(), loc, rewriter);
   rewriter.replaceOpWithNewOp<arith::CmpIOp>(op, parentOp.getPredicateAttr(),
                                              lhs, rhs);
+}
+
+template <typename ExtractOpTy>
+void BubbleUpExtract<ExtractOpTy>::bubbleUpOperation(
+    ExtractOpTy op, arith::SelectOp parentOp, Location loc,
+    PatternRewriter &rewriter) const {
+  Value condition = parentOp.getCondition();
+  if (isa<ShapedType>(condition.getType()))
+    condition = createExtractOp(op, condition, loc, rewriter);
+  Value trueValue = createExtractOp(op, parentOp.getTrueValue(), loc, rewriter);
+  Value falseValue =
+      createExtractOp(op, parentOp.getFalseValue(), loc, rewriter);
+  rewriter.replaceOpWithNewOp<arith::SelectOp>(op, condition, trueValue,
+                                               falseValue);
 }
 
 template <>

--- a/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "TritonToUnstructure/OffsetAnalysis.h"
+#include "TritonControlFlowOpt/ControlFlowRewrite.h"
 #include "Utils/Utils.h"
 
 #include "bishengir/Dialect/Annotation/IR/Annotation.h"
@@ -77,6 +78,7 @@ PtrOffsetInfo &PtrOffsetInfo::operator=(const PtrOffsetInfo &other) {
   setOffsets(other.getOffsets());
   setStructured(other.getStructured());
   setScalarLike(other.isScalarLike());
+  setPointerDescriptorOwned(other.isPointerDescriptorOwned());
   return *this;
 }
 
@@ -88,6 +90,9 @@ SmallVector<Value> PtrOffsetInfo::getOffsets() const {
 SmallVector<Value> &PtrOffsetInfo::getOffsetsRef() { return this->tptOffsets; }
 
 bool PtrOffsetInfo::isScalarLike() const { return this->scalarLike; }
+bool PtrOffsetInfo::isPointerDescriptorOwned() const {
+  return this->pointerDescriptorOwned;
+}
 
 SmallVector<PtrOffsetInfo::AxisInfo> &PtrOffsetInfo::getStructuredRef() {
   return this->structured;
@@ -151,6 +156,10 @@ void PtrOffsetInfo::setScalarLike(bool scalarLike) {
   this->scalarLike = scalarLike;
 }
 
+void PtrOffsetInfo::setPointerDescriptorOwned(bool pointerDescriptorOwned) {
+  this->pointerDescriptorOwned = pointerDescriptorOwned;
+}
+
 bool PtrOffsetInfo::isStructured(int dim) const {
   return this->scalarLike || structured[dim] == AxisInfo::structured ||
          structured[dim] == AxisInfo::scalar;
@@ -184,7 +193,8 @@ void PtrOffsetInfo::setZeroOffset() {
     offset = builder.create<arith::ConstantOp>(
         ptr.getLoc(), DenseElementsAttr::get(
                           RankedTensorType::get(tensorType.getShape(),
-                                                builder.getIntegerType(64)),
+                                                builder.getIntegerType(64),
+                                                tensorType.getEncoding()),
                           builder.getZeroAttr(builder.getIntegerType(64))));
   } else {
     offset = builder.create<arith::ConstantOp>(ptr.getLoc(),
@@ -206,6 +216,111 @@ PtrOffsetInfo combineInfo(const PtrOffsetInfo &lhs, const PtrOffsetInfo &rhs) {
     structuredRef[i] = std::min(lhsStructured[i], rhsStructured[i]);
   return info;
 }
+
+namespace {
+
+bool isScalarPointer(Value value) {
+  auto pointerType = dyn_cast<triton::PointerType>(value.getType());
+  return pointerType && !isa<ShapedType>(pointerType.getPointeeType());
+}
+
+bool isTensorPointer(Value value) {
+  auto tensorType = dyn_cast<RankedTensorType>(value.getType());
+  return tensorType && isa<triton::PointerType>(tensorType.getElementType());
+}
+
+// A scalar pointer selected or carried by structured control flow is already a
+// complete runtime address. Recording the SSA value itself as the source avoids
+// choosing one incoming source and losing the other branch or loop iteration.
+// Later addptr users can still accumulate a separate offset from this address.
+void recordOpaqueScalarPointer(
+    Value pointer, llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+  offsetMap[pointer] = PtrOffsetInfo();
+  offsetMap[pointer].setPtr(pointer);
+  offsetMap[pointer].setZeroOffset();
+  offsetMap[pointer].setScalarLike(true);
+}
+
+// A tensor pointer without a proven common scalar base may choose a different
+// source for every element. This includes opaque function arguments,
+// per-lane selects, and loop phi values whose incoming provenance has not been
+// merged. Preserve the pointer tensor itself as the complete opaque base and
+// attach a zero displacement. Later addptr parsing can accumulate an additional
+// offset without discarding the runtime lane-wise source choice.
+void recordOpaqueTensorPointer(
+    Value pointerTensor, llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+  auto tensorType = cast<RankedTensorType>(pointerTensor.getType());
+  offsetMap[pointerTensor] = PtrOffsetInfo();
+  offsetMap[pointerTensor].setPtr(pointerTensor);
+  offsetMap[pointerTensor].setZeroOffset();
+  offsetMap[pointerTensor].setUnstructured(tensorType.getRank());
+}
+
+// PointerDescriptorBoundary stores loop-carried slot indices in the common
+// init/region-argument/result/terminator coordinate space. Only those slots
+// belong to the CFO descriptor protocol; unmarked tensor-pointer loops retain
+// the established main-dev provenance analysis.
+bool isPointerDescriptorBoundarySlot(Operation *loop, unsigned slot) {
+  auto slots = dyn_cast_or_null<DenseI32ArrayAttr>(
+      loop->getAttr(controlflow::kPointerDescriptorBoundaryAttr));
+  if (!slots)
+    return false;
+  return llvm::is_contained(slots.asArrayRef(), static_cast<int32_t>(slot));
+}
+
+bool isScalarPointerOffsetBoundarySlot(Operation *loop, unsigned slot) {
+  auto slots = dyn_cast_or_null<DenseI32ArrayAttr>(
+      loop->getAttr(kScalarPointerOffsetBoundaryAttr));
+  return slots &&
+         llvm::is_contained(slots.asArrayRef(), static_cast<int32_t>(slot));
+}
+
+bool isScalarPointerOffsetBoundaryRegionArgument(LoopLikeOpInterface loopOp,
+                                                 BlockArgument regionIterArg) {
+  if (auto whileOp = dyn_cast<scf::WhileOp>(loopOp.getOperation())) {
+    if (regionIterArg.getOwner() != whileOp.getBeforeBody() &&
+        regionIterArg.getOwner() != whileOp.getAfterBody())
+      return false;
+    return isScalarPointerOffsetBoundarySlot(loopOp.getOperation(),
+                                             regionIterArg.getArgNumber());
+  }
+
+  if (auto forOp = dyn_cast<scf::ForOp>(loopOp.getOperation())) {
+    if (regionIterArg.getOwner() != forOp.getBody() ||
+        regionIterArg.getArgNumber() == 0)
+      return false;
+    return isScalarPointerOffsetBoundarySlot(loopOp.getOperation(),
+                                             regionIterArg.getArgNumber() - 1);
+  }
+  return false;
+}
+
+bool isPointerDescriptorBoundaryRegionArgument(LoopLikeOpInterface loopOp,
+                                               BlockArgument regionIterArg) {
+  if (auto whileOp = dyn_cast<scf::WhileOp>(loopOp.getOperation())) {
+    if (regionIterArg.getOwner() != whileOp.getBeforeBody() &&
+        regionIterArg.getOwner() != whileOp.getAfterBody())
+      return false;
+    return isPointerDescriptorBoundarySlot(whileOp,
+                                           regionIterArg.getArgNumber());
+  }
+
+  for (auto [slot, argument] : llvm::enumerate(loopOp.getRegionIterArgs())) {
+    if (argument == regionIterArg)
+      return isPointerDescriptorBoundarySlot(loopOp.getOperation(), slot);
+  }
+  return false;
+}
+
+bool isPointerDescriptorBoundaryResult(LoopLikeOpInterface loopOp,
+                                       Value result) {
+  auto opResult = dyn_cast<OpResult>(result);
+  return opResult && opResult.getOwner() == loopOp.getOperation() &&
+         isPointerDescriptorBoundarySlot(loopOp.getOperation(),
+                                         opResult.getResultNumber());
+}
+
+} // namespace
 
 void parse(Value operand, const Location &loc, RewriterBase &rewriter,
            llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
@@ -260,6 +375,12 @@ void parse(Value operand, const Location &loc, RewriterBase &rewriter,
       if (auto ptrType = dyn_cast<triton::PointerType>(operand.getType())) {
         offsetMap[operand] =
             PtrOffsetInfo(operand, PtrOffsetInfo::AxisInfo::scalar);
+      } else if (isTensorPointer(operand)) {
+        // CFO may rebuild a tensor pointer from one invariant opaque function
+        // argument plus a separately carried displacement. The argument itself
+        // is the complete per-lane base: it has no common scalar provenance and
+        // must remain unstructured even when the added displacement is affine.
+        recordOpaqueTensorPointer(operand, offsetMap);
       } else {
         offsetMap[operand] = PtrOffsetInfo();
       }
@@ -296,6 +417,34 @@ void parseLoopRegionIterArg(LoopLikeOpInterface loopOp, const Location &loc,
                             RewriterBase &rewriter,
                             llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap,
                             BlockArgument regionIterArg) {
+  // This argument is a dynamic relative offset created by T2U.  Do not copy
+  // the loop init provenance here: doing so makes every backedge restart from
+  // the initial offset and drops the accumulated delta.  Record the argument
+  // itself as the offset identity so every later addptr keeps the live carrier
+  // (`offset(region_arg) = region_arg`) when adding its backedge delta.
+  if (isScalarPointerOffsetBoundaryRegionArgument(loopOp, regionIterArg)) {
+    offsetMap.erase(regionIterArg);
+    offsetMap[regionIterArg] = PtrOffsetInfo();
+    offsetMap[regionIterArg].setOffset(regionIterArg);
+    offsetMap[regionIterArg].setScalarLike(true);
+    return;
+  }
+
+  if (isScalarPointer(regionIterArg) &&
+      isPointerDescriptorBoundaryRegionArgument(loopOp, regionIterArg)) {
+    recordOpaqueScalarPointer(regionIterArg, offsetMap);
+    return;
+  }
+
+  // CFO descriptor slots may merge different incoming bases. Without a fixed
+  // point, preserve the runtime phi itself rather than choosing one edge.
+  // Ordinary unmarked loops stay on the established init/condition analysis.
+  if (isTensorPointer(regionIterArg) &&
+      isPointerDescriptorBoundaryRegionArgument(loopOp, regionIterArg)) {
+    recordOpaqueTensorPointer(regionIterArg, offsetMap);
+    return;
+  }
+
   if (auto whileOp = dyn_cast<scf::WhileOp>(loopOp.getOperation());
       whileOp && whileOp.getAfterBody() == regionIterArg.getOwner()) {
     auto argNum = regionIterArg.getArgNumber();
@@ -419,11 +568,132 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
   // Get addPtr base_ptr
   Value ptr = op.getPtr();
   parse(ptr, op.getLoc(), rewriter, offsetMap);
+  auto ptrInfo = offsetMap.find(ptr);
+  if (ptrInfo == offsetMap.end()) {
+    op.emitOpError("could not analyze the pointer base");
+    return;
+  }
   // Get addPtr offset
   Value offsetValue = op.getOffset();
+  PtrOffsetInfo ptrOffsetInfo = ptrInfo->second;
+  bool isRebuild = op->hasAttr(controlflow::kPointerDescriptorRebuildAttr);
+  Attribute offsetForm =
+      op->getAttr(controlflow::kPointerDescriptorOffsetFormAttr);
+  auto structuredAxes = dyn_cast_or_null<DenseI32ArrayAttr>(
+      op->getAttr(controlflow::kPointerDescriptorStructuredAxesAttr));
+  auto resultType = dyn_cast<RankedTensorType>(op.getType());
+  SmallVector<PtrOffsetInfo::AxisInfo> descriptorAxes;
+  if (structuredAxes) {
+    if (!isRebuild || !resultType ||
+        structuredAxes.asArrayRef().size() !=
+            static_cast<size_t>(resultType.getRank())) {
+      op.emitOpError("invalid pointer descriptor structured-axis metadata");
+      return;
+    }
+    for (int32_t axis : structuredAxes.asArrayRef()) {
+      if (axis == 1)
+        descriptorAxes.push_back(PtrOffsetInfo::AxisInfo::structured);
+      else if (axis == 0)
+        descriptorAxes.push_back(PtrOffsetInfo::AxisInfo::unstructured);
+      else {
+        op.emitOpError(
+            "pointer descriptor structured axes must contain only 0 or 1");
+        return;
+      }
+    }
+  }
+  bool isStridedRankOne = false;
+  if (offsetForm) {
+    auto form = dyn_cast<StringAttr>(offsetForm);
+    if (!isRebuild || !form ||
+        form.getValue() != controlflow::kStrided1DOffsetForm) {
+      op.emitOpError("invalid pointer descriptor offset form");
+      return;
+    }
+    auto offsetType = dyn_cast<RankedTensorType>(offsetValue.getType());
+    auto offsetElementType =
+        offsetType ? dyn_cast<IntegerType>(offsetType.getElementType())
+                   : IntegerType();
+    auto baseSplat = ptr.getDefiningOp<triton::SplatOp>();
+    if (!resultType || resultType.getRank() != 1 || !offsetType ||
+        !isa<triton::PointerType>(resultType.getElementType()) ||
+        !offsetElementType || offsetElementType.getWidth() > 64 ||
+        resultType.getShape() != offsetType.getShape() ||
+        resultType.getEncoding() != offsetType.getEncoding() || !baseSplat ||
+        !isa<triton::PointerType>(baseSplat.getSrc().getType())) {
+      op.emitOpError(
+          "expected strided_1d on a rank-1 tensor pointer rebuilt from a "
+          "scalar pointer base and a compatible ranked integer offset");
+      return;
+    }
+    if (descriptorAxes.size() != 1 ||
+        descriptorAxes.front() != PtrOffsetInfo::AxisInfo::structured) {
+      op.emitOpError(
+          "strided_1d requires PointerDescriptorStructuredAxes = [1]");
+      return;
+    }
+    isStridedRankOne = true;
+  }
+  bool isCompleteOffsetCarrier = isRebuild && !isStridedRankOne;
+  bool isDescriptorOwned =
+      isRebuild || ptrOffsetInfo.isPointerDescriptorOwned();
+
+  if (isCompleteOffsetCarrier) {
+    // The carrier is complete relative to the descriptor base, but parsing
+    // that base may expose an additional displacement from its scalar source.
+    // Preserve both parts when reconstructing the complete pointer offset.
+    auto offsetType = dyn_cast<RankedTensorType>(offsetValue.getType());
+    auto offsetElementType =
+        offsetType ? dyn_cast<IntegerType>(offsetType.getElementType())
+                   : IntegerType();
+    if (!resultType || !offsetType || !offsetElementType ||
+        resultType.getShape() != offsetType.getShape() ||
+        resultType.getEncoding() != offsetType.getEncoding()) {
+      op.emitOpError("expected a shape- and encoding-compatible ranked integer "
+                     "complete-offset carrier");
+      return;
+    }
+    if (offsetElementType.getWidth() > 64) {
+      op.emitOpError("complete-offset carrier wider than i64 is unsupported");
+      return;
+    }
+
+    RewriterBase::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(op);
+    if (offsetElementType.getWidth() != 64) {
+      auto carrierType =
+          RankedTensorType::get(offsetType.getShape(), rewriter.getI64Type(),
+                                offsetType.getEncoding());
+      offsetValue = rewriter.create<arith::ExtSIOp>(op.getLoc(), carrierType,
+                                                    offsetValue);
+    }
+    Value baseDisplacement = ptrOffsetInfo.getOffset();
+    if (!baseDisplacement ||
+        baseDisplacement.getType() != offsetValue.getType()) {
+      op.emitOpError(
+          "expected pointer-base displacement compatible with complete "
+          "carrier");
+      return;
+    }
+    Value completeOffset = rewriter.create<arith::AddIOp>(
+        op.getLoc(), baseDisplacement, offsetValue);
+    ptrOffsetInfo.setOffset(completeOffset);
+    // setUnstructured() updates only the per-axis classification; it does not
+    // clear the independent scalar-like property inherited from a splatted
+    // base. A complete offset carrier is intentionally opaque here, so there
+    // is no proof that all lanes address the same element. Keep this state
+    // conservative and force the lane-wise memory-access path.
+    ptrOffsetInfo.setScalarLike(false);
+    if (descriptorAxes.empty())
+      ptrOffsetInfo.setUnstructured(resultType.getRank());
+    else
+      ptrOffsetInfo.setStructured(descriptorAxes);
+    ptrOffsetInfo.setPointerDescriptorOwned(true);
+    offsetMap[op.getResult()] = ptrOffsetInfo;
+    return;
+  }
+
   parse(offsetValue, op.getLoc(), rewriter, offsetMap);
-  PtrOffsetInfo ptrOffsetInfo = offsetMap.at(ptr);
-  PtrOffsetInfo offsetOffsetInfo = offsetMap.at(offsetValue);
   // Modify IR
 
   RewriterBase::InsertionGuard guard(rewriter);
@@ -432,7 +702,8 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
     auto offsetElementType = cast<IntegerType>(offsetType.getElementType());
     if (offsetElementType.getWidth() != 64) {
       auto newOffsetType = RankedTensorType::get(offsetType.getShape(),
-                                                 rewriter.getIntegerType(64));
+                                                 rewriter.getIntegerType(64),
+                                                 offsetType.getEncoding());
       offsetValue = rewriter.create<arith::ExtSIOp>(op.getLoc(), newOffsetType,
                                                     offsetValue);
     }
@@ -456,9 +727,25 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
   });
   // Set addPtr offset map
   auto dst = op.getResult();
+  PtrOffsetInfo offsetOffsetInfo = offsetMap.at(op.getOffset());
   auto dstOffsetInfo = combineInfo(ptrOffsetInfo, offsetOffsetInfo);
   dstOffsetInfo.setPtr(ptrOffsetInfo.getPtr());
   dstOffsetInfo.setOffset(offset);
+  dstOffsetInfo.setPointerDescriptorOwned(isDescriptorOwned);
+  // CFO's strided_1d descriptor is an explicit proof that a scalar pointer
+  // base plus this rank-1 lane offset remains a contiguous SIMD access. The
+  // generic offset join above cannot retain that proof when the lane offset
+  // was built through several arithmetic operations, so restore the marker's
+  // classification after the join. Complete opaque carriers intentionally do
+  // not enter this branch and keep their conservative unstructured state.
+  if (isStridedRankOne) {
+    dstOffsetInfo.setStructured(descriptorAxes);
+    // The descriptor describes a lane-varying, structured offset.  It is
+    // contiguous, but it is not a scalar-like pointer: scalarLike would
+    // route the load/store converter through splatAndLoadScenario(), which
+    // loads lane zero once and fills every lane with that value.
+    dstOffsetInfo.setScalarLike(false);
+  }
   offsetMap[dst] = dstOffsetInfo;
   LLVM_DEBUG({
     auto &os = llvm::dbgs();
@@ -495,7 +782,9 @@ void parseSplat(triton::SplatOp op, const Location &loc, RewriterBase &rewriter,
     rewriter.setInsertionPoint(op);
     Value valueOffset = srcOffsetInfo.getOffset();
     Value offset = rewriter.create<triton::SplatOp>(
-        loc, RankedTensorType::get(dstShape, rewriter.getIntegerType(64)),
+        loc,
+        RankedTensorType::get(dstShape, rewriter.getIntegerType(64),
+                              dstType.getEncoding()),
         valueOffset);
     dstOffsetInfo.setOffset(offset);
   }
@@ -505,6 +794,8 @@ void parseSplat(triton::SplatOp op, const Location &loc, RewriterBase &rewriter,
     dstStructured.push_back(dim == 1 ? PtrOffsetInfo::AxisInfo::scalar
                                      : PtrOffsetInfo::AxisInfo::scalarlike);
   dstOffsetInfo.setScalarLike(true);
+  dstOffsetInfo.setPointerDescriptorOwned(
+      srcOffsetInfo.isPointerDescriptorOwned());
   offsetMap[dst] = dstOffsetInfo;
 }
 
@@ -633,6 +924,8 @@ void parseBitcast(triton::BitcastOp op, const Location &loc,
     offsetMap[dst] = PtrOffsetInfo(srcStructured);
   }
   offsetMap[dst].setScalarLike(srcOffsetInfo.isScalarLike());
+  offsetMap[dst].setPointerDescriptorOwned(
+      srcOffsetInfo.isPointerDescriptorOwned());
 }
 
 void parseLoad(triton::LoadOp op, const Location &loc, RewriterBase &rewriter,
@@ -700,6 +993,8 @@ void parseBroadcast(triton::BroadcastOp op, const Location &loc,
   // Set broadcast offset map
   offsetMap[dst] = PtrOffsetInfo(srcOffsetInfo.getPtr());
   offsetMap[dst].setScalarLike(srcOffsetInfo.isScalarLike());
+  offsetMap[dst].setPointerDescriptorOwned(
+      srcOffsetInfo.isPointerDescriptorOwned());
 
   if (srcOffsetInfo.getPtr()) {
     RewriterBase::InsertionGuard guard(rewriter);
@@ -707,7 +1002,8 @@ void parseBroadcast(triton::BroadcastOp op, const Location &loc,
     Value valueOffset = srcOffsetInfo.getOffset();
     Value offset = rewriter.create<triton::BroadcastOp>(
         loc,
-        RankedTensorType::get(dstType.getShape(), rewriter.getIntegerType(64)),
+        RankedTensorType::get(dstType.getShape(), rewriter.getIntegerType(64),
+                              dstType.getEncoding()),
         valueOffset);
 
     offsetMap[dst].setOffset(offset);
@@ -736,6 +1032,8 @@ void parseExpandDims(triton::ExpandDimsOp op, const Location &loc,
   auto dst = op.getResult();
   offsetMap[dst] = PtrOffsetInfo(srcOffsetInfo.getPtr());
   offsetMap[dst].setScalarLike(srcOffsetInfo.isScalarLike());
+  offsetMap[dst].setPointerDescriptorOwned(
+      srcOffsetInfo.isPointerDescriptorOwned());
   if (srcOffsetInfo.getPtr()) {
     RewriterBase::InsertionGuard guard(rewriter);
     rewriter.setInsertionPoint(op);
@@ -787,6 +1085,16 @@ void parseClampF(triton::ClampFOp op, const Location &loc,
 void parseSelect(arith::SelectOp op, const Location &loc,
                  RewriterBase &rewriter,
                  llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+  if (isScalarPointer(op.getResult())) {
+    recordOpaqueScalarPointer(op.getResult(), offsetMap);
+    return;
+  }
+
+  if (isTensorPointer(op.getResult())) {
+    recordOpaqueTensorPointer(op.getResult(), offsetMap);
+    return;
+  }
+
   // Get select condition
   auto condition = op.getCondition();
   parse(condition, op.getLoc(), rewriter, offsetMap);
@@ -967,6 +1275,11 @@ void parseReduceReturn(triton::ReduceReturnOp op, const Location &loc,
 
 void parseIf(scf::IfOp op, const Location &loc, RewriterBase &rewriter,
              llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap, Value dst) {
+  if (isScalarPointer(dst)) {
+    recordOpaqueScalarPointer(dst, offsetMap);
+    return;
+  }
+
   const unsigned int index = cast<OpResult>(dst).getResultNumber();
   // Get if then region
   Block &thenBlock = op.getThenRegion().front();
@@ -977,6 +1290,7 @@ void parseIf(scf::IfOp op, const Location &loc, RewriterBase &rewriter,
   auto thenSrcPtr = thenOffsetInfo.getPtr();
   // Get if else region
   bool dstIsScalar = thenOffsetInfo.isScalarLike();
+  bool descriptorOwned = thenOffsetInfo.isPointerDescriptorOwned();
   SmallVector<PtrOffsetInfo::AxisInfo> elseStructured;
   if (op.elseBlock()) {
     Block &elseBlock = op.getElseRegion().front();
@@ -985,6 +1299,8 @@ void parseIf(scf::IfOp op, const Location &loc, RewriterBase &rewriter,
     PtrOffsetInfo elseOffsetInfo = offsetMap.at(elseYieldedValue);
     elseStructured = elseOffsetInfo.getStructuredRef();
     dstIsScalar = dstIsScalar && elseOffsetInfo.isScalarLike();
+    descriptorOwned =
+        descriptorOwned && elseOffsetInfo.isPointerDescriptorOwned();
     if (thenSrcPtr != elseOffsetInfo.getPtr()) {
       emitError(loc)
           << "Currently ptr type from different source not supported";
@@ -995,6 +1311,7 @@ void parseIf(scf::IfOp op, const Location &loc, RewriterBase &rewriter,
   offsetMap[dst] = PtrOffsetInfo();
   offsetMap[dst].setPtr(thenSrcPtr);
   offsetMap[dst].setScalarLike(dstIsScalar);
+  offsetMap[dst].setPointerDescriptorOwned(descriptorOwned);
   auto &dstStructured = offsetMap[dst].getStructuredRef();
   dstStructured.resize(thenStructured.size());
   for (size_t i = 0; i < dstStructured.size(); i++)
@@ -1022,6 +1339,18 @@ void parseYield(scf::YieldOp op, const Location &loc, RewriterBase &rewriter,
 void parseLoopOp(LoopLikeOpInterface op, const Location &loc,
                  RewriterBase &rewriter,
                  llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap, Value dst) {
+  if (isScalarPointer(dst) && isPointerDescriptorBoundaryResult(op, dst)) {
+    recordOpaqueScalarPointer(dst, offsetMap);
+    return;
+  }
+
+  // Apply the same boundary-slot rule to results so entry, region arguments,
+  // backedges and zero-trip results cannot disagree about the representation.
+  if (isTensorPointer(dst) && isPointerDescriptorBoundaryResult(op, dst)) {
+    recordOpaqueTensorPointer(dst, offsetMap);
+    return;
+  }
+
   auto resNum = cast<OpResult>(dst).getResultNumber();
   Value yieldedValue = nullptr;
   if (auto whileOp = dyn_cast<scf::WhileOp>(op.getOperation())) {
@@ -1062,6 +1391,8 @@ void parseExtractSlice(tensor::ExtractSliceOp op, const Location &loc,
       dstStructured.push_back(srcStructured[i]);
   }
   offsetMap[dst] = PtrOffsetInfo(srcPtr, srcOffset, dstStructured);
+  offsetMap[dst].setPointerDescriptorOwned(
+      srcPtrInfo.isPointerDescriptorOwned());
 }
 
 void parseInsertSlice(tensor::InsertSliceOp op, const Location &loc,
@@ -1104,6 +1435,8 @@ void parseInsertSlice(tensor::InsertSliceOp op, const Location &loc,
       ++srcStructuredIter;
   }
   resPtrInfo.setStructured(resStructured);
+  resPtrInfo.setPointerDescriptorOwned(srcPtrInfo.isPointerDescriptorOwned() &&
+                                       dstPtrInfo.isPointerDescriptorOwned());
   offsetMap[res] = resPtrInfo;
 }
 
@@ -1145,6 +1478,8 @@ void parseInsert(tensor::InsertOp op, const Location &loc,
     resPtrInfo.setOffset(resOffset);
   }
   resPtrInfo.setUnstructured(dstPtrInfo.getRank());
+  resPtrInfo.setPointerDescriptorOwned(srcPtrInfo.isPointerDescriptorOwned() &&
+                                       dstPtrInfo.isPointerDescriptorOwned());
   offsetMap[res] = resPtrInfo;
 }
 

--- a/third_party/ascend/lib/TritonToUnstructure/ReplaceArguments.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/ReplaceArguments.cpp
@@ -20,6 +20,7 @@
  * THE SOFTWARE.
  */
 
+#include "TritonControlFlowOpt/ControlFlowRewrite.h"
 #include "TritonToUnstructure/UnstructureConversionPass.h"
 #include "Utils/Utils.h"
 
@@ -30,17 +31,245 @@
 using namespace mlir;
 using namespace triton;
 
+namespace {
+
+inline constexpr llvm::StringLiteral kScalarPointerCarrierBoundaryAttr =
+    "ScalarPointerCarrierBoundary";
+
+static bool isScalarPointerType(Type type) {
+  auto pointerType = dyn_cast<triton::PointerType>(type);
+  return pointerType && !isa<ShapedType>(pointerType.getPointeeType());
+}
+
+static bool isPointerDescriptorBoundarySlot(Operation *loop, unsigned slot) {
+  if (!loop)
+    return false;
+  auto slots = dyn_cast_or_null<DenseI32ArrayAttr>(
+      loop->getAttr(controlflow::kPointerDescriptorBoundaryAttr));
+  return slots &&
+         llvm::is_contained(slots.asArrayRef(), static_cast<int32_t>(slot));
+}
+
+// Only scalar pointers owned by the CFO descriptor schema cross a loop as a
+// complete i64 address. Ordinary scalar pointers retain the established
+// base-plus-relative-offset representation.
+static bool useCompleteScalarAddress(Operation *loop, unsigned slot,
+                                     Type type) {
+  return loop && isa<scf::ForOp, scf::WhileOp>(loop) &&
+         isScalarPointerType(type) &&
+         (isPointerDescriptorBoundarySlot(loop, slot) ||
+          loop->hasAttr(kScalarPointerCarrierBoundaryAttr));
+}
+
+// Record the exact loop slot whose block argument is changed from a scalar
+// pointer to an i64 relative offset.  The marker is deliberately attached to
+// the cloned SCF op rather than inferred later from type alone: ordinary i64
+// loop-carried values must retain their established analysis.
+static void markScalarPointerOffsetSlot(Value value) {
+  auto blockArg = dyn_cast<BlockArgument>(value);
+  if (!blockArg)
+    return;
+  Operation *owner = blockArg.getOwner()->getParentOp();
+  if (!owner)
+    return;
+
+  unsigned slot = 0;
+  if (auto forOp = dyn_cast<scf::ForOp>(owner)) {
+    if (blockArg.getOwner() != forOp.getBody() || blockArg.getArgNumber() == 0)
+      return;
+    slot = blockArg.getArgNumber() - 1;
+  } else if (auto whileOp = dyn_cast<scf::WhileOp>(owner)) {
+    if (blockArg.getOwner() != whileOp.getBeforeBody() &&
+        blockArg.getOwner() != whileOp.getAfterBody())
+      return;
+    slot = blockArg.getArgNumber();
+  } else {
+    return;
+  }
+
+  SmallVector<int32_t> slots;
+  if (auto existing = dyn_cast_or_null<DenseI32ArrayAttr>(
+          owner->getAttr(kScalarPointerOffsetBoundaryAttr)))
+    slots.append(existing.asArrayRef().begin(), existing.asArrayRef().end());
+  if (!llvm::is_contained(slots, static_cast<int32_t>(slot)))
+    slots.push_back(static_cast<int32_t>(slot));
+  owner->setAttr(kScalarPointerOffsetBoundaryAttr,
+                 DenseI32ArrayAttr::get(owner->getContext(), slots));
+}
+
+// A scalar-pointer SCF slot is represented by one complete i64 address on all
+// structural edges. Region-local pointer users are rebuilt immediately, so no
+// pointer type crosses the control-flow boundary.
+static Value rebuildScalarPointer(Value address, Type pointerType,
+                                  OpBuilder &builder, Location loc) {
+  return builder.create<triton::IntToPtrOp>(loc, pointerType, address);
+}
+
+static Value materializeScalarPointerAddress(Value pointer, OpBuilder &builder,
+                                             Location loc) {
+  return builder.create<triton::PtrToIntOp>(loc, builder.getI64Type(), pointer);
+}
+
+static bool hasScalarPointerBase(const PtrOffsetInfo &info) {
+  return info.getPtr() && isScalarPointerType(info.getPtr().getType());
+}
+
+// A scalar pointer can use the established T2U offset representation only if
+// analysis found both a source pointer and a displacement.  An entry whose
+// source is the value itself is an opaque complete address (for example a
+// control-flow phi or a function argument), so choosing an offset for only
+// one edge would change the meaning of the other edges.
+static bool
+canRewriteScalarPointer(Value value, RewriterBase &rewriter,
+                        llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+  if (!isScalarPointerType(value.getType()))
+    return true;
+
+  parse(value, value.getLoc(), rewriter, offsetMap);
+  auto it = offsetMap.find(value);
+  if (it == offsetMap.end())
+    return false;
+  const PtrOffsetInfo &info = it->second;
+  return info.getPtr() && info.getOffset() && info.getPtr() != value;
+}
+
+// Decide the representation once for the complete SCF boundary.  The caller
+// passes this same decision to every init, region argument, yield, condition
+// operand, and result rewrite.  Thus a failed proof falls back atomically to
+// the pointer representation instead of producing a mixed-type boundary.
+static bool
+shouldPreserveScalarPointers(Operation *op, RewriterBase &rewriter,
+                             llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+  SmallVector<Value> boundaryValues;
+  if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+    boundaryValues.append(whileOp.getInits().begin(), whileOp.getInits().end());
+    boundaryValues.append(whileOp.getBeforeArguments().begin(),
+                          whileOp.getBeforeArguments().end());
+    boundaryValues.append(whileOp.getAfterArguments().begin(),
+                          whileOp.getAfterArguments().end());
+  } else if (auto loopOp = dyn_cast<LoopLikeOpInterface>(op)) {
+    boundaryValues.append(loopOp.getInits().begin(), loopOp.getInits().end());
+    boundaryValues.append(loopOp.getRegionIterArgs().begin(),
+                          loopOp.getRegionIterArgs().end());
+  } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+    boundaryValues.append(ifOp->getResults().begin(), ifOp->getResults().end());
+    boundaryValues.append(ifOp.thenYield().getResults().begin(),
+                          ifOp.thenYield().getResults().end());
+    if (ifOp.elseBlock())
+      boundaryValues.append(ifOp.elseYield().getResults().begin(),
+                            ifOp.elseYield().getResults().end());
+  } else {
+    return false;
+  }
+
+  for (Value value : boundaryValues) {
+    if (!isScalarPointerType(value.getType()))
+      continue;
+    if (!canRewriteScalarPointer(value, rewriter, offsetMap))
+      return true;
+  }
+  return false;
+}
+
+static bool hasScalarPointerResult(scf::IfOp op) {
+  return llvm::any_of(op->getResultTypes(),
+                      [](Type type) { return isScalarPointerType(type); });
+}
+
+static bool hasScalarPointerBoundary(Operation *op) {
+  SmallVector<Value> values;
+  if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+    values.append(whileOp.getInits().begin(), whileOp.getInits().end());
+    values.append(whileOp.getBeforeArguments().begin(),
+                  whileOp.getBeforeArguments().end());
+    values.append(whileOp.getAfterArguments().begin(),
+                  whileOp.getAfterArguments().end());
+    values.append(whileOp->getResults().begin(), whileOp->getResults().end());
+    values.append(whileOp.getConditionOp().getArgs().begin(),
+                  whileOp.getConditionOp().getArgs().end());
+    values.append(whileOp.getYieldOp()->getOperands().begin(),
+                  whileOp.getYieldOp()->getOperands().end());
+  } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+    values.append(forOp.getInitArgs().begin(), forOp.getInitArgs().end());
+    values.append(forOp.getRegionIterArgs().begin(),
+                  forOp.getRegionIterArgs().end());
+    values.append(forOp->getResults().begin(), forOp->getResults().end());
+    values.append(forOp.getYieldedValues().begin(),
+                  forOp.getYieldedValues().end());
+  } else {
+    return false;
+  }
+  return llvm::any_of(
+      values, [](Value value) { return isScalarPointerType(value.getType()); });
+}
+
+static void markOpaqueScalarPointerBoundary(Operation *op) {
+  if (hasScalarPointerBoundary(op))
+    op->setAttr(kScalarPointerCarrierBoundaryAttr,
+                UnitAttr::get(op->getContext()));
+}
+
+// `shouldPreserveScalarPointers` analyzes every value on the SCF boundary to
+// choose one representation.  When the choice is relative offsets, those
+// cached entries describe the old pointer-typed boundary and must be removed
+// before replaceArgs/replaceOperands rebuild the boundary.  Keeping even one
+// stale yield or result entry is enough to bypass the live backedge analysis.
+static void invalidateScalarPointerBoundaryAnalysis(
+    Operation *op, llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+  auto eraseScalarPointers = [&](ValueRange values) {
+    for (Value value : values)
+      if (isScalarPointerType(value.getType()))
+        offsetMap.erase(value);
+  };
+
+  if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+    eraseScalarPointers(whileOp.getInits());
+    eraseScalarPointers(whileOp.getBeforeArguments());
+    eraseScalarPointers(whileOp.getAfterArguments());
+    eraseScalarPointers(whileOp->getResults());
+    eraseScalarPointers(whileOp.getConditionOp().getArgs());
+    eraseScalarPointers(whileOp.getYieldOp()->getOperands());
+    return;
+  }
+  if (auto loopOp = dyn_cast<LoopLikeOpInterface>(op)) {
+    eraseScalarPointers(loopOp.getInits());
+    eraseScalarPointers(loopOp.getRegionIterArgs());
+    eraseScalarPointers(loopOp->getResults());
+    eraseScalarPointers(loopOp.getYieldedValues());
+    return;
+  }
+  if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+    eraseScalarPointers(ifOp->getResults());
+    eraseScalarPointers(ifOp.thenYield().getResults());
+    if (ifOp.elseBlock())
+      eraseScalarPointers(ifOp.elseYield().getResults());
+  }
+}
+
+} // namespace
+
 void replaceOperands(MutableArrayRef<OpOperand> oprs, RewriterBase &rewriter,
-                     llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+                     llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap,
+                     bool preserveScalarPointers) {
   for (auto it = oprs.begin(); it != oprs.end(); ++it) {
     auto &opr = *it;
     auto operand = opr.get();
     if (auto tensorType = dyn_cast<RankedTensorType>(operand.getType());
         tensorType && isa<triton::PointerType>(tensorType.getElementType())) {
       parse(operand, operand.getLoc(), rewriter, offsetMap);
-      opr.set(offsetMap.at(operand).getOffset());
+      const PtrOffsetInfo &info = offsetMap.at(operand);
+      // A complete opaque tensor base cannot be represented as an offset from
+      // one scalar source. Keep this structural edge unchanged instead of
+      // creating a type-mismatched loop signature.
+      if (hasScalarPointerBase(info))
+        opr.set(info.getOffset());
     } else if (auto ptrType =
                    dyn_cast<triton::PointerType>(operand.getType())) {
+      // An unmarked scalar pointer has no complete structural carrier schema.
+      // Keep it as a pointer on every SCF edge instead of changing only this
+      // operand to a relative offset and invalidating the parent operation.
+      if (preserveScalarPointers && isScalarPointerType(operand.getType()))
+        continue;
       parse(operand, operand.getLoc(), rewriter, offsetMap);
       if (auto tensorType =
               dyn_cast<RankedTensorType>(ptrType.getPointeeType())) {
@@ -50,6 +279,11 @@ void replaceOperands(MutableArrayRef<OpOperand> oprs, RewriterBase &rewriter,
         }
         --it;
       } else {
+        // source == operand marks a complete scalar address whose source may be
+        // selected or loop-carried at runtime. Keep it as a pointer instead of
+        // replacing it with an offset relative to one statically chosen base.
+        if (offsetMap.at(operand).getPtr() == operand)
+          continue;
         opr.set(offsetMap.at(operand).getOffset());
       }
     }
@@ -57,11 +291,20 @@ void replaceOperands(MutableArrayRef<OpOperand> oprs, RewriterBase &rewriter,
 }
 
 void replaceArgs(ValueRange args, RewriterBase &rewriter,
-                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
+                 llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap,
+                 bool preserveScalarPointers) {
   for (auto it = args.begin(); it != args.end(); ++it) {
     auto arg = *it;
     if (auto tensorType = dyn_cast<RankedTensorType>(arg.getType());
         tensorType && isa<triton::PointerType>(tensorType.getElementType())) {
+      parse(arg, arg.getLoc(), rewriter, offsetMap);
+      const PtrOffsetInfo &info = offsetMap.at(arg);
+      // The relative-offset representation is legal only with one scalar
+      // element-pointer base. Opaque tensor bases remain pointer values and
+      // are handled lane-wise (or rejected later by the boundary validator).
+      if (!hasScalarPointerBase(info))
+        continue;
+
       RewriterBase::InsertionGuard guard(rewriter);
       if (auto blockArg = dyn_cast<BlockArgument>(arg)) {
         rewriter.setInsertionPointToStart(blockArg.getOwner());
@@ -72,8 +315,7 @@ void replaceArgs(ValueRange args, RewriterBase &rewriter,
                          .create<UnrealizedConversionCastOp>(
                              arg.getLoc(), arg.getType(), ValueRange({}))
                          ->getResult(0);
-      parse(arg, arg.getLoc(), rewriter, offsetMap);
-      auto src = offsetMap.at(arg).getPtr();
+      Value src = info.getPtr();
       rewriter.replaceAllUsesWith(arg, tempVar);
       arg.setType(RankedTensorType::get(tensorType.getShape(),
                                         rewriter.getIntegerType(64)));
@@ -82,6 +324,15 @@ void replaceArgs(ValueRange args, RewriterBase &rewriter,
       rewriter.replaceOpWithNewOp<triton::AddPtrOp>(
           tempVar.getDefiningOp(), tempVar.getType(), src, arg);
     } else if (auto ptrType = dyn_cast<triton::PointerType>(arg.getType())) {
+      // Region arguments and results must use the same representation as the
+      // corresponding init/condition/yield operands.
+      if (preserveScalarPointers && isScalarPointerType(arg.getType()))
+        continue;
+      parse(arg, arg.getLoc(), rewriter, offsetMap);
+      if (!isa<RankedTensorType>(ptrType.getPointeeType()) &&
+          offsetMap.at(arg).getPtr() == arg)
+        continue;
+
       RewriterBase::InsertionGuard guard(rewriter);
       if (auto blockArg = dyn_cast<BlockArgument>(arg)) {
         rewriter.setInsertionPointToStart(blockArg.getOwner());
@@ -92,7 +343,6 @@ void replaceArgs(ValueRange args, RewriterBase &rewriter,
                          .create<UnrealizedConversionCastOp>(
                              arg.getLoc(), arg.getType(), ValueRange({}))
                          ->getResult(0);
-      parse(arg, arg.getLoc(), rewriter, offsetMap);
       rewriter.replaceAllUsesWith(arg, tempVar);
       if (auto tensorType =
               dyn_cast<RankedTensorType>(ptrType.getPointeeType())) {
@@ -110,6 +360,7 @@ void replaceArgs(ValueRange args, RewriterBase &rewriter,
             srcOp.getShape(), srcOp.getStrides(), newOffsets, srcOp.getOrder());
       } else {
         auto src = offsetMap.at(arg).getPtr();
+        offsetMap.erase(arg);
         arg.setType(rewriter.getIntegerType(64));
         rewriter.replaceOpWithNewOp<triton::AddPtrOp>(
             tempVar.getDefiningOp(), tempVar.getType(), src, arg);
@@ -124,20 +375,60 @@ void convertTensorPtrPre(Operation *op, RewriterBase &rewriter,
     auto &os = llvm::dbgs();
     os << "[convertTensorPtr]: Preorder start\n" << *op << "\n";
   });
+  bool preserveScalarPointers =
+      shouldPreserveScalarPointers(op, rewriter, offsetMap);
+  if (!preserveScalarPointers)
+    invalidateScalarPointerBoundaryAnalysis(op, offsetMap);
+  SmallVector<Value> scalarPointerOffsetArgs;
   if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
-    replaceArgs(whileOp.getBeforeArguments(), rewriter, offsetMap);
-    replaceOperands(whileOp.getInitsMutable(), rewriter, offsetMap);
-    replaceArgs(whileOp.getAfterArguments(), rewriter, offsetMap);
-    replaceArgs(whileOp->getResults(), rewriter, offsetMap);
+    if (!preserveScalarPointers)
+      llvm::copy_if(whileOp.getBeforeArguments(),
+                    std::back_inserter(scalarPointerOffsetArgs), [](Value arg) {
+                      return isScalarPointerType(arg.getType());
+                    });
+    replaceArgs(whileOp.getBeforeArguments(), rewriter, offsetMap,
+                preserveScalarPointers);
+    replaceOperands(whileOp.getInitsMutable(), rewriter, offsetMap,
+                    preserveScalarPointers);
+    replaceArgs(whileOp.getAfterArguments(), rewriter, offsetMap,
+                preserveScalarPointers);
+    replaceArgs(whileOp->getResults(), rewriter, offsetMap,
+                preserveScalarPointers);
     replaceOperands(whileOp.getConditionOp().getArgsMutable(), rewriter,
-                    offsetMap);
+                    offsetMap, preserveScalarPointers);
   } else if (auto loopOp = dyn_cast<LoopLikeOpInterface>(op)) {
-    replaceArgs(loopOp.getRegionIterArgs(), rewriter, offsetMap);
-    replaceOperands(loopOp.getInitsMutable(), rewriter, offsetMap);
+    if (!preserveScalarPointers)
+      llvm::copy_if(loopOp.getRegionIterArgs(),
+                    std::back_inserter(scalarPointerOffsetArgs), [](Value arg) {
+                      return isScalarPointerType(arg.getType());
+                    });
+    replaceArgs(loopOp.getRegionIterArgs(), rewriter, offsetMap,
+                preserveScalarPointers);
+    replaceOperands(loopOp.getInitsMutable(), rewriter, offsetMap,
+                    preserveScalarPointers);
   } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
-    replaceArgs(ifOp->getResults(), rewriter, offsetMap);
-    replaceOperands(ifOp.thenYield().getResultsMutable(), rewriter, offsetMap);
-    replaceOperands(ifOp.elseYield().getResultsMutable(), rewriter, offsetMap);
+    if (preserveScalarPointers && hasScalarPointerResult(ifOp))
+      ifOp->setAttr(kScalarPointerCarrierBoundaryAttr,
+                    UnitAttr::get(ifOp.getContext()));
+    replaceArgs(ifOp->getResults(), rewriter, offsetMap,
+                preserveScalarPointers);
+    replaceOperands(ifOp.thenYield().getResultsMutable(), rewriter, offsetMap,
+                    preserveScalarPointers);
+    replaceOperands(ifOp.elseYield().getResultsMutable(), rewriter, offsetMap,
+                    preserveScalarPointers);
+  }
+  // Publish the offset-carrier schema only after every structural edge has
+  // been rewritten. In particular, a While before argument and its paired
+  // after argument must both retain their original base provenance while they
+  // are converted. Publishing after the first region would make parsing the
+  // second region treat its still-pointer-typed argument as a base-less i64
+  // offset and attempt to rebuild tt.addptr from a null source.
+  for (Value arg : scalarPointerOffsetArgs) {
+    markScalarPointerOffsetSlot(arg);
+    // replaceArgs() may have cached the old pointer provenance before the
+    // marker was published. Drop only the marked region arguments so the
+    // subsequent body walk re-parses them as live scalar offset carriers.
+    offsetMap.erase(arg);
   }
   LLVM_DEBUG({
     auto &os = llvm::dbgs();
@@ -151,11 +442,16 @@ void convertTensorPtrPost(Operation *op, RewriterBase &rewriter,
     auto &os = llvm::dbgs();
     os << "[convertTensorPtr]: Postorder start\n" << *op << "\n";
   });
+  bool preserveScalarPointers =
+      shouldPreserveScalarPointers(op, rewriter, offsetMap);
   if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
-    replaceOperands(whileOp.getYieldOp()->getOpOperands(), rewriter, offsetMap);
+    replaceOperands(whileOp.getYieldOp()->getOpOperands(), rewriter, offsetMap,
+                    preserveScalarPointers);
   } else if (auto loopOp = dyn_cast<LoopLikeOpInterface>(op)) {
-    replaceArgs(loopOp->getResults(), rewriter, offsetMap);
-    replaceOperands(*loopOp.getYieldedValuesMutable(), rewriter, offsetMap);
+    replaceArgs(loopOp->getResults(), rewriter, offsetMap,
+                preserveScalarPointers);
+    replaceOperands(*loopOp.getYieldedValuesMutable(), rewriter, offsetMap,
+                    preserveScalarPointers);
   }
   LLVM_DEBUG({
     auto &os = llvm::dbgs();
@@ -174,22 +470,28 @@ int getPtrTensorRank(Type type) {
 }
 
 SmallVector<Value> constructOperands(ValueRange operands, Value tempVar,
-                                     IRMapping mapping) {
+                                     IRMapping mapping, OpBuilder &builder,
+                                     Operation *loop) {
   SmallVector<Value> newOperands;
-  for (auto opr : operands) {
-    opr = mapping.lookupOrDefault(opr);
-    newOperands.push_back(opr);
-    auto numAppend = getPtrTensorRank(opr.getType()) - 1;
+  for (auto [slot, originalOperand] : llvm::enumerate(operands)) {
+    Value mappedOperand = mapping.lookupOrDefault(originalOperand);
+    if (useCompleteScalarAddress(loop, slot, originalOperand.getType()))
+      mappedOperand = materializeScalarPointerAddress(mappedOperand, builder,
+                                                      originalOperand.getLoc());
+    newOperands.push_back(mappedOperand);
+    auto numAppend = getPtrTensorRank(originalOperand.getType()) - 1;
     if (numAppend > 0)
       newOperands.append(numAppend, tempVar);
   }
   return newOperands;
 }
 
-SmallVector<Type> constructTypes(TypeRange types) {
+SmallVector<Type> constructTypes(TypeRange types, Operation *loop) {
   SmallVector<Type> newTypes;
-  for (auto type : types) {
-    newTypes.push_back(type);
+  for (auto [slot, type] : llvm::enumerate(types)) {
+    newTypes.push_back(useCompleteScalarAddress(loop, slot, type)
+                           ? IntegerType::get(type.getContext(), 64)
+                           : type);
     if (auto ptrType = dyn_cast<triton::PointerType>(type)) {
       if (auto tensorType =
               dyn_cast<RankedTensorType>(ptrType.getPointeeType())) {
@@ -213,17 +515,34 @@ void replacePtrArguments(triton::FuncOp funcOp,
   std::function<WalkResult(Operation *)> convertTensorPtr = [&](Operation *op) {
     IRMapping mapping;
     Operation *newOp = nullptr;
-    rewriter.setInsertionPointAfter(op);
+    // Address carriers used by the replacement op must dominate it. Build the
+    // replacement immediately before the old op and erase the old op last.
+    rewriter.setInsertionPoint(op);
     if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+      // An opaque scalar-pointer boundary cannot be represented by the
+      // relative-offset protocol: one edge may come from an if/select and
+      // therefore has no single static base.  Convert every scalar pointer
+      // slot to a complete i64 address before constructing the replacement
+      // loop, so the loop signature is pointer-free and T2L never has to
+      // materialize a pointer from an unresolved SCF value.
+      if (shouldPreserveScalarPointers(forOp.getOperation(), rewriter,
+                                       offsetMap))
+        markOpaqueScalarPointerBoundary(forOp.getOperation());
+      SmallVector<Value> newInitArgs = constructOperands(
+          forOp.getInitArgs(), tempVar, mapping, rewriter, forOp);
       newOp = rewriter.create<scf::ForOp>(
           forOp.getLoc(), forOp.getLowerBound(), forOp.getUpperBound(),
-          forOp.getStep(),
-          constructOperands(forOp.getInitArgs(), tempVar, mapping),
+          forOp.getStep(), newInitArgs,
           [&](OpBuilder &b, Location loc, Value iv, ValueRange args) {
             mapping.map(forOp.getInductionVar(), iv);
             auto newArgIter = args.begin();
-            for (auto oldArg : forOp.getRegionIterArgs()) {
-              mapping.map(oldArg, *newArgIter);
+            for (auto [slot, oldArg] :
+                 llvm::enumerate(forOp.getRegionIterArgs())) {
+              Value mappedArg = *newArgIter;
+              if (useCompleteScalarAddress(forOp, slot, oldArg.getType()))
+                mappedArg =
+                    rebuildScalarPointer(mappedArg, oldArg.getType(), b, loc);
+              mapping.map(oldArg, mappedArg);
               std::advance(newArgIter,
                            std::max(getPtrTensorRank(oldArg.getType()), 1));
             }
@@ -231,44 +550,68 @@ void replacePtrArguments(triton::FuncOp funcOp,
               b.clone(bodyOp, mapping);
             }
             auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
-            b.create<scf::YieldOp>(
-                yieldOp.getLoc(),
-                constructOperands(yieldOp.getOperands(), tempVar, mapping));
+            b.create<scf::YieldOp>(yieldOp.getLoc(),
+                                   constructOperands(yieldOp.getOperands(),
+                                                     tempVar, mapping, b,
+                                                     forOp));
           });
     } else if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+      // Keep analyzable scalar pointers on the established relative-offset
+      // path. If any boundary edge has no stable base-plus-offset form, switch
+      // all scalar pointer edges atomically to complete i64 addresses so the
+      // before/after regions cannot acquire a mixed pointer/integer contract.
+      if (shouldPreserveScalarPointers(whileOp.getOperation(), rewriter,
+                                       offsetMap))
+        markOpaqueScalarPointerBoundary(whileOp.getOperation());
+      SmallVector<Value> newInits = constructOperands(
+          whileOp.getInits(), tempVar, mapping, rewriter, whileOp);
       newOp = rewriter.create<scf::WhileOp>(
-          whileOp.getLoc(), constructTypes(whileOp->getResultTypes()),
-          constructOperands(whileOp.getInits(), tempVar, mapping),
+          whileOp.getLoc(), constructTypes(whileOp->getResultTypes(), whileOp),
+          newInits,
           [&](OpBuilder &b, Location loc, ValueRange args) {
+            IRMapping beforeMapping;
             auto newArgIter = args.begin();
-            for (auto oldArg : whileOp.getBeforeArguments()) {
-              mapping.map(oldArg, *newArgIter);
+            for (auto [slot, oldArg] :
+                 llvm::enumerate(whileOp.getBeforeArguments())) {
+              Value mappedArg = *newArgIter;
+              if (useCompleteScalarAddress(whileOp, slot, oldArg.getType()))
+                mappedArg =
+                    rebuildScalarPointer(mappedArg, oldArg.getType(), b, loc);
+              beforeMapping.map(oldArg, mappedArg);
               std::advance(newArgIter,
                            std::max(getPtrTensorRank(oldArg.getType()), 1));
             }
             for (auto &bodyOp : whileOp.getBeforeBody()->without_terminator()) {
-              b.clone(bodyOp, mapping);
+              b.clone(bodyOp, beforeMapping);
             }
             auto conditionOp = whileOp.getConditionOp();
             b.create<scf::ConditionOp>(
                 conditionOp.getLoc(),
-                mapping.lookup(conditionOp.getCondition()),
-                constructOperands(conditionOp.getArgs(), tempVar, mapping));
+                beforeMapping.lookup(conditionOp.getCondition()),
+                constructOperands(conditionOp.getArgs(), tempVar, beforeMapping,
+                                  b, whileOp));
           },
           [&](OpBuilder &b, Location loc, ValueRange args) {
+            IRMapping afterMapping;
             auto newArgIter = args.begin();
-            for (auto oldArg : whileOp.getAfterArguments()) {
-              mapping.map(oldArg, *newArgIter);
+            for (auto [slot, oldArg] :
+                 llvm::enumerate(whileOp.getAfterArguments())) {
+              Value mappedArg = *newArgIter;
+              if (useCompleteScalarAddress(whileOp, slot, oldArg.getType()))
+                mappedArg =
+                    rebuildScalarPointer(mappedArg, oldArg.getType(), b, loc);
+              afterMapping.map(oldArg, mappedArg);
               std::advance(newArgIter,
                            std::max(getPtrTensorRank(oldArg.getType()), 1));
             }
             for (auto &bodyOp : whileOp.getAfterBody()->without_terminator()) {
-              b.clone(bodyOp, mapping);
+              b.clone(bodyOp, afterMapping);
             }
             auto yieldOp = whileOp.getYieldOp();
-            b.create<scf::YieldOp>(
-                yieldOp.getLoc(),
-                constructOperands(yieldOp.getOperands(), tempVar, mapping));
+            b.create<scf::YieldOp>(yieldOp.getLoc(),
+                                   constructOperands(yieldOp.getOperands(),
+                                                     tempVar, afterMapping, b,
+                                                     whileOp));
           });
     } else if (auto ifOp = dyn_cast<scf::IfOp>(op);
                ifOp && ifOp->getNumResults() > 0) {
@@ -279,18 +622,20 @@ void replacePtrArguments(triton::FuncOp funcOp,
               b.clone(bodyOp, mapping);
             }
             auto yieldOp = ifOp.thenYield();
-            b.create<scf::YieldOp>(
-                yieldOp.getLoc(),
-                constructOperands(yieldOp.getOperands(), tempVar, mapping));
+            b.create<scf::YieldOp>(yieldOp.getLoc(),
+                                   constructOperands(yieldOp.getOperands(),
+                                                     tempVar, mapping, b,
+                                                     /*loop=*/nullptr));
           },
           [&](OpBuilder &b, Location loc) {
             for (auto &bodyOp : ifOp.elseBlock()->without_terminator()) {
               b.clone(bodyOp, mapping);
             }
             auto yieldOp = ifOp.elseYield();
-            b.create<scf::YieldOp>(
-                yieldOp.getLoc(),
-                constructOperands(yieldOp.getOperands(), tempVar, mapping));
+            b.create<scf::YieldOp>(yieldOp.getLoc(),
+                                   constructOperands(yieldOp.getOperands(),
+                                                     tempVar, mapping, b,
+                                                     /*loop=*/nullptr));
           });
     } else if (auto loopOp = dyn_cast<LoopLikeOpInterface>(op)) {
       llvm_unreachable("Unsupported loop op");
@@ -302,8 +647,14 @@ void replacePtrArguments(triton::FuncOp funcOp,
         os << "Converting\n" << *op << "\nto\n" << *newOp << "\n";
       });
       auto resIter = newOp->result_begin();
-      for (auto res : op->getResults()) {
-        rewriter.replaceAllUsesWith(res, *resIter);
+      for (auto [slot, res] : llvm::enumerate(op->getResults())) {
+        Value replacement = *resIter;
+        if (useCompleteScalarAddress(op, slot, res.getType())) {
+          rewriter.setInsertionPointAfter(newOp);
+          replacement = rebuildScalarPointer(replacement, res.getType(),
+                                             rewriter, res.getLoc());
+        }
+        rewriter.replaceAllUsesWith(res, replacement);
         std::advance(resIter, std::max(getPtrTensorRank(res.getType()), 1));
       }
       rewriter.eraseOp(op);

--- a/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
@@ -53,6 +53,11 @@ static triton::ascend::CompileMode unstructureCompileMode =
 
 namespace {
 
+static bool isTensorOfPointers(Type type) {
+  auto tensorType = dyn_cast<RankedTensorType>(type);
+  return tensorType && isa<triton::PointerType>(tensorType.getElementType());
+}
+
 constexpr int64_t kBitsPerByte = 8;
 
 static triton::PointerType getScalarPointerType(Type type) {
@@ -381,6 +386,12 @@ LogicalResult tryRewriteIndirectFastPath(MemAccOpTy op, Location loc,
                                          Value srcPtr, Value ptrOffset,
                                          ArrayRef<int64_t> resultShape,
                                          PatternRewriter &rewriter) {
+  // Indirect backend operations accept one scalar base plus lane offsets. An
+  // opaque tensor base can contain a different pointer in every lane, so it
+  // must be handled by the scalar-loop fallback below.
+  if (!isa<triton::PointerType>(srcPtr.getType()))
+    return failure();
+
   bool rankWithinIndirectLoadStoreFastPathLimit = resultShape.size() <= 5;
 
   if (!canUseIndirectFastPath(srcPtr, ptrOffset)) {
@@ -646,16 +657,65 @@ triton::StoreOp UnstructuredMemAccessConverter<triton::StoreOp>::createMemAccOp(
 
 template <>
 template <>
-void UnstructuredMemAccessConverter<triton::LoadOp>::splatAndLoadScenario<
-    triton::LoadOp>(triton::LoadOp op, int rank,
+LogicalResult
+UnstructuredMemAccessConverter<triton::LoadOp>::splatAndLoadScenario<
+    triton::LoadOp>(triton::LoadOp op, const PtrOffsetInfo &ptrOffsetInfo,
                     PatternRewriter &rewriter) const {
   auto loc = op.getLoc();
-  SmallVector<OpFoldResult> idx(rank, rewriter.getIndexAttr(0));
-  auto extractedPtr = createExtractOp(loc, op.getPtr(), rewriter, idx);
+  if (!ptrOffsetInfo.isPointerDescriptorOwned()) {
+    // Preserve the legacy scalar-like path for unmarked pointer tensors. The
+    // analyzed-base reconstruction below is a descriptor handoff contract.
+    // Provenance is carried by PtrOffsetInfo so supported pointer-preserving
+    // operations, such as an ordinary addptr after the rebuild, do not lose
+    // ownership; unrelated pointer tensors still keep this legacy path.
+    SmallVector<OpFoldResult> indices(ptrOffsetInfo.getRank(),
+                                      rewriter.getIndexAttr(0));
+    Value extractedPtr = createExtractOp(loc, op.getPtr(), rewriter, indices);
+    Value mask = op.getMask();
+    Value other = op.getOther();
+    Value loadedValue = rewriter.create<triton::LoadOp>(
+        loc, extractedPtr, /*mask=*/nullptr, /*other=*/nullptr,
+        /*boundaryCheck=*/ArrayRef<int32_t>(),
+        /*PaddingOptionAttr=*/nullptr);
+    loadedValue = rewriter.create<triton::SplatOp>(
+        loc, op.getResult().getType(), loadedValue);
+    if (mask)
+      rewriter.replaceOpWithNewOp<arith::SelectOp>(op, mask, loadedValue,
+                                                   other);
+    else
+      rewriter.replaceOp(op, loadedValue);
+    return success();
+  }
+
+  Value scalarBase = ptrOffsetInfo.getPtr();
+  Value scalarOffset = ptrOffsetInfo.getOffset();
+  if (!scalarBase || !isa<triton::PointerType>(scalarBase.getType()) ||
+      !scalarOffset)
+    return failure();
+
+  if (auto offsetType = dyn_cast<RankedTensorType>(scalarOffset.getType())) {
+    if (offsetType.getRank() != ptrOffsetInfo.getRank() ||
+        !isa<IntegerType>(offsetType.getElementType()))
+      return failure();
+    SmallVector<OpFoldResult> indices(ptrOffsetInfo.getRank(),
+                                      rewriter.getIndexAttr(0));
+    scalarOffset = createExtractOp(loc, scalarOffset, rewriter, indices);
+  } else if (!scalarOffset.getType().isIndex() &&
+             !isa<IntegerType>(scalarOffset.getType())) {
+    return failure();
+  }
+
+  // PtrOffsetInfo already represents the analyzed address as scalarBase plus
+  // scalarOffset. Rebuild that scalar pointer directly instead of extracting
+  // a pointer lane from the original tensor-of-pointers value. This keeps the
+  // pointer producer in the T2L-supported addptr family; only the numerical
+  // offset is extracted from a tensor when necessary.
+  Value ptrToLoad = rewriter.create<triton::AddPtrOp>(loc, scalarBase.getType(),
+                                                      scalarBase, scalarOffset);
   Value mask = op.getMask();
   Value other = op.getOther();
   Value loadedValue = rewriter.create<triton::LoadOp>(
-      loc, extractedPtr, /*mask=*/nullptr, /*other=*/nullptr,
+      loc, ptrToLoad, /*mask=*/nullptr, /*other=*/nullptr,
       /*boundaryCheck=*/ArrayRef<int32_t>(),
       /*PaddingOptionAttr=*/nullptr);
   loadedValue = rewriter.create<triton::SplatOp>(loc, op.getResult().getType(),
@@ -664,6 +724,7 @@ void UnstructuredMemAccessConverter<triton::LoadOp>::splatAndLoadScenario<
     rewriter.replaceOpWithNewOp<arith::SelectOp>(op, mask, loadedValue, other);
   else
     rewriter.replaceOp(op, loadedValue);
+  return success();
 }
 
 template <typename MemAccOpTy>
@@ -711,8 +772,8 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
   });
 
   if constexpr (std::is_same_v<MemAccOpTy, triton::LoadOp>) {
-    if (ptrOffsetInfo.isScalarLike()) {
-      splatAndLoadScenario(op, ptrOffsetInfo.getRank(), rewriter);
+    if (ptrOffsetInfo.isScalarLike() &&
+        succeeded(splatAndLoadScenario(op, ptrOffsetInfo, rewriter))) {
       return success();
     }
   }
@@ -728,6 +789,10 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
 
   auto srcPtr = ptrOffsetInfo.getPtr();
   auto ptrOffset = ptrOffsetInfo.getOffset();
+  if (!isa<triton::PointerType>(srcPtr.getType()) &&
+      !isTensorOfPointers(srcPtr.getType()))
+    return rewriter.notifyMatchFailure(
+        op, "expected a scalar pointer or a tensor of scalar pointers");
 
   // LoadLike is operation with result
   bool isLoadLike = !op->use_empty();
@@ -906,8 +971,20 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
     os << extractedOffset << "\n";
   });
 
-  assert(isa<triton::PointerType>(srcPtr.getType()) && "src must be ptr type");
-  if (!fullyUnstructured) {
+  // A tensor-of-pointers base is opaque: each lane may select a different
+  // allocation. Extract the base with the same scalar or slice coordinates as
+  // the offset, then form the access pointer lane by lane.
+  if (isTensorOfPointers(srcPtr.getType())) {
+    if (fullyUnstructured)
+      srcPtr = createExtractOp(loc, srcPtr, rewriter, offsets);
+    else
+      srcPtr = createExtractOp(loc, srcPtr, rewriter, offsets, sizes, strides);
+  }
+
+  assert((isa<triton::PointerType>(srcPtr.getType()) ||
+          isTensorOfPointers(srcPtr.getType())) &&
+         "src must be a scalar pointer or tensor of pointers");
+  if (!fullyUnstructured && isa<triton::PointerType>(srcPtr.getType())) {
     srcPtr = rewriter.create<triton::SplatOp>(
         loc, RankedTensorType::get(extractedShape, srcPtr.getType()), srcPtr);
   }
@@ -1137,6 +1214,11 @@ void TritonToUnstructurePass::runOnOperation() {
     moduleOp->emitError("failed to apply Patterns");
     signalPassFailure();
   }
+
+  // The offset-boundary marker is only an intra-pass analysis handoff.  Do
+  // not expose it to T2L or let it inhibit later canonicalization.
+  moduleOp->walk(
+      [](Operation *op) { op->removeAttr(kScalarPointerOffsetBoundaryAttr); });
 
   PassManager pm(&getContext(), moduleOp.getOperationName());
   pm.addPass(createCSEPass());

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/block_ptr_addptr_base_invalid.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/block_ptr_addptr_base_invalid.mlir
@@ -1,0 +1,33 @@
+// RUN: triton-opt --triton-control-flow-opt %s | FileCheck %s
+
+module {
+  tt.func public @direct_addptr_base(%base: !tt.ptr<f32>) {
+    %c0_i32 = arith.constant 0 : i32
+    %c3_i32 = arith.constant 3 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %shifted = tt.addptr %base, %c3_i32 : !tt.ptr<f32>, i32
+    %ptr = tt.make_tensor_ptr %shifted, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf32>>
+    tt.return
+  }
+
+  tt.func public @selected_addptr_base(%base0: !tt.ptr<f32>, %base1: !tt.ptr<f32>, %cond: i1) {
+    %c0_i32 = arith.constant 0 : i32
+    %c7_i32 = arith.constant 7 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %shifted = tt.addptr %base0, %c7_i32 : !tt.ptr<f32>, i32
+    %selected = arith.select %cond, %shifted, %base1 : !tt.ptr<f32>
+    %ptr = tt.make_tensor_ptr %selected, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf32>>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: tt.func public @direct_addptr_base
+// CHECK:       %[[SHIFTED:.*]] = tt.addptr
+// CHECK:       tt.make_tensor_ptr %[[SHIFTED]],
+
+// CHECK-LABEL: tt.func public @selected_addptr_base
+// CHECK:       %[[SHIFTED:.*]] = tt.addptr
+// CHECK:       %[[SELECTED:.*]] = arith.select %{{.*}}, %[[SHIFTED]], %{{.*}} : !tt.ptr<f32>
+// CHECK:       tt.make_tensor_ptr %[[SELECTED]],

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/block_ptr_different_base.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/block_ptr_different_base.mlir
@@ -1,4 +1,4 @@
-// RUN: not triton-opt --triton-control-flow-opt %s 2>&1 | FileCheck %s
+// RUN: triton-opt --triton-control-flow-opt %s | FileCheck %s
 
 module {
   tt.func public @if_block_ptr_different_base(%base0: !tt.ptr<f32>, %base1: !tt.ptr<f32>, %cond: i1) -> !tt.ptr<tensor<16xf32>> {
@@ -20,4 +20,16 @@ module {
   }
 }
 
-// CHECK: error: failed to analyze pointer components across control flow
+// CHECK-LABEL: tt.func public @if_block_ptr_different_base(
+// CHECK-SAME:  %[[BASE0:[^ ,]+]]: !tt.ptr<f32>, %[[BASE1:[^ ,]+]]: !tt.ptr<f32>
+// CHECK:       %[[BASE0_ADDR:.*]] = tt.ptr_to_int %[[BASE0]]
+// CHECK:       %[[BASE1_ADDR:.*]] = tt.ptr_to_int %[[BASE1]]
+// CHECK:       %[[SELECTED:[^ :]+]]:2 = scf.if %{{[^ ]+}} -> (i64, i32) {
+// CHECK:         scf.yield %[[BASE0_ADDR]], %{{[^ ,]+}} : i64, i32
+// CHECK:       } else {
+// CHECK:         scf.yield %[[BASE1_ADDR]], %{{[^ ,]+}} : i64, i32
+// CHECK:       }
+// CHECK:       %[[SELECTED_BASE:.*]] = tt.int_to_ptr %[[SELECTED]]#0
+// CHECK:       %[[REBUILT:.*]] = tt.make_tensor_ptr %[[SELECTED_BASE]],
+// CHECK-SAME:      [%{{.*}}], [%{{.*}}], [%[[SELECTED]]#1]
+// CHECK:       tt.return %[[REBUILT]] : !tt.ptr<tensor<16xf32>>

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/d007_per_axis_structured_opaque_e2e.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/d007_per_axis_structured_opaque_e2e.mlir
@@ -1,0 +1,118 @@
+// RUN: triton-opt --triton-control-flow-opt %s -verify-each | FileCheck %s --check-prefix=CFO
+// RUN: triton-opt --triton-control-flow-opt --triton-to-unstructure --triton-to-linalg %s -verify-each | FileCheck %s --check-prefix=E2E --implicit-check-not='!tt.ptr' --implicit-check-not=unrealized_conversion_cast --implicit-check-not=PointerDescriptorBoundary --implicit-check-not=PointerDescriptorRebuild --implicit-check-not=PointerDescriptorOffsetForm --implicit-check-not=PointerDescriptorStructuredAxes
+
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  // A rank-1 affine range plus a uniform scalar offset remains one
+  // Structured axis and keeps the strided_1d handoff.
+  tt.func public @d007_rank1_structured(
+      %base: !tt.ptr<f32>, %output: !tt.ptr<f32>, %condition: i1) {
+    %c0 = arith.constant 0 : i32
+    %c2 = arith.constant 2 : i32
+    %c5 = arith.constant 5 : i32
+    %range = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %stride = tt.splat %c2 : i32 -> tensor<4xi32>
+    %scaled = arith.muli %range, %stride : tensor<4xi32>
+    %uniform = tt.splat %c5 : i32 -> tensor<4xi32>
+    %offset = arith.addi %scaled, %uniform : tensor<4xi32>
+    %base_tensor = tt.splat %base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %selected = scf.if %condition -> (tensor<4x!tt.ptr<f32>>) {
+      %ptr = tt.addptr %base_tensor, %offset : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scf.yield %ptr : tensor<4x!tt.ptr<f32>>
+    } else {
+      %uniform_alt = tt.splat %c0 : i32 -> tensor<4xi32>
+      %offset_alt = arith.addi %scaled, %uniform_alt : tensor<4xi32>
+      %ptr = tt.addptr %base_tensor, %offset_alt : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scf.yield %ptr : tensor<4x!tt.ptr<f32>>
+    }
+    %loaded = tt.load %selected : tensor<4x!tt.ptr<f32>>
+    %output_tensor = tt.splat %output : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %output_ptr = tt.addptr %output_tensor, %range : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    tt.store %output_ptr, %loaded : tensor<4x!tt.ptr<f32>>
+    tt.return
+  }
+
+  // An arbitrary rank-1 offset tensor is Opaque as a whole. The scalar stride
+  // and uniform offset fields must be normalized to zero.
+  tt.func public @d007_rank1_opaque(
+      %base: !tt.ptr<f32>, %output: !tt.ptr<f32>, %condition: i1,
+      %then_offsets: tensor<4xi32>, %else_offsets: tensor<4xi32>) {
+    %base_tensor = tt.splat %base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %selected = scf.if %condition -> (tensor<4x!tt.ptr<f32>>) {
+      %ptr = tt.addptr %base_tensor, %then_offsets : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scf.yield %ptr : tensor<4x!tt.ptr<f32>>
+    } else {
+      %ptr = tt.addptr %base_tensor, %else_offsets : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scf.yield %ptr : tensor<4x!tt.ptr<f32>>
+    }
+    %loaded = tt.load %selected : tensor<4x!tt.ptr<f32>>
+    %output_offsets = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %output_tensor = tt.splat %output : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %output_ptr = tt.addptr %output_tensor, %output_offsets : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    tt.store %output_ptr, %loaded : tensor<4x!tt.ptr<f32>>
+    tt.return
+  }
+
+  // Axis 0 is a make_range contribution while axis 1 comes from an opaque
+  // lane-wise input. The joined descriptor must retain [Structured, Opaque].
+  tt.func public @d007_rank2_mixed(
+      %base: !tt.ptr<f32>, %output: !tt.ptr<f32>, %condition: i1,
+      %then_axis1: tensor<4xi32>, %else_axis1: tensor<4xi32>) {
+    %axis0 = tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32>
+    %axis0_expanded = tt.expand_dims %axis0 {axis = 1 : i32} : tensor<2xi32> -> tensor<2x1xi32>
+    %axis0_broadcast = tt.broadcast %axis0_expanded : tensor<2x1xi32> -> tensor<2x4xi32>
+    %base_tensor = tt.splat %base : !tt.ptr<f32> -> tensor<2x4x!tt.ptr<f32>>
+    %selected = scf.if %condition -> (tensor<2x4x!tt.ptr<f32>>) {
+      %axis1_expanded = tt.expand_dims %then_axis1 {axis = 0 : i32} : tensor<4xi32> -> tensor<1x4xi32>
+      %axis1_broadcast = tt.broadcast %axis1_expanded : tensor<1x4xi32> -> tensor<2x4xi32>
+      %offset = arith.addi %axis0_broadcast, %axis1_broadcast : tensor<2x4xi32>
+      %ptr = tt.addptr %base_tensor, %offset : tensor<2x4x!tt.ptr<f32>>, tensor<2x4xi32>
+      scf.yield %ptr : tensor<2x4x!tt.ptr<f32>>
+    } else {
+      %axis1_expanded = tt.expand_dims %else_axis1 {axis = 0 : i32} : tensor<4xi32> -> tensor<1x4xi32>
+      %axis1_broadcast = tt.broadcast %axis1_expanded : tensor<1x4xi32> -> tensor<2x4xi32>
+      %offset = arith.addi %axis0_broadcast, %axis1_broadcast : tensor<2x4xi32>
+      %ptr = tt.addptr %base_tensor, %offset : tensor<2x4x!tt.ptr<f32>>, tensor<2x4xi32>
+      scf.yield %ptr : tensor<2x4x!tt.ptr<f32>>
+    }
+    %loaded = tt.load %selected : tensor<2x4x!tt.ptr<f32>>
+    %output_offsets = arith.constant dense<[[0, 1, 2, 3], [4, 5, 6, 7]]> : tensor<2x4xi32>
+    %output_tensor = tt.splat %output : !tt.ptr<f32> -> tensor<2x4x!tt.ptr<f32>>
+    %output_ptr = tt.addptr %output_tensor, %output_offsets : tensor<2x4x!tt.ptr<f32>>, tensor<2x4xi32>
+    tt.store %output_ptr, %loaded : tensor<2x4x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// CFO-LABEL: tt.func public @d007_rank1_structured
+// CFO: PointerDescriptorStructuredAxes = array<i32: 1>
+// CFO: PointerDescriptorOffsetForm = "strided_1d"
+// CFO-LABEL: tt.func public @d007_rank1_opaque
+// CFO: PointerDescriptorStructuredAxes = array<i32: 0>
+// CFO-LABEL: tt.func public @d007_rank2_mixed
+// CFO: PointerDescriptorStructuredAxes = array<i32: 1, 0>
+
+// E2E-LABEL: func.func @d007_rank1_structured
+// E2E-NOT: memref.load
+// E2E: %[[SOURCE_VIEW:.*]] = memref.reinterpret_cast %{{.*}} to offset: [%{{.*}}], sizes: [8], strides: [1]
+// E2E-SAME: to memref<8xf32, strided<[1], offset: ?>>
+// E2E-NOT: memref.load
+// E2E: %[[COPY_BUFFER:.*]] = memref.alloc() : memref<8xf32>
+// E2E-NOT: memref.load
+// E2E: memref.copy %[[SOURCE_VIEW]], %[[COPY_BUFFER]] : memref<8xf32, strided<[1], offset: ?>> to memref<8xf32>
+// E2E-NOT: memref.load
+// E2E: %[[SOURCE_TENSOR:.*]] = bufferization.to_tensor %[[COPY_BUFFER]]
+// E2E-NOT: memref.load
+// E2E: %[[SLICE:.*]] = tensor.extract_slice %[[SOURCE_TENSOR]][0] [4] [2] : tensor<8xf32> to tensor<4xf32>
+// E2E-NOT: memref.load
+// E2E: bufferization.materialize_in_destination %[[SLICE]]
+// E2E-NOT: memref.load
+// E2E: return
+// E2E-NOT: memref.load
+// E2E-LABEL: func.func @d007_rank1_opaque
+// E2E: memref.load
+// E2E: bufferization.materialize_in_destination
+// E2E: return
+// E2E-LABEL: func.func @d007_rank2_mixed
+// E2E: memref.load
+// E2E: bufferization.materialize_in_destination
+// E2E: return

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/pointer_descriptor_boundary_marker.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/pointer_descriptor_boundary_marker.mlir
@@ -1,0 +1,46 @@
+// RUN: triton-opt --triton-control-flow-opt --split-input-file %s | FileCheck %s
+
+module {
+  tt.func public @block_ptr_loop_marker(%base: !tt.ptr<f32>, %upper: index) -> !tt.ptr<tensor<16xf32>> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %initial = tt.make_tensor_ptr %base, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf32>>
+    %final = scf.for %iv = %c0 to %upper step %c1 iter_args(%ptr = %initial) -> (!tt.ptr<tensor<16xf32>>) {
+      %next = tt.advance %ptr, [%c1_i32] : !tt.ptr<tensor<16xf32>>
+      scf.yield %next : !tt.ptr<tensor<16xf32>>
+    }
+    tt.return %final : !tt.ptr<tensor<16xf32>>
+  }
+}
+
+// CHECK-LABEL: tt.func public @block_ptr_loop_marker
+// CHECK:       scf.for
+// CHECK:       PointerDescriptorBoundary
+
+// -----
+
+module {
+  tt.func public @tensor_ptr_loop_marker(%base: !tt.ptr<f32>, %upper: index) -> tensor<4x!tt.ptr<f32>> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %zero = tt.splat %c0_i32 : i32 -> tensor<4xi32>
+    %delta = tt.splat %c1_i32 : i32 -> tensor<4xi32>
+    %base_tensor = tt.splat %base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %initial = tt.addptr %base_tensor, %zero : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    %final = scf.for %iv = %c0 to %upper step %c1 iter_args(%ptr = %initial) -> (tensor<4x!tt.ptr<f32>>) {
+      %next = tt.addptr %ptr, %delta : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scf.yield %next : tensor<4x!tt.ptr<f32>>
+    }
+    tt.return %final : tensor<4x!tt.ptr<f32>>
+  }
+}
+
+// CHECK-LABEL: tt.func public @tensor_ptr_loop_marker
+// CHECK:       scf.for
+// CHECK:       PointerDescriptorBoundary

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scf_pointer_decouple.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scf_pointer_decouple.mlir
@@ -24,11 +24,11 @@ module {
 // CHECK-LABEL: tt.func public @for_block_ptr_dynamic_step
 // CHECK:       %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[OFF:.*]] = %{{.*}}) -> (i32) {
 // CHECK-NOT:     arith.muli
-// CHECK:         tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[OFF]]] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:         tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[OFF]]] {{.*}}order = array<i32: 0>{{.*}} : <tensor<32xf16>>
 // CHECK:         %[[NEXT:.*]] = arith.addi %[[OFF]], %{{.*}} : i32
 // CHECK:         scf.yield %[[NEXT]] : i32
 // CHECK:       }
-// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[FOR]]] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[FOR]]] {{.*}}order = array<i32: 0>{{.*}} : <tensor<32xf16>>
 
 // -----
 
@@ -51,13 +51,16 @@ module {
   }
 }
 
-// CHECK-LABEL: tt.func public @for_block_ptr_invariant_delta_carried
+// CHECK-LABEL: tt.func public @for_block_ptr_invariant_delta_carried(
+// CHECK-SAME:  %[[BASE:[^ ,]+]]: !tt.ptr<f16>
+// CHECK:       %[[BASE_ADDRESS:.*]] = tt.ptr_to_int %[[BASE]]
 // CHECK:       %[[FOR:[^:]+]]:2 = scf.for
-// CHECK-SAME:  {{.*}} iter_args(%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) -> (i32, tensor<32xf16>) {
+// CHECK-SAME:  {{.*}} -> (i32, tensor<32xf16>) {
 // CHECK-NOT:     arith.index_cast
 // CHECK-NOT:     arith.muli
 // CHECK:         %[[NEXT:.*]] = arith.addi %{{.*}}, %{{.*}} : i32
-// CHECK:         %[[LOAD_PTR:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[NEXT]]] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK-NOT:     tt.int_to_ptr %[[BASE_ADDRESS]]
+// CHECK:         %[[LOAD_PTR:.*]] = tt.make_tensor_ptr %[[BASE]], [%{{.*}}], [%{{.*}}], [%[[NEXT]]] {order = array<i32: 0>} : <tensor<32xf16>>
 // CHECK:         %[[LOADED:.*]] = tt.load %[[LOAD_PTR]] : !tt.ptr<tensor<32xf16>>
 // CHECK:         scf.yield %[[NEXT]], %[[LOADED]] : i32, tensor<32xf16>
 // CHECK:       }
@@ -85,7 +88,7 @@ module {
 // CHECK:         %[[NEXT:.*]] = arith.addi %[[OFF]], %{{.*}} : i32
 // CHECK:         scf.yield %[[NEXT]] : i32
 // CHECK:       }
-// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[FOR]]] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[FOR]]] {{.*}}order = array<i32: 0>{{.*}} : <tensor<32xf16>>
 
 // -----
 
@@ -113,7 +116,7 @@ module {
 // CHECK:         %[[NEXT_DELTA:.*]] = arith.addi %[[DELTA]], %{{.*}} : i32
 // CHECK:         scf.yield %[[NEXT_PTR]], %[[NEXT_DELTA]] : i32, i32
 // CHECK:       }
-// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[FOR]]#0] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[FOR]]#0] {{.*}}order = array<i32: 0>{{.*}} : <tensor<32xf16>>
 
 // -----
 
@@ -139,12 +142,12 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @for_block_ptr_multidim_delta
-// CHECK:       %[[FOR:.*]]:2 = scf.for {{.*}} iter_args(%[[OFF0:.*]] = %{{.*}}, %[[OFF1:.*]] = %{{.*}}) -> (i32, i32) {
+// CHECK:       %[[FOR:.*]]:2 = scf.for {{.*}} iter_args(%[[OFF0:.*]] = %{{.*}}, %[[OFF1:.*]] = %{{.*}})
 // CHECK:         %[[NEXT0:.*]] = arith.addi %[[OFF0]], %{{.*}} : i32
 // CHECK:         %[[NEXT1:.*]] = arith.addi %[[OFF1]], %{{.*}} : i32
 // CHECK:         scf.yield %[[NEXT0]], %[[NEXT1]] : i32, i32
 // CHECK:       }
-// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}], [%[[FOR]]#0, %[[FOR]]#1] {order = array<i32: 1, 0>} : <tensor<16x32xf16>>
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}], [%[[FOR]]#0, %[[FOR]]#1] {{.*}}order = array<i32: 1, 0>{{.*}} : <tensor<16x32xf16>>
 
 // -----
 
@@ -171,7 +174,7 @@ module {
 // CHECK:         %[[NEXT:.*]] = arith.addi %[[OFF]], %{{.*}} : i32
 // CHECK:         scf.yield %[[NEXT]] : i32
 // CHECK:       }
-// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[FOR]]] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[FOR]]] {{.*}}order = array<i32: 0>{{.*}} : <tensor<32xf16>>
 
 // -----
 
@@ -196,13 +199,14 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @while_block_ptr_basic
-// CHECK:       %[[WHILE:.*]]:2 = scf.while (%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) : (i32, i32) -> (i32, i32) {
+// CHECK:       %[[WHILE:.*]]:2 = scf.while
+// CHECK-SAME:  : (i32, i32) -> (i32, i32) {
 // CHECK:       scf.condition(%{{.*}}) %{{.*}}, %{{.*}} : i32, i32
 // CHECK:       } do {
-// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%{{.*}}] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%{{.*}}] {{.*}}order = array<i32: 0>{{.*}} : <tensor<32xf16>>
 // CHECK:       scf.yield %{{.*}}, %{{.*}} : i32, i32
 // CHECK:       }
-// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[WHILE]]#1] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[WHILE]]#1] {{.*}}order = array<i32: 0>{{.*}} : <tensor<32xf16>>
 
 // -----
 
@@ -231,7 +235,7 @@ module {
 // CHECK:       } else {
 // CHECK:         scf.yield %{{.*}} : i32
 // CHECK:       }
-// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[OFF]]] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[OFF]]] {{.*}}order = array<i32: 0>{{.*}} : <tensor<32xf16>>
 
 // -----
 
@@ -255,13 +259,14 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @if_tensor_ptr_same_base_offsets
-// CHECK:       %[[OFF:.*]] = scf.if %{{.*}} -> (tensor<4xi32>) {
-// CHECK:         scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:       %[[OFF:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:         scf.yield %{{.*}} : i32
 // CHECK:       } else {
-// CHECK:         scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:         scf.yield %{{.*}} : i32
 // CHECK:       }
 // CHECK:       tt.splat %{{.*}} : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
-// CHECK:       tt.addptr %{{.*}}, %[[OFF]] : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+// CHECK:       PointerDescriptorOffsetForm = "strided_1d"
+// CHECK-SAME:  PointerDescriptorRebuild
 
 // -----
 
@@ -288,6 +293,8 @@ module {
 
 // CHECK-LABEL: tt.func public @while_block_ptr_large_step
 // CHECK-DAG:   %[[C37:.*]] = arith.constant 37 : i32
+// CHECK:       %[[WHILE:.*]]:2 = scf.while
+// CHECK-SAME:  : (i32, i32) -> (i32, i32)
 // CHECK:       } do {
 // CHECK:         %[[NEXT_OFF:.*]] = arith.addi %{{.*}}, %[[C37]] : i32
 // CHECK:         scf.yield %{{.*}}, %[[NEXT_OFF]] : i32, i32
@@ -315,12 +322,14 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @while_tensor_ptr_addptr_step
+// CHECK-DAG:   %[[C4:.*]] = arith.constant 4 : i32
 // CHECK:       scf.while
-// CHECK-SAME:  tensor<4xi32>
+// CHECK-SAME:  i32
 // CHECK:       } do {
 // CHECK:         %[[STEP:.*]] = tt.splat %{{.*}} : i32 -> tensor<4xi32>
-// CHECK:         %[[NEXT_OFF:.*]] = arith.addi %{{.*}}, %[[STEP]] : tensor<4xi32>
-// CHECK:         scf.yield %{{.*}}, %[[NEXT_OFF]] : i32, tensor<4xi32>
+// CHECK:         %[[NEXT_I:.*]] = arith.addi %{{.*}}, %{{.*}} : i32
+// CHECK:         %[[NEXT_OFF:.*]] = arith.addi %{{.*}}, %[[C4]] : i32
+// CHECK:         scf.yield %[[NEXT_I]], %[[NEXT_OFF]] : i32, i32
 
 // -----
 
@@ -343,14 +352,16 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @for_tensor_ptr_preserves_wide_loop_offset
-// CHECK:       %[[STEP32:.*]] = tt.splat %{{.*}} : i32 -> tensor<4xi32>
+// CHECK:       %[[STEP32:.*]] = arith.constant 1 : i32
+// CHECK:       %[[INITIAL:.*]] = arith.constant 8 : i64
 // CHECK:       %[[FOR:.*]] = scf.for
-// CHECK-SAME:  -> (tensor<4xi64>) {
-// CHECK:         %[[STEP64:.*]] = arith.extsi %[[STEP32]] : tensor<4xi32> to tensor<4xi64>
-// CHECK:         %[[NEXT:.*]] = arith.addi %{{.*}}, %[[STEP64]] : tensor<4xi64>
-// CHECK:         scf.yield %[[NEXT]] : tensor<4xi64>
-// CHECK:       }
-// CHECK:       tt.addptr %{{.*}}, %[[FOR]] : tensor<4x!tt.ptr<f32>>, tensor<4xi64>
+// CHECK-SAME:  iter_args(%[[LOOP_OFFSET:.*]] = %[[INITIAL]]) -> (i64) {
+// CHECK:         %[[STEP64:.*]] = arith.extsi %[[STEP32]] : i32 to i64
+// CHECK:         %[[NEXT:.*]] = arith.addi %[[LOOP_OFFSET]], %[[STEP64]] : i64
+// CHECK:         scf.yield %[[NEXT]] : i64
+// CHECK:       } {PointerDescriptorBoundary = array<i32: 0>}
+// CHECK:       %[[TENSOR_OFFSET:.*]] = tt.splat %[[FOR]] : i64 -> tensor<4xi64>
+// CHECK:       tt.addptr %{{.*}}, %{{.*}} {{.*}}PointerDescriptorRebuild{{.*}} : tensor<4x!tt.ptr<f32>>, tensor<4xi64>
 
 // -----
 
@@ -393,7 +404,7 @@ module {
 // CHECK:         %[[NEXT:.*]] = arith.addi %[[SELECTED]], %{{.*}} : i32
 // CHECK:         scf.yield %[[NEXT]] : i32
 // CHECK:       }
-// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[FOR]]] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[FOR]]] {{.*}}order = array<i32: 0>{{.*}} : <tensor<32xf16>>
 
 // -----
 
@@ -439,7 +450,7 @@ module {
 // CHECK:         %[[NEXT:.*]] = arith.addi %[[SELECTED]], %{{.*}} : i32
 // CHECK:         scf.yield %{{.*}}, %[[NEXT]] : i32, i32
 // CHECK:       }
-// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[WHILE]]#1] {order = array<i32: 0>} : <tensor<32xf16>>
+// CHECK:       tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[WHILE]]#1] {{.*}}order = array<i32: 0>{{.*}} : <tensor<32xf16>>
 
 // -----
 
@@ -473,19 +484,21 @@ module {
 // CHECK-LABEL: tt.func public @for_if_tensor_ptr_same_base_post_addptr
 // CHECK-DAG:   %[[C2:.*]] = arith.constant 2 : i32
 // CHECK-DAG:   %[[POST_STEP:.*]] = tt.splat %[[C2]] : i32 -> tensor<4xi32>
-// CHECK:       %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[OFF:.*]] = %{{.*}}) -> (tensor<4xi32>) {
-// CHECK:         %[[SELECTED:.*]] = scf.if %{{.*}} -> (tensor<4xi32>) {
-// CHECK:           arith.addi %{{.*}}, %{{.*}} : tensor<4xi32>
-// CHECK:           scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:       %[[FOR:.*]] = scf.for {{.*}} iter_args(%[[OFF:.*]] = %{{.*}}) -> (i32) {
+// CHECK:         %[[SELECTED:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:           arith.addi %{{.*}}, %{{.*}} : i32
+// CHECK:           scf.yield %{{.*}} : i32
 // CHECK:         } else {
-// CHECK:           arith.addi %{{.*}}, %{{.*}} : tensor<4xi32>
-// CHECK:           scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:           arith.addi %{{.*}}, %{{.*}} : i32
+// CHECK:           scf.yield %{{.*}} : i32
 // CHECK:         }
-// CHECK:         %[[SELECTED_OFFSET:.*]] = arith.addi %{{.*}}, %[[SELECTED]] : tensor<4xi32>
-// CHECK:         %[[NEXT:.*]] = arith.addi %[[SELECTED_OFFSET]], %[[POST_STEP]] : tensor<4xi32>
-// CHECK:         scf.yield %[[NEXT]] : tensor<4xi32>
+// CHECK:         %[[NEXT:.*]] = arith.addi %[[SELECTED]], %{{.*}} : i32
+// CHECK:         scf.yield %[[NEXT]] : i32
 // CHECK:       }
-// CHECK:       tt.addptr %{{.*}}, %[[FOR]] : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+// CHECK:       PointerDescriptorOffsetForm = "strided_1d"
+// CHECK-SAME:  PointerDescriptorRebuild
+
+// -----
 
 module {
   tt.func public @for_if_block_ptr_load_after_post_advance(%base: !tt.ptr<f16>, %cond: i1) -> tensor<32xf16> {
@@ -518,7 +531,7 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @for_if_block_ptr_load_after_post_advance
-// CHECK:       %[[FOR:.*]]:2 = scf.for {{.*}} iter_args(%[[OFF:.*]] = %{{.*}}, %{{.*}} = %{{.*}}) -> (i32, tensor<32xf16>) {
+// CHECK:       %[[FOR:.*]]:2 = scf.for {{.*}} iter_args(%[[OFF:.*]] = %{{.*}}, %{{.*}} = %{{.*}})
 // CHECK:         %[[SELECTED:.*]] = scf.if %{{.*}} -> (i32) {
 // CHECK:           arith.addi %[[OFF]], %{{.*}} : i32
 // CHECK:           scf.yield %{{.*}} : i32
@@ -581,7 +594,7 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @for_nested_if_block_ptr_load_after_post_advance
-// CHECK:       %[[FOR:.*]]:2 = scf.for {{.*}} iter_args(%[[OFF:.*]] = %{{.*}}, %{{.*}} = %{{.*}}) -> (i32, tensor<16xf32>) {
+// CHECK:       %[[FOR:.*]]:2 = scf.for {{.*}} iter_args(%[[OFF:.*]] = %{{.*}}, %{{.*}} = %{{.*}})
 // CHECK:         %[[SELECTED:.*]] = scf.if %{{.*}} -> (i32) {
 // CHECK:           %[[THEN_INNER:.*]] = scf.if %{{.*}} -> (i32) {
 // CHECK:             scf.yield %{{.*}} : i32
@@ -655,28 +668,30 @@ module {
 
 // CHECK-LABEL: tt.func public @for_nested_if_tensor_ptr_load_after_post_addptr
 // CHECK:       %[[FOR:.*]]:2 = scf.for
-// CHECK-SAME:  tensor<4xi32>
-// CHECK:         %[[SELECTED:.*]] = scf.if %{{.*}} -> (tensor<4xi32>) {
-// CHECK:           %[[THEN_INNER:.*]] = scf.if %{{.*}} -> (tensor<4xi32>) {
-// CHECK:             scf.yield %{{.*}} : tensor<4xi32>
+// CHECK-SAME:  i32
+// CHECK:         %[[SELECTED:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:           %[[THEN_INNER:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:             scf.yield %{{.*}} : i32
 // CHECK:           } else {
-// CHECK:             scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:             scf.yield %{{.*}} : i32
 // CHECK:           }
-// CHECK:           tt.addptr %{{.*}}, %[[THEN_INNER]] : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
-// CHECK:           scf.yield %[[THEN_INNER]] : tensor<4xi32>
+// CHECK:           PointerDescriptorOffsetForm = "strided_1d"
+// CHECK-SAME:      PointerDescriptorRebuild
+// CHECK:           scf.yield %[[THEN_INNER]] : i32
 // CHECK:         } else {
-// CHECK:           %[[ELSE_INNER:.*]] = scf.if %{{.*}} -> (tensor<4xi32>) {
-// CHECK:             scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:           %[[ELSE_INNER:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:             scf.yield %{{.*}} : i32
 // CHECK:           } else {
-// CHECK:             scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:             scf.yield %{{.*}} : i32
 // CHECK:           }
-// CHECK:           tt.addptr %{{.*}}, %[[ELSE_INNER]] : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
-// CHECK:           scf.yield %[[ELSE_INNER]] : tensor<4xi32>
+// CHECK:           PointerDescriptorOffsetForm = "strided_1d"
+// CHECK-SAME:      PointerDescriptorRebuild
+// CHECK:           scf.yield %[[ELSE_INNER]] : i32
 // CHECK:         }
-// CHECK:         arith.addi %{{.*}}, %{{.*}} : tensor<4xi32>
+// CHECK:         arith.addi %{{.*}}, %{{.*}} : i32
 // CHECK:         tt.addptr %{{.*}}, %{{.*}} : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
 // CHECK:         %[[LOADED:.*]] = tt.load %{{.*}} : tensor<4x!tt.ptr<f32>>
-// CHECK:         scf.yield %{{.*}}, %[[LOADED]] : tensor<4xi32>, tensor<4xf32>
+// CHECK:         scf.yield %{{.*}}, %[[LOADED]] : i32, tensor<4xf32>
 // CHECK:       }
 // CHECK:       tt.return %[[FOR]]#1 : tensor<4xf32>
 
@@ -697,16 +712,21 @@ module {
   }
 }
 
-// CHECK-LABEL: tt.func public @if_block_ptr_same_base_dynamic_shape
+// CHECK-LABEL: tt.func public @if_block_ptr_same_base_dynamic_shape(
+// CHECK-SAME:  %[[BASE:[^ ,]+]]: !tt.ptr<f32>
+// CHECK:       %[[BASE_ADDRESS:.*]] = tt.ptr_to_int %[[BASE]]
 // CHECK:       %[[SHAPE:.*]] = scf.if %{{.*}} -> (i64) {
 // CHECK:         scf.yield %{{.*}} : i64
 // CHECK:       } else {
 // CHECK:         scf.yield %{{.*}} : i64
 // CHECK:       }
-// CHECK:       tt.make_tensor_ptr %{{.*}}, [%[[SHAPE]]], [%{{.*}}], [%{{.*}}] {order = array<i32: 0>} : <tensor<16xf32>>
+// CHECK-NOT:   tt.int_to_ptr %[[BASE_ADDRESS]]
+// CHECK:       tt.make_tensor_ptr %[[BASE]], [%[[SHAPE]]], [%{{.*}}], [%{{.*}}] {PointerDescriptorRebuild, order = array<i32: 0>} : <tensor<16xf32>>
+
+// -----
 
 module {
-  tt.func public @if_same_nested_result_not_decoupled(%base: !tt.ptr<f32>, %cond0: i1, %cond1: i1) -> !tt.ptr<tensor<16xf32>> {
+  tt.func public @if_same_nested_result_fully_decoupled(%base: !tt.ptr<f32>, %cond0: i1, %cond1: i1) -> !tt.ptr<tensor<16xf32>> {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
     %c2_i32 = arith.constant 2 : i32
@@ -729,19 +749,17 @@ module {
   }
 }
 
-// CHECK-LABEL: tt.func public @if_same_nested_result_not_decoupled
+// CHECK-LABEL: tt.func public @if_same_nested_result_fully_decoupled
 // CHECK:       %[[INNER_OFF:.*]] = scf.if %{{.*}} -> (i32) {
 // CHECK:         scf.yield %{{.*}} : i32
 // CHECK:       } else {
 // CHECK:         scf.yield %{{.*}} : i32
 // CHECK:       }
-// CHECK:       %[[INNER_PTR:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[INNER_OFF]]] {order = array<i32: 0>} : <tensor<16xf32>>
-// CHECK:       %[[OUTER:.*]] = scf.if %{{.*}} -> (!tt.ptr<tensor<16xf32>>) {
-// CHECK:         scf.yield %[[INNER_PTR]] : !tt.ptr<tensor<16xf32>>
-// CHECK:       } else {
-// CHECK:         scf.yield %[[INNER_PTR]] : !tt.ptr<tensor<16xf32>>
-// CHECK:       }
-// CHECK:       tt.return %[[OUTER]] : !tt.ptr<tensor<16xf32>>
+// CHECK:       scf.if %{{.*}} {
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:  }
+// CHECK:       %[[OUTER_PTR:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[INNER_OFF]]] {PointerDescriptorRebuild, order = array<i32: 0>}
+// CHECK:       tt.return %[[OUTER_PTR]] : !tt.ptr<tensor<16xf32>>
 
 // -----
 
@@ -770,13 +788,13 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @if_mixed_block_and_tensor_ptr
-// CHECK:       %[[RESULT:.*]]:2 = scf.if %{{.*}} -> (i32, tensor<4xi32>) {
-// CHECK:         scf.yield %{{.*}}, %{{.*}} : i32, tensor<4xi32>
+// CHECK:       %[[RESULT:.*]]:2 = scf.if %{{.*}} -> (i32, i32) {
+// CHECK:         scf.yield %{{.*}}, %{{.*}} : i32, i32
 // CHECK:       } else {
-// CHECK:         scf.yield %{{.*}}, %{{.*}} : i32, tensor<4xi32>
+// CHECK:         scf.yield %{{.*}}, %{{.*}} : i32, i32
 // CHECK:       }
-// CHECK-DAG:   %[[BLOCK:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[RESULT]]#0] {order = array<i32: 0>} : <tensor<16xf16>>
-// CHECK-DAG:   %[[TENSOR:.*]] = tt.addptr %{{.*}}, %[[RESULT]]#1 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+// CHECK-DAG:   %[[BLOCK:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[RESULT]]#0] {PointerDescriptorRebuild, order = array<i32: 0>} : <tensor<16xf16>>
+// CHECK-DAG:   %[[TENSOR:.*]] = tt.addptr %{{.*}}, %{{.*}} {{.*}}PointerDescriptorOffsetForm = "strided_1d"{{.*}}PointerDescriptorRebuild{{.*}} : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
 // CHECK:       tt.return %[[BLOCK]], %[[TENSOR]] : !tt.ptr<tensor<16xf16>>, tensor<4x!tt.ptr<f32>>
 
 // -----
@@ -809,7 +827,7 @@ module {
 // CHECK-SAME:    -> (i32) {
 // CHECK:           scf.yield %{{.*}} : i32
 // CHECK:         }
-// CHECK:         %[[PTR:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[FOR]]] {order = array<i32: 0>} : <tensor<16xf16>>
+// CHECK:         %[[PTR:.*]] = tt.make_tensor_ptr %{{.*}}, [%{{.*}}], [%{{.*}}], [%[[FOR]]] {{.*}}order = array<i32: 0>{{.*}} : <tensor<16xf16>>
 // CHECK:         tt.load %[[PTR]] : !tt.ptr<tensor<16xf16>>
 // CHECK:       }
 
@@ -842,15 +860,16 @@ module {
 }
 
 // CHECK-LABEL: tt.func public @sibling_if_result_initializes_for_tensor_ptr
-// CHECK:       %[[IF_OFFSETS:.*]] = scf.if %{{.*}} -> (tensor<4xi32>) {
-// CHECK:         scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:       %[[IF_OFFSETS:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:         scf.yield %{{.*}} : i32
 // CHECK:       } else {
-// CHECK:         scf.yield %{{.*}} : tensor<4xi32>
+// CHECK:         scf.yield %{{.*}} : i32
 // CHECK:       }
-// CHECK:       tt.addptr %{{.*}}, %[[IF_OFFSETS]] : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+// CHECK:       PointerDescriptorOffsetForm = "strided_1d"
+// CHECK-SAME:  PointerDescriptorRebuild
 // CHECK:       %[[FOR_OFFSETS:.*]] = scf.for
-// CHECK-SAME:  -> (tensor<4xi32>) {
-// CHECK:         scf.yield %{{.*}} : tensor<4xi32>
+// CHECK-SAME:  -> (i32) {
+// CHECK:         scf.yield %{{.*}} : i32
 // CHECK:       }
-// CHECK:       %[[FINAL:.*]] = tt.addptr %{{.*}}, %[[FOR_OFFSETS]] : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+// CHECK:       %[[FINAL:.*]] = tt.addptr %{{.*}}, %{{.*}} {{.*}}PointerDescriptorOffsetForm = "strided_1d"{{.*}}PointerDescriptorRebuild{{.*}} : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
 // CHECK:       tt.return %[[FINAL]] : tensor<4x!tt.ptr<f32>>

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scope_pointer_decouple.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scope_pointer_decouple.mlir
@@ -1,0 +1,208 @@
+// RUN: triton-opt --triton-control-flow-opt --split-input-file %s -verify-each | FileCheck %s --check-prefix=CFO
+
+module {
+  tt.func public @scope_block_ptr_result(%base: !tt.ptr<f16>, %delta: i32) -> !tt.ptr<tensor<32xf16>> {
+    %c1_i64 = arith.constant 1 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %result = scope.scope : () -> (!tt.ptr<tensor<32xf16>>) {
+      %pointer = tt.make_tensor_ptr %base, [%c32_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<32xf16>>
+      %next = tt.advance %pointer, [%delta] : !tt.ptr<tensor<32xf16>>
+      scope.return %next : !tt.ptr<tensor<32xf16>>
+    } {hivm.disable_auto_sync = true, hivm.tcore_type = #hivm.tcore_type<VECTOR>, noinline, scope_test_attr = "kept"}
+    tt.return %result : !tt.ptr<tensor<32xf16>>
+  }
+}
+
+// CFO-LABEL: tt.func public @scope_block_ptr_result
+// CFO:       %[[SCOPE:.*]]:4 = scope.scope : () -> (i64, i64, i64, i32) {
+// CFO:         scope.return %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i64, i64, i32
+// CFO:       } {hivm.disable_auto_sync = true, hivm.tcore_type = #hivm.tcore_type<VECTOR>, noinline, scope_test_attr = "kept"}
+// CFO:       tt.make_tensor_ptr
+// CFO-SAME:  PointerDescriptorRebuild
+// CFO-NOT:   PointerDescriptorBoundary
+
+// -----
+
+module {
+  tt.func public @scope_block_ptr_mixed_results(%base: !tt.ptr<f16>) -> !tt.ptr<tensor<16xf16>> {
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %results:3 = scope.scope : () -> (i32, !tt.ptr<tensor<16xf16>>, tensor<4xi32>) {
+      %ordinary = arith.constant 7 : i32
+      %tensor = arith.constant dense<9> : tensor<4xi32>
+      %pointer = tt.make_tensor_ptr %base, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf16>>
+      scope.return %ordinary, %pointer, %tensor : i32, !tt.ptr<tensor<16xf16>>, tensor<4xi32>
+    }
+    tt.return %results#1 : !tt.ptr<tensor<16xf16>>
+  }
+}
+
+// CFO-LABEL: tt.func public @scope_block_ptr_mixed_results
+// CFO:       %[[SCOPE:.*]]:6 = scope.scope : () -> (i32, i64, i64, i64, i32, tensor<4xi32>) {
+// CFO:         scope.return %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i32, i64, i64, i64, i32, tensor<4xi32>
+// CFO:       }
+// CFO:       %[[POINTER:.*]] = tt.make_tensor_ptr
+// CFO-SAME:  PointerDescriptorRebuild
+// CFO:       tt.return %[[POINTER]] : !tt.ptr<tensor<16xf16>>
+
+// -----
+
+module {
+  tt.func public @scope_tensor_ptr_scalar_base(%base: !tt.ptr<f32>) -> tensor<4x!tt.ptr<f32>> {
+    %range = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %base_tensor = tt.splat %base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %result = scope.scope : () -> (tensor<4x!tt.ptr<f32>>) {
+      %pointer = tt.addptr %base_tensor, %range : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scope.return %pointer : tensor<4x!tt.ptr<f32>>
+    }
+    tt.return %result : tensor<4x!tt.ptr<f32>>
+  }
+}
+
+// CFO-LABEL: tt.func public @scope_tensor_ptr_scalar_base
+// CFO:       %[[SCOPE:.*]]:4 = scope.scope
+// CFO-SAME:  -> (i64, i32, i32, tensor<4xi32>)
+// CFO:         scope.return %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i32, i32, tensor<4xi32>
+// CFO:       }
+// CFO:       %[[POINTER:.*]] = tt.addptr
+// CFO-SAME:  PointerDescriptorOffsetForm = "strided_1d"
+// CFO-SAME:  PointerDescriptorRebuild
+// CFO-SAME:  PointerDescriptorStructuredAxes = array<i32: 1>
+// CFO:       tt.return %[[POINTER]] : tensor<4x!tt.ptr<f32>>
+
+// -----
+
+module {
+  tt.func public @scope_tensor_ptr_external_opaque_base(%lhs_base: !tt.ptr<f32>, %rhs_base: !tt.ptr<f32>, %cond: i1) -> tensor<4x!tt.ptr<f32>> {
+    %lhs = tt.splat %lhs_base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %rhs = tt.splat %rhs_base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %condition = tt.splat %cond : i1 -> tensor<4xi1>
+    %opaque = arith.select %condition, %lhs, %rhs : tensor<4xi1>, tensor<4x!tt.ptr<f32>>
+    %delta = arith.constant dense<3> : tensor<4xi32>
+    %result = scope.scope : () -> (tensor<4x!tt.ptr<f32>>) {
+      %pointer = tt.addptr %opaque, %delta : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scope.return %pointer : tensor<4x!tt.ptr<f32>>
+    }
+    tt.return %result : tensor<4x!tt.ptr<f32>>
+  }
+}
+
+// CFO-LABEL: tt.func public @scope_tensor_ptr_external_opaque_base
+// CFO:       %[[OPAQUE:.*]] = arith.select
+// CFO:       %[[SCOPE:.*]]:3 = scope.scope
+// CFO-SAME:  -> (i32, i32, tensor<4xi32>)
+// CFO:         scope.return
+// CFO:       }
+// CFO:       %[[REBUILT:.*]] = tt.addptr %[[OPAQUE]],
+// CFO-SAME:  PointerDescriptorRebuild
+// CFO-NOT:   PointerDescriptorOffsetForm
+// CFO:       tt.return %[[REBUILT]] : tensor<4x!tt.ptr<f32>>
+
+// -----
+
+module {
+  tt.func public @scope_contains_pointer_for(%base: !tt.ptr<f16>) -> !tt.ptr<tensor<16xf16>> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %result = scope.scope : () -> (!tt.ptr<tensor<16xf16>>) {
+      %initial = tt.make_tensor_ptr %base, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf16>>
+      %final = scf.for %iv = %c0 to %c2 step %c1 iter_args(%pointer = %initial) -> (!tt.ptr<tensor<16xf16>>) {
+        %next = tt.advance %pointer, [%c1_i32] : !tt.ptr<tensor<16xf16>>
+        scf.yield %next : !tt.ptr<tensor<16xf16>>
+      }
+      scope.return %final : !tt.ptr<tensor<16xf16>>
+    } {scope_test_attr = "outer"}
+    tt.return %result : !tt.ptr<tensor<16xf16>>
+  }
+}
+
+// CFO-LABEL: tt.func public @scope_contains_pointer_for
+// CFO:       scope.scope
+// CFO:         scf.for
+// CFO-SAME:    -> (i32)
+// CFO:         } {PointerDescriptorBoundary = array<i32: 0>}
+// CFO:       } {scope_test_attr = "outer"}
+
+// -----
+
+module {
+  tt.func public @nested_scope_pointer_result(%base: !tt.ptr<f16>) -> !tt.ptr<tensor<16xf16>> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %outer = scope.scope : () -> (!tt.ptr<tensor<16xf16>>) {
+      %inner = scope.scope : () -> (!tt.ptr<tensor<16xf16>>) {
+        %pointer = tt.make_tensor_ptr %base, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf16>>
+        scope.return %pointer : !tt.ptr<tensor<16xf16>>
+      } {scope_test_attr = "inner"}
+      %next = tt.advance %inner, [%c1_i32] : !tt.ptr<tensor<16xf16>>
+      scope.return %next : !tt.ptr<tensor<16xf16>>
+    } {scope_test_attr = "outer"}
+    tt.return %outer : !tt.ptr<tensor<16xf16>>
+  }
+}
+
+// CFO-LABEL: tt.func public @nested_scope_pointer_result
+// CFO:       scope.scope : () -> (i64, i64, i64, i32) {
+// CFO:         scope.scope : () -> (i64, i64, i64, i32) {
+// CFO:         } {scope_test_attr = "inner"}
+// CFO:       } {scope_test_attr = "outer"}
+
+// -----
+
+module {
+  tt.func public @resultless_scope_contains_pointer_if(%base: !tt.ptr<f16>, %cond: i1) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    scope.scope : () -> () {
+      %initial = tt.make_tensor_ptr %base, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf16>>
+      %selected = scf.if %cond -> (!tt.ptr<tensor<16xf16>>) {
+        %then = tt.advance %initial, [%c1_i32] : !tt.ptr<tensor<16xf16>>
+        scf.yield %then : !tt.ptr<tensor<16xf16>>
+      } else {
+        %else = tt.advance %initial, [%c2_i32] : !tt.ptr<tensor<16xf16>>
+        scf.yield %else : !tt.ptr<tensor<16xf16>>
+      }
+      %loaded = tt.load %selected : !tt.ptr<tensor<16xf16>>
+      scope.return
+    } {scope_test_attr = "resultless"}
+    tt.return
+  }
+}
+
+// CFO-LABEL: tt.func public @resultless_scope_contains_pointer_if
+// CFO:       scope.scope : () -> () {
+// CFO:         scf.if
+// CFO-SAME:    -> (i32)
+// CFO:         tt.load
+// CFO:       } {scope_test_attr = "resultless"}
+
+// -----
+
+module {
+  tt.func public @scope_attributes_preserved(%base: !tt.ptr<f16>) -> !tt.ptr<tensor<16xf16>> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %result = scope.scope : () -> (!tt.ptr<tensor<16xf16>>) {
+      %pointer = tt.make_tensor_ptr %base, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf16>>
+      scope.return %pointer : !tt.ptr<tensor<16xf16>>
+    } {hivm.disable_auto_sync = true, hivm.tcore_type = #hivm.tcore_type<VECTOR>, noinline, scope_test_attr = "all-preserved"}
+    tt.return %result : !tt.ptr<tensor<16xf16>>
+  }
+}
+
+// CFO-LABEL: tt.func public @scope_attributes_preserved
+// CFO:       scope.scope : () -> (i64, i64, i64, i32) {
+// CFO:       } {hivm.disable_auto_sync = true, hivm.tcore_type = #hivm.tcore_type<VECTOR>, noinline, scope_test_attr = "all-preserved"}

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scope_pointer_downstream.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scope_pointer_downstream.mlir
@@ -1,0 +1,51 @@
+// RUN: triton-opt --triton-control-flow-opt --triton-to-unstructure --triton-to-linalg --split-input-file %s -verify-each | FileCheck %s --check-prefix=E2E --implicit-check-not='!tt.ptr' --implicit-check-not=unrealized_conversion_cast --implicit-check-not=PointerDescriptorBoundary --implicit-check-not=PointerDescriptorRebuild --implicit-check-not=PointerDescriptorOffsetForm --implicit-check-not=PointerDescriptorStructuredAxes
+
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @scope_block_ptr_load_store(%base: !tt.ptr<f32>, %output: !tt.ptr<f32>) {
+    %c0_i32 = arith.constant 0 : i32
+    %c3_i32 = arith.constant 3 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %pointer = scope.scope : () -> (!tt.ptr<tensor<16xf32>>) {
+      %initial = tt.make_tensor_ptr %base, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf32>>
+      %next = tt.advance %initial, [%c3_i32] : !tt.ptr<tensor<16xf32>>
+      scope.return %next : !tt.ptr<tensor<16xf32>>
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    %value = tt.load %pointer : !tt.ptr<tensor<16xf32>>
+    %output_pointer = tt.make_tensor_ptr %output, [%c16_i64], [%c1_i64], [%c0_i32] {order = array<i32: 0>} : !tt.ptr<tensor<16xf32>>
+    tt.store %output_pointer, %value : !tt.ptr<tensor<16xf32>>
+    tt.return
+  }
+}
+
+// E2E-LABEL: func.func @scope_block_ptr_load_store
+// E2E:       scope.scope
+// E2E:       memref.copy
+// E2E:       bufferization.materialize_in_destination %{{.*}} in writable %{{.*}}
+// E2E:       return
+
+// -----
+
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @scope_tensor_ptr_masked_load_store(%base: !tt.ptr<f32>, %output: !tt.ptr<f32>) {
+    %range = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %base_tensor = tt.splat %base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %pointer = scope.scope : () -> (tensor<4x!tt.ptr<f32>>) {
+      %next = tt.addptr %base_tensor, %range : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scope.return %next : tensor<4x!tt.ptr<f32>>
+    } {hivm.tcore_type = #hivm.tcore_type<VECTOR>}
+    %mask = arith.constant dense<true> : tensor<4xi1>
+    %other = arith.constant dense<0.000000e+00> : tensor<4xf32>
+    %value = tt.load %pointer, %mask, %other : tensor<4x!tt.ptr<f32>>
+    %output_tensor = tt.splat %output : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %output_pointer = tt.addptr %output_tensor, %range : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    tt.store %output_pointer, %value, %mask : tensor<4x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// E2E-LABEL: func.func @scope_tensor_ptr_masked_load_store
+// E2E:       scope.scope
+// E2E:       memref.copy
+// E2E:       bufferization.materialize_in_destination %{{.*}} in writable %{{.*}}
+// E2E:       return

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scope_pointer_unsupported.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scope_pointer_unsupported.mlir
@@ -1,0 +1,20 @@
+// RUN: triton-opt --triton-control-flow-opt %s -verify-each | FileCheck %s --check-prefix=FALLBACK
+
+module {
+  tt.func public @scope_internal_opaque_tensor_pointer(%lhs_base: !tt.ptr<f32>, %rhs_base: !tt.ptr<f32>, %cond: i1) -> tensor<4x!tt.ptr<f32>> {
+    %lhs = tt.splat %lhs_base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %rhs = tt.splat %rhs_base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %condition = tt.splat %cond : i1 -> tensor<4xi1>
+    %result = scope.scope : () -> (tensor<4x!tt.ptr<f32>>) {
+      %opaque = arith.select %condition, %lhs, %rhs : tensor<4xi1>, tensor<4x!tt.ptr<f32>>
+      scope.return %opaque : tensor<4x!tt.ptr<f32>>
+    }
+    tt.return %result : tensor<4x!tt.ptr<f32>>
+  }
+}
+
+// FALLBACK-LABEL: tt.func public @scope_internal_opaque_tensor_pointer
+// FALLBACK:       scope.scope
+// FALLBACK-SAME:  tensor<4x!tt.ptr<f32>>
+// FALLBACK:       arith.select
+// FALLBACK:       tt.return

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/tensor_ptr_different_base_invalid.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/tensor_ptr_different_base_invalid.mlir
@@ -1,22 +1,63 @@
-// RUN: not triton-opt --triton-control-flow-opt %s 2>&1 | FileCheck %s
+// RUN: triton-opt --triton-control-flow-opt %s -verify-each | FileCheck %s --check-prefix=CFO
+// RUN: triton-opt --triton-control-flow-opt --triton-to-unstructure %s -verify-each | FileCheck %s --check-prefix=T2U --implicit-check-not='tensor.extract {{.*}} : tensor<4x!tt.ptr<f32>>'
+// RUN: triton-opt --triton-control-flow-opt '--triton-to-unstructure=compile-on-910-95=True compile-mode=simd_simt_template' %s -verify-each | FileCheck %s --check-prefix=T2U --implicit-check-not='tensor.extract {{.*}} : tensor<4x!tt.ptr<f32>>'
+// RUN: triton-opt --triton-control-flow-opt --triton-to-unstructure --triton-to-linalg %s -verify-each | FileCheck %s --check-prefix=LINALG --implicit-check-not='!tt.ptr' --implicit-check-not=unrealized_conversion_cast --implicit-check-not=PointerDescriptorBoundary --implicit-check-not=PointerDescriptorRebuild --implicit-check-not=PointerDescriptorOffsetForm
 
-module {
-  tt.func public @if_tensor_ptr_different_base(%base0: !tt.ptr<f32>, %base1: !tt.ptr<f32>, %cond: i1) -> tensor<4x!tt.ptr<f32>> {
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @if_tensor_ptr_different_base(
+      %base0: !tt.ptr<f32>, %base1: !tt.ptr<f32>,
+      %output: !tt.ptr<f32>, %cond: i1) {
     %c1_i32 = arith.constant 1 : i32
     %c2_i32 = arith.constant 2 : i32
     %off1 = tt.splat %c1_i32 : i32 -> tensor<4xi32>
     %off2 = tt.splat %c2_i32 : i32 -> tensor<4xi32>
-    %splat0 = tt.splat %base0 : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
-    %splat1 = tt.splat %base1 : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
     %selected = scf.if %cond -> (tensor<4x!tt.ptr<f32>>) {
+      %splat0 = tt.splat %base0 : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
       %then_ptr = tt.addptr %splat0, %off1 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
       scf.yield %then_ptr : tensor<4x!tt.ptr<f32>>
     } else {
+      %splat1 = tt.splat %base1 : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
       %else_ptr = tt.addptr %splat1, %off2 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
       scf.yield %else_ptr : tensor<4x!tt.ptr<f32>>
     }
-    tt.return %selected : tensor<4x!tt.ptr<f32>>
+    // Ownership must survive an ordinary addptr after the descriptor rebuild.
+    %post_addptr = tt.addptr %selected, %off1 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    %value = tt.load %post_addptr : tensor<4x!tt.ptr<f32>>
+    %range = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %output_splat = tt.splat %output : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %output_ptr = tt.addptr %output_splat, %range : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    tt.store %output_ptr, %value : tensor<4x!tt.ptr<f32>>
+    tt.return
   }
 }
 
-// CHECK: error: failed to analyze pointer components across control flow
+// CFO-LABEL: tt.func public @if_tensor_ptr_different_base
+// CFO-DAG:   %[[BASE0:.*]] = tt.ptr_to_int %{{.*}} : !tt.ptr<f32> -> i64
+// CFO-DAG:   %[[BASE1:.*]] = tt.ptr_to_int %{{.*}} : !tt.ptr<f32> -> i64
+// CFO:       %[[SELECTED:.*]]:2 = scf.if %{{.*}} -> (i64, i32) {
+// CFO:         scf.yield %[[BASE0]], %{{.*}} : i64, i32
+// CFO:       } else {
+// CFO:         scf.yield %[[BASE1]], %{{.*}} : i64, i32
+// CFO:       }
+// CFO:       PointerDescriptorOffsetForm = "strided_1d"
+// CFO:       PointerDescriptorRebuild
+// CFO:       tt.addptr
+// CFO:       tt.load
+// CFO:       tt.store
+
+// T2U-LABEL: tt.func public @if_tensor_ptr_different_base
+// T2U-DAG:   %[[BASE0:.*]] = tt.ptr_to_int %{{.*}} : !tt.ptr<f32> -> i64
+// T2U-DAG:   %[[BASE1:.*]] = tt.ptr_to_int %{{.*}} : !tt.ptr<f32> -> i64
+// T2U:       %[[SELECTED_BASE:.*]] = arith.select %{{.*}}, %[[BASE0]], %[[BASE1]] : i64
+// T2U:       %[[SELECTED_OFFSET:.*]] = arith.select %{{.*}}, %{{.*}}, %{{.*}} : i32
+// T2U:       %[[BASE_PTR:.*]] = tt.int_to_ptr %[[SELECTED_BASE]] : i64 -> !tt.ptr<f32>
+// T2U:       tt.addptr
+// T2U:       tt.load
+
+// LINALG-LABEL: func.func @if_tensor_ptr_different_base
+// LINALG:       arith.select
+// LINALG:       hivm.hir.pointer_cast
+// LINALG:       memref.reinterpret_cast
+// LINALG:       memref.copy
+// LINALG:       bufferization.to_tensor
+// LINALG:       return

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/scalar_pointer_select.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/scalar_pointer_select.mlir
@@ -1,0 +1,83 @@
+// RUN: triton-opt --triton-to-linalg %s -verify-each | FileCheck %s
+
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @scalar_pointer_select(%lhs: !tt.ptr<f32>, %rhs: !tt.ptr<f32>, %condition: i1) -> i64 {
+    %selected = arith.select %condition, %lhs, %rhs : !tt.ptr<f32>
+    %address = tt.ptr_to_int %selected : !tt.ptr<f32> -> i64
+    tt.return %address : i64
+  }
+
+  tt.func public @scalar_pointer_roundtrip(%address: i64) -> i64 {
+    %pointer = tt.int_to_ptr %address : i64 -> !tt.ptr<f32>
+    %roundtrip = tt.ptr_to_int %pointer : !tt.ptr<f32> -> i64
+    tt.return %roundtrip : i64
+  }
+
+  func.func @pointer_cast_static_offset(%address: i64) -> f32 {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %pointer = hivm.hir.pointer_cast(%address) [%c1] : memref<?xf32>
+    %view = memref.reinterpret_cast %pointer to offset: [1], sizes: [1], strides: [1]
+        : memref<?xf32> to memref<1xf32, strided<[1], offset: 1>>
+    %value = memref.load %view[%c0] : memref<1xf32, strided<[1], offset: 1>>
+    return %value : f32
+  }
+
+  func.func @pointer_cast_dynamic_offset_subviews(%address: i64, %offset: index, %size: index) -> f32 {
+    %c0 = arith.constant 0 : index
+    %c8 = arith.constant 8 : index
+    %pointer = hivm.hir.pointer_cast(%address) [%c8] : memref<?xf32>
+    %view = memref.reinterpret_cast %pointer to offset: [%offset], sizes: [1, 8], strides: [8, 1]
+        : memref<?xf32> to memref<1x8xf32, strided<[8, 1], offset: ?>>
+    %rank_reduced = memref.subview %view[0, 0] [1, %size] [1, 1]
+        : memref<1x8xf32, strided<[8, 1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+    %subview = memref.subview %rank_reduced[0] [%size] [1]
+        : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+    %value = memref.load %subview[%c0] : memref<?xf32, strided<[1], offset: ?>>
+    return %value : f32
+  }
+}
+
+// CHECK-LABEL: func.func @scalar_pointer_select(
+// CHECK-SAME:  %[[LHS:[^ ,]+]]: memref<?xf32>, %[[RHS:[^ ,]+]]: memref<?xf32>
+// CHECK:       %[[LHS_INDEX:.*]] = memref.extract_aligned_pointer_as_index %[[LHS]]
+// CHECK:       %[[LHS_ADDRESS:.*]] = arith.index_cast %[[LHS_INDEX]] : index to i64
+// CHECK:       %[[RHS_INDEX:.*]] = memref.extract_aligned_pointer_as_index %[[RHS]]
+// CHECK:       %[[RHS_ADDRESS:.*]] = arith.index_cast %[[RHS_INDEX]] : index to i64
+// CHECK:       %[[SELECTED:.*]] = arith.select %{{.*}}, %[[LHS_ADDRESS]], %[[RHS_ADDRESS]] : i64
+// CHECK-NOT:   arith.select {{.*}} : memref
+// CHECK-NOT:   hivm.hir.pointer_cast
+// CHECK-NOT:   memref.extract_aligned_pointer_as_index
+// CHECK:       return %[[SELECTED]] : i64
+
+// CHECK-LABEL: func.func @scalar_pointer_roundtrip(
+// CHECK-SAME:  %[[ADDRESS:[^ ,]+]]: i64
+// CHECK-NOT:   hivm.hir.pointer_cast
+// CHECK-NOT:   memref.extract_aligned_pointer_as_index
+// CHECK:       return %[[ADDRESS]] : i64
+
+// CHECK-LABEL: func.func @pointer_cast_static_offset(
+// CHECK-SAME:  %[[ADDRESS:[^ ,]+]]: i64
+// CHECK:       %[[OFFSET:.*]] = arith.constant 1 : i64
+// CHECK:       %[[BYTE_WIDTH:.*]] = arith.constant 4 : i64
+// CHECK:       %[[BYTE_OFFSET:.*]] = arith.muli %[[OFFSET]], %[[BYTE_WIDTH]] : i64
+// CHECK:       %[[REAL_ADDRESS:.*]] = arith.addi %[[ADDRESS]], %[[BYTE_OFFSET]] : i64
+// CHECK:       %[[REBASED_POINTER:.*]] = hivm.hir.pointer_cast(%[[REAL_ADDRESS]]) [%[[STATIC_CAPACITY:[A-Za-z0-9_]+]]] : memref<?xf32>
+// CHECK:       %[[VIEW:.*]] = memref.reinterpret_cast %[[REBASED_POINTER]] to offset: [0], sizes: [1], strides: [1]
+// CHECK-SAME:  to memref<1xf32, strided<[1]>>
+// CHECK:       memref.load %[[VIEW]][%{{.*}}] : memref<1xf32, strided<[1]>>
+
+// CHECK-LABEL: func.func @pointer_cast_dynamic_offset_subviews(
+// CHECK-SAME:  %[[ADDRESS:[^ ,]+]]: i64, %[[OFFSET:[^ ,]+]]: index, %[[DYNAMIC_SIZE:[^ ,]+]]: index
+// CHECK:       %[[OFFSET_I64:.*]] = arith.index_cast %[[OFFSET]] : index to i64
+// CHECK:       %[[BYTE_WIDTH:.*]] = arith.constant 4 : i64
+// CHECK:       %[[BYTE_OFFSET:.*]] = arith.muli %[[OFFSET_I64]], %[[BYTE_WIDTH]] : i64
+// CHECK:       %[[REAL_ADDRESS:.*]] = arith.addi %[[ADDRESS]], %[[BYTE_OFFSET]] : i64
+// CHECK:       %[[REBASED_POINTER:.*]] = hivm.hir.pointer_cast(%[[REAL_ADDRESS]]) [%[[DYNAMIC_CAPACITY:[A-Za-z0-9_]+]]] : memref<?xf32>
+// CHECK:       %[[VIEW:.*]] = memref.reinterpret_cast %[[REBASED_POINTER]] to offset: [0], sizes: [1, 8], strides: [8, 1]
+// CHECK-SAME:  to memref<1x8xf32, strided<[8, 1], offset: ?>>
+// CHECK:       %[[RANK_REDUCED:.*]] = memref.subview %[[VIEW]][0, 0] [1, %[[DYNAMIC_SIZE]]] [1, 1]
+// CHECK-SAME:  to memref<?xf32, strided<[1], offset: ?>>
+// CHECK:       %[[SUBVIEW:.*]] = memref.subview %[[RANK_REDUCED]][0] [%[[DYNAMIC_SIZE]]] [1]
+// CHECK-SAME:  to memref<?xf32, strided<[1], offset: ?>>
+// CHECK:       memref.load %[[SUBVIEW]][%{{.*}}] : memref<?xf32, strided<[1], offset: ?>>

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/tensor_pointer_descriptor_loop.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/tensor_pointer_descriptor_loop.mlir
@@ -1,0 +1,35 @@
+// RUN: triton-opt --triton-control-flow-opt %s -verify-each | FileCheck %s --check-prefix=CFO
+// RUN: triton-opt --triton-control-flow-opt --triton-to-unstructure --triton-to-linalg %s -verify-each | FileCheck %s --check-prefix=LINALG
+
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @tensor_pointer_descriptor_loop(
+      %base: !tt.ptr<f32>, %output: !tt.ptr<f32>, %upper: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %delta = arith.constant dense<1> : tensor<4xi32>
+    %range = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %base_tensor = tt.splat %base : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %initial = tt.addptr %base_tensor, %range : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    %final = scf.for %iv = %c0 to %upper step %c1 iter_args(%ptr = %initial) -> (tensor<4x!tt.ptr<f32>>) {
+      %next = tt.addptr %ptr, %delta : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      scf.yield %next : tensor<4x!tt.ptr<f32>>
+    }
+    %value = tt.load %final : tensor<4x!tt.ptr<f32>>
+    %output_tensor = tt.splat %output : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %output_ptr = tt.addptr %output_tensor, %range : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    tt.store %output_ptr, %value : tensor<4x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// CFO-LABEL: tt.func public @tensor_pointer_descriptor_loop
+// CFO:       scf.for
+// CFO-SAME:  i32
+// CFO:       tt.addptr {{.*}}PointerDescriptorOffsetForm = "strided_1d"
+// CFO-SAME:  PointerDescriptorStructuredAxes = array<i32: 1>
+
+// LINALG-LABEL: func.func @tensor_pointer_descriptor_loop
+// LINALG:       scf.for
+// LINALG-SAME:  i32
+// LINALG-NOT:   tensor<4x!tt.ptr
+// LINALG-NOT:   unrealized_conversion_cast

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_inttoptr_offset_reset.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_inttoptr_offset_reset.mlir
@@ -1,20 +1,22 @@
 // RUN: triton-opt "--triton-to-linalg=global-kernel=false named-ops=True" --split-input-file %s | FileCheck %s
 
-// Test that ReinterpretCastOp's result type has offset: 0 after the
-// "Calculate size of PointerCastOp precisely" optimization.
+// Test the positive static offset representation selected when a scalar
+// pointer reaches the layout-sensitive memref.copy boundary.
 //
 // When a scalar tt.addptr adds a constant offset to a tt.int_to_ptr result,
-// the conversion creates a hivm.pointer_cast + memref.reinterpret_cast with
-// the original offset in the result type. The optimization then bakes the
-// offset into the base address (realAddr = addr + offset * elemSize) and
-// creates a new ReinterpretCastOp with offset 0. The result type's strided
-// layout must also have offset 0, otherwise the op offset and type offset
-// are inconsistent.
+// the conversion retains that offset in the memref view and expands the raw
+// pointer capacity to cover both the leading offset and the eight-element
+// extent. The copy must consume that exact offset-bearing view.
 
 // CHECK-LABEL: func.func @test_inttoptr_offset_reset
-// The optimized ReinterpretCastOp must have offset 0 in the result type.
-// CHECK: memref.reinterpret_cast {{.*}} strided<[1]>
-// CHECK-NOT: memref.reinterpret_cast {{.*}} strided<[1], offset: 4>
+// CHECK: %[[EXTENT:.*]] = arith.constant 8 : index
+// CHECK: %[[LEADING_OFFSET:.*]] = arith.constant 4 : index
+// CHECK: %[[CAPACITY:.*]] = arith.addi %[[EXTENT]], %[[LEADING_OFFSET]] : index
+// CHECK: %[[POINTER:.*]] = hivm.hir.pointer_cast(%{{.*}}) [%[[CAPACITY]]] : memref<?xi32>
+// CHECK: %[[OFFSET_VIEW:.*]] = memref.reinterpret_cast %[[POINTER]] to offset: [4], sizes: [8], strides: [1]
+// CHECK-SAME: to memref<8xi32, strided<[1], offset: 4>>
+// CHECK: %[[ALLOC:.*]] = memref.alloc() : memref<8xi32>
+// CHECK: memref.copy %[[OFFSET_VIEW]], %[[ALLOC]] : memref<8xi32, strided<[1], offset: 4>> to memref<8xi32>
 
 module attributes {hacc.target = #hacc.target<"Ascend910B4">} {
   tt.func public @test_inttoptr_offset_reset(%addr_ptr: !tt.ptr<i64> {tt.divisibility = 16 : i32}, %out_ptr: !tt.ptr<i32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {

--- a/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/bubbleupoperation.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/bubbleupoperation.mlir
@@ -69,6 +69,18 @@ tt.func @test_addptr_extract_bubbleup(%a: tensor<128x!tt.ptr<f32>>, %b: tensor<1
     tt.return %1 : !tt.ptr<f32>
 }
 
+// CHECK-LABEL: tt.func @test_select_pointer_extract_bubbleup
+// CHECK: %[[CONDITION:.*]] = tensor.extract %{{.*}}[%{{.*}}] {DiscreteMemAccess} : tensor<4xi1>
+// CHECK: %[[TRUE_VALUE:.*]] = tensor.extract %{{.*}}[%{{.*}}] {DiscreteMemAccess} : tensor<4x!tt.ptr<f32>>
+// CHECK: %[[FALSE_VALUE:.*]] = tensor.extract %{{.*}}[%{{.*}}] {DiscreteMemAccess} : tensor<4x!tt.ptr<f32>>
+// CHECK: arith.select %[[CONDITION]], %[[TRUE_VALUE]], %[[FALSE_VALUE]] : !tt.ptr<f32>
+tt.func @test_select_pointer_extract_bubbleup(
+    %condition: tensor<4xi1>, %true_value: tensor<4x!tt.ptr<f32>>,
+    %false_value: tensor<4x!tt.ptr<f32>>, %i: index) -> !tt.ptr<f32> {
+    %selected = arith.select %condition, %true_value, %false_value : tensor<4xi1>, tensor<4x!tt.ptr<f32>>
+    %pointer = tensor.extract %selected[%i] : tensor<4x!tt.ptr<f32>>
+    tt.return %pointer : !tt.ptr<f32>
+}
 
 // CHECK-LABEL: tt.func @test_ceil_extract_bubbleup
 tt.func @test_ceil_extract_bubbleup(%a: tensor<128xf32>, %i: index, %c: f32) -> f32 {

--- a/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/indirect_store.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/indirect_store.mlir
@@ -56,7 +56,7 @@ tt.func public @triton_indirect_store_kernel(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr
 // @triton_indirect_store.
 // LINALG-LABEL: func.func @triton_indirect_store_int_to_ptr_kernel
 // LINALG: hivm.hir.pointer_cast(%{{.*}}) [%{{.*}}] : memref<?xf32>
-// LINALG: call @triton_indirect_store{{.*}}(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<{{.*}}xf32, strided<[1]>>, tensor<8xi64>, tensor<8xf32>) -> ()
+// LINALG: call @triton_indirect_store{{.*}}(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<1xf32, strided<[1]>>, tensor<8xi64>, tensor<8xf32>) -> ()
 tt.func public @triton_indirect_store_int_to_ptr_kernel(%arg0: !tt.ptr<i64>, %arg1: !tt.ptr<f32>) {
   %base_i64 = arith.constant 1024 : i64
   %base = tt.int_to_ptr %base_i64 : i64 -> !tt.ptr<f32>

--- a/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/tensor_pointer_select.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/tensor_pointer_select.mlir
@@ -1,0 +1,27 @@
+// RUN: triton-opt %s --triton-to-unstructure | FileCheck %s
+
+tt.func public @opaque_tensor_pointer_select(
+    %lhs: !tt.ptr<f32>, %rhs: !tt.ptr<f32>) -> tensor<4xf32> {
+  %zero = arith.constant dense<0> : tensor<4xi32>
+  %one = arith.constant dense<1> : tensor<4xi32>
+  %range = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+  %lhs_tensor = tt.splat %lhs : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+  %rhs_tensor = tt.splat %rhs : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+  %lhs_ptrs = tt.addptr %lhs_tensor, %range : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+  %rhs_ptrs = tt.addptr %rhs_tensor, %range : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+  %bits = arith.andi %range, %one : tensor<4xi32>
+  %condition = arith.cmpi eq, %bits, %zero : tensor<4xi32>
+  %selected = arith.select %condition, %lhs_ptrs, %rhs_ptrs : tensor<4xi1>, tensor<4x!tt.ptr<f32>>
+  %advanced = tt.addptr %selected, %one : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+  %loaded = tt.load %advanced : tensor<4x!tt.ptr<f32>>
+  tt.return %loaded : tensor<4xf32>
+}
+
+// CHECK-LABEL: tt.func public @opaque_tensor_pointer_select
+// CHECK:       %[[SELECTED:.*]] = arith.select {{.*}} : tensor<4xi1>, tensor<4x!tt.ptr<f32>>
+// CHECK:       scf.for
+// CHECK:       %[[LANE_PTR:.*]] = tensor.extract %[[SELECTED]]{{\[}}%{{.*}}] {DiscreteMemAccess} : tensor<4x!tt.ptr<f32>>
+// CHECK:       %[[ACCESS_PTR:.*]] = tt.addptr %[[LANE_PTR]],
+// CHECK-SAME:  : !tt.ptr<f32>, i64
+// CHECK:       tt.load %[[ACCESS_PTR]] {DiscreteMemAccess} : !tt.ptr<f32>
+// CHECK:       tt.return

--- a/third_party/ascend/unittest/pytest_ut/test_control_flow_pointer_boundary.py
+++ b/third_party/ascend/unittest/pytest_ut/test_control_flow_pointer_boundary.py
@@ -1,0 +1,428 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import re
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+import triton
+import triton.language as tl
+import triton.language.extra.cann.extension as al
+
+BLOCK = 32
+N = 128
+
+
+@triton.jit
+def block_ptr_if_descriptor_kernel(a, b, out, choose_ptr, descriptor_ptr, BLOCK: tl.constexpr):
+    choose = tl.load(choose_ptr)
+    size_a = tl.load(descriptor_ptr)
+    size_b = tl.load(descriptor_ptr + 1)
+    stride_a = tl.load(descriptor_ptr + 2)
+    stride_b = tl.load(descriptor_ptr + 3)
+    # Block-pointer offsets are required to use Triton's 32-bit index type.
+    # Keep the descriptor storage wide, but narrow the values at the frontend
+    # boundary instead of changing the product's make_block_ptr contract.
+    offset_a = tl.load(descriptor_ptr + 4).to(tl.int32)
+    offset_b = tl.load(descriptor_ptr + 5).to(tl.int32)
+    if choose != 0:
+        pointer = tl.make_block_ptr(
+            base=a + 3,
+            shape=(size_a, ),
+            strides=(stride_a, ),
+            offsets=(offset_a, ),
+            block_shape=(BLOCK, ),
+            order=(0, ),
+        )
+    else:
+        pointer = tl.make_block_ptr(
+            base=b + 11,
+            shape=(size_b, ),
+            strides=(stride_b, ),
+            offsets=(offset_b, ),
+            block_shape=(BLOCK, ),
+            order=(0, ),
+        )
+    value = tl.load(pointer, boundary_check=(0, ), padding_option="zero")
+    tl.store(out + tl.arange(0, BLOCK), value)
+
+
+@triton.jit
+def block_ptr_for_descriptor_kernel(a, b, out, scalar_out, steps_ptr, descriptor_ptr, BLOCK: tl.constexpr):
+    steps = tl.load(steps_ptr)
+    size_a = tl.load(descriptor_ptr)
+    size_b = tl.load(descriptor_ptr + 1)
+    stride_a = tl.load(descriptor_ptr + 2)
+    stride_b = tl.load(descriptor_ptr + 3)
+    pointer = tl.make_block_ptr(
+        base=a,
+        shape=(size_a, ),
+        strides=(stride_a, ),
+        offsets=(1, ),
+        block_shape=(BLOCK, ),
+        order=(0, ),
+    )
+    ordinary_result = 17
+    for i in tl.range(0, steps):
+        if (i & 1) == 0:
+            pointer = tl.advance(pointer, (2, ))
+        else:
+            pointer = tl.make_block_ptr(
+                base=b,
+                shape=(size_b, ),
+                strides=(stride_b, ),
+                offsets=(i + 3, ),
+                block_shape=(BLOCK, ),
+                order=(0, ),
+            )
+        ordinary_result = ordinary_result + i + 1
+    value = tl.load(pointer, boundary_check=(0, ), padding_option="zero")
+    tl.store(out + tl.arange(0, BLOCK), value)
+    tl.store(scalar_out, ordinary_result)
+
+
+@triton.jit
+def block_ptr_while_descriptor_kernel(a, b, out, steps_ptr, switch_at_ptr, n: tl.constexpr, BLOCK: tl.constexpr):
+    steps = tl.load(steps_ptr)
+    switch_at = tl.load(switch_at_ptr)
+    pointer = tl.make_block_ptr(
+        base=a,
+        shape=(n, ),
+        strides=(1, ),
+        offsets=(0, ),
+        block_shape=(BLOCK, ),
+        order=(0, ),
+    )
+    i = 0
+    while i < steps:
+        if i == switch_at:
+            pointer = tl.make_block_ptr(
+                base=b,
+                shape=(n - 3, ),
+                strides=(1, ),
+                offsets=(1, ),
+                block_shape=(BLOCK, ),
+                order=(0, ),
+            )
+        else:
+            pointer = tl.advance(pointer, (2, ))
+        i += 1
+    value = tl.load(pointer, boundary_check=(0, ), padding_option="zero")
+    tl.store(out + tl.arange(0, BLOCK), value)
+
+
+@triton.jit
+def scalar_base_tensor_ptr_loop_kernel(x, out, steps_ptr, n: tl.constexpr, BLOCK: tl.constexpr):
+    steps = tl.load(steps_ptr)
+    lane = tl.arange(0, BLOCK)
+    pointers = x + 3 + lane
+    for _ in tl.range(0, steps):
+        pointers = pointers + 2
+    index = 3 + lane + 2 * steps
+    value = tl.load(pointers, mask=index < n, other=0.0)
+    tl.store(out + lane, value)
+
+
+@triton.jit
+def dense_splat_tensor_ptr_loop_kernel(x, out, steps_ptr, n: tl.constexpr, BLOCK: tl.constexpr):
+    steps = tl.load(steps_ptr)
+    lane = tl.arange(0, BLOCK)
+    # Keep the loop delta tensor-valued so TTIR materializes a dense splat.
+    delta = tl.full((BLOCK, ), BLOCK, tl.int32)
+    pointers = x + lane
+    for _ in tl.range(0, steps):
+        pointers = pointers + delta
+    index = lane + BLOCK * steps
+    value = tl.load(pointers, mask=index < n, other=0.0)
+    tl.store(out + lane, value)
+
+
+@triton.jit
+def dense_splat_affine_rank1_loop_kernel(x, out, steps_ptr, n: tl.constexpr, BLOCK: tl.constexpr, STRIDE: tl.constexpr):
+    steps = tl.load(steps_ptr)
+    lane = tl.arange(0, BLOCK)
+    scale = tl.full((BLOCK, ), STRIDE, tl.int32)
+    pointers = x + lane * scale
+    for _ in tl.range(0, steps):
+        pointers += 1
+    index = lane * STRIDE + steps
+    value = tl.load(pointers, mask=index < n, other=0.0)
+    tl.store(out + lane, value)
+
+
+@triton.jit
+def dense_splat_affine_rank2_loop_kernel(x, out, steps_ptr, n: tl.constexpr, BM: tl.constexpr, BN: tl.constexpr,
+                                         ROW_STRIDE: tl.constexpr):
+    steps = tl.load(steps_ptr)
+    row = tl.arange(0, BM)[:, None]
+    col = tl.arange(0, BN)[None, :]
+    scale = tl.full((BM, BN), ROW_STRIDE, tl.int32)
+    offsets = row * scale + col
+    pointers = x + offsets
+    for _ in tl.range(0, steps):
+        pointers += 1
+    value = tl.load(pointers, mask=offsets + steps < n, other=0.0)
+    tl.store(out + row * BN + col, value)
+
+
+@triton.jit
+def broadcasted_pointer_rank2_loop_kernel(x, out, steps_ptr, BM: tl.constexpr, BN: tl.constexpr,
+                                          ROW_STRIDE: tl.constexpr):
+    steps = tl.load(steps_ptr)
+    row = tl.arange(0, BM)[:, None]
+    col = tl.arange(0, BN)[None, :]
+    # Match grouped matmul's construction order: first create a lower-rank
+    # pointer tensor, then broadcast it while adding the second axis.
+    row_pointers = x + row * ROW_STRIDE
+    pointers = row_pointers + col
+    for _ in tl.range(0, steps):
+        pointers += 1
+    value = tl.load(pointers)
+    tl.store(out + row * BN + col, value)
+
+
+@triton.jit
+def opaque_tensor_ptr_loop_kernel(a, b, out, steps_ptr, n: tl.constexpr, BLOCK: tl.constexpr):
+    steps = tl.load(steps_ptr)
+    lane = tl.arange(0, BLOCK)
+    pointers = tl.where((lane & 1) == 0, a + lane, b + lane)
+    for _ in tl.range(0, steps):
+        pointers = pointers + 1
+    index = lane + steps
+    value = tl.load(pointers, mask=index < n, other=0.0)
+    tl.store(out + lane, value)
+
+
+@triton.jit
+def scope_block_ptr_kernel(x, out, delta_ptr, n: tl.constexpr, BLOCK: tl.constexpr):
+    delta = tl.load(delta_ptr).to(tl.int32)
+    pointer = tl.make_block_ptr(
+        base=x,
+        shape=(n, ),
+        strides=(1, ),
+        offsets=(1, ),
+        block_shape=(BLOCK, ),
+        order=(0, ),
+    )
+    with al.scope(core_mode="vector", disable_auto_sync=True):
+        pointer = tl.advance(pointer, (delta, ))
+    value = tl.load(pointer, boundary_check=(0, ), padding_option="zero")
+    tl.store(out + tl.arange(0, BLOCK), value)
+
+
+@triton.jit
+def scope_tensor_ptr_kernel(x, out, delta_ptr, n: tl.constexpr, BLOCK: tl.constexpr):
+    lane = tl.arange(0, BLOCK)
+    delta = tl.load(delta_ptr)
+    pointers = x + lane
+    with al.scope(core_mode="vector"):
+        pointers = pointers + delta
+    value = tl.load(pointers, mask=lane + delta < n, other=0.0)
+    tl.store(out + lane, value)
+
+
+def _inputs():
+    a_cpu = torch.arange(2048, dtype=torch.float32)
+    b_cpu = 100000.0 + torch.arange(2048, dtype=torch.float32) * 3.0
+    return a_cpu, b_cpu, a_cpu.npu(), b_cpu.npu()
+
+
+def _device_i32(value):
+    return torch.tensor([value], dtype=torch.int32, device="npu")
+
+
+def _slice(source, base_offset, logical_size, stride, offset):
+    expected = torch.zeros(BLOCK, dtype=source.dtype)
+    for lane in range(BLOCK):
+        logical_index = offset + lane
+        if 0 <= logical_index < logical_size:
+            expected[lane] = source[base_offset + logical_index * stride]
+    return expected
+
+
+def _assert_output(actual, expected):
+    torch.npu.synchronize()
+    torch.testing.assert_close(actual.cpu(), expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("choose", [0, 1])
+def test_block_ptr_if_carries_complete_dynamic_descriptor(choose):
+    a_cpu, b_cpu, a, b = _inputs()
+    descriptor = torch.tensor([40, 29, 2, 3, 3, 5], dtype=torch.int64, device="npu")
+    choose_ptr = _device_i32(choose)
+    out = torch.empty(BLOCK, dtype=torch.float32, device="npu")
+
+    block_ptr_if_descriptor_kernel[(1, )](a, b, out, choose_ptr, descriptor, BLOCK=BLOCK)
+
+    if choose:
+        expected = _slice(a_cpu, 3, 40, 2, 3)
+    else:
+        expected = _slice(b_cpu, 11, 29, 3, 5)
+    _assert_output(out, expected)
+
+
+@pytest.mark.parametrize("steps", [0, 2, 5])
+def test_block_ptr_for_carries_changing_descriptor_and_ordinary_result(steps):
+    a_cpu, b_cpu, a, b = _inputs()
+    descriptor = torch.tensor([60, 55, 2, 3], dtype=torch.int64, device="npu")
+    out = torch.empty(BLOCK, dtype=torch.float32, device="npu")
+    scalar_out = torch.empty(1, dtype=torch.int32, device="npu")
+
+    block_ptr_for_descriptor_kernel[(1, )](a, b, out, scalar_out, _device_i32(steps), descriptor, BLOCK=BLOCK)
+
+    source, logical_size, stride, offset = a_cpu, 60, 2, 1
+    for i in range(steps):
+        if (i & 1) == 0:
+            offset += 2
+        else:
+            source, logical_size, stride, offset = b_cpu, 55, 3, i + 3
+    _assert_output(out, _slice(source, 0, logical_size, stride, offset))
+    assert scalar_out.cpu().item() == 17 + steps * (steps + 1) // 2
+
+
+@pytest.mark.parametrize("steps,switch_at", [(0, -1), (4, -1), (4, 2)])
+def test_block_ptr_while_carries_descriptor(steps, switch_at):
+    a_cpu, b_cpu, a, b = _inputs()
+    out = torch.empty(BLOCK, dtype=torch.float32, device="npu")
+
+    block_ptr_while_descriptor_kernel[(1, )](a, b, out, _device_i32(steps), _device_i32(switch_at), n=N, BLOCK=BLOCK)
+
+    source, logical_size, offset = a_cpu, N, 0
+    for i in range(steps):
+        if i == switch_at:
+            source, logical_size, offset = b_cpu, N - 3, 1
+        else:
+            offset += 2
+    _assert_output(out, _slice(source, 0, logical_size, 1, offset))
+
+
+@pytest.mark.parametrize("steps", [0, 2, 4])
+def test_scalar_base_tensor_pointer_loop(steps):
+    a_cpu, _, a, _ = _inputs()
+    out = torch.empty(BLOCK, dtype=torch.float32, device="npu")
+
+    scalar_base_tensor_ptr_loop_kernel[(1, )](a, out, _device_i32(steps), n=N, BLOCK=BLOCK)
+
+    _assert_output(out, _slice(a_cpu, 0, N, 1, 3 + 2 * steps))
+
+
+@pytest.mark.parametrize("steps", [0, 1, 3])
+def test_dense_splat_tensor_pointer_loop(steps):
+    a_cpu, _, a, _ = _inputs()
+    out = torch.empty(BLOCK, dtype=torch.float32, device="npu")
+
+    dense_splat_tensor_ptr_loop_kernel[(1, )](a, out, _device_i32(steps), n=N, BLOCK=BLOCK)
+
+    _assert_output(out, _slice(a_cpu, 0, N, 1, BLOCK * steps))
+
+
+@pytest.mark.parametrize("stride,steps", [(16, 0), (16, 3), (256, 0), (256, 3)])
+def test_dense_splat_affine_rank1_loop(stride, steps):
+    n = 8192
+    source_cpu = torch.arange(n, dtype=torch.float32)
+    source = source_cpu.npu()
+    out = torch.empty(16, dtype=torch.float32, device="npu")
+
+    dense_splat_affine_rank1_loop_kernel[(1, )](source, out, _device_i32(steps), n=n, BLOCK=16, STRIDE=stride)
+
+    expected = source_cpu[torch.arange(16) * stride + steps]
+    _assert_output(out, expected)
+
+
+@pytest.mark.parametrize("steps", [0, 2])
+def test_dense_splat_affine_rank2_loop(steps):
+    bm, bn, row_stride = 8, 16, 64
+    n = 1024
+    source_cpu = torch.arange(n, dtype=torch.float32)
+    source = source_cpu.npu()
+    out = torch.empty((bm, bn), dtype=torch.float32, device="npu")
+
+    dense_splat_affine_rank2_loop_kernel[(1, )](source, out, _device_i32(steps), n=n, BM=bm, BN=bn,
+                                                ROW_STRIDE=row_stride)
+
+    rows = torch.arange(bm)[:, None]
+    cols = torch.arange(bn)[None, :]
+    expected = source_cpu[rows * row_stride + cols + steps]
+    _assert_output(out, expected)
+
+
+@pytest.mark.parametrize("steps", [0, 2])
+def test_broadcasted_pointer_rank2_loop(steps):
+    bm, bn, row_stride = 8, 16, 64
+    n = 1024
+    source_cpu = torch.arange(n, dtype=torch.float32)
+    source = source_cpu.npu()
+    out = torch.empty((bm, bn), dtype=torch.float32, device="npu")
+
+    compiled = broadcasted_pointer_rank2_loop_kernel[(1, )](
+        source,
+        out,
+        _device_i32(steps),
+        BM=bm,
+        BN=bn,
+        ROW_STRIDE=row_stride,
+    )
+
+    rows = torch.arange(bm)[:, None]
+    cols = torch.arange(bn)[None, :]
+    expected = source_cpu[rows * row_stride + cols + steps]
+    _assert_output(out, expected)
+
+    # Before descriptor propagation, the pointer broadcast becomes an opaque
+    # tensor<8x16xi32> loop carrier even though both axes are affine.
+    adapter = compiled.asm["ttadapter"]
+    assert not re.search(r"scf\.for[^\n]*-> \(tensor<8x16xi32>\)", adapter)
+    assert re.search(r"scf\.for[^\n]*-> \(i32\)", adapter)
+
+
+@pytest.mark.parametrize("steps", [0, 2, 4])
+def test_opaque_tensor_pointer_loop(steps):
+    a_cpu, b_cpu, a, b = _inputs()
+    out = torch.empty(BLOCK, dtype=torch.float32, device="npu")
+
+    opaque_tensor_ptr_loop_kernel[(1, )](a, b, out, _device_i32(steps), n=N, BLOCK=BLOCK)
+
+    expected = torch.zeros(BLOCK, dtype=torch.float32)
+    for lane in range(BLOCK):
+        index = lane + steps
+        if index < N:
+            expected[lane] = a_cpu[index] if (lane & 1) == 0 else b_cpu[index]
+    _assert_output(out, expected)
+
+
+@pytest.mark.parametrize("delta", [0, 3, 37])
+def test_scope_block_pointer_result(delta):
+    a_cpu, _, a, _ = _inputs()
+    out = torch.empty(BLOCK, dtype=torch.float32, device="npu")
+
+    scope_block_ptr_kernel[(1, )](a, out, _device_i32(delta), n=N, BLOCK=BLOCK)
+
+    _assert_output(out, _slice(a_cpu, 0, N, 1, 1 + delta))
+
+
+@pytest.mark.parametrize("delta", [0, 2, 5])
+def test_scope_tensor_pointer_result(delta):
+    a_cpu, _, a, _ = _inputs()
+    out = torch.empty(BLOCK, dtype=torch.float32, device="npu")
+
+    scope_tensor_ptr_kernel[(1, )](a, out, _device_i32(delta), n=N, BLOCK=BLOCK)
+
+    _assert_output(out, _slice(a_cpu, 0, N, 1, delta))

--- a/third_party/ascend/unittest/pytest_ut/test_inttoptr_offset_reset.py
+++ b/third_party/ascend/unittest/pytest_ut/test_inttoptr_offset_reset.py
@@ -1,8 +1,16 @@
+import re
+
+import pytest
 import torch
 import torch_npu  # noqa: F401
 
 import triton
 import triton.language as tl
+from triton.compiler.code_generator import ast_to_ttir
+from triton.compiler.compiler import ASTSource
+from triton._C.libtriton import ir
+from triton._C.libtriton.ascend import ir as ascend_ir
+from triton.backends.ascend.compiler import NPUOptions, ttir_to_linalg
 
 
 @triton.jit
@@ -47,6 +55,86 @@ def _inttoptr_dyn_offset_kernel(
     tl.store(out + offsets, slot_ids)
 
 
+@triton.jit
+def _inttoptr_indirect_load_kernel(
+    block_table_ptrs,
+    offsets_ptr,
+    out,
+    BLOCK: tl.constexpr,
+):
+    offsets = tl.arange(0, BLOCK)
+    offsets = tl.load(offsets_ptr + offsets)
+    raw_ptr = tl.load(block_table_ptrs).to(tl.pointer_type(tl.int32))
+    raw_ptrs = tl.broadcast_to(raw_ptr, (BLOCK, ))
+    values = tl.load(raw_ptrs + offsets)
+    tl.store(out + offsets, values)
+
+
+@triton.jit
+def _inttoptr_branch_local_kernel(base_ptrs, flag_ptr, out):
+    """Use an int_to_ptr only inside each branch, without a loop backedge."""
+    raw_addr = tl.load(base_ptrs)
+    flag = tl.load(flag_ptr)
+    if flag != 0:
+        ptr = raw_addr.to(tl.pointer_type(tl.int32))
+        value = tl.load(ptr)
+    else:
+        ptr = raw_addr.to(tl.pointer_type(tl.int32)) + 4
+        value = tl.load(ptr)
+    tl.store(out, value)
+
+
+@triton.jit
+def _inttoptr_for_carrier_kernel(base_ptrs, steps_ptr, out):
+    """Carry a complete scalar pointer through a for backedge."""
+    raw_addr = tl.load(base_ptrs)
+    steps = tl.load(steps_ptr)
+    ptr = raw_addr.to(tl.pointer_type(tl.int32))
+    for _ in tl.range(0, steps):
+        ptr = ptr + 1
+    tl.store(out, tl.load(ptr))
+
+
+@triton.jit
+def _inttoptr_while_carrier_kernel(base_ptrs, steps_ptr, out):
+    """Carry the complete i64 address through a while backedge."""
+    raw_addr = tl.load(base_ptrs)
+    steps = tl.load(steps_ptr)
+    address = raw_addr
+    iteration = 0
+    while iteration < steps:
+        # The loaded address is byte-addressed; one int32 element is four bytes.
+        address = address + 4
+        iteration += 1
+    ptr = address.to(tl.pointer_type(tl.int32))
+    tl.store(out, tl.load(ptr))
+
+
+@triton.jit
+def _inttoptr_nested_if_kernel(base_ptrs, steps_ptr, flag_ptr, out):
+    """Update a complete pointer carrier on both sides of a nested if."""
+    raw_addr = tl.load(base_ptrs)
+    steps = tl.load(steps_ptr)
+    flag = tl.load(flag_ptr)
+    ptr = raw_addr.to(tl.pointer_type(tl.int32))
+    for iteration in tl.range(0, steps):
+        if flag != 0:
+            ptr = ptr + 1
+        else:
+            ptr = ptr + 2
+    tl.store(out, tl.load(ptr))
+
+
+def _compile_to_adapter(kernel, signature, constants):
+    src = ASTSource(kernel, signature, constants)
+    context = ir.context()
+    ir.load_dialects(context)
+    ascend_ir.load_dialects(context)
+    options = NPUOptions()
+    ttir = ast_to_ttir(kernel, src, context, options, {}, {})
+    return str(ttir_to_linalg(ttir, {**options.__dict__}, options, named_ops=True))
+
+
 def test_inttoptr_static_offset_reset():
     """Static offset (constant 1) baked into base address."""
     block = 8
@@ -68,6 +156,88 @@ def test_inttoptr_static_offset_reset():
     # offset 1 => skip block_table[0]
     expected = block_table_cpu[1:1 + block].to(torch.int64)
     torch.testing.assert_close(out.cpu(), expected.cpu())
+
+
+def test_inttoptr_indirect_load_uses_scalar_view():
+    """An opaque int_to_ptr tensor load keeps the one-element carrier view."""
+    adapter = _compile_to_adapter(
+        _inttoptr_indirect_load_kernel,
+        {"block_table_ptrs": "*i64", "offsets_ptr": "*i32", "out": "*i32"},
+        {"BLOCK": 8},
+    )
+    assert "hivm.hir.pointer_cast" in adapter
+    assert "annotation.mark" in adapter
+    assert "memref.reinterpret_cast" in adapter
+    assert re.search(r"memref<1xi32, strided<\[1\]>>", adapter)
+
+
+def test_inttoptr_indirect_load_scalar_view_npu():
+    """A runtime int_to_ptr base keeps its one-element view in the helper ABI."""
+    source_cpu = torch.arange(16, dtype=torch.int32)
+    source = source_cpu.npu()
+    base_ptrs = torch.tensor([source.data_ptr()], dtype=torch.int64).npu()
+    offsets = torch.arange(8, dtype=torch.int32).npu()
+    out = torch.empty(8, dtype=torch.int32, device="npu")
+
+    _inttoptr_indirect_load_kernel[(1, )](base_ptrs, offsets, out, BLOCK=8)
+    torch.npu.synchronize()
+    torch.testing.assert_close(out.cpu(), source_cpu[:8])
+
+
+@pytest.mark.parametrize("flag", [0, 1])
+def test_inttoptr_branch_local(flag):
+    source_cpu = torch.arange(16, dtype=torch.int32)
+    source = source_cpu.npu()
+    base_ptrs = torch.tensor([source.data_ptr()], dtype=torch.int64).npu()
+    flag_ptr = torch.tensor([flag], dtype=torch.int32).npu()
+    out = torch.empty(1, dtype=torch.int32, device="npu")
+
+    _inttoptr_branch_local_kernel[(1, )](base_ptrs, flag_ptr, out)
+    torch.npu.synchronize()
+    expected = source_cpu[0 if flag else 4:1 if flag else 5]
+    torch.testing.assert_close(out.cpu(), expected)
+
+
+@pytest.mark.parametrize("steps", [0, 1, 4])
+def test_inttoptr_for_carrier(steps):
+    source_cpu = torch.arange(32, dtype=torch.int32)
+    source = source_cpu.npu()
+    base_ptrs = torch.tensor([source.data_ptr()], dtype=torch.int64).npu()
+    steps_ptr = torch.tensor([steps], dtype=torch.int32).npu()
+    out = torch.empty(1, dtype=torch.int32, device="npu")
+
+    _inttoptr_for_carrier_kernel[(1, )](base_ptrs, steps_ptr, out)
+    torch.npu.synchronize()
+    torch.testing.assert_close(out.cpu(), source_cpu[steps:steps + 1])
+
+
+@pytest.mark.parametrize("steps", [0, 1, 4])
+def test_inttoptr_while_carrier(steps):
+    source_cpu = torch.arange(32, dtype=torch.int32)
+    source = source_cpu.npu()
+    base_ptrs = torch.tensor([source.data_ptr()], dtype=torch.int64).npu()
+    steps_ptr = torch.tensor([steps], dtype=torch.int32).npu()
+    out = torch.empty(1, dtype=torch.int32, device="npu")
+
+    _inttoptr_while_carrier_kernel[(1, )](base_ptrs, steps_ptr, out)
+    torch.npu.synchronize()
+    torch.testing.assert_close(out.cpu(), source_cpu[steps:steps + 1])
+
+
+@pytest.mark.parametrize("flag", [0, 1])
+@pytest.mark.parametrize("steps", [0, 1, 4])
+def test_inttoptr_nested_if(flag, steps):
+    source_cpu = torch.arange(32, dtype=torch.int32)
+    source = source_cpu.npu()
+    base_ptrs = torch.tensor([source.data_ptr()], dtype=torch.int64).npu()
+    steps_ptr = torch.tensor([steps], dtype=torch.int32).npu()
+    flag_ptr = torch.tensor([flag], dtype=torch.int32).npu()
+    out = torch.empty(1, dtype=torch.int32, device="npu")
+
+    _inttoptr_nested_if_kernel[(1, )](base_ptrs, steps_ptr, flag_ptr, out)
+    torch.npu.synchronize()
+    offset = steps if flag else 2 * steps
+    torch.testing.assert_close(out.cpu(), source_cpu[offset:offset + 1])
 
 
 def test_inttoptr_dyn_offset_reset():

--- a/third_party/ascend/unittest/pytest_ut/test_scalar_pointer_control_flow.py
+++ b/third_party/ascend/unittest/pytest_ut/test_scalar_pointer_control_flow.py
@@ -1,0 +1,235 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+import triton
+import triton.language as tl
+
+BLOCK = 16
+INPUT_SIZE = 256
+
+
+@triton.jit
+def scalar_pointer_if_kernel(x, out, predicate_ptr):
+    predicate = tl.load(predicate_ptr)
+    if predicate != 0:
+        pointer = x + 3
+    else:
+        pointer = x + 11
+    tl.store(out, tl.load(pointer))
+
+
+@triton.jit
+def scalar_pointer_for_kernel(x, out, steps_ptr):
+    steps = tl.load(steps_ptr)
+    pointer = x + 2
+    for _ in tl.range(0, steps):
+        pointer = pointer + 3
+    tl.store(out, tl.load(pointer))
+
+
+@triton.jit
+def scalar_pointer_while_kernel(x, out, steps_ptr):
+    steps = tl.load(steps_ptr)
+    pointer = x + 1
+    iteration = 0
+    while iteration < steps:
+        pointer = pointer + 2
+        iteration += 1
+    tl.store(out, tl.load(pointer))
+
+
+@triton.jit
+def scalar_pointer_nested_if_for_kernel(x, out, predicate_ptr, steps_ptr):
+    predicate = tl.load(predicate_ptr)
+    steps = tl.load(steps_ptr)
+    pointer = x
+    for iteration in tl.range(0, steps):
+        if (iteration & 1) == predicate:
+            pointer = pointer + 2
+        else:
+            pointer = pointer + 1
+    tl.store(out, tl.load(pointer))
+
+
+@triton.jit
+def scalar_pointer_select_loop_kernel(x0, x1, out, predicate_ptr, steps_ptr):
+    predicate = tl.load(predicate_ptr)
+    steps = tl.load(steps_ptr)
+    pointer = tl.where(predicate != 0, x0 + 4, x1 + 7)
+    for _ in tl.range(0, steps):
+        pointer = pointer + 2
+    tl.store(out, tl.load(pointer))
+
+
+@triton.jit
+def tensor_pointer_loop_kernel(tensor_source, tensor_out, steps_ptr, BLOCK: tl.constexpr):
+    """Exercise one tensor-of-pointers loop carrier across several iterations."""
+    steps = tl.load(steps_ptr)
+    lane = tl.arange(0, BLOCK)
+    tensor_pointer = tensor_source + lane + 6
+    for _ in tl.range(0, steps):
+        tensor_pointer += 2
+    tl.store(tensor_out + lane, tl.load(tensor_pointer))
+
+
+@triton.jit
+def descriptor_boundary_scalar_kernel(x0, x1, out, steps_ptr, switch_at_ptr, N: tl.constexpr, BLOCK: tl.constexpr):
+    steps = tl.load(steps_ptr)
+    switch_at = tl.load(switch_at_ptr)
+    pointer = tl.make_block_ptr(
+        base=x0,
+        shape=(N, ),
+        strides=(1, ),
+        offsets=(0, ),
+        block_shape=(BLOCK, ),
+        order=(0, ),
+    )
+    for iteration in tl.range(0, steps):
+        if iteration == switch_at:
+            pointer = tl.make_block_ptr(
+                base=x1,
+                shape=(N, ),
+                strides=(1, ),
+                offsets=(4, ),
+                block_shape=(BLOCK, ),
+                order=(0, ),
+            )
+        else:
+            pointer = tl.advance(pointer, (1, ))
+    value = tl.load(pointer, boundary_check=(0, ), padding_option="zero")
+    tl.store(out + tl.arange(0, BLOCK), value)
+
+
+def _inputs():
+    x0_cpu = torch.arange(INPUT_SIZE, dtype=torch.float32)
+    x1_cpu = 1000.0 + 2.0 * torch.arange(INPUT_SIZE, dtype=torch.float32)
+    return x0_cpu, x1_cpu, x0_cpu.npu(), x1_cpu.npu()
+
+
+def _device_i32(value):
+    return torch.tensor([value], dtype=torch.int32, device="npu")
+
+
+def _assert_output(actual, expected):
+    torch.npu.synchronize()
+    torch.testing.assert_close(actual.cpu(), expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("predicate", [0, 1])
+def test_scalar_pointer_if_yield(predicate):
+    x0_cpu, _, x0, _ = _inputs()
+    out = torch.empty(1, dtype=torch.float32, device="npu")
+
+    scalar_pointer_if_kernel[(1, )](x0, out, _device_i32(predicate))
+
+    expected_index = 3 if predicate else 11
+    _assert_output(out, x0_cpu[expected_index:expected_index + 1])
+
+
+@pytest.mark.parametrize("steps", [0, 1, 4])
+def test_scalar_pointer_for_carried(steps):
+    x0_cpu, _, x0, _ = _inputs()
+    out = torch.empty(1, dtype=torch.float32, device="npu")
+
+    scalar_pointer_for_kernel[(1, )](x0, out, _device_i32(steps))
+
+    expected_index = 2 + 3 * steps
+    _assert_output(out, x0_cpu[expected_index:expected_index + 1])
+
+
+@pytest.mark.parametrize("steps", [0, 1, 5])
+def test_scalar_pointer_while_carried(steps):
+    x0_cpu, _, x0, _ = _inputs()
+    out = torch.empty(1, dtype=torch.float32, device="npu")
+
+    scalar_pointer_while_kernel[(1, )](x0, out, _device_i32(steps))
+
+    expected_index = 1 + 2 * steps
+    _assert_output(out, x0_cpu[expected_index:expected_index + 1])
+
+
+@pytest.mark.parametrize("predicate", [0, 1])
+@pytest.mark.parametrize("steps", [0, 1, 4])
+def test_scalar_pointer_nested_if_for(predicate, steps):
+    x0_cpu, _, x0, _ = _inputs()
+    out = torch.empty(1, dtype=torch.float32, device="npu")
+
+    scalar_pointer_nested_if_for_kernel[(1, )](x0, out, _device_i32(predicate), _device_i32(steps))
+
+    expected_index = sum(2 if (iteration & 1) == predicate else 1 for iteration in range(steps))
+    _assert_output(out, x0_cpu[expected_index:expected_index + 1])
+
+
+@pytest.mark.parametrize("predicate", [0, 1])
+@pytest.mark.parametrize("steps", [0, 3])
+def test_scalar_pointer_select_into_loop(predicate, steps):
+    x0_cpu, x1_cpu, x0, x1 = _inputs()
+    out = torch.empty(1, dtype=torch.float32, device="npu")
+
+    scalar_pointer_select_loop_kernel[(1, )](x0, x1, out, _device_i32(predicate), _device_i32(steps))
+
+    source = x0_cpu if predicate else x1_cpu
+    expected_index = (4 if predicate else 7) + 2 * steps
+    _assert_output(out, source[expected_index:expected_index + 1])
+
+
+@pytest.mark.parametrize("steps", [0, 1, 3])
+def test_tensor_pointer_loop(steps):
+    """Check a tensor-of-pointers backedge through a real NPU load/store."""
+    block = 8
+    length = 64
+    source_cpu = torch.arange(length, dtype=torch.float32)
+    source = source_cpu.npu()
+    tensor_output = torch.empty(block, dtype=torch.float32, device="npu")
+    steps_device = _device_i32(steps)
+
+    tensor_pointer_loop_kernel[(1, )](source, tensor_output, steps_device, BLOCK=block)
+
+    tensor_start = 6 + 2 * steps
+    _assert_output(tensor_output, source_cpu[tensor_start:tensor_start + block])
+
+
+@pytest.mark.parametrize("steps,switch_at", [(0, -1), (3, -1), (3, 1)])
+def test_descriptor_boundary_scalar_regression(steps, switch_at):
+    x0_cpu, x1_cpu, x0, x1 = _inputs()
+    out = torch.empty(BLOCK, dtype=torch.float32, device="npu")
+
+    descriptor_boundary_scalar_kernel[(1, )](
+        x0,
+        x1,
+        out,
+        _device_i32(steps),
+        _device_i32(switch_at),
+        N=INPUT_SIZE,
+        BLOCK=BLOCK,
+    )
+
+    source = x0_cpu
+    offset = 0
+    for iteration in range(steps):
+        if iteration == switch_at:
+            source = x1_cpu
+            offset = 4
+        else:
+            offset += 1
+    _assert_output(out, source[offset:offset + BLOCK])


### PR DESCRIPTION
This PR applies only the completed ControlFlowOpt pointer-boundary development on top of the latest main branch. It contains the BlockPtr, TensorPtr, scalar-pointer, and scope control-flow changes plus their T2L/T2U handoff fixes and reviewed tests. It does not include unrelated main-dev changes or the temporary DynamicCV exclusions used by the isolated development environment. The branch contains one commit directly based on main.