### PR TITLE
[TritonToLinalg](fix) bugfix for negative stride and value for selectOp

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/MaskAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/MaskAnalysis.cpp
@@ -429,8 +429,10 @@ LogicalResult MaskState::parseSel(arith::SelectOp selOp, const Location &loc,
     return failure();
   }
 
-  auto trueScalar = dyn_cast<IntegerAttr>(trueState.scalar.get<Attribute>());
-  auto falseScalar = dyn_cast<IntegerAttr>(falseState.scalar.get<Attribute>());
+  auto trueScalar =
+      dyn_cast_if_present<IntegerAttr>(dyn_cast<Attribute>(trueState.scalar));
+  auto falseScalar =
+      dyn_cast_if_present<IntegerAttr>(dyn_cast<Attribute>(falseState.scalar));
 
   if (trueScalar && falseScalar) {
     if(trueScalar.getInt() == 1 && falseScalar.getInt() == 0) {

--- a/third_party/ascend/lib/Utils/Utils.cpp
+++ b/third_party/ascend/lib/Utils/Utils.cpp
@@ -95,7 +95,7 @@ std::optional<int64_t> getLastStrideOfReinterpretCastOp(memref::ReinterpretCastO
 
   OpFoldResult lastStride = mixedStrides.back();
 
-  if (op.getStaticStrides().back() > 0) {
+  if (op.getStaticStrides().back() != ShapedType::kDynamic) {
     return op.getStaticStrides().back();
   } else if (isa<BlockArgument>(op.getStrides().back()) ) {
     auto u = op.getStrides().back();


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration

* Segfault on parseSel — an unsafe cast on a PointerUnion<Attribute, Value> triggered the PointerUnion::get assertion when the parsed scalar was a Value rather than an Attribute.

* Segfault on getLastStrideOfReinterpretCastOp — the predicate getStaticStrides().back() > 0 mishandled non-kDynamic non-positive strides (e.g. a literal 0), causing control flow to fall through to getStrides().back() on an empty OperandRange.

- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
