### PR TITLE
[API](feat) Deprecate legacy sync block APIs

### DIFF
--- a/third_party/ascend/language/cann/extension/aux_ops.py
+++ b/third_party/ascend/language/cann/extension/aux_ops.py
@@ -5,19 +5,16 @@ from triton.language.core import (_unwrap_if_constexpr, _tensor_member_fn, _unwr
 
 from typing import Optional, Tuple, List, overload, Union
 from triton._C.libtriton import ir
-from ._utils import custom_op
+from ._utils import _deprecated, custom_op
 
 
+@_deprecated(
+    fn_name="triton.language.sync_block_all",
+    replacement="triton.language.extra.cann.extension.sync_block_all",
+)
 @_tensor_member_fn
 @builtin
 def sync_block_all(mode, event_id, _semantic=None):
-    import warnings
-
-    warnings.warn(
-        ("This method would be deprecated. Use al.sync_block_all instead."),
-        DeprecationWarning,
-        stacklevel=1,
-    )
     mode = _unwrap_if_constexpr(mode)
     event_id = _unwrap_if_constexpr(event_id)
     assert isinstance(mode, str), f"mode: {mode} is not string"
@@ -26,16 +23,13 @@ def sync_block_all(mode, event_id, _semantic=None):
     custom_op(_semantic.builder, "sync_block_all", mode=mode, event_id=event_id)
 
 
+@_deprecated(
+    fn_name="triton.language.sync_block_set",
+    replacement="triton.language.extra.cann.extension.sync_block_set",
+)
 @_tensor_member_fn
 @builtin
 def sync_block_set(sender, receiver, event_id, _semantic=None):
-    import warnings
-
-    warnings.warn(
-        ("This method would be deprecated. Use al.sync_block_set instead."),
-        DeprecationWarning,
-        stacklevel=1,
-    )
     sender = _unwrap_if_constexpr(sender)
     receiver = _unwrap_if_constexpr(receiver)
     event_id = _unwrap_if_constexpr(event_id)
@@ -49,16 +43,13 @@ def sync_block_set(sender, receiver, event_id, _semantic=None):
     custom_op(_semantic.builder, "sync_block_set", sender=sender, event_id=event_id)
 
 
+@_deprecated(
+    fn_name="triton.language.sync_block_wait",
+    replacement="triton.language.extra.cann.extension.sync_block_wait",
+)
 @_tensor_member_fn
 @builtin
 def sync_block_wait(sender, receiver, event_id, _semantic=None):
-    import warnings
-
-    warnings.warn(
-        ("This method would be deprecated. Use al.sync_block_wait instead."),
-        DeprecationWarning,
-        stacklevel=1,
-    )
     sender = _unwrap_if_constexpr(sender)
     receiver = _unwrap_if_constexpr(receiver)
     event_id = _unwrap_if_constexpr(event_id)

--- a/third_party/ascend/unittest/pytest_ut/test_aux_ops_deprecation.py
+++ b/third_party/ascend/unittest/pytest_ut/test_aux_ops_deprecation.py
@@ -1,0 +1,59 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from triton.language import core as tl_core
+from triton.language.extra.cann.extension import aux_ops
+
+pytestmark = pytest.mark.backend("none")
+
+
+@pytest.mark.parametrize(
+    ("fn_name", "args", "expected_builder_args"),
+    [
+        pytest.param(
+            "sync_block_all",
+            ("all", 0),
+            ("sync_block_all", "all", 0),
+            id="all",
+        ),
+        pytest.param(
+            "sync_block_set",
+            ("cube", "vector", 1),
+            ("sync_block_set", "cube", 1),
+            id="set",
+        ),
+        pytest.param(
+            "sync_block_wait",
+            ("cube", "vector", 1),
+            ("sync_block_wait", "cube", 1),
+            id="wait",
+        ),
+    ],
+)
+def test_legacy_sync_block_deprecation(fn_name, args, expected_builder_args):
+    emit_sync_op = Mock()
+    semantic = SimpleNamespace(builder=SimpleNamespace(create_custom_op_for_inter_core_sync=emit_sync_op, ), )
+    fn = getattr(aux_ops, fn_name)
+    expected_message = (f"triton.language.{fn_name} is deprecated and will be removed in the next release; "
+                        f"use triton.language.extra.cann.extension.{fn_name} instead.")
+
+    assert tl_core.is_builtin(fn)
+    with pytest.warns(FutureWarning, match=fn_name) as caught:
+        fn(*args, _semantic=semantic)
+
+    assert len(caught) == 1
+    assert str(caught[0].message) == expected_message
+    emit_sync_op.assert_called_once_with(*expected_builder_args)


### PR DESCRIPTION
## Why

The legacy `triton.language.sync_block_all`, `sync_block_set`, and `sync_block_wait` wrappers still use ad-hoc `DeprecationWarning` calls. Standardize their sunset behavior with the `_deprecated` mechanism introduced for `main-dev`, and point users to the public Ascend extension APIs.

## What

- Decorate the three legacy wrappers with `_deprecated`.
- Use the full `triton.language.extra.cann.extension.sync_block_*` replacement paths.
- Remove the old inline warning code without changing the synchronization bodies.
- Add backend-independent tests for the warning message, builtin marker, and builder argument forwarding.

## Validation

- `pre-commit run --from-ref origin/main-dev --to-ref HEAD`
- `git diff origin/main-dev..HEAD --check`
- `python -m pytest --collect-only -q third_party/ascend/unittest/pytest_ut/test_aux_ops_deprecation.py` (3 tests collected)
- Source-level checks verified the three decorator arguments and removal of the inline warnings.
- The tests were not executed against the locally installed wheel because it predates the current `_semantic` protocol; CI builds and installs the current checkout before running `pytest_ut`.

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main-dev --to-ref HEAD`.
- [x] I have added Python tests under `third_party/ascend/unittest/pytest_ut`.
- [x] I have not added any `lit` tests.
