### PR TITLE
[UT](fix) Add fp16 coverage to exp elementwise test

### DIFF
--- a/third_party/ascend/unittest/pytest_ut/test_exp.py
+++ b/third_party/ascend/unittest/pytest_ut/test_exp.py
@@ -73,9 +73,7 @@ shapes = [
 ]
 
 
-@pytest.mark.parametrize('dtype, sigtype', [
-    (torch.float32, 'float32'),
-])
+@pytest.mark.parametrize('dtype, sigtype', [(torch.float32, 'float32'), (torch.float16, 'float16')])
 @pytest.mark.parametrize('N, NUMEL', shapes)
 def test_elementwsie_common(dtype, sigtype, N, NUMEL):
     N = (-N) // torch.tensor(0, dtype=dtype).element_size() if N < 0 else N


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
## Summary

Add fp16 to the dtype parametrization of exp's elementwise test, so tl.exp's fp16 support is guarded by unit tests.

## Background

The test only covered float32. When exp's implementation was modified and fp16 support was temporarily dropped, no test failed, and the regression went unnoticed until support was restored by a later change. Source changes that silently drop a supported dtype should be caught by CI.
# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
