### PR TITLE
[Autotune](fix) Enable L2 cache clearing for NPU autotune

### DIFF
--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -2260,7 +2260,7 @@ class AutoTilingTuner(Autotuner):
                     list(run_fns.values()),
                     warmup=warmup,
                     active=active,
-                    clear_l2_cache=False,
+                    clear_l2_cache=True,
                     target_kernel_name=target_kernel_name,
                 )
                 assert len(time_cost) == len(run_fns)

--- a/third_party/ascend/unittest/autotune_ut/test_do_bench_compat.py
+++ b/third_party/ascend/unittest/autotune_ut/test_do_bench_compat.py
@@ -128,6 +128,7 @@ def test_batch_bench_npu_env_uses_do_bench_npu_without_user_do_bench(monkeypatch
     def _do_bench_npu(funcs, clear_l2_cache=False, warmup=5, active=30, target_kernel_name=None, **kwargs):
         calls["do_bench_npu"] += 1
         assert len(funcs) == 2
+        assert clear_l2_cache is True
         return [1.0, 2.0]
 
     tuner = _make_tuner(_do_bench)


### PR DESCRIPTION
## Summary

- Port the L2 cache clearing behavior from #969 to `main-dev`.
- Clear L2 before every profiled NPU autotune candidate so benchmark results are less sensitive to candidate ordering.
- Extend the existing `_batch_bench` unit test to verify `clear_l2_cache=True` is forwarded to `do_bench_npu`.

## Original change

- Original PR: https://github.com/triton-lang/triton-ascend/pull/969
- Original commit: `1189253d1074bd38e70235de0f9165e5f5e6f201`
- The original PR was merged into `release/3.2.2-dev`; its head and merge commit are not ancestors of `main-dev`.

## Validation

- `python -m py_compile third_party/ascend/backend/runtime/autotuner.py third_party/ascend/unittest/autotune_ut/test_do_bench_compat.py`
- `python -m pytest -q third_party/ascend/unittest/autotune_ut/test_do_bench_compat.py` using the source-loaded `main-dev` autotuner: `9 passed`
- Repository-configured pre-commit hooks on both affected files, run twice: passed
- Repository-configured pre-commit hooks over the complete commit range: passed
- `git diff --check`: passed
