### PR TITLE
[Launcher](fix) prebuild NPU utils without torch_npu loading

### DIFF
--- a/third_party/ascend/backend/backend_register.py
+++ b/third_party/ascend/backend/backend_register.py
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+import importlib.util
 import os
 from typing import Callable, Dict
 
@@ -195,12 +196,21 @@ def get_cc_cmd():
     ]
 
 
+def _get_package_dir(package_name):
+    spec = importlib.util.find_spec(package_name)
+    if spec is None:
+        raise ModuleNotFoundError(f"No module named '{package_name}'")
+    if spec.submodule_search_locations:
+        return os.path.realpath(next(iter(spec.submodule_search_locations)))
+    if spec.origin is None:
+        raise ModuleNotFoundError(f"Cannot locate module '{package_name}'")
+    return os.path.dirname(os.path.realpath(spec.origin))
+
+
 @backend_strategy_registry.register("torch_npu", "get_cc_cmd_npu_utils")
 def get_cc_cmd_npu_utils():
-    import torch
-    import torch_npu
-    torch_path = os.path.dirname(os.path.realpath(torch.__file__))
-    torch_npu_path = os.path.dirname(os.path.realpath(torch_npu.__file__))
+    torch_path = _get_package_dir("torch")
+    torch_npu_path = _get_package_dir("torch_npu")
     cc_cmd = [
         f"-I{os.path.join(torch_path, 'include')}",
         f"-I{os.path.join(torch_npu_path, 'include')}",

--- a/third_party/ascend/backend/backend_register.py
+++ b/third_party/ascend/backend/backend_register.py
@@ -76,19 +76,6 @@ class _LazyBackendStrategyRegister:
 backend_strategy_registry = _LazyBackendStrategyRegister()
 
 
-@backend_strategy_registry.register("mindspore", "version_hash")
-def version_hash():
-    import mindspore
-    return [str(mindspore.version)]
-
-
-@backend_strategy_registry.register("torch_npu", "version_hash")
-def version_hash():
-    import torch
-    import torch_npu
-    return [torch.version.git_version, torch_npu.version.git_version]
-
-
 @backend_strategy_registry.register("mindspore", "cxx_abi")
 def get_mindspore_cxx_abi():
     return 0

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -65,13 +65,7 @@ class NPUUtils(object):
         src = Path(src_path).read_text()
         cann_version = get_cann_version()
         cann_version_str = ".".join(map(str, cann_version)) if cann_version else ""
-        key_parts = [
-            "npu_utils",
-            "torch_npu_wrapper_abi=triton_async_launch_v1",
-            "USE_TORCH_NPU",
-            f"cann_version={cann_version_str}",
-            src,
-        ]
+        key_parts = [cann_version_str, src]
         key = hashlib.md5("\0".join(key_parts).encode("utf-8")).hexdigest()
         cache = get_cache_manager(key)
         fname = "npu_utils.so"

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -75,9 +75,10 @@ class NPUUtils(object):
     def __init__(self):
         if getattr(self, "_initialized", False):
             return
-        self._initialized = True
         self._cache_path = None
         self.npu_utils_mod = None
+        self._cache_path = self._build_or_get_cached_so()
+        self._initialized = True
 
     def get_so_path(self):
         if self._cache_path is None:

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -241,6 +241,7 @@ class NPULauncher(object):
         spec = importlib.util.spec_from_file_location("__triton_launcher", self.so_launcher_path)
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
+        mod.set_npu_utils_path(NPUUtils().get_so_path())
         cst_key = lambda i: self.src.fn.arg_names.index(i) if isinstance(i, str) else i
         signature = {cst_key(key): value for key, value in self.src.signature.items()}
         self.launch = wrap_handle_tensordesc(getattr(mod, "launch"), signature)
@@ -1010,6 +1011,8 @@ static triton_allocate_workspace_t g_allocate_workspace = nullptr;
 static triton_allocate_sync_block_lock_t g_allocate_sync_block_lock = nullptr;
 static triton_async_launch_t g_async_launch = nullptr;
 static triton_release_retained_tensor_t g_release_retained_tensor = nullptr;
+static std::string g_npu_utils_path;
+static std::string g_npu_utils_error;
 
 static bool npu_utils_ready() {{
     return g_allocate_workspace &&
@@ -1018,31 +1021,57 @@ static bool npu_utils_ready() {{
            g_release_retained_tensor;
 }}
 
-static void init_npu_utils() {{
-    if (npu_utils_ready()) return;
-    const char* cache_root = std::getenv("TRITON_CACHE_DIR");
-    std::string npu_utils_path;
-    if (cache_root && cache_root[0] != '\\0') {{
-        npu_utils_path = std::string(cache_root) + "/{npu_utils_cache_relative}";
-    }} else {{
-        const char* triton_home = std::getenv("TRITON_HOME");
-        const char* home = std::getenv("HOME");
-        const char* base = triton_home && triton_home[0] != '\\0' ? triton_home : home;
-        if (!base || base[0] == '\\0') {{
-            fprintf(stderr, "Error: neither TRITON_CACHE_DIR nor TRITON_HOME/HOME is set\\n");
-            return;
+static bool init_npu_utils() {{
+    if (npu_utils_ready()) return true;
+    std::string npu_utils_path = g_npu_utils_path;
+    if (npu_utils_path.empty()) {{
+        // Compatibility fallback for callers of the exported C launcher API,
+        // which cannot inject the cache-manager-resolved path through Python.
+        const char* cache_root = std::getenv("TRITON_CACHE_DIR");
+        if (cache_root && cache_root[0] != '\\0') {{
+            npu_utils_path = std::string(cache_root) + "/{npu_utils_cache_relative}";
+        }} else {{
+            const char* triton_home = std::getenv("TRITON_HOME");
+            const char* home = std::getenv("HOME");
+            const char* base = triton_home && triton_home[0] != '\\0' ? triton_home : home;
+            if (!base || base[0] == '\\0') {{
+                g_npu_utils_error = "neither TRITON_CACHE_DIR nor TRITON_HOME/HOME is set";
+                fprintf(stderr, "Error: %s\\n", g_npu_utils_error.c_str());
+                return false;
+            }}
+            npu_utils_path = std::string(base) + "/.triton/cache/{npu_utils_cache_relative}";
         }}
-        npu_utils_path = std::string(base) + "/.triton/cache/{npu_utils_cache_relative}";
     }}
     void* handle = dlopen(npu_utils_path.c_str(), RTLD_LAZY);
     if (!handle) {{
-        fprintf(stderr, "Error: dlopen %s failed: %s\\n", npu_utils_path.c_str(), dlerror());
-        return;
+        const char* error = dlerror();
+        g_npu_utils_error = error ? error : "unknown dlopen error";
+        fprintf(stderr, "Error: dlopen %s failed: %s\\n", npu_utils_path.c_str(), g_npu_utils_error.c_str());
+        return false;
     }}
     g_allocate_workspace = (triton_allocate_workspace_t)dlsym(handle, "triton_allocate_workspace");
     g_allocate_sync_block_lock = (triton_allocate_sync_block_lock_t)dlsym(handle, "triton_allocate_sync_block_lock");
     g_async_launch = (triton_async_launch_t)dlsym(handle, "triton_async_launch");
     g_release_retained_tensor = (triton_release_retained_tensor_t)dlsym(handle, "triton_release_retained_tensor");
+    if (!npu_utils_ready()) {{
+        g_npu_utils_error = "required NPU utility symbols are unavailable";
+        fprintf(stderr, "Error: %s in %s\\n", g_npu_utils_error.c_str(), npu_utils_path.c_str());
+        return false;
+    }}
+    g_npu_utils_error.clear();
+    return true;
+}}
+
+static PyObject* set_npu_utils_path(PyObject* self, PyObject* path_obj) {{
+    const char* path = PyUnicode_AsUTF8(path_obj);
+    if (!path) return nullptr;
+    g_npu_utils_path = path;
+    if (!init_npu_utils()) {{
+        PyErr_Format(PyExc_RuntimeError, "Failed to load NPU utilities from %s: %s", path,
+                     g_npu_utils_error.c_str());
+        return nullptr;
+    }}
+    Py_RETURN_NONE;
 }}
 
 static void release_npu_tensor_handle(void* handle) {{
@@ -1488,6 +1517,8 @@ static PyObject* launch(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 }}
 
 static PyMethodDef ModuleMethods[] = {{
+  {{"set_npu_utils_path", (PyCFunction)set_npu_utils_path, METH_O,
+    "Initialize NPU utilities from the cache-manager-resolved shared-object path"}},
   {{"launch", (PyCFunction)launch, METH_FASTCALL, "Entry point for all kernels with this signature"}},
   {{nullptr, nullptr, 0, nullptr}} // sentinel
 }};
@@ -1507,9 +1538,6 @@ PyMODINIT_FUNC PyInit___triton_launcher(void) {{
   }}
   PyModule_AddFunctions(m, ModuleMethods);
   {cpp_msprof_callback}
-  // One-time initialization of NPU utils (dlsym lookup for g_async_launch etc.)
-  // Moved here from the per-call async_launch path to avoid repeated dlsym work.
-  init_npu_utils();
   return m;
 }}
 """

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -19,8 +19,6 @@
 # THE SOFTWARE.
 
 from pathlib import Path
-import contextlib
-import fcntl
 import tempfile
 import os
 import os.path
@@ -39,30 +37,6 @@ from triton.backends.ascend.utils import (_build_npu_ext, _check_cxx11_abi, conv
 # Bind the already-imported utils module once so the launch hot path can write
 # TRITON_PROFILER_REGISTERED without a per-launch `import triton` + attribute walk.
 import triton.backends.ascend.utils as _ascend_utils
-
-
-def _get_cache_lock_path(cache):
-    lock_path = getattr(cache, "lock_path", None)
-    if lock_path is not None:
-        return lock_path
-    file_cache_manager = getattr(cache, "_file_cache_manager", None)
-    return getattr(file_cache_manager, "lock_path", None)
-
-
-@contextlib.contextmanager
-def _cache_build_lock(cache):
-    lock_path = _get_cache_lock_path(cache)
-    if lock_path is None:
-        yield
-        return
-
-    os.makedirs(os.path.dirname(lock_path), exist_ok=True)
-    with open(lock_path, "a") as lock_file:
-        fcntl.flock(lock_file, fcntl.LOCK_EX)
-        try:
-            yield
-        finally:
-            fcntl.flock(lock_file, fcntl.LOCK_UN)
 
 
 class NPUUtils(object):
@@ -105,18 +79,13 @@ class NPUUtils(object):
         if cache_path is not None and os.path.exists(cache_path):
             return cache_path
 
-        with _cache_build_lock(cache):
-            cache_path = cache.get_file(fname)
-            if cache_path is not None and os.path.exists(cache_path):
-                return cache_path
-
-            with tempfile.TemporaryDirectory() as tmpdir:
-                tmp_src_path = os.path.join(tmpdir, "npu_utils.cpp")
-                with open(tmp_src_path, "w") as f:
-                    f.write(src)
-                so = _build_npu_ext("npu_utils", tmp_src_path)
-                with open(so, "rb") as f:
-                    cache_path = cache.put(f.read(), fname, binary=True)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_src_path = os.path.join(tmpdir, "npu_utils.cpp")
+            with open(tmp_src_path, "w") as f:
+                f.write(src)
+            so = _build_npu_ext("npu_utils", tmp_src_path)
+            with open(so, "rb") as f:
+                cache_path = cache.put(f.read(), fname, binary=True)
         return cache_path
 
     def _load_mod(self):

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -48,12 +48,14 @@ class NPUUtils(object):
         return cls.instance
 
     def __init__(self):
-        if getattr(self, "_initialized", False):
-            return
-        self._cache_path = None
-        self.npu_utils_mod = None
+        # NPUUtils is a singleton, but __init__ must refresh the cached shared
+        # object path on every construction. PyTorch Inductor may set
+        # TRITON_CACHE_DIR after the driver first initializes, so keeping the
+        # first path would make the launcher look for npu_utils.so in a newer
+        # cache root where it was never built.
         self._cache_path = self._build_or_get_cached_so()
-        self._initialized = True
+        if not hasattr(self, "npu_utils_mod"):
+            self.npu_utils_mod = None
 
     def get_so_path(self):
         if self._cache_path is None:

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -95,9 +95,7 @@ class NPUUtils(object):
         self.npu_utils_mod = mod
         return self.npu_utils_mod
 
-    def load_binary(self, name, kernel, shared, device, mix_mode=None):
-        if mix_mode is None:
-            name, mix_mode = name.rsplit("_", 1)
+    def load_binary(self, name, kernel, shared, device, mix_mode):
         return self._load_mod().load_kernel_binary(name, kernel, shared, device, mix_mode)
 
     def _get_npu_device_limit_form_env(self) -> tuple[int, int]:

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -207,7 +207,6 @@ class NPULauncher(object):
         spec = importlib.util.spec_from_file_location("__triton_launcher", self.so_launcher_path)
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
-        mod.set_npu_utils_path(NPUUtils().get_so_path())
         cst_key = lambda i: self.src.fn.arg_names.index(i) if isinstance(i, str) else i
         signature = {cst_key(key): value for key, value in self.src.signature.items()}
         self.launch = wrap_handle_tensordesc(getattr(mod, "launch"), signature)
@@ -977,8 +976,6 @@ static triton_allocate_workspace_t g_allocate_workspace = nullptr;
 static triton_allocate_sync_block_lock_t g_allocate_sync_block_lock = nullptr;
 static triton_async_launch_t g_async_launch = nullptr;
 static triton_release_retained_tensor_t g_release_retained_tensor = nullptr;
-static std::string g_npu_utils_path;
-static std::string g_npu_utils_error;
 
 static bool npu_utils_ready() {{
     return g_allocate_workspace &&
@@ -987,57 +984,31 @@ static bool npu_utils_ready() {{
            g_release_retained_tensor;
 }}
 
-static bool init_npu_utils() {{
-    if (npu_utils_ready()) return true;
-    std::string npu_utils_path = g_npu_utils_path;
-    if (npu_utils_path.empty()) {{
-        // Compatibility fallback for callers of the exported C launcher API,
-        // which cannot inject the cache-manager-resolved path through Python.
-        const char* cache_root = std::getenv("TRITON_CACHE_DIR");
-        if (cache_root && cache_root[0] != '\\0') {{
-            npu_utils_path = std::string(cache_root) + "/{npu_utils_cache_relative}";
-        }} else {{
-            const char* triton_home = std::getenv("TRITON_HOME");
-            const char* home = std::getenv("HOME");
-            const char* base = triton_home && triton_home[0] != '\\0' ? triton_home : home;
-            if (!base || base[0] == '\\0') {{
-                g_npu_utils_error = "neither TRITON_CACHE_DIR nor TRITON_HOME/HOME is set";
-                fprintf(stderr, "Error: %s\\n", g_npu_utils_error.c_str());
-                return false;
-            }}
-            npu_utils_path = std::string(base) + "/.triton/cache/{npu_utils_cache_relative}";
+static void init_npu_utils() {{
+    if (npu_utils_ready()) return;
+    const char* cache_root = std::getenv("TRITON_CACHE_DIR");
+    std::string npu_utils_path;
+    if (cache_root && cache_root[0] != '\\0') {{
+        npu_utils_path = std::string(cache_root) + "/{npu_utils_cache_relative}";
+    }} else {{
+        const char* triton_home = std::getenv("TRITON_HOME");
+        const char* home = std::getenv("HOME");
+        const char* base = triton_home && triton_home[0] != '\\0' ? triton_home : home;
+        if (!base || base[0] == '\\0') {{
+            fprintf(stderr, "Error: neither TRITON_CACHE_DIR nor TRITON_HOME/HOME is set\\n");
+            return;
         }}
+        npu_utils_path = std::string(base) + "/.triton/cache/{npu_utils_cache_relative}";
     }}
     void* handle = dlopen(npu_utils_path.c_str(), RTLD_LAZY);
     if (!handle) {{
-        const char* error = dlerror();
-        g_npu_utils_error = error ? error : "unknown dlopen error";
-        fprintf(stderr, "Error: dlopen %s failed: %s\\n", npu_utils_path.c_str(), g_npu_utils_error.c_str());
-        return false;
+        fprintf(stderr, "Error: dlopen %s failed: %s\\n", npu_utils_path.c_str(), dlerror());
+        return;
     }}
     g_allocate_workspace = (triton_allocate_workspace_t)dlsym(handle, "triton_allocate_workspace");
     g_allocate_sync_block_lock = (triton_allocate_sync_block_lock_t)dlsym(handle, "triton_allocate_sync_block_lock");
     g_async_launch = (triton_async_launch_t)dlsym(handle, "triton_async_launch");
     g_release_retained_tensor = (triton_release_retained_tensor_t)dlsym(handle, "triton_release_retained_tensor");
-    if (!npu_utils_ready()) {{
-        g_npu_utils_error = "required NPU utility symbols are unavailable";
-        fprintf(stderr, "Error: %s in %s\\n", g_npu_utils_error.c_str(), npu_utils_path.c_str());
-        return false;
-    }}
-    g_npu_utils_error.clear();
-    return true;
-}}
-
-static PyObject* set_npu_utils_path(PyObject* self, PyObject* path_obj) {{
-    const char* path = PyUnicode_AsUTF8(path_obj);
-    if (!path) return nullptr;
-    g_npu_utils_path = path;
-    if (!init_npu_utils()) {{
-        PyErr_Format(PyExc_RuntimeError, "Failed to load NPU utilities from %s: %s", path,
-                     g_npu_utils_error.c_str());
-        return nullptr;
-    }}
-    Py_RETURN_NONE;
 }}
 
 static void release_npu_tensor_handle(void* handle) {{
@@ -1483,8 +1454,6 @@ static PyObject* launch(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 }}
 
 static PyMethodDef ModuleMethods[] = {{
-  {{"set_npu_utils_path", (PyCFunction)set_npu_utils_path, METH_O,
-    "Initialize NPU utilities from the cache-manager-resolved shared-object path"}},
   {{"launch", (PyCFunction)launch, METH_FASTCALL, "Entry point for all kernels with this signature"}},
   {{nullptr, nullptr, 0, nullptr}} // sentinel
 }};
@@ -1504,6 +1473,9 @@ PyMODINIT_FUNC PyInit___triton_launcher(void) {{
   }}
   PyModule_AddFunctions(m, ModuleMethods);
   {cpp_msprof_callback}
+  // One-time initialization of NPU utils (dlsym lookup for g_async_launch etc.)
+  // Moved here from the per-call async_launch path to avoid repeated dlsym work.
+  init_npu_utils();
   return m;
 }}
 """

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+import importlib.metadata
 from pathlib import Path
 import tempfile
 import os
@@ -65,7 +66,8 @@ class NPUUtils(object):
         src = Path(src_path).read_text()
         cann_version = get_cann_version()
         cann_version_str = ".".join(map(str, cann_version)) if cann_version else ""
-        key_parts = [cann_version_str, src]
+        torch_npu_version = importlib.metadata.version("torch_npu")
+        key_parts = [cann_version_str, torch_npu_version, src]
         key = hashlib.md5("\0".join(key_parts).encode("utf-8")).hexdigest()
         cache = get_cache_manager(key)
         fname = "npu_utils.so"

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -1036,6 +1036,11 @@ static PyObject* set_npu_utils_path(PyObject* self, PyObject* path_obj) {{
     const char* path = PyUnicode_AsUTF8(path_obj);
     if (!path) return nullptr;
     g_npu_utils_path = path;
+    if (!init_npu_utils()) {{
+        PyErr_Format(PyExc_RuntimeError, "Failed to load NPU utilities from %s: %s", path,
+                     g_npu_utils_error.c_str());
+        return nullptr;
+    }}
     Py_RETURN_NONE;
 }}
 
@@ -1423,10 +1428,6 @@ static PyObject* launch(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
   if (PyErr_Occurred()) {{
     return nullptr;
   }}
-  if (!init_npu_utils()) {{
-    PyErr_Format(PyExc_RuntimeError, "Failed to load NPU utilities: %s", g_npu_utils_error.c_str());
-    return nullptr;
-  }}
   if (__MsprofFlagL1) {{
     {
       LINE_CHANGE_CHAR.join(
@@ -1487,7 +1488,7 @@ static PyObject* launch(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 
 static PyMethodDef ModuleMethods[] = {{
   {{"set_npu_utils_path", (PyCFunction)set_npu_utils_path, METH_O,
-    "Set the cache-manager-resolved NPU utilities path for lazy loading"}},
+    "Initialize NPU utilities from the cache-manager-resolved shared-object path"}},
   {{"launch", (PyCFunction)launch, METH_FASTCALL, "Entry point for all kernels with this signature"}},
   {{nullptr, nullptr, 0, nullptr}} // sentinel
 }};

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -19,6 +19,8 @@
 # THE SOFTWARE.
 
 from pathlib import Path
+import contextlib
+import fcntl
 import tempfile
 import os
 import os.path
@@ -39,6 +41,30 @@ from triton.backends.ascend.utils import (_build_npu_ext, _check_cxx11_abi, conv
 import triton.backends.ascend.utils as _ascend_utils
 
 
+def _get_cache_lock_path(cache):
+    lock_path = getattr(cache, "lock_path", None)
+    if lock_path is not None:
+        return lock_path
+    file_cache_manager = getattr(cache, "_file_cache_manager", None)
+    return getattr(file_cache_manager, "lock_path", None)
+
+
+@contextlib.contextmanager
+def _cache_build_lock(cache):
+    lock_path = _get_cache_lock_path(cache)
+    if lock_path is None:
+        yield
+        return
+
+    os.makedirs(os.path.dirname(lock_path), exist_ok=True)
+    with open(lock_path, "a") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+
 class NPUUtils(object):
 
     def __new__(cls):
@@ -47,17 +73,42 @@ class NPUUtils(object):
         return cls.instance
 
     def __init__(self):
+        if getattr(self, "_initialized", False):
+            return
+        self._initialized = True
+        self._cache_path = None
+        self.npu_utils_mod = None
+
+    def get_so_path(self):
+        if self._cache_path is None:
+            self._cache_path = self._build_or_get_cached_so()
+        return self._cache_path
+
+    def _build_or_get_cached_so(self):
         dirname = os.path.dirname(os.path.realpath(__file__))
         src_path = os.path.join(dirname, "npu_utils.cpp")
         src = Path(src_path).read_text()
-        version_info = get_backend_func("version_hash")
         cann_version = get_cann_version()
         cann_version_str = ".".join(map(str, cann_version)) if cann_version else ""
-        key = hashlib.md5((src + "_".join(version_info) + "_" + cann_version_str).encode("utf-8")).hexdigest()
+        key_parts = [
+            "npu_utils",
+            "torch_npu_wrapper_abi=triton_async_launch_v1",
+            "USE_TORCH_NPU",
+            f"cann_version={cann_version_str}",
+            src,
+        ]
+        key = hashlib.md5("\0".join(key_parts).encode("utf-8")).hexdigest()
         cache = get_cache_manager(key)
         fname = "npu_utils.so"
         cache_path = cache.get_file(fname)
-        if cache_path is None or not os.path.exists(cache_path):
+        if cache_path is not None and os.path.exists(cache_path):
+            return cache_path
+
+        with _cache_build_lock(cache):
+            cache_path = cache.get_file(fname)
+            if cache_path is not None and os.path.exists(cache_path):
+                return cache_path
+
             with tempfile.TemporaryDirectory() as tmpdir:
                 tmp_src_path = os.path.join(tmpdir, "npu_utils.cpp")
                 with open(tmp_src_path, "w") as f:
@@ -65,14 +116,23 @@ class NPUUtils(object):
                 so = _build_npu_ext("npu_utils", tmp_src_path)
                 with open(so, "rb") as f:
                     cache_path = cache.put(f.read(), fname, binary=True)
+        return cache_path
+
+    def _load_mod(self):
+        if self.npu_utils_mod is not None:
+            return self.npu_utils_mod
+
         import importlib.util
-        spec = importlib.util.spec_from_file_location("npu_utils", cache_path)
+        spec = importlib.util.spec_from_file_location("npu_utils", self.get_so_path())
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
         self.npu_utils_mod = mod
+        return self.npu_utils_mod
 
-    def load_binary(self, name, kernel, shared, device, mix_mode):
-        return self.npu_utils_mod.load_kernel_binary(name, kernel, shared, device, mix_mode)
+    def load_binary(self, name, kernel, shared, device, mix_mode=None):
+        if mix_mode is None:
+            name, mix_mode = name.rsplit("_", 1)
+        return self._load_mod().load_kernel_binary(name, kernel, shared, device, mix_mode)
 
     def _get_npu_device_limit_form_env(self) -> tuple[int, int]:
         """Read and validate the NPU_DEVICE_LIMIT env var, return the capped AICore and AIVector counts.
@@ -156,7 +216,7 @@ class NPUUtils(object):
 
     def get_arch(self):
         # temporarily return empty arch descriptor
-        return self.npu_utils_mod.get_arch()
+        return self._load_mod().get_arch()
 
     def get_aicore_num(self):
         # temporarily return empty arch descriptor
@@ -932,8 +992,7 @@ def make_launcher(constants, signature, metadata):
     alloc_success_code = 'return 1;'
     sync_lock_fail_code = 'fprintf(stderr, "Error: syncBlockLock allocation failed\\n"); return;'
     workspace_fail_code = 'fprintf(stderr, "Error: workspace allocation failed\\n"); return;'
-    npu_utils_mod = getattr(npu_utils, "npu_utils_mod", None)
-    npu_utils_so_path = getattr(npu_utils_mod, "__file__", "")
+    npu_utils_so_path = NPUUtils().get_so_path()
     # The generated launcher source is part of its cache key. Preserve only the
     # deterministic cache-key directory so the launcher can be reused after the
     # cache root changes.

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -1036,11 +1036,6 @@ static PyObject* set_npu_utils_path(PyObject* self, PyObject* path_obj) {{
     const char* path = PyUnicode_AsUTF8(path_obj);
     if (!path) return nullptr;
     g_npu_utils_path = path;
-    if (!init_npu_utils()) {{
-        PyErr_Format(PyExc_RuntimeError, "Failed to load NPU utilities from %s: %s", path,
-                     g_npu_utils_error.c_str());
-        return nullptr;
-    }}
     Py_RETURN_NONE;
 }}
 
@@ -1428,6 +1423,10 @@ static PyObject* launch(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
   if (PyErr_Occurred()) {{
     return nullptr;
   }}
+  if (!init_npu_utils()) {{
+    PyErr_Format(PyExc_RuntimeError, "Failed to load NPU utilities: %s", g_npu_utils_error.c_str());
+    return nullptr;
+  }}
   if (__MsprofFlagL1) {{
     {
       LINE_CHANGE_CHAR.join(
@@ -1488,7 +1487,7 @@ static PyObject* launch(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 
 static PyMethodDef ModuleMethods[] = {{
   {{"set_npu_utils_path", (PyCFunction)set_npu_utils_path, METH_O,
-    "Initialize NPU utilities from the cache-manager-resolved shared-object path"}},
+    "Set the cache-manager-resolved NPU utilities path for lazy loading"}},
   {{"launch", (PyCFunction)launch, METH_FASTCALL, "Entry point for all kernels with this signature"}},
   {{nullptr, nullptr, 0, nullptr}} // sentinel
 }};

--- a/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
+++ b/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
@@ -169,6 +169,23 @@ def test_npu_utils_initialization_builds_without_loading(monkeypatch, tmp_path):
     assert build_calls == [npu_utils]
 
 
+def test_npu_utils_load_binary_requires_explicit_mix_mode(monkeypatch, tmp_path):
+    driver = _load_driver_module()
+    cached_so = tmp_path / "npu_utils.so"
+    monkeypatch.setattr(driver.NPUUtils, "_build_or_get_cached_so", lambda self: str(cached_so))
+
+    calls = []
+    expected = ("module", "function", 0, 0, 1)
+    fake_mod = SimpleNamespace(load_kernel_binary=lambda *args: calls.append(args) or expected, )
+    npu_utils = driver.NPUUtils()
+    monkeypatch.setattr(npu_utils, "_load_mod", lambda: fake_mod)
+
+    assert npu_utils.load_binary("vector_add_kernel", b"kernel", 1, 0, "aiv") == expected
+    assert calls == [("vector_add_kernel", b"kernel", 1, 0, "aiv")]
+    with pytest.raises(TypeError, match="missing 1 required positional argument: 'mix_mode'"):
+        npu_utils.load_binary("vector_add_kernel", b"kernel", 1, 0)
+
+
 def test_npu_utils_initialization_builds_and_caches_shared_object(monkeypatch, tmp_path):
     driver = _load_driver_module()
     cache_dir = tmp_path / "cache"

--- a/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
+++ b/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
@@ -208,11 +208,13 @@ def test_npu_utils_initialization_builds_and_caches_shared_object(monkeypatch, t
     assert fake_cache.put_calls == 1
 
 
-def test_npu_utils_cache_key_uses_only_cann_version_and_source(monkeypatch, tmp_path):
+def test_npu_utils_cache_key_uses_cann_torch_npu_version_and_source(monkeypatch, tmp_path):
     driver = _load_driver_module()
+    _guard_torch_npu_import(monkeypatch)
     cached_so = tmp_path / "npu_utils.so"
     cached_so.write_bytes(b"cached")
     captured_keys = []
+    version_calls = []
 
     class FakeCache:
 
@@ -221,14 +223,21 @@ def test_npu_utils_cache_key_uses_only_cann_version_and_source(monkeypatch, tmp_
             return str(cached_so)
 
     monkeypatch.setattr(driver, "get_cann_version", lambda: (9, 0, 0))
+    monkeypatch.setattr(
+        driver.importlib.metadata,
+        "version",
+        lambda name: version_calls.append(name) or "2.7.1.post5.dev20260622",
+    )
     monkeypatch.setattr(driver, "get_cache_manager", lambda key: captured_keys.append(key) or FakeCache())
 
     npu_utils = driver.NPUUtils()
     source = (DEFAULT_DRIVER_PATH.parent / "npu_utils.cpp").read_text()
-    expected_key = hashlib.md5("\0".join(["9.0.0", source]).encode("utf-8")).hexdigest()
+    expected_key = hashlib.md5("\0".join(["9.0.0", "2.7.1.post5.dev20260622", source]).encode("utf-8")).hexdigest()
 
     assert npu_utils.get_so_path() == str(cached_so)
+    assert version_calls == ["torch_npu"]
     assert captured_keys == [expected_key]
+    assert "torch_npu" not in sys.modules
 
 
 @pytest.mark.parametrize(

--- a/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
+++ b/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
@@ -1,4 +1,5 @@
 import builtins
+import hashlib
 import importlib.util
 import os
 import sys
@@ -205,6 +206,29 @@ def test_npu_utils_initialization_builds_and_caches_shared_object(monkeypatch, t
     assert cached_so.read_bytes() == b"built"
     assert fake_cache.get_file_calls == 1
     assert fake_cache.put_calls == 1
+
+
+def test_npu_utils_cache_key_uses_only_cann_version_and_source(monkeypatch, tmp_path):
+    driver = _load_driver_module()
+    cached_so = tmp_path / "npu_utils.so"
+    cached_so.write_bytes(b"cached")
+    captured_keys = []
+
+    class FakeCache:
+
+        def get_file(self, filename):
+            assert filename == "npu_utils.so"
+            return str(cached_so)
+
+    monkeypatch.setattr(driver, "get_cann_version", lambda: (9, 0, 0))
+    monkeypatch.setattr(driver, "get_cache_manager", lambda key: captured_keys.append(key) or FakeCache())
+
+    npu_utils = driver.NPUUtils()
+    source = (DEFAULT_DRIVER_PATH.parent / "npu_utils.cpp").read_text()
+    expected_key = hashlib.md5("\0".join(["9.0.0", source]).encode("utf-8")).hexdigest()
+
+    assert npu_utils.get_so_path() == str(cached_so)
+    assert captured_keys == [expected_key]
 
 
 @pytest.mark.parametrize(

--- a/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
+++ b/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
@@ -149,18 +149,23 @@ def test_get_cc_cmd_npu_utils_resolves_torch_npu_path_without_import(monkeypatch
     assert "torch_npu" not in sys.modules
 
 
-def test_npu_utils_initialization_is_lazy(monkeypatch):
+def test_npu_utils_initialization_builds_without_loading(monkeypatch, tmp_path):
     driver = _load_driver_module()
-    monkeypatch.setattr(
-        driver,
-        "_build_npu_ext",
-        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected npu_utils build")),
-    )
+    cached_so = tmp_path / "npu_utils.so"
+    build_calls = []
+
+    def fake_build(npu_utils):
+        build_calls.append(npu_utils)
+        return str(cached_so)
+
+    monkeypatch.setattr(driver.NPUUtils, "_build_or_get_cached_so", fake_build)
 
     npu_utils = driver.NPUUtils()
 
-    assert npu_utils._cache_path is None
+    assert npu_utils._cache_path == str(cached_so)
     assert npu_utils.npu_utils_mod is None
+    assert driver.NPUUtils() is npu_utils
+    assert build_calls == [npu_utils]
 
 
 def test_npu_utils_build_rechecks_cache_after_lock(monkeypatch, tmp_path):
@@ -193,7 +198,10 @@ def test_npu_utils_build_rechecks_cache_after_lock(monkeypatch, tmp_path):
         lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected npu_utils build")),
     )
 
-    assert driver.NPUUtils()._build_or_get_cached_so() == str(cached_so)
+    npu_utils = driver.NPUUtils()
+
+    assert npu_utils._cache_path == str(cached_so)
+    assert npu_utils.npu_utils_mod is None
     assert fake_cache.get_file_calls == 2
 
 

--- a/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
+++ b/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
@@ -1,5 +1,7 @@
+import builtins
 import importlib.util
 import os
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -8,6 +10,8 @@ import pytest
 pytestmark = pytest.mark.backend("none")
 
 DEFAULT_UTILS_PATH = (Path(__file__).resolve().parents[2] / "backend" / "utils.py")
+DEFAULT_REGISTER_PATH = (Path(__file__).resolve().parents[2] / "backend" / "backend_register.py")
+DEFAULT_DRIVER_PATH = (Path(__file__).resolve().parents[2] / "backend" / "driver.py")
 
 
 def _get_utils_path():
@@ -23,6 +27,32 @@ def _load_utils_module():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def _load_register_module():
+    spec = importlib.util.spec_from_file_location("repo_backend_register", DEFAULT_REGISTER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_driver_module():
+    spec = importlib.util.spec_from_file_location("repo_backend_driver", DEFAULT_DRIVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _guard_torch_npu_import(monkeypatch):
+    monkeypatch.delitem(sys.modules, "torch_npu", raising=False)
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "torch_npu" or name.startswith("torch_npu."):
+            raise AssertionError(f"unexpected import of {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
 
 
 def _assert_npu_utils_uses_special_flags(utils, monkeypatch, tmp_path):
@@ -63,6 +93,108 @@ def _assert_npu_utils_uses_special_flags(utils, monkeypatch, tmp_path):
 def test_npu_utils_build_uses_special_flags(monkeypatch, tmp_path):
     utils = _load_utils_module()
     _assert_npu_utils_uses_special_flags(utils, monkeypatch, tmp_path)
+
+
+def test_get_backend_func_uses_torch_npu_without_import(monkeypatch):
+    utils = _load_utils_module()
+    monkeypatch.delenv("TRITON_BACKEND", raising=False)
+    monkeypatch.setattr(utils, "backend_policy", None)
+    _guard_torch_npu_import(monkeypatch)
+
+    calls = []
+
+    def fake_execute_func(category, method, *args, **kwargs):
+        calls.append((category, method, args, kwargs))
+        return "ok"
+
+    monkeypatch.setattr(
+        utils.backend_strategy_registry,
+        "execute_func",
+        fake_execute_func,
+    )
+
+    assert utils.get_backend_func("get_cc_cmd_npu_utils") == "ok"
+    assert calls == [("torch_npu", "get_cc_cmd_npu_utils", (), {})]
+    assert "torch_npu" not in sys.modules
+
+
+def test_get_cc_cmd_npu_utils_resolves_torch_npu_path_without_import(monkeypatch, tmp_path):
+    register = _load_register_module()
+    _guard_torch_npu_import(monkeypatch)
+    monkeypatch.setattr(register, "get_torch_cxx_abi", lambda: 1)
+
+    torch_path = tmp_path / "torch_pkg"
+    torch_npu_path = tmp_path / "torch_npu_pkg"
+
+    def fake_find_spec(name):
+        if name == "torch":
+            return SimpleNamespace(
+                origin=str(torch_path / "__init__.py"),
+                submodule_search_locations=[str(torch_path)],
+            )
+        if name == "torch_npu":
+            return SimpleNamespace(
+                origin=str(torch_npu_path / "__init__.py"),
+                submodule_search_locations=[str(torch_npu_path)],
+            )
+        return None
+
+    monkeypatch.setattr(register.importlib.util, "find_spec", fake_find_spec)
+
+    cc_cmd = register.get_cc_cmd_npu_utils()
+
+    assert f"-I{torch_path / 'include'}" in cc_cmd
+    assert f"-I{torch_npu_path / 'include'}" in cc_cmd
+    assert f"-L{torch_npu_path / 'lib'}" in cc_cmd
+    assert "torch_npu" not in sys.modules
+
+
+def test_npu_utils_initialization_is_lazy(monkeypatch):
+    driver = _load_driver_module()
+    monkeypatch.setattr(
+        driver,
+        "_build_npu_ext",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected npu_utils build")),
+    )
+
+    npu_utils = driver.NPUUtils()
+
+    assert npu_utils._cache_path is None
+    assert npu_utils.npu_utils_mod is None
+
+
+def test_npu_utils_build_rechecks_cache_after_lock(monkeypatch, tmp_path):
+    driver = _load_driver_module()
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    cached_so = cache_dir / "npu_utils.so"
+    cached_so.write_bytes(b"cached")
+
+    class FakeCache:
+        lock_path = str(cache_dir / "lock")
+
+        def __init__(self):
+            self.get_file_calls = 0
+
+        def get_file(self, filename):
+            self.get_file_calls += 1
+            if self.get_file_calls == 1:
+                return None
+            return str(cached_so)
+
+        def put(self, data, filename, binary=True):
+            raise AssertionError("unexpected cache put")
+
+    fake_cache = FakeCache()
+    monkeypatch.setattr(driver, "get_cache_manager", lambda key: fake_cache)
+    monkeypatch.setattr(
+        driver,
+        "_build_npu_ext",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected npu_utils build")),
+    )
+
+    assert driver.NPUUtils()._build_or_get_cached_so() == str(cached_so)
+    assert fake_cache.get_file_calls == 2
 
 
 @pytest.mark.parametrize(

--- a/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
+++ b/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
@@ -150,23 +150,32 @@ def test_get_cc_cmd_npu_utils_resolves_torch_npu_path_without_import(monkeypatch
     assert "torch_npu" not in sys.modules
 
 
-def test_npu_utils_initialization_builds_without_loading(monkeypatch, tmp_path):
+def test_npu_utils_initialization_refreshes_build_path_without_loading(monkeypatch, tmp_path):
     driver = _load_driver_module()
-    cached_so = tmp_path / "npu_utils.so"
+    producer_cache = tmp_path / "producer"
+    consumer_cache = tmp_path / "consumer"
     build_calls = []
 
     def fake_build(npu_utils):
-        build_calls.append(npu_utils)
-        return str(cached_so)
+        cache_root = os.environ["TRITON_CACHE_DIR"]
+        build_calls.append((npu_utils, cache_root))
+        return str(Path(cache_root) / "npu_utils.so")
 
     monkeypatch.setattr(driver.NPUUtils, "_build_or_get_cached_so", fake_build)
 
+    monkeypatch.setenv("TRITON_CACHE_DIR", str(producer_cache))
     npu_utils = driver.NPUUtils()
-
-    assert npu_utils._cache_path == str(cached_so)
+    assert npu_utils._cache_path == str(producer_cache / "npu_utils.so")
     assert npu_utils.npu_utils_mod is None
+
+    monkeypatch.setenv("TRITON_CACHE_DIR", str(consumer_cache))
     assert driver.NPUUtils() is npu_utils
-    assert build_calls == [npu_utils]
+    assert npu_utils._cache_path == str(consumer_cache / "npu_utils.so")
+    assert npu_utils.npu_utils_mod is None
+    assert build_calls == [
+        (npu_utils, str(producer_cache)),
+        (npu_utils, str(consumer_cache)),
+    ]
 
 
 def test_npu_utils_load_binary_requires_explicit_mix_mode(monkeypatch, tmp_path):

--- a/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
+++ b/third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py
@@ -168,41 +168,43 @@ def test_npu_utils_initialization_builds_without_loading(monkeypatch, tmp_path):
     assert build_calls == [npu_utils]
 
 
-def test_npu_utils_build_rechecks_cache_after_lock(monkeypatch, tmp_path):
+def test_npu_utils_initialization_builds_and_caches_shared_object(monkeypatch, tmp_path):
     driver = _load_driver_module()
     cache_dir = tmp_path / "cache"
     cache_dir.mkdir()
     cached_so = cache_dir / "npu_utils.so"
-    cached_so.write_bytes(b"cached")
+    built_so = tmp_path / "built_npu_utils.so"
+    built_so.write_bytes(b"built")
 
     class FakeCache:
-        lock_path = str(cache_dir / "lock")
 
         def __init__(self):
             self.get_file_calls = 0
+            self.put_calls = 0
 
         def get_file(self, filename):
             self.get_file_calls += 1
-            if self.get_file_calls == 1:
-                return None
-            return str(cached_so)
+            return None
 
         def put(self, data, filename, binary=True):
-            raise AssertionError("unexpected cache put")
+            self.put_calls += 1
+            assert data == b"built"
+            assert filename == "npu_utils.so"
+            assert binary is True
+            cached_so.write_bytes(data)
+            return str(cached_so)
 
     fake_cache = FakeCache()
     monkeypatch.setattr(driver, "get_cache_manager", lambda key: fake_cache)
-    monkeypatch.setattr(
-        driver,
-        "_build_npu_ext",
-        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected npu_utils build")),
-    )
+    monkeypatch.setattr(driver, "_build_npu_ext", lambda *args, **kwargs: str(built_so))
 
     npu_utils = driver.NPUUtils()
 
     assert npu_utils._cache_path == str(cached_so)
     assert npu_utils.npu_utils_mod is None
-    assert fake_cache.get_file_calls == 2
+    assert cached_so.read_bytes() == b"built"
+    assert fake_cache.get_file_calls == 1
+    assert fake_cache.put_calls == 1
 
 
 @pytest.mark.parametrize(

--- a/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
+++ b/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
@@ -128,7 +128,12 @@ def test_make_launcher_resolves_npu_utils_from_active_cache_root(
     assert f'npu_utils_path = std::string(base) + "/.triton/cache/{cache_key}/npu_utils.so";' in producer_src
     assert "std::string npu_utils_path = g_npu_utils_path;" in producer_src
     assert '"set_npu_utils_path", (PyCFunction)set_npu_utils_path, METH_O' in producer_src
-    assert "if (!init_npu_utils())" in producer_src
+    set_path_body = producer_src.split("static PyObject* set_npu_utils_path",
+                                       maxsplit=1)[1].split("static void release_npu_tensor_handle", maxsplit=1)[0]
+    assert "init_npu_utils()" not in set_path_body
+    launch_body = producer_src.split("static PyObject* launch",
+                                     maxsplit=1)[1].split("static PyMethodDef ModuleMethods", maxsplit=1)[0]
+    assert "if (!init_npu_utils())" in launch_body
     module_init = producer_src.split("PyMODINIT_FUNC PyInit___triton_launcher", maxsplit=1)[1]
     assert "init_npu_utils();" not in module_init
 

--- a/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
+++ b/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
@@ -3,7 +3,7 @@ import sys
 from itertools import product
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "python"))
 
@@ -126,6 +126,11 @@ def test_make_launcher_resolves_npu_utils_from_active_cache_root(
     assert f'npu_utils_path = std::string(cache_root) + "/{cache_key}/npu_utils.so";' in producer_src
     assert 'const char* triton_home = std::getenv("TRITON_HOME");' in producer_src
     assert f'npu_utils_path = std::string(base) + "/.triton/cache/{cache_key}/npu_utils.so";' in producer_src
+    assert "std::string npu_utils_path = g_npu_utils_path;" in producer_src
+    assert '"set_npu_utils_path", (PyCFunction)set_npu_utils_path, METH_O' in producer_src
+    assert "if (!init_npu_utils())" in producer_src
+    module_init = producer_src.split("PyMODINIT_FUNC PyInit___triton_launcher", maxsplit=1)[1]
+    assert "init_npu_utils();" not in module_init
 
 
 @patch.object(driver, "NPUUtils")
@@ -476,14 +481,19 @@ def test_argument_packing_differs_between_launch_paths(
 @patch.object(driver, "make_npu_launcher_stub", return_value="/tmp/fake_launcher.so")
 @patch.object(driver, "make_launcher", return_value="// wrapper src")
 @patch.object(driver, "generate_npu_header_src", return_value="// header src")
+@patch.object(driver, "NPUUtils")
 def test_npu_launcher_exposes_launcher_so_path(
+    mock_npu_utils,
     mock_header_src,
     mock_wrapper_src,
     mock_launcher_stub,
     mock_spec_from_file_location,
     mock_module_from_spec,
 ):
-    fake_module = SimpleNamespace(launch=object())
+    npu_utils_so_path = "/custom/cache-manager/path/npu_utils.so"
+    mock_npu_utils.return_value.get_so_path.return_value = npu_utils_so_path
+    set_npu_utils_path = Mock()
+    fake_module = SimpleNamespace(launch=object(), set_npu_utils_path=set_npu_utils_path)
     fake_spec = SimpleNamespace(loader=SimpleNamespace(exec_module=lambda module: None))
     mock_module_from_spec.return_value = fake_module
     mock_spec_from_file_location.return_value = fake_spec
@@ -502,6 +512,7 @@ def test_npu_launcher_exposes_launcher_so_path(
     assert mock_header_src.call_count == 1
     assert mock_wrapper_src.call_count == 1
     assert mock_launcher_stub.call_count == 1
+    set_npu_utils_path.assert_called_once_with(npu_utils_so_path)
     mock_wrapper_src.assert_called_with(
         {0: 1},
         {0: "*fp32", 1: "i32"},

--- a/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
+++ b/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
@@ -98,12 +98,14 @@ def test_make_launcher_resolves_npu_utils_from_active_cache_root(
         return SimpleNamespace(
             get_aivector_core_num=lambda: 40,
             get_aicore_num=lambda: 20,
-            npu_utils_mod=SimpleNamespace(__file__=f"{cache_root}/{cache_key}/npu_utils.so"),
+            get_so_path=lambda: f"{cache_root}/{cache_key}/npu_utils.so",
         )
 
     producer_utils = make_utils("/producer/cache")
     consumer_utils = make_utils("/consumer/cache")
-    mock_npu_utils.side_effect = [producer_utils, consumer_utils]
+    # make_launcher currently reads NPUUtils once for core counts and once for
+    # the shared-object path.
+    mock_npu_utils.side_effect = [producer_utils, producer_utils, consumer_utils, consumer_utils]
 
     producer_src = driver.make_launcher(
         constants={},

--- a/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
+++ b/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
@@ -3,7 +3,7 @@ import sys
 from itertools import product
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "python"))
 
@@ -126,11 +126,9 @@ def test_make_launcher_resolves_npu_utils_from_active_cache_root(
     assert f'npu_utils_path = std::string(cache_root) + "/{cache_key}/npu_utils.so";' in producer_src
     assert 'const char* triton_home = std::getenv("TRITON_HOME");' in producer_src
     assert f'npu_utils_path = std::string(base) + "/.triton/cache/{cache_key}/npu_utils.so";' in producer_src
-    assert "std::string npu_utils_path = g_npu_utils_path;" in producer_src
-    assert '"set_npu_utils_path", (PyCFunction)set_npu_utils_path, METH_O' in producer_src
-    assert "if (!init_npu_utils())" in producer_src
     module_init = producer_src.split("PyMODINIT_FUNC PyInit___triton_launcher", maxsplit=1)[1]
-    assert "init_npu_utils();" not in module_init
+    assert "init_npu_utils();" in module_init
+    assert "set_npu_utils_path" not in producer_src
 
 
 @patch.object(driver, "NPUUtils")
@@ -481,19 +479,14 @@ def test_argument_packing_differs_between_launch_paths(
 @patch.object(driver, "make_npu_launcher_stub", return_value="/tmp/fake_launcher.so")
 @patch.object(driver, "make_launcher", return_value="// wrapper src")
 @patch.object(driver, "generate_npu_header_src", return_value="// header src")
-@patch.object(driver, "NPUUtils")
 def test_npu_launcher_exposes_launcher_so_path(
-    mock_npu_utils,
     mock_header_src,
     mock_wrapper_src,
     mock_launcher_stub,
     mock_spec_from_file_location,
     mock_module_from_spec,
 ):
-    npu_utils_so_path = "/custom/cache-manager/path/npu_utils.so"
-    mock_npu_utils.return_value.get_so_path.return_value = npu_utils_so_path
-    set_npu_utils_path = Mock()
-    fake_module = SimpleNamespace(launch=object(), set_npu_utils_path=set_npu_utils_path)
+    fake_module = SimpleNamespace(launch=object())
     fake_spec = SimpleNamespace(loader=SimpleNamespace(exec_module=lambda module: None))
     mock_module_from_spec.return_value = fake_module
     mock_spec_from_file_location.return_value = fake_spec
@@ -512,7 +505,6 @@ def test_npu_launcher_exposes_launcher_so_path(
     assert mock_header_src.call_count == 1
     assert mock_wrapper_src.call_count == 1
     assert mock_launcher_stub.call_count == 1
-    set_npu_utils_path.assert_called_once_with(npu_utils_so_path)
     mock_wrapper_src.assert_called_with(
         {0: 1},
         {0: "*fp32", 1: "i32"},

--- a/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
+++ b/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
@@ -128,12 +128,7 @@ def test_make_launcher_resolves_npu_utils_from_active_cache_root(
     assert f'npu_utils_path = std::string(base) + "/.triton/cache/{cache_key}/npu_utils.so";' in producer_src
     assert "std::string npu_utils_path = g_npu_utils_path;" in producer_src
     assert '"set_npu_utils_path", (PyCFunction)set_npu_utils_path, METH_O' in producer_src
-    set_path_body = producer_src.split("static PyObject* set_npu_utils_path",
-                                       maxsplit=1)[1].split("static void release_npu_tensor_handle", maxsplit=1)[0]
-    assert "init_npu_utils()" not in set_path_body
-    launch_body = producer_src.split("static PyObject* launch",
-                                     maxsplit=1)[1].split("static PyMethodDef ModuleMethods", maxsplit=1)[0]
-    assert "if (!init_npu_utils())" in launch_body
+    assert "if (!init_npu_utils())" in producer_src
     module_init = producer_src.split("PyMODINIT_FUNC PyInit___triton_launcher", maxsplit=1)[1]
     assert "init_npu_utils();" not in module_init
 


### PR DESCRIPTION
## Summary

- Build or retrieve `npu_utils.so` when the `NPUUtils` singleton is first initialized.
- Keep `NPUUtils` construction limited to building/caching the shared object; do not load it as part of `NPUUtils.__init__()`.
- Load `npu_utils.so` during `NPULauncher` initialization through `set_npu_utils_path()`, before the first kernel launch.
- Preserve the #1699 behavior that resolves Torch and TorchNPU package paths without importing `torch_npu`.
- Restore the original cache-miss build flow without adding a cross-process file lock.
- Build only once for repeated singleton construction and retain retry behavior when the initial build fails.

## Background

This is an alternative initialization strategy based on #1699.

#1699 defers both construction and loading of `npu_utils.so`. This PR separates the phases at a different boundary: `NPUDriver` construction prebuilds and caches the shared object, while `NPULauncher` initialization loads it and resolves the required symbols. Kernel launch therefore does not pay first-use `dlopen()` overhead.

Because cache-key generation and compiler-path discovery no longer import `torch_npu`, compiling and linking the wrapper does not execute TorchNPU/CANN initialization in the Python process.

## Behavior

On first `NPUUtils()` construction:

1. initialize `_cache_path` and `npu_utils_mod`;
2. check the existing `npu_utils.so` cache entry;
3. build and publish the shared object directly when the cache misses;
4. retain the resolved path while leaving `npu_utils_mod` as `None`;
5. mark the singleton initialized only after the build succeeds.

Loading remains separate from construction:

- `NPUUtils.load_binary()` loads the Python extension through `_load_mod()` when binary loading requires it.
- `NPULauncher.__init__()` imports the launcher and calls `set_npu_utils_path()` with the resolved path.
- `set_npu_utils_path()` performs `dlopen()` and resolves the launcher helper symbols before the first kernel launch.

## Validation

- `25 passed`:
  - `third_party/ascend/unittest/pytest_ut/test_backend_npu_utils_build_flags.py`
  - `third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py`
- Python syntax checks passed.
- Configured pre-commit hooks passed for the changed files.
- Real NPU runtime validation has not yet been run for this alternative initialization timing.

## Trade-offs

- Creating `NPUDriver` now requires the compiler, CANN headers/libraries, and TorchNPU development files even when no kernel is launched.
- Separate processes that miss the same cache entry concurrently may perform redundant builds; this keeps the build flow consistent with the implementation before #1699.

This PR is intended to evaluate these trade-offs against fully lazy construction.