### PR TITLE
[simd_simt](fix) exclude long structured axis from SimdSimt fast path

### DIFF
--- a/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/UnstructureConversionPass.cpp
@@ -571,12 +571,15 @@ LogicalResult UnstructuredMemAccessConverter<MemAccOpTy>::matchAndRewrite(
 
   if constexpr (std::is_same_v<MemAccOpTy, triton::LoadOp> ||
                 std::is_same_v<MemAccOpTy, triton::StoreOp>) {
+    // Mirror the SimdSimtTemplate long-axis exclusion: a trailing structured
+    // run of >= 64 bytes ("long axis") is cheaper as a plain structured
+    // access (parallel-loop copy) than as an indirect gather/scatter.
     bool useUnstructuredOp =
         compileOn91095Flag &&
         ((unstructureCompileModeFlag == triton::ascend::CompileMode::SimdSimt &&
           simtRouteRequested &&
-          (ptrOffsetInfo.hasUnstructuredDim() || mixCompileDiscreteMask ||
-           routeDiscreteMaskToSimt)) ||
+          ((ptrOffsetInfo.hasUnstructuredDim() && sizeInByte < 64) ||
+           mixCompileDiscreteMask || routeDiscreteMaskToSimt)) ||
          (unstructureCompileModeFlag ==
               triton::ascend::CompileMode::SimdSimtTemplate &&
           simtTemplateLoadStoreFastPathEnabled && rankWithinSimtTemplateLimit));

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/simd_simt_unstructured.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/simd_simt_unstructured.mlir
@@ -32,7 +32,60 @@ tt.func public @simd_simt_gather(%src: !tt.ptr<f32>, %indices: !tt.ptr<i64>, %ou
   tt.return
 }
 
+// The row axis (8 gathered indices) is genuinely unstructured, but the
+// column axis is a 32xf32 = 128-byte contiguous run (a "long axis", >= 64
+// bytes). It must NOT be routed through the ascend.unstructured_load ->
+// hfusion.gather_load indirect path: that path is burst-aware but still
+// loses to a plain structured copy per row on this target. It should fall
+// back to the legacy per-row loop, which the backend can still execute as a
+// parallel structured copy (hivm.parallel_loop), not a real scalar/SIMT loop.
 // CHECK-LABEL: func.func @simd_simt_gather
+// CHECK-SAME: parallel_mode = "simd"
+// CHECK-NOT: hfusion.gather_load
+// CHECK: scf.for
+// CHECK: memref.reinterpret_cast {{.*}} sizes: [1, 32]
+// CHECK: memref.copy
+// CHECK: {{.*}}ExtractedLoadOrStore{{.*}}hivm.parallel_loop
+
+// -----
+
+// Same row-gather shape as above, but the column axis is only 8xf32 = 32
+// bytes (< 64), a genuinely short axis. This must still take the SimdSimt
+// indirect fast path -> hfusion.gather_load, to pin the boundary of the
+// long-axis exclusion and guard against the threshold regressing either way.
+tt.func public @simd_simt_gather_short_axis(%src: !tt.ptr<f32>, %indices: !tt.ptr<i64>, %out: !tt.ptr<f32>) {
+  %rows = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+  %cols = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+
+  %indices_ptrs = tt.splat %indices : !tt.ptr<i64> -> tensor<8x!tt.ptr<i64>>
+  %indices_addrs = tt.addptr %indices_ptrs, %rows : tensor<8x!tt.ptr<i64>>, tensor<8xi32>
+  %loaded_indices = tt.load %indices_addrs : tensor<8x!tt.ptr<i64>>
+
+  %indices_2d = tt.expand_dims %loaded_indices {axis = 1 : i32} : tensor<8xi64> -> tensor<8x1xi64>
+  %row_stride = arith.constant dense<8> : tensor<8x1xi64>
+  %row_offsets = arith.muli %indices_2d, %row_stride : tensor<8x1xi64>
+  %row_offsets_2d = tt.broadcast %row_offsets : tensor<8x1xi64> -> tensor<8x8xi64>
+  %cols_2d_i32 = tt.expand_dims %cols {axis = 0 : i32} : tensor<8xi32> -> tensor<1x8xi32>
+  %cols_2d_i64 = arith.extsi %cols_2d_i32 : tensor<1x8xi32> to tensor<1x8xi64>
+  %col_offsets = tt.broadcast %cols_2d_i64 : tensor<1x8xi64> -> tensor<8x8xi64>
+  %src_offsets = arith.addi %row_offsets_2d, %col_offsets : tensor<8x8xi64>
+  %src_base = tt.splat %src : !tt.ptr<f32> -> tensor<8x8x!tt.ptr<f32>>
+  %src_ptrs = tt.addptr %src_base, %src_offsets : tensor<8x8x!tt.ptr<f32>>, tensor<8x8xi64>
+  %values = tt.load %src_ptrs : tensor<8x8x!tt.ptr<f32>>
+
+  %rows_2d = tt.expand_dims %rows {axis = 1 : i32} : tensor<8xi32> -> tensor<8x1xi32>
+  %out_stride = arith.constant dense<8> : tensor<8x1xi32>
+  %out_rows = arith.muli %rows_2d, %out_stride : tensor<8x1xi32>
+  %out_rows_2d = tt.broadcast %out_rows : tensor<8x1xi32> -> tensor<8x8xi32>
+  %out_cols_2d = tt.broadcast %cols_2d_i32 : tensor<1x8xi32> -> tensor<8x8xi32>
+  %out_offsets = arith.addi %out_rows_2d, %out_cols_2d : tensor<8x8xi32>
+  %out_base = tt.splat %out : !tt.ptr<f32> -> tensor<8x8x!tt.ptr<f32>>
+  %out_ptrs = tt.addptr %out_base, %out_offsets : tensor<8x8x!tt.ptr<f32>>, tensor<8x8xi32>
+  tt.store %out_ptrs, %values : tensor<8x8x!tt.ptr<f32>>
+  tt.return
+}
+
+// CHECK-LABEL: func.func @simd_simt_gather_short_axis
 // CHECK-SAME: parallel_mode = "mix_simd_simt"
-// CHECK: %[[BURST:.*]] = arith.constant 32 : i32
+// CHECK: %[[BURST:.*]] = arith.constant 8 : i32
 // CHECK: hfusion.gather_load ins({{.*}}, %[[BURST]] : i32)


### PR DESCRIPTION
# Why
compile_mode=simd_simt 相较 compile_mode=simt_template，在部分 kernel 上存在性能劣化。

根因在 UnstructureConversionPass.cpp 判断 load/store 是否走 SIMT indirect 快速通路的逻辑,在两种模式下不对称:

- SimdSimtTemplate 分支用 sizeInByte < 64 把"长轴"(trailing 连续 structured 访存 ≥ 64 字节)排除在 indirect 通路之外,只有真正的短轴/离散访问才会走 SIMT。
- SimdSimt 分支没有这道门槛——只要存在任意 unstructured 维,不管长轴多大都无条件走 indirect 通路。

# What changed

- UnstructureConversionPass.cpp:给 SimdSimt 分支的 useUnstructuredOp 判据加上与 SimdSimtTemplate 对称的 sizeInByte < 64 门槛,长轴统一回落到 legacy 结构化路径。

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
