### PR TITLE
[API](feat) deprecate math_ops atan2 isfinited finitef

### DIFF
--- a/third_party/ascend/language/cann/extension/math_ops.py
+++ b/third_party/ascend/language/cann/extension/math_ops.py
@@ -4,10 +4,13 @@ from triton.language.core import float32, int1
 from ..libdevice import atan, isnan, isinf
 from triton.runtime.jit import jit
 
+from ..utils import _deprecated
+
 pi = core.constexpr(math_pi)
 half_pi = core.constexpr(0.5 * math_pi)
 
 
+@_deprecated(replacement="triton.language.extra.cann.libdevice.atan2")
 @core._tensor_member_fn
 @jit
 @math._add_math_2arg_docstr("atan2")
@@ -29,6 +32,7 @@ def atan2(y, x):
     return (base + add_pi + sub_pi).to(x.dtype)
 
 
+@_deprecated(replacement="triton.language.extra.cann.libdevice.isfinited")
 @core._tensor_member_fn
 @jit
 @math._add_math_1arg_docstr("isfinited")
@@ -42,6 +46,7 @@ def isfinited(x):
     return (~nan_mask & ~inf_mask).to(int1)
 
 
+@_deprecated(replacement="triton.language.extra.cann.libdevice.finitef")
 @core._tensor_member_fn
 @jit
 @math._add_math_1arg_docstr("finitef")

--- a/third_party/ascend/language/cann/utils.py
+++ b/third_party/ascend/language/cann/utils.py
@@ -1,6 +1,7 @@
 import inspect
 from functools import wraps
 from warnings import warn
+from triton.runtime.jit import JITFunction
 
 _DEPRECATED_MESSAGE_ATTR = "_deprecated_message"
 
@@ -14,6 +15,15 @@ def _deprecated(fn_name=None, replacement=None):
 
         if inspect.isclass(fn):
             setattr(fn, _DEPRECATED_MESSAGE_ATTR, message)
+            fn.__doc__ = f"{fn.__doc__ or ''}\n\n.. warning::\n   {message}"
+            return fn
+
+        if isinstance(fn, JITFunction):
+            # Wrapping a JITFunction in a plain function breaks both the host
+            # launch (`fn[grid](...)`) and the in-kernel inline path, since the
+            # code generator would no longer see a JITFunction. Warn at import
+            # time and pass the function through untouched.
+            warn(message, FutureWarning, stacklevel=2)
             fn.__doc__ = f"{fn.__doc__ or ''}\n\n.. warning::\n   {message}"
             return fn
 


### PR DESCRIPTION
## Summary
The extension math ops atan2 / isfinited / finitef duplicate functionality that already exists in triton.language.extra.cann.libdevice. Soft-deprecate these extension entry points with a FutureWarning directing users to the libdevice equivalents. They will be removed in the next release.

## Changes
1. Decorate atan2 / isfinited / finitef in math_ops.py with @_deprecated(replacement="triton.language.extra.cann.libdevice.<name>").
2. Fix _deprecated breaking @jit-decorated functions: wrapping a JITFunction in a plain function broke in-kernel inlining (the code generator no longer saw a JITFunction and raised "Cannot call @triton.jit'd outside of the scope of a kernel" at compile time) and host-side launch (`fn[grid](...)` raised TypeError). For JITFunction inputs, _deprecated now warns once at decoration time, appends the warning to the docstring, and returns the function unwrapped.

## Warning example
```bash
FutureWarning: triton.language.extra.cann.extension.atan2 is deprecated and will be removed in the next release; use triton.language.extra.cann.libdevice.atan2 instead.
FutureWarning: triton.language.extra.cann.extension.isfinited is deprecated and will be removed in the next release; use triton.language.extra.cann.libdevice.isfinited instead.
FutureWarning: triton.language.extra.cann.extension.finitef is deprecated and will be removed in the next release; use triton.language.extra.cann.libdevice.finitef instead.
```

## User Impact
Kernels calling al.atan2 / al.isfinited / al.finitef get a FutureWarning at compile time; users should migrate to the same-named ops in triton.language.extra.cann.libdevice.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
