### PR TITLE
[Autotune](feat) Add JIT-scoped cache for autotune compile failures

### DIFF
--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -30,6 +30,7 @@ import gc
 import inspect
 import os
 import pprint
+import threading
 import time
 import warnings
 from concurrent.futures import ThreadPoolExecutor
@@ -41,7 +42,10 @@ from typing import Any, Dict, List, Optional, Tuple
 from torch import Tensor
 
 import triton
+from triton import knobs
+from triton._C.libtriton import get_cache_invalidating_env_vars
 from triton.runtime.autotuner import Autotuner, Config
+from triton.runtime.jit import compute_cache_key
 from triton.backends.ascend.utils import (_InternalNPUOptionInt, _remove_deprecated_npu_options,
                                           _RESERVED_NPU_OPTION_NAMES, is_compile_on_910_95)
 
@@ -358,6 +362,14 @@ class AutoTilingTuner(Autotuner):
                                  and os.getenv("TRITON_AUTOTUNE_PARALLEL_COMPILE", "1") == "1")
         self._source_module_ast_cache: Optional[ast.Module] = None
         self._source_module_ast_resolved = False
+
+        # Negative cache for deterministic compile failures.  This is keyed by
+        # the JIT compilation identity rather than the autotune tuning key, so
+        # a failed compile can be reused when only the tuning key changes while
+        # the actual compiler inputs remain identical.
+        self._compile_failure_cache: Dict[Tuple, Dict[str, str]] = {}
+        self._compile_failure_cache_lock = threading.Lock()
+        self._cached_compile_failed_configs: List[Config] = []
 
     @staticmethod
     def _parse_explicit_tunable_params(raw_value) -> List[str]:
@@ -2191,11 +2203,137 @@ class AutoTilingTuner(Autotuner):
             selected = " [selected]" if config == self.best_config else ""
             print(f"  config={config}; {_format_autotune_timing(timing)}{selected}")
 
+    def _get_jit_compile_cache_key(self, *args, config, **meta):
+        """Return the JIT compilation identity for one autotune Config.
+
+        The autotune tuning key intentionally does not participate in this
+        identity.  If a changed tuning key produces the same JIT
+        specialization and backend options, a previous deterministic compile
+        failure can be reused safely.  If constexpr values or compile options
+        change, ``compute_cache_key`` returns a different identity and the
+        Config is compiled again.
+
+        User hooks may mutate arguments before JIT specialization, so use a
+        conservative fallback and disable negative caching for those Configs.
+        """
+        if config.pre_hook is not None or getattr(self, "user_defined_pre_hook", False):
+            return None
+
+        try:
+            current = dict(meta, **config.all_kwargs())
+            ub_cfg = dict(getattr(config, "ubtune_cfg", {}))
+            if ub_cfg:
+                current.update(ub_cfg)
+            _inject_default_simt_stack_limit(current, self.simt_stack_limit)
+
+            # Match the first call made by _batch_bench. Heuristics.run sees
+            # grid and warmup before forwarding the remaining arguments to
+            # JITFunction.run, so resolve heuristics before removing them.
+            current["warmup"] = bool(getattr(self, "compile_parallel", False))
+            jit_fn = getattr(self, "fn", None)
+            visited = set()
+            while isinstance(jit_fn, triton.runtime.Heuristics):
+                if id(jit_fn) in visited:
+                    return None
+                visited.add(id(jit_fn))
+                for name, heuristic in jit_fn.values.items():
+                    heuristic_args = {**dict(zip(jit_fn.arg_names, args)), **current}
+                    current[name] = heuristic(heuristic_args)
+                jit_fn = jit_fn.fn
+
+            # Unknown wrappers may transform arguments before JITFunction.run.
+            # Never bypass them when constructing a negative-cache key.
+            if not isinstance(jit_fn, triton.runtime.JITFunction):
+                return None
+            if getattr(jit_fn, "pre_run_hooks", None):
+                return None
+
+            # These two arguments are consumed by JITFunction.run and are not
+            # passed to the generated binder.
+            current.pop("grid", None)
+            current.pop("warmup", None)
+
+            # Keep this in sync with JITFunction.run before it invokes binder.
+            current["debug"] = current.get("debug", jit_fn.debug) or knobs.runtime.debug
+            current["instrumentation_mode"] = knobs.compilation.instrumentation_mode
+
+            device = triton.runtime.driver.active.get_current_device()
+            _, kernel_key_cache, target, _, binder = jit_fn.device_caches[device]
+            _, specialization, options = binder(*args, **current)
+            jit_key = compute_cache_key(kernel_key_cache, specialization, options)
+
+            env_vars = get_cache_invalidating_env_vars()
+            ubtuner_mode = os.environ.get("TRITON_ENABLE_UBTUNER", "")
+            if ubtuner_mode:
+                env_vars["TRITON_ENABLE_UBTUNER"] = ubtuner_mode
+
+            return (
+                jit_fn.cache_key,
+                repr(target),
+                str(sorted(env_vars.items())),
+                device,
+                jit_key,
+            )
+        except Exception:
+            # Failure-key calculation must never break normal autotuning.
+            return None
+
+    def _get_cached_compile_failure(self, compile_key):
+        if compile_key is None:
+            return None
+        with self._compile_failure_cache_lock:
+            return self._compile_failure_cache.get(compile_key)
+
+    def _remember_compile_failure(self, compile_key, exc) -> None:
+        if compile_key is None:
+            return
+        failure = {
+            "exception_type": type(exc).__name__,
+        }
+        with self._compile_failure_cache_lock:
+            self._compile_failure_cache.setdefault(compile_key, failure)
+
+    def _filter_cached_compile_failures(self, *args, configs, **kwargs):
+        active_configs = []
+        cached_configs = []
+        compile_keys = {}
+
+        for config in configs:
+            compile_key = self._get_jit_compile_cache_key(*args, config=config, **kwargs)
+            compile_keys[config] = compile_key
+            failure = self._get_cached_compile_failure(compile_key)
+            if failure is None:
+                active_configs.append(config)
+                continue
+
+            cached_configs.append(config)
+            if self.print_autotuning:
+                print("Triton autotuning: skip cached compile-failed config "
+                      f"{config}; previous failure: {failure['exception_type']}")
+
+        self._cached_compile_failed_configs = cached_configs
+        return active_configs, compile_keys
+
     def _batch_bench(self, *args, configs, **kwargs):
         from triton.compiler.errors import CompileTimeAssertionFailure, MLIRCompilationError
         from triton.runtime.errors import OutOfResources
 
         kernels_call = {config: self._make_kernel_call(*args, config=config, **kwargs) for config in configs}
+        active_configs, compile_keys = self._filter_cached_compile_failures(
+            *args,
+            configs=configs,
+            **kwargs,
+        )
+        kernels_call = {config: kernels_call[config] for config in active_configs}
+
+        if not kernels_call:
+            details = []
+            for config in configs:
+                failure = self._get_cached_compile_failure(compile_keys.get(config))
+                if failure is not None:
+                    details.append(f"config={config}: {failure['exception_type']}")
+            raise RuntimeError("All triton configs are cached compile failures.\n" + "\n".join(details))
+
         run_fns = {}
         self._compile_failed_configs = []
         exc = None
@@ -2221,12 +2359,14 @@ class AutoTilingTuner(Autotuner):
                             if hasattr(fut, "packed_metadata"):
                                 kernels_call[config].target_kernel_name = fut.packed_metadata.get("kernel_name")
                             run_fns[config] = functools.partial(kernels_call[config], warmup=False)
-                        except (CompileTimeAssertionFailure, MLIRCompilationError) as e:
+                        except (CompileTimeAssertionFailure, MLIRCompilationError, OutOfResources) as e:
                             import traceback
                             exc_stack = traceback.format_exc()
                             exc = e
                             self._try_ubtuner(*args, config=config, excp=e, run_fns=run_fns, **kwargs)
                             self._compile_failed_configs.append(config)
+                            if config not in run_fns:
+                                self._remember_compile_failure(compile_keys.get(config), e)
             except Exception as e:
                 # ignore exception from __exit__() of AsyncCompileMode
                 triton.runtime._async_compile.active_mode.set(None)
@@ -2243,6 +2383,8 @@ class AutoTilingTuner(Autotuner):
                     exc = e
                     self._try_ubtuner(*args, config=config, excp=e, run_fns=run_fns, **kwargs)
                     self._compile_failed_configs.append(config)
+                    if config not in run_fns:
+                        self._remember_compile_failure(compile_keys.get(config), e)
 
         if len(run_fns) == 0:
             raise RuntimeError(f"No valid triton configs. {type(exc).__name__}: {exc} \nStack trace: {exc_stack}")

--- a/third_party/ascend/unittest/autotune_ut/test_compile_failure_cache.py
+++ b/third_party/ascend/unittest/autotune_ut/test_compile_failure_cache.py
@@ -1,0 +1,259 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import threading
+from collections import defaultdict
+from types import MethodType, SimpleNamespace
+
+import pytest
+import triton
+import triton.language as tl
+import triton.backends.ascend.runtime.autotuner as ascend_autotuner
+from triton.backends.ascend.runtime.autotuner import AutoTilingTuner
+from triton.runtime.autotuner import Config
+from triton.runtime.errors import OutOfResources
+
+
+@triton.jit
+def _compile_key_kernel(
+    x,
+    m,
+    BLOCK_SIZE: tl.constexpr,
+    EVEN_M: tl.constexpr,
+):
+    pass
+
+
+def _make_compile_key_tuner(monkeypatch, wrapped_fn):
+    tuner = object.__new__(AutoTilingTuner)
+    tuner.fn = wrapped_fn
+    tuner.simt_stack_limit = 8192
+    tuner.compile_parallel = False
+    tuner.user_defined_pre_hook = False
+
+    binder_calls = []
+
+    def binder(*args, **kwargs):
+        binder_calls.append(dict(kwargs))
+        # Model m as a do_not_specialize runtime argument. Only constexpr
+        # values injected by Config/Heuristics participate in specialization.
+        specialization = [
+            ("constexpr", kwargs["BLOCK_SIZE"]),
+            ("constexpr", kwargs["EVEN_M"]),
+        ]
+        options = tuple((name, repr(kwargs.get(name))) for name in (
+            "num_warps",
+            "num_ctas",
+            "num_stages",
+            "debug",
+            "instrumentation_mode",
+        ))
+        return {}, specialization, options
+
+    monkeypatch.setattr(
+        triton.runtime.driver,
+        "_active",
+        SimpleNamespace(get_current_device=lambda: 0),
+    )
+    monkeypatch.setattr(ascend_autotuner, "get_cache_invalidating_env_vars", lambda: {})
+    monkeypatch.delenv("TRITON_ENABLE_UBTUNER", raising=False)
+    monkeypatch.setattr(_compile_key_kernel, "hash", "test-jit-cache-key")
+    monkeypatch.setattr(_compile_key_kernel, "debug", None)
+    monkeypatch.setattr(_compile_key_kernel, "pre_run_hooks", [])
+    monkeypatch.setattr(
+        _compile_key_kernel,
+        "device_caches",
+        {0: ({}, {}, "test-target", None, binder)},
+    )
+    return tuner, binder_calls
+
+
+def test_compile_failure_key_supports_direct_jit_function(monkeypatch):
+    tuner, binder_calls = _make_compile_key_tuner(monkeypatch, _compile_key_kernel)
+    config = Config({"BLOCK_SIZE": 128, "EVEN_M": True})
+
+    compile_key = tuner._get_jit_compile_cache_key(
+        object(),
+        16,
+        config=config,
+        grid=(1, ),
+    )
+
+    assert compile_key is not None
+    assert len(binder_calls) == 1
+    assert binder_calls[0]["BLOCK_SIZE"] == 128
+    assert binder_calls[0]["EVEN_M"] is True
+    assert "grid" not in binder_calls[0]
+    assert "warmup" not in binder_calls[0]
+
+
+def test_compile_failure_key_replays_heuristics_before_binder(monkeypatch):
+    heuristic_calls = []
+
+    def even_m(args):
+        heuristic_calls.append(dict(args))
+        return args["m"] % 2 == 0
+
+    wrapped_fn = triton.runtime.Heuristics(
+        _compile_key_kernel,
+        _compile_key_kernel.arg_names,
+        {"EVEN_M": even_m},
+    )
+    tuner, binder_calls = _make_compile_key_tuner(monkeypatch, wrapped_fn)
+    config = Config({"BLOCK_SIZE": 128})
+
+    even_key = tuner._get_jit_compile_cache_key(
+        object(),
+        16,
+        config=config,
+        grid=(1, ),
+    )
+    odd_key = tuner._get_jit_compile_cache_key(
+        object(),
+        17,
+        config=config,
+        grid=(1, ),
+    )
+    second_even_key = tuner._get_jit_compile_cache_key(
+        object(),
+        18,
+        config=config,
+        grid=(1, ),
+    )
+
+    assert even_key is not None
+    assert odd_key is not None
+    assert second_even_key is not None
+    assert even_key == second_even_key
+    assert even_key != odd_key
+    assert [call["EVEN_M"] for call in binder_calls] == [True, False, True]
+    assert heuristic_calls[0]["BLOCK_SIZE"] == 128
+    assert heuristic_calls[0]["grid"] == (1, )
+    assert heuristic_calls[0]["warmup"] is False
+    assert "grid" not in binder_calls[0]
+    assert "warmup" not in binder_calls[0]
+
+
+def test_compile_failure_key_rejects_unknown_wrapper(monkeypatch):
+
+    class UnknownWrapper:
+
+        def __init__(self, fn):
+            self.fn = fn
+
+    tuner, binder_calls = _make_compile_key_tuner(
+        monkeypatch,
+        UnknownWrapper(_compile_key_kernel),
+    )
+    config = Config({"BLOCK_SIZE": 128, "EVEN_M": True})
+
+    compile_key = tuner._get_jit_compile_cache_key(
+        object(),
+        16,
+        config=config,
+        grid=(1, ),
+    )
+
+    assert compile_key is None
+    assert binder_calls == []
+
+
+def test_compile_failure_key_is_disabled_for_jit_pre_run_hook(monkeypatch):
+    tuner, binder_calls = _make_compile_key_tuner(monkeypatch, _compile_key_kernel)
+    monkeypatch.setattr(_compile_key_kernel, "pre_run_hooks", [lambda *args, **kwargs: None])
+    config = Config({"BLOCK_SIZE": 128, "EVEN_M": True})
+
+    compile_key = tuner._get_jit_compile_cache_key(
+        object(),
+        16,
+        config=config,
+        grid=(1, ),
+    )
+
+    assert compile_key is None
+    assert binder_calls == []
+
+
+def _make_batch_bench_tuner():
+    tuner = object.__new__(AutoTilingTuner)
+    tuner.compile_parallel = False
+    tuner.enable_ubtuner = False
+    tuner.print_autotuning = False
+    tuner.user_defined_do_bench = True
+    tuner._compile_failure_cache = {}
+    tuner._compile_failure_cache_lock = threading.Lock()
+    tuner._cached_compile_failed_configs = []
+
+    kernel_calls = defaultdict(int)
+
+    def get_compile_key(self, *args, config, **kwargs):
+        return ("compile-key", config.kwargs["ID"])
+
+    def make_kernel_call(self, *args, config, **kwargs):
+
+        def kernel_call(warmup):
+            kernel_calls[config] += 1
+            if config.kwargs["ID"] == "bad":
+                raise OutOfResources(2, 1, "UB")
+            return None
+
+        return kernel_call
+
+    def do_bench(fn, quantiles):
+        fn()
+        return 1.0
+
+    tuner._get_jit_compile_cache_key = MethodType(get_compile_key, tuner)
+    tuner._make_kernel_call = MethodType(make_kernel_call, tuner)
+    tuner.do_bench = do_bench
+    return tuner, kernel_calls
+
+
+def test_batch_bench_skips_config_cached_as_compile_failure():
+    tuner, kernel_calls = _make_batch_bench_tuner()
+    bad = Config({"ID": "bad"})
+    good = Config({"ID": "good"})
+
+    first_result = tuner._batch_bench(configs=[bad, good])
+
+    assert first_result == {good: 1.0}
+    assert kernel_calls[bad] == 1
+    assert tuner._compile_failure_cache[("compile-key", "bad")] == {
+        "exception_type": "OutOfResources",
+    }
+    assert tuner._cached_compile_failed_configs == []
+
+    second_result = tuner._batch_bench(configs=[bad, good])
+
+    assert second_result == {good: 1.0}
+    assert kernel_calls[bad] == 1
+    assert tuner._compile_failed_configs == []
+    assert tuner._cached_compile_failed_configs == [bad]
+
+
+def test_batch_bench_raises_when_all_configs_are_cached_failures():
+    tuner, kernel_calls = _make_batch_bench_tuner()
+    bad = Config({"ID": "bad"})
+    tuner._remember_compile_failure(("compile-key", "bad"), OutOfResources(2, 1, "UB"))
+
+    with pytest.raises(RuntimeError, match="All triton configs are cached compile failures"):
+        tuner._batch_bench(configs=[bad])
+
+    assert kernel_calls[bad] == 0


### PR DESCRIPTION
## Summary

Add an in-memory negative cache to the Ascend `AutoTilingTuner` for Configs that fail during compilation.

When the autotune key changes, autotuning is performed again. Successfully compiled Configs may reuse the JIT kernel cache, but failed Configs previously had no corresponding cache entry and were compiled again.

This change skips a previously failed Config when its actual JIT compilation inputs remain unchanged.

## Implementation

- Generate the failure-cache key from the JIT compilation identity, including:
  - JIT function source and dependencies
  - target and device
  - JIT specialization and compiler options
  - cache-invalidating environment variables
  - existing UBTuner compiler options
- Keep the autotune key out of the failure-cache key so failures can be reused across different tuning keys.
- Retry compilation when constexpr values, compiler options, target, source, or other JIT inputs change.
- Cache the following per-Config failures:
  - `CompileTimeAssertionFailure`
  - `MLIRCompilationError`
  - `OutOfResources`
- Do not cache the original failure when UBTuner successfully recovers the Config.
- Disable failure caching conservatively when user-defined or JIT pre-run hooks may modify the compilation inputs.
- Store only the exception type to avoid retaining and repeatedly printing large compiler error messages or IR dumps.

The cache is local to the current `AutoTilingTuner` instance and is not persisted to disk.

## Validation

Added a vector-add reproducer containing:

- An invalid Config that triggers a real UB overflow:
  - `BLOCK_SIZE=20480`
  - `ITERATIONS=8`
- A valid Config:
  - `BLOCK_SIZE=1024`
  - `ITERATIONS=1`

The test runs the kernel using the key sequence `K1 -> K2 -> K1`:

1. `K1` compiles the invalid Config once and records the UB-overflow failure.
2. `K2` causes an autotune cache miss but skips the invalid Config through the new failure cache.
3. The final `K1` invocation hits the normal autotune memory cache.

The observed compile-failure counts are:

```text
[1, 0, 0]
```

The output is also compared with the PyTorch reference to verify correctness.
<img width="1945" height="316" alt="image" src="https://github.com/user-attachments/assets/92d79c49-e05d-4e37-97ea-ac5027ae738a" />
<img width="1980" height="189" alt="image" src="https://github.com/user-attachments/assets/21489433-cfde-48f2-a85b-170ecde198bf" />

