### PR TITLE
[Docs](feat) add 'tracking' issue label for long-lived work

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           # Issues
           days-before-issue-stale: 30
-          days-before-issue-close: 14
+          days-before-issue-close: 7
           stale-issue-label: "stale"
           stale-issue-message: >
             This issue has been automatically marked as **stale** because it has not had

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -42,7 +42,7 @@ jobs:
             If it still needs to be merged, feel free to reopen.
 
           # Labels to exempt from stale checks
-          exempt-issue-labels: "P0,bug,enhancement,community-task"
+          exempt-issue-labels: "P0,bug,enhancement,community-task,tracking"
           exempt-pr-labels: "P0,WIP"
 
           # Auto-remove stale label when activity occurs

--- a/docs/en/community/issue-workflow-guidelines.md
+++ b/docs/en/community/issue-workflow-guidelines.md
@@ -13,6 +13,7 @@ These labels track where an issue stands in the workflow.
 | `triage review` | Newly filed or unseen issue awaiting initial assessment by a maintainer                                                          |
 | `triaged`       | Assessment complete; type, priority, and module have been determined                                                             |
 | `wait-feedback` | Blocked on an external dependency or awaiting a response before work can proceed                                                 |
+| `tracking`      | Long-lived issue for ongoing or routine work (e.g., phased deprecation, upstream alignment) |
 | `resolved`      | Issue has been closed — either via a merged PR, or through non-code resolution (e.g., answered question, configuration guidance) |
 | `stale`         | No activity for an extended period; parties have been notified and the issue will be auto-closed if there is no response         |
 | `duplicated`    | A duplicate of an existing open issue or merged PR                                                                               |
@@ -75,5 +76,6 @@ After a thorough review of the issue content:
 After triage, the issue moves into tracking and implementation:
 
 - Keep the issue in progress until it is resolved through a merged PR or another confirmed resolution path.
+- For work that spans multiple releases or is handled incrementally (e.g., API deprecation, upstream alignment), apply `tracking` so maintainers can mark progress without closing the issue prematurely.
 - Once the issue is resolved, apply `resolved` and close it, ideally with a reference to the merged PR or a short explanation of the resolution.
-- If the issue remains inactive for an extended period, apply `stale` as the final state before auto-closure.
+- If the issue remains inactive for an extended period, apply `stale` as the final state before auto-closure. Issues labeled `tracking` are exempt from stale auto-close.


### PR DESCRIPTION
## Summary
Introduce a new issue status label `tracking` for long-lived, incrementally handled work (e.g., phased API deprecation, upstream alignment). Document its usage and exempt it from stale auto-close.

The GitHub label itself will be created manually in **Settings → Labels** after this PR is merged.

## What Is Included
- `docs/en/community/issue-workflow-guidelines.md`: add `tracking` to status labels and describe when to apply it in Phase 3
- `.github/workflows/stale.yml`: add `tracking` to `exempt-issue-labels`


## User Impact
No code behavior change. Maintainers can label umbrella issues as `tracking` to keep them open across releases without stale bot auto-closure.

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
  - [x] This PR does not need a test because it only updates docs and stale-bot config.
  - [ ] I have added tests.
- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices).
