### PR TITLE
[Docs](fix) Repair A5 libdevice API example tests from #1782

### DIFF
--- a/docs/zh/python-api/_examples/triton.language.associative_scan.py
+++ b/docs/zh/python-api/_examples/triton.language.associative_scan.py
@@ -42,7 +42,7 @@ def test_associative_scan_2d():
 
     expected = torch.cumsum(x.cpu(), dim=dim)
 
-    assert torch.allclose(output.cpu(), expected.cpu())
+    assert torch.allclose(output.cpu(), expected.cpu(), rtol=1e-3, atol=1e-3)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.brev.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.brev.py
@@ -42,7 +42,7 @@ def _brev(x):
 @pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_brev():
     x0 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
-    expected = torch.tensor([_brev(*v) for v in zip(x0.tolist())], dtype=torch.int32).npu()
+    expected = torch.tensor([_brev(v) & 0xFFFFFFFF for v in x0.tolist()], dtype=torch.int64).to(torch.int32).npu()
     output = torch.empty(8, dtype=torch.int32, device='npu')
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
     torch.testing.assert_close(output, expected, rtol=0, atol=0)

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cbrt.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cbrt.py
@@ -32,7 +32,7 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
 @pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_cbrt():
     x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32).npu()
-    expected = (torch.cbrt(x0)).to(torch.float32).npu()
+    expected = (torch.sign(x0) * torch.pow(torch.abs(x0), 1.0 / 3.0)).to(torch.float32).npu()
     output = torch.empty(8, dtype=torch.float32, device='npu')
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
     torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfcinv.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfcinv.py
@@ -32,7 +32,7 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
 @pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_erfcinv():
     x0 = (torch.rand((8, )) * 0.9 + 0.05).to(torch.float32).npu()
-    expected = (torch.erfc(torch.erfcinv(x0))).to(torch.float32).npu()
+    expected = torch.erfinv(1.0 - x0).to(torch.float32).npu()
     output = torch.empty(8, dtype=torch.float32, device='npu')
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
     torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ffs.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ffs.py
@@ -30,11 +30,11 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
 
 
 def _ffs(x):
-    """Index of the least significant set bit (0-based), 32 if none."""
+    """1-based index of the least significant set bit; 0 if none (CUDA ffs)."""
     v = int(x) & 0xFFFFFFFF
     if v == 0:
-        return 32
-    return (v & -v).bit_length() - 1
+        return 0
+    return (v & -v).bit_length()
 
 
 @pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcbrt.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcbrt.py
@@ -32,7 +32,7 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
 @pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_rcbrt():
     x0 = (torch.rand((8, )) + 0.1).to(torch.float32).npu()
-    expected = (1.0 / torch.cbrt(x0)).to(torch.float32).npu()
+    expected = (torch.sign(x0) * torch.pow(torch.abs(x0), -1.0 / 3.0)).to(torch.float32).npu()
     output = torch.empty(8, dtype=torch.float32, device='npu')
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
     torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rhadd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rhadd.py
@@ -34,7 +34,7 @@ def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLO
 def test_rhadd():
     x0 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
     x1 = (torch.randint(1, 16, (8, ))).to(torch.int32).npu()
-    expected = ((x0 + x1) // 2).to(torch.int32).npu()
+    expected = ((x0.to(torch.int64) + x1.to(torch.int64) + 1) // 2).to(torch.int32).npu()
     output = torch.empty(8, dtype=torch.int32, device='npu')
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, force_simt_only=True)
     torch.testing.assert_close(output, expected, rtol=0, atol=0)

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rd.py
@@ -25,7 +25,7 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
         x0 = offset + (loop * XBLOCK_SUB) + base
         mask = x0 < n_elements
         tmp0 = tl.load(input0 + (x0), mask=mask)
-        tmp1 = libdevice.uint2float_rd(tmp0)
+        tmp1 = libdevice.uint2float_rd(tmp0.to(tl.uint32))
         tl.store(output + (x0), tmp1, mask=mask)
 
 

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rn.py
@@ -25,7 +25,7 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
         x0 = offset + (loop * XBLOCK_SUB) + base
         mask = x0 < n_elements
         tmp0 = tl.load(input0 + (x0), mask=mask)
-        tmp1 = libdevice.uint2float_rn(tmp0)
+        tmp1 = libdevice.uint2float_rn(tmp0.to(tl.uint32))
         tl.store(output + (x0), tmp1, mask=mask)
 
 

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_ru.py
@@ -25,7 +25,7 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
         x0 = offset + (loop * XBLOCK_SUB) + base
         mask = x0 < n_elements
         tmp0 = tl.load(input0 + (x0), mask=mask)
-        tmp1 = libdevice.uint2float_ru(tmp0)
+        tmp1 = libdevice.uint2float_ru(tmp0.to(tl.uint32))
         tl.store(output + (x0), tmp1, mask=mask)
 
 

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rz.py
@@ -25,7 +25,7 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
         x0 = offset + (loop * XBLOCK_SUB) + base
         mask = x0 < n_elements
         tmp0 = tl.load(input0 + (x0), mask=mask)
-        tmp1 = libdevice.uint2float_rz(tmp0)
+        tmp1 = libdevice.uint2float_rz(tmp0.to(tl.uint32))
         tl.store(output + (x0), tmp1, mask=mask)
 
 

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rd.py
@@ -25,7 +25,7 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
         x0 = offset + (loop * XBLOCK_SUB) + base
         mask = x0 < n_elements
         tmp0 = tl.load(input0 + (x0), mask=mask)
-        tmp1 = libdevice.ull2float_rd(tmp0)
+        tmp1 = libdevice.ull2float_rd(tmp0.to(tl.uint64))
         tl.store(output + (x0), tmp1, mask=mask)
 
 

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rn.py
@@ -25,7 +25,7 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
         x0 = offset + (loop * XBLOCK_SUB) + base
         mask = x0 < n_elements
         tmp0 = tl.load(input0 + (x0), mask=mask)
-        tmp1 = libdevice.ull2float_rn(tmp0)
+        tmp1 = libdevice.ull2float_rn(tmp0.to(tl.uint64))
         tl.store(output + (x0), tmp1, mask=mask)
 
 

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_ru.py
@@ -25,7 +25,7 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
         x0 = offset + (loop * XBLOCK_SUB) + base
         mask = x0 < n_elements
         tmp0 = tl.load(input0 + (x0), mask=mask)
-        tmp1 = libdevice.ull2float_ru(tmp0)
+        tmp1 = libdevice.ull2float_ru(tmp0.to(tl.uint64))
         tl.store(output + (x0), tmp1, mask=mask)
 
 

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rz.py
@@ -25,7 +25,7 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
         x0 = offset + (loop * XBLOCK_SUB) + base
         mask = x0 < n_elements
         tmp0 = tl.load(input0 + (x0), mask=mask)
-        tmp1 = libdevice.ull2float_rz(tmp0)
+        tmp1 = libdevice.ull2float_rz(tmp0.to(tl.uint64))
         tl.store(output + (x0), tmp1, mask=mask)
 
 


### PR DESCRIPTION
## Summary
- Repair the libdevice / associative_scan API examples that fail on A5 after #1782 (wrong dtypes, missing torch ops, off-by-one expected values).
- Independent of OpClassifier fill-split (#1873). That PR should stay compiler-only.

## Test plan
- [ ] a5 job step "Run API doc example tests on NPU" is green
- [ ] `brev` / `cbrt` / `erfcinv` / `ffs` / `rcbrt` / `rhadd` / `uint2float_*` / `ull2float_*` / `associative_scan` pass