### PR TITLE
[language](fix) Allow non-power-of-two arange ranges

### DIFF
--- a/third_party/ascend/patch/triton-ascend-3.6.0.patch
+++ b/third_party/ascend/patch/triton-ascend-3.6.0.patch
@@ -863,17 +863,12 @@ index 52192cf3e..241ba3378 100644
              raise ValueError("wrong type argument to unary invert (" + input_sca_ty.__repr__() + ")")
          _1 = self.tensor(self.builder.get_all_ones_value(input_sca_ty.to_ir(self.builder)), input_sca_ty)
          return self.xor_(input, _1)
-@@ -579,8 +629,11 @@ class TritonSemantic(Generic[TensorTy]):
+@@ -579,8 +629,6 @@ class TritonSemantic(Generic[TensorTy]):
          if end <= start:
              raise ValueError("arange's end argument must be greater than the start argument")
          range = end - start
 -        if (range & (range - 1)) != 0:
 -            raise ValueError("arange's range must be a power of 2")
-+        # Check if compile_mode is simt, then range must be a power of 2
-+        if self.builder.is_simt_mode():
-+            # Check if range is a power of 2
-+            if (range & (range - 1)) != 0:
-+                raise ValueError("arange's range must be a power of 2")
          shape = [range]
          if ret_ty is None:
              ret_ty = tl.block_type(tl.int32, shape)


### PR DESCRIPTION
## Rationale

AscendNPU-IR now supports non-power-of-two tensor shapes, but the Triton Ascend patch still rejects non-power-of-two `tl.arange` ranges in SIMT mode before they reach lowering. The same patch already relaxes the generic Python block-shape and C++ tensor-size restrictions.

Remove the remaining semantic guard so both SIMD and SIMT compilation can use the downstream non-power-of-two support.

This is the Triton-Ascend frontend companion to [AscendNPU-IR !1357](https://gitcode.com/Ascend/AscendNPU-IR/pull/1357), which adds the corresponding downstream support and regression coverage.

## Validation

- `git apply --check third_party/ascend/patch/triton-ascend-3.6.0.patch`
- `pre-commit run --from-ref github-upstream/main-dev --to-ref HEAD`
- Build and device execution were not run; this machine has no Ascend NPU, and submodule initialization was intentionally skipped.

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these rules: https://cbea.ms/git-commit/#why-not-how.
- [x] I have run pre-commit from the PR base to HEAD.
- [x] This PR does not add a test because it removes a frontend rejection whose downstream behavior is covered by the linked AscendNPU-IR feature validation.
- [x] I have not added any lit tests.
