### PR TITLE
[Docs](fix) Add libdevice doc rendering and language api sidebar

### DIFF
--- a/docs/en/_static/custom.css
+++ b/docs/en/_static/custom.css
@@ -41,3 +41,11 @@ div.dtype-support-table table.docutils td:not(:first-child) {
 section#triton-ascend h1 {
     text-align: center;
 }
+
+/* The triton.language overview page keeps a visible toctree so its
+   per-category pages nest in the sidebar. Hide the article's rendering
+   of that toctree; the sidebar nav is built from the doctree and is
+   unaffected. */
+div[role="main"] .toctree-wrapper.sidebar-groups-only {
+    display: none;
+}

--- a/docs/en/_static/custom.css
+++ b/docs/en/_static/custom.css
@@ -44,8 +44,9 @@ section#triton-ascend h1 {
 
 /* The triton.language overview page keeps a visible toctree so its
    per-category pages nest in the sidebar. Hide the article's rendering
-   of that toctree; the sidebar nav is built from the doctree and is
-   unaffected. */
-div[role="main"] .toctree-wrapper.sidebar-groups-only {
+   of that toctree. The toctree-wrapper class only appears on toctrees
+   rendered by the directive in the article body; the theme's sidebar
+   nav is built separately from the doctree and is unaffected. */
+.toctree-wrapper.sidebar-groups-only {
     display: none;
 }

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -54,10 +54,10 @@ Triton Ascend
    triton <python-api/triton>
    triton.language <python-api/triton.language>
    triton.testing <python-api/triton.testing>
+   triton.language.extra.cann.libdevice <python-api/triton.language.extra.cann.libdevice>
 
 .. Temporarily disabled -- restore into the toctree above when needed:
    triton.language.extra.cann.extension <python-api/triton.language.extra.cann.extension>
-   triton.language.extra.cann.libdevice <python-api/triton.language.extra.cann.libdevice>
    triton.extension.buffer.language <python-api/triton.extension.buffer.language>
 
 .. toctree::

--- a/docs/en/python-api/triton.language/atomic_ops.rst
+++ b/docs/en/python-api/triton.language/atomic_ops.rst
@@ -1,0 +1,1 @@
+../../../zh/python-api/triton.language/atomic_ops.rst

--- a/docs/en/python-api/triton.language/comparison_ops.rst
+++ b/docs/en/python-api/triton.language/comparison_ops.rst
@@ -1,0 +1,1 @@
+../../../zh/python-api/triton.language/comparison_ops.rst

--- a/docs/en/python-api/triton.language/compiler_hint_ops.rst
+++ b/docs/en/python-api/triton.language/compiler_hint_ops.rst
@@ -1,0 +1,1 @@
+../../../zh/python-api/triton.language/compiler_hint_ops.rst

--- a/docs/en/python-api/triton.language/creation_ops.rst
+++ b/docs/en/python-api/triton.language/creation_ops.rst
@@ -1,0 +1,1 @@
+../../../zh/python-api/triton.language/creation_ops.rst

--- a/docs/en/python-api/triton.language/debug_ops.rst
+++ b/docs/en/python-api/triton.language/debug_ops.rst
@@ -1,0 +1,1 @@
+../../../zh/python-api/triton.language/debug_ops.rst

--- a/docs/en/python-api/triton.language/indexing_ops.rst
+++ b/docs/en/python-api/triton.language/indexing_ops.rst
@@ -1,0 +1,1 @@
+../../../zh/python-api/triton.language/indexing_ops.rst

--- a/docs/en/python-api/triton.language/inline_assembly.rst
+++ b/docs/en/python-api/triton.language/inline_assembly.rst
@@ -1,0 +1,1 @@
+../../../zh/python-api/triton.language/inline_assembly.rst

--- a/docs/en/python-api/triton.language/iterators.rst
+++ b/docs/en/python-api/triton.language/iterators.rst
@@ -1,0 +1,1 @@
+../../../zh/python-api/triton.language/iterators.rst

--- a/docs/en/python-api/triton.language/linear_algebra_ops.rst
+++ b/docs/en/python-api/triton.language/linear_algebra_ops.rst
@@ -1,0 +1,1 @@
+../../../zh/python-api/triton.language/linear_algebra_ops.rst

--- a/docs/en/python-api/triton.language/logical_ops.rst
+++ b/docs/en/python-api/triton.language/logical_ops.rst
@@ -1,0 +1,1 @@
+../../../zh/python-api/triton.language/logical_ops.rst

--- a/docs/en/python-api/triton.language/math_ops.rst
+++ b/docs/en/python-api/triton.language/math_ops.rst
@@ -1,0 +1,1 @@
+../../../zh/python-api/triton.language/math_ops.rst

--- a/docs/en/python-api/triton.language/memory_pointer_ops.rst
+++ b/docs/en/python-api/triton.language/memory_pointer_ops.rst
@@ -1,0 +1,1 @@
+../../../zh/python-api/triton.language/memory_pointer_ops.rst

--- a/docs/en/python-api/triton.language/programming_model.rst
+++ b/docs/en/python-api/triton.language/programming_model.rst
@@ -1,0 +1,1 @@
+../../../zh/python-api/triton.language/programming_model.rst

--- a/docs/en/python-api/triton.language/random_number_generation.rst
+++ b/docs/en/python-api/triton.language/random_number_generation.rst
@@ -1,0 +1,1 @@
+../../../zh/python-api/triton.language/random_number_generation.rst

--- a/docs/en/python-api/triton.language/reduction_ops.rst
+++ b/docs/en/python-api/triton.language/reduction_ops.rst
@@ -1,0 +1,1 @@
+../../../zh/python-api/triton.language/reduction_ops.rst

--- a/docs/en/python-api/triton.language/scan_sort_ops.rst
+++ b/docs/en/python-api/triton.language/scan_sort_ops.rst
@@ -1,0 +1,1 @@
+../../../zh/python-api/triton.language/scan_sort_ops.rst

--- a/docs/en/python-api/triton.language/shape_manipulation_ops.rst
+++ b/docs/en/python-api/triton.language/shape_manipulation_ops.rst
@@ -1,0 +1,1 @@
+../../../zh/python-api/triton.language/shape_manipulation_ops.rst

--- a/docs/zh/_static/custom.css
+++ b/docs/zh/_static/custom.css
@@ -41,3 +41,11 @@ div.dtype-support-table table.docutils td:not(:first-child) {
 section#triton-ascend h1 {
     text-align: center;
 }
+
+/* The triton.language overview page keeps a visible toctree so its
+   per-category pages nest in the sidebar. Hide the article's rendering
+   of that toctree; the sidebar nav is built from the doctree and is
+   unaffected. */
+div[role="main"] .toctree-wrapper.sidebar-groups-only {
+    display: none;
+}

--- a/docs/zh/_static/custom.css
+++ b/docs/zh/_static/custom.css
@@ -44,8 +44,9 @@ section#triton-ascend h1 {
 
 /* The triton.language overview page keeps a visible toctree so its
    per-category pages nest in the sidebar. Hide the article's rendering
-   of that toctree; the sidebar nav is built from the doctree and is
-   unaffected. */
-div[role="main"] .toctree-wrapper.sidebar-groups-only {
+   of that toctree. The toctree-wrapper class only appears on toctrees
+   rendered by the directive in the article body; the theme's sidebar
+   nav is built separately from the doctree and is unaffected. */
+.toctree-wrapper.sidebar-groups-only {
     display: none;
 }

--- a/docs/zh/debug_guide/profiling.md
+++ b/docs/zh/debug_guide/profiling.md
@@ -10,7 +10,7 @@ msProf工具用于采集和分析运行在昇腾AI处理器上算子的关键性
 
 - 注： msProf工具的使用依赖CANN包中的msopprof可执行文件，该文件中的接口功能和msprof op一致，该文件为CANN包自带，无需单独安装，msProf工具常用命令请参考[msProf常用命令](https://www.hiascend.com/document/detail/zh/mindstudio/82RC1/ODtools/Operatordevelopmenttools/atlasopdev_16_0082.html)。
 
-如下命令行是一个算子上板性能数据采集的示例，可以根据自身的需要灵活组合配置参数。实例中 --output为可选参数，用于指定收集到的性能数据的存放路径；--kernel-name为可选参数，用于指定需要收集的单个kernel的性能数据（如果不指定，则只对程序运行过程中调度的第一个算子进行采集）；$HOME/projects/test_op.py为算子可执行脚本。
+如下命令行是一个算子上板性能数据采集的示例，可以根据自身的需要灵活组合配置参数。示例中 --output为可选参数，用于指定收集到的性能数据的存放路径；--kernel-name为可选参数，用于指定需要收集的单个kernel的性能数据（如果不指定，则只对程序运行过程中调度的第一个算子进行采集）；$HOME/projects/test_op.py为算子可执行脚本。
 
 ```bash
 msprof op --kernel-name=target_kernel_name --output=$HOME/projects/output python3 $HOME/projects/test_op.py

--- a/docs/zh/index.rst
+++ b/docs/zh/index.rst
@@ -54,10 +54,10 @@ Triton Ascend
    triton <python-api/triton>
    triton.language <python-api/triton.language>
    triton.testing <python-api/triton.testing>
+   triton.language.extra.cann.libdevice <python-api/triton.language.extra.cann.libdevice>
 
 .. Temporarily disabled -- restore into the toctree above when needed:
    triton.language.extra.cann.extension <python-api/triton.language.extra.cann.extension>
-   triton.language.extra.cann.libdevice <python-api/triton.language.extra.cann.libdevice>
    triton.extension.buffer.language <python-api/triton.extension.buffer.language>
 
 .. toctree::

--- a/docs/zh/python-api/_ascend_constraints.py
+++ b/docs/zh/python-api/_ascend_constraints.py
@@ -2515,118 +2515,2068 @@ CONSTRAINTS = {
         "example":
         "triton.language.extra.cann.extension.scatter_ub_to_out",
     },
+    "triton.language.extra.cann.libdevice.abs": {
+        "replace_docstring": [
+            "Computes the element-wise absolute value of x.",
+        ],
+        "constraints": [
+            "- x: ``int32``, ``float32``",
+            "Return value: ``tl.tensor``, returns the absolute value of the input argument.",
+            "Return type: ``int32``, ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.abs",
+    },
     "triton.language.extra.cann.libdevice.acos": {
-        "example": "triton.language.extra.cann.libdevice.acos",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the arc cosine of the input argument, in the range [0, pi] radians.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.acos",
     },
     "triton.language.extra.cann.libdevice.acosh": {
-        "example": "triton.language.extra.cann.libdevice.acosh",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the inverse hyperbolic cosine of the input argument, in the range [0, +inf].",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.acosh",
+    },
+    "triton.language.extra.cann.libdevice.add_rd": {
+        "replace_docstring": [
+            "Computes x + y rounded down.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns the sum of x and y, rounded down.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.add_rd",
+    },
+    "triton.language.extra.cann.libdevice.add_rn": {
+        "replace_docstring": [
+            "Computes x + y rounded to nearest even.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns the sum of x and y, rounded to nearest even.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.add_rn",
+    },
+    "triton.language.extra.cann.libdevice.add_ru": {
+        "replace_docstring": [
+            "Computes x + y rounded up.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns the sum of x and y, rounded up.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.add_ru",
+    },
+    "triton.language.extra.cann.libdevice.add_rz": {
+        "replace_docstring": [
+            "Computes x + y rounded toward zero.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns the sum of x and y, rounded toward zero.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.add_rz",
     },
     "triton.language.extra.cann.libdevice.asin": {
-        "example": "triton.language.extra.cann.libdevice.asin",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the arc sine of the input argument, in the range [-pi/2, pi/2] radians.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.asin",
     },
     "triton.language.extra.cann.libdevice.asinh": {
-        "example": "triton.language.extra.cann.libdevice.asinh",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the inverse hyperbolic sine of the input argument.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.asinh",
     },
     "triton.language.extra.cann.libdevice.atan": {
-        "example": "triton.language.extra.cann.libdevice.atan",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the arc tangent of the input argument, in the range [-pi/2, pi/2] radians.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.atan",
     },
     "triton.language.extra.cann.libdevice.atan2": {
-        "example": "triton.language.extra.cann.libdevice.atan2",
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns the arc tangent of x / y, in the range [-pi, pi] radians.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.atan2",
     },
     "triton.language.extra.cann.libdevice.atanh": {
-        "example": "triton.language.extra.cann.libdevice.atanh",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the inverse hyperbolic tangent of the input argument, defined for inputs in [-1, 1].",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.atanh",
+    },
+    "triton.language.extra.cann.libdevice.brev": {
+        "replace_docstring": [
+            "Reverses the bit order of a 32-bit integer.",
+        ],
+        "constraints": [
+            "- x: ``int32``",
+            "Return value: ``tl.tensor``, returns the 32-bit integer with reversed bit order.",
+            "Return type: ``int32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.brev",
+    },
+    "triton.language.extra.cann.libdevice.byte_perm": {
+        "replace_docstring": [
+            "Selects bytes from two 32-bit integers x and y according to the selector s and returns the combined integer.",
+        ],
+        "constraints": [
+            "- x: ``int32``",
+            "- y: ``int32``",
+            "- s: ``int32``",
+            "Return value: ``tl.tensor``, returns the integer whose n-th byte is selected from x and y by the selector s.",
+            "Return type: ``int32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.byte_perm",
+    },
+    "triton.language.extra.cann.libdevice.cbrt": {
+        "replace_docstring": [
+            "Computes the cube root of x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the cube root of the input argument.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.cbrt",
+    },
+    "triton.language.extra.cann.libdevice.ceil": {
+        "replace_docstring": [
+            "Rounds x up to the nearest integer.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the ceiling of the input argument.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.ceil",
+    },
+    "triton.language.extra.cann.libdevice.clz": {
+        "replace_docstring": [
+            "Counts the number of leading zero bits in a 32-bit integer.",
+        ],
+        "constraints": [
+            "- x: ``int32``",
+            "Return value: ``tl.tensor``, returns the number of leading zero bits, in the range [0, 32].",
+            "Return type: ``int32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.clz",
     },
     "triton.language.extra.cann.libdevice.copysign": {
-        "example": "triton.language.extra.cann.libdevice.copysign",
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns a value with the magnitude of x and the sign of y.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.copysign",
+    },
+    "triton.language.extra.cann.libdevice.cos": {
+        "replace_docstring": [
+            "Computes the element-wise cosine of x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the cosine of the input argument.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.cos",
     },
     "triton.language.extra.cann.libdevice.cosh": {
-        "example": "triton.language.extra.cann.libdevice.cosh",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the hyperbolic cosine of the input argument.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.cosh",
+    },
+    "triton.language.extra.cann.libdevice.cospi": {
+        "replace_docstring": [
+            "Computes cos(pi * x).",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns cos(pi * x).",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.cospi",
     },
     "triton.language.extra.cann.libdevice.cyl_bessel_i0": {
-        "example": "triton.language.extra.cann.libdevice.cyl_bessel_i0",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the modified Bessel function of the first kind of order 0.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.cyl_bessel_i0",
+    },
+    "triton.language.extra.cann.libdevice.cyl_bessel_i1": {
+        "replace_docstring": [
+            "Computes the modified Bessel function of the first kind of order 1.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the modified Bessel function of the first kind of order 1.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.cyl_bessel_i1",
+    },
+    "triton.language.extra.cann.libdevice.div_rd": {
+        "replace_docstring": [
+            "Computes x / y rounded down.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns the division result.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.div_rd",
+    },
+    "triton.language.extra.cann.libdevice.div_rn": {
+        "replace_docstring": [
+            "Computes x / y rounded to nearest even.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns the division result.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.div_rn",
+    },
+    "triton.language.extra.cann.libdevice.div_ru": {
+        "replace_docstring": [
+            "Computes x / y rounded up.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns the division result.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.div_ru",
     },
     "triton.language.extra.cann.libdevice.div_rz": {
-        "example": "triton.language.extra.cann.libdevice.div_rz",
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns the division result.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.div_rz",
+    },
+    "triton.language.extra.cann.libdevice.erf": {
+        "replace_docstring": [
+            "Computes the error function of x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the error function of the input argument.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.erf",
+    },
+    "triton.language.extra.cann.libdevice.erfc": {
+        "replace_docstring": [
+            "Computes the complementary error function of x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the complementary error function of the input argument.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.erfc",
+    },
+    "triton.language.extra.cann.libdevice.erfcinv": {
+        "replace_docstring": [
+            "Computes the inverse complementary error function of x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the inverse complementary error function of the input argument.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.erfcinv",
+    },
+    "triton.language.extra.cann.libdevice.erfcx": {
+        "replace_docstring": [
+            "Computes the scaled complementary error function of x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the scaled complementary error function of the input argument.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.erfcx",
     },
     "triton.language.extra.cann.libdevice.erfinv": {
-        "example": "triton.language.extra.cann.libdevice.erfinv",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the inverse error function of the input argument.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.erfinv",
+    },
+    "triton.language.extra.cann.libdevice.exp": {
+        "replace_docstring": [
+            "Computes e raised to the power x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns e raised to the power x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.exp",
+    },
+    "triton.language.extra.cann.libdevice.exp10": {
+        "replace_docstring": [
+            "Computes 10 raised to the power x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns 10 raised to the power x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.exp10",
+    },
+    "triton.language.extra.cann.libdevice.exp2": {
+        "replace_docstring": [
+            "Computes 2 raised to the power x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns 2 raised to the power x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.exp2",
     },
     "triton.language.extra.cann.libdevice.expm1": {
-        "example": "triton.language.extra.cann.libdevice.expm1",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns e^x - 1.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.expm1",
+    },
+    "triton.language.extra.cann.libdevice.fast_cosf": {
+        "replace_docstring": [
+            "Fast approximation of the cosine of x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns a fast approximation of the cosine function.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.fast_cosf",
     },
     "triton.language.extra.cann.libdevice.fast_dividef": {
-        "example": "triton.language.extra.cann.libdevice.fast_dividef",
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns a fast approximation of the division result.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.fast_dividef",
+    },
+    "triton.language.extra.cann.libdevice.fast_exp10f": {
+        "replace_docstring": [
+            "Fast approximation of 10 raised to the power x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns a fast approximation of 10 raised to the power x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.fast_exp10f",
     },
     "triton.language.extra.cann.libdevice.fast_expf": {
-        "example": "triton.language.extra.cann.libdevice.fast_expf",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns a fast approximation of the exponential function.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.fast_expf",
+    },
+    "triton.language.extra.cann.libdevice.fast_log10f": {
+        "replace_docstring": [
+            "Fast approximation of the base-10 logarithm of x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns a fast approximation of the base-10 logarithm.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.fast_log10f",
+    },
+    "triton.language.extra.cann.libdevice.fast_log2f": {
+        "replace_docstring": [
+            "Fast approximation of the base-2 logarithm of x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns a fast approximation of the base-2 logarithm.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.fast_log2f",
+    },
+    "triton.language.extra.cann.libdevice.fast_logf": {
+        "replace_docstring": [
+            "Fast approximation of the natural logarithm of x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns a fast approximation of the natural logarithm.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.fast_logf",
+    },
+    "triton.language.extra.cann.libdevice.fast_powf": {
+        "replace_docstring": [
+            "Fast approximation of x raised to the power y.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns a fast approximation of the power function.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.fast_powf",
+    },
+    "triton.language.extra.cann.libdevice.fast_sinf": {
+        "replace_docstring": [
+            "Fast approximation of the sine of x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns a fast approximation of the sine function.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.fast_sinf",
+    },
+    "triton.language.extra.cann.libdevice.fast_tanf": {
+        "replace_docstring": [
+            "Fast approximation of the tangent of x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns a fast approximation of the tangent function.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.fast_tanf",
+    },
+    "triton.language.extra.cann.libdevice.fdim": {
+        "replace_docstring": [
+            "Computes the positive difference max(x - y, 0).",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns the positive difference between x and y.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.fdim",
+    },
+    "triton.language.extra.cann.libdevice.ffs": {
+        "replace_docstring": [
+            "Finds the index of the first (least significant) bit set to 1, in the range [0, 32].",
+        ],
+        "constraints": [
+            "- x: ``int32``",
+            "Return value: ``tl.tensor``, returns the index of the least significant bit set to 1, in the range [0, 32].",
+            "Return type: ``int32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.ffs",
+    },
+    "triton.language.extra.cann.libdevice.finitef": {
+        "replace_docstring": [
+            "Determines whether x is a finite value.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns True if the input is finite, otherwise False.",
+            "Return type: ``bool``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.finitef",
+    },
+    "triton.language.extra.cann.libdevice.float2int_rd": {
+        "replace_docstring": [
+            "Converts x to int32, rounding down.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the converted 32-bit integer.",
+            "Return type: ``int32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.float2int_rd",
+    },
+    "triton.language.extra.cann.libdevice.float2int_rn": {
+        "replace_docstring": [
+            "Converts x to int32, rounding to nearest even.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the converted 32-bit integer.",
+            "Return type: ``int32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.float2int_rn",
+    },
+    "triton.language.extra.cann.libdevice.float2int_ru": {
+        "replace_docstring": [
+            "Converts x to int32, rounding up.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the converted 32-bit integer.",
+            "Return type: ``int32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.float2int_ru",
+    },
+    "triton.language.extra.cann.libdevice.float2int_rz": {
+        "replace_docstring": [
+            "Converts x to int32, rounding toward zero.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the converted 32-bit integer.",
+            "Return type: ``int32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.float2int_rz",
+    },
+    "triton.language.extra.cann.libdevice.float2ll_rd": {
+        "replace_docstring": [
+            "Converts x to int64, rounding down.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the converted 64-bit integer.",
+            "Return type: ``int64``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.float2ll_rd",
+    },
+    "triton.language.extra.cann.libdevice.float2ll_rn": {
+        "replace_docstring": [
+            "Converts x to int64, rounding to nearest even.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the converted 64-bit integer.",
+            "Return type: ``int64``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.float2ll_rn",
+    },
+    "triton.language.extra.cann.libdevice.float2ll_ru": {
+        "replace_docstring": [
+            "Converts x to int64, rounding up.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the converted 64-bit integer.",
+            "Return type: ``int64``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.float2ll_ru",
+    },
+    "triton.language.extra.cann.libdevice.float2ll_rz": {
+        "replace_docstring": [
+            "Converts x to int64, rounding toward zero.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the converted 64-bit integer.",
+            "Return type: ``int64``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.float2ll_rz",
+    },
+    "triton.language.extra.cann.libdevice.float2uint_rd": {
+        "replace_docstring": [
+            "Converts x to uint32, rounding down.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the converted 32-bit unsigned integer.",
+            "Return type: ``uint32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.float2uint_rd",
+    },
+    "triton.language.extra.cann.libdevice.float2uint_rn": {
+        "replace_docstring": [
+            "Converts x to uint32, rounding to nearest even.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the converted 32-bit unsigned integer.",
+            "Return type: ``uint32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.float2uint_rn",
+    },
+    "triton.language.extra.cann.libdevice.float2uint_ru": {
+        "replace_docstring": [
+            "Converts x to uint32, rounding up.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the converted 32-bit unsigned integer.",
+            "Return type: ``uint32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.float2uint_ru",
+    },
+    "triton.language.extra.cann.libdevice.float2uint_rz": {
+        "replace_docstring": [
+            "Converts x to uint32, rounding toward zero.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the converted 32-bit unsigned integer.",
+            "Return type: ``uint32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.float2uint_rz",
+    },
+    "triton.language.extra.cann.libdevice.float2ull_rd": {
+        "replace_docstring": [
+            "Converts x to uint64, rounding down.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the converted 64-bit unsigned integer.",
+            "Return type: ``uint64``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.float2ull_rd",
+    },
+    "triton.language.extra.cann.libdevice.float2ull_rn": {
+        "replace_docstring": [
+            "Converts x to uint64, rounding to nearest even.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the converted 64-bit unsigned integer.",
+            "Return type: ``uint64``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.float2ull_rn",
+    },
+    "triton.language.extra.cann.libdevice.float2ull_ru": {
+        "replace_docstring": [
+            "Converts x to uint64, rounding up.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the converted 64-bit unsigned integer.",
+            "Return type: ``uint64``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.float2ull_ru",
+    },
+    "triton.language.extra.cann.libdevice.float2ull_rz": {
+        "replace_docstring": [
+            "Converts x to uint64, rounding toward zero.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the converted 64-bit unsigned integer.",
+            "Return type: ``uint64``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.float2ull_rz",
     },
     "triton.language.extra.cann.libdevice.float_as_int": {
-        "example": "triton.language.extra.cann.libdevice.float_as_int",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the float bits reinterpreted as a 32-bit integer.",
+            "Return type: ``int32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.float_as_int",
+    },
+    "triton.language.extra.cann.libdevice.float_as_uint": {
+        "replace_docstring": [
+            "Reinterprets the bits of a float32 value as uint32.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the float bits reinterpreted as a 32-bit unsigned integer.",
+            "Return type: ``uint32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.float_as_uint",
+    },
+    "triton.language.extra.cann.libdevice.floor": {
+        "replace_docstring": [
+            "Rounds x down to the nearest integer.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the floor of the input argument.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.floor",
+    },
+    "triton.language.extra.cann.libdevice.fma": {
+        "replace_docstring": [
+            "Computes x * y + z with a single rounding.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "- z: ``float32``",
+            "Return value: ``tl.tensor``, returns the fused multiply-add result.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.fma",
+    },
+    "triton.language.extra.cann.libdevice.fma_rd": {
+        "replace_docstring": [
+            "Computes x * y + z with a single rounding, rounded down.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "- z: ``float32``",
+            "Return value: ``tl.tensor``, returns the fused multiply-add result.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.fma_rd",
+    },
+    "triton.language.extra.cann.libdevice.fma_rn": {
+        "replace_docstring": [
+            "Computes x * y + z with a single rounding, rounded to nearest even.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "- z: ``float32``",
+            "Return value: ``tl.tensor``, returns the fused multiply-add result.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.fma_rn",
+    },
+    "triton.language.extra.cann.libdevice.fma_ru": {
+        "replace_docstring": [
+            "Computes x * y + z with a single rounding, rounded up.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "- z: ``float32``",
+            "Return value: ``tl.tensor``, returns the fused multiply-add result.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.fma_ru",
+    },
+    "triton.language.extra.cann.libdevice.fma_rz": {
+        "replace_docstring": [
+            "Computes x * y + z with a single rounding, rounded toward zero.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "- z: ``float32``",
+            "Return value: ``tl.tensor``, returns the fused multiply-add result.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.fma_rz",
     },
     "triton.language.extra.cann.libdevice.fmod": {
-        "example": "triton.language.extra.cann.libdevice.fmod",
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns the floating-point remainder.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.fmod",
     },
     "triton.language.extra.cann.libdevice.gamma": {
-        "example": "triton.language.extra.cann.libdevice.gamma",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the gamma function of the input argument.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.gamma",
+    },
+    "triton.language.extra.cann.libdevice.hadd": {
+        "replace_docstring": [
+            "Computes the average of x and y.",
+        ],
+        "constraints": [
+            "- x: ``int32``",
+            "- y: ``int32``",
+            "Return value: ``tl.tensor``, returns the average of x and y.",
+            "Return type: ``int32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.hadd",
     },
     "triton.language.extra.cann.libdevice.hypot": {
-        "example": "triton.language.extra.cann.libdevice.hypot",
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns the Euclidean distance between x and y.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.hypot",
     },
     "triton.language.extra.cann.libdevice.ilogb": {
-        "example": "triton.language.extra.cann.libdevice.ilogb",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the unbiased exponent of the input argument.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.ilogb",
+    },
+    "triton.language.extra.cann.libdevice.int2float_rd": {
+        "replace_docstring": [
+            "Converts an int32 value to float32.",
+        ],
+        "constraints": [
+            "- x: ``int32``",
+            "Return value: ``tl.tensor``, returns the converted floating-point value.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.int2float_rd",
+    },
+    "triton.language.extra.cann.libdevice.int2float_rn": {
+        "replace_docstring": [
+            "Converts an int32 value to float32.",
+        ],
+        "constraints": [
+            "- x: ``int32``",
+            "Return value: ``tl.tensor``, returns the converted floating-point value.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.int2float_rn",
+    },
+    "triton.language.extra.cann.libdevice.int2float_ru": {
+        "replace_docstring": [
+            "Converts an int32 value to float32.",
+        ],
+        "constraints": [
+            "- x: ``int32``",
+            "Return value: ``tl.tensor``, returns the converted floating-point value.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.int2float_ru",
+    },
+    "triton.language.extra.cann.libdevice.int2float_rz": {
+        "replace_docstring": [
+            "Converts an int32 value to float32.",
+        ],
+        "constraints": [
+            "- x: ``int32``",
+            "Return value: ``tl.tensor``, returns the converted floating-point value.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.int2float_rz",
+    },
+    "triton.language.extra.cann.libdevice.int_as_float": {
+        "replace_docstring": [
+            "Reinterprets the bits of an int32 value as float32.",
+        ],
+        "constraints": [
+            "- x: ``int32``",
+            "Return value: ``tl.tensor``, returns the 32-bit integer bits reinterpreted as a float.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.int_as_float",
     },
     "triton.language.extra.cann.libdevice.isinf": {
-        "example": "triton.language.extra.cann.libdevice.isinf",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns True if the input is infinite, otherwise False.",
+            "Return type: ``bool``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.isinf",
     },
     "triton.language.extra.cann.libdevice.isnan": {
-        "example": "triton.language.extra.cann.libdevice.isnan",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns True if the input is NaN, otherwise False.",
+            "Return type: ``bool``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.isnan",
+    },
+    "triton.language.extra.cann.libdevice.j0": {
+        "replace_docstring": [
+            "Computes the Bessel function of the first kind of order 0.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the Bessel function of the first kind of order 0.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.j0",
+    },
+    "triton.language.extra.cann.libdevice.j1": {
+        "replace_docstring": [
+            "Computes the Bessel function of the first kind of order 1.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the Bessel function of the first kind of order 1.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.j1",
+    },
+    "triton.language.extra.cann.libdevice.jn": {
+        "replace_docstring": [
+            "Computes the Bessel function of the first kind of integer order n.",
+        ],
+        "constraints": [
+            "- n: ``int32``",
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the Bessel function of the first kind of order n.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.jn",
     },
     "triton.language.extra.cann.libdevice.ldexp": {
-        "example": "triton.language.extra.cann.libdevice.ldexp",
+        "constraints": [
+            "- x: ``float32``",
+            "- exp: ``int32``",
+            "Return value: ``tl.tensor``, returns x * 2^exp.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.ldexp",
     },
     "triton.language.extra.cann.libdevice.lgamma": {
-        "example": "triton.language.extra.cann.libdevice.lgamma",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the natural logarithm of the absolute value of the gamma function of x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.lgamma",
+    },
+    "triton.language.extra.cann.libdevice.ll2float_rd": {
+        "replace_docstring": [
+            "Converts an int64 value to float32.",
+        ],
+        "constraints": [
+            "- x: ``int64``",
+            "Return value: ``tl.tensor``, returns the converted floating-point value.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.ll2float_rd",
+    },
+    "triton.language.extra.cann.libdevice.ll2float_rn": {
+        "replace_docstring": [
+            "Converts an int64 value to float32.",
+        ],
+        "constraints": [
+            "- x: ``int64``",
+            "Return value: ``tl.tensor``, returns the converted floating-point value.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.ll2float_rn",
+    },
+    "triton.language.extra.cann.libdevice.ll2float_ru": {
+        "replace_docstring": [
+            "Converts an int64 value to float32.",
+        ],
+        "constraints": [
+            "- x: ``int64``",
+            "Return value: ``tl.tensor``, returns the converted floating-point value.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.ll2float_ru",
+    },
+    "triton.language.extra.cann.libdevice.ll2float_rz": {
+        "replace_docstring": [
+            "Converts an int64 value to float32.",
+        ],
+        "constraints": [
+            "- x: ``int64``",
+            "Return value: ``tl.tensor``, returns the converted floating-point value.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.ll2float_rz",
+    },
+    "triton.language.extra.cann.libdevice.llrint": {
+        "replace_docstring": [
+            "Rounds x to the nearest int64 value.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the rounded 64-bit integer.",
+            "Return type: ``int64``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.llrint",
+    },
+    "triton.language.extra.cann.libdevice.llround": {
+        "replace_docstring": [
+            "Rounds x to the nearest int64 value.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the rounded 64-bit integer.",
+            "Return type: ``int64``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.llround",
+    },
+    "triton.language.extra.cann.libdevice.log": {
+        "replace_docstring": [
+            "Computes the natural logarithm of x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the natural logarithm of x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.log",
     },
     "triton.language.extra.cann.libdevice.log10": {
-        "example": "triton.language.extra.cann.libdevice.log10",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the base-10 logarithm of x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.log10",
     },
     "triton.language.extra.cann.libdevice.log1p": {
-        "example": "triton.language.extra.cann.libdevice.log1p",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns log(1 + x).",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.log1p",
+    },
+    "triton.language.extra.cann.libdevice.log2": {
+        "replace_docstring": [
+            "Computes the base-2 logarithm of x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the base-2 logarithm of x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.log2",
+    },
+    "triton.language.extra.cann.libdevice.logb": {
+        "replace_docstring": [
+            "Computes the unbiased exponent of x, i.e. floor(log2(|x|)).",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the exponent of the input argument.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.logb",
+    },
+    "triton.language.extra.cann.libdevice.mul24": {
+        "replace_docstring": [
+            "Computes the low 24-bit multiplication result of x and y.",
+        ],
+        "constraints": [
+            "- x: ``int32``",
+            "- y: ``int32``",
+            "Return value: ``tl.tensor``, returns the low 24 bits of x * y.",
+            "Return type: ``int32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.mul24",
+    },
+    "triton.language.extra.cann.libdevice.mul_rd": {
+        "replace_docstring": [
+            "Computes x * y rounded down.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns the floating-point multiplication result.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.mul_rd",
+    },
+    "triton.language.extra.cann.libdevice.mul_rn": {
+        "replace_docstring": [
+            "Computes x * y rounded to nearest even.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns the floating-point multiplication result.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.mul_rn",
+    },
+    "triton.language.extra.cann.libdevice.mul_ru": {
+        "replace_docstring": [
+            "Computes x * y rounded up.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns the floating-point multiplication result.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.mul_ru",
+    },
+    "triton.language.extra.cann.libdevice.mul_rz": {
+        "replace_docstring": [
+            "Computes x * y rounded toward zero.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns the floating-point multiplication result.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.mul_rz",
+    },
+    "triton.language.extra.cann.libdevice.mulhi": {
+        "replace_docstring": [
+            "Computes the high 32 bits of the product x * y.",
+        ],
+        "constraints": [
+            "- x: ``int32``",
+            "- y: ``int32``",
+            "Return value: ``tl.tensor``, returns the high 32 bits of the product x * y.",
+            "Return type: ``int32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.mulhi",
     },
     "triton.language.extra.cann.libdevice.nearbyint": {
-        "example": "triton.language.extra.cann.libdevice.nearbyint",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the nearest integer.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.nearbyint",
     },
     "triton.language.extra.cann.libdevice.nextafter": {
-        "example": "triton.language.extra.cann.libdevice.nextafter",
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns the next representable floating-point value.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.nextafter",
+    },
+    "triton.language.extra.cann.libdevice.norm3d": {
+        "replace_docstring": [
+            "Computes the Euclidean norm of (x, y, z).",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "- z: ``float32``",
+            "Return value: ``tl.tensor``, returns the Euclidean norm of a 3D vector.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.norm3d",
+    },
+    "triton.language.extra.cann.libdevice.norm4d": {
+        "replace_docstring": [
+            "Computes the Euclidean norm of (x, y, z, w).",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "- z: ``float32``",
+            "- w: ``float32``",
+            "Return value: ``tl.tensor``, returns the Euclidean norm of a 4D vector.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.norm4d",
+    },
+    "triton.language.extra.cann.libdevice.normcdf": {
+        "replace_docstring": [
+            "Computes the standard normal cumulative distribution function.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the standard normal cumulative distribution function value.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.normcdf",
+    },
+    "triton.language.extra.cann.libdevice.normcdfinv": {
+        "replace_docstring": [
+            "Computes the inverse of the standard normal cumulative distribution function.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the inverse of the standard normal cumulative distribution function.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.normcdfinv",
+    },
+    "triton.language.extra.cann.libdevice.popc": {
+        "replace_docstring": [
+            "Counts the number of bits set to 1 in x, in the range [0, 32].",
+        ],
+        "constraints": [
+            "- x: ``int32``",
+            "Return value: ``tl.tensor``, returns the number of bits set to 1, in the range [0, 32].",
+            "Return type: ``int32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.popc",
     },
     "triton.language.extra.cann.libdevice.pow": {
-        "example": "triton.language.extra.cann.libdevice.pow",
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns x raised to the power y.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.pow",
+    },
+    "triton.language.extra.cann.libdevice.rcbrt": {
+        "replace_docstring": [
+            "Computes the reciprocal cube root of x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the reciprocal cube root of x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.rcbrt",
+    },
+    "triton.language.extra.cann.libdevice.rcp_rd": {
+        "replace_docstring": [
+            "Computes 1 / x rounded down.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns 1 / x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.rcp_rd",
+    },
+    "triton.language.extra.cann.libdevice.rcp_rn": {
+        "replace_docstring": [
+            "Computes 1 / x rounded to nearest even.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns 1 / x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.rcp_rn",
+    },
+    "triton.language.extra.cann.libdevice.rcp_ru": {
+        "replace_docstring": [
+            "Computes 1 / x rounded up.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns 1 / x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.rcp_ru",
+    },
+    "triton.language.extra.cann.libdevice.rcp_rz": {
+        "replace_docstring": [
+            "Computes 1 / x rounded toward zero.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns 1 / x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.rcp_rz",
     },
     "triton.language.extra.cann.libdevice.reciprocal": {
-        "example": "triton.language.extra.cann.libdevice.reciprocal",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns 1 / x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.reciprocal",
     },
     "triton.language.extra.cann.libdevice.relu": {
-        "example": "triton.language.extra.cann.libdevice.relu",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the rectified linear unit result.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.relu",
+    },
+    "triton.language.extra.cann.libdevice.remainder": {
+        "replace_docstring": [
+            "Computes the IEEE remainder of x / y.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns the remainder of x / y.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.remainder",
+    },
+    "triton.language.extra.cann.libdevice.rhadd": {
+        "replace_docstring": [
+            "Computes the rounded average of x and y.",
+        ],
+        "constraints": [
+            "- x: ``int32``",
+            "- y: ``int32``",
+            "Return value: ``tl.tensor``, returns the rounded average of x and y.",
+            "Return type: ``int32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.rhadd",
+    },
+    "triton.language.extra.cann.libdevice.rhypot": {
+        "replace_docstring": [
+            "Computes 1 / sqrt(x^2 + y^2).",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns the reciprocal of the Euclidean distance between x and y.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.rhypot",
     },
     "triton.language.extra.cann.libdevice.rint": {
-        "example": "triton.language.extra.cann.libdevice.rint",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the nearest integer to x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.rint",
+    },
+    "triton.language.extra.cann.libdevice.rnorm3d": {
+        "replace_docstring": [
+            "Computes 1 / sqrt(x^2 + y^2 + z^2).",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "- z: ``float32``",
+            "Return value: ``tl.tensor``, returns the reciprocal of the Euclidean norm of a 3D vector.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.rnorm3d",
+    },
+    "triton.language.extra.cann.libdevice.rnorm4d": {
+        "replace_docstring": [
+            "Computes 1 / sqrt(x^2 + y^2 + z^2 + w^2).",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "- z: ``float32``",
+            "- w: ``float32``",
+            "Return value: ``tl.tensor``, returns the reciprocal of the Euclidean norm of a 4D vector.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.rnorm4d",
     },
     "triton.language.extra.cann.libdevice.round": {
-        "example": "triton.language.extra.cann.libdevice.round",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the nearest integer to x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.round",
+    },
+    "triton.language.extra.cann.libdevice.rsqrt": {
+        "replace_docstring": [
+            "Computes the reciprocal square root of x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the reciprocal square root of x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.rsqrt",
+    },
+    "triton.language.extra.cann.libdevice.rsqrt_rn": {
+        "replace_docstring": [
+            "Computes the reciprocal square root of x, rounded to nearest even.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the reciprocal square root of x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.rsqrt_rn",
+    },
+    "triton.language.extra.cann.libdevice.sad": {
+        "replace_docstring": [
+            "Computes |x - y| + z, where x and y are signed integers and z is an unsigned integer.",
+        ],
+        "constraints": [
+            "- x: ``int32``",
+            "- y: ``int32``",
+            "- z: ``int32``",
+            "Return value: ``tl.tensor``, returns |x - y| + z.",
+            "Return type: ``int32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.sad",
+    },
+    "triton.language.extra.cann.libdevice.saturatef": {
+        "replace_docstring": [
+            "Clamps x to the range [0, 1].",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns x clamped to the range [0.0, 1.0].",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.saturatef",
+    },
+    "triton.language.extra.cann.libdevice.scalbn": {
+        "replace_docstring": [
+            "Computes x * 2^n.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- n: ``int32``",
+            "Return value: ``tl.tensor``, returns x * 2^n.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.scalbn",
     },
     "triton.language.extra.cann.libdevice.signbit": {
-        "example": "triton.language.extra.cann.libdevice.signbit",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the sign bit of x.",
+            "Return type: ``int32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.signbit",
+    },
+    "triton.language.extra.cann.libdevice.sin": {
+        "replace_docstring": [
+            "Computes the element-wise sine of x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the sine of x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.sin",
     },
     "triton.language.extra.cann.libdevice.sinh": {
-        "example": "triton.language.extra.cann.libdevice.sinh",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the hyperbolic sine of x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.sinh",
+    },
+    "triton.language.extra.cann.libdevice.sinpi": {
+        "replace_docstring": [
+            "Computes sin(pi * x).",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns sin(pi * x).",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.sinpi",
+    },
+    "triton.language.extra.cann.libdevice.sqrt": {
+        "replace_docstring": [
+            "Computes the square root of x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the square root of x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.sqrt",
+    },
+    "triton.language.extra.cann.libdevice.sqrt_rd": {
+        "replace_docstring": [
+            "Computes the square root of x, rounded down.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the square root of x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.sqrt_rd",
+    },
+    "triton.language.extra.cann.libdevice.sqrt_rn": {
+        "replace_docstring": [
+            "Computes the square root of x, rounded to nearest even.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the square root of x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.sqrt_rn",
+    },
+    "triton.language.extra.cann.libdevice.sqrt_ru": {
+        "replace_docstring": [
+            "Computes the square root of x, rounded up.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the square root of x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.sqrt_ru",
+    },
+    "triton.language.extra.cann.libdevice.sqrt_rz": {
+        "replace_docstring": [
+            "Computes the square root of x, rounded toward zero.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the square root of x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.sqrt_rz",
+    },
+    "triton.language.extra.cann.libdevice.sub_rd": {
+        "replace_docstring": [
+            "Computes x - y rounded down.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns x - y, rounded down.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.sub_rd",
+    },
+    "triton.language.extra.cann.libdevice.sub_rn": {
+        "replace_docstring": [
+            "Computes x - y rounded to nearest even.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns x - y, rounded to nearest even.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.sub_rn",
+    },
+    "triton.language.extra.cann.libdevice.sub_ru": {
+        "replace_docstring": [
+            "Computes x - y rounded up.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns x - y, rounded up.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.sub_ru",
+    },
+    "triton.language.extra.cann.libdevice.sub_rz": {
+        "replace_docstring": [
+            "Computes x - y rounded toward zero.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "- y: ``float32``",
+            "Return value: ``tl.tensor``, returns x - y, rounded toward zero.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.sub_rz",
     },
     "triton.language.extra.cann.libdevice.tan": {
-        "example": "triton.language.extra.cann.libdevice.tan",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the tangent of x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.tan",
     },
     "triton.language.extra.cann.libdevice.tanh": {
-        "example": "triton.language.extra.cann.libdevice.tanh",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the hyperbolic tangent of x.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.tanh",
+    },
+    "triton.language.extra.cann.libdevice.tgamma": {
+        "replace_docstring": [
+            "Computes the gamma function of x.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the gamma function of the input argument.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.tgamma",
     },
     "triton.language.extra.cann.libdevice.trunc": {
-        "example": "triton.language.extra.cann.libdevice.trunc",
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the truncated result.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT, SIMD",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.trunc",
+    },
+    "triton.language.extra.cann.libdevice.uint2float_rd": {
+        "replace_docstring": [
+            "Converts a uint32 value to float32.",
+        ],
+        "constraints": [
+            "- x: ``uint32``",
+            "Return value: ``tl.tensor``, returns the converted floating-point value.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.uint2float_rd",
+    },
+    "triton.language.extra.cann.libdevice.uint2float_rn": {
+        "replace_docstring": [
+            "Converts a uint32 value to float32.",
+        ],
+        "constraints": [
+            "- x: ``uint32``",
+            "Return value: ``tl.tensor``, returns the converted floating-point value.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.uint2float_rn",
+    },
+    "triton.language.extra.cann.libdevice.uint2float_ru": {
+        "replace_docstring": [
+            "Converts a uint32 value to float32.",
+        ],
+        "constraints": [
+            "- x: ``uint32``",
+            "Return value: ``tl.tensor``, returns the converted floating-point value.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.uint2float_ru",
+    },
+    "triton.language.extra.cann.libdevice.uint2float_rz": {
+        "replace_docstring": [
+            "Converts a uint32 value to float32.",
+        ],
+        "constraints": [
+            "- x: ``uint32``",
+            "Return value: ``tl.tensor``, returns the converted floating-point value.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.uint2float_rz",
+    },
+    "triton.language.extra.cann.libdevice.uint_as_float": {
+        "replace_docstring": [
+            "Reinterprets the bits of a uint32 value as float32.",
+        ],
+        "constraints": [
+            "- x: ``uint32``",
+            "Return value: ``tl.tensor``, returns the 32-bit unsigned integer bits reinterpreted as a float.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.uint_as_float",
+    },
+    "triton.language.extra.cann.libdevice.ull2float_rd": {
+        "replace_docstring": [
+            "Converts a uint64 value to float32.",
+        ],
+        "constraints": [
+            "- x: ``uint64``",
+            "Return value: ``tl.tensor``, returns the converted floating-point value.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.ull2float_rd",
+    },
+    "triton.language.extra.cann.libdevice.ull2float_rn": {
+        "replace_docstring": [
+            "Converts a uint64 value to float32.",
+        ],
+        "constraints": [
+            "- x: ``uint64``",
+            "Return value: ``tl.tensor``, returns the converted floating-point value.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.ull2float_rn",
+    },
+    "triton.language.extra.cann.libdevice.ull2float_ru": {
+        "replace_docstring": [
+            "Converts a uint64 value to float32.",
+        ],
+        "constraints": [
+            "- x: ``uint64``",
+            "Return value: ``tl.tensor``, returns the converted floating-point value.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.ull2float_ru",
+    },
+    "triton.language.extra.cann.libdevice.ull2float_rz": {
+        "replace_docstring": [
+            "Converts a uint64 value to float32.",
+        ],
+        "constraints": [
+            "- x: ``uint64``",
+            "Return value: ``tl.tensor``, returns the converted floating-point value.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.ull2float_rz",
+    },
+    "triton.language.extra.cann.libdevice.y0": {
+        "replace_docstring": [
+            "Computes the Bessel function of the second kind of order 0.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the Bessel function of the second kind of order 0.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.y0",
+    },
+    "triton.language.extra.cann.libdevice.y1": {
+        "replace_docstring": [
+            "Computes the Bessel function of the second kind of order 1.",
+        ],
+        "constraints": [
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the Bessel function of the second kind of order 1.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.y1",
+    },
+    "triton.language.extra.cann.libdevice.yn": {
+        "replace_docstring": [
+            "Computes the Bessel function of the second kind of integer order n.",
+        ],
+        "constraints": [
+            "- n: ``int32``",
+            "- x: ``float32``",
+            "Return value: ``tl.tensor``, returns the Bessel function of the second kind of order n.",
+            "Return type: ``float32``",
+            "Compilation modes: SIMT",
+        ],
+        "example":
+        "triton.language.extra.cann.libdevice.yn",
     },
 }

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.abs.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.abs.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.abs(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_abs():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.abs(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_abs()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_rd.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.add_rd(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_add_rd():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (x0 + x1).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_add_rd()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_rn.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.add_rn(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_add_rn():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (x0 + x1).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_add_rn()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_ru.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.add_ru(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_add_ru():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (x0 + x1).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_add_ru()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_rz.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.add_rz(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_add_rz():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (x0 + x1).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_add_rz()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.brev.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.brev.py
@@ -1,0 +1,55 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.brev(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+def _brev(x):
+    """Reverse the 32-bit representation of x."""
+    v = int(x) & 0xFFFFFFFF
+    r = 0
+    for _ in range(32):
+        r = (r << 1) | (v & 1)
+        v >>= 1
+    return r
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_brev():
+    x0 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    expected = torch.tensor([_brev(*v) for v in zip(x0.tolist())], dtype=torch.int32).npu()
+    output = torch.empty(8, dtype=torch.int32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_brev()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.byte_perm.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.byte_perm.py
@@ -1,0 +1,60 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = tl.load(input2 + (x0), mask=mask)
+        tmp3 = libdevice.byte_perm(tmp0, tmp1, tmp2)
+        tl.store(output + (x0), tmp3, mask=mask)
+
+
+def _byte_perm(x, y, s):
+    """Select bytes from the 64-bit value (y << 32 | x) per selector s."""
+    combined = (int(y) << 32) | (int(x) & 0xFFFFFFFF)
+    result = 0
+    for i in range(4):
+        idx = (int(s) >> (4 * i)) & 0x7
+        result |= ((combined >> (8 * idx)) & 0xFF) << (8 * i)
+    return result
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_byte_perm():
+    x0 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    x1 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    x2 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    expected = torch.tensor([_byte_perm(*v) for v in zip(x0.tolist(), x1.tolist(), x2.tolist())],
+                            dtype=torch.int32).npu()
+    output = torch.empty(8, dtype=torch.int32, device='npu')
+    triton_kernel[(1, )](x0, x1, x2, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_byte_perm()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cbrt.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cbrt.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.cbrt(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_cbrt():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.cbrt(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_cbrt()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ceil.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ceil.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.ceil(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_ceil():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.ceil(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_ceil()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.clz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.clz.py
@@ -1,0 +1,51 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.clz(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+def _clz(x):
+    """Count leading zero bits of the 32-bit representation of x."""
+    v = int(x) & 0xFFFFFFFF
+    return 32 - v.bit_length() if v != 0 else 32
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_clz():
+    x0 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    expected = torch.tensor([_clz(*v) for v in zip(x0.tolist())], dtype=torch.int32).npu()
+    output = torch.empty(8, dtype=torch.int32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_clz()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cos.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cos.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.cos(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_cos():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.cos(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_cos()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cospi.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cospi.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.cospi(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_cospi():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.cos(x0 * 3.141592653589793)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_cospi()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cyl_bessel_i1.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cyl_bessel_i1.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.cyl_bessel_i1(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_cyl_bessel_i1():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (torch.special.i1(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_cyl_bessel_i1()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_rd.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.div_rd(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_div_rd():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (x0 / x1).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_div_rd()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_rn.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.div_rn(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_div_rn():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (x0 / x1).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_div_rn()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_ru.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.div_ru(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_div_ru():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (x0 / x1).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_div_ru()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erf.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.erf(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_erf():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.erf(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_erf()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfc.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfc.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.erfc(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_erfc():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.erfc(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_erfc()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfcinv.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfcinv.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.erfcinv(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_erfcinv():
+    x0 = (torch.rand((8, )) * 0.9 + 0.05).to(torch.float32).npu()
+    expected = (torch.erfc(torch.erfcinv(x0))).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_erfcinv()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfcx.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfcx.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.erfcx(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_erfcx():
+    x0 = (torch.rand((8, )) * 1.6 - 0.8).to(torch.float32).npu()
+    expected = (torch.exp(x0**2) * torch.erfc(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_erfcx()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.exp.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.exp.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.exp(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_exp():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.exp(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_exp()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.exp10.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.exp10.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.exp10(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_exp10():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.pow(10.0, x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_exp10()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.exp2.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.exp2.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.exp2(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_exp2():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.exp2(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_exp2()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_cosf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_cosf.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.fast_cosf(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_fast_cosf():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.cos(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_fast_cosf()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_exp10f.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_exp10f.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.fast_exp10f(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_fast_exp10f():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.pow(10.0, x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_fast_exp10f()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_log10f.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_log10f.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.fast_log10f(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_fast_log10f():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (torch.log10(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_fast_log10f()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_log2f.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_log2f.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.fast_log2f(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_fast_log2f():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (torch.log2(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_fast_log2f()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_logf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_logf.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.fast_logf(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_fast_logf():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (torch.log(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_fast_logf()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_powf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_powf.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.fast_powf(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_fast_powf():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (torch.pow(x0, x1)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_fast_powf()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_sinf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_sinf.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.fast_sinf(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_fast_sinf():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.sin(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_fast_sinf()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_tanf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_tanf.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.fast_tanf(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_fast_tanf():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.tan(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_fast_tanf()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fdim.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fdim.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.fdim(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_fdim():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.maximum(x0 - x1, torch.zeros_like(x0))).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_fdim()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ffs.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ffs.py
@@ -1,0 +1,53 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.ffs(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+def _ffs(x):
+    """Index of the least significant set bit (0-based), 32 if none."""
+    v = int(x) & 0xFFFFFFFF
+    if v == 0:
+        return 32
+    return (v & -v).bit_length() - 1
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_ffs():
+    x0 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    expected = torch.tensor([_ffs(*v) for v in zip(x0.tolist())], dtype=torch.int32).npu()
+    output = torch.empty(8, dtype=torch.int32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_ffs()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.finitef.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.finitef.py
@@ -1,0 +1,38 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.finitef(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+        output = torch.empty(8, dtype=torch.bool, device='npu')
+        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_rd.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.float2int_rd(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_float2int_rd():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.floor(x0).to(torch.int32)).to(torch.int32).npu()
+    output = torch.empty(8, dtype=torch.int32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_float2int_rd()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_rn.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.float2int_rn(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_float2int_rn():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.round(x0).to(torch.int32)).to(torch.int32).npu()
+    output = torch.empty(8, dtype=torch.int32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_float2int_rn()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_ru.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.float2int_ru(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_float2int_ru():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.ceil(x0).to(torch.int32)).to(torch.int32).npu()
+    output = torch.empty(8, dtype=torch.int32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_float2int_ru()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_rz.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.float2int_rz(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_float2int_rz():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.trunc(x0).to(torch.int32)).to(torch.int32).npu()
+    output = torch.empty(8, dtype=torch.int32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_float2int_rz()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_rd.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.float2ll_rd(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_float2ll_rd():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.floor(x0).to(torch.int64)).to(torch.int64).npu()
+    output = torch.empty(8, dtype=torch.int64, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_float2ll_rd()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_rn.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.float2ll_rn(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_float2ll_rn():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.round(x0).to(torch.int64)).to(torch.int64).npu()
+    output = torch.empty(8, dtype=torch.int64, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_float2ll_rn()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_ru.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.float2ll_ru(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_float2ll_ru():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.ceil(x0).to(torch.int64)).to(torch.int64).npu()
+    output = torch.empty(8, dtype=torch.int64, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_float2ll_ru()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_rz.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.float2ll_rz(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_float2ll_rz():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.trunc(x0).to(torch.int64)).to(torch.int64).npu()
+    output = torch.empty(8, dtype=torch.int64, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_float2ll_rz()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_rd.py
@@ -1,0 +1,38 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.float2uint_rd(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+        output = torch.empty(8, dtype=torch.uint32, device='npu')
+        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_rn.py
@@ -1,0 +1,38 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.float2uint_rn(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+        output = torch.empty(8, dtype=torch.uint32, device='npu')
+        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_ru.py
@@ -1,0 +1,38 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.float2uint_ru(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+        output = torch.empty(8, dtype=torch.uint32, device='npu')
+        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_rz.py
@@ -1,0 +1,38 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.float2uint_rz(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+        output = torch.empty(8, dtype=torch.uint32, device='npu')
+        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_rd.py
@@ -1,0 +1,38 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.float2ull_rd(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+        output = torch.empty(8, dtype=torch.uint64, device='npu')
+        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_rn.py
@@ -1,0 +1,38 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.float2ull_rn(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+        output = torch.empty(8, dtype=torch.uint64, device='npu')
+        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_ru.py
@@ -1,0 +1,38 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.float2ull_ru(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+        output = torch.empty(8, dtype=torch.uint64, device='npu')
+        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_rz.py
@@ -1,0 +1,38 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.float2ull_rz(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+        output = torch.empty(8, dtype=torch.uint64, device='npu')
+        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float_as_uint.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float_as_uint.py
@@ -1,0 +1,38 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.float_as_uint(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+        output = torch.empty(8, dtype=torch.uint32, device='npu')
+        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.floor.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.floor.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.floor(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_floor():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.floor(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_floor()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma.py
@@ -1,0 +1,49 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = tl.load(input2 + (x0), mask=mask)
+        tmp3 = libdevice.fma(tmp0, tmp1, tmp2)
+        tl.store(output + (x0), tmp3, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_fma():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x2 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (x0 * x1 + x2).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, x2, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_fma()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_rd.py
@@ -1,0 +1,49 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = tl.load(input2 + (x0), mask=mask)
+        tmp3 = libdevice.fma_rd(tmp0, tmp1, tmp2)
+        tl.store(output + (x0), tmp3, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_fma_rd():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x2 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (x0 * x1 + x2).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, x2, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_fma_rd()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_rn.py
@@ -1,0 +1,49 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = tl.load(input2 + (x0), mask=mask)
+        tmp3 = libdevice.fma_rn(tmp0, tmp1, tmp2)
+        tl.store(output + (x0), tmp3, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_fma_rn():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x2 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (x0 * x1 + x2).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, x2, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_fma_rn()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_ru.py
@@ -1,0 +1,49 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = tl.load(input2 + (x0), mask=mask)
+        tmp3 = libdevice.fma_ru(tmp0, tmp1, tmp2)
+        tl.store(output + (x0), tmp3, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_fma_ru():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x2 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (x0 * x1 + x2).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, x2, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_fma_ru()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_rz.py
@@ -1,0 +1,49 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = tl.load(input2 + (x0), mask=mask)
+        tmp3 = libdevice.fma_rz(tmp0, tmp1, tmp2)
+        tl.store(output + (x0), tmp3, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_fma_rz():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x2 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (x0 * x1 + x2).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, x2, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_fma_rz()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.hadd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.hadd.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.hadd(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_hadd():
+    x0 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    x1 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    expected = ((x0 + x1) // 2).to(torch.int32).npu()
+    output = torch.empty(8, dtype=torch.int32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_hadd()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_rd.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.int2float_rd(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_int2float_rd():
+    x0 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    expected = (x0.to(torch.float32)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_int2float_rd()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_rn.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.int2float_rn(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_int2float_rn():
+    x0 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    expected = (x0.to(torch.float32)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_int2float_rn()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_ru.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.int2float_ru(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_int2float_ru():
+    x0 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    expected = (x0.to(torch.float32)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_int2float_ru()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_rz.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.int2float_rz(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_int2float_rz():
+    x0 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    expected = (x0.to(torch.float32)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_int2float_rz()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int_as_float.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int_as_float.py
@@ -1,0 +1,38 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.int_as_float(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        x0 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+        output = torch.empty(8, dtype=torch.float32, device='npu')
+        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.j0.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.j0.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.j0(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_j0():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (torch.special.bessel_j0(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_j0()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.j1.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.j1.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.j1(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_j1():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (torch.special.bessel_j1(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_j1()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.jn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.jn.py
@@ -1,0 +1,40 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.jn(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        x0 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+        x1 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+        output = torch.empty(8, dtype=torch.float32, device='npu')
+        triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_rd.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.ll2float_rd(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_ll2float_rd():
+    x0 = (torch.randint(1, 16, (8, ), dtype=torch.int64)).to(torch.int64).npu()
+    expected = (x0.to(torch.float32)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_ll2float_rd()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_rn.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.ll2float_rn(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_ll2float_rn():
+    x0 = (torch.randint(1, 16, (8, ), dtype=torch.int64)).to(torch.int64).npu()
+    expected = (x0.to(torch.float32)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_ll2float_rn()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_ru.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.ll2float_ru(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_ll2float_ru():
+    x0 = (torch.randint(1, 16, (8, ), dtype=torch.int64)).to(torch.int64).npu()
+    expected = (x0.to(torch.float32)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_ll2float_ru()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_rz.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.ll2float_rz(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_ll2float_rz():
+    x0 = (torch.randint(1, 16, (8, ), dtype=torch.int64)).to(torch.int64).npu()
+    expected = (x0.to(torch.float32)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_ll2float_rz()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.llrint.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.llrint.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.llrint(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_llrint():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.round(x0).to(torch.int64)).to(torch.int64).npu()
+    output = torch.empty(8, dtype=torch.int64, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_llrint()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.llround.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.llround.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.llround(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_llround():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.round(x0).to(torch.int64)).to(torch.int64).npu()
+    output = torch.empty(8, dtype=torch.int64, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_llround()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.log(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_log():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (torch.log(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_log()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log2.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log2.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.log2(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_log2():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (torch.log2(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_log2()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.logb.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.logb.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.logb(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_logb():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (torch.floor(torch.log2(torch.abs(x0))).to(torch.int32)).to(torch.int32).npu()
+    output = torch.empty(8, dtype=torch.int32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_logb()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul24.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul24.py
@@ -1,0 +1,56 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.mul24(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+def _mul24(x, y):
+    """Low 24-bit multiplication result."""
+    v = (int(x) & 0xFFFFFF) * (int(y) & 0xFFFFFF)
+    v &= 0xFFFFFF
+    if v & 0x800000:
+        v -= 0x1000000
+    return v
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_mul24():
+    x0 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    x1 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    expected = torch.tensor([_mul24(*v) for v in zip(x0.tolist(), x1.tolist())], dtype=torch.int32).npu()
+    output = torch.empty(8, dtype=torch.int32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_mul24()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_rd.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.mul_rd(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_mul_rd():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (x0 * x1).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_mul_rd()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_rn.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.mul_rn(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_mul_rn():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (x0 * x1).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_mul_rn()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_ru.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.mul_ru(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_mul_ru():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (x0 * x1).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_mul_ru()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_rz.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.mul_rz(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_mul_rz():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (x0 * x1).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_mul_rz()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mulhi.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mulhi.py
@@ -1,0 +1,54 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.mulhi(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+def _mulhi(x, y):
+    """High 32 bits of the 64-bit product of two 32-bit integers."""
+    p = (int(x) * int(y)) & 0xFFFFFFFFFFFFFFFF
+    v = p >> 32
+    return v - 0x100000000 if v & 0x80000000 else v
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_mulhi():
+    x0 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    x1 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    expected = torch.tensor([_mulhi(*v) for v in zip(x0.tolist(), x1.tolist())], dtype=torch.int32).npu()
+    output = torch.empty(8, dtype=torch.int32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_mulhi()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.norm3d.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.norm3d.py
@@ -1,0 +1,49 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = tl.load(input2 + (x0), mask=mask)
+        tmp3 = libdevice.norm3d(tmp0, tmp1, tmp2)
+        tl.store(output + (x0), tmp3, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_norm3d():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x2 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.sqrt(x0 * x0 + x1 * x1 + x2 * x2)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, x2, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_norm3d()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.norm4d.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.norm4d.py
@@ -1,0 +1,51 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, input2, input3, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = tl.load(input2 + (x0), mask=mask)
+        tmp3 = tl.load(input3 + (x0), mask=mask)
+        tmp4 = libdevice.norm4d(tmp0, tmp1, tmp2, tmp3)
+        tl.store(output + (x0), tmp4, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_norm4d():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x2 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x3 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.sqrt(x0 * x0 + x1 * x1 + x2 * x2 + x3 * x3)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, x2, x3, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_norm4d()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.normcdf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.normcdf.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.normcdf(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_normcdf():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (0.5 * (1 + torch.erf(x0 / 1.4142135623730951))).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_normcdf()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.normcdfinv.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.normcdfinv.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.normcdfinv(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_normcdfinv():
+    x0 = (torch.rand((8, )) * 0.9 + 0.05).to(torch.float32).npu()
+    expected = (1.4142135623730951 * torch.erfinv(2 * x0 - 1)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_normcdfinv()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.popc.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.popc.py
@@ -1,0 +1,50 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.popc(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+def _popc(x):
+    """Number of bits set to 1 in the 32-bit representation of x."""
+    return bin(int(x) & 0xFFFFFFFF).count("1")
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_popc():
+    x0 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    expected = torch.tensor([_popc(*v) for v in zip(x0.tolist())], dtype=torch.int32).npu()
+    output = torch.empty(8, dtype=torch.int32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_popc()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcbrt.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcbrt.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.rcbrt(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_rcbrt():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (1.0 / torch.cbrt(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_rcbrt()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_rd.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.rcp_rd(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_rcp_rd():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (1.0 / x0).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_rcp_rd()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_rn.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.rcp_rn(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_rcp_rn():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (1.0 / x0).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_rcp_rn()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_ru.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.rcp_ru(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_rcp_ru():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (1.0 / x0).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_rcp_ru()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_rz.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.rcp_rz(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_rcp_rz():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (1.0 / x0).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_rcp_rz()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.remainder.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.remainder.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.remainder(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_remainder():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (torch.remainder(x0, x1)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_remainder()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rhadd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rhadd.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.rhadd(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_rhadd():
+    x0 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    x1 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    expected = ((x0 + x1) // 2).to(torch.int32).npu()
+    output = torch.empty(8, dtype=torch.int32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_rhadd()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rhypot.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rhypot.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.rhypot(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_rhypot():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (1.0 / torch.hypot(x0, x1)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_rhypot()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rnorm3d.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rnorm3d.py
@@ -1,0 +1,49 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = tl.load(input2 + (x0), mask=mask)
+        tmp3 = libdevice.rnorm3d(tmp0, tmp1, tmp2)
+        tl.store(output + (x0), tmp3, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_rnorm3d():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x2 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (1.0 / torch.sqrt(x0 * x0 + x1 * x1 + x2 * x2)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, x2, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_rnorm3d()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rnorm4d.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rnorm4d.py
@@ -1,0 +1,51 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, input2, input3, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = tl.load(input2 + (x0), mask=mask)
+        tmp3 = tl.load(input3 + (x0), mask=mask)
+        tmp4 = libdevice.rnorm4d(tmp0, tmp1, tmp2, tmp3)
+        tl.store(output + (x0), tmp4, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_rnorm4d():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x2 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x3 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (1.0 / torch.sqrt(x0 * x0 + x1 * x1 + x2 * x2 + x3 * x3)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, x2, x3, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_rnorm4d()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rsqrt.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rsqrt.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.rsqrt(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_rsqrt():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (torch.rsqrt(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_rsqrt()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rsqrt_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rsqrt_rn.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.rsqrt_rn(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_rsqrt_rn():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (torch.rsqrt(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_rsqrt_rn()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sad.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sad.py
@@ -1,0 +1,49 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = tl.load(input2 + (x0), mask=mask)
+        tmp3 = libdevice.sad(tmp0, tmp1, tmp2)
+        tl.store(output + (x0), tmp3, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_sad():
+    x0 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    x1 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    x2 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    expected = (torch.abs(x0 - x1) + x2).to(torch.int32).npu()
+    output = torch.empty(8, dtype=torch.int32, device='npu')
+    triton_kernel[(1, )](x0, x1, x2, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_sad()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.saturatef.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.saturatef.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.saturatef(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_saturatef():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.clamp(x0, 0.0, 1.0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_saturatef()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.scalbn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.scalbn.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.scalbn(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_scalbn():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    x1 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+    expected = (torch.ldexp(x0, x1)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_scalbn()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sin.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sin.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.sin(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_sin():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.sin(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_sin()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sinpi.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sinpi.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.sinpi(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_sinpi():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (torch.sin(x0 * 3.141592653589793)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_sinpi()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.sqrt(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_sqrt():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (torch.sqrt(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_sqrt()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_rd.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.sqrt_rd(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_sqrt_rd():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (torch.sqrt(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_sqrt_rd()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_rn.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.sqrt_rn(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_sqrt_rn():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (torch.sqrt(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_sqrt_rn()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_ru.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.sqrt_ru(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_sqrt_ru():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (torch.sqrt(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_sqrt_ru()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_rz.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.sqrt_rz(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_sqrt_rz():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (torch.sqrt(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_sqrt_rz()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_rd.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.sub_rd(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_sub_rd():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (x0 - x1).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_sub_rd()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_rn.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.sub_rn(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_sub_rn():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (x0 - x1).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_sub_rn()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_ru.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.sub_ru(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_sub_ru():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (x0 - x1).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_sub_ru()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_rz.py
@@ -1,0 +1,47 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.sub_rz(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_sub_rz():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    x1 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
+    expected = (x0 - x1).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_sub_rz()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.tgamma.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.tgamma.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.tgamma(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_tgamma():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (torch.exp(torch.lgamma(x0))).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_tgamma()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rd.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.uint2float_rd(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_uint2float_rd():
+    x0 = (torch.randint(0, 100, (8, ))).to(torch.int32).npu()
+    expected = (x0.to(torch.float32)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_uint2float_rd()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rn.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.uint2float_rn(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_uint2float_rn():
+    x0 = (torch.randint(0, 100, (8, ))).to(torch.int32).npu()
+    expected = (x0.to(torch.float32)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_uint2float_rn()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_ru.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.uint2float_ru(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_uint2float_ru():
+    x0 = (torch.randint(0, 100, (8, ))).to(torch.int32).npu()
+    expected = (x0.to(torch.float32)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_uint2float_ru()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rz.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.uint2float_rz(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_uint2float_rz():
+    x0 = (torch.randint(0, 100, (8, ))).to(torch.int32).npu()
+    expected = (x0.to(torch.float32)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_uint2float_rz()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint_as_float.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint_as_float.py
@@ -1,0 +1,38 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.uint_as_float(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        x0 = (torch.randint(0, 100, (8, ))).to(torch.int32).npu()
+        output = torch.empty(8, dtype=torch.float32, device='npu')
+        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rd.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.ull2float_rd(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_ull2float_rd():
+    x0 = (torch.randint(0, 100, (8, ), dtype=torch.int64)).to(torch.int64).npu()
+    expected = (x0.to(torch.float32)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_ull2float_rd()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rn.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.ull2float_rn(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_ull2float_rn():
+    x0 = (torch.randint(0, 100, (8, ), dtype=torch.int64)).to(torch.int64).npu()
+    expected = (x0.to(torch.float32)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_ull2float_rn()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_ru.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.ull2float_ru(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_ull2float_ru():
+    x0 = (torch.randint(0, 100, (8, ), dtype=torch.int64)).to(torch.int64).npu()
+    expected = (x0.to(torch.float32)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_ull2float_ru()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rz.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.ull2float_rz(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_ull2float_rz():
+    x0 = (torch.randint(0, 100, (8, ), dtype=torch.int64)).to(torch.int64).npu()
+    expected = (x0.to(torch.float32)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_ull2float_rz()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.y0.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.y0.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.y0(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_y0():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (torch.special.bessel_y0(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_y0()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.y1.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.y1.py
@@ -1,0 +1,45 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = libdevice.y1(tmp0)
+        tl.store(output + (x0), tmp1, mask=mask)
+
+
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_y1():
+    x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+    expected = (torch.special.bessel_y1(x0)).to(torch.float32).npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
+    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_y1()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.yn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.yn.py
@@ -1,0 +1,40 @@
+import os
+
+# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
+# additionally gated by this env switch; set it so the examples run on A5
+# hardware without extra configuration.
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
+import triton
+import triton.language as tl
+import triton.language.extra.cann.libdevice as libdevice
+import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops require an Ascend 950 target "
+                  "with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
+
+
+@triton.jit
+def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    offset = tl.program_id(0) * XBLOCK
+    base = tl.arange(0, XBLOCK_SUB)
+    loops: tl.constexpr = XBLOCK // XBLOCK_SUB
+    for loop in range(loops):
+        x0 = offset + (loop * XBLOCK_SUB) + base
+        mask = x0 < n_elements
+        tmp0 = tl.load(input0 + (x0), mask=mask)
+        tmp1 = tl.load(input1 + (x0), mask=mask)
+        tmp2 = libdevice.yn(tmp0, tmp1)
+        tl.store(output + (x0), tmp2, mask=mask)
+
+
+if __name__ == "__main__":
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        x0 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
+        x1 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
+        output = torch.empty(8, dtype=torch.float32, device='npu')
+        triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)

--- a/docs/zh/python-api/_inject_ascend_notes.py
+++ b/docs/zh/python-api/_inject_ascend_notes.py
@@ -159,7 +159,32 @@ def autodoc_process_docstring(app, what, name, obj, options, lines):
     lines.extend(note_lines)
 
 
+def _patch_module_docstrings():
+    """Patch ``__doc__`` on libdevice functions from ``replace_docstring`` entries.
+
+    The autodoc-process-docstring event above only fires when autodoc renders
+    a stub page — not when autosummary builds the summary table on the
+    overview page.  Autosummary extracts summaries from the object's real
+    ``__doc__``, and most libdevice functions have no source docstring, so
+    their table summaries would be empty.  Patch the module in place so the
+    guide-derived ``replace_docstring`` text is used everywhere.
+    """
+    import sys as _sys
+
+    _mod = _sys.modules.get("triton.language.extra.cann.libdevice")
+    if _mod is None:
+        return
+    for _name, _data in ASCEND_CONSTRAINTS.items():
+        _lines = _data.get("replace_docstring")
+        if not _lines or not _name.startswith("triton.language.extra.cann.libdevice."):
+            continue
+        _fn = getattr(_mod, _name.rsplit(".", 1)[-1], None)
+        if _fn is not None:
+            _fn.__doc__ = "\n".join(_lines)
+
+
 def setup(app):
     """Register the extension with Sphinx."""
+    _patch_module_docstrings()
     app.connect("autodoc-process-docstring", autodoc_process_docstring)
     return {"version": "0.1", "parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/zh/python-api/triton.language.extra.cann.libdevice.rst
+++ b/docs/zh/python-api/triton.language.extra.cann.libdevice.rst
@@ -12,41 +12,166 @@ Libdevice Ops
     :toctree: generated
     :nosignatures:
 
+    abs
     acos
     acosh
+    add_rd
+    add_rn
+    add_ru
+    add_rz
     asin
     asinh
     atan
     atan2
     atanh
+    brev
+    byte_perm
+    cbrt
+    ceil
+    clz
     copysign
+    cos
     cosh
+    cospi
     cyl_bessel_i0
+    cyl_bessel_i1
+    div_rd
+    div_rn
+    div_ru
     div_rz
+    erf
+    erfc
+    erfcinv
+    erfcx
     erfinv
+    exp
+    exp10
+    exp2
     expm1
+    fast_cosf
     fast_dividef
+    fast_exp10f
     fast_expf
+    fast_log10f
+    fast_log2f
+    fast_logf
+    fast_powf
+    fast_sinf
+    fast_tanf
+    fdim
+    ffs
+    finitef
+    float2int_rd
+    float2int_rn
+    float2int_ru
+    float2int_rz
+    float2ll_rd
+    float2ll_rn
+    float2ll_ru
+    float2ll_rz
+    float2uint_rd
+    float2uint_rn
+    float2uint_ru
+    float2uint_rz
+    float2ull_rd
+    float2ull_rn
+    float2ull_ru
+    float2ull_rz
     float_as_int
+    float_as_uint
+    floor
+    fma
+    fma_rd
+    fma_rn
+    fma_ru
+    fma_rz
     fmod
     gamma
+    hadd
     hypot
     ilogb
+    int2float_rd
+    int2float_rn
+    int2float_ru
+    int2float_rz
+    int_as_float
     isinf
     isnan
+    j0
+    j1
+    jn
     ldexp
     lgamma
+    ll2float_rd
+    ll2float_rn
+    ll2float_ru
+    ll2float_rz
+    llrint
+    llround
+    log
     log10
     log1p
+    log2
+    logb
+    mul24
+    mul_rd
+    mul_rn
+    mul_ru
+    mul_rz
+    mulhi
     nearbyint
     nextafter
+    norm3d
+    norm4d
+    normcdf
+    normcdfinv
+    popc
     pow
+    rcbrt
+    rcp_rd
+    rcp_rn
+    rcp_ru
+    rcp_rz
     reciprocal
     relu
+    remainder
+    rhadd
+    rhypot
     rint
+    rnorm3d
+    rnorm4d
     round
+    rsqrt
+    rsqrt_rn
+    sad
+    saturatef
+    scalbn
     signbit
+    sin
     sinh
+    sinpi
+    sqrt
+    sqrt_rd
+    sqrt_rn
+    sqrt_ru
+    sqrt_rz
+    sub_rd
+    sub_rn
+    sub_ru
+    sub_rz
     tan
     tanh
+    tgamma
     trunc
+    uint2float_rd
+    uint2float_rn
+    uint2float_ru
+    uint2float_rz
+    uint_as_float
+    ull2float_rd
+    ull2float_rn
+    ull2float_ru
+    ull2float_rz
+    y0
+    y1
+    yn

--- a/docs/zh/python-api/triton.language.rst
+++ b/docs/zh/python-api/triton.language.rst
@@ -9,7 +9,6 @@ Programming Model
 -----------------
 
 .. autosummary::
-    :toctree: generated
     :nosignatures:
 
     tensor
@@ -22,7 +21,6 @@ Creation Ops
 ------------
 
 .. autosummary::
-    :toctree: generated
     :nosignatures:
 
     arange
@@ -36,7 +34,6 @@ Shape Manipulation Ops
 ----------------------
 
 .. autosummary::
-    :toctree: generated
     :nosignatures:
 
     broadcast
@@ -55,7 +52,6 @@ Linear Algebra Ops
 ------------------
 
 .. autosummary::
-    :toctree: generated
     :nosignatures:
 
     dot
@@ -65,7 +61,6 @@ Memory/Pointer Ops
 ------------------
 
 .. autosummary::
-    :toctree: generated
     :nosignatures:
 
     load
@@ -80,7 +75,6 @@ Indexing Ops
 ------------
 
 .. autosummary::
-    :toctree: generated
     :nosignatures:
 
     flip
@@ -92,7 +86,6 @@ Math Ops
 --------
 
 .. autosummary::
-    :toctree: generated
     :nosignatures:
 
     abs
@@ -130,7 +123,6 @@ Logical Ops
 -----------
 
 .. autosummary::
-    :toctree: generated
     :nosignatures:
 
     and
@@ -147,7 +139,6 @@ Comparison Ops
 --------------
 
 .. autosummary::
-    :toctree: generated
     :nosignatures:
 
     gt
@@ -161,7 +152,6 @@ Reduction Ops
 -------------
 
 .. autosummary::
-    :toctree: generated
     :nosignatures:
 
     argmax
@@ -177,7 +167,6 @@ Scan/Sort Ops
 -------------
 
 .. autosummary::
-    :toctree: generated
     :nosignatures:
 
     associative_scan
@@ -192,7 +181,6 @@ Atomic Ops
 ----------
 
 .. autosummary::
-    :toctree: generated
     :nosignatures:
 
     atomic_add
@@ -208,7 +196,6 @@ Random Number Generation
 ------------------------
 
 .. autosummary::
-    :toctree: generated
     :nosignatures:
 
     randint4x
@@ -222,7 +209,6 @@ Iterators
 ---------
 
 .. autosummary::
-    :toctree: generated
     :nosignatures:
 
     range
@@ -233,7 +219,6 @@ Compiler Hint Ops
 -----------------
 
 .. autosummary::
-    :toctree: generated
     :nosignatures:
 
     assume
@@ -246,7 +231,6 @@ Debug Ops
 ---------
 
 .. autosummary::
-    :toctree: generated
     :nosignatures:
 
     static_print
@@ -258,7 +242,29 @@ Inline Assembly
 ---------------
 
 .. autosummary::
-    :toctree: generated
     :nosignatures:
 
     inline_asm_elementwise
+
+
+.. toctree::
+    :maxdepth: 1
+    :class: sidebar-groups-only
+
+    triton.language/programming_model
+    triton.language/creation_ops
+    triton.language/shape_manipulation_ops
+    triton.language/linear_algebra_ops
+    triton.language/memory_pointer_ops
+    triton.language/indexing_ops
+    triton.language/math_ops
+    triton.language/logical_ops
+    triton.language/comparison_ops
+    triton.language/reduction_ops
+    triton.language/scan_sort_ops
+    triton.language/atomic_ops
+    triton.language/random_number_generation
+    triton.language/iterators
+    triton.language/compiler_hint_ops
+    triton.language/debug_ops
+    triton.language/inline_assembly

--- a/docs/zh/python-api/triton.language/atomic_ops.rst
+++ b/docs/zh/python-api/triton.language/atomic_ops.rst
@@ -1,0 +1,17 @@
+Atomic Ops
+==========
+
+.. currentmodule:: triton.language
+
+.. autosummary::
+    :toctree: ../generated
+    :nosignatures:
+
+    atomic_add
+    atomic_and
+    atomic_cas
+    atomic_max
+    atomic_min
+    atomic_or
+    atomic_xchg
+    atomic_xor

--- a/docs/zh/python-api/triton.language/comparison_ops.rst
+++ b/docs/zh/python-api/triton.language/comparison_ops.rst
@@ -1,0 +1,15 @@
+Comparison Ops
+==============
+
+.. currentmodule:: triton.language
+
+.. autosummary::
+    :toctree: ../generated
+    :nosignatures:
+
+    gt
+    ge
+    lt
+    le
+    eq
+    ne

--- a/docs/zh/python-api/triton.language/compiler_hint_ops.rst
+++ b/docs/zh/python-api/triton.language/compiler_hint_ops.rst
@@ -1,0 +1,14 @@
+Compiler Hint Ops
+=================
+
+.. currentmodule:: triton.language
+
+.. autosummary::
+    :toctree: ../generated
+    :nosignatures:
+
+    assume
+    debug_barrier
+    max_constancy
+    max_contiguous
+    multiple_of

--- a/docs/zh/python-api/triton.language/creation_ops.rst
+++ b/docs/zh/python-api/triton.language/creation_ops.rst
@@ -1,0 +1,15 @@
+Creation Ops
+============
+
+.. currentmodule:: triton.language
+
+.. autosummary::
+    :toctree: ../generated
+    :nosignatures:
+
+    arange
+    cat
+    full
+    zeros
+    zeros_like
+    cast

--- a/docs/zh/python-api/triton.language/debug_ops.rst
+++ b/docs/zh/python-api/triton.language/debug_ops.rst
@@ -1,0 +1,13 @@
+Debug Ops
+=========
+
+.. currentmodule:: triton.language
+
+.. autosummary::
+    :toctree: ../generated
+    :nosignatures:
+
+    static_print
+    static_assert
+    device_print
+    device_assert

--- a/docs/zh/python-api/triton.language/indexing_ops.rst
+++ b/docs/zh/python-api/triton.language/indexing_ops.rst
@@ -1,0 +1,13 @@
+Indexing Ops
+============
+
+.. currentmodule:: triton.language
+
+.. autosummary::
+    :toctree: ../generated
+    :nosignatures:
+
+    flip
+    where
+    swizzle2d
+    gather

--- a/docs/zh/python-api/triton.language/inline_assembly.rst
+++ b/docs/zh/python-api/triton.language/inline_assembly.rst
@@ -1,0 +1,10 @@
+Inline Assembly
+===============
+
+.. currentmodule:: triton.language
+
+.. autosummary::
+    :toctree: ../generated
+    :nosignatures:
+
+    inline_asm_elementwise

--- a/docs/zh/python-api/triton.language/iterators.rst
+++ b/docs/zh/python-api/triton.language/iterators.rst
@@ -1,0 +1,12 @@
+Iterators
+=========
+
+.. currentmodule:: triton.language
+
+.. autosummary::
+    :toctree: ../generated
+    :nosignatures:
+
+    range
+    static_range
+    condition

--- a/docs/zh/python-api/triton.language/linear_algebra_ops.rst
+++ b/docs/zh/python-api/triton.language/linear_algebra_ops.rst
@@ -1,0 +1,11 @@
+Linear Algebra Ops
+==================
+
+.. currentmodule:: triton.language
+
+.. autosummary::
+    :toctree: ../generated
+    :nosignatures:
+
+    dot
+    dot_scaled

--- a/docs/zh/python-api/triton.language/logical_ops.rst
+++ b/docs/zh/python-api/triton.language/logical_ops.rst
@@ -1,0 +1,18 @@
+Logical Ops
+===========
+
+.. currentmodule:: triton.language
+
+.. autosummary::
+    :toctree: ../generated
+    :nosignatures:
+
+    and
+    or
+    xor
+    not
+    logical_and
+    logical_or
+    invert
+    lshift
+    rshift

--- a/docs/zh/python-api/triton.language/math_ops.rst
+++ b/docs/zh/python-api/triton.language/math_ops.rst
@@ -1,0 +1,39 @@
+Math Ops
+========
+
+.. currentmodule:: triton.language
+
+.. autosummary::
+    :toctree: ../generated
+    :nosignatures:
+
+    abs
+    add
+    cdiv
+    ceil
+    clamp
+    cos
+    div
+    div_rn
+    erf
+    exp
+    exp2
+    fdiv
+    floordiv
+    floor
+    fma
+    log
+    log2
+    maximum
+    minimum
+    mod
+    mul
+    neg
+    rsqrt
+    sigmoid
+    sin
+    softmax
+    sqrt
+    sqrt_rn
+    sub
+    umulhi

--- a/docs/zh/python-api/triton.language/memory_pointer_ops.rst
+++ b/docs/zh/python-api/triton.language/memory_pointer_ops.rst
@@ -1,0 +1,16 @@
+Memory/Pointer Ops
+==================
+
+.. currentmodule:: triton.language
+
+.. autosummary::
+    :toctree: ../generated
+    :nosignatures:
+
+    load
+    store
+    make_tensor_descriptor
+    load_tensor_descriptor
+    store_tensor_descriptor
+    make_block_ptr
+    advance

--- a/docs/zh/python-api/triton.language/programming_model.rst
+++ b/docs/zh/python-api/triton.language/programming_model.rst
@@ -1,0 +1,14 @@
+Programming Model
+=================
+
+.. currentmodule:: triton.language
+
+.. autosummary::
+    :toctree: ../generated
+    :nosignatures:
+
+    tensor
+    tensor_descriptor
+    program_id
+    num_programs
+    map_elementwise

--- a/docs/zh/python-api/triton.language/random_number_generation.rst
+++ b/docs/zh/python-api/triton.language/random_number_generation.rst
@@ -1,0 +1,15 @@
+Random Number Generation
+========================
+
+.. currentmodule:: triton.language
+
+.. autosummary::
+    :toctree: ../generated
+    :nosignatures:
+
+    randint4x
+    randint
+    rand
+    rand4x
+    randn
+    randn4x

--- a/docs/zh/python-api/triton.language/reduction_ops.rst
+++ b/docs/zh/python-api/triton.language/reduction_ops.rst
@@ -1,0 +1,17 @@
+Reduction Ops
+=============
+
+.. currentmodule:: triton.language
+
+.. autosummary::
+    :toctree: ../generated
+    :nosignatures:
+
+    argmax
+    argmin
+    max
+    min
+    reduce
+    reduce_or
+    sum
+    xor_sum

--- a/docs/zh/python-api/triton.language/scan_sort_ops.rst
+++ b/docs/zh/python-api/triton.language/scan_sort_ops.rst
@@ -1,0 +1,16 @@
+Scan/Sort Ops
+=============
+
+.. currentmodule:: triton.language
+
+.. autosummary::
+    :toctree: ../generated
+    :nosignatures:
+
+    associative_scan
+    bitonic_merge
+    cumprod
+    cumsum
+    histogram
+    sort
+    topk

--- a/docs/zh/python-api/triton.language/shape_manipulation_ops.rst
+++ b/docs/zh/python-api/triton.language/shape_manipulation_ops.rst
@@ -1,0 +1,20 @@
+Shape Manipulation Ops
+======================
+
+.. currentmodule:: triton.language
+
+.. autosummary::
+    :toctree: ../generated
+    :nosignatures:
+
+    broadcast
+    broadcast_to
+    expand_dims
+    interleave
+    join
+    permute
+    ravel
+    reshape
+    split
+    trans
+    view

--- a/docs/zh/quick_start.md
+++ b/docs/zh/quick_start.md
@@ -4,7 +4,7 @@
 
 **Triton-Ascend**是适配华为Ascend处理器的Triton优化版本，用于高效进行核函数自动调优、算子编译及部署，通过兼容Triton核心语法并针对昇腾NPU特性进行深度优化，能够帮助用户在昇腾平台上快速开发和部署高性能计算任务。
 
-本文以**Ubuntu 22.04**环境下通过软件包部署方式在线安装并运行向量加法实例为例，指导用户快速上手使用**Triton-Ascend**。如需体验更多安装方式请阅读[安装指南](./installation_guide.md)文档。
+本文以**Ubuntu 22.04**环境下通过软件包部署方式在线安装并运行向量加法示例为例，指导用户快速上手使用**Triton-Ascend**。如需体验更多安装方式请阅读[安装指南](./installation_guide.md)文档。
 
 ## 环境准备
 
@@ -35,9 +35,9 @@ pip install triton-ascend --extra-index-url=https://mirrors.huaweicloud.com/asce
 
 ## 快速开始
 
-**运行tutorials中向量加法实例验证结果**
+**运行tutorials中向量加法示例验证结果**
 
-向量加法实例：[01-vector-add.py](../../third_party/ascend/tutorials/01-vector-add.py)
+向量加法示例：[01-vector-add.py](../../third_party/ascend/tutorials/01-vector-add.py)
 通过对比Triton算子与PyTorch原生计算的输出结果，证明昇腾NPU设备可正确调用Triton算子并保证计算精度。
 > ⚠️ 下述命令需在 bash 环境下执行。若使用 POSIX sh，请将 `source` 替换为 `.`。
 
@@ -46,7 +46,7 @@ pip install triton-ascend --extra-index-url=https://mirrors.huaweicloud.com/asce
 source /usr/local/Ascend/ascend-toolkit/set_env.sh
 # 拉取triton-ascend源码仓及用例
 git clone https://github.com/triton-lang/triton-ascend.git
-# 运行tutorials实例
+# 运行tutorials示例
 python3 ./triton-ascend/third_party/ascend/tutorials/01-vector-add.py
 ```
 


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
### Summary
Fixes two rendering/accessibility problems in the docs:
1. triton.language APIs are no longer one flat list in the left sidebar — the nav now groups them by category (Programming Model, Creation Ops, …), matching the in-page TOC on the right.
2. The triton.language.extra.cann.libdevice page is restored to the API Reference toctree, rendering for display.
3. Supplement the missing libdevice documentation and corresponding usage examples.
For now, it only completes the display of libdevice ops based on the existing web materials. The detailed content of every op will be updated by the libdevice owner in a follow-up pr.

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
