### PR TITLE
[OpClassifier](fix) Mark pad fill CUBE_AND_VECTOR with the load chain

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -702,14 +702,20 @@ void OpClassifierPass::getUpstreamOpsWithMemoryDeps(
       findIterArgUpstreamOps(operand, upstreamOps);
     }
   }
-  if (!isa<bufferization::ToTensorOp>(cur)) {
-    // Only consider memory dependencies for non-to_tensor ops,
-    // as to_tensor already has SSA deps to its memref source
+  auto toTensor = dyn_cast<bufferization::ToTensorOp>(cur);
+  if (!toTensor) {
+    // Not to_tensor: SSA operands above already cover it. Stop.
     return;
   }
-  // Collect memory dependencies
+  // Bug if fill is missing: Vector clone of a masked load has garbage pad.
+  //
+  // Chain: fill (pad) then partial copy. getMemDefs = last writer = copy.
+  // Fill has no SSA result, so BFS never sees it.
+  //
+  // Fix: push fill here too. Then fill is CUBE_AND_VECTOR like copy, and
+  // the existing split clones pad onto the Vector alloc.
+  // Do not expand getMemDefs globally (false deps).
   if (memDepGraph) {
-    // Get operations that define memory used by current op
     for (Operation *memDef : memDepGraph->getMemDefs(cur)) {
       LLVM_DEBUG(DBGS() << "memDef: cur " << *cur << " -> memDef " << *memDef
                         << "\n");
@@ -717,6 +723,17 @@ void OpClassifierPass::getUpstreamOpsWithMemoryDeps(
         LLVM_DEBUG(DBGS() << "push op: " << *memDef << "\n");
         upstreamOps.push_back(memDef);
       }
+    }
+  }
+  Value buf = toTensor.getBuffer();
+  if (Operation *def = buf.getDefiningOp()) {
+    for (Operation *user : def->getUsers()) {
+      auto fill = dyn_cast<linalg::FillOp>(user);
+      if (!fill || fill.getDpsInits().size() != 1 ||
+          fill.getDpsInits()[0] != buf)
+        continue;
+      LLVM_DEBUG(DBGS() << "push fill writer: " << *fill << "\n");
+      upstreamOps.push_back(fill);
     }
   }
 }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_opclassifier_fill_split.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_opclassifier_fill_split.mlir
@@ -1,0 +1,43 @@
+// RUN: triton-opt --plan-compute-block %s | FileCheck %s
+
+// Bug: Vector clone of masked load (fill + partial copy) had garbage pad.
+// Cause: Vector BFS from to_tensor saw only last-writer copy, not fill.
+// Fix: fill is CUBE_AND_VECTOR like copy; existing split clones it.
+//
+// Expect Vector alloc, fill, copy with no matmul between them.
+// Cube clones use DAG (clone order is not stable across hosts).
+module {
+  // CHECK-LABEL: func.func @masked_load_split_fill_cloned(
+  // CHECK: %[[ALLOC_V:.*]] = memref.alloc() {{.*}}ssbuffer.core_type = "VECTOR"} : memref<64x64xf32>
+  // CHECK-NOT: linalg.matmul
+  // CHECK: linalg.fill {{.*}}ssbuffer.core_type = "VECTOR"} {{.*}}outs(%[[ALLOC_V]] : memref<64x64xf32>)
+  // CHECK-NOT: linalg.matmul
+  // CHECK: memref.copy {{.*}}ssbuffer.core_type = "VECTOR"} {{.*}}to memref<32x64xf32, strided<[64, 1]>>
+  // CHECK-DAG: %[[ALLOC_C:.*]] = memref.alloc() {{.*}}ssbuffer.core_type = "CUBE"} : memref<64x64xf32>
+  // CHECK-DAG: linalg.fill {{.*}}ssbuffer.core_type = "CUBE"} ins({{.*}} : f32) outs(%[[ALLOC_C]] : memref<64x64xf32>)
+  // CHECK-DAG: memref.copy {{.*}}ssbuffer.core_type = "CUBE"} {{.*}}to memref<32x64xf32, strided<[64, 1]>>
+  func.func @masked_load_split_fill_cloned(%gm: memref<?xf32>, %rhs: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant 0.000000e+00 : f32
+    %src = memref.reinterpret_cast %gm to offset: [%c0], sizes: [64, 64], strides: [32, 1]
+      : memref<?xf32> to memref<64x64xf32, strided<[32, 1], offset: ?>>
+    %alloc = memref.alloc() : memref<64x64xf32>
+    linalg.fill ins(%cst : f32) outs(%alloc : memref<64x64xf32>)
+    %sv_src = memref.subview %src[0, 0] [32, 64] [1, 1]
+      : memref<64x64xf32, strided<[32, 1], offset: ?>> to memref<32x64xf32, strided<[32, 1], offset: ?>>
+    %sv_dst = memref.subview %alloc[0, 0] [32, 64] [1, 1]
+      : memref<64x64xf32> to memref<32x64xf32, strided<[64, 1]>>
+    memref.copy %sv_src, %sv_dst
+      : memref<32x64xf32, strided<[32, 1], offset: ?>> to memref<32x64xf32, strided<[64, 1]>>
+    %t = bufferization.to_tensor %alloc restrict writable : memref<64x64xf32> to tensor<64x64xf32>
+    // VECTOR consumer keeps the load chain alive on the vector side
+    %add = arith.addf %t, %t : tensor<64x64xf32>
+    %out = tensor.empty() : tensor<64x64xf32>
+    %init = linalg.fill ins(%cst : f32) outs(%out : tensor<64x64xf32>) -> tensor<64x64xf32>
+    %mm = linalg.matmul {input_precision = "ieee"}
+      ins(%t, %rhs : tensor<64x64xf32>, tensor<64x64xf32>)
+      outs(%init : tensor<64x64xf32>) -> tensor<64x64xf32>
+    %res = arith.addf %mm, %add : tensor<64x64xf32>
+    return %res : tensor<64x64xf32>
+  }
+}


### PR DESCRIPTION
### Motivation

Masked `tl.load(..., other=0)` lowers to `linalg.fill` (pad) then a partial `memref.copy` into an alloc. Cube (dot) and Vector (unmasked store of `a`) both need that buffer, so `plan-compute-block` clones alloc + copy.

Fill has no SSA result. Vector BFS from `bufferization.to_tensor` only special-cased `getMemDefs`, which is last-writer only (the copy). Fill stayed CUBE-only. The Vector clone kept uninitialized pad. Recycled GM was often NaN.

Do not clone fill after split next to Cube fill: that ties Vector fill to Cube `0.0` and creates a false Cube→Vector dep.

### Changes Summary

- In `getUpstreamOpsWithMemoryDeps`, for `to_tensor`, walk `linalg.fill` users of the buffer (`outs == buf`) and push them into the upstream walk, same as copy.
- Fill becomes `CUBE_AND_VECTOR` with alloc/copy. Existing split clones pad onto the Vector alloc. The pad constant is mixed too, so Vector fill does not use a Cube-only `0.0`.
- Do not expand `getMemDefs` globally (false deps).

---

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
