### PR TITLE
[ssbuffer](chore) refactoring and optimization of  ExpSubfPatternPass

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -172,10 +172,6 @@ inline bool isMainLoopOp(Operation *op) {
 
 CoreType getCoreTypeOfSimpleOpOrCf(Operation *op);
 
-inline bool isCubeSimpleOpOrCf(Operation *op) {
-  return !isSyncOp(op) && getCoreTypeOfSimpleOpOrCf(op) == CoreType::CUBE_ONLY;
-}
-
 inline bool isVectorSimpleOpOrCf(Operation *op) {
   return getCoreTypeOfSimpleOpOrCf(op) == CoreType::VECTOR_ONLY;
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/ExpSubfPatternPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/ExpSubfPatternPass.cpp
@@ -40,31 +40,53 @@ using namespace math;
 
 namespace {
 
-static bool matchExpFromSubf(arith::SubFOp subfOp, math::ExpOp &expOp,
-                             CVPipeline::ComputeBlockIdManager &bm) {
-
+static math::ExpOp matchExpFromSubf(arith::SubFOp subfOp) {
   auto subfResult = subfOp.getResult();
   if (!subfOp->hasOneUse()) {
     LOG_DEBUG("SubF has multiple users, skipping");
-    return false;
+    return nullptr;
   }
 
   Operation *user = *subfResult.getUsers().begin();
-  expOp = dyn_cast<math::ExpOp>(user);
+  auto expOp = dyn_cast<math::ExpOp>(user);
   if (!expOp) {
     LOG_DEBUG("SubF user is not ExpOp, skipping");
-    return false;
+    return nullptr;
   }
   if (expOp->getBlock() != subfOp->getBlock()) {
     LOG_DEBUG("SubF and ExpOp not in the same Block, skipping");
+    return nullptr;
+  }
+  return expOp;
+}
+
+static bool isValidExt(arith::SubFOp subfOp, arith::ExtFOp extOp) {
+  if (extOp->getBlock() != subfOp->getBlock()) {
+    LOG_DEBUG("SubF and ExtfOp not in the same Block, skipping");
     return false;
   }
+  auto inType = extOp.getIn().getType();
+  if (!inType.isF16()) {
+    LOG_DEBUG("ExtF input types are not both f16, skipping extended pattern");
+    return false;
+  }
+  auto outType = extOp.getOut().getType();
+  if (!outType.isF32()) {
+    LOG_DEBUG("ExtF output types are not both f32, skipping extended pattern");
+    return false;
+  }
+
+  auto extRes = extOp.getResult();
+  if (!extRes.hasOneUse() || *extRes.getUsers().begin() != subfOp) {
+    LOG_DEBUG("ExtF has multiple users or not used by subf, skipping");
+    return false;
+  }
+
   return true;
 }
 
-static bool matchExtfFromSubf(arith::SubFOp subfOp,
-                              SmallVector<arith::ExtFOp, 2> &extfOps,
-                              CVPipeline::ComputeBlockIdManager &bm) {
+static std::optional<SmallVector<arith::ExtFOp, 2>>
+matchExtfFromSubf(arith::SubFOp subfOp) {
   auto lhs = subfOp.getLhs();
   auto rhs = subfOp.getRhs();
 
@@ -74,58 +96,25 @@ static bool matchExtfFromSubf(arith::SubFOp subfOp,
   if (!lhsDef || !rhsDef) {
     LOG_DEBUG(
         "SubF operands are not both from ExtFOp, skipping extended pattern");
-    return false;
-  }
-  if (lhsDef->getBlock() != subfOp->getBlock() ||
-      rhsDef->getBlock() != subfOp->getBlock()) {
-    LOG_DEBUG("SubF and ExtfOp not in the same Block, skipping");
-    return false;
+    return std::nullopt;
   }
 
-  auto lhsInType = lhsDef.getIn().getType();
-  auto rhsInType = rhsDef.getIn().getType();
-  auto lhsOutType = lhsDef.getOut().getType();
-  auto rhsOutType = rhsDef.getOut().getType();
-
-  if (!lhsInType.isF16() || !rhsInType.isF16()) {
-    LOG_DEBUG("ExtF input types are not both f16, skipping extended pattern");
-    return false;
+  if (!isValidExt(subfOp, lhsDef) || !isValidExt(subfOp, rhsDef)) {
+    return std::nullopt;
   }
 
-  if (!lhsOutType.isF32() || !rhsOutType.isF32()) {
-    LOG_DEBUG("ExtF output types are not both f32, skipping extended pattern");
-    return false;
-  }
-
-  SmallVector<Operation *, 2> lhsUsers;
-  for (Operation *user : lhsDef.getResult().getUsers()) {
-    lhsUsers.push_back(user);
-  }
-  if (lhsUsers.size() != 1 || lhsUsers[0] != subfOp) {
-    LOG_DEBUG("Left ExtF has multiple users or not used by subf, skipping");
-    return false;
-  }
-
-  SmallVector<Operation *, 2> rhsUsers;
-  for (Operation *user : rhsDef.getResult().getUsers()) {
-    rhsUsers.push_back(user);
-  }
-  if (rhsUsers.size() != 1 || rhsUsers[0] != subfOp) {
-    LOG_DEBUG("Right ExtF has multiple users or not used by subf, skipping");
-    return false;
-  }
-
+  SmallVector<arith::ExtFOp, 2> extfOps;
   extfOps.push_back(lhsDef);
   extfOps.push_back(rhsDef);
-  return true;
+  return extfOps;
 }
 
 static void processSubfOp(arith::SubFOp subfOp,
                           CVPipeline::ComputeBlockIdManager &bm) {
   int subfBlockId = bm.getBlockIdByOp(subfOp);
 
-  math::ExpOp expOp;
-  if (!matchExpFromSubf(subfOp, expOp, bm)) {
+  auto expOp = matchExpFromSubf(subfOp);
+  if (!expOp) {
     return;
   }
 
@@ -138,17 +127,19 @@ static void processSubfOp(arith::SubFOp subfOp,
     LOG_DEBUG("Exp blockId already matches subf, skipping update");
   }
 
-  SmallVector<arith::ExtFOp, 2> extfOps;
-  if (matchExtfFromSubf(subfOp, extfOps, bm)) {
-    for (auto extfOp : extfOps) {
-      int extfBlockId = bm.getBlockIdByOp(extfOp);
-      if (extfBlockId != subfBlockId) {
-        LOG_DEBUG("Updating extf blockId from " << extfBlockId << " to "
-                                                << subfBlockId);
-        bm.updateBlockId(extfOp, subfBlockId);
-      } else {
-        LOG_DEBUG("ExtF blockId already matches subf, skipping update");
-      }
+  auto extfOps = matchExtfFromSubf(subfOp);
+  if (!extfOps) {
+    return;
+  }
+
+  for (auto extfOp : *extfOps) {
+    int extfBlockId = bm.getBlockIdByOp(extfOp);
+    if (extfBlockId != subfBlockId) {
+      LOG_DEBUG("Updating extf blockId from " << extfBlockId << " to "
+                                              << subfBlockId);
+      bm.updateBlockId(extfOp, subfBlockId);
+    } else {
+      LOG_DEBUG("ExtF blockId already matches subf, skipping update");
     }
   }
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/PlanCubeBlock.cpp
@@ -64,6 +64,14 @@ static constexpr const char *DEBUG_TYPE = "plan-cube-block";
 
 static bool isMatmulOp(Operation *op) { return isa<linalg::MatmulOp>(op); }
 
+static bool isCubeSimpleOpOrCf(Operation *op) {
+  if (op->getBlock()->mightHaveTerminator() &&
+      op == op->getBlock()->getTerminator()) {
+    return false;
+  }
+  return !isSyncOp(op) && getCoreTypeOfSimpleOpOrCf(op) == CoreType::CUBE_ONLY;
+}
+
 namespace {
 
 class SeedRegionPlanner {


### PR DESCRIPTION
This commit simplifies the logic of ExpSubfPatternPass by extracting common sub-functions and simplifying condition check. It performs a light refactor of ExpSubfPatternPass.
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
