### PR TITLE
[UT](fix) test_index_select doesn't generate gather_load

### DIFF
--- a/third_party/ascend/unittest/pytest_ut/test_simd_simt.py
+++ b/third_party/ascend/unittest/pytest_ut/test_simd_simt.py
@@ -617,7 +617,7 @@ def index_select_kernel(
 
 @simd_simt_910_95_only
 def test_index_select():
-    N, D, M = 64, 32, 8
+    N, D, M = 64, 8, 8
 
     src = torch.arange(N * D, dtype=torch.float32, device='npu').reshape(N, D)
     indices = torch.tensor([3, 10, 0, 55, 7, 20, 63, 1], dtype=torch.int64, device='npu')


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
