### PR TITLE
[compiler](fix) restore enable_vf_fusion option behavior

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -673,6 +673,11 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
             _compile_option_list += \
                 [f"--enable-mixed-cv={enable_mixed_cv}"]
 
+        enable_vf_fusion = metadata["enable_vf_fusion"]
+        if enable_vf_fusion is not None:
+            _compile_option_list += \
+                [f"--enable-vf-fusion={enable_vf_fusion}"]
+
         enable_flatten = metadata["enable_flatten"]
         if enable_flatten is not None:
             _compile_option_list += \
@@ -1067,6 +1072,7 @@ class NPUOptions:
     tile_mix_cube_loop: int = None
     disable_auto_inject_block_sync: bool = None
     enable_mixed_cv: bool = None
+    enable_vf_fusion: bool = None
     enable_dynamic_cv_pipeline: bool = None
     enable_cube_block_merge: bool = False
     hfusion_enable_multiple_consumer_fusion: bool = False

--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -60,7 +60,6 @@ _DEPRECATED_NPU_OPTIONS = frozenset({
     "enable_select_analysis",
     "enable_sync_block_lock",
     "enable_ub_refine_opt",
-    "enable_vf_fusion",
     "force_simt_only",
     "force_simt_template",
     "graph_optimize_emit_remarks",
@@ -139,7 +138,6 @@ _DEPRECATED_NPU_OPTION_DETAILS = {
     "enable_select_analysis": "it is ignored; the backend fixes select analysis to True.",
     "enable_sync_block_lock": "it is ignored; this option has no replacement because it had no effective consumer.",
     "enable_ub_refine_opt": "it is ignored; the backend keeps UB refine optimization disabled.",
-    "enable_vf_fusion": "it is ignored; use 'vf_fusion_mode' instead.",
     "graph_optimize_emit_remarks": "it is ignored; the backend fixes graph-optimization remarks to False.",
     "graph_optimize_max_rewrites_per_function":
     "it is ignored; the backend fixes the maximum rewrites per function to 64.",


### PR DESCRIPTION
Deprecating and ignoring `enable_vf_fusion` changed the behavior and performance of existing workloads that explicitly configure this option. This PR removes `enable_vf_fusion` from the deprecated option set, restores it in `NPUOptions`, and forwards explicitly supplied values to BiShengIR through `--enable-vf-fusion`. When the option is not specified, the existing BiShengIR default behavior remains unchanged. `enable_vf_fusion` continues to act as the VF fusion switch, while `vf_fusion_mode` independently selects the fusion strategy.