### PR TITLE
[ssbuffer](fix) memdep sync for write

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
@@ -189,7 +189,8 @@ private:
                            mlir::Operation *consumedDataOp = nullptr,
                            bool isStoreDirectly = false);
   void insertMemDepSync(mlir::OpBuilder &builder, mlir::Operation *producerOp,
-                        mlir::Operation *consumerOp, int flag,
+                        mlir::Operation *consumerOp,
+                        mlir::Operation *consumerEndOp, int flag,
                         mlir::Location loc, bool isCubeToVector,
                         FlagIdReuseManager &flagIdReuseManager);
   // Match the CUBE -> VECTOR direct-store pattern inside the given SCF op:

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <memory>
 #include <optional>
+#include <set>
 
 #include "ascend/include/DynamicCVPipeline/Common/FlagIdManager.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
@@ -1024,9 +1025,27 @@ void InterCoreTransferAndSyncPass::insertInterCoreSync(
   return;
 }
 
+bool hasMemDepSyncWhitelistKernel(ModuleOp module) {
+  std::vector<std::string> whitelist{
+      "_hstu_attn_fwd",
+      "parallel_path_fwd_kernel",
+  };
+
+  // Check if any func name matches the whitelist
+  bool hasWhitelistedKernel = false;
+  for (auto func : module.getOps<func::FuncOp>()) {
+    if (llvm::is_contained(whitelist, func.getName().str())) {
+      hasWhitelistedKernel = true;
+      break;
+    }
+  }
+  return hasWhitelistedKernel;
+}
+
 void InterCoreTransferAndSyncPass::insertMemDepSync(
-    OpBuilder &builder, Operation *producerOp, Operation *consumerOp, int flag,
-    Location loc, bool isCubeToVector, FlagIdReuseManager &flagIdReuseManager) {
+    OpBuilder &builder, Operation *producerOp, Operation *consumerOp,
+    Operation *consumerEndOp, int flag, Location loc, bool isCubeToVector,
+    FlagIdReuseManager &flagIdReuseManager) {
   LOG_DEBUG("Inserting Memdep sync: "
             << (isCubeToVector ? "CUBE->VECTOR" : "VECTOR->CUBE")
             << ", flag = " << flag << "\n");
@@ -1060,19 +1079,53 @@ void InterCoreTransferAndSyncPass::insertMemDepSync(
 
   auto prodBlockIdOpt = CVPipeline::getOpBlockId(producerOp);
   auto consBlockIdOpt = CVPipeline::getOpBlockId(consumerOp);
+  StringRef prodCoreType =
+      isCubeToVector ? CVPipeline::kCoreTypeCube : CVPipeline::kCoreTypeVector;
+  StringRef consCoreType =
+      isCubeToVector ? CVPipeline::kCoreTypeVector : CVPipeline::kCoreTypeCube;
   if (prodBlockIdOpt) {
-    StringRef prodCoreType = isCubeToVector ? CVPipeline::kCoreTypeCube
-                                            : CVPipeline::kCoreTypeVector;
     attachCommonTags(setOp, *prodBlockIdOpt, prodCoreType);
   }
   if (consBlockIdOpt) {
-    StringRef consCoreType = isCubeToVector ? CVPipeline::kCoreTypeVector
-                                            : CVPipeline::kCoreTypeCube;
     attachCommonTags(waitOp, *consBlockIdOpt, consCoreType);
   }
   attachAnalyzeFlagIdTag(setOp);
   attachAnalyzeFlagIdTag(waitOp);
   flagIdReuseManager.insertRelationBetweenSetAndWait(setOp, waitOp);
+  if (hasMemDepSyncWhitelistKernel(module)) {
+    Operation *mainLoopOp = findMainLoopforTransfer(producerOp, consumerOp);
+    if (mainLoopOp) {
+      builder.setInsertionPoint(producerOp);
+      auto waitOpForWrite = builder.create<SyncBlockWaitOp>(
+          loc, srcCoreAttr, dstPipeAttr, srcPipeAttr, flagId);
+      attachCommonTags(waitOpForWrite, *prodBlockIdOpt, prodCoreType);
+
+      builder.setInsertionPointAfter(consumerEndOp);
+      auto setOpForWrite = builder.create<SyncBlockSetOp>(
+          loc, dstCoreAttr, dstPipeAttr, srcPipeAttr, flagId);
+      attachCommonTags(setOpForWrite, *consBlockIdOpt, consCoreType);
+
+      builder.setInsertionPoint(mainLoopOp);
+      auto setOpForStart = builder.create<SyncBlockSetOp>(
+          loc, dstCoreAttr, dstPipeAttr, srcPipeAttr, flagId);
+      builder.setInsertionPointAfter(mainLoopOp);
+      auto waitOpForEnd = builder.create<SyncBlockWaitOp>(
+          loc, srcCoreAttr, dstPipeAttr, srcPipeAttr, flagId);
+
+      int startEndBlockId = CVPipeline::getOpBlockId(mainLoopOp).value_or(-1);
+      attachCommonTags(setOpForStart, startEndBlockId, consCoreType);
+      attachCommonTags(waitOpForEnd, startEndBlockId, prodCoreType);
+
+      attachAnalyzeFlagIdTag(waitOpForWrite);
+      attachAnalyzeFlagIdTag(setOpForWrite);
+      attachAnalyzeFlagIdTag(setOpForStart);
+      attachAnalyzeFlagIdTag(waitOpForEnd);
+      flagIdReuseManager.insertRelationBetweenSetAndWait(setOpForWrite,
+                                                         waitOpForWrite);
+      flagIdReuseManager.insertRelationBetweenSetAndWait(setOpForStart,
+                                                         waitOpForEnd);
+    }
+  }
   LOG_DEBUG("[PIPE_MTE2 setOp]: " << *setOp << "\n");
   LOG_DEBUG("[PIPE_MTE2 waitOp]: " << *waitOp << "\n");
 }
@@ -1655,8 +1708,8 @@ LogicalResult InterCoreTransferAndSyncPass::handleMemoryDependency(
   Location loc = prodEnd->getLoc();
 
   // Insert Memdep sync
-  insertMemDepSync(builder, prodEnd, consStart, flagId, loc, isCubeToVector,
-                   flagIdReuseManager);
+  insertMemDepSync(builder, dep.predOp, consStart, consEnd, flagId, loc,
+                   isCubeToVector, flagIdReuseManager);
 
   transferIndex++;
 


### PR DESCRIPTION
# Summary
- Add `sync_block_set/wait` for memory dependencies in loop to prevent write conflicts.
- Only takes effect in two whitelist kernel.


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
