### PR TITLE
[ssbuffer](fix) Fix sparse bug in SplitIf

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
@@ -49,7 +49,8 @@ static constexpr llvm::StringLiteral interceptrFunc[]{
     "triton_flash_mla_sparse_fwd",
     "_sparse_decode_kernel",
     "chunk_gsa_fwd_k_kernel_intra",
-    "_sparse_decode_model1_kernel"};
+    "_sparse_decode_model1_kernel",
+    "sparse_flash_attention_grad_kernel"};
 
 static LogicalResult verifyFuncNames(ModuleOp module) {
   bool intercepted = false;


### PR DESCRIPTION
When sparse_flash_attention_grad_kernel is processed by SplitIfByBlockIdPass , it causes issues in the DynamicCVPipeline. This PR adds a pre-check in SplitIfByBlockIdPass::runOnOperation() that detects this kernel and triggers a full DynamicCVPipeline fallback (ERRCODE_FAILED) before any IR modification occurs.

Changes:

- Added kFallbackSparseFlashAttentionGradKernel constant for kernel name matching
- Before FallbackHelper is created, walk the module to check if sparse_flash_attention_grad_kernel is present
- If matched, set ERRCODE_FAILED attribute and return early, letting the pipeline entry point ( AddDynamicCVPipeline ) handle the full module restore
Files changed:

- third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/SplitIfByBlockId/SplitIfByBlockId.cpp