### PR TITLE
[ControlFlowOpt](fix) stabilize pointer control-flow lowering

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
@@ -48,7 +48,8 @@ static constexpr llvm::StringLiteral interceptrFunc[]{
     "_jagged_flash_attention_bwd_basic_kernel",
     "triton_flash_mla_sparse_fwd",
     "_sparse_decode_kernel",
-    "chunk_gsa_fwd_k_kernel_intra"};
+    "chunk_gsa_fwd_k_kernel_intra",
+    "_sparse_decode_model1_kernel"};
 
 static LogicalResult verifyFuncNames(ModuleOp module) {
   bool intercepted = false;

--- a/third_party/ascend/lib/TritonControlFlowOpt/TensorPtrDecompose.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/TensorPtrDecompose.cpp
@@ -851,6 +851,23 @@ static FailureOr<RankedTensorType> getIntegerTensorType(Value value) {
   return type;
 }
 
+// Sign-extension preserves the affine provenance of a tensor offset when it
+// only changes the integer element width.  Keep this check shared by
+// analysis and materialization so an extension is never classified as
+// Structured in one phase and rebuilt as Opaque in the other.
+static bool isCompatibleIntegerExtension(Value source,
+                                         RankedTensorType resultType) {
+  auto sourceType = dyn_cast<RankedTensorType>(source.getType());
+  if (!sourceType || sourceType.getRank() != resultType.getRank() ||
+      sourceType.getShape() != resultType.getShape() ||
+      sourceType.getEncoding() != resultType.getEncoding())
+    return false;
+  auto sourceElement = dyn_cast<IntegerType>(sourceType.getElementType());
+  auto resultElement = dyn_cast<IntegerType>(resultType.getElementType());
+  return sourceElement && resultElement &&
+         sourceElement.getWidth() < resultElement.getWidth();
+}
+
 static bool hasAnyOpaqueAxis(ArrayRef<AxisKind> kinds) {
   return llvm::is_contained(kinds, AxisKind::Opaque);
 }
@@ -938,6 +955,30 @@ static FailureOr<AnalyzedTensorOffset> analyzeTensorOffset(Value value) {
     if (!dense->value.isZero())
       result.uniformOffset.identity =
           ComponentIdentity::fromValue(value, getUniformOffsetComponent(rank));
+    return result;
+  }
+
+  if (auto extension = value.getDefiningOp<arith::ExtSIOp>()) {
+    Value source = extension.getIn();
+    if (!isCompatibleIntegerExtension(source, *tensorType))
+      return getOpaqueAnalyzedOffset(value);
+    FailureOr<AnalyzedTensorOffset> sourceInfo = analyzeTensorOffset(source);
+    if (failed(sourceInfo) || sourceInfo->strides.size() != rank)
+      return getOpaqueAnalyzedOffset(value);
+
+    AnalyzedTensorOffset result = makeStructuredZero();
+    result.axisKinds = sourceInfo->axisKinds;
+    for (unsigned axis = 0; axis < rank; ++axis) {
+      if (!isZeroIdentity(sourceInfo->strides[axis].identity))
+        result.strides[axis].identity =
+            ComponentIdentity::fromValue(value, getStrideComponent(axis));
+    }
+    if (!isZeroIdentity(sourceInfo->uniformOffset.identity))
+      result.uniformOffset.identity =
+          ComponentIdentity::fromValue(value, getUniformOffsetComponent(rank));
+    if (!isZeroIdentity(sourceInfo->opaqueContribution.identity))
+      result.opaqueContribution.identity = ComponentIdentity::fromValue(
+          value, getOpaqueContributionComponent(rank));
     return result;
   }
 
@@ -1215,6 +1256,37 @@ materializeTensorOffsetFields(Value value, OpBuilder &builder, Location loc) {
     if (!uniform)
       return failure();
     result->uniformOffset = uniform;
+    return result;
+  }
+
+  if (auto extension = value.getDefiningOp<arith::ExtSIOp>()) {
+    if (!isCompatibleIntegerExtension(extension.getIn(), *tensorType))
+      return fallback();
+    FailureOr<TensorOffsetValues> source =
+        materializeTensorOffsetFields(extension.getIn(), builder, loc);
+    if (failed(source) || source->strides.size() != rank)
+      return fallback();
+
+    FailureOr<TensorOffsetValues> result = makeZero(AxisKind::Structured);
+    if (failed(result))
+      return failure();
+    result->axisKinds = source->axisKinds;
+    for (unsigned axis = 0; axis < rank; ++axis) {
+      FailureOr<Value> stride =
+          castIntegerLike(builder, loc, source->strides[axis], scalarType);
+      if (failed(stride))
+        return fallback();
+      result->strides[axis] = *stride;
+    }
+    FailureOr<Value> uniform =
+        castIntegerLike(builder, loc, source->uniformOffset, scalarType);
+    if (failed(uniform))
+      return fallback();
+    result->uniformOffset = *uniform;
+    if (!isConstantZero(source->opaqueContribution)) {
+      result->opaqueContribution = builder.create<arith::ExtSIOp>(
+          loc, *tensorType, source->opaqueContribution);
+    }
     return result;
   }
 

--- a/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
@@ -2504,6 +2504,26 @@ bool isLoopCarriedValueUsedWithCondition(
   return isUsedWithCondition(loopOp->getResult(index), condition);
 }
 
+// The legacy BlockData route only needs address uses reached from inside the
+// loop. Reuse the established traversal for the region arguments, but do not
+// start another traversal from the loop result: a numerical carrier can feed
+// an unrelated reduction after the loop and eventually reach an address use.
+static bool isLoopCarriedAddressValueUsed(
+    LoopLikeOpInterface loopOp, unsigned index,
+    const std::function<bool(OpOperand *)> &condition) {
+  if (index >= loopOp.getRegionIterArgs().size() ||
+      index >= loopOp->getNumResults())
+    return false;
+  if (isUsedWithCondition(loopOp.getRegionIterArgs()[index], condition))
+    return true;
+  if (auto whileOp = dyn_cast<scf::WhileOp>(loopOp.getOperation())) {
+    if (index < whileOp.getAfterArguments().size() &&
+        isUsedWithCondition(whileOp.getAfterArguments()[index], condition))
+      return true;
+  }
+  return false;
+}
+
 bool needsLegacyBlockDataLoopRewrite(LoopLikeOpInterface loopOp) {
   auto hasPointerValue = [&](auto values) {
     return llvm::any_of(values, [&](Value value) {
@@ -2562,7 +2582,7 @@ bool needsLegacyBlockDataLoopRewrite(LoopLikeOpInterface loopOp) {
     auto integerType = dyn_cast<IntegerType>(tensorType.getElementType());
     if (!integerType || integerType.getWidth() == 1)
       continue;
-    if (isLoopCarriedValueUsedWithCondition(loopOp, index, [](OpOperand *use) {
+    if (isLoopCarriedAddressValueUsed(loopOp, index, [](OpOperand *use) {
           Operation *user = use->getOwner();
           return isa<triton::AddPtrOp>(user) ||
                  (isa<triton::LoadOp>(user) && use->getOperandNumber() == 1) ||

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -1275,6 +1275,47 @@ void TritonToLinalgPass::addDynamicLegal(
       isArithOrMathOpLegal);
 }
 
+namespace {
+
+/// Route the specific `splat(base) -> addptr(scan) -> addptr(constant) ->
+/// store` form through the existing indirect-store operation before use
+/// analysis. Lowering either addptr independently would materialize a memref
+/// while the remaining operation still expects tensor<ptr>.
+class FoldScanOffsetAddPtrChain : public OpRewritePattern<triton::AddPtrOp> {
+public:
+  using OpRewritePattern<triton::AddPtrOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(triton::AddPtrOp op,
+                                PatternRewriter &rewriter) const override {
+    if (!op->hasOneUse() || !op.getOffset().getDefiningOp<triton::ScanOp>())
+      return failure();
+    auto nextAddPtr = dyn_cast<triton::AddPtrOp>(*op->user_begin());
+    if (!nextAddPtr ||
+        !nextAddPtr.getOffset().getDefiningOp<arith::ConstantOp>() ||
+        op.getOffset().getType() != nextAddPtr.getOffset().getType() ||
+        !nextAddPtr->hasOneUse())
+      return failure();
+    auto store = dyn_cast<triton::StoreOp>(*nextAddPtr->user_begin());
+    auto baseSplat = op.getPtr().getDefiningOp<triton::SplatOp>();
+    if (!store || !baseSplat ||
+        !isa<triton::PointerType>(baseSplat.getSrc().getType()))
+      return failure();
+
+    rewriter.setInsertionPoint(nextAddPtr);
+    Value combinedOffset = rewriter.create<arith::AddIOp>(
+        nextAddPtr.getLoc(), op.getOffset(), nextAddPtr.getOffset());
+    rewriter.create<triton::ascend::IndirectStoreOp>(
+        store.getLoc(), baseSplat.getSrc(), combinedOffset, store.getValue(),
+        store.getMask());
+    rewriter.eraseOp(store);
+    rewriter.eraseOp(nextAddPtr);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+} // namespace
+
 void TritonToLinalgPass::populateTritonToLinalgCanonicalizationPatterns(
     RewritePatternSet &patterns) {
   patterns.add<LoadStoreConverter::LoadStoreCanonicalizer<triton::LoadOp>,
@@ -1282,6 +1323,7 @@ void TritonToLinalgPass::populateTritonToLinalgCanonicalizationPatterns(
                LoadStoreConverter::LoadStoreCanonicalizer<triton::AtomicRMWOp>,
                LoadStoreConverter::LoadStoreCanonicalizer<triton::AtomicCASOp>>(
       patterns.getContext());
+  patterns.add<FoldScanOffsetAddPtrChain>(patterns.getContext());
   patterns.add<TTOpConverters::BitcastCanonicalizer>(patterns.getContext());
   patterns.add<TTOpConverters::FpToFpCanonicalizer>(patterns.getContext());
   patterns.add<LoadStoreConverter::ScalarStoreCanonicalizer>(
@@ -1446,12 +1488,12 @@ void TritonToLinalgPass::populateTritonToLinalgConversionPatterns(
 }
 
 void TritonToLinalgPass::getDependentDialects(DialectRegistry &registry) const {
-  registry
-      .insert<func::FuncDialect, arith::ArithDialect, math::MathDialect,
-              linalg::LinalgDialect, affine::AffineDialect, scf::SCFDialect,
-              tensor::TensorDialect, bufferization::BufferizationDialect,
-              memref::MemRefDialect, hfusion::HFusionDialect, hivm::HIVMDialect,
-              annotation::AnnotationDialect, LLVM::LLVMDialect>();
+  registry.insert<func::FuncDialect, arith::ArithDialect, math::MathDialect,
+                  linalg::LinalgDialect, affine::AffineDialect, scf::SCFDialect,
+                  tensor::TensorDialect, bufferization::BufferizationDialect,
+                  memref::MemRefDialect, hfusion::HFusionDialect,
+                  hivm::HIVMDialect, annotation::AnnotationDialect,
+                  LLVM::LLVMDialect, triton::ascend::TritonAscendDialect>();
 }
 
 LogicalResult

--- a/third_party/ascend/lib/TritonToUnstructure/BubbleUpOperation.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/BubbleUpOperation.cpp
@@ -60,6 +60,21 @@ BubbleUpExtract<ExtractOpTy>::matchAndRewrite(ExtractOpTy op,
     return failure();
   }
 
+  // Keep the vector mask attached to discrete memory accesses. Depending on
+  // which mask conversion produced the select, the marker is either on the
+  // select itself or on the generated load loop that supplies its value.
+  if (auto selectOp = dyn_cast<arith::SelectOp>(parentOp);
+      selectOp && isa<ShapedType>(selectOp.getCondition().getType())) {
+    auto isDiscreteLoadResult = [](Value value) {
+      auto forOp = value.getDefiningOp<scf::ForOp>();
+      return forOp && forOp->hasAttr("ExtractedLoadOrStore");
+    };
+    if (selectOp->hasAttr(ConverterUtils::discreteAttrName) ||
+        isDiscreteLoadResult(selectOp.getTrueValue()) ||
+        isDiscreteLoadResult(selectOp.getFalseValue()))
+      return failure();
+  }
+
   LLVM_DEBUG({
     auto &os = llvm::dbgs();
     os << "Before bubble up\n" << op << '\n' << funcOp << "\n";

--- a/third_party/ascend/lib/TritonToUnstructure/ReplaceArguments.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/ReplaceArguments.cpp
@@ -114,11 +114,35 @@ static bool hasScalarPointerBase(const PtrOffsetInfo &info) {
   return info.getPtr() && isScalarPointerType(info.getPtr().getType());
 }
 
+// A function argument is a stable pointer base: it dominates the enclosing
+// loop and carries no control-flow-selected address.  Offset analysis records
+// this base with `ptr == value` and a zero displacement, so that identity is
+// valid for a loop init but must not be confused with a loop phi or an
+// int_to_ptr result elsewhere.
+static bool isStableFunctionScalarPointerBase(Value value) {
+  auto blockArg = dyn_cast<BlockArgument>(value);
+  if (!blockArg || !isScalarPointerType(value.getType()))
+    return false;
+  Operation *owner = blockArg.getOwner()->getParentOp();
+  return owner && isa<FunctionOpInterface>(owner);
+}
+
+// Offset analysis deliberately represents a scalar pointer selected by
+// scf.if as an opaque complete address. If such a value is a loop backedge,
+// the loop must choose the complete-address protocol before any edge is
+// rewritten; otherwise the init/region argument can become i64 while the
+// yield remains a pointer.
+static bool isOpaqueScalarPointerIfResult(Value value) {
+  return isScalarPointerType(value.getType()) &&
+         value.getDefiningOp<scf::IfOp>();
+}
+
 // A scalar pointer can use the established T2U offset representation only if
 // analysis found both a source pointer and a displacement.  An entry whose
-// source is the value itself is an opaque complete address (for example a
-// control-flow phi or a function argument), so choosing an offset for only
-// one edge would change the meaning of the other edges.
+// source is the value itself is normally an opaque complete address (for
+// example a control-flow phi).  A function argument is the one exception when
+// it is examined as the init anchor of an ordinary loop; the loop conversion
+// must then materialize a zero offset for that anchor.
 static bool
 canRewriteScalarPointer(Value value, RewriterBase &rewriter,
                         llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
@@ -140,33 +164,49 @@ canRewriteScalarPointer(Value value, RewriterBase &rewriter,
 static bool
 shouldPreserveScalarPointers(Operation *op, RewriterBase &rewriter,
                              llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap) {
-  SmallVector<Value> boundaryValues;
+  auto canRewriteBoundary = [&](Value value, bool allowStableBase) {
+    if (!isScalarPointerType(value.getType()))
+      return true;
+    if (allowStableBase && isStableFunctionScalarPointerBase(value))
+      return true;
+    return canRewriteScalarPointer(value, rewriter, offsetMap);
+  };
+
   if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
-    boundaryValues.append(whileOp.getInits().begin(), whileOp.getInits().end());
-    boundaryValues.append(whileOp.getBeforeArguments().begin(),
-                          whileOp.getBeforeArguments().end());
-    boundaryValues.append(whileOp.getAfterArguments().begin(),
-                          whileOp.getAfterArguments().end());
+    for (Value init : whileOp.getInits())
+      if (!canRewriteBoundary(init, /*allowStableBase=*/true))
+        return true;
+    for (Value arg : whileOp.getBeforeArguments())
+      if (!canRewriteBoundary(arg, /*allowStableBase=*/false))
+        return true;
+    for (Value arg : whileOp.getAfterArguments())
+      if (!canRewriteBoundary(arg, /*allowStableBase=*/false))
+        return true;
+    return false;
   } else if (auto loopOp = dyn_cast<LoopLikeOpInterface>(op)) {
-    boundaryValues.append(loopOp.getInits().begin(), loopOp.getInits().end());
-    boundaryValues.append(loopOp.getRegionIterArgs().begin(),
-                          loopOp.getRegionIterArgs().end());
+    for (Value init : loopOp.getInits())
+      if (!canRewriteBoundary(init, /*allowStableBase=*/true))
+        return true;
+    for (Value arg : loopOp.getRegionIterArgs())
+      if (!canRewriteBoundary(arg, /*allowStableBase=*/false))
+        return true;
+    for (Value value : loopOp.getYieldedValues())
+      if (isOpaqueScalarPointerIfResult(value))
+        return true;
+    return false;
   } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
-    boundaryValues.append(ifOp->getResults().begin(), ifOp->getResults().end());
-    boundaryValues.append(ifOp.thenYield().getResults().begin(),
-                          ifOp.thenYield().getResults().end());
+    for (Value value : ifOp->getResults())
+      if (!canRewriteBoundary(value, /*allowStableBase=*/false))
+        return true;
+    for (Value value : ifOp.thenYield().getResults())
+      if (!canRewriteBoundary(value, /*allowStableBase=*/false))
+        return true;
     if (ifOp.elseBlock())
-      boundaryValues.append(ifOp.elseYield().getResults().begin(),
-                            ifOp.elseYield().getResults().end());
+      for (Value value : ifOp.elseYield().getResults())
+        if (!canRewriteBoundary(value, /*allowStableBase=*/false))
+          return true;
   } else {
     return false;
-  }
-
-  for (Value value : boundaryValues) {
-    if (!isScalarPointerType(value.getType()))
-      continue;
-    if (!canRewriteScalarPointer(value, rewriter, offsetMap))
-      return true;
   }
   return false;
 }
@@ -250,7 +290,8 @@ static void invalidateScalarPointerBoundaryAnalysis(
 
 void replaceOperands(MutableArrayRef<OpOperand> oprs, RewriterBase &rewriter,
                      llvm::DenseMap<Value, PtrOffsetInfo> &offsetMap,
-                     bool preserveScalarPointers) {
+                     bool preserveScalarPointers,
+                     bool allowStableBaseInit = false) {
   for (auto it = oprs.begin(); it != oprs.end(); ++it) {
     auto &opr = *it;
     auto operand = opr.get();
@@ -271,6 +312,14 @@ void replaceOperands(MutableArrayRef<OpOperand> oprs, RewriterBase &rewriter,
       if (preserveScalarPointers && isScalarPointerType(operand.getType()))
         continue;
       parse(operand, operand.getLoc(), rewriter, offsetMap);
+      if (allowStableBaseInit && isStableFunctionScalarPointerBase(operand)) {
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPoint(opr.getOwner());
+        Value zero =
+            rewriter.create<arith::ConstantIntOp>(operand.getLoc(), 0, 64);
+        opr.set(zero);
+        continue;
+      }
       if (auto tensorType =
               dyn_cast<RankedTensorType>(ptrType.getPointeeType())) {
         for (auto offset : offsetMap.at(operand).getOffsets()) {
@@ -389,7 +438,8 @@ void convertTensorPtrPre(Operation *op, RewriterBase &rewriter,
     replaceArgs(whileOp.getBeforeArguments(), rewriter, offsetMap,
                 preserveScalarPointers);
     replaceOperands(whileOp.getInitsMutable(), rewriter, offsetMap,
-                    preserveScalarPointers);
+                    preserveScalarPointers,
+                    /*allowStableBaseInit=*/true);
     replaceArgs(whileOp.getAfterArguments(), rewriter, offsetMap,
                 preserveScalarPointers);
     replaceArgs(whileOp->getResults(), rewriter, offsetMap,
@@ -405,7 +455,8 @@ void convertTensorPtrPre(Operation *op, RewriterBase &rewriter,
     replaceArgs(loopOp.getRegionIterArgs(), rewriter, offsetMap,
                 preserveScalarPointers);
     replaceOperands(loopOp.getInitsMutable(), rewriter, offsetMap,
-                    preserveScalarPointers);
+                    preserveScalarPointers,
+                    /*allowStableBaseInit=*/true);
   } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
     if (preserveScalarPointers && hasScalarPointerResult(ifOp))
       ifOp->setAttr(kScalarPointerCarrierBoundaryAttr,

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/tensor_pointer_rankn_extsi.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/tensor_pointer_rankn_extsi.mlir
@@ -1,0 +1,33 @@
+// RUN: triton-opt --triton-control-flow-opt %s -verify-each | FileCheck %s --check-prefix=CFO
+
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @tensor_pointer_rankn_extsi(
+      %base: !tt.ptr<f32>, %upper: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %delta = arith.constant dense<1> : tensor<2x4xi32>
+    %range = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %expanded = tt.expand_dims %range {axis = 0 : i32}
+        : tensor<4xi32> -> tensor<1x4xi32>
+    %extended = arith.extsi %expanded
+        : tensor<1x4xi32> to tensor<1x4xi64>
+    %offset = tt.broadcast %extended
+        : tensor<1x4xi64> -> tensor<2x4xi64>
+    %base_tensor = tt.splat %base : !tt.ptr<f32>
+        -> tensor<2x4x!tt.ptr<f32>>
+    %initial = tt.addptr %base_tensor, %offset
+        : tensor<2x4x!tt.ptr<f32>>, tensor<2x4xi64>
+    %final = scf.for %iv = %c0 to %upper step %c1
+        iter_args(%ptr = %initial) -> (tensor<2x4x!tt.ptr<f32>>) {
+      %next = tt.addptr %ptr, %delta
+          : tensor<2x4x!tt.ptr<f32>>, tensor<2x4xi32>
+      scf.yield %next : tensor<2x4x!tt.ptr<f32>>
+    }
+    %value = tt.load %final : tensor<2x4x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// CFO-LABEL: tt.func public @tensor_pointer_rankn_extsi
+// CFO:       scf.for {{.*}}iter_args({{.*}}) -> (i64)
+// CFO:       PointerDescriptorStructuredAxes = array<i32: 1, 1>

--- a/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/bubbleupoperation.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/bubbleupoperation.mlir
@@ -82,6 +82,39 @@ tt.func @test_select_pointer_extract_bubbleup(
     tt.return %pointer : !tt.ptr<f32>
 }
 
+// CHECK-LABEL: tt.func @test_discrete_masked_select_extract_not_bubbled
+// CHECK: %[[SELECTED:.*]] = arith.select %{{.*}}, %{{.*}}, %{{.*}} {DiscreteMemAccess} : tensor<4xi1>, tensor<4xf32>
+// CHECK: %[[VALUE:.*]] = tensor.extract %[[SELECTED]][%{{.*}}] : tensor<4xf32>
+// CHECK: tt.return %[[VALUE]] : f32
+tt.func @test_discrete_masked_select_extract_not_bubbled(
+    %condition: tensor<4xi1>, %true_value: tensor<4xf32>,
+    %false_value: tensor<4xf32>, %i: index) -> f32 {
+    %selected = arith.select %condition, %true_value, %false_value {DiscreteMemAccess} : tensor<4xi1>, tensor<4xf32>
+    %value = tensor.extract %selected[%i] : tensor<4xf32>
+    tt.return %value : f32
+}
+
+// CHECK-LABEL: tt.func @test_discrete_load_loop_select_extract_not_bubbled
+// CHECK: %[[LOADED:.*]] = scf.for
+// CHECK: } {ExtractedLoadOrStore}
+// CHECK: %[[SELECTED:.*]] = arith.select %{{.*}}, %[[LOADED]], %{{.*}} : tensor<4xi1>, tensor<4xf32>
+// CHECK: %[[VALUE:.*]] = tensor.extract %[[SELECTED]][%{{.*}}] : tensor<4xf32>
+// CHECK: tt.return %[[VALUE]] : f32
+tt.func @test_discrete_load_loop_select_extract_not_bubbled(
+    %condition: tensor<4xi1>, %initial: tensor<4xf32>,
+    %other: tensor<4xf32>, %loaded_element: f32, %i: index) -> f32 {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %loaded = scf.for %iv = %c0 to %c4 step %c1 iter_args(%result = %initial) -> tensor<4xf32> {
+      %inserted = tensor.insert %loaded_element into %result[%iv] : tensor<4xf32>
+      scf.yield %inserted : tensor<4xf32>
+    } {ExtractedLoadOrStore}
+    %selected = arith.select %condition, %loaded, %other : tensor<4xi1>, tensor<4xf32>
+    %value = tensor.extract %selected[%i] : tensor<4xf32>
+    tt.return %value : f32
+}
+
 // CHECK-LABEL: tt.func @test_ceil_extract_bubbleup
 tt.func @test_ceil_extract_bubbleup(%a: tensor<128xf32>, %i: index, %c: f32) -> f32 {
     %0 = math.ceil %a : tensor<128xf32>

--- a/third_party/ascend/unittest/pytest_ut/test_scalar_pointer_control_flow.py
+++ b/third_party/ascend/unittest/pytest_ut/test_scalar_pointer_control_flow.py
@@ -59,6 +59,20 @@ def scalar_pointer_while_kernel(x, out, steps_ptr):
 
 
 @triton.jit
+def scalar_pointer_while_from_function_args_kernel(x, out, steps_ptr):
+    """Keep function-argument bases outside the loop and carry only offsets."""
+    steps = tl.load(steps_ptr)
+    input_pointer = x
+    output_pointer = out
+    iteration = 0
+    while iteration < steps:
+        input_pointer = input_pointer + 2
+        output_pointer = output_pointer + 3
+        iteration += 1
+    tl.store(output_pointer, tl.load(input_pointer))
+
+
+@triton.jit
 def scalar_pointer_nested_if_for_kernel(x, out, predicate_ptr, steps_ptr):
     predicate = tl.load(predicate_ptr)
     steps = tl.load(steps_ptr)
@@ -166,6 +180,21 @@ def test_scalar_pointer_while_carried(steps):
 
     expected_index = 1 + 2 * steps
     _assert_output(out, x0_cpu[expected_index:expected_index + 1])
+
+
+@pytest.mark.parametrize("steps", [0, 1, 5])
+def test_scalar_pointer_while_from_function_args(steps):
+    x0_cpu, _, x0, _ = _inputs()
+    out_cpu = torch.zeros(INPUT_SIZE, dtype=torch.float32)
+    out = out_cpu.npu()
+
+    scalar_pointer_while_from_function_args_kernel[(1, )](x0, out, _device_i32(steps))
+
+    expected_input_index = 2 * steps
+    expected_output_index = 3 * steps
+    expected = torch.zeros_like(out_cpu)
+    expected[expected_output_index] = x0_cpu[expected_input_index]
+    _assert_output(out, expected)
 
 
 @pytest.mark.parametrize("predicate", [0, 1])


### PR DESCRIPTION
Stabilize pointer control-flow lowering across T2U, CFO, and T2L. This single commit preserves stable scalar bases, selects complete-address carriers for opaque if loop backedges, preserves rank-N sign-extended offsets, constrains legacy BlockData address-use discovery, folds supported scan pointer stores, and prevents discrete vector masks from being bubbled away. It also includes PR #1791's sparse decode model1 fallback and focused MLIR/pytest regressions.