### PR TITLE
[ssbuffer](fix) start & end sync op insert point

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -50,6 +50,7 @@ inline constexpr llvm::StringLiteral kIntraBufCount = "ssbuffer.intra_buf_count"
 inline constexpr llvm::StringLiteral kInterCoreBufCount = "ssbuffer.inter_core_buf_count";
 inline constexpr llvm::StringLiteral kLoadStoreBufCount = "ssbuffer.load_store_buf_count";
 inline constexpr llvm::StringLiteral kAnalyzeFlagId = "ssbuffer.analyze_flag_id";
+inline constexpr llvm::StringLiteral kLoopId = "ssbuffer.loop_id";
 inline constexpr llvm::StringLiteral kLoopCarriedL0C = "ssbuffer.loop_carried_l0c";
 inline constexpr llvm::StringLiteral kCrossDeps = "ssbuffer.crossDeps";
 inline constexpr llvm::StringLiteral kIntraDeps = "ssbuffer.intraDeps";

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
@@ -77,9 +77,15 @@ private:
   int transferIndex = 0;
   int markAllocIndex = 0;
 
+  llvm::DenseMap<int, llvm::SmallVector<LoopLikeOpInterface>> loopInclusions;
+  llvm::DenseSet<int> singleLoopSet;
+
   llvm::DenseMap<mlir::Value, mlir::Value> vecValueMapping;
   llvm::DenseMap<mlir::Value, mlir::Value> cubeValueMapping;
   SSBufferManager ssbufferManager;
+
+  void analyzeLoopInclusion();
+  void moveStartEndSync(mlir::OpBuilder &builder);
 
   mlir::LogicalResult processDependencies(FlagIdManager &flagManager, FlagIdReuseManager &flagIdReuseManager);
   mlir::LogicalResult handleVectorToCube(mlir::OpBuilder &builder,

--- a/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/RemoveAttributes.cpp
@@ -42,7 +42,7 @@ static constexpr const char *DEBUG_TYPE = "RemoveAttributes";
 
 // if extra attr is needed, add to ut @
 // third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/test-remove-attrs.mlir
-static constexpr llvm::StringLiteral kAttrsToRemove[] {kBlockId, kCoreType, kTransferId, kMainLoop, kCubeFirst, kVectorFirst, kAddFromMatmul, kIntraBuffer, kAnalyzeFlagId, kLoopCarriedL0C, kMatmulADep, kMatmulBDep, kMatmulExtract, kCrossDeps, kMemCrossDeps, kClone, kIntraBufCount, kInterCoreBufCount, kLoadStoreBufCount, kInsertionOptimization, kEnableUbRefineOpt};
+static constexpr llvm::StringLiteral kAttrsToRemove[] {kBlockId, kCoreType, kTransferId, kMainLoop, kCubeFirst, kVectorFirst, kAddFromMatmul, kIntraBuffer, kAnalyzeFlagId, kLoopId, kLoopCarriedL0C, kMatmulADep, kMatmulBDep, kMatmulExtract, kCrossDeps, kMemCrossDeps, kClone, kIntraBufCount, kInterCoreBufCount, kLoadStoreBufCount, kInsertionOptimization, kEnableUbRefineOpt};
 
 void RemoveSsbufAttrPass::runOnOperation()
 {

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -127,6 +127,13 @@ static void attachAnalyzeFlagIdTag(Operation *op)
     op->setAttr(CVPipeline::kAnalyzeFlagId, UnitAttr::get(ctx));
 }
 
+static void attachLoopIdTag(Operation *op, int loopId) {
+  MLIRContext *ctx = op->getContext();
+  op->setAttr(
+      CVPipeline::kLoopId,
+      IntegerAttr::get(IntegerType::get(ctx, kIntegerBitWidth), loopId));
+}
+
 // Block Start/End Operation Retrieval
 std::pair<mlir::Operation *, mlir::Operation *> InterCoreTransferAndSyncPass::getBlockStartEnd(int targetId,
     mlir::ModuleOp module)
@@ -1035,6 +1042,12 @@ void InterCoreTransferAndSyncPass::insertInterCoreSync(
         attachAnalyzeFlagIdTag(setOpForWrite);
         attachAnalyzeFlagIdTag(setOpForStart);
         attachAnalyzeFlagIdTag(waitOpForEnd);
+
+        auto loopId =
+            mainLoopOp->getAttrOfType<IntegerAttr>(CVPipeline::kLoopId).getInt();
+        attachLoopIdTag(setOpForStart, loopId);
+        attachLoopIdTag(waitOpForEnd, loopId);
+    
         // E2: register every set->wait pair of this transfer, not just the
         // loop start/end pair. Each pair is the only proof of cross-core
         // ordering for the sync ops it connects.
@@ -1485,6 +1498,89 @@ void InterCoreTransferAndSyncPass::sortDependencies(llvm::SmallVector<Dependency
     });
 }
 
+void InterCoreTransferAndSyncPass::analyzeLoopInclusion() {
+  loopInclusions.clear();
+  int maxLoopId = -1;
+  module.walk<WalkOrder::PreOrder>([&](Operation *op) {
+    auto loopOp = dyn_cast<LoopLikeOpInterface>(op);
+    if (!loopOp) {
+      return;
+    }
+
+    int loopId = 0;
+    Operation *parentLoop =
+        loopOp.getOperation()->getParentOfType<LoopLikeOpInterface>();
+    while (parentLoop) {
+      ++loopId;
+      parentLoop = parentLoop->getParentOfType<LoopLikeOpInterface>();
+    }
+    loopOp->setAttr(
+        CVPipeline::kLoopId,
+        IntegerAttr::get(
+            IntegerType::get(loopOp->getContext(), kIntegerBitWidth), loopId));
+    loopInclusions[loopId].push_back(loopOp);
+    maxLoopId = std::max(maxLoopId, loopId);
+  });
+  for (int loopId = 0; loopId <= maxLoopId; ++loopId) {
+    if (loopInclusions[loopId].size() != 1) {
+      break;
+    }
+    bool allSingle = true;
+    for (int outerId = loopId - 1; outerId >= 0; --outerId) {
+      if (loopInclusions[outerId].size() != 1) {
+        allSingle = false;
+        break;
+      }
+    }
+    if (allSingle) {
+      singleLoopSet.insert(loopId);
+    }
+  }
+}
+
+void InterCoreTransferAndSyncPass::moveStartEndSync(OpBuilder &builder) {
+  llvm::SmallVector<Operation *> startSyncOps;
+  llvm::SmallVector<Operation *> endSyncOps;
+  module.walk<WalkOrder::PreOrder>([&](Operation *op) {
+    if (!op->hasAttr(CVPipeline::kLoopId) ||
+        !(isa<hivm::SyncBlockSetOp, hivm::SyncBlockWaitOp>(op))) {
+      return;
+    }
+    auto loopId = op->getAttrOfType<IntegerAttr>(CVPipeline::kLoopId).getInt();
+    auto it = singleLoopSet.find(loopId);
+    if (it != singleLoopSet.end()) {
+      if (isa<hivm::SyncBlockSetOp>(op)) {
+        startSyncOps.push_back(op);
+      } else if (isa<hivm::SyncBlockWaitOp>(op)) {
+        endSyncOps.push_back(op);
+      }
+    }
+  });
+
+  if (loopInclusions.count(0) == 0 || loopInclusions[0].empty()) {
+    return;
+  }
+  Operation *outerLoop = loopInclusions[0][0];
+  if (!outerLoop) {
+    return;
+  }
+  // move startSyncOps and endSyncOps to the outer loop
+  builder.setInsertionPoint(outerLoop);
+  for (auto it = startSyncOps.begin(); it != startSyncOps.end(); ++it) {
+    builder.clone(**it);
+  }
+  builder.setInsertionPointAfter(outerLoop);
+  for (auto it = endSyncOps.rbegin(); it != endSyncOps.rend(); ++it) {
+    builder.clone(**it);
+  }
+  for (auto op : startSyncOps) {
+    op->erase();
+  }
+  for (auto op : endSyncOps) {
+    op->erase();
+  }
+}
+
 // Main Processing
 LogicalResult InterCoreTransferAndSyncPass::processDependencies(
     FlagIdManager &flagManager, FlagIdReuseManager &flagIdReuseManager)
@@ -1498,6 +1594,9 @@ LogicalResult InterCoreTransferAndSyncPass::processDependencies(
         return failure();
     }
 
+    // Analyze loop nesting before inserting inter-core transfer/sync.
+    analyzeLoopInclusion();
+    
     llvm::SmallVector<DependencyInfo> &V2CDependencies = info.getV2CDependencies();
     sortDependencies(V2CDependencies, module);
     LOG_DEBUG("[DEBUG] V2CDependencies size: " << V2CDependencies.size() << "\n");
@@ -1565,6 +1664,9 @@ LogicalResult InterCoreTransferAndSyncPass::processDependencies(
         DenseMap<int, int> remapResult = flagIdReuseManager.reuseInterCoreTransferFlagIds(analyzeFlagIdOps);
         remapInterCoreTransferFlagIds(remapResult);
     }
+    
+    // move start/end sync ops
+    moveStartEndSync(builder);
 
     LOG_DEBUG("InterCoreTransferAndSyncPass success!\n");
 


### PR DESCRIPTION
# SUMMARY
move set_for_start_op & wait_for_end_op out of all loops in single loop cases
*single loop case means there's no parallel loop


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
