### PR TITLE
[ssbuffer](fix) fix mergecube bugs

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlock.cpp
@@ -44,8 +44,11 @@ static constexpr const char *DEBUG_TYPE = "merge-cube-block";
 #define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
 #define LDBG(...) LLVM_DEBUG(DBGS() << __VA_ARGS__ << "\n")
 
-static constexpr llvm::StringLiteral kDisnbleMergeCubeKernel =
-    "flex_attention_backward_dq_kernel";
+static const llvm::DenseSet<llvm::StringRef> kDisnbleMergeCubeKernel = {
+    "flex_attention_backward_dq_kernel",
+    "parallel_deltaformer_bwd_kernel_qk",
+    "_parallel_hstu_attn_bwd",
+};
 
 void MergeCubeBlockPass::findInnermostLoopBlocksWithMatmul(
     ModuleOp moduleOp, llvm::SmallVectorImpl<Block *> &innermostBlocks) {
@@ -133,7 +136,7 @@ void MergeCubeBlockPass::runOnOperation() {
   }
 
   for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
-    if (funcOp.getSymName() == kDisnbleMergeCubeKernel) {
+    if (kDisnbleMergeCubeKernel.contains(funcOp.getSymName())) {
       LDBG("Found unsupport kernel: " << funcOp.getSymName());
       return;
     }

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -1506,7 +1506,7 @@ LogicalResult InterCoreTransferAndSyncPass::handleCubeToVector(
   LOG_DEBUG("[newConsStart]" << *consStart << "\n");
   LOG_DEBUG("[newConsEnd]" << *consEnd << "\n");
 
-  if (dep.iniProducerBlockId == dep.producerBlockId) {
+  if (!isa<scf::ForOp, scf::WhileOp, scf::IfOp>(srcValue.getDefiningOp())) {
     auto producerPoint =
         getFixpipePointAfterProducer(srcValue, dep.iniProducerBlockId);
     if (producerPoint) {


### PR DESCRIPTION
fix that syncOp is inserted on wrong location
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
