### PR TITLE
[ControlFlowOpt](feat) support marked affine index carriers

### DIFF
--- a/third_party/ascend/include/TritonControlFlowOpt/ControlFlowRewrite.h
+++ b/third_party/ascend/include/TritonControlFlowOpt/ControlFlowRewrite.h
@@ -108,6 +108,18 @@ public:
   /// after cloning so later operations can reuse their exact component state.
   virtual bool shouldDecomposeOperation(Operation *op) const = 0;
 
+  /// Whether a rebuilt value may be used as a direct decomposition-cache key.
+  ///
+  /// The default preserves the existing behavior for policies whose rebuilt
+  /// values are already consumable by downstream conversion. A policy that
+  /// rebuilds an opaque tensor-of-pointers can reject the cache entry so the
+  /// next consumer re-analyzes the pointer producer and follows its normal
+  /// scalar-address lowering path instead of exposing tensor.extract of a
+  /// scalar Triton pointer to T2L.
+  virtual bool shouldCacheRebuiltDecomposition(const DecomposedValue &) const {
+    return true;
+  }
+
   /// Whether rewritten loops owned by this policy must expose their descriptor
   /// slots to downstream conversion. The shared rewrite records the exact
   /// expanded result indices because only it knows both old and new signatures.

--- a/third_party/ascend/include/TritonToLinalg/BlockPtrAnalysis.h
+++ b/third_party/ascend/include/TritonToLinalg/BlockPtrAnalysis.h
@@ -58,10 +58,11 @@ inline constexpr llvm::StringLiteral kScalarPointerCarrierAttr =
 /// legacy BlockData loop expansion solely because of their producer.
 bool needsLegacyBlockDataLoopRewrite(LoopLikeOpInterface loopOp);
 
-/// Returns the non-descriptor loop slots that carry a make-range integer
-/// tensor through a CFO-owned SCF boundary. These slots are safe to lower with
-/// the legacy BlockData mask path; pointer descriptor slots and opaque tensor
-/// carriers are deliberately excluded.
+/// Returns the non-descriptor loop slots that carry a make-range-derived
+/// affine integer tensor through a CFO-owned SCF boundary. Uniform scalar,
+/// splat, expansion, broadcast and linear arithmetic preserve that provenance.
+/// These slots are safe to lower with the legacy BlockData path; pointer
+/// descriptor slots and opaque numerical tensors are deliberately excluded.
 SmallVector<unsigned>
 getMarkedMakeRangeCarrierSlots(LoopLikeOpInterface loopOp);
 

--- a/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowRewrite.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowRewrite.cpp
@@ -171,10 +171,10 @@ struct RewriteEnv {
   }
 
   /// Records both ways in which later rewriting must understand an original
-  /// value. oldValue is the key from the original IR, info is its
-  /// component descriptor, and rebuiltValue is the pointer-like SSA value
-  /// created in the replacement IR. Pointer-aware code reads info from
-  /// decomposedValues; ordinary cloned users read rebuiltValue through
+  /// value. oldValue is the key from the original IR, info is its component
+  /// descriptor, and rebuiltValue is the pointer-like SSA value created in the
+  /// replacement IR. Pointer-aware code may encounter either SSA value, so
+  /// both keys resolve to info; ordinary cloned users read rebuiltValue through
   /// valueMapping.
   ///
   /// For example, after rebuilding an expanded loop argument:
@@ -189,13 +189,20 @@ struct RewriteEnv {
   void recordDecomposition(Value oldValue, const DecomposedValue &info,
                            Value rebuiltValue) {
     decomposedValues[oldValue] = info;
+    // A later cloned operation may consume the rebuilt value directly rather
+    // than the original value. Cache the same descriptor under that SSA value
+    // so chained pointer producers reuse the existing decomposition when the
+    // active policy says that the rebuilt representation is downstream-safe.
+    if (policy.shouldCacheRebuiltDecomposition(info))
+      decomposedValues[rebuiltValue] = info;
     valueMapping.map(oldValue, rebuiltValue);
   }
 
   // Maps values from the original region to values in the replacement region.
   IRMapping valueMapping;
-  // Concrete component state keyed by original values. Keeping this alongside
-  // the mapping lets pointer producers be flattened across nested rewrites.
+  // Concrete component state keyed by original and rebuilt pointer values.
+  // Keeping this alongside the mapping lets chained pointer producers and
+  // nested rewrites reuse an already materialized descriptor.
   DenseMap<Value, DecomposedValue> decomposedValues;
   const ControlFlowRewritePolicy &policy;
   const ControlFlowRewritePlan &plan;

--- a/third_party/ascend/lib/TritonControlFlowOpt/TensorPtrDecompose.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/TensorPtrDecompose.cpp
@@ -1976,6 +1976,14 @@ public:
     return isa<triton::AddPtrOp>(op);
   }
 
+  bool
+  shouldCacheRebuiltDecomposition(const DecomposedValue &value) const override {
+    // A scalar base can be reconstructed as an integer address by T2U. An
+    // opaque tensor-of-pointers base must instead be re-analyzed so T2U can
+    // lower each lane to an integer address before T2L sees it.
+    return hasValidLayout(value) && hasScalarBase(value);
+  }
+
   bool requiresPointerDescriptorBoundaryMarker() const override { return true; }
 
   bool shouldMarkOperationRecomposition(Operation *op) const override {

--- a/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
@@ -2593,15 +2593,107 @@ bool needsLegacyBlockDataLoopRewrite(LoopLikeOpInterface loopOp) {
   return false;
 }
 
-static bool isMakeRangeCarrier(Value value) {
+enum class MakeRangeCarrierKind { Unsupported, Uniform, Affine };
+
+// Classify the narrow integer expression subset that BlockDataParser can
+// losslessly turn into offsets and strides. Affine means that the expression
+// contains a make_range lane coordinate; Uniform means that every lane has
+// the same value and can therefore be used as an affine coefficient or
+// displacement. Unknown and lane-varying producers stay Unsupported so a CFO
+// descriptor loop never sends ordinary numerical tensors through BlockData.
+static MakeRangeCarrierKind analyzeMakeRangeCarrier(
+    Value value,
+    llvm::SmallDenseMap<Value, MakeRangeCarrierKind> &classification) {
+  if (auto cached = classification.find(value); cached != classification.end())
+    return cached->second;
+
+  auto remember = [&](MakeRangeCarrierKind kind) {
+    classification.try_emplace(value, kind);
+    return kind;
+  };
+  auto isIntegerLike = [](Type type) {
+    if (type.isIndex() || isa<IntegerType>(type))
+      return true;
+    auto shapedType = dyn_cast<ShapedType>(type);
+    return shapedType && isa<IntegerType>(shapedType.getElementType());
+  };
+  if (!isIntegerLike(value.getType()))
+    return remember(MakeRangeCarrierKind::Unsupported);
+
   Operation *producer = value.getDefiningOp();
-  if (!producer)
-    return false;
+  if (!producer) {
+    // A scalar block/function argument is lane-uniform. A tensor argument has
+    // unknown per-lane contents and cannot establish affine provenance.
+    return remember(value.getType().isIndex() ||
+                            isa<IntegerType>(value.getType())
+                        ? MakeRangeCarrierKind::Uniform
+                        : MakeRangeCarrierKind::Unsupported);
+  }
+
   if (isa<triton::MakeRangeOp>(producer))
-    return true;
-  if (auto cast = dyn_cast<tensor::CastOp>(producer))
-    return isMakeRangeCarrier(cast.getSource());
-  return false;
+    return remember(MakeRangeCarrierKind::Affine);
+
+  // Program identifiers are scalar and therefore uniform across the tensor
+  // lanes. They can participate in an affine carrier through splat, cast, and
+  // integer arithmetic without introducing an unknown per-lane value.
+  if (isa<triton::GetProgramIdOp, triton::GetNumProgramsOp>(producer))
+    return remember(MakeRangeCarrierKind::Uniform);
+
+  if (auto constant = dyn_cast<arith::ConstantOp>(producer)) {
+    Attribute attr = constant.getValue();
+    if (isa<IntegerAttr>(attr))
+      return remember(MakeRangeCarrierKind::Uniform);
+    auto elements = dyn_cast<DenseElementsAttr>(attr);
+    return remember(elements && elements.isSplat() &&
+                            isa<IntegerType>(elements.getElementType())
+                        ? MakeRangeCarrierKind::Uniform
+                        : MakeRangeCarrierKind::Unsupported);
+  }
+
+  // These operations preserve whether their only input is uniform or affine.
+  if (isa<tensor::CastOp, arith::ExtSIOp, triton::SplatOp, triton::ExpandDimsOp,
+          triton::BroadcastOp>(producer))
+    return remember(
+        analyzeMakeRangeCarrier(producer->getOperand(0), classification));
+
+  auto combineLinear = [&](Value lhs, Value rhs) {
+    MakeRangeCarrierKind lhsKind = analyzeMakeRangeCarrier(lhs, classification);
+    MakeRangeCarrierKind rhsKind = analyzeMakeRangeCarrier(rhs, classification);
+    if (lhsKind == MakeRangeCarrierKind::Unsupported ||
+        rhsKind == MakeRangeCarrierKind::Unsupported)
+      return MakeRangeCarrierKind::Unsupported;
+    if (lhsKind == MakeRangeCarrierKind::Affine ||
+        rhsKind == MakeRangeCarrierKind::Affine)
+      return MakeRangeCarrierKind::Affine;
+    return MakeRangeCarrierKind::Uniform;
+  };
+  if (auto add = dyn_cast<arith::AddIOp>(producer))
+    return remember(combineLinear(add.getLhs(), add.getRhs()));
+  if (auto sub = dyn_cast<arith::SubIOp>(producer))
+    return remember(combineLinear(sub.getLhs(), sub.getRhs()));
+  if (auto mul = dyn_cast<arith::MulIOp>(producer)) {
+    MakeRangeCarrierKind lhsKind =
+        analyzeMakeRangeCarrier(mul.getLhs(), classification);
+    MakeRangeCarrierKind rhsKind =
+        analyzeMakeRangeCarrier(mul.getRhs(), classification);
+    if (lhsKind == MakeRangeCarrierKind::Unsupported ||
+        rhsKind == MakeRangeCarrierKind::Unsupported ||
+        (lhsKind == MakeRangeCarrierKind::Affine &&
+         rhsKind == MakeRangeCarrierKind::Affine))
+      return remember(MakeRangeCarrierKind::Unsupported);
+    return remember(lhsKind == MakeRangeCarrierKind::Affine ||
+                            rhsKind == MakeRangeCarrierKind::Affine
+                        ? MakeRangeCarrierKind::Affine
+                        : MakeRangeCarrierKind::Uniform);
+  }
+
+  return remember(MakeRangeCarrierKind::Unsupported);
+}
+
+static bool isMakeRangeCarrier(Value value) {
+  llvm::SmallDenseMap<Value, MakeRangeCarrierKind> classification;
+  return analyzeMakeRangeCarrier(value, classification) ==
+         MakeRangeCarrierKind::Affine;
 }
 
 SmallVector<unsigned>

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -1829,10 +1829,11 @@ void TritonToLinalgPass::runOnOperation() {
   auto loopOpLegalFn = [](LoopLikeOpInterface loopOp) {
     Operation *op = loopOp.getOperation();
     if (op->hasAttr(controlflow::kPointerDescriptorBoundaryAttr)) {
-      // CFO descriptor loops may still carry a non-descriptor make_range
-      // tensor used by a load/store mask. Route only those loops through the
-      // narrow legacy mask-carrier rewrite; descriptor and opaque slots remain
-      // on the normal pointer-free boundary path.
+      // CFO descriptor loops may still carry a non-descriptor affine tensor
+      // derived from make_range and used by an address or load/store mask.
+      // Route only those proven slots through the narrow legacy rewrite;
+      // descriptor and opaque numerical slots remain on the normal
+      // pointer-free boundary path.
       if (!getMarkedMakeRangeCarrierSlots(loopOp).empty())
         return false;
       return hasPointerFreeControlFlowBoundary(loopOp);

--- a/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
@@ -320,6 +320,30 @@ bool isPointerDescriptorBoundaryResult(LoopLikeOpInterface loopOp,
                                          opResult.getResultNumber());
 }
 
+// Recover structured axes only when the carrier's own provenance already
+// proves that every lane is either affine, uniform, or a singleton axis.
+// Complete carriers without that proof remain opaque and keep the existing
+// indirect-access fallback.
+bool getRecoverableCarrierAxes(const PtrOffsetInfo &carrierInfo, unsigned rank,
+                               SmallVectorImpl<PtrOffsetInfo::AxisInfo> &axes) {
+  if (carrierInfo.getRank() != static_cast<int>(rank) ||
+      !carrierInfo.isStructured())
+    return false;
+
+  axes.clear();
+  axes.reserve(rank);
+  for (PtrOffsetInfo::AxisInfo axis : carrierInfo.getStructured()) {
+    if (axis == PtrOffsetInfo::AxisInfo::unstructured)
+      return false;
+    // A scalar-like value is lane-uniform, so it is a structured displacement
+    // even though the generic offset lattice records it separately.
+    axes.push_back(axis == PtrOffsetInfo::AxisInfo::scalarlike
+                       ? PtrOffsetInfo::AxisInfo::structured
+                       : axis);
+  }
+  return true;
+}
+
 } // namespace
 
 void parse(Value operand, const Location &loc, RewriterBase &rewriter,
@@ -582,6 +606,9 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
   auto structuredAxes = dyn_cast_or_null<DenseI32ArrayAttr>(
       op->getAttr(controlflow::kPointerDescriptorStructuredAxesAttr));
   auto resultType = dyn_cast<RankedTensorType>(op.getType());
+  auto baseSplat = ptr.getDefiningOp<triton::SplatOp>();
+  bool hasScalarPointerSplatBase =
+      baseSplat && isa<triton::PointerType>(baseSplat.getSrc().getType());
   SmallVector<PtrOffsetInfo::AxisInfo> descriptorAxes;
   if (structuredAxes) {
     if (!isRebuild || !resultType ||
@@ -614,13 +641,12 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
     auto offsetElementType =
         offsetType ? dyn_cast<IntegerType>(offsetType.getElementType())
                    : IntegerType();
-    auto baseSplat = ptr.getDefiningOp<triton::SplatOp>();
     if (!resultType || resultType.getRank() != 1 || !offsetType ||
         !isa<triton::PointerType>(resultType.getElementType()) ||
         !offsetElementType || offsetElementType.getWidth() > 64 ||
         resultType.getShape() != offsetType.getShape() ||
-        resultType.getEncoding() != offsetType.getEncoding() || !baseSplat ||
-        !isa<triton::PointerType>(baseSplat.getSrc().getType())) {
+        resultType.getEncoding() != offsetType.getEncoding() ||
+        !hasScalarPointerSplatBase) {
       op.emitOpError(
           "expected strided_1d on a rank-1 tensor pointer rebuilt from a "
           "scalar pointer base and a compatible ranked integer offset");
@@ -637,6 +663,11 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
   bool isCompleteOffsetCarrier = isRebuild && !isStridedRankOne;
   bool isDescriptorOwned =
       isRebuild || ptrOffsetInfo.isPointerDescriptorOwned();
+  bool descriptorIsOpaque =
+      !descriptorAxes.empty() &&
+      llvm::all_of(descriptorAxes, [](PtrOffsetInfo::AxisInfo axis) {
+        return axis == PtrOffsetInfo::AxisInfo::unstructured;
+      });
 
   if (isCompleteOffsetCarrier) {
     // The carrier is complete relative to the descriptor base, but parsing
@@ -656,6 +687,19 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
     if (offsetElementType.getWidth() > 64) {
       op.emitOpError("complete-offset carrier wider than i64 is unsupported");
       return;
+    }
+
+    SmallVector<PtrOffsetInfo::AxisInfo> recoveredAxes;
+    if (hasScalarPointerSplatBase && descriptorIsOpaque) {
+      // Only an entirely opaque descriptor can be upgraded from the carrier's
+      // own provenance. Mixed descriptors already contain the authoritative
+      // per-axis classification and must not enter the legacy recursive
+      // analysis, whose intermediate ranks need not match the result rank.
+      parse(offsetValue, op.getLoc(), rewriter, offsetMap);
+      auto carrierInfo = offsetMap.find(offsetValue);
+      if (carrierInfo != offsetMap.end())
+        getRecoverableCarrierAxes(carrierInfo->second, resultType.getRank(),
+                                  recoveredAxes);
     }
 
     RewriterBase::InsertionGuard guard(rewriter);
@@ -678,16 +722,16 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
     Value completeOffset = rewriter.create<arith::AddIOp>(
         op.getLoc(), baseDisplacement, offsetValue);
     ptrOffsetInfo.setOffset(completeOffset);
-    // setUnstructured() updates only the per-axis classification; it does not
-    // clear the independent scalar-like property inherited from a splatted
-    // base. A complete offset carrier is intentionally opaque here, so there
-    // is no proof that all lanes address the same element. Keep this state
-    // conservative and force the lane-wise memory-access path.
+    // Keep the historical opaque behavior unless the carrier analysis above
+    // proved every axis is structured or uniform.  A complete carrier can be
+    // lane-varying, so it must not be treated as structured by metadata alone.
     ptrOffsetInfo.setScalarLike(false);
-    if (descriptorAxes.empty())
-      ptrOffsetInfo.setUnstructured(resultType.getRank());
-    else
+    if (descriptorIsOpaque && !recoveredAxes.empty())
+      ptrOffsetInfo.setStructured(recoveredAxes);
+    else if (!descriptorAxes.empty())
       ptrOffsetInfo.setStructured(descriptorAxes);
+    else
+      ptrOffsetInfo.setUnstructured(resultType.getRank());
     ptrOffsetInfo.setPointerDescriptorOwned(true);
     offsetMap[op.getResult()] = ptrOffsetInfo;
     return;

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scf_pointer_decouple.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scf_pointer_decouple.mlir
@@ -271,6 +271,44 @@ module {
 // -----
 
 module {
+  tt.func public @if_tensor_ptr_same_base_chained_addptr(
+      %base: !tt.ptr<f32>, %output: !tt.ptr<f32>, %cond: i1) {
+    %then_offset = arith.constant dense<2> : tensor<16xi32>
+    %else_offset = arith.constant dense<5> : tensor<16xi32>
+    %lane = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %selected = scf.if %cond -> (tensor<16x!tt.ptr<f32>>) {
+      %base_tensor = tt.splat %base : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+      %lane_ptr = tt.addptr %base_tensor, %lane : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      %then_ptr = tt.addptr %lane_ptr, %then_offset : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      scf.yield %then_ptr : tensor<16x!tt.ptr<f32>>
+    } else {
+      %base_tensor = tt.splat %base : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+      %lane_ptr = tt.addptr %base_tensor, %lane : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      %else_ptr = tt.addptr %lane_ptr, %else_offset : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      scf.yield %else_ptr : tensor<16x!tt.ptr<f32>>
+    }
+    %output_tensor = tt.splat %output : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+    %output_ptr = tt.addptr %output_tensor, %lane : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+    %loaded = tt.load %selected : tensor<16x!tt.ptr<f32>>
+    tt.store %output_ptr, %loaded : tensor<16x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: tt.func public @if_tensor_ptr_same_base_chained_addptr
+// CHECK:       %[[CHAINED_OFF:.*]] = scf.if %{{.*}} -> (i32) {
+// CHECK:         scf.yield %{{.*}} : i32
+// CHECK:       } else {
+// CHECK:         scf.yield %{{.*}} : i32
+// CHECK:       }
+// CHECK:       %[[CHAINED_PTR:.*]] = tt.addptr
+// CHECK-SAME:  PointerDescriptorOffsetForm = "strided_1d"
+// CHECK-SAME:  PointerDescriptorRebuild
+// CHECK:       tt.load %[[CHAINED_PTR]] : tensor<16x!tt.ptr<f32>>
+
+// -----
+
+module {
   tt.func public @while_block_ptr_large_step(%base: !tt.ptr<f16>, %n: i32) -> !tt.ptr<tensor<32xf16>> {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/tensor_pointer_descriptor_loop.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/tensor_pointer_descriptor_loop.mlir
@@ -20,6 +20,40 @@ module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
     tt.store %output_ptr, %value : tensor<4x!tt.ptr<f32>>
     tt.return
   }
+
+  // A CFO descriptor loop may also carry an integer address tensor that is
+  // not one of the descriptor slots. Preserve the affine row/column layout
+  // through the legacy BlockData rewrite instead of lowering the load as an
+  // indirect gather.
+  tt.func public @marked_affine_index_carrier(
+      %input: !tt.ptr<f32>, %output: !tt.ptr<f32>, %row_stride: i32,
+      %upper: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %range = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %rows = tt.expand_dims %range {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
+    %stride = tt.splat %row_stride : i32 -> tensor<4x1xi32>
+    %scaled_rows = arith.muli %rows, %stride : tensor<4x1xi32>
+    %row_offsets = tt.broadcast %scaled_rows : tensor<4x1xi32> -> tensor<4x4xi32>
+    %columns = tt.expand_dims %range {axis = 0 : i32} : tensor<4xi32> -> tensor<1x4xi32>
+    %column_offsets = tt.broadcast %columns : tensor<1x4xi32> -> tensor<4x4xi32>
+    %initial_offsets = arith.addi %row_offsets, %column_offsets : tensor<4x4xi32>
+    %input_base = tt.splat %input : !tt.ptr<f32> -> tensor<4x4x!tt.ptr<f32>>
+    %output_base = tt.splat %output : !tt.ptr<f32> -> tensor<4x4x!tt.ptr<f32>>
+    %initial_output = tt.addptr %output_base, %initial_offsets : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
+    %advance = arith.constant dense<16> : tensor<4x4xi32>
+    %result:2 = scf.for %iv = %c0 to %upper step %c1
+        iter_args(%offsets = %initial_offsets, %output_ptrs = %initial_output)
+        -> (tensor<4x4xi32>, tensor<4x4x!tt.ptr<f32>>) {
+      %input_ptrs = tt.addptr %input_base, %offsets : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
+      %value = tt.load %input_ptrs : tensor<4x4x!tt.ptr<f32>>
+      tt.store %output_ptrs, %value : tensor<4x4x!tt.ptr<f32>>
+      %next_offsets = arith.addi %offsets, %advance : tensor<4x4xi32>
+      %next_output = tt.addptr %output_ptrs, %advance : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
+      scf.yield %next_offsets, %next_output : tensor<4x4xi32>, tensor<4x4x!tt.ptr<f32>>
+    }
+    tt.return
+  }
 }
 
 // CFO-LABEL: tt.func public @tensor_pointer_descriptor_loop
@@ -33,3 +67,12 @@ module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
 // LINALG-SAME:  i32
 // LINALG-NOT:   tensor<4x!tt.ptr
 // LINALG-NOT:   unrealized_conversion_cast
+
+// CFO-LABEL: tt.func public @marked_affine_index_carrier
+// CFO:       scf.for
+// CFO:       PointerDescriptorBoundary
+
+// LINALG-LABEL: func.func @marked_affine_index_carrier
+// LINALG:       scf.for
+// LINALG-NOT:   triton_indirect_load
+// LINALG:       return


### PR DESCRIPTION
## Summary
- Extend marked make_range carrier analysis to recognize uniform, affine, and supported linear tensor expressions.
- Route only proven affine carriers through the legacy BlockData path while keeping descriptor and opaque carriers on the pointer-free boundary path.\n- Add a regression MLIR case for a marked affine index carrier in a descriptor loop.
- Include the remote validation workflow guide used for this development branch.
- 
- The change is based on the current official main-dev and is ready for review.