### PR TITLE
[Autotune](fix) cache single-config selections

### DIFF
--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -2096,6 +2096,7 @@ class AutoTilingTuner(Autotuner):
         _inject_default_simt_stack_limit(kwargs, self.simt_stack_limit)
         did_benchmark = False
         disk_cache_hit = False
+        single_config_cache_pending = False
         if cache_miss:
             # prune configs
             pruned_configs = self.prune_configs(kwargs)
@@ -2132,6 +2133,7 @@ class AutoTilingTuner(Autotuner):
                 config = self.cache[key]
             else:
                 config = pruned_configs[0]
+                single_config_cache_pending = True
         else:
             config = self.cache[key]
 
@@ -2154,10 +2156,12 @@ class AutoTilingTuner(Autotuner):
                 *args,
                 **final_kwargs,
             )
+            if single_config_cache_pending:
+                self.cache[key] = config
             return ret
         finally:
             self.nargs = None
-            if cache_miss and not disk_cache_hit:
+            if did_benchmark and not disk_cache_hit:
                 # workaround for memory leak when some configs fail to compile
                 gc.collect()
 

--- a/third_party/ascend/unittest/autotune_ut/test_do_bench_compat.py
+++ b/third_party/ascend/unittest/autotune_ut/test_do_bench_compat.py
@@ -47,11 +47,16 @@ def _make_tuner(do_bench):
 def _make_run_tuner(configs):
     key = ("disk-cache-key", )
     tuner = object.__new__(AutoTilingTuner)
+
+    def generate_key_and_configs(*args, **kwargs):
+        tuner.nargs = {}
+        return key
+
     tuner.arg_names = []
     tuner.cache = {}
     tuner.is_simt_mode = False
     tuner.simt_stack_limit = 8192
-    tuner.generate_key_and_configs = lambda *args, **kwargs: key
+    tuner.generate_key_and_configs = generate_key_and_configs
     tuner.prune_configs = lambda kwargs: configs
     tuner.enable_ubtuner = False
     tuner.cache_results = True
@@ -245,21 +250,110 @@ def test_run_keeps_gc_on_autotune_disk_cache_miss(monkeypatch):
     assert gc_calls == [True]
     assert profile_calls == [configs[0]]
 
+    assert tuner.run() == "kernel-result"
+    assert benchmark_calls == [configs]
+    assert gc_calls == [True]
+    assert profile_calls == [configs[0]]
 
-def test_run_keeps_gc_on_single_config_cache_miss(monkeypatch):
-    tuner, _ = _make_run_tuner([Config({"BLOCK_SIZE": 16, "compile_mode": "simt_only"})])
+
+def test_run_caches_single_config_and_skips_gc(monkeypatch):
+    config = Config({"BLOCK_SIZE": 16, "compile_mode": "simt_only"})
+    tuner, key = _make_run_tuner([config])
     gc_calls = []
     profile_calls = []
+    prune_calls = []
+
+    def prune_configs(kwargs):
+        prune_calls.append(kwargs)
+        return [config]
 
     def unexpected_disk_cache(*args, **kwargs):
         raise AssertionError("single-config path must not probe disk cache")
 
+    def unexpected_batch_bench(*args, **kwargs):
+        raise AssertionError("single-config path must not benchmark")
+
+    tuner.prune_configs = prune_configs
     tuner.check_disk_cache = unexpected_disk_cache
+    tuner._batch_bench = unexpected_batch_bench
     tuner.auto_profile_dir = "profile-output"
     tuner._profile = lambda *args, config, **kwargs: profile_calls.append(config)
     monkeypatch.setattr(ascend_autotuner.gc, "collect", lambda: gc_calls.append(True))
 
     assert tuner.run() == "kernel-result"
+    assert tuner.cache[key] is config
+    assert tuner.run() == "kernel-result"
+    assert len(prune_calls) == 1
+    assert len(tuner.run_kwargs) == 2
     assert tuner.run_kwargs[-1]["simt_stack_limit"] == 8192
-    assert gc_calls == [True]
+    assert gc_calls == []
     assert profile_calls == []
+
+
+def test_run_does_not_cache_failed_single_config(monkeypatch):
+    config = Config({"BLOCK_SIZE": 16})
+    tuner, key = _make_run_tuner([config])
+    gc_calls = []
+    prune_calls = []
+    run_calls = []
+
+    def prune_configs(kwargs):
+        prune_calls.append(kwargs)
+        return [config]
+
+    def run(*args, **kwargs):
+        run_calls.append(kwargs)
+        if len(run_calls) == 1:
+            raise RuntimeError("kernel failed")
+        return "kernel-result"
+
+    def unexpected_disk_cache(*args, **kwargs):
+        raise AssertionError("single-config path must not probe disk cache")
+
+    def unexpected_batch_bench(*args, **kwargs):
+        raise AssertionError("single-config path must not benchmark")
+
+    tuner.prune_configs = prune_configs
+    tuner.fn = SimpleNamespace(run=run)
+    tuner.check_disk_cache = unexpected_disk_cache
+    tuner._batch_bench = unexpected_batch_bench
+    monkeypatch.setattr(ascend_autotuner.gc, "collect", lambda: gc_calls.append(True))
+
+    with pytest.raises(RuntimeError, match="kernel failed"):
+        tuner.run()
+    assert key not in tuner.cache
+
+    assert tuner.run() == "kernel-result"
+    assert tuner.cache[key] is config
+    assert tuner.run() == "kernel-result"
+    assert len(prune_calls) == 2
+    assert len(run_calls) == 3
+    assert gc_calls == []
+
+
+def test_run_caches_single_config_after_pruning(monkeypatch):
+    config = Config({"BLOCK_SIZE": 16})
+    tuner, key = _make_run_tuner([config, Config({"BLOCK_SIZE": 32})])
+    gc_calls = []
+    prune_calls = []
+
+    def prune_configs(kwargs):
+        prune_calls.append(kwargs)
+        return [config]
+
+    def unexpected_disk_cache(*args, **kwargs):
+        raise AssertionError("single-config path must not probe disk cache")
+
+    def unexpected_batch_bench(*args, **kwargs):
+        raise AssertionError("single-config path must not benchmark")
+
+    tuner.prune_configs = prune_configs
+    tuner.check_disk_cache = unexpected_disk_cache
+    tuner._batch_bench = unexpected_batch_bench
+    monkeypatch.setattr(ascend_autotuner.gc, "collect", lambda: gc_calls.append(True))
+
+    assert tuner.run() == "kernel-result"
+    assert tuner.cache[key] is config
+    assert tuner.run() == "kernel-result"
+    assert len(prune_calls) == 1
+    assert gc_calls == []


### PR DESCRIPTION
## Problem

`AutoTilingTuner.run()` uses an in-process cache to remember the selected `Config` for each autotune key. When pruning leaves one effective config, the Ascend fast path selects that config without benchmarking it, but previously never inserted it into `self.cache`.

As a result, every later invocation in the same process was still treated as an autotune cache miss. The Ascend cleanup also used that miss as a proxy for whether candidate compilation had happened:

```python
if cache_miss and not disk_cache_hit:
    gc.collect()
```

The single-config path does not benchmark candidate configs, so this caused a full Python GC after every invocation even though the compile-failure workaround had no candidate-benchmark work to clean up. In the reported eager workload, a large Python heap made each collection take 20-50 seconds.

Caching the config alone fixes repeated collections within one tuner instance, but it does not remove the first unnecessary collection for a new process, a newly-created tuner, or a new key: the in-process cache is empty in each of those cases. The cleanup condition therefore also needs to describe what actually happened during the current invocation.

## Cache boundaries

This change keeps the existing cache responsibilities separate:

- `AutoTilingTuner.self.cache` is the in-process selection cache mapping an autotune key to the selected `Config`.
- The autotune disk cache stores benchmark timings for choosing among multiple configs. A single effective config has no candidate timings to persist.
- The JIT/compiler caches store compiled kernel artifacts and continue to provide cross-process reuse independently of the autotune selection cache.

No autotune disk-cache format or JIT/compiler-cache behavior is changed.

## Solution

- Mark a single effective config as pending instead of caching it before execution.
- Insert it into `self.cache` only after the first `fn.run()` returns successfully.
- Leave a failed first execution uncached so a compile or runtime failure is not recorded as a resolved selection.
- Run the existing GC workaround only when this invocation actually benchmarked candidate configs and did not hit the autotune disk cache.
- Preserve the existing multi-config benchmark, disk-cache, profiling, and UB-tuner paths.

The delayed write is important because the single-config fast path does not pre-validate the config through `_batch_bench()`. The GC condition is independently important because a second process starts with an empty `self.cache`: it still has `cache_miss=True`, but it has `did_benchmark=False` and therefore no longer performs an unrelated full GC.

## Behavior after this change

| Scenario | Benchmark | Selection-cache write | Full GC |
|---|---:|---:|---:|
| Single config, first successful call | No | After `fn.run()` succeeds | No |
| Single config, later call in the same process | No | Already cached | No |
| Single config, first call in a new process | No | After `fn.run()` succeeds | No |
| Single config, first call fails | No | No | No |
| Multiple configs, in-process cache hit | No | Already cached | No |
| Multiple configs, autotune disk-cache hit | No | Loaded from disk result | No |
| Multiple configs, disk miss or disk cache disabled | Yes | Best benchmarked config | Yes, unchanged |
| UB-tuner path that benchmarks candidates | Yes | Best resulting config | Yes, unchanged |

If every candidate fails during `_batch_bench()`, the existing exception is raised before the final kernel call and cleanup block; this behavior is unchanged.

## Testing

- `third_party/ascend/unittest/autotune_ut/test_do_bench_compat.py`: **11 passed**
  - a single config is cached only after successful execution;
  - a failed first execution remains uncached and can be retried;
  - multiple configs pruned to one use the same fast path;
  - single-config paths do not benchmark, probe the autotune disk cache, profile, or invoke `gc.collect()`;
  - multi-config disk misses still benchmark and collect once, then use the in-process cache;
  - autotune disk hits still skip benchmark, profile, and GC.
- Applicable configured pre-commit hooks passed for both changed files.
- `git diff --check` passed.
- GitHub checks for head `8bee4271d79edac7b83991e54c2df77831ff86a4` passed, including pre-commit, aarch64 A3 integration tests for Python 3.10/3.11, Ascend950 pipeline tests, and wheel builds.

## Validation boundary

The reported hh4m containers are unavailable, so the original 100-step eager performance reproduction was not rerun locally. Local validation covers the source-aligned autotuner state machine without NPU execution; repository CI provides the available build and NPU integration coverage.

## New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description explaining why the change is needed.
- [x] I have added tests.
- [x] I have not added any lit tests.
