### PR TITLE
[backend](fix) remove lib-call no-inline option

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -505,23 +505,6 @@ def get_common_bishengir_compile_options(metadata):
     return [bishengir_target_opt]
 
 
-def _needs_lib_call_no_inline(metadata):
-    """Return whether the target needs the CANN 9.1 hacc.noinline workaround."""
-    arch = metadata['target'].arch
-    return arch.startswith("Ascend950")
-
-
-@functools.lru_cache()
-def _npu_compiler_supports_option(compiler_path: str, option: str) -> bool:
-    """Check an optional BiShengIR flag instead of assuming toolchain parity."""
-    try:
-        result = subprocess.run([compiler_path, "--help"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
-                                timeout=10, check=False)
-    except (OSError, subprocess.SubprocessError):
-        return False
-    return option in result.stdout
-
-
 def get_auto_bind_sub_block_option(metadata):
     # auto_tile_and_bind_subblock is read from the module.
     # enable_auto_bind_sub_block is set by the user and has a higher priority.
@@ -735,9 +718,6 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
                 "--enable-hfusion-compile=true",
                 "--enable-triton-kernel-compile=true",
             ]
-            if (_needs_lib_call_no_inline(metadata)
-                    and _npu_compiler_supports_option(npu_compiler_path, "--enable-lib-call-no-inline")):
-                _compile_option_list += ["--enable-lib-call-no-inline=false"]
         bisheng_options = metadata["bisheng_options"]
         if bisheng_options is not None:
             _compile_option_list += [f"--append-bisheng-options={bisheng_options}"]
@@ -948,9 +928,6 @@ def linalg_to_bin_enable_npu_compile_A2_A3(linalg: str, metadata, opt):
                 bishengir_hivm_opt,
                 "--enable-triton-kernel-compile=true",
             ]
-            if (_needs_lib_call_no_inline(metadata)
-                    and _npu_compiler_supports_option(npu_compiler_path, "--enable-lib-call-no-inline")):
-                _compile_option_list += ["--enable-lib-call-no-inline=false"]
 
         _compile_option_list += ["--mlir-print-ir-after-failure"]
         _compile_option_list += ["--mlir-print-stacktrace-on-diagnostic"]


### PR DESCRIPTION
## Summary

- port #1887 from `main-dev` to `main`
- stop appending `--enable-lib-call-no-inline=false` to BiShengIR commands in both Linalg-to-NPUbin paths
- remove the Ascend950 target check and compiler capability probe that were only used for this argument
- keep the remaining unordered-lock changes from #1636 unchanged

## Motivation

The explicit override was introduced by #1636. A reported Ascend950 workload passes with the 2026-08-27 Triton-Ascend build but fails at runtime with the 2026-08-28 build that contains this override. The captured TTIR and TTAdapter IR are unchanged across those builds, while the generated NPU binary differs.

This change restores the pre-#1636 command-line behavior and lets BiShengIR use its default lib-call inlining policy.

## Testing

- `PYTHONDONTWRITEBYTECODE=1 conda run -n wz_build python -m pytest -q third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py` (`3 passed, 28 skipped`)
- affected-file pre-commit, run twice successfully
- `git diff --check`
- repository source search confirms the option and its dedicated helpers are absent

NPU runtime validation was not run locally because the reported reproducer is on another Ascend950 environment.
