### PR TITLE
[compiler](fix) Fix a warning from AddDynamicCVPipeline

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
@@ -86,20 +86,33 @@ void AddDynamicCVPipelinePass::runOnOperation() {
       CVPipeline::hasFallbackAttr(moduleOp)) {
     auto errCodeAttr =
         moduleOp->getAttrOfType<IntegerAttr>(CVPipeline::ERRCODE_ATTR);
+    int errCode = errCodeAttr ? static_cast<int>(errCodeAttr.getInt())
+                              : CVPipeline::ERRCODE_FAILED;
     if (!errCodeAttr) {
       moduleOp->emitWarning() << "[" << DEBUG_TYPE << "] "
                               << "Unexpected pass failure (no fallback attr "
                                  "set); fallback to compilation without "
                                  "dynamic CV pipeline.";
     } else {
-      moduleOp->emitWarning() << "[" << DEBUG_TYPE << "] "
-                              << "Pass failed, "
-                              << "fallback to compilation without "
-                                 "dynamic CV pipeline.";
+      if (errCode == CVPipeline::ERRCODE_IGNORED) {
+        // pipeline correctly decided this kernel is not a fit
+        // (no matmul, already scope-optimized, unsupported pattern) --
+        // just print a message, no IR.
+        mlir::emitWarning(moduleOp->getLoc()) << "[" << DEBUG_TYPE << "] "
+                                              << "Kernel not applicable for dynamic CV pipeline "
+                                                 "(no matmul / already scope-optimized / unsupported "
+                                                 "pattern); falling back to standard compilation.";
+      } else {
+        // a sub-pass genuinely failed (UB overflow, flag-budget
+        // exhaustion, unsupported while-condition, i1 cross-block dep, ...) --
+        // print a warning message and print module IR.
+        moduleOp->emitWarning() << "[" << DEBUG_TYPE << "] "
+                                << "Pass failed (errcode=" << errCode << "); "
+                                   "falling back to compilation without "
+                                   "dynamic CV pipeline.";
+      }
     }
 
-    int errCode = errCodeAttr ? static_cast<int>(errCodeAttr.getInt())
-                              : CVPipeline::ERRCODE_FAILED;
     fallback.restore();
     moduleOp->setAttr(CVPipeline::ERRCODE_ATTR,
                       builder.getI32IntegerAttr(errCode));

--- a/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
@@ -98,18 +98,20 @@ void AddDynamicCVPipelinePass::runOnOperation() {
         // pipeline correctly decided this kernel is not a fit
         // (no matmul, already scope-optimized, unsupported pattern) --
         // just print a message, no IR.
-        mlir::emitWarning(moduleOp->getLoc()) << "[" << DEBUG_TYPE << "] "
-                                              << "Kernel not applicable for dynamic CV pipeline "
-                                                 "(no matmul / already scope-optimized / unsupported "
-                                                 "pattern); falling back to standard compilation.";
+        mlir::emitWarning(moduleOp->getLoc())
+            << "[" << DEBUG_TYPE << "] "
+            << "Kernel not applicable for dynamic CV pipeline "
+               "(no matmul / already scope-optimized / unsupported "
+               "pattern); falling back to standard compilation.";
       } else {
         // a sub-pass genuinely failed (UB overflow, flag-budget
         // exhaustion, unsupported while-condition, i1 cross-block dep, ...) --
         // print a warning message and print module IR.
-        moduleOp->emitWarning() << "[" << DEBUG_TYPE << "] "
-                                << "Pass failed (errcode=" << errCode << "); "
-                                   "falling back to compilation without "
-                                   "dynamic CV pipeline.";
+        moduleOp->emitWarning()
+            << "[" << DEBUG_TYPE << "] " << "Pass failed (errcode=" << errCode
+            << "); "
+               "falling back to compilation without "
+               "dynamic CV pipeline.";
       }
     }
 

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddDynamicCVPipeline/fallback_no_matmul.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddDynamicCVPipeline/fallback_no_matmul.mlir
@@ -11,4 +11,3 @@ module {
     return %0 : i32
   }
 }
-

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddDynamicCVPipeline/fallback_no_matmul.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddDynamicCVPipeline/fallback_no_matmul.mlir
@@ -1,0 +1,14 @@
+// RUN: triton-opt '--add_dynamic_cv_pipeline=compile-on-910-95=True' %s 2>&1 | FileCheck %s --implicit-check-not='note: see current operation:'
+
+// Test: Module with no linalg.matmul. PreCheckMatmul sets ERRCODE_IGNORED,
+// AddDynamicCVPipeline falls back with a "Kernel not applicable..." warning
+// that does NOT include the full module IR dump.
+
+// CHECK: warning: [AddDynamicCVPipeline] Kernel not applicable for dynamic CV pipeline
+module {
+  func.func @fallback_no_matmul(%arg0: i32, %arg1: i32) -> i32 {
+    %0 = arith.addi %arg0, %arg1 : i32
+    return %0 : i32
+  }
+}
+


### PR DESCRIPTION
Fixes a warning printed by AddDynamicCVPipeline; now it doesn't print a confusing message and dumps module IR.

Fixes #1878

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [X] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [X] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
