### PR TITLE
[ControlFlowOpt](test) Restore indirect pointer cast test

### DIFF
--- a/third_party/ascend/unittest/pytest_ut/test_indirect_load_pointer_cast_precise_size.py
+++ b/third_party/ascend/unittest/pytest_ut/test_indirect_load_pointer_cast_precise_size.py
@@ -3,7 +3,6 @@ import torch_npu  # noqa: F401
 
 import triton
 import triton.language as tl
-import pytest
 
 
 @triton.jit
@@ -29,7 +28,6 @@ def _indirect_load_from_i64_ptr_kernel(
     tl.store(out + offsets, slot_ids.to(tl.int64))
 
 
-@pytest.mark.skip(reason="The case is not supported on A5, skipping for now. Will be fixed in future.")
 def test_indirect_load_pointer_cast_precise_size_e2e():
     block_size = 4
     block = 8


### PR DESCRIPTION
Restore the indirect load pointer-cast end-to-end test on main-dev by removing the obsolete A5 skip marker. The test now remains a normal pytest collection item and will fail on compilation, execution, or numerical mismatch. Validation: YAPF v0.43.0, Python py_compile, and git diff --check.