### PR TITLE
[ControlFlowOpt](fix) preserve same-base pointer provenance

### DIFF
--- a/third_party/ascend/include/TritonControlFlowOpt/ControlFlowRewrite.h
+++ b/third_party/ascend/include/TritonControlFlowOpt/ControlFlowRewrite.h
@@ -108,6 +108,18 @@ public:
   /// after cloning so later operations can reuse their exact component state.
   virtual bool shouldDecomposeOperation(Operation *op) const = 0;
 
+  /// Whether a rebuilt value may be used as a direct decomposition-cache key.
+  ///
+  /// The default preserves the existing behavior for policies whose rebuilt
+  /// values are already consumable by downstream conversion. A policy that
+  /// rebuilds an opaque tensor-of-pointers can reject the cache entry so the
+  /// next consumer re-analyzes the pointer producer and follows its normal
+  /// scalar-address lowering path instead of exposing tensor.extract of a
+  /// scalar Triton pointer to T2L.
+  virtual bool shouldCacheRebuiltDecomposition(const DecomposedValue &) const {
+    return true;
+  }
+
   /// Whether rewritten loops owned by this policy must expose their descriptor
   /// slots to downstream conversion. The shared rewrite records the exact
   /// expanded result indices because only it knows both old and new signatures.

--- a/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowRewrite.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowRewrite.cpp
@@ -171,10 +171,10 @@ struct RewriteEnv {
   }
 
   /// Records both ways in which later rewriting must understand an original
-  /// value. oldValue is the key from the original IR, info is its
-  /// component descriptor, and rebuiltValue is the pointer-like SSA value
-  /// created in the replacement IR. Pointer-aware code reads info from
-  /// decomposedValues; ordinary cloned users read rebuiltValue through
+  /// value. oldValue is the key from the original IR, info is its component
+  /// descriptor, and rebuiltValue is the pointer-like SSA value created in the
+  /// replacement IR. Pointer-aware code may encounter either SSA value, so
+  /// both keys resolve to info; ordinary cloned users read rebuiltValue through
   /// valueMapping.
   ///
   /// For example, after rebuilding an expanded loop argument:
@@ -189,13 +189,20 @@ struct RewriteEnv {
   void recordDecomposition(Value oldValue, const DecomposedValue &info,
                            Value rebuiltValue) {
     decomposedValues[oldValue] = info;
+    // A later cloned operation may consume the rebuilt value directly rather
+    // than the original value. Cache the same descriptor under that SSA value
+    // so chained pointer producers reuse the existing decomposition when the
+    // active policy says that the rebuilt representation is downstream-safe.
+    if (policy.shouldCacheRebuiltDecomposition(info))
+      decomposedValues[rebuiltValue] = info;
     valueMapping.map(oldValue, rebuiltValue);
   }
 
   // Maps values from the original region to values in the replacement region.
   IRMapping valueMapping;
-  // Concrete component state keyed by original values. Keeping this alongside
-  // the mapping lets pointer producers be flattened across nested rewrites.
+  // Concrete component state keyed by original and rebuilt pointer values.
+  // Keeping this alongside the mapping lets chained pointer producers and
+  // nested rewrites reuse an already materialized descriptor.
   DenseMap<Value, DecomposedValue> decomposedValues;
   const ControlFlowRewritePolicy &policy;
   const ControlFlowRewritePlan &plan;

--- a/third_party/ascend/lib/TritonControlFlowOpt/TensorPtrDecompose.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/TensorPtrDecompose.cpp
@@ -1976,6 +1976,14 @@ public:
     return isa<triton::AddPtrOp>(op);
   }
 
+  bool
+  shouldCacheRebuiltDecomposition(const DecomposedValue &value) const override {
+    // A scalar base can be reconstructed as an integer address by T2U. An
+    // opaque tensor-of-pointers base must instead be re-analyzed so T2U can
+    // lower each lane to an integer address before T2L sees it.
+    return hasValidLayout(value) && hasScalarBase(value);
+  }
+
   bool requiresPointerDescriptorBoundaryMarker() const override { return true; }
 
   bool shouldMarkOperationRecomposition(Operation *op) const override {

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scf_pointer_decouple.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scf_pointer_decouple.mlir
@@ -271,6 +271,44 @@ module {
 // -----
 
 module {
+  tt.func public @if_tensor_ptr_same_base_chained_addptr(
+      %base: !tt.ptr<f32>, %output: !tt.ptr<f32>, %cond: i1) {
+    %then_offset = arith.constant dense<2> : tensor<16xi32>
+    %else_offset = arith.constant dense<5> : tensor<16xi32>
+    %lane = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %selected = scf.if %cond -> (tensor<16x!tt.ptr<f32>>) {
+      %base_tensor = tt.splat %base : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+      %lane_ptr = tt.addptr %base_tensor, %lane : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      %then_ptr = tt.addptr %lane_ptr, %then_offset : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      scf.yield %then_ptr : tensor<16x!tt.ptr<f32>>
+    } else {
+      %base_tensor = tt.splat %base : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+      %lane_ptr = tt.addptr %base_tensor, %lane : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      %else_ptr = tt.addptr %lane_ptr, %else_offset : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      scf.yield %else_ptr : tensor<16x!tt.ptr<f32>>
+    }
+    %output_tensor = tt.splat %output : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+    %output_ptr = tt.addptr %output_tensor, %lane : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+    %loaded = tt.load %selected : tensor<16x!tt.ptr<f32>>
+    tt.store %output_ptr, %loaded : tensor<16x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: tt.func public @if_tensor_ptr_same_base_chained_addptr
+// CHECK:       %[[CHAINED_OFF:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:         scf.yield %{{.*}} : i32
+// CHECK:       } else {
+// CHECK:         scf.yield %{{.*}} : i32
+// CHECK:       }
+// CHECK:       %[[CHAINED_PTR:.*]] = tt.addptr
+// CHECK-SAME:  PointerDescriptorOffsetForm = "strided_1d"
+// CHECK-SAME:  PointerDescriptorRebuild
+// CHECK:       tt.load %[[CHAINED_PTR]] : tensor<16x!tt.ptr<f32>>
+
+// -----
+
+module {
   tt.func public @while_block_ptr_large_step(%base: !tt.ptr<f16>, %n: i32) -> !tt.ptr<tensor<32xf16>> {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32


### PR DESCRIPTION
## Summary
- Preserve descriptor provenance for rebuilt pointer values across chained pointer rewrites.
- Add a regression MLIR case covering same-base tensor pointer control flow with chained addptr operations.
- 
- The change is contained in ControlFlowOpt and does not alter unrelated lowering paths.