### PR TITLE
[ssbuffer](feat) add merge cube block pass

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/BlockDependencyGraph.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/BlockDependencyGraph.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_COMMON_BLOCK_DEPENDENCY_GRAPH_H
+#define TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_COMMON_BLOCK_DEPENDENCY_GRAPH_H
+
+#include "mlir/IR/Block.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir {
+namespace CVPipeline {
+
+// Forward declarations
+class MemoryDependenceGraph;
+class ComputeBlockIdManager;
+
+struct BlockNode {
+  int blockId;
+  llvm::SmallVector<Operation *> ops;
+  bool isCube;
+  int depth;
+};
+
+class BlockDependencyGraph {
+public:
+  BlockDependencyGraph(Block *block, const MemoryDependenceGraph &memGraph,
+                       ComputeBlockIdManager &bm);
+
+  // Build block-level dependency graph (only includes dependencies within
+  // current MLIR Block)
+  llvm::LogicalResult buildGraph();
+
+  BlockNode *getBlockNode(int blockId);
+  llvm::SmallVector<int> getPredecessors(int blockId);
+  llvm::SmallVector<int> getSuccessors(int blockId);
+
+  // computeDepth
+  void computeDepths();
+  int getDepth(int blockId);
+
+  // detect cycle
+  bool wouldCreateCycle(int blockId1, int blockId2);
+
+  // rebuildgraph
+  void rebuildAfterMerge(int targetBlockId, int sourceBlockId);
+
+  llvm::DenseMap<int, BlockNode> blockNodes;
+
+private:
+  Block *block;
+  const MemoryDependenceGraph &memGraph;
+  ComputeBlockIdManager &bm;
+
+  llvm::DenseMap<int, llvm::SmallVector<int>> predecessors;
+  llvm::DenseMap<int, llvm::SmallVector<int>> successors;
+
+  void addEdge(int from, int to);
+
+  bool isInCurrentBlock(Operation *op);
+};
+
+} // namespace CVPipeline
+} // namespace mlir
+
+#endif // TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_COMMON_BLOCK_DEPENDENCY_GRAPH_H

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlockPass.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlockPass.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_PLAN_COMPUTE_BLOCK_MERGE_CUBE_BLOCK_PASS_H
+#define TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_PLAN_COMPUTE_BLOCK_MERGE_CUBE_BLOCK_PASS_H
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir {
+namespace CVPipeline {
+
+class BlockDependencyGraph;
+class MemoryDependenceGraph;
+class ComputeBlockIdManager;
+
+class MergeCubeBlockPass
+    : public PassWrapper<MergeCubeBlockPass, OperationPass<ModuleOp>> {
+public:
+  MergeCubeBlockPass() = default;
+
+  StringRef getArgument() const override { return "merge-cube-block"; }
+  StringRef getDescription() const override {
+    return "Merge cube blocks with same loaded data";
+  }
+
+  void runOnOperation() override;
+
+private:
+  void findInnermostLoopBlocksWithMatmul(
+      ModuleOp moduleOp, llvm::SmallVectorImpl<Block *> &innermostBlocks);
+
+  llvm::LogicalResult processBlock(Block *block,
+                                   const MemoryDependenceGraph &memGraph,
+                                   ComputeBlockIdManager &bm);
+
+  // Collect loaded data for each block
+  llvm::LogicalResult collectLoadedValues(
+      BlockDependencyGraph &graph, ComputeBlockIdManager &bm,
+      llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues);
+
+  // Find merge candidates (only for cube blocks)
+  llvm::LogicalResult findMergeCandidates(
+      BlockDependencyGraph &graph,
+      llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues,
+      llvm::SmallVectorImpl<std::pair<int, int>> &candidates);
+
+  bool
+  canMergeBlocks(int blockId1, int blockId2, BlockDependencyGraph &graph,
+                 const MemoryDependenceGraph &memGraph,
+                 ComputeBlockIdManager &bm,
+                 llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues);
+
+  // Execute merge
+  llvm::LogicalResult mergeBlocks(int targetBlockId, int sourceBlockId,
+                                  ComputeBlockIdManager &bm);
+
+  // Update loadedValues
+  llvm::LogicalResult updateLoadedValues(
+      int targetBlockId, int sourceBlockId,
+      llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues);
+
+  // Perform iterative merging
+  llvm::LogicalResult
+  performMerging(BlockDependencyGraph &graph,
+                 const MemoryDependenceGraph &memGraph,
+                 ComputeBlockIdManager &bm,
+                 llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues,
+                 llvm::SmallVectorImpl<std::pair<int, int>> &candidates);
+
+  // Print graph structure
+  void
+  printGraph(BlockDependencyGraph &graph,
+             llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues);
+
+  bool hasCommonInputOrOutput(int blockId1, int blockId2,
+                              BlockDependencyGraph &graph);
+  bool checkSameSourceAndSink(int blockId1, int blockId2,
+                              BlockDependencyGraph &graph);
+  bool checkNoCycle(int blockId1, int blockId2, BlockDependencyGraph &graph,
+                    const MemoryDependenceGraph &memGraph,
+                    ComputeBlockIdManager &bm);
+  bool checkSameLoadedData(
+      int blockId1, int blockId2,
+      llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues);
+
+  llvm::SmallVector<int> filterBlocksByType(int blockId,
+                                            llvm::SmallVector<int> blocks,
+                                            BlockDependencyGraph &graph);
+};
+
+} // namespace CVPipeline
+} // namespace mlir
+
+namespace mlir {
+namespace triton {
+std::unique_ptr<OperationPass<ModuleOp>> createMergeCubeBlockPass();
+} // namespace triton
+} // namespace mlir
+
+#endif // TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_PLAN_COMPUTE_BLOCK_MERGE_CUBE_BLOCK_PASS_H

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
@@ -163,6 +163,8 @@ private:
   mlir::Operation *analyzeConsumerReadInsertPoint(Value srcValue,
                                                   int iniConsumerId);
   mlir::Operation *getConsumerWaitPoint(int transferIndex);
+  mlir::Operation *getFixpipePointAfterProducer(Value depValue,
+                                                int iniProducerBlockId);
   mlir::Operation *getCopyPointBeforeStore(Value depValue,
                                            Operation *vectorEndOp,
                                            int iniProducerBlockId);

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/BlockDependencyGraph.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/BlockDependencyGraph.cpp
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "DynamicCVPipeline/Common/BlockDependencyGraph.h"
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "llvm/Support/Debug.h"
+#include <queue>
+
+using namespace mlir;
+using namespace CVPipeline;
+
+static constexpr const char *DEBUG_TYPE = "block-dependency-graph";
+#define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
+#define LDBG(...) LLVM_DEBUG(DBGS() << __VA_ARGS__ << "\n")
+
+static bool isCubeOp(Operation *op) {
+  if (!op)
+    return false;
+  auto coreTypeAttr = op->getAttrOfType<StringAttr>(CVPipeline::kCoreType);
+  if (!coreTypeAttr)
+    return false;
+
+  return coreTypeAttr.getValue() == "CUBE";
+}
+
+BlockDependencyGraph::BlockDependencyGraph(
+    Block *block, const MemoryDependenceGraph &memGraph,
+    ComputeBlockIdManager &bm)
+    : block(block), memGraph(memGraph), bm(bm) {}
+
+llvm::LogicalResult BlockDependencyGraph::buildGraph() {
+  // Step 1: Collect all compute blocks (including cube and vector) in current
+  // MLIR Block
+  block->walk([&](Operation *op) {
+    int blockId = bm.getBlockIdByOp(op);
+    if (blockId == -1)
+      return;
+
+    // Only process operations in current MLIR Block
+    if (op->getBlock() != block)
+      return;
+
+    if (!blockNodes.count(blockId)) {
+      BlockNode node;
+      node.blockId = blockId;
+      node.isCube = isCubeOp(op);
+      node.depth = 0;
+      blockNodes[blockId] = node;
+    }
+
+    blockNodes[blockId].ops.push_back(op);
+  });
+
+  LDBG("Collected " << blockNodes.size() << " blocks");
+
+  // Step 2: Build dependency relationships between blocks (only in current MLIR
+  // Block)
+  for (auto &entry : blockNodes) {
+    int blockId = entry.first;
+    auto &node = entry.second;
+
+    for (Operation *op : node.ops) {
+      // Process SSA data flow dependencies
+      for (Value operand : op->getOperands()) {
+        if (Operation *def = operand.getDefiningOp()) {
+          // Key: Check if def is in current MLIR Block
+          if (!isInCurrentBlock(def))
+            continue;
+
+          int defBlockId = bm.getBlockIdByOp(def);
+          if (defBlockId != -1 && defBlockId != blockId) {
+            addEdge(defBlockId, blockId);
+          }
+        }
+      }
+
+      // Process memory dependencies
+      for (Operation *memDef : memGraph.getMemDefs(op)) {
+        // Key: Check if memDef is in current MLIR Block
+        if (!isInCurrentBlock(memDef))
+          continue;
+
+        int defBlockId = bm.getBlockIdByOp(memDef);
+        if (defBlockId != -1 && defBlockId != blockId) {
+          addEdge(defBlockId, blockId);
+        }
+      }
+    }
+  }
+
+  // Step 3: Compute depths (for all blocks)
+  computeDepths();
+
+  return llvm::success();
+}
+
+bool BlockDependencyGraph::isInCurrentBlock(Operation *op) {
+  if (!op)
+    return false;
+
+  // Get the MLIR Block where op is located
+  Block *opBlock = op->getBlock();
+
+  // Check if it's in current MLIR Block
+  return opBlock == block;
+}
+
+void BlockDependencyGraph::addEdge(int from, int to) {
+  // Avoid duplicate additions
+  if (!llvm::is_contained(predecessors[to], from)) {
+    predecessors[to].push_back(from);
+  }
+  if (!llvm::is_contained(successors[from], to)) {
+    successors[from].push_back(to);
+  }
+}
+
+void BlockDependencyGraph::computeDepths() {
+  // Use topological sort to compute depth for each node
+  // Depth definition: maximum steps from nodes with zero in-degree
+  // Special rule: depth only increases when cube and vector type conversion
+  // occurs
+
+  llvm::DenseMap<int, int> indegree;
+  std::queue<int> queue;
+
+  // Initialize in-degree
+  for (auto &entry : blockNodes) {
+    indegree[entry.first] = predecessors[entry.first].size();
+    if (indegree[entry.first] == 0) {
+      queue.push(entry.first);
+      blockNodes[entry.first].depth = 0;
+    }
+  }
+
+  // BFS to compute depths
+  while (!queue.empty()) {
+    int current = queue.front();
+    queue.pop();
+
+    for (int succ : successors[current]) {
+      // Compute depth from current to succ
+      // If types are different (cube->vector or vector->cube), depth+1
+      // If types are the same, depth remains unchanged
+      int newDepth = blockNodes[current].depth;
+      if (blockNodes[current].isCube != blockNodes[succ].isCube) {
+        newDepth++;
+      }
+
+      // Update successor's depth (take maximum)
+      blockNodes[succ].depth = std::max(blockNodes[succ].depth, newDepth);
+
+      indegree[succ]--;
+      if (indegree[succ] == 0) {
+        queue.push(succ);
+      }
+    }
+  }
+
+  LDBG("Computed depths for all blocks");
+}
+
+int BlockDependencyGraph::getDepth(int blockId) {
+  auto it = blockNodes.find(blockId);
+  if (it != blockNodes.end()) {
+    return it->second.depth;
+  }
+  return -1;
+}
+
+BlockNode *BlockDependencyGraph::getBlockNode(int blockId) {
+  auto it = blockNodes.find(blockId);
+  if (it != blockNodes.end()) {
+    return &it->second;
+  }
+  return nullptr;
+}
+
+llvm::SmallVector<int> BlockDependencyGraph::getPredecessors(int blockId) {
+  auto it = predecessors.find(blockId);
+  if (it != predecessors.end()) {
+    return it->second;
+  }
+  return {};
+}
+
+llvm::SmallVector<int> BlockDependencyGraph::getSuccessors(int blockId) {
+  auto it = successors.find(blockId);
+  if (it != successors.end()) {
+    return it->second;
+  }
+  return {};
+}
+
+bool BlockDependencyGraph::wouldCreateCycle(int blockId1, int blockId2) {
+  // Use DFS to check reachability
+  llvm::DenseSet<int> visited;
+
+  std::function<bool(int, int)> hasPath = [&](int from, int to) -> bool {
+    if (from == to)
+      return true;
+    if (visited.count(from))
+      return false;
+    visited.insert(from);
+
+    for (int succ : successors[from]) {
+      if (hasPath(succ, to))
+        return true;
+    }
+    return false;
+  };
+
+  // If there are bidirectional paths, merging would create a cycle
+  bool path1to2 = hasPath(blockId1, blockId2);
+  visited.clear();
+  bool path2to1 = hasPath(blockId2, blockId1);
+
+  return path1to2 && path2to1;
+}
+
+void BlockDependencyGraph::rebuildAfterMerge(int targetBlockId,
+                                             int sourceBlockId) {
+  // Merge node information of two blocks
+  auto sourceIt = blockNodes.find(sourceBlockId);
+  if (sourceIt != blockNodes.end()) {
+    auto &targetNode = blockNodes[targetBlockId];
+    auto &sourceNode = sourceIt->second;
+
+    // Merge ops
+    targetNode.ops.append(sourceNode.ops.begin(), sourceNode.ops.end());
+
+    // Delete source node
+    blockNodes.erase(sourceIt);
+  }
+
+  // Merge predecessors and successors
+  auto sourcePredIt = predecessors.find(sourceBlockId);
+  if (sourcePredIt != predecessors.end()) {
+    for (int pred : sourcePredIt->second) {
+      if (!llvm::is_contained(predecessors[targetBlockId], pred)) {
+        predecessors[targetBlockId].push_back(pred);
+      }
+      // Update successors
+      auto &predSuccs = successors[pred];
+      predSuccs.erase(llvm::find(predSuccs, sourceBlockId));
+      if (!llvm::is_contained(predSuccs, targetBlockId)) {
+        predSuccs.push_back(targetBlockId);
+      }
+    }
+    predecessors.erase(sourcePredIt);
+  }
+
+  auto sourceSuccIt = successors.find(sourceBlockId);
+  if (sourceSuccIt != successors.end()) {
+    for (int succ : sourceSuccIt->second) {
+      if (!llvm::is_contained(successors[targetBlockId], succ)) {
+        successors[targetBlockId].push_back(succ);
+      }
+      // Update predecessors
+      auto &succPreds = predecessors[succ];
+      succPreds.erase(llvm::find(succPreds, sourceBlockId));
+      if (!llvm::is_contained(succPreds, targetBlockId)) {
+        succPreds.push_back(targetBlockId);
+      }
+    }
+    successors.erase(sourceSuccIt);
+  }
+
+  // Recompute depths
+  computeDepths();
+
+  LDBG("Rebuilt graph after merging block " << sourceBlockId << " into "
+                                            << targetBlockId);
+}

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlock.cpp
@@ -1,0 +1,495 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "DynamicCVPipeline/Common/BlockDependencyGraph.h"
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlockPass.h"
+#include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/Debug.h"
+
+using namespace mlir;
+using namespace CVPipeline;
+
+static constexpr const char *DEBUG_TYPE = "merge-cube-block";
+#define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
+#define LDBG(...) LLVM_DEBUG(DBGS() << __VA_ARGS__ << "\n")
+
+static constexpr llvm::StringLiteral kDisnbleMergeCubeKernel =
+    "flex_attention_backward_dq_kernel";
+
+void MergeCubeBlockPass::findInnermostLoopBlocksWithMatmul(
+    ModuleOp moduleOp, llvm::SmallVectorImpl<Block *> &innermostBlocks) {
+
+  // Find all matmul operations
+  llvm::SmallVector<linalg::MatmulOp> matmulOps;
+  moduleOp.walk([&](linalg::MatmulOp matmulOp) {
+    matmulOps.push_back(matmulOp);
+    return WalkResult::advance();
+  });
+
+  if (matmulOps.empty()) {
+    LDBG("No matmul operations found");
+    return;
+  }
+
+  // For each matmul, find its innermost loop and calculate depth
+  llvm::DenseMap<Block *, int> blockDepthMap;
+
+  for (auto matmulOp : matmulOps) {
+    // Walk up the parent chain to find all loops
+    llvm::SmallVector<Operation *> loops;
+    Operation *currentOp = matmulOp;
+
+    while (currentOp) {
+      if (auto forOp = dyn_cast<scf::ForOp>(currentOp)) {
+        loops.push_back(forOp);
+      } else if (auto whileOp = dyn_cast<scf::WhileOp>(currentOp)) {
+        loops.push_back(whileOp);
+      }
+      currentOp = currentOp->getParentOp();
+    }
+
+    // If this matmul is inside loops, record the innermost loop's block
+    if (!loops.empty()) {
+      Operation *innermostLoop =
+          loops.front(); // The first one is the innermost
+      int depth = loops.size();
+
+      // Get the block from the innermost loop
+      Block *block = nullptr;
+      if (auto forOp = dyn_cast<scf::ForOp>(innermostLoop)) {
+        block = forOp.getBody();
+      } else if (auto whileOp = dyn_cast<scf::WhileOp>(innermostLoop)) {
+        // WhileOp has a region, get the first block
+        block = whileOp.getAfterBody();
+      }
+
+      if (block) {
+        // Update depth map (keep the maximum depth for each block)
+        if (blockDepthMap.find(block) == blockDepthMap.end() ||
+            depth > blockDepthMap[block]) {
+          blockDepthMap[block] = depth;
+        }
+
+        LDBG("Matmul at " << matmulOp << " is in loop at depth " << depth);
+      }
+    }
+  }
+
+  // Find the maximum depth
+  int maxDepth = 0;
+  for (auto &entry : blockDepthMap) {
+    if (entry.second > maxDepth) {
+      maxDepth = entry.second;
+    }
+  }
+
+  LDBG("Maximum loop depth: " << maxDepth);
+
+  // Collect all blocks with maximum depth
+  for (auto &entry : blockDepthMap) {
+    if (entry.second == maxDepth) {
+      LDBG("Found innermost loop block with matmul");
+      innermostBlocks.push_back(entry.first);
+    }
+  }
+}
+
+void MergeCubeBlockPass::runOnOperation() {
+  auto moduleOp = getOperation();
+
+  if (hasFallbackAttr(moduleOp)) {
+    return;
+  }
+
+  for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
+    if (funcOp.getSymName() == kDisnbleMergeCubeKernel) {
+      LDBG("Found unsupport kernel: " << funcOp.getSymName());
+      return;
+    }
+  }
+
+  auto &aa = getAnalysis<AliasAnalysis>();
+  auto memGraph = MemoryDependenceGraph(moduleOp, aa);
+  auto bm = ComputeBlockIdManager(moduleOp);
+
+  LDBG("Starting MergeCubeBlockPass\n" << moduleOp);
+
+  // Find innermost loop blocks with matmul operations
+  llvm::SmallVector<Block *> innermostBlocks;
+  findInnermostLoopBlocksWithMatmul(moduleOp, innermostBlocks);
+
+  LDBG("Found " << innermostBlocks.size()
+                << " innermost loop blocks with matmul\n");
+
+  // Process each innermost loop block
+  for (Block *block : innermostBlocks) {
+    if (failed(processBlock(block, memGraph, bm))) {
+      CVPipeline::setFallbackAttr(moduleOp, CVPipeline::ERRCODE_FAILED);
+      return;
+    }
+  }
+
+  LDBG("MergeCubeBlockPass completed\n" << moduleOp);
+}
+
+llvm::LogicalResult
+MergeCubeBlockPass::processBlock(Block *block,
+                                 const MemoryDependenceGraph &memGraph,
+                                 ComputeBlockIdManager &bm) {
+
+  // Print block information before processing
+  LDBG("Processing Block: " << *block);
+  if (Operation *parentOp = block->getParentOp()) {
+    LDBG("  Parent operation: " << parentOp->getName().getStringRef());
+  }
+
+  // Step 1: Build Block dependency graph
+  BlockDependencyGraph graph(block, memGraph, bm);
+  if (failed(graph.buildGraph())) {
+    LDBG("Failed to build dependency graph");
+    return llvm::failure();
+  }
+
+  LDBG("Built dependency graph with " << graph.blockNodes.size()
+                                      << " blocks\n");
+
+  llvm::DenseMap<int, llvm::DenseSet<Value>> blockLoadedValues;
+
+  // Step 2: Find merge candidates
+  llvm::SmallVector<std::pair<int, int>> candidates;
+  if (failed(findMergeCandidates(graph, blockLoadedValues, candidates))) {
+    LDBG("Failed to find merge candidates");
+    return llvm::failure();
+  }
+  LDBG("Found " << candidates.size() << " merge candidates\n");
+
+  // If merge candidates are found, print graph structure
+  if (!candidates.empty()) {
+    LDBG("=== Printing dependency graph for current region ===");
+    printGraph(graph, blockLoadedValues);
+  }
+
+  // Step 3: Perform iterative merging
+  if (failed(
+          performMerging(graph, memGraph, bm, blockLoadedValues, candidates))) {
+    LDBG("Failed to perform merging");
+    return llvm::failure();
+  }
+
+  return llvm::success();
+}
+
+llvm::LogicalResult MergeCubeBlockPass::performMerging(
+    BlockDependencyGraph &graph, const MemoryDependenceGraph &memGraph,
+    ComputeBlockIdManager &bm,
+    llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues,
+    llvm::SmallVectorImpl<std::pair<int, int>> &candidates) {
+
+  bool merged = true;
+  int mergeCount = 0;
+
+  while (merged) {
+    merged = false;
+    for (auto &pair : candidates) {
+      if (canMergeBlocks(pair.first, pair.second, graph, memGraph, bm,
+                         blockLoadedValues)) {
+        LDBG("Merging block " << pair.second << " into " << pair.first);
+
+        // Execute merge
+        if (failed(mergeBlocks(pair.first, pair.second, bm))) {
+          LDBG("Failed to merge blocks");
+          return llvm::failure();
+        }
+        merged = true;
+        mergeCount++;
+
+        // Update graph structure
+        graph.rebuildAfterMerge(pair.first, pair.second);
+
+        // Re-find candidates
+        candidates.clear();
+        if (failed(findMergeCandidates(graph, blockLoadedValues, candidates))) {
+          LDBG("Failed to re-find merge candidates");
+          return llvm::failure();
+        }
+        break;
+      }
+    }
+  }
+
+  LDBG("Merged " << mergeCount << " blocks\n");
+
+  return llvm::success();
+}
+
+llvm::LogicalResult MergeCubeBlockPass::findMergeCandidates(
+    BlockDependencyGraph &graph,
+    llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues,
+    llvm::SmallVectorImpl<std::pair<int, int>> &candidates) {
+
+  // Only get cube blocks (filtered from complete dependency graph)
+  llvm::SmallVector<int> cubeBlocks;
+  for (auto &entry : graph.blockNodes) {
+    if (entry.second.isCube) {
+      cubeBlocks.push_back(entry.first);
+    }
+  }
+
+  // Check all pairs of cube blocks for merge possibility
+  for (size_t i = 0; i < cubeBlocks.size(); ++i) {
+    for (size_t j = i + 1; j < cubeBlocks.size(); ++j) {
+      int blockId1 = cubeBlocks[i];
+      int blockId2 = cubeBlocks[j];
+
+      candidates.push_back({blockId1, blockId2});
+    }
+  }
+
+  return llvm::success();
+}
+
+bool MergeCubeBlockPass::canMergeBlocks(
+    int blockId1, int blockId2, BlockDependencyGraph &graph,
+    const MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm,
+    llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues) {
+
+  // Precondition: both blocks must be cube
+  BlockNode *node1 = graph.getBlockNode(blockId1);
+  BlockNode *node2 = graph.getBlockNode(blockId2);
+
+  if (!node1 || !node2 || !node1->isCube || !node2->isCube) {
+    return false;
+  }
+
+  // Step 1: Check if they have common input or output nodes
+  if (!hasCommonInputOrOutput(blockId1, blockId2, graph)) {
+    LDBG("Blocks " << blockId1 << " and " << blockId2
+                   << " cannot merge: no common input or output nodes\n");
+    return false;
+  }
+
+  // Step 2: Check if they have same source and sink with no other nodes
+  if (!checkSameSourceAndSink(blockId1, blockId2, graph)) {
+    LDBG("Blocks " << blockId1 << " and " << blockId2
+                   << " cannot merge: different source or sink\n");
+    return false;
+  }
+
+  // Step 3: Check if merging would create a cycle
+  if (checkNoCycle(blockId1, blockId2, graph, memGraph, bm)) {
+    LDBG("Blocks " << blockId1 << " and " << blockId2
+                   << " can merge: no cycle detected\n");
+    return true;
+  }
+
+  LDBG("Blocks " << blockId1 << " and " << blockId2
+                 << " cannot merge: would create cycle\n");
+  return false;
+}
+
+bool MergeCubeBlockPass::checkSameSourceAndSink(int blockId1, int blockId2,
+                                                BlockDependencyGraph &graph) {
+
+  // Get block nodes
+  BlockNode *node1 = graph.getBlockNode(blockId1);
+  BlockNode *node2 = graph.getBlockNode(blockId2);
+
+  if (!node1 || !node2) {
+    return false;
+  }
+
+  // Get predecessors and successors
+  auto preds1 = graph.getPredecessors(blockId1);
+  auto preds2 = graph.getPredecessors(blockId2);
+
+  auto succs1 = graph.getSuccessors(blockId1);
+  auto succs2 = graph.getSuccessors(blockId2);
+
+  // Filter blocks: only keep blocks with different type from current block
+  llvm::SmallVector<int> filteredPreds1 =
+      filterBlocksByType(blockId1, preds1, graph);
+  llvm::SmallVector<int> filteredPreds2 =
+      filterBlocksByType(blockId2, preds2, graph);
+  llvm::SmallVector<int> filteredSuccs1 =
+      filterBlocksByType(blockId1, succs1, graph);
+  llvm::SmallVector<int> filteredSuccs2 =
+      filterBlocksByType(blockId2, succs2, graph);
+
+  // Check if filtered predecessors are exactly the same
+  llvm::DenseSet<int> predSet1(filteredPreds1.begin(), filteredPreds1.end());
+  llvm::DenseSet<int> predSet2(filteredPreds2.begin(), filteredPreds2.end());
+
+  if (predSet1 != predSet2) {
+    return false;
+  }
+
+  // Check if filtered successors are exactly the same
+  llvm::DenseSet<int> succSet1(filteredSuccs1.begin(), filteredSuccs1.end());
+  llvm::DenseSet<int> succSet2(filteredSuccs2.begin(), filteredSuccs2.end());
+
+  if (succSet1 != succSet2) {
+    return false;
+  }
+
+  return true;
+}
+
+llvm::SmallVector<int> MergeCubeBlockPass::filterBlocksByType(
+    int blockId, llvm::SmallVector<int> blocks, BlockDependencyGraph &graph) {
+
+  // Get current block node
+  BlockNode *currentNode = graph.getBlockNode(blockId);
+  if (!currentNode) {
+    return {};
+  }
+
+  // Filter blocks: only keep blocks with different type from current block
+  llvm::SmallVector<int> filteredBlocks;
+  for (int blockId : blocks) {
+    BlockNode *blockNode = graph.getBlockNode(blockId);
+    if (blockNode && blockNode->isCube != currentNode->isCube) {
+      filteredBlocks.push_back(blockId);
+    }
+  }
+
+  return filteredBlocks;
+}
+
+bool MergeCubeBlockPass::checkNoCycle(int blockId1, int blockId2,
+                                      BlockDependencyGraph &graph,
+                                      const MemoryDependenceGraph &memGraph,
+                                      ComputeBlockIdManager &bm) {
+
+  // Get all operations from blockId2 to be merged into blockId1
+  auto opsToUnify = bm.getOpsByBlockId(blockId2);
+
+  // Use willCreateCycle to check if merging would create a cycle
+  return !willCreateCycle(opsToUnify, memGraph, blockId1, bm);
+}
+
+bool MergeCubeBlockPass::hasCommonInputOrOutput(int blockId1, int blockId2,
+                                                BlockDependencyGraph &graph) {
+
+  // Get predecessors and successors
+  auto preds1 = graph.getPredecessors(blockId1);
+  auto preds2 = graph.getPredecessors(blockId2);
+
+  auto succs1 = graph.getSuccessors(blockId1);
+  auto succs2 = graph.getSuccessors(blockId2);
+
+  // Filter blocks: only keep blocks with different type from current block
+  llvm::SmallVector<int> filteredPreds1 =
+      filterBlocksByType(blockId1, preds1, graph);
+  llvm::SmallVector<int> filteredPreds2 =
+      filterBlocksByType(blockId2, preds2, graph);
+  llvm::SmallVector<int> filteredSuccs1 =
+      filterBlocksByType(blockId1, succs1, graph);
+  llvm::SmallVector<int> filteredSuccs2 =
+      filterBlocksByType(blockId2, succs2, graph);
+
+  // Check if there are common input nodes (predecessors)
+  llvm::DenseSet<int> predSet1(filteredPreds1.begin(), filteredPreds1.end());
+  bool hasCommonPred =
+      llvm::any_of(filteredPreds2, [&](int p) { return predSet1.count(p); });
+
+  // Check if there are common output nodes (successors)
+  llvm::DenseSet<int> succSet1(filteredSuccs1.begin(), filteredSuccs1.end());
+  bool hasCommonSucc =
+      llvm::any_of(filteredSuccs2, [&](int s) { return succSet1.count(s); });
+
+  // Return true if they have common input OR output nodes
+  return hasCommonPred || hasCommonSucc;
+}
+
+llvm::LogicalResult MergeCubeBlockPass::mergeBlocks(int targetBlockId,
+                                                    int sourceBlockId,
+                                                    ComputeBlockIdManager &bm) {
+
+  // Merge all ops of sourceBlockId into targetBlockId
+  auto sourceOps = bm.getOpsByBlockId(sourceBlockId);
+  for (Operation *op : sourceOps) {
+    bm.updateBlockId(op, targetBlockId);
+  }
+
+  return llvm::success();
+}
+
+void MergeCubeBlockPass::printGraph(
+    BlockDependencyGraph &graph,
+    llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues) {
+
+  LDBG("Total blocks in graph: " << graph.blockNodes.size());
+
+  // Print all block nodes
+  for (auto &entry : graph.blockNodes) {
+    int blockId = entry.first;
+    auto &node = entry.second;
+
+    LDBG("Block " << blockId << ":");
+    LDBG("  Type: " << (node.isCube ? "CUBE" : "VECTOR"));
+    LDBG("  Depth: " << node.depth);
+    LDBG("  Num ops: " << node.ops.size());
+
+    // Print predecessors
+    auto preds = graph.getPredecessors(blockId);
+    if (!preds.empty()) {
+      llvm::SmallVector<std::string> predStrs;
+      for (int p : preds) {
+        predStrs.push_back(std::to_string(p));
+      }
+      LDBG("  Predecessors: [" << llvm::join(predStrs, ", ") << "]");
+    } else {
+      LDBG("  Predecessors: []");
+    }
+
+    // Print successors
+    auto succs = graph.getSuccessors(blockId);
+    if (!succs.empty()) {
+      llvm::SmallVector<std::string> succStrs;
+      for (int s : succs) {
+        succStrs.push_back(std::to_string(s));
+      }
+      LDBG("  Successors: [" << llvm::join(succStrs, ", ") << "]");
+    } else {
+      LDBG("  Successors: []");
+    }
+  }
+
+  LDBG("=== End of graph ===");
+}
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::triton::createMergeCubeBlockPass() {
+  return std::make_unique<MergeCubeBlockPass>();
+}

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
@@ -25,6 +25,7 @@
 #include "DynamicCVPipeline/PlanComputeBlock/Passes.h"
 #include "DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlockPass.h"
 #include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlockPass.h"
 
@@ -75,6 +76,9 @@ void ComputeBlockOptPass::runOnOperation() {
   pm.addPass(createMergeSmallBlockPass());
   pm.addPass(createReorderOpsByBlockIdPass());
 
+  pm.addPass(createMergeCubeBlockPass());
+  pm.addPass(createReorderOpsByBlockIdPass());
+
   if (failed(runPipeline(pm, module))) {
     if (!CVPipeline::hasFallbackAttr(module)) {
       CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
@@ -107,6 +111,7 @@ void registerComputeBlockOptPasses() {
   registerPass(createPosMaskPatternPass);
   registerPass(createMergeSmallBlockPass);
   registerPass(createSplitIfByBlockIdPass);
+  registerPass(createMergeCubeBlockPass);
 }
 
 } // namespace triton

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -619,6 +619,16 @@ InterCoreTransferAndSyncPass::getConsumerWaitPoint(int transferIndex) {
   return consumerWaitPoint;
 }
 
+mlir::Operation *InterCoreTransferAndSyncPass::getFixpipePointAfterProducer(
+    Value srcValue, int producerBlockId) {
+  mlir::Operation *fixpipePoint = srcValue.getDefiningOp();
+  int blockId = CVPipeline::getOpBlockId(fixpipePoint).value_or(-1);
+  if (blockId != producerBlockId) {
+    return nullptr;
+  }
+  return fixpipePoint;
+}
+
 Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(
     OpBuilder &builder, Value srcValue, Value normalizedValue,
     Operation *vectorEndOp, Operation *cubeStartOp, Location loc,
@@ -1495,6 +1505,13 @@ LogicalResult InterCoreTransferAndSyncPass::handleCubeToVector(
   LOG_DEBUG("[newConsStart]" << *consStart << "\n");
   LOG_DEBUG("[newConsEnd]" << *consEnd << "\n");
 
+  if (dep.iniProducerBlockId == dep.producerBlockId) {
+    auto producerPoint =
+        getFixpipePointAfterProducer(srcValue, dep.iniProducerBlockId);
+    if (producerPoint) {
+      prodEnd = producerPoint;
+    }
+  }
   Operation *consumedDataOp = nullptr;
   Operation *transferOp =
       insertCubeToVectorTransfer(builder, srcValue, prodEnd, consStart, loc,

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_cube_block.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_cube_block.mlir
@@ -1,0 +1,233 @@
+// RUN: triton-opt --merge-cube-block %s | FileCheck %s
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  // ============================================
+  // Test Case 1: @test_merge_cube_blocks_with_vector
+  // ============================================
+  // Scenario: Two cube blocks with same vector predecessors and successors
+  // - Vector block 1 (block_id=1) produces vec_tensor1
+  // - Cube block 1 (block_id=2) uses vec_tensor1, produces cube_tensor1
+  // - Cube block 2 (block_id=3) uses vec_tensor1, produces cube_tensor2
+  // - Vector block 2 (block_id=4) uses cube_tensor1 and cube_tensor2
+  // Expected: The two cube blocks should be merged (block_id=3 -> block_id=2)
+  // Wrapped in two-layer for loop (only innermost should be processed)
+  // ============================================
+  // CHECK-LABEL: func.func @test_merge_cube_blocks_with_vector
+  func.func @test_merge_cube_blocks_with_vector(%arg0: memref<?xbf16>, %arg1: memref<?xbf16>, %arg2: memref<?xf32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c128 = arith.constant 128 : index
+    %cst = arith.constant 0.000000e+00 : bf16
+    %cst_f32 = arith.constant 0.000000e+00 : f32
+
+    scf.for %i = %c0 to %c128 step %c1 {
+      scf.for %j = %c0 to %c128 step %c1 {
+        %vec_alloc1 = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16>
+        %vec_cond1 = arith.constant 1 : i1
+        scf.if %vec_cond1 {
+          linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : bf16) outs(%vec_alloc1 : memref<128x128xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 1 : i32}
+        %vec_tensor1 = bufferization.to_tensor %vec_alloc1 restrict writable {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16> to tensor<128x128xbf16>
+
+        // CHECK: %{{.*}} = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+        %cube_alloc1 = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+        %cube_cond1 = arith.constant 1 : i1
+        // CHECK: scf.if %{{.*}} {
+        // CHECK:   linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+        scf.if %cube_cond1 {
+          linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : bf16) outs(%cube_alloc1 : memref<128x128xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 2 : i32}
+        %cube_tensor1 = bufferization.to_tensor %cube_alloc1 restrict writable {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16> to tensor<128x128xbf16>
+        %cube_out1 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+        // CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+        %cube_matmul1 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%vec_tensor1, %cube_tensor1 : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%cube_out1 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+        // CHECK: %{{.*}} = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+        %cube_alloc2 = memref.alloc() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+        %cube_cond2 = arith.constant 1 : i1
+        // CHECK: scf.if %{{.*}} {
+        // CHECK:   linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+        scf.if %cube_cond2 {
+          linalg.fill {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : bf16) outs(%cube_alloc2 : memref<128x128xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 3 : i32}
+        %cube_tensor2 = bufferization.to_tensor %cube_alloc2 restrict writable {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16> to tensor<128x128xbf16>
+        %cube_out2 = tensor.empty() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+        // CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+        %cube_matmul2 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} ins(%vec_tensor1, %cube_tensor2 : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%cube_out2 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+        %vec_alloc2 = memref.alloc() {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32>
+        %vec_cond2 = arith.constant 1 : i1
+        scf.if %vec_cond2 {
+          linalg.fill {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_f32 : f32) outs(%vec_alloc2 : memref<128x128xf32>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 4 : i32}
+        // Uses both cube_matmul1 and cube_matmul2
+        %vec_add = arith.addf %cube_matmul1, %cube_matmul2 {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
+        %vec_tensor2 = bufferization.to_tensor %vec_alloc2 restrict writable {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32> to tensor<128x128xf32>
+
+        scf.yield
+      }
+    }
+
+    return
+  }
+
+  // ============================================
+  // Test Case 2: @test_no_merge_with_extra_vector_dependency
+  // ============================================
+  // Scenario: Based on scenario 1, add an extra vector node pointing to one cube block
+  // - Vector block 5 (block_id=5) produces vec_tensor1
+  // - Vector block 9 (block_id=9) produces vec_tensor3
+  // - Cube block 6 (block_id=6) uses vec_tensor1, produces cube_matmul1
+  // - Cube block 7 (block_id=7) uses vec_tensor3, produces cube_matmul2
+  // - Vector block 8 (block_id=8) uses cube_matmul1 and cube_matmul2
+  // Expected: The two cube blocks should NOT be merged (different source nodes)
+  // Wrapped in two-layer for loop
+  // ============================================
+  // CHECK-LABEL: func.func @test_no_merge_with_extra_vector_dependency
+  func.func @test_no_merge_with_extra_vector_dependency(%arg0: memref<?xbf16>, %arg1: memref<?xbf16>, %arg2: memref<?xf32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c128 = arith.constant 128 : index
+    %cst = arith.constant 0.000000e+00 : bf16
+    %cst_f32 = arith.constant 0.000000e+00 : f32
+
+    // Outer for loop
+    scf.for %i = %c0 to %c128 step %c1 {
+      // Inner for loop (innermost, should be processed)
+      scf.for %j = %c0 to %c128 step %c1 {
+        // Vector block 1 (predecessor for cube block 1)
+        %vec_alloc1 = memref.alloc() {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16>
+        %vec_cond1 = arith.constant 1 : i1
+        scf.if %vec_cond1 {
+          linalg.fill {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : bf16) outs(%vec_alloc1 : memref<128x128xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 5 : i32}
+        %vec_tensor1 = bufferization.to_tensor %vec_alloc1 restrict writable {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16> to tensor<128x128xbf16>
+
+        // Cube block 1 (block_id=2) - uses vec_tensor1
+        // CHECK: memref.alloc() {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"}
+        %cube_alloc1 = memref.alloc() {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+        %cube_cond1 = arith.constant 1 : i1
+        // CHECK: scf.if %{{.*}} {
+        // CHECK:   linalg.fill {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"}
+        scf.if %cube_cond1 {
+          linalg.fill {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : bf16) outs(%cube_alloc1 : memref<128x128xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 6 : i32}
+        %cube_tensor1 = bufferization.to_tensor %cube_alloc1 restrict writable {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16> to tensor<128x128xbf16>
+        %cube_out1 = tensor.empty() {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+        // CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"}
+        %cube_matmul1 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} ins(%vec_tensor1, %cube_tensor1 : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%cube_out1 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+        // Extra vector block (block_id=5) - only used by cube block 2
+        %vec_alloc3 = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16>
+        %vec_cond3 = arith.constant 1 : i1
+        scf.if %vec_cond3 {
+          linalg.fill {ssbuffer.block_id = 9 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : bf16) outs(%vec_alloc3 : memref<128x128xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 9 : i32}
+        %vec_tensor3 = bufferization.to_tensor %vec_alloc3 restrict writable {ssbuffer.block_id = 9 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16> to tensor<128x128xbf16>
+
+        // Cube block 2 (block_id=3) - should NOT be merged (different source nodes)
+        // Uses vec_tensor3
+        // CHECK: memref.alloc() {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"}
+        %cube_alloc2 = memref.alloc() {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+        %cube_cond2 = arith.constant 1 : i1
+        // CHECK: scf.if %{{.*}} {
+        // CHECK:   linalg.fill {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"}
+        scf.if %cube_cond2 {
+          linalg.fill {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : bf16) outs(%cube_alloc2 : memref<128x128xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 7 : i32}
+        %cube_tensor2 = bufferization.to_tensor %cube_alloc2 restrict writable {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16> to tensor<128x128xbf16>
+        %cube_out2 = tensor.empty() {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+        // CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"}
+        // Uses vec_tensor3 as one of the inputs
+        %cube_matmul2 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"} ins(%vec_tensor3, %cube_tensor2 : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%cube_out2 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+        // Vector block 2 (successor for both cube blocks)
+        // Uses both cube_matmul1 and cube_matmul2
+        %vec_alloc2 = memref.alloc() {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32>
+        %vec_cond2 = arith.constant 1 : i1
+        scf.if %vec_cond2 {
+          linalg.fill {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_f32 : f32) outs(%vec_alloc2 : memref<128x128xf32>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 8 : i32}
+        %vec_add = arith.addf %cube_matmul1, %cube_matmul2 {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
+        %vec_tensor2 = bufferization.to_tensor %vec_alloc2 restrict writable {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32> to tensor<128x128xf32>
+
+        scf.yield
+      }
+    }
+
+    return
+  }
+
+  // ============================================
+  // Test Case 3: @test_no_merge_single_layer_for
+  // ============================================
+  // Scenario: Same as scenario 1, but only one layer of for loop
+  // - Vector block 1 (block_id=1) produces vec_tensor1
+  // - Cube block 1 (block_id=2) uses vec_tensor1, produces cube_matmul1
+  // - Cube block 2 (block_id=3) uses vec_tensor1, produces cube_matmul2
+  // - Vector block 2 (block_id=4) uses cube_matmul1 and cube_matmul2
+  // Expected: The two cube blocks should NOT be merged (not innermost loop)
+  // Only one layer of for loop
+  // ============================================
+  // CHECK-LABEL: func.func @test_no_merge_single_layer_for
+  func.func @test_no_merge_single_layer_for(%arg0: memref<?xbf16>, %arg1: memref<?xbf16>, %arg2: memref<?xf32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c128 = arith.constant 128 : index
+    %cst = arith.constant 0.000000e+00 : bf16
+    %cst_f32 = arith.constant 0.000000e+00 : f32
+
+    // Single layer for loop (not innermost, should NOT be processed)
+    scf.for %i = %c0 to %c128 step %c1 {
+      // Vector block 1 (predecessor for both cube blocks)
+      %vec_alloc1 = memref.alloc() {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16>
+      %vec_cond1 = arith.constant 1 : i1
+      scf.if %vec_cond1 {
+        linalg.fill {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : bf16) outs(%vec_alloc1 : memref<128x128xbf16>)
+      } {hivm.unlikely_condition, ssbuffer.block_id = 15 : i32}
+      %vec_tensor1 = bufferization.to_tensor %vec_alloc1 restrict writable {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16> to tensor<128x128xbf16>
+
+      // Cube block 1 (block_id=2) - should remain unchanged
+      // CHECK: memref.alloc() {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"}
+      %cube_alloc1 = memref.alloc() {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+      %cube_cond1 = arith.constant 1 : i1
+      // CHECK: scf.if %{{.*}} {
+      // CHECK:   linalg.fill {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"}
+      scf.if %cube_cond1 {
+        linalg.fill {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : bf16) outs(%cube_alloc1 : memref<128x128xbf16>)
+      } {hivm.unlikely_condition, ssbuffer.block_id = 16 : i32}
+      %cube_tensor1 = bufferization.to_tensor %cube_alloc1 restrict writable {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16> to tensor<128x128xbf16>
+      %cube_out1 = tensor.empty() {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+      // CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"}
+      %cube_matmul1 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"} ins(%vec_tensor1, %cube_tensor1 : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%cube_out1 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+      // Cube block 2 (block_id=3) - should remain unchanged
+      // CHECK: memref.alloc() {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"}
+      %cube_alloc2 = memref.alloc() {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+      %cube_cond2 = arith.constant 1 : i1
+      // CHECK: scf.if %{{.*}} {
+      // CHECK:   linalg.fill {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"}
+      scf.if %cube_cond2 {
+        linalg.fill {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : bf16) outs(%cube_alloc2 : memref<128x128xbf16>)
+      } {hivm.unlikely_condition, ssbuffer.block_id = 17 : i32}
+      %cube_tensor2 = bufferization.to_tensor %cube_alloc2 restrict writable {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16> to tensor<128x128xbf16>
+      %cube_out2 = tensor.empty() {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+      // CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"}
+      %cube_matmul2 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"} ins(%vec_tensor1, %cube_tensor2 : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%cube_out2 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+      // Vector block 2 (successor for both cube blocks)
+      // Uses both cube_matmul1 and cube_matmul2
+      %vec_alloc2 = memref.alloc() {ssbuffer.block_id = 18 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32>
+      %vec_cond2 = arith.constant 1 : i1
+      scf.if %vec_cond2 {
+        linalg.fill {ssbuffer.block_id = 18 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_f32 : f32) outs(%vec_alloc2 : memref<128x128xf32>)
+      } {hivm.unlikely_condition, ssbuffer.block_id = 18 : i32}
+      %vec_add = arith.addf %cube_matmul1, %cube_matmul2 {ssbuffer.block_id = 18 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
+      %vec_tensor2 = bufferization.to_tensor %vec_alloc2 restrict writable {ssbuffer.block_id = 18 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32> to tensor<128x128xf32>
+
+      scf.yield
+    }
+
+    return
+  }
+}


### PR DESCRIPTION
Add merge-cube-block pass in compute-block-opt of ssbuffer
if there are two cube blocks with restrict same vector predecessors and successors,
they are supposed to be merge into one block.

       V1                  V1     
     /     \                |
    ▼    ▼                  ▼
    C1   C2     ->          C
     \      /               |
      ▼ ▼                   ▼
        V2                  V2

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
