### PR TITLE
[CI](chore) Restore Ascend950-ci.yml on main for feature branch PR CI

### DIFF
--- a/.github/workflows/Ascend950-ci.yml
+++ b/.github/workflows/Ascend950-ci.yml
@@ -1,0 +1,382 @@
+name: Ascend950 CI
+
+on:
+  pull_request_target:
+    branches: ['feature/simd-simt-compile-mode']
+    paths: &paths
+      # Source code
+      - 'python/**'
+      - 'lib/**'
+      - 'include/**'
+      - 'bin/**'
+      - 'third_party/**'
+      - 'test/**'
+      - 'unittest/**'
+      - 'utils/**'
+      - 'scripts/**'
+      # Build configuration
+      - 'cmake/**'
+      - 'CMakeLists.txt'
+      - 'setup.py'
+      - 'pyproject.toml'
+      - 'Makefile'
+      - 'safe_compile.cmake'
+      - 'version.txt'
+      # CI itself
+      - '.github/workflows/Ascend950-ci.yml'
+
+concurrency:
+  # PR runs key on PR number (cancel earlier pushes); branch-push runs key on
+  # SHA so distinct merges don't cancel each other.
+  group: ascend950-${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+
+permissions: {}
+
+jobs:
+  # ── Wheels Build ──────────────────────────────────────────────────────────
+  # Security: under pull_request_target, the workflow file from the base
+  # branch is used. This job checks out the PR head SHA but does NOT receive
+  # any secrets in its env/steps — the only credential available is the
+  # GITHUB_TOKEN scoped to contents:read. PR code (setup.py) cannot exfiltrate
+  # secrets.
+
+  wheels-build:
+    name: Wheels Build
+    timeout-minutes: 120
+    runs-on: linux-amd64-cpu-16
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/triton:8.5.0-910b-ubuntu22.04-py3.11-latest
+
+    permissions:
+      contents: read
+
+    outputs:
+      wheel_name: ${{ steps.wheel.outputs.name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # pull_request_target: checkout PR head so we build what was proposed.
+          # push: checkout the triggering commit.
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          submodules: "true"
+          # This workflow is scoped to contents:read only and passes zero
+          # secrets to the build job — PR code cannot exfiltrate anything.
+          allow-unsafe-pr-checkout: true
+
+      - name: Add git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Cache build dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.triton/llvm
+            ~/.triton/json
+            ~/.triton/nvidia
+            ${{ github.workspace }}/.ccache
+          key: ${{ runner.os }}-${{ runner.arch }}-cann8.5.0-ubuntu22.04-910b-py3.11-wheels-${{ hashFiles('cmake/llvm-hash.txt', 'cmake/json-version.txt', 'cmake/nvidia-toolchain-version.json', 'third_party/ascend/patch/llvm_patch_*.patch') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-cann8.5.0-ubuntu22.04-910b-py3.11-wheels
+
+      - name: Build triton-ascend wheel
+        shell: bash
+        env:
+          TRITON_BUILD_WITH_CCACHE: "true"
+          TRITON_BUILD_WITH_CLANG_LLD: "TRUE"
+          TRITON_DISABLE_LINE_INFO: 1
+          CCACHE_COMPRESS: "true"
+          CCACHE_DIR: ${{ github.workspace }}/.ccache
+          TRITON_BUILD_WITH_O1: true
+          TRITON_BUILD_PROTON: OFF
+          TRITON_WHEEL_NAME: triton-ascend
+          TRITON_APPEND_CMAKE_ARGS: "-DTRITON_BUILD_UT=ON"
+        run: |
+          mkdir -p "$CCACHE_DIR"
+          ccache --zero-stats
+          NUM_PROCS=$(( $(nproc) / 3 ))
+          if [ "$NUM_PROCS" -lt 1 ]; then NUM_PROCS=1; fi
+          # setup.py or setup_ascend.py is at repo root on main, under python/ on older release branches.
+          if [ -f setup_ascend.py ]; then
+            SETUP_DIR="./"
+            SETUP_PY="setup_ascend.py"
+          elif [ -f setup.py ]; then
+            SETUP_DIR="./"
+            SETUP_PY="setup.py"
+          elif [ -f python/setup.py ]; then
+            SETUP_DIR="python"
+            SETUP_PY="setup.py"
+          else
+            echo "ERROR: setup.py or setup_ascend.py not found" >&2
+            exit 1
+          fi
+          cd "$SETUP_DIR"
+          MAX_JOBS="$NUM_PROCS" \
+          python ${SETUP_PY} bdist_wheel --dist-dir="${GITHUB_WORKSPACE}/wheelhouse"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-manylinux_2_28_x86_64-wheels-upload
+          path: ./wheelhouse/*.whl
+
+      - name: Resolve wheel filename
+        id: wheel
+        # PR build matrix produces a single wheel; capture its filename for
+        # downstream jobs (OBS URL, BY pipeline parameter).
+        run: echo "name=$(basename wheelhouse/*.whl)" >> "$GITHUB_OUTPUT"
+
+  # ── Pipeline Tests ────────────────────────────────────────────────────────
+  # This job never checks out PR code — it only downloads the binary wheel
+  # artifact, uploads it to OBS, and triggers the BY pipeline. Secrets (OBS,
+  # Blue/Yellow) are safe here because no untrusted code is executed.
+
+  pipeline-tests:
+    name: Pipeline Tests
+    needs: wheels-build
+    timeout-minutes: 360
+    if: needs.wheels-build.result == 'success'
+    runs-on: linux-aarch64-cpu-1
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/modelfoundry/ascend/triton:github_action
+
+    permissions:
+      pull-requests: read
+
+    steps:
+      - name: Resolve pipeline context
+        id: ctx
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ "${EVENT_NAME}" = "pull_request_target" ]; then
+            # PR context is directly available from the event payload.
+            # We still look up the PR for the latest title (it's mutable).
+            P=$(gh pr view "$PR_NUMBER" --repo "${REPO}" \
+                  --json title,baseRefName,headRefOid)
+            PR_TITLE=$(echo "$P" | jq -r .title)
+            BRANCH_B=$(echo "$P" | jq -r .baseRefName)
+            OBS_KEY="$PR_NUMBER"
+            KIND="pr"
+          else
+            # push to main / release/**
+            PR_TITLE="${HEAD_REF} @ ${HEAD_SHA:0:8}"
+            BRANCH_B="$HEAD_REF"
+            OBS_KEY="$HEAD_SHA"
+            KIND="branch"
+          fi
+
+          {
+            echo "pr_id=${OBS_KEY}"
+            echo "kind=${KIND}"
+            echo "branch_b=${BRANCH_B}"
+            echo "head_sha=${HEAD_SHA}"
+          } >> "$GITHUB_OUTPUT"
+
+          # PR_TITLE may contain newlines; pass via env file as multi-line values.
+          {
+            echo "PR_TITLE<<__EOF__"
+            printf '%s\n' "$PR_TITLE"
+            echo "__EOF__"
+          } >> "$GITHUB_ENV"
+
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: cibw-wheels-manylinux_2_28_x86_64-wheels-upload
+          path: wheelhouse
+
+      - name: Setup obsutil and upload to OBS
+        shell: bash
+        env:
+          AK: ${{ secrets.OBS_AK }}
+          SK: ${{ secrets.OBS_SK }}
+          PR_NUM: ${{ steps.ctx.outputs.pr_id }}
+        run: |
+          set -eu
+          if [ -z "${AK}" ] || [ -z "${SK}" ]; then
+            echo "OBS credentials are empty."
+            exit 1
+          fi
+          curl -fL "https://obs-community.obs.cn-north-1.myhuaweicloud.com/obsutil/current/obsutil_linux_arm64.tar.gz" -o obsutil.tar.gz
+          gzip -t obsutil.tar.gz || { echo "obsutil.tar.gz is not a valid gzip"; exit 1; }
+          tar xzf obsutil.tar.gz
+          rm -f obsutil.tar.gz
+          mv obsutil_linux_* obsutil
+          obsutil/obsutil config -i="${AK}" -k="${SK}" -e=https://obs.cn-southwest-2.myhuaweicloud.com
+          obsutil/obsutil cp -u wheelhouse/*.whl "obs://triton-ascend-artifacts/triton-ascend/${PR_NUM}/"
+
+      - name: Trigger BY pipeline
+        id: run
+        shell: bash
+        env:
+          BASE_URL:           ${{ secrets.BLUE_YELLOW_BASE_URL }}
+          APP_CODE:           ${{ secrets.BLUE_YELLOW_APP_CODE }}
+          APP_KEY:            ${{ secrets.BLUE_YELLOW_APP_KEY }}
+          APP_SECRET:         ${{ secrets.BLUE_YELLOW_APP_SECRET }}
+          YELLOW_PIPELINE_ID: ${{ vars.YELLOW_PIPELINE_ID }}
+          YELLOW_GROUP_ID:    ${{ vars.YELLOW_GROUP_ID }}
+          PR_ID:              ${{ steps.ctx.outputs.pr_id }}
+          URL_B:              ${{ github.server_url }}/${{ github.repository }}
+          BRANCH_B:           ${{ steps.ctx.outputs.branch_b }}
+          WHEEL_NAME:         ${{ needs.wheels-build.outputs.wheel_name }}
+        run: |
+          set -euo pipefail
+
+          STATUS_FILE="$RUNNER_TEMP/by-status"
+
+          H_CODE="X-Apig-AppCode: ${APP_CODE}"
+          H_KEY="AppKey: ${APP_KEY}"
+          H_SEC="AppSecret: ${APP_SECRET}"
+          H_JSON="Content-Type: application/json"
+
+          TS=$(date +%Y%m%d%H%M%S)
+          BRI="pr-${PR_ID}-${TS}"
+          BTI="task-${PR_ID}-${TS}"
+
+          write_status(){
+            printf 'status=%s\nmsg=%s\nblueRecordId=%s\nyellowPipelineUrl=%s\n' \
+              "$1" "$2" "$BRI" "${3:-}" > "$STATUS_FILE"
+          }
+
+          # JSON-escape arbitrary text (PR titles can contain quotes/newlines).
+          PR_TITLE_J=$(printf '%s' "${PR_TITLE}" | jq -Rs .)
+
+          if [ -z "${WHEEL_NAME:-}" ]; then
+            echo "WHEEL_NAME is empty"
+            write_status "START_FAILURE" "wheel filename not produced by build"
+            exit 1
+          fi
+          WHEEL_NAME_ENC=$(printf '%s' "$WHEEL_NAME" | jq -sRr @uri)
+          OBS_URL="https://triton-ascend-artifacts.obs.cn-southwest-2.myhuaweicloud.com/triton-ascend/${PR_ID}/${WHEEL_NAME_ENC}"
+
+          START_BODY=$(cat <<EOF
+          {
+            "bluePipelineId": "null",
+            "blueRecordId": "${BRI}",
+            "blueRecordTaskId": "${BTI}",
+            "blueRecordTaskName": "PR-${PR_ID}-CI",
+            "yellowPipelineId": "${YELLOW_PIPELINE_ID}",
+            "yellowGroupId": "${YELLOW_GROUP_ID}",
+            "starter": "p_TritonCI",
+            "branch": "main",
+            "parameter": {
+              "pr": "${PR_ID}",
+              "title": ${PR_TITLE_J},
+              "description": "${PR_ID}",
+              "url_b": "${URL_B}",
+              "branch_b": "${BRANCH_B}",
+              "obs_url": "${OBS_URL}"
+            }
+          }
+          EOF
+          )
+
+          # /start retry: only on gateway/network failures (502/504,
+          # APIG.0203, curl=000); any other response is terminal. BRI/BTI are
+          # reused across attempts so the backend can dedupe a request the
+          # gateway lost mid-flight. --max-time 70 exceeds APIG's ~60s backend
+          # timeout so curl waits out the 502 instead of giving up first.
+          START_OK=false
+          LAST_R=""; LAST_BODY=""
+          DUP_RE='(exist|duplicate|already)'
+          for ((I=1; I<=5; I++)); do
+            R=$(curl -sS --max-time 70 \
+              -o /tmp/by_start.body -w '%{http_code}' \
+              -H "$H_CODE" -H "$H_KEY" -H "$H_SEC" -H "$H_JSON" \
+              -X POST "${BASE_URL}/start" -d "${START_BODY}" || echo "000")
+            BODY=$(cat /tmp/by_start.body 2>/dev/null || true)
+            LAST_R="$R"; LAST_BODY="$BODY"
+            echo "[start #${I}] HTTP=${R} response: ${BODY}"
+
+            if [ "$R" = "200" ] && echo "$BODY" | grep -q '"code":200'; then
+              START_OK=true
+              break
+            fi
+            if echo "$BODY" | grep -Eiq "\"(error_msg|msg|message)\":\"[^\"]*${DUP_RE}"; then
+              echo "[start #${I}] backend reports duplicate task — treating as already-accepted"
+              START_OK=true
+              break
+            fi
+            if [ "$R" = "502" ] || [ "$R" = "504" ] || [ "$R" = "000" ] \
+                || echo "$BODY" | grep -q 'APIG\.0203'; then
+              SLEEP=$(( I * 5 ))
+              echo "[start #${I}] retryable failure — sleeping ${SLEEP}s before retry"
+              sleep "$SLEEP"
+              continue
+            fi
+            echo "[start #${I}] non-retryable failure — aborting"
+            break
+          done
+
+          if [ "$START_OK" != "true" ]; then
+            write_status "START_FAILURE" "HTTP=${LAST_R} body=${LAST_BODY}"
+            exit 1
+          fi
+
+          QUERY_BODY=$(cat <<EOF
+          {"blueRecordId":"${BRI}","blueRecordTaskId":"${BTI}"}
+          EOF
+          )
+
+          ST=""; MSG=""; DONE=false
+          for ((N=1; N<=720; N++)); do
+            sleep 60
+            QHTTP=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 \
+              -o /tmp/by_query.body -w '%{http_code}' \
+              -H "$H_CODE" -H "$H_KEY" -H "$H_SEC" -H "$H_JSON" \
+              -X POST "${BASE_URL}/query" -d "${QUERY_BODY}" || true)
+            QR=$(cat /tmp/by_query.body 2>/dev/null || true)
+            ST=$(printf '%s' "$QR"   | grep -o '"status":"[^"]*"'           | head -1 | cut -d'"' -f4 || true)
+            MSG=$(printf '%s' "$QR"  | grep -o '"msg":"[^"]*"'              | head -1 | cut -d'"' -f4 || true)
+            YPURL=$(printf '%s' "$QR" | grep -o '"yellowPipelineUrl":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
+            echo "[#${N}] HTTP=${QHTTP} status=${ST:-pending} msg=${MSG}"
+            echo "  body: ${QR}"
+            write_status "${ST:-PENDING}" "${MSG}" "${YPURL}"
+            case "${ST}" in
+              SUCCESS|FAILURE|MQS_SEND_FAILURE|UNAUTHORIZED|START_FAILURE|TIMEOUT|ABORT)
+                DONE=true; break;;
+            esac
+          done
+
+          if [ "$DONE" != "true" ]; then
+            write_status "TIMEOUT" "polling exceeded 720 attempts without a terminal status"
+            exit 1
+          fi
+          echo "terminal status: ${ST} - ${MSG}"
+          [ "$ST" = "SUCCESS" ] || exit 1
+
+      - name: Remove wheels from OBS
+        if: always() && steps.ctx.outputs.pr_id != ''
+        continue-on-error: true
+        shell: bash
+        env:
+          AK: ${{ secrets.OBS_AK }}
+          SK: ${{ secrets.OBS_SK }}
+          PR_NUM: ${{ steps.ctx.outputs.pr_id }}
+        run: |
+          # Guard against a missing/malformed PR_NUM: an empty value would
+          # collapse the URL to .../triton-ascend/ and `rm -rf` would wipe
+          # every namespace. Accept a positive integer (PR number) or a full
+          # git SHA (main-branch run).
+          if [[ ! "${PR_NUM:-}" =~ ^([1-9][0-9]*|[0-9a-f]{40})$ ]]; then
+            echo "Refusing to delete: PR_NUM='${PR_NUM:-}' is not a PR number or SHA" >&2
+            exit 1
+          fi
+
+          curl -fL "https://obs-community.obs.cn-north-1.myhuaweicloud.com/obsutil/current/obsutil_linux_arm64.tar.gz" -o obsutil.tar.gz
+          gzip -t obsutil.tar.gz || { echo "obsutil.tar.gz is not a valid gzip"; exit 1; }
+          tar xzf obsutil.tar.gz
+          rm -f obsutil.tar.gz
+          mv obsutil_linux_* obsutil
+          obsutil/obsutil config -i="${AK}" -k="${SK}" -e=https://obs.cn-southwest-2.myhuaweicloud.com
+          obsutil/obsutil rm -r -f "obs://triton-ascend-artifacts/triton-ascend/${PR_NUM}/" || true


### PR DESCRIPTION
## Motivation

The `feature/simd-simt-compile-mode` branch still needs the Ascend950 pipeline(wheel build + Blue/Yellow pipeline trigger), but this workflow was previously removed from main.

GitHub's `pull_request_target` event loads the workflow definition from the **default branch (main)** (official docs: "This event runs in the context of the default branch of the base repository"). As long as the file is absent from main, PRs targeting the feature branch will never trigger this workflow(confirmed empirically with PR #1905).

This PR therefore adds `Ascend950-ci.yml` back to main to serve as the `pull_request_target` trigger carrier.

## Changes

- Add `.github/workflows/Ascend950-ci.yml` to main, byte-identical to the version already merged on `feature/simd-simt-compile-mode`.

## Impact (no CI runs on main itself)

- The trigger is scoped to `branches: ['feature/simd-simt-compile-mode']`: pushes to main and PRs targeting main are never triggered.
- The `paths` filter limits triggering to PRs touching source / build config / CI files only.
- The security model is unchanged: PR code is built in a secret-free environment (`contents: read`); the steps that use secrets (OBS upload, Blue/Yellow pipeline trigger) never execute PR code — they only handle the build artifact and PR metadata.

## Verification

After merging, push once more to the head branch of a PR targeting the feature branch (e.g. #1905), or close/reopen it — the Ascend950 CI check will then appear.

---
Note: this is a scoped restore of a file previously removed from main. It performs no work on main itself; it exists only to enable PR-triggered CI for the feature branch.
