### PR TITLE
[MaskAnalysis](fix) disable loop for the mask analysis of atomic op

### DIFF
--- a/third_party/ascend/include/TritonToLinalg/MaskAnalysis.h
+++ b/third_party/ascend/include/TritonToLinalg/MaskAnalysis.h
@@ -55,6 +55,8 @@ public:
   SmallVector<OpFoldResult> offsets;
   OpFoldResult scalar;
 
+  bool strictNoLoop = false;
+
   int64_t getRank() const {
     assert(dims.size() == offsets.size() && "dims and offsets rank mismatch!");
     return dims.size();
@@ -201,6 +203,10 @@ private:
   // Operand is the result of insert
   LogicalResult parseInsert(tensor::InsertOp insertOp, const Location &loc,
                             OpBuilder &builder);
+
+  void inheritStrictFlags(const MaskState &parent) {
+    strictNoLoop = parent.strictNoLoop;
+  }
 };
 
 std::optional<MaskState> runMaskAnalysis(Operation *op, OpBuilder &builder);

--- a/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
+++ b/third_party/ascend/lib/DiscreteMaskAccessConversion/DiscreteMaskAccessConversionPass.cpp
@@ -184,6 +184,16 @@ LogicalResult isDiscreteMask(Operation *op, Value mask,
   }
 
   MaskState mstate;
+
+  // For non-XCHG atomics, when the ptr is structured and the mask is not classified as discrete 
+  // when in this pass but would be classified as discrete in T2L, it will fail.
+  // Temporarily modify the mask analysis logic so that the mask can also be recognized as discrete when in this pass.
+  // TODO: Re evaluate and align ptr analysis/mask analysis for T2U and T2L passes.
+  if (auto atomicOp = dyn_cast<mlir::triton::AtomicRMWOp>(op)) {
+    if (atomicOp.getAtomicRmwOp() != RMWOp::XCHG)
+      mstate.strictNoLoop = true;
+  }
+
   auto isContMask = mstate.parse(mask, op->getLoc(), rewriter);
   if (!isContMask.failed()) {
     mstate.eraseInsertedOps(op, rewriter);

--- a/third_party/ascend/lib/TritonToLinalg/MaskAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/MaskAnalysis.cpp
@@ -92,6 +92,8 @@ LogicalResult MaskState::parse(Value operand, const Location &loc,
   if (auto blockArgument = dyn_cast<BlockArgument>(operand)) {
     auto parentOp = blockArgument.getOwner()->getParentOp();
     if (auto loopOp = dyn_cast<LoopLikeOpInterface>(parentOp)) {
+      if (this->strictNoLoop)
+        return failure(); // temporarily disable loop
       OpOperand *initArgOperand = loopOp.getTiedLoopInit(blockArgument);
       if (initArgOperand) {
         Value initArg = initArgOperand->get();
@@ -356,11 +358,13 @@ LogicalResult MaskState::parseAdd(arith::AddIOp addOp, const Location &loc,
                                   OpBuilder &builder) {
   assert(this->isEmpty());
   MaskState lhsState;
+  lhsState.inheritStrictFlags(*this);
   if (failed(lhsState.parse(addOp.getLhs(), loc, builder))) {
     return failure();
   }
 
   MaskState rhsState;
+  rhsState.inheritStrictFlags(*this);
   if (failed(rhsState.parse(addOp.getRhs(), loc, builder))) {
     return failure();
   }
@@ -372,11 +376,13 @@ LogicalResult MaskState::parseDiv(arith::DivSIOp divOp, const Location &loc,
   assert(this->isEmpty());
   return failure(); // temporarily disable parseDiv
   MaskState lhsState;
+  lhsState.inheritStrictFlags(*this);
   if (failed(lhsState.parse(divOp.getLhs(), loc, builder))) {
     return failure();
   }
 
   MaskState rhsState;
+  rhsState.inheritStrictFlags(*this);
   if (failed(rhsState.parse(divOp.getRhs(), loc, builder))) {
     return failure();
   }
@@ -387,12 +393,14 @@ LogicalResult MaskState::parseAnd(arith::AndIOp andOp, const Location &loc,
                                   OpBuilder &builder) {
   assert(this->isEmpty());
   MaskState lhsState;
+  lhsState.inheritStrictFlags(*this);
   if (failed(lhsState.parse(andOp.getLhs(), loc, builder)) ||
       !lhsState.isMask()) {
     return failure();
   }
 
   MaskState rhsState;
+  rhsState.inheritStrictFlags(*this);
   if (failed(rhsState.parse(andOp.getRhs(), loc, builder)) ||
       !rhsState.isMask()) {
     return failure();
@@ -413,6 +421,7 @@ LogicalResult MaskState::parseSel(arith::SelectOp selOp, const Location &loc,
   auto falseValue = selOp.getFalseValue();
 
   MaskState condState;
+  condState.inheritStrictFlags(*this);
   auto condition = selOp.getCondition();
   auto cmpOp = condition.getDefiningOp<arith::CmpIOp>();
   if (!cmpOp || failed(condState.parse(condition, loc, builder))) {
@@ -420,11 +429,13 @@ LogicalResult MaskState::parseSel(arith::SelectOp selOp, const Location &loc,
   }
 
   MaskState trueState;
+  trueState.inheritStrictFlags(*this);
   if (failed(trueState.parse(trueValue, loc, builder)) || !trueState.scalar) {
     return failure();
   }
 
   MaskState falseState;
+  falseState.inheritStrictFlags(*this);
   if (failed(falseState.parse(falseValue, loc, builder)) || !falseState.scalar) {
     return failure();
   }
@@ -462,7 +473,9 @@ LogicalResult MaskState::parseCmp(arith::CmpIOp cmpOp, const Location &loc,
   }
 
   MaskState lhsState;
+  lhsState.inheritStrictFlags(*this);
   MaskState rhsState;
+  rhsState.inheritStrictFlags(*this);
   auto lhs = cmpOp.getLhs();
   auto rhs = cmpOp.getRhs();
 


### PR DESCRIPTION
temporarily disable loop for the mask analysis of atomic op

The pointer that reported the error was originally analyzed as: ptr structure; Mask is analyzed as continuous in DiscreteMaskAccessConversionPass/T2U and as discrete in T2L analysis. This situation is currently not supported.
Supported situations:
1 ptr structure； Mask continuous
2 ptr unstructure
3. Mask is analyzed as discrete in DiscreteMaskAccessConversionPass

There are issues with the current analysis related to mask loop, as the analysis of this pointer involves complex control flow and is currently not supported in a forward direction

Avoidance method: For atomic op, when mask analysis involves loops, classify it as discrete and use DiscreteMaskAccessConversionPass to support it

Follow up direction:
Analyze why the mask is continuous in DiscreteMaskAccessConversionPass/T2U analysis and discrete in T2L analysis
Re evaluate and align ptr analysis/mask analysis for T2U and T2L passes.



<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
