### PR TITLE
[ssbuffer](fix) Fix the type inconsistency between const and forOp step

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
@@ -1180,8 +1180,14 @@ int UpdateConditionInfoPass::setFlowOptCondition(scf::IfOp currentIfOp,
   int optInt =
       std::min(info->intraCoreBufferCount - 1, info->crossCoreBufferCount);
 
+  auto stepIntType = dyn_cast<IntegerType>(step.getType());
+  if (!stepIntType) {
+    LDBG("[Error] forOp step is expected to be an integer type, got "
+         << step.getType() << ", forOp=" << forOp << "\n");
+    return UPDATE_CONDITION_INFO_FAILED;
+  }
   Value optNum =
-      builder.create<arith::ConstantIntOp>(loc, optInt, CONST_INT_TYPE);
+      builder.create<arith::ConstantIntOp>(loc, optInt, stepIntType.getWidth());
   Value optOffset = builder.create<arith::MulIOp>(loc, step, optNum);
   Value lowerPlusOffset =
       builder.create<arith::AddIOp>(loc, lowerBound, optOffset);


### PR DESCRIPTION
Fix the type inconsistency between constant and forOp step value
setFlowOptCondition will create Op:
scf.for %arg21 = %LowerBound to %UpperBound step %step
  %c2 = arith.constant 2 : i64
  %83 = arith.muli %step, %c2 : i64
  %84 = arith.addi %LowerBound, %83 : i64
  %85 = arith.cmpi sge, %cnt, %84 : i64

we need to ensure type of %c2 and %step is same
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
