### PR TITLE
[ssbuffer](feat) Optimization for EXP(SUB(EXT)) pattern

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
@@ -49,6 +49,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createMoveLoadIntoUserPass();
 std::unique_ptr<OperationPass<ModuleOp>> createPosMaskPatternPass();
 
 std::unique_ptr<OperationPass<ModuleOp>> createSplitIfByBlockIdPass();
+std::unique_ptr<OperationPass<ModuleOp>> createExpSubfPatternPass();
 void registerSplitIfByBlockIdPass();
 
 } // namespace triton

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/ExpSubfPatternPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/ExpSubfPatternPass.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
+#include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+static constexpr const char *DEBUG_TYPE = "exp-subf-pattern";
+#define LOG_DEBUG(...)                                                         \
+  LLVM_DEBUG(llvm::dbgs() << " [" << DEBUG_TYPE << "] " << __VA_ARGS__ << "\n")
+
+using namespace mlir;
+using namespace arith;
+using namespace math;
+
+namespace {
+
+static bool matchExpFromSubf(arith::SubFOp subfOp, math::ExpOp &expOp,
+                             CVPipeline::ComputeBlockIdManager &bm) {
+
+  auto subfResult = subfOp.getResult();
+  if (!subfOp->hasOneUse()) {
+    LOG_DEBUG("SubF has multiple users, skipping");
+    return false;
+  }
+
+  Operation *user = *subfResult.getUsers().begin();
+  expOp = dyn_cast<math::ExpOp>(user);
+  if (!expOp) {
+    LOG_DEBUG("SubF user is not ExpOp, skipping");
+    return false;
+  }
+  if (expOp->getBlock() != subfOp->getBlock()) {
+    LOG_DEBUG("SubF and ExpOp not in the same Block, skipping");
+    return false;
+  }
+  return true;
+}
+
+static bool matchExtfFromSubf(arith::SubFOp subfOp,
+                              SmallVector<arith::ExtFOp, 2> &extfOps,
+                              CVPipeline::ComputeBlockIdManager &bm) {
+  auto lhs = subfOp.getLhs();
+  auto rhs = subfOp.getRhs();
+
+  auto lhsDef = lhs.getDefiningOp<arith::ExtFOp>();
+  auto rhsDef = rhs.getDefiningOp<arith::ExtFOp>();
+
+  if (!lhsDef || !rhsDef) {
+    LOG_DEBUG(
+        "SubF operands are not both from ExtFOp, skipping extended pattern");
+    return false;
+  }
+  if (lhsDef->getBlock() != subfOp->getBlock() ||
+      rhsDef->getBlock() != subfOp->getBlock()) {
+    LOG_DEBUG("SubF and ExtfOp not in the same Block, skipping");
+    return false;
+  }
+
+  auto lhsInType = lhsDef.getIn().getType();
+  auto rhsInType = rhsDef.getIn().getType();
+  auto lhsOutType = lhsDef.getOut().getType();
+  auto rhsOutType = rhsDef.getOut().getType();
+
+  if (!lhsInType.isF16() || !rhsInType.isF16()) {
+    LOG_DEBUG("ExtF input types are not both f16, skipping extended pattern");
+    return false;
+  }
+
+  if (!lhsOutType.isF32() || !rhsOutType.isF32()) {
+    LOG_DEBUG("ExtF output types are not both f32, skipping extended pattern");
+    return false;
+  }
+
+  SmallVector<Operation *, 2> lhsUsers;
+  for (Operation *user : lhsDef.getResult().getUsers()) {
+    lhsUsers.push_back(user);
+  }
+  if (lhsUsers.size() != 1 || lhsUsers[0] != subfOp) {
+    LOG_DEBUG("Left ExtF has multiple users or not used by subf, skipping");
+    return false;
+  }
+
+  SmallVector<Operation *, 2> rhsUsers;
+  for (Operation *user : rhsDef.getResult().getUsers()) {
+    rhsUsers.push_back(user);
+  }
+  if (rhsUsers.size() != 1 || rhsUsers[0] != subfOp) {
+    LOG_DEBUG("Right ExtF has multiple users or not used by subf, skipping");
+    return false;
+  }
+
+  extfOps.push_back(lhsDef);
+  extfOps.push_back(rhsDef);
+  return true;
+}
+
+static void processSubfOp(arith::SubFOp subfOp,
+                          CVPipeline::ComputeBlockIdManager &bm) {
+  int subfBlockId = bm.getBlockIdByOp(subfOp);
+
+  math::ExpOp expOp;
+  if (!matchExpFromSubf(subfOp, expOp, bm)) {
+    return;
+  }
+
+  int expBlockId = bm.getBlockIdByOp(expOp);
+  if (expBlockId != subfBlockId) {
+    LOG_DEBUG("Updating exp blockId from " << expBlockId << " to "
+                                           << subfBlockId);
+    bm.updateBlockId(expOp, subfBlockId);
+  } else {
+    LOG_DEBUG("Exp blockId already matches subf, skipping update");
+  }
+
+  SmallVector<arith::ExtFOp, 2> extfOps;
+  if (matchExtfFromSubf(subfOp, extfOps, bm)) {
+    for (auto extfOp : extfOps) {
+      int extfBlockId = bm.getBlockIdByOp(extfOp);
+      if (extfBlockId != subfBlockId) {
+        LOG_DEBUG("Updating extf blockId from " << extfBlockId << " to "
+                                                << subfBlockId);
+        bm.updateBlockId(extfOp, subfBlockId);
+      } else {
+        LOG_DEBUG("ExtF blockId already matches subf, skipping update");
+      }
+    }
+  }
+}
+
+} // anonymous namespace
+
+class ExpSubfPatternPass
+    : public PassWrapper<ExpSubfPatternPass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ExpSubfPatternPass)
+
+  ExpSubfPatternPass() = default;
+
+  StringRef getArgument() const override { return "exp-subf-pattern"; }
+
+  StringRef getDescription() const override {
+    return "Match exp-subf pattern and unify blockId for exp and optional extf "
+           "operations";
+  }
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    LOG_DEBUG("Input mlir:\n " << module);
+    CVPipeline::ComputeBlockIdManager bm(module);
+
+    module.walk([&](arith::SubFOp subfOp) {
+      LOG_DEBUG("Process subf: " << subfOp << "\n");
+      processSubfOp(subfOp, bm);
+    });
+  }
+};
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<OperationPass<ModuleOp>> createExpSubfPatternPass() {
+  return std::make_unique<ExpSubfPatternPass>();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
@@ -71,6 +71,7 @@ void ComputeBlockOptPass::runOnOperation() {
   pm.addPass(createReorderOpsByBlockIdPass());
   pm.addPass(createMoveLoadIntoUserPass());
   pm.addPass(createUnifyStoreBlockPass());
+  pm.addPass(createExpSubfPatternPass());
   pm.addPass(createReorderOpsByBlockIdPass());
   pm.addPass(createMergeSmallBlockPass());
   pm.addPass(createReorderOpsByBlockIdPass());
@@ -101,6 +102,7 @@ void registerComputeBlockOptPasses() {
   registerPass(createMergeCubeForBlockPass);
   registerPass(createFixpipeOptPass);
   registerPass(createUnifyStoreBlockPass);
+  registerPass(createExpSubfPatternPass);
   registerPass(createSinkI1ProducersIntoUsersPass);
   registerPass(createBroadcastUBOptPass);
   registerPass(createMoveLoadIntoUserPass);

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/exp_subf_pattern.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/exp_subf_pattern.mlir
@@ -1,0 +1,105 @@
+// RUN: triton-opt --exp-subf-pattern %s | FileCheck %s
+
+module {
+  // ============================================
+  // Test 1: Simple pattern - subf -> exp
+  // ============================================
+  // CHECK-LABEL: func @test_simple_pattern
+  func.func @test_simple_pattern(%arg0: f32, %arg1: f32) -> f32 {
+    %cst = arith.constant {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} 1.000000e+00 : f32
+    %sub = arith.subf %arg0, %arg1 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    // CHECK: math.exp %{{.*}} {ssbuffer.block_id = 1 : i32
+    %exp = math.exp %sub {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    %mulf = arith.mulf %exp, %cst {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    %addf = arith.addf %exp, %cst {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    return %addf : f32
+  }
+
+  // ============================================
+  // Test 2: Extended pattern - extf(f16->f32) -> subf -> exp
+  // ============================================
+  // CHECK-LABEL: func @test_extended_pattern
+  func.func @test_extended_pattern(%arg0: f16, %arg1: f16) -> f32 {
+    // CHECK: arith.extf %{{.*}} {ssbuffer.block_id = 1 : i32
+    %extf1 = arith.extf %arg0 {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : f16 to f32
+    // CHECK: arith.extf %{{.*}} {ssbuffer.block_id = 1 : i32
+    %extf2 = arith.extf %arg1 {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR"} : f16 to f32
+    %sub = arith.subf %extf1, %extf2 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    // CHECK: math.exp %{{.*}} {ssbuffer.block_id = 1 : i32
+    %exp = math.exp %sub {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    %mulf = arith.mulf %exp, %exp {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    return %mulf : f32
+  }
+
+  // ============================================
+  // Test 3: Extended pattern with matching blockId
+  // ============================================
+  // CHECK-LABEL: func @test_extended_pattern_matching_blockid
+  func.func @test_extended_pattern_matching_blockid(%arg0: f16, %arg1: f16) -> f32 {
+    // CHECK: arith.extf %{{.*}} {ssbuffer.block_id = 1 : i32
+    %extf1 = arith.extf %arg0 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : f16 to f32
+    // CHECK: arith.extf %{{.*}} {ssbuffer.block_id = 1 : i32
+    %extf2 = arith.extf %arg1 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : f16 to f32
+    %sub = arith.subf %extf1, %extf2 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    // CHECK: math.exp %{{.*}} {ssbuffer.block_id = 1 : i32
+    %exp = math.exp %sub {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    %mulf = arith.mulf %exp, %exp {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    return %mulf : f32
+  }
+
+  // ============================================
+  // Test 4: No match - subf has multiple users
+  // ============================================
+  // CHECK-LABEL: func @test_no_match_subf_multiple_users
+  func.func @test_no_match_subf_multiple_users(%arg0: f32, %arg1: f32) -> f32 {
+    %sub = arith.subf %arg0, %arg1 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    // CHECK: math.exp %{{.*}} {ssbuffer.block_id = 2 : i32
+    %exp = math.exp %sub {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    %addf = arith.addf %sub, %arg0 {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    return %addf : f32
+  }
+
+  // ============================================
+  // Test 5: No match extended - extf has multiple users
+  // ============================================
+  // CHECK-LABEL: func @test_no_match_extf_multiple_users
+  func.func @test_no_match_extf_multiple_users(%arg0: f16, %arg1: f16) -> f32 {
+    // CHECK: arith.extf %{{.*}} {ssbuffer.block_id = 5 : i32
+    %extf1 = arith.extf %arg0 {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : f16 to f32
+    %extf2 = arith.extf %arg1 {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR"} : f16 to f32
+    %sub = arith.subf %extf1, %extf2 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    // CHECK: math.exp %{{.*}} {ssbuffer.block_id = 1 : i32
+    %exp = math.exp %sub {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    %addf = arith.addf %extf1, %extf2 {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    %mulf = arith.mulf %exp, %addf {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    return %mulf : f32
+  }
+
+  // ============================================
+  // Test 6: No match extended - wrong type conversion
+  // ============================================
+  // CHECK-LABEL: func @test_no_match_wrong_type_conversion
+  func.func @test_no_match_wrong_type_conversion(%arg0: bf16, %arg1: bf16) -> f32 {
+    // CHECK: arith.extf %{{.*}} {ssbuffer.block_id = 5 : i32
+    %extf1 = arith.extf %arg0 {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : bf16 to f32
+    // CHECK: arith.extf %{{.*}} {ssbuffer.block_id = 6 : i32
+    %extf2 = arith.extf %arg1 {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "VECTOR"} : bf16 to f32
+    %sub = arith.subf %extf1, %extf2 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    // CHECK: math.exp %{{.*}} {ssbuffer.block_id = 1 : i32
+    %exp = math.exp %sub {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    return %exp : f32
+  }
+
+  // ============================================
+  // Test 7: Mixed pattern - one operand with extf, one without
+  // ============================================
+  // CHECK-LABEL: func @test_mixed_pattern
+  func.func @test_mixed_pattern(%arg0: f16, %arg1: f32) -> f32 {
+    // CHECK: arith.extf %{{.*}} {ssbuffer.block_id = 5 : i32
+    %extf1 = arith.extf %arg0 {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : f16 to f32
+    %sub = arith.subf %extf1, %arg1 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    // CHECK: math.exp %{{.*}} {ssbuffer.block_id = 1 : i32
+    %exp = math.exp %sub {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "VECTOR"} : f32
+    return %exp : f32
+  }
+}


### PR DESCRIPTION
# Optimization for EXP(SUB(EXT)) pattern
The following patterns should share the same blockid:
1.  exp(A-B)

3. exp(cast(A)-cast(B)) the cast must be  f16->f32

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
